### PR TITLE
feat(transactions): add "Previous" button to the edit modal

### DIFF
--- a/src/components/EditTransactionModal.test.tsx
+++ b/src/components/EditTransactionModal.test.tsx
@@ -363,8 +363,51 @@ describe('EditTransactionModal', () => {
           transaction={transaction2}
         />
       );
-      
+
       expect(screen.getByTestId('modal-title')).toHaveTextContent('Edit Transaction');
+    });
+  });
+
+  describe('Previous / Save & Next batch buttons', () => {
+    it('shows both when handlers are provided for an existing transaction', () => {
+      render(
+        <EditTransactionModal
+          isOpen
+          onClose={mockOnClose}
+          transaction={createMockTransaction()}
+          onSaveAndNext={vi.fn()}
+          onSaveAndPrevious={vi.fn()}
+        />
+      );
+      expect(screen.getByRole('button', { name: 'Previous' })).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: 'Save & Next' })).toBeInTheDocument();
+    });
+
+    it('omits Previous when there is no previous handler (e.g. first row)', () => {
+      render(
+        <EditTransactionModal
+          isOpen
+          onClose={mockOnClose}
+          transaction={createMockTransaction()}
+          onSaveAndNext={vi.fn()}
+        />
+      );
+      expect(screen.queryByRole('button', { name: 'Previous' })).toBeNull();
+      expect(screen.getByRole('button', { name: 'Save & Next' })).toBeInTheDocument();
+    });
+
+    it('shows neither for a new transaction', () => {
+      render(
+        <EditTransactionModal
+          isOpen
+          onClose={mockOnClose}
+          transaction={null}
+          onSaveAndNext={vi.fn()}
+          onSaveAndPrevious={vi.fn()}
+        />
+      );
+      expect(screen.queryByRole('button', { name: 'Previous' })).toBeNull();
+      expect(screen.queryByRole('button', { name: 'Save & Next' })).toBeNull();
     });
   });
 });

