### PR TITLE
Notifications: a transaction is new when created, not when recently dated

### DIFF
--- a/src/components/ViewportDebugOverlay.tsx
+++ b/src/components/ViewportDebugOverlay.tsx
@@ -33,12 +33,27 @@ export default function ViewportDebugOverlay(): React.JSX.Element | null {
           widest = { name: `${n.tagName}.${String(n.className).slice(0, 30)}`, right: Math.round(r.right) };
         }
       });
+      // The content chain: on the affected device the page-level numbers are
+      // all clean (440 wide, scale 1.0, no overflow) yet the visible content
+      // column stops ~55pt short of the right edge — so whichever of these
+      // boxes is narrower than its parent is the culprit.
+      const box = (sel: string): string => {
+        const el = document.querySelector(sel);
+        if (!el) return `${sel}: none`;
+        const r = el.getBoundingClientRect();
+        return `${sel}: L${Math.round(r.left)} W${Math.round(r.width)} R${Math.round(window.innerWidth - r.right)}`;
+      };
       setLines([
         `innerW ${window.innerWidth} · clientW ${doc.clientWidth}`,
         `docScrollW ${doc.scrollWidth} · bodyScrollW ${document.body.scrollWidth}`,
         vv ? `visualVp w ${Math.round(vv.width)} · scale ${vv.scale.toFixed(3)} · offL ${Math.round(vv.offsetLeft)}` : 'no visualViewport',
         `screen ${window.screen.width}x${window.screen.height} · dpr ${window.devicePixelRatio}`,
         `widest right-edge: ${widest.right}px (${widest.name})`,
+        box('main'),
+        box('main > div'),
+        box('.page-transition'),
+        box('.page-transition > *'),
+        `html ${box('html')} · body ${box('body')}`,
       ]);
     };
 

--- a/src/hooks/__tests__/useActivityLogger.test.ts
+++ b/src/hooks/__tests__/useActivityLogger.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import type { Transaction } from '../../types';
+
+/**
+ * "New transaction" must mean a row that APPEARED during this session, never
+ * one that merely loaded. The old implementation compared the newest row's
+ * DATE to the wall clock — so any transaction dated in the future (a standing
+ * order entered ahead of time) was announced as new on every page refresh,
+ * forever, while nothing was actually being added.
+ */
+const mockApp = vi.hoisted(() => ({
+  current: {
+    transactions: [] as Transaction[],
+    accounts: [] as unknown[],
+    budgets: [] as unknown[],
+    goals: [] as unknown[],
+  },
+}));
+vi.mock('../../contexts/AppContextSupabase', () => ({
+  useApp: () => mockApp.current,
+}));
+
+const logged = vi.hoisted(() => ({ items: [] as Array<{ title: string; description: string }> }));
+vi.mock('../useActivityTracking', () => ({
+  logActivity: (a: { title: string; description: string }) => { logged.items.push(a); },
+}));
+
+import { useActivityLogger } from '../useActivityLogger';
+
+// Tomorrow: the exact shape that made the old date-based check fire forever.
+const futureDated = (id: string): Transaction => ({
+  id,
+  date: new Date(Date.now() + 24 * 60 * 60 * 1000).toISOString().slice(0, 10),
+  description: 'STANDING ORDER — VANGUARD ISA',
+  amount: 200,
+  type: 'transfer',
+  category: 'cat-1',
+  accountId: 'acct-1',
+} as unknown as Transaction);
+
+describe('useActivityLogger transaction announcements', () => {
+  beforeEach(() => {
+    logged.items = [];
+    localStorage.clear();
+    mockApp.current = { transactions: [], accounts: [], budgets: [], goals: [] };
+  });
+
+  it('announces nothing when a session merely loads existing rows — even future-dated ones', () => {
+    mockApp.current.transactions = [futureDated('t1'), futureDated('t2')];
+    renderHook(() => useActivityLogger());
+
+    expect(logged.items.filter(l => l.title === 'New Transaction')).toHaveLength(0);
+  });
+
+  it('announces nothing again on refresh (a fresh mount over the same data)', () => {
+    mockApp.current.transactions = [futureDated('t1')];
+    const first = renderHook(() => useActivityLogger());
+    first.unmount();
+
+    const second = renderHook(() => useActivityLogger());
+    second.unmount();
+
+    expect(logged.items.filter(l => l.title === 'New Transaction')).toHaveLength(0);
+  });
+
+  it('announces a row that appears after the baseline, exactly once', () => {
+    mockApp.current.transactions = [futureDated('t1')];
+    const hook = renderHook(() => useActivityLogger());
+
+    mockApp.current = { ...mockApp.current, transactions: [futureDated('t1'), futureDated('t2')] };
+    hook.rerender();
+    hook.rerender(); // a second render with the same data must not re-announce
+
+    const announcements = logged.items.filter(l => l.title === 'New Transaction');
+    expect(announcements).toHaveLength(1);
+  });
+});

