### PR TITLE
feat(transactions): bulk transfer matching — link equal-and-opposite pairs in one sweep

### DIFF
--- a/src/components/TransferSweepModal.tsx
+++ b/src/components/TransferSweepModal.tsx
@@ -1,0 +1,212 @@
+import React, { useMemo, useState } from 'react';
+import { Modal, ModalBody, ModalFooter } from './common/Modal';
+import { useApp } from '../contexts/AppContextSupabase';
+import { useToast } from '../contexts/ToastContext';
+import { useCurrencyDecimal } from '../hooks/useCurrencyDecimal';
+import { sweepTransferPairs, type TransferPairSuggestion } from '../utils/transferSweep';
+import { AlertTriangleIcon, ArrowRightIcon } from './icons';
+
+/**
+ * Bulk transfer matching: find every unlinked equal-and-opposite pair in the
+ * history, let the user review and deselect, then link them all.
+ *
+ * Nothing links without an explicit tick. Ambiguous pairs (an equally-good
+ * alternative existed) start UNSELECTED and are badged, because a wrong link
+ * silently rewrites the meaning of two accounts.
+ */
+
+interface Props {
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+const CAP = 300;
+
+export default function TransferSweepModal({ isOpen, onClose }: Props): React.JSX.Element {
+  const { transactions, categories, accounts, linkTransferPair } = useApp();
+  const { formatCurrency } = useCurrencyDecimal();
+  const { showSuccess, showError } = useToast();
+  const [selected, setSelected] = useState<Set<string> | null>(null);
+  const [applying, setApplying] = useState(false);
+  const [progress, setProgress] = useState(0);
+
+  const accountName = useMemo(() => {
+    const byId = new Map(accounts.map(a => [a.id, a.name]));
+    return (id: string): string => byId.get(id) ?? 'Unknown account';
+  }, [accounts]);
+
+  const { suggestions } = useMemo(() => {
+    if (!isOpen) return { suggestions: [] as TransferPairSuggestion[] };
+    return sweepTransferPairs(transactions, {
+      onlyUncategorised: true,
+      categoryIds: new Set(categories.map(c => c.id)),
+    });
+  }, [isOpen, transactions, categories]);
+
+  const keyOf = (s: TransferPairSuggestion): string => `${s.outgoing.id}|${s.incoming.id}`;
+
+  // Default selection: every unambiguous pair.
+  const effectiveSelected = selected ?? new Set(
+    suggestions.filter(s => !s.ambiguous).map(keyOf)
+  );
+
+  const toggle = (key: string): void => {
+    const next = new Set(effectiveSelected);
+    if (next.has(key)) next.delete(key);
+    else next.add(key);
+    setSelected(next);
+  };
+
+  const visible = suggestions.slice(0, CAP);
+  const chosen = suggestions.filter(s => effectiveSelected.has(keyOf(s)));
+
+  const handleApply = async (): Promise<void> => {
+    setApplying(true);
+    setProgress(0);
+    let linked = 0;
+    let failed = 0;
+    try {
+      for (const pair of chosen) {
+        try {
+          await linkTransferPair(pair.outgoing.id, pair.incoming.id);
+          linked++;
+        } catch {
+          failed++;
+        }
+        setProgress(linked + failed);
+      }
+      if (linked > 0) {
+        showSuccess(
+          `${linked.toLocaleString()} transfer pair${linked === 1 ? '' : 's'} linked${failed > 0 ? ` — ${failed} could not be linked` : ''}.`,
+          'Transfers matched'
+        );
+      }
+      if (linked === 0 && failed > 0) {
+        showError(new Error('No pairs could be linked. Please try again.'));
+      }
+      onClose();
+    } finally {
+      setApplying(false);
+    }
+  };
+
+  return (
+    <Modal
+      isOpen={isOpen}
+      onClose={applying ? () => {} : onClose}
+      closeOnBackdrop={!applying}
+      title="Match transfers"
+      size="xl"
+    >
+      <ModalBody>
+        {suggestions.length === 0 ? (
+          <p className="text-center py-10 text-gray-500 dark:text-gray-400">
+            No unlinked transfer pairs found. Every equal-and-opposite movement in your
+            history is already linked.
+          </p>
+        ) : (
+          <>
+            <p className="text-sm text-gray-600 dark:text-gray-400 mb-3">
+              Found <strong>{suggestions.length.toLocaleString()}</strong> likely transfer
+              pair{suggestions.length === 1 ? '' : 's'} — uncategorised rows that are exactly
+              equal and opposite, in different accounts, within a few days. Linking them
+              makes both sides transfers, so they leave your income and expense totals.
+            </p>
+            <div className="overflow-x-auto">
+              <table className="w-full">
+                <thead>
+                  <tr className="text-xs text-gray-500 dark:text-gray-400 border-b border-gray-100 dark:border-gray-700">
+                    <th className="pb-2 w-8"></th>
+                    <th className="text-left pb-2 font-medium">Date</th>
+                    <th className="text-left pb-2 font-medium">From → To</th>
+                    <th className="text-left pb-2 font-medium">Description</th>
+                    <th className="text-right pb-2 font-medium">Amount</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {visible.map(s => {
+                    const key = keyOf(s);
+                    return (
+                      <tr key={key} className="border-b border-gray-50 dark:border-gray-700/50">
+                        <td className="py-2">
+                          <input
+                            type="checkbox"
+                            checked={effectiveSelected.has(key)}
+                            onChange={() => toggle(key)}
+                            disabled={applying}
+                            aria-label={`Link ${formatCurrency(Math.abs(s.outgoing.amount))} transfer`}
+                            className="rounded border-gray-300"
+                          />
+                        </td>
+                        <td className="py-2 text-sm text-gray-500 dark:text-gray-400 whitespace-nowrap">
+                          {new Date(s.outgoing.date).toLocaleDateString('en-GB', { day: '2-digit', month: 'short', year: '2-digit' })}
+                          {s.daysApart > 0 && (
+                            <span className="ml-1 text-xs text-gray-400">+{Math.round(s.daysApart)}d</span>
+                          )}
+                        </td>
+                        <td className="py-2 text-sm text-gray-700 dark:text-gray-300">
+                          <span className="inline-flex items-center gap-1 whitespace-nowrap">
+                            <span className="truncate max-w-[140px]">{accountName(s.outgoing.accountId)}</span>
+                            <ArrowRightIcon size={12} className="text-gray-400 flex-shrink-0" />
+                            <span className="truncate max-w-[140px]">{accountName(s.incoming.accountId)}</span>
+                          </span>
+                          {s.ambiguous && (
+                            <span className="ml-2 inline-flex items-center gap-1 text-xs text-amber-600 dark:text-amber-400">
+                              <AlertTriangleIcon size={12} />
+                              check
+                            </span>
+                          )}
+                        </td>
+                        <td className="py-2 text-sm text-gray-600 dark:text-gray-400">
+                          <span className="block truncate max-w-[220px]">{s.outgoing.description}</span>
+                        </td>
+                        <td className="py-2 text-sm font-medium text-right tabular-nums text-gray-900 dark:text-white whitespace-nowrap">
+                          {formatCurrency(Math.abs(s.outgoing.amount))}
+                        </td>
+                      </tr>
+                    );
+                  })}
+                  {suggestions.length > CAP && (
+                    <tr>
+                      <td colSpan={5} className="py-3 text-center text-xs text-gray-400 dark:text-gray-500">
+                        Showing the first {CAP.toLocaleString()} of {suggestions.length.toLocaleString()} pairs —
+                        link these, then run the sweep again for the rest.
+                      </td>
+                    </tr>
+                  )}
+                </tbody>
+              </table>
+            </div>
+          </>
+        )}
+      </ModalBody>
+      <ModalFooter>
+        <div className="flex items-center gap-3">
+          <p className="text-sm text-gray-600 dark:text-gray-400">
+            {applying
+              ? `Linking ${progress.toLocaleString()} of ${chosen.length.toLocaleString()}…`
+              : `${chosen.length.toLocaleString()} of ${Math.min(suggestions.length, CAP).toLocaleString()} selected`}
+          </p>
+          <div className="ml-auto flex items-center gap-2">
+            <button
+              type="button"
+              onClick={onClose}
+              disabled={applying}
+              className="px-4 py-2 text-sm font-medium rounded-lg border border-gray-300 dark:border-gray-600 text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors disabled:opacity-50"
+            >
+              Cancel
+            </button>
+            <button
+              type="button"
+              onClick={() => void handleApply()}
+              disabled={applying || chosen.length === 0}
+              className="justify-center px-4 py-2 text-sm font-medium rounded-lg bg-[#1a2332] dark:bg-blue-600 text-white hover:bg-[#2d3a4d] dark:hover:bg-blue-700 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+            >
+              {applying ? 'Linking…' : `Link ${chosen.length.toLocaleString()} pair${chosen.length === 1 ? '' : 's'}`}
+            </button>
+          </div>
+        </div>
+      </ModalFooter>
+    </Modal>
+  );
+}

--- a/src/pages/Reports.tsx
+++ b/src/pages/Reports.tsx
@@ -27,6 +27,7 @@ import { usePeriod, PERIOD_LABELS } from '../hooks/usePeriod';
 import PeriodPicker from '../components/PeriodPicker';
 import EditTransactionModal from '../components/EditTransactionModal';
 import IncomeExpenseBreakdownModal from '../components/IncomeExpenseBreakdownModal';
+import TransferSweepModal from '../components/TransferSweepModal';
 import { expandSplitTransactions } from '../utils/transactionSplits';
 import { createScopedLogger } from '../loggers/scopedLogger';
 
@@ -61,6 +62,7 @@ export default function Reports() {
     total: number;
   } | null>(null);
   const [editingBreakdownTxnId, setEditingBreakdownTxnId] = useState<string | null>(null);
+  const [showTransferSweep, setShowTransferSweep] = useState(false);
   const [isLoading, setIsLoading] = useState(true);
   const chartRef1 = useRef<HTMLDivElement>(null);
   const chartRef2 = useRef<HTMLDivElement>(null);
@@ -342,6 +344,18 @@ export default function Reports() {
           </button>
         )}
 
