### PR TITLE
fix(register): click the page background to deselect and restore Quick Add

### DIFF
--- a/src/components/QuickEditTransactionPanel.tsx
+++ b/src/components/QuickEditTransactionPanel.tsx
@@ -117,7 +117,9 @@ export default function QuickEditTransactionPanel({
   };
 
   return (
-    <div className="mt-3 bg-white dark:bg-gray-800 rounded-xl shadow-md border-2 border-[#6B86B3] px-4 py-3">
+    // data-quick-edit-panel: the register's click-outside-to-deselect handler
+    // treats clicks inside this panel as "keep the selection".
+    <div data-quick-edit-panel className="mt-3 bg-white dark:bg-gray-800 rounded-xl shadow-md border-2 border-[#6B86B3] px-4 py-3">
       <div className="flex flex-col lg:flex-row lg:items-end gap-3">
         <div className="flex items-center gap-2 lg:hidden">
           <span className="text-xs font-semibold text-gray-600 dark:text-gray-300">Quick edit</span>

--- a/src/pages/AccountTransactions.tsx
+++ b/src/pages/AccountTransactions.tsx
@@ -347,6 +347,28 @@ export default function AccountTransactions() {
     [transactionsWithBalance, selectedTransactionId]
   );
 
+  // Clicking the page background deselects: the row un-highlights and the
+  // bottom dock flips back from Quick Edit to Quick Add. Clicks inside the
+  // table, the dock, or any dialog keep the selection.
+  useEffect(() => {
+    if (!selectedTransactionId) return;
+    const handlePointerDown = (e: MouseEvent) => {
+      const target = e.target as HTMLElement | null;
+      if (!target) return;
+      if (
+        target.closest('[data-transaction-table]') ||
+        target.closest('[data-quick-edit-panel]') ||
+        target.closest('[role="dialog"]')
+      ) {
+        return;
+      }
+      setSelectedTransactionId(null);
+      setSelectedTransaction(null);
+    };
+    document.addEventListener('mousedown', handlePointerDown);
+    return () => document.removeEventListener('mousedown', handlePointerDown);
+  }, [selectedTransactionId]);
+
   // Next non-summary row below the given one in the CURRENT visible order —
   // powers "Save & Next" in both the quick-edit panel and the full modal.
   const getNextTransactionId = useCallback((currentId: string): string | null => {
@@ -843,6 +865,7 @@ export default function AccountTransactions() {
           for more visible rows. */}
       <div
         ref={tableWrapRef}
+        data-transaction-table
         style={{ height: tableHeight }}
         className="overflow-hidden"
       >


### PR DESCRIPTION
## What

Single-clicking a row flips the bottom dock to Quick Edit — but the only way back to Quick Add was the small ×. Now **a click anywhere on the page background deselects**: the highlighted row clears and the dock flips back to Quick Add, exactly as suggested.

Clicks that KEEP the selection (so nothing surprising happens mid-edit):
- inside the transaction table (row clicks re-select / open the modal as before)
- inside the Quick Edit panel itself
- inside any open dialog (edit modal, delete confirm)

## Verified live (dev preview, demo mode)
- Background mousedown → row un-highlights, dock returns to Quick Add ✅
- Mousedown in the panel's inputs → selection kept ✅
- Mousedown inside the table → selection kept ✅
- No new console errors (pre-existing demo-mode bank-connection auth noise flagged as a separate follow-up task)

## Gates
`typecheck:strict` ✅ · app typecheck ✅ · `lint` ✅ · `build` ✅ · full suite **2,816 passed**

🤖 Generated with [Claude Code](https://claude.com/claude-code)