### PR TITLE
feat(import): server-side bulk QIF import + category matching

### DIFF
--- a/api/data/import-transactions.ts
+++ b/api/data/import-transactions.ts
@@ -1,0 +1,161 @@
+import type { VercelRequest, VercelResponse } from '@vercel/node';
+import { AuthError, requireAuth } from '../_lib/auth.js';
+import { setCorsHeaders } from '../_lib/cors.js';
+import { getServiceRoleSupabase } from '../_lib/supabase.js';
+import { withSentry } from '../_lib/sentry.js';
+
+// One request = one atomic RPC = one DB transaction. The client chunks large
+// imports into requests of this size; keep it well under Vercel's body limit.
+const MAX_ROWS = 2000;
+const ALLOWED_TYPES = new Set(['income', 'expense', 'transfer']);
+
+interface ErrorResponse {
+  error: string;
+  code: string;
+}
+
+interface ImportRow {
+  date?: unknown;
+  description?: unknown;
+  amount?: unknown;
+  type?: unknown;
+  category?: unknown;
+  notes?: unknown;
+  tags?: unknown;
+  is_cleared?: unknown;
+  is_recurring?: unknown;
+}
+
+interface ImportTransactionsRequest {
+  accountId?: unknown;
+  transactions?: unknown;
+}
+
+interface ImportTransactionsResponse {
+  inserted: number;
+}
+
+const createErrorResponse = (
+  res: VercelResponse,
+  status: number,
+  error: string,
+  code: string
+) => {
+  const payload: ErrorResponse = { error, code };
+  return res.status(status).json(payload);
+};
+
+// Validate + normalise one row into the shape the RPC expects. Returns a string
+// error message on the first problem, so a bad file is rejected with a clear
+// 400 rather than surfacing as a raw database cast error.
+const normaliseRow = (row: ImportRow, index: number): { row: Record<string, unknown> } | { error: string } => {
+  const date = typeof row.date === 'string' ? row.date.trim() : '';
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(date)) {
+    return { error: `Row ${index}: date must be an ISO YYYY-MM-DD string` };
+  }
+  const description = typeof row.description === 'string' ? row.description.trim() : '';
+  if (!description) {
+    return { error: `Row ${index}: description is required` };
+  }
+  const amount = typeof row.amount === 'number' ? row.amount : Number(row.amount);
+  if (!Number.isFinite(amount)) {
+    return { error: `Row ${index}: amount must be a finite number` };
+  }
+  const type = typeof row.type === 'string' ? row.type : '';
+  if (!ALLOWED_TYPES.has(type)) {
+    return { error: `Row ${index}: type must be income, expense or transfer` };
+  }
+  const tags = Array.isArray(row.tags)
+    ? row.tags.filter((t): t is string => typeof t === 'string')
+    : undefined;
+
+  return {
+    row: {
+      date,
+      description,
+      amount,
+      type,
+      category: typeof row.category === 'string' ? row.category : '',
+      notes: typeof row.notes === 'string' ? row.notes : '',
+      ...(tags && tags.length > 0 ? { tags } : {}),
+      is_cleared: row.is_cleared === true,
+      is_recurring: row.is_recurring === true
+    }
+  };
+};
+
+async function handler(req: VercelRequest, res: VercelResponse) {
+  if (setCorsHeaders(req, res)) {
+    return;
+  }
+
+  if (req.method !== 'POST') {
+    res.setHeader('Allow', 'POST');
+    return createErrorResponse(res, 405, 'Method not allowed', 'method_not_allowed');
+  }
+
+  try {
+    const auth = await requireAuth(req);
+    const supabase = getServiceRoleSupabase();
+    const body = (req.body ?? {}) as ImportTransactionsRequest;
+
+    const accountId = typeof body.accountId === 'string' ? body.accountId.trim() : '';
+    if (!accountId) {
+      return createErrorResponse(res, 400, 'accountId is required', 'invalid_request');
+    }
+
+    if (!Array.isArray(body.transactions)) {
+      return createErrorResponse(res, 400, 'transactions must be an array', 'invalid_request');
+    }
+    if (body.transactions.length === 0) {
+      return createErrorResponse(res, 400, 'transactions must not be empty', 'invalid_request');
+    }
+    if (body.transactions.length > MAX_ROWS) {
+      return createErrorResponse(res, 413, `Too many rows in one request (max ${MAX_ROWS})`, 'too_many_rows');
+    }
+
+    const rows: Record<string, unknown>[] = [];
+    for (let i = 0; i < body.transactions.length; i += 1) {
+      const result = normaliseRow(body.transactions[i] as ImportRow, i);
+      if ('error' in result) {
+        return createErrorResponse(res, 400, result.error, 'invalid_row');
+      }
+      rows.push(result.row);
+    }
+
+    // Atomic bulk insert scoped to the Clerk-verified user. account ownership is
+    // re-checked inside the RPC (the service role bypasses RLS).
+    const { data, error } = await supabase.rpc('import_transactions_atomic', {
+      p_user_id: auth.userId,
+      p_account_id: accountId,
+      p_rows: rows
+    });
+
+    if (error) {
+      if (error.message?.includes('account_not_found_or_not_owned')) {
+        return createErrorResponse(res, 404, 'Account not found', 'not_found');
+      }
+      // Log internals server-side; never leak raw database errors to clients.
+      console.error('[import-transactions] RPC failed', {
+        code: error.code,
+        message: error.message
+      });
+      return createErrorResponse(res, 500, 'Failed to import transactions', 'internal_error');
+    }
+
+    const inserted = typeof (data as { inserted?: unknown })?.inserted === 'number'
+      ? (data as { inserted: number }).inserted
+      : rows.length;
+    const response: ImportTransactionsResponse = { inserted };
+    return res.status(200).json(response);
+  } catch (error) {
+    if (error instanceof AuthError) {
+      return createErrorResponse(res, error.status, error.message, error.code);
+    }
+    console.error('[import-transactions] Unexpected error', error);
+    return createErrorResponse(res, 500, 'Unexpected error', 'internal_error');
+  }
+}
+
+// Safety net: report any unhandled throw to Sentry (no-op without SENTRY_DSN).
+export default withSentry(handler);

