### PR TITLE
style(data-pages): finish green→blue UI-accent sweep (#2563eb)

### DIFF
--- a/src/components/ActivityBadge.tsx
+++ b/src/components/ActivityBadge.tsx
@@ -120,7 +120,7 @@ export function InlineBadge({
   if (count === 0) return null;
 
   return (
-    <span className={`text-xs font-medium text-emerald-700 dark:text-emerald-400 ${className}`}>
+    <span className={`text-xs font-medium text-blue-700 dark:text-blue-400 ${className}`}>
       {prefix}{count}
     </span>
   );

--- a/src/components/AdvancedAnalytics.tsx
+++ b/src/components/AdvancedAnalytics.tsx
@@ -66,7 +66,7 @@ export default function AdvancedAnalytics() {
       case 'medium':
         return 'text-yellow-600 dark:text-yellow-400 bg-yellow-50 dark:bg-yellow-900/20';
       case 'low':
-        return 'text-emerald-700 dark:text-emerald-400 bg-blue-50 dark:bg-blue-900/20';
+        return 'text-blue-700 dark:text-blue-400 bg-blue-50 dark:bg-blue-900/20';
     }
   };
 
@@ -88,7 +88,7 @@ export default function AdvancedAnalytics() {
       case 'negative':
         return <AlertCircleIcon size={20} className="text-red-600 dark:text-red-400" />;
       case 'neutral':
-        return <InfoIcon size={20} className="text-emerald-700 dark:text-emerald-400" />;
+        return <InfoIcon size={20} className="text-blue-700 dark:text-blue-400" />;
     }
   };
 
@@ -111,7 +111,7 @@ export default function AdvancedAnalytics() {
             </p>
           </div>
           <div className="flex items-center gap-2">
-            <div className={`w-3 h-3 rounded-full ${isAnalyzing ? 'bg-yellow-400 animate-pulse' : 'bg-green-400'}`} />
+            <div className={`w-3 h-3 rounded-full ${isAnalyzing ? 'bg-yellow-400 animate-pulse' : 'bg-blue-500'}`} />
             <span className="text-sm">
               {isAnalyzing ? 'Analyzing...' : 'Up to date'}
             </span>
@@ -166,7 +166,7 @@ export default function AdvancedAnalytics() {
                         {insight.description}
                       </p>
                       {insight.actionable && (
-                        <button className="mt-2 text-sm text-emerald-700 dark:text-emerald-400 hover:underline">
+                        <button className="mt-2 text-sm text-blue-700 dark:text-blue-400 hover:underline">
                           Take action →
                         </button>
                       )}
@@ -310,7 +310,7 @@ export default function AdvancedAnalytics() {
                       </div>
                     </div>
                     {prediction.recommendation && (
-                      <p className="mt-3 text-sm text-emerald-700 dark:text-emerald-400">
+                      <p className="mt-3 text-sm text-blue-700 dark:text-blue-400">
                         💡 {prediction.recommendation}
                       </p>
                     )}
@@ -331,8 +331,8 @@ export default function AdvancedAnalytics() {
           <div className="space-y-4">
             {opportunities.length > 0 ? (
               <>
-                <div className="bg-green-50 dark:bg-green-900/20 rounded-lg p-4 mb-4">
-                  <p className="text-sm text-green-800 dark:text-green-200">
+                <div className="bg-blue-50 dark:bg-blue-900/20 rounded-lg p-4 mb-4">
+                  <p className="text-sm text-blue-800 dark:text-blue-200">
                     <strong>Total Potential Savings:</strong> {formatCurrency(
                       opportunities.reduce((sum, opp) => sum.plus(opp.potentialSavings), toDecimal(0))
                     )} per year

--- a/src/components/BillNegotiator.tsx
+++ b/src/components/BillNegotiator.tsx
@@ -65,16 +65,16 @@ export default function BillNegotiator() {
   return (
     <div className="space-y-6">
       {/* Summary Card */}
-      <div className="bg-gradient-to-r from-green-500 to-emerald-600 rounded-2xl p-6 text-white">
+      <div className="bg-gradient-to-r from-blue-600 to-blue-700 rounded-2xl p-6 text-white">
         <div className="flex items-center justify-between">
           <div>
             <h3 className="text-xl font-bold mb-2">Bill Negotiation Assistant</h3>
-            <p className="text-green-100">
+            <p className="text-blue-100">
               AI-powered suggestions to reduce your recurring bills
             </p>
           </div>
           <div className="text-right">
-            <p className="text-sm text-green-100">Potential Annual Savings</p>
+            <p className="text-sm text-blue-100">Potential Annual Savings</p>
             <p className="text-3xl font-bold">{formatCurrency(totalPotentialSavings.times(12))}</p>
           </div>
         </div>
@@ -91,7 +91,7 @@ export default function BillNegotiator() {
                 key={suggestion.merchant}
                 className={`bg-white dark:bg-gray-800 rounded-xl p-6 border ${
                   isCompleted 
-                    ? 'border-green-200 dark:border-green-800 opacity-75' 
+                    ? 'border-blue-200 dark:border-blue-800 opacity-75'
                     : 'border-gray-200 dark:border-gray-700'
                 }`}
               >
@@ -102,7 +102,7 @@ export default function BillNegotiator() {
                         {suggestion.merchant}
                       </h4>
                       {isCompleted && (
-                        <span className="flex items-center gap-1 text-green-600 dark:text-green-400 text-sm">
+                        <span className="flex items-center gap-1 text-blue-600 dark:text-blue-400 text-sm">
                           <CheckIcon size={16} />
                           Negotiated
                         </span>
@@ -214,7 +214,7 @@ export default function BillNegotiator() {
               <ul className="space-y-2">
                 {selectedBill.negotiationTips.map((tip, index) => (
                   <li key={index} className="flex items-start gap-2">
-                    <CheckIcon size={16} className="text-green-600 dark:text-green-400 mt-0.5 flex-shrink-0" />
+                    <CheckIcon size={16} className="text-blue-600 dark:text-blue-400 mt-0.5 flex-shrink-0" />
                     <span className="text-sm text-gray-700 dark:text-gray-300">{tip}</span>
                   </li>
                 ))}
@@ -249,7 +249,7 @@ export default function BillNegotiator() {
                   setShowTipsModal(false);
                   setSelectedBill(null);
                 }}
-                className="flex-1 px-4 py-2 bg-green-600 text-white rounded-lg hover:bg-green-700 transition-colors"
+                className="flex-1 px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors"
               >
                 Mark as Negotiated
               </button>

--- a/src/components/BudgetRecommendations.tsx
+++ b/src/components/BudgetRecommendations.tsx
@@ -295,9 +295,9 @@ export default function BudgetRecommendations() {
               <div className="flex items-start gap-3">
                 <div className="mt-0.5">
                   {insight.type === 'achievement' ? (
-                    <CheckIcon size={20} className="text-green-600 dark:text-green-400" />
+                    <CheckIcon size={20} className="text-blue-600 dark:text-blue-400" />
                   ) : insight.type === 'opportunity' ? (
-                    <PiggyBankIcon size={20} className="text-emerald-700 dark:text-emerald-400" />
+                    <PiggyBankIcon size={20} className="text-blue-700 dark:text-blue-400" />
                   ) : (
                     <AlertTriangleIcon size={20} className="text-yellow-600 dark:text-yellow-400" />
                   )}
@@ -427,7 +427,7 @@ export default function BudgetRecommendations() {
 
       {analysis.recommendations.length === 0 && (
         <div className="bg-white dark:bg-gray-800 rounded-xl shadow p-8 text-center">
-          <CheckIcon className="mx-auto text-green-500 mb-3" size={48} />
+          <CheckIcon className="mx-auto text-blue-600 mb-3" size={48} />
           <h3 className="text-lg font-semibold mb-2">No Recommendations Available</h3>
           <p className="text-gray-600 dark:text-gray-400">
             Your budgets are well-aligned with your spending patterns!

--- a/src/components/BudgetRollover.tsx
+++ b/src/components/BudgetRollover.tsx
@@ -231,7 +231,7 @@ export default function BudgetRollover() {
         {/* Status */}
         <div className="flex items-center gap-4">
           <div className="flex items-center gap-2">
-            <div className={`w-2 h-2 rounded-full ${rolloverSettings.enabled ? 'bg-green-500' : 'bg-gray-400'}`} />
+            <div className={`w-2 h-2 rounded-full ${rolloverSettings.enabled ? 'bg-blue-600' : 'bg-gray-400'}`} />
             <span className="text-sm text-gray-700 dark:text-gray-300">
               Rollover {rolloverSettings.enabled ? 'Enabled' : 'Disabled'}
             </span>
@@ -239,7 +239,7 @@ export default function BudgetRollover() {
           {rolloverSettings.autoApply && (
             <div className="flex items-center gap-2">
               <RepeatIcon size={14} className="text-blue-500" />
-              <span className="text-sm text-emerald-700 dark:text-emerald-400">Auto-apply</span>
+              <span className="text-sm text-blue-700 dark:text-blue-400">Auto-apply</span>
             </div>
           )}
         </div>
@@ -297,7 +297,7 @@ export default function BudgetRollover() {
                 <div className="flex items-center justify-between mb-3">
                   <h4 className="font-medium text-gray-900 dark:text-white">{data.categoryName}</h4>
                   {data.willRollover && (
-                    <CheckCircleIcon size={16} className="text-green-500" />
+                    <CheckCircleIcon size={16} className="text-blue-600" />
                   )}
                 </div>
                 
@@ -323,7 +323,7 @@ export default function BudgetRollover() {
                   {data.willRollover && (
                     <div className="flex justify-between pt-2 border-t border-gray-200 dark:border-gray-700">
                       <span className="text-gray-600 dark:text-gray-400">Will Rollover:</span>
-                      <span className="font-medium text-emerald-700 dark:text-emerald-400">
+                      <span className="font-medium text-green-600 dark:text-green-400">
                         {formatCurrency(data.rolloverAmount)}
                       </span>
                     </div>

--- a/src/components/BulkEditPanel.tsx
+++ b/src/components/BulkEditPanel.tsx
@@ -183,7 +183,7 @@ export default function BulkEditPanel({
           <div className="space-y-3">
             <button
               onClick={() => setShowPreview(!showPreview)}
-              className="flex items-center gap-2 text-sm text-emerald-700 dark:text-emerald-400 hover:text-emerald-800"
+              className="flex items-center gap-2 text-sm text-blue-700 dark:text-blue-400 hover:text-blue-800"
             >
               <EyeIcon size={16} />
               {showPreview ? 'Hide' : 'Show'} preview of changes

--- a/src/components/DataValidation.tsx
+++ b/src/components/DataValidation.tsx
@@ -706,12 +706,12 @@ export default function DataValidation({ isOpen, onClose }: DataValidationProps)
         </div>
 
         {validationIssues.length === 0 ? (
-          <div className="bg-green-50 dark:bg-green-900/20 rounded-lg p-8 text-center">
-            <CheckCircleIcon className="mx-auto text-green-600 dark:text-green-400 mb-3" size={48} />
-            <h4 className="text-lg font-medium text-green-900 dark:text-green-300">
+          <div className="bg-blue-50 dark:bg-blue-900/20 rounded-lg p-8 text-center">
+            <CheckCircleIcon className="mx-auto text-blue-600 dark:text-blue-400 mb-3" size={48} />
+            <h4 className="text-lg font-medium text-blue-900 dark:text-blue-300">
               All data looks good!
             </h4>
-            <p className="text-sm text-green-800 dark:text-green-200 mt-1">
+            <p className="text-sm text-blue-800 dark:text-blue-200 mt-1">
               No validation issues found in your financial data.
             </p>
           </div>
@@ -807,8 +807,8 @@ export default function DataValidation({ isOpen, onClose }: DataValidationProps)
                                     issueType
                                   });
                                 }}
-                                className="flex items-center gap-1 px-2 py-1 text-xs text-emerald-700 dark:text-emerald-400
-                                         hover:bg-emerald-50 dark:hover:bg-emerald-900/20 rounded"
+                                className="flex items-center gap-1 px-2 py-1 text-xs text-blue-700 dark:text-blue-400
+                                         hover:bg-blue-50 dark:hover:bg-blue-900/20 rounded"
                               >
                                 <EyeIcon size={14} />
                                 View Details

--- a/src/components/EditTransactionModal.tsx
+++ b/src/components/EditTransactionModal.tsx
@@ -428,7 +428,7 @@ export default function EditTransactionModal({ isOpen, onClose, transaction, def
                   const colors = {
                     income: isActive ? 'bg-white dark:bg-gray-600 text-green-600 dark:text-green-400 shadow-sm' : 'text-gray-500 dark:text-gray-400 hover:text-green-600',
                     expense: isActive ? 'bg-white dark:bg-gray-600 text-red-600 dark:text-red-400 shadow-sm' : 'text-gray-500 dark:text-gray-400 hover:text-red-600',
-                    transfer: isActive ? 'bg-white dark:bg-gray-600 text-emerald-700 dark:text-emerald-400 shadow-sm' : 'text-gray-500 dark:text-gray-400 hover:text-blue-600',
+                    transfer: isActive ? 'bg-white dark:bg-gray-600 text-blue-600 dark:text-blue-400 shadow-sm' : 'text-gray-500 dark:text-gray-400 hover:text-blue-600',
                   };
                   return (
                     <button
@@ -626,7 +626,7 @@ export default function EditTransactionModal({ isOpen, onClose, transaction, def
                   onChange={(e) => updateField('cleared', e.target.checked)}
                   className="rounded border-gray-300 dark:border-gray-600"
                 />
-                <CheckIcon2 size={16} className="text-green-600 dark:text-green-400" />
+                <CheckIcon2 size={16} className="text-blue-600 dark:text-blue-400" />
                 <span className="text-sm text-gray-700 dark:text-gray-300">
                   Reconciled
                 </span>
@@ -639,14 +639,14 @@ export default function EditTransactionModal({ isOpen, onClose, transaction, def
                   disabled
                   className="rounded border-gray-300 dark:border-gray-600 disabled:opacity-50 disabled:cursor-not-allowed"
                 />
-                <LinkIcon size={16} className="text-emerald-700 dark:text-emerald-400" />
+                <LinkIcon size={16} className="text-blue-700 dark:text-blue-400" />
                 <span className="text-sm text-gray-700 dark:text-gray-300">
                   Linked to bank statement
                 </span>
               </label>
 
               {transaction?.reconciledWith && transaction.reconciledWith !== 'manual' && (
-                <div className="flex items-center gap-2 text-sm text-emerald-700 dark:text-emerald-400">
+                <div className="flex items-center gap-2 text-sm text-blue-700 dark:text-blue-400">
                   <LinkIcon size={16} />
                   <span>Reconciled with transaction ID: {transaction.reconciledWith}</span>
                 </div>

--- a/src/components/LazyErrorBoundary.tsx
+++ b/src/components/LazyErrorBoundary.tsx
@@ -66,7 +66,7 @@ export class LazyErrorBoundary extends Component<Props, State> {
           </p>
           <button
             onClick={this.handleRetry}
-            className="flex items-center gap-2 px-4 py-2 bg-[#1a2332] text-white rounded-lg hover:bg-[#2d3a4d] transition-colors focus:outline-none focus:ring-2 focus:ring-emerald-600 focus:ring-offset-2"
+            className="flex items-center gap-2 px-4 py-2 bg-[#1a2332] text-white rounded-lg hover:bg-[#2d3a4d] transition-colors focus:outline-none focus:ring-2 focus:ring-blue-600 focus:ring-offset-2"
             aria-label="Retry loading component"
           >
             <RefreshCwIcon className="w-4 h-4" aria-hidden="true" />

--- a/src/components/MarkdownEditor.tsx
+++ b/src/components/MarkdownEditor.tsx
@@ -49,7 +49,7 @@ export default function MarkdownEditor({
       .replace(/`([^`]+)`/gim, '<code class="bg-gray-100 dark:bg-gray-800 px-1 py-0.5 rounded text-sm">$1</code>')
       
       // Links
-      .replace(/\[([^\]]+)\]\(([^)]+)\)/gim, '<a href="$2" target="_blank" rel="noopener noreferrer" class="text-emerald-700 dark:text-emerald-400 hover:underline">$1</a>')
+      .replace(/\[([^\]]+)\]\(([^)]+)\)/gim, '<a href="$2" target="_blank" rel="noopener noreferrer" class="text-blue-700 dark:text-blue-400 hover:underline">$1</a>')
       
       // Lists
       .replace(/^\* (.+)$/gim, '<li class="ml-4">• $1</li>')

--- a/src/components/MarkdownNote.tsx
+++ b/src/components/MarkdownNote.tsx
@@ -24,7 +24,7 @@ const parseMarkdown = (text: string): string => {
     .replace(/`([^`]+)`/gim, '<code class="bg-gray-100 dark:bg-gray-700 px-1 py-0.5 rounded text-sm font-mono">$1</code>')
     
     // Links
-    .replace(/\[([^\]]+)\]\(([^)]+)\)/gim, '<a href="$2" target="_blank" rel="noopener noreferrer" class="text-emerald-700 dark:text-emerald-400 hover:underline">$1</a>')
+    .replace(/\[([^\]]+)\]\(([^)]+)\)/gim, '<a href="$2" target="_blank" rel="noopener noreferrer" class="text-blue-700 dark:text-blue-400 hover:underline">$1</a>')
     
     // Lists
     .replace(/^[*-] (.+)$/gim, '<li class="ml-4 mb-1">• $1</li>')

--- a/src/components/MnyMappingModal.tsx
+++ b/src/components/MnyMappingModal.tsx
@@ -143,7 +143,7 @@ export default function MnyMappingModal({ isOpen, onClose, rawData, onMappingCom
         <div className="mb-4">
           <div className="bg-blue-50 dark:bg-blue-900/20 border border-blue-200 dark:border-blue-800 rounded-lg p-4">
             <div className="flex items-start gap-2">
-              <AlertCircleIcon className="text-emerald-700 dark:text-emerald-400 mt-0.5" size={20} />
+              <AlertCircleIcon className="text-blue-700 dark:text-blue-400 mt-0.5" size={20} />
               <div className="text-sm text-blue-800 dark:text-blue-200">
                 <p className="font-semibold mb-1">Help us understand your data</p>
                 <p>We've extracted data from your Money file. Please tell us what each column represents by selecting from the dropdown menus.</p>

--- a/src/components/QuickDateFilters.tsx
+++ b/src/components/QuickDateFilters.tsx
@@ -145,7 +145,7 @@ export default function QuickDateFilters({ onDateRangeSelect, currentFrom, curre
             {(currentFrom || currentTo) && (
               <button
                 onClick={() => onDateRangeSelect('', '')}
-                className="text-xs text-emerald-700 dark:text-emerald-400 hover:text-blue-700 dark:hover:text-blue-300"
+                className="text-xs text-blue-700 dark:text-blue-400 hover:text-blue-700 dark:hover:text-blue-300"
                 aria-label="Clear date filter"
               >
                 Clear

--- a/src/components/RecurringBudgetTemplates.tsx
+++ b/src/components/RecurringBudgetTemplates.tsx
@@ -334,7 +334,7 @@ export default function RecurringBudgetTemplates() {
             <div className="flex gap-2">
               <button
                 onClick={() => applyTemplate(template)}
-                className="flex-1 flex items-center justify-center gap-2 px-3 py-2 bg-green-600 text-white rounded-lg hover:bg-green-700 text-sm"
+                className="flex-1 flex items-center justify-center gap-2 px-3 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 text-sm"
               >
                 <PlayIcon size={14} />
                 Apply

--- a/src/components/SharedBudgetsGoals.tsx
+++ b/src/components/SharedBudgetsGoals.tsx
@@ -301,7 +301,7 @@ export default function SharedBudgetsGoals() {
                   <div className="flex gap-2">
                     <button
                       onClick={() => handleReviewApproval(approval.id, true)}
-                      className="p-2 bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-400 rounded hover:bg-green-200"
+                      className="p-2 bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-400 rounded hover:bg-blue-200"
                     >
                       <CheckIcon size={16} />
                     </button>
@@ -489,7 +489,7 @@ export default function SharedBudgetsGoals() {
                   <div className="bg-gray-200 dark:bg-gray-700 rounded-full h-3 overflow-hidden">
                     <div 
                       className={`h-full transition-all duration-300 ${
-                        goal.completedAt ? 'bg-green-500' : 'bg-purple-500'
+                        goal.completedAt ? 'bg-blue-600' : 'bg-purple-500'
                       }`}
                       style={{ width: `${Math.min(percentageDecimal.toNumber(), 100)}%` }}
                     />
@@ -548,8 +548,8 @@ export default function SharedBudgetsGoals() {
                 )}
 
                 {goal.completedAt && (
-                  <div className="mt-4 p-3 bg-green-50 dark:bg-green-900/20 rounded-lg">
-                    <p className="text-sm text-green-800 dark:text-green-200 font-medium">
+                  <div className="mt-4 p-3 bg-blue-50 dark:bg-blue-900/20 rounded-lg">
+                    <p className="text-sm text-blue-800 dark:text-blue-200 font-medium">
                       <CheckIcon size={16} className="inline mr-1" />
                       Goal achieved on {format(goal.completedAt!, 'MMM d, yyyy')}!
                     </p>

--- a/src/components/SpendingPatterns.tsx
+++ b/src/components/SpendingPatterns.tsx
@@ -66,7 +66,7 @@ export default function SpendingPatterns({ onDataChange }: SpendingPatternsProps
   const getPatternTypeIcon = (type: SpendingPattern['patternType']) => {
     switch (type) {
       case 'recurring':
-        return <CalendarIcon size={16} className="text-emerald-700 dark:text-emerald-400" />;
+        return <CalendarIcon size={16} className="text-blue-700 dark:text-blue-400" />;
       case 'seasonal':
         return <ClockIcon size={16} className="text-purple-600 dark:text-purple-400" />;
       case 'trend':
@@ -170,7 +170,7 @@ export default function SpendingPatterns({ onDataChange }: SpendingPatternsProps
           <div className="flex items-center justify-between">
             <div>
               <p className="text-sm text-gray-600 dark:text-gray-400">Total Patterns</p>
-              <p className="text-2xl font-bold text-emerald-700 dark:text-emerald-400">
+              <p className="text-2xl font-bold text-blue-700 dark:text-blue-400">
                 {patterns.filter(p => p.isActive).length}
               </p>
             </div>
@@ -182,11 +182,11 @@ export default function SpendingPatterns({ onDataChange }: SpendingPatternsProps
           <div className="flex items-center justify-between">
             <div>
               <p className="text-sm text-gray-600 dark:text-gray-400">Recurring</p>
-              <p className="text-2xl font-bold text-green-600 dark:text-green-400">
+              <p className="text-2xl font-bold text-blue-600 dark:text-blue-400">
                 {patterns.filter(p => p.patternType === 'recurring' && p.isActive).length}
               </p>
             </div>
-            <CalendarIcon size={24} className="text-green-500" />
+            <CalendarIcon size={24} className="text-blue-600" />
           </div>
         </div>
 
@@ -382,7 +382,7 @@ export default function SpendingPatterns({ onDataChange }: SpendingPatternsProps
                       </div>
                     </td>
                     <td className="px-6 py-4 whitespace-nowrap text-right text-sm font-medium">
-                      <button className="text-emerald-700 dark:text-emerald-400 hover:text-blue-900 dark:hover:text-blue-300">
+                      <button className="text-blue-700 dark:text-blue-400 hover:text-blue-900 dark:hover:text-blue-300">
                         <EyeIcon size={16} />
                       </button>
                     </td>

--- a/src/components/TaxPlanning.tsx
+++ b/src/components/TaxPlanning.tsx
@@ -87,11 +87,11 @@ export default function TaxPlanning(): React.JSX.Element {
   return (
     <div className="space-y-6">
       {/* Header */}
-      <div className="bg-gradient-to-r from-green-600 to-emerald-600 rounded-2xl p-6 text-white">
+      <div className="bg-gradient-to-r from-blue-600 to-blue-700 rounded-2xl p-6 text-white">
         <div className="flex items-center justify-between">
           <div>
             <h2 className="text-2xl font-bold mb-2">Tax Planning Center</h2>
-            <p className="text-green-100">
+            <p className="text-blue-100">
               Track deductions, estimate taxes, and optimize your tax strategy
             </p>
           </div>
@@ -109,7 +109,7 @@ export default function TaxPlanning(): React.JSX.Element {
             </select>
             <button
               onClick={generateReport}
-              className="flex items-center gap-2 px-4 py-2 bg-white text-green-600 rounded-lg hover:bg-green-50 transition-colors"
+              className="flex items-center gap-2 px-4 py-2 bg-white text-blue-600 rounded-lg hover:bg-blue-50 transition-colors"
             >
               <DownloadIcon size={16} />
               Export Report
@@ -124,7 +124,7 @@ export default function TaxPlanning(): React.JSX.Element {
           <div className="bg-white dark:bg-gray-800 rounded-xl p-6 shadow">
             <div className="flex items-center justify-between mb-2">
               <span className="text-sm text-gray-600 dark:text-gray-400">Total Income</span>
-              <DollarSignIcon size={20} className="text-green-600 dark:text-green-400" />
+              <DollarSignIcon size={20} className="text-blue-600 dark:text-blue-400" />
             </div>
             <p className="text-2xl font-bold text-gray-900 dark:text-white">
               {formatCurrency(taxEstimate.income)}
@@ -134,7 +134,7 @@ export default function TaxPlanning(): React.JSX.Element {
           <div className="bg-white dark:bg-gray-800 rounded-xl p-6 shadow">
             <div className="flex items-center justify-between mb-2">
               <span className="text-sm text-gray-600 dark:text-gray-400">Total Deductions</span>
-              <FileTextIcon size={20} className="text-emerald-700 dark:text-emerald-400" />
+              <FileTextIcon size={20} className="text-blue-700 dark:text-blue-400" />
             </div>
             <p className="text-2xl font-bold text-gray-900 dark:text-white">
               {formatCurrency(taxEstimate.deductions)}
@@ -261,7 +261,7 @@ export default function TaxPlanning(): React.JSX.Element {
                         </div>
                         <div className="w-full bg-gray-200 dark:bg-gray-700 rounded-full h-3">
                           <div
-                            className="bg-green-600 h-3 rounded-full"
+                            className="bg-blue-600 h-3 rounded-full"
                             style={{ width: `${Math.min(taxEstimate.effectiveRate, 100)}%` }}
                           />
                         </div>
@@ -386,7 +386,7 @@ export default function TaxPlanning(): React.JSX.Element {
                       </div>
                       <div className="bg-blue-50 dark:bg-blue-900/20 rounded-lg p-4">
                         <p className="text-sm text-gray-600 dark:text-gray-400">Est. Tax Impact</p>
-                        <p className="text-xl font-bold text-emerald-700 dark:text-emerald-400">
+                        <p className="text-xl font-bold text-green-600 dark:text-green-400">
                           {formatCurrency(
                             capitalGains.reduce((sum, g) => sum.plus(g.estimatedTax), toDecimal(0))
                           )}
@@ -461,13 +461,13 @@ export default function TaxPlanning(): React.JSX.Element {
                         <div className={`p-3 rounded-lg ${
                           optimization.category === 'retirement' ? 'bg-purple-100 dark:bg-purple-900/30' :
                           optimization.category === 'investment' ? 'bg-blue-100 dark:bg-blue-900/30' :
-                          optimization.category === 'charitable' ? 'bg-green-100 dark:bg-green-900/30' :
+                          optimization.category === 'charitable' ? 'bg-blue-100 dark:bg-blue-900/30' :
                           'bg-gray-100 dark:bg-gray-700'
                         }`}>
                           <PiggyBankIcon size={24} className={
                             optimization.category === 'retirement' ? 'text-purple-600 dark:text-purple-400' :
-                            optimization.category === 'investment' ? 'text-emerald-700 dark:text-emerald-400' :
-                            optimization.category === 'charitable' ? 'text-green-600 dark:text-green-400' :
+                            optimization.category === 'investment' ? 'text-blue-700 dark:text-blue-400' :
+                            optimization.category === 'charitable' ? 'text-blue-600 dark:text-blue-400' :
                             'text-gray-600 dark:text-gray-400'
                           } />
                         </div>

--- a/src/components/TransactionDetailsView.tsx
+++ b/src/components/TransactionDetailsView.tsx
@@ -147,7 +147,7 @@ export default function TransactionDetailsView({
               <div className="flex items-center gap-3">
                 {transaction.cleared ? (
                   <>
-                    <CheckIcon2 size={20} className="text-green-600 dark:text-green-400" />
+                    <CheckIcon2 size={20} className="text-blue-600 dark:text-blue-400" />
                     <span className="text-sm text-gray-700 dark:text-gray-300">
                       Transaction reconciled
                     </span>
@@ -164,7 +164,7 @@ export default function TransactionDetailsView({
 
               {transaction.reconciledWith && transaction.reconciledWith !== 'manual' && (
                 <div className="flex items-center gap-3">
-                  <LinkIcon size={20} className="text-emerald-700 dark:text-emerald-400" />
+                  <LinkIcon size={20} className="text-blue-700 dark:text-blue-400" />
                   <span className="text-sm text-gray-700 dark:text-gray-300">
                     Linked to bank statement (ID: {transaction.reconciledWith})
                   </span>

--- a/src/components/ValidationTransactionModal.tsx
+++ b/src/components/ValidationTransactionModal.tsx
@@ -219,7 +219,7 @@ export default function ValidationTransactionModal({
                           </div>
                         )}
                         {issueType === 'large-transactions' && (
-                          <div className="text-sm text-emerald-700 dark:text-emerald-400 mt-2">
+                          <div className="text-sm text-blue-700 dark:text-blue-400 mt-2">
                             ℹ️ Unusually large transaction (&gt;10x average)
                           </div>
                         )}
@@ -232,7 +232,7 @@ export default function ValidationTransactionModal({
                       <>
                         <button
                           onClick={() => handleSave(transaction.id)}
-                          className="p-2 text-green-600 hover:bg-green-50 dark:hover:bg-green-900/20 rounded-lg"
+                          className="p-2 text-blue-600 hover:bg-blue-50 dark:hover:bg-blue-900/20 rounded-lg"
                           title="Save changes"
                         >
                           <CheckIcon size={20} />
@@ -249,7 +249,7 @@ export default function ValidationTransactionModal({
                       <>
                         <button
                           onClick={() => handleEdit(transaction)}
-                          className="p-2 text-blue-600 hover:bg-emerald-50 dark:hover:bg-emerald-900/20 rounded-lg"
+                          className="p-2 text-blue-600 hover:bg-blue-50 dark:hover:bg-blue-900/20 rounded-lg"
                           title="Edit transaction"
                         >
                           <EditIcon size={20} />

--- a/src/components/ZeroBasedBudgeting.tsx
+++ b/src/components/ZeroBasedBudgeting.tsx
@@ -331,7 +331,7 @@ export default function ZeroBasedBudgeting(): React.JSX.Element {
                   <p className="text-2xl font-bold">{formatCurrency(totals.approved)}</p>
                   <p className="text-xs text-gray-500">{approvedPercentage}%</p>
                 </div>
-                <CheckCircleIcon size={32} className="text-green-600" />
+                <CheckCircleIcon size={32} className="text-blue-600" />
               </div>
             </div>
             
@@ -380,7 +380,7 @@ export default function ZeroBasedBudgeting(): React.JSX.Element {
             
             <button
               onClick={() => setShowItemModal(true)}
-              className="flex items-center gap-2 px-4 py-2 bg-green-600 text-white rounded-lg hover:bg-green-700"
+              className="flex items-center gap-2 px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700"
             >
               <PlusIcon size={20} />
               Add Budget Item
@@ -402,7 +402,7 @@ export default function ZeroBasedBudgeting(): React.JSX.Element {
                     key={item.id}
                     className={`flex items-center justify-between p-4 rounded-lg border ${
                       item.isApproved 
-                        ? 'bg-green-50 dark:bg-green-900/20 border-green-300 dark:border-green-700' 
+                        ? 'bg-blue-50 dark:bg-blue-900/20 border-blue-300 dark:border-blue-700'
                         : 'bg-gray-50 dark:bg-gray-700/50 border-gray-300 dark:border-gray-600'
                     }`}
                   >
@@ -472,7 +472,7 @@ export default function ZeroBasedBudgeting(): React.JSX.Element {
           {/* Tips */}
           <div className="bg-blue-50 dark:bg-blue-900/20 rounded-lg p-6">
             <div className="flex items-start gap-3">
-              <InfoIcon size={24} className="text-emerald-700 dark:text-emerald-400 mt-0.5" />
+              <InfoIcon size={24} className="text-blue-700 dark:text-blue-400 mt-0.5" />
               <div>
                 <h3 className="font-semibold text-blue-900 dark:text-blue-100 mb-2">
                   Zero-Based Budgeting Tips

--- a/src/components/common/AccessibleModal.tsx
+++ b/src/components/common/AccessibleModal.tsx
@@ -168,7 +168,7 @@ export const AccessibleModal: React.FC<AccessibleModalProps> = ({
               <button
                 ref={closeButtonRef}
                 onClick={onClose}
-                className="p-2 hover:bg-gray-100 dark:hover:bg-gray-700 rounded-lg transition-colors focus:outline-none focus:ring-2 focus:ring-emerald-600"
+                className="p-2 hover:bg-gray-100 dark:hover:bg-gray-700 rounded-lg transition-colors focus:outline-none focus:ring-2 focus:ring-blue-600"
                 aria-label="Close dialog"
               >
                 <XIcon className="h-5 w-5" />

--- a/src/components/common/ExternalLink.tsx
+++ b/src/components/common/ExternalLink.tsx
@@ -18,7 +18,7 @@ interface ExternalLinkProps {
 export function ExternalLink({ 
   href, 
   children, 
-  className = 'text-emerald-700 dark:text-emerald-400 hover:underline',
+  className = 'text-blue-700 dark:text-blue-400 hover:underline',
   showIcon = true 
 }: ExternalLinkProps): React.JSX.Element {
   return (

--- a/src/components/subscription/BillingDashboard.tsx
+++ b/src/components/subscription/BillingDashboard.tsx
@@ -109,7 +109,7 @@ export default function BillingDashboard({
 
   const getStatusBadge = (status: string) => {
     const statusConfig = {
-      active: { color: 'bg-green-100 text-green-800 dark:bg-green-900/20 dark:text-green-200', icon: CheckCircleIcon },
+      active: { color: 'bg-blue-100 text-blue-800 dark:bg-blue-900/20 dark:text-blue-200', icon: CheckCircleIcon },
       trialing: { color: 'bg-blue-100 text-blue-800 dark:bg-blue-900/20 dark:text-blue-200', icon: CheckCircleIcon },
       past_due: { color: 'bg-red-100 text-red-800 dark:bg-red-900/20 dark:text-red-200', icon: AlertTriangleIcon },
       cancelled: { color: 'bg-gray-100 text-gray-800 dark:bg-gray-700 dark:text-gray-200', icon: AlertTriangleIcon },
@@ -284,7 +284,7 @@ export default function BillingDashboard({
             {subscription.status === 'trialing' && subscription.trialEnd && (
               <div className="bg-blue-50 dark:bg-blue-900/20 border border-blue-200 dark:border-blue-800 rounded-lg p-4">
                 <div className="flex items-start gap-3">
-                  <CheckCircleIcon size={20} className="text-emerald-700 dark:text-emerald-400 flex-shrink-0 mt-0.5" />
+                  <CheckCircleIcon size={20} className="text-blue-700 dark:text-blue-400 flex-shrink-0 mt-0.5" />
                   <div>
                     <h4 className="text-blue-900 dark:text-blue-300 font-medium">
                       Free Trial Active
@@ -441,7 +441,7 @@ export default function BillingDashboard({
                     <td className="py-4">
                       <span className={`text-xs px-2 py-1 rounded-full ${
                         invoice.status === 'paid' 
-                          ? 'bg-green-100 text-green-800 dark:bg-green-900/20 dark:text-green-200'
+                          ? 'bg-blue-100 text-blue-800 dark:bg-blue-900/20 dark:text-blue-200'
                           : 'bg-red-100 text-red-800 dark:bg-red-900/20 dark:text-red-200'
                       }`}>
                         {invoice.status}
@@ -453,7 +453,7 @@ export default function BillingDashboard({
                           href={invoice.invoicePdf}
                           target="_blank"
                           rel="noopener noreferrer"
-                          className="text-emerald-700 dark:text-emerald-400 hover:text-blue-700 dark:hover:text-blue-300"
+                          className="text-blue-700 dark:text-blue-400 hover:text-blue-700 dark:hover:text-blue-300"
                         >
                           <DownloadIcon size={16} />
                         </a>

--- a/src/components/subscription/PaymentForm.tsx
+++ b/src/components/subscription/PaymentForm.tsx
@@ -177,7 +177,7 @@ export default function PaymentForm({
             <span className="text-lg font-semibold text-gray-900 dark:text-white">
               Total:
             </span>
-            <span className="text-lg font-bold text-emerald-700 dark:text-emerald-400">
+            <span className="text-lg font-bold text-green-600 dark:text-green-400">
               {formattedPlanPrice}/{billingLabel.toLowerCase()}
             </span>
           </div>

--- a/src/pages/Accounts.tsx
+++ b/src/pages/Accounts.tsx
@@ -140,8 +140,8 @@ export default function Accounts({ onAccountClick }: { onAccountClick?: (account
     { 
       type: 'current', 
       title: 'Current Accounts', 
-      icon: WalletIcon, 
-      color: 'text-emerald-700 dark:text-emerald-400',
+      icon: WalletIcon,
+      color: 'text-blue-700 dark:text-blue-400',
       bgColor: 'bg-blue-200 dark:bg-blue-900/20',
       borderColor: 'border-blue-200 dark:border-blue-800'
     },
@@ -291,7 +291,7 @@ export default function Accounts({ onAccountClick }: { onAccountClick?: (account
             </div>
             <div className="bg-white dark:bg-gray-800 rounded-xl p-4 border border-gray-100 dark:border-gray-700">
               <p className="text-xs text-gray-500 uppercase tracking-wider font-medium">Assets</p>
-              <p className="text-2xl font-bold mt-1 text-emerald-600">{formatDisplayCurrency(totalAssets)}</p>
+              <p className="text-2xl font-bold mt-1 text-green-600 dark:text-green-400">{formatDisplayCurrency(totalAssets)}</p>
             </div>
             <div className="bg-white dark:bg-gray-800 rounded-xl p-4 border border-gray-100 dark:border-gray-700">
               <p className="text-xs text-gray-500 uppercase tracking-wider font-medium">Liabilities</p>
@@ -309,7 +309,7 @@ export default function Accounts({ onAccountClick }: { onAccountClick?: (account
             onClick={() => handleGroupByChange('type')}
             className={`px-3 py-1.5 text-sm font-medium rounded-md transition-colors ${
               groupBy === 'type'
-                ? 'bg-[#1a2332] dark:bg-emerald-600 text-white'
+                ? 'bg-[#1a2332] dark:bg-blue-600 text-white'
                 : 'text-gray-600 dark:text-gray-400 hover:text-gray-900'
             }`}
           >
@@ -319,7 +319,7 @@ export default function Accounts({ onAccountClick }: { onAccountClick?: (account
             onClick={() => handleGroupByChange('institution')}
             className={`px-3 py-1.5 text-sm font-medium rounded-md transition-colors ${
               groupBy === 'institution'
-                ? 'bg-[#1a2332] dark:bg-emerald-600 text-white'
+                ? 'bg-[#1a2332] dark:bg-blue-600 text-white'
                 : 'text-gray-600 dark:text-gray-400 hover:text-gray-900'
             }`}
           >
@@ -517,7 +517,7 @@ export default function Accounts({ onAccountClick }: { onAccountClick?: (account
                                 <p className={`text-sm font-semibold tabular-nums ${
                                   getUnreconciledCount(account.id) > 0
                                     ? 'text-amber-600 dark:text-amber-400'
-                                    : 'text-green-600 dark:text-green-400'
+                                    : 'text-blue-600 dark:text-blue-400'
                                 }`}>
                                   {getUnreconciledCount(account.id)}
                                 </p>
@@ -573,7 +573,7 @@ export default function Accounts({ onAccountClick }: { onAccountClick?: (account
                                       variant="ghost"
                                       size="md"
                                       disabled={syncing}
-                                      className="text-green-600 hover:text-green-700 dark:text-green-400 dark:hover:text-green-200 hover:bg-green-100/50 dark:hover:bg-green-900/30 min-w-[48px] min-h-[48px]"
+                                      className="text-blue-600 hover:text-blue-700 dark:text-blue-400 dark:hover:text-blue-200 hover:bg-blue-100/50 dark:hover:bg-blue-900/30 min-w-[48px] min-h-[48px]"
                                       title="Sync bank data"
                                     />
                                     <span className="absolute bottom-full left-1/2 transform -translate-x-1/2 mb-2 px-3 py-1.5 text-xs text-white bg-gray-900/90 dark:bg-gray-700/90 backdrop-blur-sm rounded-lg opacity-0 group-hover:opacity-100 transition-all duration-200 whitespace-nowrap pointer-events-none shadow-lg border border-white/10">

--- a/src/pages/Analytics.tsx
+++ b/src/pages/Analytics.tsx
@@ -432,7 +432,7 @@ export default function Analytics(): React.JSX.Element {
               <div className="flex items-center justify-between">
                 <div>
                   <p className="text-sm text-gray-600 dark:text-gray-400">Savings Rate</p>
-                  <p className="text-2xl font-bold text-emerald-700 dark:text-emerald-400">
+                  <p className="text-2xl font-bold text-green-600 dark:text-green-400">
                     {`${formatPercentage(keyMetrics.savingsRate, 1)}%`}
                   </p>
                 </div>

--- a/src/pages/Budget.tsx
+++ b/src/pages/Budget.tsx
@@ -366,7 +366,7 @@ export default function Budget() {
                   onClick={() => handleToggleActive(budget.id, budget.isActive)}
                   className={`px-3 py-1 text-sm rounded ${
                     budget.isActive !== false
-                      ? 'bg-green-100 dark:bg-green-900/20 text-green-700 dark:text-green-300'
+                      ? 'bg-blue-100 dark:bg-blue-900/20 text-blue-700 dark:text-blue-300'
                       : 'bg-gray-100 dark:bg-gray-700 text-gray-700 dark:text-gray-300'
                   }`}
                 >

--- a/src/pages/Calendar.tsx
+++ b/src/pages/Calendar.tsx
@@ -177,7 +177,7 @@ export default function Calendar() {
       <div className="grid grid-cols-2 sm:grid-cols-4 gap-3 mb-4">
         <div className="bg-white dark:bg-gray-800 rounded-lg shadow-sm border border-gray-100 dark:border-gray-700 px-4 py-2">
           <span className="text-sm text-gray-500 dark:text-gray-400">Income</span>
-          <p className="text-lg font-semibold text-emerald-700">{formatCurrency(monthSummary.totalIncome)}</p>
+          <p className="text-lg font-semibold text-green-600 dark:text-green-400">{formatCurrency(monthSummary.totalIncome)}</p>
         </div>
         <div className="bg-white dark:bg-gray-800 rounded-lg shadow-sm border border-gray-100 dark:border-gray-700 px-4 py-2">
           <span className="text-sm text-gray-500 dark:text-gray-400">Expenses</span>
@@ -185,7 +185,7 @@ export default function Calendar() {
         </div>
         <div className="bg-white dark:bg-gray-800 rounded-lg shadow-sm border border-gray-100 dark:border-gray-700 px-4 py-2">
           <span className="text-sm text-gray-500 dark:text-gray-400">Net</span>
-          <p className={`text-lg font-semibold ${monthSummary.totalIncome - monthSummary.totalExpense >= 0 ? 'text-emerald-700' : 'text-red-600'}`}>
+          <p className={`text-lg font-semibold ${monthSummary.totalIncome - monthSummary.totalExpense >= 0 ? 'text-green-600 dark:text-green-400' : 'text-red-600'}`}>
             {formatCurrency(monthSummary.totalIncome - monthSummary.totalExpense)}
           </p>
         </div>
@@ -257,8 +257,8 @@ export default function Calendar() {
               className={`
                 min-h-[60px] sm:min-h-[100px] p-1 sm:p-2 border-b border-r border-gray-50 dark:border-gray-700/50
                 ${!day.isCurrentMonth ? 'bg-gray-50 dark:bg-gray-800/50 opacity-40' : 'bg-white dark:bg-gray-800'}
-                ${day.isToday ? 'ring-2 ring-inset ring-emerald-500' : ''}
-                ${day.transactionCount > 0 ? 'cursor-pointer hover:bg-gray-50 dark:hover:bg-gray-700/50 focus:outline-none focus:ring-2 focus:ring-inset focus:ring-emerald-500' : ''}
+                ${day.isToday ? 'ring-2 ring-inset ring-blue-500' : ''}
+                ${day.transactionCount > 0 ? 'cursor-pointer hover:bg-gray-50 dark:hover:bg-gray-700/50 focus:outline-none focus:ring-2 focus:ring-inset focus:ring-blue-500' : ''}
                 transition-colors
               `}
             >
@@ -266,7 +266,7 @@ export default function Calendar() {
               <div className="flex items-center justify-between mb-1">
                 <span className={`text-sm font-medium ${
                   day.isToday
-                    ? 'bg-emerald-700 text-white w-6 h-6 rounded-full flex items-center justify-center text-xs'
+                    ? 'bg-blue-600 text-white w-6 h-6 rounded-full flex items-center justify-center text-xs'
                     : day.isCurrentMonth
                       ? 'text-gray-900 dark:text-gray-200'
                       : 'text-gray-400 dark:text-gray-600'
@@ -282,7 +282,7 @@ export default function Calendar() {
 
               {/* Transaction amounts */}
               {day.isCurrentMonth && day.income > 0 && (
-                <div className="text-xs text-emerald-700 dark:text-emerald-400 font-medium truncate">
+                <div className="text-xs text-green-600 dark:text-green-400 font-medium truncate">
                   +{formatCurrency(day.income)}
                 </div>
               )}

--- a/src/pages/Goals.tsx
+++ b/src/pages/Goals.tsx
@@ -217,7 +217,7 @@ export default function Goals() {
                 {formatCurrency(totalTargetAmount)}
               </p>
             </div>
-            <TrendingUpIcon className="h-8 w-8 text-green-600" />
+            <TrendingUpIcon className="h-8 w-8 text-blue-600" />
           </div>
         </div>
 
@@ -312,7 +312,7 @@ export default function Goals() {
                       <div className="w-full bg-gray-200 dark:bg-gray-700 rounded-full h-2">
                         <div
                           className={`h-2 rounded-full transition-all duration-300 ${
-                            progressValue >= 100 ? "bg-green-600" : progressValue >= 75 ? "bg-[#1a2332]" : progressValue >= 50 ? "bg-yellow-600" : "bg-gray-400"
+                            progressValue >= 100 ? "bg-blue-600" : progressValue >= 75 ? "bg-[#1a2332]" : progressValue >= 50 ? "bg-yellow-600" : "bg-gray-400"
                           }`}
                           style={{ width: `${Math.min(progressValue, 100)}%` }}
                         />
@@ -380,7 +380,7 @@ export default function Goals() {
                   Build your emergency fund or save for a big purchase
                 </p>
               </div>
-              <div className="p-4 bg-green-50 dark:bg-green-900/20 rounded-lg">
+              <div className="p-4 bg-blue-50 dark:bg-blue-900/20 rounded-lg">
                 <div className="text-2xl mb-2">💳</div>
                 <h4 className="font-medium text-gray-900 dark:text-white text-sm">Debt Payoff</h4>
                 <p className="text-xs text-gray-600 dark:text-gray-400 mt-1">
@@ -464,7 +464,7 @@ export default function Goals() {
           <div className="mt-6">
             <button
               onClick={() => setShowAchievements(!showAchievements)}
-              className="text-emerald-700 dark:text-emerald-400 hover:text-blue-700 dark:hover:text-blue-300 font-medium flex items-center gap-2"
+              className="text-blue-700 dark:text-blue-400 hover:text-blue-800 dark:hover:text-blue-300 font-medium flex items-center gap-2"
             >
               <span>🏆</span>
               {showAchievements ? 'Hide' : 'View'} Achievement History

--- a/src/pages/ReportsHub.tsx
+++ b/src/pages/ReportsHub.tsx
@@ -39,7 +39,7 @@ export default function ReportsHub() {
                   onClick={() => setActiveTab(tab.id)}
                   className={`flex items-center gap-2 px-4 py-3 text-sm font-medium border-b-2 transition-colors whitespace-nowrap ${
                     isActive
-                      ? 'border-[#1a2332] text-[#1a2332] dark:border-emerald-400 dark:text-emerald-400'
+                      ? 'border-[#1a2332] text-[#1a2332] dark:border-blue-400 dark:text-blue-400'
                       : 'border-transparent text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-300 hover:border-gray-300'
                   }`}
                   aria-selected={isActive}

--- a/src/pages/settings/AuditLogs.tsx
+++ b/src/pages/settings/AuditLogs.tsx
@@ -104,8 +104,8 @@ export default function AuditLogs() {
 
   const getActionColor = (action: string) => {
     switch (action) {
-      case 'create': return 'text-green-600 dark:text-green-400';
-      case 'update': return 'text-emerald-700 dark:text-emerald-400';
+      case 'create': return 'text-blue-600 dark:text-blue-400';
+      case 'update': return 'text-blue-700 dark:text-blue-400';
       case 'delete': return 'text-red-600 dark:text-red-400';
       case 'login': return 'text-purple-600 dark:text-purple-400';
       case 'logout': return 'text-gray-600 dark:text-gray-400';


### PR DESCRIPTION
## What

The **final pass** of the green → mid-blue accent sweep — the money-heavy pages I'd deliberately deferred: **budgets, analytics/tax, accounts, calendar, reports, goals**, and the remaining modals/misc (31 files). After this, **no emerald/teal remains in any component**.

## Kept green (financial semantics)
- Amounts, income, **gains/returns** (`>= 0 ? green : red`), surplus/savings/assets, net, dividends; income/expense **Type tabs**.
- **Budget-health** (remaining ≥ 0 green / over red), progress **traffic-lights**, and scale badges: risk, ESG rating, confidence, difficulty, impact, savings-rate, long-term-gain, due-status, on-target.
- **Normalised** money values that were styled `emerald` → **green** (rollover, calendar income/net, total assets/invested, tax impact, savings rate, plan price…).

## Changed → blue (neutral chrome)
Decorative header banners/gradients, section/stat icons, focus rings, single progress/score bars, "Live"/"Market Open"/enabled **status dots**, active tabs, selection/approved highlights, success panels/ticks, the calendar "today" indicator, action buttons, markdown/external **links**, the edit modal's **reconciled tick + link icons** and **transfer Type tab**, and category legends (investment/charitable, current-account, audit-log create/update).

## Judgement calls worth noting
- **Traffic-light / scale colours kept green** (risk, ratings, confidence, difficulty, budget-usage) — red/amber/green is a meaningful convention; recolouring would break it.
- **Category legends** where green/emerald sat next to an already-blue sibling were merged to blue (distinguished by their labels).
- `src/styles/accessibility-colors.css` left as-is (semantic a11y colour tokens, not UI accents).

## Verification
- `typecheck:strict` ✅ · `lint` ✅ · `test:unit` ✅ (2882) · `build` ✅
- Final grep confirms zero emerald/teal in components; each file was money-checked before editing.

This completes request #2 — the whole app's UI accents are now the theme blue, with income/expense/gains still green/red.

🤖 Generated with [Claude Code](https://claude.com/claude-code)