### PR TITLE
fix(banking): name card-only connections + linking step in Settings connect flow

### DIFF
--- a/api/banking/exchange-token.ts
+++ b/api/banking/exchange-token.ts
@@ -10,7 +10,8 @@ import { applyRateLimit } from '../_lib/rate-limit.js';
 import { encryptSecret } from '../_lib/encryption.js';
 import { getServiceRoleSupabase } from '../_lib/supabase.js';
 import { decodeStateToken } from '../_lib/state.js';
-import { exchangeCodeForToken, fetchAccounts } from '../_lib/truelayer.js';
+import { exchangeCodeForToken, fetchAccounts, fetchCards } from '../_lib/truelayer.js';
+import type { TrueLayerAccount, TrueLayerCard } from '../_lib/truelayer.js';
 import { withSentry } from '../_lib/sentry.js';
 
 interface ProviderMetadata {
@@ -19,16 +20,16 @@ interface ProviderMetadata {
   logo?: string;
 }
 
-const getProviderFromAccounts = (
-  accounts: Array<{
+const getProviderMetadata = (
+  sources: Array<{
     provider?: {
       provider_id: string;
       display_name: string;
       logo_uri?: string;
     };
   }>
-): ProviderMetadata => {
-  const provider = accounts[0]?.provider;
+): ProviderMetadata | null => {
+  const provider = sources.find((source) => source.provider)?.provider;
   if (provider) {
     return {
       id: provider.provider_id,
@@ -36,10 +37,7 @@ const getProviderFromAccounts = (
       logo: provider.logo_uri
     };
   }
-  return {
-    id: `truelayer-${Date.now()}`,
-    name: 'Unknown institution'
-  };
+  return null;
 };
 
 async function handler(req: VercelRequest, res: VercelResponse) {
@@ -85,15 +83,24 @@ async function handler(req: VercelRequest, res: VercelResponse) {
       name: 'Unknown institution'
     };
 
+    // Cards (e.g. Amex) live on a separate TrueLayer surface, and cards-only
+    // providers reject the bank-accounts endpoint entirely — so fetch each
+    // surface independently and let either one identify the institution.
+    let accounts: TrueLayerAccount[] = [];
+    let cards: TrueLayerCard[] = [];
     try {
-      const accounts = await fetchAccounts(accessToken);
-      accountsCount = accounts.length;
-      if (accounts.length > 0) {
-        providerMetadata = getProviderFromAccounts(accounts);
-      }
+      accounts = await fetchAccounts(accessToken);
     } catch (accountError) {
       console.warn('Failed to fetch account details from TrueLayer', accountError);
     }
+    try {
+      cards = await fetchCards(accessToken);
+    } catch (cardError) {
+      console.warn('Failed to fetch card details from TrueLayer', cardError);
+    }
+
+    accountsCount = accounts.length + cards.length;
+    providerMetadata = getProviderMetadata([...accounts, ...cards]) ?? providerMetadata;
 
     const nowIso = new Date().toISOString();
     const connectionPayload = {

--- a/src/components/BankConnections.tsx
+++ b/src/components/BankConnections.tsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect, useMemo } from 'react';
 import { useAuth as useClerkAuth } from '@clerk/clerk-react';
 import { bankConnectionService, type BankConnection, type BankInstitution } from '../services/bankConnectionService';
 import { Modal } from './common/Modal';
+import LinkBankAccountsModal from './banking/LinkBankAccountsModal';
 import BankingOpsAlertStatsCard from './BankingOpsAlertStatsCard';
 import type { BankingAuditDateRangePreset, BankingAuditScope } from '../utils/bankingOpsUrlState';
 import {
@@ -46,6 +47,7 @@ export default function BankConnections({
   const [isLoading, setIsLoading] = useState(false);
   const [syncingConnections, setSyncingConnections] = useState<Set<string>>(new Set());
   const [configStatus, setConfigStatus] = useState({ plaid: false, trueLayer: false });
+  const [linkingConnectionId, setLinkingConnectionId] = useState<string | null>(null);
   const logger = useMemo(() => createScopedLogger('BankConnections'), []);
   const { getToken } = useClerkAuth();
 
@@ -81,7 +83,12 @@ export default function BankConnections({
       if (event.origin !== window.location.origin) {
         return;
       }
-      const payload = event.data as { type?: string; status?: 'success' | 'error'; error?: string } | null;
+      const payload = event.data as {
+        type?: string;
+        status?: 'success' | 'error';
+        error?: string;
+        connectionId?: string;
+      } | null;
       if (!payload || payload.type !== 'wealthtracker:bank-oauth-complete') {
         return;
       }
@@ -91,7 +98,11 @@ export default function BankConnections({
       void loadConnections();
       if (payload.status === 'success') {
         setShowAddBank(false);
-        onAccountsLinked?.();
+        if (payload.connectionId) {
+          setLinkingConnectionId(payload.connectionId);
+        } else {
+          onAccountsLinked?.();
+        }
       } else if (payload.error) {
         logger.error('OAuth callback returned error', new Error(payload.error));
       }
@@ -189,6 +200,22 @@ export default function BankConnections({
     
     for (const connection of activeConnections) {
       await handleSync(connection.id);
+    }
+  };
+
+  const handleLinkComplete = async (connectionId: string) => {
+    setLinkingConnectionId(null);
+    setSyncingConnections(prev => new Set(prev).add(connectionId));
+    try {
+      await bankConnectionService.syncTransactionsOnly(connectionId);
+      void loadConnections();
+      onAccountsLinked?.();
+    } finally {
+      setSyncingConnections(prev => {
+        const next = new Set(prev);
+        next.delete(connectionId);
+        return next;
+      });
     }
   };
 
@@ -317,6 +344,14 @@ export default function BankConnections({
                   </div>
                 </div>
                 <div className="flex items-center gap-2">
+                  <button
+                    onClick={() => setLinkingConnectionId(connection.id)}
+                    disabled={connection.status === 'reauth_required'}
+                    className="p-2 text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-white disabled:opacity-50"
+                    title="Link accounts"
+                  >
+                    <LinkIcon size={20} />
+                  </button>
                   <button
                     onClick={() => handleSync(connection.id)}
                     disabled={syncingConnections.has(connection.id) || connection.status === 'reauth_required'}
@@ -454,6 +489,16 @@ export default function BankConnections({
           </button>
         </div>
       </Modal>
+
+      {/* Link discovered bank accounts/cards to app accounts */}
+      {linkingConnectionId && (
+        <LinkBankAccountsModal
+          isOpen={true}
+          onClose={() => setLinkingConnectionId(null)}
+          connectionId={linkingConnectionId}
+          onLinkComplete={handleLinkComplete}
+        />
+      )}
     </div>
   );
 }

--- a/src/components/banking/LinkBankAccountsModal.tsx
+++ b/src/components/banking/LinkBankAccountsModal.tsx
@@ -26,6 +26,29 @@ const normalizeSortCode = (value: string | undefined): string =>
 const normalizeAccountNumber = (value: string | undefined): string =>
   (value ?? '').replace(/\s/g, '').toLowerCase();
 
+const isCard = (discovered: DiscoveredBankAccount): boolean =>
+  discovered.kind === 'card' || discovered.type === 'credit';
+
+// Cards expose no sort code or account number — only a last-4 mask. Restrict
+// mask matching to credit accounts, and only auto-select on a unique hit, so
+// a shared last-4 across accounts can't mislink.
+const findCardMaskMatch = (
+  discovered: DiscoveredBankAccount,
+  existingAccounts: Account[]
+): Account | null => {
+  if (!isCard(discovered) || !discovered.mask) {
+    return null;
+  }
+  const matches = existingAccounts.filter((account) => {
+    if (account.type !== 'credit') {
+      return false;
+    }
+    const aAccountNumber = normalizeAccountNumber(account.accountNumber);
+    return aAccountNumber.length >= 4 && aAccountNumber.slice(-4) === discovered.mask;
+  });
+  return matches.length === 1 ? matches[0] : null;
+};
+
 const findSmartMatch = (
   discovered: DiscoveredBankAccount,
   existingAccounts: Account[]
@@ -34,7 +57,7 @@ const findSmartMatch = (
   const dAccountNumber = normalizeAccountNumber(discovered.accountNumber);
 
   if (!dSortCode && !dAccountNumber) {
-    return null;
+    return findCardMaskMatch(discovered, existingAccounts)?.id ?? null;
   }
 
   for (const account of existingAccounts) {
@@ -70,7 +93,10 @@ const getMatchReason = (
   const dSortCode = normalizeSortCode(discovered.sortCode);
   const dAccountNumber = normalizeAccountNumber(discovered.accountNumber);
 
-  if (!dSortCode && !dAccountNumber) return null;
+  if (!dSortCode && !dAccountNumber) {
+    const cardMatch = findCardMaskMatch(discovered, existingAccounts);
+    return cardMatch ? `Card ending ${discovered.mask} matches` : null;
+  }
 
   for (const account of existingAccounts) {
     const aSortCode = normalizeSortCode(account.sortCode);


### PR DESCRIPTION
## Why

Connecting American Express (two cards) from Settings → Data Management → Bank Connections produced a connection called **"Unknown institution" with 0 accounts linked**, and the flow never offered the link-to-existing-accounts step.

#104 added the TrueLayer Cards API plumbing (discover/sync/link all handle cards), but three gaps remained upstream of it in the connect flow.

## What

**1. `exchange-token` is now card-aware.** It only ever called `/data/v1/accounts`; cards-only providers (Amex) reject that endpoint, so the connection was stored as `Unknown institution` with a random `institution_id` — which also breaks the reconnect dedupe (`user_id, institution_id, provider`). Accounts and cards are now fetched independently and either surface supplies the institution name/logo/id; `accountsCount` includes cards.

**2. Settings connect flow gets the linking step.** `BankConnections.tsx` ignored the `connectionId` in the OAuth-complete message, so the `LinkBankAccountsModal` (which the Open Banking page already opens) never appeared. It now opens after a successful connect, and each connection row gains a **Link accounts** button so linking is reachable any time. Linking finishes with a transactions-only sync.

**3. Card smart-matching in the link modal.** Cards expose no sort code/account number, so discovered cards now auto-suggest a match by last-4 mask against existing `credit` accounts — unique match only, so a shared last-4 can never mislink.

## Verification

- `npm run typecheck:strict` ✅
- standalone strict tsc over `api/banking/exchange-token.ts` (api/ isn't in the project tsconfig) ✅
- `npx eslint` on all three files — zero errors ✅
- `bankConnectionService.test.ts` 27/27 ✅
- `npm run build:check` ✅ (pre-existing chunk-size warnings only)

## Notes

- After deploy: disconnect the existing "Unknown institution" row and reconnect Amex; it will store correctly named and the linking modal will offer both cards.
- Existing bank connections are untouched (`fetchCards` already returns `[]` on 403 for pre-cards tokens).

🤖 Generated with [Claude Code](https://claude.com/claude-code)