### PR TITLE
chore(hardening): withSentry on all 22 API routes + restore fail-loud + flake fix

### DIFF
--- a/api/account/delete.ts
+++ b/api/account/delete.ts
@@ -5,7 +5,7 @@ import { getServiceRoleSupabase } from '../_lib/supabase.js';
 import { getRequiredEnv, getOptionalEnv } from '../_lib/env.js';
 import { getStripe } from '../_lib/stripe.js';
 import { applyRateLimit } from '../_lib/rate-limit.js';
-import { captureServerError } from '../_lib/sentry.js';
+import { captureServerError, withSentry } from '../_lib/sentry.js';
 
 /**
  * Self-service account deletion — GDPR Art. 17 (right to erasure).
@@ -34,7 +34,7 @@ interface DeleteAccountRequest {
   confirmation?: string;
 }
 
-export default async function handler(req: VercelRequest, res: VercelResponse) {
+async function handler(req: VercelRequest, res: VercelResponse) {
   if (setCorsHeaders(req, res)) {
     return;
   }
@@ -176,3 +176,6 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     return res.status(500).json({ error: 'Account deletion failed', code: 'internal_error' });
   }
 }
+
+// Safety net: report any unhandled throw to Sentry (no-op without SENTRY_DSN).
+export default withSentry(handler);

--- a/api/banking/connections.ts
+++ b/api/banking/connections.ts
@@ -4,8 +4,9 @@ import { AuthError, requireAuth } from '../_lib/auth.js';
 import { setCorsHeaders } from '../_lib/cors.js';
 import { createErrorResponse } from '../_lib/http-error.js';
 import { getServiceRoleSupabase } from '../_lib/supabase.js';
+import { withSentry } from '../_lib/sentry.js';
 
-export default async function handler(req: VercelRequest, res: VercelResponse) {
+async function handler(req: VercelRequest, res: VercelResponse) {
   if (setCorsHeaders(req, res)) {
     return;
   }
@@ -65,3 +66,6 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     return createErrorResponse(res, 500, message, 'internal_error');
   }
 }
+
+// Safety net: report any unhandled throw to Sentry (no-op without SENTRY_DSN).
+export default withSentry(handler);

--- a/api/banking/create-link-token.ts
+++ b/api/banking/create-link-token.ts
@@ -9,10 +9,11 @@ import { createErrorResponse } from '../_lib/http-error.js';
 import { applyRateLimit } from '../_lib/rate-limit.js';
 import { createStateToken } from '../_lib/state.js';
 import { buildAuthUrl, getRedirectUri, isSandboxEnvironment } from '../_lib/truelayer.js';
+import { withSentry } from '../_lib/sentry.js';
 
 const AUTH_SCOPES = ['info', 'accounts', 'balance', 'transactions', 'offline_access'];
 
-export default async function handler(req: VercelRequest, res: VercelResponse) {
+async function handler(req: VercelRequest, res: VercelResponse) {
   if (setCorsHeaders(req, res)) {
     return;
   }
@@ -55,3 +56,6 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     return createErrorResponse(res, 500, message, 'internal_error');
   }
 }
+
+// Safety net: report any unhandled throw to Sentry (no-op without SENTRY_DSN).
+export default withSentry(handler);

--- a/api/banking/dead-letter-admin-audit-export.ts
+++ b/api/banking/dead-letter-admin-audit-export.ts
@@ -5,6 +5,7 @@ import { requireBankingOpsAdmin } from '../_lib/banking-ops.js';
 import { setCorsHeaders } from '../_lib/cors.js';
 import { createErrorResponse } from '../_lib/http-error.js';
 import { getServiceRoleSupabase } from '../_lib/supabase.js';
+import { withSentry } from '../_lib/sentry.js';
 
 const DEFAULT_LIMIT = 1000;
 const MAX_LIMIT = 5000;
@@ -125,7 +126,7 @@ const toCsv = (rows: DeadLetterAuditDbRow[]): string => {
   return lines.join('\n');
 };
 
-export default async function handler(req: VercelRequest, res: VercelResponse) {
+async function handler(req: VercelRequest, res: VercelResponse) {
   if (setCorsHeaders(req, res)) {
     return;
   }
@@ -202,3 +203,6 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     return createErrorResponse(res, 500, message, 'internal_error');
   }
 }
+
+// Safety net: report any unhandled throw to Sentry (no-op without SENTRY_DSN).
+export default withSentry(handler);

--- a/api/banking/dead-letter-admin-audit.ts
+++ b/api/banking/dead-letter-admin-audit.ts
@@ -9,6 +9,7 @@ import { requireBankingOpsAdmin } from '../_lib/banking-ops.js';
 import { setCorsHeaders } from '../_lib/cors.js';
 import { createErrorResponse } from '../_lib/http-error.js';
 import { getServiceRoleSupabase } from '../_lib/supabase.js';
+import { withSentry } from '../_lib/sentry.js';
 
 const DEFAULT_LIMIT = 25;
 const MAX_LIMIT = 200;
@@ -102,7 +103,7 @@ const mapAuditRow = (row: DeadLetterAuditDbRow): DeadLetterAdminAuditRow => ({
   completedAt: row.completed_at
 });
 
-export default async function handler(req: VercelRequest, res: VercelResponse) {
+async function handler(req: VercelRequest, res: VercelResponse) {
   if (setCorsHeaders(req, res)) {
     return;
   }
@@ -250,3 +251,6 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     return createErrorResponse(res, 500, message, 'internal_error');
   }
 }
+
+// Safety net: report any unhandled throw to Sentry (no-op without SENTRY_DSN).
+export default withSentry(handler);

--- a/api/banking/dead-letter-admin.ts
+++ b/api/banking/dead-letter-admin.ts
@@ -13,6 +13,7 @@ import {
 import { setCorsHeaders } from '../_lib/cors.js';
 import { createErrorResponse } from '../_lib/http-error.js';
 import { getServiceRoleSupabase } from '../_lib/supabase.js';
+import { withSentry } from '../_lib/sentry.js';
 
 const RESET_ALL_CONFIRMATION = 'RESET_ALL_DEAD_LETTERED';
 const DEFAULT_PREVIEW_LIMIT = 25;
@@ -97,7 +98,7 @@ const applyResetUpdate = async (
   return fallback.error;
 };
 
-export default async function handler(req: VercelRequest, res: VercelResponse) {
+async function handler(req: VercelRequest, res: VercelResponse) {
   if (setCorsHeaders(req, res)) {
     return;
   }
@@ -289,3 +290,6 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     return createErrorResponse(res, 500, message, 'internal_error');
   }
 }
+
+// Safety net: report any unhandled throw to Sentry (no-op without SENTRY_DSN).
+export default withSentry(handler);

--- a/api/banking/disconnect.ts
+++ b/api/banking/disconnect.ts
@@ -4,8 +4,9 @@ import { AuthError, requireAuth } from '../_lib/auth.js';
 import { setCorsHeaders } from '../_lib/cors.js';
 import { createErrorResponse } from '../_lib/http-error.js';
 import { getServiceRoleSupabase } from '../_lib/supabase.js';
+import { withSentry } from '../_lib/sentry.js';
 
-export default async function handler(req: VercelRequest, res: VercelResponse) {
+async function handler(req: VercelRequest, res: VercelResponse) {
   if (setCorsHeaders(req, res)) {
     return;
   }
@@ -48,3 +49,6 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     return createErrorResponse(res, 500, message, 'internal_error');
   }
 }
+
+// Safety net: report any unhandled throw to Sentry (no-op without SENTRY_DSN).
+export default withSentry(handler);

--- a/api/banking/discover-accounts.ts
+++ b/api/banking/discover-accounts.ts
@@ -13,6 +13,7 @@ import {
   withTrueLayerAccessToken
 } from '../_lib/banking-sync.js';
 import { fetchAccountBalance, fetchAccounts } from '../_lib/truelayer.js';
+import { withSentry } from '../_lib/sentry.js';
 
 const mapAccountType = (accountType: string | undefined): string => {
   const normalized = (accountType ?? '').toLowerCase();
@@ -28,7 +29,7 @@ const mapAccountType = (accountType: string | undefined): string => {
   }
 };
 
-export default async function handler(req: VercelRequest, res: VercelResponse) {
+async function handler(req: VercelRequest, res: VercelResponse) {
   if (setCorsHeaders(req, res)) {
     return;
   }
@@ -103,3 +104,6 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     return createErrorResponse(res, 500, message, 'internal_error');
   }
 }
+
+// Safety net: report any unhandled throw to Sentry (no-op without SENTRY_DSN).
+export default withSentry(handler);

--- a/api/banking/exchange-token.ts
+++ b/api/banking/exchange-token.ts
@@ -11,6 +11,7 @@ import { encryptSecret } from '../_lib/encryption.js';
 import { getServiceRoleSupabase } from '../_lib/supabase.js';
 import { decodeStateToken } from '../_lib/state.js';
 import { exchangeCodeForToken, fetchAccounts } from '../_lib/truelayer.js';
+import { withSentry } from '../_lib/sentry.js';
 
 interface ProviderMetadata {
   id: string;
@@ -41,7 +42,7 @@ const getProviderFromAccounts = (
   };
 };
 
-export default async function handler(req: VercelRequest, res: VercelResponse) {
+async function handler(req: VercelRequest, res: VercelResponse) {
   if (setCorsHeaders(req, res)) {
     return;
   }
@@ -178,3 +179,6 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     return createErrorResponse(res, 500, 'Unexpected error', 'internal_error');
   }
 }
+
+// Safety net: report any unhandled throw to Sentry (no-op without SENTRY_DSN).
+export default withSentry(handler);

--- a/api/banking/health.ts
+++ b/api/banking/health.ts
@@ -1,8 +1,9 @@
 import type { VercelRequest, VercelResponse } from '@vercel/node';
 import { AuthError, requireAuth } from '../_lib/auth.js';
 import { setCorsHeaders } from '../_lib/cors.js';
+import { withSentry } from '../_lib/sentry.js';
 
-export default function handler(req: VercelRequest, res: VercelResponse) {
+function handler(req: VercelRequest, res: VercelResponse) {
   if (setCorsHeaders(req, res)) {
     return;
   }
@@ -33,3 +34,6 @@ export default function handler(req: VercelRequest, res: VercelResponse) {
       return res.status(500).json({ error: 'Unexpected error', code: 'internal_error' });
     });
 }
+
+// Safety net: report any unhandled throw to Sentry (no-op without SENTRY_DSN).
+export default withSentry(handler);

--- a/api/banking/link-accounts.ts
+++ b/api/banking/link-accounts.ts
@@ -8,8 +8,9 @@ import { getServiceRoleSupabase } from '../_lib/supabase.js';
 import { setCorsHeaders } from '../_lib/cors.js';
 import { createErrorResponse } from '../_lib/http-error.js';
 import { getUserTrueLayerConnection } from '../_lib/banking-sync.js';
+import { withSentry } from '../_lib/sentry.js';
 
-export default async function handler(req: VercelRequest, res: VercelResponse) {
+async function handler(req: VercelRequest, res: VercelResponse) {
   if (setCorsHeaders(req, res)) {
     return;
   }
@@ -137,3 +138,6 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     return createErrorResponse(res, 500, message, 'internal_error');
   }
 }
+
+// Safety net: report any unhandled throw to Sentry (no-op without SENTRY_DSN).
+export default withSentry(handler);

--- a/api/banking/ops-alert-stats.ts
+++ b/api/banking/ops-alert-stats.ts
@@ -9,6 +9,7 @@ import {
 import { setCorsHeaders } from '../_lib/cors.js';
 import { createErrorResponse } from '../_lib/http-error.js';
 import { getServiceRoleSupabase } from '../_lib/supabase.js';
+import { withSentry } from '../_lib/sentry.js';
 
 const DEFAULT_LIMIT = 50;
 const MAX_LIMIT = 200;
@@ -45,7 +46,7 @@ const relationMissing = (error: unknown): boolean => {
   return candidate.code === '42P01';
 };
 
-export default async function handler(req: VercelRequest, res: VercelResponse) {
+async function handler(req: VercelRequest, res: VercelResponse) {
   if (setCorsHeaders(req, res)) {
     return;
   }
@@ -195,3 +196,6 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     return createErrorResponse(res, 500, message, 'internal_error');
   }
 }
+
+// Safety net: report any unhandled throw to Sentry (no-op without SENTRY_DSN).
+export default withSentry(handler);

--- a/api/banking/ops-alert-test.ts
+++ b/api/banking/ops-alert-test.ts
@@ -8,6 +8,7 @@ import { requireBankingOpsAdmin } from '../_lib/banking-ops.js';
 import { setCorsHeaders } from '../_lib/cors.js';
 import { createErrorResponse } from '../_lib/http-error.js';
 import { getServiceRoleSupabase } from '../_lib/supabase.js';
+import { withSentry } from '../_lib/sentry.js';
 
 const TEST_EVENT_TYPE = 'banking.ops_alert_test';
 
@@ -19,7 +20,7 @@ const relationMissing = (error: unknown): boolean => {
   return candidate.code === '42P01';
 };
 
-export default async function handler(req: VercelRequest, res: VercelResponse) {
+async function handler(req: VercelRequest, res: VercelResponse) {
   if (setCorsHeaders(req, res)) {
     return;
   }
@@ -91,3 +92,6 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     return createErrorResponse(res, 500, message, 'internal_error');
   }
 }
+
+// Safety net: report any unhandled throw to Sentry (no-op without SENTRY_DSN).
+export default withSentry(handler);

--- a/api/banking/sync-accounts.ts
+++ b/api/banking/sync-accounts.ts
@@ -7,7 +7,7 @@ import { AuthError, requireAuth } from '../_lib/auth.js';
 import { getServiceRoleSupabase } from '../_lib/supabase.js';
 import { setCorsHeaders } from '../_lib/cors.js';
 import { createErrorResponse } from '../_lib/http-error.js';
-import { captureServerError } from '../_lib/sentry.js';
+import { captureServerError, withSentry } from '../_lib/sentry.js';
 import {
   getUserTrueLayerConnection,
   isReauthRequiredError,
@@ -291,7 +291,7 @@ const persistAccountsAndLinks = async (
   }
 };
 
-export default async function handler(req: VercelRequest, res: VercelResponse) {
+async function handler(req: VercelRequest, res: VercelResponse) {
   if (setCorsHeaders(req, res)) {
     return;
   }
@@ -404,3 +404,6 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
       : createErrorResponse(res, 500, 'Account sync failed', 'internal_error');
   }
 }
+
+// Safety net: report any unhandled throw to Sentry (no-op without SENTRY_DSN).
+export default withSentry(handler);

--- a/api/banking/sync-transactions.ts
+++ b/api/banking/sync-transactions.ts
@@ -7,7 +7,7 @@ import type {
 import { AuthError, requireAuth } from '../_lib/auth.js';
 import { setCorsHeaders } from '../_lib/cors.js';
 import { createErrorResponse } from '../_lib/http-error.js';
-import { captureServerError } from '../_lib/sentry.js';
+import { captureServerError, withSentry } from '../_lib/sentry.js';
 import { applyRateLimit } from '../_lib/rate-limit.js';
 import { getServiceRoleSupabase } from '../_lib/supabase.js';
 import {
@@ -115,7 +115,7 @@ const chunk = <T>(values: T[], size: number): T[][] => {
   return output;
 };
 
-export default async function handler(req: VercelRequest, res: VercelResponse) {
+async function handler(req: VercelRequest, res: VercelResponse) {
   if (setCorsHeaders(req, res)) {
     return;
   }
@@ -406,3 +406,6 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
       : createErrorResponse(res, 500, 'Transaction sync failed', 'internal_error');
   }
 }
+
+// Safety net: report any unhandled throw to Sentry (no-op without SENTRY_DSN).
+export default withSentry(handler);

--- a/api/billing/portal.ts
+++ b/api/billing/portal.ts
@@ -4,12 +4,13 @@ import { setCorsHeaders, isRedirectUrlAllowed } from '../_lib/cors.js';
 import { getServiceRoleSupabase } from '../_lib/supabase.js';
 import { getStripe } from '../_lib/stripe.js';
 import { applyRateLimit } from '../_lib/rate-limit.js';
+import { withSentry } from '../_lib/sentry.js';
 
 interface PortalRequest {
   returnUrl?: string;
 }
 
-export default async function handler(req: VercelRequest, res: VercelResponse) {
+async function handler(req: VercelRequest, res: VercelResponse) {
   if (setCorsHeaders(req, res)) {
     return;
   }
@@ -66,3 +67,6 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     return res.status(500).json({ error: 'Failed to create portal session', code: 'internal_error' });
   }
 }
+
+// Safety net: report any unhandled throw to Sentry (no-op without SENTRY_DSN).
+export default withSentry(handler);

--- a/api/cron/retention.ts
+++ b/api/cron/retention.ts
@@ -1,7 +1,7 @@
 import type { VercelRequest, VercelResponse } from '@vercel/node';
 import { getServiceRoleSupabase } from '../_lib/supabase.js';
 import { getRequiredEnv, getOptionalEnv } from '../_lib/env.js';
-import { captureServerError } from '../_lib/sentry.js';
+import { captureServerError, withSentry } from '../_lib/sentry.js';
 
 /**
  * Weekly data-retention enforcement (GDPR Art. 5(1)(e)).
@@ -14,7 +14,7 @@ import { captureServerError } from '../_lib/sentry.js';
  * api/stripe/reconcile.ts.
  */
 
