### PR TITLE
perf(dashboard): paint real balances from one round trip while the transaction pages stream in

### DIFF
--- a/src/components/dashboard/ImprovedDashboard.tsx
+++ b/src/components/dashboard/ImprovedDashboard.tsx
@@ -40,6 +40,7 @@ import { formatDecimal } from '../../utils/decimal-format';
 import { toDecimal } from '../../utils/decimal';
 import { expandSplitTransactions } from '../../utils/transactionSplits';
 import { computeIncomeExpense } from '../../utils/incomeExpense';
+import { computeAccountBalances } from '../../utils/accountBalances';
 
 /**
  * Improved Dashboard with better information hierarchy
@@ -50,7 +51,7 @@ import { computeIncomeExpense } from '../../utils/incomeExpense';
  * 4. Mobile-optimized - works great on all screen sizes
  */
 export function ImprovedDashboard() {
-  const { accounts, transactions, transactionSplits, budgets, categories } = useApp();
+  const { accounts, transactions, transactionSplits, budgets, categories, serverBalances } = useApp();
   const { formatCurrency: formatCurrencyWithSymbol, displayCurrency } = useCurrencyDecimal();
   const navigate = useNavigate();
   const location = useLocation();
@@ -102,22 +103,21 @@ export function ImprovedDashboard() {
     setSelectedAccountIds(accounts.slice(0, 4).map(a => a.id));
   }, [accounts]);
 
+  // Real balance = openingBalance + Σ transactions, computed in ONE pass over
+  // the whole transaction set. The previous per-account filters were
+  // O(accounts × transactions) and ran up to five times per account —
+  // ~50 MILLION Decimal operations per render on a 50k-row dataset. While the
+  // transaction pages are still streaming in, the server's one-round-trip
+  // balances stand in (see computeAccountBalances).
+  const accountBalanceMap = useMemo(
+    () => computeAccountBalances(accounts, transactions, serverBalances),
+    [accounts, transactions, serverBalances]
+  );
+
   // Calculate key metrics — all money sums use Decimal arithmetic (float math
   // is banned on currency values; IEEE-754 drifts on long sums).
   const metrics = useMemo(() => {
-    // Real balance = openingBalance + Σ transactions, computed in ONE pass
-    // over the whole transaction set. The previous per-account filters were
-    // O(accounts × transactions) and ran up to five times per account —
-    // ~50 MILLION Decimal operations per render on a 50k-row dataset.
-    const txnTotals = new Map<string, ReturnType<typeof toDecimal>>();
-    for (const t of transactions) {
-      txnTotals.set(t.accountId, (txnTotals.get(t.accountId) ?? toDecimal(0)).plus(toDecimal(t.amount)));
-    }
-    const balances = new Map<string, number>();
-    for (const acc of accounts) {
-      balances.set(acc.id, toDecimal(acc.openingBalance ?? 0).plus(txnTotals.get(acc.id) ?? toDecimal(0)).toNumber());
-    }
-    const effectiveBalance = (acc: typeof accounts[0]): number => balances.get(acc.id) ?? 0;
+    const effectiveBalance = (acc: typeof accounts[0]): number => accountBalanceMap.get(acc.id) ?? 0;
 
     const totalAssets = accounts
       .filter(acc => effectiveBalance(acc) > 0)
@@ -208,7 +208,7 @@ export function ImprovedDashboard() {
       netWorthChange: 0, // Will be calculated from actual historical data when available
       netWorthChangePercent: 0 // Will be calculated from actual historical data when available
     };
-  }, [accounts, transactions, transactionSplits, budgets]);
+  }, [accounts, accountBalanceMap, transactions, transactionSplits, budgets]);
 
   // Performance figures for the SELECTED period. Income/expenses come from
   // CATEGORY SEMANTICS (utils/incomeExpense): a refund filed under an expense
@@ -244,21 +244,6 @@ export function ImprovedDashboard() {
     }];
   }, [metrics.netWorth]);
   
