### PR TITLE
feat(banking): credit-card feeds via the TrueLayer Cards API (Amex etc.)

### DIFF
--- a/api/_lib/truelayer.ts
+++ b/api/_lib/truelayer.ts
@@ -170,6 +170,119 @@ export const refreshAccessToken = async (refreshToken: string): Promise<TokenRes
   return data;
 };
 
+export interface TrueLayerCard {
+  account_id: string;
+  card_network?: string;
+  card_type?: string;
+  currency?: string;
+  display_name?: string;
+  partial_card_number?: string;
+  name_on_card?: string;
+  provider: AccountProviderInfo;
+}
+
+interface CardsResponse {
+  results: TrueLayerCard[];
+}
+
+interface CardBalanceResult {
+  /** Amount OWED on the card (positive = expenditure). */
+  current?: number | string | null;
+  /** Remaining CREDIT — never a balance; never use as a fallback. */
+  available?: number | string | null;
+}
+
+interface CardBalancesResponse {
+  results: CardBalanceResult[];
+}
+
+/**
+ * The user's cards on this connection. A connection authorised BEFORE the
+ * `cards` scope was added will be rejected with 403 — treated as "no cards"
+ * so pre-existing bank connections keep syncing untouched; the user re-links
+ * to pick up card access.
+ */
+export const fetchCards = async (accessToken: string): Promise<TrueLayerCard[]> => {
+  const response = await fetch(`${getApiBaseUrl()}/data/v1/cards`, {
+    headers: {
+      Authorization: `Bearer ${accessToken}`
+    }
+  });
+
+  if (response.status === 403) {
+    return [];
+  }
+  if (!response.ok) {
+    const details = await response.text();
+    throw new Error(`TrueLayer cards fetch failed: ${response.status} ${details}`);
+  }
+
+  const data = (await response.json()) as CardsResponse;
+  return Array.isArray(data.results) ? data.results : [];
+};
+
+/**
+ * The card's `current` figure: the amount OWED (positive). Deliberately no
+ * fallback to `available` — that is remaining credit, and using it would
+ * report a £20 debt on a £3,300 limit as £3,280 of money.
+ */
+export const fetchCardBalance = async (
+  accessToken: string,
+  accountId: string
+): Promise<number | null> => {
+  const response = await fetch(`${getApiBaseUrl()}/data/v1/cards/${encodeURIComponent(accountId)}/balance`, {
+    headers: {
+      Authorization: `Bearer ${accessToken}`
+    }
+  });
+
+  if (!response.ok) {
+    const details = await response.text();
+    throw new Error(`TrueLayer card balance fetch failed (${accountId}): ${response.status} ${details}`);
+  }
+
+  const payload = (await response.json()) as CardBalancesResponse;
+  const balanceRow = Array.isArray(payload.results) ? payload.results[0] : undefined;
+  if (!balanceRow) {
+    return null;
+  }
+  return toNumber(balanceRow.current);
+};
+
+/**
+ * Card transactions. Same row shape as account transactions, but the SIGN
+ * convention is inverted: positive = money out of the card (a purchase).
+ * Callers normalise via cardAmountToAppSigned.
+ */
+export const fetchCardTransactions = async (
+  accessToken: string,
+  accountId: string,
+  options: { from?: string; to?: string } = {}
+): Promise<TrueLayerTransaction[]> => {
+  const url = new URL(`${getApiBaseUrl()}/data/v1/cards/${encodeURIComponent(accountId)}/transactions`);
+  if (options.from) {
+    url.searchParams.set('from', options.from);
+  }
+  if (options.to) {
+    url.searchParams.set('to', options.to);
+  }
+
+  const response = await fetch(url.toString(), {
+    headers: {
+      Authorization: `Bearer ${accessToken}`
+    }
+  });
+
+  if (!response.ok) {
+    const details = await response.text();
+    throw new Error(`TrueLayer card transactions fetch failed (${accountId}): ${response.status} ${details}`);
+  }
+
+  const payload = (await response.json()) as TransactionsResponse;
+  // Same PII rule as account transactions: never log contents.
+  return Array.isArray(payload.results) ? payload.results : [];
+};
+
 export const fetchAccounts = async (accessToken: string): Promise<TrueLayerAccount[]> => {
   const response = await fetch(`${getApiBaseUrl()}/data/v1/accounts`, {
     headers: {

--- a/api/banking/create-link-token.ts
+++ b/api/banking/create-link-token.ts
@@ -11,7 +11,10 @@ import { createStateToken } from '../_lib/state.js';
 import { buildAuthUrl, getRedirectUri, isSandboxEnvironment } from '../_lib/truelayer.js';
 import { withSentry } from '../_lib/sentry.js';
 
-const AUTH_SCOPES = ['info', 'accounts', 'balance', 'transactions', 'offline_access'];
+// 'cards' unlocks credit-card providers (American Express etc.) in the auth
+// dialog and the /data/v1/cards endpoints. Existing connections keep their
+// old scopes until re-linked.
+const AUTH_SCOPES = ['info', 'accounts', 'balance', 'cards', 'transactions', 'offline_access'];
 
 async function handler(req: VercelRequest, res: VercelResponse) {
   if (setCorsHeaders(req, res)) {

--- a/api/banking/discover-accounts.ts
+++ b/api/banking/discover-accounts.ts
@@ -12,7 +12,12 @@ import {
   getUserTrueLayerConnection,
   withTrueLayerAccessToken
 } from '../_lib/banking-sync.js';
-import { fetchAccountBalance, fetchAccounts } from '../_lib/truelayer.js';
+import { fetchAccountBalance, fetchAccounts, fetchCardBalance, fetchCards } from '../_lib/truelayer.js';
+import {
+  cardBalanceToAppBalance,
+  cardDisplayName,
+  cardMask
+} from '../../src/services/banking/cardNormalization.js';
 import { withSentry } from '../_lib/sentry.js';
 
 const mapAccountType = (accountType: string | undefined): string => {
@@ -55,8 +60,11 @@ async function handler(req: VercelRequest, res: VercelResponse) {
 
     const accounts = await withTrueLayerAccessToken(supabase, connection, async (accessToken) => {
       const truelayerAccounts = await fetchAccounts(accessToken);
+      // Credit cards live on a separate API surface. fetchCards returns []
+      // when the connection's token lacks the cards scope (pre-cards links).
+      const truelayerCards = await fetchCards(accessToken);
 
-      return Promise.all(
+      const discoveredAccounts = await Promise.all(
         truelayerAccounts.map(async (account): Promise<DiscoveredBankAccount> => {
           let balance = 0;
           try {
@@ -84,10 +92,35 @@ async function handler(req: VercelRequest, res: VercelResponse) {
             currency: account.currency || 'GBP',
             sortCode: account.account_number?.sort_code ?? undefined,
             accountNumber: accountNumber ?? undefined,
-            mask
+            mask,
+            kind: 'account'
           };
         })
       );
+
+      const discoveredCards = await Promise.all(
+        truelayerCards.map(async (card): Promise<DiscoveredBankAccount> => {
+          // Card `current` = amount OWED (positive) → app liability (negative).
+          let balance = 0;
+          try {
+            balance = cardBalanceToAppBalance(await fetchCardBalance(accessToken, card.account_id));
+          } catch {
+            // Balance endpoint failures should not block discovery.
+          }
+
+          return {
+            externalAccountId: card.account_id,
+            name: cardDisplayName(card, connection.institution_name),
+            type: 'credit',
+            balance,
+            currency: card.currency || 'GBP',
+            mask: cardMask(card.partial_card_number),
+            kind: 'card'
+          };
+        })
+      );
+
+      return [...discoveredAccounts, ...discoveredCards];
     });
 
     const response: DiscoverAccountsResponse = {

--- a/api/banking/link-accounts.ts
+++ b/api/banking/link-accounts.ts
@@ -69,7 +69,9 @@ async function handler(req: VercelRequest, res: VercelResponse) {
             account_id: link.accountId,
             external_account_id: link.externalAccountId,
             external_account_name: link.externalAccountName,
-            external_account_mask: link.externalAccountMask ?? null
+            external_account_mask: link.externalAccountMask ?? null,
+            // 'card' → sync reads /data/v1/cards for this external account.
+            external_kind: link.kind === 'card' ? 'card' : 'account'
           },
           { onConflict: 'connection_id,external_account_id' }
         );

--- a/api/banking/sync-accounts.ts
+++ b/api/banking/sync-accounts.ts
@@ -16,7 +16,12 @@ import {
   markConnectionSyncSuccess,
   withTrueLayerAccessToken
 } from '../_lib/banking-sync.js';
-import { fetchAccountBalance, fetchAccounts } from '../_lib/truelayer.js';
+import { fetchAccountBalance, fetchAccounts, fetchCardBalance, fetchCards } from '../_lib/truelayer.js';
+import {
+  cardBalanceToAppBalance,
+  cardDisplayName,
+  cardMask
+} from '../../src/services/banking/cardNormalization.js';
 import { selectAdoptableAccountId, type AdoptionCandidate } from '../../src/services/banking/accountMatching.js';
 
 const inferMask = (account: {
@@ -72,6 +77,8 @@ interface SyncedTrueLayerAccount {
   mask?: string;
   accountNumber?: string | null;
   sortCode?: string | null;
+  /** 'card' → served by /data/v1/cards; 'account' → /data/v1/accounts. */
+  kind: 'account' | 'card';
 }
 
 interface LinkedAccountRow {
@@ -260,7 +267,8 @@ const persistAccountsAndLinks = async (
           account_id: accountId,
           external_account_id: account.externalAccountId,
           external_account_mask: account.mask ?? null,
-          external_account_name: account.name
+          external_account_name: account.name,
+          external_kind: account.kind
         },
         {
           onConflict: 'connection_id,external_account_id'
@@ -317,9 +325,12 @@ async function handler(req: VercelRequest, res: VercelResponse) {
 
     const accounts = await withTrueLayerAccessToken(supabase, connection, async (accessToken) => {
       const truelayerAccounts = await fetchAccounts(accessToken);
+      // Cards live on a separate API surface; [] when the token predates the
+      // cards scope, so old bank connections sync exactly as before.
+      const truelayerCards = await fetchCards(accessToken);
 
-      return Promise.all(
-        truelayerAccounts.map(async (account) => {
+      const syncedAccounts = await Promise.all(
+        truelayerAccounts.map(async (account): Promise<SyncedTrueLayerAccount> => {
           let balance = 0;
           try {
             const fetchedBalance = await fetchAccountBalance(accessToken, account.account_id);
@@ -339,10 +350,39 @@ async function handler(req: VercelRequest, res: VercelResponse) {
             currency: account.currency || 'GBP',
             mask: inferMask(account),
             accountNumber: identifiers.accountNumber,
-            sortCode: identifiers.sortCode
+            sortCode: identifiers.sortCode,
+            kind: 'account'
           };
         })
       );
+
+      const syncedCards = await Promise.all(
+        truelayerCards.map(async (card): Promise<SyncedTrueLayerAccount> => {
+          // Card `current` = amount OWED (positive) → app liability (negative).
+          let balance = 0;
+          try {
+            balance = cardBalanceToAppBalance(await fetchCardBalance(accessToken, card.account_id));
+          } catch {
+            // Balance endpoint failures should not block discovery.
+          }
+
+          return {
+            externalAccountId: card.account_id,
+            name: cardDisplayName(card, connection.institution_name),
+            type: 'credit',
+            balance,
+            currency: card.currency || 'GBP',
+            mask: cardMask(card.partial_card_number),
+            // Cards carry no sort code / account number, so reconnect
+            // re-adoption is skipped for them (see findAdoptableAccountId).
+            accountNumber: null,
+            sortCode: null,
+            kind: 'card'
+          };
+        })
+      );
+
+      return [...syncedAccounts, ...syncedCards];
     });
 
     await persistAccountsAndLinks(supabase, auth.userId, connection, accounts);

--- a/api/banking/sync-transactions.ts
+++ b/api/banking/sync-transactions.ts
@@ -20,7 +20,8 @@ import {
   withTrueLayerAccessToken
 } from '../_lib/banking-sync.js';
 import type { TrueLayerTransaction } from '../_lib/truelayer.js';
-import { fetchTransactions } from '../_lib/truelayer.js';
+import { fetchCardTransactions, fetchTransactions } from '../_lib/truelayer.js';
+import { cardAmountToAppSigned } from '../../src/services/banking/cardNormalization.js';
 
 const coerceIsoDateTime = (value: string, endOfDay: boolean): string | null => {
   const trimmed = value.trim();
@@ -147,7 +148,7 @@ async function handler(req: VercelRequest, res: VercelResponse) {
 
     const linkedAccountsResult = await supabase
       .from('linked_accounts')
-      .select('account_id, external_account_id')
+      .select('account_id, external_account_id, external_kind')
       .eq('connection_id', connection.id);
 
     if (linkedAccountsResult.error) {
@@ -205,17 +206,27 @@ async function handler(req: VercelRequest, res: VercelResponse) {
       const allTransactions: Array<{
         accountId: string;
         transaction: TrueLayerTransaction;
+        isCard: boolean;
       }> = [];
 
       for (const linkedAccount of mappedLinkedAccounts) {
-        const transactions = await fetchTransactions(accessToken, linkedAccount.external_account_id, {
-          from: dateRange.from,
-          to: dateRange.to
-        });
+        // Cards are served by /data/v1/cards with an INVERTED sign convention
+        // (positive = money out); the amounts are normalised below.
+        const isCard = (linkedAccount as { external_kind?: string }).external_kind === 'card';
+        const transactions = isCard
+          ? await fetchCardTransactions(accessToken, linkedAccount.external_account_id, {
+              from: dateRange.from,
+              to: dateRange.to
+            })
+          : await fetchTransactions(accessToken, linkedAccount.external_account_id, {
+              from: dateRange.from,
+              to: dateRange.to
+            });
         transactions.forEach((transaction) => {
           allTransactions.push({
             accountId: linkedAccount.account_id,
-            transaction
+            transaction,
+            isCard
           });
         });
       }
@@ -224,14 +235,18 @@ async function handler(req: VercelRequest, res: VercelResponse) {
     });
 
     const prepared = fetchedTransactions
-      .map(({ accountId, transaction }) => {
+      .map(({ accountId, transaction, isCard }) => {
         const externalTransactionId = toExternalTransactionId(transaction);
         if (!externalTransactionId) {
           return null;
         }
 
-        const amount = normalizeAmount(transaction.amount);
-        const type = transaction.amount < 0 ? 'expense' : 'income';
+        // Cards: positive = purchase (money out) → app-negative expense.
+        // Accounts: already app-signed (debits negative).
+        const amount = isCard
+          ? cardAmountToAppSigned(transaction.amount)
+          : normalizeAmount(transaction.amount);
+        const type = amount < 0 ? 'expense' : 'income';
         const description = transaction.description?.trim() || transaction.merchant_name?.trim() || 'Bank transaction';
 
         return {
@@ -246,6 +261,7 @@ async function handler(req: VercelRequest, res: VercelResponse) {
           date: toDateOnly(transaction.timestamp),
           metadata: {
             provider: 'truelayer',
+            sourceKind: isCard ? 'card' : 'account',
             sourceAccountId: transaction.account_id,
             transactionType: transaction.transaction_type ?? null,
             merchantName: transaction.merchant_name ?? null,

--- a/src/components/banking/LinkBankAccountsModal.tsx
+++ b/src/components/banking/LinkBankAccountsModal.tsx
@@ -169,7 +169,8 @@ export default function LinkBankAccountsModal({
           externalAccountMask: discovered?.mask,
           balance: discovered?.balance ?? 0,
           sortCode: discovered?.sortCode,
-          accountNumber: discovered?.accountNumber
+          accountNumber: discovered?.accountNumber,
+          kind: discovered?.kind
         };
       });
 

--- a/src/services/__tests__/scheduledReportService.test.ts
+++ b/src/services/__tests__/scheduledReportService.test.ts
@@ -76,16 +76,21 @@ describe('ScheduledReportService (deterministic)', () => {
   });
 
   it('calculates next weekly run using the injected clock', () => {
-    const now = vi.fn(() => new Date('2024-01-01T09:00:00Z')); // Tuesday
+    const base = new Date('2024-01-01T09:00:00Z'); // a Monday
+    const now = vi.fn(() => new Date(base));
     const { service } = createService({ now });
     const report = { ...baseReport(), dayOfWeek: 3, time: '10:30' }; // Wednesday
 
     const nextRun = service.calculateNextRun(report);
 
-    expect(nextRun.getUTCDay()).toBe(3);
-    expect(nextRun.getUTCHours()).toBe(10);
-    expect(nextRun.getUTCMinutes()).toBe(30);
-    expect(nextRun.getUTCDate()).toBe(3); // Jan 3rd 2024 is Wednesday
+    // The service schedules in LOCAL time (setHours/getDay) — assert local
+    // components so the test holds in every timezone, not only where local
+    // equals UTC on the test date.
+    expect(nextRun.getDay()).toBe(3);
+    expect(nextRun.getHours()).toBe(10);
+    expect(nextRun.getMinutes()).toBe(30);
+    expect(nextRun.getTime()).toBeGreaterThan(base.getTime());
+    expect(nextRun.getTime() - base.getTime()).toBeLessThanOrEqual(8 * 24 * 60 * 60 * 1000);
   });
 
   it('runs only due reports when checking schedule', async () => {

--- a/src/services/banking/cardNormalization.test.ts
+++ b/src/services/banking/cardNormalization.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect } from 'vitest';
+import {
+  cardAmountToAppSigned,
+  cardBalanceToAppBalance,
+  cardDisplayName,
+  cardMask,
+} from './cardNormalization';
+
+describe('cardAmountToAppSigned', () => {
+  it('negates a purchase (card-positive) into an app expense (negative)', () => {
+    // TrueLayer docs: SAINSBURYS purchase, amount 24.25, DEBIT
+    expect(cardAmountToAppSigned(24.25)).toBe(-24.25);
+  });
+
+  it('negates a payment/refund (card-negative) into app income (positive)', () => {
+    expect(cardAmountToAppSigned(-500)).toBe(500);
+  });
+
+  it('rounds to 2dp HALF_UP like the rest of the pipeline', () => {
+    expect(cardAmountToAppSigned(10.005)).toBe(-10.01);
+  });
+
+  it('never emits -0 and zeroes non-finite input', () => {
+    expect(Object.is(cardAmountToAppSigned(0), -0)).toBe(false);
+    expect(cardAmountToAppSigned(Number.NaN)).toBe(0);
+    expect(cardAmountToAppSigned(Number.POSITIVE_INFINITY)).toBe(0);
+  });
+});
+
+describe('cardBalanceToAppBalance', () => {
+  it('turns owed (positive current) into a negative app liability', () => {
+    // TrueLayer docs example: current 20.0 on a 3300 limit
+    expect(cardBalanceToAppBalance(20)).toBe(-20);
+  });
+
+  it('keeps a credit balance on the card (negative current) positive in-app', () => {
+    // Overpaid card: provider reports current -15.50
+    expect(cardBalanceToAppBalance(-15.5)).toBe(15.5);
+  });
+
+  it('returns 0 for missing values — and NEVER falls back to available credit', () => {
+    expect(cardBalanceToAppBalance(null)).toBe(0);
+    expect(cardBalanceToAppBalance(undefined)).toBe(0);
+  });
+
+  it('never emits -0', () => {
+    expect(Object.is(cardBalanceToAppBalance(0), -0)).toBe(false);
+  });
+});
+
+describe('cardDisplayName', () => {
+  it('prefers the provider display name', () => {
+    expect(cardDisplayName(
+      { display_name: 'Club Credit Card', card_network: 'VISA', partial_card_number: '0044' },
+      'Lloyds'
+    )).toBe('Club Credit Card');
+  });
+
+  it('falls back to network + masked number', () => {
+    expect(cardDisplayName(
+      { card_network: 'AMEX', partial_card_number: '1005' },
+      'American Express'
+    )).toBe('AMEX •••• 1005');
+  });
+
+  it('falls back to the institution name when the card is anonymous', () => {
+    expect(cardDisplayName({}, 'American Express')).toBe('American Express');
+  });
+});
+
+describe('cardMask', () => {
+  it('takes the last 4 of the partial number', () => {
+    expect(cardMask('0044')).toBe('0044');
+    expect(cardMask('XXXX XXXX XXXX 1005')).toBe('1005');
+  });
+
+  it('handles short or missing values', () => {
+    expect(cardMask('44')).toBe('44');
+    expect(cardMask(undefined)).toBeUndefined();
+    expect(cardMask('')).toBeUndefined();
+  });
+});

--- a/src/services/banking/cardNormalization.ts
+++ b/src/services/banking/cardNormalization.ts
@@ -1,0 +1,67 @@
+import Decimal from 'decimal.js';
+
+type DecimalInstance = InstanceType<typeof Decimal>;
+
+/**
+ * TrueLayer CARD data → app conventions. Cards are served by a separate API
+ * surface (/data/v1/cards) whose conventions are the OPPOSITE of the accounts
+ * endpoints in two treacherous ways:
+ *
+ *  1. Card transactions: a POSITIVE amount is money flowing OUT of the card
+ *     ("A positive transaction amount reflects the flow of funds out of a
+ *     card, such as a purchase" — TrueLayer docs). Bank accounts use negative
+ *     for debits. The app stores signed amounts (expenses negative), so card
+ *     amounts are NEGATED.
+ *
+ *  2. Card balance: `current` is the amount OWED (expenditure, positive), and
+ *     `available` is the REMAINING CREDIT — not a balance at all. The app
+ *     stores liabilities as negative balances, so the card balance is
+ *     -current, and `available` must never be used as a fallback (a £20 debt
+ *     on a £3,300 limit would otherwise read as £3,280 in credit).
+ *
+ * All arithmetic in Decimal; results rounded to 2dp HALF_UP to match the
+ * pipeline's normalizeAmount contract.
+ */
+
+const round2 = (value: DecimalInstance): number =>
+  value.toDecimalPlaces(2, Decimal.ROUND_HALF_UP).toNumber();
+
+/** Card transaction amount → app-signed amount (purchases negative). */
+export const cardAmountToAppSigned = (cardAmount: number): number => {
+  if (!Number.isFinite(cardAmount)) {
+    return 0;
+  }
+  return round2(new Decimal(cardAmount).negated().plus(0)); // plus(0) normalises -0
+};
+
+/** Card `current` (owed, positive) → app balance (liability, negative). */
+export const cardBalanceToAppBalance = (current: number | null | undefined): number => {
+  if (typeof current !== 'number' || !Number.isFinite(current)) {
+    return 0;
+  }
+  return round2(new Decimal(current).negated().plus(0));
+};
+
+/** Display name for a discovered card, e.g. "Club Credit Card" or "VISA •••• 0044". */
+export const cardDisplayName = (card: {
+  display_name?: string;
+  card_network?: string;
+  partial_card_number?: string;
+}, fallback: string): string => {
+  const displayName = card.display_name?.trim();
+  if (displayName) {
+    return displayName;
+  }
+  const network = card.card_network?.trim();
+  const partial = card.partial_card_number?.trim();
+  if (network && partial) {
+    return `${network} •••• ${partial.slice(-4)}`;
+  }
+  return network || fallback;
+};
+
+/** The last-4 mask for a card, from its partial card number. */
+export const cardMask = (partialCardNumber: string | undefined): string | undefined => {
+  const cleaned = (partialCardNumber ?? '').replace(/\s+/g, '');
+  return cleaned.length >= 4 ? cleaned.slice(-4) : cleaned || undefined;
+};

--- a/src/services/exportService.test.ts
+++ b/src/services/exportService.test.ts
@@ -59,7 +59,14 @@ describe('ExportService', () => {
     });
 
     expect(report.id).toMatch(/^id-/);
-    expect(report.nextRun.toISOString()).toBe('2025-01-08T09:00:00.000Z');
+    // The service schedules at LOCAL 9am (setHours) — assert in local terms,
+    // computed independently from the same fixed clock, so the test passes in
+    // every timezone instead of only where local == UTC on the test date.
+    const expectedWeekly = new Date(FIXED_NOW);
+    expectedWeekly.setDate(expectedWeekly.getDate() + 7);
+    expectedWeekly.setHours(9, 0, 0, 0);
+    expect(report.nextRun.getTime()).toBe(expectedWeekly.getTime());
+    expect(report.nextRun.getHours()).toBe(9);
     expect(storage.setItem).toHaveBeenCalledWith(
       'scheduled-reports',
       expect.stringContaining('"name":"Weekly Summary"')
@@ -88,7 +95,11 @@ describe('ExportService', () => {
 
     const updated = service.updateScheduledReport(report.id, { frequency: 'daily' });
     expect(updated?.frequency).toBe('daily');
-    expect(updated?.nextRun.toISOString()).toBe('2025-01-02T09:00:00.000Z');
+    // Local-time semantics (see above): next local day at local 9am.
+    const expectedDaily = new Date(FIXED_NOW);
+    expectedDaily.setDate(expectedDaily.getDate() + 1);
+    expectedDaily.setHours(9, 0, 0, 0);
+    expect(updated?.nextRun.getTime()).toBe(expectedDaily.getTime());
   });
 
   it('manages export templates via storage-backed persistence', () => {

--- a/src/types/banking-api.ts
+++ b/src/types/banking-api.ts
@@ -39,6 +39,12 @@ export interface DiscoveredBankAccount {
   sortCode?: string;
   accountNumber?: string;
   mask?: string;
+  /**
+   * Which TrueLayer surface serves this external account: 'account' →
+   * /data/v1/accounts (banks), 'card' → /data/v1/cards (credit cards, e.g.
+   * American Express). Absent means 'account' (pre-cards clients).
+   */
+  kind?: 'account' | 'card';
 }
 
 export interface DiscoverAccountsResponse {
@@ -60,6 +66,8 @@ export interface LinkAccountsRequest {
     // disconnect→reconnect can re-adopt it instead of creating a duplicate.
     sortCode?: string;
     accountNumber?: string;
+    /** 'card' when the external account is served by the Cards API. */
+    kind?: 'account' | 'card';
   }>;
 }
 

--- a/supabase/migrations/20260718100000_linked_accounts_card_kind.sql
+++ b/supabase/migrations/20260718100000_linked_accounts_card_kind.sql
@@ -1,0 +1,25 @@
+-- Credit-card feeds (TrueLayer Cards API) — linked_accounts learns which
+-- API surface an external account lives on.
+--
+-- IMPORTANT: Run this SQL in the Supabase SQL Editor to apply to production DB.
+-- Safe to apply before the matching client deploys: the column defaults to
+-- 'account', which is exactly today's behaviour for every existing link.
+--
+-- TrueLayer serves credit cards (American Express etc.) from /data/v1/cards,
+-- a separate surface from /data/v1/accounts, with different balance and sign
+-- conventions. The sync endpoints must know which surface each linked
+-- external account belongs to: 'account' → /accounts endpoints (unchanged),
+-- 'card' → /cards endpoints (new).
+
+BEGIN;
+
+ALTER TABLE public.linked_accounts
+  ADD COLUMN IF NOT EXISTS external_kind text NOT NULL DEFAULT 'account';
+
+ALTER TABLE public.linked_accounts
+  DROP CONSTRAINT IF EXISTS linked_accounts_external_kind_check;
+ALTER TABLE public.linked_accounts
+  ADD CONSTRAINT linked_accounts_external_kind_check
+  CHECK (external_kind IN ('account', 'card'));
+
+COMMIT;


### PR DESCRIPTION
The investigation's conclusion, built: **American Express (and card issuers generally) were missing from the connect list because of our integration, not your TrueLayer tier.** TrueLayer serves credit cards from a separate API surface (`/data/v1/cards`) behind a **`cards` scope** our auth link never requested — and the sync pipeline only read the `/accounts` endpoints.

## ⚠️ Requires a small migration (Steve runs it)

`supabase/migrations/20260718100000_linked_accounts_card_kind.sql` — adds `linked_accounts.external_kind` (`'account' | 'card'`, defaults to `'account'` = today's behaviour for every existing link). Safe to run before the deploy.

## The two treacherous card conventions (isolated in pure, tested helpers)

- **Card transactions: positive = money OUT.** The exact opposite of the bank-account endpoints (TrueLayer docs: *"A positive transaction amount reflects the flow of funds out of a card, such as a purchase"*). Normalised to the app's signed convention via Decimal.
- **Card balance: `current` = amount owed** (positive) → stored as a negative app liability. `available` is *remaining credit* and is deliberately never used as a fallback — a £20 debt on a £3,300 limit would otherwise read as £3,280 of money.

## Pipeline

- Auth link now requests the `cards` scope → card issuers (Amex) appear in the TrueLayer connect dialog. (Confirmed against the live Console: this layout has no per-scope toggle — requesting the scope is the whole trick.)
- `fetchCards` treats 403 as "no cards", so **connections authorised before the scope existed keep syncing exactly as before** — re-link to gain card access.
- Discovery, account sync, and transaction sync all handle `kind='card'` end to end: type `credit`, network + last-4 naming, `/cards` transaction fetch with the sign flip, same dedupe + atomic import RPC + audit as bank rows. Cards have no sort code, so reconnect re-adoption is safely skipped for them.

## Also in this PR

Three **pre-existing timezone-coupled test failures** (exportService ×2, scheduledReportService ×1) surfaced today — the services deliberately schedule at *local* time, but the tests asserted UTC instants, passing only where the machine's offset is zero for the fixture dates. Tests now assert local semantics; verified under `TZ=America/Honolulu` and `TZ=Asia/Tokyo` as well as locally.

**Tests:** 13 new card-normalisation cases (sign flip, owed→liability, no-available-fallback, -0 hygiene, naming/masks); 3,110 passing; strict types; zero lint.

## After merge + migration (Steve)

1. Run the migration.
2. In the app: **connect American Express as a new connection** — it should now appear in TrueLayer's dialog. Link the discovered card to your existing "American Express - BA Credit Card" account (the link modal lets you pick it), and transactions/balances flow in on sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)