### PR TITLE
feat(accounts): per-account last-sync date + one-click bank data pull

### DIFF
--- a/api/banking/connections.ts
+++ b/api/banking/connections.ts
@@ -30,32 +30,48 @@ async function handler(req: VercelRequest, res: VercelResponse) {
     }
 
     const connectionIds = (data ?? []).map((connection) => connection.id);
-    const linkedAccountCountByConnection = new Map<string, number>();
+    // Collect the WealthTracker account ids each connection is linked to, so the
+    // client can map an account → its connection (for a per-account "last synced"
+    // label and sync button on the Accounts page).
+    const linkedAccountIdsByConnection = new Map<string, string[]>();
     if (connectionIds.length > 0) {
       const linkedResult = await supabase
         .from('linked_accounts')
-        .select('connection_id')
+        .select('connection_id, account_id')
         .in('connection_id', connectionIds);
 
-      if (!linkedResult.error) {
+      if (linkedResult.error) {
+        // Non-fatal: still return the connections list, but log so the "every
+        // account shows 0 links / no sync button" degradation is diagnosable.
+        console.error('[connections] failed to load linked_accounts', {
+          message: linkedResult.error.message
+        });
+      } else {
         (linkedResult.data ?? []).forEach((row) => {
-          const current = linkedAccountCountByConnection.get(row.connection_id) ?? 0;
-          linkedAccountCountByConnection.set(row.connection_id, current + 1);
+          const list = linkedAccountIdsByConnection.get(row.connection_id) ?? [];
+          if (row.account_id) {
+            list.push(row.account_id as string);
+          }
+          linkedAccountIdsByConnection.set(row.connection_id, list);
         });
       }
     }
 
-    const response: ConnectionsResponse = (data ?? []).map((connection) => ({
-      id: connection.id,
-      provider: connection.provider,
-      institutionId: connection.institution_id,
-      institutionName: connection.institution_name,
-      institutionLogo: connection.institution_logo ?? undefined,
-      status: connection.status as ConnectionsResponse[number]['status'],
-      lastSync: connection.last_sync ?? undefined,
-      accountsCount: linkedAccountCountByConnection.get(connection.id) ?? 0,
-      expiresAt: connection.expires_at ?? undefined
-    }));
+    const response: ConnectionsResponse = (data ?? []).map((connection) => {
+      const linkedAccountIds = linkedAccountIdsByConnection.get(connection.id) ?? [];
+      return {
+        id: connection.id,
+        provider: connection.provider,
+        institutionId: connection.institution_id,
+        institutionName: connection.institution_name,
+        institutionLogo: connection.institution_logo ?? undefined,
+        status: connection.status as ConnectionsResponse[number]['status'],
+        lastSync: connection.last_sync ?? undefined,
+        accountsCount: linkedAccountIds.length,
+        linkedAccountIds,
+        expiresAt: connection.expires_at ?? undefined
+      };
+    });
 
     return res.status(200).json(response);
   } catch (error) {

--- a/src/contexts/AppContextSupabase.tsx
+++ b/src/contexts/AppContextSupabase.tsx
@@ -90,6 +90,12 @@ export interface AppContextType extends AppState {
   lastSyncTime: Date | null;
   syncError: string | null;
   isUsingSupabase: boolean;
+  /**
+   * Re-pull ONLY accounts + transactions from Supabase (e.g. after a bank sync).
+   * Deliberately narrow — budgets/goals load from PlanningService, so a whole-app
+   * refresh would blank them for cloud users.
+   */
+  refreshAccountsAndTransactions: () => Promise<void>;
 }
 
 const AppContext = createContext<AppContextType | undefined>(undefined);
@@ -322,6 +328,25 @@ export function AppProvider({ children }: { children: React.ReactNode }) {
       setSyncError('Failed to sync data');
     } finally {
       setIsSyncing(false);
+    }
+  }, []);
+
+  // Narrow refresh for the bank-sync path: only accounts + transactions come from
+  // Supabase here (getAccounts/getTransactions route to the cloud services), so we
+  // never touch budgets/goals/categories which load from a different source.
+  const refreshAccountsAndTransactions = useCallback(async () => {
+    try {
+      const [updatedAccounts, updatedTransactions] = await Promise.all([
+        DataService.getAccounts(),
+        DataService.getTransactions()
+      ]);
+      setAccounts(updatedAccounts);
+      setTransactions(updatedTransactions);
+      setLastSyncTime(new Date());
+      setSyncError(null);
+    } catch (error) {
+      appLogger.error('Failed to refresh accounts and transactions', error);
+      setSyncError('Failed to refresh account data');
     }
   }, []);
 
