### PR TITLE
fix(a11y): keyboard CTAs, modal labels, bottom-sheet focus trap, chart text alts

### DIFF
--- a/src/components/GoalCelebrationModal.tsx
+++ b/src/components/GoalCelebrationModal.tsx
@@ -43,6 +43,7 @@ export default function GoalCelebrationModal({ isOpen, onClose, goal, message }:
       isOpen={isOpen}
       onClose={onClose}
       title=""
+      ariaLabel="Goal achieved"
       size="sm"
     >
       <div className="text-center py-6">

--- a/src/components/MobileBottomSheet.tsx
+++ b/src/components/MobileBottomSheet.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useRef, useState, ReactNode } from 'react';
 import { XIcon } from './icons';
+import { useFocusManager } from './common/useFocusManager';
 
 interface MobileBottomSheetProps {
   isOpen: boolean;
@@ -28,6 +29,7 @@ export function MobileBottomSheet({
   const [startHeight, setStartHeight] = useState(0);
   const sheetRef = useRef<HTMLDivElement>(null);
   const contentRef = useRef<HTMLDivElement>(null);
+  const { saveFocus, restoreFocus, trapFocus, getFocusableElements, moveFocusToElement } = useFocusManager();
 
   useEffect(() => {
     if (isOpen) {
@@ -35,10 +37,10 @@ export function MobileBottomSheet({
       const windowHeight = window.innerHeight;
       const initialHeight = windowHeight * snapPoints[initialSnapPoint];
       setCurrentHeight(initialHeight);
-      
+
       // Prevent body scroll when bottom sheet is open
       document.body.style.overflow = 'hidden';
-      
+
       // Add escape key handler
       const handleEscape = (e: KeyboardEvent) => {
         if (e.key === 'Escape') {
@@ -46,13 +48,26 @@ export function MobileBottomSheet({
         }
       };
       document.addEventListener('keydown', handleEscape);
-      
+
+      // Trap focus inside the sheet so keyboard/switch users can't Tab out into
+      // the inert page behind it (the sheet is aria-modal). Restore focus to the
+      // previously-focused element on close.
+      saveFocus();
+      let releaseTrap: (() => void) | undefined;
+      if (sheetRef.current) {
+        releaseTrap = trapFocus(sheetRef.current);
+        const focusables = getFocusableElements(sheetRef.current);
+        moveFocusToElement(focusables[0] ?? sheetRef.current);
+      }
+
       return () => {
         document.body.style.overflow = '';
         document.removeEventListener('keydown', handleEscape);
+        releaseTrap?.();
+        restoreFocus();
       };
     }
-  }, [isOpen, snapPoints, initialSnapPoint, onClose]);
+  }, [isOpen, snapPoints, initialSnapPoint, onClose, saveFocus, restoreFocus, trapFocus, getFocusableElements, moveFocusToElement]);
 
   const handleTouchStart = (e: React.TouchEvent) => {
     const touch = e.touches[0];
@@ -128,6 +143,7 @@ export function MobileBottomSheet({
         role="dialog"
         aria-modal="true"
         aria-labelledby={title ? 'bottom-sheet-title' : undefined}
+        tabIndex={-1}
       >
         {/* Drag Handle */}
         {showHandle && (

--- a/src/components/charts/DashboardCharts.tsx
+++ b/src/components/charts/DashboardCharts.tsx
@@ -30,6 +30,27 @@ const defaultTickFormatter = (value: number): string => {
   return formatDecimal(value, value >= 10 ? 0 : 2);
 };
 
+/**
+ * Build a complete text alternative of a chart's data for screen readers.
+ *
+ * Recharts 3.x already provides keyboard navigation of data points
+ * (accessibilityLayer), but no static summary of the numbers. We render the
+ * chart as role="img" with this label so a screen reader announces every
+ * value, not just a vague title. (A sibling data <table> isn't possible here:
+ * each chart is the single child of a caller-side ResponsiveContainer.)
+ */
+const buildChartSummary = (
+  title: string | undefined,
+  points: Array<{ label: string; value: string }>
+): string => {
+  const prefix = title ? `${title}. ` : '';
+  if (points.length === 0) {
+    return `${prefix}No data`.trim();
+  }
+  const body = points.map((p) => `${p.label}: ${p.value}`).join('; ');
+  return `${prefix}${body}`;
+};
+
 interface BarChartProps {
   data: Array<Record<string, unknown>>;
   /** Key holding the bar value (e.g. 'netWorth'). */
@@ -57,8 +78,16 @@ export function BarChart({
   showGrid = true,
   'aria-label': ariaLabel
 }: BarChartProps): React.JSX.Element {
+  const formatValue = formatter ?? defaultTickFormatter;
+  const summary = buildChartSummary(
+    ariaLabel,
+    data.map((row) => ({
+      label: String(row[xKey] ?? ''),
+      value: formatValue(Number(row[dataKey] ?? 0))
+    }))
+  );
   return (
-    <RechartsBarChart data={data} aria-label={ariaLabel}>
+    <RechartsBarChart data={data} role="img" aria-label={summary}>
       {showGrid && <CartesianGrid strokeDasharray="3 3" stroke="rgba(55, 65, 81, 0.3)" />}
       <XAxis dataKey={xKey} tick={{ fill: '#6B7280', fontSize: 12 }} />
       <YAxis
@@ -108,8 +137,14 @@ export function PieChart<T extends PieDatum>({
   // index so onClick hands back the caller's own object, not a copy.
   const chartData = data.map((d, index) => ({ name: d.name, value: d.value, index }));
 
+  const formatValue = formatter ?? ((value: number) => formatDecimal(value, 2));
+  const summary = buildChartSummary(
+    ariaLabel,
+    data.map((d) => ({ label: d.name, value: formatValue(d.value) }))
+  );
+
   return (
-    <RechartsPieChart aria-label={ariaLabel}>
+    <RechartsPieChart role="img" aria-label={summary}>
       <Pie
         data={chartData}
         dataKey="value"

--- a/src/components/common/Modal.tsx
+++ b/src/components/common/Modal.tsx
@@ -10,16 +10,23 @@ interface ModalProps {
   size?: 'sm' | 'md' | 'lg' | 'xl' | 'full';
   showCloseButton?: boolean;
   ariaDescribedBy?: string;
+  /**
+   * Accessible name for modals that intentionally render no visible title
+   * (e.g. GoalCelebrationModal). Without it a title-less dialog announces only
+   * "dialog" to screen readers.
+   */
+  ariaLabel?: string;
 }
 
-export function Modal({ 
-  isOpen, 
-  onClose, 
-  title, 
-  children, 
+export function Modal({
+  isOpen,
+  onClose,
+  title,
+  children,
   size = 'md',
   showCloseButton = true,
-  ariaDescribedBy
+  ariaDescribedBy,
+  ariaLabel
 }: ModalProps): React.JSX.Element | null {
   const modalRef = useRef<HTMLDivElement>(null);
   const previousActiveElement = useRef<HTMLElement | null>(null);
@@ -140,18 +147,26 @@ export function Modal({
           `}
           role="dialog"
           aria-modal="true"
-          aria-labelledby="modal-title"
+          // Only label by the heading when there is a real title; otherwise an
+          // empty <h2> would leave the dialog with no accessible name. Title-less
+          // callers supply ariaLabel instead.
+          aria-labelledby={title ? 'modal-title' : undefined}
+          aria-label={!title ? ariaLabel : undefined}
           aria-describedby={ariaDescribedBy}
           tabIndex={-1}
         >
           {/* Header - Always visible */}
           <div className="flex items-center justify-between px-6 py-5 border-b border-gray-200 dark:border-gray-800 bg-gradient-to-r from-gray-50 to-white dark:from-gray-900 dark:to-gray-800 flex-shrink-0">
-            <h2
-              id="modal-title"
-              className="text-xl font-bold text-gray-900 dark:text-white"
-            >
-              {title}
-            </h2>
+            {title ? (
+              <h2
+                id="modal-title"
+                className="text-xl font-bold text-gray-900 dark:text-white"
+              >
+                {title}
+              </h2>
+            ) : (
+              <span aria-hidden="true" />
+            )}
             {showCloseButton && (
               <button
                 onClick={onClose}

--- a/src/pages/Goals.tsx
+++ b/src/pages/Goals.tsx
@@ -157,18 +157,20 @@ export default function Goals() {
     <PageWrapper 
       title="Goals"
       rightContent={
-        <div 
+        <button
+          type="button"
           onClick={() => setIsModalOpen(true)}
-          className="cursor-pointer"
-          title="Add Goal"
+          className="cursor-pointer rounded-full focus:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2"
+          aria-label="Add goal"
         >
           <svg
             width="48"
             height="48"
             viewBox="0 0 48 48"
             xmlns="http://www.w3.org/2000/svg"
+            aria-hidden="true"
+            focusable="false"
             className="transition-all duration-200 hover:scale-110 drop-shadow-lg hover:drop-shadow-xl"
-            
           >
             <circle
               cx="24"
@@ -189,7 +191,7 @@ export default function Goals() {
               />
             </g>
           </svg>
-        </div>
+        </button>
       }
     >
 

--- a/src/pages/Investments.tsx
+++ b/src/pages/Investments.tsx
@@ -157,18 +157,20 @@ export default function Investments() {
       title="Investments"
       rightContent={
         investmentAccounts.length > 0 && (
-          <div 
+          <button
+            type="button"
             onClick={() => setShowAddInvestmentModal(true)}
-            className="cursor-pointer"
-            title="Add Investment"
+            className="cursor-pointer rounded-full focus:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2"
+            aria-label="Add investment"
           >
             <svg
               width="48"
               height="48"
               viewBox="0 0 48 48"
               xmlns="http://www.w3.org/2000/svg"
+              aria-hidden="true"
+              focusable="false"
               className="transition-all duration-200 hover:scale-110 drop-shadow-lg hover:drop-shadow-xl"
-              
             >
               <circle
                 cx="24"
@@ -189,7 +191,7 @@ export default function Investments() {
                 />
               </g>
             </svg>
-          </div>
+          </button>
         )
       }
     >


### PR DESCRIPTION
Accessibility batch from `AUDIT_2026-06-12_DEEP_REAUDIT.md` — the CLAUDE.md "Design/AXE polish" focus area.

## #16 — keyboard-inaccessible primary CTAs (highest impact)
`Goals.tsx` / `Investments.tsx` "Add" buttons were `<div onClick title="Add Goal">` — not focusable, no role, no accessible name. Keyboard and screen-reader users **could not open these modals at all**. Now real `<button type="button" aria-label="Add goal/investment">` with a visible focus ring; the decorative SVG is `aria-hidden`.

## #31 — modal with an empty accessible name
`common/Modal.tsx` set `aria-labelledby="modal-title"` unconditionally, so a title-less modal (`GoalCelebrationModal`, `title=""`) announced only "dialog". Now labels by the heading only when a title exists, and a new optional `ariaLabel` prop names title-less dialogs — `GoalCelebrationModal` → "Goal achieved".

## #32 — MobileBottomSheet had no focus trap
`role="dialog"`/`aria-modal` but Tab escaped into the inert page behind the sheet on mobile viewports. Now reuses the shared `useFocusManager` trap, saves/restores focus on open/close, and the sheet is `tabIndex=-1` as a focus fallback.

## #33 — charts had no text alternative
`charts/DashboardCharts.tsx` exposed only a vague `aria-label`. Each chart now renders `role="img"` with a complete textual summary of **every** data point. (A sibling data `<table>` isn't possible here — each chart is the single child of a caller-side `ResponsiveContainer`; `role="img"` + data-summarizing label is the audit-sanctioned alternative.)

## Verification
- `npm run typecheck:strict` — clean
- `npm run lint` — clean
- `npm run build` — clean (pre-existing chunk-size warning only)
- 134 component/integration tests pass (Modal, GoalCelebrationModal, AddInvestmentModal, charts, Investment portfolio integration)

🤖 Generated with [Claude Code](https://claude.com/claude-code)