### PR TITLE
feat(import): pure-JS Microsoft Money (.mny) reader

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -35,6 +35,7 @@
         "html2canvas": "^1.4.1",
         "jspdf": "^4.2.1",
         "jspdf-autotable": "^5.0.8",
+        "mdb-reader": "^3.2.0",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
         "react-dropzone": "^14.3.8",
@@ -2214,6 +2215,18 @@
         "@emnapi/core": "^1.7.1",
         "@emnapi/runtime": "^1.7.1"
       }
+    },
+    "node_modules/@nodable/entities": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-3.0.0.tgz",
+      "integrity": "sha512-8L9xFeTYKhm49xfIypoe2W5wV1m/3Z58kT+7kR9A8OyFxcPduI4VmxaUMQyKYrRjUoLLSXv6EKKID5Tvj9cUVw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodable"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
@@ -6312,6 +6325,18 @@
         "node": ">= 8"
       }
     },
+    "node_modules/anynum": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/anynum/-/anynum-1.0.1.tgz",
+      "integrity": "sha512-N6//FLET/tXYNM/F6ABca1oH6fWB+KlTt909Le28WMDBk8oaT4vY17DCrwg2MvmuqUKt3Ni4N5dGJ/EoBgcO6A==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/arg": {
       "version": "5.0.2",
       "resolved": "https://registry.npmjs.org/arg/-/arg-5.0.2.tgz",
@@ -6466,6 +6491,21 @@
       },
       "peerDependencies": {
         "postcss": "^8.1.0"
+      }
+    },
+    "node_modules/available-typed-arrays": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
+      "integrity": "sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==",
+      "license": "MIT",
+      "dependencies": {
+        "possible-typed-array-names": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/axe-core": {
@@ -6727,6 +6767,20 @@
         "node": ">=8"
       }
     },
+    "node_modules/browserify-aes": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz",
+      "integrity": "sha512-+7CHXqGuspUn/Sl5aO7Ea0xWGAtETPXNSAjHo48JfLdPWcMng33Xe4znFvQweqc/uzk5zSOI3H52CYnjCfb5hA==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-xor": "^1.0.3",
+        "cipher-base": "^1.0.0",
+        "create-hash": "^1.1.0",
+        "evp_bytestokey": "^1.0.3",
+        "inherits": "^2.0.1",
+        "safe-buffer": "^5.0.1"
+      }
+    },
     "node_modules/browserslist": {
       "version": "4.27.0",
       "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.27.0.tgz",
@@ -6801,6 +6855,12 @@
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/buffer-xor": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/buffer-xor/-/buffer-xor-1.0.3.tgz",
+      "integrity": "sha512-571s0T7nZWK6vB67HI5dyUF7wXiNcfaPPPTl6zYCNApANjIvYJTg7hlud/+cJpdAhS7dVzqMLmfhfHR3rAcOjQ==",
       "license": "MIT"
     },
     "node_modules/bytes": {
@@ -6965,6 +7025,24 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/call-bind": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.9.tgz",
+      "integrity": "sha512-a/hy+pNsFUTR+Iz8TCJvXudKVLAnz/DyeSUo10I5yvFDQJBFU2s9uqQpoSrJlroHUKoKqzg+epxyP9lqFdzfBQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "get-intrinsic": "^1.3.0",
+        "set-function-length": "^1.2.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/call-bind-apply-helpers": {
@@ -7228,6 +7306,20 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/cipher-base": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.7.tgz",
+      "integrity": "sha512-Mz9QMT5fJe7bKI7MH31UilT5cEK5EHHRCccw/YRFsRY47AuNgaV6HY3rscp0/I4Q+tTW/5zoqpSeRRI54TkDWA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.4",
+        "safe-buffer": "^5.2.1",
+        "to-buffer": "^1.2.2"
+      },
+      "engines": {
+        "node": ">= 0.10"
       }
     },
     "node_modules/cjs-module-lexer": {
@@ -7713,6 +7805,25 @@
         "url": "https://opencollective.com/core-js"
       }
     },
+    "node_modules/core-util-is": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
+      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
+      "license": "MIT"
+    },
+    "node_modules/create-hash": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
+      "integrity": "sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg==",
+      "license": "MIT",
+      "dependencies": {
+        "cipher-base": "^1.0.1",
+        "inherits": "^2.0.1",
+        "md5.js": "^1.3.4",
+        "ripemd160": "^2.0.1",
+        "sha.js": "^2.4.0"
+      }
+    },
     "node_modules/create-require": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
@@ -8040,6 +8151,23 @@
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/define-data-property": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
+      "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
+      "license": "MIT",
+      "dependencies": {
+        "es-define-property": "^1.0.0",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/define-lazy-prop": {
       "version": "2.0.0",
@@ -9148,6 +9276,16 @@
         "bare-events": "^2.7.0"
       }
     },
+    "node_modules/evp_bytestokey": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/evp_bytestokey/-/evp_bytestokey-1.0.3.tgz",
+      "integrity": "sha512-/f2Go4TognH/KvCISP7OUsHn85hT9nUkxxA9BEWxFn+Oj9o8ZNLm/40hdlgSLyuOimsrTKLUMEorQexp/aPQeA==",
+      "license": "MIT",
+      "dependencies": {
+        "md5.js": "^1.3.4",
+        "safe-buffer": "^5.1.1"
+      }
+    },
     "node_modules/execa": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/execa/-/execa-3.2.0.tgz",