-export default async function handler(req: VercelRequest, res: VercelResponse) {
+async function handler(req: VercelRequest, res: VercelResponse) {
   const authHeader = Array.isArray(req.headers.authorization)
     ? req.headers.authorization[0]
     : req.headers.authorization ?? '';
@@ -48,3 +48,6 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
   console.log('[retention] Audit log purge complete', { retainDays, deleted });
   return res.status(200).json({ retainDays, deleted });
 }
+
+// Safety net: report any unhandled throw to Sentry (no-op without SENTRY_DSN).
+export default withSentry(handler);

--- a/api/data/delete-transaction.ts
+++ b/api/data/delete-transaction.ts
@@ -2,6 +2,7 @@ import type { VercelRequest, VercelResponse } from '@vercel/node';
 import { AuthError, requireAuth } from '../_lib/auth.js';
 import { setCorsHeaders } from '../_lib/cors.js';
 import { getServiceRoleSupabase } from '../_lib/supabase.js';
+import { withSentry } from '../_lib/sentry.js';
 
 interface ErrorResponse {
   error: string;
@@ -26,7 +27,7 @@ const createErrorResponse = (
   return res.status(status).json(payload);
 };
 
-export default async function handler(req: VercelRequest, res: VercelResponse) {
+async function handler(req: VercelRequest, res: VercelResponse) {
   if (setCorsHeaders(req, res)) {
     return;
   }
@@ -76,3 +77,6 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     return createErrorResponse(res, 500, 'Unexpected error', 'internal_error');
   }
 }
+
+// Safety net: report any unhandled throw to Sentry (no-op without SENTRY_DSN).
+export default withSentry(handler);

--- a/api/stripe/reconcile.ts
+++ b/api/stripe/reconcile.ts
@@ -3,7 +3,7 @@ import type Stripe from 'stripe';
 import { getStripe, getTierForPriceId, mapStripeStatus } from '../_lib/stripe.js';
 import { getServiceRoleSupabase } from '../_lib/supabase.js';
 import { getRequiredEnv, getOptionalEnv } from '../_lib/env.js';
-import { captureServerError } from '../_lib/sentry.js';
+import { captureServerError, withSentry } from '../_lib/sentry.js';
 
 /**
  * Daily reconciliation between Stripe (source of truth) and the local
@@ -21,7 +21,7 @@ interface SubscriptionRow {
   cancel_at_period_end: boolean | null;
 }
 
-export default async function handler(req: VercelRequest, res: VercelResponse) {
+async function handler(req: VercelRequest, res: VercelResponse) {
   const authHeader = Array.isArray(req.headers.authorization)
     ? req.headers.authorization[0]
     : req.headers.authorization ?? '';
@@ -136,3 +136,6 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
   }
   return res.status(200).json({ checked, corrected, failures });
 }
+
+// Safety net: report any unhandled throw to Sentry (no-op without SENTRY_DSN).
+export default withSentry(handler);

--- a/api/stripe/webhook.ts
+++ b/api/stripe/webhook.ts
@@ -3,7 +3,7 @@ import type Stripe from 'stripe';
 import { getStripe, getTierForPriceId, mapStripeStatus } from '../_lib/stripe.js';
 import { getServiceRoleSupabase } from '../_lib/supabase.js';
 import { getRequiredEnv } from '../_lib/env.js';
-import { captureServerError } from '../_lib/sentry.js';
+import { captureServerError, withSentry } from '../_lib/sentry.js';
 
 // Stripe signature verification requires the RAW request body — disable
 // Vercel's automatic JSON parsing for this route.
@@ -121,7 +121,7 @@ const syncSubscription = async (subscription: Stripe.Subscription): Promise<void
   // user_profiles automatically.
 };
 
-export default async function handler(req: VercelRequest, res: VercelResponse) {
+async function handler(req: VercelRequest, res: VercelResponse) {
   if (req.method !== 'POST') {
     res.setHeader('Allow', 'POST');
     return res.status(405).json({ error: 'Method not allowed', code: 'method_not_allowed' });
@@ -249,3 +249,6 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     return res.status(500).json({ error: 'Event processing failed', code: 'internal_error' });
   }
 }
+
+// Safety net: report any unhandled throw to Sentry (no-op without SENTRY_DSN).
+export default withSentry(handler);

--- a/api/subscriptions/create-checkout.ts
+++ b/api/subscriptions/create-checkout.ts
@@ -4,6 +4,7 @@ import { setCorsHeaders, isRedirectUrlAllowed } from '../_lib/cors.js';
 import { getServiceRoleSupabase } from '../_lib/supabase.js';
 import { getStripe, getPriceIdForTier, type PaidTier } from '../_lib/stripe.js';
 import { applyRateLimit } from '../_lib/rate-limit.js';
+import { withSentry } from '../_lib/sentry.js';
 
 interface CreateCheckoutRequest {
   planType?: string;
@@ -11,7 +12,7 @@ interface CreateCheckoutRequest {
   cancelUrl?: string;
 }
 
-export default async function handler(req: VercelRequest, res: VercelResponse) {
+async function handler(req: VercelRequest, res: VercelResponse) {
   if (setCorsHeaders(req, res)) {
     return;
   }
@@ -101,3 +102,6 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     return res.status(500).json({ error: 'Failed to create checkout session', code: 'internal_error' });
   }
 }
+
+// Safety net: report any unhandled throw to Sentry (no-op without SENTRY_DSN).
+export default withSentry(handler);

--- a/api/subscriptions/status.ts
+++ b/api/subscriptions/status.ts
@@ -3,6 +3,7 @@ import { AuthError, requireAuth } from '../_lib/auth.js';
 import { setCorsHeaders } from '../_lib/cors.js';
 import { getServiceRoleSupabase } from '../_lib/supabase.js';
 import { applyRateLimit } from '../_lib/rate-limit.js';
+import { withSentry } from '../_lib/sentry.js';
 
 interface SubscriptionRow {
   id: string;
@@ -16,7 +17,7 @@ interface SubscriptionRow {
   cancel_at_period_end: boolean | null;
 }
 
-export default async function handler(req: VercelRequest, res: VercelResponse) {
+async function handler(req: VercelRequest, res: VercelResponse) {
   if (setCorsHeaders(req, res)) {
     return;
   }
@@ -81,3 +82,6 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     return res.status(500).json({ error: 'Failed to load subscription status', code: 'internal_error' });
   }
 }
+
+// Safety net: report any unhandled throw to Sentry (no-op without SENTRY_DSN).
+export default withSentry(handler);

--- a/scripts/restore-database.mjs
+++ b/scripts/restore-database.mjs
@@ -73,6 +73,7 @@ const main = async () => {
 
   const started = Date.now();
   let totalRestored = 0;
+  let failedChunks = 0;
 
   for (const table of TABLES) {
     if (onlyTable && table !== onlyTable) continue;
@@ -102,17 +103,27 @@ const main = async () => {
       const { error } = await supabase.from(table).upsert(chunk, { onConflict: 'id' });
       if (error) {
         console.log(`  ✗ ${table.padEnd(26)} chunk ${i / CHUNK}: ${error.message}`);
+        failedChunks += 1;
         continue;
       }
       restored += chunk.length;
     }
     totalRestored += restored;
-    console.log(`  ✓ ${table.padEnd(26)} restored ${restored}/${rows.length} rows`);
+    const mark = restored === rows.length ? '✓' : '⚠';
+    console.log(`  ${mark} ${table.padEnd(26)} restored ${restored}/${rows.length} rows`);
   }
 
   console.log(`\n${apply ? 'Restored' : 'Would restore'}: ${totalRestored} rows in ${Date.now() - started} ms`);
   if (!apply && totalRestored > 0) console.log('Re-run with --apply to write.');
   if (apply) console.log('Run npm run audit:data to verify the accounting invariant after restore.');
+
+  // A partial restore must NEVER exit 0 (the false-green the backup-side review
+  // flagged): in a DR scenario a green exit is read as "data is back", and a
+  // silently missing chunk of transactions breaks the ledger invariant.
+  if (failedChunks > 0) {
+    console.error(`\n✗ INCOMPLETE RESTORE: ${failedChunks} chunk(s) failed — data is PARTIAL. Fix the errors above and re-run.`);
+    process.exit(2);
+  }
 };
 
 main().catch((err) => {

--- a/src/test/integration/DashboardInteractionsIntegration.test.tsx
+++ b/src/test/integration/DashboardInteractionsIntegration.test.tsx
@@ -72,13 +72,17 @@ describe('Dashboard Interactions Integration', () => {
         expect(screen.getByRole('heading', { level: 1, name: /dashboard/i })).toBeInTheDocument();
       });
 
-      // Generous timeout: the dashboard component is lazy-loaded and the
-      // chunk can resolve slowly when the full suite runs under load.
-      const assetsLabel = await screen.findByText(/assets/i, { selector: 'p' }, { timeout: 5000 });
-      const liabilitiesLabel = await screen.findByText(/liabilities/i, { selector: 'p' }, { timeout: 5000 });
+      // The dashboard is lazy-loaded and its chunk can resolve slowly when the
+      // full coverage suite runs under load. Query both labels concurrently so
+      // their wait windows overlap (sequential 5s waits could otherwise sum
+      // past the per-test timeout) and give the test an explicit generous cap.
+      const [assetsLabel, liabilitiesLabel] = await Promise.all([
+        screen.findByText(/assets/i, { selector: 'p' }, { timeout: 15000 }),
+        screen.findByText(/liabilities/i, { selector: 'p' }, { timeout: 15000 })
+      ]);
       expect(assetsLabel).toBeInTheDocument();
       expect(liabilitiesLabel).toBeInTheDocument();
-    });
+    }, 20000);
 
     it('should display monthly performance metrics', async () => {
       renderWithProviders(<Dashboard />);


### PR DESCRIPTION
Two deferred backlog items, plus a flake fix surfaced by the pre-push gate.

## withSentry() rollout (closes the observability gap left by #45)
The wrapper existed but only critical handlers had explicit capture — an unhandled throw anywhere else served Vercel's raw `FUNCTION_INVOCATION_FAILED` page (what reconcile did before #48). All **22 handlers** are now wrapped: unhandled errors report to Sentry with route+method context and answer with the app's generic 500 JSON. No-op without `SENTRY_DSN`; explicit in-handler captures unchanged. Structurally verified: exactly one default export per file; webhook's `export const config` untouched.

## restore-database.mjs fail-loud (the review's restore-side false-green)
Failed upsert chunks were logged but the script exited 0 — a green exit in a DR scenario reads as "data is back" while transactions are silently missing. Partial restores now print **INCOMPLETE RESTORE**, mark partial tables with ⚠, and **exit 2**, mirroring the backup script.

## Flake fix (bonus)
`DashboardInteractionsIntegration > should display dashboard with summary cards` timed out under the full coverage suite (two sequential 5s lazy-load waits summing past the per-test timeout). Now queries both labels concurrently with an explicit 20s cap. Full suite verified green under load (2981 passed).

## Verification
`typecheck:strict` / `lint` / `build` clean; full `test:coverage` green (2981 passed, coverage 63.2% ≥ floor); pre-push gate passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)