### PR TITLE
fix(banking): stop leaking raw errors & PII from sync path (re-audit #19/#20)

### DIFF
--- a/api/_lib/http-error.ts
+++ b/api/_lib/http-error.ts
@@ -1,0 +1,27 @@
+import type { VercelResponse } from '@vercel/node';
+import type { ErrorResponse } from '../../src/types/banking-api.js';
+
+/**
+ * Standard error response for banking/API endpoints.
+ *
+ * SECURITY: `details` (raw Supabase/driver error objects, stack traces, etc.)
+ * is logged SERVER-SIDE only and is NEVER serialised into the client payload.
+ * Returning it leaks internal schema, constraint names, and row ids to callers.
+ * The client always receives just `{ error, code }`.
+ *
+ * This replaces ~13 near-identical per-handler copies, several of which DID
+ * spread `details` into the JSON response (audit 2026-06-12, finding #19).
+ */
+export const createErrorResponse = (
+  res: VercelResponse,
+  status: number,
+  error: string,
+  code: string,
+  details?: unknown
+): VercelResponse => {
+  if (details !== undefined) {
+    console.error(`[banking] ${code} (${status}): ${error}`, details);
+  }
+  const payload: ErrorResponse = { error, code };
+  return res.status(status).json(payload);
+};

--- a/api/_lib/truelayer.ts
+++ b/api/_lib/truelayer.ts
@@ -256,9 +256,9 @@ export const fetchTransactions = async (
 
   const payload = (await response.json()) as TransactionsResponse;
   const results = Array.isArray(payload.results) ? payload.results : [];
-  console.log('[truelayer] fetchTransactions accountId:', accountId, 'returned:', results.length, 'transactions, status:', response.status);
-  if (results.length > 0) {
-    console.log('[truelayer] first transaction sample:', JSON.stringify(results[0]).slice(0, 300));
-  }
+  // Intentionally NOT logging transaction contents or the account id: a raw
+  // transaction carries the user's merchant, amount and description (PII), and
+  // the external account id is sensitive. Sync counts are recorded in
+  // sync_history server-side for observability instead.
   return results;
 };

--- a/api/banking/connections.ts
+++ b/api/banking/connections.ts
@@ -1,22 +1,9 @@
 import type { VercelRequest, VercelResponse } from '@vercel/node';
-import type { ConnectionsResponse, ErrorResponse } from '../../src/types/banking-api.js';
+import type { ConnectionsResponse } from '../../src/types/banking-api.js';
 import { AuthError, requireAuth } from '../_lib/auth.js';
 import { setCorsHeaders } from '../_lib/cors.js';
+import { createErrorResponse } from '../_lib/http-error.js';
 import { getServiceRoleSupabase } from '../_lib/supabase.js';
-
-const createErrorResponse = (
-  res: VercelResponse,
-  status: number,
-  error: string,
-  code: string,
-  details?: unknown
-) => {
-  res.status(status).json({
-    error,
-    code,
-    details
-  } satisfies ErrorResponse);
-};
 
 export default async function handler(req: VercelRequest, res: VercelResponse) {
   if (setCorsHeaders(req, res)) {

--- a/api/banking/create-link-token.ts
+++ b/api/banking/create-link-token.ts
@@ -1,30 +1,16 @@
 import type { VercelRequest, VercelResponse } from '@vercel/node';
 import { randomBytes } from 'node:crypto';
 import type {
-  CreateLinkTokenResponse,
-  ErrorResponse
+  CreateLinkTokenResponse
 } from '../../src/types/banking-api.js';
 import { AuthError, requireAuth } from '../_lib/auth.js';
 import { setCorsHeaders } from '../_lib/cors.js';
+import { createErrorResponse } from '../_lib/http-error.js';
 import { applyRateLimit } from '../_lib/rate-limit.js';
 import { createStateToken } from '../_lib/state.js';
 import { buildAuthUrl, getRedirectUri, isSandboxEnvironment } from '../_lib/truelayer.js';
 
 const AUTH_SCOPES = ['info', 'accounts', 'balance', 'transactions', 'offline_access'];
-
-const createErrorResponse = (
-  res: VercelResponse,
-  status: number,
-  error: string,
-  code: string,
-  details?: unknown
-) => {
-  res.status(status).json({
-    error,
-    code,
-    details
-  } satisfies ErrorResponse);
-};
 
 export default async function handler(req: VercelRequest, res: VercelResponse) {
   if (setCorsHeaders(req, res)) {

--- a/api/banking/dead-letter-admin-audit-export.ts
+++ b/api/banking/dead-letter-admin-audit-export.ts
@@ -1,9 +1,9 @@
 import { Buffer } from 'node:buffer';
 import type { VercelRequest, VercelResponse } from '@vercel/node';
-import type { ErrorResponse } from '../../src/types/banking-api.js';
 import { AuthError, requireAuth } from '../_lib/auth.js';
 import { requireBankingOpsAdmin } from '../_lib/banking-ops.js';
 import { setCorsHeaders } from '../_lib/cors.js';
+import { createErrorResponse } from '../_lib/http-error.js';
 import { getServiceRoleSupabase } from '../_lib/supabase.js';
 
 const DEFAULT_LIMIT = 1000;
@@ -26,20 +26,6 @@ interface DeadLetterAuditDbRow {
   created_at: string;
   completed_at: string | null;
 }
-
-const createErrorResponse = (
-  res: VercelResponse,
-  status: number,
-  error: string,
-  code: string,
-  details?: unknown
-) => {
-  const payload: ErrorResponse = { error, code };
-  if (details !== undefined) {
-    payload.details = details;
-  }
-  return res.status(status).json(payload);
-};
 
 const relationMissing = (error: unknown): boolean => {
   if (!error || typeof error !== 'object') {

--- a/api/banking/dead-letter-admin-audit.ts
+++ b/api/banking/dead-letter-admin-audit.ts
@@ -2,12 +2,12 @@ import { Buffer } from 'node:buffer';
 import type { VercelRequest, VercelResponse } from '@vercel/node';
 import type {
   DeadLetterAdminAuditResponse,
-  DeadLetterAdminAuditRow,
-  ErrorResponse
+  DeadLetterAdminAuditRow
 } from '../../src/types/banking-api.js';
 import { AuthError, requireAuth } from '../_lib/auth.js';
 import { requireBankingOpsAdmin } from '../_lib/banking-ops.js';
 import { setCorsHeaders } from '../_lib/cors.js';
+import { createErrorResponse } from '../_lib/http-error.js';
 import { getServiceRoleSupabase } from '../_lib/supabase.js';
 
 const DEFAULT_LIMIT = 25;
@@ -30,20 +30,6 @@ interface DeadLetterAuditDbRow {
   created_at: string;
   completed_at: string | null;
 }
-
-const createErrorResponse = (
-  res: VercelResponse,
-  status: number,
-  error: string,
-  code: string,
-  details?: unknown
-) => {
-  const payload: ErrorResponse = { error, code };
-  if (details !== undefined) {
-    payload.details = details;
-  }
-  return res.status(status).json(payload);
-};
 
 const relationMissing = (error: unknown): boolean => {
   if (!error || typeof error !== 'object') {

--- a/api/banking/dead-letter-admin.ts
+++ b/api/banking/dead-letter-admin.ts
@@ -2,8 +2,7 @@ import type { VercelRequest, VercelResponse } from '@vercel/node';
 import type {
   DeadLetterAdminListResponse,
   DeadLetterAdminResetRequest,
-  DeadLetterAdminResetResponse,
-  ErrorResponse
+  DeadLetterAdminResetResponse
 } from '../../src/types/banking-api.js';
 import { AuthError, requireAuth } from '../_lib/auth.js';
 import {
@@ -12,26 +11,13 @@ import {
   requireBankingOpsAdmin
 } from '../_lib/banking-ops.js';
 import { setCorsHeaders } from '../_lib/cors.js';
+import { createErrorResponse } from '../_lib/http-error.js';
 import { getServiceRoleSupabase } from '../_lib/supabase.js';
 
 const RESET_ALL_CONFIRMATION = 'RESET_ALL_DEAD_LETTERED';
 const DEFAULT_PREVIEW_LIMIT = 25;
 const MAX_PREVIEW_LIMIT = 200;
 const MAX_RESET_LIMIT = 500;
-
-const createErrorResponse = (
-  res: VercelResponse,
-  status: number,
-  error: string,
-  code: string,
-  details?: unknown
-) => {
-  const payload: ErrorResponse = { error, code };
-  if (details !== undefined) {
-    payload.details = details;
-  }
-  return res.status(status).json(payload);
-};
 
 const relationMissing = (error: unknown): boolean => {
   if (!error || typeof error !== 'object') {

--- a/api/banking/disconnect.ts
+++ b/api/banking/disconnect.ts
@@ -1,22 +1,9 @@
 import type { VercelRequest, VercelResponse } from '@vercel/node';
-import type { DisconnectRequest, DisconnectResponse, ErrorResponse } from '../../src/types/banking-api.js';
+import type { DisconnectRequest, DisconnectResponse } from '../../src/types/banking-api.js';
 import { AuthError, requireAuth } from '../_lib/auth.js';
 import { setCorsHeaders } from '../_lib/cors.js';
+import { createErrorResponse } from '../_lib/http-error.js';
 import { getServiceRoleSupabase } from '../_lib/supabase.js';
-
-const createErrorResponse = (
-  res: VercelResponse,
-  status: number,
-  error: string,
-  code: string,
-  details?: unknown
-) => {
-  res.status(status).json({
-    error,
-    code,
-    details
-  } satisfies ErrorResponse);
-};
 
 export default async function handler(req: VercelRequest, res: VercelResponse) {
   if (setCorsHeaders(req, res)) {

--- a/api/banking/discover-accounts.ts
+++ b/api/banking/discover-accounts.ts
@@ -2,31 +2,17 @@ import type { VercelRequest, VercelResponse } from '@vercel/node';
 import type {
   DiscoverAccountsRequest,
   DiscoverAccountsResponse,
-  DiscoveredBankAccount,
-  ErrorResponse
+  DiscoveredBankAccount
 } from '../../src/types/banking-api.js';
 import { AuthError, requireAuth } from '../_lib/auth.js';
 import { getServiceRoleSupabase } from '../_lib/supabase.js';
 import { setCorsHeaders } from '../_lib/cors.js';
+import { createErrorResponse } from '../_lib/http-error.js';
 import {
   getUserTrueLayerConnection,
   withTrueLayerAccessToken
 } from '../_lib/banking-sync.js';
 import { fetchAccountBalance, fetchAccounts } from '../_lib/truelayer.js';
-
-const createErrorResponse = (
-  res: VercelResponse,
-  status: number,
-  error: string,
-  code: string,
-  details?: unknown
-) => {
-  const payload: ErrorResponse = { error, code };
-  if (details !== undefined) {
-    payload.details = details;
-  }
-  return res.status(status).json(payload);
-};
 
 const mapAccountType = (accountType: string | undefined): string => {
   const normalized = (accountType ?? '').toLowerCase();

--- a/api/banking/exchange-token.ts
+++ b/api/banking/exchange-token.ts
@@ -1,11 +1,11 @@
 import type { VercelRequest, VercelResponse } from '@vercel/node';
 import type {
   ExchangeTokenRequest,
-  ExchangeTokenResponse,
-  ErrorResponse
+  ExchangeTokenResponse
 } from '../../src/types/banking-api.js';
 import { AuthError, requireAuth } from '../_lib/auth.js';
 import { setCorsHeaders } from '../_lib/cors.js';
+import { createErrorResponse } from '../_lib/http-error.js';
 import { applyRateLimit } from '../_lib/rate-limit.js';
 import { encryptSecret } from '../_lib/encryption.js';
 import { getServiceRoleSupabase } from '../_lib/supabase.js';
@@ -17,20 +17,6 @@ interface ProviderMetadata {
   name: string;
   logo?: string;
 }
-
-const createErrorResponse = (
-  res: VercelResponse,
-  status: number,
-  error: string,
-  code: string,
-  details?: unknown
-) => {
-  const payload: ErrorResponse = { error, code };
-  if (details) {
-    payload.details = details;
-  }
-  return res.status(status).json(payload);
-};
 
 const getProviderFromAccounts = (
   accounts: Array<{

--- a/api/banking/link-accounts.ts
+++ b/api/banking/link-accounts.ts
@@ -1,27 +1,13 @@
 import type { VercelRequest, VercelResponse } from '@vercel/node';
 import type {
-  ErrorResponse,
   LinkAccountsRequest,
   LinkAccountsResponse
 } from '../../src/types/banking-api.js';
 import { AuthError, requireAuth } from '../_lib/auth.js';
 import { getServiceRoleSupabase } from '../_lib/supabase.js';
 import { setCorsHeaders } from '../_lib/cors.js';
+import { createErrorResponse } from '../_lib/http-error.js';
 import { getUserTrueLayerConnection } from '../_lib/banking-sync.js';
-
-const createErrorResponse = (
-  res: VercelResponse,
-  status: number,
-  error: string,
-  code: string,
-  details?: unknown
-) => {
-  const payload: ErrorResponse = { error, code };
-  if (details !== undefined) {
-    payload.details = details;
-  }
-  return res.status(status).json(payload);
-};
 
 export default async function handler(req: VercelRequest, res: VercelResponse) {
   if (setCorsHeaders(req, res)) {

--- a/api/banking/ops-alert-stats.ts
+++ b/api/banking/ops-alert-stats.ts
@@ -1,5 +1,5 @@
 import type { VercelRequest, VercelResponse } from '@vercel/node';
-import type { ErrorResponse, OpsAlertStatsResponse } from '../../src/types/banking-api.js';
+import type { OpsAlertStatsResponse } from '../../src/types/banking-api.js';
 import { AuthError, requireAuth } from '../_lib/auth.js';
 import {
   getOpsAlertNotifyEvery,
@@ -7,6 +7,7 @@ import {
   requireBankingOpsAdmin
 } from '../_lib/banking-ops.js';
 import { setCorsHeaders } from '../_lib/cors.js';
+import { createErrorResponse } from '../_lib/http-error.js';
 import { getServiceRoleSupabase } from '../_lib/supabase.js';
 
 const DEFAULT_LIMIT = 50;
@@ -19,20 +20,6 @@ interface OpsAlertCounterRow {
   suppressed_count: number;
   updated_at: string | null;
 }
-
-const createErrorResponse = (
-  res: VercelResponse,
-  status: number,
-  error: string,
-  code: string,
-  details?: unknown
-) => {
-  const payload: ErrorResponse = { error, code };
-  if (details !== undefined) {
-    payload.details = details;
-  }
-  return res.status(status).json(payload);
-};
 
 const parsePositiveInt = (
   value: string | undefined,

--- a/api/banking/ops-alert-test.ts
+++ b/api/banking/ops-alert-test.ts
@@ -1,29 +1,15 @@
 import type { VercelRequest, VercelResponse } from '@vercel/node';
 import type {
-  ErrorResponse,
   OpsAlertTestRequest,
   OpsAlertTestResponse
 } from '../../src/types/banking-api.js';
 import { AuthError, requireAuth } from '../_lib/auth.js';
 import { requireBankingOpsAdmin } from '../_lib/banking-ops.js';
 import { setCorsHeaders } from '../_lib/cors.js';
+import { createErrorResponse } from '../_lib/http-error.js';
 import { getServiceRoleSupabase } from '../_lib/supabase.js';
 
 const TEST_EVENT_TYPE = 'banking.ops_alert_test';
-
-const createErrorResponse = (
-  res: VercelResponse,
-  status: number,
-  error: string,
-  code: string,
-  details?: unknown
-) => {
-  const payload: ErrorResponse = { error, code };
-  if (details !== undefined) {
-    payload.details = details;
-  }
-  return res.status(status).json(payload);
-};
 
 const relationMissing = (error: unknown): boolean => {
   if (!error || typeof error !== 'object') {

--- a/api/banking/sync-accounts.ts
+++ b/api/banking/sync-accounts.ts
@@ -1,12 +1,12 @@
 import type { VercelRequest, VercelResponse } from '@vercel/node';
 import type {
-  ErrorResponse,
   SyncAccountsRequest,
   SyncAccountsResponse
 } from '../../src/types/banking-api.js';
 import { AuthError, requireAuth } from '../_lib/auth.js';
 import { getServiceRoleSupabase } from '../_lib/supabase.js';
 import { setCorsHeaders } from '../_lib/cors.js';
+import { createErrorResponse } from '../_lib/http-error.js';
 import {
   getUserTrueLayerConnection,
   markConnectionSyncFailure,
@@ -14,20 +14,6 @@ import {
   withTrueLayerAccessToken
 } from '../_lib/banking-sync.js';
 import { fetchAccountBalance, fetchAccounts } from '../_lib/truelayer.js';
-
-const createErrorResponse = (
-  res: VercelResponse,
-  status: number,
-  error: string,
-  code: string,
-  details?: unknown
-) => {
-  const payload: ErrorResponse = { error, code };
-  if (details !== undefined) {
-    payload.details = details;
-  }
-  return res.status(status).json(payload);
-};
 
 const inferMask = (account: {
   account_number?: {

--- a/api/banking/sync-transactions.ts
+++ b/api/banking/sync-transactions.ts
@@ -1,12 +1,12 @@
 import type { VercelRequest, VercelResponse } from '@vercel/node';
 import Decimal from 'decimal.js';
 import type {
-  ErrorResponse,
   SyncTransactionsRequest,
   SyncTransactionsResponse
 } from '../../src/types/banking-api.js';
 import { AuthError, requireAuth } from '../_lib/auth.js';
 import { setCorsHeaders } from '../_lib/cors.js';
+import { createErrorResponse } from '../_lib/http-error.js';
 import { applyRateLimit } from '../_lib/rate-limit.js';
 import { getServiceRoleSupabase } from '../_lib/supabase.js';
 import {
@@ -17,20 +17,6 @@ import {
 } from '../_lib/banking-sync.js';
 import type { TrueLayerTransaction } from '../_lib/truelayer.js';
 import { fetchTransactions } from '../_lib/truelayer.js';
-
-const createErrorResponse = (
-  res: VercelResponse,
-  status: number,
-  error: string,
-  code: string,
-  details?: unknown
-) => {
-  const payload: ErrorResponse = { error, code };
-  if (details !== undefined) {
-    payload.details = details;
-  }
-  return res.status(status).json(payload);
-};
 
 const coerceIsoDateTime = (value: string, endOfDay: boolean): string | null => {
   const trimmed = value.trim();
@@ -165,9 +151,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     }
 
     const linkedAccounts = linkedAccountsResult.data ?? [];
-    console.log('[sync-transactions] connection_id:', connection.id, 'linked_accounts:', linkedAccounts.length, linkedAccounts.map(la => ({ account_id: la.account_id, external: la.external_account_id })));
     if (linkedAccounts.length === 0) {
-      console.log('[sync-transactions] EXIT: no linked accounts found for connection', connection.id);
       await markConnectionSyncSuccess(supabase, connection.id);
       await supabase.from('sync_history').insert({
         connection_id: connection.id,
@@ -198,10 +182,8 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
 
     const validAccountIds = new Set((accountsResult.data ?? []).map((account) => account.id));
     const mappedLinkedAccounts = linkedAccounts.filter((item) => validAccountIds.has(item.account_id));
-    console.log('[sync-transactions] valid accounts:', validAccountIds.size, 'mapped linked accounts:', mappedLinkedAccounts.length);
 
     if (mappedLinkedAccounts.length === 0) {
-      console.log('[sync-transactions] EXIT: no valid mapped linked accounts');
       await markConnectionSyncSuccess(supabase, connection.id);
       const response: SyncTransactionsResponse = {
         success: true,
@@ -232,8 +214,6 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
 
       return allTransactions;
     });
-
-    console.log('[sync-transactions] TrueLayer returned', fetchedTransactions.length, 'raw transactions');
 
     const prepared = fetchedTransactions
       .map(({ accountId, transaction }) => {
@@ -310,7 +290,6 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     }
 
     const insertCandidates = uniquePrepared.filter((row) => !existingIds.has(row.external_transaction_id));
-    console.log('[sync-transactions] prepared:', prepared.length, 'unique:', uniquePrepared.length, 'existing:', existingIds.size, 'to insert:', insertCandidates.length);
     let insertedCount = 0;
     for (const insertChunk of chunk(insertCandidates, 200)) {
       if (insertChunk.length === 0) {
@@ -323,12 +302,17 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
 
       if (insertResult.error) {
         if (isSchemaMismatchError(insertResult.error)) {
+          // Log the raw driver error server-side for diagnosis; never return the
+          // Supabase error object to the client (it exposes internal schema).
+          console.error('[sync-transactions] schema mismatch on insert', {
+            code: insertResult.error.code,
+            message: insertResult.error.message
+          });
           return createErrorResponse(
             res,
             500,
             'Missing required transaction deduplication columns; apply open banking enhancement migration.',
-            'schema_mismatch',
-            insertResult.error
+            'schema_mismatch'
           );
         }
         throw new Error(`Failed to insert transactions: ${insertResult.error.message}`);
@@ -359,6 +343,9 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     }
 
     const message = error instanceof Error ? error.message : 'Unexpected error';
+    // The detailed message can carry DB/driver internals — keep it server-side
+    // (console + sync_history audit) and return a generic message to the client.
+    console.error('[sync-transactions] sync failed', { message });
     const body = req.body as SyncTransactionsRequest | undefined;
     if (body?.connectionId) {
       const sb = getServiceRoleSupabase();
@@ -373,6 +360,6 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
       });
     }
 
-    return createErrorResponse(res, 500, message, 'internal_error');
+    return createErrorResponse(res, 500, 'Transaction sync failed', 'internal_error');
   }
 }


### PR DESCRIPTION
Banking observability hardening from `AUDIT_2026-06-12_DEEP_REAUDIT.md`.

## #19 — raw error leakage
The 13 banking handlers each carried a near-identical local `createErrorResponse`, and several spread a `details` argument (raw Supabase/driver error objects) straight into the JSON response — exposing internal schema, constraint names and row ids to callers.

- New shared helper `api/_lib/http-error.ts`: logs `details` **server-side** and returns only `{ error, code }`.
- All 13 handlers now import it; the ~13 duplicated definitions are removed.
- `sync-transactions` additionally returns a generic `"Transaction sync failed"` instead of the raw `error.message`, and logs the detail server-side.
- Net effect: even handlers that still pass an error object as `details` no longer leak it — the helper logs, never serialises, it.

## #20 — PII in server logs
Removed debug `console.log`s that dumped:
- bank `external_account_id`s (`sync-transactions`)
- a full TrueLayer transaction sample — merchant, amount, description (`truelayer.ts`)

Sync counts remain in `sync_history` for observability without the PII.

## Verification
- `npm run typecheck:strict` — clean
- `npm run lint` — clean (zero warnings)
- `npm run build` — clean (pre-existing chunk-size warning only)

No `src/` runtime changes, so no unit tests affected (`api/` is excluded from vitest); validated via typecheck + build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)