### PR TITLE
feat(register): searchable Category combobox in the quick-edit bar

### DIFF
--- a/src/components/CategorySelector.test.tsx
+++ b/src/components/CategorySelector.test.tsx
@@ -1,0 +1,98 @@
+/**
+ * CategorySelector tests
+ *
+ * Focus: the searchable-combobox behaviour used by the transaction modal and
+ * the account-register quick-edit bar — type-to-filter, and the `includeAllTypes`
+ * flag that lists BOTH income and expense detail categories (Money-style
+ * cross-type filing) rather than only the current transaction's direction.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, fireEvent, cleanup } from '@testing-library/react';
+import CategorySelector from './CategorySelector';
+import { __setAppContextValue, __resetAppContextValue } from '../test/mocks/AppContextSupabase';
+import type { Category } from '../types';
+
+// A minimal two-direction category tree: one income detail (Payslip) and one
+// expense detail (Groceries), each under its own sub/type parents.
+const tree: Category[] = [
+  { id: 'type-income', name: 'Income', type: 'income', level: 'type' },
+  { id: 'type-expense', name: 'Expenses', type: 'expense', level: 'type' },
+  { id: 'sub-salary', name: 'Salary', type: 'income', level: 'sub', parentId: 'type-income' },
+  { id: 'sub-food', name: 'Food', type: 'expense', level: 'sub', parentId: 'type-expense' },
+  { id: 'det-payslip', name: 'Payslip', type: 'income', level: 'detail', parentId: 'sub-salary' },
+  { id: 'det-groceries', name: 'Groceries', type: 'expense', level: 'detail', parentId: 'sub-food' },
+];
+
+const PLACEHOLDER = 'Pick a category';
+
+beforeEach(() => {
+  __setAppContextValue({
+    categories: tree,
+    getSubCategories: (parentId?: string) =>
+      tree.filter(c => c.level === 'sub' && c.parentId === parentId),
+    getDetailCategories: (parentId?: string) =>
+      tree.filter(c => c.level === 'detail' && c.parentId === parentId),
+  });
+});
+
+afterEach(() => {
+  cleanup();
+  __resetAppContextValue();
+});
+
+/** Render the picker and open its dropdown (click the collapsed trigger). */
+function renderOpen(props: Partial<React.ComponentProps<typeof CategorySelector>> = {}) {
+  const onCategoryChange = vi.fn();
+  render(
+    <CategorySelector
+      selectedCategory=""
+      onCategoryChange={onCategoryChange}
+      transactionType="income"
+      placeholder={PLACEHOLDER}
+      {...props}
+    />
+  );
+  fireEvent.click(screen.getByText(PLACEHOLDER));
+  return { onCategoryChange };
+}
+
+describe('CategorySelector', () => {
+  it('lists only the transaction direction by default', () => {
+    renderOpen();
+    expect(screen.getByText('Payslip')).toBeInTheDocument();
+    expect(screen.queryByText('Groceries')).not.toBeInTheDocument();
+  });
+
+  it('lists both directions when includeAllTypes is set', () => {
+    renderOpen({ includeAllTypes: true });
+    expect(screen.getByText('Payslip')).toBeInTheDocument();
+    expect(screen.getByText('Groceries')).toBeInTheDocument();
+  });
+
+  it('filters the list as the user types', () => {
+    renderOpen({ includeAllTypes: true });
+    fireEvent.change(screen.getByPlaceholderText(PLACEHOLDER), { target: { value: 'groc' } });
+    expect(screen.getByText('Groceries')).toBeInTheDocument();
+    expect(screen.queryByText('Payslip')).not.toBeInTheDocument();
+  });
+
+  it('reports the chosen category id when an option is clicked', () => {
+    const { onCategoryChange } = renderOpen({ includeAllTypes: true });
+    fireEvent.click(screen.getByText('Groceries'));
+    expect(onCategoryChange).toHaveBeenCalledWith('det-groceries');
+  });
+
+  it('omits the helper hint when showHelperText is false', () => {
+    render(
+      <CategorySelector
+        selectedCategory=""
+        onCategoryChange={vi.fn()}
+        transactionType="income"
+        placeholder={PLACEHOLDER}
+        showHelperText={false}
+      />
+    );
+    expect(screen.queryByText(/Select a category for this/)).not.toBeInTheDocument();
+  });
+});

