### PR TITLE
fix(register): match Quick Edit panel border to Quick Add / search box

### DIFF
--- a/src/components/QuickEditTransactionPanel.tsx
+++ b/src/components/QuickEditTransactionPanel.tsx
@@ -119,7 +119,7 @@ export default function QuickEditTransactionPanel({
   return (
     // data-quick-edit-panel: the register's click-outside-to-deselect handler
     // treats clicks inside this panel as "keep the selection".
-    <div data-quick-edit-panel className="mt-3 bg-white dark:bg-gray-800 rounded-xl shadow-md border-2 border-[#6B86B3] px-4 py-3">
+    <div data-quick-edit-panel className="mt-3 bg-white dark:bg-gray-800 rounded-xl shadow-md border border-gray-100 dark:border-gray-700 px-4 py-3">
       <div className="flex flex-col lg:flex-row lg:items-end gap-3">
         <div className="flex items-center gap-2 lg:hidden">
           <span className="text-xs font-semibold text-gray-600 dark:text-gray-300">Quick edit</span>


### PR DESCRIPTION
## What

The Quick Edit dock (shown when a transaction row is selected) had a heavy **blue** border, while the Quick Add form and the search/filter box use a subtle gray one. Aligned the Quick Edit panel to the same subtle border so the bottom dock looks identical whichever mode it's in.

- `border-2 border-[#6B86B3]` → `border border-gray-100 dark:border-gray-700`

## Verified live (dev preview, demo mode)
- Quick Edit and Quick Add boxes now render an **identical** computed border (same width, same `rgb(243,244,246)` color) ✅
- Screenshot confirms the blue is gone ✅ · no console errors ✅

## Gates
`lint` ✅ · app typecheck ✅ · pre-commit unit suite ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)