### PR TITLE
fix(a11y): one coherent focus-indication strategy

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -2,13 +2,14 @@
 @tailwind components;
 @tailwind utilities;
 
-/* Remove all blue focus outlines globally */
-*:focus,
-*:focus-visible,
-*:focus-within {
-  outline: none !important;
-  box-shadow: none !important;
-}
+/* Focus indication strategy: accessibility-colors.css is the single source of
+   truth — it draws a 2px accent outline on :focus-visible only (keyboard
+   focus; text inputs on any focus, per browser heuristics). The old rule here
+   nuked outline AND box-shadow on every :focus/:focus-within with !important,
+   which killed all Tailwind focus rings, stripped shadows from focused
+   containers, and forced components into !important arms races to show any
+   focus state at all. Mouse clicks show no outline (they don't match
+   :focus-visible), so nothing "blue flashes" on ordinary clicking. */
 
 /* Pull to Refresh Styles */
 .pull-to-refresh {
@@ -123,8 +124,10 @@ input[type="range"] {
   --color-income: #0d9f6f;
   --color-expense: #d94052;
   --color-accent: #d4a843;
-  --focus-ring-color: #2d3a4d;
-  --color-border-focus: #2d3a4d;
+  /* Keyboard-focus outline colour (consumed by accessibility-colors.css).
+     The accent blue — the old navy #2d3a4d was near-invisible in dark mode. */
+  --focus-ring-color: #2563eb;
+  --color-border-focus: #2563eb;
 }
 
 /* Default Theme (Wealth) */


### PR DESCRIPTION
Audit item 2, approved this morning. The focus CSS was three layers at war:

1. `index.css` **nuked** every `outline` + `box-shadow` on `:focus/:focus-visible/:focus-within` with `!important` — killing all Tailwind focus rings and stripping shadows from focused containers;
2. `accessibility-colors.css` re-added outlines with its own `!important` (winning on specificity) — in near-invisible **navy**;
3. components out-gunned both with even more specific `!important` utilities (#85).

## Now
- **`accessibility-colors.css` is the single source of focus indication**: a 2px outline on `:focus-visible` (keyboard focus; text inputs on any focus, per browser heuristics).
- **`--focus-ring-color` → accent blue `#2563eb`** (the old `#2d3a4d` was near-black in dark mode).
- The global nuke is **deleted**, so focus rings and container shadows behave as their authors wrote them (e.g. the category search box keeps its raised shadow while focused).

## What you'll see
- Tabbing around: consistent **blue** focus outlines (previously navy-on-navy).
- Clicking into a **text field**: a neat 2px blue outline while active — the standard professional pattern (this was the "black rectangle" from before, now in the right colour everywhere). Easy to soften to a border-only treatment if you'd prefer — say the word.
- Ordinary mouse clicks on buttons/links: nothing (they don't match `:focus-visible`).

## Verification
- Preview: nuke rule absent from served CSS; `--focus-ring-color` resolves `#2563eb`; `shadow-sm` container keeps its shadow with a focused child (previously stripped).
- CSS-only · `typecheck:strict` ✅ · `lint` ✅ · `test:unit` ✅ (2902) · `build` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)