### PR TITLE
feat(register): Payment/Deposit columns + sort by any header

### DIFF
--- a/src/pages/AccountTransactions.tsx
+++ b/src/pages/AccountTransactions.tsx
@@ -12,6 +12,7 @@ import QuickEditTransactionPanel from '../components/QuickEditTransactionPanel';
 import CategorySelector from '../components/CategorySelector';
 import { usePreferences } from '../contexts/PreferencesContext';
 import { VirtualizedTable, Column } from '../components/VirtualizedTable';
+import { compareTransactions } from '../utils/transactionSort';
 import type { Transaction } from '../types';
 
 type TransactionWithBalance = Transaction & { balance: number };
@@ -73,7 +74,7 @@ export default function AccountTransactions() {
     window.addEventListener('resize', measureTableHeight);
     return () => window.removeEventListener('resize', measureTableHeight);
   }, [measureTableHeight, showFilters]);
-  const [sortField, setSortField] = useState<'date' | 'description' | 'amount' | 'category' | 'tags'>('date');
+  const [sortField, setSortField] = useState<'date' | 'description' | 'amount' | 'category' | 'tags' | 'payment' | 'deposit'>('date');
   const [sortDirection, setSortDirection] = useState<'asc' | 'desc'>('asc');
   
   // State for modals and selection
@@ -122,31 +123,7 @@ export default function AccountTransactions() {
           (t.notes && t.notes.toLowerCase().includes(search))
         );
       })
-      .sort((a, b) => {
-        let aValue: string | number | Date = a[sortField as keyof Transaction] as string | number | Date;
-        let bValue: string | number | Date = b[sortField as keyof Transaction] as string | number | Date;
-        
-        if (sortField === 'date') {
-          const dateA = new Date(a.date).getTime();
-          const dateB = new Date(b.date).getTime();
-          
-          // If dates are different, sort by date
-          if (dateA !== dateB) {
-            aValue = dateA;
-            bValue = dateB;
-          } else {
-            // If dates are the same, sort by type (income first, then transfers, then expenses)
-            const typeOrder = { income: 0, transfer: 1, expense: 2 };
-            return typeOrder[a.type] - typeOrder[b.type];
-          }
-        }
-        
-        if (sortDirection === 'asc') {
-          return aValue > bValue ? 1 : -1;
-        } else {
-          return aValue < bValue ? 1 : -1;
-        }
-      });
+      .sort((a, b) => compareTransactions(a, b, sortField, sortDirection, categories));
   }, [account, transactions, searchTerm, dateFrom, dateTo, typeFilter, sortField, sortDirection, categories]);
   
   // Calculate running balance
@@ -565,7 +542,8 @@ export default function AccountTransactions() {
         </span>
       ),
       className: 'text-left',
