### PR TITLE
feat(transactions): split transactions — schema, integrity RPC, and editor (phases 1+2)

### DIFF
--- a/src/components/EditTransactionModal.test.tsx
+++ b/src/components/EditTransactionModal.test.tsx
@@ -4,7 +4,7 @@
  */
 
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { render, screen, fireEvent } from '@testing-library/react';
 import EditTransactionModal from './EditTransactionModal';
 import type { Transaction } from '../types';
 
@@ -107,6 +107,7 @@ vi.mock('../components/icons', () => ({
   ArrowRightLeftIcon: () => <div data-testid="arrow-right-left-icon">↔️</div>,
   BanknoteIcon: () => <div data-testid="banknote-icon">💵</div>,
   PaperclipIcon: () => <div data-testid="paperclip-icon">📎</div>,
+  XIcon: () => <div data-testid="x-icon">✕</div>,
 }));
 
 describe('EditTransactionModal', () => {
@@ -414,6 +415,73 @@ describe('EditTransactionModal', () => {
       );
       expect(screen.queryByRole('button', { name: 'Previous' })).toBeNull();
       expect(screen.queryByRole('button', { name: 'Save & Next' })).toBeNull();
+    });
+  });
+
+  describe('split mode', () => {
+    const splitToggle = () =>
+      screen.getByRole('checkbox', { name: /split across multiple categories/i });
+
+    it('offers the split toggle when editing a transaction', () => {
+      renderModal(true, createMockTransaction());
+      expect(splitToggle()).toBeInTheDocument();
+      expect(splitToggle()).not.toBeChecked();
+    });
+
+    it('hides the toggle for new transactions (create single first, then split)', () => {
+      renderModal(true, null);
+      expect(
+        screen.queryByRole('checkbox', { name: /split across multiple categories/i })
+      ).toBeNull();
+    });
+
+    it('seeds two split lines when toggled on', () => {
+      renderModal(true, createMockTransaction());
+      fireEvent.click(splitToggle());
+
+      expect(screen.getAllByLabelText(/split line \d+ amount/i)).toHaveLength(2);
+      expect(screen.getByRole('button', { name: /add another category/i })).toBeInTheDocument();
+      // Two empty lines have no categories yet — save is blocked and says why
+      expect(screen.getByText(/every split line needs a category/i)).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: 'Save Changes' })).toBeDisabled();
+    });
+
+    it('shows the live remainder when the totals do not match', () => {
+      renderModal(true, createMockTransaction());
+      fireEvent.click(splitToggle());
+
+      fireEvent.change(screen.getByLabelText('Split line 1 amount'), { target: { value: '60' } });
+      // Mocked form amount is '' (0), so allocating 60 leaves -60 outstanding
+      expect(screen.getByText(/remaining to allocate/i)).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: 'Save Changes' })).toBeDisabled();
+    });
+
+    it('adds and removes split lines (minimum of two enforced)', () => {
+      renderModal(true, createMockTransaction());
+      fireEvent.click(splitToggle());
+
+      // Two lines: no remove buttons (the minimum)
+      expect(screen.queryByRole('button', { name: /remove split line/i })).toBeNull();
+
+      fireEvent.click(screen.getByRole('button', { name: /add another category/i }));
+      expect(screen.getAllByLabelText(/split line \d+ amount/i)).toHaveLength(3);
+      expect(screen.getAllByRole('button', { name: /remove split line/i })).toHaveLength(3);
+
+      fireEvent.click(screen.getByRole('button', { name: 'Remove split line 3' }));
+      expect(screen.getAllByLabelText(/split line \d+ amount/i)).toHaveLength(2);
+      expect(screen.queryByRole('button', { name: /remove split line/i })).toBeNull();
+    });
+
+    it('returns to the single category picker when toggled back off', () => {
+      renderModal(true, createMockTransaction());
+      fireEvent.click(splitToggle());
+      // Split mode renders one (stubbed) selector per line — two of them —
+      // and no amount-free single picker.
+      expect(screen.getAllByTestId('category-selector')).toHaveLength(2);
+
+      fireEvent.click(splitToggle());
+      expect(screen.getAllByTestId('category-selector')).toHaveLength(1);
+      expect(screen.getByRole('button', { name: 'Save Changes' })).not.toBeDisabled();
     });
   });
 });

--- a/src/components/EditTransactionModal.tsx
+++ b/src/components/EditTransactionModal.tsx
@@ -2,8 +2,15 @@ import { useState, useEffect, useRef, useMemo } from 'react';
 import { useApp } from '../contexts/AppContextSupabase';
 import { useTransactionNotifications } from '../hooks/useTransactionNotifications';
 import { usePayeeMemory } from '../hooks/usePayeeMemory';
-import { CalendarIcon, TagIcon, FileTextIcon, CheckIcon2, LinkIcon, PlusIcon, HashIcon, WalletIcon, ArrowRightLeftIcon, BanknoteIcon, PaperclipIcon } from '../components/icons';
+import { CalendarIcon, TagIcon, FileTextIcon, CheckIcon2, LinkIcon, PlusIcon, HashIcon, WalletIcon, ArrowRightLeftIcon, BanknoteIcon, PaperclipIcon, XIcon } from '../components/icons';
 import type { Transaction } from '../types';
+import {
+  splitRemainder,
+  validateSplitDrafts,
+  signSplitAmounts,
+  displaySplitAmount,
+  type SplitLineDraft,
+} from '../utils/transactionSplits';
 import CategoryCreationModal from './CategoryCreationModal';
 import CategorySelector from './CategorySelector';
 import TagSelector from './TagSelector';
