### PR TITLE
fix(banking): surface OAuth connect errors + grouped alphabetical account picker

### DIFF
--- a/src/components/BankConnections.tsx
+++ b/src/components/BankConnections.tsx
@@ -48,6 +48,7 @@ export default function BankConnections({
   const [syncingConnections, setSyncingConnections] = useState<Set<string>>(new Set());
   const [configStatus, setConfigStatus] = useState({ plaid: false, trueLayer: false });
   const [linkingConnectionId, setLinkingConnectionId] = useState<string | null>(null);
+  const [oauthError, setOauthError] = useState<string | null>(null);
   const logger = useMemo(() => createScopedLogger('BankConnections'), []);
   const { getToken } = useClerkAuth();
 
@@ -97,14 +98,19 @@ export default function BankConnections({
       cleanup();
       void loadConnections();
       if (payload.status === 'success') {
+        setOauthError(null);
         setShowAddBank(false);
         if (payload.connectionId) {
           setLinkingConnectionId(payload.connectionId);
         } else {
           onAccountsLinked?.();
         }
-      } else if (payload.error) {
-        logger.error('OAuth callback returned error', new Error(payload.error));
+      } else {
+        // The popup closes itself moments after an error — if we don't show
+        // the message here, the failure is completely invisible to the user.
+        const errorText = payload.error || 'The bank connection was not completed.';
+        logger.error('OAuth callback returned error', new Error(errorText));
+        setOauthError(errorText);
       }
     };
 
@@ -137,6 +143,7 @@ export default function BankConnections({
 
   const handleConnect = async (institution: BankInstitution) => {
     setIsLoading(true);
+    setOauthError(null);
     try {
       const result = await bankConnectionService.connectBank(
         institution.id,
@@ -158,6 +165,7 @@ export default function BankConnections({
 
   const handleReauthorize = async (connectionId: string) => {
     setIsLoading(true);
+    setOauthError(null);
     try {
       const result = await bankConnectionService.reauthorizeConnection(connectionId);
       if (result.url) {
@@ -271,6 +279,28 @@ export default function BankConnections({
         initialAuditScope={defaultOpsAuditScope}
         initialAuditDateRangePreset={defaultOpsAuditDateRangePreset}
       />
+
+      {/* OAuth failure — surfaced here because the popup self-closes */}
+      {oauthError && (
+        <div className="bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-xl p-4">
+          <div className="flex items-start gap-3">
+            <AlertCircleIcon className="text-red-600 dark:text-red-400 mt-0.5" size={20} />
+            <div className="flex-1">
+              <p className="font-medium text-red-800 dark:text-red-200">
+                Bank connection failed
+              </p>
+              <p className="text-sm text-red-700 dark:text-red-300 mt-1">{oauthError}</p>
+            </div>
+            <button
+              type="button"
+              onClick={() => setOauthError(null)}
+              className="text-sm text-red-700 dark:text-red-300 underline"
+            >
+              Dismiss
+            </button>
+          </div>
+        </div>
+      )}
 
       {/* Header */}
       <div className="flex items-center justify-between">

--- a/src/components/banking/LinkBankAccountsModal.tsx
+++ b/src/components/banking/LinkBankAccountsModal.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState, useCallback, lazy, Suspense } from 'react';
+import React, { useEffect, useState, useCallback, useMemo, lazy, Suspense } from 'react';
 import { Modal, ModalBody, ModalFooter } from '../common/Modal';
 import { bankConnectionService } from '../../services/bankConnectionService';
 import { useApp } from '../../contexts/AppContextSupabase';
@@ -116,6 +116,33 @@ const getMatchReason = (
 
 const CREATE_NEW_VALUE = '__create_new__';
 
+// The picker groups accounts the way the app sections them, alphabetised
+// within each group — a raw insertion-order list is unusable at 200 accounts.
+const ACCOUNT_GROUP_ORDER: Array<{ label: string; types: Array<Account['type']> }> = [
+  { label: 'Current Accounts', types: ['current', 'checking'] },
+  { label: 'Savings', types: ['savings'] },
+  { label: 'Credit Cards', types: ['credit'] },
+  { label: 'Loans', types: ['loan'] },
+  { label: 'Mortgages', types: ['mortgage'] },
+  { label: 'Investments', types: ['investment'] },
+  { label: 'Assets', types: ['asset', 'assets'] },
+  { label: 'Liabilities', types: ['liability'] },
+  { label: 'Other', types: ['other'] }
+];
+
+const groupAccountsForPicker = (
+  accounts: Account[]
+): Array<{ label: string; accounts: Account[] }> => {
+  const active = accounts.filter((a) => a.isActive !== false);
+  return ACCOUNT_GROUP_ORDER.map((group) => ({
+    label: group.label,
+    accounts: active
+      .filter((a) => group.types.includes(a.type))
+      .sort((a, b) => a.name.localeCompare(b.name, undefined, { sensitivity: 'base' }))
+  })).filter((group) => group.accounts.length > 0);
+};
+
+
 export default function LinkBankAccountsModal({
   isOpen,
   onClose,
@@ -130,6 +157,7 @@ export default function LinkBankAccountsModal({
   const [isLinking, setIsLinking] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [createAccountFor, setCreateAccountFor] = useState<string | null>(null);
+  const accountGroups = useMemo(() => groupAccountsForPicker(accounts), [accounts]);
 
   const loadDiscoveredAccounts = useCallback(async () => {
     setIsLoading(true);
@@ -306,15 +334,17 @@ export default function LinkBankAccountsModal({
                         className="w-full px-3 py-2 bg-white dark:bg-gray-800-sm border border-gray-300/50 dark:border-gray-600/50 rounded-xl focus:outline-none focus:ring-2 focus:ring-primary focus:border-transparent dark:text-white text-sm"
                       >
                         <option value="">-- Skip (don&apos;t link) --</option>
-                        {accounts
-                          .filter((a) => a.isActive !== false)
-                          .map((a) => (
-                            <option key={a.id} value={a.id}>
-                              {a.name}
-                              {a.institution ? ` (${a.institution})` : ''}
-                              {a.sortCode ? ` - ${a.sortCode}` : ''}
-                            </option>
-                          ))}
+                        {accountGroups.map((group) => (
+                          <optgroup key={group.label} label={group.label}>
+                            {group.accounts.map((a) => (
+                              <option key={a.id} value={a.id}>
+                                {a.name}
+                                {a.institution ? ` (${a.institution})` : ''}
+                                {a.sortCode ? ` - ${a.sortCode}` : ''}
+                              </option>
+                            ))}
+                          </optgroup>
+                        ))}
                         <option value={CREATE_NEW_VALUE}>+ Create New Account</option>
                       </select>
 


### PR DESCRIPTION
## Why

Two failures Steve hit re-linking feeds after the migration:

**Silent OAuth failures.** Amex authorisation completes at the provider, then nothing appears in the app. Vercel logs show those attempts never reach `exchange-token` — TrueLayer is redirecting back with an `error` instead of a `code`. The callback popup self-closes after 1.2s and `BankConnections` only console-logged the message, so the failure was invisible. Now a dismissible red banner shows the provider's exact error text (cleared on retry/success). Besides being correct UX, this tells us the actual TrueLayer error for the Amex investigation.

**Unusable account picker.** The Link-accounts dropdown rendered 200+ accounts in insertion order. Now grouped into the app's account sections with alphabetical ordering inside each group (native `<optgroup>`). Searchable combobox to follow separately.

## Verification
- `npm run typecheck:strict` ✅ · eslint on both files ✅ · banking suites 49/49 ✅ · `npm run build:check` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)