### PR TITLE
feat(register): drag to reorder and resize columns

### DIFF
--- a/src/components/VirtualizedTable.tsx
+++ b/src/components/VirtualizedTable.tsx
@@ -1,4 +1,4 @@
-import React, { memo, useMemo, ReactNode, useCallback } from 'react';
+import React, { memo, useMemo, useState, ReactNode, useCallback } from 'react';
 import { VirtualizedList } from './VirtualizedList';
 
 export interface Column<T> {
@@ -9,6 +9,8 @@ export interface Column<T> {
   className?: string;
   headerClassName?: string;
   sortable?: boolean;
+  /** Set false to suppress the resize handle (e.g. a flex-filler column). */
+  resizable?: boolean;
 }
 
 export interface VirtualizedTableProps<T> {
@@ -31,6 +33,10 @@ export interface VirtualizedTableProps<T> {
   onLoadMore?: () => void;
   hasMore?: boolean;
   threshold?: number;
+  /** Opt-in: drag a header onto another to reorder columns. */
+  onColumnReorder?: (fromKey: string, toKey: string) => void;
+  /** Opt-in: drag a header's right edge to resize. New width in px. */
+  onColumnResize?: (key: string, width: number) => void;
 }
 
 // Table header component
@@ -44,7 +50,9 @@ const TableHeader = memo(function TableHeader<T>({
   onSelectionChange,
   onSort,
   sortColumn,
-  sortDirection
+  sortDirection,
+  onColumnReorder,
+  onColumnResize
 }: {
   columns: Column<T>[];
   headerClassName?: string;
@@ -56,7 +64,33 @@ const TableHeader = memo(function TableHeader<T>({
   onSort?: (column: string, direction: 'asc' | 'desc') => void;
   sortColumn?: string;
   sortDirection?: 'asc' | 'desc';
+  onColumnReorder?: (fromKey: string, toKey: string) => void;
+  onColumnResize?: (key: string, width: number) => void;
 }) {
+  const [dragKey, setDragKey] = useState<string | null>(null);
+  const [overKey, setOverKey] = useState<string | null>(null);
+
+  // Drag the right edge of a header to resize. Uses the cell's live rendered
+  // width as the baseline so it works regardless of px/flex sizing.
+  const startResize = useCallback((e: React.MouseEvent, key: string) => {
+    e.preventDefault();
+    e.stopPropagation();
+    const cell = (e.currentTarget as HTMLElement).parentElement;
+    const startX = e.clientX;
+    const startWidth = cell ? cell.getBoundingClientRect().width : 120;
+    const onMove = (ev: MouseEvent) => {
+      const next = Math.max(48, Math.round(startWidth + (ev.clientX - startX)));
+      onColumnResize?.(key, next);
+    };
+    const onUp = () => {
+      document.removeEventListener('mousemove', onMove);
+      document.removeEventListener('mouseup', onUp);
+      document.body.style.cursor = '';
+    };
+    document.body.style.cursor = 'col-resize';
+    document.addEventListener('mousemove', onMove);
+    document.addEventListener('mouseup', onUp);
+  }, [onColumnResize]);
   const allSelected = useMemo(() => {
     if (!selectedItems || items.length === 0) return false;
     return items.every((item, index) => 
@@ -98,29 +132,62 @@ const TableHeader = memo(function TableHeader<T>({
         </div>
       )}
       
-      {columns.map((column) => (
-        <div
-          key={column.key}
-          className={`px-3 py-2 font-medium text-sm ${headerClassName ? '' : 'text-gray-700 dark:text-gray-300'} ${column.headerClassName || ''}`}
-          style={{ width: column.width }}
-        >
-          {column.sortable && onSort ? (
-            <button
-              onClick={() => handleSort(column.key)}
-              className={`inline-flex items-center gap-1 ${headerClassName ? 'hover:text-gray-100' : 'hover:text-gray-900 dark:hover:text-gray-100'}`}
-            >
-              {column.header}
-              {sortColumn === column.key && (
-                <span className="text-xs">
-                  {sortDirection === 'asc' ? '↑' : '↓'}
-                </span>
-              )}
-            </button>
-          ) : (
-            column.header
-          )}
-        </div>
-      ))}
+      {columns.map((column) => {
+        const reorderable = !!onColumnReorder;
+        const resizable = !!onColumnResize && column.resizable !== false;
+        const isDropTarget = !!dragKey && dragKey !== column.key && overKey === column.key;
+        return (
+          <div
+            key={column.key}
+            draggable={reorderable}
+            onDragStart={reorderable ? (e) => {
+              setDragKey(column.key);
+              e.dataTransfer.effectAllowed = 'move';
+              e.dataTransfer.setData('text/plain', column.key);
+            } : undefined}
+            onDragOver={reorderable ? (e) => {
+              e.preventDefault();
+              if (dragKey && dragKey !== column.key) setOverKey(column.key);
+            } : undefined}
+            onDragLeave={reorderable ? () => setOverKey(k => (k === column.key ? null : k)) : undefined}
+            onDrop={reorderable ? (e) => {
+              e.preventDefault();
+              const from = dragKey ?? e.dataTransfer.getData('text/plain');
+              if (from && from !== column.key) onColumnReorder!(from, column.key);
+              setDragKey(null);
+              setOverKey(null);
+            } : undefined}
+            onDragEnd={reorderable ? () => { setDragKey(null); setOverKey(null); } : undefined}
+            className={`relative px-3 py-2 font-medium text-sm ${headerClassName ? '' : 'text-gray-700 dark:text-gray-300'} ${column.headerClassName || ''} ${reorderable ? 'cursor-move select-none' : ''} ${isDropTarget ? 'border-l-2 border-blue-400' : ''} ${dragKey === column.key ? 'opacity-50' : ''}`}
+            style={{ width: column.width }}
+          >
+            {column.sortable && onSort ? (
+              <button
+                onClick={() => handleSort(column.key)}
+                className={`inline-flex items-center gap-1 ${headerClassName ? 'hover:text-gray-100' : 'hover:text-gray-900 dark:hover:text-gray-100'}`}
+              >
+                {column.header}
+                {sortColumn === column.key && (
+                  <span className="text-xs">
+                    {sortDirection === 'asc' ? '↑' : '↓'}
+                  </span>
+                )}
+              </button>
+            ) : (
+              column.header
+            )}
+            {resizable && (
+              <div
+                onMouseDown={(e) => startResize(e, column.key)}
+                onClick={(e) => e.stopPropagation()}
+                draggable={false}
+                className="absolute top-0 right-0 h-full w-1.5 cursor-col-resize hover:bg-blue-400/50"
+                aria-hidden="true"
+              />
+            )}
+          </div>
+        );
+      })}
     </div>
   );
 });
@@ -146,7 +213,9 @@ const VirtualizedTableComponent = memo(function VirtualizedTable<T>({
   isLoading = false,
   onLoadMore,
   hasMore = false,
-  threshold = 100
+  threshold = 100,
+  onColumnReorder,
+  onColumnResize
 }: VirtualizedTableProps<T>) {
   // Memoize row renderer
   const renderRow = useCallback((item: T, index: number, style: React.CSSProperties) => {
@@ -238,6 +307,8 @@ const VirtualizedTableComponent = memo(function VirtualizedTable<T>({
           onSort={onSort}
           sortColumn={sortColumn}
           sortDirection={sortDirection}
+          onColumnReorder={onColumnReorder}
+          onColumnResize={onColumnResize}
         />
         <div className="text-center py-12 text-gray-500 dark:text-gray-400">
           {emptyMessage}
@@ -259,8 +330,10 @@ const VirtualizedTableComponent = memo(function VirtualizedTable<T>({
         onSort={onSort}
         sortColumn={sortColumn}
         sortDirection={sortDirection}
+        onColumnReorder={onColumnReorder}
+        onColumnResize={onColumnResize}
       />
-      
+
       <VirtualizedList
         items={items}
         renderItem={renderRow as (item: unknown, index: number, style: React.CSSProperties) => React.ReactElement}

--- a/src/pages/AccountTransactions.tsx
+++ b/src/pages/AccountTransactions.tsx
@@ -13,6 +13,7 @@ import CategorySelector from '../components/CategorySelector';
 import { usePreferences } from '../contexts/PreferencesContext';
 import { VirtualizedTable, Column } from '../components/VirtualizedTable';
 import { compareTransactions } from '../utils/transactionSort';
+import { orderColumnKeys, moveColumnKey } from '../utils/columnLayout';
 import type { Transaction } from '../types';
 
 type TransactionWithBalance = Transaction & { balance: number };
@@ -36,6 +37,19 @@ type DisplayRow = TransactionWithBalance | OpeningBalanceRow;
 function isOpeningBalanceRow(row: DisplayRow): row is OpeningBalanceRow {
   return 'isOpeningBalance' in row && row.isOpeningBalance === true;
 }
+
+// Persisted (per browser) column layout for the account register.
+const COLUMN_ORDER_KEY = 'accountRegister.columnOrder.v1';
+const COLUMN_WIDTHS_KEY = 'accountRegister.columnWidths.v1';
+
+const readStored = <T,>(key: string, fallback: T): T => {
+  try {
+    const raw = localStorage.getItem(key);
+    return raw ? (JSON.parse(raw) as T) : fallback;
+  } catch {
+    return fallback;
+  }
+};
 
 export default function AccountTransactions() {
   const { accountId } = useParams<{ accountId: string }>();
@@ -76,6 +90,20 @@ export default function AccountTransactions() {
   }, [measureTableHeight, showFilters]);
   const [sortField, setSortField] = useState<'date' | 'description' | 'amount' | 'category' | 'tags' | 'payment' | 'deposit'>('date');
   const [sortDirection, setSortDirection] = useState<'asc' | 'desc'>('asc');
+  // Column layout (order + widths), drag-controlled and persisted per browser.
+  const [columnOrder, setColumnOrder] = useState<string[]>(() => readStored<string[]>(COLUMN_ORDER_KEY, []));
+  const [columnWidths, setColumnWidths] = useState<Record<string, number>>(() => readStored<Record<string, number>>(COLUMN_WIDTHS_KEY, {}));
+
+  useEffect(() => {
+    try { localStorage.setItem(COLUMN_ORDER_KEY, JSON.stringify(columnOrder)); } catch { /* storage may be unavailable */ }
+  }, [columnOrder]);
+  useEffect(() => {
+    try { localStorage.setItem(COLUMN_WIDTHS_KEY, JSON.stringify(columnWidths)); } catch { /* storage may be unavailable */ }
+  }, [columnWidths]);
+
+  const handleColumnResize = useCallback((key: string, width: number) => {
+    setColumnWidths(prev => ({ ...prev, [key]: width }));
+  }, []);
   
   // State for modals and selection
   const [selectedTransaction, setSelectedTransaction] = useState<Transaction | null>(null);
@@ -489,8 +517,9 @@ export default function AccountTransactions() {
     return category.name;
   }, [categories, accounts]);
 
-  // Define table columns for VirtualizedTable
-  const columns: Column<DisplayRow>[] = useMemo(() => [
+  // Define table columns for VirtualizedTable (base definitions; order + widths
+  // are applied below from the persisted layout).
+  const baseColumns: Column<DisplayRow>[] = useMemo(() => [
     {
       key: 'date',
       header: 'Date',
@@ -530,7 +559,10 @@ export default function AccountTransactions() {
       ),
       className: 'flex-1 min-w-0',
       headerClassName: 'flex-1 min-w-0',
-      sortable: true
+      sortable: true,
+      // The flex filler: it absorbs the slack when other columns are resized, so
+      // it has no resize handle of its own.
+      resizable: false
     },
     {
       key: 'category',
@@ -614,7 +646,21 @@ export default function AccountTransactions() {
       headerClassName: 'text-right'
     }
   ], [formatCurrency, account?.currency, getCategoryName]);
-  
+
+  // Apply the persisted order + widths on top of the base definitions.
+  const columns: Column<DisplayRow>[] = useMemo(() => {
+    const baseKeys = baseColumns.map(c => c.key);
+    const byKey = new Map(baseColumns.map(c => [c.key, c] as const));
+    return orderColumnKeys(baseKeys, columnOrder)
+      .map(key => byKey.get(key))
+      .filter((c): c is Column<DisplayRow> => Boolean(c))
+      .map(c => (columnWidths[c.key] != null ? { ...c, width: columnWidths[c.key] } : c));
+  }, [baseColumns, columnOrder, columnWidths]);
+
+  const handleColumnReorder = useCallback((fromKey: string, toKey: string) => {
+    setColumnOrder(prev => moveColumnKey(orderColumnKeys(baseColumns.map(c => c.key), prev), fromKey, toKey));
+  }, [baseColumns]);
+
   if (!account) {
     return (
       <div className="flex flex-col items-center justify-center h-64">
@@ -879,6 +925,8 @@ export default function AccountTransactions() {
           }}
           sortColumn={sortField}
           sortDirection={sortDirection}
+          onColumnReorder={handleColumnReorder}
+          onColumnResize={handleColumnResize}
           emptyMessage="No transactions found"
           threshold={50}
           className="virtualized-table bg-white dark:bg-gray-800 rounded-2xl shadow-lg border-2 border-[#6B86B3] h-full"

--- a/src/utils/columnLayout.test.ts
+++ b/src/utils/columnLayout.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect } from 'vitest';
+import { orderColumnKeys, moveColumnKey } from './columnLayout';
+
+const BASE = ['date', 'r', 'description', 'category', 'tags', 'payment', 'deposit', 'balance'];
+
+describe('orderColumnKeys', () => {
+  it('returns the base order when nothing is saved', () => {
+    expect(orderColumnKeys(BASE, [])).toEqual(BASE);
+  });
+
+  it('applies a saved order', () => {
+    const saved = ['date', 'r', 'description', 'payment', 'category', 'tags', 'deposit', 'balance'];
+    expect(orderColumnKeys(BASE, saved)).toEqual(saved);
+  });
+
+  it('drops unknown saved keys (e.g. a removed column) and appends new base keys', () => {
+    // saved knows the old 'amount' column and is missing the new 'deposit'
+    const saved = ['amount', 'date', 'description'];
+    expect(orderColumnKeys(BASE, saved)).toEqual([
+      'date', 'description', // known-and-saved, in saved order
+      'r', 'category', 'tags', 'payment', 'deposit', 'balance' // the rest, default order
+    ]);
+  });
+});
+
+describe('moveColumnKey', () => {
+  it('moves a key to immediately before the target', () => {
+    expect(moveColumnKey(BASE, 'payment', 'category')).toEqual([
+      'date', 'r', 'description', 'payment', 'category', 'tags', 'deposit', 'balance'
+    ]);
+  });
+
+  it('can move a key earlier or later', () => {
+    expect(moveColumnKey(BASE, 'date', 'tags')).toEqual([
+      'r', 'description', 'category', 'date', 'tags', 'payment', 'deposit', 'balance'
+    ]);
+  });
+
+  it('is a no-op for same key or missing keys', () => {
+    expect(moveColumnKey(BASE, 'date', 'date')).toEqual(BASE);
+    expect(moveColumnKey(BASE, 'nope', 'category')).toEqual(BASE);
+    expect(moveColumnKey(BASE, 'date', 'nope')).toEqual(BASE);
+  });
+
+  it('does not mutate the input array', () => {
+    const input = [...BASE];
+    moveColumnKey(input, 'payment', 'date');
+    expect(input).toEqual(BASE);
+  });
+});

--- a/src/utils/columnLayout.ts
+++ b/src/utils/columnLayout.ts
@@ -1,0 +1,32 @@
+/**
+ * Pure helpers for a drag-controlled, persisted table column layout.
+ * Kept separate from the register component so the ordering logic is testable
+ * without simulating drag-and-drop.
+ */
+
+/**
+ * Order the base column keys by a saved preference, appending any columns the
+ * saved order doesn't mention. This means added/removed columns can never
+ * corrupt a persisted layout — unknown saved keys are dropped, new base keys
+ * are appended in their default position.
+ */
+export function orderColumnKeys(baseKeys: string[], saved: string[]): string[] {
+  const known = new Set(baseKeys);
+  const ordered = saved.filter(key => known.has(key));
+  const orderedSet = new Set(ordered);
+  return [...ordered, ...baseKeys.filter(key => !orderedSet.has(key))];
+}
+
+/**
+ * Move `fromKey` to sit immediately before `toKey`. No-op (returns the input)
+ * if either key is missing or they're the same.
+ */
+export function moveColumnKey(order: string[], fromKey: string, toKey: string): string[] {
+  if (fromKey === toKey || !order.includes(fromKey) || !order.includes(toKey)) {
+    return order;
+  }
+  const withoutFrom = order.filter(key => key !== fromKey);
+  const targetIndex = withoutFrom.indexOf(toKey);
+  withoutFrom.splice(targetIndex, 0, fromKey);
+  return withoutFrom;
+}


### PR DESCRIPTION
## Summary

PR 3 of the register upgrades. You can now **rearrange and resize** the account-register columns, MS Money style, and the layout **persists** (per browser, across every account register):

- **Reorder** — drag a column header onto another to move it.
- **Resize** — drag a header's right edge. The **Description** column stays the flex filler (no resize handle) and absorbs the slack, so the widths you set are honoured *without* introducing a fragile horizontal scroll on the virtualized body.

## How it's built (kept safe)
- Reorder/resize are **opt-in props** on the shared `VirtualizedTable` (`onColumnReorder` / `onColumnResize`, plus a per-column `resizable` flag). The only other consumer — `AuditLogs` — passes none of them, so it's completely unchanged.
- Order + widths live in `AccountTransactions` state, persisted to `localStorage`. A saved layout **can't be corrupted** by columns being added or removed later (unknown saved keys are dropped, new columns appended in their default spot).
- The ordering logic is a pure, unit-tested util (`columnLayout`).

## Verification
- Driven live in the preview: dragged **Payment** before **Category** (order updated + persisted) and resized **Category** 280→400px (width updated + persisted); both **survived a reload**. All headers stay draggable, 7 resize handles (all columns except the flex Description). No console errors.
- 7 new unit tests for the reorder/order-merge logic. `typecheck:strict`, `lint`, `test:unit` (2869), `build` all pass.

## Still to come
PR 2 — the **"View"** dropdown (show/hide columns + time-range "archive" presets: 1 / 3 / 6 / 12 months / All / Custom). Awaiting your two answers on defaults (time-range default; whether to keep the old Amount column as a hidden option).

🤖 Generated with [Claude Code](https://claude.com/claude-code)