### PR TITLE
feat(categories): un-categorise a transaction from the pickers

### DIFF
--- a/src/components/CategorySelector.test.tsx
+++ b/src/components/CategorySelector.test.tsx
@@ -170,4 +170,71 @@ describe('CategorySelector', () => {
       expect(payslip).toHaveAttribute('aria-selected', 'true');
     });
   });
+
+  describe('excludeIds', () => {
+    it('leaves excluded categories out of the list', () => {
+      renderOpen({ includeAllTypes: true, excludeIds: ['det-groceries'] });
+      expect(screen.queryByText('Groceries')).not.toBeInTheDocument();
+      expect(screen.getByText('Payslip')).toBeInTheDocument();
+    });
+  });
+
+  describe('allowClear (un-categorise)', () => {
+    it('offers a pinned Uncategorised option that selects the blank category', () => {
+      const { onCategoryChange } = renderOpen({ allowClear: true });
+      fireEvent.click(screen.getByText('Uncategorised'));
+      expect(onCategoryChange).toHaveBeenCalledWith('');
+    });
+
+    it('hides the option without allowClear', () => {
+      renderOpen();
+      expect(screen.queryByText('Uncategorised')).not.toBeInTheDocument();
+    });
+
+    it('keeps the option while the search could still mean it', () => {
+      renderOpen({ allowClear: true });
+      const input = screen.getByPlaceholderText(PLACEHOLDER);
+      fireEvent.change(input, { target: { value: 'unc' } });
+      expect(screen.getByText('Uncategorised')).toBeInTheDocument();
+      fireEvent.change(input, { target: { value: 'payslip' } });
+      expect(screen.queryByText('Uncategorised')).not.toBeInTheDocument();
+    });
+
+    it('is the first keyboard stop and selects the blank category with Enter', () => {
+      const { onCategoryChange } = renderOpen({ allowClear: true });
+      const input = screen.getByPlaceholderText(PLACEHOLDER);
+      fireEvent.keyDown(input, { key: 'ArrowDown' });
+      fireEvent.keyDown(input, { key: 'Enter' });
+      expect(onCategoryChange).toHaveBeenCalledWith('');
+    });
+
+    it('clears the selection with Delete on the closed picker', () => {
+      const onCategoryChange = vi.fn();
+      render(
+        <CategorySelector
+          selectedCategory="det-payslip"
+          onCategoryChange={onCategoryChange}
+          transactionType="income"
+          placeholder={PLACEHOLDER}
+          allowClear
+        />
+      );
+      fireEvent.keyDown(screen.getByRole('combobox', { name: 'Category' }), { key: 'Delete' });
+      expect(onCategoryChange).toHaveBeenCalledWith('');
+    });
+
+    it('does NOT clear on Delete without allowClear', () => {
+      const onCategoryChange = vi.fn();
+      render(
+        <CategorySelector
+          selectedCategory="det-payslip"
+          onCategoryChange={onCategoryChange}
+          transactionType="income"
+          placeholder={PLACEHOLDER}
+        />
+      );
+      fireEvent.keyDown(screen.getByRole('combobox', { name: 'Category' }), { key: 'Delete' });
+      expect(onCategoryChange).not.toHaveBeenCalled();
+    });
+  });
 });

