### PR TITLE
One pattern for every categorisation popup, and a Group toggle on the breakdowns

### DIFF
--- a/src/components/AccountBreakdownModal.tsx
+++ b/src/components/AccountBreakdownModal.tsx
@@ -1,5 +1,6 @@
 import React, { useMemo, useState } from 'react';
 import { Modal, ModalBody } from './common/Modal';
+import { ALL_ACCOUNT_SECTIONS, sectionTypeForAccount } from '../utils/accountSections';
 
 /**
  * The drill-in behind the Accounts page's Net Worth / Assets / Liabilities
@@ -17,6 +18,8 @@ export interface AccountBreakdownRow {
   id: string;
   name: string;
   institution?: string;
+  /** The account's type, for the Group view's sections. */
+  accountType: string;
   /** Signed balance, from the page's own computeAccountBalance. */
   balance: number;
   /** Formatted in the account's own currency by the page's formatter. */
@@ -51,6 +54,8 @@ export default function AccountBreakdownModal({
   // on the liabilities view, not the least negative number.
   const [sortKey, setSortKey] = useState<SortKey>('balance');
   const [sortDir, setSortDir] = useState<1 | -1>(-1);
+  // Group by account type — the same sections as the main Accounts screen.
+  const [grouped, setGrouped] = useState(false);
 
   const handleSort = (key: SortKey): void => {
     if (key === sortKey) {
@@ -74,13 +79,27 @@ export default function AccountBreakdownModal({
   const liabilities = useMemo(() => rows.filter(r => r.balance < 0), [rows]);
 
   const sections = useMemo(() => {
+    const included = view === 'assets' ? assets : view === 'liabilities' ? liabilities : rows;
+
+    if (grouped) {
+      // The SAME sections, titles and order as the main Accounts screen —
+      // shared definition, so the two can never disagree. The active sort
+      // still applies within each group.
+      return ALL_ACCOUNT_SECTIONS
+        .map(section => ({
+          name: section.title as string | null,
+          rows: sortRows(included.filter(r => sectionTypeForAccount(r.accountType) === section.type)),
+        }))
+        .filter(section => section.rows.length > 0);
+    }
+
     if (view === 'assets') return [{ name: null as string | null, rows: sortRows(assets) }];
     if (view === 'liabilities') return [{ name: null as string | null, rows: sortRows(liabilities) }];
     return [
       { name: 'Assets' as string | null, rows: sortRows(assets) },
       { name: 'Liabilities' as string | null, rows: sortRows(liabilities) },
     ];
-  }, [view, assets, liabilities, sortRows]);
+  }, [view, grouped, rows, assets, liabilities, sortRows]);
 
   const total = useMemo(() => {
     const included = view === 'assets' ? assets : view === 'liabilities' ? liabilities : rows;
@@ -90,12 +109,32 @@ export default function AccountBreakdownModal({
   const arrow = (key: SortKey): string => (sortKey === key ? (sortDir === 1 ? ' ↑' : ' ↓') : '');
 
   return (
-    <Modal isOpen={view !== null} onClose={onClose} title={view ? TITLES[view] : ''} size="lg">
+    <Modal
+      isOpen={view !== null}
+      onClose={onClose}
+      title={view ? TITLES[view] : ''}
+      size="lg"
+      headerActions={
+        <button
+          type="button"
+          onClick={() => setGrouped(g => !g)}
+          aria-pressed={grouped}
+          className={`px-4 py-1.5 text-sm font-medium rounded-lg border transition-colors ${
+            grouped
+              ? 'bg-[#1a2332] dark:bg-blue-600 border-[#1a2332] dark:border-blue-600 text-white'
+              : 'border-gray-300 dark:border-gray-600 text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700'
+          }`}
+          title="Group accounts by type, the way the Accounts screen does"
+        >
+          Group
+        </button>
+      }
+    >
       <ModalBody>
         <table className="w-full">
           <thead>
             <tr className="text-xs text-gray-500 dark:text-gray-400 border-b border-gray-100 dark:border-gray-700">
-              <th className="pb-2 font-medium text-left">
+              <th className="pb-2 font-medium text-center">
                 <button
                   type="button"
                   onClick={() => handleSort('name')}
@@ -105,7 +144,7 @@ export default function AccountBreakdownModal({
                   Account{arrow('name')}
                 </button>
               </th>
-              <th className="pb-2 font-medium text-right">
+              <th className="pb-2 font-medium text-center">
                 <button
                   type="button"
                   onClick={() => handleSort('balance')}
@@ -129,7 +168,7 @@ export default function AccountBreakdownModal({
                       </span>
                     </td>
                     <td className={`py-1.5 text-xs font-semibold text-right tabular-nums ${
-                      section.name === 'Liabilities'
+                      section.rows.reduce((s, r) => s + r.balance, 0) < 0
                         ? 'text-red-600 dark:text-red-400'
                         : 'text-green-600 dark:text-green-400'
                     }`}>
@@ -137,7 +176,7 @@ export default function AccountBreakdownModal({
                     </td>
                   </tr>
                 )}
-                {section.rows.length === 0 && (
+                {!grouped && section.rows.length === 0 && (
                   <tr>
                     <td colSpan={2} className="py-4 text-center text-sm text-gray-400 dark:text-gray-500">
                       Nothing here — every account stands {view === 'liabilities' ? 'positive' : 'negative'}.

--- a/src/components/BulkCategorizeModal.tsx
+++ b/src/components/BulkCategorizeModal.tsx
@@ -157,13 +157,13 @@ export default function BulkCategorizeModal({ isOpen, onClose }: Props): React.J
               <table className="block sm:table w-full">
                 <thead className="hidden sm:table-header-group">
                   <tr className="text-xs text-gray-500 dark:text-gray-400 border-b border-gray-100 dark:border-gray-700">
-                    <th className="text-left pb-2 pr-3 font-medium">Payee</th>
-                    <th className="text-right pb-2 pr-3 font-medium">Rows</th>
-                    {/* pr matches the body cells so each heading ends where
-                        its column ends, instead of "Total" leaning on
-                        "Category". */}
-                    <th className="text-right pb-2 pr-3 font-medium">Total</th>
-                    <th className="text-left pb-2 font-medium w-72 lg:w-96">Category</th>
+                    {/* Headings sit CENTRED over their columns — the app-wide
+                        convention. pr matches the body cells so each heading
+                        centres on its column, not on the gap beside it. */}
+                    <th className="text-center pb-2 pr-3 font-medium">Payee</th>
+                    <th className="text-center pb-2 pr-3 font-medium">Rows</th>
+                    <th className="text-center pb-2 pr-3 font-medium">Total</th>
+                    <th className="text-center pb-2 font-medium w-80 lg:w-[26rem]">Category</th>
                   </tr>
                 </thead>
                 <tbody className="block sm:table-row-group">

--- a/src/components/CategorySelector.tsx
+++ b/src/components/CategorySelector.tsx
@@ -4,6 +4,45 @@ import { useApp } from '../contexts/AppContextSupabase';
 import type { Category } from '../types';
 import { ChevronDownIcon, TagIcon, PlusIcon, ArrowLeftIcon, CheckIcon } from './icons';
 
+/**
+ * A category name on ONE line, whatever its length: the trigger box is a
+ * fixed height, so a wrapping label was always a layout bug. The text first
+ * shrinks (down to an 11px floor) and only then ellipsises — long
+ * Money-style names like "Household : Other/Misc (Private/Not Seen)" stay
+ * whole and readable instead of breaking onto a second line. Every
+ * categorisation surface uses this selector, so every popup gets the same
+ * pattern for free.
+ */
+function FitLabel({ text, muted }: { text: string; muted: boolean }): JSX.Element {
+  const ref = useRef<HTMLSpanElement>(null);
+  useLayoutEffect(() => {
+    const el = ref.current;
+    if (!el) return;
+    const fit = (): void => {
+      el.style.fontSize = '';
+      let size = parseFloat(getComputedStyle(el).fontSize);
+      while (el.scrollWidth > el.clientWidth && size > 11) {
+        size -= 0.5;
+        el.style.fontSize = `${size}px`;
+      }
+    };
+    fit();
+    const ro = new ResizeObserver(fit);
+    ro.observe(el);
+    return () => ro.disconnect();
+  }, [text]);
+  return (
+    <span
+      ref={ref}
+      className={`block whitespace-nowrap overflow-hidden text-ellipsis ${
+        muted ? 'text-gray-500 dark:text-gray-400' : 'text-gray-900 dark:text-white'
+      }`}
+    >
+      {text}
+    </span>
+  );
+}
+
 /** Fixed-position coordinates for the portaled dropdown (usePortal mode). */
 interface MenuPosition {
   left: number;
@@ -424,8 +463,8 @@ export default function CategorySelector({
           className="w-full px-3 py-2 h-[42px] bg-white dark:bg-gray-800 border border-gray-300 dark:border-gray-600 rounded-xl shadow-sm cursor-text flex items-center"
           onClick={handleInputClick}
         >
-          <div className="flex items-center justify-between">
-            <div className="flex-1">
+          <div className="flex w-full min-w-0 items-center justify-between gap-1">
+            <div className="flex-1 min-w-0">
               {showDropdown ? (
                 <input
                   type="text"
@@ -441,9 +480,10 @@ export default function CategorySelector({
                   autoFocus
                 />
               ) : (
-                <span className={`block ${selectedCategory ? 'text-gray-900 dark:text-white' : 'text-gray-500 dark:text-gray-400'}`}>
-                  {selectedCategory ? getSelectedCategoryName() : placeholder}
-                </span>
+                <FitLabel
+                  text={selectedCategory ? getSelectedCategoryName() : placeholder}
+                  muted={!selectedCategory}
+                />
               )}
             </div>
             <ChevronDownIcon

--- a/src/components/IncomeExpenseBreakdownModal.tsx
+++ b/src/components/IncomeExpenseBreakdownModal.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useMemo, useState } from 'react';
 import CategorySelector from './CategorySelector';
+import { XIcon } from './icons';
 import { Modal, ModalBody } from './common/Modal';
 import { useCurrencyDecimal } from '../hooks/useCurrencyDecimal';
 import { bucketContribution } from '../utils/incomeExpense';
@@ -189,8 +190,9 @@ export default function IncomeExpenseBreakdownModal({
 
   const arrow = (key: SortKey): string => (sortKey === key ? (sortDir === 1 ? ' ↑' : ' ↓') : '');
 
-  const headerButton = (key: SortKey, label: string, align: 'left' | 'right' = 'left') => (
-    <th className={`pb-2 font-medium text-${align}`}>
+  // Headings sit CENTRED over their columns — the app-wide convention.
+  const headerButton = (key: SortKey, label: string, _align: 'left' | 'right' = 'left') => (
+    <th className="pb-2 font-medium text-center">
       <button
         type="button"
         onClick={() => handleSort(key)}
@@ -225,19 +227,38 @@ export default function IncomeExpenseBreakdownModal({
           // Picking is not opening: the cell swallows the click so the row's
           // click-to-edit stays available everywhere else on the row.
           <td className="block sm:table-cell col-span-3 pb-2 sm:py-1.5 pr-0 sm:pr-3" onClick={(e) => e.stopPropagation()}>
-            <CategorySelector
-              selectedCategory={pendingChoices[t.id] ?? ''}
-              onCategoryChange={(categoryId) => setPendingChoices(prev => ({ ...prev, [t.id]: categoryId }))}
-              transactionType={t.amount < 0 ? 'expense' : 'income'}
-              includeAllTypes
-              showHelperText={false}
-              usePortal
-              placeholder="Choose a category…"
-              // One fixed width for every row from sm up — a fluid picker
-              // sized itself to each row's leftover space and the column
-              // read ragged. Phones get the full row width instead.
-              className="w-full sm:w-72"
-            />
+            <span className="flex items-center gap-1.5">
+              <CategorySelector
+                selectedCategory={pendingChoices[t.id] ?? ''}
+                onCategoryChange={(categoryId) => setPendingChoices(prev => ({ ...prev, [t.id]: categoryId }))}
+                transactionType={t.amount < 0 ? 'expense' : 'income'}
+                includeAllTypes
+                showHelperText={false}
+                usePortal
+                placeholder="Choose a category…"
+                // One fixed width for every row from sm up — a fluid picker
+                // sized itself to each row's leftover space and the column
+                // read ragged. Phones get the full row width instead.
+                className="w-full sm:w-80"
+              />
+              {/* Same pattern as Categorise by payee: an accidental pick must
+                  be reversible, and the slot is RESERVED so every picker in
+                  the column stays one width. */}
+              <span className="w-8 shrink-0 flex justify-center">
+                {(pendingChoices[t.id] ?? '') !== '' && (
+                  <button
+                    type="button"
+                    onClick={() => setPendingChoices(prev => ({ ...prev, [t.id]: '' }))}
+                    disabled={saving}
+                    className="p-1.5 rounded-lg text-gray-400 hover:text-gray-700 dark:hover:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors disabled:opacity-50"
+                    title="Clear — back to Choose a category"
+                    aria-label="Clear chosen category"
+                  >
+                    <XIcon size={14} />
+                  </button>
+                )}
+              </span>
+            </span>
           </td>
         ) : (
           <td className="block sm:table-cell col-span-3 sm:col-auto py-0 sm:py-2 pr-0 sm:pr-3 text-sm text-gray-500 dark:text-gray-400">

--- a/src/pages/Accounts.tsx
+++ b/src/pages/Accounts.tsx
@@ -797,7 +797,7 @@ export default function Accounts({ onAccountClick }: { onAccountClick?: (account
             <button
               type="button"
               onClick={() => setBreakdownView('net')}
-              className="bg-[#1a2332] dark:bg-gray-700 rounded-xl p-4 text-white text-left hover:bg-[#2d3a4d] dark:hover:bg-gray-600 transition-colors"
+              className="flex flex-col items-start bg-[#1a2332] dark:bg-gray-700 rounded-xl p-4 text-white text-left hover:bg-[#2d3a4d] dark:hover:bg-gray-600 transition-colors"
               title="See the accounts behind this figure"
             >
               <p className="text-xs text-white/60 uppercase tracking-wider font-medium">Net Worth</p>
@@ -806,7 +806,7 @@ export default function Accounts({ onAccountClick }: { onAccountClick?: (account
             <button
               type="button"
               onClick={() => setBreakdownView('assets')}
-              className="bg-white dark:bg-gray-800 rounded-xl p-4 border border-gray-100 dark:border-gray-700 text-left hover:border-gray-300 dark:hover:border-gray-500 hover:shadow-md transition-all"
+              className="flex flex-col items-start bg-white dark:bg-gray-800 rounded-xl p-4 border border-gray-100 dark:border-gray-700 text-left hover:border-gray-300 dark:hover:border-gray-500 hover:shadow-md transition-all"
               title="See the accounts behind this figure"
             >
               <p className="text-xs text-gray-500 uppercase tracking-wider font-medium">Assets</p>
@@ -815,7 +815,7 @@ export default function Accounts({ onAccountClick }: { onAccountClick?: (account
             <button
               type="button"
               onClick={() => setBreakdownView('liabilities')}
-              className="bg-white dark:bg-gray-800 rounded-xl p-4 border border-gray-100 dark:border-gray-700 text-left hover:border-gray-300 dark:hover:border-gray-500 hover:shadow-md transition-all"
+              className="flex flex-col items-start bg-white dark:bg-gray-800 rounded-xl p-4 border border-gray-100 dark:border-gray-700 text-left hover:border-gray-300 dark:hover:border-gray-500 hover:shadow-md transition-all"
               title="See the accounts behind this figure"
             >
               <p className="text-xs text-gray-500 uppercase tracking-wider font-medium">Liabilities</p>
@@ -1125,6 +1125,7 @@ export default function Accounts({ onAccountClick }: { onAccountClick?: (account
           id: a.id,
           name: a.name,
           institution: a.institution,
+          accountType: a.type,
           balance: computeAccountBalance(a.id),
           formatted: formatDisplayCurrency(computeAccountBalance(a.id), a.currency),
         }))}


### PR DESCRIPTION
User-tested against real data:

- **Category names never wrap** — fixed in the CategorySelector itself: one-line label that shrinks its font (11px floor) then ellipsises. Every categorisation surface inherits the pattern by construction.
- **Headers centred over their columns** in the payee, one-by-one and account-breakdown popups (house convention).
- **One-by-one gains the reserved-slot clear ×** (same pattern as payee) — accidental picks are reversible and pickers stay one width. Pickers widened in both popups.
- **Accounts summary cards stack label-over-figure again** — a global `button { display:inline-flex }` reset had flattened them when they became clickable; they now declare their own column layout.
- **Group toggle** on Net Worth / Assets / Liabilities breakdowns — slate when on, groups by the same account-type sections as the main Accounts screen (shared definition), per-group subtotals, active sort within groups.

Verified in-browser (grouped sections, subtotals, active state, centred headers, stacked cards). Gates green (3,475 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)