### PR TITLE
feat(splits): phase 3 — split-aware reporting + rebuilt delete-category dialog

### DIFF
--- a/src/components/CategorySelector.tsx
+++ b/src/components/CategorySelector.tsx
@@ -40,6 +40,11 @@ interface CategorySelectorProps {
    * (which open the list upward in-flow) are unchanged.
    */
   usePortal?: boolean;
+  /**
+   * Category ids to leave out of the list — e.g. the category being DELETED
+   * in the reassignment dialog must not be offered as its own replacement.
+   */
+  excludeIds?: string[];
 }
 
 export default function CategorySelector({
@@ -52,6 +57,7 @@ export default function CategorySelector({
   includeAllTypes = false,
   showHelperText = true,
   usePortal = false,
+  excludeIds,
 }: CategorySelectorProps): React.JSX.Element {
   const { categories, addCategory, getSubCategories, getDetailCategories } = useApp();
   const [showDropdown, setShowDropdown] = useState(false);
@@ -137,7 +143,9 @@ export default function CategorySelector({
       detailCategories.push(...details);
     });
 
-    return detailCategories;
+    return excludeIds && excludeIds.length > 0
+      ? detailCategories.filter(c => !excludeIds.includes(c.id))
+      : detailCategories;
   };
 
   // Filter categories based on search term

--- a/src/components/CategoryTransactionsModal.test.tsx
+++ b/src/components/CategoryTransactionsModal.test.tsx
@@ -47,11 +47,19 @@ const transactions = [
   txn({ id: 't1', description: 'A S CAR VALET SER', amount: -45 }),
   txn({ id: 't2', description: 'TFL CONGESTN CHRGE', amount: -12.5, date: new Date('2026-06-25') }),
   txn({ id: 't3', description: 'SOME OTHER CATEGORY ROW', category: 'cat-elsewhere' }),
+  // A split parent: £60 of it filed under cat-other, £40 elsewhere
+  txn({ id: 't4', description: 'TESCO SUPERSTORE', amount: -100, category: '', isSplit: true }),
+];
+
+const transactionSplits = [
+  { id: 's1', transactionId: 't4', category: 'cat-other', amount: -60, sortOrder: 1 },
+  { id: 's2', transactionId: 't4', category: 'cat-elsewhere', amount: -40, sortOrder: 2 },
 ];
 
 vi.mock('../contexts/AppContextSupabase', () => ({
   useApp: () => ({
     transactions,
+    transactionSplits,
     accounts: [{ id: 'acc-1', name: 'HSBC Premier - Current Account' }],
   }),
 }));
@@ -87,6 +95,22 @@ describe('CategoryTransactionsModal', () => {
 
     expect(screen.getByTestId('edit-transaction-modal')).toBeInTheDocument();
     expect(screen.getByText('Editing: TFL CONGESTN CHRGE')).toBeInTheDocument();
+  });
+
+  it('lists a split line under its category with the LINE amount and a badge', () => {
+    renderModal();
+    // The £60 cat-other line of the £100 split appears; the parent's total doesn't
+    const splitRow = screen.getByRole('button', { name: /TESCO SUPERSTORE/ });
+    expect(splitRow).toHaveTextContent('split');
+    expect(splitRow).toHaveTextContent('£60.00');
+    expect(splitRow).not.toHaveTextContent('£100.00');
+  });
+
+  it('opens the PARENT transaction when a split line is clicked', () => {
+    renderModal();
+    fireEvent.click(screen.getByRole('button', { name: /TESCO SUPERSTORE/ }));
+    // The editor receives the real parent transaction, not the virtual line
+    expect(screen.getByText('Editing: TESCO SUPERSTORE')).toBeInTheDocument();
   });
 
   it('returns to the list when the editor closes', () => {

--- a/src/components/CategoryTransactionsModal.tsx
+++ b/src/components/CategoryTransactionsModal.tsx
@@ -6,6 +6,7 @@ import { XCircleIcon } from './icons/XCircleIcon';
 import { useApp } from '../contexts/AppContextSupabase';
 import { useCurrencyDecimal } from '../hooks/useCurrencyDecimal';
 import EditTransactionModal from './EditTransactionModal';
+import { expandSplitTransactions, type SplitExpandedTransaction } from '../utils/transactionSplits';
 import type { Transaction } from '../types';
 
 interface CategoryTransactionsModalProps {
@@ -23,7 +24,7 @@ export default function CategoryTransactionsModal({
   categoryId,
   categoryName 
 }: CategoryTransactionsModalProps) {
-  const { transactions, accounts } = useApp();
+  const { transactions, transactionSplits, accounts } = useApp();
   const { formatCurrency } = useCurrencyDecimal();
   
   // Filter states
@@ -38,10 +39,13 @@ export default function CategoryTransactionsModal({
   // list on its own.
   const [editingTransaction, setEditingTransaction] = useState<Transaction | null>(null);
 
-  // Get all transactions for this category
-  const categoryTransactions = useMemo(() => {
-    return transactions.filter(t => t.category === categoryId);
-  }, [transactions, categoryId]);
+  // All rows filed under this category — split parents expand into their
+  // per-line virtual rows first, so a split line shows here under ITS
+  // category, carrying the line's amount (not the parent's total).
+  const categoryTransactions = useMemo<SplitExpandedTransaction[]>(() => {
+    return expandSplitTransactions(transactions, transactionSplits)
+      .filter(t => t.category === categoryId);
+  }, [transactions, transactionSplits, categoryId]);
   
   // Apply filters
   const filteredTransactions = useMemo(() => {
@@ -339,8 +343,19 @@ export default function CategoryTransactionsModal({
                   <button
                     key={transaction.id}
                     type="button"
-                    onClick={() => setEditingTransaction(transaction)}
-                    title="Edit or re-categorise this transaction"
+                    onClick={() => {
+                      // A split line belongs to its parent transaction — the
+                      // editor opens THAT (with all its split lines loaded).
+                      const target = transaction.isSplitLine
+                        ? transactions.find(t => t.id === transaction.splitParentId)
+                        : transaction;
+                      if (target) {
+                        setEditingTransaction(target);
+                      }
+                    }}
+                    title={transaction.isSplitLine
+                      ? 'Part of a split transaction — opens the full transaction to edit its splits'
+                      : 'Edit or re-categorise this transaction'}
                     className="w-full text-left flex items-center justify-between p-3 bg-gray-50 dark:bg-gray-700 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-600 transition-colors cursor-pointer"
                   >
                     <div className="flex-1">
@@ -348,6 +363,11 @@ export default function CategoryTransactionsModal({
                         <div>
                           <span className="block font-medium text-gray-900 dark:text-white">
                             {transaction.description}
+                            {transaction.isSplitLine && (
+                              <span className="ml-2 align-middle text-xs font-medium italic text-blue-600 dark:text-blue-400">
+                                split
+                              </span>
+                            )}
                           </span>
                           <span className="block text-sm text-gray-500 dark:text-gray-400 mt-0.5">
                             {new Date(transaction.date).toLocaleDateString()} • {account?.name || 'Unknown Account'}

--- a/src/components/EnhancedExportManager.tsx
+++ b/src/components/EnhancedExportManager.tsx
@@ -1,6 +1,7 @@
-import React, { useState } from 'react';
+import React, { useState, useMemo } from 'react';
 import { FileTextIcon, DownloadIcon, CalendarIcon, FileSpreadsheetIcon, FilePlusIcon, XIcon, TrendingUpIcon, DollarSignIcon, PieChartIcon, ReceiptIcon } from './icons';
 import { useApp } from '../contexts/AppContextSupabase';
+import { expandSplitTransactions } from '../utils/transactionSplits';
 import { format, startOfMonth, endOfMonth, startOfYear, endOfYear, subMonths } from 'date-fns';
 import { useCurrencyDecimal } from '../hooks/useCurrencyDecimal';
 import { formatDecimal } from '../utils/decimal-format';
@@ -113,7 +114,13 @@ const REPORT_TEMPLATES = [
 ];
 
 export default function EnhancedExportManager(): React.JSX.Element {
-  const { accounts, transactions, budgets } = useApp();
+  const { accounts, transactions: rawTransactions, transactionSplits, budgets } = useApp();
+  // Exports work on the split-EXPANDED view (one row per split line) so
+  // category summaries and budget analysis count split lines correctly.
+  const transactions = useMemo(
+    () => expandSplitTransactions(rawTransactions, transactionSplits),
+    [rawTransactions, transactionSplits]
+  );
   const { formatCurrency } = useCurrencyDecimal();
   const [isOpen, setIsOpen] = useState(false);
   const [selectedTemplate, setSelectedTemplate] = useState<string | null>(null);

--- a/src/components/EnvelopeBudgeting.test.tsx
+++ b/src/components/EnvelopeBudgeting.test.tsx
@@ -93,7 +93,8 @@ let currentMockBudgets = mockBudgets;
 vi.mock('../contexts/AppContextSupabase', () => ({
   useApp: () => ({
     categories: mockCategories,
-    getDecimalTransactions: () => mockTransactions
+    transactions: mockTransactions,
+    transactionSplits: []
   })
 }));
 

--- a/src/components/EnvelopeBudgeting.tsx
+++ b/src/components/EnvelopeBudgeting.tsx
@@ -4,6 +4,8 @@ import { useCurrencyDecimal } from '../hooks/useCurrencyDecimal';
 import { formatDecimal } from '../utils/decimal-format';
 import { useBudgets } from '../contexts/BudgetContext';
 import { toDecimal, parseMoneyInput } from '../utils/decimal';
+import { toDecimalTransaction } from '../utils/decimal-converters';
+import { expandSplitTransactions } from '../utils/transactionSplits';
 import type { DecimalInstance } from '../types/decimal-types';
 import type { DecimalTransaction } from '../types/decimal-types';
 import { 
@@ -29,7 +31,7 @@ interface Envelope {
 }
 
 export default function EnvelopeBudgeting() {
-  const { categories, getDecimalTransactions } = useApp();
+  const { categories, transactions: rawTransactions, transactionSplits } = useApp();
   const { budgets, addBudget, updateBudget } = useBudgets();
   const { formatCurrency } = useCurrencyDecimal();
   
@@ -49,7 +51,12 @@ export default function EnvelopeBudgeting() {
     priority: 'medium' as 'high' | 'medium' | 'low'
   });
 
-  const transactions = getDecimalTransactions();
+  // Split parents expand into per-line rows so split lines spend against
+  // THEIR categories' envelopes.
+  const transactions = useMemo(
+    () => expandSplitTransactions(rawTransactions, transactionSplits).map(toDecimalTransaction),
+    [rawTransactions, transactionSplits]
+  );
   const currentMonth = new Date().toISOString().slice(0, 7);
 
   // Create envelopes from existing budgets

--- a/src/components/ExcelExport.test.tsx
+++ b/src/components/ExcelExport.test.tsx
@@ -129,6 +129,7 @@ vi.mock('../hooks/useCurrencyDecimal', () => ({
 vi.mock('../contexts/AppContextSupabase', () => ({
   useApp: () => ({
     transactions: mockTransactions,
+    transactionSplits: [],
     accounts: mockAccounts,
     budgets: mockBudgets,
     categories: mockCategories

--- a/src/components/ExcelExport.tsx
+++ b/src/components/ExcelExport.tsx
@@ -1,5 +1,6 @@
-import React, { useState } from 'react';
+import React, { useState, useMemo } from 'react';
 import { useApp } from '../contexts/AppContextSupabase';
+import { expandSplitTransactions } from '../utils/transactionSplits';
 import { useCurrencyDecimal } from '../hooks/useCurrencyDecimal';
 import { Modal } from './common/Modal';
 import { 
@@ -46,7 +47,14 @@ interface ExportOptions {
 }
 
 export default function ExcelExport({ isOpen, onClose }: ExcelExportProps): React.JSX.Element {
-  const { transactions, accounts, budgets, categories } = useApp();
+  const { transactions: rawTransactions, transactionSplits, accounts, budgets, categories } = useApp();
+  // Exports work on the split-EXPANDED view: a split parent becomes one row
+  // per line, so category columns and breakdowns are correct and totals
+  // still sum exactly (lines sum to the parent by the DB invariant).
+  const transactions = useMemo(
+    () => expandSplitTransactions(rawTransactions, transactionSplits),
+    [rawTransactions, transactionSplits]
+  );
   const { getCurrencySymbol, displayCurrency } = useCurrencyDecimal();
   const currencySymbol = getCurrencySymbol(displayCurrency);
   const [isExporting, setIsExporting] = useState(false);

--- a/src/components/FinancialSummary.tsx
+++ b/src/components/FinancialSummary.tsx
@@ -1,5 +1,6 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useMemo } from 'react';
 import { useApp } from '../contexts/AppContextSupabase';
+import { expandSplitTransactions } from '../utils/transactionSplits';
 import { financialSummaryService, type SummaryData } from '../services/financialSummaryService';
 import { CalendarIcon, TrendingUpIcon, TrendingDownIcon, PieChartIcon, TargetIcon } from './icons';
 import { useCurrencyDecimal } from '../hooks/useCurrencyDecimal';
@@ -13,7 +14,13 @@ interface FinancialSummaryProps {
 }
 
 export default function FinancialSummary({ period }: FinancialSummaryProps) {
-  const { transactions, accounts, budgets, goals } = useApp();
+  const { transactions: rawTransactions, transactionSplits, accounts, budgets, goals } = useApp();
+  // Split parents expand into per-line rows so category rankings count split
+  // lines under their categories (totals are unchanged — lines sum exactly).
+  const transactions = useMemo(
+    () => expandSplitTransactions(rawTransactions, transactionSplits),
+    [rawTransactions, transactionSplits]
+  );
   const { formatCurrency, getCurrencySymbol, displayCurrency } = useCurrencyDecimal();
   const [summary, setSummary] = useState<SummaryData | null>(null);
   const [showDetails, setShowDetails] = useState(false);

--- a/src/components/SharedBudgetsGoals.tsx
+++ b/src/components/SharedBudgetsGoals.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useCallback } from 'react';
+import React, { useState, useEffect, useCallback, useMemo } from 'react';
 import { useApp } from '../contexts/AppContextSupabase';
 import { householdService } from '../services/householdService';
 import {
@@ -21,6 +21,7 @@ import {
 import { CreateBudgetModal, CreateGoalModal } from './SharedBudgetsModals';
 import { useCurrency } from '../hooks/useCurrency';
 import { toDecimal } from '../utils/decimal';
+import { expandSplitTransactions } from '../utils/transactionSplits';
 import type { DecimalInstance } from '../utils/decimal';
 import { formatDecimal } from '../utils/decimal-format';
 import { format } from 'date-fns';
@@ -50,7 +51,13 @@ interface GoalFormState {
 }
 
 export default function SharedBudgetsGoals() {
-  const { transactions, categories, addBudget, addGoal } = useApp();
+  const { transactions: rawTransactions, transactionSplits, categories, addBudget, addGoal } = useApp();
+  // Split parents expand into per-line rows so shared-budget spending counts
+  // split lines against their categories.
+  const transactions = useMemo(
+    () => expandSplitTransactions(rawTransactions, transactionSplits),
+    [rawTransactions, transactionSplits]
+  );
   const { formatCurrency } = useCurrency();
   const [household] = useState(householdService.getHousehold());
   const [currentMember] = useState(household?.members[0]); // Assume first member is current user

--- a/src/components/SpendingAlerts.tsx
+++ b/src/components/SpendingAlerts.tsx
@@ -5,6 +5,8 @@ import { useLocalStorage } from '../hooks/useLocalStorage';
 import { useCurrencyDecimal } from '../hooks/useCurrencyDecimal';
 import { calculateBudgetSpending, calculateBudgetPercentage } from '../utils/calculations-decimal';
 import { toDecimal } from '../utils/decimal';
+import { toDecimalTransaction } from '../utils/decimal-converters';
+import { expandSplitTransactions } from '../utils/transactionSplits';
 import { formatDecimal } from '../utils/decimal-format';
 import type { DecimalInstance, DecimalBudget } from '../types/decimal-types';
 import {
@@ -103,7 +105,7 @@ const DEFAULT_ALERT_CONFIGS: AlertConfig[] = [
 ];
 
 export default function SpendingAlerts() {
-  const { categories, getDecimalTransactions } = useApp();
+  const { categories, transactions, transactionSplits } = useApp();
   const { budgets } = useBudgets();
   const { formatCurrency } = useCurrencyDecimal();
   
@@ -121,7 +123,10 @@ export default function SpendingAlerts() {
         ...b,
         amount: toDecimal(b.amount)
       }));
-      const decimalTransactions = getDecimalTransactions();
+      // Split parents expand into per-line rows so split lines alert
+      // against THEIR categories' budgets.
+      const decimalTransactions = expandSplitTransactions(transactions, transactionSplits)
+        .map(toDecimalTransaction);
       const newAlerts: Alert[] = [];
       
       const now = new Date();
@@ -211,7 +216,7 @@ export default function SpendingAlerts() {
     const interval = setInterval(checkAlerts, 60000); // Check every minute
     
     return () => clearInterval(interval);
-  }, [budgets, alertConfigs, mutedCategories, getDecimalTransactions, alerts, setAlerts]);
+  }, [budgets, alertConfigs, mutedCategories, transactions, transactionSplits, alerts, setAlerts]);
 
   // Calculate alert statistics
   const alertStats = useMemo((): AlertStats => {

--- a/src/components/dashboard/ImprovedDashboard.tsx
+++ b/src/components/dashboard/ImprovedDashboard.tsx
@@ -25,6 +25,7 @@ import { Modal, ModalBody } from '../common/Modal';
 import { PieChart, BarChart, ResponsiveContainer } from '../charts/DashboardCharts';
 import { formatDecimal } from '../../utils/decimal-format';
 import { toDecimal } from '../../utils/decimal';
+import { expandSplitTransactions } from '../../utils/transactionSplits';
 
 /**
  * Improved Dashboard with better information hierarchy
@@ -35,7 +36,7 @@ import { toDecimal } from '../../utils/decimal';
  * 4. Mobile-optimized - works great on all screen sizes
  */
 export function ImprovedDashboard() {
-  const { accounts, transactions, budgets } = useApp();
+  const { accounts, transactions, transactionSplits, budgets } = useApp();
   const { formatCurrency: formatCurrencyWithSymbol, displayCurrency } = useCurrencyDecimal();
   const navigate = useNavigate();
   const location = useLocation();
@@ -129,8 +130,11 @@ export function ImprovedDashboard() {
     // Calculate budget status for active budgets
     const activeBudgets = budgets.filter(b => b.isActive);
     
+    // Split parents expand into per-line rows so a split line spends
+    // against ITS category's budget.
+    const recentExpanded = expandSplitTransactions(recentTransactions, transactionSplits);
     const budgetStatus = activeBudgets.map(budget => {
-      const categoryTransactions = recentTransactions.filter(t => 
+      const categoryTransactions = recentExpanded.filter(t =>
         t.category === budget.categoryId && t.type === 'expense'
       );
       const spent = categoryTransactions.reduce((sum, t) => sum + Math.abs(t.amount), 0);
@@ -167,7 +171,7 @@ export function ImprovedDashboard() {
       netWorthChange: 0, // Will be calculated from actual historical data when available
       netWorthChangePercent: 0 // Will be calculated from actual historical data when available
     };
-  }, [accounts, transactions, budgets]);
+  }, [accounts, transactions, transactionSplits, budgets]);
   
   // Generate net worth data for chart - ONLY REAL DATA
   const netWorthData = useMemo(() => {

--- a/src/contexts/AppContextSupabase.tsx
+++ b/src/contexts/AppContextSupabase.tsx
@@ -126,6 +126,12 @@ export interface AppContextType extends AppState {
    * category, enforced server-side. Returns the number actually updated.
    */
   applyCategoryToUncategorized: (ids: string[], category: string) => Promise<number>;
+  /**
+   * Every split line of the user's transactions, loaded at boot and kept in
+   * step by setTransactionSplits. Category-aggregation surfaces expand split
+   * parents into these via expandSplitTransactions.
+   */
+  transactionSplits: TransactionSplit[];
   /** Splits for one transaction, in display order (empty when not split). */
   getTransactionSplits: (transactionId: string) => Promise<TransactionSplit[]>;
   /**
@@ -153,6 +159,11 @@ export function AppProvider({ children }: { children: React.ReactNode }) {
   const [categories, setCategories] = useState<Category[]>([]);
   const [tags, setTags] = useState<Tag[]>([]);
   const [recurringTransactions, setRecurringTransactions] = useState<RecurringTransaction[]>([]);
+  // Every split line of the user's transactions, loaded once at boot and kept
+  // in step by setTransactionSplits/deleteTransaction. Category-aggregation
+  // surfaces (counters, budgets, analytics, exports) expand split parents
+  // into these lines via expandSplitTransactions.
+  const [transactionSplits, setTransactionSplitsState] = useState<TransactionSplit[]>([]);
   
   const [isLoading, setIsLoading] = useState(true);
   const [isSyncing, setIsSyncing] = useState(false);
@@ -227,6 +238,15 @@ export function AppProvider({ children }: { children: React.ReactNode }) {
         // Now load transactions, budgets, and goals (post-remap views).
         const data = await DataService.loadAppData();
         setTransactions(data.transactions);
+
+        // Split lines ride along with transactions; a failure here must not
+        // block the app (split parents then pass through aggregation whole).
+        try {
+          setTransactionSplitsState(await DataService.getAllTransactionSplits());
+        } catch (splitError) {
+          appLogger.error('Failed to load transaction splits', splitError);
+          setTransactionSplitsState([]);
+        }
 
         // Without an authenticated user (demo / local-only mode) the
         // SimpleAccountService path above returns nothing — it needs a
@@ -561,6 +581,19 @@ export function AppProvider({ children }: { children: React.ReactNode }) {
       const oldTransaction = transactions.find(t => t.id === transactionId);
       const result = await DataService.setTransactionSplits(transactionId, splits, expectedAmount);
 
+      // Keep the aggregation-facing splits state in step. Re-read the rows
+      // (rather than synthesising them) so ids match the server's; a failed
+      // re-read only staleness-es this transaction's lines until next load.
+      try {
+        const freshSplits = result.isSplit ? await DataService.getTransactionSplits(transactionId) : [];
+        setTransactionSplitsState(prev => [
+          ...prev.filter(s => s.transactionId !== transactionId),
+          ...freshSplits,
+        ]);
+      } catch (splitReadError) {
+        appLogger.error('Failed to refresh splits after save', splitReadError);
+      }
+
       // Mirror the atomic server change locally: the flag, the blanked
       // category while split, and the amount the splits sum to.
       setTransactions(prev => prev.map(t =>
@@ -597,6 +630,8 @@ export function AppProvider({ children }: { children: React.ReactNode }) {
       const transaction = transactions.find(t => t.id === id);
       await DataService.deleteTransaction(id);
       setTransactions(prev => prev.filter(t => t.id !== id));
+      // Its split lines cascade away in the DB (FK); mirror locally.
+      setTransactionSplitsState(prev => prev.filter(s => s.transactionId !== id));
       
       // Update account balance (Decimal arithmetic; the DB balance is reversed
       // atomically inside delete_transaction_atomic).
@@ -964,6 +999,7 @@ export function AppProvider({ children }: { children: React.ReactNode }) {
     deleteTransaction,
     setTransactionsCleared,
     applyCategoryToUncategorized,
+    transactionSplits,
     getTransactionSplits,
     setTransactionSplits,
 

--- a/src/pages/Budget.tsx
+++ b/src/pages/Budget.tsx
@@ -15,6 +15,7 @@ import type { Budget } from '../types';
 import PageWrapper from '../components/PageWrapper';
 import PageTip from '../components/PageTip';
 import { calculateBudgetSpending, calculateBudgetRemaining, calculateBudgetPercentage } from '../utils/calculations-decimal';
+import { expandSplitTransactions } from '../utils/transactionSplits';
 import { toDecimal } from '../utils/decimal';
 import type { DecimalInstance } from '../utils/decimal';
 import { formatDecimal } from '../utils/decimal-format';
@@ -31,7 +32,7 @@ export default function Budget() {
   };
   
   // Get data from context
-  const { budgets, updateBudget, deleteBudget, transactions, categories } = useApp();
+  const { budgets, updateBudget, deleteBudget, transactions, transactionSplits, categories } = useApp();
   const { checkEnhancedBudgetAlerts, checkBudgetAlerts, alertThreshold } = useNotifications();
 
   // Memoize current date values
@@ -45,6 +46,14 @@ export default function Budget() {
 
   // Calculate spent amounts for each budget with memoization
   const budgetsWithSpent = useMemo(() => {
+    // Split parents expand into their per-line rows first, so a split line
+    // spends against ITS category's budget. Converted to decimal once, not
+    // per budget.
+    const decimalTransactions = expandSplitTransactions(transactions, transactionSplits).map(t => ({
+      ...t,
+      amount: toDecimal(t.amount)
+    }));
+
     return budgets
       .filter(budget => budget !== null && budget !== undefined)
       .map((budget) => {
@@ -53,13 +62,7 @@ export default function Budget() {
           ...budget,
           amount: toDecimal(budget.amount)
         };
-        
-        // Convert transactions to decimal for calculations
-        const decimalTransactions = transactions.map(t => ({
-          ...t,
-          amount: toDecimal(t.amount)
-        }));
-        
+
         // Calculate date range for budget period
         let startDate: Date;
         let endDate: Date;
@@ -94,7 +97,7 @@ export default function Budget() {
           remaining: remaining.toNumber()
         };
       });
-  }, [budgets, transactions, currentMonth, currentYear]);
+  }, [budgets, transactions, transactionSplits, currentMonth, currentYear]);
 
   const categoryNameById = useMemo(() => {
     const map = new Map<string, string>();

--- a/src/pages/FinancialSummaries.tsx
+++ b/src/pages/FinancialSummaries.tsx
@@ -1,5 +1,6 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useMemo } from 'react';
 import { useApp } from '../contexts/AppContextSupabase';
+import { expandSplitTransactions } from '../utils/transactionSplits';
 import { financialSummaryService } from '../services/financialSummaryService';
 import PageWrapper from '../components/PageWrapper';
 import FinancialSummary from '../components/FinancialSummary';
@@ -9,7 +10,13 @@ import { useCurrencyDecimal } from '../hooks/useCurrencyDecimal';
 import { formatDecimal } from '../utils/decimal-format';
 
 export default function FinancialSummaries() {
-  const { transactions, accounts, budgets, goals } = useApp();
+  const { transactions: rawTransactions, transactionSplits, accounts, budgets, goals } = useApp();
+  // Split parents expand into per-line rows so category rankings count split
+  // lines under their categories (totals are unchanged — lines sum exactly).
+  const transactions = useMemo(
+    () => expandSplitTransactions(rawTransactions, transactionSplits),
+    [rawTransactions, transactionSplits]
+  );
   const { formatCurrency } = useCurrencyDecimal();
   const [activeTab, setActiveTab] = useState<'weekly' | 'monthly'>('weekly');
   const [showHistory, setShowHistory] = useState(false);

--- a/src/pages/settings/Categories.tsx
+++ b/src/pages/settings/Categories.tsx
@@ -2,7 +2,9 @@ import { useState, useMemo } from 'react';
 import { useApp } from '../../contexts/AppContextSupabase';
 import { useToast } from '../../contexts/ToastContext';
 import { MS_MONEY_CATEGORY_SET } from '../../data/msMoneyCategories';
+import { expandSplitTransactions, splitsByTransaction } from '../../utils/transactionSplits';
 import CategoryCreationModal from '../../components/CategoryCreationModal';
+import CategorySelector from '../../components/CategorySelector';
 import CategoryTransactionsModal from '../../components/CategoryTransactionsModal';
 import { AlertCircleIcon, Settings2Icon, GripVerticalIcon } from '../../components/icons';
 import { PlusIcon, XIcon, CheckIcon, ChevronRightIcon, ChevronDownIcon, DeleteIcon } from '../../components/icons';
@@ -162,6 +164,8 @@ export default function CategoriesSettings() {
   const {
     transactions,
     categories,
+    transactionSplits,
+    setTransactionSplits,
     updateCategory,
     deleteCategory,
     updateTransaction,
@@ -172,18 +176,26 @@ export default function CategoriesSettings() {
   const { showSuccess, showError } = useToast();
   const [isImporting, setIsImporting] = useState(false);
 
-  // Direct transaction count per category id, computed once per data change.
-  // Every row shows its counter (view AND edit/delete modes) — the old per-row
-  // transactions.filter() was O(rows × transactions) at 16k+ transactions.
+  // Split parents expand into their per-line virtual rows so a split line
+  // counts under ITS category, not nowhere (the parent's category is blank).
+  const expandedTransactions = useMemo(
+    () => expandSplitTransactions(transactions, transactionSplits),
+    [transactions, transactionSplits]
+  );
+
+  // Transaction count per category id (split lines included), computed once
+  // per data change. Every row shows its counter (view AND edit/delete
+  // modes) — the old per-row transactions.filter() was O(rows × transactions)
+  // at 16k+ transactions.
   const categoryTransactionCounts = useMemo(() => {
     const counts = new Map<string, number>();
-    for (const t of transactions) {
+    for (const t of expandedTransactions) {
       if (t.category) {
         counts.set(t.category, (counts.get(t.category) ?? 0) + 1);
       }
     }
     return counts;
-  }, [transactions]);
+  }, [expandedTransactions]);
 
   // The type-level ids are user-specific UUIDs after cloud migration — the old
   // hardcoded 'type-income'/'type-expense'/'type-transfer' anchors matched
@@ -221,18 +233,6 @@ export default function CategoriesSettings() {
     }
   };
   
-  // Helper function to get category path
-  const getCategoryPath = (categoryId: string): string => {
-    const category = categories.find(c => c.id === categoryId);
-    if (!category) return categoryId;
-    
-    if (category.level === 'detail' && category.parentId) {
-      const parent = categories.find(c => c.id === category.parentId);
-      return parent ? `${parent.name} > ${category.name}` : category.name;
-    }
-    
-    return category.name;
-  };
 
   const [isEditMode, setIsEditMode] = useState(false);
   const [isDeleteMode, setIsDeleteMode] = useState(false);
@@ -240,6 +240,7 @@ export default function CategoriesSettings() {
   const [editingCategoryName, setEditingCategoryName] = useState('');
   const [showCategoryModal, setShowCategoryModal] = useState(false);
   const [deletingCategoryId, setDeletingCategoryId] = useState<string | null>(null);
+  const [isReassigning, setIsReassigning] = useState(false);
   const [reassignCategoryId, setReassignCategoryId] = useState<string>('');
   const [expandedCategories, setExpandedCategories] = useState<Set<string>>(new Set());
   const [activeId, setActiveId] = useState<string | null>(null);
@@ -494,7 +495,10 @@ export default function CategoriesSettings() {
       return;
     }
 
-    const transactionCount = transactions.filter(t => t.category === categoryId).length;
+    // Count on the EXPANDED view so a category used only inside split lines
+    // still routes through reassignment — deleting it outright would orphan
+    // those lines' categorisation (the DB refuses that delete anyway).
+    const transactionCount = expandedTransactions.filter(t => t.category === categoryId).length;
     const childCategories = categories.filter(c => c.parentId === categoryId);
 
     if (childCategories.length > 0) {
@@ -827,64 +831,94 @@ export default function CategoriesSettings() {
             </div>
             {(() => {
               const category = categories.find(c => c.id === deletingCategoryId);
-              const transactionCount = transactions.filter(t => t.category === deletingCategoryId).length;
+              const directRows = transactions.filter(t => t.category === deletingCategoryId && !t.isSplit);
+              const affectedSplitLines = transactionSplits.filter(s => s.category === deletingCategoryId);
+              const transactionCount = directRows.length + affectedSplitLines.length;
 
               return (
                 <>
                   <p className="text-gray-600 dark:text-gray-400 mb-4">
-                    The category "{category?.name}" has {transactionCount} transaction{transactionCount !== 1 ? 's' : ''} associated with it.
+                    The category "{category?.name}" has {transactionCount} transaction{transactionCount !== 1 ? 's' : ''} associated with it
+                    {affectedSplitLines.length > 0 && (
+                      <> (including {affectedSplitLines.length} split line{affectedSplitLines.length !== 1 ? 's' : ''})</>
+                    )}.
                   </p>
                   <p className="text-gray-600 dark:text-gray-400 mb-4">
                     Please select a category to reassign these transactions to:
                   </p>
-                  <select
-                    value={reassignCategoryId}
-                    onChange={(e) => setReassignCategoryId(e.target.value)}
-                    className="w-full px-3 py-2 bg-white dark:bg-gray-800-sm border border-gray-300/50 dark:border-gray-600/50 rounded-xl focus:outline-none focus:ring-2 focus:ring-primary focus:border-transparent dark:text-white mb-6"
-                  >
-                    <option value="">Select a category...</option>
-                    {categories
-                      .filter(c => 
-                        c.id !== deletingCategoryId && 
-                        c.level === 'detail' && 
-                        (category?.type === 'both' || c.type === 'both' || c.type === category?.type)
-                      )
-                      .map(c => (
-                        <option key={c.id} value={c.id}>
-                          {getCategoryPath(c.id)}
-                        </option>
-                      ))
-                    }
-                  </select>
+                  {/* Same searchable grouped picker as the transaction editor —
+                      it filters out inactive categories (a closed account's
+                      transfer categories, stale renames) automatically. */}
+                  <div className="mb-6">
+                    <CategorySelector
+                      selectedCategory={reassignCategoryId}
+                      onCategoryChange={setReassignCategoryId}
+                      transactionType={category?.type === 'income' ? 'income' : 'expense'}
+                      includeAllTypes={category?.type === 'both'}
+                      excludeIds={[deletingCategoryId]}
+                      placeholder="Search or select category…"
+                      allowCreate={false}
+                      showHelperText={false}
+                      usePortal
+                    />
+                  </div>
                   <div className="flex gap-3">
                     <button
                       onClick={() => {
                         setDeletingCategoryId(null);
                         setReassignCategoryId('');
                       }}
-                      className="flex-1 px-4 py-2 border border-gray-300 dark:border-gray-600 text-gray-700 dark:text-gray-300 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-700"
+                      disabled={isReassigning}
+                      className="flex-1 px-4 py-2 border border-gray-300 dark:border-gray-600 text-gray-700 dark:text-gray-300 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-700 disabled:opacity-50"
                     >
                       Cancel
                     </button>
                     <button
-                      onClick={() => {
-                        if (reassignCategoryId) {
-                          // Reassign all transactions from the deleted category to the new category
-                          const transactionsToReassign = transactions.filter(t => t.category === deletingCategoryId);
-                          transactionsToReassign.forEach(transaction => {
-                            updateTransaction(transaction.id, { category: reassignCategoryId });
-                          });
-                          
-                          // Now delete the category
-                          deleteCategory(deletingCategoryId);
+                      onClick={async () => {
+                        if (!reassignCategoryId || reassignCategoryId === deletingCategoryId || isReassigning) {
+                          return;
+                        }
+                        setIsReassigning(true);
+                        try {
+                          // Ordinary rows move in one pass; failures surface
+                          // instead of silently racing the category delete.
+                          await Promise.all(directRows.map(transaction =>
+                            updateTransaction(transaction.id, { category: reassignCategoryId })
+                          ));
+
+                          // Split lines: swap the category inside each affected
+                          // parent's split set. Amounts are untouched, so the
+                          // sum invariant holds and the RPC accepts.
+                          const affectedParents = splitsByTransaction(affectedSplitLines);
+                          for (const parentId of affectedParents.keys()) {
+                            const allLines = transactionSplits
+                              .filter(s => s.transactionId === parentId)
+                              .sort((a, b) => a.sortOrder - b.sortOrder);
+                            const parent = transactions.find(t => t.id === parentId);
+                            await setTransactionSplits(
+                              parentId,
+                              allLines.map(line => ({
+                                category: line.category === deletingCategoryId ? reassignCategoryId : line.category,
+                                amount: line.amount,
+                                ...(line.memo ? { memo: line.memo } : {}),
+                              })),
+                              parent?.amount ?? null
+                            );
+                          }
+
+                          await deleteCategory(deletingCategoryId);
                           setDeletingCategoryId(null);
                           setReassignCategoryId('');
+                        } catch (error) {
+                          showError(error);
+                        } finally {
+                          setIsReassigning(false);
                         }
                       }}
                       className="flex-1 px-4 py-2 bg-red-500 text-white rounded-lg hover:bg-red-600 disabled:opacity-50"
-                      disabled={!reassignCategoryId}
+                      disabled={!reassignCategoryId || isReassigning}
                     >
-                      Delete & Reassign
+                      {isReassigning ? 'Reassigning…' : 'Delete & Reassign'}
                     </button>
                   </div>
                 </>

--- a/src/services/api/dataService.ts
+++ b/src/services/api/dataService.ts
@@ -28,7 +28,7 @@ type AccountServiceLike = Pick<typeof AccountService,
   subscribeToAccounts?: (userId: string, callback: (payload: unknown) => void) => () => void;
 };
 type TransactionServiceLike = Pick<typeof TransactionService,
-  'getTransactions' | 'createTransaction' | 'updateTransaction' | 'deleteTransaction' | 'setTransactionsCleared' | 'applyCategoryToUncategorized' | 'getTransactionSplits' | 'setTransactionSplits'> & {
+  'getTransactions' | 'createTransaction' | 'updateTransaction' | 'deleteTransaction' | 'setTransactionsCleared' | 'applyCategoryToUncategorized' | 'getTransactionSplits' | 'setTransactionSplits' | 'getAllTransactionSplits'> & {
   subscribeToTransactions?: (userId: string, callback: (payload: unknown) => void) => () => void;
 };
 type UserIdServiceLike = Pick<typeof userIdService,
@@ -326,6 +326,16 @@ class DataServiceImpl {
     return count;
   }
 
+  /** Every split line of the user's transactions (for category aggregation). */
+  async getAllTransactionSplits(): Promise<TransactionSplit[]> {
+    const userId = this.userIdService.getCurrentDatabaseUserId();
+    if (userId && this.supabaseChecker()) {
+      return this.transactionService.getAllTransactionSplits(userId);
+    }
+
+    return this.readCollection<TransactionSplit>(STORAGE_KEYS.TRANSACTION_SPLITS);
+  }
+
   /** Splits for one transaction, in display order (empty when not split). */
   async getTransactionSplits(transactionId: string): Promise<TransactionSplit[]> {
     const userId = this.userIdService.getCurrentDatabaseUserId();
@@ -537,6 +547,10 @@ export class DataService {
 
   static applyCategoryToUncategorized(ids: string[], category: string): Promise<number> {
     return this.service.applyCategoryToUncategorized(ids, category);
+  }
+
+  static getAllTransactionSplits(): Promise<TransactionSplit[]> {
+    return this.service.getAllTransactionSplits();
   }
 
   static getTransactionSplits(transactionId: string): Promise<TransactionSplit[]> {

--- a/src/services/api/transactionService.ts
+++ b/src/services/api/transactionService.ts
@@ -357,6 +357,55 @@ class TransactionServiceImpl {
     }
   }
 
+  /** Every split line of the user's transactions (for category aggregation). */
+  async getAllTransactionSplits(userId?: string): Promise<TransactionSplit[]> {
+    if (!this.isSupabaseReady()) {
+      return (await this.storage.get<TransactionSplit[]>(STORAGE_KEYS.TRANSACTION_SPLITS)) ?? [];
+    }
+
+    try {
+      const client = this.supabaseClient!;
+      // Page like getTransactions — splits are few today, but the 1000-row
+      // PostgREST cap would silently truncate a heavy splitter's data.
+      const PAGE_SIZE = 1000;
+      const rows: Record<string, unknown>[] = [];
+      let from = 0;
+      for (;;) {
+        let query = client
+          .from('transaction_splits')
+          .select('*')
+          .order('transaction_id', { ascending: true })
+          .order('sort_order', { ascending: true })
+          .range(from, from + PAGE_SIZE - 1);
+        if (userId) {
+          query = query.eq('user_id', userId);
+        }
+        const { data, error } = await query;
+        if (error) {
+          this.logger.error('Error fetching transaction splits:', error);
+          throw new Error(handleSupabaseError(error));
+        }
+        const page = (data || []) as Record<string, unknown>[];
+        rows.push(...page);
+        if (page.length < PAGE_SIZE) {
+          break;
+        }
+        from += PAGE_SIZE;
+      }
+      return rows.map(row => ({
+        id: String(row.id),
+        transactionId: String(row.transaction_id),
+        category: String(row.category),
+        amount: Number(row.amount),
+        memo: typeof row.memo === 'string' && row.memo !== '' ? row.memo : undefined,
+        sortOrder: Number(row.sort_order),
+      }));
+    } catch (error) {
+      this.logger.error('TransactionService.getAllTransactionSplits error:', error as Error);
+      throw error;
+    }
+  }
+
   /** Splits for one transaction, in display order (empty when not split). */
   async getTransactionSplits(transactionId: string): Promise<TransactionSplit[]> {
     if (!this.isSupabaseReady()) {
@@ -761,6 +810,10 @@ export class TransactionService {
 
   static applyCategoryToUncategorized(ids: string[], category: string, userId?: string): Promise<number> {
     return this.service.applyCategoryToUncategorized(ids, category, userId);
+  }
+
+  static getAllTransactionSplits(userId?: string): Promise<TransactionSplit[]> {
+    return this.service.getAllTransactionSplits(userId);
   }
 
   static getTransactionSplits(transactionId: string): Promise<TransactionSplit[]> {

--- a/src/test/mocks/AppContextSupabase.ts
+++ b/src/test/mocks/AppContextSupabase.ts
@@ -37,6 +37,7 @@ const baseValue = {
   deleteTransaction: noop,
   setTransactionsCleared: asyncNoop,
   applyCategoryToUncategorized: async () => 0,
+  transactionSplits: [],
   getTransactionSplits: async () => [],
   setTransactionSplits: async () => ({ isSplit: false, splitCount: 0, amount: 0 }),
   refreshAccountsAndTransactions: asyncNoop,

--- a/src/utils/transactionSplits.test.ts
+++ b/src/utils/transactionSplits.test.ts
@@ -5,8 +5,11 @@ import {
   validateSplitDrafts,
   signSplitAmounts,
   displaySplitAmount,
+  expandSplitTransactions,
+  splitsByTransaction,
   type SplitLineDraft,
 } from './transactionSplits';
+import type { Transaction, TransactionSplit } from '../types';
 
 const line = (category: string, amount: string): SplitLineDraft => ({ category, amount });
 
@@ -90,6 +93,81 @@ describe('signSplitAmounts', () => {
     );
     expect(result[0].memo).toBe('petrol');
     expect(result[1]).not.toHaveProperty('memo');
+  });
+});
+
+describe('expandSplitTransactions', () => {
+  const txn = (over: Partial<Transaction>): Transaction => ({
+    id: 'x',
+    date: new Date('2026-06-17'),
+    description: 'TESCO STORES',
+    amount: -100,
+    type: 'expense',
+    accountId: 'acc-1',
+    category: 'cat-a',
+    cleared: false,
+    ...over,
+  }) as Transaction;
+
+  const split = (over: Partial<TransactionSplit>): TransactionSplit => ({
+    id: 's1',
+    transactionId: 't1',
+    category: 'cat-a',
+    amount: -60,
+    sortOrder: 1,
+    ...over,
+  });
+
+  it('passes non-split transactions through untouched', () => {
+    const list = [txn({ id: 't1' }), txn({ id: 't2', category: 'cat-b' })];
+    expect(expandSplitTransactions(list, [])).toEqual(list);
+    // Splits belonging to OTHER transactions change nothing either
+    expect(expandSplitTransactions(list, [split({ transactionId: 't9' })])).toEqual(list);
+  });
+
+  it('replaces a split parent with one row per line', () => {
+    const parent = txn({ id: 't1', isSplit: true, category: '', amount: -100 });
+    const lines = [
+      split({ id: 's1', transactionId: 't1', category: 'groceries', amount: -60, sortOrder: 1 }),
+      split({ id: 's2', transactionId: 't1', category: 'household', amount: -40, sortOrder: 2, memo: 'bin bags' }),
+    ];
+    const result = expandSplitTransactions([parent], lines);
+
+    expect(result).toHaveLength(2);
+    expect(result.map(r => r.category)).toEqual(['groceries', 'household']);
+    expect(result.map(r => r.amount)).toEqual([-60, -40]);
+    expect(result.every(r => r.isSplitLine && r.splitParentId === 't1')).toBe(true);
+    expect(result.every(r => r.description === 'TESCO STORES')).toBe(true);
+    // Synthetic ids never collide with the parent's
+    expect(result.every(r => r.id !== 't1')).toBe(true);
+    // A line memo travels as the row's note
+    expect(result[1].notes).toBe('bin bags');
+    // Line amounts sum to the parent amount (the DB invariant)
+    expect(result.reduce((sum, r) => sum + r.amount, 0)).toBe(parent.amount);
+  });
+
+  it('derives the virtual row type from the line sign (cashback nets, never inflates)', () => {
+    const parent = txn({ id: 't1', isSplit: true, category: '', amount: -100 });
+    const lines = [
+      split({ id: 's1', transactionId: 't1', category: 'groceries', amount: -120, sortOrder: 1 }),
+      split({ id: 's2', transactionId: 't1', category: 'cashback', amount: 20, sortOrder: 2 }),
+    ];
+    const [groceries, cashback] = expandSplitTransactions([parent], lines);
+    expect(groceries.type).toBe('expense');
+    expect(cashback.type).toBe('income');
+  });
+
+  it('passes a split parent through whole when its lines are missing', () => {
+    const parent = txn({ id: 't1', isSplit: true, category: '', amount: -100 });
+    expect(expandSplitTransactions([parent], [])).toEqual([parent]);
+  });
+
+  it('orders lines by sortOrder via splitsByTransaction', () => {
+    const map = splitsByTransaction([
+      split({ id: 's2', sortOrder: 2 }),
+      split({ id: 's1', sortOrder: 1 }),
+    ]);
+    expect(map.get('t1')?.map(s => s.id)).toEqual(['s1', 's2']);
   });
 });
 

--- a/src/utils/transactionSplits.ts
+++ b/src/utils/transactionSplits.ts
@@ -1,4 +1,5 @@
 import { toDecimal, parseMoneyInput, type DecimalInstance } from './decimal';
+import type { Transaction, TransactionSplit } from '../types';
 
 /**
  * Split-editor money maths. Everything runs through Decimal — the "totals
@@ -87,4 +88,84 @@ export function signSplitAmounts(
 export function displaySplitAmount(storedAmount: number, type: 'income' | 'expense'): string {
   const value = toDecimal(storedAmount);
   return (type === 'expense' ? value.negated() : value).toString();
+}
+
+/**
+ * A transaction as seen by CATEGORY-AGGREGATION surfaces: either a real
+ * transaction passed through, or one line of a split parent projected into a
+ * virtual row that carries the line's category and amount.
+ */
+export interface SplitExpandedTransaction extends Transaction {
+  /** True for a virtual row projected from one split line. */
+  isSplitLine?: boolean;
+  /** The real transaction the line belongs to (open THIS in editors). */
+  splitParentId?: string;
+}
+
+/** Group splits by their parent transaction id, in sort order. */
+export function splitsByTransaction(splits: TransactionSplit[]): Map<string, TransactionSplit[]> {
+  const map = new Map<string, TransactionSplit[]>();
+  for (const split of splits) {
+    const list = map.get(split.transactionId);
+    if (list) {
+      list.push(split);
+    } else {
+      map.set(split.transactionId, [split]);
+    }
+  }
+  for (const list of map.values()) {
+    list.sort((a, b) => a.sortOrder - b.sortOrder);
+  }
+  return map;
+}
+
+/**
+ * Expand split parents into per-line virtual rows for CATEGORY aggregation
+ * (counters, category transaction lists, budgets, analytics, exports).
+ *
+ * - Non-split transactions pass through untouched.
+ * - A split parent is REPLACED by one row per line: same date/payee/account,
+ *   the line's category and signed amount, a synthetic id, and splitParentId
+ *   pointing back at the real row. Line amounts sum to the parent amount by
+ *   the set_transaction_splits invariant, so totals stay exact.
+ * - A parent whose lines are missing (splits not loaded yet) passes through
+ *   unchanged rather than vanishing from view.
+ *
+ * NEVER feed the result into balance arithmetic, the account register, or
+ * any write path — virtual rows have synthetic ids and exist only so
+ * "amount per category" style views can treat split lines as first-class.
+ */
+export function expandSplitTransactions(
+  transactions: Transaction[],
+  splits: TransactionSplit[]
+): SplitExpandedTransaction[] {
+  if (splits.length === 0) {
+    return transactions;
+  }
+  const byTransaction = splitsByTransaction(splits);
+  const expanded: SplitExpandedTransaction[] = [];
+  for (const transaction of transactions) {
+    const lines = transaction.isSplit ? byTransaction.get(transaction.id) : undefined;
+    if (!lines || lines.length === 0) {
+      expanded.push(transaction);
+      continue;
+    }
+    for (const line of lines) {
+      expanded.push({
+        ...transaction,
+        id: `${transaction.id}::split::${line.id}`,
+        category: line.category,
+        amount: line.amount,
+        // Sign⇄type coherence: a positive line inside an expense split (e.g.
+        // cashback) behaves like the cross-type income filing consumers
+        // already understand — aggregators that abs() expense amounts must
+        // not count it as MORE spending.
+        type: line.amount >= 0 ? 'income' : 'expense',
+        notes: line.memo ?? transaction.notes,
+        isSplitLine: true,
+        splitParentId: transaction.id,
+      });
+    }
+  }
+  return expanded;
 }


### PR DESCRIPTION
Completes the split-transactions plan (phases 1+2 in #98) and fixes the Delete Category dialog issues reported in chat. **No migration needed** — this is all client-side, built on the schema from #98.

## Split-aware reporting

One canonical mechanism: `expandSplitTransactions(transactions, splits)` gives category-aggregation surfaces an **expanded view** where each split parent is replaced by one virtual row per line (line category + amount, back-reference to the parent). Line amounts sum exactly to the parent by the DB invariant, so totals are conserved everywhere; a cashback line derives an income-like type from its sign, so it nets rather than inflates. The expansion is never fed to balance arithmetic or write paths.

Now counting split lines under their categories:
- **Categories page counters** and the **category transactions list** — a split line appears under its own category with the *line* amount and a "split" badge; clicking it opens the parent transaction with all its lines
- **Budgets** (Budget page, dashboard budget status, spending alerts, envelope budgeting, shared budgets)
- **Financial summaries** (top-category rankings)
- **Excel/PDF exports** (one row per split line; category breakdowns correct)

The context loads all split lines once at boot (paged) and keeps them in step on every split save/delete; a load failure degrades gracefully (parents pass through whole).

## Delete Category dialog

- The hard-to-read native dropdown is replaced with the **same searchable grouped picker as the transaction editor** — which also fixes the stale entries: it filters out inactive categories (the "To/From GREEN S A" / "HSBC Premier Account" husks you saw were deactivated categories that only this dropdown displayed), transfer and system categories, and (via a new `excludeIds` prop) the category being deleted.
- Reassignment now **moves split lines too** (swapped atomically via `set_transaction_splits` — amounts untouched, so the sum invariant holds), the dialog counts them ("3 transactions (including 1 split line)"), and a category used *only* inside splits routes through reassignment instead of being deletable into orphaned lines.
- Writes are properly awaited with a busy state and an error toast — the old handler fired updates without awaiting and raced the category delete.

## Verified live (demo mode)

Split line shown under Groceries at £200 (parent £307.29) with badge → clicking opened the parent editor with both lines loaded → deleted "Dining Out" (3 rows incl. 1 split line) reassigning to Fuel → Restaurants (8)→(5), Transportation (2)→(5), totals conserved, split parent intact, no console errors.

**Tests:** 3,068 passing incl. new expansion-util cases (pass-through, per-line replacement, sign-derived type, missing-lines fallback, ordering) and split-line list cases. Strict typecheck + zero lint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)