### PR TITLE
fix(routing+accounts): a closed account is not a missing one, and a stale tab recovers itself

### DIFF
--- a/src/components/DebugErrorBoundary.tsx
+++ b/src/components/DebugErrorBoundary.tsx
@@ -1,6 +1,7 @@
 import React, { Component, ErrorInfo, ReactNode } from 'react';
 import { createScopedLogger } from '../loggers/scopedLogger';
 import { captureException } from '../lib/sentry';
+import { isChunkLoadError } from '../utils/chunkLoadError';
 
 interface Props {
   children: ReactNode;
@@ -50,16 +51,22 @@ export class DebugErrorBoundary extends Component<Props, State> {
       return this.props.children;
     }
 
+    // Same distinction the inner boundary draws: code that would not download
+    // is a deploy race, not a crash, and saying so turns a scary page into an
+    // obvious one-click fix.
+    const staleChunk = isChunkLoadError(this.state.error);
+
     if (!import.meta.env.DEV) {
       return (
         <div className="min-h-screen bg-gray-50 dark:bg-gray-900 flex items-center justify-center p-6">
           <div className="max-w-md w-full text-center">
             <h1 className="text-2xl font-semibold text-gray-900 dark:text-white mb-2">
-              Something went wrong
+              {staleChunk ? 'WealthTracker has been updated' : 'Something went wrong'}
             </h1>
             <p className="text-sm text-gray-600 dark:text-gray-400 mb-6">
-              The page could not be displayed. Your data has not been changed.
-              Reloading usually fixes it.
+              {staleChunk
+                ? "This tab is still running the older version, so the page couldn't load. Reload to pick up the update — nothing you've saved is affected."
+                : 'The page could not be displayed. Your data has not been changed. Reloading usually fixes it.'}
             </p>
             <button
               onClick={() => window.location.reload()}

--- a/src/components/EditTransactionModal.transferJump.test.tsx
+++ b/src/components/EditTransactionModal.transferJump.test.tsx
@@ -187,24 +187,28 @@ describe('EditTransactionModal — jump to the other side', () => {
     expect(mocks.navigate).toHaveBeenCalledWith('/accounts/acc-b?txn=txn-in&demo=true');
   });
 
-  it('disables the jump, with the reason, when the other account is closed', () => {
-    // Closed accounts are absent from the context's account list.
+  it('still takes the jump when the other account is closed, saying what to expect', () => {
+    // Closed accounts are absent from the context's account list — so the name
+    // cannot be printed, and the label stays generic. The jump is offered all
+    // the same: the register owns the closed-account offer ("Re-open and
+    // view"), so the way through arrives where the user asked for it rather
+    // than being described as homework on another page.
     mocks.app.accounts = [account('acc-a', 'Current Account')];
     renderModal(OUT_LEG);
 
     const button = jumpButton();
-    expect(button).toBeDisabled();
+    expect(button).toBeEnabled();
     expect(button).toHaveTextContent('Jump to the other side →');
     expect(button).toHaveAttribute(
       'title',
-      'That account is closed — re-open it from the Accounts page to view this leg'
+      'That account is closed — the register will offer to re-open it'
     );
     expect(
-      screen.getByText(/re-open it from the Accounts page to view this leg/i)
+      screen.getByText(/that account is closed — the register will offer to re-open it/i)
     ).toBeInTheDocument();
 
     fireEvent.click(button);
-    expect(mocks.navigate).not.toHaveBeenCalled();
+    expect(mocks.navigate).toHaveBeenCalledWith('/accounts/acc-b?txn=txn-in');
   });
 
   it('does not offer the jump for a transfer with no linked side', () => {

--- a/src/components/EditTransactionModal.tsx
+++ b/src/components/EditTransactionModal.tsx
@@ -585,8 +585,13 @@ export default function EditTransactionModal({ isOpen, onClose, transaction, def
     [transaction, transactions, accounts]
   );
 
+  // The jump is taken even when that account is CLOSED: the register itself
+  // owns the closed-account offer now (name, explanation, "Re-open and view"),
+  // so the way through arrives where the user asked for it instead of being
+  // described to them. `isOpen` still shapes the label — a closed account's
+  // name isn't in the context list to print.
   const handleJumpToOtherSide = (): void => {
-    if (!otherSide?.isOpen) return;
+    if (!otherSide) return;
     const params = new URLSearchParams();
     params.set('txn', otherSide.transactionId);
     if (new URLSearchParams(location.search).get('demo') === 'true') {
@@ -824,21 +829,20 @@ export default function EditTransactionModal({ isOpen, onClose, transaction, def
                       <button
                         type="button"
                         onClick={handleJumpToOtherSide}
-                        disabled={!otherSide.isOpen}
                         title={otherSide.isOpen
                           ? 'Open the matching transaction in its own account'
-                          : 'That account is closed — re-open it from the Accounts page to view this leg'}
-                        className="mt-2 inline-block text-sm font-medium text-primary hover:text-secondary disabled:opacity-50 disabled:cursor-not-allowed disabled:hover:text-primary"
+                          : 'That account is closed — the register will offer to re-open it'}
+                        className="mt-2 inline-block text-sm font-medium text-primary hover:text-secondary"
                       >
                         {otherSide.accountName
                           ? `Jump to the other side in ${otherSide.accountName} →`
                           : 'Jump to the other side →'}
                       </button>
-                      {/* A disabled button's title is never announced (its
-                          label wins), so the reason is said out loud here. */}
+                      {/* A button's title is not announced (its label wins), so
+                          what to expect on the other end is said out loud. */}
                       {!otherSide.isOpen && (
                         <p className="mt-1 text-xs text-gray-500 dark:text-gray-400">
-                          That account is closed — re-open it from the Accounts page to view this leg.
+                          That account is closed — the register will offer to re-open it.
                         </p>
                       )}
                     </>

--- a/src/components/ErrorBoundary.test.tsx
+++ b/src/components/ErrorBoundary.test.tsx
@@ -1,0 +1,105 @@
+/**
+ * ErrorBoundary Tests
+ * A failed chunk download is a deploy race, not a crash, and the boundary has
+ * to say so — the generic card's "Try Again" cannot fix it (React caches a
+ * failed lazy import and re-throws it on every later render).
+ */
+
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect, afterEach } from 'vitest';
+import ErrorBoundary from './ErrorBoundary';
+
+function Exploding({ error }: { error: Error }): React.JSX.Element {
+  throw error;
+}
+
+function setOnline(value: boolean): void {
+  Object.defineProperty(window.navigator, 'onLine', {
+    configurable: true,
+    get: () => value,
+  });
+}
+
+describe('ErrorBoundary', () => {
+  afterEach(() => {
+    setOnline(true);
+  });
+
+  describe('stale chunk after a deploy', () => {
+    it('offers the update and a reload rather than the crash copy', () => {
+      render(
+        <ErrorBoundary>
+          <Exploding error={new TypeError('Importing a module script failed.')} />
+        </ErrorBoundary>
+      );
+
+      expect(screen.getByText('WealthTracker has been updated')).toBeInTheDocument();
+      expect(screen.getByText(/still running the older version/)).toBeInTheDocument();
+      expect(screen.getByText(/nothing you've saved is affected/)).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: 'Reload' })).toBeInTheDocument();
+      expect(screen.queryByRole('button', { name: 'Try Again' })).not.toBeInTheDocument();
+      expect(screen.queryByText('Oops! Something went wrong')).not.toBeInTheDocument();
+    });
+
+    it('recognises the Chrome wording too', () => {
+      render(
+        <ErrorBoundary>
+          <Exploding error={new TypeError('Failed to fetch dynamically imported module: /assets/Transactions-8f3a1c.js')} />
+        </ErrorBoundary>
+      );
+
+      expect(screen.getByText('WealthTracker has been updated')).toBeInTheDocument();
+    });
+
+    it('says the honest thing when the tab is offline', () => {
+      setOnline(false);
+
+      render(
+        <ErrorBoundary>
+          <Exploding error={new TypeError('Importing a module script failed.')} />
+        </ErrorBoundary>
+      );
+
+      expect(screen.getByText("You're offline")).toBeInTheDocument();
+      expect(screen.getByText(/Reconnect and reload/)).toBeInTheDocument();
+      expect(screen.queryByText('WealthTracker has been updated')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('genuine crash', () => {
+    it('keeps the generic copy and the Try Again action', () => {
+      render(
+        <ErrorBoundary>
+          <Exploding error={new TypeError("Cannot read properties of undefined (reading 'balance')")} />
+        </ErrorBoundary>
+      );
+
+      expect(screen.getByText('Oops! Something went wrong')).toBeInTheDocument();
+      expect(screen.getByText("Cannot read properties of undefined (reading 'balance')")).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: 'Try Again' })).toBeInTheDocument();
+      expect(screen.queryByText('WealthTracker has been updated')).not.toBeInTheDocument();
+    });
+
+    it('does not mistake a failed API call for a stale chunk', () => {
+      render(
+        <ErrorBoundary>
+          <Exploding error={new TypeError('Failed to fetch')} />
+        </ErrorBoundary>
+      );
+
+      expect(screen.getByText('Oops! Something went wrong')).toBeInTheDocument();
+      expect(screen.queryByText('WealthTracker has been updated')).not.toBeInTheDocument();
+    });
+  });
+
+  it('renders its children when nothing has thrown', () => {
+    render(
+      <ErrorBoundary>
+        <p>Register</p>
+      </ErrorBoundary>
+    );
+
+    expect(screen.getByText('Register')).toBeInTheDocument();
+  });
+});

--- a/src/components/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary.tsx
@@ -1,9 +1,10 @@
 import { Component, useRef } from 'react';
 import type { ReactNode, ErrorInfo } from 'react';
 import { useLocation } from 'react-router-dom';
-import { AlertTriangleIcon, RefreshCwIcon, HomeIcon } from './icons';
+import { AlertTriangleIcon, RefreshCwIcon, HomeIcon, DownloadIcon, WifiOffIcon } from './icons';
 import { captureException } from '../lib/sentry';
 import { createScopedLogger } from '../loggers/scopedLogger';
+import { isChunkLoadError } from '../utils/chunkLoadError';
 
 interface Props {
   children: ReactNode;
@@ -112,21 +113,43 @@ class ErrorBoundaryClass extends Component<Props & { resetKey?: string }, State>
 
   render() {
     if (this.state.hasError) {
+      // Code that won't download is not a crash: a deploy has replaced the files
+      // this tab was booted with (or, offline, they were never cached). Name
+      // that, and offer the one action that fixes it — the generic crash card
+      // tells the user nothing and its "Try Again" cannot work, because React
+      // caches a lazy import's rejection and re-throws it on every later render.
+      const staleChunk = isChunkLoadError(this.state.error);
+      const offline = typeof navigator !== 'undefined' && navigator.onLine === false;
+
       return this.props.fallback || (
         <div className="min-h-[400px] flex items-center justify-center p-4">
           <div className="max-w-md w-full bg-white dark:bg-gray-800 rounded-2xl shadow-xl p-8 text-center">
             <div className="flex justify-center mb-6">
-              <div className="w-20 h-20 bg-red-100 dark:bg-red-900/30 rounded-full flex items-center justify-center">
-                <AlertTriangleIcon size={40} className="text-red-600 dark:text-red-400" />
-              </div>
+              {staleChunk ? (
+                <div className="w-20 h-20 bg-blue-100 dark:bg-blue-900/30 rounded-full flex items-center justify-center">
+                  {offline
+                    ? <WifiOffIcon size={40} className="text-blue-600 dark:text-blue-400" />
+                    : <DownloadIcon size={40} className="text-blue-600 dark:text-blue-400" />}
+                </div>
+              ) : (
+                <div className="w-20 h-20 bg-red-100 dark:bg-red-900/30 rounded-full flex items-center justify-center">
+                  <AlertTriangleIcon size={40} className="text-red-600 dark:text-red-400" />
+                </div>
+              )}
             </div>
-            
+
             <h3 className="text-2xl font-bold text-gray-900 dark:text-white mb-2">
-              Oops! Something went wrong
+              {staleChunk
+                ? (offline ? "You're offline" : 'WealthTracker has been updated')
+                : 'Oops! Something went wrong'}
             </h3>
-            
+
             <p className="text-gray-600 dark:text-gray-400 mb-6">
-              {this.state.error?.message || 'An unexpected error occurred. Please try again.'}
+              {staleChunk
+                ? (offline
+                    ? "This part of the app hadn't been downloaded yet, so it couldn't load. Reconnect and reload to carry on — nothing you've saved is affected."
+                    : "This tab is still running the older version, so part of the page couldn't load. Reload to pick up the update — nothing you've saved is affected.")
+                : (this.state.error?.message || 'An unexpected error occurred. Please try again.')}
             </p>
 
             {process.env.NODE_ENV === 'development' && this.state.error && (
@@ -148,14 +171,24 @@ class ErrorBoundaryClass extends Component<Props & { resetKey?: string }, State>
             )}
 
             <div className="flex flex-col sm:flex-row gap-3 justify-center">
-              <button
-                onClick={() => this.setState({ hasError: false, error: undefined, errorInfo: undefined })}
-                className="flex items-center justify-center gap-2 px-6 py-3 bg-[#1a2332] text-white rounded-lg hover:bg-[#2d3a4d] transition-colors"
-              >
-                <RefreshCwIcon size={18} />
-                Try Again
-              </button>
-              
+              {staleChunk ? (
+                <button
+                  onClick={() => window.location.reload()}
+                  className="flex items-center justify-center gap-2 px-6 py-3 bg-[#1a2332] text-white rounded-lg hover:bg-[#2d3a4d] transition-colors"
+                >
+                  <RefreshCwIcon size={18} />
+                  Reload
+                </button>
+              ) : (
+                <button
+                  onClick={() => this.setState({ hasError: false, error: undefined, errorInfo: undefined })}
+                  className="flex items-center justify-center gap-2 px-6 py-3 bg-[#1a2332] text-white rounded-lg hover:bg-[#2d3a4d] transition-colors"
+                >
+                  <RefreshCwIcon size={18} />
+                  Try Again
+                </button>
+              )}
+
               <button
                 onClick={() => window.location.href = '/'}
                 className="flex items-center justify-center gap-2 px-6 py-3 bg-gray-200 dark:bg-gray-700 text-gray-700 dark:text-gray-300 rounded-lg hover:bg-gray-300 dark:hover:bg-gray-600 transition-colors"

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -1,7 +1,8 @@
-import React, { useState, useEffect, useCallback, useRef, lazy, Suspense } from 'react';
+import React, { useState, useEffect, useCallback, useRef, Suspense } from 'react';
 import { Link, useLocation, Outlet, useNavigate } from 'react-router-dom';
+import { lazyWithRecovery } from '../utils/lazyWithRecovery';
 
-const AddTransactionModal = lazy(() => import('./AddTransactionModal'));
+const AddTransactionModal = lazyWithRecovery(() => import('./AddTransactionModal'));
 import { UserButton } from '@clerk/clerk-react';
 import { HomeIcon, CreditCardIcon, WalletIcon, TrendingUpIcon, SettingsIcon, MenuIcon, XIcon, ArrowRightLeftIcon, BarChart3Icon, GoalIcon, ChevronRightIcon, DatabaseIcon, TagIcon, Settings2Icon, TargetIcon, HashIcon, SearchIcon, PieChartIcon, ShieldIcon, UploadIcon, DownloadIcon, FolderIcon, BankIcon, CalendarIcon } from '../components/icons';
 import { SidebarLink, TopNavItem, TopNavDropdown } from './layout/NavComponents';

--- a/src/components/LazyErrorBoundary.tsx
+++ b/src/components/LazyErrorBoundary.tsx
@@ -1,5 +1,6 @@
 import React, { Component, ReactNode } from 'react';
-import { AlertCircleIcon, RefreshCwIcon } from './icons';
+import { AlertCircleIcon, RefreshCwIcon, DownloadIcon } from './icons';
+import { isChunkLoadError } from '../utils/chunkLoadError';
 
 interface Props {
   children: ReactNode;
@@ -53,24 +54,36 @@ export class LazyErrorBoundary extends Component<Props, State> {
         return <>{this.props.fallback}</>;
       }
 
+      // A chunk that would not download needs a fresh document, not a retry:
+      // React caches the failed lazy import and re-throws it on every later
+      // render, so the retry button below would do nothing at all here.
+      const staleChunk = isChunkLoadError(this.state.error);
+      const subject = this.props.componentName ?? 'this part of the page';
+
       return (
         <div className="flex flex-col items-center justify-center p-8 bg-white dark:bg-gray-800 rounded-lg shadow-md">
-          <AlertCircleIcon className="w-12 h-12 text-red-500 mb-4" aria-hidden="true" />
+          {staleChunk ? (
+            <DownloadIcon className="w-12 h-12 text-blue-600 dark:text-blue-400 mb-4" aria-hidden="true" />
+          ) : (
+            <AlertCircleIcon className="w-12 h-12 text-red-500 mb-4" aria-hidden="true" />
+          )}
           <h3 className="text-lg font-semibold text-gray-900 dark:text-white mb-2">
-            Something went wrong
+            {staleChunk ? 'WealthTracker has been updated' : 'Something went wrong'}
           </h3>
           <p className="text-gray-600 dark:text-gray-400 text-center mb-4">
-            {this.props.componentName
-              ? `Failed to load ${this.props.componentName}`
-              : 'Failed to load this component'}
+            {staleChunk
+              ? `This tab is still running the older version, so ${subject} couldn't load. Reload to pick up the update — nothing you've saved is affected.`
+              : this.props.componentName
+                ? `Failed to load ${this.props.componentName}`
+                : 'Failed to load this component'}
           </p>
           <button
-            onClick={this.handleRetry}
+            onClick={staleChunk ? () => window.location.reload() : this.handleRetry}
             className="flex items-center gap-2 px-4 py-2 bg-[#1a2332] text-white rounded-lg hover:bg-[#2d3a4d] transition-colors focus:outline-none focus:ring-2 focus:ring-blue-600 focus:ring-offset-2"
-            aria-label="Retry loading component"
+            aria-label={staleChunk ? 'Reload the page' : 'Retry loading component'}
           >
             <RefreshCwIcon className="w-4 h-4" aria-hidden="true" />
-            Try Again
+            {staleChunk ? 'Reload' : 'Try Again'}
           </button>
           {process.env.NODE_ENV === 'development' && this.state.error && (
             <details className="mt-4 w-full">

--- a/src/components/banking/LinkBankAccountsModal.tsx
+++ b/src/components/banking/LinkBankAccountsModal.tsx
@@ -1,15 +1,23 @@
-import React, { useEffect, useState, useCallback, lazy, Suspense } from 'react';
+import React, { useEffect, useState, useCallback, Suspense } from 'react';
 import { Modal, ModalBody, ModalFooter } from '../common/Modal';
 import { bankConnectionService } from '../../services/bankConnectionService';
 import { useApp } from '../../contexts/AppContextSupabase';
 import { useCurrencyDecimal } from '../../hooks/useCurrencyDecimal';
+import { lazyWithRecovery } from '../../utils/lazyWithRecovery';
+import LazyErrorBoundary from '../LazyErrorBoundary';
 import type { DiscoveredBankAccount } from '../../types/banking-api';
 import type { Account } from '../../types';
 
 import AccountPickerCombobox from './AccountPickerCombobox';
 import { CREATE_NEW_VALUE } from './accountPickerOptions';
 
-const AddAccountModal = lazy(() => import('../AddAccountModal'));
+// The only lazy import in the app that must NOT reload the page on its own.
+// It is reached part-way through linking a bank connection: discovery has
+// already run against the bank, and the user has matched accounts by hand.
+// Reloading would discard every match and re-run discovery, so a stale chunk
+// is handled in place instead (see the fallback below) — they can link what
+// they have matched and choose when to take the update.
+const AddAccountModal = lazyWithRecovery(() => import('../AddAccountModal'), { autoReload: false });
 
 interface LinkBankAccountsModalProps {
   isOpen: boolean;
@@ -162,6 +170,17 @@ export default function LinkBankAccountsModal({
       loadDiscoveredAccounts();
     }
   }, [isOpen, connectionId, loadDiscoveredAccounts]);
+
+  // Leaving the create-account step: the dropdown that opened it goes back to
+  // "skip" so it never claims an account that was never created.
+  const cancelCreateAccount = useCallback(() => {
+    setLinks(prev => prev.map(link =>
+      link.externalAccountId === createAccountFor
+        ? { ...link, selectedAccountId: '' }
+        : link
+    ));
+    setCreateAccountFor(null);
+  }, [createAccountFor]);
 
   const updateLink = (externalAccountId: string, selectedAccountId: string) => {
     if (selectedAccountId === CREATE_NEW_VALUE) {
@@ -366,36 +385,67 @@ export default function LinkBankAccountsModal({
     {createAccountFor && (() => {
       const da = discoveredAccounts.find(d => d.externalAccountId === createAccountFor);
       return (
-        <Suspense fallback={null}>
-          <AddAccountModal
-            isOpen={true}
-            onClose={() => {
-              // Reset dropdown to skip since they cancelled
-              setLinks(prev => prev.map(link =>
-                link.externalAccountId === createAccountFor
-                  ? { ...link, selectedAccountId: '' }
-                  : link
-              ));
-              setCreateAccountFor(null);
-            }}
-            prefill={{
-              name: da?.name,
-              type: da?.type === 'checking' ? 'current' : da?.type as 'current' | 'savings' | 'credit' | 'loan' | 'investment' | 'assets' | 'other' | undefined,
-              balance: da?.balance?.toString(),
-              currency: da?.currency,
-              sortCode: da?.sortCode,
-              accountNumber: da?.accountNumber,
-            }}
-            onAccountCreated={(newAccountId) => {
-              setLinks(prev => prev.map(link =>
-                link.externalAccountId === createAccountFor
-                  ? { ...link, selectedAccountId: newAccountId }
-                  : link
-              ));
-              setCreateAccountFor(null);
-            }}
-          />
-        </Suspense>
+        <LazyErrorBoundary
+          componentName="the new account form"
+          fallback={
+            <Modal
+              isOpen={true}
+              onClose={cancelCreateAccount}
+              title="Couldn't open the new account form"
+              size="sm"
+            >
+              <ModalBody>
+                <p className="text-sm text-gray-600 dark:text-gray-400">
+                  This tab couldn&apos;t load the form — usually because WealthTracker has
+                  been updated since you opened this screen. Your matches are still here:
+                  link them first if you want to keep them, because reloading starts this
+                  screen again.
+                </p>
+              </ModalBody>
+              <ModalFooter>
+                <div className="flex gap-3 w-full">
+                  <button
+                    type="button"
+                    onClick={cancelCreateAccount}
+                    className="flex-1 justify-center bg-[#1a2332] text-white px-4 py-2 rounded-lg hover:bg-secondary transition-colors"
+                  >
+                    Back to matching
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => window.location.reload()}
+                    className="flex-1 justify-center bg-gray-200 dark:bg-gray-700 text-gray-700 dark:text-gray-300 px-4 py-2 rounded-lg hover:bg-gray-300 dark:hover:bg-gray-600 transition-colors"
+                  >
+                    Reload
+                  </button>
+                </div>
+              </ModalFooter>
+            </Modal>
+          }
+        >
+          <Suspense fallback={null}>
+            <AddAccountModal
+              isOpen={true}
+              onClose={cancelCreateAccount}
+              prefill={{
+                name: da?.name,
+                type: da?.type === 'checking' ? 'current' : da?.type as 'current' | 'savings' | 'credit' | 'loan' | 'investment' | 'assets' | 'other' | undefined,
+                balance: da?.balance?.toString(),
+                currency: da?.currency,
+                sortCode: da?.sortCode,
+                accountNumber: da?.accountNumber,
+              }}
+              onAccountCreated={(newAccountId) => {
+                setLinks(prev => prev.map(link =>
+                  link.externalAccountId === createAccountFor
+                    ? { ...link, selectedAccountId: newAccountId }
+                    : link
+                ));
+                setCreateAccountFor(null);
+              }}
+            />
+          </Suspense>
+        </LazyErrorBoundary>
       );
     })()}
     </>

--- a/src/components/charts/LazyChart.tsx
+++ b/src/components/charts/LazyChart.tsx
@@ -1,17 +1,18 @@
-import { lazy, Suspense } from 'react';
+import { Suspense } from 'react';
 import type { ComponentProps } from 'react';
+import { lazyWithRecovery } from '../../utils/lazyWithRecovery';
 
 // Lazy load recharts components
-const LazyLineChart = lazy(() => 
+const LazyLineChart = lazyWithRecovery(() =>
   import('recharts').then(module => ({ default: module.LineChart }))
 );
-const LazyBarChart = lazy(() => 
+const LazyBarChart = lazyWithRecovery(() =>
   import('recharts').then(module => ({ default: module.BarChart }))
 );
-const LazyPieChart = lazy(() => 
+const LazyPieChart = lazyWithRecovery(() =>
   import('recharts').then(module => ({ default: module.PieChart }))
 );
-const LazyAreaChart = lazy(() => 
+const LazyAreaChart = lazyWithRecovery(() =>
   import('recharts').then(module => ({ default: module.AreaChart }))
 );
 

--- a/src/components/charts/OptimizedCharts.tsx
+++ b/src/components/charts/OptimizedCharts.tsx
@@ -1,12 +1,12 @@
 import React, {
   Suspense,
-  lazy,
   useEffect,
   useState,
   type ComponentProps,
   type ComponentType
 } from 'react';
 import { Skeleton } from '../loading/Skeleton';
+import { lazyWithRecovery } from '../../utils/lazyWithRecovery';
 
 import type { default as PieChartWrapperComponent } from './wrappers/PieChartWrapper';
 import type { default as BarChartWrapperComponent } from './wrappers/BarChartWrapper';
@@ -44,23 +44,23 @@ type ChartComponentKey =
 type ChartComponentProps<K extends ChartComponentKey> = ChartModule[K] extends ComponentType<infer P> ? P : never;
 type ChartComponentType<K extends ChartComponentKey> = ComponentType<ChartComponentProps<K>>;
 
-const LazyPieChartWrapper = lazy(() =>
+const LazyPieChartWrapper = lazyWithRecovery(() =>
   import(/* webpackChunkName: "chart-pie" */ './wrappers/PieChartWrapper')
 );
 
-const LazyBarChartWrapper = lazy(() =>
+const LazyBarChartWrapper = lazyWithRecovery(() =>
   import(/* webpackChunkName: "chart-bar" */ './wrappers/BarChartWrapper')
 );
 
-const LazyLineChartWrapper = lazy(() =>
+const LazyLineChartWrapper = lazyWithRecovery(() =>
   import(/* webpackChunkName: "chart-line" */ './wrappers/LineChartWrapper')
 );
 
-const LazyAreaChartWrapper = lazy(() =>
+const LazyAreaChartWrapper = lazyWithRecovery(() =>
   import(/* webpackChunkName: "chart-area" */ './wrappers/AreaChartWrapper')
 );
 
-const LazyTreemapWrapper = lazy(() =>
+const LazyTreemapWrapper = lazyWithRecovery(() =>
   import(/* webpackChunkName: "chart-treemap" */ './wrappers/TreemapWrapper')
 );
 

--- a/src/pages/AccountTransactions.tsx
+++ b/src/pages/AccountTransactions.tsx
@@ -12,16 +12,32 @@ import AccountSettingsModal from '../components/AccountSettingsModal';
 import QuickEditTransactionPanel from '../components/QuickEditTransactionPanel';
 import CategorySelector from '../components/CategorySelector';
 import { usePreferences } from '../contexts/PreferencesContext';
+import { useToast } from '../contexts/ToastContext';
 import { VirtualizedTable, Column } from '../components/VirtualizedTable';
 import { InfiniteScrollTransactionList } from '../components/InfiniteScrollTransactionList';
+import { LoadingState } from '../components/loading/LoadingState';
 import { compareTransactions } from '../utils/transactionSort';
 import { orderColumnKeys, moveColumnKey } from '../utils/columnLayout';
 import { computeArchiveWindow, ARCHIVE_PRESETS, type ArchiveRange } from '../utils/archiveRange';
 import { effectiveOpeningDate, findSiblingAccount } from '../utils/openingDates';
+import { DataService } from '../services/api/dataService';
 import GroupedAccountSelect from '../components/common/GroupedAccountSelect';
-import type { Transaction } from '../types';
+import type { Account, Transaction } from '../types';
 
 type TransactionWithBalance = Transaction & { balance: number };
+
+/**
+ * Whether this id belongs to a CLOSED account, once we have asked.
+ *
+ * The app context carries only OPEN accounts, so an id that misses it is not
+ * automatically a missing account: closing one hides it and keeps every
+ * transaction (the Microsoft Money model), and a payee drill, a report drill
+ * or a bookmark lands on a closed account's register as readily as an open
+ * one's. 'idle' means the question never arose — the account is open.
+ */
+type ClosedAccountLookup =
+  | { status: 'idle' | 'loading' }
+  | { status: 'done'; account: Account | null };
 
 interface OpeningBalanceRow {
   id: 'opening-balance';
@@ -72,13 +88,66 @@ export default function AccountTransactions() {
   const { accountId } = useParams<{ accountId: string }>();
   const navigate = useNavigate();
   const location = useLocation();
-  const { accounts, transactions, categories, deleteTransaction, addTransaction, updateAccount, refreshCategories } = useApp();
+  const {
+    accounts, transactions, categories, isLoading,
+    deleteTransaction, addTransaction, updateAccount,
+    refreshCategories, refreshAccountsAndTransactions,
+  } = useApp();
   const { formatCurrency } = useCurrencyDecimal();
+  const { showError } = useToast();
   const { compactView, setCompactView: _setCompactView } = usePreferences();
-  
-  // Find the specific account
+
+  // Find the specific account — the context holds the OPEN ones only.
   const account = accounts.find(acc => acc.id === accountId);
-  
+  const accountIsOpen = account !== undefined;
+
+  // Asked for only on a miss, and only once the open list has arrived, so an
+  // ordinary register costs no extra request.
+  const [closedLookup, setClosedLookup] = useState<ClosedAccountLookup>({ status: 'idle' });
+  const [reopening, setReopening] = useState(false);
+
+  useEffect(() => {
+    if (isLoading || accountIsOpen) return;
+    if (!accountId) {
+      setClosedLookup({ status: 'done', account: null });
+      return;
+    }
+    let cancelled = false;
+    setClosedLookup({ status: 'loading' });
+    DataService.getClosedAccounts()
+      .then(list => {
+        if (!cancelled) {
+          setClosedLookup({ status: 'done', account: list.find(a => a.id === accountId) ?? null });
+        }
+      })
+      .catch(() => {
+        // A failed lookup says nothing about the account; "not in the open
+        // list, and we cannot check" reads as no longer existing.
+        if (!cancelled) setClosedLookup({ status: 'done', account: null });
+      });
+    return () => { cancelled = true; };
+  }, [accountId, accountIsOpen, isLoading]);
+
+  // Closed accounts have no register — the Accounts page's rule — so the way
+  // through is to re-open the account, offered here where the need arises.
+  // The refresh recipe matches the Accounts page's Reopen button: closed
+  // accounts are filtered out at load, and the DB trigger re-activates the
+  // account's transfer category. Once the account is back in the open list
+  // this page renders its register in place, deep link and all.
+  const handleReopenAccount = useCallback(async (): Promise<void> => {
+    if (!accountId || reopening) return;
+    setReopening(true);
+    try {
+      await updateAccount(accountId, { isActive: true });
+      await refreshAccountsAndTransactions();
+      await refreshCategories();
+    } catch (error) {
+      showError(error);
+    } finally {
+      setReopening(false);
+    }
+  }, [accountId, reopening, updateAccount, refreshAccountsAndTransactions, refreshCategories, showError]);
+
   // State for search and filtering
   const [searchTerm, setSearchTerm] = useState('');
   const [dateFrom, setDateFrom] = useState('');
@@ -170,6 +239,13 @@ export default function AccountTransactions() {
   // location.search is a dependency for the already-mounted case: landing on
   // the register that is ALREADY open only changes the search string, and
   // without it this effect would never wake to consume the pending id.
+  //
+  // Both halves run whatever state the account is in, which is what carries a
+  // deep link across a re-open: the id is stashed and resolved into SELECTION
+  // STATE while the closed page is showing (transactions are loaded per user,
+  // not per open account), and that state outlives the re-open because the
+  // component never unmounts. If the row genuinely isn't loaded yet the id
+  // stays pending and the re-open's refresh wakes this effect again.
   useEffect(() => {
     const txn = pendingTxnRef.current;
     if (!txn) return;
@@ -511,8 +587,12 @@ export default function AccountTransactions() {
   // category option used to deselect, unmount the modal mid-click, and dump
   // the user back on the register with nothing saved. The listbox guard keeps
   // the selection for any other portaled picker menu (the dock's, say) too.
+  //
+  // Nor while the account is CLOSED: the register isn't rendered then, so
+  // there is no row to click away from — and a mousedown on "Re-open and
+  // view" would wipe the ?txn selection this page is about to show.
   useEffect(() => {
-    if (!selectedTransactionId || isEditModalOpen) return;
+    if (!accountIsOpen || !selectedTransactionId || isEditModalOpen) return;
     const handlePointerDown = (e: MouseEvent) => {
       const target = e.target as HTMLElement | null;
       if (!target) return;
@@ -530,7 +610,7 @@ export default function AccountTransactions() {
     };
     document.addEventListener('mousedown', handlePointerDown);
     return () => document.removeEventListener('mousedown', handlePointerDown);
-  }, [selectedTransactionId, isEditModalOpen]);
+  }, [accountIsOpen, selectedTransactionId, isEditModalOpen]);
 
   // Next non-summary row below the given one in the CURRENT visible order —
   // powers "Save & Next" in both the quick-edit panel and the full modal.
@@ -884,11 +964,61 @@ export default function AccountTransactions() {
   }, [baseColumns]);
 
   if (!account) {
+    // Still finding out which of the three it is — the open list may not have
+    // arrived, or the closed lookup may be in flight. Saying "not found" here
+    // would flash an error at an account that exists.
+    if (isLoading || closedLookup.status !== 'done') {
+      return <LoadingState message="Loading account…" />;
+    }
+
+    // Closed: an honest page, not an error. Its history is intact; what it
+    // hasn't got is an open register (the same rule as the Accounts page,
+    // where a closed account offers Reopen rather than a way in).
+    if (closedLookup.account) {
+      return (
+        <div className="flex flex-col h-full">
+          {/* No back-arrow chrome above the card: the two actions below ARE the
+              page, and a second "Back to Accounts" would only duplicate one. */}
+          <div className="bg-white dark:bg-gray-800 rounded-2xl shadow-lg border border-gray-100 dark:border-gray-700 p-6 max-w-2xl">
+            <h1 className="text-xl font-bold text-gray-900 dark:text-white">
+              {closedLookup.account.name}
+            </h1>
+            <p className="mt-2 text-sm text-gray-600 dark:text-gray-400">
+              This account is closed, and closed accounts don&rsquo;t have an open register.
+              To see its transactions the account must be re-opened first. Nothing else
+              changes — every transaction is preserved either way, and you can close it
+              again from the Accounts page whenever you&rsquo;re done.
+            </p>
+            <div className="mt-5 flex flex-wrap items-center gap-2">
+              <button
+                type="button"
+                onClick={() => { void handleReopenAccount(); }}
+                disabled={reopening}
+                className="px-4 py-2 text-sm font-medium rounded-lg bg-[#1a2332] dark:bg-blue-600 text-white hover:bg-[#2d3a4d] dark:hover:bg-blue-700 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+              >
+                {reopening ? 'Re-opening…' : 'Re-open and view'}
+              </button>
+              <button
+                type="button"
+                onClick={() => navigate(preserveDemoParam('/accounts', location.search))}
+                disabled={reopening}
+                className="inline-flex items-center gap-2 px-4 py-2 text-sm font-medium rounded-lg border border-gray-300 dark:border-gray-600 text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors disabled:opacity-50"
+              >
+                <ArrowLeftIcon size={16} />
+                Back to Accounts
+              </button>
+            </div>
+          </div>
+        </div>
+      );
+    }
+
+    // Neither open nor closed: there is no such account any more.
     return (
       <div className="flex flex-col items-center justify-center h-64">
-        <p className="text-gray-500 dark:text-gray-400">Account not found</p>
+        <p className="text-gray-500 dark:text-gray-400">This account no longer exists</p>
         <button
-          onClick={() => navigate('/accounts')}
+          onClick={() => navigate(preserveDemoParam('/accounts', location.search))}
           className="mt-4 text-primary hover:text-secondary"
         >
           Return to Accounts
@@ -896,7 +1026,7 @@ export default function AccountTransactions() {
       </div>
     );
   }
-  
+
   return (
     <div className="flex flex-col h-full">
       {/* Back button */}

--- a/src/pages/Accounts.tsx
+++ b/src/pages/Accounts.tsx
@@ -1,4 +1,5 @@
-import { useState, useMemo, useEffect, useCallback, lazy, Suspense, type ReactNode } from 'react';
+import { useState, useMemo, useEffect, useCallback, Suspense, type ReactNode } from 'react';
+import { lazyWithRecovery } from '../utils/lazyWithRecovery';
 import { useNavigate, useLocation } from 'react-router-dom';
 import { useApp } from '../contexts/AppContextSupabase';
 import { useToast } from '../contexts/ToastContext';
@@ -16,7 +17,7 @@ import { TRUELAYER_JWKS_CIRCUIT_EVENT_PREFIX } from '../constants/bankingOps';
 
 // Bank connection management lives on this page (the natural home for it);
 // the Data Management page keeps only its URL-driven deep links for ops alerts.
-const BankConnections = lazy(() => import('../components/BankConnections'));
+const BankConnections = lazyWithRecovery(() => import('../components/BankConnections'));
 import type { Account } from '../types';
 import { ALL_ACCOUNT_SECTIONS, sectionTypeForAccount } from '../utils/accountSections';
 import {

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -1,4 +1,5 @@
-import { useState, useEffect, lazy, Suspense } from 'react';
+import { useState, useEffect, Suspense } from 'react';
+import { lazyWithRecovery } from '../utils/lazyWithRecovery';
 import { useApp } from '../contexts/AppContextSupabase';
 import { usePreferences } from '../contexts/PreferencesContext';
 import { supabase } from '../lib/supabase';
@@ -9,9 +10,9 @@ import LazyErrorBoundary from '../components/LazyErrorBoundary';
 import PageTip from '../components/PageTip';
 
 // Lazy load only modals and heavy features for better performance
-const TestDataWarningModal = lazy(() => import('../components/TestDataWarningModal'));
-const OnboardingModal = lazy(() => import('../components/OnboardingModal'));
-const ImprovedDashboard = lazy(() => import('../components/dashboard/ImprovedDashboard').then(module => ({ default: module.ImprovedDashboard })));
+const TestDataWarningModal = lazyWithRecovery(() => import('../components/TestDataWarningModal'));
+const OnboardingModal = lazyWithRecovery(() => import('../components/OnboardingModal'));
+const ImprovedDashboard = lazyWithRecovery(() => import('../components/dashboard/ImprovedDashboard').then(module => ({ default: module.ImprovedDashboard })));
 
 
 export default function Dashboard() {

--- a/src/pages/EnhancedImport.tsx
+++ b/src/pages/EnhancedImport.tsx
@@ -1,4 +1,5 @@
-import React, { useState, useCallback, lazy, Suspense } from 'react';
+import React, { useState, useCallback, Suspense } from 'react';
+import { lazyWithRecovery } from '../utils/lazyWithRecovery';
 import { useApp } from '../contexts/AppContextSupabase';
 import { importRulesService } from '../services/importRulesService';
 import PageWrapper from '../components/PageWrapper';
@@ -28,15 +29,15 @@ import {
 // comment above the modal block). This is the single home for bringing data
 // in, so it pulls in many modals — deferring each chunk (and its hooks) until
 // first use keeps the page itself light.
-const EnhancedImportWizard = lazy(() => import('../components/EnhancedImportWizard'));
-const BatchImportModal = lazy(() => import('../components/BatchImportModal'));
-const ImportRulesManager = lazy(() => import('../components/ImportRulesManager'));
-const MsMoneyImportModal = lazy(() => import('../components/MsMoneyImportModal'));
-const DataMigrationWizard = lazy(() => import('../components/DataMigrationWizard'));
-const ImportDataModal = lazy(() => import('../components/ImportDataModal'));
-const CSVImportWizard = lazy(() => import('../components/CSVImportWizard'));
-const OFXImportModal = lazy(() => import('../components/OFXImportModal'));
-const QIFImportModal = lazy(() => import('../components/QIFImportModal'));
+const EnhancedImportWizard = lazyWithRecovery(() => import('../components/EnhancedImportWizard'));
+const BatchImportModal = lazyWithRecovery(() => import('../components/BatchImportModal'));
+const ImportRulesManager = lazyWithRecovery(() => import('../components/ImportRulesManager'));
+const MsMoneyImportModal = lazyWithRecovery(() => import('../components/MsMoneyImportModal'));
+const DataMigrationWizard = lazyWithRecovery(() => import('../components/DataMigrationWizard'));
+const ImportDataModal = lazyWithRecovery(() => import('../components/ImportDataModal'));
+const CSVImportWizard = lazyWithRecovery(() => import('../components/CSVImportWizard'));
+const OFXImportModal = lazyWithRecovery(() => import('../components/OFXImportModal'));
+const QIFImportModal = lazyWithRecovery(() => import('../components/QIFImportModal'));
 
 const bankFormats = [
   'Barclays', 'HSBC', 'Lloyds', 'NatWest', 'Santander', 'Monzo', 'Starling',

--- a/src/pages/ExportManager.tsx
+++ b/src/pages/ExportManager.tsx
@@ -1,4 +1,5 @@
-import React, { useState, useEffect, lazy, Suspense } from 'react';
+import React, { useState, useEffect, Suspense } from 'react';
+import { lazyWithRecovery } from '../utils/lazyWithRecovery';
 import { exportService } from '../services/exportService';
 import type { ExportOptions, ExportTemplate } from '../services/exportService';
 import { useApp } from '../contexts/AppContextSupabase';
@@ -23,8 +24,8 @@ import { createScopedLogger } from '../loggers/scopedLogger';
 // exporter both used to live under Settings ▸ Data Management. They move here so
 // every way OUT of the app is on one page. Kept lazy — moving a component must
 // not turn its chunk into an always-loaded static import.
-const EnhancedExportManager = lazy(() => import('../components/EnhancedExportManager'));
-const ExcelExport = lazy(() => import('../components/ExcelExport'));
+const EnhancedExportManager = lazyWithRecovery(() => import('../components/EnhancedExportManager'));
+const ExcelExport = lazyWithRecovery(() => import('../components/ExcelExport'));
 
 const exportManagerLogger = createScopedLogger('ExportManagerPage');
 

--- a/src/pages/Transactions.tsx
+++ b/src/pages/Transactions.tsx
@@ -5,12 +5,13 @@ import { usePreferences } from '../contexts/PreferencesContext';
 import { useLayout } from '../contexts/LayoutContext';
 import { useCurrencyDecimal } from '../hooks/useCurrencyDecimal';
 import { toDecimal } from '../utils/decimal';
-import { lazy, Suspense } from 'react';
+import { Suspense } from 'react';
+import { lazyWithRecovery } from '../utils/lazyWithRecovery';
 
 // Lazy load heavy modals to improve initial page load
-const EditTransactionModal = lazy(() => import('../components/EditTransactionModal'));
-const TransactionDetailsView = lazy(() => import('../components/TransactionDetailsView'));
-const QuickDateFilters = lazy(() => import('../components/QuickDateFilters'));
+const EditTransactionModal = lazyWithRecovery(() => import('../components/EditTransactionModal'));
+const TransactionDetailsView = lazyWithRecovery(() => import('../components/TransactionDetailsView'));
+const QuickDateFilters = lazyWithRecovery(() => import('../components/QuickDateFilters'));
 import { CalendarIcon, SearchIcon, ChevronLeftIcon, ChevronRightIcon, ChevronUpIcon, ChevronDownIcon, TrendingUpIcon, TrendingDownIcon } from '../components/icons';
 import DatePicker from '../components/common/DatePicker';
 import { Modal, ModalBody } from '../components/common/Modal';
@@ -22,7 +23,7 @@ import TransactionContextMenu from '../components/TransactionContextMenu';
 import { useToast } from '../contexts/ToastContext';
 import { TransactionRow } from '../components/TransactionRow';
 // Lazy load list components that are conditionally rendered
-const InfiniteScrollTransactionList = lazy(() => import('../components/InfiniteScrollTransactionList').then(m => ({ default: m.InfiniteScrollTransactionList })));
+const InfiniteScrollTransactionList = lazyWithRecovery(() => import('../components/InfiniteScrollTransactionList').then(m => ({ default: m.InfiniteScrollTransactionList })));
 import { useTransactionFilters } from '../hooks/useTransactionFilters';
 import { useDebounce } from '../hooks/useDebounce';
 import { SkeletonTableRow, SkeletonList } from '../components/loading/Skeleton';

--- a/src/pages/__tests__/AccountTransactions.test.tsx
+++ b/src/pages/__tests__/AccountTransactions.test.tsx
@@ -1,0 +1,226 @@
+import React from 'react';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { PreferencesProvider } from '../../contexts/PreferencesContext';
+import { ToastProvider } from '../../contexts/ToastContext';
+import { NotificationProvider } from '../../contexts/NotificationContext';
+import { __setAppContextValue, __resetAppContextValue } from '../../test/mocks/AppContextSupabase';
+import { DataService } from '../../services/api/dataService';
+import AccountTransactions from '../AccountTransactions';
+import type { Account, Category, Transaction } from '../../types';
+
+/**
+ * What the register does with an account id it cannot find in the open list.
+ *
+ * The app context carries only OPEN accounts, so every jump into a CLOSED
+ * account's register — the payee drill, a report drill, a transfer's other
+ * side, a bookmark — used to land on a bare "Account not found". Closing an
+ * account keeps every transaction, so that page was simply wrong. There are
+ * three states now: open (the register), closed (an honest page offering the
+ * re-open, the Accounts-page rule), and genuinely gone.
+ *
+ * Closed accounts load from DataService.getClosedAccounts — not the context —
+ * so they are injected by spying on that call. Every figure and name here is
+ * synthetic (this repo is public).
+ */
+
+const OPEN_ACCOUNT: Account = {
+  id: 'acc-open', name: 'Synthetic Current', type: 'current', balance: 0,
+  currency: 'GBP', lastUpdated: new Date('2026-01-01'), openingBalance: 0, isActive: true,
+};
+
+const CLOSED_ACCOUNT: Account = {
+  id: 'acc-closed', name: 'Retired Savings', type: 'savings', balance: 0,
+  currency: 'GBP', lastUpdated: new Date('2026-01-01'), openingBalance: 0, isActive: false,
+};
+
+const CATEGORIES: Category[] = [
+  { id: 'type-expense', name: 'Expenses', type: 'expense', level: 'type', isSystem: true },
+  { id: 'grp-food', name: 'Food', type: 'expense', level: 'sub', parentId: 'type-expense' },
+  { id: 'det-groceries', name: 'Groceries', type: 'expense', level: 'detail', parentId: 'grp-food' },
+];
+
+const OPEN_ROW: Transaction = {
+  id: 'txn-open', date: new Date('2026-02-02'), description: 'Synthetic open row',
+  amount: -12.5, type: 'expense', category: 'det-groceries', accountId: 'acc-open', cleared: false,
+};
+
+const CLOSED_ROW: Transaction = {
+  id: 'txn-closed', date: new Date('2026-02-03'), description: 'Synthetic closed row',
+  amount: -30, type: 'expense', category: 'det-groceries', accountId: 'acc-closed', cleared: false,
+};
+
+const updateAccount = vi.fn(async () => {});
+const refreshCategories = vi.fn(async () => {});
+// The reopen's re-pull, as the real context does it: the account leaves the
+// closed list and joins the open one.
+const refreshAccountsAndTransactions = vi.fn(async () => {
+  __setAppContextValue({ accounts: [OPEN_ACCOUNT, { ...CLOSED_ACCOUNT, isActive: true }] });
+});
+
+const renderRegister = (path: string): void => {
+  render(
+    <MemoryRouter initialEntries={[path]}>
+      <PreferencesProvider>
+        {/* The reopen reports failures through the app's toasts, and a selected
+            row's editor raises transaction notifications — the same provider
+            stack the route sits in. */}
+        <ToastProvider>
+          <NotificationProvider>
+            <Routes>
+              <Route path="/accounts" element={<div>Accounts page</div>} />
+              <Route path="/accounts/:accountId" element={<AccountTransactions />} />
+            </Routes>
+          </NotificationProvider>
+        </ToastProvider>
+      </PreferencesProvider>
+    </MemoryRouter>
+  );
+};
+
+const reopenButton = (): HTMLElement => screen.getByRole('button', { name: 'Re-open and view' });
+
+describe('Account register — open, closed, and gone', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    updateAccount.mockClear();
+    refreshCategories.mockClear();
+    refreshAccountsAndTransactions.mockClear();
+    __setAppContextValue({
+      accounts: [OPEN_ACCOUNT],
+      transactions: [OPEN_ROW, CLOSED_ROW],
+      categories: CATEGORIES,
+      isLoading: false,
+      updateAccount,
+      refreshCategories,
+      refreshAccountsAndTransactions,
+    });
+    vi.spyOn(DataService, 'getClosedAccounts').mockResolvedValue([CLOSED_ACCOUNT]);
+  });
+
+  afterEach(() => {
+    // Only the closed-accounts spy is restored. vi.restoreAllMocks() would
+    // also strip the shared setup's window.matchMedia implementation, and the
+    // register's row components read prefers-reduced-motion through it.
+    vi.mocked(DataService.getClosedAccounts).mockRestore();
+    __resetAppContextValue();
+  });
+
+  it('renders the register for an open account, without asking for the closed list', async () => {
+    renderRegister('/accounts/acc-open');
+
+    expect(await screen.findByRole('heading', { level: 1, name: 'Synthetic Current' })).toBeInTheDocument();
+    // The row is on show (the phone list and the desktop table both render it).
+    expect(screen.getAllByText('Synthetic open row').length).toBeGreaterThan(0);
+    expect(screen.queryByRole('button', { name: 'Re-open and view' })).not.toBeInTheDocument();
+    // An ordinary register costs no extra request: the lookup only fires on a miss.
+    expect(DataService.getClosedAccounts).not.toHaveBeenCalled();
+  });
+
+  it('meets a closed account with its name and the re-open offer, not its transactions', async () => {
+    renderRegister('/accounts/acc-closed');
+
+    // Named, so the user knows which account they have landed on…
+    expect(await screen.findByRole('heading', { level: 1, name: 'Retired Savings' })).toBeInTheDocument();
+    // …and told what is true: closed, no register, history intact.
+    expect(screen.getByText(/closed accounts don’t have an open register/i)).toBeInTheDocument();
+    expect(screen.getByText(/every transaction is preserved either way/i)).toBeInTheDocument();
+    expect(reopenButton()).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Back to Accounts' })).toBeInTheDocument();
+
+    // The register itself stays shut — closed accounts are not browsable.
+    expect(screen.queryByText('Synthetic closed row')).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /Search & filters/ })).not.toBeInTheDocument();
+    // Never the old dead end.
+    expect(screen.queryByText(/not found/i)).not.toBeInTheDocument();
+  });
+
+  it('says an account is gone only when it is in neither list', async () => {
+    vi.spyOn(DataService, 'getClosedAccounts').mockResolvedValue([]);
+    renderRegister('/accounts/acc-vanished');
+
+    expect(await screen.findByText('This account no longer exists')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Return to Accounts' })).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Re-open and view' })).not.toBeInTheDocument();
+  });
+
+  it('waits for the closed list rather than flashing an error at an account that exists', async () => {
+    let release: (accounts: Account[]) => void = () => {};
+    vi.spyOn(DataService, 'getClosedAccounts').mockReturnValue(
+      new Promise<Account[]>(resolve => { release = resolve; })
+    );
+
+    renderRegister('/accounts/acc-closed');
+
+    // In flight: no verdict either way.
+    expect(await screen.findByText('Loading account…')).toBeInTheDocument();
+    expect(screen.queryByText('This account no longer exists')).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Re-open and view' })).not.toBeInTheDocument();
+
+    release([CLOSED_ACCOUNT]);
+
+    expect(await screen.findByRole('heading', { level: 1, name: 'Retired Savings' })).toBeInTheDocument();
+    expect(screen.queryByText('Loading account…')).not.toBeInTheDocument();
+  });
+
+  it('waits while the open list is still arriving', async () => {
+    __setAppContextValue({ accounts: [], isLoading: true });
+    renderRegister('/accounts/acc-open');
+
+    expect(await screen.findByText('Loading account…')).toBeInTheDocument();
+    // Nothing is decided yet, so nothing is asked of the server either.
+    expect(DataService.getClosedAccounts).not.toHaveBeenCalled();
+  });
+
+  it('re-opens the account through the context, then renders its register in place', async () => {
+    renderRegister('/accounts/acc-closed');
+    fireEvent.click(await screen.findByRole('button', { name: 'Re-open and view' }));
+
+    await waitFor(() => {
+      expect(updateAccount).toHaveBeenCalledWith('acc-closed', { isActive: true });
+    });
+    // The Accounts page's recipe: re-pull the open list (closed accounts are
+    // filtered out at load) and the categories (the DB trigger re-activated
+    // the account's transfer category).
+    await waitFor(() => {
+      expect(refreshAccountsAndTransactions).toHaveBeenCalledTimes(1);
+      expect(refreshCategories).toHaveBeenCalledTimes(1);
+    });
+
+    // The user stays put and the register takes over — no second navigation.
+    expect(await screen.findByRole('button', { name: /Search & filters/ })).toBeInTheDocument();
+    expect(screen.getAllByText('Synthetic closed row').length).toBeGreaterThan(0);
+    expect(screen.queryByRole('button', { name: 'Re-open and view' })).not.toBeInTheDocument();
+  });
+
+  it('keeps the ?txn deep link across the re-open', async () => {
+    renderRegister('/accounts/acc-closed?txn=txn-closed');
+
+    const button = await screen.findByRole('button', { name: 'Re-open and view' });
+    // mousedown as well as click: the register's click-outside-to-deselect
+    // handler listens on mousedown, and pressing this very button used to be
+    // "outside" — which would have thrown away the row the link asked for.
+    fireEvent.mouseDown(button);
+    fireEvent.click(button);
+
+    // The deep-linked row arrives selected, docked in the quick-edit panel.
+    const description = await screen.findByLabelText('Description');
+    expect(description).toHaveValue('Synthetic closed row');
+    expect(document.querySelector('[data-quick-edit-panel]')).not.toBeNull();
+  });
+
+  it('leaves the account closed when the re-open fails', async () => {
+    updateAccount.mockRejectedValueOnce(new Error('network is down'));
+    renderRegister('/accounts/acc-closed');
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Re-open and view' }));
+
+    await waitFor(() => {
+      expect(refreshAccountsAndTransactions).not.toHaveBeenCalled();
+    });
+    // Still the offer, not a half-open register — and the button is usable again.
+    expect(reopenButton()).toBeEnabled();
+    expect(screen.queryByRole('button', { name: /Search & filters/ })).not.toBeInTheDocument();
+  });
+});

--- a/src/pages/reports/reportRegistry.ts
+++ b/src/pages/reports/reportRegistry.ts
@@ -1,4 +1,5 @@
-import { lazy, type ComponentType, type ElementType, type LazyExoticComponent } from 'react';
+import { type ComponentType, type ElementType, type LazyExoticComponent } from 'react';
+import { lazyWithRecovery } from '../../utils/lazyWithRecovery';
 import {
   BarChart3Icon,
   CalendarIcon,
@@ -79,7 +80,7 @@ export const REPORTS: ReportDefinition[] = [
     group: 'what-i-have',
     icon: WalletIcon,
     usesPeriod: true,
-    component: lazy(() => import('./NetWorthStatementReport')),
+    component: lazyWithRecovery(() => import('./NetWorthStatementReport')),
   },
   {
     id: 'net-worth-over-time',
@@ -91,7 +92,7 @@ export const REPORTS: ReportDefinition[] = [
     // The whole history is the point of this one — a month of net worth is a
     // dot, and even a year says little about the direction of travel.
     defaultPeriod: 'all',
-    component: lazy(() => import('../NetWorthReport')),
+    component: lazyWithRecovery(() => import('../NetWorthReport')),
   },
   {
     id: 'account-balances',
@@ -100,7 +101,7 @@ export const REPORTS: ReportDefinition[] = [
     group: 'what-i-have',
     icon: LandmarkIcon,
     usesPeriod: true,
-    component: lazy(() => import('./AccountBalancesReport')),
+    component: lazyWithRecovery(() => import('./AccountBalancesReport')),
   },
   {
     id: 'monthly-income-expenses',
@@ -109,7 +110,7 @@ export const REPORTS: ReportDefinition[] = [
     group: 'spending',
     icon: CalendarIcon,
     usesPeriod: true,
-    component: lazy(() => import('../Reports')),
+    component: lazyWithRecovery(() => import('../Reports')),
   },
   {
     id: 'spending-by-category',
@@ -118,7 +119,7 @@ export const REPORTS: ReportDefinition[] = [
     group: 'spending',
     icon: PieChartIcon,
     usesPeriod: true,
-    component: lazy(() => import('./SpendingByCategoryReport')),
+    component: lazyWithRecovery(() => import('./SpendingByCategoryReport')),
   },
   {
     id: 'income-and-spending-over-time',
@@ -130,7 +131,7 @@ export const REPORTS: ReportDefinition[] = [
     // Month-by-month bars need enough months to compare, and a year covers the
     // seasonal swings (Christmas, holidays, annual bills) exactly once.
     defaultPeriod: 'last-12-months',
-    component: lazy(() => import('./IncomeSpendingOverTimeReport')),
+    component: lazyWithRecovery(() => import('./IncomeSpendingOverTimeReport')),
   },
   {
     id: 'spending-by-payee',
@@ -139,7 +140,7 @@ export const REPORTS: ReportDefinition[] = [
     group: 'spending',
     icon: UsersIcon,
     usesPeriod: true,
-    component: lazy(() => import('./SpendingByPayeeReport')),
+    component: lazyWithRecovery(() => import('./SpendingByPayeeReport')),
   },
   {
     id: 'period-comparison',
@@ -148,7 +149,7 @@ export const REPORTS: ReportDefinition[] = [
     group: 'spending',
     icon: RepeatIcon,
     usesPeriod: true,
-    component: lazy(() => import('./PeriodComparisonReport')),
+    component: lazyWithRecovery(() => import('./PeriodComparisonReport')),
   },
   {
     id: 'custom-reports',
@@ -158,7 +159,7 @@ export const REPORTS: ReportDefinition[] = [
     icon: FileTextIcon,
     // Custom reports carry their own date and account filters.
     usesPeriod: false,
-    component: lazy(() => import('../CustomReports')),
+    component: lazyWithRecovery(() => import('../CustomReports')),
   },
 ];
 

--- a/src/pages/settings/DataManagement.tsx
+++ b/src/pages/settings/DataManagement.tsx
@@ -1,4 +1,5 @@
-import { useState, lazy, Suspense, useMemo } from 'react';
+import { useState, Suspense, useMemo } from 'react';
+import { lazyWithRecovery } from '../../utils/lazyWithRecovery';
 import { Link } from 'react-router-dom';
 import { useApp } from '../../contexts/AppContextSupabase';
 import { DownloadIcon, DeleteIcon, AlertCircleIcon, UploadIcon, DatabaseIcon, SearchIcon, EditIcon, LinkIcon, WrenchIcon, LightbulbIcon, XCircleIcon, type IconProps } from '../../components/icons';
@@ -9,18 +10,18 @@ import { DataService } from '../../services/api/dataService';
 import { supabase } from '../../lib/supabase';
 import { STORAGE_KEYS } from '../../services/storageAdapter';
 
-const ArchiveManager = lazy(() => import('../../components/ArchiveManager'));
+const ArchiveManager = lazyWithRecovery(() => import('../../components/ArchiveManager'));
 
 // Lazy load heavy components to reduce initial bundle size. Import and export
 // tools moved to the Manage pages (see the link cards below); what remains here
 // is genuine data administration — cleanup tools, backups, and the danger zone.
-const DuplicateDetection = lazy(() => import('../../components/DuplicateDetection'));
-const BulkTransactionEdit = lazy(() => import('../../components/BulkTransactionEdit'));
-const TransactionReconciliation = lazy(() => import('../../components/TransactionReconciliation'));
-const DataValidation = lazy(() => import('../../components/DataValidation'));
-const SmartCategorizationSettings = lazy(() => import('../../components/SmartCategorizationSettings'));
-const BankConnections = lazy(() => import('../../components/BankConnections'));
-const AutomaticBackupSettings = lazy(() => import('../../components/AutomaticBackupSettings'));
+const DuplicateDetection = lazyWithRecovery(() => import('../../components/DuplicateDetection'));
+const BulkTransactionEdit = lazyWithRecovery(() => import('../../components/BulkTransactionEdit'));
+const TransactionReconciliation = lazyWithRecovery(() => import('../../components/TransactionReconciliation'));
+const DataValidation = lazyWithRecovery(() => import('../../components/DataValidation'));
+const SmartCategorizationSettings = lazyWithRecovery(() => import('../../components/SmartCategorizationSettings'));
+const BankConnections = lazyWithRecovery(() => import('../../components/BankConnections'));
+const AutomaticBackupSettings = lazyWithRecovery(() => import('../../components/AutomaticBackupSettings'));
 const dataManagementLogger = createScopedLogger('DataManagementPage');
 
 export default function DataManagementSettings() {

--- a/src/utils/chunkLoadError.test.ts
+++ b/src/utils/chunkLoadError.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect } from 'vitest';
+import { isChunkLoadError } from './chunkLoadError';
+
+describe('isChunkLoadError', () => {
+  // The same failure — a chunk this tab asked for is no longer on the CDN —
+  // reported by each engine, plus the two shapes a host's SPA fallback creates.
+  const chunkFailures: Array<[string, unknown]> = [
+    ['Chrome / Edge', new TypeError('Failed to fetch dynamically imported module: https://app.example/assets/Transactions-8f3a1c.js')],
+    ['Safari', new TypeError('Importing a module script failed.')],
+    ['Firefox', new TypeError('error loading dynamically imported module: https://app.example/assets/Transactions-8f3a1c.js')],
+    ['SPA fallback served index.html', new TypeError("Failed to load module script: Expected a JavaScript module script but the server responded with a MIME type of \"text/html\".")],
+    ['webpack-style loader', Object.assign(new Error('Loading chunk 42 failed.'), { name: 'ChunkLoadError' })],
+    ["a chunk's stylesheet", new Error('Unable to preload CSS for /assets/Transactions-8f3a1c.css')],
+    ['a message with no Error wrapper', 'Importing a module script failed.'],
+  ];
+
+  it.each(chunkFailures)('recognises the %s wording', (_engine, error) => {
+    expect(isChunkLoadError(error)).toBe(true);
+  });
+
+  const genuineCrashes: Array<[string, unknown]> = [
+    ['a bug inside a module that did load', new TypeError("Cannot read properties of undefined (reading 'balance')")],
+    ['a failed API call', new TypeError('Failed to fetch')],
+    ['a thrown string', 'Something went wrong'],
+    ['no error at all', undefined],
+    ['null', null],
+    ['an object with no message', {}],
+  ];
+
+  it.each(genuineCrashes)('leaves %s to the generic crash path', (_case, error) => {
+    expect(isChunkLoadError(error)).toBe(false);
+  });
+});

--- a/src/utils/chunkLoadError.ts
+++ b/src/utils/chunkLoadError.ts
@@ -1,0 +1,51 @@
+/**
+ * A dynamic import fails for two very different reasons, and the app must treat
+ * them differently:
+ *
+ *  - the browser could not FETCH the chunk. Almost always because this tab
+ *    holds the index it booted with and a deploy has since replaced every
+ *    hashed filename in it — reloading fixes it; or
+ *  - the chunk was fetched and its module code threw. That is a real bug, and
+ *    reloading only reproduces it.
+ *
+ * Only the first is recoverable. Every engine words it differently, hence the
+ * list. Anything unmatched counts as a genuine crash, which is the safe
+ * direction: the user sees the real error rather than a surprise reload.
+ */
+const CHUNK_LOAD_ERROR_PATTERNS: readonly RegExp[] = [
+  /failed to fetch dynamically imported module/i,        // Chrome, Edge
+  /error loading dynamically imported module/i,          // Firefox
+  /importing a module script failed/i,                   // Safari
+  /failed to load module script/i,                       // Chrome, when the host answers a missing asset with index.html
+  /expected a javascript(?:-or-wasm)? module script/i,   // the MIME-type half of that same failure
+  /chunkloaderror/i,                                     // the error NAME used by webpack-style loaders
+  /loading chunk \S+ failed/i,                           // and its message
+  /unable to preload css/i,                              // Vite's preload helper, for a chunk's stylesheet
+];
+
+function toMatchableText(error: unknown): string {
+  if (typeof error === 'string') {
+    return error;
+  }
+
+  if (error !== null && typeof error === 'object') {
+    const name = 'name' in error && typeof error.name === 'string' ? error.name : '';
+    const message = 'message' in error && typeof error.message === 'string' ? error.message : '';
+    return `${name} ${message}`;
+  }
+
+  return '';
+}
+
+/**
+ * True when `error` is a failure to download application code, rather than a
+ * failure inside it.
+ */
+export function isChunkLoadError(error: unknown): boolean {
+  const text = toMatchableText(error);
+  if (text.trim() === '') {
+    return false;
+  }
+
+  return CHUNK_LOAD_ERROR_PATTERNS.some(pattern => pattern.test(text));
+}

--- a/src/utils/lazyWithPreload.ts
+++ b/src/utils/lazyWithPreload.ts
@@ -1,48 +1,38 @@
 import { lazy, ComponentType, LazyExoticComponent } from 'react';
+import { importWithChunkRecovery } from './lazyWithRecovery';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export interface PreloadableComponent<T extends ComponentType<any>> extends LazyExoticComponent<T> {
   preload: () => Promise<{ default: T }>;
 }
 
-// After a deploy, a long-lived tab holds an index that references chunk
-// hashes that no longer exist — its next route navigation fails with
-// "Importing a module script failed" (the Bank Feeds error). One automatic
-// reload fetches the fresh index and fixes it; the sessionStorage guard
-// stops a reload loop if the failure is real (e.g. offline).
-const RELOAD_GUARD_KEY = 'chunk_reload_guard';
-
-function importWithStaleChunkRecovery<T>(factory: () => Promise<T>): Promise<T> {
-  return factory().then(module => {
-    window.sessionStorage.removeItem(RELOAD_GUARD_KEY);
-    return module;
-  }).catch((error: unknown) => {
-    if (window.sessionStorage.getItem(RELOAD_GUARD_KEY) !== 'true') {
-      window.sessionStorage.setItem(RELOAD_GUARD_KEY, 'true');
-      window.location.reload();
-      // The page is reloading — never resolve, so no broken UI flashes.
-      return new Promise<T>(() => {});
-    }
-    throw error;
-  });
-}
-
+// Stale-chunk recovery (the "Importing a module script failed" deploy race)
+// lives in lazyWithRecovery — this only adds preloading on top of it, so a
+// preload that hits a stale chunk heals the tab before the user even clicks.
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export function lazyWithPreload<T extends ComponentType<any>>(
   factory: () => Promise<{ default: T }>
 ): PreloadableComponent<T> {
-  const recovering = () => importWithStaleChunkRecovery(factory);
+  const recovering = () => importWithChunkRecovery(factory);
   const Component = lazy(recovering) as PreloadableComponent<T>;
   Component.preload = recovering;
   return Component;
+}
+
+// Nobody asked for a preload, so a failed one must not surface as an unhandled
+// rejection. The same import runs again when the user actually navigates, where
+// Suspense and the error boundary handle it in front of them.
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function preloadQuietly<T extends ComponentType<any>>(component: PreloadableComponent<T>): void {
+  component.preload().catch(() => {});
 }
 
 // Preload a component when the user hovers over a link
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export function preloadOnHover<T extends ComponentType<any>>(component: PreloadableComponent<T>): { onMouseEnter: () => void; onTouchStart: () => void } {
   return {
-    onMouseEnter: () => component.preload(),
-    onTouchStart: () => component.preload(),
+    onMouseEnter: () => preloadQuietly(component),
+    onTouchStart: () => preloadQuietly(component),
   };
 }
 
@@ -50,10 +40,10 @@ export function preloadOnHover<T extends ComponentType<any>>(component: Preloada
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export function preloadWhenIdle<T extends ComponentType<any>>(component: PreloadableComponent<T>): void {
   if ('requestIdleCallback' in window) {
-    requestIdleCallback(() => component.preload());
+    requestIdleCallback(() => preloadQuietly(component));
   } else {
     // Fallback for browsers that don't support requestIdleCallback
-    setTimeout(() => component.preload(), 1);
+    setTimeout(() => preloadQuietly(component), 1);
   }
 }
 

--- a/src/utils/lazyWithRecovery.test.ts
+++ b/src/utils/lazyWithRecovery.test.ts
@@ -1,0 +1,223 @@
+import { describe, it, expect, vi } from 'vitest';
+import { importWithChunkRecovery, type ChunkRecoveryEnvironment } from './lazyWithRecovery';
+
+const RELOAD_COOLDOWN_MS = 60_000;
+
+// The wording Safari uses; the other engines are covered in chunkLoadError.test.ts.
+const staleChunkError = (): Error => new TypeError('Importing a module script failed.');
+
+interface TestHarness {
+  environment: ChunkRecoveryEnvironment;
+  reload: ReturnType<typeof vi.fn>;
+  readGuard: () => string | null;
+  advance: (ms: number) => void;
+}
+
+function createHarness(options: {
+  now?: number;
+  guard?: string | null;
+  online?: boolean;
+  storageWritable?: boolean;
+} = {}): TestHarness {
+  let now = options.now ?? 1_700_000_000_000;
+  let guard = options.guard ?? null;
+  const reload = vi.fn();
+
+  return {
+    environment: {
+      now: () => now,
+      readGuard: () => guard,
+      writeGuard: (value: string) => {
+        if (options.storageWritable === false) {
+          return false;
+        }
+        guard = value;
+        return true;
+      },
+      isOnline: () => options.online ?? true,
+      reload,
+    },
+    reload,
+    readGuard: () => guard,
+    advance: (ms: number) => { now += ms; },
+  };
+}
+
+type Settlement = { state: 'pending' } | { state: 'resolved'; value: unknown } | { state: 'rejected'; error: unknown };
+
+// Recovery deliberately returns a promise that never settles while the document
+// is being replaced, so every assertion has to allow for "still pending".
+async function settle(promise: Promise<unknown>): Promise<Settlement> {
+  let settlement: Settlement = { state: 'pending' };
+  promise.then(
+    value => { settlement = { state: 'resolved', value }; },
+    error => { settlement = { state: 'rejected', error }; }
+  );
+  await new Promise(resolve => setTimeout(resolve, 0));
+  return settlement;
+}
+
+describe('importWithChunkRecovery', () => {
+  it('passes a successful import straight through and leaves the guard alone', async () => {
+    const harness = createHarness();
+
+    const module = await importWithChunkRecovery(
+      () => Promise.resolve({ default: 'component' }),
+      { environment: harness.environment }
+    );
+
+    expect(module).toEqual({ default: 'component' });
+    expect(harness.reload).not.toHaveBeenCalled();
+    expect(harness.readGuard()).toBeNull();
+  });
+
+  it('reloads once on a stale chunk, records the attempt, and never settles', async () => {
+    const harness = createHarness({ now: 5_000 });
+
+    const settlement = await settle(importWithChunkRecovery(
+      () => Promise.reject(staleChunkError()),
+      { environment: harness.environment }
+    ));
+
+    expect(harness.reload).toHaveBeenCalledTimes(1);
+    expect(harness.readGuard()).toBe('5000');
+    expect(settlement.state).toBe('pending');
+  });
+
+  it('throws instead of reloading again inside the cooldown', async () => {
+    const harness = createHarness({ now: 5_000 });
+
+    await settle(importWithChunkRecovery(
+      () => Promise.reject(staleChunkError()),
+      { environment: harness.environment }
+    ));
+    harness.advance(RELOAD_COOLDOWN_MS - 1);
+
+    const error = staleChunkError();
+    const settlement = await settle(importWithChunkRecovery(
+      () => Promise.reject(error),
+      { environment: harness.environment }
+    ));
+
+    expect(harness.reload).toHaveBeenCalledTimes(1);
+    expect(settlement).toEqual({ state: 'rejected', error });
+  });
+
+  it('is not re-armed by a successful import in between, so it cannot loop', async () => {
+    const harness = createHarness({ now: 5_000 });
+
+    await settle(importWithChunkRecovery(
+      () => Promise.reject(staleChunkError()),
+      { environment: harness.environment }
+    ));
+    // What happens after the reload: the route chunk loads from the fresh index,
+    // then a child chunk that is genuinely unfetchable fails again.
+    await importWithChunkRecovery(
+      () => Promise.resolve({ default: 'route' }),
+      { environment: harness.environment }
+    );
+    harness.advance(2_000);
+
+    const settlement = await settle(importWithChunkRecovery(
+      () => Promise.reject(staleChunkError()),
+      { environment: harness.environment }
+    ));
+
+    expect(harness.reload).toHaveBeenCalledTimes(1);
+    expect(settlement.state).toBe('rejected');
+  });
+
+  it('recovers again once the cooldown has passed (a later deploy)', async () => {
+    const harness = createHarness({ now: 5_000 });
+
+    await settle(importWithChunkRecovery(
+      () => Promise.reject(staleChunkError()),
+      { environment: harness.environment }
+    ));
+    harness.advance(RELOAD_COOLDOWN_MS + 1);
+
+    const settlement = await settle(importWithChunkRecovery(
+      () => Promise.reject(staleChunkError()),
+      { environment: harness.environment }
+    ));
+
+    expect(harness.reload).toHaveBeenCalledTimes(2);
+    expect(settlement.state).toBe('pending');
+  });
+
+  it('treats a guard timestamp in the future as expired rather than wedging', async () => {
+    const harness = createHarness({ now: 5_000, guard: '9999999999999' });
+
+    const settlement = await settle(importWithChunkRecovery(
+      () => Promise.reject(staleChunkError()),
+      { environment: harness.environment }
+    ));
+
+    expect(harness.reload).toHaveBeenCalledTimes(1);
+    expect(settlement.state).toBe('pending');
+  });
+
+  it('recovers a failure in the .then() that picks a named export', async () => {
+    const harness = createHarness();
+
+    const settlement = await settle(importWithChunkRecovery(
+      () => Promise.reject(staleChunkError())
+        .then((module: { InfiniteScrollTransactionList: string }) => ({ default: module.InfiniteScrollTransactionList })),
+      { environment: harness.environment }
+    ));
+
+    expect(harness.reload).toHaveBeenCalledTimes(1);
+    expect(settlement.state).toBe('pending');
+  });
+
+  it('rethrows a module that loaded and then crashed, without reloading', async () => {
+    const harness = createHarness();
+    const error = new TypeError("Cannot read properties of undefined (reading 'map')");
+
+    const settlement = await settle(importWithChunkRecovery(
+      () => Promise.reject(error),
+      { environment: harness.environment }
+    ));
+
+    expect(harness.reload).not.toHaveBeenCalled();
+    expect(settlement).toEqual({ state: 'rejected', error });
+  });
+
+  it('rethrows without reloading when the call site opts out', async () => {
+    const harness = createHarness();
+    const error = staleChunkError();
+
+    const settlement = await settle(importWithChunkRecovery(
+      () => Promise.reject(error),
+      { autoReload: false, environment: harness.environment }
+    ));
+
+    expect(harness.reload).not.toHaveBeenCalled();
+    expect(harness.readGuard()).toBeNull();
+    expect(settlement).toEqual({ state: 'rejected', error });
+  });
+
+  it('rethrows without reloading when the browser is offline', async () => {
+    const harness = createHarness({ online: false });
+
+    const settlement = await settle(importWithChunkRecovery(
+      () => Promise.reject(staleChunkError()),
+      { environment: harness.environment }
+    ));
+
+    expect(harness.reload).not.toHaveBeenCalled();
+    expect(settlement.state).toBe('rejected');
+  });
+
+  it('rethrows without reloading when the guard cannot be stored', async () => {
+    const harness = createHarness({ storageWritable: false });
+
+    const settlement = await settle(importWithChunkRecovery(
+      () => Promise.reject(staleChunkError()),
+      { environment: harness.environment }
+    ));
+
+    expect(harness.reload).not.toHaveBeenCalled();
+    expect(settlement.state).toBe('rejected');
+  });
+});

--- a/src/utils/lazyWithRecovery.ts
+++ b/src/utils/lazyWithRecovery.ts
@@ -1,0 +1,121 @@
+import { lazy } from 'react';
+import type { ComponentType, LazyExoticComponent } from 'react';
+import { isChunkLoadError } from './chunkLoadError';
+
+/**
+ * Every deploy replaces the hashed chunk filenames on the CDN, but a tab that
+ * was already open keeps the index it booted with. Its next lazy import asks
+ * for a file that no longer exists and fails ("Importing a module script
+ * failed" in Safari, worded differently elsewhere), and the error boundary
+ * takes over the page. One automatic reload fetches the fresh index and the tab
+ * is healthy again — that is what this does, for route chunks and for the
+ * modals, lists and reports the routes load in turn.
+ *
+ * The guard is a TIMESTAMP, and a successful import deliberately does NOT clear
+ * it. Clearing on success looks tidier but loops: after the reload the route
+ * chunk loads fine and clears the guard, so a chunk that is genuinely
+ * unfetchable (a half-published deploy, a blocked asset, a partly-cached app
+ * with no network) would fail → reload → clear → fail → reload for as long as
+ * the tab is open. Time-boxing instead caps recovery at one reload per tab per
+ * minute: ample for the stale-index case, where the retry happens seconds after
+ * boot, and incapable of looping.
+ */
+const RELOAD_GUARD_KEY = 'chunk_reload_guard';
+const RELOAD_COOLDOWN_MS = 60_000;
+
+export interface ChunkRecoveryEnvironment {
+  now: () => number;
+  readGuard: () => string | null;
+  /** Returns false when the guard could not be persisted — see the browser implementation. */
+  writeGuard: (value: string) => boolean;
+  isOnline: () => boolean;
+  reload: () => void;
+}
+
+const browserEnvironment: ChunkRecoveryEnvironment = {
+  now: () => Date.now(),
+  readGuard: () => {
+    try {
+      return window.sessionStorage.getItem(RELOAD_GUARD_KEY);
+    } catch {
+      return null;
+    }
+  },
+  writeGuard: (value: string) => {
+    // Locked-down storage settings make setItem throw. Without a guard an
+    // automatic reload could loop, so a failed write means "do not reload" and
+    // the user gets the boundary's Reload button instead.
+    try {
+      window.sessionStorage.setItem(RELOAD_GUARD_KEY, value);
+      return true;
+    } catch {
+      return false;
+    }
+  },
+  isOnline: () => (typeof navigator === 'undefined' ? true : navigator.onLine !== false),
+  reload: () => window.location.reload(),
+};
+
+export interface ChunkRecoveryOptions {
+  /**
+   * Set false where reloading would throw away work the user cannot get back.
+   * The import then rejects normally, so the call site must show its own
+   * recovery — an unhandled rejection here costs the user the whole page.
+   */
+  autoReload?: boolean;
+  environment?: ChunkRecoveryEnvironment;
+}
+
+function claimReloadAttempt(environment: ChunkRecoveryEnvironment): boolean {
+  const stored = environment.readGuard();
+  const lastAttemptAt = stored === null ? Number.NaN : Number.parseInt(stored, 10);
+
+  if (Number.isFinite(lastAttemptAt)) {
+    const elapsed = environment.now() - lastAttemptAt;
+    // A negative elapsed means the clock moved backwards; treat that as expired
+    // rather than locking recovery out until the clock catches up.
+    if (elapsed >= 0 && elapsed < RELOAD_COOLDOWN_MS) {
+      return false;
+    }
+  }
+
+  return environment.writeGuard(String(environment.now()));
+}
+
+/**
+ * Wraps a whole import expression — including any `.then()` that picks a named
+ * export — so a failure in either link is recovered.
+ */
+export function importWithChunkRecovery<T>(
+  load: () => Promise<T>,
+  options: ChunkRecoveryOptions = {}
+): Promise<T> {
+  const { autoReload = true, environment = browserEnvironment } = options;
+
+  return load().catch((error: unknown) => {
+    // Offline, a reload replaces a running app with the browser's error page,
+    // so it makes things worse rather than better.
+    const recoverable = autoReload && isChunkLoadError(error) && environment.isOnline();
+
+    if (!recoverable || !claimReloadAttempt(environment)) {
+      throw error;
+    }
+
+    environment.reload();
+    // The document is on its way out. Never settling keeps a half-built page —
+    // or a flash of the error boundary — off the screen while it goes.
+    return new Promise<T>(() => {});
+  });
+}
+
+/**
+ * `React.lazy` with stale-chunk recovery. Use this for every lazily loaded
+ * component; use `lazyWithPreload` when the component also needs preloading.
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function lazyWithRecovery<T extends ComponentType<any>>(
+  factory: () => Promise<{ default: T }>,
+  options?: ChunkRecoveryOptions
+): LazyExoticComponent<T> {
+  return lazy(() => importWithChunkRecovery(factory, options));
+}

--- a/src/utils/transferOtherSide.test.ts
+++ b/src/utils/transferOtherSide.test.ts
@@ -69,7 +69,7 @@ describe('resolveTransferOtherSide', () => {
     });
   });
 
-  it('reports a closed other side without a name — its register cannot open', () => {
+  it('reports a closed other side without a name — it is not in the open list', () => {
     expect(resolveTransferOtherSide(OUT, [OUT], [account('acc-a', 'Current Account')])).toEqual({
       transactionId: 'in',
       accountId: 'acc-b',

--- a/src/utils/transferOtherSide.ts
+++ b/src/utils/transferOtherSide.ts
@@ -10,7 +10,9 @@ export interface TransferOtherSide {
   accountName?: string;
   /**
    * False when that account is closed (or otherwise absent from the open
-   * list). Closed accounts have no register, so the jump cannot be taken.
+   * list). The jump is still offered — the register meets a closed account
+   * with the re-open offer — but its name cannot be printed, and the caller
+   * says up front what will happen on arrival.
    */
   isOpen: boolean;
 }


### PR DESCRIPTION
## What

**Closed-account dead end.** Jumping to a transaction in a closed account (payee drill, report drills, bookmarks, `?txn=` deep links) landed on a flat *"Account not found"* — untrue: the account exists, it's closed. Only the cloud path filters closed accounts out of the loaded list, which is why this only ever showed on real data. The register now distinguishes **open / closed / missing**, with the closed state naming the account, explaining that closed accounts have no open register (history preserved), and offering **Re-open and view** using the same mechanism as the Accounts page. Fixed at the destination, so every route in is covered at once.

Found while in there: the click-outside-to-deselect handler counted a press on "Re-open and view" as *outside*, wiping the deep-linked selection before the table could mount — so a re-open landed on a register with nothing highlighted. Guarded and regression-tested by reverting.

**"Jump to the other side"** no longer sits disabled when the far leg is in a closed account: it navigates and lets the destination make the offer. One implementation instead of two, and the offer appears where the user asked for it.

**Stale-chunk recovery, everywhere.** After a deploy, a long-lived tab holds an index referencing chunk files that no longer exist; the next lazy import fails with *"Importing a module script failed"*. Recovery already existed but wrapped only route-level imports — **47 component-level imports bypassed it**, including four inside the Transactions page (the owner's repro exactly).

Three things that had to change with it:
- **The loop guard.** A boolean cleared by any success works today only by ordering accident; wrapping child chunks turns it into an infinite reload loop (fail → reload → route loads and clears guard → child fails → reload → …). It's a timestamp now: at most one automatic reload per tab per minute, immune to clock skew and unwritable storage.
- **Recovery is conditional on a genuine chunk failure.** Previously *any* import rejection reloaded — including a module that downloaded fine and threw during evaluation, where reload doesn't help and destroys typed input.
- **One deliberate opt-out**: bank-account linking, the only lazy import reached part-way through real work (discovery already run against the bank, accounts hand-matched). It keeps its own in-place message rather than reloading.

**Error copy** when recovery can't help: *"WealthTracker has been updated"* / reload to pick it up / nothing saved is affected, plus an offline variant. "Try Again" is replaced, not kept — React re-throws a cached failed import, so it could never have worked for this error class.

## Verification
- 3,862 tests passing (+38); strict typecheck + lint clean.
- Browser-verified: all eight primary routes navigate clean after 47 lazy sites changed; the missing-account state renders its new honest copy.
- Closed-account state is cloud-path-only (demo keeps closed accounts in the loaded list), so it's covered by unit tests rather than a demo click-through — the owner's real-data check is the payee drill into a closed account.

## Known gap, flagged not papered over
22 runtime `await import(...)` calls (services inside event handlers, e.g. PDF export) are unwrapped — auto-reloading mid-export would be destructive. Needs per-site judgement; separate work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)