### PR TITLE
feat(archive): soft-archive transactions — hide old history, never delete

### DIFF
--- a/src/components/ArchiveManager.tsx
+++ b/src/components/ArchiveManager.tsx
@@ -1,0 +1,157 @@
+/**
+ * Archive manager — set how far back each account keeps transactions in the
+ * live register. Soft archive: nothing is deleted, balances are untouched, and
+ * reports still see everything. Investment accounts are excluded in v1.
+ */
+import { useMemo, useState, useCallback } from 'react';
+import { useApp } from '../contexts/AppContextSupabase';
+import { useToast } from '../contexts/ToastContext';
+import { ArchiveIcon, CheckCircleIcon } from './icons';
+import {
+  ARCHIVE_PRESETS, resolveCutoff, countArchivable, type ArchivePreset,
+} from '../utils/archive';
+
+export default function ArchiveManager() {
+  const { accounts, transactions, archiveTransactionsBefore, unarchiveAccount } = useApp();
+  const { showSuccess, showError, showWarning, showInfo } = useToast();
+
+  const [preset, setPreset] = useState<ArchivePreset>('12m');
+  const [customDate, setCustomDate] = useState('');
+  const [busyAccountId, setBusyAccountId] = useState<string | null>(null);
+
+  // Archivable accounts: open, non-investment (investments excluded in v1).
+  const eligibleAccounts = useMemo(
+    () => accounts.filter(a => a.isActive !== false && a.type !== 'investment'),
+    [accounts]
+  );
+
+  const cutoff = useMemo(() => resolveCutoff(preset, customDate), [preset, customDate]);
+
+  const archivedCountFor = useCallback(
+    (accountId: string) => transactions.reduce((n, t) => n + (t.archived && t.accountId === accountId ? 1 : 0), 0),
+    [transactions]
+  );
+
+  const handleArchive = useCallback(async (accountId: string) => {
+    if (!cutoff) { showWarning('Choose a date range first.'); return; }
+    setBusyAccountId(accountId);
+    try {
+      const count = await archiveTransactionsBefore(accountId, cutoff);
+      if (count > 0) showSuccess(`Archived ${count.toLocaleString()} transaction${count === 1 ? '' : 's'}.`);
+      else showInfo('No reconciled transactions to archive in that range.');
+    } catch (error) {
+      showError(error);
+    } finally {
+      setBusyAccountId(null);
+    }
+  }, [cutoff, archiveTransactionsBefore, showSuccess, showInfo, showWarning, showError]);
+
+  const handleUnarchive = useCallback(async (accountId: string) => {
+    setBusyAccountId(accountId);
+    try {
+      const count = await unarchiveAccount(accountId);
+      showSuccess(`Restored ${count.toLocaleString()} transaction${count === 1 ? '' : 's'}.`);
+    } catch (error) {
+      showError(error);
+    } finally {
+      setBusyAccountId(null);
+    }
+  }, [unarchiveAccount, showSuccess, showError]);
+
+  const fmtDate = (d: Date | string) => new Date(d).toLocaleDateString();
+
+  return (
+    <div>
+      <p className="text-sm text-gray-500 dark:text-gray-400 mb-4">
+        Archiving keeps your live register fast and focused by hiding older, reconciled transactions.
+        Nothing is deleted — balances and reports stay exact, and you can bring archived transactions back any time.
+      </p>
+
+      {/* Cutoff selector */}
+      <div className="rounded-xl border border-gray-200 dark:border-gray-700 p-4 mb-4">
+        <p className="text-sm font-medium text-gray-900 dark:text-white mb-2">Archive transactions older than</p>
+        <div className="flex flex-wrap items-center gap-2">
+          <div className="inline-flex flex-wrap rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 p-0.5">
+            {ARCHIVE_PRESETS.map(p => (
+              <button
+                key={p.value}
+                onClick={() => setPreset(p.value)}
+                className={`px-3 py-1.5 text-sm font-medium rounded-md transition-colors ${
+                  preset === p.value
+                    ? 'bg-[#1a2332] dark:bg-blue-600 text-white'
+                    : 'text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-white'
+                }`}
+              >
+                {p.label}
+              </button>
+            ))}
+          </div>
+          {preset === 'custom' && (
+            <input
+              type="date"
+              value={customDate}
+              onChange={(e) => setCustomDate(e.target.value)}
+              className="px-3 py-1.5 text-sm rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-900 text-gray-900 dark:text-white"
+              aria-label="Custom archive cutoff date"
+            />
+          )}
+        </div>
+        {cutoff && (
+          <p className="text-xs text-gray-500 dark:text-gray-400 mt-2">
+            Reconciled transactions dated on or before <span className="font-medium">{fmtDate(cutoff)}</span> will be archived.
+            Unreconciled ones stay visible.
+          </p>
+        )}
+        {preset === 'all' && (
+          <p className="text-xs text-gray-500 dark:text-gray-400 mt-2">“Keep all” archives nothing — use the Restore action to bring an account fully back.</p>
+        )}
+      </div>
+
+      {/* Per-account list */}
+      <div className="space-y-2">
+        {eligibleAccounts.length === 0 && (
+          <p className="text-sm text-gray-500 dark:text-gray-400">No archivable accounts.</p>
+        )}
+        {eligibleAccounts.map(account => {
+          const willArchive = cutoff ? countArchivable(transactions, account.id, cutoff) : 0;
+          const archivedNow = archivedCountFor(account.id);
+          const busy = busyAccountId === account.id;
+          return (
+            <div key={account.id} className="rounded-xl border border-gray-200 dark:border-gray-700 p-3 flex items-center gap-3">
+              <span className="shrink-0 grid place-items-center h-9 w-9 rounded-lg bg-gray-100 dark:bg-gray-700 text-[#1a2332] dark:text-blue-400">
+                <ArchiveIcon size={18} />
+              </span>
+              <div className="min-w-0 flex-1">
+                <p className="text-sm font-medium text-gray-900 dark:text-white truncate">{account.name}</p>
+                <p className="text-xs text-gray-500 dark:text-gray-400">
+                  {account.archiveThroughDate
+                    ? <>Archived through {fmtDate(account.archiveThroughDate)} · {archivedNow.toLocaleString()} hidden</>
+                    : 'Showing all history'}
+                </p>
+              </div>
+              <div className="flex items-center gap-2 shrink-0">
+                {archivedNow > 0 && (
+                  <button
+                    onClick={() => handleUnarchive(account.id)}
+                    disabled={busy}
+                    className="px-3 py-1.5 text-sm rounded-lg border border-gray-300 dark:border-gray-600 text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-700 disabled:opacity-40 inline-flex items-center gap-1"
+                  >
+                    <CheckCircleIcon size={14} /> Restore all
+                  </button>
+                )}
+                <button
+                  onClick={() => handleArchive(account.id)}
+                  disabled={busy || !cutoff || willArchive === 0}
+                  title={!cutoff ? 'Pick a date range above' : willArchive === 0 ? 'Nothing reconciled in that range' : `Archive ${willArchive} transaction(s)`}
+                  className="px-3 py-1.5 text-sm rounded-lg bg-[#1a2332] dark:bg-blue-600 text-white hover:bg-[#2d3a4d] dark:hover:bg-blue-700 disabled:opacity-40 disabled:cursor-not-allowed inline-flex items-center gap-1"
+                >
+                  {busy ? 'Working…' : cutoff && willArchive > 0 ? `Archive ${willArchive.toLocaleString()}` : 'Archive'}
+                </button>
+              </div>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/src/contexts/AppContextSupabase.tsx
+++ b/src/contexts/AppContextSupabase.tsx
@@ -126,6 +126,10 @@ export interface AppContextType extends AppState {
    * category, enforced server-side. Returns the number actually updated.
    */
   applyCategoryToUncategorized: (ids: string[], category: string) => Promise<number>;
+  /** Soft-archive an account's reconciled transactions on/before the cutoff. */
+  archiveTransactionsBefore: (accountId: string, cutoff: Date) => Promise<number>;
+  /** Bring an account's archived transactions back into the live register. */
+  unarchiveAccount: (accountId: string) => Promise<number>;
   /**
    * Every split line of the user's transactions, loaded at boot and kept in
    * step by setTransactionSplits. Category-aggregation surfaces expand split
@@ -571,6 +575,36 @@ export function AppProvider({ children }: { children: React.ReactNode }) {
       setTransactions(prev => prev.map(t => (idSet.has(t.id) ? { ...t, cleared } : t)));
     } catch (error) {
       appLogger.error('Failed to set cleared status', error);
+      throw error;
+    }
+  }, []);
+
+  // Soft-archive: hide an account's reconciled transactions on/before the
+  // cutoff. Balance-neutral — we only flip the `archived` flag and record the
+  // cutoff; every account balance and report stays exact.
+  const archiveTransactionsBefore = useCallback(async (accountId: string, cutoff: Date) => {
+    try {
+      const count = await DataService.archiveTransactionsBefore(accountId, cutoff);
+      setTransactions(prev => prev.map(t =>
+        t.accountId === accountId && !t.archived && t.cleared === true && new Date(t.date) <= cutoff
+          ? { ...t, archived: true } : t
+      ));
+      setAccounts(prev => prev.map(a => (a.id === accountId ? { ...a, archiveThroughDate: cutoff } : a)));
+      return count;
+    } catch (error) {
+      appLogger.error('Failed to archive transactions', error);
+      throw error;
+    }
+  }, []);
+
+  const unarchiveAccount = useCallback(async (accountId: string) => {
+    try {
+      const count = await DataService.unarchiveAccount(accountId);
+      setTransactions(prev => prev.map(t => (t.accountId === accountId && t.archived ? { ...t, archived: false } : t)));
+      setAccounts(prev => prev.map(a => (a.id === accountId ? { ...a, archiveThroughDate: null } : a)));
+      return count;
+    } catch (error) {
+      appLogger.error('Failed to unarchive account', error);
       throw error;
     }
   }, []);
@@ -1065,6 +1099,8 @@ export function AppProvider({ children }: { children: React.ReactNode }) {
     deleteTransaction,
     setTransactionsCleared,
     applyCategoryToUncategorized,
+    archiveTransactionsBefore,
+    unarchiveAccount,
     transactionSplits,
     getTransactionSplits,
     setTransactionSplits,

--- a/src/pages/AccountTransactions.tsx
+++ b/src/pages/AccountTransactions.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useMemo, useRef, useEffect, useLayoutEffect, useCallback } from 'react';
 import { useParams, useNavigate, useLocation } from 'react-router-dom';
 import { useApp } from '../contexts/AppContextSupabase';
-import { parseMoneyInput } from '../utils/decimal';
+import { parseMoneyInput, toDecimal } from '../utils/decimal';
 import { preserveDemoParam } from '../utils/navigation';
 import { useCurrencyDecimal } from '../hooks/useCurrencyDecimal';
 import { ArrowLeftIcon, SearchIcon, PlusIcon, CalendarIcon, XIcon, SettingsIcon, FilterIcon, ChevronUpIcon, ChevronDownIcon, MaximizeIcon, MinimizeIcon, EyeIcon } from '../components/icons';
@@ -120,6 +120,10 @@ export default function AccountTransactions() {
   const [hiddenColumns, setHiddenColumns] = useState<string[]>(() => readStored<string[]>(HIDDEN_COLUMNS_KEY, DEFAULT_HIDDEN_COLUMNS));
   const [archive, setArchive] = useState<ArchiveState>(() => readStored<ArchiveState>(ARCHIVE_KEY, { range: 'all', from: '', to: '' }));
   const [showView, setShowView] = useState(false);
+  // Soft archive (persistent, server-side) — distinct from the date-window
+  // "archive" dropdown above. Off by default; the toggle appears only when the
+  // account actually has archived transactions.
+  const [showArchived, setShowArchived] = useState(false);
   const viewRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
@@ -166,17 +170,28 @@ export default function AccountTransactions() {
 
   const scrollContainerRef = useRef<HTMLDivElement>(null);
   
+  // Every transaction for this account, unfiltered — the basis for running
+  // balances (so hiding rows never corrupts the displayed balance).
+  const fullAccountTransactions = useMemo<Transaction[]>(
+    () => (account ? transactions.filter(t => t.accountId === account.id) : []),
+    [account, transactions]
+  );
+  const hasArchivedHere = useMemo(() => fullAccountTransactions.some(t => t.archived), [fullAccountTransactions]);
+
   // Get account-specific transactions
   const accountTransactions = useMemo<Transaction[]>(() => {
     if (!account) return [];
-    
-    
+
+
     return transactions
       .filter(t => t.accountId === account.id)
       .filter(t => {
+        // Soft archive: hidden from the live register unless the user opts in.
+        if (!showArchived && t.archived) return false;
+
         // Type filter
         if (typeFilter !== 'all' && t.type !== typeFilter) return false;
-        
+
         // Date range filter (Search & filters)
         if (dateFrom && new Date(t.date) < new Date(dateFrom)) return false;
         if (dateTo && new Date(t.date) > new Date(dateTo)) return false;
@@ -197,49 +212,43 @@ export default function AccountTransactions() {
         );
       })
       .sort((a, b) => compareTransactions(a, b, sortField, sortDirection, categories));
-  }, [account, transactions, searchTerm, dateFrom, dateTo, typeFilter, archiveWindow, sortField, sortDirection, categories]);
+  }, [account, transactions, searchTerm, dateFrom, dateTo, typeFilter, archiveWindow, showArchived, sortField, sortDirection, categories]);
   
   // Calculate running balance
   const transactionsWithBalance = useMemo<TransactionWithBalance[]>(() => {
     if (!account) return [] as TransactionWithBalance[];
     
     
-    // Sort transactions by date and type for proper balance calculation
-    // Within the same date: income first, then transfers, then expenses
+    // Running balance is computed over the FULL account history — every
+    // transaction, ignoring the view filters — so hiding rows (archived, date
+    // window, search) never corrupts the balance shown against a visible row.
+    // Within the same date: income first, then transfers, then expenses.
     const typeOrder = { income: 0, transfer: 1, expense: 2 };
-    const sortedForBalance = [...accountTransactions].sort((a, b) => {
+    const sortedForBalance = [...fullAccountTransactions].sort((a, b) => {
       const dateA = new Date(a.date).getTime();
       const dateB = new Date(b.date).getTime();
-      
-      // First sort by date
       if (dateA !== dateB) {
         return dateA - dateB;
       }
-      
-      // If same date, sort by type (income first, then transfers, then expenses)
       return typeOrder[a.type] - typeOrder[b.type];
     });
-    
+
     // Start from opening balance or 0
     let runningBalance = account.openingBalance || 0;
-    
-    // Calculate running balance for each transaction
-    const withBalance = sortedForBalance.map((transaction) => {
-      // Since amounts are already signed (negative for expenses), just add them
+
+    // Calculate running balance for each transaction (amounts are pre-signed)
+    const balanceMap = new Map<string, number>();
+    for (const transaction of sortedForBalance) {
       runningBalance += transaction.amount;
-      return { ...transaction, balance: runningBalance };
-    });
-    
-    // Now sort back to the user's requested order, but keep the calculated balances
-    const balanceMap = new Map(withBalance.map(t => [t.id, t.balance]));
-    
-    const result = accountTransactions.map(t => ({
+      balanceMap.set(transaction.id, runningBalance);
+    }
+
+    // Display the filtered subset, each carrying its true running balance.
+    return accountTransactions.map(t => ({
       ...t,
-      balance: balanceMap.get(t.id) || 0
+      balance: balanceMap.get(t.id) ?? 0
     }));
-    
-    return result;
-  }, [account, accountTransactions]);
+  }, [account, accountTransactions, fullAccountTransactions]);
 
   // Build display rows with virtual Opening Balance as first entry
   const displayRows = useMemo<DisplayRow[]>(() => {
@@ -247,16 +256,33 @@ export default function AccountTransactions() {
 
     const openingBalance = account.openingBalance ?? 0;
 
-    // Date: use openingBalanceDate, or 1 day before oldest transaction, or today
+    // The lead row's balance is whatever the balance was JUST BEFORE the
+    // earliest VISIBLE transaction. With nothing hidden that equals the opening
+    // balance ("Opening Balance"); when earlier history is hidden (archived, or
+    // a date window) it's the carried-forward figure ("Brought forward"), so
+    // the visible running balances stay continuous and correct.
+    const earliestVisible = transactionsWithBalance.length > 0
+      ? transactionsWithBalance.reduce((min, t) => (new Date(t.date) < new Date(min.date) ? t : min))
+      : null;
+    // No visible rows → the lead balance is the full account balance (opening
+    // plus every transaction, all of which are currently hidden).
+    const fullBalance = fullAccountTransactions
+      .reduce((sum, t) => sum.plus(toDecimal(t.amount)), toDecimal(openingBalance)).toNumber();
+    const leadBalance = earliestVisible
+      ? toDecimal(earliestVisible.balance).minus(toDecimal(earliestVisible.amount)).toNumber()
+      : fullBalance;
+    const isBroughtForward = Math.abs(leadBalance - openingBalance) > 0.005;
+
+    // Date: cutoff/earliest-visible for a brought-forward line, else the
+    // opening date, else a day before the oldest, else today.
     let obDate: Date;
-    if (account.openingBalanceDate) {
+    if (isBroughtForward && earliestVisible) {
+      obDate = new Date(earliestVisible.date);
+      obDate.setDate(obDate.getDate() - 1);
+    } else if (account.openingBalanceDate) {
       obDate = new Date(account.openingBalanceDate);
-    } else if (transactionsWithBalance.length > 0) {
-      const oldest = transactionsWithBalance.reduce((min, t) => {
-        const d = new Date(t.date).getTime();
-        return d < min ? d : min;
-      }, Infinity);
-      obDate = new Date(oldest);
+    } else if (earliestVisible) {
+      obDate = new Date(earliestVisible.date);
       obDate.setDate(obDate.getDate() - 1);
     } else {
       obDate = new Date();
@@ -266,9 +292,9 @@ export default function AccountTransactions() {
       id: 'opening-balance',
       isOpeningBalance: true,
       date: obDate,
-      description: 'Opening Balance',
-      amount: openingBalance,
-      balance: openingBalance,
+      description: isBroughtForward ? 'Brought forward' : 'Opening Balance',
+      amount: leadBalance,
+      balance: leadBalance,
       type: 'income',
       category: '',
       accountId: account.id,
@@ -281,7 +307,7 @@ export default function AccountTransactions() {
       return [...transactionsWithBalance, openingBalanceRow];
     }
     return [openingBalanceRow, ...transactionsWithBalance];
-  }, [account, transactionsWithBalance, sortField, sortDirection]);
+  }, [account, transactionsWithBalance, fullAccountTransactions, sortField, sortDirection]);
 
   // Calculate unreconciled total
   const unreconciledTotal = useMemo(() => {
@@ -292,13 +318,15 @@ export default function AccountTransactions() {
       .reduce((sum, t) => sum + t.amount, 0);
   }, [account, accountTransactions]);
 
-  // Compute account balance from transactions (opening balance + sum of all txns)
+  // The true account balance = opening + Σ ALL its transactions. Computed over
+  // the FULL set (never the filtered view) so archiving/date filters never
+  // change the headline balance. Decimal — money is never summed as float.
   const computedAccountBalance = useMemo(() => {
     if (!account) return 0;
-    const openingBalance = account.openingBalance ?? 0;
-    const txnTotal = accountTransactions.reduce((sum, t) => sum + t.amount, 0);
-    return openingBalance + txnTotal;
-  }, [account, accountTransactions]);
+    return fullAccountTransactions
+      .reduce((sum, t) => sum.plus(toDecimal(t.amount)), toDecimal(account.openingBalance ?? 0))
+      .toNumber();
+  }, [account, fullAccountTransactions]);
 
   // Bank balance from TrueLayer sync (or null if not available)
   const bankBalance = account?.bankBalance ?? null;
@@ -887,6 +915,22 @@ export default function AccountTransactions() {
           )}
           {showFilters ? <ChevronUpIcon size={14} /> : <ChevronDownIcon size={14} />}
         </button>
+
+        {/* Soft-archive toggle — only when this account has archived history */}
+        {hasArchivedHere && (
+          <button
+            onClick={() => setShowArchived(prev => !prev)}
+            className={`flex items-center gap-2 px-3 py-1.5 text-sm border rounded-lg transition-colors ${
+              showArchived
+                ? 'border-[#1a2332] dark:border-blue-500 text-[#1a2332] dark:text-blue-400 bg-gray-50 dark:bg-gray-700'
+                : 'border-gray-300 dark:border-gray-600 text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700'
+            }`}
+            title="Archived transactions are hidden from the live list but never deleted"
+          >
+            <EyeIcon size={14} />
+            {showArchived ? 'Hide archived' : 'Show archived'}
+          </button>
+        )}
 
         {/* View: choose which columns to show, and how far back to list */}
         <div className="relative" ref={viewRef}>

--- a/src/pages/Transactions.tsx
+++ b/src/pages/Transactions.tsx
@@ -41,6 +41,7 @@ const Transactions = React.memo(function Transactions() {
   const [breakdownType, setBreakdownType] = useState<'income' | 'expense' | 'net' | null>(null);
   const [filterType, setFilterType] = useState<'all' | 'income' | 'expense'>('all');
   const [filterAccountId, setFilterAccountId] = useState<string>('');
+  const [showArchived, setShowArchived] = useState(false);
   const [searchQuery, setSearchQuery] = useState('');
   const debouncedSearchQuery = useDebounce(searchQuery, 300);
   const [dateFrom, setDateFrom] = useState('');
@@ -84,8 +85,17 @@ const Transactions = React.memo(function Transactions() {
     direction: sortDirection
   }), [sortField, sortDirection]);
 
+  // Soft archive: hide archived transactions from the live register unless the
+  // user opts to show them. Reports read the full context set, not this — so
+  // hiding here never affects any report or balance.
+  const archivedCount = useMemo(() => transactions.reduce((n, t) => n + (t.archived ? 1 : 0), 0), [transactions]);
+  const liveTransactions = useMemo(
+    () => (showArchived ? transactions : transactions.filter(t => !t.archived)),
+    [transactions, showArchived]
+  );
+
   const { transactions: filteredAndSortedTransactions, getCategoryPath } = useTransactionFilters(
-    transactions,
+    liveTransactions,
     accounts,
     categories,
     filterOptions,
@@ -669,6 +679,22 @@ const Transactions = React.memo(function Transactions() {
               />
             </div>
           </div>
+
+          {/* Archived transactions toggle — only shown when some exist */}
+          {archivedCount > 0 && (
+            <div className="flex items-center gap-2 pt-1">
+              <input
+                id="show-archived"
+                type="checkbox"
+                checked={showArchived}
+                onChange={(e) => { setShowArchived(e.target.checked); resetPagination(); }}
+                className="h-4 w-4 rounded border-gray-300 dark:border-gray-600"
+              />
+              <label htmlFor="show-archived" className="text-sm text-gray-600 dark:text-gray-400 cursor-pointer">
+                Show {archivedCount.toLocaleString()} archived transaction{archivedCount === 1 ? '' : 's'}
+              </label>
+            </div>
+          )}
         </div>
         </div>
         </div>

--- a/src/pages/settings/DataManagement.tsx
+++ b/src/pages/settings/DataManagement.tsx
@@ -11,6 +11,7 @@ import type { MsMoneyImportResult } from '../../services/import/msMoney/transfor
 import type { ImportProgress } from '../../services/import/msMoney/msMoneyImport';
 
 const MsMoneyImportModal = lazy(() => import('../../components/MsMoneyImportModal'));
+const ArchiveManager = lazy(() => import('../../components/ArchiveManager'));
 
 // Lazy load heavy components to reduce initial bundle size
 const DataMigrationWizard = lazy(() => import('../../components/DataMigrationWizard'));
@@ -225,6 +226,13 @@ export default function DataManagementSettings() {
           <ActionButton icon={DownloadIcon} title="Quick Export" description="Full data as JSON" onClick={handleExportData} />
           <ActionButton icon={GridIcon} title="Excel Export" description="Spreadsheet format" onClick={() => setShowExcelExport(true)} />
         </div>
+      </Section>
+
+      {/* ── Archive ────────────────────────────────────────────── */}
+      <Section title="Archive" description="Keep the live register fast by hiding older, reconciled transactions. Nothing is deleted — balances and reports stay exact.">
+        <Suspense fallback={<LoadingState />}>
+          <ArchiveManager />
+        </Suspense>
       </Section>
 
       {/* ── Backups ────────────────────────────────────────────── */}

--- a/src/services/__tests__/dataService.test.ts
+++ b/src/services/__tests__/dataService.test.ts
@@ -227,6 +227,57 @@ describe('DataService (deterministic fallback)', () => {
     expect(await localService.getClosedAccounts()).toHaveLength(1);
   });
 
+  it('archives reconciled transactions on/before the cutoff (local) and can restore them', async () => {
+    const storage = createStorage({
+      [STORAGE_KEYS.ACCOUNTS]: [baseAccount({ id: 'acct-1' })],
+      [STORAGE_KEYS.TRANSACTIONS]: [
+        baseTransaction({ id: 'old-cleared', date: new Date('2023-01-01'), cleared: true }),   // archive
+        baseTransaction({ id: 'old-uncleared', date: new Date('2023-01-01'), cleared: false }),// stays (unreconciled)
+        baseTransaction({ id: 'recent', date: new Date('2026-01-01'), cleared: true }),         // stays (after cutoff)
+      ]
+    });
+    const service = createDataService({
+      isSupabaseConfigured: () => false, storageAdapter: storage, logger, uuid, now, userIdService: userId
+    });
+
+    const archived = await service.archiveTransactionsBefore('acct-1', new Date('2024-01-01'));
+    expect(archived).toBe(1);
+    let txns = storage.snapshot(STORAGE_KEYS.TRANSACTIONS) as Transaction[];
+    expect(txns.find(t => t.id === 'old-cleared')?.archived).toBe(true);
+    expect(txns.find(t => t.id === 'old-uncleared')?.archived).toBeFalsy();
+    expect(txns.find(t => t.id === 'recent')?.archived).toBeFalsy();
+    // account records the cutoff
+    const accts = storage.snapshot(STORAGE_KEYS.ACCOUNTS) as Account[];
+    expect(accts[0].archiveThroughDate).toEqual(new Date('2024-01-01'));
+
+    const restored = await service.unarchiveAccount('acct-1');
+    expect(restored).toBe(1);
+    txns = storage.snapshot(STORAGE_KEYS.TRANSACTIONS) as Transaction[];
+    expect(txns.every(t => !t.archived)).toBe(true);
+    expect((storage.snapshot(STORAGE_KEYS.ACCOUNTS) as Account[])[0].archiveThroughDate).toBeNull();
+  });
+
+  it('reconcile-sweep: clearing an old transaction under the cutoff archives it (local)', async () => {
+    const storage = createStorage({
+      [STORAGE_KEYS.ACCOUNTS]: [baseAccount({ id: 'acct-1', archiveThroughDate: new Date('2024-01-01') })],
+      [STORAGE_KEYS.TRANSACTIONS]: [
+        baseTransaction({ id: 'old', date: new Date('2023-06-01'), cleared: false }),   // under cutoff → sweeps
+        baseTransaction({ id: 'recent', date: new Date('2026-06-01'), cleared: false }), // after cutoff → stays live
+      ]
+    });
+    const service = createDataService({
+      isSupabaseConfigured: () => false, storageAdapter: storage, logger, uuid, now, userIdService: userId
+    });
+
+    await service.setTransactionsCleared(['old', 'recent'], true);
+    const txns = storage.snapshot(STORAGE_KEYS.TRANSACTIONS) as Transaction[];
+    expect(txns.find(t => t.id === 'old')?.archived).toBe(true);       // dropped off the live list
+    expect(txns.find(t => t.id === 'recent')?.archived).toBeFalsy();   // still visible
+    // un-clearing never un-archives (unarchive is an explicit action)
+    await service.setTransactionsCleared(['old'], false);
+    expect((storage.snapshot(STORAGE_KEYS.TRANSACTIONS) as Transaction[]).find(t => t.id === 'old')?.archived).toBe(true);
+  });
+
   it('allows static DataService reconfiguration for tests', async () => {
     const storage = createStorage({
       [STORAGE_KEYS.ACCOUNTS]: [baseAccount({ id: 'static-account' })]

--- a/src/services/api/accountService.ts
+++ b/src/services/api/accountService.ts
@@ -36,6 +36,7 @@ const ACCOUNT_CAMEL_TO_DB: Record<string, string> = {
   lastReconciledDate: 'last_reconciled_date',
   lowBalanceAlertEnabled: 'low_balance_alert_enabled',
   lowBalanceThreshold: 'low_balance_threshold',
+  archiveThroughDate: 'archive_through_date',
 };
 
 function mapAccountToDb(obj: Record<string, unknown>): Record<string, unknown> {
@@ -62,6 +63,7 @@ function mapAccountFromDb(row: Record<string, unknown>): Record<string, unknown>
     lastUpdated: row.last_updated ?? row.updated_at,
     lowBalanceAlertEnabled: row.low_balance_alert_enabled === true,
     lowBalanceThreshold: row.low_balance_threshold != null ? Number(row.low_balance_threshold) : undefined,
+    archiveThroughDate: row.archive_through_date != null ? new Date(String(row.archive_through_date)) : null,
   };
 }
 

--- a/src/services/api/dataService.ts
+++ b/src/services/api/dataService.ts
@@ -29,7 +29,7 @@ type AccountServiceLike = Pick<typeof AccountService,
   subscribeToAccounts?: (userId: string, callback: (payload: unknown) => void) => () => void;
 };
 type TransactionServiceLike = Pick<typeof TransactionService,
-  'getTransactions' | 'createTransaction' | 'updateTransaction' | 'deleteTransaction' | 'setTransactionsCleared' | 'applyCategoryToUncategorized' | 'getTransactionSplits' | 'setTransactionSplits' | 'getAllTransactionSplits' | 'linkTransferPair' | 'createTransferCounterpart'> & {
+  'getTransactions' | 'createTransaction' | 'updateTransaction' | 'deleteTransaction' | 'setTransactionsCleared' | 'applyCategoryToUncategorized' | 'getTransactionSplits' | 'setTransactionSplits' | 'getAllTransactionSplits' | 'linkTransferPair' | 'createTransferCounterpart' | 'archiveTransactionsBefore' | 'unarchiveAccount'> & {
   subscribeToTransactions?: (userId: string, callback: (payload: unknown) => void) => () => void;
 };
 type UserIdServiceLike = Pick<typeof userIdService,
@@ -329,16 +329,83 @@ class DataServiceImpl {
     this.guardCloudWrite();
 
     const transactions = await this.readCollection<Transaction>(STORAGE_KEYS.TRANSACTIONS);
+    const accounts = await this.readCollection<Account>(STORAGE_KEYS.ACCOUNTS);
+    const cutoffByAccount = new Map(
+      accounts.map(a => [a.id, a.archiveThroughDate ? new Date(a.archiveThroughDate) : null])
+    );
     const idSet = new Set(ids);
     let count = 0;
     const updated = transactions.map(t => {
       if (idSet.has(t.id)) {
         count += 1;
-        return { ...t, cleared };
+        // Reconcile-sweep (mirrors the cloud trigger): a transaction that
+        // becomes reconciled on/before its account's archive cutoff is
+        // archived automatically, so it drops off the live list cleanly.
+        const cutoff = cutoffByAccount.get(t.accountId);
+        const sweep = cleared && !t.archived && cutoff != null && new Date(t.date) <= cutoff;
+        return { ...t, cleared, ...(sweep ? { archived: true } : {}) };
       }
       return t;
     });
     await this.persistCollection(STORAGE_KEYS.TRANSACTIONS, updated);
+    return count;
+  }
+
+  /**
+   * Soft-archive an account's reconciled transactions on/before the cutoff and
+   * stamp the account's archive_through_date. Balance-neutral (archiving only
+   * hides rows). Cloud: one atomic RPC. Local: flag the matching transactions
+   * and update the account. Returns the number archived.
+   */
+  async archiveTransactionsBefore(accountId: string, cutoff: Date): Promise<number> {
+    const userId = this.userIdService.getCurrentDatabaseUserId();
+    if (userId && this.supabaseChecker()) {
+      return this.transactionService.archiveTransactionsBefore(
+        accountId, cutoff.toISOString().slice(0, 10), userId
+      );
+    }
+    this.guardCloudWrite();
+
+    const transactions = await this.readCollection<Transaction>(STORAGE_KEYS.TRANSACTIONS);
+    let count = 0;
+    const updated = transactions.map(t => {
+      if (t.accountId === accountId && !t.archived && t.cleared === true && new Date(t.date) <= cutoff) {
+        count += 1;
+        return { ...t, archived: true };
+      }
+      return t;
+    });
+    await this.persistCollection(STORAGE_KEYS.TRANSACTIONS, updated);
+
+    const accounts = await this.readCollection<Account>(STORAGE_KEYS.ACCOUNTS);
+    await this.persistCollection(
+      STORAGE_KEYS.ACCOUNTS,
+      accounts.map(a => (a.id === accountId ? { ...a, archiveThroughDate: cutoff } : a))
+    );
+    return count;
+  }
+
+  /** Bring an account's archived transactions back into the live register. */
+  async unarchiveAccount(accountId: string): Promise<number> {
+    const userId = this.userIdService.getCurrentDatabaseUserId();
+    if (userId && this.supabaseChecker()) {
+      return this.transactionService.unarchiveAccount(accountId, userId);
+    }
+    this.guardCloudWrite();
+
+    const transactions = await this.readCollection<Transaction>(STORAGE_KEYS.TRANSACTIONS);
+    let count = 0;
+    const updated = transactions.map(t => {
+      if (t.accountId === accountId && t.archived) { count += 1; return { ...t, archived: false }; }
+      return t;
+    });
+    await this.persistCollection(STORAGE_KEYS.TRANSACTIONS, updated);
+
+    const accounts = await this.readCollection<Account>(STORAGE_KEYS.ACCOUNTS);
+    await this.persistCollection(
+      STORAGE_KEYS.ACCOUNTS,
+      accounts.map(a => (a.id === accountId ? { ...a, archiveThroughDate: null } : a))
+    );
     return count;
   }
 
@@ -731,6 +798,14 @@ export class DataService {
 
   static applyCategoryToUncategorized(ids: string[], category: string): Promise<number> {
     return this.service.applyCategoryToUncategorized(ids, category);
+  }
+
+  static archiveTransactionsBefore(accountId: string, cutoff: Date): Promise<number> {
+    return this.service.archiveTransactionsBefore(accountId, cutoff);
+  }
+
+  static unarchiveAccount(accountId: string): Promise<number> {
+    return this.service.unarchiveAccount(accountId);
   }
 
   static getAllTransactionSplits(): Promise<TransactionSplit[]> {

--- a/src/services/api/supabaseClient.ts
+++ b/src/services/api/supabaseClient.ts
@@ -61,6 +61,14 @@ type Database = {
         Args: { p_user_id: string; p_categories: Record<string, unknown>[] };
         Returns: Record<string, unknown>[];
       };
+      archive_transactions_before: {
+        Args: { p_account_id: string; p_cutoff: string; p_user_id?: string };
+        Returns: Record<string, unknown>;
+      };
+      unarchive_account: {
+        Args: { p_account_id: string; p_user_id?: string };
+        Returns: Record<string, unknown>;
+      };
     };
     Enums: Record<string, never>;
     CompositeTypes: Record<string, never>;

--- a/src/services/api/transactionService.ts
+++ b/src/services/api/transactionService.ts
@@ -42,6 +42,7 @@ const CAMEL_TO_DB: Record<string, string> = {
   recurringTransactionId: 'recurring_transaction_id',
   linkedTransferId: 'linked_transfer_id',
   linkedTransferSplitId: 'linked_transfer_split_id',
+  archived: 'archived',
   plaidTransactionId: 'plaid_transaction_id',
   paymentChannel: 'payment_channel',
   addedBy: 'added_by',
@@ -582,6 +583,56 @@ class TransactionServiceImpl {
    * neutral by construction. Cloud-only here — the local/demo path lives in
    * DataService (which owns local storage semantics).
    */
+  /**
+   * Soft-archive an account's reconciled transactions on/before a cutoff. The
+   * RPC also stamps accounts.archive_through_date, atomically. Cloud-only —
+   * DataService owns the local-mode path (it touches the accounts collection
+   * too). Balance-neutral. Returns the number archived.
+   */
+  async archiveTransactionsBefore(accountId: string, cutoffIso: string, userId?: string): Promise<number> {
+    if (!this.isSupabaseReady()) {
+      throw new Error('archiveTransactionsBefore requires the cloud connection (local mode goes through DataService)');
+    }
+    try {
+      const { data, error } = await this.supabaseClient!.rpc('archive_transactions_before', {
+        p_account_id: accountId,
+        p_cutoff: cutoffIso,
+        ...(userId ? { p_user_id: userId } : {}),
+      });
+      if (error) {
+        this.logger.error('Error archiving transactions:', error);
+        throw new Error(handleSupabaseError(error));
+      }
+      const result = (data ?? {}) as { archived?: number };
+      return typeof result.archived === 'number' ? result.archived : 0;
+    } catch (error) {
+      this.logger.error('TransactionService.archiveTransactionsBefore error:', error as Error);
+      throw error;
+    }
+  }
+
+  /** Bring an account's archived transactions back into the live register. Cloud-only. */
+  async unarchiveAccount(accountId: string, userId?: string): Promise<number> {
+    if (!this.isSupabaseReady()) {
+      throw new Error('unarchiveAccount requires the cloud connection (local mode goes through DataService)');
+    }
+    try {
+      const { data, error } = await this.supabaseClient!.rpc('unarchive_account', {
+        p_account_id: accountId,
+        ...(userId ? { p_user_id: userId } : {}),
+      });
+      if (error) {
+        this.logger.error('Error unarchiving account:', error);
+        throw new Error(handleSupabaseError(error));
+      }
+      const result = (data ?? {}) as { unarchived?: number };
+      return typeof result.unarchived === 'number' ? result.unarchived : 0;
+    } catch (error) {
+      this.logger.error('TransactionService.unarchiveAccount error:', error as Error);
+      throw error;
+    }
+  }
+
   async linkTransferPair(
     idA: string,
     idB: string,
@@ -929,6 +980,14 @@ export class TransactionService {
 
   static linkTransferPair(idA: string, idB: string, userId?: string): Promise<{ a: Transaction; b: Transaction }> {
     return this.service.linkTransferPair(idA, idB, userId);
+  }
+
+  static archiveTransactionsBefore(accountId: string, cutoffIso: string, userId?: string): Promise<number> {
+    return this.service.archiveTransactionsBefore(accountId, cutoffIso, userId);
+  }
+
+  static unarchiveAccount(accountId: string, userId?: string): Promise<number> {
+    return this.service.unarchiveAccount(accountId, userId);
   }
 
   static createTransferCounterpart(

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -23,6 +23,12 @@ export interface Account {
   lastUpdated: Date;
   openingBalance?: number;
   openingBalanceDate?: Date;
+  /**
+   * Soft-archive cutoff: transactions on/before this date (that are
+   * reconciled) are hidden from the live register. NULL/undefined = nothing
+   * archived ("keep all"). Balances are unaffected — see soft_archive.
+   */
+  archiveThroughDate?: Date | null;
   holdings?: Holding[];
   notes?: string;
   isActive?: boolean;
@@ -65,6 +71,12 @@ export interface Transaction {
   isRecurring?: boolean;
   isSplit?: boolean;
   isImported?: boolean;
+  /**
+   * Soft-archived: hidden from the live register but never deleted and still
+   * counted in balances and reports. Set by the archive operation and the
+   * reconcile-sweep; cleared by unarchive. See the soft_archive migration.
+   */
+  archived?: boolean;
   pending?: boolean;
   plaidTransactionId?: string;
   merchant?: string;

--- a/src/utils/archive.test.ts
+++ b/src/utils/archive.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect } from 'vitest';
+import {
+  resolveCutoff, isArchivable, countArchivable, broughtForwardBalance, hasArchived,
+} from './archive';
+import type { Transaction } from '../types';
+
+const NOW = new Date('2026-07-21T00:00:00Z');
+
+const txn = (o: Partial<Transaction>): Transaction => ({
+  id: 'x', accountId: 'a1', amount: 0, date: new Date('2024-01-01'),
+  description: '', category: '', type: 'expense', ...o,
+});
+
+describe('resolveCutoff', () => {
+  it('maps presets to N months back and passes custom/all through', () => {
+    expect(resolveCutoff('12m', '', NOW)?.toISOString().slice(0, 10)).toBe('2025-07-21');
+    expect(resolveCutoff('24m', '', NOW)?.toISOString().slice(0, 10)).toBe('2024-07-21');
+    expect(resolveCutoff('all', '', NOW)).toBeNull();
+    expect(resolveCutoff('custom', '2023-01-15', NOW)?.toISOString().slice(0, 10)).toBe('2023-01-15');
+    expect(resolveCutoff('custom', '', NOW)).toBeNull();
+  });
+});
+
+describe('isArchivable / countArchivable', () => {
+  const cutoff = new Date('2025-01-01');
+  it('only reconciled transactions on/before the cutoff qualify', () => {
+    expect(isArchivable(txn({ cleared: true, date: new Date('2024-06-01') }), cutoff)).toBe(true);
+    // unreconciled → stays live
+    expect(isArchivable(txn({ cleared: false, date: new Date('2024-06-01') }), cutoff)).toBe(false);
+    // after cutoff → stays live
+    expect(isArchivable(txn({ cleared: true, date: new Date('2025-06-01') }), cutoff)).toBe(false);
+  });
+
+  it('counts only the account’s not-yet-archived, archivable transactions', () => {
+    const txns = [
+      txn({ id: '1', accountId: 'a1', cleared: true, date: new Date('2024-01-01') }),      // yes
+      txn({ id: '2', accountId: 'a1', cleared: true, date: new Date('2024-01-01'), archived: true }), // already archived
+      txn({ id: '3', accountId: 'a1', cleared: false, date: new Date('2024-01-01') }),     // unreconciled
+      txn({ id: '4', accountId: 'a2', cleared: true, date: new Date('2024-01-01') }),      // other account
+    ];
+    expect(countArchivable(txns, 'a1', cutoff)).toBe(1);
+  });
+});
+
+describe('broughtForwardBalance', () => {
+  it('adds only the archived transactions of the account to opening (Decimal, no float drift)', () => {
+    const txns = [
+      txn({ accountId: 'a1', amount: 0.1, archived: true }),
+      txn({ accountId: 'a1', amount: 0.2, archived: true }),
+      txn({ accountId: 'a1', amount: 999, archived: false }), // live → excluded
+      txn({ accountId: 'a2', amount: 5, archived: true }),    // other account → excluded
+    ];
+    expect(broughtForwardBalance(txns, 'a1', 1)).toBe(1.3); // 1 + 0.1 + 0.2 exactly
+  });
+});
+
+describe('hasArchived', () => {
+  it('detects archived rows overall and per account', () => {
+    const txns = [txn({ accountId: 'a1', archived: true }), txn({ accountId: 'a2' })];
+    expect(hasArchived(txns)).toBe(true);
+    expect(hasArchived(txns, 'a1')).toBe(true);
+    expect(hasArchived(txns, 'a2')).toBe(false);
+  });
+});

--- a/src/utils/archive.ts
+++ b/src/utils/archive.ts
@@ -1,0 +1,77 @@
+/**
+ * Soft-archive client logic — pure, so it drives both local-mode writes and
+ * the register's brought-forward maths, and is fully testable.
+ *
+ * Archiving hides old reconciled transactions from the LIVE register without
+ * deleting them or touching balances. The account balance stays
+ * `initial + Σ(all)`; the register just seeds its running balance from the sum
+ * of the hidden (archived) rows so the visible rows still end at the true
+ * current balance. See the soft_archive migration for the server side.
+ */
+import type { Transaction } from '../types';
+import { toDecimal } from './decimal';
+
+export type ArchivePreset = '6m' | '12m' | '24m' | 'all' | 'custom';
+
+export const ARCHIVE_PRESETS: { value: ArchivePreset; label: string }[] = [
+  { value: '6m', label: '6 months' },
+  { value: '12m', label: '12 months' },
+  { value: '24m', label: '24 months' },
+  { value: 'all', label: 'Keep all' },
+  { value: 'custom', label: 'Custom date' },
+];
+
+const PRESET_MONTHS: Record<string, number> = { '6m': 6, '12m': 12, '24m': 24 };
+
+/**
+ * Resolve a preset (or custom date) to a cutoff: transactions on/before it are
+ * eligible to archive. 'all' means "keep everything" → null (no cutoff).
+ */
+export function resolveCutoff(
+  preset: ArchivePreset,
+  customDate: string,
+  now: Date = new Date()
+): Date | null {
+  if (preset === 'all') return null;
+  if (preset === 'custom') return customDate ? new Date(customDate) : null;
+  const months = PRESET_MONTHS[preset] ?? 0;
+  const d = new Date(now);
+  d.setMonth(d.getMonth() - months);
+  return d;
+}
+
+/** A transaction is eligible to archive when it is reconciled and on/before the cutoff. */
+export function isArchivable(txn: Transaction, cutoff: Date): boolean {
+  return txn.cleared === true && new Date(txn.date) <= cutoff;
+}
+
+/** How many of an account's transactions a given cutoff would archive. */
+export function countArchivable(transactions: Transaction[], accountId: string, cutoff: Date): number {
+  let n = 0;
+  for (const t of transactions) {
+    if (t.accountId === accountId && !t.archived && isArchivable(t, cutoff)) n++;
+  }
+  return n;
+}
+
+/**
+ * The "brought forward" opening for an account's LIVE register = the account's
+ * true opening balance plus the sum of its archived (hidden) transactions.
+ * Decimal maths — money is never summed as float.
+ */
+export function broughtForwardBalance(
+  transactions: Transaction[],
+  accountId: string,
+  openingBalance: number
+): number {
+  let sum = toDecimal(openingBalance);
+  for (const t of transactions) {
+    if (t.accountId === accountId && t.archived) sum = sum.plus(toDecimal(t.amount));
+  }
+  return sum.toNumber();
+}
+
+/** Whether an account has any archived transactions (for the "Show archived" affordance). */
+export function hasArchived(transactions: Transaction[], accountId?: string): boolean {
+  return transactions.some(t => t.archived && (accountId === undefined || t.accountId === accountId));
+}

--- a/supabase/migrations/20260721130000_soft_archive.sql
+++ b/supabase/migrations/20260721130000_soft_archive.sql
@@ -1,0 +1,150 @@
+-- ============================================================================
+-- Soft archive — hide old, reconciled transactions from the live register
+-- without deleting anything or touching balances.
+--
+-- The Microsoft Money lesson: Money HARD-DELETED archived rows and then
+-- adjusted each account's opening balance to compensate — a fragile,
+-- unrecoverable operation people were warned off. We do neither.
+--
+-- Model:
+--   * A transaction is "archived" purely as a VIEW flag. It stays in the
+--     table, stays counted in the account balance, and stays available to
+--     reports. Only the live register hides it.
+--   * accounts.archive_through_date records how far back the account is
+--     archived (NULL = nothing archived). "Keep all" = NULL.
+--   * archive: flag reconciled (is_cleared) transactions on/before the cutoff.
+--     Unreconciled ones deliberately stay live (a nudge to reconcile them).
+--   * reconcile-sweep: when a transaction on/before the account's cutoff
+--     becomes reconciled, it is archived automatically — so it "drops off the
+--     live list cleanly" (a trigger, so every reconcile path is covered).
+--   * unarchive: clears the flag and the cutoff for an account. One click,
+--     because nothing ever left.
+--
+-- Balances are NEVER mutated here: balance = initial_balance + Σ(ALL txns)
+-- holds regardless of the flag, so every displayed balance and every report
+-- stays exact. The live register seeds its running balance from the sum of the
+-- hidden (archived) rows — computed client-side.
+-- ============================================================================
+
+BEGIN;
+
+ALTER TABLE public.accounts
+  ADD COLUMN IF NOT EXISTS archive_through_date date;
+
+ALTER TABLE public.transactions
+  ADD COLUMN IF NOT EXISTS archived boolean NOT NULL DEFAULT false;
+
+-- The live register reads WHERE archived = false; a partial index keeps that
+-- fast and small even with a long archived tail.
+CREATE INDEX IF NOT EXISTS idx_transactions_live
+  ON public.transactions (user_id, account_id, date)
+  WHERE archived = false;
+
+-- ── Archive an account's history before a cutoff ────────────────────────────
+-- Flags reconciled, not-yet-archived transactions dated on/before the cutoff
+-- and records the cutoff on the account. Investment accounts are excluded in
+-- v1 (their transfers/cost-basis want special handling). Balance-neutral.
+CREATE OR REPLACE FUNCTION public.archive_transactions_before(
+  p_user_id uuid,
+  p_account_id uuid,
+  p_cutoff date
+)
+RETURNS jsonb
+LANGUAGE plpgsql SECURITY INVOKER
+SET search_path = public
+AS $$
+DECLARE
+  v_acct public.accounts;
+  v_count integer;
+BEGIN
+  SELECT * INTO v_acct
+    FROM public.accounts
+   WHERE id = p_account_id AND user_id = p_user_id
+   FOR UPDATE;
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'account_not_found' USING ERRCODE = 'P0002';
+  END IF;
+  IF v_acct.type = 'investment' THEN
+    RAISE EXCEPTION 'investment accounts cannot be archived yet' USING ERRCODE = 'P0001';
+  END IF;
+
+  UPDATE public.transactions
+     SET archived = true, updated_at = now()
+   WHERE user_id = p_user_id
+     AND account_id = p_account_id
+     AND is_cleared = true
+     AND archived = false
+     AND date <= p_cutoff;
+  GET DIAGNOSTICS v_count = ROW_COUNT;
+
+  UPDATE public.accounts
+     SET archive_through_date = p_cutoff, updated_at = now()
+   WHERE id = p_account_id AND user_id = p_user_id;
+
+  RETURN jsonb_build_object('archived', v_count, 'cutoff', p_cutoff);
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.archive_transactions_before(uuid, uuid, date) FROM PUBLIC, anon;
+GRANT EXECUTE ON FUNCTION public.archive_transactions_before(uuid, uuid, date) TO authenticated, service_role;
+
+-- ── Unarchive an account (bring all its history back) ───────────────────────
+CREATE OR REPLACE FUNCTION public.unarchive_account(
+  p_user_id uuid,
+  p_account_id uuid
+)
+RETURNS jsonb
+LANGUAGE plpgsql SECURITY INVOKER
+SET search_path = public
+AS $$
+DECLARE
+  v_count integer;
+BEGIN
+  UPDATE public.transactions
+     SET archived = false, updated_at = now()
+   WHERE user_id = p_user_id AND account_id = p_account_id AND archived = true;
+  GET DIAGNOSTICS v_count = ROW_COUNT;
+
+  UPDATE public.accounts
+     SET archive_through_date = NULL, updated_at = now()
+   WHERE id = p_account_id AND user_id = p_user_id;
+
+  RETURN jsonb_build_object('unarchived', v_count);
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.unarchive_account(uuid, uuid) FROM PUBLIC, anon;
+GRANT EXECUTE ON FUNCTION public.unarchive_account(uuid, uuid) TO authenticated, service_role;
+
+-- ── Reconcile-sweep trigger ─────────────────────────────────────────────────
+-- When a transaction on/before its account's cutoff becomes reconciled, it is
+-- archived automatically, so reconciling old items keeps them from lingering
+-- in the live register. Never un-archives (unarchive is an explicit action).
+CREATE OR REPLACE FUNCTION public.sweep_reconciled_into_archive()
+RETURNS trigger
+LANGUAGE plpgsql
+SET search_path = public
+AS $$
+DECLARE
+  v_cutoff date;
+BEGIN
+  IF NEW.is_cleared IS TRUE
+     AND (OLD.is_cleared IS DISTINCT FROM NEW.is_cleared)
+     AND NEW.archived = false THEN
+    SELECT archive_through_date INTO v_cutoff
+      FROM public.accounts WHERE id = NEW.account_id;
+    IF v_cutoff IS NOT NULL AND NEW.date <= v_cutoff THEN
+      NEW.archived := true;
+    END IF;
+  END IF;
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS trg_sweep_reconciled_into_archive ON public.transactions;
+CREATE TRIGGER trg_sweep_reconciled_into_archive
+  BEFORE UPDATE OF is_cleared ON public.transactions
+  FOR EACH ROW
+  EXECUTE FUNCTION public.sweep_reconciled_into_archive();
+
+COMMIT;


### PR DESCRIPTION
Approved from our design discussion. Archiving keeps the live register fast and focused by hiding older, reconciled transactions — Microsoft Money's idea, but **safe**.

## The cornerstone: nothing is deleted, no balance is touched
Money hard-deleted archived rows and adjusted opening balances (fragile, unrecoverable). We don't. A transaction is archived purely as a **view flag** — it stays in the table, stays counted in `balance = initial + Σ(all txns)`, and stays visible to reports. Verified on the real 50k dataset: archiving HSBC Premier before 2023 hid **8,955 rows (11,334 → 2,379 live)** while the balance stayed **penny-identical at £29,964.55**, and restore brought everything back.

## Behaviour (as we agreed)
- **Reconciled only** — unreconciled transactions stay visible as a nudge.
- **Per-account cutoff** with presets (6/12/24 months, custom date, or *Keep all*). Investment accounts excluded in v1.
- **Reconcile-sweep** — reconciling an old transaction under the cutoff archives it automatically, so it drops off the live list cleanly (a DB trigger in the cloud, mirrored in the local reconcile path).
- **One-click Restore** per account.
- **Reports read the full context set**, so they never under-report archived history — the register is the only thing that filters.

## Register correctness (also fixes a latent bug)
The running balances and the headline account balance now compute over the **full** account history, and the lead row shows **“Brought forward”** when earlier history is hidden — so visible balances stay continuous and the header always shows the true total. This also cures a pre-existing bug in the old per-account date-window filter, which silently mis-computed the running balance when it hid rows.

## Pieces
- Migration `20260721130000`: `accounts.archive_through_date`, `transactions.archived` + partial index, `archive_transactions_before` / `unarchive_account` RPCs, the reconcile-sweep trigger.
- Cloud RPCs + local-mode fallbacks; pure logic in `utils/archive.ts`; an **Archive** section on Data Management + a **Show archived** toggle on the registers.

## Verification
Full cycle exercised in a real browser on your imported data (screenshots: header £29,964.55, “Brought forward £4,918.12”, 8,955 hidden). Unit tests for the utils, local archive/unarchive, and the reconcile-sweep; smoke suite **3,152 passing**; strict typecheck, lint, build all clean.

## To deploy
Merge, then apply `supabase/migrations/20260721130000_soft_archive.sql` in the SQL editor (the cloud RPCs + trigger live there). Local/demo mode works without it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)