### PR TITLE
feat(categories+ui): merge two categories into one, sortable review tables, grouped account pickers

### DIFF
--- a/src/components/AddTransactionModal.tsx
+++ b/src/components/AddTransactionModal.tsx
@@ -6,6 +6,7 @@ import { getCurrencySymbol } from '../utils/currency';
 // Import { Modal, ModalBody, ModalFooter } from './common/Modal'; // Unused imports
 import { ResponsiveModal } from './ResponsiveModal';
 import MoneyInput from './common/MoneyInput';
+import GroupedAccountSelect from './common/GroupedAccountSelect';
 import { useModalForm } from '../hooks/useModalForm';
 import { parseMoneyInput } from '../utils/decimal';
 import MarkdownEditor from './MarkdownEditor';
@@ -172,21 +173,17 @@ export default function AddTransactionModal({ isOpen, onClose }: AddTransactionM
               <label htmlFor="account-select" className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
                 Account
               </label>
-              <select
+              <GroupedAccountSelect
                 id="account-select"
+                accounts={accounts}
                 value={formData.accountId}
-                onChange={(e) => updateField('accountId', e.target.value)}
+                onChange={(accountId) => updateField('accountId', accountId)}
+                placeholder="Select account"
+                formatLabel={(account) => `${account.name} (${account.type})`}
                 className="w-full px-3 py-3 sm:py-2 text-base sm:text-sm bg-white dark:bg-gray-700 border-2 border-gray-300 dark:border-gray-500 rounded-lg focus:outline-none focus:ring-2 focus:ring-primary dark:focus:ring-blue-400 focus:border-transparent dark:text-white min-h-[48px] sm:min-h-[auto]"
                 required
                 aria-label="Select account for transaction"
-              >
-                <option value="">Select account</option>
-                {accounts.map(account => (
-                  <option key={account.id} value={account.id}>
-                    {account.name} ({account.type})
-                  </option>
-                ))}
-              </select>
+              />
             </div>
 
             <div>

--- a/src/components/BulkCategorizeModal.sort.test.tsx
+++ b/src/components/BulkCategorizeModal.sort.test.tsx
@@ -1,0 +1,168 @@
+/**
+ * BulkCategorizeModal — sorting the payee table.
+ *
+ * The rules worth pinning: the list opens in the order buildPayeeGroups
+ * emitted (biggest payees first) so nothing moves before it is asked to, the
+ * money column sorts by magnitude, and the Category column puts the payees
+ * still undecided LAST in both directions — that column is clicked to see
+ * what has already been settled.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, fireEvent, cleanup, within } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import BulkCategorizeModal from './BulkCategorizeModal';
+import { __setAppContextValue, __resetAppContextValue } from '../test/mocks/AppContextSupabase';
+import type { Category, Transaction } from '../types';
+
+vi.mock('../contexts/ToastContext', () => ({
+  useToast: () => ({
+    showToast: vi.fn(),
+    showSuccess: vi.fn(),
+    showError: vi.fn(),
+    showWarning: vi.fn(),
+    showInfo: vi.fn(),
+    dismissToast: vi.fn(),
+  }),
+}));
+
+vi.mock('../hooks/useCurrencyDecimal', () => ({
+  useCurrencyDecimal: () => ({
+    formatCurrency: (amount: number) => `£${Math.abs(amount).toFixed(2)}`,
+    displayCurrency: 'GBP',
+    getCurrencySymbol: () => '£',
+    convert: vi.fn(),
+    convertAndFormat: vi.fn(),
+    convertAndSum: vi.fn(),
+  }),
+}));
+
+vi.mock('../hooks/useAccountNames', () => ({
+  useAccountNames: () => (id: string) => (id === 'acc-current' ? 'Current account' : id),
+}));
+
+const CATEGORIES: Category[] = [
+  { id: 'cat-food', name: 'Food', type: 'expense', level: 'detail' },
+  { id: 'cat-home', name: 'Home', type: 'expense', level: 'detail' },
+];
+
+const txn = (over: Partial<Transaction> & { id: string }): Transaction => ({
+  date: new Date('2026-05-01'),
+  amount: -10,
+  description: 'Mango Ltd',
+  category: '',
+  accountId: 'acc-current',
+  type: 'expense',
+  ...over,
+});
+
+const uncategorised = (payee: string, amounts: number[]): Transaction[] =>
+  amounts.map((amount, i) => txn({ id: `${payee}-${i}`, description: payee, amount }));
+
+/** Rows filed before, so the group arrives with its category already chosen. */
+const filedBefore = (payee: string, categoryId: string, howMany: number): Transaction[] =>
+  Array.from({ length: howMany }, (_, i) =>
+    txn({ id: `${payee}-hist-${i}`, description: payee, amount: -5, category: categoryId })
+  );
+
+/**
+ * Three payees that disagree on every column:
+ *   Mango Ltd    5 rows  £1200  → Food (filed 3 of 3 before)
+ *   Alpha Store  4 rows  £30    → undecided
+ *   Zebra Cafe   3 rows  £500   → Home (filed 2 of 2 before)
+ */
+const HISTORY: Transaction[] = [
+  ...uncategorised('Mango Ltd', [-300, -300, -300, -200, -100]),
+  ...filedBefore('Mango Ltd', 'cat-food', 3),
+  ...uncategorised('Alpha Store', [-10, -10, -5, -5]),
+  ...uncategorised('Zebra Cafe', [-200, -200, -100]),
+  ...filedBefore('Zebra Cafe', 'cat-home', 2),
+];
+
+const renderModal = (): void => {
+  render(
+    <MemoryRouter>
+      <BulkCategorizeModal isOpen onClose={vi.fn()} />
+    </MemoryRouter>
+  );
+};
+
+/** The payee rows in render order, each identified by its Rows count. */
+const rowCounts = (): string[] =>
+  within(screen.getByRole('table'))
+    .getAllByRole('row')
+    .slice(1)
+    .map(r => within(r).getAllByRole('cell')[1].textContent?.trim() ?? '');
+
+beforeEach(() => {
+  __setAppContextValue({ transactions: HISTORY, categories: CATEGORIES });
+});
+
+afterEach(() => {
+  cleanup();
+  __resetAppContextValue();
+});
+
+describe('BulkCategorizeModal — sorting the payee table', () => {
+  it('opens with the biggest payees first, exactly as the groups arrive', () => {
+    renderModal();
+
+    expect(rowCounts()).toEqual(['5', '4', '3']);
+    expect(screen.getByRole('button', { name: 'Rows ↓' })).toBeInTheDocument();
+  });
+
+  it('flips Rows to fewest-first on a click', () => {
+    renderModal();
+
+    fireEvent.click(screen.getByRole('button', { name: /^Rows/ }));
+
+    expect(rowCounts()).toEqual(['3', '4', '5']);
+    expect(screen.getByRole('button', { name: 'Rows ↑' })).toBeInTheDocument();
+  });
+
+  it('sorts Total by magnitude, biggest first, and flips on a second click', () => {
+    renderModal();
+
+    fireEvent.click(screen.getByRole('button', { name: /^Total/ }));
+    // £1200, £500, £30 — not the row counts, which run 5, 3, 4 here.
+    expect(rowCounts()).toEqual(['5', '3', '4']);
+
+    fireEvent.click(screen.getByRole('button', { name: /^Total/ }));
+    expect(rowCounts()).toEqual(['4', '3', '5']);
+  });
+
+  it('sorts Payee alphabetically, ignoring case', () => {
+    renderModal();
+
+    fireEvent.click(screen.getByRole('button', { name: /^Payee/ }));
+
+    // Alpha Store, Mango Ltd, Zebra Cafe.
+    expect(rowCounts()).toEqual(['4', '5', '3']);
+  });
+
+  it('sorts Category by the chosen name, keeping undecided payees last BOTH ways', () => {
+    renderModal();
+    // Alpha Store is the undecided one — nothing in its history to pre-fill.
+    expect(screen.getByText('Choose a category…')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: /^Category/ }));
+    // Food (Mango, 5), Home (Zebra, 3), then the undecided Alpha (4).
+    expect(rowCounts()).toEqual(['5', '3', '4']);
+
+    fireEvent.click(screen.getByRole('button', { name: /^Category/ }));
+    // The chosen two swap; the undecided payee does NOT rise to the top.
+    expect(rowCounts()).toEqual(['3', '5', '4']);
+  });
+
+  it('sends a payee to the undecided block the moment its category is cleared', () => {
+    renderModal();
+    fireEvent.click(screen.getByRole('button', { name: /^Category/ }));
+    expect(rowCounts()).toEqual(['5', '3', '4']);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Clear category for Mango Ltd' }));
+
+    // Home (Zebra, 3) is now the only decision left; both blanks follow it.
+    expect(rowCounts()[0]).toBe('3');
+    expect(rowCounts().slice(1).sort()).toEqual(['4', '5']);
+  });
+});

