### PR TITLE
Accounts fixed columns, feed refresh automation, and filing without the clicks

### DIFF
--- a/src/components/BulkCategorizeModal.tsx
+++ b/src/components/BulkCategorizeModal.tsx
@@ -5,7 +5,7 @@ import { useApp } from '../contexts/AppContextSupabase';
 import { useToast } from '../contexts/ToastContext';
 import { useCurrencyDecimal } from '../hooks/useCurrencyDecimal';
 import { buildPayeeGroups, type PayeeGroup } from '../utils/payeeGroups';
-import { ArrowDownIcon, ArrowUpIcon } from './icons';
+import { ArrowDownIcon, ArrowUpIcon, XIcon } from './icons';
 
 /**
  * Bulk categorise by payee: file a whole merchant in one decision.
@@ -133,7 +133,9 @@ export default function BulkCategorizeModal({ isOpen, onClose }: Props): React.J
       onClose={applying ? () => {} : onClose}
       closeOnBackdrop={!applying}
       title="Categorise by payee"
-      size="xl"
+      // 2xl: the category picker is the working column of this screen, and at
+      // xl it was the cramped one — long "Parent > Child" names need the room.
+      size="2xl"
     >
       <ModalBody>
         {groups.length === 0 ? (
@@ -158,7 +160,7 @@ export default function BulkCategorizeModal({ isOpen, onClose }: Props): React.J
                     <th className="text-left pb-2 font-medium">Payee</th>
                     <th className="text-right pb-2 font-medium">Rows</th>
                     <th className="text-right pb-2 font-medium">Total</th>
-                    <th className="text-left pb-2 font-medium w-72">Category</th>
+                    <th className="text-left pb-2 font-medium w-72 lg:w-96">Category</th>
                   </tr>
                 </thead>
                 <tbody className="block sm:table-row-group">
@@ -172,7 +174,7 @@ export default function BulkCategorizeModal({ isOpen, onClose }: Props): React.J
                             {group.direction === 'expense'
                               ? <ArrowDownIcon size={12} className="text-red-500 flex-shrink-0" />
                               : <ArrowUpIcon size={12} className="text-green-600 flex-shrink-0" />}
-                            <span className="text-sm text-gray-900 dark:text-white truncate max-w-[220px]">
+                            <span className="text-sm text-gray-900 dark:text-white truncate max-w-[220px] lg:max-w-[340px]">
                               {group.displayName}
                             </span>
                           </span>
@@ -216,16 +218,35 @@ export default function BulkCategorizeModal({ isOpen, onClose }: Props): React.J
                           {formatCurrency(group.total)}
                         </td>
                         <td className="block sm:table-cell col-span-3 sm:col-auto pb-3 pt-0 sm:py-2">
-                          <CategorySelector
-                            selectedCategory={chosen}
-                            onCategoryChange={(categoryId) => setChoice(group, categoryId)}
-                            transactionType={group.direction}
-                            includeAllTypes
-                            showHelperText={false}
-                            usePortal
-                            placeholder="Choose a category…"
-                            className="w-full"
-                          />
+                          <span className="flex items-center gap-1.5">
+                            <CategorySelector
+                              selectedCategory={chosen}
+                              onCategoryChange={(categoryId) => setChoice(group, categoryId)}
+                              transactionType={group.direction}
+                              includeAllTypes
+                              showHelperText={false}
+                              usePortal
+                              placeholder="Choose a category…"
+                              className="w-full flex-1 min-w-0"
+                            />
+                            {/* The way OUT of a pre-fill. A suggestion the
+                                user does not trust for a bulk decision must
+                                be clearable — back to "Choose a category…",
+                                which excludes this payee from the apply and
+                                leaves its rows for line-by-line filing. */}
+                            {chosen !== '' && (
+                              <button
+                                type="button"
+                                onClick={() => setChoice(group, '')}
+                                disabled={applying}
+                                className="shrink-0 p-1.5 rounded-lg text-gray-400 hover:text-gray-700 dark:hover:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors disabled:opacity-50"
+                                title="Clear — leave this payee to categorise line by line"
+                                aria-label={`Clear category for ${group.displayName}`}
+                              >
+                                <XIcon size={14} />
+                              </button>
+                            )}
+                          </span>
                         </td>
                       </tr>
                     );

--- a/src/components/IncomeExpenseBreakdownModal.tsx
+++ b/src/components/IncomeExpenseBreakdownModal.tsx
@@ -1,4 +1,5 @@
-import React, { useMemo, useState } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
+import CategorySelector from './CategorySelector';
 import { Modal, ModalBody } from './common/Modal';
 import { useCurrencyDecimal } from '../hooks/useCurrencyDecimal';
 import { bucketContribution } from '../utils/incomeExpense';
@@ -35,6 +36,15 @@ interface Props {
   total: number | null;
   categories: Category[];
   onEditTransaction: (transactionId: string) => void;
+  /**
+   * Present only on the uncategorised drill: turns the Category column into
+   * an inline picker so rows can be filed WITHOUT opening each one. Choices
+   * accumulate; Save appears in the header once any exist; saved rows leave
+   * the list. Receives categoryId → transaction ids, returns rows updated.
+   * Split lines are excluded — their category lives on the split line, not
+   * the parent this callback fills.
+   */
+  onApplyCategories?: (assignments: Map<string, string[]>) => Promise<number>;
 }
 
 type SortKey = 'category' | 'date' | 'description' | 'amount';
