### PR TITLE
feat(transactions): searchable Category combobox in the edit modal

### DIFF
--- a/src/components/CategorySelector.tsx
+++ b/src/components/CategorySelector.tsx
@@ -1,7 +1,17 @@
-import { useState, useRef, useEffect } from 'react';
+import { useState, useRef, useEffect, useLayoutEffect, useCallback } from 'react';
+import { createPortal } from 'react-dom';
 import { useApp } from '../contexts/AppContextSupabase';
 import type { Category } from '../types';
 import { ChevronDownIcon, TagIcon, PlusIcon, ArrowLeftIcon, CheckIcon } from './icons';
+
+/** Fixed-position coordinates for the portaled dropdown (usePortal mode). */
+interface MenuPosition {
+  left: number;
+  width: number;
+  maxHeight: number;
+  top?: number;
+  bottom?: number;
+}
 
 interface CategorySelectorProps {
   selectedCategory: string;
@@ -22,6 +32,14 @@ interface CategorySelectorProps {
    * would break the single-row layout.
    */
   showHelperText?: boolean;
+  /**
+   * Render the dropdown in a fixed-position portal on document.body instead of
+   * absolutely inside this component. Needed inside scroll containers that clip
+   * their overflow (the Edit Transaction modal's `overflow-y-auto` body would
+   * otherwise cut the list off). Off by default so existing non-clipped usages
+   * (which open the list upward in-flow) are unchanged.
+   */
+  usePortal?: boolean;
 }
 
 export default function CategorySelector({
@@ -30,8 +48,10 @@ export default function CategorySelector({
   transactionType,
   placeholder = "Select category...",
   className = "",
+  allowCreate = true,
   includeAllTypes = false,
   showHelperText = true,
+  usePortal = false,
 }: CategorySelectorProps): React.JSX.Element {
   const { categories, addCategory, getSubCategories, getDetailCategories } = useApp();
   const [showDropdown, setShowDropdown] = useState(false);
@@ -40,7 +60,52 @@ export default function CategorySelector({
   const [newCategoryName, setNewCategoryName] = useState('');
   const [selectedParentId, setSelectedParentId] = useState('');
   const dropdownRef = useRef<HTMLDivElement>(null);
+  const triggerRef = useRef<HTMLDivElement>(null);
+  const menuRef = useRef<HTMLDivElement>(null);
   const newCategoryInputRef = useRef<HTMLInputElement>(null);
+  // Fixed coordinates for the portaled dropdown (usePortal mode only).
+  const [menuPos, setMenuPos] = useState<MenuPosition | null>(null);
+
+  // Anchor the portaled menu to the trigger. Chooses up/down by available space
+  // and recomputes on scroll/resize so it tracks the trigger inside a scrolling
+  // modal body.
+  const computeMenuPosition = useCallback(() => {
+    const el = triggerRef.current;
+    if (!el) return;
+    const rect = el.getBoundingClientRect();
+    const gap = 4;
+    const maxMenu = 384; // matches the non-portal max-h-96
+    const spaceBelow = window.innerHeight - rect.bottom;
+    const spaceAbove = rect.top;
+    const openUp = spaceBelow < Math.min(maxMenu, 240) && spaceAbove > spaceBelow;
+    const available = (openUp ? spaceAbove : spaceBelow) - gap - 8;
+    const maxHeight = Math.max(160, Math.min(maxMenu, available));
+    setMenuPos({
+      left: rect.left,
+      width: rect.width,
+      maxHeight,
+      ...(openUp
+        ? { bottom: window.innerHeight - rect.top + gap }
+        : { top: rect.bottom + gap }),
+    });
+  }, []);
+
+  // Position (and keep positioning) the portaled menu while it is open.
+  useLayoutEffect(() => {
+    if (!usePortal || !showDropdown) {
+      setMenuPos(null);
+      return;
+    }
+    computeMenuPosition();
+    const onReflow = () => computeMenuPosition();
+    // Capture phase so it also fires for the scrolling modal body, not just window.
+    window.addEventListener('scroll', onReflow, true);
+    window.addEventListener('resize', onReflow);
+    return () => {
+      window.removeEventListener('scroll', onReflow, true);
+      window.removeEventListener('resize', onReflow);
+    };
+  }, [usePortal, showDropdown, computeMenuPosition]);
 
   // Get sub-categories for the transaction type
   const getSubCategoriesForType = (): Category[] => {
@@ -116,7 +181,13 @@ export default function CategorySelector({
   // Handle clicking outside to close dropdown
   useEffect(() => {
     const handleClickOutside = (event: MouseEvent) => {
-      if (dropdownRef.current && !dropdownRef.current.contains(event.target as Node)) {
+      const target = event.target as Node;
+      // The portaled menu lives outside dropdownRef, so check it separately —
+      // otherwise a click on a list item would count as "outside" and close the
+      // menu before the option's onClick could fire.
+      const inTrigger = dropdownRef.current?.contains(target) ?? false;
+      const inMenu = menuRef.current?.contains(target) ?? false;
+      if (!inTrigger && !inMenu) {
         setShowDropdown(false);
         setSearchTerm('');
         setShowCreateForm(false);
@@ -191,6 +262,7 @@ export default function CategorySelector({
     <div className={`relative ${className}`} ref={dropdownRef}>
       <div className="relative">
         <div
+          ref={triggerRef}
           className="w-full px-3 py-2 h-[42px] bg-white dark:bg-gray-800-sm border border-gray-300/50 dark:border-gray-600/50 rounded-xl focus-within:ring-2 focus-within:ring-primary focus-within:border-transparent cursor-text flex items-center"
           onClick={handleInputClick}
         >
@@ -219,9 +291,24 @@ export default function CategorySelector({
           </div>
         </div>
 
-        {/* Dropdown */}
-        {showDropdown && (
-          <div className="absolute bottom-full left-0 right-0 mb-1 bg-white dark:bg-gray-700 border border-gray-300 dark:border-gray-600 rounded-lg shadow-lg max-h-96 overflow-y-auto z-50">
+        {/* Dropdown — in-flow (opens upward) by default, or a fixed-position
+            portal on document.body when usePortal escapes a clipping modal. */}
+        {showDropdown && (() => {
+          const menu = (
+          <div
+            ref={usePortal ? menuRef : undefined}
+            style={usePortal && menuPos ? {
+              position: 'fixed',
+              left: menuPos.left,
+              width: menuPos.width,
+              maxHeight: menuPos.maxHeight,
+              zIndex: 9999,
+              ...(menuPos.top !== undefined ? { top: menuPos.top } : { bottom: menuPos.bottom }),
+            } : undefined}
+            className={usePortal
+              ? 'overflow-y-auto bg-white dark:bg-gray-700 border border-gray-300 dark:border-gray-600 rounded-lg shadow-lg'
+              : 'absolute bottom-full left-0 right-0 mb-1 bg-white dark:bg-gray-700 border border-gray-300 dark:border-gray-600 rounded-lg shadow-lg max-h-96 overflow-y-auto z-50'}
+          >
             {showCreateForm ? (
               /* Create New Category Form */
               <div className="p-3">
@@ -327,27 +414,32 @@ export default function CategorySelector({
                 )}
 
                 {/* Add New Category Option */}
-                <div className="border-t border-gray-200 dark:border-gray-600">
-                  <div
-                    className="px-3 py-2.5 cursor-pointer hover:bg-gray-100 dark:hover:bg-gray-600 text-primary dark:text-blue-400"
-                    onClick={() => {
-                      setShowCreateForm(true);
-                      if (searchTerm) {
-                        setNewCategoryName(searchTerm);
-                        setSearchTerm('');
-                      }
-                    }}
-                  >
-                    <div className="flex items-center gap-2">
-                      <PlusIcon size={14} />
-                      <span className="font-medium text-sm">Add New Category</span>
+                {allowCreate && (
+                  <div className="border-t border-gray-200 dark:border-gray-600">
+                    <div
+                      className="px-3 py-2.5 cursor-pointer hover:bg-gray-100 dark:hover:bg-gray-600 text-primary dark:text-blue-400"
+                      onClick={() => {
+                        setShowCreateForm(true);
+                        if (searchTerm) {
+                          setNewCategoryName(searchTerm);
+                          setSearchTerm('');
+                        }
+                      }}
+                    >
+                      <div className="flex items-center gap-2">
+                        <PlusIcon size={14} />
+                        <span className="font-medium text-sm">Add New Category</span>
+                      </div>
                     </div>
                   </div>
-                </div>
+                )}
               </>
             )}
           </div>
-        )}
+          );
+          if (!usePortal) return menu;
+          return menuPos ? createPortal(menu, document.body) : null;
+        })()}
       </div>
 
       {/* Helper Text */}

--- a/src/components/EditTransactionModal.test.tsx
+++ b/src/components/EditTransactionModal.test.tsx
@@ -32,6 +32,12 @@ vi.mock('./CategoryCreationModal', () => ({
   default: () => null,
 }));
 
+// Stubbed like the other heavy children — the picker's own behaviour is
+// covered by CategorySelector.test.tsx; here we only care about the modal.
+vi.mock('./CategorySelector', () => ({
+  default: () => <div data-testid="category-selector">Category Selector</div>,
+}));
+
 vi.mock('./TagSelector', () => ({
   default: () => <div data-testid="tag-selector">Tag Selector</div>,
 }));

--- a/src/components/EditTransactionModal.tsx
+++ b/src/components/EditTransactionModal.tsx
@@ -5,6 +5,7 @@ import { usePayeeMemory } from '../hooks/usePayeeMemory';
 import { CalendarIcon, TagIcon, FileTextIcon, CheckIcon2, LinkIcon, PlusIcon, HashIcon, WalletIcon, ArrowRightLeftIcon, BanknoteIcon, PaperclipIcon } from '../components/icons';
 import type { Transaction } from '../types';
 import CategoryCreationModal from './CategoryCreationModal';
+import CategorySelector from './CategorySelector';
 import TagSelector from './TagSelector';
 import { getCurrencySymbol } from '../utils/currency';
 import { Modal, ModalBody, ModalFooter } from './common/Modal';
@@ -535,46 +536,40 @@ export default function EditTransactionModal({ isOpen, onClose, transaction, def
               {/* Category is deliberately optional for income/expense — an
                   uncategorised transaction sits in the virtual "Uncategorised"
                   bucket. Transfers still require their target account. */}
-              <select
-                value={formData.category}
-                onChange={(e) => {
-                  const val = e.target.value;
-                  updateField('category', val);
-                }}
-                className="w-full px-3 py-3 sm:py-2 h-12 sm:h-[42px] text-base sm:text-sm bg-white dark:bg-gray-700 border-2 border-gray-300 dark:border-gray-500 rounded-lg focus:outline-none focus:ring-2 focus:ring-primary dark:focus:ring-blue-400 focus:border-transparent dark:text-white"
-                required={formData.type === 'transfer'}
-                aria-label="Transaction category"
-              >
-                {formData.type === 'transfer' ? (
-                  <>
-                    <option value="">Select account to transfer to</option>
-                    {groupedCategories.transferAccounts.map(acct => (
-                      <option key={acct.id} value={acct.id}>{acct.name}</option>
-                    ))}
-                  </>
-                ) : (
-                  <>
-                    <option value="">Select category</option>
-                    {/* Which direction's tree to browse: normally the
-                        transaction's own, flipped by the cross-type toggle
-                        (Money-style: a refund can file under an expense). */}
-                    {((formData.type === 'income') !== crossTypeCategories) && groupedCategories.incomeGroups.map(group => (
-                      <optgroup key={group.label} label={`Income: ${group.label}`}>
-                        {group.items.map(item => (
-                          <option key={item.id} value={item.id}>{item.name}</option>
-                        ))}
-                      </optgroup>
-                    ))}
-                    {((formData.type === 'expense') !== crossTypeCategories) && groupedCategories.expenseGroups.map(group => (
-                      <optgroup key={group.label} label={group.label}>
-                        {group.items.map(item => (
-                          <option key={item.id} value={item.id}>{item.name}</option>
-                        ))}
-                      </optgroup>
-                    ))}
-                  </>
-                )}
-              </select>
+              {formData.type === 'transfer' ? (
+                <select
+                  value={formData.category}
+                  onChange={(e) => updateField('category', e.target.value)}
+                  className="w-full px-3 py-3 sm:py-2 h-12 sm:h-[42px] text-base sm:text-sm bg-white dark:bg-gray-700 border-2 border-gray-300 dark:border-gray-500 rounded-lg focus:outline-none focus:ring-2 focus:ring-primary dark:focus:ring-blue-400 focus:border-transparent dark:text-white"
+                  required
+                  aria-label="Transfer destination account"
+                >
+                  <option value="">Select account to transfer to</option>
+                  {groupedCategories.transferAccounts.map(acct => (
+                    <option key={acct.id} value={acct.id}>{acct.name}</option>
+                  ))}
+                </select>
+              ) : (
+                /* Searchable combobox: click to type-filter, or use the chevron
+                   to browse. usePortal escapes the modal body's overflow-y-auto
+                   clipping. Which direction's tree it lists is the transaction's
+                   own, flipped by the cross-type toggle (Money-style: a refund
+                   can file under an expense). The modal's own "Create new
+                   category" button covers creation, so the inline one is off. */
+                <CategorySelector
+                  selectedCategory={formData.category}
+                  onCategoryChange={(id) => updateField('category', id)}
+                  transactionType={
+                    crossTypeCategories
+                      ? (formData.type === 'income' ? 'expense' : 'income')
+                      : formData.type
+                  }
+                  placeholder="Search or select category…"
+                  allowCreate={false}
+                  showHelperText={false}
+                  usePortal
+                />
+              )}
             </div>
 
             {/* Tags */}


### PR DESCRIPTION
## What & why

Request #3 of the current UI batch — the companion to #74 (quick-edit bar). The **Edit Transaction modal** used a plain `<select>` for Category, so filing a transaction meant scrolling the whole tree each time. This swaps the income/expense branch for the searchable **`CategorySelector`** combobox (click to type-filter, or use the chevron to browse), matching the quick-edit bar and the add-transaction modal. The **"Transfer To"** branch keeps its native account `<select>`.

## The portal

The modal body is `overflow-y-auto`, which would clip an in-flow dropdown. So this adds an opt-in **`usePortal`** to `CategorySelector`:
- The menu renders in a **fixed-position portal on `document.body`**, escaping the modal's clipping.
- Anchored to the trigger; **chooses up/down by available space** and **caps its height to the viewport**; recomputes on scroll/resize (capture phase, so it tracks the scrolling modal body).
- Click-outside now also treats the portaled menu as "inside", so clicking an option doesn't pre-close the menu.
- **Off by default** — the three existing usages (add-transaction modal, quick-edit bar) are unchanged (they open in-flow, upward).

## Bonus: `allowCreate` now works

The `allowCreate` prop was dead (the inline "Add New Category" row always showed). It now gates that row. The edit modal (which has its own **"Create new category"** button) and the add-transaction modal both already pass `allowCreate={false}`, so their inline create is now correctly hidden. The quick-edit bar keeps it (default `true`).

Cross-type filing is preserved: which direction's tree the combobox lists follows the existing cross-type toggle via an `effectiveType` (income↔expense).

## Verification

- `npm run typecheck:strict` ✅ · `npm run lint` ✅ · `npm run test:unit` ✅ (2881 passed) · `npm run build` ✅
- **Live (demo, New Transaction modal):** the dropdown renders as a **direct child of `document.body`** (escapes the `overflow-y-auto` clip), positions at the trigger, caps height to fit the viewport, **filters as you type** ("fuel" → Fuel), and **selecting closes + sets** the value ("Transportation › Fuel"). Inline "Add New Category" correctly absent.
- `EditTransactionModal.test.tsx` stubs `CategorySelector` like the other heavy children; the picker's own behaviour is covered by `CategorySelector.test.tsx`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)