### PR TITLE
SECURITY: close service-role key leak (deployed-bundle pentest gate)

### DIFF
--- a/api/_lib/supabase.ts
+++ b/api/_lib/supabase.ts
@@ -1,18 +1,18 @@
 import { createClient, type SupabaseClient } from '@supabase/supabase-js';
-import { getRequiredEnv, getOptionalEnv } from './env.js';
+import { getRequiredEnv } from './env.js';
 
 let supabase: SupabaseClient | null = null;
 
 export const getServiceRoleSupabase = (): SupabaseClient => {
   if (!supabase) {
     const url = getRequiredEnv('VITE_SUPABASE_URL');
-    // SECURITY: the service-role key is server-only and must use a non-VITE_ name —
-    // VITE_-prefixed vars get inlined into the public browser bundle at build time.
-    // The legacy fallback exists only so existing deployments keep working until the
-    // Vercel env var is renamed; remove it once SUPABASE_SERVICE_ROLE_KEY is set there.
-    const key =
-      getOptionalEnv('SUPABASE_SERVICE_ROLE_KEY') ??
-      getRequiredEnv('VITE_SUPABASE_SERVICE_ROLE_KEY');
+    // SECURITY: the service-role key is server-only and MUST use a non-VITE_ name.
+    // VITE_-prefixed vars are inlined into the public browser bundle at build time —
+    // the old `?? VITE_SUPABASE_SERVICE_ROLE_KEY` fallback meant that whenever that
+    // var existed in the build env, the master key leaked into dist/ (confirmed live
+    // in production 2026-06-12). The fallback is removed: only the non-prefixed name
+    // is accepted, so a VITE_-prefixed service-role var can never be relied upon.
+    const key = getRequiredEnv('SUPABASE_SERVICE_ROLE_KEY');
     supabase = createClient(url, key, {
       auth: {
         persistSession: false,

--- a/scripts/pentest.mjs
+++ b/scripts/pentest.mjs
@@ -57,10 +57,18 @@ const record = (name, pass, detail) => {
 // ── 1. Anon READ isolation ──────────────────────────────────────────────────
 const FINANCIAL_TABLES = ['transactions', 'accounts', 'users', 'budgets', 'goals', 'categories'];
 const BANKING_TABLES = ['bank_connections', 'linked_accounts', 'sync_history'];
+// Tables the 2026-06-10 hardening MISSED — added after the 2026-06-12 re-audit
+// found them anon-readable (dashboard_layouts/widget_preferences are user-keyed;
+// the plaid_* tables are legacy/service-role-only). Probed so the gap can't
+// silently reopen.
+const PREVIOUSLY_MISSED_TABLES = [
+  'dashboard_layouts', 'widget_preferences',
+  'plaid_connections', 'plaid_accounts', 'plaid_webhooks',
+];
 
 const testAnonReads = async () => {
   console.log('\n[1] Anonymous read isolation (anon key must read NOTHING):');
-  for (const table of [...FINANCIAL_TABLES, ...BANKING_TABLES]) {
+  for (const table of [...FINANCIAL_TABLES, ...BANKING_TABLES, ...PREVIOUSLY_MISSED_TABLES]) {
     const { data, error } = await anon.from(table).select('*').limit(5);
     if (error) {
       // A hard-blocked read (RLS error) or a not-yet-created table: no leak.
@@ -112,7 +120,46 @@ const testAnonWrites = async () => {
 };
 
 // ── 3. Service-role key absent from the client bundle ───────────────────────
-const testBundleSecrets = () => {
+// --prod-url=https://your-app.vercel.app scans the DEPLOYED bundle instead of
+// local dist/. CRITICAL: the leak only manifests when the bundle is built with
+// the build env that has VITE_SUPABASE_SERVICE_ROLE_KEY set — so scanning a
+// locally-built dist/ can pass while production leaks. Always run the prod-url
+// mode against the live deployment.
+const PROD_URL = process.argv.find((a) => a.startsWith('--prod-url='))?.split('=')[1];
+
+// The real leak is a JWT whose payload has "role":"service_role". Decoding
+// every JWT (vs a raw "service_role" string match) avoids false positives from
+// variable names / comments that happen to contain the string.
+const containsServiceRoleJwt = (content) => {
+  const jwts = content.match(/eyJ[A-Za-z0-9_-]+\.eyJ[A-Za-z0-9_-]+/g) ?? [];
+  for (const tok of jwts) {
+    try {
+      const payload = JSON.parse(Buffer.from(tok.split('.')[1], 'base64').toString('utf8'));
+      if (payload?.role === 'service_role') return true;
+    } catch { /* not a decodable JWT payload */ }
+  }
+  return false;
+};
+
+const testBundleSecrets = async () => {
+  if (PROD_URL) {
+    console.log(`\n[3] DEPLOYED bundle (${PROD_URL}) must not contain the service-role key:`);
+    try {
+      const html = await (await fetch(PROD_URL)).text();
+      const chunks = [...new Set([...html.matchAll(/\/assets\/[^"'\s)]+?\.js/g)].map((m) => m[0]))];
+      let leaked = 0;
+      for (const c of chunks) {
+        const js = await (await fetch(new URL(c, PROD_URL))).text();
+        if (containsServiceRoleJwt(js)) leaked += 1;
+      }
+      record('service-role key absent from DEPLOYED bundle', leaked === 0,
+        leaked === 0 ? `${chunks.length} deployed chunks clean` : `${leaked} deployed chunk(s) contain a service_role JWT`);
+    } catch (e) {
+      record('deployed bundle scanned', false, `fetch failed: ${e.message}`);
+    }
+    return;
+  }
+
   console.log('\n[3] Built client bundle must not contain the service-role key:');
   const distAssets = path.join('dist', 'assets');
   if (!existsSync(distAssets)) {
@@ -122,13 +169,10 @@ const testBundleSecrets = () => {
   const jsFiles = readdirSync(distAssets).filter((f) => f.endsWith('.js'));
   let leaked = 0;
   for (const f of jsFiles) {
-    const content = readFileSync(path.join(distAssets, f), 'utf8');
-    // The service-role JWT has "role":"service_role" in its payload; the var
-    // name would also be a giveaway.
-    if (content.includes('service_role') || content.includes('SERVICE_ROLE_KEY')) leaked += 1;
+    if (containsServiceRoleJwt(readFileSync(path.join(distAssets, f), 'utf8'))) leaked += 1;
   }
   record('service-role key absent from client bundle', leaked === 0,
-    leaked === 0 ? `${jsFiles.length} JS chunks clean` : `${leaked} chunk(s) reference service_role`);
+    leaked === 0 ? `${jsFiles.length} JS chunks clean` : `${leaked} chunk(s) contain a service_role JWT`);
 };
 
 // ── 4. Anon cannot call privileged RPCs ─────────────────────────────────────
@@ -150,7 +194,7 @@ const main = async () => {
 
   await testAnonReads();
   await testAnonWrites();
-  testBundleSecrets();
+  await testBundleSecrets();
   await testAnonRpc();
 
   const failed = results.filter((r) => !r.pass);


### PR DESCRIPTION
Incident response for the service-role key leaking into the production bundle.

The Vercel-side fix (rename VITE_SUPABASE_SERVICE_ROLE_KEY → SUPABASE_SERVICE_ROLE_KEY,
redeploy) is already done and verified — the deployed bundle no longer contains
any service_role JWT. This PR is the code hardening so it can't recur:

- `api/_lib/supabase.ts`: removed the `?? VITE_SUPABASE_SERVICE_ROLE_KEY`
  fallback — only the non-prefixed name is accepted.
- `scripts/pentest.mjs`: bundle check now decodes JWTs (flags `role:service_role`,
  not a raw string match) and adds `--prod-url` to scan the DEPLOYED bundle —
  the gate that catches this (local-dist scans passed because the leak only
  exists when built with Vercel's env). Live run: 18/18.

⚠️ Follow-up (mandatory): rotate the service-role key — it was publicly exposed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)