### PR TITLE
feat(register): single-viewport layout, one bottom dock, optional category

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -1,0 +1,11 @@
+{
+  "version": "0.0.1",
+  "configurations": [
+    {
+      "name": "wealthtracker-dev",
+      "runtimeExecutable": "npm",
+      "runtimeArgs": ["run", "dev"],
+      "port": 5173
+    }
+  ]
+}

--- a/src/components/EditTransactionModal.tsx
+++ b/src/components/EditTransactionModal.tsx
@@ -523,6 +523,9 @@ export default function EditTransactionModal({ isOpen, onClose, transaction, def
                   </button>
                 )}
               </div>
+              {/* Category is deliberately optional for income/expense — an
+                  uncategorised transaction sits in the virtual "Uncategorised"
+                  bucket. Transfers still require their target account. */}
               <select
                 value={formData.category}
                 onChange={(e) => {
@@ -530,7 +533,7 @@ export default function EditTransactionModal({ isOpen, onClose, transaction, def
                   updateField('category', val);
                 }}
                 className="w-full px-3 py-3 sm:py-2 h-12 sm:h-[42px] text-base sm:text-sm bg-white dark:bg-gray-700 border-2 border-gray-300 dark:border-gray-500 rounded-lg focus:outline-none focus:ring-2 focus:ring-primary dark:focus:ring-blue-400 focus:border-transparent dark:text-white"
-                required
+                required={formData.type === 'transfer'}
                 aria-label="Transaction category"
               >
                 {formData.type === 'transfer' ? (

--- a/src/pages/AccountTransactions.tsx
+++ b/src/pages/AccountTransactions.tsx
@@ -1,10 +1,10 @@
-import React, { useState, useMemo, useRef, useEffect, useCallback } from 'react';
+import React, { useState, useMemo, useRef, useEffect, useLayoutEffect, useCallback } from 'react';
 import { useParams, useNavigate, useLocation } from 'react-router-dom';
 import { useApp } from '../contexts/AppContextSupabase';
 import { parseMoneyInput } from '../utils/decimal';
 import { preserveDemoParam } from '../utils/navigation';
 import { useCurrencyDecimal } from '../hooks/useCurrencyDecimal';
-import { ArrowLeftIcon, SearchIcon, PlusIcon, CalendarIcon, XIcon, SettingsIcon } from '../components/icons';
+import { ArrowLeftIcon, SearchIcon, PlusIcon, CalendarIcon, XIcon, SettingsIcon, FilterIcon, ChevronUpIcon, ChevronDownIcon, MaximizeIcon, MinimizeIcon } from '../components/icons';
 import LocalMerchantLogo from '../components/LocalMerchantLogo';
 import DatePicker from '../components/common/DatePicker';
 import EditTransactionModal from '../components/EditTransactionModal';
@@ -52,6 +52,27 @@ export default function AccountTransactions() {
   const [dateFrom, setDateFrom] = useState('');
   const [dateTo, setDateTo] = useState('');
   const [typeFilter, setTypeFilter] = useState<'all' | 'income' | 'expense' | 'transfer'>('all');
+  // Single-viewport layout: search collapses behind a toggle, and the table
+  // can expand over the bottom add/edit dock for bulk browsing.
+  const [showFilters, setShowFilters] = useState(false);
+  const [tableExpanded, setTableExpanded] = useState(false);
+  // The table's height is MEASURED (viewport minus everything above it and a
+  // reserve for the bottom dock) so the whole page always fits one screen,
+  // whatever banners/nav are present. Fixed calc() guesses drift.
+  const tableWrapRef = useRef<HTMLDivElement>(null);
+  const [tableHeight, setTableHeight] = useState(480);
+  const measureTableHeight = useCallback(() => {
+    const el = tableWrapRef.current;
+    if (!el) return;
+    const top = el.getBoundingClientRect().top;
+    const dockReserve = tableExpanded ? 32 : 224; // dock (~178) + gaps/padding, or just padding
+    setTableHeight(Math.max(240, window.innerHeight - top - dockReserve));
+  }, [tableExpanded]);
+  useLayoutEffect(() => {
+    measureTableHeight();
+    window.addEventListener('resize', measureTableHeight);
+    return () => window.removeEventListener('resize', measureTableHeight);
+  }, [measureTableHeight, showFilters]);
   const [sortField, setSortField] = useState<'date' | 'description' | 'amount' | 'category' | 'tags'>('date');
   const [sortDirection, setSortDirection] = useState<'asc' | 'desc'>('asc');
   
@@ -687,9 +708,33 @@ export default function AccountTransactions() {
         </div>
       </div>
       
-      {/* Main content */}
-      <div className="grid gap-6">
-      {/* Search and Filter Bar */}
+      {/* Main content — single-viewport layout: toolbar, table, bottom dock */}
+      <div className="flex flex-col gap-3">
+      {/* Toolbar: filter toggle + table size toggle */}
+      <div className="flex items-center justify-between">
+        <button
+          onClick={() => setShowFilters(prev => !prev)}
+          className="flex items-center gap-2 px-3 py-1.5 text-sm border border-gray-300 dark:border-gray-600 rounded-lg text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors"
+        >
+          <FilterIcon size={14} />
+          Search &amp; filters
+          {(searchTerm || typeFilter !== 'all' || dateFrom || dateTo) && (
+            <span className="w-2 h-2 rounded-full bg-blue-500" title="Filters active" />
+          )}
+          {showFilters ? <ChevronUpIcon size={14} /> : <ChevronDownIcon size={14} />}
+        </button>
+        <button
+          onClick={() => setTableExpanded(prev => !prev)}
+          className="flex items-center gap-2 px-3 py-1.5 text-sm border border-gray-300 dark:border-gray-600 rounded-lg text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors"
+          title={tableExpanded ? 'Shrink the table and show the add/edit bar' : 'Expand the table over the add/edit bar'}
+        >
+          {tableExpanded ? <MinimizeIcon size={14} /> : <MaximizeIcon size={14} />}
+          {tableExpanded ? 'Standard view' : 'Expand table'}
+        </button>
+      </div>
+
+      {/* Search and Filter Bar (collapsed by default to keep one viewport) */}
+      {showFilters && (
       <div className="bg-white dark:bg-gray-800 rounded-2xl shadow-lg border border-gray-100 dark:border-gray-700 p-4">
         <div className="flex flex-col gap-4">
           <div className="flex flex-col lg:flex-row gap-4">
@@ -788,24 +833,18 @@ export default function AccountTransactions() {
                 </button>
               )}
             </div>
-            {/* Compact View Toggle - Hidden but kept in code */}
-            {/* <div className="flex-1 flex justify-end">
-              <button
-                onClick={() => setCompactView(!compactView)}
-                className="flex items-center gap-2 px-3 py-3 sm:py-2 text-sm border-2 border-gray-400 dark:border-gray-500 rounded-2xl hover:bg-gray-50 dark:hover:bg-gray-600 transition-colors min-h-[48px] sm:min-h-[auto]"
-                title={compactView ? "Expand view" : "Compact view"}
-              >
-                {compactView ? <MaximizeIcon size={18} /> : <MinimizeIcon size={18} />}
-                <span className="hidden sm:inline">{compactView ? 'Expand' : 'Compact'}</span>
-              </button>
-            </div> */}
           </div>
         </div>
       </div>
-      
-      {/* Transactions Table - Updated Layout */}
-      <div 
-        className="h-[calc(100vh-22rem)] min-h-[400px] overflow-hidden"
+      )}
+
+      {/* Transactions Table — measured to keep the whole page in one viewport;
+          the table scrolls internally. Expanded mode trades the bottom dock
+          for more visible rows. */}
+      <div
+        ref={tableWrapRef}
+        style={{ height: tableHeight }}
+        className="overflow-hidden"
       >
         <VirtualizedTable
           items={displayRows}
@@ -836,8 +875,10 @@ export default function AccountTransactions() {
         />
       </div>
 
-      {/* Quick edit: single click pins this condensed editor under the table */}
-      {quickEditTarget && !isEditModalOpen && (
+      {/* Bottom dock — ONE always-visible bar (hidden only in expanded mode):
+          editing the selected row, or adding a new transaction when nothing
+          is selected. */}
+      {!tableExpanded && quickEditTarget && !isEditModalOpen && (
         <QuickEditTransactionPanel
           transaction={quickEditTarget}
           onNext={
@@ -852,8 +893,9 @@ export default function AccountTransactions() {
         />
       )}
 
-      {/* Quick Add Transaction */}
-      <div className="bg-white dark:bg-gray-800 rounded-xl shadow-md border border-gray-100 dark:border-gray-700 px-4 py-3 mt-4">
+      {/* Quick Add Transaction (the dock's default mode) */}
+      {!tableExpanded && !(quickEditTarget && !isEditModalOpen) && (
+      <div className="bg-white dark:bg-gray-800 rounded-xl shadow-md border border-gray-100 dark:border-gray-700 px-4 py-3">
         <form onSubmit={handleQuickAdd}>
           {/* Row 1: Date | Type | Description */}
           <div className="flex items-end gap-3">
@@ -964,8 +1006,9 @@ export default function AccountTransactions() {
           )}
         </form>
       </div>
+      )}
       </div>
-      
+
       {/* Edit Modal */}
       {selectedTransaction && (
         <EditTransactionModal

--- a/src/services/validationService.ts
+++ b/src/services/validationService.ts
@@ -34,7 +34,11 @@ export const transactionSchema = z.object({
     { message: 'Amount must be greater than 0' }
   ),
   type: z.enum(['income', 'expense']),
-  category: z.string().min(1, 'Category is required'),
+  // Category is optional (the Microsoft Money model): an empty category means
+  // the transaction sits in the virtual "Uncategorised" bucket that reports,
+  // budgets, and the register all understand. Transfers enforce their target
+  // account separately in the transaction modals.
+  category: z.string().optional().default(''),
   subcategory: z.string().optional(),
   accountId: z.string().uuid('Invalid account ID'),
   tags: z.array(z.string().transform(tag => sanitizeText(tag))).optional(),


### PR DESCRIPTION
## One viewable page — verified live in a browser

The account register now fits a single viewport, exactly as sketched:

1. **Top**: compact account header. **Search & filters collapse behind a toggle** in a slim toolbar (a blue dot shows when filters are active) — collapsed by default to reclaim the space.
2. **Middle**: the transaction table fills all remaining height and scrolls **internally** — its height is *measured* (viewport minus everything above it minus the dock), not guessed with `calc()`, so it adapts to any banner/nav and never forces page scroll.
3. **Bottom**: **one** always-visible dock. You were right that two look-alike bars was wrong — the pre-existing Quick Add form and the new Quick Edit panel are now a single dock: Add by default, flipping to Edit when a row is selected (X returns to Add).
4. **"Expand table"** trades the dock for more visible rows; "Standard view" restores it.

Verified with a live dev server (demo mode) at multiple viewport sizes: **zero page overflow** in standard, expanded, and filters-open modes; row-click dock switching and Save & Next confirmed working; no console errors.

## Category is now optional (Money model)

- "Save Changes" no longer demands a category for income/expense — only transfers still require their target account. The validation schema allows empty.
- No physical "Uncategorised" category row is needed: an empty category **is** the virtual Uncategorised bucket, and every consumer already treats it that way (reports show "Uncategorized", the register shows an "Add category…" hint, netting/budgets bucket it by transaction direction).
- Verified live: cleared a category in the modal, saved without error, register updated.

## Verification
- `typecheck:strict` ✅ · app typecheck ✅ · `lint` ✅ · `build` ✅ · full suite **2,816 passed**
- Live browser verification of all layout modes + the no-category save path

No migration needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)