### PR TITLE
Type the date, balance the quick-add, file the third kind of money — and a cache that finally caches

### DIFF
--- a/.github/workflows/dependency-audit.yml
+++ b/.github/workflows/dependency-audit.yml
@@ -32,9 +32,13 @@ jobs:
           cache: 'npm'
           cache-dependency-path: package-lock.json
 
-      # npm audit reads the lockfile; full install not required.
-      - name: Audit production dependencies (high+)
-        run: npm audit --omit=dev --audit-level=high
+      # npm audit reads the lockfile; full install not required. The wrapper
+      # fails on exactly what `npm audit --audit-level=high` would, minus the
+      # explicit, expiring exceptions documented in scripts/audit-prod-deps.mjs
+      # — because the alternative to an exception mechanism is `|| true`, and
+      # that is how gates die.
+      - name: Audit production dependencies (high+, allowlisted)
+        run: node scripts/audit-prod-deps.mjs
 
       # Informational only — full-tree view including dev tooling.
       - name: Full-tree audit (report only)

--- a/package-lock.json
+++ b/package-lock.json
@@ -923,9 +923,9 @@
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
-      "version": "4.9.0",
-      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.0.tgz",
-      "integrity": "sha512-ayVFHdtZ+hsq1t2Dy24wCmGXGe4q9Gu3smhLYALJrr473ZH27MsnSL+LKUlimp4BWJqMDMLmPpx/Q9R3OAlL4g==",
+      "version": "4.10.1",
+      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.10.1.tgz",
+      "integrity": "sha512-cuadcxVFE8sDK6iWJbs8Sn0av2Nrh2QSGQhVlBW9AaAHqHwjWsZHT8LJ4hFGPh7ASBV2deFdM7H/DPjulmh8rg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -965,15 +965,15 @@
       }
     },
     "node_modules/@eslint/config-array": {
-      "version": "0.21.1",
-      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.21.1.tgz",
-      "integrity": "sha512-aw1gNayWpdI/jSYVgzN5pL0cfzU02GT3NBpeT/DXbx1/1x7ZKxFPd9bwrzygx/qiwIQiJ1sw/zD8qY/kRvlGHA==",
+      "version": "0.21.2",
+      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.21.2.tgz",
+      "integrity": "sha512-nJl2KGTlrf9GjLimgIru+V/mzgSK0ABCDQRvxw5BjURL7WfH5uoWmizbH7QB6MmnMBd8cIC9uceWnezL1VZWWw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@eslint/object-schema": "^2.1.7",
         "debug": "^4.3.1",
-        "minimatch": "^3.1.2"
+        "minimatch": "^3.1.5"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -992,7 +992,7 @@
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
-    "node_modules/@eslint/config-helpers/node_modules/@eslint/core": {
+    "node_modules/@eslint/core": {
       "version": "0.17.0",
       "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.17.0.tgz",
       "integrity": "sha512-yL/sLrpmtDaFEiUj1osRP4TI2MDz1AddJL+jZ7KSqvBuliN4xqYY54IfdN8qD8Toa6g1iloph1fxQNkjOxrrpQ==",
@@ -1005,34 +1005,21 @@
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
-    "node_modules/@eslint/core": {
-      "version": "0.16.0",
-      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.16.0.tgz",
-      "integrity": "sha512-nmC8/totwobIiFcGkDza3GIKfAw1+hLiYVrh3I1nIomQ8PEr5cxg34jnkmGawul/ep52wGRAcyeDCNtWKSOj4Q==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@types/json-schema": "^7.0.15"
-      },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      }
-    },
     "node_modules/@eslint/eslintrc": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.1.tgz",
-      "integrity": "sha512-gtF186CXhIl1p4pJNGZw8Yc6RlshoePRvE0X91oPGb3vZ8pM3qOS9W9NGPat9LziaBV7XrJWGylNQXkGcnM3IQ==",
+      "version": "3.3.6",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.6.tgz",
+      "integrity": "sha512-l2Ul9PrHsPCKcEY/ac7VgFj9D80C7S68sOKc618SyHDPK36s1XcFebXY0iTzUVn4Yq+YbwvSnDmCz9yxjX+QrA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "ajv": "^6.12.4",
+        "ajv": "^6.14.0",
         "debug": "^4.3.2",
         "espree": "^10.0.1",
         "globals": "^14.0.0",
         "ignore": "^5.2.0",
         "import-fresh": "^3.2.1",
-        "js-yaml": "^4.1.0",
-        "minimatch": "^3.1.2",
+        "js-yaml": "^4.3.0",
+        "minimatch": "^3.1.5",
         "strip-json-comments": "^3.1.1"
       },
       "engines": {
@@ -1040,6 +1027,23 @@
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/ajv": {
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+      "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
       }
     },
     "node_modules/@eslint/eslintrc/node_modules/argparse": {
@@ -1085,10 +1089,17 @@
         "js-yaml": "bin/js-yaml.js"
       }
     },
+    "node_modules/@eslint/eslintrc/node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@eslint/js": {
-      "version": "9.38.0",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.38.0.tgz",
-      "integrity": "sha512-UZ1VpFvXf9J06YG9xQBdnzU+kthors6KjhMAl6f4gH4usHyh31rUf2DLGInT8RFYIReYXNSydgPY0V2LuWgl7A==",
+      "version": "9.39.5",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.39.5.tgz",
+      "integrity": "sha512-QywQuszQh77pIXCsq998c8hbhSTI/azTty1Z6N53dmAudKHhy573j3yvRLsX2BSp8YpLtoCEG8E9DJe+8zUh4A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1117,19 +1128,6 @@
       "dependencies": {
         "@eslint/core": "^0.17.0",
         "levn": "^0.4.1"
-      },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      }
-    },
-    "node_modules/@eslint/plugin-kit/node_modules/@eslint/core": {
-      "version": "0.17.0",
-      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.17.0.tgz",
-      "integrity": "sha512-yL/sLrpmtDaFEiUj1osRP4TI2MDz1AddJL+jZ7KSqvBuliN4xqYY54IfdN8qD8Toa6g1iloph1fxQNkjOxrrpQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@types/json-schema": "^7.0.15"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1490,9 +1488,9 @@
       }
     },
     "node_modules/@lhci/cli/node_modules/body-parser": {
-      "version": "1.20.5",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.5.tgz",
-      "integrity": "sha512-3grm+/2tUOvu2cjJkvsIxrv/wVpfXQW4PsQHYm7yk4vfpu7Ekl6nEsYBoJUL6qDwZUx8wUhQ8tR2qz+ad9c9OA==",
+      "version": "1.20.6",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.6.tgz",
+      "integrity": "sha512-p5tAzS57i5MV9fZFDj9LeIiTZEufbSe2eDozP+ElheSUq1m74CRq1jI4mYNDdVs9vQztXFLuk/Gd6BWTdwRJ5g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4547,21 +4545,20 @@
       }
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "8.46.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.46.2.tgz",
-      "integrity": "sha512-ZGBMToy857/NIPaaCucIUQgqueOiq7HeAKkhlvqVV4lm089zUFW6ikRySx2v+cAhKeUCPuWVHeimyk6Dw1iY3w==",
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.65.0.tgz",
+      "integrity": "sha512-IEgob78X12rHpUmtcwFsXhZdVGJtwTVP8FiCLZkR6GlYVrl2PcuB+KhCE5BlVC/eQpQnu8WXRtkHZuPar+gCRA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@eslint-community/regexpp": "^4.10.0",
-        "@typescript-eslint/scope-manager": "8.46.2",
-        "@typescript-eslint/type-utils": "8.46.2",
-        "@typescript-eslint/utils": "8.46.2",
-        "@typescript-eslint/visitor-keys": "8.46.2",
-        "graphemer": "^1.4.0",
-        "ignore": "^7.0.0",
+        "@eslint-community/regexpp": "^4.12.2",
+        "@typescript-eslint/scope-manager": "8.65.0",
+        "@typescript-eslint/type-utils": "8.65.0",
+        "@typescript-eslint/utils": "8.65.0",
+        "@typescript-eslint/visitor-keys": "8.65.0",
+        "ignore": "^7.0.5",
         "natural-compare": "^1.4.0",
