### PR TITLE
fix(import): an imported statement is not a checked statement, and an empty tag is not its own closing tag

### DIFF
--- a/src/components/OFXImportModal.test.tsx
+++ b/src/components/OFXImportModal.test.tsx
@@ -7,12 +7,21 @@ import type { Account } from '../types';
 
 type ImportTransactionsResult = Awaited<ReturnType<typeof ofxImportService.importTransactions>>;
 
+/** A bank statement for sort code 12-34-56, account 12345678. */
+const OFX_BANK_ACCOUNT: ImportTransactionsResult['ofxAccount'] = {
+  accountId: '12345678',
+  bankId: '123456',
+  accountType: 'CHECKING',
+  isCreditCardStatement: false,
+};
+
 const createMockImportResult = (
   overrides: Partial<ImportTransactionsResult> = {}
 ): ImportTransactionsResult => ({
   transactions: [],
   matchedAccount: null,
-  unmatchedAccount: null,
+  ofxAccount: OFX_BANK_ACCOUNT,
+  matchConfidence: null,
   duplicates: 0,
   newTransactions: 0,
   ...overrides,
@@ -73,10 +82,26 @@ vi.mock('./loading/LoadingState', () => ({
 
 // Mock AppContext
 const mockAddTransaction = vi.fn();
-const mockAccounts = [
-  { id: 'acc1', name: 'Current Account', type: 'checking' },
-  { id: 'acc2', name: 'Savings Account', type: 'savings' },
-  { id: 'acc3', name: 'Credit Card', type: 'credit' }
+const mockUpdateAccount = vi.fn();
+const mockAccount = (overrides: Partial<Account> & Pick<Account, 'id' | 'name' | 'type'>): Account => ({
+  balance: 0,
+  currency: 'GBP',
+  lastUpdated: new Date('2026-01-01'),
+  ...overrides
+});
+
+const mockAccounts: Account[] = [
+  mockAccount({ id: 'acc1', name: 'Current Account', type: 'checking' }),
+  mockAccount({ id: 'acc2', name: 'Savings Account', type: 'savings' }),
+  mockAccount({ id: 'acc3', name: 'Credit Card', type: 'credit' }),
+  // Already has its bank details recorded — nothing may ever be written over them.
+  mockAccount({
+    id: 'acc4',
+    name: 'Filed Account',
+    type: 'current',
+    sortCode: '12-34-56',
+    accountNumber: '12345678'
+  })
 ];
 
 const mockTransactions = [
@@ -104,7 +129,8 @@ vi.mock('../contexts/AppContextSupabase', () => ({
     accounts: mockAccounts,
     transactions: mockTransactions,
     categories: mockCategories,
-    addTransaction: mockAddTransaction
+    addTransaction: mockAddTransaction,
+    updateAccount: mockUpdateAccount
   })
 }));
 
@@ -306,60 +332,128 @@ describe('OFXImportModal', () => {
       });
     });
 
-    it('shows matched account when found', async () => {
+    it('says a guessed match is a guess', async () => {
       const mockParseResult = createMockImportResult({
         transactions: [sampleTransaction],
-        matchedAccount: { id: 'acc1', name: 'Current Account', type: 'checking' } as Account,
-        unmatchedAccount: { accountId: '12345678' },
+        matchedAccount: mockAccounts[0],
+        matchConfidence: 'heuristic',
         newTransactions: 1
       });
-      
+
       vi.mocked(ofxImportService.importTransactions).mockResolvedValueOnce(mockParseResult);
-      
+
       render(<OFXImportModal {...defaultProps} />);
-      
+
       const file = new File(['OFX content'], 'test.ofx', { type: 'application/ofx' });
       const fileInput = document.getElementById('ofx-upload')!
-      
+
       fireEvent.change(fileInput, { target: { files: [file] } });
-      
+
       await waitFor(() => {
         expect(screen.getByText('Automatically matched to: Current Account')).toBeInTheDocument();
-        expect(screen.getByText(/Based on account number ending in 5678/)).toBeInTheDocument();
+        expect(screen.getByText(/A best guess from the account's name and type/)).toBeInTheDocument();
         expect(screen.getByTestId('link-icon')).toBeInTheDocument();
       });
+    });
+
+    it('says an identifier match is the account\'s own recorded details', async () => {
+      const mockParseResult = createMockImportResult({
+        transactions: [sampleTransaction],
+        matchedAccount: mockAccounts[0],
+        matchConfidence: 'identifier',
+        newTransactions: 1
+      });
+
+      vi.mocked(ofxImportService.importTransactions).mockResolvedValueOnce(mockParseResult);
+
+      render(<OFXImportModal {...defaultProps} />);
+
+      const file = new File(['OFX content'], 'test.ofx', { type: 'application/ofx' });
+      const fileInput = document.getElementById('ofx-upload')!
+
+      fireEvent.change(fileInput, { target: { files: [file] } });
+
+      await waitFor(() => {
+        expect(screen.getByText(/Its recorded bank details are the ones in this file/)).toBeInTheDocument();
+      });
+    });
+
+    it('lets the destination be changed even after an automatic match', async () => {
+      // A match the user cannot overrule is a trap when the match is a guess.
+      const mockParseResult = createMockImportResult({
+        transactions: [sampleTransaction],
+        matchedAccount: mockAccounts[0],
+        matchConfidence: 'heuristic',
+        newTransactions: 1
+      });
+
+      vi.mocked(ofxImportService.importTransactions).mockResolvedValueOnce(mockParseResult);
+
+      render(<OFXImportModal {...defaultProps} />);
+
+      const file = new File(['OFX content'], 'test.ofx', { type: 'application/ofx' });
+      const fileInput = document.getElementById('ofx-upload')!
+
+      fireEvent.change(fileInput, { target: { files: [file] } });
+
+      await waitFor(() => {
+        expect(screen.getByRole('combobox', { name: 'Import to Account' })).toBeInTheDocument();
+      });
+
+      chooseAccount(SAVINGS_ACCOUNT);
+      expect(screen.getByRole('combobox', { name: 'Import to Account' }))
+        .toHaveTextContent(SAVINGS_ACCOUNT);
     });
 
     it('shows unmatched account warning when no match found', async () => {
       const mockParseResult = createMockImportResult({
         transactions: [sampleTransaction],
-        unmatchedAccount: {
-          accountId: '12345678',
-          bankId: '123456789'
-        },
         newTransactions: 1
       });
-      
+
       vi.mocked(ofxImportService.importTransactions).mockResolvedValueOnce(mockParseResult);
-      
+
       render(<OFXImportModal {...defaultProps} />);
-      
+
       const file = new File(['OFX content'], 'test.ofx', { type: 'application/ofx' });
       const fileInput = document.getElementById('ofx-upload')!
-      
+
       fireEvent.change(fileInput, { target: { files: [file] } });
-      
+
       await waitFor(() => {
         expect(screen.getByText('No matching account found')).toBeInTheDocument();
-        expect(screen.getByText(/OFX Account: \*\*\*\*5678.*Sort code: 456789/)).toBeInTheDocument();
+        expect(screen.getByText(/OFX Account: \*\*\*\*5678.*Sort code: 12-34-56/)).toBeInTheDocument();
         expect(screen.getByTestId('unlink-icon')).toBeInTheDocument();
       });
+    });
+
+    it('does not present a 9-digit routing number as a sort code', async () => {
+      // A US routing number is not a UK sort code, and its last 6 digits are
+      // not one either — showing it as one invents a fact about the file.
+      const mockParseResult = createMockImportResult({
+        transactions: [sampleTransaction],
+        ofxAccount: { ...OFX_BANK_ACCOUNT, bankId: '123456789' },
+        newTransactions: 1
+      });
+
+      vi.mocked(ofxImportService.importTransactions).mockResolvedValueOnce(mockParseResult);
+
+      render(<OFXImportModal {...defaultProps} />);
+
+      const file = new File(['OFX content'], 'test.ofx', { type: 'application/ofx' });
+      const fileInput = document.getElementById('ofx-upload')!
+
+      fireEvent.change(fileInput, { target: { files: [file] } });
+
+      await waitFor(() => {
+        expect(screen.getByText(/OFX Account: \*\*\*\*5678/)).toBeInTheDocument();
+      });
+      expect(screen.queryByText(/Sort code/)).not.toBeInTheDocument();
     });
 
     it('shows account selection dropdown when no match found', async () => {
       const mockParseResult = createMockImportResult({
         transactions: [sampleTransaction],
-        unmatchedAccount: { accountId: '12345678' },
         newTransactions: 1
       });
       
@@ -386,7 +480,8 @@ describe('OFXImportModal', () => {
           .map(child => child.getAttribute('aria-label'))
       ).toEqual(['Current Accounts', 'Savings Accounts', 'Credit Cards']);
       expect(screen.getAllByRole('option').map(o => o.textContent)).toEqual([
-        'Current Account (checking)', 'Savings Account (savings)', 'Credit Card (credit)',
+        'Current Account (checking)', 'Filed Account (current)',
+        'Savings Account (savings)', 'Credit Card (credit)',
       ]);
     });
 
@@ -564,7 +659,6 @@ describe('OFXImportModal', () => {
         transactions: [{ id: 'trans1', amount: 100, description: 'Test' }],
         duplicates: 0,
         matchedAccount: null,
-        unmatchedAccount: null
       };
       
       vi.mocked(ofxImportService.importTransactions).mockResolvedValueOnce(mockParseResult);
@@ -587,7 +681,6 @@ describe('OFXImportModal', () => {
         transactions: [{ id: 'trans1', amount: 100, description: 'Test' }],
         duplicates: 0,
         matchedAccount: null,
-        unmatchedAccount: null
       };
       
       vi.mocked(ofxImportService.importTransactions).mockResolvedValueOnce(mockParseResult);
@@ -757,16 +850,13 @@ describe('OFXImportModal', () => {
     });
 
     it('handles unmatched account without bank ID', async () => {
-      const mockParseResult = {
-        transactions: [{ id: 'trans1', amount: 100, description: 'Test' }],
-        duplicates: 0,
+      const mockParseResult = createMockImportResult({
+        transactions: [sampleTransaction],
         matchedAccount: null,
-        unmatchedAccount: { 
-          accountId: '12345678'
-          // No bankId
-        }
-      };
-      
+        // No bankId, so no sort code to show.
+        ofxAccount: { accountId: '12345678', accountType: 'CHECKING', isCreditCardStatement: false }
+      });
+
       vi.mocked(ofxImportService.importTransactions).mockResolvedValueOnce(mockParseResult);
       
       render(<OFXImportModal {...defaultProps} />);
@@ -787,7 +877,6 @@ describe('OFXImportModal', () => {
         transactions: [],
         duplicates: 0,
         matchedAccount: null,
-        unmatchedAccount: null
       };
       
       vi.mocked(ofxImportService.importTransactions).mockResolvedValueOnce(mockParseResult);
@@ -810,7 +899,6 @@ describe('OFXImportModal', () => {
         transactions: [{ id: 'trans1', amount: 100, description: 'Test' }],
         duplicates: 0,
         matchedAccount: null,
-        unmatchedAccount: null
       };
       
       const mockImportResult = {
@@ -842,6 +930,174 @@ describe('OFXImportModal', () => {
         expect(screen.getByText('Import Successful!')).toBeInTheDocument();
         expect(screen.getByText('Imported 1 transactions to Savings Account')).toBeInTheDocument();
       });
+    });
+  });
+
+  /**
+   * Filling in an account's blank sort code / account number from the file
+   * being imported. It can only ever fill a blank, it only ever touches the
+   * account the transactions went into, and it always says what it did.
+   */
+  describe('Saving the file\'s details to the account', () => {
+    const CREDIT_CARD = 'Credit Card (credit)';
+    const FILED_ACCOUNT = 'Filed Account (current)';
+
+    const CARD_STATEMENT: ImportTransactionsResult['ofxAccount'] = {
+      // A card statement whose <ACCTID> is the full card number, as some
+      // banks really do publish it.
+      accountId: '4929123456789012',
+      accountType: 'CREDITCARD',
+      isCreditCardStatement: true,
+    };
+
+    /** Upload a file, choose a destination, and press Import. */
+    const runImport = async (
+      parsed: Partial<ImportTransactionsResult>,
+      accountLabel: string | null,
+      importedAccount: Account
+    ): Promise<void> => {
+      const parseResult = createMockImportResult({
+        transactions: [sampleTransaction],
+        newTransactions: 1,
+        ...parsed
+      });
+
+      vi.mocked(ofxImportService.importTransactions)
+        .mockResolvedValueOnce(parseResult)
+        .mockResolvedValueOnce(
+          createMockImportResult({
+            ...parseResult,
+            matchedAccount: importedAccount
+          })
+        );
+
+      render(<OFXImportModal {...defaultProps} />);
+      fireEvent.change(document.getElementById('ofx-upload')!, {
+        target: { files: [new File(['OFX content'], 'test.ofx', { type: 'application/ofx' })] }
+      });
+
+      await waitFor(() => {
+        expect(screen.getByRole('combobox', { name: 'Import to Account' })).toBeInTheDocument();
+      });
+      if (accountLabel) chooseAccount(accountLabel);
+    };
+
+    const pressImport = async (): Promise<void> => {
+      fireEvent.click(screen.getByTestId('loading-button'));
+      await waitFor(() => {
+        expect(screen.getByText('Import Successful!')).toBeInTheDocument();
+      });
+    };
+
+    it('fills in a chosen account\'s blank details and says it did', async () => {
+      await runImport({}, SAVINGS_ACCOUNT, mockAccounts[1]);
+
+      expect(screen.getByRole('checkbox', { name: /Save this file's/ })).toBeChecked();
+      await pressImport();
+
+      expect(mockUpdateAccount).toHaveBeenCalledWith('acc2', {
+        sortCode: '12-34-56',
+        accountNumber: '12345678'
+      });
+      expect(screen.getByText(/Also saved to Savings Account/)).toBeInTheDocument();
+      expect(screen.getByText(/sort code 12-34-56 and account number ending 5678/)).toBeInTheDocument();
+    });
+
+    it('does not call a chosen account a guess, even after the box is unticked', async () => {
+      await runImport({}, SAVINGS_ACCOUNT, mockAccounts[1]);
+
+      const checkbox = screen.getByRole('checkbox', { name: /Save this file's/ });
+      fireEvent.click(checkbox);
+
+      expect(checkbox).not.toBeChecked();
+      expect(screen.queryByText(/Off by default because this account was a guess/)).not.toBeInTheDocument();
+
+      await pressImport();
+      expect(mockUpdateAccount).not.toHaveBeenCalled();
+    });
+
+    it('never names a full account number in what it tells the user', async () => {
+      await runImport({}, SAVINGS_ACCOUNT, mockAccounts[1]);
+      await pressImport();
+
+      expect(document.body.textContent).not.toContain('12345678');
+    });
+
+    it('leaves an account that already has its details completely alone', async () => {
+      await runImport({}, FILED_ACCOUNT, mockAccounts[3]);
+
+      expect(screen.queryByRole('checkbox', { name: /Save this file's/ })).not.toBeInTheDocument();
+      await pressImport();
+
+      expect(mockUpdateAccount).not.toHaveBeenCalled();
+      expect(screen.queryByText(/Also saved to/)).not.toBeInTheDocument();
+    });
+
+    it('does not act on a guessed match unless the user says so', async () => {
+      await runImport(
+        {
+          matchedAccount: mockAccounts[1],
+          matchConfidence: 'heuristic'
+        },
+        null,
+        mockAccounts[1]
+      );
+
+      const checkbox = screen.getByRole('checkbox', { name: /Save this file's/ });
+      expect(checkbox).not.toBeChecked();
+      expect(screen.getByText(/Off by default because this account was a guess/)).toBeInTheDocument();
+
+      await pressImport();
+      expect(mockUpdateAccount).not.toHaveBeenCalled();
+    });
+
+    it('acts on a guessed match once the user ticks the box', async () => {
+      await runImport(
+        {
+          matchedAccount: mockAccounts[1],
+          matchConfidence: 'heuristic'
+        },
+        null,
+        mockAccounts[1]
+      );
+
+      fireEvent.click(screen.getByRole('checkbox', { name: /Save this file's/ }));
+      await pressImport();
+
+      expect(mockUpdateAccount).toHaveBeenCalledWith('acc2', {
+        sortCode: '12-34-56',
+        accountNumber: '12345678'
+      });
+    });
+
+    it('stores only the last 4 digits of a card, and never the number itself', async () => {
+      await runImport({ ofxAccount: CARD_STATEMENT }, CREDIT_CARD, mockAccounts[2]);
+      await pressImport();
+
+      expect(mockUpdateAccount).toHaveBeenCalledWith('acc3', { accountNumber: '9012' });
+      expect(screen.getByText(/card ending 9012/)).toBeInTheDocument();
+      // The full card number must not survive anywhere the user can see it,
+      // let alone anywhere it would be stored.
+      expect(document.body.textContent).not.toContain('4929123456789012');
+    });
+
+    it('refuses to write a card statement onto a current account', async () => {
+      // <ACCTID> may be a full card number; its first 8 digits are not an
+      // account number, and storing them would be storing part of a card.
+      await runImport({ ofxAccount: CARD_STATEMENT }, SAVINGS_ACCOUNT, mockAccounts[1]);
+
+      expect(screen.queryByRole('checkbox', { name: /Save this file's/ })).not.toBeInTheDocument();
+      await pressImport();
+      expect(mockUpdateAccount).not.toHaveBeenCalled();
+    });
+
+    it('still reports the import as done when saving the details fails', async () => {
+      mockUpdateAccount.mockRejectedValueOnce(new Error('offline'));
+      await runImport({}, SAVINGS_ACCOUNT, mockAccounts[1]);
+      await pressImport();
+
+      expect(screen.getByText('Imported 1 transactions to Savings Account')).toBeInTheDocument();
+      expect(screen.getByText(/Couldn't save .* to Savings Account/)).toBeInTheDocument();
     });
   });
 });

--- a/src/components/OFXImportModal.tsx
+++ b/src/components/OFXImportModal.tsx
@@ -1,6 +1,11 @@
-import React, { useState, useCallback } from 'react';
+import React, { useState, useCallback, useMemo } from 'react';
 import { useApp } from '../contexts/AppContextSupabase';
 import { ofxImportService } from '../services/ofxImportService';
+import {
+  planAccountDetailsBackfill,
+  readOfxAccountIdentifiers
+} from '../utils/ofxAccountIdentifiers';
+import { keepLastFour } from '../utils/accountNumberInput';
 import { Modal } from './common/Modal';
 import {
   UploadIcon,
@@ -32,6 +37,10 @@ type ImportOutcome =
       imported: number;
       duplicates: number;
       account: Account | null;
+      /** Set when the import also filled in the account's blank bank details. */
+      savedDetails?: { accountName: string; summary: string };
+      /** Set when saving those details failed — the transactions still landed. */
+      savedDetailsError?: string;
     }
   | {
       success: false;
@@ -39,32 +48,42 @@ type ImportOutcome =
     };
 
 export default function OFXImportModal({ isOpen, onClose }: OFXImportModalProps): React.JSX.Element {
-  const { accounts, transactions, categories, addTransaction } = useApp();
+  const { accounts, transactions, categories, addTransaction, updateAccount } = useApp();
   const [file, setFile] = useState<File | null>(null);
   const [isProcessing, setIsProcessing] = useState(false);
   const [parseResult, setParseResult] = useState<ImportTransactionsResult | null>(null);
   const [importResult, setImportResult] = useState<ImportOutcome | null>(null);
   const [selectedAccountId, setSelectedAccountId] = useState<string>('');
   const [skipDuplicates, setSkipDuplicates] = useState(true);
+  /**
+   * Whether the destination account is the user's own choice rather than the
+   * importer's guess. It decides the DEFAULT for saving the file's details
+   * onto the account: an account someone picked by name is a decision, while
+   * the automatic match can be nothing more than "the only savings account
+   * you have", which is not something to write onto a record permanently.
+   */
+  const [accountIsUserChoice, setAccountIsUserChoice] = useState(false);
+  /** null = follow the default above; true/false = the user said so. */
+  const [saveDetailsOverride, setSaveDetailsOverride] = useState<boolean | null>(null);
 
   const parseFile = useCallback(async (targetFile: File) => {
     setIsProcessing(true);
-    
+
     try {
       const content = await targetFile.text();
       const result = await ofxImportService.importTransactions(
         content,
         accounts,
         transactions,
-        { 
+        {
           skipDuplicates: false,
           categories,
           autoCategorize: true
         }
       );
-      
+
       setParseResult(result);
-      
+
       if (result.matchedAccount) {
         setSelectedAccountId(result.matchedAccount.id);
       }
@@ -75,7 +94,47 @@ export default function OFXImportModal({ isOpen, onClose }: OFXImportModalProps)
       setIsProcessing(false);
     }
   }, [accounts, categories, transactions]);
-  
+
+  const selectedAccount = useMemo(
+    () => accounts.find(a => a.id === selectedAccountId) ?? null,
+    [accounts, selectedAccountId]
+  );
+
+  // What the file says about its own account, in the only forms fit to show
+  // anyone: a sort code, and the last 4 digits. Never the whole number — on a
+  // card statement that is the full card number.
+  const fileLastFour = parseResult?.ofxAccount
+    ? keepLastFour(parseResult.ofxAccount.accountId)
+    : '';
+  const fileSortCode = parseResult?.ofxAccount
+    ? readOfxAccountIdentifiers(parseResult.ofxAccount).sortCode ?? ''
+    : '';
+
+  // What this file could fill in on the chosen account — null whenever there
+  // is nothing to add, which is most of the time: details already recorded,
+  // details that disagree with the file, or a file of the wrong kind.
+  const detailsToSave = useMemo(() => {
+    if (!parseResult?.ofxAccount || !selectedAccount) return null;
+    return planAccountDetailsBackfill(parseResult.ofxAccount, selectedAccount);
+  }, [parseResult, selectedAccount]);
+
+  // An identifier match is the account's own recorded sort code / account
+  // number, so it is as good as the user pointing at it.
+  const matchIsCertain =
+    parseResult?.matchConfidence === 'identifier' &&
+    parseResult.matchedAccount?.id === selectedAccountId;
+
+  // Automatic when the destination is a decision (the user picked it, or the
+  // account's own recorded details are the file's), off when it is a guess.
+  const saveDetailsByDefault = accountIsUserChoice || matchIsCertain;
+  const saveDetails = detailsToSave !== null && (saveDetailsOverride ?? saveDetailsByDefault);
+
+  const handleAccountChange = useCallback((accountId: string) => {
+    setSelectedAccountId(accountId);
+    setAccountIsUserChoice(true);
+    setSaveDetailsOverride(null);
+  }, []);
+
   // Handle file upload
   const handleFileUpload = useCallback((event: React.ChangeEvent<HTMLInputElement>) => {
     const uploadedFile = event.target.files?.[0];
@@ -90,7 +149,9 @@ export default function OFXImportModal({ isOpen, onClose }: OFXImportModalProps)
     setFile(uploadedFile);
     setParseResult(null);
     setImportResult(null);
-    
+    setAccountIsUserChoice(false);
+    setSaveDetailsOverride(null);
+
     // Parse the file
     parseFile(uploadedFile);
   }, [parseFile]);
@@ -104,6 +165,8 @@ export default function OFXImportModal({ isOpen, onClose }: OFXImportModalProps)
       setFile(droppedFile);
       setParseResult(null);
       setImportResult(null);
+      setAccountIsUserChoice(false);
+      setSaveDetailsOverride(null);
       parseFile(droppedFile);
     }
   }, [parseFile]);
@@ -132,13 +195,40 @@ export default function OFXImportModal({ isOpen, onClose }: OFXImportModalProps)
       for (const transaction of result.transactions) {
         addTransaction(transaction);
       }
-      
+
       const account = result.matchedAccount ?? accounts.find(a => a.id === selectedAccountId) ?? null;
+
+      // Fill in the account's blank bank details from the file, but only ever
+      // on the account the transactions themselves just went into, and only
+      // after they landed — an import that failed must not leave an edited
+      // account behind. The plan is worked out again here against that real
+      // destination rather than reused from the preview, so what gets written
+      // is decided by where the money went.
+      let savedDetails: { accountName: string; summary: string } | undefined;
+      let savedDetailsError: string | undefined;
+      const plan = saveDetails && account
+        ? planAccountDetailsBackfill(result.ofxAccount, account)
+        : null;
+
+      if (plan && account) {
+        try {
+          await updateAccount(account.id, plan.updates);
+          savedDetails = { accountName: account.name, summary: plan.summary };
+        } catch (error) {
+          // The transactions are already in. Say so rather than failing the
+          // whole import over a detail the user can still type in by hand.
+          logger.error('Failed to save bank details from OFX file', error);
+          savedDetailsError = `Couldn't save ${plan.summary} to ${account.name}. The transactions imported fine — you can add the details in the account's settings.`;
+        }
+      }
+
       setImportResult({
         success: true,
         imported: result.newTransactions,
         duplicates: result.duplicates,
-        account
+        account,
+        savedDetails,
+        savedDetailsError
       });
     } catch (error) {
       logger.error('Import error', error);
@@ -149,14 +239,16 @@ export default function OFXImportModal({ isOpen, onClose }: OFXImportModalProps)
     } finally {
       setIsProcessing(false);
     }
-  }, [accounts, addTransaction, file, parseResult, selectedAccountId, skipDuplicates, transactions, categories]);
-  
+  }, [accounts, addTransaction, file, parseResult, saveDetails, selectedAccountId, skipDuplicates, transactions, categories, updateAccount]);
+
   // Reset modal
   const resetModal = useCallback(() => {
     setFile(null);
     setParseResult(null);
     setImportResult(null);
     setSelectedAccountId('');
+    setAccountIsUserChoice(false);
+    setSaveDetailsOverride(null);
   }, []);
   
   return (
@@ -235,9 +327,9 @@ export default function OFXImportModal({ isOpen, onClose }: OFXImportModalProps)
               <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
                 Import to Account
               </label>
-              
+
               {parseResult.matchedAccount ? (
-                <div className="p-4 bg-blue-50 dark:bg-blue-900/20 border border-blue-200 dark:border-blue-800 rounded-lg">
+                <div className="p-4 mb-3 bg-blue-50 dark:bg-blue-900/20 border border-blue-200 dark:border-blue-800 rounded-lg">
                   <div className="flex items-start gap-3">
                     <LinkIcon className="text-blue-600 dark:text-blue-400 mt-0.5" size={20} />
                     <div>
@@ -245,45 +337,72 @@ export default function OFXImportModal({ isOpen, onClose }: OFXImportModalProps)
                         Automatically matched to: {parseResult.matchedAccount.name}
                       </p>
                       <p className="text-sm text-blue-800 dark:text-blue-200 mt-1">
-                        Based on account number ending in {parseResult.unmatchedAccount?.accountId.slice(-4)}
+                        {parseResult.matchConfidence === 'identifier'
+                          ? `Its recorded bank details are the ones in this file (account ending ${fileLastFour}).`
+                          : `A best guess from the account's name and type — nothing recorded on your accounts matches account ending ${fileLastFour}, so check this is right.`}
                       </p>
                     </div>
                   </div>
                 </div>
               ) : (
-                <>
-                  {parseResult.unmatchedAccount && (
-                    <div className="p-4 mb-3 bg-yellow-50 dark:bg-yellow-900/20 border border-yellow-200 dark:border-yellow-800 rounded-lg">
-                      <div className="flex items-start gap-3">
-                        <UnlinkIcon className="text-yellow-600 dark:text-yellow-400 mt-0.5" size={20} />
-                        <div>
-                          <p className="font-medium text-yellow-900 dark:text-yellow-300">
-                            No matching account found
-                          </p>
-                          <p className="text-sm text-yellow-800 dark:text-yellow-200 mt-1">
-                            OFX Account: ****{parseResult.unmatchedAccount.accountId.slice(-4)}
-                            {parseResult.unmatchedAccount.bankId && ` (Sort code: ${parseResult.unmatchedAccount.bankId.slice(-6)})`}
-                          </p>
-                        </div>
+                parseResult.ofxAccount && (
+                  <div className="p-4 mb-3 bg-yellow-50 dark:bg-yellow-900/20 border border-yellow-200 dark:border-yellow-800 rounded-lg">
+                    <div className="flex items-start gap-3">
+                      <UnlinkIcon className="text-yellow-600 dark:text-yellow-400 mt-0.5" size={20} />
+                      <div>
+                        <p className="font-medium text-yellow-900 dark:text-yellow-300">
+                          No matching account found
+                        </p>
+                        <p className="text-sm text-yellow-800 dark:text-yellow-200 mt-1">
+                          OFX Account: ****{fileLastFour}
+                          {fileSortCode && ` (Sort code: ${fileSortCode})`}
+                        </p>
                       </div>
                     </div>
-                  )}
-                  
-                  <AccountSelector
-                    accounts={accounts}
-                    selectedAccountId={selectedAccountId}
-                    onAccountChange={setSelectedAccountId}
-                    placeholder="Search or select an account…"
-                    formatLabel={(account) => `${account.name} (${account.type})`}
-                    className="w-full px-3 py-2 h-[42px] border border-gray-300 dark:border-gray-600 rounded-lg focus:ring-2 focus:ring-primary focus:border-transparent dark:bg-gray-700 dark:text-white"
-                    usePortal
-                    required
-                    ariaLabel="Import to Account"
-                  />
-                </>
+                  </div>
+                )
+              )}
+
+              {/* Always offered, even after an automatic match: the match can
+                  be a guess, and a guess the user cannot overrule is a trap. */}
+              <AccountSelector
+                accounts={accounts}
+                selectedAccountId={selectedAccountId}
+                onAccountChange={handleAccountChange}
+                placeholder="Search or select an account…"
+                formatLabel={(account) => `${account.name} (${account.type})`}
+                className="w-full px-3 py-2 h-[42px] border border-gray-300 dark:border-gray-600 rounded-lg focus:ring-2 focus:ring-primary focus:border-transparent dark:bg-gray-700 dark:text-white"
+                usePortal
+                required
+                ariaLabel="Import to Account"
+              />
+
+              {/* Filling in blank bank details is an edit to the account, so it
+                  is stated here before it happens rather than discovered in
+                  the account's settings weeks later. */}
+              {detailsToSave && selectedAccount && (
+                <div className="mt-3 p-3 bg-gray-50 dark:bg-gray-700/50 border border-gray-200 dark:border-gray-600 rounded-lg">
+                  <label className="flex items-start gap-2">
+                    <input
+                      type="checkbox"
+                      checked={saveDetails}
+                      onChange={(e) => setSaveDetailsOverride(e.target.checked)}
+                      className="mt-0.5 rounded border-gray-300 text-primary focus:ring-primary"
+                    />
+                    <span className="text-sm font-medium text-gray-700 dark:text-gray-300">
+                      Save this file&apos;s {detailsToSave.summary} to {selectedAccount.name}
+                    </span>
+                  </label>
+                  <p className="text-xs text-gray-500 dark:text-gray-400 ml-6 mt-1">
+                    {selectedAccount.name} has none recorded, so this file has to be
+                    matched by hand every time. Saving them now means the next one
+                    finds it on its own.
+                    {!saveDetailsByDefault && ' Off by default because this account was a guess — confirm it is the right one first.'}
+                  </p>
+                </div>
               )}
             </div>
-            
+
             {/* Import Options */}
             <div>
               <label className="flex items-center gap-2">
@@ -357,6 +476,22 @@ export default function OFXImportModal({ isOpen, onClose }: OFXImportModalProps)
                 {importResult.duplicates > 0 && (
                   <p className="text-sm text-yellow-600 dark:text-yellow-400 mb-6">
                     Skipped {importResult.duplicates} duplicate transactions
+                  </p>
+                )}
+
+                {/* An edit to an account is not something to leave someone to
+                    find on their own months later. */}
+                {importResult.savedDetails && (
+                  <p className="text-sm text-gray-600 dark:text-gray-400 mb-6">
+                    Also saved to {importResult.savedDetails.accountName}:{' '}
+                    {importResult.savedDetails.summary}. The next file from this
+                    account will match it without asking.
+                  </p>
+                )}
+
+                {importResult.savedDetailsError && (
+                  <p className="text-sm text-yellow-600 dark:text-yellow-400 mb-6">
+                    {importResult.savedDetailsError}
                   </p>
                 )}
               </>

--- a/src/services/ofxImportService.test.ts
+++ b/src/services/ofxImportService.test.ts
@@ -134,7 +134,8 @@ NEWFILEUID:NONE
         bankId: '123456',
         accountId: '12345678',
         accountType: 'CHECKING',
-        branchId: undefined
+        branchId: undefined,
+        isCreditCardStatement: false
       });
 
       expect(result.transactions).toHaveLength(3);
@@ -250,6 +251,36 @@ NEWFILEUID:NONE
 
       const result = ofxImportService.parseOFX(creditCardOFX);
       expect(result.account.accountType).toBe('CREDITCARD');
+      expect(result.account.isCreditCardStatement).toBe(true);
+    });
+
+    it('recognises a card statement that omits ACCTTYPE, rather than filing it as a current account', () => {
+      const creditCardOFX = validOFXContent
+        .replace('<BANKACCTFROM>', '<CCACCTFROM>')
+        .replace('</BANKACCTFROM>', '</CCACCTFROM>')
+        .replace('<ACCTTYPE>CHECKING\n', '')
+        .replace('<BANKID>123456\n', '');
+
+      const result = ofxImportService.parseOFX(creditCardOFX);
+      expect(result.account.isCreditCardStatement).toBe(true);
+      expect(result.account.accountType).toBe('CREDITCARD');
+    });
+
+    it('reads the account tags from the account section, not from anywhere in the file', () => {
+      // A payee address block carrying its own <BANKID> must not become the
+      // statement's sort code.
+      const ofxWithPayeeBlock = validOFXContent.replace(
+        '<BANKACCTFROM>',
+        `<PAYEEBANKACCTFROM>
+<BANKID>999999
+<ACCTID>99999999
+</PAYEEBANKACCTFROM>
+<BANKACCTFROM>`
+      );
+
+      const result = ofxImportService.parseOFX(ofxWithPayeeBlock);
+      expect(result.account.bankId).toBe('123456');
+      expect(result.account.accountId).toBe('12345678');
     });
   });
 
@@ -307,6 +338,53 @@ NEWFILEUID:NONE
     });
   });
 
+  describe('matchAccount confidence', () => {
+    const ofxAccount = {
+      accountId: '12345678',
+      accountType: 'CHECKING',
+      bankId: '123456',
+      isCreditCardStatement: false
+    };
+
+    it('calls a match on the account\'s own recorded details an identifier match', () => {
+      const recorded: Account = {
+        ...mockAccounts[1],
+        id: 'acc-recorded',
+        sortCode: '12-34-56',
+        accountNumber: '12345678'
+      };
+
+      const match = ofxImportService.matchAccount(ofxAccount, [recorded]);
+      expect(match).toEqual({ account: recorded, confidence: 'identifier' });
+    });
+
+    it('prefers the recorded identifiers over an account whose NAME happens to contain the digits', () => {
+      const recorded: Account = {
+        ...mockAccounts[1],
+        id: 'acc-recorded',
+        sortCode: '12-34-56',
+        accountNumber: '12345678'
+      };
+
+      // mockAccounts[0] is named "Main Current Account (****5678)".
+      const match = ofxImportService.matchAccount(ofxAccount, [...mockAccounts, recorded]);
+      expect(match?.account).toBe(recorded);
+    });
+
+    it('calls a name-substring match a guess', () => {
+      const match = ofxImportService.matchAccount(ofxAccount, mockAccounts);
+      expect(match).toEqual({ account: mockAccounts[0], confidence: 'heuristic' });
+    });
+
+    it('calls the only-account-of-this-type fallback a guess', () => {
+      const match = ofxImportService.matchAccount(
+        { accountId: '99999999', accountType: 'SAVINGS', isCreditCardStatement: false },
+        mockAccounts
+      );
+      expect(match).toEqual({ account: mockAccounts[1], confidence: 'heuristic' });
+    });
+  });
+
   describe('importTransactions', () => {
     const existingTransactions: Transaction[] = [
       {
@@ -344,7 +422,6 @@ NEWFILEUID:NONE
       expect(result.newTransactions).toBe(3);
       expect(result.duplicates).toBe(0);
       expect(result.matchedAccount).toBe(mockAccounts[0]);
-      expect(result.unmatchedAccount).toBeUndefined();
 
       expect(result.transactions).toHaveLength(3);
       
@@ -399,6 +476,19 @@ NEWFILEUID:NONE
 
       expect(result.matchedAccount).toBe(mockAccounts[1]);
       expect(result.transactions.every(t => t.accountId === 'acc2')).toBe(true);
+      // The caller named the account, so the file did not choose it and there
+      // is no confidence in the match to report.
+      expect(result.matchConfidence).toBeNull();
+    });
+
+    it('always reports the file\'s own account, matched or not', async () => {
+      const matched = await ofxImportService.importTransactions(validOFXContent, mockAccounts, []);
+      expect(matched.ofxAccount.accountId).toBe('12345678');
+      expect(matched.matchConfidence).toBe('heuristic');
+
+      const unmatched = await ofxImportService.importTransactions(validOFXContent, [], []);
+      expect(unmatched.ofxAccount.accountId).toBe('12345678');
+      expect(unmatched.matchConfidence).toBeNull();
     });
 
     it('detects and skips duplicate transactions', async () => {
@@ -514,11 +604,12 @@ NEWFILEUID:NONE
       );
 
       expect(result.matchedAccount).toBeNull();
-      expect(result.unmatchedAccount).toEqual({
+      expect(result.ofxAccount).toEqual({
         bankId: '123456',
         accountId: '12345678',
         accountType: 'CHECKING',
-        branchId: undefined
+        branchId: undefined,
+        isCreditCardStatement: false
       });
       expect(result.transactions.every(t => t.accountId === 'default')).toBe(true);
     });
@@ -729,5 +820,45 @@ NEWFILEUID:NONE
       expect(result.newTransactions).toBe(3);
       expect(result.matchedAccount).toBe(mockAccounts[0]);
     });
+  });
+});
+
+describe('a tag that is present but empty', () => {
+  // Regression: a Coutts (Sage-format) export writes <MEMO></MEMO> for a
+  // transaction with no memo. The old reader was `closed || unclosed`, and ''
+  // is falsy, so it fell through to the line-terminated read and captured the
+  // literal "</MEMO>". 17 of the 19 transactions in the reported file were
+  // described that way.
+  const emptyMemoOFX = `<OFX>
+<BANKMSGSRSV1><STMTTRNRS><STMTRS>
+<CURDEF>GBP</CURDEF>
+<BANKACCTFROM><BANKID>123456</BANKID><ACCTID>12345678</ACCTID><ACCTTYPE>CHECKING</ACCTTYPE></BANKACCTFROM>
+<BANKTRANLIST>
+<STMTTRN>
+<TRNTYPE>CREDIT</TRNTYPE>
+<DTPOSTED>20260806000000.000</DTPOSTED>
+<TRNAMT>2000</TRNAMT>
+<FITID>ABC123</FITID>
+<NAME>Two Way Sweep from account 04357</NAME>
+<MEMO></MEMO>
+</STMTTRN>
+</BANKTRANLIST>
+</STMTRS></STMTTRNRS></BANKMSGSRSV1>
+</OFX>`;
+
+  it('reads an empty element as empty, not as its own closing tag', () => {
+    const parsed = ofxImportService.parseOFX(emptyMemoOFX);
+    expect(parsed.transactions).toHaveLength(1);
+    expect(parsed.transactions[0].name).toBe('Two Way Sweep from account 04357');
+    expect(parsed.transactions[0].memo).toBeUndefined();
+  });
+
+  it('leaves no value shaped like a tag anywhere in the parse', () => {
+    const parsed = ofxImportService.parseOFX(emptyMemoOFX);
+    const values = parsed.transactions.flatMap(t => [t.name, t.memo, t.type, t.fitId, t.checkNum, t.refNum]);
+    // Whole-parse assertion rather than memo-only: the same reader served
+    // TRNTYPE, TRNAMT, FITID, NAME, CHECKNUM and REFNUM, so an empty
+    // <TRNAMT></TRNAMT> would have become the string "</TRNAMT>".
+    expect(values.filter(v => typeof v === 'string' && /^<\/?[A-Z]+>$/.test(v))).toEqual([]);
   });
 });

--- a/src/services/ofxImportService.test.ts
+++ b/src/services/ofxImportService.test.ts
@@ -322,6 +322,18 @@ NEWFILEUID:NONE
       }
     ];
 
+    it('never marks an imported OFX transaction as cleared', async () => {
+      const result = await ofxImportService.importTransactions(
+        validOFXContent,
+        mockAccounts,
+        []
+      );
+      expect(result.transactions.length).toBeGreaterThan(0);
+      // Every one, not "none happened to be true" — a partly-cleared import is
+      // the shape that hides a row nobody checked.
+      expect(result.transactions.every(t => t.cleared === false)).toBe(true);
+    });
+
     it('imports transactions successfully', async () => {
       const result = await ofxImportService.importTransactions(
         validOFXContent,
@@ -345,7 +357,10 @@ NEWFILEUID:NONE
         amount: -25.50,
         type: 'expense',
         accountId: 'acc1',
-        cleared: true
+        // Imported statements arrive UNRECONCILED. The bank having processed a
+        // payment is not the same as the user having checked it against their
+        // statement, and importing is precisely when that check should happen.
+        cleared: false
       });
       expectDateOnly(trx1.date, '2024-01-15');
       expect(trx1.notes).toContain('FITID: 2024011501');
@@ -357,7 +372,7 @@ NEWFILEUID:NONE
         amount: 2500,
         type: 'income',
         accountId: 'acc1',
-        cleared: true
+        cleared: false
       });
       expectDateOnly(trx2.date, '2024-01-20');
 
@@ -368,7 +383,7 @@ NEWFILEUID:NONE
         amount: -100,
         type: 'expense',
         accountId: 'acc1',
-        cleared: true
+        cleared: false
       });
       expectDateOnly(trx3.date, '2024-01-10');
       expect(trx3.notes).toContain('Check #: 1234');

--- a/src/services/ofxImportService.ts
+++ b/src/services/ofxImportService.ts
@@ -364,7 +364,14 @@ export class OFXImportService {
         type,
         accountId: matchedAccount?.id || 'default',
         category: '',
-        cleared: true, // OFX transactions are already cleared
+        // Deliberately NOT cleared, despite the file coming from the bank.
+        // "Cleared" here does not mean the bank has processed it — it means the
+        // USER has checked it against their statement and finalised the
+        // reconciliation. Importing a statement is the moment that check should
+        // happen, so arriving pre-cleared skips the one step that would catch a
+        // missing or wrong row and leave the account agreeing with the bank.
+        // Every other file importer already defaults this false; OFX was alone.
+        cleared: false,
         notes,
         isRecurring: false
       };

--- a/src/services/ofxImportService.ts
+++ b/src/services/ofxImportService.ts
@@ -1,6 +1,7 @@
 import type { Transaction, Account, Category } from '../types';
 import { smartCategorizationService } from './smartCategorizationService';
 import { toDecimal, toNumber } from '../utils/decimal';
+import { findAccountByOfxIdentifiers } from '../utils/ofxAccountIdentifiers';
 
 interface OFXTransaction {
   type: string;
@@ -13,11 +14,34 @@ interface OFXTransaction {
   refNum?: string;
 }
 
-interface OFXAccount {
+export interface OFXAccount {
   bankId?: string;
   accountId: string;
   accountType: string;
   branchId?: string;
+  /**
+   * True when the statement came from <CCACCTFROM> rather than <BANKACCTFROM>.
+   * It matters because in a card section <ACCTID> is the CARD number, which
+   * some banks publish in full — so nothing may treat it as an account number.
+   */
+  isCreditCardStatement: boolean;
+}
+
+/**
+ * How much the account match is worth trusting.
+ *
+ * 'identifier' means the account's own recorded sort code / account number (or
+ * a card's last 4) is the one in the file — a fact. 'heuristic' means the file
+ * was matched by a digit or two appearing in the account's name, or by being
+ * the only account of its type — a guess that is usually right and sometimes
+ * spectacularly wrong. Callers that write anything permanent must tell them
+ * apart.
+ */
+export type AccountMatchConfidence = 'identifier' | 'heuristic';
+
+export interface AccountMatch {
+  account: Account;
+  confidence: AccountMatchConfidence;
 }
 
 interface OFXParseResult {
@@ -55,14 +79,11 @@ export class OFXImportService {
     const balance = this.parseBalance(ofxContent);
     
     // Parse date range
-    const startDate = this.extractValue(ofxContent, '<DTSTART>', '</DTSTART>') || 
-                     this.extractValue(ofxContent, '<DTSTART>', '\n');
-    const endDate = this.extractValue(ofxContent, '<DTEND>', '</DTEND>') || 
-                   this.extractValue(ofxContent, '<DTEND>', '\n');
+    const startDate = this.readTag(ofxContent, 'DTSTART');
+    const endDate = this.readTag(ofxContent, 'DTEND');
     
     // Parse currency
-    const currency = this.extractValue(ofxContent, '<CURDEF>', '</CURDEF>') || 
-                    this.extractValue(ofxContent, '<CURDEF>', '\n') || 
+    const currency = this.readTag(ofxContent, 'CURDEF') || 
                     'GBP';
     
     return {
@@ -79,36 +100,57 @@ export class OFXImportService {
    * Parse account information from OFX
    */
   private parseAccountInfo(content: string): OFXAccount {
-    // Try bank account first
-    let accountId = this.extractValue(content, '<ACCTID>', '</ACCTID>') || 
-                   this.extractValue(content, '<ACCTID>', '\n');
-    
-    // Try credit card account
-    if (!accountId) {
-      accountId = this.extractValue(content, '<ACCTID>', '</ACCTID>') || 
-                 this.extractValue(content, '<ACCTID>', '\n');
-    }
-    
+    // Which section describes the account decides what <ACCTID> MEANS: in
+    // <CCACCTFROM> it is the card number, in <BANKACCTFROM> the account
+    // number. Read the tags from inside that section rather than from the
+    // whole file, so a value from elsewhere in the statement cannot stand in
+    // for one the section omitted.
+    const cardBlock = this.extractBlock(content, 'CCACCTFROM');
+    const bankBlock = this.extractBlock(content, 'BANKACCTFROM');
+    const isCreditCardStatement = cardBlock !== null;
+    const accountBlock = cardBlock ?? bankBlock ?? content;
+
+    const accountId = this.readTag(accountBlock, 'ACCTID');
+
     if (!accountId) {
       throw new Error('Account ID not found in OFX file');
     }
-    
-    const bankId = this.extractValue(content, '<BANKID>', '</BANKID>') || 
-                  this.extractValue(content, '<BANKID>', '\n');
-    
-    const branchId = this.extractValue(content, '<BRANCHID>', '</BRANCHID>') || 
-                    this.extractValue(content, '<BRANCHID>', '\n');
-    
-    const accountType = this.extractValue(content, '<ACCTTYPE>', '</ACCTTYPE>') || 
-                       this.extractValue(content, '<ACCTTYPE>', '\n') || 
-                       'CHECKING';
-    
+
+    const bankId = this.readTag(accountBlock, 'BANKID');
+
+    const branchId = this.readTag(accountBlock, 'BRANCHID');
+
+    // Card sections routinely omit <ACCTTYPE> — it would be saying the
+    // obvious. Defaulting those to CHECKING would file a card statement as a
+    // current account, so the section itself supplies the answer.
+    const accountType = this.readTag(accountBlock, 'ACCTTYPE') ||
+                       (isCreditCardStatement ? 'CREDITCARD' : 'CHECKING');
+
     return {
       bankId: bankId || undefined,
       accountId: accountId.trim(),
       accountType,
-      branchId: branchId || undefined
+      branchId: branchId || undefined,
+      isCreditCardStatement
     };
+  }
+
+  /**
+   * The contents of an OFX element, or null when the file has no such element.
+   * SGML-style OFX often omits closing tags on leaf values but not on the
+   * blocks, so an unclosed block is treated as absent rather than swallowing
+   * the rest of the file.
+   */
+  private extractBlock(content: string, tagName: string): string | null {
+    const openTag = `<${tagName}>`;
+    const closeTag = `</${tagName}>`;
+    const start = content.indexOf(openTag);
+    if (start === -1) return null;
+
+    const end = content.indexOf(closeTag, start + openTag.length);
+    if (end === -1) return null;
+
+    return content.substring(start + openTag.length, end);
   }
   
   /**
@@ -124,31 +166,23 @@ export class OFXImportService {
     while ((match = transactionPattern.exec(content)) !== null) {
       const transBlock = match[1];
       
-      const type = this.extractValue(transBlock, '<TRNTYPE>', '</TRNTYPE>') || 
-                  this.extractValue(transBlock, '<TRNTYPE>', '\n') || 
+      const type = this.readTag(transBlock, 'TRNTYPE') || 
                   'OTHER';
       
-      const datePosted = this.extractValue(transBlock, '<DTPOSTED>', '</DTPOSTED>') || 
-                        this.extractValue(transBlock, '<DTPOSTED>', '\n');
+      const datePosted = this.readTag(transBlock, 'DTPOSTED');
       
-      const amountStr = this.extractValue(transBlock, '<TRNAMT>', '</TRNAMT>') || 
-                       this.extractValue(transBlock, '<TRNAMT>', '\n');
+      const amountStr = this.readTag(transBlock, 'TRNAMT');
       
-      const fitId = this.extractValue(transBlock, '<FITID>', '</FITID>') || 
-                   this.extractValue(transBlock, '<FITID>', '\n');
+      const fitId = this.readTag(transBlock, 'FITID');
       
-      const name = this.extractValue(transBlock, '<NAME>', '</NAME>') || 
-                  this.extractValue(transBlock, '<NAME>', '\n') || 
+      const name = this.readTag(transBlock, 'NAME') || 
                   'Unknown';
       
-      const memo = this.extractValue(transBlock, '<MEMO>', '</MEMO>') || 
-                  this.extractValue(transBlock, '<MEMO>', '\n');
+      const memo = this.readTag(transBlock, 'MEMO');
       
-      const checkNum = this.extractValue(transBlock, '<CHECKNUM>', '</CHECKNUM>') || 
-                      this.extractValue(transBlock, '<CHECKNUM>', '\n');
+      const checkNum = this.readTag(transBlock, 'CHECKNUM');
       
-      const refNum = this.extractValue(transBlock, '<REFNUM>', '</REFNUM>') || 
-                    this.extractValue(transBlock, '<REFNUM>', '\n');
+      const refNum = this.readTag(transBlock, 'REFNUM');
       
       if (datePosted && amountStr && fitId) {
         transactions.push({
@@ -171,11 +205,9 @@ export class OFXImportService {
    * Parse balance information
    */
   private parseBalance(content: string): { amount: number; dateAsOf: string } | undefined {
-    const balanceAmount = this.extractValue(content, '<BALAMT>', '</BALAMT>') || 
-                         this.extractValue(content, '<BALAMT>', '\n');
+    const balanceAmount = this.readTag(content, 'BALAMT');
     
-    const balanceDate = this.extractValue(content, '<DTASOF>', '</DTASOF>') || 
-                       this.extractValue(content, '<DTASOF>', '\n');
+    const balanceDate = this.readTag(content, 'DTASOF');
     
     if (balanceAmount && balanceDate) {
       return {
@@ -193,15 +225,41 @@ export class OFXImportService {
   private extractValue(content: string, startTag: string, endTag: string): string | null {
     const startIndex = content.indexOf(startTag);
     if (startIndex === -1) return null;
-    
+
     const valueStart = startIndex + startTag.length;
-    const valueEnd = endTag === '\n' 
+    const valueEnd = endTag === '\n'
       ? content.indexOf('\n', valueStart)
       : content.indexOf(endTag, valueStart);
-    
+
     if (valueEnd === -1) return null;
-    
+
     return content.substring(valueStart, valueEnd).trim();
+  }
+
+  /**
+   * A tag's value, whether or not it is closed — and telling APART "the tag is
+   * not here" from "the tag is here and empty".
+   *
+   * The old readers were `closed || unclosed`, which cannot make that
+   * distinction, because an empty value is '' and '' is falsy. A Coutts export
+   * writes <MEMO></MEMO> for a transaction with no memo, so the closed read
+   * correctly returned '', the || fell through to the unclosed read, and that
+   * one runs to the end of the LINE — capturing the literal text "</MEMO>".
+   * Every affected transaction was then described as "</MEMO>".
+   *
+   * It was never memo-specific: the same pattern read TRNTYPE, DTPOSTED,
+   * TRNAMT, FITID, NAME, CHECKNUM and REFNUM, so any of them, present but
+   * empty, yielded its own closing tag as its value. An empty <TRNAMT></TRNAMT>
+   * would have become the string "</TRNAMT>".
+   *
+   * So: try the closed form first and RETURN it if the tag was there at all,
+   * empty or not. Only fall back to the line-terminated read when the tag is
+   * genuinely unclosed — the SGML style OFX 1.x also permits.
+   */
+  private readTag(content: string, tagName: string): string | null {
+    const closed = this.extractValue(content, `<${tagName}>`, `</${tagName}>`);
+    if (closed !== null) return closed;
+    return this.extractValue(content, `<${tagName}>`, '\n');
   }
   
   /**
@@ -255,9 +313,32 @@ export class OFXImportService {
    * Match OFX account to existing account
    */
   findMatchingAccount(ofxAccount: OFXAccount, existingAccounts: Account[]): Account | null {
+    return this.matchAccount(ofxAccount, existingAccounts)?.account ?? null;
+  }
+
+  /**
+   * Match OFX account to existing account, saying how sure the match is.
+   *
+   * The first tier is the only one that is evidence: the account's own
+   * recorded sort code / account number is the file's. Everything below it
+   * looks for the file's digits inside a display name or falls back to "the
+   * only account of that type", both of which match by coincidence often
+   * enough that nothing permanent should be written on their say-so.
+   */
+  matchAccount(ofxAccount: OFXAccount, existingAccounts: Account[]): AccountMatch | null {
+    const byIdentifier = findAccountByOfxIdentifiers(ofxAccount, existingAccounts);
+    if (byIdentifier) {
+      return { account: byIdentifier, confidence: 'identifier' };
+    }
+
+    const guess = this.guessMatchingAccount(ofxAccount, existingAccounts);
+    return guess ? { account: guess, confidence: 'heuristic' } : null;
+  }
+
+  private guessMatchingAccount(ofxAccount: OFXAccount, existingAccounts: Account[]): Account | null {
     // First try exact account number match (last 4 digits)
     const ofxLast4 = ofxAccount.accountId.slice(-4);
-    
+
     for (const account of existingAccounts) {
       // Check if account name or institution contains the account number
       if (account.name.includes(ofxLast4) || 
@@ -312,20 +393,33 @@ export class OFXImportService {
   ): Promise<{
     transactions: Omit<Transaction, 'id'>[];
     matchedAccount: Account | null;
-    unmatchedAccount?: OFXAccount;
+    /**
+     * What the file says about its own account, matched or not. Callers need
+     * it to show which account the statement came from, and to offer its
+     * details to an account that has none recorded.
+     */
+    ofxAccount: OFXAccount;
+    /**
+     * How the account above was found — null when the caller named the
+     * account itself, because then the file did not choose it.
+     */
+    matchConfidence: AccountMatchConfidence | null;
     duplicates: number;
     newTransactions: number;
   }> {
     const parseResult = this.parseOFX(ofxContent);
-    
+
     // Find matching account
     let matchedAccount: Account | null = null;
+    let matchConfidence: AccountMatchConfidence | null = null;
     if (options.accountId) {
       matchedAccount = existingAccounts.find(a => a.id === options.accountId) || null;
     } else {
-      matchedAccount = this.findMatchingAccount(parseResult.account, existingAccounts);
+      const match = this.matchAccount(parseResult.account, existingAccounts);
+      matchedAccount = match?.account ?? null;
+      matchConfidence = match?.confidence ?? null;
     }
-    
+
     const transactions: Omit<Transaction, 'id'>[] = [];
     let duplicates = 0;
     
@@ -397,7 +491,8 @@ export class OFXImportService {
     return {
       transactions,
       matchedAccount,
-      unmatchedAccount: matchedAccount ? undefined : parseResult.account,
+      ofxAccount: parseResult.account,
+      matchConfidence,
       duplicates,
       newTransactions: transactions.length
     };

--- a/src/utils/ofxAccountIdentifiers.test.ts
+++ b/src/utils/ofxAccountIdentifiers.test.ts
@@ -1,0 +1,203 @@
+import { describe, it, expect } from 'vitest';
+import {
+  findAccountByOfxIdentifiers,
+  planAccountDetailsBackfill,
+  readOfxAccountIdentifiers,
+  type OfxAccountIdentifiers
+} from './ofxAccountIdentifiers';
+import type { Account } from '../types';
+
+const bankStatement = (overrides: Partial<OfxAccountIdentifiers> = {}): OfxAccountIdentifiers => ({
+  accountId: '12345678',
+  bankId: '123456',
+  isCreditCardStatement: false,
+  ...overrides
+});
+
+const cardStatement = (overrides: Partial<OfxAccountIdentifiers> = {}): OfxAccountIdentifiers => ({
+  accountId: '4929123456789012',
+  isCreditCardStatement: true,
+  ...overrides
+});
+
+const account = (overrides: Partial<Account> = {}): Account => ({
+  id: 'acc1',
+  name: 'Current Account',
+  type: 'current',
+  balance: 0,
+  currency: 'GBP',
+  lastUpdated: new Date('2026-01-01'),
+  ...overrides
+});
+
+describe('readOfxAccountIdentifiers', () => {
+  it('reads a sort code and an 8-digit account number', () => {
+    expect(readOfxAccountIdentifiers(bankStatement())).toEqual({
+      sortCode: '12-34-56',
+      accountNumber: '12345678',
+      cardLastFour: '5678'
+    });
+  });
+
+  it('splits an ACCTID that carries the sort code in front of the account number', () => {
+    const values = readOfxAccountIdentifiers(bankStatement({ accountId: '12345687654321' }));
+    expect(values.accountNumber).toBe('87654321');
+    expect(values.sortCode).toBe('12-34-56');
+  });
+
+  it('refuses an account number it cannot recognise rather than guessing 8 digits', () => {
+    // 12 digits with no sort code in front: could be anything.
+    expect(readOfxAccountIdentifiers(bankStatement({ accountId: '987654321098' })).accountNumber)
+      .toBeUndefined();
+  });
+
+  it('ignores a sort code that is not a full 6 digits', () => {
+    expect(readOfxAccountIdentifiers(bankStatement({ bankId: '1234' })).sortCode).toBeUndefined();
+  });
+
+  it('never derives an account number from a card statement', () => {
+    const values = readOfxAccountIdentifiers(cardStatement());
+    expect(values.accountNumber).toBeUndefined();
+    expect(values.cardLastFour).toBe('9012');
+  });
+});
+
+describe('planAccountDetailsBackfill', () => {
+  it('fills both details on a blank current account', () => {
+    const plan = planAccountDetailsBackfill(bankStatement(), account());
+    expect(plan).toEqual({
+      updates: { sortCode: '12-34-56', accountNumber: '12345678' },
+      summary: 'sort code 12-34-56 and account number ending 5678'
+    });
+  });
+
+  it('never mentions a full account number in what it tells the user', () => {
+    const plan = planAccountDetailsBackfill(bankStatement(), account());
+    expect(plan?.summary).not.toContain('12345678');
+  });
+
+  it('leaves an account that already has both details completely alone', () => {
+    const plan = planAccountDetailsBackfill(
+      bankStatement(),
+      account({ sortCode: '12-34-56', accountNumber: '12345678' })
+    );
+    expect(plan).toBeNull();
+  });
+
+  it('never overwrites a recorded detail with a different one', () => {
+    const plan = planAccountDetailsBackfill(
+      bankStatement(),
+      account({ sortCode: '99-99-99', accountNumber: '11112222' })
+    );
+    expect(plan).toBeNull();
+  });
+
+  it('fills only the blank half when the recorded half agrees with the file', () => {
+    const plan = planAccountDetailsBackfill(bankStatement(), account({ sortCode: '12-34-56' }));
+    expect(plan).toEqual({
+      updates: { accountNumber: '12345678' },
+      summary: 'account number ending 5678'
+    });
+  });
+
+  it('fills nothing when a recorded sort code contradicts the file, even though the account number is blank', () => {
+    // The file is not this account's, so the blank field is not an invitation.
+    const plan = planAccountDetailsBackfill(bankStatement(), account({ sortCode: '99-99-99' }));
+    expect(plan).toBeNull();
+  });
+
+  it('stores only the last 4 digits of a card, and no sort code', () => {
+    const plan = planAccountDetailsBackfill(cardStatement(), account({ type: 'credit' }));
+    expect(plan).toEqual({
+      updates: { accountNumber: '9012' },
+      summary: 'card ending 9012'
+    });
+    expect(plan?.updates.sortCode).toBeUndefined();
+  });
+
+  it('never lets a full card number reach the stored value', () => {
+    const plan = planAccountDetailsBackfill(cardStatement(), account({ type: 'credit' }));
+    expect(plan?.updates.accountNumber).toHaveLength(4);
+  });
+
+  it('handles a card statement that already arrives masked', () => {
+    const plan = planAccountDetailsBackfill(
+      cardStatement({ accountId: 'XXXXXXXXXXXX3456' }),
+      account({ type: 'credit' })
+    );
+    expect(plan?.updates.accountNumber).toBe('3456');
+  });
+
+  it('refuses to put a card statement onto a current account', () => {
+    // <ACCTID> here may be a full PAN; the first 8 digits of one are not an
+    // account number, they are the wrong half of a card number.
+    expect(planAccountDetailsBackfill(cardStatement(), account())).toBeNull();
+  });
+
+  it('refuses to put a bank statement onto a credit account', () => {
+    expect(planAccountDetailsBackfill(bankStatement(), account({ type: 'credit' }))).toBeNull();
+  });
+
+  it('treats the database spelling of a current account as one', () => {
+    const plan = planAccountDetailsBackfill(bankStatement(), account({ type: 'checking' }));
+    expect(plan?.updates).toEqual({ sortCode: '12-34-56', accountNumber: '12345678' });
+  });
+
+  it('fills nothing on account types that record no bank details', () => {
+    for (const type of ['loan', 'investment', 'assets', 'other'] as const) {
+      expect(planAccountDetailsBackfill(bankStatement(), account({ type }))).toBeNull();
+    }
+  });
+
+  it('fills nothing when the file has no recognisable identifiers', () => {
+    const plan = planAccountDetailsBackfill(
+      bankStatement({ accountId: 'GB29NWBK', bankId: undefined }),
+      account()
+    );
+    expect(plan).toBeNull();
+  });
+
+  it('treats a whitespace-only recorded value as blank', () => {
+    const plan = planAccountDetailsBackfill(bankStatement(), account({ sortCode: '   ' }));
+    expect(plan?.updates.sortCode).toBe('12-34-56');
+  });
+});
+
+describe('findAccountByOfxIdentifiers', () => {
+  const savings = account({ id: 'savings', name: 'Savings', type: 'savings' });
+
+  it('matches the account whose recorded details are the file\'s', () => {
+    const target = account({ id: 'target', sortCode: '12-34-56', accountNumber: '12345678' });
+    expect(findAccountByOfxIdentifiers(bankStatement(), [savings, target])).toBe(target);
+  });
+
+  it('ignores formatting differences in the recorded sort code', () => {
+    const target = account({ id: 'target', sortCode: '123456', accountNumber: '12345678' });
+    expect(findAccountByOfxIdentifiers(bankStatement(), [target])).toBe(target);
+  });
+
+  it('does not match when the recorded sort code differs', () => {
+    const target = account({ id: 'target', sortCode: '99-99-99', accountNumber: '12345678' });
+    expect(findAccountByOfxIdentifiers(bankStatement(), [target])).toBeNull();
+  });
+
+  it('matches on account number alone when no sort code is recorded', () => {
+    const target = account({ id: 'target', accountNumber: '12345678' });
+    expect(findAccountByOfxIdentifiers(bankStatement(), [target])).toBe(target);
+  });
+
+  it('matches a card on its last 4 digits', () => {
+    const card = account({ id: 'card', type: 'credit', accountNumber: '9012' });
+    expect(findAccountByOfxIdentifiers(cardStatement(), [savings, card])).toBe(card);
+  });
+
+  it('refuses to choose between two accounts carrying the same identifiers', () => {
+    const first = account({ id: 'a', accountNumber: '12345678' });
+    const second = account({ id: 'b', accountNumber: '12345678' });
+    expect(findAccountByOfxIdentifiers(bankStatement(), [first, second])).toBeNull();
+  });
+
+  it('returns null when no account records anything', () => {
+    expect(findAccountByOfxIdentifiers(bankStatement(), [savings, account()])).toBeNull();
+  });
+});

--- a/src/utils/ofxAccountIdentifiers.ts
+++ b/src/utils/ofxAccountIdentifiers.ts
@@ -1,0 +1,235 @@
+/**
+ * What an OFX statement says about the account it came from, and what may
+ * safely be copied out of it onto one of the user's accounts.
+ *
+ * Three rules do all the work, and each of them exists because getting it
+ * wrong writes something permanent onto a real account:
+ *
+ *  - A card's <ACCTID> is the CARD number, and some banks put the whole PAN in
+ *    it. A full card number must never be stored: it would land in the user's
+ *    backups, their JSON export and their audit history. A credit account
+ *    therefore keeps the last 4 digits and nothing else — the same shape the
+ *    account form asks for (see accountNumberInput) and the same shape
+ *    findCardMaskMatch compares a bank feed against.
+ *  - A sort code belongs to a bank account. A card has none, so one is never
+ *    stored against one, whatever the file happens to contain.
+ *  - Anything that cannot be recognised for certain is left alone. Storing a
+ *    wrong sort code is worse than storing none at all, because the NEXT
+ *    import would then match confidently to the wrong account.
+ */
+
+import type { Account } from '../types';
+import {
+  BANK_ACCOUNT_NUMBER_LENGTH,
+  CARD_LAST_FOUR_LENGTH,
+  digitsOnly,
+  formatSortCode,
+  keepLastFour
+} from './accountNumberInput';
+
+/** A UK sort code is exactly 6 digits, written XX-XX-XX. */
+export const SORT_CODE_LENGTH = 6;
+
+/** The identifiers an OFX statement carries about its own account. */
+export interface OfxAccountIdentifiers {
+  /** <ACCTID> — the account number, or on a card statement the card number. */
+  accountId: string;
+  /** <BANKID> — the sort code. Card statements do not have one. */
+  bankId?: string;
+  /** True when the statement came from <CCACCTFROM> rather than <BANKACCTFROM>. */
+  isCreditCardStatement: boolean;
+}
+
+/** The identifiers above, cleaned into the shapes an account actually stores. */
+export interface OfxIdentifierValues {
+  /** Formatted XX-XX-XX, and only when the file gave a full 6 digits. */
+  sortCode?: string;
+  /** A full 8-digit bank account number, and only when one is recognisable. */
+  accountNumber?: string;
+  /** The last 4 digits — everything a credit account stores, and no more. */
+  cardLastFour?: string;
+}
+
+/** The fields a backfill would write, plus wording safe to show the user. */
+export interface AccountDetailsBackfill {
+  /** Only ever fields the account has left blank. */
+  updates: Pick<Account, 'sortCode' | 'accountNumber'>;
+  /**
+   * What was filled, in words. Never contains a full account or card number:
+   * a sort code and a last 4 are enough for a person to recognise the account,
+   * and a message is one more place a full number would end up.
+   */
+  summary: string;
+}
+
+/** The account fields this module reads. Keeps callers free of the full type. */
+type AccountIdentity = Pick<Account, 'type' | 'sortCode' | 'accountNumber'>;
+
+const isBlank = (value: string | undefined): boolean => (value ?? '').trim() === '';
+
+/** Compare two stored identifiers ignoring formatting (12-34-56 vs 123456). */
+const sameDigits = (a: string | undefined, b: string | undefined): boolean =>
+  digitsOnly(a ?? '') === digitsOnly(b ?? '');
+
+/**
+ * The account types that have a sort code and an account number at all.
+ * 'checking' is the database's own spelling of 'current' (see
+ * sectionTypeForAccount in accountGrouping) — a row that reaches here
+ * untranslated is still a current account and still has bank details.
+ */
+const isBankAccountType = (type: Account['type']): boolean =>
+  type === 'current' || type === 'savings' || type === 'checking';
+
+/**
+ * Clean the raw OFX tags into storable values.
+ *
+ * The account number is deliberately conservative. Exactly 8 digits is a UK
+ * account number. Some banks instead put the sort code and the account number
+ * together in one <ACCTID>, which is recognisable because the first 6 digits
+ * are the <BANKID> we already have — that case splits cleanly. Anything else
+ * (an IBAN, a padded reference, a 12-digit foreign number) yields nothing,
+ * because a guessed 8 digits would be stored as fact.
+ */
+export const readOfxAccountIdentifiers = (ofx: OfxAccountIdentifiers): OfxIdentifierValues => {
+  const accountDigits = digitsOnly(ofx.accountId);
+  const bankDigits = digitsOnly(ofx.bankId ?? '');
+
+  const sortCode = bankDigits.length === SORT_CODE_LENGTH ? formatSortCode(bankDigits) : undefined;
+  const cardLastFour =
+    accountDigits.length >= CARD_LAST_FOUR_LENGTH ? keepLastFour(accountDigits) : undefined;
+
+  let accountNumber: string | undefined;
+  if (!ofx.isCreditCardStatement) {
+    if (accountDigits.length === BANK_ACCOUNT_NUMBER_LENGTH) {
+      accountNumber = accountDigits;
+    } else if (
+      bankDigits.length === SORT_CODE_LENGTH &&
+      accountDigits.length === SORT_CODE_LENGTH + BANK_ACCOUNT_NUMBER_LENGTH &&
+      accountDigits.startsWith(bankDigits)
+    ) {
+      accountNumber = accountDigits.slice(SORT_CODE_LENGTH);
+    }
+  }
+
+  return { sortCode, accountNumber, cardLastFour };
+};
+
+/**
+ * True when the file is unmistakably a bank statement rather than a card one:
+ * it quoted a sort code, and cards do not have those.
+ */
+const isDefinitelyBankStatement = (ofx: OfxAccountIdentifiers): boolean =>
+  !ofx.isCreditCardStatement && digitsOnly(ofx.bankId ?? '').length === SORT_CODE_LENGTH;
+
+/**
+ * What (if anything) this statement may fill in on this account.
+ *
+ * Returns null far more often than not, and every null is deliberate: a
+ * detail already recorded, a detail the file states differently from the
+ * account, a file of the wrong kind for the account, or an account type that
+ * has no bank details to record. Nothing recorded is ever replaced — the only
+ * write this function will ever describe is one into an empty field.
+ */
+export const planAccountDetailsBackfill = (
+  ofx: OfxAccountIdentifiers,
+  account: AccountIdentity
+): AccountDetailsBackfill | null => {
+  const values = readOfxAccountIdentifiers(ofx);
+
+  // A detail already on the account that disagrees with the file means this
+  // file is not this account's (or one of the two is wrong). Filling the
+  // other, still-blank field would make a half-wrong record look complete, so
+  // this stops before writing anything.
+  if (!isBlank(account.sortCode) && values.sortCode && !sameDigits(account.sortCode, values.sortCode)) {
+    return null;
+  }
+  if (
+    !isBlank(account.accountNumber) &&
+    values.accountNumber &&
+    !sameDigits(account.accountNumber, values.accountNumber)
+  ) {
+    return null;
+  }
+
+  if (account.type === 'credit') {
+    // A card statement's number is the only thing a card stores, and a file
+    // carrying a sort code is not a card statement at all.
+    if (isDefinitelyBankStatement(ofx) || !isBlank(account.accountNumber) || !values.cardLastFour) {
+      return null;
+    }
+    return {
+      updates: { accountNumber: values.cardLastFour },
+      summary: `card ending ${values.cardLastFour}`
+    };
+  }
+
+  // A card statement's <ACCTID> may be a full PAN. Trimming it to 8 digits for
+  // a bank account's field would store the wrong digits of a card number.
+  if (!isBankAccountType(account.type) || ofx.isCreditCardStatement) {
+    return null;
+  }
+
+  const updates: AccountDetailsBackfill['updates'] = {};
+  const filled: string[] = [];
+
+  if (isBlank(account.sortCode) && values.sortCode) {
+    updates.sortCode = values.sortCode;
+    filled.push(`sort code ${values.sortCode}`);
+  }
+  if (isBlank(account.accountNumber) && values.accountNumber) {
+    updates.accountNumber = values.accountNumber;
+    filled.push(`account number ending ${keepLastFour(values.accountNumber)}`);
+  }
+
+  if (filled.length === 0) {
+    return null;
+  }
+
+  return { updates, summary: filled.join(' and ') };
+};
+
+/** Does this account's own recorded identifiers say the file is its own? */
+const matchesRecordedIdentifiers = (
+  ofx: OfxAccountIdentifiers,
+  values: OfxIdentifierValues,
+  account: Account
+): boolean => {
+  if (account.type === 'credit') {
+    // The card's last 4 is the identifier, exactly as the bank feed matches it.
+    if (isDefinitelyBankStatement(ofx) || !values.cardLastFour) return false;
+    const recorded = digitsOnly(account.accountNumber ?? '');
+    return recorded.length >= CARD_LAST_FOUR_LENGTH && recorded.slice(-CARD_LAST_FOUR_LENGTH) === values.cardLastFour;
+  }
+
+  if (!isBankAccountType(account.type) || ofx.isCreditCardStatement) return false;
+  if (!values.accountNumber || isBlank(account.accountNumber)) return false;
+  if (!sameDigits(account.accountNumber, values.accountNumber)) return false;
+
+  // Sort codes only have to agree when both sides have one; a sort code that
+  // was never recorded is missing information, not a contradiction.
+  if (values.sortCode && !isBlank(account.sortCode)) {
+    return sameDigits(account.sortCode, values.sortCode);
+  }
+  return true;
+};
+
+/**
+ * The account whose OWN recorded sort code / account number matches the file.
+ *
+ * This is the only kind of account match that is a fact rather than a guess,
+ * and it is what a backfill buys the user: once the details are on the
+ * account, the next file finds it here instead of falling through to the
+ * name-and-type guesswork below it. Ambiguity counts as no match — two
+ * accounts carrying the same identifiers is a data problem, not a choice this
+ * function should make.
+ */
+export const findAccountByOfxIdentifiers = (
+  ofx: OfxAccountIdentifiers,
+  accounts: readonly Account[]
+): Account | null => {
+  const values = readOfxAccountIdentifiers(ofx);
+  if (!values.accountNumber && !values.cardLastFour) return null;
+
+  const matches = accounts.filter((account) => matchesRecordedIdentifiers(ofx, values, account));
+  return matches.length === 1 ? matches[0] : null;
+};

--- a/supabase/migrations/20260807180000_feed_rows_arrive_unreconciled.sql
+++ b/supabase/migrations/20260807180000_feed_rows_arrive_unreconciled.sql
@@ -1,0 +1,116 @@
+-- ============================================================================
+-- A bank feed row arrives unreconciled, like every other import
+-- ============================================================================
+-- IMPORTANT: apply with `npm run db:migrate` (see supabase/migrations/README.md
+-- rule 1 — never the SQL editor). One existing function is redefined and
+-- nothing else changes: no columns, no data, no grants. Rows already in the
+-- table keep whatever is_cleared they were given.
+--
+-- ── WHY ─────────────────────────────────────────────────────────────────────
+-- import_bank_transactions_atomic inserted every feed row with is_cleared =
+-- true. The OFX file importer did the same, with a comment explaining the
+-- reasoning: "OFX transactions are already cleared".
+--
+-- That reasoning conflates two different facts. The bank having PROCESSED a
+-- payment is not the same as the user having CHECKED it against their
+-- statement — and only the second is what is_cleared means in this app. It is
+-- the flag reconciliation reads, and finalising a reconciliation is what proves
+-- the account agrees with the bank.
+--
+-- So a feed that pre-clears its own rows removes the one step that would catch
+-- what a feed cannot: a payment the bank has not sent yet, one the user does
+-- not recognise, or a balance that does not add up. The reconciliation screen
+-- had nothing left to do, which is why nobody noticed it was doing nothing.
+--
+-- Every other importer already got this right — QIF respects the file's own
+-- flag and defaults false, CSV writes false, and the Money importer reads
+-- Money's clearedStatus. The feed and OFX were the two outliers; OFX is fixed
+-- in the same change.
+--
+-- ── WHAT DOES NOT CHANGE ────────────────────────────────────────────────────
+-- Existing rows. This alters what NEW feed rows are given, not history — a
+-- backfill would mark thousands of already-reconciled transactions as needing
+-- attention, which is a worse lie than the one being fixed.
+--
+-- ── BALANCE REASONING ───────────────────────────────────────────────────────
+-- Balance-neutral. is_cleared is a review flag; no amount, sign or account_id
+-- is touched, and accounts.balance is written by the same statement it always
+-- was. The only trigger keyed on this column is trg_sweep_reconciled_into_
+-- archive, which fires on UPDATE OF is_cleared, not INSERT — so nothing sweeps
+-- on the way in either before or after this change.
+-- ============================================================================
+
+BEGIN;
+
+-- The function is reproduced from 20260722140000_payee_memory_most_common.sql
+-- with one value changed, on the line marked below. Everything else — the
+-- dedupe, the payee-memory categorisation, the balance effect, the audit write
+-- and the ON CONFLICT race handling — is byte-identical to what is live.
+DO $$
+DECLARE
+  v_src text;
+BEGIN
+  SELECT pg_get_functiondef(p.oid)
+    INTO v_src
+    FROM pg_proc p
+    JOIN pg_namespace n ON n.oid = p.pronamespace
+   WHERE n.nspname = 'public'
+     AND p.proname = 'import_bank_transactions_atomic';
+
+  IF v_src IS NULL THEN
+    RAISE EXCEPTION 'import_bank_transactions_atomic_missing: expected the feed importer to exist before changing what it writes'
+      USING ERRCODE = 'P0002';
+  END IF;
+
+  -- Guard against a silent no-op: if the literal we are replacing is not there
+  -- in the shape we expect, the function has been rewritten since and blindly
+  -- swapping text could corrupt it. Fail loudly instead.
+  IF position(E'      COALESCE(r->\'metadata\', \'null\'::jsonb),\n      true,' IN v_src) = 0 THEN
+    RAISE EXCEPTION 'feed_cleared_literal_not_found: import_bank_transactions_atomic no longer inserts is_cleared the way this migration expects — review it by hand rather than letting this rewrite it'
+      USING ERRCODE = 'P0001';
+  END IF;
+
+  v_src := replace(
+    v_src,
+    E'      COALESCE(r->\'metadata\', \'null\'::jsonb),\n      true,',
+    E'      COALESCE(r->\'metadata\', \'null\'::jsonb),\n      false,  -- is_cleared: the user reconciles, the feed does not'
+  );
+
+  EXECUTE v_src;
+END;
+$$;
+
+COMMIT;
+
+-- ==== VERIFICATION — read this output after applying ====
+
+-- 1. The function now inserts false, and says why.
+-- Expected: inserts_false = true, inserts_true = false
+SELECT position('false,  -- is_cleared' IN pg_get_functiondef(p.oid)) > 0 AS inserts_false,
+       position(E'\'null\'::jsonb),\n      true,' IN pg_get_functiondef(p.oid)) > 0 AS inserts_true
+  FROM pg_proc p
+  JOIN pg_namespace n ON n.oid = p.pronamespace
+ WHERE n.nspname = 'public' AND p.proname = 'import_bank_transactions_atomic';
+
+-- 2. Everything else about it is unchanged — still INVOKER, still search_path
+--    pinned, still granted to the same roles and NOT to anon.
+-- Expected: prosecdef = false, proconfig = {search_path=public}
+SELECT p.proname, p.prosecdef, p.proconfig
+  FROM pg_proc p
+  JOIN pg_namespace n ON n.oid = p.pronamespace
+ WHERE n.nspname = 'public' AND p.proname = 'import_bank_transactions_atomic';
+
+-- Expected: authenticated and service_role only; no anon, no PUBLIC ('-')
+SELECT a.grantee::regrole::text AS grantee, a.privilege_type
+  FROM pg_proc p
+  JOIN pg_namespace n ON n.oid = p.pronamespace
+ CROSS JOIN LATERAL aclexplode(p.proacl) AS a
+ WHERE n.nspname = 'public' AND p.proname = 'import_bank_transactions_atomic'
+ ORDER BY grantee;
+
+-- 3. History is untouched — this changes what arrives next, not what arrived.
+--    Expected: whatever it was before; recorded here so the number is on file.
+SELECT count(*) FILTER (WHERE is_cleared) AS cleared_rows,
+       count(*) FILTER (WHERE NOT is_cleared) AS uncleared_rows
+  FROM public.transactions
+ WHERE external_transaction_id IS NOT NULL;


### PR DESCRIPTION
Three fixes, all found by importing a real OFX statement.

## A statement you imported is not a statement you have checked

Every OFX import arrived with every row already ticked as reconciled, and the bank feed did the same. The reasoning was written down in a comment — "OFX transactions are already cleared" — and it conflates two different facts. The bank having *processed* a payment is not the same as you having *checked* it against your statement, and only the second is what `is_cleared` means here. It is the flag reconciliation reads.

So a feed that pre-ticks its own rows removes the one step that catches what a feed cannot: a payment the bank has not sent yet, one you do not recognise, or a balance that does not add up. The reconciliation screen had nothing left to do, which is why nobody noticed it was doing nothing.

Every other importer already had this right — QIF respects the file's own flag, CSV writes false, the Money importer reads Money's own status. OFX and the bank feed were the two outliers.

**Deliberately no backfill.** Existing feed rows keep what they were given. Marking thousands of already-settled transactions as suddenly needing attention would be a worse lie than the one being fixed.

Migration `20260807180000` rewrites the feed RPC from its own live definition and refuses to run if the literal it expects is not there, rather than blindly rewriting a function that has changed underneath it.

## An empty tag is empty, not the name of its own closing tag

An import produced rows whose description was the literal text `</MEMO>`.

The cause was not memo, and not the bank. Every tag reader in the OFX parser was `closedForm || unclosedForm` — and `''` is falsy, so a legitimately **empty** element fell through to the line-terminated fallback, which then captured the closing tag as its own value. **Seventeen readers shared the pattern**: `TRNTYPE`, `TRNAMT`, `FITID`, `NAME`, `CHECKNUM`, `CURDEF`, `BALAMT` and the rest. An empty `<TRNAMT></TRNAMT>` would have parsed as the string `"</TRNAMT>"`.

Fixed with a `readTag` helper that distinguishes *absent* from *present but empty*, and all 17 call sites moved onto it.

Measured against a real file: 19 transactions, of which **17 would have shown `</MEMO>`** before, and zero after.

Worth saying plainly — this was never Sage-specific. The file is valid `OFXSGML VERSION:102`. Any bank writing an empty closed element would have hit it.

## Scraping sort code and account number from the file

When an OFX file is matched to an account that has no sort code or account number stored, those details are now taken from the file and saved.

Two constraints shaped it:

- **Only on a user's decision, not a guess.** A new `AccountMatchConfidence` type separates `identifier` matches from `heuristic` ones, and details are only written back on the former. A fuzzy name match should not silently stamp a sort code onto the wrong account.
- **Never overwrite.** If details are already there, nothing happens.
- **Never a full card number.** Credit accounts store the last four digits only. A full PAN would otherwise land in backups, JSON exports and audit history.

## Verification

- Lint clean, strict typecheck clean
- Full test suite passing; coverage 68.99% statements / 79.28% branches (floors 63 / 55)
- Migration applied to production and verified: `inserts_false = t`, still `SECURITY INVOKER`, `search_path` pinned, grants unchanged (`authenticated` + `service_role`, no `anon`), and existing rows untouched

🤖 Generated with [Claude Code](https://claude.com/claude-code)
