### PR TITLE
feat(import): native MS Money migration — transform, split-leg transfers, cloud importer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,10 @@ src-backup-*
 backups/
 test-results/
 playwright-report/
+
+# MS Money local import (never commit real financial data)
+.mny-local/
+public/mny-local-seed.json
+*.mny
+**/mny-local-*.json
+mny-local-seed.json

--- a/scripts/mnyCloudImport.mts
+++ b/scripts/mnyCloudImport.mts
@@ -1,0 +1,344 @@
+/**
+ * MS Money → WealthTracker CLOUD migration (one-shot, destructive).
+ *
+ * Takes the transformed seed produced by scripts/mnyLocalImport.mts and
+ * migrates it into the production Supabase under the user's account:
+ *
+ *   1. PREFLIGHT — the split-leg columns must exist (apply
+ *      supabase/migrations/20260720120000_split_leg_transfers.sql first);
+ *      exactly one target user must be identifiable.
+ *   2. BACKUP   — every current row (accounts, categories, transactions,
+ *      splits, budgets, goals, linked_accounts) is written to
+ *      ~/WealthTracker-backups/ BEFORE anything is touched.
+ *   3. WIPE     — deletes ALL of the user's financial data (FK order).
+ *   4. IMPORT   — inserts the full Money dataset with fresh UUIDs, remapping
+ *      every cross-reference (accounts, categories incl. To/From, transfer
+ *      pairs, split-line transfer legs).
+ *   5. VERIFY   — recounts, per-account ledger invariant
+ *      (initial_balance + Σ transactions = balance), split reconciliation,
+ *      transfer-pair and split-leg reciprocity. Decimal maths throughout.
+ *
+ * DRY RUN by default — prints the plan and stops before the wipe.
+ * The destructive run requires BOTH flags: --execute --confirm-wipe
+ *
+ * Usage:
+ *   npx tsx scripts/mnyCloudImport.mts <seed.json>                  # dry run
+ *   npx tsx scripts/mnyCloudImport.mts <seed.json> --execute --confirm-wipe
+ *
+ * Notes:
+ *   - Uses SUPABASE_SERVICE_ROLE_KEY from .env.local (never printed).
+ *   - Bank connections (TrueLayer auth) are kept; the account-level links
+ *     (linked_accounts) are cleared because the account rows they point at
+ *     are replaced — re-link accounts in Settings → Banking afterwards.
+ *   - Bypasses the app's audit-log RPCs by design (bulk migration).
+ */
+import { readFileSync, writeFileSync, mkdirSync } from 'node:fs';
+import { join } from 'node:path';
+import { homedir } from 'node:os';
+import { randomUUID } from 'node:crypto';
+import { createClient } from '@supabase/supabase-js';
+import Decimal from 'decimal.js';
+
+// ── CLI ──────────────────────────────────────────────────────────────────────
+const args = process.argv.slice(2);
+const seedPath = args.find(a => !a.startsWith('--'));
+const EXECUTE = args.includes('--execute');
+const CONFIRM = args.includes('--confirm-wipe');
+if (!seedPath) {
+  console.error('usage: tsx scripts/mnyCloudImport.mts <seed.json> [--execute --confirm-wipe]');
+  process.exit(1);
+}
+
+// ── Environment (never printed) ──────────────────────────────────────────────
+const env = Object.fromEntries(
+  readFileSync('.env.local', 'utf8')
+    .split('\n')
+    .filter(l => l.includes('=') && !l.trim().startsWith('#'))
+    .map(l => [l.slice(0, l.indexOf('=')).trim(), l.slice(l.indexOf('=') + 1).trim()])
+);
+const url = env.VITE_SUPABASE_URL;
+const serviceKey = env.SUPABASE_SERVICE_ROLE_KEY;
+if (!url || !serviceKey) {
+  console.error('Missing VITE_SUPABASE_URL / SUPABASE_SERVICE_ROLE_KEY in .env.local');
+  process.exit(1);
+}
+const sb = createClient(url, serviceKey, { auth: { persistSession: false } });
+
+// ── Seed ─────────────────────────────────────────────────────────────────────
+interface SeedAccount {
+  id: string; name: string; type: string; balance: number; openingBalance?: number;
+  openingBalanceDate?: string; currency: string; isActive?: boolean; notes?: string;
+  createdAt?: string;
+}
+interface SeedCategory {
+  id: string; name: string; type: string; level: string; parentId?: string;
+  isSystem?: boolean; isTransferCategory?: boolean; accountId?: string; isActive?: boolean;
+}
+interface SeedTransaction {
+  id: string; date: string; description: string; amount: number; type: string;
+  category?: string; accountId: string; notes?: string; cleared?: boolean;
+  bankReference?: string; isSplit?: boolean; transferAccountId?: string;
+  linkedTransferId?: string; linkedTransferSplitId?: string;
+}
+interface SeedSplit {
+  id: string; transactionId: string; category: string; amount: number; memo?: string;
+  sortOrder: number; transferAccountId?: string; linkedTransferId?: string;
+}
+const seed = JSON.parse(readFileSync(seedPath, 'utf8')) as {
+  accounts: SeedAccount[]; categories: SeedCategory[];
+  transactions: SeedTransaction[]; transactionSplits: SeedSplit[];
+};
+console.log(`Seed: ${seed.accounts.length} accounts, ${seed.categories.length} categories, ` +
+  `${seed.transactions.length} transactions, ${seed.transactionSplits.length} split lines`);
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+const fail = (msg: string): never => { console.error(`\nABORT: ${msg}`); process.exit(1); };
+
+async function fetchAll(table: string, filter?: { col: string; val: string }): Promise<Record<string, unknown>[]> {
+  const PAGE = 1000;
+  const rows: Record<string, unknown>[] = [];
+  for (let from = 0; ; from += PAGE) {
+    let q = sb.from(table).select('*').range(from, from + PAGE - 1);
+    if (filter) q = q.eq(filter.col, filter.val);
+    const { data, error } = await q;
+    if (error) fail(`reading ${table}: ${error.message}`);
+    rows.push(...(data ?? []));
+    if ((data ?? []).length < PAGE) return rows;
+  }
+}
+
+async function insertAll(table: string, rows: Record<string, unknown>[]): Promise<void> {
+  const BATCH = 500;
+  for (let i = 0; i < rows.length; i += BATCH) {
+    const { error } = await sb.from(table).insert(rows.slice(i, i + BATCH));
+    if (error) fail(`inserting into ${table} (batch at ${i}): ${error.message}`);
+    process.stdout.write(`\r  ${table}: ${Math.min(i + BATCH, rows.length)}/${rows.length}`);
+  }
+  if (rows.length) process.stdout.write('\n');
+}
+
+const dateOnly = (iso: string): string => iso.slice(0, 10);
+// 'current' is stored as 'checking' (accountService translates on read).
+const dbAccountType = (t: string): string => (t === 'current' ? 'checking' : t);
+
+(async () => {
+  // ── 1. Preflight ───────────────────────────────────────────────────────────
+  const probe = await sb.from('transaction_splits').select('transfer_account_id').limit(1);
+  const probe2 = await sb.from('transactions').select('linked_transfer_split_id').limit(1);
+  if (probe.error || probe2.error) {
+    const msg = 'split-leg columns missing — apply ' +
+      'supabase/migrations/20260720120000_split_leg_transfers.sql first.';
+    if (EXECUTE) fail(msg);
+    console.log(`\nPREFLIGHT (dry run continues): ${msg}`);
+  }
+
+  const { data: users, error: uerr } = await sb.from('users').select('id, email, clerk_id');
+  if (uerr || !users?.length) fail(`cannot identify user: ${uerr?.message ?? 'no users'}`);
+  if (users.length > 1) fail(`expected exactly 1 user, found ${users.length} — refusing to guess`);
+  const userId = users[0].id as string;
+  console.log(`Target user: ${users[0].email} (${userId})`);
+
+  // ── 2. Backup ──────────────────────────────────────────────────────────────
+  const current: Record<string, Record<string, unknown>[]> = {};
+  for (const t of ['accounts', 'categories', 'transactions', 'transaction_splits', 'budgets', 'goals']) {
+    current[t] = await fetchAll(t, { col: 'user_id', val: userId });
+  }
+  const acctIds = new Set(current.accounts.map(a => String(a.id)));
+  current.linked_accounts = (await fetchAll('linked_accounts')).filter(r => acctIds.has(String(r.account_id)));
+
+  const backupDir = join(homedir(), 'WealthTracker-backups');
+  mkdirSync(backupDir, { recursive: true });
+  const backupPath = join(backupDir, `prod-backup-${new Date().toISOString().replace(/[:.]/g, '-')}.json`);
+  writeFileSync(backupPath, JSON.stringify({ userId, backedUpAt: new Date().toISOString(), ...current }));
+  console.log(`\nBACKUP written: ${backupPath}`);
+  for (const [t, rows] of Object.entries(current)) console.log(`  ${t}: ${rows.length} rows`);
+
+  // ── Plan ───────────────────────────────────────────────────────────────────
+  console.log('\nPLAN:');
+  console.log(`  DELETE  ${current.accounts.length} accounts, ${current.transactions.length} transactions, ` +
+    `${current.transaction_splits.length} splits, ${current.categories.length} categories, ` +
+    `${current.budgets.length} budgets, ${current.goals.length} goals, ` +
+    `${current.linked_accounts.length} bank-account links (connections kept — re-link in Settings)`);
+  console.log(`  IMPORT  ${seed.accounts.length} accounts, ${seed.transactions.length} transactions, ` +
+    `${seed.transactionSplits.length} split lines, ${seed.categories.length} categories`);
+
+  if (!EXECUTE || !CONFIRM) {
+    console.log('\nDRY RUN complete — nothing was changed.');
+    console.log('To run for real: add --execute --confirm-wipe');
+    return;
+  }
+
+  // ── 3. Wipe (FK order) ─────────────────────────────────────────────────────
+  console.log('\nWIPING…');
+  // Clear self-referential FKs first so row deletion order inside each table
+  // cannot trip the references.
+  {
+    const { error } = await sb.from('transactions')
+      .update({ linked_transfer_id: null, linked_transfer_split_id: null })
+      .eq('user_id', userId).not('linked_transfer_id', 'is', null);
+    if (error) fail(`unlinking transfers: ${error.message}`);
+  }
+  for (const [table, run] of [
+    ['transaction_splits', () => sb.from('transaction_splits').delete().eq('user_id', userId)],
+    ['transactions', () => sb.from('transactions').delete().eq('user_id', userId)],
+    ['linked_accounts', () => sb.from('linked_accounts').delete().in('account_id', [...acctIds])],
+    ['budgets', () => sb.from('budgets').delete().eq('user_id', userId)],
+    ['goals', () => sb.from('goals').delete().eq('user_id', userId)],
+    ['categories', () => sb.from('categories').delete().eq('user_id', userId)],
+    ['accounts', () => sb.from('accounts').delete().eq('user_id', userId)],
+  ] as Array<[string, () => PromiseLike<{ error: { message: string } | null }>]>) {
+    const { error } = await run();
+    if (error) fail(`wiping ${table}: ${error.message} (backup is at ${backupPath})`);
+    console.log(`  wiped ${table}`);
+  }
+
+  // ── 4. Import ──────────────────────────────────────────────────────────────
+  console.log('\nIMPORTING…');
+  const acctMap = new Map(seed.accounts.map(a => [a.id, randomUUID()]));
+  const catMap = new Map(seed.categories.map(c => [c.id, randomUUID()]));
+  const txnMap = new Map(seed.transactions.map(t => [t.id, randomUUID()]));
+  const splitMap = new Map(seed.transactionSplits.map(s => [s.id, randomUUID()]));
+  const cat = (id?: string): string => (id && catMap.get(id)) || '';
+
+  await insertAll('accounts', seed.accounts.map(a => ({
+    id: acctMap.get(a.id),
+    user_id: userId,
+    name: a.name,
+    type: dbAccountType(a.type),
+    balance: a.balance,
+    initial_balance: a.openingBalance ?? 0,
+    opening_balance_date: a.openingBalanceDate ? dateOnly(a.openingBalanceDate) : null,
+    currency: a.currency || 'GBP',
+    is_active: a.isActive !== false,
+    notes: a.notes ?? null,
+    created_at: a.createdAt ?? new Date().toISOString(),
+  })));
+
+  await insertAll('categories', seed.categories.map(c => ({
+    id: catMap.get(c.id),
+    user_id: userId,
+    name: c.name,
+    type: c.type,
+    level: c.level,
+    parent_id: c.parentId ? catMap.get(c.parentId) : null,
+    is_system: c.isSystem === true,
+    is_transfer_category: c.isTransferCategory === true,
+    account_id: c.accountId ? acctMap.get(c.accountId) : null,
+    is_active: c.isActive !== false,
+  })));
+
+  // Transactions first WITHOUT linked_transfer_split_id (splits don't exist
+  // yet); the 86 split-leg counterparts get it in a second pass below.
+  await insertAll('transactions', seed.transactions.map(t => ({
+    id: txnMap.get(t.id),
+    user_id: userId,
+    account_id: acctMap.get(t.accountId),
+    description: t.description,
+    amount: t.amount,
+    type: t.type,
+    date: dateOnly(t.date),
+    category: t.isSplit ? '' : cat(t.category),
+    notes: t.notes ?? null,
+    is_cleared: t.cleared === true,
+    is_split: t.isSplit === true,
+    transfer_account_id: t.transferAccountId ? acctMap.get(t.transferAccountId) : null,
+    linked_transfer_id: t.linkedTransferId ? txnMap.get(t.linkedTransferId) : null,
+    is_recurring: false,
+    metadata: t.bankReference ? { bankReference: t.bankReference } : {},
+  })));
+
+  await insertAll('transaction_splits', seed.transactionSplits.map(s => ({
+    id: splitMap.get(s.id),
+    transaction_id: txnMap.get(s.transactionId),
+    user_id: userId,
+    category: cat(s.category),
+    amount: s.amount,
+    memo: s.memo ?? null,
+    sort_order: s.sortOrder,
+    transfer_account_id: s.transferAccountId ? acctMap.get(s.transferAccountId) : null,
+    linked_transfer_id: s.linkedTransferId ? txnMap.get(s.linkedTransferId) : null,
+  })));
+
+  const pinned = seed.transactions.filter(t => t.linkedTransferSplitId);
+  for (const t of pinned) {
+    const { error } = await sb.from('transactions')
+      .update({ linked_transfer_split_id: splitMap.get(t.linkedTransferSplitId as string) })
+      .eq('id', txnMap.get(t.id) as string);
+    if (error) fail(`pinning split leg on ${t.id}: ${error.message}`);
+  }
+  console.log(`  pinned ${pinned.length} split-leg counterparts`);
+
+  // ── 5. Verify ──────────────────────────────────────────────────────────────
+  console.log('\nVERIFYING…');
+  const dbAccts = await fetchAll('accounts', { col: 'user_id', val: userId });
+  const dbTxns = await fetchAll('transactions', { col: 'user_id', val: userId });
+  const dbSplits = await fetchAll('transaction_splits', { col: 'user_id', val: userId });
+  const dbCats = await fetchAll('categories', { col: 'user_id', val: userId });
+  console.log(`  counts: ${dbAccts.length} accounts, ${dbTxns.length} transactions, ` +
+    `${dbSplits.length} splits, ${dbCats.length} categories`);
+  if (dbAccts.length !== seed.accounts.length) fail('account count mismatch');
+  if (dbTxns.length !== seed.transactions.length) fail('transaction count mismatch');
+  if (dbSplits.length !== seed.transactionSplits.length) fail('split count mismatch');
+
+  // Ledger invariant per account: initial_balance + Σ txns == balance
+  const sums = new Map<string, Decimal>();
+  for (const t of dbTxns) {
+    const k = String(t.account_id);
+    sums.set(k, (sums.get(k) ?? new Decimal(0)).plus(String(t.amount)));
+  }
+  let badLedger = 0;
+  for (const a of dbAccts) {
+    const computed = new Decimal(String(a.initial_balance ?? 0)).plus(sums.get(String(a.id)) ?? 0);
+    if (!computed.equals(new Decimal(String(a.balance ?? 0)))) {
+      badLedger++;
+      console.log(`  LEDGER MISMATCH ${a.name}: stored ${a.balance}, computed ${computed}`);
+    }
+  }
+
+  // Splits reconcile to parents
+  const txnById = new Map(dbTxns.map(t => [String(t.id), t]));
+  const byParent = new Map<string, Decimal>();
+  for (const s of dbSplits) {
+    const k = String(s.transaction_id);
+    byParent.set(k, (byParent.get(k) ?? new Decimal(0)).plus(String(s.amount)));
+  }
+  let badSplits = 0;
+  for (const [tid, sum] of byParent) {
+    if (!sum.equals(new Decimal(String(txnById.get(tid)?.amount ?? NaN)))) badSplits++;
+  }
+
+  // Transfer reciprocity + split-leg consistency
+  const splitById = new Map(dbSplits.map(s => [String(s.id), s]));
+  let linked = 0, unlinked = 0, badPairs = 0, legs = 0, badLegs = 0;
+  for (const t of dbTxns) {
+    if (t.type !== 'transfer') continue;
+    if (!t.linked_transfer_id) { unlinked++; continue; }
+    linked++;
+    if (t.linked_transfer_split_id) {
+      legs++;
+      const line = splitById.get(String(t.linked_transfer_split_id));
+      const ok = line &&
+        String(line.transaction_id) === String(t.linked_transfer_id) &&
+        String(line.linked_transfer_id) === String(t.id) &&
+        new Decimal(String(line.amount)).negated().equals(new Decimal(String(t.amount)));
+      if (!ok) badLegs++;
+    } else {
+      const partner = txnById.get(String(t.linked_transfer_id));
+      const ok = partner &&
+        String(partner.linked_transfer_id) === String(t.id) &&
+        new Decimal(String(partner.amount)).negated().equals(new Decimal(String(t.amount)));
+      if (!ok) badPairs++;
+    }
+  }
+
+  console.log(`  ledger invariant: ${dbAccts.length - badLedger}/${dbAccts.length} accounts OK`);
+  console.log(`  splits reconcile: ${byParent.size - badSplits}/${byParent.size} OK`);
+  console.log(`  transfers: ${linked} linked (${legs} split-leg), ${unlinked} unlinked, ` +
+    `${badPairs} broken pairs, ${badLegs} broken legs`);
+
+  if (badLedger || badSplits || badPairs || badLegs) {
+    fail(`verification FAILED — backup is at ${backupPath}`);
+  }
+  console.log(`\nDONE. Backup kept at ${backupPath}`);
+  console.log('Re-link bank feeds: Settings → Banking → link accounts to the imported ones.');
+})();