@@ -9419,6 +9557,45 @@
       "integrity": "sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==",
       "license": "Unlicense"
     },
+    "node_modules/fast-xml-builder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.3.0.tgz",
+      "integrity": "sha512-F74cZEdCvuw9P41GAC3rod4X04jjWGM1JPEv/GWSqFTWLsdyMSBMBMlm9Hk3GLBgLBbdBNY8yee0pQh2RBVESQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "path-expression-matcher": "^1.6.2",
+        "xml-naming": "^0.3.0"
+      }
+    },
+    "node_modules/fast-xml-parser": {
+      "version": "5.10.1",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.10.1.tgz",
+      "integrity": "sha512-IEMIf7298kXuZSRFoGfMYrl7is8LpavODgbNz1cwIudv7KwVFnuU+UsMporfq6PD6aXSlawZlARiA3UywCTfMw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@nodable/entities": "^3.0.0",
+        "fast-xml-builder": "^1.2.0",
+        "is-unsafe": "^2.0.0",
+        "path-expression-matcher": "^1.6.2",
+        "strnum": "^2.4.1",
+        "xml-naming": "^0.3.0"
+      },
+      "bin": {
+        "fxparser": "src/cli/cli.js"
+      }
+    },
     "node_modules/fastq": {
       "version": "1.19.1",
       "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.19.1.tgz",
@@ -9558,6 +9735,21 @@
       "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/for-each": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.5.tgz",
+      "integrity": "sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==",
+      "license": "MIT",
+      "dependencies": {
+        "is-callable": "^1.2.7"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/foreground-child": {
       "version": "3.3.1",
@@ -9966,6 +10158,18 @@
         "node": ">=8"
       }
     },
+    "node_modules/has-property-descriptors": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
+      "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
+      "license": "MIT",
+      "dependencies": {
+        "es-define-property": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/has-symbols": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
@@ -9976,6 +10180,36 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hash-base": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/hash-base/-/hash-base-3.1.2.tgz",
+      "integrity": "sha512-Bb33KbowVTIj5s7Ked1OsqHUeCpz//tPwR+E2zJgJKo9Z5XolZ9b6bdUgjmYlwnWhoOQKoTd1TYToZGn5mAYOg==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.4",
+        "readable-stream": "^2.3.8",
+        "safe-buffer": "^5.2.1",
+        "to-buffer": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/hasown": {
@@ -10274,7 +10508,6 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/inquirer": {
@@ -10475,6 +10708,18 @@
         "node": ">=4"
       }
     },
+    "node_modules/is-callable": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
+      "integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/is-core-module": {
       "version": "2.16.1",
       "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.1.tgz",
@@ -10594,11 +10839,38 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/is-typed-array": {
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.15.tgz",
+      "integrity": "sha512-p3EcsicXjit7SaskXHs1hA91QxgTw46Fv6EFKKGS5DRFLD8yKnohjF3hxoju94b/OcMZoQukzpPpBE9uLVKzgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "which-typed-array": "^1.1.16"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/is-typedarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
       "integrity": "sha512-cyA56iCMHAh5CdzjJIa4aohJyeO1YbwLi3Jc35MmRU6poroFjIGZzUzupGiRPOjgHg9TLu43xbpwXk523fMxKA==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/is-unsafe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-unsafe/-/is-unsafe-2.0.0.tgz",
+      "integrity": "sha512-2LdV822R+wmI86unXA93WCFpL6g+av8ynWk0nrHyJqGop5VoocYsSLFgN8jrfalT6iGeLNM4KXuVSsULP53kEA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
       "license": "MIT"
     },
     "node_modules/is-url": {
@@ -10619,6 +10891,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+      "license": "MIT"
     },
     "node_modules/isexe": {
       "version": "2.0.0",
@@ -11508,6 +11786,29 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/md5.js": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/md5.js/-/md5.js-1.3.5.tgz",
+      "integrity": "sha512-xitP+WxNPcTTOgnTJcrhM0xvdPepipPSf3I8EIpGKeFLjt3PlJLIDG3u8EX53ZIubkb+5U2+3rELYpEhHhzdkg==",
+      "license": "MIT",
+      "dependencies": {
+        "hash-base": "^3.0.0",
+        "inherits": "^2.0.1",
+        "safe-buffer": "^5.1.2"
+      }
+    },
+    "node_modules/mdb-reader": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/mdb-reader/-/mdb-reader-3.2.0.tgz",
+      "integrity": "sha512-ShIlblasXhXGHmbHNztKdEGftALGo9NNrOviHCoSHqhYnAnMjbJSlsfHluCV5BrXpoeYNnaefviRTdik42qOAg==",
+      "license": "MIT",
+      "dependencies": {
+        "browserify-aes": "^1.0.0",
+        "create-hash": "^1.0.0",
+        "fast-xml-parser": "^4.0.0 || ^5.0.0",
+        "pako": "^2.0.0"
       }
     },
     "node_modules/media-typer": {
@@ -12457,6 +12758,21 @@
         "node": ">=8"
       }
     },
