### PR TITLE
fix(security): stop zod probing for eval — clears the last CSP violation without weakening the policy

### DIFF
--- a/src/lib/zodConfig.ts
+++ b/src/lib/zodConfig.ts
@@ -1,0 +1,19 @@
+import { z } from 'zod';
+
+/**
+ * Zod v4 probes for `new Function("")` on first use, to decide whether it can
+ * JIT-compile object validators. Our CSP forbids eval, so the probe throws,
+ * zod catches it and falls back to the interpreted path — correct, but it
+ * spends a CSP violation (a red console error, and a Sentry report) on every
+ * load to learn something the policy already decided.
+ *
+ * `jitless` short-circuits that: `jit && allowsEval.value` never evaluates the
+ * cached probe, so the eval never happens. Runtime behaviour is unchanged —
+ * the JIT path was already unreachable under the policy — we simply stop
+ * asking.
+ *
+ * MUST be imported before any module that creates a schema: zod reads this
+ * config when a schema's parser is built, which happens at module scope in
+ * several services.
+ */
+z.config({ jitless: true });

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,3 +1,6 @@
+// FIRST import: configures zod before any module-scope schema is built.
+// See the file for why (it removes a per-load CSP violation).
+import './lib/zodConfig'
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import { ClerkProvider } from '@clerk/clerk-react'


### PR DESCRIPTION
fix(security): stop zod probing for eval, clearing the last CSP
violation without weakening the policy

The self-identifying CSP reporter named the culprit on its first
production load:

  CSP Violation: "eval" blocked by script-src at
  .../assets/validationService-BgiRD4uI.js:1:12670

That offset is zod v4's `allowsEval` probe:

  try { const F = Function; new F(""); return true } catch { return false }

Zod runs it once to decide whether it may JIT-compile object validators.
Our CSP forbids eval, so the probe throws, zod catches it and uses the
interpreted path. Nothing was broken — it spent a red console error (and,
since the Sentry fix, a warning event) on every load to ask a question
the policy had already answered.

`z.config({ jitless: true })` makes zod short-circuit at
`jit && allowsEval.value`, so the cached probe never runs and the eval
never happens. Runtime behaviour is unchanged: the JIT path was already
unreachable under the policy, so we lose no speed — we stop asking.

The config lives in its own module imported FIRST in main.tsx, because
zod reads it when a schema's parser is built and several services build
schemas at module scope.

Deliberately NOT done: adding 'unsafe-eval' to the policy. It would have
silenced the same warning by handing an XSS primitive back to every
script on the page, to buy a validation fast path this app does not need.

Browser-verified: five real validationService schemas exercised after
the change, zero CSP violations raised. Strict types, lint, smoke
(3,125), build green.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