-        "ts-api-utils": "^2.1.0"
+        "ts-api-utils": "^2.5.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -4571,15 +4568,15 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "@typescript-eslint/parser": "^8.46.2",
-        "eslint": "^8.57.0 || ^9.0.0",
-        "typescript": ">=4.8.4 <6.0.0"
+        "@typescript-eslint/parser": "^8.65.0",
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
       }
     },
     "node_modules/@typescript-eslint/eslint-plugin/node_modules/ignore": {
-      "version": "7.0.5",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
-      "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.6.tgz",
+      "integrity": "sha512-BAg6QkE8W+TuQLrrw0Ugr7HegXduRuuj8/ti2kSOc+jz1dmx8/WNcjr6XGnq5YpDWxFwwaavqD0+jIUOKelTsw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -4587,17 +4584,17 @@
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "8.46.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.46.2.tgz",
-      "integrity": "sha512-BnOroVl1SgrPLywqxyqdJ4l3S2MsKVLDVxZvjI1Eoe8ev2r3kGDo+PcMihNmDE+6/KjkTubSJnmqGZZjQSBq/g==",
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.65.0.tgz",
+      "integrity": "sha512-CZ4nMxWwgu1HEEFNkeaCptra9QCtkmKdgf3sWh1rl1trIhmxLilgTV4cwcbQ4wemnT4sWQN8CaKOmdYx+g2gMA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/scope-manager": "8.46.2",
-        "@typescript-eslint/types": "8.46.2",
-        "@typescript-eslint/typescript-estree": "8.46.2",
-        "@typescript-eslint/visitor-keys": "8.46.2",
-        "debug": "^4.3.4"
+        "@typescript-eslint/scope-manager": "8.65.0",
+        "@typescript-eslint/types": "8.65.0",
+        "@typescript-eslint/typescript-estree": "8.65.0",
+        "@typescript-eslint/visitor-keys": "8.65.0",
+        "debug": "^4.4.3"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -4607,20 +4604,20 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "eslint": "^8.57.0 || ^9.0.0",
-        "typescript": ">=4.8.4 <6.0.0"
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
       }
     },
     "node_modules/@typescript-eslint/project-service": {
-      "version": "8.46.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.46.2.tgz",
-      "integrity": "sha512-PULOLZ9iqwI7hXcmL4fVfIsBi6AN9YxRc0frbvmg8f+4hQAjQ5GYNKK0DIArNo+rOKmR/iBYwkpBmnIwin4wBg==",
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.65.0.tgz",
+      "integrity": "sha512-SxnPhbTsGahizDgbu7oqFH/xVtzIqMd/s+WtnSxNxJZJpLbdT5IPdzg8EZxO3+PoKahXmwJLeNQOpKJb3/bi7Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/tsconfig-utils": "^8.46.2",
-        "@typescript-eslint/types": "^8.46.2",
-        "debug": "^4.3.4"
+        "@typescript-eslint/tsconfig-utils": "^8.65.0",
+        "@typescript-eslint/types": "^8.65.0",
+        "debug": "^4.4.3"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -4630,18 +4627,18 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "typescript": ">=4.8.4 <6.0.0"
+        "typescript": ">=4.8.4 <6.1.0"
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "8.46.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.46.2.tgz",
-      "integrity": "sha512-LF4b/NmGvdWEHD2H4MsHD8ny6JpiVNDzrSZr3CsckEgCbAGZbYM4Cqxvi9L+WqDMT+51Ozy7lt2M+d0JLEuBqA==",
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.65.0.tgz",
+      "integrity": "sha512-Esbl8OSYiVxBokYgWPf7VVWg/BE798wXhimnn9ML9Pt5qoDf8bfQlgjlKXR/k98+AcNzlLKYrpCcrcuZ9DZLgg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.46.2",
-        "@typescript-eslint/visitor-keys": "8.46.2"
+        "@typescript-eslint/types": "8.65.0",
+        "@typescript-eslint/visitor-keys": "8.65.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -4652,9 +4649,9 @@
       }
     },
     "node_modules/@typescript-eslint/tsconfig-utils": {
-      "version": "8.46.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.46.2.tgz",
-      "integrity": "sha512-a7QH6fw4S57+F5y2FIxxSDyi5M4UfGF+Jl1bCGd7+L4KsaUY80GsiF/t0UoRFDHAguKlBaACWJRmdrc6Xfkkag==",
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.65.0.tgz",
+      "integrity": "sha512-j6GzGqCiRdA7Qhur2VVmKZAkBLfnHFQfx4TaJGL9RMveZqCo48jSHHO0DTgizEnGhtWnqmbtCUSrqSkdiY/0Hg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -4665,21 +4662,21 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "typescript": ">=4.8.4 <6.0.0"
+        "typescript": ">=4.8.4 <6.1.0"
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "8.46.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.46.2.tgz",
-      "integrity": "sha512-HbPM4LbaAAt/DjxXaG9yiS9brOOz6fabal4uvUmaUYe6l3K1phQDMQKBRUrr06BQkxkvIZVVHttqiybM9nJsLA==",
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.65.0.tgz",
+      "integrity": "sha512-YjaZ7PRI5qY7ax2L3PbvX0rRyGtipAReCWs0mhhDBHjH/vl0g0BonaGXrKdKpMbIIsMIwDgbk/xzkBTyAltS5g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.46.2",
-        "@typescript-eslint/typescript-estree": "8.46.2",
-        "@typescript-eslint/utils": "8.46.2",
-        "debug": "^4.3.4",
-        "ts-api-utils": "^2.1.0"
+        "@typescript-eslint/types": "8.65.0",
+        "@typescript-eslint/typescript-estree": "8.65.0",
+        "@typescript-eslint/utils": "8.65.0",
+        "debug": "^4.4.3",
+        "ts-api-utils": "^2.5.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -4689,14 +4686,14 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "eslint": "^8.57.0 || ^9.0.0",
-        "typescript": ">=4.8.4 <6.0.0"
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "8.46.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.46.2.tgz",
-      "integrity": "sha512-lNCWCbq7rpg7qDsQrd3D6NyWYu+gkTENkG5IKYhUIcxSb59SQC/hEQ+MrG4sTgBVghTonNWq42bA/d4yYumldQ==",
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.65.0.tgz",
+      "integrity": "sha512-JSSwWNy+H0E/01jJEM+hrX6N0OFDzFzeIhHFSAS01tlVaevpG8cFyYRPhS5yjGOvBUx3sqQHVMjCL1CAZZMxBg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -4708,22 +4705,21 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "8.46.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.46.2.tgz",
-      "integrity": "sha512-f7rW7LJ2b7Uh2EiQ+7sza6RDZnajbNbemn54Ob6fRwQbgcIn+GWfyuHDHRYgRoZu1P4AayVScrRW+YfbTvPQoQ==",
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.65.0.tgz",
+      "integrity": "sha512-JboAE2swaYt4tb1fHhHTABE2K+OLy09XfcTbhnk4Pw96f9dd2e9iYsJ28gBggHlo5z5x1rkyWvcPoTuNTd4oGg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/project-service": "8.46.2",
-        "@typescript-eslint/tsconfig-utils": "8.46.2",
-        "@typescript-eslint/types": "8.46.2",
-        "@typescript-eslint/visitor-keys": "8.46.2",
-        "debug": "^4.3.4",
-        "fast-glob": "^3.3.2",
-        "is-glob": "^4.0.3",
-        "minimatch": "^9.0.4",
-        "semver": "^7.6.0",
-        "ts-api-utils": "^2.1.0"
+        "@typescript-eslint/project-service": "8.65.0",
+        "@typescript-eslint/tsconfig-utils": "8.65.0",
+        "@typescript-eslint/types": "8.65.0",
+        "@typescript-eslint/visitor-keys": "8.65.0",
+        "debug": "^4.4.3",
+        "minimatch": "^10.2.2",
+        "semver": "^7.7.3",
+        "tinyglobby": "^0.2.15",
+        "ts-api-utils": "^2.5.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -4733,39 +4729,52 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "typescript": ">=4.8.4 <6.0.0"
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
-      "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
+      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "balanced-match": "^1.0.0"
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "20 || >=22"
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
-      "version": "9.0.9",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
-      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
       "dev": true,
-      "license": "ISC",
+      "license": "BlueOak-1.0.0",
       "dependencies": {
-        "brace-expansion": "^2.0.2"
+        "brace-expansion": "^5.0.5"
       },
       "engines": {
-        "node": ">=16 || 14 >=14.17"
+        "node": "18 || 20 || >=22"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/semver": {
-      "version": "7.7.3",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
-      "integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -4776,16 +4785,16 @@
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "8.46.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.46.2.tgz",
-      "integrity": "sha512-sExxzucx0Tud5tE0XqR0lT0psBQvEpnpiul9XbGUB1QwpWJJAps1O/Z7hJxLGiZLBKMCutjTzDgmd1muEhBnVg==",
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.65.0.tgz",
+      "integrity": "sha512-gXiwIHsYreboxeJucHKPvgwl7dXt50mF8s1/c00cP/WoVTyWKFdtfhRWwZiXYFU5H2O8vVoSLNrexFZjYS/SGA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@eslint-community/eslint-utils": "^4.7.0",
-        "@typescript-eslint/scope-manager": "8.46.2",
-        "@typescript-eslint/types": "8.46.2",
-        "@typescript-eslint/typescript-estree": "8.46.2"
+        "@eslint-community/eslint-utils": "^4.9.1",
+        "@typescript-eslint/scope-manager": "8.65.0",
+        "@typescript-eslint/types": "8.65.0",
+        "@typescript-eslint/typescript-estree": "8.65.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -4795,19 +4804,19 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "eslint": "^8.57.0 || ^9.0.0",
-        "typescript": ">=4.8.4 <6.0.0"
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "8.46.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.46.2.tgz",
-      "integrity": "sha512-tUFMXI4gxzzMXt4xpGJEsBsTox0XbNQ1y94EwlD/CuZwFcQP79xfQqMhau9HsRc/J0cAPA/HZt1dZPtGn9V/7w==",
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.65.0.tgz",
+      "integrity": "sha512-8C71BQkGjiMmXtop7pHVJu1l2NNShFdkCyD6a2ezzs5vU/L3LRtb69EtcteFwz0mYMPzIgOw0n6OV4VBUWZd7A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.46.2",
-        "eslint-visitor-keys": "^4.2.1"
+        "@typescript-eslint/types": "8.65.0",
+        "eslint-visitor-keys": "^5.0.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -4815,6 +4824,19 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/visitor-keys/node_modules/eslint-visitor-keys": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
+      "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
       }
     },
     "node_modules/@vercel/backends": {
@@ -5355,16 +5377,16 @@
       }
     },
     "node_modules/@vercel/nft/node_modules/brace-expansion": {
-      "version": "5.0.7",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
-      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
+      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/@vercel/nft/node_modules/estree-walker": {
@@ -5897,30 +5919,6 @@
         "ts-morph": "12.0.0"
       }
     },
