### PR TITLE
fix(storage): persist the local encryption key across sessions + self-heal

### DIFF
--- a/AUDIT_2026-06-11_PRIVACY_GDPR.md
+++ b/AUDIT_2026-06-11_PRIVACY_GDPR.md
@@ -92,6 +92,12 @@ polish.
 
 ### 🟠 PII at rest
 - Financial data is encrypted in IndexedDB (encryptedStorageService) — good.
+  - *Updated 2026-07-08:* the AES key now persists in localStorage next to the
+    data (it was session-scoped, which orphaned all IndexedDB data every new
+    session — permanent local data loss). With a client-side key stored beside
+    the ciphertext, this at-rest encryption is same-origin obfuscation, not
+    protection against an attacker with origin access. Real protection for
+    signed-in users comes from the data living in Supabase behind RLS.
 - One plaintext localStorage item holds per-user usage counts keyed by user id
   (`usage_${user.id}`, SubscriptionContext.tsx:183) — low sensitivity but
   inconsistent with the encrypted-everything-else posture; consider moving it

--- a/src/services/encryptedStorageService.test.ts
+++ b/src/services/encryptedStorageService.test.ts
@@ -4,7 +4,7 @@
  */
 
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
-import { encryptedStorage, STORAGE_KEYS } from './encryptedStorageService';
+import { encryptedStorage, EncryptedStorageService, STORAGE_KEYS } from './encryptedStorageService';
 import { indexedDBService } from './indexedDBService';
 
 // Mock indexedDBService
