### PR TITLE
feat(transfers): Money-style transfer matching — link the other side or create it

### DIFF
--- a/src/components/CategorySelector.tsx
+++ b/src/components/CategorySelector.tsx
@@ -148,7 +148,9 @@ export default function CategorySelector({
     const detailCategories: Category[] = [];
 
     subCategories.forEach(subCat => {
-      const details = getDetailCategories(subCat.id);
+      // Inactive DETAIL categories (a closed account's To/From) stay hidden,
+      // same as inactive subs — reopening the account restores them.
+      const details = getDetailCategories(subCat.id).filter(d => d.isActive !== false);
       detailCategories.push(...details);
     });
 

--- a/src/components/EditTransactionModal.tsx
+++ b/src/components/EditTransactionModal.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useRef, useMemo } from 'react';
+import { createPortal } from 'react-dom';
 import { useApp } from '../contexts/AppContextSupabase';
 import { useTransactionNotifications } from '../hooks/useTransactionNotifications';
 import { usePayeeMemory } from '../hooks/usePayeeMemory';
@@ -12,6 +13,9 @@ import {
   type SplitLineDraft,
 } from '../utils/transactionSplits';
 import CategoryCreationModal from './CategoryCreationModal';
+import TransferMatchDialog from './TransferMatchDialog';
+import { findTransferCandidates, transferCategoryFor, type TransferCandidate } from '../utils/transferMatch';
+import { useToast } from '../contexts/ToastContext';
 import CategorySelector from './CategorySelector';
 import TagSelector from './TagSelector';
 import { getCurrencySymbol } from '../utils/currency';
@@ -60,7 +64,8 @@ interface FormData {
 }
 
 export default function EditTransactionModal({ isOpen, onClose, transaction, defaultAccountId, onSaveAndNext, onSaveAndPrevious }: EditTransactionModalProps): React.JSX.Element {
-  const { accounts, categories, updateTransaction, deleteTransaction, getTransactionSplits, setTransactionSplits } = useApp();
+  const { accounts, categories, transactions, updateTransaction, deleteTransaction, getTransactionSplits, setTransactionSplits, linkTransferPair, createTransferCounterpart } = useApp();
+  const { showSuccess, showError } = useToast();
   const { addTransaction } = useTransactionNotifications();
   const { propagateCategory } = usePayeeMemory();
   const logger = useMemo(() => createScopedLogger('EditTransactionModal'), []);
@@ -79,6 +84,14 @@ export default function EditTransactionModal({ isOpen, onClose, transaction, def
   const [isSplitMode, setIsSplitMode] = useState(false);
   const [splitLines, setSplitLines] = useState<SplitLineDraft[]>([]);
   const [splitsLoading, setSplitsLoading] = useState(false);
+  // Money-style transfer flow: converting an existing row into a transfer
+  // (via a To/From category or the Transfer type) opens a match-or-create
+  // confirmation instead of writing blindly.
+  const [transferPrompt, setTransferPrompt] = useState<{
+    targetAccountId: string;
+    candidates: TransferCandidate[];
+  } | null>(null);
+  const [transferBusy, setTransferBusy] = useState(false);
   const amountInputRef = useRef<HTMLInputElement>(null);
   // Batch mode coordination: Save & Next / Previous set a direction; a
   // successful submit consumes it and suppresses the close that useModalForm
@@ -139,10 +152,32 @@ export default function EditTransactionModal({ isOpen, onClose, transaction, def
           const targetAccountId = isNewTransferSelection
             ? data.category.slice('transfer:'.length)
             : transaction?.transferAccountId;   // preserve on edit
+
+          // A linked pair's target is structural — moving it would strand the
+          // opposite row. v1: recreate the transfer to move it.
+          if (transaction?.linkedTransferId && isNewTransferSelection &&
+              targetAccountId !== transaction.transferAccountId) {
+            throw new Error(
+              'This transfer is linked to its opposite transaction. To move it, delete the transfer and recreate it.'
+            );
+          }
+
           const resolvedType = isTransfer || isNewTransferSelection ? 'transfer' : data.type;
+          // Transfers file under the target account's To/From category. An
+          // unchanged edit keeps whatever the row already carries; a new
+          // selection resolves the target's category (legacy sentinel only if
+          // the account somehow has none).
           const resolvedCategory = isNewTransferSelection
-            ? 'transfer-out'
+            ? (transaction && targetAccountId === transaction.transferAccountId && transaction.category
+                ? transaction.category
+                : (transferCategoryFor(categories, targetAccountId ?? '')?.id ?? 'transfer-out'))
             : data.category;
+
+          // Filing under a To/From category = "make this a transfer".
+          const chosenCategoryObj = categories.find(c => c.id === data.category);
+          if (!transaction && chosenCategoryObj?.isTransferCategory) {
+            throw new Error('To record a new transfer, use the Transfer type above — it creates both sides.');
+          }
 
           const validatedData = ValidationService.validateTransaction({
             id: transaction?.id,
@@ -164,6 +199,53 @@ export default function EditTransactionModal({ isOpen, onClose, transaction, def
             if (splitError) {
               throw new Error(splitError);
             }
+          }
+
+          // Converting an EXISTING row into a transfer (To/From category
+          // chosen, or Type switched to Transfer with a target): save the
+          // ordinary field edits, then hand over to the Money-style
+          // match-or-create flow, which owns the category/type change. The
+          // row's stored amount stays authoritative for matching.
+          const conversionTargetId = !splitting && transaction && !transaction.linkedTransferId
+            ? (isNewTransferSelection && transaction.type !== 'transfer'
+                ? targetAccountId
+                : (resolvedType !== 'transfer' && chosenCategoryObj?.isTransferCategory
+                    ? chosenCategoryObj.accountId
+                    : undefined))
+            : undefined;
+          if (conversionTargetId && transaction) {
+            if (conversionTargetId === validatedData.accountId) {
+              throw new Error(
+                "That's this account's own transfer category — pick the OTHER account's To/From category."
+              );
+            }
+            if (transaction.isSplit) {
+              throw new Error('A split transaction cannot become a transfer — remove the split first.');
+            }
+            await updateTransaction(transaction.id, {
+              date: new Date(validatedData.date),
+              description: validatedData.description,
+              accountId: validatedData.accountId,
+              tags: validatedData.tags,
+              notes: validatedData.notes,
+              cleared: data.cleared,
+              reconciledWith: data.reconciledWith.trim() || undefined
+            });
+            suppressCloseRef.current = true; // the dialog decides when to close
+            setTransferPrompt({
+              targetAccountId: conversionTargetId,
+              candidates: findTransferCandidates(
+                transactions,
+                {
+                  ...transaction,
+                  accountId: validatedData.accountId,
+                  date: new Date(validatedData.date),
+                  description: validatedData.description,
+                },
+                conversionTargetId
+              ),
+            });
+            return;
           }
 
           const parsedAmount = parseMoneyInput(validatedData.amount) ?? 0;
@@ -347,7 +429,12 @@ export default function EditTransactionModal({ isOpen, onClose, transaction, def
   // Initialize form when transaction changes
   useEffect(() => {
     if (transaction) {
-      const categoryId = transaction.category || '';
+      // Existing transfers seed the target select ('transfer:<account>') so
+      // it DISPLAYS the current target instead of the placeholder; the save
+      // path preserves the row's category when the target is unchanged.
+      const categoryId = transaction.type === 'transfer' && transaction.transferAccountId
+        ? `transfer:${transaction.transferAccountId}`
+        : (transaction.category || '');
       
       // For transfers, preserve the sign to show transfer direction
       // For income/expense, always use absolute value since type determines sign
@@ -469,6 +556,23 @@ export default function EditTransactionModal({ isOpen, onClose, transaction, def
   const splitActive = isSplitMode && !!transaction && formData.type !== 'transfer';
   const splitValidationMessage = splitActive ? validateSplitDrafts(formData.amount, splitLines) : null;
   const splitRemaining = splitActive ? splitRemainder(formData.amount, splitLines) : null;
+
+  // Complete the transfer flow (link or create) and close the editor. A
+  // failure keeps the dialog open so the user can retry or cancel.
+  const completeTransfer = async (action: () => Promise<unknown>, successMessage: string): Promise<void> => {
+    setTransferBusy(true);
+    try {
+      await action();
+      showSuccess(successMessage);
+      setTransferPrompt(null);
+      onClose();
+    } catch (error) {
+      logger.error('Transfer conversion failed', error as Error);
+      showError(error);
+    } finally {
+      setTransferBusy(false);
+    }
+  };
 
   const handleDelete = () => {
     if (!transaction) return;
@@ -943,8 +1047,9 @@ export default function EditTransactionModal({ isOpen, onClose, transaction, def
         </form>
       </Modal>
 
-        {/* Delete confirmation */}
-        {showDeleteConfirm && (
+        {/* Delete confirmation — portalled: a transformed ancestor would
+            re-anchor position:fixed and hide it behind the portalled Modal. */}
+        {showDeleteConfirm && createPortal(
           <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-[60] p-4">
             <div className="bg-white dark:bg-gray-800 rounded-2xl p-4 sm:p-6 w-full max-w-md mx-4 shadow-xl">
               <h3 className="text-base sm:text-lg font-semibold text-gray-900 dark:text-white mb-2">
@@ -968,7 +1073,29 @@ export default function EditTransactionModal({ isOpen, onClose, transaction, def
                 </button>
               </div>
             </div>
-          </div>
+          </div>,
+          document.body
+        )}
+
+        {/* Money-style transfer confirmation (match-or-create) */}
+        {transaction && transferPrompt && (
+          <TransferMatchDialog
+            isOpen
+            source={transaction}
+            sourceAccountName={accounts.find(a => a.id === (formData.accountId || transaction.accountId))?.name ?? 'this account'}
+            targetAccountName={accounts.find(a => a.id === transferPrompt.targetAccountId)?.name ?? 'the other account'}
+            candidates={transferPrompt.candidates}
+            busy={transferBusy}
+            onLink={(candidateId) => void completeTransfer(
+              () => linkTransferPair(transaction.id, candidateId),
+              'Linked as a transfer.'
+            )}
+            onCreate={() => void completeTransfer(
+              () => createTransferCounterpart(transaction.id, transferPrompt.targetAccountId),
+              'Transfer created — the other side was added to the target account.'
+            )}
+            onCancel={() => setTransferPrompt(null)}
+          />
         )}
 
         {/* Category Creation Modal */}

--- a/src/components/QuickEditTransactionPanel.transfer.test.tsx
+++ b/src/components/QuickEditTransactionPanel.transfer.test.tsx
@@ -1,0 +1,174 @@
+/**
+ * QuickEditTransactionPanel — Money-style transfer flow.
+ *
+ * Filing a transaction under a "To/From <account>" category must open the
+ * match-or-create confirmation instead of writing the category blindly, and
+ * the confirmed action must run the atomic link/create operation.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import QuickEditTransactionPanel from './QuickEditTransactionPanel';
+import type { Transaction } from '../types';
+
+const mocks = vi.hoisted(() => ({
+  updateTransaction: vi.fn(async () => {}),
+  linkTransferPair: vi.fn(async () => ({ a: {}, b: {} })),
+  createTransferCounterpart: vi.fn(async () => ({ source: {}, counterpart: {} })),
+  showError: vi.fn(),
+  showSuccess: vi.fn(),
+}));
+
+const source: Transaction = {
+  id: 'src',
+  date: new Date('2026-06-10'),
+  description: 'TRANSFER TO 5755',
+  amount: -500,
+  type: 'expense',
+  accountId: 'acc-a',
+  category: '',
+  cleared: false,
+} as Transaction;
+
+// The opposite side sits in acc-b: +£500 two days later.
+const opposite: Transaction = {
+  ...source,
+  id: 'other',
+  accountId: 'acc-b',
+  amount: 500,
+  type: 'income',
+  description: 'FASTER PAYMENT RECEIVED',
+  date: new Date('2026-06-12'),
+} as Transaction;
+
+vi.mock('../contexts/AppContextSupabase', () => ({
+  useApp: () => ({
+    transactions: [source, opposite],
+    accounts: [
+      { id: 'acc-a', name: 'Current Account', type: 'checking', balance: 100, currency: 'GBP' },
+      { id: 'acc-b', name: 'Savings', type: 'savings', balance: 100, currency: 'GBP' },
+    ],
+    categories: [
+      { id: 'type-expense', name: 'Expenses', type: 'expense', level: 'type' },
+      { id: 'sub-x', name: 'Bills', type: 'expense', level: 'sub', parentId: 'type-expense' },
+      { id: 'det-x', name: 'Council Tax', type: 'expense', level: 'detail', parentId: 'sub-x' },
+      { id: 'type-transfer', name: 'Transfer', type: 'both', level: 'type' },
+      { id: 'sub-transfer', name: 'Transfer', type: 'both', level: 'sub', parentId: 'type-transfer' },
+      {
+        id: 'tofrom-b', name: 'To/From Savings', type: 'both', level: 'detail',
+        parentId: 'sub-transfer', isTransferCategory: true, accountId: 'acc-b',
+      },
+      {
+        id: 'tofrom-a', name: 'To/From Current Account', type: 'both', level: 'detail',
+        parentId: 'sub-transfer', isTransferCategory: true, accountId: 'acc-a',
+      },
+    ],
+    getSubCategories: (parentId?: string) => [
+      { id: 'sub-x', name: 'Bills', type: 'expense', level: 'sub', parentId: 'type-expense' },
+      { id: 'sub-transfer', name: 'Transfer', type: 'both', level: 'sub', parentId: 'type-transfer' },
+    ].filter(c => c.parentId === parentId),
+    getDetailCategories: (parentId?: string) => [
+      { id: 'det-x', name: 'Council Tax', type: 'expense', level: 'detail', parentId: 'sub-x' },
+      { id: 'tofrom-b', name: 'To/From Savings', type: 'both', level: 'detail', parentId: 'sub-transfer', isTransferCategory: true, accountId: 'acc-b' },
+      { id: 'tofrom-a', name: 'To/From Current Account', type: 'both', level: 'detail', parentId: 'sub-transfer', isTransferCategory: true, accountId: 'acc-a' },
+    ].filter(c => c.parentId === parentId),
+    updateTransaction: mocks.updateTransaction,
+    linkTransferPair: mocks.linkTransferPair,
+    createTransferCounterpart: mocks.createTransferCounterpart,
+    applyCategoryToUncategorized: vi.fn(async () => 0),
+  }),
+}));
+
+vi.mock('../contexts/ToastContext', () => ({
+  useToast: () => ({
+    showToast: vi.fn(),
+    showSuccess: mocks.showSuccess,
+    showError: mocks.showError,
+    showWarning: vi.fn(),
+    showInfo: vi.fn(),
+    dismissToast: vi.fn(),
+  }),
+}));
+
+vi.mock('../hooks/useCurrencyDecimal', () => ({
+  useCurrencyDecimal: () => ({
+    formatCurrency: (n: number) => `£${Math.abs(Number(n)).toFixed(2)}`,
+  }),
+}));
+
+/** File the panel's transaction under the To/From Savings category and save. */
+async function fileUnderToFromSavings() {
+  render(<QuickEditTransactionPanel transaction={source} onClose={vi.fn()} />);
+
+  // Open the category picker and choose "To/From Savings"
+  fireEvent.click(screen.getByRole('combobox', { name: 'Category' }));
+  fireEvent.click(screen.getByText('To/From Savings'));
+
+  fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+
+  // The match-or-create dialog opens instead of a plain category write
+  await waitFor(() => {
+    expect(screen.getByText('Make this a transfer')).toBeInTheDocument();
+  });
+}
+
+describe('QuickEditTransactionPanel — transfer flow', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('opens the match dialog with the found candidate instead of writing the category', async () => {
+    await fileUnderToFromSavings();
+
+    expect(screen.getByText(/Found the matching transaction in Savings/)).toBeInTheDocument();
+    expect(screen.getByText('FASTER PAYMENT RECEIVED')).toBeInTheDocument();
+    // The field edits were saved WITHOUT the category
+    expect(mocks.updateTransaction).toHaveBeenCalledTimes(1);
+    const updates = mocks.updateTransaction.mock.calls[0][1] as Record<string, unknown>;
+    expect(updates).not.toHaveProperty('category');
+  });
+
+  it('links the pair when confirmed', async () => {
+    await fileUnderToFromSavings();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Link as transfer' }));
+    await waitFor(() => {
+      expect(mocks.linkTransferPair).toHaveBeenCalledWith('src', 'other');
+    });
+    expect(mocks.createTransferCounterpart).not.toHaveBeenCalled();
+    expect(mocks.showSuccess).toHaveBeenCalled();
+  });
+
+  it('creates the counterpart when the user chooses to', async () => {
+    await fileUnderToFromSavings();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Create new instead' }));
+    await waitFor(() => {
+      expect(mocks.createTransferCounterpart).toHaveBeenCalledWith('src', 'acc-b');
+    });
+    expect(mocks.linkTransferPair).not.toHaveBeenCalled();
+  });
+
+  it("rejects the source account's own To/From category", async () => {
+    render(<QuickEditTransactionPanel transaction={source} onClose={vi.fn()} />);
+
+    fireEvent.click(screen.getByRole('combobox', { name: 'Category' }));
+    fireEvent.click(screen.getByText('To/From Current Account'));
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+
+    await waitFor(() => {
+      expect(mocks.showError).toHaveBeenCalled();
+    });
+    expect(screen.queryByText('Make this a transfer')).not.toBeInTheDocument();
+    expect(mocks.updateTransaction).not.toHaveBeenCalled();
+  });
+
+  it('cancelling the dialog leaves the transaction untouched by the transfer flow', async () => {
+    await fileUnderToFromSavings();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+    expect(screen.queryByText('Make this a transfer')).not.toBeInTheDocument();
+    expect(mocks.linkTransferPair).not.toHaveBeenCalled();
+    expect(mocks.createTransferCounterpart).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/QuickEditTransactionPanel.tsx
+++ b/src/components/QuickEditTransactionPanel.tsx
@@ -4,6 +4,8 @@ import { useToast } from '../contexts/ToastContext';
 import { usePayeeMemory } from '../hooks/usePayeeMemory';
 import { XIcon } from './icons';
 import CategorySelector from './CategorySelector';
+import TransferMatchDialog from './TransferMatchDialog';
+import { findTransferCandidates, type TransferCandidate } from '../utils/transferMatch';
 import type { Transaction } from '../types';
 
 interface QuickEditTransactionPanelProps {
@@ -24,14 +26,21 @@ export default function QuickEditTransactionPanel({
   onNext,
   onClose,
 }: QuickEditTransactionPanelProps): React.JSX.Element {
-  const { categories, updateTransaction } = useApp();
-  const { showError } = useToast();
+  const { transactions, accounts, categories, updateTransaction, linkTransferPair, createTransferCounterpart } = useApp();
+  const { showError, showSuccess } = useToast();
   const { propagateCategory } = usePayeeMemory();
 
   const [date, setDate] = useState('');
   const [description, setDescription] = useState('');
   const [category, setCategory] = useState('');
   const [isSaving, setIsSaving] = useState(false);
+  // Money-style transfer flow: filing under a "To/From <account>" category
+  // opens a match-or-create confirmation instead of a plain category write.
+  const [transferPrompt, setTransferPrompt] = useState<{
+    targetAccountId: string;
+    candidates: TransferCandidate[];
+  } | null>(null);
+  const advanceAfterTransferRef = useRef(false);
 
   // Re-sync only when a DIFFERENT transaction is selected (Save & Next flow).
   // Keyed by id, not object identity: context refreshes recreate the object
@@ -64,6 +73,42 @@ export default function QuickEditTransactionPanel({
       showError(new Error('Enter a valid date.'));
       return;
     }
+    // Filing under a To/From category = "make this a transfer" (Money-style):
+    // save the field edits, then hand over to the match-or-create flow, which
+    // owns the category/type change. Never for rows that already are
+    // transfers or splits.
+    const chosenCategory = categories.find(c => c.id === category);
+    if (!isTransfer && !isSplit && !transaction.linkedTransferId &&
+        chosenCategory?.isTransferCategory && chosenCategory.accountId) {
+      if (chosenCategory.accountId === transaction.accountId) {
+        showError(new Error(
+          "That's this account's own transfer category — pick the OTHER account's To/From category."
+        ));
+        return;
+      }
+      setIsSaving(true);
+      try {
+        await updateTransaction(transaction.id, {
+          date: parsedDate,
+          description: description.trim(),
+        });
+        advanceAfterTransferRef.current = advance;
+        setTransferPrompt({
+          targetAccountId: chosenCategory.accountId,
+          candidates: findTransferCandidates(
+            transactions,
+            { ...transaction, date: parsedDate, description: description.trim() },
+            chosenCategory.accountId
+          ),
+        });
+      } catch (error) {
+        showError(error);
+      } finally {
+        setIsSaving(false);
+      }
+      return;
+    }
+
     setIsSaving(true);
     try {
       const categoryChanged = category !== (transaction.category ?? '');
@@ -102,6 +147,30 @@ export default function QuickEditTransactionPanel({
       setIsSaving(false);
     }
   };
+
+  // Complete the transfer flow (link or create), then honour a pending
+  // Save & Next. Failures keep the dialog open so the user can retry/cancel.
+  const completeTransfer = async (action: () => Promise<unknown>, successMessage: string) => {
+    setIsSaving(true);
+    try {
+      await action();
+      showSuccess(successMessage);
+      setTransferPrompt(null);
+      const advance = advanceAfterTransferRef.current;
+      advanceAfterTransferRef.current = false;
+      if (advance && onNext) {
+        onNext();
+      }
+    } catch (error) {
+      showError(error);
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  const targetAccountName = transferPrompt
+    ? accounts.find(a => a.id === transferPrompt.targetAccountId)?.name ?? 'the other account'
+    : '';
 
   return (
     // data-quick-edit-panel: the register's click-outside-to-deselect handler
@@ -200,6 +269,29 @@ export default function QuickEditTransactionPanel({
           </button>
         </div>
       </div>
+
+      {transferPrompt && (
+        <TransferMatchDialog
+          isOpen
+          source={transaction}
+          sourceAccountName={accounts.find(a => a.id === transaction.accountId)?.name ?? 'this account'}
+          targetAccountName={targetAccountName}
+          candidates={transferPrompt.candidates}
+          busy={isSaving}
+          onLink={(candidateId) => void completeTransfer(
+            () => linkTransferPair(transaction.id, candidateId),
+            `Linked as a transfer with ${targetAccountName}.`
+          )}
+          onCreate={() => void completeTransfer(
+            () => createTransferCounterpart(transaction.id, transferPrompt.targetAccountId),
+            `Transfer created — the other side was added to ${targetAccountName}.`
+          )}
+          onCancel={() => {
+            setTransferPrompt(null);
+            advanceAfterTransferRef.current = false;
+          }}
+        />
+      )}
     </div>
   );
 }

--- a/src/components/TransferMatchDialog.test.tsx
+++ b/src/components/TransferMatchDialog.test.tsx
@@ -1,0 +1,110 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import TransferMatchDialog from './TransferMatchDialog';
+import type { Transaction } from '../types';
+import type { TransferCandidate } from '../utils/transferMatch';
+
+vi.mock('../hooks/useCurrencyDecimal', () => ({
+  useCurrencyDecimal: () => ({
+    formatCurrency: (n: number) => `£${Math.abs(Number(n)).toFixed(2)}`,
+  }),
+}));
+
+const source: Transaction = {
+  id: 'src',
+  date: new Date('2026-06-10'),
+  description: 'TRANSFER TO 5755',
+  amount: -500,
+  type: 'expense',
+  accountId: 'acc-a',
+  category: '',
+  cleared: false,
+} as Transaction;
+
+const candidate = (id: string, over: Partial<Transaction> = {}, daysApart = 0): TransferCandidate => ({
+  transaction: {
+    ...source,
+    id,
+    accountId: 'acc-b',
+    amount: 500,
+    description: 'FASTER PAYMENT RECEIVED',
+    ...over,
+  } as Transaction,
+  daysApart,
+  descriptionScore: 10,
+});
+
+const baseProps = {
+  isOpen: true,
+  source,
+  sourceAccountName: 'Current Account',
+  targetAccountName: 'Savings',
+  busy: false,
+  onLink: vi.fn(),
+  onCreate: vi.fn(),
+  onCancel: vi.fn(),
+};
+
+describe('TransferMatchDialog', () => {
+  it('describes the movement direction from the amount sign', () => {
+    render(<TransferMatchDialog {...baseProps} candidates={[candidate('c1')]} />);
+    expect(screen.getByText('£500.00 from Current Account to Savings')).toBeInTheDocument();
+  });
+
+  it('offers to link when a match exists, preselecting the best one', () => {
+    const onLink = vi.fn();
+    render(<TransferMatchDialog {...baseProps} onLink={onLink} candidates={[candidate('c1')]} />);
+    expect(screen.getByText(/Found the matching transaction in Savings/)).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Link as transfer' }));
+    expect(onLink).toHaveBeenCalledWith('c1');
+  });
+
+  it('lets the user pick between several matches', () => {
+    const onLink = vi.fn();
+    render(
+      <TransferMatchDialog
+        {...baseProps}
+        onLink={onLink}
+        candidates={[candidate('c1'), candidate('c2', { description: 'CHEQUE IN' }, 2)]}
+      />
+    );
+    expect(screen.getByText(/Found 2 possible matches/)).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('radio', { name: /CHEQUE IN/ }));
+    fireEvent.click(screen.getByRole('button', { name: 'Link as transfer' }));
+    expect(onLink).toHaveBeenCalledWith('c2');
+  });
+
+  it('still allows creating a new counterpart when matches exist', () => {
+    const onCreate = vi.fn();
+    render(<TransferMatchDialog {...baseProps} onCreate={onCreate} candidates={[candidate('c1')]} />);
+    fireEvent.click(screen.getByRole('button', { name: 'Create new instead' }));
+    expect(onCreate).toHaveBeenCalled();
+  });
+
+  it('offers creation with a balance warning when nothing matches', () => {
+    const onCreate = vi.fn();
+    render(<TransferMatchDialog {...baseProps} onCreate={onCreate} candidates={[]} />);
+    expect(screen.getByText(/No matching transaction was found in Savings/)).toBeInTheDocument();
+    expect(screen.getByText(/adjusts Savings.s balance/)).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Create the other side' }));
+    expect(onCreate).toHaveBeenCalled();
+  });
+
+  it('cancels without side effects', () => {
+    const onCancel = vi.fn();
+    const onLink = vi.fn();
+    render(<TransferMatchDialog {...baseProps} onCancel={onCancel} onLink={onLink} candidates={[candidate('c1')]} />);
+    fireEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+    expect(onCancel).toHaveBeenCalled();
+    expect(onLink).not.toHaveBeenCalled();
+  });
+
+  it('disables actions while busy', () => {
+    render(<TransferMatchDialog {...baseProps} busy candidates={[candidate('c1')]} />);
+    expect(screen.getByRole('button', { name: 'Linking…' })).toBeDisabled();
+    expect(screen.getByRole('button', { name: 'Cancel' })).toBeDisabled();
+  });
+});

--- a/src/components/TransferMatchDialog.tsx
+++ b/src/components/TransferMatchDialog.tsx
@@ -1,0 +1,176 @@
+import React, { useEffect, useState } from 'react';
+import { createPortal } from 'react-dom';
+import { useCurrencyDecimal } from '../hooks/useCurrencyDecimal';
+import { ArrowRightLeftIcon } from './icons';
+import type { Transaction } from '../types';
+import type { TransferCandidate } from '../utils/transferMatch';
+
+/**
+ * The Money-style transfer confirmation. Shown when a transaction is filed
+ * under a "To/From <account>" category:
+ *
+ *   - match(es) found in the other account → confirm linking (balance-neutral;
+ *     both rows already exist and are simply joined), picking one when several
+ *     qualify;
+ *   - nothing found → offer to CREATE the other side, Money-style (this moves
+ *     the target account's balance — which is why it always confirms first;
+ *     the system never silently invents money movements).
+ */
+interface TransferMatchDialogProps {
+  isOpen: boolean;
+  source: Transaction;
+  sourceAccountName: string;
+  targetAccountName: string;
+  candidates: TransferCandidate[];
+  busy: boolean;
+  onLink: (candidateId: string) => void;
+  onCreate: () => void;
+  onCancel: () => void;
+}
+
+export default function TransferMatchDialog({
+  isOpen,
+  source,
+  sourceAccountName,
+  targetAccountName,
+  candidates,
+  busy,
+  onLink,
+  onCreate,
+  onCancel,
+}: TransferMatchDialogProps): React.JSX.Element | null {
+  const { formatCurrency } = useCurrencyDecimal();
+  const [selectedId, setSelectedId] = useState<string | null>(null);
+
+  // Preselect the best match whenever the dialog (re)opens.
+  useEffect(() => {
+    if (isOpen) {
+      setSelectedId(candidates[0]?.transaction.id ?? null);
+    }
+  }, [isOpen, candidates]);
+
+  if (!isOpen) return null;
+
+  const isOutgoing = source.amount < 0;
+  const magnitude = formatCurrency(Math.abs(source.amount));
+  const directionText = isOutgoing
+    ? `${magnitude} from ${sourceAccountName} to ${targetAccountName}`
+    : `${magnitude} from ${targetAccountName} to ${sourceAccountName}`;
+
+  // Portal to document.body: rendered in place, a transformed ancestor (the
+  // page-transition wrapper) would re-anchor position:fixed and trap the
+  // z-index beneath the portalled Modal — the dialog existed but never
+  // painted on top.
+  return createPortal(
+    <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-[70] p-4">
+      <div className="bg-white dark:bg-gray-800 rounded-2xl p-4 sm:p-6 w-full max-w-lg mx-4 shadow-xl">
+        <div className="flex items-center gap-3 mb-3">
+          <ArrowRightLeftIcon size={22} className="text-blue-600 dark:text-blue-400" />
+          <h3 className="text-base sm:text-lg font-semibold text-gray-900 dark:text-white">
+            Make this a transfer
+          </h3>
+        </div>
+        <p className="text-sm sm:text-base text-gray-600 dark:text-gray-400 mb-4">
+          {directionText}
+        </p>
+
+        {candidates.length > 0 ? (
+          <>
+            <p className="text-sm text-gray-700 dark:text-gray-300 mb-2">
+              {candidates.length === 1
+                ? `Found the matching transaction in ${targetAccountName} — link the two sides?`
+                : `Found ${candidates.length} possible matches in ${targetAccountName} — pick the other side:`}
+            </p>
+            <div className="space-y-2 mb-4 max-h-56 overflow-y-auto" role="radiogroup" aria-label="Matching transactions">
+              {candidates.slice(0, 6).map(candidate => {
+                const t = candidate.transaction;
+                const isSelected = selectedId === t.id;
+                return (
+                  <button
+                    key={t.id}
+                    type="button"
+                    role="radio"
+                    aria-checked={isSelected}
+                    onClick={() => setSelectedId(t.id)}
+                    className={`w-full text-left p-3 rounded-lg border transition-colors ${
+                      isSelected
+                        ? 'border-blue-500 bg-blue-50 dark:bg-blue-900/20'
+                        : 'border-gray-200 dark:border-gray-700 hover:border-gray-300 dark:hover:border-gray-600'
+                    }`}
+                  >
+                    <div className="flex items-center justify-between gap-3">
+                      <div className="min-w-0">
+                        <p className="font-medium text-gray-900 dark:text-white truncate">{t.description}</p>
+                        <p className="text-xs text-gray-500 dark:text-gray-400 mt-0.5">
+                          {new Date(t.date).toLocaleDateString()}
+                          {candidate.daysApart > 0 && ` • ${Math.round(candidate.daysApart)} day${Math.round(candidate.daysApart) === 1 ? '' : 's'} apart`}
+                        </p>
+                      </div>
+                      <span className={`shrink-0 font-medium ${t.amount >= 0 ? 'text-green-600 dark:text-green-400' : 'text-red-600 dark:text-red-400'}`}>
+                        {t.amount >= 0 ? '+' : '-'}{formatCurrency(Math.abs(t.amount))}
+                      </span>
+                    </div>
+                  </button>
+                );
+              })}
+            </div>
+            <div className="flex flex-wrap gap-3 justify-end items-center">
+              <button
+                type="button"
+                onClick={onCancel}
+                disabled={busy}
+                className="px-4 py-2 border border-gray-300 dark:border-gray-600 text-gray-700 dark:text-gray-300 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-700 disabled:opacity-50"
+              >
+                Cancel
+              </button>
+              <button
+                type="button"
+                onClick={onCreate}
+                disabled={busy}
+                title={`Ignore the matches and create a brand-new transaction in ${targetAccountName}`}
+                className="px-4 py-2 border border-gray-300 dark:border-gray-600 text-gray-700 dark:text-gray-300 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-700 disabled:opacity-50"
+              >
+                Create new instead
+              </button>
+              <button
+                type="button"
+                onClick={() => selectedId && onLink(selectedId)}
+                disabled={busy || !selectedId}
+                className="px-4 py-2 bg-[#1a2332] text-white rounded-lg hover:bg-secondary disabled:opacity-50 disabled:cursor-not-allowed"
+              >
+                {busy ? 'Linking…' : 'Link as transfer'}
+              </button>
+            </div>
+          </>
+        ) : (
+          <>
+            <p className="text-sm text-gray-700 dark:text-gray-300 mb-4">
+              No matching transaction was found in {targetAccountName} (same amount, within a few
+              days). Create the other side there? This adds a new transaction and adjusts{' '}
+              {targetAccountName}&rsquo;s balance.
+            </p>
+            <div className="flex gap-3 justify-end">
+              <button
+                type="button"
+                onClick={onCancel}
+                disabled={busy}
+                className="px-4 py-2 border border-gray-300 dark:border-gray-600 text-gray-700 dark:text-gray-300 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-700 disabled:opacity-50"
+              >
+                Cancel
+              </button>
+              <button
+                type="button"
+                onClick={onCreate}
+                disabled={busy}
+                className="px-4 py-2 bg-[#1a2332] text-white rounded-lg hover:bg-secondary disabled:opacity-50 disabled:cursor-not-allowed"
+              >
+                {busy ? 'Creating…' : 'Create the other side'}
+              </button>
+            </div>
+          </>
+        )}
+      </div>
+    </div>,
+    document.body
+  );
+}

--- a/src/contexts/AppContextSupabase.tsx
+++ b/src/contexts/AppContextSupabase.tsx
@@ -145,6 +145,21 @@ export interface AppContextType extends AppState {
     splits: TransactionSplitInput[],
     expectedAmount: number | null
   ) => Promise<{ isSplit: boolean; splitCount: number; amount: number }>;
+  /**
+   * Join two existing rows (in different accounts, exactly opposite amounts)
+   * into a linked transfer pair — both become type 'transfer' carrying the
+   * other account's To/From category. Balance-neutral; atomic server-side.
+   */
+  linkTransferPair: (idA: string, idB: string) => Promise<{ a: Transaction; b: Transaction }>;
+  /**
+   * Money-style "create the other side": insert the counterpart in the target
+   * account and convert the source into a linked transfer, atomically. Moves
+   * the target account's balance by the counterpart amount.
+   */
+  createTransferCounterpart: (
+    id: string,
+    targetAccountId: string
+  ) => Promise<{ source: Transaction; counterpart: Transaction }>;
 }
 
 const AppContext = createContext<AppContextType | undefined>(undefined);
@@ -641,6 +656,41 @@ export function AppProvider({ children }: { children: React.ReactNode }) {
     }
   }, [transactions]);
 
+  const linkTransferPair = useCallback(async (idA: string, idB: string) => {
+    try {
+      const result = await DataService.linkTransferPair(idA, idB);
+      // Balance-neutral: both rows existed with these amounts already.
+      setTransactions(prev => prev.map(t =>
+        t.id === result.a.id ? result.a : t.id === result.b.id ? result.b : t
+      ));
+      return result;
+    } catch (error) {
+      appLogger.error('Failed to link transfer pair', error);
+      throw error;
+    }
+  }, []);
+
+  const createTransferCounterpart = useCallback(async (id: string, targetAccountId: string) => {
+    try {
+      const result = await DataService.createTransferCounterpart(id, targetAccountId);
+      setTransactions(prev => [
+        ...prev.map(t => (t.id === result.source.id ? result.source : t)),
+        result.counterpart,
+      ]);
+      // The DB moved the target account's balance atomically; mirror locally
+      // (Decimal arithmetic, same as the other write paths).
+      setAccounts(prev => prev.map(acc =>
+        acc.id === targetAccountId
+          ? { ...acc, balance: toDecimal(acc.balance || 0).plus(toDecimal(result.counterpart.amount)).toNumber() }
+          : acc
+      ));
+      return result;
+    } catch (error) {
+      appLogger.error('Failed to create transfer counterpart', error);
+      throw error;
+    }
+  }, []);
+
   const deleteTransaction = useCallback(async (id: string) => {
     try {
       const transaction = transactions.find(t => t.id === id);
@@ -1018,6 +1068,8 @@ export function AppProvider({ children }: { children: React.ReactNode }) {
     transactionSplits,
     getTransactionSplits,
     setTransactionSplits,
+    linkTransferPair,
+    createTransferCounterpart,
 
     // Budget operations
     addBudget,

--- a/src/services/api/dataService.ts
+++ b/src/services/api/dataService.ts
@@ -28,7 +28,7 @@ type AccountServiceLike = Pick<typeof AccountService,
   subscribeToAccounts?: (userId: string, callback: (payload: unknown) => void) => () => void;
 };
 type TransactionServiceLike = Pick<typeof TransactionService,
-  'getTransactions' | 'createTransaction' | 'updateTransaction' | 'deleteTransaction' | 'setTransactionsCleared' | 'applyCategoryToUncategorized' | 'getTransactionSplits' | 'setTransactionSplits' | 'getAllTransactionSplits'> & {
+  'getTransactions' | 'createTransaction' | 'updateTransaction' | 'deleteTransaction' | 'setTransactionsCleared' | 'applyCategoryToUncategorized' | 'getTransactionSplits' | 'setTransactionSplits' | 'getAllTransactionSplits' | 'linkTransferPair' | 'createTransferCounterpart'> & {
   subscribeToTransactions?: (userId: string, callback: (payload: unknown) => void) => () => void;
 };
 type UserIdServiceLike = Pick<typeof userIdService,
@@ -421,6 +421,127 @@ class DataServiceImpl {
     return { isSplit: true, splitCount: newSplits.length, amount: newAmount };
   }
 
+  /** The account-managed To/From category id, or the legacy sentinel. */
+  private async localTransferCategoryFor(accountId: string, amount: number): Promise<string> {
+    const categories = await this.readCollection<Category>(STORAGE_KEYS.CATEGORIES);
+    const transferCategory = categories.find(c => c.isTransferCategory === true && c.accountId === accountId);
+    return transferCategory?.id ?? (amount < 0 ? 'transfer-out' : 'transfer-in');
+  }
+
+  /**
+   * Join two existing rows into a linked transfer pair. Mirrors the
+   * link_transfer_pair RPC's invariants locally so demo/offline behave
+   * identically. Balance-neutral: amounts are untouched.
+   */
+  async linkTransferPair(idA: string, idB: string): Promise<{ a: Transaction; b: Transaction }> {
+    const userId = this.userIdService.getCurrentDatabaseUserId();
+    if (userId && this.supabaseChecker()) {
+      return this.transactionService.linkTransferPair(idA, idB, userId);
+    }
+
+    const transactions = await this.readCollection<Transaction>(STORAGE_KEYS.TRANSACTIONS);
+    const a = transactions.find(t => t.id === idA);
+    const b = transactions.find(t => t.id === idB);
+    if (!a || !b) {
+      throw new Error('Transaction not found');
+    }
+    if (a.accountId === b.accountId) {
+      throw new Error('A transfer needs two different accounts');
+    }
+    const amountA = toDecimal(a.amount);
+    if (amountA.isZero() || !toDecimal(b.amount).equals(amountA.negated())) {
+      throw new Error('Transfer sides must have exactly opposite non-zero amounts');
+    }
+    if (a.isSplit || b.isSplit) {
+      throw new Error('A split transaction cannot become a transfer — remove the split first');
+    }
+    if (a.linkedTransferId || b.linkedTransferId) {
+      throw new Error('Transaction is already part of a linked transfer');
+    }
+
+    const newA: Transaction = {
+      ...a,
+      type: 'transfer',
+      category: await this.localTransferCategoryFor(b.accountId, a.amount),
+      transferAccountId: b.accountId,
+      linkedTransferId: b.id,
+    };
+    const newB: Transaction = {
+      ...b,
+      type: 'transfer',
+      category: await this.localTransferCategoryFor(a.accountId, b.amount),
+      transferAccountId: a.accountId,
+      linkedTransferId: a.id,
+    };
+    await this.persistCollection(
+      STORAGE_KEYS.TRANSACTIONS,
+      transactions.map(t => (t.id === idA ? newA : t.id === idB ? newB : t))
+    );
+    return { a: newA, b: newB };
+  }
+
+  /**
+   * Money-style "create the other side": insert the counterpart in the target
+   * account, convert the source into a linked transfer, and move the target
+   * account's balance. Mirrors the create_transfer_counterpart RPC.
+   */
+  async createTransferCounterpart(
+    id: string,
+    targetAccountId: string
+  ): Promise<{ source: Transaction; counterpart: Transaction }> {
+    const userId = this.userIdService.getCurrentDatabaseUserId();
+    if (userId && this.supabaseChecker()) {
+      return this.transactionService.createTransferCounterpart(id, targetAccountId, userId);
+    }
+
+    const transactions = await this.readCollection<Transaction>(STORAGE_KEYS.TRANSACTIONS);
+    const source = transactions.find(t => t.id === id);
+    if (!source) {
+      throw new Error('Transaction not found');
+    }
+    if (toDecimal(source.amount).isZero()) {
+      throw new Error('A zero-amount transaction cannot become a transfer');
+    }
+    if (source.isSplit) {
+      throw new Error('A split transaction cannot become a transfer — remove the split first');
+    }
+    if (source.linkedTransferId) {
+      throw new Error('Transaction is already part of a linked transfer');
+    }
+    if (source.accountId === targetAccountId) {
+      throw new Error('A transfer needs two different accounts');
+    }
+
+    const counterpartAmount = toDecimal(source.amount).negated().toNumber();
+    const counterpart: Transaction = {
+      id: this.generateId(),
+      date: source.date,
+      description: source.description,
+      amount: counterpartAmount,
+      type: 'transfer',
+      category: await this.localTransferCategoryFor(source.accountId, counterpartAmount),
+      accountId: targetAccountId,
+      notes: source.notes,
+      cleared: false,
+      transferAccountId: source.accountId,
+      linkedTransferId: source.id,
+    } as Transaction;
+    const newSource: Transaction = {
+      ...source,
+      type: 'transfer',
+      category: await this.localTransferCategoryFor(targetAccountId, source.amount),
+      transferAccountId: targetAccountId,
+      linkedTransferId: counterpart.id,
+    };
+
+    await this.persistCollection(
+      STORAGE_KEYS.TRANSACTIONS,
+      [...transactions.map(t => (t.id === id ? newSource : t)), counterpart]
+    );
+    await this.updateAccountBalance(targetAccountId, counterpartAmount);
+    return { source: newSource, counterpart };
+  }
+
   async getBudgets(): Promise<Budget[]> {
     return this.readCollection<Budget>(STORAGE_KEYS.BUDGETS);
   }
@@ -551,6 +672,17 @@ export class DataService {
 
   static getAllTransactionSplits(): Promise<TransactionSplit[]> {
     return this.service.getAllTransactionSplits();
+  }
+
+  static linkTransferPair(idA: string, idB: string): Promise<{ a: Transaction; b: Transaction }> {
+    return this.service.linkTransferPair(idA, idB);
+  }
+
+  static createTransferCounterpart(
+    id: string,
+    targetAccountId: string
+  ): Promise<{ source: Transaction; counterpart: Transaction }> {
+    return this.service.createTransferCounterpart(id, targetAccountId);
   }
 
   static getTransactionSplits(transactionId: string): Promise<TransactionSplit[]> {

--- a/src/services/api/supabaseClient.ts
+++ b/src/services/api/supabaseClient.ts
@@ -45,6 +45,14 @@ type Database = {
         };
         Returns: Record<string, unknown>;
       };
+      link_transfer_pair: {
+        Args: { p_id_a: string; p_id_b: string; p_user_id?: string };
+        Returns: Record<string, unknown>;
+      };
+      create_transfer_counterpart: {
+        Args: { p_id: string; p_target_account_id: string; p_user_id?: string };
+        Returns: Record<string, unknown>;
+      };
       delete_unused_categories: {
         Args: { p_ids: string[]; p_user_id?: string };
         Returns: number;

--- a/src/services/api/transactionService.ts
+++ b/src/services/api/transactionService.ts
@@ -536,6 +536,77 @@ class TransactionServiceImpl {
     }
   }
 
+  /**
+   * Join two existing rows into a linked transfer pair (both sides already
+   * exist). Amount/account/link invariants are enforced by the RPC; balance-
+   * neutral by construction. Cloud-only here — the local/demo path lives in
+   * DataService (which owns local storage semantics).
+   */
+  async linkTransferPair(
+    idA: string,
+    idB: string,
+    userId?: string
+  ): Promise<{ a: Transaction; b: Transaction }> {
+    if (!this.isSupabaseReady()) {
+      throw new Error('linkTransferPair requires the cloud connection (local mode goes through DataService)');
+    }
+    try {
+      const client = this.supabaseClient!;
+      const { data, error } = await client.rpc('link_transfer_pair', {
+        p_id_a: idA,
+        p_id_b: idB,
+        ...(userId ? { p_user_id: userId } : {})
+      });
+      if (error) {
+        this.logger.error('Error linking transfer pair:', error);
+        throw new Error(handleSupabaseError(error));
+      }
+      const result = (data ?? {}) as { a?: Record<string, unknown>; b?: Record<string, unknown> };
+      return {
+        a: mapFromDbFields(result.a ?? {}) as unknown as Transaction,
+        b: mapFromDbFields(result.b ?? {}) as unknown as Transaction,
+      };
+    } catch (error) {
+      this.logger.error('TransactionService.linkTransferPair error:', error as Error);
+      throw error;
+    }
+  }
+
+  /**
+   * Money-style "create the other side": insert the counterpart in the target
+   * account and convert the source into a linked transfer, atomically (the
+   * RPC also adjusts the target account's balance and audits everything).
+   */
+  async createTransferCounterpart(
+    id: string,
+    targetAccountId: string,
+    userId?: string
+  ): Promise<{ source: Transaction; counterpart: Transaction }> {
+    if (!this.isSupabaseReady()) {
+      throw new Error('createTransferCounterpart requires the cloud connection (local mode goes through DataService)');
+    }
+    try {
+      const client = this.supabaseClient!;
+      const { data, error } = await client.rpc('create_transfer_counterpart', {
+        p_id: id,
+        p_target_account_id: targetAccountId,
+        ...(userId ? { p_user_id: userId } : {})
+      });
+      if (error) {
+        this.logger.error('Error creating transfer counterpart:', error);
+        throw new Error(handleSupabaseError(error));
+      }
+      const result = (data ?? {}) as { source?: Record<string, unknown>; counterpart?: Record<string, unknown> };
+      return {
+        source: mapFromDbFields(result.source ?? {}) as unknown as Transaction,
+        counterpart: mapFromDbFields(result.counterpart ?? {}) as unknown as Transaction,
+      };
+    } catch (error) {
+      this.logger.error('TransactionService.createTransferCounterpart error:', error as Error);
+      throw error;
+    }
+  }
+
   async deleteTransaction(id: string, userId?: string): Promise<void> {
     if (!this.isSupabaseReady()) {
       const transactions = await this.readStoredTransactions();
@@ -814,6 +885,18 @@ export class TransactionService {
 
   static getAllTransactionSplits(userId?: string): Promise<TransactionSplit[]> {
     return this.service.getAllTransactionSplits(userId);
+  }
+
+  static linkTransferPair(idA: string, idB: string, userId?: string): Promise<{ a: Transaction; b: Transaction }> {
+    return this.service.linkTransferPair(idA, idB, userId);
+  }
+
+  static createTransferCounterpart(
+    id: string,
+    targetAccountId: string,
+    userId?: string
+  ): Promise<{ source: Transaction; counterpart: Transaction }> {
+    return this.service.createTransferCounterpart(id, targetAccountId, userId);
   }
 
   static getTransactionSplits(transactionId: string): Promise<TransactionSplit[]> {

--- a/src/test/mocks/AppContextSupabase.ts
+++ b/src/test/mocks/AppContextSupabase.ts
@@ -40,6 +40,8 @@ const baseValue = {
   transactionSplits: [],
   getTransactionSplits: async () => [],
   setTransactionSplits: async () => ({ isSplit: false, splitCount: 0, amount: 0 }),
+  linkTransferPair: async () => { throw new Error('not available in mock'); },
+  createTransferCounterpart: async () => { throw new Error('not available in mock'); },
   refreshAccountsAndTransactions: asyncNoop,
   refreshCategories: asyncNoop,
   addBudget: noop,

--- a/src/utils/transferMatch.test.ts
+++ b/src/utils/transferMatch.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect } from 'vitest';
+import { findTransferCandidates, transferCategoryFor } from './transferMatch';
+import type { Transaction, Category } from '../types';
+
+const txn = (over: Partial<Transaction>): Transaction => ({
+  id: 'x',
+  date: new Date('2026-06-10'),
+  description: 'TRANSFER TO 5755',
+  amount: -500,
+  type: 'expense',
+  accountId: 'acc-a',
+  category: '',
+  cleared: false,
+  ...over,
+}) as Transaction;
+
+// The row being filed as a transfer: £500 out of account A on 10 June.
+const source = txn({ id: 'src' });
+
+describe('findTransferCandidates', () => {
+  it('finds the exact-opposite row in the target account within the window', () => {
+    const other = txn({
+      id: 'match',
+      accountId: 'acc-b',
+      amount: 500,
+      type: 'income',
+      description: 'FASTER PAYMENT RECEIVED',
+      date: new Date('2026-06-12'),
+    });
+    const result = findTransferCandidates([source, other], source, 'acc-b');
+    expect(result).toHaveLength(1);
+    expect(result[0].transaction.id).toBe('match');
+    expect(result[0].daysApart).toBe(2);
+  });
+
+  it('requires the amount to be EXACTLY the negation', () => {
+    const near = txn({ id: 'near', accountId: 'acc-b', amount: 500.01, date: new Date('2026-06-10') });
+    const sameSign = txn({ id: 'same', accountId: 'acc-b', amount: -500, date: new Date('2026-06-10') });
+    expect(findTransferCandidates([near, sameSign], source, 'acc-b')).toHaveLength(0);
+  });
+
+  it('rejects rows outside the date window', () => {
+    const late = txn({ id: 'late', accountId: 'acc-b', amount: 500, date: new Date('2026-06-20') });
+    expect(findTransferCandidates([late], source, 'acc-b')).toHaveLength(0);
+    // …but a custom window can reach it
+    expect(findTransferCandidates([late], source, 'acc-b', 30)).toHaveLength(1);
+  });
+
+  it('skips split parents, already-linked rows, other accounts, and the source itself', () => {
+    const split = txn({ id: 's1', accountId: 'acc-b', amount: 500, isSplit: true });
+    const linked = txn({ id: 's2', accountId: 'acc-b', amount: 500, linkedTransferId: 'elsewhere' });
+    const wrongAccount = txn({ id: 's3', accountId: 'acc-c', amount: 500 });
+    const self = txn({ id: 'src', accountId: 'acc-b', amount: 500 });
+    expect(findTransferCandidates([split, linked, wrongAccount, self], source, 'acc-b')).toHaveLength(0);
+  });
+
+  it('never matches zero-amount transactions', () => {
+    const zeroSource = txn({ id: 'z', amount: 0 });
+    const zeroOther = txn({ id: 'z2', accountId: 'acc-b', amount: 0 });
+    expect(findTransferCandidates([zeroOther], zeroSource, 'acc-b')).toHaveLength(0);
+  });
+
+  it('ranks by date proximity, then description similarity', () => {
+    const sameDayDifferentDesc = txn({
+      id: 'day0-far', accountId: 'acc-b', amount: 500,
+      date: new Date('2026-06-10'), description: 'CHEQUE PAID IN',
+    });
+    const sameDaySimilarDesc = txn({
+      id: 'day0-near', accountId: 'acc-b', amount: 500,
+      date: new Date('2026-06-10'), description: 'TRANSFER TO 5755',
+    });
+    const nextDay = txn({
+      id: 'day1', accountId: 'acc-b', amount: 500, date: new Date('2026-06-11'),
+    });
+    const result = findTransferCandidates(
+      [nextDay, sameDayDifferentDesc, sameDaySimilarDesc], source, 'acc-b'
+    );
+    expect(result.map(c => c.transaction.id)).toEqual(['day0-near', 'day0-far', 'day1']);
+  });
+});
+
+describe('transferCategoryFor', () => {
+  const categories: Category[] = [
+    { id: 'c1', name: 'Groceries', type: 'expense', level: 'detail' },
+    { id: 'c2', name: 'To/From Savings', type: 'both', level: 'detail', isTransferCategory: true, accountId: 'acc-b' },
+  ];
+
+  it('finds the account-managed transfer category', () => {
+    expect(transferCategoryFor(categories, 'acc-b')?.id).toBe('c2');
+  });
+
+  it('returns undefined for accounts without one', () => {
+    expect(transferCategoryFor(categories, 'acc-z')).toBeUndefined();
+  });
+});

--- a/src/utils/transferMatch.ts
+++ b/src/utils/transferMatch.ts
@@ -1,0 +1,69 @@
+import { toDecimal } from './decimal';
+import { calculateStringSimilarity } from './duplicateScan';
+import type { Transaction, Category } from '../types';
+
+/**
+ * Transfer matching (the Microsoft Money model): when a transaction is filed
+ * under a "To/From B" category, look for its opposite side already sitting in
+ * account B before creating one.
+ *
+ * A candidate must be watertight on the numbers — the amount is EXACTLY the
+ * source negated (Decimal comparison, no float slack) — and close in time
+ * (bank clearing lag means the two sides rarely post the same day). The
+ * description is deliberately only a tie-breaker: the two banks almost never
+ * describe the same movement the same way ("TRANSFER TO 5755" vs "FASTER
+ * PAYMENT RECEIVED").
+ */
+export interface TransferCandidate {
+  transaction: Transaction;
+  /** Whole/fractional days between the two sides' dates. */
+  daysApart: number;
+  /** 0–100 similarity of the two descriptions (tie-breaking only). */
+  descriptionScore: number;
+}
+
+const DAY_MS = 1000 * 60 * 60 * 24;
+
+export const TRANSFER_MATCH_WINDOW_DAYS = 4;
+
+export function findTransferCandidates(
+  transactions: Transaction[],
+  source: Transaction,
+  targetAccountId: string,
+  windowDays: number = TRANSFER_MATCH_WINDOW_DAYS
+): TransferCandidate[] {
+  const sourceAmount = toDecimal(source.amount);
+  if (sourceAmount.isZero()) {
+    return [];
+  }
+  const oppositeAmount = sourceAmount.negated();
+  const sourceTime = new Date(source.date).getTime();
+
+  const candidates: TransferCandidate[] = [];
+  for (const transaction of transactions) {
+    if (transaction.accountId !== targetAccountId) continue;
+    if (transaction.id === source.id) continue;
+    // A split parent cannot be a transfer, and an already-linked side is taken.
+    if (transaction.isSplit) continue;
+    if (transaction.linkedTransferId) continue;
+    if (!toDecimal(transaction.amount).equals(oppositeAmount)) continue;
+
+    const daysApart = Math.abs(new Date(transaction.date).getTime() - sourceTime) / DAY_MS;
+    if (daysApart > windowDays) continue;
+
+    candidates.push({
+      transaction,
+      daysApart,
+      descriptionScore: calculateStringSimilarity(source.description, transaction.description),
+    });
+  }
+
+  // Closest date wins; description similarity breaks ties.
+  candidates.sort((a, b) => a.daysApart - b.daysApart || b.descriptionScore - a.descriptionScore);
+  return candidates;
+}
+
+/** The account-managed "To/From <account>" category, if the account has one. */
+export function transferCategoryFor(categories: Category[], accountId: string): Category | undefined {
+  return categories.find(c => c.isTransferCategory === true && c.accountId === accountId);
+}

--- a/supabase/migrations/20260716100000_transfer_linking.sql
+++ b/supabase/migrations/20260716100000_transfer_linking.sql
@@ -1,0 +1,245 @@
+-- Transfer linking (the Microsoft Money model) — schema + atomic RPCs.
+--
+-- IMPORTANT: Run this SQL in the Supabase SQL Editor to apply to production DB.
+-- Safe to apply before the matching client deploys: the new column is
+-- nullable and nothing reads it until the transfer-match UI ships.
+--
+-- Filing a transaction under a "To/From B" category should make it a REAL
+-- transfer: typed 'transfer', linked to its opposite side in account B, with
+-- each side carrying the other account's To/From category. Two write paths:
+--
+--   - link_transfer_pair: BOTH sides already exist (typical when both
+--     accounts import from banks) — join them. Balance-neutral by
+--     construction: amounts are validated as exact opposites and unchanged.
+--   - create_transfer_counterpart: only one side exists (old/incomplete
+--     data) — create the opposite row in the target account, Money-style,
+--     adjusting that account's balance atomically.
+--
+-- Both are SECURITY INVOKER (RLS scopes rows) with the usual p_user_id
+-- defence-in-depth guard, and audit every row they touch. Split parents are
+-- excluded (a split cannot be a transfer; enforced here AND by the split
+-- guard trigger).
+
+BEGIN;
+
+-- ── Schema ───────────────────────────────────────────────────────────────────
+
+-- The other side of a linked transfer pair. ON DELETE SET NULL: deleting one
+-- side never leaves the survivor pointing at a ghost (it simply becomes an
+-- unlinked transfer again, eligible for re-linking).
+ALTER TABLE public.transactions
+  ADD COLUMN IF NOT EXISTS linked_transfer_id uuid
+    REFERENCES public.transactions(id) ON DELETE SET NULL;
+
+CREATE INDEX IF NOT EXISTS idx_transactions_linked_transfer
+  ON public.transactions (linked_transfer_id)
+  WHERE linked_transfer_id IS NOT NULL;
+
+-- ── Helper: the To/From category id for an account ──────────────────────────
+-- Falls back to the legacy 'transfer-out'/'transfer-in' sentinels when the
+-- account has no transfer category (should not happen — the lifecycle
+-- triggers maintain them — but a missing category must not block a link).
+
+CREATE OR REPLACE FUNCTION public.transfer_category_for(
+  p_user_id uuid,
+  p_account_id uuid,
+  p_amount numeric
+)
+RETURNS text
+LANGUAGE sql STABLE
+SET search_path = public
+AS $$
+  SELECT COALESCE(
+    (SELECT c.id::text
+       FROM public.categories c
+      WHERE c.user_id = p_user_id
+        AND c.is_transfer_category
+        AND c.account_id = p_account_id
+      LIMIT 1),
+    CASE WHEN p_amount < 0 THEN 'transfer-out' ELSE 'transfer-in' END
+  );
+$$;
+
+-- ── link_transfer_pair: join two existing rows into a transfer ───────────────
+
+CREATE OR REPLACE FUNCTION public.link_transfer_pair(
+  p_id_a uuid,
+  p_id_b uuid,
+  p_user_id uuid DEFAULT NULL
+)
+RETURNS jsonb
+LANGUAGE plpgsql SECURITY INVOKER
+SET search_path = public
+AS $$
+DECLARE
+  v_a public.transactions;
+  v_b public.transactions;
+  v_a_new public.transactions;
+  v_b_new public.transactions;
+BEGIN
+  IF p_id_a = p_id_b THEN
+    RAISE EXCEPTION 'a transaction cannot be linked to itself' USING ERRCODE = '22023';
+  END IF;
+
+  -- Deterministic lock order prevents deadlocks between concurrent links.
+  PERFORM 1 FROM public.transactions
+   WHERE id IN (p_id_a, p_id_b)
+     AND (p_user_id IS NULL OR user_id = p_user_id)
+   ORDER BY id
+   FOR UPDATE;
+
+  SELECT * INTO v_a FROM public.transactions
+   WHERE id = p_id_a AND (p_user_id IS NULL OR user_id = p_user_id);
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'transaction_not_found' USING ERRCODE = 'P0002';
+  END IF;
+  SELECT * INTO v_b FROM public.transactions
+   WHERE id = p_id_b AND (p_user_id IS NULL OR user_id = p_user_id);
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'transaction_not_found' USING ERRCODE = 'P0002';
+  END IF;
+
+  IF v_a.user_id <> v_b.user_id THEN
+    RAISE EXCEPTION 'transactions belong to different users' USING ERRCODE = '28000';
+  END IF;
+  IF v_a.account_id = v_b.account_id THEN
+    RAISE EXCEPTION 'a transfer needs two different accounts' USING ERRCODE = 'P0001';
+  END IF;
+  IF v_a.amount = 0 OR v_a.amount <> -v_b.amount THEN
+    RAISE EXCEPTION 'transfer sides must have exactly opposite non-zero amounts (% vs %)',
+      v_a.amount, v_b.amount USING ERRCODE = 'P0001';
+  END IF;
+  IF v_a.is_split OR v_b.is_split THEN
+    RAISE EXCEPTION 'a split transaction cannot become a transfer — remove the split first'
+      USING ERRCODE = 'P0001';
+  END IF;
+  IF v_a.linked_transfer_id IS NOT NULL OR v_b.linked_transfer_id IS NOT NULL THEN
+    RAISE EXCEPTION 'transaction is already part of a linked transfer' USING ERRCODE = 'P0001';
+  END IF;
+
+  -- Each side files under the OTHER account's To/From category.
+  UPDATE public.transactions
+     SET type = 'transfer',
+         category = public.transfer_category_for(v_a.user_id, v_b.account_id, v_a.amount),
+         transfer_account_id = v_b.account_id,
+         linked_transfer_id = v_b.id,
+         updated_at = now()
+   WHERE id = v_a.id
+  RETURNING * INTO v_a_new;
+
+  UPDATE public.transactions
+     SET type = 'transfer',
+         category = public.transfer_category_for(v_b.user_id, v_a.account_id, v_b.amount),
+         transfer_account_id = v_a.account_id,
+         linked_transfer_id = v_a.id,
+         updated_at = now()
+   WHERE id = v_b.id
+  RETURNING * INTO v_b_new;
+
+  -- Amounts are untouched, so this is balance-neutral by construction.
+  PERFORM public.write_financial_audit(
+    v_a_new.user_id, 'transaction', v_a_new.id, 'update', to_jsonb(v_a), to_jsonb(v_a_new));
+  PERFORM public.write_financial_audit(
+    v_b_new.user_id, 'transaction', v_b_new.id, 'update', to_jsonb(v_b), to_jsonb(v_b_new));
+
+  RETURN jsonb_build_object('a', to_jsonb(v_a_new), 'b', to_jsonb(v_b_new));
+END;
+$$;
+
+-- ── create_transfer_counterpart: Money-style "make the other side" ───────────
+
+CREATE OR REPLACE FUNCTION public.create_transfer_counterpart(
+  p_id uuid,
+  p_target_account_id uuid,
+  p_user_id uuid DEFAULT NULL
+)
+RETURNS jsonb
+LANGUAGE plpgsql SECURITY INVOKER
+SET search_path = public
+AS $$
+DECLARE
+  v_src public.transactions;
+  v_src_new public.transactions;
+  v_new public.transactions;
+  v_acct_before public.accounts;
+  v_acct_after public.accounts;
+BEGIN
+  SELECT * INTO v_src FROM public.transactions
+   WHERE id = p_id AND (p_user_id IS NULL OR user_id = p_user_id)
+   FOR UPDATE;
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'transaction_not_found' USING ERRCODE = 'P0002';
+  END IF;
+
+  IF v_src.amount = 0 THEN
+    RAISE EXCEPTION 'a zero-amount transaction cannot become a transfer' USING ERRCODE = 'P0001';
+  END IF;
+  IF v_src.is_split THEN
+    RAISE EXCEPTION 'a split transaction cannot become a transfer — remove the split first'
+      USING ERRCODE = 'P0001';
+  END IF;
+  IF v_src.linked_transfer_id IS NOT NULL THEN
+    RAISE EXCEPTION 'transaction is already part of a linked transfer' USING ERRCODE = 'P0001';
+  END IF;
+  IF v_src.account_id = p_target_account_id THEN
+    RAISE EXCEPTION 'a transfer needs two different accounts' USING ERRCODE = 'P0001';
+  END IF;
+
+  -- Lock and validate the target account up front (owned by the same user).
+  SELECT * INTO v_acct_before FROM public.accounts
+   WHERE id = p_target_account_id AND user_id = v_src.user_id
+   FOR UPDATE;
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'account_not_found_or_not_owned' USING ERRCODE = 'P0001';
+  END IF;
+
+  INSERT INTO public.transactions
+    (user_id, account_id, description, amount, type, date, category,
+     notes, transfer_account_id, linked_transfer_id, is_cleared)
+  VALUES
+    (v_src.user_id, p_target_account_id, v_src.description, -v_src.amount,
+     'transfer', v_src.date,
+     public.transfer_category_for(v_src.user_id, v_src.account_id, -v_src.amount),
+     v_src.notes, v_src.account_id, v_src.id, false)
+  RETURNING * INTO v_new;
+
+  UPDATE public.transactions
+     SET type = 'transfer',
+         category = public.transfer_category_for(v_src.user_id, p_target_account_id, v_src.amount),
+         transfer_account_id = p_target_account_id,
+         linked_transfer_id = v_new.id,
+         updated_at = now()
+   WHERE id = v_src.id
+  RETURNING * INTO v_src_new;
+
+  -- The new row moves the target account's ledger balance.
+  UPDATE public.accounts
+     SET balance = balance + v_new.amount,
+         updated_at = now()
+   WHERE id = p_target_account_id AND user_id = v_src.user_id
+  RETURNING * INTO v_acct_after;
+
+  PERFORM public.write_financial_audit(
+    v_new.user_id, 'transaction', v_new.id, 'create', NULL, to_jsonb(v_new));
+  PERFORM public.write_financial_audit(
+    v_src_new.user_id, 'transaction', v_src_new.id, 'update', to_jsonb(v_src), to_jsonb(v_src_new));
+  PERFORM public.write_financial_audit(
+    v_src.user_id, 'account', v_acct_after.id, 'update',
+    to_jsonb(v_acct_before), to_jsonb(v_acct_after));
+
+  RETURN jsonb_build_object('source', to_jsonb(v_src_new), 'counterpart', to_jsonb(v_new));
+END;
+$$;
+
+-- ── Grants ───────────────────────────────────────────────────────────────────
+
+REVOKE ALL ON FUNCTION public.transfer_category_for(uuid, uuid, numeric) FROM public, anon;
+GRANT EXECUTE ON FUNCTION public.transfer_category_for(uuid, uuid, numeric) TO authenticated, service_role;
+
+REVOKE ALL ON FUNCTION public.link_transfer_pair(uuid, uuid, uuid) FROM public, anon;
+GRANT EXECUTE ON FUNCTION public.link_transfer_pair(uuid, uuid, uuid) TO authenticated, service_role;
+
+REVOKE ALL ON FUNCTION public.create_transfer_counterpart(uuid, uuid, uuid) FROM public, anon;
+GRANT EXECUTE ON FUNCTION public.create_transfer_counterpart(uuid, uuid, uuid) TO authenticated, service_role;
+
+COMMIT;


### PR DESCRIPTION
The feature discussed in chat: filing a transaction under a **"To/From \<account\>"** category (or switching an existing row's Type to Transfer) now behaves like Microsoft Money — but **search-first**, so bank-imported histories never double-count.

## ⚠️ Requires a migration (Steve runs it)

`supabase/migrations/20260716100000_transfer_linking.sql` — safe to apply before this deploys. Contains:
- `transactions.linked_transfer_id` (FK with **ON DELETE SET NULL** — deleting one side of a pair leaves the survivor a normal unlinked transfer, never a ghost pointer)
- **`link_transfer_pair`** — atomically joins two existing rows (different accounts, *exactly* opposite non-zero amounts, neither split nor already linked) into a typed, linked transfer pair, each side filed under the **other account's To/From category**. Balance-neutral by construction. Audited.
- **`create_transfer_counterpart`** — Money-style "make the other side": inserts the opposite row in the target account, converts the source, adjusts the target's balance atomically. Audited (both transactions + the account).

## The flow

1. Pick "To/From B" on a transaction (quick-edit bar or the editor), or switch its Type to Transfer with a target.
2. The app searches account B for the opposite side: **amount exactly negated** (non-negotiable), within **±4 days** (clearing lag), not split/linked. Description similarity only breaks ties — the two banks rarely describe the same movement alike.
3. **One match** → "Found the matching transaction in B — link the two sides?" → linked, balance-neutral. **Several** → pick from a list. **None** → "Create the other side? This adds a transaction and adjusts B's balance." The system never silently invents money movements.

## Bugs fixed along the way

- **The editor's half-transfer bug**: converting an existing expense to Transfer previously flipped the type *without* creating the other side or linking anything. That path now routes through the flow above.
- Existing transfers opened in the editor showed a **placeholder** target select, and every re-save **clobbered their category** back to the `transfer-out` sentinel. Fixed (select seeds from the actual target; unchanged saves keep the category).
- A **linked pair's target can't be silently moved** (v1: delete and recreate — an explicit error says so).
- `CategorySelector` filtered inactive **sub** categories but leaked inactive **detail** ones (a closed account's To/From) — now filtered.
- `TransferMatchDialog` and the editor's delete-confirm are **portalled to `document.body`**: rendered in-tree, the page-transition wrapper's transform re-anchored `position:fixed` and painted the overlay *behind* the portalled modal (in the DOM, invisible on screen — caught during live verification).

## Verified

Live in demo mode (local path, which mirrors the RPC invariants): converted an existing expense → dialog with the no-match state → created the other side → editor closed, row left its category list. **Tests:** 20 new (matching util 8, dialog 7, quick-edit flow 5); 3,097 passing; strict types; zero lint. The cloud RPCs follow the exact patterns of `set_transaction_splits` (locking, guards, audit, balance arithmetic in SQL).

Payee-memory fan-out deliberately never runs for transfer filings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)