### PR TITLE
feat(banking): searchable combobox for the link-accounts picker

### DIFF
--- a/src/components/banking/AccountPickerCombobox.test.tsx
+++ b/src/components/banking/AccountPickerCombobox.test.tsx
@@ -1,0 +1,83 @@
+import { describe, it, expect } from 'vitest';
+import { accountMatchesSearch, groupAccountsForPicker } from './accountPickerOptions';
+import type { Account } from '../../types';
+
+const account = (overrides: Partial<Account>): Account => ({
+  id: 'id',
+  name: 'Name',
+  type: 'current',
+  balance: 0,
+  currency: 'GBP',
+  createdAt: new Date('2026-01-01'),
+  updatedAt: new Date('2026-01-01'),
+  ...overrides
+} as Account);
+
+describe('groupAccountsForPicker', () => {
+  it('groups by section in fixed order and alphabetises within each group', () => {
+    const groups = groupAccountsForPicker([
+      account({ id: 's1', name: 'Zebra Saver', type: 'savings' }),
+      account({ id: 'c1', name: 'Premier Bank', type: 'current' }),
+      account({ id: 'cc1', name: 'Amex BA', type: 'credit' }),
+      account({ id: 'c2', name: 'Basic Current', type: 'current' }),
+      account({ id: 's2', name: 'apple ISA', type: 'savings' })
+    ]);
+
+    expect(groups.map((g) => g.label)).toEqual(['Current Accounts', 'Savings', 'Credit Cards']);
+    expect(groups[0].accounts.map((a) => a.name)).toEqual(['Basic Current', 'Premier Bank']);
+    // case-insensitive alphabetical
+    expect(groups[1].accounts.map((a) => a.name)).toEqual(['apple ISA', 'Zebra Saver']);
+  });
+
+  it('merges current+checking and asset+assets into single sections', () => {
+    const groups = groupAccountsForPicker([
+      account({ id: '1', name: 'A', type: 'checking' }),
+      account({ id: '2', name: 'B', type: 'current' }),
+      account({ id: '3', name: 'C', type: 'asset' }),
+      account({ id: '4', name: 'D', type: 'assets' })
+    ]);
+    expect(groups.map((g) => g.label)).toEqual(['Current Accounts', 'Assets']);
+    expect(groups[0].accounts).toHaveLength(2);
+    expect(groups[1].accounts).toHaveLength(2);
+  });
+
+  it('excludes inactive accounts and empty sections', () => {
+    const groups = groupAccountsForPicker([
+      account({ id: '1', name: 'Open', type: 'current' }),
+      account({ id: '2', name: 'Closed', type: 'savings', isActive: false })
+    ]);
+    expect(groups).toHaveLength(1);
+    expect(groups[0].label).toBe('Current Accounts');
+  });
+});
+
+describe('accountMatchesSearch', () => {
+  const premier = account({
+    id: 'p',
+    name: 'Premier Bank',
+    institution: 'HSBC',
+    sortCode: '40-18-41'
+  });
+
+  it('matches on account name, case-insensitively', () => {
+    expect(accountMatchesSearch(premier, 'premier')).toBe(true);
+    expect(accountMatchesSearch(premier, 'PREM')).toBe(true);
+    expect(accountMatchesSearch(premier, 'zebra')).toBe(false);
+  });
+
+  it('matches on institution', () => {
+    expect(accountMatchesSearch(premier, 'hsbc')).toBe(true);
+  });
+
+  it('matches sort code with or without dashes', () => {
+    expect(accountMatchesSearch(premier, '40-18-41')).toBe(true);
+    expect(accountMatchesSearch(premier, '401841')).toBe(true);
+    expect(accountMatchesSearch(premier, '1841')).toBe(true);
+    expect(accountMatchesSearch(premier, '99-99')).toBe(false);
+  });
+
+  it('empty search matches everything', () => {
+    expect(accountMatchesSearch(premier, '')).toBe(true);
+    expect(accountMatchesSearch(premier, '   ')).toBe(true);
+  });
+});