+    "node_modules/path-expression-matcher": {
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.6.2.tgz",
+      "integrity": "sha512-enSlaiat05iasnzmgNxRj8reFdj3puY2QpNgP1aPIaVfT6nn9ICuPoFlKHk8EN22HcwewshO+mN2DGbkCEOtqQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
@@ -12631,6 +12947,15 @@
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/possible-typed-array-names": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz",
+      "integrity": "sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/postcss": {
@@ -12886,6 +13211,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/process-nextick-args": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+      "license": "MIT"
     },
     "node_modules/progress": {
       "version": "2.0.3",
@@ -13359,6 +13690,27 @@
         "pify": "^2.3.0"
       }
     },
+    "node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/readable-stream/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "license": "MIT"
+    },
     "node_modules/readdirp": {
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
@@ -13634,6 +13986,19 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/ripemd160": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-2.0.3.tgz",
+      "integrity": "sha512-5Di9UC0+8h1L6ZD2d7awM7E/T4uA1fJRlx6zk/NvdCCVEoAnFqvHmCuNeIKoCeIixBX/q8uM+6ycDvF8woqosA==",
+      "license": "MIT",
+      "dependencies": {
+        "hash-base": "^3.1.2",
+        "inherits": "^2.0.4"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/robots-parser": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/robots-parser/-/robots-parser-3.0.1.tgz",
@@ -13800,7 +14165,6 @@
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
       "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -13932,12 +14296,49 @@
       "integrity": "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==",
       "license": "MIT"
     },
+    "node_modules/set-function-length": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
+      "integrity": "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==",
+      "license": "MIT",
+      "dependencies": {
+        "define-data-property": "^1.1.4",
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2",
+        "get-intrinsic": "^1.2.4",
+        "gopd": "^1.0.1",
+        "has-property-descriptors": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/setprototypeof": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
       "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/sha.js": {
+      "version": "2.4.12",
+      "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.12.tgz",
+      "integrity": "sha512-8LzC5+bvI45BjpfXU8V5fdU2mfeKiQe1D1gIMn7XUlF3OTUrpdJpPPH4EMAnF0DsHHdSZqCdSss5qCmJKuiO3w==",
+      "license": "(MIT AND BSD-3-Clause)",
+      "dependencies": {
+        "inherits": "^2.0.4",
+        "safe-buffer": "^5.2.1",
+        "to-buffer": "^1.2.0"
+      },
+      "bin": {
+        "sha.js": "bin.js"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",
@@ -14365,7 +14766,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
       "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "safe-buffer": "~5.1.0"
@@ -14375,7 +14775,6 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/string-width": {
@@ -14565,6 +14964,21 @@
         "@types/node": {
           "optional": true
         }
+      }
+    },
+    "node_modules/strnum": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.4.1.tgz",
+      "integrity": "sha512-M9eUSMT2dCB2cTNPG7UYj6KuK7RJR2SN2+yCV/fTW3xzTCS6EaGZ5pSMgDIjB7r8zSfTGk+dvvn9rTjpVS9Mwg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "anynum": "^1.0.1"
       }
     },
     "node_modules/sucrase": {
@@ -15307,6 +15721,26 @@
         "rimraf": "bin.js"
       }
     },
+    "node_modules/to-buffer": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/to-buffer/-/to-buffer-1.2.2.tgz",
+      "integrity": "sha512-db0E3UJjcFhpDhAF4tLo03oli3pwl3dbnzXOUIlRKrp+ldk/VUxzpWYZENsw2SZiuBjHAk7DfB0VU7NKdpb6sw==",
+      "license": "MIT",
+      "dependencies": {
+        "isarray": "^2.0.5",
+        "safe-buffer": "^5.2.1",
+        "typed-array-buffer": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/to-buffer/node_modules/isarray": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
+      "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
+      "license": "MIT"
+    },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -15540,6 +15974,20 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/typed-array-buffer": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/typed-array-buffer/-/typed-array-buffer-1.0.3.tgz",
+      "integrity": "sha512-nAYYwfY3qnzX30IkA6AQZjVbtK6duGontcQm1WSG1MD94YLqK0515GNApXkoxKOWMusVssAHWLh9SeaoefYFGw==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "es-errors": "^1.3.0",
+        "is-typed-array": "^1.1.14"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/typed-query-selector": {
       "version": "2.12.0",
       "resolved": "https://registry.npmjs.org/typed-query-selector/-/typed-query-selector-2.12.0.tgz",
