### PR TITLE
perf(data-management): mount tool modals only while open

### DIFF
--- a/src/pages/settings/DataManagement.tsx
+++ b/src/pages/settings/DataManagement.tsx
@@ -437,98 +437,127 @@ export default function DataManagementSettings() {
         </div>
       )}
 
+      {/* Tool modals — mounted ONLY while open. Rendering a React.lazy
+          component (even closed, returning null) forces its chunk to download
+          AND runs its hooks: DuplicateDetection's O(n²) duplicate scan and
+          DataValidation's full-data sweep were executing on every visit to
+          this page. Gating on the show-flag defers chunk + work to first open
+          (the Suspense fallback covers the brief load). */}
+
       {/* Data Migration Wizard */}
-      <Suspense fallback={<LoadingState />}>
-        <DataMigrationWizard
-          isOpen={showMigrationWizard}
-          onClose={() => setShowMigrationWizard(false)}
-          onComplete={(data) => {
-            dataManagementLogger.info('Migration completed', data);
-            setShowMigrationWizard(false);
-          }}
-        />
-      </Suspense>
+      {showMigrationWizard && (
+        <Suspense fallback={<LoadingState />}>
+          <DataMigrationWizard
+            isOpen={showMigrationWizard}
+            onClose={() => setShowMigrationWizard(false)}
+            onComplete={(data) => {
+              dataManagementLogger.info('Migration completed', data);
+              setShowMigrationWizard(false);
+            }}
+          />
+        </Suspense>
+      )}
 
       {/* Import Modal */}
-      <Suspense fallback={<LoadingState />}>
-        <ImportDataModal
-          isOpen={showImportModal}
-          onClose={() => setShowImportModal(false)}
-        />
-      </Suspense>
+      {showImportModal && (
+        <Suspense fallback={<LoadingState />}>
+          <ImportDataModal
+            isOpen={showImportModal}
+            onClose={() => setShowImportModal(false)}
+          />
+        </Suspense>
+      )}
 
       {/* Batch Import Modal */}
-      <Suspense fallback={<LoadingState />}>
-        <BatchImportModal
-          isOpen={showBatchImport}
-          onClose={() => setShowBatchImport(false)}
-        />
-      </Suspense>
+      {showBatchImport && (
+        <Suspense fallback={<LoadingState />}>
+          <BatchImportModal
+            isOpen={showBatchImport}
+            onClose={() => setShowBatchImport(false)}
+          />
+        </Suspense>
+      )}
 
       {/* CSV Import Wizard */}
-      <Suspense fallback={<LoadingState />}>
-        <CSVImportWizard
-          isOpen={showCSVImportWizard}
-          onClose={() => setShowCSVImportWizard(false)}
-          type="transaction"
-        />
-      </Suspense>
+      {showCSVImportWizard && (
+        <Suspense fallback={<LoadingState />}>
+          <CSVImportWizard
+            isOpen={showCSVImportWizard}
+            onClose={() => setShowCSVImportWizard(false)}
+            type="transaction"
+          />
+        </Suspense>
+      )}
 
       {/* OFX Import Modal */}
-      <Suspense fallback={<LoadingState />}>
-        <OFXImportModal
-          isOpen={showOFXImportModal}
-          onClose={() => setShowOFXImportModal(false)}
-        />
-      </Suspense>
+      {showOFXImportModal && (
+        <Suspense fallback={<LoadingState />}>
+          <OFXImportModal
+            isOpen={showOFXImportModal}
+            onClose={() => setShowOFXImportModal(false)}
+          />
+        </Suspense>
+      )}
 
       {/* QIF Import Modal */}
-      <Suspense fallback={<LoadingState />}>
-        <QIFImportModal
-          isOpen={showQIFImportModal}
-          onClose={() => setShowQIFImportModal(false)}
-        />
-      </Suspense>
+      {showQIFImportModal && (
+        <Suspense fallback={<LoadingState />}>
+          <QIFImportModal
+            isOpen={showQIFImportModal}
+            onClose={() => setShowQIFImportModal(false)}
+          />
+        </Suspense>
+      )}
 
       {/* Duplicate Detection */}
