### PR TITLE
fix(banking): re-adopt existing account on reconnect instead of duplicating

### DIFF
--- a/api/banking/link-accounts.ts
+++ b/api/banking/link-accounts.ts
@@ -77,6 +77,30 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
         return createErrorResponse(res, 500, `Failed to link account: ${upsertError.message}`, 'internal_error');
       }
 
+      // Persist the provider-stable bank identifiers on the account (when the
+      // client supplied them) so a future disconnect→reconnect can re-adopt
+      // this account instead of creating a duplicate (see sync-accounts
+      // findAdoptableAccountId). Link time is the primary account-binding path,
+      // so without this the re-adoption key would be missing for manually
+      // linked accounts.
+      const identifierFields: Record<string, string> = {};
+      if (link.sortCode) identifierFields.sort_code = link.sortCode;
+      if (link.accountNumber) identifierFields.account_number = link.accountNumber;
+      if (Object.keys(identifierFields).length > 0) {
+        const { error: idError } = await supabase
+          .from('accounts')
+          .update(identifierFields)
+          .eq('id', link.accountId)
+          .eq('user_id', auth.userId);
+        if (idError) {
+          console.error('[link-accounts] failed to store bank identifiers', {
+            code: idError.code,
+            message: idError.message
+          });
+          return createErrorResponse(res, 500, 'Failed to store account identifiers', 'internal_error');
+        }
+      }
+
       // Snap the account to the bank's reported balance via the audited RPC:
       // it shifts initial_balance by the same delta as balance, so the ledger
       // invariant (balance = initial_balance + Σtxns) holds through the snap

--- a/api/banking/sync-accounts.ts
+++ b/api/banking/sync-accounts.ts
@@ -16,6 +16,7 @@ import {
   withTrueLayerAccessToken
 } from '../_lib/banking-sync.js';
 import { fetchAccountBalance, fetchAccounts } from '../_lib/truelayer.js';