@@ -752,6 +777,7 @@ export function AppProvider({ children }: { children: React.ReactNode }) {
     lastSyncTime,
     syncError,
     isUsingSupabase,
+    refreshAccountsAndTransactions,
     hasTestData: false,
     loadTestData
   };

--- a/src/hooks/__tests__/useAccountBankSync.test.ts
+++ b/src/hooks/__tests__/useAccountBankSync.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect } from 'vitest';
+import { buildAccountBankLinks } from '../useAccountBankSync';
+import type { BankConnection } from '../../services/bankConnectionService';
+
+function makeConnection(overrides: Partial<BankConnection>): BankConnection {
+  return {
+    id: 'conn-1',
+    provider: 'truelayer',
+    institutionId: 'inst-1',
+    institutionName: 'Test Bank',
+    status: 'connected',
+    accounts: [],
+    linkedAccountIds: [],
+    ...overrides
+  };
+}
+
+describe('buildAccountBankLinks', () => {
+  it('returns an empty map when there are no connections', () => {
+    expect(buildAccountBankLinks([]).size).toBe(0);
+  });
+
+  it('maps each linked account id to its connection metadata', () => {
+    const lastSync = new Date('2026-07-01T09:30:00Z');
+    const links = buildAccountBankLinks([
+      makeConnection({
+        id: 'conn-a',
+        institutionName: 'Monzo',
+        status: 'connected',
+        lastSync,
+        linkedAccountIds: ['acc-1', 'acc-2']
+      })
+    ]);
+
+    expect(links.size).toBe(2);
+    expect(links.get('acc-1')).toEqual({
+      connectionId: 'conn-a',
+      institutionName: 'Monzo',
+      status: 'connected',
+      lastSync
+    });
+    // A single bank login backing several accounts shares the same connection.
+    expect(links.get('acc-2')?.connectionId).toBe('conn-a');
+  });
+
+  it('preserves reauth_required status so the UI can prompt a reconnect', () => {
+    const links = buildAccountBankLinks([
+      makeConnection({ id: 'conn-b', status: 'reauth_required', linkedAccountIds: ['acc-9'] })
+    ]);
+    expect(links.get('acc-9')?.status).toBe('reauth_required');
+  });
+
+  it('does not create entries for connections with no linked accounts', () => {
+    const links = buildAccountBankLinks([
+      makeConnection({ id: 'conn-c', linkedAccountIds: [] })
+    ]);
+    expect(links.size).toBe(0);
+  });
+
+  it('lets a later connection win when an account id appears twice', () => {
+    const links = buildAccountBankLinks([
+      makeConnection({ id: 'conn-old', linkedAccountIds: ['acc-x'] }),
+      makeConnection({ id: 'conn-new', linkedAccountIds: ['acc-x'] })
+    ]);
+    expect(links.get('acc-x')?.connectionId).toBe('conn-new');
+  });
+});

