### PR TITLE
feat(reconciliation): add "Save & Next" to the edit-transaction modal

### DIFF
--- a/src/components/reconciliation/ReconciliationTransactionList.tsx
+++ b/src/components/reconciliation/ReconciliationTransactionList.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useMemo, useCallback } from 'react';
+import React, { useState, useMemo, useEffect, useCallback } from 'react';
 import { SearchIcon, PlusIcon } from '../icons';
 import { useCurrencyDecimal } from '../../hooks/useCurrencyDecimal';
 import type { Transaction, Category } from '../../types';
@@ -18,6 +18,12 @@ interface ReconciliationTransactionListProps {
   /** Open a transaction to edit its details/category. */
   onRowClick: (transaction: Transaction) => void;
   onAddTransaction: () => void;
+  /**
+   * Reports the currently visible transactions in display order (after sort +
+   * filter + search) so a parent can drive "Save & Next" through the exact
+   * order the user sees.
+   */
+  onVisibleOrderChange?: (orderedIds: string[]) => void;
 }
 
 export default function ReconciliationTransactionList({
@@ -30,6 +36,7 @@ export default function ReconciliationTransactionList({
   onBulkSetCleared,
   onRowClick,
   onAddTransaction,
+  onVisibleOrderChange,
 }: ReconciliationTransactionListProps): React.JSX.Element {
   const { formatCurrency } = useCurrencyDecimal();
   const [filterMode, setFilterMode] = useState<FilterMode>('all');
@@ -83,6 +90,12 @@ export default function ReconciliationTransactionList({
 
     return list;
   }, [sortedTransactions, filterMode, searchTerm, getCategoryName]);
+
+  // Surface the visible order upward so a parent can walk transactions in the
+  // exact order shown here (used to drive the modal's "Save & Next").
+  useEffect(() => {
+    onVisibleOrderChange?.(filteredTransactions.map(t => t.id));
+  }, [filteredTransactions, onVisibleOrderChange]);
 
   const visibleUnclearedIds = useMemo(
     () => filteredTransactions.filter(t => t.cleared !== true).map(t => t.id),

--- a/src/components/reconciliation/__tests__/ReconciliationTransactionList.test.tsx
+++ b/src/components/reconciliation/__tests__/ReconciliationTransactionList.test.tsx
@@ -33,6 +33,7 @@ describe('ReconciliationTransactionList', () => {
   const onBulkSetCleared = vi.fn();
   const onRowClick = vi.fn();
   const onAddTransaction = vi.fn();
+  const onVisibleOrderChange = vi.fn();
 
   const renderList = (txns: Transaction[] = transactions) =>
     renderWithProviders(
@@ -44,6 +45,7 @@ describe('ReconciliationTransactionList', () => {
         onBulkSetCleared={onBulkSetCleared}
         onRowClick={onRowClick}
         onAddTransaction={onAddTransaction}
+        onVisibleOrderChange={onVisibleOrderChange}
       />
     );
 
@@ -117,5 +119,18 @@ describe('ReconciliationTransactionList', () => {
     renderList();
     fireEvent.click(screen.getByText('Add'));
     expect(onAddTransaction).toHaveBeenCalledTimes(1);
+  });
+
+  it('reports the visible order (date-sorted) for Save & Next navigation', () => {
+    renderList();
+    // Sorted by date ascending: the 10th before the 11th.
+    expect(onVisibleOrderChange).toHaveBeenLastCalledWith(['tx-uncleared', 'tx-cleared']);
+  });
+
+  it('reports only the filtered subset when a filter is active', () => {
+    renderList();
+    fireEvent.click(screen.getByText('Uncleared'));
+    // Save & Next must walk only what the user currently sees.
+    expect(onVisibleOrderChange).toHaveBeenLastCalledWith(['tx-uncleared']);
   });
 });

--- a/src/pages/Reconciliation.tsx
+++ b/src/pages/Reconciliation.tsx
@@ -22,6 +22,10 @@ export default function Reconciliation() {
   const [showFinalizationModal, setShowFinalizationModal] = useState(false);
   const [editingTransaction, setEditingTransaction] = useState<Transaction | null>(null);
   const [isEditModalOpen, setIsEditModalOpen] = useState(false);
+  // Visible transaction order (sorted + filtered) as shown in the list, reported
+  // by ReconciliationTransactionList. Drives "Save & Next" so it walks the same
+  // order the user sees rather than the raw account order.
+  const [visibleOrderIds, setVisibleOrderIds] = useState<string[]>([]);
   // Optimistic cleared-state overlay: the checkbox flips instantly while the
   // write is in flight, and reverts (with an error toast) if it fails.
   const [pendingCleared, setPendingCleared] = useState<Map<string, boolean>>(new Map());
@@ -177,6 +181,27 @@ export default function Reconciliation() {
     setEditingTransaction(null);
   }, []);
 
+  const handleVisibleOrderChange = useCallback((orderedIds: string[]) => {
+    setVisibleOrderIds(orderedIds);
+  }, []);
+
+  // "Save & Next" navigation: find the transaction shown immediately after the
+  // current one, and swap it into the still-open modal. Mirrors AccountTransactions.
+  const getNextTransactionId = useCallback((currentId: string): string | null => {
+    const index = visibleOrderIds.indexOf(currentId);
+    if (index === -1) return null;
+    return visibleOrderIds[index + 1] ?? null;
+  }, [visibleOrderIds]);
+
+  const advanceToNextTransaction = useCallback((currentId: string): boolean => {
+    const nextId = getNextTransactionId(currentId);
+    if (!nextId) return false;
+    const nextTransaction = accountTransactions.find(t => t.id === nextId) ?? null;
+    if (!nextTransaction) return false;
+    setEditingTransaction(nextTransaction);
+    return true;
+  }, [getNextTransactionId, accountTransactions]);
+
   // Step 1: Account Selection
   if (!selectedAccountId) {
     return (
@@ -249,6 +274,7 @@ export default function Reconciliation() {
         onBulkSetCleared={handleBulkSetCleared}
         onRowClick={handleRowClick}
         onAddTransaction={handleAddTransaction}
+        onVisibleOrderChange={handleVisibleOrderChange}
       />
 
       {/* Edit / add transaction (new transactions default to this account) */}
@@ -257,6 +283,15 @@ export default function Reconciliation() {
         onClose={handleCloseEditModal}
         transaction={editingTransaction}
         defaultAccountId={selectedAccountId}
+        onSaveAndNext={
+          editingTransaction && getNextTransactionId(editingTransaction.id)
+            ? () => {
+                if (!advanceToNextTransaction(editingTransaction.id)) {
+                  handleCloseEditModal();
+                }
+              }
+            : undefined
+        }
       />
 
       {/* Finalization Modal */}


### PR DESCRIPTION
## Summary

Adds the **Save & Next** button to the Edit Transaction modal on the **Reconciliation** page, matching the one already on the account Transactions page. Previously, reconciling a transaction meant: Save → modal closes → click the next row → modal re-opens → repeat. Now you can save and step straight to the next transaction without the extra clicks.

## How it works

The reconciliation page already rendered the shared `EditTransactionModal`, which shows a Save & Next button whenever it's handed an `onSaveAndNext` callback — the page just never passed one. The wiring mirrors `AccountTransactions`.

The one subtlety: the reconciliation list's **visible order** (date+type sort, then the Uncleared/Cleared filter and search box) lives *inside* `ReconciliationTransactionList`, so "next" has to follow what the user actually sees. The list now reports its visible order upward through a new optional `onVisibleOrderChange` callback; `Reconciliation.tsx` stores that order and derives `getNextTransactionId` / `advanceToNextTransaction`. As a result Save & Next:

- walks **only the currently visible rows** — respecting an active Uncleared filter or search (a primary reconciliation workflow), rather than jumping to a hidden transaction;
- **hides on the last** visible transaction (no dead button).

## Verification

Verified live in the preview (demo mode):
- Save & Next saves and advances **Phone Bill → Grocery → Starbucks** with the modal staying open.
- With a **"Grocery" search** active it skips the filtered-out rows (248.13 → 114.43, not the interleaved Starbucks) — proving it respects the visible order.
- The button is **absent on the last** visible transaction.
- No console errors.

Gates: `typecheck:strict` ✅, `lint` ✅ (0), `test:unit` ✅ (2823 passed, incl. 2 new order-reporting tests), `build` ✅, pre-push coverage/threshold ✅.

🤖 Generated with [Claude Code](https://claude.com/claude-code)