-  // Pre-compute real balances per account (openingBalance + sum of transactions)
-  const accountBalanceMap = useMemo(() => {
-    // Single pass over transactions (Decimal — float sums drift on 50k-row
-    // histories), then one lookup per account. Was O(accounts × transactions).
-    const txnTotals = new Map<string, ReturnType<typeof toDecimal>>();
-    for (const t of transactions) {
-      txnTotals.set(t.accountId, (txnTotals.get(t.accountId) ?? toDecimal(0)).plus(toDecimal(t.amount)));
-    }
-    const map = new Map<string, number>();
-    accounts.forEach(acc => {
-      map.set(acc.id, toDecimal(acc.openingBalance ?? 0).plus(txnTotals.get(acc.id) ?? toDecimal(0)).toNumber());
-    });
-    return map;
-  }, [accounts, transactions]);
-
   const getAccountBalance = useCallback((acc: typeof accounts[0]) => accountBalanceMap.get(acc.id) ?? 0, [accountBalanceMap]);
 
   // Generate pie chart data for account distribution

--- a/src/contexts/AppContextSupabase.tsx
+++ b/src/contexts/AppContextSupabase.tsx
@@ -19,6 +19,8 @@ import {
   toDecimalGoal
 } from '../utils/decimal-converters';
 import { toDecimal } from '../utils/decimal';
