### PR TITLE
fix(dark-mode): remove legacy remaps that turned blue accents near-black

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -265,17 +265,12 @@ input[type="range"] {
   border-color: var(--color-light-accent) !important;
 }
 
-.dark .dark\:text-blue-400 {
-  color: var(--color-primary) !important;
-}
-
-.dark .dark\:border-blue-400 {
-  border-color: var(--color-primary) !important;
-}
-
-.dark .dark\:bg-blue-600 {
-  background-color: var(--color-primary) !important;
-}
+/* NOTE: this file used to remap dark:text-blue-400 / dark:border-blue-400 /
+   dark:bg-blue-600 to var(--color-primary) with !important. --color-primary is
+   near-black navy (#1a2332), so in dark mode every one of those utilities
+   rendered as unreadable near-black on dark surfaces — and the green→blue
+   accent sweep put dark:text-blue-400 on ~176 elements. The remaps are gone:
+   Tailwind's own dark-mode blues (readable on dark) now apply. */
 
 /* Smooth transitions - excluding font properties */
 * {


### PR DESCRIPTION
## Found during the post-sweep audit

`index.css` carried three legacy rules remapping `dark:text-blue-400` / `dark:border-blue-400` / `dark:bg-blue-600` to `var(--color-primary)` with `!important`. `--color-primary` is near-black navy (**#1a2332**) — so in **dark mode**, every element using those utilities rendered near-black on dark surfaces.

The green→blue accent sweep (#76–#84) put `dark:text-blue-400` on **~176 elements across 82 files**, turning a latent quirk into an app-wide dark-mode regression. It was invisible in light mode (where all review happened), which is why it slipped through.

## Fix
Delete the three remaps so Tailwind's real dark-mode blues apply.

## Verification (live, `.dark` forced in the preview)
- Probe: `dark:text-blue-400` computed **rgb(26,35,50)** before → **rgb(96,165,250)** after; remap rules confirmed gone from served CSS.
- Real page (Settings → App): the 3 affected elements (globe icon, "Show Live Preview" link, calendar icon) now render clearly on dark.
- CSS-only change · `typecheck:strict` ✅ · `lint` ✅ · `test:unit` ✅ (2902) · `build` ✅

Part of tonight's audit — full findings report to follow in chat.

🤖 Generated with [Claude Code](https://claude.com/claude-code)