### PR TITLE
fix(security): open-redirect, IDOR & gitleaks no-op (deep re-audit lower-severity batch)

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,25 +1,36 @@
 title = "WealthTracker gitleaks config"
 
-# Use default rules; allow common placeholders to reduce false positives
-[rules]
+# CRITICAL: a custom config REPLACES gitleaks' built-in ruleset. Without this
+# extend block (and with no [[rules]] of our own) the scan would run with zero
+# rules and pass everything — a silent false green. useDefault keeps the full
+# upstream ruleset and treats the allowlist below as additive.
+[extend]
+useDefault = true
 
 [allowlist]
 description = "Allow test placeholders and obvious fake values"
 regexes = [
+  # Stripe TEST keys are non-sensitive by design.
   'pk_test_[A-Za-z0-9_-]{10,}',
   'sk_test_[A-Za-z0-9_-]{10,}',
   'your-.*-here',
   'example\.com',
   'localhost',
-  'dummy',
   'PLACEHOLDER',
 ]
 
+# Paths are matched relative to the repository root. The previous entries were
+# prefixed with `wealthtracker-web/`, which no longer exists (the app IS the
+# repo root), so they matched nothing — the env examples and test fixtures were
+# never actually allowlisted.
 paths = [
-  '^.github/workflows/.*$',
-  '^wealthtracker-web/\.env\.example$',
-  '^wealthtracker-web/\.env\.production\.example$',
-  '^wealthtracker-web/\.env\.test\.example$',
-  '^wealthtracker-web/src/test/.*$',
+  '^\.github/workflows/.*$',
+  '^\.env\.example$',
+  '^\.env\.production\.example$',
+  '^\.env\.test\.example$',
+  '^src/test/.*$',
+  # Historical backup tree — *.example files only (real secrets are NOT
+  # allowlisted). Tracked backups are slated for removal; until then this keeps
+  # their placeholder env files from being flagged without blinding the scan.
+  '^WealthTracker-Backups/.*\.example$',
 ]
-

--- a/api/account/delete.ts
+++ b/api/account/delete.ts
@@ -122,6 +122,12 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
       .eq('clerk_user_id', clerkUserId);
     if (profileErr) warnings.push(`user_profiles: ${profileErr.message}`);
 
+    // subscription_logs is deliberately NOT erased here: it stores only Stripe
+    // event identifiers and {type, created} (see api/stripe/webhook.ts) — no
+    // user_id, email, or other PII — and serves as the webhook idempotency
+    // ledger. Like Stripe's own retained invoices, it falls outside the GDPR
+    // erasure scope, so there is nothing user-identifiable to remove.
+
     if (userRow) {
       // The big one: ON DELETE CASCADE removes accounts, transactions,
       // budgets, goals, categories, investments, subscriptions, invoices,

--- a/api/billing/portal.ts
+++ b/api/billing/portal.ts
@@ -40,7 +40,13 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
 
     const body = (req.body ?? {}) as PortalRequest;
     const origin = Array.isArray(req.headers.origin) ? req.headers.origin[0] : req.headers.origin;
-    const fallbackReturn = origin ? `${origin}/subscription` : undefined;
+    // The Origin header is attacker-controllable, so the derived fallback must
+    // pass the same allowlist as a caller-supplied returnUrl — otherwise it is
+    // an open redirect into the Stripe portal return flow.
+    const candidateFallback = origin ? `${origin}/subscription` : undefined;
+    const fallbackReturn = candidateFallback && isRedirectUrlAllowed(candidateFallback)
+      ? candidateFallback
+      : undefined;
     const returnUrl = typeof body.returnUrl === 'string' && isRedirectUrlAllowed(body.returnUrl)
       ? body.returnUrl
       : fallbackReturn;

--- a/src/services/api/accountService.ts
+++ b/src/services/api/accountService.ts
@@ -191,7 +191,7 @@ class AccountServiceImpl {
     }
   }
 
