### PR TITLE
fix(splits): audit remediation — split parents vs bulk/auto category writers

### DIFF
--- a/src/components/BulkTransactionEdit.split.test.tsx
+++ b/src/components/BulkTransactionEdit.split.test.tsx
@@ -1,0 +1,136 @@
+/**
+ * BulkTransactionEdit — split-transaction regression tests.
+ *
+ * A split parent's category is locked by the DB guard; bulk category changes
+ * must SKIP it (and say so) instead of aborting the whole batch on the
+ * server-side rejection. Separate from the legacy suite because these tests
+ * need a stable updateTransaction mock to assert calls against.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import BulkTransactionEdit from './BulkTransactionEdit';
+
+const mocks = vi.hoisted(() => ({
+  updateTransaction: vi.fn(async () => {}),
+  showWarning: vi.fn(),
+  showError: vi.fn(),
+}));
+
+vi.mock('../contexts/AppContextSupabase', () => ({
+  useApp: () => ({
+    transactions: [
+      {
+        id: 'plain-1',
+        date: new Date('2026-06-01'),
+        description: 'COSTA COFFEE',
+        amount: -4.5,
+        category: 'cat-food',
+        accountId: 'acc-1',
+        type: 'expense',
+        cleared: false,
+      },
+      {
+        id: 'split-1',
+        date: new Date('2026-06-02'),
+        description: 'TESCO SUPERSTORE',
+        amount: -100,
+        category: '',
+        accountId: 'acc-1',
+        type: 'expense',
+        cleared: false,
+        isSplit: true,
+      },
+    ],
+    accounts: [
+      { id: 'acc-1', name: 'Main Checking', type: 'checking', balance: 1000, currency: 'GBP' },
+    ],
+    categories: [
+      { id: 'cat-food', name: 'Food', type: 'expense', level: 'detail', parentId: 'sub-food' },
+      { id: 'cat-other', name: 'Other', type: 'both', level: 'detail', parentId: 'sub-other' },
+    ],
+    updateTransaction: mocks.updateTransaction,
+  }),
+}));
+
+vi.mock('../hooks/useCurrencyDecimal', () => ({
+  useCurrencyDecimal: () => ({
+    formatCurrency: (amount: number) => `£${Math.abs(Number(amount)).toFixed(2)}`,
+  }),
+}));
+
+vi.mock('../contexts/ToastContext', () => ({
+  useToast: () => ({
+    showToast: vi.fn(),
+    showSuccess: vi.fn(),
+    showError: mocks.showError,
+    showWarning: mocks.showWarning,
+    showInfo: vi.fn(),
+    dismissToast: vi.fn(),
+  }),
+}));
+
+describe('BulkTransactionEdit — split parents', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('skips the category on split parents and warns, instead of aborting the batch', async () => {
+    render(<BulkTransactionEdit isOpen={true} onClose={vi.fn()} />);
+
+    // Select both rows (plain + split parent)
+    const checkboxes = screen.getAllByRole('checkbox');
+    await userEvent.click(checkboxes[0]);
+    await userEvent.click(checkboxes[1]);
+
+    // Choose a bulk category change
+    const categorySection = screen.getByText(/Category/).parentElement;
+    const categorySelect = categorySection?.querySelector('select');
+    expect(categorySelect).toBeTruthy();
+    await userEvent.selectOptions(categorySelect!, 'Other');
+
+    await userEvent.click(screen.getByText('Apply Changes'));
+
+    await waitFor(() => {
+      // The plain transaction gets the category…
+      expect(mocks.updateTransaction).toHaveBeenCalledWith(
+        'plain-1',
+        expect.objectContaining({ category: expect.any(String) })
+      );
+    });
+    // …the split parent is never written with a category (in this batch its
+    // ONLY change was the category, so it gets no write at all)
+    expect(mocks.updateTransaction).not.toHaveBeenCalledWith(
+      'split-1',
+      expect.objectContaining({ category: expect.anything() })
+    );
+    expect(mocks.updateTransaction).toHaveBeenCalledTimes(1);
+    // …and the user is told what was skipped and why
+    expect(mocks.showWarning).toHaveBeenCalledWith(expect.stringMatching(/1 split transaction/));
+    expect(mocks.showError).not.toHaveBeenCalled();
+  });
+
+  it('still applies non-category changes to split parents', async () => {
+    render(<BulkTransactionEdit isOpen={true} onClose={vi.fn()} />);
+
+    const checkboxes = screen.getAllByRole('checkbox');
+    await userEvent.click(checkboxes[0]);
+    await userEvent.click(checkboxes[1]);
+
+    // Cleared status is legal on split parents (the guard only locks
+    // amount/category/type)
+    const clearedSection = screen.getByText(/Cleared Status/).parentElement;
+    const clearedSelect = clearedSection?.querySelector('select');
+    expect(clearedSelect).toBeTruthy();
+    await userEvent.selectOptions(clearedSelect!, 'true');
+
+    await userEvent.click(screen.getByText('Apply Changes'));
+
+    await waitFor(() => {
+      expect(mocks.updateTransaction).toHaveBeenCalledTimes(2);
+    });
+    expect(mocks.updateTransaction).toHaveBeenCalledWith('split-1', { cleared: true });
+    expect(mocks.showWarning).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/BulkTransactionEdit.tsx
+++ b/src/components/BulkTransactionEdit.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useMemo } from 'react';
 import { useApp } from '../contexts/AppContextSupabase';
+import { useToast } from '../contexts/ToastContext';
 import { useCurrencyDecimal } from '../hooks/useCurrencyDecimal';
 import { createScopedLogger } from '../loggers/scopedLogger';
 import { Modal } from './common/Modal';
@@ -60,6 +61,7 @@ export default function BulkTransactionEdit({
   preSelectedIds = []
 }: BulkTransactionEditProps) {
   const { transactions, accounts, categories, updateTransaction } = useApp();
+  const { showWarning, showError } = useToast();
   const { formatCurrency } = useCurrencyDecimal();
   const logger = useMemo(() => createScopedLogger('BulkTransactionEdit'), []);
   
@@ -196,16 +198,25 @@ export default function BulkTransactionEdit({
     
     try {
       let count = 0;
+      let splitCategorySkips = 0;
       for (const id of selectedIds) {
         const transaction = transactions.find(t => t.id === id);
         if (!transaction) continue;
-        
+
         const updates: Partial<Transaction> = {};
-        
+
         if (changes.category !== undefined) {
-          updates.category = changes.category;
+          if (transaction.isSplit) {
+            // A split parent's categorisation lives in its split lines — the
+            // DB guard rejects a single-category write, which would abort the
+            // whole batch mid-loop. Skip the category (other fields still
+            // apply) and tell the user below.
+            splitCategorySkips++;
+          } else {
+            updates.category = changes.category;
+          }
         }
-        
+
         if (changes.tags !== undefined) {
           updates.tags = changes.tags;
         }
@@ -226,20 +237,31 @@ export default function BulkTransactionEdit({
           updates.accountId = changes.moveToAccount;
         }
         
-        await updateTransaction(id, updates);
+        // A row whose only requested change was skipped has nothing to write.
+        if (Object.keys(updates).length > 0) {
+          await updateTransaction(id, updates);
+        }
         count++;
         setAppliedCount(count);
       }
-      
+
+      if (splitCategorySkips > 0) {
+        showWarning(
+          `Category left unchanged on ${splitCategorySkips} split transaction${splitCategorySkips === 1 ? '' : 's'} — a split's categories live in its split lines (open the transaction to edit them).`
+        );
+      }
+
       // Add to history before resetting
       addToHistory();
-      
+
       // Reset after successful update
       setSelectedIds(new Set());
       setChanges({ appendNote: false });
       onClose();
     } catch (error) {
+      // Surface the failure — a silent partial batch is worse than an error.
       logger.error('Error applying bulk changes', error as Error);
+      showError(error);
     } finally {
       setApplying(false);
     }

--- a/src/components/DataValidation.tsx
+++ b/src/components/DataValidation.tsx
@@ -110,8 +110,10 @@ export default function DataValidation({ isOpen, onClose }: DataValidationProps)
       });
     }
     
-    // 3. Check for missing categories
-    const uncategorizedTransactions = transactions.filter(t => !t.category || t.category === '');
+    // 3. Check for missing categories. A split parent's blank category means
+    // "split" (its categorisation lives in its lines), not "missing" — and the
+    // DB guard would reject stamping a category onto it anyway.
+    const uncategorizedTransactions = transactions.filter(t => (!t.category || t.category === '') && !t.isSplit);
     
     if (uncategorizedTransactions.length > 0) {
       issues.push({

--- a/src/components/ExcelExport.tsx
+++ b/src/components/ExcelExport.tsx
@@ -337,20 +337,21 @@ export default function ExcelExport({ isOpen, onClose }: ExcelExportProps): Reac
               tDate.getFullYear() === new Date().getFullYear();
           })
           // Expenses are stored signed (negative); spent is a positive magnitude.
-          .reduce((sum, t) => sum + Math.abs(toDecimal(t.amount).toNumber()), 0);
-        
-        const remaining = toDecimal(budget.amount).toNumber() - spent;
-        const percentUsed = toDecimal(budget.amount).toNumber() > 0 
-          ? (spent / toDecimal(budget.amount).toNumber()) * 100 
+          .reduce((sum, t) => sum.plus(toDecimal(t.amount).abs()), toDecimal(0));
+
+        const budgetAmount = toDecimal(budget.amount);
+        const remaining = budgetAmount.minus(spent);
+        const percentUsed = budgetAmount.greaterThan(0)
+          ? spent.dividedBy(budgetAmount).times(100).toNumber()
           : 0;
-        
+
         return {
           Category: budget.categoryId,
-          'Budget Amount': toDecimal(budget.amount).toNumber(),
-          Spent: spent,
-          Remaining: remaining,
+          'Budget Amount': budgetAmount.toNumber(),
+          Spent: spent.toNumber(),
+          Remaining: remaining.toNumber(),
           '% Used': `${formatDecimal(percentUsed, 1)}%`,
-          Status: remaining < 0 ? 'Over Budget' : percentUsed > 80 ? 'Warning' : 'On Track'
+          Status: remaining.isNegative() ? 'Over Budget' : percentUsed > 80 ? 'Warning' : 'On Track'
         };
       });
       

--- a/src/components/SmartCategorizationSettings.tsx
+++ b/src/components/SmartCategorizationSettings.tsx
@@ -48,7 +48,9 @@ export default function SmartCategorizationSettings() {
   };
 
   const handleAutoCategorize = async () => {
-    const uncategorized = transactions.filter(t => !t.category);
+    // A split parent's blank category means "split", not "uncategorised" —
+    // the DB guard rejects stamping a single category onto it.
+    const uncategorized = transactions.filter(t => !t.category && !t.isSplit);
     const results = smartCategorizationService.autoCategorize(
       uncategorized, 
       confidenceThreshold / 100

--- a/src/components/TransactionRow.tsx
+++ b/src/components/TransactionRow.tsx
@@ -253,7 +253,16 @@ export const TransactionRow = memo(function TransactionRow({
             className={`${compactView ? 'py-1.5' : 'py-3'} px-6 font-medium text-right`}
             style={{ width: columnWidths.amount }}
           >
-            {isEditingAmount && onUpdateAmount ? (
+            {transaction.isSplit ? (
+              // A split parent's amount is the sum of its split lines (locked
+              // by the DB guard) — inline editing would only ever error.
+              <span
+                className={`${amountColorClass} ${compactView ? 'text-sm' : ''}`}
+                title="Split transaction — its amount is the sum of its splits; edit them in the full editor"
+              >
+                {formattedAmount}
+              </span>
+            ) : isEditingAmount && onUpdateAmount ? (
               <input
                 type="number"
                 step="0.01"

--- a/src/components/__tests__/BulkTransactionEdit.test.tsx
+++ b/src/components/__tests__/BulkTransactionEdit.test.tsx
@@ -89,6 +89,17 @@ vi.mock('../../contexts/AppContextSupabase', () => ({
   })
 }));
 
+vi.mock('../../contexts/ToastContext', () => ({
+  useToast: () => ({
+    showToast: vi.fn(),
+    showSuccess: vi.fn(),
+    showError: vi.fn(),
+    showWarning: vi.fn(),
+    showInfo: vi.fn(),
+    dismissToast: vi.fn(),
+  }),
+}));
+
 vi.mock('../../hooks/useCurrencyDecimal', () => ({
   useCurrencyDecimal: () => ({
     formatCurrency: (amount: number, currency: string = 'USD') =>

--- a/src/contexts/AppContextSupabase.tsx
+++ b/src/contexts/AppContextSupabase.tsx
@@ -318,10 +318,18 @@ export function AppProvider({ children }: { children: React.ReactNode }) {
                 appLogger.debug('Accounts reloaded', { count: updatedAccounts.length });
                 setAccounts(updatedAccounts);
                 setLastSyncTime(new Date());
-                
+
                 // Also refresh transactions to update account balances
                 const updatedTransactions = await DataService.getTransactions();
                 setTransactions(updatedTransactions);
+
+                // Splits ride along — without this, a split edited on another
+                // device leaves this device's category views stale.
+                try {
+                  setTransactionSplitsState(await DataService.getAllTransactionSplits());
+                } catch (splitError) {
+                  appLogger.error('Failed to refresh transaction splits', splitError);
+                }
               });
             }
           );
@@ -340,7 +348,15 @@ export function AppProvider({ children }: { children: React.ReactNode }) {
                 // Reload transactions when any change happens
                 const updatedTransactions = await DataService.getTransactions();
                 setTransactions(updatedTransactions);
-                
+
+                // Splits ride along — without this, a split edited on another
+                // device leaves this device's category views stale.
+                try {
+                  setTransactionSplitsState(await DataService.getAllTransactionSplits());
+                } catch (splitError) {
+                  appLogger.error('Failed to refresh transaction splits', splitError);
+                }
+
                 // Also refresh accounts to update balances
                 const updatedAccounts = await DataService.getAccounts();
                 setAccounts(updatedAccounts);


### PR DESCRIPTION
Post-merge **Lead Engineer audit of the split-transactions arc (#97–#101)**, per Steve's request. The audit hunted four risk classes: synthetic-id leakage from the expanded view into write paths, collisions with the new split guard trigger, multi-device staleness, and float maths. Findings and fixes:

## Fixed

1. **BulkTransactionEdit vs the split guard** (the big one): a bulk *category* change over a selection containing a split parent would be rejected by the DB trigger — aborting the whole batch mid-loop, with the error going only to the console. Now: split parents are **skipped for the category field only** (tags/cleared/notes/account moves still apply — the guard only locks amount/category/type), the user is told *"Category left unchanged on N split transactions…"*, and batch failures surface as an error toast. New regression suite asserts the skip.
2. **Smart categorization's auto-categorize** treated split parents (blank category) as uncategorised — its fire-and-forget loop would have thrown an unhandled rejection per split. Excluded.
3. **DataValidation's "missing categories" fixer** — same blank-means-split misread; a split parent is no longer flagged or "fixed" to *Other*.
4. **Inline amount editing on split rows** (register): the amount is the sum of the lines and the DB locks it — the cell is now read-only for splits with an explanatory tooltip, matching the category cell.
5. **Realtime staleness**: both realtime reload handlers now refresh split lines alongside transactions, so a split edited on another device updates this device's category views without an app reload.
6. **ExcelExport budget sheet** (pre-existing, in a touched file): spent/remaining/percent used float arithmetic — now Decimal end to end.

## Audited clean

- **No synthetic-id leakage**: every consumer of `expandSplitTransactions` is a read-only aggregation; the one click-through (category transactions list) already resolves the real parent.
- Inline **category** editing already blocked on split rows; `apply_category_to_uncategorized`, imports, quick edit, and the delete-reassignment dialog all split-aware.
- No new float maths anywhere in the arc; `is_split` flows correctly through the service mapping layer.

**Tests:** 3,077 passing (2 new). Strict types, zero lint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)