### PR TITLE
fix(reconciliation)!: make the cleared toggle persist + MS Money-style flow

### DIFF
--- a/src/components/EditTransactionModal.tsx
+++ b/src/components/EditTransactionModal.tsx
@@ -21,6 +21,8 @@ interface EditTransactionModalProps {
   isOpen: boolean;
   onClose: () => void;
   transaction: Transaction | null;
+  /** Account to pre-select for NEW transactions (e.g. the account being reconciled). */
+  defaultAccountId?: string;
 }
 
 interface FormData {
@@ -37,7 +39,7 @@ interface FormData {
   reconciledWith: string;
 }
 
-export default function EditTransactionModal({ isOpen, onClose, transaction }: EditTransactionModalProps): React.JSX.Element {
+export default function EditTransactionModal({ isOpen, onClose, transaction, defaultAccountId }: EditTransactionModalProps): React.JSX.Element {
   const { accounts, categories, updateTransaction, deleteTransaction } = useApp();
   const { addTransaction } = useTransactionNotifications();
   const logger = useMemo(() => createScopedLogger('EditTransactionModal'), []);
@@ -67,7 +69,7 @@ export default function EditTransactionModal({ isOpen, onClose, transaction }: E
     type: 'expense',
     category: '',
     subCategory: '',
-    accountId: accounts.length > 0 ? accounts[0].id : '',
+    accountId: defaultAccountId ?? (accounts.length > 0 ? accounts[0].id : ''),
     tags: [],
     notes: '',
     cleared: false,
@@ -77,7 +79,7 @@ export default function EditTransactionModal({ isOpen, onClose, transaction }: E
   const { formData, updateField, handleSubmit, setFormData, errors } = useModalForm<FormData>(
     initialFormData,
     {
-      onSubmit: (data) => {
+      onSubmit: async (data) => {
         try {
           const isTransfer = data.type === 'transfer';
           // A freshly-chosen outgoing transfer encodes its target in the
@@ -136,15 +138,17 @@ export default function EditTransactionModal({ isOpen, onClose, transaction }: E
             reconciledWith: data.reconciledWith.trim() || undefined
           };
 
+          // Await the writes so a failed RPC surfaces via the form's submit
+          // error instead of silently closing the modal (fire-and-forget bug).
           if (transaction) {
-            updateTransaction(transaction.id, transactionData);
+            await updateTransaction(transaction.id, transactionData);
           } else {
-            addTransaction(transactionData);
+            await addTransaction(transactionData);
           }
 
           // Create paired transaction in target account for NEW transfers only
           if (isNewTransferSelection && targetAccountId && !transaction) {
-            addTransaction({
+            await addTransaction({
               date: new Date(validatedData.date),
               description: validatedData.description,
               amount: Math.abs(parsedAmount),
@@ -261,7 +265,7 @@ export default function EditTransactionModal({ isOpen, onClose, transaction }: E
         type: 'expense',
         subCategory: '',
         category: '',
-        accountId: accounts.length > 0 ? accounts[0].id : '',
+        accountId: defaultAccountId ?? (accounts.length > 0 ? accounts[0].id : ''),
         tags: [],
         notes: '',
         cleared: false,
@@ -270,7 +274,7 @@ export default function EditTransactionModal({ isOpen, onClose, transaction }: E
       setFormattedAmount('');
     }
     setShowDeleteConfirm(false);
-  }, [transaction, accounts, categories, setFormData]);
+  }, [transaction, accounts, categories, setFormData, defaultAccountId]);
 
 
   const handleDelete = () => {

--- a/src/components/reconciliation/ReconciliationBalanceBar.tsx
+++ b/src/components/reconciliation/ReconciliationBalanceBar.tsx
@@ -1,12 +1,14 @@
 import React, { useState, useEffect } from 'react';
-import { parseMoneyInput } from '../../utils/decimal';
+import { parseMoneyInput, toDecimal } from '../../utils/decimal';
 import { useCurrencyDecimal } from '../../hooks/useCurrencyDecimal';
+import type { ClearedSummary } from '../../hooks/useReconciliation';
 
 interface ReconciliationBalanceBarProps {
   bankBalance: number | null;
   accountBalance: number;
   clearedBalance: number;
   currency?: string;
+  clearedSummary?: ClearedSummary;
   onBankBalanceChange?: (newBalance: number) => void;
 }
 
@@ -15,6 +17,7 @@ export default function ReconciliationBalanceBar({
   accountBalance,
   clearedBalance,
   currency,
+  clearedSummary,
   onBankBalanceChange,
 }: ReconciliationBalanceBarProps): React.JSX.Element {
   const { formatCurrency } = useCurrencyDecimal();
@@ -23,7 +26,9 @@ export default function ReconciliationBalanceBar({
   const [optimisticBankBalance, setOptimisticBankBalance] = useState<number | null>(null);
 
   const displayBankBalance = bankBalance ?? optimisticBankBalance;
-  const difference = displayBankBalance != null ? displayBankBalance - clearedBalance : null;
+  const difference = displayBankBalance != null
+    ? toDecimal(displayBankBalance).minus(toDecimal(clearedBalance)).toNumber()
+    : null;
 
   // Clear optimistic value once the real prop arrives
   useEffect(() => {
@@ -122,6 +127,32 @@ export default function ReconciliationBalanceBar({
           )}
         </div>
       </div>
+
+      {/* Cleared summary (MS Money-style session totals) */}
+      {clearedSummary && clearedSummary.totalCount > 0 && (
+        <div className="mt-3 pt-3 border-t border-gray-100 dark:border-gray-700 flex flex-wrap items-center justify-center gap-x-6 gap-y-1 text-xs text-gray-500 dark:text-gray-400">
+          <span>
+            <span className="font-semibold text-gray-700 dark:text-gray-300">
+              {clearedSummary.clearedCount} of {clearedSummary.totalCount}
+            </span>{' '}
+            transactions cleared
+          </span>
+          <span>
+            Cleared deposits:{' '}
+            <span className="font-semibold text-green-600 dark:text-green-400">
+              {formatCurrency(clearedSummary.depositsTotal, currency)}
+            </span>{' '}
+            ({clearedSummary.depositsCount})
+          </span>
+          <span>
+            Cleared payments:{' '}
+            <span className="font-semibold text-red-600 dark:text-red-400">
+              {formatCurrency(clearedSummary.paymentsTotal, currency)}
+            </span>{' '}
+            ({clearedSummary.paymentsCount})
+          </span>
+        </div>
+      )}
     </div>
   );
 }

--- a/src/components/reconciliation/ReconciliationFinalizationModal.tsx
+++ b/src/components/reconciliation/ReconciliationFinalizationModal.tsx
@@ -1,7 +1,9 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { CheckCircleIcon, XIcon } from '../icons';
 import CategorySelector from '../CategorySelector';
 import { useCurrencyDecimal } from '../../hooks/useCurrencyDecimal';
+import { parseMoneyInput, toDecimal } from '../../utils/decimal';
+import { deriveAdjustment } from '../../utils/reconciliation';
 
 interface ReconciliationFinalizationModalProps {
   isOpen: boolean;
@@ -10,13 +12,21 @@ interface ReconciliationFinalizationModalProps {
   currency?: string;
   onClose: () => void;
   onFinalize: () => void;
+  /**
+   * Create a cleared adjustment transaction. Amount is SIGNED per the app-wide
+   * convention (income positive, expense negative). The modal stays open —
+   * the parent recomputes clearedBalance and the modal re-renders with the
+   * remaining difference, so several partial adjustments can be created until
+   * the difference reaches zero (the Microsoft Money model). Must return the
+   * write's promise so the modal can hold its in-flight guard until it lands.
+   */
   onCreateAdjustment: (data: {
     amount: number;
     type: 'income' | 'expense';
     description: string;
     category: string;
     date: Date;
-  }) => void;
+  }) => Promise<void>;
 }
 
 export default function ReconciliationFinalizationModal({
@@ -31,26 +41,64 @@ export default function ReconciliationFinalizationModal({
   const { formatCurrency } = useCurrencyDecimal();
 
   const hasBankBalance = bankBalance != null;
-  const difference = hasBankBalance ? bankBalance - clearedBalance : null;
+  const difference = hasBankBalance
+    ? toDecimal(bankBalance).minus(toDecimal(clearedBalance)).toNumber()
+    : null;
   const isBalanced = difference != null && Math.abs(difference) < 0.005;
 
+  const [adjustmentAmount, setAdjustmentAmount] = useState('');
+  // "Account Adjustment" is the exact payee Microsoft Money used for these.
+  const [adjustmentDescription, setAdjustmentDescription] = useState('Account Adjustment');
   const [adjustmentCategory, setAdjustmentCategory] = useState('');
   const [adjustmentDate, setAdjustmentDate] = useState(
     new Date().toISOString().split('T')[0]
   );
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  // While the user is editing the amount, a background clearedBalance change
+  // (e.g. a toggle RPC resolving) must not clobber what they typed.
+  const [amountDirty, setAmountDirty] = useState(false);
+
+  useEffect(() => {
+    if (isOpen) {
+      setAmountDirty(false);
+    }
+  }, [isOpen]);
+
+  // Pre-fill (and re-sync after each created adjustment) with the remaining
+  // difference, so the default action always zeroes the account in one step.
+  useEffect(() => {
+    if (isOpen && difference != null && !amountDirty) {
+      setAdjustmentAmount(Math.abs(difference).toFixed(2));
+    }
+  }, [isOpen, difference, amountDirty]);
 
   if (!isOpen) return null;
 
-  const handleCreateAdjustment = () => {
-    if (!adjustmentCategory || difference == null) return;
+  const parsedAmount = parseMoneyInput(adjustmentAmount);
+  const { type: adjustmentType, signedAmount } = deriveAdjustment(difference ?? 0, parsedAmount ?? null);
+  const amountValid = signedAmount != null && Math.abs(signedAmount) > 0;
 
-    onCreateAdjustment({
-      amount: difference,
-      type: difference > 0 ? 'income' : 'expense',
-      description: 'Account Reconciliation Adjustment',
-      category: adjustmentCategory,
-      date: new Date(adjustmentDate),
-    });
+  const handleCreateAdjustment = async () => {
+    if (isSubmitting || !amountValid || signedAmount == null || !adjustmentCategory || !adjustmentDescription.trim() || difference == null) {
+      return;
+    }
+
+    // In-flight guard: without it a double-click would write two identical
+    // adjustment transactions before the first RPC resolves.
+    setIsSubmitting(true);
+    try {
+      await onCreateAdjustment({
+        amount: signedAmount,
+        type: adjustmentType,
+        description: adjustmentDescription.trim(),
+        category: adjustmentCategory,
+        date: new Date(adjustmentDate),
+      });
+      // Success: let the amount field re-sync to the new remaining difference.
+      setAmountDirty(false);
+    } finally {
+      setIsSubmitting(false);
+    }
   };
 
   return (
@@ -64,6 +112,7 @@ export default function ReconciliationFinalizationModal({
           <button
             onClick={onClose}
             className="p-1 text-gray-400 hover:text-gray-600 dark:hover:text-gray-300"
+            aria-label="Close"
           >
             <XIcon size={20} />
           </button>
@@ -113,11 +162,11 @@ export default function ReconciliationFinalizationModal({
             </button>
           </div>
         ) : (
-          /* Unbalanced — show options */
+          /* Unbalanced — create adjustment(s) until the difference is zero */
           <div>
             <div className="bg-red-50 dark:bg-red-900/20 rounded-lg p-4 mb-4">
               <p className="text-sm text-red-600 dark:text-red-400 mb-1">
-                There is a difference between your bank balance and cleared balance:
+                Difference between bank balance and cleared balance:
               </p>
               <p className="text-2xl font-bold text-red-600 dark:text-red-400">
                 {formatCurrency(difference!, currency)}
@@ -129,18 +178,49 @@ export default function ReconciliationFinalizationModal({
             </div>
 
             <div className="space-y-3 mb-6">
-              <h4 className="text-sm font-semibold text-gray-700 dark:text-gray-300">
-                Create Adjustment Transaction
-              </h4>
-
-              {/* Amount (read-only) */}
               <div>
-                <label className="text-xs text-gray-500 dark:text-gray-400">Amount</label>
-                <p className="text-sm font-medium text-gray-900 dark:text-white">
-                  {formatCurrency(Math.abs(difference!), currency)}
-                  {' '}
-                  ({difference! > 0 ? 'Income' : 'Expense'})
+                <h4 className="text-sm font-semibold text-gray-700 dark:text-gray-300">
+                  Create Adjustment Transaction
+                </h4>
+                <p className="text-xs text-gray-500 dark:text-gray-400 mt-0.5">
+                  Creates a cleared {adjustmentType} that reduces the difference. You can
+                  create more than one adjustment until the difference reaches zero.
                 </p>
+              </div>
+
+              {/* Amount (editable, pre-filled with remaining difference) */}
+              <div>
+                <label htmlFor="adjustment-amount" className="text-xs text-gray-500 dark:text-gray-400 block mb-1">
+                  Amount ({adjustmentType === 'income' ? 'Income' : 'Expense'})
+                </label>
+                <input
+                  id="adjustment-amount"
+                  type="text"
+                  inputMode="decimal"
+                  value={adjustmentAmount}
+                  onChange={(e) => {
+                    setAmountDirty(true);
+                    setAdjustmentAmount(e.target.value);
+                  }}
+                  className="w-full px-3 py-2 text-sm border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-700 dark:text-white"
+                />
+                {!amountValid && adjustmentAmount.trim() !== '' && (
+                  <p className="text-xs text-red-500 mt-1">Enter an amount greater than zero.</p>
+                )}
+              </div>
+
+              {/* Description */}
+              <div>
+                <label htmlFor="adjustment-description" className="text-xs text-gray-500 dark:text-gray-400 block mb-1">
+                  Description
+                </label>
+                <input
+                  id="adjustment-description"
+                  type="text"
+                  value={adjustmentDescription}
+                  onChange={(e) => setAdjustmentDescription(e.target.value)}
+                  className="w-full px-3 py-2 text-sm border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-700 dark:text-white"
+                />
               </div>
 
               {/* Category */}
@@ -151,7 +231,7 @@ export default function ReconciliationFinalizationModal({
                 <CategorySelector
                   selectedCategory={adjustmentCategory}
                   onCategoryChange={setAdjustmentCategory}
-                  transactionType={difference! > 0 ? 'income' : 'expense'}
+                  transactionType={adjustmentType}
                   placeholder="Select category..."
                   allowCreate={false}
                 />
@@ -159,10 +239,11 @@ export default function ReconciliationFinalizationModal({
 
               {/* Date */}
               <div>
-                <label className="text-xs text-gray-500 dark:text-gray-400 block mb-1">
+                <label htmlFor="adjustment-date" className="text-xs text-gray-500 dark:text-gray-400 block mb-1">
                   Date
                 </label>
                 <input
+                  id="adjustment-date"
                   type="date"
                   value={adjustmentDate}
                   onChange={(e) => setAdjustmentDate(e.target.value)}
@@ -179,11 +260,11 @@ export default function ReconciliationFinalizationModal({
                 Go Back
               </button>
               <button
-                onClick={handleCreateAdjustment}
-                disabled={!adjustmentCategory}
+                onClick={() => void handleCreateAdjustment()}
+                disabled={isSubmitting || !amountValid || !adjustmentCategory || !adjustmentDescription.trim()}
                 className="flex-1 px-4 py-2 bg-[#1a2332] text-white rounded-lg hover:bg-secondary transition-colors text-sm font-medium disabled:opacity-50 disabled:cursor-not-allowed"
               >
-                Create Adjustment
+                {isSubmitting ? 'Creating…' : 'Create Adjustment'}
               </button>
             </div>
           </div>

--- a/src/components/reconciliation/ReconciliationTransactionList.tsx
+++ b/src/components/reconciliation/ReconciliationTransactionList.tsx
@@ -10,7 +10,13 @@ interface ReconciliationTransactionListProps {
   categories: Category[];
   currency?: string;
   openingBalance: number;
+  /** Ids with a cleared-write in flight; their checkboxes are disabled. */
+  pendingClearedIds?: ReadonlyMap<string, boolean>;
   onToggleCleared: (transactionId: string, cleared: boolean) => void;
+  /** Bulk mark/unmark; ids are the currently visible (filtered) transactions. */
+  onBulkSetCleared: (transactionIds: string[], cleared: boolean) => void;
+  /** Open a transaction to edit its details/category. */
+  onRowClick: (transaction: Transaction) => void;
   onAddTransaction: () => void;
 }
 
@@ -19,7 +25,10 @@ export default function ReconciliationTransactionList({
   categories,
   currency,
   openingBalance,
+  pendingClearedIds,
   onToggleCleared,
+  onBulkSetCleared,
+  onRowClick,
   onAddTransaction,
 }: ReconciliationTransactionListProps): React.JSX.Element {
   const { formatCurrency } = useCurrencyDecimal();
@@ -75,6 +84,31 @@ export default function ReconciliationTransactionList({
     return list;
   }, [sortedTransactions, filterMode, searchTerm, getCategoryName]);
 
+  const visibleUnclearedIds = useMemo(
+    () => filteredTransactions.filter(t => t.cleared !== true).map(t => t.id),
+    [filteredTransactions]
+  );
+  const visibleClearedIds = useMemo(
+    () => filteredTransactions.filter(t => t.cleared === true).map(t => t.id),
+    [filteredTransactions]
+  );
+
+  const handleMarkAllCleared = useCallback(() => {
+    const count = visibleUnclearedIds.length;
+    if (count === 0) return;
+    if (window.confirm(`Mark ${count} transaction${count === 1 ? '' : 's'} as cleared?`)) {
+      onBulkSetCleared(visibleUnclearedIds, true);
+    }
+  }, [visibleUnclearedIds, onBulkSetCleared]);
+
+  const handleUnmarkAll = useCallback(() => {
+    const count = visibleClearedIds.length;
+    if (count === 0) return;
+    if (window.confirm(`Mark ${count} transaction${count === 1 ? '' : 's'} as uncleared?`)) {
+      onBulkSetCleared(visibleClearedIds, false);
+    }
+  }, [visibleClearedIds, onBulkSetCleared]);
+
   return (
     <div className="flex flex-col gap-3">
       {/* Toolbar */}
@@ -107,6 +141,24 @@ export default function ReconciliationTransactionList({
             </button>
           ))}
         </div>
+
+        {/* Bulk actions */}
+        <button
+          onClick={handleMarkAllCleared}
+          disabled={visibleUnclearedIds.length === 0}
+          className="px-3 py-2 text-sm border border-gray-300 dark:border-gray-600 rounded-lg text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors disabled:opacity-40 disabled:cursor-not-allowed whitespace-nowrap"
+          title="Mark all currently shown transactions as cleared"
+        >
+          Mark all cleared
+        </button>
+        <button
+          onClick={handleUnmarkAll}
+          disabled={visibleClearedIds.length === 0}
+          className="px-3 py-2 text-sm border border-gray-300 dark:border-gray-600 rounded-lg text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors disabled:opacity-40 disabled:cursor-not-allowed whitespace-nowrap"
+          title="Mark all currently shown transactions as uncleared"
+        >
+          Unmark all
+        </button>
 
         {/* Add transaction */}
         <button
@@ -143,7 +195,9 @@ export default function ReconciliationTransactionList({
               return (
                 <div
                   key={t.id}
-                  className="grid grid-cols-[100px_50px_1fr_180px_120px_120px] gap-2 px-4 py-2 hover:bg-gray-50 dark:hover:bg-gray-750 items-center text-sm"
+                  onClick={() => onRowClick(t)}
+                  className="grid grid-cols-[100px_50px_1fr_180px_120px_120px] gap-2 px-4 py-2 hover:bg-gray-50 dark:hover:bg-gray-750 items-center text-sm cursor-pointer"
+                  title="Click to edit this transaction"
                 >
                   {/* Date */}
                   <div className="text-gray-700 dark:text-gray-300">
@@ -153,8 +207,13 @@ export default function ReconciliationTransactionList({
                   {/* R/U checkbox */}
                   <div className="text-center">
                     <button
-                      onClick={() => onToggleCleared(t.id, !t.cleared)}
-                      className={`w-6 h-6 rounded border-2 flex items-center justify-center transition-colors ${
+                      onClick={(e) => {
+                        // The row itself opens the edit modal; keep the toggle isolated.
+                        e.stopPropagation();
+                        onToggleCleared(t.id, !t.cleared);
+                      }}
+                      disabled={pendingClearedIds?.has(t.id) ?? false}
+                      className={`w-6 h-6 rounded border-2 flex items-center justify-center transition-colors disabled:opacity-60 disabled:cursor-wait ${
                         t.cleared
                           ? 'bg-green-500 border-green-500 text-white'
                           : 'border-gray-300 dark:border-gray-500 hover:border-primary'
@@ -172,7 +231,9 @@ export default function ReconciliationTransactionList({
 
                   {/* Category */}
                   <div className="text-gray-500 dark:text-gray-400 truncate">
-                    {getCategoryName(t.category)}
+                    {getCategoryName(t.category) || (
+                      <span className="italic text-gray-400 dark:text-gray-500">Add category…</span>
+                    )}
                   </div>
 
                   {/* Amount */}

--- a/src/components/reconciliation/__tests__/ReconciliationFinalizationModal.test.tsx
+++ b/src/components/reconciliation/__tests__/ReconciliationFinalizationModal.test.tsx
@@ -1,0 +1,94 @@
+import React from 'react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { screen, fireEvent } from '@testing-library/react';
+import { renderWithProviders } from '../../../test/testUtils';
+import ReconciliationFinalizationModal from '../ReconciliationFinalizationModal';
+import { deriveAdjustment } from '../../../utils/reconciliation';
+
+describe('deriveAdjustment', () => {
+  it('bank above cleared → income with a positive signed amount', () => {
+    expect(deriveAdjustment(12.04, 12.04)).toEqual({ type: 'income', signedAmount: 12.04 });
+  });
+
+  it('bank below cleared → expense with a negative signed amount', () => {
+    expect(deriveAdjustment(-12.04, 12.04)).toEqual({ type: 'expense', signedAmount: -12.04 });
+  });
+
+  it('normalises a user-entered negative amount to the difference direction', () => {
+    // The direction comes from the difference, never from the entered sign.
+    expect(deriveAdjustment(50, -20)).toEqual({ type: 'income', signedAmount: 20 });
+    expect(deriveAdjustment(-50, -20)).toEqual({ type: 'expense', signedAmount: -20 });
+  });
+
+  it('passes through a null amount while still reporting the direction', () => {
+    expect(deriveAdjustment(-5, null)).toEqual({ type: 'expense', signedAmount: null });
+  });
+});
+
+describe('ReconciliationFinalizationModal', () => {
+  const onClose = vi.fn();
+  const onFinalize = vi.fn();
+  const onCreateAdjustment = vi.fn();
+
+  const renderModal = (props: { bankBalance: number | null; clearedBalance: number }) =>
+    renderWithProviders(
+      <ReconciliationFinalizationModal
+        isOpen={true}
+        bankBalance={props.bankBalance}
+        clearedBalance={props.clearedBalance}
+        onClose={onClose}
+        onFinalize={onFinalize}
+        onCreateAdjustment={onCreateAdjustment}
+      />
+    );
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('shows the balanced state and finalizes when difference is zero', () => {
+    renderModal({ bankBalance: 100, clearedBalance: 100 });
+    expect(screen.getByText('Account Balanced!')).toBeInTheDocument();
+    fireEvent.click(screen.getByText('Complete Reconciliation'));
+    expect(onFinalize).toHaveBeenCalledTimes(1);
+  });
+
+  it('treats a sub-penny difference as balanced', () => {
+    renderModal({ bankBalance: 100.001, clearedBalance: 100 });
+    expect(screen.getByText('Account Balanced!')).toBeInTheDocument();
+  });
+
+  it('offers finalize-anyway when no bank balance is set', () => {
+    renderModal({ bankBalance: null, clearedBalance: 100 });
+    expect(screen.getByText('No Bank Balance Set')).toBeInTheDocument();
+    fireEvent.click(screen.getByText('Finalize Anyway'));
+    expect(onFinalize).toHaveBeenCalledTimes(1);
+  });
+
+  it('pre-fills the adjustment amount with the remaining difference', () => {
+    renderModal({ bankBalance: 87.96, clearedBalance: 100 });
+    // difference = -12.04 → expense of 12.04
+    const amountInput = screen.getByLabelText(/Amount/) as HTMLInputElement;
+    expect(amountInput.value).toBe('12.04');
+    expect(screen.getByText(/Amount \(Expense\)/)).toBeInTheDocument();
+  });
+
+  it('labels the adjustment as income when the bank balance is higher', () => {
+    renderModal({ bankBalance: 150, clearedBalance: 100 });
+    expect(screen.getByText(/Amount \(Income\)/)).toBeInTheDocument();
+  });
+
+  it('disables Create Adjustment until a category is chosen', () => {
+    renderModal({ bankBalance: 87.96, clearedBalance: 100 });
+    expect(screen.getByText('Create Adjustment')).toBeDisabled();
+    expect(onCreateAdjustment).not.toHaveBeenCalled();
+  });
+
+  it('rejects a zero adjustment amount', () => {
+    renderModal({ bankBalance: 87.96, clearedBalance: 100 });
+    const amountInput = screen.getByLabelText(/Amount/);
+    fireEvent.change(amountInput, { target: { value: '0' } });
+    expect(screen.getByText('Enter an amount greater than zero.')).toBeInTheDocument();
+    expect(screen.getByText('Create Adjustment')).toBeDisabled();
+  });
+});

--- a/src/components/reconciliation/__tests__/ReconciliationTransactionList.test.tsx
+++ b/src/components/reconciliation/__tests__/ReconciliationTransactionList.test.tsx
@@ -1,0 +1,121 @@
+import React from 'react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { screen, fireEvent } from '@testing-library/react';
+import { renderWithProviders } from '../../../test/testUtils';
+import ReconciliationTransactionList from '../ReconciliationTransactionList';
+import type { Transaction } from '../../../types';
+
+const transactions: Transaction[] = [
+  {
+    id: 'tx-uncleared',
+    date: new Date('2026-01-10'),
+    amount: -25.5,
+    description: 'Coffee Shop',
+    category: '',
+    accountId: 'acc-1',
+    type: 'expense',
+    cleared: false,
+  },
+  {
+    id: 'tx-cleared',
+    date: new Date('2026-01-11'),
+    amount: 100,
+    description: 'Salary Payment',
+    category: '',
+    accountId: 'acc-1',
+    type: 'income',
+    cleared: true,
+  },
+];
+
+describe('ReconciliationTransactionList', () => {
+  const onToggleCleared = vi.fn();
+  const onBulkSetCleared = vi.fn();
+  const onRowClick = vi.fn();
+  const onAddTransaction = vi.fn();
+
+  const renderList = (txns: Transaction[] = transactions) =>
+    renderWithProviders(
+      <ReconciliationTransactionList
+        transactions={txns}
+        categories={[]}
+        openingBalance={0}
+        onToggleCleared={onToggleCleared}
+        onBulkSetCleared={onBulkSetCleared}
+        onRowClick={onRowClick}
+        onAddTransaction={onAddTransaction}
+      />
+    );
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  // NOTE: no vi.restoreAllMocks() here — it would strip the global matchMedia
+  // stub installed by the test setup and break every subsequent render.
+  const spyConfirm = (answer: boolean) => {
+    const spy = vi.spyOn(window, 'confirm').mockReturnValue(answer);
+    return spy;
+  };
+
+  it('clicking a row opens it for editing', () => {
+    renderList();
+    fireEvent.click(screen.getByText('Coffee Shop'));
+    expect(onRowClick).toHaveBeenCalledTimes(1);
+    expect(onRowClick.mock.calls[0][0].id).toBe('tx-uncleared');
+  });
+
+  it('clicking the cleared checkbox toggles without opening the row', () => {
+    renderList();
+    fireEvent.click(screen.getByTitle('Mark as cleared'));
+    expect(onToggleCleared).toHaveBeenCalledWith('tx-uncleared', true);
+    expect(onRowClick).not.toHaveBeenCalled();
+  });
+
+  it('clicking a cleared checkbox unmarks it', () => {
+    renderList();
+    fireEvent.click(screen.getByTitle('Mark as uncleared'));
+    expect(onToggleCleared).toHaveBeenCalledWith('tx-cleared', false);
+  });
+
+  it('"Mark all cleared" bulk-clears visible uncleared transactions after confirm', () => {
+    const spy = spyConfirm(true);
+    renderList();
+    fireEvent.click(screen.getByText('Mark all cleared'));
+    expect(onBulkSetCleared).toHaveBeenCalledWith(['tx-uncleared'], true);
+    spy.mockRestore();
+  });
+
+  it('"Unmark all" bulk-unclears visible cleared transactions after confirm', () => {
+    const spy = spyConfirm(true);
+    renderList();
+    fireEvent.click(screen.getByText('Unmark all'));
+    expect(onBulkSetCleared).toHaveBeenCalledWith(['tx-cleared'], false);
+    spy.mockRestore();
+  });
+
+  it('does nothing when the bulk confirm is declined', () => {
+    const spy = spyConfirm(false);
+    renderList();
+    fireEvent.click(screen.getByText('Mark all cleared'));
+    expect(onBulkSetCleared).not.toHaveBeenCalled();
+    spy.mockRestore();
+  });
+
+  it('disables bulk buttons when they have nothing to act on', () => {
+    renderList([transactions[1]]); // only a cleared transaction visible
+    expect(screen.getByText('Mark all cleared')).toBeDisabled();
+    expect(screen.getByText('Unmark all')).not.toBeDisabled();
+  });
+
+  it('shows an "Add category…" hint for uncategorised transactions', () => {
+    renderList();
+    expect(screen.getAllByText('Add category…').length).toBeGreaterThan(0);
+  });
+
+  it('wires the Add button', () => {
+    renderList();
+    fireEvent.click(screen.getByText('Add'));
+    expect(onAddTransaction).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/contexts/AppContextSupabase.tsx
+++ b/src/contexts/AppContextSupabase.tsx
@@ -96,6 +96,11 @@ export interface AppContextType extends AppState {
    * refresh would blank them for cloud users.
    */
   refreshAccountsAndTransactions: () => Promise<void>;
+  /**
+   * Bulk-set the reconciliation cleared flag on transactions in one round trip.
+   * Balance-neutral (is_cleared never affects account balances).
+   */
+  setTransactionsCleared: (ids: string[], cleared: boolean) => Promise<void>;
 }
 
 const AppContext = createContext<AppContextType | undefined>(undefined);
@@ -456,6 +461,20 @@ export function AppProvider({ children }: { children: React.ReactNode }) {
     }
   }, [transactions]);
 
+  const setTransactionsCleared = useCallback(async (ids: string[], cleared: boolean) => {
+    if (ids.length === 0) {
+      return;
+    }
+    try {
+      await DataService.setTransactionsCleared(ids, cleared);
+      const idSet = new Set(ids);
+      setTransactions(prev => prev.map(t => (idSet.has(t.id) ? { ...t, cleared } : t)));
+    } catch (error) {
+      appLogger.error('Failed to set cleared status', error);
+      throw error;
+    }
+  }, []);
+
   const deleteTransaction = useCallback(async (id: string) => {
     try {
       const transaction = transactions.find(t => t.id === id);
@@ -737,7 +756,8 @@ export function AppProvider({ children }: { children: React.ReactNode }) {
     addTransaction,
     updateTransaction,
     deleteTransaction,
-    
+    setTransactionsCleared,
+
     // Budget operations
     addBudget,
     updateBudget,

--- a/src/hooks/__tests__/useReconciliation.test.ts
+++ b/src/hooks/__tests__/useReconciliation.test.ts
@@ -102,6 +102,51 @@ describe('useReconciliation', () => {
     });
   });
 
+  describe('computeClearedSummary', () => {
+    it('splits cleared transactions into deposits and payments with Decimal-safe totals', () => {
+      const { result } = renderHook(() =>
+        useReconciliation(mockAccounts, [
+          ...mockTransactions,
+          {
+            id: 'tx5',
+            date: new Date('2024-01-14'),
+            amount: 250.1,
+            description: 'Refund',
+            category: 'Income',
+            accountId: 'acc1',
+            type: 'income',
+            cleared: true
+          }
+        ])
+      );
+
+      const summary = result.current.computeClearedSummary('acc1');
+      // acc1 cleared: tx2 (-50 payment) and tx5 (+250.10 deposit)
+      expect(summary.clearedCount).toBe(2);
+      expect(summary.totalCount).toBe(4);
+      expect(summary.depositsTotal).toBe(250.1);
+      expect(summary.depositsCount).toBe(1);
+      expect(summary.paymentsTotal).toBe(-50);
+      expect(summary.paymentsCount).toBe(1);
+    });
+
+    it('returns zeroed summary for an account with no transactions', () => {
+      const { result } = renderHook(() =>
+        useReconciliation(mockAccounts, mockTransactions)
+      );
+
+      const summary = result.current.computeClearedSummary('missing-account');
+      expect(summary).toEqual({
+        clearedCount: 0,
+        totalCount: 0,
+        depositsTotal: 0,
+        depositsCount: 0,
+        paymentsTotal: 0,
+        paymentsCount: 0,
+      });
+    });
+  });
+
   describe('totalUnreconciledCount', () => {
     it('should count all uncleared transactions', () => {
       const { result } = renderHook(() =>

--- a/src/hooks/useReconciliation.ts
+++ b/src/hooks/useReconciliation.ts
@@ -1,4 +1,5 @@
 import { useMemo, useCallback } from 'react';
+import { toDecimal } from '../utils/decimal';
 import type { Account, Transaction } from '../types';
 
 export interface ReconciliationSummary {
@@ -11,12 +12,23 @@ export interface ReconciliationSummary {
   lastReconciledDate: Date | null;
 }
 
+/** MS Money-style session totals: what's been marked cleared, split by direction. */
+export interface ClearedSummary {
+  clearedCount: number;
+  totalCount: number;
+  depositsTotal: number;
+  depositsCount: number;
+  paymentsTotal: number;
+  paymentsCount: number;
+}
+
 interface UseReconciliationReturn {
   reconciliationDetails: ReconciliationSummary[];
   totalUnreconciledCount: number;
   getUnreconciledCount: (accountId: string) => number;
   computeAccountBalance: (accountId: string) => number;
   computeClearedBalance: (accountId: string) => number;
+  computeClearedSummary: (accountId: string) => ClearedSummary;
 }
 
 export function useReconciliation(accounts: Account[], transactions: Transaction[]): UseReconciliationReturn {
@@ -38,15 +50,50 @@ export function useReconciliation(accounts: Account[], transactions: Transaction
     const account = accounts.find(a => a.id === accountId);
     const openingBalance = account?.openingBalance ?? 0;
     const txns = accountTransactionMap.get(accountId) ?? [];
-    return openingBalance + txns.reduce((sum, t) => sum + t.amount, 0);
+    return txns
+      .reduce((sum, t) => sum.plus(toDecimal(t.amount)), toDecimal(openingBalance))
+      .toNumber();
   }, [accounts, accountTransactionMap]);
 
   const computeClearedBalance = useCallback((accountId: string): number => {
     const account = accounts.find(a => a.id === accountId);
     const openingBalance = account?.openingBalance ?? 0;
     const txns = accountTransactionMap.get(accountId) ?? [];
-    return openingBalance + txns.filter(t => t.cleared === true).reduce((sum, t) => sum + t.amount, 0);
+    return txns
+      .filter(t => t.cleared === true)
+      .reduce((sum, t) => sum.plus(toDecimal(t.amount)), toDecimal(openingBalance))
+      .toNumber();
   }, [accounts, accountTransactionMap]);
+
+  const computeClearedSummary = useCallback((accountId: string): ClearedSummary => {
+    const txns = accountTransactionMap.get(accountId) ?? [];
+    let depositsTotal = toDecimal(0);
+    let paymentsTotal = toDecimal(0);
+    let depositsCount = 0;
+    let paymentsCount = 0;
+    let clearedCount = 0;
+
+    for (const t of txns) {
+      if (t.cleared !== true) continue;
+      clearedCount += 1;
+      if (t.amount >= 0) {
+        depositsTotal = depositsTotal.plus(toDecimal(t.amount));
+        depositsCount += 1;
+      } else {
+        paymentsTotal = paymentsTotal.plus(toDecimal(t.amount));
+        paymentsCount += 1;
+      }
+    }
+
+    return {
+      clearedCount,
+      totalCount: txns.length,
+      depositsTotal: depositsTotal.toNumber(),
+      depositsCount,
+      paymentsTotal: paymentsTotal.toNumber(),
+      paymentsCount,
+    };
+  }, [accountTransactionMap]);
 
   const reconciliationDetails = useMemo<ReconciliationSummary[]>(() =>
     accounts.map(account => {
@@ -54,9 +101,16 @@ export function useReconciliation(accounts: Account[], transactions: Transaction
       const unreconciledCount = txns.filter(t => t.cleared !== true).length;
       const bankBalance = account.bankBalance ?? null;
       const openingBalance = account.openingBalance ?? 0;
-      const accountBalance = openingBalance + txns.reduce((sum, t) => sum + t.amount, 0);
-      const clearedBalance = openingBalance + txns.filter(t => t.cleared === true).reduce((sum, t) => sum + t.amount, 0);
-      const difference = bankBalance != null ? bankBalance - clearedBalance : null;
+      const accountBalance = txns
+        .reduce((sum, t) => sum.plus(toDecimal(t.amount)), toDecimal(openingBalance))
+        .toNumber();
+      const clearedBalance = txns
+        .filter(t => t.cleared === true)
+        .reduce((sum, t) => sum.plus(toDecimal(t.amount)), toDecimal(openingBalance))
+        .toNumber();
+      const difference = bankBalance != null
+        ? toDecimal(bankBalance).minus(toDecimal(clearedBalance)).toNumber()
+        : null;
 
       return {
         account,
@@ -88,5 +142,6 @@ export function useReconciliation(accounts: Account[], transactions: Transaction
     getUnreconciledCount,
     computeAccountBalance,
     computeClearedBalance,
+    computeClearedSummary,
   };
 }

--- a/src/hooks/useTransactionNotifications.ts
+++ b/src/hooks/useTransactionNotifications.ts
@@ -4,23 +4,24 @@ import { useNotifications } from '../contexts/NotificationContext';
 import type { Transaction } from '../types';
 
 interface UseTransactionNotificationsReturn {
-  addTransaction: (transaction: Omit<Transaction, 'id'>) => void;
+  addTransaction: (transaction: Omit<Transaction, 'id'>) => Promise<void>;
 }
 
 export function useTransactionNotifications(): UseTransactionNotificationsReturn {
   const { addTransaction: originalAddTransaction, transactions } = useApp();
   const { checkLargeTransaction, checkEnhancedTransactionAlerts } = useNotifications();
 
-  const addTransaction = useCallback((transaction: Omit<Transaction, 'id'>) => {
+  const addTransaction = useCallback(async (transaction: Omit<Transaction, 'id'>) => {
     // Create the full transaction object with ID
     const fullTransaction: Transaction = {
       ...transaction,
       id: `transaction-${Date.now()}`
     };
 
-    // Add the transaction first
-    originalAddTransaction(transaction);
-    
+    // Add the transaction first — awaited so a failed write propagates to the
+    // caller (the edit modal shows it as a submit error) instead of vanishing.
+    await originalAddTransaction(transaction);
+
     // Check for enhanced transaction alerts (includes duplicate detection, unusual spending, etc.)
     checkEnhancedTransactionAlerts(fullTransaction, transactions);
     

--- a/src/pages/Reconciliation.tsx
+++ b/src/pages/Reconciliation.tsx
@@ -1,29 +1,46 @@
 import { useState, useMemo, useCallback } from 'react';
 import { useSearchParams } from 'react-router-dom';
 import { useApp } from '../contexts/AppContextSupabase';
+import { useToast } from '../contexts/ToastContext';
 import { ArrowLeftIcon, CheckCircleIcon } from '../components/icons';
 import { useReconciliation } from '../hooks/useReconciliation';
 import ReconciliationAccountList from '../components/reconciliation/ReconciliationAccountList';
 import ReconciliationBalanceBar from '../components/reconciliation/ReconciliationBalanceBar';
 import ReconciliationTransactionList from '../components/reconciliation/ReconciliationTransactionList';
 import ReconciliationFinalizationModal from '../components/reconciliation/ReconciliationFinalizationModal';
+import EditTransactionModal from '../components/EditTransactionModal';
 import type { Transaction } from '../types';
 
 export default function Reconciliation() {
-  const { transactions, accounts, categories, updateTransaction, addTransaction, updateAccount } = useApp();
+  const { transactions, accounts, categories, addTransaction, updateAccount, setTransactionsCleared } = useApp();
+  const { showSuccess, showError } = useToast();
   const [searchParams, setSearchParams] = useSearchParams();
 
   const [selectedAccountId, setSelectedAccountId] = useState<string | null>(
     searchParams.get('account') || null
   );
   const [showFinalizationModal, setShowFinalizationModal] = useState(false);
+  const [editingTransaction, setEditingTransaction] = useState<Transaction | null>(null);
+  const [isEditModalOpen, setIsEditModalOpen] = useState(false);
+  // Optimistic cleared-state overlay: the checkbox flips instantly while the
+  // write is in flight, and reverts (with an error toast) if it fails.
+  const [pendingCleared, setPendingCleared] = useState<Map<string, boolean>>(new Map());
+
+  const overlaidTransactions = useMemo(() => {
+    if (pendingCleared.size === 0) return transactions;
+    return transactions.map(t => {
+      const pending = pendingCleared.get(t.id);
+      return pending === undefined ? t : { ...t, cleared: pending };
+    });
+  }, [transactions, pendingCleared]);
 
   const {
     reconciliationDetails,
     totalUnreconciledCount,
     computeAccountBalance,
     computeClearedBalance,
-  } = useReconciliation(accounts, transactions);
+    computeClearedSummary,
+  } = useReconciliation(accounts, overlaidTransactions);
 
   // Selected account data
   const selectedAccount = useMemo(
@@ -34,13 +51,14 @@ export default function Reconciliation() {
   const accountTransactions = useMemo(
     () =>
       selectedAccountId
-        ? transactions.filter(t => t.accountId === selectedAccountId)
+        ? overlaidTransactions.filter(t => t.accountId === selectedAccountId)
         : [],
-    [transactions, selectedAccountId]
+    [overlaidTransactions, selectedAccountId]
   );
 
   const accountBalance = selectedAccountId ? computeAccountBalance(selectedAccountId) : 0;
   const clearedBalance = selectedAccountId ? computeClearedBalance(selectedAccountId) : 0;
+  const clearedSummary = selectedAccountId ? computeClearedSummary(selectedAccountId) : undefined;
   const bankBalance = selectedAccount?.bankBalance ?? null;
 
   // Handlers
@@ -54,9 +72,42 @@ export default function Reconciliation() {
     setSearchParams({});
   }, [setSearchParams]);
 
+  const applyCleared = useCallback(async (requestedIds: string[], cleared: boolean) => {
+    // Drop ids that already have a write in flight — the checkbox is disabled
+    // while pending, and skipping here closes the race for bulk overlaps too
+    // (two in-flight writes for one id could otherwise resolve out of order).
+    const ids = requestedIds.filter(id => !pendingCleared.has(id));
+    if (ids.length === 0) {
+      return;
+    }
+
+    // Optimistic: flip immediately, revert on failure.
+    setPendingCleared(prev => {
+      const next = new Map(prev);
+      ids.forEach(id => next.set(id, cleared));
+      return next;
+    });
+
+    try {
+      await setTransactionsCleared(ids, cleared);
+    } catch (error) {
+      showError(error);
+    } finally {
+      setPendingCleared(prev => {
+        const next = new Map(prev);
+        ids.forEach(id => next.delete(id));
+        return next;
+      });
+    }
+  }, [pendingCleared, setTransactionsCleared, showError]);
+
   const handleToggleCleared = useCallback((transactionId: string, cleared: boolean) => {
-    updateTransaction(transactionId, { cleared });
-  }, [updateTransaction]);
+    void applyCleared([transactionId], cleared);
+  }, [applyCleared]);
+
+  const handleBulkSetCleared = useCallback((transactionIds: string[], cleared: boolean) => {
+    void applyCleared(transactionIds, cleared);
+  }, [applyCleared]);
 
   const handleBankBalanceChange = useCallback((newBalance: number) => {
     if (selectedAccountId) {
@@ -64,17 +115,24 @@ export default function Reconciliation() {
     }
   }, [selectedAccountId, updateAccount]);
 
-  const handleFinalize = useCallback(() => {
-    if (selectedAccountId) {
-      updateAccount(selectedAccountId, {
+  const handleFinalize = useCallback(async () => {
+    if (!selectedAccountId) {
+      return;
+    }
+    try {
+      // Await the write — success feedback must not fire on a failed save.
+      await updateAccount(selectedAccountId, {
         lastReconciledDate: new Date(),
       });
       setShowFinalizationModal(false);
+      showSuccess('Reconciliation complete.', 'Account reconciled');
       handleBack();
+    } catch (error) {
+      showError(error);
     }
-  }, [selectedAccountId, updateAccount, handleBack]);
+  }, [selectedAccountId, updateAccount, handleBack, showSuccess, showError]);
 
-  const handleCreateAdjustment = useCallback((data: {
+  const handleCreateAdjustment = useCallback(async (data: {
     amount: number;
     type: 'income' | 'expense';
     description: string;
@@ -93,19 +151,30 @@ export default function Reconciliation() {
       cleared: true,
     };
 
-    addTransaction(adjustmentTxn);
+    try {
+      // The modal stays open: the cleared adjustment shrinks the difference and
+      // the modal re-renders with the remainder (zero → balanced state), so the
+      // user can create several adjustments — the Microsoft Money model.
+      await addTransaction(adjustmentTxn);
+      showSuccess('Adjustment transaction created.', 'Adjustment added');
+    } catch (error) {
+      showError(error);
+    }
+  }, [selectedAccountId, addTransaction, showSuccess, showError]);
 
-    // After adjustment, finalize
-    updateAccount(selectedAccountId, {
-      lastReconciledDate: new Date(),
-    });
-
-    setShowFinalizationModal(false);
-    handleBack();
-  }, [selectedAccountId, addTransaction, updateAccount, handleBack]);
+  const handleRowClick = useCallback((transaction: Transaction) => {
+    setEditingTransaction(transaction);
+    setIsEditModalOpen(true);
+  }, []);
 
   const handleAddTransaction = useCallback(() => {
-    // Placeholder — will be wired to a transaction creation modal
+    setEditingTransaction(null);
+    setIsEditModalOpen(true);
+  }, []);
+
+  const handleCloseEditModal = useCallback(() => {
+    setIsEditModalOpen(false);
+    setEditingTransaction(null);
   }, []);
 
   // Step 1: Account Selection
@@ -165,6 +234,7 @@ export default function Reconciliation() {
         accountBalance={accountBalance}
         clearedBalance={clearedBalance}
         currency={selectedAccount?.currency}
+        clearedSummary={clearedSummary}
         onBankBalanceChange={handleBankBalanceChange}
       />
 
@@ -174,8 +244,19 @@ export default function Reconciliation() {
         categories={categories}
         currency={selectedAccount?.currency}
         openingBalance={selectedAccount?.openingBalance ?? 0}
+        pendingClearedIds={pendingCleared}
         onToggleCleared={handleToggleCleared}
+        onBulkSetCleared={handleBulkSetCleared}
+        onRowClick={handleRowClick}
         onAddTransaction={handleAddTransaction}
+      />
+
+      {/* Edit / add transaction (new transactions default to this account) */}
+      <EditTransactionModal
+        isOpen={isEditModalOpen}
+        onClose={handleCloseEditModal}
+        transaction={editingTransaction}
+        defaultAccountId={selectedAccountId}
       />
 
       {/* Finalization Modal */}

--- a/src/services/__tests__/transactionService.test.ts
+++ b/src/services/__tests__/transactionService.test.ts
@@ -150,4 +150,102 @@ describe('TransactionService (deterministic fallback)', () => {
       body: JSON.stringify({ transactionId: 'txn-secure' })
     });
   });
+
+  describe('setTransactionsCleared', () => {
+    it('bulk-sets cleared on matching ids in local mode and returns the count', async () => {
+      const storage = createStorage([
+        baseTransaction({ id: 'txn-1', cleared: false }),
+        baseTransaction({ id: 'txn-2', cleared: false }),
+        baseTransaction({ id: 'txn-3', cleared: true })
+      ]);
+      const service = createTransactionService({
+        isSupabaseConfigured: () => false,
+        storageAdapter: storage,
+        logger,
+        now,
+        uuid
+      });
+
+      const count = await service.setTransactionsCleared(['txn-1', 'txn-2'], true);
+
+      expect(count).toBe(2);
+      const stored = storage.snapshot();
+      expect(stored.find(t => t.id === 'txn-1')?.cleared).toBe(true);
+      expect(stored.find(t => t.id === 'txn-2')?.cleared).toBe(true);
+      expect(stored.find(t => t.id === 'txn-3')?.cleared).toBe(true);
+    });
+
+    it('can mark transactions uncleared without touching others', async () => {
+      const storage = createStorage([
+        baseTransaction({ id: 'txn-1', cleared: true }),
+        baseTransaction({ id: 'txn-2', cleared: true })
+      ]);
+      const service = createTransactionService({
+        isSupabaseConfigured: () => false,
+        storageAdapter: storage,
+        logger,
+        now,
+        uuid
+      });
+
+      const count = await service.setTransactionsCleared(['txn-2'], false);
+
+      expect(count).toBe(1);
+      const stored = storage.snapshot();
+      expect(stored.find(t => t.id === 'txn-1')?.cleared).toBe(true);
+      expect(stored.find(t => t.id === 'txn-2')?.cleared).toBe(false);
+    });
+
+    it('returns 0 and performs no write for an empty id list', async () => {
+      const storage = createStorage([baseTransaction({ id: 'txn-1' })]);
+      const service = createTransactionService({
+        isSupabaseConfigured: () => false,
+        storageAdapter: storage,
+        logger,
+        now,
+        uuid
+      });
+
+      const count = await service.setTransactionsCleared([], true);
+
+      expect(count).toBe(0);
+      expect(storage.set).not.toHaveBeenCalled();
+    });
+
+    it('calls the set_transactions_cleared RPC with owner scope in Supabase mode', async () => {
+      const rpc = vi.fn(async () => ({ data: 3, error: null }));
+      const service = createTransactionService({
+        isSupabaseConfigured: () => true,
+        storageAdapter: createStorage(),
+        logger,
+        now,
+        uuid,
+        supabaseClient: { rpc } as unknown as never
+      });
+
+      const count = await service.setTransactionsCleared(['a', 'b', 'c'], true, 'user-1');
+
+      expect(count).toBe(3);
+      expect(rpc).toHaveBeenCalledWith('set_transactions_cleared', {
+        p_ids: ['a', 'b', 'c'],
+        p_cleared: true,
+        p_user_id: 'user-1'
+      });
+    });
+
+    it('throws when the RPC reports an error', async () => {
+      const rpc = vi.fn(async () => ({ data: null, error: { message: 'boom' } }));
+      const service = createTransactionService({
+        isSupabaseConfigured: () => true,
+        storageAdapter: createStorage(),
+        logger,
+        now,
+        uuid,
+        supabaseClient: { rpc } as unknown as never
+      });
+
+      await expect(service.setTransactionsCleared(['a'], true)).rejects.toThrow();
+      expect(logger.error).toHaveBeenCalled();
+    });
+  });
 });

--- a/src/services/api/dataService.ts
+++ b/src/services/api/dataService.ts
@@ -28,7 +28,7 @@ type AccountServiceLike = Pick<typeof AccountService,
   subscribeToAccounts?: (userId: string, callback: (payload: unknown) => void) => () => void;
 };
 type TransactionServiceLike = Pick<typeof TransactionService,
-  'getTransactions' | 'createTransaction' | 'updateTransaction' | 'deleteTransaction'> & {
+  'getTransactions' | 'createTransaction' | 'updateTransaction' | 'deleteTransaction' | 'setTransactionsCleared'> & {
   subscribeToTransactions?: (userId: string, callback: (payload: unknown) => void) => () => void;
 };
 type UserIdServiceLike = Pick<typeof userIdService,
@@ -267,6 +267,27 @@ class DataServiceImpl {
     await this.persistCollection(STORAGE_KEYS.TRANSACTIONS, filtered);
   }
 
+  /** Bulk-set the reconciliation cleared flag; balance-neutral by definition. */
+  async setTransactionsCleared(ids: string[], cleared: boolean): Promise<number> {
+    const userId = this.userIdService.getCurrentDatabaseUserId();
+    if (userId && this.supabaseChecker()) {
+      return this.transactionService.setTransactionsCleared(ids, cleared, userId);
+    }
+
+    const transactions = await this.readCollection<Transaction>(STORAGE_KEYS.TRANSACTIONS);
+    const idSet = new Set(ids);
+    let count = 0;
+    const updated = transactions.map(t => {
+      if (idSet.has(t.id)) {
+        count += 1;
+        return { ...t, cleared };
+      }
+      return t;
+    });
+    await this.persistCollection(STORAGE_KEYS.TRANSACTIONS, updated);
+    return count;
+  }
+
   async getBudgets(): Promise<Budget[]> {
     return this.readCollection<Budget>(STORAGE_KEYS.BUDGETS);
   }
@@ -381,6 +402,10 @@ export class DataService {
 
   static deleteTransaction(id: string): Promise<void> {
     return this.service.deleteTransaction(id);
+  }
+
+  static setTransactionsCleared(ids: string[], cleared: boolean): Promise<number> {
+    return this.service.setTransactionsCleared(ids, cleared);
   }
 
   static getBudgets(): Promise<Budget[]> {

--- a/src/services/api/supabaseClient.ts
+++ b/src/services/api/supabaseClient.ts
@@ -28,6 +28,10 @@ type Database = {
         Args: { p_id: string; p_user_id?: string };
         Returns: Record<string, unknown>;
       };
+      set_transactions_cleared: {
+        Args: { p_ids: string[]; p_cleared: boolean; p_user_id?: string };
+        Returns: number;
+      };
       migrate_categories_atomic: {
         Args: { p_user_id: string; p_categories: Record<string, unknown>[] };
         Returns: Record<string, unknown>[];

--- a/src/services/api/transactionService.ts
+++ b/src/services/api/transactionService.ts
@@ -262,6 +262,54 @@ class TransactionServiceImpl {
     }
   }
 
+  /**
+   * Bulk-set the reconciliation cleared flag on a set of transactions in one
+   * round trip. is_cleared never affects account balances, so this goes through
+   * a dedicated RPC rather than N update_transaction_atomic calls.
+   * Returns the number of rows actually updated.
+   */
+  async setTransactionsCleared(ids: string[], cleared: boolean, userId?: string): Promise<number> {
+    if (ids.length === 0) {
+      return 0;
+    }
+
+    if (!this.isSupabaseReady()) {
+      const transactions = await this.readStoredTransactions();
+      const idSet = new Set(ids);
+      let count = 0;
+      const updated = transactions.map(t => {
+        if (idSet.has(t.id)) {
+          count += 1;
+          return { ...t, cleared, updatedAt: this.getCurrentDate() };
+        }
+        return t;
+      });
+      await this.persistTransactions(updated);
+      return count;
+    }
+
+    try {
+      const client = this.supabaseClient!;
+      // RLS scopes the update to the requesting user; passing the owner adds
+      // the same defence-in-depth IDOR guard as the other atomic RPCs.
+      const { data, error } = await client.rpc('set_transactions_cleared', {
+        p_ids: ids,
+        p_cleared: cleared,
+        ...(userId ? { p_user_id: userId } : {})
+      });
+
+      if (error) {
+        this.logger.error('Error setting cleared status:', error);
+        throw new Error(handleSupabaseError(error));
+      }
+
+      return typeof data === 'number' ? data : ids.length;
+    } catch (error) {
+      this.logger.error('TransactionService.setTransactionsCleared error:', error as Error);
+      throw error;
+    }
+  }
+
   async deleteTransaction(id: string, userId?: string): Promise<void> {
     if (!this.isSupabaseReady()) {
       const transactions = await this.readStoredTransactions();
@@ -528,6 +576,10 @@ export class TransactionService {
 
   static deleteTransaction(id: string, userId?: string): Promise<void> {
     return this.service.deleteTransaction(id, userId);
+  }
+
+  static setTransactionsCleared(ids: string[], cleared: boolean, userId?: string): Promise<number> {
+    return this.service.setTransactionsCleared(ids, cleared, userId);
   }
 
   static getTransactionsByDateRange(userId: string, startDate: Date, endDate: Date): Promise<Transaction[]> {

--- a/src/test/mocks/AppContextSupabase.ts
+++ b/src/test/mocks/AppContextSupabase.ts
@@ -34,6 +34,8 @@ const baseValue = {
   addTransaction: noop,
   updateTransaction: noop,
   deleteTransaction: noop,
+  setTransactionsCleared: asyncNoop,
+  refreshAccountsAndTransactions: asyncNoop,
   addBudget: noop,
   updateBudget: noop,
   deleteBudget: noop,

--- a/src/utils/reconciliation.ts
+++ b/src/utils/reconciliation.ts
@@ -8,6 +8,24 @@ export const getUnreconciledCount = (accountId: string, transactions: Transactio
   ).length;
 };
 
+/**
+ * Derive a reconciliation adjustment's direction and signed amount from the
+ * remaining difference (bank − cleared). Bank higher than cleared → missing
+ * income (+); bank lower → missing expense (−). The direction always comes
+ * from the difference, never from the sign the user typed.
+ */
+export function deriveAdjustment(
+  difference: number,
+  enteredAmount: number | null
+): { type: 'income' | 'expense'; signedAmount: number | null } {
+  const type: 'income' | 'expense' = difference > 0 ? 'income' : 'expense';
+  if (enteredAmount == null) {
+    return { type, signedAmount: null };
+  }
+  const absAmount = Math.abs(enteredAmount);
+  return { type, signedAmount: type === 'income' ? absAmount : -absAmount };
+}
+
 export interface ReconciliationSummary {
   account: Account;
   unreconciledCount: number;

--- a/supabase/migrations/20260707120000_reconciliation_cleared_rpcs.sql
+++ b/supabase/migrations/20260707120000_reconciliation_cleared_rpcs.sql
@@ -1,0 +1,366 @@
+-- Reconciliation: carry is_cleared through the atomic transaction RPCs.
+--
+-- IMPORTANT: Run this SQL in the Supabase SQL Editor to apply to production DB.
+--
+-- Why: the atomic RPCs replaced direct table updates (20260610140000), but the
+-- current definitions (audit-logging versions from 20260610150000, user-scope
+-- update from 20260612110000) never handled the is_cleared column added in
+-- 20260310. Result: the reconciliation page's cleared checkbox silently did
+-- nothing (the RPC "succeeded" without touching is_cleared), and adjustment
+-- transactions created as cleared landed uncleared, so a reconciliation
+-- difference could never reach zero.
+--
+-- These definitions are copied from the LATEST live versions — including the
+-- write_financial_audit calls added in 20260610150000 — with is_cleared added.
+-- Do NOT base future recreations on 20260610140000; that version predates the
+-- audit trail.
+--
+-- Changes:
+--   1. update_transaction_atomic: honour p->>'is_cleared' (keeps user scope + audit)
+--   2. create_transaction_atomic: insert is_cleared, default false (keeps audit)
+--   3. NEW set_transactions_cleared: bulk set is_cleared for a list of ids in
+--      one round trip ("mark all as cleared"), audit-logging each real change.
+--      is_cleared never affects account balances, so no balance arithmetic.
+
+BEGIN;
+
+-- ── UPDATE (from 20260612110000: user scope + audit; + is_cleared) ──────────
+CREATE OR REPLACE FUNCTION public.update_transaction_atomic(
+  p_id uuid,
+  p jsonb,
+  p_user_id uuid DEFAULT NULL
+)
+RETURNS public.transactions
+LANGUAGE plpgsql SECURITY INVOKER
+SET search_path = public
+AS $$
+DECLARE
+  v_old public.transactions;
+  v_new public.transactions;
+BEGIN
+  SELECT * INTO v_old
+    FROM public.transactions
+   WHERE id = p_id
+     AND (p_user_id IS NULL OR user_id = p_user_id)
+   FOR UPDATE;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'transaction_not_found' USING ERRCODE = 'P0002';
+  END IF;
+
+  UPDATE public.transactions SET
+    description         = COALESCE(p->>'description', description),
+    amount              = COALESCE((p->>'amount')::numeric, amount),
+    type                = COALESCE(p->>'type', type),
+    date                = COALESCE((p->>'date')::date, date),
+    account_id          = COALESCE(NULLIF(p->>'account_id', '')::uuid, account_id),
+    category            = CASE WHEN p ? 'category' THEN p->>'category' ELSE category END,
+    notes               = CASE WHEN p ? 'notes' THEN p->>'notes' ELSE notes END,
+    tags                = CASE WHEN p ? 'tags' AND jsonb_typeof(p->'tags') = 'array'
+                               THEN ARRAY(SELECT jsonb_array_elements_text(p->'tags'))
+                               ELSE tags END,
+    is_recurring        = COALESCE((p->>'is_recurring')::boolean, is_recurring),
+    is_cleared          = COALESCE((p->>'is_cleared')::boolean, is_cleared),
+    transfer_account_id = CASE WHEN p ? 'transfer_account_id'
+                               THEN NULLIF(p->>'transfer_account_id', '')::uuid
+                               ELSE transfer_account_id END,
+    metadata            = CASE WHEN p ? 'metadata' THEN p->'metadata' ELSE metadata END,
+    category_id         = CASE WHEN p ? 'category_id'
+                               THEN NULLIF(p->>'category_id', '')::uuid
+                               ELSE category_id END,
+    merchant_name       = CASE WHEN p ? 'merchant_name' THEN p->>'merchant_name' ELSE merchant_name END,
+    updated_at          = now()
+  WHERE id = p_id
+  RETURNING * INTO v_new;
+
+  IF v_old.account_id = v_new.account_id THEN
+    IF v_new.amount <> v_old.amount THEN
+      UPDATE public.accounts
+         SET balance = balance + (v_new.amount - v_old.amount),
+             updated_at = now()
+       WHERE id = v_new.account_id
+         AND user_id = v_new.user_id;
+      IF NOT FOUND THEN
+        RAISE EXCEPTION 'account_not_found_or_not_owned' USING ERRCODE = 'P0001';
+      END IF;
+    END IF;
+  ELSE
+    -- Transaction moved between accounts: reverse from old, apply to new.
+    UPDATE public.accounts
+       SET balance = balance - v_old.amount,
+           updated_at = now()
+     WHERE id = v_old.account_id
+       AND user_id = v_old.user_id;
+    IF NOT FOUND THEN
+      RAISE EXCEPTION 'account_not_found_or_not_owned' USING ERRCODE = 'P0001';
+    END IF;
+
+    UPDATE public.accounts
+       SET balance = balance + v_new.amount,
+           updated_at = now()
+     WHERE id = v_new.account_id
+       AND user_id = v_new.user_id;
+    IF NOT FOUND THEN
+      RAISE EXCEPTION 'account_not_found_or_not_owned' USING ERRCODE = 'P0001';
+    END IF;
+  END IF;
+
+  PERFORM public.write_financial_audit(
+    v_new.user_id, 'transaction', v_new.id, 'update', to_jsonb(v_old), to_jsonb(v_new)
+  );
+
+  RETURN v_new;
+END;
+$$;
+
+-- ── CREATE (from 20260610150000: audit; + is_cleared) ───────────────────────
+CREATE OR REPLACE FUNCTION public.create_transaction_atomic(p jsonb)
+RETURNS public.transactions
+LANGUAGE plpgsql SECURITY INVOKER
+SET search_path = public
+AS $$
+DECLARE
+  v_tx public.transactions;
+BEGIN
+  INSERT INTO public.transactions (
+    id, user_id, account_id, description, amount, type, date,
+    category, notes, tags, is_recurring, is_cleared, transfer_account_id,
+    metadata, category_id, merchant_name, location_city,
+    location_country, payment_channel
+  ) VALUES (
+    COALESCE(NULLIF(p->>'id', '')::uuid, gen_random_uuid()),
+    (p->>'user_id')::uuid,
+    (p->>'account_id')::uuid,
+    p->>'description',
+    (p->>'amount')::numeric,
+    p->>'type',
+    (p->>'date')::date,
+    p->>'category',
+    p->>'notes',
+    CASE WHEN p ? 'tags' AND jsonb_typeof(p->'tags') = 'array'
+         THEN ARRAY(SELECT jsonb_array_elements_text(p->'tags'))
+         ELSE NULL END,
+    COALESCE((p->>'is_recurring')::boolean, false),
+    COALESCE((p->>'is_cleared')::boolean, false),
+    NULLIF(p->>'transfer_account_id', '')::uuid,
+    COALESCE(p->'metadata', '{}'::jsonb),
+    NULLIF(p->>'category_id', '')::uuid,
+    p->>'merchant_name',
+    p->>'location_city',
+    p->>'location_country',
+    p->>'payment_channel'
+  )
+  RETURNING * INTO v_tx;
+
+  UPDATE public.accounts
+     SET balance = balance + v_tx.amount,
+         updated_at = now()
+   WHERE id = v_tx.account_id
+     AND user_id = v_tx.user_id;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'account_not_found_or_not_owned'
+      USING ERRCODE = 'P0001',
+            HINT = 'The account does not exist or does not belong to this user.';
+  END IF;
+
+  PERFORM public.write_financial_audit(
+    v_tx.user_id, 'transaction', v_tx.id, 'create', NULL, to_jsonb(v_tx)
+  );
+
+  RETURN v_tx;
+END;
+$$;
+
+-- ── BULK CLEAR (new) ────────────────────────────────────────────────────────
+-- Marks a set of transactions cleared/uncleared in one round trip. SECURITY
+-- INVOKER, so RLS scopes authenticated callers to their own rows; p_user_id is
+-- the same defence-in-depth guard the other RPCs take for service-role callers.
+-- Rows already in the requested state are skipped (no write, no audit noise).
+-- Each real change gets its own financial_audit_log entry, consistent with the
+-- per-transaction audit trail of the other RPCs.
+CREATE OR REPLACE FUNCTION public.set_transactions_cleared(
+  p_ids uuid[],
+  p_cleared boolean,
+  p_user_id uuid DEFAULT NULL
+)
+RETURNS integer
+LANGUAGE plpgsql SECURITY INVOKER
+SET search_path = public
+AS $$
+DECLARE
+  v_count integer := 0;
+  v_old public.transactions;
+  v_new public.transactions;
+BEGIN
+  FOR v_old IN
+    SELECT * FROM public.transactions
+     WHERE id = ANY(p_ids)
+       AND (p_user_id IS NULL OR user_id = p_user_id)
+       AND is_cleared IS DISTINCT FROM p_cleared
+     FOR UPDATE
+  LOOP
+    UPDATE public.transactions
+       SET is_cleared = p_cleared,
+           updated_at = now()
+     WHERE id = v_old.id
+    RETURNING * INTO v_new;
+
+    PERFORM public.write_financial_audit(
+      v_new.user_id, 'transaction', v_new.id, 'update', to_jsonb(v_old), to_jsonb(v_new)
+    );
+
+    v_count := v_count + 1;
+  END LOOP;
+
+  RETURN v_count;
+END;
+$$;
+
+-- ── BANK IMPORT (from 20260613090000; + is_cleared = true) ──────────────────
+-- Bank-imported transactions ARE the bank statement — they arrive settled, so
+-- they land cleared (Microsoft Money's "E — electronically cleared" state).
+-- Without this, every sync re-opens a reconciliation difference equal to the
+-- imported sum, inviting bogus adjustment transactions. Manual entries still
+-- start uncleared. Only change vs 20260613090000: is_cleared true on INSERT.
+CREATE OR REPLACE FUNCTION public.import_bank_transactions_atomic(
+  p_user_id uuid,
+  p_rows jsonb
+)
+RETURNS jsonb
+LANGUAGE plpgsql SECURITY INVOKER
+SET search_path = public
+AS $$
+DECLARE
+  r jsonb;
+  v_tx public.transactions;
+  v_acct uuid;
+  v_acct_key text;
+  v_is_backfill boolean;
+  v_backfills jsonb := '{}'::jsonb;   -- account_id -> backfill? (decided BEFORE its first insert)
+  v_sums jsonb := '{}'::jsonb;        -- account_id -> Σ(inserted amounts)
+  v_inserted integer := 0;
+  v_skipped integer := 0;
+  v_sum numeric;
+  v_before public.accounts;
+  v_after public.accounts;
+BEGIN
+  IF p_rows IS NULL OR jsonb_typeof(p_rows) <> 'array' THEN
+    RAISE EXCEPTION 'p_rows must be a jsonb array' USING ERRCODE = '22023';
+  END IF;
+
+  FOR r IN SELECT value FROM jsonb_array_elements(p_rows) LOOP
+    IF (r->>'user_id')::uuid IS DISTINCT FROM p_user_id THEN
+      RAISE EXCEPTION 'row user_id does not match p_user_id' USING ERRCODE = '28000';
+    END IF;
+
+    v_acct := (r->>'account_id')::uuid;
+    v_acct_key := v_acct::text;
+
+    -- Backfill detection MUST precede the account's first insert of this call:
+    -- "no previously imported bank transaction exists for this account".
+    IF NOT v_backfills ? v_acct_key THEN
+      SELECT NOT EXISTS (
+        SELECT 1 FROM public.transactions t
+        WHERE t.account_id = v_acct
+          AND t.external_transaction_id IS NOT NULL
+      ) INTO v_is_backfill;
+      v_backfills := v_backfills || jsonb_build_object(v_acct_key, v_is_backfill);
+    END IF;
+
+    -- Account-scoped dedupe (handler pre-filters per connection; this also
+    -- catches re-imports after a reconnect under a new connection_id).
+    IF EXISTS (
+      SELECT 1 FROM public.transactions t
+      WHERE t.account_id = v_acct
+        AND t.external_transaction_id = r->>'external_transaction_id'
+    ) THEN
+      v_skipped := v_skipped + 1;
+      CONTINUE;
+    END IF;
+
+    v_tx := NULL;
+    INSERT INTO public.transactions (
+      user_id, account_id, connection_id, external_transaction_id,
+      external_provider, description, amount, type, date, metadata, is_cleared
+    )
+    VALUES (
+      p_user_id,
+      v_acct,
+      NULLIF(r->>'connection_id', '')::uuid,
+      r->>'external_transaction_id',
+      r->>'external_provider',
+      r->>'description',
+      (r->>'amount')::numeric,
+      r->>'type',
+      (r->>'date')::date,
+      COALESCE(r->'metadata', 'null'::jsonb),
+      true
+    )
+    ON CONFLICT (connection_id, external_transaction_id)
+      WHERE external_transaction_id IS NOT NULL
+      DO NOTHING
+    RETURNING * INTO v_tx;
+
+    IF v_tx.id IS NULL THEN
+      v_skipped := v_skipped + 1;  -- lost a concurrent race; row already exists
+      CONTINUE;
+    END IF;
+
+    PERFORM public.write_financial_audit(
+      p_user_id, 'transaction', v_tx.id, 'create', NULL, to_jsonb(v_tx)
+    );
+
+    v_sums := jsonb_set(
+      v_sums,
+      ARRAY[v_acct_key],
+      to_jsonb(COALESCE((v_sums->>v_acct_key)::numeric, 0) + v_tx.amount)
+    );
+    v_inserted := v_inserted + 1;
+  END LOOP;
+
+  -- Apply the per-account balance effect, audited, inside the same transaction.
+  FOR v_acct_key, v_sum IN
+    SELECT key, value::numeric FROM jsonb_each_text(v_sums)
+  LOOP
+    SELECT * INTO v_before
+      FROM public.accounts
+     WHERE id = v_acct_key::uuid AND user_id = p_user_id
+     FOR UPDATE;
+    IF NOT FOUND THEN
+      RAISE EXCEPTION 'account_not_found_or_not_owned' USING ERRCODE = 'P0001';
+    END IF;
+
+    IF (v_backfills->>v_acct_key)::boolean THEN
+      -- Backfill: history already embodied in the snapshot balance.
+      UPDATE public.accounts
+         SET initial_balance = COALESCE(initial_balance, 0) - v_sum,
+             updated_at = now()
+       WHERE id = v_acct_key::uuid AND user_id = p_user_id
+       RETURNING * INTO v_after;
+    ELSE
+      -- Incremental: new money movement adjusts the ledger balance.
+      UPDATE public.accounts
+         SET balance = balance + v_sum,
+             updated_at = now()
+       WHERE id = v_acct_key::uuid AND user_id = p_user_id
+       RETURNING * INTO v_after;
+    END IF;
+
+    PERFORM public.write_financial_audit(
+      p_user_id, 'account', v_acct_key::uuid, 'update',
+      to_jsonb(v_before), to_jsonb(v_after)
+    );
+  END LOOP;
+
+  RETURN jsonb_build_object('inserted', v_inserted, 'skipped', v_skipped);
+END;
+$$;
+
+-- ── Grants ──────────────────────────────────────────────────────────────────
+REVOKE ALL ON FUNCTION public.set_transactions_cleared(uuid[], boolean, uuid) FROM public, anon;
+GRANT EXECUTE ON FUNCTION public.set_transactions_cleared(uuid[], boolean, uuid) TO authenticated, service_role;
+REVOKE ALL ON FUNCTION public.import_bank_transactions_atomic(uuid, jsonb) FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.import_bank_transactions_atomic(uuid, jsonb) TO service_role;
+
+COMMIT;


### PR DESCRIPTION
## The bug

The reconciliation page was dead on arrival: **clicking the R checkbox did nothing, and clicking a row did nothing.** Root cause: the atomic transaction RPCs from the June money-math hardening (`update_transaction_atomic`, `create_transaction_atomic`) never handled the `is_cleared` column — the RPC "succeeded" while silently ignoring the flag. Row-click editing simply didn't exist.

Worse: the finalize flow's adjustment transaction was created with `cleared: true`, which the create RPC dropped — so **a reconciliation difference could never reach £0.00** even if everything else had worked.

## ⚠️ Deploy order — migration FIRST

`supabase/migrations/20260707120000_reconciliation_cleared_rpcs.sql` must be run in the **Supabase SQL editor before this deploys**. It is fully backwards-compatible with the currently-deployed code (old clients never send `is_cleared`; COALESCE keeps existing behaviour), so apply it any time before merge.

The migration recreates the RPCs **from the latest live definitions (the audit-logging versions)** — an early draft based on the pre-audit versions would have silently removed the financial audit trail; the adversarial review + a manual trace caught this before commit.

## What it does now (Microsoft Money model)

Researched the MS Money Plus Sunset flow against primary sources (official help, KB 76422, MVP FAQ screenshots, Money 2006 For Dummies):

- **Checkbox persists** — optimistic flip with revert + error toast; per-id in-flight guard prevents same-id write races.
- **Row click opens the edit modal** — add category, fix details, everything. Uncategorised rows show an *"Add category…"* hint.
- **"Mark all cleared" / "Unmark all"** over the filtered set via a new `set_transactions_cleared` RPC — one round trip for 533 rows, no-op rows skipped, every real change audit-logged.
- **Bank imports arrive cleared** (Money's "E — electronically cleared"): imported transactions ARE the statement, so a sync no longer re-opens a difference equal to the imported sum.
- **Finalize modal = Money's "doesn't balance" dialog**: editable amount (prefilled with the remaining difference), editable description (default *"Account Adjustment"* — Money's exact payee), adjustment created **cleared**, modal stays open and recomputes so several partial adjustments can walk the difference to £0.00, then flips to "Account Balanced!" → Complete.
- Balance bar shows cleared deposits/payments totals; all reconciliation sums now Decimal.

## Review-driven fixes (adversarial workflow: 4 dimensions, 20 agents)

All confirmed findings fixed pre-commit:
1. **(major)** No in-flight guard on Create Adjustment → double-click wrote duplicate financial transactions.
2. **(moderate)** "Add" defaulted to `accounts[0]` not the reconciled account → new `defaultAccountId` prop on EditTransactionModal.
3. EditTransactionModal saves were fire-and-forget (pre-existing) → now awaited; failed RPCs surface as form errors instead of silently closing.
4. `handleFinalize` toasted success before the write landed → awaited with error toast.
5. Amount field could be clobbered by a background difference re-sync mid-typing → dirty flag.
6. Same-checkbox rapid-retoggle race → pending ids filtered + checkbox disabled while in flight.
7. Bank-sync rows always uncleared (pre-existing gap surfaced by this page) → import RPC change above.

## Verification
- `typecheck:strict` ✅ · app typecheck ✅ · `lint` ✅ (zero warnings) · `build` ✅
- Full unit suite: **2772 passed** · +32 new tests (bulk-clear service local+RPC modes, cleared summary, list interactions incl. stopPropagation, modal balanced/unbalanced/zero-amount states, `deriveAdjustment` sign convention)
- Pre-push coverage gate ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)