### PR TITLE
fix(banking): persist reauth_required so expired connections show Reauthorize (#21/#22/#23)

### DIFF
--- a/api/_lib/banking-sync.ts
+++ b/api/_lib/banking-sync.ts
@@ -19,6 +19,36 @@ const isUnauthorizedTrueLayerError = (error: unknown): boolean => {
   return /\b401\b/.test(error.message);
 };
 
+/**
+ * Raised when a connection can only be recovered by the user re-linking their
+ * bank (expired/absent refresh token, TrueLayer `invalid_grant`, etc.). The
+ * sync handler turns this into a persisted `reauth_required` status so the UI's
+ * Reauthorize CTA appears, instead of a generic `error` with a Sync button that
+ * will always fail.
+ */
+export class ReauthRequiredError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'ReauthRequiredError';
+  }
+}
+
+/**
+ * A token *refresh* failing means the long-lived refresh token is no longer
+ * valid — the user must re-consent. TrueLayer signals this as `invalid_grant`
+ * (HTTP 400), not 401, so a literal-401 check (issue #22) misses it. Treat any
+ * refresh-call failure, plus a missing refresh token, as needs-reauth.
+ */
+export const isReauthRequiredError = (error: unknown): boolean => {
+  if (error instanceof ReauthRequiredError) {
+    return true;
+  }
+  if (!(error instanceof Error)) {
+    return false;
+  }
+  return /invalid_grant|no refresh token|token refresh failed|reauth/i.test(error.message);
+};
+
 export const getUserTrueLayerConnection = async (
   supabase: SupabaseClient,
   userId: string,
@@ -52,11 +82,20 @@ const refreshConnectionAccessToken = async (
   connection: TrueLayerConnectionRow
 ): Promise<AccessTokenResolution> => {
   if (!connection.refresh_token_encrypted) {
-    throw new Error('TrueLayer access token expired and no refresh token is stored');
+    throw new ReauthRequiredError('TrueLayer access token expired and no refresh token is stored');
   }
 
   const refreshToken = decryptSecret(connection.refresh_token_encrypted);
-  const refreshed = await refreshAccessToken(refreshToken);
+  let refreshed;
+  try {
+    refreshed = await refreshAccessToken(refreshToken);
+  } catch (error) {
+    // A failed refresh (invalid_grant / 400 / 401 / expired refresh token) is
+    // unrecoverable without the user re-linking — surface it as needs-reauth
+    // rather than a transient error.
+    const detail = error instanceof Error ? error.message : 'token refresh failed';
+    throw new ReauthRequiredError(`TrueLayer token refresh failed: ${detail}`);
+  }
   const encryptedAccess = encryptSecret(refreshed.access_token);
   const encryptedRefresh = refreshed.refresh_token
     ? encryptSecret(refreshed.refresh_token)
@@ -132,6 +171,50 @@ export const markConnectionSyncFailure = async (
     .update({
       status: 'error',
       error: errorMessage.slice(0, 2000),
+      updated_at: nowIso
+    })
+    .eq('id', connectionId);
+};
+
+/**
+ * Persist the needs-reauth state the UI is already wired for (issue #21/#22):
+ * status='reauth_required' + needs_reauth=true. The BankConnections component
+ * shows its Reauthorize CTA and disables Sync for connections in this state.
+ */
+export const markConnectionNeedsReauth = async (
+  supabase: SupabaseClient,
+  connectionId: string,
+  errorMessage: string
+): Promise<void> => {
+  const nowIso = new Date().toISOString();
+  await supabase
+    .from('bank_connections')
+    .update({
+      status: 'reauth_required',
+      needs_reauth: true,
+      error: errorMessage.slice(0, 2000),
+      updated_at: nowIso
+    })
+    .eq('id', connectionId);
+};
+
+/**
+ * A sync that found no usable linked accounts (issue #23): record that it ran
+ * (last_sync) WITHOUT forcing status back to 'connected'. Unconditionally
+ * marking success here masked genuinely broken connections (error /
+ * reauth_required) as healthy. A previously-connected connection keeps its
+ * connected status via the unchanged column; a broken one retains its problem
+ * state for the user to act on.
+ */
+export const markConnectionSyncNoAccounts = async (
+  supabase: SupabaseClient,
+  connectionId: string
+): Promise<void> => {
+  const nowIso = new Date().toISOString();
+  await supabase
+    .from('bank_connections')
+    .update({
+      last_sync: nowIso,
       updated_at: nowIso
     })
     .eq('id', connectionId);

--- a/api/banking/sync-accounts.ts
+++ b/api/banking/sync-accounts.ts
@@ -9,6 +9,8 @@ import { setCorsHeaders } from '../_lib/cors.js';
 import { createErrorResponse } from '../_lib/http-error.js';
 import {
   getUserTrueLayerConnection,
+  isReauthRequiredError,
+  markConnectionNeedsReauth,
   markConnectionSyncFailure,
   markConnectionSyncSuccess,
   withTrueLayerAccessToken
@@ -277,10 +279,17 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     }
 
     const message = error instanceof Error ? error.message : 'Unexpected error';
+    // Keep the detailed message server-side; return a generic one to the client.
+    console.error('[sync-accounts] sync failed', { message });
+    const needsReauth = isReauthRequiredError(error);
     const body = req.body as SyncAccountsRequest | undefined;
     if (body?.connectionId) {
       const sb = getServiceRoleSupabase();
-      await markConnectionSyncFailure(sb, body.connectionId, message);
+      if (needsReauth) {
+        await markConnectionNeedsReauth(sb, body.connectionId, message);
+      } else {
+        await markConnectionSyncFailure(sb, body.connectionId, message);
+      }
       await sb.from('sync_history').insert({
         connection_id: body.connectionId,
         sync_type: 'accounts',
@@ -291,6 +300,8 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
       });
     }
 
-    return createErrorResponse(res, 500, message, 'internal_error');
+    return needsReauth
+      ? createErrorResponse(res, 409, 'Bank reauthorization required', 'reauth_required')
+      : createErrorResponse(res, 500, 'Account sync failed', 'internal_error');
   }
 }

--- a/api/banking/sync-transactions.ts
+++ b/api/banking/sync-transactions.ts
@@ -11,7 +11,10 @@ import { applyRateLimit } from '../_lib/rate-limit.js';
 import { getServiceRoleSupabase } from '../_lib/supabase.js';
 import {
   getUserTrueLayerConnection,
+  isReauthRequiredError,
+  markConnectionNeedsReauth,
   markConnectionSyncFailure,
+  markConnectionSyncNoAccounts,
   markConnectionSyncSuccess,
   withTrueLayerAccessToken
 } from '../_lib/banking-sync.js';
@@ -152,11 +155,13 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
 
     const linkedAccounts = linkedAccountsResult.data ?? [];
     if (linkedAccounts.length === 0) {
-      await markConnectionSyncSuccess(supabase, connection.id);
+      // No linked accounts: record the run but DON'T flip status to 'connected'
+      // (issue #23) — that would mask a broken/needs-reauth connection as healthy.
+      await markConnectionSyncNoAccounts(supabase, connection.id);
       await supabase.from('sync_history').insert({
         connection_id: connection.id,
         sync_type: 'transactions',
-        status: 'success',
+        status: 'partial',
         records_synced: 0,
         created_at: new Date().toISOString()
       });
@@ -184,7 +189,9 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     const mappedLinkedAccounts = linkedAccounts.filter((item) => validAccountIds.has(item.account_id));
 
     if (mappedLinkedAccounts.length === 0) {
-      await markConnectionSyncSuccess(supabase, connection.id);
+      // Linked accounts exist but none map to the user's accounts: same masking
+      // risk as above (issue #23) — record the run without forcing 'connected'.
+      await markConnectionSyncNoAccounts(supabase, connection.id);
       const response: SyncTransactionsResponse = {
         success: true,
         transactionsImported: 0,
@@ -346,10 +353,19 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     // The detailed message can carry DB/driver internals — keep it server-side
     // (console + sync_history audit) and return a generic message to the client.
     console.error('[sync-transactions] sync failed', { message });
+
+    // A needs-reauth failure (expired/invalid refresh token) is unrecoverable
+    // without the user re-linking: persist 'reauth_required' so the UI shows its
+    // Reauthorize CTA instead of a Sync button that will always fail (#21/#22).
+    const needsReauth = isReauthRequiredError(error);
     const body = req.body as SyncTransactionsRequest | undefined;
     if (body?.connectionId) {
       const sb = getServiceRoleSupabase();
-      await markConnectionSyncFailure(sb, body.connectionId, message);
+      if (needsReauth) {
+        await markConnectionNeedsReauth(sb, body.connectionId, message);
+      } else {
+        await markConnectionSyncFailure(sb, body.connectionId, message);
+      }
       await sb.from('sync_history').insert({
         connection_id: body.connectionId,
         sync_type: 'transactions',
@@ -360,6 +376,8 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
       });
     }
 
-    return createErrorResponse(res, 500, 'Transaction sync failed', 'internal_error');
+    return needsReauth
+      ? createErrorResponse(res, 409, 'Bank reauthorization required', 'reauth_required')
+      : createErrorResponse(res, 500, 'Transaction sync failed', 'internal_error');
   }
 }

--- a/src/components/BankConnections.tsx
+++ b/src/components/BankConnections.tsx
@@ -170,6 +170,10 @@ export default function BankConnections({
         onAccountsLinked?.();
       } else {
         logger.error('Sync failed', result.errors);
+        // Reload so a status change from the failed sync (e.g. reauth_required)
+        // surfaces immediately — otherwise the Reauthorize CTA wouldn't appear
+        // until the next manual refresh.
+        void loadConnections();
       }
     } finally {
       setSyncingConnections(prev => {


### PR DESCRIPTION
Revives the dead bank-reconnect path from `AUDIT_2026-06-12_DEEP_REAUDIT.md`. Previously an expired bank connection showed a generic `error` with an enabled (always-failing) **Sync** button and **no** Reauthorize prompt, because the backend never wrote the `reauth_required` status the UI is already wired for.

## #22 — classify needs-reauth failures
A token **refresh** failing means the long-lived refresh token is gone and the user must re-consent. TrueLayer signals this as `invalid_grant` (**HTTP 400**, not 401), so the old literal-401 check missed it entirely. Now a failed refresh, or a missing refresh token, throws a tagged `ReauthRequiredError`; new `isReauthRequiredError()` classifier.

## #21 — persist the status the UI already handles
`markConnectionNeedsReauth` sets `status='reauth_required'` + `needs_reauth=true`. `sync-transactions` and `sync-accounts` route reauth-class failures here and return **409 `reauth_required`** instead of a generic `error`. `BankConnections` now reloads on sync failure so the Reauthorize CTA appears immediately. (`connections.ts` already returns `status`, which the UI keys off at `BankConnections.tsx:204/213/318/327` — no change needed there.)

## #23 — stop masking broken connections as healthy
A sync that finds zero usable linked accounts no longer flips status to `connected` / clears the error (`markConnectionSyncNoAccounts` only stamps `last_sync`); the run is recorded in `sync_history` as `partial`. A genuinely broken/needs-reauth connection keeps its problem state instead of being reported as a clean sync.

## Bonus
Fixed a raw-error-message leak in `sync-accounts`' catch (now returns generic `Account sync failed`, logs detail server-side) — same class as #19, which the original audit only flagged in `sync-transactions`/`link-accounts`.

## Notes
- **No DB migration**: `bank_connections` already allows `status='reauth_required'` (CHECK constraint) and has the `needs_reauth` column.
- **Verification**: `typecheck:strict`, `lint`, `build` clean; 27 `bankConnectionService` tests pass. The `api/` handlers are excluded from vitest, so the backend logic is validated by typecheck + build + review (consistent with prior banking PRs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)