### PR TITLE
fix(accounts): persist low-balance-alert fields so Account Settings can save

### DIFF
--- a/src/services/__tests__/accountService.test.ts
+++ b/src/services/__tests__/accountService.test.ts
@@ -89,6 +89,61 @@ describe('AccountService (deterministic fallback)', () => {
     expect(storage.snapshot()[0].balance).toBe(250);
   });
 
+  it('maps low-balance-alert fields to snake_case columns on a cloud update (with an overdrawn opening balance)', async () => {
+    // Regression: these camelCase fields used to be sent to PostgREST verbatim
+    // (no column) which rejected the whole update — so unrelated edits like the
+    // opening balance silently failed. They must now map to snake_case columns.
+    let capturedUpdate: Record<string, unknown> = {};
+    const single = vi.fn(async () => ({
+      data: {
+        id: 'acct-1',
+        name: 'GREEN S A',
+        type: 'checking',
+        initial_balance: -18243.14,
+        is_active: true,
+        low_balance_alert_enabled: true,
+        low_balance_threshold: '150.00'
+      },
+      error: null
+    }));
+    const select = vi.fn(() => ({ single }));
+    const eqId = vi.fn(() => ({ select, eq: vi.fn(() => ({ select })) }));
+    const update = vi.fn((payload: Record<string, unknown>) => {
+      capturedUpdate = payload;
+      return { eq: eqId };
+    });
+    const from = vi.fn(() => ({ update }));
+
+    const service = createAccountService({
+      isSupabaseConfigured: () => true,
+      storageAdapter: createStorage(),
+      logger,
+      now,
+      uuid,
+      supabaseClient: { from } as unknown as never
+    });
+
+    const result = await service.updateAccount('acct-1', {
+      lowBalanceAlertEnabled: true,
+      lowBalanceThreshold: 150,
+      openingBalance: -18243.14
+    });
+
+    // Write side: camelCase → snake_case; the overdrawn balance is fine.
+    expect(from).toHaveBeenCalledWith('accounts');
+    expect(capturedUpdate).toMatchObject({
+      low_balance_alert_enabled: true,
+      low_balance_threshold: 150,
+      initial_balance: -18243.14
+    });
+    expect(capturedUpdate).not.toHaveProperty('lowBalanceAlertEnabled');
+
+    // Read side: snake_case → camelCase, numeric threshold coerced to a number.
+    expect(result.lowBalanceAlertEnabled).toBe(true);
+    expect(result.lowBalanceThreshold).toBe(150);
+    expect(result.openingBalance).toBe(-18243.14);
+  });
+
   it('allows static AccountService reconfiguration for tests', async () => {
     const storage = createStorage([baseAccount({ id: 'static' })]);
     AccountService.configure({

--- a/src/services/api/accountService.ts
+++ b/src/services/api/accountService.ts
@@ -34,6 +34,8 @@ const ACCOUNT_CAMEL_TO_DB: Record<string, string> = {
   creditLimit: 'credit_limit',
   bankBalance: 'bank_balance',
   lastReconciledDate: 'last_reconciled_date',
+  lowBalanceAlertEnabled: 'low_balance_alert_enabled',
+  lowBalanceThreshold: 'low_balance_threshold',
 };
 
 function mapAccountToDb(obj: Record<string, unknown>): Record<string, unknown> {
@@ -58,6 +60,8 @@ function mapAccountFromDb(row: Record<string, unknown>): Record<string, unknown>
     openingBalance: row.initial_balance ?? row.opening_balance,
     isActive: row.is_active,
     lastUpdated: row.last_updated ?? row.updated_at,
+    lowBalanceAlertEnabled: row.low_balance_alert_enabled === true,
+    lowBalanceThreshold: row.low_balance_threshold != null ? Number(row.low_balance_threshold) : undefined,
   };
 }
 

--- a/supabase/migrations/20260709140000_add_account_low_balance_alert.sql
+++ b/supabase/migrations/20260709140000_add_account_low_balance_alert.sql
@@ -1,0 +1,18 @@
+-- Low-balance alert persistence for accounts.
+--
+-- The "Low Balance Alert" toggle + threshold in Account Settings, and the
+-- dashboard alert that reads them, were shipped against columns that never
+-- existed on `accounts`. Every save from the Account Settings modal sent
+-- `lowBalanceAlertEnabled` / `lowBalanceThreshold`, which PostgREST rejected
+-- ("Could not find the 'lowBalanceAlertEnabled' column ... in the schema
+-- cache") — aborting the WHOLE update, so unrelated edits (e.g. the opening
+-- balance) silently failed too. Add the backing columns; the service now maps
+-- the camelCase fields to these snake_case columns.
+
+ALTER TABLE public.accounts
+  ADD COLUMN IF NOT EXISTS low_balance_alert_enabled boolean NOT NULL DEFAULT false,
+  ADD COLUMN IF NOT EXISTS low_balance_threshold numeric(20,2);
+
+-- Make PostgREST pick up the new columns immediately rather than on its next
+-- periodic reload.
+NOTIFY pgrst, 'reload schema';


### PR DESCRIPTION
## Summary

Saving **Account Settings** failed with:

> Could not find the **'lowBalanceAlertEnabled'** column of 'accounts' in the schema cache

Because that error aborts the *entire* `UPDATE`, any other edit in the same save — including a **negative/overdrawn opening balance** — silently failed with it. **Negative opening balances were never the problem** (they're valid).

## Root cause

The **Low Balance Alert** toggle + threshold exist in the Account Settings UI, the `Account` type, and the dashboard alert logic — but the `accounts` table has **no backing columns** and `accountService` has **no field mapping** for them. `mapAccountToDb` passes unmapped keys through verbatim, so the modal's `lowBalanceAlertEnabled` / `lowBalanceThreshold` reached PostgREST as camelCase and were rejected. It's a half-built feature that broke every save from that modal.

## Fix (make the feature actually persist)

- **Migration** — add `accounts.low_balance_alert_enabled` (boolean, default false) and `accounts.low_balance_threshold` (numeric), plus a `NOTIFY pgrst` schema reload.
- **accountService** — map both camelCase fields to their snake_case columns on write, and back (with numeric coercion) on read.

The account **create** path was unaffected (`AddAccountModal` doesn't send these fields). Added a cloud `updateAccount` test asserting the snake_case mapping *and* that an overdrawn opening balance passes through.

## Verification
- New account-service test (write→snake_case, read→camelCase, `-18243.14` opening balance). `typecheck:strict`, `lint`, `test:unit` (2856), `build` all pass.
- This is a cloud-only bug (demo/local mode spreads fields into localStorage and already "worked"), so it's covered by the unit test; the end-to-end save completes once the migration is applied.

## ⚠️ Requires a migration (you run it)
Apply **`supabase/migrations/20260709140000_add_account_low_balance_alert.sql`** in the Supabase SQL editor. After that, the Account Settings save (opening balance included) will succeed and the Low Balance Alert toggle will persist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)