### PR TITLE
feat(import): Data Management redesign + Microsoft Money import flow

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,7 @@
         "@types/uuid": "^10.0.0",
         "ag-grid-community": "^34.1.2",
         "ag-grid-react": "^34.1.2",
+        "buffer": "^6.0.3",
         "crypto-js": "^4.2.0",
         "date-fns": "^4.1.0",
         "decimal.js": "^10.6.0",
@@ -6635,7 +6636,6 @@
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
       "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -6816,10 +6816,9 @@
       }
     },
     "node_modules/buffer": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
-      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
-      "dev": true,
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
       "funding": [
         {
           "type": "github",
@@ -6837,7 +6836,7 @@
       "license": "MIT",
       "dependencies": {
         "base64-js": "^1.3.1",
-        "ieee754": "^1.1.13"
+        "ieee754": "^1.2.1"
       }
     },
     "node_modules/buffer-crc32": {
@@ -10378,7 +10377,6 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
       "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -15261,6 +15259,31 @@
         "buffer": "^5.5.0",
         "inherits": "^2.0.4",
         "readable-stream": "^3.4.0"
+      }
+    },
+    "node_modules/tar-stream/node_modules/buffer": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
       }
     },
     "node_modules/tar-stream/node_modules/readable-stream": {

--- a/package.json
+++ b/package.json
@@ -98,6 +98,7 @@
     "@types/uuid": "^10.0.0",
     "ag-grid-community": "^34.1.2",
     "ag-grid-react": "^34.1.2",
+    "buffer": "^6.0.3",
     "crypto-js": "^4.2.0",
     "date-fns": "^4.1.0",
     "decimal.js": "^10.6.0",

--- a/src/components/MsMoneyImportModal.tsx
+++ b/src/components/MsMoneyImportModal.tsx
@@ -1,0 +1,278 @@
+/**
+ * Microsoft Money import — the user-facing destructive "total migration" flow.
+ *
+ *   pick .mny → decrypt + transform in-browser → PREVIEW exactly what will
+ *   import → download a safety backup + type DELETE → run (with progress).
+ *
+ * Parsing is entirely client-side (see mnyReader). The destructive execution is
+ * handed to `onExecute`, which the page wires to the local or cloud path.
+ */
+import { useCallback, useRef, useState } from 'react';
+import { XCircleIcon, UploadIcon, AlertCircleIcon, CheckCircleIcon, DownloadIcon, DatabaseIcon } from './icons';
+import { readMnyExport, MnyReadError } from '../services/import/msMoney/mnyReader';
+import { MnyDecryptError } from '../services/import/msMoney/mnyDecrypt';
+import { transformMsMoneyExport, type MsMoneyImportResult } from '../services/import/msMoney/transform';
+import type { ImportProgress } from '../services/import/msMoney/msMoneyImport';
+import { createScopedLogger } from '../loggers/scopedLogger';
+
+const logger = createScopedLogger('MsMoneyImport');
+const CONFIRM_WORD = 'DELETE';
+
+type Stage = 'pick' | 'reading' | 'preview' | 'importing' | 'done' | 'error';
+
+interface Props {
+  isOpen: boolean;
+  onClose: () => void;
+  /** Download a JSON backup of the CURRENT data before wiping. */
+  onBackup: () => void;
+  /** Run the destructive import; resolves when the data is in place. */
+  onExecute: (result: MsMoneyImportResult, onProgress: (p: ImportProgress) => void) => Promise<void>;
+  /** Called after a successful import so the page can reload app data. */
+  onImported: () => void;
+}
+
+export default function MsMoneyImportModal({ isOpen, onClose, onBackup, onExecute, onImported }: Props) {
+  const [stage, setStage] = useState<Stage>('pick');
+  const [fileName, setFileName] = useState('');
+  const [result, setResult] = useState<MsMoneyImportResult | null>(null);
+  const [error, setError] = useState('');
+  const [confirmText, setConfirmText] = useState('');
+  const [backedUp, setBackedUp] = useState(false);
+  const [progress, setProgress] = useState<ImportProgress | null>(null);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  const reset = useCallback(() => {
+    setStage('pick'); setFileName(''); setResult(null); setError('');
+    setConfirmText(''); setBackedUp(false); setProgress(null);
+  }, []);
+
+  const handleClose = useCallback(() => {
+    if (stage === 'importing') return; // never interrupt a destructive write
+    reset();
+    onClose();
+  }, [stage, reset, onClose]);
+
+  const handleFile = useCallback(async (file: File) => {
+    setFileName(file.name);
+    setStage('reading');
+    setError('');
+    try {
+      const bytes = new Uint8Array(await file.arrayBuffer());
+      const exported = readMnyExport(bytes);
+      const transformed = transformMsMoneyExport(exported, new Date().toISOString());
+      setResult(transformed);
+      setStage('preview');
+    } catch (err) {
+      logger.error('Failed to read .mny file', err);
+      const msg = err instanceof MnyDecryptError || err instanceof MnyReadError
+        ? err.message
+        : 'Could not read this file. Please choose a valid Microsoft Money (.mny) file.';
+      setError(msg);
+      setStage('error');
+    }
+  }, []);
+
+  const onInputChange = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (file) void handleFile(file);
+  }, [handleFile]);
+
+  const handleBackup = useCallback(() => {
+    onBackup();
+    setBackedUp(true);
+  }, [onBackup]);
+
+  const runImport = useCallback(async () => {
+    if (!result) return;
+    setStage('importing');
+    setProgress({ phase: 'wiping', fraction: 0, message: 'Starting…' });
+    try {
+      await onExecute(result, setProgress);
+      setStage('done');
+      onImported();
+    } catch (err) {
+      logger.error('MS Money import failed', err);
+      setError(err instanceof Error ? err.message : 'The import failed. Your backup file is safe.');
+      setStage('error');
+    }
+  }, [result, onExecute, onImported]);
+
+  if (!isOpen) return null;
+
+  const s = result?.summary;
+  const confirmReady = confirmText.trim().toUpperCase() === CONFIRM_WORD && backedUp;
+
+  return (
+    <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50 p-4">
+      <div className="bg-white dark:bg-gray-800 rounded-2xl max-w-2xl w-full max-h-[90vh] overflow-hidden flex flex-col">
+        <div className="p-6 border-b border-gray-200 dark:border-gray-700 flex justify-between items-center">
+          <div className="flex items-center gap-3">
+            <DatabaseIcon size={22} className="text-[#1a2332] dark:text-blue-400" />
+            <h2 className="text-xl font-bold text-gray-900 dark:text-white">Import from Microsoft Money</h2>
+          </div>
+          <button onClick={handleClose} disabled={stage === 'importing'}
+            className="text-gray-400 hover:text-gray-600 dark:hover:text-gray-300 disabled:opacity-40"
+            aria-label="Close">
+            <XCircleIcon size={24} />
+          </button>
+        </div>
+
+        <div className="p-6 overflow-y-auto">
+          {/* ── Pick ─────────────────────────────────────────────── */}
+          {stage === 'pick' && (
+            <div className="text-center py-6">
+              <p className="text-gray-600 dark:text-gray-400 mb-6 max-w-md mx-auto">
+                Import your complete Microsoft Money history — every account, transaction,
+                category and transfer. Your <code>.mny</code> file is read entirely in your
+                browser; nothing is uploaded until you confirm.
+              </p>
+              <input ref={inputRef} type="file" accept=".mny" onChange={onInputChange} className="hidden" />
+              <button onClick={() => inputRef.current?.click()}
+                className="px-5 py-3 bg-[#1a2332] dark:bg-blue-600 text-white rounded-lg hover:bg-[#2d3a4d] dark:hover:bg-blue-700 transition-colors inline-flex items-center gap-2 font-medium">
+                <UploadIcon size={20} />
+                Choose Microsoft Money file
+              </button>
+            </div>
+          )}
+
+          {/* ── Reading ──────────────────────────────────────────── */}
+          {stage === 'reading' && (
+            <div className="text-center py-10">
+              <div className="inline-block h-8 w-8 border-2 border-[#1a2332] dark:border-blue-500 border-t-transparent rounded-full animate-spin mb-4" />
+              <p className="text-gray-600 dark:text-gray-400">Reading {fileName}…</p>
+            </div>
+          )}
+
+          {/* ── Preview + gate ───────────────────────────────────── */}
+          {stage === 'preview' && s && (
+            <div className="space-y-5">
+              <div>
+                <p className="text-sm text-gray-500 dark:text-gray-400 mb-2">
+                  Read <span className="font-medium text-gray-700 dark:text-gray-300">{fileName}</span> — here's what will be imported:
+                </p>
+                <div className="grid grid-cols-2 sm:grid-cols-3 gap-3">
+                  <Stat label="Accounts" value={`${s.accounts.total}`} sub={`${s.accounts.open} open · ${s.accounts.closed} closed`} />
+                  <Stat label="Transactions" value={s.transactions.imported.toLocaleString()} sub={`${s.transactions.transfers.toLocaleString()} transfers`} />
+                  <Stat label="Categories" value={`${s.categories.subs + s.categories.details}`} sub={`${s.categories.subs} groups`} />
+                  <Stat label="Split transactions" value={`${s.transactions.splitTransactions}`} sub={`${s.transactions.splitLines} lines`} />
+                  <Stat label="Standalone" value={s.transactions.standalone.toLocaleString()} />
+                </div>
+              </div>
+
+              {s.simplifications.length > 0 && (
+                <details className="text-sm">
+                  <summary className="cursor-pointer text-gray-600 dark:text-gray-400 font-medium">
+                    {s.simplifications.length} note{s.simplifications.length > 1 ? 's' : ''} about how a few edge cases were handled
+                  </summary>
+                  <ul className="list-disc list-inside mt-2 space-y-1 text-gray-500 dark:text-gray-400">
+                    {s.simplifications.map((line, i) => <li key={i}>{line}</li>)}
+                  </ul>
+                </details>
+              )}
+
+              {/* Danger gate */}
+              <div className="rounded-xl border border-red-200 dark:border-red-800 bg-red-50 dark:bg-red-900/20 p-4 space-y-3">
+                <div className="flex items-start gap-2">
+                  <AlertCircleIcon size={20} className="text-red-600 dark:text-red-400 mt-0.5 shrink-0" />
+                  <p className="text-sm text-red-800 dark:text-red-200">
+                    This is a <strong>total migration</strong>. It will <strong>permanently delete all of your current
+                    data</strong> (accounts, transactions, budgets, goals) and replace it with the Microsoft Money import.
+                    This cannot be undone.
+                  </p>
+                </div>
+                <button onClick={handleBackup}
+                  className={`w-full px-4 py-2 rounded-lg border text-sm font-medium inline-flex items-center justify-center gap-2 transition-colors ${
+                    backedUp
+                      ? 'border-green-300 dark:border-green-700 text-green-700 dark:text-green-300 bg-green-50 dark:bg-green-900/20'
+                      : 'border-gray-300 dark:border-gray-600 text-gray-700 dark:text-gray-200 hover:bg-white dark:hover:bg-gray-800'
+                  }`}>
+                  {backedUp ? <><CheckCircleIcon size={16} /> Backup downloaded</> : <><DownloadIcon size={16} /> Download a backup of my current data first</>}
+                </button>
+                <div>
+                  <label className="block text-sm text-gray-700 dark:text-gray-300 mb-1">
+                    Type <span className="font-mono font-bold">{CONFIRM_WORD}</span> to confirm
+                  </label>
+                  <input value={confirmText} onChange={e => setConfirmText(e.target.value)}
+                    placeholder={CONFIRM_WORD}
+                    className="w-full px-3 py-2 rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-900 text-gray-900 dark:text-white focus:outline-none focus:ring-2 focus:ring-red-500" />
+                  {!backedUp && (
+                    <p className="text-xs text-gray-500 dark:text-gray-400 mt-1">Download a backup to enable the import.</p>
+                  )}
+                </div>
+              </div>
+
+              <div className="flex gap-3">
+                <button onClick={handleClose}
+                  className="flex-1 px-4 py-2 border border-gray-300 dark:border-gray-600 text-gray-700 dark:text-gray-300 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-700">
+                  Cancel
+                </button>
+                <button onClick={runImport} disabled={!confirmReady}
+                  className="flex-1 px-4 py-2 bg-red-700 text-white rounded-lg hover:bg-red-800 disabled:opacity-40 disabled:cursor-not-allowed font-medium">
+                  Delete everything &amp; import
+                </button>
+              </div>
+            </div>
+          )}
+
+          {/* ── Importing ────────────────────────────────────────── */}
+          {stage === 'importing' && progress && (
+            <div className="py-8">
+              <p className="text-center text-gray-700 dark:text-gray-300 mb-4">{progress.message}</p>
+              <div className="h-2 rounded-full bg-gray-200 dark:bg-gray-700 overflow-hidden">
+                <div className="h-full bg-[#1a2332] dark:bg-blue-600 transition-[width] duration-300"
+                  style={{ width: `${Math.round(progress.fraction * 100)}%` }} />
+              </div>
+              <p className="text-center text-xs text-gray-500 dark:text-gray-400 mt-3">
+                Please keep this window open until the import finishes.
+              </p>
+            </div>
+          )}
+
+          {/* ── Done ─────────────────────────────────────────────── */}
+          {stage === 'done' && s && (
+            <div className="text-center py-8">
+              <CheckCircleIcon size={40} className="text-green-600 dark:text-green-400 mx-auto mb-3" />
+              <h3 className="text-lg font-semibold text-gray-900 dark:text-white mb-1">Import complete</h3>
+              <p className="text-gray-600 dark:text-gray-400 mb-6">
+                {s.accounts.total} accounts and {s.transactions.imported.toLocaleString()} transactions are now in WealthTracker.
+              </p>
+              <button onClick={handleClose}
+                className="px-5 py-2 bg-[#1a2332] dark:bg-blue-600 text-white rounded-lg hover:bg-[#2d3a4d] dark:hover:bg-blue-700 font-medium">
+                Done
+              </button>
+            </div>
+          )}
+
+          {/* ── Error ────────────────────────────────────────────── */}
+          {stage === 'error' && (
+            <div className="text-center py-8">
+              <AlertCircleIcon size={40} className="text-red-600 dark:text-red-400 mx-auto mb-3" />
+              <h3 className="text-lg font-semibold text-gray-900 dark:text-white mb-1">Something went wrong</h3>
+              <p className="text-gray-600 dark:text-gray-400 mb-6 max-w-md mx-auto">{error}</p>
+              <div className="flex gap-3 justify-center">
+                <button onClick={handleClose}
+                  className="px-4 py-2 border border-gray-300 dark:border-gray-600 text-gray-700 dark:text-gray-300 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-700">
+                  Close
+                </button>
+                <button onClick={reset}
+                  className="px-4 py-2 bg-[#1a2332] dark:bg-blue-600 text-white rounded-lg hover:bg-[#2d3a4d] dark:hover:bg-blue-700">
+                  Try another file
+                </button>
+              </div>
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function Stat({ label, value, sub }: { label: string; value: string; sub?: string }) {
+  return (
+    <div className="rounded-xl border border-gray-100 dark:border-gray-700 bg-gray-50 dark:bg-gray-800/50 p-3">
+      <p className="text-xs uppercase tracking-wider text-gray-500 dark:text-gray-400 font-medium">{label}</p>
+      <p className="text-xl font-bold text-gray-900 dark:text-white mt-0.5">{value}</p>
+      {sub && <p className="text-xs text-gray-500 dark:text-gray-400 mt-0.5">{sub}</p>}
+    </div>
+  );
+}

--- a/src/pages/settings/DataManagement.tsx
+++ b/src/pages/settings/DataManagement.tsx
@@ -1,9 +1,16 @@
-import { useState, lazy, Suspense, useMemo } from 'react';
+import { useState, lazy, Suspense, useMemo, useCallback } from 'react';
 import { useApp } from '../../contexts/AppContextSupabase';
-import { DownloadIcon, DeleteIcon, AlertCircleIcon, UploadIcon, DatabaseIcon, FileTextIcon, SearchIcon, GridIcon, EditIcon, LinkIcon, WrenchIcon, CreditCardIcon, LightbulbIcon, XCircleIcon, FolderIcon } from '../../components/icons';
+import { DownloadIcon, DeleteIcon, AlertCircleIcon, UploadIcon, DatabaseIcon, FileTextIcon, SearchIcon, GridIcon, EditIcon, LinkIcon, WrenchIcon, CreditCardIcon, LightbulbIcon, XCircleIcon, FolderIcon, type IconProps } from '../../components/icons';
 import { LoadingState } from '../../components/loading/LoadingState';
 import { createScopedLogger } from '../../loggers/scopedLogger';
 import { parseBankingOpsUrlState, replaceBrowserSearch, withBankingOpsUrlState } from '../../utils/bankingOpsUrlState';
+import { DataService } from '../../services/api/dataService';
+import { supabase } from '../../lib/supabase';
+import { STORAGE_KEYS } from '../../services/storageAdapter';
+import type { MsMoneyImportResult } from '../../services/import/msMoney/transform';
+import type { ImportProgress } from '../../services/import/msMoney/msMoneyImport';
+
+const MsMoneyImportModal = lazy(() => import('../../components/MsMoneyImportModal'));
 
 // Lazy load heavy components to reduce initial bundle size
 const DataMigrationWizard = lazy(() => import('../../components/DataMigrationWizard'));
@@ -25,7 +32,7 @@ const AutomaticBackupSettings = lazy(() => import('../../components/AutomaticBac
 const dataManagementLogger = createScopedLogger('DataManagementPage');
 
 export default function DataManagementSettings() {
-  const { accounts, transactions, budgets, clearAllData, exportData, loadTestData, hasTestData } = useApp();
+  const { accounts, transactions, budgets, clearAllData, exportData, loadTestData, hasTestData, isUsingSupabase } = useApp();
   const initialBankingOpsUrlState = useMemo(
     () => parseBankingOpsUrlState(typeof window !== 'undefined' ? window.location.search : ''),
     []
@@ -53,6 +60,29 @@ export default function DataManagementSettings() {
   const [showBankConnectionsWithAuditScope, setShowBankConnectionsWithAuditScope] = useState(initialBankingOpsUrlState.auditScope);
   const [showBankConnectionsWithAuditDateRangePreset, setShowBankConnectionsWithAuditDateRangePreset] = useState(initialBankingOpsUrlState.auditDateRangePreset);
   const [showMigrationWizard, setShowMigrationWizard] = useState(false);
+  const [showMsMoneyImport, setShowMsMoneyImport] = useState(false);
+
+  // Run the destructive MS Money import against the right backend: Supabase for
+  // signed-in users (batched inserts under RLS), local storage otherwise. The
+  // modal owns the confirmation + backup gate; this only executes.
+  const executeMsMoneyImport = useCallback(async (
+    result: MsMoneyImportResult,
+    onProgress: (p: ImportProgress) => void
+  ) => {
+    const { importToCloud, importToLocalStorage } = await import('../../services/import/msMoney/msMoneyImport');
+    const databaseUserId = DataService.getUserIds().databaseId;
+    if (isUsingSupabase && supabase && databaseUserId) {
+      await importToCloud(result, supabase, databaseUserId, () => crypto.randomUUID(), { onProgress });
+    } else {
+      await importToLocalStorage(result, STORAGE_KEYS, { onProgress });
+    }
+  }, [isUsingSupabase]);
+
+  // A total migration replaces everything — reload so the app re-reads the new
+  // dataset cleanly rather than reconciling against stale in-memory state.
+  const handleMsMoneyImported = useCallback(() => {
+    window.setTimeout(() => window.location.reload(), 1200);
+  }, []);
 
   const replaceBankingOpsQueryState = (updates: Parameters<typeof withBankingOpsUrlState>[1]) => {
     if (typeof window === 'undefined') {
@@ -122,163 +152,92 @@ export default function DataManagementSettings() {
           keeps only the URL-driven modal below so ops alert deep links
           (banking incident emails) keep working. */}
 
-      <div className="bg-white dark:bg-gray-800 rounded-2xl shadow p-6 mb-6">
-        <h3 className="text-lg font-semibold text-gray-900 dark:text-white mb-4">Import Options</h3>
-        
-        {/* Migration Wizard - Full Width */}
+      {/* ── Import ─────────────────────────────────────────────── */}
+      <Section title="Import" description="Bring data in from other apps, files, or a full Microsoft Money migration.">
+        {/* Microsoft Money — a first-class total-migration flow */}
         <button
-          onClick={() => setShowMigrationWizard(true)}
-          className="w-full mb-4 px-4 py-3 bg-gradient-to-r from-blue-600 to-purple-600 text-white rounded-lg hover:from-blue-700 hover:to-purple-700 transition-colors flex items-center justify-center gap-2 shadow-lg"
+          onClick={() => setShowMsMoneyImport(true)}
+          className="w-full mb-4 text-left rounded-xl border border-[#1a2332]/15 dark:border-blue-500/30 bg-[#1a2332]/[0.03] dark:bg-blue-500/10 hover:bg-[#1a2332]/[0.06] dark:hover:bg-blue-500/20 transition-colors p-4 flex items-center gap-4"
         >
-          <DatabaseIcon size={20} />
-          <span className="font-medium">Data Migration Wizard (Mint, Quicken, YNAB, etc.)</span>
+          <span className="shrink-0 grid place-items-center h-11 w-11 rounded-lg bg-[#1a2332] dark:bg-blue-600 text-white">
+            <DatabaseIcon size={22} />
+          </span>
+          <span className="min-w-0">
+            <span className="block font-semibold text-gray-900 dark:text-white">Import from Microsoft Money</span>
+            <span className="block text-sm text-gray-500 dark:text-gray-400">
+              Migrate your entire <code>.mny</code> file — every account, transaction and transfer. Replaces all current data.
+            </span>
+          </span>
         </button>
-        
+
+        <ActionButton icon={DatabaseIcon} title="Data Migration Wizard"
+          description="Guided import from Mint, Quicken, YNAB and more" onClick={() => setShowMigrationWizard(true)} />
+
         <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
-          <button
-            onClick={() => setShowBatchImport(true)}
-            className="px-4 py-2 bg-blue-700 text-white rounded-lg hover:bg-blue-800 transition-colors flex items-center justify-center gap-2"
-          >
-            <FolderIcon size={20} />
-            Batch Import Multiple Files
-          </button>
-
-          <button
-            onClick={() => setShowCSVImportWizard(true)}
-            className="px-4 py-2 bg-indigo-600 text-white rounded-lg hover:bg-indigo-700 transition-colors flex items-center justify-center gap-2"
-          >
-            <FileTextIcon size={20} />
-            CSV Import (Bank Statements)
-          </button>
-
-          <button
-            onClick={() => setShowOFXImportModal(true)}
-            className="px-4 py-2 bg-purple-700 text-white rounded-lg hover:bg-purple-800 transition-colors flex items-center justify-center gap-2"
-          >
-            <CreditCardIcon size={20} />
-            OFX Import (Auto Match)
-          </button>
-
-          <button
-            onClick={() => setShowQIFImportModal(true)}
-            className="px-4 py-2 bg-blue-700 text-white rounded-lg hover:bg-blue-800 transition-colors flex items-center justify-center gap-2"
-          >
-            <DatabaseIcon size={20} />
-            QIF Import (Quicken)
-          </button>
-
-          <button
-            onClick={() => setShowImportModal(true)}
-            className="px-4 py-2 bg-gray-500 text-white rounded-lg hover:bg-gray-600 transition-colors flex items-center justify-center gap-2"
-          >
-            <UploadIcon size={20} />
-            Legacy Import (MNY/MBF)
-          </button>
+          <ActionButton icon={FileTextIcon} title="CSV Import" description="Bank statement files" onClick={() => setShowCSVImportWizard(true)} />
+          <ActionButton icon={CreditCardIcon} title="OFX Import" description="Auto-matched bank data" onClick={() => setShowOFXImportModal(true)} />
+          <ActionButton icon={DatabaseIcon} title="QIF Import" description="Quicken export files" onClick={() => setShowQIFImportModal(true)} />
+          <ActionButton icon={FolderIcon} title="Batch Import" description="Several files at once" onClick={() => setShowBatchImport(true)} />
+          <ActionButton icon={UploadIcon} title="Legacy Import" description="Older MNY / MBF files" onClick={() => setShowImportModal(true)} />
         </div>
-      </div>
+      </Section>
 
-      {/* Automatic Backups Section */}
-      <div className="mb-6">
-        <Suspense fallback={<LoadingState />}>
-          <AutomaticBackupSettings />
-        </Suspense>
-      </div>
-
-      <div className="bg-white dark:bg-gray-800 rounded-2xl shadow p-6 mb-6">
-        <h3 className="text-lg font-semibold text-gray-900 dark:text-white mb-4">Export Options</h3>
-        
-        {/* Enhanced Export Manager - Full Width */}
+      {/* ── Export ─────────────────────────────────────────────── */}
+      <Section title="Export" description="Download your data for backup or use elsewhere.">
         <div className="mb-4">
           <Suspense fallback={<LoadingState />}>
             <EnhancedExportManager />
           </Suspense>
         </div>
-        
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
+          <ActionButton icon={DownloadIcon} title="Quick Export" description="Full data as JSON" onClick={handleExportData} />
+          <ActionButton icon={GridIcon} title="Excel Export" description="Spreadsheet format" onClick={() => setShowExcelExport(true)} />
+        </div>
+      </Section>
+
+      {/* ── Backups ────────────────────────────────────────────── */}
+      <Section title="Backups" description="Schedule automatic backups of your data.">
+        <Suspense fallback={<LoadingState />}>
+          <AutomaticBackupSettings />
+        </Suspense>
+      </Section>
+
+      {/* ── Tools ──────────────────────────────────────────────── */}
+      <Section title="Tools" description="Tidy up, reconcile, and improve your data.">
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
+          <ActionButton icon={LightbulbIcon} title="Smart Categorization" description="Auto-categorize with AI" onClick={() => setShowSmartCategorization(true)} />
+          <ActionButton icon={WrenchIcon} title="Import Rules" description="Transformations on import" onClick={() => setShowImportRules(true)} />
+          <ActionButton icon={SearchIcon} title="Find Duplicates" description="Detect repeated transactions" onClick={() => setShowDuplicateDetection(true)} />
+          <ActionButton icon={EditIcon} title="Bulk Edit" description="Change many at once" onClick={() => setShowBulkEdit(true)} />
+          <ActionButton icon={LinkIcon} title="Reconcile Accounts" description="Match against statements" onClick={() => setShowReconciliation(true)} />
+          <ActionButton icon={WrenchIcon} title="Validate & Clean" description="Find and fix data issues" onClick={() => setShowDataValidation(true)} />
+        </div>
+      </Section>
+
+      {/* ── Danger Zone ────────────────────────────────────────── */}
+      <div className="rounded-2xl border border-red-200 dark:border-red-900/50 bg-white dark:bg-gray-800 shadow-sm p-6 mb-6">
+        <h3 className="text-lg font-semibold text-red-700 dark:text-red-400 mb-1">Danger Zone</h3>
+        <p className="text-sm text-gray-500 dark:text-gray-400 mb-4">Irreversible actions — handle with care.</p>
         <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
           <button
-            onClick={handleExportData}
-            className="px-4 py-2 bg-blue-700 text-white rounded-lg hover:bg-blue-800 transition-colors flex items-center justify-center gap-2"
-          >
-            <DownloadIcon size={20} />
-            Quick Export (JSON)
-          </button>
-
-          <button
-            onClick={() => setShowExcelExport(true)}
-            className="px-4 py-2 bg-blue-700 text-white rounded-lg hover:bg-blue-800 transition-colors flex items-center justify-center gap-2"
-          >
-            <GridIcon size={20} />
-            Legacy Excel Export
-          </button>
-        </div>
-      </div>
-
-      <div className="bg-white dark:bg-gray-800 rounded-2xl shadow p-6">
-        <h3 className="text-lg font-semibold text-gray-900 dark:text-white mb-4">Advanced System Data Options</h3>
-        
-        <div className="space-y-3">
-          <button
-            onClick={() => setShowSmartCategorization(true)}
-            className="w-full px-4 py-2 bg-[#1a2332] text-white rounded-lg hover:bg-indigo-700 transition-colors flex items-center justify-center gap-2"
-          >
-            <LightbulbIcon size={20} />
-            Smart Categorization (AI)
-          </button>
-
-          <button
-            onClick={() => setShowImportRules(true)}
-            className="w-full px-4 py-2 bg-purple-600 text-white rounded-lg hover:bg-purple-700 transition-colors flex items-center justify-center gap-2"
-          >
-            <WrenchIcon size={20} />
-            Import Rules & Transformations
-          </button>
-
-          <button
-            onClick={() => setShowDuplicateDetection(true)}
-            className="w-full px-4 py-2 bg-yellow-700 text-white rounded-lg hover:bg-yellow-800 transition-colors flex items-center justify-center gap-2"
-          >
-            <SearchIcon size={20} />
-            Find Duplicate Transactions
-          </button>
-
-          <button
-            onClick={() => setShowBulkEdit(true)}
-            className="w-full px-4 py-2 bg-indigo-600 text-white rounded-lg hover:bg-indigo-700 transition-colors flex items-center justify-center gap-2"
-          >
-            <EditIcon size={20} />
-            Bulk Edit Transactions
-          </button>
-
-          <button
-            onClick={() => setShowReconciliation(true)}
-            className="w-full px-4 py-2 bg-cyan-700 text-white rounded-lg hover:bg-cyan-800 transition-colors flex items-center justify-center gap-2"
-          >
-            <LinkIcon size={20} />
-            Reconcile Accounts
-          </button>
-
-          <button
-            onClick={() => setShowDataValidation(true)}
-            className="w-full px-4 py-2 bg-orange-700 text-white rounded-lg hover:bg-orange-800 transition-colors flex items-center justify-center gap-2"
-          >
-            <WrenchIcon size={20} />
-            Validate & Clean Data
-          </button>
-
-          <button
             onClick={() => setShowTestDataConfirm(true)}
-            className="w-full px-4 py-2 bg-purple-700 text-white rounded-lg hover:bg-purple-800 transition-colors flex items-center justify-center gap-2"
+            className="text-left rounded-xl border border-gray-200 dark:border-gray-700 hover:bg-gray-50 dark:hover:bg-gray-700/50 transition-colors p-3 flex items-center gap-3"
           >
-            <DatabaseIcon size={20} />
-            {hasTestData ? 'Reload Test Data' : 'Load Test Data'}
+            <span className="shrink-0 grid place-items-center h-9 w-9 rounded-lg bg-gray-100 dark:bg-gray-700 text-gray-600 dark:text-gray-300"><DatabaseIcon size={18} /></span>
+            <span className="min-w-0">
+              <span className="block text-sm font-medium text-gray-900 dark:text-white">{hasTestData ? 'Reload Test Data' : 'Load Test Data'}</span>
+              <span className="block text-xs text-gray-500 dark:text-gray-400">Adds sample data to explore features</span>
+            </span>
           </button>
-          
           <button
             onClick={() => setShowDeleteConfirm(true)}
-            className="w-full px-4 py-2 bg-red-700 text-white rounded-lg hover:bg-red-800 transition-colors flex items-center justify-center gap-2"
+            className="text-left rounded-xl border border-red-200 dark:border-red-800 hover:bg-red-50 dark:hover:bg-red-900/20 transition-colors p-3 flex items-center gap-3"
           >
-            <DeleteIcon size={20} />
-            Clear All Data
+            <span className="shrink-0 grid place-items-center h-9 w-9 rounded-lg bg-red-100 dark:bg-red-900/40 text-red-600 dark:text-red-400"><DeleteIcon size={18} /></span>
+            <span className="min-w-0">
+              <span className="block text-sm font-medium text-red-700 dark:text-red-400">Clear All Data</span>
+              <span className="block text-xs text-gray-500 dark:text-gray-400">Permanently delete everything</span>
+            </span>
           </button>
         </div>
       </div>
@@ -363,6 +322,19 @@ export default function DataManagementSettings() {
           DataValidation's full-data sweep were executing on every visit to
           this page. Gating on the show-flag defers chunk + work to first open
           (the Suspense fallback covers the brief load). */}
+
+      {/* Microsoft Money Import */}
+      {showMsMoneyImport && (
+        <Suspense fallback={<LoadingState />}>
+          <MsMoneyImportModal
+            isOpen={showMsMoneyImport}
+            onClose={() => setShowMsMoneyImport(false)}
+            onBackup={handleExportData}
+            onExecute={executeMsMoneyImport}
+            onImported={handleMsMoneyImported}
+          />
+        </Suspense>
+      )}
 
       {/* Data Migration Wizard */}
       {showMigrationWizard && (
@@ -554,5 +526,38 @@ export default function DataManagementSettings() {
       )}
 
     </div>
+  );
+}
+
+/** A titled card that groups related actions — the one section shell. */
+function Section({ title, description, children }: {
+  title: string; description: string; children: React.ReactNode;
+}) {
+  return (
+    <div className="bg-white dark:bg-gray-800 rounded-2xl shadow-sm border border-gray-100 dark:border-gray-700 p-6 mb-6">
+      <h3 className="text-lg font-semibold text-gray-900 dark:text-white">{title}</h3>
+      <p className="text-sm text-gray-500 dark:text-gray-400 mb-4">{description}</p>
+      <div className="space-y-3">{children}</div>
+    </div>
+  );
+}
+
+/** The one action-button style: neutral outline, icon tile, title + hint. */
+function ActionButton({ icon: Icon, title, description, onClick }: {
+  icon: React.ComponentType<IconProps>; title: string; description: string; onClick: () => void;
+}) {
+  return (
+    <button
+      onClick={onClick}
+      className="w-full text-left rounded-xl border border-gray-200 dark:border-gray-700 hover:border-[#1a2332]/30 dark:hover:border-blue-500/40 hover:bg-gray-50 dark:hover:bg-gray-700/50 transition-colors p-3 flex items-center gap-3"
+    >
+      <span className="shrink-0 grid place-items-center h-9 w-9 rounded-lg bg-gray-100 dark:bg-gray-700 text-[#1a2332] dark:text-blue-400">
+        <Icon size={18} />
+      </span>
+      <span className="min-w-0">
+        <span className="block text-sm font-medium text-gray-900 dark:text-white">{title}</span>
+        <span className="block text-xs text-gray-500 dark:text-gray-400">{description}</span>
+      </span>
+    </button>
   );
 }

--- a/src/services/import/msMoney/mnyReader.ts
+++ b/src/services/import/msMoney/mnyReader.ts
@@ -13,6 +13,10 @@
  * (TRN_SPLIT) and transfers (TRN_XFER). Amounts are read as-is and normalised
  * to decimal strings; the transform is the single place money maths happens.
  */
+// Installs Buffer + process shims BEFORE mdb-reader's dependency subtree
+// evaluates — must stay the first import in this file.
+import './nodeGlobalsShim';
+import { Buffer } from 'buffer';
 import MDBReader from 'mdb-reader';
 import { decryptMny } from './mnyDecrypt';
 import type {

--- a/src/services/import/msMoney/msMoneyImport.test.ts
+++ b/src/services/import/msMoney/msMoneyImport.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { planCloudImport, importToLocalStorage } from './msMoneyImport';
+import type { MsMoneyImportResult } from './transform';
+
+function sampleResult(): MsMoneyImportResult {
+  return {
+    accounts: [
+      { id: 'mny-acct-1', name: 'Current', type: 'current', balance: 100, openingBalance: 0, currency: 'GBP', isActive: true, lastUpdated: new Date('2020-01-01') },
+      { id: 'mny-acct-2', name: 'Savings', type: 'savings', balance: 50, openingBalance: 0, currency: 'GBP', isActive: false, lastUpdated: new Date('2020-01-01') },
+    ],
+    categories: [
+      { id: 'type-expense', name: 'Expense', type: 'expense', level: 'type', isSystem: true },
+      { id: 'mny-cat-10', name: 'Food', type: 'expense', level: 'detail', parentId: 'type-expense' },
+      { id: 'mny-tofrom-2', name: 'To/From Savings', type: 'both', level: 'detail', parentId: 'type-transfer', isTransferCategory: true, accountId: 'mny-acct-2' },
+    ],
+    transactions: [
+      { id: 'mny-txn-100', date: new Date('2020-02-01'), description: 'Shop', amount: -20, type: 'expense', category: 'mny-cat-10', accountId: 'mny-acct-1' },
+      // transfer pair 200↔201
+      { id: 'mny-txn-200', date: new Date('2020-02-02'), description: 'To savings', amount: -30, type: 'transfer', category: 'mny-tofrom-2', accountId: 'mny-acct-1', transferAccountId: 'mny-acct-2', linkedTransferId: 'mny-txn-201' },
+      { id: 'mny-txn-201', date: new Date('2020-02-02'), description: 'From current', amount: 30, type: 'transfer', accountId: 'mny-acct-2', transferAccountId: 'mny-acct-1', linkedTransferId: 'mny-txn-200' },
+      // a split parent
+      { id: 'mny-txn-300', date: new Date('2020-02-03'), description: 'Split', amount: -50, type: 'expense', category: '', accountId: 'mny-acct-1', isSplit: true },
+    ] as MsMoneyImportResult['transactions'],
+    transactionSplits: [
+      { id: 'mny-split-300-1', transactionId: 'mny-txn-300', category: 'mny-cat-10', amount: -50, sortOrder: 1 },
+    ],
+    summary: {
+      accounts: { total: 2, open: 1, closed: 1 },
+      categories: { subs: 0, details: 2, hidden: 0 },
+      transactions: { imported: 4, standalone: 1, transfers: 2, splitTransactions: 1, splitLines: 1 },
+      simplifications: [],
+    },
+  };
+}
+
+describe('planCloudImport', () => {
+  it('remaps every cross-reference onto fresh ids and stages links separately', () => {
+    let n = 0;
+    const plan = planCloudImport(sampleResult(), 'user-abc', () => `new-${n++}`);
+
+    // System categories are NOT inserted (they exist per-user already).
+    expect(plan.categories).toHaveLength(2);
+    expect(plan.categories.some(c => c.name === 'Expense')).toBe(false);
+
+    // account 'current' maps to DB type 'checking'; closed stays is_active:false
+    const current = plan.accounts.find(a => a.name === 'Current')!;
+    expect(current.type).toBe('checking');
+    expect(current.user_id).toBe('user-abc');
+    expect(plan.accounts.find(a => a.name === 'Savings')!.is_active).toBe(false);
+
+    // Every account/category/transaction id is a fresh generated id (no mny- ids leak).
+    const allIds = [...plan.accounts, ...plan.categories, ...plan.transactions].map(r => String(r.id));
+    expect(allIds.every(id => id.startsWith('new-'))).toBe(true);
+
+    // Transactions insert WITHOUT linked_transfer_id; the two transfer legs are staged as links.
+    expect(plan.transactions.every(t => !('linked_transfer_id' in t) || t.linked_transfer_id == null)).toBe(true);
+    expect(plan.transferLinks).toHaveLength(2);
+    // Each link points at the *remapped* counterpart, never the original mny id.
+    for (const l of plan.transferLinks) {
+      expect(l.id.startsWith('new-')).toBe(true);
+      expect(l.linked_transfer_id.startsWith('new-')).toBe(true);
+    }
+
+    // Split parent keeps is_split + blank category; its line references the remapped parent + category.
+    const splitParent = plan.transactions.find(t => t.is_split === true)!;
+    expect(splitParent.category).toBe('');
+    expect(plan.splits).toHaveLength(1);
+    expect(plan.splits[0].transaction_id).toBe(splitParent.id);
+    expect(String(plan.splits[0].category).startsWith('new-')).toBe(true);
+  });
+});
+
+describe('importToLocalStorage', () => {
+  const KEYS = { ACCOUNTS: 'a', TRANSACTIONS: 't', CATEGORIES: 'c', TRANSACTION_SPLITS: 's', BUDGETS: 'b', GOALS: 'g', RECURRING: 'r' };
+  beforeEach(() => { window.localStorage.clear(); });
+
+  it('writes the imported collections and clears the rest', async () => {
+    const onProgress = vi.fn();
+    await importToLocalStorage(sampleResult(), KEYS, { onProgress });
+
+    expect(JSON.parse(window.localStorage.getItem('a')!)).toHaveLength(2);
+    expect(JSON.parse(window.localStorage.getItem('t')!)).toHaveLength(4);
+    expect(JSON.parse(window.localStorage.getItem('c')!)).toHaveLength(3);
+    expect(JSON.parse(window.localStorage.getItem('s')!)).toHaveLength(1);
+    // A total migration replaces — the other collections are emptied.
+    expect(window.localStorage.getItem('b')).toBe('[]');
+    expect(window.localStorage.getItem('g')).toBe('[]');
+    expect(window.localStorage.getItem('r')).toBe('[]');
+    // progress reaches the terminal phase
+    expect(onProgress).toHaveBeenLastCalledWith(expect.objectContaining({ phase: 'done', fraction: 1 }));
+  });
+});

--- a/src/services/import/msMoney/msMoneyImport.ts
+++ b/src/services/import/msMoney/msMoneyImport.ts
@@ -1,0 +1,240 @@
+/**
+ * Microsoft Money import execution — the destructive "total migration".
+ *
+ * Takes the app-shaped collections produced by `transformMsMoneyExport` and
+ * replaces ALL of the user's data with them. Two write paths share one plan:
+ *
+ *  - LOCAL (demo / signed-out): rewrites the wealthtracker_* storage keys, the
+ *    same contract demo seeding uses.
+ *  - CLOUD (signed in): wipes then batch-inserts through the authenticated
+ *    Supabase client under RLS — the same ordered wipe + two-pass transfer
+ *    linking + split-leg pinning proven by scripts/mnyCloudImport.mts, minus
+ *    the service role (each row is the user's own, so RLS permits it).
+ *
+ * DESTRUCTIVE: the caller MUST gate this behind an explicit confirmation and
+ * (per the import UI) a fresh export of the current data. Balances are written
+ * as the reconstructed final values, so no per-row balance maths runs here.
+ */
+import type { SupabaseClient } from '@supabase/supabase-js';
+import type { Account } from '../../../types';
+import type { MsMoneyImportResult } from './transform';
+
+export type ImportPhase =
+  | 'wiping' | 'accounts' | 'categories' | 'transactions' | 'links' | 'splits' | 'verifying' | 'done';
+
+export interface ImportProgress {
+  phase: ImportPhase;
+  /** 0–1 overall fraction, for a progress bar. */
+  fraction: number;
+  message: string;
+}
+
+export interface ImportOptions {
+  onProgress?: (p: ImportProgress) => void;
+}
+
+const BATCH = 500;
+const chunk = <T>(arr: T[], size = BATCH): T[][] => {
+  const out: T[][] = [];
+  for (let i = 0; i < arr.length; i += size) out.push(arr.slice(i, i + size));
+  return out;
+};
+
+// ── LOCAL path ───────────────────────────────────────────────────────────────
+
+/**
+ * Replace local storage with the imported collections. Mirrors the demo-seed
+ * storage contract so the app picks it up on the next load.
+ */
+export async function importToLocalStorage(
+  result: MsMoneyImportResult,
+  storageKeys: { ACCOUNTS: string; TRANSACTIONS: string; CATEGORIES: string; TRANSACTION_SPLITS: string; BUDGETS: string; GOALS: string; RECURRING: string },
+  opts: ImportOptions = {}
+): Promise<void> {
+  const { onProgress } = opts;
+  onProgress?.({ phase: 'accounts', fraction: 0.2, message: 'Writing accounts…' });
+  window.localStorage.setItem(storageKeys.ACCOUNTS, JSON.stringify(result.accounts));
+  onProgress?.({ phase: 'categories', fraction: 0.4, message: 'Writing categories…' });
+  window.localStorage.setItem(storageKeys.CATEGORIES, JSON.stringify(result.categories));
+  onProgress?.({ phase: 'transactions', fraction: 0.7, message: 'Writing transactions…' });
+  window.localStorage.setItem(storageKeys.TRANSACTIONS, JSON.stringify(result.transactions));
+  onProgress?.({ phase: 'splits', fraction: 0.9, message: 'Writing splits…' });
+  window.localStorage.setItem(storageKeys.TRANSACTION_SPLITS, JSON.stringify(result.transactionSplits));
+  // Everything else starts clean — a total migration replaces, never merges.
+  window.localStorage.setItem(storageKeys.BUDGETS, '[]');
+  window.localStorage.setItem(storageKeys.GOALS, '[]');
+  window.localStorage.setItem(storageKeys.RECURRING, '[]');
+  onProgress?.({ phase: 'done', fraction: 1, message: 'Import complete.' });
+}
+
+// ── CLOUD path (batched inserts under RLS) ──────────────────────────────────
+
+const DB_ACCOUNT_TYPE = (t: Account['type']): string => (t === 'current' ? 'checking' : t);
+const dateOnly = (d: Date | string): string =>
+  (d instanceof Date ? d.toISOString() : String(d)).slice(0, 10);
+
+interface CloudPlan {
+  accounts: Record<string, unknown>[];
+  categories: Record<string, unknown>[];
+  transactions: Record<string, unknown>[];   // inserted WITHOUT linked_transfer_id
+  transferLinks: { id: string; linked_transfer_id: string }[];
+  splits: Record<string, unknown>[];
+  splitLegPins: { id: string; linked_transfer_split_id: string }[];
+}
+
+/**
+ * Pure: turn the app-shaped collections into DB rows with fresh UUIDs and every
+ * cross-reference remapped. Separated from the I/O so it can be unit-tested.
+ */
+export function planCloudImport(
+  result: MsMoneyImportResult,
+  userId: string,
+  newId: () => string
+): CloudPlan {
+  const acctId = new Map(result.accounts.map(a => [a.id, newId()]));
+  const catId = new Map(result.categories.map(c => [c.id, newId()]));
+  const txnId = new Map(result.transactions.map(t => [t.id, newId()]));
+  const splitId = new Map(result.transactionSplits.map(s => [s.id, newId()]));
+  const cat = (id?: string): string | null => (id && catId.get(id)) || null;
+
+  const accounts = result.accounts.map((a): Record<string, unknown> => ({
+    id: acctId.get(a.id),
+    user_id: userId,
+    name: a.name,
+    type: DB_ACCOUNT_TYPE(a.type),
+    balance: a.balance,
+    initial_balance: a.openingBalance ?? 0,
+    opening_balance_date: a.openingBalanceDate ? dateOnly(a.openingBalanceDate) : null,
+    currency: a.currency || 'GBP',
+    is_active: a.isActive !== false,
+    notes: a.notes ?? null,
+  }));
+
+  const categories = result.categories
+    // System categories (type/transfer roots) already exist per-user; only the
+    // Money-derived sub/detail + To/From rows are inserted.
+    .filter(c => c.isSystem !== true)
+    .map((c): Record<string, unknown> => ({
+      id: catId.get(c.id),
+      user_id: userId,
+      name: c.name,
+      type: c.type,
+      level: c.level,
+      parent_id: c.parentId && catId.has(c.parentId) ? catId.get(c.parentId) : c.parentId ?? null,
+      is_transfer_category: c.isTransferCategory === true,
+      account_id: c.accountId ? acctId.get(c.accountId) ?? null : null,
+      is_active: c.isActive !== false,
+    }));
+
+  const transactions = result.transactions.map((t): Record<string, unknown> => ({
+    id: txnId.get(t.id),
+    user_id: userId,
+    account_id: acctId.get(t.accountId),
+    description: t.description,
+    amount: t.amount,
+    type: t.type,
+    date: dateOnly(t.date),
+    category: t.isSplit ? '' : (cat(t.category) ?? ''),
+    notes: t.notes ?? null,
+    is_cleared: t.cleared === true,
+    is_split: t.isSplit === true,
+    transfer_account_id: t.transferAccountId ? acctId.get(t.transferAccountId) ?? null : null,
+    is_recurring: false,
+  }));
+
+  // Transfer pairs reference each other, so links go in as a second pass.
+  const transferLinks = result.transactions
+    .filter(t => t.linkedTransferId && txnId.has(t.linkedTransferId))
+    .map(t => ({ id: txnId.get(t.id)!, linked_transfer_id: txnId.get(t.linkedTransferId!)! }));
+
+  const splits = result.transactionSplits.map((s): Record<string, unknown> => ({
+    id: splitId.get(s.id),
+    transaction_id: txnId.get(s.transactionId),
+    user_id: userId,
+    category: cat(s.category) ?? '',
+    amount: s.amount,
+    memo: s.memo ?? null,
+    sort_order: s.sortOrder,
+    transfer_account_id: s.transferAccountId ? acctId.get(s.transferAccountId) ?? null : null,
+    linked_transfer_id: s.linkedTransferId ? txnId.get(s.linkedTransferId) ?? null : null,
+  }));
+
+  const splitLegPins = result.transactions
+    .filter(t => t.linkedTransferSplitId && splitId.has(t.linkedTransferSplitId))
+    .map(t => ({ id: txnId.get(t.id)!, linked_transfer_split_id: splitId.get(t.linkedTransferSplitId!)! }));
+
+  return { accounts, categories, transactions, transferLinks, splits, splitLegPins };
+}
+
+/**
+ * Execute the plan against Supabase under the authenticated client. Wipe order
+ * matters: accounts BEFORE categories (the protect_transfer_category trigger
+ * only lets a To/From category go once its account row is gone), and
+ * self-referential transfer links are cleared before the transaction wipe.
+ */
+export async function importToCloud(
+  result: MsMoneyImportResult,
+  supabase: SupabaseClient,
+  userId: string,
+  newId: () => string,
+  opts: ImportOptions = {}
+): Promise<void> {
+  const { onProgress } = opts;
+  const plan = planCloudImport(result, userId, newId);
+  const fail = (stage: string, message: string): never => {
+    throw new Error(`Import failed while ${stage}: ${message}`);
+  };
+
+  onProgress?.({ phase: 'wiping', fraction: 0.02, message: 'Backing out existing data…' });
+  // Clear self-referential FKs first so the row deletes can't trip them.
+  {
+    const { error } = await supabase.from('transactions')
+      .update({ linked_transfer_id: null, linked_transfer_split_id: null })
+      .eq('user_id', userId).not('linked_transfer_id', 'is', null);
+    if (error) fail('unlinking transfers', error.message);
+  }
+  for (const [table, order] of [
+    ['transaction_splits', 0], ['transactions', 1], ['budgets', 2],
+    ['goals', 3], ['accounts', 4], ['categories', 5],
+  ] as [string, number][]) {
+    void order;
+    const { error } = await supabase.from(table).delete().eq('user_id', userId);
+    if (error) fail(`clearing ${table}`, error.message);
+  }
+
+  const insert = async (table: string, rows: Record<string, unknown>[], phase: ImportPhase, base: number, span: number) => {
+    const batches = chunk(rows);
+    let done = 0;
+    for (const b of batches) {
+      const { error } = await supabase.from(table).insert(b);
+      if (error) fail(`inserting ${table}`, error.message);
+      done += b.length;
+      onProgress?.({ phase, fraction: base + span * (done / Math.max(rows.length, 1)),
+        message: `Importing ${table.replace('_', ' ')}… ${done}/${rows.length}` });
+    }
+  };
+
+  await insert('accounts', plan.accounts, 'accounts', 0.05, 0.1);
+  await insert('categories', plan.categories, 'categories', 0.15, 0.1);
+  await insert('transactions', plan.transactions, 'transactions', 0.25, 0.45);
+
+  onProgress?.({ phase: 'links', fraction: 0.72, message: 'Linking transfers…' });
+  for (const b of chunk(plan.transferLinks)) {
+    for (const l of b) {
+      const { error } = await supabase.from('transactions')
+        .update({ linked_transfer_id: l.linked_transfer_id }).eq('id', l.id);
+      if (error) fail('linking transfers', error.message);
+    }
+  }
+
+  await insert('transaction_splits', plan.splits, 'splits', 0.8, 0.12);
+
+  onProgress?.({ phase: 'splits', fraction: 0.95, message: 'Linking split transfers…' });
+  for (const p of plan.splitLegPins) {
+    const { error } = await supabase.from('transactions')
+      .update({ linked_transfer_split_id: p.linked_transfer_split_id }).eq('id', p.id);
+    if (error) fail('pinning split legs', error.message);
+  }
+
+  onProgress?.({ phase: 'done', fraction: 1, message: 'Import complete.' });
+}

--- a/src/services/import/msMoney/nodeGlobalsShim.ts
+++ b/src/services/import/msMoney/nodeGlobalsShim.ts
@@ -1,0 +1,36 @@
+/**
+ * Minimal Node-global shims for the browser, for the .mny reader path only.
+ *
+ * mdb-reader's browser build pulls in create-hash → cipher-base →
+ * readable-stream, which reference the Node globals `Buffer` and `process` at
+ * module-evaluation time. The browser has neither. This module installs tiny
+ * shims and MUST be imported before mdb-reader so the globals exist when its
+ * dependency subtree evaluates.
+ *
+ * Scoped to the lazily-loaded import feature — it never runs in the main
+ * bundle, and it only fills gaps (real Node/Buffer are left untouched).
+ */
+import { Buffer as BufferPolyfill } from 'buffer';
+
+// A deliberately loose structural view of globalThis: the real types
+// (@types/node) declare `process` as the full Node Process, which our minimal
+// shim can't satisfy. Treating the two slots as `unknown` lets us fill only
+// the gaps without a double-cast or `any`.
+const g: { Buffer?: unknown; process?: unknown } = globalThis;
+
+if (typeof g.Buffer === 'undefined') {
+  g.Buffer = BufferPolyfill;
+}
+
+if (typeof g.process === 'undefined') {
+  // Just enough of `process` for readable-stream / cipher-base to evaluate.
+  g.process = {
+    env: {},
+    browser: true,
+    nextTick: (cb: (...args: unknown[]) => void, ...args: unknown[]) => {
+      queueMicrotask(() => cb(...args));
+    },
+    version: '',
+    versions: {},
+  };
+}


### PR DESCRIPTION
The second half of the MS Money feature — the redesigned page and the user-facing import flow, built on the pure-JS reader from #112.

## Data Management redesign (the "sharpen it up" ask)
The page was a wall of buttons in four clashing colours. Now:
- **One button system** — navy + neutral outlines, icon tiles, title + one-line hint. No gradients.
- **Grouped sections**: Import / Export / Backups / Tools / **Danger Zone**. Load-test-data and Clear-all-data moved into the Danger Zone.

## Import from Microsoft Money
A first-class card opens a guided flow:
1. **Pick** a `.mny` file — decrypted + parsed **entirely in the browser** (~5s for a 45MB file, nothing uploaded).
2. **Preview** the exact counts that will import — accounts (open/closed), transactions, transfers, splits, categories — plus notes on edge cases.
3. **Safety gate** — download a backup of current data **and** type `DELETE` to enable the button.
4. **Run** with a progress bar. Framed as a total migration: it replaces all current data.

## Execution engine (`msMoneyImport.ts`)
- **`planCloudImport`** — pure and unit-tested: remaps every id to fresh UUIDs, stages mutually-referencing transfer links and split-leg pins as separate passes, drops per-user system categories.
- **`importToCloud`** — batched inserts under **RLS** via the authenticated client. No service role, no serverless body-size limit; reproduces the ordered wipe + two-pass linking that the migration script already proved on your production data.
- **`importToLocalStorage`** — the demo/local path.

## Verification
- **Full pipeline run in a real browser against the actual 45MB `.mny`** (via a temporary dev-only route, since reverted): decrypt → parse → transform → plan reproduce the golden numbers exactly — 205 accounts, 50,860 transactions, 172 splits, 11,218 transfers, 86 split-leg pins, 259 categories (system roots excluded).
- Redesigned page + modal render with **no console errors**.
- Unit tests for the planner and local write; smoke suite **3,130 passing**; strict typecheck, lint, production build all clean.
- No `.mny` or financial data committed.

## Note on the destructive cloud run
`importToCloud` faithfully mirrors the migration script that already ran successfully on your real data, but I did **not** execute a destructive wipe against production in CI — that stays behind the modal's backup + typed-DELETE gate, triggered by a real user. Worth a first run against a throwaway/second account before wide release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)