### PR TITLE
Re-audit: Decimal in bank-sync rounding (#11), remove dead float recalculateBalance (#27)

### DIFF
--- a/api/banking/sync-transactions.ts
+++ b/api/banking/sync-transactions.ts
@@ -1,4 +1,5 @@
 import type { VercelRequest, VercelResponse } from '@vercel/node';
+import Decimal from 'decimal.js';
 import type {
   ErrorResponse,
   SyncTransactionsRequest,
@@ -85,7 +86,10 @@ const normalizeAmount = (value: number): number => {
   if (!Number.isFinite(value)) {
     return 0;
   }
-  return Math.round(value * 100) / 100;
+  // Decimal, not float: `Math.round(value * 100) / 100` is the banned IEEE-754
+  // rounding pattern (CLAUDE.md Rule #4). Match the client parseMoneyInput
+  // contract: 2dp, HALF_UP.
+  return new Decimal(value).toDecimalPlaces(2, Decimal.ROUND_HALF_UP).toNumber();
 };
 
 const toDateOnly = (timestamp?: string): string => {

--- a/src/services/api/accountService.ts
+++ b/src/services/api/accountService.ts
@@ -317,40 +317,12 @@ class AccountServiceImpl {
     }
   }
 
-  async recalculateBalance(accountId: string): Promise<number> {
-    if (!this.isSupabaseReady()) {
-      const transactions = await this.storage.get<{ account_id: string; amount: number }[]>(STORAGE_KEYS.TRANSACTIONS) || [];
-      const accountTransactions = transactions.filter(t => t.account_id === accountId);
-      const balance = accountTransactions.reduce((sum, t) => sum + t.amount, 0);
-
-      await this.updateBalance(accountId, balance);
-      return balance;
-    }
-
-    try {
-      const client = this.supabaseClient!;
-      const { data: account } = await client
-        .from('accounts')
-        .select('initial_balance')
-        .eq('id', accountId)
-        .single();
-
-      const { data: transactions } = await client
-        .from('transactions')
-        .select('amount')
-        .eq('account_id', accountId);
-
-      const transactionTotal = transactions?.reduce((sum, t) => sum + (t as { amount: number }).amount, 0) || 0;
-      const initialBalance = (account as { initial_balance?: number } | null)?.initial_balance || 0;
-      const newBalance = initialBalance + transactionTotal;
-
-      await this.updateBalance(accountId, newBalance);
-      return newBalance;
-    } catch (error) {
-      this.logger.error('AccountService.recalculateBalance error:', error as Error);
-      throw error;
-    }
-  }
+  // recalculateBalance() removed (re-audit #27): it summed transactions with
+  // float `reduce((sum, t) => sum + t.amount, 0)`, wrote the result straight to
+  // accounts.balance with no audit entry, and had no caller (not in the
+  // DataService Pick type). The canonical, audited balance path is the atomic
+  // transaction RPCs. A SQL recompute (balance = initial + Σamount) should be
+  // an audited RPC if ever needed — not a float reduce in the service layer.
 
   subscribeToAccounts(userId: string, callback: (payload: unknown) => void): () => void {
     if (!this.isSupabaseReady()) {
@@ -414,10 +386,6 @@ export class AccountService {
 
   static updateBalance(id: string, newBalance: number): Promise<void> {
     return this.service.updateBalance(id, newBalance);
-  }
-
-  static recalculateBalance(accountId: string): Promise<number> {
-    return this.service.recalculateBalance(accountId);
   }
 
   static subscribeToAccounts(userId: string, callback: (payload: unknown) => void): () => void {


### PR DESCRIPTION
Lower-severity re-audit fixes — banned float money-math (CLAUDE.md Rule #4).

- **#11 (live):** bank-sync `normalizeAmount` used `Math.round(v*100)/100`; now Decimal 2dp HALF_UP.
- **#27 (dead):** removed unused float `recalculateBalance` method + static wrapper.

Deferred: #26/#29 (dead AppContext/recalculateBalances chain — entangled with ~7 integration tests, needs a focused pass).

🤖 Generated with [Claude Code](https://claude.com/claude-code)