### PR TITLE
fix(cron): reconcile skips cleanly when Stripe isn't configured

### DIFF
--- a/api/stripe/reconcile.ts
+++ b/api/stripe/reconcile.ts
@@ -2,7 +2,7 @@ import type { VercelRequest, VercelResponse } from '@vercel/node';
 import type Stripe from 'stripe';
 import { getStripe, getTierForPriceId, mapStripeStatus } from '../_lib/stripe.js';
 import { getServiceRoleSupabase } from '../_lib/supabase.js';
-import { getRequiredEnv } from '../_lib/env.js';
+import { getRequiredEnv, getOptionalEnv } from '../_lib/env.js';
 import { captureServerError } from '../_lib/sentry.js';
 
 /**
@@ -28,6 +28,16 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
   const cronSecret = getRequiredEnv('CRON_SECRET');
   if (authHeader !== `Bearer ${cronSecret}`) {
     return res.status(401).json({ error: 'Unauthorized', code: 'unauthorized' });
+  }
+
+  // Stripe is an optional/known-pending integration. When it isn't configured,
+  // getStripe() would throw getRequiredEnv('STRIPE_SECRET_KEY') OUTSIDE the
+  // try/catch below — an unhandled crash (FUNCTION_INVOCATION_FAILED) that also
+  // bypasses Sentry capture. There are no subscriptions to reconcile without
+  // Stripe, so skip cleanly (green cron) rather than crash daily.
+  if (!getOptionalEnv('STRIPE_SECRET_KEY')) {
+    console.warn('[stripe-reconcile] STRIPE_SECRET_KEY not configured — skipping reconciliation');
+    return res.status(200).json({ skipped: 'stripe_not_configured', checked: 0, corrected: 0, failures: [] });
   }
 
   const stripe = getStripe();


### PR DESCRIPTION
Found while verifying the `CRON_SECRET` fix (which is now live — the retention cron returns 200 end-to-end).

## The bug
With cron auth now passing, the daily `stripe-reconcile` cron crashed with `FUNCTION_INVOCATION_FAILED`. `getStripe()` calls `getRequiredEnv('STRIPE_SECRET_KEY')` at the **top of the handler, outside the try/catch** — so with Stripe unconfigured (a known-pending integration), it threw an **unhandled** error: a daily crash that also **bypassed** the `captureServerError` calls in the catch blocks (so Sentry wouldn't even see it).

## The fix
There are no subscriptions to reconcile without Stripe, so guard for a missing `STRIPE_SECRET_KEY` and return a clean `200 {skipped:'stripe_not_configured'}` instead of crashing. When Stripe is configured later, the guard is a no-op and reconciliation runs normally.

## Verification
- Retention cron already returns `200 {"retainDays":2190,"deleted":0}` end-to-end (proves `CRON_SECRET` works).
- `typecheck:strict`, `lint`, `build` clean.
- After merge/redeploy I'll re-invoke reconcile with the bearer token and confirm it returns 200-skip instead of 500.

🤖 Generated with [Claude Code](https://claude.com/claude-code)