--- a/src/components/QIFImportModal.test.tsx
+++ b/src/components/QIFImportModal.test.tsx
@@ -432,7 +432,10 @@ describe('QIFImportModal', () => {
       const mockImportResult = {
         transactions: [{ id: 'trans1', amount: 100, description: 'Test' }],
         newTransactions: 1,
-        duplicates: 0
+        duplicates: 0,
+        invalidDates: 0,
+        matchedCategories: 0,
+        unmatchedCategories: []
       };
       
       vi.mocked(qifImportService.importTransactions).mockResolvedValueOnce(mockImportResult);
@@ -456,7 +459,10 @@ describe('QIFImportModal', () => {
       const mockImportResult = {
         transactions: [{ id: 'trans1', amount: 100, description: 'Test' }],
         newTransactions: 1,
-        duplicates: 3
+        duplicates: 3,
+        invalidDates: 0,
+        matchedCategories: 0,
+        unmatchedCategories: []
       };
       
       vi.mocked(qifImportService.importTransactions).mockResolvedValueOnce(mockImportResult);
@@ -510,7 +516,10 @@ describe('QIFImportModal', () => {
       const mockImportResult = {
         transactions: [{ id: 'trans1', amount: 100, description: 'Test' }],
         newTransactions: 1,
-        duplicates: 0
+        duplicates: 0,
+        invalidDates: 0,
+        matchedCategories: 0,
+        unmatchedCategories: []
       };
       
       vi.mocked(qifImportService.importTransactions).mockResolvedValueOnce(mockImportResult);
@@ -533,7 +542,10 @@ describe('QIFImportModal', () => {
       const mockImportResult = {
         transactions: [{ id: 'trans1', amount: 100, description: 'Test' }],
         newTransactions: 1,
-        duplicates: 0
+        duplicates: 0,
+        invalidDates: 0,
+        matchedCategories: 0,
+        unmatchedCategories: []
       };
       
       vi.mocked(qifImportService.importTransactions).mockResolvedValueOnce(mockImportResult);
@@ -601,7 +613,10 @@ describe('QIFImportModal', () => {
       const mockImportResult = {
         transactions: [{ id: 'trans1', amount: 100, description: 'Test' }],
         newTransactions: 1,
-        duplicates: 0
+        duplicates: 0,
+        invalidDates: 0,
+        matchedCategories: 0,
+        unmatchedCategories: []
       };
       
       vi.mocked(qifImportService.parseQIF).mockReturnValueOnce(mockParseResult);
@@ -643,7 +658,10 @@ describe('QIFImportModal', () => {
       const mockImportResult = {
         transactions: [{ id: 'trans1', amount: 100, description: 'Test' }],
         newTransactions: 1,
-        duplicates: 0
+        duplicates: 0,
+        invalidDates: 0,
+        matchedCategories: 0,
+        unmatchedCategories: []
       };
       
       vi.mocked(qifImportService.parseQIF).mockReturnValueOnce(mockParseResult);

--- a/src/components/QIFImportModal.tsx
+++ b/src/components/QIFImportModal.tsx
@@ -1,6 +1,8 @@
 import React, { useState, useCallback, useMemo } from 'react';
+import { useAuth } from '@clerk/clerk-react';
 import { useApp } from '../contexts/AppContextSupabase';
 import { qifImportService } from '../services/qifImportService';
+import { transactionImportService } from '../services/transactionImportService';
 import type { Account } from '../types';
 import type { QIFParseResult } from '../services/qifImportService';
 import { Modal } from './common/Modal';
@@ -29,6 +31,10 @@ type ImportOutcome =
       imported: number;
       duplicates: number;
       invalidDates: number;
+      matchedCategories: number;
+      unmatchedCategories: { name: string; count: number }[];
+      /** False when a chunk failed partway — imported < intended. */
+      complete: boolean;
       account: Account | null;
     }
   | {
@@ -37,10 +43,12 @@ type ImportOutcome =
     };
 
 export default function QIFImportModal({ isOpen, onClose }: QIFImportModalProps): React.JSX.Element {
-  const { accounts, transactions, categories, addTransaction } = useApp();
+  const { accounts, transactions, categories, addTransaction, refreshAccountsAndTransactions, isUsingSupabase } = useApp();
+  const { getToken } = useAuth();
   const { formatCurrency } = useCurrencyDecimal();
   const [file, setFile] = useState<File | null>(null);
   const [isProcessing, setIsProcessing] = useState(false);
+  const [progress, setProgress] = useState<{ inserted: number; total: number } | null>(null);
   const [parseResult, setParseResult] = useState<QIFParseResult | null>(null);
   const [importResult, setImportResult] = useState<ImportOutcome | null>(null);
   const [selectedAccountId, setSelectedAccountId] = useState<string>('');
@@ -103,6 +111,7 @@ export default function QIFImportModal({ isOpen, onClose }: QIFImportModalProps)
     if (!parseResult || !file || !selectedAccountId) return;
 
     setIsProcessing(true);
+    setProgress(null);
 
     try {
       const content = await file.text();
@@ -116,17 +125,44 @@ export default function QIFImportModal({ isOpen, onClose }: QIFImportModalProps)
         }
       );
 
-      for (const transaction of result.transactions) {
-        addTransaction(transaction);
+      let insertedCount = result.transactions.length;
+      let complete = true;
+
+      if (isUsingSupabase) {
+        // Cloud: write via the chunked, awaited bulk endpoint (one atomic RPC
+        // per chunk) so a large statement can't flood the API and lose rows.
+        transactionImportService.setAuthTokenProvider(() => getToken());
+        const bulk = await transactionImportService.importInChunks(
+          selectedAccountId,
+          result.transactions,
+          { onProgress: setProgress }
+        );
+        insertedCount = bulk.inserted;
+        complete = bulk.complete;
+        // Pull the freshly-inserted rows + updated balance into the app.
+        await refreshAccountsAndTransactions();
+        if (!complete) {
+          throw new Error(
+            `Imported ${bulk.inserted} of ${bulk.total} transactions before an error stopped the import.`
+          );
+        }
+      } else {
+        // Local/demo mode: no cloud endpoint — write sequentially and awaited.
+        for (const transaction of result.transactions) {
+          await addTransaction(transaction);
+        }
       }
 
       const account = accounts.find(a => a.id === selectedAccountId) ?? null;
 
       setImportResult({
         success: true,
-        imported: result.newTransactions,
+        imported: insertedCount,
         duplicates: result.duplicates,
         invalidDates: result.invalidDates,
+        matchedCategories: result.matchedCategories,
+        unmatchedCategories: result.unmatchedCategories,
+        complete,
         account
       });
     } catch (error) {
@@ -137,8 +173,9 @@ export default function QIFImportModal({ isOpen, onClose }: QIFImportModalProps)
       });
     } finally {
       setIsProcessing(false);
+      setProgress(null);
     }
-  }, [accounts, addTransaction, categories, file, parseResult, selectedAccountId, skipDuplicates, transactions, logger]);
+  }, [accounts, addTransaction, categories, file, getToken, isUsingSupabase, parseResult, refreshAccountsAndTransactions, selectedAccountId, skipDuplicates, transactions, logger]);
   
   // Reset modal
   const resetModal = useCallback(() => {
@@ -146,6 +183,7 @@ export default function QIFImportModal({ isOpen, onClose }: QIFImportModalProps)
     setParseResult(null);
     setImportResult(null);
     setSelectedAccountId('');
+    setProgress(null);
   }, []);
   
   return (
@@ -288,11 +326,28 @@ export default function QIFImportModal({ isOpen, onClose }: QIFImportModalProps)
               </div>
             </div>
             
+            {/* Progress (large cloud imports run in chunks) */}
+            {isProcessing && progress && progress.total > 0 && (
+              <div>
+                <div className="flex justify-between text-xs text-gray-600 dark:text-gray-400 mb-1">
+                  <span>Importing…</span>
+                  <span>{progress.inserted.toLocaleString()} / {progress.total.toLocaleString()}</span>
+                </div>
+                <div className="h-2 bg-gray-200 dark:bg-gray-700 rounded-full overflow-hidden">
+                  <div
+                    className="h-full bg-[#1a2332] dark:bg-blue-500 transition-all"
+                    style={{ width: `${Math.min(100, Math.round((progress.inserted / progress.total) * 100))}%` }}
+                  />
+                </div>
+              </div>
+            )}
+
             {/* Actions */}
             <div className="flex justify-end gap-3">
               <button
                 onClick={resetModal}
-                className="px-4 py-2 text-gray-700 dark:text-gray-300 hover:text-gray-900 dark:hover:text-white"
+                disabled={isProcessing}
+                className="px-4 py-2 text-gray-700 dark:text-gray-300 hover:text-gray-900 dark:hover:text-white disabled:opacity-50"
               >
                 Cancel
               </button>
@@ -334,6 +389,31 @@ export default function QIFImportModal({ isOpen, onClose }: QIFImportModalProps)
                   <p className="text-sm text-yellow-600 dark:text-yellow-400 mb-6">
                     Skipped {importResult.invalidDates} row{importResult.invalidDates === 1 ? '' : 's'} with an unrecognised date
                   </p>
+                )}
+
+                {importResult.matchedCategories > 0 && (
+                  <p className="text-sm text-green-600 dark:text-green-400 mb-2">
+                    Matched {importResult.matchedCategories.toLocaleString()} transaction{importResult.matchedCategories === 1 ? '' : 's'} to your existing categories
+                  </p>
+                )}
+
+                {importResult.unmatchedCategories.length > 0 && (
+                  <div className="text-sm text-gray-600 dark:text-gray-400 mb-6 text-left max-w-md mx-auto bg-gray-50 dark:bg-gray-700/50 rounded-lg p-3">
+                    <p className="font-medium text-gray-800 dark:text-gray-200 mb-1">
+                      {importResult.unmatchedCategories.length} categor{importResult.unmatchedCategories.length === 1 ? 'y' : 'ies'} in the file don’t exist in the app yet:
+                    </p>
+                    <ul className="list-disc list-inside space-y-0.5">
+                      {importResult.unmatchedCategories.slice(0, 8).map(c => (
+                        <li key={c.name}>{c.name} <span className="text-gray-400">({c.count})</span></li>
+                      ))}
+                      {importResult.unmatchedCategories.length > 8 && (
+                        <li className="list-none text-gray-400">…and {importResult.unmatchedCategories.length - 8} more</li>
+                      )}
+                    </ul>
+                    <p className="text-xs text-gray-500 dark:text-gray-400 mt-2">
+                      Those transactions kept their original category text so nothing is lost. Create these categories (or ask to auto-create them) to link them up.
+                    </p>
+                  </div>
                 )}
               </>
             ) : (

--- a/src/services/qifImportService.test.ts
+++ b/src/services/qifImportService.test.ts
@@ -973,4 +973,57 @@ PImpossible
       expect(result.invalidDates).toBe(1);
     });
   });
