### PR TITLE
feat(ui): payee drill-down, register deep links, sortable breakdowns, reconciliation focus filter

### DIFF
--- a/src/components/BulkCategorizeModal.tsx
+++ b/src/components/BulkCategorizeModal.tsx
@@ -2,6 +2,9 @@ import React, { useMemo, useState } from 'react';
 import { Modal, ModalBody, ModalFooter } from './common/Modal';
 import CategorySelector from './CategorySelector';
 import { useAccountNames } from '../hooks/useAccountNames';
+import { useNavigate, useLocation } from 'react-router-dom';
+import IncomeExpenseBreakdownModal from './IncomeExpenseBreakdownModal';
+import type { SplitExpandedTransaction } from '../utils/transactionSplits';
 import { useApp } from '../contexts/AppContextSupabase';
 import { useToast } from '../contexts/ToastContext';
 import { useCurrencyDecimal } from '../hooks/useCurrencyDecimal';
@@ -33,6 +36,12 @@ export default function BulkCategorizeModal({ isOpen, onClose }: Props): React.J
   const { transactions, categories, applyCategoryToUncategorized } = useApp();
   const { formatCurrency } = useCurrencyDecimal();
   const { showSuccess, showError } = useToast();
+  const navigate = useNavigate();
+  const location = useLocation();
+  // Drill into ONE payee: its rows in the same inline-filing list the
+  // one-by-one review uses — file a few by hand, save, come back, and bulk
+  // the rest.
+  const [drillGroup, setDrillGroup] = useState<PayeeGroup | null>(null);
   const [choices, setChoices] = useState<Record<string, string>>({});
   const [applying, setApplying] = useState(false);
   const [progress, setProgress] = useState(0);
@@ -177,9 +186,14 @@ export default function BulkCategorizeModal({ isOpen, onClose }: Props): React.J
                             {group.direction === 'expense'
                               ? <ArrowDownIcon size={12} className="text-red-500 flex-shrink-0" />
                               : <ArrowUpIcon size={12} className="text-green-600 flex-shrink-0" />}
-                            <span className="text-sm text-gray-900 dark:text-white truncate max-w-[220px] lg:max-w-[340px]">
+                            <button
+                              type="button"
+                              onClick={() => setDrillGroup(group)}
+                              className="text-sm text-gray-900 dark:text-white truncate max-w-[220px] lg:max-w-[340px] text-left underline decoration-dotted underline-offset-2 decoration-gray-300 dark:decoration-gray-600 hover:text-blue-700 dark:hover:text-blue-400"
+                              title={`See the ${group.count.toLocaleString()} transactions behind this payee`}
+                            >
                               {group.displayName}
-                            </span>
+                            </button>
                           </span>
                           <span className="block text-xs text-gray-400 dark:text-gray-500 mt-0.5">
                             {new Date(group.earliest).toLocaleDateString('en-GB', { month: 'short', year: 'numeric' })}
@@ -301,6 +315,48 @@ export default function BulkCategorizeModal({ isOpen, onClose }: Props): React.J
           </div>
         </div>
       </ModalFooter>
+      {/* One payee, opened up: the same inline-filing list as the
+          one-by-one review — pick categories row by row, Save in the
+          header, saved rows leave — scoped to this payee. Clicking a row
+          jumps to the transaction IN ITS ACCOUNT's register (selected and
+          scrolled to), for the times only the surrounding history can say
+          what something was. */}
+      {drillGroup && (
+        <IncomeExpenseBreakdownModal
+          isOpen
+          onClose={() => setDrillGroup(null)}
+          title={`${drillGroup.displayName} — ${drillGroup.count.toLocaleString()} uncategorised`}
+          bucket="uncategorized"
+          rows={drillGroup.transactionIds
+            .map(id => transactions.find(t => t.id === id))
+            .filter((t): t is NonNullable<typeof t> => t !== undefined) as SplitExpandedTransaction[]}
+          total={null}
+          categories={categories}
+          onEditTransaction={(txnId) => {
+            const txn = transactions.find(t => t.id === txnId);
+            if (!txn) return;
+            const params = new URLSearchParams();
+            params.set('txn', txnId);
+            if (new URLSearchParams(location.search).get('demo') === 'true') {
+              params.set('demo', 'true');
+            }
+            setDrillGroup(null);
+            onClose();
+            navigate(`/accounts/${txn.accountId}?${params.toString()}`);
+          }}
+          onApplyCategories={async (assignments) => {
+            let updated = 0;
+            for (const [categoryId, ids] of assignments) {
+              updated += await applyCategoryToUncategorized(ids, categoryId);
+            }
+            showSuccess(
+              `${updated.toLocaleString()} transaction${updated === 1 ? '' : 's'} categorised.`,
+              'Categories applied'
+            );
+            return updated;
+          }}
+        />
+      )}
     </Modal>
   );
 }