--- a/src/components/banking/AccountPickerCombobox.tsx
+++ b/src/components/banking/AccountPickerCombobox.tsx
@@ -1,0 +1,330 @@
+import React, { useState, useRef, useEffect, useLayoutEffect, useCallback, useMemo, useId } from 'react';
+import { createPortal } from 'react-dom';
+import type { Account } from '../../types';
+import { CREATE_NEW_VALUE, SKIP_ID, accountMatchesSearch, groupAccountsForPicker } from './accountPickerOptions';
+import { ChevronDownIcon, PlusIcon } from '../icons';
+
+/**
+ * Searchable combobox for picking an app account to link a discovered bank
+ * account to. Follows the accessible combobox pattern proven in
+ * CategorySelector (role="combobox", aria-activedescendant, full keyboard
+ * support), with the account-section grouping from PR #113. Always renders
+ * its menu in a fixed-position portal: it lives inside the Link Accounts
+ * modal, whose scrolling body would clip an in-flow dropdown.
+ */
+
+const accountDisplayText = (account: Account): string =>
+  `${account.name}${account.institution ? ` (${account.institution})` : ''}${account.sortCode ? ` - ${account.sortCode}` : ''}`;
+
+interface MenuPosition {
+  left: number;
+  width: number;
+  maxHeight: number;
+  top?: number;
+  bottom?: number;
+}
+
+interface AccountPickerComboboxProps {
+  accounts: Account[];
+  /** Selected app account id, '' for skip, or CREATE_NEW_VALUE. */
+  value: string;
+  onChange: (value: string) => void;
+  ariaLabel: string;
+}
+
+export default function AccountPickerCombobox({
+  accounts,
+  value,
+  onChange,
+  ariaLabel
+}: AccountPickerComboboxProps): React.JSX.Element {
+  const [open, setOpen] = useState(false);
+  const [searchTerm, setSearchTerm] = useState('');
+  const [highlightIndex, setHighlightIndex] = useState(-1);
+  const [menuPos, setMenuPos] = useState<MenuPosition | null>(null);
+  const containerRef = useRef<HTMLDivElement>(null);
+  const triggerRef = useRef<HTMLDivElement>(null);
+  const menuRef = useRef<HTMLDivElement>(null);
+
+  const instanceId = useId();
+  const listboxId = `${instanceId}-listbox`;
+  const optionDomId = (id: string): string => `${instanceId}-opt-${id}`;
+
+  const groups = useMemo(() => {
+    const grouped = groupAccountsForPicker(accounts);
+    if (!searchTerm.trim()) {
+      return grouped;
+    }
+    return grouped
+      .map((group) => ({
+        label: group.label,
+        accounts: group.accounts.filter((a) => accountMatchesSearch(a, searchTerm))
+      }))
+      .filter((group) => group.accounts.length > 0);
+  }, [accounts, searchTerm]);
+
+  // Flat render-order view of every option the arrow keys can reach.
+  const flatOptions = useMemo(
+    () => [
+      { id: SKIP_ID, label: "Skip (don't link)" },
+      ...groups.flatMap((group) =>
+        group.accounts.map((a) => ({ id: a.id, label: accountDisplayText(a) }))
+      ),
+      { id: CREATE_NEW_VALUE, label: '+ Create New Account' }
+    ],
+    [groups]
+  );
+  const highlightedId = highlightIndex >= 0 ? flatOptions[highlightIndex]?.id : undefined;
+
+  const selectedAccount = value && value !== CREATE_NEW_VALUE
+    ? accounts.find((a) => a.id === value)
+    : undefined;
+
+  // Anchor the portaled menu to the trigger; choose up/down by available space
+  // and track the trigger while the modal body scrolls.
+  const computeMenuPosition = useCallback(() => {
+    const el = triggerRef.current;
+    if (!el) return;
+    const rect = el.getBoundingClientRect();
+    const gap = 4;
+    const maxMenu = 320;
+    const spaceBelow = window.innerHeight - rect.bottom;
+    const spaceAbove = rect.top;
+    const openUp = spaceBelow < Math.min(maxMenu, 240) && spaceAbove > spaceBelow;
+    const available = (openUp ? spaceAbove : spaceBelow) - gap - 8;
+    const maxHeight = Math.max(160, Math.min(maxMenu, available));
+    setMenuPos({
+      left: rect.left,
+      width: rect.width,
+      maxHeight,
+      ...(openUp
+        ? { bottom: window.innerHeight - rect.top + gap }
+        : { top: rect.bottom + gap })
+    });
+  }, []);
+
+  useLayoutEffect(() => {
+    if (!open) {
+      setMenuPos(null);
+      return;
+    }
+    computeMenuPosition();
+    const onReflow = () => computeMenuPosition();
+    // Capture phase so the scrolling modal body also triggers repositioning.
+    window.addEventListener('scroll', onReflow, true);
+    window.addEventListener('resize', onReflow);
+    return () => {
+      window.removeEventListener('scroll', onReflow, true);
+      window.removeEventListener('resize', onReflow);
+    };
+  }, [open, computeMenuPosition]);
+
+  useEffect(() => {
+    setHighlightIndex(-1);
+  }, [open, searchTerm]);
+
+  // Close on outside click — the portaled menu is outside containerRef, so it
+  // must be checked separately or option clicks would close before firing.
+  useEffect(() => {
+    const handleClickOutside = (event: MouseEvent) => {
+      const target = event.target as Node;
+      const inTrigger = containerRef.current?.contains(target) ?? false;
+      const inMenu = menuRef.current?.contains(target) ?? false;
+      if (!inTrigger && !inMenu) {
+        setOpen(false);
+        setSearchTerm('');
+      }
+    };
+    document.addEventListener('mousedown', handleClickOutside);
+    return () => document.removeEventListener('mousedown', handleClickOutside);
+  }, []);
+
+  // Keep the highlighted option scrolled into view while arrowing.
+  useEffect(() => {
+    if (highlightIndex < 0) return;
+    const el = document.querySelector(`[data-highlighted-option="${instanceId}"]`);
+    el?.scrollIntoView?.({ block: 'nearest' });
+  }, [highlightIndex, instanceId]);
+
+  const selectOption = (id: string): void => {
+    onChange(id === SKIP_ID ? '' : id);
+    setOpen(false);
+    setSearchTerm('');
+  };
+
+  const closeAndRefocus = (): void => {
+    setOpen(false);
+    setSearchTerm('');
+    triggerRef.current?.focus();
+  };
+
+  const handleTriggerKeyDown = (e: React.KeyboardEvent<HTMLDivElement>): void => {
+    if (open) return; // the search input owns keys while open
+    if (e.key === 'Enter' || e.key === ' ' || e.key === 'ArrowDown' || e.key === 'ArrowUp') {
+      e.preventDefault();
+      setOpen(true);
+    }
+  };
+
+  const handleSearchKeyDown = (e: React.KeyboardEvent<HTMLInputElement>): void => {
+    switch (e.key) {
+      case 'ArrowDown':
+        e.preventDefault();
+        setHighlightIndex((i) => Math.min(i + 1, flatOptions.length - 1));
+        break;
+      case 'ArrowUp':
+        e.preventDefault();
+        setHighlightIndex((i) => Math.max(i - 1, 0));
+        break;
+      case 'Enter': {
+        e.preventDefault();
+        // With no explicit highlight, Enter picks the sole matching account.
+        const accountOnly = flatOptions.filter(
+          (o) => o.id !== SKIP_ID && o.id !== CREATE_NEW_VALUE
+        );
+        const chosen = flatOptions[highlightIndex] ??
+          (accountOnly.length === 1 ? accountOnly[0] : undefined);
+        if (chosen) selectOption(chosen.id);
+        break;
+      }
+      case 'Escape':
+        e.preventDefault();
+        closeAndRefocus();
+        break;
+      case 'Tab':
+        setOpen(false);
+        setSearchTerm('');
+        break;
+    }
+  };
+
+  const optionClasses = (id: string, extra = ''): string =>
+    `px-3 py-2 cursor-pointer hover:bg-gray-100 dark:hover:bg-gray-600 ${
+      highlightedId === id
+        ? 'bg-gray-100 dark:bg-gray-600'
+        : value === id
+          ? 'bg-blue-50 dark:bg-blue-900/20'
+          : ''
+    } ${extra}`;
+
+  return (
+    <div className="relative" ref={containerRef}>
+      <div
+        ref={triggerRef}
+        tabIndex={0}
+        role="combobox"
+        aria-expanded={open}
+        aria-haspopup="listbox"
+        aria-controls={open ? listboxId : undefined}
+        aria-label={ariaLabel}
+        onKeyDown={handleTriggerKeyDown}
+        onClick={() => setOpen((o) => !o)}
+        className="w-full px-3 py-2 bg-white dark:bg-gray-800 border border-gray-300/50 dark:border-gray-600/50 rounded-xl shadow-sm cursor-text flex items-center justify-between gap-2 text-sm focus:outline-none focus:ring-2 focus:ring-primary"
+      >
+        <div className="flex-1 min-w-0">
+          {open ? (
+            <input
+              type="text"
+              value={searchTerm}
+              onChange={(e) => setSearchTerm(e.target.value)}
+              onKeyDown={handleSearchKeyDown}
+              placeholder="Type to search accounts..."
+              aria-autocomplete="list"
+              aria-controls={listboxId}
+              aria-activedescendant={highlightedId ? optionDomId(highlightedId) : undefined}
+              className="w-full bg-transparent text-gray-900 dark:text-white !border-0 focus:!outline-none focus-visible:!outline-none"
+              autoFocus
+            />
+          ) : selectedAccount ? (
+            <span className="block truncate text-gray-900 dark:text-white">
+              {accountDisplayText(selectedAccount)}
+            </span>
+          ) : (
+            <span className="block truncate text-gray-500 dark:text-gray-400">
+              Skip (don&apos;t link)
+            </span>
+          )}
+        </div>
+        <ChevronDownIcon
+          size={16}
+          className={`text-gray-400 shrink-0 transition-transform ${open ? 'rotate-180' : ''}`}
+        />
+      </div>
+
+      {open && menuPos && createPortal(
+        <div
+          ref={menuRef}
+          id={listboxId}
+          role="listbox"
+          aria-label={ariaLabel}
+          style={{
+            position: 'fixed',
+            left: menuPos.left,
+            width: menuPos.width,
+            maxHeight: menuPos.maxHeight,
+            zIndex: 9999,
+            ...(menuPos.top !== undefined ? { top: menuPos.top } : { bottom: menuPos.bottom })
+          }}
+          className="overflow-y-auto bg-white dark:bg-gray-700 border border-gray-300 dark:border-gray-600 rounded-lg shadow-lg text-sm"
+        >
+          <div
+            id={optionDomId(SKIP_ID)}
+            role="option"
+            aria-selected={value === ''}
+            data-highlighted-option={highlightedId === SKIP_ID ? instanceId : undefined}
+            className={optionClasses(SKIP_ID, 'border-b border-gray-100 dark:border-gray-600')}
+            onClick={() => selectOption(SKIP_ID)}
+          >
+            <span className="italic text-gray-500 dark:text-gray-400">
+              -- Skip (don&apos;t link) --
+            </span>
+          </div>
+
+          {groups.length > 0 ? (
+            groups.map((group) => (
+              <div key={group.label}>
+                <div className="sticky top-0 z-10 px-3 py-1.5 bg-gray-50 dark:bg-gray-800 border-b border-gray-100 dark:border-gray-700 text-[11px] font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-400">
+                  {group.label}
+                </div>
+                {group.accounts.map((account) => (
+                  <div
+                    key={account.id}
+                    id={optionDomId(account.id)}
+                    role="option"
+                    aria-selected={value === account.id}
+                    data-highlighted-option={highlightedId === account.id ? instanceId : undefined}
+                    className={optionClasses(account.id, 'pl-6')}
+                    onClick={() => selectOption(account.id)}
+                  >
+                    <span className="block truncate text-gray-900 dark:text-white">
+                      {accountDisplayText(account)}
+                    </span>
+                  </div>
+                ))}
+              </div>
+            ))
+          ) : (
+            <div className="px-3 py-2 text-gray-500 dark:text-gray-400 text-center">
+              No accounts match &ldquo;{searchTerm}&rdquo;
+            </div>
+          )}
+
+          <div
+            id={optionDomId(CREATE_NEW_VALUE)}
+            role="option"
+            aria-selected={false}
+            data-highlighted-option={highlightedId === CREATE_NEW_VALUE ? instanceId : undefined}
+            className={optionClasses(CREATE_NEW_VALUE, 'border-t border-gray-200 dark:border-gray-600 text-primary dark:text-blue-400')}
+            onClick={() => selectOption(CREATE_NEW_VALUE)}
+          >
+            <div className="flex items-center gap-2">
+              <PlusIcon size={14} />
+              <span className="font-medium">Create New Account</span>
+            </div>
+          </div>
+        </div>,
+        document.body
+      )}
+    </div>
+  );
+}

