### PR TITLE
Closed-account names, a checkable check, working + shortcuts, visible group headers

### DIFF
--- a/src/components/AccountBreakdownModal.tsx
+++ b/src/components/AccountBreakdownModal.tsx
@@ -160,8 +160,8 @@ export default function AccountBreakdownModal({
             {sections.map((section, i) => (
               <React.Fragment key={section.name ?? `flat-${i}`}>
                 {section.name !== null && (
-                  <tr className="bg-gray-50 dark:bg-gray-800/60">
-                    <td className="py-1.5 pr-3 text-xs font-semibold uppercase tracking-wide text-gray-600 dark:text-gray-300">
+                  <tr className="bg-gray-100 dark:bg-gray-700/70 border-y border-gray-300 dark:border-gray-500">
+                    <td className="py-2 pr-3 text-xs font-semibold uppercase tracking-wide text-gray-700 dark:text-gray-200">
                       {section.name}
                       <span className="ml-2 font-normal normal-case text-gray-400 dark:text-gray-500">
                         ({section.rows.length})

--- a/src/components/BulkCategorizeModal.tsx
+++ b/src/components/BulkCategorizeModal.tsx
@@ -1,6 +1,7 @@
 import React, { useMemo, useState } from 'react';
 import { Modal, ModalBody, ModalFooter } from './common/Modal';
 import CategorySelector from './CategorySelector';
+import { useAccountNames } from '../hooks/useAccountNames';
 import { useApp } from '../contexts/AppContextSupabase';
 import { useToast } from '../contexts/ToastContext';
 import { useCurrencyDecimal } from '../hooks/useCurrencyDecimal';
@@ -29,17 +30,16 @@ interface Props {
 const CAP = 100;
 
 export default function BulkCategorizeModal({ isOpen, onClose }: Props): React.JSX.Element {
-  const { transactions, categories, accounts, applyCategoryToUncategorized } = useApp();
+  const { transactions, categories, applyCategoryToUncategorized } = useApp();
   const { formatCurrency } = useCurrencyDecimal();
   const { showSuccess, showError } = useToast();
   const [choices, setChoices] = useState<Record<string, string>>({});
   const [applying, setApplying] = useState(false);
   const [progress, setProgress] = useState(0);
 
-  const accountName = useMemo(() => {
-    const byId = new Map(accounts.map(a => [a.id, a.name]));
-    return (id: string): string => byId.get(id) ?? 'Unknown account';
-  }, [accounts]);
+  // Closed accounts included — Money-era payees live in accounts long since
+  // closed, and every one of them has a real name.
+  const accountName = useAccountNames();
 
   const categoryName = useMemo(() => {
     const byId = new Map(categories.map(c => [c.id, c]));

--- a/src/components/IncomeExpenseBreakdownModal.tsx
+++ b/src/components/IncomeExpenseBreakdownModal.tsx
@@ -314,8 +314,8 @@ export default function IncomeExpenseBreakdownModal({
               {view.sections.map((section, i) => (
                 <React.Fragment key={section.name ?? `flat-${i}`}>
                   {section.name !== null && (
-                    <tr className="flex items-center justify-between sm:table-row bg-gray-50 dark:bg-gray-800/60">
-                      <td colSpan={3} className="block sm:table-cell py-1.5 pr-3 text-xs font-semibold uppercase tracking-wide text-gray-600 dark:text-gray-300">
+                    <tr className="flex items-center justify-between sm:table-row bg-gray-100 dark:bg-gray-700/70 border-y border-gray-300 dark:border-gray-500">
+                      <td colSpan={3} className="block sm:table-cell py-2 pr-3 text-xs font-semibold uppercase tracking-wide text-gray-700 dark:text-gray-200">
                         {section.name}
                         <span className="ml-2 font-normal normal-case text-gray-400 dark:text-gray-500">
                           ({section.rows.length})

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -128,6 +128,18 @@ export default function Layout(): React.JSX.Element {
     setIsMobileSearchVisible(false);
   }, [location.pathname]);
 
+  // The mobile +'s "Add Transaction" deep-links /transactions?action=add.
+  // The app-wide add modal is Layout's, so Layout honours it — and consumes
+  // the param with a replace, so back or refresh cannot re-open the modal.
+  useEffect(() => {
+    const params = new URLSearchParams(location.search);
+    if (location.pathname === '/transactions' && params.get('action') === 'add') {
+      setShowGlobalAddTransaction(true);
+      params.delete('action');
+      navigate({ pathname: location.pathname, search: params.toString() }, { replace: true });
+    }
+  }, [location.pathname, location.search, navigate]);
+
   const toggleMobileMenu = useCallback(() => {
     setIsMobileMenuOpen((prev) => !prev);
   }, []);

--- a/src/components/TransferSweepModal.tsx
+++ b/src/components/TransferSweepModal.tsx
@@ -4,6 +4,7 @@ import { useApp } from '../contexts/AppContextSupabase';
 import { useToast } from '../contexts/ToastContext';
 import { useCurrencyDecimal } from '../hooks/useCurrencyDecimal';
 import { sweepTransferPairs, type TransferPairSuggestion } from '../utils/transferSweep';
+import { useAccountNames } from '../hooks/useAccountNames';
 import { AlertTriangleIcon, ArrowRightIcon } from './icons';
 
 /**
@@ -23,17 +24,17 @@ interface Props {
 const CAP = 300;
 
 export default function TransferSweepModal({ isOpen, onClose }: Props): React.JSX.Element {
-  const { transactions, categories, accounts, linkTransferPair } = useApp();
+  const { transactions, categories, linkTransferPair } = useApp();
   const { formatCurrency } = useCurrencyDecimal();
   const { showSuccess, showError } = useToast();
   const [selected, setSelected] = useState<Set<string> | null>(null);
+  const [inspecting, setInspecting] = useState<TransferPairSuggestion | null>(null);
   const [applying, setApplying] = useState(false);
   const [progress, setProgress] = useState(0);
 
-  const accountName = useMemo(() => {
-    const byId = new Map(accounts.map(a => [a.id, a.name]));
-    return (id: string): string => byId.get(id) ?? 'Unknown account';
-  }, [accounts]);
+  // Closed accounts included — old transfers routinely have one leg in an
+  // account that has since been closed.
+  const accountName = useAccountNames();
 
   const { suggestions } = useMemo(() => {
     if (!isOpen) return { suggestions: [] as TransferPairSuggestion[] };
@@ -151,14 +152,27 @@ export default function TransferSweepModal({ isOpen, onClose }: Props): React.JS
                             <span className="truncate max-w-[140px]">{accountName(s.incoming.accountId)}</span>
                           </span>
                           {s.ambiguous && (
-                            <span className="ml-2 inline-flex items-center gap-1 text-xs text-amber-600 dark:text-amber-400">
+                            <button
+                              type="button"
+                              onClick={() => setInspecting(s)}
+                              className="ml-2 inline-flex items-center gap-1 text-xs text-amber-700 dark:text-amber-400 underline decoration-dotted underline-offset-2 hover:text-amber-900 dark:hover:text-amber-300"
+                              title="Other rows matched this amount equally well — look at both sides before linking"
+                            >
                               <AlertTriangleIcon size={12} />
                               check
-                            </span>
+                            </button>
                           )}
                         </td>
-                        <td className="py-2 text-sm text-gray-600 dark:text-gray-400">
-                          <span className="block truncate max-w-[220px]">{s.outgoing.description}</span>
+                        {/* Any row can be inspected — the description opens
+                            the same both-sides popup the check badge does. */}
+                        <td
+                          className="py-2 text-sm text-gray-600 dark:text-gray-400 cursor-pointer hover:text-gray-900 dark:hover:text-gray-200"
+                          onClick={() => setInspecting(s)}
+                          title="See both sides of this pair"
+                        >
+                          <span className="block truncate max-w-[220px] underline decoration-dotted underline-offset-2 decoration-gray-300 dark:decoration-gray-600">
+                            {s.outgoing.description}
+                          </span>
                         </td>
                         <td className="py-2 text-sm font-medium text-right tabular-nums text-gray-900 dark:text-white whitespace-nowrap">
                           {formatCurrency(Math.abs(s.outgoing.amount))}
@@ -207,6 +221,74 @@ export default function TransferSweepModal({ isOpen, onClose }: Props): React.JS
           </div>
         </div>
       </ModalFooter>
+      {/* The check, made checkable: both legs side by side, in full, with
+          the reason for the flag — and a verdict either way, one tap. */}
+      {inspecting && (
+        <Modal
+          isOpen
+          onClose={() => setInspecting(null)}
+          title="Check this pair"
+          size="lg"
+        >
+          <ModalBody>
+            <p className="text-sm text-gray-600 dark:text-gray-400 mb-4">
+              Flagged because other rows matched this amount equally well — make sure
+              these two really are the same movement of money.
+              {inspecting.daysApart > 0 && (
+                <> The two sides are <strong>{Math.round(inspecting.daysApart)} day{Math.round(inspecting.daysApart) === 1 ? '' : 's'} apart</strong>.</>
+              )}
+            </p>
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+              {([
+                { label: 'Money out', t: inspecting.outgoing, colour: 'text-red-600 dark:text-red-400' },
+                { label: 'Money in', t: inspecting.incoming, colour: 'text-green-600 dark:text-green-400' },
+              ] as const).map(({ label, t, colour }) => (
+                <div key={t.id} className="rounded-xl border border-gray-200 dark:border-gray-700 p-4">
+                  <p className="text-[10px] uppercase tracking-wide text-gray-400 dark:text-gray-500 mb-1">{label}</p>
+                  <p className={`text-lg font-bold tabular-nums ${colour}`}>
+                    {formatCurrency(Math.abs(t.amount))}
+                  </p>
+                  <p className="mt-2 text-sm font-medium text-gray-900 dark:text-white">
+                    {accountName(t.accountId)}
+                  </p>
+                  <p className="text-sm text-gray-600 dark:text-gray-400 break-words">{t.description}</p>
+                  <p className="mt-1 text-xs text-gray-500 dark:text-gray-400">
+                    {new Date(t.date).toLocaleDateString('en-GB', { day: '2-digit', month: 'long', year: 'numeric' })}
+                  </p>
+                </div>
+              ))}
+            </div>
+          </ModalBody>
+          <ModalFooter>
+            <div className="flex items-center gap-2 ml-auto">
+              <button
+                type="button"
+                onClick={() => {
+                  const next = new Set(effectiveSelected);
+                  next.delete(keyOf(inspecting));
+                  setSelected(next);
+                  setInspecting(null);
+                }}
+                className="px-4 py-2 text-sm font-medium rounded-lg border border-gray-300 dark:border-gray-600 text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors"
+              >
+                Not a pair — leave it
+              </button>
+              <button
+                type="button"
+                onClick={() => {
+                  const next = new Set(effectiveSelected);
+                  next.add(keyOf(inspecting));
+                  setSelected(next);
+                  setInspecting(null);
+                }}
+                className="px-4 py-2 text-sm font-medium rounded-lg bg-[#1a2332] dark:bg-blue-600 text-white hover:bg-[#2d3a4d] dark:hover:bg-blue-700 transition-colors"
+              >
+                Yes — select this pair
+              </button>
+            </div>
+          </ModalFooter>
+        </Modal>
+      )}
     </Modal>
   );
 }

--- a/src/hooks/useAccountNames.ts
+++ b/src/hooks/useAccountNames.ts
@@ -1,0 +1,35 @@
+import { useEffect, useMemo, useState } from 'react';
+import { useApp } from '../contexts/AppContextSupabase';
+import { DataService } from '../services/api/dataService';
+import type { Account } from '../types';
+
+/**
+ * Account-id → display name, including CLOSED accounts.
+ *
+ * The app context deliberately carries only open accounts, so any surface
+ * that resolved names from it alone showed "Unknown account" for history in
+ * closed ones — measured on real data: 43 of the 90 accounts behind the
+ * uncategorised backlog were closed, every one with a perfectly good name.
+ * Closed accounts read "Name (closed)"; "Unknown account" is reserved for
+ * ids that genuinely resolve to nothing.
+ */
+export function useAccountNames(): (id: string) => string {
+  const { accounts } = useApp();
+  const [closed, setClosed] = useState<Account[]>([]);
+
+  useEffect(() => {
+    let cancelled = false;
+    DataService.getClosedAccounts()
+      .then(list => { if (!cancelled) setClosed(list); })
+      .catch(() => { /* names fall back to "Unknown account"; nothing breaks */ });
+    return () => { cancelled = true; };
+  }, []);
+
+  return useMemo(() => {
+    const byId = new Map<string, string>();
+    closed.forEach(a => byId.set(a.id, `${a.name} (closed)`));
+    // Open accounts win if an id somehow appears in both.
+    accounts.forEach(a => byId.set(a.id, a.name));
+    return (id: string): string => byId.get(id) ?? 'Unknown account';
+  }, [accounts, closed]);
+}

--- a/src/pages/Accounts.tsx
+++ b/src/pages/Accounts.tsx
@@ -80,6 +80,17 @@ export default function Accounts({ onAccountClick }: { onAccountClick?: (account
   // is a substring test over a couple of hundred rows.
   const [accountSearch, setAccountSearch] = useState('');
 
+  // The mobile +'s "Add Account" deep-links /accounts?action=add — open the
+  // modal and consume the param (replace), so back/refresh cannot re-open it.
+  useEffect(() => {
+    const params = new URLSearchParams(location.search);
+    if (params.get('action') === 'add') {
+      setIsAddModalOpen(true);
+      params.delete('action');
+      navigate({ pathname: location.pathname, search: params.toString() }, { replace: true });
+    }
+  }, [location.pathname, location.search, navigate]);
+
   const { getUnreconciledCount, computeAccountBalance: computeLedgerBalance } = useReconciliation(accounts, transactions);
 
   // The transaction pages take seconds to arrive on a long history, and until

--- a/src/pages/Categorisation.tsx
+++ b/src/pages/Categorisation.tsx
@@ -4,6 +4,7 @@ import { useCurrencyDecimal } from '../hooks/useCurrencyDecimal';
 import { computeIncomeExpense } from '../utils/incomeExpense';
 import { expandSplitTransactions, type SplitExpandedTransaction } from '../utils/transactionSplits';
 import { groupUncategorisedByAccount } from '../utils/uncategorisedByAccount';
+import { useAccountNames } from '../hooks/useAccountNames';
 import TransferSweepModal from '../components/TransferSweepModal';
 import BulkCategorizeModal from '../components/BulkCategorizeModal';
 import ReportDrillModal, { type ReportDrillTarget } from '../components/reports/ReportDrillModal';
@@ -28,7 +29,7 @@ import { ArrowRightLeftIcon, TagIcon, ListIcon, CheckCircleIcon, Building2Icon, 
  * it.
  */
 export default function Categorisation(): React.JSX.Element {
-  const { transactions, transactionSplits, accounts, categories } = useApp();
+  const { transactions, transactionSplits, categories } = useApp();
   const { formatCurrency } = useCurrencyDecimal();
 
   const [drill, setDrill] = useState<ReportDrillTarget | null>(null);
@@ -47,10 +48,10 @@ export default function Categorisation(): React.JSX.Element {
   const uncategorised = flows.uncategorizedRows;
   const count = uncategorised.length;
 
-  const accountName = useMemo(() => {
-    const byId = new Map(accounts.map(a => [a.id, a.name]));
-    return (id: string): string => byId.get(id) ?? 'Unknown account';
-  }, [accounts]);
+  // Includes CLOSED accounts — old history is exactly where the
+  // uncategorised backlog lives, and "Unknown account" was just a failure
+  // to look closed accounts up.
+  const accountName = useAccountNames();
 
   /** Where the unfiled rows actually are, worst first. */
   const byAccount = useMemo(


### PR DESCRIPTION
Four improvements from live testing:

- **"Unknown account" retired.** The categorisation surfaces resolved names only from open accounts; measured on real data, 43 of the 90 accounts behind the uncategorised backlog are closed — all with perfectly good names. A shared `useAccountNames` resolver includes them as "Name (closed)" across the by-account list, payee popup and transfer sweep.
- **The transfer sweep's "check" is checkable**: a popup shows both legs in full (account, description, amount, date) plus why it was flagged, with a one-tap verdict — select the pair or leave it. Any row's description opens the same popup.
- **The mobile + menu actually shortcuts**: `?action=add` was sent but never read. `/transactions` now opens the app-wide add-transaction modal, `/accounts` its add-account form; both consume the param with a replace so back/refresh can't re-open a modal. Verified live both routes.
- **Breakdown group headers darken** from a whisper to a real divider.

Gates green (3,475 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)