+        {/* Bulk transfer matching — the biggest single cause of uncategorised
+            rows is bank-feed transfer legs that were never linked. */}
+        {flows.uncategorizedRows.length > 0 && (
+          <button
+            type="button"
+            onClick={() => setShowTransferSweep(true)}
+            className="text-sm text-blue-700 dark:text-blue-400 hover:underline text-left"
+          >
+            Or match transfers automatically — find equal-and-opposite pairs and link them in one go
+          </button>
+        )}
+
         {/* Charts */}
         <div className="pt-4">
           <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
@@ -556,6 +570,11 @@ export default function Reports() {
         total={chartDrill?.total ?? 0}
         categories={categories}
         onEditTransaction={setEditingBreakdownTxnId}
+      />
+
+      <TransferSweepModal
+        isOpen={showTransferSweep}
+        onClose={() => setShowTransferSweep(false)}
       />
 
       {/* Edit a transaction straight from the breakdown list */}

--- a/src/utils/transferSweep.test.ts
+++ b/src/utils/transferSweep.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect } from 'vitest';
+import { sweepTransferPairs } from './transferSweep';
+import type { Transaction } from '../types';
+
+const txn = (over: Partial<Transaction> & { id: string }): Transaction => ({
+  date: new Date('2026-07-10'),
+  amount: -100,
+  description: 'Transfer',
+  category: '',
+  accountId: 'acc-a',
+  type: 'expense',
+  ...over,
+});
+
+describe('sweepTransferPairs', () => {
+  it('pairs equal-and-opposite rows across accounts, orienting out/in', () => {
+    const { suggestions } = sweepTransferPairs([
+      txn({ id: 'out', amount: -500, accountId: 'acc-a', description: 'Transfer to 5755' }),
+      txn({ id: 'in', amount: 500, accountId: 'acc-b', type: 'income', description: 'Faster payment received' }),
+    ]);
+    expect(suggestions).toHaveLength(1);
+    expect(suggestions[0].outgoing.id).toBe('out');
+    expect(suggestions[0].incoming.id).toBe('in');
+    expect(suggestions[0].daysApart).toBe(0);
+  });
+
+  it('never pairs within the same account', () => {
+    const { suggestions } = sweepTransferPairs([
+      txn({ id: 'a', amount: -500, accountId: 'acc-a' }),
+      txn({ id: 'b', amount: 500, accountId: 'acc-a', type: 'income' }),
+    ]);
+    expect(suggestions).toHaveLength(0);
+  });
+
+  it('respects the date window', () => {
+    const near = sweepTransferPairs([
+      txn({ id: 'a', amount: -500, date: new Date('2026-07-10') }),
+      txn({ id: 'b', amount: 500, accountId: 'acc-b', type: 'income', date: new Date('2026-07-13') }),
+    ]);
+    expect(near.suggestions).toHaveLength(1);
+
+    const far = sweepTransferPairs([
+      txn({ id: 'a', amount: -500, date: new Date('2026-07-10') }),
+      txn({ id: 'b', amount: 500, accountId: 'acc-b', type: 'income', date: new Date('2026-07-20') }),
+    ]);
+    expect(far.suggestions).toHaveLength(0);
+  });
+
+  it('skips already-linked, split, transfer-typed and zero rows', () => {
+    const { suggestions, scanned } = sweepTransferPairs([
+      txn({ id: 'linked', amount: -500, linkedTransferId: 'x' }),
+      txn({ id: 'split', amount: -500, isSplit: true }),
+      txn({ id: 'transfer', amount: -500, type: 'transfer' }),
+      txn({ id: 'zero', amount: 0 }),
+      txn({ id: 'match', amount: 500, accountId: 'acc-b', type: 'income' }),
+    ]);
+    expect(scanned).toBe(1);           // only 'match' is eligible
+    expect(suggestions).toHaveLength(0); // and it has no partner
+  });
+
+  it('uses each row at most once — three candidates yield one pair, not three', () => {
+    const { suggestions } = sweepTransferPairs([
+      txn({ id: 'out', amount: -100, accountId: 'acc-a' }),
+      txn({ id: 'in1', amount: 100, accountId: 'acc-b', type: 'income' }),
+      txn({ id: 'in2', amount: 100, accountId: 'acc-c', type: 'income' }),
+    ]);
+    expect(suggestions).toHaveLength(1);
+    expect(['in1', 'in2']).toContain(suggestions[0].incoming.id);
+  });
+
+  it('flags ambiguity when two candidates are equally good', () => {
+    const { suggestions } = sweepTransferPairs([
+      txn({ id: 'out', amount: -100, accountId: 'acc-a', description: 'Transfer' }),
+      txn({ id: 'in1', amount: 100, accountId: 'acc-b', type: 'income', description: 'Transfer' }),
+      txn({ id: 'in2', amount: 100, accountId: 'acc-c', type: 'income', description: 'Transfer' }),
+    ]);
+    expect(suggestions[0].ambiguous).toBe(true);
+  });
+
+  it('closest date wins over description similarity', () => {
+    const { suggestions } = sweepTransferPairs([
+      txn({ id: 'out', amount: -100, accountId: 'acc-a', date: new Date('2026-07-10'), description: 'Transfer to savings' }),
+      txn({ id: 'far-exact', amount: 100, accountId: 'acc-b', type: 'income', date: new Date('2026-07-13'), description: 'Transfer to savings' }),
+      txn({ id: 'near', amount: 100, accountId: 'acc-c', type: 'income', date: new Date('2026-07-10'), description: 'FPS credit' }),
+    ]);
+    expect(suggestions[0].incoming.id).toBe('near');
+  });
+
+  it('onlyUncategorised skips rows that carry a real category', () => {
+    const categoryIds = new Set(['cat-groceries']);
+    const { suggestions } = sweepTransferPairs([
+      txn({ id: 'out', amount: -100, category: 'cat-groceries' }),
+      txn({ id: 'in', amount: 100, accountId: 'acc-b', type: 'income' }),
+    ], { onlyUncategorised: true, categoryIds });
+    expect(suggestions).toHaveLength(0);
+
+    // A dangling category id still counts as uncategorised.
+    const dangling = sweepTransferPairs([
+      txn({ id: 'out', amount: -100, category: 'gone' }),
+      txn({ id: 'in', amount: 100, accountId: 'acc-b', type: 'income' }),
+    ], { onlyUncategorised: true, categoryIds });
+    expect(dangling.suggestions).toHaveLength(1);
+  });
+});