-      headerClassName: 'text-left'
+      headerClassName: 'text-left',
+      sortable: true
     },
     {
       key: 'tags',
@@ -584,22 +562,36 @@ export default function AccountTransactions() {
         </div>
       ),
       className: 'text-center',
-      headerClassName: 'text-center'
+      headerClassName: 'text-center',
+      sortable: true
     },
     {
-      key: 'amount',
-      header: 'Amount',
+      key: 'payment',
+      header: 'Payment',
       width: '120px',
+      // Money out — the magnitude (no sign), in red, like MS Money's Payment column.
       accessor: (transaction) => (
-        <span className={`text-sm font-medium ${
-          transaction.amount > 0
-            ? 'text-green-600 dark:text-green-400'
-            : transaction.amount < 0
-            ? 'text-red-600 dark:text-red-400'
-            : 'text-gray-900 dark:text-gray-100'
-        }`}>
-          {formatCurrency(transaction.amount, account?.currency)}
-        </span>
+        transaction.amount < 0 ? (
+          <span className="text-sm font-medium text-red-600 dark:text-red-400">
+            {formatCurrency(Math.abs(transaction.amount), account?.currency)}
+          </span>
+        ) : null
+      ),
+      className: 'text-right',
+      headerClassName: 'text-right',
+      sortable: true
+    },
+    {
+      key: 'deposit',
+      header: 'Deposit',
+      width: '120px',
+      // Money in — in green, like MS Money's Deposit column.
+      accessor: (transaction) => (
+        transaction.amount > 0 ? (
+          <span className="text-sm font-medium text-green-600 dark:text-green-400">
+            {formatCurrency(transaction.amount, account?.currency)}
+          </span>
+        ) : null
       ),
       className: 'text-right',
       headerClassName: 'text-right',
@@ -877,8 +869,11 @@ export default function AccountTransactions() {
           rowHeight={compactView ? 36 : 44}
           selectedItems={selectedTransactionId ? new Set([selectedTransactionId]) : new Set()}
           onSort={(column, direction) => {
-            if (column === 'date' || column === 'description' || column === 'amount') {
-              setSortField(column);
+            // Every header sorts except the running Balance (which stays in its
+            // chronological order regardless — see transactionsWithBalance).
+            const sortableFields = ['date', 'description', 'category', 'tags', 'payment', 'deposit'] as const;
+            if ((sortableFields as readonly string[]).includes(column)) {
+              setSortField(column as typeof sortField);
               setSortDirection(direction);
             }
           }}

--- a/src/utils/transactionSort.test.ts
+++ b/src/utils/transactionSort.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect } from 'vitest';
+import { compareTransactions, transactionSortValue } from './transactionSort';
+import type { Transaction, Category } from '../types';
+
+const cats: Category[] = [
+  { id: 'c-food', name: 'Food', type: 'expense', level: 'detail' },
+  { id: 'c-salary', name: 'Salary', type: 'income', level: 'detail' }
+];
+
+const t = (over: Partial<Transaction>): Transaction => ({
+  id: 'x',
+  date: new Date('2024-01-15'),
+  description: 'x',
+  amount: -10,
+  type: 'expense',
+  accountId: 'a',
+  category: '',
+  cleared: false,
+  ...over
+}) as Transaction;
+
+const orderedIds = (
+  txns: Transaction[],
+  field: Parameters<typeof compareTransactions>[2],
+  dir: 'asc' | 'desc'
+) => [...txns].sort((a, b) => compareTransactions(a, b, field, dir, cats)).map(x => x.id);
+
+describe('compareTransactions', () => {
+  it('orders by signed amount for amount / payment / deposit', () => {
+    const list = [t({ id: 'a', amount: -50 }), t({ id: 'b', amount: 200 }), t({ id: 'c', amount: -10 })];
+    expect(orderedIds(list, 'amount', 'asc')).toEqual(['a', 'c', 'b']); // -50, -10, 200
+    expect(orderedIds(list, 'payment', 'asc')).toEqual(['a', 'c', 'b']);
+    expect(orderedIds(list, 'deposit', 'desc')).toEqual(['b', 'c', 'a']); // 200, -10, -50
+  });
+
+  it('orders by resolved category name (case-insensitive; uncategorised first)', () => {
+    const list = [
+      t({ id: 's', category: 'c-salary' }),
+      t({ id: 'f', category: 'c-food' }),
+      t({ id: 'u', category: '' })
+    ];
+    expect(orderedIds(list, 'category', 'asc')).toEqual(['u', 'f', 's']); // '', food, salary
+  });
+
+  it('orders by description case-insensitively', () => {
+    const list = [
+      t({ id: 'z', description: 'zebra' }),
+      t({ id: 'a', description: 'Apple' }),
+      t({ id: 'm', description: 'mango' })
+    ];
+    expect(orderedIds(list, 'description', 'asc')).toEqual(['a', 'm', 'z']);
+  });
+
+  it('orders by tags', () => {
+    const list = [t({ id: 'b', tags: ['work'] }), t({ id: 'a', tags: ['bills'] }), t({ id: 'n', tags: [] })];
+    expect(orderedIds(list, 'tags', 'asc')).toEqual(['n', 'a', 'b']); // '', bills, work
+  });
+
+  it('orders by date chronologically, tie-broken by type (income→transfer→expense)', () => {
+    const list = [
+      t({ id: 'exp', date: new Date('2024-03-01'), type: 'expense' }),
+      t({ id: 'inc', date: new Date('2024-03-01'), type: 'income' }),
+      t({ id: 'old', date: new Date('2024-01-01'), type: 'expense' })
+    ];
+    expect(orderedIds(list, 'date', 'asc')).toEqual(['old', 'inc', 'exp']);
+    // desc flips the day order but keeps the same-day income-before-expense tiebreak
+    expect(orderedIds(list, 'date', 'desc')).toEqual(['inc', 'exp', 'old']);
+  });
+
+  it('exposes the comparable value via transactionSortValue', () => {
+    expect(transactionSortValue(t({ amount: -5 }), 'payment', cats)).toBe(-5);
+    expect(transactionSortValue(t({ category: 'c-food' }), 'category', cats)).toBe('food');
+  });
+});

--- a/src/utils/transactionSort.ts
+++ b/src/utils/transactionSort.ts
@@ -1,0 +1,66 @@
+import type { Transaction, Category } from '../types';
+
+export type TransactionSortField =
+  | 'date' | 'description' | 'amount' | 'category' | 'tags' | 'payment' | 'deposit';
+
+// Same-day ordering: income, then transfers, then expenses.
+const TYPE_ORDER: Record<string, number> = { income: 0, transfer: 1, expense: 2 };
+
+/**
+ * Comparable value for a transaction under a given sort field. Payment/Deposit
+ * both order by the signed amount (they're two views of the same number);
+ * category/tags order by their display text.
+ */
+export function transactionSortValue(
+  t: Transaction,
+  field: TransactionSortField,
+  categories: Category[]
+): string | number {
+  switch (field) {
+    case 'amount':
+    case 'payment':
+    case 'deposit':
+      return t.amount;
+    case 'category':
+      return (categories.find(c => c.id === t.category)?.name ?? '').toLowerCase();
+    case 'tags':
+      return (t.tags ?? []).join(', ').toLowerCase();
+    case 'description':
+      return t.description.toLowerCase();
+    case 'date':
+      return new Date(t.date).getTime();
+    default:
+      return '';
+  }
+}
+
+/**
+ * Account-register sort comparator. Every column sorts through here EXCEPT the
+ * running Balance, which is never sorted — it is computed in chronological order
+ * and mapped back per transaction, so it stays correct under any sort.
+ *
+ * Date sorts chronologically and is tie-broken by type so same-day rows keep a
+ * stable order.
+ */
+export function compareTransactions(
+  a: Transaction,
+  b: Transaction,
+  field: TransactionSortField,
+  direction: 'asc' | 'desc',
+  categories: Category[]
+): number {
+  if (field === 'date') {
+    const dateA = new Date(a.date).getTime();
+    const dateB = new Date(b.date).getTime();
+    if (dateA !== dateB) {
+      return direction === 'asc' ? dateA - dateB : dateB - dateA;
+    }
+    return (TYPE_ORDER[a.type] ?? 0) - (TYPE_ORDER[b.type] ?? 0);
+  }
+
+  const aValue = transactionSortValue(a, field, categories);
+  const bValue = transactionSortValue(b, field, categories);
+  if (aValue < bValue) return direction === 'asc' ? -1 : 1;
+  if (aValue > bValue) return direction === 'asc' ? 1 : -1;
+  return 0;
+}


### PR DESCRIPTION
## Summary

First of a few upgrades to the account register (MS Money direction). This one:

- **Payment / Deposit columns** replace the single **Amount** column — Payment shows money out (red magnitude, no sign), Deposit shows money in (green); each blank when N/A. Matches how your MS Money register reads.
- **Every header sorts** now — Date, Description, Category, Tags, Payment, Deposit — **except the running Balance**. Category sorts by its resolved name, Payment/Deposit by the signed amount, Tags by text. (Previously only Date/Description/Amount were actually wired up.)
- **The Balance stays correct under any sort.** It was already computed chronologically and mapped back per-transaction, so sorting by e.g. Category just reorders the rows — each row keeps its own running balance rather than the column recomputing itself into nonsense.

The sort comparator is extracted into a pure, unit-tested helper (`compareTransactions`).

## Verification
- Column split confirmed live in the preview (header shows Payment/Deposit, no Amount).
- Sort behaviour locked by 6 unit tests (amount/payment/deposit, category-by-name, description, tags, date + type tiebreak, both directions). The demo register wouldn't render seeded rows this session, so the ordering is covered by tests rather than a screenshot.
- `typecheck:strict`, `lint`, `test:unit` (2862), `build` all pass.

## Coming next (separate PRs, for review)
2. A **"View"** dropdown next to Search & filters: show/hide columns + time-range presets (1 / 3 / 6 / 12 months / All / Custom — the "archive" idea).
3. **Column reordering**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)