### PR TITLE
fix(banking): honest Connect-a-Bank list + Modal focus-steal fix

### DIFF
--- a/src/components/BankConnections.tsx
+++ b/src/components/BankConnections.tsx
@@ -134,9 +134,9 @@ export default function BankConnections({
 
       if (result.url) {
         startOAuthFlow(result.url);
-      } else if (result.linkToken) {
-        // Handle Plaid Link flow
-        alert('Plaid Link integration would open here with token: ' + result.linkToken);
+      } else {
+        // Plaid was removed from the app; nothing should reach here.
+        logger.error('Bank connection returned no auth URL', new Error(`provider=${institution.provider}`));
       }
     } catch (error) {
       logger.error('Failed to connect bank', error as Error);
@@ -395,8 +395,10 @@ export default function BankConnections({
           {/* Provider Info */}
           <div className="bg-blue-50 dark:bg-blue-900/20 rounded-lg p-3 text-sm">
             <p className="text-blue-800 dark:text-blue-200">
-              <strong>Secure Connection:</strong> Your credentials are never stored. 
-              Connection is established directly with your bank using OAuth.
+              <strong>Secure Connection:</strong> Your credentials are never stored.
+              Connection is established directly with your bank using OAuth. You&rsquo;ll
+              confirm your exact bank or card provider on TrueLayer&rsquo;s secure page —
+              this list is just a shortcut.
             </p>
           </div>
 
@@ -432,6 +434,24 @@ export default function BankConnections({
               </p>
             </div>
           )}
+
+          {/* Catch-all: the in-app list is a shortcut, never a gate — the
+              full provider choice lives on TrueLayer's page. */}
+          <button
+            onClick={() => handleConnect({
+              id: 'uk-ob-all',
+              name: 'your bank',
+              country: 'GB',
+              provider: 'truelayer',
+              supportsAccountDetails: true,
+              supportsTransactions: true,
+              supportsBalance: true
+            })}
+            disabled={isLoading}
+            className="w-full p-3 border border-dashed border-gray-300 dark:border-gray-600 rounded-lg text-sm text-gray-600 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-700 transition-colors"
+          >
+            Don&rsquo;t see your bank or card? <span className="font-medium text-primary dark:text-blue-400">Browse all providers</span>
+          </button>
         </div>
       </Modal>
     </div>

--- a/src/components/common/Modal.test.tsx
+++ b/src/components/common/Modal.test.tsx
@@ -575,4 +575,62 @@ describe('real-world scenarios', () => {
     expect(screen.getByText('Application Version 1.0')).toBeInTheDocument();
     expect(screen.queryByLabelText('Close modal')).not.toBeInTheDocument();
   });
+
+  describe('focus stability across parent re-renders', () => {
+    it('does not steal focus from an input when onClose identity changes', async () => {
+      // Callers routinely pass inline `onClose={() => …}` — a NEW function
+      // identity per render. The old effect depended on onClose, so every
+      // parent re-render (e.g. typing into a search box) re-ran the delayed
+      // modalRef.focus() and stole the cursor after each keystroke.
+      // (Real 50ms open-focus timer; the suite mocks system time, so fake
+      // timers are unavailable here.)
+      const settle = () => new Promise((resolve) => { setTimeout(resolve, 120); });
+
+      const view = render(
+        <Modal isOpen={true} onClose={() => {}} title="Search">
+          <ModalBody>
+            <input type="text" placeholder="Search for your bank..." />
+          </ModalBody>
+        </Modal>
+      );
+      // Let the initial open-focus timer fire first
+      await settle();
+
+      const input = screen.getByPlaceholderText('Search for your bank...');
+      input.focus();
+      expect(input).toHaveFocus();
+
+      // Simulate the caller re-rendering with a fresh onClose identity
+      // (what happens on every keystroke of a caller-owned search field)
+      view.rerender(
+        <Modal isOpen={true} onClose={() => {}} title="Search">
+          <ModalBody>
+            <input type="text" placeholder="Search for your bank..." />
+          </ModalBody>
+        </Modal>
+      );
+      await settle();
+
+      expect(input).toHaveFocus();
+    });
+
+    it('still calls the LATEST onClose on Escape after re-renders', () => {
+      const first = vi.fn();
+      const second = vi.fn();
+      const view = render(
+        <Modal isOpen={true} onClose={first} title="Test">
+          <ModalBody>content</ModalBody>
+        </Modal>
+      );
+      view.rerender(
+        <Modal isOpen={true} onClose={second} title="Test">
+          <ModalBody>content</ModalBody>
+        </Modal>
+      );
+
+      fireEvent.keyDown(document, { key: 'Escape' });
+      expect(second).toHaveBeenCalledTimes(1);
+      expect(first).not.toHaveBeenCalled();
+    });
+  });
 });

--- a/src/components/common/Modal.tsx
+++ b/src/components/common/Modal.tsx
@@ -31,6 +31,18 @@ export function Modal({
   const modalRef = useRef<HTMLDivElement>(null);
   const previousActiveElement = useRef<HTMLElement | null>(null);
 
+  // Latest-callback ref: callers routinely pass inline `onClose={() => …}`
+  // handlers whose identity changes every render. With onClose in the effect
+  // deps, ANY parent re-render (e.g. typing into a search box whose state
+  // lives in the caller) re-ran the whole setup — including the delayed
+  // modalRef.focus() that stole the cursor from the active input after every
+  // keystroke, plus a scroll-lock/listener churn. The effect now runs only on
+  // open/close and reads the current handler through the ref.
+  const onCloseRef = useRef(onClose);
+  useEffect(() => {
+    onCloseRef.current = onClose;
+  });
+
   useEffect(() => {
     if (isOpen) {
       // Store the currently focused element
@@ -63,10 +75,10 @@ export function Modal({
         }
       };
 
-      // Handle escape key
+      // Handle escape key (via the ref — see onCloseRef above)
       const handleEscapeKey = (e: KeyboardEvent) => {
         if (e.key === 'Escape') {
-          onClose();
+          onCloseRef.current();
         }
       };
 
@@ -106,7 +118,7 @@ export function Modal({
         previousActiveElement.current?.focus();
       };
     }
-  }, [isOpen, onClose]);
+  }, [isOpen]);
   
   if (!isOpen) return null;
 

--- a/src/services/bankConnectionService.ts
+++ b/src/services/bankConnectionService.ts
@@ -534,62 +534,44 @@ export class BankConnectionService {
     return this.configStatus;
   }
 
+  /**
+   * Quick-pick list for the Connect a Bank modal. Every entry launches the
+   * SAME generic TrueLayer flow — the definitive institution choice happens
+   * on TrueLayer's own secure page, which lists every provider our client
+   * can access (all UK Open Banking banks, plus card issuers like American
+   * Express now the auth link requests the cards scope). This list is
+   * recognition/reassurance only, so missing an entry never blocks anyone:
+   * the modal's "Browse all banks" action runs the identical flow.
+   *
+   * (The old list also carried Chase/Bank of America "via Plaid" — dead
+   * entries for a provider that was removed from the app.)
+   */
   async getInstitutions(_country: string = 'GB'): Promise<BankInstitution[]> {
+    const uk = (id: string, name: string): BankInstitution => ({
+      id,
+      name,
+      country: 'GB',
+      provider: 'truelayer',
+      supportsAccountDetails: true,
+      supportsTransactions: true,
+      supportsBalance: true
+    });
+
     return [
-      {
-        id: 'barclays',
-        name: 'Barclays',
-        country: 'GB',
-        provider: 'truelayer',
-        supportsAccountDetails: true,
-        supportsTransactions: true,
-        supportsBalance: true
-      },
-      {
-        id: 'hsbc',
-        name: 'HSBC',
-        country: 'GB',
-        provider: 'truelayer',
-        supportsAccountDetails: true,
-        supportsTransactions: true,
-        supportsBalance: true
-      },
-      {
-        id: 'lloyds',
-        name: 'Lloyds Bank',
-        country: 'GB',
-        provider: 'truelayer',
-        supportsAccountDetails: true,
-        supportsTransactions: true,
-        supportsBalance: true
-      },
-      {
-        id: 'natwest',
-        name: 'NatWest',
-        country: 'GB',
-        provider: 'truelayer',
-        supportsAccountDetails: true,
-        supportsTransactions: true,
-        supportsBalance: true
-      },
-      {
-        id: 'chase',
-        name: 'Chase',
-        country: 'US',
-        provider: 'plaid',
-        supportsAccountDetails: true,
-        supportsTransactions: true,
-        supportsBalance: true
-      },
-      {
-        id: 'bank-of-america',
-        name: 'Bank of America',
-        country: 'US',
-        provider: 'plaid',
-        supportsAccountDetails: true,
-        supportsTransactions: true,
-        supportsBalance: true
-      }
+      uk('amex', 'American Express'),
+      uk('barclays', 'Barclays'),
+      uk('barclaycard', 'Barclaycard'),
+      uk('first-direct', 'First Direct'),
+      uk('halifax', 'Halifax'),
+      uk('hsbc', 'HSBC'),
+      uk('lloyds', 'Lloyds Bank'),
+      uk('monzo', 'Monzo'),
+      uk('nationwide', 'Nationwide'),
+      uk('natwest', 'NatWest'),
+      uk('revolut', 'Revolut'),
+      uk('santander', 'Santander'),
+      uk('starling', 'Starling Bank'),
+      uk('tsb', 'TSB')
     ];
   }
 


### PR DESCRIPTION
Both issues from Steve's post-deploy report, and both were ours — the final layer of the "where's Amex?" onion:

## 1. The institution list was hardcoded (and lying)

The Connect-a-Bank modal showed a **six-entry hardcoded array** — including "Chase via Plaid" and "Bank of America via Plaid", fossils for a provider removed from the app whose click handler was a placeholder `alert()`. Worse, the picker is *decorative*: every TrueLayer entry launches the identical generic auth link, and the definitive bank choice happens on **TrueLayer's own secure page**. So the list's absence of Amex was pure cosmetics blocking a working flow.

Now: an honest UK quick-pick set (**American Express**, Barclaycard, First Direct, Halifax, Monzo, Nationwide, Revolut, Santander, Starling, TSB + the original four), copy explaining that TrueLayer's page has the final say, and a **"Browse all providers"** catch-all button so a missing list entry can never block a connection again. The dead Plaid branch logs an error instead of alerting.

## 2. The search box lost its cursor after every character

Root cause in the shared `Modal`: its setup effect depended on `[isOpen, onClose]`, and callers pass inline `onClose={() => …}` — a fresh function identity per render. When the caller's own state drives re-renders (this search field), **every keystroke re-ran the effect**, including a 50ms-delayed `modal.focus()` that stole the cursor — plus scroll-lock and listener churn each time. Fixed in `Modal` with a latest-callback ref and `[isOpen]`-only deps, which cures every similarly-afflicted modal in the app at once. Escape still invokes the *latest* handler (tested).

## Verified

Live in demo: typed "ame" continuously — focus held through every keystroke, list filtered to American Express, catch-all visible. New Modal tests: focus stability across `onClose` identity changes (fails against the old code) and Escape-uses-latest-handler. 3,112 passing; strict types; zero lint.

No migration needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)