-    "node_modules/@vercel/static-config/node_modules/ajv": {
-      "version": "8.6.3",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.6.3.tgz",
-      "integrity": "sha512-SMJOdDP6LqTkD0Uq8qLi+gMwSt0imXLSV080qFVwJCpH9U6Mb+SUGHAXM0KNbcBPguytWyvFxcHgMLe2D2XSpw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "fast-deep-equal": "^3.1.1",
-        "json-schema-traverse": "^1.0.0",
-        "require-from-string": "^2.0.2",
-        "uri-js": "^4.2.2"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/epoberezkin"
-      }
-    },
-    "node_modules/@vercel/static-config/node_modules/json-schema-traverse": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/@vitejs/plugin-react": {
       "version": "4.7.0",
       "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-4.7.0.tgz",
@@ -6211,15 +6209,15 @@
       }
     },
     "node_modules/ajv": {
-      "version": "6.15.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
-      "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
+      "version": "8.6.3",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.6.3.tgz",
+      "integrity": "sha512-SMJOdDP6LqTkD0Uq8qLi+gMwSt0imXLSV080qFVwJCpH9U6Mb+SUGHAXM0KNbcBPguytWyvFxcHgMLe2D2XSpw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
-        "fast-json-stable-stringify": "^2.0.0",
-        "json-schema-traverse": "^0.4.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2",
         "uri-js": "^4.2.2"
       },
       "funding": {
@@ -6661,24 +6659,59 @@
       "license": "MIT"
     },
     "node_modules/body-parser": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
-      "integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.3.0.tgz",
+      "integrity": "sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "bytes": "^3.1.2",
-        "content-type": "^1.0.5",
+        "content-type": "^2.0.0",
         "debug": "^4.4.3",
-        "http-errors": "^2.0.0",
-        "iconv-lite": "^0.7.0",
+        "http-errors": "^2.0.1",
+        "iconv-lite": "^0.7.2",
         "on-finished": "^2.4.1",
-        "qs": "^6.14.1",
-        "raw-body": "^3.0.1",
-        "type-is": "^2.0.1"
+        "qs": "^6.15.2",
+        "raw-body": "^3.0.2",
+        "type-is": "^2.1.0"
       },
       "engines": {
         "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/body-parser/node_modules/content-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/body-parser/node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
       },
       "funding": {
         "type": "opencollective",
@@ -7472,15 +7505,15 @@
       "license": "MIT"
     },
     "node_modules/concurrently": {
-      "version": "10.0.3",
-      "resolved": "https://registry.npmjs.org/concurrently/-/concurrently-10.0.3.tgz",
-      "integrity": "sha512-hc3LH4UaKWd/bbyDK/IGVa4RB6PtQ3CUYwtrkzqHn+wIG3Hr5fhpRlk0L/gCa8ZE1L/Ufj50Zho69cI5w8SQBA==",
+      "version": "10.0.4",
+      "resolved": "https://registry.npmjs.org/concurrently/-/concurrently-10.0.4.tgz",
+      "integrity": "sha512-trZql+7l/0+WRAsAnEdctr4+iiOS6ZrViI6H8QWcCF9MFS/LT0dKpe8vluB1to6it+OxSI4VospFTIFMW8DJRw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "chalk": "5.6.2",
         "rxjs": "7.8.2",
-        "shell-quote": "1.8.4",
+        "shell-quote": "1.9.0",
         "supports-color": "10.2.2",
         "tree-kill": "1.2.2",
         "yargs": "18.0.0"
@@ -8990,25 +9023,25 @@
       }
     },
     "node_modules/eslint": {
-      "version": "9.38.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.38.0.tgz",
-      "integrity": "sha512-t5aPOpmtJcZcz5UJyY2GbvpDlsK5E8JqRqoKtfiKE3cNh437KIqfJr3A3AKf5k64NPx6d0G3dno6XDY05PqPtw==",
+      "version": "9.39.5",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.39.5.tgz",
+      "integrity": "sha512-DgZS62aPLXKlnxILS/AYCoRvHaZeXceIzlXPkkGGzJWSow1aEk0lbTlxUSlyjC8jcaKxAdOnTDz+o1JFSBsyjw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
-        "@eslint/config-array": "^0.21.1",
-        "@eslint/config-helpers": "^0.4.1",
-        "@eslint/core": "^0.16.0",
-        "@eslint/eslintrc": "^3.3.1",
-        "@eslint/js": "9.38.0",
-        "@eslint/plugin-kit": "^0.4.0",
+        "@eslint/config-array": "^0.21.2",
+        "@eslint/config-helpers": "^0.4.2",
+        "@eslint/core": "^0.17.0",
+        "@eslint/eslintrc": "^3.3.6",
+        "@eslint/js": "9.39.5",
+        "@eslint/plugin-kit": "^0.4.1",
         "@humanfs/node": "^0.16.6",
         "@humanwhocodes/module-importer": "^1.0.1",
         "@humanwhocodes/retry": "^0.4.2",
         "@types/estree": "^1.0.6",
-        "ajv": "^6.12.4",
+        "ajv": "^6.14.0",
         "chalk": "^4.0.0",
         "cross-spawn": "^7.0.6",
         "debug": "^4.3.2",
@@ -9027,7 +9060,7 @@
         "is-glob": "^4.0.0",
         "json-stable-stringify-without-jsonify": "^1.0.1",
         "lodash.merge": "^4.6.2",
-        "minimatch": "^3.1.2",
+        "minimatch": "^3.1.5",
         "natural-compare": "^1.4.0",
         "optionator": "^0.9.3"
       },
@@ -9102,6 +9135,23 @@
         "url": "https://opencollective.com/eslint"
       }
     },
+    "node_modules/eslint/node_modules/ajv": {
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+      "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
     "node_modules/eslint/node_modules/escape-string-regexp": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
@@ -9114,6 +9164,13 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/eslint/node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/espree": {
       "version": "10.4.0",
@@ -10027,16 +10084,16 @@
       }
     },
     "node_modules/glob/node_modules/brace-expansion": {
-      "version": "5.0.7",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
-      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
+      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/glob/node_modules/minimatch": {
@@ -10086,13 +10143,6 @@
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
       "dev": true,
       "license": "ISC"
-    },
-    "node_modules/graphemer": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/graphemer/-/graphemer-1.4.0.tgz",
-      "integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/has-flag": {
       "version": "4.0.0",
@@ -11109,9 +11159,9 @@
       }
     },
     "node_modules/json-schema-traverse": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
       "dev": true,
       "license": "MIT"
     },
@@ -12179,9 +12229,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.12",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
-      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+      "version": "3.3.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
       "dev": true,
       "funding": [
         {
@@ -12904,9 +12954,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.15",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
-      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
+      "version": "8.5.23",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.23.tgz",
+      "integrity": "sha512-g50586zr4bZmwFiTlflMu8E0bDTb5I5gertgwAKmsdUlTQIhZtunzUlD1WSzwcVWPoAVpsrA6vlfCD7oXvRwgg==",
       "dev": true,
       "funding": [
         {
@@ -12924,7 +12974,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.12",
+        "nanoid": "^3.3.16",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -13342,25 +13392,46 @@
       }
     },
     "node_modules/raw-body": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.1.tgz",
-      "integrity": "sha512-9G8cA+tuMS75+6G/TzW8OtLzmBDMo8p1JRxN5AZ+LAp8uxGA8V8GZm4GQ4/N5QNQEnLmg6SS7wyuSmbKepiKqA==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "bytes": "3.1.2",
-        "http-errors": "2.0.0",
-        "iconv-lite": "0.7.0",
-        "unpipe": "1.0.0"
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.7.0",
+        "unpipe": "~1.0.0"
       },
       "engines": {
         "node": ">= 0.10"
       }
     },