+import { selectAdoptableAccountId, type AdoptionCandidate } from '../../src/services/banking/accountMatching.js';
 
 const inferMask = (account: {
   account_number?: {
@@ -35,6 +36,17 @@ const inferMask = (account: {
 
   return undefined;
 };
+
+/** The provider-STABLE identifier (full sort code + account number) from the
+ *  TrueLayer payload. Unlike account_id, these survive a disconnect/reconnect,
+ *  so they are the key used to re-adopt an existing account (see
+ *  findAdoptableAccountId). */
+const extractBankIdentifiers = (account: {
+  account_number?: { number?: string; sort_code?: string };
+}): { accountNumber: string | null; sortCode: string | null } => ({
+  accountNumber: account.account_number?.number?.trim() || null,
+  sortCode: account.account_number?.sort_code?.trim() || null
+});
 
 const mapAccountType = (accountType: string | undefined): string => {
   const normalized = (accountType ?? '').toLowerCase();
@@ -57,12 +69,71 @@ interface SyncedTrueLayerAccount {
   balance: number;
   currency: string;
   mask?: string;
+  accountNumber?: string | null;
+  sortCode?: string | null;
 }
 
 interface LinkedAccountRow {
   account_id: string;
   external_account_id: string;
 }
+
+/**
+ * Reconnect-safe account recovery (audit: a disconnect→reconnect created a
+ * DUPLICATE account). On a fresh connection the linked_accounts mapping is gone
+ * (disconnect hard-deletes the connection, cascade-deleting its links) and
+ * TrueLayer reissues account_id, so neither the per-connection link nor the
+ * external id can locate the user's existing account — the sync then auto-creates
+ * a duplicate. Match instead on the provider-STABLE identifier (sort code +
+ * account number, normalised). Adopt ONLY a single, unambiguous, currently-
+ * UNLINKED candidate, so we never hijack an account managed by another live
+ * connection, never merge two real accounts that merely share a name, and never
+ * touch `balance` (the caller's update path sets bank_balance only).
+ */
+const findAdoptableAccountId = async (
+  supabase: ReturnType<typeof getServiceRoleSupabase>,
+  userId: string,
+  account: SyncedTrueLayerAccount
+): Promise<string | null> => {
+  if (!account.accountNumber || !account.sortCode) {
+    return null; // bank gave no stable identifier — skip the scan entirely
+  }
+
+  // User-scoped only (never a cross-tenant scan): the user's own active accounts
+  // that carry a stored account number.
+  const candidatesResult = await supabase
+    .from('accounts')
+    .select('id, account_number, sort_code')
+    .eq('user_id', userId)
+    .eq('is_active', true)
+    .not('account_number', 'is', null);
+  if (candidatesResult.error) {
+    throw new Error(`Failed to scan accounts for re-adoption: ${candidatesResult.error.message}`);
+  }
+  const candidates: AdoptionCandidate[] = (candidatesResult.data ?? []).map((row) => ({
+    id: row.id as string,
+    accountNumber: (row.account_number as string | null) ?? null,
+    sortCode: (row.sort_code as string | null) ?? null
+  }));
+  if (candidates.length === 0) {
+    return null;
+  }
+
+  // Which of those candidates are already linked to ANY connection (never adopt
+  // a live-linked account). One query, scoped to the candidate ids.
+  const linksResult = await supabase
+    .from('linked_accounts')
+    .select('account_id')
+    .in('account_id', candidates.map((c) => c.id));
+  if (linksResult.error) {
+    throw new Error(`Failed to check existing links: ${linksResult.error.message}`);
+  }
+  const linkedAccountIds = new Set<string>(
+    (linksResult.data ?? []).map((row) => row.account_id as string)
+  );
+
+  return selectAdoptableAccountId(candidates, linkedAccountIds, account.accountNumber, account.sortCode);
+};
 
 const persistAccountsAndLinks = async (
   supabase: ReturnType<typeof getServiceRoleSupabase>,
@@ -99,6 +170,21 @@ const persistAccountsAndLinks = async (
     const existingLink = linkByExternalAccountId.get(account.externalAccountId);
     let accountId = existingLink?.account_id ?? null;
 
+    // Reconnect recovery: when this external account has no link (a fresh
+    // connection after a disconnect, or TrueLayer reissued the account_id),
+    // re-adopt the user's existing account for the same real bank account
+    // instead of auto-creating a duplicate. Routes through the update branch
+    // below, which sets bank_balance only — never `balance` — so no double-count.
+    if (!accountId) {
+      accountId = await findAdoptableAccountId(supabase, userId, account);
+    }
+
+    // Stable bank identifiers, stored so future reconnects can re-adopt this
+    // account (only overwrite when the bank actually supplied them).
+    const identifierFields: Record<string, string> = {};
+    if (account.accountNumber) identifierFields.account_number = account.accountNumber;
+    if (account.sortCode) identifierFields.sort_code = account.sortCode;
+
     if (accountId) {
       // The bank's reported figure goes to bank_balance (the reconciliation
       // reference) ONLY. `balance` is ledger-authoritative — moved exclusively
@@ -114,7 +200,8 @@ const persistAccountsAndLinks = async (
           currency: account.currency,
           institution: connection.institution_name,
           is_active: true,
-          updated_at: nowIso
+          updated_at: nowIso,
+          ...identifierFields
         })
         .eq('id', accountId)
         .eq('user_id', userId)
@@ -151,7 +238,8 @@ const persistAccountsAndLinks = async (
           institution: connection.institution_name,
           is_active: true,
           created_at: nowIso,
-          updated_at: nowIso
+          updated_at: nowIso,
+          ...identifierFields
         })
         .select('id')
         .single();
@@ -241,13 +329,16 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
             // Balance endpoint failures should not block account discovery.
           }
 
+          const identifiers = extractBankIdentifiers(account);
           return {
             externalAccountId: account.account_id,
             name: account.display_name?.trim() || connection.institution_name,
             type: mapAccountType(account.account_type),
             balance,
             currency: account.currency || 'GBP',
-            mask: inferMask(account)
+            mask: inferMask(account),
+            accountNumber: identifiers.accountNumber,
+            sortCode: identifiers.sortCode
           };
         })
       );

--- a/src/components/banking/LinkBankAccountsModal.tsx
+++ b/src/components/banking/LinkBankAccountsModal.tsx
@@ -167,7 +167,9 @@ export default function LinkBankAccountsModal({
           accountId: sl.selectedAccountId,
           externalAccountName: discovered?.name ?? '',
           externalAccountMask: discovered?.mask,
-          balance: discovered?.balance ?? 0
+          balance: discovered?.balance ?? 0,
+          sortCode: discovered?.sortCode,
+          accountNumber: discovered?.accountNumber
         };
       });
 

--- a/src/services/banking/__tests__/accountMatching.test.ts
+++ b/src/services/banking/__tests__/accountMatching.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect } from 'vitest';
+import { digitsOnly, selectAdoptableAccountId, type AdoptionCandidate } from '../accountMatching';
+
+const acct = (id: string, accountNumber: string | null, sortCode: string | null): AdoptionCandidate => ({
+  id,
+  accountNumber,
+  sortCode
+});
+
+describe('digitsOnly', () => {
+  it('strips all non-digits so formats compare equal', () => {
+    expect(digitsOnly('40-18-41')).toBe('401841');
+    expect(digitsOnly('401841')).toBe('401841');
+    expect(digitsOnly('82195747')).toBe('82195747');
+  });
+  it('treats null/undefined/empty as empty string', () => {
+    expect(digitsOnly(null)).toBe('');
+    expect(digitsOnly(undefined)).toBe('');
+    expect(digitsOnly('')).toBe('');
+  });
+});
+
+describe('selectAdoptableAccountId', () => {
+  const A1 = acct('a1', '82195747', '40-18-41'); // stored with dashes (the incident account)
+
+  it('re-adopts the single unlinked match across sort-code format variance', () => {
+    // Incoming from TrueLayer with no dashes — must still match the dashed stored value.
+    const id = selectAdoptableAccountId([A1], new Set(), '82195747', '401841');
+    expect(id).toBe('a1');
+  });
+
+  it('returns null when the bank supplies no stable identifier (regression: avoids duplicate-less adoption)', () => {
+    expect(selectAdoptableAccountId([A1], new Set(), null, null)).toBeNull();
+    expect(selectAdoptableAccountId([A1], new Set(), '82195747', null)).toBeNull();
+    expect(selectAdoptableAccountId([A1], new Set(), null, '401841')).toBeNull();
+  });
+
+  it('returns null when the existing account has no stored identifiers to match (documents the duplicate-creating gap)', () => {
+    // An account whose account_number/sort_code were never written cannot be
+    // re-adopted — the handler falls through to creating a new account. This is
+    // the eventual-consistency window closed by writing identifiers at link/sync.
+    const noIds = acct('a1', null, null);
+    expect(selectAdoptableAccountId([noIds], new Set(), '82195747', '401841')).toBeNull();
+  });
+
+  it('returns null on ambiguity (two real accounts share the identifier)', () => {
+    const dup = acct('a2', '82195747', '40-18-41');
+    expect(selectAdoptableAccountId([A1, dup], new Set(), '82195747', '401841')).toBeNull();
+  });
+
+  it('refuses to hijack an account already linked to a live connection', () => {
+    expect(selectAdoptableAccountId([A1], new Set(['a1']), '82195747', '401841')).toBeNull();
+  });
+
+  it('does not match on account number alone or sort code alone', () => {
+    const sameNumberDiffSort = acct('a1', '82195747', '99-99-99');
+    expect(selectAdoptableAccountId([sameNumberDiffSort], new Set(), '82195747', '401841')).toBeNull();
+    const sameSortDiffNumber = acct('a1', '00000000', '40-18-41');
+    expect(selectAdoptableAccountId([sameSortDiffNumber], new Set(), '82195747', '401841')).toBeNull();
+  });
+
+  it('returns null when there are no candidates at all (genuinely new account)', () => {
+    expect(selectAdoptableAccountId([], new Set(), '82195747', '401841')).toBeNull();
+  });
+});

