### PR TITLE
fix(banking): stop bank-connections fetch loop in signed-out/demo sessions

### DIFF
--- a/src/hooks/useAccountBankSync.ts
+++ b/src/hooks/useAccountBankSync.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useAuth as useClerkAuth } from '@clerk/clerk-react';
 import { bankConnectionService, type BankConnection } from '../services/bankConnectionService';
 import { useToast } from '../contexts/ToastContext';
@@ -52,7 +52,7 @@ export function buildAccountBankLinks(connections: BankConnection[]): Map<string
 
 export function useAccountBankSync(options?: { onSynced?: () => void | Promise<void> }): UseAccountBankSyncResult {
   const onSynced = options?.onSynced;
-  const { getToken } = useClerkAuth();
+  const { getToken, isSignedIn } = useClerkAuth();
   const { showSuccess, showWarning, showError } = useToast();
   const [connections, setConnections] = useState<BankConnection[]>([]);
   const [syncingConnectionIds, setSyncingConnectionIds] = useState<Set<string>>(new Set());
@@ -62,13 +62,27 @@ export function useAccountBankSync(options?: { onSynced?: () => void | Promise<v
     setConnections(bankConnectionService.getConnections());
   }, []);
 
-  // Keep the auth-token provider current and (re)load connections. Depending on
-  // getToken means that if the first mount raced ahead of Clerk minting a token,
-  // we re-fetch once a usable token exists instead of staying empty all visit.
+  // Register the auth-token provider ONCE with a stable closure that reads the
+  // latest getToken via a ref — Clerk's getToken is not referentially stable,
+  // and keying an effect on it re-ran the fetch on every render (a loop of
+  // "Missing authentication token" errors in demo/signed-out mode).
+  const getTokenRef = useRef(getToken);
+  getTokenRef.current = getToken;
   useEffect(() => {
-    bankConnectionService.setAuthTokenProvider(() => getToken());
+    bankConnectionService.setAuthTokenProvider(() => getTokenRef.current());
+  }, []);
+
+  // Load connections only when signed in. isSignedIn flipping false→true is
+  // the recover-on-token-arrival signal (a first mount that raced ahead of
+  // Clerk still re-fetches once the session exists); signed-out/demo sessions
+  // never fetch and never log auth errors.
+  useEffect(() => {
+    if (!isSignedIn) {
+      setConnections([]);
+      return;
+    }
     void reloadConnections();
-  }, [getToken, reloadConnections]);
+  }, [isSignedIn, reloadConnections]);
 
   const linksByAccountId = useMemo(() => buildAccountBankLinks(connections), [connections]);
 


### PR DESCRIPTION
## The bug

`useAccountBankSync` keyed its load effect on Clerk's `getToken`, which is **not referentially stable** — the effect re-ran on every render. In signed-out/demo sessions each run failed with `Missing authentication token`, flooding the console (~48 errors in a short visit).

## The fix

- The auth-token provider is registered **once**, with a stable closure that reads the latest `getToken` through a ref — no more effect churn.
- Connections load **only when `isSignedIn`** is true. The `false→true` transition is the recover-on-token-arrival signal (a mount that races ahead of Clerk still fetches as soon as the session exists — the behavior added for signed-in users in PR #51 is preserved, just keyed on a stable boolean instead of an unstable function identity).
- Signed-out sessions never fetch and never log.

## Verified live (dev preview, `/accounts?demo=true`)
- Full console error buffer scanned: **zero** "Missing authentication token" entries across the session (previously ~48) ✅
- Accounts page renders normally in demo mode ✅
- Unrelated pre-existing signed-out decryption noise observed during verification → spun off as a separate task chip.

## Gates
`typecheck:strict` ✅ · app typecheck ✅ · `lint` ✅ · `build` ✅ · full suite **2,816 passed**

🤖 Generated with [Claude Code](https://claude.com/claude-code)