### PR TITLE
style(reconciliation): recolour UI-accent greens to mid-blue (#2563eb)

### DIFF
--- a/src/components/TransactionReconciliation.tsx
+++ b/src/components/TransactionReconciliation.tsx
@@ -303,13 +303,13 @@ export default function TransactionReconciliation({
               
               <div className={`rounded-lg p-4 border ${
                 Math.abs(statementDifference) < 0.01
-                  ? 'bg-green-50 dark:bg-green-900/20 border-green-200 dark:border-green-800'
+                  ? 'bg-blue-50 dark:bg-blue-900/20 border-blue-200 dark:border-blue-800'
                   : 'bg-red-50 dark:bg-red-900/20 border-red-200 dark:border-red-800'
               }`}>
                 <div className="text-sm text-gray-600 dark:text-gray-400">Difference</div>
                 <div className={`text-xl font-semibold mt-1 ${
                   Math.abs(statementDifference) < 0.01
-                    ? 'text-green-600 dark:text-green-400'
+                    ? 'text-blue-600 dark:text-blue-400'
                     : 'text-red-600 dark:text-red-400'
                 }`}>
                   {formatCurrency(statementDifference)}
@@ -441,7 +441,7 @@ export default function TransactionReconciliation({
                           
                           <button
                             onClick={() => handleClearSelected([transaction.id])}
-                            className="ml-4 px-3 py-1 bg-green-600 text-white rounded hover:bg-green-700"
+                            className="ml-4 px-3 py-1 bg-blue-600 text-white rounded hover:bg-blue-700"
                           >
                             Clear
                           </button>
@@ -455,12 +455,12 @@ export default function TransactionReconciliation({
 
             {/* Success Message */}
             {unclearedTransactions.length === 0 && Math.abs(statementDifference) < 0.01 && (
-              <div className="bg-green-50 dark:bg-green-900/20 rounded-lg p-8 text-center">
-                <CheckCircleIcon className="mx-auto text-green-600 dark:text-green-400 mb-3" size={48} />
-                <h4 className="text-lg font-medium text-green-900 dark:text-green-300">
+              <div className="bg-blue-50 dark:bg-blue-900/20 rounded-lg p-8 text-center">
+                <CheckCircleIcon className="mx-auto text-blue-600 dark:text-blue-400 mb-3" size={48} />
+                <h4 className="text-lg font-medium text-blue-900 dark:text-blue-300">
                   Account Reconciled!
                 </h4>
-                <p className="text-sm text-green-800 dark:text-green-200 mt-1">
+                <p className="text-sm text-blue-800 dark:text-blue-200 mt-1">
                   All transactions are cleared and your balance matches the statement.
                 </p>
               </div>

--- a/src/components/reconciliation/ReconciliationAccountList.tsx
+++ b/src/components/reconciliation/ReconciliationAccountList.tsx
@@ -60,7 +60,7 @@ export default function ReconciliationAccountList({
                     {unreconciledCount} unreconciled
                   </span>
                 ) : (
-                  <span className="inline-flex items-center px-2.5 py-1 rounded-full text-xs font-medium bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-400">
+                  <span className="inline-flex items-center px-2.5 py-1 rounded-full text-xs font-medium bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-400">
                     All cleared
                   </span>
                 )}
@@ -90,7 +90,7 @@ export default function ReconciliationAccountList({
                   difference == null
                     ? 'text-gray-400'
                     : Math.abs(difference) < 0.005
-                    ? 'text-green-600 dark:text-green-400'
+                    ? 'text-blue-600 dark:text-blue-400'
                     : 'text-red-600 dark:text-red-400'
                 }`}>
                   {difference != null

--- a/src/components/reconciliation/ReconciliationBalanceBar.tsx
+++ b/src/components/reconciliation/ReconciliationBalanceBar.tsx
@@ -106,7 +106,7 @@ export default function ReconciliationBalanceBar({
         {/* Cleared Balance */}
         <div className="text-center">
           <p className="text-xs text-gray-500 dark:text-gray-400 mb-1">Cleared Balance</p>
-          <p className="text-lg font-bold text-emerald-700 dark:text-emerald-400">
+          <p className="text-lg font-bold text-blue-600 dark:text-blue-400">
             {formatCurrency(clearedBalance, currency)}
           </p>
         </div>
@@ -117,7 +117,7 @@ export default function ReconciliationBalanceBar({
           {difference != null ? (
             <p className={`text-lg font-bold ${
               Math.abs(difference) < 0.005
-                ? 'text-green-600 dark:text-green-400'
+                ? 'text-blue-600 dark:text-blue-400'
                 : 'text-red-600 dark:text-red-400'
             }`}>
               {formatCurrency(difference, currency)}

--- a/src/components/reconciliation/ReconciliationFinalizationModal.tsx
+++ b/src/components/reconciliation/ReconciliationFinalizationModal.tsx
@@ -138,7 +138,7 @@ export default function ReconciliationFinalizationModal({
               </button>
               <button
                 onClick={onFinalize}
-                className="flex-1 px-6 py-2 bg-green-600 text-white rounded-lg hover:bg-green-700 transition-colors font-medium"
+                className="flex-1 px-6 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors font-medium"
               >
                 Finalize Anyway
               </button>
@@ -147,8 +147,8 @@ export default function ReconciliationFinalizationModal({
         ) : isBalanced ? (
           /* Balanced — success */
           <div className="text-center py-6">
-            <CheckCircleIcon size={48} className="mx-auto text-green-500 mb-3" />
-            <h3 className="text-lg font-semibold text-green-600 dark:text-green-400 mb-1">
+            <CheckCircleIcon size={48} className="mx-auto text-blue-600 mb-3" />
+            <h3 className="text-lg font-semibold text-blue-600 dark:text-blue-400 mb-1">
               Account Balanced!
             </h3>
             <p className="text-sm text-gray-500 dark:text-gray-400 mb-6">
@@ -156,7 +156,7 @@ export default function ReconciliationFinalizationModal({
             </p>
             <button
               onClick={onFinalize}
-              className="px-6 py-2 bg-green-600 text-white rounded-lg hover:bg-green-700 transition-colors font-medium"
+              className="px-6 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors font-medium"
             >
               Complete Reconciliation
             </button>

--- a/src/components/reconciliation/ReconciliationTransactionList.tsx
+++ b/src/components/reconciliation/ReconciliationTransactionList.tsx
@@ -228,7 +228,7 @@ export default function ReconciliationTransactionList({
                       disabled={pendingClearedIds?.has(t.id) ?? false}
                       className={`w-6 h-6 rounded border-2 flex items-center justify-center transition-colors disabled:opacity-60 disabled:cursor-wait ${
                         t.cleared
-                          ? 'bg-green-500 border-green-500 text-white'
+                          ? 'bg-blue-600 border-blue-600 text-white'
                           : 'border-gray-300 dark:border-gray-500 hover:border-primary'
                       }`}
                       title={t.cleared ? 'Mark as uncleared' : 'Mark as cleared'}


### PR DESCRIPTION
## What & why

First slice of the app-wide **green → mid-blue** UI-accent sweep (request #2). You picked **Blue A — #2563eb** (Tailwind `blue-600`). The dark-navy theme's neutral accents (checkboxes, ticks, selection/status chips) move to that blue so they read as one colour family. **Money keeps its semantics** — income/positive stays green, expense/negative stays red.

Starting with **reconciliation** because it's high-traffic and where recent work landed.

## Changed → blue
- Cleared **checkbox** (checked state)
- "All cleared" status chip
- "Cleared Balance" figure + balanced-**difference** status
- Finalize / Clear **buttons**
- "Account balanced" / "Account reconciled" **success ticks + headings + panels**

## Kept green (money semantic)
- Cleared **deposits** total (paired with red payments)
- Sign-based transaction **amount** (`>0` green / `<0` red)
- Income-typed amount in `TransactionReconciliation`

## Verification
- Tailwind colour-class swaps only — no behaviour change.
- `typecheck:strict` ✅ · `lint` ✅ · `test:unit` ✅ (2881) · `build` ✅ · no snapshot tests affected.
- Live (demo): "All cleared" chip = `bg-blue-100`/`text-blue-700`; "Cleared Balance" = `text-blue-600` (rgb 37,99,235 = #2563eb).

Follow-up PRs will cover the other areas (dashboard/investments — careful with gain/loss greens, then settings/modals/wizards, then shared components/toasts).

🤖 Generated with [Claude Code](https://claude.com/claude-code)