--- a/src/hooks/useAccountBankSync.ts
+++ b/src/hooks/useAccountBankSync.ts
@@ -1,0 +1,143 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useAuth as useClerkAuth } from '@clerk/clerk-react';
+import { bankConnectionService, type BankConnection } from '../services/bankConnectionService';
+import { useToast } from '../contexts/ToastContext';
+import { createScopedLogger } from '../loggers/scopedLogger';
+
+/**
+ * Bank-connection metadata for a single WealthTracker account, surfaced on the
+ * Accounts page so each linked account can show its last sync time and offer a
+ * one-click "pull fresh bank data" action.
+ */
+export interface AccountBankLink {
+  /** The bank connection that owns this account (a login may cover several accounts). */
+  connectionId: string;
+  institutionName: string;
+  status: BankConnection['status'];
+  lastSync?: Date;
+}
+
+export interface UseAccountBankSyncResult {
+  /** Bank link for an account, or undefined for manual/unlinked accounts. */
+  getAccountLink: (accountId: string) => AccountBankLink | undefined;
+  /** True while this account's connection is mid-sync. */
+  isAccountSyncing: (accountId: string) => boolean;
+  /** Pull fresh accounts + transactions for the account's whole bank connection. */
+  syncAccount: (accountId: string) => Promise<void>;
+  /** Re-fetch connection metadata (last sync, status) without triggering a sync. */
+  reloadConnections: () => Promise<void>;
+}
+
+const logger = createScopedLogger('useAccountBankSync');
+
+/**
+ * Flatten bank connections into an account-id → link map. A connection can back
+ * several WealthTracker accounts, so each linked id points back at the shared
+ * connection metadata. Pure to keep the mapping unit-testable.
+ */
+export function buildAccountBankLinks(connections: BankConnection[]): Map<string, AccountBankLink> {
+  const map = new Map<string, AccountBankLink>();
+  connections.forEach((connection) => {
+    connection.linkedAccountIds.forEach((accountId) => {
+      map.set(accountId, {
+        connectionId: connection.id,
+        institutionName: connection.institutionName,
+        status: connection.status,
+        lastSync: connection.lastSync
+      });
+    });
+  });
+  return map;
+}
+
+export function useAccountBankSync(options?: { onSynced?: () => void | Promise<void> }): UseAccountBankSyncResult {
+  const onSynced = options?.onSynced;
+  const { getToken } = useClerkAuth();
+  const { showSuccess, showWarning, showError } = useToast();
+  const [connections, setConnections] = useState<BankConnection[]>([]);
+  const [syncingConnectionIds, setSyncingConnectionIds] = useState<Set<string>>(new Set());
+
+  const reloadConnections = useCallback(async () => {
+    await bankConnectionService.refreshConnections();
+    setConnections(bankConnectionService.getConnections());
+  }, []);
+
+  // Keep the auth-token provider current and (re)load connections. Depending on
+  // getToken means that if the first mount raced ahead of Clerk minting a token,
+  // we re-fetch once a usable token exists instead of staying empty all visit.
+  useEffect(() => {
+    bankConnectionService.setAuthTokenProvider(() => getToken());
+    void reloadConnections();
+  }, [getToken, reloadConnections]);
+
+  const linksByAccountId = useMemo(() => buildAccountBankLinks(connections), [connections]);
+
+  const getAccountLink = useCallback(
+    (accountId: string) => linksByAccountId.get(accountId),
+    [linksByAccountId]
+  );
+
+  const isAccountSyncing = useCallback(
+    (accountId: string) => {
+      const link = linksByAccountId.get(accountId);
+      return link ? syncingConnectionIds.has(link.connectionId) : false;
+    },
+    [linksByAccountId, syncingConnectionIds]
+  );
+
+  const syncAccount = useCallback(
+    async (accountId: string) => {
+      const link = linksByAccountId.get(accountId);
+      if (!link) {
+        return;
+      }
+      const { connectionId, institutionName } = link;
+      // Guard against repeat clicks while this connection is already syncing.
+      if (syncingConnectionIds.has(connectionId)) {
+        return;
+      }
+
+      setSyncingConnectionIds((prev) => new Set(prev).add(connectionId));
+
+      try {
+        const result = await bankConnectionService.syncConnection(connectionId);
+        // syncConnection refreshes the service cache; mirror it into React state so
+        // the "Last synced" label and connection status update immediately.
+        setConnections(bankConnectionService.getConnections());
+
+        if (result.success) {
+          if (onSynced) {
+            await onSynced();
+          }
+          const imported = result.transactionsImported;
+          showSuccess(
+            imported > 0
+              ? `Imported ${imported} new transaction${imported === 1 ? '' : 's'} from ${institutionName}.`
+              : `${institutionName} is up to date — no new transactions.`,
+            'Bank sync complete'
+          );
+        } else {
+          // A failed sync (e.g. expired consent → HTTP 409) is caught inside
+          // syncConnection and returned as { success: false } WITHOUT refreshing
+          // the cache, so re-fetch to surface any reauth_required status flip.
+          await reloadConnections();
+          showWarning(result.errors[0] ?? 'The bank sync did not complete.', 'Bank sync incomplete');
+        }
+      } catch (error) {
+        logger.error('Failed to sync bank account', error as Error);
+        showError(error);
+        // A failure can flip the connection to reauth_required; surface it.
+        await reloadConnections();
+      } finally {
+        setSyncingConnectionIds((prev) => {
+          const next = new Set(prev);
+          next.delete(connectionId);
+          return next;
+        });
+      }
+    },
+    [linksByAccountId, syncingConnectionIds, onSynced, reloadConnections, showSuccess, showWarning, showError]
+  );
+
+  return { getAccountLink, isAccountSyncing, syncAccount, reloadConnections };
+}

