### PR TITLE
fix(cards+reconciliation): last four digits only, and a statement that brings its balance with it

### DIFF
--- a/api/banking/discover-accounts.ts
+++ b/api/banking/discover-accounts.ts
@@ -84,14 +84,21 @@ async function handler(req: VercelRequest, res: VercelResponse) {
               ? iban.slice(-4)
               : undefined;
 
+          const type = mapAccountType(account.account_type);
+          // For a card on this surface account_number.number is the card number.
+          // It must not leave the server: the client renders this value, prefills
+          // it into the add-account form and posts it back to be stored. The mask
+          // is the whole of what the app ever matches a card on.
+          const isCard = type === 'credit';
+
           return {
             externalAccountId: account.account_id,
             name: account.display_name?.trim() || connection.institution_name,
-            type: mapAccountType(account.account_type),
+            type,
             balance,
             currency: account.currency || 'GBP',
-            sortCode: account.account_number?.sort_code ?? undefined,
-            accountNumber: accountNumber ?? undefined,
+            sortCode: isCard ? undefined : (account.account_number?.sort_code ?? undefined),
+            accountNumber: isCard ? undefined : (accountNumber ?? undefined),
             mask,
             kind: 'account'
           };

--- a/api/banking/sync-accounts.ts
+++ b/api/banking/sync-accounts.ts
@@ -171,6 +171,10 @@ const persistAccountsAndLinks = async (
   });
 
   const nowIso = new Date().toISOString();