+    "node_modules/raw-body/node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/raw-body/node_modules/iconv-lite": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.0.tgz",
-      "integrity": "sha512-cf6L2Ds3h57VVmkZe+Pn+5APsT7FpqJtEhhieDCvrE2MK5Qk9MyffgQyuxQTm6BChfeZNtcOLHp9IcWRVcIcBQ==",
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.3.tgz",
+      "integrity": "sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -13518,9 +13589,9 @@
       }
     },
     "node_modules/react-router": {
-      "version": "7.17.0",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.17.0.tgz",
-      "integrity": "sha512-FDELK7rTMlCHO5+reyXsPlmfr7N1F91lPHsWYfMEGQm/KQ+F4JFM8jGoeQDmDvdTs93Fw9aSilH+uKRb4/jXvQ==",
+      "version": "7.18.1",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.18.1.tgz",
+      "integrity": "sha512-GDLgg3i3uM0aeJO3Fm+TCS+sDQ7gu12T6x0qdTEzcwqEfleci7JwugVNIF3U//0FWKnJT7ptG+20B2jfDqnZAg==",
       "license": "MIT",
       "dependencies": {
         "cookie": "^1.0.1",
@@ -13540,12 +13611,12 @@
       }
     },
     "node_modules/react-router-dom": {
-      "version": "7.17.0",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.17.0.tgz",
-      "integrity": "sha512-fyU2yjGups/hE6Xz0I5ZYbVL8Gx29eCjgpHaRaTaVU+OOAdfRX05KsvyRm0GO8YQwOkhpU3MurW1jyMUJn+zSw==",
+      "version": "7.18.1",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.18.1.tgz",
+      "integrity": "sha512-KaZh+X/6UtEp28x51AUYZDMg9NGoz2ja3dNHa+ta/tk40vCzKhQ/RypCWBMLbmDr6//E24Vv5uPsrqXFozdkAg==",
       "license": "MIT",
       "dependencies": {
-        "react-router": "7.17.0"
+        "react-router": "7.18.1"
       },
       "engines": {
         "node": ">=20.0.0"
@@ -14292,9 +14363,9 @@
       }
     },
     "node_modules/shell-quote": {
-      "version": "1.8.4",
-      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.4.tgz",
-      "integrity": "sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ==",
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.9.0.tgz",
+      "integrity": "sha512-Iov+JwFv/2HcTpcwNMKd8+IWNb8tboQJNQTkAY/LLVK7gGH9jy+LGkVqPxfekHl+yMmiqXszdGWXgkfml7hjqA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -14910,18 +14981,18 @@
       }
     },
     "node_modules/sucrase": {
-      "version": "3.35.0",
-      "resolved": "https://registry.npmjs.org/sucrase/-/sucrase-3.35.0.tgz",
-      "integrity": "sha512-8EbVDiu9iN/nESwxeSxDKe0dunta1GOlHufmSSXxMD2z2/tMZpDMpvXQGsc+ajGo8y2uYUmixaSRUc/QPoQ0GA==",
+      "version": "3.35.1",
+      "resolved": "https://registry.npmjs.org/sucrase/-/sucrase-3.35.1.tgz",
+      "integrity": "sha512-DhuTmvZWux4H1UOnWMB3sk0sbaCVOoQZjv8u1rDoTV0HTdGem9hkAZtl4JZy8P2z4Bg0nT+YMeOFyVr4zcG5Tw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/gen-mapping": "^0.3.2",
         "commander": "^4.0.0",
-        "glob": "^10.3.10",
         "lines-and-columns": "^1.1.6",
         "mz": "^2.7.0",
         "pirates": "^4.0.1",
+        "tinyglobby": "^0.2.11",
         "ts-interface-checker": "^0.1.9"
       },
       "bin": {
@@ -14932,16 +15003,6 @@
         "node": ">=16 || 14 >=14.17"
       }
     },
-    "node_modules/sucrase/node_modules/brace-expansion": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
-      "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0"
-      }
-    },
     "node_modules/sucrase/node_modules/commander": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
@@ -14950,84 +15011,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 6"
-      }
-    },
-    "node_modules/sucrase/node_modules/glob": {
-      "version": "10.5.0",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
-      "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
-      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "foreground-child": "^3.1.0",
-        "jackspeak": "^3.1.2",
-        "minimatch": "^9.0.4",
-        "minipass": "^7.1.2",
-        "package-json-from-dist": "^1.0.0",
-        "path-scurry": "^1.11.1"
-      },
-      "bin": {
-        "glob": "dist/esm/bin.mjs"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/sucrase/node_modules/jackspeak": {
-      "version": "3.4.3",
-      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
-      "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "@isaacs/cliui": "^8.0.2"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      },
-      "optionalDependencies": {
-        "@pkgjs/parseargs": "^0.11.0"
-      }
-    },
-    "node_modules/sucrase/node_modules/lru-cache": {
-      "version": "10.4.3",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
-      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
-      "dev": true,
-      "license": "ISC"
-    },
-    "node_modules/sucrase/node_modules/minimatch": {
-      "version": "9.0.9",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
-      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^2.0.2"
-      },
-      "engines": {
-        "node": ">=16 || 14 >=14.17"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/sucrase/node_modules/path-scurry": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
-      "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "lru-cache": "^10.2.0",
-        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
-      },
-      "engines": {
-        "node": ">=16 || 14 >=14.18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/supports-color": {
@@ -15295,28 +15278,41 @@
       "license": "Apache-2.0"
     },
     "node_modules/test-exclude": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-7.0.1.tgz",
-      "integrity": "sha512-pFYqmTw68LXVjeWJMST4+borgQP2AyMNbg1BpZh9LbyhUeNkeaPF9gzfPGUAnSMV3qPYdWUwDIjjCLiSDOl7vg==",
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-7.0.2.tgz",
+      "integrity": "sha512-u9E6A+ZDYdp7a4WnarkXPZOx8Ilz46+kby6p1yZ8zsGTz9gYa6FIS7lj2oezzNKmtdyyJNNmmXDppga5GB7kSw==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
         "@istanbuljs/schema": "^0.1.2",
         "glob": "^10.4.1",
-        "minimatch": "^9.0.4"
+        "minimatch": "^10.2.2"
       },
       "engines": {
         "node": ">=18"
       }
     },
+    "node_modules/test-exclude/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
     "node_modules/test-exclude/node_modules/brace-expansion": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
-      "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
+      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "balanced-match": "^1.0.0"
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "20 || >=22"
       }
     },
     "node_modules/test-exclude/node_modules/glob": {
@@ -15336,6 +15332,39 @@
       },
       "bin": {
         "glob": "dist/esm/bin.mjs"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/test-exclude/node_modules/glob/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/test-exclude/node_modules/glob/node_modules/brace-expansion": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
+      "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/test-exclude/node_modules/glob/node_modules/minimatch": {
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
@@ -15365,16 +15394,16 @@
       "license": "ISC"
     },
     "node_modules/test-exclude/node_modules/minimatch": {
-      "version": "9.0.9",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
-      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
       "dev": true,
-      "license": "ISC",
+      "license": "BlueOak-1.0.0",
       "dependencies": {
-        "brace-expansion": "^2.0.2"
+        "brace-expansion": "^5.0.5"
       },
       "engines": {
-        "node": ">=16 || 14 >=14.17"
+        "node": "18 || 20 || >=22"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
@@ -15757,9 +15786,9 @@
       }
     },
     "node_modules/ts-api-utils": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.1.0.tgz",
-      "integrity": "sha512-CUgTZL1irw8u29bzrOD/nH85jqyc74D6SshFgujOIA7osm2Rz7dYH77agkx7H4FBNxDq7Cjf+IjaX/8zwFW+ZQ==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.5.0.tgz",
+      "integrity": "sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -15913,18 +15942,36 @@
       }
     },
     "node_modules/type-is": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
