### PR TITLE
feat(splits+dates): edit a split without unpicking its transfer, and UK dates everywhere

### DIFF
--- a/src/components/AddInvestmentModal.test.tsx
+++ b/src/components/AddInvestmentModal.test.tsx
@@ -570,9 +570,9 @@ describe('AddInvestmentModal', () => {
       expect(screen.getByPlaceholderText(/Apple Inc\./)).toHaveAttribute('required');
       expect(screen.getByPlaceholderText('100')).toHaveAttribute('required');
       expect(screen.getByPlaceholderText('150.00')).toHaveAttribute('required');
-      // Date input doesn't have placeholder, use type selector
-      const dateInput = screen.getByDisplayValue(mockFormData.date);
-      expect(dateInput).toHaveAttribute('required');
+      // The shared dd/mm/yyyy picker, so the field's value is the UK-formatted
+      // display of the ISO date held in state — find it by its label instead.
+      expect(screen.getByLabelText('Purchase date')).toHaveAttribute('required');
     });
   });
 

--- a/src/components/AddInvestmentModal.tsx
+++ b/src/components/AddInvestmentModal.tsx
@@ -5,6 +5,7 @@ import { useCurrencyDecimal } from '../hooks/useCurrencyDecimal';
 import { getCurrencySymbol } from '../utils/currency-decimal';
 import { Modal, ModalBody, ModalFooter } from './common/Modal';
 import MoneyInput from './common/MoneyInput';
+import DatePicker from './common/DatePicker';
 import { useModalForm } from '../hooks/useModalForm';
 import { toDecimal, parseMoneyInput } from '../utils/decimal';
 
