### PR TITLE
feat(register): tie-break equal sort values by date (oldest first)

### DIFF
--- a/src/utils/transactionSort.test.ts
+++ b/src/utils/transactionSort.test.ts
@@ -71,4 +71,35 @@ describe('compareTransactions', () => {
     expect(transactionSortValue(t({ amount: -5 }), 'payment', cats)).toBe(-5);
     expect(transactionSortValue(t({ category: 'c-food' }), 'category', cats)).toBe('food');
   });
+
+  it('tie-breaks equal non-date values chronologically (oldest first)', () => {
+    // Three O2 rows + one Amazon row: description sort groups the O2 rows and
+    // orders them by date within the group, regardless of input order.
+    const list = [
+      t({ id: 'o2-new', description: 'O2', date: new Date('2024-03-10') }),
+      t({ id: 'amazon', description: 'Amazon', date: new Date('2024-02-01') }),
+      t({ id: 'o2-old', description: 'O2', date: new Date('2024-01-05') }),
+      t({ id: 'o2-mid', description: 'O2', date: new Date('2024-02-15') })
+    ];
+    expect(orderedIds(list, 'description', 'asc')).toEqual(['amazon', 'o2-old', 'o2-mid', 'o2-new']);
+    // desc flips the groups, not the within-group date order
+    expect(orderedIds(list, 'description', 'desc')).toEqual(['o2-old', 'o2-mid', 'o2-new', 'amazon']);
+  });
+
+  it('tie-breaks equal amounts chronologically too', () => {
+    const list = [
+      t({ id: 'b', amount: -10, date: new Date('2024-02-01') }),
+      t({ id: 'a', amount: -10, date: new Date('2024-01-01') }),
+      t({ id: 'c', amount: -99, date: new Date('2024-03-01') })
+    ];
+    expect(orderedIds(list, 'amount', 'asc')).toEqual(['c', 'a', 'b']); // -99, then the -10s oldest-first
+  });
+
+  it('uses the same-day type order as the final tie-break', () => {
+    const list = [
+      t({ id: 'exp', description: 'O2', date: new Date('2024-01-05'), type: 'expense' }),
+      t({ id: 'inc', description: 'O2', date: new Date('2024-01-05'), type: 'income' })
+    ];
+    expect(orderedIds(list, 'description', 'asc')).toEqual(['inc', 'exp']);
+  });
 });

--- a/src/utils/transactionSort.ts
+++ b/src/utils/transactionSort.ts
@@ -64,5 +64,13 @@ export function compareTransactions(
   const bValue = transactionSortValue(b, field, categories);
   if (aValue < bValue) return direction === 'asc' ? -1 : 1;
   if (aValue > bValue) return direction === 'asc' ? 1 : -1;
-  return 0;
+
+  // Equal on the chosen column: tie-break chronologically (oldest first, then
+  // the same-day type order the Date sort uses). Sorting by Description
+  // therefore lists a payee's rows together in date order instead of leaving
+  // their relative order to chance.
+  const dateA = new Date(a.date).getTime();
+  const dateB = new Date(b.date).getTime();
+  if (dateA !== dateB) return dateA - dateB;
+  return (TYPE_ORDER[a.type] ?? 0) - (TYPE_ORDER[b.type] ?? 0);
 }


### PR DESCRIPTION
Sorting the register by a non-date column (Description, Payment, Category…) left equal rows in **arbitrary relative order**. Now equal values tie-break **chronologically (oldest first)**, then by the same-day type order the Date sort already uses.

Concretely: sort by Description and all your "O2" rows sit together, oldest at the top — the batch-categorisation flow. (Bonus that makes it even faster: payee memory doesn't care about position — categorise **any one** O2 row and every other *uncategorised* O2 row in the account fills in instantly.)

- Pure comparator change in `transactionSort.ts` (used by the account register).
- +3 tests: description grouping asc/desc, amount ties, same-day type tie-break.
- `typecheck:strict` ✅ · `lint` ✅ · `test:unit` ✅ (2905) · `build` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)