### PR TITLE
Revaluations as a first-class concept, and a safer bulk categorise

### DIFF
--- a/src/components/reports/IncomeExpenseSummaryCards.tsx
+++ b/src/components/reports/IncomeExpenseSummaryCards.tsx
@@ -16,13 +16,22 @@ import type { IncomeExpenseBreakdown } from '../../utils/incomeExpense';
  *
  * Income and Expenses are buttons: both drill into the transactions behind
  * them.
+ *
+ * Portfolio gains & losses (revaluations) are a SEPARATE, opt-in line below
+ * the cards. They are never part of the income/expense/net totals — the
+ * classifier rules them out unconditionally — because a change in an account's
+ * value is not money earned or spent, and on this day-to-day report a paper
+ * "gain" is not income received. `showRevaluations` only controls whether that
+ * separate line is displayed; it can never move a figure into the totals.
  */
 export default function IncomeExpenseSummaryCards({
   flows,
   categories,
+  showRevaluations = false,
 }: {
   flows: IncomeExpenseBreakdown;
   categories: Category[];
+  showRevaluations?: boolean;
 }): React.JSX.Element {
   const { isLoading } = useApp();
   const { formatCurrency } = useCurrencyDecimal();
@@ -38,6 +47,10 @@ export default function IncomeExpenseSummaryCards({
       expenses: flows.expenses.toNumber(),
       net: net.toNumber(),
       savingsRate: savingsRate.toNumber(),
+      // NET, signed — an upward revaluation is positive, a downward one
+      // negative. Kept out of every figure above by construction.
+      revaluation: flows.revaluation.toNumber(),
+      revaluationCount: flows.revaluationRows.length,
     };
   }, [flows]);
 