--- a/scripts/mnyCloudImport.mts
+++ b/scripts/mnyCloudImport.mts
@@ -44,6 +44,7 @@ const args = process.argv.slice(2);
 const seedPath = args.find(a => !a.startsWith('--'));
 const EXECUTE = args.includes('--execute');
 const CONFIRM = args.includes('--confirm-wipe');
+const VERIFY_ONLY = args.includes('--verify-only');
 if (!seedPath) {
   console.error('usage: tsx scripts/mnyCloudImport.mts <seed.json> [--execute --confirm-wipe]');
   process.exit(1);
@@ -138,6 +139,12 @@ const dbAccountType = (t: string): string => (t === 'current' ? 'checking' : t);
   const userId = users[0].id as string;
   console.log(`Target user: ${users[0].email} (${userId})`);
 
+  if (VERIFY_ONLY) {
+    await verifyImport(userId, seed.transactionSplits.filter(s => s.amount !== 0).length);
+    console.log('\nVERIFY-ONLY complete.');
+    return;
+  }
+
   // ── 2. Backup ──────────────────────────────────────────────────────────────
   const current: Record<string, Record<string, unknown>[]> = {};
   for (const t of ['accounts', 'categories', 'transactions', 'transaction_splits', 'budgets', 'goals']) {
@@ -184,8 +191,13 @@ const dbAccountType = (t: string): string => (t === 'current' ? 'checking' : t);
     ['linked_accounts', () => sb.from('linked_accounts').delete().in('account_id', [...acctIds])],
     ['budgets', () => sb.from('budgets').delete().eq('user_id', userId)],
     ['goals', () => sb.from('goals').delete().eq('user_id', userId)],
-    ['categories', () => sb.from('categories').delete().eq('user_id', userId)],
+    // Accounts BEFORE categories: the protect_transfer_category trigger
+    // refuses to delete a To/From category while its account row exists —
+    // deleting the account first cascades its transfer category away
+    // (categories_account_id_fkey ON DELETE CASCADE), and the remaining
+    // ordinary categories then delete freely.
     ['accounts', () => sb.from('accounts').delete().eq('user_id', userId)],
+    ['categories', () => sb.from('categories').delete().eq('user_id', userId)],
   ] as Array<[string, () => PromiseLike<{ error: { message: string } | null }>]>) {
     const { error } = await run();
     if (error) fail(`wiping ${table}: ${error.message} (backup is at ${backupPath})`);
@@ -227,9 +239,12 @@ const dbAccountType = (t: string): string => (t === 'current' ? 'checking' : t);
     is_active: c.isActive !== false,
   })));
 
-  // Transactions first WITHOUT linked_transfer_split_id (splits don't exist
-  // yet); the 86 split-leg counterparts get it in a second pass below.
-  await insertAll('transactions', seed.transactions.map(t => ({
+  // Transactions in TWO passes: linked transfer pairs reference EACH OTHER,
+  // so no batch order can satisfy linked_transfer_id on insert (the FK is
+  // checked per statement). Insert everything unlinked first, then upsert the
+  // full rows of the linked ones with linked_transfer_id set.
+  // (linked_transfer_split_id is a third pass — splits don't exist yet.)
+  const txnRow = (t: SeedTransaction, withLink: boolean): Record<string, unknown> => ({
     id: txnMap.get(t.id),
     user_id: userId,
     account_id: acctMap.get(t.accountId),
@@ -242,16 +257,45 @@ const dbAccountType = (t: string): string => (t === 'current' ? 'checking' : t);
     is_cleared: t.cleared === true,
     is_split: t.isSplit === true,
     transfer_account_id: t.transferAccountId ? acctMap.get(t.transferAccountId) : null,
-    linked_transfer_id: t.linkedTransferId ? txnMap.get(t.linkedTransferId) : null,
+    linked_transfer_id: withLink && t.linkedTransferId ? txnMap.get(t.linkedTransferId) : null,
     is_recurring: false,
     metadata: t.bankReference ? { bankReference: t.bankReference } : {},
-  })));
+  });
+  await insertAll('transactions', seed.transactions.map(t => txnRow(t, false)));
 
