### PR TITLE
fix(reports): income/expense by category semantics + distribution legend + Analytics click-to-edit

### DIFF
--- a/src/components/dashboard/ImprovedDashboard.tsx
+++ b/src/components/dashboard/ImprovedDashboard.tsx
@@ -27,6 +27,7 @@ import { PieChart, BarChart, ResponsiveContainer } from '../charts/DashboardChar
 import { formatDecimal } from '../../utils/decimal-format';
 import { toDecimal } from '../../utils/decimal';
 import { expandSplitTransactions } from '../../utils/transactionSplits';
+import { computeIncomeExpense, bucketContribution } from '../../utils/incomeExpense';
 
 /**
  * Improved Dashboard with better information hierarchy
@@ -37,7 +38,7 @@ import { expandSplitTransactions } from '../../utils/transactionSplits';
  * 4. Mobile-optimized - works great on all screen sizes
  */
 export function ImprovedDashboard() {
-  const { accounts, transactions, transactionSplits, budgets } = useApp();
+  const { accounts, transactions, transactionSplits, budgets, categories } = useApp();
   const { formatCurrency: formatCurrencyWithSymbol, displayCurrency } = useCurrencyDecimal();
   const navigate = useNavigate();
   const location = useLocation();
@@ -97,15 +98,12 @@ export function ImprovedDashboard() {
       new Date(t.date) >= thirtyDaysAgo
     );
 
-    const monthlyIncome = recentTransactions
-      .filter(t => t.type === 'income')
-      .reduce((sum, t) => sum.plus(toDecimal(t.amount)), toDecimal(0))
-      .toNumber();
-
-    const monthlyExpenses = recentTransactions
-      .filter(t => t.type === 'expense')
-      .reduce((sum, t) => sum.plus(toDecimal(t.amount).abs()), toDecimal(0))
-      .toNumber();
+    // Income/expenses by CATEGORY SEMANTICS (utils/incomeExpense): a refund
+    // filed under an expense category is an expense credit that reduces
+    // spending — direction of movement never decides the bucket.
+    const flows = computeIncomeExpense(recentTransactions, transactionSplits, categories);
+    const monthlyIncome = flows.income.toNumber();
+    const monthlyExpenses = flows.expenses.toNumber();
 
     const monthlySavings = toDecimal(monthlyIncome).minus(toDecimal(monthlyExpenses)).toNumber();
     const savingsRate = monthlyIncome > 0
@@ -165,6 +163,8 @@ export function ImprovedDashboard() {
       totalLiabilities,
       monthlyIncome,
       monthlyExpenses,
+      monthlyIncomeRows: flows.incomeRows,
+      monthlyExpenseRows: flows.expenseRows,
       monthlySavings,
       savingsRate,
       recentActivity,
@@ -176,7 +176,7 @@ export function ImprovedDashboard() {
       netWorthChange: 0, // Will be calculated from actual historical data when available
       netWorthChangePercent: 0 // Will be calculated from actual historical data when available
     };
-  }, [accounts, transactions, transactionSplits, budgets]);
+  }, [accounts, transactions, transactionSplits, budgets, categories]);
   
   // Generate net worth data for chart - ONLY REAL DATA
   const netWorthData = useMemo(() => {
@@ -377,20 +377,22 @@ export function ImprovedDashboard() {
             </thead>
             <tbody>
               {(() => {
-                const thirtyDaysAgo = new Date();
-                thirtyDaysAgo.setDate(thirtyDaysAgo.getDate() - 30);
-                const monthlyTxns = transactions
-                  .filter(t => new Date(t.date) >= thirtyDaysAgo && t.type === breakdownType)
+                // The classified rows behind the header figure (category
+                // semantics — refunds appear here as negative credits). Split
+                // lines list individually; clicking one edits its parent.
+                const rows = [...(breakdownType === 'income' ? metrics.monthlyIncomeRows : metrics.monthlyExpenseRows)]
                   .sort((a, b) => new Date(b.date).getTime() - new Date(a.date).getTime());
 
-                if (monthlyTxns.length === 0) {
+                if (rows.length === 0) {
                   return <tr><td colSpan={3} className="text-center py-8 text-gray-400">No {breakdownType} transactions this month</td></tr>;
                 }
 
-                return monthlyTxns.map(t => (
+                return rows.map(t => {
+                  const contribution = bucketContribution(t, breakdownType === 'income' ? 'income' : 'expense');
+                  return (
                   <tr
                     key={t.id}
-                    onClick={() => setEditingBreakdownTxnId(t.id)}
+                    onClick={() => setEditingBreakdownTxnId(t.splitParentId ?? t.id)}
                     className="border-b border-gray-50 dark:border-gray-700/50 last:border-0 cursor-pointer hover:bg-gray-50 dark:hover:bg-gray-700/40 transition-colors"
                     title="Click to view or edit this transaction"
                   >
@@ -399,14 +401,18 @@ export function ImprovedDashboard() {
                     </td>
                     <td className="py-2 text-sm text-gray-900 dark:text-white">
                       {t.description}
+                      {contribution < 0 && (
+                        <span className="ml-2 text-xs text-gray-400 dark:text-gray-500">(credit)</span>
+                      )}
                     </td>
                     <td className={`py-2 text-sm font-medium text-right whitespace-nowrap ${
                       breakdownType === 'income' ? 'text-green-600 dark:text-green-400' : 'text-red-600 dark:text-red-400'
                     }`}>
-                      {formatCurrencyWithSymbol(Math.abs(t.amount))}
+                      {contribution < 0 ? `-${formatCurrencyWithSymbol(Math.abs(contribution))}` : formatCurrencyWithSymbol(contribution)}
                     </td>
                   </tr>
-                ));
+                  );
+                });
               })()}
             </tbody>
             <tfoot>
@@ -727,20 +733,52 @@ export function ImprovedDashboard() {
           <p className="text-sm text-gray-500 dark:text-gray-400 mb-4">
             Your top 5 accounts by balance
           </p>
-          <div className="h-64">
-            <ResponsiveContainer width="100%" height="100%">
-                  <PieChart
-                    data={pieData}
-                    innerRadius={true}
-                    colors={COLORS}
-                    onClick={(clickedData: AccountDistributionDatum) => {
-                      navigate(`/transactions?account=${clickedData.id}`);
-                    }}
-                formatter={(value: number) => formatCurrencyWithSymbol(value, displayCurrency)}
-                contentStyle={chartStyles.pieTooltip}
-                aria-label="Pie chart showing distribution of account balances"
-              />
-            </ResponsiveContainer>
+          <div className="flex flex-col md:flex-row md:items-center gap-6">
+            <div className="h-64 md:flex-1 min-w-0">
+              <ResponsiveContainer width="100%" height="100%">
+                    <PieChart
+                      data={pieData}
+                      innerRadius={true}
+                      colors={COLORS}
+                      onClick={(clickedData: AccountDistributionDatum) => {
+                        navigate(`/transactions?account=${clickedData.id}`);
+                      }}
+                  formatter={(value: number) => formatCurrencyWithSymbol(value, displayCurrency)}
+                  contentStyle={chartStyles.pieTooltip}
+                  aria-label="Pie chart showing distribution of account balances"
+                />
+              </ResponsiveContainer>
+            </div>
+            {/* Legend: which slice is which, with values and shares */}
+            <ul className="md:w-80 space-y-2" aria-label="Account distribution legend">
+              {(() => {
+                const total = pieData.reduce((sum, d) => sum.plus(toDecimal(d.value)), toDecimal(0));
+                return pieData.map((d, i) => (
+                  <li key={d.id}>
+                    <button
+                      type="button"
+                      onClick={() => navigate(`/transactions?account=${d.id}`)}
+                      className="w-full flex items-center gap-2 rounded-lg px-2 py-1.5 hover:bg-gray-50 dark:hover:bg-gray-700/50 transition-colors text-left"
+                    >
+                      <span
+                        className="w-3 h-3 rounded-sm flex-shrink-0"
+                        style={{ backgroundColor: COLORS[i % COLORS.length] }}
+                        aria-hidden="true"
+                      />
+                      <span className="flex-1 min-w-0 truncate text-sm text-gray-700 dark:text-gray-300">{d.name}</span>
+                      <span className="text-sm font-medium tabular-nums text-gray-900 dark:text-white whitespace-nowrap">
+                        {formatCurrencyWithSymbol(d.value, displayCurrency)}
+                      </span>
+                      <span className="w-12 text-right text-xs tabular-nums text-gray-400 dark:text-gray-500">
+                        {total.greaterThan(0)
+                          ? `${toDecimal(d.value).dividedBy(total).times(100).toFixed(1)}%`
+                          : ''}
+                      </span>
+                    </button>
+                  </li>
+                ));
+              })()}
+            </ul>
           </div>
         </section>
       )}

--- a/src/pages/Analytics.tsx
+++ b/src/pages/Analytics.tsx
@@ -17,6 +17,8 @@ import { Modal, ModalBody } from '../components/common/Modal';
 import PageWrapper from '../components/PageWrapper';
 import { Decimal, toDecimal } from '../utils/decimal';
 import type { DecimalInstance } from '../utils/decimal';
+import { computeIncomeExpense, bucketContribution } from '../utils/incomeExpense';
+import EditTransactionModal from '../components/EditTransactionModal';
 
 // Lazy load heavy components to reduce bundle size
 const DashboardBuilder = lazy(() => import('../components/analytics/DashboardBuilder'));
@@ -99,12 +101,13 @@ interface Insight {
 type QueryResult = Record<string, unknown>;
 
 export default function Analytics(): React.JSX.Element {
-  const { transactions, accounts, categories: _categories, budgets, goals, investments } = useApp();
+  const { transactions, transactionSplits, accounts, categories, budgets, goals, investments } = useApp();
   const { formatCurrency } = useCurrencyDecimal();
   
   type AnalyticsTab = 'dashboards' | 'explorer' | 'insights' | 'reports';
   const [activeTab, setActiveTab] = useState<AnalyticsTab>('dashboards');
   const [breakdownType, setBreakdownType] = useState<'income' | 'expense' | null>(null);
+  const [editingBreakdownTxnId, setEditingBreakdownTxnId] = useState<string | null>(null);
   const [dashboards, setDashboards] = useState<Dashboard[]>([]);
   const [activeDashboard, setActiveDashboard] = useState<Dashboard | null>(null);
   const [savedQueries, setSavedQueries] = useState<SavedQuery[]>([]);
@@ -306,29 +309,25 @@ export default function Analytics(): React.JSX.Element {
     setShowChartWizard(false);
   };
   
-  // Calculate key metrics
+  // Calculate key metrics — income/expenses by CATEGORY SEMANTICS
+  // (utils/incomeExpense): a refund filed under an expense category reduces
+  // spending instead of inflating income; transfers never count.
   const keyMetrics = useMemo(() => {
-    const income = transactions
-      .filter(t => t.type === 'income')
-      .reduce((sum, t) => sum.plus(toDecimal(t.amount)), toDecimal(0));
+    const flows = computeIncomeExpense(transactions, transactionSplits, categories);
 
-    const expenses = transactions
-      .filter(t => t.type === 'expense')
-      .reduce((sum, t) => sum.plus(toDecimal(t.amount)), toDecimal(0));
-    
-    // `expenses` is a signed NEGATIVE sum (signed convention). net = income + expenses = income − |expenses|.
-    const savingsRate = income.greaterThan(0)
-      ? income.plus(expenses).dividedBy(income).times(100)
+    const savingsRate = flows.income.greaterThan(0)
+      ? flows.income.minus(flows.expenses).dividedBy(flows.income).times(100)
       : toDecimal(0);
 
     return {
-      totalIncome: income,
-      // Expose expenses as a positive magnitude so the card/footer agree with the abs-rendered rows.
-      totalExpenses: expenses.abs(),
+      totalIncome: flows.income,
+      totalExpenses: flows.expenses,
+      incomeRows: flows.incomeRows,
+      expenseRows: flows.expenseRows,
       savingsRate,
       transactionCount: transactions.length
     };
-  }, [transactions]);
+  }, [transactions, transactionSplits, categories]);
   
   return (
     <PageWrapper title="Analytics">
@@ -727,27 +726,62 @@ export default function Analytics(): React.JSX.Element {
             </thead>
             <tbody>
               {(() => {
-                const txns = transactions
-                  .filter(t => t.type === breakdownType)
+                // The classified rows behind the header figure (category
+                // semantics — refunds appear as negative credits). Split lines
+                // list individually; clicking any row edits the transaction.
+                const allRows = [...(breakdownType === 'income' ? keyMetrics.incomeRows : keyMetrics.expenseRows)]
                   .sort((a, b) => new Date(b.date).getTime() - new Date(a.date).getTime());
 
-                if (txns.length === 0) {
+                if (allRows.length === 0) {
                   return <tr><td colSpan={3} className="text-center py-8 text-gray-400">No transactions</td></tr>;
                 }
 
-                return txns.map(t => (
-                  <tr key={t.id} className="border-b border-gray-50 dark:border-gray-700/50 last:border-0">
+                // These totals span ALL history — cap the list so the modal
+                // doesn't render tens of thousands of DOM rows. The footer
+                // total still reflects every row.
+                const CAP = 500;
+                const rows = allRows.slice(0, CAP);
+                const capped = allRows.length > CAP;
+
+                const rendered = rows.map(t => {
+                  const contribution = bucketContribution(t, breakdownType === 'income' ? 'income' : 'expense');
+                  return (
+                  <tr
+                    key={t.id}
+                    onClick={() => setEditingBreakdownTxnId(t.splitParentId ?? t.id)}
+                    className="border-b border-gray-50 dark:border-gray-700/50 last:border-0 cursor-pointer hover:bg-gray-50 dark:hover:bg-gray-700/40 transition-colors"
+                    title="Click to view or edit this transaction"
+                  >
                     <td className="py-2 text-sm text-gray-500 dark:text-gray-400 whitespace-nowrap">
                       {new Date(t.date).toLocaleDateString('en-GB', { day: '2-digit', month: 'short' })}
                     </td>
-                    <td className="py-2 text-sm text-gray-900 dark:text-white">{t.description}</td>
+                    <td className="py-2 text-sm text-gray-900 dark:text-white">
+                      {t.description}
+                      {contribution < 0 && (
+                        <span className="ml-2 text-xs text-gray-400 dark:text-gray-500">(credit)</span>
+                      )}
+                    </td>
                     <td className={`py-2 text-sm font-medium text-right whitespace-nowrap ${
                       breakdownType === 'income' ? 'text-green-600 dark:text-green-400' : 'text-red-600 dark:text-red-400'
                     }`}>
-                      {formatCurrency(Math.abs(t.amount))}
+                      {contribution < 0 ? `-${formatCurrency(Math.abs(contribution))}` : formatCurrency(contribution)}
                     </td>
                   </tr>
-                ));
+                  );
+                });
+
+                return (
+                  <>
+                    {rendered}
+                    {capped && (
+                      <tr>
+                        <td colSpan={3} className="py-3 text-center text-xs text-gray-400 dark:text-gray-500">
+                          Showing the latest {CAP.toLocaleString()} of {allRows.length.toLocaleString()} rows — the total below covers them all.
+                        </td>
+                      </tr>
+                    )}
+                  </>
+                );
               })()}
             </tbody>
             <tfoot>
@@ -763,6 +797,15 @@ export default function Analytics(): React.JSX.Element {
           </table>
         </ModalBody>
       </Modal>
+
+      {/* Edit a transaction straight from the breakdown list */}
+      {editingBreakdownTxnId && (
+        <EditTransactionModal
+          isOpen
+          onClose={() => setEditingBreakdownTxnId(null)}
+          transaction={transactions.find(t => t.id === editingBreakdownTxnId) ?? null}
+        />
+      )}
     </PageWrapper>
   );
 }

--- a/src/utils/incomeExpense.test.ts
+++ b/src/utils/incomeExpense.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect } from 'vitest';
+import { buildCategoryKindLookup, classifyFlow, computeIncomeExpense, bucketContribution } from './incomeExpense';
+import type { Category, Transaction, TransactionSplit } from '../types';
+
+const CATEGORIES: Category[] = [
+  { id: 'type-income', name: 'Income', type: 'income', level: 'type', isSystem: true },
+  { id: 'type-expense', name: 'Expense', type: 'expense', level: 'type', isSystem: true },
+  { id: 'type-transfer', name: 'Transfer', type: 'both', level: 'type', isSystem: true },
+  { id: 'cat-salary', name: 'Salary', type: 'income', level: 'detail', parentId: 'type-income' },
+  { id: 'cat-groceries', name: 'Groceries', type: 'expense', level: 'detail', parentId: 'type-expense' },
+  { id: 'cat-clothing', name: 'Clothing', type: 'expense', level: 'detail', parentId: 'type-expense' },
+  { id: 'cat-both', name: 'Ambiguous', type: 'both', level: 'detail', parentId: 'type-expense' },
+  { id: 'tofrom-savings', name: 'To/From Savings', type: 'both', level: 'detail', parentId: 'type-transfer', isTransferCategory: true, accountId: 'acc-2' },
+];
+
+const txn = (over: Partial<Transaction>): Transaction => ({
+  id: 't1',
+  date: new Date('2026-07-10'),
+  amount: -10,
+  description: 'x',
+  category: '',
+  accountId: 'acc-1',
+  type: 'expense',
+  ...over,
+});
+
+describe('classifyFlow', () => {
+  const kinds = buildCategoryKindLookup(CATEGORIES);
+
+  it('classifies by category tree, not money direction', () => {
+    // A refund: money IN (type income, positive) filed under an expense category.
+    expect(classifyFlow(txn({ type: 'income', amount: 25, category: 'cat-clothing' }), kinds)).toBe('expense');
+    // An income clawback: money OUT filed under an income category.
+    expect(classifyFlow(txn({ type: 'expense', amount: -50, category: 'cat-salary' }), kinds)).toBe('income');
+  });
+
+  it('falls back to the stored direction when the category gives no signal', () => {
+    expect(classifyFlow(txn({ type: 'expense', category: '' }), kinds)).toBe('expense');
+    expect(classifyFlow(txn({ type: 'income', category: 'cat-both' }), kinds)).toBe('income');
+    expect(classifyFlow(txn({ type: 'income', category: 'nonexistent' }), kinds)).toBe('income');
+  });
+
+  it('transfers never count, by type or by transfer category', () => {
+    expect(classifyFlow(txn({ type: 'transfer', category: 'tofrom-savings' }), kinds)).toBe('transfer');
+    expect(classifyFlow(txn({ type: 'income', category: 'tofrom-savings' }), kinds)).toBe('transfer');
+  });
+});
+
+describe('computeIncomeExpense', () => {
+  it('a refund reduces expenses instead of inflating income', () => {
+    const transactions: Transaction[] = [
+      txn({ id: 'a', type: 'income', amount: 2500, category: 'cat-salary' }),
+      txn({ id: 'b', type: 'expense', amount: -100, category: 'cat-clothing' }),
+      // returned goods: money back in, expense category
+      txn({ id: 'c', type: 'income', amount: 40, category: 'cat-clothing' }),
+      txn({ id: 'd', type: 'transfer', amount: -500, category: 'tofrom-savings' }),
+    ];
+    const { income, expenses, incomeRows, expenseRows } = computeIncomeExpense(transactions, [], CATEGORIES);
+    expect(income.toNumber()).toBe(2500);       // NOT 2540
+    expect(expenses.toNumber()).toBe(60);       // 100 spent − 40 refunded
+    expect(incomeRows.map(r => r.id)).toEqual(['a']);
+    expect(expenseRows.map(r => r.id)).toEqual(['b', 'c']);
+  });
+
+  it('splits classify per line and the parent is not double-counted', () => {
+    const transactions: Transaction[] = [
+      txn({ id: 'p', type: 'expense', amount: -90, category: '', isSplit: true }),
+    ];
+    const splits: TransactionSplit[] = [
+      { id: 's1', transactionId: 'p', category: 'cat-groceries', amount: -100, sortOrder: 1 },
+      // cashback line inside the shop: positive, income category
+      { id: 's2', transactionId: 'p', category: 'cat-salary', amount: 10, sortOrder: 2 },
+    ];
+    const { income, expenses } = computeIncomeExpense(transactions, splits, CATEGORIES);
+    expect(expenses.toNumber()).toBe(100);
+    expect(income.toNumber()).toBe(10);
+  });
+
+  it('bounds by date when from/to given', () => {
+    const transactions: Transaction[] = [
+      txn({ id: 'old', date: new Date('2020-01-01'), type: 'expense', amount: -10, category: 'cat-groceries' }),
+      txn({ id: 'new', date: new Date('2026-07-01'), type: 'expense', amount: -20, category: 'cat-groceries' }),
+    ];
+    const { expenses } = computeIncomeExpense(transactions, [], CATEGORIES, { from: new Date('2026-01-01') });
+    expect(expenses.toNumber()).toBe(20);
+  });
+});
+
+describe('bucketContribution', () => {
+  it('signs rows so a breakdown list sums to its total', () => {
+    expect(bucketContribution({ amount: -100 }, 'expense')).toBe(100);
+    expect(bucketContribution({ amount: 40 }, 'expense')).toBe(-40); // refund credit
+    expect(bucketContribution({ amount: 2500 }, 'income')).toBe(2500);
+  });
+});

--- a/src/utils/incomeExpense.ts
+++ b/src/utils/incomeExpense.ts
@@ -1,0 +1,114 @@
+import type { Category, Transaction, TransactionSplit } from '../types';
+import { toDecimal, type DecimalInstance } from './decimal';
+import { expandSplitTransactions, type SplitExpandedTransaction } from './transactionSplits';
+
+/**
+ * Income/expense classification by CATEGORY SEMANTICS — the Microsoft Money
+ * model, and the single definition every aggregation surface must share.
+ *
+ * A transaction's `type` records the DIRECTION money moved (in/out), not what
+ * it *was*. A store refund arrives INTO a bank account but is filed under an
+ * expense category — it is an expense CREDIT that reduces spending, never
+ * income. Likewise a clawback filed under an income category reduces income.
+ * The edit modal supports this ("cross-type" filing) as a first-class
+ * concept; classifying by direction instead of category over-states both
+ * income and expenditure by every such credit.
+ *
+ * Rules:
+ *  - transfers never count (neither the type nor transfer categories);
+ *  - a category from the income tree → income; expense tree → expense —
+ *    regardless of the money's direction;
+ *  - no category / an unknown or direction-neutral ('both') category → fall
+ *    back to the stored direction, the only signal left.
+ *
+ * Split transactions classify PER LINE (a split can mix categories), with the
+ * parent never double-counted.
+ */
+
+export type FlowKind = 'income' | 'expense' | 'transfer';
+
+/** category id → its flow kind (null = no categorical signal, e.g. 'both'). */
+export function buildCategoryKindLookup(categories: Category[]): Map<string, FlowKind | null> {
+  const lookup = new Map<string, FlowKind | null>();
+  for (const c of categories) {
+    if (c.isTransferCategory === true || c.id === 'type-transfer' || c.parentId === 'type-transfer') {
+      lookup.set(c.id, 'transfer');
+    } else if (c.type === 'income' || c.type === 'expense') {
+      lookup.set(c.id, c.type);
+    } else {
+      lookup.set(c.id, null);
+    }
+  }
+  return lookup;
+}
+
+export function classifyFlow(
+  row: Pick<Transaction, 'type' | 'category'>,
+  categoryKinds: Map<string, FlowKind | null>
+): FlowKind {
+  if (row.type === 'transfer') return 'transfer';
+  const kind = row.category ? categoryKinds.get(row.category) : undefined;
+  if (kind === 'income' || kind === 'expense' || kind === 'transfer') return kind;
+  return row.type === 'income' ? 'income' : 'expense';
+}
+
+export interface IncomeExpenseBreakdown {
+  /** Net income: income-category credits minus income-category debits. */
+  income: DecimalInstance;
+  /** Net spending as a POSITIVE magnitude: debits minus refunds/credits. */
+  expenses: DecimalInstance;
+  /** The rows behind each total (split lines, not their parents). */
+  incomeRows: SplitExpandedTransaction[];
+  expenseRows: SplitExpandedTransaction[];
+}
+
+/**
+ * Aggregate income and expenses over a set of transactions using category
+ * semantics. `from`/`to` bound by transaction date (inclusive) when given.
+ */
+export function computeIncomeExpense(
+  transactions: Transaction[],
+  transactionSplits: TransactionSplit[],
+  categories: Category[],
+  opts: { from?: Date; to?: Date } = {}
+): IncomeExpenseBreakdown {
+  const kinds = buildCategoryKindLookup(categories);
+
+  const inRange = (t: Transaction): boolean => {
+    const time = new Date(t.date).getTime();
+    if (opts.from && time < opts.from.getTime()) return false;
+    if (opts.to && time > opts.to.getTime()) return false;
+    return true;
+  };
+
+  const rows = expandSplitTransactions(transactions.filter(inRange), transactionSplits);
+
+  let income = toDecimal(0);
+  let expenses = toDecimal(0);
+  const incomeRows: SplitExpandedTransaction[] = [];
+  const expenseRows: SplitExpandedTransaction[] = [];
+
+  for (const row of rows) {
+    const kind = classifyFlow(row, kinds);
+    if (kind === 'income') {
+      income = income.plus(toDecimal(row.amount));
+      incomeRows.push(row);
+    } else if (kind === 'expense') {
+      // Expenses are stored negative, so negating yields positive spending —
+      // and a positive-amount credit (refund) correctly SUBTRACTS.
+      expenses = expenses.plus(toDecimal(row.amount).negated());
+      expenseRows.push(row);
+    }
+  }
+
+  return { income, expenses, incomeRows, expenseRows };
+}
+
+/**
+ * A row's signed contribution to its bucket's total: positive for ordinary
+ * income/spending, negative for a credit (refund) — what a breakdown list
+ * should display so its rows visibly sum to the header figure.
+ */
+export function bucketContribution(row: Pick<Transaction, 'amount'>, bucket: 'income' | 'expense'): number {
+  return bucket === 'income' ? row.amount : toDecimal(row.amount).negated().toNumber();
+}


### PR DESCRIPTION
Your dashboard/analytics feedback — the income figure was money-IN, not income:

## 1. Income/expense now classify by CATEGORY, not direction
The Dashboard and Analytics totals filtered on transaction `type`, which records which **way** money moved. So a store refund — money in, filed under an expense category, exactly how you use cross-type filing — inflated income AND over-stated expenses. The Microsoft Money model is category semantics, and that's what a new shared classifier (`utils/incomeExpense.ts`) implements:

- an **expense-category credit reduces spending** (never counts as income);
- an income-category debit reduces income;
- transfers never count (by type or by To/From category);
- only rows with no categorical signal fall back to direction;
- splits classify **per line** (a cashback line inside a shop split counts as income, the shopping lines as spending), parents never double-count.

Both pages use this one classifier so they can never disagree. 7 unit tests cover the refund, clawback, fallback, transfer-exclusion, split, date-bound and display-sign cases.

**Verified on the real 50k dataset** with a seeded £100 purchase + £40 refund pair (expense category): Income stayed **£1,361.66** (refund NOT added), Expenses went **£8,201.56 → £8,261.56** (+100 − 40, to the penny).

## 2. Breakdown lists reconcile visibly
Rows are the exact classified set behind the header figure; credits render as `-£40.00 (credit)` so the list visibly sums to its total.

## 3. Analytics breakdown: click-to-edit + a sane row cap
Clicking any row opens the Edit Transaction modal (split lines open their parent) — re-categorise and it drops off the list live, same as the Dashboard. Also: the modal was rendering **35,311 DOM rows**; it now shows the latest 500 with an explicit "Showing the latest 500 of N — the total below covers them all" note.

## 4. Account Distribution legend
Colour swatch · account name · value · share % (Decimal maths) beside the pie, each row clicking through to that account's transactions.

## Known follow-up (flagging honestly)
Reports, Cash-Flow Forecast, Scheduled Reports, Excel export and Calendar still classify by direction — same bug family, deliberately out of scope here. Say the word and they all move onto the shared classifier in a follow-up sweep.

Gates: strict types, lint, smoke (3,163), coverage (76.5% branches), production build — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)