@@ -99,6 +112,44 @@ export default function IncomeExpenseSummaryCards({
           </div>
         </div>
       </div>
+
+      {/* Opt-in, and only when there is something to show. A full-width band,
+          not a fifth card, so it reads as a note beside the day-to-day figures
+          rather than a peer of income and spending. Drills in with 'neutral'
+          so rows keep their own signed amounts (a gain +, a loss −). */}
+      {showRevaluations && flows.revaluationRows.length > 0 && (
+        <button
+          type="button"
+          onClick={() => setDrill({
+            title: 'Portfolio gains & losses',
+            bucket: 'neutral',
+            rows: flows.revaluationRows,
+            total: summary.revaluation,
+          })}
+          className="mt-4 w-full flex flex-col items-start bg-white dark:bg-gray-800 rounded-2xl shadow-lg border border-gray-100 dark:border-gray-700 p-6 text-left cursor-pointer hover:bg-gray-50 dark:hover:bg-gray-700/40 transition-colors"
+        >
+          <div className="flex w-full items-baseline justify-between gap-4">
+            <p className="text-sm text-gray-600 dark:text-gray-400">
+              Portfolio gains &amp; losses
+              <span className="ml-2 text-xs text-gray-400 dark:text-gray-500">
+                {summary.revaluationCount} {summary.revaluationCount === 1 ? 'revaluation' : 'revaluations'}
+              </span>
+            </p>
+            <div className={`text-2xl font-bold ${
+              summary.revaluation >= 0 ? 'text-green-700 dark:text-green-400' : 'text-red-600 dark:text-red-400'
+            }`}>
+              {isLoading
+                ? <SkeletonText className="w-32 h-8" />
+                : summary.revaluation >= 0
+                  ? `+${formatCurrency(summary.revaluation)}`
+                  : `-${formatCurrency(Math.abs(summary.revaluation))}`}
+            </div>
+          </div>
+          <p className="mt-1 text-xs text-gray-400 dark:text-gray-500">
+            A change in what your accounts are worth — not counted in income or expenses.
+          </p>
+        </button>
+      )}
 
       <ReportDrillModal target={drill} onClose={() => setDrill(null)} categories={categories} />
     </>

--- a/src/data/__tests__/defaultCategories.test.ts
+++ b/src/data/__tests__/defaultCategories.test.ts
@@ -12,8 +12,15 @@ describe('getDefaultCategories (Microsoft Money default set)', () => {
 
   it('keeps every system category the app depends on', () => {
     for (const required of ['type-income', 'type-expense', 'type-transfer',
-      'transfer-in', 'transfer-out', 'sub-adjustments', 'account-adjustments']) {
+      'transfer-in', 'transfer-out', 'sub-adjustments', 'account-adjustments',
+      'type-revaluation', 'revaluation-market']) {
       expect(defaults.some(c => c.id === required)).toBe(true);
+    }
+  });
+
+  it('flags the revaluation categories so the classifier rules them out of spending', () => {
+    for (const id of ['type-revaluation', 'revaluation-market']) {
+      expect(defaults.find(c => c.id === id)?.isRevaluationCategory).toBe(true);
     }
   });
 
@@ -44,9 +51,10 @@ describe('getDefaultCategories (Microsoft Money default set)', () => {
     }
   });
 
-  it('minimal system set is unchanged (transfers still work without full seed)', () => {
+  it('minimal system set carries the type anchors, transfers and revaluation', () => {
     expect(getMinimalSystemCategories().map(c => c.id)).toEqual([
       'type-income', 'type-expense', 'type-transfer', 'transfer-in', 'transfer-out',
+      'type-revaluation', 'revaluation-market',
     ]);
   });
 });

--- a/src/data/defaultCategories.ts
+++ b/src/data/defaultCategories.ts
@@ -9,6 +9,7 @@ interface Category {
   color?: string;
   icon?: string;
   isSystem?: boolean;
+  isRevaluationCategory?: boolean;
 }
 
 export function getMinimalSystemCategories(): Category[] {
@@ -21,6 +22,10 @@ export function getMinimalSystemCategories(): Category[] {
     // Transfer detail categories (required for transfers to work)
     { id: 'transfer-in', name: 'Transfer In', type: 'both', level: 'detail', parentId: 'type-transfer', isSystem: true },
     { id: 'transfer-out', name: 'Transfer Out', type: 'both', level: 'detail', parentId: 'type-transfer', isSystem: true },
+
+    // Revaluation: a change in an account's VALUE, neither income nor expense
+    { id: 'type-revaluation', name: 'Revaluation', type: 'both', level: 'type', isSystem: true, isRevaluationCategory: true },
+    { id: 'revaluation-market', name: 'Market Value Change', type: 'both', level: 'detail', parentId: 'type-revaluation', isSystem: true, isRevaluationCategory: true },
   ];
 }
 
@@ -51,6 +56,10 @@ export function getDefaultCategories(): Category[] {
     // Transfer categories
     { id: 'transfer-in', name: 'Transfer In', type: 'both', level: 'detail', parentId: 'type-transfer', isSystem: true },
     { id: 'transfer-out', name: 'Transfer Out', type: 'both', level: 'detail', parentId: 'type-transfer', isSystem: true },
+
+    // Revaluation categories (portfolio value changes — not income/expense/transfer)
+    { id: 'type-revaluation', name: 'Revaluation', type: 'both', level: 'type', isSystem: true, isRevaluationCategory: true },
+    { id: 'revaluation-market', name: 'Market Value Change', type: 'both', level: 'detail', parentId: 'type-revaluation', isSystem: true, isRevaluationCategory: true },
   ];
 
   for (const group of MS_MONEY_CATEGORY_SET) {

--- a/src/pages/Reports.tsx
+++ b/src/pages/Reports.tsx
@@ -45,6 +45,20 @@ export default function Reports({ picker }: ReportViewProps): React.JSX.Element 
       return !prev;
     });
   };
+  // Portfolio gains & losses are net-worth movements, not day-to-day income or
+  // spending — and a paper "gain" is not money received — so on this income &
+  // expenditure report the revaluation line is opt-in and starts hidden. This
+  // controls VISIBILITY only: the classifier keeps revaluations out of the
+  // income/expense/net totals unconditionally, toggle or not.
+  const [showRevaluations, setShowRevaluations] = useState<boolean>(
+    () => localStorage.getItem('reportsShowRevaluations') === '1'
+  );
+  const toggleRevaluations = (): void => {
+    setShowRevaluations(prev => {
+      localStorage.setItem('reportsShowRevaluations', prev ? '0' : '1');
+      return !prev;
+    });
+  };
 
   // Category ids are UUIDs — everything user-facing resolves through this
   // lookup ("Parent : Child", "Uncategorised" for a dangling id).
