### PR TITLE
fix(banking): user-scope connection state markers + rate-limit sync/discovery (audit F1+F2)

### DIFF
--- a/api/_lib/banking-sync.ts
+++ b/api/_lib/banking-sync.ts
@@ -146,7 +146,8 @@ export const withTrueLayerAccessToken = async <T>(
 
 export const markConnectionSyncSuccess = async (
   supabase: SupabaseClient,
-  connectionId: string
+  connectionId: string,
+  userId: string
 ): Promise<void> => {
   const nowIso = new Date().toISOString();
   await supabase
@@ -157,12 +158,14 @@ export const markConnectionSyncSuccess = async (
       last_sync: nowIso,
       updated_at: nowIso
     })
-    .eq('id', connectionId);
+    .eq('id', connectionId)
+    .eq('user_id', userId);
 };
 
 export const markConnectionSyncFailure = async (
   supabase: SupabaseClient,
   connectionId: string,
+  userId: string,
   errorMessage: string
 ): Promise<void> => {
   const nowIso = new Date().toISOString();
@@ -173,7 +176,8 @@ export const markConnectionSyncFailure = async (
       error: errorMessage.slice(0, 2000),
       updated_at: nowIso
     })
-    .eq('id', connectionId);
+    .eq('id', connectionId)
+    .eq('user_id', userId);
 };
 
 /**
@@ -184,6 +188,7 @@ export const markConnectionSyncFailure = async (
 export const markConnectionNeedsReauth = async (
   supabase: SupabaseClient,
   connectionId: string,
+  userId: string,
   errorMessage: string
 ): Promise<void> => {
   const nowIso = new Date().toISOString();
@@ -195,7 +200,8 @@ export const markConnectionNeedsReauth = async (
       error: errorMessage.slice(0, 2000),
       updated_at: nowIso
     })
-    .eq('id', connectionId);
+    .eq('id', connectionId)
+    .eq('user_id', userId);
 };
 
 /**
@@ -208,7 +214,8 @@ export const markConnectionNeedsReauth = async (
  */
 export const markConnectionSyncNoAccounts = async (
   supabase: SupabaseClient,
-  connectionId: string
+  connectionId: string,
+  userId: string
 ): Promise<void> => {
   const nowIso = new Date().toISOString();
   await supabase
@@ -217,5 +224,6 @@ export const markConnectionSyncNoAccounts = async (
       last_sync: nowIso,
       updated_at: nowIso
     })
-    .eq('id', connectionId);
+    .eq('id', connectionId)
+    .eq('user_id', userId);
 };