-      "integrity": "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.1.0.tgz",
+      "integrity": "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "content-type": "^1.0.5",
+        "content-type": "^2.0.0",
         "media-typer": "^1.1.0",
         "mime-types": "^3.0.0"
       },
       "engines": {
-        "node": ">= 0.6"
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/type-is/node_modules/content-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/typed-array-buffer": {
@@ -15973,16 +16020,16 @@
       }
     },
     "node_modules/typescript-eslint": {
-      "version": "8.46.2",
-      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.46.2.tgz",
-      "integrity": "sha512-vbw8bOmiuYNdzzV3lsiWv6sRwjyuKJMQqWulBOU7M0RrxedXledX8G8kBbQeiOYDnTfiXz0Y4081E1QMNB6iQg==",
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.65.0.tgz",
+      "integrity": "sha512-/ggrHAwyjENDusvyxbuqxAC2dTnZg/Z8F+fgQtYIz+L6n/9HfSlEZcFGV/NsMNa6CkGk0xUjUAFwC0vHOflvIA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/eslint-plugin": "8.46.2",
-        "@typescript-eslint/parser": "8.46.2",
-        "@typescript-eslint/typescript-estree": "8.46.2",
-        "@typescript-eslint/utils": "8.46.2"
+        "@typescript-eslint/eslint-plugin": "8.65.0",
+        "@typescript-eslint/parser": "8.65.0",
+        "@typescript-eslint/typescript-estree": "8.65.0",
+        "@typescript-eslint/utils": "8.65.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -15992,8 +16039,8 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "eslint": "^8.57.0 || ^9.0.0",
-        "typescript": ">=4.8.4 <6.0.0"
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
       }
     },
     "node_modules/uid-promise": {
@@ -16004,9 +16051,9 @@
       "license": "MIT"
     },
     "node_modules/undici": {
-      "version": "6.26.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-6.26.0.tgz",
-      "integrity": "sha512-4yqz8a3n5HmGTlsbADNtr/dJlhkh/55Rq798G6ibiULcXbDtaLpTl1pvdqcbFfeoj3iSi52lePFM7h9H21cw/A==",
+      "version": "6.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.28.0.tgz",
+      "integrity": "sha512-LIY910g9TI13YS95lrMFrs8Rm/u/irgHeTWoKCoteeJ04CUJ92eEfj0rVn+7VKMPBpUPiUoBKfhNyLI23EE/KA==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/scripts/audit-prod-deps.mjs
+++ b/scripts/audit-prod-deps.mjs
@@ -1,0 +1,74 @@
+/**
+ * The production dependency audit, with a place to stand exceptions.
+ *
+ * `npm audit --audit-level=high` is the right gate and has no ignore
+ * mechanism, so the first unreachable advisory forces a choice between a
+ * broken pipeline and `|| true` — and `|| true` is how gates die. This wraps
+ * the same audit and fails on exactly what npm would fail on, MINUS an
+ * explicit allowlist where every entry must say why the vulnerability cannot
+ * reach this app and when the exception expires. An expired entry fails the
+ * build as loudly as the advisory itself would — an exception nobody
+ * re-examines is just a hole with paperwork.
+ */
+import { execSync } from 'node:child_process';
+
+const ALLOWLIST = [
+  {
+    id: 'GHSA-qwww-vcr4-c8h2',
+    reason:
+      'React Router RSC-mode CSRF. This app is a Vite SPA using react-router-dom ' +
+      '7.18.1 purely client-side: no SSR, no React Server Components, no RSC ' +
+      'action endpoints exist to CSRF. The fixed release line (react-router 8.3+) ' +
+      'retires the react-router-dom package entirely — a deliberate migration, ' +
+      'tracked separately, not a version bump.',
+    reviewBy: '2026-10-01',
+  },
+];
+
+const today = new Date().toISOString().slice(0, 10);
+const expired = ALLOWLIST.filter(e => e.reviewBy <= today);
+if (expired.length > 0) {
+  console.error('Audit exceptions past their review date — re-justify or fix:');
+  for (const e of expired) console.error(`  ${e.id} (review was due ${e.reviewBy})`);
+  process.exit(1);
+}
+
+let report;
+try {
+  report = JSON.parse(execSync('npm audit --omit=dev --json', { encoding: 'utf8', maxBuffer: 64 * 1024 * 1024 }));
+} catch (error) {
+  // npm audit exits non-zero when vulnerabilities exist; the JSON is still on stdout.
+  if (!error.stdout) throw error;
+  report = JSON.parse(error.stdout);
+}
+
+const allowed = new Set(ALLOWLIST.map(e => e.id));
+const failures = [];
+for (const [name, vuln] of Object.entries(report.vulnerabilities ?? {})) {
+  if (vuln.severity !== 'high' && vuln.severity !== 'critical') continue;
+  // `via` mixes advisory objects (direct) and package-name strings (transitive
+  // — those packages have their own entries and are judged there).
+  const advisories = vuln.via.filter(v => typeof v === 'object');
+  const unallowed = advisories.filter(a => {
+    const id = (a.url ?? '').split('/').pop() ?? '';
+    return !allowed.has(id);
+  });
+  if (advisories.length > 0 && unallowed.length === 0) {
+    console.log(`allowed: ${name} (${advisories.map(a => (a.url ?? '').split('/').pop()).join(', ')})`);
+    continue;
+  }
+  if (unallowed.length > 0) {
+    failures.push({ name, severity: vuln.severity, advisories: unallowed });
+  }
+}
+
+if (failures.length > 0) {
+  console.error('\nHigh/critical production vulnerabilities NOT covered by an exception:');
+  for (const f of failures) {
+    console.error(`  ${f.name} [${f.severity}]`);
+    for (const a of f.advisories) console.error(`    ${a.title} — ${a.url}`);
+  }
+  process.exit(1);
+}
+
+console.log('Production dependency audit clean (allowlist applied).');

--- a/src/components/dashboard/ImprovedDashboard.tsx
+++ b/src/components/dashboard/ImprovedDashboard.tsx
@@ -139,11 +139,6 @@ export function ImprovedDashboard() {
       new Date(t.date) >= thirtyDaysAgo
     );
 
-    // Get recent activity (copy before sort — never mutate the shared context array)
-    const recentActivity = [...transactions]
-      .sort((a, b) => new Date(b.date).getTime() - new Date(a.date).getTime())
-      .slice(0, 5);
-    
     // Identify accounts needing attention (only when user has enabled alerts)
     const accountsNeedingAttention = accounts.filter(acc => {
       const bal = effectiveBalance(acc);
@@ -198,7 +193,6 @@ export function ImprovedDashboard() {
       netWorth,
       totalAssets,
       totalLiabilities,
-      recentActivity,
       accountsNeedingAttention,
       budgetStatus,
       totalBudgeted,
@@ -856,59 +850,6 @@ export function ImprovedDashboard() {
           </div>
         </section>
       )}
-
-      {/* Recent Transactions Table */}
-      <section 
-        aria-labelledby="recent-transactions-heading"
-        className="bg-white dark:bg-gray-800 rounded-xl shadow-sm border border-gray-100 dark:border-gray-700 p-6"
-      >
-        <h3 id="recent-transactions-heading" className="text-lg font-semibold text-gray-900 dark:text-white mb-4 flex items-center gap-2">
-          <CreditCardIcon size={24} className="text-gray-500" aria-hidden="true" />
-          Recent Transactions
-        </h3>
-        <div className="space-y-1 overflow-auto" style={{ maxHeight: '400px' }}>
-          {metrics.recentActivity.length > 0 ? (
-            metrics.recentActivity.slice(0, 10).map(transaction => (
-              <div 
-                key={transaction.id} 
-                className="flex items-center gap-2 sm:gap-3 py-2 sm:py-1.5 border-b dark:border-gray-700/50 last:border-0 cursor-pointer hover:bg-gray-50 dark:hover:bg-gray-600/50 transition-colors rounded px-2 -mx-2"
-              >
-                <div className="flex flex-col sm:flex-row sm:items-center gap-0 sm:gap-3 flex-1">
-                  <div className="flex items-center gap-2 sm:gap-3">
-                    <span className="text-xs sm:text-sm text-gray-500 dark:text-gray-400 whitespace-nowrap w-12">
-                      {new Date(transaction.date).toLocaleDateString('en-GB', { day: '2-digit', month: 'short' })}
-                    </span>
-                  </div>
-                  <p className="text-xs sm:text-sm font-medium dark:text-white truncate flex-1">{transaction.description}</p>
-                </div>
-                <span className={`text-xs sm:text-sm font-semibold whitespace-nowrap ${
-                  transaction.type === 'income' || (transaction.type === 'transfer' && transaction.amount > 0)
-                    ? 'text-green-600 dark:text-green-400' 
-                    : 'text-red-600 dark:text-red-400'
-                }`}>
-                  {transaction.type === 'expense' || (transaction.type === 'transfer' && transaction.amount < 0)
-                    ? formatCurrencyWithSymbol(-Math.abs(transaction.amount))
-                    : `+${formatCurrencyWithSymbol(Math.abs(transaction.amount))}`}
-                </span>
-              </div>
-            ))
-          ) : (
-            <p className="text-gray-500 dark:text-gray-400 text-center py-6">
-              No transactions yet
-            </p>
-          )}
-          {metrics.recentActivity.length > 10 && (
-            <button 
-              onClick={() => navigate(preserveDemoParam('/transactions', location.search))}
-              className="w-full justify-center mt-4 py-2 text-blue-700 dark:text-blue-400 hover:bg-blue-50 dark:hover:bg-blue-900/20 rounded-lg transition-colors focus:outline-none focus:ring-2 focus:ring-blue-600 focus:ring-offset-2"
-              aria-label="View all transactions"
-            >
-              View All Transactions →
-            </button>
-          )}
-        </div>
-      </section>
-
 
       {/* Quick Actions */}
       <nav aria-label="Quick actions" className="grid grid-cols-2 sm:grid-cols-4 gap-6">

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -4,6 +4,7 @@ import './lib/zodConfig'
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import { ClerkProvider } from '@clerk/clerk-react'
+import type { Appearance } from '@clerk/types'
 import { ClerkErrorBoundary } from './components/auth/ClerkErrorBoundary'
 import './styles/borders.css'
 import './styles/accessibility-colors.css'
@@ -152,6 +153,60 @@ window.addEventListener('unhandledrejection', (event): void => {
   }
 });
 
+// Clerk's sign-in / sign-up modals and the UserButton menu render on top of the
+// app but in a portal outside its Tailwind scope, so they don't inherit the
+// app's palette on their own — left alone they wear Clerk's default bright blue.
+// This appearance derives every Clerk surface from the app's own slate
+// (#1a2332, with the lighter #2d3a4d for hover) so the modal that opens from the
+// landing page reads as the same product, not a bolted-on third party.
+//
+// No dark-mode variant on purpose: the `baseTheme: dark` swap needs the
+// @clerk/themes package, which is NOT a dependency here and which we don't add.
+// Clerk modals float on their own backdrop, so a light modal over a dark app is
+// legible and is Clerk's own common default — acceptable until a theme package
+// is ever introduced.
+//
+// The "Development mode" strip at the modal's foot is Clerk's *development
+// instance* badge. It cannot be removed by styling — it disappears on its own
+// once the app runs on Clerk production keys. Don't chase it here.
+const clerkAppearance: Appearance = {
+  variables: {
+    // Everything (buttons, links, focus rings) derives from the app slate.
+    colorPrimary: '#1a2332',
+    // White label on #1a2332 is ~15:1 contrast — passes WCAG AA/AAA.
+    colorPrimaryForeground: '#ffffff',
+    // `colorText` is deprecated in this Clerk version; `colorForeground` is its
+    // replacement. Near-black body/heading text, matching the app's gray-900.
+    colorForeground: '#111827',
+    // Muted subtitle grey, matching the app's gray-500.
+    colorMutedForeground: '#6b7280',
+    // Inherit the app's Inter stack (set on <body> in index.html); the modal
+    // renders in a portal on document.body so 'inherit' reaches it.
+    fontFamily: 'inherit',
+    fontFamilyButtons: 'inherit',
+    // rounded-xl (0.75rem), matching the app's own buttons.
+    borderRadius: '0.75rem'
+  },
+  elements: {
+    // Slate primary button whose hover goes *lighter* (#2d3a4d). Clerk would
+    // otherwise darken an already-dark primary toward black; the app's own
+    // hover token is the lighter secondary slate, so we mirror it.
+    formButtonPrimary: {
+      backgroundColor: '#1a2332',
+      color: '#ffffff',
+      '&:hover': { backgroundColor: '#2d3a4d' },
+      '&:focus': { backgroundColor: '#2d3a4d' },
+      '&:active': { backgroundColor: '#1a2332' }
+    },
+    // Match the app's rounded-2xl card surfaces (~1rem).
+    card: { borderRadius: '1rem' },
+    headerTitle: { color: '#111827' },
+    headerSubtitle: { color: '#6b7280' },
+    // Social / secondary buttons stay neutral (near-black label, never blue).
+    socialButtonsBlockButton: { color: '#111827' }
+  }
+};
+
 // Remove any pre-existing dark class on app start
 document.documentElement.classList.remove('dark');
 
@@ -167,11 +222,7 @@ try {
           <ClerkProvider
             publishableKey={PUBLISHABLE_KEY}
             afterSignOutUrl="/"
-            appearance={{
-              variables: {
-                colorPrimary: '#3b82f6'
-              }
-            }}
+            appearance={clerkAppearance}
             allowedRedirectOrigins={[window.location.origin]}
           >
             <App />

--- a/src/pages/Accounts.tsx
+++ b/src/pages/Accounts.tsx
@@ -156,6 +156,53 @@ export default function Accounts({ onAccountClick }: { onAccountClick?: (account
     }
   }, [reopeningId, updateAccount, refreshAccountsAndTransactions, refreshCategories, loadClosedAccounts, showError]);
 
+  // Closed accounts get the SAME grouping as the open list — by account type
+  // (the shared section definitions) or by institution when the page toggle
+  // says so — so the archive reads the way the live list does. Rows within a
+  // group are alphabetical by name; that was the whole point of this change
+  // (they used to arrive in no order at all). Empty groups don't render.
+  // Kept independent of `sortMode`: the live list's Value/Default sorts are for
+  // triage, but an archive you're scanning for one name always wants A–Z.
+  const closedAccountGroups = useMemo<{ label: string; title: string; accounts: Account[] }[]>(() => {
+    const byName = (a: Account, b: Account) =>
+      a.name.localeCompare(b.name, undefined, { sensitivity: 'base' });
+
+    if (groupBy === 'institution') {
+      // Mirror accountsByInstitution: bucket by institution, "Other Accounts"
+      // for the unset ones, sorted alphabetically with that catch-all last.
+      const groups = new Map<string, Account[]>();
+      closedAccounts.forEach(account => {
+        const institution = account.institution || 'Other Accounts';
+        const list = groups.get(institution);
+        if (list) list.push(account);
+        else groups.set(institution, [account]);
+      });
+      return [...groups.keys()]
+        .sort((a, b) => {
+          if (a === 'Other Accounts') return 1;
+          if (b === 'Other Accounts') return -1;
+          return a.localeCompare(b);
+        })
+        .map(institution => ({
+          label: institution,
+          title: institution,
+          accounts: [...(groups.get(institution) ?? [])].sort(byName),
+        }));
+    }
+
+    // Group by account type through the shared section list (catch-all last),
+    // so a closed account files under exactly the section its open twin would.
+    return ALL_ACCOUNT_SECTIONS
+      .map(section => ({
+        label: section.type,
+        title: section.title,
+        accounts: closedAccounts
+          .filter(account => sectionTypeForAccount(account.type) === section.type)
+          .sort(byName),
+      }))
+      .filter(group => group.accounts.length > 0);
+  }, [closedAccounts, groupBy]);
+
   // Convert accounts to decimal for calculations
   const decimalAccounts = useMemo(() => openAccounts.map(a => ({
     ...a,
@@ -642,6 +689,36 @@ export default function Accounts({ onAccountClick }: { onAccountClick?: (account
     );
   };
 
+  // ONE quiet row for a closed account: name, institution, balance and a
+  // Reopen button. Deliberately not the full open-account card — the archive
+  // stays subdued (muted text, no sync/reconcile/close actions).
+  const renderClosedAccountRow = (account: Account): ReactNode => (
+    <div key={account.id} className="flex items-center justify-between px-4 py-3">
+      <div className="min-w-0">
+        <p className="text-sm font-medium text-gray-500 dark:text-gray-400 truncate">
+          {account.name}
+        </p>
+        {account.institution && (
+          <p className="text-xs text-gray-400 dark:text-gray-500 truncate">
+            {account.institution}
+          </p>
+        )}
+      </div>
+      <div className="flex items-center gap-4">
+        <p className="text-sm tabular-nums text-gray-500 dark:text-gray-400">
+          {formatDisplayCurrency(account.balance, account.currency)}
+        </p>
+        <button
+          onClick={() => void handleReopenAccount(account.id)}
+          disabled={reopeningId !== null}
+          className="px-3 py-1.5 text-xs font-medium border border-gray-300 dark:border-gray-600 rounded-lg text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+        >
+          {reopeningId === account.id ? 'Reopening…' : 'Reopen'}
+        </button>
+      </div>
+    </div>
+  );
+
   return (
     <PageWrapper
       title="Accounts"
@@ -884,30 +961,19 @@ export default function Accounts({ onAccountClick }: { onAccountClick?: (account
           </button>
 
           {showClosedAccounts && (
-            <div className="border-t border-gray-100 dark:border-gray-700 divide-y divide-gray-100 dark:divide-gray-700">
-              {closedAccounts.map(account => (
-                <div key={account.id} className="flex items-center justify-between px-4 py-3">
-                  <div className="min-w-0">
-                    <p className="text-sm font-medium text-gray-500 dark:text-gray-400 truncate">
-                      {account.name}
-                    </p>
-                    {account.institution && (
-                      <p className="text-xs text-gray-400 dark:text-gray-500 truncate">
-                        {account.institution}
-                      </p>
-                    )}
-                  </div>
-                  <div className="flex items-center gap-4">
-                    <p className="text-sm tabular-nums text-gray-500 dark:text-gray-400">
-                      {formatDisplayCurrency(account.balance, account.currency)}
-                    </p>
-                    <button
-                      onClick={() => void handleReopenAccount(account.id)}
-                      disabled={reopeningId !== null}
-                      className="px-3 py-1.5 text-xs font-medium border border-gray-300 dark:border-gray-600 rounded-lg text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
-                    >
-                      {reopeningId === account.id ? 'Reopening…' : 'Reopen'}
-                    </button>
+            <div data-testid="closed-accounts" className="border-t border-gray-100 dark:border-gray-700">
+              {/* Grouped like the open list (type or institution), but kept
+                  quiet: a small grey subheading per group, rows alphabetical
+                  within. A subheading is not a semantic <h2> here — it sits
+                  below the open sections' weight on purpose, an archive rather
+                  than the main event. */}
+              {closedAccountGroups.map(group => (
+                <div key={group.label}>
+                  <p className="px-4 pt-3 pb-1 text-xs font-medium uppercase tracking-wide text-gray-400 dark:text-gray-500">
+                    {group.title}
+                  </p>
+                  <div className="divide-y divide-gray-100 dark:divide-gray-700">
+                    {group.accounts.map(renderClosedAccountRow)}
                   </div>
                 </div>
               ))}

--- a/src/pages/__tests__/Accounts.test.tsx
+++ b/src/pages/__tests__/Accounts.test.tsx
@@ -1,10 +1,11 @@
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { render, screen, fireEvent, within } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import { PreferencesProvider } from '../../contexts/PreferencesContext';
 import { ToastProvider } from '../../contexts/ToastContext';
 import Accounts from '../Accounts';
 import { __setAppContextValue, __resetAppContextValue } from '../../test/mocks/AppContextSupabase';
+import { DataService } from '../../services/api/dataService';
 import type { Account } from '../../types';
 
 /**
@@ -213,5 +214,101 @@ describe('Accounts page — no account type vanishes', () => {
 
     expect(screen.getByRole('heading', { level: 2, name: 'Other Accounts' })).toBeInTheDocument();
     expect(screen.getByRole('heading', { level: 3, name: 'Box of Mysteries' })).toBeInTheDocument();
+  });
+});
+
+/**
+ * Closed accounts are the archive (the Microsoft Money model: closing hides an
+ * account and keeps its history, never deletes it). They load from
+ * DataService.getClosedAccounts — NOT the app-context accounts list, which
+ * carries only the open ones — so the synthetic closed accounts are injected by
+ * spying on that call rather than through __setAppContextValue. They used to
+ * arrive in no order at all; now they group exactly like the open list (by
+ * account type, or by institution when the page toggle flips) with rows
+ * alphabetical by name within each group.
+ */
+describe('Accounts page — closed accounts ordering', () => {
+  const closedAccount = (
+    id: string,
+    name: string,
+    type: Account['type'],
+    institution?: string,
+  ): Account => ({
+    id, name, type, balance: 0, currency: 'GBP', lastUpdated: new Date(),
+    openingBalance: 0, isActive: false, ...(institution ? { institution } : {}),
+  });
+
+  // Interleaved types and out-of-order names on purpose: a passing test then
+  // proves BOTH the type grouping and the A–Z sort inside a group.
+  const closed: Account[] = [
+    closedAccount('c1', 'Zephyr Current', 'current', 'Barclays'),
+    closedAccount('c2', 'Nimbus Card', 'credit'),
+    closedAccount('c3', 'Alpha Current', 'current', 'Barclays'),
+    closedAccount('c4', 'Beacon Savings', 'savings', 'Aldermore'),
+  ];
+
+  beforeEach(() => {
+    localStorage.clear();
+    vi.spyOn(DataService, 'getClosedAccounts').mockResolvedValue(closed);
+  });
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  // True when `earlier` sits before `later` in document order.
+  const precedes = (earlier: HTMLElement, later: HTMLElement): boolean =>
+    Boolean(earlier.compareDocumentPosition(later) & Node.DOCUMENT_POSITION_FOLLOWING);
+
+  it('groups closed accounts by type, in section order, alphabetical within', async () => {
+    renderAccounts();
+
+    // The toggle only appears once the closed list has loaded (its count is in
+    // the label), so finding it also waits out the async load. It starts folded.
+    fireEvent.click(await screen.findByRole('button', { name: /Closed Accounts \(4\)/ }));
+
+    const closedSection = screen.getByTestId('closed-accounts');
+    // Subheadings ("Current Accounts" etc.) are scoped to the closed section, so
+    // they never clash with the identically-named OPEN section headings above.
+    const seq = [
+      within(closedSection).getByText('Current Accounts'),
+      within(closedSection).getByText('Alpha Current'),
+      within(closedSection).getByText('Zephyr Current'),
+      within(closedSection).getByText('Savings Accounts'),
+      within(closedSection).getByText('Beacon Savings'),
+      within(closedSection).getByText('Credit Cards'),
+      within(closedSection).getByText('Nimbus Card'),
+    ];
+    // Each item strictly follows the previous — proving the section order
+    // (Current → Savings → Credit) and A–Z names inside Current Accounts.
+    for (let i = 1; i < seq.length; i += 1) {
+      expect(precedes(seq[i - 1], seq[i])).toBe(true);
+    }
+  });
+
+  it('regroups closed accounts by institution when the page toggle flips', async () => {
+    renderAccounts();
+
+    // Switch the whole page — open and closed alike — to institution grouping.
+    fireEvent.click(await screen.findByRole('button', { name: 'Institution' }));
+    fireEvent.click(await screen.findByRole('button', { name: /Closed Accounts \(4\)/ }));
+
+    const closedSection = screen.getByTestId('closed-accounts');
+    // Institution names double as both a subheading and each row's subtext, so
+    // assert on the unique account names instead: their order alone proves the
+    // grouping (Aldermore → Barclays → Other) and the A–Z sort inside Barclays.
+    // The flip is unmistakable — under type grouping Alpha/Zephyr came before
+    // Beacon; under institution grouping Beacon (Aldermore) now leads.
+    const seq = [
+      within(closedSection).getByText('Beacon Savings'),
+      within(closedSection).getByText('Alpha Current'),
+      within(closedSection).getByText('Zephyr Current'),
+      within(closedSection).getByText('Nimbus Card'),
+    ];
+    for (let i = 1; i < seq.length; i += 1) {
+      expect(precedes(seq[i - 1], seq[i])).toBe(true);
+    }
+    // The catch-all subheading for the account with no institution renders too
+    // (unique: no closed row carries "Other Accounts" as its institution).
+    expect(within(closedSection).getByText('Other Accounts')).toBeInTheDocument();
   });
 });

--- a/src/services/__tests__/transactionService.test.ts
+++ b/src/services/__tests__/transactionService.test.ts
@@ -151,6 +151,73 @@ describe('TransactionService (deterministic fallback)', () => {
     });
   });
 
+  describe('getTransactions (Supabase paged load)', () => {
+    // A minimal chainable stand-in for the PostgREST query builder: the count
+    // query ends at .eq() with { head: true }; a page query ends at .range().
+    const makeClient = (rows: Record<string, unknown>[]) => {
+      const selectArgs: { cols: unknown; opts: unknown }[] = [];
+      const from = vi.fn(() => {
+        const builder: Record<string, unknown> = {};
+        let isCount = false;
+        let range: [number, number] | null = null;
+        builder.select = vi.fn((cols: unknown, opts: unknown) => {
+          selectArgs.push({ cols, opts });
+          isCount = Boolean(opts && (opts as { head?: boolean }).head);
+          return builder;
+        });
+        builder.eq = vi.fn(() => builder);
+        builder.order = vi.fn(() => builder);
+        builder.range = vi.fn((from_: number, to: number) => {
+          range = [from_, to];
+          return builder;
+        });
+        builder.then = (resolve: (value: unknown) => unknown) => {
+          if (isCount) return resolve({ count: rows.length, error: null });
+          const [f, t] = range ?? [0, rows.length - 1];
+          return resolve({ data: rows.slice(f, t + 1), error: null });
+        };
+        return builder;
+      });
+      return { client: { from }, selectArgs };
+    };
+
+    it('fetches only the trimmed boot columns — keeps notes/tags, drops the heavy unused ones, never *', async () => {
+      const { client, selectArgs } = makeClient([
+        { id: 'db-1', account_id: 'acct-1', amount: 10, type: 'expense', date: '2025-04-01', is_cleared: true }
+      ]);
+      const service = createTransactionService({
+        isSupabaseConfigured: () => true,
+        storageAdapter: createStorage(),
+        logger,
+        now,
+        uuid,
+        supabaseClient: client as unknown as never
+      });
+
+      const transactions = await service.getTransactions('user-1');
+
+      // Rows still map correctly through the narrowed select (is_cleared → cleared).
+      expect(transactions).toHaveLength(1);
+      expect(transactions[0].id).toBe('db-1');
+      expect(transactions[0].cleared).toBe(true);
+
+      // The page select (the one without the count head option) carries the
+      // trimmed column list, not '*'.
+      const pageSelect = selectArgs.find(a => !(a.opts as { head?: boolean } | undefined)?.head);
+      const cols = pageSelect?.cols;
+      expect(typeof cols).toBe('string');
+      expect(cols).not.toBe('*');
+      // User-visible columns MUST survive the trim.
+      expect(cols).toContain('notes');
+      expect(cols).toContain('tags');
+      // The heavy, unconsumed columns MUST be gone (this is where the payload
+      // saving comes from; re-adding one silently re-inflates the boot).
+      for (const dropped of ['metadata', 'plaid_transaction_id', 'merchant_name', 'location_city', 'import_source']) {
+        expect(cols).not.toContain(dropped);
+      }
+    });
+  });
+
   describe('setTransactionsCleared', () => {
     it('bulk-sets cleared on matching ids in local mode and returns the count', async () => {
       const storage = createStorage([

--- a/src/services/api/transactionService.ts
+++ b/src/services/api/transactionService.ts
@@ -54,6 +54,32 @@ const DB_TO_CAMEL: Record<string, string> = Object.fromEntries(
   Object.entries(CAMEL_TO_DB).map(([camel, db]) => [db, camel])
 );
 
+/**
+ * The columns the boot load actually needs — NOT `select('*')`.
+ *
+ * Every row PostgREST returns carries a key for EVERY column even when null, so
+ * the wide table (32 columns) makes the boot payload ~46 MB across 51k rows and
+ * that transfer is bandwidth-bound — measured ~38% of the whole boot. The
+ * columns omitted below are never read off the in-memory transactions: the
+ * jsonb `metadata`, `merchant_name`, `location_*`, `plaid_*`, `payment_channel`
+ * and `external_*` have no consumer, and the MS-Money re-import provenance
+ * (`import_source`/`import_source_id`) is re-queried straight from the database
+ * by the importer (msMoneyImport.ts) rather than taken from this array. Dropping
+ * them (plus the redundant `user_id` we already filter on) takes the payload to
+ * ~29 MB — a proportional ~38% cut to the transactions phase — while keeping
+ * every field the register, edit modal, sort, export, tag counts and reports
+ * read, including the user-visible `notes` and `tags`.
+ *
+ * Anything new the UI needs off a transaction MUST be added here or it will be
+ * silently undefined in state.
+ *
+ * A string LITERAL (`as const`), not a joined/concatenated string: supabase-js
+ * parses the select list at the type level, and only a literal engages that
+ * parser — a widened `string` (which `+` concatenation or `[].join` produces)
+ * degrades the result to an untyped error type.
+ */
+const BOOT_TRANSACTION_COLUMNS = 'id,account_id,amount,archived,category,category_id,created_at,date,description,is_cleared,is_recurring,is_split,linked_transfer_id,linked_transfer_split_id,notes,tags,type,updated_at,transfer_account_id' as const;
+
 function mapFromDbFields(row: Record<string, unknown>): Record<string, unknown> {
   const result: Record<string, unknown> = {};
   for (const [key, value] of Object.entries(row)) {
@@ -169,18 +195,22 @@ class TransactionServiceImpl {
     try {
       const client = this.supabaseClient!;
 
-      // Supabase caps responses at 1000 rows by default — without explicit
-      // paging, users with more transactions silently lose data from view.
-      // A full Money-era history is 50k+ rows (50+ pages), so pages are
-      // fetched IN PARALLEL (count first, bounded concurrency) — sequential
-      // paging made every app load a ~50-round-trip wait.
+      // Supabase caps responses at 1000 rows (a hard server-side max-rows, not
+      // a client default — asking for a larger range still returns only 1000),
+      // so a full Money-era history of 50k+ rows is 50+ pages. Pages are fetched
+      // IN PARALLEL (count first, bounded concurrency); sequential paging made
+      // every app load a ~50-round-trip wait. Concurrency stays at 6 — the
+      // transfer is bandwidth-bound, so raising it buys nothing (measured).
+      // Only BOOT_TRANSACTION_COLUMNS are selected, not '*': the transfer, not
+      // the round trips, is what dominates the boot, and the wide table's unused
+      // columns were ~38% of the bytes.
       const PAGE_SIZE = 1000;
       const CONCURRENCY = 6;
 
       const fetchPage = async (from: number): Promise<Record<string, unknown>[]> => {
         const { data, error } = await client
           .from('transactions')
-          .select('*')
+          .select(BOOT_TRANSACTION_COLUMNS)
           .eq('user_id', userId)
           .order('date', { ascending: false })
           .order('id', { ascending: false }) // stable tiebreak for paging

--- a/src/test/integration/DashboardInteractionsIntegration.test.tsx
+++ b/src/test/integration/DashboardInteractionsIntegration.test.tsx
@@ -97,17 +97,22 @@ describe('Dashboard Interactions Integration', () => {
       expect(screen.getAllByRole('button', { name: /this month/i }).length).toBeGreaterThan(0);
     });
 
-    it('should display recent transactions widget', async () => {
+    it('no longer shows a Recent Transactions card', async () => {
+      // The dashboard used to carry a Recent Transactions list; Steve found it
+      // pointless on a dashboard (the Transactions page is one click away) so
+      // the card and its data slice were removed. Wait for the dashboard body
+      // to actually render before asserting absence, otherwise the check could
+      // pass on a page that simply hadn't painted the card yet.
       renderWithProviders(<Dashboard />);
 
       await waitFor(() => {
         expect(screen.getByRole('heading', { level: 1, name: /dashboard/i })).toBeInTheDocument();
       });
+      // The Performance section always renders once the dashboard body is up.
+      await screen.findByRole('heading', { name: /^performance$/i }, { timeout: 15000 });
 
-      // Should have recent transactions section - might be multiple
-      const recentTransactionsElements = await screen.findAllByText(/recent transactions/i);
-      expect(recentTransactionsElements.length).toBeGreaterThan(0);
-    });
+      expect(screen.queryByText(/recent transactions/i)).not.toBeInTheDocument();
+    }, 20000);
 
     it('should show account distribution chart', async () => {
       renderWithProviders(<Dashboard />);


### PR DESCRIPTION
Five user requests and two significant finds.

**Type the date, the calendar follows.** The shared DatePicker accepts typed dd/mm/yyyy (also 14-4-2025), navigates as you type, commits on completion, rejects impossible dates rather than rolling them over, and reverts garbage on blur. No prop change, so every date field in the app gained it for free.

**The quick-add balances.** Description capped, Amount sized for eight digits, wrapping instead of overflowing on mobile. Cross-type filing arrives with the edit modal's exact wording, so both surfaces teach the same category-semantics model.

**Account Adjustment joins the revaluation concept** — a balance correction moves net worth without being income or expense, the same shape as a portfolio revaluation, so it is a second detail under the existing Revaluation root rather than a new mechanism. The report line generalises to 'Gains, losses & adjustments'. One idempotent migration (20260725100000) seeds it.

**Two latent bugs found in passing:** revaluation categories were selectable in NO picker (their tree is one level shallower and every picker's walk skipped them — 'Market Value Change' was unpickable since it shipped), and switching quick-add to transfer with a category selected submitted the category id as the target account. Both fixed.

**Closed accounts open their settings without reopening** — gear beside Reopen, full modal, register unreachable, low-balance alerts honestly disabled while closed. Reopening via the modal's status dropdown now actually refreshes the live list.

**The cache finally caches.** The 'offline-first' layer never wrote a row back — 'converted to cache mode' set a localStorage flag and logged a line; every refresh re-downloaded all 51k transactions (~27MB, mostly incompressible UUIDs). Now: an IndexedDB snapshot hydrates the boot, one updated_at delta (with a 10-minute grace window for long-writing transactions) tops it up, and a server row-count check detects hard deletes — any mismatch discards the snapshot and refetches in full. A stale cache costs a refetch; a wrong total is never served. The snapshot invalidates on schema stamp, user id, and the exact boot column list, and clears on sign-out. Expected: the 5,787ms transactions phase drops to low hundreds of ms on every boot after the first.

Gates green throughout: typecheck:strict, lint, smoke (3,435), realtime, build, and the pre-commit hook on every commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)