--- a/src/pages/Accounts.tsx
+++ b/src/pages/Accounts.tsx
@@ -6,10 +6,11 @@ import AddAccountModal from '../components/AddAccountModal';
 import AccountSettingsModal from '../components/AccountSettingsModal';
 import PortfolioView from '../components/PortfolioView';
 // No longer importing from lucide-react - all icons are now custom
-import { DeleteIcon, SettingsIcon, WalletIcon, PiggyBankIcon, CreditCardIcon, TrendingDownIcon, TrendingUpIcon, CheckCircleIcon, HomeIcon, PieChartIcon, BankIcon } from '../components/icons';
+import { DeleteIcon, SettingsIcon, WalletIcon, PiggyBankIcon, CreditCardIcon, TrendingDownIcon, TrendingUpIcon, CheckCircleIcon, HomeIcon, PieChartIcon, BankIcon, RefreshCwIcon, AlertTriangleIcon } from '../components/icons';
 import { IconButton } from '../components/icons/IconButton';
 import { useCurrencyDecimal } from '../hooks/useCurrencyDecimal';
 import { useReconciliation } from '../hooks/useReconciliation';
+import { useAccountBankSync } from '../hooks/useAccountBankSync';
 import PageWrapper from '../components/PageWrapper';
 import PageTip from '../components/PageTip';
 import { calculateTotalBalance } from '../utils/calculations-decimal';
