### PR TITLE
fix(reports): sweep every aggregation surface onto category semantics — one classifier everywhere

### DIFF
--- a/src/components/BudgetRollover.tsx
+++ b/src/components/BudgetRollover.tsx
@@ -92,8 +92,11 @@ export default function BudgetRollover() {
     const endDate = new Date(previousYear, previousMonth + 1, 0);
 
     const categoryNameLookup = new Map(categories.map(category => [category.id, category.name]));
-    const expenseTransactions = transactions
-      .filter(t => t.type === 'expense')
+    // Money-style netting: a refund filed to the budget's category arrives as
+    // an income-typed row and REDUCES spend — so no type filter here, only
+    // transfers are skipped.
+    const nonTransferTransactions = transactions
+      .filter(t => t.type !== 'transfer')
       .map(t => ({
         ...t,
         amount: toDecimal(t.amount)
@@ -104,14 +107,16 @@ export default function BudgetRollover() {
       const categoryName = categoryNameLookup.get(categoryId) ?? categoryId;
       const budgetAmount = toDecimal(budget.amount);
 
-      const spent = expenseTransactions
+      const netSpent = nonTransferTransactions
         .filter(t =>
           t.category === categoryId &&
           t.date >= startDate &&
           t.date <= endDate
         )
-        // Expense amounts are stored signed (negative); sum magnitudes for spend.
-        .reduce((sum, t) => sum.plus(t.amount.abs()), toDecimal(0));
+        // Signed convention: spending is negative, so negate to accumulate
+        // spend; refunds net it down. Clamped at zero for the rollover maths.
+        .reduce((sum, t) => sum.minus(t.amount), toDecimal(0));
+      const spent = netSpent.isNegative() ? toDecimal(0) : netSpent;
 
       const remaining = budgetAmount.minus(spent);
       const isExcluded = exclusionSet.has(categoryId) || exclusionSet.has(categoryName);

--- a/src/components/ExcelExport.tsx
+++ b/src/components/ExcelExport.tsx
@@ -17,6 +17,7 @@ import {
 // Dynamic import of XLSX to reduce bundle size
 let XLSX: typeof import('xlsx') | null = null;
 import { toDecimal } from '../utils/decimal';
+import { buildCategoryKindLookup, classifyFlow } from '../utils/incomeExpense';
 import type { Transaction } from '../types';
 import { formatDecimal } from '../utils/decimal-format';
 
@@ -57,6 +58,22 @@ export default function ExcelExport({ isOpen, onClose }: ExcelExportProps): Reac
   );
   const { getCurrencySymbol, displayCurrency } = useCurrencyDecimal();
   const currencySymbol = getCurrencySymbol(displayCurrency);
+
+  // Income/expense by CATEGORY semantics (utils/incomeExpense): a refund
+  // filed under an expense category nets spending down instead of counting
+  // as income. Decimal accumulation throughout — exports are financial
+  // documents.
+  const categoryKinds = useMemo(() => buildCategoryKindLookup(categories), [categories]);
+  const flowTotals = (rows: Transaction[]): { income: number; expenses: number } => {
+    let income = toDecimal(0);
+    let expenses = toDecimal(0);
+    for (const t of rows) {
+      const kind = classifyFlow(t, categoryKinds);
+      if (kind === 'income') income = income.plus(toDecimal(t.amount));
+      else if (kind === 'expense') expenses = expenses.plus(toDecimal(t.amount).negated());
+    }
+    return { income: income.toNumber(), expenses: expenses.toNumber() };
+  };
   const [isExporting, setIsExporting] = useState(false);
   
   const [options, setOptions] = useState<ExportOptions>({
@@ -91,27 +108,18 @@ export default function ExcelExport({ isOpen, onClose }: ExcelExportProps): Reac
 
   const generateSummaryData = () => {
     const filtered = filterTransactionsByDate(transactions);
-    const income = filtered
-      .filter(t => t.type === 'income')
-      .reduce((sum, t) => sum + toDecimal(t.amount).toNumber(), 0);
-    const expenses = filtered
-      .filter(t => t.type === 'expense')
-      .reduce((sum, t) => sum + Math.abs(toDecimal(t.amount).toNumber()), 0);
-    
+    const { income, expenses } = flowTotals(filtered);
+
     const categoryBreakdown = categories.map(cat => {
-      const catTransactions = filtered.filter(t => t.category === cat.name);
-      const catIncome = catTransactions
-        .filter(t => t.type === 'income')
-        .reduce((sum, t) => sum + toDecimal(t.amount).toNumber(), 0);
-      const catExpenses = catTransactions
-        .filter(t => t.type === 'expense')
-        .reduce((sum, t) => sum + Math.abs(toDecimal(t.amount).toNumber()), 0);
-      
+      // Transactions store category IDS — the old name match silently
+      // returned nothing for every real category.
+      const catTransactions = filtered.filter(t => t.category === cat.id);
+      const totals = flowTotals(catTransactions);
       return {
         Category: cat.name,
-        Income: catIncome,
-        Expenses: catExpenses,
-        Net: catIncome - catExpenses,
+        Income: totals.income,
+        Expenses: totals.expenses,
+        Net: toDecimal(totals.income).minus(toDecimal(totals.expenses)).toNumber(),
         'Transaction Count': catTransactions.length
       };
     });
@@ -128,7 +136,7 @@ export default function ExcelExport({ isOpen, onClose }: ExcelExportProps): Reac
       overview: [
         { Metric: 'Total Income', Value: income },
         { Metric: 'Total Expenses', Value: expenses },
-        { Metric: 'Net Income', Value: income - expenses },
+        { Metric: 'Net Income', Value: toDecimal(income).minus(toDecimal(expenses)).toNumber() },
         { Metric: 'Transaction Count', Value: filtered.length },
         { Metric: 'Date Range', Value: `${options.dateRange.start?.toLocaleDateString()} - ${options.dateRange.end?.toLocaleDateString()}` }
       ],
@@ -283,13 +291,8 @@ export default function ExcelExport({ isOpen, onClose }: ExcelExportProps): Reac
     if (options.accounts) {
       const accountData = accounts.map(acc => {
         const accTransactions = transactions.filter(t => t.accountId === acc.id);
-        const income = accTransactions
-          .filter(t => t.type === 'income')
-          .reduce((sum, t) => sum + toDecimal(t.amount).toNumber(), 0);
-        const expenses = accTransactions
-          .filter(t => t.type === 'expense')
-          .reduce((sum, t) => sum + Math.abs(toDecimal(t.amount).toNumber()), 0);
-        
+        const { income, expenses } = flowTotals(accTransactions);
+
         return {
           Name: acc.name,
           Type: acc.type,
@@ -298,7 +301,7 @@ export default function ExcelExport({ isOpen, onClose }: ExcelExportProps): Reac
           Institution: acc.institution || '',
           'Total Income': income,
           'Total Expenses': expenses,
-          'Net Change': income - expenses,
+          'Net Change': toDecimal(income).minus(toDecimal(expenses)).toNumber(),
           'Transaction Count': accTransactions.length,
           'Last Updated': (acc.lastUpdated instanceof Date ? acc.lastUpdated : new Date(acc.lastUpdated)).toLocaleDateString()
         };
@@ -328,16 +331,20 @@ export default function ExcelExport({ isOpen, onClose }: ExcelExportProps): Reac
     // Budgets Sheet
     if (options.budgets) {
       const budgetData = budgets.map(budget => {
-        const spent = transactions
+        const now = new Date();
+        // Money-style netting: a refund filed to the budget's category
+        // reduces spend (never a type filter — refunds arrive as income-typed
+        // rows). Clamped at zero if refunds exceed spending this month.
+        const netSpent = transactions
           .filter(t => {
             const tDate = t.date instanceof Date ? t.date : new Date(t.date);
-            return t.type === 'expense' &&
+            return t.type !== 'transfer' &&
               t.category === budget.categoryId &&
-              tDate.getMonth() === new Date().getMonth() &&
-              tDate.getFullYear() === new Date().getFullYear();
+              tDate.getMonth() === now.getMonth() &&
+              tDate.getFullYear() === now.getFullYear();
           })
-          // Expenses are stored signed (negative); spent is a positive magnitude.
-          .reduce((sum, t) => sum.plus(toDecimal(t.amount).abs()), toDecimal(0));
+          .reduce((sum, t) => sum.minus(toDecimal(t.amount)), toDecimal(0));
+        const spent = netSpent.isNegative() ? toDecimal(0) : netSpent;
 
         const budgetAmount = toDecimal(budget.amount);
         const remaining = budgetAmount.minus(spent);
@@ -375,26 +382,22 @@ export default function ExcelExport({ isOpen, onClose }: ExcelExportProps): Reac
     // Categories Sheet
     if (options.categories) {
       const categoryData = categories.map(cat => {
-        const catTransactions = transactions.filter(t => t.category === cat.name);
-        const income = catTransactions
-          .filter(t => t.type === 'income')
-          .reduce((sum, t) => sum + toDecimal(t.amount).toNumber(), 0);
-        const expenses = catTransactions
-          .filter(t => t.type === 'expense')
-          .reduce((sum, t) => sum + Math.abs(toDecimal(t.amount).toNumber()), 0);
-        
-        const budget = budgets.find(b => b.categoryId === cat.name);
-        
+        // Transactions (and budgets) reference category IDS, not names.
+        const catTransactions = transactions.filter(t => t.category === cat.id);
+        const { income, expenses } = flowTotals(catTransactions);
+
+        const budget = budgets.find(b => b.categoryId === cat.id);
+
         return {
           Name: cat.name,
           Icon: cat.icon,
           Color: cat.color,
           'Total Income': income,
           'Total Expenses': expenses,
-          'Net Amount': income - expenses,
+          'Net Amount': toDecimal(income).minus(toDecimal(expenses)).toNumber(),
           'Transaction Count': catTransactions.length,
           'Budget Amount': budget ? toDecimal(budget.amount).toNumber() : 0,
-          'Budget vs Actual': budget ? expenses - toDecimal(budget.amount).toNumber() : 0
+          'Budget vs Actual': budget ? toDecimal(expenses).minus(toDecimal(budget.amount)).toNumber() : 0
         };
       });
       

--- a/src/components/ScheduledReports.tsx
+++ b/src/components/ScheduledReports.tsx
@@ -16,6 +16,8 @@ import {
 } from './icons';
 import { generatePDFReport } from '../utils/pdfExport';
 import { exportTransactionsToCSV } from '../utils/csvExport';
+import { toDecimal } from '../utils/decimal';
+import { computeIncomeExpense } from '../utils/incomeExpense';
 interface ScheduledReport {
   id: string;
   name: string;
@@ -38,7 +40,7 @@ interface ScheduledReport {
 }
 
 export default function ScheduledReports() {
-  const { transactions, accounts, categories } = useApp();
+  const { transactions, transactionSplits, accounts, categories } = useApp();
   const { formatCurrency } = useCurrencyDecimal();
   const { addNotification } = useNotifications();
   
@@ -188,16 +190,14 @@ export default function ScheduledReports() {
         return dateMatch && accountMatch && categoryMatch;
       });
 
+      // Income/expenses by CATEGORY semantics (utils/incomeExpense): refunds
+      // filed under expense categories net spending down instead of counting
+      // as income; splits count per line; Decimal throughout.
+      const flows = computeIncomeExpense(filteredTransactions, transactionSplits, categories);
+
       if (report.format === 'summary') {
-        // Generate text summary
-        const income = filteredTransactions
-          .filter(t => t.type === 'income')
-          .reduce((sum, t) => sum + t.amount, 0);
-        
-        // Expenses are stored signed (negative); totals report the positive magnitude
-        const expenses = filteredTransactions
-          .filter(t => t.type === 'expense')
-          .reduce((sum, t) => sum + Math.abs(t.amount), 0);
+        const income = flows.income.toNumber();
+        const expenses = flows.expenses.toNumber();
 
         const summary = `
 Financial Report: ${report.name}
@@ -207,17 +207,16 @@ Period: ${report.reportConfig.dateRange === 'custom' ? `Last ${report.reportConf
 Summary:
 - Total Income: ${formatCurrency(income)}
 - Total Expenses: ${formatCurrency(expenses)}
-- Net Income: ${formatCurrency(income - expenses)}
+- Net Income: ${formatCurrency(toDecimal(income).minus(toDecimal(expenses)).toNumber())}
 - Transactions: ${filteredTransactions.length}
 
 Top Expenses by Category:
 ${Object.entries(
-  filteredTransactions
-    .filter(t => t.type === 'expense')
+  flows.expenseRows
     .reduce((acc, t) => {
       const category = categories.find(c => c.id === t.category)?.name || 'Uncategorized';
-      // Accumulate magnitudes so the descending sort ranks biggest spend first
-      acc[category] = (acc[category] || 0) + Math.abs(t.amount);
+      // Net signed spend per category (refunds subtract), ranked biggest first.
+      acc[category] = toDecimal(acc[category] || 0).minus(toDecimal(t.amount)).toNumber();
       return acc;
     }, {} as Record<string, number>)
 )
@@ -254,13 +253,8 @@ ${Object.entries(
                 title: report.name,
                 dateRange: `Last ${report.reportConfig.dateRange}`,
                 summary: {
-                  income: filteredTransactions
-                    .filter(t => t.type === 'income')
-                    .reduce((sum, t) => sum + t.amount, 0),
-                  // Signed convention: expenses are stored negative, report the magnitude
-                  expenses: filteredTransactions
-                    .filter(t => t.type === 'expense')
-                    .reduce((sum, t) => sum + Math.abs(t.amount), 0),
+                  income: flows.income.toNumber(),
+                  expenses: flows.expenses.toNumber(),
                   netIncome: 0,
                   savingsRate: 0
                 },
@@ -268,9 +262,9 @@ ${Object.entries(
                 topTransactions: filteredTransactions.slice(0, 10)
               };
               
-              reportData.summary.netIncome = reportData.summary.income - reportData.summary.expenses;
-              reportData.summary.savingsRate = reportData.summary.income > 0 
-                ? (reportData.summary.netIncome / reportData.summary.income) * 100 
+              reportData.summary.netIncome = flows.income.minus(flows.expenses).toNumber();
+              reportData.summary.savingsRate = flows.income.greaterThan(0)
+                ? flows.income.minus(flows.expenses).dividedBy(flows.income).times(100).toNumber()
                 : 0;
 
               await generatePDFReport(reportData, accounts);
@@ -297,7 +291,7 @@ ${Object.entries(
         message: `Failed to generate ${report.name}`
       });
     }
-  }, [transactions, categories, accounts, formatCurrency, addNotification]);
+  }, [transactions, transactionSplits, categories, accounts, formatCurrency, addNotification]);
 
   // Update refs after functions are defined
   useEffect(() => {

--- a/src/components/dashboard/ImprovedDashboard.tsx
+++ b/src/components/dashboard/ImprovedDashboard.tsx
@@ -134,16 +134,22 @@ export function ImprovedDashboard() {
     const activeBudgets = budgets.filter(b => b.isActive);
     
     // Split parents expand into per-line rows so a split line spends
-    // against ITS category's budget.
+    // against ITS category's budget. Money-style netting: a refund filed to
+    // the budget's category REDUCES spend (refunds arrive as income-typed
+    // rows, so there is deliberately no type filter — only transfers skip).
     const recentExpanded = expandSplitTransactions(recentTransactions, transactionSplits);
     const budgetStatus = activeBudgets.map(budget => {
       const categoryTransactions = recentExpanded.filter(t =>
-        t.category === budget.categoryId && t.type === 'expense'
+        t.category === budget.categoryId && t.type !== 'transfer'
       );
-      const spent = categoryTransactions.reduce((sum, t) => sum + Math.abs(t.amount), 0);
-      const remaining = budget.amount - spent;
-      const percentUsed = budget.amount > 0 ? (spent / budget.amount) * 100 : 0;
-      
+      const netSpent = categoryTransactions.reduce(
+        (sum, t) => sum.minus(toDecimal(t.amount)), toDecimal(0));
+      const spent = netSpent.isNegative() ? 0 : netSpent.toNumber();
+      const remaining = toDecimal(budget.amount).minus(toDecimal(spent)).toNumber();
+      const percentUsed = budget.amount > 0
+        ? toDecimal(spent).dividedBy(toDecimal(budget.amount)).times(100).toNumber()
+        : 0;
+
       return {
         ...budget,
         spent,
@@ -152,10 +158,12 @@ export function ImprovedDashboard() {
         isOverBudget: spent > budget.amount
       };
     });
-    
-    const totalBudgeted = activeBudgets.reduce((sum, b) => sum + b.amount, 0);
-    const totalSpentOnBudgets = budgetStatus.reduce((sum, b) => sum + b.spent, 0);
-    const overallBudgetPercent = totalBudgeted > 0 ? (totalSpentOnBudgets / totalBudgeted) * 100 : 0;
+
+    const totalBudgeted = activeBudgets.reduce((sum, b) => sum.plus(toDecimal(b.amount)), toDecimal(0)).toNumber();
+    const totalSpentOnBudgets = budgetStatus.reduce((sum, b) => sum.plus(toDecimal(b.spent)), toDecimal(0)).toNumber();
+    const overallBudgetPercent = totalBudgeted > 0
+      ? toDecimal(totalSpentOnBudgets).dividedBy(toDecimal(totalBudgeted)).times(100).toNumber()
+      : 0;
     
     return {
       netWorth,

--- a/src/pages/Calendar.tsx
+++ b/src/pages/Calendar.tsx
@@ -6,6 +6,7 @@ import { preserveDemoParam } from '../utils/navigation';
 import { ChevronLeftIcon, ChevronRightIcon } from '../components/icons';
 import PageWrapper from '../components/PageWrapper';
 import PageTip from '../components/PageTip';
+import { toDecimal } from '../utils/decimal';
 
 interface DayData {
   date: Date;
@@ -49,16 +50,20 @@ export default function Calendar() {
       return `${dt.getFullYear()}-${String(dt.getMonth() + 1).padStart(2, '0')}-${String(dt.getDate()).padStart(2, '0')}`;
     };
 
-    // Group transactions by date string
+    // Group transactions by date string. The calendar is a CASH-MOVEMENT day
+    // ledger (a bank-statement view): buckets are money in / money out by
+    // direction, transfers included — it is deliberately NOT an income
+    // statement, and its labels must say so (income semantics live in
+    // utils/incomeExpense for the reporting surfaces).
     const txByDate = new Map<string, { income: number; expense: number; count: number }>();
     transactions.forEach(t => {
       const dateKey = toDateKey(t.date);
       const existing = txByDate.get(dateKey) || { income: 0, expense: 0, count: 0 };
       existing.count++;
-      if (t.type === 'income' || (t.type === 'transfer' && t.amount > 0)) {
-        existing.income += Math.abs(t.amount);
+      if (t.amount >= 0) {
+        existing.income = toDecimal(existing.income).plus(toDecimal(t.amount)).toNumber();
       } else {
-        existing.expense += Math.abs(t.amount);
+        existing.expense = toDecimal(existing.expense).plus(toDecimal(t.amount).abs()).toNumber();
       }
       txByDate.set(dateKey, existing);
     });
@@ -150,8 +155,8 @@ export default function Calendar() {
   const monthSummary = useMemo(() => {
     const monthDays = calendarData.filter(d => d.isCurrentMonth);
     return {
-      totalIncome: monthDays.reduce((s, d) => s + d.income, 0),
-      totalExpense: monthDays.reduce((s, d) => s + d.expense, 0),
+      totalIncome: monthDays.reduce((s, d) => s.plus(toDecimal(d.income)), toDecimal(0)).toNumber(),
+      totalExpense: monthDays.reduce((s, d) => s.plus(toDecimal(d.expense)), toDecimal(0)).toNumber(),
       totalTransactions: monthDays.reduce((s, d) => s + d.transactionCount, 0),
     };
   }, [calendarData]);
@@ -176,17 +181,17 @@ export default function Calendar() {
       {/* Month summary bar */}
       <div className="grid grid-cols-2 sm:grid-cols-4 gap-3 mb-4">
         <div className="bg-white dark:bg-gray-800 rounded-lg shadow-sm border border-gray-100 dark:border-gray-700 px-4 py-2">
-          <span className="text-sm text-gray-500 dark:text-gray-400">Income</span>
+          <span className="text-sm text-gray-500 dark:text-gray-400">Money in</span>
           <p className="text-lg font-semibold text-green-600 dark:text-green-400">{formatCurrency(monthSummary.totalIncome)}</p>
         </div>
         <div className="bg-white dark:bg-gray-800 rounded-lg shadow-sm border border-gray-100 dark:border-gray-700 px-4 py-2">
-          <span className="text-sm text-gray-500 dark:text-gray-400">Expenses</span>
+          <span className="text-sm text-gray-500 dark:text-gray-400">Money out</span>
           <p className="text-lg font-semibold text-red-600">{formatCurrency(monthSummary.totalExpense)}</p>
         </div>
         <div className="bg-white dark:bg-gray-800 rounded-lg shadow-sm border border-gray-100 dark:border-gray-700 px-4 py-2">
           <span className="text-sm text-gray-500 dark:text-gray-400">Net</span>
-          <p className={`text-lg font-semibold ${monthSummary.totalIncome - monthSummary.totalExpense >= 0 ? 'text-green-600 dark:text-green-400' : 'text-red-600'}`}>
-            {formatCurrency(monthSummary.totalIncome - monthSummary.totalExpense)}
+          <p className={`text-lg font-semibold ${toDecimal(monthSummary.totalIncome).minus(toDecimal(monthSummary.totalExpense)).greaterThanOrEqualTo(0) ? 'text-green-600 dark:text-green-400' : 'text-red-600'}`}>
+            {formatCurrency(toDecimal(monthSummary.totalIncome).minus(toDecimal(monthSummary.totalExpense)).toNumber())}
           </p>
         </div>
         <div className="bg-white dark:bg-gray-800 rounded-lg shadow-sm border border-gray-100 dark:border-gray-700 px-4 py-2">
@@ -308,7 +313,7 @@ export default function Calendar() {
       <PageTip
         id="calendar-intro"
         title="Your financial calendar"
-        description="See your income and expenses laid out by day. Click any day with transactions to view the details. Green amounts are income, amounts in parentheses are expenses."
+        description="See money moving in and out laid out by day, like a bank statement — transfers included. Click any day with transactions to view the details. Green amounts are money in, amounts in parentheses are money out."
       />
     </PageWrapper>
   );

--- a/src/pages/Reports.tsx
+++ b/src/pages/Reports.tsx
@@ -22,6 +22,7 @@ import { useCurrencyDecimal } from '../hooks/useCurrencyDecimal';
 import { toDecimal, DecimalInstance } from '../utils/decimal';
 import { formatDecimal } from '../utils/decimal-format';
 import { computeExpenseCategoryNetTotals, bucketByCategoryDirection } from '../utils/categoryNetting';
+import { expandSplitTransactions } from '../utils/transactionSplits';
 import { createScopedLogger } from '../loggers/scopedLogger';
 
 const reportsLogger = createScopedLogger('ReportsPage');
@@ -32,7 +33,15 @@ const CATEGORY_COLORS = [
 ];
 
 export default function Reports() {
-  const { transactions, accounts, categories } = useApp();
+  const { transactions: rawTransactions, transactionSplits, accounts, categories } = useApp();
+  // Reports work on the split-EXPANDED view (like every other reporting
+  // surface): a split parent becomes one row per line, so each line's spend
+  // lands in ITS category — the pie and summary would otherwise drop split
+  // lines into the uncategorised fallback.
+  const transactions = useMemo(
+    () => expandSplitTransactions(rawTransactions, transactionSplits),
+    [rawTransactions, transactionSplits]
+  );
   const [dateRange, setDateRange] = useState<'month' | 'quarter' | 'year' | 'all' | 'custom'>('month');
   const [selectedAccount, setSelectedAccount] = useState<string>('all');
   const [isGeneratingPDF, setIsGeneratingPDF] = useState(false);
@@ -311,34 +320,36 @@ export default function Reports() {
         <div className="grid grid-cols-1 md:grid-cols-4 gap-4">
         <div className="bg-white dark:bg-gray-800 rounded-2xl shadow-lg border border-gray-100 dark:border-gray-700 p-6">
           <p className="text-sm text-gray-600 dark:text-gray-400 mb-1">Total Income</p>
-          <p className="text-2xl font-bold text-green-700 dark:text-green-400">
+          {/* div, not p: the loading skeleton renders block elements and a
+              <div> inside <p> is invalid DOM nesting */}
+          <div className="text-2xl font-bold text-green-700 dark:text-green-400">
             {isLoading ? <SkeletonText className="w-32 h-8" /> : formatCurrency(summary.income)}
-          </p>
+          </div>
         </div>
 
         <div className="bg-white dark:bg-gray-800 rounded-2xl shadow-lg border border-gray-100 dark:border-gray-700 p-6">
           <p className="text-sm text-gray-600 dark:text-gray-400 mb-1">Total Expenses</p>
-          <p className="text-2xl font-bold text-red-600 dark:text-red-400">
+          <div className="text-2xl font-bold text-red-600 dark:text-red-400">
             {isLoading ? <SkeletonText className="w-32 h-8" /> : formatCurrency(summary.expenses)}
-          </p>
+          </div>
         </div>
 
         <div className="bg-white dark:bg-gray-800 rounded-2xl shadow-lg border border-gray-100 dark:border-gray-700 p-6">
           <p className="text-sm text-gray-600 dark:text-gray-400 mb-1">Net Income</p>
-          <p className={`text-2xl font-bold ${
+          <div className={`text-2xl font-bold ${
             summary.netIncome >= 0 ? 'text-green-700 dark:text-green-400' : 'text-red-600 dark:text-red-400'
           }`}>
             {isLoading ? <SkeletonText className="w-32 h-8" /> : formatCurrency(summary.netIncome)}
-          </p>
+          </div>
         </div>
 
         <div className="bg-white dark:bg-gray-800 rounded-2xl shadow-lg border border-gray-100 dark:border-gray-700 p-6">
           <p className="text-sm text-gray-600 dark:text-gray-400 mb-1">Savings Rate</p>
-          <p className={`text-2xl font-bold ${
+          <div className={`text-2xl font-bold ${
             savingsRateValue >= 20 ? 'text-green-700 dark:text-green-400' : 'text-yellow-700 dark:text-yellow-400'
           }`}>
             {isLoading ? <SkeletonText className="w-20 h-8" /> : `${savingsRateDisplay}%`}
-          </p>
+          </div>
         </div>
         </div>
 

--- a/src/pages/__tests__/Calendar.test.tsx
+++ b/src/pages/__tests__/Calendar.test.tsx
@@ -66,8 +66,11 @@ describe('Calendar', () => {
         <Calendar />
       </MemoryRouter>
     );
-    expect(screen.getByText('Income')).toBeInTheDocument();
-    expect(screen.getByText('Expenses')).toBeInTheDocument();
+    // The calendar is a cash-movement day ledger, so its summary deliberately
+    // says money in/out, never "Income"/"Expenses" (those are category
+    // semantics — see utils/incomeExpense).
+    expect(screen.getByText('Money in')).toBeInTheDocument();
+    expect(screen.getByText('Money out')).toBeInTheDocument();
     expect(screen.getByText('Net')).toBeInTheDocument();
     expect(screen.getByText('Transactions')).toBeInTheDocument();
   });

--- a/src/services/customReportService.ts
+++ b/src/services/customReportService.ts
@@ -1,6 +1,7 @@
 import type { CustomReport, ReportComponent } from '../components/CustomReportBuilder';
 import type { Transaction, Account, Budget, Category } from '../types';
 import Decimal from 'decimal.js';
+import { buildCategoryKindLookup, classifyFlow, type FlowKind } from '../utils/incomeExpense';
 import { startOfMonth, endOfMonth, startOfQuarter, endOfQuarter, startOfYear, endOfYear, subMonths, parseISO, format } from 'date-fns';
 
 type StorageLike = Pick<Storage, 'getItem' | 'setItem'>;
@@ -169,19 +170,24 @@ export class CustomReportService {
     }
   ): Promise<unknown> {
     const { transactions, accounts, budgets, categories, dateRange } = context;
+    // Income/expense by CATEGORY semantics (utils/incomeExpense): every
+    // generator classifies rows through this one lookup, so a refund filed
+    // under an expense category nets spending down instead of counting as
+    // income — in stats, charts and comparisons alike.
+    const kinds = buildCategoryKindLookup(categories);
 
     switch (component.type) {
       case 'summary-stats':
-        return this.generateSummaryStats(transactions, component.config);
-      
+        return this.generateSummaryStats(transactions, component.config, kinds);
+
       case 'line-chart':
-        return this.generateLineChartData(transactions, dateRange, component.config);
-      
+        return this.generateLineChartData(transactions, dateRange, component.config, kinds);
+
       case 'pie-chart':
-        return this.generatePieChartData(transactions, categories, component.config);
-      
+        return this.generatePieChartData(transactions, categories, component.config, kinds);
+
       case 'bar-chart':
-        return this.generateBarChartData(transactions, dateRange, component.config);
+        return this.generateBarChartData(transactions, dateRange, component.config, kinds);
       
       case 'table':
         return this.generateTableData(transactions, accounts, component.config);
@@ -190,10 +196,10 @@ export class CustomReportService {
         return { content: component.config.content || '' };
       
       case 'category-breakdown':
-        return this.generateCategoryBreakdown(transactions, categories, budgets, component.config);
-      
+        return this.generateCategoryBreakdown(transactions, categories, budgets, component.config, kinds);
+
       case 'date-comparison':
-        return this.generateDateComparison(transactions, dateRange, component.config);
+        return this.generateDateComparison(transactions, dateRange, component.config, kinds);
       
       default:
         return null;
@@ -202,16 +208,24 @@ export class CustomReportService {
 
   private generateSummaryStats(
     transactions: Transaction[],
-    config: ReportComponent['config']
+    config: ReportComponent['config'],
+    kinds: Map<string, FlowKind | null>
   ): Record<string, number> {
-    const income = transactions
-      .filter(t => t.type === 'income')
-      .reduce((sum, t) => sum.plus(t.amount), new Decimal(0));
-    
-    const expenses = transactions
-      .filter(t => t.type === 'expense')
-      .reduce((sum, t) => sum.plus(Math.abs(t.amount)), new Decimal(0));
-    
+    let income = new Decimal(0);
+    let expenses = new Decimal(0);
+    let expenseRowCount = 0;
+    for (const t of transactions) {
+      const kind = classifyFlow(t, kinds);
+      if (kind === 'income') {
+        income = income.plus(t.amount);
+      } else if (kind === 'expense') {
+        // Signed convention: spending is negative, so negating accumulates
+        // spend and a refund credit nets it down.
+        expenses = expenses.minus(t.amount);
+        expenseRowCount++;
+      }
+    }
+
     const netIncome = income.minus(expenses);
     const savingsRate = income.gt(0) ? netIncome.div(income).times(100) : new Decimal(0);
 
@@ -221,8 +235,8 @@ export class CustomReportService {
       netIncome: netIncome.toNumber(),
       savingsRate: savingsRate.toNumber(),
       transactionCount: transactions.length,
-      avgTransaction: transactions.length > 0 
-        ? expenses.div(transactions.filter(t => t.type === 'expense').length).toNumber()
+      avgTransaction: expenseRowCount > 0
+        ? expenses.div(expenseRowCount).toNumber()
         : 0
     };
 
@@ -238,9 +252,10 @@ export class CustomReportService {
   }
 
   private generateLineChartData(
-    transactions: Transaction[], 
+    transactions: Transaction[],
     dateRange: { startDate: Date; endDate: Date },
-    config: ReportComponent['config']
+    config: ReportComponent['config'],
+    kinds: Map<string, FlowKind | null>
   ): { labels: string[]; datasets: Array<{ label: string; data: number[]; borderColor: string; backgroundColor: string; borderWidth?: number }> } {
     // Group transactions by month
     const monthlyData = new Map<string, { income: typeof Decimal.prototype; expenses: typeof Decimal.prototype }>();
@@ -256,10 +271,12 @@ export class CustomReportService {
       }
       
       const data = monthlyData.get(monthKey)!;
-      if (t.type === 'income') {
+      const kind = classifyFlow(t, kinds);
+      if (kind === 'income') {
         data.income = data.income.plus(t.amount);
-      } else if (t.type === 'expense') {
-        data.expenses = data.expenses.plus(Math.abs(t.amount));
+      } else if (kind === 'expense') {
+        // Negated signed sum: refunds net the month's spending down.
+        data.expenses = data.expenses.minus(t.amount);
       }
     });
 
@@ -288,17 +305,22 @@ export class CustomReportService {
   private generatePieChartData(
     transactions: Transaction[],
     categories: Category[],
-    config: ReportComponent['config']
+    config: ReportComponent['config'],
+    kinds: Map<string, FlowKind | null>
   ): { labels: string[]; data: number[] } {
-    // Group expenses by category
+    // Net spend per category (refunds subtract); non-positive categories are
+    // dropped — a pie slice cannot represent negative spend.
     const categoryTotals = new Map<string, typeof Decimal.prototype>();
-    
+
     transactions
-      .filter(t => t.type === 'expense')
+      .filter(t => classifyFlow(t, kinds) === 'expense')
       .forEach(t => {
         const current = categoryTotals.get(t.category) || new Decimal(0);
-        categoryTotals.set(t.category, current.plus(Math.abs(t.amount)));
+        categoryTotals.set(t.category, current.minus(t.amount));
       });
+    for (const [key, total] of [...categoryTotals.entries()]) {
+      if (!total.gt(0)) categoryTotals.delete(key);
+    }
 
     // Sort by amount and apply limit
     const sortedCategories = Array.from(categoryTotals.entries())
@@ -328,17 +350,19 @@ export class CustomReportService {
   private generateBarChartData(
     transactions: Transaction[],
     _dateRange: { startDate: Date; endDate: Date },
-    _config: ReportComponent['config']
+    _config: ReportComponent['config'],
+    kinds: Map<string, FlowKind | null>
   ): { labels: string[]; datasets: Array<{ label: string; data: number[]; backgroundColor: string; borderColor: string; borderWidth: number }> } {
-    // Similar to line chart but with bar format
+    // Similar to line chart but with bar format. Net signed spend per month —
+    // refunds filed to expense categories subtract.
     const monthlyExpenses = new Map<string, typeof Decimal.prototype>();
-    
+
     transactions
-      .filter(t => t.type === 'expense')
+      .filter(t => classifyFlow(t, kinds) === 'expense')
       .forEach(t => {
         const monthKey = format(new Date(t.date), 'MMM yyyy');
         const current = monthlyExpenses.get(monthKey) || new Decimal(0);
-        monthlyExpenses.set(monthKey, current.plus(Math.abs(t.amount)));
+        monthlyExpenses.set(monthKey, current.minus(t.amount));
       });
 
     const sortedMonths = Array.from(monthlyExpenses.keys()).sort((a, b) => 
@@ -405,7 +429,8 @@ export class CustomReportService {
     transactions: Transaction[],
     categories: Category[],
     budgets: Budget[],
-    _config: ReportComponent['config']
+    _config: ReportComponent['config'],
+    kinds: Map<string, FlowKind | null>
   ): Array<{
     category: string;
     actual: number;
@@ -421,17 +446,18 @@ export class CustomReportService {
       count: number;
     }>();
 
-    // Calculate actuals
+    // Calculate actuals — net signed spend, so refunds filed to the
+    // category reduce the actual instead of inflating it.
     transactions
-      .filter(t => t.type === 'expense')
+      .filter(t => classifyFlow(t, kinds) === 'expense')
       .forEach(t => {
         const current = categoryData.get(t.category) || {
           actual: new Decimal(0),
           budget: new Decimal(0),
           count: 0
         };
-        
-        current.actual = current.actual.plus(Math.abs(t.amount));
+
+        current.actual = current.actual.minus(t.amount);
         current.count++;
         categoryData.set(t.category, current);
       });
@@ -468,7 +494,8 @@ export class CustomReportService {
   private generateDateComparison(
     transactions: Transaction[],
     dateRange: { startDate: Date; endDate: Date },
-    _config: ReportComponent['config']
+    _config: ReportComponent['config'],
+    kinds: Map<string, FlowKind | null>
   ): {
     current: {
       income: number;
@@ -511,16 +538,17 @@ export class CustomReportService {
       return tDate >= previousStart && tDate <= previousEnd;
     });
 
-    // Calculate metrics for both periods
+    // Calculate metrics for both periods — category semantics, so refunds
+    // net expenses down in both the current and comparison windows.
     const calculateMetrics = (trans: Transaction[]) => {
-      const income = trans
-        .filter(t => t.type === 'income')
-        .reduce((sum, t) => sum.plus(t.amount), new Decimal(0));
-      
-      const expenses = trans
-        .filter(t => t.type === 'expense')
-        .reduce((sum, t) => sum.plus(Math.abs(t.amount)), new Decimal(0));
-      
+      let income = new Decimal(0);
+      let expenses = new Decimal(0);
+      for (const t of trans) {
+        const kind = classifyFlow(t, kinds);
+        if (kind === 'income') income = income.plus(t.amount);
+        else if (kind === 'expense') expenses = expenses.minus(t.amount);
+      }
+
       return {
         income: income.toNumber(),
         expenses: expenses.toNumber(),

--- a/src/utils/categoryNetting.ts
+++ b/src/utils/categoryNetting.ts
@@ -1,4 +1,5 @@
 import { toDecimal } from './decimal';
+import { categoryKindOf } from './incomeExpense';
 import type { Transaction, Category } from '../types';
 
 export interface CategoryNetTotal {
@@ -37,10 +38,11 @@ export function bucketByCategoryDirection(
   categoryById: ReadonlyMap<string, Category>
 ): 'income' | 'expense' | 'transfer' {
   if (t.type === 'transfer') return 'transfer';
-  const category = t.category ? categoryById.get(t.category) : undefined;
-  if (category?.type === 'expense') return 'expense';
-  if (category?.type === 'income') return 'income';
-  return t.type;
+  // One shared kind definition (utils/incomeExpense) — this must never drift
+  // from the Dashboard/Analytics classifier. It also treats a To/From
+  // transfer category as 'transfer' whatever the row's own direction says.
+  const kind = categoryKindOf(t.category ? categoryById.get(t.category) : undefined);
+  return kind ?? t.type;
 }
 
 export function computeExpenseCategoryNetTotals(

--- a/src/utils/incomeExpense.ts
+++ b/src/utils/incomeExpense.ts
@@ -27,19 +27,19 @@ import { expandSplitTransactions, type SplitExpandedTransaction } from './transa
 
 export type FlowKind = 'income' | 'expense' | 'transfer';
 
+/** A single category's flow kind (null = no categorical signal, e.g. 'both'). */
+export function categoryKindOf(c: Category | undefined): FlowKind | null {
+  if (!c) return null;
+  if (c.isTransferCategory === true || c.id === 'type-transfer' || c.parentId === 'type-transfer') {
+    return 'transfer';
+  }
+  if (c.type === 'income' || c.type === 'expense') return c.type;
+  return null;
+}
+
 /** category id → its flow kind (null = no categorical signal, e.g. 'both'). */
 export function buildCategoryKindLookup(categories: Category[]): Map<string, FlowKind | null> {
-  const lookup = new Map<string, FlowKind | null>();
-  for (const c of categories) {
-    if (c.isTransferCategory === true || c.id === 'type-transfer' || c.parentId === 'type-transfer') {
-      lookup.set(c.id, 'transfer');
-    } else if (c.type === 'income' || c.type === 'expense') {
-      lookup.set(c.id, c.type);
-    } else {
-      lookup.set(c.id, null);
-    }
-  }
-  return lookup;
+  return new Map(categories.map(c => [c.id, categoryKindOf(c)]));
 }
 
 export function classifyFlow(


### PR DESCRIPTION
The follow-up you asked for: *"we need to clean up the rest too. We can't just have all 'credits' applying to 'income'."*

Every remaining surface that summed income/expenses by money **direction** now classifies by **category** through the one shared definition (`utils/incomeExpense`). Reports and the Budget page were already right — their existing netting logic now *delegates to the same shared classifier*, so nothing can drift.

**Swept:**
- **Excel export** — summary/accounts/categories sheets classify by category. Also fixes two silent data bugs found in the process: category columns matched by **name** against id-storing transactions (they were always empty), and float accumulation. Budget sheet nets refunds, clamped at zero.
- **Scheduled reports** — summary text, Top Expenses ranking, PDF summary (split-aware, Decimal).
- **Custom reports** — all six generators (stats, line, pie, bar, category-vs-budget, date comparison). Fully-refunded categories drop out of pies instead of showing a bogus slice.
- **Dashboard budget widget** — a refund previously made a budget look *more* spent (it summed absolute values); now nets, in Decimal, matching the Budget page.
- **Budget rollover** — previous-month spend nets refunds, clamped at zero.
- **Reports page** — now split-expanded like every other surface, so split lines land in their own categories.
- **Calendar** — made honest rather than forced: it's a bank-statement day view (transfers included), so it now says **"Money in / Money out"** instead of claiming Income/Expenses (a transfer between your own accounts was inflating both figures).
- Plus an invalid `<div>`-inside-`<p>` DOM nesting fix in the Reports skeletons.

**Deliberately left direction-based** (not income statements): data validation (checks sign↔type coherence), anomaly detection heuristics, tax planning, the Investments cash-flow view, and cash-flow forecast pattern typing.

Verified in the browser: Reports and Dashboard now agree **to the penny** on the same window. Gates: strict types, lint, smoke (3,163), coverage pipeline, build — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)