--- a/src/services/banking/accountMatching.ts
+++ b/src/services/banking/accountMatching.ts
@@ -1,0 +1,56 @@
+/**
+ * Pure account-matching logic for reconnect-safe re-adoption.
+ *
+ * Extracted from the sync-accounts handler so the decision can be unit-tested
+ * (api/ handlers are excluded from the vitest run). The handler does the IO
+ * (queries the user's accounts and their links) and delegates the decision
+ * here.
+ *
+ * Background: when a bank connection is disconnected and re-created, the
+ * linked_accounts mapping is cascade-deleted and TrueLayer reissues the
+ * account_id, so neither the per-connection link nor the external id can locate
+ * the user's existing account — the sync would then auto-create a DUPLICATE.
+ * The provider-STABLE identifier (sort code + account number) survives a
+ * reconnect, so it is the key used to re-adopt the existing account.
+ */
+
+/** Digits-only, so "40-18-41" and "401841" compare equal. */
+export const digitsOnly = (value: string | null | undefined): string => (value ?? '').replace(/\D/g, '');
+
+export interface AdoptionCandidate {
+  id: string;
+  accountNumber: string | null;
+  sortCode: string | null;
+}
+
+/**
+ * Choose the existing account to re-adopt for an incoming bank account, or null.
+ *
+ * Adopts ONLY a single, unambiguous, currently-UNLINKED candidate, so it never:
+ *  - adopts when the bank gave no stable identifier (returns null),
+ *  - merges two real accounts that share an identifier (ambiguous → null),
+ *  - hijacks an account already linked to a live connection (linked → null).
+ *
+ * @param candidates       the user's own active accounts that have an account_number
+ * @param linkedAccountIds account ids currently linked to ANY connection
+ */
+export const selectAdoptableAccountId = (
+  candidates: readonly AdoptionCandidate[],
+  linkedAccountIds: ReadonlySet<string>,
+  wantAccountNumber: string | null | undefined,
+  wantSortCode: string | null | undefined
+): string | null => {
+  const wantNumber = digitsOnly(wantAccountNumber);
+  const wantSort = digitsOnly(wantSortCode);
+  if (!wantNumber || !wantSort) {
+    return null; // bank gave no stable identifier — cannot safely re-adopt
+  }
+
+  const matches = candidates.filter(
+    (c) => digitsOnly(c.accountNumber) === wantNumber && digitsOnly(c.sortCode) === wantSort
+  );
+  if (matches.length !== 1) {
+    return null; // zero (genuinely new account) or ambiguous (>1) → do not adopt
+  }
+  return linkedAccountIds.has(matches[0].id) ? null : matches[0].id;
+};

