### PR TITLE
feat(settings): retire the colour-theme variants — one brand, light & dark

### DIFF
--- a/src/contexts/PreferencesContext.test.tsx
+++ b/src/contexts/PreferencesContext.test.tsx
@@ -31,7 +31,6 @@ describe('PreferencesContext', () => {
     expect(result.current.compactView).toBe(true); // Default is true (compact view)
     expect(result.current.currency).toBe('GBP');
     expect(result.current.theme).toBe('light');
-    expect(result.current.colorTheme).toBe('blue');
     expect(result.current.firstName).toBe('');
   });
 
@@ -44,8 +43,6 @@ describe('PreferencesContext', () => {
           return 'USD';
         case 'money_management_theme':
           return 'dark';
-        case 'money_management_color_theme':
-          return 'green';
         case 'money_management_first_name':
           return 'John';
         default:
@@ -60,7 +57,6 @@ describe('PreferencesContext', () => {
     expect(result.current.compactView).toBe(true);
     expect(result.current.currency).toBe('USD');
     expect(result.current.theme).toBe('dark');
-    expect(result.current.colorTheme).toBe('green');
     expect(result.current.firstName).toBe('John');
   });
 

--- a/src/contexts/PreferencesContext.tsx
+++ b/src/contexts/PreferencesContext.tsx
@@ -10,8 +10,6 @@ interface PreferencesContextType {
   theme: 'light' | 'dark' | 'auto' | 'scheduled';
   setTheme: (value: 'light' | 'dark' | 'auto' | 'scheduled') => void;
   actualTheme: 'light' | 'dark';
-  colorTheme: 'blue' | 'green' | 'red' | 'pink';
-  setColorTheme: (value: 'blue' | 'green' | 'red' | 'pink') => void;
   firstName: string;
   setFirstName: (value: string) => void;
   // Theme scheduling
@@ -88,20 +86,6 @@ export function PreferencesProvider({ children }: { children: ReactNode }): Reac
     } catch (error) {
       console.error('Error reading theme from localStorage:', error);
       return 'light';
-    }
-  });
-
-  const [colorTheme, setColorTheme] = useState<'blue' | 'green' | 'red' | 'pink'>((): 'blue' | 'green' | 'red' | 'pink' => {
-    try {
-      const saved = localStorage.getItem('money_management_color_theme');
-      if (!saved || !['blue', 'green', 'red', 'pink'].includes(saved)) {
-        localStorage.setItem('money_management_color_theme', 'blue');
-        return 'blue';
-      }
-      return saved as 'blue' | 'green' | 'red' | 'pink';
-    } catch (error) {
-      console.error('Error reading colorTheme from localStorage:', error);
-      return 'blue';
     }
   });
 
@@ -342,20 +326,20 @@ export function PreferencesProvider({ children }: { children: ReactNode }): Reac
     return (): void => clearTimeout(timer);
   }, [actualTheme]);
 
