### PR TITLE
feat(transactions): bulk categorise by payee + payee memory follows the habit, not the last accident

### DIFF
--- a/src/components/BulkCategorizeModal.tsx
+++ b/src/components/BulkCategorizeModal.tsx
@@ -1,0 +1,240 @@
+import React, { useMemo, useState } from 'react';
+import { Modal, ModalBody, ModalFooter } from './common/Modal';
+import CategorySelector from './CategorySelector';
+import { useApp } from '../contexts/AppContextSupabase';
+import { useToast } from '../contexts/ToastContext';
+import { useCurrencyDecimal } from '../hooks/useCurrencyDecimal';
+import { buildPayeeGroups, type PayeeGroup } from '../utils/payeeGroups';
+import { ArrowDownIcon, ArrowUpIcon } from './icons';
+
+/**
+ * Bulk categorise by payee: file a whole merchant in one decision.
+ *
+ * The review band is dominated by ordinary spending that never got a
+ * category — the same merchants over and over. One decision per payee clears
+ * dozens of rows, and because the app's payee memory keys on payee +
+ * direction + account, the same decision also teaches future imports and
+ * bank feeds.
+ *
+ * Groups where the payee has been filed before arrive pre-filled with the
+ * category the user uses MOST for it (support count shown), so the common
+ * case is: glance, confirm, apply.
+ */
+
+interface Props {
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+const CAP = 100;
+
+export default function BulkCategorizeModal({ isOpen, onClose }: Props): React.JSX.Element {
+  const { transactions, categories, accounts, applyCategoryToUncategorized } = useApp();
+  const { formatCurrency } = useCurrencyDecimal();
+  const { showSuccess, showError } = useToast();
+  const [choices, setChoices] = useState<Record<string, string>>({});
+  const [applying, setApplying] = useState(false);
+  const [progress, setProgress] = useState(0);
+
+  const accountName = useMemo(() => {
+    const byId = new Map(accounts.map(a => [a.id, a.name]));
+    return (id: string): string => byId.get(id) ?? 'Unknown account';
+  }, [accounts]);
+
+  const categoryName = useMemo(() => {
+    const byId = new Map(categories.map(c => [c.id, c]));
+    return (id: string): string => {
+      const c = byId.get(id);
+      if (!c) return '';
+      const parent = c.parentId ? byId.get(c.parentId) : undefined;
+      return parent && parent.level !== 'type' ? `${parent.name} : ${c.name}` : c.name;
+    };
+  }, [categories]);
+
+  const groups = useMemo(
+    () => (isOpen ? buildPayeeGroups(transactions, categories) : []),
+    [isOpen, transactions, categories]
+  );
+
+  const keyOf = (g: PayeeGroup): string => `${g.payee}|${g.direction}`;
+
+  // Pre-fill from the payee's own history; the user can change any of them.
+  const effectiveChoice = (g: PayeeGroup): string =>
+    choices[keyOf(g)] ?? g.suggestedCategoryId ?? '';
+
+  const setChoice = (g: PayeeGroup, categoryId: string): void => {
+    setChoices(prev => ({ ...prev, [keyOf(g)]: categoryId }));
+  };
+
+  const visible = groups.slice(0, CAP);
+  const ready = visible.filter(g => effectiveChoice(g) !== '');
+  const rowsCovered = ready.reduce((sum, g) => sum + g.count, 0);
+
+  const handleApply = async (): Promise<void> => {
+    setApplying(true);
+    setProgress(0);
+    let done = 0;
+    let rows = 0;
+    let failed = 0;
+    try {
+      for (const group of ready) {
+        const category = effectiveChoice(group);
+        try {
+          // Only fills blanks — an explicit category is never overwritten.
+          const updated = await applyCategoryToUncategorized(group.transactionIds, category);
+          rows += updated;
+        } catch {
+          failed++;
+        }
+        done++;
+        setProgress(done);
+      }
+      if (rows > 0) {
+        showSuccess(
+          `${rows.toLocaleString()} transaction${rows === 1 ? '' : 's'} categorised across ${(done - failed).toLocaleString()} payee${done - failed === 1 ? '' : 's'}.`,
+          'Categories applied'
+        );
+      }
+      if (failed > 0 && rows === 0) {
+        showError(new Error('No transactions could be categorised. Please try again.'));
+      }
+      onClose();
+    } finally {
+      setApplying(false);
+    }
+  };
+
+  return (
+    <Modal
+      isOpen={isOpen}
+      onClose={applying ? () => {} : onClose}
+      closeOnBackdrop={!applying}
+      title="Categorise by payee"
+      size="xl"
+    >
+      <ModalBody>
+        {groups.length === 0 ? (
+          <p className="text-center py-10 text-gray-500 dark:text-gray-400">
+            Nothing to categorise — every transaction with a payee already has a category.
+          </p>
+        ) : (
+          <>
+            <p className="text-sm text-gray-600 dark:text-gray-400 mb-3">
+              One decision files a whole merchant. Payees you have filed before arrive
+              pre-filled with the category you use most for them — and whatever you choose
+              here is remembered, so future imports and bank feeds categorise themselves.
+            </p>
+            <div className="overflow-x-auto">
+              <table className="w-full">
+                <thead>
+                  <tr className="text-xs text-gray-500 dark:text-gray-400 border-b border-gray-100 dark:border-gray-700">
+                    <th className="text-left pb-2 font-medium">Payee</th>
+                    <th className="text-right pb-2 font-medium">Rows</th>
+                    <th className="text-right pb-2 font-medium">Total</th>
+                    <th className="text-left pb-2 font-medium w-72">Category</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {visible.map(group => {
+                    const key = keyOf(group);
+                    const chosen = effectiveChoice(group);
+                    return (
+                      <tr key={key} className="border-b border-gray-50 dark:border-gray-700/50">
+                        <td className="py-2 pr-3">
+                          <span className="flex items-center gap-1.5">
+                            {group.direction === 'expense'
+                              ? <ArrowDownIcon size={12} className="text-red-500 flex-shrink-0" />
+                              : <ArrowUpIcon size={12} className="text-green-600 flex-shrink-0" />}
+                            <span className="text-sm text-gray-900 dark:text-white truncate max-w-[220px]">
+                              {group.displayName}
+                            </span>
+                          </span>
+                          <span className="block text-xs text-gray-400 dark:text-gray-500 mt-0.5">
+                            {new Date(group.earliest).toLocaleDateString('en-GB', { month: 'short', year: 'numeric' })}
+                            {' – '}
+                            {new Date(group.latest).toLocaleDateString('en-GB', { month: 'short', year: 'numeric' })}
+                            {group.accountIds.length === 1
+                              ? ` · ${accountName(group.accountIds[0])}`
+                              : ` · ${group.accountIds.length} accounts`}
+                            {group.suggestedCategoryId && (
+                              <> · usually {categoryName(group.suggestedCategoryId)} ({group.suggestionSupport})</>
+                            )}
+                          </span>
+                          {/* A deliberate recent change stays one click away
+                              instead of being buried under an older habit. */}
+                          {group.lastUsedCategoryId && chosen !== group.lastUsedCategoryId && (
+                            <button
+                              type="button"
+                              onClick={() => setChoice(group, group.lastUsedCategoryId as string)}
+                              disabled={applying}
+                              className="mt-1 text-xs text-blue-700 dark:text-blue-400 hover:underline disabled:opacity-50"
+                            >
+                              use last: {categoryName(group.lastUsedCategoryId)}
+                            </button>
+                          )}
+                        </td>
+                        <td className="py-2 pr-3 text-sm text-right tabular-nums text-gray-700 dark:text-gray-300">
+                          {group.count.toLocaleString()}
+                        </td>
+                        <td className="py-2 pr-3 text-sm text-right tabular-nums text-gray-900 dark:text-white whitespace-nowrap">
+                          {formatCurrency(group.total)}
+                        </td>
+                        <td className="py-2">
+                          <CategorySelector
+                            selectedCategory={chosen}
+                            onCategoryChange={(categoryId) => setChoice(group, categoryId)}
+                            transactionType={group.direction}
+                            includeAllTypes
+                            showHelperText={false}
+                            usePortal
+                            placeholder="Choose a category…"
+                            className="w-full"
+                          />
+                        </td>
+                      </tr>
+                    );
+                  })}
+                  {groups.length > CAP && (
+                    <tr>
+                      <td colSpan={4} className="py-3 text-center text-xs text-gray-400 dark:text-gray-500">
+                        Showing the {CAP} biggest payees of {groups.length.toLocaleString()} —
+                        apply these, then reopen for the next batch.
+                      </td>
+                    </tr>
+                  )}
+                </tbody>
+              </table>
+            </div>
+          </>
+        )}
+      </ModalBody>
+      <ModalFooter>
+        <div className="flex items-center gap-3">
+          <p className="text-sm text-gray-600 dark:text-gray-400">
+            {applying
+              ? `Applying ${progress.toLocaleString()} of ${ready.length.toLocaleString()} payees…`
+              : `${ready.length.toLocaleString()} payee${ready.length === 1 ? '' : 's'} ready — ${rowsCovered.toLocaleString()} transaction${rowsCovered === 1 ? '' : 's'}`}
+          </p>
+          <div className="ml-auto flex items-center gap-2">
+            <button
+              type="button"
+              onClick={onClose}
+              disabled={applying}
+              className="px-4 py-2 text-sm font-medium rounded-lg border border-gray-300 dark:border-gray-600 text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors disabled:opacity-50"
+            >
+              Cancel
+            </button>
+            <button
+              type="button"
+              onClick={() => void handleApply()}
+              disabled={applying || ready.length === 0}
+              className="justify-center px-4 py-2 text-sm font-medium rounded-lg bg-[#1a2332] dark:bg-blue-600 text-white hover:bg-[#2d3a4d] dark:hover:bg-blue-700 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+            >
+              {applying ? 'Applying…' : `Categorise ${rowsCovered.toLocaleString()} transaction${rowsCovered === 1 ? '' : 's'}`}
+            </button>
+          </div>
+        </div>
+      </ModalFooter>
+    </Modal>
+  );
+}

--- a/src/pages/Reports.tsx
+++ b/src/pages/Reports.tsx
@@ -28,6 +28,7 @@ import PeriodPicker from '../components/PeriodPicker';
 import EditTransactionModal from '../components/EditTransactionModal';
 import IncomeExpenseBreakdownModal from '../components/IncomeExpenseBreakdownModal';
 import TransferSweepModal from '../components/TransferSweepModal';
+import BulkCategorizeModal from '../components/BulkCategorizeModal';
 import { expandSplitTransactions } from '../utils/transactionSplits';
 import { createScopedLogger } from '../loggers/scopedLogger';
 
@@ -63,6 +64,7 @@ export default function Reports() {
   } | null>(null);
   const [editingBreakdownTxnId, setEditingBreakdownTxnId] = useState<string | null>(null);
   const [showTransferSweep, setShowTransferSweep] = useState(false);
+  const [showBulkCategorize, setShowBulkCategorize] = useState(false);
   const [isLoading, setIsLoading] = useState(true);
   const chartRef1 = useRef<HTMLDivElement>(null);
   const chartRef2 = useRef<HTMLDivElement>(null);
@@ -356,6 +358,16 @@ export default function Reports() {
           </button>
         )}
 