@@ -50,8 +60,60 @@ export default function IncomeExpenseBreakdownModal({
   total,
   categories,
   onEditTransaction,
+  onApplyCategories,
 }: Props): React.JSX.Element {
   const { formatCurrency } = useCurrencyDecimal();
+  const inlineFiling = bucket === 'uncategorized' && onApplyCategories !== undefined;
+
+  // Row id → chosen category ('' = choice cleared). Saved rows leave the
+  // list locally the moment the save lands — the upstream recompute follows
+  // on its own time.
+  const [pendingChoices, setPendingChoices] = useState<Record<string, string>>({});
+  const [savedIds, setSavedIds] = useState<Set<string>>(new Set());
+  const [saving, setSaving] = useState(false);
+
+  // A fresh drill is a fresh slate.
+  useEffect(() => {
+    if (isOpen) {
+      setPendingChoices({});
+      setSavedIds(new Set());
+    }
+  }, [isOpen]);
+
+  const liveRows = useMemo(
+    () => (savedIds.size > 0 ? rows.filter(r => !savedIds.has(r.id)) : rows),
+    [rows, savedIds]
+  );
+
+  const pendingCount = useMemo(
+    () => Object.values(pendingChoices).filter(v => v !== '').length,
+    [pendingChoices]
+  );
+
+  const handleSave = async (): Promise<void> => {
+    if (!onApplyCategories || saving) return;
+    const assignments = new Map<string, string[]>();
+    for (const [rowId, categoryId] of Object.entries(pendingChoices)) {
+      if (categoryId === '') continue;
+      const list = assignments.get(categoryId);
+      if (list) list.push(rowId);
+      else assignments.set(categoryId, [rowId]);
+    }
+    if (assignments.size === 0) return;
+    setSaving(true);
+    try {
+      await onApplyCategories(assignments);
+      setSavedIds(prev => {
+        const next = new Set(prev);
+        assignments.forEach(ids => ids.forEach(id => next.add(id)));
+        return next;
+      });
+      setPendingChoices({});
+    } finally {
+      // On failure the choices stay put — nothing the user picked is lost.
+      setSaving(false);
+    }
+  };
   // Category sections by default — the Money-style view.
   const [sortKey, setSortKey] = useState<SortKey>('category');
   const [sortDir, setSortDir] = useState<1 | -1>(1);
@@ -75,7 +137,7 @@ export default function IncomeExpenseBreakdownModal({
   // Either a flat sorted list, or category sections (each with subtotal),
   // capped so an All-time window can't render tens of thousands of rows.
   const view = useMemo(() => {
-    const sorted = [...rows];
+    const sorted = [...liveRows];
     if (sortKey === 'date') {
       sorted.sort((a, b) => sortDir * (new Date(a.date).getTime() - new Date(b.date).getTime()));
     } else if (sortKey === 'description') {
@@ -117,7 +179,7 @@ export default function IncomeExpenseBreakdownModal({
     }
     return { sections: capped, truncated };
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [rows, sortKey, sortDir, categoryName, bucket]);
+  }, [liveRows, sortKey, sortDir, categoryName, bucket]);
 
   const colourClass = bucket === 'income'
     ? 'text-green-600 dark:text-green-400'
@@ -159,9 +221,26 @@ export default function IncomeExpenseBreakdownModal({
             <span className="ml-2 text-xs text-gray-400 dark:text-gray-500">(credit)</span>
           )}
         </td>
-        <td className="py-2 pr-3 text-sm text-gray-500 dark:text-gray-400">
-          {categoryName(t.category)}
-        </td>
+        {inlineFiling && !t.isSplitLine ? (
+          // Picking is not opening: the cell swallows the click so the row's
+          // click-to-edit stays available everywhere else on the row.
+          <td className="py-1.5 pr-3" onClick={(e) => e.stopPropagation()}>
+            <CategorySelector
+              selectedCategory={pendingChoices[t.id] ?? ''}
+              onCategoryChange={(categoryId) => setPendingChoices(prev => ({ ...prev, [t.id]: categoryId }))}
+              transactionType={t.amount < 0 ? 'expense' : 'income'}
+              includeAllTypes
+              showHelperText={false}
+              usePortal
+              placeholder="Choose a category…"
+              className="w-full min-w-[13rem]"
+            />
+          </td>
+        ) : (
+          <td className="py-2 pr-3 text-sm text-gray-500 dark:text-gray-400">
+            {categoryName(t.category)}
+          </td>
+        )}
         <td className={`py-2 text-sm font-medium text-right whitespace-nowrap tabular-nums ${rowColour}`}>
           {value < 0 ? `-${formatCurrency(Math.abs(value))}` : formatCurrency(value)}
         </td>
@@ -170,9 +249,26 @@ export default function IncomeExpenseBreakdownModal({
   };
 
   return (
-    <Modal isOpen={isOpen} onClose={onClose} title={title} size="lg">
+    <Modal
+      isOpen={isOpen}
+      onClose={onClose}
+      title={title}
+      size={inlineFiling ? 'xl' : 'lg'}
+      headerActions={
+        inlineFiling && pendingCount > 0 ? (
+          <button
+            type="button"
+            onClick={() => void handleSave()}
+            disabled={saving}
+            className="px-4 py-1.5 text-sm font-medium rounded-lg bg-[#1a2332] dark:bg-blue-600 text-white hover:bg-[#2d3a4d] dark:hover:bg-blue-700 transition-colors disabled:opacity-60 disabled:cursor-wait"
+          >
+            {saving ? 'Saving…' : `Save ${pendingCount}`}
+          </button>
+        ) : undefined
+      }
+    >
       <ModalBody>
-        {rows.length === 0 ? (
+        {liveRows.length === 0 ? (
           <p className="text-center py-8 text-gray-400">No transactions</p>
         ) : (
           <table className="w-full">
@@ -208,7 +304,7 @@ export default function IncomeExpenseBreakdownModal({
               {view.truncated > 0 && (
                 <tr>
                   <td colSpan={4} className="py-3 text-center text-xs text-gray-400 dark:text-gray-500">
-                    Showing {CAP.toLocaleString()} of {rows.length.toLocaleString()} rows — the total below covers them all.
+                    Showing {CAP.toLocaleString()} of {liveRows.length.toLocaleString()} rows — the total below covers them all.
                   </td>
                 </tr>
               )}

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -28,6 +28,7 @@ import KeyboardSequenceIndicator from './KeyboardSequenceIndicator';
 import { RealtimeStatusDot } from './RealtimeStatusIndicator';
 import MobileBottomNav from './MobileBottomNav';
 import { useSwipeGestures } from '../hooks/useSwipeGestures';
+import { useAutoBankSync } from '../hooks/useAutoBankSync';
 import DemoModeIndicator from './DemoModeIndicator';
 import ViewportDebugOverlay from './ViewportDebugOverlay';
 import SyncStatusIndicator from './SyncStatusIndicator';
@@ -83,6 +84,10 @@ export default function Layout(): React.JSX.Element {
   
   // Initialize global keyboard shortcuts
   const { activeSequence } = useGlobalKeyboardShortcuts(openHelp);
+
+  // Scheduled bank-feed refresh (on sign-in / daily at a set time) — the
+  // schedule itself lives in Settings; signed-out sessions do nothing.
+  useAutoBankSync();
 
   // Simple page navigation helper
   const getNextPrevPage = (direction: 'next' | 'prev', currentPath: string): string | null => {

--- a/src/components/common/Modal.tsx
+++ b/src/components/common/Modal.tsx
@@ -7,7 +7,10 @@ interface ModalProps {
   onClose: () => void;
   title: string;
   children: React.ReactNode;
-  size?: 'sm' | 'md' | 'lg' | 'xl' | 'full';
+  size?: 'sm' | 'md' | 'lg' | 'xl' | '2xl' | 'full';
+  /** Rendered in the header, left of the close button — for a primary action
+   *  that must stay visible while the body scrolls (e.g. a batch Save). */
+  headerActions?: React.ReactNode;
   showCloseButton?: boolean;
   /**
    * Clicking outside the panel closes the modal (the modern default).
@@ -28,6 +31,7 @@ export function Modal({
   isOpen,
   onClose,
   title,
+  headerActions,
   children,
   size = 'md',
   showCloseButton = true,
@@ -134,6 +138,7 @@ export function Modal({
     md: 'max-w-md',
     lg: 'max-w-2xl',
     xl: 'max-w-4xl',
+    '2xl': 'max-w-6xl',
     full: 'max-w-full mx-4'
   };
 
@@ -191,6 +196,8 @@ export function Modal({
             ) : (
               <span aria-hidden="true" />
             )}
+            <div className="flex items-center gap-2">
+            {headerActions}
             {showCloseButton && (
               <button
                 onClick={onClose}
@@ -214,6 +221,8 @@ export function Modal({
                 <XIcon size={20} />
               </button>
             )}
+            </div>
+            
           </div>
 
           {/* Children rendered as direct flex children so ModalFooter stays pinned */}

--- a/src/components/reports/ReportDrillModal.tsx
+++ b/src/components/reports/ReportDrillModal.tsx
@@ -1,5 +1,6 @@
-import React, { useState } from 'react';
+import React, { useCallback, useState } from 'react';
 import { useApp } from '../../contexts/AppContextSupabase';
+import { useToast } from '../../contexts/ToastContext';
 import IncomeExpenseBreakdownModal, { type BreakdownBucket } from '../IncomeExpenseBreakdownModal';
 import EditTransactionModal from '../EditTransactionModal';
 import type { Category } from '../../types';
@@ -30,8 +31,33 @@ export default function ReportDrillModal({
   onClose: () => void;
   categories: Category[];
 }): React.JSX.Element {
-  const { transactions } = useApp();
+  const { transactions, applyCategoryToUncategorized } = useApp();
+  const { showSuccess, showError } = useToast();
   const [editingId, setEditingId] = useState<string | null>(null);
+
+  // The uncategorised drill files rows inline in batches: one call per
+  // distinct category, blanks-only underneath, so a concurrent edit can
+  // never be overwritten. Errors surface AND rethrow — the modal keeps the
+  // user's un-saved choices when a save fails.
+  const handleApplyCategories = useCallback(
+    async (assignments: Map<string, string[]>): Promise<number> => {
+      try {
+        let updated = 0;
+        for (const [categoryId, ids] of assignments) {
+          updated += await applyCategoryToUncategorized(ids, categoryId);
+        }
+        showSuccess(
+          `${updated.toLocaleString()} transaction${updated === 1 ? '' : 's'} categorised.`,
+          'Categories applied'
+        );
+        return updated;
+      } catch (error) {
+        showError(error);
+        throw error;
+      }
+    },
+    [applyCategoryToUncategorized, showSuccess, showError]
+  );
 
   return (
     <>
@@ -44,6 +70,7 @@ export default function ReportDrillModal({
         total={target?.total ?? null}
         categories={categories}
         onEditTransaction={setEditingId}
+        onApplyCategories={target?.bucket === 'uncategorized' ? handleApplyCategories : undefined}
       />
 
       {/* A split line's editor opens its PARENT — that is the real record. */}

--- a/src/components/settings/BankFeedRefreshSettings.tsx
+++ b/src/components/settings/BankFeedRefreshSettings.tsx
@@ -1,0 +1,101 @@
+import React, { useState } from 'react';
+import { useAuth } from '@clerk/clerk-react';
+import { RefreshCwIcon } from '../icons';
+import {
+  loadAutoSyncPrefs,
+  saveAutoSyncPrefs,
+  DEFAULT_AUTO_SYNC_PREFS,
+  type AutoSyncMode,
+  type AutoSyncPrefs,
+} from '../../utils/bankAutoSync';
+
+/**
+ * The automatic bank-feed refresh schedule. Saved per user, per device, the
+ * moment it changes — there is nothing to submit. The copy is honest about
+ * the one physical limit: a web app can only act while it is open, so a
+ * daily time means "the first opportunity on or after that time each day".
+ */
+export default function BankFeedRefreshSettings(): React.JSX.Element | null {
+  const { userId, isSignedIn } = useAuth();
+  const [prefs, setPrefs] = useState<AutoSyncPrefs>(() =>
+    userId ? loadAutoSyncPrefs(userId) : DEFAULT_AUTO_SYNC_PREFS
+  );
+
+  if (!isSignedIn || !userId) return null;
+
+  const update = (next: AutoSyncPrefs): void => {
+    setPrefs(next);
+    saveAutoSyncPrefs(userId, next);
+  };
+
+  const options: Array<{ value: AutoSyncMode; label: string; detail: string }> = [
+    {
+      value: 'off',
+      label: 'Manual only',
+      detail: 'Feeds refresh only when you press a refresh button.',
+    },
+    {
+      value: 'signin',
+      label: 'When I open the app',
+      detail: 'Refreshes on sign-in, at most once an hour.',
+    },
+    {
+      value: 'daily',
+      label: 'Once a day at a set time',
+      detail: 'Runs at the time below while the app is open — or catches up the next time you open it.',
+    },
+  ];
+
+  return (
+    <div className="bg-white dark:bg-gray-800 rounded-2xl shadow-lg border border-gray-100 dark:border-gray-700 p-6 mb-6">
+      <h2 className="text-xl font-semibold text-theme-heading dark:text-white mb-1 flex items-center gap-2">
+        <RefreshCwIcon size={20} className="text-gray-500" />
+        Bank feed refresh
+      </h2>
+      <p className="text-sm text-gray-500 dark:text-gray-400 mb-4">
+        How your connected banks pull in fresh transactions.
+      </p>
+
+      <div role="radiogroup" aria-label="Automatic feed refresh" className="flex flex-col gap-2">
+        {options.map(({ value, label, detail }) => (
+          <label
+            key={value}
+            className={`flex items-start gap-3 rounded-xl border p-3 cursor-pointer transition-colors ${
+              prefs.mode === value
+                ? 'border-[#1a2332] dark:border-blue-500 bg-gray-50 dark:bg-gray-700/50'
+                : 'border-gray-200 dark:border-gray-700 hover:border-gray-300 dark:hover:border-gray-600'
+            }`}
+          >
+            <input
+              type="radio"
+              name="bank-feed-refresh-mode"
+              checked={prefs.mode === value}
+              onChange={() => update({ ...prefs, mode: value })}
+              className="mt-1"
+            />
+            <span className="min-w-0">
+              <span className="block text-sm font-medium text-gray-900 dark:text-white">{label}</span>
+              <span className="block text-xs text-gray-500 dark:text-gray-400">{detail}</span>
+            </span>
+          </label>
+        ))}
+      </div>
+
+      {prefs.mode === 'daily' && (
+        <div className="mt-3 flex items-center gap-3 pl-1">
+          <label htmlFor="daily-refresh-time" className="text-sm text-gray-700 dark:text-gray-300">
+            Refresh at
+          </label>
+          <input
+            id="daily-refresh-time"
+            type="time"
+            value={prefs.dailyTime}
+            onChange={(e) => update({ ...prefs, dailyTime: e.target.value || DEFAULT_AUTO_SYNC_PREFS.dailyTime })}
+            className="px-3 py-1.5 text-sm rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 text-gray-900 dark:text-white"
+          />
+          <span className="text-xs text-gray-400 dark:text-gray-500">every day</span>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/hooks/useAccountBankSync.ts
+++ b/src/hooks/useAccountBankSync.ts
@@ -24,6 +24,12 @@ export interface UseAccountBankSyncResult {
   isAccountSyncing: (accountId: string) => boolean;
   /** Pull fresh accounts + transactions for the account's whole bank connection. */
   syncAccount: (accountId: string) => Promise<void>;
+  /** Sync every healthy connection, one after another; one summary toast. */
+  syncAllConnections: () => Promise<void>;
+  /** How many connections a refresh-all would touch. */
+  connectedCount: number;
+  /** True while any connection is mid-sync. */
+  isSyncingAny: boolean;
   /** Re-fetch connection metadata (last sync, status) without triggering a sync. */
   reloadConnections: () => Promise<void>;
 }
@@ -153,5 +159,87 @@ export function useAccountBankSync(options?: { onSynced?: () => void | Promise<v
     [linksByAccountId, syncingConnectionIds, onSynced, reloadConnections, showSuccess, showWarning, showError]
   );
 
-  return { getAccountLink, isAccountSyncing, syncAccount, reloadConnections };
+  // One hit for every healthy connection, sequentially — banks rate-limit,
+  // and a burst of parallel token refreshes is how a "refresh all" gets a
+  // whole login temporarily locked. Per-connection toasts are suppressed in
+  // favour of one summary; failures are counted, not fatal, so one broken
+  // connection cannot stop the rest of the round.
+  const syncAllConnections = useCallback(async () => {
+    const targets = connections.filter(
+      (c) => c.status === 'connected' && !syncingConnectionIds.has(c.id)
+    );
+    if (targets.length === 0) {
+      return;
+    }
+
+    setSyncingConnectionIds((prev) => {
+      const next = new Set(prev);
+      targets.forEach((t) => next.add(t.id));
+      return next;
+    });
+
+    let imported = 0;
+    let failed = 0;
+    try {
+      for (const target of targets) {
+        try {
+          const result = await bankConnectionService.syncConnection(target.id);
+          if (result.success) {
+            imported += result.transactionsImported;
+          } else {
+            failed += 1;
+          }
+        } catch (error) {
+          logger.error('Refresh-all: connection sync failed', error as Error);
+          failed += 1;
+        } finally {
+          setSyncingConnectionIds((prev) => {
+            const next = new Set(prev);
+            next.delete(target.id);
+            return next;
+          });
+        }
+      }
+
+      // One reload at the end covers every status flip (incl. reauth_required).
+      await reloadConnections();
+      if (failed === 0 && onSynced) {
+        await onSynced();
+      }
+
+      const done = targets.length - failed;
+      if (failed > 0) {
+        showWarning(
+          `Refreshed ${done} of ${targets.length} connections — ${failed} did not complete. Check Bank Connections.`,
+          'Feed refresh incomplete'
+        );
+      } else {
+        showSuccess(
+          imported > 0
+            ? `Refreshed ${done} connection${done === 1 ? '' : 's'} — ${imported} new transaction${imported === 1 ? '' : 's'}.`
+            : `Refreshed ${done} connection${done === 1 ? '' : 's'} — everything is up to date.`,
+          'Feeds refreshed'
+        );
+      }
+    } catch (error) {
+      logger.error('Refresh-all failed', error as Error);
+      showError(error);
+      await reloadConnections();
+    }
+  }, [connections, syncingConnectionIds, onSynced, reloadConnections, showSuccess, showWarning, showError]);
+
+  const connectedCount = useMemo(
+    () => connections.filter((c) => c.status === 'connected').length,
+    [connections]
+  );
+
+  return {
+    getAccountLink,
+    isAccountSyncing,
+    syncAccount,
+    syncAllConnections,
+    connectedCount,
+    isSyncingAny: syncingConnectionIds.size > 0,
+    reloadConnections,
+  };
 }

--- a/src/hooks/useAutoBankSync.ts
+++ b/src/hooks/useAutoBankSync.ts
@@ -1,0 +1,64 @@
+import { useEffect, useRef } from 'react';
+import { useAuth as useClerkAuth } from '@clerk/clerk-react';
+import { useAccountBankSync } from './useAccountBankSync';
+import {
+  loadAutoSyncPrefs,
+  loadLastAutoSyncRun,
+  recordAutoSyncRun,
+  shouldAutoSync,
+} from '../utils/bankAutoSync';
+import { createScopedLogger } from '../loggers/scopedLogger';
+
+const logger = createScopedLogger('useAutoBankSync');
+
+/** How often the schedule is re-checked while the app sits open. */
+const CHECK_INTERVAL_MS = 60_000;
+
+/**
+ * The automatic bank-feed refresh, mounted once in Layout.
+ *
+ * Checks the user's schedule on sign-in and then once a minute while the app
+ * is open; when a refresh is due (see shouldAutoSync for the rules) it stamps
+ * the run FIRST and then syncs every healthy connection. Stamp-then-sync is
+ * deliberate: if the sync fails, the next attempt is the next scheduled
+ * moment, not a retry storm every minute against a bank that just said no.
+ * The user always has the manual refresh button for a failed round.
+ *
+ * Does nothing signed out, and nothing when the mode is 'off' — including no
+ * timers.
+ */
+export function useAutoBankSync(): void {
+  const { userId, isSignedIn } = useClerkAuth();
+  const { syncAllConnections, connectedCount } = useAccountBankSync();
+
+  // The interval callback reads these through refs so the timer is set up
+  // once per user, not torn down whenever a connection syncs.
+  const syncRef = useRef(syncAllConnections);
+  syncRef.current = syncAllConnections;
+  const connectedRef = useRef(connectedCount);
+  connectedRef.current = connectedCount;
+
+  useEffect(() => {
+    if (!isSignedIn || !userId) return;
+
+    const check = (): void => {
+      const prefs = loadAutoSyncPrefs(userId);
+      if (prefs.mode === 'off') return;
+      if (connectedRef.current === 0) return;
+      if (!shouldAutoSync(prefs, loadLastAutoSyncRun(userId), new Date())) return;
+
+      recordAutoSyncRun(userId, new Date());
+      logger.info('Auto-refreshing bank feeds', { mode: prefs.mode });
+      void syncRef.current();
+    };
+
+    // Connections load asynchronously after sign-in; a short delay gives the
+    // first check something to act on instead of always skipping on boot.
+    const boot = setTimeout(check, 5_000);
+    const interval = setInterval(check, CHECK_INTERVAL_MS);
+    return () => {
+      clearTimeout(boot);
+      clearInterval(interval);
+    };
+  }, [isSignedIn, userId]);
+}

--- a/src/pages/Accounts.tsx
+++ b/src/pages/Accounts.tsx
@@ -91,7 +91,7 @@ export default function Accounts({ onAccountClick }: { onAccountClick?: (account
     [seededBalances, computeLedgerBalance]
   );
   // Per-account bank connection metadata + one-click "pull fresh bank data".
-  const { getAccountLink, isAccountSyncing, syncAccount } = useAccountBankSync({ onSynced: refreshAccountsAndTransactions });
+  const { getAccountLink, isAccountSyncing, syncAccount, syncAllConnections, connectedCount, isSyncingAny } = useAccountBankSync({ onSynced: refreshAccountsAndTransactions });
 
   // Only OPEN accounts appear in the main list and totals; closed ones live in
   // the Closed Accounts section below (the Microsoft Money model — closing
@@ -450,14 +450,17 @@ export default function Accounts({ onAccountClick }: { onAccountClick?: (account
                         )}
                       </div>
                       
-                      {/* flex-wrap is what keeps this inside the card on a
-                          phone: three stat columns plus the action buttons
-                          need ~420px, the card offers ~330, and items-end
-                          right-aligns the excess OUT of the card's left edge.
-                          Wrapped, the stats take one row and the buttons the
-                          next, both right-aligned, both inside the card. */}
+                      {/* Phones: a wrapping row (three stat columns plus the
+                          buttons need ~420px and the card offers ~330, so the
+                          stats take one row and the buttons the next). From sm
+                          up it is a GRID of fixed columns — three stat columns,
+                          then five reserved button slots — so every figure and
+                          every button lands at the same x on every card. An
+                          account without a bank feed keeps an EMPTY feed cell
+                          rather than letting the buttons shuffle left; muscle
+                          memory is the point. */}
                       <div className="flex flex-col sm:flex-row items-stretch sm:items-center gap-2 sm:gap-3">
-                            <div className="flex flex-wrap items-center justify-end gap-x-4 gap-y-1">
+                            <div className="flex flex-wrap items-center justify-end gap-x-4 gap-y-1 sm:grid sm:grid-cols-[6.5rem_7.5rem_5.5rem_repeat(5,3rem)] sm:justify-items-end sm:items-center sm:gap-x-2 sm:gap-y-0">
                               {/* Balance info columns */}
                               <div className="text-right">
                                 <p className="text-[10px] uppercase tracking-wide text-gray-400 dark:text-gray-500">Bank Bal</p>
@@ -483,7 +486,7 @@ export default function Accounts({ onAccountClick }: { onAccountClick?: (account
                                   {getUnreconciledCount(account.id)}
                                 </p>
                               </div>
-                              <div className="flex items-center gap-1">
+                              <div className="flex items-center justify-end">
                                 {account.type === 'investment' && account.holdings && account.holdings.length > 0 && (
                                 <button
                                   onClick={() => setPortfolioAccountId(account.id)}
@@ -497,21 +500,9 @@ export default function Accounts({ onAccountClick }: { onAccountClick?: (account
                                 </button>
                                 )}
                               </div>
-                              {/* Fixed icon positions with better spacing */}
-                              <div className="flex items-center gap-2">
-                                <div className="relative group">
-                                  <IconButton
-                                    onClick={() => setSettingsAccountId(account.id)}
-                                    icon={<SettingsIcon size={20} />}
-                                    variant="ghost"
-                                    size="md"
-                                    className="text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200 min-w-[48px] min-h-[48px]"
-                                    title="Account Settings"
-                                  />
-                                  <span className="absolute bottom-full left-1/2 transform -translate-x-1/2 mb-2 px-3 py-1.5 text-xs text-white bg-gray-900/90 dark:bg-gray-700/90 backdrop-blur-sm rounded-lg opacity-0 group-hover:opacity-100 transition-all duration-200 whitespace-nowrap pointer-events-none shadow-lg border border-white/10">
-                                    Settings
-                                  </span>
-                                </div>
+                              {/* Feed slot — rendered for every account so
+                                  the three buttons to its right never move. */}
+                              <div className="flex items-center justify-end">
                                 {bankLink && (bankLink.status === 'reauth_required' ? (
                                   <div className="relative group">
                                     <IconButton
@@ -542,6 +533,20 @@ export default function Accounts({ onAccountClick }: { onAccountClick?: (account
                                     </span>
                                   </div>
                                 ))}
+                              </div>
+                                <div className="relative group">
+                                  <IconButton
+                                    onClick={() => setSettingsAccountId(account.id)}
+                                    icon={<SettingsIcon size={20} />}
+                                    variant="ghost"
+                                    size="md"
+                                    className="text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200 min-w-[48px] min-h-[48px]"
+                                    title="Account Settings"
+                                  />
+                                  <span className="absolute bottom-full left-1/2 transform -translate-x-1/2 mb-2 px-3 py-1.5 text-xs text-white bg-gray-900/90 dark:bg-gray-700/90 backdrop-blur-sm rounded-lg opacity-0 group-hover:opacity-100 transition-all duration-200 whitespace-nowrap pointer-events-none shadow-lg border border-white/10">
+                                    Settings
+                                  </span>
+                                </div>
                                 <button
                                   onClick={() => navigate(preserveDemoParam(`/reconciliation?account=${account.id}`, location.search))}
                                   className="p-3 min-w-[48px] min-h-[48px] flex items-center justify-center text-blue-500 hover:text-blue-700 dark:text-blue-400 dark:hover:text-blue-200 hover:bg-blue-100/50 dark:hover:bg-blue-900/30 rounded-lg transition-all duration-200 relative group backdrop-blur-sm"
@@ -565,7 +570,6 @@ export default function Accounts({ onAccountClick }: { onAccountClick?: (account
                                     Close
                                   </span>
                                 </div>
-                              </div>
                             </div>
                       </div>
                     </div>
@@ -594,13 +598,13 @@ export default function Accounts({ onAccountClick }: { onAccountClick?: (account
                             <p className="text-sm font-medium text-gray-800 dark:text-gray-200 truncate">{childName}</p>
                             <p className="text-[11px] text-gray-500 dark:text-gray-400">Cash account</p>
                           </div>
-                          <div className="text-right">
+                          <div className="text-right sm:w-[7.5rem]">
                             <p className="text-[10px] uppercase tracking-wide text-gray-400 dark:text-gray-500">Account Bal</p>
                             <p className="text-sm font-semibold tabular-nums text-gray-900 dark:text-white">
                               {formatDisplayCurrency(computeAccountBalance(child.id), child.currency)}
                             </p>
                           </div>
-                          <div className="text-right">
+                          <div className="text-right sm:w-[5.5rem]">
                             <p className="text-[10px] uppercase tracking-wide text-gray-400 dark:text-gray-500">Unreconciled</p>
                             <p className={`text-sm font-semibold tabular-nums ${
                               childUnreconciled > 0
@@ -902,6 +906,20 @@ export default function Accounts({ onAccountClick }: { onAccountClick?: (account
         <div className="basis-full sm:basis-auto sm:ml-auto flex items-center gap-2">
           <BankingCriticalIncidentBadge onClick={() => setBankConnectionsView('critical')} />
           <BankingCriticalIncidentBadge mode="truelayer_jwks" onClick={() => setBankConnectionsView('jwks')} />
+          {/* One hit for every feed — the per-account buttons remain for a
+              single stubborn connection. Rendered whenever any connection
+              exists so the toolbar's shape stays put. */}
+          {connectedCount > 0 && (
+            <button
+              onClick={() => void syncAllConnections()}
+              disabled={isSyncingAny}
+              className="w-full sm:w-auto justify-center px-3 py-1.5 text-sm font-medium rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors flex items-center gap-2 disabled:opacity-60 disabled:cursor-wait"
+              title="Pull fresh data from every connected bank"
+            >
+              <RefreshCwIcon size={16} className={isSyncingAny ? 'animate-spin' : ''} />
+              {isSyncingAny ? 'Refreshing…' : 'Refresh feeds'}
+            </button>
+          )}
           <button
             onClick={() => setBankConnectionsView('plain')}
             className="w-full sm:w-auto justify-center px-3 py-1.5 text-sm font-medium rounded-lg bg-[#1a2332] dark:bg-blue-600 text-white hover:bg-[#2d3a4d] dark:hover:bg-blue-700 transition-colors flex items-center gap-2"

--- a/src/pages/settings/AppSettings.tsx
+++ b/src/pages/settings/AppSettings.tsx
@@ -6,6 +6,7 @@ import BudgetAlertSettings from '../../components/BudgetAlertSettings';
 import LargeTransactionAlertSettings from '../../components/LargeTransactionAlertSettings';
 import LocaleSelector from '../../components/settings/LocaleSelector';
 import ShowTipsAgain from '../../components/settings/ShowTipsAgain';
+import BankFeedRefreshSettings from '../../components/settings/BankFeedRefreshSettings';
 import ToggleSwitch from '../../components/ui/ToggleSwitch';
 
 export default function AppSettings() {
@@ -158,6 +159,8 @@ export default function AppSettings() {
         </button>
       }
     >
+
+      <BankFeedRefreshSettings />
 
       {/* Personal Information */}
       <div className="bg-white dark:bg-gray-800 rounded-2xl shadow-lg border border-gray-100 dark:border-gray-700 p-6 mb-6">

--- a/src/utils/__tests__/bankAutoSync.test.ts
+++ b/src/utils/__tests__/bankAutoSync.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+  shouldAutoSync,
+  loadAutoSyncPrefs,
+  saveAutoSyncPrefs,
+  loadLastAutoSyncRun,
+  recordAutoSyncRun,
+  DEFAULT_AUTO_SYNC_PREFS,
+  type AutoSyncPrefs,
+} from '../bankAutoSync';
+
+const at = (iso: string): Date => new Date(iso);
+
+describe('shouldAutoSync', () => {
+  const signin: AutoSyncPrefs = { mode: 'signin', dailyTime: '08:00' };
+  const daily: AutoSyncPrefs = { mode: 'daily', dailyTime: '08:00' };
+
+  it('never fires when off', () => {
+    expect(shouldAutoSync({ mode: 'off', dailyTime: '08:00' }, null, at('2026-07-30T09:00:00'))).toBe(false);
+  });
+
+  it('signin: fires on a first-ever open', () => {
+    expect(shouldAutoSync(signin, null, at('2026-07-30T09:00:00'))).toBe(true);
+  });
+
+  it('signin: a reload twenty minutes later is the same session, not a new sign-in', () => {
+    expect(shouldAutoSync(signin, at('2026-07-30T09:00:00'), at('2026-07-30T09:20:00'))).toBe(false);
+  });
+
+  it('signin: fires again once an hour has passed', () => {
+    expect(shouldAutoSync(signin, at('2026-07-30T09:00:00'), at('2026-07-30T10:00:00'))).toBe(true);
+  });
+
+  it('daily: not before the scheduled time', () => {
+    expect(shouldAutoSync(daily, null, at('2026-07-30T07:59:00'))).toBe(false);
+  });
+
+  it('daily: fires as the scheduled minute arrives while the app is open', () => {
+    expect(shouldAutoSync(daily, at('2026-07-29T08:00:30'), at('2026-07-30T08:00:00'))).toBe(true);
+  });
+
+  it('daily: an app opened after the scheduled time catches up immediately', () => {
+    expect(shouldAutoSync(daily, at('2026-07-29T08:01:00'), at('2026-07-30T14:30:00'))).toBe(true);
+  });
+
+  it('daily: at most once per day — a run after this morning\'s moment holds until tomorrow', () => {
+    expect(shouldAutoSync(daily, at('2026-07-30T08:00:10'), at('2026-07-30T23:59:00'))).toBe(false);
+  });
+
+  it('daily: yesterday-evening run does not satisfy this morning', () => {
+    expect(shouldAutoSync(daily, at('2026-07-29T22:00:00'), at('2026-07-30T08:05:00'))).toBe(true);
+  });
+
+  it('daily: an invalid stored time falls back to the default rather than never firing', () => {
+    expect(shouldAutoSync({ mode: 'daily', dailyTime: '99:99' }, null, at('2026-07-30T08:30:00'))).toBe(true);
+  });
+});
+
+describe('per-user storage', () => {
+  beforeEach(() => localStorage.clear());
+
+  it('prefs are keyed by user — one user\'s schedule never leaks onto another', () => {
+    saveAutoSyncPrefs('user_a', { mode: 'daily', dailyTime: '07:30' });
+
+    expect(loadAutoSyncPrefs('user_a')).toEqual({ mode: 'daily', dailyTime: '07:30' });
+    expect(loadAutoSyncPrefs('user_b')).toEqual(DEFAULT_AUTO_SYNC_PREFS);
+  });
+
+  it('last-run stamps are keyed by user too', () => {
+    recordAutoSyncRun('user_a', at('2026-07-30T08:00:00Z'));
+
+    expect(loadLastAutoSyncRun('user_a')?.toISOString()).toBe('2026-07-30T08:00:00.000Z');
+    expect(loadLastAutoSyncRun('user_b')).toBeNull();
+  });
+
+  it('garbage in storage degrades to the defaults', () => {
+    localStorage.setItem('bankAutoSync:prefs:user_a', '{not json');
+    localStorage.setItem('bankAutoSync:lastRun:user_a', 'yesterday-ish');
+
+    expect(loadAutoSyncPrefs('user_a')).toEqual(DEFAULT_AUTO_SYNC_PREFS);
+    expect(loadLastAutoSyncRun('user_a')).toBeNull();
+  });
+});

--- a/src/utils/bankAutoSync.ts
+++ b/src/utils/bankAutoSync.ts
@@ -1,0 +1,94 @@
+/**
+ * Automatic bank-feed refresh: the preference, its per-user storage, and the
+ * one decision that matters — "is a refresh due right now?".
+ *
+ * The decision is a pure function so the scheduling rules live under test,
+ * not inside a hook. Storage is localStorage keyed BY USER ID: this device
+ * setting controls actions on the signed-in user's data, and an unkeyed entry
+ * would leak one user's schedule onto another's session on a shared machine —
+ * the exact mistake the notification feed made.
+ */
+
+export type AutoSyncMode = 'off' | 'signin' | 'daily';
+
+export interface AutoSyncPrefs {
+  mode: AutoSyncMode;
+  /** 24h "HH:mm"; only meaningful in 'daily' mode. */
+  dailyTime: string;
+}
+
+export const DEFAULT_AUTO_SYNC_PREFS: AutoSyncPrefs = { mode: 'off', dailyTime: '08:00' };
+
+/**
+ * 'signin' mode throttle: "refresh when I open the app", not "hammer the bank
+ * on every reload". A re-open within this window is one session, not a new
+ * sign-in.
+ */
+export const SIGNIN_MODE_MIN_GAP_MS = 60 * 60 * 1000;
+
+const prefsKey = (userId: string): string => `bankAutoSync:prefs:${userId}`;
+const lastRunKey = (userId: string): string => `bankAutoSync:lastRun:${userId}`;
+
+const isValidTime = (t: unknown): t is string =>
+  typeof t === 'string' && /^([01]\d|2[0-3]):[0-5]\d$/.test(t);
+
+export function loadAutoSyncPrefs(userId: string): AutoSyncPrefs {
+  try {
+    const raw = localStorage.getItem(prefsKey(userId));
+    if (!raw) return DEFAULT_AUTO_SYNC_PREFS;
+    const parsed: unknown = JSON.parse(raw);
+    const mode = (parsed as AutoSyncPrefs).mode;
+    const dailyTime = (parsed as AutoSyncPrefs).dailyTime;
+    return {
+      mode: mode === 'signin' || mode === 'daily' ? mode : 'off',
+      dailyTime: isValidTime(dailyTime) ? dailyTime : DEFAULT_AUTO_SYNC_PREFS.dailyTime,
+    };
+  } catch {
+    return DEFAULT_AUTO_SYNC_PREFS;
+  }
+}
+
+export function saveAutoSyncPrefs(userId: string, prefs: AutoSyncPrefs): void {
+  localStorage.setItem(prefsKey(userId), JSON.stringify(prefs));
+}
+
+export function loadLastAutoSyncRun(userId: string): Date | null {
+  const raw = localStorage.getItem(lastRunKey(userId));
+  if (!raw) return null;
+  const d = new Date(raw);
+  return Number.isNaN(d.getTime()) ? null : d;
+}
+
+export function recordAutoSyncRun(userId: string, at: Date): void {
+  localStorage.setItem(lastRunKey(userId), at.toISOString());
+}
+
+/**
+ * Is an automatic refresh due at `now`?
+ *
+ * 'signin': due when the last run is absent or over an hour old — fires on
+ * app open, throttled so reloads within a session do not re-sync.
+ *
+ * 'daily': due once the day's scheduled moment has passed and no run has
+ * happened since that moment. An app opened AFTER the scheduled time catches
+ * up immediately; an app open ACROSS it fires as the minute arrives; a run
+ * already done after today's moment means nothing more until tomorrow. The
+ * app can only act while it is open — this is a web page, not a daemon — so
+ * "every day at 08:00" honestly means "the first opportunity on or after
+ * 08:00 each day".
+ */
+export function shouldAutoSync(prefs: AutoSyncPrefs, lastRun: Date | null, now: Date): boolean {
+  if (prefs.mode === 'off') return false;
+
+  if (prefs.mode === 'signin') {
+    return lastRun === null || now.getTime() - lastRun.getTime() >= SIGNIN_MODE_MIN_GAP_MS;
+  }
+
+  const time = isValidTime(prefs.dailyTime) ? prefs.dailyTime : DEFAULT_AUTO_SYNC_PREFS.dailyTime;
+  const [hh, mm] = time.split(':').map(Number);
+  const scheduledToday = new Date(now);
+  scheduledToday.setHours(hh, mm, 0, 0);
+
+  if (now < scheduledToday) return false;
+  return lastRun === null || lastRun < scheduledToday;
+}


### PR DESCRIPTION
One batch, user-tested against real data before commit:

**Accounts page**
- Every card's stats and buttons are a fixed-column grid: Bank Bal / Account Bal / Unreconciled at set widths, then five reserved button slots (Close always furthest right, then Reconcile, Settings, Feed-refresh, Portfolio). An account without a feed keeps an empty slot — nothing ever shuffles. Verified: identical x on every card.
- New "Refresh feeds" button beside Bank Connections — every healthy connection sequentially, one summary toast.

**Feed automation** — Settings → "Bank feed refresh": manual / on opening the app (hourly throttle) / daily at a set time. Honest about web-app physics (runs at the first opportunity on or after the set time; catches up on next open). Per-user localStorage; stamp-then-sync so a failed round can't retry-storm. 13 unit tests on the scheduling rules.

**Categorise by payee** — modal widened (new 2xl size), wider category column, and a clear (×) on any chosen category so a payee can be excluded from the bulk and left for line-by-line filing.

**Review one by one** — the Category column is now an inline dropdown per row (split lines keep click-to-edit); a "Save N" button appears in the header left of the ✕ once anything is chosen; saving batch-applies (blanks-only, cannot overwrite concurrent edits) and saved rows leave the list. Descriptions still open the full editor. Modal component gains a `headerActions` slot.

Gates green (3,475 tests, 13 new).

🤖 Generated with [Claude Code](https://claude.com/claude-code)