-  // Apply color theme class
+  // Colour-theme variants were retired 2026-07-10 — one brand scheme (:root)
+  // plus light/dark. Clear any theme-* class a previous session applied and
+  // drop the stored preference.
   useEffect(() => {
     const root = document.documentElement;
-    
-    // Remove all theme classes
-    const themeClasses = ['theme-blue', 'theme-green', 'theme-red', 'theme-pink'];
-    
-    themeClasses.forEach(className => {
+    ['theme-blue', 'theme-green', 'theme-red', 'theme-pink'].forEach(className => {
       root.classList.remove(className);
     });
-    
-    // Add the selected theme class
-    root.classList.add(`theme-${colorTheme}`);
-  }, [colorTheme]);
+    try {
+      localStorage.removeItem('money_management_color_theme');
+    } catch {
+      // storage may be unavailable; nothing to clean up
+    }
+  }, []);
 
   // Consolidate all localStorage updates into a single effect for better performance
   useEffect(() => {
@@ -363,7 +347,6 @@ export function PreferencesProvider({ children }: { children: ReactNode }): Reac
       localStorage.setItem('money_management_compact_view', compactView.toString());
       localStorage.setItem('money_management_currency', currency);
       localStorage.setItem('money_management_theme', theme);
-      localStorage.setItem('money_management_color_theme', colorTheme);
       localStorage.setItem('money_management_first_name', firstName);
       localStorage.setItem('money_management_show_budget', showBudget.toString());
       localStorage.setItem('money_management_show_goals', showGoals.toString());
@@ -385,7 +368,7 @@ export function PreferencesProvider({ children }: { children: ReactNode }): Reac
     const timeoutId = setTimeout(savePreferences, 300);
     
     return (): void => clearTimeout(timeoutId);
-  }, [compactView, currency, theme, colorTheme, firstName, showBudget, showGoals, showAnalytics, showInvestments, showEnhancedInvestments, showAIAnalytics, showTaxPlanning, showHousehold, showBusinessFeatures, showFinancialPlanning, showDataIntelligence, showSummaries, themeSchedule, enableGoalCelebrations]);
+  }, [compactView, currency, theme, firstName, showBudget, showGoals, showAnalytics, showInvestments, showEnhancedInvestments, showAIAnalytics, showTaxPlanning, showHousehold, showBusinessFeatures, showFinancialPlanning, showDataIntelligence, showSummaries, themeSchedule, enableGoalCelebrations]);
 
   return (
     <PreferencesContext.Provider value={{
@@ -396,8 +379,6 @@ export function PreferencesProvider({ children }: { children: ReactNode }): Reac
       theme,
       setTheme,
       actualTheme,
-      colorTheme,
-      setColorTheme,
       firstName,
       setFirstName,
       themeSchedule,

--- a/src/index.css
+++ b/src/index.css
@@ -130,54 +130,10 @@ input[type="range"] {
   --color-border-focus: #2563eb;
 }
 
-/* Default Theme (Wealth) */
-.theme-blue,
-.theme-wealth {
-  --color-primary: #1a2332;
-  --color-secondary: #2d3a4d;
-  --color-tertiary: #d4a843;
-  --color-sidebar: #1a2332;
-  --color-sidebar-active: #2d3a4d;
-  --color-sidebar-border: #2d3a4d;
-  --color-light-accent: #f1f3f7;
-  --color-dark-accent: #0f1721;
-}
-
-/* Green Theme */
-.theme-green {
-  --color-primary: #166534;
-  --color-secondary: #14532d;
-  --color-tertiary: #86efac;
-  --color-sidebar: #166534;
-  --color-sidebar-active: #1a7a3d;
-  --color-sidebar-border: #14532d;
-  --color-light-accent: #f0fdf4;
-  --color-dark-accent: #052e16;
-}
-
-/* Red Theme */
-.theme-red {
-  --color-primary: #991b1b;
-  --color-secondary: #7f1d1d;
-  --color-tertiary: #fca5a5;
-  --color-sidebar: #991b1b;
-  --color-sidebar-active: #b91c1c;
-  --color-sidebar-border: #7f1d1d;
-  --color-light-accent: #fef2f2;
-  --color-dark-accent: #450a0a;
-}
-
-/* Pink Theme */
-.theme-pink {
-  --color-primary: #9d174d;
-  --color-secondary: #831843;
-  --color-tertiary: #f9a8d4;
-  --color-sidebar: #9d174d;
-  --color-sidebar-active: #be185d;
-  --color-sidebar-border: #831843;
-  --color-light-accent: #fdf2f8;
-  --color-dark-accent: #500724;
-}
+/* The colour-theme variants (green/red/pink primary swaps) were retired
+   2026-07-10: WealthTracker has one brand identity — the navy scheme in :root
+   with the #2563eb accent — plus light/dark modes. (Both of the 2026-07-10
+   audit's colour regressions lived in theme-variant CSS.) */
 
 /* Apply primary color to common elements */
 .bg-primary {

--- a/src/pages/settings/AppSettings.tsx
+++ b/src/pages/settings/AppSettings.tsx
@@ -15,8 +15,6 @@ export default function AppSettings() {
     setFirstName,
     theme,
     setTheme,
-    colorTheme,
-    setColorTheme,
     themeSchedule,
     setThemeSchedule,
     showBudget,
@@ -65,33 +63,6 @@ export default function AppSettings() {
     { value: 'dark', label: 'Dark', icon: MoonIcon },
     { value: 'auto', label: 'Auto', icon: MonitorIcon },
     { value: 'scheduled', label: 'Scheduled', icon: ClockIcon },
-  ];
-
-  const colorThemes = [
-    { 
-      value: 'blue', 
-      label: 'Ocean Blue', 
-      colors: ['#7ba8d1', '#5a729a', '#b8d4f1'],
-      description: 'Calm and professional'
-    },
-    { 
-      value: 'green', 
-      label: 'Forest Green', 
-      colors: ['#a9d08e', '#7fa86b', '#d4e6c4'],
-      description: 'Natural and growth-focused'
-    },
-    { 
-      value: 'red', 
-      label: 'Sunset Red', 
-      colors: ['#e2a8a8', '#b88585', '#f1d4d4'],
-      description: 'Warm and energetic'
-    },
-    { 
-      value: 'pink', 
-      label: 'Blossom Pink', 
-      colors: ['#e2a8d4', '#b885a5', '#f1d4e8'],
-      description: 'Creative and elegant'
-    },
   ];
 
   const pageToggles = [
@@ -318,42 +289,6 @@ export default function AppSettings() {
             </div>
           </div>
         )}
-
-        {/* Color Theme Palette */}
-        <div className="mb-6">
-          <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-3">
-            Color Theme
-          </label>
-          <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
-            {colorThemes.map(({ value, label, colors, description }) => (
-              <button
-                key={value}
-                onClick={() => setColorTheme(value as 'blue' | 'green' | 'red' | 'pink')}
-                className={`flex flex-col items-start gap-3 p-4 rounded-xl border-2 transition-all hover:shadow-md ${
-                  colorTheme === value
-                    ? 'border-gray-900 dark:border-gray-100 bg-gray-50 dark:bg-gray-800 text-gray-900 dark:text-white'
-                    : 'border-gray-300 dark:border-gray-600 hover:border-gray-400 dark:hover:border-gray-500 text-gray-700 dark:text-gray-300'
-                }`}
-              >
-                <div className="flex items-center gap-3 w-full">
-                  <div className="flex gap-1">
-                    {colors.map((color, index) => (
-                      <div
-                        key={index}
-                        className="w-6 h-6 rounded-full shadow-sm"
-                        style={{ backgroundColor: color }}
-                      />
-                    ))}
-                  </div>
-                  <div className="flex-1 text-left">
-                    <div className="font-medium text-sm">{label}</div>
-                    <div className="text-xs opacity-70">{description}</div>
-                  </div>
-                </div>
-              </button>
-            ))}
-          </div>
-        </div>
       </div>
 
       {/* Page Visibility */}


### PR DESCRIPTION
Your call this morning: **"Lets just go light and dark options only."**

- **AppSettings**: the Color Theme picker (Ocean Blue / Forest Green / Sunset Red / Blossom Pink) is gone; the appearance options (Light / Dark / Auto / Scheduled) are untouched.
- **PreferencesContext**: `colorTheme` state, persistence and context API removed; a one-time cleanup strips any `theme-*` class a previous session applied and deletes the stored key — users who had green/red/pink fall back to the brand scheme automatically.
- **index.css**: all five `.theme-*` variable blocks deleted; `:root` is the single source of the brand palette (the blue block duplicated it verbatim, and the variant-only variables had no consumers).

Worth noting: both of the audit's colour regressions (the dark-mode navy remap, the invisible navy focus ring) lived in theme-variant plumbing — one identity means this class of bug can't recur.

Verified live: picker gone, appearance section intact, stale root class auto-cleaned, all styling resolves from `:root`. `typecheck:strict` ✅ · `lint` ✅ · `test:unit` ✅ (2912) · `build` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)