### PR TITLE
perf: single-pass dashboard balances, boot phase timing, dev profiler

### DIFF
--- a/src/components/dashboard/ImprovedDashboard.tsx
+++ b/src/components/dashboard/ImprovedDashboard.tsx
@@ -70,13 +70,19 @@ export function ImprovedDashboard() {
   // Calculate key metrics — all money sums use Decimal arithmetic (float math
   // is banned on currency values; IEEE-754 drifts on long sums).
   const metrics = useMemo(() => {
-    // Compute real balance from openingBalance + sum of transactions per account
-    const effectiveBalance = (acc: typeof accounts[0]): number => {
-      const txnTotal = transactions
-        .filter(t => t.accountId === acc.id)
-        .reduce((sum, t) => sum.plus(toDecimal(t.amount)), toDecimal(0));
-      return toDecimal(acc.openingBalance ?? 0).plus(txnTotal).toNumber();
-    };
+    // Real balance = openingBalance + Σ transactions, computed in ONE pass
+    // over the whole transaction set. The previous per-account filters were
+    // O(accounts × transactions) and ran up to five times per account —
+    // ~50 MILLION Decimal operations per render on a 50k-row dataset.
+    const txnTotals = new Map<string, ReturnType<typeof toDecimal>>();
+    for (const t of transactions) {
+      txnTotals.set(t.accountId, (txnTotals.get(t.accountId) ?? toDecimal(0)).plus(toDecimal(t.amount)));
+    }
+    const balances = new Map<string, number>();
+    for (const acc of accounts) {
+      balances.set(acc.id, toDecimal(acc.openingBalance ?? 0).plus(txnTotals.get(acc.id) ?? toDecimal(0)).toNumber());
+    }
+    const effectiveBalance = (acc: typeof accounts[0]): number => balances.get(acc.id) ?? 0;
 
     const totalAssets = accounts
       .filter(acc => effectiveBalance(acc) > 0)
@@ -203,13 +209,15 @@ export function ImprovedDashboard() {
   
   // Pre-compute real balances per account (openingBalance + sum of transactions)
   const accountBalanceMap = useMemo(() => {
+    // Single pass over transactions (Decimal — float sums drift on 50k-row
+    // histories), then one lookup per account. Was O(accounts × transactions).
+    const txnTotals = new Map<string, ReturnType<typeof toDecimal>>();
+    for (const t of transactions) {
+      txnTotals.set(t.accountId, (txnTotals.get(t.accountId) ?? toDecimal(0)).plus(toDecimal(t.amount)));
+    }
     const map = new Map<string, number>();
     accounts.forEach(acc => {
-      const opening = acc.openingBalance ?? 0;
-      const txnTotal = transactions
-        .filter(t => t.accountId === acc.id)
-        .reduce((sum, t) => sum + t.amount, 0);
-      map.set(acc.id, opening + txnTotal);
+      map.set(acc.id, toDecimal(acc.openingBalance ?? 0).plus(txnTotals.get(acc.id) ?? toDecimal(0)).toNumber());
     });
     return map;
   }, [accounts, transactions]);

--- a/src/contexts/AppContextSupabase.tsx
+++ b/src/contexts/AppContextSupabase.tsx
@@ -204,6 +204,17 @@ export function AppProvider({ children }: { children: React.ReactNode }) {
       setIsLoading(true);
       setSyncError(null);
 
+      // Boot phase timings — one summary line at the end so a slow load can
+      // be attributed (auth? accounts? categories? transactions?) from the
+      // console of ANY environment, production included.
+      const bootStart = performance.now();
+      const phases: Record<string, number> = {};
+      let phaseStart = bootStart;
+      const markPhase = (name: string): void => {
+        phases[name] = Math.round(performance.now() - phaseStart);
+        phaseStart = performance.now();
+      };
+
       try {
         appLogger.info('Initializing app context', { userId: user?.id });
         // Initialize DataService with user info
@@ -217,6 +228,7 @@ export function AppProvider({ children }: { children: React.ReactNode }) {
             user.firstName || undefined,
             user.lastName || undefined
           );
+          markPhase('auth');
           if (databaseId) {
             appLogger.info('Database user ID resolved', { databaseId });
             
@@ -230,11 +242,13 @@ export function AppProvider({ children }: { children: React.ReactNode }) {
               user.lastName || undefined
             );
             appLogger.info('Loading application data');
-            
+            markPhase('services');
+
             // Use the database ID we just got - no need to fetch it again!
             const accounts = await SimpleAccountService.getAccounts(databaseId);
             appLogger.info('Accounts loaded', { count: accounts.length });
             setAccounts(accounts);
+            markPhase('accounts');
           } else {
             appLogger.warn('Failed to resolve database user ID - no data will be loaded');
             setAccounts([]);
@@ -253,10 +267,12 @@ export function AppProvider({ children }: { children: React.ReactNode }) {
         const planningUserId = userIdService.getCurrentDatabaseUserId();
         const loadedCategories = await PlanningService.ensureCategories(planningUserId);
         setCategories(loadedCategories);
+        markPhase('categories');
 
         // Now load transactions, budgets, and goals (post-remap views).
         const data = await DataService.loadAppData();
         setTransactions(data.transactions);
+        markPhase('transactions');
 
         // Split lines ride along with transactions; a failure here must not
         // block the app (split parents then pass through aggregation whole).
@@ -266,6 +282,7 @@ export function AppProvider({ children }: { children: React.ReactNode }) {
           appLogger.error('Failed to load transaction splits', splitError);
           setTransactionSplitsState([]);
         }
+        markPhase('splits');
 
         // Without an authenticated user (demo / local-only mode) the
         // SimpleAccountService path above returns nothing — it needs a
@@ -282,9 +299,17 @@ export function AppProvider({ children }: { children: React.ReactNode }) {
         ]);
         setBudgets(loadedBudgets);
         setGoals(loadedGoals);
+        markPhase('planning');
 
         setIsUsingSupabase(DataService.isUsingSupabase());
         setLastSyncTime(new Date());
+        // The numbers live IN the message so any console (production
+        // included) shows the breakdown without expanding an object.
+        appLogger.info(
+          `Boot data load: ${Math.round(performance.now() - bootStart)}ms total — ` +
+          Object.entries(phases).map(([name, ms]) => `${name} ${ms}ms`).join(' · ') +
+          ` (${data.transactions.length.toLocaleString()} transactions)`
+        );
 
         // Subscribe to real-time updates if using Supabase
         if (DataService.isUsingSupabase() && user) {

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -20,6 +20,30 @@ import {
 
 const bootstrapLogger = createScopedLogger('AppBootstrap');
 
+// DEV-ONLY boot profiler: `sessionStorage.bootProfile = '1'` then reload —
+// the whole boot is sampled (JS Self-Profiling API, enabled by the dev
+// server's Document-Policy header) and the trace parked on
+// `window.__bootTrace` for inspection. No-op in production builds.
+if (import.meta.env.DEV && sessionStorage.getItem('bootProfile') === '1') {
+  try {
+    type ProfilerTrace = { samples: unknown[]; stacks: unknown[]; frames: unknown[] };
+    type ProfilerLike = { stop(): Promise<ProfilerTrace> };
+    type ProfilerCtor = new (opts: { sampleInterval: number; maxBufferSize: number }) => ProfilerLike;
+    const ProfilerClass = (globalThis as { Profiler?: ProfilerCtor }).Profiler;
+    if (ProfilerClass) {
+      const profiler = new ProfilerClass({ sampleInterval: 5, maxBufferSize: 1_000_000 });
+      setTimeout(() => {
+        void profiler.stop().then(trace => {
+          (window as unknown as { __bootTrace?: ProfilerTrace }).__bootTrace = trace;
+          bootstrapLogger.info('Boot profile captured on window.__bootTrace');
+        });
+      }, 20_000);
+    }
+  } catch {
+    // Profiling is best-effort tooling; never let it affect boot.
+  }
+}
+
 // Reduced-motion preference (moved out of index.html so the CSP needs no
 // 'unsafe-inline' for scripts).
 if (typeof window !== 'undefined' && window.matchMedia('(prefers-reduced-motion: reduce)').matches) {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -65,6 +65,11 @@ export default defineConfig({
     port: 5173,
     strictPort: false,
     open: false,
+    // Enables the JS Self-Profiling API in dev, so performance work can
+    // attribute main-thread time to real functions instead of guessing.
+    headers: {
+      'Document-Policy': 'js-profiling'
+    },
     proxy: {
       '/api': {
         target: 'https://wealthtracker-web.vercel.app',


### PR DESCRIPTION
First **measured** pass at "the pages are still slow" on the 50k-row history.

## Measured first — and the measurements changed the story
Local wall-clock to dashboard paint started at **15.8s**, but profiling showed most of that is **Vite dev-mode module transformation**, not app code — with a warm server the entire 50,860-row data load is **~870ms locally** (transactions 728ms, splits 130ms). Production's cost profile is different (a ~51-page network fetch), so production needs its own numbers — which this PR makes visible.

## What lands
1. **Dashboard balance maths de-quadratic'd**: metrics and the account-balance map each re-filtered ALL transactions per account (the metrics path up to five times per account — **~50 million Decimal operations per render**). Both now build one O(transactions) map. Local wall-clock improved 15.8s → 12.9s even under dev noise, and a float accumulation became Decimal in the same move.
2. **Boot phase timing** — one console line at the end of the context load: `Boot data load: 866ms total — categories 5ms · transactions 728ms · splits 130ms · planning 4ms (50,860 transactions)` — numbers in the message, so **any environment's console (production included)** attributes a slow boot at a glance.
3. **Dev profiling tooling**: the dev server sends `Document-Policy: js-profiling`, and `sessionStorage.bootProfile='1'` samples the whole boot onto `window.__bootTrace`. No more guessing at silent 6-second tasks.

## Proposed next lever (needs a migration — your call)
Production's transactions phase is the paged fetch. A **per-account balances RPC** (SUM in Postgres, one round trip) would paint the Dashboard/Accounts real numbers instantly while transaction pages stream in behind — the right loading model for large files, and it moves balance maths toward the database as the audit has long wanted.

Gates: strict types, lint, smoke (3,107), coverage (63.07% ≥ 63% floor — close, noted), build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)