--- a/src/hooks/useActivityLogger.ts
+++ b/src/hooks/useActivityLogger.ts
@@ -1,4 +1,4 @@
-import { useEffect } from 'react';
+import { useEffect, useRef } from 'react';
 import { useApp } from '../contexts/AppContextSupabase';
 import { logActivity } from './useActivityTracking';
 import { formatDecimal } from '../utils/decimal-format';
@@ -10,28 +10,35 @@ import { toDecimal } from '../utils/decimal';
 export function useActivityLogger() {
   const { transactions, accounts, budgets, goals } = useApp();
 
-  // Track transaction changes
+  // "New transaction" means a row that APPEARED during this session — never
+  // one that merely loaded. The previous check compared the newest row's DATE
+  // against the wall clock, but a date says when the money moved, not when
+  // the row was created: any transaction dated in the future (a standing
+  // order entered ahead of time) made `now - date` negative, which is always
+  // "within the last minute", so the same row was announced as new on every
+  // refresh, forever. Tracked by id instead: the first population is the
+  // baseline and says nothing; only ids not seen before get announced.
+  const seenTransactionIds = useRef<Set<string> | null>(null);
   useEffect(() => {
     if (transactions.length === 0) return;
 
-    // Get the most recent transaction
-    const sorted = [...transactions].sort((a, b) => 
-      new Date(b.date).getTime() - new Date(a.date).getTime()
-    );
-    const latest = sorted[0];
+    if (seenTransactionIds.current === null) {
+      seenTransactionIds.current = new Set(transactions.map(t => t.id));
+      return;
+    }
 
-    // Check if this is a new transaction (added in last minute)
-    const now = Date.now();
-    const transactionTime = new Date(latest.date).getTime();
-    if (now - transactionTime < 60000) { // Within last minute
-      logActivity({
-        type: 'transaction',
-        title: 'New Transaction',
-        description: latest.description,
-        category: latest.category,
-        amount: latest.amount,
-        actionUrl: '/transactions'
-      });
+    for (const t of transactions) {
+      if (!seenTransactionIds.current.has(t.id)) {
+        seenTransactionIds.current.add(t.id);
+        logActivity({
+          type: 'transaction',
+          title: 'New Transaction',
+          description: t.description,
+          category: t.category,
+          amount: t.amount,
+          actionUrl: '/transactions'
+        });
+      }
     }
   }, [transactions]);
 


### PR DESCRIPTION
Every refresh announced the same standing order as a new transaction (badge climbing 23→29→32) while nothing was being added. The logger compared the newest row's **date** to the wall clock — and a standing order dated tomorrow makes that difference negative, i.e. always "within the last minute", so it announced itself forever.

"New" now means: an id that appears during the session. First load is the baseline and says nothing; later arrivals announce once each. Three tests pin it, including the exact future-dated shape that fired forever.

Also upgrades the `?viewport-debug=1` overlay with content-chain box measurements — on the affected device every page-level number reads clean (440 wide, scale 1.000, zero overflow) yet content stops ~55pt short of the right edge, so the next device screenshot needs to say **which box** loses the width.

Gates green (3,462 tests, 3 new).

🤖 Generated with [Claude Code](https://claude.com/claude-code)