### PR TITLE
style(controls): sharp, app-blue checkboxes & radios (not OS-accent green)

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -80,6 +80,28 @@
   }
 }
 
+/* Checkbox / radio controls (app-wide).
+   - accent-color pins them to the app blue (#2563eb) so they never inherit the
+     viewer's OS accent colour (a green macOS accent was making every box green).
+   - On desktop (pointer: fine) they're a crisp, professional size rather than the
+     chunky finger-target look; touch devices keep the larger target from the
+     media query above. This is a PC/Mac-first professional app. */
+input[type="checkbox"],
+input[type="radio"] {
+  accent-color: #2563eb;
+}
+
+@media (hover: hover) and (pointer: fine) {
+  input[type="checkbox"],
+  input[type="radio"] {
+    width: 16px;
+    height: 16px;
+    min-width: 16px;
+    min-height: 16px;
+    margin: 0;
+  }
+}
+
 /* WealthTracker Brand Colors */
 :root {
   --color-primary: #1a2332;


### PR DESCRIPTION
## What & why

You spotted the selection boxes were still **green** and looked **big / finger-friendly**. Root cause: native checkboxes/radios used `accent-color: auto`, so they inherited the **viewer's OS accent colour** (your macOS accent is green → every box rendered green), and a global rule sized them to a chunky **44px** on desktop.

This pins them to the app accent and a crisp, professional size — this is a PC/Mac-first professional app:
- **`accent-color: #2563eb`** app-wide → always the theme blue, regardless of the user's OS accent.
- **16px on desktop** (`hover: hover` + `pointer: fine`); touch devices keep the larger tap target from the existing touch media query.

Global CSS only — **no markup changes**, so it fixes every checkbox/radio in one place (View menu, Reconciled, selection boxes, settings, etc.).

## Safety
- Toggle switches are `<button role="switch">` / div-based, **not** native inputs — unaffected by an `input[type=…]` rule.
- Verified **no** native checkbox uses a custom width/appearance that `width:16px` could squash (grep).

## Verification
- Live: 15 real **App Settings** checkboxes compute to **16px** / `rgb(37,99,235)` = #2563eb (was 44px / OS-green).
- `typecheck:strict` ✅ · `lint` ✅ · `test:unit` ✅ (2881) · `build` ✅.

🤖 Generated with [Claude Code](https://claude.com/claude-code)