@@ -15705,7 +16153,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/utils-merge": {
@@ -16332,6 +16779,27 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/which-typed-array": {
+      "version": "1.1.22",
+      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.22.tgz",
+      "integrity": "sha512-fvO4ExWMFsqyhG3AiPAObMuY1lxaqgYcxbc49CNdWDDECOJNgQyvsOWVwbZc+qf3rzRtxojBK+CMEv0Ld5CYpw==",
+      "license": "MIT",
+      "dependencies": {
+        "available-typed-arrays": "^1.0.7",
+        "call-bind": "^1.0.9",
+        "call-bound": "^1.0.4",
+        "for-each": "^0.3.5",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/why-is-node-running": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
@@ -16700,6 +17168,21 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/xml-naming": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/xml-naming/-/xml-naming-0.3.0.tgz",
+      "integrity": "sha512-ghig2TBE/H11aOVgmahA3MhimvkBr6JIYknH/Dhdk10nXwdbIqBJsbfMxpvFPG8bAw77gN29aQWvKpmVoPlvPQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.0.0"
       }
     },
     "node_modules/xmlchars": {

--- a/package.json
+++ b/package.json
@@ -107,6 +107,7 @@
     "html2canvas": "^1.4.1",
     "jspdf": "^4.2.1",
     "jspdf-autotable": "^5.0.8",
+    "mdb-reader": "^3.2.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-dropzone": "^14.3.8",

--- a/src/services/import/msMoney/mnyDecrypt.ts
+++ b/src/services/import/msMoney/mnyDecrypt.ts
@@ -1,0 +1,171 @@
+/**
+ * Microsoft Money (.mny) page decryption — pure JavaScript, no native code.
+ *
+ * A .mny file is an MSISAM database (an encrypted Access/Jet variant). The
+ * first 0x0e data pages are RC4-encrypted with a per-page key derived from a
+ * salt in the (itself masked) header. This module reproduces the key
+ * derivation from Jackcess's MSISAMCryptCodecHandler so an ordinary MDB
+ * reader can then parse the decrypted bytes.
+ *
+ * We only ever READ. Password-protected Money files are out of scope: the
+ * common case (and the migration target) is the empty-password database, which
+ * is what Money writes by default. If a real password were set the derived key
+ * would not decrypt and parsing would fail loudly — never silently wrong.
+ *
+ * References:
+ *  - jackcessencrypt MSISAMCryptCodecHandler / BaseCryptCodecHandler
+ *  - mdb-reader (Jet header unmasking key)
+ */
+
+const PAGE_SIZE = 4096;
+const HEADER_MASK_KEY = Uint8Array.from([0xc7, 0xda, 0x39, 0x6b]);
+const HEADER_MASK_START = 0x18;
+const HEADER_MASK_LEN = 128;
+const SALT_OFFSET = 0x72;
+const ENCRYPTION_FLAGS_OFFSET = 0x298;
+const USE_SHA1 = 0x20;
+const NEW_ENCRYPTION = 0x6;
+const PASSWORD_LENGTH = 0x28; // 40 bytes, zero-filled for the empty password
+const DIGEST_LENGTH = 0x10; // 16
+const MAX_ENCRYPTED_PAGE = 0x0e;
+
+/** RC4 keystream cipher (symmetric — same routine encrypts and decrypts). */
+export function rc4(key: Uint8Array, data: Uint8Array): Uint8Array {
+  const s = new Uint8Array(256);
+  for (let i = 0; i < 256; i++) s[i] = i;
+  let j = 0;
+  for (let i = 0; i < 256; i++) {
+    j = (j + s[i] + key[i % key.length]) & 0xff;
+    const t = s[i]; s[i] = s[j]; s[j] = t;
+  }
+  const out = new Uint8Array(data.length);
+  let a = 0;
+  j = 0;
+  for (let k = 0; k < data.length; k++) {
+    a = (a + 1) & 0xff;
+    j = (j + s[a]) & 0xff;
+    const t = s[a]; s[a] = s[j]; s[j] = t;
+    out[k] = data[k] ^ s[(s[a] + s[j]) & 0xff];
+  }
+  return out;
+}
+
+/**
+ * SHA-1 of a byte array. A self-contained implementation (no Web Crypto) so
+ * decryption runs identically in the browser, Node, workers and jsdom without
+ * depending on `crypto.subtle`, which jsdom does not provide. It only ever
+ * hashes a fixed 40-byte buffer here, so speed is irrelevant.
+ */
+export function sha1(data: Uint8Array): Uint8Array {
+  const ml = data.length * 8;
+  // pad to 512-bit blocks: 0x80, then zeros, then 64-bit big-endian length
+  const withOne = data.length + 1;
+  const total = withOne + ((56 - (withOne % 64) + 64) % 64) + 8;
+  const msg = new Uint8Array(total);
+  msg.set(data);
+  msg[data.length] = 0x80;
+  const view = new DataView(msg.buffer);
+  view.setUint32(total - 4, ml >>> 0, false);
+  view.setUint32(total - 8, Math.floor(ml / 0x100000000), false);
+
+  let h0 = 0x67452301, h1 = 0xefcdab89, h2 = 0x98badcfe, h3 = 0x10325476, h4 = 0xc3d2e1f0;
+  const rol = (n: number, c: number) => ((n << c) | (n >>> (32 - c))) >>> 0;
+  const w = new Uint32Array(80);
+
+  for (let off = 0; off < total; off += 64) {
+    for (let i = 0; i < 16; i++) w[i] = view.getUint32(off + i * 4, false);
+    for (let i = 16; i < 80; i++) w[i] = rol(w[i - 3] ^ w[i - 8] ^ w[i - 14] ^ w[i - 16], 1);
+    let a = h0, b = h1, c = h2, d = h3, e = h4;
+    for (let i = 0; i < 80; i++) {
+      let f: number, k: number;
+      if (i < 20) { f = (b & c) | (~b & d); k = 0x5a827999; }
+      else if (i < 40) { f = b ^ c ^ d; k = 0x6ed9eba1; }
+      else if (i < 60) { f = (b & c) | (b & d) | (c & d); k = 0x8f1bbcdc; }
+      else { f = b ^ c ^ d; k = 0xca62c1d6; }
+      const t = (rol(a, 5) + f + e + k + w[i]) >>> 0;
+      e = d; d = c; c = rol(b, 30); b = a; a = t;
+    }
+    h0 = (h0 + a) >>> 0; h1 = (h1 + b) >>> 0; h2 = (h2 + c) >>> 0;
+    h3 = (h3 + d) >>> 0; h4 = (h4 + e) >>> 0;
+  }
+  const out = new Uint8Array(20);
+  new DataView(out.buffer).setUint32(0, h0, false);
+  new DataView(out.buffer).setUint32(4, h1, false);
+  new DataView(out.buffer).setUint32(8, h2, false);
+  new DataView(out.buffer).setUint32(12, h3, false);
+  new DataView(out.buffer).setUint32(16, h4, false);
+  return out;
+}
+
+function digest(algo: 'SHA-1' | 'MD5', data: Uint8Array): Uint8Array {
+  // Money's modern format (NEW_ENCRYPTION) always sets USE_SHA1, so SHA-1 is
+  // the live branch. MD5 (pre-2002 files) is handled by the loud-failure
+  // contract rather than supported.
+  if (algo === 'MD5') {
+    throw new MnyDecryptError(
+      'This looks like a very old Microsoft Money file (MD5 encryption). Only Money 2002 and later files can be imported.'
+    );
+  }
+  return sha1(data);
+}
+
+export class MnyDecryptError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'MnyDecryptError';
+  }
+}
+
+/**
+ * Decrypt a .mny file in place-safe fashion, returning a NEW byte array whose
+ * encrypted pages are decrypted and whose other pages are copied verbatim.
+ * The result is a plain (identity-codec) MSISAM database an MDB reader parses.
+ */
+export function decryptMny(bytes: Uint8Array): Uint8Array {
+  if (bytes.length < PAGE_SIZE) {
+    throw new MnyDecryptError('File is too small to be a Microsoft Money database.');
+  }
+  // Validate the engine signature before doing anything else.
+  const engine = new TextDecoder('latin1').decode(bytes.subarray(0x04, 0x13));
+  if (engine !== 'MSISAM Database') {
+    throw new MnyDecryptError('Not a Microsoft Money file (missing MSISAM signature).');
+  }
+
+  const out = bytes.slice(); // copy — never mutate the caller's buffer
+
+  // 1. Unmask the header page to recover the true salt (Jet fixed-key RC4).
+  const header = out.slice(0, PAGE_SIZE);
+  const unmasked = rc4(HEADER_MASK_KEY, header.subarray(HEADER_MASK_START, HEADER_MASK_START + HEADER_MASK_LEN));
+  header.set(unmasked, HEADER_MASK_START);
+
+  const flags = header[ENCRYPTION_FLAGS_OFFSET];
+  if ((flags & NEW_ENCRYPTION) === 0) {
+    throw new MnyDecryptError(
+      'This Microsoft Money file uses a legacy encryption scheme that is not supported. Only Money 2002 and later files can be imported.'
+    );
+  }
+
+  // 2. Derive the base hash: digest(empty password) ++ 4-byte salt.
+  const algo = (flags & USE_SHA1) !== 0 ? 'SHA-1' : 'MD5';
+  const pwdDigest = digest(algo, new Uint8Array(PASSWORD_LENGTH)).subarray(0, DIGEST_LENGTH);
+  const baseHash = new Uint8Array(DIGEST_LENGTH + 4);
+  baseHash.set(pwdDigest, 0);
+  baseHash.set(header.subarray(SALT_OFFSET, SALT_OFFSET + 4), DIGEST_LENGTH);
+
+  // 3. Decrypt each encrypted page with its page-numbered key.
+  const pageKey = new Uint8Array(DIGEST_LENGTH + 4);
+  for (let page = 1; page <= MAX_ENCRYPTED_PAGE; page++) {
+    const start = page * PAGE_SIZE;
+    if (start >= out.length) break;
+    pageKey.set(baseHash);
+    // applyPageNumber: XOR the little-endian page number over bytes 16..19.
+    pageKey[DIGEST_LENGTH + 0] = (page & 0xff) ^ baseHash[DIGEST_LENGTH + 0];
+    pageKey[DIGEST_LENGTH + 1] = ((page >>> 8) & 0xff) ^ baseHash[DIGEST_LENGTH + 1];
+    pageKey[DIGEST_LENGTH + 2] = ((page >>> 16) & 0xff) ^ baseHash[DIGEST_LENGTH + 2];
+    pageKey[DIGEST_LENGTH + 3] = ((page >>> 24) & 0xff) ^ baseHash[DIGEST_LENGTH + 3];
+    const decrypted = rc4(pageKey, out.subarray(start, start + PAGE_SIZE));
+    out.set(decrypted, start);
+  }
+
+  return out;
+}