+
+  describe('category matching', () => {
+    const appCategories: Category[] = [
+      { id: 'sub-food', name: 'Food', type: 'expense', level: 'sub' },
+      { id: 'det-groceries', name: 'Groceries', type: 'expense', level: 'detail', parentId: 'sub-food' },
+      { id: 'sub-income', name: 'Income', type: 'income', level: 'sub' },
+      { id: 'det-salary', name: 'Salary', type: 'income', level: 'detail', parentId: 'sub-income' }
+    ];
+
+    it('matches QIF categories to existing app category ids and reports unmatched', async () => {
+      const qif = `!Type:Bank
+D13/01/2024
+T-40.00
+PSupermarket
+LFood:Groceries
+^
+D15/01/2024
+T2000.00
+PEmployer
+LSalary
+^
+D16/01/2024
+T-10.00
+PMystery shop
+LObscureThing
+^`;
+
+      const result = await qifImportService.importTransactions(qif, 'acc1', [], {
+        categories: appCategories
+      });
+
+      expect(result.transactions[0].category).toBe('det-groceries'); // matched by path leaf
+      expect(result.transactions[1].category).toBe('det-salary');    // matched by name
+      expect(result.transactions[2].category).toBe('ObscureThing');  // no match — raw text kept
+      expect(result.matchedCategories).toBe(2);
+      expect(result.unmatchedCategories).toEqual([{ name: 'ObscureThing', count: 1 }]);
+    });
+
+    it('leaves categories untouched (raw name) when no app categories are provided', async () => {
+      const qif = `!Type:Bank
+D13/01/2024
+T-40.00
+PShop
+LGroceries
+^`;
+
+      const result = await qifImportService.importTransactions(qif, 'acc1', []);
+
+      expect(result.transactions[0].category).toBe('Groceries');
+      expect(result.matchedCategories).toBe(0);
+      expect(result.unmatchedCategories).toEqual([]);
+    });
+  });
 });