@@ -459,25 +459,149 @@ describe('EncryptedStorageService', () => {
   });
 
   describe('Encryption Key Management', () => {
-    it('generates new encryption key if none exists', () => {
-      mockSessionStorage.getItem.mockReturnValue(null);
+    // In-memory web-storage stub honoring the Storage read/write surface.
+    const memStorage = (initial: Record<string, string> = {}) => {
+      const map = new Map(Object.entries(initial));
+      return {
+        getItem: (k: string) => map.get(k) ?? null,
+        setItem: (k: string, v: string) => { map.set(k, v); },
+        removeItem: (k: string) => { map.delete(k); },
+        map,
+      };
+    };
 
-      // Create new instance to trigger key generation
-      const _newService = new (encryptedStorage.constructor as any)();
+    // Round-trip helper: setItem captures the encrypted record the service
+    // hands IndexedDB; getItem replays it into another (or the same) instance.
+    const encryptVia = async (service: EncryptedStorageService, value: unknown) => {
+      await service.setItem('probe', value);
+      const call = vi.mocked(indexedDBService.put).mock.calls.at(-1);
+      return call![1] as { data: string; timestamp: number; encrypted: boolean; compressed: boolean };
+    };
+    const decryptVia = async (service: EncryptedStorageService, record: object) => {
+      vi.mocked(indexedDBService.get).mockResolvedValueOnce(record);
+      return service.getItem('probe');
+    };
 
-      expect(mockSessionStorage.setItem).toHaveBeenCalledWith(
-        'wt_enc_key',
-        expect.any(String)
-      );
+    it('persists a new encryption key in localStorage (data lives in IndexedDB, which outlives the session)', () => {
+      const local = memStorage();
+      const session = memStorage();
+      void new EncryptedStorageService({ localStorage: local, sessionStorage: session });
+
+      expect(local.map.get('wt_enc_key')).toEqual(expect.any(String));
+      expect(session.map.has('wt_enc_key')).toBe(false);
     });
 
-    it('reuses existing encryption key', () => {
-      mockSessionStorage.getItem.mockReturnValue('existing-key');
-      
-      // Create new instance
-      const _newService = new (encryptedStorage.constructor as any)();
+    it('data written in one session is readable in the next (the actual bug being fixed)', async () => {
+      const local = memStorage();
+      const writer = new EncryptedStorageService({ localStorage: local, sessionStorage: memStorage() });
+      const record = await encryptVia(writer, { balance: 123.45 });
 
+      // "Next session": fresh instance, fresh sessionStorage, SAME localStorage.
+      const reader = new EncryptedStorageService({ localStorage: local, sessionStorage: memStorage() });
+      await expect(decryptVia(reader, record)).resolves.toEqual({ balance: 123.45 });
+      expect(indexedDBService.delete).not.toHaveBeenCalled();
+    });
+
+    it('migrates a legacy session-scoped key so earlier data stays readable across sessions', async () => {
+      // Legacy writer: no localStorage at all → key lives in sessionStorage.
+      const session = memStorage();
+      const writer = new EncryptedStorageService({ localStorage: null, sessionStorage: session });
+      const record = await encryptVia(writer, ['legacy']);
+      expect(session.map.get('wt_enc_key')).toEqual(expect.any(String));
+
+      // Same session, new code path: key migrates into localStorage…
+      const local = memStorage();
+      const migrator = new EncryptedStorageService({ localStorage: local, sessionStorage: session });
+      await expect(decryptVia(migrator, record)).resolves.toEqual(['legacy']);
+      expect(local.map.get('wt_enc_key')).toBe(session.map.get('wt_enc_key'));
+
+      // …so a FUTURE session (localStorage only) can still decrypt.
+      const future = new EncryptedStorageService({ localStorage: local, sessionStorage: memStorage() });
+      await expect(decryptVia(future, record)).resolves.toEqual(['legacy']);
+    });
+
+    it('survives a localStorage that throws on write (quota full) via the in-memory key', async () => {
+      const throwing = {
+        getItem: () => null,
+        setItem: () => { throw new Error('QuotaExceededError'); },
+        removeItem: () => {},
+      };
+      // Construction at module load must never throw…
+      const service = new EncryptedStorageService({ localStorage: throwing, sessionStorage: null });
+      // …and the instance still encrypts/decrypts with its memory key.
+      const record = await encryptVia(service, { ok: true });
+      await expect(decryptVia(service, record)).resolves.toEqual({ ok: true });
+    });
+
+    it('honors EXPLICIT null storages (memory key, no global fallback)', async () => {
+      const service = new EncryptedStorageService({ localStorage: null, sessionStorage: null });
+      const record = await encryptVia(service, 42);
+      await expect(decryptVia(service, record)).resolves.toBe(42);
+      // The mocked globals must not have been touched.
+      expect(mockLocalStorage.setItem).not.toHaveBeenCalled();
       expect(mockSessionStorage.setItem).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('Undecryptable data self-heal', () => {
+    const memStorage = (initial: Record<string, string> = {}) => {
+      const map = new Map(Object.entries(initial));
+      return {
+        getItem: (k: string) => map.get(k) ?? null,
+        setItem: (k: string, v: string) => { map.set(k, v); },
+        removeItem: (k: string) => { map.delete(k); },
+        map,
+      };
+    };
+
+    it('purges an entry nobody can decrypt, returns null, and warns once', async () => {
+      const writer = new EncryptedStorageService({
+        localStorage: memStorage({ wt_enc_key: 'lost-key' }),
+        sessionStorage: null,
+      });
+      await writer.setItem('probe', { a: 1 });
+      const record = vi.mocked(indexedDBService.put).mock.calls.at(-1)![1];
+
+      const warn = vi.fn();
+      const reader = new EncryptedStorageService({
+        localStorage: memStorage({ wt_enc_key: 'reader-key' }),
+        sessionStorage: null,
+        logger: { error: vi.fn(), warn },
+      });
+
+      vi.mocked(indexedDBService.get).mockResolvedValue(record);
+      const first = await reader.getItem('wealthtracker_accounts');
+      const second = await reader.getItem('wealthtracker_transactions');
+
+      expect(first).toBeNull();
+      expect(second).toBeNull();
+      // Both poisoned entries purged so the failure never repeats…
+      expect(indexedDBService.delete).toHaveBeenCalledWith('secureData', 'wealthtracker_accounts');
+      expect(indexedDBService.delete).toHaveBeenCalledWith('secureData', 'wealthtracker_transactions');
+      // …and exactly ONE warning, not an error per entry per load.
+      expect(warn).toHaveBeenCalledTimes(1);
+    });
+
+    it('retries with the freshly persisted key before purging (cross-tab desync)', async () => {
+      // Reader constructs while localStorage holds key-A…
+      const sharedLocal = memStorage({ wt_enc_key: 'key-A' });
+      const reader = new EncryptedStorageService({ localStorage: sharedLocal, sessionStorage: null });
+
+      // …meanwhile "another tab" rotates the key to key-B and writes data.
+      const writer = new EncryptedStorageService({
+        localStorage: memStorage({ wt_enc_key: 'key-B' }),
+        sessionStorage: null,
+      });
+      await writer.setItem('probe', { fresh: 'write' });
+      const record = vi.mocked(indexedDBService.put).mock.calls.at(-1)![1];
+      sharedLocal.map.set('wt_enc_key', 'key-B');
+
+      vi.mocked(indexedDBService.get).mockResolvedValueOnce(record);
+      const result = await reader.getItem('wealthtracker_transactions');
+
+      // The reader adopts the persisted key and reads the data — no purge.
+      expect(result).toEqual({ fresh: 'write' });
+      expect(indexedDBService.delete).not.toHaveBeenCalled();
     });
   });
 

--- a/src/services/encryptedStorageService.ts
+++ b/src/services/encryptedStorageService.ts
@@ -29,13 +29,18 @@ export class EncryptedStorageService {
   private readonly keyGenerator: () => string;
   private readonly navigatorRef: Pick<Navigator, 'storage'> | null;
   private memoryKey?: string;
+  private hasWarnedAboutPurgedEntries = false;
 
   constructor(options: EncryptedStorageServiceOptions = {}) {
-    this.sessionStorageRef =
-      options.sessionStorage ?? (typeof sessionStorage !== 'undefined' ? sessionStorage : null);
+    // `undefined` means "resolve the real global"; an EXPLICIT null means
+    // "no storage" (DI contract — `?? global` would silently defeat it).
+    this.sessionStorageRef = options.sessionStorage === undefined
+      ? (typeof sessionStorage !== 'undefined' ? sessionStorage : null)
+      : options.sessionStorage;
     this.shouldResolveGlobalLocalStorage = options.localStorage === undefined;
-    this.localStorageRef =
-      options.localStorage ?? (typeof localStorage !== 'undefined' ? localStorage : null);
+    this.localStorageRef = options.localStorage === undefined
+      ? (typeof localStorage !== 'undefined' ? localStorage : null)
+      : options.localStorage;
     const fallbackLogger = typeof console !== 'undefined' ? console : undefined;
     this.logger = {
       error: options.logger?.error ?? (fallbackLogger?.error?.bind(fallbackLogger) ?? (() => {})),
@@ -59,18 +64,64 @@ export class EncryptedStorageService {
   }
 
   private getOrCreateEncryptionKey(): string {
-    if (this.sessionStorageRef) {
-      let key = this.sessionStorageRef.getItem('wt_enc_key');
-      if (!key) {
-        key = this.keyGenerator();
-        this.sessionStorageRef.setItem('wt_enc_key', key);
+    // The encrypted payloads live in IndexedDB, which persists across browser
+    // sessions — so the key MUST persist too. The original session-scoped key
+    // (sessionStorage dies with the tab) made every new session mint a fresh
+    // key that could never read the previous session's data: permanent local
+    // data loss plus a decrypt-error log storm on every load.
+    //
+    // Note on the security model: with the key stored client-side next to the
+    // data, this is obfuscation against casual inspection, not protection
+    // against an attacker with origin access — the same trade-off the
+    // session-scoped key already made.
+    const local = this.getLocalStorage();
+
+    const persistedKey = this.tryReadKey(local);
+    if (persistedKey) {
+      return persistedKey;
+    }
+
+    // Migrate a legacy session-scoped key so data written earlier in THIS
+    // session stays readable in future sessions.
+    const legacySessionKey = this.tryReadKey(this.sessionStorageRef);
+    if (legacySessionKey) {
+      if (local) {
+        this.tryWriteKey(local, legacySessionKey);
       }
+      return legacySessionKey;
+    }
+
+    // This runs at module load (singleton construction): a storage write that
+    // throws (quota full, lockdown modes) must degrade to the in-memory key,
+    // never crash module evaluation and white-screen the app.
+    const key = this.keyGenerator();
+    if (local && this.tryWriteKey(local, key)) {
+      return key;
+    }
+    if (this.sessionStorageRef && this.tryWriteKey(this.sessionStorageRef, key)) {
       return key;
     }
     if (!this.memoryKey) {
-      this.memoryKey = this.keyGenerator();
+      this.memoryKey = key;
     }
     return this.memoryKey;
+  }
+
+  private tryReadKey(storage: (StorageWriter & StorageReader) | null): string | null {
+    try {
+      return storage?.getItem('wt_enc_key') ?? null;
+    } catch {
+      return null;
+    }
+  }
+
+  private tryWriteKey(storage: StorageWriter & StorageReader, key: string): boolean {
+    try {
+      storage.setItem('wt_enc_key', key);
+      return true;
+    } catch {
+      return false;
+    }
   }
 
   // Encrypt data
@@ -79,16 +130,17 @@ export class EncryptedStorageService {
     return CryptoJS.AES.encrypt(jsonString, this.encryptionKey).toString();
   }
 
-  // Decrypt data
+  // Decrypt data. Throws on failure — getItem treats an undecryptable entry
+  // as absent and purges it (no per-entry error logging here: entries written
+  // under the legacy session-scoped key are expected casualties, and a log
+  // storm on every load helps nobody).
   private decrypt(encryptedData: string): JsonValue {
-    try {
-      const bytes = CryptoJS.AES.decrypt(encryptedData, this.encryptionKey);
-      const decryptedString = bytes.toString(CryptoJS.enc.Utf8);
-      return JSON.parse(decryptedString) as JsonValue;
-    } catch (error) {
-      this.logger.error('Decryption failed:', error as Error);
+    const bytes = CryptoJS.AES.decrypt(encryptedData, this.encryptionKey);
+    const decryptedString = bytes.toString(CryptoJS.enc.Utf8);
+    if (decryptedString === '') {
       throw new Error('Failed to decrypt data');
     }
+    return JSON.parse(decryptedString) as JsonValue;
   }
 
   // Compress data using simple LZ compression
@@ -143,7 +195,7 @@ export class EncryptedStorageService {
   async getItem<T>(key: string): Promise<T | null> {
     try {
       const storedData = await indexedDBService.get<StoredData<T>>(this.storeName, key);
-      
+
       if (!storedData) {
         return null;
       }
@@ -158,7 +210,16 @@ export class EncryptedStorageService {
 
       // Decrypt if encrypted
       if (storedData.encrypted && typeof data === 'string') {
-        data = this.decrypt(data) as T;
+        try {
+          data = this.decryptWithKeyRefresh(data) as T;
+        } catch {
+          // Written under a key nobody holds any more (the legacy
+          // session-scoped scheme) — unreadable forever. Purge it so callers
+          // fall back to their defaults cleanly and the failure never repeats.
+          await this.removeItem(key);
+          this.warnOnceAboutPurgedEntries(key);
+          return null;
+        }
       } else if (storedData.compressed && typeof data === 'string') {
         data = JSON.parse(this.decompress(data)) as T;
       }
@@ -168,6 +229,36 @@ export class EncryptedStorageService {
       this.logger.error('Error retrieving data:', error as Error);
       return null;
     }
+  }
+
+  /**
+   * Decrypt, and on failure re-read the persisted key once before giving up:
+   * another tab may have minted/migrated the key AFTER this instance cached
+   * its copy at construction. Without the retry, that cross-tab desync would
+   * make the purge destroy data the persisted key can still decrypt.
+   */
+  private decryptWithKeyRefresh(encryptedData: string): JsonValue {
+    try {
+      return this.decrypt(encryptedData);
+    } catch (error) {
+      const latestKey =
+        this.tryReadKey(this.getLocalStorage()) ?? this.tryReadKey(this.sessionStorageRef);
+      if (latestKey && latestKey !== this.encryptionKey) {
+        this.encryptionKey = latestKey;
+        return this.decrypt(encryptedData); // still failing → caller purges
+      }
+      throw error;
+    }
+  }
+
+  private warnOnceAboutPurgedEntries(firstKey: string): void {
+    if (this.hasWarnedAboutPurgedEntries) return;
+    this.hasWarnedAboutPurgedEntries = true;
+    this.logger.warn(
+      `Purged locally stored data that could not be decrypted (first key: "${firstKey}"). ` +
+      'It was written under an old session-scoped encryption key and is unreadable; ' +
+      'affected entries are removed so they regenerate cleanly.'
+    );
   }
 
   // Remove item from storage


### PR DESCRIPTION
## The real bug (worse than log spam)

The AES key for locally-encrypted data lived in **sessionStorage** (dies with the tab) while the encrypted data lives in **IndexedDB** (persists forever). Every new browser session minted a fresh key that could never decrypt the previous session's data:

- **Local-mode users: permanent data loss** — anything persisted locally became unreadable next session.
- **Everyone signed out/demo: an error storm** ("Decryption failed" × every key × every load, forever — the poisoned entries were never cleaned up). This is why `localStorage.clear()` didn't help: the data was in IndexedDB, the key in sessionStorage.

## The fix

1. **The key persists in localStorage**, with migration of a live session's legacy key (data written moments earlier stays readable) and a memory fallback. Honesty note (documented in code + annotated in the GDPR audit doc): a client-side key stored beside the ciphertext is same-origin obfuscation, not real protection — the true protection for signed-in users is Supabase + RLS.
2. **Self-heal**: entries nobody can decrypt any more are treated as absent and **purged**, with exactly one `warn` per session — not an error per entry per load.

## Adversarial review hardening (all fixed pre-commit)

- **Cross-tab desync** (critical): before purging, the persisted key is re-read and decrypt retried once — a sibling tab's fresh write under a newer key is adopted, never destroyed.
- **Quota-full crash** (critical): storage writes during singleton construction are guarded; a throwing localStorage degrades to the memory key instead of failing module evaluation (white screen).
- **DI contract**: explicit `null` storage options are honored instead of silently resolving to the real globals.
- **Test pinning**: tests now prove the crypto property itself — cross-session round trip, legacy-migration round trip, cross-tab retry, quota-full survival — via the exported class and public API (no `as any`).

## Verified live (dev preview, `/accounts?demo=true`)
- First load: poisoned legacy entries purged silently, key persisted, **zero console errors** (previously dozens)
- Simulated next session (cleared sessionStorage + reload): same key reused, **zero console errors**

## Gates
`typecheck:strict` ✅ · app typecheck ✅ · `lint` ✅ · `build` ✅ · full suite **2,821 passed** (+5 new)

🤖 Generated with [Claude Code](https://claude.com/claude-code)