### PR TITLE
feat(transactions): Money category switch, batch editing, cross-type filing

### DIFF
--- a/src/components/EditTransactionModal.tsx
+++ b/src/components/EditTransactionModal.tsx
@@ -1,8 +1,7 @@
 import { useState, useEffect, useRef, useMemo } from 'react';
 import { useApp } from '../contexts/AppContextSupabase';
-import { useToast } from '../contexts/ToastContext';
 import { useTransactionNotifications } from '../hooks/useTransactionNotifications';
-import { findSamePayeeUncategorized } from '../utils/payeeAutoCategorize';
+import { usePayeeMemory } from '../hooks/usePayeeMemory';
 import { CalendarIcon, TagIcon, FileTextIcon, CheckIcon2, LinkIcon, PlusIcon, HashIcon, WalletIcon, ArrowRightLeftIcon, BanknoteIcon, PaperclipIcon } from '../components/icons';
 import type { Transaction } from '../types';
 import CategoryCreationModal from './CategoryCreationModal';
@@ -25,6 +24,12 @@ interface EditTransactionModalProps {
   transaction: Transaction | null;
   /** Account to pre-select for NEW transactions (e.g. the account being reconciled). */
   defaultAccountId?: string;
+  /**
+   * Batch mode: when provided (and editing an existing transaction), a
+   * "Save & Next" button appears — it saves, keeps the modal open, and asks
+   * the caller to swap in the next transaction from its list.
+   */
+  onSaveAndNext?: () => void;
 }
 
 interface FormData {
@@ -41,16 +46,24 @@ interface FormData {
   reconciledWith: string;
 }
 
-export default function EditTransactionModal({ isOpen, onClose, transaction, defaultAccountId }: EditTransactionModalProps): React.JSX.Element {
-  const { accounts, categories, transactions, updateTransaction, deleteTransaction, applyCategoryToUncategorized } = useApp();
+export default function EditTransactionModal({ isOpen, onClose, transaction, defaultAccountId, onSaveAndNext }: EditTransactionModalProps): React.JSX.Element {
+  const { accounts, categories, updateTransaction, deleteTransaction } = useApp();
   const { addTransaction } = useTransactionNotifications();
-  const { showSuccess } = useToast();
+  const { propagateCategory } = usePayeeMemory();
   const logger = useMemo(() => createScopedLogger('EditTransactionModal'), []);
-  
+
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
   const [showCategoryModal, setShowCategoryModal] = useState(false);
   const [formattedAmount, setFormattedAmount] = useState('');
+  // Money-style cross-type categorization: browse the OTHER direction's
+  // categories (e.g. file a refund — income by sign — under an expense
+  // category so it nets that expense down).
+  const [crossTypeCategories, setCrossTypeCategories] = useState(false);
   const amountInputRef = useRef<HTMLInputElement>(null);
+  // Batch mode coordination: "Save & Next" sets advance; a successful submit
+  // consumes it and suppresses the close that useModalForm fires afterwards.
+  const advanceAfterSaveRef = useRef(false);
+  const suppressCloseRef = useRef(false);
   
   // Initialize form with transaction data if editing, otherwise use defaults
   const initialFormData: FormData = transaction ? {
@@ -83,6 +96,10 @@ export default function EditTransactionModal({ isOpen, onClose, transaction, def
     initialFormData,
     {
       onSubmit: async (data) => {
+        // Consume the advance intent up front so a failed save never leaves a
+        // stale "advance" that would hijack the NEXT ordinary Save.
+        const advanceAfterSave = advanceAfterSaveRef.current;
+        advanceAfterSaveRef.current = false;
         try {
           const isTransfer = data.type === 'transfer';
           // A freshly-chosen outgoing transfer encodes its target in the
@@ -167,35 +184,28 @@ export default function EditTransactionModal({ isOpen, onClose, transaction, def
 
           // Payee memory (the Microsoft Money model): the category just chosen
           // spreads to every UNCATEGORIZED same-direction transaction with the
-          // same payee in this account. Explicit categories are never
-          // overwritten (enforced server-side), and a propagation failure must
-          // not fail the save that already succeeded.
-          if (resolvedType !== 'transfer' && resolvedCategory &&
+          // same payee in this account. Cross-type filings (a one-off refund
+          // correction) deliberately do NOT teach payee memory — a mixed-flow
+          // payee like PayPal must not get all its incoming money stamped with
+          // an expense category.
+          if (resolvedType !== 'transfer' && resolvedCategory && !crossTypeCategories &&
               resolvedCategory !== transaction?.category) {
-            const targets = findSamePayeeUncategorized(
-              transactions,
-              validatedData.accountId,
-              validatedData.description,
-              resolvedType,
-              transaction?.id
-            );
-            if (targets.length > 0) {
-              try {
-                const appliedCount = await applyCategoryToUncategorized(targets, resolvedCategory);
-                if (appliedCount > 0) {
-                  const categoryName = categories.find(c => c.id === resolvedCategory)?.name ?? 'this category';
-                  showSuccess(
-                    `Also applied "${categoryName}" to ${appliedCount} other "${validatedData.description}" transaction${appliedCount === 1 ? '' : 's'}.`,
-                    'Payee memory'
-                  );
-                }
-              } catch (propagationError) {
-                logger.error('Payee-memory propagation failed', propagationError as Error);
-              }
-            }
+            await propagateCategory({
+              accountId: validatedData.accountId,
+              description: validatedData.description,
+              type: resolvedType,
+              categoryId: resolvedCategory,
+              excludeId: transaction?.id,
+            });
           }
 
-          onClose();
+          // Batch mode: "Save & Next" keeps the modal open — the caller swaps
+          // in the next transaction and the form repopulates from the prop.
+          // useModalForm calls our onClose after this resolves; suppress it.
+          if (advanceAfterSave && onSaveAndNext) {
+            suppressCloseRef.current = true;
+            onSaveAndNext();
+          }
         } catch (error) {
           if (error instanceof z.ZodError) {
             logger.error('Validation failed', error);
@@ -206,6 +216,10 @@ export default function EditTransactionModal({ isOpen, onClose, transaction, def
         }
       },
       onClose: () => {
+        if (suppressCloseRef.current) {
+          suppressCloseRef.current = false;
+          return;
+        }
         onClose();
       }
     }
@@ -233,7 +247,10 @@ export default function EditTransactionModal({ isOpen, onClose, transaction, def
       }
     }
 
-    const incomeGroups = groups.filter(g => g.type === 'income');
+    // 'both'-typed groups (e.g. Adjustments) are valid for either direction —
+    // include them on both sides so an income row carrying such a category is
+    // always representable in the select.
+    const incomeGroups = groups.filter(g => g.type === 'income' || g.type === 'both');
     const expenseGroups = groups.filter(g => g.type === 'expense' || g.type === 'both');
 
     // Transfer accounts: all accounts except the current transaction's account
@@ -292,6 +309,16 @@ export default function EditTransactionModal({ isOpen, onClose, transaction, def
       });
       // Set formatted amount for display
       setFormattedAmount(formatWithCommas(amountValue));
+      // Cross-type detection: a category from the OTHER direction's tree
+      // (e.g. a refund filed under an expense category) opens with the
+      // toggle already on so the select can represent the stored value.
+      const currentCategory = categories.find(c => c.id === categoryId);
+      setCrossTypeCategories(
+        (transaction.type === 'income' || transaction.type === 'expense') &&
+        currentCategory !== undefined &&
+        (currentCategory.type === 'income' || currentCategory.type === 'expense') &&
+        currentCategory.type !== transaction.type
+      );
     } else {
       // Reset form for new transaction
       const today = new Date().toISOString().split('T')[0];
@@ -309,6 +336,7 @@ export default function EditTransactionModal({ isOpen, onClose, transaction, def
         reconciledWith: ''
       });
       setFormattedAmount('');
+      setCrossTypeCategories(false);
     }
     setShowDeleteConfirm(false);
   }, [transaction, accounts, categories, setFormData, defaultAccountId]);
@@ -396,7 +424,11 @@ export default function EditTransactionModal({ isOpen, onClose, transaction, def
                     <button
                       key={t}
                       type="button"
-                      onClick={() => { updateField('type', t); updateField('category', ''); }}
+                      onClick={() => {
+                        updateField('type', t);
+                        updateField('category', '');
+                        setCrossTypeCategories(false);
+                      }}
                       className={`flex-1 px-4 py-1.5 rounded-md text-sm font-medium transition-all ${colors[t]}`}
                     >
                       {t.charAt(0).toUpperCase() + t.slice(1)}
@@ -404,6 +436,24 @@ export default function EditTransactionModal({ isOpen, onClose, transaction, def
                   );
                 })}
               </div>
+              {(formData.type === 'income' || formData.type === 'expense') && (
+                <label className="mt-2 flex items-start gap-2 text-xs text-gray-500 dark:text-gray-400 cursor-pointer">
+                  <input
+                    type="checkbox"
+                    checked={crossTypeCategories}
+                    onChange={(e) => {
+                      setCrossTypeCategories(e.target.checked);
+                      updateField('category', '');
+                    }}
+                    className="mt-0.5"
+                  />
+                  <span>
+                    {formData.type === 'income'
+                      ? 'Categorise as an expense — e.g. a refund files under the expense category it refunds, reducing that category’s total.'
+                      : 'Categorise as income — file this outgoing under an income category, reducing that category’s total.'}
+                  </span>
+                </label>
+              )}
             </div>
 
             {/* Amount */}
@@ -493,39 +543,23 @@ export default function EditTransactionModal({ isOpen, onClose, transaction, def
                 ) : (
                   <>
                     <option value="">Select category</option>
-                    {formData.type === 'income' && groupedCategories.incomeGroups.map(group => (
+                    {/* Which direction's tree to browse: normally the
+                        transaction's own, flipped by the cross-type toggle
+                        (Money-style: a refund can file under an expense). */}
+                    {((formData.type === 'income') !== crossTypeCategories) && groupedCategories.incomeGroups.map(group => (
                       <optgroup key={group.label} label={`Income: ${group.label}`}>
                         {group.items.map(item => (
                           <option key={item.id} value={item.id}>{item.name}</option>
                         ))}
                       </optgroup>
                     ))}
-                    {formData.type === 'expense' && groupedCategories.expenseGroups.map(group => (
+                    {((formData.type === 'expense') !== crossTypeCategories) && groupedCategories.expenseGroups.map(group => (
                       <optgroup key={group.label} label={group.label}>
                         {group.items.map(item => (
                           <option key={item.id} value={item.id}>{item.name}</option>
                         ))}
                       </optgroup>
                     ))}
-                    {/* Show all categories when type not yet explicitly chosen */}
-                    {formData.type !== 'income' && formData.type !== 'expense' && (
-                      <>
-                        {groupedCategories.incomeGroups.map(group => (
-                          <optgroup key={group.label} label={`Income: ${group.label}`}>
-                            {group.items.map(item => (
-                              <option key={item.id} value={item.id}>{item.name}</option>
-                            ))}
-                          </optgroup>
-                        ))}
-                        {groupedCategories.expenseGroups.map(group => (
-                          <optgroup key={group.label} label={group.label}>
-                            {group.items.map(item => (
-                              <option key={item.id} value={item.id}>{item.name}</option>
-                            ))}
-                          </optgroup>
-                        ))}
-                      </>
-                    )}
                   </>
                 )}
               </select>
@@ -645,6 +679,17 @@ export default function EditTransactionModal({ isOpen, onClose, transaction, def
                 >
                   {isSubmitting ? 'Saving…' : transaction ? 'Save Changes' : 'Add Transaction'}
                 </button>
+                {transaction && onSaveAndNext && (
+                  <button
+                    type="submit"
+                    disabled={isSubmitting}
+                    onClick={() => { advanceAfterSaveRef.current = true; }}
+                    className="px-4 py-2 bg-emerald-700 text-white rounded-lg hover:bg-emerald-800 disabled:opacity-50 disabled:cursor-not-allowed"
+                    title="Save this transaction and move to the next one in the list"
+                  >
+                    Save &amp; Next
+                  </button>
+                )}
               </div>
             </div>
           </ModalFooter>

--- a/src/components/QuickEditTransactionPanel.tsx
+++ b/src/components/QuickEditTransactionPanel.tsx
@@ -1,0 +1,210 @@
+import React, { useState, useEffect, useMemo, useRef } from 'react';
+import { useApp } from '../contexts/AppContextSupabase';
+import { useToast } from '../contexts/ToastContext';
+import { usePayeeMemory } from '../hooks/usePayeeMemory';
+import { XIcon } from './icons';
+import type { Transaction } from '../types';
+
+interface QuickEditTransactionPanelProps {
+  transaction: Transaction;
+  /** Advance the selection to the next transaction in the visible list. */
+  onNext?: () => void;
+  onClose: () => void;
+}
+
+/**
+ * One-click batch editor: single-clicking a row in the account register pins
+ * this condensed editor under the table — date, description, category, save —
+ * so a fresh bank import can be categorised without opening the full modal
+ * for every transaction. "Save & Next" walks straight down the list.
+ */
+export default function QuickEditTransactionPanel({
+  transaction,
+  onNext,
+  onClose,
+}: QuickEditTransactionPanelProps): React.JSX.Element {
+  const { categories, updateTransaction } = useApp();
+  const { showError } = useToast();
+  const { propagateCategory } = usePayeeMemory();
+
+  const [date, setDate] = useState('');
+  const [description, setDescription] = useState('');
+  const [category, setCategory] = useState('');
+  const [isSaving, setIsSaving] = useState(false);
+
+  // Re-sync only when a DIFFERENT transaction is selected (Save & Next flow).
+  // Keyed by id, not object identity: context refreshes recreate the object
+  // and must not clobber what the user is mid-way through typing.
+  const lastSyncedIdRef = useRef<string | null>(null);
+  useEffect(() => {
+    if (lastSyncedIdRef.current === transaction.id) {
+      return;
+    }
+    lastSyncedIdRef.current = transaction.id;
+    const d = transaction.date instanceof Date ? transaction.date : new Date(transaction.date);
+    setDate(d.toISOString().split('T')[0]);
+    setDescription(transaction.description);
+    setCategory(transaction.category ?? '');
+  }, [transaction]);
+
+  // Both directions are listed (Money-style cross-type categorization is
+  // legitimate — a refund can file under the expense category it refunds).
+  const categoryGroups = useMemo(() => {
+    const active = categories.filter(c => c.isActive !== false);
+    const detailCats = active.filter(c =>
+      c.level === 'detail' && c.id !== 'transfer-in' && c.id !== 'transfer-out'
+    );
+    const subCats = active.filter(c => c.level === 'sub');
+    return subCats
+      .map(sub => ({
+        label: sub.name,
+        type: sub.type,
+        items: detailCats.filter(d => d.parentId === sub.id),
+      }))
+      .filter(g => g.items.length > 0);
+  }, [categories]);
+
+  const isTransfer = transaction.type === 'transfer';
+
+  const save = async (advance: boolean) => {
+    if (isSaving) return;
+    if (!description.trim()) {
+      showError(new Error('Description is required.'));
+      return;
+    }
+    const parsedDate = new Date(date);
+    if (!date || Number.isNaN(parsedDate.getTime())) {
+      showError(new Error('Enter a valid date.'));
+      return;
+    }
+    setIsSaving(true);
+    try {
+      const categoryChanged = category !== (transaction.category ?? '');
+      await updateTransaction(transaction.id, {
+        date: parsedDate,
+        description: description.trim(),
+        ...(isTransfer ? {} : { category }),
+      });
+
+      // Payee memory — but never for CROSS-TYPE filings (a refund put under an
+      // expense category is a one-off correction; teaching it to a mixed-flow
+      // payee would stamp expense categories onto all its incoming money).
+      const chosenCategory = categories.find(c => c.id === category);
+      const isCrossType =
+        chosenCategory !== undefined &&
+        (chosenCategory.type === 'income' || chosenCategory.type === 'expense') &&
+        chosenCategory.type !== transaction.type;
+
+      if (!isTransfer && categoryChanged && category && !isCrossType &&
+          (transaction.type === 'income' || transaction.type === 'expense')) {
+        await propagateCategory({
+          accountId: transaction.accountId,
+          description: description.trim(),
+          type: transaction.type,
+          categoryId: category,
+          excludeId: transaction.id,
+        });
+      }
+
+      if (advance && onNext) {
+        onNext();
+      }
+    } catch (error) {
+      showError(error);
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  return (
+    <div className="mt-3 bg-white dark:bg-gray-800 rounded-xl shadow-md border-2 border-[#6B86B3] px-4 py-3">
+      <div className="flex flex-col lg:flex-row lg:items-end gap-3">
+        <div className="flex items-center gap-2 lg:hidden">
+          <span className="text-xs font-semibold text-gray-600 dark:text-gray-300">Quick edit</span>
+        </div>
+
+        {/* Date */}
+        <div className="w-full lg:w-40">
+          <label htmlFor="quick-edit-date" className="block text-xs text-gray-500 dark:text-gray-400 mb-1">
+            Date
+          </label>
+          <input
+            id="quick-edit-date"
+            type="date"
+            value={date}
+            onChange={(e) => setDate(e.target.value)}
+            className="w-full px-2 py-1.5 text-sm bg-white dark:bg-gray-700 border border-gray-300 dark:border-gray-600 rounded-lg dark:text-white"
+          />
+        </div>
+
+        {/* Description */}
+        <div className="flex-1 min-w-0">
+          <label htmlFor="quick-edit-description" className="block text-xs text-gray-500 dark:text-gray-400 mb-1">
+            Description
+          </label>
+          <input
+            id="quick-edit-description"
+            type="text"
+            value={description}
+            onChange={(e) => setDescription(e.target.value)}
+            className="w-full px-2 py-1.5 text-sm bg-white dark:bg-gray-700 border border-gray-300 dark:border-gray-600 rounded-lg dark:text-white"
+          />
+        </div>
+
+        {/* Category (not editable for transfers — they carry system categories) */}
+        <div className="w-full lg:w-72">
+          <label htmlFor="quick-edit-category" className="block text-xs text-gray-500 dark:text-gray-400 mb-1">
+            Category
+          </label>
+          <select
+            id="quick-edit-category"
+            value={category}
+            onChange={(e) => setCategory(e.target.value)}
+            disabled={isTransfer}
+            className="w-full px-2 py-1.5 text-sm bg-white dark:bg-gray-700 border border-gray-300 dark:border-gray-600 rounded-lg dark:text-white disabled:opacity-50"
+          >
+            <option value="">{isTransfer ? 'Transfer' : 'Select category'}</option>
+            {!isTransfer && categoryGroups.map(group => (
+              <optgroup
+                key={group.label}
+                label={group.type === 'income' ? `Income: ${group.label}` : group.label}
+              >
+                {group.items.map(item => (
+                  <option key={item.id} value={item.id}>{item.name}</option>
+                ))}
+              </optgroup>
+            ))}
+          </select>
+        </div>
+
+        {/* Actions */}
+        <div className="flex items-center gap-2">
+          <button
+            onClick={() => void save(false)}
+            disabled={isSaving}
+            className="px-3 py-1.5 text-sm font-medium bg-[#1a2332] text-white rounded-lg hover:bg-secondary disabled:opacity-50 disabled:cursor-not-allowed whitespace-nowrap"
+          >
+            {isSaving ? 'Saving…' : 'Save'}
+          </button>
+          {onNext && (
+            <button
+              onClick={() => void save(true)}
+              disabled={isSaving}
+              className="px-3 py-1.5 text-sm font-medium bg-emerald-700 text-white rounded-lg hover:bg-emerald-800 disabled:opacity-50 disabled:cursor-not-allowed whitespace-nowrap"
+              title="Save and move to the next transaction in the list"
+            >
+              Save &amp; Next
+            </button>
+          )}
+          <button
+            onClick={onClose}
+            className="p-1.5 text-gray-400 hover:text-gray-600 dark:hover:text-gray-300"
+            aria-label="Close quick edit"
+          >
+            <XIcon size={16} />
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/contexts/AppContextSupabase.tsx
+++ b/src/contexts/AppContextSupabase.tsx
@@ -30,7 +30,7 @@ import type {
   AppState 
 } from '../types';
 import { createScopedLogger } from '../loggers/scopedLogger';
-import { planCategoryTreeImport, type CategoryTreeGroup } from '../utils/categoryTreeImport';
+import { planCategoryTreeImport, planCategoryPrune, type CategoryTreeGroup } from '../utils/categoryTreeImport';
 
 export interface Tag {
   id: string;
@@ -66,8 +66,15 @@ export interface AppContextType extends AppState {
   // Category operations — async so callers can surface persistence failures
   /** Returns the created category so callers can use its real id immediately. */
   addCategory: (category: Omit<Category, 'id'>) => Promise<Category>;
-  /** Merge a Money-style category tree; skips same-named entries. Returns counts. */
-  importCategoryTree: (tree: CategoryTreeGroup[]) => Promise<{ created: number; skipped: number }>;
+  /**
+   * Merge a Money-style category tree; skips same-named entries. With
+   * pruneOthers, unused non-system categories outside the tree are removed
+   * afterwards (categories still referenced by transactions are kept).
+   */
+  importCategoryTree: (
+    tree: CategoryTreeGroup[],
+    options?: { pruneOthers?: boolean }
+  ) => Promise<{ created: number; skipped: number; pruned: number; keptForTransactions: number }>;
   updateCategory: (id: string, updates: Partial<Category>) => Promise<void>;
   deleteCategory: (id: string) => Promise<void>;
   getSubCategories: (parentId: string) => Category[];
@@ -660,7 +667,10 @@ export function AppProvider({ children }: { children: React.ReactNode }) {
   // Import a Money-style two-level tree (sub → detail), merging idempotently:
   // same-named categories are skipped, so re-running or overlapping the default
   // set never duplicates. Two phases because details need their sub's id.
-  const importCategoryTree = useCallback(async (tree: CategoryTreeGroup[]) => {
+  const importCategoryTree = useCallback(async (
+    tree: CategoryTreeGroup[],
+    options?: { pruneOthers?: boolean }
+  ) => {
     const userId = userIdService.getCurrentDatabaseUserId();
     const plan = planCategoryTreeImport(categories, tree);
 
@@ -705,11 +715,42 @@ export function AppProvider({ children }: { children: React.ReactNode }) {
       setCategories(prev => [...prev, ...createdDetails]);
     }
 
+    // Optional replace semantics: remove unused categories OUTSIDE the tree so
+    // the user's list becomes the imported set. Anything a transaction still
+    // references is kept (never orphan a transaction's category).
+    let pruned = 0;
+    let keptForTransactions = 0;
+    if (options?.pruneOthers) {
+      const merged = [...categories, ...createdSubs, ...createdDetails];
+      // "In use" covers every reference kind: transactions, budgets (keyed by
+      // categoryId), and recurring transaction templates.
+      const usedCategoryIds = new Set(
+        [
+          ...transactions.map(t => t.category),
+          ...budgets.map(b => b.categoryId),
+          ...recurringTransactions.map(r => r.category),
+        ].filter((c): c is string => !!c && c.trim() !== '')
+      );
+      const prunePlan = planCategoryPrune(merged, tree, usedCategoryIds);
+      const idsToDelete = [...prunePlan.detailIdsToDelete, ...prunePlan.subIdsToDelete];
+      if (idsToDelete.length > 0) {
+        // The RPC re-verifies references server-side and may delete FEWER rows
+        // than planned (a stale snapshot can never destroy referenced data) —
+        // so re-read the authoritative category set instead of trusting the plan.
+        pruned = await PlanningService.deleteUnusedCategories(userId, idsToDelete);
+        const authoritative = await PlanningService.ensureCategories(userId);
+        setCategories(authoritative);
+      }
+      keptForTransactions = prunePlan.keptForTransactionsCount;
+    }
+
     return {
       created: createdSubs.length + createdDetails.length,
       skipped: plan.skippedCount,
+      pruned,
+      keptForTransactions,
     };
-  }, [categories]);
+  }, [categories, transactions, budgets, recurringTransactions]);
 
   const updateCategory = useCallback(async (id: string, updates: Partial<Category>) => {
     try {

--- a/src/data/__tests__/defaultCategories.test.ts
+++ b/src/data/__tests__/defaultCategories.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect } from 'vitest';
+import { getDefaultCategories, getMinimalSystemCategories } from '../defaultCategories';
+import { MS_MONEY_CATEGORY_SET } from '../msMoneyCategories';
+
+describe('getDefaultCategories (Microsoft Money default set)', () => {
+  const defaults = getDefaultCategories();
+
+  it('has globally unique ids', () => {
+    const ids = defaults.map(c => c.id);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  it('keeps every system category the app depends on', () => {
+    for (const required of ['type-income', 'type-expense', 'type-transfer',
+      'transfer-in', 'transfer-out', 'sub-adjustments', 'account-adjustments']) {
+      expect(defaults.some(c => c.id === required)).toBe(true);
+    }
+  });
+
+  it('contains every Microsoft Money group as a sub under the right anchor', () => {
+    for (const group of MS_MONEY_CATEGORY_SET) {
+      const sub = defaults.find(c => c.level === 'sub' && c.name === group.name && c.type === group.type);
+      expect(sub, `missing group ${group.name}`).toBeDefined();
+      expect(sub!.parentId).toBe(`type-${group.type}`);
+    }
+  });
+
+  it('contains every Money subcategory as a selectable detail under its group', () => {
+    for (const group of MS_MONEY_CATEGORY_SET) {
+      const sub = defaults.find(c => c.level === 'sub' && c.name === group.name && c.type === group.type)!;
+      const children = group.children.length > 0 ? group.children : [group.name];
+      for (const child of children) {
+        const detail = defaults.find(c => c.level === 'detail' && c.parentId === sub.id && c.name === child);
+        expect(detail, `missing detail ${group.name} > ${child}`).toBeDefined();
+      }
+    }
+  });
+
+  it('every non-type category resolves to an existing parent', () => {
+    const ids = new Set(defaults.map(c => c.id));
+    for (const c of defaults) {
+      if (c.level === 'type') continue;
+      expect(c.parentId && ids.has(c.parentId), `${c.name} has dangling parent`).toBe(true);
+    }
+  });
+
+  it('minimal system set is unchanged (transfers still work without full seed)', () => {
+    expect(getMinimalSystemCategories().map(c => c.id)).toEqual([
+      'type-income', 'type-expense', 'type-transfer', 'transfer-in', 'transfer-out',
+    ]);
+  });
+});

--- a/src/data/defaultCategories.ts
+++ b/src/data/defaultCategories.ts
@@ -1,3 +1,5 @@
+import { MS_MONEY_CATEGORY_SET } from './msMoneyCategories';
+
 interface Category {
   id: string;
   name: string;
@@ -15,107 +17,65 @@ export function getMinimalSystemCategories(): Category[] {
     { id: 'type-income', name: 'Income', type: 'income', level: 'type', isSystem: true },
     { id: 'type-expense', name: 'Expense', type: 'expense', level: 'type', isSystem: true },
     { id: 'type-transfer', name: 'Transfer', type: 'both', level: 'type', isSystem: true },
-    
+
     // Transfer detail categories (required for transfers to work)
     { id: 'transfer-in', name: 'Transfer In', type: 'both', level: 'detail', parentId: 'type-transfer', isSystem: true },
     { id: 'transfer-out', name: 'Transfer Out', type: 'both', level: 'detail', parentId: 'type-transfer', isSystem: true },
   ];
 }
 
+/** Deterministic slug for default category ids ("Cars & Bikes" → "cars-bikes"). */
+const slugify = (name: string): string =>
+  name
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+
+/**
+ * The default category tree every new user starts with: the classic
+ * Microsoft Money (UK) set (src/data/msMoneyCategories.ts) plus the system
+ * categories the app itself needs (type anchors, transfer in/out, and the
+ * Adjustments bucket used by balance-repair tooling).
+ */
 export function getDefaultCategories(): Category[] {
-  return [
+  const categories: Category[] = [
     // Type level categories
     { id: 'type-income', name: 'Income', type: 'income', level: 'type', isSystem: true },
     { id: 'type-expense', name: 'Expense', type: 'expense', level: 'type', isSystem: true },
     { id: 'type-transfer', name: 'Transfer', type: 'both', level: 'type', isSystem: true },
-    
-    // Income sub-categories
-    { id: 'sub-salary', name: 'Salary & Wages', type: 'income', level: 'sub', parentId: 'type-income', isSystem: true },
-    { id: 'sub-business', name: 'Business Income', type: 'income', level: 'sub', parentId: 'type-income', isSystem: true },
-    { id: 'sub-investment-income', name: 'Investment Income', type: 'income', level: 'sub', parentId: 'type-income', isSystem: true },
-    { id: 'sub-other-income', name: 'Other Income', type: 'income', level: 'sub', parentId: 'type-income', isSystem: true },
-    
-    // Income detail categories
-    { id: 'salary', name: 'Regular Salary', type: 'income', level: 'detail', parentId: 'sub-salary' },
-    { id: 'bonus', name: 'Bonus', type: 'income', level: 'detail', parentId: 'sub-salary' },
-    { id: 'overtime', name: 'Overtime', type: 'income', level: 'detail', parentId: 'sub-salary' },
-    { id: 'freelance', name: 'Freelance Income', type: 'income', level: 'detail', parentId: 'sub-business' },
-    { id: 'dividends', name: 'Dividends', type: 'income', level: 'detail', parentId: 'sub-investment-income' },
-    { id: 'interest', name: 'Interest', type: 'income', level: 'detail', parentId: 'sub-investment-income' },
-    { id: 'capital-gains', name: 'Capital Gains', type: 'income', level: 'detail', parentId: 'sub-investment-income' },
-    { id: 'rental-income', name: 'Rental Income', type: 'income', level: 'detail', parentId: 'sub-other-income' },
-    { id: 'gifts-received', name: 'Gifts Received', type: 'income', level: 'detail', parentId: 'sub-other-income' },
-    
-    // Expense sub-categories
-    { id: 'sub-housing', name: 'Housing', type: 'expense', level: 'sub', parentId: 'type-expense', isSystem: true },
-    { id: 'sub-transport', name: 'Transport', type: 'expense', level: 'sub', parentId: 'type-expense', isSystem: true },
-    { id: 'sub-food', name: 'Food & Dining', type: 'expense', level: 'sub', parentId: 'type-expense', isSystem: true },
-    { id: 'sub-utilities', name: 'Utilities', type: 'expense', level: 'sub', parentId: 'type-expense', isSystem: true },
-    { id: 'sub-healthcare', name: 'Healthcare', type: 'expense', level: 'sub', parentId: 'type-expense', isSystem: true },
-    { id: 'sub-entertainment', name: 'Entertainment', type: 'expense', level: 'sub', parentId: 'type-expense', isSystem: true },
-    { id: 'sub-shopping', name: 'Shopping', type: 'expense', level: 'sub', parentId: 'type-expense', isSystem: true },
-    { id: 'sub-education', name: 'Education', type: 'expense', level: 'sub', parentId: 'type-expense', isSystem: true },
-    { id: 'sub-personal', name: 'Personal Care', type: 'expense', level: 'sub', parentId: 'type-expense', isSystem: true },
-    { id: 'sub-insurance', name: 'Insurance', type: 'expense', level: 'sub', parentId: 'type-expense', isSystem: true },
-    { id: 'sub-savings', name: 'Savings & Investments', type: 'expense', level: 'sub', parentId: 'type-expense', isSystem: true },
-    { id: 'sub-taxes', name: 'Taxes', type: 'expense', level: 'sub', parentId: 'type-expense', isSystem: true },
-    { id: 'sub-other-expense', name: 'Other Expenses', type: 'expense', level: 'sub', parentId: 'type-expense', isSystem: true },
+
+    // System adjustment bucket (used by Data Validation balance repair)
     { id: 'sub-adjustments', name: 'Adjustments', type: 'both', level: 'sub', parentId: 'type-expense', isSystem: true },
-    
-    // Housing detail categories
-    { id: 'rent', name: 'Rent', type: 'expense', level: 'detail', parentId: 'sub-housing' },
-    { id: 'mortgage', name: 'Mortgage', type: 'expense', level: 'detail', parentId: 'sub-housing' },
-    { id: 'property-tax', name: 'Property Tax', type: 'expense', level: 'detail', parentId: 'sub-housing' },
-    { id: 'home-maintenance', name: 'Home Maintenance', type: 'expense', level: 'detail', parentId: 'sub-housing' },
-    { id: 'home-insurance', name: 'Home Insurance', type: 'expense', level: 'detail', parentId: 'sub-insurance' },
-    
-    // Transport detail categories
-    { id: 'fuel', name: 'Fuel', type: 'expense', level: 'detail', parentId: 'sub-transport' },
-    { id: 'public-transport', name: 'Public Transport', type: 'expense', level: 'detail', parentId: 'sub-transport' },
-    { id: 'car-maintenance', name: 'Car Maintenance', type: 'expense', level: 'detail', parentId: 'sub-transport' },
-    { id: 'car-insurance', name: 'Car Insurance', type: 'expense', level: 'detail', parentId: 'sub-insurance' },
-    { id: 'parking', name: 'Parking', type: 'expense', level: 'detail', parentId: 'sub-transport' },
-    { id: 'tolls', name: 'Tolls', type: 'expense', level: 'detail', parentId: 'sub-transport' },
-    
-    // Food detail categories
-    { id: 'groceries', name: 'Groceries', type: 'expense', level: 'detail', parentId: 'sub-food' },
-    { id: 'restaurants', name: 'Restaurants', type: 'expense', level: 'detail', parentId: 'sub-food' },
-    { id: 'takeout', name: 'Takeout/Delivery', type: 'expense', level: 'detail', parentId: 'sub-food' },
-    { id: 'coffee-shops', name: 'Coffee Shops', type: 'expense', level: 'detail', parentId: 'sub-food' },
-    
-    // Utilities detail categories
-    { id: 'electricity', name: 'Electricity', type: 'expense', level: 'detail', parentId: 'sub-utilities' },
-    { id: 'water', name: 'Water', type: 'expense', level: 'detail', parentId: 'sub-utilities' },
-    { id: 'gas', name: 'Gas', type: 'expense', level: 'detail', parentId: 'sub-utilities' },
-    { id: 'internet', name: 'Internet', type: 'expense', level: 'detail', parentId: 'sub-utilities' },
-    { id: 'phone', name: 'Phone', type: 'expense', level: 'detail', parentId: 'sub-utilities' },
-    { id: 'tv', name: 'TV/Streaming', type: 'expense', level: 'detail', parentId: 'sub-utilities' },
-    
-    // Healthcare detail categories
-    { id: 'health-insurance', name: 'Health Insurance', type: 'expense', level: 'detail', parentId: 'sub-insurance' },
-    { id: 'doctor', name: 'Doctor Visits', type: 'expense', level: 'detail', parentId: 'sub-healthcare' },
-    { id: 'dentist', name: 'Dental Care', type: 'expense', level: 'detail', parentId: 'sub-healthcare' },
-    { id: 'pharmacy', name: 'Pharmacy', type: 'expense', level: 'detail', parentId: 'sub-healthcare' },
-    { id: 'vision', name: 'Vision Care', type: 'expense', level: 'detail', parentId: 'sub-healthcare' },
-    
-    // Entertainment detail categories
-    { id: 'movies', name: 'Movies & Shows', type: 'expense', level: 'detail', parentId: 'sub-entertainment' },
-    { id: 'concerts', name: 'Concerts & Events', type: 'expense', level: 'detail', parentId: 'sub-entertainment' },
-    { id: 'sports', name: 'Sports & Recreation', type: 'expense', level: 'detail', parentId: 'sub-entertainment' },
-    { id: 'hobbies', name: 'Hobbies', type: 'expense', level: 'detail', parentId: 'sub-entertainment' },
-    { id: 'subscriptions', name: 'Subscriptions', type: 'expense', level: 'detail', parentId: 'sub-entertainment' },
-    
-    // Shopping detail categories
-    { id: 'clothing', name: 'Clothing', type: 'expense', level: 'detail', parentId: 'sub-shopping' },
-    { id: 'electronics', name: 'Electronics', type: 'expense', level: 'detail', parentId: 'sub-shopping' },
-    { id: 'household', name: 'Household Items', type: 'expense', level: 'detail', parentId: 'sub-shopping' },
-    { id: 'gifts', name: 'Gifts', type: 'expense', level: 'detail', parentId: 'sub-shopping' },
-    
-    // Adjustment categories
     { id: 'account-adjustments', name: 'Account Adjustments', type: 'both', level: 'detail', parentId: 'sub-adjustments', isSystem: true },
-    
+
     // Transfer categories
     { id: 'transfer-in', name: 'Transfer In', type: 'both', level: 'detail', parentId: 'type-transfer', isSystem: true },
     { id: 'transfer-out', name: 'Transfer Out', type: 'both', level: 'detail', parentId: 'type-transfer', isSystem: true },
   ];
+
+  for (const group of MS_MONEY_CATEGORY_SET) {
+    const subId = `sub-${slugify(group.name)}`;
+    categories.push({
+      id: subId,
+      name: group.name,
+      type: group.type,
+      level: 'sub',
+      parentId: `type-${group.type}`,
+    });
+
+    // Empty group → one self-named detail so it stays selectable (matches the
+    // Money-set import behaviour in utils/categoryTreeImport.ts).
+    const children = group.children.length > 0 ? group.children : [group.name];
+    for (const child of children) {
+      categories.push({
+        id: `${slugify(group.name)}--${slugify(child)}`,
+        name: child,
+        type: group.type,
+        level: 'detail',
+        parentId: subId,
+      });
+    }
+  }
+
+  return categories;
 }

--- a/src/hooks/usePayeeMemory.ts
+++ b/src/hooks/usePayeeMemory.ts
@@ -1,0 +1,53 @@
+import { useCallback, useMemo } from 'react';
+import { useApp } from '../contexts/AppContextSupabase';
+import { useToast } from '../contexts/ToastContext';
+import { findSamePayeeUncategorized } from '../utils/payeeAutoCategorize';
+import { createScopedLogger } from '../loggers/scopedLogger';
+
+/**
+ * Payee memory (the Microsoft Money model): when a transaction gets a
+ * category, spread it to every UNCATEGORIZED same-direction transaction with
+ * the same payee in that account. Explicit categories are never overwritten
+ * (enforced server-side too), and a propagation failure never fails the save
+ * that already succeeded — it is logged and swallowed.
+ */
+export function usePayeeMemory(): {
+  propagateCategory: (args: {
+    accountId: string;
+    description: string;
+    type: 'income' | 'expense';
+    categoryId: string;
+    excludeId?: string;
+  }) => Promise<void>;
+} {
+  const { transactions, categories, applyCategoryToUncategorized } = useApp();
+  const { showSuccess } = useToast();
+  const logger = useMemo(() => createScopedLogger('usePayeeMemory'), []);
+
+  const propagateCategory = useCallback(async ({ accountId, description, type, categoryId, excludeId }: {
+    accountId: string;
+    description: string;
+    type: 'income' | 'expense';
+    categoryId: string;
+    excludeId?: string;
+  }) => {
+    const targets = findSamePayeeUncategorized(transactions, accountId, description, type, excludeId);
+    if (targets.length === 0) {
+      return;
+    }
+    try {
+      const appliedCount = await applyCategoryToUncategorized(targets, categoryId);
+      if (appliedCount > 0) {
+        const categoryName = categories.find(c => c.id === categoryId)?.name ?? 'this category';
+        showSuccess(
+          `Also applied "${categoryName}" to ${appliedCount} other "${description}" transaction${appliedCount === 1 ? '' : 's'}.`,
+          'Payee memory'
+        );
+      }
+    } catch (error) {
+      logger.error('Payee-memory propagation failed', error as Error);
+    }
+  }, [transactions, categories, applyCategoryToUncategorized, showSuccess, logger]);
+
+  return { propagateCategory };
+}

--- a/src/pages/AccountTransactions.tsx
+++ b/src/pages/AccountTransactions.tsx
@@ -8,6 +8,7 @@ import { ArrowLeftIcon, SearchIcon, PlusIcon, CalendarIcon, XIcon, SettingsIcon 
 import LocalMerchantLogo from '../components/LocalMerchantLogo';
 import DatePicker from '../components/common/DatePicker';
 import EditTransactionModal from '../components/EditTransactionModal';
+import QuickEditTransactionPanel from '../components/QuickEditTransactionPanel';
 import CategorySelector from '../components/CategorySelector';
 import { usePreferences } from '../contexts/PreferencesContext';
 import { VirtualizedTable, Column } from '../components/VirtualizedTable';
@@ -234,6 +235,17 @@ export default function AccountTransactions() {
   // Keyboard event handler
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
+      // Never hijack Delete while the user is typing (the quick-edit panel
+      // keeps a row selected while its inputs are focused).
+      const target = e.target as HTMLElement | null;
+      if (target && (
+        target.tagName === 'INPUT' ||
+        target.tagName === 'TEXTAREA' ||
+        target.tagName === 'SELECT' ||
+        target.isContentEditable
+      )) {
+        return;
+      }
       if (e.key === 'Delete' && selectedTransactionId) {
         const transaction = transactionsWithBalance.find(t => t.id === selectedTransactionId);
         if (transaction) {
@@ -241,7 +253,7 @@ export default function AccountTransactions() {
         }
       }
     };
-    
+
     window.addEventListener('keydown', handleKeyDown);
     return () => window.removeEventListener('keydown', handleKeyDown);
   }, [selectedTransactionId, transactionsWithBalance]);
@@ -302,10 +314,39 @@ export default function AccountTransactions() {
       // Second click on already selected transaction - open edit modal
       setIsEditModalOpen(true);
     } else {
-      // First click - just select the transaction
+      // First click - select and pin the quick-edit panel under the table
       setSelectedTransactionId(item.id);
     }
   }, [selectedTransactionId]);
+
+  // The quick-edit panel always reflects the latest saved state of the
+  // selected transaction (context updates flow straight back in).
+  const quickEditTarget = useMemo(
+    () => transactionsWithBalance.find(t => t.id === selectedTransactionId) ?? null,
+    [transactionsWithBalance, selectedTransactionId]
+  );
+
+  // Next non-summary row below the given one in the CURRENT visible order —
+  // powers "Save & Next" in both the quick-edit panel and the full modal.
+  const getNextTransactionId = useCallback((currentId: string): string | null => {
+    const index = displayRows.findIndex(row => row.id === currentId);
+    if (index === -1) return null;
+    for (let i = index + 1; i < displayRows.length; i += 1) {
+      if (!isOpeningBalanceRow(displayRows[i])) {
+        return displayRows[i].id;
+      }
+    }
+    return null;
+  }, [displayRows]);
+
+  const advanceToNextTransaction = useCallback((currentId: string): boolean => {
+    const nextId = getNextTransactionId(currentId);
+    if (!nextId) return false;
+    const nextTransaction = transactionsWithBalance.find(t => t.id === nextId) ?? null;
+    setSelectedTransactionId(nextId);
+    setSelectedTransaction(nextTransaction);
+    return true;
+  }, [getNextTransactionId, transactionsWithBalance]);
   
   
   // Handle quick add
@@ -794,7 +835,23 @@ export default function AccountTransactions() {
           }}
         />
       </div>
-      
+
+      {/* Quick edit: single click pins this condensed editor under the table */}
+      {quickEditTarget && !isEditModalOpen && (
+        <QuickEditTransactionPanel
+          transaction={quickEditTarget}
+          onNext={
+            getNextTransactionId(quickEditTarget.id)
+              ? () => { advanceToNextTransaction(quickEditTarget.id); }
+              : undefined
+          }
+          onClose={() => {
+            setSelectedTransactionId(null);
+            setSelectedTransaction(null);
+          }}
+        />
+      )}
+
       {/* Quick Add Transaction */}
       <div className="bg-white dark:bg-gray-800 rounded-xl shadow-md border border-gray-100 dark:border-gray-700 px-4 py-3 mt-4">
         <form onSubmit={handleQuickAdd}>
@@ -919,6 +976,17 @@ export default function AccountTransactions() {
             setSelectedTransactionId(null);
           }}
           transaction={selectedTransaction}
+          onSaveAndNext={
+            getNextTransactionId(selectedTransaction.id)
+              ? () => {
+                  if (!advanceToNextTransaction(selectedTransaction.id)) {
+                    setIsEditModalOpen(false);
+                    setSelectedTransaction(null);
+                    setSelectedTransactionId(null);
+                  }
+                }
+              : undefined
+          }
         />
       )}
       

--- a/src/pages/Reports.tsx
+++ b/src/pages/Reports.tsx
@@ -21,6 +21,7 @@ import {
 import { useCurrencyDecimal } from '../hooks/useCurrencyDecimal';
 import { toDecimal, DecimalInstance } from '../utils/decimal';
 import { formatDecimal } from '../utils/decimal-format';
+import { computeExpenseCategoryNetTotals, bucketByCategoryDirection } from '../utils/categoryNetting';
 import { createScopedLogger } from '../loggers/scopedLogger';
 
 const reportsLogger = createScopedLogger('ReportsPage');
@@ -31,7 +32,7 @@ const CATEGORY_COLORS = [
 ];
 
 export default function Reports() {
-  const { transactions, accounts } = useApp();
+  const { transactions, accounts, categories } = useApp();
   const [dateRange, setDateRange] = useState<'month' | 'quarter' | 'year' | 'all' | 'custom'>('month');
   const [selectedAccount, setSelectedAccount] = useState<string>('all');
   const [isGeneratingPDF, setIsGeneratingPDF] = useState(false);
@@ -83,16 +84,24 @@ export default function Reports() {
     });
   }, [transactions, dateRange, selectedAccount, customStartDate, customEndDate]);
 
-  // Calculate summary statistics
+  // Calculate summary statistics — bucketed by CATEGORY direction (the same
+  // Money-style netting as the pie), so a refund filed under an expense
+  // category reduces Expenses here rather than inflating Income.
   const summary = useMemo(() => {
-    const incomeDecimal = filteredTransactions
-      .filter(t => t.type === 'income')
-      .reduce((sum, t) => sum.plus(t.amount), toDecimal(0));
+    const categoryById = new Map(categories.map(c => [c.id, c]));
+    let incomeDecimal = toDecimal(0);
+    let expensesDecimal = toDecimal(0);
 
-    // Expenses are stored signed (negative); aggregate as a positive magnitude
-    const expensesDecimal = filteredTransactions
-      .filter(t => t.type === 'expense')
-      .reduce((sum, t) => sum.plus(Math.abs(t.amount)), toDecimal(0));
+    for (const t of filteredTransactions) {
+      const bucket = bucketByCategoryDirection(t, categoryById);
+      if (bucket === 'income') {
+        // Signed sum: an outgoing filed under an income category nets it down.
+        incomeDecimal = incomeDecimal.plus(t.amount);
+      } else if (bucket === 'expense') {
+        // Spending is negative; negate so refunds net the total down.
+        expensesDecimal = expensesDecimal.minus(t.amount);
+      }
+    }
 
     const netIncomeDecimal = incomeDecimal.minus(expensesDecimal);
     const savingsRateDecimal = incomeDecimal.gt(0)
@@ -105,7 +114,7 @@ export default function Reports() {
       netIncome: netIncomeDecimal.toNumber(),
       savingsRate: savingsRateDecimal.toNumber(),
     };
-  }, [filteredTransactions]);
+  }, [filteredTransactions, categories]);
 
   const formatPercentage = (value: DecimalInstance | number, decimals: number = 1) => {
     return formatDecimal(value, decimals);
@@ -122,44 +131,36 @@ export default function Reports() {
     }
   }, [transactions, accounts]);
 
-  // Prepare data for category breakdown
-  const categoryData = useMemo(() => {
-    const categoryTotals = filteredTransactions
-      .filter(t => t.type === 'expense')
-      .reduce<Record<string, DecimalInstance>>((acc, t) => {
-        const key = t.category || 'Uncategorized';
-        const current = acc[key] ?? toDecimal(0);
-        // Expenses are stored signed (negative); totals must be positive magnitudes
-        acc[key] = current.plus(Math.abs(t.amount));
-        return acc;
-      }, {});
+  // Prepare data for category breakdown. Money-style netting: bucket by the
+  // CATEGORY's direction and net signed amounts, so a refund filed under an
+  // expense category reduces that category instead of inflating income —
+  // and slice labels show category NAMES, never raw ids.
+  const categoryData = useMemo(
+    () => computeExpenseCategoryNetTotals(filteredTransactions, categories)
+      .slice(0, 8)
+      .map(({ name, value }) => ({ name, value })),
+    [filteredTransactions, categories]
+  );
 
-    const sortedCategories = Object.entries(categoryTotals)
-      .sort(([, a], [, b]) => b.minus(a).toNumber())
-      .slice(0, 8);
-
-    return sortedCategories.map(([cat, amount]) => ({
-      name: cat,
-      value: amount.toNumber()
-    }));
-  }, [filteredTransactions]);
-
-  // Prepare data for monthly trend
+  // Prepare data for monthly trend — same category-direction netting as the
+  // summary and the pie, so all three views on this page agree.
   const monthlyTrendData = useMemo(() => {
     const monthlyData: Record<string, { income: DecimalInstance; expenses: DecimalInstance }> = {};
+    const categoryById = new Map(categories.map(c => [c.id, c]));
 
     filteredTransactions.forEach(t => {
-      if (t.type !== 'income' && t.type !== 'expense') return;
+      const bucket = bucketByCategoryDirection(t, categoryById);
+      if (bucket === 'transfer') return;
       const monthKey = new Date(t.date).toISOString().slice(0, 7);
       if (!monthlyData[monthKey]) {
         monthlyData[monthKey] = { income: toDecimal(0), expenses: toDecimal(0) };
       }
 
-      if (t.type === 'income') {
+      if (bucket === 'income') {
         monthlyData[monthKey].income = monthlyData[monthKey].income.plus(t.amount);
       } else {
-        // Expenses are stored signed (negative); plot as positive magnitudes
-        monthlyData[monthKey].expenses = monthlyData[monthKey].expenses.plus(Math.abs(t.amount));
+        // Spending is negative; negate so refunds net the month down.
+        monthlyData[monthKey].expenses = monthlyData[monthKey].expenses.minus(t.amount);
       }
     });
 
@@ -170,7 +171,7 @@ export default function Reports() {
       income: monthlyData[month].income.toNumber(),
       expenses: monthlyData[month].expenses.toNumber()
     }));
-  }, [filteredTransactions]);
+  }, [filteredTransactions, categories]);
 
   const exportToCSV = () => {
     const csv = exportTransactionsToCSV(filteredTransactions, accounts);
@@ -181,31 +182,20 @@ export default function Reports() {
   const exportToPDF = async (includeCharts: boolean = true) => {
     setIsGeneratingPDF(true);
     try {
-      // Prepare category breakdown data
-      const expenseTotals = filteredTransactions
-        .filter(t => t.type === 'expense')
-        .reduce<Record<string, DecimalInstance>>((acc, t) => {
-          const key = t.category || 'Uncategorized';
-          const current = acc[key] ?? toDecimal(0);
-          // Expenses are stored signed (negative); totals must be positive magnitudes
-          acc[key] = current.plus(Math.abs(t.amount));
-          return acc;
-        }, {});
-
-      const totalExpensesDecimal = Object.values(expenseTotals).reduce(
-        (sum, amount) => sum.plus(amount),
+      // Prepare category breakdown data (same Money-style netting as the pie).
+      const netTotals = computeExpenseCategoryNetTotals(filteredTransactions, categories);
+      const totalExpensesDecimal = netTotals.reduce(
+        (sum, entry) => sum.plus(toDecimal(entry.value)),
         toDecimal(0)
       );
 
-      const categoryBreakdown = Object.entries(expenseTotals)
-        .sort(([, a], [, b]) => b.minus(a).toNumber())
-        .map(([category, amount]) => ({
-          category,
-          amount: amount.toNumber(),
-          percentage: totalExpensesDecimal.gt(0)
-            ? amount.dividedBy(totalExpensesDecimal).times(100).toNumber()
-            : 0
-        }));
+      const categoryBreakdown = netTotals.map(({ name, value }) => ({
+        category: name,
+        amount: value,
+        percentage: totalExpensesDecimal.gt(0)
+          ? toDecimal(value).dividedBy(totalExpensesDecimal).times(100).toNumber()
+          : 0
+      }));
 
       const reportData = {
         title: 'Financial Report',

--- a/src/pages/settings/Categories.tsx
+++ b/src/pages/settings/Categories.tsx
@@ -184,18 +184,22 @@ export default function CategoriesSettings() {
   const handleImportMoneySet = async () => {
     if (isImporting) return;
     if (!window.confirm(
-      'Import the Microsoft Money category set? Existing categories with the same names are kept — nothing is deleted or overwritten.'
+      'Switch to the Microsoft Money category set? The Money tree is imported and unused default categories are removed. Categories that transactions use, transfer categories, and system categories are always kept.'
     )) {
       return;
     }
     setIsImporting(true);
     try {
-      const result = await importCategoryTree(MS_MONEY_CATEGORY_SET);
+      const result = await importCategoryTree(MS_MONEY_CATEGORY_SET, { pruneOthers: true });
+      const parts: string[] = [];
+      if (result.created > 0) parts.push(`added ${result.created}`);
+      if (result.pruned > 0) parts.push(`removed ${result.pruned} unused defaults`);
+      if (result.keptForTransactions > 0) parts.push(`kept ${result.keptForTransactions} in use by transactions`);
       showSuccess(
-        result.created > 0
-          ? `Added ${result.created} categories (${result.skipped} already existed).`
-          : 'All Microsoft Money categories already exist — nothing to add.',
-        'Category import complete'
+        parts.length > 0
+          ? `Categories updated: ${parts.join(', ')}.`
+          : 'Your categories already match the Microsoft Money set.',
+        'Money set applied'
       );
     } catch (error) {
       showError(error);
@@ -722,8 +726,8 @@ export default function CategoriesSettings() {
               Microsoft Money category set
             </h3>
             <p className="text-xs text-gray-500 dark:text-gray-400 mt-0.5">
-              Import the classic Money (UK) category tree. Merges with what you have —
-              same-named categories are kept, nothing is deleted.
+              Switch to the classic Money (UK) category tree. Unused default categories
+              are removed; anything your transactions use is kept.
             </p>
           </div>
           <button

--- a/src/services/api/planningService.ts
+++ b/src/services/api/planningService.ts
@@ -423,6 +423,48 @@ export class PlanningService {
     return newCategory;
   }
 
+  /**
+   * Bulk delete of UNUSED categories (the Money-set "replace" import). Cloud
+   * mode goes through the delete_unused_categories RPC, which re-verifies
+   * EVERY row server-side (no transaction/budget/recurring references, no
+   * children outside the batch, never type/transfer categories) — a stale
+   * client snapshot can therefore never destroy referenced data. Returns the
+   * number of rows actually deleted.
+   */
+  static async deleteUnusedCategories(userId: string | null, ids: string[]): Promise<number> {
+    if (ids.length === 0) {
+      return 0;
+    }
+
+    if (this.cloudReady && userId) {
+      const { data, error } = await supabase!.rpc('delete_unused_categories', {
+        p_ids: ids,
+        p_user_id: userId
+      });
+      if (error) throw new Error(handleSupabaseError(error));
+      const deleted = typeof data === 'number' ? data : 0;
+      // The RPC may have skipped rows; refresh the cache from the cloud so
+      // the local view matches what actually survived.
+      const { data: rows, error: readError } = await supabase!
+        .from('categories')
+        .select('*')
+        .eq('user_id', userId);
+      if (!readError && rows) {
+        await this.saveCategories((rows as Row[]).map(categoryFromDb));
+      }
+      return deleted;
+    }
+
+    // Local mode: the in-memory snapshot IS the source of truth, so the
+    // planner has seen every row and a plain filter is safe.
+    const categories = await this.getCategories();
+    const idSet = new Set(ids);
+    const remaining = categories.filter(c => !idSet.has(c.id) && !idSet.has(c.parentId ?? ''));
+    const deleted = categories.length - remaining.length;
+    await this.saveCategories(remaining);
+    return deleted;
+  }
+
   /** Bulk create — one insert round trip instead of N (used by tree imports). */
   static async createCategories(userId: string | null, newCategories: Array<Omit<Category, 'id'>>): Promise<Category[]> {
     if (newCategories.length === 0) {

--- a/src/services/api/supabaseClient.ts
+++ b/src/services/api/supabaseClient.ts
@@ -36,6 +36,10 @@ type Database = {
         Args: { p_ids: string[]; p_category: string; p_user_id?: string };
         Returns: number;
       };
+      delete_unused_categories: {
+        Args: { p_ids: string[]; p_user_id?: string };
+        Returns: number;
+      };
       migrate_categories_atomic: {
         Args: { p_user_id: string; p_categories: Record<string, unknown>[] };
         Returns: Record<string, unknown>[];

--- a/src/test/mocks/AppContextSupabase.ts
+++ b/src/test/mocks/AppContextSupabase.ts
@@ -42,7 +42,7 @@ const baseValue = {
   updateBudget: noop,
   deleteBudget: noop,
   addCategory: noop,
-  importCategoryTree: async () => ({ created: 0, skipped: 0 }),
+  importCategoryTree: async () => ({ created: 0, skipped: 0, pruned: 0, keptForTransactions: 0 }),
   updateCategory: noop,
   deleteCategory: noop,
   addGoal: noop,

--- a/src/utils/__tests__/calculations-decimal.test.ts
+++ b/src/utils/__tests__/calculations-decimal.test.ts
@@ -337,21 +337,61 @@ describe('Decimal Calculation Utilities', () => {
       const startDate = new Date('2023-01-01');
       const endDate = new Date('2023-01-31');
       const transactions = [
-        createMockDecimalTransaction({ 
-          category: 'groceries', 
-          type: 'expense', 
-          amount: toDecimal(100), 
-          date: new Date('2023-01-15') 
+        // Signed convention: expenses are stored negative.
+        createMockDecimalTransaction({
+          category: 'groceries',
+          type: 'expense',
+          amount: toDecimal(-100),
+          date: new Date('2023-01-15')
         }),
-        createMockDecimalTransaction({ 
-          category: 'groceries', 
-          type: 'expense', 
-          amount: toDecimal(50), 
+        createMockDecimalTransaction({
+          category: 'groceries',
+          type: 'expense',
+          amount: toDecimal(-50),
           date: new Date('2023-02-01') // Outside range
         })
       ];
       const result = calculateBudgetSpending(budget, transactions, startDate, endDate);
       expect(result.toString()).toBe('100');
+    });
+
+    it('nets refunds filed under the budget category against the spend (Money model)', () => {
+      const budget = createMockDecimalBudget({ categoryId: 'groceries' });
+      const startDate = new Date('2023-01-01');
+      const endDate = new Date('2023-01-31');
+      const transactions = [
+        createMockDecimalTransaction({
+          category: 'groceries',
+          type: 'expense',
+          amount: toDecimal(-100),
+          date: new Date('2023-01-10')
+        }),
+        // A refund: income by direction, filed under the expense category.
+        createMockDecimalTransaction({
+          category: 'groceries',
+          type: 'income',
+          amount: toDecimal(30),
+          date: new Date('2023-01-20')
+        })
+      ];
+      const result = calculateBudgetSpending(budget, transactions, startDate, endDate);
+      expect(result.toString()).toBe('70');
+    });
+
+    it('clamps at zero when refunds exceed spending in the period', () => {
+      const budget = createMockDecimalBudget({ categoryId: 'groceries' });
+      const transactions = [
+        createMockDecimalTransaction({
+          category: 'groceries',
+          type: 'income',
+          amount: toDecimal(80),
+          date: new Date('2023-01-20')
+        })
+      ];
+      const result = calculateBudgetSpending(
+        budget, transactions, new Date('2023-01-01'), new Date('2023-01-31')
+      );
+      expect(result.toString()).toBe('0');
     });
   });
 
@@ -467,16 +507,17 @@ describe('Decimal Calculation Utilities', () => {
       const startDate = new Date('2023-01-01');
       const endDate = new Date('2023-01-31');
       const transactions = [
-        createMockDecimalTransaction({ 
-          category: 'groceries', 
-          type: 'expense', 
-          amount: toDecimal(100), 
-          date: new Date('2023-01-15') 
+        // Signed convention: expenses are stored negative.
+        createMockDecimalTransaction({
+          category: 'groceries',
+          type: 'expense',
+          amount: toDecimal(-100),
+          date: new Date('2023-01-15')
         }),
-        createMockDecimalTransaction({ 
-          category: 'groceries', 
-          type: 'expense', 
-          amount: toDecimal(50), 
+        createMockDecimalTransaction({
+          category: 'groceries',
+          type: 'expense',
+          amount: toDecimal(-50),
           date: new Date('2023-02-01') // Outside range
         })
       ];
@@ -486,19 +527,28 @@ describe('Decimal Calculation Utilities', () => {
 
     it('calculates category spending without date range', () => {
       const transactions = [
-        createMockDecimalTransaction({ 
-          category: 'groceries', 
-          type: 'expense', 
-          amount: toDecimal(100)
+        createMockDecimalTransaction({
+          category: 'groceries',
+          type: 'expense',
+          amount: toDecimal(-100)
         }),
-        createMockDecimalTransaction({ 
-          category: 'groceries', 
-          type: 'expense', 
-          amount: toDecimal(50)
+        createMockDecimalTransaction({
+          category: 'groceries',
+          type: 'expense',
+          amount: toDecimal(-50)
         })
       ];
       const result = calculateCategorySpending('groceries', transactions);
       expect(result.toString()).toBe('150');
+    });
+
+    it('nets refunds filed under the category (Money model)', () => {
+      const transactions = [
+        createMockDecimalTransaction({ category: 'groceries', type: 'expense', amount: toDecimal(-100) }),
+        createMockDecimalTransaction({ category: 'groceries', type: 'income', amount: toDecimal(25) })
+      ];
+      const result = calculateCategorySpending('groceries', transactions);
+      expect(result.toString()).toBe('75');
     });
   });
 

--- a/src/utils/__tests__/categoryNetting.test.ts
+++ b/src/utils/__tests__/categoryNetting.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect } from 'vitest';
+import { computeExpenseCategoryNetTotals } from '../categoryNetting';
+import type { Transaction, Category } from '../../types';
+
+const categories: Category[] = [
+  { id: 'cat-petrol', name: 'Petrol / Diesel', type: 'expense', level: 'detail', parentId: 'sub-cars' },
+  { id: 'cat-netpay', name: 'Net Pay', type: 'income', level: 'detail', parentId: 'sub-wages' },
+  { id: 'cat-adjust', name: 'Account Adjustments', type: 'both', level: 'detail', parentId: 'sub-adj' },
+];
+
+const txn = (overrides: Partial<Transaction>): Transaction => ({
+  id: `tx-${Math.abs(overrides.amount ?? 0)}-${overrides.category ?? 'none'}-${overrides.type}`,
+  date: new Date('2026-01-01'),
+  amount: -10,
+  description: 'x',
+  category: '',
+  accountId: 'acc-1',
+  type: 'expense',
+  cleared: false,
+  ...overrides,
+});
+
+describe('computeExpenseCategoryNetTotals', () => {
+  it('nets a refund against its expense category (the Microsoft Money model)', () => {
+    const totals = computeExpenseCategoryNetTotals([
+      txn({ type: 'expense', category: 'cat-petrol', amount: -100 }),
+      // Refund: income by direction, filed under the expense category.
+      txn({ type: 'income', category: 'cat-petrol', amount: 50 }),
+    ], categories);
+
+    expect(totals).toEqual([{ key: 'cat-petrol', name: 'Petrol / Diesel', value: 50 }]);
+  });
+
+  it('resolves category NAMES for chart labels, never raw ids', () => {
+    const totals = computeExpenseCategoryNetTotals([
+      txn({ type: 'expense', category: 'cat-petrol', amount: -25 }),
+    ], categories);
+    expect(totals[0].name).toBe('Petrol / Diesel');
+  });
+
+  it('excludes expenses filed under an INCOME category from the expense breakdown', () => {
+    // An outgoing categorised as income (e.g. returned wages) nets the income
+    // side instead — it must not appear as spending.
+    const totals = computeExpenseCategoryNetTotals([
+      txn({ type: 'expense', category: 'cat-netpay', amount: -75 }),
+    ], categories);
+    expect(totals).toEqual([]);
+  });
+
+  it("buckets 'both'-typed and uncategorized rows by transaction direction", () => {
+    const totals = computeExpenseCategoryNetTotals([
+      txn({ type: 'expense', category: 'cat-adjust', amount: -20 }),
+      txn({ type: 'income', category: 'cat-adjust', amount: 5 }),   // income side — excluded
+      txn({ type: 'expense', category: '', amount: -30 }),
+    ], categories);
+
+    expect(totals).toEqual([
+      { key: 'uncategorized', name: 'Uncategorized', value: 30 },
+      { key: 'cat-adjust', name: 'Account Adjustments', value: 20 },
+    ]);
+  });
+
+  it('omits categories whose refunds meet or exceed spending', () => {
+    const totals = computeExpenseCategoryNetTotals([
+      txn({ type: 'expense', category: 'cat-petrol', amount: -40 }),
+      txn({ type: 'income', category: 'cat-petrol', amount: 40 }),
+    ], categories);
+    expect(totals).toEqual([]);
+  });
+
+  it('never counts transfers as spending', () => {
+    const totals = computeExpenseCategoryNetTotals([
+      txn({ type: 'transfer', category: 'transfer-out', amount: -500 }),
+    ], categories);
+    expect(totals).toEqual([]);
+  });
+});

--- a/src/utils/__tests__/categoryTreeImport.test.ts
+++ b/src/utils/__tests__/categoryTreeImport.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { planCategoryTreeImport, type CategoryTreeGroup } from '../categoryTreeImport';
+import { planCategoryTreeImport, planCategoryPrune, type CategoryTreeGroup } from '../categoryTreeImport';
 import { MS_MONEY_CATEGORY_SET } from '../../data/msMoneyCategories';
 import type { Category } from '../../types';
 
@@ -131,5 +131,75 @@ describe('planCategoryTreeImport', () => {
     // 16 subs + 86 details (84 named children + 2 self-named for empty groups).
     expect(plan.totalCount).toBe(16 + 86);
     expect(plan.detailsToCreate).toHaveLength(86);
+  });
+});
+
+describe('planCategoryPrune', () => {
+  const tree: CategoryTreeGroup[] = [
+    { name: 'Cars & Bikes', type: 'expense', children: ['Petrol / Diesel'] },
+    { name: 'Wages & Salary', type: 'income', children: ['Net Pay'] },
+  ];
+
+  const base: Category[] = [
+    ...typeCategories,
+    // In the tree — kept.
+    { id: 'sub-cars', name: 'Cars & Bikes', type: 'expense', level: 'sub', parentId: 'uuid-expense' },
+    { id: 'det-petrol', name: 'Petrol / Diesel', type: 'expense', level: 'detail', parentId: 'sub-cars' },
+    // Default set leftovers — prunable when unused.
+    { id: 'sub-shopping', name: 'Shopping', type: 'expense', level: 'sub', parentId: 'uuid-expense' },
+    { id: 'det-clothing', name: 'Clothing', type: 'expense', level: 'detail', parentId: 'sub-shopping' },
+    // System / transfer — never pruned.
+    { id: 'sub-adj', name: 'Adjustments', type: 'both', level: 'sub', parentId: 'uuid-expense', isSystem: true },
+    { id: 'det-tocat', name: 'To/From Bank', type: 'both', level: 'detail', parentId: 'uuid-transfer', isTransferCategory: true, accountId: 'acc-1' },
+  ];
+
+  it('prunes unused non-tree categories and keeps tree/system/transfer ones', () => {
+    const plan = planCategoryPrune(base, tree, new Set());
+    expect(plan.detailIdsToDelete).toEqual(['det-clothing']);
+    expect(plan.subIdsToDelete).toEqual(['sub-shopping']);
+    expect(plan.keptForTransactionsCount).toBe(0);
+  });
+
+  it('keeps categories that transactions still reference (and their parent sub)', () => {
+    const plan = planCategoryPrune(base, tree, new Set(['det-clothing']));
+    expect(plan.detailIdsToDelete).toEqual([]);
+    expect(plan.subIdsToDelete).toEqual([]);
+    expect(plan.keptForTransactionsCount).toBe(1);
+  });
+
+  it('prunes non-tree details inside a tree sub without touching the sub', () => {
+    const existing: Category[] = [
+      ...base,
+      // A default detail living under the KEPT tree sub.
+      { id: 'det-legacy', name: 'Old Detail', type: 'expense', level: 'detail', parentId: 'sub-cars' },
+    ];
+    const plan = planCategoryPrune(existing, tree, new Set());
+    expect(plan.detailIdsToDelete).toContain('det-legacy');
+    expect(plan.subIdsToDelete).not.toContain('sub-cars');
+  });
+
+  it('prunes legacy defaults even though the old seed stamped them isSystem', () => {
+    // The pre-Money default seed marked ordinary subs (Housing, Transport…)
+    // as isSystem — the flag must not smuggle them (or their details) past
+    // the replace semantics for existing users.
+    const existing: Category[] = [
+      ...typeCategories,
+      { id: 'sub-housing', name: 'Housing', type: 'expense', level: 'sub', parentId: 'uuid-expense', isSystem: true },
+      { id: 'det-rent', name: 'Rent', type: 'expense', level: 'detail', parentId: 'sub-housing' },
+    ];
+    const plan = planCategoryPrune(existing, tree, new Set());
+    expect(plan.detailIdsToDelete).toContain('det-rent');
+    expect(plan.subIdsToDelete).toContain('sub-housing');
+  });
+
+  it('always protects the Adjustments bucket and transfer categories by identity', () => {
+    const existing: Category[] = [
+      ...typeCategories,
+      { id: 'sub-adj2', name: 'Adjustments', type: 'both', level: 'sub', parentId: 'uuid-expense' },
+      { id: 'det-adj2', name: 'Account Adjustments', type: 'both', level: 'detail', parentId: 'sub-adj2' },
+    ];
+    const plan = planCategoryPrune(existing, tree, new Set());
+    expect(plan.detailIdsToDelete).toEqual([]);
+    expect(plan.subIdsToDelete).toEqual([]);
   });
 });

--- a/src/utils/calculations-decimal.ts
+++ b/src/utils/calculations-decimal.ts
@@ -93,14 +93,23 @@ export function calculateBudgetSpending(
   startDate: Date,
   endDate: Date
 ): DecimalInstance {
+  // Money-style netting: income filed under the budget's category (e.g. a
+  // refund on a purchase) reduces the spend instead of counting as income.
   const budgetTransactions = transactions.filter(t =>
-    t.type === 'expense' &&
+    (t.type === 'expense' || t.type === 'income') &&
     t.category === budget.categoryId &&
     t.date >= startDate &&
     t.date <= endDate
   );
 
-  return sumMagnitudes(budgetTransactions);
+  // Signed convention: spending is negative, so net spend is the negated
+  // signed sum. Clamped at zero if refunds exceed spending in the period.
+  const netSigned = budgetTransactions.reduce(
+    (sum, t) => sum.plus(t.amount),
+    new Decimal(0)
+  );
+  const spent = netSigned.negated();
+  return spent.isNegative() ? new Decimal(0) : spent;
 }
 
 /**
@@ -189,10 +198,12 @@ export function calculateCategorySpending(
   startDate?: Date,
   endDate?: Date
 ): DecimalInstance {
-  let filtered = transactions.filter(t => 
-    t.type === 'expense' && t.category === category
+  // Money-style netting (same semantics as calculateBudgetSpending): income
+  // filed under the category — a refund — reduces the spend.
+  let filtered = transactions.filter(t =>
+    (t.type === 'expense' || t.type === 'income') && t.category === category
   );
-  
+
   if (startDate) {
     filtered = filtered.filter(t => t.date >= startDate);
   }
@@ -200,7 +211,9 @@ export function calculateCategorySpending(
     filtered = filtered.filter(t => t.date <= endDate);
   }
 
-  return sumMagnitudes(filtered);
+  const netSigned = filtered.reduce((sum, t) => sum.plus(t.amount), new Decimal(0));
+  const spent = netSigned.negated();
+  return spent.isNegative() ? new Decimal(0) : spent;
 }
 
 /**
@@ -236,23 +249,33 @@ export function calculateSpendingByCategory(
   startDate?: Date,
   endDate?: Date
 ): Record<string, DecimalInstance> {
-  let filtered = transactions.filter(t => t.type === 'expense');
-  
+  // Money-style netting: include income rows so refunds filed under a
+  // category reduce its spend; categories netting ≤ 0 are dropped.
+  let filtered = transactions.filter(t => t.type === 'expense' || t.type === 'income');
+
   if (startDate) {
     filtered = filtered.filter(t => t.date >= startDate);
   }
   if (endDate) {
     filtered = filtered.filter(t => t.date <= endDate);
   }
-  
-  const spending: Record<string, DecimalInstance> = {};
-  
+
+  const netSigned: Record<string, DecimalInstance> = {};
+
   filtered.forEach(t => {
-    if (!spending[t.category]) {
-      spending[t.category] = new Decimal(0);
+    if (!netSigned[t.category]) {
+      netSigned[t.category] = new Decimal(0);
     }
-    spending[t.category] = spending[t.category].plus(t.amount.abs());
+    netSigned[t.category] = netSigned[t.category].plus(t.amount);
   });
+
+  const spending: Record<string, DecimalInstance> = {};
+  for (const [category, net] of Object.entries(netSigned)) {
+    const spent = net.negated();
+    if (spent.gt(0)) {
+      spending[category] = spent;
+    }
+  }
 
   return spending;
 }

--- a/src/utils/categoryNetting.ts
+++ b/src/utils/categoryNetting.ts
@@ -1,0 +1,91 @@
+import { toDecimal } from './decimal';
+import type { Transaction, Category } from '../types';
+
+export interface CategoryNetTotal {
+  /** Category id, or 'uncategorized'. */
+  key: string;
+  /** Display name (resolved from the category; ids never leak into charts). */
+  name: string;
+  /** Net positive spend for the category over the given transactions. */
+  value: number;
+}
+
+/**
+ * Expense totals per category with Microsoft Money netting semantics: a
+ * transaction belongs to the EXPENSE breakdown when its CATEGORY is an
+ * expense category — regardless of the transaction's own direction — and
+ * amounts are netted signed. So a £100 purchase plus a £50 refund filed under
+ * the same expense category shows £50, not £100 (and the refund never
+ * pollutes the income side).
+ *
+ * Bucketing rules:
+ * - category typed 'expense'   → expense breakdown (even for income rows)
+ * - category typed 'income'    → income side (excluded here, even for expenses)
+ * - category typed 'both' / uncategorized → falls back to the transaction type
+ * - transfers are never part of spending
+ *
+ * Categories whose net is zero or negative (refunds ≥ spending) are omitted —
+ * a pie slice cannot represent negative spend.
+ */
+/**
+ * Which report side a transaction belongs to — decided by its CATEGORY's
+ * direction when it has one (Money model), falling back to the transaction's
+ * own direction for 'both'-typed and uncategorized rows.
+ */
+export function bucketByCategoryDirection(
+  t: Transaction,
+  categoryById: ReadonlyMap<string, Category>
+): 'income' | 'expense' | 'transfer' {
+  if (t.type === 'transfer') return 'transfer';
+  const category = t.category ? categoryById.get(t.category) : undefined;
+  if (category?.type === 'expense') return 'expense';
+  if (category?.type === 'income') return 'income';
+  return t.type;
+}
+
+export function computeExpenseCategoryNetTotals(
+  transactions: Transaction[],
+  categories: Category[]
+): CategoryNetTotal[] {
+  const categoryById = new Map(categories.map(c => [c.id, c]));
+  const totals = new Map<string, ReturnType<typeof toDecimal>>();
+
+  for (const t of transactions) {
+    if (bucketByCategoryDirection(t, categoryById) !== 'expense') continue;
+
+    const key = t.category && t.category.trim() !== '' ? t.category : 'uncategorized';
+    const previous = totals.get(key) ?? toDecimal(0);
+    // Signed convention: spending is negative, so negate to accumulate spend;
+    // an income-row refund (+) filed under this category nets the total down.
+    totals.set(key, previous.minus(toDecimal(t.amount)));
+  }
+
+  const entries = [...totals.entries()]
+    .map(([key, total]) => ({
+      key,
+      name: key === 'uncategorized'
+        ? 'Uncategorized'
+        : categoryById.get(key)?.name ?? key,
+      value: total.toNumber(),
+    }))
+    .filter(entry => entry.value > 0);
+
+  // Money's tree repeats detail names across groups ("Cars & Bikes >
+  // Insurance" and "Household > Insurance") — qualify duplicates with their
+  // parent so chart slices stay distinguishable.
+  const nameCounts = new Map<string, number>();
+  entries.forEach(e => nameCounts.set(e.name, (nameCounts.get(e.name) ?? 0) + 1));
+
+  return entries
+    .map(entry => {
+      if ((nameCounts.get(entry.name) ?? 0) > 1 && entry.key !== 'uncategorized') {
+        const category = categoryById.get(entry.key);
+        const parent = category?.parentId ? categoryById.get(category.parentId) : undefined;
+        if (parent) {
+          return { ...entry, name: `${parent.name}: ${entry.name}` };
+        }
+      }
+      return entry;
+    })
+    .sort((a, b) => b.value - a.value);
+}

--- a/src/utils/categoryTreeImport.ts
+++ b/src/utils/categoryTreeImport.ts
@@ -29,6 +29,109 @@ export interface CategoryTreePlan {
 
 const norm = (name: string): string => name.trim().toLowerCase();
 
+export interface CategoryPrunePlan {
+  /** Detail-level ids safe to delete (unused, non-system, not in the tree). */
+  detailIdsToDelete: string[];
+  /** Sub-level ids safe to delete (all children pruned, not a tree group). */
+  subIdsToDelete: string[];
+  /** Categories kept only because transactions still reference them. */
+  keptForTransactionsCount: number;
+}
+
+/**
+ * Plan the removal of categories that are NOT part of the given tree — used to
+ * turn "merge the Money set in" into "make my categories BE the Money set".
+ *
+ * Never prunes: type anchors, system categories, transfer categories, anything
+ * under the Transfer anchor, tree members, or any category still referenced by
+ * a transaction (those are counted in keptForTransactionsCount instead).
+ */
+export function planCategoryPrune(
+  existing: Category[],
+  tree: CategoryTreeGroup[],
+  usedCategoryIds: ReadonlySet<string>
+): CategoryPrunePlan {
+  const incomeAnchor = existing.find(c => c.level === 'type' && c.type === 'income')?.id;
+  const expenseAnchor = existing.find(c => c.level === 'type' && c.type === 'expense')?.id;
+
+  const groupNames = new Map<string, Set<string>>([
+    ['income', new Set(tree.filter(g => g.type === 'income').map(g => norm(g.name)))],
+    ['expense', new Set(tree.filter(g => g.type === 'expense').map(g => norm(g.name)))],
+  ]);
+  // Details keyed by (type, group name, detail name); empty groups self-fill.
+  const detailKeys = new Set<string>();
+  for (const group of tree) {
+    const children = group.children.length > 0 ? group.children : [group.name];
+    for (const child of children) {
+      detailKeys.add(`${group.type}:${norm(group.name)}:${norm(child)}`);
+    }
+  }
+
+  const anchorTypeOf = (parentId: string | null | undefined): 'income' | 'expense' | null =>
+    parentId === incomeAnchor ? 'income' : parentId === expenseAnchor ? 'expense' : null;
+
+  // Protection is by IDENTITY, not by the isSystem flag: the legacy seed
+  // stamped isSystem on ordinary default subs (Housing, Transport, …) — the
+  // very categories this prune exists to remove. The genuinely load-bearing
+  // rows are the type anchors, transfer categories, and the Adjustments
+  // bucket used by balance-repair tooling (matched by name — cloud ids are
+  // per-user UUIDs).
+  const isAdjustmentsBucket = (c: Category): boolean =>
+    (c.level === 'sub' && norm(c.name) === 'adjustments' && c.type === 'both') ||
+    (c.level === 'detail' && norm(c.name) === 'account adjustments' && c.type === 'both');
+
+  const isProtected = (c: Category): boolean =>
+    c.level === 'type' || c.isTransferCategory === true ||
+    c.id === 'transfer-in' || c.id === 'transfer-out' ||
+    isAdjustmentsBucket(c);
+
+  const detailIdsToDelete: string[] = [];
+  const subIdsToDelete: string[] = [];
+  let keptForTransactionsCount = 0;
+
+  const subs = existing.filter(c => c.level === 'sub' && anchorTypeOf(c.parentId) !== null);
+
+  for (const sub of subs) {
+    const subProtected = isProtected(sub);
+    const subType = anchorTypeOf(sub.parentId)!;
+    const subInTree = groupNames.get(subType)!.has(norm(sub.name));
+
+    // A protected sub is never deleted itself, but its non-tree details ARE
+    // still candidates — otherwise legacy isSystem subs would smuggle their
+    // whole default detail set past the prune.
+    const details = existing.filter(c => c.level === 'detail' && c.parentId === sub.id);
+    let allDetailsPruned = true;
+
+    for (const detail of details) {
+      if (isProtected(detail)) {
+        allDetailsPruned = false;
+        continue;
+      }
+      const detailInTree = detailKeys.has(`${subType}:${norm(sub.name)}:${norm(detail.name)}`);
+      if (detailInTree) {
+        allDetailsPruned = false;
+        continue;
+      }
+      if (usedCategoryIds.has(detail.id)) {
+        keptForTransactionsCount += 1;
+        allDetailsPruned = false;
+        continue;
+      }
+      detailIdsToDelete.push(detail.id);
+    }
+
+    if (!subProtected && !subInTree && allDetailsPruned) {
+      if (usedCategoryIds.has(sub.id)) {
+        keptForTransactionsCount += 1;
+      } else {
+        subIdsToDelete.push(sub.id);
+      }
+    }
+  }
+
+  return { detailIdsToDelete, subIdsToDelete, keptForTransactionsCount };
+}
+
 /**
  * Diff a Money-style category tree against the user's existing categories.
  *

--- a/supabase/migrations/20260708160000_delete_unused_categories.sql
+++ b/supabase/migrations/20260708160000_delete_unused_categories.sql
@@ -1,0 +1,68 @@
+-- Safe category pruning for the "switch to the Money set" import.
+--
+-- IMPORTANT: Run this SQL in the Supabase SQL Editor to apply to production DB.
+-- Must be applied BEFORE the matching client deploys (the client fails closed
+-- if the function is missing — the import succeeds but the prune reports an
+-- error instead of falling back to an unguarded delete).
+--
+-- Why: the client plans which categories to remove from its in-memory
+-- snapshot, but that snapshot can be silently incomplete (a cloud read that
+-- fell back to an empty local cache). Deleting a category a transaction still
+-- references orphans that transaction's categorization permanently —
+-- transactions.category is TEXT with no FK. This RPC re-checks EVERYTHING
+-- server-side, so a stale client can never destroy referenced data:
+--   - never deletes type-level or transfer categories
+--   - never deletes a category referenced by a transaction, budget, or
+--     recurring transaction (by category text id, or budgets.category_id)
+--   - never deletes a category that still has a child OUTSIDE the batch
+--     (blocks the parent_id ON DELETE CASCADE from killing unseen children)
+-- Rows failing any check are silently skipped; the count of actual deletions
+-- is returned.
+
+BEGIN;
+
+CREATE OR REPLACE FUNCTION public.delete_unused_categories(
+  p_ids uuid[],
+  p_user_id uuid DEFAULT NULL
+)
+RETURNS integer
+LANGUAGE plpgsql SECURITY INVOKER
+SET search_path = public
+AS $$
+DECLARE
+  v_count integer;
+BEGIN
+  DELETE FROM public.categories c
+   WHERE c.id = ANY(p_ids)
+     AND (p_user_id IS NULL OR c.user_id = p_user_id)
+     AND c.level <> 'type'
+     AND c.is_transfer_category IS NOT TRUE
+     AND NOT EXISTS (
+       SELECT 1 FROM public.transactions t
+        WHERE t.user_id = c.user_id AND t.category = c.id::text
+     )
+     AND NOT EXISTS (
+       SELECT 1 FROM public.budgets b
+        WHERE b.user_id = c.user_id
+          AND (b.category = c.id::text OR b.category_id = c.id)
+     )
+     AND NOT EXISTS (
+       SELECT 1 FROM public.recurring_transactions r
+        WHERE r.category = c.id::text
+     )
+     AND NOT EXISTS (
+       -- A child that is NOT part of this batch keeps its parent alive.
+       SELECT 1 FROM public.categories ch
+        WHERE ch.parent_id = c.id
+          AND NOT (ch.id = ANY(p_ids))
+     );
+
+  GET DIAGNOSTICS v_count = ROW_COUNT;
+  RETURN v_count;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.delete_unused_categories(uuid[], uuid) FROM public, anon;
+GRANT EXECUTE ON FUNCTION public.delete_unused_categories(uuid[], uuid) TO authenticated, service_role;
+
+COMMIT;


### PR DESCRIPTION
Three requests from the owner, one PR (as asked).

## 1. Your categories become the Money set

- **"Import Money set" now replaces**: the Money tree is imported and unused default categories are removed. Anything a transaction, budget, or recurring template references is always kept — and that guarantee is enforced **in the database**, not just the client: deletions go through a new `delete_unused_categories` RPC that re-verifies every row server-side. (The adversarial review rated the client-only version **critical** — a silently-empty transaction cache could have orphaned real categorizations. The RPC closes it for good.)
- **New users start with the Money set** as their default tree (plus the system anchors, transfer in/out, and the Adjustments bucket).
- Review catch worth reading twice: the legacy seed stamped `isSystem` on ordinary defaults like *Housing* — protection by flag would have made the replace a **silent no-op for every existing user**. The planner now protects by identity instead.

> ⚠️ Note for the owner: the default set for new users includes the personal group names from your Money file ("Steve - …", "Gem - …"). That's what was asked for — flagging it so it's a decision, not an accident, for the multi-tenant future.

## 2. Batch editing — the click-economy fix

- **Single click** on a register row pins a condensed **Quick Edit** panel under the table: date, description, category, **Save**, **Save & Next** (walks straight down the list). Both directions' categories are listed.
- **Double click** still opens the full modal — which now also has **Save & Next**: save, stay open, flip to the next transaction.
- Robustness from review: panel syncs by transaction id (background refreshes can't clobber typing), date is validated, and the Delete-key shortcut no longer fires while typing in inputs.

## 3. Cross-type categorization (the Money model)

- New toggle under Type: *"Categorise as an expense/income"* — a £50 refund (income by sign) files under the expense category it refunds. Signs, balances, and money math are untouched; only the category browsing flips.
- **Reports and budgets net by category direction** — the refund *reduces* that expense category everywhere: pie chart, PDF export, summary cards, monthly trend (review caught the trend/summary disagreeing with the pie), budget spend, and spending alerts.
- Bonus fixes en route: pie/PDF labels now show category **names** (they showed raw UUIDs after cloud migration), and duplicate Money names ("Insurance") are qualified by parent group.
- Guardrail: cross-type filings **never teach payee memory** — one PayPal refund correction must not stamp "Shopping" onto every future incoming PayPal payment.

## ⚠️ Migration
`supabase/migrations/20260708160000_delete_unused_categories.sql` — run in the Supabase SQL editor **before** using the Money-set switch. The client fails closed (import succeeds, prune reports an error) if it's missing; there is deliberately **no** unguarded fallback.

## Review
Adversarial workflow: 3 reviewers → 14 findings → per-finding refutation (17 agents, ~1.4M tokens). **11 confirmed** (1 critical, 3 major) — all fixed pre-commit. 2 refuted.

## Verification
- `typecheck:strict` ✅ · app typecheck ✅ · `lint` ✅ (zero warnings) · `build` ✅
- Full suite: **2,816 passed** (+21 new tests: prune planner incl. the legacy-isSystem case, netting semantics, default-set shape, refund netting for budgets/categories)

🤖 Generated with [Claude Code](https://claude.com/claude-code)