--- a/src/types/banking-api.ts
+++ b/src/types/banking-api.ts
@@ -56,6 +56,10 @@ export interface LinkAccountsRequest {
     externalAccountName: string;
     externalAccountMask?: string;
     balance: number;
+    // Provider-stable bank identifiers, persisted on the account so a future
+    // disconnect→reconnect can re-adopt it instead of creating a duplicate.
+    sortCode?: string;
+    accountNumber?: string;
   }>;
 }
 


### PR DESCRIPTION
## The incident
A single HSBC account ("GREEN S A") ended up split across **two** WealthTracker account records — the recent transactions landed in a brand-new duplicate instead of the user's existing account. (The user's live data was separately repaired by an audited merge.)

## Root cause
`disconnect.ts` **hard-deletes** the `bank_connections` row. Its FKs are asymmetric: `linked_accounts.connection_id` is `ON DELETE CASCADE` (the account↔external mapping is destroyed) while `transactions.connection_id` is `ON DELETE SET NULL` (transactions survive, orphaned). On reconnect, TrueLayer issues a **new** `account_id` and `exchange-token` inserts a **fresh** connection with no links — so `sync-accounts` found nothing to match and auto-created a duplicate account.

## Fix — re-adopt by a provider-stable identifier
`account_id` is reissued on reconnect, but **sort code + account number are stable**. `sync-accounts.findAdoptableAccountId` now, before auto-creating, re-adopts the user's single, unambiguous, currently-**unlinked** account whose normalised `sort_code` + `account_number` match. It routes through the existing update branch (writes `bank_balance` only, never `balance`), so the ledger invariant holds and there's **no double-count** on the next sync.

- **Pure, unit-tested decision core** — `src/services/banking/accountMatching.ts` (`api/` is excluded from vitest). 9 cases: sort-code format variance (`40-18-41` ↔ `401841`), missing identifiers, ambiguity, already-linked, number-only/sort-only, empty.
- **Identifiers are now written on every binding path** so the re-adoption key exists: `sync-accounts` (create + update) and `link-accounts` (the manual-link path, which previously never stored them) — threaded from `discover-accounts` → `LinkAccountsRequest` → `LinkBankAccountsModal`.

## Adversarial review (4 lenses, all addressed)
- **false-adoption** → sound: user-scoped, single-candidate, unlinked-only — cannot hijack or cross-tenant.
- **balance double-count** → sound: re-adoption never touches `balance`; next sync is incremental with account-scoped dedupe.
- **syntax/normalisation** → sound.
- **fixes-original** → this PR closes the gap it found (identifiers were only written by sync, not at link time).

## Known limitation (explicitly documented, not silent)
Re-adoption needs the surviving account to already carry `sort_code`/`account_number`. Going forward every link/sync writes them, and **the originally-affected account already has them, so it's protected now**. An account last synced under the *old* code and reconnected *before any new sync/link* would still duplicate once — it becomes adoptable after a single sync. A retroactive SQL backfill isn't possible (the stored mask is last-4 only); recovering the full identifier requires a provider re-fetch, which a normal sync performs.

## Verification
`typecheck:strict`, `lint`, `build` clean; **36 tests pass** (9 new `accountMatching` + 27 `bankConnectionService`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)