### PR TITLE
Notifications RLS joins the Clerk bridge; migration rules get a README

### DIFF
--- a/scripts/seedDemoUser.mts
+++ b/scripts/seedDemoUser.mts
@@ -16,8 +16,10 @@
  *    first-login bootstrap sees them and does nothing.
  *
  * Transfer legs are linked by direct update (type/category/linked ids on both
- * sides) because the link_transfer_pair RPC is not present in production —
- * probed 2026-07-26. The update mirrors what that RPC does.
+ * sides), mirroring what the link_transfer_pair RPC does. A 2026-07-26 probe
+ * concluded that RPC was absent in production; a later catalog check proved
+ * it exists — the probe hit a stale PostgREST schema cache. The direct
+ * update is kept anyway: it needs no RPC grant and is equally verifiable.
  *
  * Usage:
  *   npx tsx scripts/seedDemoUser.mts --email demo@example.com --password 'S3cret!' [--env .env.local]

--- a/supabase/migrations/20260730134450_notifications_rls_clerk_bridge.sql
+++ b/supabase/migrations/20260730134450_notifications_rls_clerk_bridge.sql
@@ -1,0 +1,35 @@
+-- Modernise notifications RLS onto the Clerk bridge.
+--
+-- The four original policies keyed on auth.uid(), which is ALWAYS NULL under
+-- Clerk authentication — so every client call against this table has failed
+-- closed since the Clerk migration, and the table was effectively
+-- service-role-only. Fails-closed is safe, but it is also a silently dead
+-- feature: notificationService has seven client call sites that could never
+-- read or write a row.
+--
+-- Rewritten in the exact shape every other per-user table uses:
+-- requesting_user_id() (SECURITY DEFINER, maps the JWT's clerk_id to
+-- users.id), scoped TO authenticated. anon matches no policy and stays at
+-- deny-all, which the old untargeted policies only achieved by accident.
+
+DROP POLICY IF EXISTS "Users can create their own notifications" ON public.notifications;
+DROP POLICY IF EXISTS "Users can delete their own notifications" ON public.notifications;
+DROP POLICY IF EXISTS "Users can update their own notifications" ON public.notifications;
+DROP POLICY IF EXISTS "Users can view their own notifications" ON public.notifications;
+
+CREATE POLICY notifications_select_own ON public.notifications
+  FOR SELECT TO authenticated
+  USING (user_id = public.requesting_user_id());
+
+CREATE POLICY notifications_insert_own ON public.notifications
+  FOR INSERT TO authenticated
+  WITH CHECK (user_id = public.requesting_user_id());
+
+CREATE POLICY notifications_update_own ON public.notifications
+  FOR UPDATE TO authenticated
+  USING (user_id = public.requesting_user_id())
+  WITH CHECK (user_id = public.requesting_user_id());
+
+CREATE POLICY notifications_delete_own ON public.notifications
+  FOR DELETE TO authenticated
+  USING (user_id = public.requesting_user_id());

--- a/supabase/migrations/README.md
+++ b/supabase/migrations/README.md
@@ -1,0 +1,40 @@
+# Migrations — the rules
+
+The migration history was reconciled against the live database on 2026-07-30:
+every file in this directory is recorded as applied, `npm run db:migrate`
+reports "Remote database is up to date", and it must stay that way. These
+rules are what keep it true.
+
+## The rules
+
+1. **Every schema change goes through `npm run db:migrate`.** Never run
+   schema SQL in the Supabase SQL editor — the editor records nothing, and
+   unrecorded changes are exactly how the history once drifted 49 migrations
+   apart from reality.
+
+   ```sh
+   npm run db:migration:new <short_name>   # writes the file here
+   # edit the file, then:
+   SUPABASE_DB_URL="$(grep -m1 '^SUPABASE_DB_URL=' .env.local | cut -d= -f2-)" npm run db:migrate
+   ```
+
+   (npm does not read `.env.local` on its own — the inline export is needed.)
+
+2. **Never rename a file in this directory.** Filenames are the version
+   ids the remote history records; renaming one desyncs local from remote
+   and `db push` will try to replay it.
+
+3. **Some early files are recorded as applied even though later migrations
+   deliberately replaced what they created** (e.g. `20260309000000`,
+   `20260310000400`, `20260310000600`, `20260311000000`, superseded by
+   `20260610130000`). That is correct and intentional: history records what
+   ran, not what survives. They must never be replayed — which rule 2 and a
+   truthful history already guarantee.
+
+4. **Never use `db push --include-all`.** Plain `npm run db:migrate` proposes
+   only unrecorded migrations, which is the entire safety model.
+
+5. **If the pooler refuses the connection with `EADDRNOTALLOWED … not in
+   tenant allow_list`, that is the IP allowlist, not the password.** The
+   dashboard's Network Restrictions hold specific IPs and home IPs are
+   dynamic — add the current one and retry.


### PR DESCRIPTION
Closes the two parked items from the migration reconciliation, plus one correction:

- **notifications RLS modernised.** Its four policies keyed on `auth.uid()` — always NULL under Clerk — so every client call failed closed and the feature was silently dead. Rewritten on `requesting_user_id()` TO authenticated, the same shape as every other per-user table; anon stays deny-all by design. Applied via `npm run db:migrate` (the first migration through the sanctioned path since the repair — the push proposed exactly this one file) and catalog-verified: four policies, all `authenticated`, migration list 52/52.
- **`supabase/migrations/README.md`** states the standing rules where the next person will look: db:migrate only, never rename, the recorded-but-superseded early versions, no `--include-all`, and the dynamic-IP pooler gotcha.
- **Seeder comment corrected**: `link_transfer_pair` DOES exist in production (catalog-checked); the earlier probe that said otherwise hit a stale PostgREST schema cache.

Gates green via the pre-commit hook.

🤖 Generated with [Claude Code](https://claude.com/claude-code)