@@ -81,7 +95,18 @@ export default function Reports({ picker }: ReportViewProps): React.JSX.Element 
   return (
     <div className="max-w-[1400px] mx-auto space-y-6">
       <div className="flex flex-wrap items-center justify-between gap-3">
-        <ReportAccountFilter accounts={accounts} filter={filter} />
+        <div className="flex flex-wrap items-center gap-4">
+          <ReportAccountFilter accounts={accounts} filter={filter} />
+          <label className="flex items-center gap-2 text-sm text-gray-600 dark:text-gray-400 cursor-pointer">
+            <input
+              type="checkbox"
+              checked={showRevaluations}
+              onChange={toggleRevaluations}
+              className="rounded border-gray-300 dark:border-gray-600 focus:ring-2 focus:ring-primary"
+            />
+            Show portfolio gains &amp; losses
+          </label>
+        </div>
         <ReportExportBar
           title="Monthly income and expenses"
           dateRange={PERIOD_LABELS[picker.period]}
@@ -92,7 +117,7 @@ export default function Reports({ picker }: ReportViewProps): React.JSX.Element 
         />
       </div>
 
-      <IncomeExpenseSummaryCards flows={flows} categories={categories} />
+      <IncomeExpenseSummaryCards flows={flows} categories={categories} showRevaluations={showRevaluations} />
 
       {/* Rows with no category are EXCLUDED from every figure above — said out
           loud, with the three ways to clear them. */}

--- a/src/services/api/planningService.ts
+++ b/src/services/api/planningService.ts
@@ -546,6 +546,7 @@ const categoryFromDb = (row: Row): Category => ({
   icon: str(row.icon),
   isSystem: row.is_system === true,
   isTransferCategory: row.is_transfer_category === true,
+  isRevaluationCategory: row.is_revaluation_category === true,
   accountId: str(row.account_id) ?? undefined,
   isActive: row.is_active !== false
 });
@@ -561,6 +562,7 @@ const categoryToDb = (c: Partial<Category>, userId?: string): Row => {
   if (c.icon !== undefined) row.icon = c.icon;
   if (c.isSystem !== undefined) row.is_system = c.isSystem;
   if (c.isTransferCategory !== undefined) row.is_transfer_category = c.isTransferCategory;
+  if (c.isRevaluationCategory !== undefined) row.is_revaluation_category = c.isRevaluationCategory;
   if (c.accountId !== undefined) row.account_id = c.accountId || null;
   if (c.isActive !== undefined) row.is_active = c.isActive;
   return row;
@@ -577,6 +579,7 @@ const categoryToRpcPayload = (c: Category): Record<string, unknown> => ({
   icon: c.icon ?? null,
   isSystem: c.isSystem ?? false,
   isTransferCategory: c.isTransferCategory ?? false,
+  isRevaluationCategory: c.isRevaluationCategory ?? false,
   accountId: c.accountId ?? null,
   isActive: c.isActive ?? true
 });

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -255,6 +255,7 @@ export interface Category {
   isSystem?: boolean;
   description?: string;
   isTransferCategory?: boolean; // Indicates this is an account-specific transfer category
+  isRevaluationCategory?: boolean; // Indicates a change in VALUE (portfolio revaluation) — not income, expense or transfer
   accountId?: string; // The account this transfer category is associated with
   isActive?: boolean; // Used for soft-deleting categories (e.g., when account is deleted)
 }

--- a/src/utils/categoryNetting.ts
+++ b/src/utils/categoryNetting.ts
@@ -36,11 +36,13 @@ export interface CategoryNetTotal {
 export function bucketByCategoryDirection(
   t: Transaction,
   categoryById: ReadonlyMap<string, Category>
-): 'income' | 'expense' | 'transfer' | 'uncategorized' {
+): 'income' | 'expense' | 'transfer' | 'revaluation' | 'uncategorized' {
   if (t.type === 'transfer') return 'transfer';
   // One shared kind definition (utils/incomeExpense) — this must never drift
   // from the Dashboard/Analytics classifier. It also treats a To/From
-  // transfer category as 'transfer' whatever the row's own direction says.
+  // transfer category as 'transfer' whatever the row's own direction says, and
+  // a revaluation category as 'revaluation' — neither is spending, so both are
+  // filtered out by the callers below.
   // 'uncategorized' is STRICT: no category, or a dangling id — such rows
   // never hit an income/expense report. A real direction-neutral ('both')
   // category was deliberately filed, so direction decides its side.

--- a/src/utils/incomeExpense.test.ts
+++ b/src/utils/incomeExpense.test.ts
@@ -11,6 +11,8 @@ const CATEGORIES: Category[] = [
   { id: 'cat-clothing', name: 'Clothing', type: 'expense', level: 'detail', parentId: 'type-expense' },
   { id: 'cat-both', name: 'Ambiguous', type: 'both', level: 'detail', parentId: 'type-expense' },
   { id: 'tofrom-savings', name: 'To/From Savings', type: 'both', level: 'detail', parentId: 'type-transfer', isTransferCategory: true, accountId: 'acc-2' },
+  { id: 'type-revaluation', name: 'Revaluation', type: 'both', level: 'type', isSystem: true, isRevaluationCategory: true },
+  { id: 'cat-reval', name: 'Market Value Change', type: 'both', level: 'detail', parentId: 'type-revaluation', isRevaluationCategory: true },
 ];
 
 const txn = (over: Partial<Transaction>): Transaction => ({
@@ -47,6 +49,13 @@ describe('classifyFlow', () => {
   it('transfers never count, by type or by transfer category', () => {
     expect(classifyFlow(txn({ type: 'transfer', category: 'tofrom-savings' }), kinds)).toBe('transfer');
     expect(classifyFlow(txn({ type: 'income', category: 'tofrom-savings' }), kinds)).toBe('transfer');
+  });
+
+  it('revaluation categories classify as revaluation, whatever the money direction', () => {
+    // Portfolio up: money "in" (positive) filed under a revaluation category.
+    expect(classifyFlow(txn({ type: 'income', amount: 5000, category: 'cat-reval' }), kinds)).toBe('revaluation');
+    // Portfolio down: money "out" (negative) — still a revaluation, never spending.
+    expect(classifyFlow(txn({ type: 'expense', amount: -3000, category: 'cat-reval' }), kinds)).toBe('revaluation');
   });
 });
 
@@ -94,6 +103,35 @@ describe('computeIncomeExpense', () => {
     expect(uncategorizedRows.map(r => r.id)).toEqual(['b', 'c']);
     expect(uncategorizedIn.toNumber()).toBe(250000);
     expect(uncategorizedOut.toNumber()).toBe(75);
+  });
+
+  it('revaluations net signed on their own line — never income, expenses or review', () => {
+    const transactions: Transaction[] = [
+      txn({ id: 'a', type: 'income', amount: 2500, category: 'cat-salary' }),
+      txn({ id: 'b', type: 'expense', amount: -100, category: 'cat-groceries' }),
+      // portfolio up, then partly down — signed, they net against each other
+      txn({ id: 'up', type: 'income', amount: 5000, category: 'cat-reval' }),
+      txn({ id: 'down', type: 'expense', amount: -2000, category: 'cat-reval' }),
+    ];
+    const { income, expenses, revaluation, revaluationRows, uncategorizedRows } =
+      computeIncomeExpense(transactions, [], CATEGORIES);
+    expect(income.toNumber()).toBe(2500);           // the +5000 is NOT income
+    expect(expenses.toNumber()).toBe(100);          // the −2000 is NOT spending
+    expect(revaluation.toNumber()).toBe(3000);      // 5000 − 2000, signed
+    expect(revaluationRows.map(r => r.id)).toEqual(['up', 'down']);
+    // Classified rows leave the review band — a revaluation is not uncategorised.
+    expect(uncategorizedRows).toHaveLength(0);
+  });
+
+  it('a downward revaluation is a fall in value, not spending', () => {
+    const { expenses, revaluation, expenseRows } = computeIncomeExpense(
+      [txn({ id: 'crash', type: 'expense', amount: -4000, category: 'cat-reval' })],
+      [],
+      CATEGORIES
+    );
+    expect(expenses.toNumber()).toBe(0);
+    expect(expenseRows).toHaveLength(0);
+    expect(revaluation.toNumber()).toBe(-4000);
   });
 
   it('bounds by date when from/to given', () => {

--- a/src/utils/incomeExpense.ts
+++ b/src/utils/incomeExpense.ts
@@ -16,6 +16,10 @@ import { expandSplitTransactions, type SplitExpandedTransaction } from './transa
  *
  * Rules:
  *  - transfers never count (neither the type nor transfer categories);
+ *  - revaluation categories never count towards income or expenses either — a
+ *    change in an account's VALUE (a portfolio revaluation) is not money earned
+ *    or spent, it is an increase or decrease to net worth. The balances already
+ *    include it; the classifier only decides which LINE reports it on;
  *  - a category from the income tree → income; expense tree → expense —
  *    regardless of the money's direction;
  *  - NO category (or an unknown / direction-neutral one) → the row does NOT
@@ -29,14 +33,18 @@ import { expandSplitTransactions, type SplitExpandedTransaction } from './transa
  * parent never double-counted.
  */
 
-export type FlowKind = 'income' | 'expense' | 'transfer' | 'uncategorized';
+export type FlowKind = 'income' | 'expense' | 'transfer' | 'revaluation' | 'uncategorized';
 
 /** A single category's flow kind (null = no categorical signal, e.g. 'both'). */
 export function categoryKindOf(c: Category | undefined): FlowKind | null {
   if (!c) return null;
+  // Transfer keeps precedence: it is the older concept and a category can't
+  // sensibly be both. Revaluation is the same shape one rung down — its own
+  // kind, ruled out of income/expense by category semantics.
   if (c.isTransferCategory === true || c.id === 'type-transfer' || c.parentId === 'type-transfer') {
     return 'transfer';
   }
+  if (c.isRevaluationCategory === true) return 'revaluation';
   if (c.type === 'income' || c.type === 'expense') return c.type;
   return null;
 }
@@ -55,7 +63,7 @@ export function classifyFlow(
   // id. A row with any real category never lands in the review list.
   if (!row.category || !categoryKinds.has(row.category)) return 'uncategorized';
   const kind = categoryKinds.get(row.category);
-  if (kind === 'income' || kind === 'expense' || kind === 'transfer') return kind;
+  if (kind === 'income' || kind === 'expense' || kind === 'transfer' || kind === 'revaluation') return kind;
   // A real but direction-neutral ('both') category: the user DID file it —
   // the money's direction decides which side of the report it lands on.
   return row.type === 'income' ? 'income' : 'expense';
@@ -77,6 +85,17 @@ export interface IncomeExpenseBreakdown {
   uncategorizedRows: SplitExpandedTransaction[];
   uncategorizedIn: DecimalInstance;
   uncategorizedOut: DecimalInstance;
+  /**
+   * Net change in VALUE from revaluation-category rows — SIGNED (an upward
+   * revaluation is positive, a downward one negative). Never part of income or
+   * expenses: a portfolio moving up is not income and a portfolio moving down
+   * is not spending, and the account balances already carry the change. The
+   * classification only decides that these rows report on their OWN line, so a
+   * report can show them without ever letting them distort what was earned or
+   * spent.
+   */
+  revaluation: DecimalInstance;
+  revaluationRows: SplitExpandedTransaction[];
 }
 
 /**
@@ -104,9 +123,11 @@ export function computeIncomeExpense(
   let expenses = toDecimal(0);
   let uncategorizedIn = toDecimal(0);
   let uncategorizedOut = toDecimal(0);
+  let revaluation = toDecimal(0);
   const incomeRows: SplitExpandedTransaction[] = [];
   const expenseRows: SplitExpandedTransaction[] = [];
   const uncategorizedRows: SplitExpandedTransaction[] = [];
+  const revaluationRows: SplitExpandedTransaction[] = [];
 
   for (const row of rows) {
     const kind = classifyFlow(row, kinds);
@@ -118,6 +139,12 @@ export function computeIncomeExpense(
       // and a positive-amount credit (refund) correctly SUBTRACTS.
       expenses = expenses.plus(toDecimal(row.amount).negated());
       expenseRows.push(row);
+    } else if (kind === 'revaluation') {
+      // Signed as stored: an upward revaluation (+) and a downward one (−) net
+      // against each other. Deliberately touches NEITHER income nor expenses —
+      // a value change is not money earned or spent.
+      revaluation = revaluation.plus(toDecimal(row.amount));
+      revaluationRows.push(row);
     } else if (kind === 'uncategorized') {
       const amount = toDecimal(row.amount);
       if (amount.greaterThanOrEqualTo(0)) uncategorizedIn = uncategorizedIn.plus(amount);
@@ -126,7 +153,11 @@ export function computeIncomeExpense(
     }
   }
 
-  return { income, expenses, incomeRows, expenseRows, uncategorizedRows, uncategorizedIn, uncategorizedOut };
+  return {
+    income, expenses, incomeRows, expenseRows,
+    uncategorizedRows, uncategorizedIn, uncategorizedOut,
+    revaluation, revaluationRows,
+  };
 }
 
 /**

--- a/src/utils/payeeGroups.test.ts
+++ b/src/utils/payeeGroups.test.ts
@@ -9,6 +9,8 @@ const CATEGORIES: Category[] = [
   { id: 'cat-repairs', name: 'Repairs', type: 'expense', level: 'detail', parentId: 'type-expense' },
   { id: 'cat-food', name: 'Food', type: 'expense', level: 'detail', parentId: 'type-expense' },
   { id: 'cat-salary', name: 'Salary', type: 'income', level: 'detail', parentId: 'type-income' },
+  { id: 'type-revaluation', name: 'Revaluation', type: 'both', level: 'type', isSystem: true, isRevaluationCategory: true },
+  { id: 'cat-reval', name: 'Market Value Change', type: 'both', level: 'detail', parentId: 'type-revaluation', isRevaluationCategory: true },
 ];
 
 const txn = (over: Partial<Transaction> & { id: string }): Transaction => ({
@@ -130,6 +132,23 @@ describe('buildPayeeGroups', () => {
       txn({ id: 'done', description: 'Boots', category: 'cat-consumables' }),
     ], CATEGORIES);
     expect(groups).toHaveLength(0);
+  });
+
+  it('a row filed under a revaluation category never seeds a payee suggestion', () => {
+    // Rows filed under Revaluation are classified (not income/expense), so they
+    // drop out of suggestion history: a change in an account's value is not a
+    // spending habit and must never be proposed to fill an uncategorised row.
+    const groups = buildPayeeGroups([
+      txn({ id: 'r1', description: 'Portfolio Value', amount: 5000, type: 'income', category: 'cat-reval', date: new Date('2026-01-01') }),
+      txn({ id: 'r2', description: 'Portfolio Value', amount: -2000, category: 'cat-reval', date: new Date('2026-02-01') }),
+      // an uncategorised row for the same payee needing a decision
+      txn({ id: 'new', description: 'Portfolio Value', amount: 3000, type: 'income' }),
+    ], CATEGORIES);
+
+    const group = groups.find(g => g.payee === 'PORTFOLIO VALUE' && g.direction === 'income')!;
+    expect(group.transactionIds).toEqual(['new']);
+    expect(group.suggestedCategoryId).toBeUndefined();
+    expect(group.suggestionSampleSize).toBeUndefined();
   });
 
   it('treats a dangling category id as uncategorised', () => {

--- a/supabase/migrations/20260723190000_revaluation_categories.sql
+++ b/supabase/migrations/20260723190000_revaluation_categories.sql
@@ -1,0 +1,146 @@
+-- ── Revaluations: a third kind of money movement ─────────────────────────────
+--
+-- An investment portfolio's value changes without a single pound moving in or
+-- out. That is not income, not an expense, and not a transfer — it is an
+-- increase or decrease to net worth, full stop. Microsoft Money had this
+-- concept; this app did not, and the measured cost of the gap was hundreds of
+-- valuation rows sitting permanently in the uncategorised review band (some
+-- filed as groceries by users given no correct answer to choose).
+--
+-- The mechanism deliberately mirrors is_transfer_category: a flag on the
+-- category, so the classifier (utils/incomeExpense.ts) can rule the row out of
+-- income and expense by CATEGORY SEMANTICS, the way it already rules transfers
+-- out. Revaluation rows keep their amounts — the account balances already
+-- include them, which is the whole point — they are simply reported as their
+-- own line instead of polluting spending.
+--
+-- Seeded per user: a "Revaluation" root with one detail category, mirroring
+-- the Transfer tree's shape so every category picker shows it with no special
+-- cases. Users add finer-grained children themselves if they want them.
+
+BEGIN;
+
+ALTER TABLE public.categories
+  ADD COLUMN IF NOT EXISTS is_revaluation_category boolean NOT NULL DEFAULT false;
+
+COMMENT ON COLUMN public.categories.is_revaluation_category IS
+  'Rows filed here are changes in VALUE (portfolio revaluations), not income, expenses or transfers — excluded from spending totals, reported as their own line.';
+
+-- One root + one detail per existing user, idempotently: a user who already
+-- has a revaluation root (any category flagged at level ''type'') is skipped.
+INSERT INTO public.categories (user_id, name, type, level, parent_id, is_system, is_revaluation_category)
+SELECT u.id, 'Revaluation', 'both', 'type', NULL, true, true
+  FROM public.users u
+ WHERE NOT EXISTS (
+   SELECT 1 FROM public.categories c
+    WHERE c.user_id = u.id AND c.is_revaluation_category AND c.level = 'type'
+ );
+
+INSERT INTO public.categories (user_id, name, type, level, parent_id, is_system, is_revaluation_category)
+SELECT root.user_id, 'Market Value Change', 'both', 'detail', root.id, true, true
+  FROM public.categories root
+ WHERE root.is_revaluation_category AND root.level = 'type'
+   AND NOT EXISTS (
+     SELECT 1 FROM public.categories c
+      WHERE c.user_id = root.user_id AND c.is_revaluation_category AND c.level = 'detail'
+   );
+
+-- The localStorage→cloud migration must carry the flag, or a local user's
+-- revaluation categories would silently lose their meaning on sign-up. This is
+-- the SAME function as 20260611100000 — every line identical (return type,
+-- idempotency guard, error codes, the transactions/budgets remap, GRANT/REVOKE)
+-- — with the single addition of the is_revaluation_category column and its
+-- isRevaluationCategory payload key in the pass-2 insert.
+CREATE OR REPLACE FUNCTION public.migrate_categories_atomic(
+  p_user_id uuid,
+  p_categories jsonb
+)
+RETURNS SETOF public.categories
+LANGUAGE plpgsql SECURITY INVOKER
+SET search_path = public
+AS $$
+DECLARE
+  v_map jsonb := '{}'::jsonb;
+  v_item jsonb;
+  v_old_id text;
+BEGIN
+  -- Idempotency guard: a user who already has cloud categories must never be
+  -- double-seeded (re-running would duplicate the tree and re-remap nothing).
+  IF EXISTS (SELECT 1 FROM public.categories WHERE user_id = p_user_id) THEN
+    RAISE EXCEPTION 'categories_already_migrated' USING ERRCODE = 'P0003';
+  END IF;
+
+  IF p_categories IS NULL OR jsonb_typeof(p_categories) <> 'array'
+     OR jsonb_array_length(p_categories) = 0 THEN
+    RAISE EXCEPTION 'categories_payload_empty' USING ERRCODE = 'P0004';
+  END IF;
+
+  -- Pass 1: old id → fresh uuid for every category.
+  FOR v_item IN SELECT * FROM jsonb_array_elements(p_categories) LOOP
+    v_old_id := v_item->>'id';
+    IF v_old_id IS NULL OR v_old_id = '' THEN
+      RAISE EXCEPTION 'category_missing_id' USING ERRCODE = 'P0004';
+    END IF;
+    v_map := v_map || jsonb_build_object(v_old_id, gen_random_uuid()::text);
+  END LOOP;
+
+  -- Pass 2: insert rows (parent links deferred to pass 3 so the client does
+  -- not need to send parents before children).
+  FOR v_item IN SELECT * FROM jsonb_array_elements(p_categories) LOOP
+    INSERT INTO public.categories (
+      id, user_id, name, type, level, parent_id,
+      color, icon, is_system, is_transfer_category, is_revaluation_category,
+      account_id, is_active
+    ) VALUES (
+      (v_map->>(v_item->>'id'))::uuid,
+      p_user_id,
+      v_item->>'name',
+      v_item->>'type',
+      v_item->>'level',
+      NULL,
+      v_item->>'color',
+      v_item->>'icon',
+      COALESCE((v_item->>'isSystem')::boolean, false),
+      COALESCE((v_item->>'isTransferCategory')::boolean, false),
+      COALESCE((v_item->>'isRevaluationCategory')::boolean, false),
+      NULLIF(v_item->>'accountId', '')::uuid,
+      COALESCE((v_item->>'isActive')::boolean, true)
+    );
+  END LOOP;
+
+  -- Pass 3: wire parent links through the map.
+  FOR v_item IN SELECT * FROM jsonb_array_elements(p_categories) LOOP
+    IF v_item->>'parentId' IS NOT NULL AND v_map ? (v_item->>'parentId') THEN
+      UPDATE public.categories
+         SET parent_id = (v_map->>(v_item->>'parentId'))::uuid
+       WHERE id = (v_map->>(v_item->>'id'))::uuid
+         AND user_id = p_user_id;
+    END IF;
+  END LOOP;
+
+  -- Pass 4: remap the TEXT category references on this user's transactions
+  -- and budgets — same transaction, so a failure rolls everything back and
+  -- no reference is ever orphaned.
+  UPDATE public.transactions t
+     SET category = v_map->>t.category
+   WHERE t.user_id = p_user_id
+     AND t.category IS NOT NULL
+     AND v_map ? t.category;
+
+  UPDATE public.budgets b
+     SET category = v_map->>b.category
+   WHERE b.user_id = p_user_id
+     AND b.category IS NOT NULL
+     AND v_map ? b.category;
+
+  RETURN QUERY
+    SELECT * FROM public.categories
+     WHERE user_id = p_user_id
+     ORDER BY level, name;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.migrate_categories_atomic(uuid, jsonb) FROM public, anon;
+GRANT EXECUTE ON FUNCTION public.migrate_categories_atomic(uuid, jsonb) TO authenticated, service_role;
+
+COMMIT;


### PR DESCRIPTION
Portfolio value changes get their own kind of money movement.

An investment account's value changes without a pound moving in or out. That is
not income, not an expense, and not a transfer — it is an increase or decrease
to net worth. The app had no concept for it, so valuation rows sat permanently
in the uncategorised review band with no correct answer to choose; offered
none, some had been filed as groceries, quietly inflating spending.

The mechanism mirrors `is_transfer_category`: a flag on the category, honoured
by the single classifier, so filing a row under a revaluation category removes
it from income, expenses and the review band in one move. The migration seeds a
"Revaluation" root with a "Market Value Change" detail per user, shaped like
the Transfer tree so every category picker shows it with no special cases.

Revaluations are excluded from the income/expense/net totals unconditionally.
On the income & expenditure report — a day-to-day view, where a paper gain is
not money received — the gains & losses line is opt-in and hidden by default;
a persisted toggle controls visibility only, and can never move a figure into
the totals.

## Verification

typecheck:strict, lint (zero warnings), smoke (3,330 passing), build, and the
coverage gate all green. The line sits behind a default-off toggle; it has not
been exercised in a browser against real data.

(Rebased onto main: the review-band census and bulk-categorise threshold
commits described in this PR's first draft turned out to already be inside
#141's squash, so this PR is the revaluation work alone.)