### PR TITLE
feat(datepicker): drill-up month & year navigation

### DIFF
--- a/src/components/common/DatePicker.test.tsx
+++ b/src/components/common/DatePicker.test.tsx
@@ -1,0 +1,64 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import DatePicker from './DatePicker';
+
+const open = () => fireEvent.click(screen.getByPlaceholderText('dd/mm/yyyy'));
+
+describe('DatePicker drill-up navigation', () => {
+  it('opens in day view showing the selected month and year', () => {
+    render(<DatePicker value="2024-02-15" onChange={() => {}} />);
+    open();
+    expect(screen.getByRole('button', { name: 'Select month' })).toHaveTextContent('February 2024');
+  });
+
+  it('drills day → month → year, pages back, and back down to a far-past date', () => {
+    const onChange = vi.fn();
+    render(<DatePicker value="2026-07-10" onChange={onChange} />);
+    open();
+
+    // days -> months (year 2026 in the header)
+    fireEvent.click(screen.getByRole('button', { name: 'Select month' }));
+    expect(screen.getByRole('button', { name: 'Select year' })).toHaveTextContent('2026');
+
+    // months -> years (block 2016–2027; 2008 not present yet)
+    fireEvent.click(screen.getByRole('button', { name: 'Select year' }));
+    expect(screen.getByRole('button', { name: 'Previous years' })).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: '2008' })).toBeNull();
+
+    // page back one 12-year block -> 2004–2015, then pick 2008
+    fireEvent.click(screen.getByRole('button', { name: 'Previous years' }));
+    fireEvent.click(screen.getByRole('button', { name: '2008' }));
+    expect(screen.getByRole('button', { name: 'Select year' })).toHaveTextContent('2008');
+
+    // months -> days for Jan 2008, then pick the 15th
+    fireEvent.click(screen.getByRole('button', { name: 'Jan' }));
+    expect(screen.getByRole('button', { name: 'Select month' })).toHaveTextContent('January 2008');
+    fireEvent.click(screen.getByRole('button', { name: '15' }));
+
+    expect(onChange).toHaveBeenCalledWith('2008-01-15');
+  });
+
+  it('steps a year at a time in month view', () => {
+    render(<DatePicker value="2024-06-01" onChange={() => {}} />);
+    open();
+    fireEvent.click(screen.getByRole('button', { name: 'Select month' }));
+
+    fireEvent.click(screen.getByRole('button', { name: 'Previous year' }));
+    expect(screen.getByRole('button', { name: 'Select year' })).toHaveTextContent('2023');
+
+    fireEvent.click(screen.getByRole('button', { name: 'Next year' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Next year' }));
+    expect(screen.getByRole('button', { name: 'Select year' })).toHaveTextContent('2025');
+  });
+
+  it('reopens in day view even after drilling up to the year grid', () => {
+    render(<DatePicker value="2024-02-15" onChange={() => {}} />);
+    open();
+    fireEvent.click(screen.getByRole('button', { name: 'Select month' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Select year' }));
+    // close via outside click, then reopen
+    fireEvent.mouseDown(document.body);
+    open();
+    expect(screen.getByRole('button', { name: 'Select month' })).toHaveTextContent('February 2024');
+  });
+});

--- a/src/components/common/DatePicker.tsx
+++ b/src/components/common/DatePicker.tsx
@@ -14,6 +14,11 @@ const MONTHS = [
   'January', 'February', 'March', 'April', 'May', 'June',
   'July', 'August', 'September', 'October', 'November', 'December'
 ];
+const MONTHS_SHORT = MONTHS.map(m => m.slice(0, 3));
+// Years shown per page in the year view (a clean 3×4 grid).
+const YEAR_PAGE = 12;
+
+type PickerView = 'days' | 'months' | 'years';
 
 function getDaysInMonth(year: number, month: number): number {
   return new Date(year, month + 1, 0).getDate();
@@ -49,6 +54,9 @@ export default function DatePicker({ value, onChange, className = '', 'aria-labe
 
   const [viewYear, setViewYear] = useState(selectedYear ?? new Date().getFullYear());
   const [viewMonth, setViewMonth] = useState(selectedMonth ?? new Date().getMonth());
+  // Drill-up navigation: days → months → years, so jumping far back (e.g. to
+  // 2008) is two clicks on the header instead of dozens on the arrow.
+  const [view, setView] = useState<PickerView>('days');
 
   // Sync view when value changes externally
   useEffect(() => {
@@ -95,11 +103,24 @@ export default function DatePicker({ value, onChange, className = '', 'aria-labe
     setIsOpen(false);
   };
 
+  // Header drill-down picks a month/year to VIEW (not the value) and steps back
+  // down a level: years → months → days.
+  const selectMonth = (month: number) => {
+    setViewMonth(month);
+    setView('days');
+  };
+
+  const selectYear = (year: number) => {
+    setViewYear(year);
+    setView('months');
+  };
+
   const selectToday = () => {
     const now = new Date();
     onChange(toYMD(now.getFullYear(), now.getMonth(), now.getDate()));
     setViewYear(now.getFullYear());
     setViewMonth(now.getMonth());
+    setView('days');
     setIsOpen(false);
   };
 
@@ -146,6 +167,16 @@ export default function DatePicker({ value, onChange, className = '', 'aria-labe
     return day === now.getDate() && viewMonth === now.getMonth() && viewYear === now.getFullYear();
   };
 
+  // Start of the 12-year block currently in view (e.g. 2004–2015 for 2008).
+  const yearPageStart = viewYear - (((viewYear % YEAR_PAGE) + YEAR_PAGE) % YEAR_PAGE);
+  const nowYear = new Date().getFullYear();
+  const nowMonth = new Date().getMonth();
+
+  const openPicker = () => {
+    setView('days');
+    setIsOpen(o => !o);
+  };
+
   return (
     <div ref={containerRef} className="relative">
       <div className="relative">
@@ -154,7 +185,7 @@ export default function DatePicker({ value, onChange, className = '', 'aria-labe
           type="text"
           readOnly
           value={formatDisplayDate(value)}
-          onClick={() => setIsOpen(o => !o)}
+          onClick={openPicker}
           placeholder="dd/mm/yyyy"
           aria-label={ariaLabel}
           className={`w-full px-3 py-2 pr-10 cursor-pointer ${className}`}
@@ -167,62 +198,136 @@ export default function DatePicker({ value, onChange, className = '', 'aria-labe
 
       {isOpen && (
         <div className="absolute z-50 mt-1 bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-600 rounded-xl shadow-lg p-3 w-[280px]">
-          {/* Header */}
+          {/* Header — the arrows step within the current view (month / year /
+              12-year block) and the label drills UP a level (day→month→year). */}
           <div className="flex items-center justify-between mb-2">
             <button
               type="button"
-              onClick={prevMonth}
+              onClick={
+                view === 'days'
+                  ? prevMonth
+                  : view === 'months'
+                  ? () => setViewYear(y => y - 1)
+                  : () => setViewYear(y => y - YEAR_PAGE)
+              }
               className="p-1 hover:bg-gray-100 dark:hover:bg-gray-700 rounded-lg transition-colors"
-              aria-label="Previous month"
+              aria-label={view === 'days' ? 'Previous month' : view === 'months' ? 'Previous year' : 'Previous years'}
             >
               <ChevronLeftIcon size={18} />
             </button>
-            <span className="text-sm font-medium text-gray-700 dark:text-gray-200">
-              {MONTHS[viewMonth]} {viewYear}
-            </span>
+            {view === 'years' ? (
+              <span className="text-sm font-medium text-gray-700 dark:text-gray-200">
+                {yearPageStart} – {yearPageStart + YEAR_PAGE - 1}
+              </span>
+            ) : (
+              <button
+                type="button"
+                onClick={() => setView(view === 'days' ? 'months' : 'years')}
+                className="text-sm font-medium text-gray-700 dark:text-gray-200 px-2 py-1 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors"
+                aria-label={view === 'days' ? 'Select month' : 'Select year'}
+              >
+                {view === 'days' ? `${MONTHS[viewMonth]} ${viewYear}` : viewYear}
+              </button>
+            )}
             <button
               type="button"
-              onClick={nextMonth}
+              onClick={
+                view === 'days'
+                  ? nextMonth
+                  : view === 'months'
+                  ? () => setViewYear(y => y + 1)
+                  : () => setViewYear(y => y + YEAR_PAGE)
+              }
               className="p-1 hover:bg-gray-100 dark:hover:bg-gray-700 rounded-lg transition-colors"
-              aria-label="Next month"
+              aria-label={view === 'days' ? 'Next month' : view === 'months' ? 'Next year' : 'Next years'}
             >
               <ChevronRightIcon size={18} />
             </button>
           </div>
 
-          {/* Day headers */}
-          <div className="grid grid-cols-7 mb-1">
-            {DAYS.map((d, i) => (
-              <div key={i} className="text-center text-xs font-medium text-gray-400 dark:text-gray-500 py-1">
-                {d}
+          {view === 'days' && (
+            <>
+              {/* Day headers */}
+              <div className="grid grid-cols-7 mb-1">
+                {DAYS.map((d, i) => (
+                  <div key={i} className="text-center text-xs font-medium text-gray-400 dark:text-gray-500 py-1">
+                    {d}
+                  </div>
+                ))}
               </div>
-            ))}
-          </div>
 
-          {/* Day grid */}
-          <div className="grid grid-cols-7">
-            {cells.map((cell, i) => {
-              const selected = isSelected(cell.day, cell.current);
-              const today = isToday(cell.day, cell.current);
-              return (
-                <button
-                  key={i}
-                  type="button"
-                  onClick={() => cell.current && selectDay(cell.day)}
-                  disabled={!cell.current}
-                  className={`
-                    w-9 h-9 text-sm rounded-lg flex items-center justify-center transition-colors
-                    ${!cell.current ? 'text-gray-300 dark:text-gray-600 cursor-default' : 'hover:bg-gray-100 dark:hover:bg-gray-700 cursor-pointer'}
-                    ${selected ? 'bg-[#1a2332] text-white hover:bg-secondary' : ''}
-                    ${today && !selected ? 'border border-primary text-primary font-semibold' : ''}
-                    ${cell.current && !selected && !today ? 'text-gray-700 dark:text-gray-200' : ''}
-                  `}
-                >
-                  {cell.day}
-                </button>
-              );
-            })}
-          </div>
+              {/* Day grid */}
+              <div className="grid grid-cols-7">
+                {cells.map((cell, i) => {
+                  const selected = isSelected(cell.day, cell.current);
+                  const today = isToday(cell.day, cell.current);
+                  return (
+                    <button
+                      key={i}
+                      type="button"
+                      onClick={() => cell.current && selectDay(cell.day)}
+                      disabled={!cell.current}
+                      className={`
+                        w-9 h-9 text-sm rounded-lg flex items-center justify-center transition-colors
+                        ${!cell.current ? 'text-gray-300 dark:text-gray-600 cursor-default' : 'hover:bg-gray-100 dark:hover:bg-gray-700 cursor-pointer'}
+                        ${selected ? 'bg-[#1a2332] text-white hover:bg-secondary' : ''}
+                        ${today && !selected ? 'border border-primary text-primary font-semibold' : ''}
+                        ${cell.current && !selected && !today ? 'text-gray-700 dark:text-gray-200' : ''}
+                      `}
+                    >
+                      {cell.day}
+                    </button>
+                  );
+                })}
+              </div>
+            </>
+          )}
+
+          {view === 'months' && (
+            <div className="grid grid-cols-3 gap-1">
+              {MONTHS_SHORT.map((label, i) => {
+                const selected = selectedYear === viewYear && selectedMonth === i;
+                const current = nowYear === viewYear && nowMonth === i;
+                return (
+                  <button
+                    key={label}
+                    type="button"
+                    onClick={() => selectMonth(i)}
+                    className={`
+                      h-10 text-sm rounded-lg flex items-center justify-center transition-colors
+                      ${selected ? 'bg-[#1a2332] text-white hover:bg-secondary' : 'hover:bg-gray-100 dark:hover:bg-gray-700 text-gray-700 dark:text-gray-200'}
+                      ${current && !selected ? 'border border-primary text-primary font-semibold' : ''}
+                    `}
+                  >
+                    {label}
+                  </button>
+                );
+              })}
+            </div>
+          )}
+
+          {view === 'years' && (
+            <div className="grid grid-cols-3 gap-1">
+              {Array.from({ length: YEAR_PAGE }, (_, i) => yearPageStart + i).map(year => {
+                const selected = selectedYear === year;
+                const current = nowYear === year;
+                return (
+                  <button
+                    key={year}
+                    type="button"
+                    onClick={() => selectYear(year)}
+                    className={`
+                      h-10 text-sm rounded-lg flex items-center justify-center transition-colors
+                      ${selected ? 'bg-[#1a2332] text-white hover:bg-secondary' : 'hover:bg-gray-100 dark:hover:bg-gray-700 text-gray-700 dark:text-gray-200'}
+                      ${current && !selected ? 'border border-primary text-primary font-semibold' : ''}
+                    `}
+                  >
+                    {year}
+                  </button>
+                );
+              })}
+            </div>
+          )}
 
           {/* Footer */}
           <div className="flex justify-between mt-2 pt-2 border-t border-gray-100 dark:border-gray-700">


### PR DESCRIPTION
## Summary

The shared date picker only moved **one month at a time** via the ‹ › arrows. Now that imported history goes back to 2008, jumping there from the opening-balance field meant ~200 clicks. This adds the standard three-level navigation you see in most pickers.

- Click the **"February 2024"** header → a **month grid** (Jan–Dec) for that year.
- Click the **year** → a **year grid** (a 12-year block); the arrows now page **12 years** at a time.
- Click a year → months; click a month → days. Reaching **Jan 2008 from 2026 is ~6 clicks** instead of ~220.

Details: arrows step within the current view (month / year / 12-year block); the selected and the current month/year are highlighted; reopening the picker resets to day view at the selected date.

**Applies everywhere the shared `common/DatePicker` is used** — the Account Settings opening-balance date (your ask) plus the Transactions and AccountTransactions date filters. The transaction edit modals use the native browser picker, which already has year navigation.

## Verification
- Driven live in the preview: opened the filter, drilled 2026 → months → years → paged back to 2004–2015 → 2008 → Jan → 15th; the field set to **15/01/2008** and the picker closed. Reopen returned to day view at Jan 2008. No new console errors.
- 4 new tests (`DatePicker.test.tsx`) covering the full drill-down, year-page paging, year stepping, and the reopen-resets-to-days behaviour.
- `typecheck:strict`, `lint`, `test:unit` (2855), `build` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)