### PR TITLE
feat(ui): adjustable performance period, custom-report polish, valid PWA manifest, self-identifying CSP violations

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <link rel="icon" type="image/svg+xml" href="/vite.svg" />
+    <link rel="icon" type="image/svg+xml" href="/icon.svg" />
     <link rel="manifest" href="/manifest.json" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
     <meta name="theme-color" content="#1a2332" />

--- a/public/icon.svg
+++ b/public/icon.svg
@@ -1,0 +1,14 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" role="img" aria-label="WealthTracker">
+  <rect width="512" height="512" rx="112" fill="#1a2332"/>
+  <!-- Rising trend line: the app's one idea, wealth over time -->
+  <polyline points="112,344 208,248 288,312 400,168"
+            fill="none" stroke="#4ade80" stroke-width="34"
+            stroke-linecap="round" stroke-linejoin="round"/>
+  <!-- Arrow head closing the trend -->
+  <polyline points="330,168 400,168 400,238"
+            fill="none" stroke="#4ade80" stroke-width="34"
+            stroke-linecap="round" stroke-linejoin="round"/>
+  <!-- Baseline -->
+  <line x1="112" y1="400" x2="400" y2="400"
+        stroke="#ffffff" stroke-opacity="0.35" stroke-width="20" stroke-linecap="round"/>
+</svg>

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,0 +1,50 @@
+{
+  "id": "wealth-tracker-pwa",
+  "name": "WealthTracker - Personal Finance Manager",
+  "short_name": "WealthTracker",
+  "description": "Track your finances, manage budgets, and achieve your financial goals with WealthTracker",
+  "start_url": "/",
+  "scope": "/",
+  "display": "standalone",
+  "display_override": ["window-controls-overlay", "standalone", "minimal-ui"],
+  "orientation": "any",
+  "lang": "en-GB",
+  "theme_color": "#1a2332",
+  "background_color": "#f8fafc",
+  "categories": ["finance", "productivity", "business"],
+  "prefer_related_applications": false,
+  "icons": [
+    {
+      "src": "/icon.svg",
+      "sizes": "any",
+      "type": "image/svg+xml",
+      "purpose": "any"
+    },
+    {
+      "src": "/icon.svg",
+      "sizes": "any",
+      "type": "image/svg+xml",
+      "purpose": "maskable"
+    }
+  ],
+  "shortcuts": [
+    {
+      "name": "Dashboard",
+      "short_name": "Dashboard",
+      "description": "View your financial dashboard",
+      "url": "/dashboard"
+    },
+    {
+      "name": "Accounts",
+      "short_name": "Accounts",
+      "description": "See every account and balance",
+      "url": "/accounts"
+    },
+    {
+      "name": "Reports",
+      "short_name": "Reports",
+      "description": "Income, expenses and net worth over time",
+      "url": "/reports"
+    }
+  ]
+}

