### PR TITLE
fix(ci): make bundle gate real (ratchet) + reconcile coverage docs to 63%

### DIFF
--- a/.github/workflows/handoff-snapshot.yml
+++ b/.github/workflows/handoff-snapshot.yml
@@ -112,5 +112,4 @@ jobs:
         run: npm run build:check
 
       - name: Run bundle check
-        continue-on-error: true
         run: npm run bundle:check

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,8 +14,8 @@
 | Strict types | `npm run typecheck:strict` | ✅ | TS 5.8 strict |
 | Smoke tests | `npm run test:smoke` | ✅ | JSdom + Vitest |
 | Realtime suite | `npm run test:realtime` | ✅ | Driven by `scripts/realtime-tests.json` |
-| Coverage | `npm run test:coverage` | ✅ | 77.6 % statements / 57 % branches |
-| Threshold | `node scripts/verify-coverage-threshold.mjs …` | ✅ | ≥75 % statements / ≥55 % branches |
+| Coverage | `npm run test:coverage` | ✅ | Enforced floor ≥63 % statements / ≥55 % branches |
+| Threshold | `node scripts/verify-coverage-threshold.mjs …` | ✅ | ≥63 % statements / ≥55 % branches (recalibrated 2026-06 after dead Redux removal) |
 | Supabase smoke | `npm run test:supabase-smoke` | ✅ | Logs saved to `logs/supabase-smoke/` |
 | Build parity | `npm run build` | ✅ | Mirrors Vercel’s `vite build` via `scripts/build-web.mjs` |
 
@@ -63,7 +63,7 @@ npm run typecheck:strict
 npm run test:smoke
 npm run test:realtime
 npm run test:coverage
-node scripts/verify-coverage-threshold.mjs coverage/coverage-final.json --statements=75 --branches=55
+node scripts/verify-coverage-threshold.mjs coverage/coverage-final.json --statements=63 --branches=55
 
 # Supabase smoke (requires real creds)
 RUN_SUPABASE_REAL_TESTS=true npm run test:supabase-smoke

--- a/scripts/bundle-size-check.mjs
+++ b/scripts/bundle-size-check.mjs
@@ -1,13 +1,26 @@
 #!/usr/bin/env node
 
 /**
- * Bundle size check script
- * Reports bundle sizes from the dist/ directory after a build.
- * Exits with 0 (informational only).
+ * Bundle size gate.
+ *
+ * Measures the GZIPPED size of the built JS (the bytes a browser actually
+ * downloads) and fails the build if the largest single chunk or the JS total
+ * exceeds its budget. This is a RATCHET: the budgets are set just above today's
+ * measured size so the gate prevents regression/growth (audit 2026-06-12 #14:
+ * "nothing prevents growth") without breaking the current build. Lower the
+ * budgets as the bundle-optimization work (BLOCKER #2) lands — never raise them
+ * without a deliberate decision.
+ *
+ * Budgets can be overridden via env for experiments:
+ *   BUNDLE_MAX_CHUNK_GZIP_KB, BUNDLE_MAX_TOTAL_JS_GZIP_KB
+ *
+ * Pass --report for a per-file breakdown. Exits non-zero when a budget is
+ * exceeded (or when dist/ is missing in CI, where a build is expected).
  */
 
 import fs from 'fs';
 import path from 'path';
+import zlib from 'zlib';
 import { fileURLToPath } from 'url';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
@@ -15,45 +28,66 @@ const distDir = path.resolve(__dirname, '..', 'dist');
 const assetsDir = path.join(distDir, 'assets');
 const isReport = process.argv.includes('--report');
 