-  await insertAll('transaction_splits', seed.transactionSplits.map(s => ({
+  const linkedTxns = seed.transactions.filter(t => t.linkedTransferId);
+  {
+    const BATCH = 500;
+    for (let i = 0; i < linkedTxns.length; i += BATCH) {
+      const { error } = await sb.from('transactions')
+        .upsert(linkedTxns.slice(i, i + BATCH).map(t => txnRow(t, true)), { onConflict: 'id' });
+      if (error) fail(`linking transfer pairs (batch at ${i}): ${error.message}`);
+      process.stdout.write(`\r  transfer links: ${Math.min(i + BATCH, linkedTxns.length)}/${linkedTxns.length}`);
+    }
+    process.stdout.write('\n');
+  }
+
+  // The cloud schema requires every split line to be categorised
+  // (transaction_splits_category_not_blank); Money split lines with no
+  // category file under "Unassigned (MS Money import)" — same meaning,
+  // now explicit.
+  const unassigned = catMap.get('mny-unassigned');
+  if (!unassigned) fail('seed is missing the mny-unassigned category');
+  // Zero-amount lines are empty Money artifacts (no category, no memo, no
+  // effect on any sum) and the cloud schema refuses them — drop, not remap.
+  // Refuse if one is a transfer leg (would strand its counterpart).
+  const zeroLegs = seed.transactionSplits.filter(s => s.amount === 0 && s.linkedTransferId);
+  if (zeroLegs.length) fail(`zero-amount split line(s) that are transfer legs: ${zeroLegs.map(s => s.id).join(', ')}`);
+  const importSplits = seed.transactionSplits.filter(s => s.amount !== 0);
+  const droppedZero = seed.transactionSplits.length - importSplits.length;
+  if (droppedZero) console.log(`  ${droppedZero} zero-amount empty split line(s) dropped (no effect on sums)`);
+  const blankLines = importSplits.filter(s => !cat(s.category)).length;
+  if (blankLines) console.log(`  ${blankLines} uncategorised split line(s) → Unassigned (MS Money import)`);
+  await insertAll('transaction_splits', importSplits.map(s => ({
     id: splitMap.get(s.id),
     transaction_id: txnMap.get(s.transactionId),
     user_id: userId,
-    category: cat(s.category),
+    category: cat(s.category) || unassigned,
     amount: s.amount,
     memo: s.memo ?? null,
     sort_order: s.sortOrder,
@@ -269,6 +313,13 @@ const dbAccountType = (t: string): string => (t === 'current' ? 'checking' : t);
   console.log(`  pinned ${pinned.length} split-leg counterparts`);
 
   // ── 5. Verify ──────────────────────────────────────────────────────────────
+  await verifyImport(userId, importSplits.length);
+  console.log(`\nDONE. Backup kept at ${backupPath}`);
+  console.log('Re-link bank feeds: Settings → Banking → link accounts to the imported ones.');
+})();
+
+/** Full post-import verification — Decimal maths, fails the process on any breach. */
+async function verifyImport(userId: string, expectedSplits: number): Promise<void> {
   console.log('\nVERIFYING…');
   const dbAccts = await fetchAll('accounts', { col: 'user_id', val: userId });
   const dbTxns = await fetchAll('transactions', { col: 'user_id', val: userId });
@@ -278,7 +329,7 @@ const dbAccountType = (t: string): string => (t === 'current' ? 'checking' : t);
     `${dbSplits.length} splits, ${dbCats.length} categories`);
   if (dbAccts.length !== seed.accounts.length) fail('account count mismatch');
   if (dbTxns.length !== seed.transactions.length) fail('transaction count mismatch');
-  if (dbSplits.length !== seed.transactionSplits.length) fail('split count mismatch');
+  if (dbSplits.length !== expectedSplits) fail('split count mismatch');
 
   // Ledger invariant per account: initial_balance + Σ txns == balance
   const sums = new Map<string, Decimal>();
@@ -309,7 +360,9 @@ const dbAccountType = (t: string): string => (t === 'current' ? 'checking' : t);
 
   // Transfer reciprocity + split-leg consistency
   const splitById = new Map(dbSplits.map(s => [String(s.id), s]));
+  const currencyByAcct = new Map(dbAccts.map(a => [String(a.id), String(a.currency ?? 'GBP')]));
   let linked = 0, unlinked = 0, badPairs = 0, legs = 0, badLegs = 0;
+  let crossCurrencyPairs = 0;
   for (const t of dbTxns) {
     if (t.type !== 'transfer') continue;
     if (!t.linked_transfer_id) { unlinked++; continue; }
@@ -324,21 +377,28 @@ const dbAccountType = (t: string): string => (t === 'current' ? 'checking' : t);
       if (!ok) badLegs++;
     } else {
       const partner = txnById.get(String(t.linked_transfer_id));
+      // Exact negation only applies when both accounts share a currency —
+      // Money records each side of a cross-currency transfer in its own
+      // currency (e.g. −$1,336.25 ↔ +£1,069.00), so those pairs only need
+      // to be reciprocal.
+      const sameCurrency = partner &&
+        currencyByAcct.get(String(t.account_id)) === currencyByAcct.get(String(partner.account_id));
+      if (partner && !sameCurrency) crossCurrencyPairs++;
       const ok = partner &&
         String(partner.linked_transfer_id) === String(t.id) &&
-        new Decimal(String(partner.amount)).negated().equals(new Decimal(String(t.amount)));
+        (!sameCurrency ||
+          new Decimal(String(partner.amount)).negated().equals(new Decimal(String(t.amount))));
       if (!ok) badPairs++;
     }
   }
 
   console.log(`  ledger invariant: ${dbAccts.length - badLedger}/${dbAccts.length} accounts OK`);
   console.log(`  splits reconcile: ${byParent.size - badSplits}/${byParent.size} OK`);
-  console.log(`  transfers: ${linked} linked (${legs} split-leg), ${unlinked} unlinked, ` +
+  console.log(`  transfers: ${linked} linked (${legs} split-leg, ` +
+    `${crossCurrencyPairs} cross-currency legs), ${unlinked} unlinked, ` +
     `${badPairs} broken pairs, ${badLegs} broken legs`);
 
   if (badLedger || badSplits || badPairs || badLegs) {
-    fail(`verification FAILED — backup is at ${backupPath}`);
+    fail('verification FAILED — see ~/WealthTracker-backups for the pre-wipe backups');
   }
-  console.log(`\nDONE. Backup kept at ${backupPath}`);
-  console.log('Re-link bank feeds: Settings → Banking → link accounts to the imported ones.');
-})();
+}

--- a/scripts/mnyLocalImport.mts
+++ b/scripts/mnyLocalImport.mts
@@ -1,0 +1,64 @@
+/**
+ * DEV-ONLY local proving harness for the MS Money import.
+ *
+ * Reads the normalised .mny export JSON from the SCRATCHPAD (never the repo),
+ * runs the real transform, and writes a local seed to the gitignored
+ * `mny-local-seed.json` at the project root. The dev-only loader in the app
+ * (?mnyimport=local) injects that seed into local storage so the whole file
+ * can be browsed in a purely local WealthTracker — no cloud, no live data.
+ *
+ * Usage:  npx tsx scripts/mnyLocalImport.mts <exportDir>
+ * The seed contains real financial data and is gitignored — delete it after
+ * review.
+ */
+import { readFileSync, writeFileSync, mkdirSync } from 'node:fs';
+import { join } from 'node:path';
+import { transformMsMoneyExport, type MnyExport } from '../src/services/import/msMoney/transform.ts';
+
+const exportDir = process.argv[2];
+if (!exportDir) {
+  console.error('usage: tsx scripts/mnyLocalImport.mts <exportDir>');
+  process.exit(1);
+}
+
+const read = <T>(name: string): T =>
+  JSON.parse(readFileSync(join(exportDir, name), 'utf8')) as T;
+
+const exp: MnyExport = {
+  accounts: read('accounts.json'),
+  categories: read('categories.json'),
+  payees: read('payees.json'),
+  // Prefer the forensics-enriched v2 (isTransferLine + split reconciliation
+  // fields) when present.
+  transactions: (() => {
+    try { return read('transactions_v2.json'); } catch { return read('transactions.json'); }
+  })(),
+};
+
+const result = transformMsMoneyExport(exp, new Date().toISOString());
+
+const seed = {
+  generatedAt: new Date().toISOString(),
+  accounts: result.accounts,
+  categories: result.categories,
+  transactions: result.transactions,
+  transactionSplits: result.transactionSplits,
+  summary: result.summary,
+};
+
+// OUTSIDE public/ on purpose: public/ is copied into dist by every build,
+// and this file holds real financial data. A dev-only Vite middleware
+// (vite.config.ts) serves it at /mny-local-seed.json on the dev server.
+const outDir = join(process.cwd(), '.mny-local');
+mkdirSync(outDir, { recursive: true });
+const outPath = join(outDir, 'mny-local-seed.json');
+writeFileSync(outPath, JSON.stringify(seed));
+
+const s = result.summary;
+console.log('MS Money → WealthTracker local seed written:', outPath);
+console.log(`  accounts:     ${s.accounts.total} (${s.accounts.open} open, ${s.accounts.closed} closed)`);
+console.log(`  categories:   ${s.categories.subs} sub + ${s.categories.details} detail (${s.categories.hidden} hidden→inactive)`);
+console.log(`  transactions: ${s.transactions.imported} imported`);
+console.log(`     standalone ${s.transactions.standalone} | transfers ${s.transactions.transfers} | split ${s.transactions.splitTransactions} (${s.transactions.splitLines} lines)`);
+console.log('  simplifications:');
+for (const line of s.simplifications) console.log(`     - ${line}`);

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -27,6 +27,7 @@ import { ProtectedSuspense } from './components/auth/ProtectedSuspense';
 import SafariWarning from './components/SafariWarning';
 import ConsentBanner from './components/ConsentBanner';
 import { isDemoMode, initializeDemoData } from './utils/demoData';
+import { isMnyLocalImportRequested, loadMnyLocalSeed } from './utils/mnyLocalImport';
 import { DebugErrorBoundary } from './components/DebugErrorBoundary';
 
 // Lazy load all pages for code splitting with preload support
@@ -85,8 +86,14 @@ function App(): React.JSX.Element {
     
     // Initialize demo mode if requested
     if (isDemoMode()) {
-      initializeDemoData();
-      // Demo mode activated - Using sample data for UI/UX testing
+      // DEV-ONLY: ?demo=true&mnyimport=local loads the local MS Money seed
+      // instead of the demo sample data (a no-op in production builds).
+      if (isMnyLocalImportRequested()) {
+        void loadMnyLocalSeed();
+      } else {
+        initializeDemoData();
+        // Demo mode activated - Using sample data for UI/UX testing
+      }
     }
     
     // Simplified storage check - don't auto-clear

--- a/src/components/AccountSettingsModal.tsx
+++ b/src/components/AccountSettingsModal.tsx
@@ -6,8 +6,8 @@ import { parseMoneyInput } from '../utils/decimal';
 import type { Account as BaseAccount } from '../types';
 
 // Extend the base Account type with additional fields needed for settings
+// (type comes from BaseAccount — the single canonical union).
 interface Account extends BaseAccount {
-  type: "current" | "savings" | "credit" | "loan" | "investment" | "assets" | "other" | "mortgage" | "checking" | "asset";
   sortCode?: string;
   accountNumber?: string;
 }

--- a/src/contexts/AccountContext.tsx
+++ b/src/contexts/AccountContext.tsx
@@ -21,7 +21,7 @@ interface Holding {
 interface Account {
   id: string;
   name: string;
-  type: 'current' | 'savings' | 'credit' | 'loan' | 'investment' | 'assets' | 'other' | 'mortgage' | 'checking' | 'asset';
+  type: 'current' | 'savings' | 'credit' | 'loan' | 'investment' | 'assets' | 'other' | 'mortgage' | 'checking' | 'asset' | 'liability';
   balance: number;
   currency: string;
   institution?: string;

--- a/src/lib/supabaseToken.ts
+++ b/src/lib/supabaseToken.ts
@@ -19,6 +19,16 @@ export function registerSupabaseTokenGetter(getter: TokenGetter | null): void {
   clerkTokenGetter = getter;
 }
 
+/**
+ * Whether a Clerk session is currently registered. The getter is registered
+ * exactly while a user is signed in (AuthContext), so this doubles as the
+ * data layer's "signed-in session exists" signal — used to stop local-storage
+ * fallbacks from leaking demo/import data into a signed-in view.
+ */
+export function hasSupabaseTokenGetter(): boolean {
+  return clerkTokenGetter !== null;
+}
+
 export async function getSupabaseAccessToken(): Promise<string | null> {
   if (!clerkTokenGetter) {
     return null;

--- a/src/services/__tests__/dataService.test.ts
+++ b/src/services/__tests__/dataService.test.ts
@@ -122,6 +122,111 @@ describe('DataService (deterministic fallback)', () => {
     expect(data.categories).toHaveLength(1);
   });
 
+  it('refuses to edit or un-split a split containing a linked transfer line', async () => {
+    // A split whose second line is one leg of a transfer (the counterpart
+    // transaction points back at it). Replacing or removing the lines would
+    // strand the counterpart, so both must be rejected.
+    const storage = createStorage({
+      [STORAGE_KEYS.ACCOUNTS]: [baseAccount()],
+      [STORAGE_KEYS.TRANSACTIONS]: [
+        baseTransaction({ id: 'split-parent', amount: -100, isSplit: true, category: '' }),
+        baseTransaction({
+          id: 'counterpart',
+          accountId: 'acct-2',
+          amount: 30,
+          type: 'transfer',
+          linkedTransferId: 'split-parent',
+          linkedTransferSplitId: 'line-2'
+        })
+      ],
+      [STORAGE_KEYS.TRANSACTION_SPLITS]: [
+        { id: 'line-1', transactionId: 'split-parent', category: 'food', amount: -70, sortOrder: 1 },
+        {
+          id: 'line-2',
+          transactionId: 'split-parent',
+          category: 'tofrom-acct-2',
+          amount: -30,
+          sortOrder: 2,
+          transferAccountId: 'acct-2',
+          linkedTransferId: 'counterpart'
+        }
+      ]
+    });
+    const service = createDataService({
+      isSupabaseConfigured: () => false,
+      storageAdapter: storage,
+      logger,
+      uuid,
+      now,
+      userIdService: userId
+    });
+
+    await expect(
+      service.setTransactionSplits(
+        'split-parent',
+        [
+          { category: 'food', amount: -50 },
+          { category: 'travel', amount: -50 }
+        ],
+        -100
+      )
+    ).rejects.toThrow(/linked transfer line/);
+    await expect(service.setTransactionSplits('split-parent', [], null)).rejects.toThrow(
+      /linked transfer line/
+    );
+    // nothing was persisted — the split and its leg line survive intact
+    expect(storage.snapshot(STORAGE_KEYS.TRANSACTION_SPLITS)).toHaveLength(2);
+  });
+
+  it('never falls back to local storage while a signed-in session is still resolving', async () => {
+    // A Clerk session exists (hasCloudSession true) but the database user id
+    // hasn't resolved — e.g. during init, or when resolution fails. Local
+    // storage holds demo/import data that must NOT leak into the signed-in
+    // view, and writes must refuse rather than divert into local storage.
+    const storage = createStorage({
+      [STORAGE_KEYS.ACCOUNTS]: [
+        baseAccount({ id: 'demo-open' }),
+        baseAccount({ id: 'demo-closed', isActive: false })
+      ],
+      [STORAGE_KEYS.TRANSACTIONS]: [baseTransaction()],
+      [STORAGE_KEYS.BUDGETS]: [{ id: 'demo-budget' }],
+      [STORAGE_KEYS.CATEGORIES]: [{ id: 'demo-cat' }]
+    });
+    const service = createDataService({
+      isSupabaseConfigured: () => true,
+      hasCloudSession: () => true,
+      storageAdapter: storage,
+      logger,
+      uuid,
+      now,
+      userIdService: userId // getCurrentDatabaseUserId → null
+    });
+
+    expect(await service.getAccounts()).toEqual([]);
+    expect(await service.getClosedAccounts()).toEqual([]);
+    expect(await service.getTransactions()).toEqual([]);
+    expect(await service.getAllTransactionSplits()).toEqual([]);
+    expect(await service.getBudgets()).toEqual([]);
+    expect(await service.getCategories()).toEqual([]);
+    await expect(service.createTransaction(baseTransaction({ id: undefined as never })))
+      .rejects.toThrow(/Still connecting/);
+    await expect(service.deleteAccount('demo-open')).rejects.toThrow(/Still connecting/);
+    expect(storage.set).not.toHaveBeenCalled();
+
+    // No session at all (demo / local-only mode): the local fallback still works.
+    const localService = createDataService({
+      isSupabaseConfigured: () => true,
+      hasCloudSession: () => false,
+      storageAdapter: storage,
+      logger,
+      uuid,
+      now,
+      userIdService: userId
+    });
+    expect(await localService.getAccounts()).toHaveLength(2);
+    expect(await localService.getClosedAccounts()).toHaveLength(1);
+  });
+
   it('allows static DataService reconfiguration for tests', async () => {
     const storage = createStorage({
       [STORAGE_KEYS.ACCOUNTS]: [baseAccount({ id: 'static-account' })]

--- a/src/services/api/dataService.ts
+++ b/src/services/api/dataService.ts
@@ -9,6 +9,7 @@ import { UserService } from './userService';
 import { AccountService } from './accountService';
 import { TransactionService } from './transactionService';
 import { isSupabaseConfigured } from './supabaseClient';
+import { hasSupabaseTokenGetter } from '../../lib/supabaseToken';
 import { storageAdapter, STORAGE_KEYS } from '../storageAdapter';
 import { userIdService } from '../userIdService';
 import { toDecimal } from '../../utils/decimal';
@@ -35,6 +36,7 @@ type UserIdServiceLike = Pick<typeof userIdService,
   'ensureUserExists' | 'getCurrentDatabaseUserId' | 'getCurrentUserIds'>;
 type StorageAdapterLike = Pick<typeof storageAdapter, 'get' | 'set'>;
 type SupabaseChecker = () => boolean;
+type CloudSessionChecker = () => boolean;
 type DateProvider = () => Date;
 type UuidGenerator = () => string;
 
@@ -48,6 +50,8 @@ export interface DataServiceOptions {
   now?: DateProvider;
   uuid?: UuidGenerator;
   isSupabaseConfigured?: SupabaseChecker;
+  /** Whether a signed-in (Clerk) session exists right now. */
+  hasCloudSession?: CloudSessionChecker;
 }
 
 class DataServiceImpl {
@@ -60,6 +64,7 @@ class DataServiceImpl {
   private readonly nowProvider: DateProvider;
   private readonly uuid: UuidGenerator;
   private readonly supabaseChecker: SupabaseChecker;
+  private readonly hasCloudSession: CloudSessionChecker;
 
   constructor(options: DataServiceOptions = {}) {
     this.accountService = options.accountService ?? AccountService;
@@ -82,11 +87,29 @@ class DataServiceImpl {
       return `${Date.now()}-${Math.random().toString(16).slice(2)}`;
     });
     this.supabaseChecker = options.isSupabaseConfigured ?? isSupabaseConfigured;
+    this.hasCloudSession = options.hasCloudSession ?? hasSupabaseTokenGetter;
   }
 
   private isSupabaseReady(): boolean {
     const userId = this.userIdService.getCurrentDatabaseUserId();
     return Boolean(userId && this.supabaseChecker());
+  }
+
+  /**
+   * A signed-in (Clerk) session exists but the database user id hasn't
+   * resolved yet — still connecting, or resolution failed. In this state the
+   * browser-local fallback must NOT run: it would read demo/import data (or
+   * divert writes) inside a signed-in view. Reads return empty; writes refuse.
+   */
+  private isCloudSessionPending(): boolean {
+    return this.supabaseChecker() && this.hasCloudSession() &&
+      !this.userIdService.getCurrentDatabaseUserId();
+  }
+
+  private guardCloudWrite(): void {
+    if (this.isCloudSessionPending()) {
+      throw new Error('Still connecting to your account — please try again in a moment.');
+    }
   }
 
   private async readCollection<T>(key: string): Promise<T[]> {
@@ -123,7 +146,9 @@ class DataServiceImpl {
   async loadAppData(): Promise<AppData> {
     const userId = this.userIdService.getCurrentDatabaseUserId();
     if (!userId && this.supabaseChecker()) {
-      this.logger.warn('[DataService] No database ID available, using localStorage fallback');
+      this.logger.warn(this.hasCloudSession()
+        ? '[DataService] Signed in but database user id unresolved — returning empty data (local fallback blocked)'
+        : '[DataService] No database ID available, using localStorage fallback');
     }
 
     try {
@@ -153,6 +178,7 @@ class DataServiceImpl {
     if (userId && this.supabaseChecker()) {
       return this.accountService.getAccounts(userId);
     }
+    if (this.isCloudSessionPending()) return [];
     return this.readCollection<Account>(STORAGE_KEYS.ACCOUNTS);
   }
 
@@ -162,6 +188,7 @@ class DataServiceImpl {
     if (userId && this.supabaseChecker()) {
       return this.accountService.getClosedAccounts(userId);
     }
+    if (this.isCloudSessionPending()) return [];
     const accounts = await this.readCollection<Account>(STORAGE_KEYS.ACCOUNTS);
     return accounts.filter(a => a.isActive === false);
   }
@@ -171,6 +198,7 @@ class DataServiceImpl {
     if (userId && this.supabaseChecker()) {
       return this.accountService.createAccount(userId, account);
     }
+    this.guardCloudWrite();
 
     const accounts = await this.readCollection<Account>(STORAGE_KEYS.ACCOUNTS);
     const newAccount: Account = {
@@ -187,6 +215,7 @@ class DataServiceImpl {
     if (userId && this.supabaseChecker()) {
       return this.accountService.updateAccount(id, updates, userId);
     }
+    this.guardCloudWrite();
 
     const accounts = await this.readCollection<Account>(STORAGE_KEYS.ACCOUNTS);
     const index = accounts.findIndex(account => account.id === id);
@@ -204,6 +233,7 @@ class DataServiceImpl {
     if (userId && this.supabaseChecker()) {
       return this.accountService.deleteAccount(id, userId);
     }
+    this.guardCloudWrite();
 
     // Local mode mirrors the cloud semantics: a SOFT close (reopenable from
     // the Closed Accounts section), never a hard delete.
@@ -220,6 +250,7 @@ class DataServiceImpl {
       return this.transactionService.getTransactions(userId);
     }
 
+    if (this.isCloudSessionPending()) return [];
     return this.readCollection<Transaction>(STORAGE_KEYS.TRANSACTIONS);
   }
 
@@ -228,6 +259,7 @@ class DataServiceImpl {
     if (userId && this.supabaseChecker()) {
       return this.transactionService.createTransaction(userId, transaction);
     }
+    this.guardCloudWrite();
 
     const transactions = await this.readCollection<Transaction>(STORAGE_KEYS.TRANSACTIONS);
     const newTransaction: Transaction = {
@@ -246,6 +278,7 @@ class DataServiceImpl {
     if (userId && this.supabaseChecker()) {
       return this.transactionService.updateTransaction(id, updates, userId);
     }
+    this.guardCloudWrite();
 
     const transactions = await this.readCollection<Transaction>(STORAGE_KEYS.TRANSACTIONS);
     const index = transactions.findIndex(transaction => transaction.id === id);
@@ -271,6 +304,7 @@ class DataServiceImpl {
     if (userId && this.supabaseChecker()) {
       return this.transactionService.deleteTransaction(id, userId);
     }
+    this.guardCloudWrite();
 
     const transactions = await this.readCollection<Transaction>(STORAGE_KEYS.TRANSACTIONS);
     const transaction = transactions.find(t => t.id === id);
@@ -287,6 +321,7 @@ class DataServiceImpl {
     if (userId && this.supabaseChecker()) {
       return this.transactionService.setTransactionsCleared(ids, cleared, userId);
     }
+    this.guardCloudWrite();
 
     const transactions = await this.readCollection<Transaction>(STORAGE_KEYS.TRANSACTIONS);
     const idSet = new Set(ids);
@@ -311,6 +346,7 @@ class DataServiceImpl {
     if (userId && this.supabaseChecker()) {
       return this.transactionService.applyCategoryToUncategorized(ids, category, userId);
     }
+    this.guardCloudWrite();
 
     const transactions = await this.readCollection<Transaction>(STORAGE_KEYS.TRANSACTIONS);
     const idSet = new Set(ids);
@@ -333,6 +369,7 @@ class DataServiceImpl {
       return this.transactionService.getAllTransactionSplits(userId);
     }
 
+    if (this.isCloudSessionPending()) return [];
     return this.readCollection<TransactionSplit>(STORAGE_KEYS.TRANSACTION_SPLITS);
   }
 
@@ -343,6 +380,7 @@ class DataServiceImpl {
       return this.transactionService.getTransactionSplits(transactionId);
     }
 
+    if (this.isCloudSessionPending()) return [];
     const stored = await this.readCollection<TransactionSplit>(STORAGE_KEYS.TRANSACTION_SPLITS);
     return stored
       .filter(s => s.transactionId === transactionId)
@@ -364,6 +402,7 @@ class DataServiceImpl {
     if (userId && this.supabaseChecker()) {
       return this.transactionService.setTransactionSplits(transactionId, splits, expectedAmount, userId);
     }
+    this.guardCloudWrite();
 
     const transactions = await this.readCollection<Transaction>(STORAGE_KEYS.TRANSACTIONS);
     const index = transactions.findIndex(t => t.id === transactionId);
@@ -376,6 +415,14 @@ class DataServiceImpl {
     }
 
     const stored = await this.readCollection<TransactionSplit>(STORAGE_KEYS.TRANSACTION_SPLITS);
+    // A line that is one leg of a linked transfer is structural — replacing or
+    // removing it would strand the opposite transaction. Same v1 stance as
+    // moving a linked transfer: delete/unlink first, then edit.
+    if (stored.some(s => s.transactionId === transactionId && s.linkedTransferId)) {
+      throw new Error(
+        'This split contains a linked transfer line — delete the linked transfer first, then edit the split.'
+      );
+    }
     const others = stored.filter(s => s.transactionId !== transactionId);
 
     if (splits.length === 0) {
@@ -438,6 +485,7 @@ class DataServiceImpl {
     if (userId && this.supabaseChecker()) {
       return this.transactionService.linkTransferPair(idA, idB, userId);
     }
+    this.guardCloudWrite();
 
     const transactions = await this.readCollection<Transaction>(STORAGE_KEYS.TRANSACTIONS);
     const a = transactions.find(t => t.id === idA);
@@ -493,6 +541,7 @@ class DataServiceImpl {
     if (userId && this.supabaseChecker()) {
       return this.transactionService.createTransferCounterpart(id, targetAccountId, userId);
     }
+    this.guardCloudWrite();
 
     const transactions = await this.readCollection<Transaction>(STORAGE_KEYS.TRANSACTIONS);
     const source = transactions.find(t => t.id === id);
@@ -542,15 +591,21 @@ class DataServiceImpl {
     return { source: newSource, counterpart };
   }
 
+  // Budgets/goals/categories are local-only here (PlanningService owns the
+  // cloud path) — but a signed-in session must still never read them from
+  // browser-local storage, so the same pending gate applies.
   async getBudgets(): Promise<Budget[]> {
+    if (this.isCloudSessionPending()) return [];
     return this.readCollection<Budget>(STORAGE_KEYS.BUDGETS);
   }
 
   async getGoals(): Promise<Goal[]> {
+    if (this.isCloudSessionPending()) return [];
     return this.readCollection<Goal>(STORAGE_KEYS.GOALS);
   }
 
   async getCategories(): Promise<Category[]> {
+    if (this.isCloudSessionPending()) return [];
     return this.readCollection<Category>(STORAGE_KEYS.CATEGORIES);
   }
 

--- a/src/services/api/transactionService.ts
+++ b/src/services/api/transactionService.ts
@@ -41,6 +41,7 @@ const CAMEL_TO_DB: Record<string, string> = {
   updatedAt: 'updated_at',
   recurringTransactionId: 'recurring_transaction_id',
   linkedTransferId: 'linked_transfer_id',
+  linkedTransferSplitId: 'linked_transfer_split_id',
   plaidTransactionId: 'plaid_transaction_id',
   paymentChannel: 'payment_channel',
   addedBy: 'added_by',
@@ -358,6 +359,20 @@ class TransactionServiceImpl {
   }
 
   /** Every split line of the user's transactions (for category aggregation). */
+  /** DB split row → app TransactionSplit, including transfer-leg fields. */
+  private mapSplitRow(row: Record<string, unknown>): TransactionSplit {
+    return {
+      id: String(row.id),
+      transactionId: String(row.transaction_id),
+      category: String(row.category),
+      amount: Number(row.amount),
+      memo: typeof row.memo === 'string' && row.memo !== '' ? row.memo : undefined,
+      sortOrder: Number(row.sort_order),
+      ...(row.transfer_account_id ? { transferAccountId: String(row.transfer_account_id) } : {}),
+      ...(row.linked_transfer_id ? { linkedTransferId: String(row.linked_transfer_id) } : {}),
+    };
+  }
+
   async getAllTransactionSplits(userId?: string): Promise<TransactionSplit[]> {
     if (!this.isSupabaseReady()) {
       return (await this.storage.get<TransactionSplit[]>(STORAGE_KEYS.TRANSACTION_SPLITS)) ?? [];
@@ -367,6 +382,7 @@ class TransactionServiceImpl {
       const client = this.supabaseClient!;
       // Page like getTransactions — splits are few today, but the 1000-row
       // PostgREST cap would silently truncate a heavy splitter's data.
+      // (Row mapping shared with getTransactionSplits via mapSplitRow.)
       const PAGE_SIZE = 1000;
       const rows: Record<string, unknown>[] = [];
       let from = 0;
@@ -392,14 +408,7 @@ class TransactionServiceImpl {
         }
         from += PAGE_SIZE;
       }
-      return rows.map(row => ({
-        id: String(row.id),
-        transactionId: String(row.transaction_id),
-        category: String(row.category),
-        amount: Number(row.amount),
-        memo: typeof row.memo === 'string' && row.memo !== '' ? row.memo : undefined,
-        sortOrder: Number(row.sort_order),
-      }));
+      return rows.map(row => this.mapSplitRow(row));
     } catch (error) {
       this.logger.error('TransactionService.getAllTransactionSplits error:', error as Error);
       throw error;
@@ -428,14 +437,7 @@ class TransactionServiceImpl {
         throw new Error(handleSupabaseError(error));
       }
 
-      return ((data || []) as Record<string, unknown>[]).map(row => ({
-        id: String(row.id),
-        transactionId: String(row.transaction_id),
-        category: String(row.category),
-        amount: Number(row.amount),
-        memo: typeof row.memo === 'string' && row.memo !== '' ? row.memo : undefined,
-        sortOrder: Number(row.sort_order),
-      }));
+      return ((data || []) as Record<string, unknown>[]).map(row => this.mapSplitRow(row));
     } catch (error) {
       this.logger.error('TransactionService.getTransactionSplits error:', error as Error);
       throw error;

--- a/src/services/import/msMoney/transform.test.ts
+++ b/src/services/import/msMoney/transform.test.ts
@@ -1,0 +1,219 @@
+import { describe, it, expect } from 'vitest';
+import { transformMsMoneyExport, type MnyExport } from './transform';
+
+const NOW = '2026-07-20T12:00:00.000Z';
+
+function build(over: Partial<MnyExport> = {}): MnyExport {
+  return {
+    accounts: [
+      { id: 1, name: 'HSBC Current', moneyType: 'bank', currencyCode: 'GBP', openingBalance: '0', reconstructedBalance: '150.50', closed: false, openDate: '2010-01-01', closeDate: null, comment: null },
+      { id: 2, name: 'Old Savings', moneyType: 'bank', currencyCode: 'GBP', openingBalance: '0', reconstructedBalance: '0', closed: true, openDate: '2009-01-01', closeDate: '2015-06-01', comment: 'closed' },
+      { id: 3, name: 'Amex', moneyType: 'credit', currencyCode: 'GBP', openingBalance: '0', reconstructedBalance: '-27368.77', closed: false, openDate: '2012-01-01', closeDate: null, comment: null },
+    ],
+    categories: [
+      { id: 130, name: 'INCOME', parentId: null, level: 0, fullPath: 'INCOME', hidden: false, kind: 'income' },
+      { id: 131, name: 'EXPENSE', parentId: null, level: 0, fullPath: 'EXPENSE', hidden: false, kind: 'expense' },
+      { id: 200, name: 'Bills', parentId: 131, level: 1, fullPath: 'EXPENSE : Bills', hidden: false, kind: 'expense' },
+      { id: 201, name: 'Telephone', parentId: 200, level: 2, fullPath: 'EXPENSE : Bills : Telephone', hidden: false, kind: 'expense' },
+      { id: 202, name: 'Old Thing', parentId: 200, level: 2, fullPath: 'EXPENSE : Bills : Old Thing', hidden: true, kind: 'expense' },
+      { id: 210, name: 'Salary', parentId: 130, level: 1, fullPath: 'INCOME : Salary', hidden: false, kind: 'income' },
+    ],
+    payees: [
+      { id: 50, name: 'BT', parentId: null, hidden: false },
+      { id: 51, name: 'ACME LTD', parentId: null, hidden: false },
+    ],
+    transactions: [
+      // standalone expense with payee + category
+      { id: 1000, accountId: 1, date: '2020-05-01', amount: '-42.50', categoryId: 201, payeeId: 50, memo: 'line rental', ref: 'DD1', clearedStatus: 2, linkAccountId: null, role: 'standalone' },
+      // standalone income (salary)
+      { id: 1001, accountId: 1, date: '2020-05-25', amount: '2500.00', categoryId: 210, payeeId: 51, memo: null, ref: null, clearedStatus: 1, linkAccountId: null, role: 'standalone' },
+      // transfer pair between acct 1 and acct 3
+      { id: 1002, accountId: 1, date: '2020-06-01', amount: '-100.00', categoryId: null, payeeId: null, memo: 'pay card', ref: null, clearedStatus: 0, linkAccountId: 3, role: 'transfer', transferPairTxnId: 1003 },
+      { id: 1003, accountId: 3, date: '2020-06-01', amount: '100.00', categoryId: null, payeeId: null, memo: 'pay card', ref: null, clearedStatus: 0, linkAccountId: 1, role: 'transfer', transferPairTxnId: 1002 },
+      // balanced split: parent -100 = -70 + -30
+      { id: 1010, accountId: 1, date: '2020-07-01', amount: '-100.00', categoryId: null, payeeId: 51, memo: null, ref: null, clearedStatus: 2, linkAccountId: null, role: 'splitParent' },
+      { id: 1011, accountId: 1, date: '2020-07-01', amount: '-70.00', categoryId: 201, payeeId: null, memo: 'phone', ref: null, clearedStatus: 2, linkAccountId: null, role: 'splitChild', splitParentId: 1010 },
+      { id: 1012, accountId: 1, date: '2020-07-01', amount: '-30.00', categoryId: 202, payeeId: null, memo: null, ref: null, clearedStatus: 2, linkAccountId: null, role: 'splitChild', splitParentId: 1010 },
+      // partial split: parent -251.99 but child only covers -250.00
+      { id: 1020, accountId: 1, date: '2020-08-01', amount: '-251.99', categoryId: null, payeeId: 51, memo: null, ref: null, clearedStatus: 2, linkAccountId: null, role: 'splitParent' },
+      { id: 1021, accountId: 1, date: '2020-08-01', amount: '-250.00', categoryId: 201, payeeId: null, memo: null, ref: null, clearedStatus: 2, linkAccountId: null, role: 'splitChild', splitParentId: 1020 },
+    ],
+    ...over,
+  };
+}
+
+describe('transformMsMoneyExport — accounts', () => {
+  it('maps types, closed→inactive, and uses the reconstructed balance (never the dead stored one)', () => {
+    const { accounts } = transformMsMoneyExport(build(), NOW);
+    const hsbc = accounts.find(a => a.id === 'mny-acct-1')!;
+    expect(hsbc.type).toBe('current');
+    expect(hsbc.balance).toBe(150.5);
+    expect(hsbc.isActive).toBe(true);
+
+    const old = accounts.find(a => a.id === 'mny-acct-2')!;
+    expect(old.isActive).toBe(false); // closed → inactive, never deleted
+
+    const amex = accounts.find(a => a.id === 'mny-acct-3')!;
+    expect(amex.type).toBe('credit');
+    expect(amex.balance).toBe(-27368.77); // liability shows negative
+  });
+});
+
+describe('transformMsMoneyExport — categories', () => {
+  it('maps Money 3-level tree onto type/sub/detail with the system type parents', () => {
+    const { categories } = transformMsMoneyExport(build(), NOW);
+    expect(categories.find(c => c.id === 'type-income')?.level).toBe('type');
+
+    const bills = categories.find(c => c.id === 'mny-cat-200')!;
+    expect(bills.level).toBe('sub');
+    expect(bills.parentId).toBe('type-expense');
+
+    const phone = categories.find(c => c.id === 'mny-cat-201')!;
+    expect(phone.level).toBe('detail');
+    expect(phone.parentId).toBe('mny-cat-200');
+    expect(phone.type).toBe('expense');
+  });
+
+  it('marks hidden Money categories inactive (kept, but out of the pickers)', () => {
+    const { categories, summary } = transformMsMoneyExport(build(), NOW);
+    expect(categories.find(c => c.id === 'mny-cat-202')?.isActive).toBe(false);
+    expect(summary.categories.hidden).toBe(1);
+  });
+});
+
+describe('transformMsMoneyExport — transactions', () => {
+  it('maps standalone rows with payee as description, sign-derived type, reconciled→cleared', () => {
+    const { transactions } = transformMsMoneyExport(build(), NOW);
+    const t = transactions.find(x => x.id === 'mny-txn-1000')!;
+    expect(t.description).toBe('BT');
+    expect(t.amount).toBe(-42.5);
+    expect(t.type).toBe('expense');
+    expect(t.category).toBe('mny-cat-201');
+    expect(t.cleared).toBe(true); // cs 2
+    expect(t.notes).toBe('line rental'); // memo kept as notes (distinct payee)
+
+    const inc = transactions.find(x => x.id === 'mny-txn-1001')!;
+    expect(inc.type).toBe('income');
+    expect(inc.cleared).toBe(false); // cs 1 is not reconciled
+  });
+
+  it('imports transfers as two linked transfer transactions filed under To/From categories', () => {
+    const { transactions, categories } = transformMsMoneyExport(build(), NOW);
+    const a = transactions.find(x => x.id === 'mny-txn-1002')!;
+    const b = transactions.find(x => x.id === 'mny-txn-1003')!;
+    expect(a.type).toBe('transfer');
+    expect(a.transferAccountId).toBe('mny-acct-3');
+    expect(a.linkedTransferId).toBe('mny-txn-1003');
+    expect(b.transferAccountId).toBe('mny-acct-1');
+    expect(b.linkedTransferId).toBe('mny-txn-1002');
+    expect(a.amount + b.amount).toBe(0); // both legs net to zero
+
+    // Each leg is filed under the OTHER account's "To/From <account>" category.
+    expect(a.category).toBe('mny-tofrom-3');
+    expect(b.category).toBe('mny-tofrom-1');
+    const tf3 = categories.find(c => c.id === 'mny-tofrom-3')!;
+    expect(tf3.isTransferCategory).toBe(true);
+    expect(tf3.accountId).toBe('mny-acct-3');
+    expect(tf3.parentId).toBe('type-transfer');
+    expect(tf3.name).toBe('To/From Amex');
+  });
+
+  it('imports a balanced split as one split transaction whose lines sum to the total', () => {
+    const { transactions, transactionSplits, summary } = transformMsMoneyExport(build(), NOW);
+    const parent = transactions.find(x => x.id === 'mny-txn-1010')!;
+    expect(parent.isSplit).toBe(true);
+    expect(parent.category).toBe('');
+    const lines = transactionSplits.filter(s => s.transactionId === 'mny-txn-1010');
+    expect(lines).toHaveLength(2);
+    expect(lines.reduce((s, l) => s + l.amount, 0)).toBe(parent.amount); // -100
+    expect(lines.map(l => l.category)).toEqual(['mny-cat-201', 'mny-cat-202']);
+    // the split children are NOT also emitted as standalone transactions
+    expect(transactions.find(x => x.id === 'mny-txn-1011')).toBeUndefined();
+    // build() has TWO split parents (1010 balanced + 1020 partial); 1010 → 2
+    // lines, 1020 → 1 child + 1 Unassigned remainder = 4 lines total.
+    expect(summary.transactions.splitTransactions).toBe(2);
+    expect(summary.transactions.splitLines).toBe(4);
+  });
+
+  it('imports a PARTIAL split as a split whose lines (incl. an Unassigned remainder) sum to the exact total', () => {
+    const { transactions, transactionSplits, categories } = transformMsMoneyExport(build(), NOW);
+    const parent = transactions.find(x => x.id === 'mny-txn-1020')!;
+    expect(parent.isSplit).toBe(true);
+    expect(parent.amount).toBe(-251.99);
+    const lines = transactionSplits.filter(s => s.transactionId === 'mny-txn-1020');
+    // the recorded child (-250) + an Unassigned remainder (-1.99)
+    expect(lines).toHaveLength(2);
+    const remainder = lines.find(l => l.category === 'mny-unassigned')!;
+    expect(remainder.amount).toBeCloseTo(-1.99, 2);
+    expect(lines.reduce((s, l) => s + l.amount, 0)).toBeCloseTo(-251.99, 2);
+    // the Unassigned category exists
+    expect(categories.find(c => c.id === 'mny-unassigned')?.level).toBe('detail');
+    // the child is not also emitted as a standalone transaction
+    expect(transactions.find(x => x.id === 'mny-txn-1021')).toBeUndefined();
+  });
+
+  it('corrects sign-flipped liability-account splits so the lines sum to the parent', () => {
+    // Parent +200 in a liability account, children recorded as -120 + -80.
+    const exp = build({
+      transactions: [
+        { id: 3000, accountId: 3, date: '2021-01-01', amount: '200.00', categoryId: null, payeeId: null, memo: null, ref: null, clearedStatus: 2, linkAccountId: null, role: 'splitParent' },
+        { id: 3001, accountId: 3, date: '2021-01-01', amount: '-120.00', categoryId: 201, payeeId: null, memo: null, ref: null, clearedStatus: 2, linkAccountId: null, role: 'splitChild', splitParentId: 3000 },
+        { id: 3002, accountId: 3, date: '2021-01-01', amount: '-80.00', categoryId: 201, payeeId: null, memo: null, ref: null, clearedStatus: 2, linkAccountId: null, role: 'splitChild', splitParentId: 3000 },
+      ],
+    });
+    const { transactionSplits, summary } = transformMsMoneyExport(exp, NOW);
+    const lines = transactionSplits.filter(s => s.transactionId === 'mny-txn-3000');
+    expect(lines.map(l => l.amount)).toEqual([120, 80]); // signs flipped to match parent
+    expect(lines.reduce((s, l) => s + l.amount, 0)).toBe(200);
+    expect(summary.simplifications.some(s => /sign/.test(s))).toBe(true);
+  });
+
+  it('links a transfer whose partner is a split line BIDIRECTIONALLY (line ↔ counterpart)', () => {
+    // A split in account 1 has a line that transfers to account 3; account 3's
+    // counterpart leg (id 4001) points back at the split child (4000).
+    const exp = build({
+      transactions: [
+        { id: 3500, accountId: 1, date: '2021-02-01', amount: '-100.00', categoryId: null, payeeId: null, memo: null, ref: null, clearedStatus: 2, linkAccountId: null, role: 'splitParent' },
+        { id: 3501, accountId: 1, date: '2021-02-01', amount: '-70.00', categoryId: 201, payeeId: null, memo: null, ref: null, clearedStatus: 2, linkAccountId: null, role: 'splitChild', splitParentId: 3500 },
+        { id: 4000, accountId: 1, date: '2021-02-01', amount: '-30.00', categoryId: null, payeeId: null, memo: null, ref: null, clearedStatus: 2, linkAccountId: 3, role: 'splitChild', splitParentId: 3500, isTransferLine: true, transferPairTxnId: 4001 },
+        { id: 4001, accountId: 3, date: '2021-02-01', amount: '30.00', categoryId: null, payeeId: null, memo: null, ref: null, clearedStatus: 2, linkAccountId: 1, role: 'transfer', transferPairTxnId: 4000 },
+      ],
+    });
+    const { transactions, transactionSplits, summary } = transformMsMoneyExport(exp, NOW);
+    // the split's transfer line is categorised To/From account 3 AND carries
+    // the leg fields pointing at the counterpart transaction
+    const line = transactionSplits
+      .filter(s => s.transactionId === 'mny-txn-3500')
+      .find(l => l.amount === -30)!;
+    expect(line.category).toBe('mny-tofrom-3');
+    expect(line.transferAccountId).toBe('mny-acct-3');
+    expect(line.linkedTransferId).toBe('mny-txn-4001');
+    // a plain category line carries NO leg fields
+    const plainLine = transactionSplits.find(s => s.id === 'mny-split-3500-1')!;
+    expect(plainLine.linkedTransferId).toBeUndefined();
+    // the counterpart leg links back: at the split PARENT, pinned to the line
+    const counterpart = transactions.find(x => x.id === 'mny-txn-4001')!;
+    expect(counterpart.type).toBe('transfer');
+    expect(counterpart.category).toBe('mny-tofrom-1');
+    expect(counterpart.linkedTransferId).toBe('mny-txn-3500');
+    expect(counterpart.linkedTransferSplitId).toBe(line.id);
+    // the split child is not also emitted as its own transaction
+    expect(transactions.find(x => x.id === 'mny-txn-4000')).toBeUndefined();
+    expect(summary.simplifications.some(s => /fully linked/.test(s))).toBe(true);
+  });
+
+  it('per-account reconstructed balance equals opening + Σ(its imported non-split-child amounts)', () => {
+    // The app's ledger invariant. Sum every imported transaction for account 1
+    // (standalone + transfer leg + split parent totals) and check it matches
+    // the account's reconstructed balance the extractor computed.
+    const exp = build();
+    const { accounts, transactions } = transformMsMoneyExport(exp, NOW);
+    const acct1 = accounts.find(a => a.id === 'mny-acct-1')!;
+    const sum = transactions
+      .filter(t => t.accountId === 'mny-acct-1')
+      .reduce((s, t) => s + t.amount, 0);
+    const computed = (acct1.openingBalance ?? 0) + sum;
+    // -42.50 + 2500 - 100 (transfer out) - 100 (split) - 251.99 (partial) = 2005.51
+    expect(computed).toBeCloseTo(2005.51, 2);
+  });
+});

--- a/src/services/import/msMoney/transform.ts
+++ b/src/services/import/msMoney/transform.ts
@@ -1,0 +1,486 @@
+import { toDecimal } from '../../../utils/decimal';
+import type { Account, Category, Transaction, TransactionSplit } from '../../../types';
+
+/**
+ * Microsoft Money → WealthTracker transform.
+ *
+ * Input is the normalised JSON produced by the native .mny reader (Jackcess +
+ * Jackcess-Encrypt): every account, transaction, category and payee, with
+ * amounts as EXACT decimal strings. This module maps that faithfully onto the
+ * app's own model — and it maps cleanly because Money's internal model IS the
+ * app's model: transfers as linked pairs, splits as a parent whose children
+ * carry the categories, closed-not-deleted accounts, a 3-level category tree,
+ * payee-per-transaction.
+ *
+ * Money is parsed through Decimal (never float) and stored as the app's
+ * numeric amount at the boundary, exactly as the rest of the app stores it.
+ *
+ * The output is the four collections the app persists locally
+ * (accounts / categories / transactions / transaction splits), plus a summary
+ * of what was imported and what was simplified — so a human can check it.
+ */
+
+// ── Input shapes (from the .mny export JSON) ────────────────────────────────
+
+export interface MnyAccount {
+  id: number;
+  name: string;
+  moneyType: 'bank' | 'credit' | 'cash' | 'asset' | 'liability' | 'investment' | string;
+  currencyCode: string | null;
+  openingBalance: string;
+  reconstructedBalance: string;
+  closed: boolean;
+  openDate: string | null;
+  closeDate: string | null;
+  comment: string | null;
+}
+
+export interface MnyCategory {
+  id: number;
+  name: string;
+  parentId: number | null;
+  level: number; // 0 = INCOME/EXPENSE root, 1 = sub, 2 = detail
+  fullPath: string;
+  hidden: boolean;
+  kind: 'income' | 'expense';
+}
+
+export interface MnyPayee {
+  id: number;
+  name: string;
+  parentId: number | null;
+  hidden: boolean;
+}
+
+export type MnyRole = 'standalone' | 'splitParent' | 'splitChild' | 'transfer';
+
+export interface MnyTransaction {
+  id: number;
+  accountId: number;
+  date: string | null;      // ISO yyyy-MM-dd (extractor already nulled the year-9999 sentinel)
+  amount: string;           // signed decimal string, base currency
+  categoryId: number | null;
+  payeeId: number | null;
+  memo: string | null;
+  ref: string | null;
+  clearedStatus: number;    // 0 unreconciled, 1 cleared, 2 reconciled
+  linkAccountId: number | null;
+  role: MnyRole;
+  splitParentId?: number | null;
+  transferPairTxnId?: number | null;
+  // v2 enrichments (from the split-anomaly forensics):
+  isTransferLine?: boolean;             // a split child that is itself a transfer
+  splitChildCount?: number;             // on split parents
+  splitChildSum?: string;               // on split parents
+  splitUnassignedRemainder?: string;    // on split parents
+  splitReconciles?: boolean;            // on split parents
+}
+
+export interface MnyExport {
+  accounts: MnyAccount[];
+  categories: MnyCategory[];
+  payees: MnyPayee[];
+  transactions: MnyTransaction[];
+}
+
+// ── Output ──────────────────────────────────────────────────────────────────
+
+export interface MsMoneyImportResult {
+  accounts: Account[];
+  categories: Category[];
+  transactions: Transaction[];
+  transactionSplits: TransactionSplit[];
+  summary: MsMoneyImportSummary;
+}
+
+export interface MsMoneyImportSummary {
+  accounts: { total: number; open: number; closed: number };
+  categories: { subs: number; details: number; hidden: number };
+  transactions: {
+    imported: number;
+    standalone: number;
+    transfers: number;
+    splitTransactions: number;
+    splitLines: number;
+  };
+  simplifications: string[];
+}
+
+// Stable, traceable ids so a re-run is idempotent and rows are debuggable.
+const acctId = (h: number): string => `mny-acct-${h}`;
+const catId = (h: number): string => `mny-cat-${h}`;
+const txnId = (h: number): string => `mny-txn-${h}`;
+const splitId = (parentH: number, seq: number): string => `mny-split-${parentH}-${seq}`;
+// The per-account "To/From <account>" transfer category, mirroring the app's
+// native account-managed transfer categories.
+const transferCatId = (h: number): string => `mny-tofrom-${h}`;
+
+const TYPE_ID: Record<'income' | 'expense', string> = {
+  income: 'type-income',
+  expense: 'type-expense',
+};
+
+// The uncategorised remainder of a partial Money split gets its own detail
+// category, so a partial split still visually sums to its total (Money itself
+// left that portion uncategorised in some months).
+const UNASSIGNED_CAT_ID = 'mny-unassigned';
+
+/** Money's account super-type → the app's account type. */
+const mapAccountType = (moneyType: string): Account['type'] => {
+  switch (moneyType) {
+    case 'bank': return 'current';
+    case 'credit': return 'credit';
+    case 'cash': return 'current';
+    case 'asset': return 'asset';
+    case 'liability': return 'liability';
+    case 'investment': return 'investment';
+    default: return 'other';
+  }
+};
+
+const toNumber = (decimalString: string): number => toDecimal(decimalString).toNumber();
+
+const isoToDate = (iso: string): Date => new Date(`${iso}T00:00:00.000Z`);
+
+// ── Accounts ─────────────────────────────────────────────────────────────────
+
+function transformAccounts(mny: MnyAccount[], nowIso: string): Account[] {
+  return mny.map((a): Account => {
+    // The app computes running balance as openingBalance + Σtransactions — the
+    // SAME invariant Money uses. Money's opening is authoritative; its stored
+    // "current" balance is a dead cache (uninitialised memory) so we never use
+    // it. The reconstructed balance rides along as the display `balance`; the
+    // ledger recomputes it from the imported transactions and must agree.
+    return {
+      id: acctId(a.id),
+      name: a.name,
+      type: mapAccountType(a.moneyType),
+      balance: toNumber(a.reconstructedBalance),
+      openingBalance: toNumber(a.openingBalance),
+      openingBalanceDate: a.openDate ? isoToDate(a.openDate) : undefined,
+      currency: a.currencyCode || 'GBP',
+      isActive: !a.closed,
+      notes: a.comment || undefined,
+      lastUpdated: new Date(nowIso),
+      createdAt: a.openDate ? isoToDate(a.openDate) : new Date(nowIso),
+      updatedAt: new Date(nowIso),
+    };
+  });
+}
+
+// ── Categories (Money's 3-level tree → the app's type/sub/detail) ───────────
+
+function transformCategories(mny: MnyCategory[]): { categories: Category[]; hiddenCount: number } {
+  const categories: Category[] = [
+    { id: 'type-income', name: 'Income', type: 'income', level: 'type', isSystem: true },
+    { id: 'type-expense', name: 'Expense', type: 'expense', level: 'type', isSystem: true },
+    { id: 'type-transfer', name: 'Transfer', type: 'both', level: 'type', isSystem: true },
+    // Holds the uncategorised remainder of Money's partial splits.
+    { id: UNASSIGNED_CAT_ID, name: 'Unassigned (MS Money import)', type: 'both', level: 'detail', parentId: 'type-expense' },
+  ];
+  let hiddenCount = 0;
+
+  for (const c of mny) {
+    if (c.level === 0) continue; // INCOME/EXPENSE roots → the app's system type ids
+    if (c.hidden) hiddenCount++;
+    categories.push({
+      id: catId(c.id),
+      name: c.name,
+      type: c.kind,
+      level: c.level === 1 ? 'sub' : 'detail',
+      parentId: c.level === 1 ? TYPE_ID[c.kind] : catId(c.parentId as number),
+      // Money "hidden" ≈ the app's inactive: kept for existing transactions,
+      // hidden from the category pickers.
+      isActive: !c.hidden,
+    });
+  }
+  return { categories, hiddenCount };
+}
+
+// ── Transactions ─────────────────────────────────────────────────────────────
+
+function transformTransactions(
+  exp: MnyExport,
+  // hacct → the "To/From <account>" category id, so each transfer leg is filed
+  // under the OTHER account's transfer category (the app's native model).
+  toFromByAccount: Map<number, string>
+): {
+  transactions: Transaction[];
+  splits: TransactionSplit[];
+  counts: MsMoneyImportSummary['transactions'];
+  simplifications: string[];
+} {
+  const payeeName = new Map<number, string>(exp.payees.map(p => [p.id, p.name]));
+  // Only categories the app actually emits (Money levels 1/2) are valid
+  // targets; a line categorised at a Money ROOT (INCOME/EXPENSE) has no app
+  // equivalent and becomes uncategorised.
+  const emittedCatIds = new Set<number>(exp.categories.filter(c => c.level >= 1).map(c => c.id));
+
+  // Split children grouped under their parent, and the set of all split-child
+  // ids (a transfer whose partner is a split child needs special handling).
+  const childrenByParent = new Map<number, MnyTransaction[]>();
+  const splitChildIds = new Set<number>();
+  for (const t of exp.transactions) {
+    if (t.role === 'splitChild' && t.splitParentId != null) {
+      splitChildIds.add(t.id);
+      const list = childrenByParent.get(t.splitParentId);
+      if (list) list.push(t);
+      else childrenByParent.set(t.splitParentId, [t]);
+    }
+  }
+
+  // A transfer whose partner is a split LINE links to that line, so the line
+  // ids (and each child's parent) are fixed up front — same numbering the
+  // emitting loop uses (children in encounter order, 1-based).
+  const splitLineIdByChild = new Map<number, string>();
+  const splitParentByChild = new Map<number, number>();
+  for (const [parentId, kids] of childrenByParent) {
+    kids.forEach((k, i) => {
+      splitLineIdByChild.set(k.id, splitId(parentId, i + 1));
+      splitParentByChild.set(k.id, parentId);
+    });
+  }
+
+  const transactions: Transaction[] = [];
+  const splits: TransactionSplit[] = [];
+  const counts = { imported: 0, standalone: 0, transfers: 0, splitTransactions: 0, splitLines: 0 };
+  let remainderLines = 0;    // "Unassigned" lines added to genuinely-partial splits
+  let signFlipped = 0;       // liability-account splits with inverted child signs
+  let splitLegTransfers = 0; // transfer legs whose partner is a line inside a split
+
+  const resolveCategory = (categoryId: number | null): string =>
+    categoryId != null && emittedCatIds.has(categoryId) ? catId(categoryId) : '';
+
+  const describe = (t: MnyTransaction): string => {
+    const payee = t.payeeId != null ? payeeName.get(t.payeeId) : undefined;
+    return (payee && payee.trim()) || (t.memo && t.memo.trim()) || 'Imported transaction';
+  };
+
+  // The memo becomes notes only when a distinct payee already supplied the
+  // description, so we never duplicate the same text into both fields.
+  const notesOf = (t: MnyTransaction): string | undefined => {
+    const payee = t.payeeId != null ? payeeName.get(t.payeeId) : undefined;
+    return payee && t.memo ? t.memo : undefined;
+  };
+
+  const baseFields = (t: MnyTransaction) => ({
+    date: isoToDate(t.date as string),
+    description: describe(t),
+    accountId: acctId(t.accountId),
+    // Money cs: 2 = reconciled (the app's "cleared"); 0/1 are not.
+    cleared: t.clearedStatus === 2,
+    notes: notesOf(t),
+    bankReference: t.ref || undefined,
+  });
+
+  // A split LINE's category: a transfer line → the destination account's
+  // To/From category; otherwise its own mapped category.
+  const lineCategory = (k: MnyTransaction): string =>
+    k.isTransferLine && k.linkAccountId != null
+      ? (toFromByAccount.get(k.linkAccountId) ?? '')
+      : resolveCategory(k.categoryId);
+
+  for (const t of exp.transactions) {
+    if (t.role === 'splitChild') continue; // consumed by their parent below
+
+    if (t.role === 'transfer') {
+      const amount = toNumber(t.amount);
+      const toFrom = t.linkAccountId != null ? toFromByAccount.get(t.linkAccountId) : undefined;
+      // If this transfer's PARTNER is a split line (a transfer recorded inside
+      // another account's split), the pair still links fully: this leg points
+      // at the split PARENT, and linkedTransferSplitId pins the exact line
+      // that is the opposite leg. The line points back (see the split branch).
+      const partnerIsSplitLine =
+        t.transferPairTxnId != null && splitChildIds.has(t.transferPairTxnId);
+      if (partnerIsSplitLine) splitLegTransfers++;
+      transactions.push({
+        id: txnId(t.id),
+        ...baseFields(t),
+        amount,
+        type: 'transfer',
+        category: toFrom ?? '',
+        transferAccountId: t.linkAccountId != null ? acctId(t.linkAccountId) : undefined,
+        linkedTransferId: partnerIsSplitLine
+          ? txnId(splitParentByChild.get(t.transferPairTxnId as number) as number)
+          : t.transferPairTxnId != null ? txnId(t.transferPairTxnId) : undefined,
+        linkedTransferSplitId: partnerIsSplitLine
+          ? splitLineIdByChild.get(t.transferPairTxnId as number)
+          : undefined,
+      } as Transaction);
+      counts.transfers++;
+      counts.imported++;
+      continue;
+    }
+
+    if (t.role === 'splitParent') {
+      const kids = childrenByParent.get(t.id) ?? [];
+      const parentAmount = toDecimal(t.amount);
+      let childAmounts = kids.map(k => toDecimal(k.amount));
+      let childSum = childAmounts.reduce((s, a) => s.plus(a), toDecimal(0));
+
+      // Sign-flip artifact (Money liability accounts): children carry the
+      // parent's magnitude with inverted sign. Negate them so they sum to the
+      // parent — the category breakdown is right, only the sign convention
+      // differed.
+      if (!childSum.equals(parentAmount) && childSum.equals(parentAmount.negated()) && !parentAmount.isZero()) {
+        childAmounts = childAmounts.map(a => a.negated());
+        childSum = childSum.negated();
+        signFlipped++;
+      }
+
+      const parentAppId = txnId(t.id);
+      transactions.push({
+        id: parentAppId,
+        ...baseFields(t),
+        amount: toNumber(t.amount),
+        type: parentAmount.isNegative() ? 'expense' : 'income',
+        category: '',
+        isSplit: true,
+      } as Transaction);
+
+      let seq = 0;
+      kids.forEach((k, i) => {
+        // A transfer line links to its counterpart transaction — but only when
+        // that counterpart is a real top-level row (never another split line).
+        const isLinkedLeg =
+          k.isTransferLine === true &&
+          k.linkAccountId != null &&
+          k.transferPairTxnId != null &&
+          !splitChildIds.has(k.transferPairTxnId);
+        splits.push({
+          id: splitId(t.id, ++seq),
+          transactionId: parentAppId,
+          category: lineCategory(k),
+          amount: childAmounts[i].toNumber(),
+          memo: k.memo || undefined,
+          sortOrder: seq,
+          ...(isLinkedLeg
+            ? {
+                transferAccountId: acctId(k.linkAccountId as number),
+                linkedTransferId: txnId(k.transferPairTxnId as number),
+              }
+            : {}),
+        });
+        counts.splitLines++;
+      });
+
+      // Genuine partial split (Money never recorded the rest): add an
+      // "Unassigned" line for the remainder so the split still sums to the
+      // parent total — nothing invented, just made explicit.
+      const remainder = parentAmount.minus(childSum);
+      if (!remainder.isZero()) {
+        splits.push({
+          id: splitId(t.id, ++seq),
+          transactionId: parentAppId,
+          category: UNASSIGNED_CAT_ID,
+          amount: remainder.toNumber(),
+          sortOrder: seq,
+        });
+        counts.splitLines++;
+        remainderLines++;
+      }
+
+      counts.splitTransactions++;
+      counts.imported++;
+      continue;
+    }
+
+    // standalone
+    const amount = toNumber(t.amount);
+    transactions.push({
+      id: txnId(t.id),
+      ...baseFields(t),
+      amount,
+      type: amount < 0 ? 'expense' : 'income',
+      category: resolveCategory(t.categoryId),
+    } as Transaction);
+    counts.standalone++;
+    counts.imported++;
+  }
+
+  const simplifications: string[] = [];
+  if (remainderLines > 0) {
+    simplifications.push(
+      `${remainderLines} split(s) that MS Money left partially uncategorised now carry an "Unassigned (MS Money import)" line for the remainder, so every split sums to its exact total.`
+    );
+  }
+  if (signFlipped > 0) {
+    simplifications.push(
+      `${signFlipped} split(s) in liability accounts had their category-line signs corrected so the lines sum to the parent total.`
+    );
+  }
+  if (splitLegTransfers > 0) {
+    simplifications.push(
+      `${splitLegTransfers} transfer(s) whose counterpart is a line inside a split are fully linked — the split line and the opposite transaction reference each other bidirectionally.`
+    );
+  }
+
+  return { transactions, splits, counts, simplifications };
+}
+
+// ── Top level ─────────────────────────────────────────────────────────────────
+
+/**
+ * A "To/From <account>" transfer category for every account that appears as a
+ * transfer counterpart — mirroring the app's account-managed transfer
+ * categories, so imported transfers read "To/From <account>" and populate the
+ * Transfer Categories section.
+ */
+function buildTransferCategories(
+  mnyAccounts: MnyAccount[],
+  transactions: MnyTransaction[]
+): { categories: Category[]; byAccount: Map<number, string> } {
+  const nameById = new Map<number, MnyAccount>(mnyAccounts.map(a => [a.id, a]));
+  const targets = new Set<number>();
+  for (const t of transactions) {
+    // Targets come from both standalone transfers AND split lines that are
+    // themselves transfers — each needs its counterpart's To/From category.
+    if (t.linkAccountId != null && (t.role === 'transfer' || (t.role === 'splitChild' && t.isTransferLine))) {
+      targets.add(t.linkAccountId);
+    }
+  }
+  const categories: Category[] = [];
+  const byAccount = new Map<number, string>();
+  for (const hacct of targets) {
+    const acct = nameById.get(hacct);
+    if (!acct) continue;
+    const id = transferCatId(hacct);
+    byAccount.set(hacct, id);
+    categories.push({
+      id,
+      name: `To/From ${acct.name}`,
+      type: 'both',
+      level: 'detail',
+      parentId: 'type-transfer',
+      isTransferCategory: true,
+      accountId: acctId(hacct),
+      isActive: !acct.closed,
+    });
+  }
+  return { categories, byAccount };
+}
+
+export function transformMsMoneyExport(exp: MnyExport, nowIso: string): MsMoneyImportResult {
+  const accounts = transformAccounts(exp.accounts, nowIso);
+  const { categories, hiddenCount } = transformCategories(exp.categories);
+  const transfer = buildTransferCategories(exp.accounts, exp.transactions);
+  categories.push(...transfer.categories);
+  const { transactions, splits, counts, simplifications } = transformTransactions(exp, transfer.byAccount);
+
+  const summary: MsMoneyImportSummary = {
+    accounts: {
+      total: accounts.length,
+      open: accounts.filter(a => a.isActive !== false).length,
+      closed: accounts.filter(a => a.isActive === false).length,
+    },
+    categories: {
+      subs: categories.filter(c => c.level === 'sub').length,
+      details: categories.filter(c => c.level === 'detail').length,
+      hidden: hiddenCount,
+    },
+    transactions: counts,
+    simplifications,
+  };
+
+  return { accounts, categories, transactions, transactionSplits: splits, summary };
+}

--- a/src/types/decimal-types.ts
+++ b/src/types/decimal-types.ts
@@ -25,7 +25,7 @@ export interface DecimalHolding {
 export interface DecimalAccount {
   id: string;
   name: string;
-  type: 'current' | 'savings' | 'credit' | 'loan' | 'investment' | 'asset' | 'mortgage' | 'assets' | 'other' | 'checking';
+  type: 'current' | 'savings' | 'credit' | 'loan' | 'investment' | 'asset' | 'liability' | 'mortgage' | 'assets' | 'other' | 'checking';
   balance: DecimalInstance;
   currency: string;
   institution?: string;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -16,7 +16,7 @@ export interface Holding {
 export interface Account {
   id: string;
   name: string;
-  type: 'current' | 'savings' | 'credit' | 'loan' | 'investment' | 'asset' | 'mortgage' | 'assets' | 'other' | 'checking';
+  type: 'current' | 'savings' | 'credit' | 'loan' | 'investment' | 'asset' | 'liability' | 'mortgage' | 'assets' | 'other' | 'checking';
   balance: number;
   currency: string;
   institution?: string;
@@ -82,6 +82,13 @@ export interface Transaction {
   addedBy?: string; // Member ID who added this transaction
   linkedTransferId?: string; // ID of the corresponding transfer transaction in the other account
   transferAccountId?: string; // Account ID of the other side of a transfer
+  /**
+   * When the linked side is a SPLIT transaction (this leg's opposite is one
+   * line inside it, not the whole row): the id of that TransactionSplit line.
+   * linkedTransferId then points at the split parent. Absent for ordinary
+   * transaction↔transaction pairs.
+   */
+  linkedTransferSplitId?: string;
 
   // Transfer-specific metadata for wealth management
   transferMetadata?: {
@@ -152,6 +159,15 @@ export interface TransactionSplit {
   amount: number;
   memo?: string;
   sortOrder: number;
+  /**
+   * Set when this LINE is one leg of a transfer (the Microsoft Money model —
+   * a transfer recorded inside a split): the account on the other side, and
+   * the counterpart transaction over there. The counterpart's
+   * linkedTransferId points back at this line's parent transaction, and its
+   * linkedTransferSplitId at this line.
+   */
+  transferAccountId?: string;
+  linkedTransferId?: string;
 }
 
 /** Input for creating/replacing a transaction's splits (ids are server-assigned). */

--- a/src/utils/mnyLocalImport.ts
+++ b/src/utils/mnyLocalImport.ts
@@ -1,0 +1,90 @@
+import { STORAGE_KEYS } from '../services/storageAdapter';
+import { createScopedLogger } from '../loggers/scopedLogger';
+
+/**
+ * DEV-ONLY local preview loader for the MS Money import.
+ *
+ * Purely a proving harness — NOT the shippable feature. Gated to
+ * `import.meta.env.DEV`; a no-op in production builds. It reads the gitignored
+ * `.mny-local/mny-local-seed.json` (produced by `scripts/mnyLocalImport.mts`,
+ * served at /mny-local-seed.json by a dev-only Vite middleware — never part
+ * of a build) and
+ * writes it into local storage exactly the way demo mode seeds data, so the
+ * whole Microsoft Money file can be browsed in a purely local WealthTracker —
+ * no cloud, no live data.
+ *
+ * Activate with `?demo=true&mnyimport=local` on localhost:
+ *   - `demo=true` rides the existing demo auth-bypass (view without signing in)
+ *     and puts the app in local-storage mode.
+ *   - `mnyimport=local` suppresses the demo SAMPLE data and injects the Money
+ *     seed instead (see App.tsx bootstrap).
+ */
+
+const logger = createScopedLogger('MnyLocalImport');
+const LOADED_FLAG = 'mny_local_seed_loaded';
+
+export function isMnyLocalImportRequested(): boolean {
+  if (!import.meta.env.DEV || typeof window === 'undefined') return false;
+  return new URLSearchParams(window.location.search).get('mnyimport') === 'local';
+}
+
+interface MnySeed {
+  accounts: unknown[];
+  categories: unknown[];
+  transactions: unknown[];
+  transactionSplits: unknown[];
+  summary?: unknown;
+}
+
+/**
+ * Write the seed into local storage once, then reload so the app reads it.
+ * Idempotent within a session via a sessionStorage flag; the caller must NOT
+ * also run initializeDemoData when this is active.
+ */
+export async function loadMnyLocalSeed(): Promise<void> {
+  if (!import.meta.env.DEV || typeof window === 'undefined') return;
+
+  // Already injected this session — the app is about to read it; do nothing.
+  if (window.sessionStorage.getItem(LOADED_FLAG) === 'true') {
+    return;
+  }
+
+  try {
+    const res = await fetch('/mny-local-seed.json', { cache: 'no-store' });
+    if (!res.ok) {
+      logger.error('Seed fetch failed', { status: res.status });
+      return;
+    }
+    const seed = (await res.json()) as MnySeed;
+
+    // Mirror initializeDemoData's storage contract exactly: the wealthtracker_-
+    // prefixed keys, plus the transaction-splits key, then force the
+    // localStorage→IndexedDB migration so the fresh seed is picked up.
+    window.localStorage.setItem(STORAGE_KEYS.ACCOUNTS, JSON.stringify(seed.accounts));
+    window.localStorage.setItem(STORAGE_KEYS.TRANSACTIONS, JSON.stringify(seed.transactions));
+    window.localStorage.setItem(STORAGE_KEYS.CATEGORIES, JSON.stringify(seed.categories));
+    window.localStorage.setItem(STORAGE_KEYS.TRANSACTION_SPLITS, JSON.stringify(seed.transactionSplits));
+    // Empty out the other demo collections so nothing stale lingers.
+    window.localStorage.setItem(STORAGE_KEYS.BUDGETS, '[]');
+    window.localStorage.setItem(STORAGE_KEYS.GOALS, '[]');
+    window.localStorage.setItem(STORAGE_KEYS.RECURRING, '[]');
+    // demoMode flag keeps the app in local mode (the demo=true param already
+    // bypassed auth); it does NOT re-seed sample data — that only runs for
+    // isDemoMode() with the mnyimport param absent.
+    window.localStorage.setItem('demoMode', 'true');
+    window.sessionStorage.removeItem('wt_migration_completed');
+    window.sessionStorage.setItem(LOADED_FLAG, 'true');
+
+    logger.info('MS Money local seed injected', {
+      accounts: seed.accounts.length,
+      transactions: seed.transactions.length,
+    });
+
+    // Reload so the app reads the freshly-seeded local storage. The URL keeps
+    // demo=true&mnyimport=local; on the reload the flag short-circuits this
+    // function and App skips demo seeding.
+    window.location.reload();
+  } catch (error) {
+    logger.error('Failed to load MS Money local seed', error);
+  }
+}

--- a/supabase/migrations/20260720120000_split_leg_transfers.sql
+++ b/supabase/migrations/20260720120000_split_leg_transfers.sql
@@ -1,0 +1,226 @@
+-- ============================================================================
+-- Split-line transfer legs (the Microsoft Money model)
+--
+-- A transfer can be recorded as one LINE inside a split transaction: the line
+-- carries the leg (other account + counterpart transaction), and the
+-- counterpart transaction points back at the split parent plus the exact line.
+--
+--   transaction_splits.transfer_account_id  → the account on the other side
+--   transaction_splits.linked_transfer_id   → the counterpart transaction
+--   transactions.linked_transfer_split_id   → the exact line that is the
+--                                             opposite leg (its
+--                                             linked_transfer_id then points
+--                                             at the split PARENT)
+--
+-- Invariants:
+--   - Amounts are exactly opposite between the LINE and the counterpart
+--     (not the parent, whose total includes the other lines).
+--   - Deleting either side unlinks the other (SET NULL), never cascades.
+--   - set_transaction_splits refuses to edit/un-split a split containing a
+--     linked leg line — replacing the lines would strand the counterpart.
+--     (Mirrors the client-side guard in dataService.)
+-- ============================================================================
+
+BEGIN;
+
+-- The MS Money importer files accounts as 'asset' / 'liability' — the app's
+-- Accounts page has always had sections for both, but the original CHECK
+-- predates them ('assets' was a legacy spelling no app code writes). Extend
+-- rather than remap so the page sections match the stored type verbatim.
+-- ('current' is still stored as 'checking' — accountService translates.)
+ALTER TABLE public.accounts DROP CONSTRAINT IF EXISTS accounts_type_check;
+ALTER TABLE public.accounts ADD CONSTRAINT accounts_type_check CHECK (
+  type = ANY (ARRAY[
+    'checking'::text, 'savings'::text, 'credit'::text, 'cash'::text,
+    'investment'::text, 'loan'::text, 'assets'::text, 'other'::text,
+    'asset'::text, 'liability'::text, 'mortgage'::text
+  ])
+);
+
+ALTER TABLE public.transaction_splits
+  ADD COLUMN IF NOT EXISTS transfer_account_id uuid
+    REFERENCES public.accounts(id) ON DELETE SET NULL,
+  ADD COLUMN IF NOT EXISTS linked_transfer_id uuid
+    REFERENCES public.transactions(id) ON DELETE SET NULL;
+
+ALTER TABLE public.transactions
+  ADD COLUMN IF NOT EXISTS linked_transfer_split_id uuid
+    REFERENCES public.transaction_splits(id) ON DELETE SET NULL;
+
+CREATE INDEX IF NOT EXISTS idx_transaction_splits_linked_transfer
+  ON public.transaction_splits (linked_transfer_id)
+  WHERE linked_transfer_id IS NOT NULL;
+
+CREATE INDEX IF NOT EXISTS idx_transactions_linked_transfer_split
+  ON public.transactions (linked_transfer_split_id)
+  WHERE linked_transfer_split_id IS NOT NULL;
+
+-- ── set_transaction_splits: add the linked-leg guard ─────────────────────────
+-- Full body from 20260713100000_transaction_splits.sql with ONE addition: the
+-- "split_has_linked_transfer_line" check after the transfer check. Everything
+-- else is byte-identical.
+CREATE OR REPLACE FUNCTION public.set_transaction_splits(
+  p_transaction_id uuid,
+  p_splits jsonb,
+  p_expected_amount numeric DEFAULT NULL,
+  p_user_id uuid DEFAULT NULL
+)
+RETURNS jsonb
+LANGUAGE plpgsql SECURITY INVOKER
+SET search_path = public
+AS $$
+DECLARE
+  v_old public.transactions;
+  v_new public.transactions;
+  v_split jsonb;
+  v_category text;
+  v_amount numeric(20,2);
+  v_sum numeric(20,2) := 0;
+  v_count integer := 0;
+  v_ord integer := 0;
+  v_old_splits jsonb;
+  v_new_splits jsonb;
+  v_acct_before public.accounts;
+  v_acct_after public.accounts;
+BEGIN
+  IF p_splits IS NOT NULL AND jsonb_typeof(p_splits) <> 'array' THEN
+    RAISE EXCEPTION 'p_splits must be a jsonb array' USING ERRCODE = '22023';
+  END IF;
+
+  SELECT * INTO v_old
+    FROM public.transactions
+   WHERE id = p_transaction_id
+     AND (p_user_id IS NULL OR user_id = p_user_id)
+   FOR UPDATE;
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'transaction_not_found' USING ERRCODE = 'P0002';
+  END IF;
+
+  IF v_old.type = 'transfer' THEN
+    RAISE EXCEPTION 'transfers cannot be split' USING ERRCODE = 'P0001';
+  END IF;
+
+  -- split_has_linked_transfer_line: a line that is one leg of a linked
+  -- transfer is structural — replacing or removing it would strand the
+  -- counterpart transaction. Delete/unlink the transfer first.
+  IF EXISTS (
+    SELECT 1 FROM public.transaction_splits s
+     WHERE s.transaction_id = p_transaction_id
+       AND s.linked_transfer_id IS NOT NULL
+  ) THEN
+    RAISE EXCEPTION 'This split contains a linked transfer line — delete the linked transfer first, then edit the split.'
+      USING ERRCODE = 'P0001';
+  END IF;
+
+  SELECT COALESCE(jsonb_agg(to_jsonb(s) ORDER BY s.sort_order), '[]'::jsonb)
+    INTO v_old_splits
+    FROM public.transaction_splits s
+   WHERE s.transaction_id = p_transaction_id;
+
+  -- Let this function's own writes through the split guard (transaction-local).
+  PERFORM set_config('app.split_rpc', '1', true);
+
+  DELETE FROM public.transaction_splits WHERE transaction_id = p_transaction_id;
+
+  -- ── Un-split ──────────────────────────────────────────────────────────────
+  IF p_splits IS NULL OR jsonb_array_length(p_splits) = 0 THEN
+    IF v_old.is_split THEN
+      UPDATE public.transactions
+         SET is_split = false, updated_at = now()
+       WHERE id = p_transaction_id
+      RETURNING * INTO v_new;
+
+      PERFORM public.write_financial_audit(
+        v_new.user_id, 'transaction', v_new.id, 'update',
+        to_jsonb(v_old) || jsonb_build_object('splits', v_old_splits),
+        to_jsonb(v_new) || jsonb_build_object('splits', '[]'::jsonb)
+      );
+    END IF;
+    RETURN jsonb_build_object('is_split', false, 'split_count', 0, 'amount', v_old.amount);
+  END IF;
+
+  -- ── Split ─────────────────────────────────────────────────────────────────
+  IF jsonb_array_length(p_splits) < 2 THEN
+    RAISE EXCEPTION 'a split needs at least 2 lines' USING ERRCODE = '22023';
+  END IF;
+
+  FOR v_split IN SELECT value FROM jsonb_array_elements(p_splits) LOOP
+    v_category := btrim(COALESCE(v_split->>'category', ''));
+    IF v_category = '' THEN
+      RAISE EXCEPTION 'every split line needs a category' USING ERRCODE = '22023';
+    END IF;
+    IF NOT EXISTS (
+      SELECT 1 FROM public.categories c
+       WHERE c.id::text = v_category
+         AND c.user_id = v_old.user_id
+         AND c.is_transfer_category IS NOT TRUE
+    ) THEN
+      RAISE EXCEPTION 'unknown or transfer category: %', v_category USING ERRCODE = '22023';
+    END IF;
+
+    v_amount := (v_split->>'amount')::numeric(20,2);
+    IF v_amount IS NULL OR v_amount = 0 THEN
+      RAISE EXCEPTION 'every split line needs a non-zero amount' USING ERRCODE = '22023';
+    END IF;
+
+    v_ord := v_ord + 1;
+    INSERT INTO public.transaction_splits
+      (transaction_id, user_id, category, amount, memo, sort_order)
+    VALUES
+      (p_transaction_id, v_old.user_id, v_category, v_amount,
+       NULLIF(btrim(COALESCE(v_split->>'memo', '')), ''), v_ord);
+
+    v_sum := v_sum + v_amount;
+    v_count := v_count + 1;
+  END LOOP;
+
+  IF p_expected_amount IS NOT NULL AND v_sum <> p_expected_amount THEN
+    RAISE EXCEPTION 'split_total_mismatch: split lines sum to % but the transaction amount is %',
+      v_sum, p_expected_amount USING ERRCODE = 'P0001';
+  END IF;
+
+  UPDATE public.transactions
+     SET is_split = true,
+         category = '',            -- categorisation lives in the split lines
+         amount = v_sum,
+         updated_at = now()
+   WHERE id = p_transaction_id
+  RETURNING * INTO v_new;
+
+  IF v_new.amount <> v_old.amount THEN
+    SELECT * INTO v_acct_before
+      FROM public.accounts
+     WHERE id = v_new.account_id AND user_id = v_new.user_id
+     FOR UPDATE;
+    IF NOT FOUND THEN
+      RAISE EXCEPTION 'account_not_found_or_not_owned' USING ERRCODE = 'P0001';
+    END IF;
+
+    UPDATE public.accounts
+       SET balance = balance + (v_new.amount - v_old.amount),
+           updated_at = now()
+     WHERE id = v_new.account_id AND user_id = v_new.user_id
+    RETURNING * INTO v_acct_after;
+
+    PERFORM public.write_financial_audit(
+      v_new.user_id, 'account', v_acct_after.id, 'update',
+      to_jsonb(v_acct_before), to_jsonb(v_acct_after)
+    );
+  END IF;
+
+  SELECT COALESCE(jsonb_agg(to_jsonb(s) ORDER BY s.sort_order), '[]'::jsonb)
+    INTO v_new_splits
+    FROM public.transaction_splits s
+   WHERE s.transaction_id = p_transaction_id;
+
+  PERFORM public.write_financial_audit(
+    v_new.user_id, 'transaction', v_new.id, 'update',
+    to_jsonb(v_old) || jsonb_build_object('splits', v_old_splits),
+    to_jsonb(v_new) || jsonb_build_object('splits', v_new_splits)
+  );
+
+  RETURN jsonb_build_object('is_split', true, 'split_count', v_count, 'amount', v_sum);
+END;
+$$;
+
+COMMIT;

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -2,6 +2,7 @@ import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 import compression from 'vite-plugin-compression2'
 import path from 'path'
+import fs from 'fs'
 import tailwindcss from 'tailwindcss'
 import autoprefixer from 'autoprefixer'
 
@@ -17,6 +18,27 @@ export default defineConfig({
   },
   plugins: [
     react(),
+    // DEV-ONLY: serve the gitignored MS Money local seed (real financial
+    // data) from OUTSIDE public/ — public/ is copied verbatim into dist, so
+    // keeping the seed there would bundle it into a build. apply:'serve'
+    // means this route exists only on the dev server; builds never see it.
+    {
+      name: 'mny-local-seed-dev-only',
+      apply: 'serve' as const,
+      configureServer(server) {
+        server.middlewares.use((req, res, next) => {
+          if (req.url?.split('?')[0] !== '/mny-local-seed.json') { next(); return; }
+          const seedPath = path.resolve(process.cwd(), '.mny-local/mny-local-seed.json');
+          if (!fs.existsSync(seedPath)) {
+            res.statusCode = 404;
+            res.end('mny-local-seed.json not generated — run scripts/mnyLocalImport.mts');
+            return;
+          }
+          res.setHeader('Content-Type', 'application/json');
+          fs.createReadStream(seedPath).pipe(res);
+        });
+      },
+    },
     // Add gzip compression for better mobile performance
     compression({
       algorithms: ['gzip'],


### PR DESCRIPTION
## What

The complete native **MS Money (.mny) → WealthTracker** migration path, proven on the local dev server against Steve's real 45MB Money file (205 accounts / 50,860 transactions) and now ready for the one-shot cloud migration.

### Importer core (`src/services/import/msMoney/`)
- Pure, fully-tested transform from the normalised .mny export JSON to app collections — Decimal end-to-end, zero floats.
- Money's model maps 1:1: 3-level category tree, per-account **To/From** transfer categories, transfers as linked pairs, closed-not-deleted accounts.
- **Every split survives as a real split** (172 splits / 366 lines in the proving run, 0 sum mismatches): partial splits get an explicit *Unassigned (MS Money import)* remainder line; sign-flipped liability splits corrected.

### Split-line transfer legs (new model capability)
Money records some transfers as a **line inside a split**. Now first-class:
- `TransactionSplit.transferAccountId/.linkedTransferId` (line → counterpart), `Transaction.linkedTransferSplitId` (counterpart → exact line; its `linkedTransferId` → the split parent).
- Editing/un-splitting a split containing a linked leg is refused (local dataService + `set_transaction_splits` RPC) — a split edit can no longer strand a transfer counterpart.
- Cloud round-trip mapped in transactionService.
- Proving run: **11,218/11,218 transfers bidirectionally linked** (86 split-leg pairs, 0 broken, 0 dangling).

### Migration `20260720120000_split_leg_transfers.sql`
- Adds the three leg columns (FKs `ON DELETE SET NULL` — deleting either side unlinks, never cascades) + partial indexes.
- Extends `accounts_type_check` with `asset`/`liability`/`mortgage` (the Accounts page has always had these sections; canonical `Account['type']` union updated, duplicate stale unions removed).
- Rebuilds `set_transaction_splits` with the linked-leg guard (body otherwise byte-identical to 20260713).

### Signed-in local-storage leak fix
DataService fell back to browser-local storage whenever the database user id wasn't resolved — leaking demo/import data into a signed-in view (surfaced as a phantom "Closed Accounts (111)"). Now: while a Clerk session exists but the id is unresolved, **reads return empty and writes refuse**; the local fallback only runs with no session at all.

### Tooling
- **Dev proving harness**: `?demo=true&mnyimport=local` loads a gitignored seed generated into `.mny-local/` — deliberately outside `public/` and served by a dev-only Vite middleware, so **no build can ever bundle the real financial data**.
- **`scripts/mnyCloudImport.mts`**: the one-shot destructive cloud migration. Preflight (migration applied, single user) → full JSON backup to `~/WealthTracker-backups/` → wipe → import with UUID remapping of every cross-reference → Decimal verification (per-account ledger invariant, split reconciliation, transfer/leg reciprocity). **Dry-run by default**; the real run requires `--execute --confirm-wipe`. Dry-run executed against prod: backup written, plan verified.

## Verification
- transform + dataService tests **16/16**; smoke suite **3,124 passed**; lint + `typecheck:strict` + `build:check` clean.
- Local wipe-and-reimport re-verified in-browser after every change (Net Worth £17,260,881.56 stable, no console errors).

## Deployment order
1. Merge (Vercel deploys — app reads are tolerant of the columns not existing yet).
2. Apply `supabase/migrations/20260720120000_split_leg_transfers.sql` in the SQL editor.
3. Run the cloud import (dry-run first, then `--execute --confirm-wipe`).
4. Re-link bank feeds in Settings → Banking (account rows are replaced; connections are kept).

🤖 Generated with [Claude Code](https://claude.com/claude-code)