--- a/src/components/CustomReportBuilder.tsx
+++ b/src/components/CustomReportBuilder.tsx
@@ -472,7 +472,9 @@ export default function CustomReportBuilder({
         <h3 className="text-sm font-medium text-gray-700 dark:text-gray-300 mb-3">
           Report Filters
         </h3>
-        <div className="flex flex-wrap gap-3">
+        {/* items-start keeps the single-choice controls at their natural
+            height instead of stretching them to match the taller lists. */}
+        <div className="flex flex-wrap items-start gap-3">
           <select
             value={filters.dateRange}
             onChange={(e) => handleDateRangeChange(e.target.value as CustomReport['filters']['dateRange'])}
@@ -504,9 +506,10 @@ export default function CustomReportBuilder({
           {accounts.length > 0 && (
             <select
               multiple
+              size={9}
               value={filters.accounts ?? []}
               onChange={handleAccountSelection}
-              className="px-3 py-2 bg-white dark:bg-gray-800 border border-gray-300 dark:border-gray-600 rounded-lg text-sm min-w-[160px]"
+              className="px-3 py-2 bg-white dark:bg-gray-800 border border-gray-300 dark:border-gray-600 rounded-lg text-sm min-w-[160px] max-w-full"
             >
               {accounts.map(account => (
                 <option key={account.id} value={account.id}>
@@ -519,9 +522,10 @@ export default function CustomReportBuilder({
           {categories.length > 0 && (
             <select
               multiple
+              size={9}
               value={filters.categories ?? []}
               onChange={handleCategorySelection}
-              className="px-3 py-2 bg-white dark:bg-gray-800 border border-gray-300 dark:border-gray-600 rounded-lg text-sm min-w-[160px]"
+              className="px-3 py-2 bg-white dark:bg-gray-800 border border-gray-300 dark:border-gray-600 rounded-lg text-sm min-w-[160px] max-w-full"
             >
               {categories.map(category => (
                 <option key={category.id} value={category.id}>
@@ -534,9 +538,10 @@ export default function CustomReportBuilder({
           {tags && tags.length > 0 && (
             <select
               multiple
+              size={9}
               value={filters.tags ?? []}
               onChange={handleTagSelection}
-              className="px-3 py-2 bg-white dark:bg-gray-800 border border-gray-300 dark:border-gray-600 rounded-lg text-sm min-w-[160px]"
+              className="px-3 py-2 bg-white dark:bg-gray-800 border border-gray-300 dark:border-gray-600 rounded-lg text-sm min-w-[160px] max-w-full"
             >
               {tags.map(tag => (
                 <option key={String(tag)} value={String(tag)}>

--- a/src/components/dashboard/ImprovedDashboard.tsx
+++ b/src/components/dashboard/ImprovedDashboard.tsx
@@ -25,7 +25,7 @@ import EditTransactionModal from '../EditTransactionModal';
 import IncomeExpenseBreakdownModal from '../IncomeExpenseBreakdownModal';
 import { Modal, ModalBody } from '../common/Modal';
 import PeriodPicker from '../../components/PeriodPicker';
-import { usePeriod } from '../../hooks/usePeriod';
+import { PERIOD_LABELS, usePeriod } from '../../hooks/usePeriod';
 import { customReportService } from '../../services/customReportService';
 import {
   BUILT_IN_REPORTS,
@@ -74,6 +74,9 @@ export function ImprovedDashboard() {
   });
   const [showReportPicker, setShowReportPicker] = useState(false);
   const reportsPeriod = usePeriod('dashboardReports', 'last-12-months');
+  // Performance keeps its OWN period (and storage key) so changing what the
+  // pinned reports cover never silently rewrites the headline income figure.
+  const performancePeriod = usePeriod('dashboardPerformance', 'this-month');
 
   const togglePinnedReport = (id: PinnableReportId): void => {
     setPinnedReports(prev => {
@@ -128,7 +131,8 @@ export function ImprovedDashboard() {
 
     const netWorth = toDecimal(totalAssets).minus(toDecimal(totalLiabilities)).toNumber();
 
-    // Calculate monthly change (last 30 days)
+    // Budget progress reads the last 30 days — a rolling month of spending,
+    // deliberately independent of the Performance card's chosen period.
     const thirtyDaysAgo = new Date();
     thirtyDaysAgo.setDate(thirtyDaysAgo.getDate() - 30);
 
@@ -136,18 +140,6 @@ export function ImprovedDashboard() {
       new Date(t.date) >= thirtyDaysAgo
     );
 
-    // Income/expenses by CATEGORY SEMANTICS (utils/incomeExpense): a refund
-    // filed under an expense category is an expense credit that reduces
-    // spending — direction of movement never decides the bucket.
-    const flows = computeIncomeExpense(recentTransactions, transactionSplits, categories);
-    const monthlyIncome = flows.income.toNumber();
-    const monthlyExpenses = flows.expenses.toNumber();
-
-    const monthlySavings = toDecimal(monthlyIncome).minus(toDecimal(monthlyExpenses)).toNumber();
-    const savingsRate = monthlyIncome > 0
-      ? toDecimal(monthlySavings).dividedBy(toDecimal(monthlyIncome)).times(100).toNumber()
-      : 0;
-    
     // Get recent activity (copy before sort — never mutate the shared context array)
     const recentActivity = [...transactions]
       .sort((a, b) => new Date(b.date).getTime() - new Date(a.date).getTime())
@@ -207,12 +199,6 @@ export function ImprovedDashboard() {
       netWorth,
       totalAssets,
       totalLiabilities,
-      monthlyIncome,
-      monthlyExpenses,
-      monthlyIncomeRows: flows.incomeRows,
-      monthlyExpenseRows: flows.expenseRows,
-      monthlySavings,
-      savingsRate,
       recentActivity,
       accountsNeedingAttention,
       budgetStatus,
@@ -222,8 +208,27 @@ export function ImprovedDashboard() {
       netWorthChange: 0, // Will be calculated from actual historical data when available
       netWorthChangePercent: 0 // Will be calculated from actual historical data when available
     };
-  }, [accounts, transactions, transactionSplits, budgets, categories]);
-  
+  }, [accounts, transactions, transactionSplits, budgets]);
+
+  // Performance figures for the SELECTED period. Income/expenses come from
+  // CATEGORY SEMANTICS (utils/incomeExpense): a refund filed under an expense
+  // category is an expense credit that reduces spending — direction of
+  // movement never decides the bucket. The cards and the breakdown modal read
+  // these same totals, so both always describe one and the same window.
+  const performance = useMemo(() => {
+    const { from, to } = performancePeriod.range;
+    const flows = computeIncomeExpense(transactions, transactionSplits, categories, {
+      from: from ?? undefined,
+      to: to ?? undefined,
+    });
+    return {
+      income: flows.income.toNumber(),
+      expenses: flows.expenses.toNumber(),
+      incomeRows: flows.incomeRows,
+      expenseRows: flows.expenseRows,
+    };
+  }, [transactions, transactionSplits, categories, performancePeriod.range]);
+
   // Generate net worth data for chart - ONLY REAL DATA
   const netWorthData = useMemo(() => {
     // Only show current month's actual data
@@ -367,15 +372,20 @@ export function ImprovedDashboard() {
         </div>
       </section>
 
-      {/* Secondary Focus: This Month's Performance */}
-      <section 
-        aria-labelledby="monthly-performance-heading"
+      {/* Secondary Focus: Performance over the chosen period */}
+      <section
+        aria-labelledby="performance-heading"
         className="bg-white dark:bg-gray-800 rounded-xl shadow-sm border border-gray-100 dark:border-gray-700 p-6"
       >
-        <h3 id="monthly-performance-heading" className="text-lg font-semibold text-gray-900 dark:text-white mb-4">
-          This Month's Performance
-        </h3>
-        
+        <div className="flex flex-wrap items-center gap-3 mb-4">
+          <h3 id="performance-heading" className="text-lg font-semibold text-gray-900 dark:text-white">
+            Performance
+          </h3>
+          <div className="ml-auto">
+            <PeriodPicker picker={performancePeriod} />
+          </div>
+        </div>
+
         <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
           <button
             type="button"
@@ -385,7 +395,7 @@ export function ImprovedDashboard() {
             <div>
               <p className="text-sm text-gray-600 dark:text-gray-400">Income</p>
               <p className="text-xl font-bold text-green-600 dark:text-green-400">
-                {formatCurrencyWithSymbol(metrics.monthlyIncome)}
+                {formatCurrencyWithSymbol(performance.income)}
               </p>
             </div>
             <TrendingUpIcon size={24} className="text-green-500" />
@@ -399,7 +409,7 @@ export function ImprovedDashboard() {
             <div>
               <p className="text-sm text-gray-600 dark:text-gray-400">Expenses</p>
               <p className="text-xl font-bold text-red-600 dark:text-red-400">
-                {formatCurrencyWithSymbol(metrics.monthlyExpenses)}
+                {formatCurrencyWithSymbol(performance.expenses)}
               </p>
             </div>
             <TrendingDownIcon size={24} className="text-red-500" />
@@ -499,10 +509,10 @@ export function ImprovedDashboard() {
       <IncomeExpenseBreakdownModal
         isOpen={breakdownType !== null}
         onClose={() => setBreakdownType(null)}
-        title={`${breakdownType === 'income' ? 'Income' : 'Expenses'} This Month`}
+        title={`${breakdownType === 'income' ? 'Income' : 'Expenses'} — ${PERIOD_LABELS[performancePeriod.period]}`}
         bucket={breakdownType ?? 'income'}
-        rows={breakdownType === 'income' ? metrics.monthlyIncomeRows : metrics.monthlyExpenseRows}
-        total={breakdownType === 'income' ? metrics.monthlyIncome : metrics.monthlyExpenses}
+        rows={breakdownType === 'income' ? performance.incomeRows : performance.expenseRows}
+        total={breakdownType === 'income' ? performance.income : performance.expenses}
         categories={categories}
         onEditTransaction={setEditingBreakdownTxnId}
       />

--- a/src/pages/CustomReports.tsx
+++ b/src/pages/CustomReports.tsx
@@ -157,6 +157,9 @@ export default function CustomReports(): React.JSX.Element {
         <h2 className="text-lg font-semibold text-gray-900 dark:text-white mb-4">
           Quick Start Templates
         </h2>
+        {/* Each card stacks its name over its description: the global
+            `button { display: inline-flex }` (index.css) otherwise lays the
+            two out as a row, running the name straight into the text. */}
         <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
           <button
             onClick={() => {
@@ -192,7 +195,7 @@ export default function CustomReports(): React.JSX.Element {
                 updatedAt: new Date()
               });
             }}
-            className="p-4 border-2 border-dashed border-gray-300 dark:border-gray-600 rounded-lg hover:border-primary hover:bg-gray-50 dark:hover:bg-gray-700 text-left"
+            className="flex flex-col items-start p-4 border-2 border-dashed border-gray-300 dark:border-gray-600 rounded-lg hover:border-primary hover:bg-gray-50 dark:hover:bg-gray-700 text-left"
           >
             <h3 className="font-medium text-gray-900 dark:text-white">Monthly Summary</h3>
             <p className="text-sm text-gray-600 dark:text-gray-400 mt-1">
@@ -220,7 +223,7 @@ export default function CustomReports(): React.JSX.Element {
                 updatedAt: new Date()
               });
             }}
-            className="p-4 border-2 border-dashed border-gray-300 dark:border-gray-600 rounded-lg hover:border-primary hover:bg-gray-50 dark:hover:bg-gray-700 text-left"
+            className="flex flex-col items-start p-4 border-2 border-dashed border-gray-300 dark:border-gray-600 rounded-lg hover:border-primary hover:bg-gray-50 dark:hover:bg-gray-700 text-left"
           >
             <h3 className="font-medium text-gray-900 dark:text-white">Budget vs Actual</h3>
             <p className="text-sm text-gray-600 dark:text-gray-400 mt-1">
@@ -248,7 +251,7 @@ export default function CustomReports(): React.JSX.Element {
                 updatedAt: new Date()
               });
             }}
-            className="p-4 border-2 border-dashed border-gray-300 dark:border-gray-600 rounded-lg hover:border-primary hover:bg-gray-50 dark:hover:bg-gray-700 text-left"
+            className="flex flex-col items-start p-4 border-2 border-dashed border-gray-300 dark:border-gray-600 rounded-lg hover:border-primary hover:bg-gray-50 dark:hover:bg-gray-700 text-left"
           >
             <h3 className="font-medium text-gray-900 dark:text-white">Year-over-Year</h3>
             <p className="text-sm text-gray-600 dark:text-gray-400 mt-1">

--- a/src/security/csp.ts
+++ b/src/security/csp.ts
@@ -189,24 +189,51 @@ export const applyCSPMetaTag = (): void => {
 export const setupCSPReporting = (): void => {
   if (typeof window !== 'undefined' && 'SecurityPolicyViolationEvent' in window && typeof document !== 'undefined') {
     document.addEventListener('securitypolicyviolation', (e: SecurityPolicyViolationEvent) => {
-      securityLogger.error('CSP Violation:', {
-        blockedURI: e.blockedURI,
-        violatedDirective: e.violatedDirective,
-        originalPolicy: e.originalPolicy,
-        disposition: e.disposition,
-        documentURI: e.documentURI,
-        effectiveDirective: e.effectiveDirective,
-        lineNumber: e.lineNumber,
-        columnNumber: e.columnNumber,
-        sourceFile: e.sourceFile,
-        statusCode: e.statusCode,
-      });
+      // The WHERE goes in the MESSAGE, not a collapsed object: a violation
+      // whose origin you have to expand a console group to find is a
+      // violation nobody chases. (Chasing a production `eval` block is
+      // exactly how this line earned its keep.)
+      const origin = e.sourceFile
+        ? `${e.sourceFile}:${e.lineNumber}:${e.columnNumber}`
+        : 'unknown source';
+      securityLogger.error(
+        `CSP Violation: "${e.blockedURI}" blocked by ${e.violatedDirective} at ${origin}`,
+        {
+          blockedURI: e.blockedURI,
+          violatedDirective: e.violatedDirective,
+          effectiveDirective: e.effectiveDirective,
+          disposition: e.disposition,
+          documentURI: e.documentURI,
+          sourceFile: e.sourceFile,
+          lineNumber: e.lineNumber,
+          columnNumber: e.columnNumber,
+          statusCode: e.statusCode,
+        }
+      );
 
-      // In production, you might want to send this to a logging service
+      // Report it: a CSP violation in production is either an attack signal
+      // or a broken feature, and both deserve to reach monitoring rather
+      // than living in one user's console. (Sentry ingest itself was blocked
+      // by this very policy until the connect-src fix — hence the guard
+      // against reporting a violation caused by reporting.)
       const isProduction = typeof import.meta !== 'undefined' && import.meta.env?.MODE === 'production';
-      if (isProduction) {
-        // Example: Send to logging service
-        // logService.logCSPViolation({...});
+      if (isProduction && !e.blockedURI.includes('sentry')) {
+        void import('../lib/sentry').then(({ captureMessage }) => {
+          captureMessage(
+            `CSP violation: ${e.blockedURI} blocked by ${e.violatedDirective}`,
+            'warning',
+            {
+              blockedURI: e.blockedURI,
+              violatedDirective: e.violatedDirective,
+              sourceFile: e.sourceFile,
+              lineNumber: e.lineNumber,
+              columnNumber: e.columnNumber,
+              documentURI: e.documentURI,
+            }
+          );
+        }).catch(() => {
+          // Monitoring must never break the app it monitors.
+        });
       }
     });
   }

--- a/src/test/integration/DashboardInteractionsIntegration.test.tsx
+++ b/src/test/integration/DashboardInteractionsIntegration.test.tsx
@@ -84,13 +84,17 @@ describe('Dashboard Interactions Integration', () => {
       expect(liabilitiesLabel).toBeInTheDocument();
     }, 20000);
 
-    it('should display monthly performance metrics', async () => {
+    it('should display performance metrics for the selected period', async () => {
       renderWithProviders(<Dashboard />);
 
-      const performanceHeading = await screen.findByText(/this month's performance/i);
+      // The section is period-adjustable now, so it is titled "Performance"
+      // with a period picker beside it rather than a fixed "This Month's".
+      const performanceHeading = await screen.findByRole('heading', { name: /^performance$/i });
       expect(performanceHeading).toBeInTheDocument();
       expect(screen.getByText(/income/i)).toBeInTheDocument();
       expect(screen.getByText(/expenses/i)).toBeInTheDocument();
+      // The picker offering the same windows as the rest of the app.
+      expect(screen.getAllByRole('button', { name: /this month/i }).length).toBeGreaterThan(0);
     });
 
     it('should display recent transactions widget', async () => {


### PR DESCRIPTION
Your three UI tasks plus the two bugs from your production console. Kept as one PR because every piece is small and they ship together.

## Your tasks
1. **"This Month's Performance" is now adjustable** — retitled **Performance**, with the same period picker as the Reports hub (This month / Last month / Tax year / 12 months / All time / Custom). It keeps its **own** saved period, so changing what your pinned reports cover never silently rewrites the headline income figure. The cards, the breakdown modal **and its title** all follow the selected window — nothing says "This Month" while showing a tax year.
2. **Quick Start Template spacing** — root cause was the *same* global rule behind your earlier stat-card misalignment: `button { display: inline-flex }` lays a button's children out as a **row**, running the bold name straight into the description. Each template now stacks name over description.
3. **Report Filters boxes** — account / category / tag lists now show **nine** options instead of four, and the date `select` beside them keeps its natural height instead of stretching.

## From your console
4. **"The manifest is not valid JSON data"** — `public/` was **empty**: `/manifest.json` didn't exist, so the request fell through to the SPA rewrite and the browser parsed **index.html** as JSON. The favicon was broken identically (`/vite.svg`, also missing). Adds a real manifest (identity, navy theme colour, shortcuts to Dashboard/Accounts/Reports) and an original SVG icon, favicon pointed at it. Both verified to serve correctly and ship in the build.
5. **CSP violations now name their own source** — `CSP Violation: "eval" blocked by script-src at <file>:<line>:<col>`, and reported to Sentry in production (working again since the connect-src fix), guarded so a Sentry-caused violation can't recurse.

**Deliberately NOT done:** silencing the `eval` itself. The real header forbids eval while the runtime meta tag claims `'unsafe-eval'` — the header is right. Granting unsafe-eval to quiet an unidentified dependency would trade a genuine XSS protection for a tidy console. The instrumentation will name the caller on your next production load; send it to me and I'll fix the actual cause.

## Notes
Removed `monthlySavings`/`savingsRate` — computed and returned, rendered nowhere (already dead on main). An integration test asserting the old heading was **updated** to the new behaviour, not deleted. Strict types, lint, smoke, build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)