### PR TITLE
fix(banking): tolerate 501 endpoint_not_supported from cards-only providers (Amex linking)

### DIFF
--- a/api/_lib/truelayer.ts
+++ b/api/_lib/truelayer.ts
@@ -200,7 +200,9 @@ interface CardBalancesResponse {
  * The user's cards on this connection. A connection authorised BEFORE the
  * `cards` scope was added will be rejected with 403 — treated as "no cards"
  * so pre-existing bank connections keep syncing untouched; the user re-links
- * to pick up card access.
+ * to pick up card access. 501 endpoint_not_supported (a provider with no
+ * cards surface) is likewise "no cards" — deterministic per provider, so
+ * tolerating it cannot mask a transient failure.
  */
 export const fetchCards = async (accessToken: string): Promise<TrueLayerCard[]> => {
   const response = await fetch(`${getApiBaseUrl()}/data/v1/cards`, {
@@ -209,7 +211,7 @@ export const fetchCards = async (accessToken: string): Promise<TrueLayerCard[]> 
     }
   });
 
-  if (response.status === 403) {
+  if (response.status === 403 || response.status === 501) {
     return [];
   }
   if (!response.ok) {
@@ -290,6 +292,15 @@ export const fetchAccounts = async (accessToken: string): Promise<TrueLayerAccou
     }
   });
 
+  // Cards-only providers (e.g. American Express) reject the bank-accounts
+  // surface with 501 endpoint_not_supported — a deterministic per-provider
+  // response, so "no bank accounts" is the truth, not an error. ONLY 501 is
+  // tolerated: any other failure must still throw, because sync-accounts
+  // prunes stale links against this result and a transient failure mapped to
+  // [] would delete the user's account links.
+  if (response.status === 501) {
+    return [];
+  }
   if (!response.ok) {
     const details = await response.text();
     throw new Error(`TrueLayer accounts fetch failed: ${response.status} ${details}`);


### PR DESCRIPTION
## Why

After #107 deployed, reconnecting American Express now stores the connection correctly named — but the **Link Your Bank Accounts** step fails with:

> TrueLayer accounts fetch failed: 501 {"error_description":"Feature not supported by the provider","error":"endpoint_not_supported"}

Amex is a cards-only provider and rejects the `/data/v1/accounts` surface outright. `fetchAccounts` treated any non-OK response as fatal, so discovery threw before ever reaching the cards fetch. #104 covered the missing-`cards`-scope case (403 → `[]`) but not the cards-only-provider case (501).

## What

One file, +13/−2: both `fetchAccounts` and `fetchCards` now map **501 only** to an empty list — "this provider has no such surface". This unblocks `discover-accounts`, `sync-accounts`, and `exchange-token` for cards-only providers in one place.

The tolerance is deliberately narrow: 501 is a deterministic per-provider response. Every other failure still throws, because `sync-accounts` prunes stale `linked_accounts` against the fetched set — a transient 5xx mapped to `[]` would silently delete a user's account links.

## Verification

- `npm run typecheck:strict` ✅ · standalone strict tsc over `api/_lib/truelayer.ts` ✅
- `npx eslint api/_lib/truelayer.ts` — zero errors ✅
- `cardNormalization` + `bankConnectionService` suites: 40/40 ✅
- `npm run build:check` ✅

## After deploy

Steve: open the AMEX connection → **Link accounts** — discovery should now list both Amex cards (type `credit`, balances negative-owed) ready to link.

🤖 Generated with [Claude Code](https://claude.com/claude-code)