--- a/src/services/qifImportService.ts
+++ b/src/services/qifImportService.ts
@@ -1,5 +1,6 @@
 import type { Transaction, Category } from '../types';
 import { smartCategorizationService } from './smartCategorizationService';
+import { buildCategoryMatcher } from '../utils/qifCategoryMatch';
 import { toDecimal, toNumber } from '../utils/decimal';
 
 export interface QIFTransaction {
@@ -293,11 +294,22 @@ export class QIFImportService {
     duplicates: number;
     newTransactions: number;
     invalidDates: number;
+    /** How many rows inherited an existing app category from their QIF category. */
+    matchedCategories: number;
+    /** Distinct QIF categories with no app match, most common first. */
+    unmatchedCategories: { name: string; count: number }[];
   }> {
     const parseResult = this.parseQIF(qifContent);
     const transactions: Omit<Transaction, 'id'>[] = [];
     let duplicates = 0;
-    
+
+    // Match the QIF file's own categories to the app's existing ones.
+    const categoryMatcher = options.categories && options.categories.length > 0
+      ? buildCategoryMatcher(options.categories)
+      : null;
+    let matchedCategoryCount = 0;
+    const unmatchedCategoryCounts = new Map<string, number>();
+
     for (const qifTrx of parseResult.transactions) {
       // Duplicate check by date, SIGNED amount, and payee similarity
       const isDuplicate = existingTransactions.some(existing => {
@@ -343,14 +355,32 @@ export class QIFImportService {
         description = description ? `${description} - ${qifTrx.memo}` : qifTrx.memo;
       }
       description = description || 'QIF Transaction';
-      
+
+      // Category: prefer the QIF file's own category (MS Money already tagged
+      // it) matched to a category that exists in the app. A name with no match
+      // is kept as-is and reported, so the user can create/auto-create it rather
+      // than have it silently guessed or dropped.
+      let resolvedCategory = qifTrx.category || '';
+      if (qifTrx.category && categoryMatcher) {
+        const matchedId = categoryMatcher.match(qifTrx.category, type);
+        if (matchedId) {
+          resolvedCategory = matchedId;
+          matchedCategoryCount++;
+        } else {
+          unmatchedCategoryCounts.set(
+            qifTrx.category,
+            (unmatchedCategoryCounts.get(qifTrx.category) ?? 0) + 1
+          );
+        }
+      }
+
       const transaction: Omit<Transaction, 'id'> = {
         date: new Date(qifTrx.date),
         description,
         amount,
         type,
         accountId: targetAccountId,
-        category: qifTrx.category || '',
+        category: resolvedCategory,
         cleared: qifTrx.cleared || false,
         notes: qifTrx.checkNumber ? `Check #: ${qifTrx.checkNumber}` : undefined,
         isRecurring: false
@@ -378,7 +408,10 @@ export class QIFImportService {
       transactions,
       duplicates,
       newTransactions: transactions.length,
-      invalidDates: parseResult.invalidDateCount
+      invalidDates: parseResult.invalidDateCount,
+      matchedCategories: matchedCategoryCount,
+      unmatchedCategories: Array.from(unmatchedCategoryCounts, ([name, count]) => ({ name, count }))
+        .sort((a, b) => b.count - a.count)
     };
   }
 }

--- a/src/services/transactionImportService.test.ts
+++ b/src/services/transactionImportService.test.ts
@@ -1,0 +1,118 @@
+import { describe, it, expect, vi } from 'vitest';
+import { TransactionImportService } from './transactionImportService';
+import type { Transaction } from '../types';
+
+const makeTxns = (n: number): Omit<Transaction, 'id'>[] =>
+  Array.from({ length: n }, (_, i) => ({
+    date: new Date('2024-01-01'),
+    description: `Txn ${i}`,
+    amount: -1,
+    type: 'expense',
+    accountId: 'acc1',
+    category: '',
+    cleared: false
+  }) as Omit<Transaction, 'id'>);
+
+const okResp = (inserted: number) => ({
+  ok: true,
+  status: 200,
+  json: async () => ({ inserted })
+});
+const errResp = (status: number, error: string) => ({
+  ok: false,
+  status,
+  json: async () => ({ error })
+});
+
+const bodyOf = (init: unknown): { accountId: string; transactions: { description: string }[] } =>
+  JSON.parse((init as RequestInit).body as string);
+
+describe('TransactionImportService', () => {
+  it('chunks large imports into multiple requests and sums inserted', async () => {
+    const fetchMock = vi.fn(async (_url: unknown, init: unknown) => okResp(bodyOf(init).transactions.length));
+    const svc = new TransactionImportService({
+      fetch: fetchMock as unknown as typeof fetch,
+      authTokenProvider: () => 'tok'
+    });
+
+    const result = await svc.importInChunks('acc1', makeTxns(2500));
+
+    expect(result).toEqual({ inserted: 2500, total: 2500, complete: true });
+    expect(fetchMock).toHaveBeenCalledTimes(3); // 1000 + 1000 + 500
+  });
+
+  it('posts to the endpoint with the bearer token and account id', async () => {
+    const fetchMock = vi.fn(async () => okResp(1));
+    const svc = new TransactionImportService({
+      fetch: fetchMock as unknown as typeof fetch,
+      authTokenProvider: async () => 'my-token'
+    });
+
+    await svc.importInChunks('acc-42', makeTxns(1));
+
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toContain('/api/data/import-transactions');
+    expect(init.headers).toMatchObject({ Authorization: 'Bearer my-token' });
+    expect(bodyOf(init).accountId).toBe('acc-42');
+  });
+
+  it('reports progress as chunks complete', async () => {
+    const fetchMock = vi.fn(async (_url: unknown, init: unknown) => okResp(bodyOf(init).transactions.length));
+    const svc = new TransactionImportService({
+      fetch: fetchMock as unknown as typeof fetch,
+      authTokenProvider: () => 't'
+    });
+
+    const seen: number[] = [];
+    await svc.importInChunks('acc1', makeTxns(2000), { onProgress: p => seen.push(p.inserted) });
+
+    expect(seen).toEqual([1000, 2000]);
+  });
+
+  it('retries a failing chunk then stops, reporting rows already committed', async () => {
+    const fetchMock = vi.fn(async (_url: unknown, init: unknown) => {
+      // First chunk (starts at Txn 0) succeeds; the second always 500s.
+      return bodyOf(init).transactions[0].description === 'Txn 0'
+        ? okResp(bodyOf(init).transactions.length)
+        : errResp(500, 'boom');
+    });
+    const svc = new TransactionImportService({
+      fetch: fetchMock as unknown as typeof fetch,
+      authTokenProvider: () => 't'
+    });
+
+    const result = await svc.importInChunks('acc1', makeTxns(2000));
+
+    expect(result.complete).toBe(false);
+    expect(result.inserted).toBe(1000); // first chunk landed
+    expect(result.error).toContain('boom');
+    // chunk 1 (1 call) + chunk 2 retried up to 3 times
+    expect(fetchMock).toHaveBeenCalledTimes(4);
+  });
+
+  it('never calls fetch and reports incomplete when no token is available', async () => {
+    const fetchMock = vi.fn();
+    const svc = new TransactionImportService({
+      fetch: fetchMock as unknown as typeof fetch,
+      authTokenProvider: () => null
+    });
+
+    const result = await svc.importInChunks('acc1', makeTxns(1));
+
+    expect(result.complete).toBe(false);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('is a no-op for an empty import', async () => {
+    const fetchMock = vi.fn();
+    const svc = new TransactionImportService({
+      fetch: fetchMock as unknown as typeof fetch,
+      authTokenProvider: () => 't'
+    });
+
+    const result = await svc.importInChunks('acc1', []);
+
+    expect(result).toEqual({ inserted: 0, total: 0, complete: true });
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+});

--- a/src/services/transactionImportService.ts
+++ b/src/services/transactionImportService.ts
@@ -1,0 +1,186 @@
+import type { Transaction } from '../types';
+import { createScopedLogger } from '../loggers/scopedLogger';
+
+/**
+ * Bulk transaction import client.
+ *
+ * File imports (QIF/CSV) used to write one row at a time from the browser,
+ * un-awaited — a large statement fired thousands of concurrent writes that the
+ * API rejected en masse. This posts the rows to /api/data/import-transactions in
+ * awaited chunks, each of which the server inserts in a single atomic RPC.
+ */
+
+type FetchLike = typeof fetch;
+type AuthTokenProvider = () => Promise<string | null> | string | null;
+
+interface TransactionImportServiceOptions {
+  fetch?: FetchLike;
+  apiBaseUrl?: string;
+  authTokenProvider?: AuthTokenProvider | null;
+}
+
+export interface BulkImportProgress {
+  /** Rows confirmed inserted so far. */
+  inserted: number;
+  /** Total rows to import. */
+  total: number;
+}
+
+export interface BulkImportResult {
+  inserted: number;
+  total: number;
+  /** True when every chunk succeeded. */
+  complete: boolean;
+  /** Message from the first chunk that failed, if any. */
+  error?: string;
+}
+
+// Must stay <= the endpoint's MAX_ROWS, and small enough to sit well under
+// Vercel's request body limit (11k rows -> ~11 requests).
+const CHUNK_SIZE = 1000;
+const MAX_ATTEMPTS = 3;
+
+const logger = createScopedLogger('TransactionImportService');
+
+interface ImportRow {
+  date: string;
+  description: string;
+  amount: number;
+  type: string;
+  category: string;
+  notes: string;
+  tags?: string[];
+  is_cleared: boolean;
+  is_recurring: boolean;
+}
+
+const toIsoDate = (value: Date | string): string => {
+  const date = value instanceof Date ? value : new Date(value);
+  return date.toISOString().split('T')[0];
+};
+
+const toRow = (t: Omit<Transaction, 'id'>): ImportRow => {
+  const tags = Array.isArray(t.tags) ? t.tags.filter(tag => typeof tag === 'string' && tag.length > 0) : [];
+  return {
+    date: toIsoDate(t.date),
+    description: t.description,
+    amount: t.amount,
+    type: t.type,
+    category: t.category ?? '',
+    notes: t.notes ?? '',
+    ...(tags.length > 0 ? { tags } : {}),
+    is_cleared: Boolean(t.cleared),
+    is_recurring: Boolean((t as { isRecurring?: boolean }).isRecurring)
+  };
+};
+
+const chunk = <T>(items: T[], size: number): T[][] => {
+  const out: T[][] = [];
+  for (let i = 0; i < items.length; i += size) {
+    out.push(items.slice(i, i + size));
+  }
+  return out;
+};
+
+export class TransactionImportService {
+  private fetcher: FetchLike | null;
+  private apiBaseUrl: string;
+  private tokenProvider: AuthTokenProvider | null;
+
+  constructor(options: TransactionImportServiceOptions = {}) {
+    const defaultFetch = typeof fetch !== 'undefined' ? (fetch.bind(globalThis) as FetchLike) : null;
+    this.fetcher = options.fetch ?? defaultFetch;
+    const envBase = typeof import.meta !== 'undefined'
+      ? (import.meta.env?.VITE_BANKING_API_BASE_URL as string | undefined)
+      : undefined;
+    this.apiBaseUrl = (options.apiBaseUrl ?? envBase ?? '').trim();
+    this.tokenProvider = options.authTokenProvider ?? null;
+  }
+
+  setAuthTokenProvider(provider: AuthTokenProvider | null): void {
+    this.tokenProvider = provider;
+  }
+
+  private resolveUrl(path: string): string {
+    const base = this.apiBaseUrl.replace(/\/+$/, '');
+    return base ? `${base}${path}` : path;
+  }
+
+  private async postChunk(accountId: string, rows: ImportRow[]): Promise<number> {
+    if (!this.fetcher) {
+      throw new Error('Fetch API is not available');
+    }
+    const token = this.tokenProvider ? await this.tokenProvider() : null;
+    if (!token) {
+      throw new Error('Missing authentication token');
+    }
+
+    const response = await this.fetcher(this.resolveUrl('/api/data/import-transactions'), {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${token}`
+      },
+      body: JSON.stringify({ accountId, transactions: rows })
+    });
+
+    if (!response.ok) {
+      let message = `Import request failed (${response.status})`;
+      try {
+        const payload = await response.json() as { error?: string };
+        if (payload?.error) {
+          message = payload.error;
+        }
+      } catch {
+        // non-JSON error body — keep the status-based message
+      }
+      throw new Error(message);
+    }
+
+    const payload = await response.json() as { inserted?: number };
+    return typeof payload?.inserted === 'number' ? payload.inserted : rows.length;
+  }
+
+  /**
+   * Import transactions into an account in awaited chunks. Each chunk is retried
+   * up to MAX_ATTEMPTS on transient failure; on persistent failure the import
+   * stops and reports how many rows landed (chunks that already succeeded are
+   * committed server-side and are not rolled back).
+   */
+  async importInChunks(
+    accountId: string,
+    transactions: Omit<Transaction, 'id'>[],
+    opts: { onProgress?: (progress: BulkImportProgress) => void } = {}
+  ): Promise<BulkImportResult> {
+    const total = transactions.length;
+    if (total === 0) {
+      return { inserted: 0, total: 0, complete: true };
+    }
+
+    const batches = chunk(transactions.map(toRow), CHUNK_SIZE);
+    let inserted = 0;
+
+    for (const batch of batches) {
+      let attempt = 0;
+      for (;;) {
+        attempt += 1;
+        try {
+          inserted += await this.postChunk(accountId, batch);
+          opts.onProgress?.({ inserted, total });
+          break;
+        } catch (error) {
+          const message = error instanceof Error ? error.message : 'Import failed';
+          if (attempt >= MAX_ATTEMPTS) {
+            logger.error('Chunk failed after retries; stopping import', error as Error);
+            return { inserted, total, complete: false, error: message };
+          }
+          logger.warn(`Chunk attempt ${attempt} failed, retrying`, message);
+        }
+      }
+    }
+
+    return { inserted, total, complete: true };
+  }
+}
+
+export const transactionImportService = new TransactionImportService();

--- a/src/utils/qifCategoryMatch.test.ts
+++ b/src/utils/qifCategoryMatch.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect } from 'vitest';
+import { buildCategoryMatcher } from './qifCategoryMatch';
+import type { Category } from '../types';
+
+const cats: Category[] = [
+  { id: 'sub-bills', name: 'Bills', type: 'expense', level: 'sub' },
+  { id: 'det-electric', name: 'Electric', type: 'expense', level: 'detail', parentId: 'sub-bills' },
+  { id: 'sub-food', name: 'Food', type: 'expense', level: 'sub' },
+  { id: 'det-groceries', name: 'Groceries', type: 'expense', level: 'detail', parentId: 'sub-food' },
+  { id: 'sub-income', name: 'Income', type: 'income', level: 'sub' },
+  { id: 'det-salary', name: 'Salary', type: 'income', level: 'detail', parentId: 'sub-income' },
+  // "Other" exists under two parents / two directions — tests disambiguation.
+  { id: 'det-other-exp', name: 'Other', type: 'expense', level: 'detail', parentId: 'sub-bills' },
+  { id: 'det-other-inc', name: 'Other', type: 'income', level: 'detail', parentId: 'sub-income' }
+];
+
+describe('buildCategoryMatcher', () => {
+  const { match } = buildCategoryMatcher(cats);
+
+  it('matches a leaf name case-insensitively', () => {
+    expect(match('groceries', 'expense')).toBe('det-groceries');
+    expect(match('  GROCERIES  ', 'expense')).toBe('det-groceries');
+  });
+
+  it('matches the leaf of a MS Money Parent:Sub path', () => {
+    expect(match('Food:Groceries', 'expense')).toBe('det-groceries');
+    expect(match('Bills:Electric', 'expense')).toBe('det-electric');
+    expect(match('Bills/Electric', 'expense')).toBe('det-electric');
+  });
+
+  it('disambiguates a name under two parents by the parent segment', () => {
+    expect(match('Bills:Other', 'expense')).toBe('det-other-exp');
+    expect(match('Income:Other', 'income')).toBe('det-other-inc');
+  });
+
+  it('disambiguates by transaction direction when the parent is absent', () => {
+    expect(match('Other', 'income')).toBe('det-other-inc');
+    expect(match('Other', 'expense')).toBe('det-other-exp');
+  });
+
+  it('returns null when nothing matches', () => {
+    expect(match('Nonexistent', 'expense')).toBeNull();
+    expect(match('', 'expense')).toBeNull();
+  });
+
+  it('ignores sub/parent categories — transactions use detail leaves', () => {
+    expect(match('Bills', 'expense')).toBeNull();
+  });
+
+  it('skips inactive categories', () => {
+    const matcher = buildCategoryMatcher([
+      ...cats,
+      { id: 'det-dead', name: 'DeadCat', type: 'expense', level: 'detail', parentId: 'sub-bills', isActive: false }
+    ]);
+    expect(matcher.match('DeadCat', 'expense')).toBeNull();
+  });
+});

--- a/src/utils/qifCategoryMatch.ts
+++ b/src/utils/qifCategoryMatch.ts
@@ -1,0 +1,92 @@
+import type { Category } from '../types';
+
+/**
+ * Match category NAMES carried in a QIF file (the `L` field, e.g. MS Money's
+ * "Bills:Utilities") to the detail categories the user already has in the app,
+ * so imported transactions inherit real category IDs instead of raw text.
+ *
+ * Matching is normalized (case/'spacing'-insensitive) and hierarchy-aware:
+ * the leaf segment is matched first, disambiguated by the parent segment and
+ * then the transaction's direction when a name exists under more than one
+ * parent. Returns null when there is no confident match — the caller keeps the
+ * original text and reports it, rather than guessing wrong.
+ */
+
+export interface CategoryMatcher {
+  match: (qifCategory: string, txnType: 'income' | 'expense' | 'transfer') => string | null;
+}
+
+const norm = (value: string): string => value.trim().toLowerCase().replace(/\s+/g, ' ');
+
+const splitPath = (raw: string): string[] =>
+  raw.split(/[:/>]/).map(norm).filter(Boolean);
+
+export function buildCategoryMatcher(categories: Category[]): CategoryMatcher {
+  const active = categories.filter(c => c.isActive !== false);
+  const byId = new Map(active.map(c => [c.id, c]));
+  const details = active.filter(c => c.level === 'detail');
+
+  // Normalized detail name -> the detail categories carrying it. A name can
+  // legitimately exist under several parents (e.g. "Other").
+  const detailByName = new Map<string, Category[]>();
+  for (const detail of details) {
+    const key = norm(detail.name);
+    const existing = detailByName.get(key);
+    if (existing) {
+      existing.push(detail);
+    } else {
+      detailByName.set(key, [detail]);
+    }
+  }
+
+  const parentNameOf = (category: Category): string | null => {
+    if (!category.parentId) {
+      return null;
+    }
+    const parent = byId.get(category.parentId);
+    return parent ? norm(parent.name) : null;
+  };
+
+  const match = (qifCategory: string, txnType: 'income' | 'expense' | 'transfer'): string | null => {
+    if (!qifCategory) {
+      return null;
+    }
+    const segments = splitPath(qifCategory);
+    if (segments.length === 0) {
+      return null;
+    }
+    const leaf = segments[segments.length - 1];
+    const parent = segments.length >= 2 ? segments[segments.length - 2] : null;
+
+    let candidates = detailByName.get(leaf);
+    if (!candidates || candidates.length === 0) {
+      return null;
+    }
+    if (candidates.length === 1) {
+      return candidates[0].id;
+    }
+
+    // Disambiguate by the parent segment from the QIF path.
+    if (parent) {
+      const byParent = candidates.filter(c => parentNameOf(c) === parent);
+      if (byParent.length === 1) {
+        return byParent[0].id;
+      }
+      if (byParent.length > 1) {
+        candidates = byParent;
+      }
+    }
+
+    // Then by transaction direction ('both' is always eligible).
+    if (txnType === 'income' || txnType === 'expense') {
+      const byType = candidates.filter(c => c.type === txnType || c.type === 'both');
+      if (byType.length >= 1) {
+        candidates = byType;
+      }
+    }
+
+    return candidates[0]?.id ?? null;
+  };
+
+  return { match };
+}

--- a/supabase/migrations/20260709120000_import_transactions_atomic.sql
+++ b/supabase/migrations/20260709120000_import_transactions_atomic.sql
@@ -1,0 +1,102 @@
+-- Bulk atomic import for manual/file imports (QIF, CSV, OFX).
+--
+-- WHY: file imports previously wrote one row at a time from the browser,
+-- un-awaited. A large statement (e.g. an 11k-row MS Money QIF) fired thousands
+-- of concurrent create_transaction_atomic RPCs, which the API rate/connection
+-- limits reject en masse — most rows silently failed. Bank feeds don't hit this
+-- because they insert via a single server-side bulk RPC. This gives file imports
+-- the same treatment.
+--
+-- One call = one database transaction: every insert + the single balance effect
+-- + the audit rows commit together or not at all. Columns and casts mirror
+-- create_transaction_atomic exactly (note the cleared column is `is_cleared`).
+--
+-- Security: SERVER-ONLY (service_role). p_user_id is the boundary — the service
+-- role bypasses RLS, so every row is written as p_user_id and the target account
+-- is verified to belong to p_user_id (FOR UPDATE) before anything is inserted.
+-- account_id is taken from p_account_id (a file import targets one account), not
+-- from the rows, so a caller can't scatter rows into accounts it doesn't own.
+
+CREATE OR REPLACE FUNCTION public.import_transactions_atomic(
+  p_user_id uuid,
+  p_account_id uuid,
+  p_rows jsonb
+)
+RETURNS jsonb
+LANGUAGE plpgsql SECURITY INVOKER
+SET search_path = public
+AS $$
+DECLARE
+  r jsonb;
+  v_tx public.transactions;
+  v_sum numeric := 0;
+  v_inserted integer := 0;
+  v_before public.accounts;
+  v_after public.accounts;
+BEGIN
+  IF p_rows IS NULL OR jsonb_typeof(p_rows) <> 'array' THEN
+    RAISE EXCEPTION 'p_rows must be a jsonb array' USING ERRCODE = '22023';
+  END IF;
+
+  -- Lock + ownership check up front (service role bypasses RLS, so this is the
+  -- security boundary). Reused as the "before" snapshot for the balance audit.
+  SELECT * INTO v_before
+    FROM public.accounts
+   WHERE id = p_account_id AND user_id = p_user_id
+   FOR UPDATE;
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'account_not_found_or_not_owned'
+      USING ERRCODE = 'P0001',
+            HINT = 'The account does not exist or does not belong to this user.';
+  END IF;
+
+  FOR r IN SELECT value FROM jsonb_array_elements(p_rows) LOOP
+    INSERT INTO public.transactions (
+      user_id, account_id, description, amount, type, date,
+      category, notes, tags, is_recurring, is_cleared
+    ) VALUES (
+      p_user_id,
+      p_account_id,
+      r->>'description',
+      (r->>'amount')::numeric,
+      r->>'type',
+      (r->>'date')::date,
+      NULLIF(r->>'category', ''),
+      NULLIF(r->>'notes', ''),
+      CASE WHEN r ? 'tags' AND jsonb_typeof(r->'tags') = 'array'
+           THEN ARRAY(SELECT jsonb_array_elements_text(r->'tags'))
+           ELSE NULL END,
+      COALESCE((r->>'is_recurring')::boolean, false),
+      COALESCE((r->>'is_cleared')::boolean, false)
+    )
+    RETURNING * INTO v_tx;
+
+    PERFORM public.write_financial_audit(
+      p_user_id, 'transaction', v_tx.id, 'create', NULL, to_jsonb(v_tx)
+    );
+
+    v_sum := v_sum + v_tx.amount;
+    v_inserted := v_inserted + 1;
+  END LOOP;
+
+  -- One balance effect for the whole batch, keeping the ledger invariant
+  -- (balance = initial_balance + Σ amount). Audited like every other balance move.
+  IF v_inserted > 0 THEN
+    UPDATE public.accounts
+       SET balance = balance + v_sum,
+           updated_at = now()
+     WHERE id = p_account_id AND user_id = p_user_id
+     RETURNING * INTO v_after;
+
+    PERFORM public.write_financial_audit(
+      p_user_id, 'account', p_account_id, 'update',
+      to_jsonb(v_before), to_jsonb(v_after)
+    );
+  END IF;
+
+  RETURN jsonb_build_object('inserted', v_inserted);
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.import_transactions_atomic(uuid, uuid, jsonb) FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.import_transactions_atomic(uuid, uuid, jsonb) TO service_role;


### PR DESCRIPTION
## Summary

Makes file imports actually handle a large statement (your ~11k-row MS Money QIF), and matches the file's categories to the ones you already have in the app.

**Why this was needed:** the QIF importer wrote one row at a time from the browser, **un-awaited** — so an 11k-row file fired thousands of concurrent writes that Supabase (free tier) rejected en masse, and the failures were swallowed. That's why only ~20 of your 11k landed (a *separate* problem from the date bug in #66). Your bank feeds don't hit this because they insert via a single **server-side bulk RPC**; file imports now use the same architecture.

## Write path (mirrors the bank-sync design)

- **Migration** `import_transactions_atomic(p_user_id, p_account_id, p_rows)` — one DB transaction inserts a batch, bumps `balance` once (keeps the `balance = initial_balance + Σ amount` invariant), writes the same `write_financial_audit` rows, and verifies the account belongs to the user. `SECURITY INVOKER`, **`service_role` only** — same posture as your bank RPC. Columns/casts mirror `create_transaction_atomic` (incl. `is_cleared`).
- **Endpoint** `api/data/import-transactions.ts` — `requireAuth` (Clerk JWT → DB user id), service-role client, validates + caps rows, calls the RPC scoped to the verified user. Mirrors `api/data/delete-transaction.ts`. `account_id` comes from the request but the RPC re-checks ownership, so a caller can't write into an account it doesn't own.
- **Client** `transactionImportService` — maps rows, **chunks** (~1,000/request → ~11 calls for 11k, well under Vercel's body limit), awaited, retries transient failures, reports progress. `QIFImportModal` uses it in cloud mode (local/demo keeps an awaited per-row path), then refreshes once. The success screen now shows the **real inserted count** and a progress bar.

## Category matching (your question)

MS Money already tagged most transactions (the QIF `L` field), so instead of guessing from descriptions we match those names to the **detail categories you already have**:
- normalized (case/spacing-insensitive), **hierarchy-aware** (`Bills:Electric` → your "Electric"), disambiguated by parent segment then by transaction direction;
- unmatched names are **kept as-is (nothing lost)** and reported — the import result lists the distinct categories that don't exist yet, with counts, so we can auto-create the stragglers next if you want (zero manual tagging).

## Verification
- New tests: `qifCategoryMatch` (7), `transactionImportService` chunking/retry/token/partial-failure (6), `importTransactions` category matching (2); existing 38 modal + 41 QIF tests updated for the new result shape.
- Full suite **2851** green; `typecheck:strict`, `lint`, `build` clean. Modal render smoke-tested in preview (no console errors).
- `api/` isn't in the local tsconfig, so the **RPC + endpoint are validated by this PR's Vercel build/deploy**.

## ⚠️ Requires a migration (you run it)
Apply **`supabase/migrations/20260709120000_import_transactions_atomic.sql`** in the Supabase SQL editor before using the new cloud import. Until it's applied, the endpoint will 500 (function missing).

After this merges + the migration is applied, we do the cleanup: delete the 20 stray rows and re-import — it'll bring in all ~11k with correct dates and matched categories.

🤖 Generated with [Claude Code](https://claude.com/claude-code)