### PR TITLE
feat(security): shared-store rate limiter + trusted client keying (#18)

### DIFF
--- a/api/_lib/rate-limit.ts
+++ b/api/_lib/rate-limit.ts
@@ -1,13 +1,28 @@
 import type { VercelRequest, VercelResponse } from '@vercel/node';
+import { getOptionalEnv } from './env.js';
 
 /**
- * Lightweight sliding-window rate limiter.
+ * Rate limiter (audit finding #18).
  *
- * HONEST LIMITATION: state is per serverless instance — a determined attacker
- * spread across many cold starts can exceed the nominal limit. This is a
- * meaningful brake on casual abuse and credential stuffing, not a hard
- * guarantee. For a hard guarantee, back this with a shared store
- * (Upstash/Redis) — the call-site API is designed so only this file changes.
+ * Two layers, chosen at runtime:
+ *
+ *  1. SHARED STORE (Upstash Redis over REST) when UPSTASH_REDIS_REST_URL/TOKEN
+ *     (or the Vercel-marketplace KV_REST_API_URL/TOKEN names) are configured:
+ *     one fixed window per (route, client) across ALL serverless instances —
+ *     limits no longer multiply by instance count.
+ *  2. IN-MEMORY fallback otherwise — the previous per-instance behaviour, kept
+ *     so the module is inert-until-configured (same pattern as api/_lib/sentry).
+ *
+ * Client key: `x-real-ip`, which Vercel's proxy sets from the CONNECTING IP
+ * and overwrites if a client supplies it — unlike the leftmost
+ * `x-forwarded-for` entry (the previous key), which is client-controlled and
+ * let an attacker mint a fresh bucket per request by rotating the header.
+ *
+ * Failure policy: the limiter is an abuse/cost brake in front of auth'd
+ * endpoints, not an access-control boundary — on store errors/timeouts it
+ * FAILS OVER to the per-instance in-memory limiter (NOT fully open), so a
+ * Redis blip can never take the API down, while an attacker who induces store
+ * timeouts still hits the old in-memory floor.
  */
 
 interface WindowEntry {
@@ -17,12 +32,33 @@ interface WindowEntry {
 const buckets = new Map<string, WindowEntry>();
 const MAX_BUCKETS = 10_000; // memory guard for long-lived instances
 
+const UPSTASH_TIMEOUT_MS = 800;
+
+const getStoreConfig = (): { url: string; token: string } | null => {
+  const url = getOptionalEnv('UPSTASH_REDIS_REST_URL') ?? getOptionalEnv('KV_REST_API_URL');
+  const token = getOptionalEnv('UPSTASH_REDIS_REST_TOKEN') ?? getOptionalEnv('KV_REST_API_TOKEN');
+  return url && token ? { url, token } : null;
+};
+
 const getClientKey = (req: VercelRequest): string => {
+  // Trusted on Vercel: set by the proxy from the connection, not spoofable
+  // through it.
+  const realIp = req.headers['x-real-ip'];
+  if (typeof realIp === 'string' && realIp.trim()) {
+    return realIp.trim();
+  }
+  // Fallback outside Vercel: the RIGHTmost x-forwarded-for hop is the one
+  // appended by the nearest proxy; the leftmost is client-supplied. A trailing
+  // comma must not yield an empty hop (that would lump everyone into one
+  // shared empty-string bucket) — fall through to the socket instead.
   const forwarded = req.headers['x-forwarded-for'];
-  const ip = typeof forwarded === 'string'
-    ? forwarded.split(',')[0].trim()
-    : req.socket?.remoteAddress ?? 'unknown';
-  return ip;
+  if (typeof forwarded === 'string' && forwarded.trim()) {
+    const hops = forwarded.split(',').map((h) => h.trim()).filter(Boolean);
+    if (hops.length > 0) {
+      return hops[hops.length - 1];
+    }
+  }
+  return req.socket?.remoteAddress ?? 'unknown';
 };
 
 export interface RateLimitOptions {
@@ -34,18 +70,77 @@ export interface RateLimitOptions {
   windowMs: number;
 }
 
+interface LimitDecision {
+  limited: boolean;
+  retryAfterSeconds: number;
+}
+
 /**
- * Returns true (and writes a 429 response) when the caller is over the limit.
- * Usage at the top of a handler:
- *   if (applyRateLimit(req, res, { name: 'checkout', limit: 10, windowMs: 60_000 })) return;
+ * Fixed window in Redis: INCR the (route, client) key and set its TTL on first
+ * hit — one pipeline round-trip. Returns null on any store failure (fail open).
  */
-export const applyRateLimit = (
-  req: VercelRequest,
-  res: VercelResponse,
+const checkSharedStore = async (
+  store: { url: string; token: string },
+  key: string,
   options: RateLimitOptions
-): boolean => {
+): Promise<LimitDecision | null> => {
+  try {
+    const response = await fetch(`${store.url}/pipeline`, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${store.token}`,
+        'Content-Type': 'application/json'
+      },
+      body: JSON.stringify([
+        ['INCR', key],
+        ['PEXPIRE', key, String(options.windowMs), 'NX'],
+        ['PTTL', key]
+      ]),
+      signal: AbortSignal.timeout(UPSTASH_TIMEOUT_MS)
+    });
+    if (!response.ok) {
+      console.error('[rate-limit] store returned non-OK', { status: response.status });
+      return null;
+    }
+    const results = (await response.json()) as Array<{ result?: unknown; error?: string }>;
+    // Upstash pipelines are NON-atomic and keep executing past a failed
+    // command — every command's error field must be inspected. In particular,
+    // a store that rejected PEXPIRE NX would leave the INCR key with NO TTL:
+    // the counter would grow forever and permanently 429 a legitimate client
+    // (on checkout/account-delete!). Any command error, or a counter that has
+    // no expiry (PTTL -1 after the first hit), is treated as a store failure
+    // → fail over to in-memory instead of trusting a counter that never resets.
+    const failedCommand = results?.find((r) => r?.error);
+    if (failedCommand) {
+      console.error('[rate-limit] pipeline command failed', { error: failedCommand.error });
+      return null;
+    }
+    const count = Number(results?.[0]?.result);
+    const pttl = Number(results?.[2]?.result);
+    if (!Number.isFinite(count)) {
+      console.error('[rate-limit] unexpected store response shape');
+      return null;
+    }
+    if (pttl === -1 && count > 1) {
+      console.error('[rate-limit] counter has no TTL — refusing to enforce a window that never resets');
+      return null;
+    }
+    const retryAfterSeconds = Number.isFinite(pttl) && pttl > 0
+      ? Math.ceil(pttl / 1000)
+      : Math.ceil(options.windowMs / 1000);
+    return { limited: count > options.limit, retryAfterSeconds };
+  } catch (error) {
+    // Timeout/network/etc: fail open — availability beats strictness for a brake.
+    console.error('[rate-limit] store check failed', {
+      message: error instanceof Error ? error.message : 'unknown'
+    });
+    return null;
+  }
+};
+
+/** The previous per-instance sliding window, kept as the unconfigured fallback. */
+const checkInMemory = (key: string, options: RateLimitOptions): LimitDecision => {
   const now = Date.now();
-  const key = `${options.name}:${getClientKey(req)}`;
 
   if (buckets.size > MAX_BUCKETS) {
     buckets.clear();
@@ -61,17 +156,42 @@ export const applyRateLimit = (
   entry.timestamps = entry.timestamps.filter(t => t > windowStart);
 
   if (entry.timestamps.length >= options.limit) {
-    const retryAfterSeconds = Math.ceil(
-      (entry.timestamps[0] + options.windowMs - now) / 1000
-    );
-    res.setHeader('Retry-After', String(Math.max(1, retryAfterSeconds)));
+    return {
+      limited: true,
+      retryAfterSeconds: Math.max(
+        1,
+        Math.ceil((entry.timestamps[0] + options.windowMs - now) / 1000)
+      )
+    };
+  }
+
+  entry.timestamps.push(now);
+  return { limited: false, retryAfterSeconds: 0 };
+};
+
+/**
+ * Returns true (and writes a 429 response) when the caller is over the limit.
+ * Usage at the top of a handler:
+ *   if (await applyRateLimit(req, res, { name: 'checkout', limit: 10, windowMs: 60_000 })) return;
+ */
+export const applyRateLimit = async (
+  req: VercelRequest,
+  res: VercelResponse,
+  options: RateLimitOptions
+): Promise<boolean> => {
+  const key = `rl:${options.name}:${getClientKey(req)}`;
+
+  const store = getStoreConfig();
+  const decision = (store && (await checkSharedStore(store, key, options)))
+    ?? checkInMemory(key, options);
+
+  if (decision.limited) {
+    res.setHeader('Retry-After', String(Math.max(1, decision.retryAfterSeconds)));
     res.status(429).json({
       error: 'Too many requests, please try again shortly',
       code: 'rate_limited'
     });
     return true;
   }
-
-  entry.timestamps.push(now);
   return false;
 };

--- a/api/account/delete.ts
+++ b/api/account/delete.ts
@@ -44,7 +44,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     return res.status(405).json({ error: 'Method not allowed', code: 'method_not_allowed' });
   }
 
-  if (applyRateLimit(req, res, { name: 'account-delete', limit: 3, windowMs: 60_000 })) {
+  if (await applyRateLimit(req, res, { name: 'account-delete', limit: 3, windowMs: 60_000 })) {
     return;
   }
 

--- a/api/banking/create-link-token.ts
+++ b/api/banking/create-link-token.ts
@@ -17,7 +17,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     return;
   }
 
-  if (applyRateLimit(req, res, { name: 'link-token', limit: 10, windowMs: 60_000 })) {
+  if (await applyRateLimit(req, res, { name: 'link-token', limit: 10, windowMs: 60_000 })) {
     return;
   }
 

--- a/api/banking/exchange-token.ts
+++ b/api/banking/exchange-token.ts
@@ -46,7 +46,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     return;
   }
 
-  if (applyRateLimit(req, res, { name: 'exchange-token', limit: 10, windowMs: 60_000 })) {
+  if (await applyRateLimit(req, res, { name: 'exchange-token', limit: 10, windowMs: 60_000 })) {
     return;
   }
 

--- a/api/banking/sync-transactions.ts
+++ b/api/banking/sync-transactions.ts
@@ -120,7 +120,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     return;
   }
 
-  if (applyRateLimit(req, res, { name: 'sync-transactions', limit: 6, windowMs: 60_000 })) {
+  if (await applyRateLimit(req, res, { name: 'sync-transactions', limit: 6, windowMs: 60_000 })) {
     return;
   }
 

--- a/api/billing/portal.ts
+++ b/api/billing/portal.ts
@@ -19,7 +19,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     return res.status(405).json({ error: 'Method not allowed', code: 'method_not_allowed' });
   }
 
-  if (applyRateLimit(req, res, { name: 'billing-portal', limit: 10, windowMs: 60_000 })) {
+  if (await applyRateLimit(req, res, { name: 'billing-portal', limit: 10, windowMs: 60_000 })) {
     return;
   }
 

--- a/api/subscriptions/create-checkout.ts
+++ b/api/subscriptions/create-checkout.ts
@@ -21,7 +21,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     return res.status(405).json({ error: 'Method not allowed', code: 'method_not_allowed' });
   }
 
-  if (applyRateLimit(req, res, { name: 'create-checkout', limit: 10, windowMs: 60_000 })) {
+  if (await applyRateLimit(req, res, { name: 'create-checkout', limit: 10, windowMs: 60_000 })) {
     return;
   }
 

--- a/api/subscriptions/status.ts
+++ b/api/subscriptions/status.ts
@@ -26,7 +26,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     return res.status(405).json({ error: 'Method not allowed', code: 'method_not_allowed' });
   }
 
-  if (applyRateLimit(req, res, { name: 'subscription-status', limit: 60, windowMs: 60_000 })) {
+  if (await applyRateLimit(req, res, { name: 'subscription-status', limit: 60, windowMs: 60_000 })) {
     return;
   }
 

--- a/scripts/verify-server-env.mjs
+++ b/scripts/verify-server-env.mjs
@@ -45,7 +45,10 @@ const EXPECTED = [
   'TRUELAYER_CLIENT_SECRET',
   'TRUELAYER_REDIRECT_URI',
   'ENCRYPTION_KEY',
-  'SENTRY_DSN'
+  'SENTRY_DSN',
+  // Shared-store rate limiter (Upstash / Vercel KV) — in-memory fallback when absent.
+  'UPSTASH_REDIS_REST_URL',
+  'UPSTASH_REDIS_REST_TOKEN'
 ];
 
 // Vars that must NOT exist: VITE_-prefixed secrets get inlined into the


### PR DESCRIPTION
Closes audit finding **#18** — the limiter's state was per serverless instance (nominal limits multiply by instance count) and keyed on the **leftmost** `x-forwarded-for` entry, which is client-controlled: rotating the header minted a fresh bucket per request, making every limit trivially bypassable.

## What this does
- **Shared store** — Upstash Redis over REST (`UPSTASH_REDIS_REST_URL/TOKEN`, or the Vercel-marketplace `KV_REST_API_*` names): one fixed window per (route, client) across **all** instances, in a single pipeline round-trip (`INCR` + `PEXPIRE NX` + `PTTL`). **Inert until provisioned**: without credentials the previous in-memory behaviour is retained unchanged (same ships-dark pattern as the Sentry module).
- **Trusted keying** — `x-real-ip`, which Vercel's proxy sets from the connecting IP and overwrites if client-supplied. Off-Vercel fallback: the **rightmost** XFF hop, with a trailing-comma guard so an empty hop can't lump all clients into one shared bucket.
- **Failure policy** — store errors/timeouts **fail over** to the in-memory limiter (not fully open): a Redis blip can't take the API down, and inducing store timeouts doesn't buy an attacker a bypass of the old floor.
- `applyRateLimit` is now async; all **7 call sites** converted to `await` (each verified as an async handler; no floating promises).

## Hardening from the 2-lens adversarial review
- **Pipeline error inspection** (the review's must-fix): Upstash pipelines are non-atomic and continue past failed commands. Every command's `error` field is now checked, and a counter with **no TTL** (`PTTL -1` after the first hit) is treated as a store failure → in-memory failover. Without this, a store that rejected `PEXPIRE NX` would leave a counter that never expires — **permanently 429ing a legitimate user on checkout/account-delete**.
- Failure-policy doc corrected (fails **over**, not open) so a future edit doesn't "align" the code to the weaker comment.
- Review confirmed: keying closes the rotate-XFF hole on Vercel (no client-controlled path to the key), JSON-encoded pipeline bodies can't be command-injected via crafted headers, `PEXPIRE NX` prevents window extension, both paths allow exactly `limit` requests/window (no off-by-one), and `fetch`/`AbortSignal.timeout` exist on the Vercel Node runtime.

## Activation
Provision an Upstash Redis (easiest: Vercel → Storage → Upstash for Redis — it injects `KV_REST_API_*` automatically, which this code accepts). Until then, behaviour is identical to today.

## Verification
`typecheck:strict`, `lint`, `build` clean; pre-commit gate (build + lint + unit) passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)