--- a/src/services/import/msMoney/mnyReader.test.ts
+++ b/src/services/import/msMoney/mnyReader.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync, existsSync } from 'node:fs';
+import { rc4, sha1, decryptMny, MnyDecryptError } from './mnyDecrypt';
+import { readMnyExport } from './mnyReader';
+import { transformMsMoneyExport } from './transform';
+
+describe('rc4', () => {
+  // Canonical RC4 test vector (RFC 6229 / the classic "Key"/"Plaintext" case).
+  it('matches the known "Key"/"Plaintext" vector', () => {
+    const key = new TextEncoder().encode('Key');
+    const plain = new TextEncoder().encode('Plaintext');
+    const cipher = rc4(key, plain);
+    expect(Buffer.from(cipher).toString('hex')).toBe('bbf316e8d940af0ad3');
+    // symmetric: decrypting the cipher returns the plaintext
+    expect(Buffer.from(rc4(key, cipher)).toString('utf8')).toBe('Plaintext');
+  });
+});
+
+describe('sha1', () => {
+  const hex = (u: Uint8Array) => Buffer.from(u).toString('hex');
+  it('matches known digests (empty, "abc", 40 zero bytes)', () => {
+    expect(hex(sha1(new Uint8Array(0)))).toBe('da39a3ee5e6b4b0d3255bfef95601890afd80709');
+    expect(hex(sha1(new TextEncoder().encode('abc')))).toBe('a9993e364706816aba3e25717850c26c9cd0d89d');
+    // the exact input the decryptor hashes (empty-password digest)
+    expect(hex(sha1(new Uint8Array(40)))).toBe('b80de5d138758541c5f05265ad144ab9fa86d1db');
+  });
+});
+
+describe('decryptMny', () => {
+  it('rejects a non-Money file with a clear message', async () => {
+    const notMoney = new Uint8Array(8192); // zero-filled, no MSISAM signature
+    expect(() => decryptMny(notMoney)).toThrow(MnyDecryptError);
+    expect(() => decryptMny(notMoney)).toThrow(/Not a Microsoft Money file/);
+  });
+
+  it('rejects a file too small to be a database', () => {
+    expect(() => decryptMny(new Uint8Array(16))).toThrow(/too small/);
+  });
+});
+
+// Real-file verification (opt-in): set MNY_TEST_FILE to a real .mny path. The
+// file holds real financial data so it is never committed — this mirrors the
+// repo's gated real-infra test pattern (Supabase smoke).
+const realFile = process.env.MNY_TEST_FILE;
+describe.runIf(realFile && existsSync(realFile!))('readMnyExport (real .mny)', () => {
+  it('decrypts + extracts the whole database and every split reconciles once transformed', async () => {
+    const bytes = new Uint8Array(readFileSync(realFile!));
+    const exp = readMnyExport(bytes);
+
+    expect(exp.accounts.length).toBeGreaterThan(0);
+    expect(exp.transactions.length).toBeGreaterThan(0);
+
+    // Roles cover every transaction exactly once.
+    const roles = exp.transactions.reduce<Record<string, number>>((m, t) => {
+      m[t.role] = (m[t.role] ?? 0) + 1; return m;
+    }, {});
+    const total = Object.values(roles).reduce((a, b) => a + b, 0);
+    expect(total).toBe(exp.transactions.length);
+
+    // The transform must accept the extracted export and every split parent
+    // must reconcile to its lines (the core money-safety invariant).
+    const out = transformMsMoneyExport(exp, new Date('2020-01-01').toISOString());
+    const linesByTxn = new Map<string, number>();
+    for (const s of out.transactionSplits) {
+      linesByTxn.set(s.transactionId, Math.round(((linesByTxn.get(s.transactionId) ?? 0) + s.amount) * 100) / 100);
+    }
+    const parentAmount = new Map(out.transactions.map(t => [t.id, t.amount]));
+    for (const [txnId, sum] of linesByTxn) {
+      expect(sum).toBeCloseTo(parentAmount.get(txnId)!, 2);
+    }
+  });
+});