--- a/src/utils/transferSweep.ts
+++ b/src/utils/transferSweep.ts
@@ -1,0 +1,147 @@
+import { toDecimal } from './decimal';
+import { calculateStringSimilarity } from './duplicateScan';
+import type { Transaction } from '../types';
+
+/**
+ * Bulk transfer matching — find every unlinked equal-and-opposite pair in one
+ * sweep, so a bank-feed history full of un-paired "Transfer (Online) to/from"
+ * rows can be cleaned in one pass instead of one transaction at a time.
+ *
+ * The single-transaction path (utils/transferMatch) answers "is the other
+ * side of THIS transfer already here?". This answers "which rows in my whole
+ * history are obviously two sides of the same movement?" — the pairing rules
+ * are deliberately strict, because a wrong link silently rewrites two
+ * accounts' meaning:
+ *
+ *  - amounts are EXACTLY opposite (Decimal, no float slack) and non-zero;
+ *  - the two sides are in DIFFERENT accounts;
+ *  - dates within `windowDays` (bank clearing lag);
+ *  - neither side already linked, a split parent, or typed 'transfer';
+ *  - each row is used at most once — closest date wins, description
+ *    similarity breaks ties, and a row with several equally-good candidates
+ *    is reported as AMBIGUOUS rather than guessed at.
+ *
+ * Nothing is mutated here: the caller reviews, deselects, then applies.
+ */
+
+export interface TransferPairSuggestion {
+  /** The money-out side. */
+  outgoing: Transaction;
+  /** The money-in side. */
+  incoming: Transaction;
+  /** Whole/fractional days between the two dates. */
+  daysApart: number;
+  /** 0–100 description similarity (tie-break/confidence only). */
+  descriptionScore: number;
+  /** True when other equally-close candidates existed for this row. */
+  ambiguous: boolean;
+}
+
+export interface TransferSweepResult {
+  suggestions: TransferPairSuggestion[];
+  /** Rows considered (unlinked, uncategorised-or-not, non-split). */
+  scanned: number;
+}
+
+const DAY_MS = 1000 * 60 * 60 * 24;
+export const SWEEP_WINDOW_DAYS = 4;
+
+const pennies = (amount: number): number => toDecimal(amount).times(100).toDecimalPlaces(0).toNumber();
+
+export function sweepTransferPairs(
+  transactions: Transaction[],
+  opts: { windowDays?: number; onlyUncategorised?: boolean; categoryIds?: Set<string> } = {}
+): TransferSweepResult {
+  const windowDays = opts.windowDays ?? SWEEP_WINDOW_DAYS;
+
+  const eligible = transactions.filter(t => {
+    if (t.isSplit) return false;
+    if (t.linkedTransferId) return false;
+    if (t.type === 'transfer') return false;
+    if (toDecimal(t.amount).isZero()) return false;
+    if (opts.onlyUncategorised) {
+      const hasRealCategory = !!t.category && (!opts.categoryIds || opts.categoryIds.has(t.category));
+      if (hasRealCategory) return false;
+    }
+    return true;
+  });
+
+  // Bucket by exact penny amount so each row only inspects its opposites.
+  const byAmount = new Map<number, Transaction[]>();
+  for (const t of eligible) {
+    const key = pennies(t.amount);
+    const list = byAmount.get(key);
+    if (list) list.push(t);
+    else byAmount.set(key, [t]);
+  }
+
+  const used = new Set<string>();
+  const suggestions: TransferPairSuggestion[] = [];
+
+  // Deterministic order: oldest first, so a re-run pairs identically.
+  const ordered = [...eligible].sort(
+    (a, b) => new Date(a.date).getTime() - new Date(b.date).getTime() || a.id.localeCompare(b.id)
+  );
+
+  for (const row of ordered) {
+    if (used.has(row.id)) continue;
+    const opposites = byAmount.get(-pennies(row.amount)) ?? [];
+    const rowTime = new Date(row.date).getTime();
+
+    const candidates = opposites
+      .filter(o =>
+        !used.has(o.id) &&
+        o.id !== row.id &&
+        o.accountId !== row.accountId &&
+        Math.abs(new Date(o.date).getTime() - rowTime) <= windowDays * DAY_MS
+      )
+      .map(o => ({
+        transaction: o,
+        daysApart: Math.abs(new Date(o.date).getTime() - rowTime) / DAY_MS,
+        descriptionScore: calculateStringSimilarity(row.description, o.description),
+      }))
+      .sort((a, b) => a.daysApart - b.daysApart || b.descriptionScore - a.descriptionScore);
+
+    const best = candidates[0];
+    if (!best) continue;
+
+    // Ambiguous when an equally-good alternative exists — checked in BOTH
+    // directions, because which side the sweep reaches first is an accident
+    // of ordering: the row may have several candidate partners, or several
+    // rows may be competing for the partner it chose.
+    const equallyGood = (list: Array<{ daysApart: number; descriptionScore: number }>): boolean =>
+      list.length > 1 &&
+      list[1].daysApart === list[0].daysApart &&
+      list[1].descriptionScore === list[0].descriptionScore;
+
+    const partnerTime = new Date(best.transaction.date).getTime();
+    const reverseCandidates = (byAmount.get(pennies(row.amount)) ?? [])
+      .filter(o =>
+        !used.has(o.id) &&
+        o.id !== best.transaction.id &&
+        o.accountId !== best.transaction.accountId &&
+        Math.abs(new Date(o.date).getTime() - partnerTime) <= windowDays * DAY_MS
+      )
+      .map(o => ({
+        daysApart: Math.abs(new Date(o.date).getTime() - partnerTime) / DAY_MS,
+        descriptionScore: calculateStringSimilarity(best.transaction.description, o.description),
+      }))
+      .sort((a, b) => a.daysApart - b.daysApart || b.descriptionScore - a.descriptionScore);
+
+    const ambiguous = equallyGood(candidates) || equallyGood(reverseCandidates);
+
+    used.add(row.id);
+    used.add(best.transaction.id);
+
+    const rowIsOutgoing = toDecimal(row.amount).isNegative();
+    suggestions.push({
+      outgoing: rowIsOutgoing ? row : best.transaction,
+      incoming: rowIsOutgoing ? best.transaction : row,
+      daysApart: best.daysApart,
+      descriptionScore: best.descriptionScore,
+      ambiguous,
+    });
+  }
+
+  return { suggestions, scanned: eligible.length };
+}


