### PR TITLE
feat(ui+splits): mixed-direction splits, sync keeps account names, register stops clipping

### DIFF
--- a/api/banking/sync-accounts.ts
+++ b/api/banking/sync-accounts.ts
@@ -195,6 +195,19 @@ const persistAccountsAndLinks = async (
     if (account.sortCode) identifierFields.sort_code = account.sortCode;
 
     if (accountId) {
+      // The account's name belongs to the USER: sync fills a blank name but
+      // never overwrites one that has been typed — feeds used to rename
+      // accounts to the bank's own label on every sync.
+      const currentName = await supabase
+        .from('accounts')
+        .select('name')
+        .eq('id', accountId)
+        .eq('user_id', userId)
+        .maybeSingle();
+      // A failed lookup counts as "named": renaming is only safe when the
+      // account is POSITIVELY known to be blank.
+      const hasUserName = currentName.error !== null || Boolean(currentName.data?.name?.trim());
+
       // The bank's reported figure goes to bank_balance (the reconciliation
       // reference) ONLY. `balance` is ledger-authoritative — moved exclusively
       // by the atomic transaction RPCs — so overwriting it here would silently
@@ -203,7 +216,7 @@ const persistAccountsAndLinks = async (
       const updateResult = await supabase
         .from('accounts')
         .update({
-          name: account.name,
+          ...(hasUserName ? {} : { name: account.name }),
           type: account.type,
           bank_balance: account.balance,
           currency: account.currency,

--- a/src/components/CategorySelector.tsx
+++ b/src/components/CategorySelector.tsx
@@ -92,6 +92,12 @@ interface CategorySelectorProps {
    * delete-reassignment dialog).
    */
   allowClear?: boolean;
+  /**
+   * Trigger height. 'compact' matches the register quick-add dock's 32px
+   * fields — the default 42px trigger stood taller than every neighbour in
+   * that bottom-aligned row and floated its label above the others.
+   */
+  size?: 'default' | 'compact';
 }
 
 export default function CategorySelector({
@@ -106,6 +112,7 @@ export default function CategorySelector({
   usePortal = false,
   excludeIds,
   allowClear = false,
+  size = 'default',
 }: CategorySelectorProps): React.JSX.Element {
   const { categories, addCategory, getSubCategories, getDetailCategories } = useApp();
   const [showDropdown, setShowDropdown] = useState(false);
@@ -460,7 +467,11 @@ export default function CategorySelector({
           aria-controls={showDropdown ? listboxId : undefined}
           aria-label="Category"
           onKeyDown={handleTriggerKeyDown}
-          className="w-full px-3 py-2 h-[42px] bg-white dark:bg-gray-800 border border-gray-300 dark:border-gray-600 rounded-xl shadow-sm cursor-text flex items-center"
+          className={`w-full bg-white dark:bg-gray-800 border border-gray-300 dark:border-gray-600 shadow-sm cursor-text flex items-center ${
+            size === 'compact'
+              ? 'px-2.5 py-1.5 h-auto sm:h-[32px] text-xs rounded-lg'
+              : 'px-3 py-2 h-[42px] rounded-xl'
+          }`}
           onClick={handleInputClick}
         >
           <div className="flex w-full min-w-0 items-center justify-between gap-1">
@@ -610,7 +621,9 @@ export default function CategorySelector({
                 {groupedOptions.length > 0 ? (
                   groupedOptions.map((group) => (
                     <div key={group.id}>
-                      <div className="sticky top-0 z-10 px-3 py-1.5 bg-gray-50 dark:bg-gray-800 border-b border-gray-100 dark:border-gray-700 text-[11px] font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-400">
+                      {/* Same darker group-header treatment as the Accounts
+                          sections — one scheme for every grouping band. */}
+                      <div className="sticky top-0 z-10 px-3 py-1.5 bg-gray-100 dark:bg-gray-700 border-b border-gray-300 dark:border-gray-500 text-[11px] font-semibold uppercase tracking-wide text-gray-600 dark:text-gray-300">
                         {group.name}
                       </div>
                       {group.items.map((category) => (

--- a/src/components/CustomReportBuilder.tsx
+++ b/src/components/CustomReportBuilder.tsx
@@ -468,7 +468,7 @@ export default function CustomReportBuilder({
       </div>
 
       {/* Global Filters */}
-      <div className="p-4 bg-gray-50 dark:bg-gray-800/50 border-b border-gray-200 dark:border-gray-700">
+      <div className="p-4 bg-gray-100 dark:bg-gray-700/70 border-b border-gray-300 dark:border-gray-500">
         <h3 className="text-sm font-medium text-gray-700 dark:text-gray-300 mb-3">
           Report Filters
         </h3>

--- a/src/components/EditTransactionModal.tsx
+++ b/src/components/EditTransactionModal.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef, useMemo } from 'react';
+import { useState, useEffect, useRef, useMemo, useCallback } from 'react';
 import { createPortal } from 'react-dom';
 import { useApp } from '../contexts/AppContextSupabase';
 import { useTransactionNotifications } from '../hooks/useTransactionNotifications';
@@ -195,7 +195,10 @@ export default function EditTransactionModal({ isOpen, onClose, transaction, def
           // is enforced before any write so a lopsided split never half-saves.
           const splitting = isSplitMode && !!transaction && resolvedType !== 'transfer';
           if (splitting) {
-            const splitError = validateSplitDrafts(data.amount, splitLines);
+            const splitError = validateSplitDrafts(data.amount, splitLines, {
+              parentType: resolvedType as 'income' | 'expense',
+              directionFor: splitDirectionFor,
+            });
             if (splitError) {
               throw new Error(splitError);
             }
@@ -291,7 +294,7 @@ export default function EditTransactionModal({ isOpen, onClose, transaction, def
               });
               await setTransactionSplits(
                 transaction.id,
-                signSplitAmounts(splitLines, resolvedType as 'income' | 'expense'),
+                signSplitAmounts(splitLines, resolvedType as 'income' | 'expense', splitDirectionFor),
                 signedAmount
               );
             } else if (transaction.isSplit) {
@@ -489,6 +492,17 @@ export default function EditTransactionModal({ isOpen, onClose, transaction, def
     setShowDeleteConfirm(false);
   }, [transaction, accounts, categories, setFormData, defaultAccountId]);
 
+  // A split line's DIRECTION comes from its category's tree: an income
+  // category inside an expense split counts AGAINST the total (a £30,000
+  // payment can be £40,000 of expense and £10,000 of income). Neutral
+  // categories (Revaluation etc., type 'both') follow the parent.
+  // Declared before the splits-loading effect below, which depends on it.
+  const splitDirectionFor = useCallback((categoryId: string): 'income' | 'expense' | null => {
+    const cat = categories.find(c => c.id === categoryId);
+    if (!cat || cat.type === 'both') return null;
+    return cat.type;
+  }, [categories]);
+
   // Load an already-split transaction's lines into the editor (stored signed
   // amounts convert back to the entered domain). Non-split rows reset the
   // split state so batch mode (Save & Next) never leaks lines between rows.
@@ -500,10 +514,12 @@ export default function EditTransactionModal({ isOpen, onClose, transaction, def
       getTransactionSplits(transaction.id)
         .then(splits => {
           if (cancelled) return;
-          const direction = transaction.type === 'income' ? 'income' : 'expense';
+          const parentDirection = transaction.type === 'income' ? 'income' : 'expense';
+          // Each line converts back using ITS OWN direction (its category's
+          // tree), so a mixed split round-trips to positive magnitudes.
           setSplitLines(splits.map(s => ({
             category: s.category,
-            amount: displaySplitAmount(s.amount, direction),
+            amount: displaySplitAmount(s.amount, splitDirectionFor(s.category) ?? parentDirection),
             ...(s.memo ? { memo: s.memo } : {}),
           })));
         })
@@ -525,7 +541,7 @@ export default function EditTransactionModal({ isOpen, onClose, transaction, def
     return () => {
       cancelled = true;
     };
-  }, [transaction, getTransactionSplits, logger]);
+  }, [transaction, getTransactionSplits, logger, splitDirectionFor]);
 
   const handleSplitToggle = (checked: boolean): void => {
     setIsSplitMode(checked);
@@ -554,8 +570,16 @@ export default function EditTransactionModal({ isOpen, onClose, transaction, def
   // Save is blocked while the split doesn't balance; the remainder line
   // doubles as the explanation.
   const splitActive = isSplitMode && !!transaction && formData.type !== 'transfer';
-  const splitValidationMessage = splitActive ? validateSplitDrafts(formData.amount, splitLines) : null;
-  const splitRemaining = splitActive ? splitRemainder(formData.amount, splitLines) : null;
+  const splitDirectionOpts = {
+    parentType: (formData.type === 'income' ? 'income' : 'expense') as 'income' | 'expense',
+    directionFor: splitDirectionFor,
+  };
+  const splitValidationMessage = splitActive
+    ? validateSplitDrafts(formData.amount, splitLines, splitDirectionOpts)
+    : null;
+  const splitRemaining = splitActive
+    ? splitRemainder(formData.amount, splitLines, splitDirectionOpts)
+    : null;
 
   // Complete the transfer flow (link or create) and close the editor. A
   // failure keeps the dialog open so the user can retry or cancel.
@@ -682,7 +706,9 @@ export default function EditTransactionModal({ isOpen, onClose, transaction, def
                   );
                 })}
               </div>
-              {(formData.type === 'income' || formData.type === 'expense') && (
+              {/* Hidden in split mode: split lines always offer BOTH trees,
+                  so there is no whole-transaction tree to flip. */}
+              {(formData.type === 'income' || formData.type === 'expense') && !splitActive && (
                 <label className="mt-2 flex items-start gap-2 text-xs text-gray-500 dark:text-gray-400 cursor-pointer">
                   <input
                     type="checkbox"
@@ -813,11 +839,13 @@ export default function EditTransactionModal({ isOpen, onClose, transaction, def
                             <CategorySelector
                               selectedCategory={line.category}
                               onCategoryChange={(id) => updateSplitLine(index, { category: id })}
-                              transactionType={
-                                crossTypeCategories
-                                  ? (formData.type === 'income' ? 'expense' : 'income')
-                                  : formData.type
-                              }
+                              transactionType={formData.type}
+                              // BOTH trees, per line: a split may mix expense
+                              // and income lines (an income line counts
+                              // against an expense total), so every line
+                              // offers every category and the line's
+                              // direction follows the one chosen.
+                              includeAllTypes
                               placeholder="Search or select category…"
                               allowCreate={false}
                               showHelperText={false}

--- a/src/components/EnhancedPortfolioView.tsx
+++ b/src/components/EnhancedPortfolioView.tsx
@@ -237,7 +237,7 @@ export default function EnhancedPortfolioView({
         <>
         
         {/* Sort Options */}
-        <div className="px-6 py-3 border-b border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-700/50">
+        <div className="px-6 py-3 border-b border-gray-300 dark:border-gray-500 bg-gray-100 dark:bg-gray-700/70">
           <div className="flex items-center gap-4">
             <span className="text-sm text-gray-600 dark:text-gray-400">Sort by:</span>
             <button

--- a/src/components/PortfolioView.tsx
+++ b/src/components/PortfolioView.tsx
@@ -127,7 +127,7 @@ export default function PortfolioView({
         <>
         
         {/* Sort Options */}
-        <div className="px-6 py-3 border-b border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-700/50">
+        <div className="px-6 py-3 border-b border-gray-300 dark:border-gray-500 bg-gray-100 dark:bg-gray-700/70">
           <div className="flex items-center gap-4">
             <span className="text-sm text-gray-600 dark:text-gray-400">Sort by:</span>
             <button

--- a/src/components/QuickEditTransactionPanel.tsx
+++ b/src/components/QuickEditTransactionPanel.tsx
@@ -199,8 +199,9 @@ export default function QuickEditTransactionPanel({
           />
         </div>
 
-        {/* Description */}
-        <div className="flex-1 min-w-0">
+        {/* Description — flex-1 like Category, so the two split the row's
+            slack EQUALLY instead of Description hogging it. */}
+        <div className="w-full lg:flex-1 lg:min-w-0">
           <label htmlFor="quick-edit-description" className="block text-xs text-gray-500 dark:text-gray-400 mb-1">
             Description
           </label>
@@ -216,8 +217,9 @@ export default function QuickEditTransactionPanel({
         {/* Category (not editable for transfers — they carry system categories).
             Searchable combobox: click to type-filter, or use the chevron to
             browse the full list. Both directions are offered (Money-style
-            cross-type filing — a refund can file under the expense it refunds). */}
-        <div className="w-full lg:w-72">
+            cross-type filing — a refund can file under the expense it refunds).
+            flex-1 to match Description — the pair share the slack equally. */}
+        <div className="w-full lg:flex-1 lg:min-w-0">
           <span className="block text-xs text-gray-500 dark:text-gray-400 mb-1">
             Category
           </span>

--- a/src/components/SmartCategorization.tsx
+++ b/src/components/SmartCategorization.tsx
@@ -435,7 +435,7 @@ export function BulkCategorization({
         </div>
 
         {/* Actions bar */}
-        <div className="px-6 py-3 bg-gray-50 dark:bg-gray-900/50 border-b border-gray-200 dark:border-gray-700">
+        <div className="px-6 py-3 bg-gray-100 dark:bg-gray-700/70 border-b border-gray-300 dark:border-gray-500">
           <div className="flex items-center justify-between">
             <div className="flex items-center gap-2">
               <span className="text-sm text-gray-600 dark:text-gray-400">

--- a/src/components/TransferSweepModal.tsx
+++ b/src/components/TransferSweepModal.tsx
@@ -1,4 +1,5 @@
 import React, { useMemo, useState } from 'react';
+import { useNavigate, useLocation } from 'react-router-dom';
 import { Modal, ModalBody, ModalFooter } from './common/Modal';
 import { useApp } from '../contexts/AppContextSupabase';
 import { useToast } from '../contexts/ToastContext';
@@ -24,9 +25,11 @@ interface Props {
 const CAP = 300;
 
 export default function TransferSweepModal({ isOpen, onClose }: Props): React.JSX.Element {
-  const { transactions, categories, linkTransferPair } = useApp();
+  const { transactions, categories, accounts, linkTransferPair } = useApp();
   const { formatCurrency } = useCurrencyDecimal();
   const { showSuccess, showError } = useToast();
+  const navigate = useNavigate();
+  const location = useLocation();
   const [selected, setSelected] = useState<Set<string> | null>(null);
   const [inspecting, setInspecting] = useState<TransferPairSuggestion | null>(null);
   const [applying, setApplying] = useState(false);
@@ -244,8 +247,36 @@ export default function TransferSweepModal({ isOpen, onClose }: Props): React.JS
               {([
                 { label: 'Money out', t: inspecting.outgoing, colour: 'text-red-600 dark:text-red-400' },
                 { label: 'Money in', t: inspecting.incoming, colour: 'text-green-600 dark:text-green-400' },
-              ] as const).map(({ label, t, colour }) => (
-                <div key={t.id} className="rounded-xl border border-gray-200 dark:border-gray-700 p-4">
+              ] as const).map(({ label, t, colour }) => {
+                // A leg in a CLOSED account has no register to open — the
+                // card stays informational instead of dead-ending.
+                const accountIsOpen = accounts.some(a => a.id === t.accountId);
+                return (
+                /* Either leg jumps into its own account register with the
+                   transaction selected and centred — the same ?txn deep link
+                   the categorisation drills use. */
+                <button
+                  key={t.id}
+                  type="button"
+                  disabled={!accountIsOpen}
+                  onClick={() => {
+                    if (!accountIsOpen) return;
+                    const params = new URLSearchParams();
+                    params.set('txn', t.id);
+                    if (new URLSearchParams(location.search).get('demo') === 'true') {
+                      params.set('demo', 'true');
+                    }
+                    setInspecting(null);
+                    onClose();
+                    navigate(`/accounts/${t.accountId}?${params.toString()}`);
+                  }}
+                  title={accountIsOpen
+                    ? 'Open this transaction in its account'
+                    : 'This account is closed — its register cannot be opened'}
+                  className={`text-left rounded-xl border border-gray-200 dark:border-gray-700 p-4 transition-all ${
+                    accountIsOpen ? 'hover:border-primary hover:shadow-md cursor-pointer' : 'cursor-default'
+                  }`}
+                >
                   <p className="text-[10px] uppercase tracking-wide text-gray-400 dark:text-gray-500 mb-1">{label}</p>
                   <p className={`text-lg font-bold tabular-nums ${colour}`}>
                     {formatCurrency(Math.abs(t.amount))}
@@ -257,8 +288,9 @@ export default function TransferSweepModal({ isOpen, onClose }: Props): React.JS
                   <p className="mt-1 text-xs text-gray-500 dark:text-gray-400">
                     {new Date(t.date).toLocaleDateString('en-GB', { day: '2-digit', month: 'long', year: 'numeric' })}
                   </p>
-                </div>
-              ))}
+                </button>
+                );
+              })}
             </div>
           </ModalBody>
           <ModalFooter>

--- a/src/components/VirtualizedTable.tsx
+++ b/src/components/VirtualizedTable.tsx
@@ -122,7 +122,7 @@ const TableHeader = memo(function TableHeader<T>({
   }, [onSort, sortColumn, sortDirection]);
 
   return (
-    <div className={`flex items-center border-b border-gray-200 dark:border-gray-700 ${headerClassName || 'bg-gray-50 dark:bg-gray-800'}`}>
+    <div className={`flex items-center border-b border-gray-300 dark:border-gray-500 ${headerClassName || 'bg-gray-100 dark:bg-gray-700'}`}>
       {showCheckbox && (
         <div className="px-4 py-3 w-12">
           <input
@@ -258,8 +258,10 @@ const VirtualizedTableComponent = memo(function VirtualizedTable<T>({
 
     const baseRowClass = 'flex items-center border-b border-gray-200 dark:border-gray-700 transition-colors duration-150';
     const clickableClass = onRowClick ? 'cursor-pointer select-none' : '';
-    // Only apply hover effects if not selected
-    const hoverClass = onRowClick && !isSelected ? 'hover:shadow-[0_-6px_10px_-2px_rgba(0,0,0,0.15),0_6px_10px_-2px_rgba(0,0,0,0.15)] hover:z-10 hover:transform hover:scale-[1.01] hover:bg-gray-50 dark:hover:bg-gray-800' : '';
+    // Only apply hover effects if not selected. No scale: these rows sit in
+    // an overflow-clipped table, and a 1.01 scale pushed the rightmost
+    // column's digits past the edge — the shadow and z-lift suffice.
+    const hoverClass = onRowClick && !isSelected ? 'hover:shadow-[0_-6px_10px_-2px_rgba(0,0,0,0.15),0_6px_10px_-2px_rgba(0,0,0,0.15)] hover:z-10 hover:bg-gray-50 dark:hover:bg-gray-800' : '';
     // Don't apply stripe classes to selected rows
     const stripeClass = !isSelected && index % 2 === 1 ? 'bg-gray-100 dark:bg-gray-800/50' : !isSelected ? 'bg-white dark:bg-gray-900' : '';
 

--- a/src/index.css
+++ b/src/index.css
@@ -366,14 +366,19 @@ button.rounded-full:focus-visible,
   -webkit-tap-highlight-color: transparent !important;
 }
 
-/* Selected transaction row with Apple-style glass effect */
+/* Selected transaction row with Apple-style glass effect.
+   NO scale and NO horizontal margin: the rows are absolutely-positioned
+   virtual rows clipped by the table's overflow-hidden edge, so a 1.01 scale
+   or an 8px side margin pushed the Balance column's last digits out of view
+   (worst on 5+ digit balances). The shadow, gradient and z-index carry the
+   "lifted" look on their own. */
 .selected-transaction-row {
-  @apply relative z-30 transform scale-[1.01];
+  @apply relative z-30;
   background: linear-gradient(135deg, rgba(255,255,255,0.9) 0%, rgba(239,246,255,0.85) 100%) !important;
   backdrop-filter: blur(12px) saturate(1.5);
   -webkit-backdrop-filter: blur(12px) saturate(1.5);
   border-radius: 12px !important;
-  margin: 4px 8px !important;
+  margin: 4px 0 !important;
   box-shadow: 
     0 4px 6px -1px rgba(0, 0, 0, 0.1),
     0 2px 4px -1px rgba(0, 0, 0, 0.06),

--- a/src/pages/AccountTransactions.tsx
+++ b/src/pages/AccountTransactions.tsx
@@ -763,7 +763,9 @@ export default function AccountTransactions() {
     {
       key: 'payment',
       header: 'Payment',
-      width: '120px',
+      // 130px fits a 7-figure amount with pennies; Description is the flex
+      // column, so the extra width comes out of it automatically.
+      width: '130px',
       // Money out — the magnitude (no sign), in red, like MS Money's Payment column.
       accessor: (transaction) => (
         transaction.amount < 0 ? (
@@ -779,7 +781,7 @@ export default function AccountTransactions() {
     {
       key: 'deposit',
       header: 'Deposit',
-      width: '120px',
+      width: '130px',
       // Money in — in green, like MS Money's Deposit column.
       accessor: (transaction) => (
         transaction.amount > 0 ? (
@@ -831,7 +833,9 @@ export default function AccountTransactions() {
     {
       key: 'balance',
       header: 'Balance',
-      width: '120px',
+      // The register's rightmost column: room for a signed 7-figure running
+      // balance ("-£1,234,567.89") without truncating at the table edge.
+      width: '140px',
       accessor: (transaction) => (
         <span className={`text-sm font-medium ${
           transaction.balance < 0
@@ -1307,7 +1311,7 @@ export default function AccountTransactions() {
               <DatePicker
                 value={quickAddForm.date}
                 onChange={(val) => { setQuickAddError(''); setQuickAddForm({ ...quickAddForm, date: val }); }}
-                className="bg-white dark:bg-gray-700 border border-gray-300 dark:border-gray-600 rounded-lg focus:outline-none focus:ring-1 focus:ring-primary dark:text-white text-xs"
+                className="h-auto sm:h-[32px] bg-white dark:bg-gray-700 border border-gray-300 dark:border-gray-600 rounded-lg focus:outline-none focus:ring-1 focus:ring-primary dark:text-white text-xs"
                 aria-label="Transaction date"
               />
             </div>
@@ -1394,6 +1398,9 @@ export default function AccountTransactions() {
                   // the combobox counted as field height and hoisted the picker
                   // above its neighbours. The label already names the field.
                   showHelperText={false}
+                  // Match the row's 32px fields — the default 42px trigger
+                  // still stood proud of its neighbours.
+                  size="compact"
                 />
               )}
             </div>

--- a/src/pages/Accounts.tsx
+++ b/src/pages/Accounts.tsx
@@ -590,7 +590,7 @@ export default function Accounts({ onAccountClick }: { onAccountClick?: (account
                       return (
                         <div
                           key={child.id}
-                          className="mt-3 ml-6 sm:ml-9 flex items-center gap-3 rounded-xl border border-dashed border-gray-200 dark:border-gray-600 bg-gray-50 dark:bg-gray-700/40 px-3 py-2.5 cursor-pointer hover:border-gray-300 dark:hover:border-gray-500 transition-colors"
+                          className="mt-3 ml-6 sm:ml-9 flex items-center gap-3 rounded-xl border border-dashed border-gray-300 dark:border-gray-500 bg-gray-100 dark:bg-gray-700/60 px-3 py-2.5 cursor-pointer hover:border-gray-400 dark:hover:border-gray-400 transition-colors"
                           onClick={(e) => {
                             e.stopPropagation();
                             if ((e.target as HTMLElement).closest('button, input')) return;
@@ -685,7 +685,7 @@ export default function Accounts({ onAccountClick }: { onAccountClick?: (account
           onClick={() => toggleGroupCollapsed(collapseKeyFor(label))}
           aria-expanded={isExpanded}
           aria-controls={regionId}
-          className="w-full bg-gray-50 dark:bg-gray-800/50 border-b border-gray-100 dark:border-gray-700 px-4 sm:px-6 py-3 sm:py-4 text-left hover:bg-gray-100/70 dark:hover:bg-gray-800 transition-colors"
+          className="w-full bg-gray-100 dark:bg-gray-700/70 border-b border-gray-300 dark:border-gray-500 px-4 sm:px-6 py-3 sm:py-4 text-left hover:bg-gray-200/70 dark:hover:bg-gray-700 transition-colors"
         >
           <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-2">
             <div className="flex items-center gap-2 md:gap-3">

--- a/src/utils/transactionSplits.test.ts
+++ b/src/utils/transactionSplits.test.ts
@@ -183,3 +183,95 @@ describe('displaySplitAmount', () => {
     expect(displaySplitAmount(90, 'income')).toBe('90');
   });
 });
+
+describe('mixed-direction splits (category decides each line)', () => {
+  // The resolver a real editor builds from the category tree: 'exp:*' ids are
+  // expense categories, 'inc:*' income, 'both:*' neutral (Revaluation etc.).
+  const directionFor = (id: string): 'income' | 'expense' | null =>
+    id.startsWith('exp:') ? 'expense' : id.startsWith('inc:') ? 'income' : null;
+
+  it("balances Steve's case: a 30,000 expense split as 40,000 expense + 10,000 income", () => {
+    const lines = [line('exp:fees', '40000'), line('inc:interest', '10000')];
+    const opts = { parentType: 'expense' as const, directionFor };
+    expect(sumSplitDrafts(lines, opts).toString()).toBe('30000');
+    expect(splitRemainder('30000', lines, opts).isZero()).toBe(true);
+    expect(validateSplitDrafts('30000', lines, opts)).toBeNull();
+  });
+
+  it('signs each line by ITS category, not the parent', () => {
+    expect(
+      signSplitAmounts([line('exp:fees', '40000'), line('inc:interest', '10000')], 'expense', directionFor)
+    ).toEqual([
+      { category: 'exp:fees', amount: -40000 },
+      { category: 'inc:interest', amount: 10000 },
+    ]);
+    // Signed lines sum to the signed parent (-30000): the DB invariant holds.
+    // The mirror case: an income parent with an expense line taken out of it.
+    expect(
+      signSplitAmounts([line('inc:salary', '5000'), line('exp:fees', '500')], 'income', directionFor)
+    ).toEqual([
+      { category: 'inc:salary', amount: 5000 },
+      { category: 'exp:fees', amount: -500 },
+    ]);
+  });
+
+  it('an income parent nets expense lines the same way, mirrored', () => {
+    // 4,500 received = 5,000 salary less 500 of fees
+    const lines = [line('inc:salary', '5000'), line('exp:fees', '500')];
+    const opts = { parentType: 'income' as const, directionFor };
+    expect(sumSplitDrafts(lines, opts).toString()).toBe('4500');
+    expect(validateSplitDrafts('4500', lines, opts)).toBeNull();
+  });
+
+  it('direction-neutral categories follow the parent', () => {
+    const lines = [line('exp:fees', '80'), line('both:revaluation', '20')];
+    const opts = { parentType: 'expense' as const, directionFor };
+    expect(sumSplitDrafts(lines, opts).toString()).toBe('100');
+    expect(signSplitAmounts(lines, 'expense', directionFor).map(l => l.amount)).toEqual([-80, -20]);
+  });
+
+  it('a minus typed on a counter-direction line still works (double negative adds)', () => {
+    // Typing -100 on an income line inside an expense split contributes +100
+    const lines = [line('exp:fees', '200'), line('inc:interest', '-100')];
+    const opts = { parentType: 'expense' as const, directionFor };
+    expect(sumSplitDrafts(lines, opts).toString()).toBe('300');
+    // And it signs to stored -100 (income line entered negative)
+    expect(signSplitAmounts(lines, 'expense', directionFor).map(l => l.amount)).toEqual([-200, -100]);
+  });
+
+  it('remainder reads in the entered domain while mixing', () => {
+    const opts = { parentType: 'expense' as const, directionFor };
+    // 30,000 to allocate; 40,000 expense entered so far → income lines still
+    // owe 10,000 → remainder -10,000 (over-allocated until they arrive)
+    expect(splitRemainder('30000', [line('exp:fees', '40000')], opts).toString()).toBe('-10000');
+    expect(
+      splitRemainder('30000', [line('exp:fees', '40000'), line('inc:interest', '6000')], opts).toString()
+    ).toBe('-4000');
+  });
+
+  it('blocks an unbalanced mixed split', () => {
+    const opts = { parentType: 'expense' as const, directionFor };
+    expect(
+      validateSplitDrafts('30000', [line('exp:fees', '40000'), line('inc:interest', '9999')], opts)
+    ).toMatch(/must match/);
+  });
+
+  it('display round-trips a mixed split line by line', () => {
+    const signed = signSplitAmounts(
+      [line('exp:fees', '40000'), line('inc:interest', '10000')],
+      'expense',
+      directionFor
+    );
+    // Stored -40000 on the expense line → shown 40000; stored +10000 on the
+    // income line → shown 10000. Both positive magnitudes, as typed.
+    expect(displaySplitAmount(signed[0].amount, 'expense')).toBe('40000');
+    expect(displaySplitAmount(signed[1].amount, 'income')).toBe('10000');
+  });
+
+  it('exact decimal maths survives mixing (no float drift)', () => {
+    const lines = [line('exp:a', '0.1'), line('exp:b', '0.3'), line('inc:c', '0.2')];
+    const opts = { parentType: 'expense' as const, directionFor };
+    expect(sumSplitDrafts(lines, opts).toString()).toBe('0.2');
+    expect(validateSplitDrafts('0.2', lines, opts)).toBeNull();
+  });
+});

--- a/src/utils/transactionSplits.ts
+++ b/src/utils/transactionSplits.ts
@@ -19,27 +19,73 @@ export interface SplitLineDraft {
   memo?: string;
 }
 
-/** Sum of the entered split amounts; blank/invalid rows count as 0. */
-export function sumSplitDrafts(lines: SplitLineDraft[]): DecimalInstance {
-  return lines.reduce(
-    (sum, line) => sum.plus(parseMoneyInput(line.amount) ?? 0),
-    toDecimal(0)
-  );
+export type SplitDirection = 'income' | 'expense';
+
+/**
+ * Resolves a category id to the direction its TREE implies — 'income',
+ * 'expense', or null for the direction-neutral categories (Revaluation,
+ * Unassigned, blanks), which follow the parent transaction's direction.
+ *
+ * This is what lets one split MIX directions: a £30,000 payment can carry a
+ * £40,000 expense line and a £10,000 income line, because the income line
+ * counts AGAINST the expense total exactly as its category says it should.
+ */
+export type SplitDirectionFor = (categoryId: string) => SplitDirection | null;
+
+interface SplitDirectionOpts {
+  parentType: SplitDirection;
+  directionFor: SplitDirectionFor;
+}
+
+/** The pre-mixing behaviour: every line follows the parent's direction. */
+const FOLLOW_PARENT: SplitDirectionOpts = {
+  parentType: 'expense',
+  directionFor: () => null,
+};
+
+function lineDirection(line: SplitLineDraft, opts: SplitDirectionOpts): SplitDirection {
+  return opts.directionFor(line.category) ?? opts.parentType;
+}
+
+/**
+ * How much of the parent total the lines account for, in the ENTERED domain.
+ * A line whose category runs WITH the parent adds; one whose category runs
+ * COUNTER to it subtracts (£40,000 expense − £10,000 income = £30,000 of an
+ * expense parent). Blank/invalid rows count as 0. Without opts, every line
+ * follows the parent — the original single-direction behaviour.
+ */
+export function sumSplitDrafts(
+  lines: SplitLineDraft[],
+  opts: SplitDirectionOpts = FOLLOW_PARENT
+): DecimalInstance {
+  return lines.reduce((sum, line) => {
+    const entered = toDecimal(parseMoneyInput(line.amount) ?? 0);
+    const contribution = lineDirection(line, opts) === opts.parentType ? entered : entered.negated();
+    return sum.plus(contribution);
+  }, toDecimal(0));
 }
 
 /**
  * What is still left to allocate: entered total amount minus the split sum.
  * Zero (exactly) means the split is balanced and may be saved.
  */
-export function splitRemainder(totalAmount: string, lines: SplitLineDraft[]): DecimalInstance {
-  return toDecimal(parseMoneyInput(totalAmount) ?? 0).minus(sumSplitDrafts(lines));
+export function splitRemainder(
+  totalAmount: string,
+  lines: SplitLineDraft[],
+  opts: SplitDirectionOpts = FOLLOW_PARENT
+): DecimalInstance {
+  return toDecimal(parseMoneyInput(totalAmount) ?? 0).minus(sumSplitDrafts(lines, opts));
 }
 
 /**
  * Validate the draft against the save rules. Returns null when saveable,
  * otherwise the user-facing reason the save is blocked.
  */
-export function validateSplitDrafts(totalAmount: string, lines: SplitLineDraft[]): string | null {
+export function validateSplitDrafts(
+  totalAmount: string,
+  lines: SplitLineDraft[],
+  opts: SplitDirectionOpts = FOLLOW_PARENT
+): string | null {
   if (lines.length < 2) {
     return 'A split needs at least two category lines.';
   }
@@ -52,26 +98,30 @@ export function validateSplitDrafts(totalAmount: string, lines: SplitLineDraft[]
       return 'Every split line needs a non-zero amount.';
     }
   }
-  if (!splitRemainder(totalAmount, lines).isZero()) {
+  if (!splitRemainder(totalAmount, lines, opts).isZero()) {
     return 'The split total must match the transaction amount.';
   }
   return null;
 }
 
 /**
- * Convert entered magnitudes to DB-signed amounts. Expenses store negative,
- * so an entered 120 becomes -120 and an entered -20 (a cashback line)
- * becomes +20; income lines keep their entered sign. This mirrors what
- * signTransactionAmount does to the single amount field, extended to allow
- * per-line negatives.
+ * Convert entered magnitudes to DB-signed amounts. Expense-direction lines
+ * store negative, income-direction lines positive — the direction being the
+ * LINE's own (from its category), not the parent's, so a mixed split signs
+ * each line correctly. An entered -20 on an expense line (cashback typed as
+ * a minus) still lands as +20. The DB's set_transaction_splits invariant
+ * (signed lines sum to the signed parent amount) holds exactly whenever
+ * validateSplitDrafts passed with the same opts.
  */
 export function signSplitAmounts(
   lines: SplitLineDraft[],
-  type: 'income' | 'expense'
+  type: SplitDirection,
+  directionFor: SplitDirectionFor = () => null
 ): { category: string; amount: number; memo?: string }[] {
+  const opts: SplitDirectionOpts = { parentType: type, directionFor };
   return lines.map(line => {
     const entered = toDecimal(parseMoneyInput(line.amount) ?? 0);
-    const signed = type === 'expense' ? entered.negated() : entered;
+    const signed = lineDirection(line, opts) === 'expense' ? entered.negated() : entered;
     return {
       category: line.category,
       // `plus(0)` normalises -0 → 0 to match signTransactionAmount's `|| 0`.
@@ -82,12 +132,13 @@ export function signSplitAmounts(
 }
 
 /**
- * Convert stored (signed) split amounts back to the entered domain for the
- * editor — the inverse of signSplitAmounts.
+ * Convert a stored (signed) split amount back to the entered domain for the
+ * editor — the inverse of signSplitAmounts, per line: pass the LINE's
+ * resolved direction (its category's, falling back to the parent's).
  */
-export function displaySplitAmount(storedAmount: number, type: 'income' | 'expense'): string {
+export function displaySplitAmount(storedAmount: number, direction: SplitDirection): string {
   const value = toDecimal(storedAmount);
-  return (type === 'expense' ? value.negated() : value).toString();
+  return (direction === 'expense' ? value.negated() : value).toString();
 }
 
 /**


### PR DESCRIPTION
## What

- **Mixed-direction splits**: a split line's direction comes from its OWN category's tree — one split may mix expense and income lines (the income line counts against an expense total), validated so the signed lines sum exactly to the transaction. Both trees offered per line, exact Decimal maths, clean round-trip. The `set_transaction_splits` invariant (signed-sum equality) already permitted this — no migration.
- **Bank sync**: feeds no longer overwrite account names. The update path renames only when the current name is positively blank; a failed lookup counts as named. New accounts still take the bank's name.
- **Match transfers**: both leg cards in "Check this pair" deep-link to the transaction centred in its own register; closed-account legs stay informational with an explanatory tooltip instead of dead-ending.
- **Register clipping**: the selected-row "lift" (1.01 scale + 8px side margin on absolutely-positioned virtual rows) pushed the Balance column's digits past the table's clipped edge — both removed; shadow/gradient/z-index carry the look. Hover had the same scale bug. Money columns widened (Payment/Deposit 130px, Balance 140px) for 7-figure amounts; Description flexes down.
- **Quick docks**: quick-add fields all level (new `size="compact"` CategorySelector trigger, trimmed DatePicker height); quick-edit Description and Category split the row's slack equally.
- **Group headers app-wide** get the darker band treatment (Accounts sections, cash sub-boxes, category-picker section bands, portfolio bars, panel headers, default table header).

## Verification

- 30/30 splits unit tests (9 new mixed-direction cases incl. the 40k−10k=30k scenario, income-parent mirror, neutral categories, float-drift guard).
- Browser-verified: split editor offers both trees, remainder counts down to "Fully allocated ✓" with a mixed pair, saved with the register amount untouched; selected-row balance text ends at the same pixel as unselected rows with 15px edge clearance and `transform: none`; quick docks measured level (all labels same top, fields same height/width).
- Strict typecheck, lint, smoke — green. Sync rename-protection is server-side (not demo-exercisable); split persistence through the RPC awaits real data — demo's split save is a no-op.

🤖 Generated with [Claude Code](https://claude.com/claude-code)