### PR TITLE
fix(auth): stop Safari cross-tab reload loop after bank-feed cancel

### DIFF
--- a/src/pages/BankingCallback.tsx
+++ b/src/pages/BankingCallback.tsx
@@ -33,6 +33,17 @@ export default function BankingCallback() {
     }
   }, []);
 
+  // When we run as an OAuth popup, close ourselves once the opener has been
+  // notified — on error/cancel as well as success. Leaving the popup open left
+  // a second app window running, which (on Safari) could trigger a cross-tab
+  // reload loop. No-op for the full-page redirect flow (no window.opener), where
+  // the in-page buttons below are the correct exit.
+  const closeIfPopup = useCallback((delayMs: number) => {
+    if (window.opener && !window.opener.closed) {
+      window.setTimeout(() => window.close(), delayMs);
+    }
+  }, []);
+
   useEffect(() => {
     if (!isLoaded) {
       return;
@@ -42,6 +53,7 @@ export default function BankingCallback() {
       setStatus('error');
       setMessage(errorDescription || error);
       notifyOpener({ status: 'error', error: errorDescription || error });
+      closeIfPopup(1200);
       return;
     }
 
@@ -52,6 +64,7 @@ export default function BankingCallback() {
         status: 'error',
         error: 'Missing authorization details from bank connection.'
       });
+      closeIfPopup(1200);
       return;
     }
 
@@ -64,20 +77,19 @@ export default function BankingCallback() {
         setStatus('success');
         setMessage('Bank connection successful. You can now link your accounts.');
         notifyOpener({ status: 'success', connectionId: connection?.id });
-        if (window.opener && !window.opener.closed) {
-          window.setTimeout(() => window.close(), 800);
-        }
+        closeIfPopup(800);
       } catch (err) {
         logger.error('Banking callback failed', err as Error);
         setStatus('error');
         const errorMessage = err instanceof Error ? err.message : 'Unable to complete bank connection.';
         setMessage(errorMessage);
         notifyOpener({ status: 'error', error: errorMessage });
+        closeIfPopup(1200);
       }
     };
 
     void run();
-  }, [code, state, error, errorDescription, getToken, isLoaded, notifyOpener]);
+  }, [code, state, error, errorDescription, getToken, isLoaded, notifyOpener, closeIfPopup]);
 
   return (
     <PageWrapper title="Bank Connection">

--- a/src/utils/clerkSafarifix.ts
+++ b/src/utils/clerkSafarifix.ts
@@ -116,19 +116,15 @@ const applySafariFixes = () => {
     clerkSafariLogger.error('Failed to patch fetch for Safari', error);
   }
 
-  // 2. Add storage event listeners to sync auth state
-  if (window.addEventListener) {
-    window.addEventListener('storage', (e) => {
-      // Sync Clerk session across tabs in Safari
-      if (e.key?.includes('clerk') || e.key?.includes('__session')) {
-        clerkSafariLogger.info('Safari: syncing Clerk session across tabs');
-        // Force a session refresh
-        window.location.reload();
-      }
-    });
-  }
+  // NOTE: We deliberately do NOT reload on Clerk 'storage' events. A previous
+  // version called window.location.reload() on every cross-tab session write,
+  // which caused an infinite reload ping-pong whenever two app windows were
+  // open (e.g. the bank-OAuth popup + the main window): each window's periodic
+  // token refresh fired a 'storage' event in the other, reloading it, which
+  // wrote the token again, and so on. Clerk already synchronises sessions
+  // across tabs natively, so no manual handling is needed here.
 
-  // 3. Polyfill for Safari's missing features
+  // 2. Polyfill for Safari's missing features
   polyfillSafari();
 };
 


### PR DESCRIPTION
## Summary

Fixes an endless page-reload loop (and the accompanying flood of failed Supabase requests) that a user hit on **Safari** after opening the bank-feed OAuth popup and cancelling out of it.

Two bugs combined:

### 1. The loop cause — `clerkSafarifix.ts`
On Safari the app installed a `storage` event listener that called `window.location.reload()` on every Clerk `__session` write. The `storage` event only fires in **other** tabs/windows of the same origin, so with two app windows open, each window's periodic Clerk token refresh reloaded the *other* window → an infinite reload ping-pong. Every reload aborted the in-flight REST calls, which is why the console showed a wall of `TypeError: Load failed` / "due to access control checks" on the Supabase requests.

Clerk already synchronises sessions across tabs natively, so this manual reload was both redundant and harmful. **Removed it** (with an explanatory comment to prevent regression).

### 2. Why a second window was lingering — `BankingCallback.tsx`
The OAuth callback runs in a popup (opened via `window.open` in `BankConnections`). It self-closed on **success** but not on **error/cancel**, so cancelling left an orphaned second window open — the trigger for bug #1. It now closes itself on error/cancel too, via a small `closeIfPopup` helper that **no-ops in the full-page-redirect flow** (no `window.opener`), where the in-page buttons remain the correct exit.

Either fix alone stops the loop; together they also stop orphaned popups from being left behind. With the reload gone, two app tabs simply coexist.

## Verification
- `typecheck:strict` ✅, `lint` ✅ (0), `test:unit` ✅ (2828 passed), `build` ✅, pre-push gates ✅.
- Smoke-tested the callback page in the preview: it renders its "Connection Issue" error state cleanly and (with no `window.opener` in that tab) correctly does **not** try to close — no console errors.
- The Safari-only reload loop itself isn't reproducible in the Chromium preview; the fix is a straight removal of the harmful listener, covered by the build + typecheck.

## Note (separate, not fixed here)
The console also showed **Clerk running with development keys on the production domain** ("strict usage limits… should not be used when deploying"), which can cause auth/token flakiness. Flagged for a possible follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)