--- a/src/components/BulkCategorizeModal.tsx
+++ b/src/components/BulkCategorizeModal.tsx
@@ -32,6 +32,12 @@ interface Props {
 
 const CAP = 100;
 
+type SortKey = 'payee' | 'rows' | 'total' | 'category';
+
+/** Case-insensitive, so "Boots" and "BOOTS" sit together, not in two blocks. */
+const compareText = (a: string, b: string): number =>
+  a.localeCompare(b, undefined, { sensitivity: 'base' });
+
 export default function BulkCategorizeModal({ isOpen, onClose }: Props): React.JSX.Element {
   const { transactions, categories, applyCategoryToUncategorized } = useApp();
   const { formatCurrency } = useCurrencyDecimal();
@@ -45,6 +51,11 @@ export default function BulkCategorizeModal({ isOpen, onClose }: Props): React.J
   const [choices, setChoices] = useState<Record<string, string>>({});
   const [applying, setApplying] = useState(false);
   const [progress, setProgress] = useState(0);
+  // buildPayeeGroups already emits biggest-first (count desc, then total
+  // desc), so Rows descending IS today's order — and Array#sort is stable, so
+  // its total tie-break survives untouched until another column is clicked.
+  const [sortKey, setSortKey] = useState<SortKey>('rows');
+  const [sortDir, setSortDir] = useState<1 | -1>(-1);
 
   // Closed accounts included — Money-era payees live in accounts long since
   // closed, and every one of them has a real name.
@@ -98,7 +109,51 @@ export default function BulkCategorizeModal({ isOpen, onClose }: Props): React.J
     setChoices(prev => ({ ...prev, [keyOf(g)]: categoryId }));
   };
 
-  const visible = groups.slice(0, CAP);
+  /** The chosen category's display name, or '' while the payee is undecided. */
+  const chosenName = (g: PayeeGroup): string => {
+    const id = effectiveChoice(g);
+    return id === '' ? '' : categoryName(id);
+  };
+
+  const compareGroups = (a: PayeeGroup, b: PayeeGroup): number => {
+    switch (sortKey) {
+      case 'payee':
+        return sortDir * compareText(a.displayName, b.displayName);
+      case 'rows':
+        return sortDir * (a.count - b.count);
+      // Group totals are magnitudes already, but Math.abs keeps the column
+      // honest if a future group ever carries a signed total.
+      case 'total':
+        return sortDir * (Math.abs(a.total) - Math.abs(b.total));
+      case 'category': {
+        const an = chosenName(a);
+        const bn = chosenName(b);
+        // Undecided payees sink to the bottom in BOTH directions — hence not
+        // multiplied by sortDir. This column is clicked to see what has
+        // already been decided; a screenful of "Choose a category…" on top
+        // would answer the opposite question.
+        if (an === '' || bn === '') return an === bn ? 0 : an === '' ? 1 : -1;
+        return sortDir * compareText(an, bn);
+      }
+    }
+  };
+
+  const handleSort = (key: SortKey): void => {
+    if (key === sortKey) {
+      setSortDir(d => (d === 1 ? -1 : 1));
+    } else {
+      setSortKey(key);
+      setSortDir(key === 'rows' || key === 'total' ? -1 : 1);
+    }
+  };
+  const arrow = (key: SortKey): string =>
+    sortKey === key ? (sortDir === 1 ? ' ↑' : ' ↓') : '';
+
+  // The cap is applied FIRST and the sort second, deliberately: the cap means
+  // "the 100 biggest payees", and it goes on meaning that whichever column
+  // the user sorts by afterwards. Sorting never pulls in a 101st payee.
+  // (slice hands back a fresh array, so `groups` itself is never reordered.)
+  const visible = groups.slice(0, CAP).sort(compareGroups);
   const ready = visible.filter(g => effectiveChoice(g) !== '');
   const rowsCovered = ready.reduce((sum, g) => sum + g.count, 0);
 
@@ -169,10 +224,23 @@ export default function BulkCategorizeModal({ isOpen, onClose }: Props): React.J
                     {/* Headings sit CENTRED over their columns — the app-wide
                         convention. pr matches the body cells so each heading
                         centres on its column, not on the gap beside it. */}
-                    <th className="text-center pb-2 pr-3 font-medium">Payee</th>
-                    <th className="text-center pb-2 pr-3 font-medium">Rows</th>
-                    <th className="text-center pb-2 pr-3 font-medium">Total</th>
-                    <th className="text-center pb-2 font-medium w-80 lg:w-[26rem]">Category</th>
+                    {([
+                      ['payee', 'Payee', 'pr-3', 'Sort by payee name'],
+                      ['rows', 'Rows', 'pr-3', 'Sort by how many transactions'],
+                      ['total', 'Total', 'pr-3', 'Sort by amount size'],
+                      ['category', 'Category', 'w-80 lg:w-[26rem]', 'Sort by the category chosen — payees still undecided last'],
+                    ] as const).map(([key, label, extra, hint]) => (
+                      <th key={key} className={`text-center pb-2 font-medium ${extra}`}>
+                        <button
+                          type="button"
+                          onClick={() => handleSort(key)}
+                          className="hover:text-gray-800 dark:hover:text-gray-200 transition-colors"
+                          title={hint}
+                        >
+                          {label}{arrow(key)}
+                        </button>
+                      </th>
+                    ))}
                   </tr>
                 </thead>
                 <tbody className="block sm:table-row-group">

--- a/src/components/BulkEditPanel.tsx
+++ b/src/components/BulkEditPanel.tsx
@@ -8,6 +8,7 @@ import {
   ArrowRightIcon,
   EyeIcon
 } from './icons';
+import GroupedAccountSelect from './common/GroupedAccountSelect';
 import type { Transaction, Account, Category } from '../types';
 import type { DecimalInstance } from '../types/decimal-types';
 
@@ -163,18 +164,14 @@ export default function BulkEditPanel({
               <ArrowRightIcon size={16} className="inline mr-1" />
               Move to Account
             </label>
-            <select
+            <GroupedAccountSelect
+              accounts={accounts}
               value={changes.moveToAccount ?? ''}
-              onChange={(e) => setChanges({ ...changes, moveToAccount: e.target.value || undefined })}
+              onChange={(accountId) => setChanges({ ...changes, moveToAccount: accountId || undefined })}
+              placeholder="Keep in current account"
+              formatLabel={(acc) => `${acc.name} (${formatCurrency(acc.balance)})`}
               className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-800"
-            >
-              <option value="">Keep in current account</option>
-              {accounts.map(acc => (
-                <option key={acc.id} value={acc.id}>
-                  {acc.name} ({formatCurrency(acc.balance)})
-                </option>
-              ))}
-            </select>
+            />
           </div>
         </div>
 

--- a/src/components/BulkTransactionEdit.tsx
+++ b/src/components/BulkTransactionEdit.tsx
@@ -16,6 +16,7 @@ import {
   RepeatIcon
 } from './icons';
 import BulkEditPanel from './BulkEditPanel';
+import { GroupedAccountOptions } from './common/GroupedAccountSelect';
 import type { Transaction } from '../types';
 import type { DecimalInstance } from '../types/decimal-types';
 
@@ -452,9 +453,9 @@ export default function BulkTransactionEdit({
                                rounded bg-white dark:bg-gray-700"
                       size={3}
                     >
-                      {accounts.map(acc => (
-                        <option key={acc.id} value={acc.id}>{acc.name}</option>
-                      ))}
+                      {/* Multi-select, so it keeps its own <select> and takes
+                          only the grouped options. */}
+                      <GroupedAccountOptions accounts={accounts} />
                     </select>
                   </div>
                   <div>

--- a/src/components/EditTransactionModal.test.tsx
+++ b/src/components/EditTransactionModal.test.tsx
@@ -231,6 +231,27 @@ describe('EditTransactionModal', () => {
       expect(screen.getByText('Notes')).toBeInTheDocument();
     });
 
+    it('bands the account picker into the Accounts page sections', () => {
+      // The owner's complaint: seventy accounts in one flat unsorted list.
+      // Sections in page order, alphabetical inside each, wording unchanged.
+      renderModal(true, null);
+
+      const accountSelect = screen.getByRole('combobox');
+      expect(Array.from(accountSelect.querySelectorAll('optgroup')).map(g => g.label)).toEqual([
+        'Current Accounts', 'Savings Accounts', 'Credit Cards', 'Loans', 'Investments', 'Assets',
+      ]);
+
+      const creditCards = accountSelect.querySelector('optgroup[label="Credit Cards"]');
+      expect(Array.from(creditCards?.querySelectorAll('option') ?? []).map(o => o.textContent)).toEqual([
+        'American Express Gold (credit)', 'Natwest Credit Card (credit)',
+      ]);
+      // A mortgage files under Loans, as it does on the Accounts page.
+      const loans = accountSelect.querySelector('optgroup[label="Loans"]');
+      expect(Array.from(loans?.querySelectorAll('option') ?? []).map(o => o.textContent)).toEqual([
+        'Natwest Mortgage (mortgage)', 'Natwest Personal Loan (loan)',
+      ]);
+    });
+
     it('displays transaction type options', () => {
       renderModal(true, null);
       

--- a/src/components/EditTransactionModal.transferJump.test.tsx
+++ b/src/components/EditTransactionModal.transferJump.test.tsx
@@ -241,4 +241,29 @@ describe('EditTransactionModal — jump to the other side', () => {
 
     expect(queryJumpButton()).toBeNull();
   });
+
+  it('offers every OTHER account as a transfer target, banded and named plainly', () => {
+    // The target rides in the category field as 'transfer:<id>' until save
+    // resolves it — the shared grouped select must not change that, nor start
+    // printing types or balances beside the name.
+    mocks.app.accounts = [
+      account('acc-a', 'Current Account'),
+      { ...account('acc-b', 'Savings'), type: 'savings' },
+      { ...account('acc-c', 'Barclaycard'), type: 'credit' },
+      { ...account('acc-d', 'Closed Card'), type: 'credit', isActive: false },
+    ];
+    renderModal(OUT_LEG);
+
+    const target = screen.getByLabelText<HTMLSelectElement>('Transfer destination account');
+    expect(Array.from(target.querySelectorAll('optgroup')).map(g => g.label)).toEqual([
+      'Savings Accounts', 'Credit Cards',
+    ]);
+    expect(Array.from(target.querySelectorAll('option')).map(o => o.textContent)).toEqual([
+      'Select account to transfer to', 'Savings', 'Barclaycard',
+    ]);
+    expect(Array.from(target.querySelectorAll('optgroup option')).map(o => (o as HTMLOptionElement).value))
+      .toEqual(['transfer:acc-b', 'transfer:acc-c']);
+    // An existing transfer opens showing the target it already has.
+    expect(target.value).toBe('transfer:acc-b');
+  });
 });

--- a/src/components/EditTransactionModal.tsx
+++ b/src/components/EditTransactionModal.tsx
@@ -17,7 +17,7 @@ import CategoryCreationModal from './CategoryCreationModal';
 import TransferMatchDialog from './TransferMatchDialog';
 import { findTransferCandidates, transferCategoryFor, type TransferCandidate } from '../utils/transferMatch';
 import { resolveTransferOtherSide } from '../utils/transferOtherSide';
-import { groupAccountsBySection } from '../utils/accountGrouping';
+import GroupedAccountSelect from './common/GroupedAccountSelect';
 import { useToast } from '../contexts/ToastContext';
 import CategorySelector from './CategorySelector';
 import TagSelector from './TagSelector';
@@ -377,46 +377,15 @@ export default function EditTransactionModal({ isOpen, onClose, transaction, def
     }
   );
 
-  // Build unified flat category list grouped by parent sub-category
-  const groupedCategories = useMemo(() => {
-    // Inactive categories (a closed account's transfer category) never appear
-    // in transaction dropdowns; reopening the account restores them.
-    const detailCats = categories.filter(c =>
-      c.level === 'detail' && c.id !== 'transfer-in' && c.id !== 'transfer-out' && c.isActive !== false
-    );
-    const subCats = categories.filter(c => c.level === 'sub' && c.isActive !== false);
-
-    // Group detail categories by their parent sub-category
-    const groups: { label: string; type: 'income' | 'expense' | 'both'; items: { id: string; name: string; parentName: string }[] }[] = [];
-    for (const sub of subCats) {
-      const children = detailCats.filter(d => d.parentId === sub.id);
-      if (children.length > 0) {
-        groups.push({
-          label: sub.name,
-          type: sub.type as 'income' | 'expense' | 'both',
-          items: children.map(c => ({ id: c.id, name: c.name, parentName: sub.name }))
-        });
-      }
-    }
-
-    // 'both'-typed groups (e.g. Adjustments) are valid for either direction —
-    // include them on both sides so an income row carrying such a category is
-    // always representable in the select.
-    const incomeGroups = groups.filter(g => g.type === 'income' || g.type === 'both');
-    const expenseGroups = groups.filter(g => g.type === 'expense' || g.type === 'both');
-
-    // Transfer accounts: all accounts except the current transaction's account,
-    // banded into the SAME sections the Accounts page uses (Current, Savings,
-    // Credit Cards…) and alphabetical inside each — one flat unordered list of
-    // every account was unreadable once there were more than a handful.
-    const transferAccountSections = groupAccountsBySection(
-      accounts
-        .filter(a => a.isActive !== false && a.id !== formData.accountId)
-        .map(a => ({ id: `transfer:${a.id}`, name: a.name, type: a.type }))
-    );
-
-    return { incomeGroups, expenseGroups, transferAccountSections };
-  }, [categories, accounts, formData.accountId]);
+  // Transfer targets: every active account except the one this transaction
+  // sits in. The select carries 'transfer:<id>' because the target rides in
+  // the category field until save resolves it.
+  const transferTargetOptions = useMemo(
+    () => accounts
+      .filter(a => a.isActive !== false && a.id !== formData.accountId)
+      .map(a => ({ id: `transfer:${a.id}`, name: a.name, type: a.type })),
+    [accounts, formData.accountId]
+  );
 
   // Helper function to format number with commas
   const formatWithCommas = (value: string | number): string => {
@@ -664,19 +633,15 @@ export default function EditTransactionModal({ isOpen, onClose, transaction, def
                 <WalletIcon size={16} />
                 Account
               </label>
-              <select
+              <GroupedAccountSelect
+                accounts={accounts}
                 value={formData.accountId}
-                onChange={(e) => updateField('accountId', e.target.value)}
+                onChange={(accountId) => updateField('accountId', accountId)}
+                placeholder="Select account"
+                formatLabel={(acc) => `${acc.name} (${acc.type})`}
                 className="w-full px-3 py-3 sm:py-2 h-12 sm:h-[42px] text-base sm:text-sm bg-white dark:bg-gray-700 border-2 border-gray-300 dark:border-gray-500 rounded-lg focus:outline-none focus:ring-2 focus:ring-primary dark:focus:ring-blue-400 focus:border-transparent dark:text-white"
                 required
-              >
-                <option value="">Select account</option>
-                {accounts.map(acc => (
-                  <option key={acc.id} value={acc.id}>
-                    {acc.name} ({acc.type})
-                  </option>
-                ))}
-              </select>
+              />
             </div>
 
             {/* Description */}
@@ -842,22 +807,15 @@ export default function EditTransactionModal({ isOpen, onClose, transaction, def
                   bucket. Transfers still require their target account. */}
               {formData.type === 'transfer' ? (
                 <>
-                  <select
+                  <GroupedAccountSelect
+                    accounts={transferTargetOptions}
                     value={formData.category}
-                    onChange={(e) => updateField('category', e.target.value)}
+                    onChange={(target) => updateField('category', target)}
+                    placeholder="Select account to transfer to"
                     className="w-full px-3 py-3 sm:py-2 h-12 sm:h-[42px] text-base sm:text-sm bg-white dark:bg-gray-700 border-2 border-gray-300 dark:border-gray-500 rounded-lg focus:outline-none focus:ring-2 focus:ring-primary dark:focus:ring-blue-400 focus:border-transparent dark:text-white"
                     required
                     aria-label="Transfer destination account"
-                  >
-                    <option value="">Select account to transfer to</option>
-                    {groupedCategories.transferAccountSections.map(group => (
-                      <optgroup key={group.label} label={group.title}>
-                        {group.accounts.map(acct => (
-                          <option key={acct.id} value={acct.id}>{acct.name}</option>
-                        ))}
-                      </optgroup>
-                    ))}
-                  </select>
+                  />
                   {/* Both halves of a linked transfer carry this, so it reads
                       the same whichever leg is open — and the register's ?txn
                       deep link selects, centres and docks the row on arrival. */}

--- a/src/components/ImportRulesManager.tsx
+++ b/src/components/ImportRulesManager.tsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect } from 'react';
 import { useApp } from '../contexts/AppContextSupabase';
 import { importRulesService } from '../services/importRulesService';
 import MoneyInput from './common/MoneyInput';
+import GroupedAccountSelect from './common/GroupedAccountSelect';
 import { parseMoneyInput } from '../utils/decimal';
 import { 
   PlusIcon, 
@@ -715,16 +716,15 @@ function RuleFormModal({ rule, categories, accounts, onSave, onClose }: RuleForm
                     )}
 
                     {action.type === 'setAccount' && (
-                      <select
-                        value={action.value}
-                        onChange={(e) => updateAction(index, { value: e.target.value })}
+                      <GroupedAccountSelect
+                        accounts={accounts}
+                        // An action starts with no value at all; '' is the
+                        // placeholder the select shows for it.
+                        value={action.value ?? ''}
+                        onChange={(accountId) => updateAction(index, { value: accountId })}
+                        placeholder="Select account"
                         className="flex-1 px-2 py-1 bg-white dark:bg-gray-700 border border-gray-300 dark:border-gray-600 rounded text-sm"
-                      >
-                        <option value="">Select account</option>
-                        {accounts.map(acc => (
-                          <option key={acc.id} value={acc.id}>{acc.name}</option>
-                        ))}
-                      </select>
+                      />
                     )}
 
                     <button

--- a/src/components/IncomeExpenseBreakdownModal.tsx
+++ b/src/components/IncomeExpenseBreakdownModal.tsx
@@ -104,12 +104,15 @@ export default function IncomeExpenseBreakdownModal({
     setSaving(true);
     try {
       await onApplyCategories(assignments);
-      setSavedIds(prev => {
-        const next = new Set(prev);
-        assignments.forEach(ids => ids.forEach(id => next.add(id)));
-        return next;
-      });
+      const nextSaved = new Set(savedIds);
+      assignments.forEach(ids => ids.forEach(id => nextSaved.add(id)));
+      setSavedIds(nextSaved);
       setPendingChoices({});
+      // The save just filed the LAST outstanding row: the popup's job is
+      // done, so it closes instead of sitting on an empty list.
+      if (rows.every(r => nextSaved.has(r.id))) {
+        onClose();
+      }
     } finally {
       // On failure the choices stay put — nothing the user picked is lost.
       setSaving(false);

--- a/src/components/OFXImportModal.test.tsx
+++ b/src/components/OFXImportModal.test.tsx
@@ -365,6 +365,10 @@ describe('OFXImportModal', () => {
         expect(screen.getByText('Current Account (checking)')).toBeInTheDocument();
         expect(screen.getByText('Savings Account (savings)')).toBeInTheDocument();
         expect(screen.getByText('Credit Card (credit)')).toBeInTheDocument();
+        // Banded like every other account picker in the app.
+        expect(Array.from(select.querySelectorAll('optgroup')).map(g => g.label)).toEqual([
+          'Current Accounts', 'Savings Accounts', 'Credit Cards',
+        ]);
       });
     });
 

--- a/src/components/OFXImportModal.tsx
+++ b/src/components/OFXImportModal.tsx
@@ -13,6 +13,7 @@ import {
   RefreshCwIcon
 } from './icons';
 import { LoadingButton } from './loading/LoadingState';
+import GroupedAccountSelect from './common/GroupedAccountSelect';
 import type { Account } from '../types';
 import { createScopedLogger } from '../loggers/scopedLogger';
 
@@ -268,19 +269,15 @@ export default function OFXImportModal({ isOpen, onClose }: OFXImportModalProps)
                     </div>
                   )}
                   
-                  <select
+                  <GroupedAccountSelect
+                    accounts={accounts}
                     value={selectedAccountId}
-                    onChange={(e) => setSelectedAccountId(e.target.value)}
+                    onChange={setSelectedAccountId}
+                    placeholder="Select an account..."
+                    formatLabel={(account) => `${account.name} (${account.type})`}
                     className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg focus:ring-2 focus:ring-primary focus:border-transparent dark:bg-gray-700 dark:text-white"
                     required
-                  >
-                    <option value="">Select an account...</option>
-                    {accounts.map(account => (
-                      <option key={account.id} value={account.id}>
-                        {account.name} ({account.type})
-                      </option>
-                    ))}
-                  </select>
+                  />
                 </>
               )}
             </div>

--- a/src/components/QIFImportModal.test.tsx
+++ b/src/components/QIFImportModal.test.tsx
@@ -289,6 +289,11 @@ describe('QIFImportModal', () => {
         expect(screen.getByText('Current Account (checking)')).toBeInTheDocument();
         expect(screen.getByText('Savings Account (savings)')).toBeInTheDocument();
         expect(screen.getByText('Credit Card (credit)')).toBeInTheDocument();
+        // Banded like every other account picker — the DB's 'checking' still
+        // files under Current Accounts.
+        expect(Array.from(select.querySelectorAll('optgroup')).map(g => g.label)).toEqual([
+          'Current Accounts', 'Savings Accounts', 'Credit Cards',
+        ]);
       });
     });
 

--- a/src/components/QIFImportModal.tsx
+++ b/src/components/QIFImportModal.tsx
@@ -15,6 +15,7 @@ import {
   RefreshCwIcon
 } from './icons';
 import { LoadingButton } from './loading/LoadingState';
+import GroupedAccountSelect from './common/GroupedAccountSelect';
 import { createScopedLogger } from '../loggers/scopedLogger';
 import { useCurrencyDecimal } from '../hooks/useCurrencyDecimal';
 
@@ -268,19 +269,15 @@ export default function QIFImportModal({ isOpen, onClose }: QIFImportModalProps)
               <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
                 Import to Account <span className="text-red-500">*</span>
               </label>
-              <select
+              <GroupedAccountSelect
+                accounts={accounts}
                 value={selectedAccountId}
-                onChange={(e) => setSelectedAccountId(e.target.value)}
+                onChange={setSelectedAccountId}
+                placeholder="Select an account..."
+                formatLabel={(account) => `${account.name} (${account.type})`}
                 className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg focus:ring-2 focus:ring-primary focus:border-transparent dark:bg-gray-700 dark:text-white"
                 required
-              >
-                <option value="">Select an account...</option>
-                {accounts.map(account => (
-                  <option key={account.id} value={account.id}>
-                    {account.name} ({account.type})
-                  </option>
-                ))}
-              </select>
+              />
               <p className="text-xs text-gray-500 dark:text-gray-400 mt-1">
                 QIF files don't contain account information, so you need to select the destination account
               </p>

--- a/src/components/TransactionModal.tsx
+++ b/src/components/TransactionModal.tsx
@@ -5,6 +5,7 @@ import { XIcon } from './icons/XIcon';
 import TagSelector from './TagSelector';
 import CategorySelector from './CategorySelector';
 import MoneyInput from './common/MoneyInput';
+import GroupedAccountSelect from './common/GroupedAccountSelect';
 import type { Transaction } from '../types';
 
 interface TransactionModalProps {
@@ -388,25 +389,22 @@ export default function TransactionModal({ isOpen, onClose, transaction }: Trans
             <label htmlFor="account" className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
               Account <span className="text-red-500" aria-label="required">*</span>
             </label>
-            <select
+            <GroupedAccountSelect
               id="account"
+              accounts={accounts}
               value={formData.accountId}
-              onChange={(e) => setFormData({ ...formData, accountId: e.target.value })}
+              onChange={(accountId) => setFormData({ ...formData, accountId })}
               onBlur={() => handleBlur('account')}
+              placeholder="Select an account"
               aria-required="true"
               aria-invalid={touched.account && !!errors.account}
               aria-describedby={touched.account && errors.account ? 'account-error' : undefined}
               className={`w-full px-3 py-2 bg-white dark:bg-gray-800-sm border ${
-                touched.account && errors.account 
-                  ? 'border-red-500 dark:border-red-500' 
+                touched.account && errors.account
+                  ? 'border-red-500 dark:border-red-500'
                   : 'border-gray-300/50 dark:border-gray-600/50'
               } rounded-xl focus:outline-none focus:ring-2 focus:ring-primary focus:border-transparent dark:text-white`}
-            >
-              <option value="">Select an account</option>
-              {accounts.map(account => (
-                <option key={account.id} value={account.id}>{account.name}</option>
-              ))}
-            </select>
+            />
             {touched.account && errors.account && (
               <p id="account-error" className="mt-1 text-sm text-red-500" role="alert">
                 {errors.account}

--- a/src/components/TransactionReconciliation.tsx
+++ b/src/components/TransactionReconciliation.tsx
@@ -3,6 +3,7 @@ import { useApp } from '../contexts/AppContextSupabase';
 import { useCurrencyDecimal } from '../hooks/useCurrencyDecimal';
 import { Modal } from './common/Modal';
 import MoneyInput from './common/MoneyInput';
+import GroupedAccountSelect from './common/GroupedAccountSelect';
 import { CheckCircleIcon, LinkIcon, RefreshCwIcon, CalendarIcon } from './icons';
 import type { Transaction } from '../types';
 import type { DecimalInstance } from '../types/decimal-types';
@@ -226,19 +227,15 @@ export default function TransactionReconciliation({
           <div className="grid grid-cols-2 gap-6">
             <div>
               <label className="block text-sm font-medium mb-2">Account</label>
-              <select
+              <GroupedAccountSelect
+                accounts={accounts}
                 value={selectedAccount}
-                onChange={(e) => setSelectedAccount(e.target.value)}
+                onChange={setSelectedAccount}
+                placeholder="Select an account..."
+                formatLabel={(acc) => `${acc.name} (${formatCurrency(acc.balance)})`}
                 className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg
                          bg-white dark:bg-gray-700"
-              >
-                <option value="">Select an account...</option>
-                {accounts.map(acc => (
-                  <option key={acc.id} value={acc.id}>
-                    {acc.name} ({formatCurrency(acc.balance)})
-                  </option>
-                ))}
-              </select>
+              />
             </div>
             
             <div>

--- a/src/components/TransferSweepModal.stranded.test.tsx
+++ b/src/components/TransferSweepModal.stranded.test.tsx
@@ -1,10 +1,15 @@
 /**
- * TransferSweepModal — the "Stranded transfers" tier.
+ * TransferSweepModal — the "Stranded transfers" tier, and the column sorting
+ * over BOTH of the modal's tables.
  *
  * Covers the wiring the classifier's own tests cannot: that the section exists
  * only when there is something in it, that a review spells out the consequence
  * BEFORE anything happens, and that confirming runs the exact write sequence
  * (unlink → file the displaced row → link) through the app context.
+ *
+ * The sorting tests pin the two rules that are easy to lose: the default order
+ * is whatever the sweep/classifier emitted (nothing moves until a heading is
+ * clicked), and reordering rows never disturbs the selection.
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
@@ -74,6 +79,48 @@ const CLAIMED_TWIN_HISTORY: Transaction[] = [
     category: 'transfer-cat', transferAccountId: 'acc-current', linkedTransferId: 'counterpart',
   }),
 ];
+
+/**
+ * Three clean pairs that disagree on every column, so each heading has to
+ * prove itself. The sweep emits them oldest-first — A (£50), B (£900),
+ * C (£300) — which is neither the amount order, the description order, nor
+ * the account order.
+ */
+const PAIR_HISTORY: Transaction[] = [
+  txn({ id: 'pair-a-out', amount: -50, accountId: 'acc-current', description: 'Zulu payment', date: new Date('2026-01-10') }),
+  txn({ id: 'pair-a-in', amount: 50, accountId: 'acc-joint', type: 'income', description: 'Zulu payment', date: new Date('2026-01-10') }),
+  txn({ id: 'pair-b-out', amount: -900, accountId: 'acc-joint', description: 'Alpha payment', date: new Date('2026-02-20') }),
+  txn({ id: 'pair-b-in', amount: 900, accountId: 'acc-credit', type: 'income', description: 'Alpha payment', date: new Date('2026-02-20') }),
+  txn({ id: 'pair-c-out', amount: -300, accountId: 'acc-credit', description: 'Mike payment', date: new Date('2026-03-05') }),
+  txn({ id: 'pair-c-in', amount: 300, accountId: 'acc-current', type: 'income', description: 'Mike payment', date: new Date('2026-03-05') }),
+];
+
+const SORT_CATEGORIES: Category[] = [
+  ...CATEGORIES,
+  { id: 'cat-salary', name: 'Salary', type: 'income', level: 'detail' },
+];
+
+/**
+ * One finding of each of three kinds, again disagreeing on every column:
+ *   £75  10 Mar  Credit card     no other side
+ *   £200 01 May  Joint account   taken
+ *   £1000 20 Jun Current account filed
+ */
+const STRANDED_SORT_HISTORY: Transaction[] = [
+  ...CLAIMED_TWIN_HISTORY,
+  txn({ id: 'lonely', amount: -75, accountId: 'acc-credit', date: new Date('2026-03-10'), description: 'Transfer to savings' }),
+  txn({ id: 'mystery', amount: -1000, accountId: 'acc-current', date: new Date('2026-06-20'), description: 'Sweep to reserve' }),
+  txn({ id: 'filed', amount: 1000, accountId: 'acc-joint', type: 'income', date: new Date('2026-06-20'), description: 'Bonus', category: 'cat-salary' }),
+];
+
+/** One table's rows in render order, each identified by its Amount cell. */
+const orderOf = (rowTitle: string, amountCell: number): string[] =>
+  screen.getAllByRole('row')
+    .filter(r => r.getAttribute('title') === rowTitle)
+    .map(r => within(r).getAllByRole('cell')[amountCell].textContent?.trim() ?? '');
+
+const pairOrder = (): string[] => orderOf('See both sides of this pair', 4);
+const strandedOrder = (): string[] => orderOf('Look at the evidence for this row', 3);
 
 const renderModal = (): void => {
   render(
@@ -175,6 +222,106 @@ describe('TransferSweepModal — reviewing a claimed twin', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Leave the existing pair alone' }));
 
     expect(screen.queryByText('Stranded transfers')).not.toBeInTheDocument();
+  });
+});
+
+describe('TransferSweepModal — sorting the clean pairs', () => {
+  beforeEach(() => {
+    __setAppContextValue({ transactions: PAIR_HISTORY, categories: CATEGORIES });
+  });
+
+  it('opens in the order the sweep emitted, with no column claimed', () => {
+    renderModal();
+
+    expect(pairOrder()).toEqual(['£50.00', '£900.00', '£300.00']);
+    // Exact names: an arrow on any heading would mean a column had been
+    // applied, and something would have moved before the user asked.
+    expect(screen.getByRole('button', { name: 'Date' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Amount' })).toBeInTheDocument();
+  });
+
+  it('sorts Amount by magnitude, biggest first, and flips on a second click', () => {
+    renderModal();
+
+    fireEvent.click(screen.getByRole('button', { name: /^Amount/ }));
+    expect(pairOrder()).toEqual(['£900.00', '£300.00', '£50.00']);
+
+    fireEvent.click(screen.getByRole('button', { name: /^Amount/ }));
+    expect(pairOrder()).toEqual(['£50.00', '£300.00', '£900.00']);
+  });
+
+  it('sorts the accounts column by the RESOLVED names, not the ids', () => {
+    renderModal();
+
+    fireEvent.click(screen.getByRole('button', { name: /^From/ }));
+
+    // Credit card →, Current account →, Joint account → : ids would have
+    // given acc-credit, acc-current, acc-joint — the same order by accident,
+    // so the £300 row leading is what separates the two.
+    expect(pairOrder()).toEqual(['£300.00', '£50.00', '£900.00']);
+  });
+
+  it('reorders rows without disturbing the selection', () => {
+    renderModal();
+    fireEvent.click(screen.getByLabelText('Link £900.00 transfer'));
+    expect(screen.getByText('2 of 3 selected')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: /^Amount/ }));
+
+    // Selection is keyed by the pair's two transaction ids, so the row that
+    // has just moved to the top is still the one the user unticked.
+    expect(pairOrder()).toEqual(['£900.00', '£300.00', '£50.00']);
+    expect(screen.getByLabelText('Link £900.00 transfer')).not.toBeChecked();
+    expect(screen.getByLabelText('Link £50.00 transfer')).toBeChecked();
+    expect(screen.getByText('2 of 3 selected')).toBeInTheDocument();
+  });
+});
+
+describe('TransferSweepModal — sorting the stranded list', () => {
+  beforeEach(() => {
+    __setAppContextValue({ transactions: STRANDED_SORT_HISTORY, categories: SORT_CATEGORIES });
+  });
+
+  it('opens oldest-first, exactly as the classifier emits them', () => {
+    renderModal();
+
+    expect(strandedOrder()).toEqual(['£75.00', '£200.00', '£1000.00']);
+    expect(screen.getByRole('button', { name: 'Date ↑' })).toBeInTheDocument();
+  });
+
+  it('flips Date to newest-first on a click', () => {
+    renderModal();
+
+    fireEvent.click(screen.getByRole('button', { name: /^Date/ }));
+
+    expect(strandedOrder()).toEqual(['£1000.00', '£200.00', '£75.00']);
+    expect(screen.getByRole('button', { name: 'Date ↓' })).toBeInTheDocument();
+  });
+
+  it('sorts Account by the resolved account name', () => {
+    renderModal();
+
+    fireEvent.click(screen.getByRole('button', { name: /^Account/ }));
+
+    // Credit card, Current account, Joint account.
+    expect(strandedOrder()).toEqual(['£75.00', '£1000.00', '£200.00']);
+  });
+
+  it('sorts "What is wrong" by the badge each row shows', () => {
+    renderModal();
+
+    fireEvent.click(screen.getByRole('button', { name: /^What is wrong/ }));
+
+    // filed, no other side, taken.
+    expect(strandedOrder()).toEqual(['£1000.00', '£75.00', '£200.00']);
+  });
+
+  it('sorts Amount by magnitude, biggest first', () => {
+    renderModal();
+
+    fireEvent.click(screen.getByRole('button', { name: /^Amount/ }));
+
+    expect(strandedOrder()).toEqual(['£1000.00', '£200.00', '£75.00']);
   });
 });
 

--- a/src/components/TransferSweepModal.tsx
+++ b/src/components/TransferSweepModal.tsx
@@ -37,6 +37,13 @@ interface Props {
 const CAP = 300;
 const STRANDED_CAP = 100;
 
+type PairSortKey = 'date' | 'accounts' | 'description' | 'amount';
+type StrandedSortKey = 'date' | 'account' | 'problem' | 'amount';
+
+/** Case-insensitive, so "BARCLAYS" and "Barclays" sit together, not in two blocks. */
+const compareText = (a: string, b: string): number =>
+  a.localeCompare(b, undefined, { sensitivity: 'base' });
+
 /** The one-line summary of a finding, in the list. */
 function strandedSummary(finding: StrandedFinding, accountName: (id: string) => string): string {
   const days = (n: number): string => `${Math.round(n)} day${Math.round(n) === 1 ? '' : 's'}`;
@@ -104,6 +111,53 @@ const STRANDED_DONE: Record<StrandedFinding['kind'], string> = {
   'one-sided': 'Filed as Account Adjustment — neither income nor spending.',
 };
 
+/** Both account names, in the order the "From → To" cell reads them. */
+function pairRoute(s: TransferPairSuggestion, accountName: (id: string) => string): string {
+  return `${accountName(s.outgoing.accountId)} → ${accountName(s.incoming.accountId)}`;
+}
+
+/** Ascending by the given column; the caller applies the direction. */
+function comparePairs(
+  a: TransferPairSuggestion,
+  b: TransferPairSuggestion,
+  key: PairSortKey,
+  accountName: (id: string) => string
+): number {
+  switch (key) {
+    case 'accounts':
+      return compareText(pairRoute(a, accountName), pairRoute(b, accountName));
+    case 'description':
+      return compareText(a.outgoing.description, b.outgoing.description);
+    // Magnitude: the two legs are equal and opposite, so the sign carries no
+    // information here — only the size of the movement does.
+    case 'amount':
+      return Math.abs(a.outgoing.amount) - Math.abs(b.outgoing.amount);
+    case 'date':
+      return new Date(a.outgoing.date).getTime() - new Date(b.outgoing.date).getTime();
+  }
+}
+
+/** Ascending by the given column; the caller applies the direction. */
+function compareFindings(
+  a: StrandedFinding,
+  b: StrandedFinding,
+  key: StrandedSortKey,
+  accountName: (id: string) => string
+): number {
+  switch (key) {
+    case 'account':
+      return compareText(accountName(a.row.accountId), accountName(b.row.accountId));
+    // By the badge the row actually shows — duplicate / taken / filed / no
+    // other side — so the column sorts by what the user can read in it.
+    case 'problem':
+      return compareText(STRANDED_BADGES[a.kind], STRANDED_BADGES[b.kind]);
+    case 'amount':
+      return Math.abs(a.row.amount) - Math.abs(b.row.amount);
+    case 'date':
+      return new Date(a.row.date).getTime() - new Date(b.row.date).getTime();
+  }
+}
+
 export default function TransferSweepModal({ isOpen, onClose }: Props): React.JSX.Element {
   const {
     transactions, categories, accounts, linkTransferPair,
@@ -130,6 +184,17 @@ export default function TransferSweepModal({ isOpen, onClose }: Props): React.JS
   // just with the reopen offered where the user actually needs it.
   const [reopenPrompt, setReopenPrompt] = useState<{ accountId: string; txnId: string } | null>(null);
   const [reopening, setReopening] = useState(false);
+  // The clean-pair table starts UNSORTED. The sweep emits its own pairing
+  // order and no column reproduces it: the Date cell shows the OUTGOING leg,
+  // while the sweep ordered by whichever leg it reached first, and a pair's
+  // two legs can fall on different days. So "as the sweep found them" is a
+  // state of its own — nothing moves until a heading is clicked.
+  const [pairSortKey, setPairSortKey] = useState<PairSortKey | null>(null);
+  const [pairSortDir, setPairSortDir] = useState<1 | -1>(1);
+  // The stranded classifier already emits oldest-first, so Date ascending IS
+  // today's order — and Array#sort is stable, so its id tie-break survives.
+  const [strandedSortKey, setStrandedSortKey] = useState<StrandedSortKey>('date');
+  const [strandedSortDir, setStrandedSortDir] = useState<1 | -1>(1);
 
   // Closed accounts included — old transfers routinely have one leg in an
   // account that has since been closed.
@@ -171,11 +236,42 @@ export default function TransferSweepModal({ isOpen, onClose }: Props): React.JS
     setSelected(next);
   };
 
-  const visible = suggestions.slice(0, CAP);
+  const sortPairsBy = (key: PairSortKey): void => {
+    if (pairSortKey === key) {
+      setPairSortDir(d => (d === 1 ? -1 : 1));
+    } else {
+      setPairSortKey(key);
+      setPairSortDir(key === 'date' || key === 'amount' ? -1 : 1);
+    }
+  };
+  const pairArrow = (key: PairSortKey): string =>
+    pairSortKey === key ? (pairSortDir === 1 ? ' ↑' : ' ↓') : '';
+
+  const sortStrandedBy = (key: StrandedSortKey): void => {
+    if (strandedSortKey === key) {
+      setStrandedSortDir(d => (d === 1 ? -1 : 1));
+    } else {
+      setStrandedSortKey(key);
+      setStrandedSortDir(key === 'date' || key === 'amount' ? -1 : 1);
+    }
+  };
+  const strandedArrow = (key: StrandedSortKey): string =>
+    strandedSortKey === key ? (strandedSortDir === 1 ? ' ↑' : ' ↓') : '';
+
+  // The cap is applied FIRST and the sort second, so "the first 300 the sweep
+  // found" goes on meaning exactly that whichever column is sorted by. Row
+  // order is presentation only: selection is keyed by the pair's two ids, and
+  // both `effectiveSelected` and `chosen` read the unsorted list.
+  const pairPage = suggestions.slice(0, CAP);
+  const visible = pairSortKey === null
+    ? pairPage
+    : [...pairPage].sort((a, b) => pairSortDir * comparePairs(a, b, pairSortKey, accountName));
   const chosen = suggestions.filter(s => effectiveSelected.has(keyOf(s)));
 
   const liveFindings = findings.filter(f => !dismissed.has(keyOfFinding(f)));
-  const visibleFindings = liveFindings.slice(0, STRANDED_CAP);
+  const visibleFindings = liveFindings.slice(0, STRANDED_CAP).sort(
+    (a, b) => strandedSortDir * compareFindings(a, b, strandedSortKey, accountName)
+  );
   /** The adjustment filing is the ONLY offer for these two kinds — without the category they cannot run. */
   const needsAdjustmentCategory = (f: StrandedFinding): boolean =>
     f.kind === 'claimed' || f.kind === 'one-sided';
@@ -319,10 +415,23 @@ export default function TransferSweepModal({ isOpen, onClose }: Props): React.JS
                 <thead>
                   <tr className="text-xs text-gray-500 dark:text-gray-400 border-b border-gray-100 dark:border-gray-700">
                     <th className="pb-2 w-8"></th>
-                    <th className="text-left pb-2 font-medium">Date</th>
-                    <th className="text-left pb-2 font-medium">From → To</th>
-                    <th className="text-left pb-2 font-medium">Description</th>
-                    <th className="text-right pb-2 font-medium">Amount</th>
+                    {([
+                      ['date', 'Date', 'text-center', 'Sort by date'],
+                      ['accounts', 'From → To', 'text-center', 'Sort by account names'],
+                      ['description', 'Description', 'text-center', 'Sort by description'],
+                      ['amount', 'Amount', 'text-center', 'Sort by amount size'],
+                    ] as const).map(([key, label, align, hint]) => (
+                      <th key={key} className={`${align} pb-2 font-medium`}>
+                        <button
+                          type="button"
+                          onClick={() => sortPairsBy(key)}
+                          className="hover:text-gray-800 dark:hover:text-gray-200 transition-colors"
+                          title={hint}
+                        >
+                          {label}{pairArrow(key)}
+                        </button>
+                      </th>
+                    ))}
                   </tr>
                 </thead>
                 <tbody>
@@ -423,10 +532,23 @@ export default function TransferSweepModal({ isOpen, onClose }: Props): React.JS
               <table className="w-full">
                 <thead>
                   <tr className="text-xs text-gray-500 dark:text-gray-400 border-b border-gray-100 dark:border-gray-700">
-                    <th className="text-left pb-2 font-medium">Date</th>
-                    <th className="text-left pb-2 font-medium">Account</th>
-                    <th className="text-left pb-2 font-medium">What is wrong</th>
-                    <th className="text-right pb-2 font-medium">Amount</th>
+                    {([
+                      ['date', 'Date', 'text-center', 'Sort by date'],
+                      ['account', 'Account', 'text-center', 'Sort by account name'],
+                      ['problem', 'What is wrong', 'text-center', 'Sort by what is wrong'],
+                      ['amount', 'Amount', 'text-center', 'Sort by amount size'],
+                    ] as const).map(([key, label, align, hint]) => (
+                      <th key={key} className={`${align} pb-2 font-medium`}>
+                        <button
+                          type="button"
+                          onClick={() => sortStrandedBy(key)}
+                          className="hover:text-gray-800 dark:hover:text-gray-200 transition-colors"
+                          title={hint}
+                        >
+                          {label}{strandedArrow(key)}
+                        </button>
+                      </th>
+                    ))}
                     <th className="pb-2 w-24"></th>
                   </tr>
                 </thead>

--- a/src/components/common/GroupedAccountSelect.test.tsx
+++ b/src/components/common/GroupedAccountSelect.test.tsx
@@ -1,0 +1,223 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import GroupedAccountSelect, { GroupedAccountOptions } from './GroupedAccountSelect';
+
+/**
+ * The one account dropdown, pinned: sections in the Accounts page's order,
+ * alphabetical inside each, empty sections absent — and every call site's own
+ * wording (labels, placeholder) still its own.
+ */
+
+interface TestAccount {
+  id: string;
+  name: string;
+  type: string;
+  balance: number;
+}
+
+const account = (id: string, name: string, type: string, balance = 0): TestAccount =>
+  ({ id, name, type, balance });
+
+const select = (): HTMLSelectElement => screen.getByLabelText<HTMLSelectElement>('Account');
+
+const sectionLabels = (): string[] =>
+  Array.from(select().querySelectorAll('optgroup')).map(group => group.label);
+
+/** Option text in render order, placeholder included. */
+const optionTexts = (): string[] =>
+  Array.from(select().querySelectorAll('option')).map(option => option.textContent ?? '');
+
+/** Option text under one section heading. */
+const optionsInSection = (label: string): string[] => {
+  const group = Array.from(select().querySelectorAll('optgroup')).find(g => g.label === label);
+  return group ? Array.from(group.querySelectorAll('option')).map(o => o.textContent ?? '') : [];
+};
+
+const mixedAccounts: TestAccount[] = [
+  account('a1', 'Zebra Savings', 'savings'),
+  account('a2', 'Barclaycard', 'credit'),
+  account('a3', 'Halifax Current', 'current'),
+  account('a4', 'Alpha Savings', 'savings'),
+  account('a5', 'Abbey Current', 'checking'),
+];
+
+describe('GroupedAccountSelect', () => {
+  it('bands options into the Accounts page sections, in page order', () => {
+    render(
+      <GroupedAccountSelect
+        aria-label="Account"
+        accounts={mixedAccounts}
+        value=""
+        onChange={vi.fn()}
+      />
+    );
+
+    expect(sectionLabels()).toEqual(['Current Accounts', 'Savings Accounts', 'Credit Cards']);
+  });
+
+  it('sorts alphabetically inside a section, case-insensitively', () => {
+    render(
+      <GroupedAccountSelect
+        aria-label="Account"
+        accounts={[
+          account('a1', 'zebra current', 'current'),
+          account('a2', 'Alpha Current', 'current'),
+          account('a3', 'beta current', 'current'),
+        ]}
+        value=""
+        onChange={vi.fn()}
+      />
+    );
+
+    expect(optionsInSection('Current Accounts')).toEqual([
+      'Alpha Current', 'beta current', 'zebra current',
+    ]);
+  });
+
+  it('omits sections nothing files under rather than printing bare headings', () => {
+    render(
+      <GroupedAccountSelect
+        aria-label="Account"
+        accounts={[account('a1', 'Solo Investment', 'investment')]}
+        value=""
+        onChange={vi.fn()}
+      />
+    );
+
+    expect(sectionLabels()).toEqual(['Investments']);
+  });
+
+  it('files a type with no section of its own under the catch-all, last', () => {
+    render(
+      <GroupedAccountSelect
+        aria-label="Account"
+        accounts={[
+          account('a1', 'Hoverboard Fund', 'hoverboard'),
+          account('a2', 'Halifax Current', 'current'),
+        ]}
+        value=""
+        onChange={vi.fn()}
+      />
+    );
+
+    expect(sectionLabels()).toEqual(['Current Accounts', 'Other Accounts']);
+  });
+
+  it('prints the caller’s own option wording when it passes a formatter', () => {
+    render(
+      <GroupedAccountSelect
+        aria-label="Account"
+        accounts={[account('a1', 'Halifax Current', 'current', 1234.5)]}
+        value=""
+        onChange={vi.fn()}
+        formatLabel={(acc) => `${acc.name} (£${acc.balance.toFixed(2)})`}
+      />
+    );
+
+    expect(optionsInSection('Current Accounts')).toEqual(['Halifax Current (£1234.50)']);
+  });
+
+  it('names the account when no formatter is given', () => {
+    render(
+      <GroupedAccountSelect
+        aria-label="Account"
+        accounts={[account('a1', 'Halifax Current', 'current', 1234.5)]}
+        value=""
+        onChange={vi.fn()}
+      />
+    );
+
+    expect(optionsInSection('Current Accounts')).toEqual(['Halifax Current']);
+  });
+
+  it('leads with the placeholder when one is given, and with nothing when not', () => {
+    const { unmount } = render(
+      <GroupedAccountSelect
+        aria-label="Account"
+        accounts={[account('a1', 'Halifax Current', 'current')]}
+        value=""
+        onChange={vi.fn()}
+        placeholder="Select account"
+      />
+    );
+    expect(optionTexts()).toEqual(['Select account', 'Halifax Current']);
+    unmount();
+
+    render(
+      <GroupedAccountSelect
+        aria-label="Account"
+        accounts={[account('a1', 'Halifax Current', 'current')]}
+        value=""
+        onChange={vi.fn()}
+      />
+    );
+    expect(optionTexts()).toEqual(['Halifax Current']);
+  });
+
+  it('reports the chosen account id, not the event', () => {
+    const onChange = vi.fn();
+    render(
+      <GroupedAccountSelect
+        aria-label="Account"
+        accounts={mixedAccounts}
+        value=""
+        onChange={onChange}
+        placeholder="Select account"
+      />
+    );
+
+    fireEvent.change(select(), { target: { value: 'a2' } });
+
+    expect(onChange).toHaveBeenCalledWith('a2');
+  });
+
+  it('shows the selected account, however the sections reorder it', () => {
+    render(
+      <GroupedAccountSelect
+        aria-label="Account"
+        accounts={mixedAccounts}
+        value="a1"
+        onChange={vi.fn()}
+        placeholder="Select account"
+      />
+    );
+
+    expect(select().value).toBe('a1');
+  });
+
+  it('passes the call site’s own select attributes straight through', () => {
+    render(
+      <GroupedAccountSelect
+        id="account-select"
+        aria-label="Account"
+        aria-describedby="account-error"
+        className="house-styling"
+        required
+        disabled
+        accounts={[account('a1', 'Halifax Current', 'current')]}
+        value=""
+        onChange={vi.fn()}
+      />
+    );
+
+    const field = select();
+    expect(field.id).toBe('account-select');
+    expect(field).toBeRequired();
+    expect(field).toBeDisabled();
+    expect(field).toHaveClass('house-styling');
+    expect(field).toHaveAttribute('aria-describedby', 'account-error');
+  });
+});
+
+describe('GroupedAccountOptions', () => {
+  it('groups the options of a select it does not own (the multi-select filter)', () => {
+    render(
+      <select aria-label="Account" multiple size={3} defaultValue={[]}>
+        <GroupedAccountOptions accounts={mixedAccounts} />
+      </select>
+    );
+
+    expect(sectionLabels()).toEqual(['Current Accounts', 'Savings Accounts', 'Credit Cards']);
+    expect(optionsInSection('Savings Accounts')).toEqual(['Alpha Savings', 'Zebra Savings']);
+  });
+});

--- a/src/components/common/GroupedAccountSelect.tsx
+++ b/src/components/common/GroupedAccountSelect.tsx
@@ -1,0 +1,88 @@
+import { useMemo, type SelectHTMLAttributes } from 'react';
+import { groupAccountsBySection, type GroupableAccount } from '../../utils/accountGrouping';
+
+/**
+ * The one account dropdown. Every place that asks "which account?" bands its
+ * options into the Accounts page's own sections (Current, Savings, Credit
+ * Cards…), alphabetical inside each, empty sections omitted — because a flat
+ * list of seventy accounts in insertion order is not a picker, it is a search.
+ *
+ * The sections come from `accountGrouping`, so a dropdown and the Accounts
+ * page can never disagree about where an account belongs.
+ */
+
+/** What an option needs: an id to carry as the value, plus what groups it. */
+export interface SelectableAccount extends GroupableAccount {
+  id: string;
+}
+
+/**
+ * Everything a caller can still hand the underlying <select>. Grouping owns
+ * the children; value/onChange are narrowed to the account id; `multiple` is
+ * excluded because this component is single-select — a multi-select list can
+ * still reuse the grouping via <GroupedAccountOptions>.
+ */
+type PassThroughSelectProps = Omit<
+  SelectHTMLAttributes<HTMLSelectElement>,
+  'value' | 'defaultValue' | 'onChange' | 'children' | 'multiple'
+>;
+
+interface GroupedAccountOptionsProps<T extends SelectableAccount> {
+  accounts: readonly T[];
+  /** Option text. Defaults to the account name; call sites that print a
+      balance or a type pass their own so their wording is unchanged. */
+  formatLabel?: (account: T) => string;
+}
+
+/** The grouped <optgroup>/<option> block, for a select this component can't own. */
+export function GroupedAccountOptions<T extends SelectableAccount>({
+  accounts,
+  formatLabel
+}: GroupedAccountOptionsProps<T>): React.JSX.Element {
+  const sections = useMemo(() => groupAccountsBySection(accounts), [accounts]);
+  return (
+    <>
+      {sections.map(section => (
+        <optgroup key={section.label} label={section.title}>
+          {section.accounts.map(account => (
+            <option key={account.id} value={account.id}>
+              {formatLabel ? formatLabel(account) : account.name}
+            </option>
+          ))}
+        </optgroup>
+      ))}
+    </>
+  );
+}
+
+export interface GroupedAccountSelectProps<T extends SelectableAccount>
+  extends PassThroughSelectProps {
+  /** Already filtered by the caller — this component only orders and bands. */
+  accounts: readonly T[];
+  /** The selected account id, or '' for the placeholder. */
+  value: string;
+  onChange: (accountId: string) => void;
+  /** Leading empty-value option ("Select account"). Omitted when unset. */
+  placeholder?: string;
+  formatLabel?: (account: T) => string;
+}
+
+export default function GroupedAccountSelect<T extends SelectableAccount>({
+  accounts,
+  value,
+  onChange,
+  placeholder,
+  formatLabel,
+  ...selectProps
+}: GroupedAccountSelectProps<T>): React.JSX.Element {
+  return (
+    <select
+      {...selectProps}
+      value={value}
+      onChange={(event) => onChange(event.target.value)}
+    >
+      {placeholder !== undefined && <option value="">{placeholder}</option>}
+      <GroupedAccountOptions accounts={accounts} formatLabel={formatLabel} />
+    </select>
+  );
+}

--- a/src/components/pwa/OfflineTransactionForm.tsx
+++ b/src/components/pwa/OfflineTransactionForm.tsx
@@ -9,6 +9,7 @@ import { useCategories } from '../../contexts/CategoryContext';
 import { useAccounts } from '../../contexts/AccountContext';
 import { formatCurrency } from '../../utils/formatters';
 import MoneyInput from '../common/MoneyInput';
+import GroupedAccountSelect from '../common/GroupedAccountSelect';
 import { toDecimal, parseMoneyInput } from '../../utils/decimal';
 import { 
   WifiOffIcon, 
@@ -251,19 +252,15 @@ export const OfflineTransactionForm: React.FC<OfflineTransactionFormProps> = ({
               <label className="block text-sm font-medium mb-1">
                 Account <span className="text-red-500">*</span>
               </label>
-              <select
+              <GroupedAccountSelect
+                accounts={accounts}
                 value={formData.accountId}
-                onChange={(e) => setFormData({ ...formData, accountId: e.target.value })}
+                onChange={(accountId) => setFormData({ ...formData, accountId })}
+                placeholder="Select an account"
+                formatLabel={(account) => `${account.name} (${formatCurrency(account.balance)})`}
                 className="w-full px-3 py-2 border rounded-lg dark:bg-gray-700 dark:border-gray-600"
                 required
-              >
-                <option value="">Select an account</option>
-                {accounts.map((account) => (
-                  <option key={account.id} value={account.id}>
-                    {account.name} ({formatCurrency(account.balance)})
-                  </option>
-                ))}
-              </select>
+              />
             </div>
 
             {/* Notes */}

--- a/src/contexts/AppContextSupabase.tsx
+++ b/src/contexts/AppContextSupabase.tsx
@@ -31,6 +31,7 @@ import type {
   TransactionSplit,
   TransactionSplitInput,
   Category,
+  CategoryMergeResult,
   Budget,
   Goal,
   RecurringTransaction,
@@ -84,6 +85,14 @@ export interface AppContextType extends AppState {
   ) => Promise<{ created: number; skipped: number; pruned: number; keptForTransactions: number }>;
   updateCategory: (id: string, updates: Partial<Category>) => Promise<void>;
   deleteCategory: (id: string) => Promise<void>;
+  /**
+   * Join two categories: every reference (transactions, split lines, budgets,
+   * recurring templates) moves from `sourceId` to `targetId` and the source is
+   * removed — all in ONE server-side transaction, so it either happens or it
+   * does not. Balance-neutral. Returns what actually moved, as the database
+   * counted it.
+   */
+  mergeCategories: (sourceId: string, targetId: string) => Promise<CategoryMergeResult>;
   getSubCategories: (parentId: string) => Category[];
   getDetailCategories: (parentId: string) => Category[];
   
@@ -1122,6 +1131,45 @@ export function AppProvider({ children }: { children: React.ReactNode }) {
     }
   }, []);
 
+  const mergeCategories = useCallback(async (sourceId: string, targetId: string) => {
+    try {
+      const result = await DataService.mergeCategories(sourceId, targetId);
+
+      // Mirror exactly what the merge moved. Balance-neutral throughout: not
+      // one amount, sign or account changes, so no account is touched.
+      setTransactions(prev => prev.map(t =>
+        t.category === sourceId ? { ...t, category: targetId } : t
+      ));
+      setTransactionSplitsState(prev => prev.map(s =>
+        s.category === sourceId ? { ...s, category: targetId } : s
+      ));
+      setBudgets(prev => prev.map(b =>
+        b.categoryId === sourceId ? { ...b, categoryId: targetId } : b
+      ));
+      setRecurringTransactions(prev => prev.map(r =>
+        r.category === sourceId ? { ...r, category: targetId } : r
+      ));
+      setCategories(prev => prev.filter(c => c.id !== sourceId));
+
+      // Import rules are the one place a category id is stored in THIS browser
+      // rather than the database, so they cannot join the merge's transaction —
+      // they follow it immediately instead. Loaded on demand so the rules
+      // engine stays out of the boot bundle. A failure here costs a stale rule,
+      // never the merge: the history is already joined and correct.
+      try {
+        const { importRulesService } = await import('../services/importRulesService');
+        importRulesService.remapCategory(sourceId, targetId);
+      } catch (rulesError) {
+        appLogger.error('Failed to re-point import rules after a category merge', rulesError);
+      }
+
+      return result;
+    } catch (error) {
+      appLogger.error('Failed to merge categories', error);
+      throw error;
+    }
+  }, []);
+
   const deleteCategory = useCallback(async (id: string) => {
     try {
       await PlanningService.deleteCategory(userIdService.getCurrentDatabaseUserId(), id);
@@ -1289,6 +1337,7 @@ export function AppProvider({ children }: { children: React.ReactNode }) {
     importCategoryTree,
     updateCategory,
     deleteCategory,
+    mergeCategories,
     getSubCategories,
     getDetailCategories,
     

--- a/src/pages/AccountTransactions.tsx
+++ b/src/pages/AccountTransactions.tsx
@@ -18,7 +18,7 @@ import { compareTransactions } from '../utils/transactionSort';
 import { orderColumnKeys, moveColumnKey } from '../utils/columnLayout';
 import { computeArchiveWindow, ARCHIVE_PRESETS, type ArchiveRange } from '../utils/archiveRange';
 import { effectiveOpeningDate, findSiblingAccount } from '../utils/openingDates';
-import { groupAccountsBySection } from '../utils/accountGrouping';
+import GroupedAccountSelect from '../components/common/GroupedAccountSelect';
 import type { Transaction } from '../types';
 
 type TransactionWithBalance = Transaction & { balance: number };
@@ -494,26 +494,33 @@ export default function AccountTransactions() {
     [transactionsWithBalance, selectedTransactionId]
   );
 
-  // Transfer targets for the quick-add dock, banded into the same sections the
-  // Accounts page uses. Which accounts are offered is unchanged — every account
-  // but this one — only the order they read in.
-  const transferTargetSections = useMemo(
-    () => groupAccountsBySection(accounts.filter(acc => acc.id !== account?.id)),
+  // Transfer targets for the quick-add dock: every account but this one. The
+  // select bands them into the Accounts page's sections.
+  const transferTargets = useMemo(
+    () => accounts.filter(acc => acc.id !== account?.id),
     [accounts, account?.id]
   );
 
   // Clicking the page background deselects: the row un-highlights and the
   // bottom dock flips back from Quick Edit to Quick Add. Clicks inside the
   // table, the dock, or any dialog keep the selection.
+  //
+  // NEVER while the edit modal is open: the modal only renders while a row is
+  // selected, and its pickers (category, tags, date) render their menus in
+  // PORTALS on document.body — outside the dialog subtree — so a click on a
+  // category option used to deselect, unmount the modal mid-click, and dump
+  // the user back on the register with nothing saved. The listbox guard keeps
+  // the selection for any other portaled picker menu (the dock's, say) too.
   useEffect(() => {
-    if (!selectedTransactionId) return;
+    if (!selectedTransactionId || isEditModalOpen) return;
     const handlePointerDown = (e: MouseEvent) => {
       const target = e.target as HTMLElement | null;
       if (!target) return;
       if (
         target.closest('[data-transaction-table]') ||
         target.closest('[data-quick-edit-panel]') ||
-        target.closest('[role="dialog"]')
+        target.closest('[role="dialog"]') ||
+        target.closest('[role="listbox"]')
       ) {
         return;
       }
@@ -523,7 +530,7 @@ export default function AccountTransactions() {
     };
     document.addEventListener('mousedown', handlePointerDown);
     return () => document.removeEventListener('mousedown', handlePointerDown);
-  }, [selectedTransactionId]);
+  }, [selectedTransactionId, isEditModalOpen]);
 
   // Next non-summary row below the given one in the CURRENT visible order —
   // powers "Save & Next" in both the quick-edit panel and the full modal.
@@ -1374,22 +1381,14 @@ export default function AccountTransactions() {
                 {quickAddForm.type === 'transfer' ? 'To Account' : 'Category'}
               </label>
               {quickAddForm.type === 'transfer' ? (
-                <select
+                <GroupedAccountSelect
+                  accounts={transferTargets}
                   value={quickAddForm.category}
-                  onChange={(e) => { setQuickAddError(''); setQuickAddForm({ ...quickAddForm, category: e.target.value }); }}
+                  onChange={(accountId) => { setQuickAddError(''); setQuickAddForm({ ...quickAddForm, category: accountId }); }}
+                  placeholder="Select account..."
+                  formatLabel={(acc) => `${acc.name} (${formatCurrency(acc.balance)})`}
                   className="w-full px-2.5 py-1.5 h-auto sm:h-[32px] text-xs bg-white dark:bg-gray-700 border border-gray-300 dark:border-gray-600 rounded-lg focus:outline-none focus:ring-1 focus:ring-primary dark:text-white"
-                >
-                  <option value="">Select account...</option>
-                  {transferTargetSections.map(group => (
-                    <optgroup key={group.label} label={group.title}>
-                      {group.accounts.map(acc => (
-                        <option key={acc.id} value={acc.id}>
-                          {acc.name} ({formatCurrency(acc.balance)})
-                        </option>
-                      ))}
-                    </optgroup>
-                  ))}
-                </select>
+                />
               ) : (
                 /* Which direction's tree it lists is this row's own, flipped by
                    the cross-type checkbox below — the same control the edit

--- a/src/pages/settings/Categories.merge.test.tsx
+++ b/src/pages/settings/Categories.merge.test.tsx
@@ -1,0 +1,337 @@
+/**
+ * Settings → Categories: the category MERGE.
+ *
+ * Covers the things the service tests cannot see: that the affordance exists
+ * and is reachable, that a category which cannot be merged says so instead of
+ * quietly doing nothing, that the confirmation spells out the consequence with
+ * REAL counts before anything happens, and that confirming calls the one
+ * atomic operation with the right two categories.
+ *
+ * Also pins the fix to the older "Delete & Reassign" flow: a category used only
+ * by a BUDGET must still route through reassignment (deleting it outright left
+ * that budget pointing at an id that no longer existed, silently reporting £0
+ * spent for ever after), and that flow now runs through the same merge.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, fireEvent, cleanup, waitFor, within } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import CategoriesSettings from './Categories';
+import { __setAppContextValue, __resetAppContextValue } from '../../test/mocks/AppContextSupabase';
+import type { Budget, Category, Transaction, TransactionSplit } from '../../types';
+
+const toast = vi.hoisted(() => ({
+  showSuccess: vi.fn(),
+  showError: vi.fn(),
+  showWarning: vi.fn(),
+  showInfo: vi.fn(),
+  showToast: vi.fn(),
+  dismissToast: vi.fn(),
+}));
+
+vi.mock('../../contexts/ToastContext', () => ({ useToast: () => toast }));
+
+vi.mock('../../hooks/useCurrencyDecimal', () => ({
+  useCurrencyDecimal: () => ({
+    formatCurrency: (amount: number) => `£${Math.abs(amount).toFixed(2)}`,
+    displayCurrency: 'GBP',
+    getCurrencySymbol: () => '£',
+    convert: vi.fn(),
+    convertAndFormat: vi.fn(),
+    convertAndSum: vi.fn(),
+  }),
+}));
+
+const SOURCE = 'cat-food-shopping';
+const TARGET = 'cat-groceries';
+
+const CATEGORIES: Category[] = [
+  { id: 'type-income', name: 'Income', type: 'income', level: 'type', isSystem: true },
+  { id: 'type-expense', name: 'Expenses', type: 'expense', level: 'type', isSystem: true },
+  { id: 'type-transfer', name: 'Transfer', type: 'both', level: 'type', isSystem: true },
+  { id: 'sub-food', name: 'Food', type: 'expense', level: 'sub', parentId: 'type-expense' },
+  { id: SOURCE, name: 'Food Shopping', type: 'expense', level: 'detail', parentId: 'sub-food' },
+  { id: TARGET, name: 'Groceries', type: 'expense', level: 'detail', parentId: 'sub-food' },
+  {
+    id: 'transfer-joint', name: 'To/From Joint', type: 'both', level: 'detail',
+    parentId: 'type-transfer', isTransferCategory: true,
+  },
+];
+
+const txn = (over: Partial<Transaction> & { id: string }): Transaction => ({
+  date: new Date('2026-05-01'),
+  amount: -20,
+  description: 'Tesco',
+  category: SOURCE,
+  accountId: 'acc-current',
+  type: 'expense',
+  ...over,
+});
+
+/** Three whole rows, one split line inside a fourth, and one budget. */
+const TRANSACTIONS: Transaction[] = [
+  txn({ id: 'txn-a' }),
+  txn({ id: 'txn-b' }),
+  txn({ id: 'txn-c' }),
+  txn({ id: 'txn-split', category: '', isSplit: true, amount: -60 }),
+  txn({ id: 'txn-elsewhere', category: TARGET }),
+];
+
+const SPLITS: TransactionSplit[] = [
+  { id: 's1', transactionId: 'txn-split', category: SOURCE, amount: -40, sortOrder: 1 },
+  { id: 's2', transactionId: 'txn-split', category: TARGET, amount: -20, sortOrder: 2 },
+];
+
+const BUDGETS: Budget[] = [
+  {
+    id: 'bud-1', categoryId: SOURCE, amount: 400, period: 'monthly', isActive: true,
+    spent: 0, createdAt: new Date('2026-01-01'), updatedAt: new Date('2026-01-01'),
+  },
+];
+
+const mergeCategories = vi.fn(async (sourceId: string, targetId: string) => ({
+  sourceId,
+  targetId,
+  transactions: 3,
+  splitLines: 1,
+  splitTransactions: 1,
+  budgets: 1,
+  recurring: 0,
+}));
+
+const deleteCategory = vi.fn();
+
+const setup = (overrides: Record<string, unknown> = {}): void => {
+  __setAppContextValue({
+    categories: CATEGORIES,
+    transactions: TRANSACTIONS,
+    transactionSplits: SPLITS,
+    budgets: BUDGETS,
+    getSubCategories: (parentId?: string) => CATEGORIES.filter(c => c.parentId === parentId),
+    getDetailCategories: (parentId?: string) => CATEGORIES.filter(c => c.parentId === parentId),
+    mergeCategories,
+    deleteCategory,
+    ...overrides,
+  });
+  render(<MemoryRouter><CategoriesSettings /></MemoryRouter>);
+};
+
+/** Edit mode → Merge mode → expand Food, so the detail rows are on screen. */
+const enterMergeMode = (): void => {
+  fireEvent.click(screen.getByTitle('Edit Categories'));
+  fireEvent.click(screen.getByTitle('Merge Categories'));
+  fireEvent.click(screen.getByLabelText('Expand Food'));
+};
+
+/** Pick a target inside the dialog's category picker. */
+const chooseTarget = (name: string): void => {
+  const dialog = screen.getByRole('dialog');
+  fireEvent.click(within(dialog).getByRole('combobox'));
+  fireEvent.click(screen.getByRole('option', { name }));
+};
+
+const flatten = (text: string | null | undefined): string =>
+  (text ?? '').replace(/\s+/g, ' ').trim();
+
+describe('Categories settings — merge', () => {
+  beforeEach(() => {
+    mergeCategories.mockClear();
+    deleteCategory.mockClear();
+    Object.values(toast).forEach(fn => fn.mockClear());
+  });
+
+  afterEach(() => {
+    cleanup();
+    __resetAppContextValue();
+  });
+
+  it('offers merge only inside edit mode', () => {
+    setup();
+    expect(screen.queryByTitle('Merge Categories')).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByTitle('Edit Categories'));
+    expect(screen.getByTitle('Merge Categories')).toBeInTheDocument();
+  });
+
+  it('opens the merge dialog for a detail category', () => {
+    setup();
+    enterMergeMode();
+
+    fireEvent.click(screen.getByTitle('Merge "Food Shopping" into another category'));
+
+    const dialog = screen.getByRole('dialog');
+    expect(within(dialog).getByRole('heading', { name: 'Merge Category' })).toBeInTheDocument();
+    expect(flatten(dialog.textContent)).toContain(
+      'Everything filed under “Food Shopping” moves to the category you choose, and “Food Shopping” is then removed.'
+    );
+  });
+
+  it('spells out exactly what moves, with real counts, before anything happens', () => {
+    setup();
+    enterMergeMode();
+    fireEvent.click(screen.getByTitle('Merge "Food Shopping" into another category'));
+
+    // Nothing is claimed until a target is named.
+    expect(flatten(screen.getByRole('dialog').textContent)).not.toContain('move to');
+
+    chooseTarget('Groceries');
+
+    expect(flatten(screen.getByRole('dialog').textContent)).toContain(
+      '3 transactions, 1 split line and 1 budget move to “Groceries”; “Food Shopping” is then removed. ' +
+      'Payee memory and future imports follow “Groceries”.'
+    );
+    expect(mergeCategories).not.toHaveBeenCalled();
+  });
+
+  it('says nothing about counts that are zero', () => {
+    setup({ transactions: [txn({ id: 'txn-elsewhere', category: TARGET })], transactionSplits: [], budgets: [] });
+    enterMergeMode();
+    fireEvent.click(screen.getByTitle('Merge "Food Shopping" into another category'));
+    chooseTarget('Groceries');
+
+    const text = flatten(screen.getByRole('dialog').textContent);
+    expect(text).toContain('Nothing is filed under “Food Shopping”, so it is simply removed.');
+    expect(text).not.toContain('0 transactions');
+  });
+
+  it('cannot be confirmed until a target is chosen', () => {
+    setup();
+    enterMergeMode();
+    fireEvent.click(screen.getByTitle('Merge "Food Shopping" into another category'));
+
+    const dialog = screen.getByRole('dialog');
+    expect(within(dialog).getByRole('button', { name: 'Merge' })).toBeDisabled();
+
+    chooseTarget('Groceries');
+    expect(within(screen.getByRole('dialog')).getByRole('button', { name: 'Merge' })).toBeEnabled();
+  });
+
+  it('confirming runs ONE merge and reports what the database moved', async () => {
+    setup();
+    enterMergeMode();
+    fireEvent.click(screen.getByTitle('Merge "Food Shopping" into another category'));
+    chooseTarget('Groceries');
+    fireEvent.click(within(screen.getByRole('dialog')).getByRole('button', { name: 'Merge' }));
+
+    await waitFor(() => expect(mergeCategories).toHaveBeenCalledTimes(1));
+    expect(mergeCategories).toHaveBeenCalledWith(SOURCE, TARGET);
+    // The old flow deleted the category as a separate step; the merge owns it.
+    expect(deleteCategory).not.toHaveBeenCalled();
+
+    await waitFor(() => expect(toast.showSuccess).toHaveBeenCalledWith(
+      '3 transactions, 1 split line and 1 budget moved from "Food Shopping" to "Groceries".',
+      'Categories merged'
+    ));
+    await waitFor(() => expect(screen.queryByRole('dialog')).not.toBeInTheDocument());
+  });
+
+  it('surfaces the database’s own refusal rather than a generic failure', async () => {
+    mergeCategories.mockRejectedValueOnce(
+      new Error('merge_direction_mismatch: "Food Shopping" is an expense category and "Salary" is an income one')
+    );
+    setup();
+    enterMergeMode();
+    fireEvent.click(screen.getByTitle('Merge "Food Shopping" into another category'));
+    chooseTarget('Groceries');
+    fireEvent.click(within(screen.getByRole('dialog')).getByRole('button', { name: 'Merge' }));
+
+    await waitFor(() => expect(toast.showError).toHaveBeenCalled());
+    expect(String(toast.showError.mock.calls[0][0])).toContain('merge_direction_mismatch');
+    // The dialog stays open so the user can pick a different target.
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+  });
+
+  describe('categories that cannot be merged explain themselves', () => {
+    it('greys out a group and says why, instead of hiding it', () => {
+      setup();
+      enterMergeMode();
+
+      const groupRow = screen.getByTitle(
+        "Merging a whole group isn't supported yet — merge the detail categories inside it instead."
+      );
+      expect(groupRow.className).toContain('cursor-not-allowed');
+      expect(groupRow.closest('.opacity-60')).not.toBeNull();
+
+      fireEvent.click(groupRow);
+
+      expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+      expect(String(toast.showError.mock.calls[0][0])).toContain('Merging a whole group');
+    });
+
+    it('greys out an account’s transfer category and points at the account', () => {
+      setup();
+      enterMergeMode();
+
+      const transferRow = screen.getByTitle(
+        'Transfer categories are managed automatically from their account. Close the account to hide it instead.'
+      );
+      fireEvent.click(transferRow);
+
+      expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+      expect(String(toast.showError.mock.calls[0][0])).toContain('Close the account');
+    });
+
+    it('leaves every row clickable again once merge mode is off', () => {
+      setup();
+      enterMergeMode();
+      fireEvent.click(screen.getByTitle('Cancel Merge'));
+
+      expect(screen.queryByTitle('Merge "Food Shopping" into another category')).not.toBeInTheDocument();
+    });
+  });
+});
+
+describe('Categories settings — delete & reassign runs through the same merge', () => {
+  beforeEach(() => {
+    mergeCategories.mockClear();
+    deleteCategory.mockClear();
+    Object.values(toast).forEach(fn => fn.mockClear());
+  });
+
+  afterEach(() => {
+    cleanup();
+    __resetAppContextValue();
+  });
+
+  const enterDeleteMode = (): void => {
+    fireEvent.click(screen.getByTitle('Edit Categories'));
+    fireEvent.click(screen.getByTitle('Delete Categories'));
+    fireEvent.click(screen.getByLabelText('Expand Food'));
+  };
+
+  it('routes a category with references through reassignment and merges in one call', async () => {
+    setup();
+    enterDeleteMode();
+
+    fireEvent.click(screen.getByText('Food Shopping'));
+
+    const dialog = screen.getByRole('dialog');
+    expect(within(dialog).getByRole('heading', { name: 'Delete Category' })).toBeInTheDocument();
+    expect(flatten(dialog.textContent)).toContain(
+      '3 transactions, 1 split line and 1 budget are filed under “Food Shopping”'
+    );
+
+    fireEvent.click(within(dialog).getByRole('combobox'));
+    fireEvent.click(screen.getByRole('option', { name: 'Groceries' }));
+    fireEvent.click(within(dialog).getByRole('button', { name: 'Delete & Reassign' }));
+
+    await waitFor(() => expect(mergeCategories).toHaveBeenCalledWith(SOURCE, TARGET));
+    // One atomic call — not a round trip per row, then a split rewrite, then a delete.
+    expect(mergeCategories).toHaveBeenCalledTimes(1);
+    expect(deleteCategory).not.toHaveBeenCalled();
+  });
+
+  it('a category used only by a BUDGET still asks where its budget should go', () => {
+    // The regression: with no transactions the old flow deleted outright, and
+    // the budget kept a dangling category id.
+    setup({ transactions: [], transactionSplits: [] });
+    enterDeleteMode();
+
+    fireEvent.click(screen.getByText('Food Shopping'));
+
+    expect(flatten(screen.getByRole('dialog').textContent)).toContain(
+      '1 budget is filed under “Food Shopping”, so it needs somewhere to go'
+    );
+    expect(deleteCategory).not.toHaveBeenCalled();
+  });
+});

--- a/src/pages/settings/Categories.tsx
+++ b/src/pages/settings/Categories.tsx
@@ -2,14 +2,15 @@ import { useState, useMemo } from 'react';
 import { useApp } from '../../contexts/AppContextSupabase';
 import { useToast } from '../../contexts/ToastContext';
 import { DEFAULT_CATEGORY_TREE } from '../../data/defaultCategoryTree';
-import { expandSplitTransactions, splitsByTransaction } from '../../utils/transactionSplits';
+import { expandSplitTransactions } from '../../utils/transactionSplits';
 import CategoryCreationModal from '../../components/CategoryCreationModal';
 import CategorySelector from '../../components/CategorySelector';
 import CategoryTransactionsModal from '../../components/CategoryTransactionsModal';
 import CategoryDataHealthPanel from '../../components/CategoryDataHealthPanel';
 import { computeCategoryHealth } from '../../utils/categoryHealth';
-import { AlertCircleIcon, Settings2Icon, GripVerticalIcon } from '../../components/icons';
+import { AlertCircleIcon, Settings2Icon, GripVerticalIcon, MergeIcon } from '../../components/icons';
 import { PlusIcon, XIcon, CheckIcon, ChevronRightIcon, ChevronDownIcon, DeleteIcon } from '../../components/icons';
+import type { Category as AppCategory, CategoryMergeResult } from '../../types';
 import { IconButton } from '../../components/icons/IconButton';
 import { DndContext, closestCenter, KeyboardSensor, PointerSensor, useSensor, useSensors, DragOverlay } from '@dnd-kit/core';
 import type { DragEndEvent, DragStartEvent } from '@dnd-kit/core';
@@ -30,14 +31,43 @@ interface Category {
   order?: number;
 }
 
+/**
+ * Why this category cannot be merged away — the sentence the user sees — or
+ * null when it can be. Mirrors the merge_categories RPC's refusals
+ * (20260805214322) so an ineligible row explains itself BEFORE the round trip
+ * rather than after it.
+ *
+ * v1 is leaf-to-leaf: the affordance is offered on detail categories only, and
+ * a group says so instead of being silently absent.
+ */
+function mergeBlockedReason(category: AppCategory, categories: AppCategory[]): string | null {
+  if (category.isTransferCategory === true) {
+    return 'Transfer categories are managed automatically from their account. Close the account to hide it instead.';
+  }
+  if (category.isRevaluationCategory === true || category.isSystem === true) {
+    return 'The app files transactions under this built-in category automatically, so it cannot be merged away.';
+  }
+  if (category.isUnassignedBucket === true) {
+    return "Rows here aren't categorised at all — file them from the review band rather than merging the whole bucket into a real category.";
+  }
+  if (category.level !== 'detail' || categories.some(c => c.parentId === category.id)) {
+    return "Merging a whole group isn't supported yet — merge the detail categories inside it instead.";
+  }
+  return null;
+}
+
 interface SortableCategoryProps {
   category: Category;
   isEditMode: boolean;
   isDeleteMode: boolean;
+  isMergeMode: boolean;
+  /** Set when merge mode is on and this row cannot be merged; the row dims and says why. */
+  mergeBlockedReason?: string | null;
   isEditing: boolean;
   editingName: string;
   onEdit: () => void;
   onDelete: () => void;
+  onMerge: () => void;
   onNameChange: (name: string) => void;
   onSave: () => void;
   onCancel: () => void;
@@ -46,14 +76,17 @@ interface SortableCategoryProps {
   isDraggable?: boolean;
 }
 
-function SortableCategory({ 
-  category, 
+function SortableCategory({
+  category,
   isEditMode,
-  isDeleteMode, 
-  isEditing, 
+  isDeleteMode,
+  isMergeMode,
+  mergeBlockedReason: mergeBlocked,
+  isEditing,
   editingName,
-  onEdit, 
-  onDelete, 
+  onEdit,
+  onDelete,
+  onMerge,
   onNameChange,
   onSave,
   onCancel,
@@ -68,9 +101,9 @@ function SortableCategory({
     transform,
     transition,
     isDragging,
-  } = useSortable({ 
+  } = useSortable({
     id: category.id,
-    disabled: !isEditMode || !isDraggable || isDeleteMode
+    disabled: !isEditMode || !isDraggable || isDeleteMode || isMergeMode
   });
 
   const style = {
@@ -78,12 +111,18 @@ function SortableCategory({
     transition,
   };
 
+  // In merge mode an ineligible row is dimmed and carries its reason as a
+  // tooltip — visibly off rather than missing, so the tree still reads as the
+  // whole tree. Clicking it says the same thing out loud (a toast), because a
+  // title attribute is no use on a touch screen.
+  const mergeUnavailable = isMergeMode && mergeBlocked != null;
+
   return (
     <div ref={setNodeRef} style={style}>
-      <div 
+      <div
         className={`flex items-center justify-between p-2 rounded ${
           isDragging ? 'opacity-50' : ''
-        } ${
+        } ${mergeUnavailable ? 'opacity-60' : ''} ${
           isEditMode ? 'hover:bg-gray-100 dark:hover:bg-gray-700' : 'hover:bg-gray-50 dark:hover:bg-gray-800'
         }`}
       >
@@ -108,13 +147,26 @@ function SortableCategory({
               onClick={(e) => e.stopPropagation()}
             />
           ) : (
-            <div 
+            <div
+              title={
+                mergeUnavailable
+                  ? mergeBlocked ?? undefined
+                  : isMergeMode
+                    ? `Merge "${category.name}" into another category`
+                    : undefined
+              }
               className={`flex items-center gap-2 flex-1 ${
-                !isEditMode && !isDeleteMode && onClick ? 'cursor-pointer' : ''
+                mergeUnavailable
+                  ? 'cursor-not-allowed'
+                  : isMergeMode || (!isEditMode && !isDeleteMode && onClick)
+                    ? 'cursor-pointer'
+                    : ''
               }`}
               onClick={(e) => {
                 e.stopPropagation();
-                if (isDeleteMode) {
+                if (isMergeMode) {
+                  onMerge();
+                } else if (isDeleteMode) {
                   onDelete();
                 } else if (isEditMode) {
                   onEdit();
@@ -124,8 +176,10 @@ function SortableCategory({
               }}
             >
               <span className={`${category.level === 'sub' ? 'font-medium' : ''} text-gray-900 dark:text-white ${
-                isDeleteMode ? 'hover:text-red-600 dark:hover:text-red-400' : 
-                isEditMode ? 'hover:text-primary dark:hover:text-primary' : 
+                mergeUnavailable ? '' :
+                isMergeMode ? 'hover:text-primary dark:hover:text-primary' :
+                isDeleteMode ? 'hover:text-red-600 dark:hover:text-red-400' :
+                isEditMode ? 'hover:text-primary dark:hover:text-primary' :
                 !isEditMode && !isDeleteMode ? 'hover:text-primary dark:hover:text-primary' : ''
               }`}>
                 {category.name}
@@ -162,15 +216,32 @@ function SortableCategory({
   );
 }
 
+/** "1,240 transactions, 12 split lines and 1 budget" — zero counts say nothing. */
+function movingClause(transactions: number, splitLines: number, budgets: number): string {
+  const parts: string[] = [];
+  if (transactions > 0) {
+    parts.push(`${transactions.toLocaleString()} transaction${transactions === 1 ? '' : 's'}`);
+  }
+  if (splitLines > 0) {
+    parts.push(`${splitLines.toLocaleString()} split line${splitLines === 1 ? '' : 's'}`);
+  }
+  if (budgets > 0) {
+    parts.push(`${budgets.toLocaleString()} budget${budgets === 1 ? '' : 's'}`);
+  }
+  if (parts.length === 0) return '';
+  if (parts.length === 1) return parts[0];
+  return `${parts.slice(0, -1).join(', ')} and ${parts[parts.length - 1]}`;
+}
+
 export default function CategoriesSettings() {
   const {
     transactions,
     categories,
+    budgets,
     transactionSplits,
-    setTransactionSplits,
     updateCategory,
     deleteCategory,
-    updateTransaction,
+    mergeCategories,
     getSubCategories,
     getDetailCategories,
     importCategoryTree
@@ -246,12 +317,16 @@ export default function CategoriesSettings() {
 
   const [isEditMode, setIsEditMode] = useState(false);
   const [isDeleteMode, setIsDeleteMode] = useState(false);
+  const [isMergeMode, setIsMergeMode] = useState(false);
   const [editingCategoryId, setEditingCategoryId] = useState<string | null>(null);
   const [editingCategoryName, setEditingCategoryName] = useState('');
   const [showCategoryModal, setShowCategoryModal] = useState(false);
   const [deletingCategoryId, setDeletingCategoryId] = useState<string | null>(null);
   const [isReassigning, setIsReassigning] = useState(false);
   const [reassignCategoryId, setReassignCategoryId] = useState<string>('');
+  const [mergingCategoryId, setMergingCategoryId] = useState<string | null>(null);
+  const [mergeTargetId, setMergeTargetId] = useState<string>('');
+  const [isMerging, setIsMerging] = useState(false);
   const [expandedCategories, setExpandedCategories] = useState<Set<string>>(new Set());
   const [activeId, setActiveId] = useState<string | null>(null);
   const [categoryOrder, setCategoryOrder] = useState<{ [parentId: string]: string[] }>({});
@@ -491,6 +566,19 @@ export default function CategoriesSettings() {
     setEditingCategoryName('');
   };
 
+  /**
+   * Everything that would be orphaned if this category disappeared: whole
+   * transactions filed under it, split LINES inside other transactions, and
+   * budgets pointing at it. Split parents are excluded from the transaction
+   * figure because their own category is blank — their filing lives in the
+   * lines, which are counted separately.
+   */
+  const referencesTo = (categoryId: string): { transactions: number; splitLines: number; budgets: number } => ({
+    transactions: transactions.filter(t => t.category === categoryId && !t.isSplit).length,
+    splitLines: transactionSplits.filter(s => s.category === categoryId).length,
+    budgets: budgets.filter(b => b.categoryId === categoryId).length,
+  });
+
   const handleDelete = (categoryId: string) => {
     const category = categories.find(c => c.id === categoryId);
     if (!category) return;
@@ -505,15 +593,16 @@ export default function CategoriesSettings() {
       return;
     }
 
-    // Count on the EXPANDED view so a category used only inside split lines
-    // still routes through reassignment — deleting it outright would orphan
-    // those lines' categorisation (the DB refuses that delete anyway).
-    const transactionCount = expandedTransactions.filter(t => t.category === categoryId).length;
+    // EVERY reference routes through reassignment, not just transactions: a
+    // budget left pointing at a deleted category keeps a dangling id and
+    // silently reports £0 spent for ever after.
+    const references = referencesTo(categoryId);
+    const referenceCount = references.transactions + references.splitLines + references.budgets;
     const childCategories = categories.filter(c => c.parentId === categoryId);
 
     if (childCategories.length > 0) {
       alert('Cannot delete category with subcategories. Delete subcategories first.');
-    } else if (transactionCount > 0) {
+    } else if (referenceCount > 0) {
       setDeletingCategoryId(categoryId);
       setReassignCategoryId('');
     } else {
@@ -521,6 +610,37 @@ export default function CategoriesSettings() {
         deleteCategory(categoryId);
       }
     }
+  };
+
+  const handleMerge = (categoryId: string) => {
+    const category = categories.find(c => c.id === categoryId);
+    if (!category) return;
+
+    const blocked = mergeBlockedReason(category, categories);
+    if (blocked) {
+      showError(new Error(blocked));
+      return;
+    }
+    setMergingCategoryId(categoryId);
+    setMergeTargetId('');
+  };
+
+  /**
+   * Run a merge and report what the DATABASE moved, not what was predicted.
+   * Shared by the merge dialog and by "Delete & Reassign", which is the same
+   * operation reached from the other end.
+   */
+  const runMerge = async (sourceId: string, targetId: string): Promise<void> => {
+    const sourceName = categories.find(c => c.id === sourceId)?.name ?? 'that category';
+    const targetName = categories.find(c => c.id === targetId)?.name ?? 'the new category';
+    const result: CategoryMergeResult = await mergeCategories(sourceId, targetId);
+    const moved = movingClause(result.transactions, result.splitLines, result.budgets);
+    showSuccess(
+      moved
+        ? `${moved} moved from "${sourceName}" to "${targetName}".`
+        : `"${sourceName}" was empty, so it has simply been removed.`,
+      'Categories merged'
+    );
   };
 
   const handleCategoryClick = (categoryId: string, categoryName: string) => {
@@ -592,10 +712,13 @@ export default function CategoriesSettings() {
                       category={subCategory as Category}
                       isEditMode={isEditMode}
                       isDeleteMode={isDeleteMode}
+                      isMergeMode={isMergeMode}
+                      mergeBlockedReason={isMergeMode ? mergeBlockedReason(subCategory, categories) : null}
                       isEditing={editingCategoryId === subCategory.id}
                       editingName={editingCategoryName}
                       onEdit={() => startEditing(subCategory.id, subCategory.name)}
                       onDelete={() => handleDelete(subCategory.id)}
+                      onMerge={() => handleMerge(subCategory.id)}
                       onNameChange={setEditingCategoryName}
                       onSave={saveEdit}
                       onCancel={cancelEdit}
@@ -634,10 +757,13 @@ export default function CategoriesSettings() {
                                   category={detailCategory as Category}
                                   isEditMode={isEditMode}
                                   isDeleteMode={isDeleteMode}
+                                  isMergeMode={isMergeMode}
+                                  mergeBlockedReason={isMergeMode ? mergeBlockedReason(detailCategory, categories) : null}
                                   isEditing={editingCategoryId === detailCategory.id}
                                   editingName={editingCategoryName}
                                   onEdit={() => startEditing(detailCategory.id, detailCategory.name)}
                                   onDelete={() => handleDelete(detailCategory.id)}
+                                  onMerge={() => handleMerge(detailCategory.id)}
                                   onNameChange={setEditingCategoryName}
                                   onSave={saveEdit}
                                   onCancel={cancelEdit}
@@ -669,20 +795,42 @@ export default function CategoriesSettings() {
             onClick={() => {
               setIsEditMode(!isEditMode);
               if (isDeleteMode) setIsDeleteMode(false);
+              if (isMergeMode) setIsMergeMode(false);
               setEditingCategoryId(null);
             }}
             className={`w-8 h-8 flex items-center justify-center transition-colors ${
-              isEditMode 
-                ? 'text-white bg-gray-600 hover:bg-gray-700' 
+              isEditMode
+                ? 'text-white bg-gray-600 hover:bg-gray-700'
                 : 'text-gray-500 hover:text-gray-700'
             }`}
             title={isEditMode ? 'Done Editing' : 'Edit Categories'}
           >
             <Settings2Icon size={16} />
           </button>
+          {/* Merge sits beside Delete, inside Edit mode, because it is the same
+              kind of structural change reached the same way: a mode, then the
+              category you mean. One click of a row, not a button per row —
+              which would put a control on every line of a long tree. */}
           {isEditMode && (
             <IconButton
-              onClick={() => setIsDeleteMode(!isDeleteMode)}
+              onClick={() => {
+                setIsMergeMode(!isMergeMode);
+                if (!isMergeMode) setIsDeleteMode(false);
+                setEditingCategoryId(null);
+              }}
+              icon={<MergeIcon size={16} />}
+              variant={isMergeMode ? 'primary' : 'ghost'}
+              size="sm"
+              className={isMergeMode ? '' : 'text-gray-500 hover:text-gray-700'}
+              title={isMergeMode ? 'Cancel Merge' : 'Merge Categories'}
+            />
+          )}
+          {isEditMode && (
+            <IconButton
+              onClick={() => {
+                setIsDeleteMode(!isDeleteMode);
+                if (!isDeleteMode) setIsMergeMode(false);
+              }}
               icon={<DeleteIcon size={16} />}
               variant={isDeleteMode ? 'danger' : 'ghost'}
               size="sm"
@@ -711,26 +859,32 @@ export default function CategoriesSettings() {
       {/* Instructions */}
       {(isEditMode || isDeleteMode) ? (
         <div className={`lg:shrink-0 border rounded-2xl p-4 mb-6 ${
-          isDeleteMode 
-            ? 'bg-red-50 dark:bg-red-900/20 border-red-200 dark:border-red-800' 
+          isDeleteMode
+            ? 'bg-red-50 dark:bg-red-900/20 border-red-200 dark:border-red-800'
             : 'bg-blue-50 dark:bg-blue-900/20 border-blue-200 dark:border-blue-800'
         }`}>
           <div className={`text-sm space-y-2 ${
             isDeleteMode ? 'text-red-800 dark:text-red-200' : 'text-blue-800 dark:text-blue-200'
           }`}>
-            <p><strong>{isDeleteMode ? 'Delete Mode Active:' : 'Edit Mode Active:'}</strong></p>
+            <p><strong>{isDeleteMode ? 'Delete Mode Active:' : isMergeMode ? 'Merge Mode Active:' : 'Edit Mode Active:'}</strong></p>
             <ul className="list-disc list-inside space-y-1 ml-2">
               {isDeleteMode ? (
                 <>
                   <li>Click on any category to delete it</li>
-                  <li>Categories with transactions will prompt for reassignment</li>
+                  <li>Categories still in use will prompt for reassignment</li>
                   <li>Categories with subcategories must have subcategories deleted first</li>
+                </>
+              ) : isMergeMode ? (
+                <>
+                  <li>Click the category you want to merge away, then choose the one it joins</li>
+                  <li>Everything filed under it moves across — transactions, split lines and budgets</li>
+                  <li>Groups and the app&apos;s own categories are greyed out and say why</li>
                 </>
               ) : (
                 <>
                   <li>Click on any category name to rename it</li>
                   <li>Drag detail categories to different subcategories to reorganize them</li>
-                  <li>Toggle Delete Mode to remove categories</li>
+                  <li>Toggle Merge Mode to join two categories, or Delete Mode to remove one</li>
                   <li>Default categories can be edited just like custom ones</li>
                 </>
               )}
@@ -802,10 +956,13 @@ export default function CategoriesSettings() {
                       category={category as Category}
                       isEditMode={isEditMode}
                       isDeleteMode={isDeleteMode}
+                      isMergeMode={isMergeMode}
+                      mergeBlockedReason={isMergeMode ? mergeBlockedReason(category, categories) : null}
                       isEditing={editingCategoryId === category.id}
                       editingName={editingCategoryName}
                       onEdit={() => startEditing(category.id, category.name)}
                       onDelete={() => handleDelete(category.id)}
+                      onMerge={() => handleMerge(category.id)}
                       onNameChange={setEditingCategoryName}
                       onSave={saveEdit}
                       onCancel={cancelEdit}
@@ -837,27 +994,33 @@ export default function CategoriesSettings() {
       {/* Category Delete Confirmation Dialog */}
       {deletingCategoryId && (
         <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50 p-4">
-          <div className="bg-white dark:bg-gray-800 rounded-2xl p-6 max-w-md w-full">
+          <div
+            role="dialog"
+            aria-modal="true"
+            aria-labelledby="delete-category-heading"
+            className="bg-white dark:bg-gray-800 rounded-2xl p-6 max-w-md w-full"
+          >
             <div className="flex items-center gap-3 mb-4">
               <AlertCircleIcon className="text-orange-500" size={24} />
-              <h3 className="text-lg font-semibold text-gray-900 dark:text-white">Delete Category</h3>
+              <h3 id="delete-category-heading" className="text-lg font-semibold text-gray-900 dark:text-white">
+                Delete Category
+              </h3>
             </div>
             {(() => {
               const category = categories.find(c => c.id === deletingCategoryId);
-              const directRows = transactions.filter(t => t.category === deletingCategoryId && !t.isSplit);
-              const affectedSplitLines = transactionSplits.filter(s => s.category === deletingCategoryId);
-              const transactionCount = directRows.length + affectedSplitLines.length;
+              const references = referencesTo(deletingCategoryId);
+              const held = movingClause(references.transactions, references.splitLines, references.budgets);
+              const only = references.transactions + references.splitLines + references.budgets === 1;
+              const targetName = categories.find(c => c.id === reassignCategoryId)?.name;
 
               return (
                 <>
                   <p className="text-gray-600 dark:text-gray-400 mb-4">
-                    The category "{category?.name}" has {transactionCount} transaction{transactionCount !== 1 ? 's' : ''} associated with it
-                    {affectedSplitLines.length > 0 && (
-                      <> (including {affectedSplitLines.length} split line{affectedSplitLines.length !== 1 ? 's' : ''})</>
-                    )}.
+                    {held} {only ? 'is' : 'are'} filed under &ldquo;{category?.name}&rdquo;,
+                    so {only ? 'it needs' : 'they need'} somewhere to go before it can be removed.
                   </p>
                   <p className="text-gray-600 dark:text-gray-400 mb-4">
-                    Please select a category to reassign these transactions to:
+                    Please select a category to reassign them to:
                   </p>
                   {/* Same searchable grouped picker as the transaction editor —
                       it filters out inactive categories (a closed account's
@@ -875,6 +1038,15 @@ export default function CategoriesSettings() {
                       usePortal
                     />
                   </div>
+                  {/* Consequence before the button, in the same words the merge
+                      dialog uses — because this IS a merge, reached from the
+                      "I want this gone" end. */}
+                  {reassignCategoryId && (
+                    <p className="text-sm text-gray-600 dark:text-gray-400 mb-6">
+                      {held} move to &ldquo;{targetName}&rdquo;; &ldquo;{category?.name}&rdquo; is then removed.
+                      Payee memory and future imports follow &ldquo;{targetName}&rdquo;.
+                    </p>
+                  )}
                   <div className="flex gap-3">
                     <button
                       onClick={() => {
@@ -893,33 +1065,11 @@ export default function CategoriesSettings() {
                         }
                         setIsReassigning(true);
                         try {
-                          // Ordinary rows move in one pass; failures surface
-                          // instead of silently racing the category delete.
-                          await Promise.all(directRows.map(transaction =>
-                            updateTransaction(transaction.id, { category: reassignCategoryId })
-                          ));
-
-                          // Split lines: swap the category inside each affected
-                          // parent's split set. Amounts are untouched, so the
-                          // sum invariant holds and the RPC accepts.
-                          const affectedParents = splitsByTransaction(affectedSplitLines);
-                          for (const parentId of affectedParents.keys()) {
-                            const allLines = transactionSplits
-                              .filter(s => s.transactionId === parentId)
-                              .sort((a, b) => a.sortOrder - b.sortOrder);
-                            const parent = transactions.find(t => t.id === parentId);
-                            await setTransactionSplits(
-                              parentId,
-                              allLines.map(line => ({
-                                category: line.category === deletingCategoryId ? reassignCategoryId : line.category,
-                                amount: line.amount,
-                                ...(line.memo ? { memo: line.memo } : {}),
-                              })),
-                              parent?.amount ?? null
-                            );
-                          }
-
-                          await deleteCategory(deletingCategoryId);
+                          // ONE atomic call. This used to be a round trip per
+                          // transaction, then a split rewrite per parent, then
+                          // the delete — with budgets left behind entirely and
+                          // nothing to undo a half-finished run.
+                          await runMerge(deletingCategoryId, reassignCategoryId);
                           setDeletingCategoryId(null);
                           setReassignCategoryId('');
                         } catch (error) {
@@ -932,6 +1082,104 @@ export default function CategoriesSettings() {
                       disabled={!reassignCategoryId || isReassigning}
                     >
                       {isReassigning ? 'Reassigning…' : 'Delete & Reassign'}
+                    </button>
+                  </div>
+                </>
+              );
+            })()}
+          </div>
+        </div>
+      )}
+
+      {/* Category Merge Dialog */}
+      {mergingCategoryId && (
+        <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50 p-4">
+          <div
+            role="dialog"
+            aria-modal="true"
+            aria-labelledby="merge-category-heading"
+            className="bg-white dark:bg-gray-800 rounded-2xl p-6 max-w-md w-full"
+          >
+            <div className="flex items-center gap-3 mb-4">
+              <MergeIcon className="text-primary" size={24} />
+              <h3 id="merge-category-heading" className="text-lg font-semibold text-gray-900 dark:text-white">
+                Merge Category
+              </h3>
+            </div>
+            {(() => {
+              const source = categories.find(c => c.id === mergingCategoryId);
+              const target = categories.find(c => c.id === mergeTargetId);
+              const references = referencesTo(mergingCategoryId);
+              const moving = movingClause(references.transactions, references.splitLines, references.budgets);
+              // A budget already on the target means the user ends up with two
+              // on one category. Said out loud, once, only when it applies.
+              const targetBudgets = mergeTargetId
+                ? budgets.filter(b => b.categoryId === mergeTargetId).length
+                : 0;
+
+              return (
+                <>
+                  <p className="text-gray-600 dark:text-gray-400 mb-4">
+                    Everything filed under &ldquo;{source?.name}&rdquo; moves to the category you choose,
+                    and &ldquo;{source?.name}&rdquo; is then removed.
+                  </p>
+                  <div className="mb-6">
+                    <CategorySelector
+                      selectedCategory={mergeTargetId}
+                      onCategoryChange={setMergeTargetId}
+                      transactionType={source?.type === 'income' ? 'income' : 'expense'}
+                      includeAllTypes={source?.type === 'both'}
+                      excludeIds={[mergingCategoryId]}
+                      placeholder="Merge into…"
+                      allowCreate={false}
+                      showHelperText={false}
+                      usePortal
+                    />
+                  </div>
+                  {mergeTargetId && (
+                    <div className="mb-6 rounded-xl border border-amber-300 dark:border-amber-600 bg-amber-50 dark:bg-amber-900/20 p-3">
+                      <p className="text-sm text-amber-800 dark:text-amber-200">
+                        {moving
+                          ? <>{moving} move to &ldquo;{target?.name}&rdquo;; &ldquo;{source?.name}&rdquo; is then removed.</>
+                          : <>Nothing is filed under &ldquo;{source?.name}&rdquo;, so it is simply removed.</>}
+                        {' '}Payee memory and future imports follow &ldquo;{target?.name}&rdquo;.
+                        {references.budgets > 0 && targetBudgets > 0 && (
+                          <> &ldquo;{target?.name}&rdquo; will then have {(targetBudgets + references.budgets).toLocaleString()} budgets — tidy them on the Budgets page.</>
+                        )}
+                      </p>
+                    </div>
+                  )}
+                  <div className="flex gap-3">
+                    <button
+                      onClick={() => {
+                        setMergingCategoryId(null);
+                        setMergeTargetId('');
+                      }}
+                      disabled={isMerging}
+                      className="flex-1 justify-center px-4 py-2 border border-gray-300 dark:border-gray-600 text-gray-700 dark:text-gray-300 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-700 disabled:opacity-50"
+                    >
+                      Cancel
+                    </button>
+                    <button
+                      onClick={async () => {
+                        if (!mergeTargetId || mergeTargetId === mergingCategoryId || isMerging) {
+                          return;
+                        }
+                        setIsMerging(true);
+                        try {
+                          await runMerge(mergingCategoryId, mergeTargetId);
+                          setMergingCategoryId(null);
+                          setMergeTargetId('');
+                        } catch (error) {
+                          showError(error);
+                        } finally {
+                          setIsMerging(false);
+                        }
+                      }}
+                      className="flex-1 px-4 py-2 bg-[#1a2332] text-white rounded-lg hover:bg-secondary disabled:opacity-50"
+                      disabled={!mergeTargetId || isMerging}
+                    >
+                      {isMerging ? 'Merging…' : 'Merge'}
                     </button>
                   </div>
                 </>

--- a/src/services/__tests__/dataService.test.ts
+++ b/src/services/__tests__/dataService.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { createDataService, DataService } from '../api/dataService';
-import type { Account, Category, Transaction } from '../../types';
+import type { Account, Budget, Category, Transaction, TransactionSplit } from '../../types';
 import { STORAGE_KEYS } from '../storageAdapter';
 
 const createStorage = (initial: Record<string, unknown> = {}) => {
@@ -499,6 +499,222 @@ describe('DataService repairClaimedTransfer (local mode)', () => {
 
     await expect(service.repairClaimedTransfer('stranded', 'counterpart', 'partner', ADJUSTMENT))
       .rejects.toThrow(/Unknown or transfer category/);
+  });
+});
+
+
+// The demo/offline half of the category merge. Cloud mode is one atomic RPC
+// (merge_categories, migration 20260805214322); local mode has no server to be
+// atomic on, so it validates EVERYTHING before its single set of writes — which
+// is what keeps demo mode honest about what the real thing will do.
+//
+// The point of these tests is the SURFACES: the old delete-and-reassign moved
+// transactions and split lines and silently stranded budgets, which is exactly
+// the class of bug that survives a "looks fine" manual check.
+describe('DataService mergeCategories (local mode)', () => {
+  const expenseCategory = (over: Partial<Category> & { id: string }): Category => ({
+    name: over.id,
+    type: 'expense',
+    level: 'detail',
+    parentId: 'sub-food',
+    ...over
+  });
+
+  const SOURCE = expenseCategory({ id: 'cat-food-shopping', name: 'Food Shopping' });
+  const TARGET = expenseCategory({ id: 'cat-groceries', name: 'Groceries' });
+
+  const buildService = (storage: ReturnType<typeof createStorage>) =>
+    createDataService({
+      isSupabaseConfigured: () => false,
+      storageAdapter: storage,
+      logger: { error: vi.fn(), warn: vi.fn(), log: vi.fn() },
+      uuid: vi.fn(() => 'generated-id'),
+      now: vi.fn(() => new Date('2025-09-01T00:00:00.000Z')),
+      userIdService: {
+        ensureUserExists: vi.fn(),
+        getCurrentDatabaseUserId: vi.fn(() => null),
+        getCurrentUserIds: vi.fn(() => ({ clerkId: null, databaseId: null }))
+      }
+    });
+
+  /** One of every reference surface pointing at the source. */
+  const fullHistory = (extraCategories: Category[] = []) => createStorage({
+    [STORAGE_KEYS.ACCOUNTS]: [baseAccount()],
+    [STORAGE_KEYS.CATEGORIES]: [SOURCE, TARGET, ...extraCategories],
+    [STORAGE_KEYS.TRANSACTIONS]: [
+      baseTransaction({ id: 'txn-a', category: SOURCE.id }),
+      baseTransaction({ id: 'txn-b', category: SOURCE.id }),
+      baseTransaction({ id: 'txn-other', category: TARGET.id }),
+      baseTransaction({ id: 'txn-split', category: '', isSplit: true, amount: 60 })
+    ],
+    [STORAGE_KEYS.TRANSACTION_SPLITS]: [
+      { id: 's1', transactionId: 'txn-split', category: SOURCE.id, amount: 40, sortOrder: 1, memo: 'wine' },
+      { id: 's2', transactionId: 'txn-split', category: 'cat-other', amount: 20, sortOrder: 2 }
+    ],
+    [STORAGE_KEYS.BUDGETS]: [
+      { id: 'bud-1', categoryId: SOURCE.id, amount: 400, period: 'monthly', isActive: true, spent: 0 },
+      { id: 'bud-2', categoryId: 'cat-other', amount: 50, period: 'monthly', isActive: true, spent: 0 }
+    ]
+  });
+
+  it('moves every reference surface — transactions, split lines AND budgets — then removes the source', async () => {
+    const storage = fullHistory();
+    const service = buildService(storage);
+
+    const result = await service.mergeCategories(SOURCE.id, TARGET.id);
+
+    expect(result).toMatchObject({
+      transactions: 2,
+      splitLines: 1,
+      splitTransactions: 1,
+      budgets: 1
+    });
+
+    const transactions = storage.snapshot(STORAGE_KEYS.TRANSACTIONS) as Transaction[];
+    expect(transactions.filter(t => t.category === TARGET.id).map(t => t.id))
+      .toEqual(['txn-a', 'txn-b', 'txn-other']);
+    // The split parent's category stays blank — that blank means "split", not
+    // "uncategorised", and filling it in is what the database refuses outright.
+    expect(transactions.find(t => t.id === 'txn-split')?.category).toBe('');
+
+    const splits = storage.snapshot(STORAGE_KEYS.TRANSACTION_SPLITS) as TransactionSplit[];
+    expect(splits.find(s => s.id === 's1')).toMatchObject({
+      category: TARGET.id, amount: 40, memo: 'wine'
+    });
+    expect(splits.find(s => s.id === 's2')?.category).toBe('cat-other');
+
+    // The surface the old delete-and-reassign left behind.
+    const budgets = storage.snapshot(STORAGE_KEYS.BUDGETS) as Budget[];
+    expect(budgets.find(b => b.id === 'bud-1')?.categoryId).toBe(TARGET.id);
+    expect(budgets.find(b => b.id === 'bud-2')?.categoryId).toBe('cat-other');
+
+    const categories = storage.snapshot(STORAGE_KEYS.CATEGORIES) as Category[];
+    expect(categories.map(c => c.id)).toEqual([TARGET.id]);
+
+    // Balance-neutral: not one amount moved, so no account did either.
+    const accounts = storage.snapshot(STORAGE_KEYS.ACCOUNTS) as Account[];
+    expect(accounts[0].balance).toBe(100);
+  });
+
+  it('merges an empty category without touching anything else', async () => {
+    const storage = createStorage({
+      [STORAGE_KEYS.CATEGORIES]: [SOURCE, TARGET],
+      [STORAGE_KEYS.TRANSACTIONS]: [baseTransaction({ category: TARGET.id })],
+      [STORAGE_KEYS.TRANSACTION_SPLITS]: [],
+      [STORAGE_KEYS.BUDGETS]: []
+    });
+    const service = buildService(storage);
+
+    const result = await service.mergeCategories(SOURCE.id, TARGET.id);
+
+    expect(result).toMatchObject({ transactions: 0, splitLines: 0, budgets: 0 });
+    expect((storage.snapshot(STORAGE_KEYS.CATEGORIES) as Category[]).map(c => c.id))
+      .toEqual([TARGET.id]);
+  });
+
+  // Every refusal below must leave browser storage EXACTLY as it was: the
+  // validations all run before the first write, so a rejected merge is not a
+  // partial merge.
+  describe('refusals write nothing at all', () => {
+    const expectUntouched = (storage: ReturnType<typeof createStorage>): void => {
+      const transactions = storage.snapshot(STORAGE_KEYS.TRANSACTIONS) as Transaction[];
+      expect(transactions.filter(t => t.category === SOURCE.id)).toHaveLength(2);
+      const splits = storage.snapshot(STORAGE_KEYS.TRANSACTION_SPLITS) as TransactionSplit[];
+      expect(splits.find(s => s.id === 's1')?.category).toBe(SOURCE.id);
+      const budgets = storage.snapshot(STORAGE_KEYS.BUDGETS) as Budget[];
+      expect(budgets.find(b => b.id === 'bud-1')?.categoryId).toBe(SOURCE.id);
+      const categories = storage.snapshot(STORAGE_KEYS.CATEGORIES) as Category[];
+      expect(categories.some(c => c.id === SOURCE.id)).toBe(true);
+    };
+
+    it('refuses a category that is not there', async () => {
+      const storage = fullHistory();
+      await expect(buildService(storage).mergeCategories(SOURCE.id, 'nope'))
+        .rejects.toThrow('Category not found');
+      expectUntouched(storage);
+    });
+
+    it('refuses merging a category into itself', async () => {
+      const storage = fullHistory();
+      await expect(buildService(storage).mergeCategories(SOURCE.id, SOURCE.id))
+        .rejects.toThrow(/cannot be merged into itself/);
+      expectUntouched(storage);
+    });
+
+    it('refuses a transfer category on either side', async () => {
+      const transfer = expenseCategory({
+        id: 'cat-transfer', name: 'To/From Joint', type: 'both', isTransferCategory: true
+      });
+      const storage = fullHistory([transfer]);
+      await expect(buildService(storage).mergeCategories(transfer.id, TARGET.id))
+        .rejects.toThrow(/managed automatically from their account/);
+      await expect(buildService(storage).mergeCategories(SOURCE.id, transfer.id))
+        .rejects.toThrow(/invent transfers that never happened/);
+      expectUntouched(storage);
+    });
+
+    it('refuses to merge away a built-in category the app files under itself', async () => {
+      const adjustment = expenseCategory({
+        id: 'cat-adjustment', name: 'Account Adjustment', type: 'both',
+        isSystem: true, isRevaluationCategory: true
+      });
+      const storage = fullHistory([adjustment]);
+      await expect(buildService(storage).mergeCategories(adjustment.id, TARGET.id))
+        .rejects.toThrow(/built-in category/);
+      expectUntouched(storage);
+    });
+
+    it('refuses the import’s unassigned bucket on either side', async () => {
+      const bucket = expenseCategory({
+        id: 'cat-unassigned', name: 'Unassigned (MS Money import)', type: 'both',
+        isUnassignedBucket: true
+      });
+      const storage = fullHistory([bucket]);
+      await expect(buildService(storage).mergeCategories(bucket.id, TARGET.id))
+        .rejects.toThrow(/file them from the review band/);
+      await expect(buildService(storage).mergeCategories(SOURCE.id, bucket.id))
+        .rejects.toThrow(/un-file transactions that are already filed/);
+      expectUntouched(storage);
+    });
+
+    it('refuses a group on either side — v1 is leaf to leaf', async () => {
+      const group = expenseCategory({ id: 'sub-food', name: 'Food', level: 'sub', parentId: 'type-expense' });
+      const storage = fullHistory([group]);
+      await expect(buildService(storage).mergeCategories(group.id, TARGET.id))
+        .rejects.toThrow(/merging a whole group is not supported yet|has categories under it/i);
+      await expect(buildService(storage).mergeCategories(SOURCE.id, group.id))
+        .rejects.toThrow(/is a group/);
+      expectUntouched(storage);
+    });
+
+    it('refuses to merge an expense category into an income one', async () => {
+      const salary = expenseCategory({
+        id: 'cat-salary', name: 'Salary', type: 'income', parentId: 'sub-earnings'
+      });
+      const storage = fullHistory([salary]);
+      await expect(buildService(storage).mergeCategories(SOURCE.id, salary.id))
+        .rejects.toThrow(/wrong side of every report/);
+      expectUntouched(storage);
+    });
+
+    it('accepts a direction-neutral target, which carries no side of its own', async () => {
+      // A revaluation leaf is 'both': "this was a balance correction, not
+      // spending" is a legitimate re-filing of an expense category.
+      const neutral = expenseCategory({ id: 'cat-neutral', name: 'Other', type: 'both', parentId: undefined });
+      const storage = fullHistory([neutral]);
+
+      await expect(buildService(storage).mergeCategories(SOURCE.id, neutral.id)).resolves.toMatchObject({
+        transactions: 2
+      });
+    });
+
+    it('refuses a hidden target', async () => {
+      const closed = expenseCategory({ id: 'cat-closed', name: 'Old Shop', isActive: false });
+      const storage = fullHistory([closed]);
+      await expect(buildService(storage).mergeCategories(SOURCE.id, closed.id))
+        .rejects.toThrow(/is hidden/);
+      expectUntouched(storage);
+    });
   });
 });
 

--- a/src/services/__tests__/importRulesService.test.ts
+++ b/src/services/__tests__/importRulesService.test.ts
@@ -160,6 +160,61 @@ describe('ImportRulesService', () => {
     });
   });
 
+  /**
+   * A category merge happens in the database; import rules live in THIS
+   * browser, so they follow it immediately afterwards. A rule left pointing at
+   * a merged-away category would go on matching imports and file them under an
+   * id that no longer exists — worse than either outcome the merge offers.
+   */
+  describe('remapCategory (following a category merge)', () => {
+    it('re-points every setCategory action from the merged-away category', () => {
+      service.addRule({ ...mockRule, name: 'Groceries rule' });
+      storage.setItem.mockClear();
+
+      const changed = service.remapCategory('Shopping', 'Household');
+
+      expect(changed).toBe(1);
+      expect(service.getRules()[0].actions[0].value).toBe('Household');
+      expect(storage.setItem).toHaveBeenCalled();
+    });
+
+    it('leaves other actions and other categories alone', () => {
+      service.addRule({
+        ...mockRule,
+        actions: [
+          { type: 'setCategory', value: 'Shopping' },
+          { type: 'addTag', value: 'Shopping' },
+          { type: 'setCategory', value: 'Travel' }
+        ]
+      });
+
+      service.remapCategory('Shopping', 'Household');
+
+      const actions = service.getRules()[0].actions;
+      expect(actions[0]).toMatchObject({ type: 'setCategory', value: 'Household' });
+      // Same string, different kind of action — a tag is not a category.
+      expect(actions[1]).toMatchObject({ type: 'addTag', value: 'Shopping' });
+      expect(actions[2]).toMatchObject({ type: 'setCategory', value: 'Travel' });
+    });
+
+    it('writes nothing when no rule refers to the merged-away category', () => {
+      service.addRule(mockRule);
+      storage.setItem.mockClear();
+
+      expect(service.remapCategory('Travel', 'Household')).toBe(0);
+      expect(storage.setItem).not.toHaveBeenCalled();
+    });
+
+    it('refuses a no-op remap onto itself', () => {
+      service.addRule(mockRule);
+      storage.setItem.mockClear();
+
+      expect(service.remapCategory('Shopping', 'Shopping')).toBe(0);
+      expect(service.remapCategory('', 'Household')).toBe(0);
+      expect(storage.setItem).not.toHaveBeenCalled();
+    });
+  });
+
   describe('condition matching', () => {
     let transaction: Partial<Transaction>;
 

--- a/src/services/api/dataService.ts
+++ b/src/services/api/dataService.ts
@@ -8,13 +8,14 @@
 import { UserService } from './userService';
 import { AccountService } from './accountService';
 import { TransactionService, type TransactionLoadResult, type TransactionLoadStats } from './transactionService';
+import { PlanningService } from './planningService';
 import { isSupabaseConfigured } from './supabaseClient';
 import { hasSupabaseTokenGetter } from '../../lib/supabaseToken';
 import { storageAdapter, STORAGE_KEYS } from '../storageAdapter';
 import { userIdService } from '../userIdService';
 import { toDecimal } from '../../utils/decimal';
 import { normalizeTransactionDates, toDateValue } from '../../utils/dateBoundary';
-import type { Account, Transaction, TransactionSplit, TransactionSplitInput, Budget, Goal, Category } from '../../types';
+import type { Account, Transaction, TransactionSplit, TransactionSplitInput, Budget, Goal, Category, CategoryMergeResult } from '../../types';
 
 export interface AppData {
   accounts: Account[];
@@ -44,6 +45,7 @@ type TransactionServiceLike = Pick<typeof TransactionService,
    */
   loadTransactionsForBoot?: (userId: string) => Promise<TransactionLoadResult>;
 };
+type PlanningServiceLike = Pick<typeof PlanningService, 'mergeCategories'>;
 type UserIdServiceLike = Pick<typeof userIdService,
   'ensureUserExists' | 'getCurrentDatabaseUserId' | 'getCurrentUserIds'>;
 type StorageAdapterLike = Pick<typeof storageAdapter, 'get' | 'set'>;
@@ -55,6 +57,7 @@ type UuidGenerator = () => string;
 export interface DataServiceOptions {
   accountService?: AccountServiceLike;
   transactionService?: TransactionServiceLike;
+  planningService?: PlanningServiceLike;
   userService?: typeof UserService;
   userIdService?: UserIdServiceLike;
   storageAdapter?: StorageAdapterLike;
@@ -69,6 +72,7 @@ export interface DataServiceOptions {
 class DataServiceImpl {
   private readonly accountService: AccountServiceLike;
   private readonly transactionService: TransactionServiceLike;
+  private readonly planningService: PlanningServiceLike;
   private readonly userService: typeof UserService;
   private readonly userIdService: UserIdServiceLike;
   private readonly storage: StorageAdapterLike;
@@ -81,6 +85,7 @@ class DataServiceImpl {
   constructor(options: DataServiceOptions = {}) {
     this.accountService = options.accountService ?? AccountService;
     this.transactionService = options.transactionService ?? TransactionService;
+    this.planningService = options.planningService ?? PlanningService;
     this.userService = options.userService ?? UserService;
     this.userIdService = options.userIdService ?? userIdService;
     this.storage = options.storageAdapter ?? storageAdapter;
@@ -898,6 +903,135 @@ class DataServiceImpl {
     return { source: newSource, counterpart };
   }
 
+  /**
+   * Join two categories: every reference moves from source to target, then the
+   * source goes.
+   *
+   * Cloud mode is ONE call — merge_categories does all of it in a single
+   * database transaction, so there is no half-merged state to compensate for
+   * and no audit gap. Local/demo mirrors the RPC's rules and its outcome, and
+   * is likewise all-or-nothing: every validation runs BEFORE the first persist,
+   * so a refusal leaves browser storage exactly as it was.
+   *
+   * Recurring templates have no local writer (nothing persists
+   * STORAGE_KEYS.RECURRING today), so the local count for them is always 0 —
+   * the cloud path moves the real ones.
+   */
+  async mergeCategories(sourceId: string, targetId: string): Promise<CategoryMergeResult> {
+    const userId = this.userIdService.getCurrentDatabaseUserId();
+    if (userId && this.supabaseChecker()) {
+      return this.planningService.mergeCategories(userId, sourceId, targetId);
+    }
+    this.guardCloudWrite();
+
+    if (!sourceId || !targetId) {
+      throw new Error('A merge needs the category to merge away and the category to merge it into');
+    }
+    if (sourceId === targetId) {
+      throw new Error('A category cannot be merged into itself');
+    }
+
+    const categories = await this.readCollection<Category>(STORAGE_KEYS.CATEGORIES);
+    const source = categories.find(c => c.id === sourceId);
+    const target = categories.find(c => c.id === targetId);
+    if (!source || !target) {
+      throw new Error('Category not found');
+    }
+
+    // The source guards, in the RPC's order and wording.
+    if (source.level === 'type') {
+      throw new Error(`"${source.name}" is a top-level heading, not a category things are filed under`);
+    }
+    if (source.isTransferCategory === true) {
+      throw new Error('Transfer categories are managed automatically from their account — close the account instead');
+    }
+    if (source.isRevaluationCategory === true || source.isSystem === true) {
+      throw new Error(`"${source.name}" is a built-in category the app files transactions under automatically, so it cannot be merged away`);
+    }
+    if (source.isUnassignedBucket === true) {
+      throw new Error(`Rows in "${source.name}" are not categorised at all — file them from the review band rather than merging the whole bucket into a real category`);
+    }
+    if (categories.some(c => c.parentId === sourceId)) {
+      throw new Error(`"${source.name}" has categories under it — merging a whole group is not supported yet; merge its detail categories one at a time`);
+    }
+
+    // The target guards.
+    if (target.level === 'type') {
+      throw new Error(`"${target.name}" is a top-level heading — nothing is filed against one`);
+    }
+    if (target.isTransferCategory === true) {
+      throw new Error(`"${target.name}" belongs to an account's transfer bookkeeping — filing ordinary transactions there would invent transfers that never happened`);
+    }
+    if (target.isUnassignedBucket === true) {
+      throw new Error(`"${target.name}" means "not categorised" — merging into it would un-file transactions that are already filed`);
+    }
+    if (target.isActive === false) {
+      throw new Error(`"${target.name}" is hidden, so nothing can be filed under it — pick a category that is in use`);
+    }
+    if (categories.some(c => c.parentId === targetId)) {
+      throw new Error(`"${target.name}" is a group, and transactions belong to a category inside it — pick one of its detail categories`);
+    }
+
+    // Direction: a 'both' target takes either, because it carries no direction
+    // of its own; nothing else crosses.
+    if (target.type !== 'both' && target.type !== source.type) {
+      throw new Error(
+        `"${source.name}" is an ${source.type} category and "${target.name}" is an ${target.type} one — merging across the two would file money on the wrong side of every report`
+      );
+    }
+
+    const transactions = await this.readLocalTransactions();
+    const splits = await this.readCollection<TransactionSplit>(STORAGE_KEYS.TRANSACTION_SPLITS);
+    const budgets = await this.readCollection<Budget>(STORAGE_KEYS.BUDGETS);
+
+    let movedTransactions = 0;
+    const nextTransactions = transactions.map(t => {
+      if (t.category !== sourceId) return t;
+      movedTransactions += 1;
+      return { ...t, category: targetId };
+    });
+
+    // Split lines keep their amounts and memos: two lines of one transaction
+    // landing on the same target stay two lines, because adding them together
+    // would destroy the user's own breakdown.
+    let movedSplitLines = 0;
+    const touchedParents = new Set<string>();
+    const nextSplits = splits.map(s => {
+      if (s.category !== sourceId) return s;
+      movedSplitLines += 1;
+      touchedParents.add(s.transactionId);
+      return { ...s, category: targetId };
+    });
+
+    let movedBudgets = 0;
+    const nextBudgets = budgets.map(b => {
+      if (b.categoryId !== sourceId) return b;
+      movedBudgets += 1;
+      return { ...b, categoryId: targetId, updatedAt: this.nowProvider() };
+    });
+
+    // Every check has passed, so the writes go together. Categories LAST: if a
+    // write fails part way, references pointing at a category that still exists
+    // is a recoverable state, and the reverse is not.
+    await this.persistCollection(STORAGE_KEYS.TRANSACTIONS, nextTransactions);
+    await this.persistCollection(STORAGE_KEYS.TRANSACTION_SPLITS, nextSplits);
+    await this.persistCollection(STORAGE_KEYS.BUDGETS, nextBudgets);
+    await this.persistCollection(
+      STORAGE_KEYS.CATEGORIES,
+      categories.filter(c => c.id !== sourceId)
+    );
+
+    return {
+      sourceId,
+      targetId,
+      transactions: movedTransactions,
+      splitLines: movedSplitLines,
+      splitTransactions: touchedParents.size,
+      budgets: movedBudgets,
+      recurring: 0
+    };
+  }
+
   // Budgets/goals/categories are local-only here (PlanningService owns the
   // cloud path) — but a signed-in session must still never read them from
   // browser-local storage, so the same pending gate applies.
@@ -1084,6 +1218,10 @@ export class DataService {
     expectedAmount: number | null
   ): Promise<{ isSplit: boolean; splitCount: number; amount: number }> {
     return this.service.setTransactionSplits(transactionId, splits, expectedAmount);
+  }
+
+  static mergeCategories(sourceId: string, targetId: string): Promise<CategoryMergeResult> {
+    return this.service.mergeCategories(sourceId, targetId);
   }
 
   static getBudgets(): Promise<Budget[]> {

--- a/src/services/api/planningService.ts
+++ b/src/services/api/planningService.ts
@@ -21,11 +21,15 @@ import { supabase, isSupabaseConfigured, handleSupabaseError } from './supabaseC
 import { storageAdapter, STORAGE_KEYS } from '../storageAdapter';
 import { createScopedLogger } from '../../loggers/scopedLogger';
 import { getDefaultCategories } from '../../data/defaultCategories';
-import type { Budget, Goal, Category } from '../../types';
+import type { Budget, Goal, Category, CategoryMergeResult } from '../../types';
 
 const logger = createScopedLogger('PlanningService');
 
 type Row = Record<string, unknown>;
+
+/** jsonb counter → number, refusing to invent a figure the database did not send. */
+const count = (value: unknown): number =>
+  typeof value === 'number' && Number.isFinite(value) ? value : 0;
 
 const str = (v: unknown): string | undefined => (typeof v === 'string' ? v : undefined);
 const num = (v: unknown): number => (typeof v === 'number' && Number.isFinite(v) ? v : 0);
@@ -579,6 +583,52 @@ export class PlanningService {
     categories[index] = { ...categories[index], ...updates };
     await this.saveCategories(categories);
     return categories[index];
+  }
+
+  /**
+   * Join two categories: every reference moves from source to target and the
+   * source is removed — in ONE database transaction (merge_categories,
+   * migration 20260805214322).
+   *
+   * The RPC validates every precondition against the rows as they are NOW
+   * (ownership, direction, groups, transfer/system/unassigned categories) and
+   * surfaces its errors verbatim, because each one names the exact rule that
+   * stopped it. There is no half-applied state for the caller to explain away.
+   *
+   * Cloud only: local/demo mode goes through DataService, which mirrors these
+   * rules against browser storage.
+   */
+  static async mergeCategories(
+    userId: string | null,
+    sourceId: string,
+    targetId: string
+  ): Promise<CategoryMergeResult> {
+    if (!this.cloudReady || !userId) {
+      throw new Error('mergeCategories requires the cloud connection (local mode goes through DataService)');
+    }
+
+    const { data, error } = await supabase!.rpc('merge_categories', {
+      p_source_id: sourceId,
+      p_target_id: targetId,
+      p_user_id: userId
+    });
+    if (error) throw new Error(handleSupabaseError(error));
+
+    const result = (data ?? {}) as Row;
+    // The source is gone server-side; drop it from the cache rather than
+    // leaving a category the database no longer has in the offline snapshot.
+    const cache = await this.getCategories();
+    await this.saveCategories(cache.filter(c => c.id !== sourceId));
+
+    return {
+      sourceId,
+      targetId,
+      transactions: count(result.transactions),
+      splitLines: count(result.split_lines),
+      splitTransactions: count(result.split_transactions),
+      budgets: count(result.budgets),
+      recurring: count(result.recurring)
+    };
   }
 
   static async deleteCategory(userId: string | null, id: string): Promise<void> {

--- a/src/services/api/supabaseClient.ts
+++ b/src/services/api/supabaseClient.ts
@@ -82,6 +82,10 @@ type Database = {
         Args: { p_ids: string[]; p_user_id: string };
         Returns: number;
       };
+      merge_categories: {
+        Args: { p_source_id: string; p_target_id: string; p_user_id: string };
+        Returns: Record<string, unknown>;
+      };
       migrate_categories_atomic: {
         Args: { p_user_id: string; p_categories: Record<string, unknown>[] };
         Returns: Record<string, unknown>[];

--- a/src/services/importRulesService.ts
+++ b/src/services/importRulesService.ts
@@ -91,6 +91,48 @@ export class ImportRulesService {
     this.saveRules();
   }
 
+  /**
+   * Re-point every "set category" action from one category to another, and
+   * report how many rules changed.
+   *
+   * Rules are the third place a category id is stored (transactions and budgets
+   * are the others), and the only one that lives in this browser rather than
+   * the database — so a category merge cannot carry them along inside its
+   * transaction. It calls this immediately afterwards instead: a rule left
+   * pointing at a merged-away category would go on matching imports and file
+   * them under an id that no longer exists, which is worse than either
+   * outcome the merge offers.
+   *
+   * Nothing is written when no rule refers to `fromCategoryId`.
+   */
+  remapCategory(fromCategoryId: string, toCategoryId: string): number {
+    if (!fromCategoryId || !toCategoryId || fromCategoryId === toCategoryId) {
+      return 0;
+    }
+
+    let changed = 0;
+    this.rules = this.rules.map(rule => {
+      if (!rule.actions.some(a => a.type === 'setCategory' && a.value === fromCategoryId)) {
+        return rule;
+      }
+      changed += 1;
+      return {
+        ...rule,
+        actions: rule.actions.map(action =>
+          action.type === 'setCategory' && action.value === fromCategoryId
+            ? { ...action, value: toCategoryId }
+            : action
+        ),
+        updatedAt: this.nowProvider()
+      };
+    });
+
+    if (changed > 0) {
+      this.saveRules();
+    }
+    return changed;
+  }
+
   private checkCondition(condition: ImportRuleCondition, transaction: Partial<Transaction>): boolean {
     let fieldValue: string | number | Date | null;
     

--- a/src/test/mocks/AppContextSupabase.ts
+++ b/src/test/mocks/AppContextSupabase.ts
@@ -61,6 +61,15 @@ const baseValue = {
   importCategoryTree: async () => ({ created: 0, skipped: 0, pruned: 0, keptForTransactions: 0 }),
   updateCategory: noop,
   deleteCategory: noop,
+  mergeCategories: async (sourceId: string, targetId: string) => ({
+    sourceId,
+    targetId,
+    transactions: 0,
+    splitLines: 0,
+    splitTransactions: 0,
+    budgets: 0,
+    recurring: 0,
+  }),
   // Async, like the real context: callers chain .catch() on these, and a
   // double that hands back `undefined` crashes the very code it is meant to
   // stand in for.

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -261,6 +261,22 @@ export interface Category {
   isActive?: boolean; // Used for soft-deleting categories (e.g., when account is deleted)
 }
 
+/**
+ * What a category merge actually moved — the database's own counts, not the
+ * client's prediction, so the confirmation toast reports what happened rather
+ * than what was expected. `splitTransactions` is the number of split PARENTS
+ * touched; `splitLines` the number of individual lines inside them.
+ */
+export interface CategoryMergeResult {
+  sourceId: string;
+  targetId: string;
+  transactions: number;
+  splitLines: number;
+  splitTransactions: number;
+  budgets: number;
+  recurring: number;
+}
+
 export interface Investment {
   id: string;
   accountId: string;

--- a/supabase/migrations/20260805214322_merge_categories.sql
+++ b/supabase/migrations/20260805214322_merge_categories.sql
@@ -1,0 +1,430 @@
+-- ============================================================================
+-- CATEGORY MERGE — "these two are the same thing" becomes ONE transaction
+-- ============================================================================
+-- IMPORTANT: apply with `npm run db:migrate` (see supabase/migrations/README.md
+-- rule 1 — never the SQL editor). Safe to apply before the matching client
+-- deploys: everything here is a NEW function, nothing existing is redefined,
+-- and no column changes. A database with this applied and the old client
+-- running behaves exactly as it does now.
+--
+-- ── WHY: a merge is one intention, and it was five half-done writes ────────
+--
+-- Two categories that mean the same thing ("Groceries" and "Food Shopping")
+-- are the commonest mess in imported history, and until now the only way to
+-- join them was to DELETE one and use the reassignment dialog that appears —
+-- a merge in disguise, and an incomplete one. That dialog moved whole
+-- transactions (one HTTP round trip per row) and split lines, then deleted the
+-- category. It never moved:
+--
+--   * budgets            — budgets.category is TEXT with no FK, so a budget
+--                          pointing at the deleted category kept a dangling id
+--                          and silently reported £0 spent for ever after;
+--                          budgets.category_id (uuid, FK ON DELETE SET NULL)
+--                          was quietly nulled instead;
+--   * recurring templates — recurring_transactions.category, same TEXT-no-FK
+--                          shape, same silent orphan;
+--   * transactions.category_id — the uuid twin of the text column, also
+--                          ON DELETE SET NULL.
+--
+-- And it was not atomic: a browser closed (or a token expired) between the row
+-- updates and the delete left the history half-moved, with no record of which
+-- half. For a ledger that is not untidiness, it is a hole in the compliance
+-- artifact — financial_audit_log is supposed to answer "what happened to this
+-- row and who did it", and for a partly-applied merge it could not.
+--
+-- merge_categories below moves EVERY reference and removes the source in one
+-- database transaction. Either the user's history is joined or it is untouched;
+-- there is no third outcome.
+--
+-- Balance-neutral by construction: no amount, sign or account_id is written by
+-- any statement here, so no account balance arithmetic appears — the same
+-- property (and the same reasoning) as link_transfer_pair and
+-- repair_claimed_transfer.
+--
+-- ── AUDIT VOLUME: one entry per row, deliberately ──────────────────────────
+--
+-- A merge can rewrite thousands of transactions, so "one summary entry" is
+-- tempting. It is also wrong, and the schema already settled the question:
+-- apply_category_to_uncategorized (20260708100000) is the other bulk
+-- re-categorisation in this database, over exactly the same kind of row
+-- volume (a payee fan-out across a whole import), and it writes one
+-- financial_audit_log entry per row changed. So does set_transactions_cleared,
+-- and so does clear_transfer_links. The log's job is to answer "what happened
+-- to THIS transaction"; a summary row cannot answer it for any of them.
+--
+-- Split lines follow the other half of the house pattern: set_transaction_splits
+-- audits a split at its PARENT transaction, with the whole line set embedded in
+-- before/after. This does the same — one entry per affected parent, carrying
+-- the before and after line sets — rather than inventing a per-line entity that
+-- nothing else in the schema writes.
+--
+-- The source category's removal gets its own entry (entity 'category', action
+-- 'delete'), which is the line that says "the merge happened, and when".
+-- ============================================================================
+
+BEGIN;
+
+-- ── merge_categories: every reference moves, or none does ───────────────────
+--
+--   p_source_id  the category being merged away — it is removed at the end;
+--   p_target_id  the category everything is filed under afterwards;
+--   p_user_id    the usual defence-in-depth owner guard (RLS scopes the rows;
+--                this makes a mis-routed id fail closed one step earlier).
+--
+-- Returns the counts of what actually moved, as jsonb, so the client reports
+-- what the database did rather than what it predicted:
+--   {transactions, split_lines, split_transactions, budgets, recurring}
+--
+-- Error style follows split_amount_locked (20260713100000) and
+-- repair_claimed_transfer (20260805145035): a machine-readable code, then the
+-- sentence the user actually needs. The client surfaces error.message verbatim,
+-- so a bare code would reach a human toast.
+CREATE OR REPLACE FUNCTION public.merge_categories(
+  p_source_id uuid,
+  p_target_id uuid,
+  p_user_id uuid DEFAULT NULL
+)
+RETURNS jsonb
+LANGUAGE plpgsql SECURITY INVOKER
+SET search_path = public
+AS $$
+DECLARE
+  v_source public.categories;
+  v_target public.categories;
+  v_owner  uuid;
+  v_old_txn       public.transactions;
+  v_new_txn       public.transactions;
+  v_parent        public.transactions;
+  v_old_budget    public.budgets;
+  v_new_budget    public.budgets;
+  v_old_recurring public.recurring_transactions;
+  v_new_recurring public.recurring_transactions;
+  v_before_splits jsonb;
+  v_after_splits  jsonb;
+  v_lines_moved      integer;
+  v_transactions     integer := 0;
+  v_split_lines      integer := 0;
+  v_split_parents    integer := 0;
+  v_budgets          integer := 0;
+  v_recurring        integer := 0;
+BEGIN
+  IF p_source_id IS NULL OR p_target_id IS NULL THEN
+    RAISE EXCEPTION 'merge_needs_two_categories: a merge needs the category to merge away and the category to merge it into'
+      USING ERRCODE = '22023';
+  END IF;
+  IF p_source_id = p_target_id THEN
+    RAISE EXCEPTION 'merge_source_is_target: a category cannot be merged into itself'
+      USING ERRCODE = '22023';
+  END IF;
+
+  -- Lock both rows up front, in id order, so concurrent merges take them the
+  -- same way round (and a merge cannot race the deletion of its own target).
+  PERFORM 1 FROM public.categories
+   WHERE id IN (p_source_id, p_target_id)
+     AND (p_user_id IS NULL OR user_id = p_user_id)
+   ORDER BY id
+   FOR UPDATE;
+
+  SELECT * INTO v_source FROM public.categories
+   WHERE id = p_source_id AND (p_user_id IS NULL OR user_id = p_user_id);
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'category_not_found' USING ERRCODE = 'P0002',
+      HINT = 'The category being merged away no longer exists, or is not yours.';
+  END IF;
+
+  SELECT * INTO v_target FROM public.categories
+   WHERE id = p_target_id AND (p_user_id IS NULL OR user_id = p_user_id);
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'category_not_found' USING ERRCODE = 'P0002',
+      HINT = 'The category being merged into no longer exists, or is not yours.';
+  END IF;
+
+  v_owner := v_source.user_id;
+  IF v_target.user_id <> v_owner THEN
+    RAISE EXCEPTION 'categories belong to different users' USING ERRCODE = '28000';
+  END IF;
+
+  -- ── What may not be merged AWAY ──────────────────────────────────────────
+  IF v_source.level = 'type' THEN
+    RAISE EXCEPTION 'merge_source_is_type_root: "%" is a top-level heading, not a category things are filed under', v_source.name
+      USING ERRCODE = 'P0001';
+  END IF;
+  IF v_source.is_transfer_category IS TRUE THEN
+    RAISE EXCEPTION 'merge_source_is_transfer_category: transfer categories are managed automatically from their account — close the account instead'
+      USING ERRCODE = 'P0001';
+  END IF;
+  -- Revaluation leaves and anything else the app files under by itself: the
+  -- code resolves these by flag, so merging one away would break a write path,
+  -- not just a report.
+  IF v_source.is_revaluation_category IS TRUE OR v_source.is_system IS TRUE THEN
+    RAISE EXCEPTION 'merge_source_is_system_category: "%" is a built-in category the app files transactions under automatically, so it cannot be merged away', v_source.name
+      USING ERRCODE = 'P0001';
+  END IF;
+  -- The import's Unassigned bucket means "NOT categorised" (20260724100000).
+  -- Merging it into a real category would file every unreviewed row as
+  -- something the user never chose — the exact guess that flag exists to stop.
+  IF v_source.is_unassigned_bucket IS TRUE THEN
+    RAISE EXCEPTION 'merge_source_is_unassigned_bucket: rows in "%" are not categorised at all — file them from the review band rather than merging the whole bucket into a real category', v_source.name
+      USING ERRCODE = 'P0001';
+  END IF;
+  -- v1 is leaf-to-leaf. A category with children is a GROUP, and merging one
+  -- means re-parenting its children as well — a different operation, with its
+  -- own consequences to explain. Refused loudly rather than half-done.
+  IF EXISTS (SELECT 1 FROM public.categories WHERE parent_id = p_source_id) THEN
+    RAISE EXCEPTION 'merge_source_has_children: "%" has categories under it — merging a whole group is not supported yet; merge its detail categories one at a time, or move them first', v_source.name
+      USING ERRCODE = 'P0001';
+  END IF;
+
+  -- ── What may not be merged INTO ──────────────────────────────────────────
+  IF v_target.level = 'type' THEN
+    RAISE EXCEPTION 'merge_target_is_type_root: "%" is a top-level heading — nothing is filed against one', v_target.name
+      USING ERRCODE = 'P0001';
+  END IF;
+  IF v_target.is_transfer_category IS TRUE THEN
+    RAISE EXCEPTION 'merge_target_is_transfer_category: "%" belongs to an account''s transfer bookkeeping — filing ordinary transactions there would invent transfers that never happened', v_target.name
+      USING ERRCODE = 'P0001';
+  END IF;
+  IF v_target.is_unassigned_bucket IS TRUE THEN
+    RAISE EXCEPTION 'merge_target_is_unassigned_bucket: "%" means "not categorised" — merging into it would un-file transactions that are already filed', v_target.name
+      USING ERRCODE = 'P0001';
+  END IF;
+  IF v_target.is_active IS FALSE THEN
+    RAISE EXCEPTION 'merge_target_inactive: "%" is hidden, so nothing can be filed under it — pick a category that is in use', v_target.name
+      USING ERRCODE = 'P0001';
+  END IF;
+  IF EXISTS (SELECT 1 FROM public.categories WHERE parent_id = p_target_id) THEN
+    RAISE EXCEPTION 'merge_target_is_group: "%" is a group, and transactions belong to a category inside it — pick one of its detail categories', v_target.name
+      USING ERRCODE = 'P0001';
+  END IF;
+
+  -- ── Direction ────────────────────────────────────────────────────────────
+  -- income → income, expense → expense. A 'both' target (a revaluation leaf,
+  -- an unparented "other" category) takes either, because it carries no
+  -- direction of its own; a 'both' SOURCE cannot go to a directional target,
+  -- since its rows may point both ways and half of them would land on the
+  -- wrong side of every report.
+  IF v_target.type <> 'both' AND v_target.type <> v_source.type THEN
+    RAISE EXCEPTION 'merge_direction_mismatch: "%" is an % category and "%" is an % one — merging across the two would file money on the wrong side of every report',
+      v_source.name, v_source.type, v_target.name, v_target.type
+      USING ERRCODE = 'P0001';
+  END IF;
+
+  -- ── 1. Whole transactions ────────────────────────────────────────────────
+  -- Both reference columns move together. The CASE on `category` matters for a
+  -- SPLIT parent reached through the uuid column: its category is blank BY
+  -- DESIGN, and protect_split_transaction_fields (20260713100000) rejects any
+  -- update that gives a split parent a category — leaving the blank alone is
+  -- what lets that row's category_id move without tripping the guard.
+  FOR v_old_txn IN
+    SELECT * FROM public.transactions
+     WHERE user_id = v_owner
+       AND (category = p_source_id::text OR category_id = p_source_id)
+     ORDER BY id     -- concurrent calls walk the rows the same way
+     FOR UPDATE
+  LOOP
+    UPDATE public.transactions
+       SET category    = CASE WHEN category = p_source_id::text
+                              THEN p_target_id::text ELSE category END,
+           category_id = CASE WHEN category_id = p_source_id
+                              THEN p_target_id ELSE category_id END,
+           updated_at  = now()
+     WHERE id = v_old_txn.id
+    RETURNING * INTO v_new_txn;
+
+    PERFORM public.write_financial_audit(
+      v_owner, 'transaction', v_new_txn.id, 'update',
+      to_jsonb(v_old_txn), to_jsonb(v_new_txn)
+    );
+
+    v_transactions := v_transactions + 1;
+  END LOOP;
+
+  -- ── 2. Split lines, audited on their parent ──────────────────────────────
+  -- The parent is locked (not just read) so a concurrent set_transaction_splits
+  -- cannot rewrite the line set between the two snapshots. Amounts are
+  -- untouched, so the sum invariant the splits schema enforces still holds and
+  -- no balance moves. Two lines of the same parent landing on the SAME target
+  -- category is left as two lines: their memos and their history are the
+  -- user's, and silently adding them together would destroy both.
+  FOR v_parent IN
+    SELECT t.* FROM public.transactions t
+     WHERE t.user_id = v_owner
+       AND t.id IN (
+         SELECT s.transaction_id FROM public.transaction_splits s
+          WHERE s.user_id = v_owner AND s.category = p_source_id::text
+       )
+     ORDER BY t.id
+     FOR UPDATE
+  LOOP
+    SELECT COALESCE(jsonb_agg(to_jsonb(s) ORDER BY s.sort_order), '[]'::jsonb)
+      INTO v_before_splits
+      FROM public.transaction_splits s
+     WHERE s.transaction_id = v_parent.id;
+
+    UPDATE public.transaction_splits
+       SET category = p_target_id::text,
+           updated_at = now()
+     WHERE transaction_id = v_parent.id
+       AND category = p_source_id::text;
+    GET DIAGNOSTICS v_lines_moved = ROW_COUNT;
+
+    -- A parent whose lines moved on under us between the lookup and the lock
+    -- gets no write and no audit entry — the same "no write, no audit noise"
+    -- rule clear_transfer_links follows, and it keeps the returned counts true.
+    IF v_lines_moved > 0 THEN
+      SELECT COALESCE(jsonb_agg(to_jsonb(s) ORDER BY s.sort_order), '[]'::jsonb)
+        INTO v_after_splits
+        FROM public.transaction_splits s
+       WHERE s.transaction_id = v_parent.id;
+
+      PERFORM public.write_financial_audit(
+        v_owner, 'transaction', v_parent.id, 'update',
+        to_jsonb(v_parent) || jsonb_build_object('splits', v_before_splits),
+        to_jsonb(v_parent) || jsonb_build_object('splits', v_after_splits)
+      );
+
+      v_split_lines   := v_split_lines + v_lines_moved;
+      v_split_parents := v_split_parents + 1;
+    END IF;
+  END LOOP;
+
+  -- ── 3. Budgets ───────────────────────────────────────────────────────────
+  -- The surface the delete-and-reassign dialog never moved. Audited like the
+  -- rest: budgets have no other audited write path today, and this one is not
+  -- going to be the first silent change to what a budget measures.
+  FOR v_old_budget IN
+    SELECT * FROM public.budgets
+     WHERE user_id = v_owner
+       AND (category = p_source_id::text OR category_id = p_source_id)
+     ORDER BY id
+     FOR UPDATE
+  LOOP
+    UPDATE public.budgets
+       SET category    = CASE WHEN category = p_source_id::text
+                              THEN p_target_id::text ELSE category END,
+           category_id = CASE WHEN category_id = p_source_id
+                              THEN p_target_id ELSE category_id END,
+           updated_at  = now()
+     WHERE id = v_old_budget.id
+    RETURNING * INTO v_new_budget;
+
+    PERFORM public.write_financial_audit(
+      v_owner, 'budget', v_new_budget.id, 'update',
+      to_jsonb(v_old_budget), to_jsonb(v_new_budget)
+    );
+
+    v_budgets := v_budgets + 1;
+  END LOOP;
+
+  -- ── 4. Recurring templates ───────────────────────────────────────────────
+  -- recurring_transactions.user_id is the CLERK id (text), not the uuid every
+  -- other table here uses, so these rows cannot be scoped by v_owner. They do
+  -- not need to be: a category id is a globally unique uuid, so matching on it
+  -- can only reach this owner's templates — the same reasoning
+  -- delete_unused_categories (20260708160000) relies on. RLS
+  -- (requesting_clerk_id) is the second lock.
+  FOR v_old_recurring IN
+    SELECT * FROM public.recurring_transactions
+     WHERE category = p_source_id::text
+     ORDER BY id
+     FOR UPDATE
+  LOOP
+    UPDATE public.recurring_transactions
+       SET category = p_target_id::text,
+           updated_at = now()
+     WHERE id = v_old_recurring.id
+    RETURNING * INTO v_new_recurring;
+
+    PERFORM public.write_financial_audit(
+      v_owner, 'recurring_transaction', v_new_recurring.id, 'update',
+      to_jsonb(v_old_recurring), to_jsonb(v_new_recurring)
+    );
+
+    v_recurring := v_recurring + 1;
+  END LOOP;
+
+  -- ── 5. Nothing may still point at the source ─────────────────────────────
+  -- The invariant that makes the delete safe, checked rather than assumed: if
+  -- a reference surface is ever added and this function is not taught about
+  -- it, the merge fails loudly here instead of orphaning that reference
+  -- silently. The raise aborts the whole call, so "nothing has changed" is
+  -- literally true — every move above rolls back with it.
+  IF EXISTS (
+       SELECT 1 FROM public.transactions
+        WHERE user_id = v_owner
+          AND (category = p_source_id::text OR category_id = p_source_id))
+     OR EXISTS (
+       SELECT 1 FROM public.transaction_splits
+        WHERE user_id = v_owner AND category = p_source_id::text)
+     OR EXISTS (
+       SELECT 1 FROM public.budgets
+        WHERE user_id = v_owner
+          AND (category = p_source_id::text OR category_id = p_source_id))
+     OR EXISTS (
+       SELECT 1 FROM public.recurring_transactions
+        WHERE category = p_source_id::text)
+     OR EXISTS (
+       SELECT 1 FROM public.categories WHERE parent_id = p_source_id)
+  THEN
+    RAISE EXCEPTION 'merge_left_references: something still refers to "%" after the move, so nothing has been changed', v_source.name
+      USING ERRCODE = 'P0001';
+  END IF;
+
+  -- ── 6. The source goes ───────────────────────────────────────────────────
+  -- A hard delete, because that is what deleting a category already does
+  -- (PlanningService.deleteCategory). is_active is NOT the convention here: it
+  -- is the account lifecycle's way of hiding a closed account's transfer
+  -- category, and a deactivated leftover would sit in this user's tree for ever
+  -- meaning nothing.
+  DELETE FROM public.categories
+   WHERE id = p_source_id AND user_id = v_owner;
+
+  PERFORM public.write_financial_audit(
+    v_owner, 'category', v_source.id, 'delete', to_jsonb(v_source), NULL
+  );
+
+  RETURN jsonb_build_object(
+    'source_id',          p_source_id,
+    'target_id',          p_target_id,
+    'transactions',       v_transactions,
+    'split_lines',        v_split_lines,
+    'split_transactions', v_split_parents,
+    'budgets',            v_budgets,
+    'recurring',          v_recurring
+  );
+END;
+$$;
+
+COMMENT ON FUNCTION public.merge_categories(uuid, uuid, uuid) IS
+  'Joins two categories in ONE transaction: moves every reference (transactions.category/category_id, transaction_splits.category, budgets.category/category_id, recurring_transactions.category) from source to target, verifies nothing still points at the source, then deletes it. Balance-neutral. One financial_audit_log entry per row moved (splits audited on their parent, as set_transaction_splits does), plus a category delete entry. Refuses groups, type roots, transfer/system/unassigned categories and cross-direction merges.';
+
+-- ── Grants ──────────────────────────────────────────────────────────────────
+-- FROM PUBLIC, anon — naming anon explicitly, because REVOKE ... FROM PUBLIC
+-- alone does NOT remove Supabase's named default grant to anon (the trap
+-- documented at length in 20260725120000). Re-running these is a no-op.
+REVOKE ALL ON FUNCTION public.merge_categories(uuid, uuid, uuid) FROM PUBLIC, anon;
+GRANT EXECUTE ON FUNCTION public.merge_categories(uuid, uuid, uuid) TO authenticated, service_role;
+
+COMMIT;
+
+-- ============================================================================
+-- VERIFICATION — read this output after applying
+-- ============================================================================
+-- Expected: one row, showing `authenticated, service_role` and neither PUBLIC
+-- nor anon.
+SELECT
+  format('%I.%I(%s)', n.nspname, p.proname,
+         pg_get_function_identity_arguments(p.oid)) AS routine,
+  COALESCE(
+    (SELECT string_agg(DISTINCT COALESCE(g.rolname, 'PUBLIC'), ', ')
+       FROM aclexplode(p.proacl) a
+       LEFT JOIN pg_roles g ON g.oid = a.grantee
+      WHERE a.privilege_type = 'EXECUTE'
+        AND COALESCE(g.rolname, 'PUBLIC') IN ('PUBLIC', 'anon', 'authenticated', 'service_role')),
+    '—'
+  ) AS execute_granted_to
+FROM pg_proc p
+JOIN pg_namespace n ON n.oid = p.pronamespace
+WHERE n.nspname = 'public'
+  AND p.proname = 'merge_categories'
+ORDER BY 1;


### PR DESCRIPTION
## What

- **Category merge** — Settings → Categories gains a Merge mode: pick a category, choose what it joins, and a consequence-first dialog states the real counts ("3 transactions, 1 split line and 1 budget move to X; Y is then removed") before one atomic `merge_categories` RPC moves every reference — transactions, split lines (audited on their parents with full line sets), budgets, recurring templates, both uuid twins — verifies nothing still points at the source, then removes it. One audit entry per row moved. Guardrails: no groups (v1 is leaf-to-leaf, greyed with reasons), no transfer/system/revaluation categories, no unassigned bucket either side, no cross-direction merges. Local import rules are re-pointed client-side.
- **Three real bugs the investigation surfaced**, all fixed by routing the old delete-with-reassign through the same call: it never moved **budgets** (a budget on a deleted category kept a dangling id and read £0 spent for ever), never moved recurring templates or the `category_id` columns, hard-deleted a budget-only category with no reassignment offered, and ran one HTTP round trip per transaction with no atomicity.
- **Sortable headers** in Match transfers (both tables) and Categorise by payee. The payee Category column groups undecided rows last in *both* directions; pair selection survives re-sorting (regression-tested).
- **Register boot-out fix** — clicking a category in the edit modal closed it mid-pick: the modal's portalled menus render outside the dialog subtree, so the register's click-outside-to-deselect unmounted the editor mid-click. Would have bitten any register edit, not just deep-linked ones.
- **Drill auto-close** — filing the last outstanding row dismisses the popup back to Categorisation.
- **Grouped account pickers** across eleven transaction editors via one new shared component, with the two earlier transfer selects retrofitted onto it so exactly one implementation exists.

## Verification
- 3,824 tests passing (+40); strict typecheck + lint clean.
- Migration `20260805214322_merge_categories.sql` reviewed line-by-line against live contracts and **already applied via `db:migrate`** (history truthful, grants verified: authenticated/service_role only).
- Browser-verified in demo: a real merge (Clothing → Food & Drink) showing the consequence sentence, the database's own counts in the toast, and group-refusal explanations rendering; grouped account picker banding; drill auto-close; category pick no longer closing the editor.

## Follow-ups noted (deliberate scope calls)
Account *filters* on Transactions/report builder (one-liners with the new component), and an older bank-wizard account combobox — the last duplicate grouping implementation, with intentionally different headings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)