+        {flows.uncategorizedRows.length > 0 && (
+          <button
+            type="button"
+            onClick={() => setShowBulkCategorize(true)}
+            className="text-sm text-blue-700 dark:text-blue-400 hover:underline text-left"
+          >
+            Or categorise by payee — file a whole merchant at once and teach future imports
+          </button>
+        )}
+
         {/* Charts */}
         <div className="pt-4">
           <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
@@ -575,6 +587,11 @@ export default function Reports() {
       <TransferSweepModal
         isOpen={showTransferSweep}
         onClose={() => setShowTransferSweep(false)}
+      />
+
+      <BulkCategorizeModal
+        isOpen={showBulkCategorize}
+        onClose={() => setShowBulkCategorize(false)}
       />
 
       {/* Edit a transaction straight from the breakdown list */}

--- a/src/utils/payeeGroups.test.ts
+++ b/src/utils/payeeGroups.test.ts
@@ -1,0 +1,158 @@
+import { describe, it, expect } from 'vitest';
+import { buildPayeeGroups } from './payeeGroups';
+import type { Category, Transaction } from '../types';
+
+const CATEGORIES: Category[] = [
+  { id: 'type-income', name: 'Income', type: 'income', level: 'type', isSystem: true },
+  { id: 'type-expense', name: 'Expense', type: 'expense', level: 'type', isSystem: true },
+  { id: 'cat-consumables', name: 'Consumables', type: 'expense', level: 'detail', parentId: 'type-expense' },
+  { id: 'cat-repairs', name: 'Repairs', type: 'expense', level: 'detail', parentId: 'type-expense' },
+  { id: 'cat-salary', name: 'Salary', type: 'income', level: 'detail', parentId: 'type-income' },
+];
+
+const txn = (over: Partial<Transaction> & { id: string }): Transaction => ({
+  date: new Date('2026-07-10'),
+  amount: -20,
+  description: 'Boots',
+  category: '',
+  accountId: 'acc-a',
+  type: 'expense',
+  ...over,
+});
+
+describe('buildPayeeGroups', () => {
+  it('groups uncategorised rows by payee and totals them', () => {
+    const groups = buildPayeeGroups([
+      txn({ id: '1', description: 'Boots', amount: -20 }),
+      txn({ id: '2', description: 'BOOTS', amount: -35 }),   // case-insensitive
+      txn({ id: '3', description: ' boots ', amount: -5 }),  // trimmed
+      txn({ id: '4', description: 'Clinton Cards', amount: -8 }),
+    ], CATEGORIES);
+
+    expect(groups[0].payee).toBe('BOOTS');
+    expect(groups[0].count).toBe(3);
+    expect(groups[0].total).toBe(60);
+    expect(groups[0].transactionIds).toEqual(['1', '2', '3']);
+    expect(groups[1].payee).toBe('CLINTON CARDS');
+  });
+
+  it('separates money-in from money-out for the same payee', () => {
+    const groups = buildPayeeGroups([
+      txn({ id: 'spend', description: 'Amazon', amount: -50 }),
+      txn({ id: 'refund', description: 'Amazon', amount: 15, type: 'income' }),
+    ], CATEGORIES);
+
+    expect(groups).toHaveLength(2);
+    expect(groups.find(g => g.direction === 'expense')?.transactionIds).toEqual(['spend']);
+    expect(groups.find(g => g.direction === 'income')?.transactionIds).toEqual(['refund']);
+  });
+
+  it('suggests the MOST COMMON category the payee already uses, not the latest one-off', () => {
+    const groups = buildPayeeGroups([
+      // history: mostly Consumables, one recent Repairs
+      txn({ id: 'h1', description: 'Amazon', amount: -10, category: 'cat-consumables', date: new Date('2026-01-01') }),
+      txn({ id: 'h2', description: 'Amazon', amount: -12, category: 'cat-consumables', date: new Date('2026-02-01') }),
+      txn({ id: 'h3', description: 'Amazon', amount: -90, category: 'cat-repairs', date: new Date('2026-06-01') }),
+      // the uncategorised row needing a decision
+      txn({ id: 'new', description: 'Amazon', amount: -30 }),
+    ], CATEGORIES);
+
+    const amazon = groups.find(g => g.payee === 'AMAZON' && g.direction === 'expense')!;
+    expect(amazon.transactionIds).toEqual(['new']);
+    expect(amazon.suggestedCategoryId).toBe('cat-consumables');
+    expect(amazon.suggestionSupport).toBe(2);
+  });
+
+  it('ties in the history break toward the most recent', () => {
+    const groups = buildPayeeGroups([
+      txn({ id: 'h1', description: 'Amazon', amount: -10, category: 'cat-consumables', date: new Date('2026-01-01') }),
+      txn({ id: 'h2', description: 'Amazon', amount: -90, category: 'cat-repairs', date: new Date('2026-06-01') }),
+      txn({ id: 'new', description: 'Amazon', amount: -30 }),
+    ], CATEGORIES);
+
+    expect(groups.find(g => g.payee === 'AMAZON')?.suggestedCategoryId).toBe('cat-repairs');
+  });
+
+  it('never groups transfers, splits, linked rows, or the bank fallback description', () => {
+    const groups = buildPayeeGroups([
+      txn({ id: 'transfer', description: 'Move', type: 'transfer' }),
+      txn({ id: 'split', description: 'Shop', isSplit: true }),
+      txn({ id: 'linked', description: 'Pair', linkedTransferId: 'x' }),
+      txn({ id: 'fallback', description: 'Bank transaction' }),
+      txn({ id: 'blank', description: '   ' }),
+      txn({ id: 'real', description: 'Boots' }),
+    ], CATEGORIES);
+
+    expect(groups).toHaveLength(1);
+    expect(groups[0].transactionIds).toEqual(['real']);
+  });
+
+  it('rows with a real category are history, never groups to decide', () => {
+    const groups = buildPayeeGroups([
+      txn({ id: 'done', description: 'Boots', category: 'cat-consumables' }),
+    ], CATEGORIES);
+    expect(groups).toHaveLength(0);
+  });
+
+  it('treats a dangling category id as uncategorised', () => {
+    const groups = buildPayeeGroups([
+      txn({ id: 'orphan', description: 'Boots', category: 'category-that-was-deleted' }),
+    ], CATEGORIES);
+    expect(groups).toHaveLength(1);
+    expect(groups[0].transactionIds).toEqual(['orphan']);
+  });
+
+  it('orders by row count so the biggest wins come first', () => {
+    const groups = buildPayeeGroups([
+      txn({ id: 'a1', description: 'Rare', amount: -1000 }),
+      txn({ id: 'b1', description: 'Common', amount: -1 }),
+      txn({ id: 'b2', description: 'Common', amount: -1 }),
+    ], CATEGORIES);
+    expect(groups[0].payee).toBe('COMMON');
+  });
+
+  it('records span: dates and accounts covered', () => {
+    const groups = buildPayeeGroups([
+      txn({ id: '1', description: 'Boots', date: new Date('2026-03-01'), accountId: 'acc-a' }),
+      txn({ id: '2', description: 'Boots', date: new Date('2026-07-01'), accountId: 'acc-b' }),
+    ], CATEGORIES);
+    expect(groups[0].earliest).toEqual(new Date('2026-03-01'));
+    expect(groups[0].latest).toEqual(new Date('2026-07-01'));
+    expect(groups[0].accountIds).toEqual(['acc-a', 'acc-b']);
+  });
+});
+
+describe('buildPayeeGroups — last-used alongside the habit', () => {
+  const CATS: Category[] = [
+    { id: 'type-expense', name: 'Expense', type: 'expense', level: 'type', isSystem: true },
+    { id: 'cat-consumables', name: 'Consumables', type: 'expense', level: 'detail', parentId: 'type-expense' },
+    { id: 'cat-repairs', name: 'Repairs', type: 'expense', level: 'detail', parentId: 'type-expense' },
+  ];
+  const t = (over: Partial<Transaction> & { id: string }): Transaction => ({
+    date: new Date('2026-07-10'), amount: -20, description: 'Amazon', category: '',
+    accountId: 'acc-a', type: 'expense', ...over,
+  });
+
+  it('exposes the most RECENT category when it differs from the habit', () => {
+    const [group] = buildPayeeGroups([
+      t({ id: 'h1', category: 'cat-consumables', date: new Date('2026-01-01') }),
+      t({ id: 'h2', category: 'cat-consumables', date: new Date('2026-02-01') }),
+      t({ id: 'h3', category: 'cat-repairs', date: new Date('2026-06-01') }),
+      t({ id: 'new' }),
+    ], CATS);
+
+    expect(group.suggestedCategoryId).toBe('cat-consumables'); // the habit
+    expect(group.lastUsedCategoryId).toBe('cat-repairs');      // one click away
+  });
+
+  it('omits last-used when it IS the habit (nothing to offer)', () => {
+    const [group] = buildPayeeGroups([
+      t({ id: 'h1', category: 'cat-consumables', date: new Date('2026-01-01') }),
+      t({ id: 'h2', category: 'cat-consumables', date: new Date('2026-06-01') }),
+      t({ id: 'new' }),
+    ], CATS);
+
+    expect(group.suggestedCategoryId).toBe('cat-consumables');
+    expect(group.lastUsedCategoryId).toBeUndefined();
+  });
+});

--- a/src/utils/payeeGroups.ts
+++ b/src/utils/payeeGroups.ts
@@ -1,0 +1,135 @@
+import type { Category, Transaction } from '../types';
+import { toDecimal } from './decimal';
+import { normalizePayee, FALLBACK_BANK_DESCRIPTION } from './payeeAutoCategorize';
+import { classifyFlow, buildCategoryKindLookup } from './incomeExpense';
+
+/**
+ * Group uncategorised transactions by payee so a whole merchant can be filed
+ * in one decision — the fastest route out of a review band full of ordinary
+ * spending (Boots ×167, Clinton Cards ×110 …), where one-at-a-time editing
+ * would take thousands of clicks.
+ *
+ * Grouping key is payee + DIRECTION: money out to a shop and money in from
+ * it (a refund) are different decisions, and the app's payee memory is
+ * direction-scoped too, so the groups mirror what will be remembered.
+ *
+ * Each group carries a SUGGESTION taken from how the user has already filed
+ * that same payee — the most COMMON existing category (ties broken by the
+ * most recent), because a bulk decision covering dozens of rows should
+ * follow the habit rather than the last accident.
+ */
+
+export interface PayeeGroup {
+  /** Normalised payee (upper-cased, trimmed) — the memory key. */
+  payee: string;
+  /** The description as it reads in the register (first occurrence). */
+  displayName: string;
+  direction: 'income' | 'expense';
+  transactionIds: string[];
+  count: number;
+  /** Total magnitude across the group. */
+  total: number;
+  earliest: Date;
+  latest: Date;
+  /** Accounts the group spans (names resolved by the caller). */
+  accountIds: string[];
+  /** The category this payee is filed under MOST often (the suggestion). */
+  suggestedCategoryId?: string;
+  /** How many existing rows carry that suggestion. */
+  suggestionSupport?: number;
+  /**
+   * The category used MOST RECENTLY for this payee, when it differs from the
+   * suggestion — so a deliberate recent change is one click away instead of
+   * being buried under an old habit.
+   */
+  lastUsedCategoryId?: string;
+}
+
+export function buildPayeeGroups(
+  transactions: Transaction[],
+  categories: Category[]
+): PayeeGroup[] {
+  const kinds = buildCategoryKindLookup(categories);
+  const categoryIds = new Set(categories.map(c => c.id));
+
+  const isUncategorised = (t: Transaction): boolean =>
+    !t.category || !categoryIds.has(t.category);
+
+  // How the user already files each payee+direction (categorised rows only).
+  const history = new Map<string, Map<string, { count: number; latest: number }>>();
+  for (const t of transactions) {
+    if (isUncategorised(t)) continue;
+    if (t.type === 'transfer') continue;
+    const kind = classifyFlow(t, kinds);
+    if (kind !== 'income' && kind !== 'expense') continue;
+    const payee = normalizePayee(t.description);
+    if (!payee || payee === FALLBACK_BANK_DESCRIPTION) continue;
+    const key = `${payee}|${kind}`;
+    const byCategory = history.get(key) ?? new Map();
+    const entry = byCategory.get(t.category) ?? { count: 0, latest: 0 };
+    entry.count++;
+    entry.latest = Math.max(entry.latest, new Date(t.date).getTime());
+    byCategory.set(t.category, entry);
+    history.set(key, byCategory);
+  }
+
+  const groups = new Map<string, PayeeGroup>();
+  for (const t of transactions) {
+    if (!isUncategorised(t)) continue;
+    if (t.type === 'transfer' || t.linkedTransferId) continue;
+    if (t.isSplit) continue;
+    const payee = normalizePayee(t.description);
+    if (!payee || payee === FALLBACK_BANK_DESCRIPTION) continue;
+
+    // Direction from the money itself: an uncategorised row has no category
+    // to classify by, so the sign IS the only signal — and it is exactly what
+    // payee memory will key on when it remembers this decision.
+    const direction: 'income' | 'expense' = t.amount >= 0 ? 'income' : 'expense';
+    const key = `${payee}|${direction}`;
+    const date = new Date(t.date);
+
+    const existing = groups.get(key);
+    if (existing) {
+      existing.transactionIds.push(t.id);
+      existing.count++;
+      existing.total = toDecimal(existing.total).plus(toDecimal(Math.abs(t.amount))).toNumber();
+      if (date < existing.earliest) existing.earliest = date;
+      if (date > existing.latest) existing.latest = date;
+      if (!existing.accountIds.includes(t.accountId)) existing.accountIds.push(t.accountId);
+      continue;
+    }
+
+    const byCategory = history.get(key);
+    let suggestedCategoryId: string | undefined;
+    let suggestionSupport: number | undefined;
+    let lastUsedCategoryId: string | undefined;
+    if (byCategory && byCategory.size > 0) {
+      const entries = [...byCategory.entries()];
+      const [bestId, best] = [...entries].sort(
+        (a, b) => b[1].count - a[1].count || b[1].latest - a[1].latest
+      )[0];
+      suggestedCategoryId = bestId;
+      suggestionSupport = best.count;
+      const [recentId] = [...entries].sort((a, b) => b[1].latest - a[1].latest)[0];
+      if (recentId !== bestId) lastUsedCategoryId = recentId;
+    }
+
+    groups.set(key, {
+      payee,
+      displayName: t.description.trim(),
+      direction,
+      transactionIds: [t.id],
+      count: 1,
+      total: Math.abs(t.amount),
+      earliest: date,
+      latest: date,
+      accountIds: [t.accountId],
+      suggestedCategoryId,
+      suggestionSupport,
+      lastUsedCategoryId,
+    });
+  }
+
+  // Biggest wins first: most rows, then largest value.
+  return [...groups.values()].sort((a, b) => b.count - a.count || b.total - a.total);
+}

--- a/supabase/migrations/20260722140000_payee_memory_most_common.sql
+++ b/supabase/migrations/20260722140000_payee_memory_most_common.sql
@@ -1,0 +1,211 @@
+-- ============================================================================
+-- Payee memory: prefer the category a payee is MOST COMMONLY filed under,
+-- not merely the most recent one.
+--
+-- The original rule (ORDER BY date DESC LIMIT 1) is right for a payee whose
+-- meaning genuinely changes, but it flip-flops on mixed payees: file one
+-- Amazon order as Household : Repairs and every subsequent Amazon import
+-- inherits Repairs, however many dozens of Consumables rows preceded it.
+--
+-- New rule: most-used category for that payee + direction wins; the most
+-- recent use breaks ties. So a habit holds, a genuine change still takes
+-- over once it becomes the habit, and a single accident no longer
+-- redirects the future. The user's own explicit choices are still never
+-- overwritten — this only ever fills a blank.
+--
+-- Scope note: this is the same rule the in-app bulk "Categorise by payee"
+-- tool uses (utils/payeeGroups), so the server and the client agree.
+-- ============================================================================
+
+BEGIN;
+
+CREATE OR REPLACE FUNCTION public.payee_memory_category(
+  p_account_id uuid,
+  p_description text,
+  p_type text
+) RETURNS text
+    LANGUAGE sql
+    STABLE
+    SECURITY INVOKER
+    SET search_path = public
+AS $$
+  SELECT t.category
+    FROM public.transactions t
+   WHERE t.account_id = p_account_id
+     AND upper(btrim(t.description)) = upper(btrim(p_description))
+     AND t.type = p_type
+     AND t.type <> 'transfer'
+     AND t.category IS NOT NULL AND btrim(t.category) <> ''
+     AND t.category NOT IN ('transfer-in', 'transfer-out')
+   GROUP BY t.category
+   ORDER BY COUNT(*) DESC, MAX(t.date) DESC, MAX(t.created_at) DESC
+   LIMIT 1;
+$$;
+
+REVOKE ALL ON FUNCTION public.payee_memory_category(uuid, text, text) FROM public;
+GRANT EXECUTE ON FUNCTION public.payee_memory_category(uuid, text, text)
+  TO authenticated, service_role;
+
+COMMENT ON FUNCTION public.payee_memory_category(uuid, text, text) IS
+  'Payee memory: the category most often used for this payee+direction in this account (ties → most recent). Used by bank-feed import prefill.';
+
+-- ── Re-declare the bank import RPC to use the helper ───────────────────────
+CREATE OR REPLACE FUNCTION public.import_bank_transactions_atomic(
+  p_user_id uuid,
+  p_rows jsonb
+)
+RETURNS jsonb
+LANGUAGE plpgsql SECURITY INVOKER
+SET search_path = public
+AS $$
+DECLARE
+  r jsonb;
+  v_tx public.transactions;
+  v_acct uuid;
+  v_acct_key text;
+  v_is_backfill boolean;
+  v_backfills jsonb := '{}'::jsonb;   -- account_id -> backfill? (decided BEFORE its first insert)
+  v_sums jsonb := '{}'::jsonb;        -- account_id -> Σ(inserted amounts)
+  v_inserted integer := 0;
+  v_skipped integer := 0;
+  v_sum numeric;
+  v_before public.accounts;
+  v_after public.accounts;
+  v_category text;
+BEGIN
+  IF p_rows IS NULL OR jsonb_typeof(p_rows) <> 'array' THEN
+    RAISE EXCEPTION 'p_rows must be a jsonb array' USING ERRCODE = '22023';
+  END IF;
+
+  FOR r IN SELECT value FROM jsonb_array_elements(p_rows) LOOP
+    IF (r->>'user_id')::uuid IS DISTINCT FROM p_user_id THEN
+      RAISE EXCEPTION 'row user_id does not match p_user_id' USING ERRCODE = '28000';
+    END IF;
+
+    v_acct := (r->>'account_id')::uuid;
+    v_acct_key := v_acct::text;
+
+    -- Backfill detection MUST precede the account's first insert of this call:
+    -- "no previously imported bank transaction exists for this account".
+    IF NOT v_backfills ? v_acct_key THEN
+      SELECT NOT EXISTS (
+        SELECT 1 FROM public.transactions t
+        WHERE t.account_id = v_acct
+          AND t.external_transaction_id IS NOT NULL
+      ) INTO v_is_backfill;
+      v_backfills := v_backfills || jsonb_build_object(v_acct_key, v_is_backfill);
+    END IF;
+
+    -- Account-scoped dedupe (handler pre-filters per connection; this also
+    -- catches re-imports after a reconnect under a new connection_id).
+    IF EXISTS (
+      SELECT 1 FROM public.transactions t
+      WHERE t.account_id = v_acct
+        AND t.external_transaction_id = r->>'external_transaction_id'
+    ) THEN
+      v_skipped := v_skipped + 1;
+      CONTINUE;
+    END IF;
+
+    -- Payee memory: inherit the category this payee is MOST OFTEN filed
+    -- under in this account, for the same direction (an expense never
+    -- inherits an income category). Most-recent used to win, which let a
+    -- single one-off redirect every future import of that payee.
+    -- Transfer rows and the transfer system categories are excluded — a
+    -- reclassified standing order must not stamp 'transfer-out' onto next
+    -- month's plain import. The handler's 'Bank transaction' fallback for
+    -- description-less rows is a sentinel, not a payee — matching on it
+    -- would fuse unrelated merchants into one mega-payee, so it never
+    -- participates. Rows inserted earlier in this same batch participate,
+    -- so a categorized payee cascades through the whole import.
+    v_category := NULLIF(btrim(COALESCE(r->>'category', '')), '');
+    IF v_category IS NULL
+       AND upper(btrim(COALESCE(r->>'description', ''))) <> 'BANK TRANSACTION' THEN
+      -- Most-USED category for this payee+direction (ties → most recent),
+      -- via the shared helper so the server and the in-app bulk tool agree.
+      v_category := public.payee_memory_category(
+        v_acct, r->>'description', r->>'type'
+      );
+    END IF;
+
+    v_tx := NULL;
+    INSERT INTO public.transactions (
+      user_id, account_id, connection_id, external_transaction_id,
+      external_provider, description, amount, type, date, metadata,
+      is_cleared, category
+    )
+    VALUES (
+      p_user_id,
+      v_acct,
+      NULLIF(r->>'connection_id', '')::uuid,
+      r->>'external_transaction_id',
+      r->>'external_provider',
+      r->>'description',
+      (r->>'amount')::numeric,
+      r->>'type',
+      (r->>'date')::date,
+      COALESCE(r->'metadata', 'null'::jsonb),
+      true,
+      v_category
+    )
+    ON CONFLICT (connection_id, external_transaction_id)
+      WHERE external_transaction_id IS NOT NULL
+      DO NOTHING
+    RETURNING * INTO v_tx;
+
+    IF v_tx.id IS NULL THEN
+      v_skipped := v_skipped + 1;  -- lost a concurrent race; row already exists
+      CONTINUE;
+    END IF;
+
+    PERFORM public.write_financial_audit(
+      p_user_id, 'transaction', v_tx.id, 'create', NULL, to_jsonb(v_tx)
+    );
+
+    v_sums := jsonb_set(
+      v_sums,
+      ARRAY[v_acct_key],
+      to_jsonb(COALESCE((v_sums->>v_acct_key)::numeric, 0) + v_tx.amount)
+    );
+    v_inserted := v_inserted + 1;
+  END LOOP;
+
+  -- Apply the per-account balance effect, audited, inside the same transaction.
+  FOR v_acct_key, v_sum IN
+    SELECT key, value::numeric FROM jsonb_each_text(v_sums)
+  LOOP
+    SELECT * INTO v_before
+      FROM public.accounts
+     WHERE id = v_acct_key::uuid AND user_id = p_user_id
+     FOR UPDATE;
+    IF NOT FOUND THEN
+      RAISE EXCEPTION 'account_not_found_or_not_owned' USING ERRCODE = 'P0001';
+    END IF;
+
+    IF (v_backfills->>v_acct_key)::boolean THEN
+      -- Backfill: history already embodied in the snapshot balance.
+      UPDATE public.accounts
+         SET initial_balance = COALESCE(initial_balance, 0) - v_sum,
+             updated_at = now()
+       WHERE id = v_acct_key::uuid AND user_id = p_user_id
+       RETURNING * INTO v_after;
+    ELSE
+      -- Incremental: new money movement adjusts the ledger balance.
+      UPDATE public.accounts
+         SET balance = balance + v_sum,
+             updated_at = now()
+       WHERE id = v_acct_key::uuid AND user_id = p_user_id
+       RETURNING * INTO v_after;
+    END IF;
+
+    PERFORM public.write_financial_audit(
+      p_user_id, 'account', v_acct_key::uuid, 'update',
+      to_jsonb(v_before), to_jsonb(v_after)
+    );
+  END LOOP;
+
+  RETURN jsonb_build_object('inserted', v_inserted, 'skipped', v_skipped);
+END;
+$$;
+
+COMMIT;


### PR DESCRIPTION
**I scanned production before building, and it reframed the problem.** Of your 9,229 uncategorised rows:

| What | Rows |
|---|---:|
| Transfer pairs (PR #135 clears these) | 2,544 |
| **Ordinary merchants, no category** | **5,625** |
| Adjustments / valuations *(the work I had queued next)* | 809 |
| Interest / unpaired transfer-worded | 251 |

The same merchants, over and over: **Boots ×167, "Goverment 'Top Up'" ×126, WISEVILLE ×115, Clinton Cards ×110**. And 4,977 of the 6,685 rows left after transfer-matching sit in **752 repeated-payee groups** — the top 20 covering 1,732 rows. So the lever is one decision per **payee**, not per transaction.

## The tool
From the Reports review band: *"Or categorise by payee"* lists your merchants biggest-first — payee, row count, total, date span, accounts — each with a category picker. One decision files the whole merchant. Applying only ever **fills blanks**; a category you set explicitly is never overwritten (the server re-enforces it).

## Payee memory now follows the habit — your Amazon question
It inherited the **most recent** category, so filing one Amazon order as Household : Repairs redirected *every* future Amazon import, however many Consumables rows preceded it. Now the **most-used** category wins, ties broken by recency: a habit holds, a genuine change takes over once it becomes the habit, and one accident no longer steers the future. Where your most recent choice differs, the list offers it as a one-click **"use last: …"**, so a deliberate change is never buried.

**Migration `20260722140000_payee_memory_most_common.sql`** moves the bank-import prefill onto a shared `payee_memory_category()` helper implementing the same rule — server and app can't drift. **For your SQL editor when this lands.**

## Verification
11 unit tests (grouping/normalisation, direction split, most-common suggestion, tie→recency, last-used exposure/omission, exclusions, dangling category ids, ordering, span). Browser-verified end to end: Boots ×5 with no history awaited a choice; Amazon ×3 arrived pre-filled *"usually Groceries : Food & Drink (2)"* despite a more recent £300 one-off elsewhere; applying categorised all 3 Amazon rows and left Boots untouched. Strict types, lint, smoke (3,125), build green.

Stacked on #135 and #136 — merge those first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)