### PR TITLE
style(dashboard): recolour UI-accent greens to mid-blue (#2563eb)

### DIFF
--- a/src/components/FinancialSummary.tsx
+++ b/src/components/FinancialSummary.tsx
@@ -57,7 +57,7 @@ export default function FinancialSummary({ period }: FinancialSummaryProps) {
         </div>
         <button
           onClick={() => setShowDetails(!showDetails)}
-          className="text-sm text-emerald-700 dark:text-emerald-400 hover:text-blue-700 dark:hover:text-blue-300"
+          className="text-sm text-blue-700 dark:text-blue-400 hover:text-blue-800 dark:hover:text-blue-300"
         >
           {showDetails ? 'Hide' : 'Show'} Details
         </button>

--- a/src/components/dashboard/ImprovedDashboard.tsx
+++ b/src/components/dashboard/ImprovedDashboard.tsx
@@ -461,7 +461,7 @@ export function ImprovedDashboard() {
             {metrics.budgetStatus.length > 3 && (
               <button 
                 onClick={() => navigate(preserveDemoParam('/budget', location.search))}
-                className="w-full mt-2 py-2 text-emerald-700 dark:text-emerald-400 text-sm hover:bg-emerald-50 dark:hover:bg-emerald-900/20 rounded-lg transition-colors"
+                className="w-full mt-2 py-2 text-blue-700 dark:text-blue-400 text-sm hover:bg-blue-50 dark:hover:bg-blue-900/20 rounded-lg transition-colors"
               >
                 View All Budgets ({metrics.budgetStatus.length}) →
               </button>
@@ -487,7 +487,7 @@ export function ImprovedDashboard() {
           </h3>
           <button
             onClick={() => setShowAccountSettings(!showAccountSettings)}
-            className="p-2 hover:bg-gray-100 dark:hover:bg-gray-700 rounded-lg transition-colors focus:outline-none focus:ring-2 focus:ring-emerald-600 focus:ring-offset-2"
+            className="p-2 hover:bg-gray-100 dark:hover:bg-gray-700 rounded-lg transition-colors focus:outline-none focus:ring-2 focus:ring-blue-600 focus:ring-offset-2"
             aria-label="Customize displayed accounts"
             aria-expanded={showAccountSettings}
           >
@@ -504,7 +504,7 @@ export function ImprovedDashboard() {
               </p>
               <button
                 onClick={() => setShowAccountSettings(false)}
-                className="p-1 hover:bg-gray-200 dark:hover:bg-gray-600 rounded focus:outline-none focus:ring-2 focus:ring-emerald-600"
+                className="p-1 hover:bg-gray-200 dark:hover:bg-gray-600 rounded focus:outline-none focus:ring-2 focus:ring-blue-600"
                 aria-label="Close account settings"
               >
                 <XIcon size={16} className="text-gray-500" />
@@ -520,7 +520,7 @@ export function ImprovedDashboard() {
                     onClick={() => toggleAccountSelection(account.id)}
                     className={`flex items-center gap-2.5 px-3 py-2 rounded-lg text-left transition-colors ${
                       isSelected
-                        ? 'bg-emerald-50 dark:bg-emerald-900/20 border border-emerald-200 dark:border-emerald-700'
+                        ? 'bg-blue-50 dark:bg-blue-900/20 border border-blue-200 dark:border-blue-700'
                         : 'bg-white dark:bg-gray-600 border border-gray-200 dark:border-gray-500 hover:bg-gray-50 dark:hover:bg-gray-550'
                     }`}
                     aria-pressed={isSelected ? 'true' : 'false'}
@@ -553,7 +553,7 @@ export function ImprovedDashboard() {
             displayedAccounts.map(account => (
               <div 
                 key={account.id}
-                className="flex items-center justify-between p-4 bg-gray-50 dark:bg-gray-700 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-600 transition-colors cursor-pointer focus:outline-none focus:ring-2 focus:ring-emerald-600 focus:ring-offset-2"
+                className="flex items-center justify-between p-4 bg-gray-50 dark:bg-gray-700 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-600 transition-colors cursor-pointer focus:outline-none focus:ring-2 focus:ring-blue-600 focus:ring-offset-2"
                 data-testid="account-balance-card"
                 onClick={() => navigate(preserveDemoParam(`/accounts/${account.id}`, location.search))}
                 role="button"
@@ -765,7 +765,7 @@ export function ImprovedDashboard() {
           {metrics.recentActivity.length > 10 && (
             <button 
               onClick={() => navigate(preserveDemoParam('/transactions', location.search))}
-              className="w-full mt-4 py-2 text-emerald-700 dark:text-emerald-400 hover:bg-emerald-50 dark:hover:bg-emerald-900/20 rounded-lg transition-colors focus:outline-none focus:ring-2 focus:ring-emerald-600 focus:ring-offset-2"
+              className="w-full mt-4 py-2 text-blue-700 dark:text-blue-400 hover:bg-blue-50 dark:hover:bg-blue-900/20 rounded-lg transition-colors focus:outline-none focus:ring-2 focus:ring-blue-600 focus:ring-offset-2"
               aria-label="View all transactions"
             >
               View All Transactions →
@@ -779,7 +779,7 @@ export function ImprovedDashboard() {
       <nav aria-label="Quick actions" className="grid grid-cols-2 sm:grid-cols-4 gap-6">
         <button
           onClick={() => setShowAddTransactionModal(true)}
-          className="p-8 bg-white dark:bg-gray-800 rounded-xl shadow-sm border border-gray-100 dark:border-gray-700 hover:shadow-md transition-all text-center min-h-[140px] flex flex-col items-center justify-center focus:outline-none focus:ring-2 focus:ring-emerald-600 focus:ring-offset-2"
+          className="p-8 bg-white dark:bg-gray-800 rounded-xl shadow-sm border border-gray-100 dark:border-gray-700 hover:shadow-md transition-all text-center min-h-[140px] flex flex-col items-center justify-center focus:outline-none focus:ring-2 focus:ring-blue-600 focus:ring-offset-2"
           aria-label="Add a new transaction"
         >
           <CreditCardIcon size={32} className="mx-auto mb-3 text-[#1a2332] dark:text-gray-300" aria-hidden="true" />
@@ -790,10 +790,10 @@ export function ImprovedDashboard() {
 
         <button
           onClick={() => navigate(preserveDemoParam('/accounts', location.search))}
-          className="p-8 bg-white dark:bg-gray-800 rounded-xl shadow-sm border border-gray-100 dark:border-gray-700 hover:shadow-md transition-all text-center min-h-[140px] flex flex-col items-center justify-center focus:outline-none focus:ring-2 focus:ring-emerald-600 focus:ring-offset-2"
+          className="p-8 bg-white dark:bg-gray-800 rounded-xl shadow-sm border border-gray-100 dark:border-gray-700 hover:shadow-md transition-all text-center min-h-[140px] flex flex-col items-center justify-center focus:outline-none focus:ring-2 focus:ring-blue-600 focus:ring-offset-2"
           aria-label="View all accounts"
         >
-          <WalletIcon size={32} className="mx-auto mb-3 text-emerald-600" aria-hidden="true" />
+          <WalletIcon size={32} className="mx-auto mb-3 text-blue-600" aria-hidden="true" />
           <span className="text-base font-semibold text-gray-900 dark:text-white">
             View Accounts
           </span>
@@ -801,7 +801,7 @@ export function ImprovedDashboard() {
 
         <button
           onClick={() => navigate(preserveDemoParam('/budget', location.search))}
-          className="p-8 bg-white dark:bg-gray-800 rounded-xl shadow-sm border border-gray-100 dark:border-gray-700 hover:shadow-md transition-all text-center min-h-[140px] flex flex-col items-center justify-center focus:outline-none focus:ring-2 focus:ring-emerald-600 focus:ring-offset-2"
+          className="p-8 bg-white dark:bg-gray-800 rounded-xl shadow-sm border border-gray-100 dark:border-gray-700 hover:shadow-md transition-all text-center min-h-[140px] flex flex-col items-center justify-center focus:outline-none focus:ring-2 focus:ring-blue-600 focus:ring-offset-2"
           aria-label="Set up or view budgets"
         >
           <TargetIcon size={32} className="mx-auto mb-3 text-amber-600" aria-hidden="true" />
@@ -812,10 +812,10 @@ export function ImprovedDashboard() {
 
         <button
           onClick={() => navigate(preserveDemoParam('/analytics', location.search))}
-          className="p-8 bg-white dark:bg-gray-800 rounded-xl shadow-sm border border-gray-100 dark:border-gray-700 hover:shadow-md transition-all text-center min-h-[140px] flex flex-col items-center justify-center focus:outline-none focus:ring-2 focus:ring-emerald-600 focus:ring-offset-2"
+          className="p-8 bg-white dark:bg-gray-800 rounded-xl shadow-sm border border-gray-100 dark:border-gray-700 hover:shadow-md transition-all text-center min-h-[140px] flex flex-col items-center justify-center focus:outline-none focus:ring-2 focus:ring-blue-600 focus:ring-offset-2"
           aria-label="View financial analytics"
         >
-          <TrendingUpIcon size={32} className="mx-auto mb-3 text-[#2d4a3e] dark:text-emerald-400" aria-hidden="true" />
+          <TrendingUpIcon size={32} className="mx-auto mb-3 text-blue-600 dark:text-blue-400" aria-hidden="true" />
           <span className="text-base font-semibold text-gray-900 dark:text-white">
             Analytics
           </span>


### PR DESCRIPTION
## What & why

Dashboard slice of the green → mid-blue accent sweep (accent **#2563eb**). Neutral chrome → blue; every money/gain green kept.

## ImprovedDashboard → blue
- Quick-action **focus rings** (×8)
- The two "view all" **expand buttons**
- The **selected** budget-item highlight
- The **View Accounts** (wallet) and **Analytics** quick-action icons

## Kept green (money / gain)
- Net-worth **change %** (up), **Assets** total, the **income card** + its value + trending-up icon, income/expense **breakdown**, **account balance** sign, **transaction amounts**
- The **budget-usage health bar** (green = healthy < 60%) — kept because that bar already uses **blue** for the 60–80% band, so recolouring would collide (same collision rule as Toast/OfflineStatus)

## FinancialSummary
- → blue: the **"Show/Hide details"** toggle
- Kept green: the **Income** metric card (paired with the red Expenses card) and its change/amount figures

`CashFlowForecast` was entirely money-coloured → unchanged.

## Verification
- Only income/gain greens remain (re-grepped); no emerald/teal left.
- Live (demo dashboard): the two changed action icons compute to `rgb(37,99,235)` = **#2563eb**, and 7 money greens persist.
- `typecheck:strict` ✅ · `lint` ✅ · `test:unit` ✅ (2881) · `build` ✅.

Independent of #79 (disjoint files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)