-  async updateAccount(id: string, updates: Partial<Account>): Promise<Account> {
+  async updateAccount(id: string, updates: Partial<Account>, userId?: string): Promise<Account> {
     if (!this.isSupabaseReady()) {
       const accounts = await this.readAccounts();
       const index = accounts.findIndex(account => account.id === id);
@@ -214,10 +214,17 @@ class AccountServiceImpl {
     try {
       const client = this.supabaseClient!;
       const dbUpdates = mapAccountToDb(updates as unknown as Record<string, unknown>);
-      const { data, error } = await client
+      // RLS already scopes writes to the authenticated user; the optional
+      // user_id filter is defence-in-depth so a caller that knows the owner
+      // can never touch a mis-routed row even if RLS were ever relaxed.
+      let query = client
         .from('accounts')
         .update(dbUpdates as never)
-        .eq('id', id)
+        .eq('id', id);
+      if (userId) {
+        query = query.eq('user_id', userId);
+      }
+      const { data, error } = await query
         .select()
         .single();
 
@@ -233,7 +240,7 @@ class AccountServiceImpl {
     }
   }
 
-  async deleteAccount(id: string): Promise<void> {
+  async deleteAccount(id: string, userId?: string): Promise<void> {
     if (!this.isSupabaseReady()) {
       const accounts = await this.readAccounts();
       const filtered = accounts.filter(account => account.id !== id);
@@ -243,10 +250,16 @@ class AccountServiceImpl {
 
     try {
       const client = this.supabaseClient!;
-      const { error } = await client
+      // RLS scopes the soft-delete to the authenticated user; the optional
+      // user_id filter is belt-and-braces for callers that know the owner.
+      let query = client
         .from('accounts')
         .update({ is_active: false } as never)
         .eq('id', id);
+      if (userId) {
+        query = query.eq('user_id', userId);
+      }
+      const { error } = await query;
 
       if (error) {
         this.logger.error('Error deleting account:', error);
@@ -400,12 +413,12 @@ export class AccountService {
     return this.service.createAccount(userId, account);
   }
 
-  static updateAccount(id: string, updates: Partial<Account>): Promise<Account> {
-    return this.service.updateAccount(id, updates);
+  static updateAccount(id: string, updates: Partial<Account>, userId?: string): Promise<Account> {
+    return this.service.updateAccount(id, updates, userId);
   }
 
-  static deleteAccount(id: string): Promise<void> {
-    return this.service.deleteAccount(id);
+  static deleteAccount(id: string, userId?: string): Promise<void> {
+    return this.service.deleteAccount(id, userId);
   }
 
   static getAccountById(id: string): Promise<Account | null> {

--- a/src/services/api/dataService.ts
+++ b/src/services/api/dataService.ts
@@ -175,7 +175,7 @@ class DataServiceImpl {
   async updateAccount(id: string, updates: Partial<Account>): Promise<Account> {
     const userId = this.userIdService.getCurrentDatabaseUserId();
     if (userId && this.supabaseChecker()) {
-      return this.accountService.updateAccount(id, updates);
+      return this.accountService.updateAccount(id, updates, userId);
     }
 
     const accounts = await this.readCollection<Account>(STORAGE_KEYS.ACCOUNTS);
@@ -192,7 +192,7 @@ class DataServiceImpl {
   async deleteAccount(id: string): Promise<void> {
     const userId = this.userIdService.getCurrentDatabaseUserId();
     if (userId && this.supabaseChecker()) {
-      return this.accountService.deleteAccount(id);
+      return this.accountService.deleteAccount(id, userId);
     }
 
     const accounts = await this.readCollection<Account>(STORAGE_KEYS.ACCOUNTS);
@@ -230,7 +230,7 @@ class DataServiceImpl {
   async updateTransaction(id: string, updates: Partial<Transaction>): Promise<Transaction> {
     const userId = this.userIdService.getCurrentDatabaseUserId();
     if (userId && this.supabaseChecker()) {
-      return this.transactionService.updateTransaction(id, updates);
+      return this.transactionService.updateTransaction(id, updates, userId);
     }
 
     const transactions = await this.readCollection<Transaction>(STORAGE_KEYS.TRANSACTIONS);
@@ -255,7 +255,7 @@ class DataServiceImpl {
   async deleteTransaction(id: string): Promise<void> {
     const userId = this.userIdService.getCurrentDatabaseUserId();
     if (userId && this.supabaseChecker()) {
-      return this.transactionService.deleteTransaction(id);
+      return this.transactionService.deleteTransaction(id, userId);
     }
 
     const transactions = await this.readCollection<Transaction>(STORAGE_KEYS.TRANSACTIONS);

--- a/src/services/api/supabaseClient.ts
+++ b/src/services/api/supabaseClient.ts
@@ -21,7 +21,7 @@ type Database = {
         Returns: Record<string, unknown>;
       };
       update_transaction_atomic: {
-        Args: { p_id: string; p: Record<string, unknown> };
+        Args: { p_id: string; p: Record<string, unknown>; p_user_id?: string };
         Returns: Record<string, unknown>;
       };
       delete_transaction_atomic: {

--- a/src/services/api/transactionService.ts
+++ b/src/services/api/transactionService.ts
@@ -210,7 +210,7 @@ class TransactionServiceImpl {
     }
   }
 
-  async updateTransaction(id: string, updates: Partial<Transaction>): Promise<Transaction> {
+  async updateTransaction(id: string, updates: Partial<Transaction>, userId?: string): Promise<Transaction> {
     if (!this.isSupabaseReady()) {
       const transactions = await this.readStoredTransactions();
       const index = transactions.findIndex(t => t.id === id);
@@ -244,7 +244,10 @@ class TransactionServiceImpl {
       // moves) in one database transaction with SQL numeric math.
       const { data, error } = await client.rpc('update_transaction_atomic', {
         p_id: id,
-        p: dbUpdates
+        p: dbUpdates,
+        // Defence-in-depth IDOR guard: RLS already scopes the row, and passing
+        // the owner makes the RPC fail closed on a mis-routed id.
+        ...(userId ? { p_user_id: userId } : {})
       });
 
       if (error) {
@@ -259,7 +262,7 @@ class TransactionServiceImpl {
     }
   }
 
-  async deleteTransaction(id: string): Promise<void> {
+  async deleteTransaction(id: string, userId?: string): Promise<void> {
     if (!this.isSupabaseReady()) {
       const transactions = await this.readStoredTransactions();
       const filtered = transactions.filter(t => t.id !== id);
@@ -276,8 +279,12 @@ class TransactionServiceImpl {
       const client = this.supabaseClient!;
 
       // Atomic RPC: deletes the row and reverses the balance in one database
-      // transaction. RLS scopes the delete to the requesting user.
-      const { error } = await client.rpc('delete_transaction_atomic', { p_id: id });
+      // transaction. RLS scopes the delete to the requesting user; passing the
+      // owner adds a defence-in-depth IDOR guard so a mis-routed id fails closed.
+      const { error } = await client.rpc('delete_transaction_atomic', {
+        p_id: id,
+        ...(userId ? { p_user_id: userId } : {})
+      });
 
       if (error) {
         this.logger.error('Error deleting transaction:', error);
@@ -515,12 +522,12 @@ export class TransactionService {
     return this.service.createTransaction(userId, transaction);
   }
 
-  static updateTransaction(id: string, updates: Partial<Transaction>): Promise<Transaction> {
-    return this.service.updateTransaction(id, updates);
+  static updateTransaction(id: string, updates: Partial<Transaction>, userId?: string): Promise<Transaction> {
+    return this.service.updateTransaction(id, updates, userId);
   }
 
-  static deleteTransaction(id: string): Promise<void> {
-    return this.service.deleteTransaction(id);
+  static deleteTransaction(id: string, userId?: string): Promise<void> {
+    return this.service.deleteTransaction(id, userId);
   }
 
   static getTransactionsByDateRange(userId: string, startDate: Date, endDate: Date): Promise<Transaction[]> {

--- a/supabase/migrations/20260612110000_update_transaction_atomic_user_scope.sql
+++ b/supabase/migrations/20260612110000_update_transaction_atomic_user_scope.sql
@@ -1,0 +1,101 @@
+-- Defence-in-depth IDOR guard for update_transaction_atomic.
+--
+-- The function is SECURITY INVOKER, so RLS already restricts the row it can
+-- lock and update to the requesting user. delete_transaction_atomic additionally
+-- accepts an explicit p_user_id and refuses to act on a row owned by anyone
+-- else; update_transaction_atomic did not, leaving the two paths inconsistent.
+-- This migration brings update in line: an optional p_user_id that, when the
+-- caller supplies it, must match the row's owner or the lookup fails closed.
+--
+-- Adding a parameter changes the function's identity, so the old (uuid, jsonb)
+-- overload is dropped first to avoid two co-existing signatures (one unscoped).
+
+DROP FUNCTION IF EXISTS public.update_transaction_atomic(uuid, jsonb);
+
+CREATE OR REPLACE FUNCTION public.update_transaction_atomic(
+  p_id uuid,
+  p jsonb,
+  p_user_id uuid DEFAULT NULL
+)
+RETURNS public.transactions
+LANGUAGE plpgsql SECURITY INVOKER
+SET search_path = public
+AS $$
+DECLARE
+  v_old public.transactions;
+  v_new public.transactions;
+BEGIN
+  SELECT * INTO v_old
+    FROM public.transactions
+   WHERE id = p_id
+     AND (p_user_id IS NULL OR user_id = p_user_id)
+   FOR UPDATE;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'transaction_not_found' USING ERRCODE = 'P0002';
+  END IF;
+
+  UPDATE public.transactions SET
+    description         = COALESCE(p->>'description', description),
+    amount              = COALESCE((p->>'amount')::numeric, amount),
+    type                = COALESCE(p->>'type', type),
+    date                = COALESCE((p->>'date')::date, date),
+    account_id          = COALESCE(NULLIF(p->>'account_id', '')::uuid, account_id),
+    category            = CASE WHEN p ? 'category' THEN p->>'category' ELSE category END,
+    notes               = CASE WHEN p ? 'notes' THEN p->>'notes' ELSE notes END,
+    tags                = CASE WHEN p ? 'tags' AND jsonb_typeof(p->'tags') = 'array'
+                               THEN ARRAY(SELECT jsonb_array_elements_text(p->'tags'))
+                               ELSE tags END,
+    is_recurring        = COALESCE((p->>'is_recurring')::boolean, is_recurring),
+    transfer_account_id = CASE WHEN p ? 'transfer_account_id'
+                               THEN NULLIF(p->>'transfer_account_id', '')::uuid
+                               ELSE transfer_account_id END,
+    metadata            = CASE WHEN p ? 'metadata' THEN p->'metadata' ELSE metadata END,
+    category_id         = CASE WHEN p ? 'category_id'
+                               THEN NULLIF(p->>'category_id', '')::uuid
+                               ELSE category_id END,
+    merchant_name       = CASE WHEN p ? 'merchant_name' THEN p->>'merchant_name' ELSE merchant_name END,
+    updated_at          = now()
+  WHERE id = p_id
+  RETURNING * INTO v_new;
+
+  IF v_old.account_id = v_new.account_id THEN
+    IF v_new.amount <> v_old.amount THEN
+      UPDATE public.accounts
+         SET balance = balance + (v_new.amount - v_old.amount),
+             updated_at = now()
+       WHERE id = v_new.account_id
+         AND user_id = v_new.user_id;
+      IF NOT FOUND THEN
+        RAISE EXCEPTION 'account_not_found_or_not_owned' USING ERRCODE = 'P0001';
+      END IF;
+    END IF;
+  ELSE
+    UPDATE public.accounts
+       SET balance = balance - v_old.amount,
+           updated_at = now()
+     WHERE id = v_old.account_id
+       AND user_id = v_old.user_id;
+    IF NOT FOUND THEN
+      RAISE EXCEPTION 'account_not_found_or_not_owned' USING ERRCODE = 'P0001';
+    END IF;
+
+    UPDATE public.accounts
+       SET balance = balance + v_new.amount,
+           updated_at = now()
+     WHERE id = v_new.account_id
+       AND user_id = v_new.user_id;
+    IF NOT FOUND THEN
+      RAISE EXCEPTION 'account_not_found_or_not_owned' USING ERRCODE = 'P0001';
+    END IF;
+  END IF;
+
+  PERFORM public.write_financial_audit(
+    v_new.user_id, 'transaction', v_new.id, 'update', to_jsonb(v_old), to_jsonb(v_new)
+  );
+
+  RETURN v_new;
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.update_transaction_atomic(uuid, jsonb, uuid) TO authenticated, service_role;


### PR DESCRIPTION
Lower-severity hardening batch from `AUDIT_2026-06-12_DEEP_REAUDIT.md`.

## Findings closed
- **#17 billing-portal open redirect** — the `Origin`-derived `returnUrl` fallback now passes the same `isRedirectUrlAllowed` allowlist as a caller-supplied `returnUrl`. The `Origin` header is attacker-controllable, so the unvalidated fallback was an open redirect into the Stripe portal return flow.
- **#25 `update_transaction_atomic` IDOR scoping** — add an optional `p_user_id` scope (matching `delete_transaction_atomic`) so the RPC fails closed on a mis-routed id; the resolved db user id is now threaded through `transactionService`/`dataService` for both update and delete. Migration drops the old `(uuid, jsonb)` overload first to avoid a co-existing unscoped signature. RLS + `SECURITY INVOKER` already guarded this at runtime; this is defence-in-depth and consistency.
- **#28 account update/soft-delete scoping** — thread the owner's `user_id` into the Supabase mutation path as defence-in-depth over RLS.
- **#30 account-delete `subscription_logs`** — investigated: the table stores only Stripe event ids + `{type, created}` (no `user_id`, no PII), so there is nothing user-identifiable to erase. Documented the intentional retention so it isn't mistaken for a GDPR gap.
- **#15 gitleaks allowlist** — **critical correctness fix**: a custom gitleaks config *replaces* the built-in ruleset, and with an empty `[rules]` and no `[extend]`, the scan was running with **zero rules** (a silent false green). Added `[extend] useDefault = true`; also fixed dead `wealthtracker-web/`-prefixed path globs to be repo-root-relative so env examples and test fixtures are actually allowlisted.

## Verification
- `npm run typecheck:strict` — clean
- `npm run lint` — clean
- `npm run build` — clean (pre-existing chunk-size warning only)
- 142 affected service/context tests pass

## Apply note
The migration `20260612110000_update_transaction_atomic_user_scope.sql` must be applied to production (SQL Editor) after merge, like the prior re-audit migrations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)