--- a/src/services/import/msMoney/mnyReader.ts
+++ b/src/services/import/msMoney/mnyReader.ts
@@ -1,0 +1,247 @@
+/**
+ * Microsoft Money (.mny) reader — decrypts and extracts the raw tables into the
+ * normalised `MnyExport` shape that `transform.ts` consumes.
+ *
+ * This is the pure-JS equivalent of the earlier Jackcess/Java extraction and
+ * is verified to reproduce it exactly (same accounts, categories, transactions,
+ * splits — see mnyReader.test.ts). The chain is:
+ *
+ *     .mny bytes → decryptMny → MDBReader → extractMnyExport → transform
+ *
+ * Money's internal model maps cleanly onto the app's: accounts (ACCT), a
+ * 3-level category tree (CAT), payees (PAY), transactions (TRN) with splits
+ * (TRN_SPLIT) and transfers (TRN_XFER). Amounts are read as-is and normalised
+ * to decimal strings; the transform is the single place money maths happens.
+ */
+import MDBReader from 'mdb-reader';
+import { decryptMny } from './mnyDecrypt';
+import type {
+  MnyExport, MnyAccount, MnyCategory, MnyPayee, MnyTransaction, MnyRole,
+} from './transform';
+
+// A row from mdb-reader — column values are number | string | Date | boolean | null.
+type Row = Record<string, unknown>;
+
+const num = (v: unknown): number | null => (typeof v === 'number' ? v : v == null ? null : Number(v));
+const str = (v: unknown): string | null => (typeof v === 'string' && v !== '' ? v : null);
+const bool = (v: unknown): boolean => v === true || v === 1;
+
+/** Money's amounts arrive as JS numbers; store them as exact decimal strings. */
+const decStr = (v: unknown): string => {
+  const n = num(v);
+  return n == null ? '0' : n.toString();
+};
+
+/** Money nulls a date by writing a year ≥ 9999; treat those as "no date". */
+const NULL_YEAR = 9999;
+const isoDate = (v: unknown): string | null => {
+  if (v == null) return null;
+  const d = v instanceof Date ? v : new Date(v as string);
+  if (Number.isNaN(d.getTime()) || d.getUTCFullYear() >= NULL_YEAR) return null;
+  return d.toISOString().slice(0, 10);
+};
+
+// ACCT.at (Money's account super-type) → the moneyType strings transform maps.
+const AT_TO_MONEYTYPE: Record<number, MnyAccount['moneyType']> = {
+  0: 'bank', 1: 'credit', 2: 'cash', 3: 'asset', 4: 'liability', 5: 'investment',
+};
+
+// A category's income/expense kind is decided by which tree root it ultimately
+// descends from (INCOME root = 130; everything else, incl. the EXPENSE root
+// 131, is expense).
+const INCOME_ROOT = 130;
+
+/** Sum in integer pennies so the reconciliation flags never see float drift. */
+const pennies = (v: unknown): number => Math.round((num(v) ?? 0) * 100);
+
+export class MnyReadError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'MnyReadError';
+  }
+}
+
+/**
+ * Decrypt + parse a .mny file into the normalised export. Throws
+ * MnyReadError / MnyDecryptError with a user-facing message on any failure so
+ * the import UI can surface it rather than showing a stack trace.
+ */
+export function readMnyExport(bytes: Uint8Array): MnyExport {
+  const decrypted = decryptMny(bytes);
+
+  let reader: MDBReader;
+  try {
+    // mdb-reader wants a Buffer; in the browser this is the `buffer` polyfill.
+    reader = new MDBReader(Buffer.from(decrypted));
+  } catch (err) {
+    throw new MnyReadError(
+      `Could not read the Microsoft Money database — the file may be corrupt. (${(err as Error).message})`
+    );
+  }
+
+  const table = (name: string): Row[] => {
+    try {
+      return reader.getTable(name).getData() as Row[];
+    } catch {
+      throw new MnyReadError(`This Microsoft Money file is missing its ${name} table and cannot be imported.`);
+    }
+  };
+
+  const acctRows = table('ACCT');
+  const catRows = table('CAT');
+  const payRows = table('PAY');
+  const trnRows = table('TRN');
+  const splitRows = table('TRN_SPLIT');
+  const xferRows = table('TRN_XFER');
+  const crncRows = table('CRNC');
+
+  return {
+    accounts: extractAccounts(acctRows, crncRows, trnRows, splitRows),
+    categories: extractCategories(catRows),
+    payees: extractPayees(payRows),
+    transactions: extractTransactions(trnRows, splitRows, xferRows),
+  };
+}
+
+function extractCategories(catRows: Row[]): MnyCategory[] {
+  const byId = new Map<number, Row>();
+  for (const c of catRows) byId.set(num(c.hcat)!, c);
+
+  const kindOf = (c: Row): 'income' | 'expense' => {
+    let cur: Row | undefined = c;
+    for (let guard = 0; cur && (num(cur.nLevel) ?? 0) > 0 && cur.hcatParent != null && guard < 32; guard++) {
+      cur = byId.get(num(cur.hcatParent)!);
+    }
+    return cur && num(cur.hcat) === INCOME_ROOT ? 'income' : 'expense';
+  };
+  // Money stores names as a back-slashed path; the leaf is the display name.
+  const leaf = (c: Row): string => {
+    const full = str(c.szAls) ?? str(c.szFull) ?? '';
+    const parts = full.split('\\');
+    return parts[parts.length - 1] || full;
+  };
+
+  return catRows.map((c): MnyCategory => {
+    const level = num(c.nLevel) ?? 0;
+    return {
+      id: num(c.hcat)!,
+      name: leaf(c),
+      parentId: level === 0 ? null : (num(c.hcatParent) ?? null),
+      level,
+      fullPath: str(c.szFull) ?? '',
+      hidden: bool(c.fHidden),
+      kind: kindOf(c),
+    };
+  });
+}
+
+function extractPayees(payRows: Row[]): MnyPayee[] {
+  return payRows.map((p): MnyPayee => ({
+    id: num(p.hpay)!,
+    name: str(p.szFull) ?? str(p.szAls) ?? `Payee ${num(p.hpay)}`,
+    parentId: num(p.hpayParent) ?? null,
+    hidden: bool(p.fHidden),
+  }));
+}
+
+function extractAccounts(
+  acctRows: Row[], crncRows: Row[], trnRows: Row[], splitRows: Row[]
+): MnyAccount[] {
+  const isoByCrnc = new Map<number, string | null>();
+  for (const c of crncRows) isoByCrnc.set(num(c.hcrnc)!, str(c.szIsoCode));
+
+  // The stored balance (XACCT.amtBalance) is a dead runtime cache — Money
+  // recomputes it. Authoritative balance = opening + Σ(the account's own
+  // transactions), excluding split children (their parent carries the total).
+  const splitChildIds = new Set<number>();
+  for (const s of splitRows) splitChildIds.add(num(s.htrn)!);
+  const sumByAcct = new Map<number, number>();
+  for (const t of trnRows) {
+    const id = num(t.htrn)!;
+    if (splitChildIds.has(id)) continue;
+    const acct = num(t.hacct)!;
+    sumByAcct.set(acct, (sumByAcct.get(acct) ?? 0) + pennies(t.amt));
+  }
+
+  return acctRows.map((a): MnyAccount => {
+    const id = num(a.hacct)!;
+    const open = pennies(a.amtOpen);
+    const reconstructed = open + (sumByAcct.get(id) ?? 0);
+    return {
+      id,
+      name: str(a.szFull) ?? str(a.szAls) ?? `Account ${id}`,
+      moneyType: AT_TO_MONEYTYPE[num(a.at) ?? -1] ?? 'other',
+      currencyCode: isoByCrnc.get(num(a.hcrnc)!) ?? null,
+      openingBalance: (open / 100).toFixed(2),
+      reconstructedBalance: (reconstructed / 100).toFixed(2),
+      closed: bool(a.fClosed),
+      openDate: isoDate(a.dtOpen),
+      closeDate: isoDate(a.dtClose),
+      comment: str(a.mComment),
+    };
+  });
+}
+
+function extractTransactions(trnRows: Row[], splitRows: Row[], xferRows: Row[]): MnyTransaction[] {
+  const parentOfChild = new Map<number, number>();
+  const childrenOfParent = new Map<number, number[]>();
+  for (const s of splitRows) {
+    const child = num(s.htrn)!;
+    const parent = num(s.htrnParent)!;
+    parentOfChild.set(child, parent);
+    (childrenOfParent.get(parent) ?? childrenOfParent.set(parent, []).get(parent)!).push(child);
+  }
+  const transferPair = new Map<number, number>();
+  for (const x of xferRows) {
+    const from = num(x.htrnFrom)!;
+    const link = num(x.htrnLink)!;
+    transferPair.set(from, link);
+    transferPair.set(link, from);
+  }
+  const trnById = new Map<number, Row>();
+  for (const t of trnRows) trnById.set(num(t.htrn)!, t);
+
+  const roleOf = (t: Row): MnyRole => {
+    const id = num(t.htrn)!;
+    if (parentOfChild.has(id)) return 'splitChild';
+    if (childrenOfParent.has(id)) return 'splitParent';
+    if (t.hacctLink != null || transferPair.has(id)) return 'transfer';
+    return 'standalone';
+  };
+
+  return trnRows.map((t): MnyTransaction => {
+    const id = num(t.htrn)!;
+    const role = roleOf(t);
+    const base: MnyTransaction = {
+      id,
+      accountId: num(t.hacct)!,
+      date: isoDate(t.dt),
+      amount: decStr(t.amt),
+      categoryId: num(t.hcat) ?? null,
+      payeeId: num(t.lHpay) ?? null, // payee FK is lHpay, NOT hpay
+      memo: str(t.mMemo),
+      ref: str(t.szId),
+      clearedStatus: num(t.cs) ?? 0,
+      linkAccountId: num(t.hacctLink) ?? null,
+      role,
+    };
+
+    if (role === 'splitChild') {
+      base.splitParentId = parentOfChild.get(id) ?? null;
+      base.isTransferLine = t.hacctLink != null;
+    }
+    if (role === 'transfer' || role === 'splitChild') {
+      base.transferPairTxnId = transferPair.get(id) ?? null;
+    }
+    if (role === 'splitParent') {
+      const kids = (childrenOfParent.get(id) ?? []).map(h => trnById.get(h)).filter((r): r is Row => !!r);
+      const parentPennies = pennies(t.amt);
+      const childPennies = kids.reduce((s, k) => s + pennies(k.amt), 0);
+      base.splitChildCount = kids.length;
+      base.splitChildSum = (childPennies / 100).toFixed(2);
+      base.splitUnassignedRemainder = ((parentPennies - childPennies) / 100).toFixed(2);
+      base.splitReconciles = childPennies === parentPennies;
+    }
+    return base;
+  });
+}


