### PR TITLE
fix: Stripe lost-event retry, drop plaintext Plaid tables, server-env preflight (#6/#10/#36)

### DIFF
--- a/api/stripe/webhook.ts
+++ b/api/stripe/webhook.ts
@@ -145,7 +145,14 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
   const supabase = getServiceRoleSupabase();
 
   // Idempotency: subscription_logs.event_id is UNIQUE. A duplicate delivery
-  // hits the conflict and is acknowledged without reprocessing.
+  // hits the conflict — but a conflict alone does NOT mean the event was
+  // handled. The row is inserted processed:false BEFORE handling, so if a
+  // previous attempt threw (e.g. the Clerk-created users row didn't exist
+  // yet), the row sits at processed:false while Stripe retries. Acking those
+  // retries unconditionally permanently dropped the event — a paying
+  // customer's tier was never written (audit finding #6). Only short-circuit
+  // when the prior attempt actually finished (processed:true); otherwise fall
+  // through and reprocess.
   const logInsert = await supabase
     .from('subscription_logs')
     .insert({
@@ -157,14 +164,34 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
 
   if (logInsert.error) {
     if (logInsert.error.code === '23505') {
-      // Already received this event — acknowledge so Stripe stops retrying.
-      return res.status(200).json({ received: true, duplicate: true });
+      const existingEvent = await supabase
+        .from('subscription_logs')
+        .select('processed')
+        .eq('event_id', event.id)
+        .maybeSingle();
+
+      if (existingEvent.error) {
+        console.error('[stripe-webhook] Failed to check duplicate event state', {
+          code: existingEvent.error.code,
+          message: existingEvent.error.message
+        });
+        // 500 → Stripe retries; better than guessing the processed state.
+        return res.status(500).json({ error: 'Failed to check event state', code: 'internal_error' });
+      }
+
+      if ((existingEvent.data as { processed: boolean | null } | null)?.processed) {
+        // Genuinely already handled — acknowledge so Stripe stops retrying.
+        return res.status(200).json({ received: true, duplicate: true });
+      }
+      // processed:false → the earlier attempt failed mid-handling. Fall
+      // through and reprocess this retry; the row already exists.
+    } else {
+      console.error('[stripe-webhook] Failed to record event', {
+        code: logInsert.error.code,
+        message: logInsert.error.message
+      });
+      return res.status(500).json({ error: 'Failed to record event', code: 'internal_error' });
     }
-    console.error('[stripe-webhook] Failed to record event', {
-      code: logInsert.error.code,
-      message: logInsert.error.message
-    });
-    return res.status(500).json({ error: 'Failed to record event', code: 'internal_error' });
   }
 
   try {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "dev": "./scripts/dev.sh",
     "dev:vite": "vite",
-    "build": "vite build",
+    "build": "node scripts/verify-server-env.mjs && vite build",
     "build:check": "tsc -b && vite build",
     "build:bypass": "vite build --mode production",
     "build:lenient": "tsc -p tsconfig.lenient.json --noEmit && vite build",

--- a/scripts/backup-database.mjs
+++ b/scripts/backup-database.mjs
@@ -63,8 +63,7 @@ export const TABLES = [
   'sync_history',
   'sync_metadata',
   'webhook_events',
-  'dashboard_layouts',
-  'plaid_connections'
+  'dashboard_layouts'
 ];
 
 const PAGE = 1000;

--- a/scripts/build-web.mjs
+++ b/scripts/build-web.mjs
@@ -5,6 +5,17 @@ import { spawnSync } from 'node:child_process';
 // This handles both monorepo and flat structures
 // Vercel will set the correct working directory
 
+// Server-env preflight: fails the build on Vercel when core server secrets
+// are missing or a VITE_-prefixed secret would be inlined into the bundle.
+// Report-only outside Vercel (CI/local have no server secrets by design).
+const preflight = spawnSync('node', ['scripts/verify-server-env.mjs'], {
+  stdio: 'inherit',
+  shell: false,
+});
+if ((preflight.status ?? 1) !== 0) {
+  process.exit(preflight.status ?? 1);
+}
+
 console.log('Build helper: Running vite build...');
 
 const result = spawnSync('npx', ['vite', 'build'], {

--- a/scripts/delete-user.mjs
+++ b/scripts/delete-user.mjs
@@ -50,7 +50,7 @@ const UUID_TABLES = [
   'investments', 'transactions', 'budgets', 'goals', 'categories', 'accounts',
   'subscriptions', 'invoices', 'payment_methods', 'subscription_usage',
   'subscription_logs', 'subscription_events', 'bank_connections',
-  'linked_accounts', 'sync_history', 'dashboard_layouts', 'plaid_connections'
+  'linked_accounts', 'sync_history', 'dashboard_layouts'
 ];
 const CLERK_TABLES = [['user_profiles', 'clerk_user_id'], ['recurring_transactions', 'user_id']];
 

--- a/scripts/verify-server-env.mjs
+++ b/scripts/verify-server-env.mjs
@@ -1,0 +1,87 @@
+#!/usr/bin/env node
+
+/**
+ * Server-env preflight (AUDIT_2026-06-12_DEEP_REAUDIT.md finding #36).
+ *
+ * Before this, server secrets (CLERK_SECRET_KEY, SUPABASE_SERVICE_ROLE_KEY,
+ * Stripe/TrueLayer creds…) were validated nowhere at build time — a missing
+ * one only surfaced at request time as a 500. This runs at the start of the
+ * Vercel build (scripts/build-web.mjs) so a misconfigured deploy fails the
+ * BUILD, not the first user request.
+ *
+ * Enforcement is scoped to where it can't cause false failures:
+ *   - Vercel production build  → REQUIRED vars hard-fail when missing.
+ *   - Any Vercel build         → the LEAK GUARD hard-fails: a VITE_-prefixed
+ *     service-role var would be inlined into the public browser bundle by
+ *     Vite. That exact regression shipped the master key to production on
+ *     2026-06-12 — it must never build again.
+ *   - GitHub CI / local        → report-only, exit 0 (server secrets are
+ *     intentionally absent there; this is documented, not an oversight).
+ *
+ * EXPECTED vars warn (never fail) everywhere: some (Stripe, CRON_SECRET) are
+ * known-unconfigured while that rollout is pending, and failing on them would
+ * block unrelated deploys.
+ */
+
+const isVercel = process.env.VERCEL === '1';
+const isVercelProd = isVercel && process.env.VERCEL_ENV === 'production';
+
+// Hard requirements for the core data path (Supabase + Clerk auth bridge).
+const REQUIRED_IN_PROD = [
+  'VITE_SUPABASE_URL',
+  'VITE_SUPABASE_ANON_KEY',
+  'SUPABASE_SERVICE_ROLE_KEY',
+  'CLERK_SECRET_KEY'
+];
+
+// Used by api/ handlers; absence degrades a feature rather than the core app.
+const EXPECTED = [
+  'STRIPE_SECRET_KEY',
+  'STRIPE_WEBHOOK_SECRET',
+  'STRIPE_PRICE_PRO_MONTHLY',
+  'STRIPE_PRICE_PREMIUM_MONTHLY',
+  'CRON_SECRET',
+  'TRUELAYER_CLIENT_ID',
+  'TRUELAYER_CLIENT_SECRET',
+  'TRUELAYER_REDIRECT_URI',
+  'ENCRYPTION_KEY'
+];
+
+// Vars that must NOT exist: VITE_-prefixed secrets get inlined into the
+// public bundle at build time.
+const FORBIDDEN = ['VITE_SUPABASE_SERVICE_ROLE_KEY'];
+
+const missing = (names) => names.filter((n) => !process.env[n] || !process.env[n].trim());
+const present = (names) => names.filter((n) => process.env[n] && process.env[n].trim());
+
+const missingRequired = missing(REQUIRED_IN_PROD);
+const missingExpected = missing(EXPECTED);
+const forbiddenPresent = present(FORBIDDEN);
+
+const ctx = isVercel ? `vercel/${process.env.VERCEL_ENV ?? 'unknown'}` : 'local/ci';
+console.log(`\n🔐 Server-env preflight (${ctx})`);
+
+if (forbiddenPresent.length > 0) {
+  console.error(`✗ FORBIDDEN env var(s) set: ${forbiddenPresent.join(', ')}`);
+  console.error('  VITE_-prefixed secrets are inlined into the public browser bundle.');
+  console.error('  Move the value to the non-prefixed name and delete this variable.');
+  if (isVercel) {
+    process.exit(1);
+  }
+  console.error('  (Not failing outside Vercel — fix it before deploying.)');
+}
+
+if (missingRequired.length > 0) {
+  if (isVercelProd) {
+    console.error(`✗ Missing REQUIRED server env in production build: ${missingRequired.join(', ')}`);
+    console.error('  Failing the build — these would 500 on the first request.');
+    process.exit(1);
+  }
+  console.log(`  required-but-unset here (ok outside Vercel production): ${missingRequired.join(', ')}`);
+}
+
+if (missingExpected.length > 0) {
+  console.warn(`  ⚠ expected-but-unset (feature-degrading, not fatal): ${missingExpected.join(', ')}`);
+}
+
+console.log('✓ Server-env preflight passed.\n');

--- a/supabase/migrations/20260613100000_drop_legacy_plaid_tables.sql
+++ b/supabase/migrations/20260613100000_drop_legacy_plaid_tables.sql
@@ -1,0 +1,23 @@
+-- Drop the legacy Plaid tables (AUDIT_2026-06-12_DEEP_REAUDIT.md finding #10).
+--
+-- plaid_connections stored `access_token text NOT NULL` in PLAINTEXT — unlike
+-- the live TrueLayer path (bank_connections.access_token_encrypted). The app
+-- migrated to TrueLayer; no code populates or reads these tables, and all
+-- three were verified EMPTY in production on 2026-06-13 (service-role count:
+-- plaid_connections 0, plaid_accounts 0, plaid_webhooks 0). The 20260612100000
+-- migration already locked their RLS to service_role-only as an interim
+-- measure; removing them eliminates the plaintext-token footgun entirely.
+--
+-- accounts.plaid_connection_id / accounts.plaid_account_id COLUMNS are kept:
+-- they're nullable, harmless, and still mapped by the account service. Only
+-- the FK into the dropped table goes.
+--
+-- The pentest harness (scripts/pentest.mjs) keeps probing these table names
+-- and treats "table absent" as PASS — so an accidental re-creation with weak
+-- RLS would be caught.
+
+ALTER TABLE public.accounts DROP CONSTRAINT IF EXISTS accounts_plaid_connection_id_fkey;
+
+DROP TABLE IF EXISTS public.plaid_webhooks;
+DROP TABLE IF EXISTS public.plaid_accounts;
+DROP TABLE IF EXISTS public.plaid_connections;


### PR DESCRIPTION
Group C from `AUDIT_2026-06-12_DEEP_REAUDIT.md`.

## #6 — Stripe webhook permanently dropped failed events (entitlement loss)
The event row is inserted `processed:false` **before** handling. If handling threw (e.g. the known race where the Clerk-created `users` row doesn't exist yet), the row stayed `processed:false` — and Stripe's retry hit the unique `event_id` conflict and was acked `duplicate:true` **without checking the processed flag**. Net effect: a paying customer's tier/status was never written, permanently.

Now a 23505 conflict SELECTs the existing row: short-circuit only when `processed:true`; a `processed:false` row means the prior attempt failed mid-handling, so the retry falls through and reprocesses. If the state check itself fails, return 500 so Stripe keeps retrying rather than guessing.

## #10 — legacy Plaid tables dropped (plaintext token footgun)
`plaid_connections.access_token` was `text NOT NULL` — plaintext, unlike the live encrypted TrueLayer path. Evidence gathered before dropping:
- All three tables verified **empty in production** (service-role count 2026-06-13: 0/0/0 rows).
- No app code reads or writes them (only utility scripts listed them — updated).
- Migration `20260613100000` drops `plaid_webhooks`/`plaid_accounts`/`plaid_connections` plus the `accounts` FK; the nullable `accounts.plaid_*` columns stay (still mapped by the account service).
- The pentest harness keeps probing these table names (absent = pass), so a weak re-creation would be caught.

## #36 — server-env preflight (build-time, scoped enforcement)
New `scripts/verify-server-env.mjs`, wired into both `package.json` `"build"` and `scripts/build-web.mjs` (verified via the Vercel API that the project has `framework: null`, i.e. it builds with `npm run build`):
- **Vercel production**: hard-fails when core data-path secrets are missing (`VITE_SUPABASE_URL`, `VITE_SUPABASE_ANON_KEY`, `SUPABASE_SERVICE_ROLE_KEY`, `CLERK_SECRET_KEY`) — they'd 500 on the first request.
- **Any Vercel build**: hard-fails if `VITE_SUPABASE_SERVICE_ROLE_KEY` exists — the exact Vite-inlining regression that leaked the master key to the production bundle on 2026-06-12 can never build again.
- Known-pending vars (Stripe, `CRON_SECRET`, TrueLayer) only **warn**, so they can't block unrelated deploys; CI/local are report-only by design (documented in the script).

All three modes were tested: local → exit 0; simulated prod-with-missing → exit 1; simulated forbidden-var → exit 1.

## Apply note
Run `supabase/migrations/20260613100000_drop_legacy_plaid_tables.sql` in the SQL Editor together with `20260612110000` and `20260613090000` from the earlier PRs.

## Verification
`typecheck:strict`, `lint`, `build` (now incl. preflight) all clean; pre-commit gate passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)