### PR TITLE
fix(sync): guard SyncConflictResolver's async state updates after unmount

### DIFF
--- a/src/components/SyncConflictResolver.test.tsx
+++ b/src/components/SyncConflictResolver.test.tsx
@@ -1,0 +1,93 @@
+/**
+ * SyncConflictResolver Tests
+ * Loading behaviour + the unmount guard that stops the async conflict load
+ * from calling setState after teardown (the intermittent "window is not
+ * defined" quality-gates failure). The exact CI crash mode — jsdom's window
+ * being torn down between test files — can't be reproduced inside one test,
+ * so the race test asserts the observable contract instead: a load that
+ * resolves after unmount must complete without errors or warnings.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, act } from '@testing-library/react';
+import { SyncConflictResolver } from './SyncConflictResolver';
+
+const mocks = vi.hoisted(() => ({
+  getConflicts: vi.fn<() => Promise<unknown[]>>(async () => []),
+  resolveConflict: vi.fn<(id: string, resolution: 'local' | 'server') => Promise<void>>(async () => {}),
+}));
+
+vi.mock('../services/offlineService', () => ({
+  offlineService: {
+    getConflicts: mocks.getConflicts,
+    resolveConflict: mocks.resolveConflict,
+  },
+}));
+
+const conflict = (id: string): Record<string, unknown> => ({
+  id,
+  entity: 'transaction',
+  localData: { description: 'TESCO STORES', amount: -45.5 },
+  serverData: null,
+  timestamp: 1720000000000,
+  resolved: false,
+});
+
+describe('SyncConflictResolver', () => {
+  let errorSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.getConflicts.mockResolvedValue([]);
+    errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    errorSpy.mockRestore();
+  });
+
+  it('renders nothing when there are no conflicts', async () => {
+    const { container } = render(<SyncConflictResolver />);
+    await act(async () => {});
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('shows the conflict indicator once conflicts load', async () => {
+    mocks.getConflicts.mockResolvedValue([conflict('c1')]);
+    render(<SyncConflictResolver />);
+    expect(
+      await screen.findByRole('button', { name: /resolve sync conflicts/i })
+    ).toBeInTheDocument();
+  });
+
+  it('drops unparseable and already-resolved conflicts', async () => {
+    mocks.getConflicts.mockResolvedValue([
+      conflict('c1'),
+      { ...conflict('c2'), resolved: true },
+      'not-a-conflict',
+      null,
+    ]);
+    render(<SyncConflictResolver />);
+    const indicator = await screen.findByRole('button', { name: /resolve sync conflicts/i });
+    // Only c1 survives — a single conflict shows no count badge
+    expect(indicator.textContent).not.toMatch(/\d/);
+  });
+
+  it('ignores a conflict load that resolves after unmount (teardown race)', async () => {
+    let resolveLoad: (value: unknown[]) => void = () => {};
+    mocks.getConflicts.mockReturnValue(
+      new Promise<unknown[]>(resolve => {
+        resolveLoad = resolve;
+      })
+    );
+
+    const { unmount } = render(<SyncConflictResolver />);
+    unmount();
+
+    await act(async () => {
+      resolveLoad([conflict('c1')]);
+    });
+
+    expect(errorSpy).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/SyncConflictResolver.tsx
+++ b/src/components/SyncConflictResolver.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useState } from 'react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { offlineService } from '../services/offlineService';
 import { AlertCircleIcon, CheckIcon, XIcon } from './icons';
 import { formatCurrency } from '../utils/formatters';
@@ -101,8 +101,24 @@ export function SyncConflictResolver(): React.JSX.Element | null {
   const [selectedConflict, setSelectedConflict] = useState<Conflict | null>(null);
   const [isOpen, setIsOpen] = useState(false);
 
+  // The IndexedDB reads below can resolve AFTER unmount; a late setState then
+  // crashes (react-dom touches window, already torn down in tests — the
+  // intermittent "window is not defined" quality-gates failure). Every
+  // post-await setState checks this ref first. Reset on mount because Strict
+  // Mode remounts reuse the same ref.
+  const isMountedRef = useRef(true);
+  useEffect(() => {
+    isMountedRef.current = true;
+    return () => {
+      isMountedRef.current = false;
+    };
+  }, []);
+
   const loadConflicts = useCallback(async () => {
     const unresolved: unknown[] = await offlineService.getConflicts();
+    if (!isMountedRef.current) {
+      return;
+    }
     const normalized = unresolved
       .map(normalizeConflict)
       .filter((conflict): conflict is Conflict => Boolean(conflict) && conflict !== null && !conflict.resolved);
@@ -117,6 +133,9 @@ export function SyncConflictResolver(): React.JSX.Element | null {
     const shouldCloseAfterResolve = conflicts.length <= 1;
     await offlineService.resolveConflict(conflictId, resolution);
     await loadConflicts();
+    if (!isMountedRef.current) {
+      return;
+    }
     setSelectedConflict(null);
 
     if (shouldCloseAfterResolve) {


### PR DESCRIPTION
Fixes the intermittent **"window is not defined"** quality-gates failure (seen on PR #98's first CI run, surfacing from `Layout.test.tsx`).

**Root cause:** `SyncConflictResolver.loadConflicts` awaits an IndexedDB read and then called `setConflicts`/`setSelectedConflict` unconditionally. When the component unmounts before the promise resolves — routine in CI, where jsdom's window is torn down between test files — the late `setState` reached react-dom's `getCurrentEventPriority` with no `window` and crashed the whole run.

**Fix:** an `isMountedRef` gates every post-await `setState` in `loadConflicts` and `resolveConflict` (ref resets on mount so Strict Mode remounts behave).

**Tests:** new `SyncConflictResolver.test.tsx` — loading, filtering of unparseable/already-resolved conflicts, and the unmount race (a deferred load resolved after unmount must complete without errors or console output). The exact CI crash mode (cross-file window teardown) can't be reproduced inside a single test, so the race test asserts the observable contract. Full smoke suite: 3,061 passing; strict types + zero lint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)