-      <Suspense fallback={<LoadingState />}>
-        <DuplicateDetection
-          isOpen={showDuplicateDetection}
-          onClose={() => setShowDuplicateDetection(false)}
-        />
-      </Suspense>
+      {showDuplicateDetection && (
+        <Suspense fallback={<LoadingState />}>
+          <DuplicateDetection
+            isOpen={showDuplicateDetection}
+            onClose={() => setShowDuplicateDetection(false)}
+          />
+        </Suspense>
+      )}
 
       {/* Excel Export */}
-      <Suspense fallback={<LoadingState />}>
-        <ExcelExport
-          isOpen={showExcelExport}
-          onClose={() => setShowExcelExport(false)}
-        />
-      </Suspense>
+      {showExcelExport && (
+        <Suspense fallback={<LoadingState />}>
+          <ExcelExport
+            isOpen={showExcelExport}
+            onClose={() => setShowExcelExport(false)}
+          />
+        </Suspense>
+      )}
 
       {/* Bulk Edit */}
-      <Suspense fallback={<LoadingState />}>
-        <BulkTransactionEdit
-          isOpen={showBulkEdit}
-          onClose={() => setShowBulkEdit(false)}
-        />
-      </Suspense>
+      {showBulkEdit && (
+        <Suspense fallback={<LoadingState />}>
+          <BulkTransactionEdit
+            isOpen={showBulkEdit}
+            onClose={() => setShowBulkEdit(false)}
+          />
+        </Suspense>
+      )}
 
       {/* Reconciliation */}
-      <Suspense fallback={<LoadingState />}>
-        <TransactionReconciliation
-          isOpen={showReconciliation}
-          onClose={() => setShowReconciliation(false)}
-        />
-      </Suspense>
+      {showReconciliation && (
+        <Suspense fallback={<LoadingState />}>
+          <TransactionReconciliation
+            isOpen={showReconciliation}
+            onClose={() => setShowReconciliation(false)}
+          />
+        </Suspense>
+      )}
 
       {/* Data Validation */}
-      <Suspense fallback={<LoadingState />}>
-        <DataValidation
-          isOpen={showDataValidation}
-          onClose={() => setShowDataValidation(false)}
-        />
-      </Suspense>
+      {showDataValidation && (
+        <Suspense fallback={<LoadingState />}>
+          <DataValidation
+            isOpen={showDataValidation}
+            onClose={() => setShowDataValidation(false)}
+          />
+        </Suspense>
+      )}
 
       {/* Smart Categorization Modal */}
       {showSmartCategorization && (


### PR DESCRIPTION
## What & why

**Settings > Data Management was very slow to load.** Root cause: eleven `React.lazy` tool modals (migration wizard, the four import modals, duplicate detection, Excel export, bulk edit, reconciliation, data validation) were rendered **unconditionally** with `isOpen={false}`. Rendering a lazy component — even one that returns `null` — forces its chunk to download/parse *and* runs its hooks. The worst offenders while "closed":

- **`DuplicateDetection`** — an **O(n²) pairwise duplicate scan** over all transactions (~16k rows now ⇒ on the order of 10⁸ comparisons on the main thread) ran on every visit to the page.
- **`DataValidation`** — its full-data validation sweep ran on mount and re-ran on every transactions change.
- Plus 11 lazy chunks fetched+parsed just to show the page.

## Fix

Gate each modal behind its show-flag — the exact pattern this file already uses for SmartCategorization / ImportRules / BankConnections — so the chunk fetch and all computation defer to first open (the existing `Suspense` fallback covers the brief load).

**Behaviour note:** closing a modal now unmounts it, so a reopened tool starts fresh rather than retaining half-done state (arguably correct for import wizards/scans).

## Verification
- Live (dev preview): page renders with **zero** heavy modal modules fetched (was all 11); clicking **QIF Import (Quicken)** loads exactly its chunk and opens the modal; the others stay unloaded; no console errors.
- `typecheck:strict` ✅ · `lint` ✅ · `test:unit` ✅ (2882) · `build` ✅

Follow-up flagged separately: make the duplicate scan itself sub-O(n²) so *opening* Duplicate Detection is also fast on large accounts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)