### PR TITLE
feat(categories): MS Money category set import + fix broken category admin

### DIFF
--- a/src/components/CategoryCreationModal.tsx
+++ b/src/components/CategoryCreationModal.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 import { useApp } from '../contexts/AppContextSupabase';
+import { useToast } from '../contexts/ToastContext';
 import { PlusIcon } from './icons/PlusIcon';
 import { Modal, ModalBody, ModalFooter } from './common/Modal';
 import { useModalForm } from '../hooks/useModalForm';
@@ -26,9 +27,11 @@ export default function CategoryCreationModal({
   initialType = 'expense' 
 }: CategoryCreationModalProps): React.JSX.Element {
   const { categories, addCategory, getSubCategories, getDetailCategories } = useApp();
-  
+  const { showError } = useToast();
+
   const [showNewCategory, setShowNewCategory] = useState(false);
   const [showNewSpecific, setShowNewSpecific] = useState(false);
+  const [isSaving, setIsSaving] = useState(false);
   
   const { formData, updateField, reset } = useModalForm<FormData>(
     {
@@ -50,8 +53,14 @@ export default function CategoryCreationModal({
     income: ['Employment', 'Investments', 'Business', 'Other Income']
   };
 
+  // Resolve the type-level anchor dynamically — cloud-migrated categories have
+  // UUID ids, so the old literal `type-${type}` matched nothing (empty dropdown)
+  // and new categories were created orphaned under a non-existent parent.
+  const typeAnchorId =
+    categories.find(c => c.level === 'type' && c.type === formData.type)?.id ?? `type-${formData.type}`;
+
   // Get available categories based on type
-  const availableCategories = getSubCategories(`type-${formData.type}`);
+  const availableCategories = getSubCategories(typeAnchorId);
   const existingCategoryNames = availableCategories.map(cat => cat.name);
   
   // Filter suggestions to only show ones that don't exist yet
@@ -59,70 +68,52 @@ export default function CategoryCreationModal({
     name => !existingCategoryNames.includes(name)
   );
 
-  const handleSubmit = () => {
-    let resultCategoryId = formData.selectedCategory || formData.selectedSpecific;
-    
-    // Create new category if needed
-    if (showNewCategory && formData.newCategoryName.trim()) {
-      const newCategory = {
-        name: formData.newCategoryName.trim(),
-        type: formData.type,
-        level: 'sub' as const,
-        parentId: `type-${formData.type}`,
-        isSystem: false
-      };
-      
-      addCategory(newCategory);
-      
-      // For new categories, we'll use a generated ID - the AppContext will handle the actual ID
-      resultCategoryId = `new-sub-${formData.newCategoryName.trim()}`;
-    }
+  const handleSubmit = async () => {
+    if (isSaving) return;
+    setIsSaving(true);
+    try {
+      let resultCategoryId = formData.selectedCategory || formData.selectedSpecific;
 
-    // Create new specific category if needed
-    if ((formData.selectedCategory || resultCategoryId) && showNewSpecific && formData.newSpecificName.trim()) {
-      const parentId = formData.selectedCategory || resultCategoryId;
-      
-      const newSpecific = {
-        name: formData.newSpecificName.trim(),
-        type: formData.type,
-        level: 'detail' as const,
-        parentId: parentId.startsWith('new-sub-') ? `type-${formData.type}` : parentId, // Use type if parent is new
-        isSystem: false
-      };
-      
-      addCategory(newSpecific);
-      resultCategoryId = `new-detail-${formData.newSpecificName.trim()}`;
-    }
+      // Create new sub-level category if needed. addCategory returns the created
+      // row, so downstream code can use the REAL id — no name-lookup timeouts.
+      if (showNewCategory && formData.newCategoryName.trim()) {
+        const createdSub = await addCategory({
+          name: formData.newCategoryName.trim(),
+          type: formData.type,
+          level: 'sub' as const,
+          parentId: typeAnchorId,
+          isSystem: false
+        });
+        resultCategoryId = createdSub.id;
+      }
 
-    // Notify parent component
-    if (onCategoryCreated && resultCategoryId) {
-      // Use a timeout to allow state to update
-      setTimeout(() => {
-        if (resultCategoryId.startsWith('new-')) {
-          // Find the actual created category
-          const categoryName = resultCategoryId.includes('detail') ? 
-            formData.newSpecificName.trim() : formData.newCategoryName.trim();
-          const level = resultCategoryId.includes('detail') ? 'detail' : 'sub';
-          
-          const foundCategory = categories.find(c => 
-            c.name === categoryName && c.level === level
-          );
-          
-          if (foundCategory && onCategoryCreated) {
-            onCategoryCreated(foundCategory.id);
-          }
-        } else if (onCategoryCreated) {
-          onCategoryCreated(resultCategoryId);
-        }
-      }, 150);
-    }
+      // Create new detail category under the selected sub if needed.
+      if (formData.selectedCategory && showNewSpecific && formData.newSpecificName.trim()) {
+        const createdDetail = await addCategory({
+          name: formData.newSpecificName.trim(),
+          type: formData.type,
+          level: 'detail' as const,
+          parentId: formData.selectedCategory,
+          isSystem: false
+        });
+        resultCategoryId = createdDetail.id;
+      }
 
-    // Reset form
-    reset();
-    setShowNewCategory(false);
-    setShowNewSpecific(false);
-    
-    onClose();
+      if (onCategoryCreated && resultCategoryId) {
+        onCategoryCreated(resultCategoryId);
+      }
+
+      // Reset form
+      reset();
+      setShowNewCategory(false);
+      setShowNewSpecific(false);
+
+      onClose();
+    } catch (error) {
+      showError(error);
+    } finally {
+      setIsSaving(false);
+    }
   };
 
   const handleCategoryChange = (value: string) => {
@@ -299,13 +290,13 @@ export default function CategoryCreationModal({
             Cancel
           </button>
           <button
-            onClick={handleSubmit}
-            disabled={!((formData.selectedCategory || (showNewCategory && formData.newCategoryName.trim())) || 
+            onClick={() => void handleSubmit()}
+            disabled={isSaving || !((formData.selectedCategory || (showNewCategory && formData.newCategoryName.trim())) ||
                       (formData.selectedSpecific || (showNewSpecific && formData.newSpecificName.trim())))}
             className="flex-1 px-4 py-2 text-sm sm:text-base bg-[#1a2332] text-white rounded-lg hover:bg-secondary disabled:opacity-50 disabled:cursor-not-allowed flex items-center justify-center gap-2"
           >
             <PlusIcon size={16} />
-            Create Category
+            {isSaving ? 'Creating…' : 'Create Category'}
           </button>
         </div>
       </ModalFooter>

--- a/src/components/CategorySelector.tsx
+++ b/src/components/CategorySelector.tsx
@@ -129,10 +129,9 @@ export default function CategorySelector({
     setShowDropdown(!showDropdown);
   };
 
-  const handleCreateCategory = (): void => {
+  const handleCreateCategory = async (): Promise<void> => {
     if (!newCategoryName.trim() || !selectedParentId) return;
 
-    const newId = crypto.randomUUID();
     const newCategory: Omit<Category, 'id'> = {
       name: newCategoryName.trim(),
       type: transactionType === 'transfer' ? 'both' : transactionType,
@@ -140,22 +139,16 @@ export default function CategorySelector({
       parentId: selectedParentId,
     };
 
-    addCategory(newCategory);
-
-    // The addCategory creates the ID internally, so find the newly added category
-    // We need to select it after a tick so the state updates
-    setTimeout(() => {
-      // Find the category we just created by name and parent
-      const created = categories.find(c =>
-        c.name === newCategoryName.trim() && c.parentId === selectedParentId
-      );
-      if (created) {
-        onCategoryChange(created.id);
-      } else {
-        // Fallback: use the id we generated (addCategory uses crypto.randomUUID internally)
-        onCategoryChange(newId);
-      }
-    }, 50);
+    try {
+      // addCategory returns the created row — select its REAL id directly.
+      // (The old name-lookup-after-a-tick read a stale closure and its fallback
+      // selected an id that was never persisted, filing the transaction under a
+      // category that doesn't exist.)
+      const created = await addCategory(newCategory);
+      onCategoryChange(created.id);
+    } catch {
+      // addCategory already logs; leave the current selection unchanged.
+    }
 
     // Reset and close
     setNewCategoryName('');

--- a/src/contexts/AppContextSupabase.tsx
+++ b/src/contexts/AppContextSupabase.tsx
@@ -30,6 +30,7 @@ import type {
   AppState 
 } from '../types';
 import { createScopedLogger } from '../loggers/scopedLogger';
+import { planCategoryTreeImport, type CategoryTreeGroup } from '../utils/categoryTreeImport';
 
 export interface Tag {
   id: string;
@@ -63,7 +64,10 @@ export interface AppContextType extends AppState {
   contributeToGoal: (id: string, amount: number) => Promise<void>;
   
   // Category operations — async so callers can surface persistence failures
-  addCategory: (category: Omit<Category, 'id'>) => Promise<void>;
+  /** Returns the created category so callers can use its real id immediately. */
+  addCategory: (category: Omit<Category, 'id'>) => Promise<Category>;
+  /** Merge a Money-style category tree; skips same-named entries. Returns counts. */
+  importCategoryTree: (tree: CategoryTreeGroup[]) => Promise<{ created: number; skipped: number }>;
   updateCategory: (id: string, updates: Partial<Category>) => Promise<void>;
   deleteCategory: (id: string) => Promise<void>;
   getSubCategories: (parentId: string) => Category[];
@@ -605,11 +609,66 @@ export function AppProvider({ children }: { children: React.ReactNode }) {
         category
       );
       setCategories(prev => [...prev, created]);
+      return created;
     } catch (error) {
       appLogger.error('Failed to add category', error);
       throw error;
     }
   }, []);
+
+  // Import a Money-style two-level tree (sub → detail), merging idempotently:
+  // same-named categories are skipped, so re-running or overlapping the default
+  // set never duplicates. Two phases because details need their sub's id.
+  const importCategoryTree = useCallback(async (tree: CategoryTreeGroup[]) => {
+    const userId = userIdService.getCurrentDatabaseUserId();
+    const plan = planCategoryTreeImport(categories, tree);
+
+    const createdSubs = await PlanningService.createCategories(userId, plan.subsToCreate);
+    // Commit phase 1 to state immediately: if the details insert below fails,
+    // a retry re-plans against state that INCLUDES these subs and skips them —
+    // otherwise the re-insert would hit the (user_id, name, parent_id) unique
+    // constraint and every retry would fail until a page reload.
+    if (createdSubs.length > 0) {
+      setCategories(prev => [...prev, ...createdSubs]);
+    }
+
+    // Resolve each detail's parent among existing + freshly created subs.
+    // IMPORTANT: index by the ANCHOR the sub lives under (same predicate the
+    // planner matches with), not by the sub's own `type` — a sub that ended up
+    // typed 'both' would otherwise be matched by the planner but missing here.
+    const typeAnchorIds = new Map<'income' | 'expense', string | undefined>([
+      ['income', categories.find(c => c.level === 'type' && c.type === 'income')?.id],
+      ['expense', categories.find(c => c.level === 'type' && c.type === 'expense')?.id],
+    ]);
+    const subIdByKey = new Map<string, string>();
+    const keyOf = (type: 'income' | 'expense', name: string) => `${type}:${name.trim().toLowerCase()}`;
+    for (const sub of [...categories, ...createdSubs]) {
+      if (sub.level !== 'sub') continue;
+      if (sub.parentId === typeAnchorIds.get('income')) {
+        subIdByKey.set(keyOf('income', sub.name), sub.id);
+      } else if (sub.parentId === typeAnchorIds.get('expense')) {
+        subIdByKey.set(keyOf('expense', sub.name), sub.id);
+      }
+    }
+
+    const detailRows: Array<Omit<Category, 'id'>> = [];
+    for (const detail of plan.detailsToCreate) {
+      const parentId = subIdByKey.get(keyOf(detail.type, detail.subName));
+      if (!parentId) {
+        throw new Error(`Import failed: parent category "${detail.subName}" was not created.`);
+      }
+      detailRows.push({ ...detail.category, parentId });
+    }
+    const createdDetails = await PlanningService.createCategories(userId, detailRows);
+    if (createdDetails.length > 0) {
+      setCategories(prev => [...prev, ...createdDetails]);
+    }
+
+    return {
+      created: createdSubs.length + createdDetails.length,
+      skipped: plan.skippedCount,
+    };
+  }, [categories]);
 
   const updateCategory = useCallback(async (id: string, updates: Partial<Category>) => {
     try {
@@ -771,6 +830,7 @@ export function AppProvider({ children }: { children: React.ReactNode }) {
     
     // Category operations
     addCategory,
+    importCategoryTree,
     updateCategory,
     deleteCategory,
     getSubCategories,

--- a/src/data/msMoneyCategories.ts
+++ b/src/data/msMoneyCategories.ts
@@ -1,0 +1,157 @@
+import type { CategoryTreeGroup } from '../utils/categoryTreeImport';
+
+/**
+ * Microsoft Money (UK) starter category set.
+ *
+ * Transcribed from a real Money Plus Sunset "Set up your categories" list.
+ * Money's two levels map onto the app's hierarchy as:
+ *   Money Category    → 'sub'    (under the Income/Expense type category)
+ *   Money Subcategory → 'detail' (selectable on transactions)
+ * Money's "Category Group" reporting rollup has no equivalent level and is
+ * intentionally dropped. Groups with no subcategories get a single detail of
+ * the same name so they remain selectable.
+ */
+export const MS_MONEY_CATEGORY_SET: CategoryTreeGroup[] = [
+  // ── Expense ────────────────────────────────────────────────────────────────
+  {
+    name: 'Bank & Portfolio Charges',
+    type: 'expense',
+    children: ['Bank Charges & Fees', 'Interest Paid', 'Loan Interest Paid'],
+  },
+  {
+    name: 'Bills (Household)',
+    type: 'expense',
+    children: [
+      'Council Tax',
+      'Gas & Electricity',
+      'Mobile Phone',
+      'Other Bills',
+      'Other Bills (Private/Not Seen)',
+      'Telephone/Broadband/Sky/Tv Licence',
+      'Water & Sewerage',
+    ],
+  },
+  {
+    name: 'Cars & Bikes',
+    type: 'expense',
+    children: [
+      'Financing & Leasing Charges',
+      'Insurance',
+      'Other Costs',
+      'Other/Misc Costs (Private/Not Seen)',
+      'Petrol / Diesel',
+      'Petrol / Diesel - (Private/Not Seen)',
+      'Road Tax',
+      'Servicing, Maintenance & Repairs',
+      'Servicing, Maintenance & Repairs (Trackday/Sports Car Related)',
+      'Taxis/UBER',
+      'Taxis/UBER (Private/Not Seen)',
+      'Trackday Related',
+      'Trackday Related (Private/Not Seen)',
+    ],
+  },
+  {
+    name: 'Child Costs',
+    type: 'expense',
+    children: [
+      'Child Support/Maintenance',
+      'Clothes',
+      'Days Out',
+      'Other Child Costs (Private/Not Seen)',
+      'Other/Misc',
+      'School Related',
+    ],
+  },
+  {
+    name: 'Computer Related',
+    type: 'expense',
+    children: ['Hardware', 'Other Computer', 'Other Computer (Private/Not Seen)', 'Software'],
+  },
+  {
+    name: 'Food Related Costs',
+    type: 'expense',
+    children: [
+      'Dining Out',
+      'Dining Out (Private/Not Seen)',
+      'Food Shopping',
+      'Food Shopping (Private/Not Seen)',
+      'Takeaways',
+      'Takeaways (Private/Not Seen)',
+    ],
+  },
+  {
+    name: 'Gifts',
+    type: 'expense',
+    children: ['Birthday Gifts', 'Other Gifts', 'Other Gifts (Private/Not Seen)', 'Xmas Gifts'],
+  },
+  {
+    name: 'Healthcare',
+    type: 'expense',
+    children: ['Counsellor', 'Dental', 'Eyecare', 'Hospital', 'Life Insurance'],
+  },
+  {
+    name: 'Holidays',
+    type: 'expense',
+    children: ['Family Holidays', 'Other', 'Other (Private/Not Seen)', 'Weekend Holidays'],
+  },
+  {
+    name: 'Household',
+    type: 'expense',
+    children: [
+      'Buying & Selling Costs',
+      'Cleaning & Ironing',
+      'Consumables',
+      'Consumables (Private/Not Seen)',
+      'Furnishings',
+      'Improvements',
+      'Insurance',
+      'Maintenance, Repairs & Gardening',
+      'Other/Misc (Private/Not Seen)',
+    ],
+  },
+  {
+    name: 'Personal',
+    type: 'expense',
+    children: [
+      'Gem - House/Other',
+      'Gem - Legal Fees',
+      'Gem - Maintenance',
+      'Steve - (Kids Investments)',
+      'Steve - Cash Withdrawals',
+      'Steve - Cash Withdrawals - (Private/Not Seen)',
+      'Steve - Clothing',
+      'Steve - Clothing - (Private/Not Seen)',
+      'Steve - General',
+      'Steve - General - (Private/Not Seen)',
+      'Steve - John Green',
+      'Steve - Legal & Professional',
+    ],
+  },
+  {
+    name: 'Xfer to Deleted Account',
+    type: 'expense',
+    children: [],
+  },
+
+  // ── Income ─────────────────────────────────────────────────────────────────
+  {
+    name: 'Investment Income',
+    type: 'income',
+    children: ['Bank Interest', 'Capital Gains', 'Dividends', 'Interest', 'Mortgage Income', 'Other Income'],
+  },
+  {
+    name: 'Other Income',
+    type: 'income',
+    children: ['Child Benefit', 'Rental Income'],
+  },
+  {
+    name: 'Wages & Salary',
+    type: 'income',
+    children: ['Consultancy', 'Net Pay', 'Net Pay - Golf Club'],
+  },
+  {
+    name: 'Xfer from Deleted Account',
+    type: 'income',
+    children: [],
+  },
+];

--- a/src/pages/settings/Categories.tsx
+++ b/src/pages/settings/Categories.tsx
@@ -1,5 +1,7 @@
-import { useState } from 'react';
+import { useState, useMemo } from 'react';
 import { useApp } from '../../contexts/AppContextSupabase';
+import { useToast } from '../../contexts/ToastContext';
+import { MS_MONEY_CATEGORY_SET } from '../../data/msMoneyCategories';
 import CategoryCreationModal from '../../components/CategoryCreationModal';
 import CategoryTransactionsModal from '../../components/CategoryTransactionsModal';
 import { AlertCircleIcon, Settings2Icon, GripVerticalIcon } from '../../components/icons';
@@ -157,15 +159,50 @@ function SortableCategory({
 }
 
 export default function CategoriesSettings() {
-  const { 
-    transactions, 
+  const {
+    transactions,
     categories,
     updateCategory,
     deleteCategory,
     updateTransaction,
     getSubCategories,
-    getDetailCategories
+    getDetailCategories,
+    importCategoryTree
   } = useApp();
+  const { showSuccess, showError } = useToast();
+  const [isImporting, setIsImporting] = useState(false);
+
+  // The type-level ids are user-specific UUIDs after cloud migration — the old
+  // hardcoded 'type-income'/'type-expense'/'type-transfer' anchors matched
+  // nothing, which rendered every section empty. Resolve them dynamically.
+  const typeAnchorIds = useMemo(() => ({
+    income: categories.find(c => c.level === 'type' && c.type === 'income')?.id ?? 'type-income',
+    expense: categories.find(c => c.level === 'type' && c.type === 'expense')?.id ?? 'type-expense',
+    transfer: categories.find(c => c.level === 'type' && c.type === 'both')?.id ?? 'type-transfer',
+  }), [categories]);
+
+  const handleImportMoneySet = async () => {
+    if (isImporting) return;
+    if (!window.confirm(
+      'Import the Microsoft Money category set? Existing categories with the same names are kept — nothing is deleted or overwritten.'
+    )) {
+      return;
+    }
+    setIsImporting(true);
+    try {
+      const result = await importCategoryTree(MS_MONEY_CATEGORY_SET);
+      showSuccess(
+        result.created > 0
+          ? `Added ${result.created} categories (${result.skipped} already existed).`
+          : 'All Microsoft Money categories already exist — nothing to add.',
+        'Category import complete'
+      );
+    } catch (error) {
+      showError(error);
+    } finally {
+      setIsImporting(false);
+    }
+  };
   
   // Helper function to get category path
   const getCategoryPath = (categoryId: string): string => {
@@ -332,10 +369,17 @@ export default function CategoriesSettings() {
       const overParent = categories.find(c => c.id === overCategory.parentId);
       
       if (activeParent && overParent && activeParent.id !== overParent.id) {
-        // Move subcategory to new parent type
-        updateCategory(active.id as string, { 
+        // Move subcategory to new parent type. Compare against the RESOLVED
+        // anchor ids — cloud-migrated anchors are UUIDs, so matching the old
+        // literal 'type-income'/'type-expense' always fell through to 'both'
+        // and silently corrupted the category's type on cross-section drags.
+        updateCategory(active.id as string, {
           parentId: overParent.id,
-          type: overParent.id === 'type-income' ? 'income' : overParent.id === 'type-expense' ? 'expense' : 'both'
+          type: overParent.id === typeAnchorIds.income
+            ? 'income'
+            : overParent.id === typeAnchorIds.expense
+              ? 'expense'
+              : 'both'
         });
         
         // Update order
@@ -637,6 +681,28 @@ export default function CategoriesSettings() {
         </div>
       )}
 
+      {/* Starter set import */}
+      {!isEditMode && !isDeleteMode && (
+        <div className="bg-white dark:bg-gray-800 rounded-2xl shadow-lg border border-gray-100 dark:border-gray-700 p-4 mb-6 flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3">
+          <div>
+            <h3 className="text-sm font-semibold text-gray-900 dark:text-white">
+              Microsoft Money category set
+            </h3>
+            <p className="text-xs text-gray-500 dark:text-gray-400 mt-0.5">
+              Import the classic Money (UK) category tree. Merges with what you have —
+              same-named categories are kept, nothing is deleted.
+            </p>
+          </div>
+          <button
+            onClick={() => void handleImportMoneySet()}
+            disabled={isImporting}
+            className="px-4 py-2 text-sm font-medium bg-[#1a2332] text-white rounded-lg hover:bg-secondary transition-colors disabled:opacity-50 disabled:cursor-not-allowed whitespace-nowrap self-start sm:self-auto"
+          >
+            {isImporting ? 'Importing…' : 'Import Money set'}
+          </button>
+        </div>
+      )}
+
       {/* Categories Tree */}
       <div className="bg-white dark:bg-gray-800 rounded-2xl shadow-lg border border-gray-100 dark:border-gray-700 p-6">
         <DndContext 
@@ -646,9 +712,9 @@ export default function CategoriesSettings() {
           onDragEnd={handleDragEnd}
         >
           <div className="space-y-6">
-            {renderCategorySection('Income Categories', 'type-income')}
-            {renderCategorySection('Expense Categories', 'type-expense')}
-            {renderCategorySection('Transfer Categories', 'type-transfer')}
+            {renderCategorySection('Income Categories', typeAnchorIds.income)}
+            {renderCategorySection('Expense Categories', typeAnchorIds.expense)}
+            {renderCategorySection('Transfer Categories', typeAnchorIds.transfer)}
           
           {/* Other Categories */}
           <div>

--- a/src/services/api/planningService.ts
+++ b/src/services/api/planningService.ts
@@ -423,6 +423,31 @@ export class PlanningService {
     return newCategory;
   }
 
+  /** Bulk create — one insert round trip instead of N (used by tree imports). */
+  static async createCategories(userId: string | null, newCategories: Array<Omit<Category, 'id'>>): Promise<Category[]> {
+    if (newCategories.length === 0) {
+      return [];
+    }
+
+    if (this.cloudReady && userId) {
+      const rows = newCategories.map(category => categoryToDb(category, userId));
+      const { data, error } = await supabase!
+        .from('categories')
+        .insert(rows as never)
+        .select();
+      if (error) throw new Error(handleSupabaseError(error));
+      const created = ((data ?? []) as Row[]).map(categoryFromDb);
+      const cache = await this.getCategories();
+      await this.saveCategories([...cache, ...created]);
+      return created;
+    }
+
+    const created = newCategories.map(category => ({ ...category, id: crypto.randomUUID() } as Category));
+    const categories = await this.getCategories();
+    await this.saveCategories([...categories, ...created]);
+    return created;
+  }
+
   static async updateCategory(userId: string | null, id: string, updates: Partial<Category>): Promise<Category> {
     if (this.cloudReady && userId) {
       const { data, error } = await supabase!

--- a/src/test/mocks/AppContextSupabase.ts
+++ b/src/test/mocks/AppContextSupabase.ts
@@ -40,6 +40,7 @@ const baseValue = {
   updateBudget: noop,
   deleteBudget: noop,
   addCategory: noop,
+  importCategoryTree: async () => ({ created: 0, skipped: 0 }),
   updateCategory: noop,
   deleteCategory: noop,
   addGoal: noop,

--- a/src/test/testUtils.tsx
+++ b/src/test/testUtils.tsx
@@ -11,6 +11,7 @@ import { BrowserRouter } from 'react-router-dom';
 import { vi } from 'vitest';
 import { AppProvider } from './mocks/AppContextSupabase';
 import { PreferencesProvider } from '../contexts/PreferencesContext';
+import { ToastProvider } from '../contexts/ToastContext';
 import { NotificationProvider } from '../contexts/NotificationContext';
 import { LayoutProvider } from '../contexts/LayoutContext';
 import { ThemeProvider } from '../design-system';
@@ -184,11 +185,13 @@ export const AllProviders: React.FC<AllProvidersProps> = ({
       <PreferencesProvider>
           <ThemeProvider>
             <AppProvider initialData={initialState}>
-              <NotificationProvider>
-                <LayoutProvider>
-                  {children}
-                </LayoutProvider>
-              </NotificationProvider>
+              <ToastProvider>
+                <NotificationProvider>
+                  <LayoutProvider>
+                    {children}
+                  </LayoutProvider>
+                </NotificationProvider>
+              </ToastProvider>
             </AppProvider>
           </ThemeProvider>
         </PreferencesProvider>

--- a/src/utils/__tests__/categoryTreeImport.test.ts
+++ b/src/utils/__tests__/categoryTreeImport.test.ts
@@ -1,0 +1,135 @@
+import { describe, it, expect } from 'vitest';
+import { planCategoryTreeImport, type CategoryTreeGroup } from '../categoryTreeImport';
+import { MS_MONEY_CATEGORY_SET } from '../../data/msMoneyCategories';
+import type { Category } from '../../types';
+
+const typeCategories: Category[] = [
+  { id: 'uuid-income', name: 'Income', type: 'income', level: 'type', isSystem: true },
+  { id: 'uuid-expense', name: 'Expense', type: 'expense', level: 'type', isSystem: true },
+  { id: 'uuid-transfer', name: 'Transfer', type: 'both', level: 'type', isSystem: true },
+];
+
+describe('planCategoryTreeImport', () => {
+  it('creates every sub and detail against a bare category set', () => {
+    const tree: CategoryTreeGroup[] = [
+      { name: 'Cars & Bikes', type: 'expense', children: ['Petrol / Diesel', 'Road Tax'] },
+      { name: 'Wages & Salary', type: 'income', children: ['Net Pay'] },
+    ];
+
+    const plan = planCategoryTreeImport(typeCategories, tree);
+
+    expect(plan.subsToCreate).toHaveLength(2);
+    expect(plan.subsToCreate[0]).toMatchObject({
+      name: 'Cars & Bikes',
+      type: 'expense',
+      level: 'sub',
+      parentId: 'uuid-expense',
+    });
+    expect(plan.detailsToCreate).toHaveLength(3);
+    expect(plan.detailsToCreate[0]).toMatchObject({
+      subName: 'Cars & Bikes',
+      type: 'expense',
+      category: { name: 'Petrol / Diesel', level: 'detail', type: 'expense' },
+    });
+    expect(plan.skippedCount).toBe(0);
+    expect(plan.totalCount).toBe(5);
+  });
+
+  it('skips same-named subs and details case-insensitively (idempotent re-import)', () => {
+    const existing: Category[] = [
+      ...typeCategories,
+      { id: 'sub-1', name: 'cars & bikes', type: 'expense', level: 'sub', parentId: 'uuid-expense' },
+      { id: 'det-1', name: 'PETROL / DIESEL', type: 'expense', level: 'detail', parentId: 'sub-1' },
+    ];
+    const tree: CategoryTreeGroup[] = [
+      { name: 'Cars & Bikes', type: 'expense', children: ['Petrol / Diesel', 'Road Tax'] },
+    ];
+
+    const plan = planCategoryTreeImport(existing, tree);
+
+    expect(plan.subsToCreate).toHaveLength(0);
+    expect(plan.detailsToCreate).toHaveLength(1);
+    expect(plan.detailsToCreate[0].category.name).toBe('Road Tax');
+    expect(plan.skippedCount).toBe(2); // the sub + the existing detail
+  });
+
+  it('merges new details into an existing default sub instead of duplicating it', () => {
+    const existing: Category[] = [
+      ...typeCategories,
+      { id: 'sub-inv', name: 'Investment Income', type: 'income', level: 'sub', parentId: 'uuid-income', isSystem: true },
+      { id: 'det-div', name: 'Dividends', type: 'income', level: 'detail', parentId: 'sub-inv' },
+    ];
+    const tree: CategoryTreeGroup[] = [
+      { name: 'Investment Income', type: 'income', children: ['Bank Interest', 'Dividends'] },
+    ];
+
+    const plan = planCategoryTreeImport(existing, tree);
+
+    expect(plan.subsToCreate).toHaveLength(0);
+    expect(plan.detailsToCreate.map(d => d.category.name)).toEqual(['Bank Interest']);
+  });
+
+  it('gives an empty group a single self-named detail so it stays selectable', () => {
+    const tree: CategoryTreeGroup[] = [
+      { name: 'Xfer to Deleted Account', type: 'expense', children: [] },
+    ];
+
+    const plan = planCategoryTreeImport(typeCategories, tree);
+
+    expect(plan.detailsToCreate).toHaveLength(1);
+    expect(plan.detailsToCreate[0].category.name).toBe('Xfer to Deleted Account');
+  });
+
+  it("dedupes against a 'both'-typed sub under the anchor (type is not part of the match)", () => {
+    // A cross-section drag historically minted subs typed 'both' under a real
+    // anchor. The planner treats them as existing; the context resolver must
+    // therefore index subs by ANCHOR (not by their own type) or details would
+    // have no parent to attach to.
+    const existing: Category[] = [
+      ...typeCategories,
+      { id: 'sub-h', name: 'Healthcare', type: 'both', level: 'sub', parentId: 'uuid-expense' },
+    ];
+    const tree: CategoryTreeGroup[] = [
+      { name: 'Healthcare', type: 'expense', children: ['Dental'] },
+    ];
+
+    const plan = planCategoryTreeImport(existing, tree);
+    expect(plan.subsToCreate).toHaveLength(0);
+    expect(plan.detailsToCreate.map(d => d.category.name)).toEqual(['Dental']);
+  });
+
+  it('does not match a same-named sub under the wrong type anchor', () => {
+    const existing: Category[] = [
+      ...typeCategories,
+      // "Other Income" name but parked under EXPENSE — must not be treated as a match.
+      { id: 'sub-x', name: 'Other Income', type: 'expense', level: 'sub', parentId: 'uuid-expense' },
+    ];
+    const tree: CategoryTreeGroup[] = [
+      { name: 'Other Income', type: 'income', children: ['Child Benefit'] },
+    ];
+
+    const plan = planCategoryTreeImport(existing, tree);
+    expect(plan.subsToCreate).toHaveLength(1);
+    expect(plan.subsToCreate[0].parentId).toBe('uuid-income');
+  });
+
+  it('throws when the type anchors are missing (categories not loaded)', () => {
+    expect(() => planCategoryTreeImport([], [{ name: 'X', type: 'expense', children: [] }]))
+      .toThrow(/type categories are not loaded/);
+  });
+
+  it('plans the full Microsoft Money set cleanly against a bare tree', () => {
+    const plan = planCategoryTreeImport(typeCategories, MS_MONEY_CATEGORY_SET);
+
+    // 16 groups: 12 expense + 4 income.
+    expect(plan.subsToCreate).toHaveLength(16);
+    // Every detail resolves to a group in the set, and empty groups self-fill.
+    const subNames = new Set(plan.subsToCreate.map(s => s.name));
+    plan.detailsToCreate.forEach(d => expect(subNames.has(d.subName)).toBe(true));
+    expect(plan.detailsToCreate.map(d => d.category.name)).toContain('Xfer to Deleted Account');
+    expect(plan.skippedCount).toBe(0);
+    // 16 subs + 86 details (84 named children + 2 self-named for empty groups).
+    expect(plan.totalCount).toBe(16 + 86);
+    expect(plan.detailsToCreate).toHaveLength(86);
+  });
+});

--- a/src/utils/categoryTreeImport.ts
+++ b/src/utils/categoryTreeImport.ts
@@ -1,0 +1,107 @@
+import type { Category } from '../types';
+
+/** One Money-style category with its selectable subcategories. */
+export interface CategoryTreeGroup {
+  name: string;
+  type: 'income' | 'expense';
+  /** Detail names. Empty → a single detail with the group's own name is created. */
+  children: string[];
+}
+
+export interface CategoryTreePlan {
+  /** Missing sub-level categories, ready to insert (parentId = the type anchor). */
+  subsToCreate: Array<Omit<Category, 'id'>>;
+  /**
+   * Missing detail-level categories. parentId is resolved AFTER the subs
+   * insert (a detail's parent may be created in the same import), so each
+   * entry carries the (type, subName) key to look the parent up by.
+   */
+  detailsToCreate: Array<{
+    subName: string;
+    type: 'income' | 'expense';
+    category: Omit<Category, 'id' | 'parentId'>;
+  }>;
+  /** Sub/detail entries skipped because a same-named category already exists. */
+  skippedCount: number;
+  /** Total sub + detail entries in the requested tree. */
+  totalCount: number;
+}
+
+const norm = (name: string): string => name.trim().toLowerCase();
+
+/**
+ * Diff a Money-style category tree against the user's existing categories.
+ *
+ * Matching is case-insensitive by (parent, name) so re-importing is a no-op
+ * and overlaps with the default set (e.g. an existing "Investment Income"
+ * sub) merge instead of duplicating. Throws if a type anchor is missing —
+ * every account has the system Income/Expense type categories, so a missing
+ * anchor means categories haven't loaded and importing would misfile the tree.
+ */
+export function planCategoryTreeImport(
+  existing: Category[],
+  tree: CategoryTreeGroup[]
+): CategoryTreePlan {
+  const typeAnchors: Record<'income' | 'expense', string | undefined> = {
+    income: existing.find(c => c.level === 'type' && c.type === 'income')?.id,
+    expense: existing.find(c => c.level === 'type' && c.type === 'expense')?.id,
+  };
+  if (!typeAnchors.income || !typeAnchors.expense) {
+    throw new Error('Cannot import categories: the Income/Expense type categories are not loaded yet.');
+  }
+
+  const subsToCreate: CategoryTreePlan['subsToCreate'] = [];
+  const detailsToCreate: CategoryTreePlan['detailsToCreate'] = [];
+  let skippedCount = 0;
+  let totalCount = 0;
+
+  for (const group of tree) {
+    const anchorId = typeAnchors[group.type]!;
+    totalCount += 1;
+
+    const existingSub = existing.find(
+      c => c.level === 'sub' && c.parentId === anchorId && norm(c.name) === norm(group.name)
+    );
+
+    if (existingSub) {
+      skippedCount += 1;
+    } else {
+      subsToCreate.push({
+        name: group.name,
+        type: group.type,
+        level: 'sub',
+        parentId: anchorId,
+        isActive: true,
+      });
+    }
+
+    // Empty group → one detail named after the group so it stays selectable.
+    const detailNames = group.children.length > 0 ? group.children : [group.name];
+
+    for (const detailName of detailNames) {
+      totalCount += 1;
+      const existingDetail = existingSub
+        ? existing.find(
+            c => c.level === 'detail' && c.parentId === existingSub.id && norm(c.name) === norm(detailName)
+          )
+        : undefined;
+
+      if (existingDetail) {
+        skippedCount += 1;
+      } else {
+        detailsToCreate.push({
+          subName: group.name,
+          type: group.type,
+          category: {
+            name: detailName,
+            type: group.type,
+            level: 'detail',
+            isActive: true,
+          },
+        });
+      }
+    }
+  }
+
+  return { subsToCreate, detailsToCreate, skippedCount, totalCount };
+}


### PR DESCRIPTION
## Why the Categories page looked empty

It wasn't that nothing was set up — the page (and the **+ Add Category** modal, and drag-reorganising) anchored everything on the literal ids `type-income`/`type-expense`/`type-transfer`, but the cloud migration re-keyed every category to per-user UUIDs. So for signed-in users:
- every section rendered empty,
- the Add modal's category dropdown was empty and its creations were **orphaned** under a parent id that doesn't exist,
- CategorySelector's inline-create had a fallback that could file a transaction under an id that was **never persisted**.

All fixed by resolving the type anchors dynamically, and by making `addCategory` return the created row so callers use real ids (the 150ms `setTimeout` name-lookup hacks are gone; saves are awaited with error toasts and in-flight guards).

## The feature: "Import Money set"

Settings → Categories now has an **Import Money set** button that merges the exact Microsoft Money (UK) tree from the owner's Money file — 16 groups / 86 detail categories (Bills (Household) → Council Tax, Cars & Bikes → Petrol / Diesel, Wages & Salary → Net Pay, etc.). Money's *Category* maps to the app's sub level, *Subcategory* to the selectable detail level; Money's "Category Group" rollup has no equivalent and is dropped.

Import semantics:
- **Idempotent merge** — case-insensitive (parent, name) matching; re-running is a no-op, and overlaps with the default set (e.g. "Investment Income") gain the Money details instead of duplicating. Nothing is deleted.
- Two-phase bulk insert (subs, then details) — one round trip per level via new `PlanningService.createCategories`.
- Phase-1 subs commit to React state immediately, so a mid-import failure leaves a **retryable** state (a retry converges) instead of wedging on the `(user_id, name, parent_id)` unique constraint until reload.

## Review

Adversarial workflow (2 reviewers → per-finding refutation, 10 agents). Confirmed and fixed pre-commit:
1. **(major)** non-atomic import: phase-2 failure wedged every retry on the DB unique constraint → phase-1 state commit.
2. **(moderate)** cross-section sub drag still compared literal anchor ids and silently wrote `type: 'both'` for cloud users — corruption newly *reachable* because this PR makes the sections render → compares resolved anchors now.
3. **(minor)** planner/resolver contract mismatch on `'both'`-typed subs could throw mid-import → resolver indexes by anchor, same predicate as the planner.
4. **(pre-existing, out of diff)** DataValidation's balance fix writes dangling category references for cloud users → spun off as a follow-up task.

## Verification
- `typecheck:strict` ✅ · app typecheck ✅ · `lint` ✅ (zero warnings) · `build` ✅
- Full suite: **2,780 passed**; +8 planner tests (idempotent re-import, default-set merge, wrong-anchor non-match, `'both'`-typed dedupe, empty-group self-detail, missing-anchor throw, full-set plan totals)
- Test wrapper now includes `ToastProvider`, matching the real provider tree.

No migration needed — pure client + existing tables.

🤖 Generated with [Claude Code](https://claude.com/claude-code)