### PR TITLE
fix(tooling): make typecheck:strict actually type-check

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "test:generate": "node scripts/generate-test-templates.js high-priority",
     "test:generate:single": "node scripts/generate-test-templates.js single",
     "typecheck": "tsc --noEmit",
-    "typecheck:strict": "tsc --noEmit --strict",
+    "typecheck:strict": "tsc -b",
     "test:smoke": "vitest run",
     "handoff:update": "echo 'No handoff snapshots configured'",
     "test:supabase-smoke": "RUN_SUPABASE_REAL_TESTS=true node scripts/run-supabase-smoke.mjs",


### PR DESCRIPTION
## Why

Found during the 2026-07-21 audit work: **`npm run typecheck:strict` checks zero files.** The root `tsconfig.json` is `"files": []` with project references, and plain `tsc` (without `-b`) does not follow references — so the gate always exits 0. Verified against a real duplicate-declaration compile error: the script passed it; `tsc -b` (inside `build:check`) caught it. CI is affected too: `handoff-snapshot.yml` runs this script as its typecheck step.

## What

One line: `tsc --noEmit --strict` → `tsc -b`. Strictness and no-emit already live in `tsconfig.app.json` (`strict: true`, `noEmit: true`), so the script's contract is unchanged — it just enforces it now. This is byte-for-byte the same check `build:check` performs before `vite build`, so nothing that passes CI today starts failing.

## Proof

| Scenario | Old command | New command |
|---|---|---|
| Deliberate type error in src/ | exit **0** (bug) | exit **2**, names the error |
| Clean tree | exit 0 | exit 0 |

No CLAUDE.md change needed — the documented command (`npm run typecheck:strict`) is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)