### PR TITLE
perf(duplicates): index the duplicate scan — no more O(n²) Levenshtein sweep

### DIFF
--- a/src/components/DuplicateDetection.tsx
+++ b/src/components/DuplicateDetection.tsx
@@ -3,7 +3,7 @@ import { useApp } from '../contexts/AppContextSupabase';
 import { useCurrencyDecimal } from '../hooks/useCurrencyDecimal';
 import { parseMoneyInput } from '../utils/decimal';
 import { Modal } from './common/Modal';
-import { 
+import {
   AlertTriangleIcon,
   CheckIcon,
   TrashIcon,
@@ -13,27 +13,21 @@ import {
   FilterIcon
 } from './icons';
 import type { Transaction } from '../types';
-import { toDecimal } from '../utils/decimal';
 import { formatDecimal } from '../utils/decimal-format';
+import {
+  buildDuplicateScanIndex,
+  calculateSimilarity,
+  findDuplicateGroups,
+  findDuplicateMatches,
+  type DuplicateGroup,
+  type DuplicateThresholds,
+} from '../utils/duplicateScan';
 
 interface DuplicateDetectionProps {
   isOpen: boolean;
   onClose: () => void;
   newTransactions?: Partial<Transaction>[];
   onConfirm?: (transactions: Partial<Transaction>[]) => void;
-}
-
-interface DuplicateGroup {
-  original: Transaction;
-  potential: Transaction[];
-  confidence: number;
-}
-
-interface SimilarityScore {
-  dateScore: number;
-  amountScore: number;
-  descriptionScore: number;
-  totalScore: number;
 }
 
 export default function DuplicateDetection({ 
@@ -54,191 +48,62 @@ export default function DuplicateDetection({
   const [similarityThreshold, setSimilarityThreshold] = useState(80); // percentage
   const [autoSelectHighConfidence, setAutoSelectHighConfidence] = useState(true);
 
-  // Calculate string similarity using Levenshtein distance
-  const calculateStringSimilarity = useCallback((str1: string, str2: string): number => {
-    const s1 = str1.toLowerCase().trim();
-    const s2 = str2.toLowerCase().trim();
-    
-    if (s1 === s2) return 100;
-    
-    const matrix: number[][] = [];
-    const len1 = s1.length;
-    const len2 = s2.length;
-    
-    for (let i = 0; i <= len2; i++) {
-      matrix[i] = [i];
-    }
-    
-    for (let j = 0; j <= len1; j++) {
-      matrix[0][j] = j;
-    }
-    
-    for (let i = 1; i <= len2; i++) {
-      for (let j = 1; j <= len1; j++) {
-        if (s2.charAt(i - 1) === s1.charAt(j - 1)) {
-          matrix[i][j] = matrix[i - 1][j - 1];
-        } else {
-          matrix[i][j] = Math.min(
-            matrix[i - 1][j - 1] + 1,
-            matrix[i][j - 1] + 1,
-            matrix[i - 1][j] + 1
-          );
-        }
-      }
-    }
-    
-    const distance = matrix[len2][len1];
-    const maxLen = Math.max(len1, len2);
-    return Math.round((1 - distance / maxLen) * 100);
-  }, []);
+  // The scan thresholds, in the shape the duplicateScan util consumes.
+  const thresholds = useMemo<DuplicateThresholds>(
+    () => ({ dateThreshold, amountThreshold, similarityThreshold }),
+    [dateThreshold, amountThreshold, similarityThreshold]
+  );
 
-  // Calculate similarity between two transactions
-  const calculateSimilarity = useCallback((t1: Transaction, t2: Transaction): SimilarityScore => {
-    // Ensure dates are Date objects
-    const date1 = t1.date instanceof Date ? t1.date : new Date(t1.date);
-    const date2 = t2.date instanceof Date ? t2.date : new Date(t2.date);
-    
-    // Date similarity (within threshold)
-    const daysDiff = Math.abs(
-      (date1.getTime() - date2.getTime()) / (1000 * 60 * 60 * 24)
-    );
-    const dateScore = daysDiff <= dateThreshold ? 100 - (daysDiff / dateThreshold) * 50 : 0;
-    
-    // Amount similarity
-    const amount1 = toDecimal(t1.amount).toNumber();
-    const amount2 = toDecimal(t2.amount).toNumber();
-    const amountDiff = Math.abs(amount1 - amount2);
-    const amountScore = amountDiff <= amountThreshold ? 100 : 
-      Math.max(0, 100 - (amountDiff / Math.max(amount1, amount2)) * 100);
-    
-    // Description similarity
-    const descriptionScore = calculateStringSimilarity(t1.description, t2.description);
-    
-    // Total weighted score
-    const totalScore = (dateScore * 0.3 + amountScore * 0.4 + descriptionScore * 0.3);
-    
-    return {
-      dateScore,
-      amountScore,
-      descriptionScore,
-      totalScore
-    };
-  }, [dateThreshold, amountThreshold, calculateStringSimilarity]);
-
-  // Find duplicates in existing transactions
-  const existingDuplicateGroups = useMemo(() => {
-    const groups: DuplicateGroup[] = [];
-    const processed = new Set<string>();
-    
-    for (let i = 0; i < transactions.length; i++) {
-      if (processed.has(transactions[i].id)) continue;
-      
-      const potential: Transaction[] = [];
-      
-      for (let j = i + 1; j < transactions.length; j++) {
-        if (processed.has(transactions[j].id)) continue;
-        
-        const similarity = calculateSimilarity(transactions[i], transactions[j]);
-        
-        if (similarity.totalScore >= similarityThreshold) {
-          potential.push(transactions[j]);
-          processed.add(transactions[j].id);
-        }
-      }
-      
-      if (potential.length > 0) {
-        processed.add(transactions[i].id);
-        groups.push({
-          original: transactions[i],
-          potential,
-          confidence: Math.max(...potential.map(t => 
-            calculateSimilarity(transactions[i], t).totalScore
-          ))
-        });
-      }
-    }
-    
-    return groups;
-  }, [transactions, similarityThreshold, calculateSimilarity]);
+  // Find duplicates in existing transactions (indexed scan — see duplicateScan.ts)
+  const existingDuplicateGroups = useMemo(
+    () => findDuplicateGroups(transactions, thresholds),
+    [transactions, thresholds]
+  );
 
   // Check new transactions against existing ones
   const checkNewTransactions = useCallback(() => {
     if (!newTransactions || newTransactions.length === 0) return;
-    
+
     setScanning(true);
     setScanProgress(0);
-    
+
+    // One index over the existing transactions, matched against per new row.
+    const index = buildDuplicateScanIndex(transactions, thresholds);
     const groups: DuplicateGroup[] = [];
     const toRemove = new Set<string>();
-    
-    newTransactions.forEach((newTrans, index) => {
-      setScanProgress(((index + 1) / newTransactions.length) * 100);
-      
-      const matches: Transaction[] = [];
-      
-      transactions.forEach(existing => {
-        if (!newTrans.date || !newTrans.description || newTrans.amount === undefined) return;
-        
-        const tempTransaction: Transaction = {
-          ...newTrans,
-          id: `new-${index}`,
-          date: newTrans.date,
-          description: newTrans.description,
-          amount: newTrans.amount,
-          type: newTrans.type || 'expense',
-          accountId: newTrans.accountId || '',
-          category: newTrans.category || '',
-          cleared: newTrans.cleared || false
-        };
-        
-        const similarity = calculateSimilarity(tempTransaction, existing);
-        
-        if (similarity.totalScore >= similarityThreshold) {
-          matches.push(existing);
-        }
-      });
-      
+
+    newTransactions.forEach((newTrans, i) => {
+      setScanProgress(((i + 1) / newTransactions.length) * 100);
+
+      if (!newTrans.date || !newTrans.description || newTrans.amount === undefined) return;
+
+      const candidate: Transaction = {
+        ...newTrans,
+        id: `new-${i}`,
+        date: newTrans.date,
+        description: newTrans.description,
+        amount: newTrans.amount,
+        type: newTrans.type || 'expense',
+        accountId: newTrans.accountId || '',
+        category: newTrans.category || '',
+        cleared: newTrans.cleared || false
+      };
+
+      const { matches, confidence } = findDuplicateMatches(index, candidate);
+
       if (matches.length > 0) {
-        const confidence = Math.max(...matches.map(t => 
-          calculateSimilarity({
-            ...newTrans,
-            id: `new-${index}`,
-            date: newTrans.date!,
-            description: newTrans.description!,
-            amount: newTrans.amount!,
-            type: newTrans.type || 'expense',
-            accountId: newTrans.accountId || '',
-            category: newTrans.category || '',
-            cleared: newTrans.cleared || false
-          }, t).totalScore
-        ));
-        
-        groups.push({
-          original: {
-            ...newTrans,
-            id: `new-${index}`,
-            date: newTrans.date!,
-            description: newTrans.description!,
-            amount: newTrans.amount!,
-            type: newTrans.type || 'expense',
-            accountId: newTrans.accountId || '',
-            category: newTrans.category || '',
-            cleared: newTrans.cleared || false
-          },
-          potential: matches,
-          confidence
-        });
-        
+        groups.push({ original: candidate, potential: matches, confidence });
+
         if (autoSelectHighConfidence && confidence >= 90) {
-          toRemove.add(`new-${index}`);
+          toRemove.add(`new-${i}`);
         }
       }
     });
-    
+
     setDuplicateGroups(groups);
     setSelectedDuplicates(toRemove);
     setScanning(false);
-  }, [newTransactions, similarityThreshold, calculateSimilarity, transactions, autoSelectHighConfidence]);
+  }, [newTransactions, thresholds, transactions, autoSelectHighConfidence]);
 
   // Run duplicate check when modal opens
   useEffect(() => {
@@ -511,7 +376,7 @@ export default function DuplicateDetection({
                         </div>
                       </div>
                       <div className="text-xs text-gray-500">
-                        {formatDecimal(calculateSimilarity(group.original, transaction).totalScore, 0)}% similar
+                        {formatDecimal(calculateSimilarity(group.original, transaction, thresholds).totalScore, 0)}% similar
                       </div>
                     </div>
                   ))}

--- a/src/index.css
+++ b/src/index.css
@@ -80,14 +80,16 @@
   }
 }
 
-/* Checkbox / radio controls (app-wide).
+/* Checkbox / radio / range controls (app-wide).
    - accent-color pins them to the app blue (#2563eb) so they never inherit the
-     viewer's OS accent colour (a green macOS accent was making every box green).
-   - On desktop (pointer: fine) they're a crisp, professional size rather than the
-     chunky finger-target look; touch devices keep the larger target from the
-     media query above. This is a PC/Mac-first professional app. */
+     viewer's OS accent colour (a green macOS accent was making every box and
+     slider green).
+   - On desktop (pointer: fine) checkboxes/radios are a crisp, professional
+     size rather than the chunky finger-target look; touch devices keep the
+     larger target from the media query above. PC/Mac-first professional app. */
 input[type="checkbox"],
-input[type="radio"] {
+input[type="radio"],
+input[type="range"] {
   accent-color: #2563eb;
 }
 

--- a/src/utils/duplicateScan.test.ts
+++ b/src/utils/duplicateScan.test.ts
@@ -1,0 +1,276 @@
+import { describe, it, expect } from 'vitest';
+import type { Transaction } from '../types';
+import {
+  buildDuplicateScanIndex,
+  calculateSimilarity,
+  calculateStringSimilarity,
+  findDuplicateGroups,
+  findDuplicateMatches,
+  type DuplicateGroup,
+  type DuplicateThresholds,
+} from './duplicateScan';
+
+const DAY_MS = 1000 * 60 * 60 * 24;
+const BASE = new Date('2024-03-01T00:00:00Z').getTime();
+
+let nextId = 0;
+function mkTx(overrides: Partial<Transaction> & { daysOffset?: number } = {}): Transaction {
+  const { daysOffset = 0, ...rest } = overrides;
+  return {
+    id: rest.id ?? `t${nextId++}`,
+    date: rest.date ?? new Date(BASE + daysOffset * DAY_MS),
+    description: rest.description ?? 'TESCO STORES 3021',
+    amount: rest.amount ?? 45.67,
+    type: rest.type ?? 'expense',
+    accountId: rest.accountId ?? 'acc-1',
+    category: rest.category ?? 'cat-1',
+    cleared: rest.cleared ?? false,
+    ...rest,
+  };
+}
+
+const THRESHOLDS: DuplicateThresholds = {
+  dateThreshold: 3,
+  amountThreshold: 0.01,
+  similarityThreshold: 80,
+};
+
+/**
+ * Verbatim port of the ORIGINAL component algorithm's loop structure
+ * (nested i/j sweep, processed set, recomputed confidence), scoring through
+ * the util's calculateSimilarity. findDuplicateGroups must reproduce this
+ * exactly — only faster.
+ */
+function referenceGroups(transactions: Transaction[], thresholds: DuplicateThresholds): DuplicateGroup[] {
+  const groups: DuplicateGroup[] = [];
+  const processed = new Set<string>();
+
+  for (let i = 0; i < transactions.length; i++) {
+    if (processed.has(transactions[i].id)) continue;
+
+    const potential: Transaction[] = [];
+
+    for (let j = i + 1; j < transactions.length; j++) {
+      if (processed.has(transactions[j].id)) continue;
+      const similarity = calculateSimilarity(transactions[i], transactions[j], thresholds);
+      if (similarity.totalScore >= thresholds.similarityThreshold) {
+        potential.push(transactions[j]);
+        processed.add(transactions[j].id);
+      }
+    }
+
+    if (potential.length > 0) {
+      processed.add(transactions[i].id);
+      groups.push({
+        original: transactions[i],
+        potential,
+        confidence: Math.max(...potential.map(t =>
+          calculateSimilarity(transactions[i], t, thresholds).totalScore
+        )),
+      });
+    }
+  }
+
+  return groups;
+}
+
+/** Comparable shape: ids + confidence only. */
+const shape = (groups: DuplicateGroup[]) =>
+  groups.map(g => ({
+    original: g.original.id,
+    potential: g.potential.map(t => t.id),
+    confidence: g.confidence,
+  }));
+
+describe('calculateStringSimilarity', () => {
+  it('is 100 for identical strings ignoring case/whitespace', () => {
+    expect(calculateStringSimilarity('  Tesco ', 'tesco')).toBe(100);
+  });
+
+  it('drops with edit distance', () => {
+    // "abcd" vs "abcx": distance 1 of maxLen 4 → 75
+    expect(calculateStringSimilarity('abcd', 'abcx')).toBe(75);
+  });
+
+  it('is 0 for completely different strings of equal length', () => {
+    expect(calculateStringSimilarity('aaaa', 'zzzz')).toBe(0);
+  });
+});
+
+describe('findDuplicateGroups', () => {
+  it('groups exact duplicates with ~100% confidence', () => {
+    const a = mkTx();
+    const b = mkTx();
+    const groups = findDuplicateGroups([a, b], THRESHOLDS);
+    expect(groups).toHaveLength(1);
+    expect(groups[0].original.id).toBe(a.id);
+    expect(groups[0].potential.map(t => t.id)).toEqual([b.id]);
+    expect(groups[0].confidence).toBeCloseTo(100, 5);
+  });
+
+  it('puts a three-way duplicate into a single group seeded by the first', () => {
+    const [a, b, c] = [mkTx(), mkTx(), mkTx()];
+    const groups = findDuplicateGroups([a, b, c], THRESHOLDS);
+    expect(shape(groups)).toEqual([
+      { original: a.id, potential: [b.id, c.id], confidence: groups[0].confidence },
+    ]);
+  });
+
+  it('matches near dates within the threshold and rejects beyond it', () => {
+    const near = findDuplicateGroups([mkTx(), mkTx({ daysOffset: 2 })], THRESHOLDS);
+    // date 100-(2/3)*50=66.7 → *0.3 = 20, amount 40, desc 30 → ~90
+    expect(near).toHaveLength(1);
+    expect(near[0].confidence).toBeGreaterThanOrEqual(80);
+
+    const far = findDuplicateGroups([mkTx(), mkTx({ daysOffset: 5 })], THRESHOLDS);
+    // dateScore 0 → max 70 < 80
+    expect(far).toHaveLength(0);
+  });
+
+  it('treats amounts within the amount threshold as exact and scores others relatively', () => {
+    const close = findDuplicateGroups([mkTx({ amount: 45.67 }), mkTx({ amount: 45.68 })], THRESHOLDS);
+    expect(close).toHaveLength(1); // diff 0.01 ≤ threshold → amountScore 100
+
+    const far = findDuplicateGroups([mkTx({ amount: 100 }), mkTx({ amount: 250 })], THRESHOLDS);
+    // relative diff 60% → amountScore 40 → total ≈ 30+16+30 = 76 < 80
+    expect(far).toHaveLength(0);
+  });
+
+  it('rejects pairs whose descriptions differ too much', () => {
+    const groups = findDuplicateGroups(
+      [mkTx({ description: 'TESCO STORES 3021' }), mkTx({ description: 'AMAZON MARKETPLACE' })],
+      THRESHOLDS
+    );
+    expect(groups).toHaveLength(0);
+  });
+
+  it('matches identical negative amounts', () => {
+    const groups = findDuplicateGroups([mkTx({ amount: -50 }), mkTx({ amount: -50 })], THRESHOLDS);
+    expect(groups).toHaveLength(1);
+  });
+
+  it('does NOT auto-match unrelated negative amounts (signed-denominator fix)', () => {
+    // With the original signed Math.max denominator, -5 vs -10 scored an
+    // amountScore of 200, matching at ANY threshold regardless of date/desc.
+    const groups = findDuplicateGroups(
+      [
+        mkTx({ amount: -5, description: 'SHELL PETROL', daysOffset: 0 }),
+        mkTx({ amount: -10, description: 'NETFLIX.COM', daysOffset: 10 }),
+      ],
+      THRESHOLDS
+    );
+    expect(groups).toHaveLength(0);
+  });
+
+  it('lets identical desc+amount pairs match on the ≤70 fallback path regardless of date', () => {
+    const txs = [mkTx(), mkTx({ daysOffset: 30 })]; // dateScore 0
+    // amount 100*0.4 + desc 100*0.3 = 70.00000000000001 in IEEE floats
+    expect(findDuplicateGroups(txs, { ...THRESHOLDS, similarityThreshold: 70 })).toHaveLength(1);
+    expect(findDuplicateGroups(txs, { ...THRESHOLDS, similarityThreshold: 71 })).toHaveLength(0);
+  });
+
+  it('never groups a transaction into more than one group', () => {
+    const txs = [mkTx(), mkTx(), mkTx({ daysOffset: 1 }), mkTx({ daysOffset: 2 })];
+    const groups = findDuplicateGroups(txs, THRESHOLDS);
+    const seen = new Set<string>();
+    for (const g of groups) {
+      for (const id of [g.original.id, ...g.potential.map(t => t.id)]) {
+        expect(seen.has(id)).toBe(false);
+        seen.add(id);
+      }
+    }
+  });
+});
+
+describe('parity with the original pairwise algorithm', () => {
+  // Deterministic LCG so the sample set is stable across runs.
+  let seed = 42;
+  const rand = (): number => {
+    seed = (seed * 1664525 + 1013904223) >>> 0;
+    return seed / 2 ** 32;
+  };
+  const pick = <T,>(arr: T[]): T => arr[Math.floor(rand() * arr.length)];
+
+  const DESCRIPTIONS = [
+    'TESCO STORES 3021',
+    'TESCO STORES 3022',
+    'SAINSBURYS LOCAL',
+    'AMAZON MARKETPLACE',
+    'SHELL PETROL 449',
+    'NETFLIX.COM',
+    'COUNCIL TAX DD',
+    'Payment - Thank You',
+  ];
+  const AMOUNTS = [3.99, 12.5, 45.67, 45.68, 120, 250.75, -3.99, -45.67, -120, 8.2];
+
+  const sample: Transaction[] = Array.from({ length: 220 }, (_, i) =>
+    mkTx({
+      id: `s${i}`,
+      description: rand() < 0.15 ? `${pick(DESCRIPTIONS)} ${Math.floor(rand() * 10)}` : pick(DESCRIPTIONS),
+      amount: pick(AMOUNTS),
+      daysOffset: Math.floor(rand() * 45),
+    })
+  );
+
+  const cases: DuplicateThresholds[] = [
+    { dateThreshold: 3, amountThreshold: 0.01, similarityThreshold: 80 },
+    { dateThreshold: 3, amountThreshold: 0.01, similarityThreshold: 90 },
+    { dateThreshold: 3, amountThreshold: 0.01, similarityThreshold: 71 },
+    { dateThreshold: 3, amountThreshold: 5, similarityThreshold: 65 },
+    { dateThreshold: 7, amountThreshold: 0.01, similarityThreshold: 50 },
+    { dateThreshold: 0, amountThreshold: 0.01, similarityThreshold: 80 },
+  ];
+
+  for (const thresholds of cases) {
+    it(`matches the reference at threshold ${thresholds.similarityThreshold}% (date ${thresholds.dateThreshold}d, amount ${thresholds.amountThreshold})`, () => {
+      const fast = findDuplicateGroups(sample, thresholds);
+      const reference = referenceGroups(sample, thresholds);
+      expect(shape(fast)).toEqual(shape(reference));
+    });
+  }
+
+  it('findDuplicateMatches agrees with a full scan for import candidates', () => {
+    const thresholds = THRESHOLDS;
+    const index = buildDuplicateScanIndex(sample, thresholds);
+    const candidates = Array.from({ length: 40 }, (_, i) =>
+      mkTx({
+        id: `new-${i}`,
+        description: pick(DESCRIPTIONS),
+        amount: pick(AMOUNTS),
+        daysOffset: Math.floor(rand() * 45),
+      })
+    );
+
+    for (const candidate of candidates) {
+      const fast = findDuplicateMatches(index, candidate);
+      const referenceMatches = sample.filter(e =>
+        calculateSimilarity(candidate, e, thresholds).totalScore >= thresholds.similarityThreshold
+      );
+      const referenceConfidence = referenceMatches.length > 0
+        ? Math.max(...referenceMatches.map(e => calculateSimilarity(candidate, e, thresholds).totalScore))
+        : 0;
+      expect(fast.matches.map(t => t.id)).toEqual(referenceMatches.map(t => t.id));
+      expect(fast.confidence).toBe(referenceConfidence);
+    }
+  });
+});
+
+describe('scale', () => {
+  it('handles thousands of transactions without a pairwise blowup', () => {
+    // 12,000 rows over ~4 years. The old O(n²) sweep ran ~72M Levenshteins
+    // here (minutes); the indexed scan only compares date-window neighbours
+    // and must finish comfortably inside the test timeout.
+    const txs: Transaction[] = Array.from({ length: 12000 }, (_, i) =>
+      mkTx({
+        id: `big${i}`,
+        description: `MERCHANT ${i % 900}`,
+        amount: (i % 500) + 0.99,
+        daysOffset: Math.floor(i / 8),
+      })
+    );
+    const groups = findDuplicateGroups(txs, THRESHOLDS);
+    // Same merchant+amount rows recur every 900 indexes ⇒ far apart in time ⇒
+    // no duplicates expected; the assertion is that we got a clean result fast.
+    expect(Array.isArray(groups)).toBe(true);
+  });
+});

--- a/src/utils/duplicateScan.ts
+++ b/src/utils/duplicateScan.ts
@@ -1,0 +1,312 @@
+import type { Transaction } from '../types';
+import { toDecimal } from './decimal';
+
+/**
+ * Duplicate-transaction scanning.
+ *
+ * Extracted from DuplicateDetection.tsx and restructured so the common case no
+ * longer does an O(n²) pairwise sweep with a Levenshtein computation per pair
+ * (~16k transactions ⇒ ~128 million string comparisons that froze the main
+ * thread for seconds):
+ *
+ * - A pair can only reach the similarity threshold when its dates are within
+ *   the date threshold IF the threshold is above what amount + description
+ *   alone can contribute (70%). Above that (the 80% default), candidates come
+ *   from a date-sorted index and each transaction is compared only against its
+ *   date-window neighbours — ~O(n log n) on real data.
+ * - At thresholds ≤ 70% distant dates can still match, so the scan falls back
+ *   to all pairs — but computes the cheap date/amount scores first and skips
+ *   the expensive Levenshtein whenever even a perfect description score could
+ *   not reach the threshold (plus a length-difference upper bound on the
+ *   description score, since edit distance is at least the length difference).
+ *
+ * Scoring is kept bit-for-bit identical to the original algorithm, with ONE
+ * deliberate fix: the original divided the amount difference by the SIGNED
+ * larger amount, so two negative amounts (e.g. -5 and -10) scored above 100%
+ * "similarity" and auto-matched as duplicates regardless of date or
+ * description. The denominator is now the larger ABSOLUTE amount, keeping the
+ * amount score in 0..100 (which is also what makes the date-window pruning
+ * mathematically sound).
+ */
+
+export interface DuplicateThresholds {
+  /** Days within which two dates are considered close. */
+  dateThreshold: number;
+  /** Absolute currency difference treated as an exact amount match. */
+  amountThreshold: number;
+  /** Minimum total score (0–100) for a pair to count as duplicates. */
+  similarityThreshold: number;
+}
+
+export interface SimilarityScore {
+  dateScore: number;
+  amountScore: number;
+  descriptionScore: number;
+  totalScore: number;
+}
+
+export interface DuplicateGroup {
+  original: Transaction;
+  potential: Transaction[];
+  confidence: number;
+}
+
+const DAY_MS = 1000 * 60 * 60 * 24;
+/**
+ * Highest total score reachable with a date score of 0, computed with the
+ * exact float operations the total uses (100 * 0.3 is 30.000000000000004 in
+ * IEEE-754, so this is deliberately NOT written as the literal 70).
+ */
+const MAX_SCORE_WITHOUT_DATE = 0 * 0.3 + 100 * 0.4 + 100 * 0.3;
+const MAX_DESCRIPTION_CONTRIBUTION = 100 * 0.3;
+
+const timeOf = (date: Date | string): number =>
+  (date instanceof Date ? date : new Date(date)).getTime();
+
+/** Two-row Levenshtein distance — same DP as the original full matrix. */
+function levenshteinDistance(s1: string, s2: string): number {
+  const len1 = s1.length;
+  const len2 = s2.length;
+  if (len1 === 0) return len2;
+  if (len2 === 0) return len1;
+
+  let prev: number[] = new Array<number>(len1 + 1);
+  let curr: number[] = new Array<number>(len1 + 1);
+  for (let j = 0; j <= len1; j++) prev[j] = j;
+
+  for (let i = 1; i <= len2; i++) {
+    curr[0] = i;
+    for (let j = 1; j <= len1; j++) {
+      curr[j] = s2.charCodeAt(i - 1) === s1.charCodeAt(j - 1)
+        ? prev[j - 1]
+        : Math.min(prev[j - 1] + 1, curr[j - 1] + 1, prev[j] + 1);
+    }
+    const swap = prev;
+    prev = curr;
+    curr = swap;
+  }
+  return prev[len1];
+}
+
+/** Similarity of two ALREADY normalized (lowercased + trimmed) strings, 0–100. */
+function normalizedStringSimilarity(s1: string, s2: string): number {
+  if (s1 === s2) return 100;
+  // s1 === s2 covers the both-empty case, so maxLen > 0 here.
+  const maxLen = Math.max(s1.length, s2.length);
+  return Math.round((1 - levenshteinDistance(s1, s2) / maxLen) * 100);
+}
+
+/** String similarity as a percentage (case/whitespace-insensitive). */
+export function calculateStringSimilarity(str1: string, str2: string): number {
+  return normalizedStringSimilarity(str1.toLowerCase().trim(), str2.toLowerCase().trim());
+}
+
+function dateScoreOf(time1: number, time2: number, dateThreshold: number): number {
+  const daysDiff = Math.abs((time1 - time2) / DAY_MS);
+  return daysDiff <= dateThreshold ? 100 - (daysDiff / dateThreshold) * 50 : 0;
+}
+
+function amountScoreOf(amount1: number, amount2: number, amountThreshold: number): number {
+  const amountDiff = Math.abs(amount1 - amount2);
+  return amountDiff <= amountThreshold
+    ? 100
+    : Math.max(0, 100 - (amountDiff / Math.max(Math.abs(amount1), Math.abs(amount2))) * 100);
+}
+
+/** Full similarity breakdown between two transactions. */
+export function calculateSimilarity(
+  t1: Transaction,
+  t2: Transaction,
+  thresholds: DuplicateThresholds
+): SimilarityScore {
+  const dateScore = dateScoreOf(timeOf(t1.date), timeOf(t2.date), thresholds.dateThreshold);
+  const amountScore = amountScoreOf(
+    toDecimal(t1.amount).toNumber(),
+    toDecimal(t2.amount).toNumber(),
+    thresholds.amountThreshold
+  );
+  const descriptionScore = calculateStringSimilarity(t1.description, t2.description);
+  const totalScore = dateScore * 0.3 + amountScore * 0.4 + descriptionScore * 0.3;
+  return { dateScore, amountScore, descriptionScore, totalScore };
+}
+
+interface PreparedTransaction {
+  txn: Transaction;
+  /** Position in the original transactions array (group/member ordering). */
+  index: number;
+  time: number;
+  amount: number;
+  /** Normalized (lowercased + trimmed) description. */
+  desc: string;
+}
+
+export interface DuplicateScanIndex {
+  prepared: PreparedTransaction[];
+  /** Valid-dated transactions, ascending by time (candidate window lookups). */
+  byTime: PreparedTransaction[];
+  thresholds: DuplicateThresholds;
+  /** Whether the threshold is high enough that matches require close dates. */
+  datePruned: boolean;
+}
+
+/** Build the reusable index once, then match many candidates against it. */
+export function buildDuplicateScanIndex(
+  transactions: Transaction[],
+  thresholds: DuplicateThresholds
+): DuplicateScanIndex {
+  const prepared = transactions.map((txn, index) => ({
+    txn,
+    index,
+    time: timeOf(txn.date),
+    amount: toDecimal(txn.amount).toNumber(),
+    desc: txn.description.toLowerCase().trim(),
+  }));
+  const byTime = prepared
+    .filter(p => !Number.isNaN(p.time))
+    .sort((a, b) => a.time - b.time);
+  return {
+    prepared,
+    byTime,
+    thresholds,
+    datePruned: thresholds.similarityThreshold > MAX_SCORE_WITHOUT_DATE,
+  };
+}
+
+/** First position in byTime whose time is >= target. */
+function lowerBound(byTime: PreparedTransaction[], target: number): number {
+  let lo = 0;
+  let hi = byTime.length;
+  while (lo < hi) {
+    const mid = (lo + hi) >>> 1;
+    if (byTime[mid].time < target) lo = mid + 1;
+    else hi = mid;
+  }
+  return lo;
+}
+
+function candidatesFor(index: DuplicateScanIndex, time: number): PreparedTransaction[] {
+  if (!index.datePruned) {
+    return index.prepared;
+  }
+  if (Number.isNaN(time)) {
+    // An invalid date always scores 0 on the date axis, which cannot reach a
+    // date-pruned threshold — no candidates can match.
+    return [];
+  }
+  const windowMs = index.thresholds.dateThreshold * DAY_MS;
+  const lo = lowerBound(index.byTime, time - windowMs);
+  const out: PreparedTransaction[] = [];
+  for (let i = lo; i < index.byTime.length && index.byTime[i].time <= time + windowMs; i++) {
+    out.push(index.byTime[i]);
+  }
+  return out;
+}
+
+/**
+ * Total score if the pair meets the threshold, else null. Computes the cheap
+ * date/amount scores first and only runs the Levenshtein when a perfect (or
+ * length-bounded) description score could still reach the threshold.
+ */
+function matchScore(
+  time: number,
+  amount: number,
+  desc: string,
+  other: PreparedTransaction,
+  thresholds: DuplicateThresholds
+): number | null {
+  const threshold = thresholds.similarityThreshold;
+  const dateScore = dateScoreOf(time, other.time, thresholds.dateThreshold);
+  const amountScore = amountScoreOf(amount, other.amount, thresholds.amountThreshold);
+  // Same association as the original total: (date*0.3 + amount*0.4) + desc*0.3
+  const partial = dateScore * 0.3 + amountScore * 0.4;
+  // NaN partials fail this check, matching the original "NaN never matches".
+  if (!(partial + MAX_DESCRIPTION_CONTRIBUTION >= threshold)) {
+    return null;
+  }
+
+  let descriptionScore: number;
+  if (desc === other.desc) {
+    descriptionScore = 100;
+  } else {
+    // Edit distance is at least the length difference, so this bounds the
+    // description score from above without running the DP.
+    const maxLen = Math.max(desc.length, other.desc.length);
+    const descriptionBound = Math.round((1 - Math.abs(desc.length - other.desc.length) / maxLen) * 100);
+    if (partial + descriptionBound * 0.3 < threshold) {
+      return null;
+    }
+    descriptionScore = normalizedStringSimilarity(desc, other.desc);
+  }
+
+  const totalScore = partial + descriptionScore * 0.3;
+  return totalScore >= threshold ? totalScore : null;
+}
+
+/**
+ * Match one candidate transaction (e.g. an imported row) against the indexed
+ * set. Matches are returned in the indexed transactions' original order;
+ * confidence is the best match's total score (0 when there are no matches).
+ */
+export function findDuplicateMatches(
+  index: DuplicateScanIndex,
+  candidate: Transaction
+): { matches: Transaction[]; confidence: number } {
+  const time = timeOf(candidate.date);
+  const amount = toDecimal(candidate.amount).toNumber();
+  const desc = candidate.description.toLowerCase().trim();
+
+  const found: Array<{ entry: PreparedTransaction; score: number }> = [];
+  for (const other of candidatesFor(index, time)) {
+    const score = matchScore(time, amount, desc, other, index.thresholds);
+    if (score !== null) {
+      found.push({ entry: other, score });
+    }
+  }
+  found.sort((a, b) => a.entry.index - b.entry.index);
+  return {
+    matches: found.map(f => f.entry.txn),
+    confidence: found.length > 0 ? Math.max(...found.map(f => f.score)) : 0,
+  };
+}
+
+/**
+ * Group duplicate transactions. Semantics match the original pairwise sweep
+ * exactly: transactions are seeded in array order, a seed's group contains
+ * every not-yet-claimed transaction that meets the threshold against the seed
+ * (in array order), claimed transactions never join another group, and the
+ * group's confidence is its best match score.
+ */
+export function findDuplicateGroups(
+  transactions: Transaction[],
+  thresholds: DuplicateThresholds
+): DuplicateGroup[] {
+  const index = buildDuplicateScanIndex(transactions, thresholds);
+  const groups: DuplicateGroup[] = [];
+  const processed = new Set<string>();
+
+  for (const seed of index.prepared) {
+    if (processed.has(seed.txn.id)) continue;
+
+    const matches: Array<{ entry: PreparedTransaction; score: number }> = [];
+    for (const other of candidatesFor(index, seed.time)) {
+      if (other.index === seed.index || processed.has(other.txn.id)) continue;
+      const score = matchScore(seed.time, seed.amount, seed.desc, other, thresholds);
+      if (score !== null) {
+        matches.push({ entry: other, score });
+      }
+    }
+
+    if (matches.length > 0) {
+      matches.sort((a, b) => a.entry.index - b.entry.index);
+      for (const m of matches) processed.add(m.entry.txn.id);
+      processed.add(seed.txn.id);
+      groups.push({
+        original: seed.txn,
+        potential: matches.map(m => m.entry.txn),
+        confidence: Math.max(...matches.map(m => m.score)),
+      });
+    }
+  }
+
+  return groups;
+}


### PR DESCRIPTION
## What & why

Opening **Duplicate Detection** ran an O(n²) pairwise sweep with a Levenshtein computation per pair — **~128M string comparisons at ~16k transactions**, freezing the main thread (#86 stopped it running on every Data Management visit; this fixes the scan itself). The algorithm now lives in `src/utils/duplicateScan.ts` and is index-driven:

- **Above a 70% similarity threshold** (the 80% default): a match mathematically *requires* dates within the date threshold (amount 40% + description 30% max out at 70), so candidates come from a **date-sorted index** and each transaction compares only against its date-window neighbours — ~O(n log n) on real data.
- **At thresholds ≤ 70%** (slider goes down to 50): falls back to all pairs, but computes the cheap date/amount scores first and **skips the Levenshtein** whenever even a perfect (or length-bounded — edit distance ≥ length difference) description score couldn't reach the threshold.
- **Group semantics reproduced exactly** — seed order, claim-once, member order, confidence — proven by parity tests against a verbatim port of the original loop across six threshold/date/amount combinations (including the float-exact 70/71 boundary and `dateThreshold: 0` NaN case).

## One deliberate scoring fix

The original divided the amount difference by the **signed** larger amount, so two negative amounts (−5 vs −10) scored **>100% "similarity"** and auto-matched as duplicates regardless of date or description — garbage groups on real signed data. The denominator is now the larger **absolute** amount (score bounded 0–100 — which is also what makes the date-window pruning mathematically sound). Regression-tested; visible in the demo: a −£261 vs −£416 pair now scores a sane 80%, not 160%.

## Also
- The **import duplicate check** (`checkNewTransactions`) reuses the same index, replacing its own m×n full scan.
- `input[type="range"]` added to the `accent-color` rule — the similarity slider was still rendering OS-accent green (same root cause as #81).

## Verification
- **20 new tests** (`duplicateScan.test.ts`): threshold behaviours, negative-amount regression, uniqueness of group membership, parity ×6, import-match parity, and a **12,000-row scale test** — whole suite runs in ~160ms (the old sweep took minutes on that input; the 5s test timeout is the structural guard against a pairwise regression).
- Existing `DuplicateDetection.test.tsx` (20 tests) passes unchanged.
- Live (demo): modal opens instantly, "Found 6 duplicate groups", sane scores, no console errors.
- `typecheck:strict` ✅ · `lint` ✅ · `test:unit` ✅ (2902) · `build` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)