### PR TITLE
Reduce required approving reviews to 1

### DIFF
--- a/.github/branch-protection.json
+++ b/.github/branch-protection.json
@@ -16,7 +16,7 @@
   "required_pull_request_reviews": {
     "dismiss_stale_reviews": true,
     "require_code_owner_reviews": true,
-    "required_approving_review_count": 2,
+    "required_approving_review_count": 1,
     "require_last_push_approval": true
   },
   "restrictions": null,


### PR DESCRIPTION
## Summary

Reduce the required approving review count from 2 to 1 to make the workflow more manageable.

### Changes:
- Updated `.github/branch-protection.json`: `required_approving_review_count`: 2 → 1

### Impact:
- PRs will now require only 1 approval instead of 2
- All other branch protection settings remain unchanged
- Code owner reviews are still required
- The workflow will automatically apply this change after merge

🤖 Generated with [Claude Code](https://claude.ai/code)