### PR TITLE
fix(reports): uncategorised rows hit NO report — direction is never guessed

### DIFF
--- a/src/pages/Reports.tsx
+++ b/src/pages/Reports.tsx
@@ -50,7 +50,7 @@ export default function Reports() {
   const picker = usePeriod('reportsPeriod');
   const [selectedAccount, setSelectedAccount] = useState<string>('all');
   const [isGeneratingPDF, setIsGeneratingPDF] = useState(false);
-  const [breakdownType, setBreakdownType] = useState<'income' | 'expense' | null>(null);
+  const [breakdownType, setBreakdownType] = useState<'income' | 'expense' | 'uncategorized' | null>(null);
   const [editingBreakdownTxnId, setEditingBreakdownTxnId] = useState<string | null>(null);
   const [isLoading, setIsLoading] = useState(true);
   const chartRef1 = useRef<HTMLDivElement>(null);
@@ -294,6 +294,27 @@ export default function Reports() {
         </div>
         </div>
 
+        {/* Uncategorised review band — these rows are EXCLUDED from every
+            total above (no category = not income, not an expense). Shown so
+            the data gets cleaned rather than silently miscounted. */}
+        {flows.uncategorizedRows.length > 0 && (
+          <button
+            type="button"
+            onClick={() => setBreakdownType('uncategorized')}
+            className="w-full flex flex-wrap items-center gap-x-4 gap-y-1 rounded-2xl border border-amber-300 dark:border-amber-600 bg-amber-50 dark:bg-amber-900/20 px-5 py-3 text-left hover:bg-amber-100 dark:hover:bg-amber-900/30 transition-colors"
+          >
+            <span className="text-sm font-semibold text-amber-800 dark:text-amber-300">
+              {flows.uncategorizedRows.length.toLocaleString()} uncategorised transaction{flows.uncategorizedRows.length === 1 ? '' : 's'} excluded from these totals
+            </span>
+            <span className="text-sm text-amber-700 dark:text-amber-400 tabular-nums">
+              {formatCurrency(flows.uncategorizedIn.toNumber())} in · {formatCurrency(flows.uncategorizedOut.toNumber())} out
+            </span>
+            <span className="ml-auto text-xs text-amber-700 dark:text-amber-400">
+              Click to review and categorise
+            </span>
+          </button>
+        )}
+
         {/* Charts */}
         <div className="pt-4">
           <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
@@ -451,7 +472,11 @@ export default function Reports() {
       <Modal
         isOpen={breakdownType !== null}
         onClose={() => setBreakdownType(null)}
-        title={breakdownType === 'income' ? 'Income Breakdown' : 'Expense Breakdown'}
+        title={
+          breakdownType === 'income' ? 'Income Breakdown'
+          : breakdownType === 'expense' ? 'Expense Breakdown'
+          : 'Uncategorised Transactions'
+        }
         size="md"
       >
         <ModalBody>
@@ -465,7 +490,10 @@ export default function Reports() {
             </thead>
             <tbody>
               {(() => {
-                const allRows = [...(breakdownType === 'income' ? flows.incomeRows : flows.expenseRows)]
+                const source = breakdownType === 'income' ? flows.incomeRows
+                  : breakdownType === 'expense' ? flows.expenseRows
+                  : flows.uncategorizedRows;
+                const allRows = [...source]
                   .sort((a, b) => new Date(b.date).getTime() - new Date(a.date).getTime());
 
                 if (allRows.length === 0) {
@@ -477,27 +505,34 @@ export default function Reports() {
                 const rows = allRows.slice(0, CAP);
 
                 const rendered = rows.map(t => {
-                  const contribution = bucketContribution(t, breakdownType === 'income' ? 'income' : 'expense');
+                  // Uncategorised rows have no bucket: show their signed
+                  // amount as-is (they count toward NO total until filed).
+                  const value = breakdownType === 'uncategorized'
+                    ? t.amount
+                    : bucketContribution(t, breakdownType === 'income' ? 'income' : 'expense');
+                  const valueClass = breakdownType === 'income' ? 'text-green-600 dark:text-green-400'
+                    : breakdownType === 'expense' ? 'text-red-600 dark:text-red-400'
+                    : value >= 0 ? 'text-green-600 dark:text-green-400' : 'text-red-600 dark:text-red-400';
                   return (
                     <tr
                       key={t.id}
                       onClick={() => setEditingBreakdownTxnId(t.splitParentId ?? t.id)}
                       className="border-b border-gray-50 dark:border-gray-700/50 last:border-0 cursor-pointer hover:bg-gray-50 dark:hover:bg-gray-700/40 transition-colors"
-                      title="Click to view or edit this transaction"
+                      title={breakdownType === 'uncategorized'
+                        ? 'Click to give this transaction a category'
+                        : 'Click to view or edit this transaction'}
                     >
                       <td className="py-2 text-sm text-gray-500 dark:text-gray-400 whitespace-nowrap">
                         {new Date(t.date).toLocaleDateString('en-GB', { day: '2-digit', month: 'short' })}
                       </td>
                       <td className="py-2 text-sm text-gray-900 dark:text-white">
                         {t.description}
-                        {contribution < 0 && (
+                        {breakdownType !== 'uncategorized' && value < 0 && (
                           <span className="ml-2 text-xs text-gray-400 dark:text-gray-500">(credit)</span>
                         )}
                       </td>
-                      <td className={`py-2 text-sm font-medium text-right whitespace-nowrap ${
-                        breakdownType === 'income' ? 'text-green-600 dark:text-green-400' : 'text-red-600 dark:text-red-400'
-                      }`}>
-                        {contribution < 0 ? `-${formatCurrency(Math.abs(contribution))}` : formatCurrency(contribution)}
+                      <td className={`py-2 text-sm font-medium text-right whitespace-nowrap ${valueClass}`}>
+                        {value < 0 ? `-${formatCurrency(Math.abs(value))}` : formatCurrency(value)}
                       </td>
                     </tr>
                   );
@@ -518,14 +553,24 @@ export default function Reports() {
               })()}
             </tbody>
             <tfoot>
-              <tr className="border-t-2 border-gray-200 dark:border-gray-600">
-                <td colSpan={2} className="pt-3 text-sm font-semibold text-gray-900 dark:text-white">Total</td>
-                <td className={`pt-3 text-sm font-bold text-right ${
-                  breakdownType === 'income' ? 'text-green-600 dark:text-green-400' : 'text-red-600 dark:text-red-400'
-                }`}>
-                  {formatCurrency(breakdownType === 'income' ? summary.income : summary.expenses)}
-                </td>
-              </tr>
+              {breakdownType === 'uncategorized' ? (
+                <tr className="border-t-2 border-gray-200 dark:border-gray-600">
+                  <td colSpan={3} className="pt-3 text-xs text-gray-500 dark:text-gray-400">
+                    These transactions count toward NO total until they are given a category
+                    ({formatCurrency(flows.uncategorizedIn.toNumber())} in · {formatCurrency(flows.uncategorizedOut.toNumber())} out).
+                    Set up a category like &ldquo;Income : Miscellaneous&rdquo; if you need a catch-all.
+                  </td>
+                </tr>
+              ) : (
+                <tr className="border-t-2 border-gray-200 dark:border-gray-600">
+                  <td colSpan={2} className="pt-3 text-sm font-semibold text-gray-900 dark:text-white">Total</td>
+                  <td className={`pt-3 text-sm font-bold text-right ${
+                    breakdownType === 'income' ? 'text-green-600 dark:text-green-400' : 'text-red-600 dark:text-red-400'
+                  }`}>
+                    {formatCurrency(breakdownType === 'income' ? summary.income : summary.expenses)}
+                  </td>
+                </tr>
+              )}
             </tfoot>
           </table>
         </ModalBody>

--- a/src/utils/__tests__/categoryNetting.test.ts
+++ b/src/utils/__tests__/categoryNetting.test.ts
@@ -47,15 +47,14 @@ describe('computeExpenseCategoryNetTotals', () => {
     expect(totals).toEqual([]);
   });
 
-  it("buckets 'both'-typed and uncategorized rows by transaction direction", () => {
+  it("uncategorized rows never reach the spending breakdown; a real 'both' category counts by its row's direction", () => {
     const totals = computeExpenseCategoryNetTotals([
-      txn({ type: 'expense', category: 'cat-adjust', amount: -20 }),
-      txn({ type: 'income', category: 'cat-adjust', amount: 5 }),   // income side — excluded
-      txn({ type: 'expense', category: '', amount: -30 }),
+      txn({ type: 'expense', category: 'cat-adjust', amount: -20 }), // 'both' + outgoing → spend
+      txn({ type: 'income', category: 'cat-adjust', amount: 5 }),    // 'both' + incoming → income side, not spend
+      txn({ type: 'expense', category: '', amount: -30 }),           // NO category → excluded entirely
     ], categories);
 
     expect(totals).toEqual([
-      { key: 'uncategorized', name: 'Uncategorized', value: 30 },
       { key: 'cat-adjust', name: 'Account Adjustments', value: 20 },
     ]);
   });

--- a/src/utils/categoryNetting.ts
+++ b/src/utils/categoryNetting.ts
@@ -3,7 +3,7 @@ import { categoryKindOf } from './incomeExpense';
 import type { Transaction, Category } from '../types';
 
 export interface CategoryNetTotal {
-  /** Category id, or 'uncategorized'. */
+  /** Category id. */
   key: string;
   /** Display name (resolved from the category; ids never leak into charts). */
   name: string;
@@ -36,13 +36,17 @@ export interface CategoryNetTotal {
 export function bucketByCategoryDirection(
   t: Transaction,
   categoryById: ReadonlyMap<string, Category>
-): 'income' | 'expense' | 'transfer' {
+): 'income' | 'expense' | 'transfer' | 'uncategorized' {
   if (t.type === 'transfer') return 'transfer';
   // One shared kind definition (utils/incomeExpense) — this must never drift
   // from the Dashboard/Analytics classifier. It also treats a To/From
   // transfer category as 'transfer' whatever the row's own direction says.
-  const kind = categoryKindOf(t.category ? categoryById.get(t.category) : undefined);
-  return kind ?? t.type;
+  // 'uncategorized' is STRICT: no category, or a dangling id — such rows
+  // never hit an income/expense report. A real direction-neutral ('both')
+  // category was deliberately filed, so direction decides its side.
+  const category = t.category ? categoryById.get(t.category) : undefined;
+  if (!category) return 'uncategorized';
+  return categoryKindOf(category) ?? t.type;
 }
 
 export function computeExpenseCategoryNetTotals(
@@ -53,21 +57,21 @@ export function computeExpenseCategoryNetTotals(
   const totals = new Map<string, ReturnType<typeof toDecimal>>();
 
   for (const t of transactions) {
+    // Only rows with a real expense category count — an uncategorised row
+    // never reaches the spending breakdown (it can't: 'expense' requires the
+    // category to have resolved to the expense tree).
     if (bucketByCategoryDirection(t, categoryById) !== 'expense') continue;
 
-    const key = t.category && t.category.trim() !== '' ? t.category : 'uncategorized';
-    const previous = totals.get(key) ?? toDecimal(0);
+    const previous = totals.get(t.category) ?? toDecimal(0);
     // Signed convention: spending is negative, so negate to accumulate spend;
     // an income-row refund (+) filed under this category nets the total down.
-    totals.set(key, previous.minus(toDecimal(t.amount)));
+    totals.set(t.category, previous.minus(toDecimal(t.amount)));
   }
 
   const entries = [...totals.entries()]
     .map(([key, total]) => ({
       key,
-      name: key === 'uncategorized'
-        ? 'Uncategorized'
-        : categoryById.get(key)?.name ?? key,
+      name: categoryById.get(key)?.name ?? key,
       value: total.toNumber(),
     }))
     .filter(entry => entry.value > 0);
@@ -80,7 +84,7 @@ export function computeExpenseCategoryNetTotals(
 
   return entries
     .map(entry => {
-      if ((nameCounts.get(entry.name) ?? 0) > 1 && entry.key !== 'uncategorized') {
+      if ((nameCounts.get(entry.name) ?? 0) > 1) {
         const category = categoryById.get(entry.key);
         const parent = category?.parentId ? categoryById.get(category.parentId) : undefined;
         if (parent) {

--- a/src/utils/incomeExpense.test.ts
+++ b/src/utils/incomeExpense.test.ts
@@ -34,10 +34,14 @@ describe('classifyFlow', () => {
     expect(classifyFlow(txn({ type: 'expense', amount: -50, category: 'cat-salary' }), kinds)).toBe('income');
   });
 
-  it('falls back to the stored direction when the category gives no signal', () => {
-    expect(classifyFlow(txn({ type: 'expense', category: '' }), kinds)).toBe('expense');
+  it('NO category (or a dangling id) → uncategorized, never a direction guess', () => {
+    expect(classifyFlow(txn({ type: 'expense', category: '' }), kinds)).toBe('uncategorized');
+    expect(classifyFlow(txn({ type: 'income', category: 'nonexistent' }), kinds)).toBe('uncategorized');
+  });
+
+  it("a REAL direction-neutral ('both') category was deliberately filed — direction decides its side, never the review list", () => {
     expect(classifyFlow(txn({ type: 'income', category: 'cat-both' }), kinds)).toBe('income');
-    expect(classifyFlow(txn({ type: 'income', category: 'nonexistent' }), kinds)).toBe('income');
+    expect(classifyFlow(txn({ type: 'expense', category: 'cat-both' }), kinds)).toBe('expense');
   });
 
   it('transfers never count, by type or by transfer category', () => {
@@ -74,6 +78,22 @@ describe('computeIncomeExpense', () => {
     const { income, expenses } = computeIncomeExpense(transactions, splits, CATEGORIES);
     expect(expenses.toNumber()).toBe(100);
     expect(income.toNumber()).toBe(10);
+  });
+
+  it('uncategorised rows hit NO total and are listed for review', () => {
+    const transactions: Transaction[] = [
+      txn({ id: 'a', type: 'income', amount: 2500, category: 'cat-salary' }),
+      // a £250k "Adjustment" credit with no category must NOT be income
+      txn({ id: 'b', type: 'income', amount: 250000, category: '' }),
+      txn({ id: 'c', type: 'expense', amount: -75, category: '' }),
+    ];
+    const { income, expenses, uncategorizedRows, uncategorizedIn, uncategorizedOut } =
+      computeIncomeExpense(transactions, [], CATEGORIES);
+    expect(income.toNumber()).toBe(2500);
+    expect(expenses.toNumber()).toBe(0);
+    expect(uncategorizedRows.map(r => r.id)).toEqual(['b', 'c']);
+    expect(uncategorizedIn.toNumber()).toBe(250000);
+    expect(uncategorizedOut.toNumber()).toBe(75);
   });
 
   it('bounds by date when from/to given', () => {

--- a/src/utils/incomeExpense.ts
+++ b/src/utils/incomeExpense.ts
@@ -18,14 +18,18 @@ import { expandSplitTransactions, type SplitExpandedTransaction } from './transa
  *  - transfers never count (neither the type nor transfer categories);
  *  - a category from the income tree → income; expense tree → expense —
  *    regardless of the money's direction;
- *  - no category / an unknown or direction-neutral ('both') category → fall
- *    back to the stored direction, the only signal left.
+ *  - NO category (or an unknown / direction-neutral one) → the row does NOT
+ *    hit the report at all. Direction is never guessed: an uncategorised
+ *    credit is not income and an uncategorised debit is not spending — it is
+ *    unclassified data the user needs to file (Steve: "no category shouldn't
+ *    be tagged as income or expense in a report — forces people to keep
+ *    their data clean"). Reports surface these rows separately for review.
  *
  * Split transactions classify PER LINE (a split can mix categories), with the
  * parent never double-counted.
  */
 
-export type FlowKind = 'income' | 'expense' | 'transfer';
+export type FlowKind = 'income' | 'expense' | 'transfer' | 'uncategorized';
 
 /** A single category's flow kind (null = no categorical signal, e.g. 'both'). */
 export function categoryKindOf(c: Category | undefined): FlowKind | null {
@@ -47,8 +51,13 @@ export function classifyFlow(
   categoryKinds: Map<string, FlowKind | null>
 ): FlowKind {
   if (row.type === 'transfer') return 'transfer';
-  const kind = row.category ? categoryKinds.get(row.category) : undefined;
+  // 'uncategorized' means STRICTLY that: no category at all, or a dangling
+  // id. A row with any real category never lands in the review list.
+  if (!row.category || !categoryKinds.has(row.category)) return 'uncategorized';
+  const kind = categoryKinds.get(row.category);
   if (kind === 'income' || kind === 'expense' || kind === 'transfer') return kind;
+  // A real but direction-neutral ('both') category: the user DID file it —
+  // the money's direction decides which side of the report it lands on.
   return row.type === 'income' ? 'income' : 'expense';
 }
 
@@ -60,6 +69,14 @@ export interface IncomeExpenseBreakdown {
   /** The rows behind each total (split lines, not their parents). */
   incomeRows: SplitExpandedTransaction[];
   expenseRows: SplitExpandedTransaction[];
+  /**
+   * Rows with no usable category — EXCLUDED from both totals, listed here so
+   * reports can show a "needs a category" review affordance. Money in/out
+   * are the signed sums of these rows (for display only, never totals).
+   */
+  uncategorizedRows: SplitExpandedTransaction[];
+  uncategorizedIn: DecimalInstance;
+  uncategorizedOut: DecimalInstance;
 }
 
 /**
@@ -85,8 +102,11 @@ export function computeIncomeExpense(
 
   let income = toDecimal(0);
   let expenses = toDecimal(0);
+  let uncategorizedIn = toDecimal(0);
+  let uncategorizedOut = toDecimal(0);
   const incomeRows: SplitExpandedTransaction[] = [];
   const expenseRows: SplitExpandedTransaction[] = [];
+  const uncategorizedRows: SplitExpandedTransaction[] = [];
 
   for (const row of rows) {
     const kind = classifyFlow(row, kinds);
@@ -98,10 +118,15 @@ export function computeIncomeExpense(
       // and a positive-amount credit (refund) correctly SUBTRACTS.
       expenses = expenses.plus(toDecimal(row.amount).negated());
       expenseRows.push(row);
+    } else if (kind === 'uncategorized') {
+      const amount = toDecimal(row.amount);
+      if (amount.greaterThanOrEqualTo(0)) uncategorizedIn = uncategorizedIn.plus(amount);
+      else uncategorizedOut = uncategorizedOut.plus(amount.abs());
+      uncategorizedRows.push(row);
     }
   }
 
-  return { income, expenses, incomeRows, expenseRows };
+  return { income, expenses, incomeRows, expenseRows, uncategorizedRows, uncategorizedIn, uncategorizedOut };
 }
 
 /**


### PR DESCRIPTION
**Your rule, verbatim**: *"if it does not have a category, then it doesn't hit the report. Forces people to keep their data clean… no category shouldn't be tagged as 'income' (or an expense) in a report."*

The classifier previously fell back to money direction when a row had no category — which is how a £250k uncategorised "Adjustment" credit and unlinked bank-feed transfer legs masqueraded as income. Now:

- **'Uncategorised' is strict**: no category at all, or a dangling category id. Those rows are excluded from income, expenses, pies, trends, exports and comparisons alike — every consumer shares the one classifier, so the policy lands everywhere at once.
- **A row with any real category never enters the review list**: transfer categories classify as transfers (invisible to income/expense entirely — *"transfers should not be thought of at all"*), group-level filing counts fine, and a deliberately direction-neutral category counts on the side its money moved.
- **Never silently**: the Reports page shows an amber review band whenever the period holds uncategorised rows — count + money in/out, click to review — opening a list where each row is one click from the Edit Transaction modal. The footer suggests creating e.g. "Income : Miscellaneous" as a deliberate catch-all.

**Measured on production** (read-only): last-12-months income goes from the fictional **£2,427,591** to the real **£233,082.83** (all under your Investment Income tree), with **580 truly-uncategorised rows** (£2.19M in / £1.19M out — adjustments, valuation updates, unlinked transfer legs) surfaced for review instead of being counted.

Tests updated to the policy + a new exclusion case (a £250k uncategorised credit contributes £0 income). Browser-verified with a seeded uncategorised credit: Income unmoved, band shows it, row click opens the editor. Strict types, lint, smoke (3,166), build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)