@@ -17,7 +18,7 @@ import { toDecimal } from '../utils/decimal';
 import { SkeletonCard } from '../components/loading/Skeleton';
 
 export default function Accounts({ onAccountClick }: { onAccountClick?: (accountId: string) => void }) {
-  const { accounts, transactions, updateAccount, deleteAccount } = useApp();
+  const { accounts, transactions, updateAccount, deleteAccount, refreshAccountsAndTransactions } = useApp();
   const { formatCurrency: formatDisplayCurrency } = useCurrencyDecimal();
   const navigate = useNavigate();
   const location = useLocation();
@@ -30,6 +31,8 @@ export default function Accounts({ onAccountClick }: { onAccountClick?: (account
   });
 
   const { getUnreconciledCount, computeAccountBalance } = useReconciliation(accounts, transactions);
+  // Per-account bank connection metadata + one-click "pull fresh bank data".
+  const { getAccountLink, isAccountSyncing, syncAccount } = useAccountBankSync({ onSynced: refreshAccountsAndTransactions });
 
   // Convert accounts to decimal for calculations
   const decimalAccounts = useMemo(() => accounts.map(a => ({
@@ -368,9 +371,12 @@ export default function Accounts({ onAccountClick }: { onAccountClick?: (account
               </div>
 
               <div className="p-3 sm:p-4 space-y-3">
-                {typeAccounts.map((account) => (
-                  <div 
-                    key={account.id} 
+                {typeAccounts.map((account) => {
+                  const bankLink = getAccountLink(account.id);
+                  const syncing = isAccountSyncing(account.id);
+                  return (
+                  <div
+                    key={account.id}
                     className="p-3 sm:p-4 bg-white dark:bg-gray-800 rounded-2xl shadow-lg border border-gray-100 dark:border-gray-700 hover:shadow-xl hover:border-gray-200 transition-all duration-300 cursor-pointer"
                     onClick={(e) => {
                       // Don't navigate if clicking on buttons or inputs
@@ -395,6 +401,19 @@ export default function Accounts({ onAccountClick }: { onAccountClick?: (account
                         <p className="text-xs text-gray-500 dark:text-gray-300">
                           Last updated: {new Date(account.lastUpdated).toLocaleDateString()}
                         </p>
+                        {bankLink && (
+                          <p className="text-xs text-gray-500 dark:text-gray-300">
+                            Last bank sync:{' '}
+                            {bankLink.lastSync
+                              ? new Date(bankLink.lastSync).toLocaleString()
+                              : 'Never'}
+                            {bankLink.status === 'reauth_required' && (
+                              <span className="ml-1 text-amber-600 dark:text-amber-400">
+                                · reconnect needed
+                              </span>
+                            )}
+                          </p>
+                        )}
                         {account.openingBalance !== undefined && (
                           <p className="text-xs text-gray-500 dark:text-gray-300 mt-1">
                             Opening balance: {formatDisplayCurrency(account.openingBalance, account.currency)} 
@@ -478,6 +497,36 @@ export default function Accounts({ onAccountClick }: { onAccountClick?: (account
                                     Settings
                                   </span>
                                 </div>
+                                {bankLink && (bankLink.status === 'reauth_required' ? (
+                                  <div className="relative group">
+                                    <IconButton
+                                      onClick={() => navigate(preserveDemoParam('/open-banking', location.search))}
+                                      icon={<AlertTriangleIcon size={20} />}
+                                      variant="ghost"
+                                      size="md"
+                                      className="text-amber-500 hover:text-amber-700 dark:text-amber-400 dark:hover:text-amber-300 hover:bg-amber-100/50 dark:hover:bg-amber-900/30 min-w-[48px] min-h-[48px]"
+                                      title="Reconnect bank"
+                                    />
+                                    <span className="absolute bottom-full left-1/2 transform -translate-x-1/2 mb-2 px-3 py-1.5 text-xs text-white bg-gray-900/90 dark:bg-gray-700/90 backdrop-blur-sm rounded-lg opacity-0 group-hover:opacity-100 transition-all duration-200 whitespace-nowrap pointer-events-none shadow-lg border border-white/10">
+                                      Reconnect bank
+                                    </span>
+                                  </div>
+                                ) : (
+                                  <div className="relative group">
+                                    <IconButton
+                                      onClick={() => void syncAccount(account.id)}
+                                      icon={<RefreshCwIcon size={20} className={syncing ? 'animate-spin' : ''} />}
+                                      variant="ghost"
+                                      size="md"
+                                      disabled={syncing}
+                                      className="text-green-600 hover:text-green-700 dark:text-green-400 dark:hover:text-green-200 hover:bg-green-100/50 dark:hover:bg-green-900/30 min-w-[48px] min-h-[48px]"
+                                      title="Sync bank data"
+                                    />
+                                    <span className="absolute bottom-full left-1/2 transform -translate-x-1/2 mb-2 px-3 py-1.5 text-xs text-white bg-gray-900/90 dark:bg-gray-700/90 backdrop-blur-sm rounded-lg opacity-0 group-hover:opacity-100 transition-all duration-200 whitespace-nowrap pointer-events-none shadow-lg border border-white/10">
+                                      {syncing ? 'Syncing…' : 'Sync bank data'}
+                                    </span>
+                                  </div>
+                                ))}
                                 <button
                                   onClick={() => navigate(preserveDemoParam(`/reconciliation?account=${account.id}`, location.search))}
                                   className="p-3 min-w-[48px] min-h-[48px] flex items-center justify-center text-blue-500 hover:text-blue-700 dark:text-blue-400 dark:hover:text-blue-200 hover:bg-blue-100/50 dark:hover:bg-blue-900/30 rounded-lg transition-all duration-200 relative group backdrop-blur-sm"
@@ -506,7 +555,8 @@ export default function Accounts({ onAccountClick }: { onAccountClick?: (account
                       </div>
                     </div>
                   </div>
-                ))}
+                  );
+                })}
               </div>
             </div>
           );

--- a/src/services/bankConnectionService.ts
+++ b/src/services/bankConnectionService.ts
@@ -28,6 +28,8 @@ export interface BankConnection {
   lastSync?: Date;
   accounts: string[];
   accountsCount?: number;
+  /** WealthTracker account ids linked to this connection. */
+  linkedAccountIds: string[];
   createdAt?: Date;
   expiresAt?: Date;
   error?: string;
@@ -487,6 +489,7 @@ export class BankConnectionService {
         lastSync: connection.lastSync ? new Date(connection.lastSync) : undefined,
         accounts: [],
         accountsCount: connection.accountsCount,
+        linkedAccountIds: connection.linkedAccountIds ?? [],
         expiresAt: connection.expiresAt ? new Date(connection.expiresAt) : undefined
       }));
     } catch (error) {

--- a/src/types/banking-api.ts
+++ b/src/types/banking-api.ts
@@ -123,6 +123,8 @@ export interface BankConnection {
   status: 'connected' | 'error' | 'reauth_required';
   lastSync?: string;
   accountsCount: number;
+  /** WealthTracker account ids linked to this connection (for per-account UI). */
+  linkedAccountIds: string[];
   expiresAt?: string;
 }
 


### PR DESCRIPTION
## What & why

On the Accounts page, each **bank-linked** account now shows a **Last bank sync** date and a **refresh button** next to Settings/Reconcile that pulls fresh accounts + transactions for that account's bank connection — no more detour through Open Banking for a quick sync. Requested by the account owner.

Connections that need reauthorization show an amber **Reconnect bank** button (→ `/open-banking`) instead of the sync button, and the line reads `· reconnect needed`.

> Honest scope note: the refresh pulls the whole bank **connection** (every account under that login). For a single-account login it behaves exactly as "sync this account."

## Changes

**Backend contract**
- `GET /api/banking/connections` now returns `linkedAccountIds: string[]` per connection (from `linked_accounts`), so the client can map a WealthTracker `account.id` → its bank connection. A `linked_accounts` lookup failure is now logged (non-fatal) instead of silently hiding the feature.

**Client**
- New `useAccountBankSync` hook: loads connections, builds a pure `account → link` map (`buildAccountBankLinks`, unit-tested), exposes `syncAccount()` with per-connection syncing state and success/warning/error toasts.
- New `AppContext.refreshAccountsAndTransactions()`: a **narrow** refresh that re-pulls only accounts + transactions from Supabase. Deliberately not the whole-app refresh — that path reads budgets/goals from localStorage and would blank them for cloud users.
- On sync failure (e.g. expired consent → 409) the hook re-fetches connections so a server-side `reauth_required` flip surfaces the reconnect UI immediately.
- Connection load re-runs when the Clerk token becomes available (recovers from a token-not-ready first mount).

## Review

A pre-PR adversarial review surfaced four issues, all fixed before commit:
1. **(major)** whole-app `refreshData` would blank budgets/goals for cloud users → replaced with narrow `refreshAccountsAndTransactions`.
2. **(major)** reauth failure left stale "connected" status → reload connections on failure.
3. **(moderate)** silent `linked_accounts` query failure → now logged.
4. **(minor)** load-once race with Clerk token → effect depends on `getToken`.

## Verification
- `typecheck:strict` ✅ · app typecheck ✅ · `lint` ✅ · `build` ✅
- Pre-commit unit gate: 2745 passed ✅ · Pre-push coverage 64.47% (≥63) / branches 75.66% (≥55) ✅
- New: `buildAccountBankLinks` mapping tests (5 cases)

🤖 Generated with [Claude Code](https://claude.com/claude-code)