### PR TITLE
style(shell): recolour app-shell UI-accent greens to mid-blue (#2563eb)

### DIFF
--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -195,13 +195,13 @@ export default function Layout(): React.JSX.Element {
       <div className="sr-only focus:not-sr-only focus:absolute focus:top-4 focus:left-4 z-50">
         <a 
           href="#main-content" 
-          className="inline-block px-4 py-2 bg-[#1a2332] text-white rounded-md focus:outline-none focus:ring-2 focus:ring-emerald-600 focus:ring-offset-2"
+          className="inline-block px-4 py-2 bg-[#1a2332] text-white rounded-md focus:outline-none focus:ring-2 focus:ring-blue-600 focus:ring-offset-2"
         >
           Skip to main content
         </a>
         <a 
           href="#main-navigation" 
-          className="inline-block px-4 py-2 ml-2 bg-[#1a2332] text-white rounded-md focus:outline-none focus:ring-2 focus:ring-emerald-600 focus:ring-offset-2"
+          className="inline-block px-4 py-2 ml-2 bg-[#1a2332] text-white rounded-md focus:outline-none focus:ring-2 focus:ring-blue-600 focus:ring-offset-2"
         >
           Skip to navigation
         </a>
@@ -321,7 +321,7 @@ export default function Layout(): React.JSX.Element {
                   <div className="absolute right-0 top-full mt-1 bg-white dark:bg-gray-800 rounded-lg shadow-xl border border-gray-200 dark:border-gray-700 py-2 w-72 z-50">
                     {currentHelp && (
                       <div className="px-4 py-3 border-b border-gray-100 dark:border-gray-700">
-                        <p className="text-xs font-semibold text-emerald-700 dark:text-emerald-400 uppercase tracking-wider mb-1">About this page</p>
+                        <p className="text-xs font-semibold text-blue-700 dark:text-blue-400 uppercase tracking-wider mb-1">About this page</p>
                         <p className="text-xs text-gray-600 dark:text-gray-400 leading-relaxed">{currentHelp[1]}</p>
                       </div>
                     )}
@@ -673,12 +673,12 @@ export default function Layout(): React.JSX.Element {
       
       {/* Auto-resolved notification */}
       {conflictState.autoResolvedCount > 0 && (
-        <div className="fixed top-20 right-4 z-50 bg-green-100 dark:bg-green-900/90 p-3 rounded-lg shadow-lg animate-fade-in-out">
+        <div className="fixed top-20 right-4 z-50 bg-blue-100 dark:bg-blue-900/90 p-3 rounded-lg shadow-lg animate-fade-in-out">
           <div className="flex items-center gap-2">
-            <svg className="w-4 h-4 text-green-600 dark:text-green-400" fill="currentColor" viewBox="0 0 20 20">
+            <svg className="w-4 h-4 text-blue-600 dark:text-blue-400" fill="currentColor" viewBox="0 0 20 20">
               <path fillRule="evenodd" d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z" clipRule="evenodd" />
             </svg>
-            <span className="text-sm text-green-800 dark:text-green-200">
+            <span className="text-sm text-blue-800 dark:text-blue-200">
               {conflictState.autoResolvedCount} conflict{conflictState.autoResolvedCount !== 1 ? 's' : ''} auto-resolved
             </span>
           </div>

--- a/src/components/OfflineIndicator.test.tsx
+++ b/src/components/OfflineIndicator.test.tsx
@@ -159,19 +159,21 @@ describe('OfflineIndicator', () => {
       expect(banner).toHaveClass('bg-orange-500', 'text-white');
     });
 
-    it('shows green background when back online', () => {
+    it('shows blue background when back online', () => {
       setNavigatorOnline(true);
-      
+
       render(<OfflineIndicator />);
-      
+
       // Go offline first
       triggerOfflineEvent();
       // Then come back online
       triggerOnlineEvent();
-      
-      const banner = screen.getByText('Back online').closest('.bg-green-500');
+
+      // "Back online" uses the theme accent blue (the app-wide green→blue sweep;
+      // the offline state stays orange, so the two states remain distinct).
+      const banner = screen.getByText('Back online').closest('.bg-blue-600');
       expect(banner).toBeInTheDocument();
-      expect(banner).toHaveClass('bg-green-500', 'text-white');
+      expect(banner).toHaveClass('bg-blue-600', 'text-white');
     });
 
     it('displays WiFi off icon when offline', () => {

--- a/src/components/OfflineIndicator.tsx
+++ b/src/components/OfflineIndicator.tsx
@@ -39,7 +39,7 @@ export default function OfflineIndicator(): React.JSX.Element | null {
         className={`flex items-center gap-3 px-4 py-3 rounded-lg shadow-lg ${
           isOffline
             ? 'bg-orange-500 text-white'
-            : 'bg-green-500 text-white'
+            : 'bg-blue-600 text-white'
         }`}
       >
         {isOffline ? (

--- a/src/components/RealtimeStatusIndicator.tsx
+++ b/src/components/RealtimeStatusIndicator.tsx
@@ -40,7 +40,7 @@ export function RealtimeStatusIndicator({
 
   const getStatusColor = () => {
     if (connectionState.isConnected) {
-      return 'bg-green-500';
+      return 'bg-blue-600';
     } else if (connectionState.isReconnecting) {
       return 'bg-yellow-500 animate-pulse';
     } else {
@@ -190,7 +190,7 @@ export function RealtimeStatusDot(): React.JSX.Element {
     return <></>;
   }
 
-  const statusColor = connectionState.isConnected ? 'bg-green-500' : 'bg-yellow-500 animate-pulse';
+  const statusColor = connectionState.isConnected ? 'bg-blue-600' : 'bg-yellow-500 animate-pulse';
   const statusText = connectionState.isConnected ? 'Real-time sync active' : 'Reconnecting to real-time sync...';
 
   return (

--- a/src/components/SafariWarning.tsx
+++ b/src/components/SafariWarning.tsx
@@ -157,7 +157,7 @@ export default function SafariWarning(): React.JSX.Element | null {
                   href="https://www.microsoft.com/edge"
                   target="_blank"
                   rel="noopener noreferrer"
-                  className="flex items-center gap-2 px-3 py-2 bg-green-100 dark:bg-green-900/30 text-green-700 dark:text-green-300 rounded-lg hover:bg-green-200 dark:hover:bg-green-900/40 transition-colors"
+                  className="flex items-center gap-2 px-3 py-2 bg-blue-100 dark:bg-blue-900/30 text-blue-700 dark:text-blue-300 rounded-lg hover:bg-blue-200 dark:hover:bg-blue-900/40 transition-colors"
                 >
                   <GlobeIcon size={18} />
                   Edge

--- a/src/components/ServiceWorkerUpdateNotification.tsx
+++ b/src/components/ServiceWorkerUpdateNotification.tsx
@@ -85,7 +85,7 @@ export default function ServiceWorkerUpdateNotification({
           <div className="flex-shrink-0">
             <RefreshCwIcon 
               size={24} 
-              className={`text-emerald-700 dark:text-emerald-400 ${isUpdating ? 'animate-spin' : ''}`}
+              className={`text-blue-700 dark:text-blue-400 ${isUpdating ? 'animate-spin' : ''}`}
             />
           </div>
           
@@ -101,7 +101,7 @@ export default function ServiceWorkerUpdateNotification({
               <button
                 onClick={handleUpdate}
                 disabled={isUpdating}
-                className="px-4 py-2 text-sm font-medium text-white bg-[#1a2332] hover:bg-[#2d3a4d] disabled:bg-blue-400 rounded-lg transition-colors duration-200 focus:outline-none focus:ring-2 focus:ring-emerald-600 focus:ring-offset-2 dark:focus:ring-offset-gray-800"
+                className="px-4 py-2 text-sm font-medium text-white bg-[#1a2332] hover:bg-[#2d3a4d] disabled:bg-blue-400 rounded-lg transition-colors duration-200 focus:outline-none focus:ring-2 focus:ring-blue-600 focus:ring-offset-2 dark:focus:ring-offset-gray-800"
               >
                 {isUpdating ? 'Updating...' : 'Update Now'}
               </button>

--- a/src/components/SyncConflictResolver.tsx
+++ b/src/components/SyncConflictResolver.tsx
@@ -243,8 +243,8 @@ function ConflictDetail({ conflict, onResolve, onBack }: ConflictDetailProps): R
 
           <div className="space-y-4">
             <h3 className="font-medium text-gray-900 dark:text-white flex items-center gap-2">
-              <span className="text-green-500">Server Version</span>
-              <span className="text-xs bg-green-100 dark:bg-green-900/20 text-green-800 dark:text-green-200 px-2 py-1 rounded">
+              <span className="text-blue-600">Server Version</span>
+              <span className="text-xs bg-blue-100 dark:bg-blue-900/20 text-blue-800 dark:text-blue-200 px-2 py-1 rounded">
                 Latest from Server
               </span>
             </h3>


### PR DESCRIPTION
## What & why

Third slice of the green → mid-blue accent sweep (accent **#2563eb**). Covers global **app-shell chrome**: skip-link focus rings, the "About this page" label, the auto-resolved-conflict notification (Layout), the service-worker update prompt, the Safari-warning action button, sync-conflict version labels, and the realtime/offline **"connected/online" status dots**.

## Kept green on purpose (documented exceptions)
The default is success/status → blue, but two cases keep green to preserve a needed distinction:
- **Toast `success`** — `info` toasts are already blue, so recolouring success would make the two indistinguishable ("Saved ✓" vs "FYI").
- **OfflineStatus online dot** — `syncing` is already blue in the same 3-state indicator.

No money/gain greens exist in these files.

## Verification
- `typecheck:strict` ✅ · `lint` ✅ · `test:unit` ✅ (2881) · `build` ✅
- Updated `OfflineIndicator.test.tsx` to assert the new blue "back online" banner (offline stays orange, so states remain distinct).

Independent of #77 (disjoint files). Remaining after this: the data-heavy pages (dashboard, investments, portfolio, budgets, analytics, tax) — those need per-line care since green there often signals a gain, which stays green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)