--- a/src/components/banking/LinkBankAccountsModal.tsx
+++ b/src/components/banking/LinkBankAccountsModal.tsx
@@ -1,10 +1,13 @@
-import React, { useEffect, useState, useCallback, useMemo, lazy, Suspense } from 'react';
+import React, { useEffect, useState, useCallback, lazy, Suspense } from 'react';
 import { Modal, ModalBody, ModalFooter } from '../common/Modal';
 import { bankConnectionService } from '../../services/bankConnectionService';
 import { useApp } from '../../contexts/AppContextSupabase';
 import { useCurrencyDecimal } from '../../hooks/useCurrencyDecimal';
 import type { DiscoveredBankAccount } from '../../types/banking-api';
 import type { Account } from '../../types';
+
+import AccountPickerCombobox from './AccountPickerCombobox';
+import { CREATE_NEW_VALUE } from './accountPickerOptions';
 
 const AddAccountModal = lazy(() => import('../AddAccountModal'));
 
@@ -114,33 +117,6 @@ const getMatchReason = (
   return null;
 };
 
-const CREATE_NEW_VALUE = '__create_new__';
-
-// The picker groups accounts the way the app sections them, alphabetised
-// within each group — a raw insertion-order list is unusable at 200 accounts.
-const ACCOUNT_GROUP_ORDER: Array<{ label: string; types: Array<Account['type']> }> = [
-  { label: 'Current Accounts', types: ['current', 'checking'] },
-  { label: 'Savings', types: ['savings'] },
-  { label: 'Credit Cards', types: ['credit'] },
-  { label: 'Loans', types: ['loan'] },
-  { label: 'Mortgages', types: ['mortgage'] },
-  { label: 'Investments', types: ['investment'] },
-  { label: 'Assets', types: ['asset', 'assets'] },
-  { label: 'Liabilities', types: ['liability'] },
-  { label: 'Other', types: ['other'] }
-];
-
-const groupAccountsForPicker = (
-  accounts: Account[]
-): Array<{ label: string; accounts: Account[] }> => {
-  const active = accounts.filter((a) => a.isActive !== false);
-  return ACCOUNT_GROUP_ORDER.map((group) => ({
-    label: group.label,
-    accounts: active
-      .filter((a) => group.types.includes(a.type))
-      .sort((a, b) => a.name.localeCompare(b.name, undefined, { sensitivity: 'base' }))
-  })).filter((group) => group.accounts.length > 0);
-};
 
 
 export default function LinkBankAccountsModal({
@@ -157,7 +133,6 @@ export default function LinkBankAccountsModal({
   const [isLinking, setIsLinking] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [createAccountFor, setCreateAccountFor] = useState<string | null>(null);
-  const accountGroups = useMemo(() => groupAccountsForPicker(accounts), [accounts]);
 
   const loadDiscoveredAccounts = useCallback(async () => {
     setIsLoading(true);
@@ -325,28 +300,12 @@ export default function LinkBankAccountsModal({
                       <label className="block text-xs font-medium text-gray-600 dark:text-gray-400 mb-1">
                         Link to:
                       </label>
-                      <select
+                      <AccountPickerCombobox
+                        accounts={accounts}
                         value={selectedId}
-                        onChange={(e) =>
-                          updateLink(da.externalAccountId, e.target.value)
-                        }
-                        aria-label={`Link ${da.name} to account`}
-                        className="w-full px-3 py-2 bg-white dark:bg-gray-800-sm border border-gray-300/50 dark:border-gray-600/50 rounded-xl focus:outline-none focus:ring-2 focus:ring-primary focus:border-transparent dark:text-white text-sm"
-                      >
-                        <option value="">-- Skip (don&apos;t link) --</option>
-                        {accountGroups.map((group) => (
-                          <optgroup key={group.label} label={group.label}>
-                            {group.accounts.map((a) => (
-                              <option key={a.id} value={a.id}>
-                                {a.name}
-                                {a.institution ? ` (${a.institution})` : ''}
-                                {a.sortCode ? ` - ${a.sortCode}` : ''}
-                              </option>
-                            ))}
-                          </optgroup>
-                        ))}
-                        <option value={CREATE_NEW_VALUE}>+ Create New Account</option>
-                      </select>
+                        onChange={(v) => updateLink(da.externalAccountId, v)}
+                        ariaLabel={`Link ${da.name} to account`}
+                      />
 
                       {/* Match reason */}
                       {isMatched && selectedId && (() => {

--- a/src/components/banking/accountPickerOptions.ts
+++ b/src/components/banking/accountPickerOptions.ts
@@ -1,0 +1,60 @@
+import type { Account } from '../../types';
+
+/**
+ * Pure option-model helpers for AccountPickerCombobox, in their own module so
+ * the component file only exports a component (react-refresh requirement).
+ */
+
+export const CREATE_NEW_VALUE = '__create_new__';
+export const SKIP_ID = '__skip__';
+
+// Same section order the app uses elsewhere; alphabetised within each group.
+const ACCOUNT_GROUP_ORDER: Array<{ label: string; types: Array<Account['type']> }> = [
+  { label: 'Current Accounts', types: ['current', 'checking'] },
+  { label: 'Savings', types: ['savings'] },
+  { label: 'Credit Cards', types: ['credit'] },
+  { label: 'Loans', types: ['loan'] },
+  { label: 'Mortgages', types: ['mortgage'] },
+  { label: 'Investments', types: ['investment'] },
+  { label: 'Assets', types: ['asset', 'assets'] },
+  { label: 'Liabilities', types: ['liability'] },
+  { label: 'Other', types: ['other'] }
+];
+
+export const groupAccountsForPicker = (
+  accounts: Account[]
+): Array<{ label: string; accounts: Account[] }> => {
+  const active = accounts.filter((a) => a.isActive !== false);
+  return ACCOUNT_GROUP_ORDER.map((group) => ({
+    label: group.label,
+    accounts: active
+      .filter((a) => group.types.includes(a.type))
+      .sort((a, b) => a.name.localeCompare(b.name, undefined, { sensitivity: 'base' }))
+  })).filter((group) => group.accounts.length > 0);
+};
+
+/** Type-to-filter across name, institution and sort code (dashes optional). */
+export const accountMatchesSearch = (account: Account, rawTerm: string): boolean => {
+  const term = rawTerm.trim().toLowerCase();
+  if (!term) {
+    return true;
+  }
+  if (account.name.toLowerCase().includes(term)) {
+    return true;
+  }
+  if (account.institution && account.institution.toLowerCase().includes(term)) {
+    return true;
+  }
+  if (account.sortCode) {
+    const digitsTerm = term.replace(/\D/g, '');
+    const sortDigits = account.sortCode.replace(/\D/g, '');
+    if (digitsTerm.length >= 2 && sortDigits.includes(digitsTerm)) {
+      return true;
+    }
+    if (account.sortCode.toLowerCase().includes(term)) {
+      return true;
+    }
+  }
+  return false;
+};
+


### PR DESCRIPTION
## Why

Steve's ask after linking HSBC against 200+ imported accounts: "alphabetical as a minimum, alphabetical and in their sections ideally, and with a search function preferably — similar to our transaction category lists." #113 delivered the first two tiers; this delivers the third.

## What

`AccountPickerCombobox` — the CategorySelector combobox pattern (#92) adapted to accounts:

- **Type-to-filter** across account name, institution, and sort code (dashes optional: `401841` matches `40-18-41`)
- **Sections kept** (Current Accounts / Savings / Credit Cards / Loans / Mortgages / Investments / Assets / Liabilities / Other) with sticky headers, alphabetical within each
- **Skip** and **+ Create New Account** affordances preserved, as is auto-match preselection
- **Keyboard parity** with CategorySelector: Enter/Space/arrows open, arrows walk filtered options via `aria-activedescendant`, Enter selects (or picks the sole match), Escape closes and refocuses, Tab closes
- **Portaled menu** — the Link Accounts modal body scrolls and would clip an in-flow dropdown
- Pure helpers in `accountPickerOptions.ts` (react-refresh clean) with unit tests

## Stacked on #113

Base is `fix/banking-ux-errors-and-picker` — merge #113 first; GitHub will retarget this to `main` automatically.

## Verification
- Unit tests 7/7 (grouping order, current+checking merge, inactive exclusion, name/institution/sort-code matching) + banking service 27/27
- `npm run build:check` exit 0 (includes the real `tsc -b` typecheck) · eslint zero warnings

## Note for reviewers
Found during this work: `npm run typecheck:strict` (`tsc --noEmit --strict`) is a **vacuous gate** — the root tsconfig has `files: []` with project references, and plain `tsc` without `-b` checks nothing (it returned 0 against a file with a real compile error; `tsc -b` caught it). Coverage exists via `build:check`, but the standalone script is misleading and should be fixed to `tsc -b --noEmit` or equivalent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)