### PR TITLE
feat(categories): click-to-edit transactions from the category list (+ preview server config)

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -6,6 +6,12 @@
       "runtimeExecutable": "npm",
       "runtimeArgs": ["run", "dev"],
       "port": 5173
+    },
+    {
+      "name": "wealthtracker-preview",
+      "runtimeExecutable": "npm",
+      "runtimeArgs": ["run", "preview"],
+      "port": 4173
     }
   ]
 }

--- a/src/components/CategoryTransactionsModal.test.tsx
+++ b/src/components/CategoryTransactionsModal.test.tsx
@@ -1,0 +1,103 @@
+/**
+ * CategoryTransactionsModal Tests
+ * List rendering + the click-through into the transaction editor.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import CategoryTransactionsModal from './CategoryTransactionsModal';
+import type { Transaction } from '../types';
+
+// The editor's own behaviour is covered by EditTransactionModal.test.tsx;
+// here we only verify the wiring: which transaction it receives and that
+// closing it returns to the list.
+vi.mock('./EditTransactionModal', () => ({
+  default: ({ isOpen, transaction, onClose }: {
+    isOpen: boolean;
+    transaction: Transaction | null;
+    onClose: () => void;
+  }) =>
+    isOpen ? (
+      <div data-testid="edit-transaction-modal">
+        <span>Editing: {transaction?.description}</span>
+        <button onClick={onClose}>close-editor</button>
+      </div>
+    ) : null,
+}));
+
+vi.mock('../hooks/useCurrencyDecimal', () => ({
+  useCurrencyDecimal: () => ({
+    formatCurrency: (n: number) => `£${Math.abs(Number(n)).toFixed(2)}`,
+  }),
+}));
+
+const txn = (over: Partial<Transaction>): Transaction => ({
+  id: 'x',
+  date: new Date('2026-06-17'),
+  description: 'x',
+  amount: -45,
+  type: 'expense',
+  accountId: 'acc-1',
+  category: 'cat-other',
+  cleared: false,
+  ...over,
+}) as Transaction;
+
+const transactions = [
+  txn({ id: 't1', description: 'A S CAR VALET SER', amount: -45 }),
+  txn({ id: 't2', description: 'TFL CONGESTN CHRGE', amount: -12.5, date: new Date('2026-06-25') }),
+  txn({ id: 't3', description: 'SOME OTHER CATEGORY ROW', category: 'cat-elsewhere' }),
+];
+
+vi.mock('../contexts/AppContextSupabase', () => ({
+  useApp: () => ({
+    transactions,
+    accounts: [{ id: 'acc-1', name: 'HSBC Premier - Current Account' }],
+  }),
+}));
+
+function renderModal() {
+  return render(
+    <CategoryTransactionsModal
+      isOpen
+      onClose={vi.fn()}
+      categoryId="cat-other"
+      categoryName="Other Costs"
+    />
+  );
+}
+
+describe('CategoryTransactionsModal', () => {
+  it('lists only the transactions in the category, as buttons', () => {
+    renderModal();
+    expect(screen.getByText('A S CAR VALET SER')).toBeInTheDocument();
+    expect(screen.getByText('TFL CONGESTN CHRGE')).toBeInTheDocument();
+    expect(screen.queryByText('SOME OTHER CATEGORY ROW')).not.toBeInTheDocument();
+    // Rows are real buttons so keyboard users can open the editor
+    expect(
+      screen.getByRole('button', { name: /A S CAR VALET SER/ })
+    ).toBeInTheDocument();
+  });
+
+  it('opens the transaction editor for the clicked row', () => {
+    renderModal();
+    expect(screen.queryByTestId('edit-transaction-modal')).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: /TFL CONGESTN CHRGE/ }));
+
+    expect(screen.getByTestId('edit-transaction-modal')).toBeInTheDocument();
+    expect(screen.getByText('Editing: TFL CONGESTN CHRGE')).toBeInTheDocument();
+  });
+
+  it('returns to the list when the editor closes', () => {
+    renderModal();
+    fireEvent.click(screen.getByRole('button', { name: /A S CAR VALET SER/ }));
+    expect(screen.getByTestId('edit-transaction-modal')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByText('close-editor'));
+
+    expect(screen.queryByTestId('edit-transaction-modal')).not.toBeInTheDocument();
+    // List is still there behind it
+    expect(screen.getByText('A S CAR VALET SER')).toBeInTheDocument();
+  });
+});

--- a/src/components/CategoryTransactionsModal.tsx
+++ b/src/components/CategoryTransactionsModal.tsx
@@ -5,6 +5,8 @@ import { SearchIcon } from './icons/SearchIcon';
 import { XCircleIcon } from './icons/XCircleIcon';
 import { useApp } from '../contexts/AppContextSupabase';
 import { useCurrencyDecimal } from '../hooks/useCurrencyDecimal';
+import EditTransactionModal from './EditTransactionModal';
+import type { Transaction } from '../types';
 
 interface CategoryTransactionsModalProps {
   isOpen: boolean;
@@ -30,7 +32,12 @@ export default function CategoryTransactionsModal({
   const [searchQuery, setSearchQuery] = useState('');
   const [debouncedSearchQuery, setDebouncedSearchQuery] = useState('');
   const [transactionFilter, setTransactionFilter] = useState<TransactionFilter>('all');
-  
+  // Row click-through: opens the full transaction editor so rows can be
+  // re-categorised (or otherwise fixed) without leaving this list. Saving a
+  // category change recomputes categoryTransactions, so the row leaves the
+  // list on its own.
+  const [editingTransaction, setEditingTransaction] = useState<Transaction | null>(null);
+
   // Get all transactions for this category
   const categoryTransactions = useMemo(() => {
     return transactions.filter(t => t.category === categoryId);
@@ -156,6 +163,7 @@ export default function CategoryTransactionsModal({
       setTransactionFilter('all');
       setFromDate('');
       setToDate('');
+      setEditingTransaction(null);
     }
   }, [isOpen]);
   
@@ -328,36 +336,39 @@ export default function CategoryTransactionsModal({
               {filteredTransactions.map(transaction => {
                 const account = accounts.find(a => a.id === transaction.accountId);
                 return (
-                  <div
+                  <button
                     key={transaction.id}
-                    className="flex items-center justify-between p-3 bg-gray-50 dark:bg-gray-700 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-600 transition-colors"
+                    type="button"
+                    onClick={() => setEditingTransaction(transaction)}
+                    title="Edit or re-categorise this transaction"
+                    className="w-full text-left flex items-center justify-between p-3 bg-gray-50 dark:bg-gray-700 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-600 transition-colors cursor-pointer"
                   >
                     <div className="flex-1">
                       <div className="flex items-start justify-between">
                         <div>
-                          <p className="font-medium text-gray-900 dark:text-white">
+                          <span className="block font-medium text-gray-900 dark:text-white">
                             {transaction.description}
-                          </p>
-                          <p className="text-sm text-gray-500 dark:text-gray-400 mt-0.5">
+                          </span>
+                          <span className="block text-sm text-gray-500 dark:text-gray-400 mt-0.5">
                             {new Date(transaction.date).toLocaleDateString()} • {account?.name || 'Unknown Account'}
-                          </p>
+                          </span>
                         </div>
                         <div className="text-right ml-4">
-                          <p className={`font-medium ${
+                          <span className={`block font-medium ${
                             transaction.type === 'income' || (transaction.type === 'transfer' && transaction.amount > 0)
-                              ? 'text-green-600 dark:text-green-400' 
+                              ? 'text-green-600 dark:text-green-400'
                               : 'text-red-600 dark:text-red-400'
                           }`}>
                             {transaction.amount >= 0 ? '+' : '-'}
                             {formatCurrency(Math.abs(transaction.amount))}
-                          </p>
-                          <p className="text-xs text-gray-500 dark:text-gray-400 mt-0.5">
+                          </span>
+                          <span className="block text-xs text-gray-500 dark:text-gray-400 mt-0.5">
                             {transaction.type === 'transfer' ? `transfer (${transaction.amount > 0 ? 'in' : 'out'})` : transaction.type}
-                          </p>
+                          </span>
                         </div>
                       </div>
                     </div>
-                  </div>
+                  </button>
                 );
               })}
             </div>
@@ -380,6 +391,16 @@ export default function CategoryTransactionsModal({
           </div>
         </div>
       </div>
+
+      {/* Full editor for the clicked row — portals to document.body, so it
+          stacks above this modal. */}
+      {editingTransaction && (
+        <EditTransactionModal
+          isOpen
+          onClose={() => setEditingTransaction(null)}
+          transaction={editingTransaction}
+        />
+      )}
     </div>
   );
 }