@@ -290,12 +291,14 @@ export default function AddInvestmentModal({ isOpen, onClose, accountId }: AddIn
               <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
                 Purchase Date*
               </label>
-              <input
-                type="date"
+              {/* dd/mm/yyyy everywhere — a native date input renders in the
+                  browser's locale, not the app's. */}
+              <DatePicker
                 value={formData.date}
-                onChange={(e) => updateField('date', e.target.value)}
-                className="w-full px-3 py-2 bg-white dark:bg-gray-800-sm border border-gray-300/50 dark:border-gray-600/50 rounded-xl focus:outline-none focus:ring-2 focus:ring-primary focus:border-transparent dark:text-white"
+                onChange={(val) => updateField('date', val)}
+                className="bg-white dark:bg-gray-800-sm border border-gray-300/50 dark:border-gray-600/50 rounded-xl focus:outline-none focus:ring-2 focus:ring-primary focus:border-transparent dark:text-white"
                 required
+                aria-label="Purchase date"
               />
             </div>
           </div>

--- a/src/components/AddTransactionModal.tsx
+++ b/src/components/AddTransactionModal.tsx
@@ -7,6 +7,7 @@ import { getCurrencySymbol } from '../utils/currency';
 import { ResponsiveModal } from './ResponsiveModal';
 import MoneyInput from './common/MoneyInput';
 import GroupedAccountSelect from './common/GroupedAccountSelect';
+import DatePicker from './common/DatePicker';
 import { useModalForm } from '../hooks/useModalForm';
 import { parseMoneyInput } from '../utils/decimal';
 import MarkdownEditor from './MarkdownEditor';
@@ -302,12 +303,13 @@ export default function AddTransactionModal({ isOpen, onClose }: AddTransactionM
               <label htmlFor="date-input" className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
                 Date
               </label>
-              <input
+              {/* dd/mm/yyyy everywhere — a native date input renders in the
+                  browser's locale, not the app's. */}
+              <DatePicker
                 id="date-input"
-                type="date"
                 value={formData.date}
-                onChange={(e) => updateField('date', e.target.value)}
-                className="w-full px-3 py-3 sm:py-2 text-base sm:text-sm bg-white dark:bg-gray-700 border-2 border-gray-300 dark:border-gray-500 rounded-lg focus:outline-none focus:ring-2 focus:ring-primary dark:focus:ring-blue-400 focus:border-transparent dark:text-white min-h-[48px] sm:min-h-[auto]"
+                onChange={(val) => updateField('date', val)}
+                className="text-base sm:text-sm bg-white dark:bg-gray-700 border-2 border-gray-300 dark:border-gray-500 rounded-lg focus:outline-none focus:ring-2 focus:ring-primary dark:focus:ring-blue-400 focus:border-transparent dark:text-white min-h-[48px] sm:min-h-[auto]"
                 required
                 aria-label="Transaction date"
               />

--- a/src/components/ArchiveManager.tsx
+++ b/src/components/ArchiveManager.tsx
@@ -7,6 +7,7 @@ import { useMemo, useState, useCallback } from 'react';
 import { useApp } from '../contexts/AppContextSupabase';
 import { useToast } from '../contexts/ToastContext';
 import { ArchiveIcon, CheckCircleIcon } from './icons';
+import DatePicker from './common/DatePicker';
 import {
   ARCHIVE_PRESETS, resolveCutoff, countArchivable, type ArchivePreset,
 } from '../utils/archive';
@@ -82,13 +83,17 @@ export default function ArchiveManager() {
             ))}
           </div>
           {preset === 'custom' && (
-            <input
-              type="date"
-              value={customDate}
-              onChange={(e) => setCustomDate(e.target.value)}
-              className="px-3 py-1.5 text-sm rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-900 text-gray-900 dark:text-white"
-              aria-label="Custom archive cutoff date"
-            />
+            /* dd/mm/yyyy everywhere — a native date input renders in the
+               browser's locale, not the app's. */
+            <div className="w-40">
+              <DatePicker
+                size="sm"
+                value={customDate}
+                onChange={setCustomDate}
+                className="text-sm rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-900 text-gray-900 dark:text-white"
+                aria-label="Custom archive cutoff date"
+              />
+            </div>
           )}
         </div>
         {cutoff && (

--- a/src/components/BulkTransactionEdit.tsx
+++ b/src/components/BulkTransactionEdit.tsx
@@ -17,6 +17,8 @@ import {
 } from './icons';
 import BulkEditPanel from './BulkEditPanel';
 import { GroupedAccountOptions } from './common/GroupedAccountSelect';
+import DatePicker from './common/DatePicker';
+import { formatDateForInput } from '../utils/dateFormatter';
 import type { Transaction } from '../types';
 import type { DecimalInstance } from '../types/decimal-types';
 
@@ -397,34 +399,40 @@ export default function BulkTransactionEdit({
                 <div className="grid grid-cols-2 gap-4">
                   <div>
                     <label className="block text-sm font-medium mb-1">Date Range</label>
+                    {/* dd/mm/yyyy everywhere — a native date input renders in
+                        the browser's locale, not the app's. */}
                     <div className="flex gap-2">
-                      <input
-                        type="date"
-                        value={filters.dateRange.start?.toISOString().split('T')[0] || ''}
-                        onChange={(e) => setFilters({
-                          ...filters,
-                          dateRange: {
-                            ...filters.dateRange,
-                            start: e.target.value ? new Date(e.target.value) : null
-                          }
-                        })}
-                        className="flex-1 px-2 py-1 text-sm border border-gray-300 dark:border-gray-600 
-                                 rounded bg-white dark:bg-gray-700"
-                      />
+                      <div className="flex-1 min-w-0">
+                        <DatePicker
+                          size="sm"
+                          value={formatDateForInput(filters.dateRange.start)}
+                          onChange={(val) => setFilters({
+                            ...filters,
+                            dateRange: {
+                              ...filters.dateRange,
+                              start: val ? new Date(val) : null
+                            }
+                          })}
+                          className="text-sm border border-gray-300 dark:border-gray-600 rounded bg-white dark:bg-gray-700"
+                          aria-label="Filter from date"
+                        />
+                      </div>
                       <span className="self-center">to</span>
-                      <input
-                        type="date"
-                        value={filters.dateRange.end?.toISOString().split('T')[0] || ''}
-                        onChange={(e) => setFilters({
-                          ...filters,
-                          dateRange: {
-                            ...filters.dateRange,
-                            end: e.target.value ? new Date(e.target.value) : null
-                          }
-                        })}
-                        className="flex-1 px-2 py-1 text-sm border border-gray-300 dark:border-gray-600 
-                                 rounded bg-white dark:bg-gray-700"
-                      />
+                      <div className="flex-1 min-w-0">
+                        <DatePicker
+                          size="sm"
+                          value={formatDateForInput(filters.dateRange.end)}
+                          onChange={(val) => setFilters({
+                            ...filters,
+                            dateRange: {
+                              ...filters.dateRange,
+                              end: val ? new Date(val) : null
+                            }
+                          })}
+                          className="text-sm border border-gray-300 dark:border-gray-600 rounded bg-white dark:bg-gray-700"
+                          aria-label="Filter to date"
+                        />
+                      </div>
                     </div>
                   </div>
                   <div>

--- a/src/components/CategorySelector.test.tsx
+++ b/src/components/CategorySelector.test.tsx
@@ -26,6 +26,12 @@ const tree: Category[] = [
   { id: 'det-groceries', name: 'Groceries', type: 'expense', level: 'detail', parentId: 'sub-food' },
   { id: 'type-revaluation', name: 'Revaluation', type: 'both', level: 'type', isRevaluationCategory: true },
   { id: 'rev-adjustment', name: 'Account Adjustment', type: 'both', level: 'detail', parentId: 'type-revaluation', isRevaluationCategory: true },
+  // The account-managed To/From categories: detail rows hanging off the
+  // Transfer type root, one per account, maintained by the account lifecycle.
+  { id: 'type-transfer', name: 'Transfer', type: 'both', level: 'type' },
+  { id: 'tofrom-savings', name: 'To/From Savings', type: 'both', level: 'detail', parentId: 'type-transfer', isTransferCategory: true, accountId: 'acct-savings' },
+  { id: 'tofrom-current', name: 'To/From Current', type: 'both', level: 'detail', parentId: 'type-transfer', isTransferCategory: true, accountId: 'acct-current' },
+  { id: 'tofrom-closed', name: 'To/From Old ISA', type: 'both', level: 'detail', parentId: 'type-transfer', isTransferCategory: true, accountId: 'acct-closed', isActive: false },
 ];
 
 const PLACEHOLDER = 'Pick a category';
@@ -201,6 +207,63 @@ describe('CategorySelector', () => {
       fireEvent.change(screen.getByPlaceholderText(PLACEHOLDER), { target: { value: 'adjust' } });
       expect(screen.getByText('Account Adjustment')).toBeInTheDocument();
       expect(screen.queryByText('Payslip')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('transfer targets (the split-line leg)', () => {
+    it('are absent unless asked for — a whole transaction transfers via the Type toggle', () => {
+      renderOpen({ includeAllTypes: true });
+      expect(screen.queryByText('To/From Savings')).not.toBeInTheDocument();
+      expect(screen.queryByText('Transfer to another account')).not.toBeInTheDocument();
+    });
+
+    it('appear under their own heading, last, when a line may BE a transfer', () => {
+      renderOpen({ includeAllTypes: true, includeTransferTargets: true });
+      expect(screen.getByText('Transfer to another account')).toBeInTheDocument();
+      expect(screen.getByText('To/From Savings')).toBeInTheDocument();
+      const headings = screen
+        .getAllByText(/^(Salary|Food|Revaluation|Transfer to another account)$/)
+        .map(el => el.textContent);
+      expect(headings[headings.length - 1]).toBe('Transfer to another account');
+    });
+
+    it("leaves out the transaction's own account — a transfer to itself moves nothing", () => {
+      renderOpen({
+        includeAllTypes: true,
+        includeTransferTargets: true,
+        transferSourceAccountId: 'acct-current',
+      });
+      expect(screen.getByText('To/From Savings')).toBeInTheDocument();
+      expect(screen.queryByText('To/From Current')).not.toBeInTheDocument();
+    });
+
+    it('leaves out a closed account (its category is inactive)', () => {
+      renderOpen({ includeAllTypes: true, includeTransferTargets: true });
+      expect(screen.queryByText('To/From Old ISA')).not.toBeInTheDocument();
+    });
+
+    it('reports the chosen To/From category id, and filters with the search', () => {
+      const { onCategoryChange } = renderOpen({
+        includeAllTypes: true,
+        includeTransferTargets: true,
+        transferSourceAccountId: 'acct-current',
+      });
+      fireEvent.change(screen.getByPlaceholderText(PLACEHOLDER), { target: { value: 'to/from' } });
+      expect(screen.queryByText('Groceries')).not.toBeInTheDocument();
+      fireEvent.click(screen.getByText('To/From Savings'));
+      expect(onCategoryChange).toHaveBeenCalledWith('tofrom-savings');
+    });
+
+    it('is reachable by keyboard like any other option', () => {
+      const { onCategoryChange } = renderOpen({
+        includeAllTypes: true,
+        includeTransferTargets: true,
+        transferSourceAccountId: 'acct-current',
+      });
+      const input = screen.getByPlaceholderText(PLACEHOLDER);
+      fireEvent.change(input, { target: { value: 'savings' } });
+      fireEvent.keyDown(input, { key: 'Enter' });
+      expect(onCategoryChange).toHaveBeenCalledWith('tofrom-savings');
     });
   });
 

--- a/src/components/CategorySelector.tsx
+++ b/src/components/CategorySelector.tsx
@@ -105,7 +105,32 @@ interface CategorySelectorProps {
    * everywhere a transaction is being filed: a transaction belongs to a leaf.
    */
   allowGroupSelection?: boolean;
+  /**
+   * Offer the account "To/From <account>" categories as their own section, so
+   * a line can say "this part of the money moved to another account" — the
+   * Microsoft Money split leg.
+   *
+   * ONLY split-line pickers set this. A WHOLE transaction becomes a transfer
+   * through the Type toggle, which creates both sides; offering a To/From
+   * category as its category would be a second, contradictory way to say the
+   * same thing.
+   */
+  includeTransferTargets?: boolean;
+  /**
+   * The account the transaction sits in. Its own To/From category is left out
+   * of the transfer section — a transfer from an account to itself moves no
+   * money and has no other side to create.
+   */
+  transferSourceAccountId?: string;
 }
+
+/**
+ * Section id for the transfer targets. They hang off the Transfer type root as
+ * ordinary detail categories, so they have no shared parent to group under —
+ * and the heading wants to say what choosing one MEANS, not repeat the tree.
+ */
+const TRANSFER_SECTION_ID = '__transfer_targets__';
+const TRANSFER_SECTION_NAME = 'Transfer to another account';
 
 export default function CategorySelector({
   selectedCategory,
@@ -121,6 +146,8 @@ export default function CategorySelector({
   allowClear = false,
   size = 'default',
   allowGroupSelection = false,
+  includeTransferTargets = false,
+  transferSourceAccountId,
 }: CategorySelectorProps): React.JSX.Element {
   const { categories, addCategory, getSubCategories, getDetailCategories } = useApp();
   const [showDropdown, setShowDropdown] = useState(false);
@@ -217,6 +244,24 @@ export default function CategorySelector({
       : details;
   };
 
+  /**
+   * The account "To/From <account>" categories, offered only where a line may
+   * BE a transfer. A closed account's category is inactive and stays hidden;
+   * the transaction's own account is left out (nothing moves).
+   */
+  const getTransferTargetDetails = (): Category[] => {
+    if (!includeTransferTargets) return [];
+    const targets = categories.filter(c =>
+      c.isTransferCategory === true &&
+      c.isActive !== false &&
+      c.accountId !== undefined &&
+      c.accountId !== transferSourceAccountId
+    );
+    return excludeIds && excludeIds.length > 0
+      ? targets.filter(c => !excludeIds.includes(c.id))
+      : targets;
+  };
+
   // Get all detail categories for the transaction type
   const getAllDetailCategories = (): Category[] => {
     const subCategories = getSubCategoriesForType();
@@ -230,6 +275,7 @@ export default function CategorySelector({
     });
 
     detailCategories.push(...getRevaluationDetails());
+    detailCategories.push(...getTransferTargetDetails());
 
     return excludeIds && excludeIds.length > 0
       ? detailCategories.filter(c => !excludeIds.includes(c.id))
@@ -253,7 +299,13 @@ export default function CategorySelector({
   // Group the search-filtered detail categories under their parent sub-category
   // (Bills, Food, Personal…), preserving sub-category order — the dropdown shows
   // titled sections instead of a flat list, while search still filters items.
-  const getGroupedOptions = (): Array<{ id: string; name: string; items: Category[] }> => {
+  const getGroupedOptions = (): Array<{
+    id: string;
+    name: string;
+    items: Category[];
+    /** Whether the group HEADING is itself a choice ("All Food"). */
+    selectable: boolean;
+  }> => {
     const matchedIds = new Set(getFilteredOptions().map(c => c.id));
     const groupMatchesSearch = (name: string): boolean =>
       allowGroupSelection && name.toLowerCase().includes(searchTerm.toLowerCase());
@@ -262,6 +314,7 @@ export default function CategorySelector({
         id: sub.id,
         name: sub.name,
         items: getDetailCategories(sub.id).filter(d => matchedIds.has(d.id)),
+        selectable: allowGroupSelection,
       }))
       // A group with no (matching) leaves still belongs in the list when the
       // group ITSELF can be chosen and the search names it.
@@ -273,9 +326,16 @@ export default function CategorySelector({
         id: root.id,
         name: root.name,
         items: getDetailCategories(root.id).filter(d => matchedIds.has(d.id)),
+        selectable: allowGroupSelection,
       }))
       .filter(group => group.items.length > 0);
-    return [...groups, ...revaluationGroups];
+    // Transfers last of all, and never selectable as a group: "transfer" is
+    // not a category anything can be filed under — only a specific account is.
+    const transferItems = getTransferTargetDetails().filter(c => matchedIds.has(c.id));
+    const transferGroups = transferItems.length > 0
+      ? [{ id: TRANSFER_SECTION_ID, name: TRANSFER_SECTION_NAME, items: transferItems, selectable: false }]
+      : [];
+    return [...groups, ...revaluationGroups, ...transferGroups];
   };
 
   // Get parent category name for display
@@ -473,7 +533,7 @@ export default function CategorySelector({
   const flatOptions: Array<Pick<Category, 'id' | 'name'>> = [
     ...(showClearOption ? [{ id: UNCATEGORISED_ID, name: 'Uncategorised' }] : []),
     ...groupedOptions.flatMap(g =>
-      allowGroupSelection
+      g.selectable
         ? [{ id: g.id, name: `All ${g.name}` }, ...g.items]
         : g.items
     ),
@@ -654,7 +714,7 @@ export default function CategorySelector({
                       {/* The group as a choice in its own right, above its
                           leaves — a budget on "Food" covers everything under
                           it. Only rendered where groups are selectable. */}
-                      {allowGroupSelection && (
+                      {group.selectable && (
                         <div
                           id={optionDomId(group.id)}
                           role="option"

--- a/src/components/CategoryTransactionsModal.tsx
+++ b/src/components/CategoryTransactionsModal.tsx
@@ -6,6 +6,7 @@ import { XCircleIcon } from './icons/XCircleIcon';
 import { useApp } from '../contexts/AppContextSupabase';
 import { useCurrencyDecimal } from '../hooks/useCurrencyDecimal';
 import EditTransactionModal from './EditTransactionModal';
+import DatePicker from './common/DatePicker';
 import { expandSplitTransactions, type SplitExpandedTransaction } from '../utils/transactionSplits';
 import type { Transaction } from '../types';
 
@@ -237,20 +238,28 @@ export default function CategoryTransactionsModal({
             {/* Date Range */}
             <div className="flex flex-wrap gap-2 items-center">
               <CalendarIcon className="text-gray-400 hidden sm:block" size={18} />
+              {/* dd/mm/yyyy everywhere — a native date input renders in the
+                  browser's locale, not the app's. */}
               <div className="flex flex-wrap gap-2 items-center flex-1">
-                <input
-                  type="date"
-                  value={fromDate}
-                  onChange={(e) => setFromDate(e.target.value)}
-                  className="flex-1 min-w-[130px] px-2 py-1.5 border border-gray-300 dark:border-gray-600 rounded-lg dark:bg-gray-700 dark:text-white text-sm"
-                />
+                <div className="flex-1 min-w-[130px]">
+                  <DatePicker
+                    size="sm"
+                    value={fromDate}
+                    onChange={setFromDate}
+                    className="border border-gray-300 dark:border-gray-600 rounded-lg dark:bg-gray-700 dark:text-white text-sm"
+                    aria-label="Filter from date"
+                  />
+                </div>
                 <span className="text-gray-500 dark:text-gray-400 text-sm">to</span>
-                <input
-                  type="date"
-                  value={toDate}
-                  onChange={(e) => setToDate(e.target.value)}
-                  className="flex-1 min-w-[130px] px-2 py-1.5 border border-gray-300 dark:border-gray-600 rounded-lg dark:bg-gray-700 dark:text-white text-sm"
-                />
+                <div className="flex-1 min-w-[130px]">
+                  <DatePicker
+                    size="sm"
+                    value={toDate}
+                    onChange={setToDate}
+                    className="border border-gray-300 dark:border-gray-600 rounded-lg dark:bg-gray-700 dark:text-white text-sm"
+                    aria-label="Filter to date"
+                  />
+                </div>
               </div>
             </div>
             

--- a/src/components/CustomReportBuilder.tsx
+++ b/src/components/CustomReportBuilder.tsx
@@ -13,6 +13,7 @@ import {
   CalendarIcon,
   SaveIcon
 } from './icons';
+import DatePicker from './common/DatePicker';
 import { useApp } from '../contexts/AppContextSupabase';
 import { useNotifications } from '../contexts/NotificationContext';
 
@@ -486,20 +487,26 @@ export default function CustomReportBuilder({
             <option value="custom">Custom Range</option>
           </select>
           
+          {/* dd/mm/yyyy everywhere — a native date input renders in the
+              browser's locale, not the app's. */}
           {filters.dateRange === 'custom' && (
             <>
-              <input
-                type="date"
-                value={filters.customStartDate || ''}
-                onChange={(e) => handleCustomStartDateChange(e.target.value)}
-                className="px-3 py-2 bg-white dark:bg-gray-800 border border-gray-300 dark:border-gray-600 rounded-lg text-sm"
-              />
-              <input
-                type="date"
-                value={filters.customEndDate || ''}
-                onChange={(e) => handleCustomEndDateChange(e.target.value)}
-                className="px-3 py-2 bg-white dark:bg-gray-800 border border-gray-300 dark:border-gray-600 rounded-lg text-sm"
-              />
+              <div className="w-40">
+                <DatePicker
+                  value={filters.customStartDate || ''}
+                  onChange={handleCustomStartDateChange}
+                  className="bg-white dark:bg-gray-800 border border-gray-300 dark:border-gray-600 rounded-lg text-sm"
+                  aria-label="Report start date"
+                />
+              </div>
+              <div className="w-40">
+                <DatePicker
+                  value={filters.customEndDate || ''}
+                  onChange={handleCustomEndDateChange}
+                  className="bg-white dark:bg-gray-800 border border-gray-300 dark:border-gray-600 rounded-lg text-sm"
+                  aria-label="Report end date"
+                />
+              </div>
             </>
           )}
 

--- a/src/components/DividendTracker.tsx
+++ b/src/components/DividendTracker.tsx
@@ -3,6 +3,8 @@ import { dividendService } from '../services/dividendService';
 import type { Dividend, DividendSummary, DividendProjection } from '../services/dividendService';
 import { parseMoneyInput } from '../utils/decimal';
 import MoneyInput from './common/MoneyInput';
+import DatePicker from './common/DatePicker';
+import { formatDateForInput } from '../utils/dateFormatter';
 import { useApp } from '../contexts/AppContextSupabase';
 import { useCurrency } from '../hooks/useCurrency';
 import { useCurrencyDecimal } from '../hooks/useCurrencyDecimal';
@@ -551,25 +553,29 @@ function DividendModal({ dividend, symbols, onSave, onClose }: DividendModalProp
               />
             </div>
             
+            {/* dd/mm/yyyy everywhere — a native date input renders in the
+                browser's locale, not the app's. Both hold real Dates and are
+                required, so an emptied value (the picker's Clear) is ignored
+                rather than stored as an Invalid Date. */}
             <div>
               <label className="block text-sm font-medium mb-1">Payment Date</label>
-              <input
-                type="date"
-                value={formData.paymentDate.toISOString().split('T')[0]}
-                onChange={(e) => setFormData({ ...formData, paymentDate: new Date(e.target.value) })}
-                className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-700"
+              <DatePicker
+                value={formatDateForInput(formData.paymentDate)}
+                onChange={(val) => { if (val) setFormData({ ...formData, paymentDate: new Date(val) }); }}
+                className="border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-700"
                 required
+                aria-label="Payment date"
               />
             </div>
-            
+
             <div>
               <label className="block text-sm font-medium mb-1">Ex-Dividend Date</label>
-              <input
-                type="date"
-                value={formData.exDividendDate.toISOString().split('T')[0]}
-                onChange={(e) => setFormData({ ...formData, exDividendDate: new Date(e.target.value) })}
-                className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-700"
+              <DatePicker
+                value={formatDateForInput(formData.exDividendDate)}
+                onChange={(val) => { if (val) setFormData({ ...formData, exDividendDate: new Date(val) }); }}
+                className="border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-700"
                 required
+                aria-label="Ex-dividend date"
               />
             </div>
             

--- a/src/components/EditTransactionModal.accountJump.test.tsx
+++ b/src/components/EditTransactionModal.accountJump.test.tsx
@@ -1,0 +1,202 @@
+/**
+ * EditTransactionModal — "See this transaction in <account>".
+ *
+ * Editing a row from the categorise page, a report drill or the dashboard
+ * shows the row on its own. The surrounding rows and the running balance are
+ * often what actually explains it, so the editor offers a way into the
+ * register, deep-linked (?txn=<id>) so the row is selected and centred on
+ * arrival. It is the same mechanic as the transfer jump, pointed at the row's
+ * OWN account — and it stays out of the way when the register IS the host.
+ *
+ * This file drives the real useModalForm, so the date field assertion here is
+ * the genuine ISO round-trip through the component's own state.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import EditTransactionModal from './EditTransactionModal';
+import type { Account, Transaction } from '../types';
+
+// One stable context object, mutated between tests: the modal re-seeds its
+// form from `accounts`/`categories` identity, so a fresh object per render
+// would loop it forever.
+const mocks = vi.hoisted(() => ({
+  navigate: vi.fn(),
+  search: { value: '' },
+  app: {
+    accounts: [] as Account[],
+    transactions: [] as Transaction[],
+    categories: [
+      { id: 'type-expense', name: 'Expenses', type: 'expense', level: 'type' },
+      { id: 'sub-bills', name: 'Bills', type: 'expense', level: 'sub', parentId: 'type-expense' },
+      { id: 'det-tax', name: 'Council Tax', type: 'expense', level: 'detail', parentId: 'sub-bills' },
+    ],
+    updateTransaction: vi.fn(async () => {}),
+    deleteTransaction: vi.fn(),
+    getTransactionSplits: vi.fn(async () => []),
+    setTransactionSplits: vi.fn(async () => ({ isSplit: false, splitCount: 0, amount: 0 })),
+    linkTransferPair: vi.fn(async () => ({ a: {}, b: {} })),
+    createTransferCounterpart: vi.fn(async () => ({ source: {}, counterpart: {} })),
+  },
+}));
+
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual<typeof import('react-router-dom')>('react-router-dom');
+  return {
+    ...actual,
+    useNavigate: () => mocks.navigate,
+    useLocation: () => ({
+      pathname: '/transactions',
+      search: mocks.search.value,
+      hash: '',
+      state: null,
+      key: 'test',
+    }),
+  };
+});
+
+vi.mock('../contexts/AppContextSupabase', () => ({ useApp: () => mocks.app }));
+
+vi.mock('../contexts/ToastContext', () => ({
+  useToast: () => ({
+    showToast: vi.fn(),
+    showSuccess: vi.fn(),
+    showError: vi.fn(),
+    showWarning: vi.fn(),
+    showInfo: vi.fn(),
+    dismissToast: vi.fn(),
+  }),
+}));
+
+vi.mock('../hooks/useTransactionNotifications', () => ({
+  useTransactionNotifications: () => ({ addTransaction: vi.fn(async () => {}) }),
+}));
+
+vi.mock('../hooks/usePayeeMemory', () => ({
+  usePayeeMemory: () => ({ propagateCategory: vi.fn(async () => {}) }),
+}));
+
+vi.mock('./common/Modal', () => ({
+  Modal: ({ isOpen, children, title }: { isOpen: boolean; children: ReactNode; title: string }) =>
+    isOpen ? <div role="dialog" aria-label={title}>{children}</div> : null,
+  ModalBody: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  ModalFooter: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+}));
+
+vi.mock('./CategorySelector', () => ({ default: () => <div data-testid="category-selector" /> }));
+vi.mock('./TagSelector', () => ({ default: () => <div data-testid="tag-selector" /> }));
+vi.mock('./MarkdownEditor', () => ({ default: () => <div data-testid="markdown-editor" /> }));
+vi.mock('./DocumentManager', () => ({ default: () => <div data-testid="document-manager" /> }));
+vi.mock('./CategoryCreationModal', () => ({ default: () => null }));
+
+const account = (id: string, name: string): Account => ({
+  id,
+  name,
+  type: 'current',
+  balance: 1000,
+  currency: 'GBP',
+  lastUpdated: new Date('2026-06-01'),
+  isActive: true,
+});
+
+// The date from the owner's report: 6 July 2017, which a US-locale native
+// input printed as 07/06/2017.
+const SHOP: Transaction = {
+  id: 'txn-shop',
+  date: new Date('2017-07-06T00:00:00.000Z'),
+  description: 'Groceries',
+  amount: -42.5,
+  type: 'expense',
+  category: 'det-tax',
+  accountId: 'acc-a',
+  cleared: false,
+};
+
+const seeInAccount = (): HTMLElement | null =>
+  screen.queryByRole('button', { name: /see this transaction in/i });
+
+const renderModal = (
+  transaction: Transaction | null,
+  props: { onClose?: ReturnType<typeof vi.fn>; hideJumpToAccountId?: string } = {}
+): { onClose: ReturnType<typeof vi.fn> } => {
+  const onClose = props.onClose ?? vi.fn();
+  render(
+    <EditTransactionModal
+      isOpen
+      onClose={onClose}
+      transaction={transaction}
+      {...(props.hideJumpToAccountId ? { hideJumpToAccountId: props.hideJumpToAccountId } : {})}
+    />
+  );
+  return { onClose };
+};
+
+describe('EditTransactionModal — see this transaction in its account', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.search.value = '';
+    mocks.app.accounts = [account('acc-a', 'Current Account'), account('acc-b', 'Savings')];
+    mocks.app.transactions = [SHOP];
+  });
+
+  it('names the account and deep-links the row into its register', () => {
+    const { onClose } = renderModal(SHOP);
+
+    const link = seeInAccount();
+    expect(link).toHaveTextContent('See this transaction in Current Account');
+
+    fireEvent.click(link as HTMLElement);
+
+    // The editor gets out of the way first; the register then selects,
+    // centres and docks the row.
+    expect(onClose).toHaveBeenCalledTimes(1);
+    expect(mocks.navigate).toHaveBeenCalledWith('/accounts/acc-a?txn=txn-shop');
+  });
+
+  it('preserves demo mode in the deep link', () => {
+    mocks.search.value = '?demo=true';
+    renderModal(SHOP);
+
+    fireEvent.click(seeInAccount() as HTMLElement);
+    expect(mocks.navigate).toHaveBeenCalledWith('/accounts/acc-a?txn=txn-shop&demo=true');
+  });
+
+  it('falls back to a generic label when the account is closed, and still goes', () => {
+    // Closed accounts are absent from the context list, so there is no name to
+    // print. The register meets a closed account with its re-open offer, so the
+    // jump is still taken rather than disabled.
+    mocks.app.accounts = [account('acc-b', 'Savings')];
+    renderModal(SHOP);
+
+    expect(seeInAccount()).toHaveTextContent('See this transaction in its account');
+
+    fireEvent.click(seeInAccount() as HTMLElement);
+    expect(mocks.navigate).toHaveBeenCalledWith('/accounts/acc-a?txn=txn-shop');
+  });
+
+  it('is absent for a new transaction — there is nothing to jump to', () => {
+    renderModal(null);
+
+    expect(seeInAccount()).toBeNull();
+  });
+
+  it("is absent when the host IS that account's register", () => {
+    renderModal(SHOP, { hideJumpToAccountId: 'acc-a' });
+
+    expect(seeInAccount()).toBeNull();
+  });
+
+  it('still offers the jump when the host register is a DIFFERENT account', () => {
+    renderModal(SHOP, { hideJumpToAccountId: 'acc-b' });
+
+    expect(seeInAccount()).toHaveTextContent('See this transaction in Current Account');
+  });
+
+  it('shows the row date in UK order, driven by the real form state', () => {
+    renderModal(SHOP);
+
+    // 6 July 2017 — the native input this replaced showed 07/06/2017.
+    expect(screen.getByLabelText('Transaction date')).toHaveValue('06/07/2017');
+  });
+});

--- a/src/components/EditTransactionModal.splitLeg.test.tsx
+++ b/src/components/EditTransactionModal.splitLeg.test.tsx
@@ -1,0 +1,309 @@
+/**
+ * EditTransactionModal — a split LINE that is itself a transfer.
+ *
+ * The Microsoft Money model, and Steve's case: one £35,000 payment arrives,
+ * £30,000 of it settles a loan (money moving between his own accounts) and
+ * £5,000 is interest (income). That is one transaction with two lines, one of
+ * which is a transfer — and until now the split-line picker offered only
+ * income/expense categories, so it could not be said at all.
+ *
+ * The other half of the story is editing a split that ALREADY contains a leg:
+ * re-filing the line NEXT TO one strands nothing and must work, while the leg
+ * itself stays exactly as the transaction on its other side expects it.
+ *
+ * The real CategorySelector renders here — the point of these tests is what
+ * the picker offers and what reaches the writer.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import EditTransactionModal from './EditTransactionModal';
+import type { Account, Category, Transaction, TransactionSplit } from '../types';
+
+const CURRENT = '11111111-1111-4111-8111-111111111111';
+const SAVINGS = '22222222-2222-4222-8222-222222222222';
+const TXN = '33333333-3333-4333-8333-333333333333';
+
+const categories: Category[] = [
+  { id: 'type-expense', name: 'Expenses', type: 'expense', level: 'type' },
+  { id: 'sub-bills', name: 'Bills', type: 'expense', level: 'sub', parentId: 'type-expense' },
+  { id: 'det-tax', name: 'Council Tax', type: 'expense', level: 'detail', parentId: 'sub-bills' },
+  { id: 'type-income', name: 'Income', type: 'income', level: 'type' },
+  { id: 'sub-earnings', name: 'Earnings', type: 'income', level: 'sub', parentId: 'type-income' },
+  { id: 'det-interest', name: 'Interest', type: 'income', level: 'detail', parentId: 'sub-earnings' },
+  // Where the MS Money importer parks a line it could not classify — the
+  // filing the owner is trying to correct.
+  {
+    id: 'unassigned', name: 'Unassigned (MS Money import)', type: 'both', level: 'detail',
+    parentId: 'sub-bills', isUnassignedBucket: true,
+  },
+  // Account-managed To/From categories: detail rows under the Transfer root.
+  { id: 'type-transfer', name: 'Transfer', type: 'both', level: 'type' },
+  {
+    id: 'tofrom-savings', name: 'To/From Savings', type: 'both', level: 'detail',
+    parentId: 'type-transfer', isTransferCategory: true, accountId: SAVINGS,
+  },
+  {
+    id: 'tofrom-current', name: 'To/From Current Account', type: 'both', level: 'detail',
+    parentId: 'type-transfer', isTransferCategory: true, accountId: CURRENT,
+  },
+];
+
+const account = (id: string, name: string): Account => ({
+  id,
+  name,
+  type: 'current',
+  balance: 1000,
+  currency: 'GBP',
+  lastUpdated: new Date('2026-06-01'),
+  isActive: true,
+});
+
+const EXPENSE: Transaction = {
+  id: TXN,
+  date: new Date('2026-06-10'),
+  description: 'Monthly outgoings',
+  amount: -400,
+  type: 'expense',
+  category: 'det-tax',
+  accountId: CURRENT,
+  cleared: false,
+};
+
+/** The same row, already split, with its second line half of a transfer. */
+const SPLIT_WITH_LEG: Transaction = { ...EXPENSE, category: '', isSplit: true };
+
+const STORED_LINES: TransactionSplit[] = [
+  { id: 'unfiled', transactionId: TXN, category: 'unassigned', amount: -300, sortOrder: 1 },
+  {
+    id: 'leg-line', transactionId: TXN, category: 'tofrom-savings', amount: -100, sortOrder: 2,
+    transferAccountId: SAVINGS, linkedTransferId: 'counterpart',
+  },
+];
+
+const mocks = vi.hoisted(() => ({
+  navigate: vi.fn(),
+  app: {
+    accounts: [] as Account[],
+    transactions: [] as Transaction[],
+    categories: [] as Category[],
+    updateTransaction: vi.fn(async () => {}),
+    deleteTransaction: vi.fn(),
+    addCategory: vi.fn(),
+    getSubCategories: (_parentId?: string): Category[] => [],
+    getDetailCategories: (_parentId?: string): Category[] => [],
+    getTransactionSplits: vi.fn(async (): Promise<TransactionSplit[]> => []),
+    setTransactionSplits: vi.fn(async () => ({
+      isSplit: true, splitCount: 2, amount: -400, counterparts: [],
+    })),
+    linkTransferPair: vi.fn(),
+    createTransferCounterpart: vi.fn(),
+  },
+}));
+
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual<typeof import('react-router-dom')>('react-router-dom');
+  return {
+    ...actual,
+    useNavigate: () => mocks.navigate,
+    useLocation: () => ({ pathname: '/accounts/x', search: '', hash: '', state: null, key: 'test' }),
+  };
+});
+
+vi.mock('../contexts/AppContextSupabase', () => ({ useApp: () => mocks.app }));
+
+vi.mock('../contexts/ToastContext', () => ({
+  useToast: () => ({
+    showToast: vi.fn(), showSuccess: vi.fn(), showError: vi.fn(),
+    showWarning: vi.fn(), showInfo: vi.fn(), dismissToast: vi.fn(),
+  }),
+}));
+
+vi.mock('../hooks/useTransactionNotifications', () => ({
+  useTransactionNotifications: () => ({ addTransaction: vi.fn(async () => {}) }),
+}));
+
+vi.mock('../hooks/usePayeeMemory', () => ({
+  usePayeeMemory: () => ({ propagateCategory: vi.fn(async () => {}) }),
+}));
+
+vi.mock('./common/Modal', () => ({
+  Modal: ({ isOpen, children, title }: { isOpen: boolean; children: ReactNode; title: string }) =>
+    isOpen ? <div role="dialog" aria-label={title}>{children}</div> : null,
+  ModalBody: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  ModalFooter: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+}));
+
+vi.mock('./TagSelector', () => ({ default: () => <div data-testid="tag-selector" /> }));
+vi.mock('./MarkdownEditor', () => ({ default: () => <div data-testid="markdown-editor" /> }));
+vi.mock('./DocumentManager', () => ({ default: () => <div data-testid="document-manager" /> }));
+vi.mock('./CategoryCreationModal', () => ({ default: () => null }));
+
+const PICKER_PLACEHOLDER = 'Search or select category…';
+
+const splitToggle = (): HTMLElement =>
+  screen.getByRole('checkbox', { name: /split across multiple categories/i });
+
+const renderModal = (transaction: Transaction): void => {
+  render(<EditTransactionModal isOpen onClose={vi.fn()} transaction={transaction} />);
+};
+
+/** Open the nth split-line picker (in line order) and choose a category. */
+const chooseCategory = (label: string, pickerIndex: number): void => {
+  fireEvent.click(screen.getAllByRole('combobox', { name: 'Category' })[pickerIndex]);
+  fireEvent.click(screen.getByText(label));
+};
+
+describe('EditTransactionModal — split lines that are transfers', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.app.accounts = [account(CURRENT, 'Current Account'), account(SAVINGS, 'Savings')];
+    mocks.app.transactions = [EXPENSE];
+    mocks.app.categories = categories;
+    mocks.app.getSubCategories = (parentId?: string) =>
+      categories.filter(c => c.parentId === parentId);
+    mocks.app.getDetailCategories = (parentId?: string) =>
+      categories.filter(c => c.parentId === parentId && c.level === 'detail');
+    mocks.app.getTransactionSplits.mockResolvedValue([]);
+  });
+
+  describe('creating one', () => {
+    it('offers the To/From account categories on a split line, under their own heading', () => {
+      renderModal(EXPENSE);
+      fireEvent.click(splitToggle());
+
+      // The second (empty) line's picker.
+      fireEvent.click(screen.getAllByText(PICKER_PLACEHOLDER)[0]);
+
+      expect(screen.getByText('Transfer to another account')).toBeInTheDocument();
+      expect(screen.getByText('To/From Savings')).toBeInTheDocument();
+      // Never the account this transaction is already in.
+      expect(screen.queryByText('To/From Current Account')).not.toBeInTheDocument();
+      // And the ordinary categories are still all there.
+      expect(screen.getByText('Council Tax')).toBeInTheDocument();
+      expect(screen.getByText('Interest')).toBeInTheDocument();
+    });
+
+    it('says what the line now means, before it is saved', () => {
+      renderModal(EXPENSE);
+      fireEvent.click(splitToggle());
+      chooseCategory('To/From Savings', 1);
+
+      expect(
+        screen.getByText(/Transfer with Savings — saving creates the matching transaction there/)
+      ).toBeInTheDocument();
+    });
+
+    it('asks the writer for the leg, with the account on the other side', async () => {
+      renderModal(EXPENSE);
+      fireEvent.click(splitToggle());
+
+      fireEvent.change(screen.getByLabelText('Split line 1 amount'), { target: { value: '300' } });
+      chooseCategory('To/From Savings', 1);
+      fireEvent.change(screen.getByLabelText('Split line 2 amount'), { target: { value: '100' } });
+
+      // The remainder reads zero — a transfer line counts toward the parent
+      // total exactly like any other line.
+      expect(screen.getByText('Fully allocated ✓')).toBeInTheDocument();
+
+      fireEvent.click(screen.getByRole('button', { name: 'Save Changes' }));
+
+      await waitFor(() => expect(mocks.app.setTransactionSplits).toHaveBeenCalledTimes(1));
+      expect(mocks.app.setTransactionSplits).toHaveBeenCalledWith(
+        TXN,
+        [
+          { category: 'det-tax', amount: -300 },
+          { category: 'tofrom-savings', amount: -100, transferAccountId: SAVINGS },
+        ],
+        -400
+      );
+    });
+
+    it('drops the target again when the line is re-filed as an ordinary category', () => {
+      renderModal(EXPENSE);
+      fireEvent.click(splitToggle());
+      chooseCategory('To/From Savings', 1);
+      expect(screen.getByText(/Transfer with Savings/)).toBeInTheDocument();
+
+      // The picker now shows the chosen name, so reopen it by its label.
+      fireEvent.click(screen.getAllByRole('combobox', { name: 'Category' })[1]);
+      fireEvent.click(screen.getByText('Interest'));
+
+      expect(screen.queryByText(/Transfer with Savings/)).not.toBeInTheDocument();
+    });
+  });
+
+  describe('editing a split that already contains one', () => {
+    beforeEach(() => {
+      mocks.app.transactions = [SPLIT_WITH_LEG];
+      mocks.app.getTransactionSplits.mockResolvedValue(STORED_LINES);
+    });
+
+    it('shows the leg as a transfer, not as an editable category', async () => {
+      renderModal(SPLIT_WITH_LEG);
+
+      expect(await screen.findByText('Transfer — Savings')).toBeInTheDocument();
+      expect(
+        screen.getByText(/its other side is already recorded there, so this line can't change/)
+      ).toBeInTheDocument();
+      // One picker for the ordinary line; none for the leg.
+      expect(screen.getAllByRole('combobox', { name: 'Category' })).toHaveLength(1);
+      // Its amount is shown, not offered for editing.
+      expect(screen.getByLabelText('Split line 2 amount').tagName).not.toBe('INPUT');
+    });
+
+    it('will not let the split be un-split — that deletes every line', async () => {
+      renderModal(SPLIT_WITH_LEG);
+      await screen.findByText('Transfer — Savings');
+
+      expect(splitToggle()).toBeDisabled();
+      expect(splitToggle()).toHaveAttribute(
+        'title',
+        'One of these lines is a transfer — delete that transfer first to un-split this transaction'
+      );
+    });
+
+    it('is honest about a leg whose other side has been deleted', async () => {
+      // transfer_account_id survives, linked_transfer_id does not (ON DELETE
+      // SET NULL). The row that matches it may still be sitting in that
+      // account unmatched, so saving must not invent a second one — and the
+      // line must not promise that it will.
+      mocks.app.getTransactionSplits.mockResolvedValue([
+        STORED_LINES[0],
+        { ...STORED_LINES[1], linkedTransferId: undefined },
+      ]);
+      renderModal(SPLIT_WITH_LEG);
+
+      expect(
+        await screen.findByText(/the matching transaction there is missing. Saving leaves this line as it is/)
+      ).toBeInTheDocument();
+      // It is not locked — nothing points at it any more.
+      expect(screen.getAllByRole('combobox', { name: 'Category' })).toHaveLength(2);
+      expect(splitToggle()).toBeEnabled();
+    });
+
+    it("files the line NEXT to the leg, and hands the leg back exactly as stored", async () => {
+      // The owner's case: 78 of his splits contain a leg and 33 still have a
+      // line needing a category. Categorising one strands nothing.
+      renderModal(SPLIT_WITH_LEG);
+      await screen.findByText('Transfer — Savings');
+
+      chooseCategory('Council Tax', 0);
+      fireEvent.click(screen.getByRole('button', { name: 'Save Changes' }));
+
+      await waitFor(() => expect(mocks.app.setTransactionSplits).toHaveBeenCalledTimes(1));
+      expect(mocks.app.setTransactionSplits).toHaveBeenCalledWith(
+        TXN,
+        [
+          { id: 'unfiled', category: 'det-tax', amount: -300 },
+          {
+            id: 'leg-line', category: 'tofrom-savings', amount: -100,
+            transferAccountId: SAVINGS,
+          },
+        ],
+        -400
+      );
+    });
+  });
+});

--- a/src/components/EditTransactionModal.test.tsx
+++ b/src/components/EditTransactionModal.test.tsx
@@ -74,6 +74,10 @@ vi.mock('./common/Modal', () => ({
   ModalFooter: ({ children }: any) => <div data-testid="modal-footer">{children}</div>,
 }));
 
+// Hoisted so the date-field tests can read what the form was actually told to
+// store — a fresh vi.fn() per render would be unassertable.
+const { mockUpdateField } = vi.hoisted(() => ({ mockUpdateField: vi.fn() }));
+
 vi.mock('../hooks/useModalForm', () => ({
   useModalForm: () => ({
     formData: {
@@ -89,7 +93,7 @@ vi.mock('../hooks/useModalForm', () => ({
       cleared: false,
       reconciledWith: ''
     },
-    updateField: vi.fn(),
+    updateField: mockUpdateField,
     handleSubmit: vi.fn(),
     setFormData: vi.fn(),
   }),
@@ -106,9 +110,13 @@ vi.mock('../services/validationService', () => ({
   },
 }));
 
-// Mock all icons with simple divs
+// Mock all icons with simple divs. The shared DatePicker draws from the same
+// module, so its glyphs (calendar + the calendar's own chevrons) belong here too.
 vi.mock('../components/icons', () => ({
   CalendarIcon: () => <div data-testid="calendar-icon">📅</div>,
+  ChevronLeftIcon: () => <div data-testid="chevron-left-icon">‹</div>,
+  ChevronRightIcon: () => <div data-testid="chevron-right-icon">›</div>,
+  ArrowUpRightIcon: () => <div data-testid="arrow-up-right-icon">↗️</div>,
   TagIcon: () => <div data-testid="tag-icon">🏷️</div>,
   FileTextIcon: () => <div data-testid="file-text-icon">📄</div>,
   CheckIcon2: () => <div data-testid="check-icon-2">✓</div>,
@@ -306,7 +314,8 @@ describe('EditTransactionModal', () => {
     it('displays form field icons', () => {
       renderModal(true, null);
       
-      expect(screen.getByTestId('calendar-icon')).toBeInTheDocument();
+      // Two: the Date field's label, and the date picker's own trailing glyph.
+      expect(screen.getAllByTestId('calendar-icon')).toHaveLength(2);
       expect(screen.getByTestId('wallet-icon')).toBeInTheDocument();
       expect(screen.getAllByTestId('file-text-icon')).toHaveLength(2); // Description and Notes
       expect(screen.getByTestId('arrow-right-left-icon')).toBeInTheDocument();
@@ -342,6 +351,35 @@ describe('EditTransactionModal', () => {
       expect(screen.getByRole('button', { name: /delete/i })).toBeInTheDocument();
       expect(screen.getByRole('button', { name: /cancel/i })).toBeInTheDocument();
       expect(screen.getByRole('button', { name: /save changes/i })).toBeInTheDocument();
+    });
+  });
+
+  describe('date field', () => {
+    // The reported bug: the modal used a native <input type="date">, which
+    // renders in the BROWSER's locale. A register row reading 07/02/2022 opened
+    // here as 02/07/2022 — 7 February against 2 July, on money.
+    it('reads the stored ISO date back in UK order', () => {
+      renderModal(true, createMockTransaction());
+
+      const field = screen.getByLabelText('Transaction date');
+      // 2023-01-15 — day first, so 15 cannot be mistaken for a month.
+      expect(field).toHaveValue('15/01/2023');
+      expect(field).toHaveAttribute('placeholder', 'dd/mm/yyyy');
+      // Not a native control: those are the ones that follow the browser.
+      expect(field).toHaveAttribute('type', 'text');
+      expect(field).toBeRequired();
+    });
+
+    it('stores a typed UK date as ISO, unchanged', () => {
+      renderModal(true, createMockTransaction());
+
+      fireEvent.change(screen.getByLabelText('Transaction date'), {
+        target: { value: '06/07/2017' },
+      });
+
+      // 6 July 2017 — the value handed to the form is the ISO the DB holds,
+      // so the caller's state shape is untouched by the presentation change.
+      expect(mockUpdateField).toHaveBeenCalledWith('date', '2017-07-06');
     });
   });
 

--- a/src/components/EditTransactionModal.tsx
+++ b/src/components/EditTransactionModal.tsx
@@ -4,7 +4,7 @@ import { useNavigate, useLocation } from 'react-router-dom';
 import { useApp } from '../contexts/AppContextSupabase';
 import { useTransactionNotifications } from '../hooks/useTransactionNotifications';
 import { usePayeeMemory } from '../hooks/usePayeeMemory';
-import { CalendarIcon, TagIcon, FileTextIcon, CheckIcon2, LinkIcon, PlusIcon, HashIcon, WalletIcon, ArrowRightLeftIcon, BanknoteIcon, PaperclipIcon, XIcon } from '../components/icons';
+import { CalendarIcon, TagIcon, FileTextIcon, CheckIcon2, LinkIcon, PlusIcon, HashIcon, WalletIcon, ArrowRightLeftIcon, ArrowUpRightIcon, BanknoteIcon, PaperclipIcon, XIcon } from '../components/icons';
 import type { Transaction } from '../types';
 import {
   splitRemainder,
@@ -17,7 +17,9 @@ import CategoryCreationModal from './CategoryCreationModal';
 import TransferMatchDialog from './TransferMatchDialog';
 import { findTransferCandidates, transferCategoryFor, type TransferCandidate } from '../utils/transferMatch';
 import { resolveTransferOtherSide } from '../utils/transferOtherSide';
+import { buildTransactionRegisterPath } from '../utils/transactionDeepLink';
 import GroupedAccountSelect from './common/GroupedAccountSelect';
+import DatePicker from './common/DatePicker';
 import { useToast } from '../contexts/ToastContext';
 import CategorySelector from './CategorySelector';
 import TagSelector from './TagSelector';
@@ -51,6 +53,13 @@ interface EditTransactionModalProps {
    * saves and swaps in the PREVIOUS transaction from the caller's list.
    */
   onSaveAndPrevious?: () => void;
+  /**
+   * The account whose own register is hosting this modal. "See this
+   * transaction in <account>" is suppressed for it — offering a jump to where
+   * the user already is would be noise. Passed by the host rather than
+   * guessed from the URL, which cannot tell a register from a modal over it.
+   */
+  hideJumpToAccountId?: string;
 }
 
 interface FormData {
@@ -67,7 +76,7 @@ interface FormData {
   reconciledWith: string;
 }
 
-export default function EditTransactionModal({ isOpen, onClose, transaction, defaultAccountId, onSaveAndNext, onSaveAndPrevious }: EditTransactionModalProps): React.JSX.Element {
+export default function EditTransactionModal({ isOpen, onClose, transaction, defaultAccountId, onSaveAndNext, onSaveAndPrevious, hideJumpToAccountId }: EditTransactionModalProps): React.JSX.Element {
   const { accounts, categories, transactions, updateTransaction, deleteTransaction, getTransactionSplits, setTransactionSplits, linkTransferPair, createTransferCounterpart } = useApp();
   const { showSuccess, showError } = useToast();
   const { addTransaction } = useTransactionNotifications();
@@ -204,6 +213,8 @@ export default function EditTransactionModal({ isOpen, onClose, transaction, def
             const splitError = validateSplitDrafts(data.amount, splitLines, {
               parentType: resolvedType as 'income' | 'expense',
               directionFor: splitDirectionFor,
+              parentAccountId: validatedData.accountId,
+              isTransferCategory,
             });
             if (splitError) {
               throw new Error(splitError);
@@ -285,10 +296,12 @@ export default function EditTransactionModal({ isOpen, onClose, transaction, def
           if (transaction) {
             if (splitting) {
               // A split parent's amount/category/type are guarded by a DB
-              // trigger — only set_transaction_splits may change them. The
-              // ordinary update carries everything else; the RPC then swaps
-              // the split lines in, re-validates the sum against the entered
-              // amount server-side, and syncs amount + account balance.
+              // trigger — only the split RPCs may change them. The ordinary
+              // update carries everything else; the RPC then writes the split
+              // lines (matching them to the stored ones by id, so a line that
+              // is half of a transfer survives an edit to its neighbours),
+              // re-validates the sum against the entered amount server-side,
+              // and syncs amount + account balance.
               await updateTransaction(transaction.id, {
                 date: transactionData.date,
                 description: transactionData.description,
@@ -483,6 +496,21 @@ export default function EditTransactionModal({ isOpen, onClose, transaction, def
     return cat.type;
   }, [categories]);
 
+  // Picking a "To/From <account>" category on a split line IS the sentence
+  // "this part of the money moved to that account" — the same rule the
+  // whole-transaction conversion follows. The account it names becomes the
+  // line's transfer target; any other category clears it.
+  const splitTransferTargetFor = useCallback((categoryId: string): string | undefined => {
+    const cat = categories.find(c => c.id === categoryId);
+    return cat?.isTransferCategory === true ? cat.accountId : undefined;
+  }, [categories]);
+
+  const isTransferCategory = useCallback(
+    (categoryId: string): boolean =>
+      categories.find(c => c.id === categoryId)?.isTransferCategory === true,
+    [categories]
+  );
+
   // Load an already-split transaction's lines into the editor (stored signed
   // amounts convert back to the entered domain). Non-split rows reset the
   // split state so batch mode (Save & Next) never leaks lines between rows.
@@ -497,10 +525,18 @@ export default function EditTransactionModal({ isOpen, onClose, transaction, def
           const parentDirection = transaction.type === 'income' ? 'income' : 'expense';
           // Each line converts back using ITS OWN direction (its category's
           // tree), so a mixed split round-trips to positive magnitudes.
+          // Identity and leg fields come from the stored row and travel back
+          // out untouched: the writer matches lines by id, and a line already
+          // linked to a counterpart may not change.
           setSplitLines(splits.map(s => ({
+            id: s.id,
             category: s.category,
             amount: displaySplitAmount(s.amount, splitDirectionFor(s.category) ?? parentDirection),
             ...(s.memo ? { memo: s.memo } : {}),
+            ...(s.transferAccountId
+              ? { transferAccountId: s.transferAccountId, savedTransferAccountId: s.transferAccountId }
+              : {}),
+            ...(s.linkedTransferId ? { linkedTransferId: s.linkedTransferId } : {}),
           })));
         })
         .catch(error => {
@@ -539,6 +575,21 @@ export default function EditTransactionModal({ isOpen, onClose, transaction, def
     setSplitLines(prev => prev.map((line, i) => (i === index ? { ...line, ...patch } : line)));
   };
 
+  /**
+   * Re-file one line. The transfer target is derived from the category rather
+   * than stored twice: choosing "To/From Savings" makes the line a leg to
+   * Savings, choosing anything else stops it being one. (A line already linked
+   * to a counterpart never reaches here — the editor renders it read-only.)
+   */
+  const changeSplitLineCategory = (index: number, categoryId: string): void => {
+    const target = splitTransferTargetFor(categoryId);
+    setSplitLines(prev => prev.map((line, i) => {
+      if (i !== index) return line;
+      const { transferAccountId: _replaced, ...rest } = line;
+      return { ...rest, category: categoryId, ...(target ? { transferAccountId: target } : {}) };
+    }));
+  };
+
   const addSplitLine = (): void => {
     setSplitLines(prev => [...prev, { category: '', amount: '' }]);
   };
@@ -550,9 +601,16 @@ export default function EditTransactionModal({ isOpen, onClose, transaction, def
   // Save is blocked while the split doesn't balance; the remainder line
   // doubles as the explanation.
   const splitActive = isSplitMode && !!transaction && formData.type !== 'transfer';
+  // One of these lines is already half of a transfer with another account.
+  // That line is read-only and the split cannot be un-split (un-splitting
+  // deletes every line, stranding the row on the other side) — but every
+  // OTHER line stays editable, which is what the writer's line matching buys.
+  const splitHasLinkedLeg = splitLines.some(line => Boolean(line.linkedTransferId));
   const splitDirectionOpts = {
     parentType: (formData.type === 'income' ? 'income' : 'expense') as 'income' | 'expense',
     directionFor: splitDirectionFor,
+    parentAccountId: formData.accountId,
+    isTransferCategory,
   };
   const splitValidationMessage = splitActive
     ? validateSplitDrafts(formData.amount, splitLines, splitDirectionOpts)
@@ -585,21 +643,40 @@ export default function EditTransactionModal({ isOpen, onClose, transaction, def
     [transaction, transactions, accounts]
   );
 
-  // The jump is taken even when that account is CLOSED: the register itself
-  // owns the closed-account offer now (name, explanation, "Re-open and view"),
-  // so the way through arrives where the user asked for it instead of being
-  // described to them. `isOpen` still shapes the label — a closed account's
-  // name isn't in the context list to print.
+  // Every jump out of this modal works the same way: close the editor (so it
+  // isn't left hanging over the register it just opened), then deep-link the
+  // row. Taken even when the account is CLOSED — the register itself owns the
+  // closed-account offer (name, explanation, "Re-open and view"), so the way
+  // through arrives where the user asked for it instead of being described.
+  const jumpToRegister = useCallback((accountId: string, transactionId: string): void => {
+    onClose();
+    navigate(buildTransactionRegisterPath(accountId, transactionId, location.search));
+  }, [navigate, location.search, onClose]);
+
+  // `isOpen` shapes the transfer label only — a closed account's name isn't in
+  // the context list to print.
   const handleJumpToOtherSide = (): void => {
     if (!otherSide) return;
-    const params = new URLSearchParams();
-    params.set('txn', otherSide.transactionId);
-    if (new URLSearchParams(location.search).get('demo') === 'true') {
-      params.set('demo', 'true');
-    }
-    onClose();
-    navigate(`/accounts/${otherSide.accountId}?${params.toString()}`);
+    jumpToRegister(otherSide.accountId, otherSide.transactionId);
   };
+
+  // "See this transaction in <account>": the same mechanic pointed at the
+  // row's OWN account, for the context the edit screen can't give — the
+  // surrounding rows and the running balance. The SAVED account is the target,
+  // not the form's current pick, because that is where the row is right now.
+  const ownAccountJump = useMemo(() => {
+    if (!transaction || transaction.accountId === hideJumpToAccountId) return null;
+    const account = accounts.find(a => a.id === transaction.accountId);
+    return {
+      accountId: transaction.accountId,
+      transactionId: transaction.id,
+      // A closed account is absent from the loaded list, so the label goes
+      // generic rather than blank; the register handles the rest on arrival.
+      label: account
+        ? `See this transaction in ${account.name}`
+        : 'See this transaction in its account',
+    };
+  }, [transaction, accounts, hideJumpToAccountId]);
 
   const handleDelete = () => {
     if (!transaction) return;
@@ -620,15 +697,17 @@ export default function EditTransactionModal({ isOpen, onClose, transaction, def
                 <CalendarIcon size={16} />
                 Date
               </label>
-              {/* appearance-none + min-w-0: iOS gives a date input an
-                  intrinsic width that ignores w-full, so this box ran past
-                  the modal edge all its siblings stopped at. */}
-              <input
-                type="date"
+              {/* The shared dd/mm/yyyy picker, NOT a native date input: a
+                  native renders in the BROWSER's locale, so a row the
+                  register showed as 07/02/2022 opened here as 02/07/2022.
+                  min-w-0 keeps the box inside the grid column its siblings
+                  stop at. */}
+              <DatePicker
                 value={formData.date}
-                onChange={(e) => updateField('date', e.target.value)}
-                className="appearance-none min-w-0 w-full px-3 py-3 sm:py-2 h-12 sm:h-[42px] text-base sm:text-sm bg-white dark:bg-gray-700 border-2 border-gray-300 dark:border-gray-500 rounded-lg focus:outline-none focus:ring-2 focus:ring-primary dark:focus:ring-blue-400 focus:border-transparent dark:text-white"
+                onChange={(val) => updateField('date', val)}
+                className="min-w-0 h-12 sm:h-[42px] text-base sm:text-sm bg-white dark:bg-gray-700 border-2 border-gray-300 dark:border-gray-500 rounded-lg focus:outline-none focus:ring-2 focus:ring-primary dark:focus:ring-blue-400 focus:border-transparent dark:text-white"
                 required
+                aria-label="Transaction date"
               />
             </div>
 
@@ -798,10 +877,19 @@ export default function EditTransactionModal({ isOpen, onClose, transaction, def
                   is added single-category first, then split; transfers encode
                   their target in the category and cannot split). */}
               {transaction && formData.type !== 'transfer' && (
-                <label className="mb-2 flex items-center gap-2 text-sm text-gray-700 dark:text-gray-300 cursor-pointer">
+                <label className={`mb-2 flex items-center gap-2 text-sm text-gray-700 dark:text-gray-300 ${
+                  splitHasLinkedLeg ? 'cursor-not-allowed opacity-60' : 'cursor-pointer'
+                }`}>
                   <input
                     type="checkbox"
                     checked={isSplitMode}
+                    // Un-splitting deletes every line, and one of these lines is
+                    // half of a transfer — the row on the other side would be
+                    // left pointing at nothing.
+                    disabled={splitHasLinkedLeg}
+                    title={splitHasLinkedLeg
+                      ? 'One of these lines is a transfer — delete that transfer first to un-split this transaction'
+                      : undefined}
                     onChange={(e) => handleSplitToggle(e.target.checked)}
                   />
                   <span>Split across multiple categories</span>
@@ -857,47 +945,113 @@ export default function EditTransactionModal({ isOpen, onClose, transaction, def
                     <p className="text-sm text-gray-500 dark:text-gray-400 py-2">Loading splits…</p>
                   ) : (
                     <>
-                      {splitLines.map((line, index) => (
-                        <div key={index} className="flex gap-2 items-center">
-                          <div className="flex-1 min-w-0">
-                            <CategorySelector
-                              selectedCategory={line.category}
-                              onCategoryChange={(id) => updateSplitLine(index, { category: id })}
-                              transactionType={formData.type}
-                              // BOTH trees, per line: a split may mix expense
-                              // and income lines (an income line counts
-                              // against an expense total), so every line
-                              // offers every category and the line's
-                              // direction follows the one chosen.
-                              includeAllTypes
-                              placeholder="Search or select category…"
-                              allowCreate={false}
-                              showHelperText={false}
-                              usePortal
-                            />
+                      {splitLines.map((line, index) => {
+                        // A line already linked to a transaction in another
+                        // account is structural: its category, amount and
+                        // target are pinned by that row, so it is SHOWN, not
+                        // edited. Every other line on the split stays free —
+                        // which is the whole point of being able to open this
+                        // at all.
+                        const lockedLeg = Boolean(line.linkedTransferId);
+                        const legAccountName = line.transferAccountId
+                          ? accounts.find(a => a.id === line.transferAccountId)?.name
+                          : undefined;
+                        return (
+                        <div key={line.id ?? `new-${index}`} className="space-y-1">
+                          <div className="flex gap-2 items-center">
+                            <div className="flex-1 min-w-0">
+                              {lockedLeg ? (
+                                <div
+                                  className="w-full px-3 py-2 h-[42px] flex items-center rounded-xl bg-gray-100 dark:bg-gray-700/60 border border-gray-300/50 dark:border-gray-600/50 text-sm text-gray-700 dark:text-gray-300 truncate"
+                                  title="This line is one half of a transfer — delete that transfer to change it"
+                                >
+                                  {legAccountName
+                                    ? `Transfer — ${legAccountName}`
+                                    : 'Transfer — the linked account'}
+                                </div>
+                              ) : (
+                                <CategorySelector
+                                  selectedCategory={line.category}
+                                  onCategoryChange={(id) => changeSplitLineCategory(index, id)}
+                                  transactionType={formData.type}
+                                  // BOTH trees, per line: a split may mix expense
+                                  // and income lines (an income line counts
+                                  // against an expense total), so every line
+                                  // offers every category and the line's
+                                  // direction follows the one chosen.
+                                  includeAllTypes
+                                  // …and the To/From account categories, which
+                                  // make THIS LINE one leg of a transfer. Only
+                                  // split lines offer them: a whole transaction
+                                  // becomes a transfer via the Type toggle.
+                                  includeTransferTargets
+                                  transferSourceAccountId={formData.accountId}
+                                  placeholder="Search or select category…"
+                                  allowCreate={false}
+                                  showHelperText={false}
+                                  usePortal
+                                />
+                              )}
+                            </div>
+                            {lockedLeg ? (
+                              <div
+                                className="w-28 shrink-0 px-3 py-2 h-[42px] flex items-center justify-end rounded-xl bg-gray-100 dark:bg-gray-700/60 border border-gray-300/50 dark:border-gray-600/50 text-gray-700 dark:text-gray-300"
+                                aria-label={`Split line ${index + 1} amount`}
+                              >
+                                {formatWithCommas(line.amount)}
+                              </div>
+                            ) : (
+                              <MoneyInput
+                                value={line.amount}
+                                onChange={(raw) => updateSplitLine(index, { amount: raw })}
+                                // A MINUS line is legitimate here (cashback inside a
+                                // shop reduces the total), so negatives stay enterable.
+                                allowNegative
+                                aria-label={`Split line ${index + 1} amount`}
+                                className="w-28 shrink-0 px-3 py-2 h-[42px] text-right bg-white dark:bg-gray-800-sm border border-gray-300/50 dark:border-gray-600/50 rounded-xl focus:outline-none focus:ring-2 focus:ring-primary focus:border-transparent text-gray-900 dark:text-white"
+                              />
+                            )}
+                            {splitLines.length > 2 && !lockedLeg && (
+                              <button
+                                type="button"
+                                onClick={() => removeSplitLine(index)}
+                                aria-label={`Remove split line ${index + 1}`}
+                                title="Remove this split line"
+                                className="shrink-0 p-2 text-gray-400 hover:text-red-600 dark:text-gray-500 dark:hover:text-red-400"
+                              >
+                                <XIcon size={18} />
+                              </button>
+                            )}
+                            {/* The removed button's width, kept, so a locked
+                                line's amount stays in the same column. */}
+                            {splitLines.length > 2 && lockedLeg && (
+                              <span className="shrink-0 w-[34px]" aria-hidden="true" />
+                            )}
                           </div>
-                          <MoneyInput
-                            value={line.amount}
-                            onChange={(raw) => updateSplitLine(index, { amount: raw })}
-                            // A MINUS line is legitimate here (cashback inside a
-                            // shop reduces the total), so negatives stay enterable.
-                            allowNegative
-                            aria-label={`Split line ${index + 1} amount`}
-                            className="w-28 shrink-0 px-3 py-2 h-[42px] text-right bg-white dark:bg-gray-800-sm border border-gray-300/50 dark:border-gray-600/50 rounded-xl focus:outline-none focus:ring-2 focus:ring-primary focus:border-transparent text-gray-900 dark:text-white"
-                          />
-                          {splitLines.length > 2 && (
-                            <button
-                              type="button"
-                              onClick={() => removeSplitLine(index)}
-                              aria-label={`Remove split line ${index + 1}`}
-                              title="Remove this split line"
-                              className="shrink-0 p-2 text-gray-400 hover:text-red-600 dark:text-gray-500 dark:hover:text-red-400"
-                            >
-                              <XIcon size={18} />
-                            </button>
+                          {/* What this line MEANS, said once: money leaving for
+                              (or arriving from) a named account, not a category
+                              — and exactly what saving will do about it. */}
+                          {line.transferAccountId && (
+                            <p className="flex items-center gap-1.5 pl-1 text-xs text-blue-700 dark:text-blue-400">
+                              <ArrowRightLeftIcon size={12} />
+                              <span>
+                                {lockedLeg
+                                  ? `Transfer with ${legAccountName ?? 'the linked account'} — its other side is already recorded there, so this line can't change. Delete that transfer to edit it.`
+                                  : line.transferAccountId === line.savedTransferAccountId
+                                    // Already a leg, but its counterpart is gone
+                                    // (deleted, or never imported). Saving must
+                                    // NOT make a new one: the row that matches it
+                                    // may be sitting in that account unmatched,
+                                    // and inventing a second would double the
+                                    // movement.
+                                    ? `Transfer with ${legAccountName ?? 'that account'} — the matching transaction there is missing. Saving leaves this line as it is; nothing new is created.`
+                                    : `Transfer with ${legAccountName ?? 'that account'} — saving creates the matching transaction there.`}
+                              </span>
+                            </p>
                           )}
                         </div>
-                      ))}
+                        );
+                      })}
                       <div className="flex justify-between items-center pt-1">
                         <button
                           type="button"
@@ -1042,6 +1196,19 @@ export default function EditTransactionModal({ isOpen, onClose, transaction, def
               <div className="mb-3 p-3 bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-lg">
                 <p className="text-sm text-red-700 dark:text-red-300">{errors.submit}</p>
               </div>
+            )}
+            {/* Low-key on purpose: a way out to context, not a competing
+                action next to Save. Any unsaved edits are abandoned, same as
+                Cancel, so it reads as leaving rather than committing. */}
+            {ownAccountJump && (
+              <button
+                type="button"
+                onClick={() => jumpToRegister(ownAccountJump.accountId, ownAccountJump.transactionId)}
+                className="mb-3 inline-flex items-center gap-1.5 text-sm font-medium text-primary hover:text-secondary"
+              >
+                <ArrowUpRightIcon size={14} />
+                {ownAccountJump.label}
+              </button>
             )}
             <div className="flex justify-between gap-3 w-full">
               {transaction && (

--- a/src/components/EnhancedExportManager.tsx
+++ b/src/components/EnhancedExportManager.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useMemo } from 'react';
 import { FileTextIcon, DownloadIcon, CalendarIcon, FileSpreadsheetIcon, FilePlusIcon, XIcon, TrendingUpIcon, DollarSignIcon, PieChartIcon, ReceiptIcon } from './icons';
+import DatePicker from './common/DatePicker';
 import { useApp } from '../contexts/AppContextSupabase';
 import { expandSplitTransactions } from '../utils/transactionSplits';
 import { format, startOfMonth, endOfMonth, startOfYear, endOfYear, subMonths } from 'date-fns';
@@ -629,19 +630,21 @@ export default function EnhancedExportManager(): React.JSX.Element {
                   ))}
                 </div>
 
+                {/* dd/mm/yyyy everywhere — a native date input renders in the
+                    browser's locale, not the app's. */}
                 {options.dateRange === 'custom' && (
                   <div className="grid grid-cols-2 gap-3 mt-3">
-                    <input
-                      type="date"
-                      value={options.startDate}
-                      onChange={(e) => setOptions(prev => ({ ...prev, startDate: e.target.value }))}
-                      className="px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-700"
+                    <DatePicker
+                      value={options.startDate ?? ''}
+                      onChange={(val) => setOptions(prev => ({ ...prev, startDate: val }))}
+                      className="border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-700"
+                      aria-label="Export start date"
                     />
-                    <input
-                      type="date"
-                      value={options.endDate}
-                      onChange={(e) => setOptions(prev => ({ ...prev, endDate: e.target.value }))}
-                      className="px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-700"
+                    <DatePicker
+                      value={options.endDate ?? ''}
+                      onChange={(val) => setOptions(prev => ({ ...prev, endDate: val }))}
+                      className="border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-700"
+                      aria-label="Export end date"
                     />
                   </div>
                 )}

--- a/src/components/ExcelExport.test.tsx
+++ b/src/components/ExcelExport.test.tsx
@@ -229,18 +229,25 @@ describe('ExcelExport', () => {
       
       const now = new Date();
       const firstOfMonth = new Date(now.getFullYear(), now.getMonth(), 1);
-      
-      expect(startDate.value).toBe(firstOfMonth.toISOString().split('T')[0]);
-      expect(endDate.value).toBe(now.toISOString().split('T')[0]);
+
+      // The shared picker displays UK dd/mm/yyyy; the state behind it stays ISO.
+      const uk = (d: Date): string =>
+        `${String(d.getDate()).padStart(2, '0')}/${String(d.getMonth() + 1).padStart(2, '0')}/${d.getFullYear()}`;
+
+      expect(startDate.value).toBe(uk(firstOfMonth));
+      expect(endDate.value).toBe(uk(now));
     });
 
     it('can change date range', () => {
       render(<ExcelExport isOpen={true} onClose={mockOnClose} />);
-      
+
       const startDate = screen.getByLabelText('Start Date');
-      fireEvent.change(startDate, { target: { value: '2024-01-01' } });
-      
-      expect((startDate as HTMLInputElement).value).toBe('2024-01-01');
+      // Typed as a UK date; blur settles the draft, so what is left on screen
+      // is the committed value rather than the raw keystrokes.
+      fireEvent.change(startDate, { target: { value: '01/03/2024' } });
+      fireEvent.blur(startDate);
+
+      expect((startDate as HTMLInputElement).value).toBe('01/03/2024');
     });
   });
 

--- a/src/components/ExcelExport.tsx
+++ b/src/components/ExcelExport.tsx
@@ -3,7 +3,9 @@ import { useApp } from '../contexts/AppContextSupabase';
 import { expandSplitTransactions } from '../utils/transactionSplits';
 import { useCurrencyDecimal } from '../hooks/useCurrencyDecimal';
 import { Modal } from './common/Modal';
-import { 
+import DatePicker from './common/DatePicker';
+import { formatDateForInput } from '../utils/dateFormatter';
+import {
   DownloadIcon,
   FileTextIcon,
   SettingsIcon,
@@ -495,38 +497,36 @@ export default function ExcelExport({ isOpen, onClose }: ExcelExportProps): Reac
               Date Range (for transactions)
             </h3>
             <div className="grid grid-cols-2 gap-4">
+              {/* dd/mm/yyyy everywhere — a native date input renders in the
+                  browser's locale, not the app's. */}
               <div>
                 <label className="block text-sm font-medium mb-1" htmlFor="excel-export-start-date">Start Date</label>
-                <input
+                <DatePicker
                   id="excel-export-start-date"
-                  type="date"
-                  value={options.dateRange.start?.toISOString().split('T')[0] || ''}
-                  onChange={(e) => setOptions({
+                  value={formatDateForInput(options.dateRange.start)}
+                  onChange={(val) => setOptions({
                     ...options,
                     dateRange: {
                       ...options.dateRange,
-                      start: e.target.value ? new Date(e.target.value) : null
+                      start: val ? new Date(val) : null
                     }
                   })}
-                  className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg
-                           bg-white dark:bg-gray-800"
+                  className="border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-800"
                 />
               </div>
               <div>
                 <label className="block text-sm font-medium mb-1" htmlFor="excel-export-end-date">End Date</label>
-                <input
+                <DatePicker
                   id="excel-export-end-date"
-                  type="date"
-                  value={options.dateRange.end?.toISOString().split('T')[0] || ''}
-                  onChange={(e) => setOptions({
+                  value={formatDateForInput(options.dateRange.end)}
+                  onChange={(val) => setOptions({
                     ...options,
                     dateRange: {
                       ...options.dateRange,
-                      end: e.target.value ? new Date(e.target.value) : null
+                      end: val ? new Date(val) : null
                     }
                   })}
-                  className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg
-                           bg-white dark:bg-gray-800"
+                  className="border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-800"
                 />
               </div>
             </div>

--- a/src/components/GoalModal.test.tsx
+++ b/src/components/GoalModal.test.tsx
@@ -58,7 +58,8 @@ const fillRequiredFields = (): void => {
   fireEvent.change(screen.getByLabelText('Goal Name'), { target: { value: 'House Deposit' } });
   fireEvent.change(screen.getByLabelText('Current Amount (£)'), { target: { value: '2500.50' } });
   fireEvent.change(screen.getByLabelText('Target Amount (£)'), { target: { value: '20000' } });
-  fireEvent.change(screen.getByLabelText('Target Date'), { target: { value: '2027-06-30' } });
+  // The shared dd/mm/yyyy picker: typed UK, held as ISO.
+  fireEvent.change(screen.getByLabelText('Target Date'), { target: { value: '30/06/2027' } });
 };
 
 const submit = (label: RegExp): void => {

--- a/src/components/GoalModal.tsx
+++ b/src/components/GoalModal.tsx
@@ -3,6 +3,7 @@ import { useApp } from "../contexts/AppContextSupabase";
 import type { Goal } from "../types";
 import { Modal, ModalBody, ModalFooter } from './common/Modal';
 import MoneyInput from './common/MoneyInput';
+import DatePicker from './common/DatePicker';
 import { useModalForm } from '../hooks/useModalForm';
 import { parseMoneyInput } from '../utils/decimal';
 
@@ -221,12 +222,13 @@ export default function GoalModal({ isOpen, onClose, goal }: GoalModalProps): Re
             <label htmlFor={`${fieldId}-date`} className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
               Target Date
             </label>
-            <input
+            {/* dd/mm/yyyy everywhere — a native date input renders in the
+                browser's locale, not the app's. */}
+            <DatePicker
               id={`${fieldId}-date`}
-              type="date"
               required
               value={formData.targetDate}
-              onChange={(e) => updateField('targetDate', e.target.value)}
+              onChange={(val) => updateField('targetDate', val)}
               className={inputClasses}
             />
           </div>

--- a/src/components/PeriodPicker.tsx
+++ b/src/components/PeriodPicker.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { PERIOD_LABELS, type PeriodKey, type UsePeriodResult } from '../hooks/usePeriod';
+import DatePicker from './common/DatePicker';
 
 const ORDER: PeriodKey[] = ['this-month', 'last-month', 'tax-year', 'last-12-months', 'all', 'custom'];
 
@@ -37,22 +38,28 @@ export default function PeriodPicker({ picker }: { picker: UsePeriodResult }): R
       </div>
 
       {period === 'custom' && (
+        /* dd/mm/yyyy everywhere — a native date input renders in the
+           browser's locale, not the app's. */
         <div className="flex items-center gap-2">
-          <input
-            type="date"
-            value={customStart}
-            onChange={e => setCustomStart(e.target.value)}
-            aria-label="Custom period start date"
-            className="px-2 py-1.5 text-sm rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 text-gray-900 dark:text-white"
-          />
+          <div className="w-36">
+            <DatePicker
+              size="sm"
+              value={customStart}
+              onChange={setCustomStart}
+              aria-label="Custom period start date"
+              className="text-sm rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 text-gray-900 dark:text-white"
+            />
+          </div>
           <span className="text-sm text-gray-500 dark:text-gray-400">to</span>
-          <input
-            type="date"
-            value={customEnd}
-            onChange={e => setCustomEnd(e.target.value)}
-            aria-label="Custom period end date"
-            className="px-2 py-1.5 text-sm rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 text-gray-900 dark:text-white"
-          />
+          <div className="w-36">
+            <DatePicker
+              size="sm"
+              value={customEnd}
+              onChange={setCustomEnd}
+              aria-label="Custom period end date"
+              className="text-sm rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 text-gray-900 dark:text-white"
+            />
+          </div>
         </div>
       )}
     </div>

--- a/src/components/SharedBudgetsModals.tsx
+++ b/src/components/SharedBudgetsModals.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import MoneyInput from './common/MoneyInput';
+import DatePicker from './common/DatePicker';
 import type { Category } from '../types';
 
 type BudgetPeriod = 'monthly' | 'weekly' | 'yearly';
@@ -154,12 +155,14 @@ export function CreateGoalModal({ form, setForm, categories, onSubmit, onClose }
             </div>
             <div>
               <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Target Date</label>
-              <input
-                type="date"
+              {/* dd/mm/yyyy everywhere — a native date input renders in the
+                  browser's locale, not the app's. */}
+              <DatePicker
                 value={form.targetDate}
-                onChange={(e) => setForm({ ...form, targetDate: e.target.value })}
-                className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-700"
+                onChange={(val) => setForm({ ...form, targetDate: val })}
+                className="border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-700"
                 required
+                aria-label="Target date"
               />
             </div>
           </div>

--- a/src/components/TransactionModal.tsx
+++ b/src/components/TransactionModal.tsx
@@ -6,6 +6,7 @@ import TagSelector from './TagSelector';
 import CategorySelector from './CategorySelector';
 import MoneyInput from './common/MoneyInput';
 import GroupedAccountSelect from './common/GroupedAccountSelect';
+import DatePicker from './common/DatePicker';
 import type { Transaction } from '../types';
 
 interface TransactionModalProps {
@@ -257,19 +258,19 @@ export default function TransactionModal({ isOpen, onClose, transaction }: Trans
             <label htmlFor="date" className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
               Date <span className="text-red-500" aria-label="required">*</span>
             </label>
-            <input
+            {/* dd/mm/yyyy everywhere — a native date input renders in the
+                browser's locale, not the app's. */}
+            <DatePicker
               id="date"
-              type="date"
               required
               value={formData.date}
-              onChange={(e) => setFormData({ ...formData, date: e.target.value })}
+              onChange={(val) => setFormData({ ...formData, date: val })}
               onBlur={() => handleBlur('date')}
-              aria-required="true"
               aria-invalid={touched.date && !!errors.date}
               aria-describedby={touched.date && errors.date ? 'date-error' : undefined}
-              className={`w-full px-3 py-2 bg-white dark:bg-gray-800-sm border ${
-                touched.date && errors.date 
-                  ? 'border-red-500 dark:border-red-500' 
+              className={`bg-white dark:bg-gray-800-sm border ${
+                touched.date && errors.date
+                  ? 'border-red-500 dark:border-red-500'
                   : 'border-gray-300/50 dark:border-gray-600/50'
               } rounded-xl focus:outline-none focus:ring-2 focus:ring-primary focus:border-transparent dark:text-white`}
             />

--- a/src/components/TransactionReconciliation.tsx
+++ b/src/components/TransactionReconciliation.tsx
@@ -4,6 +4,8 @@ import { useCurrencyDecimal } from '../hooks/useCurrencyDecimal';
 import { Modal } from './common/Modal';
 import MoneyInput from './common/MoneyInput';
 import GroupedAccountSelect from './common/GroupedAccountSelect';
+import DatePicker from './common/DatePicker';
+import { formatDateForInput } from '../utils/dateFormatter';
 import { CheckCircleIcon, LinkIcon, RefreshCwIcon, CalendarIcon } from './icons';
 import type { Transaction } from '../types';
 import type { DecimalInstance } from '../types/decimal-types';
@@ -254,31 +256,27 @@ export default function TransactionReconciliation({
           </div>
           
           <div className="grid grid-cols-2 gap-6 mt-4">
+            {/* dd/mm/yyyy everywhere — a native date input renders in the
+                browser's locale, not the app's. Both ends hold real Dates, so
+                an emptied value (the picker's Clear) is ignored rather than
+                stored as an Invalid Date. */}
             <div>
               <label className="block text-sm font-medium mb-2">Start Date</label>
-              <input
-                type="date"
-                value={dateRange.start.toISOString().split('T')[0]}
-                onChange={(e) => setDateRange({
-                  ...dateRange,
-                  start: new Date(e.target.value)
-                })}
-                className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg
-                         bg-white dark:bg-gray-700"
+              <DatePicker
+                value={formatDateForInput(dateRange.start)}
+                onChange={(val) => { if (val) setDateRange({ ...dateRange, start: new Date(val) }); }}
+                className="border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-700"
+                aria-label="Reconciliation start date"
               />
             </div>
-            
+
             <div>
               <label className="block text-sm font-medium mb-2">End Date</label>
-              <input
-                type="date"
-                value={dateRange.end.toISOString().split('T')[0]}
-                onChange={(e) => setDateRange({
-                  ...dateRange,
-                  end: new Date(e.target.value)
-                })}
-                className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg
-                         bg-white dark:bg-gray-700"
+              <DatePicker
+                value={formatDateForInput(dateRange.end)}
+                onChange={(val) => { if (val) setDateRange({ ...dateRange, end: new Date(val) }); }}
+                className="border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-700"
+                aria-label="Reconciliation end date"
               />
             </div>
           </div>

--- a/src/components/TransferSweepModal.splitLine.test.tsx
+++ b/src/components/TransferSweepModal.splitLine.test.tsx
@@ -1,0 +1,233 @@
+/**
+ * TransferSweepModal — LINE matches, and the split lines with no other side.
+ *
+ * The owner's case end to end through the UI: £35,000 arrives, £30,000 of it
+ * settles a loan (a transfer LINE inside the split), and the £30,000 already
+ * sitting in the loan account is offered as that line's other side. Nothing
+ * about the two ROWS matches — so what these tests pin is that the offer shows
+ * the evidence that makes it judgeable (the line's own amount against the
+ * parent's total, the account it names, the row over there) and that accepting
+ * it calls the LINE write, never the whole-transaction one.
+ *
+ * The last block covers the deliberate absence: a line whose other side cannot
+ * be found is explained and left alone. There is no fix button, on purpose.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, fireEvent, cleanup, waitFor, within } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import TransferSweepModal from './TransferSweepModal';
+import { __setAppContextValue, __resetAppContextValue } from '../test/mocks/AppContextSupabase';
+import type { Category, Transaction, TransactionSplit } from '../types';
+
+vi.mock('../contexts/ToastContext', () => ({
+  useToast: () => ({
+    showToast: vi.fn(),
+    showSuccess: vi.fn(),
+    showError: vi.fn(),
+    showWarning: vi.fn(),
+    showInfo: vi.fn(),
+    dismissToast: vi.fn(),
+  }),
+}));
+
+vi.mock('../hooks/useCurrencyDecimal', () => ({
+  useCurrencyDecimal: () => ({
+    formatCurrency: (amount: number) => `£${Math.abs(amount).toFixed(2)}`,
+    displayCurrency: 'GBP',
+    getCurrencySymbol: () => '£',
+    convert: vi.fn(),
+    convertAndFormat: vi.fn(),
+    convertAndSum: vi.fn(),
+  }),
+}));
+
+vi.mock('../hooks/useAccountNames', () => ({
+  useAccountNames: () => (id: string) => ({
+    'acc-current': 'Current account',
+    'acc-loan': 'Friend loan',
+  }[id] ?? id),
+}));
+
+const txn = (over: Partial<Transaction> & { id: string }): Transaction => ({
+  date: new Date('2026-07-10'),
+  amount: -200,
+  description: 'Transfer (Online)',
+  category: '',
+  accountId: 'acc-current',
+  type: 'expense',
+  ...over,
+});
+
+const CATEGORIES: Category[] = [
+  {
+    id: 'revaluation-adjustment', name: 'Account Adjustment', type: 'both', level: 'detail',
+    parentId: 'type-revaluation', isRevaluationCategory: true,
+  },
+  { id: 'cat-dental', name: 'Dental', type: 'expense', level: 'detail' },
+];
+
+const PARENT: Transaction = txn({
+  id: 'repayment', accountId: 'acc-current', amount: 35000, type: 'income',
+  description: 'Repaid in full', isSplit: true,
+});
+
+const LOAN_ROW: Transaction = txn({
+  id: 'loan-row', accountId: 'acc-loan', amount: -30000, description: 'Repaid in full',
+});
+
+const SPLITS: TransactionSplit[] = [
+  { id: 'leg', transactionId: 'repayment', category: 'tofrom-loan', amount: 30000, sortOrder: 1, transferAccountId: 'acc-loan' },
+  { id: 'interest', transactionId: 'repayment', category: 'cat-interest', amount: 5000, sortOrder: 2 },
+];
+
+const renderModal = (): void => {
+  render(
+    <MemoryRouter>
+      <TransferSweepModal isOpen onClose={vi.fn()} />
+    </MemoryRouter>
+  );
+};
+
+afterEach(() => {
+  cleanup();
+  __resetAppContextValue();
+});
+
+describe('TransferSweepModal — a split line matched to its other side', () => {
+  beforeEach(() => {
+    __setAppContextValue({
+      transactions: [PARENT, LOAN_ROW],
+      transactionSplits: SPLITS,
+      categories: CATEGORIES,
+    });
+  });
+
+  it('lists the line beside the clean pairs, marked for what it is', () => {
+    renderModal();
+
+    const row = screen.getByTitle('See this split line and its match');
+    expect(within(row).getByText('split line')).toBeInTheDocument();
+    // The evidence that makes it judgeable: the LINE's amount, and the
+    // parent's total beside it — the two differing is the whole point.
+    expect(within(row).getByText('Repaid in full')).toBeInTheDocument();
+    expect(within(row).getByText('£30000.00 of the £35000.00 in this split')).toBeInTheDocument();
+    // From → To reads by the LINE's sign: money left the loan account.
+    expect(within(row).getByText('Friend loan')).toBeInTheDocument();
+    expect(within(row).getByText('Current account')).toBeInTheDocument();
+    // Ticked by default, exactly like an unambiguous pair.
+    expect(screen.getByLabelText('Link £30000.00 split line transfer')).toBeChecked();
+    expect(screen.getByText('1 of 1 selected')).toBeInTheDocument();
+  });
+
+  it('shows both sides, and the line\'s own account, when the row is opened', () => {
+    renderModal();
+    fireEvent.click(screen.getByTitle('See this split line and its match'));
+
+    const dialog = screen.getAllByRole('dialog')[1];
+    expect(within(dialog).getByRole('heading', { name: 'Check this split line' })).toBeInTheDocument();
+    expect(within(dialog).getByText('One line of a split')).toBeInTheDocument();
+    expect(within(dialog).getByText('Its other side')).toBeInTheDocument();
+    expect(within(dialog).getByText(/moving to Friend loan/)).toBeInTheDocument();
+    expect(within(dialog).getByText(/The rest of the split is untouched/)).toBeInTheDocument();
+  });
+
+  it('applies through linkSplitLineTransfer, with the LINE id — never the parent\'s', async () => {
+    const calls: string[] = [];
+    __setAppContextValue({
+      linkTransferPair: async (idA: string, idB: string) => {
+        calls.push(`pair:${idA},${idB}`);
+        return { a: PARENT, b: LOAN_ROW };
+      },
+      linkSplitLineTransfer: async (splitId: string, transactionId: string) => {
+        calls.push(`line:${splitId},${transactionId}`);
+        return { split: SPLITS[0], transaction: LOAN_ROW };
+      },
+    });
+    renderModal();
+    expect(calls).toEqual([]);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Link 1 pair' }));
+
+    await waitFor(() => expect(calls).toEqual(['line:leg,loan-row']));
+  });
+
+  it('does not apply a line the user unticked', async () => {
+    const calls: string[] = [];
+    __setAppContextValue({
+      linkSplitLineTransfer: async (splitId: string, transactionId: string) => {
+        calls.push(`line:${splitId},${transactionId}`);
+        return { split: SPLITS[0], transaction: LOAN_ROW };
+      },
+    });
+    renderModal();
+
+    fireEvent.click(screen.getByLabelText('Link £30000.00 split line transfer'));
+    expect(screen.getByText('0 of 1 selected')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /^Link/ })).toBeDisabled();
+    expect(calls).toEqual([]);
+  });
+
+  it('sorts alongside the pairs, in one table', () => {
+    const pairOut = txn({ id: 'pair-out', accountId: 'acc-current', amount: -50, date: new Date('2026-01-10') });
+    const pairIn = txn({ id: 'pair-in', accountId: 'acc-loan', amount: 50, type: 'income', date: new Date('2026-01-10') });
+    __setAppContextValue({
+      transactions: [PARENT, LOAN_ROW, pairOut, pairIn],
+      transactionSplits: SPLITS,
+      categories: CATEGORIES,
+    });
+    renderModal();
+
+    /** The match table in render order: 'pair' or 'line' per row. */
+    const kinds = (): string[] =>
+      screen.getAllByRole('row')
+        .map(r => r.getAttribute('title'))
+        .filter((t): t is string => Boolean(t?.startsWith('See ')))
+        .map(t => (t === 'See both sides of this pair' ? 'pair' : 'line'));
+
+    // Pairs first, then the line matches — the order the sweep found them in.
+    expect(kinds()).toEqual(['pair', 'line']);
+    expect(screen.getByText('2 of 2 selected')).toBeInTheDocument();
+
+    // Amount sorts by magnitude, biggest first — across both kinds.
+    fireEvent.click(screen.getByRole('button', { name: /^Amount/ }));
+    expect(kinds()).toEqual(['line', 'pair']);
+
+    // And the selection followed the rows that moved.
+    expect(screen.getByLabelText('Link £30000.00 split line transfer')).toBeChecked();
+    expect(screen.getByLabelText('Link £50.00 transfer')).toBeChecked();
+  });
+});
+
+describe('TransferSweepModal — a split line with no other side', () => {
+  it('explains the problem and offers no fix at all', () => {
+    __setAppContextValue({
+      transactions: [PARENT],
+      transactionSplits: SPLITS,
+      categories: CATEGORIES,
+    });
+    renderModal();
+
+    expect(screen.getByText('Split lines with no other side')).toBeInTheDocument();
+    expect(screen.getByText(/Nothing in Friend loan within a few days is the other side of this line/))
+      .toBeInTheDocument();
+    expect(screen.getByText(/Nothing here is changed for you/)).toBeInTheDocument();
+    // The evidence: the line's amount, and the parent's total under it.
+    expect(screen.getByText('of £35000.00')).toBeInTheDocument();
+    // Read-only: the only button on the row opens the transaction.
+    expect(screen.queryByRole('button', { name: /Review/ })).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Open' })).toBeInTheDocument();
+  });
+
+  it('names the category when the matching row is filed under one', () => {
+    __setAppContextValue({
+      transactions: [PARENT, { ...LOAN_ROW, category: 'cat-dental' }],
+      transactionSplits: SPLITS,
+      categories: CATEGORIES,
+    });
+    renderModal();
+
+    expect(screen.getByText(/is filed under “Dental”/)).toBeInTheDocument();
+    expect(screen.queryByTitle('See this split line and its match')).not.toBeInTheDocument();
+  });
+});

--- a/src/components/TransferSweepModal.tsx
+++ b/src/components/TransferSweepModal.tsx
@@ -4,11 +4,13 @@ import { Modal, ModalBody, ModalFooter } from './common/Modal';
 import { useApp } from '../contexts/AppContextSupabase';
 import { useToast } from '../contexts/ToastContext';
 import { useCurrencyDecimal } from '../hooks/useCurrencyDecimal';
-import { sweepTransferPairs, type TransferPairSuggestion } from '../utils/transferSweep';
+import { sweepTransferPairs, type SplitLegSuggestion, type TransferPairSuggestion } from '../utils/transferSweep';
 import {
   findStrandedTransfers,
+  findUnmatchedSplitLegs,
   resolveAdjustmentCategory,
   type StrandedFinding,
+  type UnmatchedSplitLegFinding,
 } from '../utils/strandedTransfers';
 import { applyStrandedFinding } from '../utils/strandedTransferActions';
 import { useAccountNames } from '../hooks/useAccountNames';
@@ -23,10 +25,20 @@ import type { Transaction } from '../types';
  * alternative existed) start UNSELECTED and are badged, because a wrong link
  * silently rewrites the meaning of two accounts.
  *
+ * The same table also carries LINE matches: one line of a split paired with
+ * the row that is its other side (£35,000 arrives, £30,000 of it settles a
+ * loan — the parent and that row match nothing, the LINE and that row match
+ * exactly). They tick, sort and apply alongside the whole-transaction pairs,
+ * and are marked as what they are, because accepting one changes a line inside
+ * a transaction rather than the transaction itself.
+ *
  * Below the clean pairs sits the residue — rows that look like transfers but
  * whose other side is taken, filed or missing (utils/strandedTransfers). Those
  * are per-row, confirm-first corrections, each spelling out its consequence
- * before it happens.
+ * before it happens. Last of all, and deliberately WITHOUT any action, sit the
+ * split lines whose other side could not be found at all: see
+ * findUnmatchedSplitLegs for why inventing one, or re-filing the line, would
+ * both be worse than saying so plainly.
  */
 
 interface Props {
@@ -111,29 +123,105 @@ const STRANDED_DONE: Record<StrandedFinding['kind'], string> = {
   'one-sided': 'Filed as Account Adjustment — neither income nor spending.',
 };
 
-/** Both account names, in the order the "From → To" cell reads them. */
-function pairRoute(s: TransferPairSuggestion, accountName: (id: string) => string): string {
-  return `${accountName(s.outgoing.accountId)} → ${accountName(s.incoming.accountId)}`;
+/**
+ * One line of the match table: a whole-transaction pair, or one LINE of a
+ * split matched to the row on its other side. They share the table because
+ * they are the same offer — "these two are one movement of money" — and differ
+ * only in what accepting one writes.
+ */
+type SweepRow =
+  | { kind: 'pair'; key: string; pair: TransferPairSuggestion }
+  | { kind: 'leg'; key: string; leg: SplitLegSuggestion };
+
+/** Selection key for a line match; the pair form is `keyOf` inside the component. */
+const keyOfLeg = (l: SplitLegSuggestion): string => `split:${l.split.id}|${l.candidate.id}`;
+
+/**
+ * The two accounts a line match moves money between, in "From → To" order. A
+ * line has no direction of its own beyond its SIGN: a positive line is money
+ * arriving in the parent's account, so the row over there is the out side.
+ */
+function legAccounts(leg: SplitLegSuggestion): { from: string; to: string } {
+  return leg.split.amount > 0
+    ? { from: leg.candidate.accountId, to: leg.parent.accountId }
+    : { from: leg.parent.accountId, to: leg.candidate.accountId };
+}
+
+/** What each sortable column reads, whichever kind of row it is looking at. */
+interface RowFacts {
+  date: number;
+  route: string;
+  description: string;
+  /** Size of the movement — for a line match, the LINE's, not the parent's. */
+  magnitude: number;
+}
+
+function factsOf(row: SweepRow, accountName: (id: string) => string): RowFacts {
+  if (row.kind === 'pair') {
+    const { outgoing, incoming } = row.pair;
+    return {
+      date: new Date(outgoing.date).getTime(),
+      route: `${accountName(outgoing.accountId)} → ${accountName(incoming.accountId)}`,
+      description: outgoing.description,
+      // Magnitude: the two legs are equal and opposite, so the sign carries no
+      // information here — only the size of the movement does.
+      magnitude: Math.abs(outgoing.amount),
+    };
+  }
+  const { split, parent } = row.leg;
+  // A line has no date or payee of its own: it takes the parent's.
+  const { from, to } = legAccounts(row.leg);
+  return {
+    date: new Date(parent.date).getTime(),
+    route: `${accountName(from)} → ${accountName(to)}`,
+    description: parent.description,
+    magnitude: Math.abs(split.amount),
+  };
 }
 
 /** Ascending by the given column; the caller applies the direction. */
-function comparePairs(
-  a: TransferPairSuggestion,
-  b: TransferPairSuggestion,
+function compareRows(
+  a: SweepRow,
+  b: SweepRow,
   key: PairSortKey,
   accountName: (id: string) => string
 ): number {
+  const left = factsOf(a, accountName);
+  const right = factsOf(b, accountName);
   switch (key) {
     case 'accounts':
-      return compareText(pairRoute(a, accountName), pairRoute(b, accountName));
+      return compareText(left.route, right.route);
     case 'description':
-      return compareText(a.outgoing.description, b.outgoing.description);
-    // Magnitude: the two legs are equal and opposite, so the sign carries no
-    // information here — only the size of the movement does.
+      return compareText(left.description, right.description);
     case 'amount':
-      return Math.abs(a.outgoing.amount) - Math.abs(b.outgoing.amount);
+      return left.magnitude - right.magnitude;
     case 'date':
-      return new Date(a.outgoing.date).getTime() - new Date(b.outgoing.date).getTime();
+      return left.date - right.date;
+  }
+}
+
+/**
+ * Why the sweep could not offer a match for a split line — said in full,
+ * because no action is offered and the sentence is all the user gets.
+ */
+function unmatchedLegReason(
+  finding: UnmatchedSplitLegFinding,
+  accountName: (id: string) => string
+): string {
+  const there = accountName(finding.target);
+  switch (finding.reason) {
+    case 'nothing-matches':
+      return `Nothing in ${there} within a few days is the other side of this line.`;
+    case 'linked':
+      return `The row that would match it in ${there} is already half of another transfer.`;
+    case 'split':
+      return `The row that would match it in ${there} is itself split, and a split cannot be one side of a transfer.`;
+    case 'archived':
+      return `The row that would match it in ${there} is archived — bring it back into the register, then run this again.`;
+    case 'filed':
+      return `The row that would match it in ${there} is filed under “${finding.blockerCategoryName}” — the same money, or a coincidence? Nothing here will guess.`;
+    case 'taken':
+      return `The row that would match it in ${there} is already being offered to another match above — settle that one, then run this again.`;
   }
 }
 
@@ -160,8 +248,8 @@ function compareFindings(
 
 export default function TransferSweepModal({ isOpen, onClose }: Props): React.JSX.Element {
   const {
-    transactions, categories, accounts, linkTransferPair,
-    repairClaimedTransfer, setTransactionArchived, updateTransaction,
+    transactions, categories, accounts, transactionSplits, linkTransferPair,
+    linkSplitLineTransfer, repairClaimedTransfer, setTransactionArchived, updateTransaction,
     updateAccount, refreshAccountsAndTransactions, refreshCategories,
   } = useApp();
   const { formatCurrency } = useCurrencyDecimal();
@@ -170,6 +258,7 @@ export default function TransferSweepModal({ isOpen, onClose }: Props): React.JS
   const location = useLocation();
   const [selected, setSelected] = useState<Set<string> | null>(null);
   const [inspecting, setInspecting] = useState<TransferPairSuggestion | null>(null);
+  const [inspectingLeg, setInspectingLeg] = useState<SplitLegSuggestion | null>(null);
   const [applying, setApplying] = useState(false);
   const [progress, setProgress] = useState(0);
   const [reviewing, setReviewing] = useState<StrandedFinding | null>(null);
@@ -200,13 +289,21 @@ export default function TransferSweepModal({ isOpen, onClose }: Props): React.JS
   // account that has since been closed.
   const accountName = useAccountNames();
 
-  const { suggestions } = useMemo(() => {
-    if (!isOpen) return { suggestions: [] as TransferPairSuggestion[] };
+  // One pass finds both: the whole-transaction pairs, and the split LINES
+  // whose other side is sitting unmatched in the account they name.
+  const { suggestions, legSuggestions } = useMemo(() => {
+    if (!isOpen) {
+      return {
+        suggestions: [] as TransferPairSuggestion[],
+        legSuggestions: [] as SplitLegSuggestion[],
+      };
+    }
     return sweepTransferPairs(transactions, {
       onlyUncategorised: true,
       categoryIds: new Set(categories.map(c => c.id)),
+      splits: transactionSplits,
     });
-  }, [isOpen, transactions, categories]);
+  }, [isOpen, transactions, categories, transactionSplits]);
 
   /**
    * The residue the clean sweep cannot pair. Composed with the suggestions
@@ -218,15 +315,33 @@ export default function TransferSweepModal({ isOpen, onClose }: Props): React.JS
     return findStrandedTransfers(transactions, categories, { sweepSuggestions: suggestions }).findings;
   }, [isOpen, transactions, categories, suggestions]);
 
+  /** Split lines with no other side anywhere — reported, never acted on. */
+  const legFindings = useMemo(() => {
+    if (!isOpen) return [] as UnmatchedSplitLegFinding[];
+    return findUnmatchedSplitLegs(transactions, transactionSplits, categories, {
+      sweepSuggestions: suggestions,
+      legSuggestions,
+    }).findings;
+  }, [isOpen, transactions, transactionSplits, categories, suggestions, legSuggestions]);
+
   // Resolved from the user's own categories — never created, never hardcoded.
   const adjustmentCategory = useMemo(() => resolveAdjustmentCategory(categories), [categories]);
 
   const keyOf = (s: TransferPairSuggestion): string => `${s.outgoing.id}|${s.incoming.id}`;
   const keyOfFinding = (f: StrandedFinding): string => `${f.kind}|${f.row.id}`;
 
-  // Default selection: every unambiguous pair.
+  // Whole-transaction pairs first, then the line matches: the same order the
+  // sweep found them in, and the order the table opens in.
+  const rows: SweepRow[] = [
+    ...suggestions.map(pair => ({ kind: 'pair' as const, key: keyOf(pair), pair })),
+    ...legSuggestions.map(leg => ({ kind: 'leg' as const, key: keyOfLeg(leg), leg })),
+  ];
+  const isAmbiguous = (row: SweepRow): boolean =>
+    row.kind === 'pair' ? row.pair.ambiguous : row.leg.ambiguous;
+
+  // Default selection: every unambiguous match, of either kind.
   const effectiveSelected = selected ?? new Set(
-    suggestions.filter(s => !s.ambiguous).map(keyOf)
+    rows.filter(row => !isAmbiguous(row)).map(row => row.key)
   );
 
   const toggle = (key: string): void => {
@@ -260,13 +375,13 @@ export default function TransferSweepModal({ isOpen, onClose }: Props): React.JS
 
   // The cap is applied FIRST and the sort second, so "the first 300 the sweep
   // found" goes on meaning exactly that whichever column is sorted by. Row
-  // order is presentation only: selection is keyed by the pair's two ids, and
-  // both `effectiveSelected` and `chosen` read the unsorted list.
-  const pairPage = suggestions.slice(0, CAP);
+  // order is presentation only: selection is keyed by the ids each match is
+  // made of, and both `effectiveSelected` and `chosen` read the unsorted list.
+  const pairPage = rows.slice(0, CAP);
   const visible = pairSortKey === null
     ? pairPage
-    : [...pairPage].sort((a, b) => pairSortDir * comparePairs(a, b, pairSortKey, accountName));
-  const chosen = suggestions.filter(s => effectiveSelected.has(keyOf(s)));
+    : [...pairPage].sort((a, b) => pairSortDir * compareRows(a, b, pairSortKey, accountName));
+  const chosen = rows.filter(row => effectiveSelected.has(row.key));
 
   const liveFindings = findings.filter(f => !dismissed.has(keyOfFinding(f)));
   const visibleFindings = liveFindings.slice(0, STRANDED_CAP).sort(
@@ -299,12 +414,31 @@ export default function TransferSweepModal({ isOpen, onClose }: Props): React.JS
   };
 
   /**
+   * Open a transaction in its own account register, with the row selected (the
+   * same ?txn deep link the categorisation drills use). A row in a CLOSED
+   * account has no register, so it routes through the re-open prompt first.
+   */
+  const openTransaction = (t: Transaction): void => {
+    if (!accounts.some(a => a.id === t.accountId)) {
+      setReopenPrompt({ accountId: t.accountId, txnId: t.id });
+      return;
+    }
+    const params = new URLSearchParams();
+    params.set('txn', t.id);
+    if (new URLSearchParams(location.search).get('demo') === 'true') {
+      params.set('demo', 'true');
+    }
+    setInspecting(null);
+    setInspectingLeg(null);
+    setReviewing(null);
+    onClose();
+    navigate(`/accounts/${t.accountId}?${params.toString()}`);
+  };
+
+  /**
    * One transaction as an evidence card — shared by the clean-pair check and
    * every stranded review, so the two read as the same thing.
    *
-   * The card jumps into its own account register with the transaction selected
-   * (the same ?txn deep link the categorisation drills use); a leg in a CLOSED
-   * account has no register, so it routes through the re-open prompt first.
    * `flex flex-col items-start` is load-bearing: it overrides the global
    * `button { display: inline-flex }` rule, which otherwise lays the card's
    * lines out side by side.
@@ -320,21 +454,7 @@ export default function TransferSweepModal({ isOpen, onClose }: Props): React.JS
       <button
         key={t.id}
         type="button"
-        onClick={() => {
-          if (!accountIsOpen) {
-            setReopenPrompt({ accountId: t.accountId, txnId: t.id });
-            return;
-          }
-          const params = new URLSearchParams();
-          params.set('txn', t.id);
-          if (new URLSearchParams(location.search).get('demo') === 'true') {
-            params.set('demo', 'true');
-          }
-          setInspecting(null);
-          setReviewing(null);
-          onClose();
-          navigate(`/accounts/${t.accountId}?${params.toString()}`);
-        }}
+        onClick={() => openTransaction(t)}
         title={accountIsOpen
           ? 'Open this transaction in its account'
           : 'This account is closed — click to re-open it and view the transaction'}
@@ -358,15 +478,63 @@ export default function TransferSweepModal({ isOpen, onClose }: Props): React.JS
     );
   };
 
+  /**
+   * ONE LINE of a split as an evidence card. The line's own amount is what
+   * matches, so that is what leads; the parent's total is shown beside it
+   * because the two differing is the entire point of a mixed split, and a card
+   * that hid it would look like an arithmetic error. Opens the parent — the
+   * line has no register row of its own.
+   */
+  const renderSplitLineCard = (leg: SplitLegSuggestion): React.JSX.Element => {
+    const { split, parent } = leg;
+    const accountIsOpen = accounts.some(a => a.id === parent.accountId);
+    return (
+      <button
+        key={split.id}
+        type="button"
+        onClick={() => openTransaction(parent)}
+        title={accountIsOpen
+          ? 'Open the transaction this line belongs to'
+          : 'This account is closed — click to re-open it and view the transaction'}
+        className="flex flex-col items-start text-left rounded-xl border border-blue-200 dark:border-blue-800 bg-blue-50/40 dark:bg-blue-900/10 p-4 transition-all hover:border-primary hover:shadow-md cursor-pointer"
+      >
+        <p className="text-[10px] uppercase tracking-wide text-gray-400 dark:text-gray-500 mb-1">
+          One line of a split
+        </p>
+        <p className={`text-lg font-bold tabular-nums ${split.amount < 0 ? 'text-red-600 dark:text-red-400' : 'text-green-600 dark:text-green-400'}`}>
+          {formatCurrency(Math.abs(split.amount))}
+        </p>
+        <p className="mt-2 text-sm font-medium text-gray-900 dark:text-white">
+          {accountName(parent.accountId)}
+        </p>
+        <p className="text-sm text-gray-600 dark:text-gray-400 break-words">{parent.description}</p>
+        <p className="mt-1 text-xs text-gray-500 dark:text-gray-400">
+          {new Date(parent.date).toLocaleDateString('en-GB', { day: '2-digit', month: 'long', year: 'numeric' })}
+        </p>
+        <p className="mt-2 text-xs font-medium text-blue-700 dark:text-blue-300">
+          {formatCurrency(Math.abs(split.amount))} of the {formatCurrency(Math.abs(parent.amount))} in this split,
+          {' '}moving to {accountName(leg.candidate.accountId)}
+        </p>
+      </button>
+    );
+  };
+
   const handleApply = async (): Promise<void> => {
     setApplying(true);
     setProgress(0);
     let linked = 0;
     let failed = 0;
     try {
-      for (const pair of chosen) {
+      for (const row of chosen) {
         try {
-          await linkTransferPair(pair.outgoing.id, pair.incoming.id);
+          if (row.kind === 'pair') {
+            await linkTransferPair(row.pair.outgoing.id, row.pair.incoming.id);
+          } else {
+            // A line match links the LINE, not the parent — a different write
+            // entirely, and the reason the two kinds share a table but not a
+            // call.
+            await linkSplitLineTransfer(row.leg.split.id, row.leg.candidate.id);
+          }
           linked++;
         } catch {
           failed++;
@@ -380,7 +548,7 @@ export default function TransferSweepModal({ isOpen, onClose }: Props): React.JS
         );
       }
       if (linked === 0 && failed > 0) {
-        showError(new Error('No pairs could be linked. Please try again.'));
+        showError(new Error('No matches could be linked. Please try again.'));
       }
       onClose();
     } finally {
@@ -397,18 +565,26 @@ export default function TransferSweepModal({ isOpen, onClose }: Props): React.JS
       size="xl"
     >
       <ModalBody>
-        {suggestions.length === 0 && liveFindings.length === 0 ? (
+        {rows.length === 0 && liveFindings.length === 0 && legFindings.length === 0 ? (
           <p className="text-center py-10 text-gray-500 dark:text-gray-400">
             No unlinked transfer pairs found. Every equal-and-opposite movement in your
             history is already linked.
           </p>
-        ) : suggestions.length > 0 && (
+        ) : rows.length > 0 && (
           <>
             <p className="text-sm text-gray-600 dark:text-gray-400 mb-3">
-              Found <strong>{suggestions.length.toLocaleString()}</strong> likely transfer
-              pair{suggestions.length === 1 ? '' : 's'} — uncategorised rows that are exactly
+              Found <strong>{rows.length.toLocaleString()}</strong> likely transfer
+              pair{rows.length === 1 ? '' : 's'} — uncategorised rows that are exactly
               equal and opposite, in different accounts, within a few days. Linking them
               makes both sides transfers, so they leave your income and expense totals.
+              {legSuggestions.length > 0 && (
+                <>
+                  {' '}<strong>{legSuggestions.length.toLocaleString()}</strong> of
+                  them {legSuggestions.length === 1 ? 'matches a single line' : 'match single lines'} inside
+                  a split, not a whole row — marked <em>split line</em> below, because linking one
+                  changes that line and the row it matches, and nothing else in the transaction.
+                </>
+              )}
             </p>
             <div className="overflow-x-auto">
               <table className="w-full">
@@ -435,66 +611,131 @@ export default function TransferSweepModal({ isOpen, onClose }: Props): React.JS
                   </tr>
                 </thead>
                 <tbody>
-                  {visible.map(s => {
-                    const key = keyOf(s);
-                    return (
-                      /* The WHOLE line drills into the both-sides popup — date,
-                         accounts, description or amount, it makes no difference.
-                         Only the checkbox cell stays out of it, so ticking a
-                         pair never accidentally opens the inspection. */
-                      <tr
-                        key={key}
-                        onClick={() => setInspecting(s)}
-                        className="border-b border-gray-50 dark:border-gray-700/50 cursor-pointer hover:bg-gray-50 dark:hover:bg-gray-700/40 transition-colors"
-                        title="See both sides of this pair"
-                      >
-                        <td className="py-2" onClick={(e) => e.stopPropagation()}>
-                          <input
-                            type="checkbox"
-                            checked={effectiveSelected.has(key)}
-                            onChange={() => toggle(key)}
-                            disabled={applying}
-                            aria-label={`Link ${formatCurrency(Math.abs(s.outgoing.amount))} transfer`}
-                            className="rounded border-gray-300"
-                          />
-                        </td>
-                        <td className="py-2 text-sm text-gray-500 dark:text-gray-400 whitespace-nowrap">
-                          {new Date(s.outgoing.date).toLocaleDateString('en-GB', { day: '2-digit', month: 'short', year: '2-digit' })}
-                          {s.daysApart > 0 && (
-                            <span className="ml-1 text-xs text-gray-400">+{Math.round(s.daysApart)}d</span>
-                          )}
-                        </td>
-                        <td className="py-2 text-sm text-gray-700 dark:text-gray-300">
-                          <span className="inline-flex items-center gap-1 whitespace-nowrap">
-                            <span className="truncate max-w-[140px]">{accountName(s.outgoing.accountId)}</span>
-                            <ArrowRightIcon size={12} className="text-gray-400 flex-shrink-0" />
-                            <span className="truncate max-w-[140px]">{accountName(s.incoming.accountId)}</span>
+                  {visible.map(row => row.kind === 'pair' ? (
+                    /* The WHOLE line drills into the both-sides popup — date,
+                       accounts, description or amount, it makes no difference.
+                       Only the checkbox cell stays out of it, so ticking a
+                       pair never accidentally opens the inspection. */
+                    <tr
+                      key={row.key}
+                      onClick={() => setInspecting(row.pair)}
+                      className="border-b border-gray-50 dark:border-gray-700/50 cursor-pointer hover:bg-gray-50 dark:hover:bg-gray-700/40 transition-colors"
+                      title="See both sides of this pair"
+                    >
+                      <td className="py-2" onClick={(e) => e.stopPropagation()}>
+                        <input
+                          type="checkbox"
+                          checked={effectiveSelected.has(row.key)}
+                          onChange={() => toggle(row.key)}
+                          disabled={applying}
+                          aria-label={`Link ${formatCurrency(Math.abs(row.pair.outgoing.amount))} transfer`}
+                          className="rounded border-gray-300"
+                        />
+                      </td>
+                      <td className="py-2 text-sm text-gray-500 dark:text-gray-400 whitespace-nowrap">
+                        {new Date(row.pair.outgoing.date).toLocaleDateString('en-GB', { day: '2-digit', month: 'short', year: '2-digit' })}
+                        {row.pair.daysApart > 0 && (
+                          <span className="ml-1 text-xs text-gray-400">+{Math.round(row.pair.daysApart)}d</span>
+                        )}
+                      </td>
+                      <td className="py-2 text-sm text-gray-700 dark:text-gray-300">
+                        <span className="inline-flex items-center gap-1 whitespace-nowrap">
+                          <span className="truncate max-w-[140px]">{accountName(row.pair.outgoing.accountId)}</span>
+                          <ArrowRightIcon size={12} className="text-gray-400 flex-shrink-0" />
+                          <span className="truncate max-w-[140px]">{accountName(row.pair.incoming.accountId)}</span>
+                        </span>
+                        {row.pair.ambiguous && (
+                          <span
+                            className="ml-2 inline-flex items-center gap-1 text-xs text-amber-700 dark:text-amber-400 underline decoration-dotted underline-offset-2"
+                            title="Other rows matched this amount equally well — look at both sides before linking"
+                          >
+                            <AlertTriangleIcon size={12} />
+                            check
                           </span>
-                          {s.ambiguous && (
-                            <span
-                              className="ml-2 inline-flex items-center gap-1 text-xs text-amber-700 dark:text-amber-400 underline decoration-dotted underline-offset-2"
-                              title="Other rows matched this amount equally well — look at both sides before linking"
-                            >
-                              <AlertTriangleIcon size={12} />
-                              check
-                            </span>
-                          )}
-                        </td>
-                        <td className="py-2 text-sm text-gray-600 dark:text-gray-400">
-                          <span className="block truncate max-w-[220px] underline decoration-dotted underline-offset-2 decoration-gray-300 dark:decoration-gray-600">
-                            {s.outgoing.description}
+                        )}
+                      </td>
+                      <td className="py-2 text-sm text-gray-600 dark:text-gray-400">
+                        <span className="block truncate max-w-[220px] underline decoration-dotted underline-offset-2 decoration-gray-300 dark:decoration-gray-600">
+                          {row.pair.outgoing.description}
+                        </span>
+                      </td>
+                      <td className="py-2 text-sm font-medium text-right tabular-nums text-gray-900 dark:text-white whitespace-nowrap">
+                        {formatCurrency(Math.abs(row.pair.outgoing.amount))}
+                      </td>
+                    </tr>
+                  ) : (
+                    /* A LINE match. Same columns, same ticking, same bulk
+                       apply — with the blue accent and the "split line" badge
+                       saying that accepting it changes one line inside a
+                       transaction, and with the line's own amount against the
+                       parent's total, since those two differing is the whole
+                       point of the thing. */
+                    <tr
+                      key={row.key}
+                      onClick={() => setInspectingLeg(row.leg)}
+                      className="border-b border-gray-50 dark:border-gray-700/50 border-l-2 border-l-blue-400 dark:border-l-blue-500 bg-blue-50/30 dark:bg-blue-900/10 cursor-pointer hover:bg-blue-50/60 dark:hover:bg-blue-900/20 transition-colors"
+                      title="See this split line and its match"
+                    >
+                      <td className="py-2 pl-1" onClick={(e) => e.stopPropagation()}>
+                        <input
+                          type="checkbox"
+                          checked={effectiveSelected.has(row.key)}
+                          onChange={() => toggle(row.key)}
+                          disabled={applying}
+                          aria-label={`Link ${formatCurrency(Math.abs(row.leg.split.amount))} split line transfer`}
+                          className="rounded border-gray-300"
+                        />
+                      </td>
+                      <td className="py-2 text-sm text-gray-500 dark:text-gray-400 whitespace-nowrap">
+                        {new Date(row.leg.parent.date).toLocaleDateString('en-GB', { day: '2-digit', month: 'short', year: '2-digit' })}
+                        {row.leg.daysApart > 0 && (
+                          <span className="ml-1 text-xs text-gray-400">+{Math.round(row.leg.daysApart)}d</span>
+                        )}
+                      </td>
+                      <td className="py-2 text-sm text-gray-700 dark:text-gray-300">
+                        <span className="inline-flex items-center gap-1 whitespace-nowrap">
+                          <span className="truncate max-w-[140px]">
+                            {accountName(legAccounts(row.leg).from)}
                           </span>
-                        </td>
-                        <td className="py-2 text-sm font-medium text-right tabular-nums text-gray-900 dark:text-white whitespace-nowrap">
-                          {formatCurrency(Math.abs(s.outgoing.amount))}
-                        </td>
-                      </tr>
-                    );
-                  })}
-                  {suggestions.length > CAP && (
+                          <ArrowRightIcon size={12} className="text-gray-400 flex-shrink-0" />
+                          <span className="truncate max-w-[140px]">
+                            {accountName(legAccounts(row.leg).to)}
+                          </span>
+                        </span>
+                        <span
+                          className="ml-2 inline-flex items-center rounded-full px-2 py-0.5 text-[10px] font-medium bg-blue-100 dark:bg-blue-900/40 text-blue-800 dark:text-blue-200"
+                          title="One line of a split transaction — not the whole row"
+                        >
+                          split line
+                        </span>
+                        {row.leg.ambiguous && (
+                          <span
+                            className="ml-2 inline-flex items-center gap-1 text-xs text-amber-700 dark:text-amber-400 underline decoration-dotted underline-offset-2"
+                            title="Other rows matched this line equally well — look at both sides before linking"
+                          >
+                            <AlertTriangleIcon size={12} />
+                            check
+                          </span>
+                        )}
+                      </td>
+                      <td className="py-2 text-sm text-gray-600 dark:text-gray-400">
+                        <span className="block truncate max-w-[220px] underline decoration-dotted underline-offset-2 decoration-gray-300 dark:decoration-gray-600">
+                          {row.leg.parent.description}
+                        </span>
+                        <span className="block text-xs text-gray-500 dark:text-gray-400">
+                          {formatCurrency(Math.abs(row.leg.split.amount))} of the{' '}
+                          {formatCurrency(Math.abs(row.leg.parent.amount))} in this split
+                        </span>
+                      </td>
+                      <td className="py-2 text-sm font-medium text-right tabular-nums text-gray-900 dark:text-white whitespace-nowrap">
+                        {formatCurrency(Math.abs(row.leg.split.amount))}
+                      </td>
+                    </tr>
+                  ))}
+                  {rows.length > CAP && (
                     <tr>
                       <td colSpan={5} className="py-3 text-center text-xs text-gray-400 dark:text-gray-500">
-                        Showing the first {CAP.toLocaleString()} of {suggestions.length.toLocaleString()} pairs —
+                        Showing the first {CAP.toLocaleString()} of {rows.length.toLocaleString()} pairs —
                         link these, then run the sweep again for the rest.
                       </td>
                     </tr>
@@ -510,7 +751,7 @@ export default function TransferSweepModal({ isOpen, onClose }: Props): React.JS
             a decision with a consequence, so each is reviewed on its own. The
             section simply does not exist when there is nothing to show. */}
         {liveFindings.length > 0 && (
-          <section className={suggestions.length > 0 ? 'mt-6 pt-5 border-t border-gray-200 dark:border-gray-700' : ''}>
+          <section className={rows.length > 0 ? 'mt-6 pt-5 border-t border-gray-200 dark:border-gray-700' : ''}>
             <h3 className="text-sm font-semibold text-gray-900 dark:text-white">
               Stranded transfers
               <span className="ml-2 text-xs font-normal text-gray-500 dark:text-gray-400">
@@ -607,6 +848,91 @@ export default function TransferSweepModal({ isOpen, onClose }: Props): React.JS
             </div>
           </section>
         )}
+
+        {/* Split lines whose other side could not be found. NOTHING here is
+            offered as a fix, deliberately: creating the missing row could
+            double a movement that already exists somewhere, and re-filing the
+            line would rewrite what the user said the money was for — from a
+            list that cannot even show them the rest of the split. So the
+            finding says what is wrong, and the row opens the transaction. */}
+        {legFindings.length > 0 && (
+          <section className={rows.length > 0 || liveFindings.length > 0 ? 'mt-6 pt-5 border-t border-gray-200 dark:border-gray-700' : ''}>
+            <h3 className="text-sm font-semibold text-gray-900 dark:text-white">
+              Split lines with no other side
+              <span className="ml-2 text-xs font-normal text-gray-500 dark:text-gray-400">
+                {legFindings.length.toLocaleString()}
+              </span>
+            </h3>
+            <p className="text-sm text-gray-600 dark:text-gray-400 mt-1 mb-3">
+              One line inside each of these transactions says money moved to another account, but
+              nothing over there matches it. <strong>Nothing here is changed for you</strong> — the
+              missing row may exist under a different date or amount, and inventing one would count
+              the same money twice. Open the transaction and decide.
+            </p>
+            <div className="overflow-x-auto">
+              <table className="w-full">
+                <thead>
+                  <tr className="text-xs text-gray-500 dark:text-gray-400 border-b border-gray-100 dark:border-gray-700">
+                    <th className="text-center pb-2 font-medium">Date</th>
+                    <th className="text-center pb-2 font-medium">Account</th>
+                    <th className="text-center pb-2 font-medium">What is wrong</th>
+                    <th className="text-center pb-2 font-medium">Line</th>
+                    <th className="pb-2 w-24"></th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {legFindings.slice(0, STRANDED_CAP).map(f => (
+                    <tr
+                      key={f.split.id}
+                      className="border-b border-gray-50 dark:border-gray-700/50 align-top"
+                    >
+                      <td className="py-2 text-sm text-gray-500 dark:text-gray-400 whitespace-nowrap">
+                        {new Date(f.parent.date).toLocaleDateString('en-GB', { day: '2-digit', month: 'short', year: '2-digit' })}
+                      </td>
+                      <td className="py-2 text-sm text-gray-700 dark:text-gray-300">
+                        <span className="block truncate max-w-[140px]">{accountName(f.parent.accountId)}</span>
+                      </td>
+                      <td className="py-2 text-sm text-gray-600 dark:text-gray-400">
+                        <span className="block truncate max-w-[260px] text-gray-900 dark:text-white">
+                          {f.parent.description}
+                        </span>
+                        <span className="inline-flex items-center gap-1 text-xs text-amber-700 dark:text-amber-400 mt-0.5">
+                          <AlertTriangleIcon size={12} />
+                          split line, no other side
+                        </span>
+                        <span className="block text-xs mt-0.5 max-w-[420px]">
+                          {unmatchedLegReason(f, accountName)}
+                        </span>
+                      </td>
+                      <td className="py-2 text-sm font-medium text-right tabular-nums text-gray-900 dark:text-white whitespace-nowrap">
+                        {formatCurrency(Math.abs(f.split.amount))}
+                        <span className="block text-xs font-normal text-gray-500 dark:text-gray-400">
+                          of {formatCurrency(Math.abs(f.parent.amount))}
+                        </span>
+                      </td>
+                      <td className="py-2 text-right">
+                        <button
+                          type="button"
+                          onClick={() => openTransaction(f.parent)}
+                          className="px-3 py-1.5 text-xs font-medium rounded-lg border border-gray-300 dark:border-gray-600 text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors"
+                        >
+                          Open
+                        </button>
+                      </td>
+                    </tr>
+                  ))}
+                  {legFindings.length > STRANDED_CAP && (
+                    <tr>
+                      <td colSpan={5} className="py-3 text-center text-xs text-gray-400 dark:text-gray-500">
+                        Showing the first {STRANDED_CAP.toLocaleString()} of {legFindings.length.toLocaleString()}.
+                      </td>
+                    </tr>
+                  )}
+                </tbody>
+              </table>
+            </div>
+          </section>
+        )}
       </ModalBody>
       <ModalFooter>
         <div className="flex items-center gap-3">
@@ -616,9 +942,9 @@ export default function TransferSweepModal({ isOpen, onClose }: Props): React.JS
           <p className="text-sm text-gray-600 dark:text-gray-400">
             {applying
               ? `Linking ${progress.toLocaleString()} of ${chosen.length.toLocaleString()}…`
-              : suggestions.length === 0
-                ? 'Each stranded row is fixed on its own, above.'
-                : `${chosen.length.toLocaleString()} of ${Math.min(suggestions.length, CAP).toLocaleString()} selected`}
+              : rows.length === 0
+                ? 'Each row here is sorted out on its own, above.'
+                : `${chosen.length.toLocaleString()} of ${Math.min(rows.length, CAP).toLocaleString()} selected`}
           </p>
           <div className="ml-auto flex items-center gap-2">
             <button
@@ -627,9 +953,9 @@ export default function TransferSweepModal({ isOpen, onClose }: Props): React.JS
               disabled={applying}
               className="px-4 py-2 text-sm font-medium rounded-lg border border-gray-300 dark:border-gray-600 text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors disabled:opacity-50"
             >
-              {suggestions.length === 0 ? 'Close' : 'Cancel'}
+              {rows.length === 0 ? 'Close' : 'Cancel'}
             </button>
-            {suggestions.length > 0 && (
+            {rows.length > 0 && (
               <button
                 type="button"
                 onClick={() => void handleApply()}
@@ -692,6 +1018,68 @@ export default function TransferSweepModal({ isOpen, onClose }: Props): React.JS
                 className="px-4 py-2 text-sm font-medium rounded-lg bg-[#1a2332] dark:bg-blue-600 text-white hover:bg-[#2d3a4d] dark:hover:bg-blue-700 transition-colors"
               >
                 Yes — select this pair
+              </button>
+            </div>
+          </ModalFooter>
+        </Modal>
+      )}
+
+      {/* The same check for a LINE match, with the one thing that makes it
+          different said plainly: what matches is the line, not the transaction
+          it sits in, and only that line changes. */}
+      {inspectingLeg && (
+        <Modal
+          isOpen
+          onClose={() => setInspectingLeg(null)}
+          title="Check this split line"
+          size="lg"
+        >
+          <ModalBody>
+            <p className="text-sm text-gray-600 dark:text-gray-400 mb-4">
+              {inspectingLeg.ambiguous
+                ? 'Flagged because other rows matched this line equally well — make sure these two really are the same movement of money.'
+                : 'One line of this split says money moved to another account, and the row beside it is exactly its opposite.'}
+              {' '}Linking them makes <strong>that line</strong> and that row two halves of one
+              transfer. The rest of the split is untouched, and the transaction&rsquo;s own total
+              does not move.
+              {inspectingLeg.daysApart > 0 && (
+                <> The two sides are <strong>{Math.round(inspectingLeg.daysApart)} day{Math.round(inspectingLeg.daysApart) === 1 ? '' : 's'} apart</strong>.</>
+              )}
+            </p>
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+              {renderSplitLineCard(inspectingLeg)}
+              {renderLeg(
+                'Its other side',
+                inspectingLeg.candidate,
+                inspectingLeg.candidate.amount < 0 ? 'text-red-600 dark:text-red-400' : 'text-green-600 dark:text-green-400'
+              )}
+            </div>
+          </ModalBody>
+          <ModalFooter>
+            <div className="flex items-center gap-2 ml-auto">
+              <button
+                type="button"
+                onClick={() => {
+                  const next = new Set(effectiveSelected);
+                  next.delete(keyOfLeg(inspectingLeg));
+                  setSelected(next);
+                  setInspectingLeg(null);
+                }}
+                className="px-4 py-2 text-sm font-medium rounded-lg border border-gray-300 dark:border-gray-600 text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors"
+              >
+                Not a match — leave it
+              </button>
+              <button
+                type="button"
+                onClick={() => {
+                  const next = new Set(effectiveSelected);
+                  next.add(keyOfLeg(inspectingLeg));
+                  setSelected(next);
+                  setInspectingLeg(null);
+                }}
+                className="px-4 py-2 text-sm font-medium rounded-lg bg-[#1a2332] dark:bg-blue-600 text-white hover:bg-[#2d3a4d] dark:hover:bg-blue-700 transition-colors"
+              >
+                Yes — select this line
               </button>
             </div>
           </ModalFooter>
@@ -865,6 +1253,7 @@ export default function TransferSweepModal({ isOpen, onClose }: Props): React.JS
                       const target = reopenPrompt.accountId;
                       setReopenPrompt(null);
                       setInspecting(null);
+                      setInspectingLeg(null);
                       onClose();
                       navigate(`/accounts/${target}?${params.toString()}`);
                     } catch (error) {

--- a/src/components/ZeroBasedBudgetingModals.tsx
+++ b/src/components/ZeroBasedBudgetingModals.tsx
@@ -1,8 +1,10 @@
 import React, { useState } from 'react';
 import { Modal, ModalBody, ModalFooter } from './common/Modal';
 import MoneyInput from './common/MoneyInput';
+import DatePicker from './common/DatePicker';
 import type { Category } from '../types';
 import { parseMoneyInput } from '../utils/decimal';
+import { formatDateForInput } from '../utils/dateFormatter';
 
 // Types shared with ZeroBasedBudgeting
 export interface ZeroBudgetItem {
@@ -68,25 +70,29 @@ export function NewPeriodModal({ onSave, onClose }: NewPeriodModalProps) {
             </div>
 
             <div className="grid grid-cols-2 gap-4">
+              {/* dd/mm/yyyy everywhere — a native date input renders in the
+                  browser's locale, not the app's. These two hold real Dates
+                  and are required, so an emptied value (the picker's Clear)
+                  is ignored rather than stored as an Invalid Date. */}
               <div>
                 <label className="block text-sm font-medium mb-1">Start Date</label>
-                <input
-                  type="date"
-                  value={formData.startDate.toISOString().split('T')[0]}
-                  onChange={(e) => setFormData({ ...formData, startDate: new Date(e.target.value) })}
-                  className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-700"
+                <DatePicker
+                  value={formatDateForInput(formData.startDate)}
+                  onChange={(val) => { if (val) setFormData({ ...formData, startDate: new Date(val) }); }}
+                  className="border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-700"
                   required
+                  aria-label="Budget start date"
                 />
               </div>
 
               <div>
                 <label className="block text-sm font-medium mb-1">End Date</label>
-                <input
-                  type="date"
-                  value={formData.endDate.toISOString().split('T')[0]}
-                  onChange={(e) => setFormData({ ...formData, endDate: new Date(e.target.value) })}
-                  className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-700"
+                <DatePicker
+                  value={formatDateForInput(formData.endDate)}
+                  onChange={(val) => { if (val) setFormData({ ...formData, endDate: new Date(val) }); }}
+                  className="border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-700"
                   required
+                  aria-label="Budget end date"
                 />
               </div>
             </div>

--- a/src/components/common/DatePicker.tsx
+++ b/src/components/common/DatePicker.tsx
@@ -7,7 +7,26 @@ interface DatePickerProps {
   className?: string;
   'aria-label'?: string;
   id?: string;
+  /** Mirrors a native date input's `required` for forms that rely on it. */
+  required?: boolean;
+  /** Runs AFTER the typed draft settles, so a caller's touched/validation
+   *  bookkeeping sees the committed value rather than the half-typed one. */
+  onBlur?: () => void;
+  'aria-invalid'?: boolean;
+  'aria-describedby'?: string;
+  /**
+   * Chrome density. 'sm' matches the compact filter rows (px-2 py-1.5) that
+   * native inputs used; padding lives here rather than in className because
+   * Tailwind resolves competing padding utilities by stylesheet order, not by
+   * the order they appear in the class attribute.
+   */
+  size?: 'sm' | 'md';
 }
+
+const SIZES = {
+  sm: { field: 'px-2 py-1.5 pr-8', icon: 'right-2', iconSize: 14 },
+  md: { field: 'px-3 py-2 pr-10', icon: 'right-3', iconSize: 16 },
+} as const;
 
 const DAYS = ['M', 'T', 'W', 'T', 'F', 'S', 'S'];
 const MONTHS = [
@@ -63,7 +82,18 @@ function parseTypedDate(input: string): string | null {
   return toYMD(year, month - 1, day);
 }
 
-export default function DatePicker({ value, onChange, className = '', 'aria-label': ariaLabel, id }: DatePickerProps) {
+export default function DatePicker({
+  value,
+  onChange,
+  className = '',
+  'aria-label': ariaLabel,
+  id,
+  required,
+  onBlur,
+  'aria-invalid': ariaInvalid,
+  'aria-describedby': ariaDescribedBy,
+  size = 'md',
+}: DatePickerProps) {
   const [isOpen, setIsOpen] = useState(false);
   const containerRef = useRef<HTMLDivElement>(null);
   const inputRef = useRef<HTMLInputElement>(null);
@@ -264,6 +294,8 @@ export default function DatePicker({ value, onChange, className = '', 'aria-labe
     setIsOpen(true);
   };
 
+  const chrome = SIZES[size];
+
   return (
     <div ref={containerRef} className="relative">
       <div className="relative">
@@ -275,16 +307,22 @@ export default function DatePicker({ value, onChange, className = '', 'aria-labe
           onChange={(e) => handleTyping(e.target.value)}
           onFocus={openPicker}
           onClick={openPicker}
-          onBlur={settleDraft}
+          onBlur={() => {
+            settleDraft();
+            onBlur?.();
+          }}
           onKeyDown={handleKeyDown}
           placeholder="dd/mm/yyyy"
           aria-label={ariaLabel}
+          aria-invalid={ariaInvalid}
+          aria-describedby={ariaDescribedBy}
+          required={required}
           autoComplete="off"
-          className={`w-full px-3 py-2 pr-10 ${className}`}
+          className={`w-full ${chrome.field} ${className}`}
         />
         <CalendarIcon
-          size={16}
-          className="absolute right-3 top-1/2 -translate-y-1/2 text-gray-400 pointer-events-none"
+          size={chrome.iconSize}
+          className={`absolute ${chrome.icon} top-1/2 -translate-y-1/2 text-gray-400 pointer-events-none`}
         />
       </div>
 

--- a/src/components/pwa/OfflineTransactionForm.tsx
+++ b/src/components/pwa/OfflineTransactionForm.tsx
@@ -10,14 +10,14 @@ import { useAccounts } from '../../contexts/AccountContext';
 import { formatCurrency } from '../../utils/formatters';
 import MoneyInput from '../common/MoneyInput';
 import GroupedAccountSelect from '../common/GroupedAccountSelect';
+import DatePicker from '../common/DatePicker';
 import { toDecimal, parseMoneyInput } from '../../utils/decimal';
 import { 
   WifiOffIcon, 
   CheckCircleIcon, 
   AlertCircleIcon,
   DollarSignIcon,
-  CalendarIcon,
-  FileTextIcon 
+  FileTextIcon
 } from '../icons';
 
 interface OfflineTransactionFormProps {
@@ -216,15 +216,15 @@ export const OfflineTransactionForm: React.FC<OfflineTransactionFormProps> = ({
             {/* Date */}
             <div>
               <label className="block text-sm font-medium mb-1">Date</label>
-              <div className="relative">
-                <CalendarIcon className="absolute left-3 top-1/2 transform -translate-y-1/2 h-4 w-4 text-gray-400" />
-                <input
-                  type="date"
-                  value={formData.date}
-                  onChange={(e) => setFormData({ ...formData, date: e.target.value })}
-                  className="w-full pl-10 pr-3 py-2 border rounded-lg dark:bg-gray-700 dark:border-gray-600"
-                />
-              </div>
+              {/* dd/mm/yyyy everywhere — a native date input renders in the
+                  browser's locale, not the app's. The picker carries its own
+                  calendar glyph, so the decorative leading one goes. */}
+              <DatePicker
+                value={formData.date}
+                onChange={(val) => setFormData({ ...formData, date: val })}
+                className="border rounded-lg dark:bg-gray-700 dark:border-gray-600"
+                aria-label="Transaction date"
+              />
             </div>
 
             {/* Category */}

--- a/src/components/reconciliation/ReconciliationFinalizationModal.tsx
+++ b/src/components/reconciliation/ReconciliationFinalizationModal.tsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect } from 'react';
 import { CheckCircleIcon, XIcon } from '../icons';
 import CategorySelector from '../CategorySelector';
 import MoneyInput from '../common/MoneyInput';
+import DatePicker from '../common/DatePicker';
 import { useCurrencyDecimal } from '../../hooks/useCurrencyDecimal';
 import { parseMoneyInput, toDecimal } from '../../utils/decimal';
 import { deriveAdjustment } from '../../utils/reconciliation';
@@ -242,12 +243,13 @@ export default function ReconciliationFinalizationModal({
                 <label htmlFor="adjustment-date" className="text-xs text-gray-500 dark:text-gray-400 block mb-1">
                   Date
                 </label>
-                <input
+                {/* dd/mm/yyyy everywhere — a native date input renders in the
+                    browser's locale, not the app's. */}
+                <DatePicker
                   id="adjustment-date"
-                  type="date"
                   value={adjustmentDate}
-                  onChange={(e) => setAdjustmentDate(e.target.value)}
-                  className="w-full px-3 py-2 text-sm border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-700 dark:text-white"
+                  onChange={setAdjustmentDate}
+                  className="text-sm border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-700 dark:text-white"
                 />
               </div>
             </div>

--- a/src/contexts/AppContextSupabase.tsx
+++ b/src/contexts/AppContextSupabase.tsx
@@ -20,7 +20,7 @@ import {
   toDecimalAccount,
   toDecimalGoal
 } from '../utils/decimal-converters';
-import { toDecimal } from '../utils/decimal';
+import { toDecimal, type DecimalInstance } from '../utils/decimal';
 import { normalizeTransactionDates } from '../utils/dateBoundary';
 import { TransactionService } from '../services/api/transactionService';
 import type { ServerAccountBalance } from '../utils/accountBalances';
@@ -30,6 +30,7 @@ import type {
   Transaction,
   TransactionSplit,
   TransactionSplitInput,
+  SplitWriteResult,
   Category,
   CategoryMergeResult,
   Budget,
@@ -162,21 +163,40 @@ export interface AppContextType extends AppState {
   getTransactionSplits: (transactionId: string) => Promise<TransactionSplit[]>;
   /**
    * Replace a transaction's splits atomically (empty array un-splits it).
-   * Split lines must sum EXACTLY to expectedAmount — enforced server-side by
-   * the set_transaction_splits RPC, which also syncs the transaction amount
-   * and account balance when the sum changes them.
+   * Split lines must sum EXACTLY to expectedAmount — enforced server-side,
+   * which also syncs the transaction amount and account balance when the sum
+   * changes them.
+   *
+   * A line may declare a `transferAccountId`, making it one LEG of a transfer:
+   * the counterpart transaction is created in that account and linked to the
+   * exact line, in the same server-side transaction, and comes back in
+   * `counterparts`. An already-linked leg may only move position or memo —
+   * changing its amount, target or category, or dropping it, is refused,
+   * because the row on the other side is pinned to it.
    */
   setTransactionSplits: (
     transactionId: string,
     splits: TransactionSplitInput[],
     expectedAmount: number | null
-  ) => Promise<{ isSplit: boolean; splitCount: number; amount: number }>;
+  ) => Promise<SplitWriteResult>;
   /**
    * Join two existing rows (in different accounts, exactly opposite amounts)
    * into a linked transfer pair — both become type 'transfer' carrying the
    * other account's To/From category. Balance-neutral; atomic server-side.
    */
   linkTransferPair: (idA: string, idB: string) => Promise<{ a: Transaction; b: Transaction }>;
+  /**
+   * Join one LINE of a split to an existing row as the two halves of a
+   * transfer — the line-level counterpart of linkTransferPair, for the case
+   * where the movement is only part of the transaction it sits in (£35,000
+   * arrives, £30,000 of it settles a loan). The amounts must be exactly
+   * opposite between the LINE and the row, never the split parent, whose total
+   * legitimately differs. Balance-neutral; atomic server-side.
+   */
+  linkSplitLineTransfer: (
+    splitId: string,
+    transactionId: string
+  ) => Promise<{ split: TransactionSplit; transaction: Transaction }>;
   /**
    * Break linked transfer pairs (the un-doing of linkTransferPair): clears the
    * link on the named rows so they can be re-paired or re-filed. Balance-neutral.
@@ -766,27 +786,45 @@ export function AppProvider({ children }: { children: React.ReactNode }) {
       }
 
       // Mirror the atomic server change locally: the flag, the blanked
-      // category while split, and the amount the splits sum to.
-      setTransactions(prev => prev.map(t =>
-        t.id === transactionId
-          ? {
-              ...t,
-              isSplit: result.isSplit,
-              amount: result.amount,
-              ...(result.isSplit ? { category: '' } : {}),
-            }
-          : t
-      ));
+      // category while split, and the amount the splits sum to. A line that
+      // became a transfer leg also put a REAL row in another account — those
+      // come back from the database, so they are added as written rather than
+      // synthesised here.
+      setTransactions(prev => [
+        ...prev.map(t =>
+          t.id === transactionId
+            ? {
+                ...t,
+                isSplit: result.isSplit,
+                amount: result.amount,
+                ...(result.isSplit ? { category: '' } : {}),
+              }
+            : t
+        ),
+        ...result.counterparts,
+      ]);
 
-      // Balance follows the amount (Decimal arithmetic; the DB balance was
-      // adjusted atomically inside set_transaction_splits).
+      // Balances follow the money (Decimal arithmetic; the DB moved them
+      // atomically inside the split RPC): the parent's account by whatever the
+      // new total changed, each counterpart's account by the row now sitting
+      // in it.
+      const deltas = new Map<string, DecimalInstance>();
+      const owe = (accountId: string, amount: DecimalInstance): void => {
+        deltas.set(accountId, (deltas.get(accountId) ?? toDecimal(0)).plus(amount));
+      };
       if (oldTransaction && result.amount !== oldTransaction.amount) {
-        const difference = toDecimal(result.amount).minus(toDecimal(oldTransaction.amount));
-        setAccounts(prev => prev.map(acc =>
-          acc.id === oldTransaction.accountId
-            ? { ...acc, balance: toDecimal(acc.balance || 0).plus(difference).toNumber() }
-            : acc
-        ));
+        owe(oldTransaction.accountId, toDecimal(result.amount).minus(toDecimal(oldTransaction.amount)));
+      }
+      for (const counterpart of result.counterparts) {
+        owe(counterpart.accountId, toDecimal(counterpart.amount));
+      }
+      if (deltas.size > 0) {
+        setAccounts(prev => prev.map(acc => {
+          const delta = deltas.get(acc.id);
+          return delta
+            ? { ...acc, balance: toDecimal(acc.balance || 0).plus(delta).toNumber() }
+            : acc;
+        }));
       }
 
       return result;
@@ -806,6 +844,21 @@ export function AppProvider({ children }: { children: React.ReactNode }) {
       return result;
     } catch (error) {
       appLogger.error('Failed to link transfer pair', error);
+      throw error;
+    }
+  }, []);
+
+  const linkSplitLineTransfer = useCallback(async (splitId: string, transactionId: string) => {
+    try {
+      const result = await DataService.linkSplitLineTransfer(splitId, transactionId);
+      // State comes from what the database wrote: linking re-types and
+      // re-categorises the row over there, and pins it to the exact line.
+      // Balance-neutral — both sides existed with these amounts already.
+      setTransactions(prev => prev.map(t => (t.id === result.transaction.id ? result.transaction : t)));
+      setTransactionSplitsState(prev => prev.map(s => (s.id === result.split.id ? result.split : s)));
+      return result;
+    } catch (error) {
+      appLogger.error('Failed to link split line transfer', error);
       throw error;
     }
   }, []);
@@ -1316,6 +1369,7 @@ export function AppProvider({ children }: { children: React.ReactNode }) {
     getTransactionSplits,
     setTransactionSplits,
     linkTransferPair,
+    linkSplitLineTransfer,
     unlinkTransfers,
     setTransactionArchived,
     repairClaimedTransfer,

--- a/src/pages/AccountTransactions.tsx
+++ b/src/pages/AccountTransactions.tsx
@@ -1628,6 +1628,9 @@ export default function AccountTransactions() {
               ? () => { advanceToPreviousTransaction(selectedTransaction.id); }
               : undefined
           }
+          // This IS the register the modal's "see it in its account" link
+          // would jump to, so the link stays hidden here.
+          hideJumpToAccountId={accountId}
         />
       )}
       

--- a/src/pages/ExportManager.tsx
+++ b/src/pages/ExportManager.tsx
@@ -16,6 +16,8 @@ import {
 } from '../components/icons';
 import PageWrapper from '../components/PageWrapper';
 import PageTip from '../components/PageTip';
+import DatePicker from '../components/common/DatePicker';
+import { formatDateForInput } from '../utils/dateFormatter';
 import { LoadingState } from '../components/loading/LoadingState';
 import type { Investment } from '../types';
 import { createScopedLogger } from '../loggers/scopedLogger';
@@ -253,30 +255,26 @@ export default function ExportManager() {
                     <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
                       Start Date
                     </label>
-                    <input
-                      type="date"
+                    {/* dd/mm/yyyy everywhere — a native date input renders in
+                        the browser's locale, not the app's. The range holds
+                        real Dates, so an emptied value (the picker's Clear) is
+                        ignored rather than stored as an Invalid Date. */}
+                    <DatePicker
                       aria-label="Start date"
-                      value={exportOptions.startDate.toISOString().split('T')[0]}
-                      onChange={(e) => setExportOptions({
-                        ...exportOptions,
-                        startDate: new Date(e.target.value)
-                      })}
-                      className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-700 text-gray-900 dark:text-white"
+                      value={formatDateForInput(exportOptions.startDate)}
+                      onChange={(val) => { if (val) setExportOptions({ ...exportOptions, startDate: new Date(val) }); }}
+                      className="border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-700 text-gray-900 dark:text-white"
                     />
                   </div>
                   <div>
                     <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
                       End Date
                     </label>
-                    <input
-                      type="date"
+                    <DatePicker
                       aria-label="End date"
-                      value={exportOptions.endDate.toISOString().split('T')[0]}
-                      onChange={(e) => setExportOptions({
-                        ...exportOptions,
-                        endDate: new Date(e.target.value)
-                      })}
-                      className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-700 text-gray-900 dark:text-white"
+                      value={formatDateForInput(exportOptions.endDate)}
+                      onChange={(val) => { if (val) setExportOptions({ ...exportOptions, endDate: new Date(val) }); }}
+                      className="border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-700 text-gray-900 dark:text-white"
                     />
                   </div>
                 </div>

--- a/src/pages/settings/AuditLogs.tsx
+++ b/src/pages/settings/AuditLogs.tsx
@@ -9,6 +9,7 @@ import {
   SearchIcon
 } from '../../components/icons';
 import PageWrapper from '../../components/PageWrapper';
+import DatePicker from '../../components/common/DatePicker';
 import { VirtualizedTable, Column } from '../../components/VirtualizedTable';
 import type { AuditLog } from '../../services/securityService';
 
@@ -302,11 +303,13 @@ export default function AuditLogs() {
               <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
                 Start Date
               </label>
-              <input
-                type="date"
+              {/* dd/mm/yyyy everywhere — a native date input renders in the
+                  browser's locale, not the app's. */}
+              <DatePicker
                 value={filters.startDate}
-                onChange={(e) => handleFilterChange('startDate', e.target.value)}
-                className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-700 text-gray-900 dark:text-white"
+                onChange={(val) => handleFilterChange('startDate', val)}
+                className="border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-700 text-gray-900 dark:text-white"
+                aria-label="Audit log start date"
               />
             </div>
 
@@ -315,11 +318,11 @@ export default function AuditLogs() {
               <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
                 End Date
               </label>
-              <input
-                type="date"
+              <DatePicker
                 value={filters.endDate}
-                onChange={(e) => handleFilterChange('endDate', e.target.value)}
-                className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-700 text-gray-900 dark:text-white"
+                onChange={(val) => handleFilterChange('endDate', val)}
+                className="border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-700 text-gray-900 dark:text-white"
+                aria-label="Audit log end date"
               />
             </div>
           </div>

--- a/src/services/__tests__/dataService.test.ts
+++ b/src/services/__tests__/dataService.test.ts
@@ -122,12 +122,13 @@ describe('DataService (deterministic fallback)', () => {
     expect(data.categories).toHaveLength(1);
   });
 
-  it('refuses to edit or un-split a split containing a linked transfer line', async () => {
+  it('refuses an edit that would drop a linked transfer line, and refuses to un-split', async () => {
     // A split whose second line is one leg of a transfer (the counterpart
-    // transaction points back at it). Replacing or removing the lines would
-    // strand the counterpart, so both must be rejected.
+    // transaction points back at it). A line set that does not name that line
+    // by id is asking for it to be deleted — which would leave the counterpart
+    // pointing at nothing — and un-splitting deletes every line. Both refused.
     const storage = createStorage({
-      [STORAGE_KEYS.ACCOUNTS]: [baseAccount()],
+      [STORAGE_KEYS.ACCOUNTS]: [baseAccount(), baseAccount({ id: 'acct-2', name: 'Savings' })],
       [STORAGE_KEYS.TRANSACTIONS]: [
         baseTransaction({ id: 'split-parent', amount: -100, isSplit: true, category: '' }),
         baseTransaction({
@@ -170,9 +171,9 @@ describe('DataService (deterministic fallback)', () => {
         ],
         -100
       )
-    ).rejects.toThrow(/linked transfer line/);
+    ).rejects.toThrow(/transferring to "Savings" is one half of a transfer/);
     await expect(service.setTransactionSplits('split-parent', [], null)).rejects.toThrow(
-      /linked transfer line/
+      /transferring to "Savings" is one half of a transfer/
     );
     // nothing was persisted — the split and its leg line survive intact
     expect(storage.snapshot(STORAGE_KEYS.TRANSACTION_SPLITS)).toHaveLength(2);
@@ -354,6 +355,377 @@ describe('DataService Decimal balance deltas (local mode)', () => {
 
     const accounts = storage.snapshot(STORAGE_KEYS.ACCOUNTS) as Account[];
     expect(accounts[0].balance).toBe(-70.3);
+  });
+});
+
+
+// The demo/offline half of the split-leg write path — the mirror of
+// set_transaction_splits_with_legs (migration 20260806094058). Two jobs:
+// creating a leg (Steve's case: one payment that both settles a loan and pays
+// interest), and letting the REST of a split that contains a leg be edited,
+// which the old replace-the-whole-set writer had to refuse wholesale.
+describe('DataService split transfer legs (local mode)', () => {
+  const logger = { error: vi.fn(), warn: vi.fn(), log: vi.fn() };
+  const now = vi.fn(() => new Date('2025-09-01T00:00:00.000Z'));
+  const userId = {
+    ensureUserExists: vi.fn(),
+    getCurrentDatabaseUserId: vi.fn(() => null),
+    getCurrentUserIds: vi.fn(() => ({ clerkId: null, databaseId: null }))
+  };
+
+  /** Sequential ids: a leg write mints a line AND a counterpart in one call. */
+  const buildService = (storage: ReturnType<typeof createStorage>): DataService => {
+    let n = 0;
+    return createDataService({
+      isSupabaseConfigured: () => false,
+      storageAdapter: storage,
+      logger,
+      uuid: () => `new-${++n}`,
+      now,
+      userIdService: userId
+    });
+  };
+
+  const transferCategory = (accountId: string): Category => ({
+    id: `tofrom-${accountId}`,
+    name: `To/From ${accountId}`,
+    type: 'both',
+    level: 'detail',
+    isTransferCategory: true,
+    accountId
+  });
+
+  // ── Creating a leg: £35,000 arrives, £30,000 of it settles a loan ─────────
+  describe('creating a leg', () => {
+    const lendingHistory = () => createStorage({
+      [STORAGE_KEYS.ACCOUNTS]: [
+        baseAccount({ id: 'current', name: 'Current', balance: 35000, currency: 'GBP' }),
+        baseAccount({ id: 'loan', name: 'Friend Loan', balance: 30000, currency: 'GBP' })
+      ],
+      [STORAGE_KEYS.TRANSACTIONS]: [
+        baseTransaction({
+          id: 'repayment', accountId: 'current', amount: 35000,
+          type: 'income', category: 'interest', description: 'Repaid in full'
+        })
+      ],
+      [STORAGE_KEYS.TRANSACTION_SPLITS]: [],
+      [STORAGE_KEYS.CATEGORIES]: [
+        transferCategory('loan'),
+        { id: 'interest', name: 'Interest', type: 'income', level: 'detail' } as Category
+      ]
+    });
+
+    const repaymentSplit = [
+      { category: 'tofrom-loan', amount: 30000, transferAccountId: 'loan' },
+      { category: 'interest', amount: 5000 }
+    ];
+
+    it('creates the counterpart with the opposite LINE amount and links both ways', async () => {
+      const storage = lendingHistory();
+      const service = buildService(storage);
+
+      const result = await service.setTransactionSplits('repayment', repaymentSplit, 35000);
+
+      expect(result.counterparts).toHaveLength(1);
+      const [counterpart] = result.counterparts;
+      // Opposite of the LINE (30,000), NOT of the parent (35,000) — the whole
+      // point of a mixed split.
+      expect(counterpart).toMatchObject({
+        amount: -30000,
+        accountId: 'loan',
+        type: 'transfer',
+        transferAccountId: 'current',
+        linkedTransferId: 'repayment'
+      });
+
+      const lines = storage.snapshot(STORAGE_KEYS.TRANSACTION_SPLITS) as TransactionSplit[];
+      const leg = lines.find(l => l.transferAccountId === 'loan');
+      expect(leg).toMatchObject({ amount: 30000, linkedTransferId: counterpart.id });
+      // The counterpart pins the exact LINE, so the pair is navigable from
+      // either end.
+      expect(counterpart.linkedTransferSplitId).toBe(leg?.id);
+      // The other line is untouched by any of this.
+      expect(lines.find(l => l.category === 'interest')).toMatchObject({ amount: 5000 });
+    });
+
+    it('leaves the parent total alone and moves only the target account', async () => {
+      const storage = lendingHistory();
+      const service = buildService(storage);
+
+      await service.setTransactionSplits('repayment', repaymentSplit, 35000);
+
+      const stored = storage.snapshot(STORAGE_KEYS.TRANSACTIONS) as Transaction[];
+      expect(stored.find(t => t.id === 'repayment')).toMatchObject({
+        isSplit: true, amount: 35000, category: ''
+      });
+      const accounts = storage.snapshot(STORAGE_KEYS.ACCOUNTS) as Account[];
+      // The loan is settled: 30,000 owed, 30,000 repaid.
+      expect(accounts.find(a => a.id === 'loan')?.balance).toBe(0);
+      // The receiving account already carried the 35,000; nothing moved there.
+      expect(accounts.find(a => a.id === 'current')?.balance).toBe(35000);
+    });
+
+    it('refuses a leg pointing back at the transaction\'s own account', async () => {
+      const storage = lendingHistory();
+      const service = buildService(storage);
+
+      await expect(service.setTransactionSplits('repayment', [
+        { category: 'tofrom-current', amount: 30000, transferAccountId: 'current' },
+        { category: 'interest', amount: 5000 }
+      ], 35000)).rejects.toThrow(/two different accounts/);
+      expect(storage.snapshot(STORAGE_KEYS.TRANSACTION_SPLITS)).toHaveLength(0);
+    });
+
+    it('refuses a leg across currencies, and writes nothing at all', async () => {
+      const storage = lendingHistory();
+      const accounts = storage.snapshot(STORAGE_KEYS.ACCOUNTS) as Account[];
+      await storage.set(STORAGE_KEYS.ACCOUNTS, accounts.map(a =>
+        a.id === 'loan' ? { ...a, currency: 'USD' } : a
+      ));
+      const service = buildService(storage);
+
+      await expect(service.setTransactionSplits('repayment', repaymentSplit, 35000))
+        .rejects.toThrow(/different currencies/);
+
+      // All-or-nothing: no lines, no counterpart, no balance moved.
+      expect(storage.snapshot(STORAGE_KEYS.TRANSACTION_SPLITS)).toHaveLength(0);
+      expect(storage.snapshot(STORAGE_KEYS.TRANSACTIONS)).toHaveLength(1);
+      const after = storage.snapshot(STORAGE_KEYS.ACCOUNTS) as Account[];
+      expect(after.find(a => a.id === 'loan')?.balance).toBe(30000);
+    });
+
+    it('refuses a leg whose lines do not sum to the transaction, writing nothing', async () => {
+      const storage = lendingHistory();
+      const service = buildService(storage);
+
+      await expect(service.setTransactionSplits('repayment', [
+        { category: 'tofrom-loan', amount: 30000, transferAccountId: 'loan' },
+        { category: 'interest', amount: 4000 }
+      ], 35000)).rejects.toThrow(/must sum to the transaction amount/);
+
+      expect(storage.snapshot(STORAGE_KEYS.TRANSACTION_SPLITS)).toHaveLength(0);
+      expect(storage.snapshot(STORAGE_KEYS.TRANSACTIONS)).toHaveLength(1);
+      const after = storage.snapshot(STORAGE_KEYS.ACCOUNTS) as Account[];
+      expect(after.find(a => a.id === 'loan')?.balance).toBe(30000);
+    });
+
+    it('refuses a To/From category that names a different account from the line', async () => {
+      const storage = lendingHistory();
+      const accounts = storage.snapshot(STORAGE_KEYS.ACCOUNTS) as Account[];
+      const categories = storage.snapshot(STORAGE_KEYS.CATEGORIES) as Category[];
+      await storage.set(STORAGE_KEYS.ACCOUNTS, [...accounts, baseAccount({ id: 'isa', name: 'ISA' })]);
+      await storage.set(STORAGE_KEYS.CATEGORIES, [...categories, transferCategory('isa')]);
+      const service = buildService(storage);
+
+      // Filed under the ISA's To/From category, but transferring to the loan:
+      // the category names the account, so the two cannot disagree.
+      await expect(service.setTransactionSplits('repayment', [
+        { category: 'tofrom-isa', amount: 30000, transferAccountId: 'loan' },
+        { category: 'interest', amount: 5000 }
+      ], 35000)).rejects.toThrow(/transfers to a different account/);
+
+      // And a To/From category with no target at all says "transfer" without
+      // saying where to.
+      await expect(service.setTransactionSplits('repayment', [
+        { category: 'tofrom-loan', amount: 30000 },
+        { category: 'interest', amount: 5000 }
+      ], 35000)).rejects.toThrow(/which account is on the other side/);
+      expect(storage.snapshot(STORAGE_KEYS.TRANSACTION_SPLITS)).toHaveLength(0);
+    });
+  });
+
+  // ── The owner's case: file a NEIGHBOUR of a leg ───────────────────────────
+  // 78 of his split parents contain a linked leg and 33 still carry an
+  // unfiled line. Categorising one of those strands nothing, and must work.
+  describe('editing a split that already contains a leg', () => {
+    const splitWithLeg = () => createStorage({
+      [STORAGE_KEYS.ACCOUNTS]: [
+        baseAccount({ id: 'current', name: 'Current', balance: -400 }),
+        baseAccount({ id: 'savings', name: 'Savings', balance: 100 })
+      ],
+      [STORAGE_KEYS.TRANSACTIONS]: [
+        baseTransaction({
+          id: 'parent', accountId: 'current', amount: -400,
+          type: 'expense', category: '', isSplit: true
+        }),
+        baseTransaction({
+          id: 'counterpart', accountId: 'savings', amount: 100, type: 'transfer',
+          category: 'tofrom-current', transferAccountId: 'current',
+          linkedTransferId: 'parent', linkedTransferSplitId: 'leg-line'
+        })
+      ],
+      [STORAGE_KEYS.TRANSACTION_SPLITS]: [
+        {
+          id: 'leg-line', transactionId: 'parent', category: 'tofrom-savings',
+          amount: -100, sortOrder: 1, transferAccountId: 'savings',
+          linkedTransferId: 'counterpart'
+        },
+        { id: 'unfiled', transactionId: 'parent', category: 'unassigned', amount: -300, sortOrder: 2 }
+      ],
+      [STORAGE_KEYS.CATEGORIES]: [
+        transferCategory('savings'),
+        { id: 'unassigned', name: 'Unassigned', type: 'both', level: 'detail', isUnassignedBucket: true } as Category,
+        { id: 'rent', name: 'Rent', type: 'expense', level: 'detail' } as Category
+      ]
+    });
+
+    /** The leg exactly as stored, carried back out untouched. */
+    const legAsStored = {
+      id: 'leg-line', category: 'tofrom-savings', amount: -100, transferAccountId: 'savings'
+    };
+
+    it('re-files the ordinary line and leaves the leg byte-identical', async () => {
+      const storage = splitWithLeg();
+      const service = buildService(storage);
+
+      const result = await service.setTransactionSplits('parent', [
+        legAsStored,
+        { id: 'unfiled', category: 'rent', amount: -300 }
+      ], -400);
+
+      // Nothing was created: an edit beside a leg is not a new transfer.
+      expect(result.counterparts).toEqual([]);
+
+      const lines = storage.snapshot(STORAGE_KEYS.TRANSACTION_SPLITS) as TransactionSplit[];
+      expect(lines.find(l => l.id === 'unfiled')).toMatchObject({ category: 'rent', amount: -300 });
+      // Same line, same amount, same target, same link — the counterpart on
+      // the other side still points at something real.
+      expect(lines.find(l => l.id === 'leg-line')).toEqual({
+        id: 'leg-line',
+        transactionId: 'parent',
+        category: 'tofrom-savings',
+        amount: -100,
+        sortOrder: 1,
+        transferAccountId: 'savings',
+        linkedTransferId: 'counterpart'
+      });
+      const stored = storage.snapshot(STORAGE_KEYS.TRANSACTIONS) as Transaction[];
+      expect(stored.find(t => t.id === 'counterpart')).toMatchObject({
+        amount: 100, linkedTransferId: 'parent', linkedTransferSplitId: 'leg-line'
+      });
+      // Balance-neutral: the total is what it always was.
+      expect(stored.find(t => t.id === 'parent')?.amount).toBe(-400);
+      const accounts = storage.snapshot(STORAGE_KEYS.ACCOUNTS) as Account[];
+      expect(accounts.map(a => a.balance)).toEqual([-400, 100]);
+    });
+
+    it('lets the ordinary line change amount, as long as the total still adds up', async () => {
+      const storage = splitWithLeg();
+      const service = buildService(storage);
+
+      await service.setTransactionSplits('parent', [
+        legAsStored,
+        { id: 'unfiled', category: 'rent', amount: -250 }
+      ], -350);
+
+      const stored = storage.snapshot(STORAGE_KEYS.TRANSACTIONS) as Transaction[];
+      expect(stored.find(t => t.id === 'parent')?.amount).toBe(-350);
+      // Only the parent's own account moves; the leg (and so the other
+      // account) is exactly as it was.
+      const accounts = storage.snapshot(STORAGE_KEYS.ACCOUNTS) as Account[];
+      expect(accounts.find(a => a.id === 'current')?.balance).toBe(-350);
+      expect(accounts.find(a => a.id === 'savings')?.balance).toBe(100);
+    });
+
+    it('adds a new ordinary line beside the leg', async () => {
+      const storage = splitWithLeg();
+      const service = buildService(storage);
+
+      await service.setTransactionSplits('parent', [
+        legAsStored,
+        { id: 'unfiled', category: 'rent', amount: -250 },
+        { category: 'rent', amount: -50, memo: 'the rest' }
+      ], -400);
+
+      const lines = storage.snapshot(STORAGE_KEYS.TRANSACTION_SPLITS) as TransactionSplit[];
+      expect(lines).toHaveLength(3);
+      expect(lines.find(l => l.id === 'leg-line')?.linkedTransferId).toBe('counterpart');
+    });
+
+    it.each([
+      ['its amount', { ...legAsStored, amount: -120 }, /has to stay as it is/],
+      ['its target', { ...legAsStored, transferAccountId: 'current' }, /two different accounts/],
+      ['its category', { ...legAsStored, category: 'rent' }, /names the account on the other side/],
+    ])('refuses to change a linked leg: %s', async (_what, leg, message) => {
+      const storage = splitWithLeg();
+      const service = buildService(storage);
+
+      await expect(service.setTransactionSplits('parent', [
+        leg,
+        { id: 'unfiled', category: 'rent', amount: -300 }
+      ], -400)).rejects.toThrow(message);
+
+      // Nothing at all was written, so the counterpart is never orphaned.
+      const lines = storage.snapshot(STORAGE_KEYS.TRANSACTION_SPLITS) as TransactionSplit[];
+      expect(lines.find(l => l.id === 'leg-line')).toMatchObject({
+        amount: -100, transferAccountId: 'savings', linkedTransferId: 'counterpart'
+      });
+      expect(lines.find(l => l.id === 'unfiled')?.category).toBe('unassigned');
+    });
+
+    it('refuses an edit that drops the leg, naming the account it would strand', async () => {
+      const storage = splitWithLeg();
+      const service = buildService(storage);
+
+      await expect(service.setTransactionSplits('parent', [
+        { id: 'unfiled', category: 'rent', amount: -300 },
+        { category: 'rent', amount: -100 }
+      ], -400)).rejects.toThrow(/transferring to "Savings" is one half of a transfer/);
+
+      const lines = storage.snapshot(STORAGE_KEYS.TRANSACTION_SPLITS) as TransactionSplit[];
+      expect(lines).toHaveLength(2);
+      expect(lines.find(l => l.id === 'leg-line')?.linkedTransferId).toBe('counterpart');
+    });
+
+    it('never mints a second counterpart for a leg it already has', async () => {
+      const storage = splitWithLeg();
+      const service = buildService(storage);
+
+      const result = await service.setTransactionSplits('parent', [
+        legAsStored,
+        { id: 'unfiled', category: 'rent', amount: -300 }
+      ], -400);
+
+      expect(result.counterparts).toEqual([]);
+      const stored = storage.snapshot(STORAGE_KEYS.TRANSACTIONS) as Transaction[];
+      expect(stored.filter(t => t.type === 'transfer')).toHaveLength(1);
+    });
+
+    it('does not invent a counterpart for a leg whose other side was deleted', async () => {
+      // linked_transfer_id goes (ON DELETE SET NULL), transfer_account_id
+      // stays. The row that matches it may still be sitting in Savings
+      // unmatched, so re-saving must leave the line alone rather than double
+      // the movement.
+      const storage = splitWithLeg();
+      const lines = storage.snapshot(STORAGE_KEYS.TRANSACTION_SPLITS) as TransactionSplit[];
+      await storage.set(STORAGE_KEYS.TRANSACTION_SPLITS, lines.map(l =>
+        l.id === 'leg-line' ? { ...l, linkedTransferId: undefined } : l
+      ));
+      const service = buildService(storage);
+
+      const result = await service.setTransactionSplits('parent', [
+        legAsStored,
+        { id: 'unfiled', category: 'rent', amount: -300 }
+      ], -400);
+
+      expect(result.counterparts).toEqual([]);
+      const after = storage.snapshot(STORAGE_KEYS.TRANSACTION_SPLITS) as TransactionSplit[];
+      expect(after.find(l => l.id === 'leg-line')).toMatchObject({ transferAccountId: 'savings' });
+      expect(after.find(l => l.id === 'leg-line')?.linkedTransferId).toBeUndefined();
+      const accounts = storage.snapshot(STORAGE_KEYS.ACCOUNTS) as Account[];
+      expect(accounts.find(a => a.id === 'savings')?.balance).toBe(100);
+    });
+
+    it('refuses a line claiming to be one this split does not have', async () => {
+      const storage = splitWithLeg();
+      const service = buildService(storage);
+
+      await expect(service.setTransactionSplits('parent', [
+        legAsStored,
+        { id: 'somebody-elses-line', category: 'rent', amount: -300 }
+      ], -400)).rejects.toThrow(/not part of this split any more/);
+      expect(storage.snapshot(STORAGE_KEYS.TRANSACTION_SPLITS)).toHaveLength(2);
+    });
   });
 });
 
@@ -756,5 +1128,123 @@ describe('DataService createTransferCounterpart currency guard (local mode)', ()
     expect(transactions).toHaveLength(1);
     const accounts = storage.snapshot(STORAGE_KEYS.ACCOUNTS) as Account[];
     expect(accounts.find(a => a.id === 'acct-gbp')?.balance).toBe(100);
+  });
+});
+
+
+// The demo/offline half of a LINE match. Cloud mode is one atomic RPC
+// (link_split_line_transfer, migration 20260806094058); local mode has no
+// server to be atomic on, so it validates EVERYTHING before its first persist
+// — which is what keeps demo mode honest about what the real thing will do.
+//
+// The invariant these tests exist for: the amounts are compared against the
+// LINE, never the split PARENT, whose total is SUPPOSED to differ.
+describe('DataService linkSplitLineTransfer (local mode)', () => {
+  const buildService = (storage: ReturnType<typeof createStorage>) =>
+    createDataService({
+      isSupabaseConfigured: () => false,
+      storageAdapter: storage,
+      logger: { error: vi.fn(), warn: vi.fn(), log: vi.fn() },
+      uuid: vi.fn(() => 'generated-id'),
+      now: vi.fn(() => new Date('2025-09-01T00:00:00.000Z')),
+      userIdService: {
+        ensureUserExists: vi.fn(),
+        getCurrentDatabaseUserId: vi.fn(() => null),
+        getCurrentUserIds: vi.fn(() => ({ clerkId: null, databaseId: null }))
+      }
+    });
+
+  /** £35,000 arrives; £30,000 of it settles the loan, £5,000 is interest. */
+  const lending = (over: { row?: Partial<Transaction>; line?: Partial<TransactionSplit> } = {}) =>
+    createStorage({
+      [STORAGE_KEYS.ACCOUNTS]: [
+        baseAccount({ id: 'current', name: 'Current', balance: 35000 }),
+        baseAccount({ id: 'loan', name: 'Friend Loan', balance: 30000 })
+      ],
+      [STORAGE_KEYS.TRANSACTIONS]: [
+        baseTransaction({
+          id: 'parent', accountId: 'current', amount: 35000, type: 'income',
+          category: '', isSplit: true, description: 'Repaid in full'
+        }),
+        baseTransaction({
+          id: 'loan-row', accountId: 'loan', amount: -30000, type: 'expense',
+          category: '', description: 'Repaid in full', ...over.row
+        })
+      ],
+      [STORAGE_KEYS.TRANSACTION_SPLITS]: [
+        {
+          id: 'leg', transactionId: 'parent', category: 'tofrom-loan',
+          amount: 30000, sortOrder: 1, transferAccountId: 'loan', ...over.line
+        },
+        { id: 'interest', transactionId: 'parent', category: 'interest', amount: 5000, sortOrder: 2 }
+      ],
+      [STORAGE_KEYS.CATEGORIES]: [
+        {
+          id: 'tofrom-current', name: 'To/From Current', type: 'both', level: 'detail',
+          isTransferCategory: true, accountId: 'current'
+        } as Category,
+        { id: 'interest', name: 'Interest', type: 'income', level: 'detail' } as Category
+      ]
+    });
+
+  it('links the LINE to the row, and files the row against the split\'s account', async () => {
+    const storage = lending();
+    const service = buildService(storage);
+
+    const result = await service.linkSplitLineTransfer('leg', 'loan-row');
+
+    expect(result.split).toMatchObject({ id: 'leg', transferAccountId: 'loan', linkedTransferId: 'loan-row' });
+    // The row over there points at BOTH the parent and the exact line, which
+    // is what makes the pair navigable from either end.
+    expect(result.transaction).toMatchObject({
+      id: 'loan-row',
+      type: 'transfer',
+      category: 'tofrom-current',
+      transferAccountId: 'current',
+      linkedTransferId: 'parent',
+      linkedTransferSplitId: 'leg'
+    });
+
+    const lines = storage.snapshot(STORAGE_KEYS.TRANSACTION_SPLITS) as TransactionSplit[];
+    expect(lines.find(l => l.id === 'leg')?.linkedTransferId).toBe('loan-row');
+    // The other line is untouched, and so is the parent.
+    expect(lines.find(l => l.id === 'interest')).toMatchObject({ amount: 5000, category: 'interest' });
+    const stored = storage.snapshot(STORAGE_KEYS.TRANSACTIONS) as Transaction[];
+    expect(stored.find(t => t.id === 'parent')).toMatchObject({ amount: 35000, isSplit: true });
+
+    // Balance-neutral: both rows already existed with these amounts.
+    const accounts = storage.snapshot(STORAGE_KEYS.ACCOUNTS) as Account[];
+    expect(accounts.find(a => a.id === 'current')?.balance).toBe(35000);
+    expect(accounts.find(a => a.id === 'loan')?.balance).toBe(30000);
+  });
+
+  it.each([
+    ['the row is a penny out', { row: { amount: -29999.99 } }, /exactly opposite/],
+    ['the row matches the PARENT, not the line', { row: { amount: -35000 } }, /exactly opposite/],
+    ['the row sits in a different account from the one the line names', { row: { accountId: 'other' } }, /different account/],
+    ['the row is in the split\'s own account', { row: { accountId: 'current' } }, /two different accounts/],
+    ['the row is already half of a transfer', { row: { linkedTransferId: 'someone' } }, /already part of a linked transfer/],
+    ['the row is already some other line\'s opposite', { row: { linkedTransferSplitId: 'other-line' } }, /already part of a linked transfer/],
+    ['the row is itself split', { row: { isSplit: true } }, /split transaction cannot become a transfer/],
+    ['the row is archived', { row: { archived: true } }, /archived/],
+    ['the line is already linked', { line: { linkedTransferId: 'counterpart' } }, /already one half of a transfer/],
+  ])('refuses when %s — and writes nothing at all', async (_case, over, message) => {
+    const storage = lending(over);
+    const service = buildService(storage);
+
+    await expect(service.linkSplitLineTransfer('leg', 'loan-row')).rejects.toThrow(message);
+
+    const lines = storage.snapshot(STORAGE_KEYS.TRANSACTION_SPLITS) as TransactionSplit[];
+    expect(lines.find(l => l.id === 'leg')?.linkedTransferId).toBe(over.line?.linkedTransferId);
+    const stored = storage.snapshot(STORAGE_KEYS.TRANSACTIONS) as Transaction[];
+    expect(stored.find(t => t.id === 'loan-row')?.type).not.toBe('transfer');
+  });
+
+  it('refuses a line or a row that is not there', async () => {
+    const service = buildService(lending());
+    await expect(service.linkSplitLineTransfer('nope', 'loan-row'))
+      .rejects.toThrow(/split line no longer exists/);
+    await expect(service.linkSplitLineTransfer('leg', 'nope'))
+      .rejects.toThrow(/Transaction not found/);
   });
 });

--- a/src/services/__tests__/transactionService.test.ts
+++ b/src/services/__tests__/transactionService.test.ts
@@ -945,6 +945,7 @@ describe('TransactionService — owner id cannot be silently omitted', () => {
       { category: 'cat-2', amount: 15 }
     ], 25)],
     ['linkTransferPair', s => s.linkTransferPair('txn-1', 'txn-2')],
+    ['linkSplitLineTransfer', s => s.linkSplitLineTransfer('split-1', 'txn-2')],
     ['clearTransferLinks', s => s.clearTransferLinks(['txn-1'])],
     ['setTransactionArchived', s => s.setTransactionArchived('txn-1', true)],
     ['repairClaimedTransfer', s => s.repairClaimedTransfer('txn-1', 'txn-2', 'txn-3', 'cat-1')],
@@ -1063,6 +1064,40 @@ describe('TransactionService — transfer repair goes through audited RPCs', () 
     expect(result.stranded.date).toBeInstanceOf(Date);
     expect(result.counterpart.id).toBe('counterpart');
     expect(result.partner.id).toBe('partner');
+  });
+
+  it('links a split LINE in ONE call and converts both rows it returns', async () => {
+    const { service, rpc } = createRpcService({
+      split: {
+        id: 'leg', transaction_id: 'parent', category: 'tofrom-current',
+        amount: '30000.00', sort_order: 1,
+        transfer_account_id: 'loan', linked_transfer_id: 'loan-row'
+      },
+      transaction: {
+        id: 'loan-row', account_id: 'loan', amount: -30000, type: 'transfer',
+        date: '2026-07-10', description: 'Repaid in full',
+        transfer_account_id: 'current', linked_transfer_id: 'parent',
+        linked_transfer_split_id: 'leg'
+      }
+    });
+
+    const result = await service.linkSplitLineTransfer('leg', 'loan-row', 'user-1');
+
+    expect(rpc).toHaveBeenCalledTimes(1);
+    expect(rpc).toHaveBeenCalledWith('link_split_line_transfer', {
+      p_split_id: 'leg',
+      p_transaction_id: 'loan-row',
+      p_user_id: 'user-1'
+    });
+    // numeric columns arrive as strings from PostgREST; the line is the thing
+    // whose amount has to survive that intact.
+    expect(result.split).toMatchObject({
+      id: 'leg', amount: 30000, transferAccountId: 'loan', linkedTransferId: 'loan-row'
+    });
+    expect(result.transaction).toMatchObject({
+      id: 'loan-row', type: 'transfer', linkedTransferId: 'parent', linkedTransferSplitId: 'leg'
+    });
+    expect(result.transaction.date).toBeInstanceOf(Date);
   });
 
   it('surfaces the database refusal verbatim', async () => {

--- a/src/services/api/dataService.ts
+++ b/src/services/api/dataService.ts
@@ -13,9 +13,10 @@ import { isSupabaseConfigured } from './supabaseClient';
 import { hasSupabaseTokenGetter } from '../../lib/supabaseToken';
 import { storageAdapter, STORAGE_KEYS } from '../storageAdapter';
 import { userIdService } from '../userIdService';
-import { toDecimal } from '../../utils/decimal';
+import { toDecimal, type DecimalInstance } from '../../utils/decimal';
 import { normalizeTransactionDates, toDateValue } from '../../utils/dateBoundary';
-import type { Account, Transaction, TransactionSplit, TransactionSplitInput, Budget, Goal, Category, CategoryMergeResult } from '../../types';
+import { splitDeclaresTransferLeg } from '../../utils/transactionSplits';
+import type { Account, Transaction, TransactionSplit, TransactionSplitInput, SplitWriteResult, Budget, Goal, Category, CategoryMergeResult } from '../../types';
 
 export interface AppData {
   accounts: Account[];
@@ -37,7 +38,7 @@ type AccountServiceLike = Pick<typeof AccountService,
   subscribeToAccounts?: (userId: string, callback: (payload: unknown) => void) => () => void;
 };
 type TransactionServiceLike = Pick<typeof TransactionService,
-  'getTransactions' | 'createTransaction' | 'updateTransaction' | 'deleteTransaction' | 'setTransactionsCleared' | 'applyCategoryToUncategorized' | 'getTransactionSplits' | 'setTransactionSplits' | 'getAllTransactionSplits' | 'linkTransferPair' | 'clearTransferLinks' | 'setTransactionArchived' | 'repairClaimedTransfer' | 'createTransferCounterpart' | 'archiveTransactionsBefore' | 'unarchiveAccount'> & {
+  'getTransactions' | 'createTransaction' | 'updateTransaction' | 'deleteTransaction' | 'setTransactionsCleared' | 'applyCategoryToUncategorized' | 'getTransactionSplits' | 'setTransactionSplits' | 'setTransactionSplitsWithLegs' | 'getAllTransactionSplits' | 'linkTransferPair' | 'linkSplitLineTransfer' | 'clearTransferLinks' | 'setTransactionArchived' | 'repairClaimedTransfer' | 'createTransferCounterpart' | 'archiveTransactionsBefore' | 'unarchiveAccount'> & {
   subscribeToTransactions?: (userId: string, callback: (payload: unknown) => void) => () => void;
   /**
    * Optional so an injected test double stays a partial stand-in; without it
@@ -530,21 +531,55 @@ class DataServiceImpl {
 
   /**
    * Replace a transaction's splits atomically (empty array un-splits it).
-   * Server-side the RPC validates ≥2 lines / non-zero amounts / sum ==
-   * expectedAmount and syncs the amount + account balance; the local path
-   * mirrors those rules so demo/offline behave identically.
+   *
+   * Two server paths, chosen by the line set itself: one that declares a
+   * TRANSFER LEG goes to set_transaction_splits_with_legs, which matches lines
+   * by id (so an ordinary line beside a leg can be re-filed) and creates the
+   * counterpart for any line that becomes a leg; everything else takes
+   * set_transaction_splits, which replaces the set exactly as it always has.
+   * The local path mirrors both sets of rules in ONE implementation so
+   * demo/offline behave identically.
    */
   async setTransactionSplits(
     transactionId: string,
     splits: TransactionSplitInput[],
     expectedAmount: number | null
-  ): Promise<{ isSplit: boolean; splitCount: number; amount: number }> {
+  ): Promise<SplitWriteResult> {
     const userId = this.userIdService.getCurrentDatabaseUserId();
     if (userId && this.supabaseChecker()) {
-      return this.transactionService.setTransactionSplits(transactionId, splits, expectedAmount, userId);
+      if (splitDeclaresTransferLeg(splits)) {
+        return this.transactionService.setTransactionSplitsWithLegs(
+          transactionId, splits, expectedAmount, userId
+        );
+      }
+      const result = await this.transactionService.setTransactionSplits(
+        transactionId, splits, expectedAmount, userId
+      );
+      return { ...result, counterparts: [] };
     }
     this.guardCloudWrite();
+    return this.setTransactionSplitsLocally(transactionId, splits, expectedAmount);
+  }
 
+  /**
+   * The local/demo half of the split write — the mirror of
+   * set_transaction_splits AND set_transaction_splits_with_legs, kept in one
+   * place because they differ only in what they allow, not in what they mean.
+   *
+   * All-or-nothing: every check runs BEFORE the first persist, so a refusal
+   * leaves browser storage exactly as it was (the same stance as
+   * repairClaimedTransfer and mergeCategories).
+   *
+   * The rule about legs, precisely: a line already linked to a counterpart may
+   * change only its position and memo. Removing one, or changing its amount,
+   * target or category, strands or falsifies the transaction on the other side
+   * and is refused by name. Every other line in the same split is free.
+   */
+  private async setTransactionSplitsLocally(
+    transactionId: string,
+    splits: TransactionSplitInput[],
+    expectedAmount: number | null
+  ): Promise<SplitWriteResult> {
     const transactions = await this.readLocalTransactions();
     const index = transactions.findIndex(t => t.id === transactionId);
     if (index === -1) {
@@ -556,67 +591,201 @@ class DataServiceImpl {
     }
 
     const stored = await this.readCollection<TransactionSplit>(STORAGE_KEYS.TRANSACTION_SPLITS);
-    // A line that is one leg of a linked transfer is structural — replacing or
-    // removing it would strand the opposite transaction. Same v1 stance as
-    // moving a linked transfer: delete/unlink first, then edit.
-    if (stored.some(s => s.transactionId === transactionId && s.linkedTransferId)) {
-      throw new Error(
-        'This split contains a linked transfer line — delete the linked transfer first, then edit the split.'
-      );
-    }
+    const mine = stored.filter(s => s.transactionId === transactionId);
     const others = stored.filter(s => s.transactionId !== transactionId);
+    const accounts = await this.readCollection<Account>(STORAGE_KEYS.ACCOUNTS);
+    const categories = await this.readCollection<Category>(STORAGE_KEYS.CATEGORIES);
+    const accountName = (id: string | undefined): string =>
+      accounts.find(a => a.id === id)?.name ?? 'another account';
+
+    const keptIds = new Set(splits.map(s => s.id).filter((id): id is string => Boolean(id)));
+    if (keptIds.size !== splits.filter(s => s.id).length) {
+      throw new Error('Two of these lines claim to be the same stored line — reload and look again');
+    }
+    // Dropping a linked leg leaves its counterpart pointing at a line that no
+    // longer exists. Named before anything is written.
+    for (const line of mine) {
+      if (line.linkedTransferId && !keptIds.has(line.id)) {
+        throw new Error(
+          `The line transferring to "${accountName(line.transferAccountId)}" is one half of a transfer — the transaction on the other side would be left pointing at a line that no longer exists. Delete that transfer first, then edit the split.`
+        );
+      }
+    }
 
     if (splits.length === 0) {
       await this.persistCollection(STORAGE_KEYS.TRANSACTION_SPLITS, others);
       transactions[index] = { ...transaction, isSplit: false } as Transaction;
       await this.persistCollection(STORAGE_KEYS.TRANSACTIONS, transactions);
-      return { isSplit: false, splitCount: 0, amount: transaction.amount };
+      return { isSplit: false, splitCount: 0, amount: transaction.amount, counterparts: [] };
     }
 
     if (splits.length < 2) {
       throw new Error('A split needs at least 2 lines');
     }
+
     let sum = toDecimal(0);
-    for (const split of splits) {
+    const nextLines: TransactionSplit[] = [];
+    const counterparts: Transaction[] = [];
+    // account id → the delta this write owes it, applied in ONE pass at the end.
+    const balanceDeltas = new Map<string, DecimalInstance>();
+
+    for (const [i, split] of splits.entries()) {
       if (!split.category.trim()) {
         throw new Error('Every split line needs a category');
       }
       if (!split.amount) {
         throw new Error('Every split line needs a non-zero amount');
       }
+
+      const previous = split.id ? mine.find(s => s.id === split.id) : undefined;
+      if (split.id && !previous) {
+        throw new Error('One of these lines is not part of this split any more — reload and look again');
+      }
+
+      const target = split.transferAccountId;
+      const targetAccount = target ? accounts.find(a => a.id === target) : undefined;
+      if (target) {
+        if (!targetAccount) {
+          throw new Error('A transfer line names an account that is not yours, or no longer exists');
+        }
+        if (target === transaction.accountId) {
+          throw new Error('A transfer needs two different accounts');
+        }
+      }
+      // A To/From category names an account, so it must name the same one the
+      // line does. Unlike the server, a category that is simply absent from
+      // local storage is not fatal — demo/offline fixtures routinely carry
+      // transactions without the tree they were filed against.
+      const category = categories.find(c => c.id === split.category);
+      if (category?.isTransferCategory === true) {
+        if (!target) {
+          throw new Error('That line is filed under a To/From account category but does not say which account is on the other side');
+        }
+        if (category.accountId !== target) {
+          throw new Error('That line is filed under one account\'s To/From category but transfers to a different account');
+        }
+      }
+
+      const memo = split.memo ? { memo: split.memo } : {};
+      const sortOrder = i + 1;
+
+      if (previous?.linkedTransferId) {
+        // Pinned by the row on the other side: position and memo may move,
+        // nothing else may.
+        if (!toDecimal(split.amount).equals(toDecimal(previous.amount))) {
+          throw new Error(
+            `The line transferring to "${accountName(previous.transferAccountId)}" has to stay as it is, because the transaction on the other side is for exactly that much — change the other lines, or delete that transfer first.`
+          );
+        }
+        if (target !== previous.transferAccountId) {
+          throw new Error(
+            `That line is already linked to a transaction in "${accountName(previous.transferAccountId)}" — moving it would strand that row. Delete that transfer first, then edit the split.`
+          );
+        }
+        if (split.category !== previous.category) {
+          throw new Error(
+            'That line is one half of a transfer — its category names the account on the other side. Delete that transfer first, then re-file it.'
+          );
+        }
+        nextLines.push({ ...previous, ...memo, sortOrder });
+      } else {
+        const line: TransactionSplit = {
+          id: previous?.id ?? this.generateId(),
+          transactionId,
+          category: split.category,
+          amount: split.amount,
+          ...memo,
+          sortOrder,
+          ...(target ? { transferAccountId: target } : {}),
+        };
+
+        // A line that BECOMES a leg gets its other side made now. A line that
+        // already pointed at this account keeps whatever link state it has —
+        // creating a second counterpart would invent money.
+        if (target && previous?.transferAccountId !== target) {
+          const sourceAccount = accounts.find(a => a.id === transaction.accountId);
+          if (
+            sourceAccount?.currency && targetAccount?.currency &&
+            sourceAccount.currency !== targetAccount.currency
+          ) {
+            throw new Error(
+              `Transfers between accounts in different currencies are not supported yet (${sourceAccount.currency} and ${targetAccount.currency})`
+            );
+          }
+          // Opposite of the LINE, never of the parent — whose total includes
+          // the other lines, and is supposed to differ.
+          const counterpartAmount = toDecimal(split.amount).negated().toNumber();
+          const counterpart: Transaction = {
+            id: this.generateId(),
+            date: transaction.date,
+            description: transaction.description,
+            amount: counterpartAmount,
+            type: 'transfer',
+            category: this.localTransferCategoryFrom(categories, transaction.accountId, counterpartAmount),
+            accountId: target,
+            notes: split.memo ?? transaction.notes,
+            cleared: false,
+            transferAccountId: transaction.accountId,
+            linkedTransferId: transactionId,
+            linkedTransferSplitId: line.id,
+          };
+          line.linkedTransferId = counterpart.id;
+          counterparts.push(counterpart);
+          balanceDeltas.set(
+            target,
+            (balanceDeltas.get(target) ?? toDecimal(0)).plus(toDecimal(counterpartAmount))
+          );
+        }
+
+        nextLines.push(line);
+      }
+
       sum = sum.plus(toDecimal(split.amount));
     }
+
     if (expectedAmount !== null && !sum.equals(toDecimal(expectedAmount))) {
       throw new Error('The split lines must sum to the transaction amount');
     }
 
-    const newSplits: TransactionSplit[] = splits.map((split, i) => ({
-      id: this.generateId(),
-      transactionId,
-      category: split.category,
-      amount: split.amount,
-      ...(split.memo ? { memo: split.memo } : {}),
-      sortOrder: i + 1,
-    }));
-    await this.persistCollection(STORAGE_KEYS.TRANSACTION_SPLITS, [...others, ...newSplits]);
-
+    // ── Past every refusal: persist ───────────────────────────────────────────
     const newAmount = sum.toNumber();
-    transactions[index] = { ...transaction, isSplit: true, category: '', amount: newAmount } as Transaction;
-    await this.persistCollection(STORAGE_KEYS.TRANSACTIONS, transactions);
     if (newAmount !== transaction.amount) {
-      await this.updateAccountBalance(
+      balanceDeltas.set(
         transaction.accountId,
-        sum.minus(toDecimal(transaction.amount)).toNumber()
+        (balanceDeltas.get(transaction.accountId) ?? toDecimal(0))
+          .plus(sum.minus(toDecimal(transaction.amount)))
       );
     }
-    return { isSplit: true, splitCount: newSplits.length, amount: newAmount };
+
+    await this.persistCollection(STORAGE_KEYS.TRANSACTION_SPLITS, [...others, ...nextLines]);
+    transactions[index] = { ...transaction, isSplit: true, category: '', amount: newAmount } as Transaction;
+    await this.persistCollection(STORAGE_KEYS.TRANSACTIONS, [...transactions, ...counterparts]);
+    if (balanceDeltas.size > 0) {
+      await this.persistCollection(
+        STORAGE_KEYS.ACCOUNTS,
+        accounts.map(account => {
+          const delta = balanceDeltas.get(account.id);
+          // Decimal arithmetic — IEEE-754 float math is banned on money values.
+          return delta
+            ? { ...account, balance: toDecimal(account.balance || 0).plus(delta).toNumber() }
+            : account;
+        })
+      );
+    }
+
+    return { isSplit: true, splitCount: nextLines.length, amount: newAmount, counterparts };
   }
 
   /** The account-managed To/From category id, or the legacy sentinel. */
-  private async localTransferCategoryFor(accountId: string, amount: number): Promise<string> {
-    const categories = await this.readCollection<Category>(STORAGE_KEYS.CATEGORIES);
+  private localTransferCategoryFrom(categories: Category[], accountId: string, amount: number): string {
     const transferCategory = categories.find(c => c.isTransferCategory === true && c.accountId === accountId);
     return transferCategory?.id ?? (amount < 0 ? 'transfer-out' : 'transfer-in');
+  }
+
+  /** As above, reading the category collection itself. */
+  private async localTransferCategoryFor(accountId: string, amount: number): Promise<string> {
+    const categories = await this.readCollection<Category>(STORAGE_KEYS.CATEGORIES);
+    return this.localTransferCategoryFrom(categories, accountId, amount);
   }
 
   /**
@@ -670,6 +839,94 @@ class DataServiceImpl {
       transactions.map(t => (t.id === idA ? newA : t.id === idB ? newB : t))
     );
     return { a: newA, b: newB };
+  }
+
+  /**
+   * Join an existing split LINE to an existing transaction as the two halves
+   * of a transfer. Mirrors the link_split_line_transfer RPC's invariants
+   * locally so demo/offline behave identically.
+   *
+   * The amounts are compared against the LINE, never the split PARENT: the
+   * parent's total includes the other lines and is SUPPOSED to differ. Like
+   * the RPC, this is balance-neutral (nothing about any amount or account
+   * moves) and all-or-nothing: every check runs before the first persist.
+   */
+  async linkSplitLineTransfer(
+    splitId: string,
+    transactionId: string
+  ): Promise<{ split: TransactionSplit; transaction: Transaction }> {
+    const userId = this.userIdService.getCurrentDatabaseUserId();
+    if (userId && this.supabaseChecker()) {
+      return this.transactionService.linkSplitLineTransfer(splitId, transactionId, userId);
+    }
+    this.guardCloudWrite();
+
+    const splits = await this.readCollection<TransactionSplit>(STORAGE_KEYS.TRANSACTION_SPLITS);
+    const line = splits.find(s => s.id === splitId);
+    if (!line) {
+      throw new Error('That split line no longer exists');
+    }
+    const transactions = await this.readLocalTransactions();
+    const parent = transactions.find(t => t.id === line.transactionId);
+    if (!parent) {
+      throw new Error('The split that line belongs to no longer exists');
+    }
+    const transaction = transactions.find(t => t.id === transactionId);
+    if (!transaction) {
+      throw new Error('Transaction not found');
+    }
+    if (transaction.id === parent.id) {
+      throw new Error('A transaction cannot be linked to itself');
+    }
+    if (line.linkedTransferId) {
+      throw new Error('That line is already one half of a transfer — reload and look again');
+    }
+    if (transaction.linkedTransferId || transaction.linkedTransferSplitId) {
+      throw new Error('Transaction is already part of a linked transfer');
+    }
+    if (transaction.isSplit) {
+      throw new Error('A split transaction cannot become a transfer — remove the split first');
+    }
+    if (transaction.archived === true) {
+      throw new Error('That row is archived — bring it back into the register before pairing it');
+    }
+    if (transaction.accountId === parent.accountId) {
+      throw new Error('A transfer needs two different accounts');
+    }
+    if (line.transferAccountId && line.transferAccountId !== transaction.accountId) {
+      throw new Error('That line transfers to a different account from the one that row sits in');
+    }
+    const lineAmount = toDecimal(line.amount);
+    if (lineAmount.isZero() || !toDecimal(transaction.amount).equals(lineAmount.negated())) {
+      throw new Error('Transfer sides must have exactly opposite non-zero amounts');
+    }
+
+    // ── Past every refusal: persist ───────────────────────────────────────────
+    const newLine: TransactionSplit = {
+      ...line,
+      transferAccountId: transaction.accountId,
+      linkedTransferId: transaction.id,
+    };
+    // The row over there files under the To/From category of the account the
+    // SPLIT sits in, and points back at both the parent and the exact line.
+    const newTransaction: Transaction = {
+      ...transaction,
+      type: 'transfer',
+      category: await this.localTransferCategoryFor(parent.accountId, transaction.amount),
+      transferAccountId: parent.accountId,
+      linkedTransferId: parent.id,
+      linkedTransferSplitId: line.id,
+    };
+
+    await this.persistCollection(
+      STORAGE_KEYS.TRANSACTION_SPLITS,
+      splits.map(s => (s.id === splitId ? newLine : s))
+    );
+    await this.persistCollection(
+      STORAGE_KEYS.TRANSACTIONS,
+      transactions.map(t => (t.id === transactionId ? newTransaction : t))
+    );
+    return { split: newLine, transaction: newTransaction };
   }
 
   /**
@@ -1182,6 +1439,13 @@ export class DataService {
     return this.service.linkTransferPair(idA, idB);
   }
 
+  static linkSplitLineTransfer(
+    splitId: string,
+    transactionId: string
+  ): Promise<{ split: TransactionSplit; transaction: Transaction }> {
+    return this.service.linkSplitLineTransfer(splitId, transactionId);
+  }
+
   static unlinkTransfers(ids: string[]): Promise<number> {
     return this.service.unlinkTransfers(ids);
   }
@@ -1216,7 +1480,7 @@ export class DataService {
     transactionId: string,
     splits: TransactionSplitInput[],
     expectedAmount: number | null
-  ): Promise<{ isSplit: boolean; splitCount: number; amount: number }> {
+  ): Promise<SplitWriteResult> {
     return this.service.setTransactionSplits(transactionId, splits, expectedAmount);
   }
 

--- a/src/services/api/supabaseClient.ts
+++ b/src/services/api/supabaseClient.ts
@@ -52,8 +52,37 @@ type Database = {
         };
         Returns: Record<string, unknown>;
       };
+      // The split writer that understands TRANSFER LEGS. Two fields the plain
+      // set_transaction_splits payload has no use for: `id` names the stored
+      // line an element replaces (so lines are matched, not wholesale
+      // replaced), and `transfer_account_id` makes a line one leg of a
+      // transfer — spelled the database's way, because that is how it reads
+      // back out of the audit log.
+      set_transaction_splits_with_legs: {
+        Args: {
+          p_transaction_id: string;
+          p_splits: {
+            category: string;
+            amount: number;
+            memo?: string;
+            id?: string;
+            transfer_account_id?: string;
+          }[];
+          p_expected_amount: number | null;
+          p_user_id: string;
+        };
+        Returns: Record<string, unknown>;
+      };
       link_transfer_pair: {
         Args: { p_id_a: string; p_id_b: string; p_user_id: string };
+        Returns: Record<string, unknown>;
+      };
+      // The split-line counterpart of link_transfer_pair: pairs an existing
+      // split LINE with an existing transaction (amounts opposite between the
+      // LINE and the row, never the parent). Declared here because the
+      // database has it; the transfer-matching sweep is its caller.
+      link_split_line_transfer: {
+        Args: { p_split_id: string; p_transaction_id: string; p_user_id: string };
         Returns: Record<string, unknown>;
       };
       create_transfer_counterpart: {

--- a/src/services/api/transactionService.ts
+++ b/src/services/api/transactionService.ts
@@ -946,6 +946,71 @@ class TransactionServiceImpl {
   }
 
   /**
+   * Write a split whose lines may include TRANSFER LEGS — one line that is
+   * itself half of a transfer with another account (the Microsoft Money
+   * model).
+   *
+   * A separate RPC from setTransactionSplits, not a widening of it, because
+   * the two have different semantics on purpose: set_transaction_splits
+   * REPLACES the line set (and so must refuse any split containing a leg,
+   * since it cannot tell an edited line from a deleted one), while
+   * set_transaction_splits_with_legs matches incoming lines to stored ones by
+   * id — which is what lets an ordinary line be re-filed while the leg beside
+   * it stays exactly as it is. Leaving the old path strict means a stale
+   * browser tab still fails safe.
+   *
+   * Line ids and transfer targets ride in the payload in the database's own
+   * spelling (snake_case), so the audit entries the RPC writes read the same
+   * as the columns they came from. Cloud-only — DataService owns the
+   * local/demo mirror of these rules.
+   *
+   * Returns the counterpart rows the database created, so the caller updates
+   * its state (and those accounts' balances) from what was actually written.
+   */
+  async setTransactionSplitsWithLegs(
+    transactionId: string,
+    splits: TransactionSplitInput[],
+    expectedAmount: number | null,
+    userId?: string
+  ): Promise<{ isSplit: boolean; splitCount: number; amount: number; counterparts: Transaction[] }> {
+    if (!this.isSupabaseReady()) {
+      throw new Error('setTransactionSplitsWithLegs requires the cloud connection (local mode goes through DataService)');
+    }
+    try {
+      const payload = splits.map(split => ({
+        category: split.category,
+        amount: split.amount,
+        ...(split.memo ? { memo: split.memo } : {}),
+        ...(split.id ? { id: split.id } : {}),
+        ...(split.transferAccountId ? { transfer_account_id: split.transferAccountId } : {}),
+      }));
+      const { data, error } = await this.supabaseClient!.rpc('set_transaction_splits_with_legs', {
+        p_transaction_id: transactionId,
+        p_splits: payload,
+        p_expected_amount: expectedAmount,
+        p_user_id: this.requireOwnerId(userId, 'setTransactionSplitsWithLegs'),
+      });
+
+      if (error) {
+        this.logger.error('Error setting transaction splits with legs:', error);
+        throw new Error(handleSupabaseError(error));
+      }
+
+      const result = (data ?? {}) as Record<string, unknown>;
+      const rows: unknown[] = Array.isArray(result.counterparts) ? result.counterparts : [];
+      return {
+        isSplit: Boolean(result.is_split),
+        splitCount: Number(result.split_count ?? 0),
+        amount: Number(result.amount ?? expectedAmount ?? 0),
+        counterparts: this.toTransactions(rows.filter(isRecord)),
+      };
+    } catch (error) {
+      this.logger.error('TransactionService.setTransactionSplitsWithLegs error:', error as Error);
+      throw error;
+    }
+  }
+
+  /**
    * Join two existing rows into a linked transfer pair (both sides already
    * exist). Amount/account/link invariants are enforced by the RPC; balance-
    * neutral by construction. Cloud-only here — the local/demo path lives in
@@ -1143,6 +1208,52 @@ class TransactionServiceImpl {
       };
     } catch (error) {
       this.logger.error('TransactionService.linkTransferPair error:', error as Error);
+      throw error;
+    }
+  }
+
+  /**
+   * Join an existing split LINE to an existing transaction as the two halves
+   * of a transfer — the split-line counterpart of linkTransferPair, and what
+   * the transfer-matching sweep applies for a line suggestion.
+   *
+   * The amounts must be exactly opposite between the LINE and the row, never
+   * between the row and the split PARENT, whose total legitimately differs
+   * (£35,000 arrives, £30,000 of it settles a loan). The RPC enforces that and
+   * every other precondition against the rows as they are NOW, so a stale list
+   * is refused rather than acted on; balance-neutral by construction, since no
+   * amount, sign or account is written. Cloud-only here — the local/demo path
+   * lives in DataService.
+   *
+   * Returns the line and the row the database actually wrote, so the caller
+   * updates its state from them rather than guessing at the re-typing and
+   * re-categorising the RPC does.
+   */
+  async linkSplitLineTransfer(
+    splitId: string,
+    transactionId: string,
+    userId?: string
+  ): Promise<{ split: TransactionSplit; transaction: Transaction }> {
+    if (!this.isSupabaseReady()) {
+      throw new Error('linkSplitLineTransfer requires the cloud connection (local mode goes through DataService)');
+    }
+    try {
+      const { data, error } = await this.supabaseClient!.rpc('link_split_line_transfer', {
+        p_split_id: splitId,
+        p_transaction_id: transactionId,
+        p_user_id: this.requireOwnerId(userId, 'linkSplitLineTransfer'),
+      });
+      if (error) {
+        this.logger.error('Error linking split line transfer:', error);
+        throw new Error(handleSupabaseError(error));
+      }
+      const result = (data ?? {}) as { split?: Record<string, unknown>; transaction?: Record<string, unknown> };
+      return {
+        split: this.mapSplitRow(result.split ?? {}),
+        transaction: mapFromDbFields(result.transaction ?? {}) as unknown as Transaction,
+      };
+    } catch (error) {
+      this.logger.error('TransactionService.linkSplitLineTransfer error:', error as Error);
       throw error;
     }
   }
@@ -1493,6 +1604,14 @@ export class TransactionService {
     return this.service.linkTransferPair(idA, idB, userId);
   }
 
+  static linkSplitLineTransfer(
+    splitId: string,
+    transactionId: string,
+    userId?: string
+  ): Promise<{ split: TransactionSplit; transaction: Transaction }> {
+    return this.service.linkSplitLineTransfer(splitId, transactionId, userId);
+  }
+
   static repairClaimedTransfer(
     strandedId: string,
     counterpartId: string,
@@ -1532,6 +1651,15 @@ export class TransactionService {
     userId?: string
   ): Promise<{ isSplit: boolean; splitCount: number; amount: number }> {
     return this.service.setTransactionSplits(transactionId, splits, expectedAmount, userId);
+  }
+
+  static setTransactionSplitsWithLegs(
+    transactionId: string,
+    splits: TransactionSplitInput[],
+    expectedAmount: number | null,
+    userId?: string
+  ): Promise<{ isSplit: boolean; splitCount: number; amount: number; counterparts: Transaction[] }> {
+    return this.service.setTransactionSplitsWithLegs(transactionId, splits, expectedAmount, userId);
   }
 
   static getTransactionsByDateRange(userId: string, startDate: Date, endDate: Date): Promise<Transaction[]> {

--- a/src/test/mocks/AppContextSupabase.ts
+++ b/src/test/mocks/AppContextSupabase.ts
@@ -48,6 +48,7 @@ const baseValue = {
   getTransactionSplits: async () => [],
   setTransactionSplits: async () => ({ isSplit: false, splitCount: 0, amount: 0 }),
   linkTransferPair: async () => { throw new Error('not available in mock'); },
+  linkSplitLineTransfer: async () => { throw new Error('not available in mock'); },
   unlinkTransfers: async () => 0,
   setTransactionArchived: asyncNoop,
   repairClaimedTransfer: asyncNoop,

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -195,6 +195,34 @@ export interface TransactionSplitInput {
   category: string;
   amount: number;
   memo?: string;
+  /**
+   * The line this input replaces, when it came from an existing split. Sending
+   * it is what lets the writer tell "this line was edited" from "this line was
+   * removed and another arrived" — the distinction a split containing a
+   * transfer leg depends on, because a removed leg strands its counterpart.
+   * Omitted for brand-new lines (the id is then server-assigned).
+   */
+  id?: string;
+  /**
+   * Set to make this LINE one leg of a transfer: the account on the other
+   * side. A line that gains a target has its counterpart created and linked in
+   * the same write; a line that already carries this target keeps whatever
+   * link it has (never a second counterpart).
+   */
+  transferAccountId?: string;
+}
+
+/**
+ * What a split write actually did. `counterparts` holds the transactions
+ * created for lines that BECAME transfer legs in this write — real rows in
+ * other accounts, so the caller updates its state and those accounts'
+ * balances from them rather than guessing. Empty for every ordinary split.
+ */
+export interface SplitWriteResult {
+  isSplit: boolean;
+  splitCount: number;
+  amount: number;
+  counterparts: Transaction[];
 }
 
 export interface Budget {

--- a/src/utils/strandedTransfers.test.ts
+++ b/src/utils/strandedTransfers.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from 'vitest';
-import { findStrandedTransfers, resolveAdjustmentCategory } from './strandedTransfers';
+import { findStrandedTransfers, findUnmatchedSplitLegs, resolveAdjustmentCategory } from './strandedTransfers';
 import { sweepTransferPairs } from './transferSweep';
-import type { Category, Transaction } from '../types';
+import type { Category, Transaction, TransactionSplit } from '../types';
 
 const txn = (over: Partial<Transaction> & { id: string }): Transaction => ({
   date: new Date('2026-07-10'),
@@ -382,5 +382,118 @@ describe('findStrandedTransfers — ordering and determinism', () => {
       txn({ id: 'twin-b', amount: 200, accountId: 'acc-c', type: 'income', date: new Date('2026-05-02'), category: 'cat-groceries' }),
     ], CATEGORIES);
     expect(findings.filter(f => f.row.id === 'stranded')).toHaveLength(1);
+  });
+});
+
+/**
+ * Unmatched split legs — the one-sided family, for a LINE.
+ *
+ * Every case here ends in a SENTENCE and nothing else: there is no action, by
+ * design (see findUnmatchedSplitLegs), so what these tests pin is that the app
+ * never says something it cannot know — "nothing matches" only when nothing
+ * does, and the precise obstacle when there is one.
+ */
+describe('findUnmatchedSplitLegs', () => {
+  const PARENT: Transaction = txn({
+    id: 'repayment', accountId: 'acc-a', amount: 35000, type: 'income',
+    description: 'Repaid in full', isSplit: true, date: new Date('2026-07-10'),
+  });
+
+  const leg = (over: Partial<TransactionSplit> = {}): TransactionSplit => ({
+    id: 'leg', transactionId: 'repayment', category: 'cat-groceries',
+    amount: 30000, sortOrder: 1, transferAccountId: 'acc-b', ...over,
+  });
+
+  const opposite = (over: Partial<Transaction> = {}): Transaction =>
+    txn({ id: 'over-there', accountId: 'acc-b', amount: -30000, description: 'Repaid in full', ...over });
+
+  it('says nothing matches when the account really is empty', () => {
+    const { findings, scanned } = findUnmatchedSplitLegs([PARENT], [leg()], CATEGORIES);
+    expect(scanned).toBe(1);
+    expect(findings).toHaveLength(1);
+    expect(findings[0]).toMatchObject({ kind: 'unmatched-leg', reason: 'nothing-matches', target: 'acc-b' });
+    expect(findings[0].split.id).toBe('leg');
+    expect(findings[0].parent.id).toBe('repayment');
+  });
+
+  it('reports nothing at all for a leg the sweep can match', () => {
+    const { findings, scanned } = findUnmatchedSplitLegs([PARENT, opposite()], [leg()], CATEGORIES);
+    expect(scanned).toBe(0);
+    expect(findings).toEqual([]);
+  });
+
+  it('reports nothing for a linked leg — it has its other side', () => {
+    const { findings } = findUnmatchedSplitLegs(
+      [PARENT], [leg({ linkedTransferId: 'counterpart' })], CATEGORIES
+    );
+    expect(findings).toEqual([]);
+  });
+
+  it.each([
+    ['linked', { linkedTransferId: 'someone', type: 'transfer' as const }],
+    ['split', { isSplit: true }],
+    ['archived', { archived: true }],
+  ])('names the obstacle when the matching row is %s', (reason, over) => {
+    const { findings } = findUnmatchedSplitLegs([PARENT, opposite(over)], [leg()], CATEGORIES);
+    expect(findings).toHaveLength(1);
+    expect(findings[0].reason).toBe(reason);
+    expect(findings[0].parent.id).toBe('repayment');
+  });
+
+  it('names the category when the matching row is filed under one', () => {
+    const { findings } = findUnmatchedSplitLegs(
+      [PARENT, opposite({ category: 'cat-dental' })], [leg()], CATEGORIES
+    );
+    expect(findings).toHaveLength(1);
+    const [finding] = findings;
+    expect(finding.reason).toBe('filed');
+    if (finding.reason !== 'filed') throw new Error('expected a filed finding');
+    expect(finding.blockerCategoryName).toBe('Dental');
+    expect(finding.blocker.id).toBe('over-there');
+  });
+
+  it('says "taken" when the row it wanted went to another match', () => {
+    // Two lines want the same £30,000 row. One gets it; the other is told why
+    // it did not, rather than being told the loan account is empty.
+    const second: Transaction = txn({
+      id: 'repayment-2', accountId: 'acc-a', amount: 35000, type: 'income',
+      description: 'Repaid in full', isSplit: true, date: new Date('2026-07-10'),
+    });
+    const { findings } = findUnmatchedSplitLegs(
+      [PARENT, second, opposite()],
+      [leg(), leg({ id: 'leg-2', transactionId: 'repayment-2' })],
+      CATEGORIES
+    );
+    expect(findings).toHaveLength(1);
+    expect(findings[0].reason).toBe('taken');
+  });
+
+  it('ignores a leg whose parent is archived, missing, or points at its own account', () => {
+    expect(findUnmatchedSplitLegs([{ ...PARENT, archived: true }], [leg()], CATEGORIES).findings).toEqual([]);
+    expect(findUnmatchedSplitLegs([], [leg()], CATEGORIES).findings).toEqual([]);
+    expect(findUnmatchedSplitLegs([PARENT], [leg({ transferAccountId: 'acc-a' })], CATEGORIES).findings).toEqual([]);
+  });
+
+  it('respects the date window before calling a row the obstacle', () => {
+    const { findings } = findUnmatchedSplitLegs(
+      [PARENT, opposite({ date: new Date('2026-08-10'), archived: true })], [leg()], CATEGORIES
+    );
+    expect(findings[0].reason).toBe('nothing-matches');
+  });
+
+  it('lists oldest first and re-runs identically', () => {
+    const older: Transaction = txn({
+      id: 'older', accountId: 'acc-a', amount: 100, type: 'income',
+      isSplit: true, date: new Date('2026-01-05'),
+    });
+    const transactions = [PARENT, older];
+    const splits = [leg(), leg({ id: 'leg-older', transactionId: 'older', amount: 60 })];
+
+    const first = findUnmatchedSplitLegs(transactions, splits, CATEGORIES).findings.map(f => f.split.id);
+    const second = findUnmatchedSplitLegs(
+      [...transactions].reverse(), [...splits].reverse(), CATEGORIES
+    ).findings.map(f => f.split.id);
+    expect(first).toEqual(['leg-older', 'leg']);
+    expect(second).toEqual(first);
   });
 });

--- a/src/utils/strandedTransfers.ts
+++ b/src/utils/strandedTransfers.ts
@@ -1,7 +1,13 @@
 import { toDecimal } from './decimal';
 import { calculateStringSimilarity } from './duplicateScan';
-import { sweepTransferPairs, SWEEP_WINDOW_DAYS, type TransferPairSuggestion } from './transferSweep';
-import type { Category, Transaction } from '../types';
+import {
+  sweepTransferPairs,
+  unmatchedSplitLegs,
+  SWEEP_WINDOW_DAYS,
+  type SplitLegSuggestion,
+  type TransferPairSuggestion,
+} from './transferSweep';
+import type { Category, Transaction, TransactionSplit } from '../types';
 
 /**
  * Stranded transfers — the residue the clean sweep cannot touch.
@@ -396,4 +402,164 @@ function oneSidedFindingFor(
   if (hasOpposite) return null;
 
   return { kind: 'one-sided', row };
+}
+
+/**
+ * ── UNMATCHED SPLIT LEGS: the one-sided family, for a LINE ───────────────────
+ *
+ * A split line carrying a transfer target with no counterpart says "£30,000 of
+ * this went to the loan account" while the loan account's register shows
+ * nothing. That is a real inconsistency and the user should be told.
+ *
+ * It is DELIBERATELY not a member of StrandedFinding, and it carries NO
+ * ACTION, because there is no honest one:
+ *
+ *  - Creating the missing row would invent money. The line may be unmatched
+ *    because the counterpart was deleted, because the real row is sitting just
+ *    outside the window, or because the line was mis-declared — and nothing
+ *    here can tell which. set_transaction_splits_with_legs refuses to mint a
+ *    counterpart for an already-targeted line for exactly this reason.
+ *  - Filing it as Account Adjustment (the answer for a one-sided ROW) means
+ *    editing the split, which rewrites what the user said the money was for,
+ *    from a list that cannot show them the rest of the split.
+ *
+ * So: detect and explain, and let the user open the transaction. Every finding
+ * therefore says as precisely as the data allows WHY no match was offered —
+ * including when a row that would have matched exists but is unavailable,
+ * which is the difference between "your loan account is missing this" and
+ * "the row is there, it just isn't free".
+ */
+
+interface UnmatchedLegBase {
+  kind: 'unmatched-leg';
+  /** The line that declares a transfer with nothing on the other side. */
+  split: TransactionSplit;
+  /** The split parent — the line's date, payee and account. */
+  parent: Transaction;
+  /** The account the line names. */
+  target: string;
+}
+
+/** Nothing anywhere in that account, in the window, is the line's opposite. */
+export interface LegWithNoOpposite extends UnmatchedLegBase {
+  reason: 'nothing-matches';
+}
+
+/** The opposite is there, but something makes it unpairable. */
+export interface LegWithBlockedOpposite extends UnmatchedLegBase {
+  /**
+   * 'linked' — already half of a transfer; 'split' — a split parent, which
+   * cannot become a transfer; 'archived' — out of the live register; 'taken' —
+   * free, but already offered to another line or pair in this same sweep.
+   */
+  reason: 'linked' | 'split' | 'archived' | 'taken';
+  blocker: Transaction;
+}
+
+/** The opposite is free, but somebody filed it — the same "or a coincidence?" question. */
+export interface LegWithFiledOpposite extends UnmatchedLegBase {
+  reason: 'filed';
+  blocker: Transaction;
+  blockerCategoryName: string;
+}
+
+export type UnmatchedSplitLegFinding =
+  | LegWithNoOpposite
+  | LegWithBlockedOpposite
+  | LegWithFiledOpposite;
+
+export interface UnmatchedLegSweepResult {
+  findings: UnmatchedSplitLegFinding[];
+  /** Unmatched legs considered (those the sweep could not match). */
+  scanned: number;
+}
+
+export interface UnmatchedLegSweepOptions {
+  windowDays?: number;
+  /**
+   * The sweep's output, when the caller already has it. BOTH are needed or
+   * neither: a leg the sweep matched is not stranded, and a row the sweep is
+   * offering elsewhere is not missing — it is taken.
+   */
+  sweepSuggestions?: TransferPairSuggestion[];
+  legSuggestions?: SplitLegSuggestion[];
+}
+
+export function findUnmatchedSplitLegs(
+  transactions: Transaction[],
+  splits: TransactionSplit[],
+  categories: Category[],
+  opts: UnmatchedLegSweepOptions = {}
+): UnmatchedLegSweepResult {
+  if (splits.length === 0) return { findings: [], scanned: 0 };
+
+  const windowDays = opts.windowDays ?? SWEEP_WINDOW_DAYS;
+  const categoryIds = new Set(categories.map(c => c.id));
+  const categoryById = new Map(categories.map(c => [c.id, c]));
+  const byId = new Map(transactions.map(t => [t.id, t]));
+
+  const swept = opts.sweepSuggestions && opts.legSuggestions
+    ? { suggestions: opts.sweepSuggestions, legSuggestions: opts.legSuggestions }
+    : sweepTransferPairs(transactions, { windowDays, onlyUncategorised: true, categoryIds, splits });
+
+  const matched = new Set(swept.legSuggestions.map(s => s.split.id));
+  const taken = new Set<string>();
+  for (const s of swept.suggestions) {
+    taken.add(s.outgoing.id);
+    taken.add(s.incoming.id);
+  }
+  for (const s of swept.legSuggestions) taken.add(s.candidate.id);
+
+  const legs = unmatchedSplitLegs(splits, byId).filter(leg => !matched.has(leg.split.id));
+
+  // Every row, by account + amount. The "is there anything over there at all?"
+  // question is asked of the WHOLE history — linked, filed, archived and all —
+  // exactly as the one-sided classifier asks it of a row.
+  const byAccountAmount = new Map<string, Transaction[]>();
+  for (const t of transactions) {
+    if (toDecimal(t.amount).isZero()) continue;
+    const key = `${t.accountId}|${pennies(t.amount)}`;
+    const list = byAccountAmount.get(key);
+    if (list) list.push(t);
+    else byAccountAmount.set(key, [t]);
+  }
+
+  const findings: UnmatchedSplitLegFinding[] = [];
+  for (const leg of legs) {
+    const base = { kind: 'unmatched-leg' as const, split: leg.split, parent: leg.parent, target: leg.target };
+    const opposites = (byAccountAmount.get(`${leg.target}|${-pennies(leg.split.amount)}`) ?? [])
+      .map(t => ({ transaction: t, daysApart: Math.abs(timeOf(t.date) - leg.time) / DAY_MS }))
+      .filter(c => c.daysApart <= windowDays)
+      .sort((a, b) => a.daysApart - b.daysApart || a.transaction.id.localeCompare(b.transaction.id));
+
+    const blocker = opposites[0]?.transaction;
+    if (!blocker) {
+      findings.push({ ...base, reason: 'nothing-matches' });
+      continue;
+    }
+
+    if (isTakenAsTransfer(blocker)) {
+      findings.push({ ...base, reason: 'linked', blocker });
+    } else if (blocker.isSplit) {
+      findings.push({ ...base, reason: 'split', blocker });
+    } else if (blocker.archived === true) {
+      findings.push({ ...base, reason: 'archived', blocker });
+    } else if (blocker.category && categoryIds.has(blocker.category)) {
+      // The sweep's own definition of "filed", so a finding can never
+      // contradict what the sweep did with the row.
+      findings.push({
+        ...base,
+        reason: 'filed',
+        blocker,
+        blockerCategoryName: categoryById.get(blocker.category)?.name ?? blocker.category,
+      });
+    } else if (taken.has(blocker.id)) {
+      findings.push({ ...base, reason: 'taken', blocker });
+    }
+    // A free, unclaimed row is one the sweep would have offered. If one turns
+    // up here the data moved under us mid-pass, and saying nothing is better
+    // than saying something that is not true.
+  }
+
+  return { findings, scanned: legs.length };
 }

--- a/src/utils/transactionDeepLink.ts
+++ b/src/utils/transactionDeepLink.ts
@@ -1,0 +1,24 @@
+/**
+ * The register deep link for a single transaction:
+ * `/accounts/<accountId>?txn=<transactionId>`.
+ *
+ * The destination register owns everything that happens on arrival — it
+ * selects the row, centres it in the list and docks it in quick edit, and it
+ * meets a CLOSED account with the re-open offer. Callers only build the path.
+ *
+ * The demo flag is carried over explicitly rather than via preserveDemoParam:
+ * that helper drops the flag outside development, and a jump taken inside a
+ * demo session has to land inside the same session.
+ */
+export function buildTransactionRegisterPath(
+  accountId: string,
+  transactionId: string,
+  currentSearch: string
+): string {
+  const params = new URLSearchParams();
+  params.set('txn', transactionId);
+  if (new URLSearchParams(currentSearch).get('demo') === 'true') {
+    params.set('demo', 'true');
+  }
+  return `/accounts/${accountId}?${params.toString()}`;
+}

--- a/src/utils/transactionSplits.test.ts
+++ b/src/utils/transactionSplits.test.ts
@@ -7,6 +7,7 @@ import {
   displaySplitAmount,
   expandSplitTransactions,
   splitsByTransaction,
+  splitDeclaresTransferLeg,
   type SplitLineDraft,
 } from './transactionSplits';
 import type { Transaction, TransactionSplit } from '../types';
@@ -66,6 +67,80 @@ describe('validateSplitDrafts', () => {
   });
 });
 
+describe('validateSplitDrafts — transfer lines', () => {
+  // What a real editor passes: the category tree says which ids are To/From
+  // categories, and the draft carries the account each one named.
+  const opts = {
+    parentType: 'income' as const,
+    directionFor: () => null,
+    parentAccountId: 'acct-current',
+    isTransferCategory: (id: string) => id.startsWith('tofrom:'),
+  };
+
+  it("balances Steve's case: £35,000 in, £30,000 of it a transfer, £5,000 interest", () => {
+    const lines: SplitLineDraft[] = [
+      { category: 'tofrom:loan', amount: '30000', transferAccountId: 'acct-loan' },
+      { category: 'interest', amount: '5000' },
+    ];
+    // A transfer line counts toward the parent exactly like any other line.
+    expect(sumSplitDrafts(lines, opts).toString()).toBe('35000');
+    expect(validateSplitDrafts('35000', lines, opts)).toBeNull();
+  });
+
+  it('needs the account on the other side', () => {
+    const lines: SplitLineDraft[] = [
+      { category: 'tofrom:loan', amount: '30000' },
+      { category: 'interest', amount: '5000' },
+    ];
+    expect(validateSplitDrafts('35000', lines, opts)).toMatch(/name the account on the other side/);
+  });
+
+  it('needs a non-zero amount, like every other line', () => {
+    const lines: SplitLineDraft[] = [
+      { category: 'tofrom:loan', amount: '0', transferAccountId: 'acct-loan' },
+      { category: 'interest', amount: '5000' },
+    ];
+    expect(validateSplitDrafts('5000', lines, opts)).toMatch(/non-zero amount/);
+  });
+
+  it("refuses a line pointing back at the transaction's own account", () => {
+    const lines: SplitLineDraft[] = [
+      { category: 'tofrom:self', amount: '30000', transferAccountId: 'acct-current' },
+      { category: 'interest', amount: '5000' },
+    ];
+    expect(validateSplitDrafts('35000', lines, opts)).toMatch(/point at a different account/);
+  });
+
+  it('allows more than one transfer line, to different accounts', () => {
+    // Nothing in the schema is one-leg-per-split: each line carries its own
+    // target and its own counterpart, which pins that exact line back.
+    const lines: SplitLineDraft[] = [
+      { category: 'tofrom:loan', amount: '30000', transferAccountId: 'acct-loan' },
+      { category: 'tofrom:isa', amount: '4000', transferAccountId: 'acct-isa' },
+      { category: 'interest', amount: '1000' },
+    ];
+    expect(validateSplitDrafts('35000', lines, opts)).toBeNull();
+  });
+
+  it('still refuses a set that does not add up', () => {
+    const lines: SplitLineDraft[] = [
+      { category: 'tofrom:loan', amount: '30000', transferAccountId: 'acct-loan' },
+      { category: 'interest', amount: '4000' },
+    ];
+    expect(validateSplitDrafts('35000', lines, opts)).toMatch(/must match/);
+  });
+});
+
+describe('splitDeclaresTransferLeg', () => {
+  it('is true when any line names an account on the other side', () => {
+    expect(splitDeclaresTransferLeg([{ }, { transferAccountId: 'acct-loan' }])).toBe(true);
+  });
+
+  it('is false for an ordinary split', () => {
+    expect(splitDeclaresTransferLeg([{ }, { }])).toBe(false);
+  });
+});
+
 describe('signSplitAmounts', () => {
   it('negates expense lines to the DB convention', () => {
     expect(signSplitAmounts([line('a', '120'), line('b', '-20')], 'expense')).toEqual([
@@ -93,6 +168,22 @@ describe('signSplitAmounts', () => {
     );
     expect(result[0].memo).toBe('petrol');
     expect(result[1]).not.toHaveProperty('memo');
+  });
+
+  it('carries line identity and transfer targets through to the writer', () => {
+    // The writer matches lines by id (so a leg survives an edit to its
+    // neighbour) and creates the other side from the target.
+    const [leg, ordinary] = signSplitAmounts(
+      [
+        { id: 'line-1', category: 'tofrom:loan', amount: '30000', transferAccountId: 'acct-loan' },
+        { category: 'interest', amount: '5000' },
+      ],
+      'income'
+    );
+    expect(leg).toEqual({
+      id: 'line-1', category: 'tofrom:loan', amount: 30000, transferAccountId: 'acct-loan',
+    });
+    expect(ordinary).toEqual({ category: 'interest', amount: 5000 });
   });
 });
 

--- a/src/utils/transactionSplits.ts
+++ b/src/utils/transactionSplits.ts
@@ -1,5 +1,5 @@
 import { toDecimal, parseMoneyInput, type DecimalInstance } from './decimal';
-import type { Transaction, TransactionSplit } from '../types';
+import type { Transaction, TransactionSplit, TransactionSplitInput } from '../types';
 
 /**
  * Split-editor money maths. Everything runs through Decimal — the "totals
@@ -17,6 +17,34 @@ export interface SplitLineDraft {
   category: string;
   amount: string;
   memo?: string;
+  /**
+   * The stored line this draft was loaded from. Sent back on save so the
+   * writer can match lines by identity instead of replacing the whole set —
+   * the difference between "line 2 was re-categorised" and "line 1 (a transfer
+   * leg) was deleted". Absent on lines the user has just added.
+   */
+  id?: string;
+  /**
+   * The account on the other side when this line is one leg of a transfer:
+   * loaded from the stored row, or resolved from the "To/From <account>"
+   * category the user picked.
+   */
+  transferAccountId?: string;
+  /**
+   * The target the STORED line carries, kept beside the live choice above so
+   * the editor can tell a line that is BECOMING a transfer (its other side
+   * gets created on save) from one that already was (it does not — a leg
+   * whose counterpart has been deleted is re-paired, never duplicated, since
+   * the missing row may simply be sitting in that account unmatched).
+   */
+  savedTransferAccountId?: string;
+  /**
+   * The counterpart transaction, when this leg is already linked to one. Such
+   * a line is structural — its category, amount and target are pinned by the
+   * row on the other side — so the editor renders it read-only and the writer
+   * refuses to change it.
+   */
+  linkedTransferId?: string;
 }
 
 export type SplitDirection = 'income' | 'expense';
@@ -35,6 +63,20 @@ export type SplitDirectionFor = (categoryId: string) => SplitDirection | null;
 interface SplitDirectionOpts {
   parentType: SplitDirection;
   directionFor: SplitDirectionFor;
+}
+
+/**
+ * What validateSplitDrafts needs on top of direction, to judge TRANSFER lines
+ * (a line that is itself one leg of a transfer — the Microsoft Money model).
+ * Both fields are optional: surfaces that cannot produce a transfer line (the
+ * pure maths tests, any caller without a category tree) simply never trip the
+ * rules that read them.
+ */
+interface SplitValidationOpts extends SplitDirectionOpts {
+  /** The account the parent transaction sits in. */
+  parentAccountId?: string;
+  /** True for a "To/From <account>" category (Category.isTransferCategory). */
+  isTransferCategory?: (categoryId: string) => boolean;
 }
 
 /** The pre-mixing behaviour: every line follows the parent's direction. */
@@ -80,11 +122,17 @@ export function splitRemainder(
 /**
  * Validate the draft against the save rules. Returns null when saveable,
  * otherwise the user-facing reason the save is blocked.
+ *
+ * The transfer-line rules mirror the ones set_transaction_splits_with_legs
+ * enforces server-side, so the editor refuses before the round trip rather
+ * than translating a database error afterwards. A transfer line counts toward
+ * the parent total exactly like any other line — that is what makes
+ * £30,000 (transferred) + £5,000 (interest) = the £35,000 that arrived.
  */
 export function validateSplitDrafts(
   totalAmount: string,
   lines: SplitLineDraft[],
-  opts: SplitDirectionOpts = FOLLOW_PARENT
+  opts: SplitValidationOpts = FOLLOW_PARENT
 ): string | null {
   if (lines.length < 2) {
     return 'A split needs at least two category lines.';
@@ -96,6 +144,14 @@ export function validateSplitDrafts(
     const amount = parseMoneyInput(line.amount);
     if (amount === null || toDecimal(amount).isZero()) {
       return 'Every split line needs a non-zero amount.';
+    }
+    // A To/From category names an account; without one the line says
+    // "transfer" but cannot say where to, and there is no other side to make.
+    if (opts.isTransferCategory?.(line.category) === true && !line.transferAccountId) {
+      return 'A transfer line must name the account on the other side — that To/From category is not linked to an account.';
+    }
+    if (line.transferAccountId && line.transferAccountId === opts.parentAccountId) {
+      return 'A transfer line must point at a different account — this one points back at the account the transaction is already in.';
     }
   }
   if (!splitRemainder(totalAmount, lines, opts).isZero()) {
@@ -112,12 +168,15 @@ export function validateSplitDrafts(
  * a minus) still lands as +20. The DB's set_transaction_splits invariant
  * (signed lines sum to the signed parent amount) holds exactly whenever
  * validateSplitDrafts passed with the same opts.
+ *
+ * Line identity and transfer targets travel with the amounts: the writer needs
+ * both to match an edit against the stored lines rather than replacing them.
  */
 export function signSplitAmounts(
   lines: SplitLineDraft[],
   type: SplitDirection,
   directionFor: SplitDirectionFor = () => null
-): { category: string; amount: number; memo?: string }[] {
+): TransactionSplitInput[] {
   const opts: SplitDirectionOpts = { parentType: type, directionFor };
   return lines.map(line => {
     const entered = toDecimal(parseMoneyInput(line.amount) ?? 0);
@@ -127,8 +186,21 @@ export function signSplitAmounts(
       // `plus(0)` normalises -0 → 0 to match signTransactionAmount's `|| 0`.
       amount: signed.plus(0).toNumber(),
       ...(line.memo?.trim() ? { memo: line.memo.trim() } : {}),
+      ...(line.id ? { id: line.id } : {}),
+      ...(line.transferAccountId ? { transferAccountId: line.transferAccountId } : {}),
     };
   });
+}
+
+/**
+ * Does this line set say "one of these lines is a transfer"? The routing rule
+ * for the write path: a set that declares a leg — a new one, or an existing
+ * one being carried through an edit — goes to the writer that understands
+ * legs; everything else takes the ordinary replace-the-set path, which stays
+ * exactly as it was.
+ */
+export function splitDeclaresTransferLeg(lines: { transferAccountId?: string }[]): boolean {
+  return lines.some(line => Boolean(line.transferAccountId));
 }
 
 /**

--- a/src/utils/transferSweep.test.ts
+++ b/src/utils/transferSweep.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { sweepTransferPairs } from './transferSweep';
-import type { Transaction } from '../types';
+import type { Transaction, TransactionSplit } from '../types';
 
 const txn = (over: Partial<Transaction> & { id: string }): Transaction => ({
   date: new Date('2026-07-10'),
@@ -9,6 +9,14 @@ const txn = (over: Partial<Transaction> & { id: string }): Transaction => ({
   category: '',
   accountId: 'acc-a',
   type: 'expense',
+  ...over,
+});
+
+const line = (over: Partial<TransactionSplit> & { id: string }): TransactionSplit => ({
+  transactionId: 'repayment',
+  category: 'cat-x',
+  amount: 30000,
+  sortOrder: 1,
   ...over,
 });
 
@@ -100,5 +108,169 @@ describe('sweepTransferPairs', () => {
       txn({ id: 'in', amount: 100, accountId: 'acc-b', type: 'income' }),
     ], { onlyUncategorised: true, categoryIds });
     expect(dangling.suggestions).toHaveLength(1);
+  });
+});
+
+/**
+ * The owner's case, which whole-transaction matching cannot see: £35,000
+ * arrives, £30,000 of it settles a loan (a transfer LINE) and £5,000 is
+ * interest. The parent is £35,000 and the row waiting in the loan account is
+ * £30,000 — nothing about the two ROWS matches; the LINE and that row match
+ * exactly.
+ */
+describe('sweepTransferPairs — split line legs', () => {
+  const PARENT: Transaction = txn({
+    id: 'repayment',
+    accountId: 'acc-current',
+    amount: 35000,
+    type: 'income',
+    description: 'Repaid in full',
+    isSplit: true,
+  });
+
+  /** The £30,000 leg: a target, no counterpart yet. */
+  const LEG = line({ id: 'leg', amount: 30000, transferAccountId: 'acc-loan' });
+  const INTEREST = line({ id: 'interest', amount: 5000, sortOrder: 2 });
+
+  const LOAN_ROW: Transaction = txn({
+    id: 'loan-row',
+    accountId: 'acc-loan',
+    amount: -30000,
+    description: 'Repaid in full',
+  });
+
+  const sweep = (
+    transactions: Transaction[],
+    splits: TransactionSplit[] = [LEG, INTEREST]
+  ) => sweepTransferPairs(transactions, { splits });
+
+  it('matches the LINE to the free row in the account it names', () => {
+    const { suggestions, legSuggestions, legsScanned } = sweep([PARENT, LOAN_ROW]);
+
+    // The parent is a split, so the whole-transaction pass cannot see any of
+    // this — which is exactly why the line pass exists.
+    expect(suggestions).toHaveLength(0);
+    expect(legsScanned).toBe(1);
+    expect(legSuggestions).toHaveLength(1);
+    expect(legSuggestions[0]).toMatchObject({
+      daysApart: 0,
+      ambiguous: false,
+    });
+    expect(legSuggestions[0].split.id).toBe('leg');
+    expect(legSuggestions[0].parent.id).toBe('repayment');
+    expect(legSuggestions[0].candidate.id).toBe('loan-row');
+  });
+
+  it('offers nothing without the splits — the pass is opt-in', () => {
+    const { legSuggestions, legsScanned } = sweepTransferPairs([PARENT, LOAN_ROW]);
+    expect(legsScanned).toBe(0);
+    expect(legSuggestions).toEqual([]);
+  });
+
+  it.each([
+    ['the row is in a different account', txn({ id: 'loan-row', accountId: 'acc-isa', amount: -30000 })],
+    ['the amount is a penny out', txn({ id: 'loan-row', accountId: 'acc-loan', amount: -29999.99 })],
+    ['the amount is the PARENT\'s, not the line\'s', txn({ id: 'loan-row', accountId: 'acc-loan', amount: -35000 })],
+    ['the row is outside the window', txn({ id: 'loan-row', accountId: 'acc-loan', amount: -30000, date: new Date('2026-07-20') })],
+    ['the row is already linked', txn({ id: 'loan-row', accountId: 'acc-loan', amount: -30000, linkedTransferId: 'somebody' })],
+    ['the row is already some other line\'s opposite', txn({ id: 'loan-row', accountId: 'acc-loan', amount: -30000, linkedTransferSplitId: 'other-line' })],
+    ['the row is typed as a transfer', txn({ id: 'loan-row', accountId: 'acc-loan', amount: -30000, type: 'transfer' })],
+    ['the row is itself a split', txn({ id: 'loan-row', accountId: 'acc-loan', amount: -30000, isSplit: true })],
+    ['the row is archived', txn({ id: 'loan-row', accountId: 'acc-loan', amount: -30000, archived: true })],
+  ])('offers nothing when %s', (_case, candidate) => {
+    expect(sweep([PARENT, candidate]).legSuggestions).toEqual([]);
+  });
+
+  it('offers nothing for a line that is already linked, or has no target', () => {
+    const linked = sweep([PARENT, LOAN_ROW], [{ ...LEG, linkedTransferId: 'counterpart' }, INTEREST]);
+    expect(linked.legsScanned).toBe(0);
+    expect(linked.legSuggestions).toEqual([]);
+
+    const noTarget = sweep([PARENT, LOAN_ROW], [{ ...LEG, transferAccountId: undefined }, INTEREST]);
+    expect(noTarget.legSuggestions).toEqual([]);
+  });
+
+  it('offers nothing when the split parent is archived or missing', () => {
+    expect(sweep([{ ...PARENT, archived: true }, LOAN_ROW]).legSuggestions).toEqual([]);
+    expect(sweep([LOAN_ROW]).legSuggestions).toEqual([]);
+  });
+
+  it('respects onlyUncategorised exactly as the whole-transaction pass does', () => {
+    const categoryIds = new Set(['cat-loan-repayment']);
+    const filed = sweepTransferPairs(
+      [PARENT, { ...LOAN_ROW, category: 'cat-loan-repayment' }],
+      { splits: [LEG, INTEREST], onlyUncategorised: true, categoryIds }
+    );
+    expect(filed.legSuggestions).toEqual([]);
+
+    const free = sweepTransferPairs(
+      [PARENT, LOAN_ROW],
+      { splits: [LEG, INTEREST], onlyUncategorised: true, categoryIds }
+    );
+    expect(free.legSuggestions).toHaveLength(1);
+  });
+
+  it('flags ambiguity when two rows match the line equally well', () => {
+    const { legSuggestions } = sweep([
+      PARENT,
+      LOAN_ROW,
+      txn({ id: 'loan-row-twin', accountId: 'acc-loan', amount: -30000, description: 'Repaid in full' }),
+    ]);
+    expect(legSuggestions).toHaveLength(1);
+    expect(legSuggestions[0].ambiguous).toBe(true);
+  });
+
+  it('flags ambiguity when two LINES compete for the same row', () => {
+    const second: Transaction = txn({
+      id: 'repayment-2', accountId: 'acc-current', amount: 35000,
+      type: 'income', description: 'Repaid in full', isSplit: true,
+    });
+    const { legSuggestions } = sweep(
+      [PARENT, second, LOAN_ROW],
+      [LEG, INTEREST, line({ id: 'leg-2', transactionId: 'repayment-2', amount: 30000, transferAccountId: 'acc-loan' })]
+    );
+
+    // One row, two lines: the row is used once, and the match it made is
+    // flagged rather than presented as obvious.
+    expect(legSuggestions).toHaveLength(1);
+    expect(legSuggestions[0].ambiguous).toBe(true);
+  });
+
+  it('uses a row at most once across BOTH passes, and never at a pair\'s expense', () => {
+    // The loan row could serve either the whole-transaction pair or the line.
+    // The pair pass runs first and keeps it; the line is simply not offered.
+    const history = [
+      PARENT,
+      LOAN_ROW,
+      txn({ id: 'plain-out', accountId: 'acc-isa', amount: 30000, type: 'income', description: 'Repaid in full' }),
+    ];
+    const { suggestions, legSuggestions } = sweep(history);
+
+    expect(suggestions).toHaveLength(1);
+    expect(suggestions[0].outgoing.id).toBe('loan-row');
+    expect(suggestions[0].incoming.id).toBe('plain-out');
+    expect(legSuggestions).toEqual([]);
+  });
+
+  it('leaves every whole-transaction suggestion byte-identical', () => {
+    // The additivity proof: the same history swept with and without the split
+    // lines must produce the SAME pairs, in the same order, with the same
+    // orientation, days apart, score and ambiguity.
+    const history = [
+      PARENT,
+      LOAN_ROW,
+      txn({ id: 'pair-out', accountId: 'acc-a', amount: -500, date: new Date('2026-06-01') }),
+      txn({ id: 'pair-in', accountId: 'acc-b', amount: 500, type: 'income', date: new Date('2026-06-02') }),
+      txn({ id: 'pair-out-2', accountId: 'acc-b', amount: -75.5, date: new Date('2026-06-10') }),
+      txn({ id: 'pair-in-2', accountId: 'acc-c', amount: 75.5, type: 'income', date: new Date('2026-06-10') }),
+    ];
+
+    const before = sweepTransferPairs(history);
+    const after = sweepTransferPairs(history, { splits: [LEG, INTEREST] });
+
+    expect(after.suggestions).toEqual(before.suggestions);
+    expect(after.scanned).toBe(before.scanned);
+    expect(after.legSuggestions).toHaveLength(1);
+    expect(before.legSuggestions).toEqual([]);
   });
 });

--- a/src/utils/transferSweep.ts
+++ b/src/utils/transferSweep.ts
@@ -1,6 +1,6 @@
 import { toDecimal } from './decimal';
 import { calculateStringSimilarity } from './duplicateScan';
-import type { Transaction } from '../types';
+import type { Transaction, TransactionSplit } from '../types';
 
 /**
  * Bulk transfer matching — find every unlinked equal-and-opposite pair in one
@@ -21,6 +21,21 @@ import type { Transaction } from '../types';
  *    similarity breaks ties, and a row with several equally-good candidates
  *    is reported as AMBIGUOUS rather than guessed at.
  *
+ * ── The second pass: one LINE of a split ────────────────────────────────────
+ *
+ * A whole-transaction pass cannot see the movement the owner actually makes:
+ * £35,000 arrives, £30,000 of it settles a loan and £5,000 is interest. The
+ * parent is £35,000 and the row waiting in the loan account is £30,000, so
+ * NOTHING about the two rows matches — the match is between the £30,000 LINE
+ * and that row (the model in 20260720120000: a split line carrying
+ * transfer_account_id with a NULL linked_transfer_id is an unmatched leg).
+ *
+ * That pass is strictly additive. It runs AFTER the whole-transaction pass,
+ * over the rows that pass left over, so every pair above is exactly what it
+ * was before line matching existed; and it applies the same candidate rules,
+ * plus the two the RPC behind it (link_split_line_transfer) refuses by name:
+ * the row must sit in the account the LINE names, and must not be archived.
+ *
  * Nothing is mutated here: the caller reviews, deselects, then applies.
  */
 
@@ -37,10 +52,46 @@ export interface TransferPairSuggestion {
   ambiguous: boolean;
 }
 
+/**
+ * One LINE of a split matched to the transaction that is its other side.
+ *
+ * Carries everything an offer needs to be judged and acted on: the line
+ * (`link_split_line_transfer` is keyed by its id), the parent it belongs to —
+ * whose date, payee and account are the line's — and the row over there.
+ */
+export interface SplitLegSuggestion {
+  /** The unmatched leg: `transferAccountId` set, `linkedTransferId` absent. */
+  split: TransactionSplit;
+  /** The split parent. Its total legitimately differs from the line's amount. */
+  parent: Transaction;
+  /** The free row in the account the LINE names, exactly opposite the LINE. */
+  candidate: Transaction;
+  /** Whole/fractional days between the parent's date and the candidate's. */
+  daysApart: number;
+  /** 0–100 description similarity (tie-break/confidence only). */
+  descriptionScore: number;
+  /** True when other equally-close rows — or other lines — competed for this match. */
+  ambiguous: boolean;
+}
+
 export interface TransferSweepResult {
   suggestions: TransferPairSuggestion[];
+  /** Line-level matches, found after (and never instead of) the pairs above. */
+  legSuggestions: SplitLegSuggestion[];
   /** Rows considered (unlinked, uncategorised-or-not, non-split). */
   scanned: number;
+  /** Unmatched split legs considered. */
+  legsScanned: number;
+}
+
+/** A split line that says "this much went to that account", with no row there yet. */
+export interface UnmatchedSplitLeg {
+  split: TransactionSplit;
+  parent: Transaction;
+  /** The account the line names — `split.transferAccountId`, resolved non-null. */
+  target: string;
+  /** The parent's date in millis: a line has no date of its own. */
+  time: number;
 }
 
 const DAY_MS = 1000 * 60 * 60 * 24;
@@ -48,9 +99,65 @@ export const SWEEP_WINDOW_DAYS = 4;
 
 const pennies = (amount: number): number => toDecimal(amount).times(100).toDecimalPlaces(0).toNumber();
 
+const timeOf = (date: Date | string): number => new Date(date).getTime();
+
+/**
+ * Ambiguous when an equally-good alternative exists — checked in BOTH
+ * directions by every caller, because which side the sweep reaches first is an
+ * accident of ordering: a row may have several candidate partners, or several
+ * rows may be competing for the partner it chose.
+ */
+const equallyGood = (list: Array<{ daysApart: number; descriptionScore: number }>): boolean =>
+  list.length > 1 &&
+  list[1].daysApart === list[0].daysApart &&
+  list[1].descriptionScore === list[0].descriptionScore;
+
+/**
+ * Every split LINE that declares a transfer target and has no counterpart yet,
+ * oldest parent first so a re-run considers them in the same order.
+ *
+ * Excluded before anything else looks at them: a line whose parent is not in
+ * this view (nothing to date it by), one whose parent is archived (out of the
+ * live register — the stranded classifier's rule), one pointing back at its
+ * own account and one for £0 — the last two being refusals of
+ * link_split_line_transfer, so an offer built on them could never be accepted.
+ */
+export function unmatchedSplitLegs(
+  splits: TransactionSplit[],
+  byId: Map<string, Transaction>
+): UnmatchedSplitLeg[] {
+  const legs: UnmatchedSplitLeg[] = [];
+  for (const split of splits) {
+    const target = split.transferAccountId;
+    if (!target || split.linkedTransferId) continue;
+    const parent = byId.get(split.transactionId);
+    if (!parent || parent.archived === true) continue;
+    if (target === parent.accountId) continue;
+    if (toDecimal(split.amount).isZero()) continue;
+    legs.push({ split, parent, target, time: timeOf(parent.date) });
+  }
+  return legs.sort(
+    (a, b) =>
+      a.time - b.time ||
+      a.parent.id.localeCompare(b.parent.id) ||
+      a.split.sortOrder - b.split.sortOrder ||
+      a.split.id.localeCompare(b.split.id)
+  );
+}
+
 export function sweepTransferPairs(
   transactions: Transaction[],
-  opts: { windowDays?: number; onlyUncategorised?: boolean; categoryIds?: Set<string> } = {}
+  opts: {
+    windowDays?: number;
+    onlyUncategorised?: boolean;
+    categoryIds?: Set<string>;
+    /**
+     * The user's split lines. Without them the sweep behaves exactly as it did
+     * before line matching existed — no leg is looked at, and `legSuggestions`
+     * comes back empty.
+     */
+    splits?: TransactionSplit[];
+  } = {}
 ): TransferSweepResult {
   const windowDays = opts.windowDays ?? SWEEP_WINDOW_DAYS;
 
@@ -105,15 +212,6 @@ export function sweepTransferPairs(
     const best = candidates[0];
     if (!best) continue;
 
-    // Ambiguous when an equally-good alternative exists — checked in BOTH
-    // directions, because which side the sweep reaches first is an accident
-    // of ordering: the row may have several candidate partners, or several
-    // rows may be competing for the partner it chose.
-    const equallyGood = (list: Array<{ daysApart: number; descriptionScore: number }>): boolean =>
-      list.length > 1 &&
-      list[1].daysApart === list[0].daysApart &&
-      list[1].descriptionScore === list[0].descriptionScore;
-
     const partnerTime = new Date(best.transaction.date).getTime();
     const reverseCandidates = (byAmount.get(pennies(row.amount)) ?? [])
       .filter(o =>
@@ -143,5 +241,98 @@ export function sweepTransferPairs(
     });
   }
 
-  return { suggestions, scanned: eligible.length };
+  // The line-level pass, over what the pass above left behind. It shares the
+  // `used` set and runs strictly second, so it can only ever consume rows no
+  // pair wanted — every suggestion above is what it would have been without
+  // this pass existing.
+  const splits = opts.splits ?? [];
+  const legs = splits.length > 0
+    ? unmatchedSplitLegs(splits, new Map(transactions.map(t => [t.id, t])))
+    : [];
+  const legSuggestions = legs.length > 0
+    ? sweepSplitLegs(legs, eligible, used, windowDays)
+    : [];
+
+  return { suggestions, legSuggestions, scanned: eligible.length, legsScanned: legs.length };
+}
+
+/**
+ * Match each unmatched leg to the free row that is exactly the LINE's
+ * opposite, in exactly the account the line names.
+ *
+ * `eligible` is the whole-transaction pass's own candidate pool, so a line
+ * competes for rows on identical terms (unlinked, not typed 'transfer', not a
+ * split parent, uncategorised when the caller asked for that, never used
+ * twice). Two rules are added, both of them refusals of
+ * link_split_line_transfer rather than opinions of this file: an archived row
+ * cannot be paired, and neither can one already pinned as some other line's
+ * opposite.
+ */
+function sweepSplitLegs(
+  legs: UnmatchedSplitLeg[],
+  eligible: Transaction[],
+  used: Set<string>,
+  windowDays: number
+): SplitLegSuggestion[] {
+  // Free rows by account + exact penny amount: a line only ever looks in the
+  // one account it names.
+  const byAccountAmount = new Map<string, Transaction[]>();
+  for (const t of eligible) {
+    if (t.archived === true || t.linkedTransferSplitId) continue;
+    const key = `${t.accountId}|${pennies(t.amount)}`;
+    const list = byAccountAmount.get(key);
+    if (list) list.push(t);
+    else byAccountAmount.set(key, [t]);
+  }
+
+  const usedLegs = new Set<string>();
+  const suggestions: SplitLegSuggestion[] = [];
+
+  for (const leg of legs) {
+    const candidates = (byAccountAmount.get(`${leg.target}|${-pennies(leg.split.amount)}`) ?? [])
+      .filter(t => !used.has(t.id) && Math.abs(timeOf(t.date) - leg.time) <= windowDays * DAY_MS)
+      .map(t => ({
+        transaction: t,
+        daysApart: Math.abs(timeOf(t.date) - leg.time) / DAY_MS,
+        // The counterpart of a leg carries the PARENT's payee (that is what
+        // set_transaction_splits_with_legs writes), so the parent's
+        // description is the line's for comparison purposes.
+        descriptionScore: calculateStringSimilarity(leg.parent.description, t.description),
+      }))
+      .sort((a, b) => a.daysApart - b.daysApart || b.descriptionScore - a.descriptionScore);
+
+    const best = candidates[0];
+    if (!best) continue;
+
+    // The reverse direction: other unmatched lines competing for the row this
+    // one chose. `leg` itself is still unused and therefore in this list, so
+    // the top two being level means a genuine tie.
+    const candidateTime = timeOf(best.transaction.date);
+    const rivals = legs
+      .filter(other =>
+        !usedLegs.has(other.split.id) &&
+        other.target === best.transaction.accountId &&
+        pennies(other.split.amount) === -pennies(best.transaction.amount) &&
+        Math.abs(other.time - candidateTime) <= windowDays * DAY_MS
+      )
+      .map(other => ({
+        daysApart: Math.abs(other.time - candidateTime) / DAY_MS,
+        descriptionScore: calculateStringSimilarity(best.transaction.description, other.parent.description),
+      }))
+      .sort((a, b) => a.daysApart - b.daysApart || b.descriptionScore - a.descriptionScore);
+
+    used.add(best.transaction.id);
+    usedLegs.add(leg.split.id);
+
+    suggestions.push({
+      split: leg.split,
+      parent: leg.parent,
+      candidate: best.transaction,
+      daysApart: best.daysApart,
+      descriptionScore: best.descriptionScore,
+      ambiguous: equallyGood(candidates) || equallyGood(rivals),
+    });
+  }
+
+  return suggestions;
 }

--- a/supabase/migrations/20260806094058_split_transfer_legs.sql
+++ b/supabase/migrations/20260806094058_split_transfer_legs.sql
@@ -1,0 +1,678 @@
+-- ============================================================================
+-- SPLIT TRANSFER LEGS — a leg you can create by hand, and a guard that stops
+-- punishing the lines it was never about
+-- ============================================================================
+-- IMPORTANT: apply with `npm run db:migrate` (see supabase/migrations/README.md
+-- rule 1 — never the SQL editor). Safe to apply before the matching client
+-- deploys: everything here is a NEW function, nothing existing is redefined,
+-- and no column changes. A database with this applied and the old client
+-- running behaves exactly as it does now.
+--
+-- ── THE MODEL (unchanged, from 20260720120000) ──────────────────────────────
+--
+-- One LINE of a split can itself be a transfer leg:
+--
+--   transaction_splits.transfer_account_id  → the account on the other side
+--   transaction_splits.linked_transfer_id   → the counterpart transaction
+--   transactions.linked_transfer_split_id   → the exact line that is the
+--                                             opposite leg (its
+--                                             linked_transfer_id then points
+--                                             at the split PARENT)
+--
+-- Amounts are exactly opposite between the LINE and the counterpart — never
+-- between the counterpart and the PARENT, whose total legitimately differs.
+-- That difference is the whole point: £35,000 arrives, £30,000 of it settles a
+-- loan (a transfer line) and £5,000 is interest (an income line).
+--
+-- ── WHY THIS MIGRATION: TWO PROBLEMS, ONE WRITE PATH ───────────────────────
+--
+-- 1. Nobody could CREATE one. 86 of the owner's 364 split lines are transfer
+--    legs and every one was made by the MS Money importer, because
+--    set_transaction_splits refuses a To/From category outright ('unknown or
+--    transfer category') and there is no other way in. The Money answer — "one
+--    line of this split is money moving to another account" — simply could not
+--    be said in this app.
+--
+-- 2. The guard that protects legs was too COARSE, and that is the part the
+--    owner hit. set_transaction_splits REPLACES the whole line set (delete-all
+--    then insert-all), so it cannot tell "line 2 was re-categorised" from
+--    "line 1, which was a leg, was deleted". Unable to tell the difference, it
+--    refused everything: 78 split parents in production contain a linked leg,
+--    and 33 of them still carry a line that needs a category — filing work the
+--    UI made impossible, because touching ANY line meant touching them all.
+--
+-- Both have the same root cause and therefore the same fix: a writer that
+-- matches incoming lines to stored ones BY IDENTITY instead of replacing the
+-- set. Once a line has an id, "changed", "added" and "removed" are three
+-- different things, and the guard can be about the only one that hurts.
+--
+-- ── THE RULE, PRECISELY ────────────────────────────────────────────────────
+--
+-- A linked leg line is IMMUTABLE except for where it sits (sort_order) and its
+-- memo. An edit is refused only when it would:
+--
+--   * remove a linked leg      → its counterpart would point at a line that no
+--                                longer exists (a half-broken pair IS the
+--                                one-sided transfer this whole feature exists
+--                                to prevent);
+--   * change a leg's amount    → the LINE↔counterpart opposite-amounts
+--                                invariant would be false, i.e. the ledger
+--                                would claim two different sizes for one
+--                                movement of money;
+--   * change a leg's target or its category — the filing that names the
+--                                account on the other side.
+--
+-- Everything else in the same split — categories, amounts, memos, added lines,
+-- removed ordinary lines — is free. The existing "lines sum to the parent"
+-- rule is unchanged and applies to leg lines exactly like any other, so an
+-- edit that would need a leg to change size fails the SUM check with a hint
+-- saying why, rather than silently rewriting the other side of a transfer.
+--
+-- set_transaction_splits itself is DELIBERATELY LEFT ALONE, blanket guard and
+-- all. It stays the strict path: a client that does not know about legs (a
+-- stale browser tab, or the un-split path, which has no line ids to match and
+-- would strand every leg it dropped) still gets the old blunt refusal, which
+-- fails safe. The new writer below is reached only when the caller explicitly
+-- names a transfer target on a line, i.e. when it demonstrably knows what a
+-- leg is.
+--
+-- ── BALANCE REASONING ──────────────────────────────────────────────────────
+--
+-- Not balance-neutral, and cannot be: creating a leg's counterpart puts a real
+-- row in another account's register, so that account's balance moves by
+-- exactly the counterpart amount — the same arithmetic (and the same audit
+-- shape) as create_transfer_counterpart. The parent's own account moves only
+-- if the line total changed it, exactly as set_transaction_splits does today.
+-- Net worth is unaffected by the leg itself: the £30,000 leaving the loan
+-- account is the same £30,000 arriving in the current account.
+--
+-- Both functions are SECURITY INVOKER (RLS scopes the rows) with the usual
+-- p_user_id defence-in-depth guard, and audit every row they touch.
+-- ============================================================================
+
+BEGIN;
+
+-- ── set_transaction_splits_with_legs ────────────────────────────────────────
+--
+--   p_transaction_id   the split parent;
+--   p_splits           the WHOLE line set, in display order. Each element:
+--                        id                   text, optional — the stored line
+--                                             this replaces. Absent = a new
+--                                             line. A stored line whose id is
+--                                             not named is deleted.
+--                        category             text, required — a category id
+--                        amount               numeric, required, non-zero,
+--                                             signed like transactions.amount
+--                        memo                 text, optional
+--                        transfer_account_id  text, optional — makes this line
+--                                             one leg of a transfer with that
+--                                             account
+--   p_expected_amount  the client's amount field; the lines must sum to it
+--   p_user_id          the usual owner guard.
+--
+-- Never un-splits: an empty set has no leg to preserve and no line to match,
+-- so that path stays with set_transaction_splits (which refuses while a leg is
+-- present — correctly, since un-splitting deletes every line).
+--
+-- Returns {is_split, split_count, amount, counterparts}, the counterparts being
+-- the full transaction rows created for new legs, so the client updates its
+-- state (and the target accounts' balances) from what the database actually
+-- wrote rather than from what it hoped for.
+CREATE OR REPLACE FUNCTION public.set_transaction_splits_with_legs(
+  p_transaction_id uuid,
+  p_splits jsonb,
+  p_expected_amount numeric DEFAULT NULL,
+  p_user_id uuid DEFAULT NULL
+)
+RETURNS jsonb
+LANGUAGE plpgsql SECURITY INVOKER
+SET search_path = public
+AS $$
+DECLARE
+  v_old            public.transactions;
+  v_new            public.transactions;
+  v_counterpart    public.transactions;
+  v_old_line       public.transaction_splits;
+  v_new_line       public.transaction_splits;
+  v_leg            public.transaction_splits;
+  v_cat            public.categories;
+  v_acct           public.accounts;
+  v_acct_after     public.accounts;
+  v_src_acct       public.accounts;
+  v_split          jsonb;
+  v_in_id          text;
+  v_target_text    text;
+  v_target         uuid;
+  v_prev_target    uuid;
+  v_prev_link      uuid;
+  v_category       text;
+  v_memo           text;
+  v_amount         numeric(20,2);
+  v_sum            numeric(20,2) := 0;
+  v_count          integer := 0;
+  v_ord            integer := 0;
+  v_incoming_ids   text[];
+  v_stored_count   integer;
+  v_stored_sum     numeric(20,2);
+  v_old_splits     jsonb;
+  v_new_splits     jsonb;
+  v_counterparts   jsonb := '[]'::jsonb;
+BEGIN
+  IF p_splits IS NULL OR jsonb_typeof(p_splits) <> 'array' THEN
+    RAISE EXCEPTION 'p_splits must be a jsonb array' USING ERRCODE = '22023';
+  END IF;
+  IF jsonb_array_length(p_splits) < 2 THEN
+    RAISE EXCEPTION 'a split needs at least 2 lines' USING ERRCODE = '22023';
+  END IF;
+
+  SELECT * INTO v_old
+    FROM public.transactions
+   WHERE id = p_transaction_id
+     AND (p_user_id IS NULL OR user_id = p_user_id)
+   FOR UPDATE;
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'transaction_not_found' USING ERRCODE = 'P0002';
+  END IF;
+
+  IF v_old.type = 'transfer' THEN
+    RAISE EXCEPTION 'transfers cannot be split' USING ERRCODE = 'P0001';
+  END IF;
+
+  -- ── Which stored lines this edit keeps ────────────────────────────────────
+  -- Ids are compared AS TEXT throughout (the same shape categories use), so a
+  -- malformed id from a confused caller resolves to no row and gets a sentence
+  -- rather than a raw 22P02 cast error.
+  SELECT COALESCE(array_agg(x), '{}'::text[]) INTO v_incoming_ids
+    FROM (
+      SELECT NULLIF(btrim(COALESCE(e.value->>'id', '')), '') AS x
+        FROM jsonb_array_elements(p_splits) e
+    ) ids
+   WHERE x IS NOT NULL;
+
+  IF (SELECT count(*) FROM unnest(v_incoming_ids) x)
+     <> (SELECT count(DISTINCT x) FROM unnest(v_incoming_ids) x) THEN
+    RAISE EXCEPTION 'split_line_id_repeated: two of these lines claim to be the same stored line — reload and look again'
+      USING ERRCODE = '22023';
+  END IF;
+
+  SELECT COALESCE(jsonb_agg(to_jsonb(s) ORDER BY s.sort_order), '[]'::jsonb)
+    INTO v_old_splits
+    FROM public.transaction_splits s
+   WHERE s.transaction_id = p_transaction_id;
+
+  -- ── The one thing that is still refused: dropping a linked leg ────────────
+  -- Named before anything is written, so the refusal costs nothing.
+  FOR v_leg IN
+    SELECT * FROM public.transaction_splits s
+     WHERE s.transaction_id = p_transaction_id
+       AND s.linked_transfer_id IS NOT NULL
+       AND NOT (s.id::text = ANY(v_incoming_ids))
+  LOOP
+    RAISE EXCEPTION 'split_leg_line_removed: the line transferring to "%" is one half of a transfer — the transaction on the other side would be left pointing at a line that no longer exists. Delete that transfer first, then edit the split.',
+      COALESCE(
+        (SELECT a.name FROM public.accounts a WHERE a.id = v_leg.transfer_account_id),
+        'another account')
+      USING ERRCODE = 'P0001';
+  END LOOP;
+
+  -- ── Lock every account this write can move, in id order ───────────────────
+  -- One statement, deterministic order: concurrent split saves that touch the
+  -- same accounts take them the same way round and cannot deadlock. The
+  -- per-line lookups below therefore need no lock of their own.
+  PERFORM 1 FROM public.accounts a
+   WHERE a.user_id = v_old.user_id
+     AND (
+       a.id = v_old.account_id
+       OR a.id::text IN (
+         SELECT NULLIF(btrim(COALESCE(e.value->>'transfer_account_id', '')), '')
+           FROM jsonb_array_elements(p_splits) e
+       )
+     )
+   ORDER BY a.id
+   FOR UPDATE;
+
+  -- Let this function's own writes through the split guard (transaction-local).
+  PERFORM set_config('app.split_rpc', '1', true);
+
+  -- The lines this edit drops. Every leg is protected above, so nothing
+  -- deleted here can be one.
+  DELETE FROM public.transaction_splits
+   WHERE transaction_id = p_transaction_id
+     AND NOT (id::text = ANY(v_incoming_ids));
+
+  FOR v_split IN SELECT value FROM jsonb_array_elements(p_splits) LOOP
+    v_ord := v_ord + 1;
+    v_in_id := NULLIF(btrim(COALESCE(v_split->>'id', '')), '');
+    v_prev_target := NULL;
+    v_prev_link := NULL;
+
+    v_category := btrim(COALESCE(v_split->>'category', ''));
+    IF v_category = '' THEN
+      RAISE EXCEPTION 'every split line needs a category' USING ERRCODE = '22023';
+    END IF;
+
+    v_amount := (v_split->>'amount')::numeric(20,2);
+    IF v_amount IS NULL OR v_amount = 0 THEN
+      RAISE EXCEPTION 'every split line needs a non-zero amount' USING ERRCODE = '22023';
+    END IF;
+
+    v_memo := NULLIF(btrim(COALESCE(v_split->>'memo', '')), '');
+
+    -- ── The account on the other side, when this line is a leg ──────────────
+    v_target_text := NULLIF(btrim(COALESCE(v_split->>'transfer_account_id', '')), '');
+    v_target := NULL;
+    IF v_target_text IS NOT NULL THEN
+      SELECT * INTO v_acct FROM public.accounts
+       WHERE id::text = v_target_text AND user_id = v_old.user_id;
+      IF NOT FOUND THEN
+        RAISE EXCEPTION 'account_not_found_or_not_owned' USING ERRCODE = 'P0001',
+          HINT = 'A transfer line names an account that is not yours, or no longer exists.';
+      END IF;
+      IF v_acct.id = v_old.account_id THEN
+        RAISE EXCEPTION 'a transfer needs two different accounts' USING ERRCODE = 'P0001',
+          HINT = 'That line points back at the account this transaction is already in.';
+      END IF;
+      v_target := v_acct.id;
+    END IF;
+
+    -- ── The category must be one of this user's ─────────────────────────────
+    SELECT * INTO v_cat FROM public.categories c
+     WHERE c.id::text = v_category AND c.user_id = v_old.user_id;
+    IF NOT FOUND THEN
+      RAISE EXCEPTION 'unknown category: %', v_category USING ERRCODE = '22023';
+    END IF;
+    -- A To/From category IS the sentence "this line is a transfer": it must
+    -- name the same account the line does, and it may not be used without one
+    -- (a transfer to nowhere has no other side to make).
+    IF v_cat.is_transfer_category IS TRUE THEN
+      IF v_target IS NULL THEN
+        RAISE EXCEPTION 'split_leg_not_declared: that line is filed under a To/From account category but does not say which account is on the other side'
+          USING ERRCODE = '22023';
+      END IF;
+      IF v_cat.account_id IS DISTINCT FROM v_target THEN
+        RAISE EXCEPTION 'split_leg_category_mismatch: that line is filed under one account''s To/From category but transfers to a different account'
+          USING ERRCODE = '22023';
+      END IF;
+    END IF;
+    -- The converse is NOT required: the MS Money importer files a leg under
+    -- the "Unassigned" bucket where the To/From category was missing, so a
+    -- leg's category is how it is FILED, while the leg itself lives in
+    -- transfer_account_id. Demanding a To/From category here would make those
+    -- imported splits uneditable, which is the bug this migration exists to fix.
+
+    IF v_in_id IS NOT NULL THEN
+      SELECT * INTO v_old_line FROM public.transaction_splits
+       WHERE id::text = v_in_id AND transaction_id = p_transaction_id;
+      IF NOT FOUND THEN
+        RAISE EXCEPTION 'split_line_not_found: one of these lines is not part of this split any more — reload and look again'
+          USING ERRCODE = 'P0002';
+      END IF;
+      v_prev_target := v_old_line.transfer_account_id;
+      v_prev_link := v_old_line.linked_transfer_id;
+    END IF;
+
+    IF v_prev_link IS NOT NULL THEN
+      -- ── A linked leg: pinned by the row on the other side ─────────────────
+      IF v_amount <> v_old_line.amount THEN
+        RAISE EXCEPTION 'split_leg_amount_locked: the line transferring to "%" has to stay %, because the transaction on the other side is for exactly that much — change the other lines, or delete that transfer first.',
+          COALESCE((SELECT a.name FROM public.accounts a WHERE a.id = v_prev_target), 'another account'),
+          to_char(v_old_line.amount, 'FM999999999990.00')
+          USING ERRCODE = 'P0001';
+      END IF;
+      IF v_target IS DISTINCT FROM v_prev_target THEN
+        RAISE EXCEPTION 'split_leg_target_locked: that line is already linked to a transaction in "%" — moving it would strand that row. Delete that transfer first, then edit the split.',
+          COALESCE((SELECT a.name FROM public.accounts a WHERE a.id = v_prev_target), 'another account')
+          USING ERRCODE = 'P0001';
+      END IF;
+      IF v_category <> v_old_line.category THEN
+        RAISE EXCEPTION 'split_leg_category_locked: that line is one half of a transfer — its category names the account on the other side. Delete that transfer first, then re-file it.'
+          USING ERRCODE = 'P0001';
+      END IF;
+
+      -- Position and memo are not structural, so they may move.
+      UPDATE public.transaction_splits
+         SET memo = v_memo, sort_order = v_ord, updated_at = now()
+       WHERE id = v_old_line.id
+      RETURNING * INTO v_new_line;
+
+    ELSIF v_in_id IS NOT NULL THEN
+      -- ── An ordinary stored line: free to change ───────────────────────────
+      UPDATE public.transaction_splits
+         SET category = v_category,
+             amount = v_amount,
+             memo = v_memo,
+             sort_order = v_ord,
+             transfer_account_id = v_target,
+             updated_at = now()
+       WHERE id = v_old_line.id
+      RETURNING * INTO v_new_line;
+
+    ELSE
+      -- ── A new line ────────────────────────────────────────────────────────
+      INSERT INTO public.transaction_splits
+        (transaction_id, user_id, category, amount, memo, sort_order, transfer_account_id)
+      VALUES
+        (p_transaction_id, v_old.user_id, v_category, v_amount, v_memo, v_ord, v_target)
+      RETURNING * INTO v_new_line;
+    END IF;
+
+    -- ── A line that BECOMES a leg gets its other side made, here and now ────
+    -- Only when it did not already point at that account: a line whose target
+    -- is unchanged keeps whatever link state it has, so a re-save can never
+    -- mint a second counterpart for money that already has one. (An unlinked
+    -- line that still carries a target is a leg whose counterpart was deleted
+    -- — the matching sweep re-pairs those; inventing a new row here would
+    -- duplicate the movement.)
+    IF v_target IS NOT NULL AND v_new_line.linked_transfer_id IS NULL
+       AND v_prev_target IS DISTINCT FROM v_target THEN
+
+      -- The counterpart is -amount with no conversion, so both accounts must
+      -- share a currency — the same guard, and the same reasoning, as
+      -- create_transfer_counterpart (20260721090000). NULL currencies are
+      -- unspecified and never block.
+      SELECT * INTO v_src_acct FROM public.accounts
+       WHERE id = v_old.account_id AND user_id = v_old.user_id;
+      IF FOUND
+         AND v_src_acct.currency IS NOT NULL
+         AND v_acct.currency IS NOT NULL
+         AND v_src_acct.currency <> v_acct.currency THEN
+        RAISE EXCEPTION 'Transfers between accounts in different currencies are not supported yet (% and %)',
+          v_src_acct.currency, v_acct.currency
+          USING ERRCODE = 'P0001';
+      END IF;
+
+      -- Opposite of the LINE, never of the parent — the parent's total
+      -- includes the other lines, and that is the entire point of a mixed
+      -- split. The counterpart points back at BOTH the parent and the exact
+      -- line, which is what makes the pair navigable from either end.
+      INSERT INTO public.transactions
+        (user_id, account_id, description, amount, type, date, category,
+         notes, transfer_account_id, linked_transfer_id, linked_transfer_split_id, is_cleared)
+      VALUES
+        (v_old.user_id, v_target, v_old.description, -v_new_line.amount,
+         'transfer', v_old.date,
+         public.transfer_category_for(v_old.user_id, v_old.account_id, -v_new_line.amount),
+         COALESCE(v_new_line.memo, v_old.notes),
+         v_old.account_id, p_transaction_id, v_new_line.id, false)
+      RETURNING * INTO v_counterpart;
+
+      UPDATE public.transaction_splits
+         SET linked_transfer_id = v_counterpart.id, updated_at = now()
+       WHERE id = v_new_line.id
+      RETURNING * INTO v_new_line;
+
+      -- The new row moves the target account's ledger balance.
+      UPDATE public.accounts
+         SET balance = balance + v_counterpart.amount,
+             updated_at = now()
+       WHERE id = v_target AND user_id = v_old.user_id
+      RETURNING * INTO v_acct_after;
+
+      PERFORM public.write_financial_audit(
+        v_old.user_id, 'transaction', v_counterpart.id, 'create', NULL, to_jsonb(v_counterpart));
+      PERFORM public.write_financial_audit(
+        v_old.user_id, 'account', v_acct_after.id, 'update',
+        to_jsonb(v_acct), to_jsonb(v_acct_after));
+
+      v_counterparts := v_counterparts || jsonb_build_array(to_jsonb(v_counterpart));
+    END IF;
+
+    v_sum := v_sum + v_amount;
+    v_count := v_count + 1;
+  END LOOP;
+
+  IF p_expected_amount IS NOT NULL AND v_sum <> p_expected_amount THEN
+    RAISE EXCEPTION 'split_total_mismatch: split lines sum to % but the transaction amount is %',
+      v_sum, p_expected_amount
+      USING ERRCODE = 'P0001',
+            HINT = 'A transfer line''s amount is pinned by the transaction on its other side, so the remaining lines have to absorb the difference.';
+  END IF;
+
+  -- Verification, inside the transaction that would have to be rolled back:
+  -- the stored lines ARE what this call thinks it wrote. A mismatch means a
+  -- repeated id or a concurrent writer slipped past the guards above, and the
+  -- parent amount below would then be a number no line set supports.
+  SELECT count(*), COALESCE(sum(amount), 0)
+    INTO v_stored_count, v_stored_sum
+    FROM public.transaction_splits
+   WHERE transaction_id = p_transaction_id;
+  IF v_stored_count <> v_count OR v_stored_sum <> v_sum THEN
+    RAISE EXCEPTION 'split_write_inconsistent: the split now holds % line(s) totalling %, but this edit described % line(s) totalling % — nothing has been saved',
+      v_stored_count, v_stored_sum, v_count, v_sum
+      USING ERRCODE = 'P0001';
+  END IF;
+
+  UPDATE public.transactions
+     SET is_split = true,
+         category = '',            -- categorisation lives in the split lines
+         amount = v_sum,
+         updated_at = now()
+   WHERE id = p_transaction_id
+  RETURNING * INTO v_new;
+
+  IF v_new.amount <> v_old.amount THEN
+    SELECT * INTO v_acct
+      FROM public.accounts
+     WHERE id = v_new.account_id AND user_id = v_new.user_id;
+    IF NOT FOUND THEN
+      RAISE EXCEPTION 'account_not_found_or_not_owned' USING ERRCODE = 'P0001';
+    END IF;
+
+    UPDATE public.accounts
+       SET balance = balance + (v_new.amount - v_old.amount),
+           updated_at = now()
+     WHERE id = v_new.account_id AND user_id = v_new.user_id
+    RETURNING * INTO v_acct_after;
+
+    PERFORM public.write_financial_audit(
+      v_new.user_id, 'account', v_acct_after.id, 'update',
+      to_jsonb(v_acct), to_jsonb(v_acct_after));
+  END IF;
+
+  SELECT COALESCE(jsonb_agg(to_jsonb(s) ORDER BY s.sort_order), '[]'::jsonb)
+    INTO v_new_splits
+    FROM public.transaction_splits s
+   WHERE s.transaction_id = p_transaction_id;
+
+  -- A split is audited at its PARENT, with the whole line set embedded in
+  -- before/after — the house pattern set_transaction_splits established.
+  PERFORM public.write_financial_audit(
+    v_new.user_id, 'transaction', v_new.id, 'update',
+    to_jsonb(v_old) || jsonb_build_object('splits', v_old_splits),
+    to_jsonb(v_new) || jsonb_build_object('splits', v_new_splits)
+  );
+
+  RETURN jsonb_build_object(
+    'is_split', true,
+    'split_count', v_count,
+    'amount', v_sum,
+    'counterparts', v_counterparts
+  );
+END;
+$$;
+
+COMMENT ON FUNCTION public.set_transaction_splits_with_legs(uuid, jsonb, numeric, uuid) IS
+  'Writes a split whose lines may include TRANSFER LEGS, matching incoming lines to stored ones by id instead of replacing the set. Creates and links the counterpart for each line that becomes a leg (opposite of the LINE, not the parent), moving that account''s balance. A linked leg may change only its position and memo: removing one, or changing its amount, target or category, is refused by name. Everything else in the split is freely editable — which set_transaction_splits, replacing the whole set, could not allow. One financial_audit_log entry per row touched.';
+
+-- ── link_split_line_transfer: pair an existing line with an existing row ────
+--
+-- The split-line counterpart of link_transfer_pair (20260716100000), and the
+-- primitive the transfer-matching sweep needs: a split line carrying a
+-- transfer_account_id with a NULL linked_transfer_id is an UNMATCHED leg — the
+-- other side is sitting somewhere in that account, already imported by its own
+-- bank, waiting to be recognised rather than duplicated.
+--
+-- Balance-neutral by construction: no amount, sign or account_id is written by
+-- any statement here, so no balance arithmetic appears — the same property
+-- (and the same reasoning) as link_transfer_pair. The invariants below are
+-- copied from it, with the amounts compared against the LINE:
+CREATE OR REPLACE FUNCTION public.link_split_line_transfer(
+  p_split_id uuid,
+  p_transaction_id uuid,
+  p_user_id uuid DEFAULT NULL
+)
+RETURNS jsonb
+LANGUAGE plpgsql SECURITY INVOKER
+SET search_path = public
+AS $$
+DECLARE
+  v_line        public.transaction_splits;
+  v_line_new    public.transaction_splits;
+  v_parent      public.transactions;
+  v_txn         public.transactions;
+  v_txn_new     public.transactions;
+  v_old_splits  jsonb;
+  v_new_splits  jsonb;
+BEGIN
+  SELECT * INTO v_line FROM public.transaction_splits
+   WHERE id = p_split_id AND (p_user_id IS NULL OR user_id = p_user_id)
+   FOR UPDATE;
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'split_line_not_found: that split line no longer exists, or is not yours'
+      USING ERRCODE = 'P0002';
+  END IF;
+
+  SELECT * INTO v_parent FROM public.transactions
+   WHERE id = v_line.transaction_id AND (p_user_id IS NULL OR user_id = p_user_id)
+   FOR UPDATE;
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'transaction_not_found' USING ERRCODE = 'P0002',
+      HINT = 'The split that line belongs to no longer exists, or is not yours.';
+  END IF;
+
+  SELECT * INTO v_txn FROM public.transactions
+   WHERE id = p_transaction_id AND (p_user_id IS NULL OR user_id = p_user_id)
+   FOR UPDATE;
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'transaction_not_found' USING ERRCODE = 'P0002',
+      HINT = 'The transaction being paired with that line no longer exists, or is not yours.';
+  END IF;
+
+  IF v_txn.id = v_parent.id THEN
+    RAISE EXCEPTION 'a transaction cannot be linked to itself' USING ERRCODE = '22023';
+  END IF;
+  IF v_line.linked_transfer_id IS NOT NULL THEN
+    RAISE EXCEPTION 'split_line_already_linked: that line is already one half of a transfer — reload and look again'
+      USING ERRCODE = 'P0001';
+  END IF;
+  IF v_txn.linked_transfer_id IS NOT NULL OR v_txn.linked_transfer_split_id IS NOT NULL THEN
+    RAISE EXCEPTION 'transaction is already part of a linked transfer' USING ERRCODE = 'P0001';
+  END IF;
+  IF v_txn.is_split THEN
+    RAISE EXCEPTION 'a split transaction cannot become a transfer — remove the split first'
+      USING ERRCODE = 'P0001';
+  END IF;
+  IF v_txn.archived THEN
+    RAISE EXCEPTION 'archived_row_not_repairable: that row is archived — bring it back into the register before pairing it'
+      USING ERRCODE = 'P0001';
+  END IF;
+  IF v_txn.account_id = v_parent.account_id THEN
+    RAISE EXCEPTION 'a transfer needs two different accounts' USING ERRCODE = 'P0001';
+  END IF;
+  IF v_line.transfer_account_id IS NOT NULL
+     AND v_line.transfer_account_id IS DISTINCT FROM v_txn.account_id THEN
+    RAISE EXCEPTION 'split_line_target_mismatch: that line transfers to a different account from the one that row sits in'
+      USING ERRCODE = 'P0001';
+  END IF;
+  -- Against the LINE, never the parent: the parent's total includes the other
+  -- lines and is SUPPOSED to differ.
+  IF v_line.amount = 0 OR v_txn.amount <> -v_line.amount THEN
+    RAISE EXCEPTION 'transfer sides must have exactly opposite non-zero amounts (% vs %)',
+      v_txn.amount, v_line.amount USING ERRCODE = 'P0001';
+  END IF;
+
+  SELECT COALESCE(jsonb_agg(to_jsonb(s) ORDER BY s.sort_order), '[]'::jsonb)
+    INTO v_old_splits
+    FROM public.transaction_splits s
+   WHERE s.transaction_id = v_parent.id;
+
+  UPDATE public.transaction_splits
+     SET transfer_account_id = v_txn.account_id,
+         linked_transfer_id = v_txn.id,
+         updated_at = now()
+   WHERE id = v_line.id
+  RETURNING * INTO v_line_new;
+
+  -- The row over there files under the To/From category of the account the
+  -- SPLIT sits in, and points back at both the parent and the exact line.
+  UPDATE public.transactions
+     SET type = 'transfer',
+         category = public.transfer_category_for(v_parent.user_id, v_parent.account_id, v_txn.amount),
+         transfer_account_id = v_parent.account_id,
+         linked_transfer_id = v_parent.id,
+         linked_transfer_split_id = v_line.id,
+         updated_at = now()
+   WHERE id = v_txn.id
+  RETURNING * INTO v_txn_new;
+
+  SELECT COALESCE(jsonb_agg(to_jsonb(s) ORDER BY s.sort_order), '[]'::jsonb)
+    INTO v_new_splits
+    FROM public.transaction_splits s
+   WHERE s.transaction_id = v_parent.id;
+
+  PERFORM public.write_financial_audit(
+    v_txn_new.user_id, 'transaction', v_txn_new.id, 'update',
+    to_jsonb(v_txn), to_jsonb(v_txn_new));
+  PERFORM public.write_financial_audit(
+    v_parent.user_id, 'transaction', v_parent.id, 'update',
+    to_jsonb(v_parent) || jsonb_build_object('splits', v_old_splits),
+    to_jsonb(v_parent) || jsonb_build_object('splits', v_new_splits));
+
+  RETURN jsonb_build_object('split', to_jsonb(v_line_new), 'transaction', to_jsonb(v_txn_new));
+END;
+$$;
+
+COMMENT ON FUNCTION public.link_split_line_transfer(uuid, uuid, uuid) IS
+  'Links an existing split LINE to an existing transaction as the two halves of a transfer: the line takes transfer_account_id + linked_transfer_id, the row takes type/category/transfer_account_id/linked_transfer_id (the split parent) and linked_transfer_split_id (the exact line). Amounts must be exactly opposite between the LINE and the row — never the parent, whose total legitimately differs. Balance-neutral; audited on the row and on the split parent.';
+
+-- ── Grants ──────────────────────────────────────────────────────────────────
+-- FROM PUBLIC, anon — naming anon explicitly, because REVOKE ... FROM PUBLIC
+-- alone does NOT remove Supabase's named default grant to anon (the trap
+-- documented at length in 20260725120000). Re-running these is a no-op.
+REVOKE ALL ON FUNCTION public.set_transaction_splits_with_legs(uuid, jsonb, numeric, uuid) FROM PUBLIC, anon;
+GRANT EXECUTE ON FUNCTION public.set_transaction_splits_with_legs(uuid, jsonb, numeric, uuid) TO authenticated, service_role;
+
+REVOKE ALL ON FUNCTION public.link_split_line_transfer(uuid, uuid, uuid) FROM PUBLIC, anon;
+GRANT EXECUTE ON FUNCTION public.link_split_line_transfer(uuid, uuid, uuid) TO authenticated, service_role;
+
+COMMIT;
+
+-- ============================================================================
+-- VERIFICATION — read this output after applying
+-- ============================================================================
+-- Expected: exactly two rows, each showing `authenticated, service_role` and
+-- neither PUBLIC nor anon.
+SELECT
+  format('%I.%I(%s)', n.nspname, p.proname,
+         pg_get_function_identity_arguments(p.oid)) AS routine,
+  COALESCE(
+    (SELECT string_agg(DISTINCT COALESCE(g.rolname, 'PUBLIC'), ', ')
+       FROM aclexplode(p.proacl) a
+       LEFT JOIN pg_roles g ON g.oid = a.grantee
+      WHERE a.privilege_type = 'EXECUTE'
+        AND COALESCE(g.rolname, 'PUBLIC') IN ('PUBLIC', 'anon', 'authenticated', 'service_role')),
+    '—'
+  ) AS execute_granted_to
+FROM pg_proc p
+JOIN pg_namespace n ON n.oid = p.pronamespace
+WHERE n.nspname = 'public'
+  AND p.proname IN ('set_transaction_splits_with_legs', 'link_split_line_transfer')
+ORDER BY 1;
+
+-- The backlog this unblocks: split parents that contain a linked leg AND still
+-- carry a line filed in the "Unassigned" bucket. Before this migration every
+-- one of them was impossible to file through the UI, because touching any line
+-- meant touching them all. Expected to fall as the owner works through them.
+SELECT count(*) AS splits_with_a_leg_and_an_unfiled_line
+  FROM (
+    SELECT s.transaction_id
+      FROM public.transaction_splits s
+      JOIN public.categories c
+        ON c.id::text = s.category AND c.user_id = s.user_id
+     WHERE c.is_unassigned_bucket IS TRUE
+       AND EXISTS (
+             SELECT 1 FROM public.transaction_splits leg
+              WHERE leg.transaction_id = s.transaction_id
+                AND leg.linked_transfer_id IS NOT NULL)
+     GROUP BY s.transaction_id
+  ) backlog;


### PR DESCRIPTION
## The blocking bug

A split containing a linked transfer leg refused **every** edit — so changing an unrelated line's category was impossible. **33 transactions in the owner's backlog were un-categorisable.**

Root cause: saving a split *replaced* the whole line set (delete-all + insert-all), so the guard genuinely could not distinguish "line 2 re-categorised" from "line 1, a transfer leg, deleted" — and refused everything. The enabling fix: **split lines never carried their identity to the server**. Now they do, the writer matches by id, and the guard narrows to leg-immutability — a linked leg may change only its memo and sort order; removing it or changing its amount, target or category is refused, each with a sentence naming the account and the consequence.

## Also in this batch

- **Mixed splits can be built by hand**, not only imported: the split-line picker offers a "Transfer to another account" section, and saving creates + links the counterpart in one transaction. The owner's case: lend £30,000, receive £35,000 back, record it as one arrival split into loan settlement + interest.
- **Line-aware transfer matching**: an unmatched split leg is matched against rows in its target account at the **line's** amount (never the parent's), ticked/sorted/applied beside whole-transaction pairs, applying via `link_split_line_transfer`. Existing pair suggestions are **byte-identical** — proven by a test that sweeps with and without splits. A leg with no other side anywhere is surfaced with its reason and **deliberately no action**: inventing a counterpart would invent money; re-filing the line would rewrite what the user said the money was for.
- **UK dates everywhere**: 31 native `type="date"` inputs moved to the shared dd/mm/yyyy picker. Natives render in the *browser's* locale — a transaction stored `2017-07-06` displayed as `07/06/2017`. Two further bugs fell out: dates converted through UTC could print the **previous day**, and clearing a date on some forms stored an Invalid Date.
- **"See this transaction in [account]"** on every transaction editor — jumps to the register with the row selected and centred.

## Verification
- **3,959 tests passing** (+97 this batch); strict typecheck + lint clean.
- Migrations `20260806094058` (split legs + precise guard) **applied to production before this deploy** — the safe ordering; both functions smoke-checked live.
- Honest limit: production currently has **0 unmatched split legs** (all 86 were importer-created with both sides), so line-matching is forward-looking and its evidence is the 49 new unit tests, not a demo click-through.

🤖 Generated with [Claude Code](https://claude.com/claude-code)