@@ -53,7 +60,7 @@ interface FormData {
 }
 
 export default function EditTransactionModal({ isOpen, onClose, transaction, defaultAccountId, onSaveAndNext, onSaveAndPrevious }: EditTransactionModalProps): React.JSX.Element {
-  const { accounts, categories, updateTransaction, deleteTransaction } = useApp();
+  const { accounts, categories, updateTransaction, deleteTransaction, getTransactionSplits, setTransactionSplits } = useApp();
   const { addTransaction } = useTransactionNotifications();
   const { propagateCategory } = usePayeeMemory();
   const logger = useMemo(() => createScopedLogger('EditTransactionModal'), []);
@@ -65,6 +72,13 @@ export default function EditTransactionModal({ isOpen, onClose, transaction, def
   // categories (e.g. file a refund — income by sign — under an expense
   // category so it nets that expense down).
   const [crossTypeCategories, setCrossTypeCategories] = useState(false);
+  // Split mode (Money-style): categorisation moves into category+amount lines
+  // that must sum exactly to the transaction amount. Amounts here live in the
+  // ENTERED domain (positive magnitudes, minus = a reducing line like
+  // cashback); signing to the DB convention happens once at save.
+  const [isSplitMode, setIsSplitMode] = useState(false);
+  const [splitLines, setSplitLines] = useState<SplitLineDraft[]>([]);
+  const [splitsLoading, setSplitsLoading] = useState(false);
   const amountInputRef = useRef<HTMLInputElement>(null);
   // Batch mode coordination: Save & Next / Previous set a direction; a
   // successful submit consumes it and suppresses the close that useModalForm
@@ -142,6 +156,16 @@ export default function EditTransactionModal({ isOpen, onClose, transaction, def
             notes: data.notes.trim() || undefined,
           });
 
+          // Split saves only exist for EDITS of income/expense rows; the rule
+          // is enforced before any write so a lopsided split never half-saves.
+          const splitting = isSplitMode && !!transaction && resolvedType !== 'transfer';
+          if (splitting) {
+            const splitError = validateSplitDrafts(data.amount, splitLines);
+            if (splitError) {
+              throw new Error(splitError);
+            }
+          }
+
           const parsedAmount = parseMoneyInput(validatedData.amount) ?? 0;
           // Sign the stored amount. Income/expense are seeded as Math.abs, so
           // re-sign by type. Transfers ENCODE DIRECTION in their sign: an edit
@@ -168,7 +192,34 @@ export default function EditTransactionModal({ isOpen, onClose, transaction, def
           // Await the writes so a failed RPC surfaces via the form's submit
           // error instead of silently closing the modal (fire-and-forget bug).
           if (transaction) {
-            await updateTransaction(transaction.id, transactionData);
+            if (splitting) {
+              // A split parent's amount/category/type are guarded by a DB
+              // trigger — only set_transaction_splits may change them. The
+              // ordinary update carries everything else; the RPC then swaps
+              // the split lines in, re-validates the sum against the entered
+              // amount server-side, and syncs amount + account balance.
+              await updateTransaction(transaction.id, {
+                date: transactionData.date,
+                description: transactionData.description,
+                accountId: transactionData.accountId,
+                tags: transactionData.tags,
+                notes: transactionData.notes,
+                cleared: transactionData.cleared,
+                reconciledWith: transactionData.reconciledWith
+              });
+              await setTransactionSplits(
+                transaction.id,
+                signSplitAmounts(splitLines, resolvedType as 'income' | 'expense'),
+                signedAmount
+              );
+            } else if (transaction.isSplit) {
+              // Un-split FIRST — while is_split the guard trigger rejects the
+              // category/amount this update carries.
+              await setTransactionSplits(transaction.id, [], null);
+              await updateTransaction(transaction.id, transactionData);
+            } else {
+              await updateTransaction(transaction.id, transactionData);
+            }
           } else {
             await addTransaction(transactionData);
           }
@@ -195,7 +246,7 @@ export default function EditTransactionModal({ isOpen, onClose, transaction, def
           // correction) deliberately do NOT teach payee memory — a mixed-flow
           // payee like PayPal must not get all its incoming money stamped with
           // an expense category.
-          if (resolvedType !== 'transfer' && resolvedCategory && !crossTypeCategories &&
+          if (!splitting && resolvedType !== 'transfer' && resolvedCategory && !crossTypeCategories &&
               resolvedCategory !== transaction?.category) {
             await propagateCategory({
               accountId: validatedData.accountId,
@@ -351,6 +402,73 @@ export default function EditTransactionModal({ isOpen, onClose, transaction, def
     setShowDeleteConfirm(false);
   }, [transaction, accounts, categories, setFormData, defaultAccountId]);
 
+  // Load an already-split transaction's lines into the editor (stored signed
+  // amounts convert back to the entered domain). Non-split rows reset the
+  // split state so batch mode (Save & Next) never leaks lines between rows.
+  useEffect(() => {
+    let cancelled = false;
+    if (transaction?.isSplit) {
+      setIsSplitMode(true);
+      setSplitsLoading(true);
+      getTransactionSplits(transaction.id)
+        .then(splits => {
+          if (cancelled) return;
+          const direction = transaction.type === 'income' ? 'income' : 'expense';
+          setSplitLines(splits.map(s => ({
+            category: s.category,
+            amount: displaySplitAmount(s.amount, direction),
+            ...(s.memo ? { memo: s.memo } : {}),
+          })));
+        })
+        .catch(error => {
+          if (!cancelled) {
+            logger.error('Failed to load transaction splits', error as Error);
+          }
+        })
+        .finally(() => {
+          if (!cancelled) {
+            setSplitsLoading(false);
+          }
+        });
+    } else {
+      setIsSplitMode(false);
+      setSplitLines([]);
+      setSplitsLoading(false);
+    }
+    return () => {
+      cancelled = true;
+    };
+  }, [transaction, getTransactionSplits, logger]);
+
+  const handleSplitToggle = (checked: boolean): void => {
+    setIsSplitMode(checked);
+    if (checked && splitLines.length === 0) {
+      // Seed with the current single category carrying the full amount, plus
+      // one empty line to move part of it into.
+      setSplitLines([
+        { category: formData.category, amount: formData.amount },
+        { category: '', amount: '' },
+      ]);
+    }
+  };
+
+  const updateSplitLine = (index: number, patch: Partial<SplitLineDraft>): void => {
+    setSplitLines(prev => prev.map((line, i) => (i === index ? { ...line, ...patch } : line)));
+  };
+
+  const addSplitLine = (): void => {
+    setSplitLines(prev => [...prev, { category: '', amount: '' }]);
+  };
+
+  const removeSplitLine = (index: number): void => {
+    setSplitLines(prev => prev.filter((_, i) => i !== index));
+  };
+
+  // Save is blocked while the split doesn't balance; the remainder line
+  // doubles as the explanation.
+  const splitActive = isSplitMode && !!transaction && formData.type !== 'transfer';
+  const splitValidationMessage = splitActive ? validateSplitDrafts(formData.amount, splitLines) : null;
+  const splitRemaining = splitActive ? splitRemainder(formData.amount, splitLines) : null;
 
   const handleDelete = () => {
     if (!transaction) return;
@@ -425,6 +543,11 @@ export default function EditTransactionModal({ isOpen, onClose, transaction, def
               <div className="flex gap-1 items-center h-[42px] bg-gray-100 dark:bg-gray-700 rounded-lg p-1">
                 {(['income', 'expense', 'transfer'] as const).map((t) => {
                   const isActive = formData.type === t;
+                  // A split transaction's type is locked by the DB guard
+                  // (its sign convention is baked into the split lines) and
+                  // transfers cannot be split at all.
+                  const lockedBySplit = isSplitMode && !isActive &&
+                    (t === 'transfer' || transaction?.isSplit === true);
                   const colors = {
                     income: isActive ? 'bg-white dark:bg-gray-600 text-green-600 dark:text-green-400 shadow-sm' : 'text-gray-500 dark:text-gray-400 hover:text-green-600',
                     expense: isActive ? 'bg-white dark:bg-gray-600 text-red-600 dark:text-red-400 shadow-sm' : 'text-gray-500 dark:text-gray-400 hover:text-red-600',
@@ -434,12 +557,18 @@ export default function EditTransactionModal({ isOpen, onClose, transaction, def
                     <button
                       key={t}
                       type="button"
+                      disabled={lockedBySplit}
+                      title={lockedBySplit
+                        ? (t === 'transfer'
+                          ? 'Transfers cannot be split — untick the split option first'
+                          : 'Remove the split before changing the transaction type')
+                        : undefined}
                       onClick={() => {
                         updateField('type', t);
                         updateField('category', '');
                         setCrossTypeCategories(false);
                       }}
-                      className={`flex-1 px-4 py-1.5 rounded-md text-sm font-medium transition-all ${colors[t]}`}
+                      className={`flex-1 px-4 py-1.5 rounded-md text-sm font-medium transition-all disabled:opacity-40 disabled:cursor-not-allowed ${colors[t]}`}
                     >
                       {t.charAt(0).toUpperCase() + t.slice(1)}
                     </button>
@@ -520,7 +649,7 @@ export default function EditTransactionModal({ isOpen, onClose, transaction, def
               <div className="flex justify-between items-center mb-1">
                 <label className="flex items-center gap-2 text-sm font-medium text-gray-700 dark:text-gray-300">
                   <TagIcon size={16} />
-                  {formData.type === 'transfer' ? 'Transfer To' : 'Category'}
+                  {formData.type === 'transfer' ? 'Transfer To' : splitActive ? 'Split Categories' : 'Category'}
                 </label>
                 {formData.type !== 'transfer' && (
                   <button
@@ -533,6 +662,19 @@ export default function EditTransactionModal({ isOpen, onClose, transaction, def
                   </button>
                 )}
               </div>
+              {/* Split toggle — edits of income/expense rows only (a NEW row
+                  is added single-category first, then split; transfers encode
+                  their target in the category and cannot split). */}
+              {transaction && formData.type !== 'transfer' && (
+                <label className="mb-2 flex items-center gap-2 text-sm text-gray-700 dark:text-gray-300 cursor-pointer">
+                  <input
+                    type="checkbox"
+                    checked={isSplitMode}
+                    onChange={(e) => handleSplitToggle(e.target.checked)}
+                  />
+                  <span>Split across multiple categories</span>
+                </label>
+              )}
               {/* Category is deliberately optional for income/expense — an
                   uncategorised transaction sits in the virtual "Uncategorised"
                   bucket. Transfers still require their target account. */}
@@ -549,6 +691,92 @@ export default function EditTransactionModal({ isOpen, onClose, transaction, def
                     <option key={acct.id} value={acct.id}>{acct.name}</option>
                   ))}
                 </select>
+              ) : splitActive ? (
+                /* Split editor: one CategorySelector + amount per line. The
+                   remainder line is the live "totals must match" indicator —
+                   save stays blocked until it reads exactly zero. */
+                <div className="space-y-2">
+                  {splitsLoading ? (
+                    <p className="text-sm text-gray-500 dark:text-gray-400 py-2">Loading splits…</p>
+                  ) : (
+                    <>
+                      {splitLines.map((line, index) => (
+                        <div key={index} className="flex gap-2 items-center">
+                          <div className="flex-1 min-w-0">
+                            <CategorySelector
+                              selectedCategory={line.category}
+                              onCategoryChange={(id) => updateSplitLine(index, { category: id })}
+                              transactionType={
+                                crossTypeCategories
+                                  ? (formData.type === 'income' ? 'expense' : 'income')
+                                  : formData.type
+                              }
+                              placeholder="Search or select category…"
+                              allowCreate={false}
+                              showHelperText={false}
+                              usePortal
+                            />
+                          </div>
+                          <input
+                            type="text"
+                            inputMode="decimal"
+                            value={line.amount}
+                            onChange={(e) => {
+                              const value = e.target.value;
+                              if (value === '' || value === '-' || /^-?[0-9,]*\.?[0-9]{0,2}$/.test(value)) {
+                                updateSplitLine(index, { amount: value });
+                              }
+                            }}
+                            placeholder="0.00"
+                            aria-label={`Split line ${index + 1} amount`}
+                            className="w-28 shrink-0 px-3 py-2 h-[42px] text-right bg-white dark:bg-gray-800-sm border border-gray-300/50 dark:border-gray-600/50 rounded-xl focus:outline-none focus:ring-2 focus:ring-primary focus:border-transparent text-gray-900 dark:text-white"
+                          />
+                          {splitLines.length > 2 && (
+                            <button
+                              type="button"
+                              onClick={() => removeSplitLine(index)}
+                              aria-label={`Remove split line ${index + 1}`}
+                              title="Remove this split line"
+                              className="shrink-0 p-2 text-gray-400 hover:text-red-600 dark:text-gray-500 dark:hover:text-red-400"
+                            >
+                              <XIcon size={18} />
+                            </button>
+                          )}
+                        </div>
+                      ))}
+                      <div className="flex justify-between items-center pt-1">
+                        <button
+                          type="button"
+                          onClick={addSplitLine}
+                          className="text-sm text-primary hover:text-secondary flex items-center gap-1"
+                        >
+                          <PlusIcon size={14} />
+                          Add another category
+                        </button>
+                        {splitRemaining !== null && (
+                          <span
+                            className={`text-sm font-medium ${
+                              splitRemaining.isZero()
+                                ? 'text-green-600 dark:text-green-400'
+                                : 'text-red-600 dark:text-red-400'
+                            }`}
+                            aria-live="polite"
+                          >
+                            {splitRemaining.isZero()
+                              ? 'Fully allocated ✓'
+                              : `Remaining to allocate: ${(() => {
+                                  const selectedAccount = accounts.find(a => a.id === formData.accountId);
+                                  return selectedAccount ? getCurrencySymbol(selectedAccount.currency) : '';
+                                })()}${formatWithCommas(splitRemaining.toString())}`}
+                          </span>
+                        )}
+                      </div>
+                      {splitValidationMessage && (
+                        <p className="text-sm text-red-600 dark:text-red-400">{splitValidationMessage}</p>
+                      )}
+                    </>
+                  )}
+                </div>
               ) : (
                 /* Searchable combobox: click to type-filter, or use the chevron
                    to browse. usePortal escapes the modal body's overflow-y-auto
@@ -682,7 +910,7 @@ export default function EditTransactionModal({ isOpen, onClose, transaction, def
                 {transaction && onSaveAndPrevious && (
                   <button
                     type="submit"
-                    disabled={isSubmitting}
+                    disabled={isSubmitting || splitValidationMessage !== null}
                     onClick={() => { advanceDirectionRef.current = 'previous'; }}
                     className="px-4 py-2 bg-[#2d3a4d] text-white rounded-lg hover:bg-[#3a4a5f] disabled:opacity-50 disabled:cursor-not-allowed"
                     title="Save this transaction and move to the previous one in the list"
@@ -692,7 +920,7 @@ export default function EditTransactionModal({ isOpen, onClose, transaction, def
                 )}
                 <button
                   type="submit"
-                  disabled={isSubmitting}
+                  disabled={isSubmitting || splitValidationMessage !== null}
                   className="px-4 py-2 bg-[#1a2332] text-white rounded-lg hover:bg-secondary disabled:opacity-50 disabled:cursor-not-allowed"
                 >
                   {isSubmitting ? 'Saving…' : transaction ? 'Save Changes' : 'Add Transaction'}
@@ -700,7 +928,7 @@ export default function EditTransactionModal({ isOpen, onClose, transaction, def
                 {transaction && onSaveAndNext && (
                   <button
                     type="submit"
-                    disabled={isSubmitting}
+                    disabled={isSubmitting || splitValidationMessage !== null}
                     onClick={() => { advanceDirectionRef.current = 'next'; }}
                     className="px-4 py-2 bg-[#2d3a4d] text-white rounded-lg hover:bg-[#3a4a5f] disabled:opacity-50 disabled:cursor-not-allowed"
                     title="Save this transaction and move to the next one in the list"

--- a/src/components/QuickEditTransactionPanel.tsx
+++ b/src/components/QuickEditTransactionPanel.tsx
@@ -49,6 +49,9 @@ export default function QuickEditTransactionPanel({
   }, [transaction]);
 
   const isTransfer = transaction.type === 'transfer';
+  // A split transaction's categorisation lives in its split lines — the DB
+  // guard rejects a single-category write, so this panel never sends one.
+  const isSplit = transaction.isSplit === true;
 
   const save = async (advance: boolean) => {
     if (isSaving) return;
@@ -67,7 +70,7 @@ export default function QuickEditTransactionPanel({
       await updateTransaction(transaction.id, {
         date: parsedDate,
         description: description.trim(),
-        ...(isTransfer ? {} : { category }),
+        ...(isTransfer || isSplit ? {} : { category }),
       });
 
       // Payee memory — but never for CROSS-TYPE filings (a refund put under an
@@ -79,7 +82,7 @@ export default function QuickEditTransactionPanel({
         (chosenCategory.type === 'income' || chosenCategory.type === 'expense') &&
         chosenCategory.type !== transaction.type;
 
-      if (!isTransfer && categoryChanged && category && !isCrossType &&
+      if (!isTransfer && !isSplit && categoryChanged && category && !isCrossType &&
           (transaction.type === 'income' || transaction.type === 'expense')) {
         await propagateCategory({
           accountId: transaction.accountId,
@@ -148,6 +151,13 @@ export default function QuickEditTransactionPanel({
           {isTransfer ? (
             <div className="w-full px-3 h-[42px] flex items-center text-sm bg-white dark:bg-gray-800 border border-gray-300/50 dark:border-gray-600/50 rounded-xl text-gray-500 dark:text-gray-400">
               Transfer
+            </div>
+          ) : isSplit ? (
+            <div
+              className="w-full px-3 h-[42px] flex items-center text-sm bg-white dark:bg-gray-800 border border-gray-300/50 dark:border-gray-600/50 rounded-xl text-blue-600 dark:text-blue-400 italic"
+              title="Split across multiple categories — open the full editor (double-click the row) to change its splits"
+            >
+              Split
             </div>
           ) : (
             <CategorySelector

--- a/src/components/TransactionRow.test.tsx
+++ b/src/components/TransactionRow.test.tsx
@@ -598,6 +598,46 @@ describe('TransactionRow', () => {
     });
   });
 
+  describe('Split Transactions', () => {
+    it('shows "Split" in the category column instead of a category path', () => {
+      render(
+        <table>
+          <tbody>
+            <TransactionRow
+              {...defaultProps}
+              transaction={{ ...mockTransaction, isSplit: true, category: '' }}
+              categoryPath=""
+            />
+          </tbody>
+        </table>
+      );
+
+      expect(screen.getByText('Split')).toBeInTheDocument();
+      expect(screen.queryByText('Uncategorized')).not.toBeInTheDocument();
+    });
+
+    it('never offers inline category editing for a split transaction', () => {
+      render(
+        <table>
+          <tbody>
+            <TransactionRow
+              {...defaultProps}
+              transaction={{ ...mockTransaction, isSplit: true, category: '' }}
+              categoryPath=""
+              availableCategories={[{ id: 'cat-1', name: 'Groceries' }]}
+              onUpdateCategory={vi.fn()}
+            />
+          </tbody>
+        </table>
+      );
+
+      // A normal row would render a "click to change" category button here;
+      // a split row's categorisation is only editable through the full editor.
+      expect(screen.queryByRole('button', { name: /change category/i })).not.toBeInTheDocument();
+      expect(screen.getByText('Split')).toBeInTheDocument();
+    });
+  });
+
   describe('Performance', () => {
     it('memoizes component correctly', () => {
       const { rerender } = render(

--- a/src/components/TransactionRow.tsx
+++ b/src/components/TransactionRow.tsx
@@ -198,7 +198,17 @@ export const TransactionRow = memo(function TransactionRow({
             className={`${compactView ? 'py-1.5' : 'py-3'} px-6 text-gray-900 dark:text-gray-100 text-left`}
             style={{ width: columnWidths.category }}
           >
-            {isEditingCategory && availableCategories && onUpdateCategory ? (
+            {transaction.isSplit ? (
+              // Money-style: a split transaction shows "Split" in the category
+              // column; its categorisation lives in the split lines and is
+              // edited through the full transaction editor, never inline.
+              <span
+                className={`${compactView ? 'text-sm' : ''} truncate block italic text-blue-600 dark:text-blue-400`}
+                title="Split across multiple categories — open the transaction to edit its splits"
+              >
+                Split
+              </span>
+            ) : isEditingCategory && availableCategories && onUpdateCategory ? (
               <select
                 className="w-full text-sm bg-white dark:bg-gray-700 border border-gray-300 dark:border-gray-600 rounded px-2 py-1 focus:outline-none focus:ring-1 focus:ring-blue-500"
                 value={transaction.category || ''}
@@ -383,7 +393,9 @@ export const TransactionRow = memo(function TransactionRow({
           />
         </td>
       )}
-      {columnOrder.map(column => renderCell(column))}
+      {columnOrder.map(column => (
+        <React.Fragment key={column}>{renderCell(column)}</React.Fragment>
+      ))}
     </tr>
   );
 }, (prevProps, nextProps) => {
@@ -393,6 +405,7 @@ export const TransactionRow = memo(function TransactionRow({
     prevProps.transaction.amount === nextProps.transaction.amount &&
     prevProps.transaction.description === nextProps.transaction.description &&
     prevProps.transaction.category === nextProps.transaction.category &&
+    prevProps.transaction.isSplit === nextProps.transaction.isSplit &&
     prevProps.transaction.cleared === nextProps.transaction.cleared &&
     prevProps.account?.id === nextProps.account?.id &&
     prevProps.categoryPath === nextProps.categoryPath &&

--- a/src/contexts/AppContextSupabase.tsx
+++ b/src/contexts/AppContextSupabase.tsx
@@ -20,14 +20,16 @@ import {
 } from '../utils/decimal-converters';
 import { toDecimal } from '../utils/decimal';
 import type { DecimalTransaction, DecimalAccount, DecimalGoal } from '../types/decimal-types';
-import type { 
-  Account, 
-  Transaction, 
-  Category, 
-  Budget, 
-  Goal, 
+import type {
+  Account,
+  Transaction,
+  TransactionSplit,
+  TransactionSplitInput,
+  Category,
+  Budget,
+  Goal,
   RecurringTransaction,
-  AppState 
+  AppState
 } from '../types';
 import { createScopedLogger } from '../loggers/scopedLogger';
 import { planCategoryTreeImport, planCategoryPrune, type CategoryTreeGroup } from '../utils/categoryTreeImport';
@@ -124,6 +126,19 @@ export interface AppContextType extends AppState {
    * category, enforced server-side. Returns the number actually updated.
    */
   applyCategoryToUncategorized: (ids: string[], category: string) => Promise<number>;
+  /** Splits for one transaction, in display order (empty when not split). */
+  getTransactionSplits: (transactionId: string) => Promise<TransactionSplit[]>;
+  /**
+   * Replace a transaction's splits atomically (empty array un-splits it).
+   * Split lines must sum EXACTLY to expectedAmount — enforced server-side by
+   * the set_transaction_splits RPC, which also syncs the transaction amount
+   * and account balance when the sum changes them.
+   */
+  setTransactionSplits: (
+    transactionId: string,
+    splits: TransactionSplitInput[],
+    expectedAmount: number | null
+  ) => Promise<{ isSplit: boolean; splitCount: number; amount: number }>;
 }
 
 const AppContext = createContext<AppContextType | undefined>(undefined);
@@ -516,9 +531,10 @@ export function AppProvider({ children }: { children: React.ReactNode }) {
     try {
       const count = await DataService.applyCategoryToUncategorized(ids, category);
       const idSet = new Set(ids);
-      // Mirror the server's fill-blanks semantics locally: only blank rows flip.
+      // Mirror the server's fill-blanks semantics locally: only blank,
+      // NON-SPLIT rows flip (a split parent's blank category means "split").
       setTransactions(prev => prev.map(t =>
-        idSet.has(t.id) && (!t.category || t.category.trim() === '') ? { ...t, category } : t
+        idSet.has(t.id) && !t.isSplit && (!t.category || t.category.trim() === '') ? { ...t, category } : t
       ));
       return count;
     } catch (error) {
@@ -526,6 +542,55 @@ export function AppProvider({ children }: { children: React.ReactNode }) {
       throw error;
     }
   }, []);
+
+  const getTransactionSplits = useCallback(async (transactionId: string) => {
+    try {
+      return await DataService.getTransactionSplits(transactionId);
+    } catch (error) {
+      appLogger.error('Failed to load transaction splits', error);
+      throw error;
+    }
+  }, []);
+
+  const setTransactionSplits = useCallback(async (
+    transactionId: string,
+    splits: TransactionSplitInput[],
+    expectedAmount: number | null
+  ) => {
+    try {
+      const oldTransaction = transactions.find(t => t.id === transactionId);
+      const result = await DataService.setTransactionSplits(transactionId, splits, expectedAmount);
+
+      // Mirror the atomic server change locally: the flag, the blanked
+      // category while split, and the amount the splits sum to.
+      setTransactions(prev => prev.map(t =>
+        t.id === transactionId
+          ? {
+              ...t,
+              isSplit: result.isSplit,
+              amount: result.amount,
+              ...(result.isSplit ? { category: '' } : {}),
+            }
+          : t
+      ));
+
+      // Balance follows the amount (Decimal arithmetic; the DB balance was
+      // adjusted atomically inside set_transaction_splits).
+      if (oldTransaction && result.amount !== oldTransaction.amount) {
+        const difference = toDecimal(result.amount).minus(toDecimal(oldTransaction.amount));
+        setAccounts(prev => prev.map(acc =>
+          acc.id === oldTransaction.accountId
+            ? { ...acc, balance: toDecimal(acc.balance || 0).plus(difference).toNumber() }
+            : acc
+        ));
+      }
+
+      return result;
+    } catch (error) {
+      appLogger.error('Failed to set transaction splits', error);
+      throw error;
+    }
+  }, [transactions]);
 
   const deleteTransaction = useCallback(async (id: string) => {
     try {
@@ -899,6 +964,8 @@ export function AppProvider({ children }: { children: React.ReactNode }) {
     deleteTransaction,
     setTransactionsCleared,
     applyCategoryToUncategorized,
+    getTransactionSplits,
+    setTransactionSplits,
 
     // Budget operations
     addBudget,

--- a/src/services/api/dataService.ts
+++ b/src/services/api/dataService.ts
@@ -12,7 +12,7 @@ import { isSupabaseConfigured } from './supabaseClient';
 import { storageAdapter, STORAGE_KEYS } from '../storageAdapter';
 import { userIdService } from '../userIdService';
 import { toDecimal } from '../../utils/decimal';
-import type { Account, Transaction, Budget, Goal, Category } from '../../types';
+import type { Account, Transaction, TransactionSplit, TransactionSplitInput, Budget, Goal, Category } from '../../types';
 
 export interface AppData {
   accounts: Account[];
@@ -28,7 +28,7 @@ type AccountServiceLike = Pick<typeof AccountService,
   subscribeToAccounts?: (userId: string, callback: (payload: unknown) => void) => () => void;
 };
 type TransactionServiceLike = Pick<typeof TransactionService,
-  'getTransactions' | 'createTransaction' | 'updateTransaction' | 'deleteTransaction' | 'setTransactionsCleared' | 'applyCategoryToUncategorized'> & {
+  'getTransactions' | 'createTransaction' | 'updateTransaction' | 'deleteTransaction' | 'setTransactionsCleared' | 'applyCategoryToUncategorized' | 'getTransactionSplits' | 'setTransactionSplits'> & {
   subscribeToTransactions?: (userId: string, callback: (payload: unknown) => void) => () => void;
 };
 type UserIdServiceLike = Pick<typeof userIdService,
@@ -326,6 +326,91 @@ class DataServiceImpl {
     return count;
   }
 
+  /** Splits for one transaction, in display order (empty when not split). */
+  async getTransactionSplits(transactionId: string): Promise<TransactionSplit[]> {
+    const userId = this.userIdService.getCurrentDatabaseUserId();
+    if (userId && this.supabaseChecker()) {
+      return this.transactionService.getTransactionSplits(transactionId);
+    }
+
+    const stored = await this.readCollection<TransactionSplit>(STORAGE_KEYS.TRANSACTION_SPLITS);
+    return stored
+      .filter(s => s.transactionId === transactionId)
+      .sort((a, b) => a.sortOrder - b.sortOrder);
+  }
+
+  /**
+   * Replace a transaction's splits atomically (empty array un-splits it).
+   * Server-side the RPC validates ≥2 lines / non-zero amounts / sum ==
+   * expectedAmount and syncs the amount + account balance; the local path
+   * mirrors those rules so demo/offline behave identically.
+   */
+  async setTransactionSplits(
+    transactionId: string,
+    splits: TransactionSplitInput[],
+    expectedAmount: number | null
+  ): Promise<{ isSplit: boolean; splitCount: number; amount: number }> {
+    const userId = this.userIdService.getCurrentDatabaseUserId();
+    if (userId && this.supabaseChecker()) {
+      return this.transactionService.setTransactionSplits(transactionId, splits, expectedAmount, userId);
+    }
+
+    const transactions = await this.readCollection<Transaction>(STORAGE_KEYS.TRANSACTIONS);
+    const index = transactions.findIndex(t => t.id === transactionId);
+    if (index === -1) {
+      throw new Error('Transaction not found');
+    }
+    const transaction = transactions[index];
+    if (transaction.type === 'transfer') {
+      throw new Error('Transfers cannot be split');
+    }
+
+    const stored = await this.readCollection<TransactionSplit>(STORAGE_KEYS.TRANSACTION_SPLITS);
+    const others = stored.filter(s => s.transactionId !== transactionId);
+
+    if (splits.length === 0) {
+      await this.persistCollection(STORAGE_KEYS.TRANSACTION_SPLITS, others);
+      transactions[index] = { ...transaction, isSplit: false } as Transaction;
+      await this.persistCollection(STORAGE_KEYS.TRANSACTIONS, transactions);
+      return { isSplit: false, splitCount: 0, amount: transaction.amount };
+    }
+
+    if (splits.length < 2) {
+      throw new Error('A split needs at least 2 lines');
+    }
+    let sum = toDecimal(0);
+    for (const split of splits) {
+      if (!split.category.trim()) {
+        throw new Error('Every split line needs a category');
+      }
+      if (!split.amount) {
+        throw new Error('Every split line needs a non-zero amount');
+      }
+      sum = sum.plus(toDecimal(split.amount));
+    }
+    if (expectedAmount !== null && !sum.equals(toDecimal(expectedAmount))) {
+      throw new Error('The split lines must sum to the transaction amount');
+    }
+
+    const newSplits: TransactionSplit[] = splits.map((split, i) => ({
+      id: this.generateId(),
+      transactionId,
+      category: split.category,
+      amount: split.amount,
+      ...(split.memo ? { memo: split.memo } : {}),
+      sortOrder: i + 1,
+    }));
+    await this.persistCollection(STORAGE_KEYS.TRANSACTION_SPLITS, [...others, ...newSplits]);
+
+    const newAmount = sum.toNumber();
+    transactions[index] = { ...transaction, isSplit: true, category: '', amount: newAmount } as Transaction;
+    await this.persistCollection(STORAGE_KEYS.TRANSACTIONS, transactions);
+    if (newAmount !== transaction.amount) {
+      await this.updateAccountBalance(transaction.accountId, -transaction.amount + newAmount);
+    }
+    return { isSplit: true, splitCount: newSplits.length, amount: newAmount };
+  }
+
   async getBudgets(): Promise<Budget[]> {
     return this.readCollection<Budget>(STORAGE_KEYS.BUDGETS);
   }
@@ -452,6 +537,18 @@ export class DataService {
 
   static applyCategoryToUncategorized(ids: string[], category: string): Promise<number> {
     return this.service.applyCategoryToUncategorized(ids, category);
+  }
+
+  static getTransactionSplits(transactionId: string): Promise<TransactionSplit[]> {
+    return this.service.getTransactionSplits(transactionId);
+  }
+
+  static setTransactionSplits(
+    transactionId: string,
+    splits: TransactionSplitInput[],
+    expectedAmount: number | null
+  ): Promise<{ isSplit: boolean; splitCount: number; amount: number }> {
+    return this.service.setTransactionSplits(transactionId, splits, expectedAmount);
   }
 
   static getBudgets(): Promise<Budget[]> {

--- a/src/services/api/supabaseClient.ts
+++ b/src/services/api/supabaseClient.ts
@@ -36,6 +36,15 @@ type Database = {
         Args: { p_ids: string[]; p_category: string; p_user_id?: string };
         Returns: number;
       };
+      set_transaction_splits: {
+        Args: {
+          p_transaction_id: string;
+          p_splits: { category: string; amount: number; memo?: string }[];
+          p_expected_amount: number | null;
+          p_user_id?: string;
+        };
+        Returns: Record<string, unknown>;
+      };
       delete_unused_categories: {
         Args: { p_ids: string[]; p_user_id?: string };
         Returns: number;

--- a/src/services/api/transactionService.ts
+++ b/src/services/api/transactionService.ts
@@ -1,7 +1,8 @@
 
 import { supabase, isSupabaseConfigured, handleSupabaseError } from './supabaseClient';
-import type { Transaction } from '../../types';
+import type { Transaction, TransactionSplit, TransactionSplitInput } from '../../types';
 import { storageAdapter, STORAGE_KEYS } from '../storageAdapter';
+import { toDecimal } from '../../utils/decimal';
 
 type StorageAdapterLike = Pick<typeof storageAdapter, 'get' | 'set'>;
 type SupabaseClientLike = typeof supabase;
@@ -356,6 +357,136 @@ class TransactionServiceImpl {
     }
   }
 
+  /** Splits for one transaction, in display order (empty when not split). */
+  async getTransactionSplits(transactionId: string): Promise<TransactionSplit[]> {
+    if (!this.isSupabaseReady()) {
+      const stored = (await this.storage.get<TransactionSplit[]>(STORAGE_KEYS.TRANSACTION_SPLITS)) ?? [];
+      return stored
+        .filter(s => s.transactionId === transactionId)
+        .sort((a, b) => a.sortOrder - b.sortOrder);
+    }
+
+    try {
+      const client = this.supabaseClient!;
+      const { data, error } = await client
+        .from('transaction_splits')
+        .select('*')
+        .eq('transaction_id', transactionId)
+        .order('sort_order', { ascending: true });
+
+      if (error) {
+        this.logger.error('Error fetching transaction splits:', error);
+        throw new Error(handleSupabaseError(error));
+      }
+
+      return ((data || []) as Record<string, unknown>[]).map(row => ({
+        id: String(row.id),
+        transactionId: String(row.transaction_id),
+        category: String(row.category),
+        amount: Number(row.amount),
+        memo: typeof row.memo === 'string' && row.memo !== '' ? row.memo : undefined,
+        sortOrder: Number(row.sort_order),
+      }));
+    } catch (error) {
+      this.logger.error('TransactionService.getTransactionSplits error:', error as Error);
+      throw error;
+    }
+  }
+
+  /**
+   * Replace a transaction's splits atomically (empty array un-splits it).
+   * The server RPC enforces the invariants — ≥2 lines, valid non-transfer
+   * categories, non-zero amounts, and sum == expectedAmount — and syncs the
+   * transaction's amount/account balance when the sum changes it. The local
+   * fallback mirrors the same rules so demo/offline behave identically.
+   */
+  async setTransactionSplits(
+    transactionId: string,
+    splits: TransactionSplitInput[],
+    expectedAmount: number | null,
+    userId?: string
+  ): Promise<{ isSplit: boolean; splitCount: number; amount: number }> {
+    if (!this.isSupabaseReady()) {
+      const transactions = await this.readStoredTransactions();
+      const transaction = transactions.find(t => t.id === transactionId);
+      if (!transaction) {
+        throw new Error('transaction_not_found');
+      }
+      if (transaction.type === 'transfer') {
+        throw new Error('transfers cannot be split');
+      }
+
+      const stored = (await this.storage.get<TransactionSplit[]>(STORAGE_KEYS.TRANSACTION_SPLITS)) ?? [];
+      const others = stored.filter(s => s.transactionId !== transactionId);
+
+      if (splits.length === 0) {
+        await this.storage.set(STORAGE_KEYS.TRANSACTION_SPLITS, others);
+        await this.persistTransactions(transactions.map(t =>
+          t.id === transactionId ? { ...t, isSplit: false, updatedAt: this.getCurrentDate() } : t
+        ));
+        return { isSplit: false, splitCount: 0, amount: transaction.amount };
+      }
+
+      if (splits.length < 2) {
+        throw new Error('a split needs at least 2 lines');
+      }
+      let sum = toDecimal(0);
+      for (const split of splits) {
+        if (!split.category.trim()) {
+          throw new Error('every split line needs a category');
+        }
+        if (!split.amount) {
+          throw new Error('every split line needs a non-zero amount');
+        }
+        sum = sum.plus(toDecimal(split.amount));
+      }
+      if (expectedAmount !== null && !sum.equals(toDecimal(expectedAmount))) {
+        throw new Error('split_total_mismatch: the split lines must sum to the transaction amount');
+      }
+
+      const newSplits = splits.map((split, index) => ({
+        id: this.uuid(),
+        transactionId,
+        category: split.category,
+        amount: split.amount,
+        ...(split.memo ? { memo: split.memo } : {}),
+        sortOrder: index + 1,
+      }));
+      await this.storage.set(STORAGE_KEYS.TRANSACTION_SPLITS, [...others, ...newSplits]);
+      await this.persistTransactions(transactions.map(t =>
+        t.id === transactionId
+          ? { ...t, isSplit: true, category: '', amount: sum.toNumber(), updatedAt: this.getCurrentDate() }
+          : t
+      ));
+      return { isSplit: true, splitCount: splits.length, amount: sum.toNumber() };
+    }
+
+    try {
+      const client = this.supabaseClient!;
+      const { data, error } = await client.rpc('set_transaction_splits', {
+        p_transaction_id: transactionId,
+        p_splits: splits,
+        p_expected_amount: expectedAmount,
+        ...(userId ? { p_user_id: userId } : {})
+      });
+
+      if (error) {
+        this.logger.error('Error setting transaction splits:', error);
+        throw new Error(handleSupabaseError(error));
+      }
+
+      const result = (data ?? {}) as Record<string, unknown>;
+      return {
+        isSplit: Boolean(result.is_split),
+        splitCount: Number(result.split_count ?? 0),
+        amount: Number(result.amount ?? expectedAmount ?? 0),
+      };
+    } catch (error) {
+      this.logger.error('TransactionService.setTransactionSplits error:', error as Error);
+      throw error;
+    }
+  }
+
   async deleteTransaction(id: string, userId?: string): Promise<void> {
     if (!this.isSupabaseReady()) {
       const transactions = await this.readStoredTransactions();
@@ -630,6 +761,19 @@ export class TransactionService {
 
   static applyCategoryToUncategorized(ids: string[], category: string, userId?: string): Promise<number> {
     return this.service.applyCategoryToUncategorized(ids, category, userId);
+  }
+
+  static getTransactionSplits(transactionId: string): Promise<TransactionSplit[]> {
+    return this.service.getTransactionSplits(transactionId);
+  }
+
+  static setTransactionSplits(
+    transactionId: string,
+    splits: TransactionSplitInput[],
+    expectedAmount: number | null,
+    userId?: string
+  ): Promise<{ isSplit: boolean; splitCount: number; amount: number }> {
+    return this.service.setTransactionSplits(transactionId, splits, expectedAmount, userId);
   }
 
   static getTransactionsByDateRange(userId: string, startDate: Date, endDate: Date): Promise<Transaction[]> {

--- a/src/services/encryptedStorageService.ts
+++ b/src/services/encryptedStorageService.ts
@@ -424,6 +424,7 @@ export const encryptedStorage = new EncryptedStorageService();
 export const STORAGE_KEYS = {
   ACCOUNTS: 'wealthtracker_accounts',
   TRANSACTIONS: 'wealthtracker_transactions',
+  TRANSACTION_SPLITS: 'wealthtracker_transaction_splits',
   BUDGETS: 'wealthtracker_budgets',
   GOALS: 'wealthtracker_goals',
   TAGS: 'wealthtracker_tags',

--- a/src/test/mocks/AppContextSupabase.ts
+++ b/src/test/mocks/AppContextSupabase.ts
@@ -37,6 +37,8 @@ const baseValue = {
   deleteTransaction: noop,
   setTransactionsCleared: asyncNoop,
   applyCategoryToUncategorized: async () => 0,
+  getTransactionSplits: async () => [],
+  setTransactionSplits: async () => ({ isSplit: false, splitCount: 0, amount: 0 }),
   refreshAccountsAndTransactions: asyncNoop,
   refreshCategories: asyncNoop,
   addBudget: noop,

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -135,6 +135,32 @@ export interface Transaction {
   };
 }
 
+/**
+ * One category line of a split transaction. A split transaction stays a
+ * single ledger row (one date, one payee, one signed amount, one balance
+ * effect); its categorisation moves into lines that MUST sum exactly to the
+ * transaction amount — enforced by the set_transaction_splits RPC and its
+ * guard trigger. Amounts are signed with the same convention as
+ * Transaction.amount; a negative-relative line (e.g. cashback inside a shop)
+ * is legal, exactly like Microsoft Money.
+ */
+export interface TransactionSplit {
+  id: string;
+  transactionId: string;
+  /** Category id as text — same convention as Transaction.category. */
+  category: string;
+  amount: number;
+  memo?: string;
+  sortOrder: number;
+}
+
+/** Input for creating/replacing a transaction's splits (ids are server-assigned). */
+export interface TransactionSplitInput {
+  category: string;
+  amount: number;
+  memo?: string;
+}
+
 export interface Budget {
   id: string;
   categoryId: string;  // Changed from 'category' to match service implementation

--- a/src/utils/transactionSplits.test.ts
+++ b/src/utils/transactionSplits.test.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect } from 'vitest';
+import {
+  sumSplitDrafts,
+  splitRemainder,
+  validateSplitDrafts,
+  signSplitAmounts,
+  displaySplitAmount,
+  type SplitLineDraft,
+} from './transactionSplits';
+
+const line = (category: string, amount: string): SplitLineDraft => ({ category, amount });
+
+describe('sumSplitDrafts / splitRemainder', () => {
+  it('sums entered amounts exactly (no float drift)', () => {
+    // 0.1 + 0.2 is the classic float trap; Decimal must make it exactly 0.3
+    const lines = [line('a', '0.1'), line('b', '0.2')];
+    expect(sumSplitDrafts(lines).toString()).toBe('0.3');
+    expect(splitRemainder('0.3', lines).isZero()).toBe(true);
+  });
+
+  it('treats blank or invalid amounts as 0', () => {
+    const lines = [line('a', '10'), line('b', ''), line('c', 'abc')];
+    expect(sumSplitDrafts(lines).toString()).toBe('10');
+  });
+
+  it('handles negative lines (cashback inside a shop)', () => {
+    const lines = [line('groceries', '120'), line('cashback', '-20')];
+    expect(sumSplitDrafts(lines).toString()).toBe('100');
+    expect(splitRemainder('100', lines).isZero()).toBe(true);
+  });
+
+  it('reports what is left to allocate', () => {
+    expect(splitRemainder('100', [line('a', '60')]).toString()).toBe('40');
+    expect(splitRemainder('100', [line('a', '60'), line('b', '55')]).toString()).toBe('-15');
+  });
+
+  it('accepts formatted input with currency symbols and commas', () => {
+    expect(splitRemainder('1,250.00', [line('a', '£1,000'), line('b', '250')]).isZero()).toBe(true);
+  });
+});
+
+describe('validateSplitDrafts', () => {
+  it('requires at least two lines', () => {
+    expect(validateSplitDrafts('100', [line('a', '100')])).toMatch(/at least two/);
+  });
+
+  it('requires a category on every line', () => {
+    expect(validateSplitDrafts('100', [line('a', '60'), line('', '40')])).toMatch(/needs a category/);
+  });
+
+  it('requires a non-zero amount on every line', () => {
+    expect(validateSplitDrafts('100', [line('a', '100'), line('b', '')])).toMatch(/non-zero amount/);
+    expect(validateSplitDrafts('100', [line('a', '100'), line('b', '0')])).toMatch(/non-zero amount/);
+  });
+
+  it('blocks a save when the totals do not match', () => {
+    expect(validateSplitDrafts('100', [line('a', '60'), line('b', '30')])).toMatch(/must match/);
+  });
+
+  it('returns null for a balanced split', () => {
+    expect(validateSplitDrafts('100', [line('a', '60'), line('b', '40')])).toBeNull();
+    expect(validateSplitDrafts('100', [line('a', '120'), line('b', '-20')])).toBeNull();
+  });
+});
+
+describe('signSplitAmounts', () => {
+  it('negates expense lines to the DB convention', () => {
+    expect(signSplitAmounts([line('a', '120'), line('b', '-20')], 'expense')).toEqual([
+      { category: 'a', amount: -120 },
+      { category: 'b', amount: 20 },
+    ]);
+  });
+
+  it('keeps income lines as entered', () => {
+    expect(signSplitAmounts([line('a', '90'), line('b', '10')], 'income')).toEqual([
+      { category: 'a', amount: 90 },
+      { category: 'b', amount: 10 },
+    ]);
+  });
+
+  it('never emits -0', () => {
+    const [signed] = signSplitAmounts([line('a', '0')], 'expense');
+    expect(Object.is(signed.amount, -0)).toBe(false);
+  });
+
+  it('passes trimmed memos through and drops blank ones', () => {
+    const result = signSplitAmounts(
+      [{ category: 'a', amount: '10', memo: '  petrol  ' }, { category: 'b', amount: '5', memo: '   ' }],
+      'expense'
+    );
+    expect(result[0].memo).toBe('petrol');
+    expect(result[1]).not.toHaveProperty('memo');
+  });
+});
+
+describe('displaySplitAmount', () => {
+  it('round-trips with signSplitAmounts for expenses', () => {
+    // stored -120 (an expense line) displays as the entered 120
+    expect(displaySplitAmount(-120, 'expense')).toBe('120');
+    // stored +20 (the cashback line) displays as the entered -20
+    expect(displaySplitAmount(20, 'expense')).toBe('-20');
+  });
+
+  it('is identity for income', () => {
+    expect(displaySplitAmount(90, 'income')).toBe('90');
+  });
+});

--- a/src/utils/transactionSplits.ts
+++ b/src/utils/transactionSplits.ts
@@ -1,0 +1,90 @@
+import { toDecimal, parseMoneyInput, type DecimalInstance } from './decimal';
+
+/**
+ * Split-editor money maths. Everything runs through Decimal — the "totals
+ * must match" rule is an exact comparison, never a float one.
+ *
+ * The editor works in the ENTERED domain: the user types magnitudes the same
+ * way the main Amount field collects them (positive for a normal line; a
+ * MINUS line models e.g. cashback inside a shop, reducing the total). Signing
+ * to the DB convention (expenses negative) happens once at save time via
+ * signSplitAmounts.
+ */
+
+/** One editor row: category id + the raw amount string as typed. */
+export interface SplitLineDraft {
+  category: string;
+  amount: string;
+  memo?: string;
+}
+
+/** Sum of the entered split amounts; blank/invalid rows count as 0. */
+export function sumSplitDrafts(lines: SplitLineDraft[]): DecimalInstance {
+  return lines.reduce(
+    (sum, line) => sum.plus(parseMoneyInput(line.amount) ?? 0),
+    toDecimal(0)
+  );
+}
+
+/**
+ * What is still left to allocate: entered total amount minus the split sum.
+ * Zero (exactly) means the split is balanced and may be saved.
+ */
+export function splitRemainder(totalAmount: string, lines: SplitLineDraft[]): DecimalInstance {
+  return toDecimal(parseMoneyInput(totalAmount) ?? 0).minus(sumSplitDrafts(lines));
+}
+
+/**
+ * Validate the draft against the save rules. Returns null when saveable,
+ * otherwise the user-facing reason the save is blocked.
+ */
+export function validateSplitDrafts(totalAmount: string, lines: SplitLineDraft[]): string | null {
+  if (lines.length < 2) {
+    return 'A split needs at least two category lines.';
+  }
+  for (const line of lines) {
+    if (!line.category) {
+      return 'Every split line needs a category.';
+    }
+    const amount = parseMoneyInput(line.amount);
+    if (amount === null || toDecimal(amount).isZero()) {
+      return 'Every split line needs a non-zero amount.';
+    }
+  }
+  if (!splitRemainder(totalAmount, lines).isZero()) {
+    return 'The split total must match the transaction amount.';
+  }
+  return null;
+}
+
+/**
+ * Convert entered magnitudes to DB-signed amounts. Expenses store negative,
+ * so an entered 120 becomes -120 and an entered -20 (a cashback line)
+ * becomes +20; income lines keep their entered sign. This mirrors what
+ * signTransactionAmount does to the single amount field, extended to allow
+ * per-line negatives.
+ */
+export function signSplitAmounts(
+  lines: SplitLineDraft[],
+  type: 'income' | 'expense'
+): { category: string; amount: number; memo?: string }[] {
+  return lines.map(line => {
+    const entered = toDecimal(parseMoneyInput(line.amount) ?? 0);
+    const signed = type === 'expense' ? entered.negated() : entered;
+    return {
+      category: line.category,
+      // `plus(0)` normalises -0 → 0 to match signTransactionAmount's `|| 0`.
+      amount: signed.plus(0).toNumber(),
+      ...(line.memo?.trim() ? { memo: line.memo.trim() } : {}),
+    };
+  });
+}
+
+/**
+ * Convert stored (signed) split amounts back to the entered domain for the
+ * editor — the inverse of signSplitAmounts.
+ */
+export function displaySplitAmount(storedAmount: number, type: 'income' | 'expense'): string {
+  const value = toDecimal(storedAmount);
+  return (type === 'expense' ? value.negated() : value).toString();
+}

--- a/supabase/migrations/20260713100000_transaction_splits.sql
+++ b/supabase/migrations/20260713100000_transaction_splits.sql
@@ -1,0 +1,376 @@
+-- Split transactions — phase 1: schema + server-side integrity.
+--
+-- IMPORTANT: Run this SQL in the Supabase SQL Editor to apply to production DB.
+-- Safe to apply before the matching client deploys: nothing reads
+-- transaction_splits or is_split until the split editor ships, and the two
+-- recreated RPCs only gain guards (split parents cannot exist before this
+-- migration, so the added conditions match zero rows today).
+--
+-- Model (the Microsoft Money one): a split transaction stays ONE ledger row —
+-- one date, one payee, one signed amount, one balance effect — while its
+-- categorisation moves into transaction_splits lines that MUST sum exactly to
+-- the transaction amount. The parent's category is blank while split; split
+-- lines carry signed amounts (a negative line models e.g. cashback inside a
+-- shop, exactly like Money).
+--
+-- Integrity is enforced server-side, not just in the editor:
+--   - set_transaction_splits is the ONLY path that can change a split
+--     parent's amount, category, type, or is_split — a BEFORE UPDATE trigger
+--     rejects everything else (quick edits, bulk tools, stale clients).
+--   - The RPC validates sum(splits) = amount, syncs the amount and account
+--     balance atomically when an edit changes it, and audits every change.
+--   - apply_category_to_uncategorized (payee-memory fan-out) skips split
+--     parents: their blank category means "split", not "uncategorised".
+--   - delete_unused_categories refuses to delete a category any split uses.
+
+BEGIN;
+
+-- ── Schema ───────────────────────────────────────────────────────────────────
+
+ALTER TABLE public.transactions
+  ADD COLUMN IF NOT EXISTS is_split boolean NOT NULL DEFAULT false;
+
+CREATE TABLE IF NOT EXISTS public.transaction_splits (
+  id             uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  transaction_id uuid NOT NULL REFERENCES public.transactions(id) ON DELETE CASCADE,
+  user_id        uuid NOT NULL,
+  category       text NOT NULL,                -- category id as text (matches transactions.category)
+  amount         numeric(20,2) NOT NULL,       -- signed, same convention as transactions.amount
+  memo           text,
+  sort_order     integer NOT NULL DEFAULT 0,
+  created_at     timestamptz NOT NULL DEFAULT now(),
+  updated_at     timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT transaction_splits_category_not_blank CHECK (btrim(category) <> ''),
+  CONSTRAINT transaction_splits_amount_nonzero CHECK (amount <> 0)
+);
+
+CREATE INDEX IF NOT EXISTS idx_transaction_splits_transaction
+  ON public.transaction_splits (transaction_id, sort_order);
+-- Phase 3 (split-aware reporting) will aggregate by category per user.
+CREATE INDEX IF NOT EXISTS idx_transaction_splits_user_category
+  ON public.transaction_splits (user_id, category);
+
+ALTER TABLE public.transaction_splits ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS transaction_splits_all_own ON public.transaction_splits;
+CREATE POLICY transaction_splits_all_own ON public.transaction_splits
+  FOR ALL TO authenticated
+  USING (user_id = public.requesting_user_id())
+  WITH CHECK (user_id = public.requesting_user_id());
+
+-- ── Guard: split parents are read-only outside set_transaction_splits ───────
+-- The RPC marks its own writes with a transaction-local flag; every other
+-- UPDATE that would break the sum invariant (amount), re-categorise a split
+-- parent (category), flip its sign convention (type), or forge the flag
+-- (is_split) is rejected.
+
+CREATE OR REPLACE FUNCTION public.protect_split_transaction_fields()
+RETURNS trigger
+LANGUAGE plpgsql
+SET search_path = public
+AS $$
+BEGIN
+  IF current_setting('app.split_rpc', true) = '1' THEN
+    RETURN NEW;
+  END IF;
+
+  IF NEW.is_split IS DISTINCT FROM OLD.is_split THEN
+    RAISE EXCEPTION 'is_split can only change through set_transaction_splits'
+      USING ERRCODE = 'P0001';
+  END IF;
+
+  IF OLD.is_split THEN
+    IF NEW.amount IS DISTINCT FROM OLD.amount THEN
+      RAISE EXCEPTION 'split_amount_locked: this transaction is split — its amount is the sum of its splits; edit the splits instead'
+        USING ERRCODE = 'P0001';
+    END IF;
+    IF NEW.type IS DISTINCT FROM OLD.type THEN
+      RAISE EXCEPTION 'split_type_locked: remove the split before changing the transaction type'
+        USING ERRCODE = 'P0001';
+    END IF;
+    IF btrim(COALESCE(NEW.category, '')) <> '' THEN
+      RAISE EXCEPTION 'split_category_locked: this transaction is split — its categorisation lives in its split lines'
+        USING ERRCODE = 'P0001';
+    END IF;
+  END IF;
+
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS trg_protect_split_transaction_fields ON public.transactions;
+CREATE TRIGGER trg_protect_split_transaction_fields
+  BEFORE UPDATE ON public.transactions
+  FOR EACH ROW
+  EXECUTE FUNCTION public.protect_split_transaction_fields();
+
+-- ── set_transaction_splits: the one write path ───────────────────────────────
+-- Replace-all semantics. An empty/NULL p_splits un-splits the transaction
+-- (the caller re-categorises through the normal update path afterwards).
+-- p_expected_amount is the client's amount field: when supplied, a split set
+-- that does not sum to it is REJECTED (the user-facing "totals must match"
+-- rule, enforced server-side). When the sum differs from the stored amount
+-- (the same edit changed the amount), the amount and account balance are
+-- synced atomically, mirroring update_transaction_atomic.
+
+CREATE OR REPLACE FUNCTION public.set_transaction_splits(
+  p_transaction_id uuid,
+  p_splits jsonb,
+  p_expected_amount numeric DEFAULT NULL,
+  p_user_id uuid DEFAULT NULL
+)
+RETURNS jsonb
+LANGUAGE plpgsql SECURITY INVOKER
+SET search_path = public
+AS $$
+DECLARE
+  v_old public.transactions;
+  v_new public.transactions;
+  v_split jsonb;
+  v_category text;
+  v_amount numeric(20,2);
+  v_sum numeric(20,2) := 0;
+  v_count integer := 0;
+  v_ord integer := 0;
+  v_old_splits jsonb;
+  v_new_splits jsonb;
+  v_acct_before public.accounts;
+  v_acct_after public.accounts;
+BEGIN
+  IF p_splits IS NOT NULL AND jsonb_typeof(p_splits) <> 'array' THEN
+    RAISE EXCEPTION 'p_splits must be a jsonb array' USING ERRCODE = '22023';
+  END IF;
+
+  SELECT * INTO v_old
+    FROM public.transactions
+   WHERE id = p_transaction_id
+     AND (p_user_id IS NULL OR user_id = p_user_id)
+   FOR UPDATE;
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'transaction_not_found' USING ERRCODE = 'P0002';
+  END IF;
+
+  IF v_old.type = 'transfer' THEN
+    RAISE EXCEPTION 'transfers cannot be split' USING ERRCODE = 'P0001';
+  END IF;
+
+  SELECT COALESCE(jsonb_agg(to_jsonb(s) ORDER BY s.sort_order), '[]'::jsonb)
+    INTO v_old_splits
+    FROM public.transaction_splits s
+   WHERE s.transaction_id = p_transaction_id;
+
+  -- Let this function's own writes through the split guard (transaction-local).
+  PERFORM set_config('app.split_rpc', '1', true);
+
+  DELETE FROM public.transaction_splits WHERE transaction_id = p_transaction_id;
+
+  -- ── Un-split ──────────────────────────────────────────────────────────────
+  IF p_splits IS NULL OR jsonb_array_length(p_splits) = 0 THEN
+    IF v_old.is_split THEN
+      UPDATE public.transactions
+         SET is_split = false, updated_at = now()
+       WHERE id = p_transaction_id
+      RETURNING * INTO v_new;
+
+      PERFORM public.write_financial_audit(
+        v_new.user_id, 'transaction', v_new.id, 'update',
+        to_jsonb(v_old) || jsonb_build_object('splits', v_old_splits),
+        to_jsonb(v_new) || jsonb_build_object('splits', '[]'::jsonb)
+      );
+    END IF;
+    RETURN jsonb_build_object('is_split', false, 'split_count', 0, 'amount', v_old.amount);
+  END IF;
+
+  -- ── Split ─────────────────────────────────────────────────────────────────
+  IF jsonb_array_length(p_splits) < 2 THEN
+    RAISE EXCEPTION 'a split needs at least 2 lines' USING ERRCODE = '22023';
+  END IF;
+
+  FOR v_split IN SELECT value FROM jsonb_array_elements(p_splits) LOOP
+    v_category := btrim(COALESCE(v_split->>'category', ''));
+    IF v_category = '' THEN
+      RAISE EXCEPTION 'every split line needs a category' USING ERRCODE = '22023';
+    END IF;
+    IF NOT EXISTS (
+      SELECT 1 FROM public.categories c
+       WHERE c.id::text = v_category
+         AND c.user_id = v_old.user_id
+         AND c.is_transfer_category IS NOT TRUE
+    ) THEN
+      RAISE EXCEPTION 'unknown or transfer category: %', v_category USING ERRCODE = '22023';
+    END IF;
+
+    v_amount := (v_split->>'amount')::numeric(20,2);
+    IF v_amount IS NULL OR v_amount = 0 THEN
+      RAISE EXCEPTION 'every split line needs a non-zero amount' USING ERRCODE = '22023';
+    END IF;
+
+    v_ord := v_ord + 1;
+    INSERT INTO public.transaction_splits
+      (transaction_id, user_id, category, amount, memo, sort_order)
+    VALUES
+      (p_transaction_id, v_old.user_id, v_category, v_amount,
+       NULLIF(btrim(COALESCE(v_split->>'memo', '')), ''), v_ord);
+
+    v_sum := v_sum + v_amount;
+    v_count := v_count + 1;
+  END LOOP;
+
+  IF p_expected_amount IS NOT NULL AND v_sum <> p_expected_amount THEN
+    RAISE EXCEPTION 'split_total_mismatch: split lines sum to % but the transaction amount is %',
+      v_sum, p_expected_amount USING ERRCODE = 'P0001';
+  END IF;
+
+  UPDATE public.transactions
+     SET is_split = true,
+         category = '',            -- categorisation lives in the split lines
+         amount = v_sum,
+         updated_at = now()
+   WHERE id = p_transaction_id
+  RETURNING * INTO v_new;
+
+  IF v_new.amount <> v_old.amount THEN
+    SELECT * INTO v_acct_before
+      FROM public.accounts
+     WHERE id = v_new.account_id AND user_id = v_new.user_id
+     FOR UPDATE;
+    IF NOT FOUND THEN
+      RAISE EXCEPTION 'account_not_found_or_not_owned' USING ERRCODE = 'P0001';
+    END IF;
+
+    UPDATE public.accounts
+       SET balance = balance + (v_new.amount - v_old.amount),
+           updated_at = now()
+     WHERE id = v_new.account_id AND user_id = v_new.user_id
+    RETURNING * INTO v_acct_after;
+
+    PERFORM public.write_financial_audit(
+      v_new.user_id, 'account', v_acct_after.id, 'update',
+      to_jsonb(v_acct_before), to_jsonb(v_acct_after)
+    );
+  END IF;
+
+  SELECT COALESCE(jsonb_agg(to_jsonb(s) ORDER BY s.sort_order), '[]'::jsonb)
+    INTO v_new_splits
+    FROM public.transaction_splits s
+   WHERE s.transaction_id = p_transaction_id;
+
+  PERFORM public.write_financial_audit(
+    v_new.user_id, 'transaction', v_new.id, 'update',
+    to_jsonb(v_old) || jsonb_build_object('splits', v_old_splits),
+    to_jsonb(v_new) || jsonb_build_object('splits', v_new_splits)
+  );
+
+  RETURN jsonb_build_object('is_split', true, 'split_count', v_count, 'amount', v_sum);
+END;
+$$;
+
+-- ── Payee-memory fan-out must skip split parents ─────────────────────────────
+-- A split parent's category is blank BY DESIGN — without this guard the
+-- fan-out would treat it as uncategorised and stamp a single category onto
+-- it (the trigger above would reject the write mid-loop and fail the whole
+-- propagation). Recreated from 20260708100000; the only change is the
+-- `AND NOT is_split` condition.
+
+CREATE OR REPLACE FUNCTION public.apply_category_to_uncategorized(
+  p_ids uuid[],
+  p_category text,
+  p_user_id uuid DEFAULT NULL
+)
+RETURNS integer
+LANGUAGE plpgsql SECURITY INVOKER
+SET search_path = public
+AS $$
+DECLARE
+  v_count integer := 0;
+  v_old public.transactions;
+  v_new public.transactions;
+BEGIN
+  FOR v_old IN
+    SELECT * FROM public.transactions
+     WHERE id = ANY(p_ids)
+       AND (p_user_id IS NULL OR user_id = p_user_id)
+       AND (category IS NULL OR btrim(category) = '')
+       AND NOT is_split
+     FOR UPDATE
+  LOOP
+    UPDATE public.transactions
+       SET category = p_category,
+           updated_at = now()
+     WHERE id = v_old.id
+    RETURNING * INTO v_new;
+
+    PERFORM public.write_financial_audit(
+      v_new.user_id, 'transaction', v_new.id, 'update', to_jsonb(v_old), to_jsonb(v_new)
+    );
+
+    v_count := v_count + 1;
+  END LOOP;
+
+  RETURN v_count;
+END;
+$$;
+
+-- ── Category pruning must respect split usage ────────────────────────────────
+-- Recreated from 20260708160000; the only change is the transaction_splits
+-- NOT EXISTS (transaction_splits.category is TEXT with no FK, same as
+-- transactions.category — deleting a category a split references would
+-- orphan that split line's categorisation permanently).
+
+CREATE OR REPLACE FUNCTION public.delete_unused_categories(
+  p_ids uuid[],
+  p_user_id uuid DEFAULT NULL
+)
+RETURNS integer
+LANGUAGE plpgsql SECURITY INVOKER
+SET search_path = public
+AS $$
+DECLARE
+  v_count integer;
+BEGIN
+  DELETE FROM public.categories c
+   WHERE c.id = ANY(p_ids)
+     AND (p_user_id IS NULL OR c.user_id = p_user_id)
+     AND c.level <> 'type'
+     AND c.is_transfer_category IS NOT TRUE
+     AND NOT EXISTS (
+       SELECT 1 FROM public.transactions t
+        WHERE t.user_id = c.user_id AND t.category = c.id::text
+     )
+     AND NOT EXISTS (
+       SELECT 1 FROM public.transaction_splits s
+        WHERE s.user_id = c.user_id AND s.category = c.id::text
+     )
+     AND NOT EXISTS (
+       SELECT 1 FROM public.budgets b
+        WHERE b.user_id = c.user_id
+          AND (b.category = c.id::text OR b.category_id = c.id)
+     )
+     AND NOT EXISTS (
+       SELECT 1 FROM public.recurring_transactions r
+        WHERE r.category = c.id::text
+     )
+     AND NOT EXISTS (
+       -- A child that is NOT part of this batch keeps its parent alive.
+       SELECT 1 FROM public.categories ch
+        WHERE ch.parent_id = c.id
+          AND NOT (ch.id = ANY(p_ids))
+     );
+
+  GET DIAGNOSTICS v_count = ROW_COUNT;
+  RETURN v_count;
+END;
+$$;
+
+-- ── Grants ───────────────────────────────────────────────────────────────────
+
+REVOKE ALL ON FUNCTION public.set_transaction_splits(uuid, jsonb, numeric, uuid) FROM public, anon;
+GRANT EXECUTE ON FUNCTION public.set_transaction_splits(uuid, jsonb, numeric, uuid) TO authenticated, service_role;
+
+REVOKE ALL ON FUNCTION public.apply_category_to_uncategorized(uuid[], text, uuid) FROM public, anon;
+GRANT EXECUTE ON FUNCTION public.apply_category_to_uncategorized(uuid[], text, uuid) TO authenticated, service_role;
+
+REVOKE ALL ON FUNCTION public.delete_unused_categories(uuid[], uuid) FROM public, anon;
+GRANT EXECUTE ON FUNCTION public.delete_unused_categories(uuid[], uuid) TO authenticated, service_role;
+
+COMMIT;


### PR DESCRIPTION
Money-style **split transactions**, phases 1 and 2 of the plan agreed in chat. A split stays ONE ledger row — one date, one payee, one signed amount, one balance effect — while its categorisation moves into `transaction_splits` lines that **must sum exactly to the transaction amount**.

## ⚠️ Requires a migration (Steve runs it)

`supabase/migrations/20260713100000_transaction_splits.sql` — safe to apply before merging this PR (nothing reads the new schema until the client ships, and the two recreated RPCs only gain guards). It contains:

- `transactions.is_split` flag + `transaction_splits` table (RLS matching the other user tables, indexes incl. one for phase-3 aggregation)
- **`set_transaction_splits` RPC** — the only write path: replace-all semantics, ≥2 lines, valid non-transfer categories, non-zero amounts, `sum == p_expected_amount` enforced **server-side**, atomic amount + account-balance sync, full audit trail. Empty array un-splits.
- **Guard trigger** — outside the RPC, a split parent's `amount`, `category`, `type` and `is_split` are read-only, so quick edits, bulk tools and stale clients can never break the sum invariant.
- `apply_category_to_uncategorized` (payee fan-out) now **skips split parents** — their blank category means "split", not "uncategorised".
- `delete_unused_categories` refuses to delete a category any split line uses.

## The editor (to the agreed spec)

- **"Split across multiple categories"** toggle when editing an income/expense row (new rows are created single-category first, then split — and transfers can't split, the type button explains why).
- Each line: the searchable grouped category picker + an amount box; **"Add another category"** adds lines; a **delete button** appears on every line once there are more than two.
- A live **"Remaining to allocate: £x.xx"** indicator — red while unbalanced, **"Fully allocated ✓"** in green at exactly zero, and **Save stays disabled until it balances**, with the reason shown. All maths in Decimal — exact comparison, no float drift.
- A minus line models cashback-inside-a-shop (£120 groceries − £20 cashback = £100 transaction), exactly like MS Money.
- Split rows show an italic **"Split"** in the register's category column (inline category editing is disabled for them) and a "Split" placeholder in the quick-edit bar.

## Verified live (demo mode, exercising the local/offline path which mirrors the server rules)

Split a £307.29 expense into Groceries £200 + Dining Out £107.29: remainder indicator showed 107.29 outstanding in red with save blocked, unblocked at zero, saved cleanly — the row left the Groceries category list and totals/counters updated.

## Tests

3,057 passing (smoke suite) including new coverage: split maths (16 cases incl. float-trap 0.1+0.2, negative lines, currency-formatted input), the modal split UI (6), and the register "Split" chip (2). Strict typecheck + zero lint. Also fixed a pre-existing React missing-`key` warning in `TransactionRow.renderCell`.

**Phase 3** (split-aware reporting: category counters/lists, budgets, analytics, exports treating split lines as first-class) is deliberately not in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)