### PR TITLE
feat(accounts): rename accounts from Account Settings

### DIFF
--- a/src/components/AccountSettingsModal.test.tsx
+++ b/src/components/AccountSettingsModal.test.tsx
@@ -75,9 +75,9 @@ describe('AccountSettingsModal', () => {
       expect(screen.getByText('Account Settings')).toBeInTheDocument();
     });
 
-    it('displays account name', () => {
+    it('displays the account name in an editable field', () => {
       render(<AccountSettingsModal {...defaultProps} />);
-      expect(screen.getByText('Test Account')).toBeInTheDocument();
+      expect(screen.getByLabelText('Account name')).toHaveValue('Test Account');
     });
 
     it('renders all form fields', () => {
@@ -297,6 +297,7 @@ describe('AccountSettingsModal', () => {
       
       await waitFor(() => {
         expect(onSave).toHaveBeenCalledWith('acc1', {
+          name: 'Test Account',
           type: 'savings',
           institution: 'New Bank',
           notes: 'Test notes',
@@ -343,15 +344,42 @@ describe('AccountSettingsModal', () => {
     it('parses opening balance as float', async () => {
       const onSave = vi.fn();
       render(<AccountSettingsModal {...defaultProps} onSave={onSave} />);
-      
+
       fireEvent.change(screen.getByLabelText('Opening balance amount'), { target: { value: '123.45' } });
       fireEvent.click(screen.getByText('Save Changes'));
-      
+
       await waitFor(() => {
         expect(onSave).toHaveBeenCalledWith('acc1', expect.objectContaining({
           openingBalance: 123.45
         }));
       });
+    });
+
+    it('saves a renamed account (trimmed)', async () => {
+      const onSave = vi.fn();
+      render(<AccountSettingsModal {...defaultProps} onSave={onSave} />);
+
+      fireEvent.change(screen.getByLabelText('Account name'), { target: { value: '  HSBC Current — Steve  ' } });
+      fireEvent.click(screen.getByText('Save Changes'));
+
+      await waitFor(() => {
+        expect(onSave).toHaveBeenCalledWith('acc1', expect.objectContaining({
+          name: 'HSBC Current — Steve'
+        }));
+      });
+    });
+
+    it('never blanks the name: an emptied field is omitted from the update', async () => {
+      const onSave = vi.fn();
+      render(<AccountSettingsModal {...defaultProps} onSave={onSave} />);
+
+      fireEvent.change(screen.getByLabelText('Account name'), { target: { value: '   ' } });
+      fireEvent.click(screen.getByText('Save Changes'));
+
+      await waitFor(() => {
+        expect(onSave).toHaveBeenCalledTimes(1);
+      });
+      expect(onSave.mock.calls[0][1]).not.toHaveProperty('name');
     });
 
     it('includes opening balance when provided', async () => {

--- a/src/components/AccountSettingsModal.tsx
+++ b/src/components/AccountSettingsModal.tsx
@@ -20,6 +20,7 @@ interface AccountSettingsModalProps {
 }
 
 interface FormData {
+  name: string;
   type: Account['type'];
   openingBalance: string;
   openingBalanceDate: string;
@@ -50,6 +51,7 @@ export default function AccountSettingsModal({
 }: AccountSettingsModalProps) {
   const { formData, updateField, handleSubmit, setFormData, errors, isSubmitting } = useModalForm<FormData>(
     {
+      name: '',
       type: 'current',
       openingBalance: '',
       openingBalanceDate: '',
@@ -68,6 +70,10 @@ export default function AccountSettingsModal({
         const updates: Partial<Account> = {
           type: data.type,
           institution: data.institution || undefined,
+          // Display name only — bank-feed links key on connection/account ids
+          // (external_account_name is stored separately), so renaming is safe.
+          // Never blank a name: an empty field leaves the current name as-is.
+          ...(data.name.trim() !== '' ? { name: data.name.trim() } : {}),
           notes: data.notes || undefined,
           sortCode: data.sortCode || undefined,
           accountNumber: data.accountNumber || undefined,
@@ -92,6 +98,7 @@ export default function AccountSettingsModal({
   useEffect(() => {
     if (account) {
       setFormData({
+        name: account.name || '',
         type: account.type || 'current',
         openingBalance: account.openingBalance != null ? account.openingBalance.toFixed(2) : '',
         openingBalanceDate: account.openingBalanceDate
@@ -130,9 +137,26 @@ export default function AccountSettingsModal({
     <Modal isOpen={isOpen} onClose={onClose} title="Account Settings" size="md">
       <form onSubmit={handleSubmit}>
         <ModalBody className="space-y-4">
-          <p className="text-sm text-gray-500 dark:text-gray-400 -mt-2 mb-4">
-            {account.name}
-          </p>
+          {/* Account Name */}
+          <div>
+            <label htmlFor="account-name" className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+              Account Name
+            </label>
+            <input
+              id="account-name"
+              type="text"
+              required
+              value={formData.name}
+              onChange={(e) => updateField('name', e.target.value)}
+              className="w-full px-3 py-2 bg-white dark:bg-gray-800 border border-gray-300/50 dark:border-gray-600/50 rounded-xl focus:outline-none focus:ring-2 focus:ring-primary focus:border-transparent dark:text-white"
+              aria-label="Account name"
+            />
+            <p className="mt-1 text-xs text-gray-500 dark:text-gray-400">
+              Display name only — renaming never affects bank feed links, which
+              are matched on the bank's own account identifiers
+            </p>
+          </div>
+
           {/* Account Type */}
           <div>
             <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">

--- a/src/components/__tests__/AccountSettingsModal.test.tsx
+++ b/src/components/__tests__/AccountSettingsModal.test.tsx
@@ -66,7 +66,7 @@ describe('AccountSettingsModal', () => {
       render(<AccountSettingsModal {...defaultProps} />);
       
       expect(screen.getByText('Account Settings')).toBeInTheDocument();
-      expect(screen.getByText('Test Account')).toBeInTheDocument();
+      expect(screen.getByLabelText('Account name')).toHaveValue('Test Account');
       expect(screen.getByText('Account Type')).toBeInTheDocument();
       expect(screen.getByLabelText('Opening balance amount')).toBeInTheDocument();
     });


### PR DESCRIPTION
Account names (an imported **GREEN S A**, or manually created Amex/Mortgage accounts) could never be changed — the settings modal showed the name as static text. This adds an editable, required **Account Name** field at the top of Account Settings.

**Safe for bank feeds** — exactly as you assumed: feed links are matched on the bank's own account identifiers (the link table stores `external_account_name` separately for reference), never on the display name. The accounts page already refreshes transfer categories on rename (a DB trigger renames the account's "To/From …" category to match), so pickers stay in sync too.

Guard rails:
- Name is trimmed; a blank/whitespace value is **omitted** from the update so a name can never be accidentally blanked (field is also `required`).

Tests: rename payload (trimmed) + blank-name omission + updated display assertions (46 pass across both modal test files). Verified live in demo. `typecheck:strict` ✅ · `lint` ✅ · `test:unit` ✅ (2904) · `build` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)