### PR TITLE
Bank connect deep-links, drillable account totals, aligned categorisation modals

### DIFF
--- a/api/_lib/truelayer.ts
+++ b/api/_lib/truelayer.ts
@@ -13,6 +13,8 @@ interface AuthUrlOptions {
   enableOpenBanking?: boolean;
   enableOauth?: boolean;
   enableMock?: boolean;
+  /** A single TrueLayer provider id — deep-links past TrueLayer's chooser. */
+  providerId?: string;
 }
 
 interface TokenResponse {
@@ -84,6 +86,35 @@ export const getRedirectUri = (): string => getRequiredEnv('TRUELAYER_REDIRECT_U
 export const isSandboxEnvironment = (): boolean =>
   getEnvironment() !== 'production';
 
+/**
+ * Our institution ids → TrueLayer provider ids, taken from TrueLayer's live
+ * registry (GET https://auth.truelayer.com/api/providers, checked
+ * 2026-08-03) — not guessed. Passing exactly one provider in `providers`
+ * skips TrueLayer's own bank chooser, so clicking "American Express" in our
+ * shortcut list lands directly on the Amex consent screen instead of asking
+ * the user to find Amex a second time. An unmapped id falls back to the full
+ * UK list — a worse journey, never a broken one.
+ */
+const TRUELAYER_PROVIDER_BY_INSTITUTION: Record<string, string> = {
+  amex: 'ob-amex',
+  barclays: 'ob-barclays',
+  barclaycard: 'ob-barclaycard',
+  'first-direct': 'ob-first-direct',
+  halifax: 'ob-halifax',
+  hsbc: 'ob-hsbc',
+  lloyds: 'ob-lloyds',
+  monzo: 'ob-monzo',
+  nationwide: 'ob-nationwide',
+  natwest: 'ob-natwest',
+  revolut: 'ob-revolut',
+  santander: 'ob-santander-personal',
+  starling: 'ob-starling',
+  tsb: 'ob-tsb',
+};
+
+export const providerForInstitution = (institutionId: string | undefined): string | undefined =>
+  institutionId ? TRUELAYER_PROVIDER_BY_INSTITUTION[institutionId] : undefined;
+
 export const buildAuthUrl = (options: AuthUrlOptions): string => {
   const url = new URL(getAuthBaseUrl());
   url.searchParams.set('response_type', 'code');
@@ -94,10 +125,14 @@ export const buildAuthUrl = (options: AuthUrlOptions): string => {
   url.searchParams.set('nonce', options.nonce);
   url.searchParams.set('state', options.state);
 
-  // CRITICAL: TrueLayer requires at least one provider to be specified
-  // In sandbox, use 'mock' provider. In production, use 'uk-ob-all' for all UK banks
+  // CRITICAL: TrueLayer requires at least one provider to be specified.
+  // Sandbox always uses 'mock'. In production a single mapped provider deep
+  // links straight to that bank's consent screen; otherwise the full UK list.
   const isSandbox = isSandboxEnvironment();
-  url.searchParams.set('providers', isSandbox ? 'mock' : 'uk-ob-all');
+  url.searchParams.set(
+    'providers',
+    isSandbox ? 'mock' : (options.providerId ?? 'uk-ob-all')
+  );
 
   if (options.enableMock) {
     url.searchParams.set('enable_mock', 'true');

--- a/api/banking/create-link-token.ts
+++ b/api/banking/create-link-token.ts
@@ -8,7 +8,7 @@ import { setCorsHeaders } from '../_lib/cors.js';
 import { createErrorResponse } from '../_lib/http-error.js';
 import { applyRateLimit } from '../_lib/rate-limit.js';
 import { createStateToken } from '../_lib/state.js';
-import { buildAuthUrl, getRedirectUri, isSandboxEnvironment } from '../_lib/truelayer.js';
+import { buildAuthUrl, getRedirectUri, isSandboxEnvironment, providerForInstitution } from '../_lib/truelayer.js';
 import { withSentry } from '../_lib/sentry.js';
 
 // 'cards' unlocks credit-card providers (American Express etc.) in the auth
@@ -35,7 +35,15 @@ async function handler(req: VercelRequest, res: VercelResponse) {
 
     const state = createStateToken(auth.userId);
     const nonce = randomBytes(12).toString('hex');
+    // The client has always sent which bank was clicked; honouring it is what
+    // makes the shortcut list an actual shortcut. Only ids in our own map
+    // reach the URL — arbitrary input never does.
+    const institutionId =
+      typeof (req.body as { institutionId?: unknown })?.institutionId === 'string'
+        ? (req.body as { institutionId: string }).institutionId
+        : undefined;
     const authUrl = buildAuthUrl({
+      providerId: providerForInstitution(institutionId),
       redirectUri: getRedirectUri(),
       scope: AUTH_SCOPES,
       nonce,

--- a/src/components/AccountBreakdownModal.tsx
+++ b/src/components/AccountBreakdownModal.tsx
@@ -1,0 +1,186 @@
+import React, { useMemo, useState } from 'react';
+import { Modal, ModalBody } from './common/Modal';
+
+/**
+ * The drill-in behind the Accounts page's Net Worth / Assets / Liabilities
+ * cards: which accounts, at what balances, those figures are made of.
+ *
+ * The rows arrive from the page ALREADY computed with the same balance
+ * function the cards use, so the modal's totals cannot disagree with the
+ * card that opened it. Assets are the accounts standing positive,
+ * liabilities the ones standing negative — same split as the cards.
+ */
+
+export type AccountBreakdownView = 'net' | 'assets' | 'liabilities';
+
+export interface AccountBreakdownRow {
+  id: string;
+  name: string;
+  institution?: string;
+  /** Signed balance, from the page's own computeAccountBalance. */
+  balance: number;
+  /** Formatted in the account's own currency by the page's formatter. */
+  formatted: string;
+}
+
+interface Props {
+  view: AccountBreakdownView | null;
+  onClose: () => void;
+  rows: AccountBreakdownRow[];
+  /** Formats a base-currency total, matching the summary cards. */
+  formatTotal: (value: number) => string;
+  onOpenAccount: (accountId: string) => void;
+}
+
+type SortKey = 'name' | 'balance';
+
+const TITLES: Record<AccountBreakdownView, string> = {
+  net: 'Net Worth',
+  assets: 'Assets',
+  liabilities: 'Liabilities',
+};
+
+export default function AccountBreakdownModal({
+  view,
+  onClose,
+  rows,
+  formatTotal,
+  onOpenAccount,
+}: Props): React.JSX.Element {
+  // Balance sorts by MAGNITUDE so "high first" means the biggest debt first
+  // on the liabilities view, not the least negative number.
+  const [sortKey, setSortKey] = useState<SortKey>('balance');
+  const [sortDir, setSortDir] = useState<1 | -1>(-1);
+
+  const handleSort = (key: SortKey): void => {
+    if (key === sortKey) {
+      setSortDir(d => (d === 1 ? -1 : 1));
+    } else {
+      setSortKey(key);
+      setSortDir(key === 'balance' ? -1 : 1);
+    }
+  };
+
+  const sortRows = useMemo(() => {
+    return (list: AccountBreakdownRow[]): AccountBreakdownRow[] =>
+      [...list].sort((a, b) =>
+        sortKey === 'name'
+          ? sortDir * a.name.localeCompare(b.name)
+          : sortDir * (Math.abs(a.balance) - Math.abs(b.balance))
+      );
+  }, [sortKey, sortDir]);
+
+  const assets = useMemo(() => rows.filter(r => r.balance > 0), [rows]);
+  const liabilities = useMemo(() => rows.filter(r => r.balance < 0), [rows]);
+
+  const sections = useMemo(() => {
+    if (view === 'assets') return [{ name: null as string | null, rows: sortRows(assets) }];
+    if (view === 'liabilities') return [{ name: null as string | null, rows: sortRows(liabilities) }];
+    return [
+      { name: 'Assets' as string | null, rows: sortRows(assets) },
+      { name: 'Liabilities' as string | null, rows: sortRows(liabilities) },
+    ];
+  }, [view, assets, liabilities, sortRows]);
+
+  const total = useMemo(() => {
+    const included = view === 'assets' ? assets : view === 'liabilities' ? liabilities : rows;
+    return included.reduce((sum, r) => sum + r.balance, 0);
+  }, [view, assets, liabilities, rows]);
+
+  const arrow = (key: SortKey): string => (sortKey === key ? (sortDir === 1 ? ' ↑' : ' ↓') : '');
+
+  return (
+    <Modal isOpen={view !== null} onClose={onClose} title={view ? TITLES[view] : ''} size="lg">
+      <ModalBody>
+        <table className="w-full">
+          <thead>
+            <tr className="text-xs text-gray-500 dark:text-gray-400 border-b border-gray-100 dark:border-gray-700">
+              <th className="pb-2 font-medium text-left">
+                <button
+                  type="button"
+                  onClick={() => handleSort('name')}
+                  className="hover:text-gray-800 dark:hover:text-gray-200 transition-colors"
+                  title="Sort by account name"
+                >
+                  Account{arrow('name')}
+                </button>
+              </th>
+              <th className="pb-2 font-medium text-right">
+                <button
+                  type="button"
+                  onClick={() => handleSort('balance')}
+                  className="hover:text-gray-800 dark:hover:text-gray-200 transition-colors"
+                  title="Sort by balance size"
+                >
+                  Balance{arrow('balance')}
+                </button>
+              </th>
+            </tr>
+          </thead>
+          <tbody>
+            {sections.map((section, i) => (
+              <React.Fragment key={section.name ?? `flat-${i}`}>
+                {section.name !== null && (
+                  <tr className="bg-gray-50 dark:bg-gray-800/60">
+                    <td className="py-1.5 pr-3 text-xs font-semibold uppercase tracking-wide text-gray-600 dark:text-gray-300">
+                      {section.name}
+                      <span className="ml-2 font-normal normal-case text-gray-400 dark:text-gray-500">
+                        ({section.rows.length})
+                      </span>
+                    </td>
+                    <td className={`py-1.5 text-xs font-semibold text-right tabular-nums ${
+                      section.name === 'Liabilities'
+                        ? 'text-red-600 dark:text-red-400'
+                        : 'text-green-600 dark:text-green-400'
+                    }`}>
+                      {formatTotal(section.rows.reduce((s, r) => s + r.balance, 0))}
+                    </td>
+                  </tr>
+                )}
+                {section.rows.length === 0 && (
+                  <tr>
+                    <td colSpan={2} className="py-4 text-center text-sm text-gray-400 dark:text-gray-500">
+                      Nothing here — every account stands {view === 'liabilities' ? 'positive' : 'negative'}.
+                    </td>
+                  </tr>
+                )}
+                {section.rows.map(row => (
+                  <tr
+                    key={row.id}
+                    onClick={() => onOpenAccount(row.id)}
+                    className="border-b border-gray-50 dark:border-gray-700/50 cursor-pointer hover:bg-gray-50 dark:hover:bg-gray-700/40 transition-colors"
+                    title="Open this account"
+                  >
+                    <td className="py-2 pr-3">
+                      <span className="block text-sm text-gray-900 dark:text-white truncate">{row.name}</span>
+                      {row.institution && (
+                        <span className="block text-xs text-gray-400 dark:text-gray-500">{row.institution}</span>
+                      )}
+                    </td>
+                    <td className={`py-2 text-sm font-medium text-right whitespace-nowrap tabular-nums ${
+                      row.balance < 0 ? 'text-red-600 dark:text-red-400' : 'text-green-600 dark:text-green-400'
+                    }`}>
+                      {row.formatted}
+                    </td>
+                  </tr>
+                ))}
+              </React.Fragment>
+            ))}
+          </tbody>
+          <tfoot>
+            <tr className="border-t-2 border-gray-200 dark:border-gray-600">
+              <td className="pt-3 text-sm font-semibold text-gray-900 dark:text-white">
+                {view === 'net' ? 'Net worth' : 'Total'}
+              </td>
+              <td className={`pt-3 text-sm font-bold text-right tabular-nums ${
+                total < 0 ? 'text-red-600 dark:text-red-400' : 'text-gray-900 dark:text-white'
+              }`}>
+                {formatTotal(total)}
+              </td>
+            </tr>
+          </tfoot>
+        </table>
+      </ModalBody>
+    </Modal>
+  );
+}

--- a/src/components/BankConnections.tsx
+++ b/src/components/BankConnections.tsx
@@ -458,12 +458,11 @@ export default function BankConnections({
           </div>
 
           {/* Provider Info */}
-          <div className="bg-blue-50 dark:bg-blue-900/20 rounded-lg p-3 text-sm">
-            <p className="text-blue-800 dark:text-blue-200">
-              <strong>Secure Connection:</strong> Your credentials are never stored.
-              Connection is established directly with your bank using OAuth. You&rsquo;ll
-              confirm your exact bank or card provider on TrueLayer&rsquo;s secure page —
-              this list is just a shortcut.
+          <div className="bg-[#1a2332] dark:bg-gray-700 rounded-lg p-3 text-sm">
+            <p className="text-white/80">
+              <strong className="text-white">Secure Connection:</strong> Your credentials are never stored.
+              Connection is established directly with your bank using OAuth on
+              TrueLayer&rsquo;s secure page.
             </p>
           </div>
 

--- a/src/components/BulkCategorizeModal.tsx
+++ b/src/components/BulkCategorizeModal.tsx
@@ -157,9 +157,12 @@ export default function BulkCategorizeModal({ isOpen, onClose }: Props): React.J
               <table className="block sm:table w-full">
                 <thead className="hidden sm:table-header-group">
                   <tr className="text-xs text-gray-500 dark:text-gray-400 border-b border-gray-100 dark:border-gray-700">
-                    <th className="text-left pb-2 font-medium">Payee</th>
-                    <th className="text-right pb-2 font-medium">Rows</th>
-                    <th className="text-right pb-2 font-medium">Total</th>
+                    <th className="text-left pb-2 pr-3 font-medium">Payee</th>
+                    <th className="text-right pb-2 pr-3 font-medium">Rows</th>
+                    {/* pr matches the body cells so each heading ends where
+                        its column ends, instead of "Total" leaning on
+                        "Category". */}
+                    <th className="text-right pb-2 pr-3 font-medium">Total</th>
                     <th className="text-left pb-2 font-medium w-72 lg:w-96">Category</th>
                   </tr>
                 </thead>
@@ -229,23 +232,27 @@ export default function BulkCategorizeModal({ isOpen, onClose }: Props): React.J
                               placeholder="Choose a category…"
                               className="w-full flex-1 min-w-0"
                             />
-                            {/* The way OUT of a pre-fill. A suggestion the
-                                user does not trust for a bulk decision must
-                                be clearable — back to "Choose a category…",
-                                which excludes this payee from the apply and
-                                leaves its rows for line-by-line filing. */}
-                            {chosen !== '' && (
-                              <button
-                                type="button"
-                                onClick={() => setChoice(group, '')}
-                                disabled={applying}
-                                className="shrink-0 p-1.5 rounded-lg text-gray-400 hover:text-gray-700 dark:hover:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors disabled:opacity-50"
-                                title="Clear — leave this payee to categorise line by line"
-                                aria-label={`Clear category for ${group.displayName}`}
-                              >
-                                <XIcon size={14} />
-                              </button>
-                            )}
+                            {/* The way OUT of a pre-fill: back to "Choose a
+                                category…", excluding this payee from the
+                                apply so its rows can be filed line by line.
+                                The slot is RESERVED even when empty, so
+                                every picker in the column is one width —
+                                rows with and without a clear button used to
+                                render pickers of different sizes. */}
+                            <span className="w-8 shrink-0 flex justify-center">
+                              {chosen !== '' && (
+                                <button
+                                  type="button"
+                                  onClick={() => setChoice(group, '')}
+                                  disabled={applying}
+                                  className="p-1.5 rounded-lg text-gray-400 hover:text-gray-700 dark:hover:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors disabled:opacity-50"
+                                  title="Clear — leave this payee to categorise line by line"
+                                  aria-label={`Clear category for ${group.displayName}`}
+                                >
+                                  <XIcon size={14} />
+                                </button>
+                              )}
+                            </span>
                           </span>
                         </td>
                       </tr>

--- a/src/components/IncomeExpenseBreakdownModal.tsx
+++ b/src/components/IncomeExpenseBreakdownModal.tsx
@@ -209,13 +209,13 @@ export default function IncomeExpenseBreakdownModal({
       <tr
         key={t.id}
         onClick={() => onEditTransaction(t.splitParentId ?? t.id)}
-        className="border-b border-gray-50 dark:border-gray-700/50 cursor-pointer hover:bg-gray-50 dark:hover:bg-gray-700/40 transition-colors"
+        className="grid grid-cols-[auto_1fr_auto] gap-x-3 py-1 sm:py-0 sm:table-row border-b border-gray-50 dark:border-gray-700/50 cursor-pointer hover:bg-gray-50 dark:hover:bg-gray-700/40 transition-colors"
         title={bucket === 'uncategorized' ? 'Click to give this transaction a category' : 'Click to view or edit this transaction'}
       >
-        <td className="py-2 pr-3 text-sm text-gray-500 dark:text-gray-400 whitespace-nowrap">
+        <td className="block sm:table-cell py-2 pr-0 sm:pr-3 text-sm text-gray-500 dark:text-gray-400 whitespace-nowrap">
           {new Date(t.date).toLocaleDateString('en-GB', { day: '2-digit', month: 'short', year: '2-digit' })}
         </td>
-        <td className="py-2 pr-3 text-sm text-gray-900 dark:text-white">
+        <td className="block sm:table-cell min-w-0 py-2 pr-0 sm:pr-3 text-sm text-gray-900 dark:text-white">
           {t.description}
           {(bucket === 'income' || bucket === 'expense') && value < 0 && (
             <span className="ml-2 text-xs text-gray-400 dark:text-gray-500">(credit)</span>
@@ -224,7 +224,7 @@ export default function IncomeExpenseBreakdownModal({
         {inlineFiling && !t.isSplitLine ? (
           // Picking is not opening: the cell swallows the click so the row's
           // click-to-edit stays available everywhere else on the row.
-          <td className="py-1.5 pr-3" onClick={(e) => e.stopPropagation()}>
+          <td className="block sm:table-cell col-span-3 pb-2 sm:py-1.5 pr-0 sm:pr-3" onClick={(e) => e.stopPropagation()}>
             <CategorySelector
               selectedCategory={pendingChoices[t.id] ?? ''}
               onCategoryChange={(categoryId) => setPendingChoices(prev => ({ ...prev, [t.id]: categoryId }))}
@@ -233,15 +233,18 @@ export default function IncomeExpenseBreakdownModal({
               showHelperText={false}
               usePortal
               placeholder="Choose a category…"
-              className="w-full min-w-[13rem]"
+              // One fixed width for every row from sm up — a fluid picker
+              // sized itself to each row's leftover space and the column
+              // read ragged. Phones get the full row width instead.
+              className="w-full sm:w-72"
             />
           </td>
         ) : (
-          <td className="py-2 pr-3 text-sm text-gray-500 dark:text-gray-400">
+          <td className="block sm:table-cell col-span-3 sm:col-auto py-0 sm:py-2 pr-0 sm:pr-3 text-sm text-gray-500 dark:text-gray-400">
             {categoryName(t.category)}
           </td>
         )}
-        <td className={`py-2 text-sm font-medium text-right whitespace-nowrap tabular-nums ${rowColour}`}>
+        <td className={`block sm:table-cell py-2 text-sm font-medium text-right whitespace-nowrap tabular-nums ${rowColour}`}>
           {value < 0 ? `-${formatCurrency(Math.abs(value))}` : formatCurrency(value)}
         </td>
       </tr>
@@ -253,7 +256,9 @@ export default function IncomeExpenseBreakdownModal({
       isOpen={isOpen}
       onClose={onClose}
       title={title}
-      size={inlineFiling ? 'xl' : 'lg'}
+      // 2xl when filing inline: the picker is the working column, and at xl
+      // it was the squeezed one.
+      size={inlineFiling ? '2xl' : 'lg'}
       headerActions={
         inlineFiling && pendingCount > 0 ? (
           <button
@@ -268,11 +273,15 @@ export default function IncomeExpenseBreakdownModal({
       }
     >
       <ModalBody>
+        {/* Below sm the table reflows: each row is a small grid — date,
+            description and amount on one line, the category (or its picker)
+            full-width beneath — because four fixed columns cannot share a
+            phone. From sm up, the table is a table. */}
         {liveRows.length === 0 ? (
           <p className="text-center py-8 text-gray-400">No transactions</p>
         ) : (
-          <table className="w-full">
-            <thead>
+          <table className="block sm:table w-full">
+            <thead className="hidden sm:table-header-group">
               <tr className="text-xs text-gray-500 dark:text-gray-400 border-b border-gray-100 dark:border-gray-700">
                 {headerButton('date', 'Date')}
                 {headerButton('description', 'Description')}
@@ -280,18 +289,18 @@ export default function IncomeExpenseBreakdownModal({
                 {headerButton('amount', 'Amount', 'right')}
               </tr>
             </thead>
-            <tbody>
+            <tbody className="block sm:table-row-group">
               {view.sections.map((section, i) => (
                 <React.Fragment key={section.name ?? `flat-${i}`}>
                   {section.name !== null && (
-                    <tr className="bg-gray-50 dark:bg-gray-800/60">
-                      <td colSpan={3} className="py-1.5 pr-3 text-xs font-semibold uppercase tracking-wide text-gray-600 dark:text-gray-300">
+                    <tr className="flex items-center justify-between sm:table-row bg-gray-50 dark:bg-gray-800/60">
+                      <td colSpan={3} className="block sm:table-cell py-1.5 pr-3 text-xs font-semibold uppercase tracking-wide text-gray-600 dark:text-gray-300">
                         {section.name}
                         <span className="ml-2 font-normal normal-case text-gray-400 dark:text-gray-500">
                           ({section.rows.length})
                         </span>
                       </td>
-                      <td className={`py-1.5 text-xs font-semibold text-right tabular-nums ${colourClass || 'text-gray-600 dark:text-gray-300'}`}>
+                      <td className={`block sm:table-cell py-1.5 text-xs font-semibold text-right tabular-nums ${colourClass || 'text-gray-600 dark:text-gray-300'}`}>
                         {section.subtotal < 0
                           ? `-${formatCurrency(Math.abs(section.subtotal))}`
                           : formatCurrency(section.subtotal)}
@@ -302,25 +311,25 @@ export default function IncomeExpenseBreakdownModal({
                 </React.Fragment>
               ))}
               {view.truncated > 0 && (
-                <tr>
-                  <td colSpan={4} className="py-3 text-center text-xs text-gray-400 dark:text-gray-500">
+                <tr className="block sm:table-row">
+                  <td colSpan={4} className="block sm:table-cell py-3 text-center text-xs text-gray-400 dark:text-gray-500">
                     Showing {CAP.toLocaleString()} of {liveRows.length.toLocaleString()} rows — the total below covers them all.
                   </td>
                 </tr>
               )}
             </tbody>
-            <tfoot>
+            <tfoot className="block sm:table-footer-group">
               {bucket === 'uncategorized' ? (
-                <tr className="border-t-2 border-gray-200 dark:border-gray-600">
-                  <td colSpan={4} className="pt-3 text-xs text-gray-500 dark:text-gray-400">
+                <tr className="block sm:table-row border-t-2 border-gray-200 dark:border-gray-600">
+                  <td colSpan={4} className="block sm:table-cell pt-3 text-xs text-gray-500 dark:text-gray-400">
                     These transactions count toward NO total until they are given a category.
                     Set up a category like &ldquo;Income : Miscellaneous&rdquo; if you need a catch-all.
                   </td>
                 </tr>
               ) : (
-                <tr className="border-t-2 border-gray-200 dark:border-gray-600">
-                  <td colSpan={3} className="pt-3 text-sm font-semibold text-gray-900 dark:text-white">Total</td>
-                  <td className={`pt-3 text-sm font-bold text-right tabular-nums ${colourClass}`}>
+                <tr className="flex items-center justify-between sm:table-row border-t-2 border-gray-200 dark:border-gray-600">
+                  <td colSpan={3} className="block sm:table-cell pt-3 text-sm font-semibold text-gray-900 dark:text-white">Total</td>
+                  <td className={`block sm:table-cell pt-3 text-sm font-bold text-right tabular-nums ${colourClass}`}>
                     {total !== null ? formatCurrency(total) : ''}
                   </td>
                 </tr>

--- a/src/pages/Accounts.tsx
+++ b/src/pages/Accounts.tsx
@@ -6,6 +6,7 @@ import { DataService } from '../services/api/dataService';
 import { preserveDemoParam } from '../utils/navigation';
 import AddAccountModal from '../components/AddAccountModal';
 import AccountSettingsModal from '../components/AccountSettingsModal';
+import AccountBreakdownModal, { type AccountBreakdownView } from '../components/AccountBreakdownModal';
 import PortfolioView from '../components/PortfolioView';
 // No longer importing from lucide-react - all icons are now custom
 import { ArchiveIcon, SettingsIcon, WalletIcon, CheckCircleIcon, PieChartIcon, BankIcon, RefreshCwIcon, AlertTriangleIcon, ChevronRightIcon, ChevronDownIcon, XCircleIcon, SearchIcon } from '../components/icons';
@@ -42,6 +43,7 @@ export default function Accounts({ onAccountClick }: { onAccountClick?: (account
   const [bankConnectionsView, setBankConnectionsView] = useState<null | 'plain' | 'critical' | 'jwks'>(null);
   const [portfolioAccountId, setPortfolioAccountId] = useState<string | null>(null);
   const [settingsAccountId, setSettingsAccountId] = useState<string | null>(null);
+  const [breakdownView, setBreakdownView] = useState<AccountBreakdownView | null>(null);
   const [isLoading, setIsLoading] = useState(true);
   const [groupBy, setGroupBy] = useState<'type' | 'institution'>(() => {
     return (localStorage.getItem('accountsGroupBy') as 'type' | 'institution') || 'type';
@@ -423,12 +425,7 @@ export default function Accounts({ onAccountClick }: { onAccountClick?: (account
                             )}
                           </p>
                         )}
-                        {account.openingBalance !== undefined && (
-                          <p className="text-xs text-gray-500 dark:text-gray-300 mt-1">
-                            Opening balance: {formatDisplayCurrency(account.openingBalance, account.currency)} 
-                            {account.openingBalanceDate && ` on ${new Date(account.openingBalanceDate).toLocaleDateString()}`}
-                          </p>
-                        )}
+
                         {account.type === 'investment' && account.holdings && account.holdings.length > 0 && (
                           <div className="text-xs text-gray-500 dark:text-gray-300 mt-1 space-y-1">
                             <p>
@@ -794,20 +791,36 @@ export default function Accounts({ onAccountClick }: { onAccountClick?: (account
         // One column on a phone: these are eight-digit figures at text-2xl,
         // and a grid cell will not shrink below an unbreakable number — three
         // abreast forced the whole page to scroll sideways at 375px.
+        // Each figure drills into the accounts behind it.
         return (
           <div className="grid grid-cols-1 sm:grid-cols-3 gap-3 sm:gap-4 mb-6">
-            <div className="bg-[#1a2332] dark:bg-gray-700 rounded-xl p-4 text-white">
+            <button
+              type="button"
+              onClick={() => setBreakdownView('net')}
+              className="bg-[#1a2332] dark:bg-gray-700 rounded-xl p-4 text-white text-left hover:bg-[#2d3a4d] dark:hover:bg-gray-600 transition-colors"
+              title="See the accounts behind this figure"
+            >
               <p className="text-xs text-white/60 uppercase tracking-wider font-medium">Net Worth</p>
               <p className="text-2xl font-bold mt-1">{formatDisplayCurrency(totalBalance)}</p>
-            </div>
-            <div className="bg-white dark:bg-gray-800 rounded-xl p-4 border border-gray-100 dark:border-gray-700">
+            </button>
+            <button
+              type="button"
+              onClick={() => setBreakdownView('assets')}
+              className="bg-white dark:bg-gray-800 rounded-xl p-4 border border-gray-100 dark:border-gray-700 text-left hover:border-gray-300 dark:hover:border-gray-500 hover:shadow-md transition-all"
+              title="See the accounts behind this figure"
+            >
               <p className="text-xs text-gray-500 uppercase tracking-wider font-medium">Assets</p>
               <p className="text-2xl font-bold mt-1 text-green-600 dark:text-green-400">{formatDisplayCurrency(totalAssets)}</p>
-            </div>
-            <div className="bg-white dark:bg-gray-800 rounded-xl p-4 border border-gray-100 dark:border-gray-700">
+            </button>
+            <button
+              type="button"
+              onClick={() => setBreakdownView('liabilities')}
+              className="bg-white dark:bg-gray-800 rounded-xl p-4 border border-gray-100 dark:border-gray-700 text-left hover:border-gray-300 dark:hover:border-gray-500 hover:shadow-md transition-all"
+              title="See the accounts behind this figure"
+            >
               <p className="text-xs text-gray-500 uppercase tracking-wider font-medium">Liabilities</p>
               <p className="text-2xl font-bold mt-1 text-red-600">{formatDisplayCurrency(totalLiabilities)}</p>
-            </div>
+            </button>
           </div>
         );
       })()}
@@ -1105,6 +1118,24 @@ export default function Accounts({ onAccountClick }: { onAccountClick?: (account
       {/* Account Settings Modal — serves the open cards AND the closed rows, so
           the account can come from either list. A closed account is not in
           context state (it is loaded separately), hence the second lookup. */}
+            <AccountBreakdownModal
+        view={breakdownView}
+        onClose={() => setBreakdownView(null)}
+        rows={decimalAccounts.map(a => ({
+          id: a.id,
+          name: a.name,
+          institution: a.institution,
+          balance: computeAccountBalance(a.id),
+          formatted: formatDisplayCurrency(computeAccountBalance(a.id), a.currency),
+        }))}
+        formatTotal={(v) => formatDisplayCurrency(v)}
+        onOpenAccount={(accountId) => {
+          setBreakdownView(null);
+          if (onAccountClick) onAccountClick(accountId);
+          else navigate(preserveDemoParam(`/accounts/${accountId}`, location.search));
+        }}
+      />
+
       <AccountSettingsModal
         isOpen={!!settingsAccountId}
         onClose={() => setSettingsAccountId(null)}

--- a/src/services/bankConnectionService.ts
+++ b/src/services/bankConnectionService.ts
@@ -564,6 +564,8 @@ export class BankConnectionService {
       supportsBalance: true
     });
 
+    // Sorted programmatically so a future addition cannot land out of order
+    // (Barclaycard vs Barclays already had, alphabetically, swapped places).
     return [
       uk('amex', 'American Express'),
       uk('barclays', 'Barclays'),
@@ -579,7 +581,7 @@ export class BankConnectionService {
       uk('santander', 'Santander'),
       uk('starling', 'Starling Bank'),
       uk('tsb', 'TSB')
-    ];
+    ].sort((a, b) => a.name.localeCompare(b.name));
   }
 
   async connectBank(


### PR DESCRIPTION
User-tested against real data before commit:

**Connect a Bank actually shortcuts** — the client always sent which bank was clicked; the server now honours it, mapping each institution to its TrueLayer provider id (from TrueLayer's live registry) so the auth page lands directly on that bank's consent screen instead of asking again. Unmapped → full UK list fallback. The list is alphabetically sorted (enforced — Barclaycard/Barclays were genuinely swapped) and the Secure Connection banner wears the app slate.

**Accounts** — Net Worth / Assets / Liabilities cards open a sortable breakdown (name A↔Z, balance by size — "high first" on liabilities = biggest debt first); rows open the account; totals computed with the page's own balance function so modal and card cannot disagree. Opening balance removed from cards.

**Categorise by payee** — reserved clear-button slot so every picker is one width; headers padded to match their columns ("Total" was touching "Category").

**Review one by one** — 2xl modal with fixed-width pickers from sm up; below sm the table reflows (date/description/amount one line, picker full-width beneath) — verified at 440px, where the fixed-width picker alone would have forced sideways scrolling.

Gates green (3,475 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)