### PR TITLE
fix(import): auto-detect QIF date order so UK (D/M/Y) imports stop dropping rows

### DIFF
--- a/src/components/QIFImportModal.tsx
+++ b/src/components/QIFImportModal.tsx
@@ -28,6 +28,7 @@ type ImportOutcome =
       success: true;
       imported: number;
       duplicates: number;
+      invalidDates: number;
       account: Account | null;
     }
   | {
@@ -125,6 +126,7 @@ export default function QIFImportModal({ isOpen, onClose }: QIFImportModalProps)
         success: true,
         imported: result.newTransactions,
         duplicates: result.duplicates,
+        invalidDates: result.invalidDates,
         account
       });
     } catch (error) {
@@ -214,6 +216,11 @@ export default function QIFImportModal({ isOpen, onClose }: QIFImportModalProps)
                 <p className="text-sm text-gray-600 dark:text-gray-400">
                   {parseResult.transactions.length} transactions found
                   {parseResult.accountType && ` (Type: ${parseResult.accountType})`}
+                </p>
+                <p className="text-xs text-gray-500 dark:text-gray-400 mt-0.5">
+                  Dates read as {parseResult.dateOrder === 'dmy' ? 'Day/Month/Year (UK)' : 'Month/Day/Year (US)'}
+                  {parseResult.invalidDateCount > 0 &&
+                    ` · ${parseResult.invalidDateCount} row${parseResult.invalidDateCount === 1 ? '' : 's'} skipped (unrecognised date)`}
                 </p>
               </div>
             </div>
@@ -320,6 +327,12 @@ export default function QIFImportModal({ isOpen, onClose }: QIFImportModalProps)
                 {(importResult.duplicates ?? 0) > 0 && (
                   <p className="text-sm text-yellow-600 dark:text-yellow-400 mb-6">
                     Skipped {importResult.duplicates} potential duplicate transactions
+                  </p>
+                )}
+
+                {importResult.invalidDates > 0 && (
+                  <p className="text-sm text-yellow-600 dark:text-yellow-400 mb-6">
+                    Skipped {importResult.invalidDates} row{importResult.invalidDates === 1 ? '' : 's'} with an unrecognised date
                   </p>
                 )}
               </>

--- a/src/services/qifImportService.test.ts
+++ b/src/services/qifImportService.test.ts
@@ -819,4 +819,158 @@ PIncomplete transaction`;
       expect(result.transactions[0].amount).toBe(-50);
     });
   });
+
+  describe('date order detection (UK vs US)', () => {
+    it('detects UK D/M/Y when a day exceeds 12 and parses dates correctly', () => {
+      const ukQIF = `!Type:Bank
+D13/09/2024
+T-50.00
+PDay thirteen
+^
+D25/12/2024
+T-75.00
+PChristmas
+^
+D09/02/2024
+T-20.00
+PNinth of Feb
+^`;
+
+      const result = qifImportService.parseQIF(ukQIF);
+
+      expect(result.dateOrder).toBe('dmy');
+      expect(result.invalidDateCount).toBe(0);
+      expect(result.transactions.map(t => t.date)).toEqual([
+        '2024-09-13', // 13 Sep
+        '2024-12-25', // 25 Dec
+        '2024-02-09'  // 9 Feb
+      ]);
+    });
+
+    it('does NOT drop UK dates on the 13th-31st (regression for the silent-drop bug)', () => {
+      // The old US-only parser turned these into invalid months (e.g. 2024-13-09)
+      // which serialised to null and were silently dropped — losing ~60% of a
+      // real statement. They must all import now.
+      const ukQIF = `!Type:Bank
+D13/01/2024
+T-1.00
+PA
+^
+D20/03/2024
+T-2.00
+PB
+^
+D31/07/2024
+T-3.00
+PC
+^`;
+
+      const result = qifImportService.parseQIF(ukQIF);
+
+      expect(result.dateOrder).toBe('dmy');
+      expect(result.transactions).toHaveLength(3);
+      expect(result.transactions.map(t => t.date)).toEqual([
+        '2024-01-13',
+        '2024-03-20',
+        '2024-07-31'
+      ]);
+    });
+
+    it('keeps M/D/Y (US) detection when a month-position value exceeds 12', () => {
+      const usQIF = `!Type:Bank
+D01/15/2024
+T-10.00
+PUS date
+^
+D03/28/2024
+T-20.00
+PAnother
+^`;
+
+      const result = qifImportService.parseQIF(usQIF);
+
+      expect(result.dateOrder).toBe('mdy');
+      expect(result.transactions.map(t => t.date)).toEqual(['2024-01-15', '2024-03-28']);
+    });
+
+    it('defaults ambiguous files (no field over 12) to M/D/Y', () => {
+      const ambiguousQIF = `!Type:Bank
+D05/06/2024
+T-10.00
+PAmbiguous
+^`;
+
+      const result = qifImportService.parseQIF(ambiguousQIF);
+
+      expect(result.dateOrder).toBe('mdy');
+      expect(result.transactions[0].date).toBe('2024-05-06'); // month 05, day 06
+    });
+
+    it('handles UK 2-digit years with day-first order', () => {
+      vi.setSystemTime(new Date('2024-06-15'));
+
+      const ukQIF = `!Type:Bank
+D13/09'24
+T-50.00
+PShort year UK
+^`;
+
+      const result = qifImportService.parseQIF(ukQIF);
+
+      expect(result.dateOrder).toBe('dmy');
+      expect(result.transactions[0].date).toBe('2024-09-13');
+
+      vi.useRealTimers();
+    });
+
+    it('parses unambiguous ISO (year-first) dates', () => {
+      const isoQIF = `!Type:Bank
+D2024-09-13
+T-50.00
+PISO date
+^`;
+
+      const result = qifImportService.parseQIF(isoQIF);
+
+      expect(result.transactions).toHaveLength(1);
+      expect(result.transactions[0].date).toBe('2024-09-13');
+    });
+
+    it('drops rows with an impossible date and counts them instead of guessing', () => {
+      const badQIF = `!Type:Bank
+D13/09/2024
+T-50.00
+PGood
+^
+D30/02/2024
+T-10.00
+PImpossible (30 Feb)
+^`;
+
+      const result = qifImportService.parseQIF(badQIF);
+
+      // 13>12 makes this a day-first file; 30 Feb is not a real date → dropped.
+      expect(result.dateOrder).toBe('dmy');
+      expect(result.transactions).toHaveLength(1);
+      expect(result.transactions[0].date).toBe('2024-09-13');
+      expect(result.invalidDateCount).toBe(1);
+    });
+
+    it('reports invalidDates through importTransactions', async () => {
+      const badQIF = `!Type:Bank
+D13/09/2024
+T-50.00
+PGood
+^
+D30/02/2024
+T-10.00
+PImpossible
+^`;
+
+      const result = await qifImportService.importTransactions(badQIF, 'acc1', []);
+
+      expect(result.newTransactions).toBe(1);
+      expect(result.invalidDates).toBe(1);
+    });
+  });
 });

--- a/src/services/qifImportService.ts
+++ b/src/services/qifImportService.ts
@@ -12,9 +12,16 @@ export interface QIFTransaction {
   cleared?: boolean;
 }
 
+/** Order of the day/month fields in a QIF date. */
+export type QIFDateOrder = 'dmy' | 'mdy';
+
 export interface QIFParseResult {
   transactions: QIFTransaction[];
   accountType?: string;
+  /** Day/month field order inferred across the whole file's dates. */
+  dateOrder: QIFDateOrder;
+  /** Rows dropped because their date could not be parsed (never guessed). */
+  invalidDateCount: number;
 }
 
 export class QIFImportService {
@@ -23,7 +30,10 @@ export class QIFImportService {
    */
   parseQIF(content: string): QIFParseResult {
     const lines = content.split('\n').map(line => line.trim());
-    const transactions: QIFTransaction[] = [];
+    // First pass: collect transactions keeping each date as its RAW string. QIF
+    // gives no format hint, so we can't decide day/month order until we've seen
+    // every date in the file (see detectDateOrder).
+    const rawTransactions: QIFTransaction[] = [];
     let currentTransaction: Partial<QIFTransaction> = {};
     let accountType: string | undefined;
     let inAccountHeader = false;
@@ -54,7 +64,7 @@ export class QIFImportService {
         }
         // End of transaction
         if (currentTransaction.date && currentTransaction.amount !== undefined) {
-          transactions.push(currentTransaction as QIFTransaction);
+          rawTransactions.push(currentTransaction as QIFTransaction);
         }
         currentTransaction = {};
         continue;
@@ -64,14 +74,14 @@ export class QIFImportService {
         // Skip account metadata lines (name/type/balance/description)
         continue;
       }
-      
+
       // Parse transaction fields
       const fieldType = line.charAt(0);
       const value = line.substring(1);
-      
+
       switch (fieldType) {
-        case 'D': // Date
-          currentTransaction.date = this.parseQIFDate(value);
+        case 'D': // Date — kept raw here, resolved once the whole file is seen
+          currentTransaction.date = value;
           break;
         case 'T': // Amount
         case 'U': // Amount (investment)
@@ -94,53 +104,160 @@ export class QIFImportService {
           break;
       }
     }
-    
+
     // Add last transaction if exists
     if (currentTransaction.date && currentTransaction.amount !== undefined) {
-      transactions.push(currentTransaction as QIFTransaction);
+      rawTransactions.push(currentTransaction as QIFTransaction);
     }
-    
-    return { transactions, accountType };
+
+    // Second pass: infer the date order from every raw date, then resolve each
+    // to ISO. Rows whose date can't be parsed are dropped and counted — never
+    // silently coerced to "today" (which the old parser did, hiding the error).
+    const dateOrder = this.detectDateOrder(rawTransactions.map(trx => trx.date));
+    const transactions: QIFTransaction[] = [];
+    let invalidDateCount = 0;
+    for (const trx of rawTransactions) {
+      const isoDate = this.parseQIFDate(trx.date, dateOrder);
+      if (!isoDate) {
+        invalidDateCount++;
+        continue;
+      }
+      trx.date = isoDate;
+      transactions.push(trx);
+    }
+
+    return { transactions, accountType, dateOrder, invalidDateCount };
   }
   
   /**
-   * Parse QIF date format (M/D/Y or M/D'Y)
+   * Split a QIF date into its three raw parts, or null if it isn't a 3-part
+   * D/M/Y-style date. Handles the '/' , '.' and '-' separators and Quicken's
+   * apostrophe year separator (e.g. 12/25'23).
    */
-  private parseQIFDate(dateStr: string): string {
-    // Replace single quote with /
-    dateStr = dateStr.replace(/'/g, '/');
-    
-    // Split date parts
-    const parts = dateStr.split('/');
-    if (parts.length !== 3) {
-      // Try other date formats
-      const date = new Date(dateStr);
-      if (!isNaN(date.getTime())) {
-        return date.toISOString().split('T')[0];
-      }
-      return new Date().toISOString().split('T')[0];
+  private splitDateParts(dateStr: string): string[] | null {
+    const cleaned = (dateStr ?? '').replace(/'/g, '/').trim();
+    if (!cleaned) {
+      return null;
     }
-    
-    let [month, day, year] = parts;
-    
-    // Handle 2-digit year
-    if (year.length === 2) {
-      const currentYear = new Date().getFullYear();
-      const century = Math.floor(currentYear / 100) * 100;
-      const yearNum = parseInt(year);
-      // If year is greater than current year's last 2 digits + 10, assume previous century
-      if (yearNum > (currentYear % 100) + 10) {
-        year = (century - 100 + yearNum).toString();
+    const parts = cleaned.split(/[/.-]/).map(part => part.trim()).filter(Boolean);
+    return parts.length === 3 ? parts : null;
+  }
+
+  /**
+   * Infer the day/month field order across ALL of a file's dates.
+   *
+   * QIF carries no format hint, so we reason from the values: a first field
+   * greater than 12 can only be a day (→ D/M/Y, e.g. UK / MS Money), a second
+   * field greater than 12 can only be a day (→ M/D/Y, e.g. US / Quicken). Real
+   * statements always contain a day past the 12th, so this is decisive in
+   * practice. Files where nothing exceeds 12 (or that contradict themselves)
+   * fall back to M/D/Y — QIF's Quicken heritage.
+   */
+  private detectDateOrder(rawDates: string[]): QIFDateOrder {
+    let dayFirst = false;   // saw a first field that can only be a day
+    let monthFirst = false; // saw a second field that can only be a day
+    for (const raw of rawDates) {
+      const parts = this.splitDateParts(raw);
+      if (!parts) {
+        continue;
+      }
+      const first = parseInt(parts[0], 10);
+      const second = parseInt(parts[1], 10);
+      if (!Number.isFinite(first) || !Number.isFinite(second)) {
+        continue;
+      }
+      // A 4-digit / >31 leading field is a year (ISO YYYY-MM-DD) — no D/M signal.
+      if (parts[0].length === 4 || first > 31) {
+        continue;
+      }
+      if (first > 12 && first <= 31) {
+        dayFirst = true;
+      }
+      if (second > 12 && second <= 31) {
+        monthFirst = true;
+      }
+    }
+    return dayFirst && !monthFirst ? 'dmy' : 'mdy';
+  }
+
+  /**
+   * Resolve a raw QIF date to an ISO YYYY-MM-DD string using the detected field
+   * order. Returns null for anything that isn't a real calendar date — callers
+   * drop those rows rather than inventing a date.
+   */
+  private parseQIFDate(dateStr: string, order: QIFDateOrder): string | null {
+    const parts = this.splitDateParts(dateStr);
+    if (!parts) {
+      // Non-slash forms (e.g. "5 Jan 2024") — let the platform parser try.
+      const cleaned = (dateStr ?? '').replace(/'/g, '/').trim();
+      if (!cleaned) {
+        return null;
+      }
+      const parsed = new Date(cleaned);
+      return Number.isNaN(parsed.getTime()) ? null : parsed.toISOString().split('T')[0];
+    }
+
+    let year: number;
+    let month: number;
+    let day: number;
+
+    const first = parseInt(parts[0], 10);
+    if (parts[0].length === 4 || first > 31) {
+      // Year-first ISO form: YYYY-MM-DD (unambiguous).
+      year = first;
+      month = parseInt(parts[1], 10);
+      day = parseInt(parts[2], 10);
+    } else {
+      const second = parseInt(parts[1], 10);
+      year = this.normalizeYear(parts[2]);
+      if (order === 'dmy') {
+        day = first;
+        month = second;
       } else {
-        year = (century + yearNum).toString();
+        month = first;
+        day = second;
       }
     }
-    
-    // Pad month and day
-    month = month.padStart(2, '0');
-    day = day.padStart(2, '0');
-    
-    return `${year}-${month}-${day}`;
+
+    if (!this.isValidYmd(year, month, day)) {
+      return null;
+    }
+
+    const pad = (value: number, length = 2): string => value.toString().padStart(length, '0');
+    return `${pad(year, 4)}-${pad(month)}-${pad(day)}`;
+  }
+
+  /**
+   * Expand a QIF year to a 4-digit year. 2-digit years assume the current
+   * century unless that lands more than ~10 years in the future, in which case
+   * the previous century is used (matching Quicken's windowing).
+   */
+  private normalizeYear(yearStr: string): number {
+    const year = parseInt(yearStr, 10);
+    if (!Number.isFinite(year)) {
+      return NaN;
+    }
+    if (yearStr.length > 2) {
+      return year;
+    }
+    const currentYear = new Date().getFullYear();
+    const century = Math.floor(currentYear / 100) * 100;
+    if (year > (currentYear % 100) + 10) {
+      return century - 100 + year;
+    }
+    return century + year;
+  }
+
+  /** True only for a real calendar date (rejects e.g. 31 Feb or month 13). */
+  private isValidYmd(year: number, month: number, day: number): boolean {
+    if (![year, month, day].every(Number.isFinite)) {
+      return false;
+    }
+    if (month < 1 || month > 12 || day < 1 || day > 31) {
+      return false;
+    }
+    const dt = new Date(Date.UTC(year, month - 1, day));
+    return dt.getUTCFullYear() === year && dt.getUTCMonth() === month - 1 && dt.getUTCDate() === day;
   }
   
   /**
@@ -175,6 +292,7 @@ export class QIFImportService {
     transactions: Omit<Transaction, 'id'>[];
     duplicates: number;
     newTransactions: number;
+    invalidDates: number;
   }> {
     const parseResult = this.parseQIF(qifContent);
     const transactions: Omit<Transaction, 'id'>[] = [];
@@ -259,7 +377,8 @@ export class QIFImportService {
     return {
       transactions,
       duplicates,
-      newTransactions: transactions.length
+      newTransactions: transactions.length,
+      invalidDates: parseResult.invalidDateCount
     };
   }
 }


### PR DESCRIPTION
## Summary

Fixes the QIF import silently dropping the majority of a UK bank/MS Money statement.

The parser assumed **US month-first** dates (`M/D/Y`). MS Money and UK bank QIF exports are **day-first** (`D/M/Y`), so importing an 11k-row UK statement:

- **Dropped every transaction dated the 13th–31st.** `13/09/2024` was parsed as month 13 → `Invalid Date` → serialised to `null` → rejected by the database. That's ~19 of every 30 days — **roughly 60% of the statement vanished silently.**
- **Imported the survivors (days 1–12) with day and month swapped** (wrong dates).
- Still reported **"11,000+ imported"**, because the importer counts parsed rows, not confirmed writes.

## Fix

Infer the day/month order across the **whole file**:
- a first field > 12 can only be a day → **D/M/Y** (UK);
- a second field > 12 can only be a day → **M/D/Y** (US).

Real statements always contain a day past the 12th, so detection is decisive in practice. Ambiguous files (nothing over 12) and self-contradictory ones default to **M/D/Y** — preserving Quicken's heritage and every existing test. Also:
- handles year-first ISO dates (`YYYY-MM-DD`);
- keeps the existing 2-digit-year windowing;
- **rejects impossible dates** (e.g. 30 Feb, month 13) instead of coercing them to *today* — such rows are dropped and counted (`invalidDateCount`) rather than mis-saved.

The QIF import modal now shows the **detected format** ("Dates read as Day/Month/Year (UK)") and any **skipped-row count**, so a mis-detection is visible instead of silent.

## Tests
8 new cases: UK detection, the 13th–31st silent-drop regression, US detection, ambiguous default, UK 2-digit year, ISO dates, and impossible-date drop + count. All **39** `qifImportService` tests pass; full suite **2836** green; `typecheck:strict`, `lint`, `build` clean.

Driving a real file-upload import through the browser preview isn't feasible with the tooling, so verification is via the (now comprehensive) unit tests + build.

## Not in this PR
- The import UI fires writes without awaiting them, which is why the count was inflated. With dates now valid the writes succeed, so the count is accurate for correct data — but making the count reflect *actual* writes (and using a bulk insert) is a sensible follow-up.
- **Data cleanup**: the transactions already imported into *Green S A* have swapped/wrong dates and need removing before a clean re-import. That's a production data operation — handled separately with the account owner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)