### PR TITLE
fix(reconciliation): preserve demo/testMode params on in-page navigation

### DIFF
--- a/src/pages/Reconciliation.tsx
+++ b/src/pages/Reconciliation.tsx
@@ -9,6 +9,7 @@ import ReconciliationBalanceBar from '../components/reconciliation/Reconciliatio
 import ReconciliationTransactionList from '../components/reconciliation/ReconciliationTransactionList';
 import ReconciliationFinalizationModal from '../components/reconciliation/ReconciliationFinalizationModal';
 import EditTransactionModal from '../components/EditTransactionModal';
+import { preserveRuntimeControlParams } from '../utils/runtimeMode';
 import type { Transaction } from '../types';
 
 export default function Reconciliation() {
@@ -68,12 +69,14 @@ export default function Reconciliation() {
   // Handlers
   const handleSelectAccount = useCallback((accountId: string) => {
     setSelectedAccountId(accountId);
-    setSearchParams({ account: accountId });
+    // Preserve demo/testMode so an in-page navigation doesn't drop the flag that
+    // keeps a demo/test session alive (which would bounce us to the landing page).
+    setSearchParams(prev => preserveRuntimeControlParams(prev, { account: accountId }));
   }, [setSearchParams]);
 
   const handleBack = useCallback(() => {
     setSelectedAccountId(null);
-    setSearchParams({});
+    setSearchParams(prev => preserveRuntimeControlParams(prev));
   }, [setSearchParams]);
 
   const applyCleared = useCallback(async (requestedIds: string[], cleared: boolean) => {

--- a/src/utils/runtimeMode.test.ts
+++ b/src/utils/runtimeMode.test.ts
@@ -7,7 +7,8 @@ import {
   sanitizeRuntimeControlSearch,
   sanitizeRuntimeControlSearchWithDetails,
   sanitizeRuntimeControlStorageWithDetails,
-  sanitizeRuntimeControlStorage
+  sanitizeRuntimeControlStorage,
+  preserveRuntimeControlParams
 } from './runtimeMode';
 
 describe('runtimeMode guards', () => {
@@ -51,6 +52,41 @@ describe('sanitizeRuntimeControlSearch', () => {
     expect(sanitizeRuntimeControlSearch('?testMode=true', env)).toBe('?testMode=true');
     expect(sanitizeRuntimeControlSearch('?foo=bar&demo=true', env)).toBe('?foo=bar&demo=true');
     expect(sanitizeRuntimeControlSearch('?foo=bar&testMode=true', env)).toBe('?foo=bar&testMode=true');
+  });
+});
+
+describe('preserveRuntimeControlParams', () => {
+  it('carries demo/testMode from the current search into the next params', () => {
+    const current = new URLSearchParams('demo=true&account=old');
+    expect(preserveRuntimeControlParams(current, { account: 'new' })).toEqual({
+      account: 'new',
+      demo: 'true'
+    });
+  });
+
+  it('preserves testMode as well as demo', () => {
+    const current = new URLSearchParams('testMode=true');
+    expect(preserveRuntimeControlParams(current, { account: 'x' })).toEqual({
+      account: 'x',
+      testMode: 'true'
+    });
+  });
+
+  it('keeps the control params when the next params are empty (e.g. going back)', () => {
+    const current = new URLSearchParams('account=x&demo=true');
+    expect(preserveRuntimeControlParams(current)).toEqual({ demo: 'true' });
+  });
+
+  it('adds nothing when no control params are present', () => {
+    const current = new URLSearchParams('account=x');
+    expect(preserveRuntimeControlParams(current, { account: 'y' })).toEqual({ account: 'y' });
+  });
+
+  it('does not mutate the caller-provided next object', () => {
+    const current = new URLSearchParams('demo=true');
+    const next = { account: 'x' };
+    preserveRuntimeControlParams(current, next);
+    expect(next).toEqual({ account: 'x' });
   });
 });
 

--- a/src/utils/runtimeMode.ts
+++ b/src/utils/runtimeMode.ts
@@ -81,6 +81,28 @@ export const sanitizeRuntimeControlSearch = (search: string, env: RuntimeModeEnv
   return sanitizeRuntimeControlSearchWithDetails(search, env).sanitizedSearch;
 };
 
+/**
+ * Copy the runtime-control params (demo/testMode) from an existing search into
+ * a new params object. In-page navigations that call setSearchParams replace
+ * the whole query string, so without this they'd drop the flag that keeps a
+ * demo/test session alive and bounce the user out to the landing page. No-op in
+ * production, where these params are sanitized out of the URL on load, so there
+ * is nothing present to copy.
+ */
+export const preserveRuntimeControlParams = (
+  current: URLSearchParams,
+  next: Record<string, string> = {}
+): Record<string, string> => {
+  const merged: Record<string, string> = { ...next };
+  RUNTIME_CONTROL_QUERY_PARAMS.forEach((param) => {
+    const value = current.get(param);
+    if (value !== null) {
+      merged[param] = value;
+    }
+  });
+  return merged;
+};
+
 export const sanitizeRuntimeControlStorageWithDetails = (
   env: RuntimeModeEnv,
   storage: RuntimeStorageLike | null | undefined


### PR DESCRIPTION
## Summary

On the **Reconciliation** page, selecting an account or clicking **Back** dropped the `?demo=true` (and `testMode`) query param and bounced the user out to the marketing landing page — mid-flow, in demo mode.

**Root cause:** `handleSelectAccount` called `setSearchParams({ account: accountId })` and `handleBack` called `setSearchParams({})`. Both replace the *entire* query string, discarding the runtime-control flags. The route guard (`ProtectedRoute`) gates demo access on `queryParams.get('demo') === 'true'` — with **no** localStorage fallback for demo (unlike `testMode`) — so a signed-out demo session immediately redirected to `/`.

**Impact:** demo-mode only (real authenticated use has no demo param to lose), but the demo experience is explicitly used for UI/UX testing, so navigating the reconciliation flow in demo was broken.

## Fix

Adds a small shared helper in `src/utils/runtimeMode.ts`, co-located with the existing `RUNTIME_CONTROL_QUERY_PARAMS`:

```ts
preserveRuntimeControlParams(current: URLSearchParams, next = {}): Record<string, string>
```

It copies whichever runtime-control params (`demo` / `testMode`) are present in the current search into the next params object. Reconciliation's two `setSearchParams` calls now use it via the **functional-updater** form (`setSearchParams(prev => …)`), so navigation keeps the flags alive without adding `searchParams` to the callback deps. It's a **no-op in production**, where these params are sanitized out of the URL on load — nothing to copy.

`setSearchParams` is used **nowhere else** in `src/`, so no other page shares this gap.

## Verification

Live, in demo mode (no test shims this time — the fix does the work):
- Selecting an account → URL stays `?account=…&demo=true`, renders the account (no landing bounce), demo banner still active.
- **Back** → URL stays `?demo=true`, returns to the account list.
- No console errors.

Gates: `typecheck:strict` ✅, `lint` ✅ (0), `test:unit` ✅ (2828 passed, incl. 5 new helper tests), `build` ✅.

🤖 Generated with [Claude Code](https://claude.com/claude-code)