### PR TITLE
style(registers): recolour UI-accent greens to mid-blue (#2563eb)

### DIFF
--- a/src/components/InfiniteScrollTransactionList.tsx
+++ b/src/components/InfiniteScrollTransactionList.tsx
@@ -179,7 +179,7 @@ export const InfiniteScrollTransactionList = memo(function InfiniteScrollTransac
           ) : (
             <button
               onClick={loadMoreItems}
-              className="px-4 py-2 text-sm text-emerald-700 dark:text-emerald-400 hover:bg-emerald-50 dark:hover:bg-emerald-900/20 rounded-lg transition-colors"
+              className="px-4 py-2 text-sm text-blue-700 dark:text-blue-400 hover:bg-blue-50 dark:hover:bg-blue-900/20 rounded-lg transition-colors"
             >
               Load More
             </button>

--- a/src/components/SwipeableTransactionRow.tsx
+++ b/src/components/SwipeableTransactionRow.tsx
@@ -92,7 +92,7 @@ export const SwipeableTransactionRow = memo(function SwipeableTransactionRow({
                 setOffset(0);
                 setIsRevealed(null);
               }}
-              className="p-3 bg-green-500 text-white rounded-lg"
+              className="p-3 bg-blue-600 text-white rounded-lg"
               aria-label="Reconcile"
             >
               <CheckIcon size={20} />
@@ -211,7 +211,7 @@ export const SwipeableTransactionRow = memo(function SwipeableTransactionRow({
                 {formatCurrency(transaction.amount)}
               </p>
               {transaction.cleared && (
-                <CheckIcon size={16} className="text-green-600 dark:text-green-400 ml-auto mt-1" />
+                <CheckIcon size={16} className="text-blue-600 dark:text-blue-400 ml-auto mt-1" />
               )}
             </div>
           </div>

--- a/src/components/TransactionRow.tsx
+++ b/src/components/TransactionRow.tsx
@@ -140,7 +140,7 @@ export const TransactionRow = memo(function TransactionRow({
             style={{ width: columnWidths.reconciled }}
           >
             {transaction.cleared && (
-              <CheckIcon className="text-green-500 mx-auto" size={compactView ? 14 : 16} data-testid="check-icon" />
+              <CheckIcon className="text-blue-600 mx-auto" size={compactView ? 14 : 16} data-testid="check-icon" />
             )}
           </td>
         );
@@ -200,7 +200,7 @@ export const TransactionRow = memo(function TransactionRow({
           >
             {isEditingCategory && availableCategories && onUpdateCategory ? (
               <select
-                className="w-full text-sm bg-white dark:bg-gray-700 border border-gray-300 dark:border-gray-600 rounded px-2 py-1 focus:outline-none focus:ring-1 focus:ring-emerald-500"
+                className="w-full text-sm bg-white dark:bg-gray-700 border border-gray-300 dark:border-gray-600 rounded px-2 py-1 focus:outline-none focus:ring-1 focus:ring-blue-500"
                 value={transaction.category || ''}
                 onChange={(e) => {
                   onUpdateCategory(transaction.id, e.target.value);
@@ -219,7 +219,7 @@ export const TransactionRow = memo(function TransactionRow({
               // (WCAG 2.1.1 — a span with onClick is invisible to AT).
               <button
                 type="button"
-                className={`${compactView ? 'text-sm' : ''} truncate block w-full text-left cursor-pointer hover:bg-gray-100 dark:hover:bg-gray-700 rounded px-1 -mx-1 focus:outline-none focus:ring-1 focus:ring-emerald-500`}
+                className={`${compactView ? 'text-sm' : ''} truncate block w-full text-left cursor-pointer hover:bg-gray-100 dark:hover:bg-gray-700 rounded px-1 -mx-1 focus:outline-none focus:ring-1 focus:ring-blue-500`}
                 title={`${categoryPath} (click to change)`}
                 aria-label={`Change category, currently ${categoryPath || 'uncategorized'}`}
                 onClick={() => setIsEditingCategory(true)}
@@ -247,7 +247,7 @@ export const TransactionRow = memo(function TransactionRow({
               <input
                 type="number"
                 step="0.01"
-                className="w-full text-sm text-right bg-white dark:bg-gray-700 border border-gray-300 dark:border-gray-600 rounded px-2 py-1 focus:outline-none focus:ring-1 focus:ring-emerald-500"
+                className="w-full text-sm text-right bg-white dark:bg-gray-700 border border-gray-300 dark:border-gray-600 rounded px-2 py-1 focus:outline-none focus:ring-1 focus:ring-blue-500"
                 value={editAmount}
                 aria-label="Edit transaction amount"
                 onChange={(e) => setEditAmount(e.target.value)}
@@ -277,7 +277,7 @@ export const TransactionRow = memo(function TransactionRow({
               // Real button so keyboard and screen-reader users can edit too.
               <button
                 type="button"
-                className={`${amountColorClass} ${compactView ? 'text-sm' : ''} cursor-pointer hover:bg-gray-100 dark:hover:bg-gray-700 rounded px-1 -mx-1 focus:outline-none focus:ring-1 focus:ring-emerald-500 w-full text-right`}
+                className={`${amountColorClass} ${compactView ? 'text-sm' : ''} cursor-pointer hover:bg-gray-100 dark:hover:bg-gray-700 rounded px-1 -mx-1 focus:outline-none focus:ring-1 focus:ring-blue-500 w-full text-right`}
                 onClick={() => {
                   setEditAmount(String(Math.abs(transaction.amount)));
                   setIsEditingAmount(true);

--- a/src/pages/AccountTransactions.tsx
+++ b/src/pages/AccountTransactions.tsx
@@ -602,7 +602,7 @@ export default function AccountTransactions() {
       width: '35px',
       accessor: (transaction) => (
         transaction.cleared ? (
-          <span className="text-green-600 dark:text-green-400">✓</span>
+          <span className="text-blue-600 dark:text-blue-400">✓</span>
         ) : null
       ),
       className: 'text-center',
@@ -856,7 +856,7 @@ export default function AccountTransactions() {
               return (
                 <span className={`text-sm font-bold whitespace-nowrap ${
                   difference === 0
-                    ? 'text-green-600 dark:text-green-400'
+                    ? 'text-blue-600 dark:text-blue-400'
                     : 'text-red-600 dark:text-red-400'
                 }`}>
                   {formatCurrency(difference, account.currency)}
@@ -1154,7 +1154,7 @@ export default function AccountTransactions() {
                 {([
                   { value: 'expense', label: 'Exp', activeColor: 'text-red-600 dark:text-red-400' },
                   { value: 'income', label: 'Inc', activeColor: 'text-green-600 dark:text-green-400' },
-                  { value: 'transfer', label: 'Txfr', activeColor: 'text-emerald-700 dark:text-emerald-400' },
+                  { value: 'transfer', label: 'Txfr', activeColor: 'text-blue-600 dark:text-blue-400' },
                 ] as const).map(({ value, label, activeColor }) => (
                   <button
                     key={value}


### PR DESCRIPTION
## What & why

Transaction-register slice of the green → mid-blue accent sweep (accent **#2563eb**). First of the data-page pass, where money greens must be preserved.

## Changed → blue (neutral chrome)
- **Cleared/reconciled ticks** — `TransactionRow` check-icon, `AccountTransactions` ✓ column, `SwipeableTransactionRow` cleared tick
- **Inline-edit focus rings** (`TransactionRow`)
- **"Reconcile" swipe action** (`SwipeableTransactionRow`)
- **Balanced-difference status** (`AccountTransactions` header — the "difference = 0 → good" cue, matching the reconciliation PR)
- **Transfer** type-filter tab (transfer isn't income)
- **"Load More"** button (`InfiniteScrollTransactionList`)

## Kept green (money / income semantic)
- Trending-up / gain icons, signed amount colours, the **Deposit / "money in"** column, account & bank **balance** figures, income totals + net
- The **income** type-filter/segment active state stays green so the filter matches the green income amounts it selects (**expense** stays red)

`Transactions.tsx` and `CategoryTransactionsModal.tsx` were entirely money-coloured → unchanged.

## Verification
- Targeted edits (money greens must stay) — verified by re-grepping each file: only income/gain/amount/balance greens remain.
- `typecheck:strict` ✅ · `lint` ✅ · `test:unit` ✅ (2881) · `build` ✅.
- Same class-swap pattern already verified live in #76/#77; register live-preview is limited by demo seeding, so this relies on the gates + diff review (as the earlier register PRs did).

🤖 Generated with [Claude Code](https://claude.com/claude-code)