### PR TITLE
feat(ui): pinned reconciliation header, centred register jumps, UK dates in the dock

### DIFF
--- a/src/components/IncomeExpenseBreakdownModal.tsx
+++ b/src/components/IncomeExpenseBreakdownModal.tsx
@@ -239,7 +239,7 @@ export default function IncomeExpenseBreakdownModal({
                 // One fixed width for every row from sm up — a fluid picker
                 // sized itself to each row's leftover space and the column
                 // read ragged. Phones get the full row width instead.
-                className="w-full sm:w-80"
+                className="w-full sm:w-96 lg:w-[30rem]"
               />
               {/* Same pattern as Categorise by payee: an accidental pick must
                   be reversible, and the slot is RESERVED so every picker in

--- a/src/components/QuickEditTransactionPanel.tsx
+++ b/src/components/QuickEditTransactionPanel.tsx
@@ -4,6 +4,7 @@ import { useToast } from '../contexts/ToastContext';
 import { usePayeeMemory } from '../hooks/usePayeeMemory';
 import { XIcon } from './icons';
 import CategorySelector from './CategorySelector';
+import DatePicker from './common/DatePicker';
 import TransferMatchDialog from './TransferMatchDialog';
 import { findTransferCandidates, type TransferCandidate } from '../utils/transferMatch';
 import type { Transaction } from '../types';
@@ -186,12 +187,15 @@ export default function QuickEditTransactionPanel({
           <label htmlFor="quick-edit-date" className="block text-xs text-gray-500 dark:text-gray-400 mb-1">
             Date
           </label>
-          <input
+          {/* The shared dd/mm/yyyy picker, NOT a native date input: natives
+              render in the browser's locale, which showed American dates to a
+              register displaying UK ones. */}
+          <DatePicker
             id="quick-edit-date"
-            type="date"
             value={date}
-            onChange={(e) => setDate(e.target.value)}
-            className="w-full px-3 h-[42px] text-sm bg-white dark:bg-gray-700 border border-gray-300 dark:border-gray-600 rounded-xl dark:text-white"
+            onChange={setDate}
+            className="h-[42px] text-sm bg-white dark:bg-gray-700 border border-gray-300 dark:border-gray-600 rounded-xl dark:text-white"
+            aria-label="Transaction date"
           />
         </div>
 

--- a/src/components/TransferMatchDialog.tsx
+++ b/src/components/TransferMatchDialog.tsx
@@ -40,9 +40,14 @@ export default function TransferMatchDialog({
   onCancel,
 }: TransferMatchDialogProps): React.JSX.Element | null {
   const { formatCurrency } = useCurrencyDecimal();
-  const [selectedId, setSelectedId] = useState<string | null>(null);
+  // Seeded at mount, not just in the effect: the effect alone left a frame
+  // where the dialog was visible with "Link as transfer" still disabled — a
+  // click in that window (a fast user, or a slow CI runner) silently no-ops.
+  const [selectedId, setSelectedId] = useState<string | null>(
+    () => candidates[0]?.transaction.id ?? null
+  );
 
-  // Preselect the best match whenever the dialog (re)opens.
+  // Re-preselect the best match whenever the dialog re-opens.
   useEffect(() => {
     if (isOpen) {
       setSelectedId(candidates[0]?.transaction.id ?? null);

--- a/src/components/TransferSweepModal.tsx
+++ b/src/components/TransferSweepModal.tsx
@@ -128,8 +128,17 @@ export default function TransferSweepModal({ isOpen, onClose }: Props): React.JS
                   {visible.map(s => {
                     const key = keyOf(s);
                     return (
-                      <tr key={key} className="border-b border-gray-50 dark:border-gray-700/50">
-                        <td className="py-2">
+                      /* The WHOLE line drills into the both-sides popup — date,
+                         accounts, description or amount, it makes no difference.
+                         Only the checkbox cell stays out of it, so ticking a
+                         pair never accidentally opens the inspection. */
+                      <tr
+                        key={key}
+                        onClick={() => setInspecting(s)}
+                        className="border-b border-gray-50 dark:border-gray-700/50 cursor-pointer hover:bg-gray-50 dark:hover:bg-gray-700/40 transition-colors"
+                        title="See both sides of this pair"
+                      >
+                        <td className="py-2" onClick={(e) => e.stopPropagation()}>
                           <input
                             type="checkbox"
                             checked={effectiveSelected.has(key)}
@@ -152,24 +161,16 @@ export default function TransferSweepModal({ isOpen, onClose }: Props): React.JS
                             <span className="truncate max-w-[140px]">{accountName(s.incoming.accountId)}</span>
                           </span>
                           {s.ambiguous && (
-                            <button
-                              type="button"
-                              onClick={() => setInspecting(s)}
-                              className="ml-2 inline-flex items-center gap-1 text-xs text-amber-700 dark:text-amber-400 underline decoration-dotted underline-offset-2 hover:text-amber-900 dark:hover:text-amber-300"
+                            <span
+                              className="ml-2 inline-flex items-center gap-1 text-xs text-amber-700 dark:text-amber-400 underline decoration-dotted underline-offset-2"
                               title="Other rows matched this amount equally well — look at both sides before linking"
                             >
                               <AlertTriangleIcon size={12} />
                               check
-                            </button>
+                            </span>
                           )}
                         </td>
-                        {/* Any row can be inspected — the description opens
-                            the same both-sides popup the check badge does. */}
-                        <td
-                          className="py-2 text-sm text-gray-600 dark:text-gray-400 cursor-pointer hover:text-gray-900 dark:hover:text-gray-200"
-                          onClick={() => setInspecting(s)}
-                          title="See both sides of this pair"
-                        >
+                        <td className="py-2 text-sm text-gray-600 dark:text-gray-400">
                           <span className="block truncate max-w-[220px] underline decoration-dotted underline-offset-2 decoration-gray-300 dark:decoration-gray-600">
                             {s.outgoing.description}
                           </span>
@@ -232,8 +233,9 @@ export default function TransferSweepModal({ isOpen, onClose }: Props): React.JS
         >
           <ModalBody>
             <p className="text-sm text-gray-600 dark:text-gray-400 mb-4">
-              Flagged because other rows matched this amount equally well — make sure
-              these two really are the same movement of money.
+              {inspecting.ambiguous
+                ? 'Flagged because other rows matched this amount equally well — make sure these two really are the same movement of money.'
+                : 'Both sides of this suggested pair, in full — make sure these two really are the same movement of money.'}
               {inspecting.daysApart > 0 && (
                 <> The two sides are <strong>{Math.round(inspecting.daysApart)} day{Math.round(inspecting.daysApart) === 1 ? '' : 's'} apart</strong>.</>
               )}

--- a/src/components/VirtualizedList.tsx
+++ b/src/components/VirtualizedList.tsx
@@ -15,6 +15,13 @@ export interface VirtualizedListProps<T> {
   className?: string;
   estimatedItemSize?: number;
   threshold?: number;
+  /**
+   * Index to bring into view, CENTRED in the viewport — the deep-link "jump
+   * to this row" affordance. Applied whenever the value changes; retried
+   * briefly because AutoSizer's first pass renders at height 0 and a scroll
+   * issued then silently clamps to the top.
+   */
+  scrollToIndex?: number;
   onItemsRendered?: (props: {
     visibleStartIndex: number;
     visibleStopIndex: number;
@@ -61,9 +68,11 @@ export const VirtualizedList = memo(function VirtualizedList<T>({
   className = '',
   estimatedItemSize = 80,
   threshold = 100,
+  scrollToIndex,
   onItemsRendered
 }: VirtualizedListProps<T>) {
   const listRef = useRef<List | VariableSizeList | null>(null);
+  const plainContainerRef = useRef<HTMLDivElement | null>(null);
   const itemHeightMap = useRef<Map<number, number>>(new Map());
   
   // Determine if we need variable size list
@@ -115,11 +124,40 @@ export const VirtualizedList = memo(function VirtualizedList<T>({
   
   // Determine if we should enable virtual scrolling
   const shouldVirtualize = items.length > threshold;
-  
+
+  // Centre the requested row. react-window owns the maths on the virtual
+  // path; on the plain path it is offsetTop against the scroll container.
+  // Retried at 0/100/300ms: AutoSizer's first pass is zero-height, and a
+  // scroll issued against a zero-height list clamps to the top.
+  useEffect(() => {
+    if (scrollToIndex === undefined || scrollToIndex < 0 || scrollToIndex >= items.length) return;
+    const apply = (): void => {
+      if (listRef.current) {
+        listRef.current.scrollToItem(scrollToIndex, 'center');
+        return;
+      }
+      const container = plainContainerRef.current;
+      const row = container?.children[scrollToIndex] as HTMLElement | undefined;
+      if (container && row) {
+        // offsetTop answers to the nearest POSITIONED ancestor, which the
+        // container is not — rects are unambiguous.
+        const delta = row.getBoundingClientRect().top - container.getBoundingClientRect().top;
+        container.scrollTop = Math.max(
+          0,
+          container.scrollTop + delta - container.clientHeight / 2 + row.clientHeight / 2
+        );
+      }
+    };
+    apply();
+    const timers = [setTimeout(apply, 100), setTimeout(apply, 300)];
+    return () => timers.forEach(clearTimeout);
+  }, [scrollToIndex, items.length]);
+
+
   // Render non-virtualized list for small datasets
   if (!shouldVirtualize) {
     return (
-      <div className={`flex-1 min-h-0 overflow-y-auto ${className}`}>
+      <div ref={plainContainerRef} className={`flex-1 min-h-0 overflow-y-auto ${className}`}>
         {items.map((item, index) => (
           <div key={getItemKey(item, index)}>
             {renderItem(item, index, {})}

--- a/src/components/VirtualizedTable.tsx
+++ b/src/components/VirtualizedTable.tsx
@@ -37,6 +37,8 @@ export interface VirtualizedTableProps<T> {
   onColumnReorder?: (fromKey: string, toKey: string) => void;
   /** Opt-in: drag a header's right edge to resize. New width in px. */
   onColumnResize?: (key: string, width: number) => void;
+  /** Key of a row to bring into view, centred — the deep-link jump. */
+  scrollToKey?: string | null;
 }
 
 // Table header component
@@ -215,8 +217,17 @@ const VirtualizedTableComponent = memo(function VirtualizedTable<T>({
   hasMore = false,
   threshold = 100,
   onColumnReorder,
-  onColumnResize
+  onColumnResize,
+  scrollToKey
 }: VirtualizedTableProps<T>) {
+  // Resolve the deep-link key to its position in the CURRENT row order, so
+  // the list can centre it regardless of sort or filters.
+  const scrollToIndex = useMemo(() => {
+    if (!scrollToKey) return undefined;
+    const index = items.findIndex((item, i) => getItemKey(item, i) === scrollToKey);
+    return index >= 0 ? index : undefined;
+  }, [items, getItemKey, scrollToKey]);
+
   // Memoize row renderer
   const renderRow = useCallback((item: T, index: number, style: React.CSSProperties) => {
     const itemKey = getItemKey(item, index);
@@ -343,6 +354,7 @@ const VirtualizedTableComponent = memo(function VirtualizedTable<T>({
         hasMore={hasMore}
         isLoading={isLoading}
         threshold={threshold}
+        scrollToIndex={scrollToIndex}
       />
     </div>
   );

--- a/src/pages/AccountTransactions.tsx
+++ b/src/pages/AccountTransactions.tsx
@@ -165,6 +165,9 @@ export default function AccountTransactions() {
     navigate({ pathname: location.pathname, search: params.toString() }, { replace: true });
   }, [location.pathname, location.search, navigate]);
 
+  // location.search is a dependency for the already-mounted case: landing on
+  // the register that is ALREADY open only changes the search string, and
+  // without it this effect would never wake to consume the pending id.
   useEffect(() => {
     const txn = pendingTxnRef.current;
     if (!txn) return;
@@ -173,7 +176,8 @@ export default function AccountTransactions() {
     pendingTxnRef.current = null;
     setSelectedTransaction(target);
     setSelectedTransactionId(txn);
-  }, [transactions]);
+    setScrollTargetId(txn);
+  }, [transactions, location.search]);
 
   const toggleColumn = useCallback((key: string) => {
     setHiddenColumns(prev => (prev.includes(key) ? prev.filter(k => k !== key) : [...prev, key]));
@@ -185,6 +189,10 @@ export default function AccountTransactions() {
   const [showAccountSettings, setShowAccountSettings] = useState(false);
   const [deleteConfirmTransaction, setDeleteConfirmTransaction] = useState<Transaction | null>(null);
   const [selectedTransactionId, setSelectedTransactionId] = useState<string | null>(null);
+  // Deep-link only: the row the register should centre on. Manual row clicks
+  // never set it — a click means the row is already on screen, and yanking
+  // the viewport to centre it would fight the user's own scrolling.
+  const [scrollTargetId, setScrollTargetId] = useState<string | null>(null);
   
   // State for quick add form
   const [quickAddForm, setQuickAddForm] = useState({
@@ -466,6 +474,9 @@ export default function AccountTransactions() {
   const handleTransactionClick = useCallback((item: DisplayRow) => {
     if (isOpeningBalanceRow(item)) return;
     setSelectedTransaction(item);
+    // The user has taken over — a later sort or filter must not snap the
+    // viewport back to the deep-linked row.
+    setScrollTargetId(null);
 
     if (selectedTransactionId === item.id) {
       // Second click on already selected transaction - open edit modal
@@ -475,27 +486,6 @@ export default function AccountTransactions() {
       setSelectedTransactionId(item.id);
     }
   }, [selectedTransactionId]);
-
-  // The quick-edit panel always reflects the latest saved state of the
-  // selected transaction (context updates flow straight back in).
-  // Scroll the virtualised register to the selected row when it arrived via
-  // the deep link. react-window scrolls via its outer element's scrollTop;
-  // best-effort — a failed lookup simply leaves the dock as the pointer.
-  const scrolledToRef = useRef<string | null>(null);
-  useEffect(() => {
-    if (!selectedTransactionId || scrolledToRef.current === selectedTransactionId) return;
-    const index = displayRows.findIndex(row => row.id === selectedTransactionId);
-    if (index < 0) return;
-    scrolledToRef.current = selectedTransactionId;
-    try {
-      const scroller = tableWrapRef.current?.querySelector('div[style*="overflow"]') as HTMLElement | null;
-      if (scroller) {
-        scroller.scrollTop = Math.max(0, index * (compactView ? 36 : 44) - 120);
-      }
-    } catch {
-      // Selection alone still identifies the row via the dock.
-    }
-  }, [selectedTransactionId, displayRows, compactView]);
 
   const quickEditTarget = useMemo(
     () => transactionsWithBalance.find(t => t.id === selectedTransactionId) ?? null,
@@ -519,6 +509,7 @@ export default function AccountTransactions() {
       }
       setSelectedTransactionId(null);
       setSelectedTransaction(null);
+      setScrollTargetId(null);
     };
     document.addEventListener('mousedown', handlePointerDown);
     return () => document.removeEventListener('mousedown', handlePointerDown);
@@ -1244,6 +1235,7 @@ export default function AccountTransactions() {
           getItemKey={(row: DisplayRow) => row.id}
           onRowClick={(item) => handleTransactionClick(item)}
           rowHeight={compactView ? 36 : 44}
+          scrollToKey={scrollTargetId}
           selectedItems={selectedTransactionId ? new Set([selectedTransactionId]) : new Set()}
           onSort={(column, direction) => {
             // Every header sorts except the running Balance (which stays in its
@@ -1398,6 +1390,10 @@ export default function AccountTransactions() {
                   }
                   placeholder="Category..."
                   allowCreate={false}
+                  // The dock row bottom-aligns its fields; the helper line under
+                  // the combobox counted as field height and hoisted the picker
+                  // above its neighbours. The label already names the field.
+                  showHelperText={false}
                 />
               )}
             </div>

--- a/src/pages/Reconciliation.tsx
+++ b/src/pages/Reconciliation.tsx
@@ -154,11 +154,16 @@ export default function Reconciliation() {
     // Preserve demo/testMode so an in-page navigation doesn't drop the flag that
     // keeps a demo/test session alive (which would bounce us to the landing page).
     setSearchParams(prev => preserveRuntimeControlParams(prev, { account: accountId }));
+    // Same route, so the router restores nothing: without this, a scrolled
+    // account list hands its scroll position to the detail view and the page
+    // opens with the header off-screen.
+    window.scrollTo(0, 0);
   }, [setSearchParams]);
 
   const handleBack = useCallback(() => {
     setSelectedAccountId(null);
     setSearchParams(prev => preserveRuntimeControlParams(prev));
+    window.scrollTo(0, 0);
   }, [setSearchParams]);
 
   const applyCleared = useCallback(async (requestedIds: string[], cleared: boolean) => {
@@ -392,40 +397,48 @@ export default function Reconciliation() {
   // Step 2: Transaction Review
   return (
     <div className="flex flex-col h-full gap-4">
-      {/* Header */}
-      <div className="flex flex-wrap items-center justify-between gap-3">
-        <div className="flex items-center gap-3 min-w-0">
+      {/* The header and balance bar stay pinned below the app nav while the
+          transaction list scrolls: reconciliation is done by watching the
+          cleared balance approach the bank's figure, so the numbers — and the
+          way out, Finalize — must never scroll away. The negative margins
+          bleed the strip across the page gutters so passing rows (and their
+          shadows) never peek out at the sides. */}
+      <div className="sticky top-16 md:top-12 z-30 bg-[#f8f9fb] dark:bg-gray-900 -mx-4 px-4 md:-mx-6 md:px-6 lg:-mx-8 lg:px-8 pb-2 flex flex-col gap-4">
+        {/* Header */}
+        <div className="flex flex-wrap items-center justify-between gap-3">
+          <div className="flex items-center gap-3 min-w-0">
+            <button
+              onClick={handleBack}
+              className="flex items-center gap-2 text-gray-600 dark:text-gray-400 hover:text-gray-800 dark:hover:text-gray-200"
+            >
+              <ArrowLeftIcon size={20} />
+              Back
+            </button>
+            <h1 className="text-xl md:text-2xl font-bold text-gray-900 dark:text-white truncate">
+              {selectedAccount?.name ?? 'Account'}
+            </h1>
+          </div>
+
           <button
-            onClick={handleBack}
-            className="flex items-center gap-2 text-gray-600 dark:text-gray-400 hover:text-gray-800 dark:hover:text-gray-200"
+            type="button"
+            onClick={() => setShowFinalizationModal(true)}
+            className="flex items-center gap-2 px-4 py-2 bg-amber-100 text-amber-800 border border-amber-300 rounded-lg hover:bg-amber-200 transition-colors font-medium dark:bg-amber-900/30 dark:text-amber-300 dark:border-amber-600 dark:hover:bg-amber-900/50"
           >
-            <ArrowLeftIcon size={20} />
-            Back
+            <CheckCircleIcon size={18} />
+            Finalize Reconciliation
           </button>
-          <h1 className="text-xl md:text-2xl font-bold text-gray-900 dark:text-white truncate">
-            {selectedAccount?.name ?? 'Account'}
-          </h1>
         </div>
 
-        <button
-          type="button"
-          onClick={() => setShowFinalizationModal(true)}
-          className="flex items-center gap-2 px-4 py-2 bg-amber-100 text-amber-800 border border-amber-300 rounded-lg hover:bg-amber-200 transition-colors font-medium dark:bg-amber-900/30 dark:text-amber-300 dark:border-amber-600 dark:hover:bg-amber-900/50"
-        >
-          <CheckCircleIcon size={18} />
-          Finalize Reconciliation
-        </button>
+        {/* Balance Bar */}
+        <ReconciliationBalanceBar
+          bankBalance={bankBalance}
+          accountBalance={accountBalance}
+          clearedBalance={clearedBalance}
+          currency={selectedAccount?.currency}
+          clearedSummary={clearedSummary}
+          onBankBalanceChange={handleBankBalanceChange}
+        />
       </div>
-
-      {/* Balance Bar */}
-      <ReconciliationBalanceBar
-        bankBalance={bankBalance}
-        accountBalance={accountBalance}
-        clearedBalance={clearedBalance}
-        currency={selectedAccount?.currency}
-        clearedSummary={clearedSummary}
-        onBankBalanceChange={handleBankBalanceChange}
-      />
 
       {/* Transaction List */}
       <ReconciliationTransactionList


### PR DESCRIPTION
## What

- **Reconciliation**: the account header (Back, name, Finalize) and the balance bar pin just below the app nav while the transaction list scrolls — the figures being reconciled against never scroll away. Entering or leaving an account resets to the top instead of inheriting the account list's scroll offset (the page used to open with the header already off-screen).
- **Register deep link**: jump-to-transaction now centres the target row via the virtualised list's own `scrollToItem(index, 'center')` (new `scrollToKey` prop threaded through VirtualizedTable → VirtualizedList, with retries across AutoSizer's zero-height first pass). The old DOM query matched the wrong element or fired too early and clamped to the top — i.e. the oldest row. Also fixed: landing on a register that was already mounted consumed the link without selecting.
- **Quick edit dock**: native `<input type="date">` replaced with the app's dd/mm/yyyy DatePicker — natives render in the browser's locale and showed US dates against a UK register.
- **Quick add dock**: category picker aligns with its neighbours (its helper line counted as field height in the bottom-aligned row).
- **Match transfers**: the whole suggestion row opens the both-sides "Check this pair" popup (checkbox cell excepted); popup copy is now conditional so unflagged rows aren't described as flagged.
- **Payee drill**: category pickers widened (`sm:w-96 lg:w-[30rem]`) to fill their column.

## Verification

- Strict typecheck, lint, smoke, realtime, Supabase smoke, coverage — all green via hooks.
- Browser-verified in demo: sticky strip pins at the nav edge with rows passing beneath; detail view opens at scroll 0 from a scrolled list; deep link lands the row selected and pixel-centred (row centre == viewport centre); dock date reads 24/05/2026 for a row dated 24/05/2026; quick-add Date/Description/Category bottoms align.
- Sweep-modal row click and drill picker width verified structurally (demo has no unfiled rows to exercise them live).

🤖 Generated with [Claude Code](https://claude.com/claude-code)