--- a/src/components/EditTransactionModal.tsx
+++ b/src/components/EditTransactionModal.tsx
@@ -30,6 +30,11 @@ interface EditTransactionModalProps {
    * the caller to swap in the next transaction from its list.
    */
   onSaveAndNext?: () => void;
+  /**
+   * Batch mode counterpart: when provided, a "Previous" button appears that
+   * saves and swaps in the PREVIOUS transaction from the caller's list.
+   */
+  onSaveAndPrevious?: () => void;
 }
 
 interface FormData {
@@ -46,7 +51,7 @@ interface FormData {
   reconciledWith: string;
 }
 
-export default function EditTransactionModal({ isOpen, onClose, transaction, defaultAccountId, onSaveAndNext }: EditTransactionModalProps): React.JSX.Element {
+export default function EditTransactionModal({ isOpen, onClose, transaction, defaultAccountId, onSaveAndNext, onSaveAndPrevious }: EditTransactionModalProps): React.JSX.Element {
   const { accounts, categories, updateTransaction, deleteTransaction } = useApp();
   const { addTransaction } = useTransactionNotifications();
   const { propagateCategory } = usePayeeMemory();
@@ -60,9 +65,10 @@ export default function EditTransactionModal({ isOpen, onClose, transaction, def
   // category so it nets that expense down).
   const [crossTypeCategories, setCrossTypeCategories] = useState(false);
   const amountInputRef = useRef<HTMLInputElement>(null);
-  // Batch mode coordination: "Save & Next" sets advance; a successful submit
-  // consumes it and suppresses the close that useModalForm fires afterwards.
-  const advanceAfterSaveRef = useRef(false);
+  // Batch mode coordination: Save & Next / Previous set a direction; a
+  // successful submit consumes it and suppresses the close that useModalForm
+  // fires afterwards.
+  const advanceDirectionRef = useRef<'next' | 'previous' | null>(null);
   const suppressCloseRef = useRef(false);
   
   // Initialize form with transaction data if editing, otherwise use defaults
@@ -98,8 +104,8 @@ export default function EditTransactionModal({ isOpen, onClose, transaction, def
       onSubmit: async (data) => {
         // Consume the advance intent up front so a failed save never leaves a
         // stale "advance" that would hijack the NEXT ordinary Save.
-        const advanceAfterSave = advanceAfterSaveRef.current;
-        advanceAfterSaveRef.current = false;
+        const advanceDirection = advanceDirectionRef.current;
+        advanceDirectionRef.current = null;
         try {
           const isTransfer = data.type === 'transfer';
           // A freshly-chosen outgoing transfer encodes its target in the
@@ -202,9 +208,12 @@ export default function EditTransactionModal({ isOpen, onClose, transaction, def
           // Batch mode: "Save & Next" keeps the modal open — the caller swaps
           // in the next transaction and the form repopulates from the prop.
           // useModalForm calls our onClose after this resolves; suppress it.
-          if (advanceAfterSave && onSaveAndNext) {
+          if (advanceDirection === 'next' && onSaveAndNext) {
             suppressCloseRef.current = true;
             onSaveAndNext();
+          } else if (advanceDirection === 'previous' && onSaveAndPrevious) {
+            suppressCloseRef.current = true;
+            onSaveAndPrevious();
           }
         } catch (error) {
           if (error instanceof z.ZodError) {
@@ -675,6 +684,17 @@ export default function EditTransactionModal({ isOpen, onClose, transaction, def
                 >
                   Cancel
                 </button>
+                {transaction && onSaveAndPrevious && (
+                  <button
+                    type="submit"
+                    disabled={isSubmitting}
+                    onClick={() => { advanceDirectionRef.current = 'previous'; }}
+                    className="px-4 py-2 bg-[#2d3a4d] text-white rounded-lg hover:bg-[#3a4a5f] disabled:opacity-50 disabled:cursor-not-allowed"
+                    title="Save this transaction and move to the previous one in the list"
+                  >
+                    Previous
+                  </button>
+                )}
                 <button
                   type="submit"
                   disabled={isSubmitting}
@@ -686,7 +706,7 @@ export default function EditTransactionModal({ isOpen, onClose, transaction, def
                   <button
                     type="submit"
                     disabled={isSubmitting}
-                    onClick={() => { advanceAfterSaveRef.current = true; }}
+                    onClick={() => { advanceDirectionRef.current = 'next'; }}
                     className="px-4 py-2 bg-[#2d3a4d] text-white rounded-lg hover:bg-[#3a4a5f] disabled:opacity-50 disabled:cursor-not-allowed"
                     title="Save this transaction and move to the next one in the list"
                   >

--- a/src/pages/AccountTransactions.tsx
+++ b/src/pages/AccountTransactions.tsx
@@ -438,6 +438,26 @@ export default function AccountTransactions() {
     setSelectedTransaction(nextTransaction);
     return true;
   }, [getNextTransactionId, transactionsWithBalance]);
+
+  const getPreviousTransactionId = useCallback((currentId: string): string | null => {
+    const index = displayRows.findIndex(row => row.id === currentId);
+    if (index === -1) return null;
+    for (let i = index - 1; i >= 0; i -= 1) {
+      if (!isOpeningBalanceRow(displayRows[i])) {
+        return displayRows[i].id;
+      }
+    }
+    return null;
+  }, [displayRows]);
+
+  const advanceToPreviousTransaction = useCallback((currentId: string): boolean => {
+    const previousId = getPreviousTransactionId(currentId);
+    if (!previousId) return false;
+    const previousTransaction = transactionsWithBalance.find(t => t.id === previousId) ?? null;
+    setSelectedTransactionId(previousId);
+    setSelectedTransaction(previousTransaction);
+    return true;
+  }, [getPreviousTransactionId, transactionsWithBalance]);
   
   
   // Handle quick add
@@ -1247,6 +1267,11 @@ export default function AccountTransactions() {
                     setSelectedTransactionId(null);
                   }
                 }
+              : undefined
+          }
+          onSaveAndPrevious={
+            getPreviousTransactionId(selectedTransaction.id)
+              ? () => { advanceToPreviousTransaction(selectedTransaction.id); }
               : undefined
           }
         />

--- a/src/pages/Reconciliation.tsx
+++ b/src/pages/Reconciliation.tsx
@@ -205,6 +205,21 @@ export default function Reconciliation() {
     return true;
   }, [getNextTransactionId, accountTransactions]);
 
+  const getPreviousTransactionId = useCallback((currentId: string): string | null => {
+    const index = visibleOrderIds.indexOf(currentId);
+    if (index <= 0) return null;
+    return visibleOrderIds[index - 1] ?? null;
+  }, [visibleOrderIds]);
+
+  const advanceToPreviousTransaction = useCallback((currentId: string): boolean => {
+    const previousId = getPreviousTransactionId(currentId);
+    if (!previousId) return false;
+    const previousTransaction = accountTransactions.find(t => t.id === previousId) ?? null;
+    if (!previousTransaction) return false;
+    setEditingTransaction(previousTransaction);
+    return true;
+  }, [getPreviousTransactionId, accountTransactions]);
+
   // Step 1: Account Selection
   if (!selectedAccountId) {
     return (
@@ -293,6 +308,11 @@ export default function Reconciliation() {
                   handleCloseEditModal();
                 }
               }
+            : undefined
+        }
+        onSaveAndPrevious={
+          editingTransaction && getPreviousTransactionId(editingTransaction.id)
+            ? () => { advanceToPreviousTransaction(editingTransaction.id); }
             : undefined
         }
       />


### PR DESCRIPTION
## Summary (request #1)

Adds a **Previous** button to the Edit Transaction modal, between **Cancel** and **Save Changes** — the counterpart to Save & Next. It saves the current transaction and steps to the **previous** one in the list, so you can walk a sorted register in both directions without closing the modal.

Footer is now: **Cancel · Previous · Save Changes · Save & Next**.

## How it works
- Mirrors the Save & Next machinery. The modal's internal advance ref now carries a direction (`'next' | 'previous'`); on a successful save it calls the matching handler.
- `AccountTransactions` and `Reconciliation` each gained `getPreviousTransactionId` / `advanceToPreviousTransaction`, walking their list backward (skipping the opening-balance row / respecting the reconciliation visible order).
- Both **Previous** and **Save & Next** only appear for existing transactions, and only when a neighbour exists in that direction (so Previous is hidden on the first row, Save & Next on the last).

## Verification
- 3 new modal tests: both buttons shown when neighbours exist, Previous hidden on the first row, neither shown for a new transaction. `typecheck:strict`, `lint`, `test:unit` (2876), `build` all pass.
- (The button visibility/logic is unit-tested and mirrors the already-in-production Save & Next; the demo register wouldn't render seeded rows to screenshot the footer, as in the recent register PRs.)

## The other three you asked for
- **#2 green → mid-blue sweep** — I'll confirm scope with you (see my message) before doing the sweep.
- **#3/#4 searchable Category combobox** (edit modal + quick-edit) — next PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)