### PR TITLE
feat(accounts): MS Money-style account closing + protected transfer categories

### DIFF
--- a/src/components/AccountSettingsModal.tsx
+++ b/src/components/AccountSettingsModal.tsx
@@ -242,11 +242,13 @@ export default function AccountSettingsModal({
               onChange={(e) => updateField('isActive', e.target.value === 'active')}
               className="w-full px-3 py-2 bg-white dark:bg-gray-800-sm border border-gray-300/50 dark:border-gray-600/50 rounded-xl focus:outline-none focus:ring-2 focus:ring-primary focus:border-transparent dark:text-white"
             >
-              <option value="active">Active</option>
-              <option value="closed">Closed (Archived)</option>
+              <option value="active">Open</option>
+              <option value="closed">Closed</option>
             </select>
             <p className="mt-1 text-xs text-gray-500 dark:text-gray-400">
-              Closed accounts are moved to the Archived section
+              Closed accounts move to the Closed Accounts section — history is
+              preserved, the account's transfer category is hidden from
+              transaction dropdowns, and you can reopen it at any time.
             </p>
           </div>
 

--- a/src/components/CategorySelector.tsx
+++ b/src/components/CategorySelector.tsx
@@ -33,7 +33,11 @@ export default function CategorySelector({
     const typeCategory = categories.find(cat =>
       cat.level === 'type' && (cat.type === transactionType || cat.type === 'both')
     );
-    return typeCategory ? getSubCategories(typeCategory.id) : [];
+    // Inactive categories (a closed account's transfer category) never appear
+    // in the picker; reopening the account restores them.
+    return typeCategory
+      ? getSubCategories(typeCategory.id).filter(c => c.isActive !== false)
+      : [];
   };
 
   // Get all detail categories for the transaction type

--- a/src/components/EditTransactionModal.tsx
+++ b/src/components/EditTransactionModal.tsx
@@ -213,8 +213,12 @@ export default function EditTransactionModal({ isOpen, onClose, transaction, def
 
   // Build unified flat category list grouped by parent sub-category
   const groupedCategories = useMemo(() => {
-    const detailCats = categories.filter(c => c.level === 'detail' && c.id !== 'transfer-in' && c.id !== 'transfer-out');
-    const subCats = categories.filter(c => c.level === 'sub');
+    // Inactive categories (a closed account's transfer category) never appear
+    // in transaction dropdowns; reopening the account restores them.
+    const detailCats = categories.filter(c =>
+      c.level === 'detail' && c.id !== 'transfer-in' && c.id !== 'transfer-out' && c.isActive !== false
+    );
+    const subCats = categories.filter(c => c.level === 'sub' && c.isActive !== false);
 
     // Group detail categories by their parent sub-category
     const groups: { label: string; type: 'income' | 'expense' | 'both'; items: { id: string; name: string; parentName: string }[] }[] = [];

--- a/src/contexts/AppContextSupabase.tsx
+++ b/src/contexts/AppContextSupabase.tsx
@@ -101,6 +101,12 @@ export interface AppContextType extends AppState {
    */
   refreshAccountsAndTransactions: () => Promise<void>;
   /**
+   * Re-pull categories (e.g. after closing/reopening an account, whose DB
+   * trigger flips the linked transfer category's active flag server-side).
+   * Never throws — a failed refresh just leaves the current snapshot.
+   */
+  refreshCategories: () => Promise<void>;
+  /**
    * Bulk-set the reconciliation cleared flag on transactions in one round trip.
    * Balance-neutral (is_cleared never affects account balances).
    */
@@ -343,6 +349,17 @@ export function AppProvider({ children }: { children: React.ReactNode }) {
       setSyncError('Failed to sync data');
     } finally {
       setIsSyncing(false);
+    }
+  }, []);
+
+  const refreshCategories = useCallback(async () => {
+    try {
+      const loaded = await PlanningService.ensureCategories(
+        userIdService.getCurrentDatabaseUserId()
+      );
+      setCategories(loaded);
+    } catch (error) {
+      appLogger.error('Failed to refresh categories', error);
     }
   }, []);
 
@@ -883,6 +900,7 @@ export function AppProvider({ children }: { children: React.ReactNode }) {
     syncError,
     isUsingSupabase,
     refreshAccountsAndTransactions,
+    refreshCategories,
     hasTestData: false,
     loadTestData
   };

--- a/src/pages/Accounts.tsx
+++ b/src/pages/Accounts.tsx
@@ -1,12 +1,15 @@
-import { useState, useMemo, useEffect } from 'react';
+import { useState, useMemo, useEffect, useCallback } from 'react';
 import { useNavigate, useLocation } from 'react-router-dom';
 import { useApp } from '../contexts/AppContextSupabase';
+import { useToast } from '../contexts/ToastContext';
+import { DataService } from '../services/api/dataService';
 import { preserveDemoParam } from '../utils/navigation';
 import AddAccountModal from '../components/AddAccountModal';
 import AccountSettingsModal from '../components/AccountSettingsModal';
 import PortfolioView from '../components/PortfolioView';
 // No longer importing from lucide-react - all icons are now custom
-import { DeleteIcon, SettingsIcon, WalletIcon, PiggyBankIcon, CreditCardIcon, TrendingDownIcon, TrendingUpIcon, CheckCircleIcon, HomeIcon, PieChartIcon, BankIcon, RefreshCwIcon, AlertTriangleIcon } from '../components/icons';
+import { ArchiveIcon, SettingsIcon, WalletIcon, PiggyBankIcon, CreditCardIcon, TrendingDownIcon, TrendingUpIcon, CheckCircleIcon, HomeIcon, PieChartIcon, BankIcon, RefreshCwIcon, AlertTriangleIcon, ChevronRightIcon, ChevronDownIcon } from '../components/icons';
+import type { Account } from '../types';
 import { IconButton } from '../components/icons/IconButton';
 import { useCurrencyDecimal } from '../hooks/useCurrencyDecimal';
 import { useReconciliation } from '../hooks/useReconciliation';
@@ -18,7 +21,8 @@ import { toDecimal } from '../utils/decimal';
 import { SkeletonCard } from '../components/loading/Skeleton';
 
 export default function Accounts({ onAccountClick }: { onAccountClick?: (accountId: string) => void }) {
-  const { accounts, transactions, updateAccount, deleteAccount, refreshAccountsAndTransactions } = useApp();
+  const { accounts, transactions, updateAccount, deleteAccount, refreshAccountsAndTransactions, refreshCategories } = useApp();
+  const { showError } = useToast();
   const { formatCurrency: formatDisplayCurrency } = useCurrencyDecimal();
   const navigate = useNavigate();
   const location = useLocation();
@@ -34,8 +38,48 @@ export default function Accounts({ onAccountClick }: { onAccountClick?: (account
   // Per-account bank connection metadata + one-click "pull fresh bank data".
   const { getAccountLink, isAccountSyncing, syncAccount } = useAccountBankSync({ onSynced: refreshAccountsAndTransactions });
 
+  // Only OPEN accounts appear in the main list and totals; closed ones live in
+  // the Closed Accounts section below (the Microsoft Money model — closing
+  // hides an account without touching its history, and it can be reopened).
+  const openAccounts = useMemo(() => accounts.filter(a => a.isActive !== false), [accounts]);
+  const [closedAccounts, setClosedAccounts] = useState<Account[]>([]);
+  const [showClosedAccounts, setShowClosedAccounts] = useState(false);
+  const [reopeningId, setReopeningId] = useState<string | null>(null);
+
+  const loadClosedAccounts = useCallback(async () => {
+    try {
+      setClosedAccounts(await DataService.getClosedAccounts());
+    } catch {
+      // Non-fatal: the section simply shows empty; a retry happens on next open.
+      setClosedAccounts([]);
+    }
+  }, []);
+
+  useEffect(() => {
+    void loadClosedAccounts();
+  }, [loadClosedAccounts]);
+
+  const handleReopenAccount = useCallback(async (accountId: string) => {
+    if (reopeningId) return;
+    setReopeningId(accountId);
+    try {
+      await updateAccount(accountId, { isActive: true });
+      // The reopened account isn't in context state (closed ones are filtered
+      // out at load), so re-pull actives and refresh the closed list. The DB
+      // trigger also re-activated its transfer category — refresh categories
+      // so it reappears in dropdowns without a reload.
+      await refreshAccountsAndTransactions();
+      await refreshCategories();
+      await loadClosedAccounts();
+    } catch (error) {
+      showError(error);
+    } finally {
+      setReopeningId(null);
+    }
+  }, [reopeningId, updateAccount, refreshAccountsAndTransactions, refreshCategories, loadClosedAccounts, showError]);
+
   // Convert accounts to decimal for calculations
-  const decimalAccounts = useMemo(() => accounts.map(a => ({
+  const decimalAccounts = useMemo(() => openAccounts.map(a => ({
     ...a,
     balance: toDecimal(a.balance),
     openingBalance: a.openingBalance ? toDecimal(a.openingBalance) : undefined,
@@ -50,11 +94,11 @@ export default function Accounts({ onAccountClick }: { onAccountClick?: (account
       gainPercent: h.gainPercent ? toDecimal(h.gainPercent) : undefined,
       costBasis: h.costBasis ? toDecimal(h.costBasis) : undefined
     })) : undefined
-  })), [accounts]);
-  
+  })), [openAccounts]);
+
   // Group accounts by type (memoized)
-  const accountsByType = useMemo(() => 
-    accounts.reduce((groups, account) => {
+  const accountsByType = useMemo(() =>
+    openAccounts.reduce((groups, account) => {
       const type = account.type;
       if (!groups[type]) {
         groups[type] = [];
@@ -62,7 +106,7 @@ export default function Accounts({ onAccountClick }: { onAccountClick?: (account
       groups[type].push(account);
       return groups;
     }, {} as Record<string, typeof accounts>),
-    [accounts]
+    [openAccounts]
   );
 
   // Set loading to false when accounts are loaded
@@ -155,7 +199,7 @@ export default function Accounts({ onAccountClick }: { onAccountClick?: (account
   // Group accounts by institution
   const accountsByInstitution = useMemo(() => {
     const groups: Record<string, typeof accounts> = {};
-    accounts.forEach(account => {
+    openAccounts.forEach(account => {
       const institution = account.institution || 'Other Accounts';
       if (!groups[institution]) {
         groups[institution] = [];
@@ -170,7 +214,7 @@ export default function Accounts({ onAccountClick }: { onAccountClick?: (account
       return a.localeCompare(b);
     }).forEach(key => { sorted[key] = groups[key]; });
     return sorted;
-  }, [accounts]);
+  }, [openAccounts]);
 
   const handleGroupByChange = (value: 'type' | 'institution') => {
     setGroupBy(value);
@@ -188,9 +232,19 @@ export default function Accounts({ onAccountClick }: { onAccountClick?: (account
     return typeConfig?.color || 'text-gray-600';
   };
 
-  const handleDelete = (accountId: string) => {
-    if (window.confirm('Are you sure you want to archive this account? It will be hidden from your accounts list but all transaction history will be preserved.')) {
-      deleteAccount(accountId);
+  const handleClose = (accountId: string) => {
+    if (window.confirm('Close this account? It moves to the Closed Accounts section — every transaction is preserved and you can reopen it at any time. Its transfer category is hidden from transaction dropdowns while closed.')) {
+      void (async () => {
+        try {
+          await deleteAccount(accountId);
+          // The DB trigger deactivated the account's transfer category —
+          // refresh categories so it leaves dropdowns without a reload.
+          await refreshCategories();
+          await loadClosedAccounts();
+        } catch (error) {
+          showError(error);
+        }
+      })();
     }
   };
 
@@ -539,15 +593,15 @@ export default function Accounts({ onAccountClick }: { onAccountClick?: (account
                                 </button>
                                 <div className="relative group">
                                   <IconButton
-                                    onClick={() => handleDelete(account.id)}
-                                    icon={<DeleteIcon size={20} />}
+                                    onClick={() => handleClose(account.id)}
+                                    icon={<ArchiveIcon size={20} />}
                                     variant="ghost"
                                     size="md"
                                     className="text-red-500 hover:text-red-700 dark:text-red-400 dark:hover:text-red-300 hover:bg-red-100/50 dark:hover:bg-red-900/30 min-w-[48px] min-h-[48px]"
-                                    title="Delete account"
+                                    title="Close account"
                                   />
                                   <span className="absolute bottom-full right-0 mb-2 px-3 py-1.5 text-xs text-white bg-gray-900/90 dark:bg-gray-700/90 backdrop-blur-sm rounded-lg opacity-0 group-hover:opacity-100 transition-all duration-200 whitespace-nowrap pointer-events-none shadow-lg border border-white/10">
-                                    Delete
+                                    Close
                                   </span>
                                 </div>
                               </div>
@@ -564,7 +618,7 @@ export default function Accounts({ onAccountClick }: { onAccountClick?: (account
         )}
       </div>
 
-      {accounts.length === 0 && (
+      {openAccounts.length === 0 && (
         <div className="bg-white dark:bg-gray-800 rounded-2xl shadow-lg border border-gray-100 dark:border-gray-700 p-8 text-center">
           <p className="text-gray-500 dark:text-gray-400">
             No accounts yet. Click "Add Account" to get started!
@@ -572,8 +626,56 @@ export default function Accounts({ onAccountClick }: { onAccountClick?: (account
         </div>
       )}
 
+      {/* Closed Accounts (Microsoft Money model: hidden, never deleted) */}
+      {closedAccounts.length > 0 && (
+        <div className="mt-6 bg-white dark:bg-gray-800 rounded-2xl shadow-lg border border-gray-100 dark:border-gray-700 overflow-hidden">
+          <button
+            onClick={() => setShowClosedAccounts(prev => !prev)}
+            className="w-full flex items-center justify-between px-4 py-3 text-left hover:bg-gray-50 dark:hover:bg-gray-750 transition-colors"
+          >
+            <span className="flex items-center gap-2 text-sm font-semibold text-gray-600 dark:text-gray-300">
+              {showClosedAccounts ? <ChevronDownIcon size={16} /> : <ChevronRightIcon size={16} />}
+              Closed Accounts ({closedAccounts.length})
+            </span>
+            <span className="text-xs text-gray-400 dark:text-gray-500">
+              History preserved — reopen any time
+            </span>
+          </button>
 
-      <AddAccountModal 
+          {showClosedAccounts && (
+            <div className="border-t border-gray-100 dark:border-gray-700 divide-y divide-gray-100 dark:divide-gray-700">
+              {closedAccounts.map(account => (
+                <div key={account.id} className="flex items-center justify-between px-4 py-3">
+                  <div className="min-w-0">
+                    <p className="text-sm font-medium text-gray-500 dark:text-gray-400 truncate">
+                      {account.name}
+                    </p>
+                    {account.institution && (
+                      <p className="text-xs text-gray-400 dark:text-gray-500 truncate">
+                        {account.institution}
+                      </p>
+                    )}
+                  </div>
+                  <div className="flex items-center gap-4">
+                    <p className="text-sm tabular-nums text-gray-500 dark:text-gray-400">
+                      {formatDisplayCurrency(account.balance, account.currency)}
+                    </p>
+                    <button
+                      onClick={() => void handleReopenAccount(account.id)}
+                      disabled={reopeningId !== null}
+                      className="px-3 py-1.5 text-xs font-medium border border-gray-300 dark:border-gray-600 rounded-lg text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+                    >
+                      {reopeningId === account.id ? 'Reopening…' : 'Reopen'}
+                    </button>
+                  </div>
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+      )}
+
+      <AddAccountModal
         isOpen={isAddModalOpen} 
         onClose={() => setIsAddModalOpen(false)} 
       />
@@ -608,6 +710,15 @@ export default function Accounts({ onAccountClick }: { onAccountClick?: (account
         account={accounts.find(a => a.id === settingsAccountId) || null}
         onSave={async (accountId, updates) => {
           await updateAccount(accountId, updates);
+          // Closing/reopening (or renaming) via settings also updates the
+          // account's transfer category via the DB trigger — keep the Closed
+          // Accounts section and category dropdowns in sync without a reload.
+          if (updates.isActive !== undefined) {
+            await loadClosedAccounts();
+          }
+          if (updates.isActive !== undefined || updates.name !== undefined) {
+            await refreshCategories();
+          }
         }}
       />
 

--- a/src/pages/settings/Categories.tsx
+++ b/src/pages/settings/Categories.tsx
@@ -284,8 +284,20 @@ export default function CategoriesSettings() {
 
     const activeCategory = categories.find(c => c.id === active.id);
     const overCategory = categories.find(c => c.id === over.id);
-    
+
     if (!activeCategory || !overCategory) return;
+
+    // Transfer categories are system-managed structure — dragging one under an
+    // income/expense sub (or dropping a normal category onto one) would
+    // corrupt the tree in a way the rename/delete guards can't repair.
+    if (activeCategory.isTransferCategory || overCategory.isTransferCategory) {
+      if (activeCategory.parentId !== overCategory.parentId || activeCategory.level !== overCategory.level) {
+        showError(new Error(
+          'Transfer categories are managed automatically from their account and cannot be moved.'
+        ));
+        return;
+      }
+    }
 
     // Handle reordering within the same parent
     if (activeCategory.parentId === overCategory.parentId && activeCategory.level === overCategory.level) {
@@ -425,6 +437,15 @@ export default function CategoriesSettings() {
   };
 
   const startEditing = (categoryId: string, categoryName: string) => {
+    // Transfer category names track their account ("To/From <account name>");
+    // rename the account instead and the category follows automatically.
+    const category = categories.find(c => c.id === categoryId);
+    if (category?.isTransferCategory) {
+      showError(new Error(
+        'Transfer category names follow their account. Rename the account and this updates automatically.'
+      ));
+      return;
+    }
     setEditingCategoryId(categoryId);
     setEditingCategoryName(categoryName);
   };
@@ -445,6 +466,16 @@ export default function CategoriesSettings() {
   const handleDelete = (categoryId: string) => {
     const category = categories.find(c => c.id === categoryId);
     if (!category) return;
+
+    // Account transfer categories are system-managed bookkeeping: created
+    // with the account, renamed with it, hidden when it closes. Deleting one
+    // would orphan that account's transfer history (the DB blocks it too).
+    if (category.isTransferCategory) {
+      showError(new Error(
+        'Transfer categories are managed automatically from their account. Close the account to hide it instead.'
+      ));
+      return;
+    }
 
     const transactionCount = transactions.filter(t => t.category === categoryId).length;
     const childCategories = categories.filter(c => c.parentId === categoryId);
@@ -469,7 +500,9 @@ export default function CategoriesSettings() {
   };
 
   const renderCategorySection = (title: string, parentId: string) => {
-    const subCategories = getSubCategories(parentId);
+    // Inactive categories (a closed account's transfer category) stay out of
+    // sight — reopening the account brings them back automatically.
+    const subCategories = getSubCategories(parentId).filter(c => c.isActive !== false);
     
     // Sort subcategories by order
     const orderedSubCategories = [...subCategories].sort((a, b) => {
@@ -487,7 +520,7 @@ export default function CategoriesSettings() {
     });
     
     const allDetailIds = orderedSubCategories.flatMap(sub => 
-      getDetailCategories(sub.id).map(d => d.id)
+      getDetailCategories(sub.id).filter(d => d.isActive !== false).map(d => d.id)
     );
     
     return (
@@ -500,7 +533,7 @@ export default function CategoriesSettings() {
             <div className="space-y-1">
               {orderedSubCategories.map(subCategory => {
                 const isExpanded = expandedCategories.has(subCategory.id);
-                const detailCategories = getDetailCategories(subCategory.id);
+                const detailCategories = getDetailCategories(subCategory.id).filter(d => d.isActive !== false);
                 
                 // Sort detail categories by order
                 const orderedDetailCategories = [...detailCategories].sort((a, b) => {
@@ -720,7 +753,7 @@ export default function CategoriesSettings() {
           <div>
             <h3 className="text-lg font-medium text-gray-700 dark:text-gray-300 mb-3">Other Categories</h3>
             <div className="space-y-1">
-              {categories.filter(cat => cat.type === 'both' && cat.level === 'detail' && !cat.parentId).map(category => {
+              {categories.filter(cat => cat.type === 'both' && cat.level === 'detail' && !cat.parentId && cat.isActive !== false).map(category => {
                 const transactionCount = transactions.filter(t => t.category === category.id).length;
 
                 return (

--- a/src/services/__tests__/accountService.test.ts
+++ b/src/services/__tests__/accountService.test.ts
@@ -102,4 +102,48 @@ describe('AccountService (deterministic fallback)', () => {
     const accounts = await AccountService.getAccounts('user');
     expect(accounts[0].id).toBe('static');
   });
+
+  describe('getClosedAccounts', () => {
+    it('returns only closed (isActive false) accounts in local mode', async () => {
+      const storage = createStorage([
+        baseAccount({ id: 'open-1', isActive: true }),
+        baseAccount({ id: 'closed-1', isActive: false }),
+        baseAccount({ id: 'legacy-no-flag', isActive: undefined })
+      ]);
+      const service = createAccountService({
+        isSupabaseConfigured: () => false,
+        storageAdapter: storage,
+        logger,
+        now,
+        uuid
+      });
+
+      const closed = await service.getClosedAccounts('user');
+
+      // Legacy rows without the flag count as open — only explicit closes hide.
+      expect(closed.map(a => a.id)).toEqual(['closed-1']);
+    });
+
+    it('queries Supabase for is_active=false rows in cloud mode', async () => {
+      const order = vi.fn(async () => ({ data: [], error: null }));
+      const eqActive = vi.fn(() => ({ order }));
+      const eqUser = vi.fn(() => ({ eq: eqActive }));
+      const select = vi.fn(() => ({ eq: eqUser }));
+      const from = vi.fn(() => ({ select }));
+      const service = createAccountService({
+        isSupabaseConfigured: () => true,
+        storageAdapter: createStorage(),
+        logger,
+        now,
+        uuid,
+        supabaseClient: { from } as unknown as never
+      });
+
+      await service.getClosedAccounts('user-1');
+
+      expect(from).toHaveBeenCalledWith('accounts');
+      expect(eqUser).toHaveBeenCalledWith('user_id', 'user-1');
+      expect(eqActive).toHaveBeenCalledWith('is_active', false);
+    });
+  });
 });

--- a/src/services/api/accountService.ts
+++ b/src/services/api/accountService.ts
@@ -132,6 +132,38 @@ class AccountServiceImpl {
     }
   }
 
+  /**
+   * Closed (deactivated) accounts — the Microsoft Money model: closing hides
+   * an account and its transfer category but preserves every transaction, and
+   * it can be reopened at any time from the Closed Accounts section.
+   */
+  async getClosedAccounts(userId: string): Promise<Account[]> {
+    if (!this.isSupabaseReady()) {
+      const accounts = await this.readAccounts();
+      return accounts.filter(a => a.isActive === false);
+    }
+
+    try {
+      const client = this.supabaseClient!;
+      const { data, error } = await client
+        .from('accounts')
+        .select('*')
+        .eq('user_id', userId)
+        .eq('is_active', false)
+        .order('created_at', { ascending: true });
+
+      if (error) {
+        this.logger.error('Error fetching closed accounts:', error);
+        throw new Error(handleSupabaseError(error));
+      }
+
+      return (data || []).map(row => mapAccountFromDb(row as Record<string, unknown>)) as unknown as Account[];
+    } catch (error) {
+      this.logger.error('AccountService.getClosedAccounts error:', error as Error);
+      return [];
+    }
+  }
+
   async createAccount(
     userId: string,
     account: Omit<Account, 'id' | 'created_at' | 'updated_at'>
@@ -242,9 +274,14 @@ class AccountServiceImpl {
 
   async deleteAccount(id: string, userId?: string): Promise<void> {
     if (!this.isSupabaseReady()) {
+      // Local mode mirrors the cloud semantics: closing is a SOFT close
+      // (isActive=false, reopenable), never a hard delete — the Close button
+      // promises "you can reopen it at any time".
       const accounts = await this.readAccounts();
-      const filtered = accounts.filter(account => account.id !== id);
-      await this.persistAccounts(filtered);
+      const updated = accounts.map(account =>
+        account.id === id ? { ...account, isActive: false } : account
+      );
+      await this.persistAccounts(updated);
       return;
     }
 
@@ -376,6 +413,10 @@ export class AccountService {
 
   static getAccounts(userId: string): Promise<Account[]> {
     return this.service.getAccounts(userId);
+  }
+
+  static getClosedAccounts(userId: string): Promise<Account[]> {
+    return this.service.getClosedAccounts(userId);
   }
 
   static createAccount(

--- a/src/services/api/dataService.ts
+++ b/src/services/api/dataService.ts
@@ -24,7 +24,7 @@ export interface AppData {
 
  type Logger = Pick<Console, 'log' | 'warn' | 'error'>;
 type AccountServiceLike = Pick<typeof AccountService,
-  'getAccounts' | 'createAccount' | 'updateAccount' | 'deleteAccount'> & {
+  'getAccounts' | 'getClosedAccounts' | 'createAccount' | 'updateAccount' | 'deleteAccount'> & {
   subscribeToAccounts?: (userId: string, callback: (payload: unknown) => void) => () => void;
 };
 type TransactionServiceLike = Pick<typeof TransactionService,
@@ -156,6 +156,16 @@ class DataServiceImpl {
     return this.readCollection<Account>(STORAGE_KEYS.ACCOUNTS);
   }
 
+  /** Closed accounts for the Accounts page's Closed Accounts section. */
+  async getClosedAccounts(): Promise<Account[]> {
+    const userId = this.userIdService.getCurrentDatabaseUserId();
+    if (userId && this.supabaseChecker()) {
+      return this.accountService.getClosedAccounts(userId);
+    }
+    const accounts = await this.readCollection<Account>(STORAGE_KEYS.ACCOUNTS);
+    return accounts.filter(a => a.isActive === false);
+  }
+
   async createAccount(account: Omit<Account, 'id'>): Promise<Account> {
     const userId = this.userIdService.getCurrentDatabaseUserId();
     if (userId && this.supabaseChecker()) {
@@ -195,9 +205,13 @@ class DataServiceImpl {
       return this.accountService.deleteAccount(id, userId);
     }
 
+    // Local mode mirrors the cloud semantics: a SOFT close (reopenable from
+    // the Closed Accounts section), never a hard delete.
     const accounts = await this.readCollection<Account>(STORAGE_KEYS.ACCOUNTS);
-    const filtered = accounts.filter(account => account.id !== id);
-    await this.persistCollection(STORAGE_KEYS.ACCOUNTS, filtered);
+    const updated = accounts.map(account =>
+      account.id === id ? { ...account, isActive: false } : account
+    );
+    await this.persistCollection(STORAGE_KEYS.ACCOUNTS, updated);
   }
 
   async getTransactions(): Promise<Transaction[]> {
@@ -394,6 +408,10 @@ export class DataService {
 
   static loadAppData(): Promise<AppData> {
     return this.service.loadAppData();
+  }
+
+  static getClosedAccounts(): Promise<Account[]> {
+    return this.service.getClosedAccounts();
   }
 
   static getAccounts(): Promise<Account[]> {

--- a/src/test/mocks/AppContextSupabase.ts
+++ b/src/test/mocks/AppContextSupabase.ts
@@ -37,6 +37,7 @@ const baseValue = {
   setTransactionsCleared: asyncNoop,
   applyCategoryToUncategorized: async () => 0,
   refreshAccountsAndTransactions: asyncNoop,
+  refreshCategories: asyncNoop,
   addBudget: noop,
   updateBudget: noop,
   deleteBudget: noop,

--- a/supabase/migrations/20260708140000_transfer_categories_lifecycle.sql
+++ b/supabase/migrations/20260708140000_transfer_categories_lifecycle.sql
@@ -1,0 +1,204 @@
+-- Transfer-category lifecycle: system-managed per-account categories that
+-- track their account (the Microsoft Money model).
+--
+-- IMPORTANT: Run this SQL in the Supabase SQL Editor to apply to production DB.
+-- Safe to apply before the matching code deploys.
+--
+-- Every account gets a 'To/From <name>' transfer category via the existing
+-- insert trigger, but nothing managed it afterwards: it could be deleted from
+-- the Categories page (losing the transfer bookkeeping for that account),
+-- account renames left the old name behind, and closing an account left its
+-- transfer category live in every dropdown.
+--
+-- Naming collisions: categories are UNIQUE (user_id, name, parent_id) while
+-- account names are not unique, so every write below is collision-guarded —
+-- a clash keeps the old category name (or skips creation) rather than
+-- aborting the surrounding operation (account rename, bank sync, migration).
+--
+-- Changes:
+--   1. create_transfer_category_for_account: idempotent; skips when the user
+--      has no Transfer type category yet (parentless rows render as junk) or
+--      when the name would collide.
+--   2. NEW sync trigger on accounts UPDATE: rename follows the account,
+--      is_active mirrors the account (closed account → hidden category).
+--   3. NEW protect trigger on categories DELETE: a transfer category cannot
+--      be deleted while its account (and the user row) exists. The users-row
+--      check lets full user erasure (GDPR cascade from DELETE FROM users)
+--      proceed regardless of FK cascade ordering.
+--   4. Self-heal: fix names/active flags of existing transfer categories and
+--      recreate any that were deleted, all collision-guarded.
+
+BEGIN;
+
+-- ── 1. CREATE (hardened, idempotent, collision-safe) ────────────────────────
+CREATE OR REPLACE FUNCTION public.create_transfer_category_for_account() RETURNS trigger
+    LANGUAGE plpgsql
+    AS $$
+DECLARE
+  transfer_type_id UUID;
+BEGIN
+  -- Prefer the structural match (the Transfer type category is the only
+  -- type-level 'both'); fall back to the name for legacy datasets.
+  SELECT id INTO transfer_type_id
+  FROM categories
+  WHERE user_id = NEW.user_id
+    AND level = 'type'
+    AND (type = 'both' OR name = 'Transfer')
+  ORDER BY (type = 'both') DESC
+  LIMIT 1;
+
+  -- No Transfer anchor yet (categories seed lazily on first app load): skip
+  -- rather than minting a parentless category; the self-heal in a later
+  -- migration run (or support tooling) can backfill.
+  IF transfer_type_id IS NULL THEN
+    RETURN NEW;
+  END IF;
+
+  -- Idempotent: an account gets exactly one transfer category. ON CONFLICT
+  -- keeps account creation alive if another category already owns the name.
+  IF NOT EXISTS (
+    SELECT 1 FROM categories
+    WHERE account_id = NEW.id AND is_transfer_category = TRUE
+  ) THEN
+    INSERT INTO categories (
+      user_id, name, type, level, parent_id,
+      is_system, is_transfer_category, account_id, is_active
+    ) VALUES (
+      NEW.user_id,
+      'To/From ' || NEW.name,
+      'both',
+      'detail',
+      transfer_type_id,
+      FALSE,
+      TRUE,
+      NEW.id,
+      COALESCE(NEW.is_active, TRUE)
+    )
+    ON CONFLICT (user_id, name, parent_id) DO NOTHING;
+  END IF;
+
+  RETURN NEW;
+END;
+$$;
+
+-- ── 2. SYNC on account update ───────────────────────────────────────────────
+-- Rename follows the account; open/closed mirrors onto the category so a
+-- closed account's transfer category vanishes from transaction dropdowns.
+-- If the new name would collide with another category under the same parent,
+-- the old category name is kept (is_active still syncs) — an account rename
+-- or bank sync must never abort on a category naming clash.
+CREATE OR REPLACE FUNCTION public.sync_transfer_category_for_account() RETURNS trigger
+    LANGUAGE plpgsql
+    AS $$
+BEGIN
+  IF NEW.name IS DISTINCT FROM OLD.name
+     OR NEW.is_active IS DISTINCT FROM OLD.is_active THEN
+    UPDATE categories c
+       SET name = CASE
+             WHEN NOT EXISTS (
+               SELECT 1 FROM categories x
+                WHERE x.user_id = c.user_id
+                  AND x.parent_id IS NOT DISTINCT FROM c.parent_id
+                  AND x.name = 'To/From ' || NEW.name
+                  AND x.id <> c.id
+             ) THEN 'To/From ' || NEW.name
+             ELSE c.name
+           END,
+           is_active = COALESCE(NEW.is_active, TRUE),
+           updated_at = now()
+     WHERE c.account_id = NEW.id
+       AND c.is_transfer_category = TRUE;
+  END IF;
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS sync_transfer_category_on_account_update ON public.accounts;
+CREATE TRIGGER sync_transfer_category_on_account_update
+  AFTER UPDATE ON public.accounts
+  FOR EACH ROW EXECUTE FUNCTION public.sync_transfer_category_for_account();
+
+-- ── 3. PROTECT against deletion ─────────────────────────────────────────────
+-- A transfer category is system bookkeeping for its account: while the
+-- account row exists (open OR closed — closed accounts keep their history),
+-- the category must not be deleted. The users-row check makes full user
+-- erasure (DELETE FROM users cascading through categories/accounts in
+-- whatever order Postgres picks) immune to this protection.
+CREATE OR REPLACE FUNCTION public.protect_transfer_category() RETURNS trigger
+    LANGUAGE plpgsql
+    AS $$
+BEGIN
+  IF OLD.is_transfer_category = TRUE
+     AND OLD.account_id IS NOT NULL
+     AND EXISTS (SELECT 1 FROM accounts WHERE id = OLD.account_id)
+     AND EXISTS (SELECT 1 FROM users WHERE id = OLD.user_id) THEN
+    RAISE EXCEPTION 'transfer_category_protected'
+      USING ERRCODE = 'P0001',
+            HINT = 'Transfer categories are managed automatically from the account. Close the account instead.';
+  END IF;
+  RETURN OLD;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS protect_transfer_category_on_delete ON public.categories;
+CREATE TRIGGER protect_transfer_category_on_delete
+  BEFORE DELETE ON public.categories
+  FOR EACH ROW EXECUTE FUNCTION public.protect_transfer_category();
+
+-- ── 4. SELF-HEAL existing data (collision-guarded) ──────────────────────────
+-- Fix drifted names/active flags; a name that would collide keeps its current
+-- name but still gets the right is_active.
+UPDATE categories c
+   SET name = CASE
+         WHEN c.name IS DISTINCT FROM 'To/From ' || a.name
+              AND NOT EXISTS (
+                SELECT 1 FROM categories x
+                 WHERE x.user_id = c.user_id
+                   AND x.parent_id IS NOT DISTINCT FROM c.parent_id
+                   AND x.name = 'To/From ' || a.name
+                   AND x.id <> c.id
+              )
+         THEN 'To/From ' || a.name
+         ELSE c.name
+       END,
+       is_active = COALESCE(a.is_active, TRUE),
+       updated_at = now()
+  FROM accounts a
+ WHERE c.account_id = a.id
+   AND c.is_transfer_category = TRUE
+   AND (c.name IS DISTINCT FROM 'To/From ' || a.name
+        OR c.is_active IS DISTINCT FROM COALESCE(a.is_active, TRUE));
+
+-- Recreate transfer categories that were deleted while unprotected. Requires
+-- the user's Transfer anchor to exist (no parentless junk) and skips name
+-- collisions rather than failing the migration.
+INSERT INTO categories (
+  user_id, name, type, level, parent_id,
+  is_system, is_transfer_category, account_id, is_active
+)
+SELECT
+  a.user_id,
+  'To/From ' || a.name,
+  'both',
+  'detail',
+  t.id,
+  FALSE,
+  TRUE,
+  a.id,
+  COALESCE(a.is_active, TRUE)
+FROM accounts a
+JOIN LATERAL (
+  SELECT id FROM categories tt
+   WHERE tt.user_id = a.user_id
+     AND tt.level = 'type'
+     AND (tt.type = 'both' OR tt.name = 'Transfer')
+   ORDER BY (tt.type = 'both') DESC
+   LIMIT 1
+) t ON TRUE
+WHERE NOT EXISTS (
+  SELECT 1 FROM categories c
+  WHERE c.account_id = a.id AND c.is_transfer_category = TRUE
+)
+ON CONFLICT (user_id, name, parent_id) DO NOTHING;
+
+COMMIT;


### PR DESCRIPTION
## What this does

Two asks from the owner, both modeled on how Microsoft Money actually worked (verified against Money's official help, MVP FAQs, and Money For Dummies):

### 1. Transfer categories are now truly system-managed
- **Cannot be deleted** (one was just lost this way) — blocked in the UI *and* by a DB trigger, so nothing can orphan an account's transfer bookkeeping.
- **Cannot be renamed or drag-moved** — their names follow the account automatically (rename the account → "To/From <new name>" updates itself), exactly like Money's transfer pseudo-categories.
- **Auto-created for every account** (existing insert trigger, now hardened) and **self-healed** by the migration — the one deleted earlier gets recreated on apply.

### 2. Accounts close, they don't die
- New **"Closed Accounts"** collapsed section at the bottom of the Accounts page: closed accounts with balances and one-click **Reopen**. (Money hid closed accounts behind a toggle; the section is the YNAB/Actual refinement of the same idea.)
- The Delete button is now **Close** with honest wording; Account Settings offers Open/Closed. History always preserved.
- **A closed account's transfer category disappears from every transaction dropdown** (DB trigger mirrors `is_active`), and reappears on reopen — no reload needed (context refresh on close/reopen/rename).
- Local/demo mode: Close was silently a **hard delete** — now a soft close matching the promise (review catch).

## ⚠️ Migration
`supabase/migrations/20260708140000_transfer_categories_lifecycle.sql` — run in the Supabase SQL editor; safe before deploy. Every write is collision-guarded (categories are unique per (user, name, parent) while account names aren't — clashes keep the old name rather than aborting anything).

## Review
Adversarial workflow (2 reviewers → per-finding refutation, 11 agents). All 9 confirmed findings fixed pre-commit, notably:
- **(major)** the rename-sync trigger could abort account updates on a name clash — including **bank syncs writing duplicate display names → permanent sync outage**; now collision-safe.
- **(major)** the protect trigger could **abort GDPR full-user erasure** depending on FK cascade ordering; a users-row existence check makes erasure immune.
- **(major)** the migration self-heal could hit the categories unique constraint and roll back the whole apply; now guarded.
- **(major)** drag-and-drop bypassed the rename/delete guards and could reparent a transfer category under Expenses; blocked.
- **(major)** local-mode hard delete; **(moderate)** stale dropdowns until reload; **(moderate)** silent close/reopen failures — all fixed.

## Verification
- `typecheck:strict` ✅ · app typecheck ✅ · `lint` ✅ (zero warnings) · `build` ✅
- Full suite: **2,796 passed** (+2 closed-accounts service tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)