--- a/src/components/CategorySelector.tsx
+++ b/src/components/CategorySelector.tsx
@@ -45,6 +45,14 @@ interface CategorySelectorProps {
    * in the reassignment dialog must not be offered as its own replacement.
    */
   excludeIds?: string[];
+  /**
+   * Offer "Uncategorised" as a pinned first option (selects the blank
+   * category, id ''), and let Delete/Backspace on the closed picker clear the
+   * selection. For editors where a transaction may legitimately have no
+   * category; OFF where a real category is required (split lines, the
+   * delete-reassignment dialog).
+   */
+  allowClear?: boolean;
 }
 
 export default function CategorySelector({
@@ -58,6 +66,7 @@ export default function CategorySelector({
   showHelperText = true,
   usePortal = false,
   excludeIds,
+  allowClear = false,
 }: CategorySelectorProps): React.JSX.Element {
   const { categories, addCategory, getSubCategories, getDetailCategories } = useApp();
   const [showDropdown, setShowDropdown] = useState(false);
@@ -238,8 +247,13 @@ export default function CategorySelector({
     setShowDropdown(true);
   };
 
+  // Internal stand-in id for the "Uncategorised" option — the real value is
+  // '' (blank category), but '' is falsy and would fall through the
+  // highlight/activedescendant logic.
+  const UNCATEGORISED_ID = '__uncategorised__';
+
   const handleCategorySelect = (categoryId: string): void => {
-    onCategoryChange(categoryId);
+    onCategoryChange(categoryId === UNCATEGORISED_ID ? '' : categoryId);
     setShowDropdown(false);
     setSearchTerm('');
   };
@@ -273,12 +287,16 @@ export default function CategorySelector({
     if (e.key === 'Enter' || e.key === ' ' || e.key === 'ArrowDown' || e.key === 'ArrowUp') {
       e.preventDefault();
       setShowDropdown(true);
+    } else if (allowClear && selectedCategory && (e.key === 'Delete' || e.key === 'Backspace')) {
+      // Money-style: clearing the category un-categorises the transaction.
+      e.preventDefault();
+      onCategoryChange('');
     }
   };
 
   const handleSearchKeyDown = (
     e: React.KeyboardEvent<HTMLInputElement>,
-    flatOptions: Category[]
+    flatOptions: Array<Pick<Category, 'id' | 'name'>>
   ): void => {
     switch (e.key) {
       case 'ArrowDown':
@@ -346,8 +364,14 @@ export default function CategorySelector({
 
   const subCategories = getSubCategoriesForType();
   const groupedOptions = getGroupedOptions();
+  // "Uncategorised" stays visible while the search could still mean it
+  // ('' matches everything, "unc" matches, "food" hides it).
+  const showClearOption = allowClear && 'uncategorised'.includes(searchTerm.toLowerCase());
   // Flat view of the visible options, in render order — what the arrow keys walk.
-  const flatOptions = groupedOptions.flatMap(g => g.items);
+  const flatOptions: Array<Pick<Category, 'id' | 'name'>> = [
+    ...(showClearOption ? [{ id: UNCATEGORISED_ID, name: 'Uncategorised' }] : []),
+    ...groupedOptions.flatMap(g => g.items),
+  ];
   const highlightedId = highlightIndex >= 0 ? flatOptions[highlightIndex]?.id : undefined;
 
   return (
@@ -489,6 +513,23 @@ export default function CategorySelector({
               </div>
             ) : (
               <>
+                {/* Un-categorise: pinned above the groups; selecting it blanks
+                    the category (the transaction moves to the virtual
+                    Uncategorised bucket). */}
+                {showClearOption && (
+                  <div
+                    id={optionDomId(UNCATEGORISED_ID)}
+                    role="option"
+                    aria-selected={selectedCategory === ''}
+                    data-highlighted-option={highlightedId === UNCATEGORISED_ID ? instanceId : undefined}
+                    className={`px-3 py-2 cursor-pointer border-b border-gray-100 dark:border-gray-600 hover:bg-gray-100 dark:hover:bg-gray-600 ${
+                      highlightedId === UNCATEGORISED_ID ? 'bg-gray-100 dark:bg-gray-600' : ''
+                    }`}
+                    onClick={() => handleCategorySelect(UNCATEGORISED_ID)}
+                  >
+                    <span className="italic text-gray-500 dark:text-gray-400">Uncategorised</span>
+                  </div>
+                )}
                 {/* Category list — grouped under their parent sub-category
                     (Bills, Food, Personal…) with sticky section headers. */}
                 {groupedOptions.length > 0 ? (
@@ -523,7 +564,7 @@ export default function CategorySelector({
                       ))}
                     </div>
                   ))
-                ) : (
+                ) : showClearOption ? null : (
                   <div className="px-3 py-2 text-gray-500 dark:text-gray-400 text-center">
                     {searchTerm ? 'No categories found' : 'No categories available'}
                   </div>

--- a/src/components/EditTransactionModal.tsx
+++ b/src/components/EditTransactionModal.tsx
@@ -796,6 +796,7 @@ export default function EditTransactionModal({ isOpen, onClose, transaction, def
                   allowCreate={false}
                   showHelperText={false}
                   usePortal
+                  allowClear
                 />
               )}
             </div>

--- a/src/components/QuickEditTransactionPanel.tsx
+++ b/src/components/QuickEditTransactionPanel.tsx
@@ -167,6 +167,7 @@ export default function QuickEditTransactionPanel({
               includeAllTypes
               showHelperText={false}
               placeholder="Search or select category…"
+              allowClear
             />
           )}
         </div>


### PR DESCRIPTION
Fixes the one-way door reported in chat: once a transaction had a category, the pickers could only *change* it — there was no way back to uncategorised.

**Design choice (of the two options discussed):** blank stays the single representation of "uncategorised" — payee memory's fill-blanks rule, imports, the counters and the fan-out guards are all built on blank meaning uncategorised. A real 'Uncategorised' category row would create a second, competing representation of the same idea. So instead, the pickers gain a way to *choose* blank:

- **"Uncategorised"** appears as a pinned first option in the searchable picker (italic, so it reads as a state rather than a category). It's the first keyboard stop, and it stays visible while your search could still mean it (typing "unc…" keeps it; "food" hides it). Selecting it blanks the category.
- **Delete/Backspace on the closed picker** clears the current selection — the exact interaction requested.
- Enabled in the transaction editor and the quick-edit bar. Deliberately **not** offered for split lines (the DB rejects blank line categories — un-split instead) or the delete-reassignment dialog (blank there is indistinguishable from "not chosen yet"). The register's inline dropdown already had an "Uncategorized" option, so all category pickers are now level.
- Un-categorising never triggers payee-memory fan-out, and a cleared row becomes a fill-blanks target again — by design, that's what uncategorised means.

**Verified live (demo mode):** opened a categorised row from the Groceries category list, picked "Uncategorised", saved — the row left the list and the totals dropped by exactly its amount.

**Tests:** 6 new CategorySelector cases (option shown/hidden, search retention, keyboard path, Delete-clears, Delete-inert-without-the-flag) plus a case for the recent `excludeIds` prop; 3,075 passing, strict types, zero lint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)