### PR DESCRIPTION
First of two PRs for the in-app **Import from Microsoft Money** feature. This one is the engine; the Data Management redesign + import flow follow.

## What
Reads a native `.mny` file in **plain JavaScript** — no Java, no native modules, no WASM. Runs in ~40ms in the browser or Node.

- **`mnyDecrypt.ts`** — MSISAM page decryption. Unmasks the Jet header to recover the salt, derives the per-page RC4 key exactly like `jackcessencrypt`, decrypts the first 0x0e pages. Self-contained RC4 + SHA-1 (deliberately no `crypto.subtle`, so it behaves identically in browser / Node / jsdom / workers). Read-only; password-protected and pre-2002 (MD5) files fail with a clear message rather than silently wrong data.
- **`mnyReader.ts`** — parses the decrypted database (via `mdb-reader`) into the normalised `MnyExport` shape that the existing, already-tested `transform.ts` consumes: account-type & category-kind mappings, split/transfer roles, the v2 split-anomaly enrichments, null-date sentinel, and balance reconstruction (opening + Σ transactions, since Money's stored balance is a dead cache).

## Why it's trustworthy
Verified to **reproduce the earlier Jackcess/Java extraction exactly** — running the reader's output through `transform.ts` yields byte-identical accounts, categories, all 50,860 transactions, and 366 split lines versus the golden seed we already imported to production (only the generation timestamp differs).

## Tests
- RC4 and SHA-1 known-answer vectors; decrypt error handling (non-Money / too-small files).
- A **gated real-file test** (`MNY_TEST_FILE=/path/to.mny`) that decrypts, extracts, and asserts every split reconciles once transformed — mirrors the repo's real-infra test pattern. The `.mny` holds real financial data and is **never committed**.
- Full smoke suite: 3,128 passed. Strict typecheck, lint, production build all clean.

## Follow-up (next PR)
The Data Management page full rework + the import flow (file picker → preview → 'this deletes everything' gate → run). One packaging note to handle there: `mdb-reader`'s browser build needs a `Buffer` polyfill, which I'll wire and verify in a real browser as the first step of that PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)