--- a/api/banking/sync-accounts.ts
+++ b/api/banking/sync-accounts.ts
@@ -6,6 +6,7 @@ import type {
 import { AuthError, requireAuth } from '../_lib/auth.js';
 import { getServiceRoleSupabase } from '../_lib/supabase.js';
 import { setCorsHeaders } from '../_lib/cors.js';
+import { applyRateLimit } from '../_lib/rate-limit.js';
 import { createErrorResponse } from '../_lib/http-error.js';
 import { captureServerError, withSentry } from '../_lib/sentry.js';
 import {
@@ -304,13 +305,19 @@ async function handler(req: VercelRequest, res: VercelResponse) {
     return;
   }
 
+  if (await applyRateLimit(req, res, { name: 'sync-accounts', limit: 6, windowMs: 60_000 })) {
+    return;
+  }
+
   if (req.method !== 'POST') {
     res.setHeader('Allow', 'POST');
     return createErrorResponse(res, 405, 'Method not allowed', 'method_not_allowed');
   }
 
+  let authUserId: string | null = null;
   try {
     const auth = await requireAuth(req);
+    authUserId = auth.userId;
     const supabase = getServiceRoleSupabase();
     const body = req.body as SyncAccountsRequest | undefined;
     if (!body || typeof body.connectionId !== 'string' || !body.connectionId.trim()) {
@@ -387,7 +394,7 @@ async function handler(req: VercelRequest, res: VercelResponse) {
 
     await persistAccountsAndLinks(supabase, auth.userId, connection, accounts);
 
-    await markConnectionSyncSuccess(supabase, connection.id);
+    await markConnectionSyncSuccess(supabase, connection.id, auth.userId);
     await supabase.from('sync_history').insert({
       connection_id: connection.id,
       sync_type: 'accounts',
@@ -422,15 +429,21 @@ async function handler(req: VercelRequest, res: VercelResponse) {
       await captureServerError(error, { handler: 'sync-accounts' });
     }
     const body = req.body as SyncAccountsRequest | undefined;
-    if (body?.connectionId) {
-      const sb = getServiceRoleSupabase();
+    // body.connectionId is client-supplied and the service-role client
+    // bypasses RLS — re-validate ownership before persisting any failure
+    // state, or one user could flip another's connection to error/reauth.
+    const sb = getServiceRoleSupabase();
+    const ownedConnection = body?.connectionId && authUserId
+      ? await getUserTrueLayerConnection(sb, authUserId, body.connectionId.trim())
+      : null;
+    if (ownedConnection && authUserId) {
       if (needsReauth) {
-        await markConnectionNeedsReauth(sb, body.connectionId, message);
+        await markConnectionNeedsReauth(sb, ownedConnection.id, authUserId, message);
       } else {
-        await markConnectionSyncFailure(sb, body.connectionId, message);
+        await markConnectionSyncFailure(sb, ownedConnection.id, authUserId, message);
       }
       await sb.from('sync_history').insert({
-        connection_id: body.connectionId,
+        connection_id: ownedConnection.id,
         sync_type: 'accounts',
         status: 'failed',
         records_synced: 0,

--- a/api/banking/sync-transactions.ts
+++ b/api/banking/sync-transactions.ts
@@ -130,8 +130,10 @@ async function handler(req: VercelRequest, res: VercelResponse) {
     return createErrorResponse(res, 405, 'Method not allowed', 'method_not_allowed');
   }
 
+  let authUserId: string | null = null;
   try {
     const auth = await requireAuth(req);
+    authUserId = auth.userId;
     const supabase = getServiceRoleSupabase();
     const body = req.body as SyncTransactionsRequest | undefined;
     if (!body || typeof body.connectionId !== 'string' || !body.connectionId.trim()) {
@@ -159,7 +161,7 @@ async function handler(req: VercelRequest, res: VercelResponse) {
     if (linkedAccounts.length === 0) {
       // No linked accounts: record the run but DON'T flip status to 'connected'
       // (issue #23) — that would mask a broken/needs-reauth connection as healthy.
-      await markConnectionSyncNoAccounts(supabase, connection.id);
+      await markConnectionSyncNoAccounts(supabase, connection.id, auth.userId);
       await supabase.from('sync_history').insert({
         connection_id: connection.id,
         sync_type: 'transactions',
@@ -193,7 +195,7 @@ async function handler(req: VercelRequest, res: VercelResponse) {
     if (mappedLinkedAccounts.length === 0) {
       // Linked accounts exist but none map to the user's accounts: same masking
       // risk as above (issue #23) — record the run without forcing 'connected'.
-      await markConnectionSyncNoAccounts(supabase, connection.id);
+      await markConnectionSyncNoAccounts(supabase, connection.id, auth.userId);
       const response: SyncTransactionsResponse = {
         success: true,
         transactionsImported: 0,
@@ -365,7 +367,7 @@ async function handler(req: VercelRequest, res: VercelResponse) {
 
     const duplicatesSkipped = prepared.length - insertedCount;
 
-    await markConnectionSyncSuccess(supabase, connection.id);
+    await markConnectionSyncSuccess(supabase, connection.id, auth.userId);
     await supabase.from('sync_history').insert({
       connection_id: connection.id,
       sync_type: 'transactions',
@@ -400,15 +402,21 @@ async function handler(req: VercelRequest, res: VercelResponse) {
     if (!needsReauth) {
       await captureServerError(error, { handler: 'sync-transactions' });
     }
-    if (body?.connectionId) {
-      const sb = getServiceRoleSupabase();
+    // body.connectionId is client-supplied and the service-role client
+    // bypasses RLS — re-validate ownership before persisting any failure
+    // state, or one user could flip another's connection to error/reauth.
+    const sb = getServiceRoleSupabase();
+    const ownedConnection = body?.connectionId && authUserId
+      ? await getUserTrueLayerConnection(sb, authUserId, body.connectionId.trim())
+      : null;
+    if (ownedConnection && authUserId) {
       if (needsReauth) {
-        await markConnectionNeedsReauth(sb, body.connectionId, message);
+        await markConnectionNeedsReauth(sb, ownedConnection.id, authUserId, message);
       } else {
-        await markConnectionSyncFailure(sb, body.connectionId, message);
+        await markConnectionSyncFailure(sb, ownedConnection.id, authUserId, message);
       }
       await sb.from('sync_history').insert({
-        connection_id: body.connectionId,
+        connection_id: ownedConnection.id,
         sync_type: 'transactions',
         status: 'failed',
         records_synced: 0,


### PR DESCRIPTION
## Why

Today's lead-engineer audit of PRs #95–#112 surfaced two security findings in the banking sync handlers; this closes both.

**F1 — cross-user connection tampering window (medium).** The `catch` blocks in `sync-accounts` / `sync-transactions` persisted failure state using the raw client-supplied `body.connectionId`, and the `markConnection*` helpers updated `bank_connections` filtered **only by id** — under the service-role client, which bypasses RLS. Any exception thrown before ownership validation would let an authenticated attacker flip a victim's connection to `error`/`reauth_required` (silently stopping their feed, showing a false Reauthorize prompt) and write bogus `sync_history` rows. Now:
- all four marker helpers (`SyncSuccess`, `SyncFailure`, `NeedsReauth`, `SyncNoAccounts`) require and filter by `user_id`
- the catch blocks re-validate ownership (`getUserTrueLayerConnection`) before persisting anything

**F2 — missing rate limits (low).** `sync-accounts` and `discover-accounts` make fan-out TrueLayer calls (one balance call per account) but had no rate limit, unlike their siblings. Added `applyRateLimit` mirroring `sync-transactions`: 6/min for sync-accounts, 10/min for discover-accounts.

## Verification
- `npm run typecheck:strict` ✅ · standalone strict tsc over all 4 api files ✅ · eslint ✅ · `npm run build:check` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)