### PR TITLE
feat(reports): custom report viewer — "Generate" finally shows the report

### DIFF
--- a/src/components/CustomReportViewer.tsx
+++ b/src/components/CustomReportViewer.tsx
@@ -1,0 +1,292 @@
+import React from 'react';
+import {
+  ResponsiveContainer,
+  LineChart,
+  Line,
+  BarChart,
+  Bar,
+  PieChart as RechartsPieChart,
+  Pie,
+  Cell,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  Legend,
+} from 'recharts';
+import { useCurrencyDecimal } from '../hooks/useCurrencyDecimal';
+import { formatDecimal } from '../utils/decimal-format';
+import type { CustomReport, ReportComponent } from './CustomReportBuilder';
+
+/**
+ * Renders a generated custom report. Until now "Generate" computed the data
+ * and then only showed a toast — there was nothing to look at. Each component
+ * type maps to the same chart vocabulary the rest of the app uses (recharts,
+ * one library), and every figure comes from customReportService's generators,
+ * which classify through the shared category semantics.
+ */
+
+const CATEGORY_COLORS = [
+  '#3B82F6', '#10B981', '#F59E0B', '#EF4444',
+  '#8B5CF6', '#EC4899', '#6366F1', '#14B8A6'
+];
+
+export interface GeneratedReport {
+  report: CustomReport;
+  dateRange: { startDate: Date; endDate: Date };
+  data: Record<string, unknown>;
+}
+
+interface ChartSeries {
+  labels: string[];
+  datasets: Array<{ label: string; data: number[]; borderColor?: string; backgroundColor?: string }>;
+}
+
+const compactTick = (value: number): string => {
+  const abs = Math.abs(value);
+  const sign = value < 0 ? '-' : '';
+  if (abs >= 1_000_000) return `${sign}${formatDecimal(abs / 1_000_000, 1)}M`;
+  if (abs >= 1_000) return `${sign}${formatDecimal(abs / 1_000, 0)}K`;
+  return formatDecimal(value, 0);
+};
+
+/** Chart.js-shaped {labels, datasets} → recharts' row-per-label form. */
+function toRows(series: ChartSeries): Array<Record<string, string | number>> {
+  return series.labels.map((label, i) => {
+    const row: Record<string, string | number> = { label };
+    series.datasets.forEach(ds => { row[ds.label] = ds.data[i] ?? 0; });
+    return row;
+  });
+}
+
+export default function CustomReportViewer({
+  generated,
+  onClose,
+}: {
+  generated: GeneratedReport;
+  onClose: () => void;
+}): React.JSX.Element {
+  const { formatCurrency } = useCurrencyDecimal();
+  const { report, dateRange, data } = generated;
+
+  const money = (v: number | string): string =>
+    formatCurrency(typeof v === 'number' ? v : Number(v));
+
+  const widthClass = (width: ReportComponent['width']): string =>
+    width === 'full' ? 'lg:col-span-3' : width === 'half' ? 'lg:col-span-2' : 'lg:col-span-1';
+
+  const renderComponent = (component: ReportComponent): React.ReactNode => {
+    const componentData = data[component.id];
+    if (componentData === undefined || componentData === null) {
+      return <p className="text-sm text-gray-400">No data</p>;
+    }
+
+    switch (component.type) {
+      case 'summary-stats': {
+        const stats = componentData as Record<string, number>;
+        const entries = Object.entries(stats);
+        if (entries.length === 0) return <p className="text-sm text-gray-400">No data</p>;
+        return (
+          <div className="grid grid-cols-2 gap-3">
+            {entries.map(([key, value]) => (
+              <div key={key}>
+                <p className="text-xs uppercase tracking-wide text-gray-500 dark:text-gray-400">
+                  {key.replace(/([A-Z])/g, ' $1').replace(/^./, c => c.toUpperCase()).trim()}
+                </p>
+                <p className="text-lg font-semibold text-gray-900 dark:text-white tabular-nums">
+                  {/count|Count/.test(key) ? value.toLocaleString() : money(value)}
+                </p>
+              </div>
+            ))}
+          </div>
+        );
+      }
+
+      case 'line-chart':
+      case 'bar-chart': {
+        const series = componentData as ChartSeries;
+        if (!series.labels?.length) return <p className="text-sm text-gray-400">No data</p>;
+        const rows = toRows(series);
+        const isLine = component.type === 'line-chart';
+        return (
+          <div className="h-64">
+            <ResponsiveContainer width="100%" height="100%">
+              {isLine ? (
+                <LineChart data={rows}>
+                  <CartesianGrid strokeDasharray="3 3" stroke="rgba(107, 114, 128, 0.2)" />
+                  <XAxis dataKey="label" tick={{ fill: '#6B7280', fontSize: 11 }} minTickGap={24} />
+                  <YAxis tick={{ fill: '#6B7280', fontSize: 11 }} tickFormatter={compactTick} width={56} />
+                  <Tooltip formatter={money} />
+                  <Legend />
+                  {series.datasets.map((ds, i) => (
+                    <Line
+                      key={ds.label}
+                      type="monotone"
+                      dataKey={ds.label}
+                      stroke={ds.borderColor ?? CATEGORY_COLORS[i % CATEGORY_COLORS.length]}
+                      strokeWidth={2}
+                      dot={false}
+                      isAnimationActive={false}
+                    />
+                  ))}
+                </LineChart>
+              ) : (
+                <BarChart data={rows}>
+                  <CartesianGrid strokeDasharray="3 3" stroke="rgba(107, 114, 128, 0.2)" />
+                  <XAxis dataKey="label" tick={{ fill: '#6B7280', fontSize: 11 }} minTickGap={24} />
+                  <YAxis tick={{ fill: '#6B7280', fontSize: 11 }} tickFormatter={compactTick} width={56} />
+                  <Tooltip formatter={money} />
+                  <Legend />
+                  {series.datasets.map((ds, i) => (
+                    <Bar
+                      key={ds.label}
+                      dataKey={ds.label}
+                      fill={ds.backgroundColor ?? CATEGORY_COLORS[i % CATEGORY_COLORS.length]}
+                      radius={[3, 3, 0, 0]}
+                      isAnimationActive={false}
+                    />
+                  ))}
+                </BarChart>
+              )}
+            </ResponsiveContainer>
+          </div>
+        );
+      }
+
+      case 'pie-chart': {
+        const pie = componentData as { labels: string[]; data: number[] };
+        if (!pie.labels?.length) return <p className="text-sm text-gray-400">No data</p>;
+        const rows = pie.labels.map((name, i) => ({ name, value: pie.data[i] ?? 0 }));
+        return (
+          <div className="h-64 flex items-center gap-4">
+            <div className="h-full flex-1 basis-0 min-w-[140px]">
+              <ResponsiveContainer width="100%" height="100%">
+                <RechartsPieChart>
+                  <Pie data={rows} dataKey="value" nameKey="name" innerRadius="55%" outerRadius="88%" strokeWidth={0} isAnimationActive={false}>
+                    {rows.map((row, i) => (
+                      <Cell key={row.name} fill={CATEGORY_COLORS[i % CATEGORY_COLORS.length]} />
+                    ))}
+                  </Pie>
+                  <Tooltip formatter={money} />
+                </RechartsPieChart>
+              </ResponsiveContainer>
+            </div>
+            <ul className="w-44 space-y-1">
+              {rows.slice(0, 8).map((row, i) => (
+                <li key={row.name} className="flex items-center gap-2 text-xs">
+                  <span className="w-2.5 h-2.5 rounded-sm flex-shrink-0" style={{ backgroundColor: CATEGORY_COLORS[i % CATEGORY_COLORS.length] }} />
+                  <span className="flex-1 min-w-0 truncate text-gray-600 dark:text-gray-300">{row.name}</span>
+                  <span className="tabular-nums text-gray-900 dark:text-white">{money(row.value)}</span>
+                </li>
+              ))}
+            </ul>
+          </div>
+        );
+      }
+
+      case 'table': {
+        const rows = componentData as Array<{
+          date: string; description: string; category: string; account: string; amount: number;
+        }>;
+        if (rows.length === 0) return <p className="text-sm text-gray-400">No transactions</p>;
+        return (
+          <div className="overflow-x-auto">
+            <table className="w-full">
+              <thead>
+                <tr className="text-xs text-gray-500 dark:text-gray-400 border-b border-gray-100 dark:border-gray-700">
+                  <th className="text-left pb-2 font-medium">Date</th>
+                  <th className="text-left pb-2 font-medium">Description</th>
+                  <th className="text-left pb-2 font-medium">Category</th>
+                  <th className="text-left pb-2 font-medium">Account</th>
+                  <th className="text-right pb-2 font-medium">Amount</th>
+                </tr>
+              </thead>
+              <tbody>
+                {rows.map((row, i) => (
+                  <tr key={`${row.date}-${i}`} className="border-b border-gray-50 dark:border-gray-700/50">
+                    <td className="py-2 text-sm text-gray-500 dark:text-gray-400 whitespace-nowrap">{row.date}</td>
+                    <td className="py-2 text-sm text-gray-900 dark:text-white">{row.description}</td>
+                    <td className="py-2 text-sm text-gray-500 dark:text-gray-400">{row.category}</td>
+                    <td className="py-2 text-sm text-gray-500 dark:text-gray-400">{row.account}</td>
+                    <td className={`py-2 text-sm font-medium text-right tabular-nums ${
+                      row.amount < 0 ? 'text-red-600 dark:text-red-400' : 'text-green-600 dark:text-green-400'
+                    }`}>
+                      {money(row.amount)}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        );
+      }
+
+      case 'text-block': {
+        const block = componentData as { content: string };
+        return <p className="text-sm text-gray-700 dark:text-gray-300 whitespace-pre-wrap">{block.content}</p>;
+      }
+
+      default: {
+        // category-breakdown and any future type: render its rows generically
+        // rather than silently showing nothing.
+        const rows = Array.isArray(componentData) ? componentData as Array<Record<string, unknown>> : [];
+        if (rows.length === 0) return <p className="text-sm text-gray-400">No data</p>;
+        return (
+          <ul className="space-y-1">
+            {rows.slice(0, 10).map((row, i) => (
+              <li key={i} className="flex items-center justify-between text-sm">
+                <span className="text-gray-700 dark:text-gray-300 truncate">
+                  {String(row.category ?? row.name ?? row.label ?? '—')}
+                </span>
+                <span className="tabular-nums text-gray-900 dark:text-white">
+                  {typeof row.amount === 'number' ? money(row.amount)
+                    : typeof row.spent === 'number' ? money(row.spent)
+                    : ''}
+                </span>
+              </li>
+            ))}
+          </ul>
+        );
+      }
+    }
+  };
+
+  return (
+    <div className="max-w-[1400px] mx-auto">
+      <div className="flex flex-wrap items-center gap-3 mb-6">
+        <div>
+          <h2 className="text-2xl font-bold text-gray-900 dark:text-white">{report.name}</h2>
+          <p className="text-sm text-gray-500 dark:text-gray-400">
+            {report.description ? `${report.description} · ` : ''}
+            {dateRange.startDate.toLocaleDateString('en-GB')} – {dateRange.endDate.toLocaleDateString('en-GB')}
+          </p>
+        </div>
+        <button
+          type="button"
+          onClick={onClose}
+          className="ml-auto px-4 py-2 text-sm font-medium rounded-lg border border-gray-300 dark:border-gray-600 text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors"
+        >
+          Back to reports
+        </button>
+      </div>
+
+      {report.components.length === 0 ? (
+        <p className="text-center py-16 text-gray-400">This report has no components yet.</p>
+      ) : (
+        <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
+          {report.components.map(component => (
+            <section
+              key={component.id}
+              className={`bg-white dark:bg-gray-800 rounded-2xl shadow-sm border border-gray-100 dark:border-gray-700 p-6 ${widthClass(component.width)}`}
+            >
+              <h3 className="text-base font-semibold text-gray-900 dark:text-white mb-4">
+                {component.title}
+              </h3>
+              {renderComponent(component)}
+            </section>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/dashboard/reportWidgets/DashboardReportWidgets.tsx
+++ b/src/components/dashboard/reportWidgets/DashboardReportWidgets.tsx
@@ -180,7 +180,7 @@ export function ExpenseCategoriesWidget({ range }: { range: PeriodRange }): Reac
         <p className="text-center py-10 text-sm text-gray-400">No categorised spending in this period</p>
       ) : (
         <div className="flex items-center gap-3 h-44">
-          <div className="h-full flex-1 min-w-0">
+          <div className="h-full flex-1 basis-0 min-w-[120px]">
             <ResponsiveContainer width="100%" height="100%">
               <RechartsPieChart>
                 <Pie data={data} dataKey="value" nameKey="name" innerRadius="55%" outerRadius="88%" strokeWidth={0} isAnimationActive={false}>

--- a/src/pages/CustomReports.tsx
+++ b/src/pages/CustomReports.tsx
@@ -3,6 +3,7 @@ import { useApp } from '../contexts/AppContextSupabase';
 import { useNotifications } from '../contexts/NotificationContext';
 import { customReportService } from '../services/customReportService';
 import CustomReportBuilder from '../components/CustomReportBuilder';
+import CustomReportViewer, { type GeneratedReport } from '../components/CustomReportViewer';
 import type { CustomReport } from '../components/CustomReportBuilder';
 import {
   PlusIcon,
@@ -23,7 +24,7 @@ export default function CustomReports(): React.JSX.Element {
   const [showBuilder, setShowBuilder] = useState(false);
   const [editingReport, setEditingReport] = useState<CustomReport | undefined>();
   const [generatingReport, setGeneratingReport] = useState<string | null>(null);
-  const [_generatedData, setGeneratedData] = useState<unknown>(null);
+  const [generatedData, setGeneratedData] = useState<GeneratedReport | null>(null);
 
   useEffect(() => {
     loadReports();
@@ -92,15 +93,9 @@ export default function CustomReports(): React.JSX.Element {
         categories
       });
       
+      // Show the report itself — "generated" used to mean a toast and
+      // nothing to look at.
       setGeneratedData(data);
-      
-      // Navigate to report viewer
-      // For now, just show a success message
-      addNotification({
-        type: 'success',
-        title: 'Report Generated',
-        message: 'Your report has been generated successfully'
-      });
     } catch {
       addNotification({
         type: 'error',
@@ -111,6 +106,15 @@ export default function CustomReports(): React.JSX.Element {
       setGeneratingReport(null);
     }
   };
+
+  if (generatedData) {
+    return (
+      <CustomReportViewer
+        generated={generatedData}
+        onClose={() => setGeneratedData(null)}
+      />
+    );
+  }
 
   if (showBuilder || editingReport) {
     return (


### PR DESCRIPTION
The gap the Dashboard pinned-reports picker exposed: custom reports could be built, saved, duplicated and generated… and generating one computed every figure and then showed a **toast**. There was nothing to look at, anywhere in the app.

## What lands
`CustomReportViewer` renders a generated report — **summary stats, line/bar/pie charts, transaction tables and text blocks** — on the report's own full/half/third widths. Charts use recharts (the app's single charting library) and every figure comes from the existing generators, which already classify through the shared category semantics, so a custom report agrees with the hub. Unknown component types render generically rather than silently showing nothing. "Generate" now opens the viewer; "Back to reports" returns.

## Layout bug found while verifying
The pie's chart column used `flex-1 min-w-0`, which resolves to a **zero flex basis** when the sibling legend has a fixed width — the chart collapsed to 0px and drew nothing while its legend still listed values, so it read as *"data loaded, chart broken"*. Fixed with `flex-1 basis-0` plus a minimum width, **here and in the Dashboard's pinned expense-categories widget**, which shared the pattern.

## Verification
Browser-verified on a report exercising all six component types: every component rendered with real figures (income £70,816.44, expenses £18,665), all three charts drew (the pie showing 11 sectors after the fix), table and text block populated. Strict types, lint, smoke (3,114), build green.

Stacked on #135 (bulk transfer matching) — merge that first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)