### PR TITLE
CSS: the touch-target rule stops overriding position:fixed

### DIFF
--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -183,11 +183,12 @@ export default function Layout(): React.JSX.Element {
 
   return (
     // A block, not a flex row. The row layout served a sidebar that no longer
-    // exists, and it made <main> share its width with EVERY in-flow sibling:
-    // on a real iPhone something rendered a 56px box beside it (measured on
-    // device: main W384 R56 on a 440pt screen while html/body were full
-    // width), pinning every page 56px left of centre. In a block layout a
-    // stray sibling costs nothing — it falls below instead of beside.
+    // exists, and it made <main> share its width with EVERY in-flow sibling.
+    // The "invisible 56px sibling" that squeezed main on real iPhones was
+    // later identified: a touch-device CSS rule (index.css) was overriding
+    // position:fixed on every BUTTON, dropping the w-14 floating + into
+    // normal flow beside main. That rule is fixed too — block layout stays
+    // because main's width should never be negotiable in the first place.
     <div className="min-h-screen bg-[#f8f9fb] dark:bg-gray-900">
       <DemoModeIndicator />
       <EnhancedSkipLinks />

--- a/src/index.css
+++ b/src/index.css
@@ -22,6 +22,16 @@
   /* Ensure all interactive elements have minimum touch target size.
      .toggle-switch is exempt — it carries its own ≥44px hit area via
      padding while the visible track stays slim. */
+  /* NO position here. This block once set `position: relative` on every
+     button — and `button:not(.toggle-switch)` outranks Tailwind's `.fixed`
+     (a :not() with a class inside scores 0,1,1 against the utility's 0,1,0),
+     so on every TOUCH device each fixed-positioned button in the app fell
+     silently into normal flow. That one line was the floating + button
+     rendering at the LEFT screen edge, the scroll-to-top button sitting
+     mid-page, and the invisible 56px flex sibling that squeezed <main> and
+     pinned every page off-centre — none of it ever reproducible on a
+     desktop, because this media query never matches one. Positioning
+     belongs to components; this block's job is minimum hit areas only. */
   .touch-target,
   button:not(.toggle-switch),
   a,
@@ -32,18 +42,15 @@
   [role="link"],
   [role="menuitem"],
   [role="tab"] {
-    position: relative;
     min-width: 44px;
     min-height: 44px;
   }
-  
-  /* For inline elements that can't be resized, expand touch area */
-  a:not(.touch-target-expanded),
-  button:not(.touch-target-expanded) {
+
+  /* The invisible expanded hit area needs a positioned parent — the ONE
+     place that may set it, on its own opt-in class. */
+  .touch-target-small {
     position: relative;
   }
-  
-  /* Invisible expanded touch area for small elements */
   .touch-target-small::after {
     content: "";
     position: absolute;


### PR DESCRIPTION
The last mobile mystery, cracked by its own screenshot: the floating + at the far LEFT edge while its own popup menu opened correctly bottom-right. The button is a `<button>`; the menu is a `<div>` — and the touch-target block in index.css set `position: relative` on every button under `@media (hover: none) and (pointer: coarse)`. `button:not(.toggle-switch)` scores specificity 0,1,1 against Tailwind's `.fixed` at 0,1,0, so on **every touch device — and never on any desktop** — each fixed-positioned button silently fell into normal flow.

One line, four symptoms: the + at the left edge, scroll-to-top mid-page, the offline + astray, and the "invisible 56px flex sibling" that pinned every page off-centre (it was the w-14 + button, in flow, beside main).

Reproduced both ways in a desktop browser: injecting the old rule flips the +'s computed position to `relative` and lands it at x=−16 — matching the device screenshot to the pixel; the corrected rule leaves it `fixed` at 16px from the right. The block keeps its 44px minimum hit areas; `.touch-target-small` keeps its own `position: relative` for the ::after trick.

Gates green (3,462 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)