### PR DESCRIPTION
**I scanned your production data first**: there are **1,273 unlinked transfer pairs** sitting in your uncategorised rows — **£11.8M** of movements between your own accounts that the reports can't classify. Same-day, exactly equal-and-opposite examples it found:

| Amount | Out | In |
|---|---|---|
| £540,000 | Transfer between 5747 & 5755 | Transfer HSBC Current / Joint |
| £385,000 | Transfer between 5747 & 5755 | Transfer HSBC Current / Joint |
| £285,000 | Transfer HSBC Current / Joint | Transfer between 5747 & 5755 |

Linking them clears **~2,546 review-band rows (a 28% cut)** and removes that £11.8M of noise from income/expense entirely.

## The tool
From the Reports review band, a new link — *"Or match transfers automatically"* — opens a review list: date, from → to accounts, description, amount. **Unambiguous pairs start ticked; ambiguous ones start unticked and badged "check".** Nothing links without an explicit tick. Applying goes through the existing atomic `link_transfer_pair` RPC with progress and a partial-failure count; the modal can't be dismissed mid-apply.

## The matching rules (deliberately strict — a wrong link silently rewrites two accounts' meaning)
Exactly opposite amounts (Decimal, no float slack) · different accounts · within a date window (bank clearing lag) · neither side already linked, split, or typed transfer · each row used at most once · closest date wins, description similarity breaks ties.

**Ambiguity is checked in both directions** — a row may have several candidate partners, *or* several rows may compete for the partner it chose. Which side the sweep reaches first is an accident of ordering, and my one-way check missed half the ambiguous cases until a unit test caught it.

## Verification
8 unit tests (orientation, same-account rejection, date window, skip-linked/split/transfer/zero, each-row-once, both-direction ambiguity, closest-date-beats-description, uncategorised-only including dangling category ids). Browser-verified end to end: pairs detected and pre-selected, "Link 1 pair" turned **both** sides into linked transfers, modal closed. Strict types, lint, smoke (3,114), build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)