### PR TITLE
CI integrity: no skip-as-success — nightly smoke fails loudly; pentest rejects invalid keys

### DIFF
--- a/.github/workflows/supabase-smoke.yml
+++ b/.github/workflows/supabase-smoke.yml
@@ -22,19 +22,25 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      # NOTE: deliberately NOT continue-on-error. A real smoke failure must turn
+      # this workflow RED — a nightly that can't go red is theatre. And missing
+      # credentials FAIL loudly (exit 1) rather than silently skipping to green:
+      # this is the live infra safety net; if it can't run, that is itself a
+      # problem worth surfacing. (Earlier this job silently skipped for months
+      # because the SUPABASE_SERVICE_ROLE_KEY secret was absent, reporting
+      # "success" the whole time.)
       - name: Run Supabase smoke tests
-        continue-on-error: true
         env:
           RUN_SUPABASE_REAL_TESTS: 'true'
           VITE_SUPABASE_URL: ${{ secrets.VITE_SUPABASE_URL }}
           VITE_SUPABASE_ANON_KEY: ${{ secrets.VITE_SUPABASE_ANON_KEY }}
           # Server-only secret — intentionally NOT VITE_-prefixed so it can never
-          # be inlined into a client bundle. Rename the GitHub secret to match.
+          # be inlined into a client bundle.
           SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
         run: |
           if [ -z "$VITE_SUPABASE_URL" ] || [ -z "$VITE_SUPABASE_ANON_KEY" ] || [ -z "$SUPABASE_SERVICE_ROLE_KEY" ]; then
-            echo "Supabase credentials not set, skipping smoke tests"
-            exit 0
+            echo "::error::Supabase credentials not set — the smoke test cannot run. Failing loudly instead of skipping to a false green."
+            exit 1
           fi
           npm run test:supabase-smoke
 

--- a/scripts/pentest.mjs
+++ b/scripts/pentest.mjs
@@ -71,8 +71,17 @@ const testAnonReads = async () => {
   for (const table of [...FINANCIAL_TABLES, ...BANKING_TABLES, ...PREVIOUSLY_MISSED_TABLES]) {
     const { data, error } = await anon.from(table).select('*').limit(5);
     if (error) {
-      // A hard-blocked read (RLS error) or a not-yet-created table: no leak.
-      record(`anon cannot read ${table}`, true, error.code === 'PGRST205' ? 'table absent' : 'blocked by RLS');
+      // CRITICAL: an auth/key error is NOT a security pass — it means the anon
+      // key itself is broken, so this probe tests NOTHING about isolation.
+      // Counting it as "blocked" is a false green (a truncated/invalid key
+      // would make every probe "pass"). Flag it as a hard failure.
+      if (/invalid api key|invalid jwt|no api key|jws/i.test(error.message ?? '')) {
+        record(`anon cannot read ${table}`, false,
+          `INVALID ANON KEY — probe is meaningless, fix the key: "${error.message}"`);
+      } else {
+        // A genuine RLS rejection or a not-yet-created table: no data leaked.
+        record(`anon cannot read ${table}`, true, error.code === 'PGRST205' ? 'table absent' : 'blocked by RLS');
+      }
     } else if ((data?.length ?? 0) === 0) {
       // RLS does not throw — it filters to an EMPTY SET. Zero rows back to the
       // anon key is the secure outcome (the rows exist but are invisible).


### PR DESCRIPTION
Closes the "green that means nothing" class of issue, surfaced when the nightly
Supabase-smoke job was found to have silently skipped for months (missing
SUPABASE_SERVICE_ROLE_KEY secret → exit 0 → "success", testing nothing).

- **supabase-smoke.yml**: removed `continue-on-error` (a real failure now turns
  the job RED) and missing-creds now `exit 1` with `::error::` instead of
  `exit 0`. The secret has been added; the job now runs for real (2/2 vs prod).
- **scripts/pentest.mjs**: the anon-read check counted *any* error as
  "blocked = pass" — so an invalid/truncated anon key false-passed every table.
  Auth/key errors are now hard failures; only genuine RLS rejections or empty
  result sets count as secure. (Found via a real truncated-key incident.)

Audit conclusion for the record: at the test level, vitest never reports skips
as passes — the false-green was workflow-level, and this was the one genuine
case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)