### PR TITLE
feat(accounts): nest investment cash accounts inside their investment account (hacctRel pairing)

### DIFF
--- a/src/components/MsMoneyImportModal.tsx
+++ b/src/components/MsMoneyImportModal.tsx
@@ -156,6 +156,13 @@ export default function MsMoneyImportModal({ isOpen, onClose, onBackup, onExecut
                   <Stat label="Categories" value={`${s.categories.subs + s.categories.details}`} sub={`${s.categories.subs} groups`} />
                   <Stat label="Split transactions" value={`${s.transactions.splitTransactions}`} sub={`${s.transactions.splitLines} lines`} />
                   <Stat label="Standalone" value={s.transactions.standalone.toLocaleString()} />
+                  {s.accounts.investmentCashPairs > 0 && (
+                    <Stat
+                      label="Investment cash pairs"
+                      value={`${s.accounts.investmentCashPairs}`}
+                      sub="cash accounts nested inside their investment account"
+                    />
+                  )}
                 </div>
               </div>
 

--- a/src/pages/Accounts.tsx
+++ b/src/pages/Accounts.tsx
@@ -61,6 +61,29 @@ export default function Accounts({ onAccountClick }: { onAccountClick?: (account
   // the Closed Accounts section below (the Microsoft Money model — closing
   // hides an account without touching its history, and it can be reopened).
   const openAccounts = useMemo(() => accounts.filter(a => a.isActive !== false), [accounts]);
+
+  // Investment↔cash pairing (the Microsoft Money model): a cash account whose
+  // parentAccountId points at another OPEN account renders nested inside that
+  // parent's card instead of as a top-level card, and its balance counts
+  // toward the parent's group total. It stays a full account — own register,
+  // transfers, reconciliation — only its placement here changes.
+  const nestedByParent = useMemo(() => {
+    const ids = new Set(openAccounts.map(a => a.id));
+    const map = new Map<string, Account[]>();
+    openAccounts.forEach(a => {
+      if (a.parentAccountId && ids.has(a.parentAccountId)) {
+        const list = map.get(a.parentAccountId);
+        if (list) list.push(a);
+        else map.set(a.parentAccountId, [a]);
+      }
+    });
+    return map;
+  }, [openAccounts]);
+
+  const topLevelAccounts = useMemo(() => {
+    const ids = new Set(openAccounts.map(a => a.id));
+    return openAccounts.filter(a => !(a.parentAccountId && ids.has(a.parentAccountId)));
+  }, [openAccounts]);
   const [closedAccounts, setClosedAccounts] = useState<Account[]>([]);
   const [showClosedAccounts, setShowClosedAccounts] = useState(false);
   const [reopeningId, setReopeningId] = useState<string | null>(null);
@@ -115,9 +138,10 @@ export default function Accounts({ onAccountClick }: { onAccountClick?: (account
     })) : undefined
   })), [openAccounts]);
 
-  // Group accounts by type (memoized)
+  // Group accounts by type (memoized) — nested cash accounts are not
+  // top-level cards, so they don't group here.
   const accountsByType = useMemo(() =>
-    openAccounts.reduce((groups, account) => {
+    topLevelAccounts.reduce((groups, account) => {
       const type = account.type;
       if (!groups[type]) {
         groups[type] = [];
@@ -125,7 +149,7 @@ export default function Accounts({ onAccountClick }: { onAccountClick?: (account
       groups[type].push(account);
       return groups;
     }, {} as Record<string, typeof accounts>),
-    [openAccounts]
+    [topLevelAccounts]
   );
 
   // Set loading to false when accounts are loaded
@@ -141,27 +165,30 @@ export default function Accounts({ onAccountClick }: { onAccountClick?: (account
     amount: toDecimal(t.amount),
   })), [transactions]);
 
-  // Group decimal accounts by type for calculations
-  const decimalAccountsByType = useMemo(() =>
-    decimalAccounts.reduce((groups, account) => {
-      const type = account.type;
+  // Group decimal accounts by their EFFECTIVE type for the section totals: a
+  // nested cash account counts toward its PARENT's section (Investments), not
+  // its own type (Current Accounts).
+  const decimalAccountsByType = useMemo(() => {
+    const typeById = new Map(openAccounts.map(a => [a.id, a.type]));
+    return decimalAccounts.reduce((groups, account) => {
+      const type = (account.parentAccountId && typeById.get(account.parentAccountId)) || account.type;
       if (!groups[type]) {
         groups[type] = [];
       }
       groups[type].push(account);
       return groups;
-    }, {} as Record<string, typeof decimalAccounts>),
-    [decimalAccounts]
-  );
+    }, {} as Record<string, typeof decimalAccounts>);
+  }, [decimalAccounts, openAccounts]);
 
   // The shared account-type sections (same groupings everywhere).
   const accountTypes = ACCOUNT_TYPE_SECTIONS;
 
 
-  // Group accounts by institution
+  // Group accounts by institution (nested cash accounts ride with their
+  // parent's card, so only top-level accounts group here)
   const accountsByInstitution = useMemo(() => {
     const groups: Record<string, typeof accounts> = {};
-    openAccounts.forEach(account => {
+    topLevelAccounts.forEach(account => {
       const institution = account.institution || 'Other Accounts';
       if (!groups[institution]) {
         groups[institution] = [];
@@ -176,7 +203,7 @@ export default function Accounts({ onAccountClick }: { onAccountClick?: (account
       return a.localeCompare(b);
     }).forEach(key => { sorted[key] = groups[key]; });
     return sorted;
-  }, [openAccounts]);
+  }, [topLevelAccounts]);
 
   const handleGroupByChange = (value: 'type' | 'institution') => {
     setGroupBy(value);
@@ -427,6 +454,51 @@ export default function Accounts({ onAccountClick }: { onAccountClick?: (account
                             </div>
                       </div>
                     </div>
+
+                    {/* Nested cash accounts (investment↔cash pairing): the
+                        Money model shows the pair as one account, cash inside. */}
+                    {(nestedByParent.get(account.id) ?? []).map(child => {
+                      const childName = child.name === `${account.name} (Cash)` ? 'Cash' : child.name;
+                      const childUnreconciled = getUnreconciledCount(child.id);
+                      return (
+                        <div
+                          key={child.id}
+                          className="mt-3 ml-6 sm:ml-9 flex items-center gap-3 rounded-xl border border-dashed border-gray-200 dark:border-gray-600 bg-gray-50 dark:bg-gray-700/40 px-3 py-2.5 cursor-pointer hover:border-gray-300 dark:hover:border-gray-500 transition-colors"
+                          onClick={(e) => {
+                            e.stopPropagation();
+                            if ((e.target as HTMLElement).closest('button, input')) return;
+                            if (onAccountClick) {
+                              onAccountClick(child.id);
+                            } else {
+                              navigate(preserveDemoParam(`/accounts/${child.id}`, location.search));
+                            }
+                          }}
+                        >
+                          <WalletIcon className="text-teal-600 dark:text-teal-400 flex-shrink-0" size={14} />
+                          <div className="flex-1 min-w-0">
+                            <p className="text-sm font-medium text-gray-800 dark:text-gray-200 truncate">{childName}</p>
+                            <p className="text-[11px] text-gray-500 dark:text-gray-400">Cash account</p>
+                          </div>
+                          <div className="text-right">
+                            <p className="text-[10px] uppercase tracking-wide text-gray-400 dark:text-gray-500">Account Bal</p>
+                            <p className="text-sm font-semibold tabular-nums text-gray-900 dark:text-white">
+                              {formatDisplayCurrency(computeAccountBalance(child.id), child.currency)}
+                            </p>
+                          </div>
+                          <div className="text-right">
+                            <p className="text-[10px] uppercase tracking-wide text-gray-400 dark:text-gray-500">Unreconciled</p>
+                            <p className={`text-sm font-semibold tabular-nums ${
+                              childUnreconciled > 0
+                                ? 'text-amber-600 dark:text-amber-400'
+                                : 'text-blue-600 dark:text-blue-400'
+                            }`}>
+                              {childUnreconciled}
+                            </p>
+                          </div>
+                          <ChevronRightIcon size={16} className="text-gray-400 flex-shrink-0" />
+                        </div>
+                      );
+                    })}
                   </div>
     );
   };
@@ -582,10 +654,12 @@ export default function Accounts({ onAccountClick }: { onAccountClick?: (account
         ) : groupBy === 'institution' ? (
           /* Institution grouping view */
           Object.entries(accountsByInstitution).map(([institution, instAccounts]) => {
-            const instDecimalAccounts = decimalAccounts.filter(da => {
-              const original = instAccounts.find(a => a.id === da.id);
-              return !!original;
-            });
+            // Nested cash accounts count toward their parent's institution
+            // total, wherever the cash account itself claims to live.
+            const instIds = new Set(instAccounts.map(a => a.id));
+            const instDecimalAccounts = decimalAccounts.filter(da =>
+              instIds.has(da.id) || (da.parentAccountId != null && instIds.has(da.parentAccountId))
+            );
             const instTotal = calculateTotalBalance(instDecimalAccounts, decimalTransactions);
 
             return (

--- a/src/services/api/accountService.ts
+++ b/src/services/api/accountService.ts
@@ -37,6 +37,7 @@ const ACCOUNT_CAMEL_TO_DB: Record<string, string> = {
   lowBalanceAlertEnabled: 'low_balance_alert_enabled',
   lowBalanceThreshold: 'low_balance_threshold',
   archiveThroughDate: 'archive_through_date',
+  parentAccountId: 'parent_account_id',
 };
 
 function mapAccountToDb(obj: Record<string, unknown>): Record<string, unknown> {
@@ -64,6 +65,7 @@ function mapAccountFromDb(row: Record<string, unknown>): Record<string, unknown>
     lowBalanceAlertEnabled: row.low_balance_alert_enabled === true,
     lowBalanceThreshold: row.low_balance_threshold != null ? Number(row.low_balance_threshold) : undefined,
     archiveThroughDate: row.archive_through_date != null ? new Date(String(row.archive_through_date)) : null,
+    parentAccountId: row.parent_account_id ?? null,
   };
 }
 

--- a/src/services/api/simpleAccountService.ts
+++ b/src/services/api/simpleAccountService.ts
@@ -46,6 +46,8 @@ type DbAccount = {
   credit_limit?: number | null;
   notes?: string | null;
   opening_balance_date?: string | null;
+  archive_through_date?: string | null;
+  parent_account_id?: string | null;
 };
 
 function transformAccountFromDb(row: Record<string, unknown>): Account {
@@ -69,6 +71,8 @@ function transformAccountFromDb(row: Record<string, unknown>): Account {
     creditLimit: dbAccount.credit_limit,
     notes: dbAccount.notes ?? '',
     openingBalanceDate: dbAccount.opening_balance_date ? new Date(dbAccount.opening_balance_date) : undefined,
+    archiveThroughDate: dbAccount.archive_through_date ? new Date(dbAccount.archive_through_date) : null,
+    parentAccountId: dbAccount.parent_account_id ?? null,
   } as Account;
 }
 
@@ -82,6 +86,8 @@ const ACCOUNT_CAMEL_TO_DB: Record<string, string> = {
   creditLimit: 'credit_limit',
   lastUpdated: 'updated_at',
   openingBalanceDate: 'opening_balance_date',
+  archiveThroughDate: 'archive_through_date',
+  parentAccountId: 'parent_account_id',
 };
 
 function mapAccountUpdatesToDb(updates: Partial<Account>): Record<string, unknown> {

--- a/src/services/import/msMoney/mnyReader.test.ts
+++ b/src/services/import/msMoney/mnyReader.test.ts
@@ -50,6 +50,13 @@ describe.runIf(realFile && existsSync(realFile!))('readMnyExport (real .mny)', (
     expect(exp.accounts.length).toBeGreaterThan(0);
     expect(exp.transactions.length).toBeGreaterThan(0);
 
+    // hacctRel pairing survives extraction: at least one investment account is
+    // linked to a cash account, and the transform nests the cash side.
+    const byId = new Map(exp.accounts.map(a => [a.id, a]));
+    const pairs = exp.accounts.filter(a =>
+      a.moneyType === 'investment' && a.relatedAccountId != null && byId.has(a.relatedAccountId));
+    expect(pairs.length).toBeGreaterThan(0);
+
     // Roles cover every transaction exactly once.
     const roles = exp.transactions.reduce<Record<string, number>>((m, t) => {
       m[t.role] = (m[t.role] ?? 0) + 1; return m;
@@ -60,6 +67,7 @@ describe.runIf(realFile && existsSync(realFile!))('readMnyExport (real .mny)', (
     // The transform must accept the extracted export and every split parent
     // must reconcile to its lines (the core money-safety invariant).
     const out = transformMsMoneyExport(exp, new Date('2020-01-01').toISOString());
+    expect(out.summary.accounts.investmentCashPairs).toBeGreaterThan(0);
     const linesByTxn = new Map<string, number>();
     for (const s of out.transactionSplits) {
       linesByTxn.set(s.transactionId, Math.round(((linesByTxn.get(s.transactionId) ?? 0) + s.amount) * 100) / 100);

--- a/src/services/import/msMoney/mnyReader.ts
+++ b/src/services/import/msMoney/mnyReader.ts
@@ -14,9 +14,12 @@
  * to decimal strings; the transform is the single place money maths happens.
  */
 // Installs Buffer + process shims BEFORE mdb-reader's dependency subtree
-// evaluates — must stay the first import in this file.
+// evaluates — must stay the first import in this file. Buffer is then used as
+// a GLOBAL (never imported from 'buffer'): mdb-reader validates its input
+// against the runtime's own Buffer class — Node's real one under tests, the
+// shim-installed polyfill in the browser — and the 'buffer' package import
+// would pin the polyfill even in Node, which mdb-reader rejects.
 import './nodeGlobalsShim';
-import { Buffer } from 'buffer';
 import MDBReader from 'mdb-reader';
 import { decryptMny } from './mnyDecrypt';
 import type {
@@ -175,6 +178,10 @@ function extractAccounts(
       id,
       name: str(a.szFull) ?? str(a.szAls) ?? `Account ${id}`,
       moneyType: AT_TO_MONEYTYPE[num(a.at) ?? -1] ?? 'other',
+      // Money pairs every investment account with its "(Cash)" account via
+      // ACCT.hacctRel (bidirectional). The transform uses it to nest the cash
+      // side inside its investment account.
+      relatedAccountId: num(a.hacctRel) ?? null,
       currencyCode: isoByCrnc.get(num(a.hcrnc)!) ?? null,
       openingBalance: (open / 100).toFixed(2),
       reconstructedBalance: (reconstructed / 100).toFixed(2),

--- a/src/services/import/msMoney/msMoneyImport.test.ts
+++ b/src/services/import/msMoney/msMoneyImport.test.ts
@@ -7,6 +7,9 @@ function sampleResult(): MsMoneyImportResult {
     accounts: [
       { id: 'mny-acct-1', name: 'Current', type: 'current', balance: 100, openingBalance: 0, currency: 'GBP', isActive: true, lastUpdated: new Date('2020-01-01') },
       { id: 'mny-acct-2', name: 'Savings', type: 'savings', balance: 50, openingBalance: 0, currency: 'GBP', isActive: false, lastUpdated: new Date('2020-01-01') },
+      // investment↔cash pair (Money's hacctRel): the cash side carries the parent ref
+      { id: 'mny-acct-3', name: 'Broker', type: 'investment', balance: 0, openingBalance: 0, currency: 'GBP', isActive: true, lastUpdated: new Date('2020-01-01') },
+      { id: 'mny-acct-4', name: 'Broker (Cash)', type: 'current', parentAccountId: 'mny-acct-3', balance: 25, openingBalance: 0, currency: 'GBP', isActive: true, lastUpdated: new Date('2020-01-01') },
     ],
     categories: [
       { id: 'type-expense', name: 'Expense', type: 'expense', level: 'type', isSystem: true },
@@ -25,7 +28,7 @@ function sampleResult(): MsMoneyImportResult {
       { id: 'mny-split-300-1', transactionId: 'mny-txn-300', category: 'mny-cat-10', amount: -50, sortOrder: 1 },
     ],
     summary: {
-      accounts: { total: 2, open: 1, closed: 1 },
+      accounts: { total: 4, open: 3, closed: 1, investmentCashPairs: 1 },
       categories: { subs: 0, details: 2, hidden: 0 },
       transactions: { imported: 4, standalone: 1, transfers: 2, splitTransactions: 1, splitLines: 1 },
       simplifications: [],
@@ -61,6 +64,14 @@ describe('planCloudImport', () => {
       expect(l.linked_transfer_id.startsWith('new-')).toBe(true);
     }
 
+    // Accounts insert WITHOUT parent_account_id; the investment↔cash pairing
+    // is staged as a second pass against the remapped ids.
+    expect(plan.accounts.every(a => !('parent_account_id' in a))).toBe(true);
+    expect(plan.accountParents).toHaveLength(1);
+    const broker = plan.accounts.find(a => a.name === 'Broker')!;
+    const brokerCash = plan.accounts.find(a => a.name === 'Broker (Cash)')!;
+    expect(plan.accountParents[0]).toEqual({ id: brokerCash.id, parent_account_id: broker.id });
+
     // Split parent keeps is_split + blank category; its line references the remapped parent + category.
     const splitParent = plan.transactions.find(t => t.is_split === true)!;
     expect(splitParent.category).toBe('');
@@ -87,7 +98,7 @@ describe('importToLocalStorage', () => {
     const onProgress = vi.fn();
     await importToLocalStorage(sampleResult(), KEYS, { onProgress });
 
-    expect(JSON.parse(window.localStorage.getItem('a')!)).toHaveLength(2);
+    expect(JSON.parse(window.localStorage.getItem('a')!)).toHaveLength(4);
     expect(JSON.parse(window.localStorage.getItem('t')!)).toHaveLength(4);
     expect(JSON.parse(window.localStorage.getItem('c')!)).toHaveLength(3);
     expect(JSON.parse(window.localStorage.getItem('s')!)).toHaveLength(1);

--- a/src/services/import/msMoney/msMoneyImport.ts
+++ b/src/services/import/msMoney/msMoneyImport.ts
@@ -74,7 +74,8 @@ const dateOnly = (d: Date | string): string =>
   (d instanceof Date ? d.toISOString() : String(d)).slice(0, 10);
 
 interface CloudPlan {
-  accounts: Record<string, unknown>[];
+  accounts: Record<string, unknown>[];       // inserted WITHOUT parent_account_id
+  accountParents: { id: string; parent_account_id: string }[];
   categories: Record<string, unknown>[];
   transactions: Record<string, unknown>[];   // inserted WITHOUT linked_transfer_id
   transferLinks: { id: string; linked_transfer_id: string }[];
@@ -109,6 +110,13 @@ export function planCloudImport(
     is_active: a.isActive !== false,
     notes: a.notes ?? null,
   }));
+
+  // Investment↔cash pairings reference other account rows, so they go in as a
+  // second pass once every account exists (insert batching makes same-batch
+  // FK ordering unreliable).
+  const accountParents = result.accounts
+    .filter(a => a.parentAccountId && acctId.has(a.parentAccountId))
+    .map(a => ({ id: acctId.get(a.id)!, parent_account_id: acctId.get(a.parentAccountId!)! }));
 
   const categories = result.categories
     // System categories (type/transfer roots) already exist per-user; only the
@@ -163,7 +171,7 @@ export function planCloudImport(
     .filter(t => t.linkedTransferSplitId && splitId.has(t.linkedTransferSplitId))
     .map(t => ({ id: txnId.get(t.id)!, linked_transfer_split_id: splitId.get(t.linkedTransferSplitId!)! }));
 
-  return { accounts, categories, transactions, transferLinks, splits, splitLegPins };
+  return { accounts, accountParents, categories, transactions, transferLinks, splits, splitLegPins };
 }
 
 /**
@@ -230,6 +238,13 @@ export async function importToCloud(
   };
 
   await insert('accounts', plan.accounts, 'accounts', 0.05, 0.1);
+
+  for (const p of plan.accountParents) {
+    const { error } = await supabase.from('accounts')
+      .update({ parent_account_id: p.parent_account_id }).eq('id', p.id);
+    if (error) fail('pairing investment cash accounts', error.message);
+  }
+
   await insert('categories', plan.categories, 'categories', 0.15, 0.1);
   await insert('transactions', plan.transactions, 'transactions', 0.25, 0.45);
 

--- a/src/services/import/msMoney/transform.test.ts
+++ b/src/services/import/msMoney/transform.test.ts
@@ -217,3 +217,33 @@ describe('transformMsMoneyExport — transactions', () => {
     expect(computed).toBeCloseTo(2005.51, 2);
   });
 });
+
+describe('transformMsMoneyExport — investment cash pairing (hacctRel)', () => {
+  const invAccounts = [
+    { id: 10, name: 'Rathbones - Share ISA', moneyType: 'investment', relatedAccountId: 11, currencyCode: 'GBP', openingBalance: '0', reconstructedBalance: '0', closed: false, openDate: null, closeDate: null, comment: null },
+    { id: 11, name: 'Rathbones - Share ISA (Cash)', moneyType: 'bank', relatedAccountId: 10, currencyCode: 'GBP', openingBalance: '0', reconstructedBalance: '250.00', closed: false, openDate: null, closeDate: null, comment: null },
+    // hacctRel between two NON-investment accounts (never seen in practice) —
+    // left unpaired rather than guessed at
+    { id: 12, name: 'Bank A', moneyType: 'bank', relatedAccountId: 13, currencyCode: 'GBP', openingBalance: '0', reconstructedBalance: '0', closed: false, openDate: null, closeDate: null, comment: null },
+    { id: 13, name: 'Bank B', moneyType: 'bank', relatedAccountId: 12, currencyCode: 'GBP', openingBalance: '0', reconstructedBalance: '0', closed: false, openDate: null, closeDate: null, comment: null },
+  ];
+
+  it('nests the cash side under its investment account; the investment side stays top-level', () => {
+    const { accounts, summary } = transformMsMoneyExport(build({ accounts: invAccounts, transactions: [] }), NOW);
+    expect(accounts.find(a => a.id === 'mny-acct-11')!.parentAccountId).toBe('mny-acct-10');
+    expect(accounts.find(a => a.id === 'mny-acct-10')!.parentAccountId).toBeUndefined();
+    expect(summary.accounts.investmentCashPairs).toBe(1);
+  });
+
+  it('ignores hacctRel links that are not investment↔cash', () => {
+    const { accounts } = transformMsMoneyExport(build({ accounts: invAccounts, transactions: [] }), NOW);
+    expect(accounts.find(a => a.id === 'mny-acct-12')!.parentAccountId).toBeUndefined();
+    expect(accounts.find(a => a.id === 'mny-acct-13')!.parentAccountId).toBeUndefined();
+  });
+
+  it('accounts without hacctRel are unaffected', () => {
+    const { accounts, summary } = transformMsMoneyExport(build(), NOW);
+    expect(accounts.every(a => a.parentAccountId === undefined)).toBe(true);
+    expect(summary.accounts.investmentCashPairs).toBe(0);
+  });
+});

--- a/src/services/import/msMoney/transform.ts
+++ b/src/services/import/msMoney/transform.ts
@@ -26,6 +26,11 @@ export interface MnyAccount {
   id: number;
   name: string;
   moneyType: 'bank' | 'credit' | 'cash' | 'asset' | 'liability' | 'investment' | string;
+  /**
+   * ACCT.hacctRel — Money's investment↔cash pairing, set on BOTH sides.
+   * The transform nests the cash side under its investment account.
+   */
+  relatedAccountId?: number | null;
   currencyCode: string | null;
   openingBalance: string;
   reconstructedBalance: string;
@@ -94,7 +99,7 @@ export interface MsMoneyImportResult {
 }
 
 export interface MsMoneyImportSummary {
-  accounts: { total: number; open: number; closed: number };
+  accounts: { total: number; open: number; closed: number; investmentCashPairs: number };
   categories: { subs: number; details: number; hidden: number };
   transactions: {
     imported: number;
@@ -144,17 +149,32 @@ const isoToDate = (iso: string): Date => new Date(`${iso}T00:00:00.000Z`);
 
 // ── Accounts ─────────────────────────────────────────────────────────────────
 
-function transformAccounts(mny: MnyAccount[], nowIso: string): Account[] {
-  return mny.map((a): Account => {
+function transformAccounts(mny: MnyAccount[], nowIso: string): { accounts: Account[]; cashPairs: number } {
+  // Money's hacctRel pairing is bidirectional; the CHILD of the pair is the
+  // non-investment (cash) side, nested under its investment account. Any other
+  // hacctRel combination (it only ever links investment↔cash in practice) is
+  // left unpaired rather than guessed at.
+  const byId = new Map<number, MnyAccount>(mny.map(a => [a.id, a]));
+  const parentOf = (a: MnyAccount): number | null => {
+    if (a.relatedAccountId == null || a.moneyType === 'investment') return null;
+    const related = byId.get(a.relatedAccountId);
+    return related && related.moneyType === 'investment' ? related.id : null;
+  };
+  let cashPairs = 0;
+
+  const accounts = mny.map((a): Account => {
     // The app computes running balance as openingBalance + Σtransactions — the
     // SAME invariant Money uses. Money's opening is authoritative; its stored
     // "current" balance is a dead cache (uninitialised memory) so we never use
     // it. The reconstructed balance rides along as the display `balance`; the
     // ledger recomputes it from the imported transactions and must agree.
+    const parent = parentOf(a);
+    if (parent != null) cashPairs++;
     return {
       id: acctId(a.id),
       name: a.name,
       type: mapAccountType(a.moneyType),
+      parentAccountId: parent != null ? acctId(parent) : undefined,
       balance: toNumber(a.reconstructedBalance),
       openingBalance: toNumber(a.openingBalance),
       openingBalanceDate: a.openDate ? isoToDate(a.openDate) : undefined,
@@ -166,6 +186,7 @@ function transformAccounts(mny: MnyAccount[], nowIso: string): Account[] {
       updatedAt: new Date(nowIso),
     };
   });
+  return { accounts, cashPairs };
 }
 
 // ── Categories (Money's 3-level tree → the app's type/sub/detail) ───────────
@@ -461,7 +482,7 @@ function buildTransferCategories(
 }
 
 export function transformMsMoneyExport(exp: MnyExport, nowIso: string): MsMoneyImportResult {
-  const accounts = transformAccounts(exp.accounts, nowIso);
+  const { accounts, cashPairs } = transformAccounts(exp.accounts, nowIso);
   const { categories, hiddenCount } = transformCategories(exp.categories);
   const transfer = buildTransferCategories(exp.accounts, exp.transactions);
   categories.push(...transfer.categories);
@@ -472,6 +493,7 @@ export function transformMsMoneyExport(exp: MnyExport, nowIso: string): MsMoneyI
       total: accounts.length,
       open: accounts.filter(a => a.isActive !== false).length,
       closed: accounts.filter(a => a.isActive === false).length,
+      investmentCashPairs: cashPairs,
     },
     categories: {
       subs: categories.filter(c => c.level === 'sub').length,

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -29,6 +29,14 @@ export interface Account {
    * archived ("keep all"). Balances are unaffected — see soft_archive.
    */
   archiveThroughDate?: Date | null;
+  /**
+   * Investment↔cash pairing (the Microsoft Money model): set on a CASH
+   * account, pointing at the investment account it belongs to. The Accounts
+   * page nests it inside that parent and counts its balance in the parent's
+   * section; the cash account itself stays a full, real account (register,
+   * transfers, reconciliation). NULL/undefined = a normal top-level account.
+   */
+  parentAccountId?: string | null;
   holdings?: Holding[];
   notes?: string;
   isActive?: boolean;

--- a/supabase/migrations/20260722090000_investment_cash_pairing.sql
+++ b/supabase/migrations/20260722090000_investment_cash_pairing.sql
@@ -1,0 +1,43 @@
+-- ============================================================================
+-- Investment cash pairing — nest an investment account's cash side inside it.
+--
+-- The Microsoft Money model: every investment account has a linked "(Cash)"
+-- account (ACCT.hacctRel) that holds the money side — transfers land there,
+-- share purchases spend from it. In Money the pair displays as ONE account;
+-- listing the cash side as a free-standing current account (as the first
+-- import did) is wrong.
+--
+-- accounts.parent_account_id records the pairing: set on the CASH account,
+-- pointing at its investment account. NULL = a normal top-level account.
+-- The cash account remains a full, real account — its own register, its own
+-- transfers, its own reconciliation — only its PLACEMENT changes: the
+-- Accounts page shows it nested inside its parent, and its balance counts
+-- toward the parent's section total instead of Current Accounts.
+--
+-- ON DELETE SET NULL: if the investment account ever goes away, the cash
+-- account gracefully becomes top-level rather than blocking the delete.
+-- ============================================================================
+
+BEGIN;
+
+ALTER TABLE public.accounts
+  ADD COLUMN IF NOT EXISTS parent_account_id uuid
+    REFERENCES public.accounts(id) ON DELETE SET NULL;
+
+-- An account can never be its own parent.
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint WHERE conname = 'accounts_parent_not_self'
+  ) THEN
+    ALTER TABLE public.accounts
+      ADD CONSTRAINT accounts_parent_not_self
+      CHECK (parent_account_id IS NULL OR parent_account_id <> id);
+  END IF;
+END $$;
+
+CREATE INDEX IF NOT EXISTS idx_accounts_parent_account_id
+  ON public.accounts (parent_account_id)
+  WHERE parent_account_id IS NOT NULL;
+
+COMMIT;


### PR DESCRIPTION
**Item 1 from your feedback — lands BEFORE your full .mny re-import so the import creates the pairings.**

> *In MS Money, they are not separate, and in my app I do not want them to be separate… Every investment account in MS Money has a 'cash account'.*

## How Money links them
Your file pairs each investment account with its cash account explicitly — `ACCT.hacctRel`, bidirectional, **36 pairs**. No name-matching guesswork: the reader now extracts it, and the transform sets `parentAccountId` on the **cash side only**, and only for a genuine investment↔cash link.

## What lands
- **DB**: `accounts.parent_account_id` (self-FK, `ON DELETE SET NULL`, no-self-parent check) — migration `20260722090000_investment_cash_pairing.sql` for you to apply. The cloud importer applies pairings as a second pass after all accounts insert (same proven pattern as transfer links).
- **Accounts page**: a paired cash account stops being a top-level Current Accounts card and renders as an indented **Cash** row *inside* its investment account's card — balance, unreconciled count, click-through to its own register. Its balance counts toward the **Investments** section total (and the parent's institution group), not Current Accounts. It stays a full account underneath: register, transfers, reconciliation all work exactly as before.
- **Import wizard** summary shows the detected pair count, so you can eyeball it before confirming.
- Two rides-along fixes: the Archive section forgot its "Archived through…" label after a reload (missing read-mapping), and the gated real-.mny test could never actually run (Buffer class clash) — fixed, and it now runs.

## Verification
- **Against your real .mny** (gated test, read-only): pairing survives extraction, the transform nests it, every split still reconciles — passing.
- **In the browser** on the previously imported local dataset: Current Accounts **29 → 18** top-level cards, cash rows nested under their investment accounts, clicking the Cash row inside *EIS Investments* opened that cash account's register.
- Strict types, lint, smoke (3,156), production build: all green.

## Notes
- Nesting applies only while the investment parent is **open**; if the parent is closed, the cash account stays top-level rather than hiding inside an invisible card.
- Replaces #123 (auto-closed when its base branch #122 merged and was deleted; rebased onto main, identical content). Your **production** data pairs up when you run the full .mny re-import — existing rows aren't touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