--- a/src/components/CategorySelector.tsx
+++ b/src/components/CategorySelector.tsx
@@ -10,6 +10,18 @@ interface CategorySelectorProps {
   placeholder?: string;
   className?: string;
   allowCreate?: boolean;
+  /**
+   * List detail categories from BOTH directions (income + expense), not just
+   * `transactionType`. For the Money-style cross-type filing the quick-edit
+   * bar offers (a refund filed under the expense category it refunds).
+   */
+  includeAllTypes?: boolean;
+  /**
+   * Render the "Select a category for this … transaction" hint under the box.
+   * Off in compact/inline contexts (the quick-edit bar) where a second line
+   * would break the single-row layout.
+   */
+  showHelperText?: boolean;
 }
 
 export default function CategorySelector({
@@ -18,6 +30,8 @@ export default function CategorySelector({
   transactionType,
   placeholder = "Select category...",
   className = "",
+  includeAllTypes = false,
+  showHelperText = true,
 }: CategorySelectorProps): React.JSX.Element {
   const { categories, addCategory, getSubCategories, getDetailCategories } = useApp();
   const [showDropdown, setShowDropdown] = useState(false);
@@ -30,6 +44,14 @@ export default function CategorySelector({
 
   // Get sub-categories for the transaction type
   const getSubCategoriesForType = (): Category[] => {
+    // includeAllTypes: gather sub-categories under EVERY type tree (both
+    // directions), for the quick-edit bar's cross-type list.
+    if (includeAllTypes) {
+      return categories
+        .filter(cat => cat.level === 'type')
+        .flatMap(tc => getSubCategories(tc.id))
+        .filter(c => c.isActive !== false);
+    }
     const typeCategory = categories.find(cat =>
       cat.level === 'type' && (cat.type === transactionType || cat.type === 'both')
     );
@@ -329,7 +351,7 @@ export default function CategorySelector({
       </div>
 
       {/* Helper Text */}
-      {!selectedCategory && !showDropdown && (
+      {showHelperText && !selectedCategory && !showDropdown && (
         <p className="text-xs text-gray-500 dark:text-gray-400 mt-1">
           Select a category for this {transactionType} transaction
         </p>

--- a/src/components/QuickEditTransactionPanel.tsx
+++ b/src/components/QuickEditTransactionPanel.tsx
@@ -1,8 +1,9 @@
-import React, { useState, useEffect, useMemo, useRef } from 'react';
+import React, { useState, useEffect, useRef } from 'react';
 import { useApp } from '../contexts/AppContextSupabase';
 import { useToast } from '../contexts/ToastContext';
 import { usePayeeMemory } from '../hooks/usePayeeMemory';
 import { XIcon } from './icons';
+import CategorySelector from './CategorySelector';
 import type { Transaction } from '../types';
 
 interface QuickEditTransactionPanelProps {
@@ -46,23 +47,6 @@ export default function QuickEditTransactionPanel({
     setDescription(transaction.description);
     setCategory(transaction.category ?? '');
   }, [transaction]);
-
-  // Both directions are listed (Money-style cross-type categorization is
-  // legitimate — a refund can file under the expense category it refunds).
-  const categoryGroups = useMemo(() => {
-    const active = categories.filter(c => c.isActive !== false);
-    const detailCats = active.filter(c =>
-      c.level === 'detail' && c.id !== 'transfer-in' && c.id !== 'transfer-out'
-    );
-    const subCats = active.filter(c => c.level === 'sub');
-    return subCats
-      .map(sub => ({
-        label: sub.name,
-        type: sub.type,
-        items: detailCats.filter(d => d.parentId === sub.id),
-      }))
-      .filter(g => g.items.length > 0);
-  }, [categories]);
 
   const isTransfer = transaction.type === 'transfer';
 
@@ -135,7 +119,7 @@ export default function QuickEditTransactionPanel({
             type="date"
             value={date}
             onChange={(e) => setDate(e.target.value)}
-            className="w-full px-2 py-1.5 text-sm bg-white dark:bg-gray-700 border border-gray-300 dark:border-gray-600 rounded-lg dark:text-white"
+            className="w-full px-3 h-[42px] text-sm bg-white dark:bg-gray-700 border border-gray-300 dark:border-gray-600 rounded-xl dark:text-white"
           />
         </div>
 
@@ -149,34 +133,32 @@ export default function QuickEditTransactionPanel({
             type="text"
             value={description}
             onChange={(e) => setDescription(e.target.value)}
-            className="w-full px-2 py-1.5 text-sm bg-white dark:bg-gray-700 border border-gray-300 dark:border-gray-600 rounded-lg dark:text-white"
+            className="w-full px-3 h-[42px] text-sm bg-white dark:bg-gray-700 border border-gray-300 dark:border-gray-600 rounded-xl dark:text-white"
           />
         </div>
 
-        {/* Category (not editable for transfers — they carry system categories) */}
+        {/* Category (not editable for transfers — they carry system categories).
+            Searchable combobox: click to type-filter, or use the chevron to
+            browse the full list. Both directions are offered (Money-style
+            cross-type filing — a refund can file under the expense it refunds). */}
         <div className="w-full lg:w-72">
-          <label htmlFor="quick-edit-category" className="block text-xs text-gray-500 dark:text-gray-400 mb-1">
+          <span className="block text-xs text-gray-500 dark:text-gray-400 mb-1">
             Category
-          </label>
-          <select
-            id="quick-edit-category"
-            value={category}
-            onChange={(e) => setCategory(e.target.value)}
-            disabled={isTransfer}
-            className="w-full px-2 py-1.5 text-sm bg-white dark:bg-gray-700 border border-gray-300 dark:border-gray-600 rounded-lg dark:text-white disabled:opacity-50"
-          >
-            <option value="">{isTransfer ? 'Transfer' : 'Select category'}</option>
-            {!isTransfer && categoryGroups.map(group => (
-              <optgroup
-                key={group.label}
-                label={group.type === 'income' ? `Income: ${group.label}` : group.label}
-              >
-                {group.items.map(item => (
-                  <option key={item.id} value={item.id}>{item.name}</option>
-                ))}
-              </optgroup>
-            ))}
-          </select>
+          </span>
+          {isTransfer ? (
+            <div className="w-full px-3 h-[42px] flex items-center text-sm bg-white dark:bg-gray-800 border border-gray-300/50 dark:border-gray-600/50 rounded-xl text-gray-500 dark:text-gray-400">
+              Transfer
+            </div>
+          ) : (
+            <CategorySelector
+              selectedCategory={category}
+              onCategoryChange={setCategory}
+              transactionType={transaction.type}
+              includeAllTypes
+              showHelperText={false}
+              placeholder="Search or select category…"
+            />
+          )}
         </div>
 
         {/* Actions */}
@@ -184,7 +166,7 @@ export default function QuickEditTransactionPanel({
           <button
             onClick={() => void save(false)}
             disabled={isSaving}
-            className="px-3 py-1.5 text-sm font-medium bg-[#1a2332] text-white rounded-lg hover:bg-secondary disabled:opacity-50 disabled:cursor-not-allowed whitespace-nowrap"
+            className="px-4 h-[42px] inline-flex items-center justify-center text-sm font-medium bg-[#1a2332] text-white rounded-xl hover:bg-secondary disabled:opacity-50 disabled:cursor-not-allowed whitespace-nowrap"
           >
             {isSaving ? 'Saving…' : 'Save'}
           </button>
@@ -192,7 +174,7 @@ export default function QuickEditTransactionPanel({
             <button
               onClick={() => void save(true)}
               disabled={isSaving}
-              className="px-3 py-1.5 text-sm font-medium bg-[#2d3a4d] text-white rounded-lg hover:bg-[#3a4a5f] disabled:opacity-50 disabled:cursor-not-allowed whitespace-nowrap"
+              className="px-4 h-[42px] inline-flex items-center justify-center text-sm font-medium bg-[#2d3a4d] text-white rounded-xl hover:bg-[#3a4a5f] disabled:opacity-50 disabled:cursor-not-allowed whitespace-nowrap"
               title="Save and move to the next transaction in the list"
             >
               Save &amp; Next

--- a/src/test/mocks/AppContextSupabase.ts
+++ b/src/test/mocks/AppContextSupabase.ts
@@ -6,6 +6,7 @@ import {
   getDefaultTestGoals,
 } from '../../data/defaultTestData';
 import { getDefaultCategories } from '../../data/defaultCategories';
+import type { Category } from '../../types';
 
 const accounts = getDefaultTestAccounts();
 const transactions = getDefaultTestTransactions();
@@ -52,8 +53,8 @@ const baseValue = {
   updateTag: noop,
   deleteTag: noop,
   getTagUsageCount: () => 0,
-  getSubCategories: () => [],
-  getDetailCategories: () => [],
+  getSubCategories: (_parentId?: string): Category[] => [],
+  getDetailCategories: (_parentId?: string): Category[] => [],
   getCategoryById: () => undefined,
   getCategoryPath: () => '',
   recurringTransactions: [],


### PR DESCRIPTION
## What & why

Request #4 of the current UI batch. The account-register **quick-edit bar** (single-click a row to categorise a fresh import) used a plain `<select>` for Category, so every row meant scrolling the whole list. This swaps it for the existing **searchable `CategorySelector` combobox** — click to type-filter, or use the chevron to browse the full list — the same friction-free UX the transaction modal already offers. (Search text can be copy/pasted down a description-sorted batch.)

## Changes

- **`CategorySelector`** — two additive, opt-in props (existing usages unchanged by default):
  - `includeAllTypes` — list detail categories from **both** income and expense trees, preserving the quick-edit bar's Money-style cross-type filing (a refund can file under the expense it refunds).
  - `showHelperText` — off in the compact bar so the "Select a category…" hint can't break the single-row layout.
- **`QuickEditTransactionPanel`** — render `CategorySelector` for editable rows; a static "Transfer" box for transfers (they carry system categories); remove the now-dead `categoryGroups` memo; unify the bar to a 42px control height so the combobox sits flush with date/description/buttons.
- **Test mock** — type the `getSubCategories`/`getDetailCategories` stubs so tests can override them with real category trees.
- **New tests** — `CategorySelector.test.tsx` covers `includeAllTypes`, type-to-filter, selection, and the helper-text opt-out (5 tests).

## Verification

- `npm run typecheck:strict` ✅ · `npm run lint` ✅ · `npm run test:unit` ✅ (2881 passed) · `npm run build` ✅
- Live (demo): confirmed the shared combobox opens, lists categories, and **filters as you type** ("groc" → Food & Drink › Groceries). The quick-edit panel itself needs a seeded transaction row (demo seeding gap), so that specific mount is covered by the unit tests + strict build rather than a screenshot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)