--- a/src/components/MobileBottomSheet.tsx
+++ b/src/components/MobileBottomSheet.tsx
@@ -146,9 +146,14 @@ export function MobileBottomSheet({
         tabIndex={-1}
       >
         {/* Drag Handle */}
+        {/* The drag overlay is ABSOLUTE, so it paints above the header
+            regardless of DOM order — full-width it sat exactly on top of
+            the close button and silently ate every tap on the X. Stopping
+            it short of the right edge (right-16) leaves the X reachable
+            while the rest of the top strip still drags. */}
         {showHandle && (
           <div
-            className="absolute top-0 left-0 right-0 h-12 cursor-grab active:cursor-grabbing"
+            className="absolute top-0 left-0 right-16 h-12 cursor-grab active:cursor-grabbing"
             onTouchStart={handleTouchStart}
             onTouchMove={handleTouchMove}
             onTouchEnd={handleTouchEnd}
@@ -167,7 +172,7 @@ export function MobileBottomSheet({
             </h2>
             <button
               onClick={onClose}
-              className="p-2 text-gray-400 hover:text-gray-600 dark:hover:text-gray-300 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-700"
+              className="relative z-10 p-2 text-gray-400 hover:text-gray-600 dark:hover:text-gray-300 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-700"
               aria-label="Close bottom sheet"
             >
               <XIcon size={20} />

--- a/src/pages/AccountTransactions.tsx
+++ b/src/pages/AccountTransactions.tsx
@@ -149,6 +149,32 @@ export default function AccountTransactions() {
 
   const archiveWindow = useMemo(() => computeArchiveWindow(archive.range, archive.from, archive.to), [archive]);
 
+  // Deep link from the categorisation drill: /accounts/:id?txn=<txnId>
+  // selects that transaction (the quick-edit dock shows it in full), widens
+  // the date window to All so it cannot be filtered out of sight, and
+  // scrolls the register to its row. The param is consumed with a replace —
+  // the established pattern — so back/refresh does not re-trigger it.
+  const pendingTxnRef = useRef<string | null>(null);
+  useEffect(() => {
+    const params = new URLSearchParams(location.search);
+    const txn = params.get('txn');
+    if (!txn) return;
+    pendingTxnRef.current = txn;
+    setArchive(prev => (prev.range === 'all' ? prev : { range: 'all', from: '', to: '' }));
+    params.delete('txn');
+    navigate({ pathname: location.pathname, search: params.toString() }, { replace: true });
+  }, [location.pathname, location.search, navigate]);
+
+  useEffect(() => {
+    const txn = pendingTxnRef.current;
+    if (!txn) return;
+    const target = transactions.find(t => t.id === txn);
+    if (!target) return; // rows may still be loading; retry on next change
+    pendingTxnRef.current = null;
+    setSelectedTransaction(target);
+    setSelectedTransactionId(txn);
+  }, [transactions]);
+
   const toggleColumn = useCallback((key: string) => {
     setHiddenColumns(prev => (prev.includes(key) ? prev.filter(k => k !== key) : [...prev, key]));
   }, []);
@@ -452,6 +478,25 @@ export default function AccountTransactions() {
 
   // The quick-edit panel always reflects the latest saved state of the
   // selected transaction (context updates flow straight back in).
+  // Scroll the virtualised register to the selected row when it arrived via
+  // the deep link. react-window scrolls via its outer element's scrollTop;
+  // best-effort — a failed lookup simply leaves the dock as the pointer.
+  const scrolledToRef = useRef<string | null>(null);
+  useEffect(() => {
+    if (!selectedTransactionId || scrolledToRef.current === selectedTransactionId) return;
+    const index = displayRows.findIndex(row => row.id === selectedTransactionId);
+    if (index < 0) return;
+    scrolledToRef.current = selectedTransactionId;
+    try {
+      const scroller = tableWrapRef.current?.querySelector('div[style*="overflow"]') as HTMLElement | null;
+      if (scroller) {
+        scroller.scrollTop = Math.max(0, index * (compactView ? 36 : 44) - 120);
+      }
+    } catch {
+      // Selection alone still identifies the row via the dock.
+    }
+  }, [selectedTransactionId, displayRows, compactView]);
+
   const quickEditTarget = useMemo(
     () => transactionsWithBalance.find(t => t.id === selectedTransactionId) ?? null,
     [transactionsWithBalance, selectedTransactionId]

--- a/src/pages/Reconciliation.tsx
+++ b/src/pages/Reconciliation.tsx
@@ -38,6 +38,19 @@ export default function Reconciliation() {
     setSortMode(value);
     try { localStorage.setItem('reconciliationSortMode', value); } catch { /* storage unavailable */ }
   }, []);
+  // Hide the accounts that are already done — everything cleared AND no bank
+  // balance difference — so the list is only the work. Grouping still applies:
+  // the filter drops accounts within each section, never the sections shape.
+  const [onlyAttention, setOnlyAttention] = useState<boolean>(() =>
+    localStorage.getItem('reconciliationOnlyAttention') === 'true'
+  );
+  const handleOnlyAttentionToggle = useCallback(() => {
+    setOnlyAttention(prev => {
+      const next = !prev;
+      try { localStorage.setItem('reconciliationOnlyAttention', String(next)); } catch { /* storage unavailable */ }
+      return next;
+    });
+  }, []);
   const [showFinalizationModal, setShowFinalizationModal] = useState(false);
   const [editingTransaction, setEditingTransaction] = useState<Transaction | null>(null);
   const [isEditModalOpen, setIsEditModalOpen] = useState(false);
@@ -65,8 +78,25 @@ export default function Reconciliation() {
     computeClearedSummary,
   } = useReconciliation(accounts, overlaidTransactions);
 
+  // An account needs attention when transactions are still unreconciled, or a
+  // stated bank balance disagrees with the cleared balance. difference is
+  // Decimal-computed, so a balanced account is exactly 0.
+  const attentionCount = useMemo(
+    () =>
+      reconciliationDetails.filter(
+        s => s.unreconciledCount > 0 || (s.difference != null && s.difference !== 0)
+      ).length,
+    [reconciliationDetails]
+  );
+
   // Build the grouped, sorted account list (same sections as the Accounts page).
   const accountGroups = useMemo<ReconciliationGroup[]>(() => {
+    const visibleDetails = onlyAttention
+      ? reconciliationDetails.filter(
+          s => s.unreconciledCount > 0 || (s.difference != null && s.difference !== 0)
+        )
+      : reconciliationDetails;
+
     const sortSummaries = (list: typeof reconciliationDetails) => {
       const sorted = [...list];
       if (sortMode === 'name') sorted.sort((a, b) => a.account.name.localeCompare(b.account.name));
@@ -77,7 +107,7 @@ export default function Reconciliation() {
 
     if (groupBy === 'institution') {
       const byInstitution = new Map<string, typeof reconciliationDetails>();
-      for (const s of reconciliationDetails) {
+      for (const s of visibleDetails) {
         const key = s.account.institution || 'Other Accounts';
         (byInstitution.get(key) ?? byInstitution.set(key, []).get(key)!).push(s);
       }
@@ -93,11 +123,11 @@ export default function Reconciliation() {
     const groups: ReconciliationGroup[] = ALL_ACCOUNT_SECTIONS.map(section => ({
       title: section.title,
       summaries: sortSummaries(
-        reconciliationDetails.filter(s => sectionTypeForAccount(s.account.type) === section.type)
+        visibleDetails.filter(s => sectionTypeForAccount(s.account.type) === section.type)
       ),
     })).filter(g => g.summaries.length > 0);
     return groups;
-  }, [reconciliationDetails, groupBy, sortMode]);
+  }, [reconciliationDetails, groupBy, sortMode, onlyAttention]);
 
   // Selected account data
   const selectedAccount = useMemo(
@@ -333,6 +363,21 @@ export default function Reconciliation() {
                 Value {sortMode === 'balance-asc' ? '↑' : '↓'}
               </button>
             </div>
+          </div>
+          <div className="w-full sm:w-auto flex items-center">
+            <button
+              type="button"
+              onClick={handleOnlyAttentionToggle}
+              aria-pressed={onlyAttention}
+              title="Hide accounts that are fully reconciled with no balance difference"
+              className={`w-full sm:w-auto px-3 py-1.5 text-sm font-medium rounded-lg border transition-colors ${
+                onlyAttention
+                  ? 'bg-[#1a2332] dark:bg-blue-600 border-[#1a2332] dark:border-blue-600 text-white'
+                  : 'border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-200'
+              }`}
+            >
+              Needs attention only{attentionCount > 0 ? ` (${attentionCount})` : ''}
+            </button>
           </div>
         </div>
 

--- a/src/pages/Transactions.tsx
+++ b/src/pages/Transactions.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useMemo, useCallback } from 'react';
-import { useSearchParams } from 'react-router-dom';
+import { useSearchParams , useNavigate, useLocation } from 'react-router-dom';
 import { useApp } from '../contexts/AppContextSupabase';
 import { usePreferences } from '../contexts/PreferencesContext';
 import { useLayout } from '../contexts/LayoutContext';
@@ -28,6 +28,8 @@ import { useDebounce } from '../hooks/useDebounce';
 import { SkeletonTableRow, SkeletonList } from '../components/loading/Skeleton';
 
 const Transactions = React.memo(function Transactions() {
+  const navigate = useNavigate();
+  const location = useLocation();
   const { transactions, accounts, deleteTransaction, updateTransaction, categories, getDecimalTransactions } = useApp();
   const { compactView, setCompactView: _setCompactView, currency: displayCurrency } = usePreferences();
   const { isWideView } = useLayout();
@@ -39,6 +41,10 @@ const Transactions = React.memo(function Transactions() {
   const [viewingTransaction, setViewingTransaction] = useState<Transaction | null>(null);
   const [isDetailsViewOpen, setIsDetailsViewOpen] = useState(false);
   const [breakdownType, setBreakdownType] = useState<'income' | 'expense' | 'net' | null>(null);
+  // Sorting for the breakdown popup's headers (house convention: every
+  // drilled-into transaction list sorts by its columns).
+  const [breakdownSortKey, setBreakdownSortKey] = useState<'date' | 'description' | 'account' | 'amount'>('date');
+  const [breakdownSortDir, setBreakdownSortDir] = useState<1 | -1>(-1);
   const [filterType, setFilterType] = useState<'all' | 'income' | 'expense'>('all');
   const [filterAccountId, setFilterAccountId] = useState<string>('');
   const [showArchived, setShowArchived] = useState(false);
@@ -487,6 +493,24 @@ const Transactions = React.memo(function Transactions() {
       }
       rightContent={
         <div className="flex items-center gap-2">
+          {/* Same affordance Accounts has: add from the page header. Opens
+              via the ?action=add deep link Layout already honours, so the
+              header button, the mobile + menu and any future entry point
+              share ONE code path. */}
+          <button
+            onClick={() => {
+              const params = new URLSearchParams(location.search);
+              params.set('action', 'add');
+              navigate({ pathname: '/transactions', search: params.toString() });
+            }}
+            className="inline-flex items-center gap-2 px-4 py-2 bg-[#1a2332] text-white text-sm font-medium rounded-lg hover:bg-[#2d3a4d] transition-colors shadow-sm"
+            title="Add Transaction"
+          >
+            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round">
+              <path d="M12 5v14M5 12h14" />
+            </svg>
+            Add Transaction
+          </button>
           {/* Compact View Toggle - Hidden but kept in code */}
           {/* <div 
             onClick={() => setCompactView(!compactView)}
@@ -999,10 +1023,26 @@ const Transactions = React.memo(function Transactions() {
           <table className="w-full">
             <thead>
               <tr className="text-xs text-gray-500 dark:text-gray-400 border-b border-gray-100 dark:border-gray-700">
-                <th className="text-left pb-2 font-medium">Date</th>
-                <th className="text-left pb-2 font-medium">Description</th>
-                <th className="text-left pb-2 font-medium">Account</th>
-                <th className="text-right pb-2 font-medium">Amount</th>
+                {([
+                  ['date', 'Date'],
+                  ['description', 'Description'],
+                  ['account', 'Account'],
+                  ['amount', 'Amount'],
+                ] as const).map(([key, label]) => (
+                  <th key={key} className="text-center pb-2 font-medium">
+                    <button
+                      type="button"
+                      onClick={() => {
+                        if (breakdownSortKey === key) setBreakdownSortDir(d => (d === 1 ? -1 : 1));
+                        else { setBreakdownSortKey(key); setBreakdownSortDir(key === 'date' || key === 'amount' ? -1 : 1); }
+                      }}
+                      className="hover:text-gray-800 dark:hover:text-gray-200 transition-colors"
+                      title={`Sort by ${label.toLowerCase()}`}
+                    >
+                      {label}{breakdownSortKey === key ? (breakdownSortDir === 1 ? ' ↑' : ' ↓') : ''}
+                    </button>
+                  </th>
+                ))}
               </tr>
             </thead>
             <tbody>
@@ -1013,7 +1053,15 @@ const Transactions = React.memo(function Transactions() {
                     if (breakdownType === 'expense') return t.type === 'expense';
                     return t.type === 'income' || t.type === 'expense';
                   })
-                  .sort((a, b) => new Date(b.date).getTime() - new Date(a.date).getTime());
+                  .sort((a, b) => {
+                    const accName = (t: typeof a): string => accounts.find(x => x.id === t.accountId)?.name ?? '';
+                    switch (breakdownSortKey) {
+                      case 'description': return breakdownSortDir * a.description.localeCompare(b.description);
+                      case 'account': return breakdownSortDir * accName(a).localeCompare(accName(b));
+                      case 'amount': return breakdownSortDir * (Math.abs(a.amount) - Math.abs(b.amount));
+                      default: return breakdownSortDir * (new Date(a.date).getTime() - new Date(b.date).getTime());
+                    }
+                  });
 
                 if (txns.length === 0) {
                   return <tr><td colSpan={4} className="text-center py-8 text-gray-400">No transactions</td></tr>;


### PR DESCRIPTION
## What

- **Categorise by payee → drill down**: clicking a payee name opens that merchant's own transaction list with inline category filing and a header Save; clicking a row jumps to the transaction inside its account register (`?txn=<id>` deep link selects and scrolls to it, register switched to All history so old rows are reachable).
- **Transactions page**: Add Transaction button top-right of the page header (mirrors Accounts' Add Account); the Income/Expenses/Net breakdown popups get sortable Date/Description/Account/Amount headers — and a stray negation that inverted the arrow direction is fixed (↓ now genuinely means newest/biggest first).
- **Reconciliation**: a "Needs attention only" toggle beside Group by/Sort hides accounts that are fully reconciled with no bank-balance difference. Group sections are preserved (empty ones drop), the button shows a live count, and the choice persists per device like its two neighbours.
- **Mobile bottom sheet**: the invisible full-width drag strip painted above the header and swallowed every tap on the close X — it now stops 64px short of the right edge and the X is raised above it.

## Verification

- Strict typecheck, lint, smoke (3475), realtime suite, Supabase smoke, coverage 64.91%/77.56% — all green (pre-commit + pre-push hooks).
- Browser-verified at desktop and 440px: sheet X tappable and closes; breakdown sort toggles biggest↔smallest first; reconciliation filter hides a fully-cleared account and restores it on toggle-off with sections intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)