### PR TITLE
style(settings/onboarding): recolour UI-accent greens to mid-blue (#2563eb)

### DIFF
--- a/src/components/BankFormatSelector.tsx
+++ b/src/components/BankFormatSelector.tsx
@@ -167,7 +167,7 @@ export default function BankFormatSelector({ onBankSelected, selectedBank, class
             placeholder="Search banks, payment services, or investment platforms..."
             value={searchTerm}
             onChange={(e) => setSearchTerm(e.target.value)}
-            className="w-full pl-10 pr-4 py-2 border border-gray-300 dark:border-gray-600 rounded-lg focus:ring-2 focus:ring-emerald-600 focus:border-transparent dark:bg-gray-700 dark:text-white"
+            className="w-full pl-10 pr-4 py-2 border border-gray-300 dark:border-gray-600 rounded-lg focus:ring-2 focus:ring-blue-600 focus:border-transparent dark:bg-gray-700 dark:text-white"
           />
         </div>
         
@@ -178,7 +178,7 @@ export default function BankFormatSelector({ onBankSelected, selectedBank, class
             <select
               value={selectedRegion}
               onChange={(e) => setSelectedRegion(e.target.value)}
-              className="px-3 py-1 border border-gray-300 dark:border-gray-600 rounded focus:ring-2 focus:ring-emerald-600 dark:bg-gray-700 dark:text-white text-sm"
+              className="px-3 py-1 border border-gray-300 dark:border-gray-600 rounded focus:ring-2 focus:ring-blue-600 dark:bg-gray-700 dark:text-white text-sm"
             >
               <option value="all">All Regions</option>
               {Object.entries(REGION_GROUPS).map(([key, name]) => (
@@ -192,7 +192,7 @@ export default function BankFormatSelector({ onBankSelected, selectedBank, class
             <select
               value={selectedType}
               onChange={(e) => setSelectedType(e.target.value)}
-              className="px-3 py-1 border border-gray-300 dark:border-gray-600 rounded focus:ring-2 focus:ring-emerald-600 dark:bg-gray-700 dark:text-white text-sm"
+              className="px-3 py-1 border border-gray-300 dark:border-gray-600 rounded focus:ring-2 focus:ring-blue-600 dark:bg-gray-700 dark:text-white text-sm"
             >
               <option value="all">All Types</option>
               {Object.entries(TYPE_GROUPS).map(([key, name]) => (

--- a/src/components/CSVImportWizard.tsx
+++ b/src/components/CSVImportWizard.tsx
@@ -449,8 +449,8 @@ export default function CSVImportWizard({ isOpen, onClose, type }: CSVImportWiza
           {currentStep === 'result' && importResult && (
             <div className="p-6">
               <div className="text-center mb-6">
-                <div className="inline-flex items-center justify-center w-16 h-16 bg-green-100 dark:bg-green-900/30 rounded-full mb-4">
-                  <CheckIcon size={32} className="text-green-600 dark:text-green-400" />
+                <div className="inline-flex items-center justify-center w-16 h-16 bg-blue-100 dark:bg-blue-900/30 rounded-full mb-4">
+                  <CheckIcon size={32} className="text-blue-600 dark:text-blue-400" />
                 </div>
                 <h3 className="text-2xl font-bold text-gray-900 dark:text-white mb-2">
                   Import Complete!
@@ -459,11 +459,11 @@ export default function CSVImportWizard({ isOpen, onClose, type }: CSVImportWiza
 
               {/* Results Summary */}
               <div className="grid grid-cols-3 gap-4 mb-6">
-                <div className="bg-green-50 dark:bg-green-900/20 rounded-lg p-4 text-center">
-                  <p className="text-3xl font-bold text-green-600 dark:text-green-400">
+                <div className="bg-blue-50 dark:bg-blue-900/20 rounded-lg p-4 text-center">
+                  <p className="text-3xl font-bold text-blue-600 dark:text-blue-400">
                     {importResult.success}
                   </p>
-                  <p className="text-sm text-green-800 dark:text-green-300">Imported</p>
+                  <p className="text-sm text-blue-800 dark:text-blue-300">Imported</p>
                 </div>
                 
                 {importResult.duplicates > 0 && (
@@ -596,7 +596,7 @@ function StepIndicator({
         <div
           className={`relative w-10 h-10 rounded-full flex items-center justify-center transition-all duration-300 ${
             isComplete
-              ? 'bg-gradient-to-br from-green-400 to-green-600 text-white shadow-lg shadow-green-500/30 scale-105'
+              ? 'bg-gradient-to-br from-blue-400 to-blue-600 text-white shadow-lg shadow-blue-600/30 scale-105'
               : isActive
               ? 'bg-gradient-to-br from-primary to-secondary text-white shadow-lg shadow-primary/30 scale-110'
               : 'bg-gray-200 dark:bg-gray-700 text-gray-500 dark:text-gray-400'
@@ -611,7 +611,7 @@ function StepIndicator({
       </div>
       <span className={`text-xs mt-2 font-medium transition-colors duration-200 ${
         isComplete
-          ? 'text-green-600 dark:text-green-400'
+          ? 'text-blue-600 dark:text-blue-400'
           : isActive 
           ? 'text-primary' 
           : 'text-gray-500 dark:text-gray-400'

--- a/src/components/DataMigrationWizard.tsx
+++ b/src/components/DataMigrationWizard.tsx
@@ -52,7 +52,7 @@ const MIGRATION_SOURCES = [
     name: 'Mint',
     description: 'Import from Intuit Mint',
     icon: CreditCardIcon,
-    color: 'bg-green-500',
+    color: 'bg-blue-600',
     fileTypes: ['.csv'],
     instructions: 'Export your data from Mint as CSV files before it shuts down.'
   },
@@ -249,7 +249,7 @@ export default function DataMigrationWizard({
                   <div
                     className={`w-10 h-10 rounded-full flex items-center justify-center transition-colors ${
                       currentStep > step.id
-                        ? 'bg-green-500 text-white'
+                        ? 'bg-blue-600 text-white'
                         : currentStep === step.id
                         ? 'bg-blue-500 text-white'
                         : 'bg-gray-200 dark:bg-gray-700 text-gray-500'
@@ -269,7 +269,7 @@ export default function DataMigrationWizard({
                   <div
                     className={`flex-1 h-0.5 mx-2 transition-colors ${
                       currentStep > step.id
-                        ? 'bg-green-500'
+                        ? 'bg-blue-600'
                         : 'bg-gray-200 dark:bg-gray-700'
                     }`}
                   />
@@ -423,7 +423,7 @@ export default function DataMigrationWizard({
 
               <div className="mt-6 p-4 bg-blue-50 dark:bg-blue-900/20 rounded-lg">
                 <div className="flex items-start gap-2">
-                  <ZapIcon size={20} className="text-emerald-700 dark:text-emerald-400 mt-0.5" />
+                  <ZapIcon size={20} className="text-blue-700 dark:text-blue-400 mt-0.5" />
                   <div>
                     <p className="text-sm font-medium text-blue-900 dark:text-blue-300 mb-1">
                       Smart Mapping Active
@@ -506,7 +506,7 @@ export default function DataMigrationWizard({
                 </>
               ) : (
                 <>
-                  <CheckCircleIcon size={64} className="text-green-500 mx-auto mb-4" />
+                  <CheckCircleIcon size={64} className="text-blue-600 mx-auto mb-4" />
                   <h3 className="text-lg font-semibold text-gray-900 dark:text-white mb-2">
                     Ready to Import
                   </h3>

--- a/src/components/EnhancedImportWizard.tsx
+++ b/src/components/EnhancedImportWizard.tsx
@@ -347,7 +347,7 @@ export default function EnhancedImportWizard({ isOpen, onClose }: EnhancedImport
                       className="flex items-center justify-between p-3 bg-gray-50 dark:bg-gray-700 rounded-lg"
                     >
                       <div className="flex items-center gap-3">
-                        <FileTextIcon size={20} className="text-emerald-700 dark:text-emerald-400" />
+                        <FileTextIcon size={20} className="text-blue-700 dark:text-blue-400" />
                         <div>
                           <p className="font-medium text-gray-900 dark:text-white">
                             {file.name}
@@ -434,13 +434,13 @@ export default function EnhancedImportWizard({ isOpen, onClose }: EnhancedImport
                 {/* Summary */}
                 <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
                   <div className="bg-blue-50 dark:bg-blue-900/20 p-4 rounded-lg">
-                    <p className="text-2xl font-bold text-emerald-700 dark:text-emerald-400">
+                    <p className="text-2xl font-bold text-blue-700 dark:text-blue-400">
                       {importResult.totalFiles}
                     </p>
                     <p className="text-sm text-gray-600 dark:text-gray-400">Files Processed</p>
                   </div>
-                  <div className="bg-green-50 dark:bg-green-900/20 p-4 rounded-lg">
-                    <p className="text-2xl font-bold text-green-600 dark:text-green-400">
+                  <div className="bg-blue-50 dark:bg-blue-900/20 p-4 rounded-lg">
+                    <p className="text-2xl font-bold text-blue-600 dark:text-blue-400">
                       {importResult.successfulFiles}
                     </p>
                     <p className="text-sm text-gray-600 dark:text-gray-400">Successful</p>
@@ -467,7 +467,7 @@ export default function EnhancedImportWizard({ isOpen, onClose }: EnhancedImport
                       key={index}
                       className={`flex items-center justify-between p-3 rounded-lg ${
                         file.status === 'success'
-                          ? 'bg-green-50 dark:bg-green-900/20'
+                          ? 'bg-blue-50 dark:bg-blue-900/20'
                           : file.status === 'error'
                           ? 'bg-red-50 dark:bg-red-900/20'
                           : 'bg-gray-50 dark:bg-gray-700'
@@ -475,7 +475,7 @@ export default function EnhancedImportWizard({ isOpen, onClose }: EnhancedImport
                     >
                       <div className="flex items-center gap-3">
                         {file.status === 'success' ? (
-                          <CheckIcon size={20} className="text-green-600 dark:text-green-400" />
+                          <CheckIcon size={20} className="text-blue-600 dark:text-blue-400" />
                         ) : file.status === 'error' ? (
                           <XIcon size={20} className="text-red-600 dark:text-red-400" />
                         ) : (
@@ -564,13 +564,13 @@ export default function EnhancedImportWizard({ isOpen, onClose }: EnhancedImport
                 return (
                   <React.Fragment key={step}>
                     <div className={`flex items-center gap-2 ${
-                      isActive ? 'text-emerald-700 dark:text-emerald-400' : 
-                      isPast ? 'text-green-600 dark:text-green-400' : 
+                      isActive ? 'text-blue-700 dark:text-blue-400' : 
+                      isPast ? 'text-blue-600 dark:text-blue-400' : 
                       'text-gray-400 dark:text-gray-600'
                     }`}>
                       <div className={`w-8 h-8 rounded-full flex items-center justify-center text-sm font-medium ${
                         isActive ? 'bg-[#1a2332] text-white' :
-                        isPast ? 'bg-green-600 text-white' :
+                        isPast ? 'bg-blue-600 text-white' :
                         'bg-gray-200 dark:bg-gray-700 text-gray-600 dark:text-gray-400'
                       }`}>
                         {isPast ? <CheckIcon size={16} /> : stepNumber}
@@ -584,7 +584,7 @@ export default function EnhancedImportWizard({ isOpen, onClose }: EnhancedImport
                     </div>
                     {index < 3 && (
                       <div className={`flex-1 h-0.5 mx-2 ${
-                        isPast ? 'bg-green-600' : 'bg-gray-200 dark:bg-gray-700'
+                        isPast ? 'bg-blue-600' : 'bg-gray-200 dark:bg-gray-700'
                       }`} />
                     )}
                   </React.Fragment>

--- a/src/components/SimpleSignIn.tsx
+++ b/src/components/SimpleSignIn.tsx
@@ -22,13 +22,13 @@ export default function SimpleSignIn() {
         <SignedOut>
           <div className="space-y-4">
             <SignInButton mode="modal">
-              <button className="w-full py-3 px-4 bg-gradient-to-r from-blue-500 to-indigo-600 text-white rounded-xl font-medium hover:from-blue-600 hover:to-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-emerald-600 transition-all shadow-lg">
+              <button className="w-full py-3 px-4 bg-gradient-to-r from-blue-500 to-indigo-600 text-white rounded-xl font-medium hover:from-blue-600 hover:to-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-600 transition-all shadow-lg">
                 Sign In
               </button>
             </SignInButton>
             
             <SignUpButton mode="modal">
-              <button className="w-full py-3 px-4 border-2 border-blue-500 text-emerald-700 dark:text-emerald-400 rounded-xl font-medium hover:bg-blue-50 dark:hover:bg-gray-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-emerald-600 transition-all">
+              <button className="w-full py-3 px-4 border-2 border-blue-500 text-blue-700 dark:text-blue-400 rounded-xl font-medium hover:bg-blue-50 dark:hover:bg-gray-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-600 transition-all">
                 Create Account
               </button>
             </SignUpButton>
@@ -41,7 +41,7 @@ export default function SimpleSignIn() {
             <UserButton afterSignOutUrl="/" />
             <a 
               href="/dashboard" 
-              className="block w-full py-3 px-4 bg-gradient-to-r from-blue-500 to-indigo-600 text-white rounded-xl font-medium hover:from-blue-600 hover:to-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-emerald-600 transition-all shadow-lg"
+              className="block w-full py-3 px-4 bg-gradient-to-r from-blue-500 to-indigo-600 text-white rounded-xl font-medium hover:from-blue-600 hover:to-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-600 transition-all shadow-lg"
             >
               Go to Dashboard
             </a>

--- a/src/components/auth/SimpleSignIn.tsx
+++ b/src/components/auth/SimpleSignIn.tsx
@@ -22,13 +22,13 @@ export default function SimpleSignIn() {
         <SignedOut>
           <div className="space-y-4">
             <SignInButton mode="modal">
-              <button className="w-full py-3 px-4 bg-gradient-to-r from-blue-500 to-indigo-600 text-white rounded-xl font-medium hover:from-blue-600 hover:to-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-emerald-600 transition-all shadow-lg">
+              <button className="w-full py-3 px-4 bg-gradient-to-r from-blue-500 to-indigo-600 text-white rounded-xl font-medium hover:from-blue-600 hover:to-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-600 transition-all shadow-lg">
                 Sign In
               </button>
             </SignInButton>
             
             <SignUpButton mode="modal">
-              <button className="w-full py-3 px-4 border-2 border-blue-500 text-emerald-700 dark:text-emerald-400 rounded-xl font-medium hover:bg-blue-50 dark:hover:bg-gray-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-emerald-600 transition-all">
+              <button className="w-full py-3 px-4 border-2 border-blue-500 text-blue-700 dark:text-blue-400 rounded-xl font-medium hover:bg-blue-50 dark:hover:bg-gray-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-600 transition-all">
                 Create Account
               </button>
             </SignUpButton>
@@ -49,7 +49,7 @@ export default function SimpleSignIn() {
             <UserButton afterSignOutUrl="/" />
             <a 
               href="/dashboard" 
-              className="block w-full py-3 px-4 bg-gradient-to-r from-blue-500 to-indigo-600 text-white rounded-xl font-medium hover:from-blue-600 hover:to-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-emerald-600 transition-all shadow-lg"
+              className="block w-full py-3 px-4 bg-gradient-to-r from-blue-500 to-indigo-600 text-white rounded-xl font-medium hover:from-blue-600 hover:to-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-600 transition-all shadow-lg"
             >
               Go to Dashboard
             </a>

--- a/src/pages/settings/DataManagement.tsx
+++ b/src/pages/settings/DataManagement.tsx
@@ -217,7 +217,7 @@ export default function DataManagementSettings() {
         <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
           <button
             onClick={() => setShowBatchImport(true)}
-            className="px-4 py-2 bg-green-700 text-white rounded-lg hover:bg-green-800 transition-colors flex items-center justify-center gap-2"
+            className="px-4 py-2 bg-blue-700 text-white rounded-lg hover:bg-blue-800 transition-colors flex items-center justify-center gap-2"
           >
             <FolderIcon size={20} />
             Batch Import Multiple Files
@@ -241,7 +241,7 @@ export default function DataManagementSettings() {
 
           <button
             onClick={() => setShowQIFImportModal(true)}
-            className="px-4 py-2 bg-teal-700 text-white rounded-lg hover:bg-teal-800 transition-colors flex items-center justify-center gap-2"
+            className="px-4 py-2 bg-blue-700 text-white rounded-lg hover:bg-blue-800 transition-colors flex items-center justify-center gap-2"
           >
             <DatabaseIcon size={20} />
             QIF Import (Quicken)
@@ -277,7 +277,7 @@ export default function DataManagementSettings() {
         <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
           <button
             onClick={handleExportData}
-            className="px-4 py-2 bg-green-700 text-white rounded-lg hover:bg-green-800 transition-colors flex items-center justify-center gap-2"
+            className="px-4 py-2 bg-blue-700 text-white rounded-lg hover:bg-blue-800 transition-colors flex items-center justify-center gap-2"
           >
             <DownloadIcon size={20} />
             Quick Export (JSON)
@@ -285,7 +285,7 @@ export default function DataManagementSettings() {
 
           <button
             onClick={() => setShowExcelExport(true)}
-            className="px-4 py-2 bg-emerald-700 text-white rounded-lg hover:bg-emerald-800 transition-colors flex items-center justify-center gap-2"
+            className="px-4 py-2 bg-blue-700 text-white rounded-lg hover:bg-blue-800 transition-colors flex items-center justify-center gap-2"
           >
             <GridIcon size={20} />
             Legacy Excel Export

--- a/src/pages/settings/DeletedAccounts.tsx
+++ b/src/pages/settings/DeletedAccounts.tsx
@@ -112,8 +112,8 @@ export default function DeletedAccounts() {
 
       {/* Success Message */}
       {successMessage && (
-        <div className="mb-6 p-4 bg-green-50 dark:bg-green-900/20 border border-green-200 dark:border-green-800 rounded-lg">
-          <div className="flex items-center gap-2 text-green-700 dark:text-green-300">
+        <div className="mb-6 p-4 bg-blue-50 dark:bg-blue-900/20 border border-blue-200 dark:border-blue-800 rounded-lg">
+          <div className="flex items-center gap-2 text-blue-700 dark:text-blue-300">
             <CheckCircleIcon size={20} />
             <span>{successMessage}</span>
           </div>
@@ -123,7 +123,7 @@ export default function DeletedAccounts() {
       {/* Info Section */}
       <div className="bg-blue-50 dark:bg-blue-900/20 border border-blue-200 dark:border-blue-800 rounded-lg p-6 mb-6">
         <div className="flex items-start gap-3">
-          <ArchiveIcon size={24} className="text-emerald-700 dark:text-emerald-400 mt-1" />
+          <ArchiveIcon size={24} className="text-blue-700 dark:text-blue-400 mt-1" />
           <div>
             <h3 className="font-semibold text-gray-900 dark:text-white mb-2">About Archived Accounts</h3>
             <p className="text-sm text-gray-600 dark:text-gray-400">
@@ -195,7 +195,7 @@ export default function DeletedAccounts() {
                       flex items-center gap-2 px-4 py-2 rounded-lg transition-colors ml-4
                       ${restoringId === account.id
                         ? 'bg-gray-300 dark:bg-gray-600 text-gray-500 cursor-not-allowed'
-                        : 'bg-green-600 hover:bg-green-700 text-white'
+                        : 'bg-blue-600 hover:bg-blue-700 text-white'
                       }
                     `}
                   >

--- a/src/pages/settings/SecuritySettings.tsx
+++ b/src/pages/settings/SecuritySettings.tsx
@@ -131,7 +131,7 @@ export default function SecuritySettings() {
         {setupMessage && (
           <div className={`mb-6 p-4 rounded-lg flex items-center gap-3 ${
             setupMessage.type === 'success' 
-              ? 'bg-green-50 dark:bg-green-900/20 text-green-800 dark:text-green-200'
+              ? 'bg-blue-50 dark:bg-blue-900/20 text-blue-800 dark:text-blue-200'
               : 'bg-red-50 dark:bg-red-900/20 text-red-800 dark:text-red-200'
           }`}>
             {setupMessage.type === 'success' ? (
@@ -162,7 +162,7 @@ export default function SecuritySettings() {
                 className={`px-4 py-2 rounded-lg font-medium transition-colors ${
                   settings.twoFactorEnabled
                     ? 'bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-400 hover:bg-red-200 dark:hover:bg-red-900/50'
-                    : 'bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-400 hover:bg-green-200 dark:hover:bg-green-900/50'
+                    : 'bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-400 hover:bg-blue-200 dark:hover:bg-blue-900/50'
                 }`}
               >
                 {settings.twoFactorEnabled ? 'Disable' : 'Enable'}
@@ -170,8 +170,8 @@ export default function SecuritySettings() {
             </div>
             
             {settings.twoFactorEnabled && (
-              <div className="mt-4 p-3 bg-green-50 dark:bg-green-900/20 rounded-lg">
-                <p className="text-sm text-green-800 dark:text-green-200 flex items-center gap-2">
+              <div className="mt-4 p-3 bg-blue-50 dark:bg-blue-900/20 rounded-lg">
+                <p className="text-sm text-blue-800 dark:text-blue-200 flex items-center gap-2">
                   <CheckCircleIcon size={16} />
                   Two-factor authentication is active
                 </p>
@@ -199,7 +199,7 @@ export default function SecuritySettings() {
                     ? 'bg-gray-100 text-gray-400 dark:bg-gray-700 cursor-not-allowed'
                     : settings.biometricEnabled
                     ? 'bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-400 hover:bg-red-200 dark:hover:bg-red-900/50'
-                    : 'bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-400 hover:bg-green-200 dark:hover:bg-green-900/50'
+                    : 'bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-400 hover:bg-blue-200 dark:hover:bg-blue-900/50'
                 }`}
               >
                 {!biometricAvailable ? 'Not Available' : settings.biometricEnabled ? 'Disable' : 'Enable'}
@@ -220,7 +220,7 @@ export default function SecuritySettings() {
             <div className="flex items-start justify-between">
               <div className="flex-1">
                 <h3 className="text-lg font-semibold text-gray-900 dark:text-white flex items-center gap-2">
-                  <LockIcon size={20} className="text-green-600 dark:text-green-400" />
+                  <LockIcon size={20} className="text-blue-600 dark:text-blue-400" />
                   End-to-End Encryption
                 </h3>
                 <p className="mt-1 text-sm text-gray-600 dark:text-gray-400">
@@ -232,7 +232,7 @@ export default function SecuritySettings() {
                 className={`px-4 py-2 rounded-lg font-medium transition-colors ${
                   settings.encryptionEnabled
                     ? 'bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-400 hover:bg-red-200 dark:hover:bg-red-900/50'
-                    : 'bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-400 hover:bg-green-200 dark:hover:bg-green-900/50'
+                    : 'bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-400 hover:bg-blue-200 dark:hover:bg-blue-900/50'
                 }`}
               >
                 {settings.encryptionEnabled ? 'Disable' : 'Enable'}
@@ -240,8 +240,8 @@ export default function SecuritySettings() {
             </div>
             
             {settings.encryptionEnabled && (
-              <div className="mt-4 p-3 bg-green-50 dark:bg-green-900/20 rounded-lg">
-                <p className="text-sm text-green-800 dark:text-green-200 flex items-center gap-2">
+              <div className="mt-4 p-3 bg-blue-50 dark:bg-blue-900/20 rounded-lg">
+                <p className="text-sm text-blue-800 dark:text-blue-200 flex items-center gap-2">
                   <CheckCircleIcon size={16} />
                   All data is encrypted using AES-256-GCM
                 </p>
@@ -254,7 +254,7 @@ export default function SecuritySettings() {
             <div className="flex items-start justify-between">
               <div className="flex-1">
                 <h3 className="text-lg font-semibold text-gray-900 dark:text-white flex items-center gap-2">
-                  <EyeIcon size={20} className="text-emerald-700 dark:text-emerald-400" />
+                  <EyeIcon size={20} className="text-blue-700 dark:text-blue-400" />
                   Read-Only Mode
                 </h3>
                 <p className="mt-1 text-sm text-gray-600 dark:text-gray-400">
@@ -266,7 +266,7 @@ export default function SecuritySettings() {
                 className={`px-4 py-2 rounded-lg font-medium transition-colors ${
                   settings.readOnlyMode
                     ? 'bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-400 hover:bg-red-200 dark:hover:bg-red-900/50'
-                    : 'bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-400 hover:bg-green-200 dark:hover:bg-green-900/50'
+                    : 'bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-400 hover:bg-blue-200 dark:hover:bg-blue-900/50'
                 }`}
               >
                 {settings.readOnlyMode ? 'Disable' : 'Enable'}

--- a/src/pages/settings/ThemeSettings.tsx
+++ b/src/pages/settings/ThemeSettings.tsx
@@ -141,7 +141,7 @@ export default function ThemeSettings() {
           <div className="bg-white dark:bg-gray-800 rounded-lg shadow-sm p-4">
             <div className="flex items-center gap-3">
               {getCurrentTheme() === 'dark' ? (
-                <MoonIcon size={20} className="text-emerald-700 dark:text-emerald-400" />
+                <MoonIcon size={20} className="text-blue-700 dark:text-blue-400" />
               ) : (
                 <SunIcon size={20} className="text-yellow-600 dark:text-yellow-400" />
               )}
@@ -156,7 +156,7 @@ export default function ThemeSettings() {
 
           <div className="bg-white dark:bg-gray-800 rounded-lg shadow-sm p-4">
             <div className="flex items-center gap-3">
-              <ClockIcon size={20} className="text-green-600 dark:text-green-400" />
+              <ClockIcon size={20} className="text-blue-600 dark:text-blue-400" />
               <div>
                 <p className="text-sm text-gray-600 dark:text-gray-400">Active Schedule</p>
                 <p className="font-semibold text-gray-900 dark:text-white">
@@ -252,14 +252,14 @@ export default function ThemeSettings() {
                     key={schedule.id}
                     className={`bg-white dark:bg-gray-800 rounded-lg shadow-sm p-6 border-2 ${
                       schedule.isActive
-                        ? 'border-green-500 dark:border-green-400'
+                        ? 'border-blue-600 dark:border-blue-400'
                         : 'border-transparent'
                     }`}
                   >
                     <div className="flex items-start justify-between mb-4">
                       <div className="flex items-center gap-3">
                         <div className={`w-3 h-3 rounded-full ${
-                          schedule.isActive ? 'bg-green-500' : 'bg-gray-400'
+                          schedule.isActive ? 'bg-blue-600' : 'bg-gray-400'
                         }`} />
                         <div>
                           <h4 className="font-semibold text-gray-900 dark:text-white">
@@ -276,7 +276,7 @@ export default function ThemeSettings() {
                           className={`p-2 rounded ${
                             schedule.isActive
                               ? 'text-red-600 dark:text-red-400 hover:text-red-900 dark:hover:text-red-300'
-                              : 'text-green-600 dark:text-green-400 hover:text-green-900 dark:hover:text-green-300'
+                              : 'text-blue-600 dark:text-blue-400 hover:text-blue-900 dark:hover:text-blue-300'
                           }`}
                           title={schedule.isActive ? 'Deactivate schedule' : 'Activate schedule'}
                         >
@@ -284,7 +284,7 @@ export default function ThemeSettings() {
                         </button>
                         <button
                           onClick={() => setEditingSchedule(schedule)}
-                          className="p-2 text-emerald-700 dark:text-emerald-400 hover:text-blue-900 dark:hover:text-blue-300"
+                          className="p-2 text-blue-700 dark:text-blue-400 hover:text-blue-900 dark:hover:text-blue-300"
                           title="Edit schedule"
                         >
                           <EditIcon size={16} />
@@ -387,7 +387,7 @@ export default function ThemeSettings() {
                     </div>
                     <div className="flex items-center gap-2">
                       <button
-                        className="p-2 text-emerald-700 dark:text-emerald-400 hover:text-blue-900 dark:hover:text-blue-300"
+                        className="p-2 text-blue-700 dark:text-blue-400 hover:text-blue-900 dark:hover:text-blue-300"
                         title="Preview preset"
                       >
                         <EyeIcon size={16} />


### PR DESCRIPTION
## What & why

Second slice of the green → mid-blue UI-accent sweep (request #2, accent **#2563eb**). Covers the **settings, auth and import/onboarding** surfaces.

These screens carry no monetary values, so every green here is UI chrome and all of it moves to blue:
- Enabled/secure **status chips** + secure icons (Security Settings)
- **Action buttons** (Data Management export/backup/restore — previously three different greens, now unified blue)
- **Focus rings** (sign-in, bank-format search)
- **Step indicators** + **success ticks/panels** (CSV / enhanced import / migration wizards)
- **Active toggles** + edit actions (Theme schedule, Deleted Accounts restore)

The big bold numbers in the import summaries are **counts** (files processed, imported), not money.

## Verification
- Mechanical Tailwind class swap (`green/emerald/teal-{stop}` → blue; `-500` → `blue-600` for solid accents). No money/gain greens exist in these files (verified by reading each).
- `typecheck:strict` ✅ · `lint` ✅ · `test:unit` ✅ (2881) · `build` ✅.
- Live (demo): Security Settings "Enable" buttons now `bg-blue-100`/`text-blue-700`.

Part of the incremental sweep — remaining areas (shared components/indicators/toasts, then dashboard/investments with gains kept green) follow in later PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)