### PR DESCRIPTION
Two small changes on this branch:

## 1. Click-to-edit from the category transactions list

MS Money-style tidy-up workflow: rows in the **"Transactions in \<category\>"** modal (Settings → Categories → click a category) are now clickable and open the full **Edit Transaction** editor for that row.

- The same editor as the account register: searchable grouped category picker, cross-type filing, description/date/amount edits — and the **payee-memory fan-out**, so re-filing one row also fills that payee's uncategorised rows.
- On save, the row **leaves the list automatically** (it no longer belongs to the category), the modal totals update, and the category counters in the tree behind update live.
- Rows are real `<button>`s — keyboard users can Tab + Enter into the editor.

**Verified live (demo mode)**: clicked "Uber Ride" in Entertainment (11) → re-filed to Transportation > Fuel → saved. Row left the list (expense total dropped by exactly £134.20) and the tree behind updated to Entertainment (10) / Transportation (2). No new console errors.

**Tests**: new `CategoryTransactionsModal.test.tsx` (list filtering, click-through wiring, editor close returns to list) + `EditTransactionModal` suite still green (28/28). Strict typecheck and lint clean.

Split-transaction support (multi-category with amount validation) is deliberately NOT in this PR — it needs a schema migration and split-aware aggregation, proposed separately.

## 2. Vite preview server in .claude/launch.json

Completes the committed launch configuration (previously only the dev server, added in #57): adds `wealthtracker-preview` (`npm run preview`, port 4173, serves the production build). `package.json`'s stale `sync:server` script (points at a non-existent `sync-server.js`) was deliberately skipped. Commands and ports only — no secrets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)