### PR TITLE
Mobile: the phone keeps what a phone needs

### DIFF
--- a/src/components/InfiniteScrollTransactionList.tsx
+++ b/src/components/InfiniteScrollTransactionList.tsx
@@ -207,7 +207,8 @@ export const InfiniteScrollTransactionList = memo(function InfiniteScrollTransac
       {visibleTransactions.length > 10 && (
         <button
           onClick={() => window.scrollTo({ top: 0, behavior: 'smooth' })}
-          className="fixed bottom-20 right-4 z-20 p-3 bg-white dark:bg-gray-800 rounded-full shadow-lg hover:shadow-xl transition-shadow"
+          className="fixed z-20 p-3 bg-white dark:bg-gray-800 rounded-full shadow-lg hover:shadow-xl transition-shadow"
+          style={{ right: '1rem', bottom: 'calc(5rem + env(safe-area-inset-bottom))' }}
           aria-label="Scroll to top"
         >
           <svg className="w-5 h-5 text-gray-600 dark:text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -3,7 +3,7 @@ import { Link, useLocation, Outlet, useNavigate } from 'react-router-dom';
 
 const AddTransactionModal = lazy(() => import('./AddTransactionModal'));
 import { UserButton } from '@clerk/clerk-react';
-import { HomeIcon, CreditCardIcon, WalletIcon, TrendingUpIcon, SettingsIcon, MenuIcon, XIcon, ArrowRightLeftIcon, BarChart3Icon, GoalIcon, ChevronRightIcon, DatabaseIcon, TagIcon, Settings2Icon, TargetIcon, LineChartIcon, HashIcon, SearchIcon, PieChartIcon, ShieldIcon, UploadIcon, DownloadIcon, FolderIcon, BankIcon, CalendarIcon } from '../components/icons';
+import { HomeIcon, CreditCardIcon, WalletIcon, TrendingUpIcon, SettingsIcon, MenuIcon, XIcon, ArrowRightLeftIcon, BarChart3Icon, GoalIcon, ChevronRightIcon, DatabaseIcon, TagIcon, Settings2Icon, TargetIcon, HashIcon, SearchIcon, PieChartIcon, ShieldIcon, UploadIcon, DownloadIcon, FolderIcon, BankIcon, CalendarIcon } from '../components/icons';
 import { SidebarLink, TopNavItem, TopNavDropdown } from './layout/NavComponents';
 import { usePreferences } from '../contexts/PreferencesContext';
 import { PageTransition, NavigationProgress } from './layout/SimplePageTransition';
@@ -37,7 +37,6 @@ export default function Layout(): React.JSX.Element {
   const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false);
   const [settingsExpanded, setSettingsExpanded] = useState(false);
   const [accountsExpanded, setAccountsExpanded] = useState(false);
-  const [planExpanded, setPlanExpanded] = useState(false);
   // advancedExpanded removed — Advanced section now uses TopNavDropdown on desktop and direct links on mobile
   const [investmentsExpanded, setInvestmentsExpanded] = useState(false);
   const [openDropdown, setOpenDropdown] = useState<string | null>(null);
@@ -51,7 +50,6 @@ export default function Layout(): React.JSX.Element {
     isDemoModeRuntimeAllowed(import.meta.env) && searchParams.get('demo') === 'true';
   const { registration } = useServiceWorker();
   const {
-    showGoals,
     showInvestments,
     showEnhancedInvestments,
   } = usePreferences();
@@ -538,35 +536,9 @@ export default function Layout(): React.JSX.Element {
                   </div>
                 )}
                 
-                {/* Plan with Sub-navigation — mirrors the desktop Plan menu.
-                    This replaced the Forecasting section, which was the only
-                    route to a Budget on mobile: there wasn't one. Forecasting
-                    and Goals ride inside it, keeping their feature gate. */}
-                <div>
-                  <Link
-                    to={isDemoModeRoutingEnabled ? '/budget?demo=true' : '/budget'}
-                    onClick={() => {
-                      setPlanExpanded(!planExpanded);
-                      toggleMobileMenu();
-                    }}
-                    className="w-full flex items-center gap-2 px-3 py-2.5 md:py-2 rounded-lg transition-colors min-h-[40px] md:min-h-[auto] bg-secondary text-white dark:text-gray-300 hover:bg-secondary dark:hover:bg-gray-800/50"
-                  >
-                    <TargetIcon size={18} />
-                    <span className="flex-1 text-sm text-left">Plan</span>
-                    <ChevronRightIcon
-                      size={14}
-                      className={`text-gray-400 transition-transform duration-200 ${planExpanded ? 'rotate-90' : ''}`}
-                    />
-                  </Link>
-                  {planExpanded && (
-                    <div className="mt-1 space-y-1">
-                      <SidebarLink to="/budget" icon={BarChart3Icon} label="Budget" isCollapsed={false} isSubItem={true} onNavigate={toggleMobileMenu} />
-                      <SidebarLink to="/calendar" icon={CalendarIcon} label="Calendar" isCollapsed={false} isSubItem={true} onNavigate={toggleMobileMenu} />
-                      {showGoals && <SidebarLink to="/goals" icon={GoalIcon} label="Goals" isCollapsed={false} isSubItem={true} onNavigate={toggleMobileMenu} />}
-                      {showGoals && <SidebarLink to="/forecasting" icon={LineChartIcon} label="Forecasting" isCollapsed={false} isSubItem={true} onNavigate={toggleMobileMenu} />}
-                    </div>
-                  )}
-                </div>
+                {/* Plan (Budget, Goals, Forecasting, Calendar) is desk work
+                    and deliberately absent here — the drawer is the phone's
+                    menu, and the desktop top-nav keeps the full Plan menu. */}
                 <SidebarLink to="/reports" icon={PieChartIcon} label="Reports" isCollapsed={false} onNavigate={toggleMobileMenu} />
                 {/* Settings with Sub-navigation */}
                 <div>

--- a/src/components/MobileBottomNav.tsx
+++ b/src/components/MobileBottomNav.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import { Link, useLocation } from 'react-router-dom';
-import { HomeIcon, WalletIcon, BarChart3Icon, CheckCircleIcon, TagIcon, TrendingUpIcon, SettingsIcon, PlusIcon, XIcon } from './icons';
+import { HomeIcon, WalletIcon, BarChart3Icon, CheckCircleIcon, TagIcon, PlusIcon, XIcon } from './icons';
 
 interface MobileNavItem {
   to: string;
@@ -70,22 +70,6 @@ export default function MobileBottomNav(): React.JSX.Element {
               <WalletIcon size={20} />
               <span>Add Account</span>
             </Link>
-            <Link
-              to="/budget?action=add"
-              className="flex items-center gap-3 px-4 py-3 hover:bg-gray-100 dark:hover:bg-gray-700 rounded-lg"
-              onClick={() => setShowQuickActions(false)}
-            >
-              <TrendingUpIcon size={20} />
-              <span>Add Budget</span>
-            </Link>
-            <Link
-              to="/goals?action=add"
-              className="flex items-center gap-3 px-4 py-3 hover:bg-gray-100 dark:hover:bg-gray-700 rounded-lg"
-              onClick={() => setShowQuickActions(false)}
-            >
-              <SettingsIcon size={20} />
-              <span>Set Goal</span>
-            </Link>
           </div>
         </div>
       )}
@@ -93,12 +77,15 @@ export default function MobileBottomNav(): React.JSX.Element {
       {/* Quick Action Button */}
       <button
         onClick={() => setShowQuickActions(!showQuickActions)}
-        // Rides on top of the safe-area inset the nav below now honours,
-        // rather than a bare 5rem: the nav grew by the inset, so a fixed
-        // offset would have put this button through it on any notched phone.
-        className={`md:hidden fixed bottom-[calc(5rem+env(safe-area-inset-bottom))] right-4 w-14 h-14 bg-primary dark:bg-[#1a2332] text-white rounded-full shadow-lg z-50 flex items-center justify-center transition-transform ${
+        // Position via inline style, not utility classes: on the actual
+        // device this button rendered at the LEFT edge while the same build
+        // put it bottom-right in every desktop browser. An inline style is
+        // beyond the reach of whatever ate the classes. Bottom rides the
+        // safe-area inset the nav honours.
+        className={`md:hidden fixed w-14 h-14 bg-primary dark:bg-[#1a2332] text-white rounded-full shadow-lg z-50 flex items-center justify-center transition-transform ${
           showQuickActions ? 'rotate-45' : ''
         }`}
+        style={{ right: '1rem', bottom: 'calc(5rem + env(safe-area-inset-bottom))' }}
         aria-label="Quick actions"
       >
         {showQuickActions ? <XIcon size={24} /> : <PlusIcon size={24} />}

--- a/src/components/QuickDateFilters.tsx
+++ b/src/components/QuickDateFilters.tsx
@@ -104,7 +104,8 @@ export default function QuickDateFilters({ onDateRangeSelect, currentFrom, curre
         <span className="text-sm font-medium text-gray-700 dark:text-gray-300">Quick Date Filters</span>
       </div>
       
-      <div className="flex flex-wrap gap-2">
+      {/* Equal thirds on phones — free wrapping left a ragged edge. */}
+      <div className="grid grid-cols-3 gap-2 sm:flex sm:flex-wrap">
         {quickRanges.map((range) => {
           const value = range.getValue();
           const active = isActive(value);

--- a/src/components/dashboard/ImprovedDashboard.tsx
+++ b/src/components/dashboard/ImprovedDashboard.tsx
@@ -856,8 +856,9 @@ export function ImprovedDashboard() {
         </section>
       )}
 
-      {/* Quick Actions */}
-      <nav aria-label="Quick actions" className="grid grid-cols-2 sm:grid-cols-4 gap-6">
+      {/* Quick Actions — desktop only: on a phone the + button's menu
+          covers adding, and budgets/goals are desk work. */}
+      <nav aria-label="Quick actions" className="hidden md:grid md:grid-cols-4 gap-6">
         <button
           onClick={() => setShowAddTransactionModal(true)}
           className="p-8 bg-white dark:bg-gray-800 rounded-xl shadow-sm border border-gray-100 dark:border-gray-700 hover:shadow-md transition-all text-center min-h-[140px] flex flex-col items-center justify-center focus:outline-none focus:ring-2 focus:ring-blue-600 focus:ring-offset-2"

--- a/src/components/pwa/QuickAddOfflineButton.tsx
+++ b/src/components/pwa/QuickAddOfflineButton.tsx
@@ -21,7 +21,8 @@ export const QuickAddOfflineButton: React.FC = () => {
     <>
       <button
         onClick={() => setShowForm(true)}
-        className="fixed bottom-20 right-4 z-40 bg-[#1a2332] hover:bg-[#2d3a4d] text-white rounded-full p-4 shadow-lg transition-all transform hover:scale-110"
+        className="fixed z-40 bg-[#1a2332] hover:bg-[#2d3a4d] text-white rounded-full p-4 shadow-lg transition-all transform hover:scale-110"
+        style={{ right: '1rem', bottom: 'calc(9.5rem + env(safe-area-inset-bottom))' }}
         title="Add transaction (offline)"
       >
         <div className="relative">

--- a/src/pages/Accounts.tsx
+++ b/src/pages/Accounts.tsx
@@ -391,9 +391,16 @@ export default function Accounts({ onAccountClick }: { onAccountClick?: (account
                       <div className="flex-1 min-w-0">
                         <div className="flex items-center gap-2">
                           <TypeIcon className={typeColor} size={16} />
-                          <h3 className="text-base md:text-lg font-medium text-gray-900 dark:text-white hover:text-blue-600 dark:hover:text-blue-400 transition-colors">
+                          <h3 className="text-base md:text-lg font-medium text-gray-900 dark:text-white hover:text-blue-600 dark:hover:text-blue-400 transition-colors truncate min-w-0 flex-1">
                             {account.name}
                           </h3>
+                          {/* The figure the card exists to show, where a
+                              banking list puts it: right of the name. The
+                              stats row's copy hides below sm to avoid saying
+                              it twice. */}
+                          <span className="sm:hidden shrink-0 text-base font-semibold tabular-nums text-gray-900 dark:text-white">
+                            {formatDisplayCurrency(computeAccountBalance(account.id), account.currency)}
+                          </span>
                         </div>
                         {account.institution && (
                           <p className="text-xs md:text-sm text-gray-500 dark:text-gray-400">
@@ -460,7 +467,7 @@ export default function Accounts({ onAccountClick }: { onAccountClick?: (account
                                     : 'N/A'}
                                 </p>
                               </div>
-                              <div className="text-right">
+                              <div className="hidden sm:block text-right">
                                 <p className="text-[10px] uppercase tracking-wide text-gray-400 dark:text-gray-500">Account Bal</p>
                                 <p className="text-sm font-semibold tabular-nums text-gray-900 dark:text-white">
                                   {formatDisplayCurrency(computeAccountBalance(account.id), account.currency)}

--- a/src/pages/Transactions.tsx
+++ b/src/pages/Transactions.tsx
@@ -655,11 +655,13 @@ const Transactions = React.memo(function Transactions() {
             />
           </Suspense>
           
-          {/* Custom Date Range */}
-          <div className="flex flex-wrap items-center gap-2">
+          {/* Custom Date Range — label on its own line, the two pickers as
+              equal halves beneath it on phones; the single wrapping row from
+              sm up. */}
+          <div className="grid grid-cols-2 items-center gap-2 sm:flex sm:flex-wrap">
             <CalendarIcon size={18} className="text-gray-500 dark:text-gray-400 hidden sm:block" />
-            <span className="text-sm font-medium text-gray-700 dark:text-gray-300">Custom Range:</span>
-            <div className="flex-1 min-w-[150px]">
+            <span className="col-span-2 sm:col-auto text-sm font-medium text-gray-700 dark:text-gray-300">Custom Range:</span>
+            <div className="min-w-0 sm:flex-1 sm:min-w-[150px]">
               <DatePicker
                 id="date-from"
                 value={dateFrom}
@@ -668,8 +670,8 @@ const Transactions = React.memo(function Transactions() {
                 aria-label="Filter from date"
               />
             </div>
-            <span className="text-sm text-gray-500 dark:text-gray-400">to</span>
-            <div className="flex-1 min-w-[150px]">
+            <span className="hidden sm:inline text-sm text-gray-500 dark:text-gray-400">to</span>
+            <div className="min-w-0 sm:flex-1 sm:min-w-[150px]">
               <DatePicker
                 id="date-to"
                 value={dateTo}


### PR DESCRIPTION
Five device-testing requests:

1. **The + button** positions itself by inline style — on the actual device the class-positioned button rendered at the LEFT edge while every desktop browser put it bottom-right. Scroll-to-top and the offline + get the same treatment; the offline + also moves up so the two can never stack.
2. **The + menu** offers exactly Add Transaction and Add Account; budgets and goals are desk work. The dashboard's four quick-action tiles become desktop-only (the + covers adding on a phone).
3. **Account cards** lead with the figure: name left, balance right on the same line, the way a banking list reads. The stats row's duplicate balance hides below sm.
4. **The date search** on Transactions gets the grid treatment — quick filters in equal thirds, custom-range pickers as two equal halves under their label.
5. **The drawer loses Plan** (Budget, Calendar, Goals, Forecasting) — desktop keeps its full Plan menu.

Verified at 440px and 1280px in demo mode; measurements in the commit. Gates green (3,462 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)