### PR TITLE
feat(dashboard): pinned reports — choose which live reports show on the Dashboard

### DIFF
--- a/src/components/dashboard/ImprovedDashboard.tsx
+++ b/src/components/dashboard/ImprovedDashboard.tsx
@@ -23,6 +23,18 @@ import { preserveDemoParam } from '../../utils/navigation';
 import AddTransactionModal from '../AddTransactionModal';
 import EditTransactionModal from '../EditTransactionModal';
 import IncomeExpenseBreakdownModal from '../IncomeExpenseBreakdownModal';
+import { Modal, ModalBody } from '../common/Modal';
+import PeriodPicker from '../../components/PeriodPicker';
+import { usePeriod } from '../../hooks/usePeriod';
+import { customReportService } from '../../services/customReportService';
+import {
+  BUILT_IN_REPORTS,
+  NetWorthWidget,
+  IncomeExpenseTrendWidget,
+  ExpenseCategoriesWidget,
+  CustomReportWidget,
+  type PinnableReportId,
+} from './reportWidgets/DashboardReportWidgets';
 import { PieChart, BarChart, ResponsiveContainer } from '../charts/DashboardCharts';
 import { formatDecimal } from '../../utils/decimal-format';
 import { toDecimal } from '../../utils/decimal';
@@ -50,6 +62,26 @@ export function ImprovedDashboard() {
   // category — and the list re-derives live, so a re-categorised transaction
   // drops out of it immediately.
   const [editingBreakdownTxnId, setEditingBreakdownTxnId] = useState<string | null>(null);
+  // Pinned reports: the user chooses which live reports show on the
+  // Dashboard (built-ins + their custom reports). What matters is different
+  // to different users.
+  const [pinnedReports, setPinnedReports] = useState<PinnableReportId[]>(() => {
+    try {
+      const stored = JSON.parse(localStorage.getItem('dashboardPinnedReports') ?? 'null');
+      if (Array.isArray(stored)) return stored as PinnableReportId[];
+    } catch { /* fall through to the default */ }
+    return ['net-worth'];
+  });
+  const [showReportPicker, setShowReportPicker] = useState(false);
+  const reportsPeriod = usePeriod('dashboardReports', 'last-12-months');
+
+  const togglePinnedReport = (id: PinnableReportId): void => {
+    setPinnedReports(prev => {
+      const next = prev.includes(id) ? prev.filter(p => p !== id) : [...prev, id];
+      localStorage.setItem('dashboardPinnedReports', JSON.stringify(next));
+      return next;
+    });
+  };
   
   // Load saved preferences from localStorage
   useEffect(() => {
@@ -374,6 +406,93 @@ export function ImprovedDashboard() {
           </button>
         </div>
       </section>
+
+      {/* Pinned reports: the user's choice of live reports, at a glance.
+          Same shared maths as the full Reports hub — the glance and the full
+          view can never disagree. */}
+      <section
+        aria-labelledby="pinned-reports-heading"
+        className="bg-white dark:bg-gray-800 rounded-xl shadow-sm border border-gray-100 dark:border-gray-700 p-6"
+      >
+        <div className="flex flex-wrap items-center gap-3 mb-4">
+          <h3 id="pinned-reports-heading" className="text-lg font-semibold text-gray-900 dark:text-white flex items-center gap-2">
+            <BarChart3Icon size={24} className="text-gray-500" />
+            Your Reports
+          </h3>
+          <div className="ml-auto flex items-center gap-2">
+            {pinnedReports.length > 0 && <PeriodPicker picker={reportsPeriod} />}
+            <button
+              type="button"
+              onClick={() => setShowReportPicker(true)}
+              className="p-2 rounded-lg text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors"
+              title="Choose which reports appear here"
+              aria-label="Choose reports"
+            >
+              <SettingsIcon size={18} />
+            </button>
+          </div>
+        </div>
+
+        {pinnedReports.length === 0 ? (
+          <button
+            type="button"
+            onClick={() => setShowReportPicker(true)}
+            className="w-full justify-center py-8 text-sm text-gray-400 dark:text-gray-500 hover:text-gray-600 dark:hover:text-gray-300 transition-colors"
+          >
+            No reports pinned — click to choose the reports you want at a glance
+          </button>
+        ) : (
+          <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
+            {pinnedReports.map(id => {
+              if (id === 'net-worth') return <NetWorthWidget key={id} range={reportsPeriod.range} />;
+              if (id === 'income-expense-trend') return <IncomeExpenseTrendWidget key={id} range={reportsPeriod.range} />;
+              if (id === 'expense-categories') return <ExpenseCategoriesWidget key={id} range={reportsPeriod.range} />;
+              if (id.startsWith('custom:')) return <CustomReportWidget key={id} reportId={id.slice('custom:'.length)} />;
+              return null;
+            })}
+          </div>
+        )}
+      </section>
+
+      {/* Report picker */}
+      <Modal
+        isOpen={showReportPicker}
+        onClose={() => setShowReportPicker(false)}
+        title="Choose your dashboard reports"
+        size="sm"
+      >
+        <ModalBody>
+          <p className="text-sm text-gray-500 dark:text-gray-400 mb-3">
+            Pick the reports you want at a glance. They stay live and click through to the full report.
+          </p>
+          <div className="space-y-1">
+            {BUILT_IN_REPORTS.map(({ id, label, icon: Icon }) => (
+              <label key={id} className="flex items-center gap-3 py-2 px-2 -mx-2 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-700/40 cursor-pointer">
+                <input
+                  type="checkbox"
+                  checked={pinnedReports.includes(id)}
+                  onChange={() => togglePinnedReport(id)}
+                  className="rounded border-gray-300"
+                />
+                <Icon size={16} className="text-gray-500" />
+                <span className="text-sm text-gray-800 dark:text-gray-200">{label}</span>
+              </label>
+            ))}
+            {customReportService.getCustomReports().map(report => (
+              <label key={report.id} className="flex items-center gap-3 py-2 px-2 -mx-2 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-700/40 cursor-pointer">
+                <input
+                  type="checkbox"
+                  checked={pinnedReports.includes(`custom:${report.id}`)}
+                  onChange={() => togglePinnedReport(`custom:${report.id}`)}
+                  className="rounded border-gray-300"
+                />
+                <span className="text-sm text-gray-800 dark:text-gray-200 truncate">{report.name}</span>
+                <span className="ml-auto text-xs text-gray-400">custom</span>
+              </label>
+            ))}
+          </div>
+        </ModalBody>
+      </Modal>
 
       {/* Income/Expense breakdown — the shared component (category sections,
           sortable headings, click-to-edit) also used by the Reports page. */}

--- a/src/components/dashboard/reportWidgets/DashboardReportWidgets.tsx
+++ b/src/components/dashboard/reportWidgets/DashboardReportWidgets.tsx
@@ -1,0 +1,233 @@
+import React, { useMemo } from 'react';
+import { useNavigate, useLocation } from 'react-router-dom';
+import {
+  ResponsiveContainer,
+  LineChart,
+  Line,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  PieChart as RechartsPieChart,
+  Pie,
+  Cell,
+} from 'recharts';
+import { useApp } from '../../../contexts/AppContextSupabase';
+import { useCurrencyDecimal } from '../../../hooks/useCurrencyDecimal';
+import { preserveDemoParam } from '../../../utils/navigation';
+import { buildMonthlyTrend } from '../../../utils/monthlyTrend';
+import { buildNetWorthSnapshots } from '../../../utils/netWorthSeries';
+import { computeExpenseCategoryNetTotals } from '../../../utils/categoryNetting';
+import { expandSplitTransactions } from '../../../utils/transactionSplits';
+import { formatDecimal } from '../../../utils/decimal-format';
+import { customReportService } from '../../../services/customReportService';
+import type { PeriodRange } from '../../../hooks/usePeriod';
+import { ChevronRightIcon, TrendingUpIcon, PieChartIcon, BarChart3Icon, FileTextIcon } from '../../icons';
+
+/**
+ * Compact, live versions of the Reports-hub reports for the Dashboard's
+ * "pinned reports" section. Each widget computes from the SAME shared maths
+ * as its full report (utils/monthlyTrend, utils/netWorthSeries,
+ * utils/categoryNetting), so the glance and the full view can never
+ * disagree. Every card clicks through to the Reports hub.
+ */
+
+const CATEGORY_COLORS = [
+  '#3B82F6', '#10B981', '#F59E0B', '#EF4444',
+  '#8B5CF6', '#EC4899', '#6366F1', '#14B8A6'
+];
+
+const compactTick = (value: number): string => {
+  const abs = Math.abs(value);
+  const sign = value < 0 ? '-' : '';
+  if (abs >= 1_000_000) return `${sign}${formatDecimal(abs / 1_000_000, 1)}M`;
+  if (abs >= 1_000) return `${sign}${formatDecimal(abs / 1_000, 0)}K`;
+  return formatDecimal(value, 0);
+};
+
+/** Everything a pinned report can be. Custom reports use `custom:<id>`. */
+export type PinnableReportId = 'net-worth' | 'income-expense-trend' | 'expense-categories' | `custom:${string}`;
+
+export const BUILT_IN_REPORTS: Array<{ id: PinnableReportId; label: string; icon: React.ElementType }> = [
+  { id: 'net-worth', label: 'Net Worth Over Time', icon: TrendingUpIcon },
+  { id: 'income-expense-trend', label: 'Income vs Expenses Trend', icon: BarChart3Icon },
+  { id: 'expense-categories', label: 'Expense Categories', icon: PieChartIcon },
+];
+
+function WidgetCard({ title, icon: Icon, onOpen, children }: {
+  title: string;
+  icon: React.ElementType;
+  onOpen: () => void;
+  children: React.ReactNode;
+}): React.JSX.Element {
+  return (
+    <div className="bg-white dark:bg-gray-800 rounded-xl shadow-sm border border-gray-100 dark:border-gray-700 p-4 flex flex-col">
+      <button
+        type="button"
+        onClick={onOpen}
+        className="flex items-center gap-2 mb-2 text-left group"
+        title="Open the full report"
+      >
+        <Icon size={18} className="text-gray-500" />
+        <span className="text-sm font-semibold text-gray-900 dark:text-white group-hover:text-blue-600 dark:group-hover:text-blue-400 transition-colors">
+          {title}
+        </span>
+        <ChevronRightIcon size={14} className="text-gray-400 ml-auto" />
+      </button>
+      {children}
+    </div>
+  );
+}
+
+export function NetWorthWidget({ range }: { range: PeriodRange }): React.JSX.Element {
+  const { accounts, transactions } = useApp();
+  const { formatCurrency } = useCurrencyDecimal();
+  const navigate = useNavigate();
+  const location = useLocation();
+
+  const snapshots = useMemo(
+    () => buildNetWorthSnapshots(accounts, transactions, range),
+    [accounts, transactions, range]
+  );
+  const latest = snapshots.length > 0 ? snapshots[snapshots.length - 1] : null;
+
+  return (
+    <WidgetCard
+      title="Net Worth Over Time"
+      icon={TrendingUpIcon}
+      onOpen={() => navigate(preserveDemoParam('/reports', location.search))}
+    >
+      <p className="text-xl font-bold text-gray-900 dark:text-white mb-2">
+        {latest ? formatCurrency(latest.netWorth) : '—'}
+      </p>
+      <div className="h-36">
+        <ResponsiveContainer width="100%" height="100%">
+          <LineChart data={snapshots}>
+            <XAxis dataKey="label" tick={{ fill: '#6B7280', fontSize: 10 }} minTickGap={32} />
+            <YAxis tick={{ fill: '#6B7280', fontSize: 10 }} tickFormatter={compactTick} width={44} />
+            <Tooltip formatter={(v: number | string) => formatCurrency(typeof v === 'number' ? v : Number(v))} />
+            <Line type="monotone" dataKey="netWorth" name="Net Worth" stroke="#1a2332" strokeWidth={2} dot={false} isAnimationActive={false} />
+          </LineChart>
+        </ResponsiveContainer>
+      </div>
+    </WidgetCard>
+  );
+}
+
+export function IncomeExpenseTrendWidget({ range }: { range: PeriodRange }): React.JSX.Element {
+  const { transactions, transactionSplits, categories } = useApp();
+  const { formatCurrency } = useCurrencyDecimal();
+  const navigate = useNavigate();
+  const location = useLocation();
+
+  const data = useMemo(() => {
+    const rows = expandSplitTransactions(transactions, transactionSplits).filter(t => {
+      const time = new Date(t.date).getTime();
+      if (range.from && time < range.from.getTime()) return false;
+      if (range.to && time > range.to.getTime()) return false;
+      return true;
+    });
+    return buildMonthlyTrend(rows, categories);
+  }, [transactions, transactionSplits, categories, range]);
+
+  return (
+    <WidgetCard
+      title="Income vs Expenses"
+      icon={BarChart3Icon}
+      onOpen={() => navigate(preserveDemoParam('/reports', location.search))}
+    >
+      <div className="h-44">
+        <ResponsiveContainer width="100%" height="100%">
+          <LineChart data={data}>
+            <CartesianGrid strokeDasharray="3 3" stroke="rgba(107, 114, 128, 0.2)" />
+            <XAxis dataKey="month" tick={{ fill: '#6B7280', fontSize: 10 }} minTickGap={32} />
+            <YAxis tick={{ fill: '#6B7280', fontSize: 10 }} tickFormatter={compactTick} width={44} />
+            <Tooltip formatter={(v: number | string) => formatCurrency(typeof v === 'number' ? v : Number(v))} />
+            <Line type="monotone" dataKey="income" name="Income" stroke="#10B981" strokeWidth={2} dot={false} isAnimationActive={false} />
+            <Line type="monotone" dataKey="expenses" name="Expenses" stroke="#EF4444" strokeWidth={2} dot={false} isAnimationActive={false} />
+          </LineChart>
+        </ResponsiveContainer>
+      </div>
+    </WidgetCard>
+  );
+}
+
+export function ExpenseCategoriesWidget({ range }: { range: PeriodRange }): React.JSX.Element {
+  const { transactions, transactionSplits, categories } = useApp();
+  const { formatCurrency } = useCurrencyDecimal();
+  const navigate = useNavigate();
+  const location = useLocation();
+
+  const data = useMemo(() => {
+    const rows = expandSplitTransactions(transactions, transactionSplits).filter(t => {
+      const time = new Date(t.date).getTime();
+      if (range.from && time < range.from.getTime()) return false;
+      if (range.to && time > range.to.getTime()) return false;
+      return true;
+    });
+    return computeExpenseCategoryNetTotals(rows, categories)
+      .slice(0, 6)
+      .map(({ key, name, value }) => ({ categoryId: key, name, value }));
+  }, [transactions, transactionSplits, categories, range]);
+
+  return (
+    <WidgetCard
+      title="Expense Categories"
+      icon={PieChartIcon}
+      onOpen={() => navigate(preserveDemoParam('/reports', location.search))}
+    >
+      {data.length === 0 ? (
+        <p className="text-center py-10 text-sm text-gray-400">No categorised spending in this period</p>
+      ) : (
+        <div className="flex items-center gap-3 h-44">
+          <div className="h-full flex-1 min-w-0">
+            <ResponsiveContainer width="100%" height="100%">
+              <RechartsPieChart>
+                <Pie data={data} dataKey="value" nameKey="name" innerRadius="55%" outerRadius="88%" strokeWidth={0} isAnimationActive={false}>
+                  {data.map((entry, index) => (
+                    <Cell key={entry.name} fill={CATEGORY_COLORS[index % CATEGORY_COLORS.length]} />
+                  ))}
+                </Pie>
+                <Tooltip formatter={(v: number | string) => formatCurrency(typeof v === 'number' ? v : Number(v))} />
+              </RechartsPieChart>
+            </ResponsiveContainer>
+          </div>
+          <ul className="w-36 space-y-1">
+            {data.slice(0, 5).map((d, i) => (
+              <li key={d.categoryId} className="flex items-center gap-1.5 text-xs text-gray-600 dark:text-gray-300">
+                <span className="w-2 h-2 rounded-sm flex-shrink-0" style={{ backgroundColor: CATEGORY_COLORS[i % CATEGORY_COLORS.length] }} />
+                <span className="truncate">{d.name}</span>
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+    </WidgetCard>
+  );
+}
+
+/** A pinned custom report: name + description, click-through to the hub. */
+export function CustomReportWidget({ reportId }: { reportId: string }): React.JSX.Element | null {
+  const navigate = useNavigate();
+  const location = useLocation();
+  const report = useMemo(
+    () => customReportService.getCustomReports().find(r => r.id === reportId) ?? null,
+    [reportId]
+  );
+  if (!report) return null;
+
+  return (
+    <WidgetCard
+      title={report.name}
+      icon={FileTextIcon}
+      onOpen={() => navigate(preserveDemoParam('/reports', location.search))}
+    >
+      <p className="text-sm text-gray-500 dark:text-gray-400">
+        {report.description || 'Custom report'}
+      </p>
+      <p className="mt-2 text-xs text-gray-400 dark:text-gray-500">
+        {report.components.length} component{report.components.length === 1 ? '' : 's'} — open to generate
+      </p>
+    </WidgetCard>
+  );
+}

--- a/src/pages/NetWorthReport.tsx
+++ b/src/pages/NetWorthReport.tsx
@@ -19,6 +19,7 @@ import { Modal, ModalBody } from '../components/common/Modal';
 import { toDecimal } from '../utils/decimal';
 import { formatDecimal } from '../utils/decimal-format';
 import { preserveDemoParam } from '../utils/navigation';
+import { buildNetWorthSnapshots } from '../utils/netWorthSeries';
 import { CalendarIcon, TrendingUpIcon, ChevronRightIcon } from '../components/icons';
 
 /**
@@ -33,13 +34,6 @@ import { CalendarIcon, TrendingUpIcon, ChevronRightIcon } from '../components/ic
  * click an account to open its register.
  */
 
-interface Snapshot {
-  date: Date;
-  label: string;
-  netWorth: number;
-  assets: number;
-  liabilities: number;
-}
 
 const compactTick = (value: number): string => {
   const abs = Math.abs(value);
@@ -82,66 +76,10 @@ export default function NetWorthReport(): React.JSX.Element {
     [transactions]
   );
 
-  const snapshots = useMemo<Snapshot[]>(() => {
-    if (accounts.length === 0) return [];
-
-    const now = new Date();
-    const firstTxnDate = sortedTransactions.length > 0 ? new Date(sortedTransactions[0].date) : now;
-    const start = picker.range.from ?? firstTxnDate;
-    const end = picker.range.to ?? now;
-    if (start > end) return [];
-
-    // Point cadence: daily for short windows, month-end beyond ~3 months
-    // (Money's cadence), always ending on the window's final day.
-    const spanDays = (end.getTime() - start.getTime()) / 86_400_000;
-    const points: Date[] = [];
-    if (spanDays <= 92) {
-      for (const d = new Date(start); d <= end; d.setDate(d.getDate() + 1)) {
-        points.push(new Date(d));
-      }
-    } else {
-      // End of each month from the start month onward.
-      const cursor = new Date(start.getFullYear(), start.getMonth() + 1, 0);
-      while (cursor < end) {
-        points.push(new Date(cursor));
-        cursor.setMonth(cursor.getMonth() + 2, 0);
-      }
-      points.push(new Date(end));
-    }
-
-    // One forward walk: balances accumulate from the very beginning (a
-    // point's balance includes ALL history before it, not just the window).
-    const balances = new Map(accounts.map(a => [a.id, toDecimal(a.openingBalance ?? 0)]));
-    const monthly = spanDays > 92;
-    let i = 0;
-    const out: Snapshot[] = [];
-    for (const point of points) {
-      const cutoff = new Date(point);
-      cutoff.setHours(23, 59, 59, 999);
-      while (i < sortedTransactions.length && new Date(sortedTransactions[i].date) <= cutoff) {
-        const t = sortedTransactions[i];
-        const bal = balances.get(t.accountId);
-        if (bal !== undefined) balances.set(t.accountId, bal.plus(toDecimal(t.amount)));
-        i++;
-      }
-      let assets = toDecimal(0);
-      let liabilities = toDecimal(0);
-      for (const b of balances.values()) {
-        if (b.greaterThan(0)) assets = assets.plus(b);
-        else liabilities = liabilities.plus(b.abs());
-      }
-      out.push({
-        date: point,
-        label: point.toLocaleDateString('en-GB', monthly
-          ? { month: 'short', year: '2-digit' }
-          : { day: '2-digit', month: 'short' }),
-        assets: assets.toNumber(),
-        liabilities: liabilities.toNumber(),
-        netWorth: assets.minus(liabilities).toNumber(),
-      });
-    }
-    return out;
-  }, [accounts, sortedTransactions, picker.range]);
+  const snapshots = useMemo(
+    () => buildNetWorthSnapshots(accounts, sortedTransactions, picker.range),
+    [accounts, sortedTransactions, picker.range]
+  );
 
   // Per-account balances at the drilled date (same cumulative rule).
   const drillBalances = useMemo(() => {

--- a/src/pages/Reports.tsx
+++ b/src/pages/Reports.tsx
@@ -20,7 +20,8 @@ import {
 import { useCurrencyDecimal } from '../hooks/useCurrencyDecimal';
 import { toDecimal, DecimalInstance } from '../utils/decimal';
 import { formatDecimal } from '../utils/decimal-format';
-import { computeExpenseCategoryNetTotals, bucketByCategoryDirection } from '../utils/categoryNetting';
+import { computeExpenseCategoryNetTotals } from '../utils/categoryNetting';
+import { buildMonthlyTrend } from '../utils/monthlyTrend';
 import { computeIncomeExpense } from '../utils/incomeExpense';
 import { usePeriod, PERIOD_LABELS } from '../hooks/usePeriod';
 import PeriodPicker from '../components/PeriodPicker';
@@ -163,37 +164,12 @@ export default function Reports() {
       }
     };
 
-  // Prepare data for monthly trend — same category-direction netting as the
-  // summary and the pie, so all three views on this page agree.
-  const monthlyTrendData = useMemo(() => {
-    const monthlyData: Record<string, { income: DecimalInstance; expenses: DecimalInstance }> = {};
-    const categoryById = new Map(categories.map(c => [c.id, c]));
-
-    filteredTransactions.forEach(t => {
-      const bucket = bucketByCategoryDirection(t, categoryById);
-      if (bucket === 'transfer') return;
-      const monthKey = new Date(t.date).toISOString().slice(0, 7);
-      if (!monthlyData[monthKey]) {
-        monthlyData[monthKey] = { income: toDecimal(0), expenses: toDecimal(0) };
-      }
-
-      if (bucket === 'income') {
-        monthlyData[monthKey].income = monthlyData[monthKey].income.plus(t.amount);
-      } else {
-        // Spending is negative; negate so refunds net the month down.
-        monthlyData[monthKey].expenses = monthlyData[monthKey].expenses.minus(t.amount);
-      }
-    });
-
-    const sortedMonths = Object.keys(monthlyData).sort();
-
-    return sortedMonths.map(month => ({
-      monthKey: month, // raw YYYY-MM, drives the click-to-drill filter
-      month: new Date(month + '-01').toLocaleDateString('en-GB', { month: 'short', year: 'numeric' }),
-      income: monthlyData[month].income.toNumber(),
-      expenses: monthlyData[month].expenses.toNumber()
-    }));
-  }, [filteredTransactions, categories]);
+  // Monthly trend via the shared builder (also drives the Dashboard's pinned
+  // trend widget — one implementation, no drift).
+  const monthlyTrendData = useMemo(
+    () => buildMonthlyTrend(filteredTransactions, categories),
+    [filteredTransactions, categories]
+  );
 
   const exportToCSV = () => {
     const csv = exportTransactionsToCSV(filteredTransactions, accounts);

--- a/src/utils/monthlyTrend.ts
+++ b/src/utils/monthlyTrend.ts
@@ -1,0 +1,49 @@
+import type { Category, Transaction } from '../types';
+import { toDecimal, type DecimalInstance } from './decimal';
+import { bucketByCategoryDirection } from './categoryNetting';
+
+export interface MonthlyTrendPoint {
+  /** Raw YYYY-MM — drives click-to-drill filters. */
+  monthKey: string;
+  /** Display label, e.g. "Jul 2026". */
+  month: string;
+  income: number;
+  expenses: number;
+}
+
+/**
+ * Month-by-month income/expenses under the app's category semantics (shared
+ * classifier; transfers and uncategorised rows never count). Used by the
+ * Reports trend chart and the Dashboard's pinned trend widget — one
+ * implementation so the two can never disagree.
+ *
+ * `rows` must already be split-expanded (each split line lands in ITS
+ * category's month).
+ */
+export function buildMonthlyTrend(rows: Transaction[], categories: Category[]): MonthlyTrendPoint[] {
+  const monthlyData: Record<string, { income: DecimalInstance; expenses: DecimalInstance }> = {};
+  const categoryById = new Map(categories.map(c => [c.id, c]));
+
+  rows.forEach(t => {
+    const bucket = bucketByCategoryDirection(t, categoryById);
+    if (bucket !== 'income' && bucket !== 'expense') return;
+    const monthKey = new Date(t.date).toISOString().slice(0, 7);
+    if (!monthlyData[monthKey]) {
+      monthlyData[monthKey] = { income: toDecimal(0), expenses: toDecimal(0) };
+    }
+
+    if (bucket === 'income') {
+      monthlyData[monthKey].income = monthlyData[monthKey].income.plus(t.amount);
+    } else {
+      // Spending is negative; negate so refunds net the month down.
+      monthlyData[monthKey].expenses = monthlyData[monthKey].expenses.minus(t.amount);
+    }
+  });
+
+  return Object.keys(monthlyData).sort().map(month => ({
+    monthKey: month,
+    month: new Date(month + '-01').toLocaleDateString('en-GB', { month: 'short', year: 'numeric' }),
+    income: monthlyData[month].income.toNumber(),
+    expenses: monthlyData[month].expenses.toNumber(),
+  }));
+}

--- a/src/utils/netWorthSeries.ts
+++ b/src/utils/netWorthSeries.ts
@@ -1,0 +1,86 @@
+import type { Account, Transaction } from '../types';
+import { toDecimal } from './decimal';
+import type { PeriodRange } from '../hooks/usePeriod';
+
+export interface NetWorthSnapshot {
+  date: Date;
+  label: string;
+  netWorth: number;
+  assets: number;
+  liabilities: number;
+}
+
+/**
+ * Net worth over time from first principles: per-account running balance
+ * (opening balance + cumulative transactions, Decimal throughout) snapshotted
+ * at each point in the period. One forward walk — balances accumulate from
+ * the very beginning, so a point inside the window carries ALL history
+ * before it. Shared by the Net Worth report and the Dashboard's pinned
+ * net-worth widget.
+ *
+ * Point cadence: daily for windows under ~3 months, month-end beyond (the
+ * Money cadence), always ending on the window's final day.
+ */
+export function buildNetWorthSnapshots(
+  accounts: Account[],
+  transactions: Transaction[],
+  range: PeriodRange,
+  now: Date = new Date()
+): NetWorthSnapshot[] {
+  if (accounts.length === 0) return [];
+
+  const sorted = [...transactions].sort(
+    (a, b) => new Date(a.date).getTime() - new Date(b.date).getTime()
+  );
+
+  const firstTxnDate = sorted.length > 0 ? new Date(sorted[0].date) : now;
+  const start = range.from ?? firstTxnDate;
+  const end = range.to ?? now;
+  if (start > end) return [];
+
+  const spanDays = (end.getTime() - start.getTime()) / 86_400_000;
+  const points: Date[] = [];
+  if (spanDays <= 92) {
+    for (const d = new Date(start); d <= end; d.setDate(d.getDate() + 1)) {
+      points.push(new Date(d));
+    }
+  } else {
+    const cursor = new Date(start.getFullYear(), start.getMonth() + 1, 0);
+    while (cursor < end) {
+      points.push(new Date(cursor));
+      cursor.setMonth(cursor.getMonth() + 2, 0);
+    }
+    points.push(new Date(end));
+  }
+
+  const balances = new Map(accounts.map(a => [a.id, toDecimal(a.openingBalance ?? 0)]));
+  const monthly = spanDays > 92;
+  let i = 0;
+  const out: NetWorthSnapshot[] = [];
+  for (const point of points) {
+    const cutoff = new Date(point);
+    cutoff.setHours(23, 59, 59, 999);
+    while (i < sorted.length && new Date(sorted[i].date) <= cutoff) {
+      const t = sorted[i];
+      const bal = balances.get(t.accountId);
+      if (bal !== undefined) balances.set(t.accountId, bal.plus(toDecimal(t.amount)));
+      i++;
+    }
+    let assets = toDecimal(0);
+    let liabilities = toDecimal(0);
+    for (const b of balances.values()) {
+      if (b.greaterThan(0)) assets = assets.plus(b);
+      else liabilities = liabilities.plus(b.abs());
+    }
+    out.push({
+      date: point,
+      label: point.toLocaleDateString('en-GB', monthly
+        ? { month: 'short', year: '2-digit' }
+        : { day: '2-digit', month: 'short' }),
+      assets: assets.toNumber(),
+      liabilities: liabilities.toNumber(),
+      netWorth: assets.minus(liabilities).toNumber(),
+    });
+  }
+  return out;
+}


### PR DESCRIPTION
**Your item 4**: *"give the user the option to choose which report they want to see on the Dashboard screen… whichever is most important to them they can see at a glance… That is to then include custom reports. What is important is different to different users."*

## What lands
- A new **"Your Reports"** Dashboard section. The gear opens a picker listing every live report — **Net Worth Over Time, Income vs Expenses Trend, Expense Categories, plus each saved custom report** — as checkboxes. Selection persists per browser; the default pins Net Worth (your Money favourite). The empty state invites picking.
- Pinned built-ins render as **compact live widgets** with their own shared period picker (defaults to 12 months, persisted). Every card clicks through to the full report in the hub.
- **One set of maths**: the trend logic moved into `utils/monthlyTrend.ts` and the net-worth walk into `utils/netWorthSeries.ts` — the Reports pages and the Dashboard widgets consume the same builders, so the glance and the full view can never disagree (verified: widget and full report matched exactly on identical data).
- Custom reports pin as name/description cards linking to the hub for now, because **the custom-report viewer doesn't exist yet** — the Custom Reports "Generate" button computes data and then just shows a toast. Building that viewer (which would upgrade pinned customs to live charts) is flagged as its own follow-up.

## Verification
Browser-verified: default Net Worth widget renders and matches the full report; picker lists all three built-ins; pinning renders all three live widgets; outside-click closes the picker (the new app-wide modal behaviour); selection survives reload. Strict types, lint, smoke (3,106), build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)