### PR TITLE
Reports gallery, Money-style matrix, and the end of the duplicated import

### DIFF
--- a/scripts/backfillFeedCategories.mts
+++ b/scripts/backfillFeedCategories.mts
@@ -1,0 +1,481 @@
+/**
+ * Restore the categories the MS Money re-import's feed-overlap suppression lost.
+ *
+ * ── The regression this repairs ────────────────────────────────────────────
+ * The re-import (scripts/mnyReimportPlan.mts) deleted the file rows the bank
+ * feed already covered and kept the FEED row for each overlapping pair. The
+ * feed row is the better record of the amount and the date — and it carries no
+ * category, whereas the file row carried the category the user had assigned in
+ * Microsoft Money. Since a row with no category is deliberately excluded from
+ * every report (utils/incomeExpense.ts — direction is never guessed), the money
+ * survived and its classification did not.
+ *
+ * Everything needed to undo that is still on disk and in the database:
+ *   - the apply pass wrote a COMPLETE backup of every deleted row, categories
+ *     included, before it deleted anything;
+ *   - the re-import REUSED the user's categories rather than recreating them,
+ *     so those category ids are still valid. This script does not assume that:
+ *     it checks every id against the live `categories` table and reports any
+ *     that have vanished, loudly, rather than writing a dangling reference.
+ *
+ * ── How the pairs are re-derived ───────────────────────────────────────────
+ * With `findFeedOverlap` — the same matcher, at the same tolerance, that
+ * produced the suppression in the first place. A second rule worded differently
+ * could pair rows the first one did not, and this repair would then be
+ * inventing categories instead of restoring them. All the decisions live in
+ * src/services/import/msMoney/feedCategoryBackfill.ts and are tested with
+ * synthetic fixtures; this file is I/O.
+ *
+ * ── The two modes ──────────────────────────────────────────────────────────
+ * DRY RUN (default) is READ-ONLY. It prints what it would change — counts and
+ * category groups only, never an amount, a payee or an account name — and, with
+ * --out, writes the plan and its baseline to a file OUTSIDE the repository.
+ *
+ * APPLY refuses unless: the target database is the one the confirmation flag
+ * claims it is; a plan file from a dry run is supplied and the live database
+ * still matches it; and the plan has no anomalies. It then writes in batches —
+ * one request per (category, 100 ids), never one per row — with every statement
+ * scoped by `user_id`, `external_transaction_id IS NOT NULL` and
+ * `category IS NULL`, so Postgres itself refuses to touch a file row or to
+ * overwrite a category somebody has since set. Afterwards it re-reads the feed
+ * rows and reports the before/after.
+ *
+ * Nothing here deletes anything, and nothing here can widen its own scope: the
+ * only rows it can reach are bank-feed rows that currently have no category.
+ *
+ * Usage:
+ *   # preview (read-only)
+ *   npx tsx scripts/backfillFeedCategories.mts \
+ *     --backup /path/outside/repo/mny-reimport-backup-<stamp>.json \
+ *     --out /path/outside/repo
+ *
+ *   # apply, against the database the plan was taken from
+ *   npx tsx scripts/backfillFeedCategories.mts --apply \
+ *     --backup /path/outside/repo/mny-reimport-backup-<stamp>.json \
+ *     --plan /path/outside/repo/feed-category-backfill-plan-<stamp>.json \
+ *     --i-understand-this-writes-to-production
+ *
+ *   # the same against the scratch project
+ *   npx tsx scripts/backfillFeedCategories.mts --apply --env .env.scratch … \
+ *     --i-know-this-is-a-scratch-database
+ */
+import { readFileSync, writeFileSync, mkdirSync, existsSync } from 'node:fs';
+import { join, resolve, sep } from 'node:path';
+import { createHash } from 'node:crypto';
+import { createClient } from '@supabase/supabase-js';
+import {
+  planFeedCategoryBackfill, summariseByCategoryGroup, compareBackfillBaseline, applyCategoryBackfill,
+  proposalKey, BACKFILL_PLAN_VERSION,
+  type BackedUpFileRow, type LiveFeedRow, type CategoryRow, type BackfillPlan, type BackfillBaseline,
+} from '../src/services/import/msMoney/feedCategoryBackfill.ts';
+
+// ── CLI ──────────────────────────────────────────────────────────────────────
+const args = process.argv.slice(2);
+const flag = (name: string): string | undefined => {
+  const i = args.indexOf(`--${name}`);
+  return i >= 0 ? args[i + 1] : undefined;
+};
+const APPLY = args.includes('--apply');
+const CONFIRM_PRODUCTION = args.includes('--i-understand-this-writes-to-production');
+const CONFIRM_SCRATCH = args.includes('--i-know-this-is-a-scratch-database');
+const backupPath = flag('backup');
+const outDir = flag('out');
+const planPath = flag('plan');
+const envPath = flag('env') ?? '.env.local';
+const toleranceDays = Number(flag('tolerance') ?? 3);
+const userOverride = flag('user');
+
+const USAGE = 'usage: tsx scripts/backfillFeedCategories.mts --backup <re-import backup json> ' +
+  '[--out <dir outside the repo>] [--env .env.local] [--tolerance 3] [--user <uuid>]\n' +
+  '       …--apply --plan <plan from the dry run> ' +
+  '(--i-understand-this-writes-to-production | --i-know-this-is-a-scratch-database)';
+
+function fail(msg: string): never {
+  console.error(`\nABORT: ${msg}`);
+  process.exit(1);
+}
+
+if (!backupPath) {
+  console.error(USAGE);
+  process.exit(1);
+}
+if (!existsSync(backupPath)) fail(`backup not found: ${backupPath}`);
+if (!Number.isFinite(toleranceDays) || toleranceDays < 0) {
+  fail(`--tolerance must be a non-negative number, got ${flag('tolerance')}`);
+}
+
+const repoRoot = resolve('.');
+const outsideRepo = (path: string): string => {
+  const resolved = resolve(path);
+  if (resolved === repoRoot || resolved.startsWith(repoRoot + sep)) {
+    fail(`${resolved} is INSIDE the repository, which is public. Real rows never go there.`);
+  }
+  return resolved;
+};
+const backupResolved = outsideRepo(backupPath);
+const outResolved = outDir ? outsideRepo(outDir) : null;
+
+// ── Environment (never printed) ──────────────────────────────────────────────
+const readEnv = (path: string): Record<string, string> => Object.fromEntries(
+  readFileSync(path, 'utf8')
+    .split('\n')
+    .filter(l => l.includes('=') && !l.trim().startsWith('#'))
+    .map(l => [l.slice(0, l.indexOf('=')).trim(), l.slice(l.indexOf('=') + 1).trim()])
+);
+const urlOf = (path: string): string | undefined =>
+  existsSync(path) ? readEnv(path).VITE_SUPABASE_URL : undefined;
+
+if (!existsSync(envPath)) fail(`env file not found: ${envPath}`);
+const env = readEnv(envPath);
+const url = env.VITE_SUPABASE_URL;
+const serviceKey = env.SUPABASE_SERVICE_ROLE_KEY;
+if (!url || !serviceKey) fail(`Missing VITE_SUPABASE_URL / SUPABASE_SERVICE_ROLE_KEY in ${envPath}`);
+
+/**
+ * Which database is this, really? The confirmation flag is an ASSERTION about
+ * the target and it is checked against the file that defines that target —
+ * exactly as scripts/mnyReimportPlan.mts checks it. Claiming production while
+ * pointed at scratch means the numbers just reviewed belong elsewhere; claiming
+ * scratch while pointed at production is the accident worth preventing.
+ */
+if (APPLY) {
+  const prodUrl = urlOf('.env.local');
+  const scratchUrl = urlOf('.env.scratch');
+  if (CONFIRM_PRODUCTION === CONFIRM_SCRATCH) {
+    fail('--apply needs exactly ONE of --i-understand-this-writes-to-production / ' +
+      '--i-know-this-is-a-scratch-database — the flag states which database this is, and it is verified.');
+  }
+  if (CONFIRM_PRODUCTION) {
+    if (scratchUrl && url === scratchUrl) {
+      fail('--i-understand-this-writes-to-production was given, but the target is the SAME project as ' +
+        '.env.scratch. Use --i-know-this-is-a-scratch-database for scratch runs.');
+    }
+    if (!prodUrl) fail('.env.local is missing, so "this is production" cannot be verified. Refusing.');
+    if (url !== prodUrl) {
+      fail(`--i-understand-this-writes-to-production was given, but ${envPath} does not name the same project ` +
+        'as .env.local. Refusing to write to a database nobody has identified.');
+    }
+  }
+  if (CONFIRM_SCRATCH) {
+    if (!scratchUrl) fail('.env.scratch is missing, so "this is scratch" cannot be verified. Refusing.');
+    if (url !== scratchUrl) {
+      fail(`--i-know-this-is-a-scratch-database was given, but ${envPath} does not name the same project as ` +
+        '.env.scratch. Refusing.');
+    }
+    if (prodUrl && url === prodUrl) fail('.env.scratch and .env.local name the SAME project. Refusing to touch it.');
+  }
+  if (!planPath) {
+    fail('--apply needs --plan <file written by the dry run>: it is the baseline the live database is checked against.');
+  }
+}
+
+const sb = createClient(url, serviceKey, { auth: { persistSession: false } });
+
+// ── Reads ────────────────────────────────────────────────────────────────────
+async function fetchAll<T>(table: string, cols: string, userId: string): Promise<T[]> {
+  const PAGE = 1000;
+  const rows: T[] = [];
+  for (let from = 0; ; from += PAGE) {
+    const { data, error } = await sb.from(table).select(cols).eq('user_id', userId)
+      .order('id').range(from, from + PAGE - 1).returns<T[]>();
+    if (error) fail(`reading ${table}: ${error.message}`);
+    const page: T[] = data ?? [];
+    rows.push(...page);
+    if (page.length < PAGE) return rows;
+  }
+}
+
+// ── The backup ───────────────────────────────────────────────────────────────
+interface BackupShape {
+  userId?: unknown;
+  transactions?: unknown;
+}
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === 'object' && value !== null && !Array.isArray(value);
+
+const str = (value: unknown): string | null => (typeof value === 'string' ? value : null);
+const bool = (value: unknown): boolean | null => (typeof value === 'boolean' ? value : null);
+const num = (value: unknown): string | number => (typeof value === 'number' ? value : String(value ?? 0));
+
+interface LoadedBackup { userId: string; rows: BackedUpFileRow[]; sha256: string }
+
+/**
+ * Read the re-import's backup and take only what a pairing needs. Every field is
+ * narrowed from `unknown`: the file is 45 MB of JSON written by another run, and
+ * a field that is not the shape this expects must be visible, not coerced.
+ */
+function loadBackup(path: string): LoadedBackup {
+  const raw = readFileSync(path, 'utf8');
+  const parsed: unknown = JSON.parse(raw);
+  if (!isRecord(parsed)) fail(`${path} is not a JSON object`);
+  const doc: BackupShape = parsed;
+  if (!Array.isArray(doc.transactions)) fail(`${path} has no \`transactions\` array — that is not a re-import backup`);
+  const userId = str(doc.userId);
+  if (!userId) fail(`${path} names no userId`);
+
+  const rows: BackedUpFileRow[] = [];
+  for (const entry of doc.transactions) {
+    if (!isRecord(entry)) fail(`${path} contains a transaction entry that is not an object`);
+    const id = str(entry.id);
+    const accountId = str(entry.account_id);
+    const date = str(entry.date);
+    const type = str(entry.type);
+    if (!id || !accountId || !date || !type) fail(`${path} contains a transaction with no id/account/date/type`);
+    rows.push({
+      id,
+      account_id: accountId,
+      date: date.slice(0, 10),
+      amount: num(entry.amount),
+      description: str(entry.description),
+      category: str(entry.category),
+      type,
+      is_split: bool(entry.is_split),
+      external_transaction_id: str(entry.external_transaction_id),
+    });
+  }
+  return { userId, rows, sha256: createHash('sha256').update(raw).digest('hex') };
+}
+
+// ── Plan ─────────────────────────────────────────────────────────────────────
+interface LiveState {
+  userId: string;
+  feedRows: LiveFeedRow[];
+  categories: CategoryRow[];
+  plan: BackfillPlan;
+}
+
+async function computeLive(backup: LoadedBackup): Promise<LiveState> {
+  const userId = userOverride ?? backup.userId;
+  if (userOverride && userOverride !== backup.userId) {
+    console.log(`NOTE: --user overrides the backup's own user (${backup.userId} → ${userOverride}).\n`);
+  }
+
+  const feedRows = (await fetchAll<LiveFeedRow>(
+    'transactions', 'id,account_id,date,amount,description,category,external_transaction_id', userId
+  )).filter(r => r.external_transaction_id != null);
+  const categories = await fetchAll<CategoryRow>('categories', 'id,name,parent_id,level,is_transfer_category', userId);
+
+  const plan = planFeedCategoryBackfill({
+    fileRows: backup.rows,
+    feedRows,
+    categories,
+    dateToleranceDays: toleranceDays,
+  });
+  return { userId, feedRows, categories, plan };
+}
+
+function printPlan(state: LiveState, backup: LoadedBackup): void {
+  const { plan } = state;
+  console.log(`Target user: ${state.userId}`);
+  console.log(`Backup     : ${backup.rows.length} deleted file rows (sha256 ${backup.sha256.slice(0, 12)}…)`);
+  console.log(`Matcher    : findFeedOverlap, ±${toleranceDays} days, exact pence, same account, strictly 1:1\n`);
+
+  console.log('BANK-FEED ROWS AS THEY STAND');
+  console.log(`  total                              : ${plan.feedRowsTotal}`);
+  console.log(`  with a category                    : ${plan.feedRowsTotal - plan.feedRowsWithoutCategory}`);
+  console.log(`  with NO category                   : ${plan.feedRowsWithoutCategory}`);
+
+  console.log('\nRE-DERIVED PAIRS (file row the re-import dropped → feed row it kept)');
+  console.log(`  pairs found                        : ${plan.pairsFound}`);
+  console.log(`  feed rows with no file counterpart : ${plan.feedRowsWithoutFileCounterpart}` +
+    ` — never touched by this repair`);
+  console.log(`    …of those, still uncategorised   : ${plan.feedOnlyWithoutCategory}` +
+    ' — genuine feed-only spending; belongs to the uncategorised review workflow');
+
+  console.log('\nWOULD CHANGE');
+  console.log(`  feed rows given back their category: ${plan.proposals.length}`);
+
+  console.log('\nSKIPPED');
+  console.log(`  feed row already has a category    : ${plan.skipped.feedAlreadyCategorised}` +
+    ' — never overwritten (the user or payee memory filed it since)');
+  console.log(`  the file row had no category either: ${plan.skipped.fileHadNoCategory}`);
+  console.log(`  file category is a transfer category: ${plan.skipped.fileCategoryIsTransfer}` +
+    ' — never written onto a feed row');
+  console.log(`  file category no longer exists     : ${plan.skipped.fileCategoryMissing}`);
+  if (plan.skipped.fileCategoryMissing > 0) {
+    console.log('');
+    console.log('  ############################################################');
+    console.log(`  ## ${plan.skipped.fileCategoryMissing} pair(s) name a category that is NOT in the database.`);
+    console.log('  ## The re-import was supposed to have REUSED every category,');
+    console.log('  ## so this should be zero. It is not. Investigate before applying:');
+    for (const id of plan.missingCategoryIds.slice(0, 20)) console.log(`  ##   ${id}`);
+    if (plan.missingCategoryIds.length > 20) {
+      console.log(`  ##   …and ${plan.missingCategoryIds.length - 20} more distinct id(s)`);
+    }
+    console.log('  ############################################################');
+  }
+
+  if (plan.proposals.length) {
+    console.log('\nBY CATEGORY GROUP (counts only — no amounts, no payees, no accounts)');
+    for (const { group, count } of summariseByCategoryGroup(plan.proposals, state.categories)) {
+      console.log(`  ${String(count).padStart(5)}  ${group}`);
+    }
+    const sameDay = plan.proposals.filter(p => p.dayGap === 0).length;
+    console.log(`\n  match quality: ${sameDay}/${plan.proposals.length} same-day pairs`);
+  }
+
+  console.log('\nAFTERWARDS (projected)');
+  const remaining = plan.feedRowsWithoutCategory - plan.proposals.length;
+  console.log(`  feed rows still without a category : ${remaining}` +
+    ` (was ${plan.feedRowsWithoutCategory}; ${plan.proposals.length} fewer)`);
+
+  if (plan.anomalies.length) {
+    console.log('\nANOMALIES — nothing may be applied while any of these stand:');
+    for (const line of plan.anomalies.slice(0, 20)) console.log(`  - ${line}`);
+    if (plan.anomalies.length > 20) console.log(`  …and ${plan.anomalies.length - 20} more`);
+  }
+}
+
+const stamp = (): string => new Date().toISOString().replace(/[:.]/g, '-');
+
+/** The picture the drift check compares — recomputed live at apply time. */
+function liveBaselineState(state: LiveState, backup: LoadedBackup): Omit<BackfillBaseline, 'version'> {
+  return {
+    userId: state.userId,
+    dateToleranceDays: toleranceDays,
+    backupSha256: backup.sha256,
+    proposalKeys: state.plan.proposals.map(proposalKey).sort(),
+    feedRowsTotal: state.plan.feedRowsTotal,
+    feedRowsWithoutCategory: state.plan.feedRowsWithoutCategory,
+  };
+}
+
+function buildBaseline(state: LiveState, backup: LoadedBackup): BackfillBaseline {
+  return { version: BACKFILL_PLAN_VERSION, ...liveBaselineState(state, backup) };
+}
+
+// ── DRY RUN ─────────────────────────────────────────────────────────────────
+async function dryRun(backup: LoadedBackup): Promise<void> {
+  console.log('Feed-category backfill — DRY RUN, read-only, nothing is written.\n');
+  const state = await computeLive(backup);
+  printPlan(state, backup);
+
+  if (!outResolved) {
+    console.log('\nNo --out given, so no plan file was written and --apply has no baseline to check against.');
+    console.log('Re-run with --out <dir outside the repo> to produce an applicable plan.');
+    console.log('\nDRY RUN complete — nothing was changed.');
+    return;
+  }
+
+  mkdirSync(outResolved, { recursive: true });
+  const planFile = join(outResolved, `feed-category-backfill-plan-${stamp()}.json`);
+  writeFileSync(planFile, JSON.stringify({
+    generatedAt: new Date().toISOString(),
+    backupFile: backupResolved,
+    toleranceDays,
+    baseline: buildBaseline(state, backup),
+    proposals: state.plan.proposals,
+    skipped: state.plan.skipped,
+    missingCategoryIds: state.plan.missingCategoryIds,
+    anomalies: state.plan.anomalies,
+  }, null, 1));
+  console.log(`\nPLAN + BASELINE: ${planFile}`);
+  console.log('  (names real row ids — keep it out of the repository)');
+  console.log('\nTo apply this exact plan:');
+  console.log(`  npx tsx scripts/backfillFeedCategories.mts --apply --env ${envPath} \\`);
+  console.log(`    --backup ${backupResolved} --plan ${planFile} \\`);
+  console.log('    --i-understand-this-writes-to-production   # or --i-know-this-is-a-scratch-database');
+  console.log('\nDRY RUN complete — nothing was changed.');
+}
+
+// ── APPLY ───────────────────────────────────────────────────────────────────
+async function apply(backup: LoadedBackup): Promise<void> {
+  console.log('Feed-category backfill — APPLY. This SETS a category on bank-feed rows that have none.\n');
+  console.log(`Target: ${new URL(url).host} (from ${envPath})\n`);
+
+  if (!planPath) fail('--apply needs --plan <file written by the dry run>.');
+  if (!existsSync(planPath)) fail(`plan file not found: ${planPath}`);
+  const parsedPlan: unknown = JSON.parse(readFileSync(planPath, 'utf8'));
+  if (!isRecord(parsedPlan) || !isRecord(parsedPlan.baseline)) {
+    fail(`${planPath} carries no baseline — it was not written by a dry run with --out.`);
+  }
+  const baselineDoc = parsedPlan.baseline;
+  const baseline: BackfillBaseline = {
+    version: typeof baselineDoc.version === 'number' ? baselineDoc.version : -1,
+    userId: str(baselineDoc.userId) ?? '',
+    dateToleranceDays: typeof baselineDoc.dateToleranceDays === 'number' ? baselineDoc.dateToleranceDays : -1,
+    backupSha256: str(baselineDoc.backupSha256) ?? '',
+    proposalKeys: Array.isArray(baselineDoc.proposalKeys)
+      ? baselineDoc.proposalKeys.filter((k): k is string => typeof k === 'string')
+      : [],
+    feedRowsTotal: typeof baselineDoc.feedRowsTotal === 'number' ? baselineDoc.feedRowsTotal : -1,
+    feedRowsWithoutCategory: typeof baselineDoc.feedRowsWithoutCategory === 'number' ? baselineDoc.feedRowsWithoutCategory : -1,
+  };
+
+  const state = await computeLive(backup);
+  printPlan(state, backup);
+
+  if (state.plan.anomalies.length) {
+    fail(`${state.plan.anomalies.length} anomal(ies) above. Nothing has been written.`);
+  }
+
+  const drift = compareBackfillBaseline(baseline, liveBaselineState(state, backup));
+  console.log('\nDRIFT CHECK against the reviewed plan');
+  if (drift.drifted) {
+    for (const line of drift.lines) console.error(`  ${line}`);
+    fail('the database is not what the plan describes. Nothing has been written. ' +
+      'Re-run the DRY RUN, read the new numbers, and apply that plan instead.');
+  }
+  if (drift.lines.length) for (const line of drift.lines) console.log(`  ${line}`);
+  else console.log('  the live database matches the plan exactly — same rows, same categories, same backup.');
+
+  if (!state.plan.proposals.length) {
+    console.log('\nNothing to write — every paired feed row already has a category. Exiting without touching anything.');
+    return;
+  }
+
+  // ── The write ─────────────────────────────────────────────────────────────
+  console.log('\nWRITING (batched by category; every statement carries user_id, ' +
+    'external_transaction_id IS NOT NULL and category IS NULL)');
+  const outcome = await applyCategoryBackfill(sb, state.userId, state.plan.proposals, (done, total) => {
+    process.stdout.write(`\r  ${done}/${total}`);
+  });
+  process.stdout.write('\n');
+  console.log(`  ${outcome.rowsUpdated} row(s) updated in ${outcome.requests} request(s).`);
+  if (outcome.rowsDeclined > 0) {
+    console.log(`  ${outcome.rowsDeclined} row(s) were declined by the database — they stopped qualifying ` +
+      '(a category arrived between the plan and the write). Nothing was overwritten.');
+  }
+
+  // ── Verify ────────────────────────────────────────────────────────────────
+  console.log('\nVERIFYING (re-reading every bank-feed row)');
+  const after = await computeLive(backup);
+  console.log(`  bank-feed rows                     : ${state.plan.feedRowsTotal} → ${after.plan.feedRowsTotal}`);
+  console.log(`  feed rows WITHOUT a category       : ${state.plan.feedRowsWithoutCategory} → ` +
+    `${after.plan.feedRowsWithoutCategory}  (${state.plan.feedRowsWithoutCategory - after.plan.feedRowsWithoutCategory} repaired)`);
+  console.log(`  of those, feed-only (no file row)  : ${after.plan.feedOnlyWithoutCategory}` +
+    ' — the residual for the uncategorised review workflow');
+  console.log(`  proposals left outstanding         : ${after.plan.proposals.length}`);
+
+  const failures: string[] = [];
+  if (after.plan.feedRowsTotal !== state.plan.feedRowsTotal) {
+    failures.push(`the bank-feed population changed size (${state.plan.feedRowsTotal} → ${after.plan.feedRowsTotal}) — ` +
+      'this repair never inserts or deletes a row');
+  }
+  const categoryIds = new Set(after.categories.map(c => c.id));
+  const dangling = after.feedRows.filter(r => r.category != null && r.category !== '' && !categoryIds.has(r.category));
+  if (dangling.length) failures.push(`${dangling.length} feed row(s) now point at a category that does not exist`);
+  if (after.plan.proposals.length > 0) {
+    failures.push(`${after.plan.proposals.length} proposal(s) did not take effect`);
+  }
+
+  if (failures.length) {
+    console.error('\nVERIFICATION FAILED:');
+    for (const f of failures) console.error(`  - ${f}`);
+    process.exit(1);
+  }
+  console.log('\nDONE — categories restored on feed rows that had none. No row was inserted, deleted, ' +
+    'or had an existing category changed.');
+  console.log('Re-running --apply now is a no-op (every paired row already has its category).');
+}
+
+// ── Entry point ─────────────────────────────────────────────────────────────
+(async () => {
+  const backup = loadBackup(backupResolved);
+  if (APPLY) await apply(backup);
+  else await dryRun(backup);
+})().catch((thrown: unknown) => {
+  console.error(`\nFAILED: ${thrown instanceof Error ? thrown.message : String(thrown)}`);
+  process.exit(1);
+});

--- a/scripts/mnyCloudImport.mts
+++ b/scripts/mnyCloudImport.mts
@@ -95,6 +95,11 @@ console.log(`Seed: ${seed.accounts.length} accounts, ${seed.categories.length} c
 // ── Helpers ──────────────────────────────────────────────────────────────────
 const fail = (msg: string): never => { console.error(`\nABORT: ${msg}`); process.exit(1); };
 
+// Kept in step with src/services/import/msMoney/msMoneyImport.ts (not imported:
+// this script runs standalone under tsx, outside the app's module graph).
+const MS_MONEY_IMPORT_SOURCE = 'ms-money';
+const IMPORT_PROVENANCE_CONFLICT = 'user_id,import_source,import_source_id';
+
 async function fetchAll(table: string, filter?: { col: string; val: string }): Promise<Record<string, unknown>[]> {
   const PAGE = 1000;
   const rows: Record<string, unknown>[] = [];
@@ -108,10 +113,17 @@ async function fetchAll(table: string, filter?: { col: string; val: string }): P
   }
 }
 
-async function insertAll(table: string, rows: Record<string, unknown>[]): Promise<void> {
+async function insertAll(
+  table: string, rows: Record<string, unknown>[], onConflict?: string
+): Promise<void> {
   const BATCH = 500;
   for (let i = 0; i < rows.length; i += BATCH) {
-    const { error } = await sb.from(table).insert(rows.slice(i, i + BATCH));
+    const slice = rows.slice(i, i + BATCH);
+    // With a conflict target this becomes ON CONFLICT DO NOTHING — the
+    // database refuses a duplicate instead of the script creating one.
+    const { error } = onConflict
+      ? await sb.from(table).upsert(slice, { onConflict, ignoreDuplicates: true })
+      : await sb.from(table).insert(slice);
     if (error) fail(`inserting into ${table} (batch at ${i}): ${error.message}`);
     process.stdout.write(`\r  ${table}: ${Math.min(i + BATCH, rows.length)}/${rows.length}`);
   }
@@ -129,6 +141,14 @@ const dbAccountType = (t: string): string => (t === 'current' ? 'checking' : t);
   if (probe.error || probe2.error) {
     const msg = 'split-leg columns missing — apply ' +
       'supabase/migrations/20260720120000_split_leg_transfers.sql first.';
+    if (EXECUTE) fail(msg);
+    console.log(`\nPREFLIGHT (dry run continues): ${msg}`);
+  }
+  const probe3 = await sb.from('transactions').select('import_source_id').limit(1);
+  if (probe3.error) {
+    const msg = 'import-provenance columns missing — apply ' +
+      'supabase/migrations/20260722170000_transaction_import_provenance.sql first ' +
+      '(without them the import is not idempotent).';
     if (EXECUTE) fail(msg);
     console.log(`\nPREFLIGHT (dry run continues): ${msg}`);
   }
@@ -260,8 +280,14 @@ const dbAccountType = (t: string): string => (t === 'current' ? 'checking' : t);
     linked_transfer_id: withLink && t.linkedTransferId ? txnMap.get(t.linkedTransferId) : null,
     is_recurring: false,
     metadata: t.bankReference ? { bankReference: t.bankReference } : {},
+    // Import provenance (migration 20260722170000): the transform's stable
+    // per-source id, so a second run is refused by the unique index instead of
+    // duplicating the file. NOT external_transaction_id — that is the bank
+    // feed's column and its dedupe/backfill logic keys off it.
+    import_source: MS_MONEY_IMPORT_SOURCE,
+    import_source_id: t.id,
   });
-  await insertAll('transactions', seed.transactions.map(t => txnRow(t, false)));
+  await insertAll('transactions', seed.transactions.map(t => txnRow(t, false)), IMPORT_PROVENANCE_CONFLICT);
 
   const linkedTxns = seed.transactions.filter(t => t.linkedTransferId);
   {

--- a/scripts/mnyExtract.mts
+++ b/scripts/mnyExtract.mts
@@ -1,0 +1,83 @@
+/**
+ * Extract a Microsoft Money .mny file into the normalised export JSON that
+ * `scripts/mnyLocalImport.mts` consumes.
+ *
+ * WHY THIS EXISTS
+ * ---------------
+ * `readMnyExport` was only ever reachable from the browser import modal, so
+ * regenerating the seed meant clicking through a wizard. That is fine once and
+ * useless as a check you want to repeat: the seed is the input to the
+ * idempotency harness and to every comparison against production, so producing
+ * it has to be deterministic and re-runnable.
+ *
+ * SAFETY
+ * ------
+ * The .mny is opened READ-ONLY and never written back. Output goes to an
+ * explicit directory which MUST NOT be inside the repository — this repo is
+ * public and the export contains real financial data. Default is the
+ * gitignored `.mny-local/export/`.
+ *
+ * Usage:
+ *   npx tsx scripts/mnyExtract.mts <path-to.mny> [--out <dir>]
+ *
+ * Then:
+ *   npx tsx scripts/mnyLocalImport.mts .mny-local/export
+ */
+import { readFileSync, writeFileSync, mkdirSync, statSync } from 'node:fs';
+import { join, resolve, relative, isAbsolute } from 'node:path';
+import { readMnyExport } from '../src/services/import/msMoney/mnyReader.ts';
+
+const args = process.argv.slice(2);
+const flag = (name: string): string | undefined => {
+  const i = args.indexOf(`--${name}`);
+  return i >= 0 ? args[i + 1] : undefined;
+};
+const die = (msg: string): never => {
+  console.error(`ABORT: ${msg}`);
+  process.exit(1);
+};
+
+const mnyPath = args.find(a => !a.startsWith('--') && args[args.indexOf(a) - 1] !== '--out');
+if (!mnyPath) die('usage: tsx scripts/mnyExtract.mts <path-to.mny> [--out <dir>]');
+
+const outDir = resolve(flag('out') ?? join(process.cwd(), '.mny-local', 'export'));
+
+// The repo is PUBLIC. Refuse to write extracted financial data anywhere git
+// might pick it up. `.mny-local/` is gitignored; anything else under the repo
+// root is not worth the risk of assuming.
+const repoRoot = resolve(process.cwd());
+const rel = relative(repoRoot, outDir);
+const insideRepo = rel !== '' && !rel.startsWith('..') && !isAbsolute(rel);
+if (insideRepo && !rel.startsWith('.mny-local')) {
+  die(`refusing to write extracted financial data inside the repo at ${outDir} — use .mny-local/ or a path outside the repository`);
+}
+
+let bytes: Uint8Array;
+try {
+  const stat = statSync(mnyPath);
+  if (!stat.isFile()) die(`${mnyPath} is not a file`);
+  bytes = new Uint8Array(readFileSync(mnyPath));
+} catch (err) {
+  die(`could not read ${mnyPath}: ${(err as Error).message}`);
+}
+
+console.log(`Reading ${mnyPath} (${(bytes.byteLength / 1024 / 1024).toFixed(1)} MB, read-only)…`);
+
+const exp = readMnyExport(bytes);
+
+mkdirSync(outDir, { recursive: true });
+const write = (name: string, value: unknown): void => {
+  writeFileSync(join(outDir, name), JSON.stringify(value, null, 1));
+};
+write('accounts.json', exp.accounts);
+write('categories.json', exp.categories);
+write('payees.json', exp.payees);
+write('transactions.json', exp.transactions);
+
+// Counts only — never row contents. This output is read in a public chat.
+console.log(`\nWrote ${outDir}`);
+console.log(`  accounts     ${exp.accounts.length}`);
+console.log(`  categories   ${exp.categories.length}`);
+console.log(`  payees       ${exp.payees.length}`);
+console.log(`  transactions ${exp.transactions.length}`);
+console.log(`\nNext: npx tsx scripts/mnyLocalImport.mts ${relative(process.cwd(), outDir) || outDir}`);

--- a/scripts/mnyIdempotencyCheck.mts
+++ b/scripts/mnyIdempotencyCheck.mts
@@ -10,6 +10,8 @@
  *   run 2  NO wipe → plan → write         → snapshot B
  *   assert A == B  (row counts, per-table; duplicate-signature counts;
  *                   provenance coverage), and that run 2 planned zero inserts
+ *   assert the category tree is whole — system roots present, and NO category
+ *          left pointing at a parent row that does not exist
  *   then   force a raw duplicate insert   → assert the DATABASE rejects it
  *
  * ── THIS SCRIPT WRITES. IT MUST NEVER POINT AT PRODUCTION. ─────────────────
@@ -27,7 +29,7 @@ import { readFileSync, existsSync } from 'node:fs';
 import { randomUUID } from 'node:crypto';
 import { createClient, type SupabaseClient } from '@supabase/supabase-js';
 import {
-  planCloudImport, executeCloudPlan, wipeCloudData, fetchImportedSourceIds,
+  planCloudImport, executeCloudPlan, wipeCloudData, fetchExistingImportState,
   MS_MONEY_IMPORT_SOURCE,
 } from '../src/services/import/msMoney/msMoneyImport.ts';
 import type { MsMoneyImportResult } from '../src/services/import/msMoney/transform.ts';
@@ -105,6 +107,10 @@ interface Snapshot {
   /** Rows carrying MS Money provenance, and distinct source ids among them. */
   provenancedRows: number;
   distinctSourceIds: number;
+  /** Categories whose parent_id names a row that does not exist. Must be 0. */
+  orphanedCategories: number;
+  /** Categories with is_system = true at level 'type' — the tree's roots. */
+  systemRoots: number;
 }
 
 async function countRows(table: string, userId: string): Promise<number> {
@@ -144,19 +150,39 @@ async function snapshot(userId: string): Promise<Snapshot> {
   let groups = 0, extra = 0;
   for (const n of signatures.values()) if (n > 1) { groups++; extra += n - 1; }
 
+  // Category tree integrity: every parent_id must name a row that exists. The
+  // FK enforces this for rows the database accepted, but the check is cheap and
+  // it is the exact failure this harness exists to catch.
+  const catRows: { id: string; parent_id: string | null; level: string; is_system: boolean | null }[] = [];
+  for (let from = 0; ; from += PAGE) {
+    const { data, error } = await sb.from('categories')
+      .select('id,parent_id,level,is_system')
+      .eq('user_id', userId).order('id').range(from, from + PAGE - 1);
+    if (error) die(`snapshotting categories: ${error.message}`);
+    const rows = data ?? [];
+    catRows.push(...rows);
+    if (rows.length < PAGE) break;
+  }
+  const catIds = new Set(catRows.map(r => r.id));
+  const orphanedCategories = catRows.filter(r => r.parent_id != null && !catIds.has(r.parent_id)).length;
+  const systemRoots = catRows.filter(r => r.level === 'type' && r.is_system === true).length;
+
   return {
     counts,
     duplicateSignatureGroups: groups,
     duplicateSignatureExtraRows: extra,
     provenancedRows: provenanced,
     distinctSourceIds: sourceIds.size,
+    orphanedCategories,
+    systemRoots,
   };
 }
 
 const show = (label: string, s: Snapshot): void => {
   console.log(`  ${label}: ` + Object.entries(s.counts).map(([k, v]) => `${k}=${v}`).join(' ') +
     ` | dup-signature groups=${s.duplicateSignatureGroups} extra=${s.duplicateSignatureExtraRows}` +
-    ` | provenanced=${s.provenancedRows} distinct-source-ids=${s.distinctSourceIds}`);
+    ` | provenanced=${s.provenancedRows} distinct-source-ids=${s.distinctSourceIds}` +
+    ` | system-roots=${s.systemRoots} orphaned-categories=${s.orphanedCategories}`);
 };
 
 // ── Run ──────────────────────────────────────────────────────────────────────
@@ -172,13 +198,26 @@ const show = (label: string, s: Snapshot): void => {
     die('provenance columns missing — apply supabase/migrations/20260722170000_transaction_import_provenance.sql to the scratch database first.');
   }
 
-  const runOnce = async (label: string): Promise<number> => {
-    const existingBySourceId = await fetchImportedSourceIds(sb as SupabaseClient, userId);
-    const plan = planCloudImport(result, userId, randomUUID, { existingBySourceId });
+  const runOnce = async (label: string): Promise<{ transactions: number; accounts: number; categories: number }> => {
+    // Exactly what importToCloud does: read the user's current state, then plan
+    // against it — so the seed's placeholder category roots resolve onto the
+    // rows the user actually holds instead of onto ids nothing ever writes.
+    const existing = await fetchExistingImportState(sb as SupabaseClient, userId);
+    const plan = planCloudImport(result, userId, randomUUID, existing);
     console.log(`  ${label}: plan → ${plan.transactions.length} transactions to insert, ` +
       `${plan.skippedExisting} already present, ${plan.splits.length} split lines`);
+    console.log(`  ${label}: plan → ${plan.accounts.length} accounts + ${plan.categories.length} categories to insert, ` +
+      `${plan.skippedExistingAccounts} accounts / ${plan.skippedExistingCategories} categories already present, ` +
+      `${plan.categoriesWithUnresolvedParent} with an unresolvable parent`);
+    if (plan.categoriesWithUnresolvedParent > 0) {
+      die(`${label}: ${plan.categoriesWithUnresolvedParent} categories have no resolvable parent — the seed tree is broken`);
+    }
     await executeCloudPlan(plan, sb as SupabaseClient);
-    return plan.transactions.length;
+    return {
+      transactions: plan.transactions.length,
+      accounts: plan.accounts.length,
+      categories: plan.categories.length,
+    };
   };
 
   console.log(`Scratch target: ${new URL(target.VITE_SUPABASE_URL).host} (user ${userId})\n`);
@@ -214,7 +253,15 @@ const show = (label: string, s: Snapshot): void => {
       failures.push(`${table}: ${a.counts[table]} after run 1 but ${b.counts[table]} after run 2`);
     }
   }
-  if (inserted2 !== 0) failures.push(`run 2 planned ${inserted2} inserts; expected 0`);
+  if (inserted2.transactions !== 0) failures.push(`run 2 planned ${inserted2.transactions} transaction inserts; expected 0`);
+  if (inserted2.accounts !== 0) failures.push(`run 2 planned ${inserted2.accounts} account inserts; expected 0`);
+  if (inserted2.categories !== 0) failures.push(`run 2 planned ${inserted2.categories} category inserts; expected 0`);
+  for (const [label, s] of [['run 1', a], ['run 2', b]] as const) {
+    if (s.orphanedCategories !== 0) {
+      failures.push(`after ${label}: ${s.orphanedCategories} categories point at a parent row that does not exist`);
+    }
+    if (s.systemRoots === 0) failures.push(`after ${label}: the category tree has no system type roots`);
+  }
   if (a.duplicateSignatureGroups !== b.duplicateSignatureGroups) {
     failures.push(`duplicate-signature groups moved ${a.duplicateSignatureGroups} → ${b.duplicateSignatureGroups}`);
   }
@@ -224,8 +271,8 @@ const show = (label: string, s: Snapshot): void => {
   if (a.provenancedRows !== a.distinctSourceIds) {
     failures.push(`run 1 wrote ${a.provenancedRows} provenanced rows but only ${a.distinctSourceIds} distinct source ids`);
   }
-  if (inserted1 !== result.transactions.length) {
-    failures.push(`run 1 inserted ${inserted1} of ${result.transactions.length} source transactions`);
+  if (inserted1.transactions !== result.transactions.length) {
+    failures.push(`run 1 inserted ${inserted1.transactions} of ${result.transactions.length} source transactions`);
   }
   if (!guardHeld && victim?.length) failures.push('the unique index did NOT reject a forced duplicate');
 

--- a/scripts/mnyIdempotencyCheck.mts
+++ b/scripts/mnyIdempotencyCheck.mts
@@ -1,0 +1,239 @@
+/**
+ * Import idempotency harness — proves that running the MS Money importer TWICE
+ * leaves the database exactly as one run left it.
+ *
+ * This is the primary evidence that the provenance work does what it claims.
+ * It exercises the REAL write path (`planCloudImport` + `executeCloudPlan`
+ * from src/services/import/msMoney/msMoneyImport.ts), not a re-implementation.
+ *
+ *   run 1  wipe → plan → write            → snapshot A
+ *   run 2  NO wipe → plan → write         → snapshot B
+ *   assert A == B  (row counts, per-table; duplicate-signature counts;
+ *                   provenance coverage), and that run 2 planned zero inserts
+ *   then   force a raw duplicate insert   → assert the DATABASE rejects it
+ *
+ * ── THIS SCRIPT WRITES. IT MUST NEVER POINT AT PRODUCTION. ─────────────────
+ * The target comes from a separate env file (`--env .env.scratch`) and the
+ * script REFUSES to run if that file's VITE_SUPABASE_URL matches the one in
+ * `.env.local`, or if `--i-know-this-is-a-scratch-database` is absent. No
+ * secret is ever printed.
+ *
+ * Usage:
+ *   npx tsx scripts/mnyIdempotencyCheck.mts \
+ *     --env .env.scratch --seed .mny-local/mny-local-seed.json \
+ *     --i-know-this-is-a-scratch-database
+ */
+import { readFileSync, existsSync } from 'node:fs';
+import { randomUUID } from 'node:crypto';
+import { createClient, type SupabaseClient } from '@supabase/supabase-js';
+import {
+  planCloudImport, executeCloudPlan, wipeCloudData, fetchImportedSourceIds,
+  MS_MONEY_IMPORT_SOURCE,
+} from '../src/services/import/msMoney/msMoneyImport.ts';
+import type { MsMoneyImportResult } from '../src/services/import/msMoney/transform.ts';
+
+// ── CLI ──────────────────────────────────────────────────────────────────────
+const args = process.argv.slice(2);
+const flag = (name: string): string | undefined => {
+  const i = args.indexOf(`--${name}`);
+  return i >= 0 ? args[i + 1] : undefined;
+};
+const envPath = flag('env');
+const seedPath = flag('seed');
+const CONFIRMED = args.includes('--i-know-this-is-a-scratch-database');
+
+const die = (msg: string): never => { console.error(`ABORT: ${msg}`); process.exit(1); };
+
+if (!envPath || !seedPath) {
+  die('usage: tsx scripts/mnyIdempotencyCheck.mts --env <.env.scratch> --seed <seed.json> --i-know-this-is-a-scratch-database');
+}
+if (!CONFIRMED) die('refusing to write without --i-know-this-is-a-scratch-database');
+if (!existsSync(envPath!)) die(`env file not found: ${envPath}`);
+if (!existsSync(seedPath!)) die(`seed not found: ${seedPath}`);
+
+const readEnv = (path: string): Record<string, string> => Object.fromEntries(
+  readFileSync(path, 'utf8')
+    .split('\n')
+    .filter(l => l.includes('=') && !l.trim().startsWith('#'))
+    .map(l => [l.slice(0, l.indexOf('=')).trim(), l.slice(l.indexOf('=') + 1).trim()])
+);
+
+const target = readEnv(envPath!);
+if (!target.VITE_SUPABASE_URL || !target.SUPABASE_SERVICE_ROLE_KEY) {
+  die(`${envPath} must define VITE_SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY`);
+}
+// Hard production guard: same project ref as .env.local ⇒ refuse, always.
+if (existsSync('.env.local')) {
+  const prod = readEnv('.env.local');
+  if (prod.VITE_SUPABASE_URL && prod.VITE_SUPABASE_URL === target.VITE_SUPABASE_URL) {
+    die('the target is the SAME Supabase project as .env.local. This harness writes and deletes — point it at a scratch project.');
+  }
+}
+
+const sb = createClient(target.VITE_SUPABASE_URL, target.SUPABASE_SERVICE_ROLE_KEY, {
+  auth: { persistSession: false },
+});
+
+// ── Seed → the app-shaped import result ─────────────────────────────────────
+interface SeedShape {
+  accounts: MsMoneyImportResult['accounts'];
+  categories: MsMoneyImportResult['categories'];
+  transactions: MsMoneyImportResult['transactions'];
+  transactionSplits: MsMoneyImportResult['transactionSplits'];
+  summary?: MsMoneyImportResult['summary'];
+}
+const seed = JSON.parse(readFileSync(seedPath!, 'utf8')) as SeedShape;
+const result: MsMoneyImportResult = {
+  accounts: seed.accounts,
+  categories: seed.categories,
+  transactions: seed.transactions,
+  transactionSplits: seed.transactionSplits,
+  summary: seed.summary ?? {
+    accounts: { total: 0, open: 0, closed: 0, investmentCashPairs: 0 },
+    categories: { subs: 0, details: 0, hidden: 0 },
+    transactions: { imported: 0, standalone: 0, transfers: 0, splitTransactions: 0, splitLines: 0 },
+    simplifications: [],
+  },
+};
+
+// ── Snapshot ─────────────────────────────────────────────────────────────────
+interface Snapshot {
+  counts: Record<string, number>;
+  /** How many (account, date, pence, description) signatures appear >1 time. */
+  duplicateSignatureGroups: number;
+  duplicateSignatureExtraRows: number;
+  /** Rows carrying MS Money provenance, and distinct source ids among them. */
+  provenancedRows: number;
+  distinctSourceIds: number;
+}
+
+async function countRows(table: string, userId: string): Promise<number> {
+  const { count, error } = await sb.from(table).select('*', { count: 'exact', head: true }).eq('user_id', userId);
+  if (error) die(`counting ${table}: ${error.message}`);
+  return count ?? 0;
+}
+
+async function snapshot(userId: string): Promise<Snapshot> {
+  const counts: Record<string, number> = {};
+  for (const t of ['accounts', 'categories', 'transactions', 'transaction_splits']) {
+    counts[t] = await countRows(t, userId);
+  }
+
+  const PAGE = 1000;
+  const signatures = new Map<string, number>();
+  const sourceIds = new Set<string>();
+  let provenanced = 0;
+  for (let from = 0; ; from += PAGE) {
+    const { data, error } = await sb.from('transactions')
+      .select('account_id,date,amount,description,import_source,import_source_id')
+      .eq('user_id', userId).order('id').range(from, from + PAGE - 1);
+    if (error) die(`snapshotting transactions: ${error.message}`);
+    const rows = data ?? [];
+    for (const r of rows) {
+      const pence = Math.round(Number(r.amount) * 100);
+      const key = `${r.account_id}|${r.date}|${pence}|${String(r.description ?? '').trim().toUpperCase()}`;
+      signatures.set(key, (signatures.get(key) ?? 0) + 1);
+      if (r.import_source === MS_MONEY_IMPORT_SOURCE) {
+        provenanced++;
+        if (r.import_source_id) sourceIds.add(String(r.import_source_id));
+      }
+    }
+    if (rows.length < PAGE) break;
+  }
+
+  let groups = 0, extra = 0;
+  for (const n of signatures.values()) if (n > 1) { groups++; extra += n - 1; }
+
+  return {
+    counts,
+    duplicateSignatureGroups: groups,
+    duplicateSignatureExtraRows: extra,
+    provenancedRows: provenanced,
+    distinctSourceIds: sourceIds.size,
+  };
+}
+
+const show = (label: string, s: Snapshot): void => {
+  console.log(`  ${label}: ` + Object.entries(s.counts).map(([k, v]) => `${k}=${v}`).join(' ') +
+    ` | dup-signature groups=${s.duplicateSignatureGroups} extra=${s.duplicateSignatureExtraRows}` +
+    ` | provenanced=${s.provenancedRows} distinct-source-ids=${s.distinctSourceIds}`);
+};
+
+// ── Run ──────────────────────────────────────────────────────────────────────
+(async () => {
+  const { data: users, error } = await sb.from('users').select('id, email');
+  if (error) die(`cannot read users: ${error.message}`);
+  if (!users?.length) die('the scratch database has no user row to import against');
+  if (users.length > 1) die(`expected exactly 1 user in the scratch database, found ${users.length}`);
+  const userId = users[0].id as string;
+
+  const probe = await sb.from('transactions').select('import_source_id').limit(1);
+  if (probe.error) {
+    die('provenance columns missing — apply supabase/migrations/20260722170000_transaction_import_provenance.sql to the scratch database first.');
+  }
+
+  const runOnce = async (label: string): Promise<number> => {
+    const existingBySourceId = await fetchImportedSourceIds(sb as SupabaseClient, userId);
+    const plan = planCloudImport(result, userId, randomUUID, { existingBySourceId });
+    console.log(`  ${label}: plan → ${plan.transactions.length} transactions to insert, ` +
+      `${plan.skippedExisting} already present, ${plan.splits.length} split lines`);
+    await executeCloudPlan(plan, sb as SupabaseClient);
+    return plan.transactions.length;
+  };
+
+  console.log(`Scratch target: ${new URL(target.VITE_SUPABASE_URL).host} (user ${userId})\n`);
+
+  console.log('RUN 1 (wipe, then import)');
+  await wipeCloudData(sb as SupabaseClient, userId);
+  const inserted1 = await runOnce('run 1');
+  const a = await snapshot(userId);
+  show('after run 1', a);
+
+  console.log('\nRUN 2 (NO wipe — the same file imported straight over the top)');
+  const inserted2 = await runOnce('run 2');
+  const b = await snapshot(userId);
+  show('after run 2', b);
+
+  console.log('\nDATABASE-LEVEL GUARD');
+  const { data: victim } = await sb.from('transactions')
+    .select('user_id,account_id,description,amount,type,date,import_source,import_source_id')
+    .eq('user_id', userId).eq('import_source', MS_MONEY_IMPORT_SOURCE).limit(1);
+  let guardHeld = false;
+  if (victim?.length) {
+    const { error: dupError } = await sb.from('transactions').insert([{ ...victim[0], id: randomUUID() }]);
+    guardHeld = dupError != null;
+    console.log(`  forced duplicate insert → ${guardHeld ? 'REJECTED by the database ✓' : 'ACCEPTED ✗'}`);
+  } else {
+    console.log('  skipped — no provenanced row to duplicate');
+  }
+
+  // ── Verdict ────────────────────────────────────────────────────────────────
+  const failures: string[] = [];
+  for (const table of Object.keys(a.counts)) {
+    if (a.counts[table] !== b.counts[table]) {
+      failures.push(`${table}: ${a.counts[table]} after run 1 but ${b.counts[table]} after run 2`);
+    }
+  }
+  if (inserted2 !== 0) failures.push(`run 2 planned ${inserted2} inserts; expected 0`);
+  if (a.duplicateSignatureGroups !== b.duplicateSignatureGroups) {
+    failures.push(`duplicate-signature groups moved ${a.duplicateSignatureGroups} → ${b.duplicateSignatureGroups}`);
+  }
+  if (a.duplicateSignatureExtraRows !== b.duplicateSignatureExtraRows) {
+    failures.push(`duplicate-signature extra rows moved ${a.duplicateSignatureExtraRows} → ${b.duplicateSignatureExtraRows}`);
+  }
+  if (a.provenancedRows !== a.distinctSourceIds) {
+    failures.push(`run 1 wrote ${a.provenancedRows} provenanced rows but only ${a.distinctSourceIds} distinct source ids`);
+  }
+  if (inserted1 !== result.transactions.length) {
+    failures.push(`run 1 inserted ${inserted1} of ${result.transactions.length} source transactions`);
+  }
+  if (!guardHeld && victim?.length) failures.push('the unique index did NOT reject a forced duplicate');
+
+  console.log('');
+  if (failures.length) {
+    console.error('IDEMPOTENCY CHECK FAILED:');
+    for (const f of failures) console.error(`  - ${f}`);
+    process.exit(1);
+  }
+  console.log('IDEMPOTENCY CHECK PASSED — run 2 changed nothing, and the database refuses a duplicate.');
+})();

--- a/scripts/mnyReimportPlan.mts
+++ b/scripts/mnyReimportPlan.mts
@@ -1,0 +1,307 @@
+/**
+ * MS Money re-import PLAN — read-only preview. NOTHING IS EVER DELETED HERE.
+ *
+ * ── Why this exists ────────────────────────────────────────────────────────
+ * The transaction table holds two independent populations that overlap in time:
+ *
+ *   A. FILE IMPORT   — the full Microsoft Money history, written in one pass.
+ *                      Recreatable at any time from the .mny file.
+ *   B. BANK FEED     — live open-banking rows, each carrying
+ *                      `external_transaction_id`. NOT recreatable: once
+ *                      deleted, the provider's own record of it is gone from
+ *                      this database and a future sync will not re-fetch it
+ *                      (the feed only backfills once, at link time).
+ *
+ * Where the Money file's coverage and the feed's backfill window overlap, the
+ * same real-world payment exists in BOTH populations, and nothing reconciled
+ * them — so reports double-counted every transaction in that window.
+ *
+ * ── What a clean re-import has to do ───────────────────────────────────────
+ *   1. delete ONLY population A (and its `transaction_splits` children);
+ *   2. re-import the file with provenance, so every row carries a stable
+ *      `import_source_id` and the unique index refuses a second copy;
+ *   3. SUPPRESS the file rows that population B already covers, so the
+ *      overlap is not recreated. Wiping and re-importing WITHOUT step 3 lands
+ *      the file straight back on top of the feed and reproduces the very
+ *      duplicates it was meant to remove.
+ *
+ * Where a file row and a feed row describe the same payment, the FEED row is
+ * the one kept: it is what the bank actually reports, it carries the
+ * provider's id, it is what future syncs reconcile against, and unlike the
+ * file row it cannot be recreated.
+ *
+ * ── Discriminator for population A ─────────────────────────────────────────
+ * `import_source = 'ms-money'` once migration 20260722170000 is applied and a
+ * provenance-carrying import has run. For the CURRENT rows — written before
+ * provenance existed — the script falls back to
+ * `external_transaction_id IS NULL`, and prints the evidence for that fallback
+ * (row counts per created_at day, per provenance state) so a human can confirm
+ * the two populations really are cleanly separable before anything is run. If
+ * they are not cleanly separable the script says so and refuses.
+ *
+ * ── Safety ─────────────────────────────────────────────────────────────────
+ *   * READ-ONLY. There is no delete path in this file at all.
+ *   * `--apply` is recognised and deliberately NOT IMPLEMENTED (see the guard
+ *     at the bottom). Enabling it is a human decision.
+ *   * A full JSON backup of every row the plan would delete is written to the
+ *     output directory, which must be OUTSIDE the repository (the repo is
+ *     public and these rows are real financial data).
+ *
+ * Usage:
+ *   npx tsx scripts/mnyReimportPlan.mts --out /path/to/scratchpad
+ *   npx tsx scripts/mnyReimportPlan.mts --out … --seed .mny-local/mny-local-seed.json
+ */
+import { readFileSync, writeFileSync, mkdirSync, existsSync } from 'node:fs';
+import { join, resolve } from 'node:path';
+import { createClient } from '@supabase/supabase-js';
+import Decimal from 'decimal.js';
+import { findFeedOverlap, type ExistingFeedTransaction } from '../src/services/import/msMoney/feedOverlap.ts';
+import type { Transaction } from '../src/types/index.ts';
+
+// ── CLI ──────────────────────────────────────────────────────────────────────
+const args = process.argv.slice(2);
+const flag = (name: string): string | undefined => {
+  const i = args.indexOf(`--${name}`);
+  return i >= 0 ? args[i + 1] : undefined;
+};
+const APPLY = args.includes('--apply');
+const outDir = flag('out');
+const seedPath = flag('seed');
+const toleranceDays = Number(flag('tolerance') ?? 3);
+
+if (!outDir) {
+  console.error('usage: tsx scripts/mnyReimportPlan.mts --out <dir outside the repo> [--seed seed.json] [--tolerance 3]');
+  process.exit(1);
+}
+const outResolved = resolve(outDir);
+if (outResolved.startsWith(resolve('.')) ) {
+  console.error(`ABORT: --out must be OUTSIDE the repository (the repo is public). Got ${outResolved}`);
+  process.exit(1);
+}
+
+// ── Environment (never printed) ──────────────────────────────────────────────
+const env = Object.fromEntries(
+  readFileSync('.env.local', 'utf8')
+    .split('\n')
+    .filter(l => l.includes('=') && !l.trim().startsWith('#'))
+    .map(l => [l.slice(0, l.indexOf('=')).trim(), l.slice(l.indexOf('=') + 1).trim()])
+);
+const url = env.VITE_SUPABASE_URL;
+const serviceKey = env.SUPABASE_SERVICE_ROLE_KEY;
+if (!url || !serviceKey) {
+  console.error('Missing VITE_SUPABASE_URL / SUPABASE_SERVICE_ROLE_KEY in .env.local');
+  process.exit(1);
+}
+const sb = createClient(url, serviceKey, { auth: { persistSession: false } });
+
+const fail = (msg: string): never => { console.error(`\nABORT: ${msg}`); process.exit(1); };
+
+interface DbTxn {
+  id: string;
+  user_id: string;
+  account_id: string;
+  description: string | null;
+  amount: string | number;
+  type: string;
+  date: string;
+  category: string | null;
+  is_split: boolean | null;
+  linked_transfer_id: string | null;
+  external_transaction_id: string | null;
+  import_source: string | null;
+  import_source_id: string | null;
+  created_at: string;
+}
+
+async function fetchAll<T>(table: string, cols: string, filter?: (q: ReturnType<typeof sb.from>) => unknown): Promise<T[]> {
+  const PAGE = 1000;
+  const rows: T[] = [];
+  for (let from = 0; ; from += PAGE) {
+    let q = sb.from(table).select(cols).order('id').range(from, from + PAGE - 1);
+    if (filter) q = filter(q) as typeof q;
+    const { data, error } = await q;
+    if (error) fail(`reading ${table}: ${error.message}`);
+    const page = (data ?? []) as unknown as T[];
+    rows.push(...page);
+    if (page.length < PAGE) return rows;
+  }
+}
+
+const money = (v: string | number): Decimal => new Decimal(String(v));
+const gbp = (d: Decimal): string => `£${d.abs().toFixed(2)}`;
+
+(async () => {
+  console.log('MS Money re-import PLAN — dry run, read-only, nothing is deleted.\n');
+
+  const { data: users, error: uerr } = await sb.from('users').select('id, email');
+  if (uerr || !users?.length) fail(`cannot read users: ${uerr?.message ?? 'none'}`);
+
+  // Provenance columns are optional: this plan is most useful BEFORE migration
+  // 20260722170000 is applied, when every file row is still unmarked.
+  const probe = await sb.from('transactions').select('import_source_id').limit(1);
+  const hasProvenance = !probe.error;
+  if (!hasProvenance) {
+    console.log('NOTE: migration 20260722170000 is not applied yet — no row carries import');
+    console.log('      provenance, so population A is identified by the fallback discriminator.\n');
+  }
+
+  const BASE_COLS = 'id,user_id,account_id,description,amount,type,date,category,is_split,' +
+    'linked_transfer_id,external_transaction_id,created_at';
+  // The target is the user actually holding the imported history.
+  const raw = await fetchAll<Omit<DbTxn, 'import_source' | 'import_source_id'> & Partial<DbTxn>>(
+    'transactions',
+    hasProvenance ? `${BASE_COLS},import_source,import_source_id` : BASE_COLS
+  );
+  const all: DbTxn[] = raw.map(t => ({
+    ...t, import_source: t.import_source ?? null, import_source_id: t.import_source_id ?? null,
+  }));
+  const byUser = new Map<string, DbTxn[]>();
+  for (const t of all) {
+    const list = byUser.get(t.user_id);
+    if (list) list.push(t); else byUser.set(t.user_id, [t]);
+  }
+  const [userId, rows] = [...byUser.entries()].sort((a, b) => b[1].length - a[1].length)[0] ?? [];
+  if (!userId || !rows) fail('no transactions found');
+  console.log(`Target user: ${userId} — ${rows.length} transactions ` +
+    `(other users hold ${all.length - rows.length}, untouched by this plan)\n`);
+
+  // ── 1. Separate the two populations ────────────────────────────────────────
+  const feedRows = rows.filter(t => t.external_transaction_id != null);
+  const provenanced = rows.filter(t => t.import_source != null);
+  const legacyImport = rows.filter(t => t.external_transaction_id == null && t.import_source == null);
+
+  console.log('POPULATIONS');
+  console.log(`  bank feed  (external_transaction_id set) : ${feedRows.length}  — NEVER deleted`);
+  console.log(`  file import (import_source set)          : ${provenanced.length}`);
+  console.log(`  file import (legacy, no provenance)      : ${legacyImport.length}`);
+
+  // Both discriminators must agree that the populations are disjoint.
+  const bothMarkers = rows.filter(t => t.external_transaction_id != null && t.import_source != null);
+  if (bothMarkers.length) {
+    fail(`${bothMarkers.length} row(s) carry BOTH a bank-feed id and file provenance — ` +
+      'the two populations are not cleanly separable; resolve by hand before any deletion.');
+  }
+
+  const byDay = new Map<string, { feed: number; file: number }>();
+  for (const t of rows) {
+    const d = t.created_at.slice(0, 10);
+    const e = byDay.get(d) ?? { feed: 0, file: 0 };
+    if (t.external_transaction_id != null) e.feed++; else e.file++;
+    byDay.set(d, e);
+  }
+  console.log('  evidence — rows by created_at day (feed / file):');
+  for (const [d, e] of [...byDay].sort()) console.log(`    ${d}: ${e.feed} / ${e.file}`);
+
+  const toDelete = [...provenanced, ...legacyImport];
+  if (!toDelete.length) { console.log('\nNothing to re-import — no file-import rows found.'); return; }
+
+  // ── 2. Which file rows would the feed already cover on re-import? ──────────
+  // Modelled directly on the rows in the database: a re-import reproduces the
+  // same transactions in the same accounts, so matching file rows against feed
+  // rows here is equivalent to matching the seed against them.
+  const asImportShape: Transaction[] = toDelete.map(t => ({
+    id: t.import_source_id ?? t.id,
+    date: new Date(`${t.date}T00:00:00.000Z`),
+    description: t.description ?? '',
+    accountId: t.account_id,
+    amount: money(t.amount).toNumber(),
+    type: t.type as Transaction['type'],
+    category: t.category ?? '',
+    cleared: false,
+    isSplit: t.is_split === true,
+  } as Transaction));
+
+  const asFeedShape: ExistingFeedTransaction[] = feedRows.map(t => ({
+    id: t.id,
+    accountId: t.account_id,
+    date: t.date,
+    amount: String(t.amount),
+    description: t.description ?? '',
+  }));
+
+  const overlap = findFeedOverlap(asImportShape, asFeedShape, { dateToleranceDays: toleranceDays });
+  const suppressedById = new Map(toDelete.map(t => [t.import_source_id ?? t.id, t]));
+  const suppressedRows = [...overlap.suppressedSourceIds].map(id => suppressedById.get(id)!).filter(Boolean);
+  const suppressedValue = suppressedRows.reduce((s, t) => s.plus(money(t.amount)), new Decimal(0));
+
+  console.log(`\nFEED OVERLAP (±${toleranceDays} days, exact pence, same account, 1:1)`);
+  console.log(`  file rows the feed already covers   : ${overlap.matches.length}  (${gbp(suppressedValue)})`);
+  console.log(`  feed rows with no file counterpart  : ${overlap.unmatchedFeedIds.length}  — genuine feed-only spending, kept`);
+  console.log(`  overlaps deliberately NOT suppressed : ${overlap.keptDespiteOverlap.transfers} transfer leg(s), ` +
+    `${overlap.keptDespiteOverlap.splitParents} split parent(s)`);
+  const sameDay = overlap.matches.filter(m => m.dayGap === 0).length;
+  const strongDesc = overlap.matches.filter(m => m.descriptionSimilarity > 0).length;
+  console.log(`  match quality: ${sameDay}/${overlap.matches.length} same-day, ` +
+    `${strongDesc}/${overlap.matches.length} with overlapping description text`);
+
+  // ── 3. Relationships the delete path must handle ──────────────────────────
+  const deleteIds = new Set(toDelete.map(t => t.id));
+  const splits = await fetchAll<{ id: string; transaction_id: string; user_id: string }>(
+    'transaction_splits', 'id,transaction_id,user_id'
+  );
+  const splitsUnderDelete = splits.filter(s => deleteIds.has(s.transaction_id));
+  const orphanedSplits = splits.filter(s => !deleteIds.has(s.transaction_id) && s.user_id === userId);
+  const feedLinkedToDeleted = feedRows.filter(t => t.linked_transfer_id && deleteIds.has(t.linked_transfer_id));
+
+  console.log('\nRELATIONSHIPS');
+  console.log(`  transaction_splits under deleted parents : ${splitsUnderDelete.length} (deleted with them)`);
+  console.log(`  transaction_splits under KEPT parents    : ${orphanedSplits.length} (untouched)`);
+  console.log(`  feed rows whose linked_transfer_id points at a deleted row: ${feedLinkedToDeleted.length}` +
+    (feedLinkedToDeleted.length ? ' — must be NULLed before deletion, not left dangling' : ''));
+
+  // ── 4. The plan ───────────────────────────────────────────────────────────
+  const deletedValue = toDelete.reduce((s, t) => s.plus(money(t.amount)), new Decimal(0));
+  const reimportCount = toDelete.length - overlap.matches.length;
+  console.log('\nPLAN');
+  console.log(`  DELETE  ${toDelete.length} file-import transactions (net ${gbp(deletedValue)}) ` +
+    `+ ${splitsUnderDelete.length} split lines`);
+  console.log(`  KEEP    ${feedRows.length} bank-feed transactions, all accounts, all categories, ` +
+    'all budgets, all goals');
+  console.log(`  IMPORT  ${reimportCount} transactions from the file ` +
+    `(= ${toDelete.length} source rows − ${overlap.matches.length} the feed already covers)`);
+  console.log(`  NET     ${feedRows.length + reimportCount} transactions afterwards ` +
+    `(was ${rows.length}; ${rows.length - feedRows.length - reimportCount} fewer)`);
+
+  if (seedPath) {
+    if (!existsSync(seedPath)) fail(`seed not found: ${seedPath}`);
+    const seed = JSON.parse(readFileSync(seedPath, 'utf8')) as { transactions: unknown[] };
+    console.log(`  seed check: ${seed.transactions.length} transactions in ${seedPath}` +
+      (seed.transactions.length === toDelete.length ? ' — matches the rows to delete' :
+        ` — DIFFERS from the ${toDelete.length} rows to delete; investigate before running`));
+  }
+
+  // ── 5. Backup (outside the repo) ──────────────────────────────────────────
+  mkdirSync(outResolved, { recursive: true });
+  const stamp = new Date().toISOString().replace(/[:.]/g, '-');
+  const backupPath = join(outResolved, `mny-reimport-plan-${stamp}.json`);
+  writeFileSync(backupPath, JSON.stringify({
+    generatedAt: new Date().toISOString(),
+    userId,
+    discriminator: 'external_transaction_id IS NULL (legacy) OR import_source IS NOT NULL',
+    toleranceDays,
+    wouldDeleteTransactions: toDelete,
+    wouldDeleteSplits: splitsUnderDelete,
+    feedOverlapMatches: overlap.matches,
+    feedRowsKept: feedRows.map(t => t.id),
+  }, null, 1));
+  console.log(`\nBACKUP of every row this plan would delete: ${backupPath}`);
+  console.log('  (contains real financial data — keep it out of the repository)');
+
+  // ── 6. The destructive path — deliberately absent ─────────────────────────
+  if (APPLY) {
+    console.error('\n--apply is NOT IMPLEMENTED.');
+    console.error('');
+    console.error('TODO (human): before enabling a delete path here, it must');
+    console.error('  1. NULL linked_transfer_id / linked_transfer_split_id on any KEPT row that');
+    console.error('     points at a row being deleted (feed rows can reference imported ones);');
+    console.error('  2. delete transaction_splits children before their parents;');
+    console.error('  3. re-run the importer with BOTH the provenance columns and the feed-overlap');
+    console.error('     suppression set, or the overlap this plan measures comes straight back;');
+    console.error('  4. re-assert the ledger invariant per account');
+    console.error('     (initial_balance + Σ transactions = balance) afterwards — deleting rows');
+    console.error('     changes the sum and `balance` must be rebased to match;');
+    console.error('  5. run scripts/mnyIdempotencyCheck.mts against a scratch copy first.');
+    process.exit(2);
+  }
+  console.log('\nDRY RUN complete — nothing was changed.');
+})();

--- a/scripts/mnyReimportPlan.mts
+++ b/scripts/mnyReimportPlan.mts
@@ -1,5 +1,5 @@
 /**
- * MS Money re-import PLAN — read-only preview. NOTHING IS EVER DELETED HERE.
+ * MS Money re-import — PLAN (read-only) and APPLY (scoped delete + re-import).
  *
  * ── Why this exists ────────────────────────────────────────────────────────
  * The transaction table holds two independent populations that overlap in time:
@@ -32,30 +32,73 @@
  *
  * ── Discriminator for population A ─────────────────────────────────────────
  * `import_source = 'ms-money'` once migration 20260722170000 is applied and a
- * provenance-carrying import has run. For the CURRENT rows — written before
- * provenance existed — the script falls back to
- * `external_transaction_id IS NULL`, and prints the evidence for that fallback
- * (row counts per created_at day, per provenance state) so a human can confirm
- * the two populations really are cleanly separable before anything is run. If
- * they are not cleanly separable the script says so and refuses.
+ * provenance-carrying import has run. For rows written before provenance
+ * existed the discriminator is `external_transaction_id IS NULL`, and the
+ * script prints the evidence for it (row counts per created_at day, per
+ * provenance state) so a human can confirm the two populations really are
+ * cleanly separable. If they are not — if any single row carries BOTH markers
+ * — the script refuses, in dry run and in apply alike.
  *
- * ── Safety ─────────────────────────────────────────────────────────────────
- *   * READ-ONLY. There is no delete path in this file at all.
- *   * `--apply` is recognised and deliberately NOT IMPLEMENTED (see the guard
- *     at the bottom). Enabling it is a human decision.
- *   * A full JSON backup of every row the plan would delete is written to the
- *     output directory, which must be OUTSIDE the repository (the repo is
- *     public and these rows are real financial data).
+ * ── The two modes ──────────────────────────────────────────────────────────
+ * DRY RUN (default) is read-only. It prints the plan and writes it, with the
+ * rows it would delete, to a file OUTSIDE the repository. That file is also
+ * the BASELINE: apply re-reads it and refuses to run if the database has moved
+ * since (see PlanBaseline / compareToBaseline in
+ * src/services/import/msMoney/reimportGuards.ts).
+ *
+ * APPLY is destructive and, in order:
+ *   0. refuses unless the target database is the one the confirmation flag
+ *      claims it is, and unless the plan file, the seed and the live database
+ *      still agree;
+ *   0b. does NOTHING AT ALL if the database is already in the target state —
+ *      so a second run is a no-op, not a second demolition;
+ *   1. writes a complete backup of every row it will delete, reads it back and
+ *      verifies it row for row. No verified backup ⇒ no delete (the delete
+ *      function cannot even be called without the receipt that check issues);
+ *   2. deletes the file rows, each DELETE carrying
+ *      `external_transaction_id IS NULL` so the database itself refuses to
+ *      hand over a bank-feed row;
+ *   3. re-imports through the REAL importer (`planCloudImport` +
+ *      `executeCloudPlan` — batched, retrying, idempotent), with the
+ *      feed-overlap suppression set and full provenance;
+ *   4. verifies: counts, the bank-feed population unchanged row for row, no
+ *      orphaned category, no parentless split, provenance on every imported
+ *      row, and the per-account ledger invariant. Any breach exits non-zero.
+ *
+ * THIS OPERATION IS NOT ATOMIC ACROSS TABLES. If it dies partway it says
+ * exactly what it had done and where the backup is.
  *
  * Usage:
- *   npx tsx scripts/mnyReimportPlan.mts --out /path/to/scratchpad
- *   npx tsx scripts/mnyReimportPlan.mts --out … --seed .mny-local/mny-local-seed.json
+ *   # preview (read-only) — writes the plan + baseline outside the repo
+ *   npx tsx scripts/mnyReimportPlan.mts --out /path/outside/repo \
+ *     --seed .mny-local/mny-local-seed.json
+ *
+ *   # apply, against the database the plan was taken from
+ *   npx tsx scripts/mnyReimportPlan.mts --apply --out /path/outside/repo \
+ *     --seed .mny-local/mny-local-seed.json \
+ *     --plan /path/outside/repo/mny-reimport-plan-<stamp>.json \
+ *     --i-understand-this-deletes-production-rows
+ *
+ *   # the same against the scratch project (--env .env.scratch)
+ *   npx tsx scripts/mnyReimportPlan.mts --apply --env .env.scratch … \
+ *     --i-know-this-is-a-scratch-database
  */
 import { readFileSync, writeFileSync, mkdirSync, existsSync } from 'node:fs';
-import { join, resolve } from 'node:path';
-import { createClient } from '@supabase/supabase-js';
+import { join, resolve, sep } from 'node:path';
+import { createHash, randomUUID } from 'node:crypto';
+import { createClient, type SupabaseClient } from '@supabase/supabase-js';
 import Decimal from 'decimal.js';
-import { findFeedOverlap, type ExistingFeedTransaction } from '../src/services/import/msMoney/feedOverlap.ts';
+import { findFeedOverlap, type ExistingFeedTransaction, type FeedOverlapResult } from '../src/services/import/msMoney/feedOverlap.ts';
+import {
+  planCloudImport, executeCloudPlan, fetchExistingImportState, MS_MONEY_IMPORT_SOURCE,
+} from '../src/services/import/msMoney/msMoneyImport.ts';
+import {
+  splitPopulations, findFeedRowsInDeleteSet, compareToBaseline, verifyBackupContents,
+  describeTargetState, mapFeedRowsToSeedNamespace, findOrphanedCategoryIds, findParentlessSplitIds,
+  deleteFileOriginRows, REIMPORT_PLAN_VERSION,
+  type PlanBaseline, type LivePlanState,
+} from '../src/services/import/msMoney/reimportGuards.ts';
+import type { MsMoneyImportResult } from '../src/services/import/msMoney/transform.ts';
 import type { Transaction } from '../src/types/index.ts';
 
 // ── CLI ──────────────────────────────────────────────────────────────────────
@@ -65,36 +108,134 @@ const flag = (name: string): string | undefined => {
   return i >= 0 ? args[i + 1] : undefined;
 };
 const APPLY = args.includes('--apply');
+const CONFIRM_PRODUCTION = args.includes('--i-understand-this-deletes-production-rows');
+const CONFIRM_SCRATCH = args.includes('--i-know-this-is-a-scratch-database');
 const outDir = flag('out');
 const seedPath = flag('seed');
+const planPath = flag('plan');
+const envPath = flag('env') ?? '.env.local';
 const toleranceDays = Number(flag('tolerance') ?? 3);
 
+const USAGE = 'usage: tsx scripts/mnyReimportPlan.mts --out <dir outside the repo> ' +
+  '[--seed seed.json] [--env .env.local] [--tolerance 3]\n' +
+  '       …--apply --seed <seed.json> --plan <plan from the dry run> ' +
+  '(--i-understand-this-deletes-production-rows | --i-know-this-is-a-scratch-database)';
+
+// ── Where the run got to, for the message it prints if it dies ──────────────
+// Declared before the first guard, because the first guard can already abort.
+const progress = {
+  backupPath: null as string | null,
+  splitsDeleted: 0,
+  transactionsDeleted: 0,
+  deleteFinished: false,
+  importFinished: false,
+  verified: false,
+};
+
+function reportInterruptedState(): void {
+  console.error('\n──────────────────────────────────────────────────────────────');
+  console.error('STATE AT FAILURE — this operation is NOT atomic across tables.');
+  console.error(`  backup written      : ${progress.backupPath ?? 'NO — nothing was deleted'}`);
+  console.error(`  split lines deleted : ${progress.splitsDeleted}`);
+  console.error(`  transactions deleted: ${progress.transactionsDeleted}` +
+    (progress.deleteFinished ? ' (delete pass finished)' : ' (delete pass INCOMPLETE)'));
+  console.error(`  re-import           : ${progress.importFinished ? 'finished' : 'NOT finished'}`);
+  console.error(`  verification        : ${progress.verified ? 'passed' : 'NOT run / not passed'}`);
+  console.error('');
+  if (!progress.backupPath) {
+    console.error('  Nothing was deleted. The database is untouched.');
+  } else {
+    console.error('  Every deleted row is in the backup above (complete rows, transactions + splits).');
+    console.error('  RECOVERY: re-run the DRY RUN to take a fresh plan of the database as it now is,');
+    console.error('  then run --apply again with that plan. The importer is idempotent and the seed is');
+    console.error('  the source of truth, so a resumed run finishes the job rather than duplicating it.');
+    console.error('  Bank-feed rows are untouched by every path in this script.');
+  }
+  console.error('──────────────────────────────────────────────────────────────');
+}
+
+/** Declared, not inferred: TS only narrows on a never-returning call when the type is written down. */
+function fail(msg: string): never {
+  console.error(`\nABORT: ${msg}`);
+  // Once the backup exists, every abort is an abort MID-OPERATION: say what was
+  // done before saying goodbye.
+  if (APPLY && progress.backupPath) reportInterruptedState();
+  process.exit(1);
+}
+
 if (!outDir) {
-  console.error('usage: tsx scripts/mnyReimportPlan.mts --out <dir outside the repo> [--seed seed.json] [--tolerance 3]');
+  console.error(USAGE);
   process.exit(1);
 }
 const outResolved = resolve(outDir);
-if (outResolved.startsWith(resolve('.')) ) {
+const repoRoot = resolve('.');
+if (outResolved === repoRoot || outResolved.startsWith(repoRoot + sep)) {
   console.error(`ABORT: --out must be OUTSIDE the repository (the repo is public). Got ${outResolved}`);
   process.exit(1);
 }
+if (!Number.isFinite(toleranceDays) || toleranceDays < 0) fail(`--tolerance must be a non-negative number, got ${flag('tolerance')}`);
 
 // ── Environment (never printed) ──────────────────────────────────────────────
-const env = Object.fromEntries(
-  readFileSync('.env.local', 'utf8')
+const readEnv = (path: string): Record<string, string> => Object.fromEntries(
+  readFileSync(path, 'utf8')
     .split('\n')
     .filter(l => l.includes('=') && !l.trim().startsWith('#'))
     .map(l => [l.slice(0, l.indexOf('=')).trim(), l.slice(l.indexOf('=') + 1).trim()])
 );
+const urlOf = (path: string): string | undefined =>
+  existsSync(path) ? readEnv(path).VITE_SUPABASE_URL : undefined;
+
+if (!existsSync(envPath)) fail(`env file not found: ${envPath}`);
+const env = readEnv(envPath);
 const url = env.VITE_SUPABASE_URL;
 const serviceKey = env.SUPABASE_SERVICE_ROLE_KEY;
-if (!url || !serviceKey) {
-  console.error('Missing VITE_SUPABASE_URL / SUPABASE_SERVICE_ROLE_KEY in .env.local');
-  process.exit(1);
-}
-const sb = createClient(url, serviceKey, { auth: { persistSession: false } });
+if (!url || !serviceKey) fail(`Missing VITE_SUPABASE_URL / SUPABASE_SERVICE_ROLE_KEY in ${envPath}`);
 
-const fail = (msg: string): never => { console.error(`\nABORT: ${msg}`); process.exit(1); };
+/**
+ * Which database is this, really?
+ *
+ * The confirmation flag is not a formality, it is an ASSERTION about the
+ * target, and each one is checked against the file that defines that target.
+ * Claiming production while pointed at scratch means the numbers just reviewed
+ * belong to a different database; claiming scratch while pointed at production
+ * is the accident this whole script exists to avoid. Both are refused.
+ *
+ * (The mirror image of the guard in scripts/mnyIdempotencyCheck.mts, which only
+ * ever writes to scratch and so refuses production outright. This script's
+ * normal home IS production, so it cannot use that rule — it has to check the
+ * claim instead.)
+ */
+if (APPLY) {
+  const prodUrl = urlOf('.env.local');
+  const scratchUrl = urlOf('.env.scratch');
+  if (CONFIRM_PRODUCTION === CONFIRM_SCRATCH) {
+    fail('--apply needs exactly ONE of --i-understand-this-deletes-production-rows / ' +
+      '--i-know-this-is-a-scratch-database — the flag states which database this is, and it is verified.');
+  }
+  if (CONFIRM_PRODUCTION) {
+    if (scratchUrl && url === scratchUrl) {
+      fail('--i-understand-this-deletes-production-rows was given, but the target is the SAME project as ' +
+        '.env.scratch. Use --i-know-this-is-a-scratch-database for scratch runs.');
+    }
+    if (!prodUrl) fail('.env.local is missing, so "this is production" cannot be verified. Refusing.');
+    if (url !== prodUrl) {
+      fail(`--i-understand-this-deletes-production-rows was given, but ${envPath} does not name the same ` +
+        'project as .env.local. Refusing to delete from a database nobody has identified.');
+    }
+  }
+  if (CONFIRM_SCRATCH) {
+    if (!scratchUrl) fail('.env.scratch is missing, so "this is scratch" cannot be verified. Refusing.');
+    if (url !== scratchUrl) {
+      fail(`--i-know-this-is-a-scratch-database was given, but ${envPath} does not name the same project as ` +
+        '.env.scratch. Refusing.');
+    }
+    if (prodUrl && url === prodUrl) fail('.env.scratch and .env.local name the SAME project. Refusing to touch it.');
+  }
+  if (!seedPath) fail('--apply needs --seed: the re-import is driven by the extracted .mny seed.');
+  if (!planPath) fail('--apply needs --plan <file written by the dry run>: it is the baseline the live database is checked against.');
+}
+
+const sb = createClient(url, serviceKey, { auth: { persistSession: false } });
 
 interface DbTxn {
   id: string;
@@ -112,16 +253,22 @@ interface DbTxn {
   import_source_id: string | null;
   created_at: string;
 }
+interface DbSplit { id: string; transaction_id: string; user_id: string }
 
-async function fetchAll<T>(table: string, cols: string, filter?: (q: ReturnType<typeof sb.from>) => unknown): Promise<T[]> {
+/** Paged read of one table. `userId` scopes it to the target user when given. */
+async function fetchAll<T>(table: string, cols: string, userId?: string): Promise<T[]> {
   const PAGE = 1000;
   const rows: T[] = [];
   for (let from = 0; ; from += PAGE) {
-    let q = sb.from(table).select(cols).order('id').range(from, from + PAGE - 1);
-    if (filter) q = filter(q) as typeof q;
-    const { data, error } = await q;
+    // `.returns<T[]>()` is PostgREST's own way to state the row shape when the
+    // column list is a runtime string — no cast, and no `as unknown as`. It has
+    // to come after the filters: it hands back a transform builder, not a
+    // filter builder.
+    const filtered = sb.from(table).select(cols);
+    const scoped = userId ? filtered.eq('user_id', userId) : filtered;
+    const { data, error } = await scoped.order('id').range(from, from + PAGE - 1).returns<T[]>();
     if (error) fail(`reading ${table}: ${error.message}`);
-    const page = (data ?? []) as unknown as T[];
+    const page: T[] = data ?? [];
     rows.push(...page);
     if (page.length < PAGE) return rows;
   }
@@ -130,24 +277,77 @@ async function fetchAll<T>(table: string, cols: string, filter?: (q: ReturnType<
 const money = (v: string | number): Decimal => new Decimal(String(v));
 const gbp = (d: Decimal): string => `£${d.abs().toFixed(2)}`;
 
-(async () => {
-  console.log('MS Money re-import PLAN — dry run, read-only, nothing is deleted.\n');
+// ── The seed ────────────────────────────────────────────────────────────────
+interface SeedShape {
+  accounts: MsMoneyImportResult['accounts'];
+  categories: MsMoneyImportResult['categories'];
+  transactions: MsMoneyImportResult['transactions'];
+  transactionSplits: MsMoneyImportResult['transactionSplits'];
+  summary?: MsMoneyImportResult['summary'];
+}
+interface LoadedSeed { result: MsMoneyImportResult; sha256: string }
 
+function loadSeed(path: string): LoadedSeed {
+  if (!existsSync(path)) fail(`seed not found: ${path}`);
+  const raw = readFileSync(path, 'utf8');
+  const seed = JSON.parse(raw) as SeedShape;
+  if (!Array.isArray(seed.transactions) || !Array.isArray(seed.accounts)) {
+    fail(`seed ${path} does not look like an .mny extract (no transactions/accounts arrays)`);
+  }
+  return {
+    sha256: createHash('sha256').update(raw).digest('hex'),
+    result: {
+      accounts: seed.accounts,
+      categories: seed.categories,
+      transactions: seed.transactions,
+      transactionSplits: seed.transactionSplits,
+      summary: seed.summary ?? {
+        accounts: { total: 0, open: 0, closed: 0, investmentCashPairs: 0 },
+        categories: { subs: 0, details: 0, hidden: 0 },
+        transactions: { imported: 0, standalone: 0, transfers: 0, splitTransactions: 0, splitLines: 0 },
+        simplifications: [],
+      },
+    },
+  };
+}
+
+// ── Plan computation, shared by both modes ──────────────────────────────────
+interface LivePlan {
+  userId: string;
+  rows: DbTxn[];
+  feedRows: DbTxn[];
+  toDelete: DbTxn[];
+  allSplits: DbSplit[];
+  splitsUnderDelete: DbSplit[];
+  dbOverlap: FeedOverlapResult;
+  seedOverlap: FeedOverlapResult | null;
+  unmappedFeedRows: number;
+  duplicateAccountNames: string[];
+  hasProvenanceColumns: boolean;
+}
+
+async function computeLivePlan(seed: LoadedSeed | null): Promise<LivePlan> {
   const { data: users, error: uerr } = await sb.from('users').select('id, email');
   if (uerr || !users?.length) fail(`cannot read users: ${uerr?.message ?? 'none'}`);
 
-  // Provenance columns are optional: this plan is most useful BEFORE migration
-  // 20260722170000 is applied, when every file row is still unmarked.
+  // Provenance columns are optional only for the preview: this plan is most
+  // useful BEFORE migration 20260722170000 is applied, when every file row is
+  // still unmarked. Applying without them would write an import that is not
+  // idempotent, so apply requires them.
   const probe = await sb.from('transactions').select('import_source_id').limit(1);
   const hasProvenance = !probe.error;
   if (!hasProvenance) {
+    if (APPLY) {
+      fail('provenance columns missing — apply ' +
+        'supabase/migrations/20260722170000_transaction_import_provenance.sql first, or the re-import ' +
+        'cannot be idempotent and this whole exercise repeats itself.');
+    }
     console.log('NOTE: migration 20260722170000 is not applied yet — no row carries import');
     console.log('      provenance, so population A is identified by the fallback discriminator.\n');
   }
 
   const BASE_COLS = 'id,user_id,account_id,description,amount,type,date,category,is_split,' +
     'linked_transfer_id,external_transaction_id,created_at';
-  // The target is the user actually holding the imported history.
   const raw = await fetchAll<Omit<DbTxn, 'import_source' | 'import_source_id'> & Partial<DbTxn>>(
     'transactions',
     hasProvenance ? `${BASE_COLS},import_source,import_source_id` : BASE_COLS
@@ -160,25 +360,22 @@ const gbp = (d: Decimal): string => `£${d.abs().toFixed(2)}`;
     const list = byUser.get(t.user_id);
     if (list) list.push(t); else byUser.set(t.user_id, [t]);
   }
+  // The target is the user actually holding the imported history.
   const [userId, rows] = [...byUser.entries()].sort((a, b) => b[1].length - a[1].length)[0] ?? [];
   if (!userId || !rows) fail('no transactions found');
   console.log(`Target user: ${userId} — ${rows.length} transactions ` +
     `(other users hold ${all.length - rows.length}, untouched by this plan)\n`);
 
   // ── 1. Separate the two populations ────────────────────────────────────────
-  const feedRows = rows.filter(t => t.external_transaction_id != null);
-  const provenanced = rows.filter(t => t.import_source != null);
-  const legacyImport = rows.filter(t => t.external_transaction_id == null && t.import_source == null);
-
+  const populations = splitPopulations(rows);
   console.log('POPULATIONS');
-  console.log(`  bank feed  (external_transaction_id set) : ${feedRows.length}  — NEVER deleted`);
-  console.log(`  file import (import_source set)          : ${provenanced.length}`);
-  console.log(`  file import (legacy, no provenance)      : ${legacyImport.length}`);
+  console.log(`  bank feed  (external_transaction_id set) : ${populations.feed.length}  — NEVER deleted`);
+  console.log(`  file import (import_source set)          : ${populations.provenanced.length}`);
+  console.log(`  file import (legacy, no provenance)      : ${populations.legacy.length}`);
 
   // Both discriminators must agree that the populations are disjoint.
-  const bothMarkers = rows.filter(t => t.external_transaction_id != null && t.import_source != null);
-  if (bothMarkers.length) {
-    fail(`${bothMarkers.length} row(s) carry BOTH a bank-feed id and file provenance — ` +
+  if (populations.conflicted.length) {
+    fail(`${populations.conflicted.length} row(s) carry BOTH a bank-feed id and file provenance — ` +
       'the two populations are not cleanly separable; resolve by hand before any deletion.');
   }
 
@@ -192,13 +389,23 @@ const gbp = (d: Decimal): string => `£${d.abs().toFixed(2)}`;
   console.log('  evidence — rows by created_at day (feed / file):');
   for (const [d, e] of [...byDay].sort()) console.log(`    ${d}: ${e.feed} / ${e.file}`);
 
-  const toDelete = [...provenanced, ...legacyImport];
-  if (!toDelete.length) { console.log('\nNothing to re-import — no file-import rows found.'); return; }
+  const toDelete = [...populations.provenanced, ...populations.legacy];
+  // Belt and braces: the delete set is derived from the split above, so this
+  // can only fire if that ever changes. It is still asserted, every run.
+  const contaminated = findFeedRowsInDeleteSet(toDelete);
+  if (contaminated.length) {
+    fail(`${contaminated.length} row(s) in the delete set carry a bank-feed id (${contaminated[0].id}, …) — refusing.`);
+  }
 
   // ── 2. Which file rows would the feed already cover on re-import? ──────────
-  // Modelled directly on the rows in the database: a re-import reproduces the
-  // same transactions in the same accounts, so matching file rows against feed
-  // rows here is equivalent to matching the seed against them.
+  // Measured twice, deliberately:
+  //   * in the DATABASE's namespace, file rows against feed rows — the evidence
+  //     a human reads, since both sides are rows they can go and look at;
+  //   * in the SEED's namespace, the actual .mny rows against the same feed rows
+  //     translated onto the seed's accounts — which is what the re-import will
+  //     really suppress, and therefore what apply uses.
+  // On an unedited database the two agree. Where they do not, the difference is
+  // printed rather than averaged away.
   const asImportShape: Transaction[] = toDelete.map(t => ({
     id: t.import_source_id ?? t.id,
     date: new Date(`${t.date}T00:00:00.000Z`),
@@ -211,7 +418,7 @@ const gbp = (d: Decimal): string => `£${d.abs().toFixed(2)}`;
     isSplit: t.is_split === true,
   } as Transaction));
 
-  const asFeedShape: ExistingFeedTransaction[] = feedRows.map(t => ({
+  const asFeedShape: ExistingFeedTransaction[] = populations.feed.map(t => ({
     id: t.id,
     accountId: t.account_id,
     date: t.date,
@@ -219,89 +426,452 @@ const gbp = (d: Decimal): string => `£${d.abs().toFixed(2)}`;
     description: t.description ?? '',
   }));
 
-  const overlap = findFeedOverlap(asImportShape, asFeedShape, { dateToleranceDays: toleranceDays });
+  const dbOverlap = findFeedOverlap(asImportShape, asFeedShape, { dateToleranceDays: toleranceDays });
+
+  let seedOverlap: FeedOverlapResult | null = null;
+  let unmappedFeedRows = 0;
+  let duplicateAccountNames: string[] = [];
+  if (seed) {
+    const dbAccounts = await fetchAll<{ id: string; name: string }>('accounts', 'id,name', userId);
+    const mapped = mapFeedRowsToSeedNamespace(
+      seed.result.accounts.map(a => ({ id: a.id, name: a.name })),
+      dbAccounts,
+      populations.feed.map(t => ({
+        id: t.id, account_id: t.account_id, date: t.date, amount: t.amount, description: t.description,
+      }))
+    );
+    unmappedFeedRows = mapped.unmapped.length;
+    duplicateAccountNames = mapped.duplicateNames;
+    seedOverlap = findFeedOverlap(seed.result.transactions, mapped.rows, { dateToleranceDays: toleranceDays });
+  }
+
   const suppressedById = new Map(toDelete.map(t => [t.import_source_id ?? t.id, t]));
-  const suppressedRows = [...overlap.suppressedSourceIds].map(id => suppressedById.get(id)!).filter(Boolean);
+  const suppressedRows = [...dbOverlap.suppressedSourceIds]
+    .map(id => suppressedById.get(id))
+    .filter((t): t is DbTxn => t != null);
   const suppressedValue = suppressedRows.reduce((s, t) => s.plus(money(t.amount)), new Decimal(0));
 
   console.log(`\nFEED OVERLAP (±${toleranceDays} days, exact pence, same account, 1:1)`);
-  console.log(`  file rows the feed already covers   : ${overlap.matches.length}  (${gbp(suppressedValue)})`);
-  console.log(`  feed rows with no file counterpart  : ${overlap.unmatchedFeedIds.length}  — genuine feed-only spending, kept`);
-  console.log(`  overlaps deliberately NOT suppressed : ${overlap.keptDespiteOverlap.transfers} transfer leg(s), ` +
-    `${overlap.keptDespiteOverlap.splitParents} split parent(s)`);
-  const sameDay = overlap.matches.filter(m => m.dayGap === 0).length;
-  const strongDesc = overlap.matches.filter(m => m.descriptionSimilarity > 0).length;
-  console.log(`  match quality: ${sameDay}/${overlap.matches.length} same-day, ` +
-    `${strongDesc}/${overlap.matches.length} with overlapping description text`);
+  console.log(`  file rows the feed already covers   : ${dbOverlap.matches.length}  (${gbp(suppressedValue)})`);
+  console.log(`  feed rows with no file counterpart  : ${dbOverlap.unmatchedFeedIds.length}  — genuine feed-only spending, kept`);
+  console.log(`  overlaps deliberately NOT suppressed : ${dbOverlap.keptDespiteOverlap.transfers} transfer leg(s), ` +
+    `${dbOverlap.keptDespiteOverlap.splitParents} split parent(s)`);
+  const sameDay = dbOverlap.matches.filter(m => m.dayGap === 0).length;
+  const strongDesc = dbOverlap.matches.filter(m => m.descriptionSimilarity > 0).length;
+  console.log(`  match quality: ${sameDay}/${dbOverlap.matches.length} same-day, ` +
+    `${strongDesc}/${dbOverlap.matches.length} with overlapping description text`);
+  if (seedOverlap) {
+    console.log(`  same measurement against the SEED itself: ${seedOverlap.matches.length} suppressed ` +
+      `(this is the number the re-import uses)`);
+    if (seedOverlap.matches.length !== dbOverlap.matches.length) {
+      console.log('  NOTE: the two measurements differ. That means the rows in the database are not row-for-row');
+      console.log('        the rows in this seed (edited, partially imported, or a different export).');
+    }
+    if (unmappedFeedRows) {
+      console.log(`  ${unmappedFeedRows} feed row(s) sit in accounts the seed does not have — kept, and they`);
+      console.log('        cannot overlap anything the import writes.');
+    }
+    if (duplicateAccountNames.length) {
+      console.log(`  ${duplicateAccountNames.length} account name(s) appear more than once; they are paired in the`);
+      console.log('        same order the importer pairs them, so the overlap is measured where it lands.');
+    }
+  }
 
   // ── 3. Relationships the delete path must handle ──────────────────────────
   const deleteIds = new Set(toDelete.map(t => t.id));
-  const splits = await fetchAll<{ id: string; transaction_id: string; user_id: string }>(
-    'transaction_splits', 'id,transaction_id,user_id'
-  );
-  const splitsUnderDelete = splits.filter(s => deleteIds.has(s.transaction_id));
-  const orphanedSplits = splits.filter(s => !deleteIds.has(s.transaction_id) && s.user_id === userId);
-  const feedLinkedToDeleted = feedRows.filter(t => t.linked_transfer_id && deleteIds.has(t.linked_transfer_id));
+  const allSplits = await fetchAll<DbSplit>('transaction_splits', 'id,transaction_id,user_id');
+  const splitsUnderDelete = allSplits.filter(s => deleteIds.has(s.transaction_id));
+  const orphanedSplits = allSplits.filter(s => !deleteIds.has(s.transaction_id) && s.user_id === userId);
+  const feedLinkedToDeleted = populations.feed.filter(t => t.linked_transfer_id && deleteIds.has(t.linked_transfer_id));
 
   console.log('\nRELATIONSHIPS');
   console.log(`  transaction_splits under deleted parents : ${splitsUnderDelete.length} (deleted with them)`);
   console.log(`  transaction_splits under KEPT parents    : ${orphanedSplits.length} (untouched)`);
   console.log(`  feed rows whose linked_transfer_id points at a deleted row: ${feedLinkedToDeleted.length}` +
-    (feedLinkedToDeleted.length ? ' — must be NULLed before deletion, not left dangling' : ''));
+    (feedLinkedToDeleted.length
+      ? ' — the FK is ON DELETE SET NULL, so the survivor is unlinked, never left dangling'
+      : ''));
 
-  // ── 4. The plan ───────────────────────────────────────────────────────────
-  const deletedValue = toDelete.reduce((s, t) => s.plus(money(t.amount)), new Decimal(0));
-  const reimportCount = toDelete.length - overlap.matches.length;
+  return {
+    userId, rows, feedRows: populations.feed, toDelete, allSplits, splitsUnderDelete,
+    dbOverlap, seedOverlap, unmappedFeedRows, duplicateAccountNames, hasProvenanceColumns: hasProvenance,
+  };
+}
+
+/** The plan's headline numbers, printed identically in both modes. */
+function printPlan(plan: LivePlan, seed: LoadedSeed | null): { importCount: number; netCount: number } {
+  const deletedValue = plan.toDelete.reduce((s, t) => s.plus(money(t.amount)), new Decimal(0));
+  const suppressedCount = plan.seedOverlap?.matches.length ?? plan.dbOverlap.matches.length;
+  const sourceCount = seed ? seed.result.transactions.length : plan.toDelete.length;
+  const importCount = sourceCount - suppressedCount;
+  const netCount = plan.feedRows.length + importCount;
+
   console.log('\nPLAN');
-  console.log(`  DELETE  ${toDelete.length} file-import transactions (net ${gbp(deletedValue)}) ` +
-    `+ ${splitsUnderDelete.length} split lines`);
-  console.log(`  KEEP    ${feedRows.length} bank-feed transactions, all accounts, all categories, ` +
+  console.log(`  DELETE  ${plan.toDelete.length} file-import transactions (net ${gbp(deletedValue)}) ` +
+    `+ ${plan.splitsUnderDelete.length} split lines`);
+  console.log(`  KEEP    ${plan.feedRows.length} bank-feed transactions, all accounts, all categories, ` +
     'all budgets, all goals');
-  console.log(`  IMPORT  ${reimportCount} transactions from the file ` +
-    `(= ${toDelete.length} source rows − ${overlap.matches.length} the feed already covers)`);
-  console.log(`  NET     ${feedRows.length + reimportCount} transactions afterwards ` +
-    `(was ${rows.length}; ${rows.length - feedRows.length - reimportCount} fewer)`);
+  console.log(`  IMPORT  ${importCount} transactions from the file ` +
+    `(= ${sourceCount} source rows − ${suppressedCount} the feed already covers)`);
+  console.log(`  NET     ${netCount} transactions afterwards ` +
+    `(was ${plan.rows.length}; ${plan.rows.length - netCount} fewer)`);
 
-  if (seedPath) {
-    if (!existsSync(seedPath)) fail(`seed not found: ${seedPath}`);
-    const seed = JSON.parse(readFileSync(seedPath, 'utf8')) as { transactions: unknown[] };
-    console.log(`  seed check: ${seed.transactions.length} transactions in ${seedPath}` +
-      (seed.transactions.length === toDelete.length ? ' — matches the rows to delete' :
-        ` — DIFFERS from the ${toDelete.length} rows to delete; investigate before running`));
+  if (seed) {
+    console.log(`  seed check: ${seed.result.transactions.length} transactions in the seed` +
+      (seed.result.transactions.length === plan.toDelete.length ? ' — matches the rows to delete' :
+        ` — DIFFERS from the ${plan.toDelete.length} rows to delete; investigate before applying`));
   }
+  return { importCount, netCount };
+}
 
-  // ── 5. Backup (outside the repo) ──────────────────────────────────────────
+function buildBaseline(plan: LivePlan, seed: LoadedSeed, counts: { importCount: number; netCount: number }): PlanBaseline {
+  return {
+    version: REIMPORT_PLAN_VERSION,
+    userId: plan.userId,
+    toleranceDays,
+    seedSha256: seed.sha256,
+    seedTransactionCount: seed.result.transactions.length,
+    deleteTransactionIds: plan.toDelete.map(t => t.id),
+    deleteSplitIds: plan.splitsUnderDelete.map(s => s.id),
+    feedTransactionIds: plan.feedRows.map(t => t.id),
+    suppressedSourceIds: [...(plan.seedOverlap?.suppressedSourceIds ?? new Set<string>())],
+    expectedImportCount: counts.importCount,
+    expectedNetCount: counts.netCount,
+  };
+}
+
+const stamp = (): string => new Date().toISOString().replace(/[:.]/g, '-');
+
+// ── DRY RUN ─────────────────────────────────────────────────────────────────
+async function dryRun(seed: LoadedSeed | null): Promise<void> {
+  console.log('MS Money re-import PLAN — dry run, read-only, nothing is deleted.\n');
+  const plan = await computeLivePlan(seed);
+  if (!plan.toDelete.length) { console.log('\nNothing to re-import — no file-import rows found.'); return; }
+  const counts = printPlan(plan, seed);
+
   mkdirSync(outResolved, { recursive: true });
-  const stamp = new Date().toISOString().replace(/[:.]/g, '-');
-  const backupPath = join(outResolved, `mny-reimport-plan-${stamp}.json`);
-  writeFileSync(backupPath, JSON.stringify({
+  const planFile = join(outResolved, `mny-reimport-plan-${stamp()}.json`);
+  writeFileSync(planFile, JSON.stringify({
     generatedAt: new Date().toISOString(),
-    userId,
+    userId: plan.userId,
     discriminator: 'external_transaction_id IS NULL (legacy) OR import_source IS NOT NULL',
     toleranceDays,
-    wouldDeleteTransactions: toDelete,
-    wouldDeleteSplits: splitsUnderDelete,
-    feedOverlapMatches: overlap.matches,
-    feedRowsKept: feedRows.map(t => t.id),
+    baseline: seed ? buildBaseline(plan, seed, counts) : null,
+    wouldDeleteTransactions: plan.toDelete,
+    wouldDeleteSplits: plan.splitsUnderDelete,
+    feedOverlapMatches: plan.dbOverlap.matches,
+    seedOverlapMatches: plan.seedOverlap?.matches ?? null,
+    feedRowsKept: plan.feedRows.map(t => t.id),
   }, null, 1));
-  console.log(`\nBACKUP of every row this plan would delete: ${backupPath}`);
+  console.log(`\nPLAN + BACKUP of every row this plan would delete: ${planFile}`);
   console.log('  (contains real financial data — keep it out of the repository)');
-
-  // ── 6. The destructive path — deliberately absent ─────────────────────────
-  if (APPLY) {
-    console.error('\n--apply is NOT IMPLEMENTED.');
-    console.error('');
-    console.error('TODO (human): before enabling a delete path here, it must');
-    console.error('  1. NULL linked_transfer_id / linked_transfer_split_id on any KEPT row that');
-    console.error('     points at a row being deleted (feed rows can reference imported ones);');
-    console.error('  2. delete transaction_splits children before their parents;');
-    console.error('  3. re-run the importer with BOTH the provenance columns and the feed-overlap');
-    console.error('     suppression set, or the overlap this plan measures comes straight back;');
-    console.error('  4. re-assert the ledger invariant per account');
-    console.error('     (initial_balance + Σ transactions = balance) afterwards — deleting rows');
-    console.error('     changes the sum and `balance` must be rebased to match;');
-    console.error('  5. run scripts/mnyIdempotencyCheck.mts against a scratch copy first.');
-    process.exit(2);
+  if (!seed) {
+    console.log('\nNo --seed given, so this file carries NO baseline and --apply will not accept it.');
+    console.log('Re-run with --seed <the .mny extract> to produce an applicable plan.');
+  } else {
+    console.log('\nTo apply this exact plan:');
+    console.log(`  npx tsx scripts/mnyReimportPlan.mts --apply --env ${envPath} --out ${outResolved} \\`);
+    console.log(`    --seed ${seedPath} --plan ${planFile} \\`);
+    console.log('    --i-understand-this-deletes-production-rows   # or --i-know-this-is-a-scratch-database');
   }
   console.log('\nDRY RUN complete — nothing was changed.');
-})();
+}
+
+// ── APPLY ───────────────────────────────────────────────────────────────────
+
+/** Full rows, every column, for the backup. Paged like every other read here. */
+async function fetchFullRows(table: string, userId: string): Promise<Record<string, unknown>[]> {
+  const PAGE = 1000;
+  const rows: Record<string, unknown>[] = [];
+  for (let from = 0; ; from += PAGE) {
+    const { data, error } = await sb.from(table).select('*').eq('user_id', userId)
+      .order('id').range(from, from + PAGE - 1);
+    if (error) fail(`reading ${table} for the backup: ${error.message}`);
+    const page = (data ?? []) as Record<string, unknown>[];
+    rows.push(...page);
+    if (page.length < PAGE) return rows;
+  }
+}
+
+/** Per-account ledger invariant: initial_balance + Σ transactions === balance. */
+async function ledgerBreaches(userId: string): Promise<{ broken: number; accounts: number }> {
+  const accounts = await fetchAll<{ id: string; balance: string | number | null; initial_balance: string | number | null }>(
+    'accounts', 'id,balance,initial_balance', userId);
+  const txns = await fetchAll<{ account_id: string; amount: string | number }>(
+    'transactions', 'account_id,amount', userId);
+  const sums = new Map<string, Decimal>();
+  for (const t of txns) sums.set(t.account_id, (sums.get(t.account_id) ?? new Decimal(0)).plus(money(t.amount)));
+  let broken = 0;
+  for (const a of accounts) {
+    const computed = money(a.initial_balance ?? 0).plus(sums.get(a.id) ?? new Decimal(0));
+    if (!computed.equals(money(a.balance ?? 0))) broken++;
+  }
+  return { broken, accounts: accounts.length };
+}
+
+async function apply(seed: LoadedSeed): Promise<void> {
+  console.log('MS Money re-import APPLY — this DELETES file-import rows and re-imports them.\n');
+  console.log(`Target: ${new URL(url).host} (from ${envPath})\n`);
+
+  if (!planPath) fail('--apply needs --plan <file written by the dry run>.');
+  const baselineFile = planPath;
+  if (!existsSync(baselineFile)) fail(`plan file not found: ${baselineFile}`);
+  const planDoc = JSON.parse(readFileSync(baselineFile, 'utf8')) as { baseline?: PlanBaseline | null };
+  const baseline = planDoc.baseline;
+  if (!baseline) {
+    fail(`${baselineFile} carries no baseline — it was written by a dry run without --seed. Re-run the dry run with --seed.`);
+  }
+
+  const plan = await computeLivePlan(seed);
+  const counts = printPlan(plan, seed);
+
+  // ── 0b. Is the work already done? ─────────────────────────────────────────
+  const seedSourceIds = new Set(seed.result.transactions.map(t => t.id));
+  const suppressed = plan.seedOverlap?.suppressedSourceIds ?? new Set<string>();
+  const target = describeTargetState({
+    fileRows: plan.toDelete,
+    seedSourceIds,
+    suppressedSourceIds: suppressed,
+    importSource: MS_MONEY_IMPORT_SOURCE,
+  });
+  console.log('\nTARGET STATE');
+  if (target.satisfied) {
+    console.log('  the database ALREADY holds exactly the rows a successful apply would leave.');
+    console.log('  Nothing to do: no backup, no delete, no import. Exiting without touching anything.');
+    return;
+  }
+  for (const reason of target.reasons) console.log(`  not yet: ${reason}`);
+
+  // Provenanced rows about to be deleted must have come from THIS seed.
+  const foreignProvenance = plan.toDelete.filter(
+    t => t.import_source_id != null && !seedSourceIds.has(t.import_source_id)
+  );
+  if (foreignProvenance.length) {
+    fail(`${foreignProvenance.length} row(s) to delete carry an import_source_id that is not in this seed ` +
+      `(e.g. ${foreignProvenance[0].import_source_id}) — this seed is not the export those rows came from.`);
+  }
+
+  // ── 1. Drift ──────────────────────────────────────────────────────────────
+  const live: LivePlanState = {
+    userId: plan.userId,
+    toleranceDays,
+    seedSha256: seed.sha256,
+    seedTransactionCount: seed.result.transactions.length,
+    deleteTransactionIds: plan.toDelete.map(t => t.id),
+    deleteSplitIds: plan.splitsUnderDelete.map(s => s.id),
+    feedTransactionIds: plan.feedRows.map(t => t.id),
+    suppressedSourceIds: [...suppressed],
+    expectedImportCount: counts.importCount,
+    expectedNetCount: counts.netCount,
+  };
+  const drift = compareToBaseline(baseline, live);
+  console.log('\nDRIFT CHECK against the reviewed plan');
+  if (drift.drifted) {
+    for (const line of drift.lines) console.error(`  ${line}`);
+    fail('the database is not what the plan describes. Nothing has been touched. ' +
+      'Re-run the DRY RUN, read the new numbers, and apply that plan instead.');
+  }
+  console.log('  the live database matches the plan exactly — same rows, same seed, same counts.');
+
+  const ledgerBefore = await ledgerBreaches(plan.userId);
+
+  // ── 2. Backup, before anything is destroyed ───────────────────────────────
+  mkdirSync(outResolved, { recursive: true });
+  const backupPath = join(outResolved, `mny-reimport-backup-${stamp()}.json`);
+  console.log('\nBACKUP');
+  const deleteIds = new Set(plan.toDelete.map(t => t.id));
+  const splitIdsToDelete = plan.splitsUnderDelete.map(s => s.id);
+  const splitIdSet = new Set(splitIdsToDelete);
+  const fullTxns = (await fetchFullRows('transactions', plan.userId)).filter(r => deleteIds.has(String(r.id)));
+  const fullSplits = (await fetchFullRows('transaction_splits', plan.userId)).filter(r => splitIdSet.has(String(r.id)));
+  writeFileSync(backupPath, JSON.stringify({
+    writtenAt: new Date().toISOString(),
+    userId: plan.userId,
+    planFile: baselineFile,
+    seedSha256: seed.sha256,
+    note: 'Complete rows, every column, for every row the apply pass deleted. Re-inserting ' +
+      'transactions then splits restores them exactly; links that pointed at them were SET NULL by the FK.',
+    transactions: fullTxns,
+    splits: fullSplits,
+  }));
+  progress.backupPath = backupPath;
+  console.log(`  written: ${backupPath}`);
+
+  // Read it BACK off the disk — a file that cannot be re-read is not a backup.
+  const { receipt, problems } = verifyBackupContents(readFileSync(backupPath, 'utf8'), {
+    path: backupPath,
+    transactionIds: [...deleteIds],
+    splitIds: splitIdsToDelete,
+  });
+  if (!receipt) {
+    for (const p of problems) console.error(`  ${p}`);
+    progress.backupPath = null; // nothing was deleted; do not imply a usable backup
+    fail('the backup does not hold every row that would be deleted. NOTHING has been deleted.');
+  }
+  console.log(`  verified on disk: ${receipt.transactionIds.size} transactions + ${receipt.splitIds.size} split lines, ` +
+    'no bank-feed row among them.');
+
+  // ── 3. Delete ─────────────────────────────────────────────────────────────
+  console.log('\nDELETING (file-import rows only; every statement carries external_transaction_id IS NULL)');
+  const outcome = await deleteFileOriginRows(
+    sb,
+    receipt,
+    plan.toDelete.map(t => t.id),
+    splitIdsToDelete,
+    (stage, done, total) => {
+      if (stage === 'splits') progress.splitsDeleted = done; else progress.transactionsDeleted = done;
+      process.stdout.write(`\r  ${stage}: ${done}/${total}`);
+    }
+  );
+  process.stdout.write('\n');
+  progress.splitsDeleted = outcome.splitsDeleted;
+  progress.transactionsDeleted = outcome.transactionsDeleted;
+  if (outcome.transactionsDeleted !== plan.toDelete.length || outcome.splitsDeleted !== splitIdsToDelete.length) {
+    fail(`delete pass removed ${outcome.transactionsDeleted}/${plan.toDelete.length} transactions and ` +
+      `${outcome.splitsDeleted}/${splitIdsToDelete.length} split lines. Some rows refused to go ` +
+      '(a bank-feed id appearing mid-run would do it). STOP and investigate before re-importing.');
+  }
+  progress.deleteFinished = true;
+  console.log(`  deleted ${outcome.transactionsDeleted} transactions and ${outcome.splitsDeleted} split lines.`);
+
+  // ── 4. Re-import through the real importer ────────────────────────────────
+  console.log('\nRE-IMPORTING (planCloudImport + executeCloudPlan — the same path the app uses)');
+  const existing = await fetchExistingImportState(sb, plan.userId);
+  const importPlan = planCloudImport(seed.result, plan.userId, randomUUID, {
+    ...existing,
+    suppressedSourceIds: suppressed,
+  });
+  console.log(`  plan: ${importPlan.transactions.length} transactions, ${importPlan.splits.length} split lines, ` +
+    `${importPlan.accounts.length} new accounts, ${importPlan.categories.length} new categories`);
+  console.log(`  skipped: ${importPlan.skippedFeedOverlap} covered by the feed, ${importPlan.skippedExisting} already present, ` +
+    `${importPlan.skippedExistingAccounts} accounts / ${importPlan.skippedExistingCategories} categories reused`);
+  if (importPlan.categoriesWithUnresolvedParent > 0) {
+    fail(`${importPlan.categoriesWithUnresolvedParent} categories have no resolvable parent — the seed tree is broken. ` +
+      'The delete has already run; see the state report.');
+  }
+  if (importPlan.transactions.length !== counts.importCount) {
+    fail(`the importer planned ${importPlan.transactions.length} inserts but the reviewed plan said ` +
+      `${counts.importCount}. Refusing to write. The delete has already run; see the state report.`);
+  }
+  let lastPhase = '';
+  await executeCloudPlan(importPlan, sb, {
+    onProgress: p => {
+      if (p.phase !== lastPhase) { if (lastPhase) process.stdout.write('\n'); lastPhase = p.phase; }
+      process.stdout.write(`\r  ${p.message.padEnd(60)}`);
+    },
+  });
+  process.stdout.write('\n');
+  progress.importFinished = true;
+
+  // ── 5. Verify ─────────────────────────────────────────────────────────────
+  console.log('\nVERIFYING');
+  const failures: string[] = [];
+  const after = await fetchAll<DbTxn>('transactions',
+    'id,user_id,account_id,description,amount,type,date,category,is_split,linked_transfer_id,' +
+    'external_transaction_id,import_source,import_source_id,created_at', plan.userId);
+  const afterSplits = await fetchAll<DbSplit>('transaction_splits', 'id,transaction_id,user_id', plan.userId);
+  const afterCategories = await fetchAll<{ id: string; parent_id: string | null }>('categories', 'id,parent_id', plan.userId);
+  const afterAccounts = await fetchAll<{ id: string }>('accounts', 'id', plan.userId);
+
+  const afterPopulations = splitPopulations(after);
+  console.log(`  counts: ${after.length} transactions, ${afterSplits.length} split lines, ` +
+    `${afterAccounts.length} accounts, ${afterCategories.length} categories`);
+
+  // (a) every bank-feed row still there, row for row.
+  const feedBefore = new Set(plan.feedRows.map(t => t.id));
+  const feedAfter = new Set(afterPopulations.feed.map(t => t.id));
+  const lostFeed = [...feedBefore].filter(id => !feedAfter.has(id));
+  const newFeed = [...feedAfter].filter(id => !feedBefore.has(id));
+  console.log(`  bank-feed rows: ${feedBefore.size} before → ${feedAfter.size} after`);
+  if (lostFeed.length) failures.push(`${lostFeed.length} bank-feed row(s) are GONE (e.g. ${lostFeed[0]})`);
+  if (newFeed.length) failures.push(`${newFeed.length} bank-feed row(s) appeared that were not there before`);
+
+  // (b) no row carries both markers; no file row is left without provenance.
+  if (afterPopulations.conflicted.length) failures.push(`${afterPopulations.conflicted.length} row(s) now carry BOTH markers`);
+  if (afterPopulations.legacy.length) failures.push(`${afterPopulations.legacy.length} file row(s) still carry no provenance`);
+  const provenanced = afterPopulations.provenanced.filter(t => t.import_source === MS_MONEY_IMPORT_SOURCE);
+  const distinctSourceIds = new Set(provenanced.map(t => t.import_source_id));
+  console.log(`  provenance: ${provenanced.length} rows carry ms-money provenance, ` +
+    `${distinctSourceIds.size} distinct source ids`);
+  if (provenanced.length !== counts.importCount) {
+    failures.push(`${provenanced.length} provenanced rows, expected ${counts.importCount}`);
+  }
+  if (distinctSourceIds.size !== provenanced.length) {
+    failures.push('two imported rows share an import_source_id');
+  }
+  const suppressedPresent = [...suppressed].filter(id => distinctSourceIds.has(id));
+  if (suppressedPresent.length) {
+    failures.push(`${suppressedPresent.length} feed-covered row(s) were re-imported anyway (e.g. ${suppressedPresent[0]})`);
+  }
+
+  // (c) totals.
+  if (after.length !== counts.netCount) failures.push(`${after.length} transactions, the plan said ${counts.netCount}`);
+
+  // (d) referential integrity.
+  const orphanedCategories = findOrphanedCategoryIds(afterCategories);
+  if (orphanedCategories.length) failures.push(`${orphanedCategories.length} categor(ies) point at a parent that does not exist`);
+  const afterTxnIds = new Set(after.map(t => t.id));
+  const parentless = findParentlessSplitIds(afterSplits, afterTxnIds);
+  if (parentless.length) failures.push(`${parentless.length} split line(s) have no parent transaction`);
+  const danglingLinks = after.filter(t => t.linked_transfer_id != null && !afterTxnIds.has(t.linked_transfer_id));
+  if (danglingLinks.length) failures.push(`${danglingLinks.length} transfer link(s) point at a row that does not exist`);
+  console.log(`  integrity: ${orphanedCategories.length} orphaned categories, ${parentless.length} parentless splits, ` +
+    `${danglingLinks.length} dangling transfer links`);
+
+  // (e) did the double-counting actually go away?
+  const signature = (t: DbTxn): string =>
+    `${t.account_id}|${t.date}|${money(t.amount).times(100).round().toString()}|${(t.description ?? '').trim().toUpperCase()}`;
+  const seen = new Map<string, number>();
+  for (const t of after) seen.set(signature(t), (seen.get(signature(t)) ?? 0) + 1);
+  const dupGroups = [...seen.values()].filter(n => n > 1).length;
+  console.log(`  duplicate (account, date, pence, description) groups remaining: ${dupGroups}`);
+
+  progress.verified = failures.length === 0;
+
+  // ── 6. The ledger invariant ───────────────────────────────────────────────
+  const ledgerAfter = await ledgerBreaches(plan.userId);
+  console.log(`  ledger invariant (initial_balance + Σ txns = balance): ` +
+    `${ledgerAfter.accounts - ledgerAfter.broken}/${ledgerAfter.accounts} accounts OK ` +
+    `(was ${ledgerBefore.accounts - ledgerBefore.broken}/${ledgerBefore.accounts} before)`);
+
+  if (failures.length) {
+    console.error('\nVERIFICATION FAILED:');
+    for (const f of failures) console.error(`  - ${f}`);
+    console.error(`\nThe backup of every deleted row is at ${backupPath}`);
+    process.exit(1);
+  }
+
+  console.log('\nDONE — file rows replaced, bank-feed rows untouched, every imported row carries provenance.');
+  console.log(`Backup of every deleted row: ${backupPath}`);
+  console.log('Re-running --apply now is a no-op (the target-state check short-circuits it).');
+
+  if (ledgerAfter.broken > ledgerBefore.broken) {
+    // Removing the feed-covered duplicates changes Σ transactions, so the
+    // stored balance no longer matches. That is a real, expected consequence —
+    // and it is repaired by the tool that owns balance repair, not by a second
+    // balance-writing path invented here.
+    console.error(`\nREQUIRED FOLLOW-UP: ${ledgerAfter.broken - ledgerBefore.broken} more account(s) now break the ledger`);
+    console.error('invariant than before — the suppressed duplicates were part of the stored balance. Repair with:');
+    console.error('  node scripts/repair-balance-drift.mjs --strategy=trust-ledger          # dry run');
+    console.error('  node scripts/repair-balance-drift.mjs --strategy=trust-ledger --apply');
+    process.exit(3);
+  }
+}
+
+// ── Entry point ─────────────────────────────────────────────────────────────
+(async () => {
+  const seed = seedPath ? loadSeed(seedPath) : null;
+  if (!APPLY) { await dryRun(seed); return; }
+  if (!seed) fail('--apply needs --seed.');
+  await apply(seed);
+})().catch((thrown: unknown) => {
+  console.error(`\nFAILED: ${thrown instanceof Error ? thrown.message : String(thrown)}`);
+  if (APPLY) reportInterruptedState();
+  process.exit(1);
+});
+
+process.on('SIGINT', () => {
+  console.error('\nInterrupted.');
+  if (APPLY) reportInterruptedState();
+  process.exit(130);
+});

--- a/scripts/mnyReimportPlan.mts
+++ b/scripts/mnyReimportPlan.mts
@@ -91,6 +91,7 @@ import Decimal from 'decimal.js';
 import { findFeedOverlap, type ExistingFeedTransaction, type FeedOverlapResult } from '../src/services/import/msMoney/feedOverlap.ts';
 import {
   planCloudImport, executeCloudPlan, fetchExistingImportState, MS_MONEY_IMPORT_SOURCE,
+  type CloudPlan,
 } from '../src/services/import/msMoney/msMoneyImport.ts';
 import {
   splitPopulations, findFeedRowsInDeleteSet, compareToBaseline, verifyBackupContents,
@@ -115,10 +116,21 @@ const seedPath = flag('seed');
 const planPath = flag('plan');
 const envPath = flag('env') ?? '.env.local';
 const toleranceDays = Number(flag('tolerance') ?? 3);
+/**
+ * Correct a reused account's `initial_balance` to the file's value.
+ *
+ * OPT-IN and never implied. `planCloudImport` reuses an account by name and
+ * then leaves it out of the insert, so its opening balance survives every
+ * re-import untouched — including one somebody fabricated by "repairing" a
+ * balance discrepancy into it. Without this flag the disagreement is reported
+ * and the apply pass REFUSES to call itself successful; with it, the file wins.
+ */
+const REBASE_OPENING_BALANCES = args.includes('--rebase-opening-balances');
 
 const USAGE = 'usage: tsx scripts/mnyReimportPlan.mts --out <dir outside the repo> ' +
   '[--seed seed.json] [--env .env.local] [--tolerance 3]\n' +
   '       …--apply --seed <seed.json> --plan <plan from the dry run> ' +
+  '[--rebase-opening-balances] ' +
   '(--i-understand-this-deletes-production-rows | --i-know-this-is-a-scratch-database)';
 
 // ── Where the run got to, for the message it prints if it dies ──────────────
@@ -326,6 +338,35 @@ interface LivePlan {
   hasProvenanceColumns: boolean;
 }
 
+/**
+ * Suppression BY ACCOUNT, with the transfer handovers called out separately.
+ *
+ * The totals hide the thing worth seeing: before handovers existed, the rows
+ * left behind in a fed account were the transfers — and the transfers are the
+ * biggest rows in the window. Per account, "233 suppressed (3 handed over)"
+ * says both that the window is covered and how much of it needed a handover.
+ */
+function suppressionByAccount(
+  overlap: FeedOverlapResult,
+  nameOf: (accountId: string) => string
+): string[] {
+  const totals = new Map<string, { suppressed: number; handovers: number }>();
+  for (const m of overlap.matches) {
+    const entry = totals.get(m.accountId) ?? { suppressed: 0, handovers: 0 };
+    entry.suppressed++;
+    if (m.isTransferHandover) entry.handovers++;
+    totals.set(m.accountId, entry);
+  }
+  return [...totals.entries()]
+    .sort((a, b) => b[1].suppressed - a[1].suppressed || a[0].localeCompare(b[0]))
+    .map(([id, e]) => `${nameOf(id)}: ${e.suppressed} suppressed` +
+      (e.handovers ? ` (${e.handovers} transfer leg${e.handovers === 1 ? '' : 's'} handed to the feed row)` : ''));
+}
+
+/** `sourceId>feedId`, the pairing the baseline compares — order-independent. */
+const handoverKeys = (overlap: FeedOverlapResult | null): string[] =>
+  (overlap?.transferHandovers ?? []).map(h => `${h.importSourceId}>${h.feedTransactionId}`).sort();
+
 async function computeLivePlan(seed: LoadedSeed | null): Promise<LivePlan> {
   const { data: users, error: uerr } = await sb.from('users').select('id, email');
   if (uerr || !users?.length) fail(`cannot read users: ${uerr?.message ?? 'none'}`);
@@ -424,20 +465,28 @@ async function computeLivePlan(seed: LoadedSeed | null): Promise<LivePlan> {
     date: t.date,
     amount: String(t.amount),
     description: t.description ?? '',
+    // Both are handover gates, not match gates: a split parent cannot be
+    // re-typed as a transfer, and a row already in a linked pair is not ours.
+    isSplit: t.is_split === true,
+    linkedTransferId: t.linked_transfer_id,
   }));
 
   const dbOverlap = findFeedOverlap(asImportShape, asFeedShape, { dateToleranceDays: toleranceDays });
+
+  const dbAccounts = await fetchAll<{ id: string; name: string }>('accounts', 'id,name', userId);
+  const dbAccountName = new Map(dbAccounts.map(a => [a.id, a.name]));
+  const seedAccountName = new Map((seed?.result.accounts ?? []).map(a => [a.id, a.name]));
 
   let seedOverlap: FeedOverlapResult | null = null;
   let unmappedFeedRows = 0;
   let duplicateAccountNames: string[] = [];
   if (seed) {
-    const dbAccounts = await fetchAll<{ id: string; name: string }>('accounts', 'id,name', userId);
     const mapped = mapFeedRowsToSeedNamespace(
       seed.result.accounts.map(a => ({ id: a.id, name: a.name })),
       dbAccounts,
       populations.feed.map(t => ({
         id: t.id, account_id: t.account_id, date: t.date, amount: t.amount, description: t.description,
+        is_split: t.is_split, linked_transfer_id: t.linked_transfer_id,
       }))
     );
     unmappedFeedRows = mapped.unmapped.length;
@@ -460,9 +509,24 @@ async function computeLivePlan(seed: LoadedSeed | null): Promise<LivePlan> {
   const strongDesc = dbOverlap.matches.filter(m => m.descriptionSimilarity > 0).length;
   console.log(`  match quality: ${sameDay}/${dbOverlap.matches.length} same-day, ` +
     `${strongDesc}/${dbOverlap.matches.length} with overlapping description text`);
+
+  const handoverRows = dbOverlap.transferHandovers
+    .map(h => suppressedById.get(h.importSourceId))
+    .filter((t): t is DbTxn => t != null);
+  const handoverValue = handoverRows.reduce((s, t) => s.plus(money(t.amount)), new Decimal(0));
+  console.log(`  transfer legs handed over to their feed row: ${dbOverlap.transferHandovers.length} ` +
+    `(${gbp(handoverValue)} gross) — the feed row becomes the transfer, the counterpart is re-linked to it`);
+  console.log('  measured in the DATABASE\'s namespace, by account:');
+  for (const line of suppressionByAccount(dbOverlap, id => dbAccountName.get(id) ?? id)) {
+    console.log(`    ${line}`);
+  }
+
   if (seedOverlap) {
     console.log(`  same measurement against the SEED itself: ${seedOverlap.matches.length} suppressed ` +
-      `(this is the number the re-import uses)`);
+      `(this is the number the re-import uses), ${seedOverlap.transferHandovers.length} handed over`);
+    for (const line of suppressionByAccount(seedOverlap, id => seedAccountName.get(id) ?? id)) {
+      console.log(`    ${line}`);
+    }
     if (seedOverlap.matches.length !== dbOverlap.matches.length) {
       console.log('  NOTE: the two measurements differ. That means the rows in the database are not row-for-row');
       console.log('        the rows in this seed (edited, partially imported, or a different export).');
@@ -535,9 +599,84 @@ function buildBaseline(plan: LivePlan, seed: LoadedSeed, counts: { importCount: 
     deleteSplitIds: plan.splitsUnderDelete.map(s => s.id),
     feedTransactionIds: plan.feedRows.map(t => t.id),
     suppressedSourceIds: [...(plan.seedOverlap?.suppressedSourceIds ?? new Set<string>())],
+    transferHandovers: handoverKeys(plan.seedOverlap),
     expectedImportCount: counts.importCount,
     expectedNetCount: counts.netCount,
   };
+}
+
+// ── The import plan itself, built identically in both modes ─────────────────
+
+/** Complete rows (`select *`) for a named set of ids. Batched to keep URLs sane. */
+async function fetchRowsByIds(table: string, ids: readonly string[]): Promise<Map<string, Record<string, unknown>>> {
+  const out = new Map<string, Record<string, unknown>>();
+  for (let i = 0; i < ids.length; i += 100) {
+    const batch = ids.slice(i, i + 100);
+    const { data, error } = await sb.from(table).select('*').in('id', batch);
+    if (error) fail(`reading ${table} rows: ${error.message}`);
+    for (const row of (data ?? []) as Record<string, unknown>[]) out.set(String(row.id), row);
+  }
+  return out;
+}
+
+/**
+ * Build the importer's plan — the same call in the dry run and in apply, so the
+ * numbers reviewed are the numbers executed.
+ *
+ * The two extra inputs are what make a transfer handover possible: the
+ * handovers themselves (which leg, which feed row), and the COMPLETE feed rows
+ * they name, because promoting one goes out through the batched whole-row merge.
+ * Reading the accounts whole does the same job for `--rebase-opening-balances`.
+ */
+async function buildImportPlan(
+  seed: LoadedSeed,
+  plan: LivePlan,
+  /**
+   * PREVIEW the plan apply would build AFTER its delete pass.
+   *
+   * The dry run necessarily reads a database that still holds every file row,
+   * so planning against it honestly yields "nothing to insert — it is all
+   * already there". Dropping the provenance the delete is about to remove is
+   * what makes the preview describe the run being previewed. Accounts and
+   * categories are NOT dropped: the delete does not touch them.
+   */
+  simulatePostDelete = false
+): Promise<CloudPlan> {
+  const suppressed = plan.seedOverlap?.suppressedSourceIds ?? new Set<string>();
+  const handovers = plan.seedOverlap?.transferHandovers ?? [];
+  const existing = await fetchExistingImportState(sb, plan.userId);
+  const feedTransactionRowsById = await fetchRowsByIds('transactions', handovers.map(h => h.feedTransactionId));
+  const existingAccountRowsById = await fetchRowsByIds(
+    'accounts', (existing.existingAccounts ?? []).map(a => a.id));
+  return planCloudImport(seed.result, plan.userId, randomUUID, {
+    ...existing,
+    ...(simulatePostDelete
+      ? { existingBySourceId: new Map<string, string>(), existingTransactionLinks: new Map() }
+      : {}),
+    suppressedSourceIds: suppressed,
+    transferHandovers: handovers,
+    feedTransactionRowsById,
+    existingAccountRowsById,
+    rebaseOpeningBalances: REBASE_OPENING_BALANCES,
+  });
+}
+
+/** The plan's opinion of the opening balances, printed identically in both modes. */
+function printOpeningBalances(importPlan: CloudPlan): void {
+  console.log('\nOPENING BALANCES on reused accounts');
+  if (!importPlan.openingBalanceMismatches.length) {
+    console.log('  every reused account\'s initial_balance already agrees with the file.');
+    return;
+  }
+  for (const m of importPlan.openingBalanceMismatches) {
+    console.log(`  ${m.accountName}: stored ${m.storedValue} → file ${m.fileValue}` +
+      (m.rebased ? '   [WILL BE CORRECTED]' : '   [left alone]'));
+  }
+  if (!REBASE_OPENING_BALANCES) {
+    console.log('  These are NOT corrected by default — a reused account may hold a figure the user meant.');
+    console.log('  Re-run with --rebase-opening-balances to make the file authoritative. Until then the');
+    console.log('  apply pass will refuse to report success while any of them disagrees.');
+  }
 }
 
 const stamp = (): string => new Date().toISOString().replace(/[:.]/g, '-');
@@ -548,6 +687,27 @@ async function dryRun(seed: LoadedSeed | null): Promise<void> {
   const plan = await computeLivePlan(seed);
   if (!plan.toDelete.length) { console.log('\nNothing to re-import — no file-import rows found.'); return; }
   const counts = printPlan(plan, seed);
+
+  // Build the REAL import plan, read-only, so the numbers about to be written
+  // into the baseline have already been through the importer once.
+  if (seed) {
+    const importPlan = await buildImportPlan(seed, plan, true);
+    console.log('\nIMPORTER PLAN (built read-only, as apply would build it once the delete has run)');
+    console.log(`  ${importPlan.transactions.length} transactions, ${importPlan.splits.length} split lines, ` +
+      `${importPlan.accounts.length} new accounts, ${importPlan.categories.length} new categories`);
+    console.log(`  ${importPlan.linkRows.length} transfer link rows, ` +
+      `${importPlan.feedPromotionRows.length} bank-feed rows promoted into transfers ` +
+      `(${importPlan.feedPromotions.length} handovers resolved)`);
+    if (importPlan.transactions.length !== counts.importCount) {
+      console.log(`  MISMATCH: the importer plans ${importPlan.transactions.length} inserts, this plan says ` +
+        `${counts.importCount}. Apply would refuse. Investigate before applying.`);
+    }
+    if (importPlan.unpromotableHandovers.length) {
+      console.log(`  ${importPlan.unpromotableHandovers.length} handover(s) could not be resolved to a feed row; ` +
+        'those legs would be imported as ordinary rows.');
+    }
+    printOpeningBalances(importPlan);
+  }
 
   mkdirSync(outResolved, { recursive: true });
   const planFile = join(outResolved, `mny-reimport-plan-${stamp()}.json`);
@@ -561,6 +721,7 @@ async function dryRun(seed: LoadedSeed | null): Promise<void> {
     wouldDeleteSplits: plan.splitsUnderDelete,
     feedOverlapMatches: plan.dbOverlap.matches,
     seedOverlapMatches: plan.seedOverlap?.matches ?? null,
+    seedTransferHandovers: plan.seedOverlap?.transferHandovers ?? null,
     feedRowsKept: plan.feedRows.map(t => t.id),
   }, null, 1));
   console.log(`\nPLAN + BACKUP of every row this plan would delete: ${planFile}`);
@@ -661,6 +822,7 @@ async function apply(seed: LoadedSeed): Promise<void> {
     deleteSplitIds: plan.splitsUnderDelete.map(s => s.id),
     feedTransactionIds: plan.feedRows.map(t => t.id),
     suppressedSourceIds: [...suppressed],
+    transferHandovers: handoverKeys(plan.seedOverlap),
     expectedImportCount: counts.importCount,
     expectedNetCount: counts.netCount,
   };
@@ -736,15 +898,18 @@ async function apply(seed: LoadedSeed): Promise<void> {
 
   // ── 4. Re-import through the real importer ────────────────────────────────
   console.log('\nRE-IMPORTING (planCloudImport + executeCloudPlan — the same path the app uses)');
-  const existing = await fetchExistingImportState(sb, plan.userId);
-  const importPlan = planCloudImport(seed.result, plan.userId, randomUUID, {
-    ...existing,
-    suppressedSourceIds: suppressed,
-  });
+  const importPlan = await buildImportPlan(seed, plan);
   console.log(`  plan: ${importPlan.transactions.length} transactions, ${importPlan.splits.length} split lines, ` +
     `${importPlan.accounts.length} new accounts, ${importPlan.categories.length} new categories`);
   console.log(`  skipped: ${importPlan.skippedFeedOverlap} covered by the feed, ${importPlan.skippedExisting} already present, ` +
     `${importPlan.skippedExistingAccounts} accounts / ${importPlan.skippedExistingCategories} categories reused`);
+  console.log(`  handovers: ${importPlan.feedPromotions.length} feed row(s) become the transfer leg they replace ` +
+    `(${importPlan.feedPromotionRows.length} need writing)`);
+  printOpeningBalances(importPlan);
+  if (importPlan.unpromotableHandovers.length) {
+    fail(`${importPlan.unpromotableHandovers.length} transfer handover(s) name a feed row that could not be read, ` +
+      'so their legs would be imported instead of handed over. The delete has already run; see the state report.');
+  }
   if (importPlan.categoriesWithUnresolvedParent > 0) {
     fail(`${importPlan.categoriesWithUnresolvedParent} categories have no resolvable parent — the seed tree is broken. ` +
       'The delete has already run; see the state report.');
@@ -825,6 +990,43 @@ async function apply(seed: LoadedSeed): Promise<void> {
   for (const t of after) seen.set(signature(t), (seen.get(signature(t)) ?? 0) + 1);
   const dupGroups = [...seen.values()].filter(n => n > 1).length;
   console.log(`  duplicate (account, date, pence, description) groups remaining: ${dupGroups}`);
+
+  // (f) every handed-over feed row really did become the transfer, and its
+  //     counterpart really does point back at it. A handover that half-happened
+  //     is worse than no handover: the payment exists once and links to nothing.
+  const afterById = new Map(after.map(t => [t.id, t]));
+  let promotionsOk = 0;
+  for (const promotion of importPlan.feedPromotions) {
+    const row = afterById.get(promotion.id);
+    if (!row) { failures.push(`promoted feed row ${promotion.id} is not in the database`); continue; }
+    if (row.external_transaction_id == null) {
+      failures.push(`promoted row ${promotion.id} lost its bank-feed id`);
+    }
+    if (row.type !== 'transfer') {
+      failures.push(`promoted row ${promotion.id} is typed '${row.type}', not 'transfer'`);
+    }
+    if ((row.linked_transfer_id ?? null) !== promotion.linked_transfer_id) {
+      failures.push(`promoted row ${promotion.id} is not linked to the counterpart the plan named`);
+      continue;
+    }
+    if (promotion.linked_transfer_id) {
+      const counterpart = afterById.get(promotion.linked_transfer_id);
+      if (!counterpart) failures.push(`the counterpart of promoted row ${promotion.id} is missing`);
+      else if (counterpart.linked_transfer_id !== promotion.id) {
+        failures.push(`the counterpart of promoted row ${promotion.id} points somewhere else`);
+      }
+    }
+    promotionsOk++;
+  }
+  console.log(`  transfer handovers: ${promotionsOk}/${importPlan.feedPromotions.length} feed rows are the ` +
+    'transfer leg they replaced, linked both ways');
+
+  // (g) a fabricated opening balance must not survive a "successful" re-import.
+  const unfixedOpeningBalances = importPlan.openingBalanceMismatches.filter(m => !m.rebased);
+  if (unfixedOpeningBalances.length) {
+    failures.push(`${unfixedOpeningBalances.length} reused account(s) still hold an initial_balance the file ` +
+      'disagrees with — re-run with --rebase-opening-balances, or correct them by hand');
+  }
 
   progress.verified = failures.length === 0;
 

--- a/scripts/periodTotals.mts
+++ b/scripts/periodTotals.mts
@@ -1,0 +1,171 @@
+/**
+ * What does the app report for a period, straight from the database?
+ *
+ * A cross-check for the question "the app says X and my old software says Y" —
+ * the one that found the MS Money import's duplicate rows. It answers with the
+ * SAME classifier the UI uses (`computeIncomeExpense`), imported directly: a
+ * second implementation of the rules in SQL that agreed would prove nothing,
+ * and one that disagreed would not say which of the two was wrong.
+ *
+ * READ-ONLY. It issues nothing but SELECTs, and pages every one of them —
+ * PostgREST caps a request at 1000 rows and returns the truncation silently,
+ * which is exactly how a balance was once reported £67k adrift.
+ *
+ * Prints totals and per-group subtotals. Never a payee, never an account name.
+ *
+ * Usage:
+ *   npx tsx scripts/periodTotals.mts --from 2026-05-01 --to 2026-05-31
+ *   npx tsx scripts/periodTotals.mts --from 2026-01-01 --to 2026-12-31 --env .env.scratch
+ */
+import { readFileSync, existsSync } from 'node:fs';
+import { createClient } from '@supabase/supabase-js';
+import { computeIncomeExpense } from '../src/utils/incomeExpense.ts';
+import type { Category, Transaction, TransactionSplit } from '../src/types';
+
+const args = process.argv.slice(2);
+const flag = (name: string): string | undefined => {
+  const i = args.indexOf(`--${name}`);
+  return i >= 0 ? args[i + 1] : undefined;
+};
+
+const FROM = flag('from');
+const TO = flag('to');
+const envPath = flag('env') ?? '.env.local';
+const userOverride = flag('user');
+
+const fail = (msg: string): never => { console.error(`ABORT: ${msg}`); process.exit(1); };
+
+const ISO_DAY = /^\d{4}-\d{2}-\d{2}$/;
+if (!FROM || !TO) fail('usage: tsx scripts/periodTotals.mts --from YYYY-MM-DD --to YYYY-MM-DD [--env .env.local] [--user <uuid>]');
+if (!ISO_DAY.test(FROM) || !ISO_DAY.test(TO)) fail('--from and --to must be YYYY-MM-DD');
+if (FROM > TO) fail(`--from (${FROM}) is after --to (${TO})`);
+if (!existsSync(envPath)) fail(`env file not found: ${envPath}`);
+
+const env = Object.fromEntries(readFileSync(envPath, 'utf8').split('\n')
+  .filter(l => l.includes('=') && !l.trim().startsWith('#'))
+  .map(l => [l.slice(0, l.indexOf('=')).trim(), l.slice(l.indexOf('=') + 1).trim()]));
+const url = env.VITE_SUPABASE_URL;
+const serviceKey = env.SUPABASE_SERVICE_ROLE_KEY;
+if (!url || !serviceKey) fail(`Missing VITE_SUPABASE_URL / SUPABASE_SERVICE_ROLE_KEY in ${envPath}`);
+const sb = createClient(url, serviceKey, { auth: { persistSession: false } });
+
+interface DbCategory {
+  id: string; name: string; type: string | null; parent_id: string | null;
+  level: string | null; is_transfer_category: boolean | null;
+}
+interface DbTransaction {
+  id: string; date: string; description: string | null; account_id: string;
+  amount: string | number; type: string; category: string | null; is_split: boolean | null;
+}
+interface DbSplit { id: string; transaction_id: string; amount: string | number; category: string | null; memo: string | null }
+
+/** Resolve the user whose data this is, refusing to guess between several. */
+async function resolveUser(): Promise<string> {
+  if (userOverride) return userOverride;
+  const { data, error } = await sb.from('users').select('id').limit(5).returns<Array<{ id: string }>>();
+  if (error) fail(`reading users: ${error.message}`);
+  const users = data ?? [];
+  if (users.length === 1) return users[0].id;
+  fail(`${users.length} users in this database — say which with --user <uuid>`);
+}
+
+const USER = await resolveUser();
+
+/** Every SELECT here is paged: a silent 1000-row truncation is a wrong answer. */
+async function page<T>(table: string, cols: string, narrow?: (from: number) => PromiseLike<{ data: T[] | null; error: { message: string } | null }>): Promise<T[]> {
+  const PAGE = 1000;
+  const rows: T[] = [];
+  for (let from = 0; ; from += PAGE) {
+    const query = narrow
+      ? narrow(from)
+      : sb.from(table).select(cols).eq('user_id', USER).order('id').range(from, from + PAGE - 1).returns<T[]>();
+    const { data, error } = await query;
+    if (error) fail(`reading ${table}: ${error.message}`);
+    const got: T[] = data ?? [];
+    rows.push(...got);
+    if (got.length < PAGE) return rows;
+  }
+}
+
+const PAGE = 1000;
+const cats = await page<DbCategory>('categories', 'id,name,type,parent_id,level,is_transfer_category');
+const txns = await page<DbTransaction>('transactions', '', from => sb
+  .from('transactions')
+  .select('id,date,description,account_id,amount,type,category,is_split')
+  .eq('user_id', USER).gte('date', FROM).lte('date', TO)
+  .order('id').range(from, from + PAGE - 1).returns<DbTransaction[]>());
+const txnIds = new Set(txns.map(t => t.id));
+const splits = (await page<DbSplit>('transaction_splits', 'id,transaction_id,amount,category,memo'))
+  .filter(s => txnIds.has(s.transaction_id));
+
+const categories: Category[] = cats.map(c => ({
+  id: c.id,
+  name: c.name,
+  type: (c.type === 'income' || c.type === 'expense' || c.type === 'both') ? c.type : 'both',
+  level: (c.level === 'type' || c.level === 'sub' || c.level === 'detail') ? c.level : 'detail',
+  parentId: c.parent_id ?? undefined,
+  isTransferCategory: c.is_transfer_category ?? undefined,
+}));
+const transactions: Transaction[] = txns.map(t => ({
+  id: t.id,
+  date: new Date(`${t.date.slice(0, 10)}T00:00:00.000Z`),
+  description: t.description ?? '',
+  accountId: t.account_id,
+  amount: Number(t.amount),
+  type: t.type === 'income' || t.type === 'transfer' ? t.type : 'expense',
+  category: t.category ?? '',
+  cleared: false,
+  isSplit: t.is_split === true,
+}));
+const transactionSplits: TransactionSplit[] = splits.map(s => ({
+  id: s.id,
+  transactionId: s.transaction_id,
+  amount: Number(s.amount),
+  category: s.category ?? '',
+  description: s.memo ?? undefined,
+}));
+
+const result = computeIncomeExpense(transactions, transactionSplits, categories);
+const gbp = (value: number): string =>
+  `£${value.toLocaleString('en-GB', { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`;
+
+console.log(`Period ${FROM} … ${TO}`);
+console.log(`${transactions.length} transactions, ${transactionSplits.length} split lines\n`);
+console.log(`  Total income          : ${gbp(result.income.toNumber())}  (${result.incomeRows.length} rows)`);
+console.log(`  Total expenses        : ${gbp(result.expenses.toNumber())}  (${result.expenseRows.length} rows)`);
+console.log(`  Income less expenses  : ${gbp(result.income.minus(result.expenses).toNumber())}`);
+console.log(`\n  EXCLUDED, no category : ${result.uncategorizedRows.length} rows ` +
+  `(in ${gbp(result.uncategorizedIn.toNumber())}, out ${gbp(result.uncategorizedOut.toNumber())})`);
+
+const byId = new Map(categories.map(c => [c.id, c]));
+/** The nearest 'sub'-level ancestor — the level Money's reports subtotal at. */
+const groupOf = (id: string): string => {
+  const seen = new Set<string>();
+  let current = byId.get(id);
+  let fallback = current?.name ?? '(no category)';
+  while (current && !seen.has(current.id)) {
+    if (current.level === 'sub') return current.name;
+    seen.add(current.id);
+    fallback = current.name;
+    const parent = current.parentId ? byId.get(current.parentId) : undefined;
+    if (!parent || parent.level === 'type') break;
+    current = parent;
+  }
+  return fallback;
+};
+
+for (const [label, rows, sign] of [
+  ['EXPENSES BY GROUP', result.expenseRows, -1],
+  ['INCOME BY GROUP', result.incomeRows, 1],
+] as const) {
+  if (!rows.length) continue;
+  const totals = new Map<string, number>();
+  for (const row of rows) {
+    const group = groupOf(row.category);
+    totals.set(group, (totals.get(group) ?? 0) + row.amount * sign);
+  }
+  console.log(`\n${label}`);
+  for (const [group, value] of [...totals.entries()].sort((a, b) => b[1] - a[1] || a[0].localeCompare(b[0]))) {
+    console.log(`  ${gbp(value).padStart(13)}  ${group}`);
+  }
+}

--- a/scripts/repair-balance-drift.mjs
+++ b/scripts/repair-balance-drift.mjs
@@ -17,9 +17,27 @@
  *       discrepancy into the opening balance. Right for rows seeded with a
  *       balance but no initial_balance.
  *
+ * ── Why trust-balance is now guarded ────────────────────────────────────────
+ * On an account holding imported Microsoft Money history, trust-balance is
+ * almost always the WRONG answer, and it has been the wrong answer twice.
+ * The transactions there are a reconstructed ledger from the file: when the
+ * stored balance disagrees with them the discrepancy is a fact about the
+ * IMPORT — a double-counted overlap with a bank feed, a missed row — and
+ * absorbing it into `initial_balance` does not fix it, it HIDES it. The
+ * invariant then holds, the audit goes quiet, and the account's opening
+ * balance is a fabricated number nobody can explain. Every subsequent
+ * re-import preserves it, because the importer reuses an existing account
+ * rather than rewriting it.
+ *
+ * So trust-balance refuses an account with `import_source = 'ms-money'` rows
+ * unless a SECOND explicit flag is given, and every repair prints the size of
+ * the rebase before it is written.
+ *
  * Usage:
  *   node scripts/repair-balance-drift.mjs --strategy=trust-ledger          # dry run
  *   node scripts/repair-balance-drift.mjs --strategy=trust-ledger --apply  # write
+ *   node scripts/repair-balance-drift.mjs --strategy=trust-balance \
+ *     --i-know-this-hides-an-import-discrepancy   # required on imported accounts
  */
 
 import { createClient } from '@supabase/supabase-js';
@@ -58,6 +76,11 @@ if (strategy !== 'trust-ledger' && strategy !== 'trust-balance') {
 // different strategies — e.g. a missing opening balance vs a corrupted total).
 const accountArg = args.find((a) => a.startsWith('--account='));
 const onlyAccountId = accountArg?.split('=')[1] ?? null;
+// The second flag trust-balance needs before it will touch an account holding
+// imported Money history. Named for what it actually does, not for what the
+// operator hopes it does.
+const OVERRIDE_IMPORTED = args.includes('--i-know-this-hides-an-import-discrepancy');
+const MS_MONEY_IMPORT_SOURCE = 'ms-money';
 
 const supabase = createClient(url, key, { auth: { persistSession: false } });
 const d = (v) => new Decimal(v ?? 0);
@@ -82,14 +105,24 @@ const main = async () => {
   console.log(`Target: ${url}\n`);
 
   const accounts = await fetchAll('accounts', 'id, name, balance, initial_balance');
-  const transactions = await fetchAll('transactions', 'account_id, amount');
+  // `import_source` only exists once migration 20260722170000 is applied. Where
+  // it does not, no row can be an import row and the guard simply never fires.
+  const transactions = await fetchAll('transactions', 'account_id, amount, import_source')
+    .catch(() => fetchAll('transactions', 'account_id, amount'));
 
   const sums = new Map();
+  // Which accounts hold imported Money history? Counted, not just flagged, so
+  // the refusal below can say how much of the account it is talking about.
+  const importedRows = new Map();
   for (const t of transactions) {
     sums.set(t.account_id, (sums.get(t.account_id) ?? d(0)).plus(d(t.amount)));
+    if (t.import_source === MS_MONEY_IMPORT_SOURCE) {
+      importedRows.set(t.account_id, (importedRows.get(t.account_id) ?? 0) + 1);
+    }
   }
 
   let repaired = 0;
+  let refused = 0;
   for (const a of accounts) {
     if (onlyAccountId && a.id !== onlyAccountId) continue;
     const txnSum = sums.get(a.id) ?? d(0);
@@ -101,11 +134,30 @@ const main = async () => {
       ? { balance: expected.toNumber() }
       : { initial_balance: stored.minus(txnSum).toNumber() };
 
+    // How big is this rebase? Printed for BOTH strategies, always, because the
+    // number is the whole argument: a £26,727 "repair" is not a rounding fix,
+    // it is a discrepancy being moved somewhere nobody will look at it again.
+    const drift = stored.minus(expected);
     console.log(
       `${a.name.padEnd(32)} ${strategy === 'trust-ledger'
         ? `balance ${stored.toFixed(2)} → ${expected.toFixed(2)}`
-        : `initial ${d(a.initial_balance).toFixed(2)} → ${stored.minus(txnSum).toFixed(2)}`}`
+        : `initial ${d(a.initial_balance).toFixed(2)} → ${stored.minus(txnSum).toFixed(2)}`}` +
+      `   (moves ${drift.abs().toFixed(2)})`
     );
+
+    const imported = importedRows.get(a.id) ?? 0;
+    if (strategy === 'trust-balance' && imported > 0 && !OVERRIDE_IMPORTED) {
+      console.log(
+        `  REFUSED: ${imported} transaction(s) here came from the Microsoft Money import, so the\n` +
+        `  ledger is a reconstruction and this ${drift.abs().toFixed(2)} discrepancy is a fact about the\n` +
+        '  import — absorbing it into initial_balance hides it rather than fixing it.\n' +
+        '  Fix the import (scripts/mnyReimportPlan.mts), or use --strategy=trust-ledger.\n' +
+        '  If you have genuinely decided the stored balance is right, re-run with\n' +
+        '  --i-know-this-hides-an-import-discrepancy.'
+      );
+      refused += 1;
+      continue;
+    }
 
     if (apply) {
       const { error } = await supabase
@@ -121,6 +173,9 @@ const main = async () => {
   }
 
   console.log(`\n${apply ? 'Repaired' : 'Would repair'}: ${repaired} account(s)`);
+  if (refused > 0) {
+    console.log(`Refused: ${refused} account(s) holding imported Money history (see above).`);
+  }
   if (!apply && repaired > 0) {
     console.log('Re-run with --apply to write the corrections.');
   }

--- a/scripts/reviewBand.mts
+++ b/scripts/reviewBand.mts
@@ -1,0 +1,317 @@
+/**
+ * What is actually IN the uncategorised review band?
+ *
+ * Rows with no category are excluded from every report by design (direction is
+ * never guessed). That is the right rule and it leaves a question: what is
+ * sitting in there, and which of it is a report bug rather than data the user
+ * genuinely has to file?
+ *
+ * This classifies the band by evidence rather than by guessing:
+ *   - is the row half of a transfer that simply is not tagged as one? (a
+ *     matching opposite amount, same day or near it, in another account)
+ *   - does the same payee appear elsewhere WITH a category, so the answer is
+ *     already in the data?
+ *   - is it a bank-feed row the Money file never had?
+ *   - or is it genuinely novel — a payee seen nowhere else?
+ *
+ * READ-ONLY. Every read is paged. Prints counts, amounts and payee shapes;
+ * payee text is truncated and only shown for the largest groups, because this
+ * output is read in a chat transcript.
+ *
+ * Usage:
+ *   npx tsx scripts/reviewBand.mts --user <uuid> [--from 2025-07-01] [--to 2026-06-30]
+ */
+import { readFileSync, existsSync } from 'node:fs';
+import { createClient } from '@supabase/supabase-js';
+import { buildCategoryKindLookup, classifyFlow } from '../src/utils/incomeExpense.ts';
+import { toDecimal } from '../src/utils/decimal.ts';
+import type { Category } from '../src/types';
+
+const args = process.argv.slice(2);
+const flag = (name: string): string | undefined => {
+  const i = args.indexOf(`--${name}`);
+  return i >= 0 ? args[i + 1] : undefined;
+};
+const envPath = flag('env') ?? '.env.local';
+const FROM = flag('from');
+const TO = flag('to');
+const userOverride = flag('user');
+/** Days either side within which an opposite amount counts as the other leg. */
+const PAIR_WINDOW_DAYS = Number(flag('window') ?? 3);
+
+const fail = (msg: string): never => { console.error(`ABORT: ${msg}`); process.exit(1); };
+if (!existsSync(envPath)) fail(`env file not found: ${envPath}`);
+
+const env = Object.fromEntries(readFileSync(envPath, 'utf8').split('\n')
+  .filter(l => l.includes('=') && !l.trim().startsWith('#'))
+  .map(l => [l.slice(0, l.indexOf('=')).trim(), l.slice(l.indexOf('=') + 1).trim()]));
+const url = env.VITE_SUPABASE_URL;
+const serviceKey = env.SUPABASE_SERVICE_ROLE_KEY;
+if (!url || !serviceKey) fail(`Missing VITE_SUPABASE_URL / SUPABASE_SERVICE_ROLE_KEY in ${envPath}`);
+const sb = createClient(url, serviceKey, { auth: { persistSession: false } });
+
+interface DbCategory {
+  id: string; name: string; type: string | null; parent_id: string | null;
+  level: string | null; is_transfer_category: boolean | null;
+}
+interface DbTransaction {
+  id: string; date: string; description: string | null; account_id: string;
+  amount: string | number; type: string; category: string | null;
+  external_transaction_id: string | null;
+}
+interface DbAccount { id: string; name: string }
+
+async function resolveUser(): Promise<string> {
+  if (userOverride) return userOverride;
+  const { data, error } = await sb.from('users').select('id').limit(5).returns<Array<{ id: string }>>();
+  if (error) fail(`reading users: ${error.message}`);
+  const users = data ?? [];
+  if (users.length === 1) return users[0].id;
+  return fail(`${users.length} users in this database — say which with --user <uuid>`);
+}
+const USER = await resolveUser();
+
+const PAGE = 1000;
+/** Paged, always: PostgREST truncates at 1000 rows without saying so. */
+async function pageAll<T>(build: (from: number) => PromiseLike<{ data: T[] | null; error: { message: string } | null }>): Promise<T[]> {
+  const rows: T[] = [];
+  for (let from = 0; ; from += PAGE) {
+    const { data, error } = await build(from);
+    if (error) fail(error.message);
+    const got: T[] = data ?? [];
+    rows.push(...got);
+    if (got.length < PAGE) return rows;
+  }
+}
+
+const cats = await pageAll<DbCategory>(from => sb.from('categories')
+  .select('id,name,type,parent_id,level,is_transfer_category')
+  .eq('user_id', USER).order('id').range(from, from + PAGE - 1).returns<DbCategory[]>());
+const accounts = await pageAll<DbAccount>(from => sb.from('accounts')
+  .select('id,name').eq('user_id', USER).order('id').range(from, from + PAGE - 1).returns<DbAccount[]>());
+const txns = await pageAll<DbTransaction>(from => {
+  let q = sb.from('transactions')
+    .select('id,date,description,account_id,amount,type,category,external_transaction_id')
+    .eq('user_id', USER);
+  if (FROM) q = q.gte('date', FROM);
+  if (TO) q = q.lte('date', TO);
+  return q.order('id').range(from, from + PAGE - 1).returns<DbTransaction[]>();
+});
+
+const categories: Category[] = cats.map(c => ({
+  id: c.id,
+  name: c.name,
+  type: (c.type === 'income' || c.type === 'expense' || c.type === 'both') ? c.type : 'both',
+  level: (c.level === 'type' || c.level === 'sub' || c.level === 'detail') ? c.level : 'detail',
+  parentId: c.parent_id ?? undefined,
+  isTransferCategory: c.is_transfer_category ?? undefined,
+}));
+const kinds = buildCategoryKindLookup(categories);
+const accountName = new Map(accounts.map(a => [a.id, a.name]));
+
+const pence = (v: string | number): number => Math.round(Number(toDecimal(String(v)).times(100)));
+const gbp = (p: number): string =>
+  `£${(p / 100).toLocaleString('en-GB', { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`;
+const day = (d: string): string => d.slice(0, 10);
+const dayNumber = (d: string): number => Math.floor(Date.parse(`${day(d)}T00:00:00.000Z`) / 86_400_000);
+
+/** Normalise a payee enough to recognise the same one twice. */
+const payeeKey = (description: string | null): string =>
+  (description ?? '')
+    .toUpperCase()
+    .replace(/\d{4,}/g, ' ')          // card/reference numbers
+    .replace(/[^A-Z& ]+/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+
+const band = txns.filter(t => classifyFlow(
+  { type: t.type === 'income' || t.type === 'transfer' ? t.type : 'expense', category: t.category ?? '' },
+  kinds
+) === 'uncategorized');
+
+console.log(`Scope: ${FROM ?? 'all time'} … ${TO ?? 'all time'}`);
+console.log(`${txns.length} transactions, of which ${band.length} are in the review band ` +
+  `(${((band.length / Math.max(txns.length, 1)) * 100).toFixed(1)}%)\n`);
+
+// ── 1. Unlabelled transfers: an opposite amount in another account, near in time
+const byAmount = new Map<number, DbTransaction[]>();
+for (const t of txns) {
+  const key = Math.abs(pence(t.amount));
+  const g = byAmount.get(key);
+  if (g) g.push(t); else byAmount.set(key, [t]);
+}
+
+const pairedIds = new Set<string>();
+let pairedBothInBand = 0;
+let pairedOtherSideFiled = 0;
+for (const row of band) {
+  const amount = pence(row.amount);
+  if (amount === 0) continue;
+  const candidates = byAmount.get(Math.abs(amount)) ?? [];
+  const match = candidates.find(other =>
+    other.id !== row.id &&
+    other.account_id !== row.account_id &&
+    pence(other.amount) === -amount &&
+    Math.abs(dayNumber(other.date) - dayNumber(row.date)) <= PAIR_WINDOW_DAYS &&
+    !pairedIds.has(other.id)
+  );
+  if (!match) continue;
+  pairedIds.add(row.id);
+  pairedIds.add(match.id);
+  const otherInBand = classifyFlow(
+    { type: match.type === 'income' || match.type === 'transfer' ? match.type : 'expense', category: match.category ?? '' },
+    kinds
+  ) === 'uncategorized';
+  if (otherInBand) pairedBothInBand++; else pairedOtherSideFiled++;
+}
+
+const unpaired = band.filter(t => !pairedIds.has(t.id));
+const sumAbs = (rows: DbTransaction[]): number => rows.reduce((s, r) => s + Math.abs(pence(r.amount)), 0);
+
+console.log('1. LOOKS LIKE AN UNTAGGED TRANSFER');
+console.log(`   an equal and opposite amount sits in another account within ±${PAIR_WINDOW_DAYS} days`);
+console.log(`   band rows paired          : ${band.length - unpaired.length}  (${gbp(sumAbs(band.filter(t => pairedIds.has(t.id))))} gross)`);
+console.log(`     …both legs uncategorised: ${pairedBothInBand}`);
+console.log(`     …other leg already filed: ${pairedOtherSideFiled}`);
+
+// ── 2. Of the rest, is the payee already filed elsewhere?
+const filedByPayee = new Map<string, Map<string, number>>();
+for (const t of txns) {
+  if (!t.category) continue;
+  const kind = classifyFlow(
+    { type: t.type === 'income' || t.type === 'transfer' ? t.type : 'expense', category: t.category },
+    kinds
+  );
+  if (kind === 'uncategorized') continue;
+  const key = payeeKey(t.description);
+  if (!key) continue;
+  const counts = filedByPayee.get(key) ?? new Map<string, number>();
+  counts.set(t.category, (counts.get(t.category) ?? 0) + 1);
+  filedByPayee.set(key, counts);
+}
+
+const answerable = unpaired.filter(t => filedByPayee.has(payeeKey(t.description)));
+const novel = unpaired.filter(t => !filedByPayee.has(payeeKey(t.description)));
+
+console.log('\n2. THE ANSWER IS ALREADY IN THE DATA');
+console.log('   the same payee appears elsewhere WITH a category');
+console.log(`   band rows                 : ${answerable.length}  (${gbp(sumAbs(answerable))} gross)`);
+
+console.log('\n3. GENUINELY NEW — payee seen nowhere else, or no description at all');
+console.log(`   band rows                 : ${novel.length}  (${gbp(sumAbs(novel))} gross)`);
+const blank = novel.filter(t => !payeeKey(t.description));
+console.log(`     …of which no description: ${blank.length}`);
+
+// ── Provenance and shape of what remains
+const feedRows = unpaired.filter(t => t.external_transaction_id != null);
+console.log('\nPROVENANCE OF THE UNPAIRED REMAINDER');
+console.log(`   from the bank feed        : ${feedRows.length}`);
+console.log(`   from the Money file       : ${unpaired.length - feedRows.length}`);
+
+console.log('\nWHERE THE UNPAIRED ROWS SIT');
+const byAccount = new Map<string, { n: number; gross: number }>();
+for (const t of unpaired) {
+  const e = byAccount.get(t.account_id) ?? { n: 0, gross: 0 };
+  e.n++; e.gross += Math.abs(pence(t.amount));
+  byAccount.set(t.account_id, e);
+}
+for (const [id, e] of [...byAccount.entries()].sort((a, b) => b[1].gross - a[1].gross).slice(0, 12)) {
+  console.log(`   ${String(e.n).padStart(5)} rows  ${gbp(e.gross).padStart(15)}  ${accountName.get(id) ?? id}`);
+}
+
+// ── How much of "answerable" is safely answerable?
+//
+// A payee only predicts a category if it AGREES with itself. "BOOTS" filed
+// under Food Shopping 125 times out of 130 predicts; "ADJUSTMENT" filed under
+// ten different things predicts nothing, and auto-filing it would invent data
+// rather than recover it. The threshold is what separates a suggestion worth
+// applying from one worth showing.
+const MIN_SAMPLES = 3;
+const MIN_AGREEMENT = 0.8;
+interface Verdict { confident: boolean; category: string; agreement: number; samples: number }
+const verdictFor = (description: string | null): Verdict | null => {
+  const counts = filedByPayee.get(payeeKey(description));
+  if (!counts) return null;
+  const entries = [...counts.entries()].sort((a, b) => b[1] - a[1]);
+  const samples = entries.reduce((s, [, n]) => s + n, 0);
+  const [category, top] = entries[0];
+  const agreement = top / samples;
+  return { confident: samples >= MIN_SAMPLES && agreement >= MIN_AGREEMENT, category, agreement, samples };
+};
+
+const confident = answerable.filter(t => verdictFor(t.description)?.confident === true);
+const unsure = answerable.filter(t => verdictFor(t.description)?.confident === false);
+
+console.log('\n2a. …AND HOW MUCH OF THAT IS SAFE TO ACT ON');
+console.log(`   the payee agrees with itself (≥${MIN_SAMPLES} filings, ≥${MIN_AGREEMENT * 100}% one category)`);
+console.log(`   confident                 : ${confident.length}  (${gbp(sumAbs(confident))} gross)`);
+console.log(`   payee filed inconsistently: ${unsure.length}  (${gbp(sumAbs(unsure))} gross)` +
+  ' — a suggestion here would invent data, not recover it');
+
+// ── What payee memory itself would do, by its own rule
+//
+// The analysis above normalises payee text and looks across accounts, which is
+// looser than the shipped `payee_memory_category`: that matches the EXACT
+// description within ONE account for the same direction, and returns the most
+// common category with no minimum sample count and no agreement threshold.
+// Measuring the shipped rule directly is the difference between a real risk and
+// an exaggerated one.
+interface Memory { category: string; top: number; samples: number }
+const exactMemory = new Map<string, Memory>();
+{
+  const tally = new Map<string, Map<string, number>>();
+  for (const t of txns) {
+    if (!t.category || t.type === 'transfer') continue;
+    if (t.category === 'transfer-in' || t.category === 'transfer-out') continue;
+    const key = `${t.account_id}|${(t.description ?? '').trim().toUpperCase()}|${t.type}`;
+    const counts = tally.get(key) ?? new Map<string, number>();
+    counts.set(t.category, (counts.get(t.category) ?? 0) + 1);
+    tally.set(key, counts);
+  }
+  for (const [key, counts] of tally) {
+    const entries = [...counts.entries()].sort((a, b) => b[1] - a[1]);
+    exactMemory.set(key, {
+      category: entries[0][0],
+      top: entries[0][1],
+      samples: entries.reduce((s, [, n]) => s + n, 0),
+    });
+  }
+}
+
+let wouldPrefill = 0;
+let prefillThin = 0;      // decided by a single prior filing
+let prefillContested = 0; // the payee has been filed more than one way
+let prefillGross = 0;
+let contestedGross = 0;
+for (const row of band) {
+  if (row.type === 'transfer') continue;
+  const hit = exactMemory.get(`${row.account_id}|${(row.description ?? '').trim().toUpperCase()}|${row.type}`);
+  if (!hit) continue;
+  wouldPrefill++;
+  prefillGross += Math.abs(pence(row.amount));
+  if (hit.samples === 1) prefillThin++;
+  if (hit.top < hit.samples) { prefillContested++; contestedGross += Math.abs(pence(row.amount)); }
+}
+
+console.log('\n4. WHAT THE SHIPPED PAYEE MEMORY WOULD DO');
+console.log('   exact description, same account, same direction — its own rule');
+console.log(`   band rows it would prefill: ${wouldPrefill}  (${gbp(prefillGross)} gross)`);
+console.log(`     …on a single prior filing: ${prefillThin}`);
+console.log(`     …payee filed >1 way      : ${prefillContested}  (${gbp(contestedGross)} gross)` +
+  ' — the most common wins with no threshold');
+
+console.log('\nTHE BIGGEST ANSWERABLE PAYEES (already filed elsewhere)');
+const answerableByPayee = new Map<string, { n: number; gross: number }>();
+for (const t of answerable) {
+  const key = payeeKey(t.description);
+  const e = answerableByPayee.get(key) ?? { n: 0, gross: 0 };
+  e.n++; e.gross += Math.abs(pence(t.amount));
+  answerableByPayee.set(key, e);
+}
+for (const [key, e] of [...answerableByPayee.entries()].sort((a, b) => b[1].n - a[1].n).slice(0, 15)) {
+  const counts = filedByPayee.get(key);
+  const top = counts ? [...counts.entries()].sort((a, b) => b[1] - a[1])[0] : undefined;
+  const catName = top ? (cats.find(c => c.id === top[0])?.name ?? '?') : '?';
+  const agreement = top && counts ? `${top[1]}/${[...counts.values()].reduce((s, n) => s + n, 0)}` : '';
+  console.log(`   ${String(e.n).padStart(4)} rows  ${gbp(e.gross).padStart(13)}  ${key.slice(0, 28).padEnd(28)} → ${catName} (${agreement})`);
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -233,6 +233,13 @@ function App(): React.JSX.Element {
                               <ReportsHub />
                             </ProtectedSuspense>
                           } />
+                          {/* Each report in the gallery has its own URL, so it
+                              can be bookmarked and pinned to the Dashboard. */}
+                          <Route path="reports/:reportId" element={
+                            <ProtectedSuspense>
+                              <ReportsHub />
+                            </ProtectedSuspense>
+                          } />
                           <Route path="goals" element={
                             <ProtectedSuspense>
                               <Goals />

--- a/src/components/BulkCategorizeModal.tsx
+++ b/src/components/BulkCategorizeModal.tsx
@@ -58,9 +58,32 @@ export default function BulkCategorizeModal({ isOpen, onClose }: Props): React.J
 
   const keyOf = (g: PayeeGroup): string => `${g.payee}|${g.direction}`;
 
+  /**
+   * A suggestion is only pre-filled when the payee AGREES with itself.
+   *
+   * This screen applies a category to every row in a group at once, so a
+   * pre-filled choice is one the user can accept without ever having examined
+   * it. That is safe for a shop filed the same way 125 times out of 130, and
+   * unsafe for a generic description — "ACCOUNT ADJUSTMENT", "UPDATE ON
+   * PORTFOLIO VALUE" — filed a dozen different ways, where the most common
+   * category is a plurality of a quarter and the rows behind it are portfolio
+   * revaluations worth more than a year of real spending.
+   *
+   * Below the threshold the group still appears, still shows what the payee
+   * has been filed as, and simply starts empty: it asks rather than assumes.
+   */
+  const SUGGESTION_MIN_AGREEMENT = 0.8;
+  const suggestionIsTrustworthy = (g: PayeeGroup): boolean => {
+    if (g.suggestedCategoryId === undefined) return false;
+    const support = g.suggestionSupport ?? 0;
+    const sample = g.suggestionSampleSize ?? support;
+    if (sample <= 0) return false;
+    return support / sample >= SUGGESTION_MIN_AGREEMENT;
+  };
+
   // Pre-fill from the payee's own history; the user can change any of them.
   const effectiveChoice = (g: PayeeGroup): string =>
-    choices[keyOf(g)] ?? g.suggestedCategoryId ?? '';
+    choices[keyOf(g)] ?? (suggestionIsTrustworthy(g) ? (g.suggestedCategoryId ?? '') : '');
 
   const setChoice = (g: PayeeGroup, categoryId: string): void => {
     setChoices(prev => ({ ...prev, [keyOf(g)]: categoryId }));
@@ -156,8 +179,17 @@ export default function BulkCategorizeModal({ isOpen, onClose }: Props): React.J
                             {group.accountIds.length === 1
                               ? ` · ${accountName(group.accountIds[0])}`
                               : ` · ${group.accountIds.length} accounts`}
+                            {/* "9" reads the same out of 10 filings as out of
+                                36, so the sample size is shown beside it and
+                                a payee that disagrees with itself says so. */}
                             {group.suggestedCategoryId && (
-                              <> · usually {categoryName(group.suggestedCategoryId)} ({group.suggestionSupport})</>
+                              suggestionIsTrustworthy(group) ? (
+                                <> · usually {categoryName(group.suggestedCategoryId)}{' '}
+                                  ({group.suggestionSupport} of {group.suggestionSampleSize ?? group.suggestionSupport})</>
+                              ) : (
+                                <> · filed inconsistently — {categoryName(group.suggestedCategoryId)}{' '}
+                                  only {group.suggestionSupport} of {group.suggestionSampleSize ?? group.suggestionSupport} times</>
+                              )
                             )}
                           </span>
                           {/* A deliberate recent change stays one click away

--- a/src/components/IncomeExpenseBreakdownModal.tsx
+++ b/src/components/IncomeExpenseBreakdownModal.tsx
@@ -2,6 +2,7 @@ import React, { useMemo, useState } from 'react';
 import { Modal, ModalBody } from './common/Modal';
 import { useCurrencyDecimal } from '../hooks/useCurrencyDecimal';
 import { bucketContribution } from '../utils/incomeExpense';
+import { buildCategoryNameLookup } from '../utils/categoryNames';
 import { toDecimal } from '../utils/decimal';
 import type { Category } from '../types';
 import type { SplitExpandedTransaction } from '../utils/transactionSplits';
@@ -49,16 +50,8 @@ export default function IncomeExpenseBreakdownModal({
   const [sortKey, setSortKey] = useState<SortKey>('category');
   const [sortDir, setSortDir] = useState<1 | -1>(1);
 
-  const categoryName = useMemo(() => {
-    const byId = new Map(categories.map(c => [c.id, c]));
-    return (id: string | undefined): string => {
-      if (!id) return 'Uncategorised';
-      const c = byId.get(id);
-      if (!c) return 'Uncategorised';
-      const parent = c.parentId ? byId.get(c.parentId) : undefined;
-      return parent && parent.level !== 'type' ? `${parent.name} : ${c.name}` : c.name;
-    };
-  }, [categories]);
+  // One shared definition of a category's display name (utils/categoryNames).
+  const categoryName = useMemo(() => buildCategoryNameLookup(categories), [categories]);
 
   const valueOf = (t: SplitExpandedTransaction): number =>
     bucket === 'uncategorized' ? t.amount : bucketContribution(t, bucket);

--- a/src/components/IncomeExpenseBreakdownModal.tsx
+++ b/src/components/IncomeExpenseBreakdownModal.tsx
@@ -17,7 +17,13 @@ import type { SplitExpandedTransaction } from '../utils/transactionSplits';
  * display negative so the list visibly sums to its total.
  */
 
-export type BreakdownBucket = 'income' | 'expense' | 'uncategorized';
+/**
+ * 'neutral' is the account view: rows keep their own signed amount (money in
+ * positive, money out negative) and the total is the net movement — used when
+ * the drill-in is "this account, this period" rather than one side of the
+ * income/expense report.
+ */
+export type BreakdownBucket = 'income' | 'expense' | 'uncategorized' | 'neutral';
 
 interface Props {
   isOpen: boolean;
@@ -54,7 +60,7 @@ export default function IncomeExpenseBreakdownModal({
   const categoryName = useMemo(() => buildCategoryNameLookup(categories), [categories]);
 
   const valueOf = (t: SplitExpandedTransaction): number =>
-    bucket === 'uncategorized' ? t.amount : bucketContribution(t, bucket);
+    bucket === 'income' || bucket === 'expense' ? bucketContribution(t, bucket) : t.amount;
 
   const handleSort = (key: SortKey): void => {
     if (key === sortKey) setSortDir(d => (d === 1 ? -1 : 1));
@@ -149,7 +155,7 @@ export default function IncomeExpenseBreakdownModal({
         </td>
         <td className="py-2 pr-3 text-sm text-gray-900 dark:text-white">
           {t.description}
-          {bucket !== 'uncategorized' && value < 0 && (
+          {(bucket === 'income' || bucket === 'expense') && value < 0 && (
             <span className="ml-2 text-xs text-gray-400 dark:text-gray-500">(credit)</span>
           )}
         </td>

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -308,7 +308,7 @@ export default function Layout(): React.JSX.Element {
                   '/transactions': 'View, filter, and edit all transactions. Right-click for quick actions. Click categories or amounts to edit inline.',
                   '/budget': 'Set and track budgets by category. Try envelope budgeting or zero-based budgeting.',
                   '/calendar': 'See your income and expenses laid out by day on a monthly calendar.',
-                  '/reports': 'Income & expense analysis, net worth tracking, and custom report builder.',
+                  '/reports': 'A gallery of reports — net worth, account balances, spending by category or payee, period comparisons, and your own custom reports. The period you choose follows you between them.',
                   '/goals': 'Track savings targets, debt payoff goals, and investment milestones.',
                   '/investments': 'Portfolio overview with holdings, performance, and allocation analysis.',
                   '/settings': 'App preferences, data management, security, and account configuration.',

--- a/src/components/MonthlyIncomeExpenseMatrix.tsx
+++ b/src/components/MonthlyIncomeExpenseMatrix.tsx
@@ -1,0 +1,306 @@
+import React, { useState } from 'react';
+import { useCurrencyDecimal } from '../hooks/useCurrencyDecimal';
+import { CalendarIcon } from './icons';
+import type { MatrixGroup, MonthlyCategoryMatrix } from '../utils/monthlyCategoryMatrix';
+
+/**
+ * "Monthly income and expenses" — the Microsoft Money report: every category
+ * down the side, the months of the selected period across the top, group
+ * subtotals, and Total Income / Total Expenses / Income less Expenses in the
+ * footer.
+ *
+ * Unlike Money's version this follows the page's shared period picker rather
+ * than demanding custom dates, and every figure is a drill-in: clicking a
+ * cell opens the transactions behind it.
+ *
+ * The table scrolls inside its own box (both axes) with a sticky heading row
+ * and a sticky category column, so the page itself never scrolls sideways.
+ */
+
+export interface MatrixDrillTarget {
+  bucket: 'income' | 'expense';
+  /** Categories behind the figure; null = the whole side. */
+  categoryIds: string[] | null;
+  /** YYYY-MM, or null for the whole-period Total column. */
+  monthKey: string | null;
+  label: string;
+  total: number;
+}
+
+interface Props {
+  matrix: MonthlyCategoryMatrix;
+  onDrill: (target: MatrixDrillTarget) => void;
+}
+
+const DETAIL_KEY = 'reportsMatrixSubcategories';
+
+const CELL = 'px-3 py-1.5 text-right tabular-nums whitespace-nowrap border-b border-gray-100 dark:border-gray-700';
+const LABEL_CELL = 'sticky left-0 z-10 px-3 py-1.5 text-left whitespace-nowrap border-b border-r border-gray-100 dark:border-gray-700';
+const HEAD_CELL = 'sticky top-0 bg-gray-100 dark:bg-gray-900 px-3 py-2 text-xs font-semibold uppercase tracking-wider text-gray-600 dark:text-gray-300 border-b border-gray-200 dark:border-gray-600';
+
+interface RowSpec {
+  key: string;
+  label: string;
+  indent?: boolean;
+  values: number[];
+  total: number;
+  bgClass: string;
+  textClass: string;
+  /** Colour each figure by its own sign (the net row). */
+  signColour?: boolean;
+  /** Absent for rows that mix both sides — there is nothing single to drill. */
+  drill?: (monthKey: string | null, value: number) => void;
+}
+
+export default function MonthlyIncomeExpenseMatrix({ matrix, onDrill }: Props): React.JSX.Element {
+  const { formatCurrency } = useCurrencyDecimal();
+  // Group subtotals only, or every category beneath them — persisted like the
+  // page's other view preferences. Groups-only keeps a deep tree readable.
+  const [showDetail, setShowDetail] = useState<boolean>(
+    () => localStorage.getItem(DETAIL_KEY) !== '0'
+  );
+  const toggleDetail = (): void => {
+    setShowDetail(prev => {
+      localStorage.setItem(DETAIL_KEY, prev ? '0' : '1');
+      return !prev;
+    });
+  };
+
+  const { months } = matrix;
+
+  const money = (value: number): string =>
+    value < 0 ? `-${formatCurrency(Math.abs(value))}` : formatCurrency(value);
+
+  const labelOfMonth = (monthKey: string | null): string =>
+    monthKey === null
+      ? 'whole period'
+      : months.find(m => m.key === monthKey)?.label ?? monthKey;
+
+  const sideRowSpecs = (bucket: 'income' | 'expense', groups: MatrixGroup[]): RowSpec[] => {
+    const specs: RowSpec[] = [];
+    for (const group of groups) {
+      specs.push({
+        key: `${bucket}-group-${group.groupId}`,
+        label: group.name,
+        values: group.values,
+        total: group.total,
+        bgClass: 'bg-gray-50 dark:bg-gray-700',
+        textClass: 'font-semibold text-gray-900 dark:text-white',
+        drill: (monthKey, value) => onDrill({
+          bucket,
+          categoryIds: group.categoryIds,
+          monthKey,
+          label: `${group.name} — ${labelOfMonth(monthKey)}`,
+          total: value,
+        }),
+      });
+      if (!showDetail) continue;
+      // A group that only ever carries its own postings needs no repeat row.
+      if (group.rows.length === 1 && group.rows[0].categoryId === group.groupId) continue;
+      for (const row of group.rows) {
+        specs.push({
+          key: `${bucket}-row-${row.categoryId}`,
+          label: row.name,
+          indent: true,
+          values: row.values,
+          total: row.total,
+          bgClass: 'bg-white dark:bg-gray-800',
+          textClass: 'text-gray-700 dark:text-gray-300',
+          drill: (monthKey, value) => onDrill({
+            bucket,
+            categoryIds: [row.categoryId],
+            monthKey,
+            label: `${group.name} : ${row.name} — ${labelOfMonth(monthKey)}`,
+            total: value,
+          }),
+        });
+      }
+    }
+    return specs;
+  };
+
+  const totalRowSpec = (
+    key: string,
+    label: string,
+    values: number[],
+    total: number,
+    textClass: string,
+    extras: Pick<RowSpec, 'drill' | 'signColour'> = {}
+  ): RowSpec => ({
+    key,
+    label,
+    values,
+    total,
+    bgClass: 'bg-gray-100 dark:bg-gray-900',
+    textClass: `font-bold ${textClass}`,
+    ...extras,
+  });
+
+  const renderRow = (row: RowSpec): React.JSX.Element => {
+    const valueClass = (value: number): string => {
+      if (!row.signColour) return row.textClass;
+      return `${row.textClass} ${value < 0 ? 'text-red-600 dark:text-red-400' : 'text-green-700 dark:text-green-400'}`;
+    };
+
+    const figure = (value: number, monthKey: string | null): React.JSX.Element => {
+      if (value === 0) {
+        return <span className="text-gray-300 dark:text-gray-600">&mdash;</span>;
+      }
+      if (!row.drill) return <>{money(value)}</>;
+      const drill = row.drill;
+      return (
+        <button
+          type="button"
+          onClick={() => drill(monthKey, value)}
+          className="w-full text-right rounded px-1 -mx-1 hover:bg-blue-50 dark:hover:bg-blue-900/30 hover:underline focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
+          title={`${row.label} · ${labelOfMonth(monthKey)} — view these transactions`}
+        >
+          {money(value)}
+        </button>
+      );
+    };
+
+    return (
+      <tr key={row.key} className={row.bgClass}>
+        <th
+          scope="row"
+          className={`${LABEL_CELL} ${row.bgClass} ${row.textClass} ${row.indent ? 'pl-8 font-normal' : ''}`}
+        >
+          {row.label}
+        </th>
+        {row.values.map((value, index) => (
+          <td key={months[index].key} className={`${CELL} ${valueClass(value)}`}>
+            {figure(value, months[index].key)}
+          </td>
+        ))}
+        <td className={`${CELL} ${valueClass(row.total)} border-l border-gray-200 dark:border-gray-600`}>
+          {figure(row.total, null)}
+        </td>
+      </tr>
+    );
+  };
+
+  const sectionRow = (label: string): React.JSX.Element => (
+    <tr className="bg-[#1a2332] dark:bg-gray-900">
+      <th
+        scope="colgroup"
+        colSpan={months.length + 2}
+        className="sticky left-0 px-3 py-1.5 text-left text-xs font-semibold uppercase tracking-wider text-white"
+      >
+        {label}
+      </th>
+    </tr>
+  );
+
+  const hasData = months.length > 0
+    && (matrix.incomeGroups.length > 0 || matrix.expenseGroups.length > 0);
+
+  return (
+    <div className="min-w-0 bg-white dark:bg-gray-800 rounded-2xl shadow-lg border border-gray-100 dark:border-gray-700">
+      <div className="flex flex-wrap items-start justify-between gap-2 p-6 pb-3">
+        <div>
+          <h2 className="text-lg font-semibold flex items-center gap-2 text-theme-heading dark:text-white">
+            <CalendarIcon size={20} className="text-gray-500" />
+            Monthly Income and Expenses
+          </h2>
+          <p className="text-sm text-gray-500 dark:text-gray-400 mt-1">
+            Every category by month for the selected period. Click any figure to see the transactions behind it.
+          </p>
+        </div>
+        <button
+          type="button"
+          onClick={toggleDetail}
+          aria-pressed={showDetail}
+          title={showDetail ? 'Show group subtotals only' : 'Show every category under each group'}
+          className={`px-3 py-1 text-sm font-medium rounded-lg border transition-colors ${
+            showDetail
+              ? 'border-[#1a2332] dark:border-blue-500 bg-[#1a2332] dark:bg-blue-600 text-white'
+              : 'border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-200'
+          }`}
+        >
+          Subcategories
+        </button>
+      </div>
+
+      {matrix.omittedMonths > 0 && (
+        <p className="px-6 pb-3 text-xs text-amber-700 dark:text-amber-400">
+          This period spans {matrix.omittedMonths + months.length} months — the most recent {months.length} are shown
+          as columns, and the Total column still covers all of it. Choose a shorter period to see the earlier months.
+        </p>
+      )}
+
+      {!hasData ? (
+        <p className="text-center py-16 text-gray-400">No categorised transactions in this period</p>
+      ) : (
+        <div className="overflow-auto max-h-[70vh] rounded-b-2xl">
+          <table className="min-w-max text-sm border-separate border-spacing-0">
+            <caption className="sr-only">
+              Income and expenses by category and month for the selected period
+            </caption>
+            <thead>
+              <tr>
+                <th scope="col" className={`${HEAD_CELL} left-0 z-30 text-left border-r min-w-[220px]`}>
+                  Category
+                </th>
+                {months.map(month => (
+                  <th key={month.key} scope="col" className={`${HEAD_CELL} z-20 text-right min-w-[96px]`}>
+                    {month.label}
+                  </th>
+                ))}
+                <th scope="col" className={`${HEAD_CELL} z-20 text-right border-l min-w-[110px]`}>
+                  Total
+                </th>
+              </tr>
+            </thead>
+            <tbody>
+              {sectionRow('Income')}
+              {sideRowSpecs('income', matrix.incomeGroups).map(renderRow)}
+              {renderRow(totalRowSpec(
+                'total-income',
+                'Total Income',
+                matrix.incomeValues,
+                matrix.incomeTotal,
+                'text-green-700 dark:text-green-400',
+                {
+                  drill: (monthKey, value) => onDrill({
+                    bucket: 'income',
+                    categoryIds: null,
+                    monthKey,
+                    label: `Income — ${labelOfMonth(monthKey)}`,
+                    total: value,
+                  }),
+                }
+              ))}
+              {sectionRow('Expenses')}
+              {sideRowSpecs('expense', matrix.expenseGroups).map(renderRow)}
+              {renderRow(totalRowSpec(
+                'total-expenses',
+                'Total Expenses',
+                matrix.expenseValues,
+                matrix.expenseTotal,
+                'text-red-600 dark:text-red-400',
+                {
+                  drill: (monthKey, value) => onDrill({
+                    bucket: 'expense',
+                    categoryIds: null,
+                    monthKey,
+                    label: `Expenses — ${labelOfMonth(monthKey)}`,
+                    total: value,
+                  }),
+                }
+              ))}
+              {renderRow(totalRowSpec(
+                'net',
+                'Income less Expenses',
+                matrix.netValues,
+                matrix.netTotal,
+                'text-gray-900 dark:text-white',
+                { signColour: true }
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/MonthlyIncomeExpenseMatrix.tsx
+++ b/src/components/MonthlyIncomeExpenseMatrix.tsx
@@ -67,6 +67,9 @@ export default function MonthlyIncomeExpenseMatrix({ matrix, onDrill }: Props): 
   };
 
   const { months } = matrix;
+  // A Total column that repeats the single month it sums is just noise, so it
+  // only earns its place once there is more than one period to add up.
+  const showTotal = months.length > 1;
 
   const money = (value: number): string =>
     value < 0 ? `-${formatCurrency(Math.abs(value))}` : formatCurrency(value);
@@ -173,9 +176,11 @@ export default function MonthlyIncomeExpenseMatrix({ matrix, onDrill }: Props): 
             {figure(value, months[index].key)}
           </td>
         ))}
-        <td className={`${CELL} ${valueClass(row.total)} border-l border-gray-200 dark:border-gray-600`}>
-          {figure(row.total, null)}
-        </td>
+        {showTotal && (
+          <td className={`${CELL} ${valueClass(row.total)} border-l border-gray-200 dark:border-gray-600`}>
+            {figure(row.total, null)}
+          </td>
+        )}
       </tr>
     );
   };
@@ -184,7 +189,7 @@ export default function MonthlyIncomeExpenseMatrix({ matrix, onDrill }: Props): 
     <tr className="bg-[#1a2332] dark:bg-gray-900">
       <th
         scope="colgroup"
-        colSpan={months.length + 2}
+        colSpan={months.length + (showTotal ? 2 : 1)}
         className="sticky left-0 px-3 py-1.5 text-left text-xs font-semibold uppercase tracking-wider text-white"
       >
         {label}
@@ -247,9 +252,11 @@ export default function MonthlyIncomeExpenseMatrix({ matrix, onDrill }: Props): 
                     {month.label}
                   </th>
                 ))}
-                <th scope="col" className={`${HEAD_CELL} z-20 text-right border-l min-w-[110px]`}>
-                  Total
-                </th>
+                {showTotal && (
+                  <th scope="col" className={`${HEAD_CELL} z-20 text-right border-l min-w-[110px]`}>
+                    Total
+                  </th>
+                )}
               </tr>
             </thead>
             <tbody>

--- a/src/components/PeriodPicker.tsx
+++ b/src/components/PeriodPicker.tsx
@@ -19,6 +19,9 @@ export default function PeriodPicker({ picker }: { picker: UsePeriodResult }): R
             key={key}
             type="button"
             onClick={() => setPeriod(key)}
+            // The selection is styling alone otherwise — assistive technology
+            // (and tests) need it stated.
+            aria-pressed={period === key}
             className={`px-3 py-1.5 text-sm font-medium rounded-md transition-colors whitespace-nowrap ${
               period === key
                 ? 'bg-[#1a2332] dark:bg-blue-600 text-white'

--- a/src/components/__tests__/MonthlyIncomeExpenseMatrix.test.tsx
+++ b/src/components/__tests__/MonthlyIncomeExpenseMatrix.test.tsx
@@ -1,0 +1,121 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { render, screen, fireEvent, within } from '@testing-library/react';
+import { PreferencesProvider } from '../../contexts/PreferencesContext';
+import MonthlyIncomeExpenseMatrix, { type MatrixDrillTarget } from '../MonthlyIncomeExpenseMatrix';
+import { buildMonthlyCategoryMatrix } from '../../utils/monthlyCategoryMatrix';
+import { computeIncomeExpense } from '../../utils/incomeExpense';
+import type { Category, Transaction } from '../../types';
+import type { PeriodRange } from '../../hooks/usePeriod';
+
+const CATEGORIES: Category[] = [
+  { id: 'type-income', name: 'Income', type: 'income', level: 'type', isSystem: true },
+  { id: 'type-expense', name: 'Expense', type: 'expense', level: 'type', isSystem: true },
+  { id: 'grp-salary', name: 'Salary', type: 'income', level: 'sub', parentId: 'type-income' },
+  { id: 'grp-food', name: 'Food Related Costs', type: 'expense', level: 'sub', parentId: 'type-expense' },
+  { id: 'cat-groceries', name: 'Groceries', type: 'expense', level: 'detail', parentId: 'grp-food' },
+];
+
+const RANGE: PeriodRange = { from: new Date(2026, 0, 1), to: new Date(2026, 1, 28, 23, 59, 59, 999) };
+
+const TRANSACTIONS: Transaction[] = [
+  { id: 't1', date: new Date(2026, 0, 5), amount: 2000, description: 'synthetic pay', category: 'grp-salary', accountId: 'acc-1', type: 'income' },
+  { id: 't2', date: new Date(2026, 0, 12), amount: -40, description: 'synthetic shop', category: 'cat-groceries', accountId: 'acc-1', type: 'expense' },
+  { id: 't3', date: new Date(2026, 1, 12), amount: -60, description: 'synthetic shop', category: 'cat-groceries', accountId: 'acc-1', type: 'expense' },
+];
+
+const matrix = (): ReturnType<typeof buildMonthlyCategoryMatrix> => {
+  const flows = computeIncomeExpense(TRANSACTIONS, [], CATEGORIES, {
+    from: RANGE.from ?? undefined,
+    to: RANGE.to ?? undefined,
+  });
+  return buildMonthlyCategoryMatrix(flows.incomeRows, flows.expenseRows, CATEGORIES, RANGE, {
+    now: new Date(2026, 1, 20),
+  });
+};
+
+const renderMatrix = (onDrill: (t: MatrixDrillTarget) => void = vi.fn()) =>
+  render(
+    <PreferencesProvider>
+      <MonthlyIncomeExpenseMatrix matrix={matrix()} onDrill={onDrill} />
+    </PreferencesProvider>
+  );
+
+describe('MonthlyIncomeExpenseMatrix', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it('lays categories down the side and months across the top', () => {
+    renderMatrix();
+
+    expect(screen.getByRole('columnheader', { name: 'Category' })).toBeInTheDocument();
+    expect(screen.getByRole('columnheader', { name: 'Jan 26' })).toBeInTheDocument();
+    expect(screen.getByRole('columnheader', { name: 'Feb 26' })).toBeInTheDocument();
+    expect(screen.getByRole('columnheader', { name: 'Total' })).toBeInTheDocument();
+    expect(screen.getByRole('rowheader', { name: 'Food Related Costs' })).toBeInTheDocument();
+    expect(screen.getByRole('rowheader', { name: 'Salary' })).toBeInTheDocument();
+  });
+
+  it('shows the Money footer rows with income less expenses', () => {
+    renderMatrix();
+
+    const net = screen.getByRole('rowheader', { name: 'Income less Expenses' }).closest('tr');
+    expect(net).not.toBeNull();
+    // Jan: 2000 − 40, Feb: 0 − 60, period: 2000 − 100
+    expect(within(net as HTMLElement).getByText('£1,960.00')).toBeInTheDocument();
+    expect(within(net as HTMLElement).getByText('-£60.00')).toBeInTheDocument();
+    expect(within(net as HTMLElement).getByText('£1,900.00')).toBeInTheDocument();
+    expect(screen.getByRole('rowheader', { name: 'Total Expenses' })).toBeInTheDocument();
+    expect(screen.getByRole('rowheader', { name: 'Total Income' })).toBeInTheDocument();
+  });
+
+  it('drills into a single category/month cell', () => {
+    const onDrill = vi.fn();
+    renderMatrix(onDrill);
+
+    fireEvent.click(screen.getByTitle('Groceries · Feb 26 — view these transactions'));
+
+    expect(onDrill).toHaveBeenCalledWith({
+      bucket: 'expense',
+      categoryIds: ['cat-groceries'],
+      monthKey: '2026-02',
+      label: 'Food Related Costs : Groceries — Feb 26',
+      total: 60,
+    });
+  });
+
+  it('drills into a whole-period total from the Total column', () => {
+    const onDrill = vi.fn();
+    renderMatrix(onDrill);
+
+    fireEvent.click(screen.getByTitle('Total Income · whole period — view these transactions'));
+
+    expect(onDrill).toHaveBeenCalledWith({
+      bucket: 'income',
+      categoryIds: null,
+      monthKey: null,
+      label: 'Income — whole period',
+      total: 2000,
+    });
+  });
+
+  it('a month with no activity renders as a dash, not a clickable zero', () => {
+    renderMatrix();
+
+    const salaryRow = screen.getByRole('rowheader', { name: 'Salary' }).closest('tr');
+    expect(within(salaryRow as HTMLElement).queryByTitle('Salary · Feb 26 — view these transactions')).toBeNull();
+    expect(within(salaryRow as HTMLElement).getAllByText('—').length).toBe(1);
+  });
+
+  it('persists the subcategory toggle', () => {
+    renderMatrix();
+
+    expect(screen.getByRole('rowheader', { name: 'Groceries' })).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: 'Subcategories' }));
+
+    expect(localStorage.getItem('reportsMatrixSubcategories')).toBe('0');
+    expect(screen.queryByRole('rowheader', { name: 'Groceries' })).toBeNull();
+    // The group subtotal row stays.
+    expect(screen.getByRole('rowheader', { name: 'Food Related Costs' })).toBeInTheDocument();
+  });
+});

--- a/src/components/__tests__/MonthlyIncomeExpenseMatrix.test.tsx
+++ b/src/components/__tests__/MonthlyIncomeExpenseMatrix.test.tsx
@@ -56,6 +56,29 @@ describe('MonthlyIncomeExpenseMatrix', () => {
     expect(screen.getByRole('rowheader', { name: 'Salary' })).toBeInTheDocument();
   });
 
+  it('drops the Total column for a single-month period, where it would just repeat the month', () => {
+    const singleMonth: PeriodRange = { from: new Date(2026, 0, 1), to: new Date(2026, 0, 31, 23, 59, 59, 999) };
+    const flows = computeIncomeExpense(TRANSACTIONS, [], CATEGORIES, {
+      from: singleMonth.from ?? undefined,
+      to: singleMonth.to ?? undefined,
+    });
+    render(
+      <PreferencesProvider>
+        <MonthlyIncomeExpenseMatrix
+          matrix={buildMonthlyCategoryMatrix(flows.incomeRows, flows.expenseRows, CATEGORIES, singleMonth, {
+            now: new Date(2026, 0, 20),
+          })}
+          onDrill={vi.fn()}
+        />
+      </PreferencesProvider>
+    );
+
+    expect(screen.getByRole('columnheader', { name: 'Jan 26' })).toBeInTheDocument();
+    expect(screen.queryByRole('columnheader', { name: 'Total' })).not.toBeInTheDocument();
+    // The figures themselves must survive losing the column.
+    expect(screen.getByRole('rowheader', { name: 'Total Expenses' })).toBeInTheDocument();
+  });
+
   it('shows the Money footer rows with income less expenses', () => {
     renderMatrix();
 

--- a/src/components/dashboard/ImprovedDashboard.tsx
+++ b/src/components/dashboard/ImprovedDashboard.tsx
@@ -28,13 +28,12 @@ import PeriodPicker from '../../components/PeriodPicker';
 import { PERIOD_LABELS, usePeriod } from '../../hooks/usePeriod';
 import { customReportService } from '../../services/customReportService';
 import {
-  BUILT_IN_REPORTS,
   NetWorthWidget,
   IncomeExpenseTrendWidget,
   ExpenseCategoriesWidget,
   CustomReportWidget,
-  type PinnableReportId,
 } from './reportWidgets/DashboardReportWidgets';
+import { BUILT_IN_REPORTS, type PinnableReportId } from './reportWidgets/pinnableReports';
 import { PieChart, BarChart, ResponsiveContainer } from '../charts/DashboardCharts';
 import { formatDecimal } from '../../utils/decimal-format';
 import { toDecimal } from '../../utils/decimal';

--- a/src/components/dashboard/reportWidgets/DashboardReportWidgets.tsx
+++ b/src/components/dashboard/reportWidgets/DashboardReportWidgets.tsx
@@ -29,7 +29,10 @@ import { ChevronRightIcon, TrendingUpIcon, PieChartIcon, BarChart3Icon, FileText
  * "pinned reports" section. Each widget computes from the SAME shared maths
  * as its full report (utils/monthlyTrend, utils/netWorthSeries,
  * utils/categoryNetting), so the glance and the full view can never
- * disagree. Every card clicks through to the Reports hub.
+ * disagree.
+ *
+ * Every card clicks through to ITS report in the gallery — the ids below are
+ * the report gallery's stable URL segments (see pages/reports/reportRegistry).
  */
 
 const CATEGORY_COLORS = [
@@ -95,7 +98,7 @@ export function NetWorthWidget({ range }: { range: PeriodRange }): React.JSX.Ele
     <WidgetCard
       title="Net Worth Over Time"
       icon={TrendingUpIcon}
-      onOpen={() => navigate(preserveDemoParam('/reports', location.search))}
+      onOpen={() => navigate(preserveDemoParam('/reports/net-worth-over-time', location.search))}
     >
       <p className="text-xl font-bold text-gray-900 dark:text-white mb-2">
         {latest ? formatCurrency(latest.netWorth) : '—'}
@@ -134,7 +137,7 @@ export function IncomeExpenseTrendWidget({ range }: { range: PeriodRange }): Rea
     <WidgetCard
       title="Income vs Expenses"
       icon={BarChart3Icon}
-      onOpen={() => navigate(preserveDemoParam('/reports', location.search))}
+      onOpen={() => navigate(preserveDemoParam('/reports/income-and-spending-over-time', location.search))}
     >
       <div className="h-44">
         <ResponsiveContainer width="100%" height="100%">
@@ -174,7 +177,7 @@ export function ExpenseCategoriesWidget({ range }: { range: PeriodRange }): Reac
     <WidgetCard
       title="Expense Categories"
       icon={PieChartIcon}
-      onOpen={() => navigate(preserveDemoParam('/reports', location.search))}
+      onOpen={() => navigate(preserveDemoParam('/reports/spending-by-category', location.search))}
     >
       {data.length === 0 ? (
         <p className="text-center py-10 text-sm text-gray-400">No categorised spending in this period</p>
@@ -220,7 +223,7 @@ export function CustomReportWidget({ reportId }: { reportId: string }): React.JS
     <WidgetCard
       title={report.name}
       icon={FileTextIcon}
-      onOpen={() => navigate(preserveDemoParam('/reports', location.search))}
+      onOpen={() => navigate(preserveDemoParam('/reports/custom-reports', location.search))}
     >
       <p className="text-sm text-gray-500 dark:text-gray-400">
         {report.description || 'Custom report'}

--- a/src/components/dashboard/reportWidgets/DashboardReportWidgets.tsx
+++ b/src/components/dashboard/reportWidgets/DashboardReportWidgets.tsx
@@ -48,15 +48,6 @@ const compactTick = (value: number): string => {
   return formatDecimal(value, 0);
 };
 
-/** Everything a pinned report can be. Custom reports use `custom:<id>`. */
-export type PinnableReportId = 'net-worth' | 'income-expense-trend' | 'expense-categories' | `custom:${string}`;
-
-export const BUILT_IN_REPORTS: Array<{ id: PinnableReportId; label: string; icon: React.ElementType }> = [
-  { id: 'net-worth', label: 'Net Worth Over Time', icon: TrendingUpIcon },
-  { id: 'income-expense-trend', label: 'Income vs Expenses Trend', icon: BarChart3Icon },
-  { id: 'expense-categories', label: 'Expense Categories', icon: PieChartIcon },
-];
-
 function WidgetCard({ title, icon: Icon, onOpen, children }: {
   title: string;
   icon: React.ElementType;

--- a/src/components/dashboard/reportWidgets/pinnableReports.ts
+++ b/src/components/dashboard/reportWidgets/pinnableReports.ts
@@ -1,0 +1,18 @@
+/**
+ * Which reports can be pinned to the dashboard.
+ *
+ * Kept apart from the widgets that render them so that file exports components
+ * and nothing else — a module mixing components with constants loses React Fast
+ * Refresh for every component in it, which is the whole file's edit-reload loop.
+ */
+import type React from 'react';
+import { TrendingUpIcon, PieChartIcon, BarChart3Icon } from '../../icons';
+
+/** Everything a pinned report can be. Custom reports use `custom:<id>`. */
+export type PinnableReportId = 'net-worth' | 'income-expense-trend' | 'expense-categories' | `custom:${string}`;
+
+export const BUILT_IN_REPORTS: Array<{ id: PinnableReportId; label: string; icon: React.ElementType }> = [
+  { id: 'net-worth', label: 'Net Worth Over Time', icon: TrendingUpIcon },
+  { id: 'income-expense-trend', label: 'Income vs Expenses Trend', icon: BarChart3Icon },
+  { id: 'expense-categories', label: 'Expense Categories', icon: PieChartIcon },
+];

--- a/src/components/reports/IncomeExpenseSummaryCards.tsx
+++ b/src/components/reports/IncomeExpenseSummaryCards.tsx
@@ -1,0 +1,106 @@
+import React, { useMemo, useState } from 'react';
+import { useApp } from '../../contexts/AppContextSupabase';
+import { useCurrencyDecimal } from '../../hooks/useCurrencyDecimal';
+import { SkeletonText } from '../loading/Skeleton';
+import ReportDrillModal, { type ReportDrillTarget } from './ReportDrillModal';
+import { toDecimal } from '../../utils/decimal';
+import { formatDecimal } from '../../utils/decimal-format';
+import type { Category } from '../../types';
+import type { IncomeExpenseBreakdown } from '../../utils/incomeExpense';
+
+/**
+ * Total income, total expenses, what is left and the savings rate — the four
+ * figures every spending report is measured against, drawn from the SAME
+ * classified rows the report itself uses, so a card can never disagree with
+ * the table beneath it.
+ *
+ * Income and Expenses are buttons: both drill into the transactions behind
+ * them.
+ */
+export default function IncomeExpenseSummaryCards({
+  flows,
+  categories,
+}: {
+  flows: IncomeExpenseBreakdown;
+  categories: Category[];
+}): React.JSX.Element {
+  const { isLoading } = useApp();
+  const { formatCurrency } = useCurrencyDecimal();
+  const [drill, setDrill] = useState<ReportDrillTarget | null>(null);
+
+  const summary = useMemo(() => {
+    const net = flows.income.minus(flows.expenses);
+    const savingsRate = flows.income.greaterThan(0)
+      ? net.dividedBy(flows.income).times(100)
+      : toDecimal(0);
+    return {
+      income: flows.income.toNumber(),
+      expenses: flows.expenses.toNumber(),
+      net: net.toNumber(),
+      savingsRate: savingsRate.toNumber(),
+    };
+  }, [flows]);
+
+  return (
+    <>
+      <div className="grid grid-cols-1 md:grid-cols-4 gap-4">
+        {/* flex-col: buttons lay children out in a ROW by default, which would
+            put the figure beside the label — every stat card stacks label OVER
+            figure, matching the Dashboard. */}
+        <button
+          type="button"
+          onClick={() => setDrill({
+            title: 'Income Breakdown',
+            bucket: 'income',
+            rows: flows.incomeRows,
+            total: summary.income,
+          })}
+          className="flex flex-col items-start bg-white dark:bg-gray-800 rounded-2xl shadow-lg border border-gray-100 dark:border-gray-700 p-6 text-left cursor-pointer hover:bg-green-50 dark:hover:bg-green-900/10 transition-colors"
+        >
+          <p className="text-sm text-gray-600 dark:text-gray-400 mb-1">Total Income</p>
+          {/* div, not p: the loading skeleton renders block elements and a
+              <div> inside <p> is invalid DOM nesting */}
+          <div className="text-2xl font-bold text-green-700 dark:text-green-400">
+            {isLoading ? <SkeletonText className="w-32 h-8" /> : formatCurrency(summary.income)}
+          </div>
+        </button>
+
+        <button
+          type="button"
+          onClick={() => setDrill({
+            title: 'Expense Breakdown',
+            bucket: 'expense',
+            rows: flows.expenseRows,
+            total: summary.expenses,
+          })}
+          className="flex flex-col items-start bg-white dark:bg-gray-800 rounded-2xl shadow-lg border border-gray-100 dark:border-gray-700 p-6 text-left cursor-pointer hover:bg-red-50 dark:hover:bg-red-900/10 transition-colors"
+        >
+          <p className="text-sm text-gray-600 dark:text-gray-400 mb-1">Total Expenses</p>
+          <div className="text-2xl font-bold text-red-600 dark:text-red-400">
+            {isLoading ? <SkeletonText className="w-32 h-8" /> : formatCurrency(summary.expenses)}
+          </div>
+        </button>
+
+        <div className="bg-white dark:bg-gray-800 rounded-2xl shadow-lg border border-gray-100 dark:border-gray-700 p-6">
+          <p className="text-sm text-gray-600 dark:text-gray-400 mb-1">Net Income</p>
+          <div className={`text-2xl font-bold ${
+            summary.net >= 0 ? 'text-green-700 dark:text-green-400' : 'text-red-600 dark:text-red-400'
+          }`}>
+            {isLoading ? <SkeletonText className="w-32 h-8" /> : formatCurrency(summary.net)}
+          </div>
+        </div>
+
+        <div className="bg-white dark:bg-gray-800 rounded-2xl shadow-lg border border-gray-100 dark:border-gray-700 p-6">
+          <p className="text-sm text-gray-600 dark:text-gray-400 mb-1">Savings Rate</p>
+          <div className={`text-2xl font-bold ${
+            summary.savingsRate >= 20 ? 'text-green-700 dark:text-green-400' : 'text-yellow-700 dark:text-yellow-400'
+          }`}>
+            {isLoading ? <SkeletonText className="w-20 h-8" /> : `${formatDecimal(summary.savingsRate, 1)}%`}
+          </div>
+        </div>
+      </div>
+
+      <ReportDrillModal target={drill} onClose={() => setDrill(null)} categories={categories} />
+    </>
+  );
+}

--- a/src/components/reports/ReportAccountFilter.tsx
+++ b/src/components/reports/ReportAccountFilter.tsx
@@ -1,0 +1,33 @@
+import React from 'react';
+import { FilterIcon } from '../icons';
+import type { Account } from '../../types';
+import type { ReportAccountFilter as Filter } from '../../hooks/useReportAccountFilter';
+
+/**
+ * The reports' account filter — one control, one look, on every report that
+ * can be narrowed to a single account.
+ */
+export default function ReportAccountFilter({
+  accounts,
+  filter,
+}: {
+  accounts: Account[];
+  filter: Filter;
+}): React.JSX.Element {
+  return (
+    <div className="flex items-center gap-2">
+      <FilterIcon className="text-gray-500" size={18} />
+      <select
+        aria-label="Account filter"
+        value={filter.accountId}
+        onChange={e => filter.setAccountId(e.target.value)}
+        className="px-3 py-1.5 text-sm bg-white dark:bg-gray-800 border border-gray-300/50 dark:border-gray-600/50 rounded-lg focus:outline-none focus:ring-2 focus:ring-primary focus:border-transparent dark:text-white"
+      >
+        <option value="all">All accounts</option>
+        {accounts.map(account => (
+          <option key={account.id} value={account.id}>{account.name}</option>
+        ))}
+      </select>
+    </div>
+  );
+}

--- a/src/components/reports/ReportDrillModal.tsx
+++ b/src/components/reports/ReportDrillModal.tsx
@@ -1,0 +1,59 @@
+import React, { useState } from 'react';
+import { useApp } from '../../contexts/AppContextSupabase';
+import IncomeExpenseBreakdownModal, { type BreakdownBucket } from '../IncomeExpenseBreakdownModal';
+import EditTransactionModal from '../EditTransactionModal';
+import type { Category } from '../../types';
+import type { SplitExpandedTransaction } from '../../utils/transactionSplits';
+
+/**
+ * Every figure in the gallery drills into the transactions behind it — a
+ * chart slice, a matrix cell, a payee row, an account balance. This is that
+ * drill-in, once: the shared breakdown list, plus the editor a row opens.
+ *
+ * Reports raise a target and clear it; nothing else about the mechanism has
+ * to be repeated in each report.
+ */
+export interface ReportDrillTarget {
+  title: string;
+  bucket: BreakdownBucket;
+  rows: SplitExpandedTransaction[];
+  /** The figure the rows sum to; null hides the total line. */
+  total: number | null;
+}
+
+export default function ReportDrillModal({
+  target,
+  onClose,
+  categories,
+}: {
+  target: ReportDrillTarget | null;
+  onClose: () => void;
+  categories: Category[];
+}): React.JSX.Element {
+  const { transactions } = useApp();
+  const [editingId, setEditingId] = useState<string | null>(null);
+
+  return (
+    <>
+      <IncomeExpenseBreakdownModal
+        isOpen={target !== null}
+        onClose={onClose}
+        title={target?.title ?? ''}
+        bucket={target?.bucket ?? 'neutral'}
+        rows={target?.rows ?? []}
+        total={target?.total ?? null}
+        categories={categories}
+        onEditTransaction={setEditingId}
+      />
+
+      {/* A split line's editor opens its PARENT — that is the real record. */}
+      {editingId !== null && (
+        <EditTransactionModal
+          isOpen
+          onClose={() => setEditingId(null)}
+          transaction={transactions.find(t => t.id === editingId) ?? null}
+        />
+      )}
+    </>
+  );
+}

--- a/src/components/reports/ReportExportBar.tsx
+++ b/src/components/reports/ReportExportBar.tsx
@@ -1,0 +1,123 @@
+import React, { useState } from 'react';
+import { DownloadIcon, PdfIcon } from '../icons';
+import { exportTransactionsToCSV, downloadCSV } from '../../utils/csvExport';
+import { generatePDFReport } from '../../utils/pdfExport';
+import { computeExpenseCategoryNetTotals } from '../../utils/categoryNetting';
+import { buildCategoryNameLookup } from '../../utils/categoryNames';
+import { toDecimal } from '../../utils/decimal';
+import { createScopedLogger } from '../../loggers/scopedLogger';
+import type { Account, Category } from '../../types';
+import type { IncomeExpenseBreakdown } from '../../utils/incomeExpense';
+import type { SplitExpandedTransaction } from '../../utils/transactionSplits';
+
+const exportLogger = createScopedLogger('ReportExport');
+
+/**
+ * CSV and PDF export for a report — the same two buttons, the same figures,
+ * wherever they appear. The PDF carries the report's own charts when it has
+ * any (refs passed in); a report without charts simply exports the tables.
+ */
+export default function ReportExportBar({
+  title,
+  dateRange,
+  rows,
+  flows,
+  categories,
+  accounts,
+  charts,
+}: {
+  /** Title printed on the PDF. */
+  title: string;
+  /** The period, in words, printed under the title. */
+  dateRange: string;
+  /** The report's period- and account-filtered rows. */
+  rows: SplitExpandedTransaction[];
+  flows: IncomeExpenseBreakdown;
+  categories: Category[];
+  accounts: Account[];
+  charts?: Array<React.RefObject<HTMLDivElement | null>>;
+}): React.JSX.Element {
+  const [isGenerating, setIsGenerating] = useState(false);
+
+  const exportCSV = (): void => {
+    try {
+      // categories resolve the Category column to a name — a UUID in a
+      // spreadsheet is worthless.
+      const csv = exportTransactionsToCSV(rows, accounts, categories);
+      downloadCSV(csv, `${title.toLowerCase().replace(/[^a-z0-9]+/g, '-')}-${new Date().toISOString().split('T')[0]}.csv`);
+    } catch (error) {
+      exportLogger.error('Error exporting CSV', error);
+      alert('Failed to export CSV. Please try again.');
+    }
+  };
+
+  const exportPDF = async (): Promise<void> => {
+    setIsGenerating(true);
+    try {
+      const categoryName = buildCategoryNameLookup(categories);
+      const netTotals = computeExpenseCategoryNetTotals(rows, categories);
+      const totalExpenses = netTotals.reduce((sum, entry) => sum.plus(toDecimal(entry.value)), toDecimal(0));
+      const netIncome = flows.income.minus(flows.expenses);
+
+      const chartElements = (charts ?? [])
+        .map(ref => ref.current)
+        .filter((element): element is HTMLDivElement => element !== null);
+
+      await generatePDFReport(
+        {
+          title,
+          dateRange,
+          summary: {
+            income: flows.income.toNumber(),
+            expenses: flows.expenses.toNumber(),
+            netIncome: netIncome.toNumber(),
+            savingsRate: flows.income.greaterThan(0)
+              ? netIncome.dividedBy(flows.income).times(100).toNumber()
+              : 0,
+          },
+          categoryBreakdown: netTotals.map(({ name, value }) => ({
+            category: name,
+            amount: value,
+            percentage: totalExpenses.greaterThan(0)
+              ? toDecimal(value).dividedBy(totalExpenses).times(100).toNumber()
+              : 0,
+          })),
+          // categoryLabel: the PDF prints names, never category ids.
+          topTransactions: [...rows]
+            .sort((a, b) => Math.abs(b.amount) - Math.abs(a.amount))
+            .slice(0, 10)
+            .map(t => ({ ...t, categoryLabel: categoryName(t.category) })),
+          chartElements: chartElements.length > 0 ? chartElements : undefined,
+        },
+        accounts
+      );
+    } catch (error) {
+      exportLogger.error('Error generating PDF', error);
+      alert('Failed to generate PDF report. Please try again.');
+    } finally {
+      setIsGenerating(false);
+    }
+  };
+
+  return (
+    <div className="flex flex-wrap gap-2">
+      <button
+        type="button"
+        onClick={exportCSV}
+        className="flex items-center gap-2 px-3 py-1.5 text-sm font-medium bg-[#1a2332] text-white rounded-lg hover:bg-secondary transition-colors"
+      >
+        <DownloadIcon size={16} />
+        Export CSV
+      </button>
+      <button
+        type="button"
+        onClick={exportPDF}
+        disabled={isGenerating}
+        className="flex items-center gap-2 px-3 py-1.5 text-sm font-medium bg-red-600 text-white rounded-lg hover:bg-red-700 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+      >
+        <PdfIcon size={16} />
+        {isGenerating ? 'Generating…' : 'Export PDF'}
+      </button>
+    </div>
+  );
+}

--- a/src/components/reports/UncategorisedReviewBand.tsx
+++ b/src/components/reports/UncategorisedReviewBand.tsx
@@ -1,0 +1,79 @@
+import React, { useState } from 'react';
+import { useCurrencyDecimal } from '../../hooks/useCurrencyDecimal';
+import TransferSweepModal from '../TransferSweepModal';
+import BulkCategorizeModal from '../BulkCategorizeModal';
+import ReportDrillModal, { type ReportDrillTarget } from './ReportDrillModal';
+import type { Category } from '../../types';
+import type { IncomeExpenseBreakdown } from '../../utils/incomeExpense';
+
+/**
+ * The review band: rows with no category are EXCLUDED from every total in the
+ * gallery (no category = not income, not an expense), so each report says so
+ * out loud and offers the three ways out — review them one by one, match
+ * transfers automatically, or file a whole payee at once.
+ *
+ * Shown on every report whose figures those rows would otherwise have joined,
+ * so the exclusion can never look like a quiet loss of money.
+ */
+export default function UncategorisedReviewBand({
+  flows,
+  categories,
+}: {
+  flows: IncomeExpenseBreakdown;
+  categories: Category[];
+}): React.JSX.Element | null {
+  const { formatCurrency } = useCurrencyDecimal();
+  const [drill, setDrill] = useState<ReportDrillTarget | null>(null);
+  const [showTransferSweep, setShowTransferSweep] = useState(false);
+  const [showBulkCategorize, setShowBulkCategorize] = useState(false);
+
+  const count = flows.uncategorizedRows.length;
+  if (count === 0) return null;
+
+  return (
+    <div className="space-y-2">
+      <button
+        type="button"
+        onClick={() => setDrill({
+          title: 'Uncategorised Transactions',
+          bucket: 'uncategorized',
+          rows: flows.uncategorizedRows,
+          total: null,
+        })}
+        className="w-full flex flex-wrap items-center gap-x-4 gap-y-1 rounded-2xl border border-amber-300 dark:border-amber-600 bg-amber-50 dark:bg-amber-900/20 px-5 py-3 text-left hover:bg-amber-100 dark:hover:bg-amber-900/30 transition-colors"
+      >
+        <span className="text-sm font-semibold text-amber-800 dark:text-amber-300">
+          {count.toLocaleString()} uncategorised transaction{count === 1 ? '' : 's'} excluded from these totals
+        </span>
+        <span className="text-sm text-amber-700 dark:text-amber-400 tabular-nums">
+          {formatCurrency(flows.uncategorizedIn.toNumber())} in · {formatCurrency(flows.uncategorizedOut.toNumber())} out
+        </span>
+        <span className="ml-auto text-xs text-amber-700 dark:text-amber-400">
+          Click to review and categorise
+        </span>
+      </button>
+
+      <div className="flex flex-col gap-1">
+        <button
+          type="button"
+          onClick={() => setShowTransferSweep(true)}
+          className="text-sm text-blue-700 dark:text-blue-400 hover:underline text-left"
+        >
+          Or match transfers automatically — find equal-and-opposite pairs and link them in one go
+        </button>
+        <button
+          type="button"
+          onClick={() => setShowBulkCategorize(true)}
+          className="text-sm text-blue-700 dark:text-blue-400 hover:underline text-left"
+        >
+          Or categorise by payee — file a whole merchant at once and teach future imports
+        </button>
+      </div>
+
+      <ReportDrillModal target={drill} onClose={() => setDrill(null)} categories={categories} />
+
+      <TransferSweepModal isOpen={showTransferSweep} onClose={() => setShowTransferSweep(false)} />
+      <BulkCategorizeModal isOpen={showBulkCategorize} onClose={() => setShowBulkCategorize(false)} />
+    </div>
+  );
+}

--- a/src/hooks/usePeriod.test.ts
+++ b/src/hooks/usePeriod.test.ts
@@ -105,14 +105,32 @@ describe('usePeriod defaults vs the user’s own choice', () => {
     expect(third.result.current.isExplicit).toBe(true);
   });
 
-  it('treats a period stored before the flag existed as the user’s choice', () => {
-    // Older builds only ever wrote the key from the picker itself.
+  it('lets a report’s window override a period stored before the flag existed', () => {
+    // An older build wrote this key from the picker — but for one tabbed
+    // reports page, not as a standing instruction for reports that did not
+    // exist yet. Honouring it as a choice meant a returning user could never
+    // see a report's preferred window, which is the whole point of the
+    // feature. So it seeds nothing and the caller's default wins.
     localStorage.setItem(KEY, 'last-month');
 
     const { result } = renderHook(() => usePeriod(KEY, 'all'));
 
-    expect(result.current.period).toBe('last-month');
-    expect(result.current.isExplicit).toBe(true);
+    expect(result.current.period).toBe('all');
+    expect(result.current.isExplicit).toBe(false);
+  });
+
+  it('honours the very next choice the user makes after that reset', () => {
+    localStorage.setItem(KEY, 'last-month');
+
+    const first = renderHook(() => usePeriod(KEY, 'all'));
+    act(() => first.result.current.setPeriod('tax-year'));
+
+    const second = renderHook(() => usePeriod(KEY, 'all'));
+    expect(second.result.current.period).toBe('tax-year');
+    expect(second.result.current.isExplicit).toBe(true);
+
+    act(() => second.result.current.applyDefaultPeriod('all'));
+    expect(second.result.current.period).toBe('tax-year');
   });
 
   it('ignores a stored value that is not a period', () => {

--- a/src/hooks/usePeriod.test.ts
+++ b/src/hooks/usePeriod.test.ts
@@ -1,5 +1,6 @@
-import { describe, it, expect } from 'vitest';
-import { resolvePeriod } from './usePeriod';
+import { describe, it, expect, beforeEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { resolvePeriod, usePeriod } from './usePeriod';
 
 describe('resolvePeriod', () => {
   it('this-month starts on the 1st, unbounded end', () => {
@@ -41,5 +42,96 @@ describe('resolvePeriod', () => {
     expect(to?.getDate()).toBe(20);
     expect(to?.getHours()).toBe(23);
     expect(to?.getMinutes()).toBe(59);
+  });
+});
+
+/**
+ * The rule these guard: a surface may suggest the window it is worth reading
+ * over, but the moment the user picks one themselves that choice wins — here,
+ * on the next report, and after a reload.
+ */
+describe('usePeriod defaults vs the user’s own choice', () => {
+  const KEY = 'testPeriod';
+
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it('starts on the surface’s default, unchosen', () => {
+    const { result } = renderHook(() => usePeriod(KEY, 'all'));
+
+    expect(result.current.period).toBe('all');
+    expect(result.current.isExplicit).toBe(false);
+    // Nothing was chosen, so nothing is remembered.
+    expect(localStorage.getItem(KEY)).toBeNull();
+  });
+
+  it('applies another surface’s default while nothing has been chosen', () => {
+    const { result } = renderHook(() => usePeriod(KEY));
+
+    act(() => result.current.applyDefaultPeriod('last-12-months'));
+
+    expect(result.current.period).toBe('last-12-months');
+    expect(result.current.isExplicit).toBe(false);
+  });
+
+  it('never overrides a choice the user made', () => {
+    const { result } = renderHook(() => usePeriod(KEY));
+
+    act(() => result.current.setPeriod('tax-year'));
+    expect(result.current.isExplicit).toBe(true);
+
+    act(() => result.current.applyDefaultPeriod('all'));
+
+    expect(result.current.period).toBe('tax-year');
+    expect(result.current.isExplicit).toBe(true);
+  });
+
+  it('remembers the choice across a remount, defaults do not', () => {
+    const first = renderHook(() => usePeriod(KEY, 'this-month'));
+    act(() => first.result.current.applyDefaultPeriod('all'));
+    first.unmount();
+
+    // A default is a suggestion, so the next surface's own default wins.
+    const second = renderHook(() => usePeriod(KEY, 'last-12-months'));
+    expect(second.result.current.period).toBe('last-12-months');
+    expect(second.result.current.isExplicit).toBe(false);
+
+    act(() => second.result.current.setPeriod('tax-year'));
+    second.unmount();
+
+    const third = renderHook(() => usePeriod(KEY, 'all'));
+    expect(third.result.current.period).toBe('tax-year');
+    expect(third.result.current.isExplicit).toBe(true);
+  });
+
+  it('treats a period stored before the flag existed as the user’s choice', () => {
+    // Older builds only ever wrote the key from the picker itself.
+    localStorage.setItem(KEY, 'last-month');
+
+    const { result } = renderHook(() => usePeriod(KEY, 'all'));
+
+    expect(result.current.period).toBe('last-month');
+    expect(result.current.isExplicit).toBe(true);
+  });
+
+  it('ignores a stored value that is not a period', () => {
+    localStorage.setItem(KEY, 'last-fortnight');
+
+    const { result } = renderHook(() => usePeriod(KEY, 'all'));
+
+    expect(result.current.period).toBe('all');
+    expect(result.current.isExplicit).toBe(false);
+  });
+
+  it('counts editing a custom range as choosing one', () => {
+    const { result } = renderHook(() => usePeriod(KEY));
+
+    act(() => result.current.setCustomStart('2026-01-10'));
+
+    expect(result.current.isExplicit).toBe(true);
+
+    act(() => result.current.applyDefaultPeriod('all'));
+    expect(result.current.period).toBe('this-month');
   });
 });

--- a/src/hooks/usePeriod.ts
+++ b/src/hooks/usePeriod.ts
@@ -79,34 +79,91 @@ export interface UsePeriodResult {
   range: PeriodRange;
   /** True when the date falls inside the current range (inclusive). */
   inRange: (date: Date | string) => boolean;
+  /**
+   * True when the current period is the user's own choice rather than a
+   * default this surface applied for them. A choice is never overridden.
+   */
+  isExplicit: boolean;
+  /**
+   * Ask for a surface's preferred period. Honoured only while the user has
+   * made no choice of their own, and never counts as a choice itself.
+   */
+  applyDefaultPeriod: (key: PeriodKey) => void;
+}
+
+/** Where the "the user picked this themselves" flag lives, per surface. */
+const explicitStorageKey = (storageKey: string): string => `${storageKey}Explicit`;
+
+/** Storage holds whatever an older build (or the user) put there. */
+const isPeriodKey = (value: string): value is PeriodKey => value in PERIOD_LABELS;
+
+interface PeriodSelection {
+  period: PeriodKey;
+  explicit: boolean;
+}
+
+function readStoredSelection(storageKey: string, defaultKey: PeriodKey): PeriodSelection {
+  const stored = localStorage.getItem(storageKey);
+  if (stored === null || !isPeriodKey(stored)) return { period: defaultKey, explicit: false };
+
+  // The flag postdates the period itself. Before it existed the picker was the
+  // only writer, so a stored period with no flag is a choice the user made
+  // under an older build and must be honoured.
+  const flag = localStorage.getItem(explicitStorageKey(storageKey));
+  if (flag === 'false') {
+    // Stored, but only ever as a default — the caller's current default wins,
+    // so a report's preferred window applies on first paint with no flicker.
+    return { period: defaultKey, explicit: false };
+  }
+  return { period: stored, explicit: true };
 }
 
 /**
  * Period selection persisted per surface (storageKey), defaulting to
  * this-month. All consumers get identical window semantics.
+ *
+ * `defaultKey` is read once, when the surface mounts. To change the default
+ * afterwards — as the reports hub does when a report with its own preferred
+ * window opens — call `applyDefaultPeriod`.
  */
 export function usePeriod(storageKey: string, defaultKey: PeriodKey = 'this-month'): UsePeriodResult {
-  const [period, setPeriodState] = useState<PeriodKey>(() => {
-    const stored = localStorage.getItem(storageKey);
-    return stored && stored in PERIOD_LABELS ? (stored as PeriodKey) : defaultKey;
-  });
+  const [selection, setSelection] = useState<PeriodSelection>(() => readStoredSelection(storageKey, defaultKey));
   const [customStart, setCustomStart] = useState<string>(() => localStorage.getItem(`${storageKey}CustomStart`) ?? '');
   const [customEnd, setCustomEnd] = useState<string>(() => localStorage.getItem(`${storageKey}CustomEnd`) ?? '');
+  const { period, explicit } = selection;
 
-  const setPeriod = useCallback((key: PeriodKey) => {
-    setPeriodState(key);
+  const persist = useCallback((key: PeriodKey, isExplicit: boolean) => {
     localStorage.setItem(storageKey, key);
+    localStorage.setItem(explicitStorageKey(storageKey), String(isExplicit));
   }, [storageKey]);
 
+  const setPeriod = useCallback((key: PeriodKey) => {
+    setSelection({ period: key, explicit: true });
+    persist(key, true);
+  }, [persist]);
+
+  const applyDefaultPeriod = useCallback((key: PeriodKey) => {
+    // A choice the user made outranks any surface's preference, and re-applying
+    // the window already showing would only churn the reports below it.
+    if (explicit || period === key) return;
+    setSelection({ period: key, explicit: false });
+    persist(key, false);
+  }, [explicit, period, persist]);
+
+  // Editing the bounds of a custom range is as deliberate as picking one.
   const setCustomStartPersisted = useCallback((v: string) => {
     setCustomStart(v);
     localStorage.setItem(`${storageKey}CustomStart`, v);
-  }, [storageKey]);
+    setSelection({ period, explicit: true });
+    persist(period, true);
+  }, [storageKey, persist, period]);
 
   const setCustomEndPersisted = useCallback((v: string) => {
     setCustomEnd(v);
     localStorage.setItem(`${storageKey}CustomEnd`, v);
-  }, [storageKey]);
+    setSelection({ period, explicit: true });
+    persist(period, true);
+  }, [storageKey, persist, period]);
 
   const range = useMemo(
     () => resolvePeriod(period, customStart, customEnd),
@@ -129,5 +186,7 @@ export function usePeriod(storageKey: string, defaultKey: PeriodKey = 'this-mont
     setCustomEnd: setCustomEndPersisted,
     range,
     inRange,
+    isExplicit: explicit,
+    applyDefaultPeriod,
   };
 }

--- a/src/hooks/usePeriod.ts
+++ b/src/hooks/usePeriod.ts
@@ -106,15 +106,23 @@ function readStoredSelection(storageKey: string, defaultKey: PeriodKey): PeriodS
   const stored = localStorage.getItem(storageKey);
   if (stored === null || !isPeriodKey(stored)) return { period: defaultKey, explicit: false };
 
-  // The flag postdates the period itself. Before it existed the picker was the
-  // only writer, so a stored period with no flag is a choice the user made
-  // under an older build and must be honoured.
+  // Only a value this build flagged is a choice this build can trust.
+  //
+  // The flag postdates the period itself, and it is tempting to reason that an
+  // older build wrote the key only from the picker, so an unflagged value must
+  // be a deliberate choice. That is true about where the value came from and
+  // wrong about what it meant: it was chosen for ONE tabbed reports page, and
+  // reading it as a standing instruction makes it outrank the preferred window
+  // of eight reports that did not exist when it was set — so every returning
+  // user opens "Net worth over time" on last month's dot, permanently, and the
+  // preference never gets a chance to apply. Found by opening the page; the
+  // tests could not see it, because they start from an empty localStorage.
+  //
+  // So an unflagged value is treated as a default, not a decision: the report's
+  // window applies, and the next period the user picks is flagged and honoured
+  // for good. The cost is one reset, once, for someone who had chosen before.
   const flag = localStorage.getItem(explicitStorageKey(storageKey));
-  if (flag === 'false') {
-    // Stored, but only ever as a default — the caller's current default wins,
-    // so a report's preferred window applies on first paint with no flicker.
-    return { period: defaultKey, explicit: false };
-  }
+  if (flag !== 'true') return { period: defaultKey, explicit: false };
   return { period: stored, explicit: true };
 }
 

--- a/src/hooks/useReportAccountFilter.ts
+++ b/src/hooks/useReportAccountFilter.ts
@@ -1,0 +1,27 @@
+import { useCallback, useState } from 'react';
+
+const STORAGE_KEY = 'reportsAccountFilter';
+
+export interface ReportAccountFilter {
+  /** An account id, or 'all'. */
+  accountId: string;
+  setAccountId: (id: string) => void;
+}
+
+/**
+ * The reports' account filter, persisted like the shared period — so moving
+ * between reports in the gallery keeps BOTH halves of the question ("which
+ * money, over what window") rather than silently resetting one of them.
+ */
+export function useReportAccountFilter(): ReportAccountFilter {
+  const [accountId, setAccountIdState] = useState<string>(
+    () => localStorage.getItem(STORAGE_KEY) ?? 'all'
+  );
+
+  const setAccountId = useCallback((id: string) => {
+    setAccountIdState(id);
+    localStorage.setItem(STORAGE_KEY, id);
+  }, []);
+
+  return { accountId, setAccountId };
+}

--- a/src/hooks/useReportDataset.ts
+++ b/src/hooks/useReportDataset.ts
@@ -1,0 +1,59 @@
+import { useMemo } from 'react';
+import { useApp } from '../contexts/AppContextSupabase';
+import { computeIncomeExpense, type IncomeExpenseBreakdown } from '../utils/incomeExpense';
+import { expandSplitTransactions, type SplitExpandedTransaction } from '../utils/transactionSplits';
+import type { UsePeriodResult } from './usePeriod';
+import type { Account, Category, Transaction, TransactionSplit } from '../types';
+
+/**
+ * The dataset every spending report reads: the selected period and account
+ * filter applied once, split transactions expanded once, and the shared
+ * income/expense classification run once.
+ *
+ * One hook means the gallery's reports cannot disagree with each other or
+ * with the Dashboard — they are all looking at the same rows, classified by
+ * `utils/incomeExpense` (category semantics; transfers and uncategorised rows
+ * excluded from every total).
+ */
+export interface ReportDataset {
+  accounts: Account[];
+  categories: Category[];
+  /** Unfiltered, unexpanded — for editors that need the real record. */
+  allTransactions: Transaction[];
+  /** Account-filtered but NOT period-filtered — for other-window maths. */
+  accountTransactions: Transaction[];
+  transactionSplits: TransactionSplit[];
+  /** Period- and account-filtered, split-expanded. */
+  rows: SplitExpandedTransaction[];
+  flows: IncomeExpenseBreakdown;
+}
+
+export function useReportDataset(picker: UsePeriodResult, accountId: string): ReportDataset {
+  const { transactions, transactionSplits, accounts, categories } = useApp();
+  const { inRange } = picker;
+
+  const accountTransactions = useMemo(
+    () => (accountId === 'all' ? transactions : transactions.filter(t => t.accountId === accountId)),
+    [transactions, accountId]
+  );
+
+  // Split parents become one row per line so each line's value lands in ITS
+  // category — the same view every other reporting surface uses.
+  const rows = useMemo(
+    () => expandSplitTransactions(accountTransactions, transactionSplits).filter(t => inRange(t.date)),
+    [accountTransactions, transactionSplits, inRange]
+  );
+
+  // Already expanded, so splits are passed empty — no double expansion.
+  const flows = useMemo(() => computeIncomeExpense(rows, [], categories), [rows, categories]);
+
+  return {
+    accounts,
+    categories,
+    allTransactions: transactions,
+    accountTransactions,
+    transactionSplits,
+    rows,
+    flows,
+  };
+}

--- a/src/lib/zodConfig.ts
+++ b/src/lib/zodConfig.ts
@@ -1,0 +1,19 @@
+import { z } from 'zod';
+
+/**
+ * Zod v4 probes for `new Function("")` on first use, to decide whether it can
+ * JIT-compile object validators. Our CSP forbids eval, so the probe throws,
+ * zod catches it and falls back to the interpreted path — correct, but it
+ * spends a CSP violation (a red console error, and a Sentry report) on every
+ * load to learn something the policy already decided.
+ *
+ * `jitless` short-circuits that: `jit && allowsEval.value` never evaluates the
+ * cached probe, so the eval never happens. Runtime behaviour is unchanged —
+ * the JIT path was already unreachable under the policy — we simply stop
+ * asking.
+ *
+ * MUST be imported before any module that creates a schema: zod reads this
+ * config when a schema's parser is built, which happens at module scope in
+ * several services.
+ */
+z.config({ jitless: true });

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,3 +1,6 @@
+// FIRST import: configures zod before any module-scope schema is built.
+// See the file for why (it removes a per-load CSP violation).
+import './lib/zodConfig'
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import { ClerkProvider } from '@clerk/clerk-react'

--- a/src/pages/NetWorthReport.tsx
+++ b/src/pages/NetWorthReport.tsx
@@ -13,14 +13,13 @@ import {
 } from 'recharts';
 import { useApp } from '../contexts/AppContextSupabase';
 import { useCurrencyDecimal } from '../hooks/useCurrencyDecimal';
-import { usePeriod } from '../hooks/usePeriod';
-import PeriodPicker from '../components/PeriodPicker';
 import { Modal, ModalBody } from '../components/common/Modal';
 import { toDecimal } from '../utils/decimal';
 import { formatDecimal } from '../utils/decimal-format';
 import { preserveDemoParam } from '../utils/navigation';
 import { buildNetWorthSnapshots } from '../utils/netWorthSeries';
-import { CalendarIcon, TrendingUpIcon, ChevronRightIcon } from '../components/icons';
+import { TrendingUpIcon, ChevronRightIcon } from '../components/icons';
+import type { ReportViewProps } from './reports/types';
 
 /**
  * Net worth over time — the Microsoft Money report, rebuilt on real data.
@@ -43,12 +42,11 @@ const compactTick = (value: number): string => {
   return formatDecimal(value, 0);
 };
 
-export default function NetWorthReport(): React.JSX.Element {
+export default function NetWorthReport({ picker }: ReportViewProps): React.JSX.Element {
   const { accounts, transactions } = useApp();
   const { formatCurrency } = useCurrencyDecimal();
   const navigate = useNavigate();
   const location = useLocation();
-  const picker = usePeriod('netWorthPeriod', 'last-12-months');
   const [drillDate, setDrillDate] = useState<Date | null>(null);
   // Line or bar presentation — same data, same drill-in; persisted.
   const [chartType, setChartType] = useState<'line' | 'bar'>(() =>
@@ -106,14 +104,7 @@ export default function NetWorthReport(): React.JSX.Element {
 
   return (
     <div className="max-w-[1400px] mx-auto">
-      {/* Period picker */}
-      <div className="bg-white dark:bg-gray-800 rounded-2xl shadow-lg border border-gray-100 dark:border-gray-700 p-4 mb-6">
-        <div className="flex items-center gap-2">
-          <CalendarIcon className="text-gray-500" size={20} />
-          <PeriodPicker picker={picker} />
-        </div>
-      </div>
-
+      {/* The period comes from the hub, so it persists between reports. */}
       {/* Headline */}
       <div className="grid grid-cols-1 md:grid-cols-3 gap-4 mb-6">
         <div className="bg-[#1a2332] dark:bg-gray-700 rounded-2xl p-6 text-white">

--- a/src/pages/Reports.tsx
+++ b/src/pages/Reports.tsx
@@ -417,10 +417,6 @@ export default function Reports() {
           </button>
         )}
 
-        {/* The Money-style monthly matrix — the report Steve lives in, so it
-            sits directly under the headline figures it adds up to. */}
-        <MonthlyIncomeExpenseMatrix matrix={matrix} onDrill={handleMatrixDrill} />
-
         {/* Charts */}
         <div className="pt-4">
           <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
@@ -604,6 +600,10 @@ export default function Reports() {
         </div>
         </div>
         </div>
+
+        {/* The Money-style monthly matrix — the detailed read, so it sits at the
+            bottom under the summary tables and charts rather than ahead of them. */}
+        <MonthlyIncomeExpenseMatrix matrix={matrix} onDrill={handleMatrixDrill} />
       </div>
 
       {/* Income/Expense breakdown — the shared component (category sections,

--- a/src/pages/Reports.tsx
+++ b/src/pages/Reports.tsx
@@ -1,75 +1,41 @@
-import { useState, useMemo, useRef, useEffect } from 'react';
-import { useApp } from '../contexts/AppContextSupabase';
-import { PieChartIcon, TrendingUpIcon, CalendarIcon, DownloadIcon, FilterIcon, PdfIcon, ChevronDownIcon, ChevronUpIcon } from '../components/icons';
-import { exportTransactionsToCSV, downloadCSV } from '../utils/csvExport';
-import { generatePDFReport, generateSimplePDFReport } from '../utils/pdfExport';
-import { SkeletonCard, SkeletonText } from '../components/loading/Skeleton';
-import {
-  ResponsiveContainer,
-  LineChart as RechartsLineChart,
-  Line,
-  XAxis,
-  YAxis,
-  CartesianGrid,
-  Tooltip,
-  Legend,
-  PieChart as RechartsPieChart,
-  Pie,
-  Cell
-} from 'recharts';
+import React, { useMemo, useState } from 'react';
+import { ChevronDownIcon, ChevronUpIcon } from '../components/icons';
 import { useCurrencyDecimal } from '../hooks/useCurrencyDecimal';
-import { toDecimal, DecimalInstance } from '../utils/decimal';
-import { formatDecimal } from '../utils/decimal-format';
-import { computeExpenseCategoryNetTotals } from '../utils/categoryNetting';
-import { buildMonthlyTrend } from '../utils/monthlyTrend';
-import { computeIncomeExpense } from '../utils/incomeExpense';
+import { useReportDataset } from '../hooks/useReportDataset';
+import { useReportAccountFilter } from '../hooks/useReportAccountFilter';
+import ReportAccountFilter from '../components/reports/ReportAccountFilter';
+import ReportDrillModal, { type ReportDrillTarget } from '../components/reports/ReportDrillModal';
+import ReportExportBar from '../components/reports/ReportExportBar';
+import IncomeExpenseSummaryCards from '../components/reports/IncomeExpenseSummaryCards';
+import UncategorisedReviewBand from '../components/reports/UncategorisedReviewBand';
+import MonthlyIncomeExpenseMatrix, { type MatrixDrillTarget } from '../components/MonthlyIncomeExpenseMatrix';
+import EditTransactionModal from '../components/EditTransactionModal';
 import { buildMonthlyCategoryMatrix, monthKeyOf } from '../utils/monthlyCategoryMatrix';
 import { buildCategoryNameLookup } from '../utils/categoryNames';
-import { usePeriod, PERIOD_LABELS } from '../hooks/usePeriod';
-import PeriodPicker from '../components/PeriodPicker';
-import EditTransactionModal from '../components/EditTransactionModal';
-import IncomeExpenseBreakdownModal from '../components/IncomeExpenseBreakdownModal';
-import MonthlyIncomeExpenseMatrix, { type MatrixDrillTarget } from '../components/MonthlyIncomeExpenseMatrix';
-import TransferSweepModal from '../components/TransferSweepModal';
-import BulkCategorizeModal from '../components/BulkCategorizeModal';
-import { expandSplitTransactions } from '../utils/transactionSplits';
-import { createScopedLogger } from '../loggers/scopedLogger';
+import { PERIOD_LABELS } from '../hooks/usePeriod';
+import type { ReportViewProps } from './reports/types';
 
-const reportsLogger = createScopedLogger('ReportsPage');
-
-const CATEGORY_COLORS = [
-  '#3B82F6', '#10B981', '#F59E0B', '#EF4444',
-  '#8B5CF6', '#EC4899', '#6366F1', '#14B8A6'
-];
-
-export default function Reports() {
-  const { transactions: rawTransactions, transactionSplits, accounts, categories } = useApp();
-  // Reports work on the split-EXPANDED view (like every other reporting
-  // surface): a split parent becomes one row per line, so each line's spend
-  // lands in ITS category — the pie and summary would otherwise drop split
-  // lines into the uncategorised fallback.
-  const transactions = useMemo(
-    () => expandSplitTransactions(rawTransactions, transactionSplits),
-    [rawTransactions, transactionSplits]
-  );
-  // The shared reporting period (same windows and meanings everywhere).
-  const picker = usePeriod('reportsPeriod');
-  const [selectedAccount, setSelectedAccount] = useState<string>('all');
-  const [isGeneratingPDF, setIsGeneratingPDF] = useState(false);
-  const [breakdownType, setBreakdownType] = useState<'income' | 'expense' | 'uncategorized' | null>(null);
-  // Chart drill-in: a clicked trend point (one series, one month) or pie
-  // slice (one category) opens the same breakdown modal, scoped to it.
-  const [chartDrill, setChartDrill] = useState<{
-    title: string;
-    bucket: 'income' | 'expense';
-    rows: typeof transactions;
-    total: number;
-  } | null>(null);
-  const [editingBreakdownTxnId, setEditingBreakdownTxnId] = useState<string | null>(null);
-  const [showTransferSweep, setShowTransferSweep] = useState(false);
-  const [showBulkCategorize, setShowBulkCategorize] = useState(false);
-  // Top Transactions is a curiosity next to the monthly matrix, so it starts
-  // hidden; the choice is persisted like the page's other view preferences.
+/**
+ * "Monthly income and expenses" — the Microsoft Money report, and the
+ * gallery's detailed read: every category down the side, the months of the
+ * selected period across the top, with the four headline figures above it.
+ *
+ * The summary cards, the matrix and the review band are all built from ONE
+ * classification pass (utils/incomeExpense via useReportDataset), so they
+ * cannot disagree with each other or with any other report in the gallery.
+ *
+ * The trend chart and the category pie that used to share this page are now
+ * reports of their own in the gallery ("Income and spending over time",
+ * "Spending by category").
+ */
+export default function Reports({ picker }: ReportViewProps): React.JSX.Element {
+  const filter = useReportAccountFilter();
+  const { accounts, categories, rows, flows, allTransactions } = useReportDataset(picker, filter.accountId);
+  const { formatCurrency } = useCurrencyDecimal();
+  const [drill, setDrill] = useState<ReportDrillTarget | null>(null);
+  const [editingId, setEditingId] = useState<string | null>(null);
+  // Top Transactions is a curiosity next to the matrix, so it starts hidden;
+  // the choice is persisted like the report's other view preferences.
   const [showTopTransactions, setShowTopTransactions] = useState<boolean>(
     () => localStorage.getItem('reportsShowTopTransactions') === '1'
   );
@@ -79,55 +45,16 @@ export default function Reports() {
       return !prev;
     });
   };
-  const [isLoading, setIsLoading] = useState(true);
-  const chartRef1 = useRef<HTMLDivElement>(null);
-  const chartRef2 = useRef<HTMLDivElement>(null);
-  const { formatCurrency } = useCurrencyDecimal();
-
-  // Filter transactions to the shared period + account
-  const filteredTransactions = useMemo(
-    () => transactions.filter(t =>
-      picker.inRange(t.date) &&
-      (selectedAccount === 'all' || t.accountId === selectedAccount)
-    ),
-    [transactions, picker, selectedAccount]
-  );
-
-  // Calculate summary statistics — CATEGORY semantics via the shared
-  // classifier (utils/incomeExpense), so a refund filed under an expense
-  // category reduces Expenses here rather than inflating Income. The rows
-  // ride along to power the click-through breakdown. filteredTransactions is
-  // already split-expanded, so splits are passed empty (no double expansion).
-  const flows = useMemo(
-    () => computeIncomeExpense(filteredTransactions, [], categories),
-    [filteredTransactions, categories]
-  );
-
-  const summary = useMemo(() => {
-    const netIncomeDecimal = flows.income.minus(flows.expenses);
-    const savingsRateDecimal = flows.income.gt(0)
-      ? netIncomeDecimal.dividedBy(flows.income).times(100)
-      : toDecimal(0);
-
-    return {
-      income: flows.income.toNumber(),
-      expenses: flows.expenses.toNumber(),
-      netIncome: netIncomeDecimal.toNumber(),
-      savingsRate: savingsRateDecimal.toNumber(),
-    };
-  }, [flows]);
 
   // Category ids are UUIDs — everything user-facing resolves through this
   // lookup ("Parent : Child", "Uncategorised" for a dangling id).
   const categoryName = useMemo(() => buildCategoryNameLookup(categories), [categories]);
 
-  // Biggest movements in the period. A COPY: sorting filteredTransactions in
-  // place would mutate the memoised array on every render.
+  // Biggest movements in the period. A COPY: sorting `rows` in place would
+  // mutate the memoised array on every render.
   const topTransactions = useMemo(
-    () => [...filteredTransactions]
-      .sort((a, b) => Math.abs(b.amount) - Math.abs(a.amount))
-      .slice(0, 10),
-    [filteredTransactions]
+    () => [...rows].sort((a, b) => Math.abs(b.amount) - Math.abs(a.amount)).slice(0, 10),
+    [rows]
   );
 
   // The Money-style category × month matrix, built from the SAME classified
@@ -140,7 +67,7 @@ export default function Reports() {
   const handleMatrixDrill = (target: MatrixDrillTarget): void => {
     const source = target.bucket === 'income' ? flows.incomeRows : flows.expenseRows;
     const ids = target.categoryIds ? new Set(target.categoryIds) : null;
-    setChartDrill({
+    setDrill({
       title: target.label,
       bucket: target.bucket,
       rows: source.filter(t =>
@@ -151,380 +78,30 @@ export default function Reports() {
     });
   };
 
-  const formatPercentage = (value: DecimalInstance | number, decimals: number = 1) => {
-    return formatDecimal(value, decimals);
-  };
-
-  const savingsRateDecimal = toDecimal(summary.savingsRate ?? 0);
-  const savingsRateValue = savingsRateDecimal.toNumber();
-  const savingsRateDisplay = formatPercentage(savingsRateDecimal, 1);
-
-  // Set loading to false when data is loaded
-  useEffect(() => {
-    if (transactions !== undefined && accounts !== undefined) {
-      setIsLoading(false);
-    }
-  }, [transactions, accounts]);
-
-  // Prepare data for category breakdown. Money-style netting: bucket by the
-  // CATEGORY's direction and net signed amounts, so a refund filed under an
-  // expense category reduces that category instead of inflating income —
-  // and slice labels show category NAMES, never raw ids.
-  // The category id rides along so a clicked slice can list its own
-  // transactions — as `categoryId`, NOT `key`: recharts spreads datum fields
-  // onto React elements, and a `key` field collides with React's reserved
-  // prop and silently breaks sector rendering. Re-mapped to plain literals
-  // because recharts' data prop needs index-signature rows.
-  const categoryData = useMemo(
-    () => computeExpenseCategoryNetTotals(filteredTransactions, categories)
-      .slice(0, 8)
-      .map(({ key, name, value }) => ({ categoryId: key, name, value })),
-    [filteredTransactions, categories]
-  );
-
-  const drillIntoCategory = (key: string, name: string, value: number): void => {
-    setChartDrill({
-      title: `${name} — Expenses`,
-      bucket: 'expense',
-      rows: flows.expenseRows.filter(t => t.category === key),
-      total: value,
-    });
-  };
-
-  const drillIntoMonth = (monthKey: string, label: string, bucket: 'income' | 'expense', total: number): void => {
-    const source = bucket === 'income' ? flows.incomeRows : flows.expenseRows;
-    setChartDrill({
-      title: `${bucket === 'income' ? 'Income' : 'Expenses'} — ${label}`,
-      bucket,
-      rows: source.filter(t => new Date(t.date).toISOString().slice(0, 7) === monthKey),
-      total,
-    });
-  };
-
-  // recharts calls activeDot onClick with (props, event) — but the argument
-  // order has differed across versions, so scan for whichever carries the
-  // datum payload.
-  const handleTrendDotClick = (series: 'income' | 'expenses') =>
-    (...args: unknown[]): void => {
-      for (const arg of args) {
-        const payload = (arg as { payload?: { monthKey?: string; month?: string; income?: number; expenses?: number } } | null)?.payload;
-        if (payload?.monthKey && payload.month) {
-          const bucket = series === 'income' ? 'income' : 'expense';
-          drillIntoMonth(payload.monthKey, payload.month, bucket, payload[series] ?? 0);
-          return;
-        }
-      }
-    };
-
-  // Monthly trend via the shared builder (also drives the Dashboard's pinned
-  // trend widget — one implementation, no drift).
-  const monthlyTrendData = useMemo(
-    () => buildMonthlyTrend(filteredTransactions, categories),
-    [filteredTransactions, categories]
-  );
-
-  const exportToCSV = () => {
-    // categories resolve the Category column to a name — a UUID in a
-    // spreadsheet is worthless.
-    const csv = exportTransactionsToCSV(filteredTransactions, accounts, categories);
-    const filename = `financial-report-${new Date().toISOString().split('T')[0]}.csv`;
-    downloadCSV(csv, filename);
-  };
-
-  const exportToPDF = async (includeCharts: boolean = true) => {
-    setIsGeneratingPDF(true);
-    try {
-      // Prepare category breakdown data (same Money-style netting as the pie).
-      const netTotals = computeExpenseCategoryNetTotals(filteredTransactions, categories);
-      const totalExpensesDecimal = netTotals.reduce(
-        (sum, entry) => sum.plus(toDecimal(entry.value)),
-        toDecimal(0)
-      );
-
-      const categoryBreakdown = netTotals.map(({ name, value }) => ({
-        category: name,
-        amount: value,
-        percentage: totalExpensesDecimal.gt(0)
-          ? toDecimal(value).dividedBy(totalExpensesDecimal).times(100).toNumber()
-          : 0
-      }));
-
-      const reportData = {
-        title: 'Financial Report',
-        dateRange: PERIOD_LABELS[picker.period],
-        summary,
-        categoryBreakdown,
-        // categoryLabel: the PDF prints names, never category ids.
-        topTransactions: topTransactions.map(t => ({ ...t, categoryLabel: categoryName(t.category) })),
-        chartElements: includeCharts && chartRef1.current && chartRef2.current
-          ? [chartRef1.current, chartRef2.current]
-          : undefined
-      };
-
-      if (includeCharts) {
-        await generatePDFReport(reportData, accounts);
-      } else {
-        generateSimplePDFReport(reportData, accounts);
-      }
-    } catch (error) {
-      reportsLogger.error('Error generating PDF', error);
-      alert('Failed to generate PDF report. Please try again.');
-    } finally {
-      setIsGeneratingPDF(false);
-    }
-  };
-
   return (
-    <div>
-      <div className="flex justify-between items-center mb-6">
-        <div className="bg-secondary dark:bg-gray-700 rounded-2xl shadow p-4">
-          <h1 className="text-3xl font-bold text-white">Reports</h1>
-        </div>
-        <div className="flex gap-2">
-          <button
-            onClick={exportToCSV}
-            className="flex items-center gap-2 px-4 py-2 bg-[#1a2332] text-white rounded-2xl hover:bg-secondary transition-colors"
-          >
-            <DownloadIcon size={20} />
-            Export CSV
-          </button>
-          <button
-            onClick={() => exportToPDF(true)}
-            disabled={isGeneratingPDF}
-            className="flex items-center gap-2 px-4 py-2 bg-red-600 text-white rounded-2xl hover:bg-red-700 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
-          >
-            <PdfIcon size={20} />
-            {isGeneratingPDF ? 'Generating...' : 'Export PDF'}
-          </button>
-        </div>
+    <div className="max-w-[1400px] mx-auto space-y-6">
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <ReportAccountFilter accounts={accounts} filter={filter} />
+        <ReportExportBar
+          title="Monthly income and expenses"
+          dateRange={PERIOD_LABELS[picker.period]}
+          rows={rows}
+          flows={flows}
+          categories={categories}
+          accounts={accounts}
+        />
       </div>
 
-      {/* Filters — the shared period picker + account filter */}
-      <div className="bg-white dark:bg-gray-800 rounded-2xl shadow-lg border border-gray-100 dark:border-gray-700 p-4 mb-6">
-        <div className="flex flex-wrap gap-4 items-center">
-          <div className="flex items-center gap-2">
-            <CalendarIcon className="text-gray-500" size={20} />
-            <PeriodPicker picker={picker} />
-          </div>
+      <IncomeExpenseSummaryCards flows={flows} categories={categories} />
 
-          <div className="flex items-center gap-2">
-            <FilterIcon className="text-gray-500" size={20} />
-            <select
-              aria-label="Account filter"
-              value={selectedAccount}
-              onChange={(e) => setSelectedAccount(e.target.value)}
-              className="px-3 py-2 bg-white dark:bg-gray-800-sm border border-gray-300/50 dark:border-gray-600/50 rounded-xl focus:outline-none focus:ring-2 focus:ring-primary focus:border-transparent dark:text-white"
-            >
-              <option value="all">All Accounts</option>
-              {accounts.map(account => (
-                <option key={account.id} value={account.id}>{account.name}</option>
-              ))}
-            </select>
-          </div>
-        </div>
-      </div>
+      {/* Rows with no category are EXCLUDED from every figure above — said out
+          loud, with the three ways to clear them. */}
+      <UncategorisedReviewBand flows={flows} categories={categories} />
 
-      {/* Main content grid with consistent spacing */}
-      <div className="grid gap-6">
-        {/* Summary Cards */}
-        <div className="grid grid-cols-1 md:grid-cols-4 gap-4">
-        {/* flex-col: buttons lay children out in a ROW by default, which put
-            the figure beside the label — every stat card stacks label OVER
-            figure, matching the Dashboard. */}
-        <button
-          type="button"
-          onClick={() => setBreakdownType('income')}
-          className="flex flex-col items-start bg-white dark:bg-gray-800 rounded-2xl shadow-lg border border-gray-100 dark:border-gray-700 p-6 text-left cursor-pointer hover:bg-green-50 dark:hover:bg-green-900/10 transition-colors"
-        >
-          <p className="text-sm text-gray-600 dark:text-gray-400 mb-1">Total Income</p>
-          {/* div, not p: the loading skeleton renders block elements and a
-              <div> inside <p> is invalid DOM nesting */}
-          <div className="text-2xl font-bold text-green-700 dark:text-green-400">
-            {isLoading ? <SkeletonText className="w-32 h-8" /> : formatCurrency(summary.income)}
-          </div>
-        </button>
+      {/* The detailed read. */}
+      <MonthlyIncomeExpenseMatrix matrix={matrix} onDrill={handleMatrixDrill} />
 
-        <button
-          type="button"
-          onClick={() => setBreakdownType('expense')}
-          className="flex flex-col items-start bg-white dark:bg-gray-800 rounded-2xl shadow-lg border border-gray-100 dark:border-gray-700 p-6 text-left cursor-pointer hover:bg-red-50 dark:hover:bg-red-900/10 transition-colors"
-        >
-          <p className="text-sm text-gray-600 dark:text-gray-400 mb-1">Total Expenses</p>
-          <div className="text-2xl font-bold text-red-600 dark:text-red-400">
-            {isLoading ? <SkeletonText className="w-32 h-8" /> : formatCurrency(summary.expenses)}
-          </div>
-        </button>
-
-        <div className="bg-white dark:bg-gray-800 rounded-2xl shadow-lg border border-gray-100 dark:border-gray-700 p-6">
-          <p className="text-sm text-gray-600 dark:text-gray-400 mb-1">Net Income</p>
-          <div className={`text-2xl font-bold ${
-            summary.netIncome >= 0 ? 'text-green-700 dark:text-green-400' : 'text-red-600 dark:text-red-400'
-          }`}>
-            {isLoading ? <SkeletonText className="w-32 h-8" /> : formatCurrency(summary.netIncome)}
-          </div>
-        </div>
-
-        <div className="bg-white dark:bg-gray-800 rounded-2xl shadow-lg border border-gray-100 dark:border-gray-700 p-6">
-          <p className="text-sm text-gray-600 dark:text-gray-400 mb-1">Savings Rate</p>
-          <div className={`text-2xl font-bold ${
-            savingsRateValue >= 20 ? 'text-green-700 dark:text-green-400' : 'text-yellow-700 dark:text-yellow-400'
-          }`}>
-            {isLoading ? <SkeletonText className="w-20 h-8" /> : `${savingsRateDisplay}%`}
-          </div>
-        </div>
-        </div>
-
-        {/* Uncategorised review band — these rows are EXCLUDED from every
-            total above (no category = not income, not an expense). Shown so
-            the data gets cleaned rather than silently miscounted. */}
-        {flows.uncategorizedRows.length > 0 && (
-          <button
-            type="button"
-            onClick={() => setBreakdownType('uncategorized')}
-            className="w-full flex flex-wrap items-center gap-x-4 gap-y-1 rounded-2xl border border-amber-300 dark:border-amber-600 bg-amber-50 dark:bg-amber-900/20 px-5 py-3 text-left hover:bg-amber-100 dark:hover:bg-amber-900/30 transition-colors"
-          >
-            <span className="text-sm font-semibold text-amber-800 dark:text-amber-300">
-              {flows.uncategorizedRows.length.toLocaleString()} uncategorised transaction{flows.uncategorizedRows.length === 1 ? '' : 's'} excluded from these totals
-            </span>
-            <span className="text-sm text-amber-700 dark:text-amber-400 tabular-nums">
-              {formatCurrency(flows.uncategorizedIn.toNumber())} in · {formatCurrency(flows.uncategorizedOut.toNumber())} out
-            </span>
-            <span className="ml-auto text-xs text-amber-700 dark:text-amber-400">
-              Click to review and categorise
-            </span>
-          </button>
-        )}
-
-        {/* Bulk transfer matching — the biggest single cause of uncategorised
-            rows is bank-feed transfer legs that were never linked. */}
-        {flows.uncategorizedRows.length > 0 && (
-          <button
-            type="button"
-            onClick={() => setShowTransferSweep(true)}
-            className="text-sm text-blue-700 dark:text-blue-400 hover:underline text-left"
-          >
-            Or match transfers automatically — find equal-and-opposite pairs and link them in one go
-          </button>
-        )}
-
-        {flows.uncategorizedRows.length > 0 && (
-          <button
-            type="button"
-            onClick={() => setShowBulkCategorize(true)}
-            className="text-sm text-blue-700 dark:text-blue-400 hover:underline text-left"
-          >
-            Or categorise by payee — file a whole merchant at once and teach future imports
-          </button>
-        )}
-
-        {/* Charts */}
-        <div className="pt-4">
-          <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
-        {/* Monthly Trend */}
-        <div className="bg-white dark:bg-gray-800 rounded-2xl shadow-lg border border-gray-100 dark:border-gray-700 p-6">
-          <h2 className="text-lg font-semibold mb-4 flex items-center gap-2 text-theme-heading dark:text-white">
-            <TrendingUpIcon size={20} />
-            Income vs Expenses Trend
-          </h2>
-          <div className="h-64" ref={chartRef1}>
-            {isLoading ? (
-              <SkeletonCard className="h-full w-full" />
-            ) : (
-              <ResponsiveContainer width="100%" height="100%">
-                <RechartsLineChart data={monthlyTrendData}>
-                  <CartesianGrid strokeDasharray="3 3" stroke="rgba(55, 65, 81, 0.3)" />
-                  <XAxis dataKey="month" tick={{ fill: '#6B7280', fontSize: 12 }} />
-                  <YAxis
-                    tick={{ fill: '#6B7280', fontSize: 12 }}
-                    tickFormatter={(value: number) => {
-                      if (value >= 1_000_000) return `${formatDecimal(value / 1_000_000, 1)}M`;
-                      if (value >= 1_000) return `${formatDecimal(value / 1_000, 0)}K`;
-                      return formatDecimal(value, 0);
-                    }}
-                  />
-                  <Tooltip
-                    formatter={(value: number | string | Array<number | string>) =>
-                      formatCurrency(typeof value === 'number' ? value : Number(value))
-                    }
-                  />
-                  <Legend />
-                  {/* Hover shows the active dot; clicking it opens that
-                      month's transactions for THAT series. The handler scans
-                      its args for the datum because recharts' activeDot
-                      onClick argument order differs across versions. */}
-                  <Line
-                    type="monotone"
-                    dataKey="income"
-                    name="Income"
-                    stroke="#10B981"
-                    strokeWidth={2}
-                    dot={false}
-                    isAnimationActive={false}
-                    activeDot={{ r: 6, cursor: 'pointer', onClick: handleTrendDotClick('income') }}
-                  />
-                  <Line
-                    type="monotone"
-                    dataKey="expenses"
-                    name="Expenses"
-                    stroke="#EF4444"
-                    strokeWidth={2}
-                    dot={false}
-                    isAnimationActive={false}
-                    activeDot={{ r: 6, cursor: 'pointer', onClick: handleTrendDotClick('expenses') }}
-                  />
-                </RechartsLineChart>
-              </ResponsiveContainer>
-            )}
-          </div>
-        </div>
-
-        {/* Category Breakdown */}
-        <div className="bg-white dark:bg-gray-800 rounded-2xl shadow-lg border border-gray-100 dark:border-gray-700 p-6">
-          <h2 className="text-lg font-semibold mb-4 flex items-center gap-2 text-theme-heading dark:text-white">
-            <PieChartIcon size={20} />
-            Expense Categories
-          </h2>
-          <div className="h-64" ref={chartRef2}>
-            {isLoading ? (
-              <SkeletonCard className="h-full w-full" />
-            ) : (
-              <ResponsiveContainer width="100%" height="100%">
-                <RechartsPieChart>
-                  {/* Click a slice to open that category's transactions */}
-                  <Pie
-                    data={categoryData}
-                    dataKey="value"
-                    nameKey="name"
-                    innerRadius="55%"
-                    outerRadius="85%"
-                    strokeWidth={0}
-                    isAnimationActive={false}
-                    onClick={(entry) => {
-                      const datum = ((entry as { payload?: typeof categoryData[number] })?.payload ?? entry) as typeof categoryData[number];
-                      if (datum?.categoryId) drillIntoCategory(datum.categoryId, datum.name, datum.value);
-                    }}
-                  >
-                    {categoryData.map((entry, index) => (
-                      <Cell key={entry.name} fill={CATEGORY_COLORS[index % CATEGORY_COLORS.length]} />
-                    ))}
-                  </Pie>
-                  <Tooltip
-                    formatter={(value: number | string | Array<number | string>) =>
-                      formatCurrency(typeof value === 'number' ? value : Number(value))
-                    }
-                  />
-                  <Legend layout="vertical" align="right" verticalAlign="middle" />
-                </RechartsPieChart>
-              </ResponsiveContainer>
-            )}
-          </div>
-        </div>
-        </div>
-        </div>
-
-        {/* Top Transactions — collapsed by default (the matrix above is the
-            report that matters); the choice is persisted. */}
-        <div className="bg-white dark:bg-gray-800 rounded-2xl shadow-lg border border-gray-100 dark:border-gray-700">
+      <div className="bg-white dark:bg-gray-800 rounded-2xl shadow-lg border border-gray-100 dark:border-gray-700">
         <div className={`flex items-center justify-between gap-4 p-6 ${showTopTransactions ? 'border-b border-gray-200 dark:border-gray-700' : ''}`}>
           <h2 className="text-lg font-semibold text-theme-heading dark:text-white">Top Transactions</h2>
           <button
@@ -539,21 +116,28 @@ export default function Reports() {
           </button>
         </div>
         <div id="top-transactions-panel" hidden={!showTopTransactions}>
-        {/* Mobile card view */}
-        <div className="block sm:hidden">
-          <div className="space-y-3">
-            {topTransactions.map((transaction) => (
+          {/* Mobile card view */}
+          <div className="block sm:hidden p-4">
+            <div className="space-y-3">
+              {topTransactions.map(transaction => (
                 <div key={transaction.id} className="bg-gray-50 dark:bg-gray-700/50 rounded-lg p-4 space-y-2">
                   <div className="flex justify-between items-start">
                     <div className="flex-1">
-                      <p className="font-medium text-gray-900 dark:text-white">{transaction.description}</p>
+                      <button
+                        type="button"
+                        onClick={() => setEditingId(transaction.splitParentId ?? transaction.id)}
+                        className="font-medium text-left text-gray-900 dark:text-white hover:text-blue-700 dark:hover:text-blue-400 hover:underline rounded focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
+                        title="View or edit this transaction"
+                      >
+                        {transaction.description}
+                      </button>
                       <p className="text-sm text-gray-600 dark:text-gray-400">{categoryName(transaction.category)}</p>
                       <p className="text-sm text-gray-500 dark:text-gray-500">
                         {new Date(transaction.date).toLocaleDateString()}
                       </p>
                     </div>
                     <p className={`text-lg font-semibold ${
-                      transaction.type === 'income' ? 'text-green-700 dark:text-green-400' : 'text-red-600 dark:text-red-400'
+                      transaction.amount < 0 ? 'text-red-600 dark:text-red-400' : 'text-green-700 dark:text-green-400'
                     }`}>
                       {/* Amounts are stored signed; derive the sign from the value so incoming transfers show '+' */}
                       {transaction.amount < 0 ? '-' : '+'}{formatCurrency(Math.abs(transaction.amount))}
@@ -561,105 +145,63 @@ export default function Reports() {
                   </div>
                 </div>
               ))}
+            </div>
           </div>
-        </div>
-        
-        {/* Desktop table view */}
-        <div className="hidden sm:block overflow-x-auto">
-          <table className="w-full">
-            <thead className="bg-gray-50 dark:bg-gray-700">
-              <tr>
-                <th className="px-4 py-3 text-left text-sm font-medium text-gray-500 dark:text-gray-400 uppercase">Date</th>
-                <th className="px-4 py-3 text-left text-sm font-medium text-gray-500 dark:text-gray-400 uppercase hidden sm:table-cell">Description</th>
-                <th className="px-4 py-3 text-left text-sm font-medium text-gray-500 dark:text-gray-400 uppercase hidden md:table-cell">Category</th>
-                <th className="px-4 py-3 text-right text-sm font-medium text-gray-500 dark:text-gray-400 uppercase">Amount</th>
-              </tr>
-            </thead>
-            <tbody className="divide-y divide-gray-200 dark:divide-gray-700">
-              {topTransactions.map((transaction) => (
+
+          {/* Desktop table view — scrolls inside its own box. */}
+          <div className="hidden sm:block overflow-x-auto">
+            <table className="w-full">
+              <caption className="sr-only">The ten largest transactions in the selected period</caption>
+              <thead className="bg-gray-50 dark:bg-gray-700">
+                <tr>
+                  <th scope="col" className="px-4 py-3 text-left text-sm font-medium text-gray-500 dark:text-gray-400 uppercase">Date</th>
+                  <th scope="col" className="px-4 py-3 text-left text-sm font-medium text-gray-500 dark:text-gray-400 uppercase">Description</th>
+                  <th scope="col" className="px-4 py-3 text-left text-sm font-medium text-gray-500 dark:text-gray-400 uppercase hidden md:table-cell">Category</th>
+                  <th scope="col" className="px-4 py-3 text-right text-sm font-medium text-gray-500 dark:text-gray-400 uppercase">Amount</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-gray-200 dark:divide-gray-700">
+                {topTransactions.map(transaction => (
                   <tr key={transaction.id}>
-                    <td className="px-4 py-3 text-sm text-gray-900 dark:text-white">
+                    <td className="px-4 py-3 text-sm text-gray-900 dark:text-white whitespace-nowrap">
                       {new Date(transaction.date).toLocaleDateString()}
                     </td>
-                    <td className="px-4 py-3 text-sm text-gray-900 dark:text-white hidden sm:table-cell">
-                      {transaction.description}
+                    <td className="px-4 py-3 text-sm text-gray-900 dark:text-white">
+                      <button
+                        type="button"
+                        onClick={() => setEditingId(transaction.splitParentId ?? transaction.id)}
+                        className="text-left hover:text-blue-700 dark:hover:text-blue-400 hover:underline rounded focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
+                        title="View or edit this transaction"
+                      >
+                        {transaction.description}
+                      </button>
                     </td>
                     <td className="px-4 py-3 text-sm text-gray-600 dark:text-gray-400 hidden md:table-cell">
                       {categoryName(transaction.category)}
                     </td>
-                    <td className={`px-4 py-3 text-sm text-right font-medium ${
-                      transaction.type === 'income' ? 'text-green-700 dark:text-green-400' : 'text-red-600 dark:text-red-400'
+                    <td className={`px-4 py-3 text-sm text-right font-medium tabular-nums whitespace-nowrap ${
+                      transaction.amount < 0 ? 'text-red-600 dark:text-red-400' : 'text-green-700 dark:text-green-400'
                     }`}>
                       {/* Amounts are stored signed; derive the sign from the value so incoming transfers show '+' */}
                       {transaction.amount < 0 ? '-' : '+'}{formatCurrency(Math.abs(transaction.amount))}
                     </td>
                   </tr>
                 ))}
-            </tbody>
-          </table>
+              </tbody>
+            </table>
+          </div>
         </div>
-        </div>
-        </div>
-
-        {/* The Money-style monthly matrix — the detailed read, so it sits at the
-            bottom under the summary tables and charts rather than ahead of them. */}
-        <MonthlyIncomeExpenseMatrix matrix={matrix} onDrill={handleMatrixDrill} />
       </div>
 
-      {/* Income/Expense breakdown — the shared component (category sections,
-          sortable headings, click-to-edit) also used by the Dashboard. */}
-      <IncomeExpenseBreakdownModal
-        isOpen={breakdownType !== null}
-        onClose={() => setBreakdownType(null)}
-        title={
-          breakdownType === 'income' ? 'Income Breakdown'
-          : breakdownType === 'expense' ? 'Expense Breakdown'
-          : 'Uncategorised Transactions'
-        }
-        bucket={breakdownType ?? 'income'}
-        rows={
-          breakdownType === 'income' ? flows.incomeRows
-          : breakdownType === 'expense' ? flows.expenseRows
-          : flows.uncategorizedRows
-        }
-        total={
-          breakdownType === 'income' ? summary.income
-          : breakdownType === 'expense' ? summary.expenses
-          : null
-        }
-        categories={categories}
-        onEditTransaction={setEditingBreakdownTxnId}
-      />
+      <ReportDrillModal target={drill} onClose={() => setDrill(null)} categories={categories} />
 
-      {/* Chart drill-ins (a trend point or a pie slice) share the same
-          breakdown modal, scoped to the clicked month/category. */}
-      <IncomeExpenseBreakdownModal
-        isOpen={chartDrill !== null}
-        onClose={() => setChartDrill(null)}
-        title={chartDrill?.title ?? ''}
-        bucket={chartDrill?.bucket ?? 'expense'}
-        rows={chartDrill?.rows ?? []}
-        total={chartDrill?.total ?? 0}
-        categories={categories}
-        onEditTransaction={setEditingBreakdownTxnId}
-      />
-
-      <TransferSweepModal
-        isOpen={showTransferSweep}
-        onClose={() => setShowTransferSweep(false)}
-      />
-
-      <BulkCategorizeModal
-        isOpen={showBulkCategorize}
-        onClose={() => setShowBulkCategorize(false)}
-      />
-
-      {/* Edit a transaction straight from the breakdown list */}
-      {editingBreakdownTxnId && (
+      {/* A top transaction opens straight in the editor — a split line opens
+          its PARENT, which is the real record. */}
+      {editingId !== null && (
         <EditTransactionModal
           isOpen
-          onClose={() => setEditingBreakdownTxnId(null)}
-          transaction={rawTransactions.find(t => t.id === editingBreakdownTxnId) ?? null}
+          onClose={() => setEditingId(null)}
+          transaction={allTransactions.find(t => t.id === editingId) ?? null}
         />
       )}
     </div>

--- a/src/pages/Reports.tsx
+++ b/src/pages/Reports.tsx
@@ -1,6 +1,6 @@
 import { useState, useMemo, useRef, useEffect } from 'react';
 import { useApp } from '../contexts/AppContextSupabase';
-import { PieChartIcon, TrendingUpIcon, CalendarIcon, DownloadIcon, FilterIcon, PdfIcon } from '../components/icons';
+import { PieChartIcon, TrendingUpIcon, CalendarIcon, DownloadIcon, FilterIcon, PdfIcon, ChevronDownIcon, ChevronUpIcon } from '../components/icons';
 import { exportTransactionsToCSV, downloadCSV } from '../utils/csvExport';
 import { generatePDFReport, generateSimplePDFReport } from '../utils/pdfExport';
 import { SkeletonCard, SkeletonText } from '../components/loading/Skeleton';
@@ -23,10 +23,13 @@ import { formatDecimal } from '../utils/decimal-format';
 import { computeExpenseCategoryNetTotals } from '../utils/categoryNetting';
 import { buildMonthlyTrend } from '../utils/monthlyTrend';
 import { computeIncomeExpense } from '../utils/incomeExpense';
+import { buildMonthlyCategoryMatrix, monthKeyOf } from '../utils/monthlyCategoryMatrix';
+import { buildCategoryNameLookup } from '../utils/categoryNames';
 import { usePeriod, PERIOD_LABELS } from '../hooks/usePeriod';
 import PeriodPicker from '../components/PeriodPicker';
 import EditTransactionModal from '../components/EditTransactionModal';
 import IncomeExpenseBreakdownModal from '../components/IncomeExpenseBreakdownModal';
+import MonthlyIncomeExpenseMatrix, { type MatrixDrillTarget } from '../components/MonthlyIncomeExpenseMatrix';
 import TransferSweepModal from '../components/TransferSweepModal';
 import BulkCategorizeModal from '../components/BulkCategorizeModal';
 import { expandSplitTransactions } from '../utils/transactionSplits';
@@ -65,6 +68,17 @@ export default function Reports() {
   const [editingBreakdownTxnId, setEditingBreakdownTxnId] = useState<string | null>(null);
   const [showTransferSweep, setShowTransferSweep] = useState(false);
   const [showBulkCategorize, setShowBulkCategorize] = useState(false);
+  // Top Transactions is a curiosity next to the monthly matrix, so it starts
+  // hidden; the choice is persisted like the page's other view preferences.
+  const [showTopTransactions, setShowTopTransactions] = useState<boolean>(
+    () => localStorage.getItem('reportsShowTopTransactions') === '1'
+  );
+  const toggleTopTransactions = (): void => {
+    setShowTopTransactions(prev => {
+      localStorage.setItem('reportsShowTopTransactions', prev ? '0' : '1');
+      return !prev;
+    });
+  };
   const [isLoading, setIsLoading] = useState(true);
   const chartRef1 = useRef<HTMLDivElement>(null);
   const chartRef2 = useRef<HTMLDivElement>(null);
@@ -102,6 +116,40 @@ export default function Reports() {
       savingsRate: savingsRateDecimal.toNumber(),
     };
   }, [flows]);
+
+  // Category ids are UUIDs — everything user-facing resolves through this
+  // lookup ("Parent : Child", "Uncategorised" for a dangling id).
+  const categoryName = useMemo(() => buildCategoryNameLookup(categories), [categories]);
+
+  // Biggest movements in the period. A COPY: sorting filteredTransactions in
+  // place would mutate the memoised array on every render.
+  const topTransactions = useMemo(
+    () => [...filteredTransactions]
+      .sort((a, b) => Math.abs(b.amount) - Math.abs(a.amount))
+      .slice(0, 10),
+    [filteredTransactions]
+  );
+
+  // The Money-style category × month matrix, built from the SAME classified
+  // rows as the summary cards so the two can never disagree.
+  const matrix = useMemo(
+    () => buildMonthlyCategoryMatrix(flows.incomeRows, flows.expenseRows, categories, picker.range),
+    [flows, categories, picker.range]
+  );
+
+  const handleMatrixDrill = (target: MatrixDrillTarget): void => {
+    const source = target.bucket === 'income' ? flows.incomeRows : flows.expenseRows;
+    const ids = target.categoryIds ? new Set(target.categoryIds) : null;
+    setChartDrill({
+      title: target.label,
+      bucket: target.bucket,
+      rows: source.filter(t =>
+        (ids === null || ids.has(t.category)) &&
+        (target.monthKey === null || monthKeyOf(t.date) === target.monthKey)
+      ),
+      total: target.total,
+    });
+  };
 
   const formatPercentage = (value: DecimalInstance | number, decimals: number = 1) => {
     return formatDecimal(value, decimals);
@@ -176,7 +224,9 @@ export default function Reports() {
   );
 
   const exportToCSV = () => {
-    const csv = exportTransactionsToCSV(filteredTransactions, accounts);
+    // categories resolve the Category column to a name — a UUID in a
+    // spreadsheet is worthless.
+    const csv = exportTransactionsToCSV(filteredTransactions, accounts, categories);
     const filename = `financial-report-${new Date().toISOString().split('T')[0]}.csv`;
     downloadCSV(csv, filename);
   };
@@ -204,9 +254,8 @@ export default function Reports() {
         dateRange: PERIOD_LABELS[picker.period],
         summary,
         categoryBreakdown,
-        topTransactions: filteredTransactions
-          .sort((a, b) => Math.abs(b.amount) - Math.abs(a.amount))
-          .slice(0, 10),
+        // categoryLabel: the PDF prints names, never category ids.
+        topTransactions: topTransactions.map(t => ({ ...t, categoryLabel: categoryName(t.category) })),
         chartElements: includeCharts && chartRef1.current && chartRef2.current
           ? [chartRef1.current, chartRef2.current]
           : undefined
@@ -368,6 +417,10 @@ export default function Reports() {
           </button>
         )}
 
+        {/* The Money-style monthly matrix — the report Steve lives in, so it
+            sits directly under the headline figures it adds up to. */}
+        <MonthlyIncomeExpenseMatrix matrix={matrix} onDrill={handleMatrixDrill} />
+
         {/* Charts */}
         <div className="pt-4">
           <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
@@ -473,23 +526,32 @@ export default function Reports() {
         </div>
         </div>
 
-        {/* Top Transactions */}
+        {/* Top Transactions — collapsed by default (the matrix above is the
+            report that matters); the choice is persisted. */}
         <div className="bg-white dark:bg-gray-800 rounded-2xl shadow-lg border border-gray-100 dark:border-gray-700">
-        <div className="p-6 border-b border-gray-200 dark:border-gray-700">
+        <div className={`flex items-center justify-between gap-4 p-6 ${showTopTransactions ? 'border-b border-gray-200 dark:border-gray-700' : ''}`}>
           <h2 className="text-lg font-semibold text-theme-heading dark:text-white">Top Transactions</h2>
+          <button
+            type="button"
+            onClick={toggleTopTransactions}
+            aria-expanded={showTopTransactions}
+            aria-controls="top-transactions-panel"
+            className="flex items-center gap-1 px-3 py-1 text-sm font-medium rounded-lg border border-gray-200 dark:border-gray-700 text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-200 transition-colors"
+          >
+            {showTopTransactions ? 'Hide' : 'Show'}
+            {showTopTransactions ? <ChevronUpIcon size={16} /> : <ChevronDownIcon size={16} />}
+          </button>
         </div>
+        <div id="top-transactions-panel" hidden={!showTopTransactions}>
         {/* Mobile card view */}
         <div className="block sm:hidden">
           <div className="space-y-3">
-            {filteredTransactions
-              .sort((a, b) => Math.abs(b.amount) - Math.abs(a.amount))
-              .slice(0, 10)
-              .map((transaction) => (
+            {topTransactions.map((transaction) => (
                 <div key={transaction.id} className="bg-gray-50 dark:bg-gray-700/50 rounded-lg p-4 space-y-2">
                   <div className="flex justify-between items-start">
                     <div className="flex-1">
                       <p className="font-medium text-gray-900 dark:text-white">{transaction.description}</p>
-                      <p className="text-sm text-gray-600 dark:text-gray-400">{transaction.category}</p>
+                      <p className="text-sm text-gray-600 dark:text-gray-400">{categoryName(transaction.category)}</p>
                       <p className="text-sm text-gray-500 dark:text-gray-500">
                         {new Date(transaction.date).toLocaleDateString()}
                       </p>
@@ -518,10 +580,7 @@ export default function Reports() {
               </tr>
             </thead>
             <tbody className="divide-y divide-gray-200 dark:divide-gray-700">
-              {filteredTransactions
-                .sort((a, b) => Math.abs(b.amount) - Math.abs(a.amount))
-                .slice(0, 10)
-                .map((transaction) => (
+              {topTransactions.map((transaction) => (
                   <tr key={transaction.id}>
                     <td className="px-4 py-3 text-sm text-gray-900 dark:text-white">
                       {new Date(transaction.date).toLocaleDateString()}
@@ -530,7 +589,7 @@ export default function Reports() {
                       {transaction.description}
                     </td>
                     <td className="px-4 py-3 text-sm text-gray-600 dark:text-gray-400 hidden md:table-cell">
-                      {transaction.category}
+                      {categoryName(transaction.category)}
                     </td>
                     <td className={`px-4 py-3 text-sm text-right font-medium ${
                       transaction.type === 'income' ? 'text-green-700 dark:text-green-400' : 'text-red-600 dark:text-red-400'
@@ -542,6 +601,7 @@ export default function Reports() {
                 ))}
             </tbody>
           </table>
+        </div>
         </div>
         </div>
       </div>

--- a/src/pages/ReportsHub.tsx
+++ b/src/pages/ReportsHub.tsx
@@ -1,70 +1,89 @@
-import { useState, lazy, Suspense } from 'react';
-import { BarChart3Icon, TrendingUpIcon, FileTextIcon } from '../components/icons';
+import React, { Suspense } from 'react';
+import { Link, Navigate, useLocation, useParams } from 'react-router-dom';
+import { ArrowLeftIcon, CalendarIcon } from '../components/icons';
 import PageTip from '../components/PageTip';
+import PeriodPicker from '../components/PeriodPicker';
 import { SkeletonCard } from '../components/loading/Skeleton';
+import { usePeriod } from '../hooks/usePeriod';
+import { preserveDemoParam } from '../utils/navigation';
+import ReportGallery from './reports/ReportGallery';
+import { findReport } from './reports/reportRegistry';
 
-// Lazy load each report view
-const Reports = lazy(() => import('./Reports'));
-const NetWorthReport = lazy(() => import('./NetWorthReport'));
-const CustomReports = lazy(() => import('./CustomReports'));
+/**
+ * The reports hub — a gallery of named reports (Microsoft Money's model)
+ * rather than a row of tabs, which stops scaling the moment there is more
+ * than a handful of reports.
+ *
+ * The hub owns the shared reporting period and hands it to whichever report
+ * is open, so the period PERSISTS as the user moves between reports instead
+ * of resetting each time. Each report lives at its own /reports/<id> URL and
+ * is code-split, so opening the gallery never loads eight reports' worth of
+ * charts.
+ */
+export default function ReportsHub(): React.JSX.Element {
+  const { reportId } = useParams<{ reportId?: string }>();
+  const location = useLocation();
+  // One period for the whole hub (storage key shared with the Dashboard's
+  // pinned reports, so the two agree about the window as well).
+  const picker = usePeriod('reportsPeriod');
 
-type ReportTab = 'income-expense' | 'net-worth' | 'custom';
+  const report = findReport(reportId);
+  // An unknown id (an old bookmark, a typo) returns to the gallery rather
+  // than showing an empty frame.
+  if (reportId !== undefined && report === null) {
+    return <Navigate to={preserveDemoParam('/reports', location.search)} replace />;
+  }
 
-const tabs: { id: ReportTab; label: string; icon: React.ElementType; description: string }[] = [
-  { id: 'income-expense', label: 'Income & Expense', icon: BarChart3Icon, description: 'Breakdown of earning and spending' },
-  { id: 'net-worth', label: 'Net Worth', icon: TrendingUpIcon, description: 'Assets, liabilities, and trends' },
-  { id: 'custom', label: 'Custom Reports', icon: FileTextIcon, description: 'Build your own reports' },
-];
-
-export default function ReportsHub() {
-  const [activeTab, setActiveTab] = useState<ReportTab>('income-expense');
+  const ReportView = report?.component;
 
   return (
     <div className="space-y-0">
-      {/* Tab navigation */}
       <div className="bg-white dark:bg-gray-800 border-b border-gray-200 dark:border-gray-700 px-4 md:px-6 -mx-4 md:-mx-6 lg:-mx-8 -mt-4 md:-mt-6 lg:-mt-8 mb-6">
-        <div className="max-w-[1400px] mx-auto">
-          <div className="flex items-center justify-between py-4 px-4 md:px-0">
-            <h1 className="text-2xl font-semibold text-gray-900 dark:text-white">Reports</h1>
-          </div>
-          {/* role="tab" requires a role="tablist" parent (WCAG 1.3.1 / axe
-              aria-required-parent) */}
-          <div role="tablist" aria-label="Report tabs" className="flex gap-1 px-4 md:px-0 -mb-px overflow-x-auto">
-            {tabs.map(tab => {
-              const Icon = tab.icon;
-              const isActive = activeTab === tab.id;
-              return (
-                <button
-                  key={tab.id}
-                  onClick={() => setActiveTab(tab.id)}
-                  className={`flex items-center gap-2 px-4 py-3 text-sm font-medium border-b-2 transition-colors whitespace-nowrap ${
-                    isActive
-                      ? 'border-[#1a2332] text-[#1a2332] dark:border-blue-400 dark:text-blue-400'
-                      : 'border-transparent text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-300 hover:border-gray-300'
-                  }`}
-                  aria-selected={isActive}
-                  role="tab"
-                >
-                  <Icon size={16} />
-                  {tab.label}
-                </button>
-              );
-            })}
+        <div className="max-w-[1400px] mx-auto py-4 px-4 md:px-0">
+          {report && (
+            <Link
+              to={preserveDemoParam('/reports', location.search)}
+              className="inline-flex items-center gap-1.5 text-sm text-gray-500 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-200 transition-colors mb-2"
+            >
+              <ArrowLeftIcon size={16} />
+              All reports
+            </Link>
+          )}
+
+          <div className="flex flex-wrap items-start justify-between gap-3">
+            <div className="min-w-0">
+              <h1 className="text-2xl font-semibold text-gray-900 dark:text-white">
+                {report ? report.title : 'Reports'}
+              </h1>
+              <p className="text-sm text-gray-500 dark:text-gray-400 mt-0.5">
+                {report
+                  ? report.description
+                  : 'Choose a report. The period you pick follows you from one to the next.'}
+              </p>
+            </div>
+
+            {(report?.usesPeriod ?? true) && (
+              <div className="flex items-center gap-2">
+                <CalendarIcon className="text-gray-500 flex-shrink-0" size={18} />
+                <PeriodPicker picker={picker} />
+              </div>
+            )}
           </div>
         </div>
       </div>
 
-      {/* Tab content */}
-      <Suspense fallback={<SkeletonCard className="h-96" />}>
-        {activeTab === 'income-expense' && <Reports />}
-        {activeTab === 'net-worth' && <NetWorthReport />}
-        {activeTab === 'custom' && <CustomReports />}
-      </Suspense>
+      {ReportView ? (
+        <Suspense fallback={<SkeletonCard className="h-96" />}>
+          <ReportView picker={picker} />
+        </Suspense>
+      ) : (
+        <ReportGallery />
+      )}
 
       <PageTip
-        id="reports-intro"
+        id="reports-gallery"
         title="Financial reports"
-        description="Switch between Income & Expense, Net Worth, and Custom Reports using the tabs above. Each report can be filtered by date range and account."
+        description="Pick a report from the gallery — net worth, balances, spending by category or payee, and period comparisons. The date range you choose stays put as you move between reports, and every figure clicks through to the transactions behind it."
       />
     </div>
   );

--- a/src/pages/ReportsHub.tsx
+++ b/src/pages/ReportsHub.tsx
@@ -1,13 +1,16 @@
-import React, { Suspense } from 'react';
+import React, { Suspense, useEffect } from 'react';
 import { Link, Navigate, useLocation, useParams } from 'react-router-dom';
 import { ArrowLeftIcon, CalendarIcon } from '../components/icons';
 import PageTip from '../components/PageTip';
 import PeriodPicker from '../components/PeriodPicker';
 import { SkeletonCard } from '../components/loading/Skeleton';
-import { usePeriod } from '../hooks/usePeriod';
+import { usePeriod, type PeriodKey } from '../hooks/usePeriod';
 import { preserveDemoParam } from '../utils/navigation';
 import ReportGallery from './reports/ReportGallery';
 import { findReport } from './reports/reportRegistry';
+
+/** The window a report gets when it states no preference of its own. */
+const HUB_DEFAULT_PERIOD: PeriodKey = 'this-month';
 
 /**
  * The reports hub — a gallery of named reports (Microsoft Money's model)
@@ -19,15 +22,30 @@ import { findReport } from './reports/reportRegistry';
  * of resetting each time. Each report lives at its own /reports/<id> URL and
  * is code-split, so opening the gallery never loads eight reports' worth of
  * charts.
+ *
+ * Until the user picks a period, each report opens on the window it is worth
+ * reading over (net worth over time on ALL of it, not this month). The moment
+ * they pick one, that choice wins everywhere and is never overridden.
  */
 export default function ReportsHub(): React.JSX.Element {
   const { reportId } = useParams<{ reportId?: string }>();
   const location = useLocation();
-  // One period for the whole hub (storage key shared with the Dashboard's
-  // pinned reports, so the two agree about the window as well).
-  const picker = usePeriod('reportsPeriod');
 
   const report = findReport(reportId);
+  const preferredPeriod = report?.defaultPeriod ?? HUB_DEFAULT_PERIOD;
+
+  // One period for the whole hub (storage key shared with the Dashboard's
+  // pinned reports, so the two agree about the window as well). The report's
+  // preference seeds it on the first paint...
+  const picker = usePeriod('reportsPeriod', preferredPeriod);
+  const { applyDefaultPeriod } = picker;
+
+  // ...and takes effect again when a different report opens without the hub
+  // remounting. Both are no-ops once the user has chosen for themselves.
+  useEffect(() => {
+    applyDefaultPeriod(preferredPeriod);
+  }, [applyDefaultPeriod, preferredPeriod]);
+
   // An unknown id (an old bookmark, a typo) returns to the gallery rather
   // than showing an empty frame.
   if (reportId !== undefined && report === null) {

--- a/src/pages/__tests__/ReportsHub.test.tsx
+++ b/src/pages/__tests__/ReportsHub.test.tsx
@@ -14,6 +14,17 @@ import ReportsHub from '../ReportsHub';
  * The app context is the shared test double from src/test/setup.ts (synthetic
  * data only — this repo is public).
  */
+
+/**
+ * Every report is code-split, so opening one waits on a real dynamic import of
+ * a chart-heavy chunk. Testing Library's 1s default is the wrong budget for
+ * that on a loaded machine — these tests share a runner with the rest of the
+ * suite — so every wait on a report gets an explicit one. Long enough that
+ * load alone cannot fail it, short enough that a report which never renders
+ * still fails the run.
+ */
+const LOADS_LAZY_REPORT = { timeout: 15_000 } as const;
+
 const renderHub = (initialPath = '/reports') =>
   render(
     <MemoryRouter initialEntries={[initialPath]}>
@@ -92,7 +103,7 @@ describe('ReportsHub gallery', () => {
     fireEvent.click(screen.getByRole('link', { name: /Account balances/ }));
 
     // The report is code-split, so it arrives after its chunk resolves.
-    expect(await screen.findByRole('heading', { name: 'Balances by account' })).toBeInTheDocument();
+    expect(await screen.findByRole('heading', { name: 'Balances by account' }, LOADS_LAZY_REPORT)).toBeInTheDocument();
     expect(screen.getByRole('heading', { level: 1, name: 'Account balances' })).toBeInTheDocument();
 
     fireEvent.click(screen.getByRole('link', { name: 'All reports' }));
@@ -108,7 +119,7 @@ describe('ReportsHub gallery', () => {
     expect(screen.getByRole('button', { name: 'Last month' })).toHaveAttribute('aria-pressed', 'true');
 
     fireEvent.click(screen.getByRole('link', { name: /Account balances/ }));
-    await screen.findByRole('heading', { name: 'Balances by account' });
+    await screen.findByRole('heading', { name: 'Balances by account' }, LOADS_LAZY_REPORT);
 
     // Still last month — the hub owns the period, not the report.
     expect(screen.getByRole('button', { name: 'Last month' })).toHaveAttribute('aria-pressed', 'true');
@@ -117,46 +128,67 @@ describe('ReportsHub gallery', () => {
     fireEvent.click(screen.getByRole('link', { name: 'All reports' }));
     fireEvent.click(screen.getByRole('link', { name: /Net worth over time/ }));
 
-    await waitFor(() =>
-      expect(screen.getByRole('button', { name: 'Last month' })).toHaveAttribute('aria-pressed', 'true')
+    await waitFor(
+      () => expect(screen.getByRole('button', { name: 'Last month' })).toHaveAttribute('aria-pressed', 'true'),
+      LOADS_LAZY_REPORT
     );
   });
 
+  // The report's own heading is NOT a signal that its default period has been
+  // applied: the heading comes from a lazily-loaded child, and the default is
+  // applied by an effect that lands a render later. Waiting on the heading and
+  // then asserting the button synchronously passes on an idle machine and fails
+  // under load — so every one of these waits for the button itself.
   it('opens each report on the window it is worth reading over', async () => {
     // A month of net worth is a dot, not a trend.
     renderHub('/reports/net-worth-over-time');
-    await screen.findByRole('heading', { name: 'Net Worth Over Time' });
-    expect(screen.getByRole('button', { name: 'All time' })).toHaveAttribute('aria-pressed', 'true');
+    await screen.findByRole('heading', { name: 'Net Worth Over Time' }, LOADS_LAZY_REPORT);
+    await waitFor(
+      () => expect(screen.getByRole('button', { name: 'All time' })).toHaveAttribute('aria-pressed', 'true'),
+      LOADS_LAZY_REPORT
+    );
     expect(screen.getByRole('button', { name: 'This month' })).toHaveAttribute('aria-pressed', 'false');
   });
 
   it('gives a month-by-month report a year to compare', async () => {
     renderHub('/reports/income-and-spending-over-time');
-    await screen.findByRole('heading', { name: 'Income against spending' });
+    await screen.findByRole('heading', { name: 'Income against spending' }, LOADS_LAZY_REPORT);
 
-    expect(screen.getByRole('button', { name: '12 months' })).toHaveAttribute('aria-pressed', 'true');
+    await waitFor(
+      () => expect(screen.getByRole('button', { name: '12 months' })).toHaveAttribute('aria-pressed', 'true'),
+      LOADS_LAZY_REPORT
+    );
   });
 
   it('leaves reports without a preference on this month', async () => {
     renderHub('/reports/spending-by-category');
-    await screen.findByRole('heading', { name: 'Where the money went' });
+    await screen.findByRole('heading', { name: 'Where the money went' }, LOADS_LAZY_REPORT);
 
-    expect(screen.getByRole('button', { name: 'This month' })).toHaveAttribute('aria-pressed', 'true');
+    await waitFor(
+      () => expect(screen.getByRole('button', { name: 'This month' })).toHaveAttribute('aria-pressed', 'true'),
+      LOADS_LAZY_REPORT
+    );
   });
 
   it('applies the default of the report being opened, not the one just closed', async () => {
     renderHub();
 
     fireEvent.click(screen.getByRole('link', { name: /Net worth over time/ }));
-    await screen.findByRole('heading', { name: 'Net Worth Over Time' });
-    expect(screen.getByRole('button', { name: 'All time' })).toHaveAttribute('aria-pressed', 'true');
+    await screen.findByRole('heading', { name: 'Net Worth Over Time' }, LOADS_LAZY_REPORT);
+    await waitFor(
+      () => expect(screen.getByRole('button', { name: 'All time' })).toHaveAttribute('aria-pressed', 'true'),
+      LOADS_LAZY_REPORT
+    );
 
     fireEvent.click(screen.getByRole('link', { name: 'All reports' }));
     fireEvent.click(screen.getByRole('link', { name: /Spending by category/ }));
-    await screen.findByRole('heading', { name: 'Where the money went' });
+    await screen.findByRole('heading', { name: 'Where the money went' }, LOADS_LAZY_REPORT);
 
     // "All time" was never asked for, so it does not stick to the next report.
-    expect(screen.getByRole('button', { name: 'This month' })).toHaveAttribute('aria-pressed', 'true');
+    await waitFor(
+      () => expect(screen.getByRole('button', { name: 'This month' })).toHaveAttribute('aria-pressed', 'true'),
+      LOADS_LAZY_REPORT
+    );
   });
 
   it('never overrides a period the user chose, whatever the report prefers', async () => {
@@ -165,13 +197,13 @@ describe('ReportsHub gallery', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Tax year' }));
 
     fireEvent.click(screen.getByRole('link', { name: /Net worth over time/ }));
-    await screen.findByRole('heading', { name: 'Net Worth Over Time' });
+    await screen.findByRole('heading', { name: 'Net Worth Over Time' }, LOADS_LAZY_REPORT);
     expect(screen.getByRole('button', { name: 'Tax year' })).toHaveAttribute('aria-pressed', 'true');
     expect(screen.getByRole('button', { name: 'All time' })).toHaveAttribute('aria-pressed', 'false');
 
     fireEvent.click(screen.getByRole('link', { name: 'All reports' }));
     fireEvent.click(screen.getByRole('link', { name: /Income and spending over time/ }));
-    await screen.findByRole('heading', { name: 'Income against spending' });
+    await screen.findByRole('heading', { name: 'Income against spending' }, LOADS_LAZY_REPORT);
 
     expect(screen.getByRole('button', { name: 'Tax year' })).toHaveAttribute('aria-pressed', 'true');
     expect(screen.getByRole('button', { name: '12 months' })).toHaveAttribute('aria-pressed', 'false');
@@ -184,7 +216,7 @@ describe('ReportsHub gallery', () => {
 
     // A fresh visit — straight to the report with the strongest preference.
     renderHub('/reports/net-worth-over-time');
-    await screen.findByRole('heading', { name: 'Net Worth Over Time' });
+    await screen.findByRole('heading', { name: 'Net Worth Over Time' }, LOADS_LAZY_REPORT);
 
     expect(screen.getByRole('button', { name: 'Tax year' })).toHaveAttribute('aria-pressed', 'true');
   });
@@ -198,7 +230,7 @@ describe('ReportsHub gallery', () => {
     });
 
     fireEvent.click(screen.getByRole('link', { name: /Net worth over time/ }));
-    await screen.findByRole('heading', { name: 'Net Worth Over Time' });
+    await screen.findByRole('heading', { name: 'Net Worth Over Time' }, LOADS_LAZY_REPORT);
 
     expect(screen.getByRole('button', { name: 'Custom' })).toHaveAttribute('aria-pressed', 'true');
     expect(screen.getByLabelText('Custom period start date')).toHaveValue('2026-01-10');
@@ -224,13 +256,13 @@ describe('ReportsHub gallery', () => {
   ])('renders the %s report', async (id, heading) => {
     renderHub(`/reports/${id}`);
 
-    expect(await screen.findByRole('heading', { name: heading })).toBeInTheDocument();
+    expect(await screen.findByRole('heading', { name: heading }, LOADS_LAZY_REPORT)).toBeInTheDocument();
   });
 
   it('hides the period picker for reports that carry their own filters', async () => {
     renderHub('/reports/custom-reports');
 
-    expect(await screen.findByRole('heading', { level: 1, name: 'Custom reports' })).toBeInTheDocument();
+    expect(await screen.findByRole('heading', { level: 1, name: 'Custom reports' }, LOADS_LAZY_REPORT)).toBeInTheDocument();
     expect(screen.queryByRole('button', { name: 'Last month' })).not.toBeInTheDocument();
   });
 });

--- a/src/pages/__tests__/ReportsHub.test.tsx
+++ b/src/pages/__tests__/ReportsHub.test.tsx
@@ -1,0 +1,154 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { PreferencesProvider } from '../../contexts/PreferencesContext';
+import { ToastProvider } from '../../contexts/ToastContext';
+import ReportsHub from '../ReportsHub';
+
+/**
+ * The gallery is the entry point to every report, so these cover the three
+ * things that must never break: the groups render, choosing a report opens
+ * it at its own URL, and the period the user picked follows them from one
+ * report to the next.
+ *
+ * The app context is the shared test double from src/test/setup.ts (synthetic
+ * data only — this repo is public).
+ */
+const renderHub = (initialPath = '/reports') =>
+  render(
+    <MemoryRouter initialEntries={[initialPath]}>
+      <PreferencesProvider>
+        {/* The reports' clean-up tools report through the app's toasts, as
+            they do inside the real provider stack. */}
+        <ToastProvider>
+          <Routes>
+            <Route path="/reports" element={<ReportsHub />} />
+            <Route path="/reports/:reportId" element={<ReportsHub />} />
+          </Routes>
+        </ToastProvider>
+      </PreferencesProvider>
+    </MemoryRouter>
+  );
+
+describe('ReportsHub gallery', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it('lists the reports, grouped by the question they answer', () => {
+    renderHub();
+
+    expect(screen.getByRole('heading', { level: 1, name: 'Reports' })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: 'What I have' })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: 'Spending' })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: 'Custom reports' })).toBeInTheDocument();
+
+    // Titles are matched exactly, so "Net worth" cannot be satisfied by
+    // "Net worth over time".
+    for (const title of [
+      'Net worth',
+      'Net worth over time',
+      'Account balances',
+      'Monthly income and expenses',
+      'Spending by category',
+      'Income and spending over time',
+      'Spending by payee',
+      'This period vs last',
+    ]) {
+      expect(screen.getByText(title)).toBeInTheDocument();
+    }
+    // "Custom reports" names both its group and the report inside it.
+    expect(screen.getAllByText('Custom reports')).toHaveLength(2);
+
+    expect(screen.getAllByRole('link').map(link => link.getAttribute('href'))).toEqual([
+      '/reports/net-worth',
+      '/reports/net-worth-over-time',
+      '/reports/account-balances',
+      '/reports/monthly-income-expenses',
+      '/reports/spending-by-category',
+      '/reports/income-and-spending-over-time',
+      '/reports/spending-by-payee',
+      '/reports/period-comparison',
+      '/reports/custom-reports',
+    ]);
+  });
+
+  it('gives every report its own URL so it can be linked to and pinned', () => {
+    renderHub();
+
+    expect(screen.getByRole('link', { name: /Account balances/ })).toHaveAttribute(
+      'href',
+      '/reports/account-balances'
+    );
+    expect(screen.getByRole('link', { name: /Spending by payee/ })).toHaveAttribute(
+      'href',
+      '/reports/spending-by-payee'
+    );
+  });
+
+  it('opens the chosen report, and comes back to the gallery', async () => {
+    renderHub();
+
+    fireEvent.click(screen.getByRole('link', { name: /Account balances/ }));
+
+    // The report is code-split, so it arrives after its chunk resolves.
+    expect(await screen.findByRole('heading', { name: 'Balances by account' })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { level: 1, name: 'Account balances' })).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('link', { name: 'All reports' }));
+
+    expect(screen.getByRole('heading', { level: 1, name: 'Reports' })).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /Net worth over time/ })).toBeInTheDocument();
+  });
+
+  it('keeps the chosen period as the user moves between reports', async () => {
+    renderHub();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Last month' }));
+    expect(screen.getByRole('button', { name: 'Last month' })).toHaveAttribute('aria-pressed', 'true');
+
+    fireEvent.click(screen.getByRole('link', { name: /Account balances/ }));
+    await screen.findByRole('heading', { name: 'Balances by account' });
+
+    // Still last month — the hub owns the period, not the report.
+    expect(screen.getByRole('button', { name: 'Last month' })).toHaveAttribute('aria-pressed', 'true');
+    expect(screen.getByRole('button', { name: 'This month' })).toHaveAttribute('aria-pressed', 'false');
+
+    fireEvent.click(screen.getByRole('link', { name: 'All reports' }));
+    fireEvent.click(screen.getByRole('link', { name: /Net worth over time/ }));
+
+    await waitFor(() =>
+      expect(screen.getByRole('button', { name: 'Last month' })).toHaveAttribute('aria-pressed', 'true')
+    );
+  });
+
+  it('sends an unknown report id back to the gallery instead of an empty frame', () => {
+    renderHub('/reports/no-such-report');
+
+    expect(screen.getByRole('heading', { level: 1, name: 'Reports' })).toBeInTheDocument();
+  });
+
+  // Each report is code-split and only ever rendered through the hub, so this
+  // is the one place a runtime error in a report view would surface.
+  it.each([
+    ['net-worth', 'What you own'],
+    ['net-worth-over-time', 'Net Worth Over Time'],
+    ['account-balances', 'Balances by account'],
+    ['monthly-income-expenses', 'Top Transactions'],
+    ['spending-by-category', 'Where the money went'],
+    ['income-and-spending-over-time', 'Income against spending'],
+    ['spending-by-payee', 'Biggest payees'],
+    ['period-comparison', 'Biggest movers'],
+  ])('renders the %s report', async (id, heading) => {
+    renderHub(`/reports/${id}`);
+
+    expect(await screen.findByRole('heading', { name: heading })).toBeInTheDocument();
+  });
+
+  it('hides the period picker for reports that carry their own filters', async () => {
+    renderHub('/reports/custom-reports');
+
+    expect(await screen.findByRole('heading', { level: 1, name: 'Custom reports' })).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Last month' })).not.toBeInTheDocument();
+  });
+});

--- a/src/pages/__tests__/ReportsHub.test.tsx
+++ b/src/pages/__tests__/ReportsHub.test.tsx
@@ -122,6 +122,88 @@ describe('ReportsHub gallery', () => {
     );
   });
 
+  it('opens each report on the window it is worth reading over', async () => {
+    // A month of net worth is a dot, not a trend.
+    renderHub('/reports/net-worth-over-time');
+    await screen.findByRole('heading', { name: 'Net Worth Over Time' });
+    expect(screen.getByRole('button', { name: 'All time' })).toHaveAttribute('aria-pressed', 'true');
+    expect(screen.getByRole('button', { name: 'This month' })).toHaveAttribute('aria-pressed', 'false');
+  });
+
+  it('gives a month-by-month report a year to compare', async () => {
+    renderHub('/reports/income-and-spending-over-time');
+    await screen.findByRole('heading', { name: 'Income against spending' });
+
+    expect(screen.getByRole('button', { name: '12 months' })).toHaveAttribute('aria-pressed', 'true');
+  });
+
+  it('leaves reports without a preference on this month', async () => {
+    renderHub('/reports/spending-by-category');
+    await screen.findByRole('heading', { name: 'Where the money went' });
+
+    expect(screen.getByRole('button', { name: 'This month' })).toHaveAttribute('aria-pressed', 'true');
+  });
+
+  it('applies the default of the report being opened, not the one just closed', async () => {
+    renderHub();
+
+    fireEvent.click(screen.getByRole('link', { name: /Net worth over time/ }));
+    await screen.findByRole('heading', { name: 'Net Worth Over Time' });
+    expect(screen.getByRole('button', { name: 'All time' })).toHaveAttribute('aria-pressed', 'true');
+
+    fireEvent.click(screen.getByRole('link', { name: 'All reports' }));
+    fireEvent.click(screen.getByRole('link', { name: /Spending by category/ }));
+    await screen.findByRole('heading', { name: 'Where the money went' });
+
+    // "All time" was never asked for, so it does not stick to the next report.
+    expect(screen.getByRole('button', { name: 'This month' })).toHaveAttribute('aria-pressed', 'true');
+  });
+
+  it('never overrides a period the user chose, whatever the report prefers', async () => {
+    renderHub();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Tax year' }));
+
+    fireEvent.click(screen.getByRole('link', { name: /Net worth over time/ }));
+    await screen.findByRole('heading', { name: 'Net Worth Over Time' });
+    expect(screen.getByRole('button', { name: 'Tax year' })).toHaveAttribute('aria-pressed', 'true');
+    expect(screen.getByRole('button', { name: 'All time' })).toHaveAttribute('aria-pressed', 'false');
+
+    fireEvent.click(screen.getByRole('link', { name: 'All reports' }));
+    fireEvent.click(screen.getByRole('link', { name: /Income and spending over time/ }));
+    await screen.findByRole('heading', { name: 'Income against spending' });
+
+    expect(screen.getByRole('button', { name: 'Tax year' })).toHaveAttribute('aria-pressed', 'true');
+    expect(screen.getByRole('button', { name: '12 months' })).toHaveAttribute('aria-pressed', 'false');
+  });
+
+  it('remembers the choice after a reload, so no report can undo it', async () => {
+    const first = renderHub();
+    fireEvent.click(screen.getByRole('button', { name: 'Tax year' }));
+    first.unmount();
+
+    // A fresh visit — straight to the report with the strongest preference.
+    renderHub('/reports/net-worth-over-time');
+    await screen.findByRole('heading', { name: 'Net Worth Over Time' });
+
+    expect(screen.getByRole('button', { name: 'Tax year' })).toHaveAttribute('aria-pressed', 'true');
+  });
+
+  it('treats a custom range as a choice like any other', async () => {
+    renderHub();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Custom' }));
+    fireEvent.change(screen.getByLabelText('Custom period start date'), {
+      target: { value: '2026-01-10' },
+    });
+
+    fireEvent.click(screen.getByRole('link', { name: /Net worth over time/ }));
+    await screen.findByRole('heading', { name: 'Net Worth Over Time' });
+
+    expect(screen.getByRole('button', { name: 'Custom' })).toHaveAttribute('aria-pressed', 'true');
+    expect(screen.getByLabelText('Custom period start date')).toHaveValue('2026-01-10');
+  });
+
   it('sends an unknown report id back to the gallery instead of an empty frame', () => {
     renderHub('/reports/no-such-report');
 

--- a/src/pages/reports/AccountBalancesReport.tsx
+++ b/src/pages/reports/AccountBalancesReport.tsx
@@ -1,0 +1,187 @@
+import React, { useMemo, useState } from 'react';
+import { useApp } from '../../contexts/AppContextSupabase';
+import { useCurrencyDecimal } from '../../hooks/useCurrencyDecimal';
+import ReportDrillModal, { type ReportDrillTarget } from '../../components/reports/ReportDrillModal';
+import { buildAccountBalanceReport, type AccountBalanceRow } from '../../utils/accountBalanceReport';
+import { PERIOD_LABELS } from '../../hooks/usePeriod';
+import type { ReportViewProps } from './types';
+
+/**
+ * "Account balances" — the Microsoft Money statement: what each account was
+ * worth when the period opened, what moved through it, and what it is worth
+ * now.
+ *
+ * Balances are computed from first principles (opening balance + every
+ * transaction, Decimal throughout — see utils/accountBalanceReport), never
+ * from the cached `account.balance`, so the figures reconcile with the
+ * net-worth chart line for line.
+ */
+export default function AccountBalancesReport({ picker }: ReportViewProps): React.JSX.Element {
+  const { accounts, transactions, categories } = useApp();
+  const { formatCurrency } = useCurrencyDecimal();
+  const [drill, setDrill] = useState<ReportDrillTarget | null>(null);
+
+  const report = useMemo(
+    () => buildAccountBalanceReport(accounts, transactions, picker.range),
+    [accounts, transactions, picker.range]
+  );
+
+  const drillIntoAccount = (row: AccountBalanceRow): void => {
+    const rows = transactions
+      .filter(t => t.accountId === row.accountId && picker.inRange(t.date))
+      .sort((a, b) => new Date(b.date).getTime() - new Date(a.date).getTime());
+    setDrill({
+      title: `${row.name} — ${PERIOD_LABELS[picker.period]}`,
+      // The account view: rows keep their own sign and the total is the net
+      // movement, because this is not one side of the income/expense report.
+      bucket: 'neutral',
+      rows,
+      total: row.change,
+    });
+  };
+
+  const money = (value: number, currency?: string): string =>
+    value < 0
+      ? `-${formatCurrency(Math.abs(value), currency)}`
+      : formatCurrency(value, currency);
+
+  const signClass = (value: number): string =>
+    value < 0 ? 'text-red-600 dark:text-red-400' : 'text-gray-900 dark:text-white';
+
+  const headCell = 'px-3 py-2 text-xs font-semibold uppercase tracking-wider text-gray-500 dark:text-gray-400';
+  const cell = 'px-3 py-2 text-sm text-right tabular-nums whitespace-nowrap';
+
+  return (
+    <div className="max-w-[1400px] mx-auto space-y-6">
+      <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+        <div className="bg-[#1a2332] dark:bg-gray-700 rounded-2xl p-6 text-white">
+          <p className="text-xs text-white/60 uppercase tracking-wider font-medium">
+            Total balance
+          </p>
+          <p className="text-2xl font-bold mt-1">{money(report.netWorth)}</p>
+          <p className="text-xs text-white/60 mt-1">
+            As at {report.asOf.toLocaleDateString('en-GB', { day: 'numeric', month: 'long', year: 'numeric' })}
+          </p>
+        </div>
+        <div className="bg-white dark:bg-gray-800 rounded-2xl p-6 border border-gray-100 dark:border-gray-700">
+          <p className="text-xs text-gray-500 uppercase tracking-wider font-medium">In credit</p>
+          <p className="text-2xl font-bold mt-1 text-green-600 dark:text-green-400">
+            {formatCurrency(report.assets)}
+          </p>
+        </div>
+        <div className="bg-white dark:bg-gray-800 rounded-2xl p-6 border border-gray-100 dark:border-gray-700">
+          <p className="text-xs text-gray-500 uppercase tracking-wider font-medium">Overdrawn / owed</p>
+          <p className="text-2xl font-bold mt-1 text-red-600 dark:text-red-400">
+            {formatCurrency(report.liabilities)}
+          </p>
+        </div>
+      </div>
+
+      <div className="bg-white dark:bg-gray-800 rounded-2xl shadow-lg border border-gray-100 dark:border-gray-700">
+        <div className="p-6 pb-3">
+          <h2 className="text-lg font-semibold text-theme-heading dark:text-white">
+            Balances by account
+          </h2>
+          <p className="text-sm text-gray-500 dark:text-gray-400 mt-1">
+            {PERIOD_LABELS[picker.period]} — click an account to see the transactions behind its movement.
+          </p>
+        </div>
+
+        {report.rows.length === 0 ? (
+          <p className="text-center py-16 text-gray-400">No accounts yet</p>
+        ) : (
+          /* The table scrolls inside its own box; the page never scrolls sideways. */
+          <div className="overflow-x-auto rounded-b-2xl">
+            <table className="min-w-full text-sm">
+              <caption className="sr-only">
+                Opening balance, money in and out, and closing balance for every account
+              </caption>
+              <thead className="bg-gray-50 dark:bg-gray-700/50">
+                <tr>
+                  <th scope="col" className={`${headCell} text-left min-w-[180px]`}>Account</th>
+                  <th scope="col" className={`${headCell} text-right`}>Opening</th>
+                  <th scope="col" className={`${headCell} text-right`}>In</th>
+                  <th scope="col" className={`${headCell} text-right`}>Out</th>
+                  <th scope="col" className={`${headCell} text-right`}>Change</th>
+                  <th scope="col" className={`${headCell} text-right`}>Closing</th>
+                  <th scope="col" className={`${headCell} text-right`}>Transactions</th>
+                </tr>
+              </thead>
+              {report.groups.map(group => (
+                <tbody key={group.key} className="border-t border-gray-100 dark:border-gray-700">
+                  <tr className="bg-gray-50 dark:bg-gray-700/50">
+                    <th
+                      scope="row"
+                      className="px-3 py-1.5 text-left text-xs font-semibold uppercase tracking-wide text-gray-600 dark:text-gray-300"
+                    >
+                      {group.label}
+                    </th>
+                    <td className={`${cell} text-gray-500 dark:text-gray-400`}>{money(group.opening)}</td>
+                    <td className={cell} />
+                    <td className={cell} />
+                    <td className={`${cell} ${signClass(group.change)}`}>{money(group.change)}</td>
+                    <td className={`${cell} font-semibold ${signClass(group.closing)}`}>{money(group.closing)}</td>
+                    <td className={cell} />
+                  </tr>
+                  {group.rows.map(row => (
+                    <tr key={row.accountId} className="border-t border-gray-50 dark:border-gray-700/50">
+                      <th scope="row" className="px-3 py-2 text-left font-normal">
+                        <button
+                          type="button"
+                          onClick={() => drillIntoAccount(row)}
+                          className="text-sm text-gray-900 dark:text-white hover:text-blue-700 dark:hover:text-blue-400 hover:underline rounded focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
+                          title={`${row.name} — view these transactions`}
+                        >
+                          {row.name}
+                        </button>
+                      </th>
+                      <td className={`${cell} text-gray-500 dark:text-gray-400`}>
+                        {money(row.opening, row.currency)}
+                      </td>
+                      <td className={`${cell} text-green-700 dark:text-green-400`}>
+                        {row.moneyIn === 0 ? '—' : formatCurrency(row.moneyIn, row.currency)}
+                      </td>
+                      <td className={`${cell} text-red-600 dark:text-red-400`}>
+                        {row.moneyOut === 0 ? '—' : formatCurrency(row.moneyOut, row.currency)}
+                      </td>
+                      <td className={`${cell} ${signClass(row.change)}`}>
+                        {money(row.change, row.currency)}
+                      </td>
+                      <td className={`${cell} font-semibold ${signClass(row.closing)}`}>
+                        {money(row.closing, row.currency)}
+                      </td>
+                      <td className={`${cell} text-gray-500 dark:text-gray-400`}>
+                        {row.count.toLocaleString()}
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              ))}
+              <tfoot className="border-t-2 border-gray-200 dark:border-gray-600">
+                <tr>
+                  <th scope="row" className="px-3 py-3 text-left text-sm font-semibold text-gray-900 dark:text-white">
+                    Total
+                  </th>
+                  <td className={`${cell} font-semibold ${signClass(report.openingNetWorth)}`}>
+                    {money(report.openingNetWorth)}
+                  </td>
+                  <td className={cell} />
+                  <td className={cell} />
+                  <td className={`${cell} font-semibold ${signClass(report.change)}`}>
+                    {money(report.change)}
+                  </td>
+                  <td className={`${cell} font-bold ${signClass(report.netWorth)}`}>
+                    {money(report.netWorth)}
+                  </td>
+                  <td className={cell} />
+                </tr>
+              </tfoot>
+            </table>
+          </div>
+        )}
+      </div>
+
+      <ReportDrillModal target={drill} onClose={() => setDrill(null)} categories={categories} />
+    </div>
+  );
+}

--- a/src/pages/reports/IncomeSpendingOverTimeReport.tsx
+++ b/src/pages/reports/IncomeSpendingOverTimeReport.tsx
@@ -1,0 +1,302 @@
+import React, { useMemo, useRef, useState } from 'react';
+import {
+  ResponsiveContainer,
+  ComposedChart,
+  Line,
+  Bar,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  Legend,
+} from 'recharts';
+import { useCurrencyDecimal } from '../../hooks/useCurrencyDecimal';
+import { useReportDataset } from '../../hooks/useReportDataset';
+import { useReportAccountFilter } from '../../hooks/useReportAccountFilter';
+import ReportAccountFilter from '../../components/reports/ReportAccountFilter';
+import ReportDrillModal, { type ReportDrillTarget } from '../../components/reports/ReportDrillModal';
+import ReportExportBar from '../../components/reports/ReportExportBar';
+import UncategorisedReviewBand from '../../components/reports/UncategorisedReviewBand';
+import { buildMonthlyTrend } from '../../utils/monthlyTrend';
+import { toDecimal } from '../../utils/decimal';
+import { formatDecimal } from '../../utils/decimal-format';
+import { PERIOD_LABELS } from '../../hooks/usePeriod';
+import type { ReportViewProps } from './types';
+import type { SplitExpandedTransaction } from '../../utils/transactionSplits';
+
+/**
+ * "Income and spending over time" — month by month, what came in against what
+ * went out, and what was left.
+ *
+ * The series comes from the shared builder (utils/monthlyTrend), which is the
+ * same one behind the Dashboard's pinned trend widget — the glance and the
+ * full report cannot disagree. Points on the chart and figures in the table
+ * both open the transactions behind them.
+ */
+
+const compactTick = (value: number): string => {
+  const abs = Math.abs(value);
+  const sign = value < 0 ? '-' : '';
+  if (abs >= 1_000_000) return `${sign}${formatDecimal(abs / 1_000_000, 1)}M`;
+  if (abs >= 1_000) return `${sign}${formatDecimal(abs / 1_000, 0)}K`;
+  return formatDecimal(value, 0);
+};
+
+export default function IncomeSpendingOverTimeReport({ picker }: ReportViewProps): React.JSX.Element {
+  const filter = useReportAccountFilter();
+  const { accounts, categories, rows, flows } = useReportDataset(picker, filter.accountId);
+  const { formatCurrency } = useCurrencyDecimal();
+  const [drill, setDrill] = useState<ReportDrillTarget | null>(null);
+  const chartRef = useRef<HTMLDivElement>(null);
+  // Lines or bars — same data, same drill-in; the choice is persisted.
+  const [chartType, setChartType] = useState<'line' | 'bar'>(() =>
+    localStorage.getItem('reportsTrendChartType') === 'bar' ? 'bar' : 'line'
+  );
+  const handleChartType = (type: 'line' | 'bar'): void => {
+    setChartType(type);
+    localStorage.setItem('reportsTrendChartType', type);
+  };
+
+  const trend = useMemo(() => buildMonthlyTrend(rows, categories), [rows, categories]);
+
+  const totals = useMemo(() => {
+    const income = trend.reduce((sum, point) => sum.plus(toDecimal(point.income)), toDecimal(0));
+    const expenses = trend.reduce((sum, point) => sum.plus(toDecimal(point.expenses)), toDecimal(0));
+    return { income: income.toNumber(), expenses: expenses.toNumber(), net: income.minus(expenses).toNumber() };
+  }, [trend]);
+
+  const netOf = (point: { income: number; expenses: number }): number =>
+    toDecimal(point.income).minus(toDecimal(point.expenses)).toNumber();
+
+  const rowsOfMonth = (source: SplitExpandedTransaction[], monthKey: string): SplitExpandedTransaction[] =>
+    source.filter(t => new Date(t.date).toISOString().slice(0, 7) === monthKey);
+
+  const drillIntoMonth = (
+    monthKey: string,
+    label: string,
+    bucket: 'income' | 'expense',
+    total: number
+  ): void => {
+    setDrill({
+      title: `${bucket === 'income' ? 'Income' : 'Expenses'} — ${label}`,
+      bucket,
+      rows: rowsOfMonth(bucket === 'income' ? flows.incomeRows : flows.expenseRows, monthKey),
+      total,
+    });
+  };
+
+  // recharts calls activeDot onClick with (props, event) — but the argument
+  // order has differed across versions, so scan for whichever carries the
+  // datum payload.
+  const handlePointClick = (series: 'income' | 'expenses') =>
+    (...args: unknown[]): void => {
+      for (const arg of args) {
+        const payload = (arg as { payload?: { monthKey?: string; month?: string; income?: number; expenses?: number } } | null)?.payload;
+        if (payload?.monthKey && payload.month) {
+          drillIntoMonth(
+            payload.monthKey,
+            payload.month,
+            series === 'income' ? 'income' : 'expense',
+            payload[series] ?? 0
+          );
+          return;
+        }
+      }
+    };
+
+  const figureButton = (
+    label: string,
+    value: number,
+    onClick: () => void,
+    colour: string
+  ): React.JSX.Element => (
+    <button
+      type="button"
+      onClick={onClick}
+      className={`w-full text-right rounded px-1 -mx-1 tabular-nums hover:bg-blue-50 dark:hover:bg-blue-900/30 hover:underline focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 ${colour}`}
+      title={`${label} — view these transactions`}
+    >
+      {formatCurrency(value)}
+    </button>
+  );
+
+  return (
+    <div className="max-w-[1400px] mx-auto space-y-6">
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <ReportAccountFilter accounts={accounts} filter={filter} />
+        <ReportExportBar
+          title="Income and spending over time"
+          dateRange={PERIOD_LABELS[picker.period]}
+          rows={rows}
+          flows={flows}
+          categories={categories}
+          accounts={accounts}
+          charts={[chartRef]}
+        />
+      </div>
+
+      <UncategorisedReviewBand flows={flows} categories={categories} />
+
+      <div className="bg-white dark:bg-gray-800 rounded-2xl shadow-lg border border-gray-100 dark:border-gray-700 p-6">
+        <div className="flex flex-wrap items-start justify-between gap-2 mb-1">
+          <h2 className="text-lg font-semibold text-theme-heading dark:text-white">
+            Income against spending
+          </h2>
+          <div className="inline-flex rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 p-0.5">
+            {(['line', 'bar'] as const).map(type => (
+              <button
+                key={type}
+                type="button"
+                onClick={() => handleChartType(type)}
+                aria-pressed={chartType === type}
+                className={`px-3 py-1 text-sm font-medium rounded-md transition-colors ${
+                  chartType === type
+                    ? 'bg-[#1a2332] dark:bg-blue-600 text-white'
+                    : 'text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-200'
+                }`}
+              >
+                {type === 'line' ? 'Line' : 'Bar'}
+              </button>
+            ))}
+          </div>
+        </div>
+        <p className="text-sm text-gray-500 dark:text-gray-400 mb-4">
+          {PERIOD_LABELS[picker.period]} — click a point, or any figure in the table, for the transactions behind it.
+        </p>
+        {trend.length === 0 ? (
+          <p className="text-center py-16 text-gray-400">No categorised transactions in this period</p>
+        ) : (
+          <div className="h-80" ref={chartRef}>
+            <ResponsiveContainer width="100%" height="100%">
+              <ComposedChart data={trend}>
+                <CartesianGrid strokeDasharray="3 3" stroke="rgba(107, 114, 128, 0.2)" />
+                <XAxis dataKey="month" tick={{ fill: '#6B7280', fontSize: 12 }} minTickGap={24} />
+                <YAxis tick={{ fill: '#6B7280', fontSize: 12 }} tickFormatter={compactTick} width={70} />
+                <Tooltip
+                  formatter={(value: number | string) =>
+                    formatCurrency(typeof value === 'number' ? value : Number(value))
+                  }
+                  contentStyle={{ borderRadius: '8px' }}
+                />
+                <Legend />
+                {chartType === 'bar' ? (
+                  <Bar dataKey="income" name="Income" fill="#10B981" radius={[3, 3, 0, 0]} cursor="pointer" isAnimationActive={false} onClick={handlePointClick('income')} />
+                ) : (
+                  <Line
+                    type="monotone"
+                    dataKey="income"
+                    name="Income"
+                    stroke="#10B981"
+                    strokeWidth={2}
+                    dot={false}
+                    isAnimationActive={false}
+                    activeDot={{ r: 6, cursor: 'pointer', onClick: handlePointClick('income') }}
+                  />
+                )}
+                {chartType === 'bar' ? (
+                  <Bar dataKey="expenses" name="Expenses" fill="#EF4444" radius={[3, 3, 0, 0]} cursor="pointer" isAnimationActive={false} onClick={handlePointClick('expenses')} />
+                ) : (
+                  <Line
+                    type="monotone"
+                    dataKey="expenses"
+                    name="Expenses"
+                    stroke="#EF4444"
+                    strokeWidth={2}
+                    dot={false}
+                    isAnimationActive={false}
+                    activeDot={{ r: 6, cursor: 'pointer', onClick: handlePointClick('expenses') }}
+                  />
+                )}
+              </ComposedChart>
+            </ResponsiveContainer>
+          </div>
+        )}
+      </div>
+
+      <div className="bg-white dark:bg-gray-800 rounded-2xl shadow-lg border border-gray-100 dark:border-gray-700">
+        <div className="p-6 pb-3">
+          <h2 className="text-lg font-semibold text-theme-heading dark:text-white">Month by month</h2>
+        </div>
+        {trend.length === 0 ? (
+          <p className="text-center py-16 text-gray-400">No categorised transactions in this period</p>
+        ) : (
+          /* The table scrolls inside its own box; the page never scrolls sideways. */
+          <div className="overflow-x-auto rounded-b-2xl">
+            <table className="min-w-full text-sm">
+              <caption className="sr-only">Income, expenses and the balance for each month of the period</caption>
+              <thead className="bg-gray-50 dark:bg-gray-700/50">
+                <tr>
+                  <th scope="col" className="px-6 py-2 text-left text-xs font-semibold uppercase tracking-wider text-gray-500 dark:text-gray-400 min-w-[140px]">
+                    Month
+                  </th>
+                  <th scope="col" className="px-3 py-2 text-right text-xs font-semibold uppercase tracking-wider text-gray-500 dark:text-gray-400">
+                    Income
+                  </th>
+                  <th scope="col" className="px-3 py-2 text-right text-xs font-semibold uppercase tracking-wider text-gray-500 dark:text-gray-400">
+                    Expenses
+                  </th>
+                  <th scope="col" className="px-6 py-2 text-right text-xs font-semibold uppercase tracking-wider text-gray-500 dark:text-gray-400">
+                    Left over
+                  </th>
+                </tr>
+              </thead>
+              <tbody>
+                {trend.map(point => {
+                  const net = netOf(point);
+                  return (
+                    <tr key={point.monthKey} className="border-t border-gray-50 dark:border-gray-700/50">
+                      <th scope="row" className="px-6 py-2 text-left text-sm font-normal text-gray-900 dark:text-white">
+                        {point.month}
+                      </th>
+                      <td className="px-3 py-2 text-sm text-right">
+                        {figureButton(
+                          `Income, ${point.month}`,
+                          point.income,
+                          () => drillIntoMonth(point.monthKey, point.month, 'income', point.income),
+                          'text-green-700 dark:text-green-400'
+                        )}
+                      </td>
+                      <td className="px-3 py-2 text-sm text-right">
+                        {figureButton(
+                          `Expenses, ${point.month}`,
+                          point.expenses,
+                          () => drillIntoMonth(point.monthKey, point.month, 'expense', point.expenses),
+                          'text-red-600 dark:text-red-400'
+                        )}
+                      </td>
+                      <td className={`px-6 py-2 text-sm text-right font-semibold tabular-nums ${
+                        net < 0 ? 'text-red-600 dark:text-red-400' : 'text-gray-900 dark:text-white'
+                      }`}>
+                        {net < 0 ? `-${formatCurrency(Math.abs(net))}` : formatCurrency(net)}
+                      </td>
+                    </tr>
+                  );
+                })}
+              </tbody>
+              <tfoot className="border-t-2 border-gray-200 dark:border-gray-600">
+                <tr>
+                  <th scope="row" className="px-6 py-3 text-left text-sm font-semibold text-gray-900 dark:text-white">
+                    Total
+                  </th>
+                  <td className="px-3 py-3 text-sm text-right font-bold tabular-nums text-green-700 dark:text-green-400">
+                    {formatCurrency(totals.income)}
+                  </td>
+                  <td className="px-3 py-3 text-sm text-right font-bold tabular-nums text-red-600 dark:text-red-400">
+                    {formatCurrency(totals.expenses)}
+                  </td>
+                  <td className={`px-6 py-3 text-sm text-right font-bold tabular-nums ${
+                    totals.net < 0 ? 'text-red-600 dark:text-red-400' : 'text-gray-900 dark:text-white'
+                  }`}>
+                    {totals.net < 0 ? `-${formatCurrency(Math.abs(totals.net))}` : formatCurrency(totals.net)}
+                  </td>
+                </tr>
+              </tfoot>
+            </table>
+          </div>
+        )}
+      </div>
+
+      <ReportDrillModal target={drill} onClose={() => setDrill(null)} categories={categories} />
+    </div>
+  );
+}

--- a/src/pages/reports/NetWorthStatementReport.tsx
+++ b/src/pages/reports/NetWorthStatementReport.tsx
@@ -1,0 +1,176 @@
+import React, { useMemo, useState } from 'react';
+import { useApp } from '../../contexts/AppContextSupabase';
+import { useCurrencyDecimal } from '../../hooks/useCurrencyDecimal';
+import ReportDrillModal, { type ReportDrillTarget } from '../../components/reports/ReportDrillModal';
+import { buildAccountBalanceReport, type AccountBalanceRow } from '../../utils/accountBalanceReport';
+import { PERIOD_LABELS } from '../../hooks/usePeriod';
+import type { ReportViewProps } from './types';
+
+/**
+ * "Net worth" — the Microsoft Money statement: everything you own set
+ * against everything you owe, at the end of the selected period, with the
+ * move since the period opened.
+ *
+ * Shares its figures with the Account balances report and the net-worth chart
+ * (utils/accountBalanceReport): opening balance + every transaction, Decimal
+ * throughout, and an account counts as a liability when its BALANCE is
+ * negative — an overdrawn current account is money owed, whatever its type
+ * says.
+ */
+export default function NetWorthStatementReport({ picker }: ReportViewProps): React.JSX.Element {
+  const { accounts, transactions, categories } = useApp();
+  const { formatCurrency } = useCurrencyDecimal();
+  const [drill, setDrill] = useState<ReportDrillTarget | null>(null);
+
+  const report = useMemo(
+    () => buildAccountBalanceReport(accounts, transactions, picker.range),
+    [accounts, transactions, picker.range]
+  );
+
+  /** Which statement section each account sits under, e.g. "Savings". */
+  const groupLabels = useMemo(() => {
+    const labels = new Map<string, string>();
+    for (const group of report.groups) {
+      for (const row of group.rows) labels.set(row.accountId, group.label);
+    }
+    return labels;
+  }, [report.groups]);
+
+  const sides = useMemo(() => {
+    const byMagnitude = (a: AccountBalanceRow, b: AccountBalanceRow): number =>
+      Math.abs(b.closing) - Math.abs(a.closing) ||
+      a.name.localeCompare(b.name, undefined, { sensitivity: 'base' });
+    return {
+      owned: report.rows.filter(row => row.closing > 0).sort(byMagnitude),
+      owed: report.rows.filter(row => row.closing < 0).sort(byMagnitude),
+    };
+  }, [report.rows]);
+
+  const drillIntoAccount = (row: AccountBalanceRow): void => {
+    const rows = transactions
+      .filter(t => t.accountId === row.accountId && picker.inRange(t.date))
+      .sort((a, b) => new Date(b.date).getTime() - new Date(a.date).getTime());
+    setDrill({
+      title: `${row.name} — ${PERIOD_LABELS[picker.period]}`,
+      bucket: 'neutral',
+      rows,
+      total: row.change,
+    });
+  };
+
+  const money = (value: number, currency?: string): string =>
+    value < 0 ? `-${formatCurrency(Math.abs(value), currency)}` : formatCurrency(value, currency);
+
+  const section = (
+    title: string,
+    rows: AccountBalanceRow[],
+    total: number,
+    emptyText: string
+  ): React.JSX.Element => (
+    <div className="bg-white dark:bg-gray-800 rounded-2xl shadow-lg border border-gray-100 dark:border-gray-700">
+      <div className="flex items-baseline justify-between gap-3 p-6 pb-3">
+        <h2 className="text-lg font-semibold text-theme-heading dark:text-white">{title}</h2>
+        <span className="text-lg font-bold tabular-nums text-gray-900 dark:text-white">
+          {formatCurrency(total)}
+        </span>
+      </div>
+      {rows.length === 0 ? (
+        <p className="px-6 pb-6 text-sm text-gray-400">{emptyText}</p>
+      ) : (
+        <div className="overflow-x-auto rounded-b-2xl">
+          <table className="min-w-full text-sm">
+            <caption className="sr-only">{title} by account</caption>
+            <thead className="bg-gray-50 dark:bg-gray-700/50">
+              <tr>
+                <th scope="col" className="px-6 py-2 text-left text-xs font-semibold uppercase tracking-wider text-gray-500 dark:text-gray-400 min-w-[200px]">
+                  Account
+                </th>
+                <th scope="col" className="px-3 py-2 text-right text-xs font-semibold uppercase tracking-wider text-gray-500 dark:text-gray-400">
+                  Change this period
+                </th>
+                <th scope="col" className="px-6 py-2 text-right text-xs font-semibold uppercase tracking-wider text-gray-500 dark:text-gray-400">
+                  Balance
+                </th>
+              </tr>
+            </thead>
+            <tbody>
+              {rows.map(row => (
+                <tr key={row.accountId} className="border-t border-gray-50 dark:border-gray-700/50">
+                  <th scope="row" className="px-6 py-2.5 text-left font-normal">
+                    <button
+                      type="button"
+                      onClick={() => drillIntoAccount(row)}
+                      className="text-left rounded focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
+                      title={`${row.name} — view these transactions`}
+                    >
+                      <span className="block text-sm text-gray-900 dark:text-white hover:text-blue-700 dark:hover:text-blue-400 hover:underline">
+                        {row.name}
+                      </span>
+                      <span className="block text-xs text-gray-400 dark:text-gray-500">
+                        {groupLabels.get(row.accountId) ?? 'Other'}
+                      </span>
+                    </button>
+                  </th>
+                  <td className={`px-3 py-2.5 text-sm text-right tabular-nums whitespace-nowrap ${
+                    row.change < 0 ? 'text-red-600 dark:text-red-400' : 'text-green-700 dark:text-green-400'
+                  }`}>
+                    {row.change === 0 ? '—' : `${row.change > 0 ? '+' : ''}${money(row.change, row.currency)}`}
+                  </td>
+                  <td className="px-6 py-2.5 text-sm text-right font-semibold tabular-nums whitespace-nowrap text-gray-900 dark:text-white">
+                    {money(Math.abs(row.closing), row.currency)}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  );
+
+  return (
+    <div className="max-w-[1400px] mx-auto space-y-6">
+      <div className="grid grid-cols-1 md:grid-cols-4 gap-4">
+        <div className="bg-[#1a2332] dark:bg-gray-700 rounded-2xl p-6 text-white">
+          <p className="text-xs text-white/60 uppercase tracking-wider font-medium">Net worth</p>
+          <p className="text-2xl font-bold mt-1">{money(report.netWorth)}</p>
+          <p className="text-xs text-white/60 mt-1">
+            As at {report.asOf.toLocaleDateString('en-GB', { day: 'numeric', month: 'long', year: 'numeric' })}
+          </p>
+        </div>
+        <div className="bg-white dark:bg-gray-800 rounded-2xl p-6 border border-gray-100 dark:border-gray-700">
+          <p className="text-xs text-gray-500 uppercase tracking-wider font-medium">What you own</p>
+          <p className="text-2xl font-bold mt-1 text-green-600 dark:text-green-400">
+            {formatCurrency(report.assets)}
+          </p>
+        </div>
+        <div className="bg-white dark:bg-gray-800 rounded-2xl p-6 border border-gray-100 dark:border-gray-700">
+          <p className="text-xs text-gray-500 uppercase tracking-wider font-medium">What you owe</p>
+          <p className="text-2xl font-bold mt-1 text-red-600 dark:text-red-400">
+            {formatCurrency(report.liabilities)}
+          </p>
+        </div>
+        <div className="bg-white dark:bg-gray-800 rounded-2xl p-6 border border-gray-100 dark:border-gray-700">
+          <p className="text-xs text-gray-500 uppercase tracking-wider font-medium">
+            Change — {PERIOD_LABELS[picker.period]}
+          </p>
+          <p className={`text-2xl font-bold mt-1 ${
+            report.change < 0 ? 'text-red-600 dark:text-red-400' : 'text-green-600 dark:text-green-400'
+          }`}>
+            {report.change > 0 ? '+' : ''}{money(report.change)}
+          </p>
+          <p className="text-xs text-gray-400 dark:text-gray-500 mt-1">
+            From {money(report.openingNetWorth)}
+          </p>
+        </div>
+      </div>
+
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-6 items-start">
+        {section('What you own', sides.owned, report.assets, 'No account is in credit in this period')}
+        {section('What you owe', sides.owed, report.liabilities, 'Nothing owed — no account is overdrawn')}
+      </div>
+
+      <ReportDrillModal target={drill} onClose={() => setDrill(null)} categories={categories} />
+    </div>
+  );
+}

--- a/src/pages/reports/PeriodComparisonReport.tsx
+++ b/src/pages/reports/PeriodComparisonReport.tsx
@@ -1,0 +1,357 @@
+import React, { useMemo, useRef, useState } from 'react';
+import { ResponsiveContainer, BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip, Legend } from 'recharts';
+import { useCurrencyDecimal } from '../../hooks/useCurrencyDecimal';
+import { useReportDataset } from '../../hooks/useReportDataset';
+import { useReportAccountFilter } from '../../hooks/useReportAccountFilter';
+import ReportAccountFilter from '../../components/reports/ReportAccountFilter';
+import ReportDrillModal, { type ReportDrillTarget } from '../../components/reports/ReportDrillModal';
+import ReportExportBar from '../../components/reports/ReportExportBar';
+import UncategorisedReviewBand from '../../components/reports/UncategorisedReviewBand';
+import { computeIncomeExpense } from '../../utils/incomeExpense';
+import {
+  buildPeriodComparison,
+  resolveComparisonRanges,
+  COMPARISON_BASIS_LABELS,
+  type ComparisonBasis,
+  type ComparisonCategoryRow,
+  type ComparisonFigure,
+} from '../../utils/periodComparison';
+import { formatDecimal } from '../../utils/decimal-format';
+import { PERIOD_LABELS } from '../../hooks/usePeriod';
+import type { ReportViewProps } from './types';
+
+/**
+ * "This period vs last" — Money's comparison report.
+ *
+ * Two equal-length windows, classified by the one shared classifier
+ * (utils/incomeExpense) and compared by the one shared builder
+ * (utils/periodComparison). Both windows are computed from the SAME resolved
+ * bounds, so the comparison is never an apples-to-oranges pairing of a full
+ * month against a part of one.
+ *
+ * Every figure — current or comparison — clicks through to the transactions
+ * behind it.
+ */
+
+const BASIS_KEY = 'reportsComparisonBasis';
+
+const formatWindow = (window: { from: Date; to: Date }): string => {
+  const short = (date: Date): string =>
+    date.toLocaleDateString('en-GB', { day: 'numeric', month: 'short', year: 'numeric' });
+  return `${short(window.from)} – ${short(window.to)}`;
+};
+
+export default function PeriodComparisonReport({ picker }: ReportViewProps): React.JSX.Element {
+  const filter = useReportAccountFilter();
+  const { accounts, categories, accountTransactions, transactionSplits, rows, flows } =
+    useReportDataset(picker, filter.accountId);
+  const { formatCurrency } = useCurrencyDecimal();
+  const [drill, setDrill] = useState<ReportDrillTarget | null>(null);
+  const chartRef = useRef<HTMLDivElement>(null);
+  const [basis, setBasis] = useState<ComparisonBasis>(() =>
+    localStorage.getItem(BASIS_KEY) === 'same-period-last-year' ? 'same-period-last-year' : 'previous-period'
+  );
+  const handleBasis = (next: ComparisonBasis): void => {
+    setBasis(next);
+    localStorage.setItem(BASIS_KEY, next);
+  };
+
+  const ranges = useMemo(() => resolveComparisonRanges(picker.range, basis), [picker.range, basis]);
+
+  // BOTH windows are measured from the resolved bounds, so the two figures
+  // are always like for like.
+  const currentFlows = useMemo(
+    () => (ranges ? computeIncomeExpense(accountTransactions, transactionSplits, categories, ranges.current) : null),
+    [ranges, accountTransactions, transactionSplits, categories]
+  );
+  const previousFlows = useMemo(
+    () => (ranges ? computeIncomeExpense(accountTransactions, transactionSplits, categories, ranges.previous) : null),
+    [ranges, accountTransactions, transactionSplits, categories]
+  );
+
+  const comparison = useMemo(
+    () => (currentFlows && previousFlows ? buildPeriodComparison(currentFlows, previousFlows, categories) : null),
+    [currentFlows, previousFlows, categories]
+  );
+
+  const chartData = useMemo(
+    () => (comparison ? comparison.categories.slice(0, 10).map(row => ({
+      // `categoryId`, never `key`: recharts spreads datum fields onto React
+      // elements and a `key` field collides with React's reserved prop.
+      categoryId: row.categoryId,
+      name: row.name,
+      current: row.current,
+      previous: row.previous,
+    })) : []),
+    [comparison]
+  );
+
+  const drillIntoCategory = (row: ComparisonCategoryRow, window: 'current' | 'previous'): void => {
+    const source = window === 'current' ? currentFlows : previousFlows;
+    if (!source || !ranges) return;
+    const sideRows = row.bucket === 'income' ? source.incomeRows : source.expenseRows;
+    setDrill({
+      title: `${row.name} — ${formatWindow(window === 'current' ? ranges.current : ranges.previous)}`,
+      bucket: row.bucket,
+      rows: sideRows.filter(t => t.category === row.categoryId),
+      total: window === 'current' ? row.current : row.previous,
+    });
+  };
+
+  const drillIntoSide = (bucket: 'income' | 'expense', window: 'current' | 'previous', total: number): void => {
+    const source = window === 'current' ? currentFlows : previousFlows;
+    if (!source || !ranges) return;
+    setDrill({
+      title: `${bucket === 'income' ? 'Income' : 'Expenses'} — ${formatWindow(window === 'current' ? ranges.current : ranges.previous)}`,
+      bucket,
+      rows: bucket === 'income' ? source.incomeRows : source.expenseRows,
+      total,
+    });
+  };
+
+  const money = (value: number): string =>
+    value < 0 ? `-${formatCurrency(Math.abs(value))}` : formatCurrency(value);
+
+  const percent = (figure: ComparisonFigure): string =>
+    figure.changePercent === null
+      ? figure.current === 0 ? '—' : 'new'
+      : `${figure.changePercent > 0 ? '+' : ''}${formatDecimal(figure.changePercent, 1)}%`;
+
+  /** Green when the move is the good one: more income, or less spending. */
+  const moveClass = (change: number, goodWhen: 'up' | 'down'): string => {
+    if (change === 0) return 'text-gray-500 dark:text-gray-400';
+    const good = goodWhen === 'up' ? change > 0 : change < 0;
+    return good ? 'text-green-700 dark:text-green-400' : 'text-red-600 dark:text-red-400';
+  };
+
+  const summaryCard = (
+    label: string,
+    figure: ComparisonFigure,
+    goodWhen: 'up' | 'down',
+    bucket: 'income' | 'expense' | null
+  ): React.JSX.Element => (
+    <div className="bg-white dark:bg-gray-800 rounded-2xl shadow-lg border border-gray-100 dark:border-gray-700 p-6">
+      <p className="text-xs text-gray-500 uppercase tracking-wider font-medium">{label}</p>
+      {bucket === null ? (
+        <p className={`text-2xl font-bold mt-1 ${figure.current < 0 ? 'text-red-600 dark:text-red-400' : 'text-gray-900 dark:text-white'}`}>
+          {money(figure.current)}
+        </p>
+      ) : (
+        <button
+          type="button"
+          onClick={() => drillIntoSide(bucket, 'current', figure.current)}
+          className={`text-2xl font-bold mt-1 rounded hover:underline focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 ${
+            bucket === 'income' ? 'text-green-700 dark:text-green-400' : 'text-red-600 dark:text-red-400'
+          }`}
+          title={`${label} — view these transactions`}
+        >
+          {money(figure.current)}
+        </button>
+      )}
+      <p className="text-sm mt-2">
+        <span className={`font-semibold tabular-nums ${moveClass(figure.change, goodWhen)}`}>
+          {figure.change > 0 ? '+' : ''}{money(figure.change)}
+        </span>
+        <span className="text-gray-400 dark:text-gray-500"> · {percent(figure)}</span>
+      </p>
+      <p className="text-xs text-gray-400 dark:text-gray-500 mt-1">
+        {bucket === null ? (
+          <>was {money(figure.previous)}</>
+        ) : (
+          <button
+            type="button"
+            onClick={() => drillIntoSide(bucket, 'previous', figure.previous)}
+            className="rounded hover:underline focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
+            title="View the comparison period's transactions"
+          >
+            was {money(figure.previous)}
+          </button>
+        )}
+      </p>
+    </div>
+  );
+
+  return (
+    <div className="max-w-[1400px] mx-auto space-y-6">
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <div className="flex flex-wrap items-center gap-3">
+          <ReportAccountFilter accounts={accounts} filter={filter} />
+          <div className="inline-flex rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 p-0.5">
+            {(Object.keys(COMPARISON_BASIS_LABELS) as ComparisonBasis[]).map(value => (
+              <button
+                key={value}
+                type="button"
+                onClick={() => handleBasis(value)}
+                aria-pressed={basis === value}
+                className={`px-3 py-1 text-sm font-medium rounded-md transition-colors ${
+                  basis === value
+                    ? 'bg-[#1a2332] dark:bg-blue-600 text-white'
+                    : 'text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-200'
+                }`}
+              >
+                {COMPARISON_BASIS_LABELS[value]}
+              </button>
+            ))}
+          </div>
+        </div>
+        <ReportExportBar
+          title="Period comparison"
+          dateRange={PERIOD_LABELS[picker.period]}
+          rows={rows}
+          flows={flows}
+          categories={categories}
+          accounts={accounts}
+          charts={[chartRef]}
+        />
+      </div>
+
+      {ranges === null || comparison === null ? (
+        <div className="bg-white dark:bg-gray-800 rounded-2xl shadow-lg border border-gray-100 dark:border-gray-700 p-10 text-center">
+          <p className="text-gray-500 dark:text-gray-400">
+            This report needs a period with a start date to compare against.
+          </p>
+          <p className="text-sm text-gray-400 dark:text-gray-500 mt-2">
+            Choose any period other than All time — this month, last month, the tax year, twelve months, or a custom range.
+          </p>
+        </div>
+      ) : (
+        <>
+          <p className="text-sm text-gray-500 dark:text-gray-400">
+            <span className="font-medium text-gray-700 dark:text-gray-300">{formatWindow(ranges.current)}</span>
+            {' compared with '}
+            <span className="font-medium text-gray-700 dark:text-gray-300">{formatWindow(ranges.previous)}</span>
+          </p>
+
+          <UncategorisedReviewBand flows={flows} categories={categories} />
+
+          <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+            {summaryCard('Income', comparison.income, 'up', 'income')}
+            {summaryCard('Expenses', comparison.expenses, 'down', 'expense')}
+            {summaryCard('Left over', comparison.net, 'up', null)}
+          </div>
+
+          <div className="bg-white dark:bg-gray-800 rounded-2xl shadow-lg border border-gray-100 dark:border-gray-700 p-6">
+            <h2 className="text-lg font-semibold text-theme-heading dark:text-white mb-1">
+              Biggest movers
+            </h2>
+            <p className="text-sm text-gray-500 dark:text-gray-400 mb-4">
+              The categories that changed most between the two periods.
+            </p>
+            {chartData.length === 0 ? (
+              <p className="text-center py-16 text-gray-400">Nothing categorised in either period</p>
+            ) : (
+              <div className="h-96" ref={chartRef}>
+                <ResponsiveContainer width="100%" height="100%">
+                  <BarChart data={chartData} layout="vertical" margin={{ left: 8, right: 24 }}>
+                    <CartesianGrid strokeDasharray="3 3" stroke="rgba(107, 114, 128, 0.2)" horizontal={false} />
+                    <XAxis
+                      type="number"
+                      tick={{ fill: '#6B7280', fontSize: 12 }}
+                      tickFormatter={(value: number) => formatDecimal(value, 0)}
+                    />
+                    <YAxis
+                      type="category"
+                      dataKey="name"
+                      width={170}
+                      tick={{ fill: '#6B7280', fontSize: 12 }}
+                      interval={0}
+                    />
+                    <Tooltip
+                      formatter={(value: number | string) =>
+                        formatCurrency(typeof value === 'number' ? value : Number(value))
+                      }
+                      contentStyle={{ borderRadius: '8px' }}
+                    />
+                    <Legend />
+                    <Bar dataKey="current" name="This period" fill="#3B82F6" radius={[0, 3, 3, 0]} isAnimationActive={false} />
+                    <Bar dataKey="previous" name={COMPARISON_BASIS_LABELS[basis]} fill="#94A3B8" radius={[0, 3, 3, 0]} isAnimationActive={false} />
+                  </BarChart>
+                </ResponsiveContainer>
+              </div>
+            )}
+          </div>
+
+          <div className="bg-white dark:bg-gray-800 rounded-2xl shadow-lg border border-gray-100 dark:border-gray-700">
+            <div className="p-6 pb-3">
+              <h2 className="text-lg font-semibold text-theme-heading dark:text-white">Category by category</h2>
+              <p className="text-sm text-gray-500 dark:text-gray-400 mt-1">
+                Click either figure to see the transactions behind it.
+              </p>
+            </div>
+            {comparison.categories.length === 0 ? (
+              <p className="text-center py-16 text-gray-400">Nothing categorised in either period</p>
+            ) : (
+              /* The table scrolls inside its own box; the page never scrolls sideways. */
+              <div className="overflow-x-auto rounded-b-2xl">
+                <table className="min-w-full text-sm">
+                  <caption className="sr-only">Each category in both periods, with the change between them</caption>
+                  <thead className="bg-gray-50 dark:bg-gray-700/50">
+                    <tr>
+                      <th scope="col" className="px-6 py-2 text-left text-xs font-semibold uppercase tracking-wider text-gray-500 dark:text-gray-400 min-w-[220px]">
+                        Category
+                      </th>
+                      <th scope="col" className="px-3 py-2 text-right text-xs font-semibold uppercase tracking-wider text-gray-500 dark:text-gray-400">
+                        This period
+                      </th>
+                      <th scope="col" className="px-3 py-2 text-right text-xs font-semibold uppercase tracking-wider text-gray-500 dark:text-gray-400 min-w-[130px]">
+                        {COMPARISON_BASIS_LABELS[basis]}
+                      </th>
+                      <th scope="col" className="px-3 py-2 text-right text-xs font-semibold uppercase tracking-wider text-gray-500 dark:text-gray-400">
+                        Change
+                      </th>
+                      <th scope="col" className="px-6 py-2 text-right text-xs font-semibold uppercase tracking-wider text-gray-500 dark:text-gray-400">
+                        %
+                      </th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {comparison.categories.map(row => (
+                      <tr key={row.categoryId} className="border-t border-gray-50 dark:border-gray-700/50">
+                        <th scope="row" className="px-6 py-2 text-left font-normal">
+                          <span className="text-sm text-gray-900 dark:text-white">{row.name}</span>
+                          <span className="ml-2 text-xs text-gray-400 dark:text-gray-500">
+                            {row.bucket === 'income' ? 'income' : 'expense'}
+                          </span>
+                        </th>
+                        <td className="px-3 py-2 text-sm text-right">
+                          <button
+                            type="button"
+                            onClick={() => drillIntoCategory(row, 'current')}
+                            className="w-full text-right rounded px-1 -mx-1 tabular-nums text-gray-900 dark:text-white hover:bg-blue-50 dark:hover:bg-blue-900/30 hover:underline focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
+                            title={`${row.name}, this period — view these transactions`}
+                          >
+                            {money(row.current)}
+                          </button>
+                        </td>
+                        <td className="px-3 py-2 text-sm text-right">
+                          <button
+                            type="button"
+                            onClick={() => drillIntoCategory(row, 'previous')}
+                            className="w-full text-right rounded px-1 -mx-1 tabular-nums text-gray-500 dark:text-gray-400 hover:bg-blue-50 dark:hover:bg-blue-900/30 hover:underline focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
+                            title={`${row.name}, comparison period — view these transactions`}
+                          >
+                            {money(row.previous)}
+                          </button>
+                        </td>
+                        <td className={`px-3 py-2 text-sm text-right font-medium tabular-nums ${
+                          moveClass(row.change, row.bucket === 'income' ? 'up' : 'down')
+                        }`}>
+                          {row.change > 0 ? '+' : ''}{money(row.change)}
+                        </td>
+                        <td className="px-6 py-2 text-sm text-right tabular-nums text-gray-500 dark:text-gray-400">
+                          {percent(row)}
+                        </td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            )}
+          </div>
+        </>
+      )}
+
+      <ReportDrillModal target={drill} onClose={() => setDrill(null)} categories={categories} />
+    </div>
+  );
+}

--- a/src/pages/reports/ReportGallery.tsx
+++ b/src/pages/reports/ReportGallery.tsx
@@ -1,0 +1,63 @@
+import React from 'react';
+import { Link, useLocation } from 'react-router-dom';
+import { ChevronRightIcon } from '../../components/icons';
+import { preserveDemoParam } from '../../utils/navigation';
+import { REPORT_GROUPS, reportsInGroup } from './reportRegistry';
+
+/**
+ * The gallery itself: every report, grouped by the question it answers.
+ *
+ * Real links, not buttons — each report has its own URL, so it can be
+ * bookmarked, opened in a new tab, and pinned to the Dashboard.
+ */
+export default function ReportGallery(): React.JSX.Element {
+  const location = useLocation();
+
+  return (
+    <div className="space-y-8">
+      {REPORT_GROUPS.map(group => (
+        <section key={group.id} aria-labelledby={`report-group-${group.id}`}>
+          <div className="mb-3">
+            <h2
+              id={`report-group-${group.id}`}
+              className="text-lg font-semibold text-gray-900 dark:text-white"
+            >
+              {group.title}
+            </h2>
+            <p className="text-sm text-gray-500 dark:text-gray-400">{group.description}</p>
+          </div>
+
+          <ul className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-4">
+            {reportsInGroup(group.id).map(report => {
+              const Icon = report.icon;
+              return (
+                <li key={report.id}>
+                  <Link
+                    to={preserveDemoParam(`/reports/${report.id}`, location.search)}
+                    className="group h-full flex items-start gap-3 bg-white dark:bg-gray-800 rounded-2xl shadow-sm border border-gray-100 dark:border-gray-700 p-5 hover:border-[#1a2332] dark:hover:border-blue-500 hover:shadow-md transition-all focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
+                  >
+                    <span className="mt-0.5 flex-shrink-0 rounded-lg bg-gray-100 dark:bg-gray-700 p-2 text-gray-600 dark:text-gray-300">
+                      <Icon size={20} />
+                    </span>
+                    <span className="min-w-0 flex-1">
+                      <span className="block text-sm font-semibold text-gray-900 dark:text-white group-hover:text-[#1a2332] dark:group-hover:text-blue-400">
+                        {report.title}
+                      </span>
+                      <span className="mt-1 block text-sm text-gray-500 dark:text-gray-400">
+                        {report.description}
+                      </span>
+                    </span>
+                    <ChevronRightIcon
+                      size={16}
+                      className="mt-1 flex-shrink-0 text-gray-300 dark:text-gray-600 group-hover:text-gray-500 dark:group-hover:text-gray-400"
+                    />
+                  </Link>
+                </li>
+              );
+            })}
+          </ul>
+        </section>
+      ))}
+    </div>
+  );
+}

--- a/src/pages/reports/SpendingByCategoryReport.tsx
+++ b/src/pages/reports/SpendingByCategoryReport.tsx
@@ -1,0 +1,232 @@
+import React, { useMemo, useRef, useState } from 'react';
+import { ResponsiveContainer, PieChart as RechartsPieChart, Pie, Cell, Tooltip, Legend } from 'recharts';
+import { useCurrencyDecimal } from '../../hooks/useCurrencyDecimal';
+import { useReportDataset } from '../../hooks/useReportDataset';
+import { useReportAccountFilter } from '../../hooks/useReportAccountFilter';
+import ReportAccountFilter from '../../components/reports/ReportAccountFilter';
+import ReportDrillModal, { type ReportDrillTarget } from '../../components/reports/ReportDrillModal';
+import ReportExportBar from '../../components/reports/ReportExportBar';
+import UncategorisedReviewBand from '../../components/reports/UncategorisedReviewBand';
+import { computeExpenseCategoryNetTotals } from '../../utils/categoryNetting';
+import { toDecimal } from '../../utils/decimal';
+import { formatDecimal } from '../../utils/decimal-format';
+import { PERIOD_LABELS } from '../../hooks/usePeriod';
+import type { ReportViewProps } from './types';
+
+/**
+ * "Spending by category" — where the money went, ranked.
+ *
+ * Money's netting semantics throughout (utils/categoryNetting): a row belongs
+ * to a category's spend because of the CATEGORY's direction, never the
+ * money's, so a refund filed against an expense category reduces that
+ * category instead of appearing as income. Every slice and every row clicks
+ * through to the transactions behind it.
+ */
+
+const CATEGORY_COLORS = [
+  '#3B82F6', '#10B981', '#F59E0B', '#EF4444',
+  '#8B5CF6', '#EC4899', '#6366F1', '#14B8A6',
+];
+
+/** Slices beyond this become hard to tell apart; the table still lists all. */
+const PIE_SLICES = 8;
+
+export default function SpendingByCategoryReport({ picker }: ReportViewProps): React.JSX.Element {
+  const filter = useReportAccountFilter();
+  const { accounts, categories, rows, flows } = useReportDataset(picker, filter.accountId);
+  const { formatCurrency } = useCurrencyDecimal();
+  const [drill, setDrill] = useState<ReportDrillTarget | null>(null);
+  const chartRef = useRef<HTMLDivElement>(null);
+
+  // Shared implementation — the same totals the Dashboard widget and the PDF
+  // export use, so the three can never drift.
+  const totals = useMemo(
+    () => computeExpenseCategoryNetTotals(rows, categories),
+    [rows, categories]
+  );
+
+  const counts = useMemo(() => {
+    const byCategory = new Map<string, number>();
+    for (const row of flows.expenseRows) {
+      byCategory.set(row.category, (byCategory.get(row.category) ?? 0) + 1);
+    }
+    return byCategory;
+  }, [flows.expenseRows]);
+
+  const listedTotal = useMemo(
+    () => totals.reduce((sum, entry) => sum.plus(toDecimal(entry.value)), toDecimal(0)),
+    [totals]
+  );
+
+  // The datum field is `categoryId`, NOT `key`: recharts spreads datum fields
+  // onto React elements and a `key` field collides with React's reserved prop,
+  // silently breaking sector rendering.
+  const pieData = useMemo(
+    () => totals.slice(0, PIE_SLICES).map(({ key, name, value }) => ({ categoryId: key, name, value })),
+    [totals]
+  );
+
+  const drillIntoCategory = (categoryId: string, name: string, value: number): void => {
+    setDrill({
+      title: `${name} — ${PERIOD_LABELS[picker.period]}`,
+      bucket: 'expense',
+      rows: flows.expenseRows.filter(t => t.category === categoryId),
+      total: value,
+    });
+  };
+
+  const shareOf = (value: number): string =>
+    listedTotal.isZero() ? '—' : `${formatDecimal(toDecimal(value).dividedBy(listedTotal).times(100), 1)}%`;
+
+  // Categories whose refunds cancelled their spending net to zero or less and
+  // cannot be listed — say so rather than let the reader assume the rows add
+  // up to the period's total.
+  const netted = flows.expenses.greaterThan(0) && !listedTotal.equals(flows.expenses);
+
+  return (
+    <div className="max-w-[1400px] mx-auto space-y-6">
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <ReportAccountFilter accounts={accounts} filter={filter} />
+        <ReportExportBar
+          title="Spending by category"
+          dateRange={PERIOD_LABELS[picker.period]}
+          rows={rows}
+          flows={flows}
+          categories={categories}
+          accounts={accounts}
+          charts={[chartRef]}
+        />
+      </div>
+
+      <UncategorisedReviewBand flows={flows} categories={categories} />
+
+      <div className="bg-white dark:bg-gray-800 rounded-2xl shadow-lg border border-gray-100 dark:border-gray-700 p-6">
+        <div className="flex flex-wrap items-baseline justify-between gap-2 mb-1">
+          <h2 className="text-lg font-semibold text-theme-heading dark:text-white">
+            Where the money went
+          </h2>
+          <span className="text-lg font-bold tabular-nums text-red-600 dark:text-red-400">
+            {formatCurrency(flows.expenses)}
+          </span>
+        </div>
+        <p className="text-sm text-gray-500 dark:text-gray-400 mb-4">
+          {PERIOD_LABELS[picker.period]} — click a slice for the transactions behind it.
+        </p>
+        {pieData.length === 0 ? (
+          <p className="text-center py-16 text-gray-400">No categorised spending in this period</p>
+        ) : (
+          <div className="h-80" ref={chartRef}>
+            <ResponsiveContainer width="100%" height="100%">
+              <RechartsPieChart>
+                <Pie
+                  data={pieData}
+                  dataKey="value"
+                  nameKey="name"
+                  innerRadius="55%"
+                  outerRadius="85%"
+                  strokeWidth={0}
+                  isAnimationActive={false}
+                  cursor="pointer"
+                  onClick={(entry) => {
+                    const datum = ((entry as { payload?: typeof pieData[number] })?.payload ?? entry) as typeof pieData[number];
+                    if (datum?.categoryId) drillIntoCategory(datum.categoryId, datum.name, datum.value);
+                  }}
+                >
+                  {pieData.map((entry, index) => (
+                    <Cell key={entry.categoryId} fill={CATEGORY_COLORS[index % CATEGORY_COLORS.length]} />
+                  ))}
+                </Pie>
+                <Tooltip
+                  formatter={(value: number | string) =>
+                    formatCurrency(typeof value === 'number' ? value : Number(value))
+                  }
+                />
+                <Legend layout="vertical" align="right" verticalAlign="middle" />
+              </RechartsPieChart>
+            </ResponsiveContainer>
+          </div>
+        )}
+      </div>
+
+      <div className="bg-white dark:bg-gray-800 rounded-2xl shadow-lg border border-gray-100 dark:border-gray-700">
+        <div className="p-6 pb-3">
+          <h2 className="text-lg font-semibold text-theme-heading dark:text-white">Every category</h2>
+          <p className="text-sm text-gray-500 dark:text-gray-400 mt-1">
+            Ranked by spend. Click any category to see its transactions.
+          </p>
+        </div>
+        {totals.length === 0 ? (
+          <p className="text-center py-16 text-gray-400">No categorised spending in this period</p>
+        ) : (
+          /* The table scrolls inside its own box; the page never scrolls sideways. */
+          <div className="overflow-x-auto rounded-b-2xl">
+            <table className="min-w-full text-sm">
+              <caption className="sr-only">Spending by category for the selected period</caption>
+              <thead className="bg-gray-50 dark:bg-gray-700/50">
+                <tr>
+                  <th scope="col" className="px-6 py-2 text-left text-xs font-semibold uppercase tracking-wider text-gray-500 dark:text-gray-400 min-w-[220px]">
+                    Category
+                  </th>
+                  <th scope="col" className="px-3 py-2 text-right text-xs font-semibold uppercase tracking-wider text-gray-500 dark:text-gray-400">
+                    Transactions
+                  </th>
+                  <th scope="col" className="px-3 py-2 text-right text-xs font-semibold uppercase tracking-wider text-gray-500 dark:text-gray-400">
+                    Share
+                  </th>
+                  <th scope="col" className="px-6 py-2 text-right text-xs font-semibold uppercase tracking-wider text-gray-500 dark:text-gray-400">
+                    Spent
+                  </th>
+                </tr>
+              </thead>
+              <tbody>
+                {totals.map(entry => (
+                  <tr key={entry.key} className="border-t border-gray-50 dark:border-gray-700/50">
+                    <th scope="row" className="px-6 py-2 text-left font-normal">
+                      <button
+                        type="button"
+                        onClick={() => drillIntoCategory(entry.key, entry.name, entry.value)}
+                        className="text-sm text-gray-900 dark:text-white hover:text-blue-700 dark:hover:text-blue-400 hover:underline rounded focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
+                        title={`${entry.name} — view these transactions`}
+                      >
+                        {entry.name}
+                      </button>
+                    </th>
+                    <td className="px-3 py-2 text-sm text-right tabular-nums text-gray-500 dark:text-gray-400">
+                      {(counts.get(entry.key) ?? 0).toLocaleString()}
+                    </td>
+                    <td className="px-3 py-2 text-sm text-right tabular-nums text-gray-500 dark:text-gray-400">
+                      {shareOf(entry.value)}
+                    </td>
+                    <td className="px-6 py-2 text-sm text-right font-semibold tabular-nums text-gray-900 dark:text-white">
+                      {formatCurrency(entry.value)}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+              <tfoot className="border-t-2 border-gray-200 dark:border-gray-600">
+                <tr>
+                  <th scope="row" className="px-6 py-3 text-left text-sm font-semibold text-gray-900 dark:text-white">
+                    Total listed
+                  </th>
+                  <td />
+                  <td />
+                  <td className="px-6 py-3 text-sm text-right font-bold tabular-nums text-gray-900 dark:text-white">
+                    {formatCurrency(listedTotal.toNumber())}
+                  </td>
+                </tr>
+              </tfoot>
+            </table>
+          </div>
+        )}
+        {netted && (
+          <p className="px-6 pb-6 pt-3 text-xs text-gray-500 dark:text-gray-400">
+            Total spending for the period is {formatCurrency(flows.expenses)}. The difference is categories whose
+            refunds cancelled their spending — they net to zero or less, so they are not listed above.
+          </p>
+        )}
+      </div>
+
+      <ReportDrillModal target={drill} onClose={() => setDrill(null)} categories={categories} />
+    </div>
+  );
+}

--- a/src/pages/reports/SpendingByPayeeReport.tsx
+++ b/src/pages/reports/SpendingByPayeeReport.tsx
@@ -1,0 +1,278 @@
+import React, { useMemo, useRef, useState } from 'react';
+import { ResponsiveContainer, BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip, Cell } from 'recharts';
+import { useCurrencyDecimal } from '../../hooks/useCurrencyDecimal';
+import { useReportDataset } from '../../hooks/useReportDataset';
+import { useReportAccountFilter } from '../../hooks/useReportAccountFilter';
+import ReportAccountFilter from '../../components/reports/ReportAccountFilter';
+import ReportDrillModal, { type ReportDrillTarget } from '../../components/reports/ReportDrillModal';
+import ReportExportBar from '../../components/reports/ReportExportBar';
+import UncategorisedReviewBand from '../../components/reports/UncategorisedReviewBand';
+import { buildPayeeTotals, payeeKeyOf, NO_PAYEE_KEY, type PayeeTotalRow } from '../../utils/spendingByPayee';
+import { formatDecimal } from '../../utils/decimal-format';
+import { PERIOD_LABELS } from '../../hooks/usePeriod';
+import type { ReportViewProps } from './types';
+
+/**
+ * "Spending by payee" — who the money actually went to.
+ *
+ * Payee identity uses the same normalisation as the app's payee memory and
+ * the import prefill, so "the same payee" means the same thing here as it
+ * does when a bulk categorisation is remembered. The income side answers the
+ * other half of the question: who pays you.
+ *
+ * Rows are already classified by `computeIncomeExpense` — transfers and
+ * uncategorised rows never reach either side.
+ */
+
+const BAR_COLOURS = ['#3B82F6', '#10B981', '#F59E0B', '#EF4444', '#8B5CF6', '#EC4899', '#6366F1', '#14B8A6'];
+
+/** Bars beyond this stop being readable; the table still lists every payee. */
+const CHART_ROWS = 12;
+
+const SIDE_KEY = 'reportsPayeeSide';
+
+export default function SpendingByPayeeReport({ picker }: ReportViewProps): React.JSX.Element {
+  const filter = useReportAccountFilter();
+  const { accounts, categories, rows, flows } = useReportDataset(picker, filter.accountId);
+  const { formatCurrency } = useCurrencyDecimal();
+  const [drill, setDrill] = useState<ReportDrillTarget | null>(null);
+  const chartRef = useRef<HTMLDivElement>(null);
+  const [side, setSide] = useState<'expense' | 'income'>(() =>
+    localStorage.getItem(SIDE_KEY) === 'income' ? 'income' : 'expense'
+  );
+  const handleSide = (next: 'expense' | 'income'): void => {
+    setSide(next);
+    localStorage.setItem(SIDE_KEY, next);
+  };
+
+  const sideRows = side === 'income' ? flows.incomeRows : flows.expenseRows;
+  const totals = useMemo(
+    () => buildPayeeTotals(sideRows, side, categories),
+    [sideRows, side, categories]
+  );
+
+  // The datum fields are `payee`/`name`, never `key`: recharts spreads datum
+  // fields onto React elements and a `key` field collides with React's
+  // reserved prop, silently breaking rendering.
+  const chartData = useMemo(
+    () => totals.rows
+      .filter(row => row.total > 0)
+      .slice(0, CHART_ROWS)
+      .map(row => ({ payee: row.payee, name: row.displayName, value: row.total })),
+    [totals.rows]
+  );
+
+  const drillIntoPayee = (row: PayeeTotalRow): void => {
+    setDrill({
+      title: `${row.displayName} — ${PERIOD_LABELS[picker.period]}`,
+      bucket: side,
+      rows: sideRows.filter(t => payeeKeyOf(t.description) === row.payee),
+      total: row.total,
+    });
+  };
+
+  const drillIntoPayeeKey = (payee: string): void => {
+    const row = totals.rows.find(candidate => candidate.payee === payee);
+    if (row) drillIntoPayee(row);
+  };
+
+  const money = (value: number): string =>
+    value < 0 ? `-${formatCurrency(Math.abs(value))}` : formatCurrency(value);
+
+  const sideLabel = side === 'income' ? 'Received from' : 'Paid to';
+
+  return (
+    <div className="max-w-[1400px] mx-auto space-y-6">
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <div className="flex flex-wrap items-center gap-3">
+          <ReportAccountFilter accounts={accounts} filter={filter} />
+          <div className="inline-flex rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 p-0.5">
+            {([['expense', 'Spending'], ['income', 'Income']] as const).map(([value, label]) => (
+              <button
+                key={value}
+                type="button"
+                onClick={() => handleSide(value)}
+                aria-pressed={side === value}
+                className={`px-3 py-1 text-sm font-medium rounded-md transition-colors ${
+                  side === value
+                    ? 'bg-[#1a2332] dark:bg-blue-600 text-white'
+                    : 'text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-200'
+                }`}
+              >
+                {label}
+              </button>
+            ))}
+          </div>
+        </div>
+        <ReportExportBar
+          title="Spending by payee"
+          dateRange={PERIOD_LABELS[picker.period]}
+          rows={rows}
+          flows={flows}
+          categories={categories}
+          accounts={accounts}
+          charts={[chartRef]}
+        />
+      </div>
+
+      <UncategorisedReviewBand flows={flows} categories={categories} />
+
+      <div className="bg-white dark:bg-gray-800 rounded-2xl shadow-lg border border-gray-100 dark:border-gray-700 p-6">
+        <div className="flex flex-wrap items-baseline justify-between gap-2 mb-1">
+          <h2 className="text-lg font-semibold text-theme-heading dark:text-white">
+            {side === 'income' ? 'Biggest sources' : 'Biggest payees'}
+          </h2>
+          <span className={`text-lg font-bold tabular-nums ${
+            side === 'income' ? 'text-green-700 dark:text-green-400' : 'text-red-600 dark:text-red-400'
+          }`}>
+            {money(totals.total)}
+          </span>
+        </div>
+        <p className="text-sm text-gray-500 dark:text-gray-400 mb-4">
+          {PERIOD_LABELS[picker.period]} — click a bar, or any payee below, for the transactions behind it.
+        </p>
+        {chartData.length === 0 ? (
+          <p className="text-center py-16 text-gray-400">
+            No categorised {side === 'income' ? 'income' : 'spending'} in this period
+          </p>
+        ) : (
+          <div className="h-96" ref={chartRef}>
+            <ResponsiveContainer width="100%" height="100%">
+              <BarChart data={chartData} layout="vertical" margin={{ left: 8, right: 24 }}>
+                <CartesianGrid strokeDasharray="3 3" stroke="rgba(107, 114, 128, 0.2)" horizontal={false} />
+                <XAxis
+                  type="number"
+                  tick={{ fill: '#6B7280', fontSize: 12 }}
+                  tickFormatter={(value: number) => formatDecimal(value, 0)}
+                />
+                <YAxis
+                  type="category"
+                  dataKey="name"
+                  width={170}
+                  tick={{ fill: '#6B7280', fontSize: 12 }}
+                  interval={0}
+                />
+                <Tooltip
+                  formatter={(value: number | string) =>
+                    formatCurrency(typeof value === 'number' ? value : Number(value))
+                  }
+                  contentStyle={{ borderRadius: '8px' }}
+                />
+                <Bar
+                  dataKey="value"
+                  name={sideLabel}
+                  radius={[0, 3, 3, 0]}
+                  cursor="pointer"
+                  isAnimationActive={false}
+                  onClick={(entry) => {
+                    const datum = ((entry as { payload?: typeof chartData[number] })?.payload ?? entry) as typeof chartData[number];
+                    if (datum?.payee) drillIntoPayeeKey(datum.payee);
+                  }}
+                >
+                  {chartData.map((entry, index) => (
+                    <Cell key={entry.payee} fill={BAR_COLOURS[index % BAR_COLOURS.length]} />
+                  ))}
+                </Bar>
+              </BarChart>
+            </ResponsiveContainer>
+          </div>
+        )}
+      </div>
+
+      <div className="bg-white dark:bg-gray-800 rounded-2xl shadow-lg border border-gray-100 dark:border-gray-700">
+        <div className="p-6 pb-3">
+          <h2 className="text-lg font-semibold text-theme-heading dark:text-white">Every payee</h2>
+          <p className="text-sm text-gray-500 dark:text-gray-400 mt-1">
+            Ranked by value, with the category each payee is usually filed under.
+          </p>
+        </div>
+        {totals.rows.length === 0 ? (
+          <p className="text-center py-16 text-gray-400">
+            No categorised {side === 'income' ? 'income' : 'spending'} in this period
+          </p>
+        ) : (
+          /* The table scrolls inside its own box; the page never scrolls sideways. */
+          <div className="overflow-x-auto rounded-b-2xl">
+            <table className="min-w-full text-sm">
+              <caption className="sr-only">
+                {side === 'income' ? 'Income' : 'Spending'} by payee for the selected period
+              </caption>
+              <thead className="bg-gray-50 dark:bg-gray-700/50">
+                <tr>
+                  <th scope="col" className="px-6 py-2 text-left text-xs font-semibold uppercase tracking-wider text-gray-500 dark:text-gray-400 min-w-[200px]">
+                    Payee
+                  </th>
+                  <th scope="col" className="px-3 py-2 text-left text-xs font-semibold uppercase tracking-wider text-gray-500 dark:text-gray-400 min-w-[180px]">
+                    Usually filed as
+                  </th>
+                  <th scope="col" className="px-3 py-2 text-right text-xs font-semibold uppercase tracking-wider text-gray-500 dark:text-gray-400">
+                    Transactions
+                  </th>
+                  <th scope="col" className="px-3 py-2 text-right text-xs font-semibold uppercase tracking-wider text-gray-500 dark:text-gray-400">
+                    Last seen
+                  </th>
+                  <th scope="col" className="px-3 py-2 text-right text-xs font-semibold uppercase tracking-wider text-gray-500 dark:text-gray-400">
+                    Share
+                  </th>
+                  <th scope="col" className="px-6 py-2 text-right text-xs font-semibold uppercase tracking-wider text-gray-500 dark:text-gray-400">
+                    Total
+                  </th>
+                </tr>
+              </thead>
+              <tbody>
+                {totals.rows.map(row => (
+                  <tr key={row.payee} className="border-t border-gray-50 dark:border-gray-700/50">
+                    <th scope="row" className="px-6 py-2 text-left font-normal">
+                      <button
+                        type="button"
+                        onClick={() => drillIntoPayee(row)}
+                        className="text-sm text-gray-900 dark:text-white hover:text-blue-700 dark:hover:text-blue-400 hover:underline rounded focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
+                        title={`${row.displayName} — view these transactions`}
+                      >
+                        {row.displayName}
+                      </button>
+                    </th>
+                    <td className="px-3 py-2 text-sm text-gray-500 dark:text-gray-400">
+                      {row.topCategoryName}
+                    </td>
+                    <td className="px-3 py-2 text-sm text-right tabular-nums text-gray-500 dark:text-gray-400">
+                      {row.count.toLocaleString()}
+                    </td>
+                    <td className="px-3 py-2 text-sm text-right tabular-nums whitespace-nowrap text-gray-500 dark:text-gray-400">
+                      {row.latest.toLocaleDateString('en-GB', { day: '2-digit', month: 'short', year: '2-digit' })}
+                    </td>
+                    <td className="px-3 py-2 text-sm text-right tabular-nums text-gray-500 dark:text-gray-400">
+                      {formatDecimal(row.share, 1)}%
+                    </td>
+                    <td className="px-6 py-2 text-sm text-right font-semibold tabular-nums text-gray-900 dark:text-white">
+                      {money(row.total)}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+              <tfoot className="border-t-2 border-gray-200 dark:border-gray-600">
+                <tr>
+                  <th scope="row" className="px-6 py-3 text-left text-sm font-semibold text-gray-900 dark:text-white">
+                    Total
+                  </th>
+                  <td colSpan={4} />
+                  <td className="px-6 py-3 text-sm text-right font-bold tabular-nums text-gray-900 dark:text-white">
+                    {money(totals.total)}
+                  </td>
+                </tr>
+              </tfoot>
+            </table>
+          </div>
+        )}
+        {totals.rows.some(row => row.payee === NO_PAYEE_KEY) && (
+          <p className="px-6 pb-6 pt-3 text-xs text-gray-500 dark:text-gray-400">
+            &ldquo;No payee recorded&rdquo; collects rows whose description is empty or a bank placeholder — they are
+            counted, but they cannot be attributed to a merchant.
+          </p>
+        )}
+      </div>
+
+      <ReportDrillModal target={drill} onClose={() => setDrill(null)} categories={categories} />
+    </div>
+  );
+}

--- a/src/pages/reports/reportRegistry.ts
+++ b/src/pages/reports/reportRegistry.ts
@@ -10,6 +10,7 @@ import {
   UsersIcon,
   WalletIcon,
 } from '../../components/icons';
+import type { PeriodKey } from '../../hooks/usePeriod';
 import type { ReportViewProps } from './types';
 
 /**
@@ -60,6 +61,13 @@ export interface ReportDefinition {
    * hides the hub's period picker rather than showing an inert control.
    */
   usesPeriod: boolean;
+  /**
+   * The window this report is worth reading over — a trend over one month is
+   * barely a trend. Applied ONLY until the user picks a period themselves;
+   * from then on their choice follows them from report to report. Unset means
+   * the hub's own default (this month).
+   */
+  defaultPeriod?: PeriodKey;
   component: LazyExoticComponent<ComponentType<ReportViewProps>>;
 }
 
@@ -80,6 +88,9 @@ export const REPORTS: ReportDefinition[] = [
     group: 'what-i-have',
     icon: TrendingUpIcon,
     usesPeriod: true,
+    // The whole history is the point of this one — a month of net worth is a
+    // dot, and even a year says little about the direction of travel.
+    defaultPeriod: 'all',
     component: lazy(() => import('../NetWorthReport')),
   },
   {
@@ -116,6 +127,9 @@ export const REPORTS: ReportDefinition[] = [
     group: 'spending',
     icon: BarChart3Icon,
     usesPeriod: true,
+    // Month-by-month bars need enough months to compare, and a year covers the
+    // seasonal swings (Christmas, holidays, annual bills) exactly once.
+    defaultPeriod: 'last-12-months',
     component: lazy(() => import('./IncomeSpendingOverTimeReport')),
   },
   {

--- a/src/pages/reports/reportRegistry.ts
+++ b/src/pages/reports/reportRegistry.ts
@@ -1,0 +1,158 @@
+import { lazy, type ComponentType, type ElementType, type LazyExoticComponent } from 'react';
+import {
+  BarChart3Icon,
+  CalendarIcon,
+  FileTextIcon,
+  LandmarkIcon,
+  PieChartIcon,
+  RepeatIcon,
+  TrendingUpIcon,
+  UsersIcon,
+  WalletIcon,
+} from '../../components/icons';
+import type { ReportViewProps } from './types';
+
+/**
+ * The report gallery — Microsoft Money's model: a named list of reports
+ * grouped by the question they answer, not a row of tabs.
+ *
+ * Every report is addressable at /reports/<id>, so the Dashboard's pinned
+ * reports, a bookmark and the back button all point at something stable. The
+ * period picker lives at hub level (see ReportsHub) and is handed to each
+ * report, so it PERSISTS as the user moves between them.
+ */
+
+export type ReportGroupId = 'what-i-have' | 'spending' | 'custom';
+
+export interface ReportGroup {
+  id: ReportGroupId;
+  title: string;
+  description: string;
+}
+
+export const REPORT_GROUPS: ReportGroup[] = [
+  {
+    id: 'what-i-have',
+    title: 'What I have',
+    description: 'Where you stand, and how you got there.',
+  },
+  {
+    id: 'spending',
+    title: 'Spending',
+    description: 'Where the money goes, when it goes, and who it goes to.',
+  },
+  {
+    id: 'custom',
+    title: 'Custom reports',
+    description: 'Reports you build yourself.',
+  },
+];
+
+export interface ReportDefinition {
+  /** Stable URL segment — never renamed once shipped. */
+  id: string;
+  title: string;
+  description: string;
+  group: ReportGroupId;
+  icon: ElementType;
+  /**
+   * False for reports that own their own filtering (custom reports), which
+   * hides the hub's period picker rather than showing an inert control.
+   */
+  usesPeriod: boolean;
+  component: LazyExoticComponent<ComponentType<ReportViewProps>>;
+}
+
+export const REPORTS: ReportDefinition[] = [
+  {
+    id: 'net-worth',
+    title: 'Net worth',
+    description: 'Everything you own less everything you owe, account by account.',
+    group: 'what-i-have',
+    icon: WalletIcon,
+    usesPeriod: true,
+    component: lazy(() => import('./NetWorthStatementReport')),
+  },
+  {
+    id: 'net-worth-over-time',
+    title: 'Net worth over time',
+    description: 'The whole history as a line. Click any point for that day’s balances.',
+    group: 'what-i-have',
+    icon: TrendingUpIcon,
+    usesPeriod: true,
+    component: lazy(() => import('../NetWorthReport')),
+  },
+  {
+    id: 'account-balances',
+    title: 'Account balances',
+    description: 'Opening balance, money in and out, closing balance — for every account.',
+    group: 'what-i-have',
+    icon: LandmarkIcon,
+    usesPeriod: true,
+    component: lazy(() => import('./AccountBalancesReport')),
+  },
+  {
+    id: 'monthly-income-expenses',
+    title: 'Monthly income and expenses',
+    description: 'Every category down the side, the months across the top.',
+    group: 'spending',
+    icon: CalendarIcon,
+    usesPeriod: true,
+    component: lazy(() => import('../Reports')),
+  },
+  {
+    id: 'spending-by-category',
+    title: 'Spending by category',
+    description: 'What you spent on what, ranked, with the share of the total.',
+    group: 'spending',
+    icon: PieChartIcon,
+    usesPeriod: true,
+    component: lazy(() => import('./SpendingByCategoryReport')),
+  },
+  {
+    id: 'income-and-spending-over-time',
+    title: 'Income and spending over time',
+    description: 'Month by month, what came in against what went out.',
+    group: 'spending',
+    icon: BarChart3Icon,
+    usesPeriod: true,
+    component: lazy(() => import('./IncomeSpendingOverTimeReport')),
+  },
+  {
+    id: 'spending-by-payee',
+    title: 'Spending by payee',
+    description: 'Who the money actually went to, and how each payee is usually filed.',
+    group: 'spending',
+    icon: UsersIcon,
+    usesPeriod: true,
+    component: lazy(() => import('./SpendingByPayeeReport')),
+  },
+  {
+    id: 'period-comparison',
+    title: 'This period vs last',
+    description: 'The same period a year ago, or the one before — and what changed.',
+    group: 'spending',
+    icon: RepeatIcon,
+    usesPeriod: true,
+    component: lazy(() => import('./PeriodComparisonReport')),
+  },
+  {
+    id: 'custom-reports',
+    title: 'Custom reports',
+    description: 'Build a report from the components you want, and save it.',
+    group: 'custom',
+    icon: FileTextIcon,
+    // Custom reports carry their own date and account filters.
+    usesPeriod: false,
+    component: lazy(() => import('../CustomReports')),
+  },
+];
+
+export function findReport(id: string | undefined): ReportDefinition | null {
+  if (!id) return null;
+  return REPORTS.find(report => report.id === id) ?? null;
+}
+
+export function reportsInGroup(group: ReportGroupId): ReportDefinition[] {
+  return REPORTS.filter(report => report.group === group);
+}

--- a/src/pages/reports/types.ts
+++ b/src/pages/reports/types.ts
@@ -1,0 +1,11 @@
+import type { UsePeriodResult } from '../../hooks/usePeriod';
+
+/**
+ * What the hub hands every report: the shared reporting period.
+ *
+ * Kept in its own module so a report view never has to import the registry
+ * that lazy-loads it (which would put a cycle in the chunk graph).
+ */
+export interface ReportViewProps {
+  picker: UsePeriodResult;
+}

--- a/src/services/import/msMoney/feedCategoryBackfill.test.ts
+++ b/src/services/import/msMoney/feedCategoryBackfill.test.ts
@@ -1,0 +1,394 @@
+import { describe, it, expect } from 'vitest';
+import {
+  planFeedCategoryBackfill,
+  summariseByCategoryGroup,
+  compareBackfillBaseline,
+  applyCategoryBackfill,
+  batchedIds,
+  proposalKey,
+  BACKFILL_PLAN_VERSION,
+  type BackedUpFileRow,
+  type LiveFeedRow,
+  type CategoryRow,
+  type CategoryProposal,
+  type BackfillBaseline,
+  type MutationOutcome,
+  type UpdateQuery,
+  type UpdateClient,
+} from './feedCategoryBackfill';
+
+// Every value here is invented. The shapes mirror the transactions and
+// categories tables and the backup the re-import wrote; none of it came from a
+// real database, and no amount, payee or account name below is anyone's.
+
+const file = (over: Partial<BackedUpFileRow> & Pick<BackedUpFileRow, 'id'>): BackedUpFileRow => ({
+  account_id: 'acct-1',
+  date: '2026-05-04',
+  amount: '-12.34',
+  description: 'SHOP',
+  category: 'cat-food',
+  type: 'expense',
+  is_split: false,
+  external_transaction_id: null,
+  ...over,
+});
+
+const feed = (over: Partial<LiveFeedRow> & Pick<LiveFeedRow, 'id'>): LiveFeedRow => ({
+  account_id: 'acct-1',
+  date: '2026-05-04',
+  amount: '-12.34',
+  description: 'SHOP LTD 004',
+  category: null,
+  external_transaction_id: 'tl-1',
+  ...over,
+});
+
+const categories: CategoryRow[] = [
+  { id: 'type-expense', name: 'Expense', parent_id: null, level: 'type' },
+  { id: 'grp-food', name: 'Food Related', parent_id: 'type-expense', level: 'sub' },
+  { id: 'cat-food', name: 'Groceries', parent_id: 'grp-food', level: 'detail' },
+  { id: 'cat-dining', name: 'Dining Out', parent_id: 'grp-food', level: 'detail' },
+  { id: 'grp-home', name: 'Household', parent_id: 'type-expense', level: 'sub' },
+  { id: 'cat-rent', name: 'Rent', parent_id: 'grp-home', level: 'detail' },
+  { id: 'cat-transfer', name: 'To Savings', parent_id: null, level: 'detail', is_transfer_category: true },
+];
+
+const plan = (fileRows: BackedUpFileRow[], feedRows: LiveFeedRow[], days = 3) =>
+  planFeedCategoryBackfill({ fileRows, feedRows, categories, dateToleranceDays: days });
+
+describe('planFeedCategoryBackfill', () => {
+  it('proposes the deleted file row\'s category for an uncategorised feed row it paired with', () => {
+    const result = plan([file({ id: 'f-1' })], [feed({ id: 'b-1' })]);
+    expect(result.pairsFound).toBe(1);
+    expect(result.proposals).toEqual([
+      { feedTransactionId: 'b-1', fileTransactionId: 'f-1', categoryId: 'cat-food', dayGap: 0 },
+    ]);
+    expect(result.anomalies).toEqual([]);
+  });
+
+  it('pairs across the date tolerance, and not beyond it', () => {
+    const within = plan([file({ id: 'f-1', date: '2026-05-01' })], [feed({ id: 'b-1', date: '2026-05-04' })]);
+    expect(within.proposals.map(p => p.dayGap)).toEqual([3]);
+
+    const beyond = plan([file({ id: 'f-1', date: '2026-04-30' })], [feed({ id: 'b-1', date: '2026-05-04' })]);
+    expect(beyond.pairsFound).toBe(0);
+    expect(beyond.proposals).toEqual([]);
+    expect(beyond.feedRowsWithoutFileCounterpart).toBe(1);
+  });
+
+  it('does not pair a different amount, or the same amount in another account', () => {
+    const amount = plan([file({ id: 'f-1', amount: '-12.35' })], [feed({ id: 'b-1' })]);
+    expect(amount.pairsFound).toBe(0);
+
+    const account = plan([file({ id: 'f-1', account_id: 'acct-2' })], [feed({ id: 'b-1' })]);
+    expect(account.pairsFound).toBe(0);
+  });
+
+  it('never overwrites a category the feed row already has', () => {
+    const result = plan([file({ id: 'f-1' })], [feed({ id: 'b-1', category: 'cat-rent' })]);
+    expect(result.pairsFound).toBe(1);
+    expect(result.proposals).toEqual([]);
+    expect(result.skipped.feedAlreadyCategorised).toBe(1);
+  });
+
+  it('treats an empty-string category on the feed row as no category', () => {
+    const result = plan([file({ id: 'f-1' })], [feed({ id: 'b-1', category: '' })]);
+    expect(result.proposals).toHaveLength(1);
+    expect(result.skipped.feedAlreadyCategorised).toBe(0);
+  });
+
+  it('skips a pair whose file row had no category of its own', () => {
+    const none = plan([file({ id: 'f-1', category: null })], [feed({ id: 'b-1' })]);
+    expect(none.skipped.fileHadNoCategory).toBe(1);
+    expect(none.proposals).toEqual([]);
+
+    const blank = plan([file({ id: 'f-2', category: '' })], [feed({ id: 'b-2' })]);
+    expect(blank.skipped.fileHadNoCategory).toBe(1);
+  });
+
+  it('refuses, loudly and by id, a file category that no longer exists', () => {
+    const result = plan([file({ id: 'f-1', category: 'cat-deleted' })], [feed({ id: 'b-1' })]);
+    expect(result.skipped.fileCategoryMissing).toBe(1);
+    expect(result.missingCategoryIds).toEqual(['cat-deleted']);
+    expect(result.proposals).toEqual([]);
+  });
+
+  it('never writes a transfer category onto a feed row', () => {
+    const result = plan([file({ id: 'f-1', category: 'cat-transfer' })], [feed({ id: 'b-1' })]);
+    expect(result.skipped.fileCategoryIsTransfer).toBe(1);
+    expect(result.proposals).toEqual([]);
+  });
+
+  it('inherits the matcher\'s exclusions: a split parent is never a source', () => {
+    const split = plan([file({ id: 'f-2', is_split: true })], [feed({ id: 'b-2' })]);
+    expect(split.pairsFound).toBe(0);
+  });
+
+  it('never takes a category from a transfer leg, even though the matcher now pairs one', () => {
+    // The matcher hands a fed transfer leg over to its feed row (feedOverlap.ts),
+    // so the pair exists. It is still never a category source: a leg files under
+    // a To/From category, and the refusal below is what stops that landing on a
+    // bank-fed row.
+    const transfer = plan([file({ id: 'f-1', type: 'transfer', category: 'cat-transfer' })], [feed({ id: 'b-1' })]);
+    expect(transfer.pairsFound).toBe(1);
+    expect(transfer.skipped.fileCategoryIsTransfer).toBe(1);
+    expect(transfer.proposals).toEqual([]);
+  });
+
+  it('pairs 1:1 — two identical file rows against one feed row yields one proposal', () => {
+    const result = plan(
+      [file({ id: 'f-1' }), file({ id: 'f-2', category: 'cat-rent' })],
+      [feed({ id: 'b-1' })]
+    );
+    expect(result.pairsFound).toBe(1);
+    expect(result.proposals).toHaveLength(1);
+    expect(result.anomalies).toEqual([]);
+  });
+
+  it('pairs 1:1 — two identical feed rows against one file row leaves one feed row unmatched', () => {
+    const result = plan([file({ id: 'f-1' })], [feed({ id: 'b-1' }), feed({ id: 'b-2', external_transaction_id: 'tl-2' })]);
+    expect(result.pairsFound).toBe(1);
+    expect(result.feedRowsWithoutFileCounterpart).toBe(1);
+    expect(result.proposals).toHaveLength(1);
+  });
+
+  it('counts the feed-only residual that belongs to the review workflow, not to this repair', () => {
+    const result = plan(
+      [file({ id: 'f-1' })],
+      [
+        feed({ id: 'b-1' }),
+        feed({ id: 'b-2', amount: '-99.99', external_transaction_id: 'tl-2' }),
+        feed({ id: 'b-3', amount: '-88.88', category: 'cat-rent', external_transaction_id: 'tl-3' }),
+      ]
+    );
+    expect(result.feedRowsTotal).toBe(3);
+    expect(result.feedRowsWithoutCategory).toBe(2);
+    expect(result.feedRowsWithoutFileCounterpart).toBe(2);
+    expect(result.feedOnlyWithoutCategory).toBe(1);
+  });
+
+  it('reports a bank-feed row hiding in the backup as an anomaly', () => {
+    const result = plan([file({ id: 'f-1', external_transaction_id: 'tl-9' })], [feed({ id: 'b-1' })]);
+    expect(result.anomalies.join(' ')).toContain('carry a bank-feed id');
+  });
+
+  it('reports duplicate ids in either input as an anomaly', () => {
+    const result = plan([file({ id: 'dup' }), file({ id: 'dup' })], [feed({ id: 'b-1' })]);
+    expect(result.anomalies.join(' ')).toContain('duplicate transaction ids');
+  });
+});
+
+describe('summariseByCategoryGroup', () => {
+  const proposal = (categoryId: string, n: number): CategoryProposal[] =>
+    Array.from({ length: n }, (_, i) => ({
+      feedTransactionId: `${categoryId}-${i}`, fileTransactionId: `f-${categoryId}-${i}`, categoryId, dayGap: 0,
+    }));
+
+  it('rolls detail categories up to their sub-level group, biggest first', () => {
+    const summary = summariseByCategoryGroup(
+      [...proposal('cat-food', 3), ...proposal('cat-dining', 2), ...proposal('cat-rent', 4)],
+      categories
+    );
+    expect(summary).toEqual([
+      { group: 'Food Related', count: 5 },
+      { group: 'Household', count: 4 },
+    ]);
+  });
+
+  it('never rolls up as far as the type root', () => {
+    const summary = summariseByCategoryGroup(proposal('grp-food', 1), categories);
+    expect(summary).toEqual([{ group: 'Food Related', count: 1 }]);
+  });
+
+  it('names an unknown category rather than dropping it', () => {
+    expect(summariseByCategoryGroup(proposal('cat-gone', 2), categories)).toEqual([
+      { group: '(unknown category)', count: 2 },
+    ]);
+  });
+
+  it('terminates on a parent cycle instead of hanging', () => {
+    const cyclic: CategoryRow[] = [
+      { id: 'a', name: 'A', parent_id: 'b', level: 'detail' },
+      { id: 'b', name: 'B', parent_id: 'a', level: 'detail' },
+    ];
+    expect(summariseByCategoryGroup(proposal('a', 1), cyclic)).toEqual([{ group: 'B', count: 1 }]);
+  });
+});
+
+describe('compareBackfillBaseline', () => {
+  const baseline: BackfillBaseline = {
+    version: BACKFILL_PLAN_VERSION,
+    userId: 'user-1',
+    dateToleranceDays: 3,
+    backupSha256: 'abc',
+    proposalKeys: ['b-1:cat-food', 'b-2:cat-rent'],
+    feedRowsTotal: 10,
+    feedRowsWithoutCategory: 6,
+  };
+  const liveOf = (over: Partial<Omit<BackfillBaseline, 'version'>>): Omit<BackfillBaseline, 'version'> => {
+    const { version: _version, ...rest } = baseline;
+    void _version;
+    return { ...rest, ...over };
+  };
+
+  it('passes when nothing moved', () => {
+    const report = compareBackfillBaseline(baseline, liveOf({}));
+    expect(report.drifted).toBe(false);
+    expect(report.benign).toBe(false);
+    expect(report.lines).toEqual([]);
+  });
+
+  it('accepts proposals that have disappeared — those rows have since been categorised', () => {
+    const report = compareBackfillBaseline(baseline, liveOf({ proposalKeys: ['b-1:cat-food'] }));
+    expect(report.drifted).toBe(false);
+    expect(report.benign).toBe(true);
+    expect(report.lines.join(' ')).toContain('1 proposal(s) no longer apply');
+  });
+
+  it('refuses a proposal that is new since the dry run', () => {
+    const report = compareBackfillBaseline(baseline, liveOf({ proposalKeys: [...baseline.proposalKeys, 'b-3:cat-rent'] }));
+    expect(report.drifted).toBe(true);
+  });
+
+  it('refuses a proposal whose category changed', () => {
+    const report = compareBackfillBaseline(baseline, liveOf({ proposalKeys: ['b-1:cat-food', 'b-2:cat-dining'] }));
+    expect(report.drifted).toBe(true);
+  });
+
+  it('refuses a different backup, user, tolerance or plan version', () => {
+    expect(compareBackfillBaseline(baseline, liveOf({ backupSha256: 'zzz' })).drifted).toBe(true);
+    expect(compareBackfillBaseline(baseline, liveOf({ userId: 'user-2' })).drifted).toBe(true);
+    expect(compareBackfillBaseline(baseline, liveOf({ dateToleranceDays: 5 })).drifted).toBe(true);
+    expect(compareBackfillBaseline({ ...baseline, version: 0 }, liveOf({})).drifted).toBe(true);
+  });
+
+  it('notes a moved feed-row count without refusing — this repair does not change it', () => {
+    const report = compareBackfillBaseline(baseline, liveOf({ feedRowsTotal: 12, feedRowsWithoutCategory: 5 }));
+    expect(report.drifted).toBe(false);
+    expect(report.lines).toHaveLength(2);
+  });
+});
+
+describe('proposalKey', () => {
+  it('identifies a decision by the row it changes and the value it writes', () => {
+    expect(proposalKey({ feedTransactionId: 'b-1', fileTransactionId: 'f-1', categoryId: 'c-1', dayGap: 0 }))
+      .toBe('b-1:c-1');
+  });
+});
+
+describe('batchedIds', () => {
+  it('splits into request-sized batches and refuses a nonsense size', () => {
+    expect(batchedIds([1, 2, 3, 4, 5], 2)).toEqual([[1, 2], [3, 4], [5]]);
+    expect(batchedIds([], 2)).toEqual([]);
+    expect(() => batchedIds([1], 0)).toThrow('batch size must be at least 1');
+  });
+});
+
+// ── The write pass, against a client that records every statement ────────────
+
+interface RecordedStatement {
+  table: string;
+  values: { category: string };
+  filters: string[];
+  ids: string[];
+}
+
+function recordingClient(
+  outcomeFor: (statement: RecordedStatement) => MutationOutcome = s => ({ error: null, count: s.ids.length })
+): { client: UpdateClient; statements: RecordedStatement[] } {
+  const statements: RecordedStatement[] = [];
+
+  const build = (statement: RecordedStatement): UpdateQuery => {
+    const query: UpdateQuery = {
+      eq: (column, value) => { statement.filters.push(`${column}=${value}`); return query; },
+      is: (column, value) => { statement.filters.push(`${column} IS ${String(value)}`); return query; },
+      not: (column, operator, value) => { statement.filters.push(`${column} NOT ${operator} ${String(value)}`); return query; },
+      in: (column, values) => { statement.ids = [...values]; statement.filters.push(`${column} IN (${values.length})`); return query; },
+      then: (onFulfilled) => Promise.resolve(outcomeFor(statement)).then(onFulfilled),
+    };
+    return query;
+  };
+
+  return {
+    statements,
+    client: {
+      from: (table: string) => ({
+        update: (values: { category: string }, options: { count: 'exact' }) => {
+          if (options.count !== 'exact') throw new Error('the row count must be requested');
+          const statement: RecordedStatement = { table, values, filters: [], ids: [] };
+          statements.push(statement);
+          return build(statement);
+        },
+      }),
+    },
+  };
+}
+
+const proposalsFor = (categoryId: string, n: number, offset = 0): CategoryProposal[] =>
+  Array.from({ length: n }, (_, i) => ({
+    feedTransactionId: `b-${offset + i}`, fileTransactionId: `f-${offset + i}`, categoryId, dayGap: 0,
+  }));
+
+describe('applyCategoryBackfill', () => {
+  it('scopes every statement to the user, to feed rows, and to rows with no category', async () => {
+    const { client, statements } = recordingClient();
+    await applyCategoryBackfill(client, 'user-1', proposalsFor('cat-food', 2));
+    expect(statements).toHaveLength(1);
+    expect(statements[0].table).toBe('transactions');
+    expect(statements[0].values).toEqual({ category: 'cat-food' });
+    expect(statements[0].filters).toEqual([
+      'user_id=user-1',
+      'external_transaction_id NOT is null',
+      'category IS null',
+      'id IN (2)',
+    ]);
+    expect(statements[0].ids).toEqual(['b-0', 'b-1']);
+  });
+
+  it('issues one request per category per batch, never one per row', async () => {
+    const { client, statements } = recordingClient();
+    const outcome = await applyCategoryBackfill(client, 'user-1', [
+      ...proposalsFor('cat-food', 250),
+      ...proposalsFor('cat-rent', 30, 250),
+    ]);
+    // 250 food rows → 3 batches of ≤100; 30 rent rows → 1.
+    expect(statements).toHaveLength(4);
+    expect(outcome.requests).toBe(4);
+    expect(outcome.rowsUpdated).toBe(280);
+    expect(outcome.rowsDeclined).toBe(0);
+    expect(statements.map(s => s.ids.length)).toEqual([100, 100, 50, 30]);
+  });
+
+  it('reports rows the database declined rather than assuming they changed', async () => {
+    const { client } = recordingClient(s => ({ error: null, count: s.ids.length - 1 }));
+    const outcome = await applyCategoryBackfill(client, 'user-1', proposalsFor('cat-food', 5));
+    expect(outcome.rowsUpdated).toBe(4);
+    expect(outcome.rowsDeclined).toBe(1);
+  });
+
+  it('throws when the database reports an error', async () => {
+    const { client } = recordingClient(() => ({ error: { message: 'permission denied' }, count: null }));
+    await expect(applyCategoryBackfill(client, 'user-1', proposalsFor('cat-food', 1)))
+      .rejects.toThrow('permission denied');
+  });
+
+  it('refuses to assume success when the database does not report a count', async () => {
+    const { client } = recordingClient(() => ({ error: null, count: null }));
+    await expect(applyCategoryBackfill(client, 'user-1', proposalsFor('cat-food', 1)))
+      .rejects.toThrow('did not report how many rows it updated');
+  });
+
+  it('reports progress against the total, not per request', async () => {
+    const { client } = recordingClient();
+    const seen: Array<[number, number]> = [];
+    await applyCategoryBackfill(client, 'user-1', proposalsFor('cat-food', 150), (done, total) => seen.push([done, total]));
+    expect(seen).toEqual([[100, 150], [150, 150]]);
+  });
+
+  it('does nothing at all when there is nothing to propose', async () => {
+    const { client, statements } = recordingClient();
+    const outcome = await applyCategoryBackfill(client, 'user-1', []);
+    expect(statements).toEqual([]);
+    expect(outcome).toEqual({ rowsUpdated: 0, requests: 0, rowsDeclined: 0 });
+  });
+});

--- a/src/services/import/msMoney/feedCategoryBackfill.ts
+++ b/src/services/import/msMoney/feedCategoryBackfill.ts
@@ -1,0 +1,496 @@
+/**
+ * Repairing the categories the feed-overlap suppression threw away.
+ *
+ * ── What went wrong ────────────────────────────────────────────────────────
+ * The MS Money re-import suppressed every file row a bank-feed row already
+ * covered, keeping the FEED row (see feedOverlap.ts — the feed row is what the
+ * bank reports, it carries the provider's id, and it cannot be recreated).
+ *
+ * That is right about the AMOUNT and the DATE and wrong about one thing: the
+ * feed row carries no category, and the file row it replaced carried the
+ * category the user had filed the payment under in Microsoft Money. Because a
+ * row with no category is deliberately excluded from every report
+ * (`classifyFlow` in utils/incomeExpense.ts — direction is never guessed), the
+ * suppression did not lose money, it lost the CLASSIFICATION of that money, and
+ * the reports fell over accordingly.
+ *
+ * ── The repair ─────────────────────────────────────────────────────────────
+ * Every deleted file row, with its category, is in the backup the apply pass
+ * wrote before deleting anything. Re-pair those rows against the live feed rows
+ * with the SAME matcher that produced the suppression (`findFeedOverlap` — a
+ * second, differently-worded rule could pair rows the first one did not, and
+ * then we would be inventing categories rather than restoring them), and copy
+ * the category across.
+ *
+ * ── What is deliberately NOT done ──────────────────────────────────────────
+ *  - a feed row that ALREADY has a category is never touched. Between the
+ *    re-import and this repair the user, or payee memory, may have filed it;
+ *    that decision is newer than the Money file's and it wins.
+ *  - a file category id that no longer exists is never written. The categories
+ *    were reused rather than recreated by the re-import, so this should be
+ *    impossible — which is exactly why it is checked and reported loudly rather
+ *    than assumed.
+ *  - a transfer category is never written onto a feed row. Transfer categories
+ *    take a row out of income and expense entirely; restoring one onto a row
+ *    the feed reported as ordinary spending would hide it more thoroughly than
+ *    leaving it uncategorised does.
+ *  - feed rows with no file counterpart at all are left alone. They are genuine
+ *    feed-only spending that the Money file never had and never categorised;
+ *    they belong to the existing uncategorised review workflow, not here.
+ *
+ * Everything in this file is a decision, and every decision is exercised with
+ * synthetic fixtures in feedCategoryBackfill.test.ts. The script that uses it
+ * (scripts/backfillFeedCategories.mts) is I/O only.
+ */
+import { findFeedOverlap } from './feedOverlap';
+import type { ExistingFeedTransaction } from './feedOverlap';
+import type { Transaction } from '../../../types';
+
+/** Bumped when the plan file's shape changes; apply refuses an older one. */
+export const BACKFILL_PLAN_VERSION = 1;
+
+/** Ids per PostgREST request — the same size the delete pass uses. */
+export const UPDATE_BATCH_SIZE = 100;
+
+/** A row as the re-import's backup file recorded it, before it was deleted. */
+export interface BackedUpFileRow {
+  id: string;
+  account_id: string;
+  /** yyyy-mm-dd */
+  date: string;
+  amount: string | number;
+  description: string | null;
+  /** Category id as text — the thing this whole repair exists to recover. */
+  category: string | null;
+  type: string;
+  is_split: boolean | null;
+  /** Must be null on every row: the backup may never contain a feed row. */
+  external_transaction_id: string | null;
+}
+
+/** A bank-feed row as it stands in the database right now. */
+export interface LiveFeedRow {
+  id: string;
+  account_id: string;
+  date: string;
+  amount: string | number;
+  description: string | null;
+  category: string | null;
+  external_transaction_id: string | null;
+}
+
+/** Enough of a category row to decide whether it may be written. */
+export interface CategoryRow {
+  id: string;
+  name: string;
+  parent_id: string | null;
+  /** 'type' (root) | 'sub' (group) | 'detail' (leaf). */
+  level: string;
+  is_transfer_category?: boolean | null;
+}
+
+/** One row this repair would change, and the evidence for changing it. */
+export interface CategoryProposal {
+  /** The feed row to update. */
+  feedTransactionId: string;
+  /** The deleted file row the category comes from — provenance for the change. */
+  fileTransactionId: string;
+  categoryId: string;
+  /** Whole days between the two dates, from the matcher. */
+  dayGap: number;
+}
+
+export interface BackfillSkips {
+  /** The user (or payee memory) filed it after the re-import. Never overwritten. */
+  feedAlreadyCategorised: number;
+  /** The Money file had no category either — nothing to restore. */
+  fileHadNoCategory: number;
+  /** The file's category id is not in `categories` any more. LOUD. */
+  fileCategoryMissing: number;
+  /** The file's category is a transfer category — never written onto a feed row. */
+  fileCategoryIsTransfer: number;
+}
+
+export interface BackfillPlan {
+  /** Pairs the matcher re-derived from the backup and the live feed rows. */
+  pairsFound: number;
+  proposals: CategoryProposal[];
+  skipped: BackfillSkips;
+  /** Distinct category ids that have vanished — named so they can be chased. */
+  missingCategoryIds: string[];
+  /**
+   * Anything that breaks an invariant the matcher is supposed to guarantee
+   * (a feed row or a file row appearing in two pairs, a pair naming a row that
+   * is not in the inputs). Non-empty ⇒ nothing should be applied.
+   */
+  anomalies: string[];
+  /** Context for the report, none of it changed by this repair. */
+  feedRowsTotal: number;
+  feedRowsWithoutCategory: number;
+  /** Feed rows the matcher found no file row for — genuine feed-only spending. */
+  feedRowsWithoutFileCounterpart: number;
+  /** …of which, still uncategorised: the residual for the review-band workflow. */
+  feedOnlyWithoutCategory: number;
+}
+
+export interface BackfillPlanInput {
+  fileRows: readonly BackedUpFileRow[];
+  feedRows: readonly LiveFeedRow[];
+  categories: readonly CategoryRow[];
+  dateToleranceDays: number;
+}
+
+const hasCategory = (value: string | null): value is string => value != null && value !== '';
+
+/**
+ * Shape a backed-up file row the way `findFeedOverlap` expects its Money side.
+ *
+ * `Transaction.amount` is a `number`, so the conversion happens here and not in
+ * the matcher — which immediately re-reads it through `toDecimal(String(...))`
+ * and compares exact pence. This is the identical conversion
+ * scripts/mnyReimportPlan.mts fed the matcher when it produced the suppression;
+ * using a different one here is precisely how the repair could pair rows the
+ * suppression did not.
+ */
+const asMoneySide = (row: BackedUpFileRow): Transaction => ({
+  id: row.id,
+  date: new Date(`${row.date}T00:00:00.000Z`),
+  description: row.description ?? '',
+  accountId: row.account_id,
+  amount: Number(row.amount),
+  type: row.type === 'income' || row.type === 'transfer' ? row.type : 'expense',
+  category: row.category ?? '',
+  cleared: false,
+  isSplit: row.is_split === true,
+});
+
+const asFeedSide = (row: LiveFeedRow): ExistingFeedTransaction => ({
+  id: row.id,
+  accountId: row.account_id,
+  date: row.date,
+  amount: row.amount,
+  description: row.description ?? '',
+});
+
+/**
+ * Decide, without touching anything, which feed rows should get which category.
+ *
+ * The pairing is `findFeedOverlap`'s and nothing else's. Everything this
+ * function adds is a REFUSAL: a pair the matcher produced is turned into a
+ * proposal only when the feed row is still uncategorised, the file row had a
+ * category, and that category still exists and is not a transfer category.
+ */
+export function planFeedCategoryBackfill(input: BackfillPlanInput): BackfillPlan {
+  const anomalies: string[] = [];
+
+  const contaminated = input.fileRows.filter(r => r.external_transaction_id != null);
+  if (contaminated.length) {
+    anomalies.push(
+      `${contaminated.length} row(s) in the backup carry a bank-feed id (${contaminated[0].id}) — ` +
+      'that backup is not a backup of file rows'
+    );
+  }
+
+  const categoryById = new Map(input.categories.map(c => [c.id, c]));
+  const fileById = new Map(input.fileRows.map(r => [r.id, r]));
+  const feedById = new Map(input.feedRows.map(r => [r.id, r]));
+  if (fileById.size !== input.fileRows.length) anomalies.push('the backup contains duplicate transaction ids');
+  if (feedById.size !== input.feedRows.length) anomalies.push('the live feed rows contain duplicate transaction ids');
+
+  const overlap = findFeedOverlap(
+    input.fileRows.map(asMoneySide),
+    input.feedRows.map(asFeedSide),
+    { dateToleranceDays: input.dateToleranceDays }
+  );
+
+  const proposals: CategoryProposal[] = [];
+  const skipped: BackfillSkips = {
+    feedAlreadyCategorised: 0,
+    fileHadNoCategory: 0,
+    fileCategoryMissing: 0,
+    fileCategoryIsTransfer: 0,
+  };
+  const missingCategoryIds = new Set<string>();
+  const seenFeed = new Set<string>();
+  const seenFile = new Set<string>();
+
+  for (const match of overlap.matches) {
+    const feed = feedById.get(match.feedTransactionId);
+    const file = fileById.get(match.importSourceId);
+    if (!feed || !file) {
+      anomalies.push(`pair ${match.importSourceId} → ${match.feedTransactionId} names a row that is not in the inputs`);
+      continue;
+    }
+    // The matcher is 1:1 by construction. Asserted anyway, every run: a pair
+    // that is not 1:1 would let one file row's category land on two feed rows.
+    if (seenFeed.has(feed.id)) { anomalies.push(`feed row ${feed.id} appears in more than one pair`); continue; }
+    if (seenFile.has(file.id)) { anomalies.push(`file row ${file.id} appears in more than one pair`); continue; }
+    seenFeed.add(feed.id);
+    seenFile.add(file.id);
+
+    if (hasCategory(feed.category)) { skipped.feedAlreadyCategorised++; continue; }
+    if (!hasCategory(file.category)) { skipped.fileHadNoCategory++; continue; }
+
+    const category = categoryById.get(file.category);
+    if (!category) {
+      skipped.fileCategoryMissing++;
+      missingCategoryIds.add(file.category);
+      continue;
+    }
+    if (category.is_transfer_category === true) { skipped.fileCategoryIsTransfer++; continue; }
+
+    proposals.push({
+      feedTransactionId: feed.id,
+      fileTransactionId: file.id,
+      categoryId: file.category,
+      dayGap: match.dayGap,
+    });
+  }
+
+  const feedOnly = overlap.unmatchedFeedIds
+    .map(id => feedById.get(id))
+    .filter((row): row is LiveFeedRow => row != null);
+
+  return {
+    pairsFound: overlap.matches.length,
+    proposals,
+    skipped,
+    missingCategoryIds: [...missingCategoryIds],
+    anomalies,
+    feedRowsTotal: input.feedRows.length,
+    feedRowsWithoutCategory: input.feedRows.filter(r => !hasCategory(r.category)).length,
+    feedRowsWithoutFileCounterpart: overlap.unmatchedFeedIds.length,
+    feedOnlyWithoutCategory: feedOnly.filter(r => !hasCategory(r.category)).length,
+  };
+}
+
+// ── Reporting: counts only, never money and never a name a payee could be ────
+
+export interface GroupCount {
+  /** The 'sub'-level ancestor's name — "Food Related", not the leaf detail. */
+  group: string;
+  count: number;
+}
+
+/**
+ * The nearest ancestor at 'sub' level, or the category itself when it has none.
+ * Walks upward with a visited set, so a parent cycle terminates instead of
+ * hanging the report.
+ */
+function groupNameOf(categoryId: string, byId: ReadonlyMap<string, CategoryRow>): string {
+  const seen = new Set<string>();
+  let current = byId.get(categoryId);
+  let fallback = current?.name ?? '(unknown category)';
+  while (current && !seen.has(current.id)) {
+    if (current.level === 'sub') return current.name;
+    seen.add(current.id);
+    fallback = current.name;
+    const parentId = current.parent_id;
+    if (parentId == null) break;
+    const parent = byId.get(parentId);
+    // A 'type' root ("Expense") is too coarse to be a group — keep the child.
+    if (!parent || parent.level === 'type') break;
+    current = parent;
+  }
+  return fallback;
+}
+
+/**
+ * Counts per category group, biggest first, ties broken by name so two runs of
+ * the same plan print the same thing. Counts only — this output is read in a
+ * chat transcript, so no amount, payee or account ever appears in it.
+ */
+export function summariseByCategoryGroup(
+  proposals: readonly CategoryProposal[],
+  categories: readonly CategoryRow[]
+): GroupCount[] {
+  const byId = new Map(categories.map(c => [c.id, c]));
+  const counts = new Map<string, number>();
+  for (const proposal of proposals) {
+    const group = groupNameOf(proposal.categoryId, byId);
+    counts.set(group, (counts.get(group) ?? 0) + 1);
+  }
+  return [...counts.entries()]
+    .map(([group, count]) => ({ group, count }))
+    .sort((a, b) => b.count - a.count || a.group.localeCompare(b.group));
+}
+
+// ── Drift: is the database still the one the dry run described? ──────────────
+
+/** What the dry run saw, written beside its plan. Apply recomputes and compares. */
+export interface BackfillBaseline {
+  version: number;
+  userId: string;
+  dateToleranceDays: number;
+  /** sha256 of the backup file, so apply cannot be handed a DIFFERENT backup. */
+  backupSha256: string;
+  /** `feedTransactionId:categoryId`, sorted — the plan as a set of decisions. */
+  proposalKeys: string[];
+  feedRowsTotal: number;
+  feedRowsWithoutCategory: number;
+}
+
+export interface BackfillDriftReport {
+  /** True ⇒ refuse. */
+  drifted: boolean;
+  /** True ⇒ proceed, but say what shrank. */
+  benign: boolean;
+  lines: string[];
+}
+
+export const proposalKey = (proposal: CategoryProposal): string =>
+  `${proposal.feedTransactionId}:${proposal.categoryId}`;
+
+/**
+ * Compare a live plan against the reviewed one.
+ *
+ * Proposals that have DISAPPEARED are benign: the only way a pair stops being a
+ * proposal is that the feed row acquired a category, and this repair would have
+ * skipped it anyway. Anything else — a new proposal, a changed category, a
+ * different user, a different backup, a different tolerance — means the numbers
+ * that were approved are not the numbers about to be written, and it refuses.
+ */
+export function compareBackfillBaseline(
+  baseline: BackfillBaseline,
+  live: Omit<BackfillBaseline, 'version'>
+): BackfillDriftReport {
+  const lines: string[] = [];
+  let drifted = false;
+
+  const refuse = (line: string): void => { lines.push(line); drifted = true; };
+
+  if (baseline.version !== BACKFILL_PLAN_VERSION) {
+    refuse(`plan file is version ${baseline.version}, this script reads version ${BACKFILL_PLAN_VERSION}`);
+  }
+  if (baseline.userId !== live.userId) refuse(`target user changed: plan ${baseline.userId} → live ${live.userId}`);
+  if (baseline.backupSha256 !== live.backupSha256) refuse('the backup file is not the one the plan was built from (sha256 differs)');
+  if (baseline.dateToleranceDays !== live.dateToleranceDays) {
+    refuse(`match tolerance changed: ${baseline.dateToleranceDays} → ${live.dateToleranceDays} days`);
+  }
+
+  const approved = new Set(baseline.proposalKeys);
+  const now = new Set(live.proposalKeys);
+  const added = live.proposalKeys.filter(k => !approved.has(k));
+  const gone = baseline.proposalKeys.filter(k => !now.has(k));
+  if (added.length) {
+    refuse(`${added.length} proposal(s) are NEW since the dry run — the plan reviewed is not the plan pending`);
+  }
+  const benign = gone.length > 0 && !drifted;
+  if (gone.length) {
+    lines.push(`${gone.length} proposal(s) no longer apply — those feed rows have since been categorised, and ` +
+      'this repair would have skipped them. Proceeding with the rest.');
+  }
+  if (baseline.feedRowsTotal !== live.feedRowsTotal) {
+    lines.push(`bank-feed row count moved: ${baseline.feedRowsTotal} → ${live.feedRowsTotal} (not changed by this repair)`);
+  }
+  if (baseline.feedRowsWithoutCategory !== live.feedRowsWithoutCategory) {
+    lines.push(`uncategorised feed rows moved: ${baseline.feedRowsWithoutCategory} → ${live.feedRowsWithoutCategory}`);
+  }
+  return { drifted, benign, lines };
+}
+
+// ── The write pass ───────────────────────────────────────────────────────────
+
+/**
+ * The part of a PostgREST response this pass reads. `count` is what the
+ * DATABASE says it changed — asked for with `{ count: 'exact' }`, because "no
+ * error" is not the same as "the rows were updated".
+ */
+export interface MutationOutcome {
+  error: { message: string } | null;
+  count?: number | null;
+}
+
+export interface UpdateQuery extends PromiseLike<MutationOutcome> {
+  eq(column: string, value: string): UpdateQuery;
+  is(column: string, value: null): UpdateQuery;
+  not(column: string, operator: 'is', value: null): UpdateQuery;
+  in(column: string, values: readonly string[]): UpdateQuery;
+}
+
+/**
+ * The slice of the Supabase client this pass uses — narrow enough that a test
+ * can hand it an implementation and watch exactly which statements are issued
+ * with which filters, and narrow enough that the real client satisfies it
+ * directly, with no cast anywhere in the chain.
+ */
+export interface UpdateClient {
+  from(table: string): { update(values: { category: string }, options: { count: 'exact' }): UpdateQuery };
+}
+
+export interface BackfillOutcome {
+  /** Rows the database reported as changed. */
+  rowsUpdated: number;
+  /** Requests issued — one per (category, batch), never one per row. */
+  requests: number;
+  /**
+   * Proposals the database declined to change, because the row stopped
+   * qualifying between the plan and the write. Expected to be 0; not an error.
+   */
+  rowsDeclined: number;
+}
+
+export interface BackfillProgress {
+  (done: number, total: number): void;
+}
+
+/** Split a list into request-sized batches. */
+export function batchedIds<T>(items: readonly T[], size: number = UPDATE_BATCH_SIZE): T[][] {
+  if (size < 1) throw new Error('batch size must be at least 1');
+  const out: T[][] = [];
+  for (let i = 0; i < items.length; i += size) out.push(items.slice(i, i + size));
+  return out;
+}
+
+/**
+ * Write the proposed categories — batched by category, and scoped so the
+ * DATABASE, not this process, enforces what may be touched.
+ *
+ * Every statement carries all four of:
+ *   `user_id = <the target user>`     — no other user's rows are reachable;
+ *   `external_transaction_id IS NOT NULL` — a file row cannot be written to;
+ *   `category IS NULL`                — an existing category cannot be overwritten;
+ *   `id IN (…)`                       — only rows this plan proposed.
+ * The first three hold even if the id list were wrong, which is the point: the
+ * two mistakes that would matter are refused by Postgres on the row.
+ *
+ * One request per (category, batch of 100), never one per row.
+ */
+export async function applyCategoryBackfill(
+  client: UpdateClient,
+  userId: string,
+  proposals: readonly CategoryProposal[],
+  onProgress?: BackfillProgress
+): Promise<BackfillOutcome> {
+  const byCategory = new Map<string, string[]>();
+  for (const proposal of proposals) {
+    const ids = byCategory.get(proposal.categoryId);
+    if (ids) ids.push(proposal.feedTransactionId);
+    else byCategory.set(proposal.categoryId, [proposal.feedTransactionId]);
+  }
+
+  let rowsUpdated = 0;
+  let requests = 0;
+  let attempted = 0;
+  for (const [categoryId, ids] of byCategory) {
+    for (const batch of batchedIds(ids)) {
+      const outcome = await client
+        .from('transactions')
+        .update({ category: categoryId }, { count: 'exact' })
+        .eq('user_id', userId)
+        .not('external_transaction_id', 'is', null)
+        .is('category', null)
+        .in('id', batch);
+      requests++;
+      if (outcome.error) throw new Error(`updating ${batch.length} row(s): ${outcome.error.message}`);
+      if (typeof outcome.count !== 'number') {
+        throw new Error('the database did not report how many rows it updated — refusing to assume.');
+      }
+      rowsUpdated += outcome.count;
+      attempted += batch.length;
+      onProgress?.(attempted, proposals.length);
+    }
+  }
+
+  return { rowsUpdated, requests, rowsDeclined: proposals.length - rowsUpdated };
+}

--- a/src/services/import/msMoney/feedOverlap.test.ts
+++ b/src/services/import/msMoney/feedOverlap.test.ts
@@ -106,16 +106,6 @@ describe('findFeedOverlap', () => {
     expect(byDescription.matches[0].importSourceId).toBe('mny-txn-b');
   });
 
-  it('never suppresses a transfer leg, and reports the overlap it left alone', () => {
-    const money = [
-      txn({ id: 'mny-txn-1', amount: -500, type: 'transfer', transferAccountId: 'mny-acct-2', linkedTransferId: 'mny-txn-2' }),
-    ];
-    const result = findFeedOverlap(money, [feed({ id: 'feed-1', amount: -500, description: 'TRANSFER' })]);
-    expect(result.suppressedSourceIds.size).toBe(0);
-    expect(result.keptDespiteOverlap.transfers).toBe(1);
-    expect(result.unmatchedFeedIds).toEqual(['feed-1']);
-  });
-
   it('never suppresses a split parent (its lines would be orphaned)', () => {
     const money = [txn({ id: 'mny-txn-1', amount: -80, isSplit: true, category: '' })];
     const result = findFeedOverlap(money, [feed({ id: 'feed-1', amount: -80 })]);
@@ -144,5 +134,147 @@ describe('findFeedOverlap', () => {
     const money = [txn({ id: 'mny-txn-1', amount: 0.1 + 0.2 })];
     const result = findFeedOverlap(money, [feed({ id: 'feed-1', amount: '0.30' })]);
     expect(result.matches).toHaveLength(1);
+  });
+});
+
+// ── Transfer-leg handover ────────────────────────────────────────────────────
+// The shapes below are the two the real data holds: a leg whose counterpart is
+// in an account the bank does NOT feed (its Money row survives and has to be
+// re-pointed), and a pair where BOTH accounts are fed (each leg hands over, and
+// the two feed rows end up pointing at each other). Every value is invented.
+
+/** A transfer leg: `mny-acct-1` ⇄ `far`, linked to `counterpart`. */
+const leg = (over: Partial<Transaction> & Pick<Transaction, 'id' | 'amount'>): Transaction => txn({
+  type: 'transfer',
+  description: 'Card payment',
+  transferAccountId: 'mny-acct-2',
+  ...over,
+});
+
+describe('findFeedOverlap — transfer-leg handover', () => {
+  it('suppresses a fed transfer leg and names the feed row that takes its place', () => {
+    const money = [leg({ id: 'mny-txn-out', amount: -1500, linkedTransferId: 'mny-txn-in' })];
+    // Nothing in common with the Money side's wording — description is a
+    // ranking signal, never a gate, and the handover must not need it.
+    const result = findFeedOverlap(money, [feed({ id: 'feed-1', amount: -1500, description: 'BANK TRANSFER OUT' })]);
+
+    expect([...result.suppressedSourceIds]).toEqual(['mny-txn-out']);
+    expect(result.matches).toHaveLength(1);
+    expect(result.matches[0].isTransferHandover).toBe(true);
+    expect(result.transferHandovers).toEqual([{
+      importSourceId: 'mny-txn-out',
+      feedTransactionId: 'feed-1',
+      accountId: 'mny-acct-1',
+      transferAccountId: 'mny-acct-2',
+      counterpartSourceId: 'mny-txn-in',
+      counterpartSplitSourceId: null,
+      dayGap: 0,
+      descriptionSimilarity: 0,
+    }]);
+    // The feed row is USED, so it is no longer "spending the file never had",
+    // and nothing is left in the kept-despite-overlap residual.
+    expect(result.unmatchedFeedIds).toEqual([]);
+    expect(result.keptDespiteOverlap).toEqual({ transfers: 0, splitParents: 0 });
+  });
+
+  it('hands over BOTH legs when both accounts are fed', () => {
+    const money = [
+      leg({ id: 'mny-txn-out', amount: -1500, accountId: 'mny-acct-1', transferAccountId: 'mny-acct-2', linkedTransferId: 'mny-txn-in' }),
+      leg({ id: 'mny-txn-in', amount: 1500, accountId: 'mny-acct-2', transferAccountId: 'mny-acct-1', linkedTransferId: 'mny-txn-out' }),
+    ];
+    const result = findFeedOverlap(money, [
+      feed({ id: 'feed-out', amount: -1500, accountId: 'mny-acct-1' }),
+      feed({ id: 'feed-in', amount: 1500, accountId: 'mny-acct-2' }),
+    ]);
+
+    expect(result.suppressedSourceIds).toEqual(new Set(['mny-txn-out', 'mny-txn-in']));
+    expect(result.transferHandovers.map(h => [h.importSourceId, h.feedTransactionId, h.counterpartSourceId]))
+      .toEqual([
+        ['mny-txn-out', 'feed-out', 'mny-txn-in'],
+        ['mny-txn-in', 'feed-in', 'mny-txn-out'],
+      ]);
+    expect(result.unmatchedFeedIds).toEqual([]);
+  });
+
+  it('carries the split line across when the far side is a split leg', () => {
+    const money = [leg({ id: 'mny-txn-out', amount: -75, linkedTransferId: 'mny-txn-parent', linkedTransferSplitId: 'mny-split-9' })];
+    const result = findFeedOverlap(money, [feed({ id: 'feed-1', amount: -75 })]);
+    expect(result.transferHandovers[0]).toMatchObject({
+      counterpartSourceId: 'mny-txn-parent',
+      counterpartSplitSourceId: 'mny-split-9',
+    });
+  });
+
+  it('hands over a leg with no counterpart at all — there is nothing to strand', () => {
+    const money = [leg({ id: 'mny-txn-out', amount: -75, linkedTransferId: undefined, transferAccountId: undefined })];
+    const result = findFeedOverlap(money, [feed({ id: 'feed-1', amount: -75 })]);
+    expect(result.transferHandovers[0]).toMatchObject({
+      transferAccountId: null, counterpartSourceId: null, counterpartSplitSourceId: null,
+    });
+  });
+
+  it('does not widen the gate: same account, exact pence, within tolerance, or no handover', () => {
+    const money = [leg({ id: 'mny-txn-out', amount: -1500, date: new Date('2026-05-10T00:00:00.000Z') })];
+    const nothing = { transferHandovers: [], suppressed: 0 };
+    const measure = (f: ExistingFeedTransaction) => {
+      const r = findFeedOverlap(money, [f]);
+      return { transferHandovers: r.transferHandovers, suppressed: r.suppressedSourceIds.size };
+    };
+    expect(measure(feed({ id: 'f', amount: -1500, accountId: 'mny-acct-9' }))).toEqual(nothing);
+    expect(measure(feed({ id: 'f', amount: -1500.01 }))).toEqual(nothing);
+    expect(measure(feed({ id: 'f', amount: -1500, date: '2026-05-20' }))).toEqual(nothing);
+    // …and one that DOES qualify, so the assertions above mean something.
+    expect(measure(feed({ id: 'f', amount: -1500, date: '2026-05-13' })).suppressed).toBe(1);
+  });
+
+  it('lets an ordinary row claim the feed row before any transfer leg can', () => {
+    const money = [
+      txn({ id: 'mny-txn-ordinary', amount: -1500, description: 'Corner Shop' }),
+      leg({ id: 'mny-txn-transfer', amount: -1500 }),
+    ];
+    const one = findFeedOverlap(money, [feed({ id: 'feed-1', amount: -1500 })]);
+    expect([...one.suppressedSourceIds]).toEqual(['mny-txn-ordinary']);
+    expect(one.transferHandovers).toEqual([]);
+
+    // A second feed row, and the transfer leg gets one too — still strictly 1:1.
+    const two = findFeedOverlap(money, [
+      feed({ id: 'feed-1', amount: -1500 }),
+      feed({ id: 'feed-2', amount: -1500 }),
+    ]);
+    expect(two.suppressedSourceIds).toEqual(new Set(['mny-txn-ordinary', 'mny-txn-transfer']));
+    expect(two.transferHandovers.map(h => h.importSourceId)).toEqual(['mny-txn-transfer']);
+  });
+
+  it('is strictly 1:1 under handover — one feed row takes exactly one leg', () => {
+    const money = [
+      leg({ id: 'mny-txn-a', amount: -1500 }),
+      leg({ id: 'mny-txn-b', amount: -1500 }),
+    ];
+    const result = findFeedOverlap(money, [feed({ id: 'feed-1', amount: -1500 })]);
+    expect(result.transferHandovers).toHaveLength(1);
+    expect(result.suppressedSourceIds.size).toBe(1);
+  });
+
+  it('refuses the handover when the feed row could not honestly become a transfer', () => {
+    const money = [leg({ id: 'mny-txn-out', amount: -1500, linkedTransferId: 'mny-txn-in' })];
+
+    // A split feed row: the database's own trigger forbids re-typing one.
+    const split = findFeedOverlap(money, [feed({ id: 'feed-1', amount: -1500, isSplit: true })]);
+    expect(split.suppressedSourceIds.size).toBe(0);
+    expect(split.transferHandovers).toEqual([]);
+    expect(split.keptDespiteOverlap.transfers).toBe(1);
+    expect(split.unmatchedFeedIds).toEqual(['feed-1']);
+
+    // A feed row already half of someone else's transfer.
+    const linked = findFeedOverlap(money, [feed({ id: 'feed-1', amount: -1500, linkedTransferId: 'other-row' })]);
+    expect(linked.suppressedSourceIds.size).toBe(0);
+    expect(linked.keptDespiteOverlap.transfers).toBe(1);
+  });
+
+  it('treats a split parent as a split parent even when it is typed transfer', () => {
+    const money = [leg({ id: 'mny-txn-out', amount: -1500, isSplit: true })];
+    const result = findFeedOverlap(money, [feed({ id: 'feed-1', amount: -1500 })]);
+    expect(result.suppressedSourceIds.size).toBe(0);
+    expect(result.keptDespiteOverlap).toEqual({ transfers: 0, splitParents: 1 });
   });
 });

--- a/src/services/import/msMoney/feedOverlap.test.ts
+++ b/src/services/import/msMoney/feedOverlap.test.ts
@@ -1,0 +1,148 @@
+import { describe, it, expect } from 'vitest';
+import { findFeedOverlap, descriptionSimilarity, type ExistingFeedTransaction } from './feedOverlap';
+import type { Transaction } from '../../../types';
+
+// All data here is invented. The shapes mirror what transformMsMoneyExport
+// emits and what a bank feed writes; the values are made up.
+
+const txn = (over: Partial<Transaction> & Pick<Transaction, 'id' | 'amount'>): Transaction => ({
+  date: new Date('2026-05-10T00:00:00.000Z'),
+  description: 'Corner Shop',
+  accountId: 'mny-acct-1',
+  type: 'expense',
+  category: 'mny-cat-1',
+  cleared: false,
+  ...over,
+} as Transaction);
+
+const feed = (over: Partial<ExistingFeedTransaction> & Pick<ExistingFeedTransaction, 'id' | 'amount'>): ExistingFeedTransaction => ({
+  accountId: 'mny-acct-1',
+  date: '2026-05-10',
+  description: 'CORNER SHOP LTD 4471',
+  ...over,
+});
+
+describe('descriptionSimilarity', () => {
+  it('scores shared words, ignores case/punctuation, and returns 0 for nothing in common', () => {
+    expect(descriptionSimilarity('Corner Shop', 'CORNER SHOP LTD')).toBeGreaterThan(0.5);
+    expect(descriptionSimilarity('Corner Shop', 'Fuel Station')).toBe(0);
+    // Short tokens are noise and are dropped, so an all-short string scores 0.
+    expect(descriptionSimilarity('a b c', 'a b c')).toBe(0);
+  });
+});
+
+describe('findFeedOverlap', () => {
+  it('matches same account + exact pence + same day', () => {
+    const result = findFeedOverlap(
+      [txn({ id: 'mny-txn-1', amount: -12.34 })],
+      [feed({ id: 'feed-1', amount: -12.34 })]
+    );
+    expect(result.matches).toHaveLength(1);
+    expect(result.matches[0]).toMatchObject({
+      importSourceId: 'mny-txn-1', feedTransactionId: 'feed-1', dayGap: 0,
+    });
+    expect(result.suppressedSourceIds.has('mny-txn-1')).toBe(true);
+    expect(result.unmatchedFeedIds).toEqual([]);
+  });
+
+  it('tolerates a settlement-date shift but not an arbitrary one', () => {
+    const money = [txn({ id: 'mny-txn-1', amount: -50, date: new Date('2026-05-10T00:00:00.000Z') })];
+    const within = findFeedOverlap(money, [feed({ id: 'feed-1', amount: -50, date: '2026-05-12' })]);
+    expect(within.matches).toHaveLength(1);
+    expect(within.matches[0].dayGap).toBe(2);
+
+    const beyond = findFeedOverlap(money, [feed({ id: 'feed-1', amount: -50, date: '2026-05-20' })]);
+    expect(beyond.matches).toEqual([]);
+    expect(beyond.unmatchedFeedIds).toEqual(['feed-1']);
+  });
+
+  it('never matches across accounts or across a penny difference', () => {
+    const money = [txn({ id: 'mny-txn-1', amount: -12.34 })];
+    expect(findFeedOverlap(money, [feed({ id: 'f', amount: -12.34, accountId: 'mny-acct-9' })]).matches).toEqual([]);
+    expect(findFeedOverlap(money, [feed({ id: 'f', amount: -12.35 })]).matches).toEqual([]);
+  });
+
+  it('matches 1:1 — two feed rows never claim the same Money row', () => {
+    const money = [txn({ id: 'mny-txn-1', amount: -9.99 })];
+    const result = findFeedOverlap(money, [
+      feed({ id: 'feed-1', amount: -9.99 }),
+      feed({ id: 'feed-2', amount: -9.99 }),
+    ]);
+    // One is a duplicate of the imported row; the other is spending the Money
+    // file never had, and survives.
+    expect(result.matches).toHaveLength(1);
+    expect(result.unmatchedFeedIds).toEqual(['feed-2']);
+  });
+
+  it('pairs repeated same-amount rows off rather than collapsing them', () => {
+    const money = [
+      txn({ id: 'mny-txn-1', amount: -7.99, date: new Date('2026-05-10T00:00:00.000Z') }),
+      txn({ id: 'mny-txn-2', amount: -7.99, date: new Date('2026-05-10T00:00:00.000Z') }),
+      txn({ id: 'mny-txn-3', amount: -7.99, date: new Date('2026-05-10T00:00:00.000Z') }),
+    ];
+    const result = findFeedOverlap(money, [
+      feed({ id: 'feed-1', amount: -7.99 }),
+      feed({ id: 'feed-2', amount: -7.99 }),
+    ]);
+    expect(result.matches).toHaveLength(2);
+    expect(new Set(result.matches.map(m => m.importSourceId)).size).toBe(2);
+    // The third genuine copy is still imported.
+    expect(result.suppressedSourceIds.size).toBe(2);
+  });
+
+  it('prefers the nearest date, then the closest description', () => {
+    const money = [
+      txn({ id: 'mny-txn-far', amount: -20, date: new Date('2026-05-08T00:00:00.000Z'), description: 'Corner Shop' }),
+      txn({ id: 'mny-txn-near', amount: -20, date: new Date('2026-05-10T00:00:00.000Z'), description: 'Fuel Station' }),
+    ];
+    const byDate = findFeedOverlap(money, [feed({ id: 'feed-1', amount: -20, date: '2026-05-10' })]);
+    expect(byDate.matches[0].importSourceId).toBe('mny-txn-near');
+
+    const sameDay = [
+      txn({ id: 'mny-txn-a', amount: -20, description: 'Fuel Station' }),
+      txn({ id: 'mny-txn-b', amount: -20, description: 'Corner Shop' }),
+    ];
+    const byDescription = findFeedOverlap(sameDay, [feed({ id: 'feed-1', amount: -20 })]);
+    expect(byDescription.matches[0].importSourceId).toBe('mny-txn-b');
+  });
+
+  it('never suppresses a transfer leg, and reports the overlap it left alone', () => {
+    const money = [
+      txn({ id: 'mny-txn-1', amount: -500, type: 'transfer', transferAccountId: 'mny-acct-2', linkedTransferId: 'mny-txn-2' }),
+    ];
+    const result = findFeedOverlap(money, [feed({ id: 'feed-1', amount: -500, description: 'TRANSFER' })]);
+    expect(result.suppressedSourceIds.size).toBe(0);
+    expect(result.keptDespiteOverlap.transfers).toBe(1);
+    expect(result.unmatchedFeedIds).toEqual(['feed-1']);
+  });
+
+  it('never suppresses a split parent (its lines would be orphaned)', () => {
+    const money = [txn({ id: 'mny-txn-1', amount: -80, isSplit: true, category: '' })];
+    const result = findFeedOverlap(money, [feed({ id: 'feed-1', amount: -80 })]);
+    expect(result.suppressedSourceIds.size).toBe(0);
+    expect(result.keptDespiteOverlap.splitParents).toBe(1);
+  });
+
+  it('leaves everything outside the feed window untouched', () => {
+    const money = [
+      txn({ id: 'mny-txn-old', amount: -30, date: new Date('2015-01-01T00:00:00.000Z') }),
+      txn({ id: 'mny-txn-new', amount: -30, date: new Date('2026-05-10T00:00:00.000Z') }),
+    ];
+    const result = findFeedOverlap(money, [feed({ id: 'feed-1', amount: -30, date: '2026-05-10' })]);
+    expect([...result.suppressedSourceIds]).toEqual(['mny-txn-new']);
+  });
+
+  it('handles an empty feed as a plain no-op', () => {
+    const result = findFeedOverlap([txn({ id: 'mny-txn-1', amount: -1 })], []);
+    expect(result.matches).toEqual([]);
+    expect(result.suppressedSourceIds.size).toBe(0);
+    expect(result.unmatchedFeedIds).toEqual([]);
+  });
+
+  it('uses exact pence, so no float drift can slip a match through', () => {
+    // 0.1 + 0.2 in floats is 0.30000000000000004; both sides must land on 30p.
+    const money = [txn({ id: 'mny-txn-1', amount: 0.1 + 0.2 })];
+    const result = findFeedOverlap(money, [feed({ id: 'feed-1', amount: '0.30' })]);
+    expect(result.matches).toHaveLength(1);
+  });
+});

--- a/src/services/import/msMoney/feedOverlap.ts
+++ b/src/services/import/msMoney/feedOverlap.ts
@@ -29,14 +29,34 @@
  * bank's raw strings ("AMZNMktplace ..."), Money's are payee names ("Amazon");
  * requiring them to agree would miss most true duplicates.
  *
- * WHAT IS NEVER SUPPRESSED
- * ------------------------
- *  - transfers: dropping one leg would strand its counterpart and break the
- *    linked pair. Overlapping transfer legs are reported, not removed.
+ * TRANSFER LEGS: HANDOVER, NOT EXEMPTION
+ * --------------------------------------
+ * A transfer leg used to be exempt outright, on the reasoning that dropping one
+ * leg strands its counterpart. In a fed account that reasoning left the LARGEST
+ * rows in the overlap window — card payments, standing transfers — duplicated,
+ * because the feed reports them exactly like any other movement.
+ *
+ * So a transfer leg is not exempt; it is HANDED OVER. When the feed already
+ * covers it, the Money leg is suppressed and the feed row TAKES ITS PLACE in
+ * the transfer: typed `transfer`, carrying the leg's `transfer_account_id` and
+ * transfer category, linked to the counterpart — and the counterpart's own link
+ * is re-pointed at the feed row. Nothing is stranded, and the payment exists
+ * exactly once.
+ *
+ * The handover NEVER widens the match. It fires only on a pairing that already
+ * qualifies — same account, exact pence, within tolerance, strictly 1:1 — and
+ * only after every ordinary row has had its chance to claim that feed row
+ * (see the two passes below). It is refused, and the leg kept as before, when
+ * the feed row could not honestly become a transfer: a split parent (the
+ * database's own trigger forbids re-typing one) or a row already half of some
+ * other linked pair.
+ *
+ * WHAT IS STILL NEVER SUPPRESSED
+ * ------------------------------
  *  - split parents: their category breakdown lives in child rows the feed has
  *    no equivalent for; dropping the parent would orphan the split.
- * Both exclusions are counted in the result so the residual is visible rather
- * than silent.
+ *  - transfer legs whose handover was refused, for the reasons above.
+ * Both are counted in the result so the residual is visible rather than silent.
  *
  * WHY THE FEED ROW IS THE ONE KEPT
  * --------------------------------
@@ -58,6 +78,17 @@ export interface ExistingFeedTransaction {
   /** Signed amount; parsed through Decimal, never float. */
   amount: string | number;
   description: string;
+  /**
+   * Is this feed row a split parent? One cannot be re-typed as a transfer —
+   * `protect_split_transaction_fields` (migration 20260713100000) rejects it —
+   * so it is never handed a transfer leg. Omitted ⇒ not a split.
+   */
+  isSplit?: boolean;
+  /**
+   * Is this feed row already one side of a linked transfer? Then it belongs to
+   * that pair and is never re-pointed at another. Omitted ⇒ unlinked.
+   */
+  linkedTransferId?: string | null;
 }
 
 export interface FeedOverlapOptions {
@@ -70,9 +101,37 @@ export interface FeedOverlapMatch {
   importSourceId: string;
   /** Database id of the feed row that covers it. */
   feedTransactionId: string;
+  /** The account both sides share, in the Money side's namespace. */
+  accountId: string;
   /** Whole days between the two dates (0 = same day). */
   dayGap: number;
   /** 0–1 token overlap of the two descriptions; ranking only. */
+  descriptionSimilarity: number;
+  /** True when the suppressed row was a transfer leg (see `transferHandovers`). */
+  isTransferHandover: boolean;
+}
+
+/**
+ * A suppressed transfer leg and the feed row that inherits its place in the
+ * transfer. Everything the importer needs to rebuild the pair without the leg:
+ * which account the transfer faced, and which row (or split line) the other
+ * side is — still in the SEED's namespace, because the importer is the only
+ * thing that knows what database ids those become.
+ */
+export interface TransferHandover {
+  /** `mny-txn-<htrn>` of the Money transfer leg being suppressed. */
+  importSourceId: string;
+  /** Database id of the feed row that takes its place. */
+  feedTransactionId: string;
+  /** The account the leg sits in, in the Money side's namespace. */
+  accountId: string;
+  /** The account on the OTHER side of the transfer (seed namespace), if any. */
+  transferAccountId: string | null;
+  /** The other leg (seed namespace), if the pair was linked. */
+  counterpartSourceId: string | null;
+  /** The split LINE the other side is, when the counterpart is a split leg. */
+  counterpartSplitSourceId: string | null;
+  dayGap: number;
   descriptionSimilarity: number;
 }
 
@@ -85,6 +144,13 @@ export interface FeedOverlapResult {
   unmatchedFeedIds: string[];
   /** Overlaps found but deliberately left in place, by reason. */
   keptDespiteOverlap: { transfers: number; splitParents: number };
+  /**
+   * The subset of `matches` that suppressed a TRANSFER leg, with the link
+   * columns the feed row must inherit. Every entry's `importSourceId` is in
+   * `suppressedSourceIds`; acting on them is not optional, because the
+   * counterpart's link now points at a row that will not be imported.
+   */
+  transferHandovers: TransferHandover[];
 }
 
 const DEFAULT_TOLERANCE_DAYS = 3;
@@ -120,8 +186,47 @@ export function descriptionSimilarity(a: string, b: string): number {
 
 interface Candidate {
   sourceId: string;
+  accountId: string;
   day: number;
   description: string;
+}
+
+interface TransferCandidate extends Candidate {
+  transferAccountId: string | null;
+  counterpartSourceId: string | null;
+  counterpartSplitSourceId: string | null;
+}
+
+/** Append into a bucketed index without re-reading it twice. */
+function push<T>(index: Map<string, T[]>, key: string, entry: T): void {
+  const list = index.get(key);
+  if (list) list.push(entry);
+  else index.set(key, [entry]);
+}
+
+/** The best unclaimed candidate for a feed row: nearest date, description breaks ties. */
+function pickBest<T extends Candidate>(
+  pool: readonly T[],
+  claimed: ReadonlySet<string>,
+  feedDay: number,
+  feedDescription: string,
+  tolerance: number
+): { candidate: T; gap: number; similarity: number } | null {
+  let best: T | null = null;
+  let bestGap = Number.POSITIVE_INFINITY;
+  let bestSimilarity = -1;
+  for (const c of pool) {
+    if (claimed.has(c.sourceId)) continue;
+    const gap = Math.abs(c.day - feedDay) / MS_PER_DAY;
+    if (gap > tolerance) continue;
+    const similarity = descriptionSimilarity(c.description, feedDescription);
+    if (gap < bestGap || (gap === bestGap && similarity > bestSimilarity)) {
+      best = c;
+      bestGap = gap;
+      bestSimilarity = similarity;
+    }
+  }
+  return best ? { candidate: best, gap: bestGap, similarity: bestSimilarity } : null;
 }
 
 /**
@@ -130,6 +235,17 @@ interface Candidate {
  * `transactions` are the app-shaped rows from `transformMsMoneyExport`;
  * `feedRows` are the user's existing bank-fed transactions with their account
  * ids translated into the import's namespace. Neither input is mutated.
+ *
+ * Two passes, in this order and for this reason:
+ *
+ *   1. ORDINARY rows. Unchanged, and it runs first so that adding the second
+ *      pass cannot move a single pairing it used to make: a feed row only
+ *      reaches the transfer pool once nothing ordinary wanted it.
+ *   2. TRANSFER legs, over the feed rows pass 1 left unclaimed — the very rows
+ *      that used to be written off as "an overlap we chose to keep". Matching
+ *      is identical (same account, exact pence, ≤ tolerance, 1:1 against the
+ *      same `claimed` set); the difference is what happens afterwards, which is
+ *      a handover rather than a plain drop.
  */
 export function findFeedOverlap(
   transactions: readonly Transaction[],
@@ -138,78 +254,105 @@ export function findFeedOverlap(
 ): FeedOverlapResult {
   const tolerance = Math.max(0, options.dateToleranceDays ?? DEFAULT_TOLERANCE_DAYS);
 
-  // Index the importable Money rows by account + exact pence. Transfers and
-  // split parents are indexed separately: they are never suppressed, but an
-  // overlap involving one is still worth reporting.
+  // Index the Money rows by account + exact pence, in three pools: ordinary
+  // rows (suppressible outright), transfer legs (suppressible only by handover)
+  // and split parents (never suppressed at all). A transfer that is ALSO a
+  // split parent counts as a split parent — the stricter rule wins.
   const byKey = new Map<string, Candidate[]>();
-  const excludedByKey = new Map<string, (Candidate & { kind: 'transfer' | 'splitParent' })[]>();
+  const transferByKey = new Map<string, TransferCandidate[]>();
+  const splitParentByKey = new Map<string, Candidate[]>();
   const kept = { transfers: 0, splitParents: 0 };
 
   for (const t of transactions) {
     const key = `${t.accountId}|${pence(t.amount)}`;
-    const entry: Candidate = { sourceId: t.id, day: dayOf(t.date), description: t.description ?? '' };
-    if (t.type === 'transfer' || t.isSplit === true) {
-      const kind = t.type === 'transfer' ? 'transfer' : 'splitParent';
-      const list = excludedByKey.get(key);
-      if (list) list.push({ ...entry, kind });
-      else excludedByKey.set(key, [{ ...entry, kind }]);
-      continue;
-    }
-    const list = byKey.get(key);
-    if (list) list.push(entry);
-    else byKey.set(key, [entry]);
+    const entry: Candidate = {
+      sourceId: t.id, accountId: t.accountId, day: dayOf(t.date), description: t.description ?? '',
+    };
+    if (t.isSplit === true) push(splitParentByKey, key, entry);
+    else if (t.type === 'transfer') {
+      push(transferByKey, key, {
+        ...entry,
+        transferAccountId: t.transferAccountId ?? null,
+        counterpartSourceId: t.linkedTransferId ?? null,
+        counterpartSplitSourceId: t.linkedTransferSplitId ?? null,
+      });
+    } else push(byKey, key, entry);
   }
 
   const matches: FeedOverlapMatch[] = [];
+  const transferHandovers: TransferHandover[] = [];
   const claimed = new Set<string>();
-  const unmatchedFeedIds: string[] = [];
+  const matchedFeedIds = new Set<string>();
 
   // Oldest feed row first, so a run of same-amount rows pairs off in order.
   const ordered = [...feedRows].sort((a, b) => dayOf(a.date) - dayOf(b.date));
+  const keyOf = (feed: ExistingFeedTransaction): string => `${feed.accountId}|${pence(feed.amount)}`;
 
+  // ── Pass 1: ordinary rows ──────────────────────────────────────────────────
   for (const feed of ordered) {
-    const key = `${feed.accountId}|${pence(feed.amount)}`;
-    const feedDay = dayOf(feed.date);
+    const hit = pickBest(byKey.get(keyOf(feed)) ?? [], claimed, dayOf(feed.date), feed.description, tolerance);
+    if (!hit) continue;
+    claimed.add(hit.candidate.sourceId);
+    matchedFeedIds.add(feed.id);
+    matches.push({
+      importSourceId: hit.candidate.sourceId,
+      feedTransactionId: feed.id,
+      accountId: hit.candidate.accountId,
+      dayGap: hit.gap,
+      descriptionSimilarity: hit.similarity,
+      isTransferHandover: false,
+    });
+  }
 
-    const pool = (byKey.get(key) ?? []).filter(c => !claimed.has(c.sourceId));
-    let best: Candidate | null = null;
-    let bestGap = Number.POSITIVE_INFINITY;
-    let bestSimilarity = -1;
+  // ── Pass 2: transfer legs, handed over to the feed row ─────────────────────
+  for (const feed of ordered) {
+    if (matchedFeedIds.has(feed.id)) continue;
+    const hit = pickBest(transferByKey.get(keyOf(feed)) ?? [], claimed, dayOf(feed.date), feed.description, tolerance);
+    if (!hit) continue;
 
-    for (const c of pool) {
-      const gap = Math.abs(c.day - feedDay) / MS_PER_DAY;
-      if (gap > tolerance) continue;
-      const similarity = descriptionSimilarity(c.description, feed.description);
-      // Nearest date wins; description breaks ties.
-      if (gap < bestGap || (gap === bestGap && similarity > bestSimilarity)) {
-        best = c;
-        bestGap = gap;
-        bestSimilarity = similarity;
-      }
-    }
-
-    if (!best) {
-      unmatchedFeedIds.push(feed.id);
-      // A transfer leg or split parent within the same window and amount is an
-      // overlap we deliberately chose to keep — count it once, so the residual
-      // is visible instead of silent.
-      const excludedMatch = (excludedByKey.get(key) ?? []).find(
-        c => !claimed.has(c.sourceId) && Math.abs(c.day - feedDay) / MS_PER_DAY <= tolerance
-      );
-      if (excludedMatch) {
-        claimed.add(excludedMatch.sourceId);
-        if (excludedMatch.kind === 'transfer') kept.transfers++; else kept.splitParents++;
-      }
+    // The pairing qualifies. Can the feed row honestly BECOME the transfer?
+    // A split parent cannot be re-typed (the database's trigger refuses it) and
+    // a row already half of another pair is not ours to re-point. Either way the
+    // leg stays exactly as it was before handovers existed, and is counted.
+    if (feed.isSplit === true || (feed.linkedTransferId ?? null) !== null) {
+      claimed.add(hit.candidate.sourceId);
+      kept.transfers++;
       continue;
     }
 
-    claimed.add(best.sourceId);
+    claimed.add(hit.candidate.sourceId);
+    matchedFeedIds.add(feed.id);
     matches.push({
-      importSourceId: best.sourceId,
+      importSourceId: hit.candidate.sourceId,
       feedTransactionId: feed.id,
-      dayGap: bestGap,
-      descriptionSimilarity: bestSimilarity,
+      accountId: hit.candidate.accountId,
+      dayGap: hit.gap,
+      descriptionSimilarity: hit.similarity,
+      isTransferHandover: true,
     });
+    transferHandovers.push({
+      importSourceId: hit.candidate.sourceId,
+      feedTransactionId: feed.id,
+      accountId: hit.candidate.accountId,
+      transferAccountId: hit.candidate.transferAccountId,
+      counterpartSourceId: hit.candidate.counterpartSourceId,
+      counterpartSplitSourceId: hit.candidate.counterpartSplitSourceId,
+      dayGap: hit.gap,
+      descriptionSimilarity: hit.similarity,
+    });
+  }
+
+  // ── Pass 3: bookkeeping for the overlaps left standing ─────────────────────
+  // A split parent the feed also covers is a real overlap that will not be
+  // removed. Counting it keeps the residual visible instead of silent.
+  const unmatchedFeedIds: string[] = [];
+  for (const feed of ordered) {
+    if (matchedFeedIds.has(feed.id)) continue;
+    unmatchedFeedIds.push(feed.id);
+    const hit = pickBest(splitParentByKey.get(keyOf(feed)) ?? [], claimed, dayOf(feed.date), feed.description, tolerance);
+    if (!hit) continue;
+    claimed.add(hit.candidate.sourceId);
+    kept.splitParents++;
   }
 
   return {
@@ -217,5 +360,6 @@ export function findFeedOverlap(
     suppressedSourceIds: new Set(matches.map(m => m.importSourceId)),
     unmatchedFeedIds,
     keptDespiteOverlap: kept,
+    transferHandovers,
   };
 }

--- a/src/services/import/msMoney/feedOverlap.ts
+++ b/src/services/import/msMoney/feedOverlap.ts
@@ -1,0 +1,221 @@
+/**
+ * Bank-feed overlap suppression for the MS Money import.
+ *
+ * THE PROBLEM
+ * -----------
+ * A Money file is a complete history up to the day it was exported. A live
+ * bank feed backfills its own history from the day the account was linked.
+ * Where the two windows overlap, the SAME real-world transaction exists twice:
+ * once written by the file import (no feed id) and once by the feed (carrying
+ * `external_transaction_id`). Nothing reconciled them, so every overlapping
+ * payment was counted twice in reports.
+ *
+ * The importer's own `import_source_id` idempotency cannot help here: the two
+ * copies come from different systems with different identifiers. They have to
+ * be matched on what they describe.
+ *
+ * THE RULE (deliberately narrow — a false positive deletes real spending)
+ * ----------------------------------------------------------------------
+ * A Money transaction is suppressed only when a bank-feed row in the SAME
+ * account has the EXACT same amount (to the penny) and a date within
+ * `dateToleranceDays` (default 3 — feeds post on the settlement date, Money
+ * records the transaction date). Matching is strictly 1:1 and greedy: each
+ * feed row claims at most one Money row and vice versa, so at most
+ * `feedRows.length` Money rows can ever be dropped. Candidates are ranked by
+ * date distance first, then by description similarity, so when several rows
+ * are eligible the most plausible pairing wins.
+ *
+ * Description is a RANKING signal, never a gate. Feed descriptions are the
+ * bank's raw strings ("AMZNMktplace ..."), Money's are payee names ("Amazon");
+ * requiring them to agree would miss most true duplicates.
+ *
+ * WHAT IS NEVER SUPPRESSED
+ * ------------------------
+ *  - transfers: dropping one leg would strand its counterpart and break the
+ *    linked pair. Overlapping transfer legs are reported, not removed.
+ *  - split parents: their category breakdown lives in child rows the feed has
+ *    no equivalent for; dropping the parent would orphan the split.
+ * Both exclusions are counted in the result so the residual is visible rather
+ * than silent.
+ *
+ * WHY THE FEED ROW IS THE ONE KEPT
+ * --------------------------------
+ * In the overlap window the feed row is what the bank actually reports, it
+ * carries the provider's own id, and it is the row future syncs reconcile
+ * against. It cannot be recreated from the Money file; the Money row can.
+ */
+import { toDecimal } from '../../../utils/decimal';
+import type { Transaction } from '../../../types';
+
+/** A transaction already in the database that came from a bank feed. */
+export interface ExistingFeedTransaction {
+  /** Database row id — only used for reporting. */
+  id: string;
+  /** Account id in the IMPORT's namespace (caller maps the DB uuid across). */
+  accountId: string;
+  /** yyyy-mm-dd */
+  date: string;
+  /** Signed amount; parsed through Decimal, never float. */
+  amount: string | number;
+  description: string;
+}
+
+export interface FeedOverlapOptions {
+  /** Feeds post on settlement date; Money records the transaction date. */
+  dateToleranceDays?: number;
+}
+
+export interface FeedOverlapMatch {
+  /** `mny-txn-<htrn>` of the Money row the feed already covers. */
+  importSourceId: string;
+  /** Database id of the feed row that covers it. */
+  feedTransactionId: string;
+  /** Whole days between the two dates (0 = same day). */
+  dayGap: number;
+  /** 0–1 token overlap of the two descriptions; ranking only. */
+  descriptionSimilarity: number;
+}
+
+export interface FeedOverlapResult {
+  /** Money rows the feed already covers — do not import these. */
+  matches: FeedOverlapMatch[];
+  /** Fast membership test over `matches`. */
+  suppressedSourceIds: Set<string>;
+  /** Feed rows with no Money counterpart — spending the file never had. */
+  unmatchedFeedIds: string[];
+  /** Overlaps found but deliberately left in place, by reason. */
+  keptDespiteOverlap: { transfers: number; splitParents: number };
+}
+
+const DEFAULT_TOLERANCE_DAYS = 3;
+const MS_PER_DAY = 86_400_000;
+
+/** Exact pence — Decimal in, integer out, no float arithmetic anywhere. */
+const pence = (amount: string | number): number =>
+  toDecimal(String(amount)).times(100).round().toNumber();
+
+const dayOf = (value: Date | string): number => {
+  const iso = value instanceof Date ? value.toISOString() : String(value);
+  return Date.parse(`${iso.slice(0, 10)}T00:00:00.000Z`);
+};
+
+/** Alphanumeric word tokens, upper-cased; short noise words dropped. */
+const tokens = (text: string): Set<string> =>
+  new Set(
+    text
+      .toUpperCase()
+      .split(/[^A-Z0-9]+/)
+      .filter(t => t.length > 2)
+  );
+
+/** Jaccard overlap of the two token sets — 1 identical, 0 nothing in common. */
+export function descriptionSimilarity(a: string, b: string): number {
+  const ta = tokens(a);
+  const tb = tokens(b);
+  if (ta.size === 0 || tb.size === 0) return 0;
+  let shared = 0;
+  for (const t of ta) if (tb.has(t)) shared++;
+  return shared / (ta.size + tb.size - shared);
+}
+
+interface Candidate {
+  sourceId: string;
+  day: number;
+  description: string;
+}
+
+/**
+ * Decide which Money transactions the bank feed already covers.
+ *
+ * `transactions` are the app-shaped rows from `transformMsMoneyExport`;
+ * `feedRows` are the user's existing bank-fed transactions with their account
+ * ids translated into the import's namespace. Neither input is mutated.
+ */
+export function findFeedOverlap(
+  transactions: readonly Transaction[],
+  feedRows: readonly ExistingFeedTransaction[],
+  options: FeedOverlapOptions = {}
+): FeedOverlapResult {
+  const tolerance = Math.max(0, options.dateToleranceDays ?? DEFAULT_TOLERANCE_DAYS);
+
+  // Index the importable Money rows by account + exact pence. Transfers and
+  // split parents are indexed separately: they are never suppressed, but an
+  // overlap involving one is still worth reporting.
+  const byKey = new Map<string, Candidate[]>();
+  const excludedByKey = new Map<string, (Candidate & { kind: 'transfer' | 'splitParent' })[]>();
+  const kept = { transfers: 0, splitParents: 0 };
+
+  for (const t of transactions) {
+    const key = `${t.accountId}|${pence(t.amount)}`;
+    const entry: Candidate = { sourceId: t.id, day: dayOf(t.date), description: t.description ?? '' };
+    if (t.type === 'transfer' || t.isSplit === true) {
+      const kind = t.type === 'transfer' ? 'transfer' : 'splitParent';
+      const list = excludedByKey.get(key);
+      if (list) list.push({ ...entry, kind });
+      else excludedByKey.set(key, [{ ...entry, kind }]);
+      continue;
+    }
+    const list = byKey.get(key);
+    if (list) list.push(entry);
+    else byKey.set(key, [entry]);
+  }
+
+  const matches: FeedOverlapMatch[] = [];
+  const claimed = new Set<string>();
+  const unmatchedFeedIds: string[] = [];
+
+  // Oldest feed row first, so a run of same-amount rows pairs off in order.
+  const ordered = [...feedRows].sort((a, b) => dayOf(a.date) - dayOf(b.date));
+
+  for (const feed of ordered) {
+    const key = `${feed.accountId}|${pence(feed.amount)}`;
+    const feedDay = dayOf(feed.date);
+
+    const pool = (byKey.get(key) ?? []).filter(c => !claimed.has(c.sourceId));
+    let best: Candidate | null = null;
+    let bestGap = Number.POSITIVE_INFINITY;
+    let bestSimilarity = -1;
+
+    for (const c of pool) {
+      const gap = Math.abs(c.day - feedDay) / MS_PER_DAY;
+      if (gap > tolerance) continue;
+      const similarity = descriptionSimilarity(c.description, feed.description);
+      // Nearest date wins; description breaks ties.
+      if (gap < bestGap || (gap === bestGap && similarity > bestSimilarity)) {
+        best = c;
+        bestGap = gap;
+        bestSimilarity = similarity;
+      }
+    }
+
+    if (!best) {
+      unmatchedFeedIds.push(feed.id);
+      // A transfer leg or split parent within the same window and amount is an
+      // overlap we deliberately chose to keep — count it once, so the residual
+      // is visible instead of silent.
+      const excludedMatch = (excludedByKey.get(key) ?? []).find(
+        c => !claimed.has(c.sourceId) && Math.abs(c.day - feedDay) / MS_PER_DAY <= tolerance
+      );
+      if (excludedMatch) {
+        claimed.add(excludedMatch.sourceId);
+        if (excludedMatch.kind === 'transfer') kept.transfers++; else kept.splitParents++;
+      }
+      continue;
+    }
+
+    claimed.add(best.sourceId);
+    matches.push({
+      importSourceId: best.sourceId,
+      feedTransactionId: feed.id,
+      dayGap: bestGap,
+      descriptionSimilarity: bestSimilarity,
+    });
+  }
+
+  return {
+    matches,
+    suppressedSourceIds: new Set(matches.map(m => m.importSourceId)),
+    unmatchedFeedIds,
+    keptDespiteOverlap: kept,
+  };
+}

--- a/src/services/import/msMoney/msMoneyImport.test.ts
+++ b/src/services/import/msMoney/msMoneyImport.test.ts
@@ -6,6 +6,7 @@ import {
   type ExistingCategoryRow, type ExistingAccountRow, type CloudPlan,
   type CloudWriteClient, type WriteOutcome,
 } from './msMoneyImport';
+import type { TransferHandover } from './feedOverlap';
 import type { MsMoneyImportResult } from './transform';
 
 function sampleResult(): MsMoneyImportResult {
@@ -52,6 +53,8 @@ describe('executeCloudPlan write path', () => {
     accounts: [], accountParents: [], categories: [], transactions: [],
     transferLinks: [], splits: [], splitLegPins: [],
     accountParentRows: [], linkRows: [],
+    feedPromotions: [], feedPromotionRows: [], unpromotableHandovers: [],
+    openingBalanceMismatches: [], accountOpeningBalanceRows: [],
     skippedExisting: 0, skippedFeedOverlap: 0, skippedExistingAccounts: 0,
     skippedExistingCategories: 0, categoriesWithUnresolvedParent: 0,
     ...over,
@@ -60,8 +63,8 @@ describe('executeCloudPlan write path', () => {
   /** Records every write, and answers with whatever the script dictates. */
   const clientRecording = (
     answers: WriteOutcome[] = []
-  ): { client: CloudWriteClient; calls: { table: string; rows: number; merge?: boolean }[] } => {
-    const calls: { table: string; rows: number; merge?: boolean }[] = [];
+  ): { client: CloudWriteClient; calls: { table: string; rows: number; merge?: boolean; onConflict?: string }[] } => {
+    const calls: { table: string; rows: number; merge?: boolean; onConflict?: string }[] = [];
     let i = 0;
     const next = (): WriteOutcome => answers[i++] ?? { error: null, status: 201 };
     const client: CloudWriteClient = {
@@ -71,7 +74,7 @@ describe('executeCloudPlan write path', () => {
           return Promise.resolve(next());
         },
         upsert: (rows: Record<string, unknown>[], options: { onConflict: string; ignoreDuplicates: boolean }) => {
-          calls.push({ table, rows: rows.length, merge: !options.ignoreDuplicates });
+          calls.push({ table, rows: rows.length, merge: !options.ignoreDuplicates, onConflict: options.onConflict });
           return Promise.resolve(next());
         },
       }),
@@ -102,6 +105,36 @@ describe('executeCloudPlan write path', () => {
     await executeCloudPlan(emptyPlan({ transactions: [{ id: 't1' }] }), client);
     // The insert happens; no second pass follows it.
     expect(calls.filter(c => c.merge)).toHaveLength(0);
+  });
+
+  it('promotes bank-feed rows through the SAME batched merge, keyed on the primary key', async () => {
+    // A feed row carries no import provenance, so the provenance conflict
+    // target cannot address it — and there are only ever a handful, but they
+    // still go through the batched path rather than a request each.
+    const feedPromotionRows = Array.from({ length: IMPORT_BATCH_SIZE + 3 }, (_, n) => ({
+      id: `feed-${n}`, user_id: 'u1', account_id: 'a1', amount: -1, date: '2026-01-01',
+      type: 'transfer', linked_transfer_id: `txn-${n}`,
+    }));
+    const { client, calls } = clientRecording();
+
+    await executeCloudPlan(emptyPlan({ feedPromotionRows }), client);
+
+    const promotionCalls = calls.filter(c => c.table === 'transactions');
+    expect(promotionCalls.map(c => c.rows)).toEqual([IMPORT_BATCH_SIZE, 3]);
+    expect(promotionCalls.every(c => c.merge && c.onConflict === 'id')).toBe(true);
+  });
+
+  it('writes an opening-balance correction only when the plan carries one', async () => {
+    const bare = clientRecording();
+    await executeCloudPlan(emptyPlan({ accounts: [{ id: 'a1' }] }), bare.client);
+    expect(bare.calls.filter(c => c.table === 'accounts' && c.merge)).toHaveLength(0);
+
+    const rebasing = clientRecording();
+    await executeCloudPlan(
+      emptyPlan({ accountOpeningBalanceRows: [{ id: 'a1', user_id: 'u1', name: 'A', initial_balance: 0 }] }),
+      rebasing.client
+    );
+    expect(rebasing.calls).toEqual([{ table: 'accounts', rows: 1, merge: true, onConflict: 'id' }]);
   });
 
   it('retries a transient failure and then succeeds', async () => {
@@ -467,6 +500,248 @@ describe('planCloudImport — bank-feed overlap suppression', () => {
     // No orphaned split line pointing at a row that was never written.
     expect(plan.splits).toHaveLength(0);
     expect(plan.skippedFeedOverlap).toBe(1);
+  });
+});
+
+// ── Transfer-leg handover ────────────────────────────────────────────────────
+// The two real shapes, on the sample's own transfer pair (200 in `Current`
+// ⇄ 201 in `Savings`): one leg fed, and both legs fed. All ids invented.
+
+/** The id the plan gave a freshly-inserted account / category, by name. */
+const idOfAccount = (plan: CloudPlan, name: string): string =>
+  String(plan.accounts.find(a => a.name === name)?.id);
+const idOfCategory = (plan: CloudPlan, name: string): string =>
+  String(plan.categories.find(c => c.name === name)?.id);
+
+describe('planCloudImport — transfer-leg handover', () => {
+  /** A complete `transactions` row as `select *` returns it. */
+  const feedRow = (over: Record<string, unknown>): Record<string, unknown> => ({
+    id: 'feed-out', user_id: 'user-abc', account_id: 'db-acct-1', description: 'CARD PAYMENT',
+    amount: -30, type: 'expense', date: '2020-02-02', category: '', notes: null,
+    is_cleared: true, is_split: false, transfer_account_id: null, linked_transfer_id: null,
+    linked_transfer_split_id: null, external_transaction_id: 'bank-ref-1',
+    import_source: null, import_source_id: null,
+    ...over,
+  });
+
+  const handover = (over: Partial<TransferHandover> = {}): TransferHandover => ({
+    importSourceId: 'mny-txn-200',
+    feedTransactionId: 'feed-out',
+    accountId: 'mny-acct-1',
+    transferAccountId: 'mny-acct-2',
+    counterpartSourceId: 'mny-txn-201',
+    counterpartSplitSourceId: null,
+    dayGap: 0,
+    descriptionSimilarity: 0,
+    ...over,
+  });
+
+  it('promotes the feed row into the transfer and re-points the surviving counterpart', () => {
+    let n = 0;
+    const plan = planCloudImport(sampleResult(), 'user-abc', () => `new-${n++}`, {
+      suppressedSourceIds: new Set(['mny-txn-200']),
+      transferHandovers: [handover()],
+      feedTransactionRowsById: new Map([['feed-out', feedRow({})]]),
+    });
+
+    // The Money leg is gone…
+    expect(plan.transactions.map(t => t.import_source_id)).not.toContain('mny-txn-200');
+    expect(plan.unpromotableHandovers).toEqual([]);
+
+    // …and the feed row is the transfer now.
+    expect(plan.feedPromotions).toHaveLength(1);
+    const promotion = plan.feedPromotions[0];
+    expect(promotion.id).toBe('feed-out');
+    expect(promotion.transfer_account_id).toBe(idOfAccount(plan, 'Savings'));
+    const counterpartId = plan.transactions.find(t => t.import_source_id === 'mny-txn-201')?.id;
+    expect(promotion.linked_transfer_id).toBe(counterpartId);
+
+    const [row] = plan.feedPromotionRows;
+    expect(row).toMatchObject({
+      id: 'feed-out',
+      type: 'transfer',
+      linked_transfer_id: counterpartId,
+      // Untouched: this is still the bank's row, with the bank's own identity.
+      external_transaction_id: 'bank-ref-1',
+      amount: -30,
+      is_split: false,
+    });
+    // It files under the leg's own To/From category, like any other transfer.
+    expect(row.category).toBe(idOfCategory(plan, 'To/From Savings'));
+
+    // The surviving counterpart points at the FEED row, not at a row that will
+    // never exist — the whole reason a handover is not just a suppression.
+    const counterpartLink = plan.linkRows.find(r => r.import_source_id === 'mny-txn-201');
+    expect(counterpartLink?.linked_transfer_id).toBe('feed-out');
+    expect(plan.transferLinks).toContainEqual({ id: counterpartId, linked_transfer_id: 'feed-out' });
+  });
+
+  it('re-points a split LINE that pointed at the suppressed leg', () => {
+    const withSplitLeg = sampleResult();
+    withSplitLeg.transactionSplits[0] = {
+      ...withSplitLeg.transactionSplits[0],
+      linkedTransferId: 'mny-txn-200',
+      transferAccountId: 'mny-acct-1',
+    };
+    let n = 0;
+    const plan = planCloudImport(withSplitLeg, 'user-abc', () => `new-${n++}`, {
+      suppressedSourceIds: new Set(['mny-txn-200']),
+      transferHandovers: [handover()],
+      feedTransactionRowsById: new Map([['feed-out', feedRow({})]]),
+    });
+    // Without the handover this would be NULL — the line would quietly stop
+    // being half of a transfer.
+    expect(plan.splits[0].linked_transfer_id).toBe('feed-out');
+  });
+
+  it('links the two feed rows to each other when both legs are fed', () => {
+    let n = 0;
+    const plan = planCloudImport(sampleResult(), 'user-abc', () => `new-${n++}`, {
+      suppressedSourceIds: new Set(['mny-txn-200', 'mny-txn-201']),
+      transferHandovers: [
+        handover(),
+        handover({
+          importSourceId: 'mny-txn-201', feedTransactionId: 'feed-in',
+          accountId: 'mny-acct-2', transferAccountId: 'mny-acct-1',
+          counterpartSourceId: 'mny-txn-200', counterpartSplitSourceId: 'mny-split-300-1',
+        }),
+      ],
+      feedTransactionRowsById: new Map([
+        ['feed-out', feedRow({})],
+        ['feed-in', feedRow({ id: 'feed-in', account_id: 'db-acct-2', amount: 30, type: 'income', external_transaction_id: 'bank-ref-2' })],
+      ]),
+    });
+
+    expect(plan.transactions.map(t => t.import_source_id)).toEqual(['mny-txn-100', 'mny-txn-300']);
+    const byId = new Map(plan.feedPromotions.map(p => [p.id, p]));
+    expect(byId.get('feed-out')?.linked_transfer_id).toBe('feed-in');
+    expect(byId.get('feed-in')?.linked_transfer_id).toBe('feed-out');
+    // The far leg was pinned to a split LINE; that pin moves across too.
+    expect(byId.get('feed-in')?.linked_transfer_split_id).toBe(plan.splits[0].id);
+    expect(plan.feedPromotionRows).toHaveLength(2);
+  });
+
+  it('writes nothing when the feed row is already the transfer (a second run)', () => {
+    let n = 0;
+    const first = planCloudImport(sampleResult(), 'user-abc', () => `new-${n++}`, {
+      suppressedSourceIds: new Set(['mny-txn-200']),
+      transferHandovers: [handover()],
+      feedTransactionRowsById: new Map([['feed-out', feedRow({})]]),
+    });
+    const [written] = first.feedPromotionRows;
+
+    // Replay against the database exactly as that first run left it: the same
+    // accounts, the same categories, the same rows, the same links.
+    const existing = new Map(first.transactions.map(t => [String(t.import_source_id), String(t.id)]));
+    const counterpartId = existing.get('mny-txn-201');
+    let m = 0;
+    const second = planCloudImport(sampleResult(), 'user-abc', () => `again-${m++}`, {
+      suppressedSourceIds: new Set(['mny-txn-200']),
+      transferHandovers: [handover()],
+      feedTransactionRowsById: new Map([['feed-out', written]]),
+      existingBySourceId: existing,
+      existingAccounts: first.accounts.map(a => ({ id: String(a.id), name: String(a.name) })),
+      existingCategories: first.categories.map(c => ({
+        id: String(c.id), name: String(c.name), type: String(c.type), level: String(c.level),
+        parent_id: c.parent_id == null ? null : String(c.parent_id), is_system: c.is_system === true,
+      })),
+      existingTransactionLinks: new Map([
+        ['mny-txn-201', { linkedTransferId: counterpartId ? 'feed-out' : null, linkedTransferSplitId: null }],
+      ]),
+    });
+
+    expect(second.transactions).toEqual([]);
+    expect(second.accounts).toEqual([]);
+    expect(second.categories).toEqual([]);
+    expect(second.feedPromotions).toHaveLength(1);       // still known…
+    expect(second.feedPromotionRows).toEqual([]);        // …but nothing to write
+    expect(second.linkRows.map(r => r.import_source_id)).not.toContain('mny-txn-201');
+  });
+
+  it('imports the leg rather than dropping it when the feed row was not supplied', () => {
+    let n = 0;
+    const plan = planCloudImport(sampleResult(), 'user-abc', () => `new-${n++}`, {
+      suppressedSourceIds: new Set(['mny-txn-200']),
+      transferHandovers: [handover()],
+      // …and no feedTransactionRowsById at all.
+    });
+    // Losing a real transfer is worse than leaving a duplicate: the leg goes in.
+    expect(plan.transactions.map(t => t.import_source_id)).toContain('mny-txn-200');
+    expect(plan.unpromotableHandovers.map(h => h.importSourceId)).toEqual(['mny-txn-200']);
+    expect(plan.feedPromotionRows).toEqual([]);
+    expect(plan.skippedFeedOverlap).toBe(0);
+  });
+
+  it('ignores a handover for a row that is not being suppressed', () => {
+    let n = 0;
+    const plan = planCloudImport(sampleResult(), 'user-abc', () => `new-${n++}`, {
+      transferHandovers: [handover()],
+      feedTransactionRowsById: new Map([['feed-out', feedRow({})]]),
+    });
+    expect(plan.transactions.map(t => t.import_source_id)).toContain('mny-txn-200');
+    expect(plan.feedPromotions).toEqual([]);
+    expect(plan.unpromotableHandovers).toEqual([]);
+  });
+});
+
+describe('planCloudImport — opening balances on reused accounts', () => {
+  const reused = (initial: number | null): ExistingAccountRow[] => [
+    { id: 'db-acct-1', name: 'Current', initial_balance: initial },
+  ];
+  /** The file says 0 for every sample account; this row says otherwise. */
+  const completeAccountRow = { id: 'db-acct-1', user_id: 'user-abc', name: 'Current',
+    type: 'checking', balance: -26727.29, initial_balance: -26727.29, currency: 'GBP',
+    is_active: true, notes: null, parent_account_id: null };
+
+  it('reports a reused account whose opening balance disagrees with the file', () => {
+    let n = 0;
+    const plan = planCloudImport(sampleResult(), 'user-abc', () => `new-${n++}`, {
+      existingAccounts: reused(-26727.29),
+    });
+    expect(plan.skippedExistingAccounts).toBe(1);
+    expect(plan.openingBalanceMismatches).toEqual([{
+      accountId: 'db-acct-1', accountName: 'Current',
+      fileValue: '0.00', storedValue: '-26727.29', rebased: false,
+    }]);
+    // Reported, never silently corrected.
+    expect(plan.accountOpeningBalanceRows).toEqual([]);
+  });
+
+  it('corrects it only when asked, and only with the complete row to write back', () => {
+    let n = 0;
+    const plan = planCloudImport(sampleResult(), 'user-abc', () => `new-${n++}`, {
+      existingAccounts: reused(-26727.29),
+      existingAccountRowsById: new Map([['db-acct-1', completeAccountRow]]),
+      rebaseOpeningBalances: true,
+    });
+    expect(plan.openingBalanceMismatches[0].rebased).toBe(true);
+    expect(plan.accountOpeningBalanceRows).toEqual([{
+      ...completeAccountRow,
+      initial_balance: 0,
+    }]);
+    // The stored balance is NOT touched — that is a separate repair.
+    expect(plan.accountOpeningBalanceRows[0].balance).toBe(-26727.29);
+  });
+
+  it('says nothing when the two agree, or when no opening balance was offered', () => {
+    let n = 0;
+    expect(planCloudImport(sampleResult(), 'user-abc', () => `new-${n++}`, {
+      existingAccounts: reused(0),
+      rebaseOpeningBalances: true,
+    }).openingBalanceMismatches).toEqual([]);
+    expect(planCloudImport(sampleResult(), 'user-abc', () => `new-${n++}`, {
+      existingAccounts: [{ id: 'db-acct-1', name: 'Current' }],
+    }).openingBalanceMismatches).toEqual([]);
+  });
+
+  it('asks for a rebase but cannot write one without the complete row', () => {
+    let n = 0;
+    const plan = planCloudImport(sampleResult(), 'user-abc', () => `new-${n++}`, {
+      existingAccounts: reused(-26727.29),
+      rebaseOpeningBalances: true,
+    });
+    expect(plan.openingBalanceMismatches[0].rebased).toBe(false);
+    expect(plan.accountOpeningBalanceRows).toEqual([]);
   });
 });
 

--- a/src/services/import/msMoney/msMoneyImport.test.ts
+++ b/src/services/import/msMoney/msMoneyImport.test.ts
@@ -1,8 +1,10 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import {
-  planCloudImport, importToLocalStorage, wipeLocalData,
-  MS_MONEY_IMPORT_SOURCE, IMPORT_PROVENANCE_CONFLICT,
-  type ExistingCategoryRow, type ExistingAccountRow,
+  planCloudImport, importToLocalStorage, wipeLocalData, executeCloudPlan,
+  MS_MONEY_IMPORT_SOURCE, IMPORT_PROVENANCE_CONFLICT, IMPORT_BATCH_SIZE,
+  isRetryableWriteStatus,
+  type ExistingCategoryRow, type ExistingAccountRow, type CloudPlan,
+  type CloudWriteClient, type WriteOutcome,
 } from './msMoneyImport';
 import type { MsMoneyImportResult } from './transform';
 
@@ -44,6 +46,106 @@ function sampleResult(): MsMoneyImportResult {
     },
   };
 }
+
+describe('executeCloudPlan write path', () => {
+  const emptyPlan = (over: Partial<CloudPlan> = {}): CloudPlan => ({
+    accounts: [], accountParents: [], categories: [], transactions: [],
+    transferLinks: [], splits: [], splitLegPins: [],
+    accountParentRows: [], linkRows: [],
+    skippedExisting: 0, skippedFeedOverlap: 0, skippedExistingAccounts: 0,
+    skippedExistingCategories: 0, categoriesWithUnresolvedParent: 0,
+    ...over,
+  });
+
+  /** Records every write, and answers with whatever the script dictates. */
+  const clientRecording = (
+    answers: WriteOutcome[] = []
+  ): { client: CloudWriteClient; calls: { table: string; rows: number; merge?: boolean }[] } => {
+    const calls: { table: string; rows: number; merge?: boolean }[] = [];
+    let i = 0;
+    const next = (): WriteOutcome => answers[i++] ?? { error: null, status: 201 };
+    const client: CloudWriteClient = {
+      from: (table: string) => ({
+        insert: (rows: Record<string, unknown>[]) => {
+          calls.push({ table, rows: rows.length });
+          return Promise.resolve(next());
+        },
+        upsert: (rows: Record<string, unknown>[], options: { onConflict: string; ignoreDuplicates: boolean }) => {
+          calls.push({ table, rows: rows.length, merge: !options.ignoreDuplicates });
+          return Promise.resolve(next());
+        },
+      }),
+    };
+    return { client, calls };
+  };
+
+  it('writes the link pass in batches, not one request per row', async () => {
+    // The bug this replaced issued ONE http request per link — 11,218 of them
+    // for the real file — and died partway through with no way to resume.
+    const linkRows = Array.from({ length: IMPORT_BATCH_SIZE + 20 }, (_, n) => ({
+      id: `txn-${n}`, user_id: 'u1', account_id: 'a1', amount: -1, date: '2026-01-01',
+      linked_transfer_id: `txn-partner-${n}`,
+    }));
+    const { client, calls } = clientRecording();
+
+    await executeCloudPlan(emptyPlan({ linkRows }), client);
+
+    const linkCalls = calls.filter(c => c.table === 'transactions');
+    expect(linkCalls).toHaveLength(2);                       // 520 rows → 2 batches, not 520 calls
+    expect(linkCalls.map(c => c.rows)).toEqual([IMPORT_BATCH_SIZE, 20]);
+    // Merge semantics: the row already exists, so the conflict must UPDATE it.
+    expect(linkCalls.every(c => c.merge)).toBe(true);
+  });
+
+  it('writes nothing for the link pass when no row needs linking', async () => {
+    const { client, calls } = clientRecording();
+    await executeCloudPlan(emptyPlan({ transactions: [{ id: 't1' }] }), client);
+    // The insert happens; no second pass follows it.
+    expect(calls.filter(c => c.merge)).toHaveLength(0);
+  });
+
+  it('retries a transient failure and then succeeds', async () => {
+    const slept: number[] = [];
+    const { client, calls } = clientRecording([
+      { error: { message: 'fetch failed' }, status: 0 },   // the failure seen for real
+      { error: null, status: 201 },
+    ]);
+
+    await executeCloudPlan(
+      emptyPlan({ transactions: [{ id: 't1' }] }),
+      client,
+      { retry: { sleep: (ms: number) => { slept.push(ms); return Promise.resolve(); } } }
+    );
+
+    expect(calls).toHaveLength(2);        // failed once, retried once
+    expect(slept).toHaveLength(1);        // and backed off in between
+  });
+
+  it('does NOT retry a constraint violation — it fails immediately with the real message', async () => {
+    // Retrying a genuine data error just wastes the user's time and buries the
+    // message that explains what is actually wrong.
+    const slept: number[] = [];
+    const { client, calls } = clientRecording([
+      { error: { message: 'violates check constraint "transaction_splits_amount_nonzero"' }, status: 400 },
+    ]);
+
+    await expect(
+      executeCloudPlan(
+        emptyPlan({ transactions: [{ id: 't1' }] }),
+        client,
+        { retry: { sleep: (ms: number) => { slept.push(ms); return Promise.resolve(); } } }
+      )
+    ).rejects.toThrow(/transaction_splits_amount_nonzero/);
+
+    expect(calls).toHaveLength(1);        // one attempt only
+    expect(slept).toHaveLength(0);        // never backed off
+  });
+
+  it('classifies which statuses are worth retrying', () => {
+    for (const s of [0, 408, 425, 429, 500, 503]) expect(isRetryableWriteStatus(s)).toBe(true);
+    for (const s of [400, 401, 403, 404, 409, 422]) expect(isRetryableWriteStatus(s)).toBe(false);
+  });
+});
 
 describe('planCloudImport', () => {
   it('remaps every cross-reference onto fresh ids and stages links separately', () => {

--- a/src/services/import/msMoney/msMoneyImport.test.ts
+++ b/src/services/import/msMoney/msMoneyImport.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, beforeEach, vi } from 'vitest';
 import {
   planCloudImport, importToLocalStorage, wipeLocalData,
   MS_MONEY_IMPORT_SOURCE, IMPORT_PROVENANCE_CONFLICT,
+  type ExistingCategoryRow, type ExistingAccountRow,
 } from './msMoneyImport';
 import type { MsMoneyImportResult } from './transform';
 
@@ -15,7 +16,11 @@ function sampleResult(): MsMoneyImportResult {
       { id: 'mny-acct-4', name: 'Broker (Cash)', type: 'current', parentAccountId: 'mny-acct-3', balance: 25, openingBalance: 0, currency: 'GBP', isActive: true, lastUpdated: new Date('2020-01-01') },
     ],
     categories: [
+      // The transform always emits all three type roots as placeholders; they
+      // are what a real user holds as UUIDs (see transformCategories).
+      { id: 'type-income', name: 'Income', type: 'income', level: 'type', isSystem: true },
       { id: 'type-expense', name: 'Expense', type: 'expense', level: 'type', isSystem: true },
+      { id: 'type-transfer', name: 'Transfer', type: 'both', level: 'type', isSystem: true },
       { id: 'mny-cat-10', name: 'Food', type: 'expense', level: 'detail', parentId: 'type-expense' },
       { id: 'mny-tofrom-2', name: 'To/From Savings', type: 'both', level: 'detail', parentId: 'type-transfer', isTransferCategory: true, accountId: 'mny-acct-2' },
     ],
@@ -23,7 +28,8 @@ function sampleResult(): MsMoneyImportResult {
       { id: 'mny-txn-100', date: new Date('2020-02-01'), description: 'Shop', amount: -20, type: 'expense', category: 'mny-cat-10', accountId: 'mny-acct-1' },
       // transfer pair 200↔201
       { id: 'mny-txn-200', date: new Date('2020-02-02'), description: 'To savings', amount: -30, type: 'transfer', category: 'mny-tofrom-2', accountId: 'mny-acct-1', transferAccountId: 'mny-acct-2', linkedTransferId: 'mny-txn-201' },
-      { id: 'mny-txn-201', date: new Date('2020-02-02'), description: 'From current', amount: 30, type: 'transfer', accountId: 'mny-acct-2', transferAccountId: 'mny-acct-1', linkedTransferId: 'mny-txn-200' },
+      // …whose far leg is also pinned to the exact split line it answers.
+      { id: 'mny-txn-201', date: new Date('2020-02-02'), description: 'From current', amount: 30, type: 'transfer', accountId: 'mny-acct-2', transferAccountId: 'mny-acct-1', linkedTransferId: 'mny-txn-200', linkedTransferSplitId: 'mny-split-300-1' },
       // a split parent
       { id: 'mny-txn-300', date: new Date('2020-02-03'), description: 'Split', amount: -50, type: 'expense', category: '', accountId: 'mny-acct-1', isSplit: true },
     ] as MsMoneyImportResult['transactions'],
@@ -44,9 +50,10 @@ describe('planCloudImport', () => {
     let n = 0;
     const plan = planCloudImport(sampleResult(), 'user-abc', () => `new-${n++}`);
 
-    // System categories are NOT inserted (they exist per-user already).
-    expect(plan.categories).toHaveLength(2);
-    expect(plan.categories.some(c => c.name === 'Expense')).toBe(false);
+    // Nothing exists yet, so the whole tree — roots included — is created.
+    expect(plan.categories).toHaveLength(5);
+    expect(plan.categories.filter(c => c.is_system === true).map(c => c.name).sort())
+      .toEqual(['Expense', 'Income', 'Transfer']);
 
     // account 'current' maps to DB type 'checking'; closed stays is_active:false
     const current = plan.accounts.find(a => a.name === 'Current')!;
@@ -157,6 +164,180 @@ describe('planCloudImport — import provenance / idempotency', () => {
   });
 });
 
+describe('planCloudImport — category tree resolution', () => {
+  /** The three roots a real user holds, as `migrate_categories_atomic` writes them. */
+  const userRoots = (): ExistingCategoryRow[] => [
+    { id: 'db-root-income', name: 'Income', type: 'income', level: 'type', parent_id: null, is_system: true },
+    { id: 'db-root-expense', name: 'Expense', type: 'expense', level: 'type', parent_id: null, is_system: true },
+    { id: 'db-root-transfer', name: 'Transfer', type: 'both', level: 'type', parent_id: null, is_system: true },
+  ];
+
+  /** Every parent_id a plan emits must name a row that exists once it is written. */
+  const assertNoDanglingParents = (
+    plan: ReturnType<typeof planCloudImport>,
+    existing: readonly ExistingCategoryRow[] = []
+  ): void => {
+    const written = new Set<string>([
+      ...existing.map(r => r.id),
+      ...plan.categories.map(c => String(c.id)),
+    ]);
+    for (const c of plan.categories) {
+      if (c.parent_id != null) expect(written.has(String(c.parent_id))).toBe(true);
+    }
+  };
+
+  it('resolves a child of a system root onto the root the user ALREADY has', () => {
+    const existing = userRoots();
+    let n = 0;
+    const plan = planCloudImport(sampleResult(), 'user-abc', () => `new-${n++}`, {
+      existingCategories: existing,
+    });
+
+    // The roots are matched, not minted: only the two Money-derived rows go in.
+    expect(plan.categories).toHaveLength(2);
+    expect(plan.skippedExistingCategories).toBe(3);
+    const food = plan.categories.find(c => c.name === 'Food')!;
+    expect(food.parent_id).toBe('db-root-expense');
+    const toFrom = plan.categories.find(c => c.name === 'To/From Savings')!;
+    expect(toFrom.parent_id).toBe('db-root-transfer');
+    // …and never the seed's placeholder id, which is what used to leak through.
+    expect(plan.categories.map(c => c.parent_id)).not.toContain('type-expense');
+    assertNoDanglingParents(plan, existing);
+  });
+
+  it('CREATES the roots on a virgin database instead of assuming them', () => {
+    let n = 0;
+    const plan = planCloudImport(sampleResult(), 'user-abc', () => `new-${n++}`);
+
+    const roots = plan.categories.filter(c => c.level === 'type');
+    expect(roots.map(c => c.name).sort()).toEqual(['Expense', 'Income', 'Transfer']);
+    expect(roots.every(c => c.is_system === true && c.parent_id === null)).toBe(true);
+    expect(plan.skippedExistingCategories).toBe(0);
+    // Parents are emitted before their children — a batched insert cannot
+    // satisfy a forward foreign key across a batch boundary.
+    const positions = new Map(plan.categories.map((c, i) => [String(c.id), i]));
+    for (const [i, c] of plan.categories.entries()) {
+      if (c.parent_id != null) expect(positions.get(String(c.parent_id))!).toBeLessThan(i);
+    }
+    assertNoDanglingParents(plan);
+  });
+
+  it('matches a renamed root structurally, on its type', () => {
+    // Names no longer match anything, so the roots are identified structurally
+    // — the same fallback the database's own
+    // create_transfer_category_for_account uses.
+    const existing: ExistingCategoryRow[] = [
+      { id: 'db-root-income', name: 'Money In', type: 'income', level: 'type', parent_id: null, is_system: true },
+      { id: 'db-root-expense', name: 'Money Out', type: 'expense', level: 'type', parent_id: null, is_system: true },
+      { id: 'db-root-transfer', name: 'Moves', type: 'both', level: 'type', parent_id: null, is_system: true },
+    ];
+    let n = 0;
+    const plan = planCloudImport(sampleResult(), 'user-abc', () => `new-${n++}`, {
+      existingCategories: existing,
+    });
+
+    expect(plan.categories.filter(c => c.level === 'type')).toHaveLength(0);
+    expect(plan.categories.find(c => c.name === 'Food')!.parent_id).toBe('db-root-expense');
+    assertNoDanglingParents(plan, existing);
+  });
+
+  it('falls back to the name when no root carries the seed root\'s type', () => {
+    const existing: ExistingCategoryRow[] = [
+      // A legacy tree whose roots are all typed 'both' — only the name tells
+      // them apart.
+      { id: 'db-root-income', name: 'Income', type: 'both', level: 'type', parent_id: null, is_system: true },
+      { id: 'db-root-expense', name: 'Expense', type: 'both', level: 'type', parent_id: null, is_system: true },
+    ];
+    let n = 0;
+    const plan = planCloudImport(sampleResult(), 'user-abc', () => `new-${n++}`, {
+      existingCategories: existing,
+    });
+
+    expect(plan.categories.find(c => c.name === 'Food')!.parent_id).toBe('db-root-expense');
+    // The Transfer root has no counterpart at all, so it is created — and the
+    // To/From category hangs off the row that was actually written.
+    const transferRoot = plan.categories.find(c => c.name === 'Transfer' && c.level === 'type')!;
+    expect(transferRoot).toBeDefined();
+    expect(plan.categories.find(c => c.name === 'To/From Savings')!.parent_id).toBe(transferRoot.id);
+    assertNoDanglingParents(plan, existing);
+  });
+
+  it('nulls and COUNTS a parent it cannot resolve, rather than emitting a dangling id', () => {
+    const orphaned = sampleResult();
+    orphaned.categories = [
+      { id: 'mny-cat-99', name: 'Stranded', type: 'expense', level: 'detail', parentId: 'no-such-parent' },
+    ];
+    let n = 0;
+    const plan = planCloudImport(orphaned, 'user-abc', () => `new-${n++}`);
+
+    expect(plan.categoriesWithUnresolvedParent).toBe(1);
+    expect(plan.categories).toHaveLength(1);
+    expect(plan.categories[0].parent_id).toBeNull();
+    assertNoDanglingParents(plan);
+  });
+
+  it('re-running against the tree it just wrote plans nothing', () => {
+    // Snapshot of the database after a first import, as fetchExistingCategories
+    // would return it.
+    let n = 0;
+    const first = planCloudImport(sampleResult(), 'user-abc', () => `new-${n++}`);
+    const written: ExistingCategoryRow[] = first.categories.map(c => ({
+      id: String(c.id),
+      name: String(c.name),
+      type: String(c.type),
+      level: String(c.level),
+      parent_id: c.parent_id == null ? null : String(c.parent_id),
+      is_system: c.is_system === true,
+    }));
+    const writtenAccounts: ExistingAccountRow[] = first.accounts.map(a => ({
+      id: String(a.id), name: String(a.name),
+    }));
+
+    const second = planCloudImport(sampleResult(), 'user-abc', () => `new-${n++}`, {
+      existingCategories: written,
+      existingAccounts: writtenAccounts,
+      existingBySourceId: new Map(first.transactions.map(t => [String(t.import_source_id), String(t.id)])),
+    });
+
+    expect(second.categories).toHaveLength(0);
+    expect(second.accounts).toHaveLength(0);
+    expect(second.transactions).toHaveLength(0);
+    expect(second.splits).toHaveLength(0);
+    // Nothing may pin a leg to a split line this run does not write: split rows
+    // carry no provenance, so a re-minted id names a row that does not exist —
+    // and transactions.linked_transfer_split_id is a real foreign key.
+    expect(first.splitLegPins).toHaveLength(1);
+    expect(second.splitLegPins).toHaveLength(0);
+    const writtenSplitIds = new Set(second.splits.map(s => String(s.id)));
+    for (const pin of second.splitLegPins) {
+      expect(writtenSplitIds.has(pin.linked_transfer_split_id)).toBe(true);
+    }
+    expect(second.skippedExistingCategories).toBe(5);
+    expect(second.skippedExistingAccounts).toBe(4);
+    // Cross-references still resolve onto the rows already in the database.
+    expect(second.accountParents).toEqual(first.accountParents);
+    expect(second.transferLinks).toEqual(first.transferLinks);
+  });
+
+  it('claims each existing account by name at most once', () => {
+    // Two Money accounts share a name but the user holds only one such row:
+    // the first claims it, the second is inserted rather than merged away.
+    const twins = sampleResult();
+    twins.accounts = [
+      { ...twins.accounts[0] },
+      { ...twins.accounts[0], id: 'mny-acct-9' },
+    ];
+    let n = 0;
+    const plan = planCloudImport(twins, 'user-abc', () => `new-${n++}`, {
+      existingAccounts: [{ id: 'db-acct-1', name: 'current' }],
+    });
+
+    expect(plan.skippedExistingAccounts).toBe(1);
+    expect(plan.accounts).toHaveLength(1);
+    expect(plan.accounts[0].id).not.toBe('db-acct-1');
+  });
+});
+
 describe('planCloudImport — bank-feed overlap suppression', () => {
   it('drops the Money rows the feed already covers, and nothing else', () => {
     let n = 0;
@@ -206,7 +387,7 @@ describe('importToLocalStorage', () => {
 
     expect(JSON.parse(window.localStorage.getItem('a')!)).toHaveLength(4);
     expect(JSON.parse(window.localStorage.getItem('t')!)).toHaveLength(4);
-    expect(JSON.parse(window.localStorage.getItem('c')!)).toHaveLength(3);
+    expect(JSON.parse(window.localStorage.getItem('c')!)).toHaveLength(5);
     expect(JSON.parse(window.localStorage.getItem('s')!)).toHaveLength(1);
     // A total migration replaces — the other collections are emptied.
     expect(window.localStorage.getItem('b')).toBe('[]');

--- a/src/services/import/msMoney/msMoneyImport.test.ts
+++ b/src/services/import/msMoney/msMoneyImport.test.ts
@@ -1,5 +1,8 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
-import { planCloudImport, importToLocalStorage, wipeLocalData } from './msMoneyImport';
+import {
+  planCloudImport, importToLocalStorage, wipeLocalData,
+  MS_MONEY_IMPORT_SOURCE, IMPORT_PROVENANCE_CONFLICT,
+} from './msMoneyImport';
 import type { MsMoneyImportResult } from './transform';
 
 function sampleResult(): MsMoneyImportResult {
@@ -78,6 +81,109 @@ describe('planCloudImport', () => {
     expect(plan.splits).toHaveLength(1);
     expect(plan.splits[0].transaction_id).toBe(splitParent.id);
     expect(String(plan.splits[0].category).startsWith('new-')).toBe(true);
+  });
+});
+
+describe('planCloudImport — import provenance / idempotency', () => {
+  it('stamps every transaction with its stable source id', () => {
+    let n = 0;
+    const plan = planCloudImport(sampleResult(), 'user-abc', () => `new-${n++}`);
+
+    expect(plan.transactions).toHaveLength(4);
+    for (const t of plan.transactions) {
+      expect(t.import_source).toBe(MS_MONEY_IMPORT_SOURCE);
+      expect(String(t.import_source_id)).toMatch(/^mny-txn-\d+$/);
+    }
+    // The source ids are unique — they are what the unique index keys on, so a
+    // collision here would make the import unrunnable rather than idempotent.
+    const sourceIds = plan.transactions.map(t => String(t.import_source_id));
+    expect(new Set(sourceIds).size).toBe(sourceIds.length);
+    expect(plan.skippedExisting).toBe(0);
+
+    // The conflict target names exactly the unique index's columns.
+    expect(IMPORT_PROVENANCE_CONFLICT).toBe('user_id,import_source,import_source_id');
+  });
+
+  it('re-running against rows already imported inserts nothing and reuses their ids', () => {
+    // Everything the first run wrote, keyed by source id → the id it already has.
+    const existing = new Map([
+      ['mny-txn-100', 'db-100'],
+      ['mny-txn-200', 'db-200'],
+      ['mny-txn-201', 'db-201'],
+      ['mny-txn-300', 'db-300'],
+    ]);
+    let n = 0;
+    const plan = planCloudImport(sampleResult(), 'user-abc', () => `new-${n++}`, { existingBySourceId: existing });
+
+    // Nothing to insert — the second run is a no-op for transactions…
+    expect(plan.transactions).toHaveLength(0);
+    expect(plan.skippedExisting).toBe(4);
+    // …and for the split lines hanging off an already-imported parent.
+    expect(plan.splits).toHaveLength(0);
+
+    // Cross-references still resolve, but to the EXISTING row ids.
+    expect(plan.transferLinks).toEqual([
+      { id: 'db-200', linked_transfer_id: 'db-201' },
+      { id: 'db-201', linked_transfer_id: 'db-200' },
+    ]);
+  });
+
+  it('a partial re-run inserts only the rows that are missing', () => {
+    const existing = new Map([['mny-txn-100', 'db-100'], ['mny-txn-200', 'db-200']]);
+    let n = 0;
+    const plan = planCloudImport(sampleResult(), 'user-abc', () => `new-${n++}`, { existingBySourceId: existing });
+
+    expect(plan.transactions.map(t => t.import_source_id)).toEqual(['mny-txn-201', 'mny-txn-300']);
+    expect(plan.skippedExisting).toBe(2);
+    // The split parent is new, so its line is inserted and points at the new id.
+    expect(plan.splits).toHaveLength(1);
+    const splitParent = plan.transactions.find(t => t.import_source_id === 'mny-txn-300')!;
+    expect(plan.splits[0].transaction_id).toBe(splitParent.id);
+    // The surviving leg still links to the row that is already there.
+    expect(plan.transferLinks).toContainEqual({ id: 'db-200', linked_transfer_id: plan.transactions.find(t => t.import_source_id === 'mny-txn-201')!.id });
+  });
+
+  it('never writes the bank feed\'s provenance columns', () => {
+    let n = 0;
+    const plan = planCloudImport(sampleResult(), 'user-abc', () => `new-${n++}`);
+    // external_transaction_id / external_provider / connection_id belong to the
+    // bank feed; import_bank_transactions_atomic keys its dedupe AND its
+    // backfill-rebase decision off them.
+    for (const t of plan.transactions) {
+      expect('external_transaction_id' in t).toBe(false);
+      expect('external_provider' in t).toBe(false);
+      expect('connection_id' in t).toBe(false);
+    }
+  });
+});
+
+describe('planCloudImport — bank-feed overlap suppression', () => {
+  it('drops the Money rows the feed already covers, and nothing else', () => {
+    let n = 0;
+    const plan = planCloudImport(sampleResult(), 'user-abc', () => `new-${n++}`, {
+      suppressedSourceIds: new Set(['mny-txn-100']),
+    });
+
+    expect(plan.transactions.map(t => t.import_source_id)).toEqual([
+      'mny-txn-200', 'mny-txn-201', 'mny-txn-300',
+    ]);
+    expect(plan.skippedFeedOverlap).toBe(1);
+    expect(plan.skippedExisting).toBe(0);
+    // The transfer pair is untouched — suppression never strands a leg.
+    expect(plan.transferLinks).toHaveLength(2);
+    // The split parent survived, so its line still goes in.
+    expect(plan.splits).toHaveLength(1);
+  });
+
+  it('drops a suppressed split parent together with its lines', () => {
+    let n = 0;
+    const plan = planCloudImport(sampleResult(), 'user-abc', () => `new-${n++}`, {
+      suppressedSourceIds: new Set(['mny-txn-300']),
+    });
+    expect(plan.transactions.map(t => t.import_source_id)).not.toContain('mny-txn-300');
+    // No orphaned split line pointing at a row that was never written.
+    expect(plan.splits).toHaveLength(0);
+    expect(plan.skippedFeedOverlap).toBe(1);
   });
 });
 

--- a/src/services/import/msMoney/msMoneyImport.ts
+++ b/src/services/import/msMoney/msMoneyImport.ts
@@ -40,6 +40,24 @@ const chunk = <T>(arr: T[], size = BATCH): T[][] => {
   return out;
 };
 
+/**
+ * Import provenance (migration 20260722170000).
+ *
+ * Every transaction this importer writes carries `import_source` +
+ * `import_source_id` (the transform's stable `mny-txn-<htrn>`, taken straight
+ * from Money's own TRN primary key). A unique index on
+ * (user_id, import_source, import_source_id) means the DATABASE refuses a
+ * second copy, so re-running the import can never duplicate a row — the
+ * inserts below ask Postgres to skip conflicts rather than fail.
+ *
+ * This is deliberately NOT `external_transaction_id`: that column belongs to
+ * the bank feed, and `import_bank_transactions_atomic` keys both its dedupe
+ * and its backfill-rebase decision off it.
+ */
+export const MS_MONEY_IMPORT_SOURCE = 'ms-money';
+/** Conflict target matching `transactions_import_source_unique`. */
+export const IMPORT_PROVENANCE_CONFLICT = 'user_id,import_source,import_source_id';
+
 // ── LOCAL path ───────────────────────────────────────────────────────────────
 
 /**
@@ -73,7 +91,7 @@ const DB_ACCOUNT_TYPE = (t: Account['type']): string => (t === 'current' ? 'chec
 const dateOnly = (d: Date | string): string =>
   (d instanceof Date ? d.toISOString() : String(d)).slice(0, 10);
 
-interface CloudPlan {
+export interface CloudPlan {
   accounts: Record<string, unknown>[];       // inserted WITHOUT parent_account_id
   accountParents: { id: string; parent_account_id: string }[];
   categories: Record<string, unknown>[];
@@ -81,6 +99,25 @@ interface CloudPlan {
   transferLinks: { id: string; linked_transfer_id: string }[];
   splits: Record<string, unknown>[];
   splitLegPins: { id: string; linked_transfer_split_id: string }[];
+  /** Source rows already present under this user's provenance — not re-inserted. */
+  skippedExisting: number;
+  /** Source rows a bank-feed transaction already covers — not imported. */
+  skippedFeedOverlap: number;
+}
+
+export interface CloudPlanOptions {
+  /**
+   * Already-imported `import_source_id` → the id that row already has in the
+   * database. Anything named here keeps that id (so every cross-reference
+   * still resolves) and is left OUT of the insert batches — which is what
+   * makes a second run a no-op instead of a duplicate.
+   */
+  existingBySourceId?: ReadonlyMap<string, string>;
+  /**
+   * `import_source_id`s the bank feed already covers (see feedOverlap.ts).
+   * These are dropped entirely: the feed row is the surviving record.
+   */
+  suppressedSourceIds?: ReadonlySet<string>;
 }
 
 /**
@@ -90,13 +127,24 @@ interface CloudPlan {
 export function planCloudImport(
   result: MsMoneyImportResult,
   userId: string,
-  newId: () => string
+  newId: () => string,
+  options: CloudPlanOptions = {}
 ): CloudPlan {
+  const existingBySourceId = options.existingBySourceId ?? new Map<string, string>();
+  const suppressed = options.suppressedSourceIds ?? new Set<string>();
   const acctId = new Map(result.accounts.map(a => [a.id, newId()]));
   const catId = new Map(result.categories.map(c => [c.id, newId()]));
-  const txnId = new Map(result.transactions.map(t => [t.id, newId()]));
+  const txnId = new Map(
+    result.transactions
+      .filter(t => !suppressed.has(t.id))
+      .map(t => [t.id, existingBySourceId.get(t.id) ?? newId()])
+  );
   const splitId = new Map(result.transactionSplits.map(s => [s.id, newId()]));
   const cat = (id?: string): string | null => (id && catId.get(id)) || null;
+  // A transaction already in the database brings its split lines with it.
+  const alreadyImported = (sourceId: string): boolean => existingBySourceId.has(sourceId);
+  // Suppressed rows are never written, so nothing may reference them either.
+  const importable = (sourceId: string): boolean => !suppressed.has(sourceId);
 
   const accounts = result.accounts.map((a): Record<string, unknown> => ({
     id: acctId.get(a.id),
@@ -134,44 +182,85 @@ export function planCloudImport(
       is_active: c.isActive !== false,
     }));
 
-  const transactions = result.transactions.map((t): Record<string, unknown> => ({
-    id: txnId.get(t.id),
-    user_id: userId,
-    account_id: acctId.get(t.accountId),
-    description: t.description,
-    amount: t.amount,
-    type: t.type,
-    date: dateOnly(t.date),
-    category: t.isSplit ? '' : (cat(t.category) ?? ''),
-    notes: t.notes ?? null,
-    is_cleared: t.cleared === true,
-    is_split: t.isSplit === true,
-    transfer_account_id: t.transferAccountId ? acctId.get(t.transferAccountId) ?? null : null,
-    is_recurring: false,
-  }));
+  const transactions = result.transactions
+    .filter(t => importable(t.id) && !alreadyImported(t.id))
+    .map((t): Record<string, unknown> => ({
+      id: txnId.get(t.id),
+      user_id: userId,
+      account_id: acctId.get(t.accountId),
+      description: t.description,
+      amount: t.amount,
+      type: t.type,
+      date: dateOnly(t.date),
+      category: t.isSplit ? '' : (cat(t.category) ?? ''),
+      notes: t.notes ?? null,
+      is_cleared: t.cleared === true,
+      is_split: t.isSplit === true,
+      transfer_account_id: t.transferAccountId ? acctId.get(t.transferAccountId) ?? null : null,
+      is_recurring: false,
+      // Provenance: stable per-source id, so a re-import skips instead of
+      // duplicating (see MS_MONEY_IMPORT_SOURCE).
+      import_source: MS_MONEY_IMPORT_SOURCE,
+      import_source_id: t.id,
+    }));
 
   // Transfer pairs reference each other, so links go in as a second pass.
   const transferLinks = result.transactions
-    .filter(t => t.linkedTransferId && txnId.has(t.linkedTransferId))
+    .filter(t => txnId.has(t.id) && t.linkedTransferId && txnId.has(t.linkedTransferId))
     .map(t => ({ id: txnId.get(t.id)!, linked_transfer_id: txnId.get(t.linkedTransferId!)! }));
 
-  const splits = result.transactionSplits.map((s): Record<string, unknown> => ({
-    id: splitId.get(s.id),
-    transaction_id: txnId.get(s.transactionId),
-    user_id: userId,
-    category: cat(s.category) ?? '',
-    amount: s.amount,
-    memo: s.memo ?? null,
-    sort_order: s.sortOrder,
-    transfer_account_id: s.transferAccountId ? acctId.get(s.transferAccountId) ?? null : null,
-    linked_transfer_id: s.linkedTransferId ? txnId.get(s.linkedTransferId) ?? null : null,
-  }));
+  const splits = result.transactionSplits
+    .filter(s => importable(s.transactionId) && !alreadyImported(s.transactionId))
+    .map((s): Record<string, unknown> => ({
+      id: splitId.get(s.id),
+      transaction_id: txnId.get(s.transactionId),
+      user_id: userId,
+      category: cat(s.category) ?? '',
+      amount: s.amount,
+      memo: s.memo ?? null,
+      sort_order: s.sortOrder,
+      transfer_account_id: s.transferAccountId ? acctId.get(s.transferAccountId) ?? null : null,
+      linked_transfer_id: s.linkedTransferId ? txnId.get(s.linkedTransferId) ?? null : null,
+    }));
 
   const splitLegPins = result.transactions
-    .filter(t => t.linkedTransferSplitId && splitId.has(t.linkedTransferSplitId))
+    .filter(t => txnId.has(t.id) && t.linkedTransferSplitId && splitId.has(t.linkedTransferSplitId))
     .map(t => ({ id: txnId.get(t.id)!, linked_transfer_split_id: splitId.get(t.linkedTransferSplitId!)! }));
 
-  return { accounts, accountParents, categories, transactions, transferLinks, splits, splitLegPins };
+  const skippedFeedOverlap = result.transactions.filter(t => suppressed.has(t.id)).length;
+  const skippedExisting = result.transactions.length - transactions.length - skippedFeedOverlap;
+
+  return {
+    accounts, accountParents, categories, transactions, transferLinks, splits, splitLegPins,
+    skippedExisting, skippedFeedOverlap,
+  };
+}
+
+/**
+ * Every `import_source_id` this user already holds for a given importer →
+ * the transaction id it already has. Paged, because a full Money file is tens
+ * of thousands of rows and PostgREST caps a single response.
+ */
+export async function fetchImportedSourceIds(
+  supabase: SupabaseClient,
+  userId: string,
+  importSource: string = MS_MONEY_IMPORT_SOURCE
+): Promise<Map<string, string>> {
+  const PAGE = 1000;
+  const out = new Map<string, string>();
+  for (let from = 0; ; from += PAGE) {
+    const { data, error } = await supabase
+      .from('transactions')
+      .select('id, import_source_id')
+      .eq('user_id', userId)
+      .eq('import_source', importSource)
+      .order('id')
+      .range(from, from + PAGE - 1);
+    if (error) throw new Error(`Failed reading import provenance: ${error.message}`);
+    const rows = (data ?? []) as { id: string; import_source_id: string | null }[];
+    for (const r of rows) if (r.import_source_id) out.set(r.import_source_id, r.id);
+    if (rows.length < PAGE) return out;
+  }
 }
 
 /**
@@ -217,19 +306,56 @@ export async function importToCloud(
   opts: ImportOptions = {}
 ): Promise<void> {
   const { onProgress } = opts;
-  const plan = planCloudImport(result, userId, newId);
-  const fail = (stage: string, message: string): never => {
-    throw new Error(`Import failed while ${stage}: ${message}`);
-  };
 
   onProgress?.({ phase: 'wiping', fraction: 0.02, message: 'Backing out existing data…' });
   await wipeCloudData(supabase, userId);
 
-  const insert = async (table: string, rows: Record<string, unknown>[], phase: ImportPhase, base: number, span: number) => {
+  // Read provenance AFTER the wipe: whatever survived it (a partial failure, a
+  // narrower wipe) must not be inserted a second time. On a clean wipe this is
+  // empty and the plan is a full import.
+  //
+  // NOTE: this path is the TOTAL migration — `wipeCloudData` removes every
+  // transaction including bank-fed ones, so no feed rows survive for
+  // `findFeedOverlap` to reconcile against and `suppressedSourceIds` stays
+  // empty here. The scoped clear-and-reimport (scripts/mnyReimportPlan.mts)
+  // is the path that preserves feed rows, and it supplies the suppression set.
+  const existingBySourceId = await fetchImportedSourceIds(supabase, userId);
+  const plan = planCloudImport(result, userId, newId, { existingBySourceId });
+  await executeCloudPlan(plan, supabase, opts);
+}
+
+/**
+ * Write a planned import to Supabase. Separated from `importToCloud` so the
+ * idempotency harness (scripts/mnyIdempotencyCheck.mts) can run the REAL write
+ * path twice without the wipe in front of it — which is the only way to prove
+ * the second run inserts nothing.
+ *
+ * Safe to run over a database that already holds part of the plan: transactions
+ * go in with ON CONFLICT DO NOTHING against the provenance unique index, and a
+ * plan built with `existingBySourceId` will not offer them in the first place.
+ */
+export async function executeCloudPlan(
+  plan: CloudPlan,
+  supabase: SupabaseClient,
+  opts: ImportOptions = {}
+): Promise<void> {
+  const { onProgress } = opts;
+  const fail = (stage: string, message: string): never => {
+    throw new Error(`Import failed while ${stage}: ${message}`);
+  };
+
+  const insert = async (
+    table: string, rows: Record<string, unknown>[], phase: ImportPhase,
+    base: number, span: number, onConflict?: string
+  ) => {
     const batches = chunk(rows);
     let done = 0;
     for (const b of batches) {
-      const { error } = await supabase.from(table).insert(b);
+      // With a conflict target the write becomes ON CONFLICT DO NOTHING, so a
+      // row the database already holds is skipped rather than duplicated.
+      const { error } = onConflict
+        ? await supabase.from(table).upsert(b, { onConflict, ignoreDuplicates: true })
+        : await supabase.from(table).insert(b);
       if (error) fail(`inserting ${table}`, error.message);
       done += b.length;
       onProgress?.({ phase, fraction: base + span * (done / Math.max(rows.length, 1)),
@@ -246,7 +372,7 @@ export async function importToCloud(
   }
 
   await insert('categories', plan.categories, 'categories', 0.15, 0.1);
-  await insert('transactions', plan.transactions, 'transactions', 0.25, 0.45);
+  await insert('transactions', plan.transactions, 'transactions', 0.25, 0.45, IMPORT_PROVENANCE_CONFLICT);
 
   onProgress?.({ phase: 'links', fraction: 0.72, message: 'Linking transfers…' });
   for (const b of chunk(plan.transferLinks)) {

--- a/src/services/import/msMoney/msMoneyImport.ts
+++ b/src/services/import/msMoney/msMoneyImport.ts
@@ -16,7 +16,7 @@
  * as the reconstructed final values, so no per-row balance maths runs here.
  */
 import type { SupabaseClient } from '@supabase/supabase-js';
-import type { Account } from '../../../types';
+import type { Account, Category } from '../../../types';
 import type { MsMoneyImportResult } from './transform';
 
 export type ImportPhase =
@@ -94,7 +94,7 @@ const dateOnly = (d: Date | string): string =>
 export interface CloudPlan {
   accounts: Record<string, unknown>[];       // inserted WITHOUT parent_account_id
   accountParents: { id: string; parent_account_id: string }[];
-  categories: Record<string, unknown>[];
+  categories: Record<string, unknown>[];     // ordered parents-first
   transactions: Record<string, unknown>[];   // inserted WITHOUT linked_transfer_id
   transferLinks: { id: string; linked_transfer_id: string }[];
   splits: Record<string, unknown>[];
@@ -103,6 +103,32 @@ export interface CloudPlan {
   skippedExisting: number;
   /** Source rows a bank-feed transaction already covers — not imported. */
   skippedFeedOverlap: number;
+  /** Seed accounts matched onto an account the user already has — not re-inserted. */
+  skippedExistingAccounts: number;
+  /** Seed categories matched onto a category the user already has — not re-inserted. */
+  skippedExistingCategories: number;
+  /**
+   * Seed categories whose parent could not be resolved to a row that will
+   * exist after the import. They are written with `parent_id` NULL — never a
+   * dangling id — and counted here so the caller can report it.
+   */
+  categoriesWithUnresolvedParent: number;
+}
+
+/** The subset of an existing `categories` row the planner needs to match on. */
+export interface ExistingCategoryRow {
+  id: string;
+  name: string;
+  type: string;
+  level: string;
+  parent_id: string | null;
+  is_system: boolean | null;
+}
+
+/** The subset of an existing `accounts` row the planner needs to match on. */
+export interface ExistingAccountRow {
+  id: string;
+  name: string;
 }
 
 export interface CloudPlanOptions {
@@ -118,6 +144,45 @@ export interface CloudPlanOptions {
    * These are dropped entirely: the feed row is the surviving record.
    */
   suppressedSourceIds?: ReadonlySet<string>;
+  /**
+   * The user's current `categories` rows (see `fetchExistingCategories`).
+   * Seed categories are matched onto these instead of being duplicated —
+   * critically the type-level system roots, which the seed carries as the
+   * literal ids `type-income` / `type-expense` / `type-transfer` and the user
+   * holds as UUIDs. Omit (or pass empty) for a virgin database: every root is
+   * then CREATED rather than assumed.
+   */
+  existingCategories?: readonly ExistingCategoryRow[];
+  /**
+   * The user's current `accounts` rows (see `fetchExistingAccounts`). Seed
+   * accounts matching one by name reuse its id rather than inserting a second
+   * copy — accounts carry no provenance columns, so the name is the only
+   * stable identity available.
+   */
+  existingAccounts?: readonly ExistingAccountRow[];
+}
+
+/** Case/whitespace-insensitive key for name matching. */
+const normName = (name: string): string => name.trim().toLowerCase();
+
+/**
+ * Depth of a seed category within the seed's own tree, so the plan can emit
+ * parents before children (a batched insert cannot satisfy a forward FK across
+ * batch boundaries). Broken/cyclic parent chains stop the walk; the child then
+ * simply resolves later and is caught by the unresolved-parent path.
+ */
+function seedDepth(c: Category, bySeedId: ReadonlyMap<string, Category>): number {
+  const seen = new Set<string>([c.id]);
+  let depth = 0;
+  let cursor = c;
+  while (cursor.parentId) {
+    const parent = bySeedId.get(cursor.parentId);
+    if (!parent || seen.has(parent.id)) break;
+    seen.add(parent.id);
+    cursor = parent;
+    depth++;
+  }
+  return depth;
 }
 
 /**
@@ -132,8 +197,134 @@ export function planCloudImport(
 ): CloudPlan {
   const existingBySourceId = options.existingBySourceId ?? new Map<string, string>();
   const suppressed = options.suppressedSourceIds ?? new Set<string>();
-  const acctId = new Map(result.accounts.map(a => [a.id, newId()]));
-  const catId = new Map(result.categories.map(c => [c.id, newId()]));
+
+  // ── Accounts: reuse a row the user already has, else mint one ─────────────
+  // Accounts carry no provenance columns and the table has no natural unique
+  // key, so the name — claimed at most once — is the identity. On the total
+  // migration the wipe leaves nothing to claim and every account is inserted.
+  const unclaimedAccountsByName = new Map<string, string[]>();
+  for (const row of options.existingAccounts ?? []) {
+    const key = normName(row.name);
+    const bucket = unclaimedAccountsByName.get(key);
+    if (bucket) bucket.push(row.id); else unclaimedAccountsByName.set(key, [row.id]);
+  }
+  const acctId = new Map<string, string>();
+  const reusedAccountIds = new Set<string>();
+  for (const a of result.accounts) {
+    const claimed = unclaimedAccountsByName.get(normName(a.name))?.shift();
+    if (claimed) {
+      acctId.set(a.id, claimed);
+      reusedAccountIds.add(a.id);
+    } else {
+      acctId.set(a.id, newId());
+    }
+  }
+
+  const catId = new Map<string, string>();
+  const insertedCategories: Record<string, unknown>[] = [];
+  let categoriesWithUnresolvedParent = 0;
+  let reusedCategories = 0;
+  {
+    // ── Categories: resolve onto the user's own tree ────────────────────────
+    // The seed's type-level roots are placeholders (`type-income`, …) that the
+    // user holds as UUIDs, so they MUST be matched, not minted: a minted root
+    // is never inserted (system rows are the app's, not the importer's) and
+    // every child pointed at it would carry a dangling `parent_id`.
+    //
+    // Root signature: `is_system = true AND level = 'type'` — the two columns
+    // that make a row a root at all — plus the name and `type` (income /
+    // expense / both), which together identify WHICH root. Both are matched:
+    // name and type agreeing is the strongest signature, then the name alone
+    // (a legacy tree can mistype a root), then the type alone (a renamed root
+    // is still structurally itself — the same fallback the database uses in
+    // `create_transfer_category_for_account`, migration 20260708140000).
+    // There is exactly one root per type in both the app's default set and the
+    // Money seed. A user with NO matching root gets one CREATED — the roots
+    // are never assumed to exist.
+    //
+    // Everything below the roots is keyed on (parent_id, name) — the table's
+    // own `categories_user_id_name_parent_id_key`. Matching on the constraint
+    // the database enforces means a row that WOULD collide is reused instead,
+    // so a second import inserts nothing rather than failing.
+    const existingRowIds = new Set((options.existingCategories ?? []).map(r => r.id));
+    const byParentAndName = new Map<string, string>();
+    const childKey = (parentId: string | null, name: string): string =>
+      `${parentId ?? ''}\u0000${normName(name)}`;
+    for (const row of options.existingCategories ?? []) {
+      const key = childKey(row.parent_id, row.name);
+      if (!byParentAndName.has(key)) byParentAndName.set(key, row.id);
+    }
+
+    // Roots are assigned up front, strongest signature first, each existing
+    // root claimed by at most ONE seed root — so a degenerate tree (say, every
+    // root typed 'both') cannot collapse two seed roots onto the same row and
+    // re-file half the categories under the wrong parent.
+    const existingRoots = (options.existingCategories ?? [])
+      .filter(r => r.level === 'type' && r.is_system === true);
+    const claimedRoots = new Set<string>();
+    const rootMatch = new Map<string, string>();
+    const ROOT_SIGNATURES: ((seed: Category, row: ExistingCategoryRow) => boolean)[] = [
+      (s, r) => r.type === s.type && normName(r.name) === normName(s.name),
+      (s, r) => normName(r.name) === normName(s.name),
+      (s, r) => r.type === s.type,
+    ];
+    for (const matches of ROOT_SIGNATURES) {
+      for (const seedRoot of result.categories) {
+        if (seedRoot.level !== 'type' || rootMatch.has(seedRoot.id)) continue;
+        const row = existingRoots.find(r => !claimedRoots.has(r.id) && matches(seedRoot, r));
+        if (row) {
+          rootMatch.set(seedRoot.id, row.id);
+          claimedRoots.add(row.id);
+        }
+      }
+    }
+
+    const bySeedId = new Map(result.categories.map(c => [c.id, c]));
+    const ordered = result.categories
+      .map((c, index) => ({ c, index, depth: seedDepth(c, bySeedId) }))
+      .sort((a, b) => a.depth - b.depth || a.index - b.index);
+
+    for (const { c } of ordered) {
+      // Parent first: only an id that will genuinely exist after the import is
+      // allowed through. Anything else becomes NULL and is counted.
+      let parentId: string | null = null;
+      if (c.parentId) {
+        const resolved = catId.get(c.parentId);
+        if (resolved) parentId = resolved;
+        else categoriesWithUnresolvedParent++;
+      }
+
+      const isRoot = c.level === 'type';
+      const existingId = isRoot
+        ? rootMatch.get(c.id)
+        : byParentAndName.get(childKey(parentId, c.name));
+      if (existingId) {
+        catId.set(c.id, existingId);
+        if (existingRowIds.has(existingId)) reusedCategories++;
+        continue;
+      }
+
+      const id = newId();
+      catId.set(c.id, id);
+      insertedCategories.push({
+        id,
+        user_id: userId,
+        name: c.name,
+        type: c.type,
+        level: c.level,
+        parent_id: parentId,
+        is_system: c.isSystem === true,
+        is_transfer_category: c.isTransferCategory === true,
+        account_id: c.accountId ? acctId.get(c.accountId) ?? null : null,
+        is_active: c.isActive !== false,
+      });
+      // Register it so a later seed row with the same natural key resolves onto
+      // it instead of offering the database a duplicate it would reject.
+      const key = childKey(parentId, c.name);
+      if (!byParentAndName.has(key)) byParentAndName.set(key, id);
+    }
+  }
+
   const txnId = new Map(
     result.transactions
       .filter(t => !suppressed.has(t.id))
@@ -146,18 +337,20 @@ export function planCloudImport(
   // Suppressed rows are never written, so nothing may reference them either.
   const importable = (sourceId: string): boolean => !suppressed.has(sourceId);
 
-  const accounts = result.accounts.map((a): Record<string, unknown> => ({
-    id: acctId.get(a.id),
-    user_id: userId,
-    name: a.name,
-    type: DB_ACCOUNT_TYPE(a.type),
-    balance: a.balance,
-    initial_balance: a.openingBalance ?? 0,
-    opening_balance_date: a.openingBalanceDate ? dateOnly(a.openingBalanceDate) : null,
-    currency: a.currency || 'GBP',
-    is_active: a.isActive !== false,
-    notes: a.notes ?? null,
-  }));
+  const accounts = result.accounts
+    .filter(a => !reusedAccountIds.has(a.id))
+    .map((a): Record<string, unknown> => ({
+      id: acctId.get(a.id),
+      user_id: userId,
+      name: a.name,
+      type: DB_ACCOUNT_TYPE(a.type),
+      balance: a.balance,
+      initial_balance: a.openingBalance ?? 0,
+      opening_balance_date: a.openingBalanceDate ? dateOnly(a.openingBalanceDate) : null,
+      currency: a.currency || 'GBP',
+      is_active: a.isActive !== false,
+      notes: a.notes ?? null,
+    }));
 
   // Investment↔cash pairings reference other account rows, so they go in as a
   // second pass once every account exists (insert batching makes same-batch
@@ -165,22 +358,6 @@ export function planCloudImport(
   const accountParents = result.accounts
     .filter(a => a.parentAccountId && acctId.has(a.parentAccountId))
     .map(a => ({ id: acctId.get(a.id)!, parent_account_id: acctId.get(a.parentAccountId!)! }));
-
-  const categories = result.categories
-    // System categories (type/transfer roots) already exist per-user; only the
-    // Money-derived sub/detail + To/From rows are inserted.
-    .filter(c => c.isSystem !== true)
-    .map((c): Record<string, unknown> => ({
-      id: catId.get(c.id),
-      user_id: userId,
-      name: c.name,
-      type: c.type,
-      level: c.level,
-      parent_id: c.parentId && catId.has(c.parentId) ? catId.get(c.parentId) : c.parentId ?? null,
-      is_transfer_category: c.isTransferCategory === true,
-      account_id: c.accountId ? acctId.get(c.accountId) ?? null : null,
-      is_active: c.isActive !== false,
-    }));
 
   const transactions = result.transactions
     .filter(t => importable(t.id) && !alreadyImported(t.id))
@@ -209,8 +386,11 @@ export function planCloudImport(
     .filter(t => txnId.has(t.id) && t.linkedTransferId && txnId.has(t.linkedTransferId))
     .map(t => ({ id: txnId.get(t.id)!, linked_transfer_id: txnId.get(t.linkedTransferId!)! }));
 
-  const splits = result.transactionSplits
-    .filter(s => importable(s.transactionId) && !alreadyImported(s.transactionId))
+  const writtenSplits = result.transactionSplits
+    .filter(s => importable(s.transactionId) && !alreadyImported(s.transactionId));
+  const writtenSplitIds = new Set(writtenSplits.map(s => s.id));
+
+  const splits = writtenSplits
     .map((s): Record<string, unknown> => ({
       id: splitId.get(s.id),
       transaction_id: txnId.get(s.transactionId),
@@ -223,16 +403,25 @@ export function planCloudImport(
       linked_transfer_id: s.linkedTransferId ? txnId.get(s.linkedTransferId) ?? null : null,
     }));
 
+  // Only pin to a split line THIS plan writes. Split rows carry no provenance,
+  // so an already-imported parent's lines keep database ids the plan cannot
+  // know — minting a fresh one and pinning to it would write a reference to a
+  // row that does not exist (transactions.linked_transfer_split_id is a real
+  // foreign key). Those legs were pinned by the run that created them.
   const splitLegPins = result.transactions
-    .filter(t => txnId.has(t.id) && t.linkedTransferSplitId && splitId.has(t.linkedTransferSplitId))
+    .filter(t => txnId.has(t.id) && t.linkedTransferSplitId && writtenSplitIds.has(t.linkedTransferSplitId))
     .map(t => ({ id: txnId.get(t.id)!, linked_transfer_split_id: splitId.get(t.linkedTransferSplitId!)! }));
 
   const skippedFeedOverlap = result.transactions.filter(t => suppressed.has(t.id)).length;
   const skippedExisting = result.transactions.length - transactions.length - skippedFeedOverlap;
 
   return {
-    accounts, accountParents, categories, transactions, transferLinks, splits, splitLegPins,
+    accounts, accountParents, categories: insertedCategories, transactions, transferLinks,
+    splits, splitLegPins,
     skippedExisting, skippedFeedOverlap,
+    skippedExistingAccounts: reusedAccountIds.size,
+    skippedExistingCategories: reusedCategories,
+    categoriesWithUnresolvedParent,
   };
 }
 
@@ -261,6 +450,64 @@ export async function fetchImportedSourceIds(
     for (const r of rows) if (r.import_source_id) out.set(r.import_source_id, r.id);
     if (rows.length < PAGE) return out;
   }
+}
+
+/** Every category row this user holds, paged like the provenance read. */
+export async function fetchExistingCategories(
+  supabase: SupabaseClient,
+  userId: string
+): Promise<ExistingCategoryRow[]> {
+  const PAGE = 1000;
+  const out: ExistingCategoryRow[] = [];
+  for (let from = 0; ; from += PAGE) {
+    const { data, error } = await supabase
+      .from('categories')
+      .select('id, name, type, level, parent_id, is_system')
+      .eq('user_id', userId)
+      .order('id')
+      .range(from, from + PAGE - 1);
+    if (error) throw new Error(`Failed reading existing categories: ${error.message}`);
+    const rows = (data ?? []) as ExistingCategoryRow[];
+    out.push(...rows);
+    if (rows.length < PAGE) return out;
+  }
+}
+
+/** Every account row this user holds, paged like the provenance read. */
+export async function fetchExistingAccounts(
+  supabase: SupabaseClient,
+  userId: string
+): Promise<ExistingAccountRow[]> {
+  const PAGE = 1000;
+  const out: ExistingAccountRow[] = [];
+  for (let from = 0; ; from += PAGE) {
+    const { data, error } = await supabase
+      .from('accounts')
+      .select('id, name')
+      .eq('user_id', userId)
+      .order('id')
+      .range(from, from + PAGE - 1);
+    if (error) throw new Error(`Failed reading existing accounts: ${error.message}`);
+    const rows = (data ?? []) as ExistingAccountRow[];
+    out.push(...rows);
+    if (rows.length < PAGE) return out;
+  }
+}
+
+/**
+ * Everything `planCloudImport` needs to know about what the user ALREADY has:
+ * imported provenance, categories, accounts. Read in one place so every caller
+ * (the app's import, the idempotency harness) plans against the same picture.
+ */
+export async function fetchExistingImportState(
+  supabase: SupabaseClient,
+  userId: string
+): Promise<Required<Pick<CloudPlanOptions, 'existingBySourceId' | 'existingCategories' | 'existingAccounts'>>> {
+  return {
+    existingBySourceId: await fetchImportedSourceIds(supabase, userId),
+    existingCategories: await fetchExistingCategories(supabase, userId),
+    existingAccounts: await fetchExistingAccounts(supabase, userId),
+  };
 }
 
 /**
@@ -310,17 +557,19 @@ export async function importToCloud(
   onProgress?.({ phase: 'wiping', fraction: 0.02, message: 'Backing out existing data…' });
   await wipeCloudData(supabase, userId);
 
-  // Read provenance AFTER the wipe: whatever survived it (a partial failure, a
-  // narrower wipe) must not be inserted a second time. On a clean wipe this is
-  // empty and the plan is a full import.
+  // Read the existing state AFTER the wipe: whatever survived it (a partial
+  // failure, a narrower wipe) must not be inserted a second time, and the
+  // categories the user still holds are what the seed's placeholder roots have
+  // to resolve onto. On a clean wipe every collection here is empty, so the
+  // plan is a full import that CREATES its own roots.
   //
   // NOTE: this path is the TOTAL migration — `wipeCloudData` removes every
   // transaction including bank-fed ones, so no feed rows survive for
   // `findFeedOverlap` to reconcile against and `suppressedSourceIds` stays
   // empty here. The scoped clear-and-reimport (scripts/mnyReimportPlan.mts)
   // is the path that preserves feed rows, and it supplies the suppression set.
-  const existingBySourceId = await fetchImportedSourceIds(supabase, userId);
-  const plan = planCloudImport(result, userId, newId, { existingBySourceId });
+  const existing = await fetchExistingImportState(supabase, userId);
+  const plan = planCloudImport(result, userId, newId, existing);
   await executeCloudPlan(plan, supabase, opts);
 }
 

--- a/src/services/import/msMoney/msMoneyImport.ts
+++ b/src/services/import/msMoney/msMoneyImport.ts
@@ -31,10 +31,63 @@ export interface ImportProgress {
 
 export interface ImportOptions {
   onProgress?: (p: ImportProgress) => void;
+  /**
+   * Transient-failure policy for the cloud write path. A 50,000-row import over
+   * a domestic connection WILL meet a dropped socket sooner or later; the
+   * defaults below are what ships. Tests override them to run without timers.
+   */
+  retry?: {
+    /** Total attempts per write, first included. Default {@link WRITE_ATTEMPTS}. */
+    attempts?: number;
+    /** First backoff in ms; doubles each attempt. Default {@link RETRY_BASE_MS}. */
+    baseDelayMs?: number;
+    /** How the backoff waits. Defaults to a real timer. */
+    sleep?: (ms: number) => Promise<void>;
+  };
 }
 
-const BATCH = 500;
-const chunk = <T>(arr: T[], size = BATCH): T[][] => {
+/** Attempts per write, the first included: 1 try + 4 retries. */
+export const WRITE_ATTEMPTS = 5;
+/** First backoff, doubling each attempt: 0.5s, 1s, 2s, 4s — ~7.5s in total. */
+export const RETRY_BASE_MS = 500;
+
+/**
+ * Is this failure worth trying again?
+ *
+ * Only the network and the far end's own distress qualify: a dropped socket
+ * (supabase-js reports a failed fetch as status 0), a timeout, a rate limit, or
+ * a 5xx. Everything else — a unique violation, a null in a NOT NULL column, a
+ * failed CHECK — is a genuine data error that will fail identically forever, so
+ * retrying it only wastes the user's time and buries the real message.
+ */
+export function isRetryableWriteStatus(status: number): boolean {
+  return status === 0 || status === 408 || status === 425 || status === 429 || status >= 500;
+}
+
+/** The part of a PostgREST response the write path cares about. */
+export interface WriteOutcome {
+  error: { message: string } | null;
+  status: number;
+}
+
+/**
+ * The slice of the Supabase client `executeCloudPlan` actually uses. Narrow
+ * enough that a test can supply a real implementation of it — no cast, no
+ * mocking of a client that would then prove nothing about the batching.
+ */
+export interface CloudWriteClient {
+  from(table: string): {
+    insert(rows: Record<string, unknown>[]): PromiseLike<WriteOutcome>;
+    upsert(
+      rows: Record<string, unknown>[],
+      options: { onConflict: string; ignoreDuplicates: boolean }
+    ): PromiseLike<WriteOutcome>;
+  };
+}
+
+/** Rows per HTTP request on every batched write. */
+export const IMPORT_BATCH_SIZE = 500;
+const chunk = <T>(arr: T[], size = IMPORT_BATCH_SIZE): T[][] => {
   const out: T[][] = [];
   for (let i = 0; i < arr.length; i += size) out.push(arr.slice(i, i + size));
   return out;
@@ -99,6 +152,24 @@ export interface CloudPlan {
   transferLinks: { id: string; linked_transfer_id: string }[];
   splits: Record<string, unknown>[];
   splitLegPins: { id: string; linked_transfer_split_id: string }[];
+  /**
+   * The second pass, as rows the database can take in BATCHES.
+   *
+   * `transferLinks` / `splitLegPins` above say what the links ARE; these say
+   * how they are written. Each entry is a COMPLETE account/transaction row —
+   * every column the insert would have carried — plus the link columns, offered
+   * as an upsert that merges onto the row already there. Complete because it
+   * has to be: Postgres builds the candidate tuple, and therefore evaluates
+   * every NOT NULL column, BEFORE it resolves ON CONFLICT, so an
+   * id-plus-one-column payload is rejected outright.
+   *
+   * A row whose link is already exactly right in the database is left out
+   * entirely (see `existingAccounts` / `existingTransactionLinks`), so a second
+   * import writes nothing here rather than rewriting rows the user may since
+   * have edited.
+   */
+  accountParentRows: Record<string, unknown>[];
+  linkRows: Record<string, unknown>[];
   /** Source rows already present under this user's provenance — not re-inserted. */
   skippedExisting: number;
   /** Source rows a bank-feed transaction already covers — not imported. */
@@ -129,6 +200,14 @@ export interface ExistingCategoryRow {
 export interface ExistingAccountRow {
   id: string;
   name: string;
+  /** Current investment↔cash pairing, so an already-paired account is left alone. */
+  parent_account_id?: string | null;
+}
+
+/** The link columns an already-imported transaction currently carries. */
+export interface ExistingTransactionLinks {
+  linkedTransferId: string | null;
+  linkedTransferSplitId: string | null;
 }
 
 export interface CloudPlanOptions {
@@ -160,6 +239,18 @@ export interface CloudPlanOptions {
    * stable identity available.
    */
   existingAccounts?: readonly ExistingAccountRow[];
+  /**
+   * `import_source_id` → the link columns that row already holds. Purely an
+   * optimisation of the second pass: a transfer already linked exactly as the
+   * plan would link it is not rewritten. Omit it and every link is written,
+   * which is correct but does needless work — and, on a row the user has since
+   * edited, needless work that would overwrite the edit.
+   *
+   * It is also what makes a resumed import self-healing: a run that died after
+   * inserting transactions but before linking them leaves rows whose links do
+   * NOT match, so the next run picks up exactly those.
+   */
+  existingTransactionLinks?: ReadonlyMap<string, ExistingTransactionLinks>;
 }
 
 /** Case/whitespace-insensitive key for name matching. */
@@ -337,54 +428,67 @@ export function planCloudImport(
   // Suppressed rows are never written, so nothing may reference them either.
   const importable = (sourceId: string): boolean => !suppressed.has(sourceId);
 
+  // The full DB row for an account / a transaction, in ONE place: the insert
+  // and the linking pass must send byte-identical column sets, because the
+  // linking pass is an upsert of the whole row (see CloudPlan.linkRows).
+  const accountRow = (a: Account): Record<string, unknown> => ({
+    id: acctId.get(a.id),
+    user_id: userId,
+    name: a.name,
+    type: DB_ACCOUNT_TYPE(a.type),
+    balance: a.balance,
+    initial_balance: a.openingBalance ?? 0,
+    opening_balance_date: a.openingBalanceDate ? dateOnly(a.openingBalanceDate) : null,
+    currency: a.currency || 'GBP',
+    is_active: a.isActive !== false,
+    notes: a.notes ?? null,
+  });
+
+  const transactionRow = (t: MsMoneyImportResult['transactions'][number]): Record<string, unknown> => ({
+    id: txnId.get(t.id),
+    user_id: userId,
+    account_id: acctId.get(t.accountId),
+    description: t.description,
+    amount: t.amount,
+    type: t.type,
+    date: dateOnly(t.date),
+    category: t.isSplit ? '' : (cat(t.category) ?? ''),
+    notes: t.notes ?? null,
+    is_cleared: t.cleared === true,
+    is_split: t.isSplit === true,
+    transfer_account_id: t.transferAccountId ? acctId.get(t.transferAccountId) ?? null : null,
+    is_recurring: false,
+    // Provenance: stable per-source id, so a re-import skips instead of
+    // duplicating (see MS_MONEY_IMPORT_SOURCE).
+    import_source: MS_MONEY_IMPORT_SOURCE,
+    import_source_id: t.id,
+  });
+
   const accounts = result.accounts
     .filter(a => !reusedAccountIds.has(a.id))
-    .map((a): Record<string, unknown> => ({
-      id: acctId.get(a.id),
-      user_id: userId,
-      name: a.name,
-      type: DB_ACCOUNT_TYPE(a.type),
-      balance: a.balance,
-      initial_balance: a.openingBalance ?? 0,
-      opening_balance_date: a.openingBalanceDate ? dateOnly(a.openingBalanceDate) : null,
-      currency: a.currency || 'GBP',
-      is_active: a.isActive !== false,
-      notes: a.notes ?? null,
-    }));
+    .map(accountRow);
 
   // Investment↔cash pairings reference other account rows, so they go in as a
   // second pass once every account exists (insert batching makes same-batch
   // FK ordering unreliable).
-  const accountParents = result.accounts
-    .filter(a => a.parentAccountId && acctId.has(a.parentAccountId))
-    .map(a => ({ id: acctId.get(a.id)!, parent_account_id: acctId.get(a.parentAccountId!)! }));
+  const existingParentById = new Map(
+    (options.existingAccounts ?? []).map(r => [r.id, r.parent_account_id ?? null])
+  );
+  const accountParents: { id: string; parent_account_id: string }[] = [];
+  const accountParentRows: Record<string, unknown>[] = [];
+  for (const a of result.accounts) {
+    if (!a.parentAccountId || !acctId.has(a.parentAccountId)) continue;
+    const id = acctId.get(a.id)!;
+    const parentAccountId = acctId.get(a.parentAccountId)!;
+    accountParents.push({ id, parent_account_id: parentAccountId });
+    // Already paired exactly this way — leave the row alone.
+    if (existingParentById.get(id) === parentAccountId) continue;
+    accountParentRows.push({ ...accountRow(a), parent_account_id: parentAccountId });
+  }
 
   const transactions = result.transactions
     .filter(t => importable(t.id) && !alreadyImported(t.id))
-    .map((t): Record<string, unknown> => ({
-      id: txnId.get(t.id),
-      user_id: userId,
-      account_id: acctId.get(t.accountId),
-      description: t.description,
-      amount: t.amount,
-      type: t.type,
-      date: dateOnly(t.date),
-      category: t.isSplit ? '' : (cat(t.category) ?? ''),
-      notes: t.notes ?? null,
-      is_cleared: t.cleared === true,
-      is_split: t.isSplit === true,
-      transfer_account_id: t.transferAccountId ? acctId.get(t.transferAccountId) ?? null : null,
-      is_recurring: false,
-      // Provenance: stable per-source id, so a re-import skips instead of
-      // duplicating (see MS_MONEY_IMPORT_SOURCE).
-      import_source: MS_MONEY_IMPORT_SOURCE,
-      import_source_id: t.id,
-    }));
-
-  // Transfer pairs reference each other, so links go in as a second pass.
-  const transferLinks = result.transactions
-    .filter(t => txnId.has(t.id) && t.linkedTransferId && txnId.has(t.linkedTransferId))
-    .map(t => ({ id: txnId.get(t.id)!, linked_transfer_id: txnId.get(t.linkedTransferId!)! }));
+    .map(transactionRow);
 
   const writtenSplits = result.transactionSplits
     .filter(s => importable(s.transactionId) && !alreadyImported(s.transactionId));
@@ -403,21 +507,45 @@ export function planCloudImport(
       linked_transfer_id: s.linkedTransferId ? txnId.get(s.linkedTransferId) ?? null : null,
     }));
 
-  // Only pin to a split line THIS plan writes. Split rows carry no provenance,
-  // so an already-imported parent's lines keep database ids the plan cannot
-  // know — minting a fresh one and pinning to it would write a reference to a
-  // row that does not exist (transactions.linked_transfer_split_id is a real
-  // foreign key). Those legs were pinned by the run that created them.
-  const splitLegPins = result.transactions
-    .filter(t => txnId.has(t.id) && t.linkedTransferSplitId && writtenSplitIds.has(t.linkedTransferSplitId))
-    .map(t => ({ id: txnId.get(t.id)!, linked_transfer_split_id: splitId.get(t.linkedTransferSplitId!)! }));
+  // ── The second pass: transfer links and split-leg pins ────────────────────
+  // Transfer pairs reference each other, so neither side can carry its link at
+  // insert time. Split legs pin to a split LINE, which is written later still.
+  //
+  // A pin only ever points at a split line THIS plan writes. Split rows carry
+  // no provenance, so an already-imported parent's lines keep database ids the
+  // plan cannot know — minting a fresh one and pinning to it would write a
+  // reference to a row that does not exist (transactions.linked_transfer_split_id
+  // is a real foreign key). Those legs were pinned by the run that created them.
+  const currentLinks = options.existingTransactionLinks;
+  const transferLinks: { id: string; linked_transfer_id: string }[] = [];
+  const splitLegPins: { id: string; linked_transfer_split_id: string }[] = [];
+  const linkRows: Record<string, unknown>[] = [];
+  for (const t of result.transactions) {
+    const id = txnId.get(t.id);
+    if (!id) continue;
+    const linkedTransferId = t.linkedTransferId && txnId.has(t.linkedTransferId)
+      ? txnId.get(t.linkedTransferId)! : null;
+    const linkedTransferSplitId = t.linkedTransferSplitId && writtenSplitIds.has(t.linkedTransferSplitId)
+      ? splitId.get(t.linkedTransferSplitId)! : null;
+    if (!linkedTransferId && !linkedTransferSplitId) continue;
+
+    if (linkedTransferId) transferLinks.push({ id, linked_transfer_id: linkedTransferId });
+    if (linkedTransferSplitId) splitLegPins.push({ id, linked_transfer_split_id: linkedTransferSplitId });
+
+    const current = currentLinks?.get(t.id);
+    if (current
+      && current.linkedTransferId === linkedTransferId
+      && current.linkedTransferSplitId === linkedTransferSplitId) continue;
+    linkRows.push({ ...transactionRow(t), linked_transfer_id: linkedTransferId, linked_transfer_split_id: linkedTransferSplitId });
+  }
 
   const skippedFeedOverlap = result.transactions.filter(t => suppressed.has(t.id)).length;
   const skippedExisting = result.transactions.length - transactions.length - skippedFeedOverlap;
 
   return {
-    accounts, accountParents, categories: insertedCategories, transactions, transferLinks,
-    splits, splitLegPins,
+    accounts, accountParents, accountParentRows,
+    categories: insertedCategories, transactions, transferLinks,
+    splits, splitLegPins, linkRows,
     skippedExisting, skippedFeedOverlap,
     skippedExistingAccounts: reusedAccountIds.size,
     skippedExistingCategories: reusedCategories,
@@ -425,29 +553,48 @@ export function planCloudImport(
   };
 }
 
+/** An already-imported row, keyed in the map below by its `import_source_id`. */
+export interface ImportedTransactionRow extends ExistingTransactionLinks {
+  id: string;
+}
+
 /**
- * Every `import_source_id` this user already holds for a given importer →
- * the transaction id it already has. Paged, because a full Money file is tens
- * of thousands of rows and PostgREST caps a single response.
+ * Every `import_source_id` this user already holds for a given importer → the
+ * transaction id it already has, and the transfer links it already carries.
+ * Paged, because a full Money file is tens of thousands of rows and PostgREST
+ * caps a single response.
+ *
+ * The links come along on the same read precisely because it is free: the plan
+ * uses them to leave already-linked rows out of the second pass entirely.
  */
-export async function fetchImportedSourceIds(
+export async function fetchImportedTransactions(
   supabase: SupabaseClient,
   userId: string,
   importSource: string = MS_MONEY_IMPORT_SOURCE
-): Promise<Map<string, string>> {
+): Promise<Map<string, ImportedTransactionRow>> {
   const PAGE = 1000;
-  const out = new Map<string, string>();
+  const out = new Map<string, ImportedTransactionRow>();
   for (let from = 0; ; from += PAGE) {
     const { data, error } = await supabase
       .from('transactions')
-      .select('id, import_source_id')
+      .select('id, import_source_id, linked_transfer_id, linked_transfer_split_id')
       .eq('user_id', userId)
       .eq('import_source', importSource)
       .order('id')
       .range(from, from + PAGE - 1);
     if (error) throw new Error(`Failed reading import provenance: ${error.message}`);
-    const rows = (data ?? []) as { id: string; import_source_id: string | null }[];
-    for (const r of rows) if (r.import_source_id) out.set(r.import_source_id, r.id);
+    const rows = (data ?? []) as {
+      id: string; import_source_id: string | null;
+      linked_transfer_id: string | null; linked_transfer_split_id: string | null;
+    }[];
+    for (const r of rows) {
+      if (!r.import_source_id) continue;
+      out.set(r.import_source_id, {
+        id: r.id,
+        linkedTransferId: r.linked_transfer_id ?? null,
+        linkedTransferSplitId: r.linked_transfer_split_id ?? null,
+      });
+    }
     if (rows.length < PAGE) return out;
   }
 }
@@ -483,7 +630,7 @@ export async function fetchExistingAccounts(
   for (let from = 0; ; from += PAGE) {
     const { data, error } = await supabase
       .from('accounts')
-      .select('id, name')
+      .select('id, name, parent_account_id')
       .eq('user_id', userId)
       .order('id')
       .range(from, from + PAGE - 1);
@@ -502,9 +649,12 @@ export async function fetchExistingAccounts(
 export async function fetchExistingImportState(
   supabase: SupabaseClient,
   userId: string
-): Promise<Required<Pick<CloudPlanOptions, 'existingBySourceId' | 'existingCategories' | 'existingAccounts'>>> {
+): Promise<Required<Pick<CloudPlanOptions,
+  'existingBySourceId' | 'existingCategories' | 'existingAccounts' | 'existingTransactionLinks'>>> {
+  const imported = await fetchImportedTransactions(supabase, userId);
   return {
-    existingBySourceId: await fetchImportedSourceIds(supabase, userId),
+    existingBySourceId: new Map([...imported].map(([sourceId, row]) => [sourceId, row.id])),
+    existingTransactionLinks: imported,
     existingCategories: await fetchExistingCategories(supabase, userId),
     existingAccounts: await fetchExistingAccounts(supabase, userId),
   };
@@ -585,12 +735,41 @@ export async function importToCloud(
  */
 export async function executeCloudPlan(
   plan: CloudPlan,
-  supabase: SupabaseClient,
+  supabase: CloudWriteClient,
   opts: ImportOptions = {}
 ): Promise<void> {
   const { onProgress } = opts;
+  const attempts = Math.max(1, opts.retry?.attempts ?? WRITE_ATTEMPTS);
+  const baseDelayMs = opts.retry?.baseDelayMs ?? RETRY_BASE_MS;
+  const wait = opts.retry?.sleep ?? ((ms: number) => new Promise<void>(resolve => { setTimeout(resolve, ms); }));
   const fail = (stage: string, message: string): never => {
     throw new Error(`Import failed while ${stage}: ${message}`);
+  };
+
+  /**
+   * One write, retried through a transient failure and only a transient one.
+   * A dropped connection mid-import used to leave the migration half-finished
+   * with no way back; a constraint violation still fails on the spot, with the
+   * database's own message, because trying it again could only fail again.
+   */
+  const write = async (stage: string, run: () => PromiseLike<WriteOutcome>): Promise<void> => {
+    for (let attempt = 1; ; attempt++) {
+      let outcome: WriteOutcome;
+      try {
+        outcome = await run();
+      } catch (thrown) {
+        // A transport that rejects rather than resolving (a custom fetch, an
+        // aborted socket) — indistinguishable from a network drop, so treated
+        // as one.
+        outcome = { error: { message: thrown instanceof Error ? thrown.message : String(thrown) }, status: 0 };
+      }
+      if (!outcome.error) return;
+      if (!isRetryableWriteStatus(outcome.status)) fail(stage, outcome.error.message);
+      if (attempt >= attempts) {
+        fail(stage, `${outcome.error.message} (gave up after ${attempt} attempts)`);
+      }
+      await wait(baseDelayMs * 2 ** (attempt - 1));
+    }
   };
 
   const insert = async (
@@ -602,44 +781,55 @@ export async function executeCloudPlan(
     for (const b of batches) {
       // With a conflict target the write becomes ON CONFLICT DO NOTHING, so a
       // row the database already holds is skipped rather than duplicated.
-      const { error } = onConflict
-        ? await supabase.from(table).upsert(b, { onConflict, ignoreDuplicates: true })
-        : await supabase.from(table).insert(b);
-      if (error) fail(`inserting ${table}`, error.message);
+      await write(`inserting ${table}`, () => onConflict
+        ? supabase.from(table).upsert(b, { onConflict, ignoreDuplicates: true })
+        : supabase.from(table).insert(b));
       done += b.length;
       onProgress?.({ phase, fraction: base + span * (done / Math.max(rows.length, 1)),
         message: `Importing ${table.replace('_', ' ')}… ${done}/${rows.length}` });
     }
   };
 
-  await insert('accounts', plan.accounts, 'accounts', 0.05, 0.1);
+  /**
+   * The second pass, in BATCHES. `ignoreDuplicates: false` makes the conflict
+   * clause DO UPDATE, so the row already there is updated rather than skipped —
+   * the whole point, since these rows exist by now. Complete rows, because
+   * Postgres evaluates NOT NULL while building the candidate tuple, before it
+   * ever looks at ON CONFLICT: an id-plus-link payload is rejected outright.
+   *
+   * This replaces one HTTP request per link — 11,218 of them on a real Money
+   * file, which is how a home connection came to drop the import halfway.
+   */
+  const merge = async (
+    table: string, rows: Record<string, unknown>[], onConflict: string,
+    stage: string, phase: ImportPhase, base: number, span: number, label: string
+  ) => {
+    if (rows.length === 0) return;
+    onProgress?.({ phase, fraction: base, message: `${label}…` });
+    let done = 0;
+    for (const b of chunk(rows)) {
+      await write(stage, () => supabase.from(table).upsert(b, { onConflict, ignoreDuplicates: false }));
+      done += b.length;
+      onProgress?.({ phase, fraction: base + span * (done / rows.length),
+        message: `${label}… ${done}/${rows.length}` });
+    }
+  };
 
-  for (const p of plan.accountParents) {
-    const { error } = await supabase.from('accounts')
-      .update({ parent_account_id: p.parent_account_id }).eq('id', p.id);
-    if (error) fail('pairing investment cash accounts', error.message);
-  }
+  await insert('accounts', plan.accounts, 'accounts', 0.05, 0.08);
+  // Accounts carry no provenance columns, so the primary key is the only
+  // conflict target available — and every one of these rows was just written.
+  await merge('accounts', plan.accountParentRows, 'id',
+    'pairing investment cash accounts', 'accounts', 0.13, 0.02, 'Pairing investment cash accounts');
 
   await insert('categories', plan.categories, 'categories', 0.15, 0.1);
-  await insert('transactions', plan.transactions, 'transactions', 0.25, 0.45, IMPORT_PROVENANCE_CONFLICT);
+  await insert('transactions', plan.transactions, 'transactions', 0.25, 0.37, IMPORT_PROVENANCE_CONFLICT);
 
-  onProgress?.({ phase: 'links', fraction: 0.72, message: 'Linking transfers…' });
-  for (const b of chunk(plan.transferLinks)) {
-    for (const l of b) {
-      const { error } = await supabase.from('transactions')
-        .update({ linked_transfer_id: l.linked_transfer_id }).eq('id', l.id);
-      if (error) fail('linking transfers', error.message);
-    }
-  }
+  // Splits BEFORE links: a split-leg pin is a foreign key into
+  // transaction_splits, so the line it names has to exist first.
+  await insert('transaction_splits', plan.splits, 'splits', 0.62, 0.16);
 
-  await insert('transaction_splits', plan.splits, 'splits', 0.8, 0.12);
-
-  onProgress?.({ phase: 'splits', fraction: 0.95, message: 'Linking split transfers…' });
-  for (const p of plan.splitLegPins) {
-    const { error } = await supabase.from('transactions')
-      .update({ linked_transfer_split_id: p.linked_transfer_split_id }).eq('id', p.id);
-    if (error) fail('pinning split legs', error.message);
-  }
+  await merge('transactions', plan.linkRows, IMPORT_PROVENANCE_CONFLICT,
+    'linking transfers', 'links', 0.78, 0.2, 'Linking transfers');
 
   onProgress?.({ phase: 'done', fraction: 1, message: 'Import complete.' });
 }

--- a/src/services/import/msMoney/msMoneyImport.ts
+++ b/src/services/import/msMoney/msMoneyImport.ts
@@ -17,6 +17,8 @@
  */
 import type { SupabaseClient } from '@supabase/supabase-js';
 import type { Account, Category } from '../../../types';
+import { toDecimal } from '../../../utils/decimal';
+import type { TransferHandover } from './feedOverlap';
 import type { MsMoneyImportResult } from './transform';
 
 export type ImportPhase =
@@ -170,6 +172,35 @@ export interface CloudPlan {
    */
   accountParentRows: Record<string, unknown>[];
   linkRows: Record<string, unknown>[];
+  /**
+   * Bank-feed rows taking over a suppressed Money transfer leg — what the
+   * promotion IS, in database ids, for reporting and for tests.
+   */
+  feedPromotions: FeedTransferPromotion[];
+  /**
+   * The same promotions as COMPLETE rows for the batched merge — the feed row
+   * exactly as it is in the database, with only the transfer columns changed.
+   * A row whose transfer columns are already right is left out, so a second run
+   * writes nothing.
+   */
+  feedPromotionRows: Record<string, unknown>[];
+  /**
+   * Handovers that could NOT be executed — no complete feed row was supplied
+   * for them. Their Money leg is imported as normal rather than dropped (a
+   * suppressed leg with nothing taking its place would delete a real transfer),
+   * so the plan stays safe; the caller is expected to treat any entry here as a
+   * failure, because the count it reviewed will no longer match.
+   */
+  unpromotableHandovers: TransferHandover[];
+  /**
+   * Reused accounts whose stored `initial_balance` disagrees with the file's.
+   * ALWAYS reported, never silently corrected: a reused account may have been
+   * hand-edited, and the file is only authoritative if the operator says so
+   * (`rebaseOpeningBalances`).
+   */
+  openingBalanceMismatches: OpeningBalanceMismatch[];
+  /** Complete rows for the mismatches above, when a rebase was asked for. */
+  accountOpeningBalanceRows: Record<string, unknown>[];
   /** Source rows already present under this user's provenance — not re-inserted. */
   skippedExisting: number;
   /** Source rows a bank-feed transaction already covers — not imported. */
@@ -184,6 +215,32 @@ export interface CloudPlan {
    * dangling id — and counted here so the caller can report it.
    */
   categoriesWithUnresolvedParent: number;
+}
+
+/** A bank-feed row inheriting a suppressed Money transfer leg, in database ids. */
+export interface FeedTransferPromotion {
+  /** The feed row being promoted. */
+  id: string;
+  /** The Money leg it replaces (`mny-txn-…`) — reporting only. */
+  importSourceId: string;
+  /** The account on the other side of the transfer. */
+  transfer_account_id: string | null;
+  /** The other leg. Null when the Money leg had no linked counterpart. */
+  linked_transfer_id: string | null;
+  /** The split LINE the other side is, when the counterpart is a split leg. */
+  linked_transfer_split_id: string | null;
+}
+
+/** A reused account whose stored opening balance is not the file's. */
+export interface OpeningBalanceMismatch {
+  /** Database id of the account (the reused row). */
+  accountId: string;
+  accountName: string;
+  /** Both as fixed-2 strings, formatted through Decimal — never a float. */
+  fileValue: string;
+  storedValue: string;
+  /** True when this plan will correct it (see `rebaseOpeningBalances`). */
+  rebased: boolean;
 }
 
 /** The subset of an existing `categories` row the planner needs to match on. */
@@ -202,6 +259,13 @@ export interface ExistingAccountRow {
   name: string;
   /** Current investment↔cash pairing, so an already-paired account is left alone. */
   parent_account_id?: string | null;
+  /**
+   * Current opening balance. Supplied ⇒ the plan reports every reused account
+   * whose opening balance disagrees with the file's (and, on request, corrects
+   * it). Omitted ⇒ no opinion is formed, which is what every caller that has
+   * wiped the database first wants.
+   */
+  initial_balance?: string | number | null;
 }
 
 /** The link columns an already-imported transaction currently carries. */
@@ -251,6 +315,42 @@ export interface CloudPlanOptions {
    * NOT match, so the next run picks up exactly those.
    */
   existingTransactionLinks?: ReadonlyMap<string, ExistingTransactionLinks>;
+  /**
+   * Suppressed TRANSFER legs and the feed rows that inherit their place
+   * (see feedOverlap.ts). Every entry must also appear in
+   * `suppressedSourceIds` — a handover is a suppression with a successor.
+   *
+   * Supplying these is what stops a suppressed leg from silently unlinking its
+   * counterpart: the feed row is promoted into the transfer and every reference
+   * to the leg is re-pointed at it.
+   */
+  transferHandovers?: readonly TransferHandover[];
+  /**
+   * COMPLETE database rows for the bank-feed transactions named by
+   * `transferHandovers`, keyed by id (`select *`).
+   *
+   * Complete because the promotion goes out through the same batched merge as
+   * the link pass, and that merge sends whole rows: Postgres builds the
+   * candidate tuple — evaluating every NOT NULL column — before it resolves ON
+   * CONFLICT. Rows the plan does not need are ignored; a handover with no row
+   * here is refused rather than guessed at (see `unpromotableHandovers`).
+   */
+  feedTransactionRowsById?: ReadonlyMap<string, Readonly<Record<string, unknown>>>;
+  /**
+   * COMPLETE database rows for the user's accounts, keyed by id — required only
+   * to REBASE an opening balance, and for the same reason as above.
+   */
+  existingAccountRowsById?: ReadonlyMap<string, Readonly<Record<string, unknown>>>;
+  /**
+   * Correct a reused account's `initial_balance` to the file's value.
+   *
+   * OPT-IN, always. A reused account is one the importer did not create, so its
+   * opening balance may be the user's own considered figure; overwriting that
+   * silently on every re-import would be indefensible. Off, the disagreement is
+   * still REPORTED (`openingBalanceMismatches`) — which is what stops a
+   * re-import claiming success while a fabricated opening balance survives it.
+   */
+  rebaseOpeningBalances?: boolean;
 }
 
 /** Case/whitespace-insensitive key for name matching. */
@@ -287,7 +387,27 @@ export function planCloudImport(
   options: CloudPlanOptions = {}
 ): CloudPlan {
   const existingBySourceId = options.existingBySourceId ?? new Map<string, string>();
-  const suppressed = options.suppressedSourceIds ?? new Set<string>();
+  const requestedSuppression = options.suppressedSourceIds ?? new Set<string>();
+
+  // ── Transfer handovers: a suppression only counts if a successor exists ────
+  // A handover names the feed row that inherits the leg. Without the complete
+  // feed row the promotion cannot be written, and dropping the leg anyway would
+  // delete a real transfer and quietly unlink its counterpart — so that leg is
+  // NOT suppressed at all. It comes back as an ordinary import, and the caller
+  // learns about it through `unpromotableHandovers`.
+  const feedRowsById = options.feedTransactionRowsById ?? new Map<string, Readonly<Record<string, unknown>>>();
+  const handovers = options.transferHandovers ?? [];
+  const unpromotableHandovers: TransferHandover[] = [];
+  const handoverBySourceId = new Map<string, TransferHandover>();
+  for (const h of handovers) {
+    if (!requestedSuppression.has(h.importSourceId)) continue; // not a suppression: nothing to hand over
+    if (!feedRowsById.has(h.feedTransactionId)) { unpromotableHandovers.push(h); continue; }
+    handoverBySourceId.set(h.importSourceId, h);
+  }
+  const refused = new Set(unpromotableHandovers.map(h => h.importSourceId));
+  const suppressed: ReadonlySet<string> = refused.size === 0
+    ? requestedSuppression
+    : new Set([...requestedSuppression].filter(id => !refused.has(id)));
 
   // ── Accounts: reuse a row the user already has, else mint one ─────────────
   // Accounts carry no provenance columns and the table has no natural unique
@@ -423,6 +543,15 @@ export function planCloudImport(
   );
   const splitId = new Map(result.transactionSplits.map(s => [s.id, newId()]));
   const cat = (id?: string): string | null => (id && catId.get(id)) || null;
+  /**
+   * The database id a seed transaction id refers to AFTER the import.
+   *
+   * Normally the row's own id. For a handed-over transfer leg the row is never
+   * written, and the answer is the FEED row that took its place — which is what
+   * keeps the counterpart linked to something real instead of being unlinked.
+   */
+  const linkTarget = (sourceId: string): string | null =>
+    txnId.get(sourceId) ?? handoverBySourceId.get(sourceId)?.feedTransactionId ?? null;
   // A transaction already in the database brings its split lines with it.
   const alreadyImported = (sourceId: string): boolean => existingBySourceId.has(sourceId);
   // Suppressed rows are never written, so nothing may reference them either.
@@ -468,6 +597,43 @@ export function planCloudImport(
     .filter(a => !reusedAccountIds.has(a.id))
     .map(accountRow);
 
+  // ── Opening balances on REUSED accounts ───────────────────────────────────
+  // A reused account is filtered out of the insert above, so `initial_balance`
+  // is never rewritten — which is exactly how a fabricated opening balance
+  // survives every re-import, silently absorbing whatever discrepancy the
+  // ledger had at the moment somebody "repaired" it.
+  //
+  // The disagreement is always REPORTED. It is only CORRECTED when the caller
+  // asks (`rebaseOpeningBalances`), because the stored figure may be the user's
+  // own and the importer is not entitled to assume otherwise.
+  const existingAccountById = new Map((options.existingAccounts ?? []).map(r => [r.id, r]));
+  const existingAccountRowsById =
+    options.existingAccountRowsById ?? new Map<string, Readonly<Record<string, unknown>>>();
+  const openingBalanceMismatches: OpeningBalanceMismatch[] = [];
+  const accountOpeningBalanceRows: Record<string, unknown>[] = [];
+  for (const a of result.accounts) {
+    if (!reusedAccountIds.has(a.id)) continue;
+    const id = acctId.get(a.id)!;
+    const existing = existingAccountById.get(id);
+    if (!existing || existing.initial_balance === undefined) continue; // no opinion offered
+    const fileValue = toDecimal(String(a.openingBalance ?? 0));
+    const storedValue = toDecimal(String(existing.initial_balance ?? 0));
+    if (fileValue.equals(storedValue)) continue;
+    const base = existingAccountRowsById.get(id);
+    const rebased = options.rebaseOpeningBalances === true && base != null;
+    openingBalanceMismatches.push({
+      accountId: id,
+      accountName: a.name,
+      fileValue: fileValue.toFixed(2),
+      storedValue: storedValue.toFixed(2),
+      rebased,
+    });
+    // Complete row, only `initial_balance` moved: the stored balance, the name
+    // and every other column the user may have edited are written back as they
+    // are. The ledger invariant is a separate repair and stays separate.
+    if (rebased && base) accountOpeningBalanceRows.push({ ...base, initial_balance: fileValue.toNumber() });
+  }
+
   // Investment↔cash pairings reference other account rows, so they go in as a
   // second pass once every account exists (insert batching makes same-batch
   // FK ordering unreliable).
@@ -504,7 +670,7 @@ export function planCloudImport(
       memo: s.memo ?? null,
       sort_order: s.sortOrder,
       transfer_account_id: s.transferAccountId ? acctId.get(s.transferAccountId) ?? null : null,
-      linked_transfer_id: s.linkedTransferId ? txnId.get(s.linkedTransferId) ?? null : null,
+      linked_transfer_id: s.linkedTransferId ? linkTarget(s.linkedTransferId) : null,
     }));
 
   // ── The second pass: transfer links and split-leg pins ────────────────────
@@ -523,8 +689,7 @@ export function planCloudImport(
   for (const t of result.transactions) {
     const id = txnId.get(t.id);
     if (!id) continue;
-    const linkedTransferId = t.linkedTransferId && txnId.has(t.linkedTransferId)
-      ? txnId.get(t.linkedTransferId)! : null;
+    const linkedTransferId = t.linkedTransferId ? linkTarget(t.linkedTransferId) : null;
     const linkedTransferSplitId = t.linkedTransferSplitId && writtenSplitIds.has(t.linkedTransferSplitId)
       ? splitId.get(t.linkedTransferSplitId)! : null;
     if (!linkedTransferId && !linkedTransferSplitId) continue;
@@ -539,6 +704,54 @@ export function planCloudImport(
     linkRows.push({ ...transactionRow(t), linked_transfer_id: linkedTransferId, linked_transfer_split_id: linkedTransferSplitId });
   }
 
+  // ── Promoting the feed rows that took over a transfer leg ─────────────────
+  // The leg is gone; the feed row becomes the transfer in its place. It is
+  // re-typed (a transfer counted as spending is the double-count in another
+  // costume), files under the leg's To/From category, faces the same account,
+  // and points at the same counterpart — which itself now points back here.
+  //
+  // The row goes out COMPLETE, exactly as the database holds it, with only
+  // those columns changed: `is_split`, `amount`, `external_transaction_id` and
+  // everything else are written back unchanged, so nothing about the feed row's
+  // own identity moves. A row whose columns are already right is left out, so a
+  // second run of the same plan writes nothing at all.
+  const legBySourceId = new Map(result.transactions.map(t => [t.id, t]));
+  const feedPromotions: FeedTransferPromotion[] = [];
+  const feedPromotionRows: Record<string, unknown>[] = [];
+  for (const [sourceId, handover] of handoverBySourceId) {
+    const base = feedRowsById.get(handover.feedTransactionId);
+    if (!base) continue; // impossible: handoverBySourceId only holds rows we have
+    const leg = legBySourceId.get(sourceId);
+    const promotion: FeedTransferPromotion = {
+      id: handover.feedTransactionId,
+      importSourceId: sourceId,
+      transfer_account_id: handover.transferAccountId
+        ? acctId.get(handover.transferAccountId) ?? null : null,
+      linked_transfer_id: handover.counterpartSourceId
+        ? linkTarget(handover.counterpartSourceId) : null,
+      linked_transfer_split_id: handover.counterpartSplitSourceId
+        && writtenSplitIds.has(handover.counterpartSplitSourceId)
+        ? splitId.get(handover.counterpartSplitSourceId)! : null,
+    };
+    feedPromotions.push(promotion);
+
+    // The leg's To/From category, if it resolves; otherwise leave the feed
+    // row's own category alone rather than blanking a real one.
+    const currentCategory = typeof base.category === 'string' ? base.category : '';
+    const changed: Record<string, string | null> = {
+      type: 'transfer',
+      category: (leg ? cat(leg.category) : null) ?? currentCategory,
+      transfer_account_id: promotion.transfer_account_id,
+      linked_transfer_id: promotion.linked_transfer_id,
+      linked_transfer_split_id: promotion.linked_transfer_split_id,
+    };
+    const comparable = (value: unknown): string | null => (value == null ? null : String(value));
+    const alreadyRight = Object.keys(changed)
+      .every(key => comparable(base[key]) === changed[key]);
+    if (alreadyRight) continue;
+    feedPromotionRows.push({ ...base, ...changed });
+  }
+
   const skippedFeedOverlap = result.transactions.filter(t => suppressed.has(t.id)).length;
   const skippedExisting = result.transactions.length - transactions.length - skippedFeedOverlap;
 
@@ -546,6 +759,8 @@ export function planCloudImport(
     accounts, accountParents, accountParentRows,
     categories: insertedCategories, transactions, transferLinks,
     splits, splitLegPins, linkRows,
+    feedPromotions, feedPromotionRows, unpromotableHandovers,
+    openingBalanceMismatches, accountOpeningBalanceRows,
     skippedExisting, skippedFeedOverlap,
     skippedExistingAccounts: reusedAccountIds.size,
     skippedExistingCategories: reusedCategories,
@@ -630,7 +845,11 @@ export async function fetchExistingAccounts(
   for (let from = 0; ; from += PAGE) {
     const { data, error } = await supabase
       .from('accounts')
-      .select('id, name, parent_account_id')
+      // `initial_balance` comes along so the plan can SAY when a reused
+      // account's opening balance disagrees with the file (see
+      // CloudPlan.openingBalanceMismatches). Reading it costs nothing; not
+      // reading it is how the disagreement stayed invisible.
+      .select('id, name, parent_account_id, initial_balance')
       .eq('user_id', userId)
       .order('id')
       .range(from, from + PAGE - 1);
@@ -819,7 +1038,10 @@ export async function executeCloudPlan(
   // Accounts carry no provenance columns, so the primary key is the only
   // conflict target available — and every one of these rows was just written.
   await merge('accounts', plan.accountParentRows, 'id',
-    'pairing investment cash accounts', 'accounts', 0.13, 0.02, 'Pairing investment cash accounts');
+    'pairing investment cash accounts', 'accounts', 0.13, 0.01, 'Pairing investment cash accounts');
+  // Opt-in, and empty unless the caller asked for it (see rebaseOpeningBalances).
+  await merge('accounts', plan.accountOpeningBalanceRows, 'id',
+    'correcting opening balances', 'accounts', 0.14, 0.01, 'Correcting opening balances');
 
   await insert('categories', plan.categories, 'categories', 0.15, 0.1);
   await insert('transactions', plan.transactions, 'transactions', 0.25, 0.37, IMPORT_PROVENANCE_CONFLICT);
@@ -829,7 +1051,14 @@ export async function executeCloudPlan(
   await insert('transaction_splits', plan.splits, 'splits', 0.62, 0.16);
 
   await merge('transactions', plan.linkRows, IMPORT_PROVENANCE_CONFLICT,
-    'linking transfers', 'links', 0.78, 0.2, 'Linking transfers');
+    'linking transfers', 'links', 0.78, 0.16, 'Linking transfers');
+
+  // The feed rows that took over a suppressed transfer leg. Last, because each
+  // one points at rows the passes above have just written — and keyed on the
+  // primary key, because a feed row carries no import provenance to conflict on.
+  await merge('transactions', plan.feedPromotionRows, 'id',
+    'promoting bank-feed rows into transfers', 'links', 0.94, 0.04,
+    'Promoting bank-feed rows into transfers');
 
   onProgress?.({ phase: 'done', fraction: 1, message: 'Import complete.' });
 }

--- a/src/services/import/msMoney/reimportGuards.test.ts
+++ b/src/services/import/msMoney/reimportGuards.test.ts
@@ -1,0 +1,404 @@
+import { describe, it, expect } from 'vitest';
+import {
+  splitPopulations,
+  findFeedRowsInDeleteSet,
+  batched,
+  compareToBaseline,
+  verifyBackupContents,
+  describeTargetState,
+  mapFeedRowsToSeedNamespace,
+  findOrphanedCategoryIds,
+  findParentlessSplitIds,
+  deleteFileOriginRows,
+  REIMPORT_PLAN_VERSION,
+  type PlanBaseline,
+  type LivePlanState,
+  type ProvenanceMarkers,
+  type MutationOutcome,
+  type DeleteQuery,
+  type DeleteClient,
+  type BackupReceipt,
+} from './reimportGuards';
+
+// Every value here is invented. The shapes mirror the transactions table and the
+// plan file the dry run writes; none of it came from a real database.
+
+const row = (over: Partial<ProvenanceMarkers> & Pick<ProvenanceMarkers, 'id'>): ProvenanceMarkers => ({
+  external_transaction_id: null,
+  import_source: null,
+  import_source_id: null,
+  ...over,
+});
+
+describe('splitPopulations', () => {
+  it('separates the bank feed from the file import, both marker styles', () => {
+    const result = splitPopulations([
+      row({ id: 'feed-1', external_transaction_id: 'tl-1' }),
+      row({ id: 'file-1', import_source: 'ms-money', import_source_id: 'mny-txn-1' }),
+      row({ id: 'file-2' }),
+    ]);
+    expect(result.feed.map(r => r.id)).toEqual(['feed-1']);
+    expect(result.provenanced.map(r => r.id)).toEqual(['file-1']);
+    expect(result.legacy.map(r => r.id)).toEqual(['file-2']);
+    expect(result.conflicted).toEqual([]);
+  });
+
+  it('puts a row carrying BOTH markers in its own bucket, never in either population', () => {
+    const both = row({ id: 'x', external_transaction_id: 'tl-9', import_source: 'ms-money', import_source_id: 'mny-txn-9' });
+    const result = splitPopulations([both]);
+    expect(result.conflicted.map(r => r.id)).toEqual(['x']);
+    expect(result.feed).toEqual([]);
+    expect(result.provenanced).toEqual([]);
+    expect(result.legacy).toEqual([]);
+  });
+});
+
+describe('findFeedRowsInDeleteSet', () => {
+  it('names any row in the delete set that carries a bank-feed id', () => {
+    const found = findFeedRowsInDeleteSet([
+      row({ id: 'ok' }),
+      row({ id: 'not-ok', external_transaction_id: 'tl-2' }),
+    ]);
+    expect(found.map(r => r.id)).toEqual(['not-ok']);
+  });
+
+  it('is empty for a clean delete set', () => {
+    expect(findFeedRowsInDeleteSet([row({ id: 'a' }), row({ id: 'b' })])).toEqual([]);
+  });
+});
+
+describe('batched', () => {
+  it('splits into request-sized chunks and keeps every item exactly once', () => {
+    const items = Array.from({ length: 7 }, (_, i) => `id-${i}`);
+    expect(batched(items, 3)).toEqual([
+      ['id-0', 'id-1', 'id-2'], ['id-3', 'id-4', 'id-5'], ['id-6'],
+    ]);
+    expect(batched([], 3)).toEqual([]);
+    expect(() => batched(items, 0)).toThrow(/at least 1/);
+  });
+});
+
+// ── Drift detection ─────────────────────────────────────────────────────────
+
+const baseline: PlanBaseline = {
+  version: REIMPORT_PLAN_VERSION,
+  userId: 'user-1',
+  toleranceDays: 3,
+  seedSha256: 'abc123',
+  seedTransactionCount: 4,
+  deleteTransactionIds: ['t1', 't2', 't3'],
+  deleteSplitIds: ['s1'],
+  feedTransactionIds: ['f1', 'f2'],
+  suppressedSourceIds: ['mny-txn-2'],
+  expectedImportCount: 3,
+  expectedNetCount: 5,
+};
+const live = (over: Partial<LivePlanState> = {}): LivePlanState => {
+  const { version: _version, ...rest } = baseline;
+  return { ...rest, ...over };
+};
+
+describe('compareToBaseline', () => {
+  it('passes when the database is exactly what the dry run reported', () => {
+    expect(compareToBaseline(baseline, live())).toEqual({ drifted: false, lines: [] });
+  });
+
+  it('catches a row that disappeared and a row that appeared, even at equal counts', () => {
+    const report = compareToBaseline(baseline, live({ deleteTransactionIds: ['t1', 't2', 't9'] }));
+    expect(report.drifted).toBe(true);
+    expect(report.lines.join('\n')).toContain('1 gone since the dry run');
+    expect(report.lines.join('\n')).toContain('1 new since the dry run');
+  });
+
+  it('refuses a different seed file, a different user, and a moved tolerance', () => {
+    expect(compareToBaseline(baseline, live({ seedSha256: 'deadbeef' })).lines.join()).toContain('seed file is not the one');
+    expect(compareToBaseline(baseline, live({ userId: 'user-2' })).lines.join()).toContain('target user changed');
+    expect(compareToBaseline(baseline, live({ toleranceDays: 5 })).lines.join()).toContain('tolerance changed');
+  });
+
+  it('catches a bank-feed row that vanished between preview and apply', () => {
+    const report = compareToBaseline(baseline, live({ feedTransactionIds: ['f1'] }));
+    expect(report.drifted).toBe(true);
+    expect(report.lines.join('\n')).toContain('bank-feed rows to keep');
+  });
+
+  it('refuses a plan file written by a different version of the script', () => {
+    const stale = { ...baseline, version: REIMPORT_PLAN_VERSION - 1 };
+    expect(compareToBaseline(stale, live()).drifted).toBe(true);
+  });
+
+  it('catches a changed import count or final count', () => {
+    expect(compareToBaseline(baseline, live({ expectedImportCount: 2 })).drifted).toBe(true);
+    expect(compareToBaseline(baseline, live({ expectedNetCount: 99 })).drifted).toBe(true);
+  });
+});
+
+// ── Backup verification ─────────────────────────────────────────────────────
+
+const goodBackup = JSON.stringify({
+  transactions: [
+    { id: 't1', external_transaction_id: null, amount: '-1.00' },
+    { id: 't2', external_transaction_id: null, amount: '-2.00' },
+  ],
+  splits: [{ id: 's1', transaction_id: 't1', amount: '-1.00' }],
+});
+const expectation = { path: '/outside/repo/backup.json', transactionIds: ['t1', 't2'], splitIds: ['s1'] };
+
+describe('verifyBackupContents', () => {
+  it('issues a receipt only when every row about to be deleted is in the file', () => {
+    const { receipt, problems } = verifyBackupContents(goodBackup, expectation, () => '2026-07-23T00:00:00.000Z');
+    expect(problems).toEqual([]);
+    expect(receipt).not.toBeNull();
+    expect([...receipt!.transactionIds]).toEqual(['t1', 't2']);
+    expect([...receipt!.splitIds]).toEqual(['s1']);
+    expect(receipt!.path).toBe(expectation.path);
+  });
+
+  it('refuses a truncated backup — a missing row means no receipt', () => {
+    const short = JSON.stringify({ transactions: [{ id: 't1', external_transaction_id: null }], splits: [] });
+    const { receipt, problems } = verifyBackupContents(short, expectation);
+    expect(receipt).toBeNull();
+    expect(problems.join('\n')).toContain('1 gone since the dry run');
+  });
+
+  it('refuses a backup that does not parse or is not an object', () => {
+    expect(verifyBackupContents('{not json', expectation).receipt).toBeNull();
+    expect(verifyBackupContents('[]', expectation).problems.join()).toContain('not a JSON object');
+    expect(verifyBackupContents('{}', expectation).problems.join()).toContain('no `transactions` array');
+  });
+
+  it('refuses a backup holding a bank-feed row — that row should never have been in the set', () => {
+    const contaminated = JSON.stringify({
+      transactions: [
+        { id: 't1', external_transaction_id: null },
+        { id: 't2', external_transaction_id: 'tl-77' },
+      ],
+      splits: [{ id: 's1', transaction_id: 't1' }],
+    });
+    const { receipt, problems } = verifyBackupContents(contaminated, expectation);
+    expect(receipt).toBeNull();
+    expect(problems.join('\n')).toContain('carries a bank-feed id');
+  });
+
+  it('refuses a split line whose parent is not in the backup', () => {
+    const orphan = JSON.stringify({
+      transactions: [{ id: 't1', external_transaction_id: null }, { id: 't2', external_transaction_id: null }],
+      splits: [{ id: 's1', transaction_id: 'somewhere-else' }],
+    });
+    expect(verifyBackupContents(orphan, expectation).problems.join('\n')).toContain('names a parent that is not in the backup');
+  });
+});
+
+// ── Already-applied ─────────────────────────────────────────────────────────
+
+describe('describeTargetState', () => {
+  const seedSourceIds = new Set(['mny-txn-1', 'mny-txn-2', 'mny-txn-3']);
+  const suppressed = new Set(['mny-txn-2']);
+
+  it('is satisfied when exactly the unsuppressed seed rows are present with provenance', () => {
+    const result = describeTargetState({
+      fileRows: [
+        row({ id: 'a', import_source: 'ms-money', import_source_id: 'mny-txn-1' }),
+        row({ id: 'b', import_source: 'ms-money', import_source_id: 'mny-txn-3' }),
+      ],
+      seedSourceIds, suppressedSourceIds: suppressed, importSource: 'ms-money',
+    });
+    expect(result).toEqual({ satisfied: true, reasons: [] });
+  });
+
+  it('is not satisfied while legacy rows remain', () => {
+    const result = describeTargetState({
+      fileRows: [row({ id: 'legacy' })],
+      seedSourceIds, suppressedSourceIds: suppressed, importSource: 'ms-money',
+    });
+    expect(result.satisfied).toBe(false);
+    expect(result.reasons.join('\n')).toContain('no import provenance');
+  });
+
+  it('is not satisfied when a feed-covered row is present, or a seed row is missing', () => {
+    const feedCovered = describeTargetState({
+      fileRows: [
+        row({ id: 'a', import_source: 'ms-money', import_source_id: 'mny-txn-1' }),
+        row({ id: 'b', import_source: 'ms-money', import_source_id: 'mny-txn-2' }),
+        row({ id: 'c', import_source: 'ms-money', import_source_id: 'mny-txn-3' }),
+      ],
+      seedSourceIds, suppressedSourceIds: suppressed, importSource: 'ms-money',
+    });
+    expect(feedCovered.satisfied).toBe(false);
+    expect(feedCovered.reasons.join('\n')).toContain('not in the seed, or are feed-covered');
+
+    const missing = describeTargetState({
+      fileRows: [row({ id: 'a', import_source: 'ms-money', import_source_id: 'mny-txn-1' })],
+      seedSourceIds, suppressedSourceIds: suppressed, importSource: 'ms-money',
+    });
+    expect(missing.reasons.join('\n')).toContain('are not in the database');
+  });
+
+  it('notices rows written by a different importer', () => {
+    const result = describeTargetState({
+      fileRows: [
+        row({ id: 'a', import_source: 'qif', import_source_id: 'mny-txn-1' }),
+        row({ id: 'b', import_source: 'ms-money', import_source_id: 'mny-txn-3' }),
+      ],
+      seedSourceIds, suppressedSourceIds: suppressed, importSource: 'ms-money',
+    });
+    expect(result.reasons.join('\n')).toContain('different importer');
+  });
+});
+
+// ── Account namespace mapping ───────────────────────────────────────────────
+
+describe('mapFeedRowsToSeedNamespace', () => {
+  const seedAccounts = [{ id: 'mny-acct-1', name: 'Everyday' }, { id: 'mny-acct-2', name: 'Savings' }];
+  const dbAccounts = [{ id: 'uuid-a', name: 'everyday ' }, { id: 'uuid-b', name: 'Savings' }];
+
+  it('translates feed rows into the seed account ids, matching on name like the importer does', () => {
+    const { rows, unmapped, duplicateNames } = mapFeedRowsToSeedNamespace(seedAccounts, dbAccounts, [
+      { id: 'f1', account_id: 'uuid-a', date: '2026-05-01', amount: '-9.99', description: 'SHOP' },
+    ]);
+    expect(rows).toEqual([{ id: 'f1', accountId: 'mny-acct-1', date: '2026-05-01', amount: '-9.99', description: 'SHOP' }]);
+    expect(unmapped).toEqual([]);
+    expect(duplicateNames).toEqual([]);
+  });
+
+  it('keeps — never drops — a feed row in an account the seed does not have', () => {
+    const { rows, unmapped } = mapFeedRowsToSeedNamespace(seedAccounts, [...dbAccounts, { id: 'uuid-c', name: 'Bank Only' }], [
+      { id: 'f2', account_id: 'uuid-c', date: '2026-05-01', amount: '-1.00', description: null },
+    ]);
+    expect(rows).toEqual([]);
+    expect(unmapped.map(r => r.id)).toEqual(['f2']);
+  });
+
+  it('claims each existing account once and reports duplicate names', () => {
+    const { rows, duplicateNames } = mapFeedRowsToSeedNamespace(
+      [{ id: 'mny-acct-1', name: 'Everyday' }, { id: 'mny-acct-9', name: 'Everyday' }],
+      [{ id: 'uuid-a', name: 'Everyday' }, { id: 'uuid-b', name: 'Everyday' }],
+      [
+        { id: 'f1', account_id: 'uuid-a', date: '2026-05-01', amount: '-1.00', description: '' },
+        { id: 'f2', account_id: 'uuid-b', date: '2026-05-01', amount: '-1.00', description: '' },
+      ]
+    );
+    expect(rows.map(r => r.accountId)).toEqual(['mny-acct-1', 'mny-acct-9']);
+    expect(duplicateNames).toEqual(['everyday']);
+  });
+});
+
+// ── Post-apply integrity ────────────────────────────────────────────────────
+
+describe('integrity helpers', () => {
+  it('finds categories pointing at a parent that does not exist', () => {
+    expect(findOrphanedCategoryIds([
+      { id: 'c1', parent_id: null },
+      { id: 'c2', parent_id: 'c1' },
+      { id: 'c3', parent_id: 'gone' },
+    ])).toEqual(['c3']);
+  });
+
+  it('finds split lines whose parent transaction is gone', () => {
+    expect(findParentlessSplitIds(
+      [{ id: 's1', transaction_id: 't1' }, { id: 's2', transaction_id: 't-gone' }],
+      new Set(['t1'])
+    )).toEqual(['s2']);
+  });
+});
+
+// ── The delete pass ─────────────────────────────────────────────────────────
+
+interface RecordedCall { table: string; countRequested: string; filters: string[] }
+
+/** A real (if tiny) implementation of the client slice the delete pass uses. */
+function fakeClient(options: { failOn?: string; silentCount?: boolean } = {}): { client: DeleteClient; calls: RecordedCall[] } {
+  const calls: RecordedCall[] = [];
+  const client: DeleteClient = {
+    from(table: string) {
+      return {
+        delete(deleteOptions: { count: 'exact' }): DeleteQuery {
+          const call: RecordedCall = { table, countRequested: deleteOptions.count, filters: [] };
+          calls.push(call);
+          let matched = 0;
+          const query: DeleteQuery = {
+            in(column, values) {
+              call.filters.push(`in:${column}=${values.length}`);
+              matched += values.length;
+              return query;
+            },
+            is(column, value) {
+              call.filters.push(`is:${column}=${String(value)}`);
+              return query;
+            },
+            then<R1 = MutationOutcome, R2 = never>(
+              onfulfilled?: ((value: MutationOutcome) => R1 | PromiseLike<R1>) | null,
+              onrejected?: ((reason: unknown) => R2 | PromiseLike<R2>) | null
+            ): PromiseLike<R1 | R2> {
+              const outcome: MutationOutcome = options.failOn === table
+                ? { error: { message: 'connection reset' }, status: 0 }
+                : { error: null, status: 204, count: options.silentCount ? null : matched };
+              return Promise.resolve(outcome).then(onfulfilled, onrejected);
+            },
+          };
+          return query;
+        },
+      };
+    },
+  };
+  return { client, calls };
+}
+
+const receiptFor = (transactionIds: string[], splitIds: string[]): BackupReceipt => ({
+  path: '/outside/repo/backup.json',
+  transactionIds: new Set(transactionIds),
+  splitIds: new Set(splitIds),
+  verifiedAt: '2026-07-23T00:00:00.000Z',
+});
+
+describe('deleteFileOriginRows', () => {
+  it('deletes splits before transactions and filters every delete on external_transaction_id IS NULL', async () => {
+    const { client, calls } = fakeClient();
+    const result = await deleteFileOriginRows(client, receiptFor(['t1', 't2'], ['s1']), ['t1', 't2'], ['s1']);
+
+    expect(result).toEqual({ splitsDeleted: 1, transactionsDeleted: 2 });
+    expect(calls.map(c => c.table)).toEqual(['transaction_splits', 'transactions']);
+    expect(calls[1].filters).toContain('is:external_transaction_id=null');
+    // The split delete is keyed on the line's own id — never on a broad filter.
+    expect(calls[0].filters).toContain('in:id=1');
+    // Every statement asks the database how many rows it actually removed.
+    expect(calls.map(c => c.countRequested)).toEqual(['exact', 'exact']);
+  });
+
+  it('refuses to assume a count the database did not report', async () => {
+    const { client } = fakeClient({ silentCount: true });
+    await expect(deleteFileOriginRows(client, receiptFor(['t1'], []), ['t1'], []))
+      .rejects.toThrow(/did not report how many rows it deleted/);
+  });
+
+  it('refuses ids the verified backup does not cover — the backup is the authority', async () => {
+    const { client, calls } = fakeClient();
+    await expect(deleteFileOriginRows(client, receiptFor(['t1'], []), ['t1', 'not-backed-up'], []))
+      .rejects.toThrow(/not in the verified backup/);
+    expect(calls).toEqual([]);
+
+    await expect(deleteFileOriginRows(client, receiptFor(['t1'], []), ['t1'], ['s-unknown']))
+      .rejects.toThrow(/split line\(s\) that are not in the verified backup/);
+    expect(calls).toEqual([]);
+  });
+
+  it('stops on the first failed batch instead of carrying on', async () => {
+    const { client, calls } = fakeClient({ failOn: 'transaction_splits' });
+    await expect(deleteFileOriginRows(client, receiptFor(['t1'], ['s1']), ['t1'], ['s1']))
+      .rejects.toThrow(/deleting split lines: connection reset/);
+    // The transaction delete was never reached.
+    expect(calls.map(c => c.table)).toEqual(['transaction_splits']);
+  });
+
+  it('batches large id lists and reports progress against the total', async () => {
+    const { client, calls } = fakeClient();
+    const ids = Array.from({ length: 250 }, (_, i) => `t${i}`);
+    const seen: number[] = [];
+    const result = await deleteFileOriginRows(client, receiptFor(ids, []), ids, [], (stage, done) => {
+      if (stage === 'transactions') seen.push(done);
+    });
+    expect(result.transactionsDeleted).toBe(250);
+    expect(calls.filter(c => c.table === 'transactions')).toHaveLength(3);
+    expect(seen).toEqual([100, 200, 250]);
+  });
+});

--- a/src/services/import/msMoney/reimportGuards.test.ts
+++ b/src/services/import/msMoney/reimportGuards.test.ts
@@ -90,6 +90,7 @@ const baseline: PlanBaseline = {
   deleteSplitIds: ['s1'],
   feedTransactionIds: ['f1', 'f2'],
   suppressedSourceIds: ['mny-txn-2'],
+  transferHandovers: ['mny-txn-2>f1'],
   expectedImportCount: 3,
   expectedNetCount: 5,
 };
@@ -256,7 +257,11 @@ describe('mapFeedRowsToSeedNamespace', () => {
     const { rows, unmapped, duplicateNames } = mapFeedRowsToSeedNamespace(seedAccounts, dbAccounts, [
       { id: 'f1', account_id: 'uuid-a', date: '2026-05-01', amount: '-9.99', description: 'SHOP' },
     ]);
-    expect(rows).toEqual([{ id: 'f1', accountId: 'mny-acct-1', date: '2026-05-01', amount: '-9.99', description: 'SHOP' }]);
+    expect(rows).toEqual([{
+      id: 'f1', accountId: 'mny-acct-1', date: '2026-05-01', amount: '-9.99', description: 'SHOP',
+      // Carried through for the handover gates, defaulted when the read omits them.
+      isSplit: false, linkedTransferId: null,
+    }]);
     expect(unmapped).toEqual([]);
     expect(duplicateNames).toEqual([]);
   });

--- a/src/services/import/msMoney/reimportGuards.ts
+++ b/src/services/import/msMoney/reimportGuards.ts
@@ -1,0 +1,489 @@
+/**
+ * Guards for the scoped MS Money re-import (`scripts/mnyReimportPlan.mts --apply`).
+ *
+ * The script itself is I/O: read the database, write a backup, delete, re-import,
+ * verify. Everything in this file is the part that DECIDES — which rows may be
+ * touched, whether the world still looks like the plan the operator approved,
+ * whether the backup on disk is really usable, whether the work is already done.
+ * It lives here, beside the importer it protects, because it is testable: every
+ * guard below is exercised with synthetic fixtures in reimportGuards.test.ts,
+ * and none of them needs a database to be wrong out loud.
+ *
+ * The one rule the whole file exists to enforce:
+ *
+ *   A row carrying `external_transaction_id` came from the bank feed. It cannot
+ *   be recreated from the Money file, and it is NEVER deleted.
+ */
+import type { ExistingFeedTransaction } from './feedOverlap';
+
+/** Bumped whenever the plan file's shape changes; apply refuses an older one. */
+export const REIMPORT_PLAN_VERSION = 1;
+
+/** Ids per PostgREST request on the delete pass — small enough to keep the URL well under any proxy's header limit. */
+export const DELETE_BATCH_SIZE = 100;
+
+/** The provenance markers every population decision is made from. */
+export interface ProvenanceMarkers {
+  id: string;
+  /** Set by the bank feed. Non-null ⇒ untouchable. */
+  external_transaction_id: string | null;
+  /** Set by a file importer ('ms-money'). */
+  import_source: string | null;
+  import_source_id: string | null;
+}
+
+export interface PopulationSplit<T> {
+  /** Bank-fed rows: kept, always. */
+  feed: T[];
+  /** File rows written by an importer that recorded provenance. */
+  provenanced: T[];
+  /** File rows written before provenance existed — no marker of any kind. */
+  legacy: T[];
+  /**
+   * Rows carrying BOTH markers. The two populations are supposed to be
+   * disjoint; a row here means they are not, and nothing may be deleted until a
+   * human has resolved it.
+   */
+  conflicted: T[];
+}
+
+/**
+ * Separate the bank feed from the file import.
+ *
+ * `conflicted` is deliberately its own bucket rather than being counted twice:
+ * a row with both markers must not silently fall into whichever population is
+ * checked first.
+ */
+export function splitPopulations<T extends ProvenanceMarkers>(rows: readonly T[]): PopulationSplit<T> {
+  const out: PopulationSplit<T> = { feed: [], provenanced: [], legacy: [], conflicted: [] };
+  for (const row of rows) {
+    const fed = row.external_transaction_id != null;
+    const imported = row.import_source != null;
+    if (fed && imported) out.conflicted.push(row);
+    else if (fed) out.feed.push(row);
+    else if (imported) out.provenanced.push(row);
+    else out.legacy.push(row);
+  }
+  return out;
+}
+
+/**
+ * The last line of defence before a delete: any row here carries a bank-feed id
+ * and must not be in the delete set at all. Returns the offenders, so the caller
+ * can name them rather than just refusing.
+ */
+export function findFeedRowsInDeleteSet<T extends ProvenanceMarkers>(rows: readonly T[]): T[] {
+  return rows.filter(row => row.external_transaction_id != null);
+}
+
+/** Split a list into request-sized batches. */
+export function batched<T>(items: readonly T[], size: number = DELETE_BATCH_SIZE): T[][] {
+  if (size < 1) throw new Error('batch size must be at least 1');
+  const out: T[][] = [];
+  for (let i = 0; i < items.length; i += size) out.push(items.slice(i, i + size));
+  return out;
+}
+
+// ── Drift: is the database still the one the operator reviewed? ──────────────
+
+/**
+ * What the dry run saw, written beside the backup it produced. Apply recomputes
+ * every field from the live database and refuses if anything moved: the numbers
+ * a human approved have to be the numbers being executed.
+ */
+export interface PlanBaseline {
+  version: number;
+  userId: string;
+  toleranceDays: number;
+  /** sha256 of the seed file, so apply cannot be handed a DIFFERENT export. */
+  seedSha256: string;
+  seedTransactionCount: number;
+  deleteTransactionIds: string[];
+  deleteSplitIds: string[];
+  feedTransactionIds: string[];
+  /** `mny-txn-…` ids the feed already covers — not re-imported. */
+  suppressedSourceIds: string[];
+  expectedImportCount: number;
+  expectedNetCount: number;
+}
+
+/** The same picture, recomputed live at apply time. */
+export type LivePlanState = Omit<PlanBaseline, 'version'>;
+
+export interface DriftReport {
+  drifted: boolean;
+  lines: string[];
+}
+
+const sample = (ids: readonly string[], take = 5): string =>
+  ids.slice(0, take).join(', ') + (ids.length > take ? `, …(${ids.length - take} more)` : '');
+
+/** Set difference in both directions, described in words. Empty ⇒ identical. */
+function diffSets(label: string, expected: readonly string[], actual: readonly string[]): string[] {
+  const expectedSet = new Set(expected);
+  const actualSet = new Set(actual);
+  const added = actual.filter(id => !expectedSet.has(id));
+  const removed = expected.filter(id => !actualSet.has(id));
+  const lines: string[] = [];
+  if (removed.length) lines.push(`${label}: ${removed.length} gone since the dry run (${sample(removed)})`);
+  if (added.length) lines.push(`${label}: ${added.length} new since the dry run (${sample(added)})`);
+  return lines;
+}
+
+/**
+ * Compare the live database against the approved plan. Every population is
+ * compared as a SET of ids, not as a count: two rows deleted and two rows added
+ * leaves the count identical and the plan wrong.
+ */
+export function compareToBaseline(baseline: PlanBaseline, live: LivePlanState): DriftReport {
+  const lines: string[] = [];
+  if (baseline.version !== REIMPORT_PLAN_VERSION) {
+    lines.push(`plan file is version ${baseline.version}, this script writes and reads version ${REIMPORT_PLAN_VERSION}`);
+  }
+  if (baseline.userId !== live.userId) {
+    lines.push(`target user changed: plan ${baseline.userId} → live ${live.userId}`);
+  }
+  if (baseline.seedSha256 !== live.seedSha256) {
+    lines.push('the seed file is not the one the plan was built from (sha256 differs)');
+  }
+  if (baseline.seedTransactionCount !== live.seedTransactionCount) {
+    lines.push(`seed transaction count changed: ${baseline.seedTransactionCount} → ${live.seedTransactionCount}`);
+  }
+  if (baseline.toleranceDays !== live.toleranceDays) {
+    lines.push(`feed-overlap tolerance changed: ${baseline.toleranceDays} → ${live.toleranceDays} days`);
+  }
+  lines.push(...diffSets('transactions to delete', baseline.deleteTransactionIds, live.deleteTransactionIds));
+  lines.push(...diffSets('split lines to delete', baseline.deleteSplitIds, live.deleteSplitIds));
+  lines.push(...diffSets('bank-feed rows to keep', baseline.feedTransactionIds, live.feedTransactionIds));
+  lines.push(...diffSets('feed-covered source ids', baseline.suppressedSourceIds, live.suppressedSourceIds));
+  if (baseline.expectedImportCount !== live.expectedImportCount) {
+    lines.push(`rows to import changed: ${baseline.expectedImportCount} → ${live.expectedImportCount}`);
+  }
+  if (baseline.expectedNetCount !== live.expectedNetCount) {
+    lines.push(`final row count changed: ${baseline.expectedNetCount} → ${live.expectedNetCount}`);
+  }
+  return { drifted: lines.length > 0, lines };
+}
+
+// ── Backup: proof on disk before anything is destroyed ───────────────────────
+
+/**
+ * Issued ONLY by {@link verifyBackupContents}, and required by
+ * {@link deleteFileOriginRows}. The delete pass therefore cannot be called
+ * without a backup that has been written, re-read and checked row for row —
+ * the ordering is enforced by the type system, not by remembering to do it.
+ */
+export interface BackupReceipt {
+  readonly path: string;
+  readonly transactionIds: ReadonlySet<string>;
+  readonly splitIds: ReadonlySet<string>;
+  readonly verifiedAt: string;
+}
+
+export interface BackupExpectation {
+  path: string;
+  transactionIds: readonly string[];
+  splitIds: readonly string[];
+}
+
+interface BackupShape {
+  transactions?: unknown;
+  splits?: unknown;
+}
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === 'object' && value !== null && !Array.isArray(value);
+
+/**
+ * Read a written backup back and prove it holds every row about to be deleted.
+ *
+ * Checked, in this order: it parses; it carries both collections; the
+ * transaction ids are EXACTLY the ids about to be deleted (no more, no fewer);
+ * no backed-up transaction carries a bank-feed id; the split ids match and every
+ * one names a parent that is in the backup too. Any failure returns no receipt,
+ * and without a receipt nothing can be deleted.
+ */
+export function verifyBackupContents(
+  raw: string,
+  expected: BackupExpectation,
+  now: () => string = () => new Date().toISOString()
+): { receipt: BackupReceipt | null; problems: string[] } {
+  const problems: string[] = [];
+  let parsed: BackupShape;
+  try {
+    const value: unknown = JSON.parse(raw);
+    if (!isRecord(value)) {
+      return { receipt: null, problems: ['backup file is not a JSON object'] };
+    }
+    parsed = value;
+  } catch (thrown) {
+    return { receipt: null, problems: [`backup file does not parse: ${thrown instanceof Error ? thrown.message : String(thrown)}`] };
+  }
+
+  if (!Array.isArray(parsed.transactions)) problems.push('backup has no `transactions` array');
+  if (!Array.isArray(parsed.splits)) problems.push('backup has no `splits` array');
+  if (problems.length) return { receipt: null, problems };
+
+  const txnRows = (parsed.transactions as unknown[]).filter(isRecord);
+  const splitRows = (parsed.splits as unknown[]).filter(isRecord);
+  if (txnRows.length !== (parsed.transactions as unknown[]).length) {
+    problems.push('backup contains transaction entries that are not objects');
+  }
+  if (splitRows.length !== (parsed.splits as unknown[]).length) {
+    problems.push('backup contains split entries that are not objects');
+  }
+
+  const txnIds = new Set<string>();
+  for (const row of txnRows) {
+    if (typeof row.id !== 'string' || row.id === '') { problems.push('a backed-up transaction has no id'); continue; }
+    txnIds.add(row.id);
+    if (row.external_transaction_id != null) {
+      problems.push(`backed-up transaction ${row.id} carries a bank-feed id — it must never have been in the delete set`);
+    }
+  }
+  const splitIds = new Set<string>();
+  for (const row of splitRows) {
+    if (typeof row.id !== 'string' || row.id === '') { problems.push('a backed-up split line has no id'); continue; }
+    splitIds.add(row.id);
+    if (typeof row.transaction_id !== 'string' || !txnIds.has(row.transaction_id)) {
+      problems.push(`backed-up split ${row.id} names a parent that is not in the backup`);
+    }
+  }
+
+  problems.push(...diffSets('backup transactions vs rows to delete', expected.transactionIds, [...txnIds]));
+  problems.push(...diffSets('backup splits vs split lines to delete', expected.splitIds, [...splitIds]));
+
+  if (problems.length) return { receipt: null, problems };
+  return {
+    receipt: { path: expected.path, transactionIds: txnIds, splitIds, verifiedAt: now() },
+    problems: [],
+  };
+}
+
+// ── Already applied? ─────────────────────────────────────────────────────────
+
+export interface TargetStateInput {
+  /** Every file-origin row currently in the database (provenanced + legacy). */
+  fileRows: readonly ProvenanceMarkers[];
+  /** Every `mny-txn-…` id in the seed. */
+  seedSourceIds: ReadonlySet<string>;
+  /** Seed ids the bank feed already covers — deliberately absent. */
+  suppressedSourceIds: ReadonlySet<string>;
+  importSource: string;
+}
+
+/**
+ * Is the database ALREADY in the state a successful apply would leave it in?
+ *
+ * If it is, the honest thing is to do nothing at all: no backup, no delete, no
+ * re-import. This is what makes a second apply run a no-op rather than a
+ * needless second demolition of rows that are already correct.
+ */
+export function describeTargetState(input: TargetStateInput): { satisfied: boolean; reasons: string[] } {
+  const reasons: string[] = [];
+  const wanted = new Set([...input.seedSourceIds].filter(id => !input.suppressedSourceIds.has(id)));
+
+  const legacy = input.fileRows.filter(r => r.import_source == null).length;
+  if (legacy) reasons.push(`${legacy} file row(s) still carry no import provenance`);
+
+  const foreign = input.fileRows.filter(r => r.import_source != null && r.import_source !== input.importSource).length;
+  if (foreign) reasons.push(`${foreign} file row(s) come from a different importer`);
+
+  const present = new Set<string>();
+  for (const row of input.fileRows) {
+    if (row.import_source === input.importSource && row.import_source_id != null) present.add(row.import_source_id);
+  }
+  const missing = [...wanted].filter(id => !present.has(id));
+  const unexpected = [...present].filter(id => !wanted.has(id));
+  if (missing.length) reasons.push(`${missing.length} seed row(s) are not in the database (${sample(missing)})`);
+  if (unexpected.length) reasons.push(`${unexpected.length} imported row(s) are not in the seed, or are feed-covered (${sample(unexpected)})`);
+
+  return { satisfied: reasons.length === 0, reasons };
+}
+
+// ── Account namespace: the feed lives in DB ids, the seed in `mny-acct-…` ─────
+
+export interface NamedAccount { id: string; name: string }
+
+export interface FeedRowInDb {
+  id: string;
+  account_id: string;
+  date: string;
+  amount: string | number;
+  description: string | null;
+}
+
+/** Case/whitespace-insensitive, exactly as planCloudImport matches accounts. */
+const normName = (name: string): string => name.trim().toLowerCase();
+
+/**
+ * Translate the user's bank-feed rows into the seed's account namespace, so the
+ * overlap between them and the file can be measured.
+ *
+ * The pairing deliberately mirrors `planCloudImport`'s account reuse — buckets
+ * by normalised name, each seed account claiming one existing row in order —
+ * because the account a suppressed row would have landed in IS the account the
+ * re-import will reuse. Any other rule could measure the overlap in one account
+ * and write the rows into another.
+ *
+ * A feed row in an account the seed does not have cannot overlap anything; it is
+ * returned in `unmapped` and simply kept.
+ */
+export function mapFeedRowsToSeedNamespace(
+  seedAccounts: readonly NamedAccount[],
+  dbAccounts: readonly NamedAccount[],
+  feedRows: readonly FeedRowInDb[]
+): { rows: ExistingFeedTransaction[]; unmapped: FeedRowInDb[]; duplicateNames: string[] } {
+  const buckets = new Map<string, string[]>();
+  for (const row of dbAccounts) {
+    const key = normName(row.name);
+    const bucket = buckets.get(key);
+    if (bucket) bucket.push(row.id); else buckets.set(key, [row.id]);
+  }
+  const duplicateNames = [...buckets.entries()].filter(([, ids]) => ids.length > 1).map(([name]) => name);
+
+  const dbToSeed = new Map<string, string>();
+  for (const seedAccount of seedAccounts) {
+    const claimed = buckets.get(normName(seedAccount.name))?.shift();
+    if (claimed) dbToSeed.set(claimed, seedAccount.id);
+  }
+
+  const rows: ExistingFeedTransaction[] = [];
+  const unmapped: FeedRowInDb[] = [];
+  for (const feed of feedRows) {
+    const seedAccountId = dbToSeed.get(feed.account_id);
+    if (!seedAccountId) { unmapped.push(feed); continue; }
+    rows.push({
+      id: feed.id,
+      accountId: seedAccountId,
+      date: feed.date,
+      amount: feed.amount,
+      description: feed.description ?? '',
+    });
+  }
+  return { rows, unmapped, duplicateNames };
+}
+
+// ── Post-apply integrity ─────────────────────────────────────────────────────
+
+/** Categories pointing at a parent row that does not exist. Must be empty. */
+export function findOrphanedCategoryIds(rows: readonly { id: string; parent_id: string | null }[]): string[] {
+  const ids = new Set(rows.map(r => r.id));
+  return rows.filter(r => r.parent_id != null && !ids.has(r.parent_id)).map(r => r.id);
+}
+
+/** Split lines whose parent transaction is gone. Must be empty. */
+export function findParentlessSplitIds(
+  splits: readonly { id: string; transaction_id: string }[],
+  transactionIds: ReadonlySet<string>
+): string[] {
+  return splits.filter(s => !transactionIds.has(s.transaction_id)).map(s => s.id);
+}
+
+// ── The delete pass ──────────────────────────────────────────────────────────
+
+/**
+ * The part of a PostgREST response the delete pass reads. `count` is the number
+ * of rows the DATABASE says it removed — asked for with `{ count: 'exact' }` and
+ * compared against what was expected, because "no error" is not the same as
+ * "the rows are gone".
+ */
+export interface MutationOutcome {
+  error: { message: string } | null;
+  status?: number;
+  count?: number | null;
+}
+
+export interface DeleteQuery extends PromiseLike<MutationOutcome> {
+  in(column: string, values: readonly string[]): DeleteQuery;
+  is(column: string, value: null): DeleteQuery;
+}
+
+/**
+ * The slice of the Supabase client the delete pass uses — narrow enough that a
+ * test can hand it a real implementation and watch exactly which statements are
+ * issued, in which order, with which filters, and narrow enough that the real
+ * client satisfies it directly (no cast anywhere in the chain).
+ */
+export interface DeleteClient {
+  from(table: string): { delete(options: { count: 'exact' }): DeleteQuery };
+}
+
+export interface DeleteOutcome {
+  splitsDeleted: number;
+  transactionsDeleted: number;
+}
+
+export interface DeleteProgress {
+  (stage: 'splits' | 'transactions', done: number, total: number): void;
+}
+
+/**
+ * Delete the file-import rows named by a VERIFIED backup — and nothing else.
+ *
+ * Three things make this safe, and all three are required:
+ *   1. it takes a {@link BackupReceipt}, which only exists once the backup has
+ *      been written and read back, so there is no ordering to get wrong;
+ *   2. every id it deletes must be in that receipt (a caller passing a wider
+ *      list is refused, not trusted);
+ *   3. the DELETE statement itself carries `external_transaction_id IS NULL`,
+ *      so even a receipt built from a wrong query cannot take a bank-feed row —
+ *      the database enforces the rule, not just this process.
+ *
+ * Split lines go first. Their FK to `transactions` is ON DELETE CASCADE, so the
+ * database would remove them anyway; doing it explicitly means the count is
+ * observed rather than assumed.
+ *
+ * NO RETRY, deliberately — unlike the import's write path. A DELETE whose
+ * response is lost may or may not have been applied, and a second attempt on
+ * the same ids reports 0 rows either way, so a retry would have to choose
+ * between claiming success it cannot see and failing a batch that worked.
+ * Instead a dropped connection stops the pass with an accurate count of what
+ * the database confirmed, and the caller resumes by taking a FRESH plan: the
+ * rows that survived are simply the new delete set, and the importer's
+ * provenance makes the re-import idempotent. Recovery through the front door
+ * beats a retry that lies.
+ */
+export async function deleteFileOriginRows(
+  client: DeleteClient,
+  receipt: BackupReceipt,
+  transactionIds: readonly string[],
+  splitIds: readonly string[],
+  onProgress?: DeleteProgress
+): Promise<DeleteOutcome> {
+  const strayTxn = transactionIds.filter(id => !receipt.transactionIds.has(id));
+  if (strayTxn.length) {
+    throw new Error(`refusing to delete ${strayTxn.length} transaction(s) that are not in the verified backup (${sample(strayTxn)})`);
+  }
+  const straySplit = splitIds.filter(id => !receipt.splitIds.has(id));
+  if (straySplit.length) {
+    throw new Error(`refusing to delete ${straySplit.length} split line(s) that are not in the verified backup (${sample(straySplit)})`);
+  }
+
+  const removed = (stage: string, outcome: MutationOutcome): number => {
+    if (outcome.error) throw new Error(`${stage}: ${outcome.error.message}`);
+    if (typeof outcome.count !== 'number') {
+      throw new Error(`${stage}: the database did not report how many rows it deleted — refusing to assume.`);
+    }
+    return outcome.count;
+  };
+
+  let splitsDeleted = 0;
+  for (const batch of batched(splitIds)) {
+    const outcome = await client.from('transaction_splits').delete({ count: 'exact' }).in('id', batch);
+    splitsDeleted += removed('deleting split lines', outcome);
+    onProgress?.('splits', splitsDeleted, splitIds.length);
+  }
+
+  let transactionsDeleted = 0;
+  for (const batch of batched(transactionIds)) {
+    // `.is('external_transaction_id', null)` is the guard that matters: it is
+    // evaluated by Postgres, on the row, at the moment of deletion.
+    const outcome = await client.from('transactions').delete({ count: 'exact' })
+      .in('id', batch).is('external_transaction_id', null);
+    transactionsDeleted += removed('deleting transactions', outcome);
+    onProgress?.('transactions', transactionsDeleted, transactionIds.length);
+  }
+
+  return { splitsDeleted, transactionsDeleted };
+}

--- a/src/services/import/msMoney/reimportGuards.ts
+++ b/src/services/import/msMoney/reimportGuards.ts
@@ -16,8 +16,14 @@
  */
 import type { ExistingFeedTransaction } from './feedOverlap';
 
-/** Bumped whenever the plan file's shape changes; apply refuses an older one. */
-export const REIMPORT_PLAN_VERSION = 1;
+/**
+ * Bumped whenever the plan file's shape changes; apply refuses an older one.
+ *
+ * 2 — transfer-leg handover. A version-1 plan was taken when a transfer leg the
+ *     feed already covered was left in place; applying it now would import a
+ *     different set of rows from the one its operator reviewed.
+ */
+export const REIMPORT_PLAN_VERSION = 2;
 
 /** Ids per PostgREST request on the delete pass — small enough to keep the URL well under any proxy's header limit. */
 export const DELETE_BATCH_SIZE = 100;
@@ -103,6 +109,12 @@ export interface PlanBaseline {
   feedTransactionIds: string[];
   /** `mny-txn-…` ids the feed already covers — not re-imported. */
   suppressedSourceIds: string[];
+  /**
+   * `mny-txn-…>feed-uuid` for every transfer leg handed over to a feed row.
+   * The PAIRING is compared, not just the count: the same legs suppressed
+   * against different feed rows would leave the transfers pointing elsewhere.
+   */
+  transferHandovers: string[];
   expectedImportCount: number;
   expectedNetCount: number;
 }
@@ -156,6 +168,7 @@ export function compareToBaseline(baseline: PlanBaseline, live: LivePlanState): 
   lines.push(...diffSets('split lines to delete', baseline.deleteSplitIds, live.deleteSplitIds));
   lines.push(...diffSets('bank-feed rows to keep', baseline.feedTransactionIds, live.feedTransactionIds));
   lines.push(...diffSets('feed-covered source ids', baseline.suppressedSourceIds, live.suppressedSourceIds));
+  lines.push(...diffSets('transfer handovers', baseline.transferHandovers, live.transferHandovers));
   if (baseline.expectedImportCount !== live.expectedImportCount) {
     lines.push(`rows to import changed: ${baseline.expectedImportCount} → ${live.expectedImportCount}`);
   }
@@ -311,6 +324,10 @@ export interface FeedRowInDb {
   date: string;
   amount: string | number;
   description: string | null;
+  /** Carried through so the matcher can refuse to promote a split parent. */
+  is_split?: boolean | null;
+  /** Carried through so a row already in a linked pair is never re-pointed. */
+  linked_transfer_id?: string | null;
 }
 
 /** Case/whitespace-insensitive, exactly as planCloudImport matches accounts. */
@@ -359,6 +376,8 @@ export function mapFeedRowsToSeedNamespace(
       date: feed.date,
       amount: feed.amount,
       description: feed.description ?? '',
+      isSplit: feed.is_split === true,
+      linkedTransferId: feed.linked_transfer_id ?? null,
     });
   }
   return { rows, unmapped, duplicateNames };

--- a/src/services/import/msMoney/transform.test.ts
+++ b/src/services/import/msMoney/transform.test.ts
@@ -135,6 +135,28 @@ describe('transformMsMoneyExport — transactions', () => {
     expect(summary.transactions.splitLines).toBe(4);
   });
 
+  it('files an uncategorised split LINE under Unassigned — never blank, which the schema forbids', () => {
+    // A split child Money left with no category at all. transaction_splits
+    // requires a non-null, non-empty category, so a blank here is not merely
+    // untidy — it is rejected by the database, and the whole import dies.
+    const exp = build();
+    exp.transactions.push(
+      { id: 1030, accountId: 1, date: '2020-09-01', amount: '-50.00', categoryId: null, payeeId: 51, memo: null, ref: null, clearedStatus: 2, linkAccountId: null, role: 'splitParent' },
+      { id: 1031, accountId: 1, date: '2020-09-01', amount: '-20.00', categoryId: 201, payeeId: null, memo: null, ref: null, clearedStatus: 2, linkAccountId: null, role: 'splitChild', splitParentId: 1030 },
+      { id: 1032, accountId: 1, date: '2020-09-01', amount: '-30.00', categoryId: null, payeeId: null, memo: null, ref: null, clearedStatus: 2, linkAccountId: null, role: 'splitChild', splitParentId: 1030 },
+    );
+
+    const { transactionSplits } = transformMsMoneyExport(exp, NOW);
+    const lines = transactionSplits.filter(s => s.transactionId === 'mny-txn-1030');
+
+    expect(lines).toHaveLength(2);
+    expect(lines.map(l => l.category)).toEqual(['mny-cat-201', 'mny-unassigned']);
+    // No split line anywhere may be blank.
+    expect(transactionSplits.filter(s => !String(s.category ?? '').trim())).toHaveLength(0);
+    // The money still adds up — routing to Unassigned must not alter amounts.
+    expect(lines.reduce((s, l) => s + l.amount, 0)).toBe(-50);
+  });
+
   it('imports a PARTIAL split as a split whose lines (incl. an Unassigned remainder) sum to the exact total', () => {
     const { transactions, transactionSplits, categories } = transformMsMoneyExport(build(), NOW);
     const parent = transactions.find(x => x.id === 'mny-txn-1020')!;

--- a/src/services/import/msMoney/transform.test.ts
+++ b/src/services/import/msMoney/transform.test.ts
@@ -218,6 +218,77 @@ describe('transformMsMoneyExport — transactions', () => {
   });
 });
 
+describe('transformMsMoneyExport — no-duplication invariants', () => {
+  // These lock the properties a duplicated-rows investigation (2026-07-22)
+  // checked the transform against. Money stores one transfer as TWO TRN rows,
+  // one in each account; the failure mode worth guarding is either leg landing
+  // in the same account twice, or any source row being emitted more than once.
+
+  it('emits exactly one transaction per source row and never repeats an id', () => {
+    const exp = build();
+    const { transactions } = transformMsMoneyExport(exp, NOW);
+    const emitted = exp.transactions.filter(t => t.role !== 'splitChild');
+    expect(transactions).toHaveLength(emitted.length);
+    expect(new Set(transactions.map(t => t.id)).size).toBe(transactions.length);
+    // Every emitted id traces back to exactly one Money htrn.
+    expect(transactions.map(t => t.id).sort()).toEqual(emitted.map(t => `mny-txn-${t.id}`).sort());
+  });
+
+  it('puts the two legs of a transfer in DIFFERENT accounts — never both in one', () => {
+    const { transactions } = transformMsMoneyExport(build(), NOW);
+    const byId = new Map(transactions.map(t => [t.id, t]));
+    const legs = transactions.filter(t => t.type === 'transfer');
+    expect(legs.length).toBeGreaterThan(0);
+    for (const leg of legs) {
+      const partner = byId.get(leg.linkedTransferId as string)!;
+      expect(partner).toBeDefined();
+      // Same-account pairing would double-count the transfer inside one ledger.
+      expect(partner.accountId).not.toBe(leg.accountId);
+      // A leg never points at its own account either.
+      expect(leg.transferAccountId).not.toBe(leg.accountId);
+      expect(partner.linkedTransferId).toBe(leg.id);
+    }
+  });
+
+  it('keeps two genuinely identical Money rows as two transactions', () => {
+    // Money's TRN can legitimately hold repeated same-day charges (subscription
+    // batches, standing orders). They share account/date/amount/payee and differ
+    // only by htrn — collapsing them would silently delete real money.
+    const exp = build({
+      transactions: [
+        { id: 5000, accountId: 1, date: '2021-03-01', amount: '-7.99', categoryId: 201, payeeId: 50, memo: null, ref: null, clearedStatus: 2, linkAccountId: null, role: 'standalone' },
+        { id: 5001, accountId: 1, date: '2021-03-01', amount: '-7.99', categoryId: 201, payeeId: 50, memo: null, ref: null, clearedStatus: 2, linkAccountId: null, role: 'standalone' },
+      ],
+    });
+    const { transactions } = transformMsMoneyExport(exp, NOW);
+    expect(transactions).toHaveLength(2);
+    expect(transactions.map(t => t.id)).toEqual(['mny-txn-5000', 'mny-txn-5001']);
+    expect(transactions.reduce((s, t) => s + t.amount, 0)).toBeCloseTo(-15.98, 2);
+  });
+
+  it('keeps two identical transfers as two independent, correctly-paired legs', () => {
+    // Two same-day transfers of the same amount between the same accounts:
+    // four TRN rows, two pairs. Each leg must pair with its OWN partner.
+    const exp = build({
+      transactions: [
+        { id: 6000, accountId: 1, date: '2021-04-01', amount: '-250.00', categoryId: null, payeeId: null, memo: null, ref: null, clearedStatus: 0, linkAccountId: 3, role: 'transfer', transferPairTxnId: 6002 },
+        { id: 6001, accountId: 1, date: '2021-04-01', amount: '-250.00', categoryId: null, payeeId: null, memo: null, ref: null, clearedStatus: 0, linkAccountId: 3, role: 'transfer', transferPairTxnId: 6003 },
+        { id: 6002, accountId: 3, date: '2021-04-01', amount: '250.00', categoryId: null, payeeId: null, memo: null, ref: null, clearedStatus: 0, linkAccountId: 1, role: 'transfer', transferPairTxnId: 6000 },
+        { id: 6003, accountId: 3, date: '2021-04-01', amount: '250.00', categoryId: null, payeeId: null, memo: null, ref: null, clearedStatus: 0, linkAccountId: 1, role: 'transfer', transferPairTxnId: 6001 },
+      ],
+    });
+    const { transactions } = transformMsMoneyExport(exp, NOW);
+    expect(transactions).toHaveLength(4);
+    // Two legs per account, not four in one.
+    expect(transactions.filter(t => t.accountId === 'mny-acct-1')).toHaveLength(2);
+    expect(transactions.filter(t => t.accountId === 'mny-acct-3')).toHaveLength(2);
+    expect(transactions.find(t => t.id === 'mny-txn-6000')!.linkedTransferId).toBe('mny-txn-6002');
+    expect(transactions.find(t => t.id === 'mny-txn-6001')!.linkedTransferId).toBe('mny-txn-6003');
+    // Both accounts net to zero against each other.
+    expect(transactions.reduce((s, t) => s + t.amount, 0)).toBe(0);
+  });
+});
+
 describe('transformMsMoneyExport — investment cash pairing (hacctRel)', () => {
   const invAccounts = [
     { id: 10, name: 'Rathbones - Share ISA', moneyType: 'investment', relatedAccountId: 11, currencyCode: 'GBP', openingBalance: '0', reconstructedBalance: '0', closed: false, openDate: null, closeDate: null, comment: null },

--- a/src/services/import/msMoney/transform.ts
+++ b/src/services/import/msMoney/transform.ts
@@ -268,6 +268,7 @@ function transformTransactions(
   let remainderLines = 0;    // "Unassigned" lines added to genuinely-partial splits
   let signFlipped = 0;       // liability-account splits with inverted child signs
   let splitLegTransfers = 0; // transfer legs whose partner is a line inside a split
+  let zeroLines = 0;         // split lines Money recorded as worth nothing
 
   const resolveCategory = (categoryId: number | null): string =>
     categoryId != null && emittedCatIds.has(categoryId) ? catId(categoryId) : '';
@@ -296,10 +297,20 @@ function transformTransactions(
 
   // A split LINE's category: a transfer line → the destination account's
   // To/From category; otherwise its own mapped category.
-  const lineCategory = (k: MnyTransaction): string =>
-    k.isTransferLine && k.linkAccountId != null
-      ? (toFromByAccount.get(k.linkAccountId) ?? '')
-      : resolveCategory(k.categoryId);
+  //
+  // Unlike a transaction, a split line may NOT be blank — transaction_splits
+  // requires a non-null, non-empty category, and rightly so: a blank line in a
+  // split is money that belongs to no category yet still has to sum to the
+  // parent total. Money leaves 128 of these uncategorised, so they land in the
+  // same "Unassigned (MS Money import)" bucket the partial-remainder lines use,
+  // where they are visible and re-categorisable rather than silently blank.
+  const lineCategory = (k: MnyTransaction): string => {
+    const resolved =
+      k.isTransferLine && k.linkAccountId != null
+        ? (toFromByAccount.get(k.linkAccountId) ?? '')
+        : resolveCategory(k.categoryId);
+    return resolved.trim() ? resolved : UNASSIGNED_CAT_ID;
+  };
 
   for (const t of exp.transactions) {
     if (t.role === 'splitChild') continue; // consumed by their parent below
@@ -361,6 +372,14 @@ function transformTransactions(
 
       let seq = 0;
       kids.forEach((k, i) => {
+        // Money sometimes records a split line worth nothing at all. It moves no
+        // money, the schema forbids it (transaction_splits_amount_nonzero), and
+        // dropping it cannot change what the split sums to — adding zero never
+        // did. Counted, not silently swallowed.
+        if (childAmounts[i].isZero()) {
+          zeroLines++;
+          return;
+        }
         // A transfer line links to its counterpart transaction — but only when
         // that counterpart is a real top-level row (never another split line).
         const isLinkedLeg =
@@ -433,6 +452,11 @@ function transformTransactions(
   if (splitLegTransfers > 0) {
     simplifications.push(
       `${splitLegTransfers} transfer(s) whose counterpart is a line inside a split are fully linked — the split line and the opposite transaction reference each other bidirectionally.`
+    );
+  }
+  if (zeroLines > 0) {
+    simplifications.push(
+      `${zeroLines} split line(s) worth £0.00 were dropped — they move no money, so every split still sums to its exact total.`
     );
   }
 

--- a/src/test/supabase/helpers.ts
+++ b/src/test/supabase/helpers.ts
@@ -25,11 +25,46 @@ export async function ensureProfile() {
   return data;
 }
 
+/**
+ * Remove the fixture user and everything it owns.
+ *
+ * This runs against a REAL database — the same one that holds real accounts —
+ * so a delete that quietly fails leaves a synthetic user, account and
+ * transactions sitting in production for good. That is exactly what happened
+ * on 2026-07-20: the residue was found three days later during an unrelated
+ * audit, because the three deletes below ignored their errors. Each one is now
+ * checked, and the tables are re-read to confirm the rows are actually gone.
+ */
 export async function cleanupProfile(userId: string) {
   if (!supabaseService) return;
-  await supabaseService.from('transactions').delete().eq('user_id', userId);
-  await supabaseService.from('accounts').delete().eq('user_id', userId);
-  await supabaseService.from('users').delete().eq('id', userId);
+
+  for (const [table, column] of [
+    ['transactions', 'user_id'],
+    ['accounts', 'user_id'],
+    ['users', 'id'],
+  ] as const) {
+    const { error } = await supabaseService.from(table).delete().eq(column, userId);
+    if (error) {
+      throw new Error(`[supabase-smoke] failed to clean up ${table} for ${userId}: ${error.message}`);
+    }
+  }
+
+  for (const [table, column] of [
+    ['transactions', 'user_id'],
+    ['accounts', 'user_id'],
+    ['users', 'id'],
+  ] as const) {
+    const { data, error } = await supabaseService.from(table).select('id').eq(column, userId);
+    if (error) {
+      throw new Error(`[supabase-smoke] could not verify ${table} cleanup for ${userId}: ${error.message}`);
+    }
+    if ((data ?? []).length > 0) {
+      throw new Error(
+        `[supabase-smoke] ${(data ?? []).length} row(s) survived cleanup in ${table} for ${userId} — ` +
+        'left behind in a real database. Remove them before this suite is trusted again.'
+      );
+    }
+  }
 }
 
 export async function createAccount(userId: string) {

--- a/src/utils/accountBalanceReport.test.ts
+++ b/src/utils/accountBalanceReport.test.ts
@@ -1,0 +1,124 @@
+import { describe, it, expect } from 'vitest';
+import { buildAccountBalanceReport } from './accountBalanceReport';
+import type { Account, Transaction } from '../types';
+
+/** Synthetic fixtures only — no real accounts or amounts in this repo. */
+const account = (over: Partial<Account> & Pick<Account, 'id' | 'name' | 'type'>): Account => ({
+  balance: 0,
+  currency: 'GBP',
+  lastUpdated: new Date(2026, 0, 1),
+  openingBalance: 0,
+  ...over,
+});
+
+const txn = (over: Partial<Transaction> & Pick<Transaction, 'id' | 'amount' | 'date' | 'accountId'>): Transaction => ({
+  description: 'synthetic row',
+  category: 'cat-x',
+  type: 'expense',
+  ...over,
+});
+
+const ACCOUNTS: Account[] = [
+  account({ id: 'acc-current', name: 'Test Current', type: 'current', openingBalance: 100 }),
+  account({ id: 'acc-card', name: 'Test Card', type: 'credit', openingBalance: 0 }),
+];
+
+const RANGE = { from: new Date(2026, 1, 1), to: new Date(2026, 1, 28, 23, 59, 59, 999) };
+
+describe('buildAccountBalanceReport', () => {
+  it('separates history before the period from movement inside it', () => {
+    const report = buildAccountBalanceReport(
+      ACCOUNTS,
+      [
+        txn({ id: 'b1', amount: 50, date: new Date(2026, 0, 15), accountId: 'acc-current', type: 'income' }),
+        txn({ id: 'i1', amount: -30, date: new Date(2026, 1, 10), accountId: 'acc-current' }),
+        txn({ id: 'i2', amount: 20, date: new Date(2026, 1, 12), accountId: 'acc-current', type: 'income' }),
+        // After the window — not this report's business.
+        txn({ id: 'a1', amount: -999, date: new Date(2026, 2, 1), accountId: 'acc-current' }),
+      ],
+      RANGE
+    );
+
+    const row = report.rows.find(r => r.accountId === 'acc-current');
+    expect(row).toMatchObject({
+      opening: 150,
+      moneyIn: 20,
+      moneyOut: 30,
+      change: -10,
+      closing: 140,
+      count: 2,
+    });
+  });
+
+  it('reads the whole history as the period when the window is open-started', () => {
+    const report = buildAccountBalanceReport(
+      ACCOUNTS,
+      [txn({ id: 'b1', amount: 50, date: new Date(2026, 0, 15), accountId: 'acc-current', type: 'income' })],
+      { from: null, to: null },
+      new Date(2026, 1, 20)
+    );
+
+    const row = report.rows.find(r => r.accountId === 'acc-current');
+    expect(row).toMatchObject({ opening: 100, moneyIn: 50, closing: 150, count: 1 });
+  });
+
+  it('counts a negative balance as a liability whatever the account type says', () => {
+    const report = buildAccountBalanceReport(
+      ACCOUNTS,
+      [txn({ id: 'i1', amount: -60, date: new Date(2026, 1, 10), accountId: 'acc-card' })],
+      RANGE
+    );
+
+    expect(report.assets).toBe(100);
+    expect(report.liabilities).toBe(60);
+    expect(report.netWorth).toBe(40);
+    expect(report.openingNetWorth).toBe(100);
+    expect(report.change).toBe(-60);
+  });
+
+  it('groups accounts by type in statement order, with subtotals', () => {
+    const report = buildAccountBalanceReport(
+      [
+        ...ACCOUNTS,
+        account({ id: 'acc-savings', name: 'Test Savings', type: 'savings', openingBalance: 500 }),
+      ],
+      [],
+      RANGE
+    );
+
+    expect(report.groups.map(g => g.label)).toEqual(['Current accounts', 'Savings', 'Credit cards']);
+    expect(report.groups[1]).toMatchObject({ closing: 500, change: 0 });
+  });
+
+  it('ignores transactions belonging to accounts outside the report', () => {
+    const report = buildAccountBalanceReport(
+      ACCOUNTS,
+      [txn({ id: 'x1', amount: -999, date: new Date(2026, 1, 10), accountId: 'acc-deleted' })],
+      RANGE
+    );
+
+    expect(report.netWorth).toBe(100);
+    expect(report.rows.every(r => r.count === 0)).toBe(true);
+  });
+
+  it('keeps decimals exact over many small movements', () => {
+    const report = buildAccountBalanceReport(
+      [account({ id: 'acc-current', name: 'Test Current', type: 'current', openingBalance: 0 })],
+      Array.from({ length: 10 }, (_, i) =>
+        txn({ id: `t${i}`, amount: -0.1, date: new Date(2026, 1, 2 + i), accountId: 'acc-current' })
+      ),
+      RANGE
+    );
+
+    expect(report.rows[0].moneyOut).toBe(1);
+    expect(report.rows[0].closing).toBe(-1);
+  });
+
+  it('states the closing date as the end of the window', () => {
+    const report = buildAccountBalanceReport(ACCOUNTS, [], RANGE);
+    expect(report.asOf).toEqual(RANGE.to);
+
+    const now = new Date(2026, 5, 6);
+    expect(buildAccountBalanceReport(ACCOUNTS, [], { from: null, to: null }, now).asOf).toEqual(now);
+  });
+});

--- a/src/utils/accountBalanceReport.ts
+++ b/src/utils/accountBalanceReport.ts
@@ -1,0 +1,201 @@
+import type { Account, Transaction } from '../types';
+import type { PeriodRange } from '../hooks/usePeriod';
+import { toDecimal } from './decimal';
+
+/**
+ * "Account balances" and "Net worth" — the two Microsoft Money statements,
+ * from one set of figures so they can never disagree.
+ *
+ * Every balance is computed from first principles, exactly as the net-worth
+ * chart does it: opening balance + cumulative transactions, Decimal
+ * throughout. The stored `account.balance` is deliberately NOT used — it is a
+ * cached figure, and a report that quietly mixed cached and computed money
+ * would be impossible to reconcile.
+ *
+ * Assets vs liabilities follow the BALANCE's sign, not the account's type
+ * (same rule as `buildNetWorthSnapshots`), so an overdrawn current account
+ * counts as a liability while it is overdrawn.
+ */
+
+export interface AccountBalanceRow {
+  accountId: string;
+  name: string;
+  type: Account['type'];
+  currency: string;
+  /** Balance the moment the period opened (all history before it). */
+  opening: number;
+  /** Money in / out DURING the period (positive magnitudes). */
+  moneyIn: number;
+  moneyOut: number;
+  /** moneyIn − moneyOut. */
+  change: number;
+  /** Balance at the end of the period. */
+  closing: number;
+  /** Transactions inside the period. */
+  count: number;
+}
+
+export interface AccountBalanceGroup {
+  /** Stable key for the group (an account type). */
+  key: string;
+  label: string;
+  rows: AccountBalanceRow[];
+  opening: number;
+  change: number;
+  closing: number;
+}
+
+export interface AccountBalanceReport {
+  rows: AccountBalanceRow[];
+  groups: AccountBalanceGroup[];
+  /** Sum of positive closing balances. */
+  assets: number;
+  /** Sum of negative closing balances, as a positive magnitude. */
+  liabilities: number;
+  netWorth: number;
+  /** Net worth the moment the period opened, and the move since. */
+  openingNetWorth: number;
+  change: number;
+  /** The date the closing balances are stated at. */
+  asOf: Date;
+}
+
+/** Presentation order and wording for account types. */
+const TYPE_LABELS: Array<{ key: Account['type']; label: string }> = [
+  { key: 'current', label: 'Current accounts' },
+  { key: 'checking', label: 'Current accounts' },
+  { key: 'savings', label: 'Savings' },
+  { key: 'investment', label: 'Investments' },
+  { key: 'asset', label: 'Assets' },
+  { key: 'assets', label: 'Assets' },
+  { key: 'credit', label: 'Credit cards' },
+  { key: 'loan', label: 'Loans' },
+  { key: 'mortgage', label: 'Mortgages' },
+  { key: 'liability', label: 'Liabilities' },
+  { key: 'other', label: 'Other' },
+];
+
+const labelOfType = (type: Account['type']): string =>
+  TYPE_LABELS.find(entry => entry.key === type)?.label ?? 'Other';
+
+const orderOfLabel = (label: string): number => {
+  const index = TYPE_LABELS.findIndex(entry => entry.label === label);
+  return index === -1 ? TYPE_LABELS.length : index;
+};
+
+interface Accumulator {
+  opening: ReturnType<typeof toDecimal>;
+  moneyIn: ReturnType<typeof toDecimal>;
+  moneyOut: ReturnType<typeof toDecimal>;
+  count: number;
+}
+
+export function buildAccountBalanceReport(
+  accounts: Account[],
+  transactions: Transaction[],
+  range: PeriodRange,
+  now: Date = new Date()
+): AccountBalanceReport {
+  const asOf = range.to ?? now;
+  const fromTime = range.from ? range.from.getTime() : null;
+  const toTime = asOf.getTime();
+
+  const totals = new Map<string, Accumulator>();
+  for (const account of accounts) {
+    totals.set(account.id, {
+      opening: toDecimal(account.openingBalance ?? 0),
+      moneyIn: toDecimal(0),
+      moneyOut: toDecimal(0),
+      count: 0,
+    });
+  }
+
+  // One pass: everything before the window seeds the opening balance,
+  // everything inside it is the period's movement, everything after is not
+  // this report's business.
+  for (const transaction of transactions) {
+    const accumulator = totals.get(transaction.accountId);
+    if (!accumulator) continue;
+    const time = new Date(transaction.date).getTime();
+    if (Number.isNaN(time) || time > toTime) continue;
+    const amount = toDecimal(transaction.amount);
+    if (fromTime !== null && time < fromTime) {
+      accumulator.opening = accumulator.opening.plus(amount);
+      continue;
+    }
+    accumulator.count += 1;
+    if (amount.greaterThanOrEqualTo(0)) accumulator.moneyIn = accumulator.moneyIn.plus(amount);
+    else accumulator.moneyOut = accumulator.moneyOut.plus(amount.abs());
+  }
+
+  const rows: AccountBalanceRow[] = accounts.map(account => {
+    const accumulator = totals.get(account.id) ?? {
+      opening: toDecimal(account.openingBalance ?? 0),
+      moneyIn: toDecimal(0),
+      moneyOut: toDecimal(0),
+      count: 0,
+    };
+    const change = accumulator.moneyIn.minus(accumulator.moneyOut);
+    return {
+      accountId: account.id,
+      name: account.name,
+      type: account.type,
+      currency: account.currency,
+      opening: accumulator.opening.toNumber(),
+      moneyIn: accumulator.moneyIn.toNumber(),
+      moneyOut: accumulator.moneyOut.toNumber(),
+      change: change.toNumber(),
+      closing: accumulator.opening.plus(change).toNumber(),
+      count: accumulator.count,
+    };
+  });
+
+  const byLabel = new Map<string, AccountBalanceRow[]>();
+  for (const row of rows) {
+    const label = labelOfType(row.type);
+    const list = byLabel.get(label);
+    if (list) list.push(row);
+    else byLabel.set(label, [row]);
+  }
+
+  const groups: AccountBalanceGroup[] = [...byLabel.entries()]
+    .map(([label, groupRows]) => {
+      const sorted = [...groupRows].sort((a, b) =>
+        a.name.localeCompare(b.name, undefined, { sensitivity: 'base' })
+      );
+      const sum = (pick: (row: AccountBalanceRow) => number): number =>
+        sorted.reduce((acc, row) => acc.plus(toDecimal(pick(row))), toDecimal(0)).toNumber();
+      return {
+        key: label,
+        label,
+        rows: sorted,
+        opening: sum(row => row.opening),
+        change: sum(row => row.change),
+        closing: sum(row => row.closing),
+      };
+    })
+    .sort((a, b) => orderOfLabel(a.label) - orderOfLabel(b.label));
+
+  let assets = toDecimal(0);
+  let liabilities = toDecimal(0);
+  let openingNetWorth = toDecimal(0);
+  let netWorth = toDecimal(0);
+  for (const row of rows) {
+    const closing = toDecimal(row.closing);
+    if (closing.greaterThan(0)) assets = assets.plus(closing);
+    else liabilities = liabilities.plus(closing.abs());
+    netWorth = netWorth.plus(closing);
+    openingNetWorth = openingNetWorth.plus(toDecimal(row.opening));
+  }
+
+  return {
+    rows,
+    groups,
+    assets: assets.toNumber(),
+    liabilities: liabilities.toNumber(),
+    netWorth: netWorth.toNumber(),
+    openingNetWorth: openingNetWorth.toNumber(),
+    change: netWorth.minus(openingNetWorth).toNumber(),
+    asOf,
+  };
+}

--- a/src/utils/categoryNames.test.ts
+++ b/src/utils/categoryNames.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from 'vitest';
+import { buildCategoryNameLookup } from './categoryNames';
+import type { Category } from '../types';
+
+const CATEGORIES: Category[] = [
+  { id: 'type-expense', name: 'Expense', type: 'expense', level: 'type', isSystem: true },
+  { id: 'grp-food', name: 'Food Related Costs', type: 'expense', level: 'sub', parentId: 'type-expense' },
+  { id: 'cat-groceries', name: 'Groceries', type: 'expense', level: 'detail', parentId: 'grp-food' },
+];
+
+describe('buildCategoryNameLookup', () => {
+  const name = buildCategoryNameLookup(CATEGORIES);
+
+  it('qualifies a detail category with its parent', () => {
+    expect(name('cat-groceries')).toBe('Food Related Costs : Groceries');
+  });
+
+  it('never prefixes the top-level type node', () => {
+    expect(name('grp-food')).toBe('Food Related Costs');
+  });
+
+  it('never leaks a raw id for a missing or dangling category', () => {
+    expect(name('1bcb1126-66e4-48e5-960e-251f917172bd')).toBe('Uncategorised');
+    expect(name('')).toBe('Uncategorised');
+    expect(name(undefined)).toBe('Uncategorised');
+    expect(name(null)).toBe('Uncategorised');
+  });
+});

--- a/src/utils/categoryNames.ts
+++ b/src/utils/categoryNames.ts
@@ -1,0 +1,24 @@
+import type { Category } from '../types';
+
+/**
+ * One definition of how a category is NAMED for display: "Parent : Child"
+ * (the Money convention used across this app), with "Uncategorised" for a
+ * missing or dangling id.
+ *
+ * A raw category id must never reach a screen, a PDF or a CSV — ids are
+ * UUIDs and mean nothing to the user. Resolve through this lookup instead of
+ * printing `transaction.category`.
+ */
+export function buildCategoryNameLookup(
+  categories: Category[]
+): (id: string | null | undefined) => string {
+  const byId = new Map(categories.map(c => [c.id, c]));
+  return (id: string | null | undefined): string => {
+    if (!id) return 'Uncategorised';
+    const category = byId.get(id);
+    if (!category) return 'Uncategorised';
+    const parent = category.parentId ? byId.get(category.parentId) : undefined;
+    // The top 'type' nodes ("Income"/"Expense") add nothing to a label.
+    return parent && parent.level !== 'type' ? `${parent.name} : ${category.name}` : category.name;
+  };
+}

--- a/src/utils/csvExport.ts
+++ b/src/utils/csvExport.ts
@@ -1,18 +1,25 @@
-import type { Transaction, Account } from '../types';
+import type { Transaction, Account, Category } from '../types';
 import type { DecimalTransaction, DecimalAccount } from '../types/decimal-types';
 import { toDecimal } from './decimal';
 import { formatDecimal } from './decimal-format';
+import { buildCategoryNameLookup } from './categoryNames';
 
 /**
  * Export transactions to CSV format
  * Handles both regular and decimal transactions
+ *
+ * Pass `categories` so the Category column carries the human name
+ * ("Parent : Child") — a raw category id is a UUID and means nothing in a
+ * spreadsheet. Without it the stored value is written through unchanged.
  */
 export function exportTransactionsToCSV(
   transactions: Transaction[] | DecimalTransaction[],
-  accounts: Account[] | DecimalAccount[]
+  accounts: Account[] | DecimalAccount[],
+  categories?: Category[]
 ): string {
   const headers = ['Date', 'Description', 'Category', 'Type', 'Amount', 'Account', 'Tags', 'Notes', 'Cleared'];
-  
+  const categoryName = categories ? buildCategoryNameLookup(categories) : null;
+
   const rows = transactions.map(t => {
     const account = accounts.find(a => a.id === t.accountId);
     const amountDecimal = typeof t.amount === 'number' ? toDecimal(t.amount) : toDecimal(t.amount);
@@ -20,7 +27,7 @@ export function exportTransactionsToCSV(
     return [
       new Date(t.date).toISOString().split('T')[0], // YYYY-MM-DD format
       t.description,
-      t.category,
+      categoryName ? categoryName(t.category) : t.category,
       t.type,
       formatDecimal(amountDecimal, 2), // Always export with 2 decimal places
       account?.name || 'Unknown',

--- a/src/utils/monthlyCategoryMatrix.test.ts
+++ b/src/utils/monthlyCategoryMatrix.test.ts
@@ -1,0 +1,203 @@
+import { describe, it, expect } from 'vitest';
+import { buildMonthlyCategoryMatrix, monthKeyOf } from './monthlyCategoryMatrix';
+import { computeIncomeExpense } from './incomeExpense';
+import type { Category, Transaction } from '../types';
+import type { PeriodRange } from '../hooks/usePeriod';
+
+/**
+ * Synthetic tree only — no real payees, amounts or account names ever appear
+ * in this repo's fixtures.
+ */
+const CATEGORIES: Category[] = [
+  { id: 'type-income', name: 'Income', type: 'income', level: 'type', isSystem: true },
+  { id: 'type-expense', name: 'Expense', type: 'expense', level: 'type', isSystem: true },
+  { id: 'type-transfer', name: 'Transfer', type: 'both', level: 'type', isSystem: true },
+
+  // Income group with detail children
+  { id: 'grp-invest', name: 'Investment Income', type: 'income', level: 'sub', parentId: 'type-income' },
+  { id: 'cat-dividends', name: 'Dividends', type: 'income', level: 'detail', parentId: 'grp-invest' },
+  { id: 'cat-interest', name: 'Interest', type: 'income', level: 'detail', parentId: 'grp-invest' },
+  // Income group posted to directly (no children)
+  { id: 'grp-salary', name: 'Salary', type: 'income', level: 'sub', parentId: 'type-income' },
+
+  // Expense groups
+  { id: 'grp-food', name: 'Food Related Costs', type: 'expense', level: 'sub', parentId: 'type-expense' },
+  { id: 'cat-groceries', name: 'Groceries', type: 'expense', level: 'detail', parentId: 'grp-food' },
+  { id: 'cat-diningout', name: 'Dining Out', type: 'expense', level: 'detail', parentId: 'grp-food' },
+  { id: 'grp-household', name: 'Household', type: 'expense', level: 'sub', parentId: 'type-expense' },
+  { id: 'cat-repairs', name: 'Repairs', type: 'expense', level: 'detail', parentId: 'grp-household' },
+
+  { id: 'tofrom-savings', name: 'To/From Savings', type: 'both', level: 'detail', parentId: 'type-transfer', isTransferCategory: true, accountId: 'acc-2' },
+];
+
+const txn = (over: Partial<Transaction> & { id: string }): Transaction => ({
+  date: new Date(2026, 0, 15),
+  amount: -10,
+  description: 'synthetic row',
+  category: '',
+  accountId: 'acc-1',
+  type: 'expense',
+  ...over,
+});
+
+/** Jan–Mar 2026 inclusive. */
+const RANGE: PeriodRange = { from: new Date(2026, 0, 1), to: new Date(2026, 2, 31, 23, 59, 59, 999) };
+
+const build = (transactions: Transaction[], range: PeriodRange = RANGE) => {
+  const flows = computeIncomeExpense(transactions, [], CATEGORIES, {
+    from: range.from ?? undefined,
+    to: range.to ?? undefined,
+  });
+  return buildMonthlyCategoryMatrix(flows.incomeRows, flows.expenseRows, CATEGORIES, range, {
+    now: new Date(2026, 2, 20),
+  });
+};
+
+describe('monthKeyOf', () => {
+  it('keys by LOCAL month, matching the period picker windows', () => {
+    expect(monthKeyOf(new Date(2026, 6, 1, 0, 30))).toBe('2026-07');
+    expect(monthKeyOf(new Date(2026, 11, 31, 23, 30))).toBe('2026-12');
+  });
+});
+
+describe('buildMonthlyCategoryMatrix', () => {
+  it('lays the period out as columns, including months with no activity', () => {
+    const matrix = build([
+      txn({ id: 'a', date: new Date(2026, 0, 10), amount: -40, category: 'cat-groceries' }),
+      txn({ id: 'b', date: new Date(2026, 2, 10), amount: -25, category: 'cat-groceries' }),
+    ]);
+
+    expect(matrix.months.map(m => m.key)).toEqual(['2026-01', '2026-02', '2026-03']);
+    const food = matrix.expenseGroups.find(g => g.groupId === 'grp-food');
+    // February is empty but still a column, and still a zero — never a gap.
+    expect(food?.values).toEqual([40, 0, 25]);
+    expect(matrix.expenseValues).toEqual([40, 0, 25]);
+    expect(matrix.expenseTotal).toBe(65);
+  });
+
+  it('groups rows by the user\'s own tree and subtotals each group', () => {
+    const matrix = build([
+      txn({ id: 'a', date: new Date(2026, 0, 5), amount: -40, category: 'cat-groceries' }),
+      txn({ id: 'b', date: new Date(2026, 0, 9), amount: -15, category: 'cat-diningout' }),
+      txn({ id: 'c', date: new Date(2026, 1, 3), amount: -200, category: 'cat-repairs' }),
+      txn({ id: 'd', date: new Date(2026, 0, 2), amount: 30, type: 'income', category: 'cat-dividends' }),
+      txn({ id: 'e', date: new Date(2026, 0, 2), amount: 5, type: 'income', category: 'cat-interest' }),
+      // Posted straight onto a group that has no children of its own.
+      txn({ id: 'f', date: new Date(2026, 0, 28), amount: 2500, type: 'income', category: 'grp-salary' }),
+    ]);
+
+    expect(matrix.expenseGroups.map(g => g.name)).toEqual(['Food Related Costs', 'Household']);
+    const food = matrix.expenseGroups[0];
+    expect(food.total).toBe(55);
+    expect(food.values).toEqual([55, 0, 0]);
+    expect(food.rows.map(r => [r.name, r.total])).toEqual([['Dining Out', 15], ['Groceries', 40]]);
+    expect(food.categoryIds.sort()).toEqual(['cat-diningout', 'cat-groceries']);
+
+    expect(matrix.incomeGroups.map(g => [g.name, g.total])).toEqual([
+      ['Investment Income', 35],
+      ['Salary', 2500],
+    ]);
+    // A group posted to directly still owns exactly one row: itself.
+    const salary = matrix.incomeGroups[1];
+    expect(salary.rows.map(r => r.categoryId)).toEqual(['grp-salary']);
+  });
+
+  it('nets a refund down instead of inflating income, per month', () => {
+    const matrix = build([
+      txn({ id: 'a', date: new Date(2026, 0, 5), amount: -100, category: 'cat-groceries' }),
+      // Money back IN, filed under the expense category: an expense credit.
+      txn({ id: 'b', date: new Date(2026, 0, 20), amount: 40, type: 'income', category: 'cat-groceries' }),
+    ]);
+
+    expect(matrix.expenseValues).toEqual([60, 0, 0]);
+    expect(matrix.incomeTotal).toBe(0);
+    expect(matrix.incomeGroups).toEqual([]);
+  });
+
+  it('computes Income less Expenses per month and for the period', () => {
+    const matrix = build([
+      txn({ id: 'a', date: new Date(2026, 0, 1), amount: 2000, type: 'income', category: 'grp-salary' }),
+      txn({ id: 'b', date: new Date(2026, 0, 15), amount: -750.55, category: 'cat-repairs' }),
+      txn({ id: 'c', date: new Date(2026, 1, 1), amount: 2000, type: 'income', category: 'grp-salary' }),
+      txn({ id: 'd', date: new Date(2026, 1, 15), amount: -2400.45, category: 'cat-repairs' }),
+    ]);
+
+    expect(matrix.incomeValues).toEqual([2000, 2000, 0]);
+    expect(matrix.expenseValues).toEqual([750.55, 2400.45, 0]);
+    expect(matrix.netValues).toEqual([1249.45, -400.45, 0]);
+    expect(matrix.netTotal).toBe(849);
+    expect(matrix.incomeTotal - matrix.expenseTotal).toBeCloseTo(matrix.netTotal, 10);
+  });
+
+  it('excludes uncategorised rows and rows with a dangling category id', () => {
+    const matrix = build([
+      txn({ id: 'a', date: new Date(2026, 0, 5), amount: -40, category: 'cat-groceries' }),
+      txn({ id: 'b', date: new Date(2026, 0, 6), amount: -9999, category: '' }),
+      txn({ id: 'c', date: new Date(2026, 0, 7), amount: 250000, type: 'income', category: 'deleted-category-id' }),
+    ]);
+
+    expect(matrix.expenseTotal).toBe(40);
+    expect(matrix.incomeTotal).toBe(0);
+    expect(matrix.expenseGroups.flatMap(g => g.categoryIds)).toEqual(['cat-groceries']);
+  });
+
+  it('ignores transfers, by type and by transfer category', () => {
+    const matrix = build([
+      txn({ id: 'a', date: new Date(2026, 0, 5), amount: -40, category: 'cat-groceries' }),
+      txn({ id: 'b', date: new Date(2026, 0, 6), amount: -500, type: 'transfer', category: 'tofrom-savings' }),
+      // A transfer category filed on an income-direction row is still a transfer.
+      txn({ id: 'c', date: new Date(2026, 0, 7), amount: 500, type: 'income', category: 'tofrom-savings' }),
+    ]);
+
+    expect(matrix.expenseTotal).toBe(40);
+    expect(matrix.incomeTotal).toBe(0);
+    expect(matrix.netTotal).toBe(-40);
+  });
+
+  it('drops categories with no activity anywhere in the period', () => {
+    const matrix = build([
+      txn({ id: 'a', date: new Date(2026, 0, 5), amount: -40, category: 'cat-groceries' }),
+    ]);
+
+    expect(matrix.expenseGroups).toHaveLength(1);
+    expect(matrix.expenseGroups[0].rows.map(r => r.name)).toEqual(['Groceries']);
+  });
+
+  it('caps the columns on a very long window and says how many are hidden, with Total still covering the lot', () => {
+    const range: PeriodRange = { from: new Date(2024, 0, 1), to: new Date(2026, 2, 31, 23, 59, 59, 999) };
+    const flows = computeIncomeExpense(
+      [
+        txn({ id: 'old', date: new Date(2024, 0, 15), amount: -100, category: 'cat-groceries' }),
+        txn({ id: 'new', date: new Date(2026, 2, 15), amount: -25, category: 'cat-groceries' }),
+      ],
+      [],
+      CATEGORIES,
+      { from: range.from ?? undefined, to: range.to ?? undefined }
+    );
+    const matrix = buildMonthlyCategoryMatrix(flows.incomeRows, flows.expenseRows, CATEGORIES, range, {
+      now: new Date(2026, 2, 20),
+      maxMonths: 6,
+    });
+
+    expect(matrix.months).toHaveLength(6);
+    expect(matrix.omittedMonths).toBe(21); // Jan 2024 – Mar 2026 is 27 months
+    expect(matrix.months[0].key).toBe('2025-10');
+    // The hidden January 2024 spend shows in Total but in no visible column.
+    expect(matrix.expenseTotal).toBe(125);
+    expect(matrix.expenseValues.reduce((a, b) => a + b, 0)).toBe(25);
+  });
+
+  it('an open-ended window runs to today, and an empty period still yields columns', () => {
+    const matrix = build([], { from: new Date(2026, 0, 1), to: null });
+
+    expect(matrix.months.map(m => m.key)).toEqual(['2026-01', '2026-02', '2026-03']);
+    expect(matrix.incomeGroups).toEqual([]);
+    expect(matrix.expenseGroups).toEqual([]);
+    expect(matrix.netTotal).toBe(0);
+  });
+
+  it('labels columns in the UK short form', () => {
+    const matrix = build([]);
+    expect(matrix.months.map(m => m.label)).toEqual(['Jan 26', 'Feb 26', 'Mar 26']);
+  });
+});

--- a/src/utils/monthlyCategoryMatrix.ts
+++ b/src/utils/monthlyCategoryMatrix.ts
@@ -1,0 +1,270 @@
+import type { Category } from '../types';
+import type { PeriodRange } from '../hooks/usePeriod';
+import type { SplitExpandedTransaction } from './transactionSplits';
+import { toDecimal, type DecimalInstance } from './decimal';
+
+/**
+ * "Monthly income and expenses" — the Microsoft Money report, as a
+ * CATEGORY × MONTH matrix.
+ *
+ * Rows are grouped by the user's OWN category tree (the topmost non-'type'
+ * ancestor of each category is the group, so "Food Related Costs" heads its
+ * own detail categories) with a subtotal per group; columns are the months of
+ * the selected period plus a whole-period Total; the footer carries Total
+ * Income, Total Expenses and Income less Expenses.
+ *
+ * Classification is NOT re-implemented here: the caller passes the income and
+ * expense rows produced by `computeIncomeExpense`, so transfers and
+ * uncategorised rows are already excluded and every figure agrees with the
+ * page's summary cards by construction.
+ *
+ * Sign convention (matching the summary cards): income and expense values are
+ * both POSITIVE magnitudes; a credit filed against an expense category (a
+ * refund) nets its cell down and can legitimately make it negative.
+ */
+
+export interface MatrixMonth {
+  /** YYYY-MM — drives drill-in filtering. */
+  key: string;
+  /** Column heading, e.g. "Jul 26". */
+  label: string;
+}
+
+export interface MatrixRow {
+  categoryId: string;
+  /** Leaf category name (the group heading carries the parent). */
+  name: string;
+  /** One value per entry in `months`, same order. */
+  values: number[];
+  /** Whole-period total — covers months the period holds but does not show. */
+  total: number;
+}
+
+export interface MatrixGroup {
+  groupId: string;
+  name: string;
+  /** Every category id feeding this group — the drill-in filter. */
+  categoryIds: string[];
+  rows: MatrixRow[];
+  values: number[];
+  total: number;
+}
+
+export interface MonthlyCategoryMatrix {
+  months: MatrixMonth[];
+  incomeGroups: MatrixGroup[];
+  expenseGroups: MatrixGroup[];
+  incomeValues: number[];
+  incomeTotal: number;
+  expenseValues: number[];
+  expenseTotal: number;
+  /** Income less expenses, per month and for the period. */
+  netValues: number[];
+  netTotal: number;
+  /**
+   * Months inside the selected period that are NOT shown as columns (an
+   * all-time window can span decades). Totals still cover them, so the UI
+   * must say so rather than let the reader assume the columns add up.
+   */
+  omittedMonths: number;
+}
+
+/** Columns rendered at most; the rest of the period folds into Total. */
+export const DEFAULT_MAX_MONTHS = 36;
+
+/** Absolute ceiling on the month walk — a corrupt date can't hang the UI. */
+const MONTH_WALK_LIMIT = 1200;
+
+/**
+ * A date's YYYY-MM in LOCAL time — the same clock `usePeriod` uses to build
+ * its windows, so a transaction can never fall outside the columns of the
+ * period that selected it.
+ */
+export function monthKeyOf(date: Date | string): string {
+  const d = new Date(date);
+  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}`;
+}
+
+function monthLabelOf(key: string): string {
+  const year = Number(key.slice(0, 4));
+  const month = Number(key.slice(5, 7));
+  return new Date(year, month - 1, 1).toLocaleDateString('en-GB', { month: 'short', year: '2-digit' });
+}
+
+/** The group a category belongs to: its topmost ancestor below the type node. */
+function groupCategoryOf(category: Category, byId: ReadonlyMap<string, Category>): Category {
+  let node = category;
+  for (let hops = 0; hops < 16; hops++) {
+    const parent = node.parentId ? byId.get(node.parentId) : undefined;
+    if (!parent || parent.level === 'type' || parent.id === node.id) break;
+    node = parent;
+  }
+  return node;
+}
+
+function zeros(length: number): DecimalInstance[] {
+  return Array.from({ length }, () => toDecimal(0));
+}
+
+interface Bucket {
+  category: Category;
+  values: DecimalInstance[];
+  total: DecimalInstance;
+}
+
+interface GroupBucket extends Bucket {
+  rows: Map<string, Bucket>;
+}
+
+function isEmptyBucket(bucket: Bucket): boolean {
+  return bucket.total.isZero() && bucket.values.every(v => v.isZero());
+}
+
+function buildSide(
+  rows: SplitExpandedTransaction[],
+  byId: ReadonlyMap<string, Category>,
+  monthIndex: ReadonlyMap<string, number>,
+  monthCount: number,
+  bucket: 'income' | 'expense'
+): { groups: MatrixGroup[]; values: number[]; total: DecimalInstance } {
+  const groups = new Map<string, GroupBucket>();
+  const sideValues = zeros(monthCount);
+  let sideTotal = toDecimal(0);
+
+  for (const row of rows) {
+    // The classifier only emits rows with a resolvable category; a row that
+    // somehow lacks one is skipped rather than guessed at.
+    const category = row.category ? byId.get(row.category) : undefined;
+    if (!category) continue;
+
+    // Spending is stored negative — negate so the expense side reads as a
+    // positive magnitude and a refund credit subtracts.
+    const value = bucket === 'income' ? toDecimal(row.amount) : toDecimal(row.amount).negated();
+    const index = monthIndex.get(monthKeyOf(row.date));
+
+    const groupCategory = groupCategoryOf(category, byId);
+    let group = groups.get(groupCategory.id);
+    if (!group) {
+      group = { category: groupCategory, values: zeros(monthCount), total: toDecimal(0), rows: new Map() };
+      groups.set(groupCategory.id, group);
+    }
+    let leaf = group.rows.get(category.id);
+    if (!leaf) {
+      leaf = { category, values: zeros(monthCount), total: toDecimal(0) };
+      group.rows.set(category.id, leaf);
+    }
+
+    group.total = group.total.plus(value);
+    leaf.total = leaf.total.plus(value);
+    sideTotal = sideTotal.plus(value);
+    if (index !== undefined) {
+      group.values[index] = group.values[index].plus(value);
+      leaf.values[index] = leaf.values[index].plus(value);
+      sideValues[index] = sideValues[index].plus(value);
+    }
+  }
+
+  const byName = (a: { name: string }, b: { name: string }): number =>
+    a.name.localeCompare(b.name, undefined, { sensitivity: 'base' });
+
+  const outGroups: MatrixGroup[] = [...groups.values()]
+    .filter(group => !isEmptyBucket(group) || [...group.rows.values()].some(r => !isEmptyBucket(r)))
+    .map(group => ({
+      groupId: group.category.id,
+      name: group.category.name,
+      categoryIds: [...group.rows.keys()],
+      values: group.values.map(v => v.toNumber()),
+      total: group.total.toNumber(),
+      rows: [...group.rows.values()]
+        .filter(leaf => !isEmptyBucket(leaf))
+        .map(leaf => ({
+          categoryId: leaf.category.id,
+          name: leaf.category.name,
+          values: leaf.values.map(v => v.toNumber()),
+          total: leaf.total.toNumber(),
+        }))
+        .sort(byName),
+    }))
+    .sort(byName);
+
+  return { groups: outGroups, values: sideValues.map(v => v.toNumber()), total: sideTotal };
+}
+
+function enumerateMonths(
+  range: PeriodRange,
+  rowSets: SplitExpandedTransaction[][],
+  now: Date,
+  maxMonths: number
+): { months: MatrixMonth[]; omittedMonths: number } {
+  let earliest: number | null = null;
+  let latest: number | null = null;
+  // Only an OPEN end of the window needs the data scanned for its extent.
+  if (!range.from || !range.to) {
+    for (const rows of rowSets) {
+      for (const row of rows) {
+        const time = new Date(row.date).getTime();
+        if (Number.isNaN(time)) continue;
+        if (earliest === null || time < earliest) earliest = time;
+        if (latest === null || time > latest) latest = time;
+      }
+    }
+  }
+
+  const startDate = range.from ?? (earliest !== null ? new Date(earliest) : null);
+  if (!startDate) return { months: [], omittedMonths: 0 };
+  // An open-ended window runs to today, or to the last transaction if the
+  // data runs ahead of it (future-dated rows).
+  const endDate = range.to
+    ?? (latest !== null && latest > now.getTime() ? new Date(latest) : now);
+  if (endDate < startDate) return { months: [], omittedMonths: 0 };
+
+  const keys: string[] = [];
+  const cursor = new Date(startDate.getFullYear(), startDate.getMonth(), 1);
+  const last = new Date(endDate.getFullYear(), endDate.getMonth(), 1);
+  while (cursor <= last && keys.length < MONTH_WALK_LIMIT) {
+    keys.push(monthKeyOf(cursor));
+    cursor.setMonth(cursor.getMonth() + 1);
+  }
+
+  const omittedMonths = Math.max(0, keys.length - maxMonths);
+  // Keep the MOST RECENT months when a window is longer than the cap.
+  return {
+    months: keys.slice(omittedMonths).map(key => ({ key, label: monthLabelOf(key) })),
+    omittedMonths,
+  };
+}
+
+export function buildMonthlyCategoryMatrix(
+  incomeRows: SplitExpandedTransaction[],
+  expenseRows: SplitExpandedTransaction[],
+  categories: Category[],
+  range: PeriodRange,
+  opts: { now?: Date; maxMonths?: number } = {}
+): MonthlyCategoryMatrix {
+  const now = opts.now ?? new Date();
+  const maxMonths = opts.maxMonths ?? DEFAULT_MAX_MONTHS;
+  const byId = new Map(categories.map(c => [c.id, c]));
+
+  const { months, omittedMonths } = enumerateMonths(range, [incomeRows, expenseRows], now, maxMonths);
+  const monthIndex = new Map(months.map((m, i) => [m.key, i]));
+
+  const income = buildSide(incomeRows, byId, monthIndex, months.length, 'income');
+  const expense = buildSide(expenseRows, byId, monthIndex, months.length, 'expense');
+
+  const netValues = months.map((_, i) =>
+    toDecimal(income.values[i]).minus(toDecimal(expense.values[i])).toNumber()
+  );
+
+  return {
+    months,
+    incomeGroups: income.groups,
+    expenseGroups: expense.groups,
+    incomeValues: income.values,
+    incomeTotal: income.total.toNumber(),
+    expenseValues: expense.values,
+    expenseTotal: expense.total.toNumber(),
+    netValues,
+    netTotal: income.total.minus(expense.total).toNumber(),
+    omittedMonths,
+  };
+}

--- a/src/utils/payeeGroups.test.ts
+++ b/src/utils/payeeGroups.test.ts
@@ -7,6 +7,7 @@ const CATEGORIES: Category[] = [
   { id: 'type-expense', name: 'Expense', type: 'expense', level: 'type', isSystem: true },
   { id: 'cat-consumables', name: 'Consumables', type: 'expense', level: 'detail', parentId: 'type-expense' },
   { id: 'cat-repairs', name: 'Repairs', type: 'expense', level: 'detail', parentId: 'type-expense' },
+  { id: 'cat-food', name: 'Food', type: 'expense', level: 'detail', parentId: 'type-expense' },
   { id: 'cat-salary', name: 'Salary', type: 'income', level: 'detail', parentId: 'type-income' },
 ];
 
@@ -61,6 +62,43 @@ describe('buildPayeeGroups', () => {
     expect(amazon.transactionIds).toEqual(['new']);
     expect(amazon.suggestedCategoryId).toBe('cat-consumables');
     expect(amazon.suggestionSupport).toBe(2);
+    // 2 of 3 — support is meaningless without what it was chosen from.
+    expect(amazon.suggestionSampleSize).toBe(3);
+  });
+
+  it('reports the whole sample, so a payee that disagrees with itself can be seen', () => {
+    // A generic description — "ADJUSTMENT" and the like — filed every which
+    // way. The most common category is a plurality of a quarter, and a screen
+    // that applies a category to every row at once must be able to tell that
+    // apart from a shop filed the same way every time.
+    const history = [
+      ...Array.from({ length: 3 }, (_, i) =>
+        txn({ id: `a${i}`, description: 'Adjustment', amount: -10, category: 'cat-consumables', date: new Date('2026-01-01') })),
+      ...Array.from({ length: 2 }, (_, i) =>
+        txn({ id: `b${i}`, description: 'Adjustment', amount: -10, category: 'cat-repairs', date: new Date('2026-02-01') })),
+      ...Array.from({ length: 2 }, (_, i) =>
+        txn({ id: `c${i}`, description: 'Adjustment', amount: -10, category: 'cat-food', date: new Date('2026-03-01') })),
+    ];
+
+    const groups = buildPayeeGroups(
+      [...history, txn({ id: 'new', description: 'Adjustment', amount: -5000 })],
+      CATEGORIES
+    );
+
+    const group = groups.find(g => g.payee === 'ADJUSTMENT' && g.direction === 'expense')!;
+    expect(group.suggestedCategoryId).toBe('cat-consumables');
+    expect(group.suggestionSupport).toBe(3);
+    expect(group.suggestionSampleSize).toBe(7);
+    // 3/7 is a plurality, not a habit — the caller is what decides to trust it.
+    expect((group.suggestionSupport ?? 0) / (group.suggestionSampleSize ?? 1)).toBeLessThan(0.8);
+  });
+
+  it('leaves the sample undefined when the payee has no history at all', () => {
+    const groups = buildPayeeGroups([txn({ id: 'new', description: 'Brand New Shop', amount: -30 })], CATEGORIES);
+
+    const group = groups.find(g => g.payee === 'BRAND NEW SHOP')!;
+    expect(group.suggestedCategoryId).toBeUndefined();
+    expect(group.suggestionSampleSize).toBeUndefined();
   });
 
   it('ties in the history break toward the most recent', () => {

--- a/src/utils/payeeGroups.ts
+++ b/src/utils/payeeGroups.ts
@@ -38,6 +38,17 @@ export interface PayeeGroup {
   /** How many existing rows carry that suggestion. */
   suggestionSupport?: number;
   /**
+   * How many existing rows the suggestion was chosen FROM.
+   *
+   * Support alone cannot be read: "9" means one thing out of 10 filings and
+   * something else entirely out of 36. Measuring the production review band
+   * found the payees with the largest amounts behind them are the generic ones
+   * — "ACCOUNT ADJUSTMENT", "UPDATE ON PORTFOLIO VALUE" — filed a dozen
+   * different ways, where the most common category is a plurality of a quarter
+   * and applying it in bulk would invent data rather than recover it.
+   */
+  suggestionSampleSize?: number;
+  /**
    * The category used MOST RECENTLY for this payee, when it differs from the
    * suggestion — so a deliberate recent change is one click away instead of
    * being buried under an old habit.
@@ -102,6 +113,7 @@ export function buildPayeeGroups(
     const byCategory = history.get(key);
     let suggestedCategoryId: string | undefined;
     let suggestionSupport: number | undefined;
+    let suggestionSampleSize: number | undefined;
     let lastUsedCategoryId: string | undefined;
     if (byCategory && byCategory.size > 0) {
       const entries = [...byCategory.entries()];
@@ -110,6 +122,7 @@ export function buildPayeeGroups(
       )[0];
       suggestedCategoryId = bestId;
       suggestionSupport = best.count;
+      suggestionSampleSize = entries.reduce((sum, [, e]) => sum + e.count, 0);
       const [recentId] = [...entries].sort((a, b) => b[1].latest - a[1].latest)[0];
       if (recentId !== bestId) lastUsedCategoryId = recentId;
     }
@@ -126,6 +139,7 @@ export function buildPayeeGroups(
       accountIds: [t.accountId],
       suggestedCategoryId,
       suggestionSupport,
+      suggestionSampleSize,
       lastUsedCategoryId,
     });
   }

--- a/src/utils/pdfExport.ts
+++ b/src/utils/pdfExport.ts
@@ -6,6 +6,15 @@ import { formatCurrency as formatCurrencyDecimal } from './currency-decimal';
 import { formatDecimal } from './decimal-format';
 import { createScopedLogger } from '../loggers/scopedLogger';
 
+/**
+ * A transaction as it appears in a report table. `categoryLabel` carries the
+ * resolved category NAME — the stored `category` is a UUID and must never be
+ * printed.
+ */
+export interface ReportTransaction extends Transaction {
+  categoryLabel?: string;
+}
+
 interface ReportData {
   title: string;
   dateRange: string;
@@ -20,7 +29,7 @@ interface ReportData {
     amount: number;
     percentage: number;
   }>;
-  topTransactions: Transaction[];
+  topTransactions: ReportTransaction[];
   chartElements?: HTMLElement[];
 }
 
@@ -248,7 +257,8 @@ export async function generatePDFReport(data: ReportData, _accounts: Account[]):
       : transaction.description;
     pdf.text(description, margin + 25, yPosition);
     
-    pdf.text(transaction.category, margin + 100, yPosition);
+    // Never the raw id: the caller resolves the name, blank if it has none.
+    pdf.text(transaction.categoryLabel ?? '', margin + 100, yPosition);
     
     const amountColor = transaction.type === 'income' ? [34, 197, 94] as const : [239, 68, 68] as const;
     pdf.setTextColor(amountColor[0], amountColor[1], amountColor[2]);

--- a/src/utils/periodComparison.test.ts
+++ b/src/utils/periodComparison.test.ts
@@ -1,0 +1,179 @@
+import { describe, it, expect } from 'vitest';
+import {
+  buildPeriodComparison,
+  resolveComparisonRanges,
+  type ResolvedComparisonRanges,
+} from './periodComparison';
+import { computeIncomeExpense } from './incomeExpense';
+import type { Category, Transaction } from '../types';
+
+/** Synthetic fixtures only — no real payees or amounts in this repo. */
+const CATEGORIES: Category[] = [
+  { id: 'type-income', name: 'Income', type: 'income', level: 'type', isSystem: true },
+  { id: 'type-expense', name: 'Expense', type: 'expense', level: 'type', isSystem: true },
+  { id: 'grp-pay', name: 'Salary', type: 'income', level: 'sub', parentId: 'type-income' },
+  { id: 'grp-home', name: 'Home', type: 'expense', level: 'sub', parentId: 'type-expense' },
+  { id: 'cat-power', name: 'Power', type: 'expense', level: 'detail', parentId: 'grp-home' },
+];
+
+const txn = (over: Partial<Transaction> & Pick<Transaction, 'id' | 'amount' | 'date'>): Transaction => ({
+  description: 'synthetic row',
+  category: 'cat-power',
+  accountId: 'acc-1',
+  type: 'expense',
+  ...over,
+});
+
+const compare = (transactions: Transaction[], ranges: ResolvedComparisonRanges) =>
+  buildPeriodComparison(
+    computeIncomeExpense(transactions, [], CATEGORIES, ranges.current),
+    computeIncomeExpense(transactions, [], CATEGORIES, ranges.previous),
+    CATEGORIES
+  );
+
+describe('resolveComparisonRanges', () => {
+  const march = { from: new Date(2026, 2, 1), to: new Date(2026, 2, 31, 23, 59, 59, 999) };
+
+  it('puts the previous window immediately before the current one, same length', () => {
+    const ranges = resolveComparisonRanges(march, 'previous-period');
+
+    expect(ranges).not.toBeNull();
+    if (!ranges) return;
+    expect(ranges.previous.to.getTime()).toBe(march.from.getTime() - 1);
+    expect(ranges.previous.to.getTime() - ranges.previous.from.getTime()).toBe(
+      march.to.getTime() - march.from.getTime()
+    );
+    // The windows never overlap.
+    expect(ranges.previous.to.getTime()).toBeLessThan(ranges.current.from.getTime());
+  });
+
+  it('shifts both bounds back a calendar year for the year-on-year basis', () => {
+    const ranges = resolveComparisonRanges(march, 'same-period-last-year');
+
+    expect(ranges?.previous.from).toEqual(new Date(2025, 2, 1));
+    expect(ranges?.previous.to).toEqual(new Date(2025, 2, 31, 23, 59, 59, 999));
+  });
+
+  it('runs an open-ended window to the end of today', () => {
+    const now = new Date(2026, 2, 15, 9, 30);
+    const ranges = resolveComparisonRanges({ from: new Date(2026, 2, 1), to: null }, 'previous-period', now);
+
+    expect(ranges?.current.to).toEqual(new Date(2026, 2, 15, 23, 59, 59, 999));
+  });
+
+  it('refuses to compare a window with no start — All time has no "before"', () => {
+    expect(resolveComparisonRanges({ from: null, to: null }, 'previous-period')).toBeNull();
+    expect(resolveComparisonRanges({ from: null, to: new Date(2026, 2, 31) }, 'same-period-last-year')).toBeNull();
+  });
+
+  it('refuses an inverted window', () => {
+    expect(
+      resolveComparisonRanges({ from: new Date(2026, 2, 31), to: new Date(2026, 2, 1) }, 'previous-period')
+    ).toBeNull();
+  });
+});
+
+describe('buildPeriodComparison', () => {
+  const ranges = resolveComparisonRanges(
+    { from: new Date(2026, 2, 1), to: new Date(2026, 2, 31, 23, 59, 59, 999) },
+    'previous-period'
+  );
+
+  it('states each side of both windows with the change between them', () => {
+    expect(ranges).not.toBeNull();
+    if (!ranges) return;
+    const result = compare(
+      [
+        // Current window (March).
+        txn({ id: 'c1', amount: -120, date: new Date(2026, 2, 10) }),
+        txn({ id: 'c2', amount: 900, date: new Date(2026, 2, 25), category: 'grp-pay', type: 'income' }),
+        // Previous window (February).
+        txn({ id: 'p1', amount: -100, date: new Date(2026, 1, 10) }),
+        txn({ id: 'p2', amount: 600, date: new Date(2026, 1, 25), category: 'grp-pay', type: 'income' }),
+      ],
+      ranges
+    );
+
+    expect(result.expenses).toEqual({ current: 120, previous: 100, change: 20, changePercent: 20 });
+    expect(result.income).toEqual({ current: 900, previous: 600, change: 300, changePercent: 50 });
+    expect(result.net).toEqual({ current: 780, previous: 500, change: 280, changePercent: 56 });
+  });
+
+  it('reports no percentage — not infinity — when the comparison period holds nothing', () => {
+    expect(ranges).not.toBeNull();
+    if (!ranges) return;
+    const result = compare([txn({ id: 'c1', amount: -50, date: new Date(2026, 2, 10) })], ranges);
+
+    expect(result.expenses.previous).toBe(0);
+    expect(result.expenses.change).toBe(50);
+    expect(result.expenses.changePercent).toBeNull();
+    expect(result.income).toEqual({ current: 0, previous: 0, change: 0, changePercent: null });
+    expect(result.categories).toHaveLength(1);
+    expect(result.categories[0].changePercent).toBeNull();
+  });
+
+  it('shows a category that has stopped as a fall to zero', () => {
+    expect(ranges).not.toBeNull();
+    if (!ranges) return;
+    const result = compare([txn({ id: 'p1', amount: -80, date: new Date(2026, 1, 10) })], ranges);
+
+    expect(result.categories).toHaveLength(1);
+    expect(result.categories[0]).toMatchObject({
+      categoryId: 'cat-power',
+      name: 'Home : Power',
+      bucket: 'expense',
+      current: 0,
+      previous: 80,
+      change: -80,
+      changePercent: -100,
+    });
+  });
+
+  it('names categories, never ids, and orders by the biggest move', () => {
+    expect(ranges).not.toBeNull();
+    if (!ranges) return;
+    const result = compare(
+      [
+        txn({ id: 'c1', amount: -10, date: new Date(2026, 2, 5) }),
+        txn({ id: 'c2', amount: 1000, date: new Date(2026, 2, 6), category: 'grp-pay', type: 'income' }),
+        txn({ id: 'p1', amount: -5, date: new Date(2026, 1, 5) }),
+      ],
+      ranges
+    );
+
+    expect(result.categories.map(c => c.name)).toEqual(['Salary', 'Home : Power']);
+    expect(result.categories[0].bucket).toBe('income');
+  });
+
+  it('nets a refund down rather than treating it as income', () => {
+    expect(ranges).not.toBeNull();
+    if (!ranges) return;
+    const result = compare(
+      [
+        txn({ id: 'c1', amount: -100, date: new Date(2026, 2, 10) }),
+        txn({ id: 'c2', amount: 25, date: new Date(2026, 2, 12), type: 'income' }),
+      ],
+      ranges
+    );
+
+    expect(result.expenses.current).toBe(75);
+    expect(result.income.current).toBe(0);
+  });
+
+  it('holds decimals exactly across both windows', () => {
+    expect(ranges).not.toBeNull();
+    if (!ranges) return;
+    const result = compare(
+      [
+        ...Array.from({ length: 3 }, (_, i) =>
+          txn({ id: `c${i}`, amount: -0.1, date: new Date(2026, 2, 3 + i) })
+        ),
+        txn({ id: 'p1', amount: -0.1, date: new Date(2026, 1, 3) }),
+      ],
+      ranges
+    );
+
+    expect(result.expenses.current).toBe(0.3);
+    expect(result.expenses.change).toBe(0.2);
+  });
+});

--- a/src/utils/periodComparison.ts
+++ b/src/utils/periodComparison.ts
@@ -1,0 +1,174 @@
+import type { Category } from '../types';
+import type { PeriodRange } from '../hooks/usePeriod';
+import type { IncomeExpenseBreakdown } from './incomeExpense';
+import type { SplitExpandedTransaction } from './transactionSplits';
+import { toDecimal } from './decimal';
+import { buildCategoryNameLookup } from './categoryNames';
+
+/**
+ * "This period vs …" — the Microsoft Money comparison report.
+ *
+ * Two windows of EQUAL length are compared: the selected period against
+ * either the period immediately before it, or the same dates a year earlier.
+ * Nothing here classifies transactions: the caller hands over two
+ * `computeIncomeExpense` breakdowns, so transfers and uncategorised rows are
+ * already excluded and the current-period figures agree with every other
+ * report by construction.
+ *
+ * Percentages are deliberately NULL rather than infinite when the comparison
+ * window holds nothing for that line — "up 100%" from zero is a lie, and the
+ * UI says "new" instead.
+ */
+
+export type ComparisonBasis = 'previous-period' | 'same-period-last-year';
+
+export const COMPARISON_BASIS_LABELS: Record<ComparisonBasis, string> = {
+  'previous-period': 'Previous period',
+  'same-period-last-year': 'Same period last year',
+};
+
+export interface ResolvedComparisonRanges {
+  current: { from: Date; to: Date };
+  previous: { from: Date; to: Date };
+}
+
+/**
+ * Concrete bounds for both windows, or null when the selected period cannot
+ * be compared (an open-started window — All time — has no "before").
+ */
+export function resolveComparisonRanges(
+  range: PeriodRange,
+  basis: ComparisonBasis,
+  now: Date = new Date()
+): ResolvedComparisonRanges | null {
+  if (!range.from) return null;
+  const from = new Date(range.from);
+  // An open-ended window runs to the end of today.
+  const to = range.to ? new Date(range.to) : endOfDay(now);
+  if (to <= from) return null;
+
+  if (basis === 'same-period-last-year') {
+    const previousFrom = new Date(from);
+    previousFrom.setFullYear(previousFrom.getFullYear() - 1);
+    const previousTo = new Date(to);
+    previousTo.setFullYear(previousTo.getFullYear() - 1);
+    return { current: { from, to }, previous: { from: previousFrom, to: previousTo } };
+  }
+
+  // Equal-length window ending the millisecond before the current one starts.
+  const durationMs = to.getTime() - from.getTime();
+  const previousTo = new Date(from.getTime() - 1);
+  const previousFrom = new Date(previousTo.getTime() - durationMs);
+  return { current: { from, to }, previous: { from: previousFrom, to: previousTo } };
+}
+
+function endOfDay(date: Date): Date {
+  const end = new Date(date);
+  end.setHours(23, 59, 59, 999);
+  return end;
+}
+
+export interface ComparisonFigure {
+  current: number;
+  previous: number;
+  /** current − previous. Positive means MORE this period, on either side. */
+  change: number;
+  /** Change as a percentage of the previous figure; null when it was zero. */
+  changePercent: number | null;
+}
+
+export interface ComparisonCategoryRow extends ComparisonFigure {
+  categoryId: string;
+  /** "Parent : Child" — a category id must never reach the screen. */
+  name: string;
+  bucket: 'income' | 'expense';
+}
+
+export interface PeriodComparison {
+  income: ComparisonFigure;
+  expenses: ComparisonFigure;
+  /** Income less expenses in each window. */
+  net: ComparisonFigure;
+  /** Every category that carried value in either window, biggest move first. */
+  categories: ComparisonCategoryRow[];
+}
+
+function figureOf(current: number, previous: number): ComparisonFigure {
+  const currentDecimal = toDecimal(current);
+  const previousDecimal = toDecimal(previous);
+  const change = currentDecimal.minus(previousDecimal);
+  return {
+    current: currentDecimal.toNumber(),
+    previous: previousDecimal.toNumber(),
+    change: change.toNumber(),
+    changePercent: previousDecimal.isZero()
+      ? null
+      : change.dividedBy(previousDecimal.abs()).times(100).toNumber(),
+  };
+}
+
+function accumulate(
+  rows: SplitExpandedTransaction[],
+  bucket: 'income' | 'expense',
+  into: Map<string, ReturnType<typeof toDecimal>>
+): void {
+  for (const row of rows) {
+    if (!row.category) continue;
+    // Spending is stored negative — negate so both sides read as positive
+    // magnitudes and a refund credit nets its category down.
+    const value = bucket === 'income' ? toDecimal(row.amount) : toDecimal(row.amount).negated();
+    into.set(row.category, (into.get(row.category) ?? toDecimal(0)).plus(value));
+  }
+}
+
+export function buildPeriodComparison(
+  current: IncomeExpenseBreakdown,
+  previous: IncomeExpenseBreakdown,
+  categories: Category[]
+): PeriodComparison {
+  const categoryName = buildCategoryNameLookup(categories);
+  const bucketOf = new Map<string, 'income' | 'expense'>();
+
+  const currentTotals = new Map<string, ReturnType<typeof toDecimal>>();
+  const previousTotals = new Map<string, ReturnType<typeof toDecimal>>();
+  for (const [rows, bucket, into] of [
+    [current.incomeRows, 'income', currentTotals],
+    [current.expenseRows, 'expense', currentTotals],
+    [previous.incomeRows, 'income', previousTotals],
+    [previous.expenseRows, 'expense', previousTotals],
+  ] as const) {
+    accumulate(rows, bucket, into);
+    for (const row of rows) {
+      if (row.category) bucketOf.set(row.category, bucket);
+    }
+  }
+
+  const zero = toDecimal(0);
+  const categoryRows: ComparisonCategoryRow[] = [...new Set([...currentTotals.keys(), ...previousTotals.keys()])]
+    .map(categoryId => ({
+      categoryId,
+      name: categoryName(categoryId),
+      bucket: bucketOf.get(categoryId) ?? 'expense',
+      ...figureOf(
+        (currentTotals.get(categoryId) ?? zero).toNumber(),
+        (previousTotals.get(categoryId) ?? zero).toNumber()
+      ),
+    }))
+    // Biggest MOVE first — the point of the report is what changed. Ties fall
+    // back to the current figure, then the name, so the order never wobbles.
+    .sort(
+      (a, b) =>
+        Math.abs(b.change) - Math.abs(a.change) ||
+        Math.abs(b.current) - Math.abs(a.current) ||
+        a.name.localeCompare(b.name, undefined, { sensitivity: 'base' })
+    );
+
+  const income = figureOf(current.income.toNumber(), previous.income.toNumber());
+  const expenses = figureOf(current.expenses.toNumber(), previous.expenses.toNumber());
+  const net = figureOf(
+    current.income.minus(current.expenses).toNumber(),
+    previous.income.minus(previous.expenses).toNumber()
+  );
+
+  return { income, expenses, net, categories: categoryRows };
+}

--- a/src/utils/spendingByPayee.test.ts
+++ b/src/utils/spendingByPayee.test.ts
@@ -1,0 +1,145 @@
+import { describe, it, expect } from 'vitest';
+import { buildPayeeTotals, payeeKeyOf, NO_PAYEE_KEY } from './spendingByPayee';
+import { computeIncomeExpense } from './incomeExpense';
+import type { Category, Transaction } from '../types';
+
+/** Synthetic fixtures only — no real payees or amounts in this repo. */
+const CATEGORIES: Category[] = [
+  { id: 'type-income', name: 'Income', type: 'income', level: 'type', isSystem: true },
+  { id: 'type-expense', name: 'Expense', type: 'expense', level: 'type', isSystem: true },
+  { id: 'grp-shopping', name: 'Shopping', type: 'expense', level: 'sub', parentId: 'type-expense' },
+  { id: 'cat-supplies', name: 'Supplies', type: 'expense', level: 'detail', parentId: 'grp-shopping' },
+  { id: 'cat-books', name: 'Books', type: 'expense', level: 'detail', parentId: 'grp-shopping' },
+  { id: 'grp-pay', name: 'Salary', type: 'income', level: 'sub', parentId: 'type-income' },
+];
+
+const txn = (over: Partial<Transaction> & Pick<Transaction, 'id' | 'amount' | 'description'>): Transaction => ({
+  date: new Date(2026, 0, 10),
+  category: 'cat-supplies',
+  accountId: 'acc-1',
+  type: 'expense',
+  ...over,
+});
+
+describe('payeeKeyOf', () => {
+  it('normalises case and padding so one payee is one row', () => {
+    expect(payeeKeyOf('  test shop  ')).toBe('TEST SHOP');
+    expect(payeeKeyOf('Test Shop')).toBe(payeeKeyOf('TEST SHOP'));
+  });
+
+  it('folds description-less rows into a key that cannot collide with a payee', () => {
+    expect(payeeKeyOf('')).toBe(NO_PAYEE_KEY);
+    expect(payeeKeyOf('   ')).toBe(NO_PAYEE_KEY);
+    // The bank-sync sentinel is not a payee identity.
+    expect(payeeKeyOf('Bank transaction')).toBe(NO_PAYEE_KEY);
+    expect(NO_PAYEE_KEY).toBe(NO_PAYEE_KEY.toLowerCase());
+  });
+});
+
+describe('buildPayeeTotals', () => {
+  const totalsFor = (transactions: Transaction[]) => {
+    const flows = computeIncomeExpense(transactions, [], CATEGORIES);
+    return buildPayeeTotals(flows.expenseRows, 'expense', CATEGORIES);
+  };
+
+  it('groups by normalised payee and ranks by value', () => {
+    const { rows, total } = totalsFor([
+      txn({ id: 't1', amount: -10, description: 'Test Shop' }),
+      txn({ id: 't2', amount: -15, description: 'TEST SHOP' }),
+      txn({ id: 't3', amount: -40, description: 'Other Merchant' }),
+    ]);
+
+    expect(total).toBe(65);
+    expect(rows.map(r => r.payee)).toEqual(['OTHER MERCHANT', 'TEST SHOP']);
+    expect(rows[0].total).toBe(40);
+    expect(rows[1].total).toBe(25);
+    expect(rows[1].count).toBe(2);
+    // Original casing is kept for display; the key is what groups.
+    expect(rows[1].displayName).toBe('Test Shop');
+  });
+
+  it('states each payee as a share of the side total', () => {
+    const { rows } = totalsFor([
+      txn({ id: 't1', amount: -75, description: 'Payee A' }),
+      txn({ id: 't2', amount: -25, description: 'Payee B' }),
+    ]);
+
+    expect(rows[0].share).toBe(75);
+    expect(rows[1].share).toBe(25);
+  });
+
+  it('nets a refund down instead of counting it as income', () => {
+    const { rows, total } = totalsFor([
+      txn({ id: 't1', amount: -60, description: 'Payee A' }),
+      // A credit filed under an EXPENSE category is a refund, not income.
+      txn({ id: 't2', amount: 20, description: 'Payee A', type: 'income' }),
+    ]);
+
+    expect(total).toBe(40);
+    expect(rows).toHaveLength(1);
+    expect(rows[0].total).toBe(40);
+    expect(rows[0].count).toBe(2);
+  });
+
+  it('keeps decimals exact over many rows (no floating-point drift)', () => {
+    const rows: Transaction[] = Array.from({ length: 10 }, (_, i) =>
+      txn({ id: `t${i}`, amount: -0.1, description: 'Payee A' })
+    );
+
+    expect(totalsFor(rows).rows[0].total).toBe(1);
+  });
+
+  it('reports the category the payee is filed under most often, by name', () => {
+    const { rows } = totalsFor([
+      txn({ id: 't1', amount: -10, description: 'Payee A', category: 'cat-supplies' }),
+      txn({ id: 't2', amount: -10, description: 'Payee A', category: 'cat-supplies' }),
+      txn({ id: 't3', amount: -10, description: 'Payee A', category: 'cat-books' }),
+    ]);
+
+    expect(rows[0].topCategoryName).toBe('Shopping : Supplies');
+    expect(rows[0].topCategoryCount).toBe(2);
+  });
+
+  it('never counts transfers or uncategorised rows', () => {
+    const { rows, total } = totalsFor([
+      txn({ id: 't1', amount: -10, description: 'Payee A' }),
+      txn({ id: 't2', amount: -999, description: 'Payee B', type: 'transfer' }),
+      txn({ id: 't3', amount: -999, description: 'Payee C', category: '' }),
+      txn({ id: 't4', amount: -999, description: 'Payee D', category: 'no-such-category' }),
+    ]);
+
+    expect(total).toBe(10);
+    expect(rows.map(r => r.payee)).toEqual(['PAYEE A']);
+  });
+
+  it('ranks the income side the same way, with positive magnitudes', () => {
+    const flows = computeIncomeExpense(
+      [
+        txn({ id: 't1', amount: 500, description: 'Payer A', category: 'grp-pay', type: 'income' }),
+        txn({ id: 't2', amount: 250, description: 'Payer B', category: 'grp-pay', type: 'income' }),
+      ],
+      [],
+      CATEGORIES
+    );
+    const { rows, total } = buildPayeeTotals(flows.incomeRows, 'income', CATEGORIES);
+
+    expect(total).toBe(750);
+    expect(rows.map(r => r.total)).toEqual([500, 250]);
+  });
+
+  it('labels rows with no payee rather than dropping their value', () => {
+    const { rows, total } = totalsFor([
+      txn({ id: 't1', amount: -10, description: '' }),
+      txn({ id: 't2', amount: -5, description: 'BANK TRANSACTION' }),
+    ]);
+
+    expect(total).toBe(15);
+    expect(rows).toHaveLength(1);
+    expect(rows[0].payee).toBe(NO_PAYEE_KEY);
+    expect(rows[0].displayName).toBe('No payee recorded');
+  });
+
+  it('returns nothing for an empty period', () => {
+    expect(totalsFor([])).toEqual({ rows: [], total: 0 });
+  });
+});

--- a/src/utils/spendingByPayee.ts
+++ b/src/utils/spendingByPayee.ts
@@ -1,0 +1,152 @@
+import type { Category } from '../types';
+import type { SplitExpandedTransaction } from './transactionSplits';
+import { toDecimal } from './decimal';
+import { normalizePayee, FALLBACK_BANK_DESCRIPTION } from './payeeAutoCategorize';
+import { buildCategoryNameLookup } from './categoryNames';
+
+/**
+ * "Spending by payee" — the Microsoft Money report: who the money actually
+ * went to, ranked, with the categories each payee is filed under.
+ *
+ * Classification is NOT re-implemented here. The caller passes the income or
+ * expense rows produced by `computeIncomeExpense`, so transfers and
+ * uncategorised rows are already excluded and the report's total agrees with
+ * every other surface by construction.
+ *
+ * Payee identity is the same normalisation the app's payee memory and the SQL
+ * import prefill use (`normalizePayee`), so "the same payee" means the same
+ * thing in a report as it does when a bulk categorisation is remembered.
+ *
+ * Sign convention (matching the summary cards): values are POSITIVE
+ * magnitudes on both sides, and a credit filed against the same payee (a
+ * refund) nets that payee's figure DOWN — it can legitimately reach zero or
+ * turn negative.
+ */
+
+/**
+ * Grouping key for rows with no usable payee: an empty description, or the
+ * bank-sync sentinel that stands in for one. Lower case, so it can never
+ * collide with a real key (`normalizePayee` upper-cases).
+ */
+export const NO_PAYEE_KEY = '(no payee)';
+
+/** The payee identity a transaction groups under. */
+export function payeeKeyOf(description: string): string {
+  const key = normalizePayee(description);
+  return key === '' || key === FALLBACK_BANK_DESCRIPTION ? NO_PAYEE_KEY : key;
+}
+
+export interface PayeeTotalRow {
+  /** Normalised payee — the grouping key, and the drill-in filter. */
+  payee: string;
+  /** How the payee reads in the register (first occurrence, original case). */
+  displayName: string;
+  /** Net magnitude across the period (refunds subtract). */
+  total: number;
+  count: number;
+  /** Share of the side's total, 0–100. Zero when the side nets to nothing. */
+  share: number;
+  /** The category this payee is filed under most often — a name, never an id. */
+  topCategoryName: string;
+  /** How many of the payee's rows carry that category. */
+  topCategoryCount: number;
+  earliest: Date;
+  latest: Date;
+}
+
+export interface PayeeTotals {
+  rows: PayeeTotalRow[];
+  /** The side's total — the sum the rows' shares are taken of. */
+  total: number;
+}
+
+interface PayeeAccumulator {
+  payee: string;
+  displayName: string;
+  total: ReturnType<typeof toDecimal>;
+  count: number;
+  categoryCounts: Map<string, { count: number; latest: number }>;
+  earliest: Date;
+  latest: Date;
+}
+
+/**
+ * Rank payees by value for one side of the report.
+ *
+ * @param rows   Already-classified rows (`flows.expenseRows` / `flows.incomeRows`).
+ * @param bucket Which side those rows are — decides the sign of the magnitude.
+ */
+export function buildPayeeTotals(
+  rows: SplitExpandedTransaction[],
+  bucket: 'income' | 'expense',
+  categories: Category[]
+): PayeeTotals {
+  const categoryName = buildCategoryNameLookup(categories);
+  const groups = new Map<string, PayeeAccumulator>();
+  let total = toDecimal(0);
+
+  for (const row of rows) {
+    const payee = payeeKeyOf(row.description);
+    // Spending is stored negative, so negate to read as a positive magnitude
+    // and let a refund credit subtract.
+    const value = bucket === 'income' ? toDecimal(row.amount) : toDecimal(row.amount).negated();
+    const date = new Date(row.date);
+    total = total.plus(value);
+
+    const existing = groups.get(payee);
+    const group: PayeeAccumulator = existing ?? {
+      payee,
+      displayName: payee === NO_PAYEE_KEY ? 'No payee recorded' : row.description.trim(),
+      total: toDecimal(0),
+      count: 0,
+      categoryCounts: new Map(),
+      earliest: date,
+      latest: date,
+    };
+    group.total = group.total.plus(value);
+    group.count += 1;
+    if (date < group.earliest) group.earliest = date;
+    if (date > group.latest) group.latest = date;
+    if (row.category) {
+      const entry = group.categoryCounts.get(row.category) ?? { count: 0, latest: 0 };
+      entry.count += 1;
+      entry.latest = Math.max(entry.latest, date.getTime());
+      group.categoryCounts.set(row.category, entry);
+    }
+    if (!existing) groups.set(payee, group);
+  }
+
+  const sideTotal = total.toNumber();
+
+  const out: PayeeTotalRow[] = [...groups.values()].map(group => {
+    // Most-used category wins, ties broken by the most recent — the same rule
+    // the bulk-categorise suggestions follow, so the report and the tool agree
+    // about "how this payee is usually filed".
+    const ranked = [...group.categoryCounts.entries()].sort(
+      (a, b) => b[1].count - a[1].count || b[1].latest - a[1].latest
+    );
+    const value = group.total.toNumber();
+    return {
+      payee: group.payee,
+      displayName: group.displayName === '' ? 'No payee recorded' : group.displayName,
+      total: value,
+      count: group.count,
+      share: total.isZero() ? 0 : group.total.dividedBy(total).times(100).toNumber(),
+      topCategoryName: ranked.length > 0 ? categoryName(ranked[0][0]) : 'Uncategorised',
+      topCategoryCount: ranked.length > 0 ? ranked[0][1].count : 0,
+      earliest: group.earliest,
+      latest: group.latest,
+    };
+  });
+
+  // Biggest first; ties broken by row count then name so the order is stable
+  // between renders and between sessions.
+  out.sort(
+    (a, b) =>
+      b.total - a.total ||
+      b.count - a.count ||
+      a.displayName.localeCompare(b.displayName, undefined, { sensitivity: 'base' })
+  );
+
+  return { rows: out, total: sideTotal };
+}

--- a/supabase/migrations/20260722170000_transaction_import_provenance.sql
+++ b/supabase/migrations/20260722170000_transaction_import_provenance.sql
@@ -1,0 +1,75 @@
+-- ============================================================================
+-- Import provenance for transactions — makes file imports IDEMPOTENT.
+--
+-- WHY
+-- ---
+-- The MS Money importer mints a stable per-source id for every row it emits
+-- (`mny-txn-<htrn>`, straight from Money's own TRN primary key), but nothing
+-- persisted it: every insert used a fresh UUID, so the database had no way to
+-- know it had seen a row before. Re-running an import therefore inserted a
+-- second copy of everything, and no constraint stood in the way.
+--
+-- WHY NOT `external_transaction_id`
+-- ---------------------------------
+-- That column is NOT free. It is the BANK FEED's provenance (TrueLayer /
+-- open banking), and three things already depend on that meaning:
+--   * `idx_transactions_connection_external` — the partial unique index on
+--     (connection_id, external_transaction_id);
+--   * `import_bank_transactions_atomic`'s account-scoped dedupe, which skips a
+--     row when any transaction in the account already carries the same
+--     external_transaction_id;
+--   * the same function's BACKFILL detection, which asks "does this account
+--     have ANY transaction with a non-null external_transaction_id yet?" to
+--     decide whether to rebase `initial_balance` instead of `balance`.
+-- Writing file-import ids into that column would corrupt all three: imported
+-- history would masquerade as bank-fed rows and silently suppress the first
+-- real bank sync's backfill rebase. File imports get their own columns.
+--
+-- WHAT
+-- ----
+--   import_source     — which importer wrote the row ('ms-money', …). NULL for
+--                       rows the user typed in and for bank-fed rows.
+--   import_source_id  — the importer's stable id for the source record
+--                       (e.g. 'mny-txn-50264'). Unique per user per source.
+--
+-- The unique index is deliberately NOT partial: a partial index cannot be
+-- inferred by `INSERT … ON CONFLICT (cols)` unless the statement repeats the
+-- predicate, which PostgREST cannot express. Non-partial is safe here because
+-- Postgres treats NULLs as distinct, so the millions of rows with NULL
+-- provenance never collide with each other.
+--
+-- Applying this migration changes NO existing row. Legacy rows keep NULL
+-- provenance; only newly imported rows are keyed.
+-- ============================================================================
+
+BEGIN;
+
+ALTER TABLE public.transactions
+  ADD COLUMN IF NOT EXISTS import_source text,
+  ADD COLUMN IF NOT EXISTS import_source_id text;
+
+-- Both or neither — a source id with no source is unattributable, and a source
+-- with no id cannot be deduped.
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+     WHERE conrelid = 'public.transactions'::regclass
+       AND conname = 'transactions_import_provenance_complete'
+  ) THEN
+    ALTER TABLE public.transactions
+      ADD CONSTRAINT transactions_import_provenance_complete
+      CHECK ((import_source IS NULL) = (import_source_id IS NULL));
+  END IF;
+END $$;
+
+-- The database itself now refuses a duplicate import row.
+CREATE UNIQUE INDEX IF NOT EXISTS transactions_import_source_unique
+  ON public.transactions (user_id, import_source, import_source_id);
+
+COMMENT ON COLUMN public.transactions.import_source IS
+  'File-import provenance: which importer created this row (e.g. ''ms-money''). NULL for hand-entered and bank-fed rows. NOT the bank feed — that is external_provider/external_transaction_id.';
+COMMENT ON COLUMN public.transactions.import_source_id IS
+  'File-import provenance: the importer''s stable id for the source record (e.g. ''mny-txn-50264'', derived from Money''s TRN.htrn). Unique per (user_id, import_source) so a re-import updates/skips instead of duplicating.';
+
+COMMIT;


### PR DESCRIPTION
Reports get a proper home, and the MS Money import stops double-counting.

These landed together because the reports work is what exposed the import bug:
a month's expenses read half again as large as Microsoft Money's own report for
the same month, and chasing that gap took most of the branch.

## Reports

- **A gallery, not three tabs.** Eight named reports grouped by the question
  they answer, each on its own `/reports/<id>` URL so it can be linked and
  pinned, and each code-split so opening the gallery does not load eight
  reports' worth of charts. Tabs stop scaling past a handful of reports;
  Money's model does not.
- **A Money-style matrix** — every category down the side, months across the
  top, group subtotals, and Total Income / Total Expenses / Income less
  Expenses. The Total column only appears when there is more than one month to
  add up, because a Total that repeats the single month it sums is noise.
- **New reports**: spending by payee, period comparison, account balances.
- **Each report opens on the window it is worth reading over** — net worth over
  time on all of it, month-by-month reports on a year — until the user picks a
  period, after which their choice wins everywhere and is never overridden.
- Top Transactions no longer shows raw category UUIDs.

## Import

Four defects, each found by a strictly-constrained scratch database rather than
by reading the code:

- **Feed overlap.** The `.mny` history and the live bank feeds both cover the
  same recent weeks and nothing reconciled them, so every transaction in the
  overlap existed twice. The matcher now suppresses the file row and keeps the
  feed row — the bank's record, carrying the provider's id, which cannot be
  recreated.
- **Transfer legs were exempt** from that suppression, to avoid stranding a
  counterpart. In the fed accounts they matched row-for-row, so they were pure
  duplicates. A leg is now *handed over*: the file row is suppressed, the feed
  row is promoted into the transfer, and the counterpart is re-linked.
- **Categories lost by the suppression.** Keeping the feed row is right about
  the amount and the date and wrong about one thing — the feed row carries no
  category, and a row with no category is deliberately excluded from every
  report. The money survived; its classification did not. Restored by
  re-deriving the pairs with the *same* matcher that suppressed them.
- **Split lines** could be blank or worth nothing; category roots resolved to
  phantom ids.

Plus: provenance columns so a row knows where it came from, batched writes with
retry, an idempotent import proven twice-over by a harness, and a re-import
script whose backup-before-delete is enforced by the type system rather than by
remembering.

## Result

Eight consecutive months of expense totals now match the Microsoft Money report
exactly, to the penny — including the month where the file history and the live
feed overlap, which is the one that had to be right for the rest to mean
anything. Ledger invariant clean on all 205 accounts.

## Also

- A read-only `scripts/periodTotals.mts` that answers "what does the app say
  this period totals?" using the app's own classifier, so a disagreement with
  outside records can be checked without ad-hoc queries.
- Two test races fixed that passed on an idle machine and failed under load.
- The Supabase smoke suite's cleanup ignored the errors from its three deletes,
  so a cleanup that did not happen looked exactly like one that did — which is
  how a synthetic user survived in a real database for three days.

## Verification

`npm run typecheck:strict`, `npm run lint` (zero warnings), `npm run test:smoke`
(3323 passing), `npm run build`, and the coverage gate all green; the gallery
opened in a browser, which is what caught the last bug in this branch.

Not covered: no report was checked against real data on screen (demo mode has
none without authentication), and responsive layout is unverified.
