### PR TITLE
fix(ui): global button-centring bug + reconciliation grouping, stale-chunk recovery, dashboard click-to-edit

### DIFF
--- a/src/components/AccountSettingsModal.tsx
+++ b/src/components/AccountSettingsModal.tsx
@@ -334,7 +334,7 @@ export default function AccountSettingsModal({
             <button
               type="submit"
               disabled={isSubmitting}
-              className="flex-1 bg-[#1a2332] text-white px-4 py-2 rounded-lg hover:bg-secondary transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+              className="flex-1 justify-center bg-[#1a2332] text-white px-4 py-2 rounded-lg hover:bg-secondary transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
             >
               {isSubmitting ? 'Saving...' : 'Save Changes'}
             </button>
@@ -342,7 +342,7 @@ export default function AccountSettingsModal({
               type="button"
               onClick={onClose}
               disabled={isSubmitting}
-              className="flex-1 bg-gray-200 dark:bg-gray-700 text-gray-700 dark:text-gray-300 px-4 py-2 rounded-lg hover:bg-gray-300 dark:hover:bg-gray-600 transition-colors disabled:opacity-50"
+              className="flex-1 justify-center bg-gray-200 dark:bg-gray-700 text-gray-700 dark:text-gray-300 px-4 py-2 rounded-lg hover:bg-gray-300 dark:hover:bg-gray-600 transition-colors disabled:opacity-50"
             >
               Cancel
             </button>

--- a/src/components/AddAccountModal.tsx
+++ b/src/components/AddAccountModal.tsx
@@ -383,14 +383,14 @@ export default function AddAccountModal({ isOpen, onClose, prefill, onAccountCre
               type="button"
               onClick={onClose}
               disabled={isSubmitting}
-              className="flex-1 px-6 py-3 border-2 border-gray-200 dark:border-gray-700 text-gray-700 dark:text-gray-300 rounded-xl hover:bg-gray-50 dark:hover:bg-gray-800 font-medium transition-all duration-200 disabled:opacity-50 disabled:cursor-not-allowed"
+              className="flex-1 justify-center px-6 py-3 border-2 border-gray-200 dark:border-gray-700 text-gray-700 dark:text-gray-300 rounded-xl hover:bg-gray-50 dark:hover:bg-gray-800 font-medium transition-all duration-200 disabled:opacity-50 disabled:cursor-not-allowed"
             >
               Cancel
             </button>
             <button
               type="submit"
               disabled={isSubmitting}
-              className="flex-1 px-6 py-3 bg-gradient-to-r from-primary to-secondary text-white rounded-xl hover:shadow-lg hover:scale-[1.02] font-medium transition-all duration-200 disabled:opacity-50 disabled:cursor-not-allowed disabled:hover:scale-100"
+              className="flex-1 justify-center px-6 py-3 bg-gradient-to-r from-primary to-secondary text-white rounded-xl hover:shadow-lg hover:scale-[1.02] font-medium transition-all duration-200 disabled:opacity-50 disabled:cursor-not-allowed disabled:hover:scale-100"
             >
               {isSubmitting ? 'Adding...' : 'Add Account'}
             </button>

--- a/src/components/AddTransactionModal.tsx
+++ b/src/components/AddTransactionModal.tsx
@@ -352,7 +352,7 @@ export default function AddTransactionModal({ isOpen, onClose }: AddTransactionM
                 type="button"
                 onClick={onClose}
                 disabled={isSubmitting}
-                className="flex-1 px-4 py-2 min-h-[44px] text-sm sm:text-base border border-gray-300 dark:border-gray-600 text-gray-700 dark:text-gray-300 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-700 disabled:opacity-50 disabled:cursor-not-allowed"
+                className="flex-1 justify-center px-4 py-2 min-h-[44px] text-sm sm:text-base border border-gray-300 dark:border-gray-600 text-gray-700 dark:text-gray-300 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-700 disabled:opacity-50 disabled:cursor-not-allowed"
               >
                 Cancel
               </button>

--- a/src/components/AnomalyDetection.tsx
+++ b/src/components/AnomalyDetection.tsx
@@ -362,7 +362,7 @@ export default function AnomalyDetection() {
                       handleViewTransaction(selectedAnomaly.transactionId);
                       setSelectedAnomaly(null);
                     }}
-                    className="flex-1 px-4 py-2 bg-indigo-600 text-white rounded-lg hover:bg-indigo-700"
+                    className="flex-1 justify-center px-4 py-2 bg-indigo-600 text-white rounded-lg hover:bg-indigo-700"
                   >
                     View Transaction
                   </button>
@@ -373,7 +373,7 @@ export default function AnomalyDetection() {
                       navigate(`/transactions?ids=${selectedAnomaly.transactions?.join(',')}`);
                       setSelectedAnomaly(null);
                     }}
-                    className="flex-1 px-4 py-2 bg-indigo-600 text-white rounded-lg hover:bg-indigo-700"
+                    className="flex-1 justify-center px-4 py-2 bg-indigo-600 text-white rounded-lg hover:bg-indigo-700"
                   >
                     View {selectedAnomaly.transactions.length} Transactions
                   </button>

--- a/src/components/ArchiveManager.tsx
+++ b/src/components/ArchiveManager.tsx
@@ -62,12 +62,7 @@ export default function ArchiveManager() {
 
   return (
     <div>
-      <p className="text-sm text-gray-500 dark:text-gray-400 mb-4">
-        Archiving keeps your live register fast and focused by hiding older, reconciled transactions.
-        Nothing is deleted — balances and reports stay exact, and you can bring archived transactions back any time.
-      </p>
-
-      {/* Cutoff selector */}
+      {/* Cutoff selector (the Section heading already explains what archiving is) */}
       <div className="rounded-xl border border-gray-200 dark:border-gray-700 p-4 mb-4">
         <p className="text-sm font-medium text-gray-900 dark:text-white mb-2">Archive transactions older than</p>
         <div className="flex flex-wrap items-center gap-2">

--- a/src/components/BankConnections.tsx
+++ b/src/components/BankConnections.tsx
@@ -474,7 +474,7 @@ export default function BankConnections({
                 key={institution.id}
                 onClick={() => handleConnect(institution)}
                 disabled={isLoading}
-                className="w-full p-4 bg-gray-50 dark:bg-gray-700 hover:bg-gray-100 dark:hover:bg-gray-600 rounded-lg transition-colors text-left flex items-center gap-4"
+                className="w-full justify-center p-4 bg-gray-50 dark:bg-gray-700 hover:bg-gray-100 dark:hover:bg-gray-600 rounded-lg transition-colors text-left flex items-center gap-4"
               >
                 <div className="w-12 h-12 bg-white dark:bg-gray-800 rounded-lg flex items-center justify-center">
                   <Building2Icon size={24} className="text-gray-600 dark:text-gray-400" />
@@ -513,7 +513,7 @@ export default function BankConnections({
               supportsBalance: true
             })}
             disabled={isLoading}
-            className="w-full p-3 border border-dashed border-gray-300 dark:border-gray-600 rounded-lg text-sm text-gray-600 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-700 transition-colors"
+            className="w-full justify-center p-3 border border-dashed border-gray-300 dark:border-gray-600 rounded-lg text-sm text-gray-600 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-700 transition-colors"
           >
             Don&rsquo;t see your bank or card? <span className="font-medium text-primary dark:text-blue-400">Browse all providers</span>
           </button>

--- a/src/components/BankFormatSelector.tsx
+++ b/src/components/BankFormatSelector.tsx
@@ -267,7 +267,7 @@ export default function BankFormatSelector({ onBankSelected, selectedBank, class
       <div className="mt-6 pt-6 border-t border-gray-200 dark:border-gray-700">
         <button
           onClick={() => onBankSelected('custom', 'Custom Format')}
-          className={`w-full p-4 rounded-lg border-2 border-dashed text-center transition-all ${
+          className={`w-full justify-center p-4 rounded-lg border-2 border-dashed text-center transition-all ${
             selectedBank === 'custom'
               ? 'border-blue-500 bg-blue-50 dark:bg-blue-900/20'
               : 'border-gray-300 dark:border-gray-600 hover:border-gray-400 dark:hover:border-gray-500'

--- a/src/components/BankingOpsAuditPanel.tsx
+++ b/src/components/BankingOpsAuditPanel.tsx
@@ -195,7 +195,7 @@ export default function BankingOpsAuditPanel(props: BankingOpsAuditPanelProps): 
               type="button"
               onClick={loadMoreAudit}
               disabled={isLoadingMoreAudit}
-              className="w-full py-1.5 text-xs text-center text-gray-600 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-800 rounded-md border border-gray-200 dark:border-gray-700"
+              className="w-full justify-center py-1.5 text-xs text-center text-gray-600 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-800 rounded-md border border-gray-200 dark:border-gray-700"
             >
               {isLoadingMoreAudit ? 'Loading more...' : 'Load more'}
             </button>

--- a/src/components/BillNegotiator.tsx
+++ b/src/components/BillNegotiator.tsx
@@ -249,7 +249,7 @@ export default function BillNegotiator() {
                   setShowTipsModal(false);
                   setSelectedBill(null);
                 }}
-                className="flex-1 px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors"
+                className="flex-1 justify-center px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors"
               >
                 Mark as Negotiated
               </button>
@@ -258,7 +258,7 @@ export default function BillNegotiator() {
                   setShowTipsModal(false);
                   setSelectedBill(null);
                 }}
-                className="flex-1 px-4 py-2 bg-gray-200 dark:bg-gray-700 text-gray-700 dark:text-gray-300 rounded-lg hover:bg-gray-300 dark:hover:bg-gray-600 transition-colors"
+                className="flex-1 justify-center px-4 py-2 bg-gray-200 dark:bg-gray-700 text-gray-700 dark:text-gray-300 rounded-lg hover:bg-gray-300 dark:hover:bg-gray-600 transition-colors"
               >
                 Close
               </button>

--- a/src/components/BottomSheet.tsx
+++ b/src/components/BottomSheet.tsx
@@ -343,7 +343,7 @@ export function ActionSheet({
       <div className="border-t border-gray-200 dark:border-gray-700 p-2">
         <button
           onClick={onClose}
-          className="w-full py-3 font-medium text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-800 rounded-lg transition-colors"
+          className="w-full justify-center py-3 font-medium text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-800 rounded-lg transition-colors"
         >
           {cancelLabel}
         </button>

--- a/src/components/BudgetModal.tsx
+++ b/src/components/BudgetModal.tsx
@@ -141,13 +141,13 @@ export default function BudgetModal({ isOpen, onClose, budget }: BudgetModalProp
             <button
               type="button"
               onClick={onClose}
-              className="flex-1 px-4 py-2 border border-gray-300 dark:border-gray-600 text-gray-700 dark:text-gray-300 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-700"
+              className="flex-1 justify-center px-4 py-2 border border-gray-300 dark:border-gray-600 text-gray-700 dark:text-gray-300 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-700"
             >
               Cancel
             </button>
             <button
               type="submit"
-              className="flex-1 px-4 py-2 bg-[#1a2332] text-white rounded-lg hover:bg-secondary"
+              className="flex-1 justify-center px-4 py-2 bg-[#1a2332] text-white rounded-lg hover:bg-secondary"
             >
               {budget ? 'Save Changes' : 'Add Budget'}
             </button>

--- a/src/components/CategoryCreationModal.tsx
+++ b/src/components/CategoryCreationModal.tsx
@@ -285,7 +285,7 @@ export default function CategoryCreationModal({
         <div className="flex gap-2 w-full">
           <button
             onClick={onClose}
-            className="flex-1 px-4 py-2 text-sm sm:text-base border border-gray-300 dark:border-gray-600 text-gray-700 dark:text-gray-300 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-700"
+            className="flex-1 justify-center px-4 py-2 text-sm sm:text-base border border-gray-300 dark:border-gray-600 text-gray-700 dark:text-gray-300 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-700"
           >
             Cancel
           </button>

--- a/src/components/CustomReportBuilder.tsx
+++ b/src/components/CustomReportBuilder.tsx
@@ -667,7 +667,7 @@ export default function CustomReportBuilder({
         
         <button
           onClick={() => setShowCatalog(true)}
-          className="mt-4 w-full py-4 border-2 border-dashed border-gray-300 dark:border-gray-600 rounded-lg hover:border-primary hover:bg-gray-50 dark:hover:bg-gray-800 transition-colors"
+          className="mt-4 w-full justify-center py-4 border-2 border-dashed border-gray-300 dark:border-gray-600 rounded-lg hover:border-primary hover:bg-gray-50 dark:hover:bg-gray-800 transition-colors"
         >
           <PlusIcon size={24} className="mx-auto text-gray-400 dark:text-gray-600" />
           <p className="mt-2 text-sm text-gray-600 dark:text-gray-400">Add Component</p>

--- a/src/components/EditTransactionModal.tsx
+++ b/src/components/EditTransactionModal.tsx
@@ -672,7 +672,7 @@ export default function EditTransactionModal({ isOpen, onClose, transaction, def
                         updateField('category', '');
                         setCrossTypeCategories(false);
                       }}
-                      className={`flex-1 px-4 py-1.5 rounded-md text-sm font-medium transition-all disabled:opacity-40 disabled:cursor-not-allowed ${colors[t]}`}
+                      className={`flex-1 justify-center px-4 py-1.5 rounded-md text-sm font-medium transition-all disabled:opacity-40 disabled:cursor-not-allowed ${colors[t]}`}
                     >
                       {t.charAt(0).toUpperCase() + t.slice(1)}
                     </button>

--- a/src/components/EnhancedExportManager.tsx
+++ b/src/components/EnhancedExportManager.tsx
@@ -564,7 +564,7 @@ export default function EnhancedExportManager(): React.JSX.Element {
                 <div className="flex gap-3">
                   <button
                     onClick={() => setOptions(prev => ({ ...prev, format: 'pdf' }))}
-                    className={`flex-1 p-3 rounded-lg border-2 transition-all ${
+                    className={`flex-1 justify-center p-3 rounded-lg border-2 transition-all ${
                       options.format === 'pdf'
                         ? 'border-blue-500 bg-blue-50 dark:bg-blue-900/20'
                         : 'border-gray-200 dark:border-gray-700'
@@ -577,7 +577,7 @@ export default function EnhancedExportManager(): React.JSX.Element {
                   
                   <button
                     onClick={() => setOptions(prev => ({ ...prev, format: 'excel' }))}
-                    className={`flex-1 p-3 rounded-lg border-2 transition-all ${
+                    className={`flex-1 justify-center p-3 rounded-lg border-2 transition-all ${
                       options.format === 'excel'
                         ? 'border-blue-500 bg-blue-50 dark:bg-blue-900/20'
                         : 'border-gray-200 dark:border-gray-700'
@@ -590,7 +590,7 @@ export default function EnhancedExportManager(): React.JSX.Element {
                   
                   <button
                     onClick={() => setOptions(prev => ({ ...prev, format: 'csv' }))}
-                    className={`flex-1 p-3 rounded-lg border-2 transition-all ${
+                    className={`flex-1 justify-center p-3 rounded-lg border-2 transition-all ${
                       options.format === 'csv'
                         ? 'border-blue-500 bg-blue-50 dark:bg-blue-900/20'
                         : 'border-gray-200 dark:border-gray-700'

--- a/src/components/EnhancedNotificationBell.tsx
+++ b/src/components/EnhancedNotificationBell.tsx
@@ -272,7 +272,7 @@ export default function EnhancedNotificationBell(): React.JSX.Element {
               <div className="px-4 py-3 border-t border-gray-200 dark:border-gray-700">
                 <button
                   onClick={handleClearAll}
-                  className="w-full text-center text-sm text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-300"
+                  className="w-full justify-center text-center text-sm text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-300"
                 >
                   Clear all notifications
                 </button>

--- a/src/components/ErrorFallback.tsx
+++ b/src/components/ErrorFallback.tsx
@@ -21,13 +21,13 @@ export function ErrorFallback({ error, resetError }: ErrorFallbackProps): React.
         <div className="mt-6 flex gap-3">
           <button
             onClick={resetError}
-            className="flex-1 px-4 py-2 text-sm font-medium text-white bg-indigo-600 rounded-md hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500"
+            className="flex-1 justify-center px-4 py-2 text-sm font-medium text-white bg-indigo-600 rounded-md hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500"
           >
             Try again
           </button>
           <button
             onClick={() => window.location.reload()}
-            className="flex-1 px-4 py-2 text-sm font-medium text-gray-700 bg-gray-200 rounded-md hover:bg-gray-300 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-gray-500"
+            className="flex-1 justify-center px-4 py-2 text-sm font-medium text-gray-700 bg-gray-200 rounded-md hover:bg-gray-300 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-gray-500"
           >
             Reload page
           </button>

--- a/src/components/FinancialSummary.tsx
+++ b/src/components/FinancialSummary.tsx
@@ -254,7 +254,7 @@ export default function FinancialSummary({ period }: FinancialSummaryProps) {
             navigator.clipboard.writeText(summaryText);
             // Could add a toast notification here
           }}
-          className="flex-1 px-4 py-2 bg-gray-100 dark:bg-gray-700 text-gray-700 dark:text-gray-300 rounded-lg hover:bg-gray-200 dark:hover:bg-gray-600 transition-colors text-sm"
+          className="flex-1 justify-center px-4 py-2 bg-gray-100 dark:bg-gray-700 text-gray-700 dark:text-gray-300 rounded-lg hover:bg-gray-200 dark:hover:bg-gray-600 transition-colors text-sm"
         >
           Copy Summary
         </button>
@@ -264,7 +264,7 @@ export default function FinancialSummary({ period }: FinancialSummaryProps) {
             financialSummaryService.saveSummary(summary);
             // Could add a toast notification here
           }}
-          className="flex-1 px-4 py-2 bg-[#1a2332] text-white rounded-lg hover:bg-[#2d3a4d] transition-colors text-sm"
+          className="flex-1 justify-center px-4 py-2 bg-[#1a2332] text-white rounded-lg hover:bg-[#2d3a4d] transition-colors text-sm"
         >
           Save to History
         </button>

--- a/src/components/HouseholdManagement.tsx
+++ b/src/components/HouseholdManagement.tsx
@@ -225,7 +225,7 @@ export default function HouseholdManagement() {
               <div className="flex gap-3">
                 <button
                   type="submit"
-                  className="flex-1 px-4 py-2 bg-indigo-600 text-white rounded-lg hover:bg-indigo-700"
+                  className="flex-1 justify-center px-4 py-2 bg-indigo-600 text-white rounded-lg hover:bg-indigo-700"
                 >
                   Create
                 </button>
@@ -420,7 +420,7 @@ export default function HouseholdManagement() {
               <div className="flex gap-2">
                 <button
                   type="submit"
-                  className="flex-1 px-4 py-2 bg-indigo-600 text-white rounded-lg hover:bg-indigo-700"
+                  className="flex-1 justify-center px-4 py-2 bg-indigo-600 text-white rounded-lg hover:bg-indigo-700"
                 >
                   Send Invite
                 </button>
@@ -644,7 +644,7 @@ export default function HouseholdManagement() {
                   <div className="flex gap-2">
                     <button
                       type="submit"
-                      className="flex-1 px-4 py-2 bg-indigo-600 text-white rounded-lg hover:bg-indigo-700"
+                      className="flex-1 justify-center px-4 py-2 bg-indigo-600 text-white rounded-lg hover:bg-indigo-700"
                     >
                       Send Invite
                     </button>

--- a/src/components/ImportDataModal.tsx
+++ b/src/components/ImportDataModal.tsx
@@ -457,14 +457,14 @@ export default function ImportDataModal({ isOpen, onClose }: ImportDataModalProp
                 setShowTestDataWarning(false);
               }}
               disabled={parsing || importing}
-              className="flex-1 px-4 py-2 border border-gray-300 dark:border-gray-600 text-gray-700 dark:text-gray-300 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-700 disabled:opacity-50"
+              className="flex-1 justify-center px-4 py-2 border border-gray-300 dark:border-gray-600 text-gray-700 dark:text-gray-300 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-700 disabled:opacity-50"
             >
               Cancel
             </button>
             <button
               onClick={handleImport}
               disabled={!preview || importing || parsing || preview.accounts.length === 0}
-              className={`flex-1 px-4 py-2 rounded-lg ${
+              className={`flex-1 justify-center px-4 py-2 rounded-lg ${
                 preview && !importing && !parsing && preview.accounts.length > 0
                   ? 'bg-[#1a2332] text-white hover:bg-secondary'
                   : 'bg-gray-300 dark:bg-gray-600 text-gray-500 dark:text-gray-400 cursor-not-allowed'
@@ -514,19 +514,19 @@ export default function ImportDataModal({ isOpen, onClose }: ImportDataModalProp
             <div className="flex gap-3">
               <button
                 onClick={() => setShowTestDataWarning(false)}
-                className="flex-1 px-4 py-2 border border-gray-300 dark:border-gray-600 text-gray-700 dark:text-gray-300 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-700"
+                className="flex-1 justify-center px-4 py-2 border border-gray-300 dark:border-gray-600 text-gray-700 dark:text-gray-300 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-700"
               >
                 Cancel
               </button>
               <button
                 onClick={handleContinueWithTestData}
-                className="flex-1 px-4 py-2 bg-gray-500 text-white rounded-lg hover:bg-gray-600"
+                className="flex-1 justify-center px-4 py-2 bg-gray-500 text-white rounded-lg hover:bg-gray-600"
               >
                 Continue
               </button>
               <button
                 onClick={handleClearAndImport}
-                className="flex-1 px-4 py-2 bg-[#1a2332] text-white rounded-lg hover:bg-secondary"
+                className="flex-1 justify-center px-4 py-2 bg-[#1a2332] text-white rounded-lg hover:bg-secondary"
               >
                 Clear & Import
               </button>

--- a/src/components/MnyMappingModal.tsx
+++ b/src/components/MnyMappingModal.tsx
@@ -210,7 +210,7 @@ export default function MnyMappingModal({ isOpen, onClose, rawData, onMappingCom
         <div className="flex gap-3">
           <button
             onClick={onClose}
-            className="flex-1 px-4 py-2 border border-gray-300 dark:border-gray-600 text-gray-700 dark:text-gray-300 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-700"
+            className="flex-1 justify-center px-4 py-2 border border-gray-300 dark:border-gray-600 text-gray-700 dark:text-gray-300 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-700"
           >
             Cancel
           </button>

--- a/src/components/MsMoneyImportModal.tsx
+++ b/src/components/MsMoneyImportModal.tsx
@@ -203,11 +203,11 @@ export default function MsMoneyImportModal({ isOpen, onClose, onBackup, onExecut
 
               <div className="flex gap-3">
                 <button onClick={handleClose}
-                  className="flex-1 px-4 py-2 border border-gray-300 dark:border-gray-600 text-gray-700 dark:text-gray-300 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-700">
+                  className="flex-1 justify-center px-4 py-2 border border-gray-300 dark:border-gray-600 text-gray-700 dark:text-gray-300 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-700">
                   Cancel
                 </button>
                 <button onClick={runImport} disabled={!confirmReady}
-                  className="flex-1 px-4 py-2 bg-red-700 text-white rounded-lg hover:bg-red-800 disabled:opacity-40 disabled:cursor-not-allowed font-medium">
+                  className="flex-1 justify-center px-4 py-2 bg-red-700 text-white rounded-lg hover:bg-red-800 disabled:opacity-40 disabled:cursor-not-allowed font-medium">
                   Delete everything &amp; import
                 </button>
               </div>

--- a/src/components/NotificationSettings.tsx
+++ b/src/components/NotificationSettings.tsx
@@ -255,7 +255,7 @@ export default function NotificationSettings({ isOpen, onClose }: NotificationSe
               <div className="pt-4 border-t border-gray-200 dark:border-gray-700">
                 <button
                   onClick={sendTestNotification}
-                  className="w-full px-4 py-2 bg-gray-100 dark:bg-gray-700 text-gray-700 dark:text-gray-300 rounded-lg hover:bg-gray-200 dark:hover:bg-gray-600 text-sm"
+                  className="w-full justify-center px-4 py-2 bg-gray-100 dark:bg-gray-700 text-gray-700 dark:text-gray-300 rounded-lg hover:bg-gray-200 dark:hover:bg-gray-600 text-sm"
                 >
                   Send Test Notification
                 </button>

--- a/src/components/OnboardingModal.tsx
+++ b/src/components/OnboardingModal.tsx
@@ -117,7 +117,7 @@ export default function OnboardingModal({ isOpen, onComplete }: OnboardingModalP
           <div className="flex gap-3 mt-6">
             <button
               type="submit"
-              className="flex-1 px-4 py-2 bg-[#1a2332] text-white rounded-lg hover:bg-secondary"
+              className="flex-1 justify-center px-4 py-2 bg-[#1a2332] text-white rounded-lg hover:bg-secondary"
             >
               Get Started
             </button>

--- a/src/components/PWAInstallPrompt.tsx
+++ b/src/components/PWAInstallPrompt.tsx
@@ -76,13 +76,13 @@ export default function PWAInstallPrompt() {
         <div className="flex space-x-2">
           <button
             onClick={handleInstall}
-            className="flex-1 bg-[#8EA9DB] hover:bg-[#7A97C9] text-white font-medium py-2 px-4 rounded-lg transition-colors"
+            className="flex-1 justify-center bg-[#8EA9DB] hover:bg-[#7A97C9] text-white font-medium py-2 px-4 rounded-lg transition-colors"
           >
             Install
           </button>
           <button
             onClick={handleLater}
-            className="flex-1 bg-gray-100 hover:bg-gray-200 dark:bg-gray-700 dark:hover:bg-gray-600 text-gray-700 dark:text-gray-200 font-medium py-2 px-4 rounded-lg transition-colors"
+            className="flex-1 justify-center bg-gray-100 hover:bg-gray-200 dark:bg-gray-700 dark:hover:bg-gray-600 text-gray-700 dark:text-gray-200 font-medium py-2 px-4 rounded-lg transition-colors"
           >
             Later
           </button>

--- a/src/components/RealtimeStatusIndicator.tsx
+++ b/src/components/RealtimeStatusIndicator.tsx
@@ -166,7 +166,7 @@ export function RealtimeStatusIndicator({
               <button
                 onClick={handleReconnect}
                 disabled={connectionState.isReconnecting}
-                className="w-full mt-2 text-xs bg-blue-500 text-white px-3 py-2 rounded hover:bg-[#1a2332] disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+                className="w-full justify-center mt-2 text-xs bg-blue-500 text-white px-3 py-2 rounded hover:bg-[#1a2332] disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
               >
                 {connectionState.isReconnecting ? 'Reconnecting...' : 'Reconnect'}
               </button>

--- a/src/components/SafariWarning.tsx
+++ b/src/components/SafariWarning.tsx
@@ -181,13 +181,13 @@ export default function SafariWarning(): React.JSX.Element | null {
           <div className="flex gap-3 pt-4 border-t border-gray-200 dark:border-gray-700">
             <button
               onClick={handleTryAnyway}
-              className="flex-1 px-4 py-2 text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700 rounded-lg transition-colors"
+              className="flex-1 justify-center px-4 py-2 text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700 rounded-lg transition-colors"
             >
               Try Anyway
             </button>
             <button
               onClick={handleDismiss}
-              className="flex-1 px-4 py-2 bg-[#1a2332] text-white rounded-lg hover:bg-[#2d3a4d] transition-colors"
+              className="flex-1 justify-center px-4 py-2 bg-[#1a2332] text-white rounded-lg hover:bg-[#2d3a4d] transition-colors"
             >
               I'll Use Another Browser
             </button>

--- a/src/components/SimpleSignIn.tsx
+++ b/src/components/SimpleSignIn.tsx
@@ -22,13 +22,13 @@ export default function SimpleSignIn() {
         <SignedOut>
           <div className="space-y-4">
             <SignInButton mode="modal">
-              <button className="w-full py-3 px-4 bg-gradient-to-r from-blue-500 to-indigo-600 text-white rounded-xl font-medium hover:from-blue-600 hover:to-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-600 transition-all shadow-lg">
+              <button className="w-full justify-center py-3 px-4 bg-gradient-to-r from-blue-500 to-indigo-600 text-white rounded-xl font-medium hover:from-blue-600 hover:to-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-600 transition-all shadow-lg">
                 Sign In
               </button>
             </SignInButton>
             
             <SignUpButton mode="modal">
-              <button className="w-full py-3 px-4 border-2 border-blue-500 text-blue-700 dark:text-blue-400 rounded-xl font-medium hover:bg-blue-50 dark:hover:bg-gray-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-600 transition-all">
+              <button className="w-full justify-center py-3 px-4 border-2 border-blue-500 text-blue-700 dark:text-blue-400 rounded-xl font-medium hover:bg-blue-50 dark:hover:bg-gray-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-600 transition-all">
                 Create Account
               </button>
             </SignUpButton>

--- a/src/components/SmartCategorization.tsx
+++ b/src/components/SmartCategorization.tsx
@@ -195,7 +195,7 @@ export function SmartCategorization({
                 >
                   <button
                     onClick={() => applySuggestion(suggestion.categoryId)}
-                    className="flex items-center gap-2 flex-1 text-left"
+                    className="flex items-center gap-2 flex-1 justify-center text-left"
                   >
                     <span
                       className="w-2 h-2 rounded-full flex-shrink-0"

--- a/src/components/SubscriptionStatus.tsx
+++ b/src/components/SubscriptionStatus.tsx
@@ -242,13 +242,13 @@ export default function SubscriptionStatus(): React.JSX.Element {
             <>
               <button
                 onClick={() => handleUpgrade('premium')}
-                className="flex-1 px-4 py-2 bg-[#1a2332] text-white rounded-lg hover:bg-[#2d3a4d] transition-colors"
+                className="flex-1 justify-center px-4 py-2 bg-[#1a2332] text-white rounded-lg hover:bg-[#2d3a4d] transition-colors"
               >
                 Upgrade to Premium
               </button>
               <button
                 onClick={() => handleUpgrade('pro')}
-                className="flex-1 px-4 py-2 border border-purple-600 text-purple-600 dark:text-purple-400 rounded-lg hover:bg-purple-50 dark:hover:bg-purple-900/20 transition-colors"
+                className="flex-1 justify-center px-4 py-2 border border-purple-600 text-purple-600 dark:text-purple-400 rounded-lg hover:bg-purple-50 dark:hover:bg-purple-900/20 transition-colors"
               >
                 Upgrade to Pro
               </button>
@@ -259,7 +259,7 @@ export default function SubscriptionStatus(): React.JSX.Element {
             <>
               <button
                 onClick={() => handleUpgrade('pro')}
-                className="flex-1 px-4 py-2 bg-purple-600 text-white rounded-lg hover:bg-purple-700 transition-colors"
+                className="flex-1 justify-center px-4 py-2 bg-purple-600 text-white rounded-lg hover:bg-purple-700 transition-colors"
               >
                 Upgrade to Pro
               </button>

--- a/src/components/TestDataWarningModal.tsx
+++ b/src/components/TestDataWarningModal.tsx
@@ -103,14 +103,14 @@ export default function TestDataWarningModal({ isOpen, onClose, onClearData }: T
           <div className="flex gap-3 mt-6">
             <button
               onClick={handleClose}
-              className="flex-1 px-4 py-2 bg-[#1a2332] text-white rounded-lg hover:bg-secondary transition-colors"
+              className="flex-1 justify-center px-4 py-2 bg-[#1a2332] text-white rounded-lg hover:bg-secondary transition-colors"
             >
               Continue with Test Data
             </button>
             {onClearData && (
               <button
                 onClick={onClearData}
-                className="flex-1 px-4 py-2 border border-gray-300 dark:border-gray-600 text-gray-700 dark:text-gray-300 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-700 transition-colors"
+                className="flex-1 justify-center px-4 py-2 border border-gray-300 dark:border-gray-600 text-gray-700 dark:text-gray-300 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-700 transition-colors"
               >
                 Clear & Start Fresh
               </button>

--- a/src/components/TransactionDetailsView.tsx
+++ b/src/components/TransactionDetailsView.tsx
@@ -177,7 +177,7 @@ export default function TransactionDetailsView({
         <div className="p-6 border-t border-gray-200 dark:border-gray-700">
           <button
             onClick={onClose}
-            className="w-full px-4 py-2 bg-gray-100 dark:bg-gray-700 text-gray-700 dark:text-gray-300 rounded-lg hover:bg-gray-200 dark:hover:bg-gray-600 transition-colors"
+            className="w-full justify-center px-4 py-2 bg-gray-100 dark:bg-gray-700 text-gray-700 dark:text-gray-300 rounded-lg hover:bg-gray-200 dark:hover:bg-gray-600 transition-colors"
           >
             Close
           </button>

--- a/src/components/TransactionModal.tsx
+++ b/src/components/TransactionModal.tsx
@@ -478,13 +478,13 @@ export default function TransactionModal({ isOpen, onClose, transaction }: Trans
             <button
               type="button"
               onClick={onClose}
-              className="flex-1 px-4 py-2 border border-gray-300 dark:border-gray-600 text-gray-700 dark:text-gray-300 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-700 focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2"
+              className="flex-1 justify-center px-4 py-2 border border-gray-300 dark:border-gray-600 text-gray-700 dark:text-gray-300 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-700 focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2"
             >
               Cancel
             </button>
             <button
               type="submit"
-              className="flex-1 px-4 py-2 bg-[#1a2332] text-white rounded-lg hover:bg-secondary focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2 disabled:opacity-50 disabled:cursor-not-allowed"
+              className="flex-1 justify-center px-4 py-2 bg-[#1a2332] text-white rounded-lg hover:bg-secondary focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2 disabled:opacity-50 disabled:cursor-not-allowed"
               aria-describedby="submit-hint"
             >
               {transaction ? 'Save Changes' : 'Add Transaction'}

--- a/src/components/auth/ClerkErrorBoundary.tsx
+++ b/src/components/auth/ClerkErrorBoundary.tsx
@@ -205,7 +205,7 @@ export class ClerkErrorBoundary extends Component<Props, State> {
                 
                 <button
                   onClick={this.handleClearStorage}
-                  className="w-full px-4 py-2 bg-gray-200 dark:bg-gray-700 text-gray-700 dark:text-gray-300 rounded-lg hover:bg-gray-300 dark:hover:bg-gray-600 transition-colors text-sm"
+                  className="w-full justify-center px-4 py-2 bg-gray-200 dark:bg-gray-700 text-gray-700 dark:text-gray-300 rounded-lg hover:bg-gray-300 dark:hover:bg-gray-600 transition-colors text-sm"
                 >
                   Clear Storage & Retry
                 </button>

--- a/src/components/auth/SimpleSignIn.tsx
+++ b/src/components/auth/SimpleSignIn.tsx
@@ -22,13 +22,13 @@ export default function SimpleSignIn() {
         <SignedOut>
           <div className="space-y-4">
             <SignInButton mode="modal">
-              <button className="w-full py-3 px-4 bg-gradient-to-r from-blue-500 to-indigo-600 text-white rounded-xl font-medium hover:from-blue-600 hover:to-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-600 transition-all shadow-lg">
+              <button className="w-full justify-center py-3 px-4 bg-gradient-to-r from-blue-500 to-indigo-600 text-white rounded-xl font-medium hover:from-blue-600 hover:to-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-600 transition-all shadow-lg">
                 Sign In
               </button>
             </SignInButton>
             
             <SignUpButton mode="modal">
-              <button className="w-full py-3 px-4 border-2 border-blue-500 text-blue-700 dark:text-blue-400 rounded-xl font-medium hover:bg-blue-50 dark:hover:bg-gray-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-600 transition-all">
+              <button className="w-full justify-center py-3 px-4 border-2 border-blue-500 text-blue-700 dark:text-blue-400 rounded-xl font-medium hover:bg-blue-50 dark:hover:bg-gray-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-600 transition-all">
                 Create Account
               </button>
             </SignUpButton>

--- a/src/components/banking/LinkBankAccountsModal.tsx
+++ b/src/components/banking/LinkBankAccountsModal.tsx
@@ -345,7 +345,7 @@ export default function LinkBankAccountsModal({
             type="button"
             onClick={handleLink}
             disabled={isLoading || isLinking || linkedCount === 0 || hasDuplicates}
-            className="flex-1 bg-[#1a2332] text-white px-4 py-2 rounded-lg hover:bg-secondary transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+            className="flex-1 justify-center bg-[#1a2332] text-white px-4 py-2 rounded-lg hover:bg-secondary transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
           >
             {isLinking
               ? 'Linking...'
@@ -354,7 +354,7 @@ export default function LinkBankAccountsModal({
           <button
             type="button"
             onClick={onClose}
-            className="flex-1 bg-gray-200 dark:bg-gray-700 text-gray-700 dark:text-gray-300 px-4 py-2 rounded-lg hover:bg-gray-300 dark:hover:bg-gray-600 transition-colors"
+            className="flex-1 justify-center bg-gray-200 dark:bg-gray-700 text-gray-700 dark:text-gray-300 px-4 py-2 rounded-lg hover:bg-gray-300 dark:hover:bg-gray-600 transition-colors"
           >
             Cancel
           </button>

--- a/src/components/dashboard/ImprovedDashboard.tsx
+++ b/src/components/dashboard/ImprovedDashboard.tsx
@@ -21,6 +21,7 @@ import { useApp } from '../../contexts/AppContextSupabase';
 import { useCurrencyDecimal } from '../../hooks/useCurrencyDecimal';
 import { preserveDemoParam } from '../../utils/navigation';
 import AddTransactionModal from '../AddTransactionModal';
+import EditTransactionModal from '../EditTransactionModal';
 import { Modal, ModalBody } from '../common/Modal';
 import { PieChart, BarChart, ResponsiveContainer } from '../charts/DashboardCharts';
 import { formatDecimal } from '../../utils/decimal-format';
@@ -44,6 +45,10 @@ export function ImprovedDashboard() {
   const [selectedAccountIds, setSelectedAccountIds] = useState<string[]>([]);
   const [showAddTransactionModal, setShowAddTransactionModal] = useState(false);
   const [breakdownType, setBreakdownType] = useState<'income' | 'expense' | null>(null);
+  // A row in the breakdown list opens the full editor — check details, fix a
+  // category — and the list re-derives live, so a re-categorised transaction
+  // drops out of it immediately.
+  const [editingBreakdownTxnId, setEditingBreakdownTxnId] = useState<string | null>(null);
   
   // Load saved preferences from localStorage
   useEffect(() => {
@@ -383,7 +388,12 @@ export function ImprovedDashboard() {
                 }
 
                 return monthlyTxns.map(t => (
-                  <tr key={t.id} className="border-b border-gray-50 dark:border-gray-700/50 last:border-0">
+                  <tr
+                    key={t.id}
+                    onClick={() => setEditingBreakdownTxnId(t.id)}
+                    className="border-b border-gray-50 dark:border-gray-700/50 last:border-0 cursor-pointer hover:bg-gray-50 dark:hover:bg-gray-700/40 transition-colors"
+                    title="Click to view or edit this transaction"
+                  >
                     <td className="py-2 text-sm text-gray-500 dark:text-gray-400 whitespace-nowrap">
                       {new Date(t.date).toLocaleDateString('en-GB', { day: '2-digit', month: 'short' })}
                     </td>
@@ -412,6 +422,15 @@ export function ImprovedDashboard() {
           </table>
         </ModalBody>
       </Modal>
+
+      {/* Edit a transaction straight from the breakdown list */}
+      {editingBreakdownTxnId && (
+        <EditTransactionModal
+          isOpen
+          onClose={() => setEditingBreakdownTxnId(null)}
+          transaction={transactions.find(t => t.id === editingBreakdownTxnId) ?? null}
+        />
+      )}
 
       {/* Budget Status Section - Shows current budget progress */}
       {metrics.budgetStatus.length > 0 && (
@@ -465,7 +484,7 @@ export function ImprovedDashboard() {
             {metrics.budgetStatus.length > 3 && (
               <button 
                 onClick={() => navigate(preserveDemoParam('/budget', location.search))}
-                className="w-full mt-2 py-2 text-blue-700 dark:text-blue-400 text-sm hover:bg-blue-50 dark:hover:bg-blue-900/20 rounded-lg transition-colors"
+                className="w-full justify-center mt-2 py-2 text-blue-700 dark:text-blue-400 text-sm hover:bg-blue-50 dark:hover:bg-blue-900/20 rounded-lg transition-colors"
               >
                 View All Budgets ({metrics.budgetStatus.length}) →
               </button>
@@ -769,7 +788,7 @@ export function ImprovedDashboard() {
           {metrics.recentActivity.length > 10 && (
             <button 
               onClick={() => navigate(preserveDemoParam('/transactions', location.search))}
-              className="w-full mt-4 py-2 text-blue-700 dark:text-blue-400 hover:bg-blue-50 dark:hover:bg-blue-900/20 rounded-lg transition-colors focus:outline-none focus:ring-2 focus:ring-blue-600 focus:ring-offset-2"
+              className="w-full justify-center mt-4 py-2 text-blue-700 dark:text-blue-400 hover:bg-blue-50 dark:hover:bg-blue-900/20 rounded-lg transition-colors focus:outline-none focus:ring-2 focus:ring-blue-600 focus:ring-offset-2"
               aria-label="View all transactions"
             >
               View All Transactions →

--- a/src/components/pwa/ConflictResolutionModal.tsx
+++ b/src/components/pwa/ConflictResolutionModal.tsx
@@ -94,7 +94,7 @@ export const ConflictResolutionModal: React.FC<ConflictResolutionModalProps> = (
             </div>
             <button
               onClick={() => setSelectedResolution('client')}
-              className={`mt-3 w-full py-2 px-3 rounded-md text-sm font-medium transition-colors ${
+              className={`mt-3 w-full justify-center py-2 px-3 rounded-md text-sm font-medium transition-colors ${
                 selectedResolution === 'client'
                   ? 'bg-[#1a2332] text-white'
                   : 'bg-gray-100 text-gray-700 hover:bg-gray-200 dark:bg-gray-700 dark:text-gray-300'
@@ -120,7 +120,7 @@ export const ConflictResolutionModal: React.FC<ConflictResolutionModalProps> = (
             </div>
             <button
               onClick={() => setSelectedResolution('server')}
-              className={`mt-3 w-full py-2 px-3 rounded-md text-sm font-medium transition-colors ${
+              className={`mt-3 w-full justify-center py-2 px-3 rounded-md text-sm font-medium transition-colors ${
                 selectedResolution === 'server'
                   ? 'bg-blue-600 text-white'
                   : 'bg-gray-100 text-gray-700 hover:bg-gray-200 dark:bg-gray-700 dark:text-gray-300'

--- a/src/components/pwa/OfflineTransactionForm.tsx
+++ b/src/components/pwa/OfflineTransactionForm.tsx
@@ -155,7 +155,7 @@ export const OfflineTransactionForm: React.FC<OfflineTransactionFormProps> = ({
               <button
                 type="button"
                 onClick={() => setFormData({ ...formData, type: 'expense' })}
-                className={`flex-1 py-2 px-4 rounded-lg font-medium transition-colors ${
+                className={`flex-1 justify-center py-2 px-4 rounded-lg font-medium transition-colors ${
                   formData.type === 'expense'
                     ? 'bg-red-500 text-white'
                     : 'bg-gray-100 dark:bg-gray-700 text-gray-700 dark:text-gray-300'
@@ -166,7 +166,7 @@ export const OfflineTransactionForm: React.FC<OfflineTransactionFormProps> = ({
               <button
                 type="button"
                 onClick={() => setFormData({ ...formData, type: 'income' })}
-                className={`flex-1 py-2 px-4 rounded-lg font-medium transition-colors ${
+                className={`flex-1 justify-center py-2 px-4 rounded-lg font-medium transition-colors ${
                   formData.type === 'income'
                     ? 'bg-green-500 text-white'
                     : 'bg-gray-100 dark:bg-gray-700 text-gray-700 dark:text-gray-300'
@@ -284,14 +284,14 @@ export const OfflineTransactionForm: React.FC<OfflineTransactionFormProps> = ({
               <button
                 type="button"
                 onClick={onClose}
-                className="flex-1 py-2 px-4 border border-gray-300 dark:border-gray-600 rounded-lg font-medium hover:bg-gray-50 dark:hover:bg-gray-700"
+                className="flex-1 justify-center py-2 px-4 border border-gray-300 dark:border-gray-600 rounded-lg font-medium hover:bg-gray-50 dark:hover:bg-gray-700"
               >
                 Cancel
               </button>
               <button
                 type="submit"
                 disabled={isSubmitting}
-                className="flex-1 py-2 px-4 bg-[#1a2332] text-white rounded-lg font-medium hover:bg-[#2d3a4d] disabled:opacity-50 disabled:cursor-not-allowed"
+                className="flex-1 justify-center py-2 px-4 bg-[#1a2332] text-white rounded-lg font-medium hover:bg-[#2d3a4d] disabled:opacity-50 disabled:cursor-not-allowed"
               >
                 {isSubmitting ? 'Queuing...' : 'Add Transaction'}
               </button>

--- a/src/components/reconciliation/ReconciliationAccountList.tsx
+++ b/src/components/reconciliation/ReconciliationAccountList.tsx
@@ -3,18 +3,25 @@ import { Building2Icon, ChevronRightIcon } from '../icons';
 import { useCurrencyDecimal } from '../../hooks/useCurrencyDecimal';
 import type { ReconciliationSummary } from '../../hooks/useReconciliation';
 
-interface ReconciliationAccountListProps {
+export interface ReconciliationGroup {
+  title: string;
   summaries: ReconciliationSummary[];
+}
+
+interface ReconciliationAccountListProps {
+  /** Accounts grouped into titled sections (same groupings as the Accounts page). */
+  groups: ReconciliationGroup[];
   onSelectAccount: (accountId: string) => void;
 }
 
 export default function ReconciliationAccountList({
-  summaries,
+  groups,
   onSelectAccount,
 }: ReconciliationAccountListProps): React.JSX.Element {
   const { formatCurrency } = useCurrencyDecimal();
 
-  if (summaries.length === 0) {
+  const total = groups.reduce((n, g) => n + g.summaries.length, 0);
+  if (total === 0) {
     return (
       <div className="text-center py-12 text-gray-500 dark:text-gray-400">
         <p className="text-lg font-medium">No accounts to reconcile</p>
@@ -24,85 +31,95 @@ export default function ReconciliationAccountList({
   }
 
   return (
-    <div className="grid gap-3">
-      {summaries.map(({ account, unreconciledCount, bankBalance, accountBalance, difference }) => {
-        const hasDifference = difference != null && Math.abs(difference) > 0.005;
+    <div className="space-y-6">
+      {groups.map(group => group.summaries.length > 0 && (
+        <section key={group.title}>
+          <h2 className="text-sm font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-400 mb-2">
+            {group.title}
+            <span className="ml-2 font-normal normal-case text-gray-400 dark:text-gray-500">
+              ({group.summaries.length})
+            </span>
+          </h2>
+          <div className="grid gap-3">
+            {group.summaries.map(({ account, unreconciledCount, bankBalance, accountBalance, difference }) => {
+              const hasDifference = difference != null && Math.abs(difference) > 0.005;
 
-        return (
-          <button
-            key={account.id}
-            type="button"
-            onClick={() => onSelectAccount(account.id)}
-            className={`w-full text-left bg-white dark:bg-gray-800 rounded-xl border-2 transition-all hover:shadow-md ${
-              hasDifference
-                ? 'border-amber-400 dark:border-amber-500'
-                : 'border-gray-200 dark:border-gray-700 hover:border-primary'
-            } p-5`}
-          >
-            <div className="flex items-center gap-4">
-              {/* Icon + Name */}
-              <div className="flex items-center gap-3 min-w-[200px]">
-                <div className="p-2 bg-gray-100 dark:bg-gray-700 rounded-lg flex-shrink-0">
-                  <Building2Icon size={20} className="text-gray-600 dark:text-gray-400" />
-                </div>
-                <div>
-                  <h3 className="font-semibold text-gray-900 dark:text-white">{account.name}</h3>
-                  <p className="text-xs text-gray-500 dark:text-gray-400">
-                    {account.institution ?? account.type}
-                  </p>
-                </div>
-              </div>
+              return (
+                <button
+                  key={account.id}
+                  type="button"
+                  onClick={() => onSelectAccount(account.id)}
+                  className={`w-full text-left bg-white dark:bg-gray-800 rounded-xl border-2 transition-all hover:shadow-md ${
+                    hasDifference
+                      ? 'border-amber-400 dark:border-amber-500'
+                      : 'border-gray-200 dark:border-gray-700 hover:border-primary'
+                  } p-5`}
+                >
+                  {/* w-full so the columns spread edge-to-edge and the icons
+                      line up in a straight rail down the page */}
+                  <div className="w-full flex items-center gap-4">
+                    <div className="flex items-center gap-3 min-w-[200px]">
+                      <div className="p-2 bg-gray-100 dark:bg-gray-700 rounded-lg flex-shrink-0">
+                        <Building2Icon size={20} className="text-gray-600 dark:text-gray-400" />
+                      </div>
+                      <div>
+                        <h3 className="font-semibold text-gray-900 dark:text-white">{account.name}</h3>
+                        <p className="text-xs text-gray-500 dark:text-gray-400">
+                          {account.institution ?? account.type}
+                        </p>
+                      </div>
+                    </div>
 
-              {/* Unreconciled badge */}
-              <div className="min-w-[120px]">
-                {unreconciledCount > 0 ? (
-                  <span className="inline-flex items-center px-2.5 py-1 rounded-full text-xs font-medium bg-amber-100 text-amber-700 dark:bg-amber-900/30 dark:text-amber-400">
-                    {unreconciledCount} unreconciled
-                  </span>
-                ) : (
-                  <span className="inline-flex items-center px-2.5 py-1 rounded-full text-xs font-medium bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-400">
-                    All cleared
-                  </span>
-                )}
-              </div>
+                    <div className="min-w-[120px]">
+                      {unreconciledCount > 0 ? (
+                        <span className="inline-flex items-center px-2.5 py-1 rounded-full text-xs font-medium bg-amber-100 text-amber-700 dark:bg-amber-900/30 dark:text-amber-400">
+                          {unreconciledCount} unreconciled
+                        </span>
+                      ) : (
+                        <span className="inline-flex items-center px-2.5 py-1 rounded-full text-xs font-medium bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-400">
+                          All cleared
+                        </span>
+                      )}
+                    </div>
 
-              {/* Spacer to push balances right */}
-              <div className="flex-1" />
+                    <div className="flex-1" />
 
-              {/* Balance columns — spread across */}
-              <div className="text-right min-w-[120px]">
-                <p className="text-[10px] uppercase tracking-wide text-gray-400 dark:text-gray-500">Bank Balance</p>
-                <p className="text-sm font-semibold text-gray-900 dark:text-white tabular-nums">
-                  {bankBalance != null
-                    ? formatCurrency(bankBalance, account.currency)
-                    : 'N/A'}
-                </p>
-              </div>
-              <div className="text-right min-w-[120px]">
-                <p className="text-[10px] uppercase tracking-wide text-gray-400 dark:text-gray-500">Account Balance</p>
-                <p className="text-sm font-semibold text-gray-900 dark:text-white tabular-nums">
-                  {formatCurrency(accountBalance, account.currency)}
-                </p>
-              </div>
-              <div className="text-right min-w-[100px]">
-                <p className="text-[10px] uppercase tracking-wide text-gray-400 dark:text-gray-500">Difference</p>
-                <p className={`text-sm font-bold tabular-nums ${
-                  difference == null
-                    ? 'text-gray-400'
-                    : Math.abs(difference) < 0.005
-                    ? 'text-blue-600 dark:text-blue-400'
-                    : 'text-red-600 dark:text-red-400'
-                }`}>
-                  {difference != null
-                    ? formatCurrency(difference, account.currency)
-                    : 'N/A'}
-                </p>
-              </div>
-              <ChevronRightIcon size={20} className="text-gray-400 flex-shrink-0 ml-2" />
-            </div>
-          </button>
-        );
-      })}
+                    <div className="text-right min-w-[120px]">
+                      <p className="text-[10px] uppercase tracking-wide text-gray-400 dark:text-gray-500">Bank Balance</p>
+                      <p className="text-sm font-semibold text-gray-900 dark:text-white tabular-nums">
+                        {bankBalance != null
+                          ? formatCurrency(bankBalance, account.currency)
+                          : 'N/A'}
+                      </p>
+                    </div>
+                    <div className="text-right min-w-[120px]">
+                      <p className="text-[10px] uppercase tracking-wide text-gray-400 dark:text-gray-500">Account Balance</p>
+                      <p className="text-sm font-semibold text-gray-900 dark:text-white tabular-nums">
+                        {formatCurrency(accountBalance, account.currency)}
+                      </p>
+                    </div>
+                    <div className="text-right min-w-[100px]">
+                      <p className="text-[10px] uppercase tracking-wide text-gray-400 dark:text-gray-500">Difference</p>
+                      <p className={`text-sm font-bold tabular-nums ${
+                        difference == null
+                          ? 'text-gray-400'
+                          : Math.abs(difference) < 0.005
+                          ? 'text-blue-600 dark:text-blue-400'
+                          : 'text-red-600 dark:text-red-400'
+                      }`}>
+                        {difference != null
+                          ? formatCurrency(difference, account.currency)
+                          : 'N/A'}
+                      </p>
+                    </div>
+                    <ChevronRightIcon size={20} className="text-gray-400 flex-shrink-0 ml-2" />
+                  </div>
+                </button>
+              );
+            })}
+          </div>
+        </section>
+      ))}
     </div>
   );
 }

--- a/src/components/reconciliation/ReconciliationFinalizationModal.tsx
+++ b/src/components/reconciliation/ReconciliationFinalizationModal.tsx
@@ -132,13 +132,13 @@ export default function ReconciliationFinalizationModal({
             <div className="flex gap-3">
               <button
                 onClick={onClose}
-                className="flex-1 px-4 py-2 border border-gray-300 dark:border-gray-600 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-700 text-sm font-medium text-gray-700 dark:text-gray-300"
+                className="flex-1 justify-center px-4 py-2 border border-gray-300 dark:border-gray-600 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-700 text-sm font-medium text-gray-700 dark:text-gray-300"
               >
                 Go Back
               </button>
               <button
                 onClick={onFinalize}
-                className="flex-1 px-6 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors font-medium"
+                className="flex-1 justify-center px-6 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors font-medium"
               >
                 Finalize Anyway
               </button>
@@ -255,14 +255,14 @@ export default function ReconciliationFinalizationModal({
             <div className="flex gap-3">
               <button
                 onClick={onClose}
-                className="flex-1 px-4 py-2 border border-gray-300 dark:border-gray-600 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-700 text-sm font-medium text-gray-700 dark:text-gray-300"
+                className="flex-1 justify-center px-4 py-2 border border-gray-300 dark:border-gray-600 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-700 text-sm font-medium text-gray-700 dark:text-gray-300"
               >
                 Go Back
               </button>
               <button
                 onClick={() => void handleCreateAdjustment()}
                 disabled={isSubmitting || !amountValid || !adjustmentCategory || !adjustmentDescription.trim()}
-                className="flex-1 px-4 py-2 bg-[#1a2332] text-white rounded-lg hover:bg-secondary transition-colors text-sm font-medium disabled:opacity-50 disabled:cursor-not-allowed"
+                className="flex-1 justify-center px-4 py-2 bg-[#1a2332] text-white rounded-lg hover:bg-secondary transition-colors text-sm font-medium disabled:opacity-50 disabled:cursor-not-allowed"
               >
                 {isSubmitting ? 'Creating…' : 'Create Adjustment'}
               </button>

--- a/src/components/subscription/PaymentForm.tsx
+++ b/src/components/subscription/PaymentForm.tsx
@@ -251,7 +251,7 @@ export default function PaymentForm({
             type="button"
             onClick={onCancel}
             disabled={isLoading}
-            className="flex-1 px-6 py-3 text-gray-700 dark:text-gray-300 bg-white dark:bg-gray-800 border border-gray-300 dark:border-gray-600 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-700 disabled:opacity-50 transition-colors"
+            className="flex-1 justify-center px-6 py-3 text-gray-700 dark:text-gray-300 bg-white dark:bg-gray-800 border border-gray-300 dark:border-gray-600 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-700 disabled:opacity-50 transition-colors"
           >
             Cancel
           </button>

--- a/src/components/subscription/UsageLimitWarning.tsx
+++ b/src/components/subscription/UsageLimitWarning.tsx
@@ -212,7 +212,7 @@ export function UpgradeBenefits({ feature, className = '' }: UpgradeBenefitsProp
       <div className="flex flex-col sm:flex-row gap-3">
         <button
           onClick={() => window.location.href = '/subscription'}
-          className="flex-1 px-6 py-3 bg-gradient-to-r from-blue-600 to-purple-600 text-white rounded-lg hover:from-blue-700 hover:to-purple-700 transition-all duration-200 font-medium"
+          className="flex-1 justify-center px-6 py-3 bg-gradient-to-r from-blue-600 to-purple-600 text-white rounded-lg hover:from-blue-700 hover:to-purple-700 transition-all duration-200 font-medium"
         >
           Start Free Trial
         </button>

--- a/src/index.css
+++ b/src/index.css
@@ -239,12 +239,15 @@ input[type="range"] {
   /* Note: font-weight is NOT included to prevent flickering */
 }
 
-/* Default button styling to prevent square corners */
+/* Default button styling to prevent square corners.
+   Deliberately NO justify-content here: a global "center" made every
+   full-width icon+label button centre its content (the Data Management /
+   Tools / Reconciliation "zig-zag" look). Buttons that want centred content
+   declare justify-center themselves. */
 button {
   border-radius: 0.5rem; /* Default to rounded-lg */
   display: inline-flex;
   align-items: center;
-  justify-content: center;
 }
 
 /* Touch gesture styles */

--- a/src/pages/Accounts.tsx
+++ b/src/pages/Accounts.tsx
@@ -8,7 +8,7 @@ import AddAccountModal from '../components/AddAccountModal';
 import AccountSettingsModal from '../components/AccountSettingsModal';
 import PortfolioView from '../components/PortfolioView';
 // No longer importing from lucide-react - all icons are now custom
-import { ArchiveIcon, SettingsIcon, WalletIcon, PiggyBankIcon, CreditCardIcon, TrendingDownIcon, TrendingUpIcon, CheckCircleIcon, HomeIcon, PieChartIcon, BankIcon, RefreshCwIcon, AlertTriangleIcon, ChevronRightIcon, ChevronDownIcon, XCircleIcon } from '../components/icons';
+import { ArchiveIcon, SettingsIcon, WalletIcon, CheckCircleIcon, PieChartIcon, BankIcon, RefreshCwIcon, AlertTriangleIcon, ChevronRightIcon, ChevronDownIcon, XCircleIcon } from '../components/icons';
 import BankingCriticalIncidentBadge from '../components/BankingCriticalIncidentBadge';
 import { LoadingState } from '../components/loading/LoadingState';
 import { TRUELAYER_JWKS_CIRCUIT_EVENT_PREFIX } from '../constants/bankingOps';
@@ -17,6 +17,7 @@ import { TRUELAYER_JWKS_CIRCUIT_EVENT_PREFIX } from '../constants/bankingOps';
 // the Data Management page keeps only its URL-driven deep links for ops alerts.
 const BankConnections = lazy(() => import('../components/BankConnections'));
 import type { Account } from '../types';
+import { ACCOUNT_TYPE_SECTIONS } from '../utils/accountSections';
 
 type AccountSortMode = 'default' | 'name' | 'balance-desc' | 'balance-asc';
 import { IconButton } from '../components/icons/IconButton';
@@ -153,65 +154,8 @@ export default function Accounts({ onAccountClick }: { onAccountClick?: (account
     [decimalAccounts]
   );
 
-  // Define account type metadata
-  const accountTypes = [
-    { 
-      type: 'current', 
-      title: 'Current Accounts', 
-      icon: WalletIcon,
-      color: 'text-blue-700 dark:text-blue-400',
-      bgColor: 'bg-blue-200 dark:bg-blue-900/20',
-      borderColor: 'border-blue-200 dark:border-blue-800'
-    },
-    { 
-      type: 'savings', 
-      title: 'Savings Accounts', 
-      icon: PiggyBankIcon, 
-      color: 'text-green-600 dark:text-green-400',
-      bgColor: 'bg-green-200 dark:bg-green-900/20',
-      borderColor: 'border-green-200 dark:border-green-800'
-    },
-    { 
-      type: 'credit', 
-      title: 'Credit Cards', 
-      icon: CreditCardIcon, 
-      color: 'text-orange-600 dark:text-orange-400',
-      bgColor: 'bg-orange-200 dark:bg-orange-900/20',
-      borderColor: 'border-orange-200 dark:border-orange-800'
-    },
-    { 
-      type: 'loan', 
-      title: 'Loans', 
-      icon: TrendingDownIcon, 
-      color: 'text-red-600 dark:text-red-400',
-      bgColor: 'bg-red-200 dark:bg-red-900/20',
-      borderColor: 'border-red-200 dark:border-red-800'
-    },
-    { 
-      type: 'investment', 
-      title: 'Investments', 
-      icon: TrendingUpIcon, 
-      color: 'text-purple-600 dark:text-purple-400',
-      bgColor: 'bg-purple-200 dark:bg-purple-900/20',
-      borderColor: 'border-purple-200 dark:border-purple-800'
-    },
-    { 
-      type: 'asset', 
-      title: 'Assets', 
-      icon: HomeIcon, 
-      color: 'text-indigo-600 dark:text-indigo-400',
-      bgColor: 'bg-indigo-200 dark:bg-indigo-900/20',
-      borderColor: 'border-indigo-200 dark:border-indigo-800'
-    },
-    { 
-      type: 'liability', 
-      title: 'Liabilities', 
-      icon: TrendingDownIcon, 
-      color: 'text-gray-600 dark:text-gray-400',
-      bgColor: 'bg-gray-200 dark:bg-gray-900/20',
-      borderColor: 'border-gray-200 dark:border-gray-800'
-    },
-  ];
+  // The shared account-type sections (same groupings everywhere).
+  const accountTypes = ACCOUNT_TYPE_SECTIONS;
 
 
   // Group accounts by institution

--- a/src/pages/Reconciliation.tsx
+++ b/src/pages/Reconciliation.tsx
@@ -4,7 +4,8 @@ import { useApp } from '../contexts/AppContextSupabase';
 import { useToast } from '../contexts/ToastContext';
 import { ArrowLeftIcon, CheckCircleIcon } from '../components/icons';
 import { useReconciliation } from '../hooks/useReconciliation';
-import ReconciliationAccountList from '../components/reconciliation/ReconciliationAccountList';
+import ReconciliationAccountList, { type ReconciliationGroup } from '../components/reconciliation/ReconciliationAccountList';
+import { ACCOUNT_TYPE_SECTIONS } from '../utils/accountSections';
 import ReconciliationBalanceBar from '../components/reconciliation/ReconciliationBalanceBar';
 import ReconciliationTransactionList from '../components/reconciliation/ReconciliationTransactionList';
 import ReconciliationFinalizationModal from '../components/reconciliation/ReconciliationFinalizationModal';
@@ -20,6 +21,23 @@ export default function Reconciliation() {
   const [selectedAccountId, setSelectedAccountId] = useState<string | null>(
     searchParams.get('account') || null
   );
+  // Group + sort for the account list — the same controls (and persistence
+  // keys pattern) as the Accounts page, so the two pages always feel the same.
+  const [groupBy, setGroupBy] = useState<'type' | 'institution'>(() =>
+    (localStorage.getItem('reconciliationGroupBy') as 'type' | 'institution') || 'type'
+  );
+  const [sortMode, setSortMode] = useState<'default' | 'name' | 'balance-desc' | 'balance-asc'>(() => {
+    const stored = localStorage.getItem('reconciliationSortMode');
+    return stored === 'name' || stored === 'balance-desc' || stored === 'balance-asc' ? stored : 'default';
+  });
+  const handleGroupByChange = useCallback((value: 'type' | 'institution') => {
+    setGroupBy(value);
+    try { localStorage.setItem('reconciliationGroupBy', value); } catch { /* storage unavailable */ }
+  }, []);
+  const handleSortChange = useCallback((value: 'default' | 'name' | 'balance-desc' | 'balance-asc') => {
+    setSortMode(value);
+    try { localStorage.setItem('reconciliationSortMode', value); } catch { /* storage unavailable */ }
+  }, []);
   const [showFinalizationModal, setShowFinalizationModal] = useState(false);
   const [editingTransaction, setEditingTransaction] = useState<Transaction | null>(null);
   const [isEditModalOpen, setIsEditModalOpen] = useState(false);
@@ -46,6 +64,37 @@ export default function Reconciliation() {
     computeClearedBalance,
     computeClearedSummary,
   } = useReconciliation(accounts, overlaidTransactions);
+
+  // Build the grouped, sorted account list (same sections as the Accounts page).
+  const accountGroups = useMemo<ReconciliationGroup[]>(() => {
+    const sortSummaries = (list: typeof reconciliationDetails) => {
+      const sorted = [...list];
+      if (sortMode === 'name') sorted.sort((a, b) => a.account.name.localeCompare(b.account.name));
+      else if (sortMode === 'balance-desc') sorted.sort((a, b) => b.accountBalance - a.accountBalance);
+      else if (sortMode === 'balance-asc') sorted.sort((a, b) => a.accountBalance - b.accountBalance);
+      return sorted;
+    };
+
+    if (groupBy === 'institution') {
+      const byInstitution = new Map<string, typeof reconciliationDetails>();
+      for (const s of reconciliationDetails) {
+        const key = s.account.institution || 'Other Accounts';
+        (byInstitution.get(key) ?? byInstitution.set(key, []).get(key)!).push(s);
+      }
+      return [...byInstitution.entries()]
+        .sort((a, b) => a[0].localeCompare(b[0]))
+        .map(([title, summaries]) => ({ title, summaries: sortSummaries(summaries) }));
+    }
+
+    const groups: ReconciliationGroup[] = ACCOUNT_TYPE_SECTIONS.map(section => ({
+      title: section.title,
+      summaries: sortSummaries(reconciliationDetails.filter(s => s.account.type === section.type)),
+    }));
+    const known = new Set(ACCOUNT_TYPE_SECTIONS.map(s => s.type));
+    const other = reconciliationDetails.filter(s => !known.has(s.account.type));
+    if (other.length > 0) groups.push({ title: 'Other', summaries: sortSummaries(other) });
+    return groups;
+  }, [reconciliationDetails, groupBy, sortMode]);
 
   // Selected account data
   const selectedAccount = useMemo(
@@ -235,8 +284,57 @@ export default function Reconciliation() {
           </p>
         </div>
 
+        {/* Group + sort controls — mirrors the Accounts page */}
+        <div className="flex flex-wrap items-center gap-x-6 gap-y-2 mb-4">
+          <div className="flex items-center gap-2">
+            <span className="text-sm text-gray-500 dark:text-gray-400">Group by:</span>
+            <div className="inline-flex rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 p-0.5">
+              {([['type', 'Account Type'], ['institution', 'Institution']] as const).map(([value, label]) => (
+                <button key={value} onClick={() => handleGroupByChange(value)}
+                  className={`px-3 py-1.5 text-sm font-medium rounded-md transition-colors ${
+                    groupBy === value
+                      ? 'bg-[#1a2332] dark:bg-blue-600 text-white'
+                      : 'text-gray-600 dark:text-gray-400 hover:text-gray-900'
+                  }`}>
+                  {label}
+                </button>
+              ))}
+            </div>
+          </div>
+          <div className="flex items-center gap-2">
+            <span className="text-sm text-gray-500 dark:text-gray-400">Sort:</span>
+            <div className="inline-flex rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 p-0.5">
+              <button onClick={() => handleSortChange('default')}
+                className={`px-3 py-1.5 text-sm font-medium rounded-md transition-colors ${
+                  sortMode === 'default' ? 'bg-[#1a2332] dark:bg-blue-600 text-white' : 'text-gray-600 dark:text-gray-400 hover:text-gray-900'
+                }`}>
+                Default
+              </button>
+              <button onClick={() => handleSortChange('name')}
+                className={`px-3 py-1.5 text-sm font-medium rounded-md transition-colors ${
+                  sortMode === 'name' ? 'bg-[#1a2332] dark:bg-blue-600 text-white' : 'text-gray-600 dark:text-gray-400 hover:text-gray-900'
+                }`}>
+                Name A–Z
+              </button>
+              <button onClick={() => handleSortChange(sortMode === 'balance-desc' ? 'balance-asc' : 'balance-desc')}
+                title={sortMode === 'balance-desc'
+                  ? 'Sorted highest value first — click for lowest first'
+                  : sortMode === 'balance-asc'
+                    ? 'Sorted lowest value first — click for highest first'
+                    : 'Sort by account value'}
+                className={`px-3 py-1.5 text-sm font-medium rounded-md transition-colors ${
+                  sortMode === 'balance-desc' || sortMode === 'balance-asc'
+                    ? 'bg-[#1a2332] dark:bg-blue-600 text-white'
+                    : 'text-gray-600 dark:text-gray-400 hover:text-gray-900'
+                }`}>
+                Value {sortMode === 'balance-asc' ? '↑' : '↓'}
+              </button>
+            </div>
+          </div>
+        </div>
+
         <ReconciliationAccountList
-          summaries={reconciliationDetails}
+          groups={accountGroups}
           onSelectAccount={handleSelectAccount}
         />
       </div>

--- a/src/pages/settings/Categories.tsx
+++ b/src/pages/settings/Categories.tsx
@@ -869,7 +869,7 @@ export default function CategoriesSettings() {
                         setReassignCategoryId('');
                       }}
                       disabled={isReassigning}
-                      className="flex-1 px-4 py-2 border border-gray-300 dark:border-gray-600 text-gray-700 dark:text-gray-300 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-700 disabled:opacity-50"
+                      className="flex-1 justify-center px-4 py-2 border border-gray-300 dark:border-gray-600 text-gray-700 dark:text-gray-300 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-700 disabled:opacity-50"
                     >
                       Cancel
                     </button>
@@ -950,7 +950,7 @@ export default function CategoriesSettings() {
                   setViewingCategoryId(null);
                   setViewingCategoryName('');
                 }}
-                className="flex-1 px-4 py-2 border border-gray-300 dark:border-gray-600 text-gray-700 dark:text-gray-300 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-700"
+                className="flex-1 justify-center px-4 py-2 border border-gray-300 dark:border-gray-600 text-gray-700 dark:text-gray-300 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-700"
               >
                 Cancel
               </button>
@@ -958,7 +958,7 @@ export default function CategoriesSettings() {
                 onClick={() => {
                   setShowTransactionsModal(true);
                 }}
-                className="flex-1 px-4 py-2 bg-[#1a2332] text-white rounded-lg hover:bg-secondary"
+                className="flex-1 justify-center px-4 py-2 bg-[#1a2332] text-white rounded-lg hover:bg-secondary"
               >
                 View Transactions
               </button>

--- a/src/pages/settings/DataManagement.tsx
+++ b/src/pages/settings/DataManagement.tsx
@@ -319,14 +319,14 @@ export default function DataManagementSettings() {
               <button
                 onClick={() => { setShowDeleteConfirm(false); setClearConfirmText(''); setClearError(''); }}
                 disabled={isClearing}
-                className="flex-1 px-4 py-2 border border-gray-300 dark:border-gray-600 text-gray-700 dark:text-gray-300 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-700 disabled:opacity-40"
+                className="flex-1 justify-center px-4 py-2 border border-gray-300 dark:border-gray-600 text-gray-700 dark:text-gray-300 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-700 disabled:opacity-40"
               >
                 Cancel
               </button>
               <button
                 onClick={() => { void handleClearData(); }}
                 disabled={isClearing || clearConfirmText.trim().toUpperCase() !== 'DELETE'}
-                className="flex-1 px-4 py-2 bg-red-700 text-white rounded-lg hover:bg-red-800 disabled:opacity-40 disabled:cursor-not-allowed"
+                className="flex-1 justify-center px-4 py-2 bg-red-700 text-white rounded-lg hover:bg-red-800 disabled:opacity-40 disabled:cursor-not-allowed"
               >
                 {isClearing ? 'Deleting…' : 'Delete All Data'}
               </button>
@@ -357,13 +357,13 @@ export default function DataManagementSettings() {
             <div className="flex gap-3">
               <button
                 onClick={() => setShowTestDataConfirm(false)}
-                className="flex-1 px-4 py-2 border border-gray-300 dark:border-gray-600 text-gray-700 dark:text-gray-300 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-700"
+                className="flex-1 justify-center px-4 py-2 border border-gray-300 dark:border-gray-600 text-gray-700 dark:text-gray-300 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-700"
               >
                 Cancel
               </button>
               <button
                 onClick={handleLoadTestData}
-                className="flex-1 px-4 py-2 bg-purple-700 text-white rounded-lg hover:bg-purple-800"
+                className="flex-1 justify-center px-4 py-2 bg-purple-700 text-white rounded-lg hover:bg-purple-800"
               >
                 Load Test Data
               </button>

--- a/src/pages/settings/SecuritySettings.tsx
+++ b/src/pages/settings/SecuritySettings.tsx
@@ -336,7 +336,7 @@ export default function SecuritySettings() {
               )}
               <button
                 onClick={() => window.location.href = '/settings/security/audit-logs'}
-                className="w-full px-4 py-2 bg-gray-100 dark:bg-gray-700 text-gray-700 dark:text-gray-300 rounded-lg hover:bg-gray-200 dark:hover:bg-gray-600 transition-colors"
+                className="w-full justify-center px-4 py-2 bg-gray-100 dark:bg-gray-700 text-gray-700 dark:text-gray-300 rounded-lg hover:bg-gray-200 dark:hover:bg-gray-600 transition-colors"
               >
                 View Audit Logs
               </button>
@@ -414,14 +414,14 @@ export default function SecuritySettings() {
                     setTwoFactorSecret(null);
                     setVerificationCode('');
                   }}
-                  className="flex-1 px-4 py-2 border border-gray-300 dark:border-gray-600 text-gray-700 dark:text-gray-300 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-700"
+                  className="flex-1 justify-center px-4 py-2 border border-gray-300 dark:border-gray-600 text-gray-700 dark:text-gray-300 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-700"
                 >
                   Cancel
                 </button>
                 <button
                   onClick={handleVerifyTwoFactor}
                   disabled={verificationCode.length !== 6}
-                  className="flex-1 px-4 py-2 bg-[var(--color-primary)] text-white rounded-lg hover:bg-[var(--color-primary)]/90 disabled:opacity-50 disabled:cursor-not-allowed"
+                  className="flex-1 justify-center px-4 py-2 bg-[var(--color-primary)] text-white rounded-lg hover:bg-[var(--color-primary)]/90 disabled:opacity-50 disabled:cursor-not-allowed"
                 >
                   Verify & Enable
                 </button>

--- a/src/utils/accountSections.ts
+++ b/src/utils/accountSections.ts
@@ -1,0 +1,84 @@
+/**
+ * The ONE definition of the account-type sections — titles, order, icons,
+ * colours — used by every page that groups accounts (Accounts, Reconciliation).
+ * Keeping it shared guarantees the groupings always match.
+ */
+import type { ComponentType } from 'react';
+import type { IconProps } from '../components/icons';
+import {
+  WalletIcon, PiggyBankIcon, CreditCardIcon, TrendingDownIcon, TrendingUpIcon, HomeIcon,
+} from '../components/icons';
+import type { Account } from '../types';
+
+export interface AccountTypeSection {
+  type: string;
+  title: string;
+  icon: ComponentType<IconProps>;
+  color: string;
+  bgColor: string;
+  borderColor: string;
+}
+
+export const ACCOUNT_TYPE_SECTIONS: AccountTypeSection[] = [
+  {
+    type: 'current',
+    title: 'Current Accounts',
+    icon: WalletIcon,
+    color: 'text-blue-700 dark:text-blue-400',
+    bgColor: 'bg-blue-200 dark:bg-blue-900/20',
+    borderColor: 'border-blue-200 dark:border-blue-800',
+  },
+  {
+    type: 'savings',
+    title: 'Savings Accounts',
+    icon: PiggyBankIcon,
+    color: 'text-green-600 dark:text-green-400',
+    bgColor: 'bg-green-200 dark:bg-green-900/20',
+    borderColor: 'border-green-200 dark:border-green-800',
+  },
+  {
+    type: 'credit',
+    title: 'Credit Cards',
+    icon: CreditCardIcon,
+    color: 'text-orange-600 dark:text-orange-400',
+    bgColor: 'bg-orange-200 dark:bg-orange-900/20',
+    borderColor: 'border-orange-200 dark:border-orange-800',
+  },
+  {
+    type: 'loan',
+    title: 'Loans',
+    icon: TrendingDownIcon,
+    color: 'text-red-600 dark:text-red-400',
+    bgColor: 'bg-red-200 dark:bg-red-900/20',
+    borderColor: 'border-red-200 dark:border-red-800',
+  },
+  {
+    type: 'investment',
+    title: 'Investments',
+    icon: TrendingUpIcon,
+    color: 'text-purple-600 dark:text-purple-400',
+    bgColor: 'bg-purple-200 dark:bg-purple-900/20',
+    borderColor: 'border-purple-200 dark:border-purple-800',
+  },
+  {
+    type: 'asset',
+    title: 'Assets',
+    icon: HomeIcon,
+    color: 'text-indigo-600 dark:text-indigo-400',
+    bgColor: 'bg-indigo-200 dark:bg-indigo-900/20',
+    borderColor: 'border-indigo-200 dark:border-indigo-800',
+  },
+  {
+    type: 'liability',
+    title: 'Liabilities',
+    icon: TrendingDownIcon,
+    color: 'text-gray-600 dark:text-gray-400',
+    bgColor: 'bg-gray-200 dark:bg-gray-900/20',
+    borderColor: 'border-gray-200 dark:border-gray-800',
+  },
+];
+
+/** The section a given account belongs to (unknown types fall to the end). */
+export function sectionForAccountType(type: Account['type']): AccountTypeSection | undefined {
+  return ACCOUNT_TYPE_SECTIONS.find(s => s.type === type);
+}

--- a/src/utils/lazyWithPreload.ts
+++ b/src/utils/lazyWithPreload.ts
@@ -5,12 +5,35 @@ export interface PreloadableComponent<T extends ComponentType<any>> extends Lazy
   preload: () => Promise<{ default: T }>;
 }
 
+// After a deploy, a long-lived tab holds an index that references chunk
+// hashes that no longer exist — its next route navigation fails with
+// "Importing a module script failed" (the Bank Feeds error). One automatic
+// reload fetches the fresh index and fixes it; the sessionStorage guard
+// stops a reload loop if the failure is real (e.g. offline).
+const RELOAD_GUARD_KEY = 'chunk_reload_guard';
+
+function importWithStaleChunkRecovery<T>(factory: () => Promise<T>): Promise<T> {
+  return factory().then(module => {
+    window.sessionStorage.removeItem(RELOAD_GUARD_KEY);
+    return module;
+  }).catch((error: unknown) => {
+    if (window.sessionStorage.getItem(RELOAD_GUARD_KEY) !== 'true') {
+      window.sessionStorage.setItem(RELOAD_GUARD_KEY, 'true');
+      window.location.reload();
+      // The page is reloading — never resolve, so no broken UI flashes.
+      return new Promise<T>(() => {});
+    }
+    throw error;
+  });
+}
+
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export function lazyWithPreload<T extends ComponentType<any>>(
   factory: () => Promise<{ default: T }>
 ): PreloadableComponent<T> {
-  const Component = lazy(factory) as PreloadableComponent<T>;
-  Component.preload = factory;
+  const recovering = () => importWithStaleChunkRecovery(factory);
+  const Component = lazy(recovering) as PreloadableComponent<T>;
+  Component.preload = recovering;
   return Component;
 }
 


### PR DESCRIPTION
Your production test-drive feedback (items 2–6), each fixed at the root:

## 1. The "centred / zig-zag" look everywhere — one global CSS bug
`index.css` declared `button { justify-content: center }` **unconditionally** — the same class of blanket rule that caused the toggle blobs. Every full-width icon+label button centred its content: Data Management, Tools, Reconciliation, all of it. The rule is deleted; a whole-tree scan of every `<button>` tag (static *and* template-literal classNames) found the ~85 buttons that were intentionally centred (modal footer CTAs, sign-in, segmented controls) and they now declare `justify-center` explicitly. Icons line up in clean left rails everywhere.

## 2. Reconciliation page — grouped + sortable like Accounts
Accounts are grouped into the **same sections as the Accounts page**, driven by a shared single source (`utils/accountSections.ts`) that Accounts.tsx now also imports — the two pages can never drift. Same Group by (Account Type / Institution) and Sort (Default / Name A–Z / Value ↑↓) controls, persisted the same way. Row columns spread edge-to-edge.

## 3. "Bank Feeds" → *Importing a module script failed*
Stale-chunk error: after a deploy, a long-lived tab requests route chunks whose hashes no longer exist. `lazyWithPreload` now **self-heals** — one guarded automatic reload fetches the fresh index (a sessionStorage guard prevents reload loops when the failure is real, e.g. offline). Note the *slow load after* reloading is the known 50k-row initial fetch — archiving on production will shrink that directly.

## 4. Dashboard Income/Expenses breakdown — click to edit
Rows open the full Edit Transaction modal; the list derives live, so re-categorising a transaction drops it out of the list immediately — exactly the flow you described.

## 5. Small: removed the duplicated Archive section description.

## Verification
Browser-verified in demo mode: Data Management/Tools icons in straight columns; Reconciliation showing sectioned groups + toolbar; an Income row click opening the editor. Smoke **3,153 passing**; strict typecheck, lint, production build clean.

Item 1 from your list (investment cash accounts nested via Money's `hacctRel` pairing) is the next PR — landing it **before** your full .mny import so the import creates the pairings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)