+import { TransactionService } from '../services/api/transactionService';
+import type { ServerAccountBalance } from '../utils/accountBalances';
 import type { DecimalTransaction, DecimalAccount, DecimalGoal } from '../types/decimal-types';
 import type {
   Account,
@@ -136,6 +138,14 @@ export interface AppContextType extends AppState {
    * parents into these via expandSplitTransactions.
    */
   transactionSplits: TransactionSplit[];
+  /**
+   * Per-account balance summed in Postgres (initial_balance + Σ amount) in one
+   * round trip, loaded alongside the ~52-page transaction fetch. Balance
+   * surfaces read it ONLY while `transactions` is still empty, so the first
+   * paint shows real money instead of zeros; empty map when the cloud call is
+   * unavailable, in which case nothing changes.
+   */
+  serverBalances: Map<string, ServerAccountBalance>;
   /** Splits for one transaction, in display order (empty when not split). */
   getTransactionSplits: (transactionId: string) => Promise<TransactionSplit[]>;
   /**
@@ -183,7 +193,8 @@ export function AppProvider({ children }: { children: React.ReactNode }) {
   // surfaces (counters, budgets, analytics, exports) expand split parents
   // into these lines via expandSplitTransactions.
   const [transactionSplits, setTransactionSplitsState] = useState<TransactionSplit[]>([]);
-  
+  const [serverBalances, setServerBalances] = useState<Map<string, ServerAccountBalance>>(new Map());
+
   const [isLoading, setIsLoading] = useState(true);
   const [isSyncing, setIsSyncing] = useState(false);
   const [lastSyncTime, setLastSyncTime] = useState<Date | null>(null);
@@ -214,6 +225,10 @@ export function AppProvider({ children }: { children: React.ReactNode }) {
         phases[name] = Math.round(performance.now() - phaseStart);
         phaseStart = performance.now();
       };
+      // The balances round trip runs ALONGSIDE the phases below rather than
+      // between two of them, so it times itself instead of going through
+      // markPhase (which measures gaps in the sequential timeline).
+      let serverBalancesLoaded: Promise<void> | null = null;
 
       try {
         appLogger.info('Initializing app context', { userId: user?.id });
@@ -249,6 +264,17 @@ export function AppProvider({ children }: { children: React.ReactNode }) {
             appLogger.info('Accounts loaded', { count: accounts.length });
             setAccounts(accounts);
             markPhase('accounts');
+
+            // One round trip for every account's balance, started here and
+            // deliberately NOT awaited: the paged transaction load must not
+            // wait on it. Those pages are ~77% of the boot, and until they
+            // land every client-side balance is zero — these figures let the
+            // dashboard paint real money in the meantime.
+            const balancesStart = performance.now();
+            serverBalancesLoaded = TransactionService.getAccountBalances().then(balances => {
+              phases.balances = Math.round(performance.now() - balancesStart);
+              setServerBalances(balances);
+            });
           } else {
             appLogger.warn('Failed to resolve database user ID - no data will be loaded');
             setAccounts([]);
@@ -303,6 +329,9 @@ export function AppProvider({ children }: { children: React.ReactNode }) {
 
         setIsUsingSupabase(DataService.isUsingSupabase());
         setLastSyncTime(new Date());
+        // Settled long ago in practice (it started before the slowest phase) —
+        // awaited only so the summary line below can report its timing.
+        await serverBalancesLoaded;
         // The numbers live IN the message so any console shows the breakdown
         // without expanding an object — and via console.info directly, because
         // the scoped logger's console bridge is DEV-ONLY and this one line is
@@ -1129,6 +1158,7 @@ export function AppProvider({ children }: { children: React.ReactNode }) {
     archiveTransactionsBefore,
     unarchiveAccount,
     transactionSplits,
+    serverBalances,
     getTransactionSplits,
     setTransactionSplits,
     linkTransferPair,

--- a/src/pages/Accounts.tsx
+++ b/src/pages/Accounts.tsx
@@ -31,7 +31,7 @@ import { toDecimal } from '../utils/decimal';
 import { SkeletonCard } from '../components/loading/Skeleton';
 
 export default function Accounts({ onAccountClick }: { onAccountClick?: (accountId: string) => void }) {
-  const { accounts, transactions, updateAccount, deleteAccount, refreshAccountsAndTransactions, refreshCategories } = useApp();
+  const { accounts, transactions, serverBalances, updateAccount, deleteAccount, refreshAccountsAndTransactions, refreshCategories } = useApp();
   const { showError } = useToast();
   const { formatCurrency: formatDisplayCurrency } = useCurrencyDecimal();
   const navigate = useNavigate();
@@ -53,7 +53,18 @@ export default function Accounts({ onAccountClick }: { onAccountClick?: (account
       : 'default';
   });
 
-  const { getUnreconciledCount, computeAccountBalance } = useReconciliation(accounts, transactions);
+  const { getUnreconciledCount, computeAccountBalance: computeLedgerBalance } = useReconciliation(accounts, transactions);
+
+  // The transaction pages take seconds to arrive on a long history, and until
+  // the first one lands every ledger sum is just the opening balance. The
+  // server's one-round-trip figures (same invariant, summed in Postgres) stand
+  // in for that window only — the ledger computation is the source of truth
+  // and takes over the moment any transaction is present.
+  const seededBalances = transactions.length === 0 ? serverBalances : null;
+  const computeAccountBalance = useCallback(
+    (accountId: string): number => seededBalances?.get(accountId)?.balance ?? computeLedgerBalance(accountId),
+    [seededBalances, computeLedgerBalance]
+  );
   // Per-account bank connection metadata + one-click "pull fresh bank data".
   const { getAccountLink, isAccountSyncing, syncAccount } = useAccountBankSync({ onSynced: refreshAccountsAndTransactions });
 

--- a/src/services/__tests__/transactionService.test.ts
+++ b/src/services/__tests__/transactionService.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { createTransactionService, TransactionService } from '../api/transactionService';
+import { createTransactionService, TransactionService, toAccountBalanceMap } from '../api/transactionService';
 import type { Transaction } from '../../types';
 import { STORAGE_KEYS } from '../storageAdapter';
 
@@ -420,5 +420,49 @@ describe('TransactionService setTransactionSplits — local balance sync', () =>
 
     const accounts = storage.snapshot(STORAGE_KEYS.ACCOUNTS) as Array<{ balance: number }>;
     expect(accounts[0].balance).toBe(-70.3);
+  });
+});
+
+describe('toAccountBalanceMap', () => {
+  it('reads numeric balances that arrive as strings without float drift', () => {
+    const balances = toAccountBalanceMap([
+      { account_id: 'acc-1', balance: '1234.56', txn_count: '3' },
+      { account_id: 'acc-2', balance: -99.99, txn_count: 1 }
+    ]);
+
+    expect(balances.get('acc-1')).toEqual({ balance: 1234.56, txnCount: 3 });
+    expect(balances.get('acc-2')).toEqual({ balance: -99.99, txnCount: 1 });
+  });
+
+  it('skips unusable rows instead of failing the whole load', () => {
+    const balances = toAccountBalanceMap([
+      null,
+      'nonsense',
+      { account_id: '', balance: 5 },
+      { account_id: 'acc-2', balance: 'not-a-number' },
+      { account_id: 'acc-3' },
+      { account_id: 'acc-4', balance: 10 }
+    ]);
+
+    expect(balances.size).toBe(1);
+    expect(balances.get('acc-4')).toEqual({ balance: 10, txnCount: 0 });
+  });
+
+  it('returns an empty map for a payload that is not a row array', () => {
+    expect(toAccountBalanceMap(null).size).toBe(0);
+    expect(toAccountBalanceMap(undefined).size).toBe(0);
+    expect(toAccountBalanceMap({ account_id: 'acc-1', balance: 1 }).size).toBe(0);
+  });
+});
+
+describe('TransactionService.getAccountBalances', () => {
+  it('returns an empty map without the cloud connection — it is only an optimisation', async () => {
+    const service = createTransactionService({
+      isSupabaseConfigured: () => false,
+      storageAdapter: createStorage(),
+      logger: { error: vi.fn() }
+    });
+
+    await expect(service.getAccountBalances()).resolves.toEqual(new Map());
   });
 });

--- a/src/services/api/supabaseClient.ts
+++ b/src/services/api/supabaseClient.ts
@@ -69,6 +69,13 @@ type Database = {
         Args: { p_account_id: string; p_user_id?: string };
         Returns: Record<string, unknown>;
       };
+      // No arguments by design: the function reads the caller's identity from
+      // the JWT. numeric/bigint columns can arrive as strings, so the rows stay
+      // loosely typed and are narrowed at the call site.
+      account_balances: {
+        Args: Record<string, never>;
+        Returns: Record<string, unknown>[];
+      };
     };
     Enums: Record<string, never>;
     CompositeTypes: Record<string, never>;

--- a/src/services/api/transactionService.ts
+++ b/src/services/api/transactionService.ts
@@ -3,6 +3,7 @@ import { supabase, isSupabaseConfigured, handleSupabaseError } from './supabaseC
 import type { Account, Transaction, TransactionSplit, TransactionSplitInput } from '../../types';
 import { storageAdapter, STORAGE_KEYS } from '../storageAdapter';
 import { toDecimal } from '../../utils/decimal';
+import type { ServerAccountBalance } from '../../utils/accountBalances';
 
 type StorageAdapterLike = Pick<typeof storageAdapter, 'get' | 'set'>;
 type SupabaseClientLike = typeof supabase;
@@ -59,6 +60,40 @@ function mapFromDbFields(row: Record<string, unknown>): Record<string, unknown> 
     result[DB_TO_CAMEL[key] ?? key] = value;
   }
   return result;
+}
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === 'object' && value !== null;
+
+/**
+ * Shape account_balances() rows into a per-account lookup.
+ *
+ * PostgREST renders numeric as a JSON number or a string depending on the
+ * value, so every balance goes through Decimal — never parseFloat, never
+ * float addition. Rows that are not a usable {account_id, balance} pair are
+ * skipped rather than throwing: a malformed row must cost at most one
+ * account's head start, never the whole load.
+ */
+export function toAccountBalanceMap(rows: unknown): Map<string, ServerAccountBalance> {
+  const balances = new Map<string, ServerAccountBalance>();
+  if (!Array.isArray(rows)) {
+    return balances;
+  }
+  for (const row of rows) {
+    if (!isRecord(row)) continue;
+    const id = row.account_id;
+    const balance = row.balance;
+    if (typeof id !== 'string' || id === '') continue;
+    if (typeof balance !== 'number' && typeof balance !== 'string') continue;
+    // Validity gate only — the value itself is never read as a float.
+    if (!Number.isFinite(Number(balance))) continue;
+    const count = Number(row.txn_count);
+    balances.set(id, {
+      balance: toDecimal(balance).toNumber(),
+      txnCount: Number.isFinite(count) ? count : 0
+    });
+  }
+  return balances;
 }
 
 function mapToDbFields(obj: Record<string, unknown>): Record<string, unknown> {
@@ -193,6 +228,33 @@ class TransactionServiceImpl {
     } catch (error) {
       this.logger.error('TransactionService.getTransactions error:', error as Error);
       return this.readStoredTransactions();
+    }
+  }
+
+  /**
+   * Every account's balance from ONE round trip — Postgres sums
+   * initial_balance + Σ amount, instead of the client paging 50k rows to
+   * derive the same figures.
+   *
+   * Purely an optimisation for the seconds those pages are in flight, so it
+   * never throws and never blocks: any failure (local mode, RPC missing,
+   * network) returns an empty map and the app behaves exactly as it did
+   * before.
+   */
+  async getAccountBalances(): Promise<Map<string, ServerAccountBalance>> {
+    if (!this.isSupabaseReady()) {
+      return new Map();
+    }
+    try {
+      const { data, error } = await this.supabaseClient!.rpc('account_balances', {});
+      if (error) {
+        this.logger.error('Error loading account balances:', error);
+        return new Map();
+      }
+      return toAccountBalanceMap(data);
+    } catch (error) {
+      this.logger.error('TransactionService.getAccountBalances error:', error as Error);
+      return new Map();
     }
   }
 
@@ -949,6 +1011,10 @@ export class TransactionService {
 
   static getTransactions(userId: string): Promise<Transaction[]> {
     return this.service.getTransactions(userId);
+  }
+
+  static getAccountBalances(): Promise<Map<string, ServerAccountBalance>> {
+    return this.service.getAccountBalances();
   }
 
   static createTransaction(

--- a/src/test/mocks/AppContextSupabase.ts
+++ b/src/test/mocks/AppContextSupabase.ts
@@ -38,6 +38,7 @@ const baseValue = {
   setTransactionsCleared: asyncNoop,
   applyCategoryToUncategorized: async () => 0,
   transactionSplits: [],
+  serverBalances: new Map<string, { balance: number; txnCount: number }>(),
   getTransactionSplits: async () => [],
   setTransactionSplits: async () => ({ isSplit: false, splitCount: 0, amount: 0 }),
   linkTransferPair: async () => { throw new Error('not available in mock'); },

--- a/src/utils/accountBalances.test.ts
+++ b/src/utils/accountBalances.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect } from 'vitest';
+import { computeAccountBalances, type ServerAccountBalance } from './accountBalances';
+
+const accounts = [
+  { id: 'acc-1', openingBalance: 100 },
+  { id: 'acc-2', openingBalance: -50 },
+  { id: 'acc-3' }
+];
+
+const serverBalances = new Map<string, ServerAccountBalance>([
+  ['acc-1', { balance: 1234.56, txnCount: 3 }],
+  ['acc-2', { balance: -99.99, txnCount: 1 }]
+]);
+
+describe('computeAccountBalances', () => {
+  it('sums opening balance plus transactions for each account', () => {
+    const balances = computeAccountBalances(accounts, [
+      { accountId: 'acc-1', amount: 25.5 },
+      { accountId: 'acc-1', amount: -10.25 },
+      { accountId: 'acc-2', amount: -5 }
+    ]);
+
+    expect(balances.get('acc-1')).toBe(115.25);
+    expect(balances.get('acc-2')).toBe(-55);
+    expect(balances.get('acc-3')).toBe(0);
+  });
+
+  it('sums without float drift', () => {
+    const balances = computeAccountBalances(
+      [{ id: 'acc-1', openingBalance: 0 }],
+      [
+        { accountId: 'acc-1', amount: 0.1 },
+        { accountId: 'acc-1', amount: 0.2 }
+      ]
+    );
+
+    expect(balances.get('acc-1')).toBe(0.3);
+  });
+
+  it('uses server balances while the transaction pages are still empty', () => {
+    const balances = computeAccountBalances(accounts, [], serverBalances);
+
+    expect(balances.get('acc-1')).toBe(1234.56);
+    expect(balances.get('acc-2')).toBe(-99.99);
+  });
+
+  it('falls back to the opening balance for accounts the server did not report', () => {
+    const balances = computeAccountBalances(accounts, [], serverBalances);
+
+    expect(balances.get('acc-3')).toBe(0);
+  });
+
+  it('ignores server balances as soon as any transaction has arrived', () => {
+    const balances = computeAccountBalances(
+      accounts,
+      [{ accountId: 'acc-1', amount: 25 }],
+      serverBalances
+    );
+
+    expect(balances.get('acc-1')).toBe(125);
+    expect(balances.get('acc-2')).toBe(-50);
+  });
+
+  it('computes the ledger balance when no server balances are available', () => {
+    const empty = new Map<string, ServerAccountBalance>();
+
+    expect(computeAccountBalances(accounts, [], empty).get('acc-1')).toBe(100);
+    expect(computeAccountBalances(accounts, []).get('acc-1')).toBe(100);
+  });
+});

--- a/src/utils/accountBalances.ts
+++ b/src/utils/accountBalances.ts
@@ -1,0 +1,56 @@
+import { toDecimal } from './decimal';
+
+/** One account's balance as computed by the account_balances() RPC. */
+export interface ServerAccountBalance {
+  balance: number;
+  txnCount: number;
+}
+
+interface AccountLike {
+  id: string;
+  openingBalance?: number;
+}
+
+interface TransactionAmountLike {
+  accountId: string;
+  amount: number;
+}
+
+/**
+ * Ledger balance per account: openingBalance + Σ transaction amounts.
+ *
+ * Single pass over transactions (Decimal — float sums drift on 50k-row
+ * histories), then one lookup per account, so it stays O(accounts +
+ * transactions) rather than the product of the two.
+ *
+ * The transaction set arrives in ~52 pages and takes seconds on a long
+ * history; until the first page lands every ledger sum is just the opening
+ * balance, so where the server has already answered with the same invariant
+ * (initial_balance + Σ amount, summed in Postgres) its figures stand in and
+ * the dashboard opens on real money instead of zeros. They are only ever a
+ * stand-in: the client sum is the source of truth and wins back the moment
+ * any transaction is present.
+ */
+export function computeAccountBalances(
+  accounts: readonly AccountLike[],
+  transactions: readonly TransactionAmountLike[],
+  serverBalances?: ReadonlyMap<string, ServerAccountBalance>
+): Map<string, number> {
+  const txnTotals = new Map<string, ReturnType<typeof toDecimal>>();
+  for (const t of transactions) {
+    txnTotals.set(t.accountId, (txnTotals.get(t.accountId) ?? toDecimal(0)).plus(toDecimal(t.amount)));
+  }
+
+  const seedFromServer = transactions.length === 0 && (serverBalances?.size ?? 0) > 0;
+  const balances = new Map<string, number>();
+  for (const acc of accounts) {
+    const server = seedFromServer ? serverBalances?.get(acc.id) : undefined;
+    balances.set(
+      acc.id,
+      server
+        ? server.balance
+        : toDecimal(acc.openingBalance ?? 0).plus(txnTotals.get(acc.id) ?? toDecimal(0)).toNumber()
+    );
+  }
+  return balances;
+}

--- a/supabase/migrations/20260722160000_account_balances_rpc.sql
+++ b/supabase/migrations/20260722160000_account_balances_rpc.sql
@@ -1,0 +1,51 @@
+-- ============================================================================
+-- account_balances() — every account's balance in ONE round trip.
+--
+-- The dashboard's headline figures (net worth, per-account balances, assets,
+-- liabilities) are derived client-side from the FULL transaction set. A
+-- Money-era history is 50k+ rows, which PostgREST hands over in ~52 pages of
+-- 1,000 — measured at 2.7s of a 3.6s boot, with the user watching a skeleton
+-- the whole time. Postgres can produce the same invariant
+--
+--     balance = accounts.initial_balance + SUM(transactions.amount)
+--
+-- in a single aggregate, so the app can paint real balances immediately and
+-- let the page fetches stream in behind for the register and reports.
+--
+-- The sum deliberately spans ALL transactions, archived included: archiving is
+-- a view flag (see 20260721130000_soft_archive.sql) and never moves a balance.
+--
+-- SECURITY DEFINER because the aggregate must see the caller's own rows
+-- without RLS re-planning per page; identity comes from the verified JWT via
+-- requesting_user_id(), so there is no parameter to spoof and an
+-- unauthenticated caller matches nothing and gets no rows.
+-- ============================================================================
+
+BEGIN;
+
+CREATE OR REPLACE FUNCTION public.account_balances()
+RETURNS TABLE (account_id uuid, balance numeric, txn_count bigint)
+LANGUAGE sql STABLE SECURITY DEFINER
+SET search_path = public
+AS $$
+  SELECT
+    a.id,
+    COALESCE(a.initial_balance, 0) + COALESCE(SUM(t.amount), 0),
+    COUNT(t.id)
+  FROM public.accounts a
+  -- LEFT JOIN so an account with no transactions still reports its opening
+  -- balance instead of dropping out of the result.
+  LEFT JOIN public.transactions t
+         ON t.account_id = a.id
+        AND t.user_id = a.user_id
+  WHERE a.user_id = public.requesting_user_id()
+  GROUP BY a.id, a.initial_balance
+$$;
+
+COMMENT ON FUNCTION public.account_balances() IS
+  'Per-account balance (initial_balance + sum of transaction amounts) and transaction count for the calling user, in one round trip instead of the ~52 paged transaction fetches the client would otherwise need before it can show any figure. Identity is taken from the JWT, never from a parameter.';
+
+REVOKE ALL ON FUNCTION public.account_balances() FROM public;
+GRANT EXECUTE ON FUNCTION public.account_balances() TO authenticated, service_role;
+
+COMMIT;


### PR DESCRIPTION
perf(dashboard): paint real balances from one round trip while the
transaction pages stream in

Measured, from Steve's own production console:

  Boot data load: 3590ms total — auth 190ms · services 122ms ·
  accounts 124ms · categories 137ms · transactions 2764ms ·
  splits 134ms · planning 119ms (51,601 transactions)

77% of the wait is the transaction fetch — ~52 pages of 1,000 — and the
user watches a skeleton for all of it, because every headline figure
(net worth, per-account balances, assets, liabilities) is derived
client-side from the full set.

Postgres can produce the SAME invariant in one aggregate:

  balance = accounts.initial_balance + SUM(transactions.amount)

- Migration 20260722160000 adds account_balances(): one row per account
  for the CALLING user, identity from the verified JWT via
  requesting_user_id() — no parameter to spoof, and an unauthenticated
  caller matches nothing. SECURITY DEFINER so the aggregate runs once
  rather than re-planning RLS per page. LEFT JOIN so an account with no
  transactions still reports its opening balance. The sum spans ALL
  transactions, archived included — archiving is a view flag and never
  moves a balance. STEVE MUST APPLY.
- getAccountBalances() returns an empty Map on ANY failure: this is an
  optimisation and must never break a load. Without the migration the
  RPC 404s and the app behaves exactly as it does today.
- utils/accountBalances.ts holds the one selection rule, shared by the
  Dashboard and the Accounts page: server figures stand in ONLY while
  no transactions are present; the client ledger sum is the source of
  truth and wins back the moment any row arrives. Decimal throughout.
- The boot line now reports a `balances` phase, so the payoff is
  measurable in production rather than assumed.

UNVERIFIED, deliberately stated: the SQL has never been executed —
there is no database in the build environment. It is wrapped in
BEGIN/COMMIT, so a syntax error in the SQL editor rolls back with no
effect. The RPC's latency on 51,601 rows is likewise unmeasured; the
new boot phase will report it.

Written by an Opus subagent, reviewed here: its dead-field carry-over
removed, the identity clause independently verified against
20260610130000, and its dashboard changes merged with the concurrent
performance-period work so both now share one balance map.

Strict types, lint, smoke (3,135), build green.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
