### PR TITLE
fix(category-picker): remove stray focus chrome from the open search box

### DIFF
--- a/src/components/CategorySelector.tsx
+++ b/src/components/CategorySelector.tsx
@@ -277,7 +277,7 @@ export default function CategorySelector({
       <div className="relative">
         <div
           ref={triggerRef}
-          className="w-full px-3 py-2 h-[42px] bg-white dark:bg-gray-800 border border-gray-300 dark:border-gray-600 rounded-xl shadow-sm focus-within:border-blue-500 cursor-text flex items-center"
+          className="w-full px-3 py-2 h-[42px] bg-white dark:bg-gray-800 border border-gray-300 dark:border-gray-600 rounded-xl shadow-sm cursor-text flex items-center"
           onClick={handleInputClick}
         >
           <div className="flex items-center justify-between">
@@ -289,7 +289,7 @@ export default function CategorySelector({
                   onChange={handleInputChange}
                   onFocus={handleInputFocus}
                   placeholder={placeholder}
-                  className="w-full bg-transparent text-gray-900 dark:text-white focus:outline-none !border-0"
+                  className="w-full bg-transparent text-gray-900 dark:text-white !border-0 focus:!outline-none focus-visible:!outline-none"
                   autoFocus
                 />
               ) : (


### PR DESCRIPTION
## What & why

Two glitches you spotted when the category combobox opens in the edit modal:

1. **Square dark rectangle** around the search input. Root cause: `accessibility-colors.css` paints `input:focus-visible { outline: 2px solid var(--focus-ring-color) !important }` (navy `#2d3a4d`), and the combobox's inner input autofocuses on open — text inputs match `:focus-visible` on **any** focus. The inner input isn't the visual field (the rounded container is), so its own outline is suppressed with a higher-specificity important utility (`focus:!outline-none focus-visible:!outline-none`). Keyboard users still get the container affordance + the open list as the focus cue.
2. **Blue focus border** made the box the odd one out — no other input on the modal shows one. Dropped: the trigger keeps its normal gray rounded border + raised shadow, matching the rest of the form.

## Verification
- Live: focused input computes `outline: none/transparent`, `border: 0`; trigger stays gray, 12px radius, no blue.
- Confirmed both the a11y rule **and** the override exist in the compiled CSS, and the override wins on specificity among `!important` rules — so the fix holds across browsers/OS focus heuristics (the rectangle was environment-dependent).
- `typecheck:strict` ✅ · `lint` ✅ · `test:unit` ✅ (2882) · `build` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)