+  // The day the bank's figure is true for. Recorded so a manually imported
+  // statement can tell whether it is older than what the feed already holds —
+  // without it, last March's statement would overwrite this morning's sync.
+  const balanceAsOfDay = nowIso.slice(0, 10);
   const externalAccountIds = new Set<string>();
 
   for (const account of accounts) {
@@ -219,6 +223,7 @@ const persistAccountsAndLinks = async (
           ...(hasUserName ? {} : { name: account.name }),
           type: account.type,
           bank_balance: account.balance,
+          bank_balance_date: balanceAsOfDay,
           currency: account.currency,
           institution: connection.institution_name,
           is_active: true,
@@ -255,6 +260,7 @@ const persistAccountsAndLinks = async (
           type: account.type,
           balance: account.balance,
           bank_balance: account.balance,
+          bank_balance_date: balanceAsOfDay,
           initial_balance: account.balance,
           currency: account.currency,
           institution: connection.institution_name,

--- a/api/banking/sync-accounts.ts
+++ b/api/banking/sync-accounts.ts
@@ -361,11 +361,21 @@ async function handler(req: VercelRequest, res: VercelResponse) {
             // Balance endpoint failures should not block account discovery.
           }
 
-          const identifiers = extractBankIdentifiers(account);
+          const type = mapAccountType(account.account_type);
+          // A card can arrive on the ACCOUNTS surface too (account_type
+          // 'credit_card'), and there account_number.number is the card number
+          // itself. Persisting it would put a full PAN in accounts.account_number
+          // and from there into every backup, export and audit row — so a card is
+          // given exactly what the /cards surface gives one below: no identifiers
+          // and a last-4 mask. Re-adoption is unaffected; findAdoptableAccountId
+          // already returns null without a sort code, which no card has.
+          const identifiers = type === 'credit'
+            ? { accountNumber: null, sortCode: null }
+            : extractBankIdentifiers(account);
           return {
             externalAccountId: account.account_id,
             name: account.display_name?.trim() || connection.institution_name,
-            type: mapAccountType(account.account_type),
+            type,
             balance,
             currency: account.currency || 'GBP',
             mask: inferMask(account),

--- a/src/components/AccountSettingsModal.test.tsx
+++ b/src/components/AccountSettingsModal.test.tsx
@@ -253,6 +253,82 @@ describe('AccountSettingsModal', () => {
     });
   });
 
+  describe('Card Number', () => {
+    const creditAccount: Account = { ...mockAccount, type: 'credit', sortCode: undefined, accountNumber: '9012' };
+
+    it('stores the LAST four of a pasted card number, not the first', async () => {
+      const onSave = vi.fn();
+      render(<AccountSettingsModal {...defaultProps} account={creditAccount} onSave={onSave} />);
+
+      fireEvent.change(screen.getByLabelText('Last four digits of the card number'), {
+        target: { value: '4929 1234 5678 9012' }
+      });
+      fireEvent.click(screen.getByText('Save Changes'));
+
+      await waitFor(() => {
+        expect(onSave).toHaveBeenCalledWith('acc1', expect.objectContaining({
+          accountNumber: '9012'
+        }));
+      });
+    });
+
+    it('keeps the whole entry in the field so the right four survive the save', () => {
+      render(<AccountSettingsModal {...defaultProps} account={creditAccount} />);
+
+      const field = screen.getByLabelText('Last four digits of the card number');
+      fireEvent.change(field, { target: { value: '4929123456789012' } });
+
+      // Capping the input would have left '4929' — the wrong four.
+      expect(field).toHaveValue('4929123456789012');
+    });
+
+    it('trims on save even for a card the type was only just switched to', async () => {
+      const onSave = vi.fn();
+      render(<AccountSettingsModal {...defaultProps} onSave={onSave} />);
+
+      fireEvent.change(screen.getByLabelText('Bank account number'), {
+        target: { value: '12345678' }
+      });
+      fireEvent.change(screen.getByDisplayValue('Current Account'), { target: { value: 'credit' } });
+      fireEvent.click(screen.getByText('Save Changes'));
+
+      await waitFor(() => {
+        expect(onSave).toHaveBeenCalledWith('acc1', expect.objectContaining({
+          accountNumber: '5678'
+        }));
+      });
+    });
+
+    it('tells the user what will be stored rather than offering them a choice', () => {
+      render(<AccountSettingsModal {...defaultProps} account={creditAccount} />);
+
+      fireEvent.change(screen.getByLabelText('Last four digits of the card number'), {
+        target: { value: '4929123456789012' }
+      });
+
+      expect(screen.getByRole('status')).toHaveTextContent(
+        'Saving will store 9012 and discard the rest.'
+      );
+      expect(screen.queryByRole('button', { name: /Keep only/ })).not.toBeInTheDocument();
+    });
+
+    it('clears the stored number when the card field is emptied', async () => {
+      const onSave = vi.fn();
+      render(<AccountSettingsModal {...defaultProps} account={creditAccount} onSave={onSave} />);
+
+      fireEvent.change(screen.getByLabelText('Last four digits of the card number'), {
+        target: { value: '' }
+      });
+      fireEvent.click(screen.getByText('Save Changes'));
+
+      await waitFor(() => {
+        expect(onSave).toHaveBeenCalledWith('acc1', expect.objectContaining({
+          accountNumber: undefined
+        }));
+      });
+    });
+  });
+
   describe('Opening Balance', () => {
     it('accepts decimal values', () => {
       render(<AccountSettingsModal {...defaultProps} />);

--- a/src/components/AccountSettingsModal.tsx
+++ b/src/components/AccountSettingsModal.tsx
@@ -10,8 +10,9 @@ import CardNumberGuidance from './CardNumberGuidance';
 import {
   BANK_ACCOUNT_NUMBER_LENGTH,
   CARD_NUMBER_LABEL,
+  accountNumberForStorage,
   formatSortCode,
-  keepLastFour,
+  isCardAccountType,
   nextAccountNumberValue
 } from '../utils/accountNumberInput';
 
@@ -86,7 +87,10 @@ export default function AccountSettingsModal({
           ...(data.name.trim() !== '' ? { name: data.name.trim() } : {}),
           notes: data.notes || undefined,
           sortCode: data.sortCode || undefined,
-          accountNumber: data.accountNumber || undefined,
+          // A card stores its last 4 digits and nothing else, whatever the
+          // field was left holding — the trim happens here rather than while
+          // typing so a pasted number loses its FIRST twelve, not its last four.
+          accountNumber: accountNumberForStorage(data.accountNumber, isCardAccountType(data.type)),
           isActive: data.isActive,
           lowBalanceAlertEnabled: data.lowBalanceAlertEnabled,
           lowBalanceThreshold: data.lowBalanceThreshold ? parseMoneyInput(data.lowBalanceThreshold) ?? undefined : undefined
@@ -138,15 +142,11 @@ export default function AccountSettingsModal({
   // digits, which would then live in the user's backups, JSON export and
   // audit history for no benefit at all. The rules and the wording are shared
   // with AddAccountModal, which asks for the same details at creation.
-  const isCreditCard = formData.type === 'credit';
+  const isCreditCard = isCardAccountType(formData.type);
   const isBankAccount = formData.type === 'current' || formData.type === 'savings';
 
   const handleAccountNumberChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     updateField('accountNumber', nextAccountNumberValue(e.target.value, isCreditCard));
-  };
-
-  const trimToLastFour = (): void => {
-    updateField('accountNumber', keepLastFour(formData.accountNumber));
   };
 
   if (!account) return null;
@@ -270,12 +270,7 @@ export default function AccountSettingsModal({
                 {...(isBankAccount ? { maxLength: BANK_ACCOUNT_NUMBER_LENGTH } : {})}
                 className="w-full px-3 py-2 bg-white dark:bg-gray-800-sm border border-gray-300/50 dark:border-gray-600/50 rounded-xl focus:outline-none focus:ring-2 focus:ring-primary focus:border-transparent dark:text-white"
               />
-              {isCreditCard && (
-                <CardNumberGuidance
-                  value={formData.accountNumber}
-                  onKeepLastFour={trimToLastFour}
-                />
-              )}
+              {isCreditCard && <CardNumberGuidance value={formData.accountNumber} />}
             </div>
           )}
 

--- a/src/components/AddAccountModal.test.tsx
+++ b/src/components/AddAccountModal.test.tsx
@@ -1,0 +1,106 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import AddAccountModal from './AddAccountModal';
+import { PreferencesProvider } from '../contexts/PreferencesContext';
+import { __resetAppContextValue, __setAppContextValue } from '../test/mocks/AppContextSupabase';
+import type { Account } from '../types';
+
+type NewAccountPayload = Omit<Account, 'id'> & { initialBalance?: number };
+
+// Optional parameter on purpose: the context's own mock types addAccount as a
+// no-arg callback, and a required parameter would not fit it.
+const addAccount = vi.fn((account?: NewAccountPayload) =>
+  Promise.resolve({ ...account, id: 'new-account' })
+);
+
+const lastPayload = (): NewAccountPayload | undefined => addAccount.mock.calls[0]?.[0];
+
+const renderModal = () =>
+  render(
+    <PreferencesProvider>
+      <AddAccountModal isOpen onClose={vi.fn()} />
+    </PreferencesProvider>
+  );
+
+/** Fill in the name and balance the form requires, then choose Credit Card. */
+const startACard = () => {
+  fireEvent.change(screen.getByPlaceholderText('e.g., Main Checking Account'), {
+    target: { value: 'Amex' }
+  });
+  fireEvent.change(screen.getByPlaceholderText('0.00'), { target: { value: '-250' } });
+  fireEvent.click(screen.getByText('Credit Card'));
+};
+
+describe('AddAccountModal — a card is created holding its last 4 digits only', () => {
+  beforeEach(() => {
+    addAccount.mockClear();
+    __setAppContextValue({ addAccount });
+  });
+
+  afterEach(() => {
+    __resetAppContextValue();
+  });
+
+  it('stores the LAST four of a pasted card number, not the first', async () => {
+    renderModal();
+    startACard();
+
+    fireEvent.change(screen.getByLabelText('Last four digits of the card number'), {
+      target: { value: '4929 1234 5678 9012' }
+    });
+    fireEvent.click(screen.getByText('Add Account'));
+
+    await waitFor(() => expect(addAccount).toHaveBeenCalledTimes(1));
+    expect(lastPayload()?.accountNumber).toBe('9012');
+  });
+
+  it('keeps the whole number in the field so the right four can be taken', () => {
+    renderModal();
+    startACard();
+
+    const field = screen.getByLabelText('Last four digits of the card number');
+    fireEvent.change(field, { target: { value: '4929123456789012' } });
+
+    // Capping the input would have left '4929' — the wrong four.
+    expect(field).toHaveValue('4929123456789012');
+  });
+
+  it('tells the user what will be stored rather than offering them a choice', () => {
+    renderModal();
+    startACard();
+
+    fireEvent.change(screen.getByLabelText('Last four digits of the card number'), {
+      target: { value: '4929123456789012' }
+    });
+
+    expect(screen.getByRole('status')).toHaveTextContent(
+      'Saving will store 9012 and discard the rest.'
+    );
+  });
+
+  it('leaves a bank account number whole', async () => {
+    renderModal();
+
+    fireEvent.change(screen.getByPlaceholderText('e.g., Main Checking Account'), {
+      target: { value: 'HSBC Current' }
+    });
+    fireEvent.change(screen.getByPlaceholderText('0.00'), { target: { value: '1000' } });
+    fireEvent.change(screen.getByLabelText('Bank account number'), {
+      target: { value: '12345678' }
+    });
+    fireEvent.click(screen.getByText('Add Account'));
+
+    await waitFor(() => expect(addAccount).toHaveBeenCalledTimes(1));
+    expect(lastPayload()?.accountNumber).toBe('12345678');
+  });
+
+  it('stores nothing at all when the card number is left blank', async () => {
+    renderModal();
+    startACard();
+
+    fireEvent.click(screen.getByText('Add Account'));
+
+    await waitFor(() => expect(addAccount).toHaveBeenCalledTimes(1));
+    expect(lastPayload()?.accountNumber).toBeUndefined();
+  });
+});

--- a/src/components/AddAccountModal.tsx
+++ b/src/components/AddAccountModal.tsx
@@ -11,8 +11,9 @@ import CardNumberGuidance from './CardNumberGuidance';
 import {
   BANK_ACCOUNT_NUMBER_LENGTH,
   CARD_NUMBER_LABEL,
+  accountNumberForStorage,
   formatSortCode,
-  keepLastFour,
+  isCardAccountType,
   nextAccountNumberValue
 } from '../utils/accountNumberInput';
 
@@ -123,7 +124,8 @@ export default function AddAccountModal({ isOpen, onClose, prefill, onAccountCre
       // Strip formatting from sort code for storage (XX-XX-XX → XXXXXX).
       // A credit card has no sort code, so anything typed before the type was
       // switched to Credit Card is not part of what is being created.
-      const rawSortCode = formData.type === 'credit' ? '' : formData.sortCode.replace(/\D/g, '');
+      const isCard = isCardAccountType(formData.type);
+      const rawSortCode = isCard ? '' : formData.sortCode.replace(/\D/g, '');
 
       const newAccountPayload: Omit<Account, 'id'> & { initialBalance?: number } = {
         name: formData.name.trim(),
@@ -137,7 +139,10 @@ export default function AddAccountModal({ isOpen, onClose, prefill, onAccountCre
         openingBalanceDate: new Date(),
         isActive: true,
         sortCode: rawSortCode || undefined,
-        accountNumber: formData.accountNumber.trim() || undefined,
+        // A card is created holding its last 4 digits and nothing else — the
+        // field itself is uncapped so a pasted number keeps the RIGHT four
+        // (see nextAccountNumberValue), and this is where the rest is dropped.
+        accountNumber: accountNumberForStorage(formData.accountNumber, isCard),
       };
 
       // Create the account
@@ -176,7 +181,7 @@ export default function AddAccountModal({ isOpen, onClose, prefill, onAccountCre
 
   const selectedType = accountTypes.find(t => t.value === formData.type);
   const selectedCurrency = currencies.find(c => c.value === formData.currency);
-  const isCreditCard = formData.type === 'credit';
+  const isCreditCard = isCardAccountType(formData.type);
   const isBankAccount = formData.type === 'current' || formData.type === 'savings';
 
   return (
@@ -368,12 +373,7 @@ export default function AddAccountModal({ isOpen, onClose, prefill, onAccountCre
                     {...(isBankAccount ? { maxLength: BANK_ACCOUNT_NUMBER_LENGTH } : {})}
                     disabled={isSubmitting}
                   />
-                  {isCreditCard && (
-                    <CardNumberGuidance
-                      value={formData.accountNumber}
-                      onKeepLastFour={() => updateField('accountNumber', keepLastFour(formData.accountNumber))}
-                    />
-                  )}
+                  {isCreditCard && <CardNumberGuidance value={formData.accountNumber} />}
                 </div>
               </div>
             )}

--- a/src/components/BatchImportModal.test.tsx
+++ b/src/components/BatchImportModal.test.tsx
@@ -2,6 +2,8 @@ import React from 'react';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import BatchImportModal from './BatchImportModal';
+import { ofxImportService } from '../services/ofxImportService';
+import type { Account } from '../types';
 
 // Mock services
 vi.mock('../services/enhancedCsvImportService', () => ({
@@ -14,7 +16,8 @@ vi.mock('../services/enhancedCsvImportService', () => ({
 
 vi.mock('../services/ofxImportService', () => ({
   ofxImportService: {
-    parseOFX: vi.fn(() => ({ accounts: [], transactions: [] }))
+    parseOFX: vi.fn(() => ({ accounts: [], transactions: [] })),
+    importTransactions: vi.fn()
   }
 }));
 
@@ -63,13 +66,23 @@ vi.mock('./icons', () => ({
 }));
 
 // Mock useApp hook
+const mockAddTransaction = vi.fn();
+const mockUpdateAccount = vi.fn();
+const mockBatchAccount: Account = {
+  id: 'acc1',
+  name: 'Checking',
+  type: 'checking',
+  balance: 1000,
+  currency: 'USD',
+  lastUpdated: new Date('2026-01-01'),
+};
+
 vi.mock('../contexts/AppContextSupabase', () => ({
   useApp: vi.fn(() => ({
-    accounts: [
-      { id: 'acc1', name: 'Checking', type: 'checking', balance: 1000, createdAt: new Date(), currency: 'USD' }
-    ],
+    accounts: [mockBatchAccount],
     transactions: [],
-    addTransaction: vi.fn(),
+    addTransaction: mockAddTransaction,
+    updateAccount: mockUpdateAccount,
   })),
 }));
 
@@ -170,8 +183,85 @@ describe('BatchImportModal (Simplified)', () => {
   it('calls onClose when close button clicked', () => {
     const onClose = vi.fn();
     render(<BatchImportModal {...defaultProps} onClose={onClose} />);
-    
+
     fireEvent.click(screen.getByLabelText('Close modal'));
     expect(onClose).toHaveBeenCalled();
+  });
+
+  /**
+   * This screen never asks which account an OFX file belongs to: files are
+   * matched automatically and the result is a list of counts. So the statement
+   * balance is only written when the FILE named the account — the account's
+   * own recorded sort code / account number being the one in the file — and
+   * never on a name-and-type guess nobody is there to check.
+   */
+  describe('Setting the Bank Balance from a statement', () => {
+    type ImportResult = Awaited<ReturnType<typeof ofxImportService.importTransactions>>;
+
+    const importResult = (overrides: Partial<ImportResult> = {}): ImportResult => ({
+      transactions: [],
+      matchedAccount: mockBatchAccount,
+      ofxAccount: {
+        accountId: '12345678',
+        bankId: '123456',
+        accountType: 'CHECKING',
+        isCreditCardStatement: false,
+      },
+      matchConfidence: 'identifier',
+      statementBalance: { amount: 5000, dateAsOf: '2026-03-31' },
+      duplicates: 0,
+      newTransactions: 0,
+      ...overrides,
+    });
+
+    const importOfxFile = async (result: ImportResult): Promise<void> => {
+      vi.mocked(ofxImportService.importTransactions).mockResolvedValue(result);
+
+      render(<BatchImportModal {...defaultProps} />);
+
+      const file = new File([''], 'statement.ofx', { type: 'application/x-ofx' });
+      // jsdom's File has no usable text() in this environment.
+      file.text = vi.fn().mockResolvedValue('OFX content');
+
+      fireEvent.change(document.querySelector('input[type="file"]') as HTMLInputElement, {
+        target: { files: [file] }
+      });
+      await waitFor(() => {
+        expect(screen.getByText('Import All Files')).toBeInTheDocument();
+      });
+
+      fireEvent.click(screen.getByText('Import All Files'));
+      await waitFor(() => {
+        expect(screen.getByText(/Import Complete/)).toBeInTheDocument();
+      });
+    };
+
+    it('sets the Bank Balance when the file named the account itself', async () => {
+      await importOfxFile(importResult());
+
+      expect(mockUpdateAccount).toHaveBeenCalledWith('acc1', {
+        bankBalance: 5000,
+        bankBalanceDate: '2026-03-31'
+      });
+    });
+
+    it('never writes `balance` — that is the ledger, not the bank\'s figure', async () => {
+      await importOfxFile(importResult());
+
+      const written = mockUpdateAccount.mock.calls.flatMap(([, updates]) => Object.keys(updates));
+      expect(written).not.toContain('balance');
+    });
+
+    it('will not set a Bank Balance on an account it merely guessed', async () => {
+      await importOfxFile(importResult({ matchConfidence: 'heuristic' }));
+
+      expect(mockUpdateAccount).not.toHaveBeenCalled();
+    });
+
+    it('does nothing when the file states no closing balance', async () => {
+      await importOfxFile(importResult({ statementBalance: undefined }));
+
+      expect(mockUpdateAccount).not.toHaveBeenCalled();
+    });
   });
 });

--- a/src/components/BatchImportModal.tsx
+++ b/src/components/BatchImportModal.tsx
@@ -15,6 +15,15 @@ import {
 } from './icons';
 import { LoadingButton } from './loading/LoadingState';
 import { isDuplicateImport } from '../utils/importDedupe';
+import {
+  formatStatementDay,
+  planStatementBankBalance,
+  type BankBalanceRecord
+} from '../utils/statementBankBalance';
+import { formatCurrency } from '../utils/currency-decimal';
+import { createScopedLogger } from '../loggers/scopedLogger';
+
+const logger = createScopedLogger('BatchImportModal');
 
 interface BatchImportModalProps {
   isOpen: boolean;
@@ -31,10 +40,14 @@ interface FileInfo {
   imported?: number;
   duplicates?: number;
   accountMatched?: string;
+  /** Set when this file's closing balance became the account's Bank Balance. */
+  bankBalanceSet?: string;
+  /** Set when that write failed — the transactions still landed. */
+  bankBalanceWarning?: string;
 }
 
 export default function BatchImportModal({ isOpen, onClose }: BatchImportModalProps): React.JSX.Element {
-  const { accounts, transactions, addTransaction } = useApp();
+  const { accounts, transactions, addTransaction, updateAccount } = useApp();
   const [files, setFiles] = useState<FileInfo[]>([]);
   const [isProcessing, setIsProcessing] = useState(false);
   const [currentFileIndex, setCurrentFileIndex] = useState(-1);
@@ -107,7 +120,59 @@ export default function BatchImportModal({ isOpen, onClose }: BatchImportModalPr
     setFiles(files.filter((_, i) => i !== index));
   };
 
-  const processFile = async (fileInfo: FileInfo, index: number): Promise<void> => {
+  /**
+   * Give the account the statement's own closing balance, so Reconciliation
+   * has something to check the rows just imported against.
+   *
+   * Only ever `bankBalance` — never `balance`, which the transactions above
+   * have already moved.
+   *
+   * Only on an IDENTIFIER match, unlike the OFX modal. Nobody is watching this
+   * screen: files are matched to accounts automatically and the result is a
+   * list of counts. A name-and-type guess is good enough to place transactions
+   * (each one visible and removable afterwards) but not to redefine what an
+   * account reconciles against, which nothing on this screen would show.
+   */
+  const applyStatementBankBalance = async (
+    result: Awaited<ReturnType<typeof ofxImportService.importTransactions>>,
+    writtenThisRun: Map<string, BankBalanceRecord>
+  ): Promise<{ note?: string; warning?: string }> => {
+    const account = result.matchedAccount;
+    if (!account) return {};
+
+    const plan = planStatementBankBalance(
+      result.statementBalance,
+      writtenThisRun.get(account.id) ?? account,
+      { destinationConfirmed: result.matchConfidence === 'identifier' }
+    );
+    if (plan.kind !== 'set') return {};
+
+    try {
+      await updateAccount(account.id, plan.updates);
+      writtenThisRun.set(account.id, plan.updates);
+      return {
+        note: `Bank Balance ${formatCurrency(plan.amount, account.currency)} as at ${formatStatementDay(plan.dateAsOf)}`
+      };
+    } catch (error) {
+      // The transactions are already in; say what did not happen rather than
+      // reporting the whole file as failed.
+      logger.error('Failed to set bank balance from statement', error);
+      return { warning: `Couldn't update ${account.name}'s Bank Balance` };
+    }
+  };
+
+  const processFile = async (
+    fileInfo: FileInfo,
+    index: number,
+    /**
+     * What this run has already written to each account's Bank Balance. The
+     * `accounts` array is React state and does not change between files, so
+     * without this a second statement for the same account would be judged
+     * against the account as it stood before the batch — and last March's
+     * statement could overwrite this month's.
+     */
+    bankBalancesWrittenThisRun: Map<string, BankBalanceRecord>
+  ): Promise<void> => {
     setCurrentFileIndex(index);
     setFiles(prev => prev.map((f, i) => 
       i === index ? { ...f, status: 'processing' } : f
@@ -118,6 +183,8 @@ export default function BatchImportModal({ isOpen, onClose }: BatchImportModalPr
       let imported = 0;
       let duplicates = 0;
       let accountMatched = '';
+      let bankBalanceSet: string | undefined;
+      let bankBalanceWarning: string | undefined;
 
       switch (fileInfo.type) {
         case 'csv': {
@@ -178,9 +245,13 @@ export default function BatchImportModal({ isOpen, onClose }: BatchImportModalPr
             imported++;
           }
           duplicates = result.duplicates;
+
+          const balanceOutcome = await applyStatementBankBalance(result, bankBalancesWrittenThisRun);
+          bankBalanceSet = balanceOutcome.note;
+          bankBalanceWarning = balanceOutcome.warning;
           break;
         }
-        
+
         case 'qif': {
           const result = await qifImportService.importTransactions(
             content,
@@ -199,13 +270,15 @@ export default function BatchImportModal({ isOpen, onClose }: BatchImportModalPr
         }
       }
 
-      setFiles(prev => prev.map((f, i) => 
-        i === index ? { 
-          ...f, 
-          status: 'success', 
-          imported, 
+      setFiles(prev => prev.map((f, i) =>
+        i === index ? {
+          ...f,
+          status: 'success',
+          imported,
           duplicates,
-          accountMatched 
+          accountMatched,
+          bankBalanceSet,
+          bankBalanceWarning
         } : f
       ));
     } catch (error) {
@@ -231,10 +304,11 @@ export default function BatchImportModal({ isOpen, onClose }: BatchImportModalPr
     let totalImported = 0;
     let totalDuplicates = 0;
     let successfulFiles = 0;
+    const bankBalancesWrittenThisRun = new Map<string, BankBalanceRecord>();
 
     for (let i = 0; i < files.length; i++) {
       if (files[i].status === 'pending') {
-        await processFile(files[i], i);
+        await processFile(files[i], i, bankBalancesWrittenThisRun);
         
         const updatedFile = files[i];
         if (updatedFile.status === 'success') {
@@ -419,6 +493,19 @@ export default function BatchImportModal({ isOpen, onClose }: BatchImportModalPr
                             {file.accountMatched && (
                               <span className="ml-2 text-primary">
                                 → {accounts.find(a => a.id === file.accountMatched)?.name}
+                              </span>
+                            )}
+                            {/* Only ever present when a balance was actually
+                                written, so there is nothing to render when
+                                nothing happened. */}
+                            {file.bankBalanceSet && (
+                              <span className="ml-2 text-gray-600 dark:text-gray-400">
+                                • {file.bankBalanceSet}
+                              </span>
+                            )}
+                            {file.bankBalanceWarning && (
+                              <span className="ml-2 text-yellow-600 dark:text-yellow-400">
+                                • {file.bankBalanceWarning}
                               </span>
                             )}
                           </p>

--- a/src/components/CardNumberGuidance.test.tsx
+++ b/src/components/CardNumberGuidance.test.tsx
@@ -1,0 +1,35 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import CardNumberGuidance from './CardNumberGuidance';
+
+describe('CardNumberGuidance', () => {
+  it('states the rule before anything has been typed', () => {
+    render(<CardNumberGuidance value="" />);
+
+    expect(
+      screen.getByText(/Only the last 4 digits are ever saved/)
+    ).toBeInTheDocument();
+  });
+
+  it('stays quiet while the field holds four digits or fewer', () => {
+    render(<CardNumberGuidance value="9012" />);
+
+    // The live region is there but empty — it has to pre-exist its own message
+    // for a screen reader to announce it.
+    expect(screen.getByRole('status')).toBeEmptyDOMElement();
+  });
+
+  it('names the four digits that will survive a pasted card number', () => {
+    render(<CardNumberGuidance value="4929123456789012" />);
+
+    const panel = screen.getByRole('status');
+    expect(panel).toHaveTextContent('That is 16 digits.');
+    expect(panel).toHaveTextContent('Saving will store 9012 and discard the rest.');
+  });
+
+  it('offers no action, because keeping a full card number is not on offer', () => {
+    render(<CardNumberGuidance value="4929123456789012" />);
+
+    expect(screen.queryByRole('button')).not.toBeInTheDocument();
+  });
+});

--- a/src/components/CardNumberGuidance.tsx
+++ b/src/components/CardNumberGuidance.tsx
@@ -3,8 +3,6 @@ import { hasMoreThanLastFour, keepLastFour, digitsOnly } from '../utils/accountN
 interface CardNumberGuidanceProps {
   /** Whatever the card-number field currently holds. */
   value: string;
-  /** Replace the field with just the last 4 digits. */
-  onKeepLastFour: () => void;
 }
 
 /**
@@ -13,14 +11,17 @@ interface CardNumberGuidanceProps {
  * later. It lives in one component on purpose: a second copy of a security
  * warning is a second thing to forget to update.
  *
- * The over-length case does not rewrite the field. It says how many digits are
- * there, says nothing has changed yet, and offers the trim as a button naming
- * the four digits that would be kept — so a pasted full card number is a choice
- * the user makes, not something the form does behind their back.
+ * The over-length case states what will happen rather than offering a button
+ * that could be ignored. Saving keeps the last 4 whatever the field holds (see
+ * accountNumberForStorage), so the panel names the four digits that survive
+ * and says the rest is dropped — the user is told, not asked.
+ *
+ * Its live region is rendered empty rather than mounted along with the panel:
+ * a screen reader only announces a status that was already in the page when
+ * its text appeared, and this is the one message here nobody should miss.
  */
 export default function CardNumberGuidance({
-  value,
-  onKeepLastFour
+  value
 }: CardNumberGuidanceProps): React.JSX.Element {
   const digits = digitsOnly(value);
 
@@ -32,25 +33,20 @@ export default function CardNumberGuidance({
         time.
       </p>
       <p className="mt-1 text-xs text-amber-700 dark:text-amber-400">
-        Never enter the full card number. Everything in this field is kept in
-        plain text — it goes into your backups, your JSON export and your audit
-        history, and the last 4 digits are all the matching needs.
+        Only the last 4 digits are ever saved. Anything longer is dropped when
+        you save, so a full card number never reaches your backups, your JSON
+        export or your audit history.
       </p>
-      {hasMoreThanLastFour(value) && (
-        <div className="mt-2 rounded-xl border border-amber-300 dark:border-amber-700 bg-amber-50 dark:bg-amber-900/20 px-3 py-2">
-          <p className="text-xs text-amber-800 dark:text-amber-300">
-            That is {digits.length} digits — more than the last 4. Nothing has
-            been changed yet; saving would store all of it.
-          </p>
-          <button
-            type="button"
-            onClick={onKeepLastFour}
-            className="mt-1 text-xs font-medium text-amber-900 dark:text-amber-200 underline hover:no-underline"
-          >
-            Keep only the last 4 ({keepLastFour(value)})
-          </button>
-        </div>
-      )}
+      <div role="status">
+        {hasMoreThanLastFour(value) && (
+          <div className="mt-2 rounded-xl border border-amber-300 dark:border-amber-700 bg-amber-50 dark:bg-amber-900/20 px-3 py-2">
+            <p className="text-xs text-amber-800 dark:text-amber-300">
+              That is {digits.length} digits. Saving will store {keepLastFour(value)} and
+              discard the rest.
+            </p>
+          </div>
+        )}
+      </div>
     </>
   );
 }

--- a/src/components/EnhancedImportWizard.tsx
+++ b/src/components/EnhancedImportWizard.tsx
@@ -19,6 +19,12 @@ import {
 } from './icons';
 import { Modal, ModalBody, ModalFooter } from './common/Modal';
 import { isDuplicateImport } from '../utils/importDedupe';
+import {
+  formatStatementDay,
+  planStatementBankBalance,
+  type BankBalanceRecord
+} from '../utils/statementBankBalance';
+import { formatCurrency } from '../utils/currency-decimal';
 import { createScopedLogger } from '../loggers/scopedLogger';
 import BankFormatSelector from './BankFormatSelector';
 import ImportRulesManager from './ImportRulesManager';
@@ -40,6 +46,10 @@ interface FileInfo {
   imported?: number;
   duplicates?: number;
   bankFormat?: string;
+  /** Set when this file's closing balance became the account's Bank Balance. */
+  bankBalanceSet?: string;
+  /** Set when that write failed — the transactions still landed. */
+  bankBalanceWarning?: string;
 }
 
 interface ImportSummary {
@@ -50,7 +60,7 @@ interface ImportSummary {
 }
 
 export default function EnhancedImportWizard({ isOpen, onClose }: EnhancedImportWizardProps): React.JSX.Element {
-  const { accounts, transactions, addTransaction, categories } = useApp();
+  const { accounts, transactions, addTransaction, categories, updateAccount } = useApp();
   const logger = useMemo(() => createScopedLogger('EnhancedImportWizard'), []);
   
   const [currentStep, setCurrentStep] = useState<WizardStep>('files');
@@ -138,20 +148,66 @@ export default function EnhancedImportWizard({ isOpen, onClose }: EnhancedImport
   // clear button called a context reset that only emptied React state, so on a
   // cloud login the data came back on the next load. The Review step now says
   // plainly what the import does to existing data.
+  /**
+   * Give the account the statement's own closing balance, so Reconciliation
+   * has something to check the rows just imported against.
+   *
+   * Only ever `bankBalance` — never `balance`, which the transactions have
+   * already moved.
+   *
+   * Only on an IDENTIFIER match: this wizard never asks which account an OFX
+   * file belongs to, so anything less is a guess made with nobody watching.
+   * A guess is good enough to place transactions, which stay visible and
+   * removable; it is not good enough to redefine what an account reconciles
+   * against.
+   */
+  const applyStatementBankBalance = async (
+    result: Awaited<ReturnType<typeof ofxImportService.importTransactions>>,
+    writtenThisRun: Map<string, BankBalanceRecord>
+  ): Promise<{ note?: string; warning?: string }> => {
+    const account = result.matchedAccount;
+    if (!account) return {};
+
+    const plan = planStatementBankBalance(
+      result.statementBalance,
+      writtenThisRun.get(account.id) ?? account,
+      { destinationConfirmed: result.matchConfidence === 'identifier' }
+    );
+    if (plan.kind !== 'set') return {};
+
+    try {
+      await updateAccount(account.id, plan.updates);
+      writtenThisRun.set(account.id, plan.updates);
+      return {
+        note: `Bank Balance ${formatCurrency(plan.amount, account.currency)} as at ${formatStatementDay(plan.dateAsOf)}`
+      };
+    } catch (error) {
+      // The transactions are already in; report what did not happen instead of
+      // failing the file.
+      logger.error('Failed to set bank balance from statement', error as Error);
+      return { warning: `Couldn't update ${account.name}'s Bank Balance` };
+    }
+  };
+
   const processFiles = async () => {
     setIsProcessing(true);
     setCurrentStep('result');
-    
+
     let totalImported = 0;
     let totalDuplicates = 0;
     let successfulFiles = 0;
-    
+    // Statements written during THIS run, because `accounts` is React state and
+    // does not refresh between files: without it, two statements for one
+    // account would both be judged against the account as it stood before the
+    // run, and the older could overwrite the newer.
+    const bankBalancesWrittenThisRun = new Map<string, BankBalanceRecord>();
+
     try {
       for (let i = 0; i < files.length; i++) {
         const fileInfo = files[i];
         setCurrentFileIndex(i);
-        
-        setFiles(prev => prev.map((f, index) => 
+
+        setFiles(prev => prev.map((f, index) =>
           index === i ? { ...f, status: 'processing' } : f
         ));
 
@@ -159,6 +215,8 @@ export default function EnhancedImportWizard({ isOpen, onClose }: EnhancedImport
           const content = await fileInfo.file.text();
           let imported = 0;
           let duplicates = 0;
+          let bankBalanceSet: string | undefined;
+          let bankBalanceWarning: string | undefined;
 
           switch (fileInfo.type) {
             case 'csv': {
@@ -219,9 +277,13 @@ export default function EnhancedImportWizard({ isOpen, onClose }: EnhancedImport
                 imported++;
               }
               duplicates = result.duplicates;
+
+              const balanceOutcome = await applyStatementBankBalance(result, bankBalancesWrittenThisRun);
+              bankBalanceSet = balanceOutcome.note;
+              bankBalanceWarning = balanceOutcome.warning;
               break;
             }
-            
+
             case 'qif': {
               const result = await qifImportService.importTransactions(
                 content,
@@ -242,12 +304,14 @@ export default function EnhancedImportWizard({ isOpen, onClose }: EnhancedImport
             }
           }
 
-          setFiles(prev => prev.map((f, index) => 
-            index === i ? { 
-              ...f, 
+          setFiles(prev => prev.map((f, index) =>
+            index === i ? {
+              ...f,
               status: 'success',
               imported,
-              duplicates
+              duplicates,
+              bankBalanceSet,
+              bankBalanceWarning
             } : f
           ));
           
@@ -511,6 +575,18 @@ export default function EnhancedImportWizard({ isOpen, onClose }: EnhancedImport
                           {file.duplicates && file.duplicates > 0 && (
                             <p className="text-xs text-gray-600 dark:text-gray-400">
                               {file.duplicates} duplicates
+                            </p>
+                          )}
+                          {/* Present only when a balance was actually written,
+                              so nothing renders when nothing happened. */}
+                          {file.bankBalanceSet && (
+                            <p className="text-xs text-gray-600 dark:text-gray-400">
+                              {file.bankBalanceSet}
+                            </p>
+                          )}
+                          {file.bankBalanceWarning && (
+                            <p className="text-xs text-yellow-600 dark:text-yellow-400">
+                              {file.bankBalanceWarning}
                             </p>
                           )}
                         </div>

--- a/src/components/OFXImportModal.test.tsx
+++ b/src/components/OFXImportModal.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import OFXImportModal from './OFXImportModal';
 import { ofxImportService } from '../services/ofxImportService';
 import type { Account } from '../types';
@@ -94,13 +94,17 @@ const mockAccounts: Account[] = [
   mockAccount({ id: 'acc1', name: 'Current Account', type: 'checking' }),
   mockAccount({ id: 'acc2', name: 'Savings Account', type: 'savings' }),
   mockAccount({ id: 'acc3', name: 'Credit Card', type: 'credit' }),
-  // Already has its bank details recorded — nothing may ever be written over them.
+  // Already has its bank details recorded — nothing may ever be written over
+  // them — and a bank balance more recent than any statement used in these
+  // tests, which nothing may write over either.
   mockAccount({
     id: 'acc4',
     name: 'Filed Account',
     type: 'current',
     sortCode: '12-34-56',
-    accountNumber: '12345678'
+    accountNumber: '12345678',
+    bankBalance: 4200,
+    bankBalanceDate: '2026-11-30'
   })
 ];
 
@@ -1098,6 +1102,166 @@ describe('OFXImportModal', () => {
 
       expect(screen.getByText('Imported 1 transactions to Savings Account')).toBeInTheDocument();
       expect(screen.getByText(/Couldn't save .* to Savings Account/)).toBeInTheDocument();
+    });
+  });
+
+  /**
+   * Setting the account's Bank Balance from the statement's own closing
+   * balance — the figure Reconciliation compares the cleared ledger against,
+   * and without which finalising a reconciliation proves nothing.
+   */
+  describe('Setting the Bank Balance from the statement', () => {
+    const CREDIT_CARD = 'Credit Card (credit)';
+    const FILED_ACCOUNT = 'Filed Account (current)';
+
+    // Some of these tests stop at the preview and never press Import, leaving
+    // the second queued result unconsumed — and a mockResolvedValueOnce queue
+    // survives vi.clearAllMocks(), so it would be handed to the NEXT test's
+    // parse. Drop the queue with the test that made it.
+    afterEach(() => {
+      vi.mocked(ofxImportService.importTransactions).mockReset();
+    });
+
+    const CARD_STATEMENT: ImportTransactionsResult['ofxAccount'] = {
+      accountId: '4929123456789012',
+      accountType: 'CREDITCARD',
+      isCreditCardStatement: true,
+    };
+
+    /** Upload a file, choose a destination, and stop before pressing Import. */
+    const runImport = async (
+      parsed: Partial<ImportTransactionsResult>,
+      accountLabel: string,
+      importedAccount: Account
+    ): Promise<void> => {
+      const parseResult = createMockImportResult({
+        transactions: [sampleTransaction],
+        newTransactions: 1,
+        statementBalance: { amount: 5000, dateAsOf: '2026-03-31' },
+        ...parsed
+      });
+
+      vi.mocked(ofxImportService.importTransactions)
+        .mockResolvedValueOnce(parseResult)
+        .mockResolvedValueOnce(
+          createMockImportResult({
+            ...parseResult,
+            matchedAccount: importedAccount
+          })
+        );
+
+      render(<OFXImportModal {...defaultProps} />);
+      fireEvent.change(document.getElementById('ofx-upload')!, {
+        target: { files: [new File(['OFX content'], 'test.ofx', { type: 'application/ofx' })] }
+      });
+
+      await waitFor(() => {
+        expect(screen.getByRole('combobox', { name: 'Import to Account' })).toBeInTheDocument();
+      });
+      chooseAccount(accountLabel);
+    };
+
+    const pressImport = async (): Promise<void> => {
+      fireEvent.click(screen.getByTestId('loading-button'));
+      await waitFor(() => {
+        expect(screen.getByText('Import Successful!')).toBeInTheDocument();
+      });
+    };
+
+    /** Every field this import wrote to the account, across all calls. */
+    const writtenFields = (): string[] =>
+      mockUpdateAccount.mock.calls.flatMap(([, updates]) => Object.keys(updates));
+
+    it('sets the Bank Balance to the statement\'s closing figure, dated by the statement', async () => {
+      await runImport({}, SAVINGS_ACCOUNT, mockAccounts[1]);
+      await pressImport();
+
+      expect(mockUpdateAccount).toHaveBeenCalledWith('acc2', {
+        bankBalance: 5000,
+        bankBalanceDate: '2026-03-31'
+      });
+      expect(screen.getByText(/Bank Balance set to £5,000\.00, as at 31 Mar 2026/))
+        .toBeInTheDocument();
+    });
+
+    it('never writes `balance` — that is the ledger the transactions already moved', async () => {
+      await runImport({}, SAVINGS_ACCOUNT, mockAccounts[1]);
+      await pressImport();
+
+      expect(mockUpdateAccount).toHaveBeenCalled();
+      expect(writtenFields()).not.toContain('balance');
+      expect(writtenFields()).not.toContain('openingBalance');
+    });
+
+    it('says what it will do before the user commits to it', async () => {
+      await runImport({}, SAVINGS_ACCOUNT, mockAccounts[1]);
+
+      expect(
+        screen.getByText(/Savings Account's Bank Balance will be set to £5,000\.00, as at 31 Mar 2026/)
+      ).toBeInTheDocument();
+      expect(mockUpdateAccount).not.toHaveBeenCalled();
+    });
+
+    it('leaves a more recent Bank Balance alone, and says which one it kept', async () => {
+      // Filed Account's balance is dated 30 Nov 2026; this statement closes in
+      // March. Overwriting would show months of spending as a difference.
+      await runImport({}, FILED_ACCOUNT, mockAccounts[3]);
+
+      expect(
+        screen.getByText(/will be left as it is: it already holds £4,200\.00 dated 30 Nov 2026/)
+      ).toBeInTheDocument();
+
+      await pressImport();
+      expect(mockUpdateAccount).not.toHaveBeenCalled();
+      expect(screen.queryByText(/Bank Balance set to/)).not.toBeInTheDocument();
+    });
+
+    it('keeps a card statement\'s debt a debt', async () => {
+      // OFX signs the closing balance the same way it signs the purchases
+      // beside it, and this app stores a liability negative. Negating it here
+      // — as the TrueLayer card feed needs — would turn the debt into £1,234.56
+      // of assets.
+      await runImport(
+        {
+          ofxAccount: CARD_STATEMENT,
+          statementBalance: { amount: -1234.56, dateAsOf: '2026-03-31' }
+        },
+        CREDIT_CARD,
+        mockAccounts[2]
+      );
+      await pressImport();
+
+      expect(mockUpdateAccount).toHaveBeenCalledWith('acc3', {
+        bankBalance: -1234.56,
+        bankBalanceDate: '2026-03-31'
+      });
+      expect(screen.getByText(/Bank Balance set to -£1,234\.56/)).toBeInTheDocument();
+    });
+
+    it('says plainly when the file states no closing balance', async () => {
+      await runImport({ statementBalance: undefined }, SAVINGS_ACCOUNT, mockAccounts[1]);
+
+      expect(
+        screen.getByText(/This file doesn't state a closing balance/)
+      ).toBeInTheDocument();
+
+      await pressImport();
+      expect(writtenFields()).not.toContain('bankBalance');
+    });
+
+    it('still reports the import as done when the Bank Balance write fails', async () => {
+      // Filed Account has its details recorded, so the balance is the only
+      // write this import attempts.
+      await runImport(
+        { statementBalance: { amount: 5000, dateAsOf: '2026-12-31' } },
+        FILED_ACCOUNT,
+        mockAccounts[3]
+      );
+      mockUpdateAccount.mockRejectedValueOnce(new Error('offline'));
+      await pressImport();
+
+      expect(screen.getByText('Imported 1 transactions to Filed Account')).toBeInTheDocument();
+      expect(screen.getByText(/Bank Balance couldn't be updated/)).toBeInTheDocument();
     });
   });
 });

--- a/src/components/OFXImportModal.tsx
+++ b/src/components/OFXImportModal.tsx
@@ -6,6 +6,11 @@ import {
   readOfxAccountIdentifiers
 } from '../utils/ofxAccountIdentifiers';
 import { keepLastFour } from '../utils/accountNumberInput';
+import { formatStatementDay, planStatementBankBalance } from '../utils/statementBankBalance';
+// The account's OWN currency, not the user's display currency: a statement
+// states a figure in the currency the account is held in, and the reconciliation
+// screen compares it in that currency too.
+import { formatCurrency } from '../utils/currency-decimal';
 import { Modal } from './common/Modal';
 import {
   UploadIcon,
@@ -41,6 +46,10 @@ type ImportOutcome =
       savedDetails?: { accountName: string; summary: string };
       /** Set when saving those details failed — the transactions still landed. */
       savedDetailsError?: string;
+      /** Set when the statement's closing balance became the Bank Balance. */
+      bankBalance?: { amount: string; dateAsOf: string };
+      /** Set when writing that balance failed — the transactions still landed. */
+      bankBalanceError?: string;
     }
   | {
       success: false;
@@ -124,10 +133,40 @@ export default function OFXImportModal({ isOpen, onClose }: OFXImportModalProps)
     parseResult?.matchConfidence === 'identifier' &&
     parseResult.matchedAccount?.id === selectedAccountId;
 
+  // What this file would do to the account's Bank Balance — the figure
+  // Reconciliation measures against, and the reason finalising means anything.
+  // Worked out here so the preview can state it before the user commits, and
+  // again at import time against the account the money actually went into.
+  const bankBalancePlan = useMemo(
+    () =>
+      planStatementBankBalance(parseResult?.statementBalance, selectedAccount, {
+        // The destination is on screen with the figure next to it, and Import
+        // is disabled until an account is chosen — this is not a silent guess.
+        destinationConfirmed: true
+      }),
+    [parseResult, selectedAccount]
+  );
+
   // Automatic when the destination is a decision (the user picked it, or the
   // account's own recorded details are the file's), off when it is a guess.
   const saveDetailsByDefault = accountIsUserChoice || matchIsCertain;
   const saveDetails = detailsToSave !== null && (saveDetailsOverride ?? saveDetailsByDefault);
+
+  // One line about the consequence, or nothing at all. Only rendered once a
+  // destination is chosen, because until then there is no account to talk about.
+  const bankBalanceNotice = useMemo((): string | null => {
+    if (!parseResult || !selectedAccount) return null;
+
+    if (bankBalancePlan.kind === 'set') {
+      return `${selectedAccount.name}'s Bank Balance will be set to ${formatCurrency(bankBalancePlan.amount, selectedAccount.currency)}, as at ${formatStatementDay(bankBalancePlan.dateAsOf)} — the figure Reconciliation checks your cleared transactions against.`;
+    }
+
+    if (bankBalancePlan.kind === 'stale') {
+      return `${selectedAccount.name}'s Bank Balance will be left as it is: it already holds ${formatCurrency(bankBalancePlan.recordedBalance, selectedAccount.currency)} dated ${formatStatementDay(bankBalancePlan.recordedDate)}, which is later than this statement.`;
+    }
+
+    return `This file doesn't state a closing balance, so ${selectedAccount.name}'s Bank Balance stays as it is and Reconciliation has nothing to check these transactions against. You can enter it there by hand.`;
+  }, [bankBalancePlan, parseResult, selectedAccount]);
 
   const handleAccountChange = useCallback((accountId: string) => {
     setSelectedAccountId(accountId);
@@ -222,13 +261,43 @@ export default function OFXImportModal({ isOpen, onClose }: OFXImportModalProps)
         }
       }
 
+      // The statement's closing balance becomes the account's Bank Balance,
+      // exactly as a bank feed's would. ONLY bankBalance and its date are
+      // written — never `balance`, which is the ledger the transactions above
+      // have already moved; writing the statement total on top of it would
+      // count the same money twice.
+      //
+      // Recomputed against the real destination for the same reason the
+      // details plan is, and kept as its own write so that a failure here
+      // cannot be mistaken for a failure to save the bank details.
+      let bankBalance: { amount: string; dateAsOf: string } | undefined;
+      let bankBalanceError: string | undefined;
+      const balancePlan = planStatementBankBalance(result.statementBalance, account, {
+        destinationConfirmed: true
+      });
+
+      if (balancePlan.kind === 'set' && account) {
+        try {
+          await updateAccount(account.id, balancePlan.updates);
+          bankBalance = {
+            amount: formatCurrency(balancePlan.amount, account.currency),
+            dateAsOf: formatStatementDay(balancePlan.dateAsOf)
+          };
+        } catch (error) {
+          logger.error('Failed to set bank balance from OFX statement', error);
+          bankBalanceError = `The transactions imported fine, but ${account.name}'s Bank Balance couldn't be updated — Reconciliation will still compare against the old figure. You can type it in there.`;
+        }
+      }
+
       setImportResult({
         success: true,
         imported: result.newTransactions,
         duplicates: result.duplicates,
         account,
         savedDetails,
-        savedDetailsError
+        savedDetailsError,
+        bankBalance,
+        bankBalanceError
       });
     } catch (error) {
       logger.error('Import error', error);
@@ -300,7 +369,10 @@ export default function OFXImportModal({ isOpen, onClose }: OFXImportModalProps)
                     <li>• Automatic duplicate detection using transaction IDs</li>
                     <li>• Smart account matching based on account numbers</li>
                     <li>• Preserves transaction reference numbers</li>
-                    <li>• Imports cleared transactions with exact dates</li>
+                    <li>• Sets the account&apos;s Bank Balance from the statement&apos;s closing balance</li>
+                    {/* Said plainly because it changed: rows used to arrive
+                        pre-cleared, which skipped the check the file is for. */}
+                    <li>• Leaves the transactions for you to reconcile against the statement</li>
                   </ul>
                 </div>
               </div>
@@ -401,6 +473,15 @@ export default function OFXImportModal({ isOpen, onClose }: OFXImportModalProps)
                   </p>
                 </div>
               )}
+
+              {/* The Bank Balance is what makes finalising a reconciliation
+                  mean anything, so what this file does to it is said before it
+                  happens rather than discovered on the reconciliation screen. */}
+              {bankBalanceNotice && (
+                <p className="mt-3 text-sm text-gray-600 dark:text-gray-400">
+                  {bankBalanceNotice}
+                </p>
+              )}
             </div>
 
             {/* Import Options */}
@@ -476,6 +557,20 @@ export default function OFXImportModal({ isOpen, onClose }: OFXImportModalProps)
                 {importResult.duplicates > 0 && (
                   <p className="text-sm text-yellow-600 dark:text-yellow-400 mb-6">
                     Skipped {importResult.duplicates} duplicate transactions
+                  </p>
+                )}
+
+                {importResult.bankBalance && (
+                  <p className="text-sm text-gray-600 dark:text-gray-400 mb-6">
+                    Bank Balance set to {importResult.bankBalance.amount}, as at{' '}
+                    {importResult.bankBalance.dateAsOf}. Reconciliation now has
+                    something to check these transactions against.
+                  </p>
+                )}
+
+                {importResult.bankBalanceError && (
+                  <p className="text-sm text-yellow-600 dark:text-yellow-400 mb-6">
+                    {importResult.bankBalanceError}
                   </p>
                 )}
 

--- a/src/components/banking/LinkBankAccountsModal.tsx
+++ b/src/components/banking/LinkBankAccountsModal.tsx
@@ -10,6 +10,7 @@ import type { Account } from '../../types';
 
 import AccountSelector from '../common/AccountSelector';
 import { CREATE_NEW_VALUE } from './accountPickerOptions';
+import { accountNumberForStorage, formatCardNumberForDisplay } from '../../utils/accountNumberInput';
 
 // The only lazy import in the app that must NOT reload the page on its own.
 // It is reached part-way through linking a bank connection: discovery has
@@ -39,6 +40,19 @@ const normalizeAccountNumber = (value: string | undefined): string =>
 
 const isCard = (discovered: DiscoveredBankAccount): boolean =>
   discovered.kind === 'card' || discovered.type === 'credit';
+
+/**
+ * The number this discovered account may be shown as, or linked with.
+ *
+ * TrueLayer's cards surface publishes a last-4 mask and nothing else, but a
+ * credit card reached through the ACCOUNTS surface (account_type
+ * "credit_card") carries account_number.number — the full card number. Linking
+ * writes that field onto the account row, so it is cut to the last 4 here,
+ * before it can be displayed, prefilled into the new-account form, or sent to
+ * /api/banking/link-accounts.
+ */
+const linkableAccountNumber = (discovered: DiscoveredBankAccount): string | undefined =>
+  accountNumberForStorage(discovered.accountNumber, isCard(discovered));
 
 // Cards expose no sort code or account number — only a last-4 mask. Restrict
 // mask matching to credit accounts, and only auto-select on a unique hit, so
@@ -224,7 +238,7 @@ export default function LinkBankAccountsModal({
           externalAccountMask: discovered?.mask,
           balance: discovered?.balance ?? 0,
           sortCode: discovered?.sortCode,
-          accountNumber: discovered?.accountNumber,
+          accountNumber: discovered ? linkableAccountNumber(discovered) : undefined,
           kind: discovered?.kind
         };
       });
@@ -280,6 +294,12 @@ export default function LinkBankAccountsModal({
                 );
                 const selectedId = link?.selectedAccountId ?? '';
                 const isMatched = findSmartMatch(da, accounts) !== null;
+                // A card's number is shown the way a card's number is shown
+                // everywhere else — masked to its last 4. A bank account's is
+                // the real 8-digit number and is shown whole.
+                const shownAccountNumber = isCard(da)
+                  ? formatCardNumberForDisplay(linkableAccountNumber(da))
+                  : da.accountNumber ?? '';
 
                 return (
                   <div
@@ -300,10 +320,10 @@ export default function LinkBankAccountsModal({
                           {da.sortCode && (
                             <span>Sort Code: {formatSortCode(da.sortCode)}</span>
                           )}
-                          {da.accountNumber && (
-                            <span>Account: {da.accountNumber}</span>
+                          {shownAccountNumber && (
+                            <span>Account: {shownAccountNumber}</span>
                           )}
-                          {da.mask && !da.accountNumber && (
+                          {da.mask && !shownAccountNumber && (
                             <span>****{da.mask}</span>
                           )}
                           <span className="capitalize">{da.type === 'checking' ? 'Current' : da.type}</span>
@@ -452,7 +472,7 @@ export default function LinkBankAccountsModal({
                 balance: da?.balance?.toString(),
                 currency: da?.currency,
                 sortCode: da?.sortCode,
-                accountNumber: da?.accountNumber,
+                accountNumber: da ? linkableAccountNumber(da) : undefined,
               }}
               onAccountCreated={(newAccountId) => {
                 setLinks(prev => prev.map(link =>

--- a/src/pages/AccountTransactions.tsx
+++ b/src/pages/AccountTransactions.tsx
@@ -20,6 +20,7 @@ import { compareTransactions } from '../utils/transactionSort';
 import { orderColumnKeys, moveColumnKey } from '../utils/columnLayout';
 import { computeArchiveWindow, ARCHIVE_PRESETS, type ArchiveRange } from '../utils/archiveRange';
 import { effectiveOpeningDate, findSiblingAccount } from '../utils/openingDates';
+import { formatCardNumberForDisplay, isCardAccountType } from '../utils/accountNumberInput';
 import { DataService } from '../services/api/dataService';
 import AccountSelector from '../components/common/AccountSelector';
 import type { Account, Transaction } from '../types';
@@ -1048,6 +1049,19 @@ export default function AccountTransactions() {
     );
   }
 
+  // '00000000' is the placeholder an account with no number was seeded with,
+  // and it is not a number anyone wants read back at them.
+  const storedAccountNumber =
+    account.accountNumber && account.accountNumber !== '00000000' ? account.accountNumber : '';
+
+  // A card shows as XXXX XXXX XXXX 1234. Four digits on their own read like a
+  // truncation; the mask says plainly that four digits is the whole of what is
+  // held. A bank account number is a different thing — 8 real digits — so it
+  // is shown as it is.
+  const displayedAccountNumber = isCardAccountType(account.type)
+    ? formatCardNumberForDisplay(storedAccountNumber)
+    : storedAccountNumber;
+
   return (
     <div className="flex flex-col h-full">
       {/* Back button */}
@@ -1078,13 +1092,13 @@ export default function AccountTransactions() {
                 <SettingsIcon size={16} />
               </button>
             </div>
-            {(account.sortCode && account.sortCode !== '000000') || (account.accountNumber && account.accountNumber !== '00000000') ? (
+            {(account.sortCode && account.sortCode !== '000000') || displayedAccountNumber ? (
               <div className="flex items-center gap-3 mt-0.5">
                 {account.sortCode && account.sortCode !== '000000' && (
                   <span className="text-xs text-white/70">{account.sortCode}</span>
                 )}
-                {account.accountNumber && account.accountNumber !== '00000000' && (
-                  <span className="text-xs text-white/70">{account.accountNumber}</span>
+                {displayedAccountNumber && (
+                  <span className="text-xs text-white/70">{displayedAccountNumber}</span>
                 )}
               </div>
             ) : null}

--- a/src/pages/Reconciliation.tsx
+++ b/src/pages/Reconciliation.tsx
@@ -11,6 +11,7 @@ import ReconciliationTransactionList from '../components/reconciliation/Reconcil
 import ReconciliationFinalizationModal from '../components/reconciliation/ReconciliationFinalizationModal';
 import EditTransactionModal from '../components/EditTransactionModal';
 import { preserveRuntimeControlParams } from '../utils/runtimeMode';
+import { todayIsoDay } from '../utils/statementBankBalance';
 import type { Transaction } from '../types';
 
 export default function Reconciliation() {
@@ -218,7 +219,15 @@ export default function Reconciliation() {
 
   const handleBankBalanceChange = useCallback((newBalance: number) => {
     if (selectedAccountId) {
-      updateAccount(selectedAccountId, { bankBalance: newBalance });
+      // Dated as well as set. A figure typed here is what the bank says TODAY,
+      // and recording that keeps bank_balance_date describing the balance it
+      // sits beside — otherwise a hand-typed correction would inherit the date
+      // of whatever statement was imported last, and a later import of that
+      // statement's successor could be judged stale against it.
+      updateAccount(selectedAccountId, {
+        bankBalance: newBalance,
+        bankBalanceDate: todayIsoDay()
+      });
     }
   }, [selectedAccountId, updateAccount]);
 

--- a/src/pages/__tests__/AccountTransactions.test.tsx
+++ b/src/pages/__tests__/AccountTransactions.test.tsx
@@ -35,6 +35,18 @@ const CLOSED_ACCOUNT: Account = {
   currency: 'GBP', lastUpdated: new Date('2026-01-01'), openingBalance: 0, isActive: false,
 };
 
+// Bank details on show in the register header. A card stores (and is shown)
+// its last 4 digits; a bank account's 8 digits are the whole number.
+const CARD_ACCOUNT: Account = {
+  id: 'acc-card', name: 'Synthetic Card', type: 'credit', balance: 0,
+  currency: 'GBP', lastUpdated: new Date('2026-01-01'), openingBalance: 0, isActive: true,
+  accountNumber: '9012',
+};
+
+const DETAILED_ACCOUNT: Account = {
+  ...OPEN_ACCOUNT, sortCode: '12-34-56', accountNumber: '12345678',
+};
+
 const CATEGORIES: Category[] = [
   { id: 'type-expense', name: 'Expenses', type: 'expense', level: 'type', isSystem: true },
   { id: 'grp-food', name: 'Food', type: 'expense', level: 'sub', parentId: 'type-expense' },
@@ -222,5 +234,44 @@ describe('Account register — open, closed, and gone', () => {
     // Still the offer, not a half-open register — and the button is usable again.
     expect(reopenButton()).toBeEnabled();
     expect(screen.queryByRole('button', { name: /Search & filters/ })).not.toBeInTheDocument();
+  });
+
+  describe('the account number in the header', () => {
+    it('shows a card as XXXX XXXX XXXX 1234', async () => {
+      __setAppContextValue({ accounts: [CARD_ACCOUNT], transactions: [] });
+      renderRegister('/accounts/acc-card');
+
+      expect(await screen.findByText('XXXX XXXX XXXX 9012')).toBeInTheDocument();
+      // Never the bare four, which reads like a number that got cut off.
+      expect(screen.queryByText('9012')).not.toBeInTheDocument();
+    });
+
+    it('shows only the last 4 of a card row written before the rule existed', async () => {
+      __setAppContextValue({
+        accounts: [{ ...CARD_ACCOUNT, accountNumber: '4929123456789012' }],
+        transactions: []
+      });
+      renderRegister('/accounts/acc-card');
+
+      expect(await screen.findByText('XXXX XXXX XXXX 9012')).toBeInTheDocument();
+      expect(screen.queryByText('4929123456789012')).not.toBeInTheDocument();
+    });
+
+    it('leaves a bank account number alone — it is not a card number', async () => {
+      __setAppContextValue({ accounts: [DETAILED_ACCOUNT], transactions: [] });
+      renderRegister('/accounts/acc-open');
+
+      expect(await screen.findByText('12345678')).toBeInTheDocument();
+      expect(screen.getByText('12-34-56')).toBeInTheDocument();
+      expect(screen.queryByText(/^XXXX/)).not.toBeInTheDocument();
+    });
+
+    it('renders no number at all when the account has none', async () => {
+      __setAppContextValue({ accounts: [{ ...CARD_ACCOUNT, accountNumber: undefined }], transactions: [] });
+      renderRegister('/accounts/acc-card');
+
+      expect(await screen.findByRole('heading', { level: 1, name: 'Synthetic Card' })).toBeInTheDocument();
+      expect(screen.queryByText(/^XXXX/)).not.toBeInTheDocument();
+    });
   });
 });

--- a/src/services/api/accountService.ts
+++ b/src/services/api/accountService.ts
@@ -33,6 +33,7 @@ const ACCOUNT_CAMEL_TO_DB: Record<string, string> = {
   accountNumber: 'account_number',
   creditLimit: 'credit_limit',
   bankBalance: 'bank_balance',
+  bankBalanceDate: 'bank_balance_date',
   lastReconciledDate: 'last_reconciled_date',
   lowBalanceAlertEnabled: 'low_balance_alert_enabled',
   lowBalanceThreshold: 'low_balance_threshold',
@@ -58,6 +59,8 @@ function mapAccountFromDb(row: Record<string, unknown>): Record<string, unknown>
     ...row,
     type: row.type === 'checking' ? 'current' : row.type,
     bankBalance: row.bank_balance ?? null,
+    // A DATE arrives as 'YYYY-MM-DD' and stays that way — see Account.
+    bankBalanceDate: row.bank_balance_date != null ? String(row.bank_balance_date) : null,
     lastReconciledDate: row.last_reconciled_date ?? null,
     openingBalance: row.initial_balance ?? row.opening_balance,
     // Without this the fallback load path silently dropped the opening-balance

--- a/src/services/api/simpleAccountService.ts
+++ b/src/services/api/simpleAccountService.ts
@@ -41,6 +41,7 @@ type DbAccount = {
   updated_at?: Date;
   last_updated?: Date;
   bank_balance?: number | null;
+  bank_balance_date?: string | null;
   last_reconciled_date?: string | null;
   sort_code?: string | null;
   account_number?: string | null;
@@ -66,6 +67,8 @@ function transformAccountFromDb(row: Record<string, unknown>): Account {
     updatedAt: dbAccount.updated_at,
     lastUpdated: dbAccount.updated_at || dbAccount.created_at,
     bankBalance: dbAccount.bank_balance ?? null,
+    // A DATE arrives as 'YYYY-MM-DD' and stays that way — see Account.
+    bankBalanceDate: dbAccount.bank_balance_date ?? null,
     lastReconciledDate: dbAccount.last_reconciled_date ?? null,
     sortCode: dbAccount.sort_code ?? '',
     accountNumber: dbAccount.account_number ?? '',
@@ -80,6 +83,7 @@ function transformAccountFromDb(row: Record<string, unknown>): Account {
 const ACCOUNT_CAMEL_TO_DB: Record<string, string> = {
   openingBalance: 'initial_balance',
   bankBalance: 'bank_balance',
+  bankBalanceDate: 'bank_balance_date',
   lastReconciledDate: 'last_reconciled_date',
   isActive: 'is_active',
   sortCode: 'sort_code',

--- a/src/services/api/simpleAccountService.ts
+++ b/src/services/api/simpleAccountService.ts
@@ -6,6 +6,7 @@
 import { supabase } from './supabaseClient';
 import { storageAdapter, STORAGE_KEYS } from '../storageAdapter';
 import { userIdService } from '../userIdService';
+import { accountNumberForStorage, isCardAccountType } from '../../utils/accountNumberInput';
 import type { Account } from '../../types';
 import type { RealtimeChannel } from '@supabase/supabase-js';
 
@@ -178,7 +179,12 @@ class SimpleAccountServiceImpl {
         is_active: account.isActive !== false,
         institution: account.institution || null,
         sort_code: account.sortCode || null,
-        account_number: account.accountNumber || null,
+        // The last line before the insert: a credit account's number is a card
+        // number, and a full one written here would live on in every backup and
+        // export taken afterwards. Callers already trim; this is the guarantee
+        // that holds when a new one forgets to.
+        account_number:
+          accountNumberForStorage(account.accountNumber, isCardAccountType(account.type)) ?? null,
         opening_balance_date: account.openingBalanceDate instanceof Date
           ? account.openingBalanceDate.toISOString()
           : account.openingBalanceDate || null,

--- a/src/services/ofxImportService.test.ts
+++ b/src/services/ofxImportService.test.ts
@@ -266,6 +266,62 @@ NEWFILEUID:NONE
       expect(result.account.accountType).toBe('CREDITCARD');
     });
 
+    it('reads the closing balance from LEDGERBAL, never from AVAILBAL', () => {
+      // AVAILBAL on a card is the REMAINING CREDIT, so a £20 debt on a £3,300
+      // limit publishes 3280 there. Taken as the bank balance it would tell the
+      // user their card was thousands in credit.
+      const ofxWithAvailableBalance = validOFXContent.replace(
+        '</LEDGERBAL>',
+        `</LEDGERBAL>
+<AVAILBAL>
+<BALAMT>3280.00
+<DTASOF>20240131235959[0:GMT]
+</AVAILBAL>`
+      );
+
+      const result = ofxImportService.parseOFX(ofxWithAvailableBalance);
+      expect(result.balance).toEqual({ amount: 5000, dateAsOf: '2024-01-31' });
+    });
+
+    it('offers no balance when the file has only an available balance', () => {
+      const ofxWithoutLedger = validOFXContent.replace(
+        /<LEDGERBAL>[\s\S]*?<\/LEDGERBAL>/g,
+        `<AVAILBAL>
+<BALAMT>3280.00
+<DTASOF>20240131235959[0:GMT]
+</AVAILBAL>`
+      );
+
+      const result = ofxImportService.parseOFX(ofxWithoutLedger);
+      expect(result.balance).toBeUndefined();
+    });
+
+    it('survives an unreadable BALAMT instead of failing the whole import', () => {
+      // `new Decimal('12.34CR')` throws; one odd tag must not cost the user
+      // their transactions.
+      const ofxWithJunkBalance = validOFXContent.replace('<BALAMT>5000.00', '<BALAMT>5000.00CR');
+
+      const result = ofxImportService.parseOFX(ofxWithJunkBalance);
+      expect(result.balance).toBeUndefined();
+      expect(result.transactions).toHaveLength(3);
+    });
+
+    it('keeps a card statement\'s negative closing balance negative', () => {
+      // OFX signs the balance the same way it signs the transactions beside
+      // it, and this app stores a liability negative — so it passes straight
+      // through. Negating it here (as the TrueLayer card API needs) would turn
+      // a debt into an asset.
+      const creditCardOFX = validOFXContent
+        .replace('<BANKACCTFROM>', '<CCACCTFROM>')
+        .replace('</BANKACCTFROM>', '</CCACCTFROM>')
+        .replace('<ACCTTYPE>CHECKING', '<ACCTTYPE>CREDITCARD')
+        .replace('<BALAMT>5000.00', '<BALAMT>-1234.56');
+
+      const result = ofxImportService.parseOFX(creditCardOFX);
+      expect(result.account.isCreditCardStatement).toBe(true);
+      expect(result.balance?.amount).toBe(-1234.56);
+    });
+
     it('reads the account tags from the account section, not from anywhere in the file', () => {
       // A payee address block carrying its own <BANKID> must not become the
       // statement's sort code.
@@ -410,6 +466,30 @@ NEWFILEUID:NONE
       // Every one, not "none happened to be true" — a partly-cleared import is
       // the shape that hides a row nobody checked.
       expect(result.transactions.every(t => t.cleared === false)).toBe(true);
+    });
+
+    it('hands the statement\'s closing balance to the caller', async () => {
+      // Parsed and then dropped, this was the bug: the file states the very
+      // figure Reconciliation shows as "Bank Balance N/A".
+      const result = await ofxImportService.importTransactions(
+        validOFXContent,
+        mockAccounts,
+        []
+      );
+
+      expect(result.statementBalance).toEqual({ amount: 5000, dateAsOf: '2024-01-31' });
+    });
+
+    it('reports no closing balance when the file states none', async () => {
+      const ofxWithoutBalance = validOFXContent.replace(/<LEDGERBAL>[\s\S]*?<\/LEDGERBAL>/g, '');
+
+      const result = await ofxImportService.importTransactions(
+        ofxWithoutBalance,
+        mockAccounts,
+        []
+      );
+
+      expect(result.statementBalance).toBeUndefined();
     });
 
     it('imports transactions successfully', async () => {

--- a/src/services/ofxImportService.ts
+++ b/src/services/ofxImportService.ts
@@ -1,7 +1,8 @@
 import type { Transaction, Account, Category } from '../types';
 import { smartCategorizationService } from './smartCategorizationService';
-import { toDecimal, toNumber } from '../utils/decimal';
+import { parseMoneyInput, toDecimal, toNumber } from '../utils/decimal';
 import { findAccountByOfxIdentifiers } from '../utils/ofxAccountIdentifiers';
+import type { StatementBalance } from '../utils/statementBankBalance';
 
 interface OFXTransaction {
   type: string;
@@ -47,10 +48,7 @@ export interface AccountMatch {
 interface OFXParseResult {
   account: OFXAccount;
   transactions: OFXTransaction[];
-  balance?: {
-    amount: number;
-    dateAsOf: string;
-  };
+  balance?: StatementBalance;
   currency?: string;
   startDate?: string;
   endDate?: string;
@@ -202,21 +200,44 @@ export class OFXImportService {
   }
   
   /**
-   * Parse balance information
+   * The statement's CLOSING balance, read from <LEDGERBAL> and nowhere else.
+   *
+   * The distinction is not pedantry. A statement carries two balances, and the
+   * other one is a trap: <AVAILBAL> on a credit card is the REMAINING CREDIT,
+   * so a £20 debt on a £3,300 limit publishes an <AVAILBAL><BALAMT> of 3280 —
+   * the same trap cardNormalization documents for the bank feed. Reading the
+   * first <BALAMT> in the file happened to land on the ledger only because the
+   * OFX schema orders LEDGERBAL before AVAILBAL; now that this figure decides
+   * what the account reconciles against, it is read from the aggregate that
+   * defines it. A file with no closed <LEDGERBAL> has no closing balance to
+   * offer, and says so by returning nothing rather than by guessing.
+   *
+   * The amount goes through parseMoneyInput, which returns null for anything
+   * that is not a plain signed decimal. `new Decimal('12.34CR')` THROWS, and a
+   * throw here would fail the whole import over one unreadable tag.
    */
-  private parseBalance(content: string): { amount: number; dateAsOf: string } | undefined {
-    const balanceAmount = this.readTag(content, 'BALAMT');
-    
-    const balanceDate = this.readTag(content, 'DTASOF');
-    
-    if (balanceAmount && balanceDate) {
-      return {
-        amount: toNumber(toDecimal(balanceAmount)),
-        dateAsOf: this.parseOFXDate(balanceDate)
-      };
+  private parseBalance(content: string): StatementBalance | undefined {
+    const ledgerBlock = this.extractBlock(content, 'LEDGERBAL');
+    if (!ledgerBlock) {
+      return undefined;
     }
-    
-    return undefined;
+
+    const balanceAmount = this.readTag(ledgerBlock, 'BALAMT');
+    const balanceDate = this.readTag(ledgerBlock, 'DTASOF');
+
+    if (!balanceAmount || !balanceDate) {
+      return undefined;
+    }
+
+    const amount = parseMoneyInput(balanceAmount);
+    if (amount === null) {
+      return undefined;
+    }
+
+    return {
+      amount,
+      dateAsOf: this.parseOFXDate(balanceDate)
+    };
   }
   
   /**
@@ -404,6 +425,22 @@ export class OFXImportService {
      * account itself, because then the file did not choose it.
      */
     matchConfidence: AccountMatchConfidence | null;
+    /**
+     * What the bank says the account was worth at the end of the statement —
+     * the figure Reconciliation calls Bank Balance. Undefined when the file
+     * carries no <LEDGERBAL>.
+     *
+     * The sign is the file's own, untouched, and that is deliberate. OFX signs
+     * BALAMT in the same frame as the TRNAMTs beside it: on a card statement a
+     * purchase is a negative TRNAMT, so a card with money owing closes on a
+     * negative ledger balance — which is exactly how this app stores a
+     * liability. TrueLayer's /cards surface is the opposite (`current` is the
+     * amount owed, positive) and cardNormalization negates it for that reason;
+     * applying that negation here would turn a correctly-signed debt into an
+     * asset. Whichever way a file signs its balance, it signs its transactions
+     * the same way, and this importer already stores those verbatim.
+     */
+    statementBalance?: StatementBalance;
     duplicates: number;
     newTransactions: number;
   }> {
@@ -493,6 +530,7 @@ export class OFXImportService {
       matchedAccount,
       ofxAccount: parseResult.account,
       matchConfidence,
+      statementBalance: parseResult.balance,
       duplicates,
       newTransactions: transactions.length
     };

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -52,6 +52,18 @@ export interface Account {
   creditLimit?: number;
   subtype?: string;
   bankBalance?: number | null;
+  /**
+   * The day `bankBalance` is true for — a calendar day, 'YYYY-MM-DD'.
+   *
+   * A string rather than a Date on purpose. The column is a Postgres DATE: a
+   * day with no time and no zone. Wrapping it in a Date invents a midnight,
+   * and a midnight has to belong to some zone — which is how a statement dated
+   * the 31st comes to be displayed as the 30th west of Greenwich. Kept as the
+   * day itself, storage, comparison and display are all exact, and "is this
+   * statement older than what we already hold?" is a string comparison that
+   * cannot drift.
+   */
+  bankBalanceDate?: string | null;
   lastReconciledDate?: Date | null;
   lowBalanceThreshold?: number;
   lowBalanceAlertEnabled?: boolean;

--- a/src/utils/accountNumberInput.test.ts
+++ b/src/utils/accountNumberInput.test.ts
@@ -2,8 +2,11 @@ import { describe, expect, it } from 'vitest';
 import {
   BANK_ACCOUNT_NUMBER_LENGTH,
   CARD_LAST_FOUR_LENGTH,
+  accountNumberForStorage,
+  formatCardNumberForDisplay,
   formatSortCode,
   hasMoreThanLastFour,
+  isCardAccountType,
   keepLastFour,
   nextAccountNumberValue
 } from './accountNumberInput';
@@ -59,5 +62,79 @@ describe('keepLastFour', () => {
   it('leaves a value that is already short enough alone', () => {
     expect(keepLastFour('9012')).toBe('9012');
     expect(keepLastFour('12')).toBe('12');
+  });
+});
+
+describe('isCardAccountType', () => {
+  it('is true for a credit card and nothing else', () => {
+    expect(isCardAccountType('credit')).toBe(true);
+    expect(isCardAccountType('current')).toBe(false);
+    // The database's own spelling of 'current' — still a bank account.
+    expect(isCardAccountType('checking')).toBe(false);
+    expect(isCardAccountType('savings')).toBe(false);
+    expect(isCardAccountType('loan')).toBe(false);
+    expect(isCardAccountType(undefined)).toBe(false);
+  });
+});
+
+describe('accountNumberForStorage', () => {
+  it('stores only the last 4 of a card, whatever it was handed', () => {
+    expect(accountNumberForStorage('4929123456789012', true)).toBe('9012');
+    expect(accountNumberForStorage('4929 1234 5678 9012', true)).toBe('9012');
+    expect(accountNumberForStorage('4929-1234-5678-9012', true)).toBe('9012');
+  });
+
+  it('cannot be made to store more than 4 digits of a card', () => {
+    // Every length a field could hold on its way to a 19-digit Maestro number.
+    const pan = '4929123456789012345';
+    for (let length = 1; length <= pan.length; length += 1) {
+      const stored = accountNumberForStorage(pan.slice(0, length), true) ?? '';
+      expect(stored.length).toBeLessThanOrEqual(CARD_LAST_FOUR_LENGTH);
+    }
+  });
+
+  it('leaves a bank account number whole — 8 digits IS the number', () => {
+    expect(accountNumberForStorage('12345678', false)).toBe('12345678');
+    expect(accountNumberForStorage('12345678', false)).toHaveLength(BANK_ACCOUNT_NUMBER_LENGTH);
+  });
+
+  it('gives back undefined when there is nothing to store', () => {
+    expect(accountNumberForStorage('', true)).toBeUndefined();
+    expect(accountNumberForStorage('', false)).toBeUndefined();
+    expect(accountNumberForStorage(undefined, true)).toBeUndefined();
+    expect(accountNumberForStorage(undefined, false)).toBeUndefined();
+    expect(accountNumberForStorage('   ', false)).toBeUndefined();
+    // A card field holding punctuation alone has no digits worth keeping.
+    expect(accountNumberForStorage('**** ****', true)).toBeUndefined();
+  });
+
+  it('keeps a short card entry as typed rather than padding it out', () => {
+    expect(accountNumberForStorage('12', true)).toBe('12');
+  });
+});
+
+describe('formatCardNumberForDisplay', () => {
+  it('shows a stored last 4 as the card mask', () => {
+    expect(formatCardNumberForDisplay('9012')).toBe('XXXX XXXX XXXX 9012');
+  });
+
+  it('reads a legacy value that carries its own mask characters', () => {
+    expect(formatCardNumberForDisplay('****3456')).toBe('XXXX XXXX XXXX 3456');
+  });
+
+  it('shows only the last 4 of a row written before the rule existed', () => {
+    expect(formatCardNumberForDisplay('4929123456789012')).toBe('XXXX XXXX XXXX 9012');
+  });
+
+  it('gives the caller nothing to render when there is no number', () => {
+    expect(formatCardNumberForDisplay('')).toBe('');
+    expect(formatCardNumberForDisplay(undefined)).toBe('');
+    // Mask characters with no digits behind them are not a number either.
+    expect(formatCardNumberForDisplay('****')).toBe('');
+  });
+
+  it('does not invent digits for a value shorter than four', () => {
+    expect(formatCardNumberForDisplay('12')).toBe('12');
+    expect(formatCardNumberForDisplay('7')).toBe('7');
   });
 });

--- a/src/utils/accountNumberInput.ts
+++ b/src/utils/accountNumberInput.ts
@@ -9,7 +9,16 @@
  * only: that is what the bank feed publishes as its mask, and what
  * findCardMaskMatch (components/banking/LinkBankAccountsModal) compares against
  * to link a card to its feed. A card has no sort code at all.
+ *
+ * For a card, "last 4 only" is not advice — it is enforced. Whatever the field
+ * holds, and whatever an imported statement happens to quote, every save runs
+ * through accountNumberForStorage and writes four digits at most. Anything
+ * stored is stored in plain text and reaches the user's backups, their JSON
+ * export and their audit history, so a full card number must never get that
+ * far, however it arrived.
  */
+
+import type { Account } from '../types';
 
 /** A UK bank account number is exactly 8 digits. */
 export const BANK_ACCOUNT_NUMBER_LENGTH = 8;
@@ -21,6 +30,14 @@ export const CARD_LAST_FOUR_LENGTH = 4;
 export const CARD_NUMBER_LABEL = 'Card Number — last 4 digits only';
 
 export const digitsOnly = (value: string): string => value.replace(/\D/g, '');
+
+/**
+ * Whether an account's number is a CARD number rather than a bank one — the
+ * one place that question is answered, so a save and a display can never
+ * disagree about which rule applies to a given account.
+ */
+export const isCardAccountType = (type: Account['type'] | undefined): boolean =>
+  type === 'credit';
 
 /** Format a typed sort code as XX-XX-XX while it is being entered. */
 export const formatSortCode = (value: string): string => {
@@ -36,8 +53,8 @@ export const formatSortCode = (value: string): string => {
  * A bank account number is capped at its real length. A card's is deliberately
  * NOT capped: capping (or a maxLength attribute) truncates a pasted 16-digit
  * number to its FIRST four, which is silently wrong and, worse, the wrong four.
- * Whatever was entered is kept, and the form offers the trim explicitly — see
- * hasMoreThanLastFour and keepLastFour.
+ * The whole entry is kept while it is being typed so the LAST four survive to
+ * the save, where accountNumberForStorage drops the rest.
  */
 export const nextAccountNumberValue = (rawInput: string, isCard: boolean): string => {
   const digits = digitsOnly(rawInput);
@@ -51,3 +68,35 @@ export const hasMoreThanLastFour = (value: string): boolean =>
 /** The last 4 digits — the only part of a card number worth storing. */
 export const keepLastFour = (value: string): string =>
   digitsOnly(value).slice(-CARD_LAST_FOUR_LENGTH);
+
+/**
+ * The account number a save is allowed to write.
+ *
+ * This is the boundary the input deliberately does not enforce (see
+ * nextAccountNumberValue). Every path that persists an account number goes
+ * through here, so a full card number cannot be stored by typing it, pasting
+ * it, or importing a file that quotes it — the source does not matter, only
+ * the account type does. A field left empty comes back as undefined so it
+ * clears the column rather than storing a blank string.
+ */
+export const accountNumberForStorage = (
+  value: string | undefined,
+  isCard: boolean
+): string | undefined => {
+  const stored = isCard ? keepLastFour(value ?? '') : (value ?? '').trim();
+  return stored === '' ? undefined : stored;
+};
+
+/**
+ * A stored card number as it is shown back: XXXX XXXX XXXX 1234.
+ *
+ * The X's stand for digits nobody has, which is the point — they say "this is
+ * a card, and these four are all we hold". So a value carrying fewer than four
+ * digits is shown as those digits alone: padding it into a full-looking card
+ * number would claim we hold a 16-digit number when we do not. Nothing to show
+ * comes back empty, for the caller to render no element at all.
+ */
+export const formatCardNumberForDisplay = (value: string | undefined): string => {
+  const lastFour = keepLastFour(value ?? '');
+  return lastFour.length < CARD_LAST_FOUR_LENGTH ? lastFour : `XXXX XXXX XXXX ${lastFour}`;
+};

--- a/src/utils/statementBankBalance.test.ts
+++ b/src/utils/statementBankBalance.test.ts
@@ -1,0 +1,206 @@
+import { describe, it, expect } from 'vitest';
+import {
+  formatStatementDay,
+  isIsoDay,
+  planStatementBankBalance,
+  todayIsoDay,
+  type BankBalanceRecord,
+  type StatementBalance
+} from './statementBankBalance';
+
+const CONFIRMED = { destinationConfirmed: true } as const;
+const UNCONFIRMED = { destinationConfirmed: false } as const;
+
+const statement = (amount: number, dateAsOf: string): StatementBalance => ({ amount, dateAsOf });
+
+const account = (overrides: Partial<BankBalanceRecord> = {}): BankBalanceRecord => ({
+  bankBalance: null,
+  bankBalanceDate: null,
+  ...overrides
+});
+
+describe('planStatementBankBalance', () => {
+  it('sets the bank balance from the statement, dated by the statement', () => {
+    const outcome = planStatementBankBalance(statement(1234.56, '2026-03-31'), account(), CONFIRMED);
+
+    expect(outcome).toEqual({
+      kind: 'set',
+      updates: { bankBalance: 1234.56, bankBalanceDate: '2026-03-31' },
+      amount: 1234.56,
+      dateAsOf: '2026-03-31'
+    });
+  });
+
+  it('writes bankBalance and its date and NOTHING else', () => {
+    const outcome = planStatementBankBalance(statement(500, '2026-03-31'), account(), CONFIRMED);
+
+    // The whole safety argument: `balance` is the ledger the imported
+    // transactions have already moved. Writing the statement total on top of
+    // it would count the same money twice.
+    if (outcome.kind !== 'set') throw new Error('expected a balance to be set');
+    expect(Object.keys(outcome.updates).sort()).toEqual(['bankBalance', 'bankBalanceDate']);
+    expect(Object.keys(outcome.updates)).not.toContain('balance');
+  });
+
+  it('replaces an older recorded balance', () => {
+    const outcome = planStatementBankBalance(
+      statement(900, '2026-03-31'),
+      account({ bankBalance: 100, bankBalanceDate: '2026-02-28' }),
+      CONFIRMED
+    );
+
+    expect(outcome.kind).toBe('set');
+  });
+
+  it('leaves a NEWER recorded balance alone, and says which one it kept', () => {
+    // Catching up on paperwork: March's statement opened after November's.
+    const outcome = planStatementBankBalance(
+      statement(900, '2026-03-31'),
+      account({ bankBalance: 4200, bankBalanceDate: '2026-11-30' }),
+      CONFIRMED
+    );
+
+    expect(outcome).toEqual({ kind: 'stale', recordedDate: '2026-11-30', recordedBalance: 4200 });
+  });
+
+  it('re-importing the same statement settles on the same figure', () => {
+    // Equal days write, so the result does not depend on the order files were
+    // opened in.
+    const outcome = planStatementBankBalance(
+      statement(900, '2026-03-31'),
+      account({ bankBalance: 900, bankBalanceDate: '2026-03-31' }),
+      CONFIRMED
+    );
+
+    expect(outcome.kind).toBe('set');
+  });
+
+  it('writes over a balance whose date was never recorded', () => {
+    // Pre-dates the bank_balance_date column: undatable, so unprotectable.
+    const outcome = planStatementBankBalance(
+      statement(900, '2026-03-31'),
+      account({ bankBalance: 100, bankBalanceDate: null }),
+      CONFIRMED
+    );
+
+    expect(outcome.kind).toBe('set');
+  });
+
+  it('does nothing when nobody confirmed which account the file belongs to', () => {
+    const outcome = planStatementBankBalance(statement(900, '2026-03-31'), account(), UNCONFIRMED);
+
+    expect(outcome).toEqual({ kind: 'none' });
+  });
+
+  it('does nothing when the file states no closing balance', () => {
+    expect(planStatementBankBalance(undefined, account(), CONFIRMED)).toEqual({ kind: 'none' });
+  });
+
+  it('does nothing when there is no account to write to', () => {
+    expect(planStatementBankBalance(statement(900, '2026-03-31'), null, CONFIRMED))
+      .toEqual({ kind: 'none' });
+  });
+
+  it('refuses a date it cannot compare', () => {
+    // A day it cannot order is a day it cannot protect a newer figure from.
+    expect(planStatementBankBalance(statement(900, '31/03/2026'), account(), CONFIRMED))
+      .toEqual({ kind: 'none' });
+    expect(planStatementBankBalance(statement(900, ''), account(), CONFIRMED))
+      .toEqual({ kind: 'none' });
+  });
+
+  it('refuses an amount that is not a number', () => {
+    expect(planStatementBankBalance(statement(Number.NaN, '2026-03-31'), account(), CONFIRMED))
+      .toEqual({ kind: 'none' });
+  });
+
+  describe('credit cards', () => {
+    it('keeps a card debt a debt — the statement sign is passed through, not negated', () => {
+      // OFX signs a statement's balance in the same frame as the transactions
+      // beside it: a card purchase is a negative TRNAMT, so a card with money
+      // owing closes on a NEGATIVE ledger balance, which is how this app
+      // stores a liability. TrueLayer's card API is the opposite and
+      // cardNormalization negates it there; doing that here would turn a
+      // £1,234.56 debt into £1,234.56 of assets.
+      const outcome = planStatementBankBalance(
+        statement(-1234.56, '2026-03-31'),
+        account({ bankBalance: null, bankBalanceDate: null }),
+        CONFIRMED
+      );
+
+      if (outcome.kind !== 'set') throw new Error('expected a balance to be set');
+      expect(outcome.updates.bankBalance).toBe(-1234.56);
+      expect(outcome.amount).toBeLessThan(0);
+    });
+
+    it('keeps a card that is in credit in credit', () => {
+      // An overpaid or refunded card closes positive. Forcing the sign
+      // negative "because cards are liabilities" would invent a debt.
+      const outcome = planStatementBankBalance(statement(45.5, '2026-03-31'), account(), CONFIRMED);
+
+      if (outcome.kind !== 'set') throw new Error('expected a balance to be set');
+      expect(outcome.updates.bankBalance).toBe(45.5);
+    });
+  });
+
+  describe('money never goes through a float', () => {
+    it('rounds to the penny the account column holds', () => {
+      const outcome = planStatementBankBalance(statement(0.1 + 0.2, '2026-03-31'), account(), CONFIRMED);
+
+      if (outcome.kind !== 'set') throw new Error('expected a balance to be set');
+      // 0.1 + 0.2 is 0.30000000000000004 as a double.
+      expect(outcome.updates.bankBalance).toBe(0.3);
+    });
+
+    it('keeps a large statement balance exact to the penny', () => {
+      const outcome = planStatementBankBalance(
+        statement(99999999.99, '2026-03-31'),
+        account(),
+        CONFIRMED
+      );
+
+      if (outcome.kind !== 'set') throw new Error('expected a balance to be set');
+      expect(outcome.updates.bankBalance).toBe(99999999.99);
+    });
+  });
+});
+
+describe('isIsoDay', () => {
+  it('accepts a calendar day and rejects anything else', () => {
+    expect(isIsoDay('2026-03-31')).toBe(true);
+    expect(isIsoDay('2026-3-31')).toBe(false);
+    expect(isIsoDay('2026-03-31T00:00:00Z')).toBe(false);
+    expect(isIsoDay(null)).toBe(false);
+    expect(isIsoDay(undefined)).toBe(false);
+  });
+});
+
+describe('todayIsoDay', () => {
+  it('is the day where the user is, not the UTC day', () => {
+    // 09:00 in Auckland (UTC+13) is still the previous day in UTC. Typing a
+    // bank balance in the morning must not date it yesterday.
+    const morningInAuckland = new Date(2026, 2, 31, 9, 0, 0);
+
+    expect(todayIsoDay(morningInAuckland)).toBe('2026-03-31');
+    expect(isIsoDay(todayIsoDay(morningInAuckland))).toBe(true);
+  });
+
+  it('pads single-digit months and days', () => {
+    expect(todayIsoDay(new Date(2026, 0, 5, 12, 0, 0))).toBe('2026-01-05');
+  });
+});
+
+describe('formatStatementDay', () => {
+  it('reads the day off the string rather than through a timezone', () => {
+    // `new Date('2026-03-31')` is midnight UTC and renders as the 30th west of
+    // Greenwich. A statement date shown a day out is one the user cannot find.
+    expect(formatStatementDay('2026-03-31')).toBe('31 Mar 2026');
+    expect(formatStatementDay('2026-01-01')).toBe('1 Jan 2026');
+    expect(formatStatementDay('2026-12-25')).toBe('25 Dec 2026');
+  });
+
+  it('hands back anything it cannot read rather than inventing a date', () => {
+    expect(formatStatementDay('not a date')).toBe('not a date');
+    expect(formatStatementDay('2026-13-01')).toBe('2026-13-01');
+  });
+});

--- a/src/utils/statementBankBalance.ts
+++ b/src/utils/statementBankBalance.ts
@@ -1,0 +1,159 @@
+/**
+ * Whether an imported statement's closing balance may be written onto an
+ * account's Bank Balance, and what exactly gets written.
+ *
+ * WHY THIS EXISTS
+ * ---------------
+ * Bank Balance is the number Reconciliation compares the cleared ledger
+ * against; without it, Difference reads N/A and finalising a reconciliation
+ * proves nothing. Only the bank feed ever set it, so anyone importing a
+ * statement by hand had to type the closing balance in themselves — while the
+ * file they had just imported stated it. A statement import should populate it
+ * the same way a feed does.
+ *
+ * WHAT IT WILL NEVER WRITE
+ * ------------------------
+ * `balance`. That is the ledger: initial_balance plus every transaction, moved
+ * only by the atomic transaction RPCs. The statement's transactions have
+ * already moved it by the time this runs, so writing the statement's total on
+ * top would count the same money twice. bank_balance is a REFERENCE the app
+ * compares against and never adds to — which is also why a wrong one is safe:
+ * it shows up as a visible Difference, not as money that changed.
+ *
+ * THE SIGN IS THE FILE'S OWN
+ * --------------------------
+ * Nothing here normalises a sign. OFX signs a statement's balance in the same
+ * frame as the transactions printed beside it, so a card with money owing
+ * closes on a negative ledger balance — the same way this app stores a
+ * liability. (TrueLayer's card API is the opposite and cardNormalization
+ * negates it there; doing that here would turn a correctly-signed debt into an
+ * asset.) See the note on OFXImportService.importTransactions.
+ */
+
+import type { Account } from '../types';
+import { toDecimal, toNumber } from './decimal';
+
+/** A statement's closing balance and the day it is true for. */
+export interface StatementBalance {
+  amount: number;
+  /** Calendar day, 'YYYY-MM-DD'. */
+  dateAsOf: string;
+}
+
+/** The account fields this module reads — and the only ones it ever writes. */
+export type BankBalanceRecord = Pick<Account, 'bankBalance' | 'bankBalanceDate'>;
+
+export type StatementBankBalanceOutcome =
+  /** Write these fields onto the account. */
+  | { kind: 'set'; updates: BankBalanceRecord; amount: number; dateAsOf: string }
+  /** Left alone: what the account already holds is more recent than this file. */
+  | { kind: 'stale'; recordedDate: string; recordedBalance: number }
+  /** Nothing to do, and nothing worth saying. */
+  | { kind: 'none' };
+
+const ISO_DAY = /^\d{4}-\d{2}-\d{2}$/;
+
+/** A calendar day in the one form that compares and sorts correctly. */
+export const isIsoDay = (value: string | null | undefined): value is string =>
+  typeof value === 'string' && ISO_DAY.test(value);
+
+const MONTH_NAMES = [
+  'Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun',
+  'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'
+] as const;
+
+/**
+ * '2026-03-31' → '31 Mar 2026'.
+ *
+ * Read straight off the string rather than through a Date, because a Date has
+ * to put the day in some timezone: `new Date('2026-03-31')` is midnight UTC,
+ * and west of Greenwich that renders as the 30th. A statement date shown a day
+ * out is a statement the user cannot find.
+ */
+export const formatStatementDay = (isoDay: string): string => {
+  if (!isIsoDay(isoDay)) return isoDay;
+  const [year, month, day] = isoDay.split('-');
+  const monthName = MONTH_NAMES[Number(month) - 1];
+  if (!monthName) return isoDay;
+  return `${Number(day)} ${monthName} ${year}`;
+};
+
+/**
+ * Today, where the user is, as a calendar day.
+ *
+ * Local parts rather than toISOString().slice(0, 10): the latter is the UTC
+ * day, which is yesterday for anyone far enough east in the morning — and this
+ * day is compared against statement dates to decide which figure is newer.
+ */
+export const todayIsoDay = (now: Date = new Date()): string => {
+  const month = String(now.getMonth() + 1).padStart(2, '0');
+  const day = String(now.getDate()).padStart(2, '0');
+  return `${now.getFullYear()}-${month}-${day}`;
+};
+
+export interface StatementBankBalanceOptions {
+  /**
+   * True when a person has settled which account this statement belongs to —
+   * they picked it, or the account's own recorded sort code / account number
+   * is the one in the file.
+   *
+   * False for the unattended batch importers, where a file is matched by a
+   * digit or two in an account's name and nobody sees the result before it is
+   * written. Those runs still import the transactions (individually visible,
+   * individually removable); they just do not get to redefine what the account
+   * reconciles against on the strength of a guess.
+   */
+  destinationConfirmed: boolean;
+}
+
+/**
+ * What this statement should do to the account's Bank Balance.
+ *
+ * The staleness rule is the point of the recorded date: last March's statement
+ * must not overwrite a figure that is already newer, or reopening
+ * Reconciliation would show a difference of several months' spending and
+ * finalising would be worse than useless. Equal days are allowed to write —
+ * re-importing the same statement then settles on the same figure instead of
+ * depending on the order files were opened in.
+ *
+ * A recorded balance with no recorded date cannot be compared, so it is
+ * written over: the alternative is refusing forever on accounts whose balance
+ * predates the date column.
+ */
+export const planStatementBankBalance = (
+  statementBalance: StatementBalance | undefined,
+  account: BankBalanceRecord | null | undefined,
+  options: StatementBankBalanceOptions
+): StatementBankBalanceOutcome => {
+  if (!account || !options.destinationConfirmed) {
+    return { kind: 'none' };
+  }
+  if (
+    !statementBalance ||
+    !Number.isFinite(statementBalance.amount) ||
+    !isIsoDay(statementBalance.dateAsOf)
+  ) {
+    return { kind: 'none' };
+  }
+
+  const recordedDate = account.bankBalanceDate;
+  const recordedBalance = account.bankBalance;
+  if (
+    recordedBalance != null &&
+    isIsoDay(recordedDate) &&
+    recordedDate > statementBalance.dateAsOf
+  ) {
+    return { kind: 'stale', recordedDate, recordedBalance };
+  }
+
+  // Money never touches a float: the parsed amount is re-rounded through
+  // Decimal so what reaches the column is exactly what will be compared.
+  const amount = toNumber(toDecimal(statementBalance.amount));
+
+  return {
+    kind: 'set',
+    updates: { bankBalance: amount, bankBalanceDate: statementBalance.dateAsOf },
+    amount,
+    dateAsOf: statementBalance.dateAsOf
+  };
+};

--- a/supabase/migrations/20260807200000_bank_balance_as_of_date.sql
+++ b/supabase/migrations/20260807200000_bank_balance_as_of_date.sql
@@ -1,0 +1,101 @@
+-- ============================================================================
+-- Record WHEN a bank balance was true, so an old statement cannot overwrite a
+-- newer figure
+-- ============================================================================
+-- IMPORTANT: apply with `npm run db:migrate` (see supabase/migrations/README.md
+-- rule 1 — never the SQL editor). One nullable column is added and nothing else
+-- changes: no data is written, no function is redefined, no grant is altered.
+--
+-- ── WHY ─────────────────────────────────────────────────────────────────────
+-- accounts.bank_balance is the reconciliation reference — what the bank says
+-- the account holds, which the app compares its own cleared ledger against.
+-- Until now only the bank feed ever set it, so anyone importing a statement by
+-- hand met "Bank Balance N/A" and "Difference N/A", and finalising a
+-- reconciliation proved nothing. A manually imported statement states its own
+-- closing balance, and is about to start populating this field.
+--
+-- That immediately raises the question this column answers: statements are
+-- imported out of order. Someone catching up on a year of paperwork will open
+-- March before they open November. The March figure is not wrong — it is just
+-- old — and writing it over November's would show a reconciliation difference
+-- of eight months' spending, which is a worse lie than no figure at all.
+--
+-- bank_balance alone cannot tell the two apart, because it carries no date.
+-- updated_at cannot stand in for one: it moves whenever ANY column on the row
+-- changes — a rename, a threshold, an archive cutoff — so it dates the row,
+-- not the balance. Hence a column that dates only the balance.
+--
+-- A DATE, not a timestamp, because that is what the fact is: a statement's
+-- closing balance belongs to a calendar day, not to an instant in some
+-- timezone. Comparing two of them is then exact in every zone.
+--
+-- ── WHAT DOES NOT CHANGE ────────────────────────────────────────────────────
+-- Every existing row. The column is nullable and is NOT backfilled, because
+-- there is no honest value to backfill it with: nothing recorded when the
+-- balances already in the table were reported, and inventing a date (from
+-- updated_at, say) would be a guess that the staleness check would then treat
+-- as a fact and use to REFUSE a genuinely newer statement. NULL means exactly
+-- what it should mean here — "we do not know when this figure was true" — and
+-- the importer treats an undatable balance as safe to replace. The first bank
+-- sync or statement import after this migration dates it properly.
+--
+-- No constraint ties the two columns together. A CHECK requiring the date
+-- whenever bank_balance is present would reject every legacy row on its next
+-- unrelated update, and there is nothing to gain: the readers already handle
+-- a missing date, and a date with no balance is harmless.
+--
+-- ── BALANCE REASONING ───────────────────────────────────────────────────────
+-- Balance-neutral, and structurally so. This adds a column that describes
+-- bank_balance and touches no amount at all. Nothing here reads or writes
+-- accounts.balance, accounts.initial_balance or transactions.amount, so the
+-- ledger invariant (balance = initial_balance + Σ transactions) is untouched
+-- and every reported figure is identical before and after.
+--
+-- The reason that matters beyond this file: bank_balance is a REFERENCE the
+-- app compares against and never adds to. That is the whole safety argument
+-- for letting a file write it — the worst a wrong bank_balance can do is show
+-- a visible Difference on the reconciliation screen, whereas a wrong `balance`
+-- would silently change what the user believes they have. Writers of this
+-- column must set bank_balance (and now bank_balance_date) and NOTHING else;
+-- see api/banking/sync-accounts.ts, which has kept that rule since audit
+-- finding #12.
+-- ============================================================================
+
+BEGIN;
+
+ALTER TABLE public.accounts
+  ADD COLUMN IF NOT EXISTS bank_balance_date DATE;
+
+COMMENT ON COLUMN public.accounts.bank_balance_date IS
+  'The calendar day accounts.bank_balance is true for: a bank feed''s sync day, or an imported statement''s closing date (OFX <LEDGERBAL><DTASOF>). NULL means the date was never recorded, which importers treat as safe to replace. Not updated_at — that moves on any change to the row.';
+
+COMMIT;
+
+-- ==== VERIFICATION — read this output after applying ====
+
+-- 1. The column exists, is a DATE, and is nullable.
+-- Expected: one row — bank_balance_date | date | YES | (no default)
+SELECT column_name, data_type, is_nullable, column_default
+  FROM information_schema.columns
+ WHERE table_schema = 'public'
+   AND table_name = 'accounts'
+   AND column_name = 'bank_balance_date';
+
+-- 2. Nothing was backfilled: every account that had a bank balance still has
+--    exactly the same one, and none of them has acquired a date.
+-- Expected: dated_balances = 0, and with_bank_balance unchanged from before.
+SELECT count(*) FILTER (WHERE bank_balance IS NOT NULL) AS with_bank_balance,
+       count(*) FILTER (WHERE bank_balance_date IS NOT NULL) AS dated_balances
+  FROM public.accounts;
+
+-- 3. The ledger is untouched — no account's balance drifted from
+--    initial_balance + Σ its transactions.
+-- Expected: 0 rows.
+SELECT a.id, a.name, a.balance, a.initial_balance, COALESCE(t.total, 0) AS txn_total
+  FROM public.accounts a
+  LEFT JOIN (
+    SELECT account_id, sum(amount) AS total
+      FROM public.transactions
+     GROUP BY account_id
+  ) t ON t.account_id = a.id
+ WHERE a.balance IS DISTINCT FROM (COALESCE(a.initial_balance, 0) + COALESCE(t.total, 0));


### PR DESCRIPTION
Two commits. One started as a formatting request and turned into a security fix; the other makes Finalise Reconciliation mean something.

> **Migration `20260807200000` is already applied to production** (verified: column present, `date`, nullable, 0 rows backfilled against 3 existing bank balances). It had to go first — the new code writes `bankBalanceDate`, and until the column existed PostgREST would have rejected the whole account update.

## Only the last four digits, wherever the number came from

Storing a card number was a matter of the user cooperating. The field deliberately does not cap what you type — capping a pasted number keeps the **first** four, which is both wrong and the wrong four — and the form then *offered* to trim it. Ignore the offer and the whole number was saved, into `accounts.account_number`, and from there into backups, JSON exports and audit history.

The trim moves from an offer to a rule, applied at the save boundary rather than the keystroke: type all of it, only the last four persist. Enforced at both account forms, the account service's insert, and the bank-linking payload. The guidance panel now states the outcome instead of presenting a button that implied a choice.

Where a card's number is shown it now reads as one. Bank accounts are untouched — an eight-digit account number is a different thing.

### A full card number was leaving the banking API

Found while tracing those paths. TrueLayer's **accounts** surface can return `account_type: "credit_card"`, and for such an account `account_number.number` is the card number.

- `discover-accounts` sent it to the client, which rendered it, prefilled it into the add-account form and posted it back
- `sync-accounts` wrote it straight to `accounts.account_number` — **no client involved at all**

Both now give a card what the **cards** surface already gave one: no account number, no sort code, a last-four mask. That convention was already in the file with a comment explaining it; it simply was not applied to cards arriving by the other route.

Re-adoption on reconnect is unaffected — `findAdoptableAccountId` already returns null without a sort code, and no card has one.

## A statement you import brings its balance with it

Importing a statement by hand left `Bank Balance` and `Difference` showing N/A, so Finalise Reconciliation proved nothing: it had no figure to check the ledger against. The closing balance was in the file all along — the OFX parser read it, put it on the parse result, and every importer ignored it.

It is now written to the account the file was mapped to, exactly as a feed would.

**Only `bank_balance` is set, never `balance`.** The app's own balance is derived from its transactions; writing both double-counts. The plan object is typed so `balance` is unrepresentable, and tests assert the key set at runtime as well.

### Statements arrive out of order

Someone catching up on a year of paperwork opens March before November. March is not wrong, only old — and writing it over November's figure would show a reconciliation difference of eight months' spending, which is worse than no figure at all.

`bank_balance` could not tell the two apart because it carried no date, and `updated_at` cannot stand in: it moves whenever anything on the row changes. Hence the new nullable `bank_balance_date`.

**Not backfilled**, deliberately: nothing recorded when the existing balances were true, and a guessed date would be treated as fact and used to refuse a genuinely newer statement. NULL means "we don't know", which importers treat as safe to replace. The feed and the hand-typed balance now date what they write.

### Reading the right balance, and leaving its sign alone

`parseBalance` took the **first** `BALAMT` in the file, landing on the ledger balance only by schema ordering. On a card `AVAILBAL` is *remaining credit*, not what is owed — so a card statement could have set Bank Balance to available headroom. It now reads only from within `LEDGERBAL`.

A card statement's sign passes through untouched. OFX signs the closing balance the same way it signs the transactions beside it, so a card in debt closes negative — which is how this app stores a liability. The feed's card normalisation exists to flip TrueLayer's *opposite* convention; applying it here would invert a correct figure.

### What this does not cover

QIF carries no statement balance. CSV's balance column is a per-row running total, which is only a closing figure if the file happens to be complete and sorted. **Neither is invented.** Where a file carries no balance, the import says so rather than leaving someone wondering why the figure never appeared.

Also corrected the import panel's claim that it imports cleared transactions, which stopped being true when imports started arriving unreconciled.

## Verification

- Lint clean, strict typecheck clean
- **4,121 tests passing**; coverage 69.37% statements / 79.49% branches (floors 63 / 55)
- `api/` sits outside every tsconfig `include`, so those handlers were type-checked directly rather than by `tsc -b`
- Migration applied and verified in production before this branch was pushed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