-function formatBytes(bytes) {
-  if (bytes < 1024) return bytes + ' B';
-  if (bytes < 1024 * 1024) return (bytes / 1024).toFixed(1) + ' KB';
-  return (bytes / (1024 * 1024)).toFixed(2) + ' MB';
+// Ratchet budgets (KB, gzipped). Current measured: largest chunk ~293 KB,
+// total JS ~1425 KB. Headroom is intentionally small.
+const MAX_CHUNK_GZIP_KB = Number(process.env.BUNDLE_MAX_CHUNK_GZIP_KB ?? 320);
+const MAX_TOTAL_JS_GZIP_KB = Number(process.env.BUNDLE_MAX_TOTAL_JS_GZIP_KB ?? 1500);
+
+function formatKb(bytes) {
+  return `${(bytes / 1024).toFixed(1)} KB`;
 }
 
-function getFiles(dir) {
-  if (!fs.existsSync(dir)) return [];
-  return fs.readdirSync(dir)
-    .filter(f => fs.statSync(path.join(dir, f)).isFile())
-    .map(f => ({
-      name: f,
-      size: fs.statSync(path.join(dir, f)).size,
-    }))
-    .sort((a, b) => b.size - a.size);
+/** Gzipped size of a JS asset: prefer the emitted .gz, else gzip in-process. */
+function gzipSize(filePath) {
+  const gzPath = `${filePath}.gz`;
+  if (fs.existsSync(gzPath)) {
+    return fs.statSync(gzPath).size;
+  }
+  return zlib.gzipSync(fs.readFileSync(filePath), { level: 9 }).length;
 }
 
-if (!fs.existsSync(distDir)) {
-  console.log('dist/ directory not found. Run npm run build first.');
-  process.exit(0);
+if (!fs.existsSync(assetsDir)) {
+  console.error('✗ dist/assets not found. Run `npm run build` before the bundle check.');
+  process.exit(1);
 }
 
-const assets = getFiles(assetsDir);
-const jsFiles = assets.filter(f => f.name.endsWith('.js') && !f.name.endsWith('.js.gz') && !f.name.endsWith('.js.br'));
-const cssFiles = assets.filter(f => f.name.endsWith('.css') && !f.name.endsWith('.css.gz') && !f.name.endsWith('.css.br'));
+const jsFiles = fs.readdirSync(assetsDir)
+  .filter((f) => f.endsWith('.js'))
+  .map((f) => ({ name: f, gzip: gzipSize(path.join(assetsDir, f)) }))
+  .sort((a, b) => b.gzip - a.gzip);
 
-const totalJS = jsFiles.reduce((sum, f) => sum + f.size, 0);
-const totalCSS = cssFiles.reduce((sum, f) => sum + f.size, 0);
+if (jsFiles.length === 0) {
+  console.error('✗ No JS chunks found in dist/assets.');
+  process.exit(1);
+}
 
-console.log('\n📦 Bundle Size Report\n');
-console.log(`JS total:  ${formatBytes(totalJS)}`);
-console.log(`CSS total: ${formatBytes(totalCSS)}`);
-console.log(`Combined:  ${formatBytes(totalJS + totalCSS)}\n`);
+const totalJsGzip = jsFiles.reduce((sum, f) => sum + f.gzip, 0);
+const largest = jsFiles[0];
+
+console.log('\n📦 Bundle Size Gate (gzipped)\n');
+console.log(`Largest chunk: ${formatKb(largest.gzip)}  (${largest.name})  — budget ${MAX_CHUNK_GZIP_KB} KB`);
+console.log(`JS total:      ${formatKb(totalJsGzip)}  — budget ${MAX_TOTAL_JS_GZIP_KB} KB\n`);
 
 if (isReport) {
-  console.log('JS files:');
-  jsFiles.forEach(f => console.log(`  ${formatBytes(f.size).padStart(10)}  ${f.name}`));
-  console.log('\nCSS files:');
-  cssFiles.forEach(f => console.log(`  ${formatBytes(f.size).padStart(10)}  ${f.name}`));
+  console.log('JS chunks (gzipped):');
+  jsFiles.forEach((f) => console.log(`  ${formatKb(f.gzip).padStart(10)}  ${f.name}`));
+  console.log('');
 }
 
+const failures = [];
+if (largest.gzip > MAX_CHUNK_GZIP_KB * 1024) {
+  failures.push(`Largest chunk ${formatKb(largest.gzip)} exceeds budget ${MAX_CHUNK_GZIP_KB} KB (${largest.name})`);
+}
+if (totalJsGzip > MAX_TOTAL_JS_GZIP_KB * 1024) {
+  failures.push(`JS total ${formatKb(totalJsGzip)} exceeds budget ${MAX_TOTAL_JS_GZIP_KB} KB`);
+}
+
+if (failures.length > 0) {
+  console.error('✗ Bundle budget exceeded:');
+  for (const f of failures) console.error(`  - ${f}`);
+  console.error('\nReduce bundle size or, if the growth is justified, raise the budget deliberately.');
+  process.exit(1);
+}
+
+console.log('✓ Bundle within budget.');
 process.exit(0);


### PR DESCRIPTION
Governance findings from `AUDIT_2026-06-12_DEEP_REAUDIT.md`.

## #14 — bundle-size gate was a no-op
`scripts/bundle-size-check.mjs` always `exit(0)` and the CI step was `continue-on-error: true`, so CLAUDE.md advertised a "Bundle Check" gate that did nothing — nothing prevented the bundle from growing.

- Rewrote the script to measure **gzipped** size (prefers the emitted `.gz`, falls back to in-process gzip) and **fail** when the largest single chunk or the JS total exceeds budget.
- Budgets are a **ratchet** set just above today's measured size — largest chunk ~293 KB → **320 KB**, total JS ~1431 KB → **1500 KB** — so the gate blocks regression *without breaking the current build*. Env-overridable (`BUNDLE_MAX_CHUNK_GZIP_KB`, `BUNDLE_MAX_TOTAL_JS_GZIP_KB`); lower them as bundle optimisation (BLOCKER #2) lands.
- Removed `continue-on-error` from the CI step so it actually gates. CI builds (`build:check`) before this step, so `dist/` exists.

## #34 — coverage doc drift
CLAUDE.md advertised a ≥75% / 77.6% coverage floor, but the CI gate is `--statements=63 --branches=55`. Reconciled all three references in CLAUDE.md to the real **63% / 55%**, noting the recalibration after dead-Redux removal (honest over aspirational, per Rule #11).

## Verification
- New gate exits 0 against the current build (293 KB largest / 1431 KB total — within budget).
- `build:check` + `lint` + `test:unit` pass (pre-commit gate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)