### PR TITLE
fix(import+register): a statement imported twice, a day out of order, and a backup for people with no cloud

### DIFF
--- a/src/components/EditTransactionModal.deleteConfirm.test.tsx
+++ b/src/components/EditTransactionModal.deleteConfirm.test.tsx
@@ -1,0 +1,186 @@
+/**
+ * EditTransactionModal — what the delete confirmation admits to.
+ *
+ * `transactions_linked_transfer_id_fkey` is ON DELETE SET NULL and
+ * `delete_transaction_atomic` removes one row and reverses one balance. So
+ * deleting half of a linked transfer does not remove the movement: the other
+ * leg stays in the other account, still moving that account's balance, with its
+ * link silently nulled. The confirmation used to say only "This action cannot
+ * be undone", which is true and beside the point — the part that cannot be
+ * undone happens in an account the user is not looking at.
+ *
+ * These tests hold the confirmation to naming that consequence, and to staying
+ * quiet when there is no consequence to name.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, within } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import EditTransactionModal from './EditTransactionModal';
+import type { Account, Transaction } from '../types';
+
+const mocks = vi.hoisted(() => ({
+  navigate: vi.fn(),
+  app: {
+    accounts: [] as Account[],
+    transactions: [] as Transaction[],
+    categories: [
+      { id: 'type-expense', name: 'Expenses', type: 'expense', level: 'type' },
+      { id: 'sub-bills', name: 'Bills', type: 'expense', level: 'sub', parentId: 'type-expense' },
+      { id: 'det-tax', name: 'Council Tax', type: 'expense', level: 'detail', parentId: 'sub-bills' },
+    ],
+    updateTransaction: vi.fn(async () => {}),
+    deleteTransaction: vi.fn(),
+    getTransactionSplits: vi.fn(async () => []),
+    setTransactionSplits: vi.fn(async () => ({ isSplit: false, splitCount: 0, amount: 0 })),
+    linkTransferPair: vi.fn(async () => ({ a: {}, b: {} })),
+    createTransferCounterpart: vi.fn(async () => ({ source: {}, counterpart: {} })),
+  },
+}));
+
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual<typeof import('react-router-dom')>('react-router-dom');
+  return {
+    ...actual,
+    useNavigate: () => mocks.navigate,
+    useLocation: () => ({ pathname: '/accounts/acc-a', search: '', hash: '', state: null, key: 'test' }),
+  };
+});
+
+vi.mock('../contexts/AppContextSupabase', () => ({ useApp: () => mocks.app }));
+
+vi.mock('../contexts/ToastContext', () => ({
+  useToast: () => ({
+    showToast: vi.fn(),
+    showSuccess: vi.fn(),
+    showError: vi.fn(),
+    showWarning: vi.fn(),
+    showInfo: vi.fn(),
+    dismissToast: vi.fn(),
+  }),
+}));
+
+vi.mock('../hooks/useTransactionNotifications', () => ({
+  useTransactionNotifications: () => ({ addTransaction: vi.fn(async () => {}) }),
+}));
+
+vi.mock('../hooks/usePayeeMemory', () => ({
+  usePayeeMemory: () => ({ propagateCategory: vi.fn(async () => {}) }),
+}));
+
+vi.mock('./common/Modal', () => ({
+  Modal: ({ isOpen, children, title }: { isOpen: boolean; children: ReactNode; title: string }) =>
+    isOpen ? <div role="dialog" aria-label={title}>{children}</div> : null,
+  ModalBody: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  ModalFooter: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+}));
+
+vi.mock('./CategorySelector', () => ({ default: () => <div data-testid="category-selector" /> }));
+vi.mock('./TagSelector', () => ({ default: () => <div data-testid="tag-selector" /> }));
+vi.mock('./MarkdownEditor', () => ({ default: () => <div data-testid="markdown-editor" /> }));
+vi.mock('./DocumentManager', () => ({ default: () => <div data-testid="document-manager" /> }));
+vi.mock('./CategoryCreationModal', () => ({ default: () => null }));
+
+const account = (id: string, name: string): Account => ({
+  id,
+  name,
+  type: 'current',
+  balance: 1000,
+  currency: 'GBP',
+  lastUpdated: new Date('2027-02-01'),
+  isActive: true,
+});
+
+const OUT_LEG: Transaction = {
+  id: 'txn-out',
+  date: new Date('2027-02-10'),
+  description: 'Transfer to savings',
+  amount: -500,
+  type: 'transfer',
+  category: 'tofrom-b',
+  accountId: 'acc-a',
+  transferAccountId: 'acc-b',
+  linkedTransferId: 'txn-in',
+  cleared: false,
+};
+
+const IN_LEG: Transaction = {
+  id: 'txn-in',
+  date: new Date('2027-02-10'),
+  description: 'Transfer from current',
+  amount: 500,
+  type: 'transfer',
+  category: 'tofrom-a',
+  accountId: 'acc-b',
+  transferAccountId: 'acc-a',
+  linkedTransferId: 'txn-out',
+  cleared: false,
+};
+
+const EXPENSE: Transaction = {
+  id: 'txn-shop',
+  date: new Date('2027-02-10'),
+  description: 'Groceries',
+  amount: -42.5,
+  type: 'expense',
+  category: 'det-tax',
+  accountId: 'acc-a',
+  cleared: false,
+};
+
+/** Open the editor on `transaction` and press Delete to raise the confirmation. */
+const openDeleteConfirm = (transaction: Transaction): void => {
+  render(<EditTransactionModal isOpen onClose={vi.fn()} transaction={transaction} />);
+  fireEvent.click(screen.getByRole('button', { name: 'Delete' }));
+  expect(screen.getByText('Delete Transaction?')).toBeInTheDocument();
+};
+
+describe('EditTransactionModal — delete confirmation', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.app.accounts = [account('acc-a', 'Current Account'), account('acc-b', 'Savings')];
+    mocks.app.transactions = [OUT_LEG, IN_LEG, EXPENSE];
+  });
+
+  it('names the account the other half is left in, and what happens to it', () => {
+    openDeleteConfirm(OUT_LEG);
+
+    expect(
+      screen.getByText(/Deleting it will leave the other half in Savings/)
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/still counted in that account's balance but no longer linked to anything/)
+    ).toBeInTheDocument();
+  });
+
+  it('warns from the incoming leg too, naming the account facing it', () => {
+    openDeleteConfirm(IN_LEG);
+
+    expect(
+      screen.getByText(/Deleting it will leave the other half in Current Account/)
+    ).toBeInTheDocument();
+  });
+
+  it('says nothing extra for an ordinary transaction', () => {
+    openDeleteConfirm(EXPENSE);
+
+    // The generic line still stands; nothing is invented on top of it.
+    expect(
+      screen.getByText('Are you sure you want to delete this transaction? This action cannot be undone.')
+    ).toBeInTheDocument();
+    expect(screen.queryByText(/one half of a transfer/)).not.toBeInTheDocument();
+  });
+
+  it('does not offer to delete the other side for the user', () => {
+    // Cascading into another account unasked is worse than stranding a row, so
+    // this is consent and nothing more: it names the consequence and offers the
+    // same two choices it always did.
+    openDeleteConfirm(OUT_LEG);
+
+    const panel = screen.getByText('Delete Transaction?').closest('div');
+    if (!panel) throw new Error('the confirmation panel is not on screen');
+    expect(within(panel).getAllByRole('button').map(button => button.textContent))
+      .toEqual(['Cancel', 'Delete']);
+    expect(mocks.app.deleteTransaction).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/EditTransactionModal.tsx
+++ b/src/components/EditTransactionModal.tsx
@@ -16,7 +16,7 @@ import {
 import CategoryCreationModal from './CategoryCreationModal';
 import TransferMatchDialog from './TransferMatchDialog';
 import { findTransferCandidates, transferCategoryFor, type TransferCandidate } from '../utils/transferMatch';
-import { resolveTransferOtherSide } from '../utils/transferOtherSide';
+import { describeDeleteStranding, resolveTransferOtherSide } from '../utils/transferOtherSide';
 import { buildTransactionRegisterPath } from '../utils/transactionDeepLink';
 import AccountSelector from './common/AccountSelector';
 import DatePicker from './common/DatePicker';
@@ -679,6 +679,13 @@ export default function EditTransactionModal({ isOpen, onClose, transaction, def
     };
   }, [transaction, accounts, hideJumpToAccountId]);
 
+  // What deleting this row would leave behind in the other account. Null for an
+  // ordinary transaction, and then the confirmation says nothing extra.
+  const deleteStranding = useMemo(
+    () => describeDeleteStranding(transaction, transactions, accounts),
+    [transaction, transactions, accounts]
+  );
+
   const handleDelete = () => {
     if (!transaction) return;
     deleteTransaction(transaction.id);
@@ -1287,6 +1294,13 @@ export default function EditTransactionModal({ isOpen, onClose, transaction, def
               <p className="text-sm sm:text-base text-gray-600 dark:text-gray-400 mb-4">
                 Are you sure you want to delete this transaction? This action cannot be undone.
               </p>
+              {/* Only for a linked transfer, where the damage happens in an
+                  account the user is not looking at. */}
+              {deleteStranding && (
+                <p className="text-sm sm:text-base text-yellow-800 dark:text-yellow-300 bg-yellow-50 dark:bg-yellow-900/20 border border-yellow-200 dark:border-yellow-800 rounded-lg p-3 mb-4">
+                  {deleteStranding.message}
+                </p>
+              )}
               <div className="flex gap-3 justify-end">
                 <button
                   onClick={() => setShowDeleteConfirm(false)}

--- a/src/components/OFXImportModal.test.tsx
+++ b/src/components/OFXImportModal.test.tsx
@@ -22,9 +22,31 @@ const createMockImportResult = (
   matchedAccount: null,
   ofxAccount: OFX_BANK_ACCOUNT,
   matchConfidence: null,
+  statementRows: [],
+  duplicateMatches: { certain: [], possible: [] },
   duplicates: 0,
   newTransactions: 0,
   ...overrides,
+});
+
+/** N file rows, matching a mocked draft list — only the count is read here. */
+const mockStatementRows = (count: number): ImportTransactionsResult['statementRows'] =>
+  Array.from({ length: count }, (_, index) => ({
+    date: new Date('2024-01-01'),
+    amount: 100,
+    description: 'Test',
+    fitId: `fit-${index}`,
+  }));
+
+/** The file row behind a drafted transaction, as the service reports it. */
+const statementRow = (
+  transaction: ImportTransactionsResult['transactions'][number],
+  fitId: string
+): ImportTransactionsResult['statementRows'][number] => ({
+  date: transaction.date,
+  amount: transaction.amount,
+  description: transaction.description,
+  fitId,
 });
 
 const sampleTransaction: ImportTransactionsResult['transactions'][number] = {
@@ -177,6 +199,13 @@ describe('OFXImportModal', () => {
     fireEvent.click(screen.getByText(label));
   };
 
+  /** A preview summary tile, found by its label rather than by its number. */
+  const summaryTile = (label: string): HTMLElement => {
+    const tile = screen.getByText(label).parentElement;
+    if (!tile) throw new Error(`no summary tile labelled "${label}"`);
+    return tile;
+  };
+
   const CURRENT_ACCOUNT = 'Current Account (checking)';
   const SAVINGS_ACCOUNT = 'Savings Account (savings)';
 
@@ -206,7 +235,7 @@ describe('OFXImportModal', () => {
       
       expect(screen.getByText('About OFX Files')).toBeInTheDocument();
       expect(screen.getByText(/OFX.*Open Financial Exchange.*files contain standardized financial data/)).toBeInTheDocument();
-      expect(screen.getByText(/Automatic duplicate detection using transaction IDs/)).toBeInTheDocument();
+      expect(screen.getByText(/Finds transactions you already have/)).toBeInTheDocument();
       expect(screen.getByText(/Smart account matching based on account numbers/)).toBeInTheDocument();
       expect(screen.getByTestId('info-icon')).toBeInTheDocument();
     });
@@ -310,12 +339,10 @@ describe('OFXImportModal', () => {
 
   describe('File Parsing', () => {
     it('shows file info after successful parsing', async () => {
+      const second = { ...sampleTransaction, description: 'Test 2', amount: 200 };
       const mockParseResult = createMockImportResult({
-        transactions: [
-          sampleTransaction,
-          { ...sampleTransaction, description: 'Test 2', amount: 200 }
-        ],
-        duplicates: 1,
+        transactions: [sampleTransaction, second],
+        statementRows: [statementRow(sampleTransaction, 'fit-1'), statementRow(second, 'fit-2')],
         newTransactions: 2
       });
       
@@ -331,9 +358,11 @@ describe('OFXImportModal', () => {
       await waitFor(() => {
         expect(screen.getByText('test.ofx')).toBeInTheDocument();
         expect(screen.getByText('2 transactions found')).toBeInTheDocument();
-        expect(screen.getByText('2')).toBeInTheDocument(); // Total transactions
-        expect(screen.getByText('1')).toBeInTheDocument(); // Duplicates found
       });
+      // The tiles are read by their label, not by hunting for a loose "2":
+      // both of them say 2 here, and which is which is the whole point.
+      expect(summaryTile('In this file')).toHaveTextContent('2');
+      expect(summaryTile('Will be imported')).toHaveTextContent('2');
     });
 
     it('says a guessed match is a guess', async () => {
@@ -522,18 +551,18 @@ describe('OFXImportModal', () => {
       fireEvent.change(fileInput, { target: { files: [file] } });
       
       await waitFor(() => {
-        expect(screen.getByText('Skip duplicate transactions')).toBeInTheDocument();
+        expect(screen.getByText('Skip transactions you already have')).toBeInTheDocument();
       });
     });
 
     it('shows skip duplicates option checked by default', () => {
-      const checkbox = screen.getByRole('checkbox', { name: /Skip duplicate transactions/ });
+      const checkbox = screen.getByRole('checkbox', { name: /Skip transactions you already have/ });
       expect(checkbox).toBeChecked();
-      expect(screen.getByText('Uses unique transaction IDs to prevent importing the same transaction twice')).toBeInTheDocument();
+      expect(screen.getByText(/otherwise on the date and the exact amount in this\s+account/)).toBeInTheDocument();
     });
 
     it('allows toggling skip duplicates option', () => {
-      const checkbox = screen.getByRole('checkbox', { name: /Skip duplicate transactions/ });
+      const checkbox = screen.getByRole('checkbox', { name: /Skip transactions you already have/ });
       
       fireEvent.click(checkbox);
       expect(checkbox).not.toBeChecked();
@@ -554,6 +583,8 @@ describe('OFXImportModal', () => {
     beforeEach(async () => {
       const mockParseResult = {
         transactions: [{ id: 'trans1', amount: 100, description: 'Test' }],
+        statementRows: mockStatementRows(1),
+        duplicateMatches: { certain: [], possible: [] },
         duplicates: 0,
         matchedAccount: { id: 'acc1', name: 'Current Account' }
       };
@@ -581,6 +612,8 @@ describe('OFXImportModal', () => {
     it('processes import successfully', async () => {
       const mockImportResult = {
         transactions: [{ id: 'trans1', amount: 100, description: 'Test' }],
+        statementRows: mockStatementRows(1),
+        duplicateMatches: { certain: [], possible: [] },
         newTransactions: 1,
         duplicates: 0,
         matchedAccount: { id: 'acc1', name: 'Current Account' }
@@ -603,6 +636,8 @@ describe('OFXImportModal', () => {
     it('shows duplicate count in success message', async () => {
       const mockImportResult = {
         transactions: [{ id: 'trans1', amount: 100, description: 'Test' }],
+        statementRows: mockStatementRows(1),
+        duplicateMatches: { certain: [], possible: [] },
         newTransactions: 1,
         duplicates: 3,
         matchedAccount: { id: 'acc1', name: 'Current Account' }
@@ -615,7 +650,7 @@ describe('OFXImportModal', () => {
       
       await waitFor(() => {
         expect(screen.getByText('Import Successful!')).toBeInTheDocument();
-        expect(screen.getByText('Skipped 3 duplicate transactions')).toBeInTheDocument();
+        expect(screen.getByText(/Left out\s+3\s+transactions this account already had/)).toBeInTheDocument();
       });
     });
 
@@ -661,6 +696,8 @@ describe('OFXImportModal', () => {
     it('disables import button when no account selected and no match', async () => {
       const mockParseResult = {
         transactions: [{ id: 'trans1', amount: 100, description: 'Test' }],
+        statementRows: mockStatementRows(1),
+        duplicateMatches: { certain: [], possible: [] },
         duplicates: 0,
         matchedAccount: null,
       };
@@ -683,6 +720,8 @@ describe('OFXImportModal', () => {
     it('enables import button when account is manually selected', async () => {
       const mockParseResult = {
         transactions: [{ id: 'trans1', amount: 100, description: 'Test' }],
+        statementRows: mockStatementRows(1),
+        duplicateMatches: { certain: [], possible: [] },
         duplicates: 0,
         matchedAccount: null,
       };
@@ -717,6 +756,8 @@ describe('OFXImportModal', () => {
     it('resets modal when cancel button clicked', async () => {
       const mockParseResult = {
         transactions: [{ id: 'trans1', amount: 100, description: 'Test' }],
+        statementRows: mockStatementRows(1),
+        duplicateMatches: { certain: [], possible: [] },
         duplicates: 0,
         matchedAccount: null
       };
@@ -744,12 +785,16 @@ describe('OFXImportModal', () => {
     it('shows import another file button after successful import', async () => {
       const mockParseResult = {
         transactions: [{ id: 'trans1', amount: 100, description: 'Test' }],
+        statementRows: mockStatementRows(1),
+        duplicateMatches: { certain: [], possible: [] },
         duplicates: 0,
         matchedAccount: { id: 'acc1', name: 'Current Account' }
       };
       
       const mockImportResult = {
         transactions: [{ id: 'trans1', amount: 100, description: 'Test' }],
+        statementRows: mockStatementRows(1),
+        duplicateMatches: { certain: [], possible: [] },
         newTransactions: 1,
         duplicates: 0,
         matchedAccount: { id: 'acc1', name: 'Current Account' }
@@ -786,12 +831,16 @@ describe('OFXImportModal', () => {
       const onClose = vi.fn();
       const mockParseResult = {
         transactions: [{ id: 'trans1', amount: 100, description: 'Test' }],
+        statementRows: mockStatementRows(1),
+        duplicateMatches: { certain: [], possible: [] },
         duplicates: 0,
         matchedAccount: { id: 'acc1', name: 'Current Account' }
       };
       
       const mockImportResult = {
         transactions: [{ id: 'trans1', amount: 100, description: 'Test' }],
+        statementRows: mockStatementRows(1),
+        duplicateMatches: { certain: [], possible: [] },
         newTransactions: 1,
         duplicates: 0,
         matchedAccount: { id: 'acc1', name: 'Current Account' }
@@ -879,6 +928,8 @@ describe('OFXImportModal', () => {
     it('handles zero transactions found', async () => {
       const mockParseResult = {
         transactions: [],
+        statementRows: mockStatementRows(0),
+        duplicateMatches: { certain: [], possible: [] },
         duplicates: 0,
         matchedAccount: null,
       };
@@ -901,12 +952,16 @@ describe('OFXImportModal', () => {
     it('handles import with selectedAccountId when no matchedAccount', async () => {
       const mockParseResult = {
         transactions: [{ id: 'trans1', amount: 100, description: 'Test' }],
+        statementRows: mockStatementRows(1),
+        duplicateMatches: { certain: [], possible: [] },
         duplicates: 0,
         matchedAccount: null,
       };
       
       const mockImportResult = {
         transactions: [{ id: 'trans1', amount: 100, description: 'Test' }],
+        statementRows: mockStatementRows(1),
+        duplicateMatches: { certain: [], possible: [] },
         newTransactions: 1,
         duplicates: 0,
         matchedAccount: null // No matched account in result
@@ -1262,6 +1317,96 @@ describe('OFXImportModal', () => {
 
       expect(screen.getByText('Imported 1 transactions to Filed Account')).toBeInTheDocument();
       expect(screen.getByText(/Bank Balance couldn't be updated/)).toBeInTheDocument();
+    });
+  });
+  /**
+   * The preview's duplicate review. `mockTransactions` gives account acc1 one
+   * £100 transaction on 2024-01-01 described "Test Transaction"; the statement
+   * below carries the same money on the same day under the bank's own wording,
+   * which is exactly the shape that used to import a second copy in silence.
+   */
+  describe('Duplicate review', () => {
+    const sameMoneyDifferentWords: ImportTransactionsResult['statementRows'][number] = {
+      date: new Date('2024-01-01'),
+      amount: 100,
+      description: 'Immediate Faster Payment (Online) to B EXAMPLE 01-JAN-2024',
+      fitId: 'fit-1'
+    };
+
+    const openPreview = async (): Promise<void> => {
+      vi.mocked(ofxImportService.importTransactions).mockResolvedValueOnce(
+        createMockImportResult({
+          transactions: [sampleTransaction],
+          statementRows: [sameMoneyDifferentWords],
+          matchedAccount: mockAccounts[0],
+          newTransactions: 1
+        })
+      );
+
+      render(<OFXImportModal {...defaultProps} />);
+      fireEvent.change(document.getElementById('ofx-upload')!, {
+        target: { files: [new File(['OFX content'], 'test.ofx', { type: 'application/ofx' })] }
+      });
+
+      await waitFor(() => {
+        expect(screen.getByText('test.ofx')).toBeInTheDocument();
+      });
+    };
+
+    it('lists the row against the transaction it matches, and leaves it out by default', async () => {
+      await openPreview();
+
+      expect(screen.getByText('1 transaction looks like one you already have')).toBeInTheDocument();
+      // Both sides shown: the user is being asked to judge a pair, and the
+      // descriptions are the only part that differs.
+      expect(screen.getByText(/Immediate Faster Payment \(Online\) to B EXAMPLE/)).toBeInTheDocument();
+      expect(screen.getByText(/Already here as “Test Transaction” on 01\/01\/2024/)).toBeInTheDocument();
+
+      expect(screen.getByRole('checkbox', { name: /Immediate Faster Payment/ })).not.toBeChecked();
+      expect(summaryTile('In this file')).toHaveTextContent('1');
+      expect(summaryTile('Will be imported')).toHaveTextContent('0');
+    });
+
+    it('imports it after the user says it is a separate payment', async () => {
+      await openPreview();
+
+      fireEvent.click(screen.getByRole('checkbox', { name: /Immediate Faster Payment/ }));
+      expect(summaryTile('Will be imported')).toHaveTextContent('1');
+
+      vi.mocked(ofxImportService.importTransactions).mockResolvedValueOnce(
+        createMockImportResult({
+          transactions: [sampleTransaction],
+          statementRows: [sameMoneyDifferentWords],
+          matchedAccount: mockAccounts[0],
+          newTransactions: 1
+        })
+      );
+      fireEvent.click(screen.getByTestId('loading-button'));
+
+      await waitFor(() => {
+        expect(screen.getByText('Import Successful!')).toBeInTheDocument();
+      });
+      expect(ofxImportService.importTransactions).toHaveBeenLastCalledWith(
+        expect.anything(),
+        expect.anything(),
+        expect.anything(),
+        expect.objectContaining({ importAnywayFitIds: ['fit-1'] })
+      );
+    });
+
+    it('forgets the decision when the destination account changes', async () => {
+      await openPreview();
+      fireEvent.click(screen.getByRole('checkbox', { name: /Immediate Faster Payment/ }));
+
+      // Savings holds none of this, so there is nothing left to review — and
+      // the overrule must not survive into an account it was never about.
+      chooseAccount(SAVINGS_ACCOUNT);
+      expect(screen.queryByText(/looks like one you already have/)).not.toBeInTheDocument();
+      expect(summaryTile('Will be imported')).toHaveTextContent('1');
+
+      chooseAccount(CURRENT_ACCOUNT);
+      expect(screen.getByRole('checkbox', { name: /Immediate Faster Payment/ })).not.toBeChecked();
+      expect(summaryTile('Will be imported')).toHaveTextContent('0');
     });
   });
 });

--- a/src/components/OFXImportModal.tsx
+++ b/src/components/OFXImportModal.tsx
@@ -7,6 +7,12 @@ import {
 } from '../utils/ofxAccountIdentifiers';
 import { keepLastFour } from '../utils/accountNumberInput';
 import { formatStatementDay, planStatementBankBalance } from '../utils/statementBankBalance';
+import {
+  findStatementDuplicates,
+  type IncomingStatementRow,
+  type StatementDuplicateMatch
+} from '../utils/statementDuplicates';
+import { formatShortDate } from '../utils/dateFormatter';
 // The account's OWN currency, not the user's display currency: a statement
 // states a figure in the currency the account is held in, and the reconciliation
 // screen compares it in that currency too.
@@ -36,11 +42,19 @@ interface OFXImportModalProps {
 
 type ImportTransactionsResult = Awaited<ReturnType<typeof ofxImportService.importTransactions>>;
 
+/** One "you may already have this" pairing, with both sides ready to render. */
+interface DuplicateReviewRow {
+  incoming: IncomingStatementRow;
+  match: StatementDuplicateMatch;
+}
+
 type ImportOutcome =
   | {
       success: true;
       imported: number;
       duplicates: number;
+      /** How many of those the user looked at and chose to leave out. */
+      reviewedOut: number;
       account: Account | null;
       /** Set when the import also filled in the account's blank bank details. */
       savedDetails?: { accountName: string; summary: string };
@@ -74,6 +88,12 @@ export default function OFXImportModal({ isOpen, onClose }: OFXImportModalProps)
   const [accountIsUserChoice, setAccountIsUserChoice] = useState(false);
   /** null = follow the default above; true/false = the user said so. */
   const [saveDetailsOverride, setSaveDetailsOverride] = useState<boolean | null>(null);
+  /**
+   * FITIDs of rows the duplicate check flagged and the user overruled. Cleared
+   * whenever the file or the destination account changes, because a decision
+   * made about one account's register says nothing about another's.
+   */
+  const [importAnywayFitIds, setImportAnywayFitIds] = useState<ReadonlySet<string>>(() => new Set());
 
   const parseFile = useCallback(async (targetFile: File) => {
     setIsProcessing(true);
@@ -168,10 +188,50 @@ export default function OFXImportModal({ isOpen, onClose }: OFXImportModalProps)
     return `This file doesn't state a closing balance, so ${selectedAccount.name}'s Bank Balance stays as it is and Reconciliation has nothing to check these transactions against. You can enter it there by hand.`;
   }, [bankBalancePlan, parseResult, selectedAccount]);
 
+  // Which of this file's rows the chosen account already holds. Recomputed
+  // here rather than taken from the parse, because the destination is the
+  // user's to change and the answer is different for every account.
+  const duplicatePlan = useMemo(() => {
+    if (!parseResult || !selectedAccountId) return null;
+    return findStatementDuplicates(parseResult.statementRows, transactions, selectedAccountId);
+  }, [parseResult, selectedAccountId, transactions]);
+
+  /** The bank's own id on both sides — proof, so these are simply counted. */
+  const alreadyImportedCount = duplicatePlan?.certain.length ?? 0;
+
+  /** Same day, same pence, different words. Evidence, so these get reviewed. */
+  const reviewRows = useMemo((): DuplicateReviewRow[] => {
+    if (!parseResult || !duplicatePlan) return [];
+    return duplicatePlan.possible.map(match => ({
+      incoming: parseResult.statementRows[match.incomingIndex],
+      match
+    }));
+  }, [duplicatePlan, parseResult]);
+
+  const keptOut = reviewRows.filter(
+    row => row.match.fitId === null || !importAnywayFitIds.has(row.match.fitId)
+  ).length;
+
+  const willImport = parseResult
+    ? parseResult.statementRows.length -
+      (skipDuplicates ? alreadyImportedCount + keptOut : 0)
+    : 0;
+
+  const toggleImportAnyway = useCallback((fitId: string | null) => {
+    if (fitId === null) return;
+    setImportAnywayFitIds(previous => {
+      const next = new Set(previous);
+      if (next.has(fitId)) next.delete(fitId);
+      else next.add(fitId);
+      return next;
+    });
+  }, []);
+
   const handleAccountChange = useCallback((accountId: string) => {
     setSelectedAccountId(accountId);
     setAccountIsUserChoice(true);
     setSaveDetailsOverride(null);
+    setImportAnywayFitIds(new Set());
   }, []);
 
   // Handle file upload
@@ -190,6 +250,7 @@ export default function OFXImportModal({ isOpen, onClose }: OFXImportModalProps)
     setImportResult(null);
     setAccountIsUserChoice(false);
     setSaveDetailsOverride(null);
+    setImportAnywayFitIds(new Set());
 
     // Parse the file
     parseFile(uploadedFile);
@@ -206,6 +267,7 @@ export default function OFXImportModal({ isOpen, onClose }: OFXImportModalProps)
       setImportResult(null);
       setAccountIsUserChoice(false);
       setSaveDetailsOverride(null);
+      setImportAnywayFitIds(new Set());
       parseFile(droppedFile);
     }
   }, [parseFile]);
@@ -226,7 +288,9 @@ export default function OFXImportModal({ isOpen, onClose }: OFXImportModalProps)
           accountId: selectedAccountId || undefined,
           skipDuplicates,
           categories,
-          autoCategorize: true
+          autoCategorize: true,
+          // Only the rows on the review list above, and only the ones ticked.
+          importAnywayFitIds: [...importAnywayFitIds]
         }
       );
       
@@ -293,6 +357,9 @@ export default function OFXImportModal({ isOpen, onClose }: OFXImportModalProps)
         success: true,
         imported: result.newTransactions,
         duplicates: result.duplicates,
+        reviewedOut: result.duplicateMatches.possible.filter(
+          match => match.fitId === null || !importAnywayFitIds.has(match.fitId)
+        ).length,
         account,
         savedDetails,
         savedDetailsError,
@@ -308,7 +375,7 @@ export default function OFXImportModal({ isOpen, onClose }: OFXImportModalProps)
     } finally {
       setIsProcessing(false);
     }
-  }, [accounts, addTransaction, file, parseResult, saveDetails, selectedAccountId, skipDuplicates, transactions, categories, updateAccount]);
+  }, [accounts, addTransaction, file, importAnywayFitIds, parseResult, saveDetails, selectedAccountId, skipDuplicates, transactions, categories, updateAccount]);
 
   // Reset modal
   const resetModal = useCallback(() => {
@@ -318,6 +385,7 @@ export default function OFXImportModal({ isOpen, onClose }: OFXImportModalProps)
     setSelectedAccountId('');
     setAccountIsUserChoice(false);
     setSaveDetailsOverride(null);
+    setImportAnywayFitIds(new Set());
   }, []);
   
   return (
@@ -366,7 +434,11 @@ export default function OFXImportModal({ isOpen, onClose }: OFXImportModalProps)
                     OFX (Open Financial Exchange) files contain standardized financial data exported from banks and credit card companies.
                   </p>
                   <ul className="text-blue-700 dark:text-blue-300 space-y-1">
-                    <li>• Automatic duplicate detection using transaction IDs</li>
+                    {/* The old bullet promised detection "using transaction IDs",
+                        and that is exactly all it did — so every row that arrived
+                        from a bank feed, from Money or by hand, none of which
+                        carry one, was imported a second time. */}
+                    <li>• Finds transactions you already have, by the bank&apos;s own id or by date and amount</li>
                     <li>• Smart account matching based on account numbers</li>
                     <li>• Preserves transaction reference numbers</li>
                     <li>• Sets the account&apos;s Bank Balance from the statement&apos;s closing balance</li>
@@ -389,7 +461,7 @@ export default function OFXImportModal({ isOpen, onClose }: OFXImportModalProps)
               <div className="flex-1">
                 <p className="font-medium text-gray-900 dark:text-white">{file?.name}</p>
                 <p className="text-sm text-gray-600 dark:text-gray-400">
-                  {parseResult.transactions.length} transactions found
+                  {parseResult.statementRows.length} transactions found
                 </p>
               </div>
             </div>
@@ -494,27 +566,90 @@ export default function OFXImportModal({ isOpen, onClose }: OFXImportModalProps)
                   className="rounded border-gray-300 text-primary focus:ring-primary"
                 />
                 <span className="text-sm font-medium text-gray-700 dark:text-gray-300">
-                  Skip duplicate transactions
+                  Skip transactions you already have
                 </span>
               </label>
               <p className="text-xs text-gray-500 dark:text-gray-400 ml-6 mt-1">
-                Uses unique transaction IDs to prevent importing the same transaction twice
+                Matches on the bank&apos;s own transaction id where both sides have
+                one, and otherwise on the date and the exact amount in this
+                account. Anything matched that way is listed below for you to
+                confirm before it is left out.
               </p>
             </div>
-            
+
+            {/* Already held — the bank's own id says so, so this is a count
+                rather than a list: there is nothing for anyone to decide. */}
+            {skipDuplicates && alreadyImportedCount > 0 && selectedAccount && (
+              <p className="text-sm text-gray-600 dark:text-gray-400">
+                {alreadyImportedCount === 1
+                  ? `1 transaction in this file was already imported into ${selectedAccount.name} (same bank transaction id), so it will not be added again.`
+                  : `${alreadyImportedCount} transactions in this file were already imported into ${selectedAccount.name} (same bank transaction id), so they will not be added again.`}
+              </p>
+            )}
+
+            {/* The review list. Nothing here is deleted and nothing is decided
+                without the user: these rows are simply left out unless ticked. */}
+            {skipDuplicates && reviewRows.length > 0 && selectedAccount && (
+              <fieldset className="border border-yellow-200 dark:border-yellow-800 bg-yellow-50 dark:bg-yellow-900/20 rounded-lg p-4">
+                <legend className="px-2 text-sm font-semibold text-yellow-900 dark:text-yellow-300">
+                  {reviewRows.length === 1
+                    ? '1 transaction looks like one you already have'
+                    : `${reviewRows.length} transactions look like ones you already have`}
+                </legend>
+                <p className="text-sm text-yellow-800 dark:text-yellow-200 mb-3">
+                  Each of these matches a transaction already in {selectedAccount.name}
+                  {' '}to the penny, on the same day. The wording differs because payees
+                  get renamed and older rows were shortened by whatever imported them, so
+                  the description is no guide. They will <strong>not</strong> be imported —
+                  tick any that are genuinely a second, separate payment.
+                </p>
+                <ul className="space-y-2">
+                  {reviewRows.map(({ incoming, match }) => (
+                    <li key={match.fitId ?? `${match.incomingIndex}`}>
+                      <label className="flex items-start gap-3 p-3 bg-white dark:bg-gray-800 border border-yellow-200 dark:border-yellow-800 rounded-lg cursor-pointer">
+                        <input
+                          type="checkbox"
+                          checked={match.fitId !== null && importAnywayFitIds.has(match.fitId)}
+                          onChange={() => toggleImportAnyway(match.fitId)}
+                          className="mt-1 rounded border-gray-300 text-primary focus:ring-primary"
+                        />
+                        <span className="flex-1 min-w-0 text-sm">
+                          <span className="block font-medium text-gray-900 dark:text-white">
+                            {formatShortDate(incoming.date instanceof Date ? incoming.date : new Date(String(incoming.date)))}
+                            {' · '}
+                            {incoming.description}
+                            {' · '}
+                            {formatCurrency(incoming.amount, selectedAccount.currency)}
+                          </span>
+                          <span className="block text-gray-600 dark:text-gray-400">
+                            Already here as &ldquo;{match.heldDescription}&rdquo; on{' '}
+                            {formatShortDate(match.heldDate)}
+                            {match.heldCleared ? ', reconciled' : ''}
+                          </span>
+                          <span className="block text-xs text-gray-500 dark:text-gray-400">
+                            Import anyway if this is a second, separate payment of the same amount.
+                          </span>
+                        </span>
+                      </label>
+                    </li>
+                  ))}
+                </ul>
+              </fieldset>
+            )}
+
             {/* Summary */}
             <div className="grid grid-cols-2 gap-4">
               <div className="text-center p-4 bg-gray-50 dark:bg-gray-700/50 rounded-lg">
                 <p className="text-2xl font-bold text-gray-900 dark:text-white">
-                  {parseResult.transactions.length}
+                  {parseResult.statementRows.length}
                 </p>
-                <p className="text-sm text-gray-600 dark:text-gray-400">Total Transactions</p>
+                <p className="text-sm text-gray-600 dark:text-gray-400">In this file</p>
               </div>
               <div className="text-center p-4 bg-gray-50 dark:bg-gray-700/50 rounded-lg">
                 <p className="text-2xl font-bold text-gray-900 dark:text-white">
-                  {parseResult.duplicates || 0}
+                  {willImport}
                 </p>
-                <p className="text-sm text-gray-600 dark:text-gray-400">Duplicates Found</p>
+                <p className="text-sm text-gray-600 dark:text-gray-400">Will be imported</p>
               </div>
             </div>
             
@@ -556,7 +691,12 @@ export default function OFXImportModal({ isOpen, onClose }: OFXImportModalProps)
                 
                 {importResult.duplicates > 0 && (
                   <p className="text-sm text-yellow-600 dark:text-yellow-400 mb-6">
-                    Skipped {importResult.duplicates} duplicate transactions
+                    Left out {importResult.duplicates}{' '}
+                    {importResult.duplicates === 1 ? 'transaction' : 'transactions'} this
+                    account already had, so the statement period is not recorded twice.
+                    {importResult.reviewedOut > 0 && (
+                      ` ${importResult.reviewedOut} of those matched on date and amount rather than on the bank's own id — you can add any of them by hand if the wording made you doubt the match.`
+                    )}
                   </p>
                 )}
 

--- a/src/components/RestoreBackupModal.tsx
+++ b/src/components/RestoreBackupModal.tsx
@@ -14,12 +14,19 @@ import {
   validateBackupBundle,
   wipeUserFinancialData,
   type BackupBundle,
-  type RestoreOutcome,
+  type DanglingReference,
   type RestoreProgress,
 } from '../services/backupService';
+import {
+  LOCAL_BACKUP_BINDINGS,
+  LocalRestoreRefusedError,
+  localFinancialDataIsEmpty,
+  restoreLocalBackupBundle,
+  wipeLocalFinancialData,
+} from '../services/localBackupService';
 
 /**
- * Restore a backup file into this login.
+ * Restore a backup file into this login, or into this browser.
  *
  * The shape of this dialog is dictated by one fact from the database side: a
  * restore can only go into an EMPTY login. That is not caution, it is what
@@ -28,11 +35,16 @@ import {
  * login with data in it must be erased first, and erasing is a separate
  * decision with its own confirmation. Nothing here ever wipes implicitly.
  *
- * The other thing shaping this file is that the restore is chunked, so it is
- * not one transaction. A failure halfway leaves the login partly populated.
+ * The other thing shaping this file is that the CLOUD restore is chunked, so it
+ * is not one transaction. A failure halfway leaves the login partly populated.
  * That is survivable — the login was empty, so nothing of the user's is at
  * risk — but it must be SAID, not smoothed over, or the user will go looking at
  * a half-filled app believing it is whole.
+ *
+ * A LOCAL restore is one IndexedDB transaction, so it cannot end up halfway and
+ * the warning is not shown for it. That is a real difference between the two
+ * engines rather than a wording choice, so the dialog states whichever is true
+ * instead of hedging with a sentence that covers both and describes neither.
  */
 
 interface Props {
@@ -73,8 +85,24 @@ const formatExportedAt = (iso: string): string => {
   return Number.isNaN(date.getTime()) ? iso : date.toLocaleString();
 };
 
+/**
+ * What a finished restore looks like, whichever engine did it.
+ *
+ * `notStoredLocally` is the one field the cloud never fills: a browser has no
+ * investments, goal contributions or repeating templates, so a cloud-taken file
+ * restored onto a device genuinely cannot keep some of what it holds. Saying so
+ * is the difference between a restore and a restore that quietly lost things.
+ */
+interface Outcome {
+  restored: { label: string; rows: number }[];
+  notStoredLocally: { label: string; rows: number; absence: string }[];
+  accountsRelinked: number;
+  transactionsRelinked: number;
+  danglingRefs: DanglingReference[];
+}
+
 export default function RestoreBackupModal({ isOpen, onClose }: Props): React.JSX.Element {
-  const { refreshAccountsAndTransactions, refreshCategories } = useApp();
+  const { refreshAccountsAndTransactions, refreshCategories, isUsingSupabase } = useApp();
 
   const [phase, setPhase] = useState<Phase>('pick');
   const [fileName, setFileName] = useState('');
@@ -83,16 +111,37 @@ export default function RestoreBackupModal({ isOpen, onClose }: Props): React.JS
   const [targetIsEmpty, setTargetIsEmpty] = useState<boolean | null>(null);
   const [wipeConfirmText, setWipeConfirmText] = useState('');
   const [progress, setProgress] = useState<RestoreProgress | null>(null);
-  const [outcome, setOutcome] = useState<RestoreOutcome | null>(null);
+  const [outcome, setOutcome] = useState<Outcome | null>(null);
   const [failure, setFailure] = useState<{ step: string; message: string; partiallyRestored: boolean } | null>(null);
 
   const databaseUserId = DataService.getUserIds().databaseId;
+  /**
+   * Which store this restore is aimed at. A signed-in session whose database id
+   * has not resolved yet is NOT local — restoring into browser storage there
+   * would put the file somewhere the app will never read it from again.
+   */
+  const isCloudRestore = Boolean(databaseUserId);
+  const cloudSessionPending = isUsingSupabase && !databaseUserId;
+  const targetName = isCloudRestore ? 'login' : 'device';
 
   const dateRange = useMemo(() => (bundle ? transactionDateRange(bundle) : null), [bundle]);
   const populated = useMemo(
     () => (bundle ? BACKUP_ENTITIES.filter((entity) => bundle.counts[entity] > 0) : []),
     [bundle]
   );
+
+  /**
+   * What a local restore of THIS file would have to leave behind — told before
+   * the user commits, not discovered afterwards.
+   */
+  const unstorable = useMemo(() => {
+    if (!bundle || isCloudRestore) return [];
+    return BACKUP_ENTITIES
+      .filter((entity) => bundle.counts[entity] > 0 && !LOCAL_BACKUP_BINDINGS[entity].stored)
+      .map((entity) => ({ label: LOCAL_BACKUP_BINDINGS[entity].label, rows: bundle.counts[entity] }));
+  }, [bundle, isCloudRestore]);
+  const unstorableRows = unstorable.reduce((total, entry) => total + entry.rows, 0);
+  const unstorableLabels = unstorable.map((entry) => entry.label.toLowerCase()).join(', ');
 
   const reset = useCallback(() => {
     setPhase('pick');
@@ -136,53 +185,63 @@ export default function RestoreBackupModal({ isOpen, onClose }: Props): React.JS
       return;
     }
 
-    if (!databaseUserId) {
+    if (cloudSessionPending) {
       setFileProblem('This session has no database identity yet, so a restore cannot be scoped to your login. Reload the page and try again.');
       return;
     }
 
     setBundle(validation.bundle);
     try {
-      setTargetIsEmpty(await userFinancialDataIsEmpty(databaseUserId));
+      setTargetIsEmpty(databaseUserId
+        ? await userFinancialDataIsEmpty(databaseUserId)
+        : await localFinancialDataIsEmpty());
       setPhase('ready');
     } catch (error) {
       restoreLogger.error('Preflight emptiness check failed', error);
-      setFileProblem(error instanceof Error ? error.message : 'Could not check whether this login is empty.');
+      setFileProblem(error instanceof Error ? error.message : `Could not check whether this ${targetName} is empty.`);
     }
-  }, [databaseUserId]);
+  }, [databaseUserId, cloudSessionPending, targetName]);
 
   const handleWipe = useCallback(async () => {
-    if (!databaseUserId) return;
+    if (cloudSessionPending) return;
     setPhase('wiping');
     setFailure(null);
     try {
-      // The typed phrase goes through untouched. Normalising it here would make
-      // the user's typing decoration rather than confirmation.
-      await wipeUserFinancialData(wipeConfirmText, databaseUserId);
+      // The typed phrase goes through untouched on both engines. Normalising it
+      // here would make the user's typing decoration rather than confirmation.
+      if (databaseUserId) {
+        await wipeUserFinancialData(wipeConfirmText, databaseUserId);
+      } else {
+        await wipeLocalFinancialData(wipeConfirmText);
+      }
       // The local snapshot now describes history that no longer exists. Drop it
       // before anything reads it back and merges the dead rows in.
       await transactionCache.clear();
-      setTargetIsEmpty(await userFinancialDataIsEmpty(databaseUserId));
+      setTargetIsEmpty(databaseUserId
+        ? await userFinancialDataIsEmpty(databaseUserId)
+        : await localFinancialDataIsEmpty());
       setWipeConfirmText('');
       setPhase('ready');
     } catch (error) {
       restoreLogger.error('Wipe before restore failed', error);
       setFailure({
-        step: 'Erasing this login',
+        step: `Erasing this ${targetName}`,
         message: error instanceof Error ? error.message : String(error),
         partiallyRestored: false,
       });
       setPhase('failed');
     }
-  }, [databaseUserId, wipeConfirmText]);
+  }, [databaseUserId, cloudSessionPending, targetName, wipeConfirmText]);
 
   const handleRestore = useCallback(async () => {
-    if (!bundle || !databaseUserId) return;
+    if (!bundle || cloudSessionPending) return;
     setPhase('restoring');
     setFailure(null);
     setProgress(null);
     try {
-      const result = await restoreBackupBundle(bundle, databaseUserId, { onProgress: setProgress });
+      const result = databaseUserId
+        ? { ...await restoreBackupBundle(bundle, databaseUserId, { onProgress: setProgress }), notStoredLocally: [] }
+        : await restoreLocalBackupBundle(bundle, { onProgress: setProgress });
       await transactionCache.clear();
       await refreshAccountsAndTransactions();
       await refreshCategories();
@@ -194,10 +253,16 @@ export default function RestoreBackupModal({ isOpen, onClose }: Props): React.JS
       const message = error instanceof RestoreFailedError
         ? error.serverMessage
         : error instanceof Error ? error.message : String(error);
-      setFailure({ step, message, partiallyRestored: true });
+      // A local restore is one IndexedDB transaction: it either landed or it
+      // did not, so there is never a half-filled device to warn about.
+      setFailure({
+        step,
+        message,
+        partiallyRestored: Boolean(databaseUserId) && !(error instanceof LocalRestoreRefusedError),
+      });
       setPhase('failed');
     }
-  }, [bundle, databaseUserId, refreshAccountsAndTransactions, refreshCategories]);
+  }, [bundle, databaseUserId, cloudSessionPending, refreshAccountsAndTransactions, refreshCategories]);
 
   const percent = progress && progress.rowsTotal > 0
     ? Math.round((progress.rowsDone / progress.rowsTotal) * 100)
@@ -290,19 +355,20 @@ export default function RestoreBackupModal({ isOpen, onClose }: Props): React.JS
                   <AlertTriangleIcon className="text-red-600 dark:text-red-400 mt-0.5 shrink-0" size={20} />
                   <div>
                     <p className="text-sm font-semibold text-red-800 dark:text-red-300">
-                      This login already holds data, so the backup cannot go in yet
+                      This {targetName} already holds data, so the backup cannot go in yet
                     </p>
                     <p className="text-sm text-red-700 dark:text-red-300 mt-1">
-                      A restore only ever writes into an empty login. Pouring a backup on top of existing
-                      records would mix two datasets and re-date your history, so it is refused rather than
-                      attempted. To go ahead you have to erase everything in this login first — accounts,
-                      transactions, budgets, goals, the lot. That erasure is permanent and this backup file
-                      is the only way back, so keep it somewhere safe before you start.
+                      A restore only ever writes into an empty {targetName}. It REPLACES what is there
+                      rather than merging with it, so it is refused instead of quietly throwing away
+                      records you did not ask it to. To go ahead you have to erase everything in this
+                      {' '}{targetName} first — accounts, transactions, budgets, goals, the lot. That
+                      erasure is permanent and this backup file is the only way back, so keep it
+                      somewhere safe before you start.
                     </p>
                   </div>
                 </div>
                 <label className="block text-sm text-red-800 dark:text-red-300 mb-1">
-                  Type <span className="font-mono font-bold">{CONFIRM_PHRASE}</span> to erase this login
+                  Type <span className="font-mono font-bold">{CONFIRM_PHRASE}</span> to erase this {targetName}
                 </label>
                 <input
                   value={wipeConfirmText}
@@ -316,7 +382,7 @@ export default function RestoreBackupModal({ isOpen, onClose }: Props): React.JS
                   disabled={wipeConfirmText !== CONFIRM_PHRASE}
                   className="mt-3 px-4 py-2 bg-red-700 text-white rounded-lg hover:bg-red-800 disabled:opacity-40 disabled:cursor-not-allowed"
                 >
-                  Erase everything in this login
+                  Erase everything in this {targetName}
                 </button>
               </div>
             )}
@@ -325,7 +391,21 @@ export default function RestoreBackupModal({ isOpen, onClose }: Props): React.JS
               <div className="rounded-xl border border-green-200 dark:border-green-800 bg-green-50 dark:bg-green-900/20 p-4 flex items-start gap-3">
                 <CheckCircleIcon className="text-green-600 dark:text-green-400 mt-0.5 shrink-0" size={20} />
                 <p className="text-sm text-green-800 dark:text-green-300">
-                  This login is empty, so the backup can go straight in.
+                  This {targetName} is empty, so the backup can go straight in.
+                </p>
+              </div>
+            )}
+
+            {/* Only when it is true AND has a consequence: a file with nothing
+                in those tables has nothing to warn about, and a device is not
+                worse for lacking investments it was never going to show. */}
+            {!isCloudRestore && unstorableRows > 0 && (
+              <div className="rounded-xl border border-amber-200 dark:border-amber-800 bg-amber-50 dark:bg-amber-900/20 p-4 flex items-start gap-3">
+                <AlertTriangleIcon className="text-amber-600 dark:text-amber-400 mt-0.5 shrink-0" size={20} />
+                <p className="text-sm text-amber-900 dark:text-amber-200">
+                  Part of this backup cannot be kept on this device — {unstorableLabels}. Everything else
+                  goes in as normal, and the file keeps the rest: sign in and restore the same file there
+                  to get it back.
                 </p>
               </div>
             )}
@@ -369,7 +449,9 @@ export default function RestoreBackupModal({ isOpen, onClose }: Props): React.JS
               <div>
                 <p className="text-sm font-semibold text-gray-900 dark:text-white">Restore finished</p>
                 <p className="text-sm text-gray-600 dark:text-gray-400 mt-1">
-                  These are the row counts the database reported, not what the file claimed.
+                  {isCloudRestore
+                    ? 'These are the row counts the database reported, not what the file claimed.'
+                    : 'These are the rows now on this device.'}
                 </p>
               </div>
             </div>
@@ -389,6 +471,24 @@ export default function RestoreBackupModal({ isOpen, onClose }: Props): React.JS
                 <span className="text-gray-900 dark:text-white tabular-nums">{formatCount(outcome.accountsRelinked)}</span>
               </li>
             </ul>
+            {/* Named, not counted: "3 investments were skipped" tells someone
+                nothing they can act on, whereas knowing the file still holds
+                them and where they would come back does. */}
+            {outcome.notStoredLocally.length > 0 && (
+              <div className="rounded-xl border border-amber-200 dark:border-amber-800 bg-amber-50 dark:bg-amber-900/20 p-3">
+                <p className="text-sm text-amber-900 dark:text-amber-200">
+                  This device does not hold{' '}
+                  {outcome.notStoredLocally.map((entry) => entry.label.toLowerCase()).join(', ')}, so that
+                  part of the backup was not restored. It is still in the file — signing in and restoring
+                  the same file there would bring it back.
+                </p>
+                <ul className="text-xs text-amber-800 dark:text-amber-300 mt-2 space-y-0.5">
+                  {outcome.notStoredLocally.map((entry) => (
+                    <li key={entry.label}>{entry.label}: {entry.absence}</li>
+                  ))}
+                </ul>
+              </div>
+            )}
             {/* Only rendered when there is something to say. A line reading
                 "0 references could not be resolved" is noise that teaches the
                 user to skim past the line that will one day matter. */}
@@ -410,8 +510,8 @@ export default function RestoreBackupModal({ isOpen, onClose }: Props): React.JS
               </div>
             )}
             <p className="text-sm text-gray-600 dark:text-gray-400">
-              Accounts, transactions and categories on screen have already been refreshed. Budgets, goals and
-              investments load elsewhere in the app, so reload the page to see everything at once.
+              Accounts, transactions and categories on screen have already been refreshed. Budgets and goals
+              load elsewhere in the app, so reload the page to see everything at once.
             </p>
           </div>
         )}
@@ -426,7 +526,7 @@ export default function RestoreBackupModal({ isOpen, onClose }: Props): React.JS
                   Stopped at: {failure.step}
                 </p>
                 <p className="text-sm text-gray-600 dark:text-gray-400 mt-1">
-                  Nothing further was attempted. The database said:
+                  Nothing further was attempted. {isCloudRestore ? 'The database said:' : 'The reason was:'}
                 </p>
               </div>
             </div>
@@ -436,12 +536,22 @@ export default function RestoreBackupModal({ isOpen, onClose }: Props): React.JS
             <p className="rounded-xl border border-red-200 dark:border-red-800 bg-red-50 dark:bg-red-900/20 p-3 text-sm text-red-800 dark:text-red-300 font-mono break-words">
               {failure.message}
             </p>
-            {failure.partiallyRestored && (
+            {failure.partiallyRestored ? (
               <div className="rounded-xl border border-amber-200 dark:border-amber-800 bg-amber-50 dark:bg-amber-900/20 p-3">
                 <p className="text-sm text-amber-900 dark:text-amber-200">
                   This login is now <strong>partly populated</strong> — some rows went in before the failure and
                   the rest did not. Do not use the app in this state and do not assume what you can see is
                   complete. To recover, erase this login and restore the same file again from the start.
+                </p>
+              </div>
+            ) : !isCloudRestore && (
+              // Worth saying plainly rather than leaving to be inferred: the
+              // local restore is one IndexedDB transaction, so a failure is
+              // never the frightening kind that leaves a device half-filled.
+              <div className="rounded-xl border border-gray-200 dark:border-gray-700 p-3">
+                <p className="text-sm text-gray-600 dark:text-gray-400">
+                  Nothing on this device was changed — the restore is written in one go, so it either
+                  lands completely or not at all. Your backup file is untouched; you can try it again.
                 </p>
               </div>
             )}

--- a/src/hooks/__tests__/useTransactionFilters.test.ts
+++ b/src/hooks/__tests__/useTransactionFilters.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import { useTransactionFilters } from '../useTransactionFilters';
+import type { Account, Category, Transaction } from '../../types';
+
+/**
+ * The Transactions list orders its rows here, and prints a per-account running
+ * balance beside them that it accumulates elsewhere (runningBalances on the
+ * page). The two therefore have to agree about which of a day's transactions
+ * came last — and a date-only compare left that to Array.prototype.sort's
+ * stability, which is not an agreement, only a coincidence.
+ *
+ * Every figure and date here is invented; this repo is public.
+ */
+describe('useTransactionFilters — the display order', () => {
+  const ACCOUNTS: Account[] = [
+    {
+      id: 'acc-1', name: 'Synthetic Current', type: 'current', balance: 0,
+      currency: 'GBP', lastUpdated: new Date('2024-02-20'), openingBalance: 0,
+    }
+  ];
+  const CATEGORIES: Category[] = [];
+
+  const txn = (over: Partial<Transaction>): Transaction => ({
+    id: 'x',
+    date: new Date('2024-02-19'),
+    amount: -10,
+    description: 'Synthetic row',
+    category: '',
+    accountId: 'acc-1',
+    type: 'expense',
+    cleared: false,
+    ...over
+  });
+
+  const FILTERS = {
+    filterType: 'all' as const,
+    filterAccountId: '',
+    searchQuery: '',
+    dateFrom: '',
+    dateTo: ''
+  };
+
+  const orderedIds = (
+    transactions: Transaction[],
+    direction: 'asc' | 'desc'
+  ): string[] => {
+    const { result } = renderHook(() =>
+      useTransactionFilters(transactions, ACCOUNTS, CATEGORIES, FILTERS, {
+        field: 'date',
+        direction
+      })
+    );
+    return result.current.transactions.map(t => t.id);
+  };
+
+  const SAME_DAY_IN = txn({ id: 'in', type: 'income', amount: 450 });
+  const SAME_DAY_OUT = txn({ id: 'out', type: 'expense', amount: -450 });
+  const EARLIER = txn({ id: 'earlier', date: new Date('2024-02-05'), amount: -12.75 });
+
+  it('reverses exactly under desc, so the newest row really is on top', () => {
+    const list = [SAME_DAY_OUT, SAME_DAY_IN, EARLIER];
+
+    expect(orderedIds(list, 'asc')).toEqual(['earlier', 'in', 'out']);
+    // Not ['in', 'out', 'earlier'] — reversing only the day would leave the
+    // same-day pair forwards, and the running balance beside them is the
+    // balance AFTER each row, so the top one would be the day's first
+    // transaction wearing the account's balance.
+    expect(orderedIds(list, 'desc')).toEqual(['out', 'in', 'earlier']);
+  });
+
+  it('does not take its answer from the order it was handed', () => {
+    const list = [SAME_DAY_OUT, SAME_DAY_IN, EARLIER];
+    expect(orderedIds([...list].reverse(), 'desc')).toEqual(orderedIds(list, 'desc'));
+  });
+});

--- a/src/hooks/useTransactionFilters.ts
+++ b/src/hooks/useTransactionFilters.ts
@@ -1,5 +1,6 @@
 import { useMemo, useCallback } from 'react';
 import type { Transaction, Account, Category } from '../types';
+import { compareChronological } from '../utils/transactionSort';
 
 interface FilterOptions {
   filterType: 'all' | 'income' | 'expense';
@@ -118,11 +119,18 @@ export function useTransactionFilters(
     let bValue: string | number;
 
     switch (sortOptions.field) {
-      case 'date':
-        aValue = parseDate(a.date);
-        bValue = parseDate(b.date);
-        break;
-        
+      case 'date': {
+        // The shared register order, negated for newest-first — so each
+        // account's own rows come out as the exact reverse of the order its
+        // running balances were accumulated in (see runningBalances on the
+        // Transactions page) and the topmost row of an account carries that
+        // account's current balance. A date-only compare left same-day rows
+        // equal, and the display and the balances then disagreed about which
+        // of them came last.
+        const chronological = compareChronological(a, b);
+        return sortOptions.direction === 'asc' ? chronological : -chronological;
+      }
+
       case 'account': {
         const accountA = accountLookup.get(a.accountId);
         const accountB = accountLookup.get(b.accountId);
@@ -152,7 +160,9 @@ export function useTransactionFilters(
 
     if (aValue < bValue) return sortOptions.direction === 'asc' ? -1 : 1;
     if (aValue > bValue) return sortOptions.direction === 'asc' ? 1 : -1;
-    return 0;
+    // Equal on the chosen column: settle it chronologically rather than leaving
+    // it to whichever order the array arrived in.
+    return compareChronological(a, b);
   }, [sortOptions.field, sortOptions.direction, accountLookup, getCategoryPath]);
 
   // Filter predicate function

--- a/src/pages/AccountTransactions.tsx
+++ b/src/pages/AccountTransactions.tsx
@@ -16,7 +16,7 @@ import { useToast } from '../contexts/ToastContext';
 import { VirtualizedTable, Column } from '../components/VirtualizedTable';
 import { InfiniteScrollTransactionList } from '../components/InfiniteScrollTransactionList';
 import { LoadingState } from '../components/loading/LoadingState';
-import { compareTransactions } from '../utils/transactionSort';
+import { compareChronological, compareTransactions, type TransactionSortField } from '../utils/transactionSort';
 import { orderColumnKeys, moveColumnKey } from '../utils/columnLayout';
 import { computeArchiveWindow, ARCHIVE_PRESETS, type ArchiveRange } from '../utils/archiveRange';
 import { effectiveOpeningDate, findSiblingAccount } from '../utils/openingDates';
@@ -75,6 +75,18 @@ interface ArchiveState { range: ArchiveRange; from: string; to: string }
 
 // Friendly labels for the View dropdown's column checkboxes.
 const COLUMN_LABELS: Record<string, string> = { reconciled: 'Reconciled (R)' };
+
+/** The sortable columns, named as their headers name them. */
+const SORT_FIELD_LABELS: Record<TransactionSortField, string> = {
+  date: 'Date',
+  description: 'Description',
+  category: 'Category',
+  tags: 'Tags',
+  payment: 'Payment',
+  deposit: 'Deposit',
+  amount: 'Amount',
+  notes: 'Notes'
+};
 
 const readStored = <T,>(key: string, fallback: T): T => {
   try {
@@ -158,6 +170,8 @@ export default function AccountTransactions() {
   // can expand over the bottom add/edit dock for bulk browsing.
   const [showFilters, setShowFilters] = useState(false);
   const [tableExpanded, setTableExpanded] = useState(false);
+  const [sortField, setSortField] = useState<TransactionSortField>('date');
+  const [sortDirection, setSortDirection] = useState<'asc' | 'desc'>('asc');
   // The table's height is MEASURED (viewport minus everything above it and a
   // reserve for the bottom dock) so the whole page always fits one screen,
   // whatever banners/nav are present. Fixed calc() guesses drift.
@@ -170,13 +184,15 @@ export default function AccountTransactions() {
     const dockReserve = tableExpanded ? 32 : 224; // dock (~178) + gaps/padding, or just padding
     setTableHeight(Math.max(240, window.innerHeight - top - dockReserve));
   }, [tableExpanded]);
+  // Re-measured on anything that moves the table down the page: the filter
+  // panel, and the sort — a non-date sort adds a line above the table, and a
+  // table measured before that line appeared overflows the viewport by its
+  // height until the next window resize.
   useLayoutEffect(() => {
     measureTableHeight();
     window.addEventListener('resize', measureTableHeight);
     return () => window.removeEventListener('resize', measureTableHeight);
-  }, [measureTableHeight, showFilters]);
-  const [sortField, setSortField] = useState<'date' | 'description' | 'amount' | 'category' | 'tags' | 'payment' | 'deposit' | 'notes'>('date');
-  const [sortDirection, setSortDirection] = useState<'asc' | 'desc'>('asc');
+  }, [measureTableHeight, showFilters, sortField]);
   // Column layout (order + widths), drag-controlled and persisted per browser.
   const [columnOrder, setColumnOrder] = useState<string[]>(() => readStored<string[]>(COLUMN_ORDER_KEY, []));
   const [columnWidths, setColumnWidths] = useState<Record<string, number>>(() => readStored<Record<string, number>>(COLUMN_WIDTHS_KEY, {}));
@@ -389,25 +405,23 @@ export default function AccountTransactions() {
     // Running balance is computed over the FULL account history — every
     // transaction, ignoring the view filters — so hiding rows (archived, date
     // window, search) never corrupts the balance shown against a visible row.
-    // Within the same date: income first, then transfers, then expenses.
-    const typeOrder = { income: 0, transfer: 1, expense: 2 };
-    const sortedForBalance = [...fullAccountTransactions].sort((a, b) => {
-      const dateA = new Date(a.date).getTime();
-      const dateB = new Date(b.date).getTime();
-      if (dateA !== dateB) {
-        return dateA - dateB;
-      }
-      return typeOrder[a.type] - typeOrder[b.type];
-    });
+    //
+    // compareChronological, NOT a local sort: the displayed rows are ordered by
+    // the same function (compareTransactions delegates to it for Date, and
+    // negates it wholesale for newest-first), so the column the user reads is
+    // the column these figures were accumulated in. The two used to disagree on
+    // same-day rows, and a register whose Balance column disagrees with itself
+    // is worse than one without a Balance column.
+    const sortedForBalance = [...fullAccountTransactions].sort(compareChronological);
 
-    // Start from opening balance or 0
-    let runningBalance = account.openingBalance || 0;
-
-    // Calculate running balance for each transaction (amounts are pre-signed)
+    // Decimal, not float: a statement's worth of `runningBalance += amount`
+    // drifts by a fraction of a penny and the register then shows a balance
+    // that never quite equals the account's. Amounts are pre-signed.
+    let runningBalance = toDecimal(account.openingBalance ?? 0);
     const balanceMap = new Map<string, number>();
     for (const transaction of sortedForBalance) {
-      runningBalance += transaction.amount;
-      balanceMap.set(transaction.id, runningBalance);
+      runningBalance = runningBalance.plus(toDecimal(transaction.amount));
+      balanceMap.set(transaction.id, runningBalance.toNumber());
     }
 
     // Display the filtered subset, each carrying its true running balance.
@@ -428,9 +442,15 @@ export default function AccountTransactions() {
     // balance ("Opening Balance"); when earlier history is hidden (archived, or
     // a date window) it's the carried-forward figure ("Brought forward"), so
     // the visible running balances stay continuous and correct.
-    const earliestVisible = transactionsWithBalance.length > 0
-      ? transactionsWithBalance.reduce((min, t) => (new Date(t.date) < new Date(min.date) ? t : min))
-      : null;
+    //
+    // "Earliest" by compareChronological, not by date alone. Comparing only the
+    // day left several rows tied, and the reduce then kept whichever the array
+    // held first — which under a newest-first sort is the LAST of that day's
+    // rows, so the lead balance came out short by everything else on that day.
+    const earliestVisible = transactionsWithBalance.reduce<TransactionWithBalance | null>(
+      (earliest, t) => (earliest === null || compareChronological(t, earliest) < 0 ? t : earliest),
+      null
+    );
     // No visible rows → the lead balance is the full account balance (opening
     // plus every transaction, all of which are currently hidden).
     const fullBalance = fullAccountTransactions
@@ -495,7 +515,27 @@ export default function AccountTransactions() {
 
   // Bank balance from TrueLayer sync (or null if not available)
   const bankBalance = account?.bankBalance ?? null;
-  
+
+  /**
+   * What to say when the register is not in date order.
+   *
+   * The Balance column is kept, and its figures stay true — the balance map is
+   * keyed by transaction, so every row shows what the account was worth
+   * immediately after that transaction whatever order the rows sit in, and
+   * sorting by Amount to find a large payment is exactly when someone wants to
+   * know it. What stops being true is the COLUMN: it no longer runs down the
+   * page, and each row's arithmetic no longer follows from the one above.
+   *
+   * Blanking the column instead would destroy correct information and make a
+   * user-sized, user-ordered column vanish as a side effect of clicking a
+   * different header. Saying it in a line is the honest option: name the
+   * consequence, and give the way back to a running balance.
+   */
+  const balanceOrderNotice = useMemo((): string | null => {
+    if (sortField === 'date') return null;
+    return `Sorted by ${SORT_FIELD_LABELS[sortField]}, so the Balance column doesn't run down the page. Each row still shows what ${account?.name ?? 'the account'} was worth immediately after that transaction — sort by Date to read the column as a running balance.`;
+  }, [sortField, account?.name]);
+
   // Keyboard event handler
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
@@ -956,11 +996,17 @@ export default function AccountTransactions() {
       // balance ("-£1,234,567.89") without truncating at the table edge.
       width: '140px',
       accessor: (transaction) => (
-        <span className={`text-sm font-medium ${
-          transaction.balance < 0
-            ? 'text-red-600 dark:text-red-400'
-            : 'text-gray-900 dark:text-gray-100'
-        }`}>
+        // data-testid: the column's whole contract is that the rows and the
+        // balances are in the same order, and the only way to hold that to
+        // account is to read the figures off in rendered order.
+        <span
+          data-testid="register-balance"
+          className={`text-sm font-medium ${
+            transaction.balance < 0
+              ? 'text-red-600 dark:text-red-400'
+              : 'text-gray-900 dark:text-gray-100'
+          }`}
+        >
           {formatCurrency(transaction.balance, account?.currency)}
         </span>
       ),
@@ -1408,6 +1454,14 @@ export default function AccountTransactions() {
           }}
         />
       </div>
+
+      {/* Only the desktop table has a Balance column, so only it needs the
+          warning that the column has stopped being a running one. */}
+      {balanceOrderNotice && (
+        <p className="hidden lg:block text-sm text-gray-600 dark:text-gray-400">
+          {balanceOrderNotice}
+        </p>
+      )}
 
       <div
         ref={tableWrapRef}

--- a/src/pages/ExportManager.tsx
+++ b/src/pages/ExportManager.tsx
@@ -24,6 +24,7 @@ import type { Investment } from '../types';
 import { createScopedLogger } from '../loggers/scopedLogger';
 import { DataService } from '../services/api/dataService';
 import { collectBackupBundle, downloadBackupBundle, type ExportProgress } from '../services/backupService';
+import { collectLocalBackupBundle } from '../services/localBackupService';
 
 // The advanced report builder (templated PDF/Excel/CSV) and the dedicated Excel
 // exporter both used to live under Settings ▸ Data Management. They move here so
@@ -42,7 +43,7 @@ const exportManagerLogger = createScopedLogger('ExportManagerPage');
 type ActiveTab = 'export' | 'templates' | 'history';
 
 export default function ExportManager() {
-  const { transactions, accounts } = useApp();
+  const { transactions, accounts, isUsingSupabase } = useApp();
   const investments: Investment[] = []; // TODO: Add investments to AppContext
   const [activeTab, setActiveTab] = useState<ActiveTab>('export');
   const [templates, setTemplates] = useState<ExportTemplate[]>([]);
@@ -121,9 +122,18 @@ export default function ExportManager() {
   // them, and renames what is left into camelCase. A file built from it could
   // never be poured back in, which is what Settings → Data Management can now
   // do with this one. See services/backupService for the contract.
+  //
+  // Local and demo sessions read the same file out of browser storage instead.
+  // Before that they could not save their data AT ALL — every path through
+  // backupService resolves a Supabase client and threw without one — which is
+  // an odd thing to offer a person and then refuse. Same format, same file,
+  // same restore; only where the rows come from differs.
   const handleExportEverything = async () => {
     const { databaseId, clerkId } = DataService.getUserIds();
-    if (!databaseId) {
+    // Signed in but the database identity has not resolved yet. Falling through
+    // to the local path here would hand a signed-in user a file made of
+    // whatever demo or imported data their browser happens to hold.
+    if (isUsingSupabase && !databaseId) {
       setBackupError('This session has no database identity yet, so there is nothing to read. Reload the page and try again.');
       return;
     }
@@ -131,10 +141,12 @@ export default function ExportManager() {
     setIsBackingUp(true);
     setBackupProgress(null);
     try {
-      const bundle = await collectBackupBundle(
-        { databaseUserId: databaseId, clerkUserId: clerkId },
-        { onProgress: setBackupProgress }
-      );
+      const bundle = databaseId
+        ? await collectBackupBundle(
+            { databaseUserId: databaseId, clerkUserId: clerkId },
+            { onProgress: setBackupProgress }
+          )
+        : await collectLocalBackupBundle({ onProgress: setBackupProgress });
       downloadBackupBundle(bundle);
     } catch (error) {
       exportManagerLogger.error('Full backup failed', error);
@@ -423,10 +435,11 @@ export default function ExportManager() {
               <div className="bg-white dark:bg-gray-800 rounded-lg shadow-sm p-6">
                 <h3 className="text-lg font-semibold text-gray-900 dark:text-white">Full backup</h3>
                 <p className="text-sm text-gray-600 dark:text-gray-400 mt-1 mb-4">
-                  Every record we hold for you, straight from the database — accounts, transactions,
-                  splits, categories, budgets, goals, investments and the rest. This is the only export
-                  that can be restored: Settings &rarr; Data Management &rarr; Restore from backup reads
-                  it back. It also satisfies a data-portability request.
+                  {isUsingSupabase
+                    ? 'Every record we hold for you, straight from the database — accounts, transactions, splits, categories, budgets, goals, investments and the rest.'
+                    : 'Everything this browser is holding — accounts, transactions, splits, categories, budgets and goals. Nothing here has been sent anywhere, so this file is the only copy that exists.'}
+                  {' '}This is the only export that can be restored: Settings &rarr; Data Management
+                  &rarr; Restore from backup reads it back. It also satisfies a data-portability request.
                 </p>
 
                 <div className="rounded-xl border border-amber-200 dark:border-amber-800 bg-amber-50 dark:bg-amber-900/20 p-3 mb-4 flex items-start gap-3">

--- a/src/pages/Transactions.tsx
+++ b/src/pages/Transactions.tsx
@@ -25,6 +25,7 @@ import { TransactionRow } from '../components/TransactionRow';
 // Lazy load list components that are conditionally rendered
 const InfiniteScrollTransactionList = lazyWithRecovery(() => import('../components/InfiniteScrollTransactionList').then(m => ({ default: m.InfiniteScrollTransactionList })));
 import { useTransactionFilters } from '../hooks/useTransactionFilters';
+import { compareChronological } from '../utils/transactionSort';
 import { useDebounce } from '../hooks/useDebounce';
 import { SkeletonTableRow, SkeletonList } from '../components/loading/Skeleton';
 
@@ -375,25 +376,26 @@ const Transactions = React.memo(function Transactions() {
       });
   }, [filteredAndSortedTransactions, getDecimalTransactions]);
 
-  // Compute running balances per account
+  // Each transaction's running balance for ITS account.
+  //
+  // compareChronological, the same order the account register accumulates in
+  // and the same order useTransactionFilters displays a Date sort in. A local
+  // date-only sort left same-day rows to Array.prototype.sort's stability,
+  // which is not the same answer as the display's — so the newest row of a day
+  // did not carry the account's balance. Decimal, because a float running total
+  // over a whole account's history drifts.
   const runningBalances = useMemo(() => {
     const balanceMap = new Map<string, number>();
-    // Sort all transactions by date ascending for balance calculation
-    const allSorted = [...transactions].sort((a, b) => new Date(a.date).getTime() - new Date(b.date).getTime());
+    const allSorted = [...transactions].sort(compareChronological);
 
-    // Build opening balances
-    const openingBalances = new Map<string, number>();
-    accounts.forEach(acc => openingBalances.set(acc.id, acc.openingBalance ?? 0));
-
-    // Track running balance per account
-    const accountBalances = new Map<string, number>();
-    accounts.forEach(acc => accountBalances.set(acc.id, acc.openingBalance ?? 0));
+    const accountBalances = new Map<string, DecimalInstance>();
+    accounts.forEach(acc => accountBalances.set(acc.id, toDecimal(acc.openingBalance ?? 0)));
 
     allSorted.forEach(t => {
-      const current = accountBalances.get(t.accountId) ?? 0;
-      const newBalance = current + t.amount;
-      accountBalances.set(t.accountId, newBalance);
-      balanceMap.set(t.id, newBalance);
+      const current = accountBalances.get(t.accountId) ?? toDecimal(0);
+      const next = current.plus(toDecimal(t.amount));
+      accountBalances.set(t.accountId, next);
+      balanceMap.set(t.id, next.toNumber());
     });
 
     return balanceMap;

--- a/src/pages/__tests__/AccountTransactions.test.tsx
+++ b/src/pages/__tests__/AccountTransactions.test.tsx
@@ -275,3 +275,231 @@ describe('Account register — open, closed, and gone', () => {
     });
   });
 });
+
+/**
+ * The running Balance column, against the order the rows are actually in.
+ *
+ * The register accumulated balances with one local sort and displayed rows with
+ * another, and the sort it used ordered a day by TYPE — income, then transfers,
+ * then expenses. Two things were wrong at once: the display sequence did not
+ * match the sequence the balances were computed in, and the sequence itself was
+ * invented.
+ *
+ * The days below reproduce the SHAPE of the account that exposed it — one that
+ * runs an automated two-way sweep with a linked savings account: ordinary
+ * transactions through the day, then ONE sweep in the evening whose amount is
+ * the exact negative of their sum, returning the balance to zero. So the sweep
+ * is always the day's LAST transaction and the account rests at £0.00, which
+ * makes every intermediate balance checkable line by line.
+ *
+ * Every figure and date here is invented — the repo is public. Only the shape is
+ * real, and the shape is what the tests prove.
+ *
+ * The bank's order is carried by statementSequence, the file position the OFX
+ * importer now records (see the migration of the same name).
+ */
+describe('Account register — the running Balance column', () => {
+  const SWEPT_ACCOUNT: Account = {
+    id: 'acc-swept', name: 'Synthetic Swept Current', type: 'current', balance: 0,
+    currency: 'GBP', lastUpdated: new Date('2024-02-20'), openingBalance: 0, isActive: true,
+  };
+
+  const row = (
+    over: Partial<Transaction> & Pick<Transaction, 'id' | 'date' | 'amount' | 'statementSequence'>
+  ): Transaction => ({
+    description: 'Synthetic row',
+    type: 'expense',
+    category: '',
+    accountId: 'acc-swept',
+    cleared: false,
+    ...over
+  });
+
+  // Day one, in the bank's own order. The direct debit and the standing order
+  // run the account down; the evening sweep (-12.75 + -300.00 = -312.75, so
+  // +312.75) restores it. NOTE the two transfers: the standing order and the
+  // sweep are both `transfer`, and they have a real order between them that no
+  // type rule can express.
+  const DAY_ONE_DIRECT_DEBIT = row({
+    id: 'txn-one-c', date: new Date('2024-02-05'), amount: -12.75, statementSequence: 0,
+    type: 'expense', description: 'Synthetic direct debit'
+  });
+  const DAY_ONE_STANDING_ORDER = row({
+    id: 'txn-one-b', date: new Date('2024-02-05'), amount: -300, statementSequence: 1,
+    type: 'transfer', description: 'Synthetic standing order out'
+  });
+  const DAY_ONE_SWEEP_IN = row({
+    id: 'txn-one-a', date: new Date('2024-02-05'), amount: 312.75, statementSequence: 2,
+    type: 'transfer', description: 'Synthetic two way sweep in'
+  });
+
+  // Day two: the payment out came first, taking the account to -£450.00, and the
+  // sweep followed and restored it to zero. A credit AFTER a debit — exactly
+  // what the retired income-first rule denied could happen.
+  const DAY_TWO_PAYMENT_OUT = row({
+    id: 'txn-two-z', date: new Date('2024-02-19'), amount: -450, statementSequence: 3,
+    type: 'expense', description: 'Synthetic faster payment out'
+  });
+  const DAY_TWO_SWEEP_IN = row({
+    id: 'txn-two-a', date: new Date('2024-02-19'), amount: 450, statementSequence: 4,
+    type: 'transfer', description: 'Synthetic two way sweep in again'
+  });
+
+  /**
+   * Every balance the statement itself contains, for this opening balance of
+   * zero. Anything the register prints outside this set is a figure the account
+   * never held.
+   */
+  const STATEMENT_BALANCES = ['£0.00', '-£12.75', '-£312.75', '-£450.00'];
+
+  /** The Balance column, top row first, exactly as rendered. */
+  const balanceColumn = (): string[] =>
+    screen.getAllByTestId('register-balance').map(cell => cell.textContent ?? '');
+
+  /** The account's balance, as the register's own header states it. */
+  const headerAccountBalance = (): string =>
+    screen.getByText('Account Balance').parentElement?.lastElementChild?.textContent ?? '';
+
+  const sortByDate = (): void => {
+    fireEvent.click(screen.getByRole('button', { name: /^Date/ }));
+  };
+
+  const openRegister = async (): Promise<void> => {
+    renderRegister('/accounts/acc-swept');
+    await screen.findByRole('heading', { level: 1, name: 'Synthetic Swept Current' });
+  };
+
+  beforeEach(() => {
+    localStorage.clear();
+    __setAppContextValue({
+      accounts: [SWEPT_ACCOUNT],
+      // Deliberately not in date order: the data layer hands rows over
+      // newest-first, and the order they arrive in must not decide anything.
+      transactions: [DAY_TWO_SWEEP_IN, DAY_TWO_PAYMENT_OUT, DAY_ONE_SWEEP_IN, DAY_ONE_STANDING_ORDER, DAY_ONE_DIRECT_DEBIT],
+      categories: CATEGORIES,
+      isLoading: false,
+    });
+    vi.spyOn(DataService, 'getClosedAccounts').mockResolvedValue([]);
+  });
+
+  afterEach(() => {
+    vi.mocked(DataService.getClosedAccounts).mockRestore();
+    __resetAppContextValue();
+  });
+
+  it('shows the account balance on the top row when sorted newest-first', async () => {
+    await openRegister();
+    sortByDate();
+
+    // THE invariant. Newest-first, the top row is the account's last
+    // transaction, so the balance beside it is the account's balance — read off
+    // the register's own header rather than a literal, because the two agreeing
+    // is the whole point.
+    expect(balanceColumn()[0]).toBe(headerAccountBalance());
+    expect(balanceColumn()[0]).toBe('£0.00');
+    // Not the figure the type order produced: the sweep hoisted above the
+    // payment it offsets, showing the day's money in without its money out.
+    expect(balanceColumn()[0]).not.toBe('£450.00');
+    // Nor a signed zero, which reads like a rounding error in the user's money.
+    expect(balanceColumn()[0]).not.toBe('-£0.00');
+  });
+
+  it('walks a day in the bank\'s order: -12.75, -312.75, then swept to 0.00', async () => {
+    await openRegister();
+
+    // Ascending (the default): the lead Opening Balance row, then day one
+    // exactly as the statement prints it, then day two.
+    expect(balanceColumn()).toEqual([
+      '£0.00',        // Opening Balance
+      '-£12.75',      // direct debit
+      '-£312.75',     // standing order
+      '£0.00',        // evening sweep restores it
+      '-£450.00',     // day two payment
+      '£0.00'         // day two sweep
+    ]);
+
+    sortByDate();
+
+    // Descending is the exact reverse.
+    expect(balanceColumn()).toEqual([
+      '£0.00', '-£450.00', '£0.00', '-£312.75', '-£12.75', '£0.00'
+    ]);
+  });
+
+  it('prints no balance the statement does not contain', async () => {
+    // The type order put the sweep in the MIDDLE of day one (both it and the
+    // standing order are transfers, and transfers sorted before expenses),
+    // producing intermediate balances the account never held — which is how a
+    // day that closed at zero came to show a balance it never reached.
+    await openRegister();
+
+    for (const balance of balanceColumn()) {
+      expect(STATEMENT_BALANCES).toContain(balance);
+    }
+
+    sortByDate();
+
+    for (const balance of balanceColumn()) {
+      expect(STATEMENT_BALANCES).toContain(balance);
+    }
+  });
+
+  it('lands the day on the same closing balance when the bank\'s order is unknown', async () => {
+    // The honest limit. Rows imported before statement_sequence existed have
+    // none, so the tie falls to the id and the MIDDLE of a day may not match the
+    // statement. What cannot vary is where the day ENDS — so the top row under
+    // newest-first is still the account's balance.
+    __setAppContextValue({
+      transactions: [DAY_TWO_SWEEP_IN, DAY_TWO_PAYMENT_OUT, DAY_ONE_SWEEP_IN, DAY_ONE_STANDING_ORDER, DAY_ONE_DIRECT_DEBIT]
+        .map(t => ({ ...t, statementSequence: null })),
+    });
+
+    await openRegister();
+    sortByDate();
+
+    expect(balanceColumn()[0]).toBe(headerAccountBalance());
+    expect(balanceColumn()[0]).toBe('£0.00');
+  });
+
+  it('keeps a statement\'s own run contiguous when other rows have no sequence', async () => {
+    // A hand-entered row on an imported day: it has no sequence, so it sorts
+    // after the statement's rows rather than being guessed into the middle of
+    // them. The imported run stays exactly as the bank printed it — which is the
+    // run the user is checking — and the day still closes on the account's
+    // balance.
+    const HAND_ENTERED = row({
+      id: 'txn-one-hand', date: new Date('2024-02-05'), amount: -25, statementSequence: null,
+      type: 'expense', description: 'Synthetic hand entered'
+    });
+    __setAppContextValue({
+      transactions: [HAND_ENTERED, DAY_ONE_SWEEP_IN, DAY_ONE_STANDING_ORDER, DAY_ONE_DIRECT_DEBIT],
+    });
+
+    await openRegister();
+
+    expect(balanceColumn()).toEqual([
+      '£0.00', '-£12.75', '-£312.75', '£0.00', '-£25.00'
+    ]);
+  });
+
+  it('keeps every row true, and says the column has stopped running, under another sort', async () => {
+    await openRegister();
+
+    fireEvent.click(screen.getByRole('button', { name: /^Description/ }));
+
+    // Alphabetical by description — each row still carrying the balance
+    // immediately after it, which no longer runs down the page.
+    expect(balanceColumn()).toEqual([
+      '£0.00', '-£12.75', '-£450.00', '-£312.75', '£0.00', '£0.00'
+    ]);
+    expect(
+      screen.getByText(/Sorted by Description, so the Balance column doesn't run down the page/)
+    ).toBeInTheDocument();
+  });
+
+  it('says nothing about the column while it is in date order', async () => {
+    await openRegister();
+
+    expect(screen.queryByText(/the Balance column doesn't run down the page/)).not.toBeInTheDocument();
+  });
+});

--- a/src/pages/settings/DataManagement.tsx
+++ b/src/pages/settings/DataManagement.tsx
@@ -8,7 +8,6 @@ import { createScopedLogger } from '../../loggers/scopedLogger';
 import { parseBankingOpsUrlState, replaceBrowserSearch, withBankingOpsUrlState } from '../../utils/bankingOpsUrlState';
 import { DataService } from '../../services/api/dataService';
 import { supabase } from '../../lib/supabase';
-import { STORAGE_KEYS } from '../../services/storageAdapter';
 
 const ArchiveManager = lazyWithRecovery(() => import('../../components/ArchiveManager'));
 
@@ -75,16 +74,25 @@ export default function DataManagementSettings() {
   // back on the next load, which made the button a lie. The same proven wipe the
   // MS Money migration uses runs first, then the loaded snapshot is dropped, then
   // the app reloads to re-read the (empty) truth.
+  //
+  // The local branch used to call wipeLocalData, which wrote to localStorage
+  // while the app reads encrypted IndexedDB — so on a demo or local session this
+  // button reported success and deleted nothing at all.
   const handleClearData = async () => {
     setIsClearing(true);
     setClearError('');
     try {
-      const { wipeCloudData, wipeLocalData } = await import('../../services/import/msMoney/msMoneyImport');
       const databaseUserId = DataService.getUserIds().databaseId;
       if (isUsingSupabase && supabase && databaseUserId) {
+        const { wipeCloudData } = await import('../../services/import/msMoney/msMoneyImport');
         await wipeCloudData(supabase, databaseUserId);
       } else {
-        wipeLocalData(STORAGE_KEYS);
+        const { wipeLocalFinancialData, LOCAL_WIPE_CONFIRMATION } =
+          await import('../../services/localBackupService');
+        // The dialog behind this button is the confirmation (it will not enable
+        // until DELETE is typed), exactly as it is for the cloud branch above —
+        // wipeCloudData asks for no phrase either.
+        await wipeLocalFinancialData(LOCAL_WIPE_CONFIRMATION);
       }
       await resetLoadedData();
       setShowDeleteConfirm(false);
@@ -145,12 +153,16 @@ export default function DataManagementSettings() {
             to="/export-manager"
             icon={DownloadIcon}
             title="Download a backup"
-            description="Every record, straight from the database, as plain JSON"
+            description={isUsingSupabase
+              ? 'Every record, straight from the database, as plain JSON'
+              : 'Everything this browser holds, as plain JSON — the only copy there is'}
           />
           <ActionButton
             icon={UploadIcon}
             title="Restore from backup"
-            description="Read a backup file back in — only into an empty login"
+            description={isUsingSupabase
+              ? 'Read a backup file back in — only into an empty login'
+              : 'Read a backup file back in — only into an empty device'}
             onClick={() => setShowRestoreBackup(true)}
           />
         </div>

--- a/src/services/__tests__/ofxImportDuplicates.test.ts
+++ b/src/services/__tests__/ofxImportDuplicates.test.ts
@@ -1,0 +1,331 @@
+/**
+ * Re-importing a statement over a period you already have.
+ *
+ * An OFX file covering days already in the register added every one of its
+ * transactions a second time. It hid because the account is on a nightly sweep
+ * back to zero, so the duplicated payment and its duplicated sweep cancelled
+ * out: the balance stayed correct while the register showed everything twice.
+ * A balance check would not have found it, and did not.
+ *
+ * The fixtures below are invented, but they keep the shape that matters: the
+ * same money on the same day, described differently on the two sides.
+ */
+import { describe, it, expect, beforeEach } from 'vitest';
+import { ofxImportService } from '../ofxImportService';
+import { smartCategorizationService } from '../smartCategorizationService';
+import type { Account, Category, Transaction } from '../../types';
+
+const ACCOUNT_ID = 'acc-current';
+
+const accounts: Account[] = [
+  {
+    id: ACCOUNT_ID,
+    name: 'Everyday Current',
+    type: 'current',
+    balance: 0,
+    currency: 'GBP',
+    lastUpdated: new Date('2027-02-28')
+  }
+];
+
+/** One <STMTTRN>, written the way a UK bank's export writes them. */
+const stmtTrn = (
+  fitId: string,
+  day: string,
+  amount: string,
+  name: string,
+  type: string = amount.startsWith('-') ? 'DEBIT' : 'CREDIT'
+): string => `<STMTTRN>
+<TRNTYPE>${type}
+<DTPOSTED>${day}120000[0:GMT]
+<TRNAMT>${amount}
+<FITID>${fitId}
+<NAME>${name}
+</STMTTRN>`;
+
+const ofxFile = (transactions: string[]): string => `OFXHEADER:100
+DATA:OFXSGML
+VERSION:102
+
+<OFX>
+<BANKMSGSRSV1>
+<STMTTRNRS>
+<STMTRS>
+<CURDEF>GBP
+<BANKACCTFROM>
+<BANKID>123456
+<ACCTID>12345678
+<ACCTTYPE>CHECKING
+</BANKACCTFROM>
+<BANKTRANLIST>
+<DTSTART>20270201000000[0:GMT]
+<DTEND>20270228235959[0:GMT]
+${transactions.join('\n')}
+</BANKTRANLIST>
+<LEDGERBAL>
+<BALAMT>0.00
+<DTASOF>20270228235959[0:GMT]
+</LEDGERBAL>
+</STMTRS>
+</STMTTRNRS>
+</BANKMSGSRSV1>
+</OFX>`;
+
+/**
+ * Left column is what the register already held — truncated by whatever
+ * imported it, or renamed by hand ("Nadia"). Right column is what the same
+ * transaction is called in the OFX file.
+ */
+const PAIRS = [
+  { fitId: '20270207001', day: '20270207', amount: '9876.54', held: 'Sweep Transfer from account 5566', file: 'Sweep Transfer from account 55667788' },
+  { fitId: '20270207002', day: '20270207', amount: '-63.20', held: 'Direct Debit - STREAMCO', file: 'Direct Debit - STREAMCO  00110022330044' },
+  { fitId: '20270207003', day: '20270207', amount: '-2500.00', held: 'SAMPLE PERSON A', file: 'Standing Order to MISS A SAMPLE - A SAMPLE' },
+  { fitId: '20270207004', day: '20270207', amount: '-410.00', held: 'Nadia', file: 'Immediate Faster Payment (Online) to B EXAMPLE 07-FEB-2027' },
+  { fitId: '20270207005', day: '20270207', amount: '-77.45', held: 'Direct Debit - TELCO LTD  447', file: 'Direct Debit - TELCO LTD  447221900-00007' }
+];
+
+const STATEMENT = ofxFile(PAIRS.map(pair => stmtTrn(pair.fitId, pair.day, pair.amount, pair.file)));
+
+/** The register as it stood before the re-import: every row already there. */
+const alreadyHeld: Transaction[] = PAIRS.map((pair, index) => ({
+  id: `held-${index}`,
+  date: new Date('2027-02-07'),
+  description: pair.held,
+  amount: Number(pair.amount),
+  type: pair.amount.startsWith('-') ? 'expense' : 'income',
+  accountId: ACCOUNT_ID,
+  category: 'general',
+  // Every pre-existing row was reconciled; every newly imported one was not.
+  cleared: true
+}));
+
+describe('OFX re-import of a period already held', () => {
+  it('recognises every row despite truncated and renamed descriptions', async () => {
+    const result = await ofxImportService.importTransactions(STATEMENT, accounts, alreadyHeld, {
+      accountId: ACCOUNT_ID
+    });
+
+    expect(result.duplicateMatches.possible).toHaveLength(5);
+    expect(result.duplicates).toBe(5);
+    expect(result.transactions).toHaveLength(0);
+    expect(result.newTransactions).toBe(0);
+
+    // Each one paired with the right held row, not merely "something".
+    expect(result.duplicateMatches.possible.map(match => match.heldDescription)).toEqual(
+      PAIRS.map(pair => pair.held)
+    );
+  });
+
+  it('offers them for review rather than deciding alone', async () => {
+    const result = await ofxImportService.importTransactions(STATEMENT, accounts, alreadyHeld, {
+      accountId: ACCOUNT_ID
+    });
+
+    // Nothing here is proof — the bank's own id is on one side only — so every
+    // match is reviewable, carries both descriptions and says how far apart the
+    // two dates are. That is what the preview list is built from.
+    expect(result.duplicateMatches.certain).toHaveLength(0);
+    expect(result.duplicateMatches.possible).toHaveLength(5);
+    for (const match of result.duplicateMatches.possible) {
+      expect(match.basis).toBe('amount-and-date');
+      expect(match.dayGap).toBe(0);
+      expect(match.heldCleared).toBe(true);
+      expect(match.fitId).not.toBeNull();
+    }
+  });
+
+  it('imports the ones the user overrules, and only those', async () => {
+    const result = await ofxImportService.importTransactions(STATEMENT, accounts, alreadyHeld, {
+      accountId: ACCOUNT_ID,
+      importAnywayFitIds: ['20270207004']
+    });
+
+    expect(result.transactions).toHaveLength(1);
+    expect(result.transactions[0].description).toBe(
+      'Immediate Faster Payment (Online) to B EXAMPLE 07-FEB-2027'
+    );
+    expect(result.duplicates).toBe(4);
+  });
+
+  it('imports nothing twice when the user turns the check off — but says what it saw', async () => {
+    const result = await ofxImportService.importTransactions(STATEMENT, accounts, alreadyHeld, {
+      accountId: ACCOUNT_ID,
+      skipDuplicates: false
+    });
+
+    expect(result.transactions).toHaveLength(5);
+    expect(result.duplicates).toBe(0);
+    // Turning the check off decides what to DO, not what is true: the caller
+    // still gets the finding, so the screen can still say it.
+    expect(result.duplicateMatches.possible).toHaveLength(5);
+  });
+
+  it('adds a second, genuinely separate payment of the same amount on the same day', async () => {
+    // Two £20 withdrawals on one day. The register holds one; the statement
+    // carries both. Dropping both would lose real spending.
+    const file = ofxFile([
+      stmtTrn('20270210001', '20270210', '-20.00', 'CASH ATM HIGH ST'),
+      stmtTrn('20270210002', '20270210', '-20.00', 'CASH ATM HIGH ST')
+    ]);
+    const register: Transaction[] = [{
+      id: 'one-withdrawal',
+      date: new Date('2027-02-10'),
+      description: 'Cash',
+      amount: -20,
+      type: 'expense',
+      accountId: ACCOUNT_ID,
+      category: 'general',
+      cleared: true
+    }];
+
+    const result = await ofxImportService.importTransactions(file, accounts, register, {
+      accountId: ACCOUNT_ID
+    });
+
+    expect(result.duplicateMatches.possible).toHaveLength(1);
+    expect(result.transactions).toHaveLength(1);
+  });
+
+  it('will not let an override undo a FITID match', async () => {
+    // The bank saying "this is the same transaction" is not a judgement call,
+    // and the review list never shows these — so an id arriving here could only
+    // be stale, and acting on it would re-import a proven duplicate.
+    const file = ofxFile([stmtTrn('20270207002', '20270207', '-63.20', 'Direct Debit - STREAMCO  00110022330044')]);
+    const register: Transaction[] = [{
+      id: 'streamco',
+      date: new Date('2027-02-07'),
+      description: 'Streamco',
+      amount: -63.2,
+      type: 'expense',
+      accountId: ACCOUNT_ID,
+      category: 'general',
+      cleared: true,
+      notes: 'FITID: 20270207002'
+    }];
+
+    const result = await ofxImportService.importTransactions(file, accounts, register, {
+      accountId: ACCOUNT_ID,
+      importAnywayFitIds: ['20270207002']
+    });
+
+    expect(result.duplicateMatches.certain).toHaveLength(1);
+    expect(result.transactions).toHaveLength(0);
+  });
+
+  it('compares the destination account only', async () => {
+    const elsewhere: Transaction[] = alreadyHeld.map(row => ({ ...row, accountId: 'acc-savings' }));
+
+    const result = await ofxImportService.importTransactions(STATEMENT, accounts, elsewhere, {
+      accountId: ACCOUNT_ID
+    });
+
+    expect(result.duplicateMatches.possible).toHaveLength(0);
+    expect(result.transactions).toHaveLength(5);
+  });
+});
+
+describe('OFX auto-categorisation', () => {
+  const categories: Category[] = [
+    { id: 'tofrom-current', name: 'To/From Everyday Current', type: 'both', level: 'detail', isTransferCategory: true, accountId: ACCOUNT_ID },
+    { id: 'tofrom-savings', name: 'To/From Savings', type: 'both', level: 'detail', isTransferCategory: true, accountId: 'acc-savings' },
+    { id: 'groceries', name: 'Groceries', type: 'expense', level: 'detail' }
+  ];
+
+  /**
+   * What the account's own history looks like: the nightly sweep is a real
+   * transfer, correctly filed under the account's own To/From category. Its
+   * description begins with the same three words as every other faster payment
+   * on the statement — which is exactly the key the categoriser learns.
+   */
+  const sweepHistory: Transaction[] = Array.from({ length: 6 }, (_, index) => ({
+    id: `sweep-${index}`,
+    date: new Date(2027, 0, index + 1),
+    description: `Immediate Faster Payment (Online) to OWN SAVINGS 0${index}-JAN-2027`,
+    amount: -500,
+    type: 'transfer',
+    accountId: ACCOUNT_ID,
+    category: 'tofrom-current',
+    cleared: true
+  }));
+
+  beforeEach(() => {
+    smartCategorizationService.learnFromTransactions(sweepHistory, categories);
+  });
+
+  it('never files a payment as a transfer to the account it is already in', async () => {
+    const file = ofxFile([
+      stmtTrn('20270207004', '20270207', '-410.00', 'Immediate Faster Payment (Online) to B EXAMPLE 07-FEB-2027')
+    ]);
+
+    // The suggestion the guard exists to refuse is real, and confident enough
+    // to have been applied: this is the machinery that filed ordinary
+    // third-party payments as transfers to the payer's own account.
+    const suggestion = smartCategorizationService.suggestCategories({
+      id: 'draft',
+      date: new Date('2027-02-07'),
+      description: 'Immediate Faster Payment (Online) to B EXAMPLE 07-FEB-2027',
+      amount: -410,
+      type: 'expense',
+      accountId: ACCOUNT_ID,
+      category: ''
+    }, 1);
+    expect(suggestion[0].categoryId).toBe('tofrom-current');
+    expect(suggestion[0].confidence).toBeGreaterThanOrEqual(0.7);
+
+    const result = await ofxImportService.importTransactions(file, accounts, sweepHistory, {
+      accountId: ACCOUNT_ID,
+      categories,
+      autoCategorize: true
+    });
+
+    expect(result.transactions).toHaveLength(1);
+    expect(result.transactions[0].category).toBe('');
+  });
+
+  it('still applies a suggestion that means something', async () => {
+    const groceryHistory: Transaction[] = Array.from({ length: 4 }, (_, index) => ({
+      id: `shop-${index}`,
+      date: new Date(2027, 0, index + 1),
+      description: 'CARD PURCHASE MARKET STORES',
+      amount: -40,
+      type: 'expense',
+      accountId: ACCOUNT_ID,
+      category: 'groceries',
+      cleared: true
+    }));
+    const file = ofxFile([stmtTrn('20270208001', '20270208', '-38.20', 'CARD PURCHASE MARKET STORES')]);
+
+    const result = await ofxImportService.importTransactions(file, accounts, groceryHistory, {
+      accountId: ACCOUNT_ID,
+      categories,
+      autoCategorize: true
+    });
+
+    expect(result.transactions[0].category).toBe('groceries');
+  });
+
+  it('leaves the OTHER account\'s transfer category alone', async () => {
+    // Only "a transfer to the account this row is already in" is meaningless.
+    // A genuine transfer out to Savings is exactly what a To/From category is
+    // for, and the guard must not reach it.
+    const savingsHistory: Transaction[] = Array.from({ length: 4 }, (_, index) => ({
+      id: `to-savings-${index}`,
+      date: new Date(2027, 0, index + 1),
+      description: 'STANDING ORDER SAVINGS POT',
+      amount: -250,
+      type: 'transfer',
+      accountId: ACCOUNT_ID,
+      category: 'tofrom-savings',
+      cleared: true
+    }));
+    const file = ofxFile([stmtTrn('20270209001', '20270209', '-250.00', 'STANDING ORDER SAVINGS POT')]);
+
+    const result = await ofxImportService.importTransactions(file, accounts, savingsHistory, {
+      accountId: ACCOUNT_ID,
+      categories,
+      autoCategorize: true
+    });
+
+    expect(result.transactions[0].category).toBe('tofrom-savings');
+  });
+});

--- a/src/services/__tests__/transactionService.test.ts
+++ b/src/services/__tests__/transactionService.test.ts
@@ -220,6 +220,110 @@ describe('TransactionService (deterministic fallback)', () => {
       for (const dropped of ['metadata', 'plaid_transaction_id', 'merchant_name', 'location_city', 'import_source']) {
         expect(cols).not.toContain(dropped);
       }
+      // The bank's own intra-day order. Without it the register cannot walk a
+      // day the way the statement prints it — see compareChronological.
+      expect(cols).toContain('statement_sequence');
+    });
+
+    /**
+     * A database that predates 20260808090000_transaction_statement_sequence.
+     *
+     * PostgREST rejects an EXPLICIT select naming a column that does not exist,
+     * so this is not a degraded register, it is a boot that returns no
+     * transactions at all. The owner applies migrations himself, so the deploy
+     * can legitimately reach a database that has not had it yet.
+     */
+    const makeClientWithoutSequenceColumn = (rows: Record<string, unknown>[]) => {
+      const selectArgs: { cols: unknown; opts: unknown }[] = [];
+      const from = vi.fn(() => {
+        const builder: Record<string, unknown> = {};
+        let isCount = false;
+        let asked = '';
+        let range: [number, number] | null = null;
+        builder.select = vi.fn((cols: unknown, opts: unknown) => {
+          selectArgs.push({ cols, opts });
+          asked = typeof cols === 'string' ? cols : '';
+          isCount = Boolean(opts && (opts as { head?: boolean }).head);
+          return builder;
+        });
+        builder.eq = vi.fn(() => builder);
+        builder.order = vi.fn(() => builder);
+        builder.range = vi.fn((from_: number, to: number) => {
+          range = [from_, to];
+          return builder;
+        });
+        builder.then = (resolve: (value: unknown) => unknown) => {
+          if (isCount) return resolve({ count: rows.length, error: null });
+          if (asked.includes('statement_sequence')) {
+            return resolve({
+              data: null,
+              error: {
+                code: '42703',
+                message: 'column transactions.statement_sequence does not exist'
+              }
+            });
+          }
+          const [f, t] = range ?? [0, rows.length - 1];
+          return resolve({ data: rows.slice(f, t + 1), error: null });
+        };
+        return builder;
+      });
+      return { client: { from }, selectArgs };
+    };
+
+    it('still loads every transaction when the statement-sequence migration has not been applied', async () => {
+      const { client, selectArgs } = makeClientWithoutSequenceColumn([
+        { id: 'db-1', account_id: 'acct-1', amount: 10, type: 'expense', date: '2025-04-01', is_cleared: true },
+        { id: 'db-2', account_id: 'acct-1', amount: -5, type: 'expense', date: '2025-04-02', is_cleared: false }
+      ]);
+      const service = createTransactionService({
+        isSupabaseConfigured: () => true,
+        storageAdapter: createStorage(),
+        logger,
+        now,
+        uuid,
+        supabaseClient: client as unknown as never
+      });
+
+      const transactions = await service.getTransactions('user-1');
+
+      // An unordered register is a shortfall; no register at all is an outage.
+      expect(transactions.map(t => t.id)).toEqual(['db-1', 'db-2']);
+
+      const pageSelects = selectArgs
+        .filter(a => !(a.opts as { head?: boolean } | undefined)?.head)
+        .map(a => String(a.cols));
+      // Asked with the column, was refused, asked again without it.
+      expect(pageSelects[0]).toContain('statement_sequence');
+      expect(pageSelects[1]).not.toContain('statement_sequence');
+      // …and every column that was already being read survives the fallback.
+      expect(pageSelects[1]).toContain('notes');
+      expect(pageSelects[1]).toContain('tags');
+      expect(pageSelects[1]).toContain('is_cleared');
+    });
+
+    it('does not re-ask for the missing column on every page of a boot', async () => {
+      const { client, selectArgs } = makeClientWithoutSequenceColumn([
+        { id: 'db-1', account_id: 'acct-1', amount: 10, type: 'expense', date: '2025-04-01' }
+      ]);
+      const service = createTransactionService({
+        isSupabaseConfigured: () => true,
+        storageAdapter: createStorage(),
+        logger,
+        now,
+        uuid,
+        supabaseClient: client as unknown as never
+      });
+
+      await service.getTransactions('user-1');
+      await service.getTransactions('user-1');
+
+      // One discovery for the life of the service, not one per page — a 50-page
+      // history would otherwise pay for the same refusal fifty times.
+      const refused = selectArgs.filter(
+        a => !(a.opts as { head?: boolean } | undefined)?.head && String(a.cols).includes('statement_sequence')
+      );
+      expect(refused).toHaveLength(1);
     });
   });
 

--- a/src/services/api/transactionService.ts
+++ b/src/services/api/transactionService.ts
@@ -135,6 +135,7 @@ const CAMEL_TO_DB: Record<string, string> = {
   goalId: 'goal_id',
   accountName: 'account_name',
   categoryName: 'category_name',
+  statementSequence: 'statement_sequence',
   createdAt: 'created_at',
   updatedAt: 'updated_at',
   recurringTransactionId: 'recurring_transaction_id',
@@ -175,7 +176,29 @@ const DB_TO_CAMEL: Record<string, string> = Object.fromEntries(
  * parser — a widened `string` (which `+` concatenation or `[].join` produces)
  * degrades the result to an untyped error type.
  */
-const BOOT_TRANSACTION_COLUMNS = 'id,account_id,amount,archived,category,category_id,created_at,date,description,is_cleared,is_recurring,is_split,linked_transfer_id,linked_transfer_split_id,notes,tags,type,updated_at,transfer_account_id' as const;
+const BOOT_TRANSACTION_COLUMNS = 'id,account_id,amount,archived,category,category_id,created_at,date,description,is_cleared,is_recurring,is_split,linked_transfer_id,linked_transfer_split_id,notes,statement_sequence,tags,type,updated_at,transfer_account_id' as const;
+
+/**
+ * The same list without `statement_sequence`, for a database that has not had
+ * 20260808090000_transaction_statement_sequence.sql applied yet.
+ *
+ * WHY THIS EXISTS. The list above is an EXPLICIT select, and PostgREST fails the
+ * whole query on an unknown column — so shipping the column in it before the
+ * migration lands would not degrade the register's ordering, it would stop the
+ * app loading a single transaction. The owner applies migrations himself, so
+ * "deploy after the migration" is an ordering this code cannot enforce and must
+ * not depend on. Falling back makes the deploy safe in either order, and the
+ * feature light up by itself the moment the migration is applied — no second
+ * release to remember.
+ */
+const BOOT_TRANSACTION_COLUMNS_LEGACY = 'id,account_id,amount,archived,category,category_id,created_at,date,description,is_cleared,is_recurring,is_split,linked_transfer_id,linked_transfer_split_id,notes,tags,type,updated_at,transfer_account_id' as const;
+
+/**
+ * Postgres `undefined_column`. Matched on the CODE, never on the message: the
+ * code is part of the documented wire contract and the message is English prose
+ * that has changed between releases.
+ */
+const UNDEFINED_COLUMN = '42703';
 
 /**
  * One PostgREST row → the camelCase shape a Transaction claims.
@@ -255,6 +278,12 @@ class TransactionServiceImpl {
   private readonly fetchImpl: FetchLike | null;
   private readonly authTokenProvider: AuthTokenProvider | null;
   private readonly cache: TransactionCacheLike;
+  /**
+   * Set once, on the first page that comes back 42703, when this database
+   * predates 20260808090000_transaction_statement_sequence.sql. Per instance
+   * rather than per call so a 50-page boot pays for the discovery once.
+   */
+  private statementSequenceMissing = false;
 
   constructor(options: TransactionServiceOptions = {}) {
     this.cache = options.transactionCache ?? transactionCache;
@@ -343,6 +372,30 @@ class TransactionServiceImpl {
     since?: string
   ): Promise<Record<string, unknown>[]> {
     const client = this.supabaseClient!;
+    const to = from + PAGE_SIZE - 1;
+
+    // The two select lists are written out in full rather than passed as a
+    // parameter, because supabase-js parses the select list AT THE TYPE LEVEL
+    // and only a single string literal engages that parser — a union of two
+    // literals degrades the whole result to an error type (the same reason the
+    // constants are `as const` and never concatenated).
+    if (this.statementSequenceMissing) {
+      const legacyBase = client
+        .from('transactions')
+        .select(BOOT_TRANSACTION_COLUMNS_LEGACY)
+        .eq('user_id', userId);
+      const legacyScoped = since ? legacyBase.gte('updated_at', since) : legacyBase;
+      const { data, error } = await legacyScoped
+        .order('date', { ascending: false })
+        .order('id', { ascending: false }) // stable tiebreak for paging
+        .range(from, to);
+      if (error) {
+        this.logger.error('Error fetching transactions:', error);
+        throw new Error(handleSupabaseError(error));
+      }
+      return (data || []) as Record<string, unknown>[];
+    }
+
     const base = client
       .from('transactions')
       .select(BOOT_TRANSACTION_COLUMNS)
@@ -351,8 +404,17 @@ class TransactionServiceImpl {
     const { data, error } = await scoped
       .order('date', { ascending: false })
       .order('id', { ascending: false }) // stable tiebreak for paging
-      .range(from, from + PAGE_SIZE - 1);
+      .range(from, to);
+
     if (error) {
+      // This database predates the statement-sequence migration. Remember it
+      // (so the other 50 pages of a boot do not each pay for the discovery) and
+      // fetch again without the column: a register that cannot order a day the
+      // bank's way is a shortfall, no register at all is an outage.
+      if (error.code === UNDEFINED_COLUMN) {
+        this.statementSequenceMissing = true;
+        return this.fetchTransactionPage(userId, from, since);
+      }
       this.logger.error('Error fetching transactions:', error);
       throw new Error(handleSupabaseError(error));
     }

--- a/src/services/backupService.test.ts
+++ b/src/services/backupService.test.ts
@@ -756,6 +756,79 @@ describe('remapBackupIds', () => {
     expect(danglingRefs).toEqual([]);
   });
 
+  it("rewrites a goal's linked accounts, which live inside the metadata jsonb", () => {
+    // goals has no column for them, so planningService.goalToDb parks them in
+    // metadata. Left alone, a restored goal still names the accounts of the
+    // login the file came from — and nothing constrains a jsonb key, so it
+    // fails silently.
+    const source = buildBackupBundle({
+      sourceUserId: uid('0', 1),
+      exportedAt: '2026-08-07T09:30:00.000Z',
+      data: {
+        accounts: [
+          { id: A_CURRENT, name: 'Current', balance: 0 },
+          { id: A_SAVINGS, name: 'Savings', balance: 0 },
+        ],
+        goals: [{
+          id: uid('9', 1), name: 'Rainy day', target_amount: 5000,
+          metadata: {
+            type: 'savings',
+            linkedAccountIds: [A_CURRENT, A_SAVINGS],
+            // A user's own words, in the same object. They must come through
+            // exactly as written.
+            note: 'for the roof',
+          },
+        }],
+      },
+    });
+
+    const { bundle, idMap } = remapBackupIds(source, sequentialIds());
+    expect(bundle.data.goals[0].metadata).toEqual({
+      type: 'savings',
+      linkedAccountIds: [idMap.get(A_CURRENT), idMap.get(A_SAVINGS)],
+      note: 'for the roof',
+    });
+  });
+
+  it('rewrites a text id that is not shaped like a uuid', () => {
+    // A signed-out user's categories are seeded with text ids
+    // ('type-income', 'transfer-in' — data/defaultCategories), and the cloud
+    // only mints uuids for them on first sign-in. Judging a reference by its
+    // SHAPE left categories[].id remapped and transactions.category not, so a
+    // restore of that dataset came back entirely uncategorised.
+    const source = buildBackupBundle({
+      sourceUserId: uid('0', 1),
+      exportedAt: '2026-08-07T09:30:00.000Z',
+      data: {
+        accounts: [{ id: A_CURRENT, name: 'Current', balance: 0 }],
+        categories: [{ id: 'type-expense', name: 'Expenses', level: 'type' }],
+        transactions: [{
+          id: T_SHOP, account_id: A_CURRENT, date: '2021-06-06', amount: -80,
+          category: 'type-expense',
+        }],
+      },
+    });
+
+    const { bundle, idMap, danglingRefs } = remapBackupIds(source, sequentialIds());
+    expect(bundle.data.transactions[0].category).toBe(idMap.get('type-expense'));
+    expect(bundle.data.categories[0].id).toBe(idMap.get('type-expense'));
+    expect(danglingRefs).toEqual([]);
+  });
+
+  it('still leaves a free-text label alone and does not report it', () => {
+    // The other half of the same judgement: goals.category holds a word a
+    // person typed. It names no row, and there is nothing wrong with that.
+    const source = buildBackupBundle({
+      sourceUserId: uid('0', 1),
+      exportedAt: '2026-08-07T09:30:00.000Z',
+      data: { goals: [{ id: uid('9', 1), name: 'Trip', category: 'Holiday' }] },
+    });
+
+    const { bundle, danglingRefs } = remapBackupIds(source, sequentialIds());
+    expect(bundle.data.goals[0].category).toBe('Holiday');
+    expect(danglingRefs).toEqual([]);
+  });
+
   it('leaves an unresolvable reference alone and counts it', () => {
     // A category that never made it into the file. Blanking it would destroy
     // the only record of where the row was filed; the honest move is to leave

--- a/src/services/backupService.ts
+++ b/src/services/backupService.ts
@@ -611,8 +611,14 @@ export function transactionDateRange(bundle: BackupBundle): { first: string; las
  *  • `accounts.plaid_connection_id` and `transactions.connection_id` — they
  *    point at bank_connections, which a backup deliberately does not carry, and
  *    the RPC strips both before inserting.
- *  • the jsonb columns (`metadata`, `widgets`, `settings`) — nothing in the app
- *    writes a row id into any of them; they hold layout and display settings.
+ *  • the jsonb `widgets` and `settings` — they hold layout and display choices,
+ *    and nothing writes a row id into either.
+ *
+ * `metadata` used to be on that list, and it should not have been:
+ * planningService.goalToDb parks `linkedAccountIds` there, because goals has no
+ * column for them. So a goal's linked accounts survived a restore still naming
+ * the accounts of the login the file came from — wrong on both storage engines,
+ * and invisible because nothing constrains a jsonb key. See `metadataIdArrays`.
  */
 interface EntityReferences {
   /** Columns typed uuid whose value is another backed-up row's id. */
@@ -620,14 +626,32 @@ interface EntityReferences {
   /**
    * TEXT columns that hold a row id.
    *
-   * These are gated on the value LOOKING like a uuid, because the same column is
-   * free text in some rows: `goals.category` holds a label a person typed, while
-   * `transactions.category` holds a category's uuid. A label is not a reference
-   * and must not be counted as a dangling one.
+   * The same column is free text in some rows — `goals.category` holds a label
+   * a person typed, `transactions.category` holds a category's id — so the two
+   * have to be told apart. That is done by asking whether the value NAMES A ROW
+   * THE FILE CONTAINS, not by asking whether it looks like a uuid.
+   *
+   * The uuid test was the first answer and it was wrong for exactly one dataset,
+   * which happens to be the one this file's local half reads: a signed-out user's
+   * categories are seeded with text ids ('type-income', 'transfer-in' — see
+   * data/defaultCategories), because the cloud's uuid ids are minted per user by
+   * migrate_categories_atomic on first sign-in. Remapping categories[].id while
+   * skipping every transactions.category that pointed at one left the whole
+   * dataset uncategorised, silently, since nothing constrains that column.
+   * Membership of the id map is exact where a shape test could only guess.
    */
   readonly textId?: readonly string[];
   /** uuid[] columns where every element is a row id. */
   readonly uuidArray?: readonly string[];
+  /**
+   * Keys INSIDE the `metadata` jsonb holding an array of row ids.
+   *
+   * Only one exists — goals.metadata.linkedAccountIds — and it exists because
+   * goals has no column for it. Handled by key rather than by sweeping the
+   * whole jsonb: metadata also carries a user's own free text, and rewriting
+   * anything there that happened to match an id would corrupt it.
+   */
+  readonly metadataIdArrays?: readonly string[];
 }
 
 const ENTITY_REFERENCES: Readonly<Record<BackupEntity, EntityReferences>> = {
@@ -646,7 +670,7 @@ const ENTITY_REFERENCES: Readonly<Record<BackupEntity, EntityReferences>> = {
     textId: ['category'],
   },
   budgets: { uuid: ['category_id'], textId: ['category'] },
-  goals: { uuid: ['account_id'], textId: ['category'] },
+  goals: { uuid: ['account_id'], textId: ['category'], metadataIdArrays: ['linkedAccountIds'] },
   goal_contributions: { uuid: ['goal_id', 'transaction_id'] },
   investments: { uuid: ['account_id'] },
   investment_transactions: { uuid: ['investment_id'] },
@@ -720,20 +744,21 @@ function remapDismissalKey(
     const colon = segment.indexOf(':');
     const prefix = colon >= 0 ? segment.slice(0, colon + 1) : '';
     const value = colon >= 0 ? segment.slice(colon + 1) : segment;
-    // A segment that is not a uuid is a kind tag like "duplicate" or "claimed".
-    if (!UUID_PATTERN.test(value)) return segment;
     const replacement = lookup(value);
-    if (replacement === undefined) {
-      onDangling(value);
-      return segment;
-    }
-    return prefix + replacement;
+    if (replacement !== undefined) return prefix + replacement;
+    // Named no row in the file. Uuid-shaped, it should have been one; otherwise
+    // it is a kind tag like "duplicate" or "claimed" and belongs as it is.
+    if (UUID_PATTERN.test(value)) onDangling(value);
+    return segment;
   });
 
-  // Positions that held a BARE uuid — the ones canonicalSubjectKey sorted.
+  // Positions that held a BARE id — the ones canonicalSubjectKey sorted. Same
+  // discriminator as above: a row the file contains, or something uuid-shaped
+  // that was meant to be one. A kind tag is neither.
   const barePositions: number[] = [];
   segments.forEach((segment, index) => {
-    if (UUID_PATTERN.test(segment)) barePositions.push(index);
+    if (segment.includes(':')) return;
+    if (lookup(segment) !== undefined || UUID_PATTERN.test(segment)) barePositions.push(index);
   });
 
   const wasSorted = barePositions.every(
@@ -800,11 +825,16 @@ export function remapBackupIds(
 
       for (const field of spec.textId ?? []) {
         const value = readString(row, field);
-        // Not uuid-shaped means it is a label, not a reference to anything.
-        if (!value || !UUID_PATTERN.test(value)) continue;
+        if (!value) continue;
         const replacement = lookup(value);
-        if (replacement === undefined) note(field, value);
-        else next[field] = replacement;
+        if (replacement !== undefined) {
+          next[field] = replacement;
+          continue;
+        }
+        // It named no row in the file. Uuid-shaped, it was meant to be one and
+        // the user should hear about it; otherwise it is a label like "Holiday"
+        // and there is nothing wrong with it.
+        if (UUID_PATTERN.test(value)) note(field, value);
       }
 
       for (const field of spec.uuidArray ?? []) {
@@ -819,6 +849,28 @@ export function remapBackupIds(
           }
           return replacement;
         });
+      }
+
+      // The one jsonb column carrying references. Rewritten key by key, and
+      // only for the keys named in the spec, so everything else the user has
+      // in metadata travels through untouched.
+      const metadataKeys = spec.metadataIdArrays ?? [];
+      if (metadataKeys.length > 0 && isPlainObject(row.metadata)) {
+        const metadata: Record<string, unknown> = { ...row.metadata };
+        for (const key of metadataKeys) {
+          const value = metadata[key];
+          if (!Array.isArray(value)) continue;
+          metadata[key] = value.map((element) => {
+            if (typeof element !== 'string') return element;
+            const replacement = lookup(element);
+            if (replacement === undefined) {
+              note(`metadata.${key}`, element);
+              return element;
+            }
+            return replacement;
+          });
+        }
+        next.metadata = metadata;
       }
 
       if (entity === 'suggestion_dismissals') {

--- a/src/services/encryptedStorageService.ts
+++ b/src/services/encryptedStorageService.ts
@@ -123,8 +123,9 @@ export class EncryptedStorageService {
     }
   }
 
-  // Encrypt data
-  private encrypt(data: JsonValue): string {
+  // Encrypt data. Takes `unknown` because that is what JSON.stringify takes —
+  // narrowing it to JsonValue only forced every caller to cast back.
+  private encrypt(data: unknown): string {
     const jsonString = JSON.stringify(data);
     return CryptoJS.AES.encrypt(jsonString, this.encryptionKey).toString();
   }
@@ -160,7 +161,7 @@ export class EncryptedStorageService {
     // Encrypt if requested (values are otherwise stored as-is — see the
     // legacy note on decompress()).
     if (encrypted) {
-      processedData = this.encrypt(value as JsonValue);
+      processedData = this.encrypt(value);
     }
 
     const now = this.nowProvider();
@@ -264,8 +265,20 @@ export class EncryptedStorageService {
     return await indexedDBService.getAllKeys(this.storeName);
   }
 
-  // Bulk operations for better performance
-  async setItems<T extends JsonValue = JsonValue>(items: Array<StorageItem<T>>): Promise<void> {
+  /**
+   * Write several entries in ONE IndexedDB transaction.
+   *
+   * That is the property callers depend on, not just the speed: putBulk opens a
+   * single readwrite transaction, so a failure on any entry aborts the lot and
+   * storage is left exactly as it was. A restore is written through here for
+   * precisely that reason — a per-key loop could leave a user with half of one
+   * dataset and half of another.
+   *
+   * `T` is unconstrained (rather than `extends JsonValue`) so the app's own
+   * row types can be written without a cast; `encrypt` and structured clone
+   * both take anything JSON can carry.
+   */
+  async setItems<T = JsonValue>(items: Array<StorageItem<T>>): Promise<void> {
     const processedItems = await Promise.all(
       items.map(async ({ key, value, options }) => {
         const { encrypted = true, expiryDays } = options || {};
@@ -288,7 +301,8 @@ export class EncryptedStorageService {
           storedData.expiry = now + expiryDays * 24 * 60 * 60 * 1000;
         }
 
-        return { key, value: storedData } as BulkStorageItem;
+        const item: BulkStorageItem = { key, value: storedData };
+        return item;
       })
     );
 
@@ -364,7 +378,7 @@ export class EncryptedStorageService {
   }
 
   // Import data (from backup)
-  async importData(data: ExportedData, options: StorageOptions = {}): Promise<void> {
+  async importData<T = JsonValue>(data: Record<string, T>, options: StorageOptions = {}): Promise<void> {
     const items = Object.entries(data).map(([key, value]) => ({
       key,
       value,

--- a/src/services/import/msMoney/msMoneyImport.test.ts
+++ b/src/services/import/msMoney/msMoneyImport.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import {
-  planCloudImport, importToLocalStorage, wipeLocalData, executeCloudPlan,
+  planCloudImport, importToLocalStorage, executeCloudPlan,
   MS_MONEY_IMPORT_SOURCE, IMPORT_PROVENANCE_CONFLICT, IMPORT_BATCH_SIZE,
   isRetryableWriteStatus,
   type ExistingCategoryRow, type ExistingAccountRow, type CloudPlan,
@@ -745,14 +745,12 @@ describe('planCloudImport — opening balances on reused accounts', () => {
   });
 });
 
-describe('wipeLocalData', () => {
-  it('empties every financial collection', () => {
-    const KEYS = { ACCOUNTS: 'a', TRANSACTIONS: 't', CATEGORIES: 'c', TRANSACTION_SPLITS: 's', BUDGETS: 'b', GOALS: 'g', RECURRING: 'r' };
-    for (const k of Object.values(KEYS)) window.localStorage.setItem(k, '[{"id":"x"}]');
-    wipeLocalData(KEYS);
-    for (const k of Object.values(KEYS)) expect(window.localStorage.getItem(k)).toBe('[]');
-  });
-});
+// `wipeLocalData` and its test are gone. The test asserted that localStorage
+// held '[]' afterwards, which was true and irrelevant — the app reads from
+// encrypted IndexedDB, so the function cleared nothing anybody looks at and the
+// test proved it cleared the wrong place. Its replacement,
+// wipeLocalFinancialData, is covered in localBackupService.test.ts against real
+// storage.
 
 describe('importToLocalStorage', () => {
   const KEYS = { ACCOUNTS: 'a', TRANSACTIONS: 't', CATEGORIES: 'c', TRANSACTION_SPLITS: 's', BUDGETS: 'b', GOALS: 'g', RECURRING: 'r' };

--- a/src/services/import/msMoney/msMoneyImport.ts
+++ b/src/services/import/msMoney/msMoneyImport.ts
@@ -908,14 +908,12 @@ export async function wipeCloudData(supabase: SupabaseClient, userId: string): P
   }
 }
 
-/** The local-mode equivalent: empty every financial collection. */
-export function wipeLocalData(
-  storageKeys: { ACCOUNTS: string; TRANSACTIONS: string; CATEGORIES: string; TRANSACTION_SPLITS: string; BUDGETS: string; GOALS: string; RECURRING: string }
-): void {
-  for (const key of Object.values(storageKeys)) {
-    window.localStorage.setItem(key, '[]');
-  }
-}
+// The local-mode equivalent used to live here as `wipeLocalData`, and it did
+// not work: it wrote '[]' into window.localStorage while every reader in the
+// app goes through storageAdapter → encryptedStorage → IndexedDB. It cleared
+// keys nothing reads, so "Clear All Data" reported success and changed nothing.
+// Its test asserted on localStorage and passed for the same reason. The working
+// one is wipeLocalFinancialData in services/localBackupService.
 
 /**
  * Execute the plan against Supabase under the authenticated client.

--- a/src/services/localBackupService.test.ts
+++ b/src/services/localBackupService.test.ts
@@ -1,0 +1,843 @@
+import 'fake-indexeddb/auto';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import {
+  LOCAL_BACKUP_BINDINGS,
+  LOCAL_BACKUP_STORAGE_KEYS,
+  LOCAL_WIPE_CONFIRMATION,
+  LocalRestoreRefusedError,
+  collectLocalBackupBundle,
+  localFinancialDataIsEmpty,
+  restoreLocalBackupBundle,
+  wipeLocalFinancialData,
+  type LocalBackupStore,
+} from './localBackupService';
+import {
+  BACKUP_ENTITIES,
+  BACKUP_FORMAT,
+  MAX_EXACT_MONEY,
+  validateBackupBundle,
+  type BackupBundle,
+} from './backupService';
+import { storageAdapter, STORAGE_KEYS } from './storageAdapter';
+import { canonicalSubjectKey } from '../utils/suggestionDismissals';
+import { toDecimal } from '../utils/decimal';
+
+/**
+ * These run against the REAL storage stack — storageAdapter → encryptedStorage
+ * → IndexedDB (fake-indexeddb) — not a stand-in for it. The bug this feature
+ * had to fix was precisely a mismatch between the layer that was written and
+ * the layer that is read, so a test that mocked storage would have passed
+ * against the broken code too. That is what the deleted wipeLocalData test did.
+ */
+
+// ── The dataset ─────────────────────────────────────────────────────────────
+//
+// Ids are deliberately in the LOCAL shapes, not uuids: a signed-out user's
+// categories are seeded with text ids ('type-income'), and demo accounts carry
+// hand-written ones. A test built on uuids would agree with the code about
+// something that is not true of the data.
+
+const ACCOUNT_CURRENT = 'demo-acc-current';
+const ACCOUNT_CASH = 'demo-acc-cash';
+const ACCOUNT_SAVINGS = 'demo-acc-savings';
+const CAT_TYPE = 'type-expense';
+const CAT_SUB = 'sub-food';
+const CAT_DETAIL = 'detail-groceries';
+const TXN_SHOP = 'txn-shop';
+const TXN_OUT = 'txn-transfer-out';
+const TXN_IN = 'txn-transfer-in';
+const TXN_SPLIT = 'txn-split-parent';
+const SPLIT_A = 'split-a';
+const SPLIT_B = 'split-b';
+
+const seedAccounts = (): Record<string, unknown>[] => [
+  {
+    id: ACCOUNT_CURRENT, name: 'Current', type: 'current', balance: 1234.56,
+    currency: 'GBP', institution: 'HSBC', isActive: true,
+    openingBalance: 1000, openingBalanceDate: '2020-01-01',
+    lastUpdated: '2026-08-01T09:00:00.000Z', createdAt: '2020-01-01T00:00:00.000Z',
+    parentAccountId: null, sortCode: '11-22-33', accountNumber: '12345678',
+    bankBalance: 1200.07, bankBalanceDate: '2026-07-31',
+    lowBalanceAlertEnabled: true, lowBalanceThreshold: 100,
+    // No column anywhere in the schema — the leftovers hatch is the only thing
+    // between these and permanent loss on a device that has no other copy.
+    creditLimit: 500, tags: ['everyday'],
+  },
+  {
+    id: ACCOUNT_CASH, name: 'Brokerage cash', type: 'current', balance: 250,
+    currency: 'GBP', isActive: true, lastUpdated: '2026-08-01T09:00:00.000Z',
+    parentAccountId: ACCOUNT_SAVINGS,
+  },
+  {
+    id: ACCOUNT_SAVINGS, name: 'Savings', type: 'savings', balance: -0.29,
+    currency: 'GBP', isActive: true, lastUpdated: '2026-08-01T09:00:00.000Z',
+    parentAccountId: null,
+  },
+];
+
+const seedCategories = (): Record<string, unknown>[] => [
+  { id: CAT_TYPE, name: 'Expenses', type: 'expense', level: 'type', parentId: null, isSystem: true, isActive: true },
+  { id: CAT_SUB, name: 'Food', type: 'expense', level: 'sub', parentId: CAT_TYPE, isActive: true },
+  { id: CAT_DETAIL, name: 'Groceries', type: 'expense', level: 'detail', parentId: CAT_SUB, isActive: true },
+  {
+    id: 'transfer-current', name: 'To/From Current', type: 'both', level: 'detail',
+    parentId: CAT_TYPE, isTransferCategory: true, accountId: ACCOUNT_CURRENT, isActive: true,
+  },
+];
+
+const seedTransactions = (): Record<string, unknown>[] => [
+  {
+    id: TXN_SHOP, date: '2026-07-04', amount: -12.34, description: 'Corner shop',
+    category: CAT_DETAIL, accountId: ACCOUNT_CURRENT, type: 'expense',
+    cleared: true, tags: ['weekly'], notes: 'milk',
+    createdAt: '2026-07-04T10:00:00.000Z', updatedAt: '2026-07-04T10:00:00.000Z',
+  },
+  {
+    id: TXN_OUT, date: '2026-07-05', amount: -200, description: 'To Savings',
+    category: 'transfer-current', accountId: ACCOUNT_CURRENT, type: 'transfer',
+    transferAccountId: ACCOUNT_SAVINGS, linkedTransferId: TXN_IN,
+  },
+  {
+    id: TXN_IN, date: '2026-07-05', amount: 200, description: 'From Current',
+    category: 'transfer-current', accountId: ACCOUNT_SAVINGS, type: 'transfer',
+    transferAccountId: ACCOUNT_CURRENT, linkedTransferId: TXN_OUT,
+  },
+  {
+    id: TXN_SPLIT, date: '2026-07-06', amount: -100, description: 'Supermarket',
+    category: CAT_SUB, accountId: ACCOUNT_CURRENT, type: 'expense', isSplit: true,
+  },
+];
+
+const seedSplits = (): Record<string, unknown>[] => [
+  { id: SPLIT_A, transactionId: TXN_SPLIT, category: CAT_DETAIL, amount: -60.07, sortOrder: 0, memo: 'food' },
+  {
+    id: SPLIT_B, transactionId: TXN_SPLIT, category: CAT_SUB, amount: -39.93, sortOrder: 1,
+    transferAccountId: ACCOUNT_CASH, linkedTransferId: TXN_IN,
+  },
+];
+
+const seedBudgets = (): Record<string, unknown>[] => [{
+  id: 'budget-food', categoryId: CAT_SUB, amount: 400, period: 'monthly', isActive: true,
+  name: 'Food', spent: 112.34, startDate: '2026-07-01', rollover: false, rolloverAmount: 0,
+  createdAt: '2026-07-01T00:00:00.000Z', updatedAt: '2026-07-01T00:00:00.000Z',
+}];
+
+const seedGoals = (): Record<string, unknown>[] => [{
+  id: 'goal-rainy-day', name: 'Rainy day', type: 'savings', targetAmount: 5000,
+  currentAmount: 250.01, progress: 250.01, targetDate: '2027-01-01', isActive: true,
+  achieved: false, status: 'active', accountId: ACCOUNT_SAVINGS,
+  linkedAccountIds: [ACCOUNT_CURRENT], category: 'Holiday', priority: 'high',
+  createdAt: '2026-01-01T00:00:00.000Z', updatedAt: '2026-07-01T00:00:00.000Z',
+}];
+
+const seedDismissals = (): Record<string, unknown>[] => [{
+  id: 'dismissal-1', kind: 'duplicate',
+  subjectKey: canonicalSubjectKey([TXN_SHOP, TXN_SPLIT]),
+  subjectIds: [TXN_SHOP, TXN_SPLIT],
+  dismissedAt: '2026-07-10T12:00:00.000Z',
+}];
+
+async function seedEverything(): Promise<void> {
+  await storageAdapter.set(STORAGE_KEYS.ACCOUNTS, seedAccounts());
+  await storageAdapter.set(STORAGE_KEYS.CATEGORIES, seedCategories());
+  await storageAdapter.set(STORAGE_KEYS.TRANSACTIONS, seedTransactions());
+  await storageAdapter.set(STORAGE_KEYS.TRANSACTION_SPLITS, seedSplits());
+  await storageAdapter.set(STORAGE_KEYS.BUDGETS, seedBudgets());
+  await storageAdapter.set(STORAGE_KEYS.GOALS, seedGoals());
+  await storageAdapter.set(STORAGE_KEYS.SUGGESTION_DISMISSALS, seedDismissals());
+}
+
+const read = async (key: string): Promise<Record<string, unknown>[]> =>
+  (await storageAdapter.get<Record<string, unknown>[]>(key)) ?? [];
+
+/** Counter-based ids, so a remap is legible in a failure message. */
+function countingIds(): () => string {
+  let next = 0;
+  return () => `new-${String(next++).padStart(3, '0')}`;
+}
+
+beforeEach(async () => {
+  await storageAdapter.clear();
+  window.localStorage.clear();
+});
+
+// ── The mapping ─────────────────────────────────────────────────────────────
+
+describe('LOCAL_BACKUP_BINDINGS', () => {
+  it('records a decision for every table the format carries', () => {
+    for (const entity of BACKUP_ENTITIES) {
+      expect(LOCAL_BACKUP_BINDINGS[entity]).toBeDefined();
+    }
+    expect(Object.keys(LOCAL_BACKUP_BINDINGS).sort()).toEqual([...BACKUP_ENTITIES].sort());
+  });
+
+  it('points every stored table at a real STORAGE_KEYS entry', () => {
+    const known = new Set<string>(Object.values(STORAGE_KEYS));
+    for (const entity of BACKUP_ENTITIES) {
+      const binding = LOCAL_BACKUP_BINDINGS[entity];
+      if (binding.stored) expect(known.has(binding.storageKey)).toBe(true);
+    }
+  });
+
+  it('gives every table this device cannot hold a reason a person can read', () => {
+    for (const entity of BACKUP_ENTITIES) {
+      const binding = LOCAL_BACKUP_BINDINGS[entity];
+      if (!binding.stored) expect(binding.absence.length).toBeGreaterThan(10);
+    }
+  });
+
+  it('lists the storage keys a restore replaces', () => {
+    expect(LOCAL_BACKUP_STORAGE_KEYS).toEqual([
+      STORAGE_KEYS.ACCOUNTS,
+      STORAGE_KEYS.CATEGORIES,
+      STORAGE_KEYS.TRANSACTIONS,
+      STORAGE_KEYS.TRANSACTION_SPLITS,
+      STORAGE_KEYS.BUDGETS,
+      STORAGE_KEYS.GOALS,
+      STORAGE_KEYS.SUGGESTION_DISMISSALS,
+    ]);
+  });
+});
+
+// ── Export ──────────────────────────────────────────────────────────────────
+
+describe('collectLocalBackupBundle', () => {
+  it('writes a file the shared validator accepts', async () => {
+    await seedEverything();
+    const bundle = await collectLocalBackupBundle();
+
+    expect(bundle.format).toBe(BACKUP_FORMAT);
+    // Round-tripped through JSON exactly as a downloaded file would be.
+    const validation = validateBackupBundle(JSON.parse(JSON.stringify(bundle)));
+    expect(validation.ok).toBe(true);
+  });
+
+  it('writes DATABASE column names, not the app spelling', async () => {
+    await seedEverything();
+    const bundle = await collectLocalBackupBundle();
+
+    const account = bundle.data.accounts.find((row) => row.id === ACCOUNT_CURRENT);
+    expect(account).toMatchObject({
+      // 'current' in the UI is 'checking' in the database, on both engines.
+      type: 'checking',
+      initial_balance: 1000,
+      opening_balance_date: '2020-01-01',
+      account_number: '12345678',
+      bank_balance: 1200.07,
+      low_balance_alert_enabled: true,
+    });
+    expect(account).not.toHaveProperty('openingBalance');
+
+    const transfer = bundle.data.transactions.find((row) => row.id === TXN_OUT);
+    expect(transfer).toMatchObject({
+      account_id: ACCOUNT_CURRENT,
+      transfer_account_id: ACCOUNT_SAVINGS,
+      linked_transfer_id: TXN_IN,
+    });
+  });
+
+  it('parks app fields with no column in metadata rather than dropping them', async () => {
+    await seedEverything();
+    const bundle = await collectLocalBackupBundle();
+
+    const account = bundle.data.accounts.find((row) => row.id === ACCOUNT_CURRENT);
+    expect(account?.metadata).toEqual({ localOnlyFields: { creditLimit: 500, tags: ['everyday'] } });
+  });
+
+  it('leaves out an entity this device does not hold, as an empty table', async () => {
+    await seedEverything();
+    const bundle = await collectLocalBackupBundle();
+
+    expect(bundle.data.investments).toEqual([]);
+    expect(bundle.data.recurring_transactions).toEqual([]);
+    expect(bundle.counts.investments).toBe(0);
+  });
+
+  it('records the links the second pass would need', async () => {
+    await seedEverything();
+    const bundle = await collectLocalBackupBundle();
+
+    expect(bundle.links.account_parents).toEqual([
+      { id: ACCOUNT_CASH, parent_account_id: ACCOUNT_SAVINGS },
+    ]);
+    expect(bundle.links.transaction_links).toEqual([
+      { id: TXN_OUT, linked_transfer_id: TXN_IN, linked_transfer_split_id: null },
+      { id: TXN_IN, linked_transfer_id: TXN_OUT, linked_transfer_split_id: null },
+    ]);
+  });
+
+  it('refuses rather than writing a money value it cannot restore exactly', async () => {
+    await seedEverything();
+    await storageAdapter.set(STORAGE_KEYS.ACCOUNTS, [
+      { ...seedAccounts()[0], balance: MAX_EXACT_MONEY * 10 },
+    ]);
+
+    await expect(collectLocalBackupBundle()).rejects.toThrow(/lose precision/);
+  });
+
+  it('refuses a money value stored as text that is beyond exact range', async () => {
+    // Compared through Decimal — the check itself must not be the thing that
+    // loses the penny.
+    const tooBig = toDecimal(MAX_EXACT_MONEY).plus(1).toFixed(2);
+    await storageAdapter.set(STORAGE_KEYS.ACCOUNTS, [{ ...seedAccounts()[0], balance: tooBig }]);
+
+    await expect(collectLocalBackupBundle()).rejects.toThrow(/lose precision/);
+  });
+
+  it('refuses when a collection has been corrupted into something that is not a list', async () => {
+    await storageAdapter.set(STORAGE_KEYS.ACCOUNTS, { not: 'a list' });
+    await expect(collectLocalBackupBundle()).rejects.toThrow(/other than a list/);
+  });
+
+  it('reports progress for every table', async () => {
+    await seedEverything();
+    const seen: string[] = [];
+    await collectLocalBackupBundle({ onProgress: (p) => { seen.push(p.entity); } });
+    expect(new Set(seen)).toEqual(new Set(BACKUP_ENTITIES));
+  });
+});
+
+// ── Emptiness and the wipe ──────────────────────────────────────────────────
+
+describe('wipeLocalFinancialData', () => {
+  it('demands the confirmation phrase', async () => {
+    await seedEverything();
+    await expect(wipeLocalFinancialData('delete')).rejects.toThrow(/wipe_not_confirmed/);
+    expect(await read(STORAGE_KEYS.ACCOUNTS)).toHaveLength(3);
+  });
+
+  it('actually clears what the app reads', async () => {
+    // The whole point. The old wipeLocalData wrote '[]' into localStorage while
+    // every read goes through encrypted IndexedDB, so this assertion — made
+    // through the same adapter the app uses — is the one it could never pass.
+    await seedEverything();
+    expect(await localFinancialDataIsEmpty()).toBe(false);
+
+    await wipeLocalFinancialData(LOCAL_WIPE_CONFIRMATION);
+
+    for (const key of LOCAL_BACKUP_STORAGE_KEYS) {
+      expect(await read(key)).toEqual([]);
+    }
+    expect(await localFinancialDataIsEmpty()).toBe(true);
+  });
+
+  it('says what it threw away, per table', async () => {
+    await seedEverything();
+    const counts = await wipeLocalFinancialData(LOCAL_WIPE_CONFIRMATION);
+    expect(counts).toMatchObject({ accounts: 3, categories: 4, transactions: 4, transaction_splits: 2 });
+  });
+});
+
+describe('localFinancialDataIsEmpty', () => {
+  it('is true for a device that has never held anything', async () => {
+    expect(await localFinancialDataIsEmpty()).toBe(true);
+  });
+
+  it('asks about the same three tables the database does', async () => {
+    await storageAdapter.set(STORAGE_KEYS.GOALS, seedGoals());
+    // Goals alone do not make a device non-empty, exactly as
+    // user_financial_data_is_empty looks only at accounts, categories and
+    // transactions.
+    expect(await localFinancialDataIsEmpty()).toBe(true);
+
+    await storageAdapter.set(STORAGE_KEYS.CATEGORIES, seedCategories());
+    expect(await localFinancialDataIsEmpty()).toBe(false);
+  });
+});
+
+// ── The round trip ──────────────────────────────────────────────────────────
+
+describe('a genuine round trip', () => {
+  it('seed, export, wipe, restore — same data, new ids, nothing lost', async () => {
+    await seedEverything();
+
+    const before = {
+      accounts: await read(STORAGE_KEYS.ACCOUNTS),
+      categories: await read(STORAGE_KEYS.CATEGORIES),
+      transactions: await read(STORAGE_KEYS.TRANSACTIONS),
+      splits: await read(STORAGE_KEYS.TRANSACTION_SPLITS),
+      budgets: await read(STORAGE_KEYS.BUDGETS),
+      goals: await read(STORAGE_KEYS.GOALS),
+      dismissals: await read(STORAGE_KEYS.SUGGESTION_DISMISSALS),
+    };
+
+    // Exactly what the user gets: a JSON file, read back with the shared parser.
+    const exported = await collectLocalBackupBundle();
+    const onDisk = JSON.stringify(exported, null, 2);
+
+    await wipeLocalFinancialData(LOCAL_WIPE_CONFIRMATION);
+    expect(await localFinancialDataIsEmpty()).toBe(true);
+
+    const validation = validateBackupBundle(JSON.parse(onDisk));
+    if (!validation.ok) throw new Error(validation.problem);
+    const outcome = await restoreLocalBackupBundle(validation.bundle, { newId: countingIds() });
+
+    const after = {
+      accounts: await read(STORAGE_KEYS.ACCOUNTS),
+      categories: await read(STORAGE_KEYS.CATEGORIES),
+      transactions: await read(STORAGE_KEYS.TRANSACTIONS),
+      splits: await read(STORAGE_KEYS.TRANSACTION_SPLITS),
+      budgets: await read(STORAGE_KEYS.BUDGETS),
+      goals: await read(STORAGE_KEYS.GOALS),
+      dismissals: await read(STORAGE_KEYS.SUGGESTION_DISMISSALS),
+    };
+
+    // ── Nothing went missing ──
+    expect(after.accounts).toHaveLength(before.accounts.length);
+    expect(after.categories).toHaveLength(before.categories.length);
+    expect(after.transactions).toHaveLength(before.transactions.length);
+    expect(after.splits).toHaveLength(before.splits.length);
+    expect(after.budgets).toHaveLength(before.budgets.length);
+    expect(after.goals).toHaveLength(before.goals.length);
+    expect(after.dismissals).toHaveLength(before.dismissals.length);
+    expect(outcome.danglingRefs).toEqual([]);
+
+    // ── Every id is new, and consistently so ──
+    const idOf = (rows: Record<string, unknown>[], index: number): string => String(rows[index].id);
+    const oldToNew = new Map<string, string>();
+    const pair = (was: Record<string, unknown>[], now: Record<string, unknown>[]): void => {
+      was.forEach((row, index) => { oldToNew.set(String(row.id), idOf(now, index)); });
+    };
+    pair(before.accounts, after.accounts);
+    pair(before.categories, after.categories);
+    pair(before.transactions, after.transactions);
+    pair(before.splits, after.splits);
+    pair(before.budgets, after.budgets);
+    pair(before.goals, after.goals);
+    pair(before.dismissals, after.dismissals);
+
+    for (const [was, now] of oldToNew) {
+      expect(now).not.toBe(was);
+      expect(now).toMatch(/^new-\d{3}$/);
+    }
+    // No two rows were handed the same new id.
+    expect(new Set(oldToNew.values()).size).toBe(oldToNew.size);
+
+    // ── Every field survived, with references pointed at the new ids ──
+    const expectSameExceptIds = (
+      was: Record<string, unknown>[],
+      now: Record<string, unknown>[],
+      references: readonly string[]
+    ): void => {
+      was.forEach((original, index) => {
+        const expected: Record<string, unknown> = { ...original, id: oldToNew.get(String(original.id)) };
+        for (const field of references) {
+          const value = original[field];
+          if (typeof value === 'string') expected[field] = oldToNew.get(value) ?? value;
+          if (Array.isArray(value)) {
+            expected[field] = value.map((entry) =>
+              typeof entry === 'string' ? oldToNew.get(entry) ?? entry : entry);
+          }
+        }
+        expect(now[index]).toEqual(expected);
+      });
+    };
+
+    expectSameExceptIds(before.accounts, after.accounts, ['parentAccountId']);
+    expectSameExceptIds(before.categories, after.categories, ['parentId', 'accountId']);
+    expectSameExceptIds(before.transactions, after.transactions, [
+      // `category` is TEXT holding a category id — the trap. Included here on
+      // purpose: without it this assertion passes while every transaction comes
+      // back uncategorised.
+      'category', 'accountId', 'transferAccountId', 'linkedTransferId', 'linkedTransferSplitId',
+    ]);
+    expectSameExceptIds(before.splits, after.splits, [
+      'transactionId', 'category', 'transferAccountId', 'linkedTransferId',
+    ]);
+    expectSameExceptIds(before.budgets, after.budgets, ['categoryId']);
+    expectSameExceptIds(before.goals, after.goals, ['accountId', 'linkedAccountIds']);
+
+    // ── Money, to the penny ──
+    const pennies = (rows: Record<string, unknown>[], field: string): string[] =>
+      rows.map((row) => toDecimal(typeof row[field] === 'number' ? Number(row[field]) : 0).toFixed(2));
+    expect(pennies(after.accounts, 'balance')).toEqual(pennies(before.accounts, 'balance'));
+    expect(pennies(after.transactions, 'amount')).toEqual(pennies(before.transactions, 'amount'));
+    expect(pennies(after.splits, 'amount')).toEqual(pennies(before.splits, 'amount'));
+    // The split lines still sum to their parent exactly.
+    const parent = after.transactions.find((row) => row.description === 'Supermarket');
+    const sum = after.splits.reduce(
+      (total, row) => total.plus(toDecimal(Number(row.amount))), toDecimal(0));
+    expect(sum.toFixed(2)).toBe(toDecimal(Number(parent?.amount)).toFixed(2));
+
+    // ── Relationships ──
+    const account = (name: string): Record<string, unknown> =>
+      after.accounts.find((row) => row.name === name)!;
+    // The cash account still hangs under the investment account it belongs to.
+    expect(account('Brokerage cash').parentAccountId).toBe(account('Savings').id);
+    // Both halves of the transfer still name each other.
+    const out = after.transactions.find((row) => row.description === 'To Savings')!;
+    const income = after.transactions.find((row) => row.description === 'From Current')!;
+    expect(out.linkedTransferId).toBe(income.id);
+    expect(income.linkedTransferId).toBe(out.id);
+    expect(out.transferAccountId).toBe(account('Savings').id);
+    // Splits still belong to their parent.
+    expect(new Set(after.splits.map((row) => row.transactionId))).toEqual(new Set([parent?.id]));
+    // The category tree still hangs together.
+    const category = (name: string): Record<string, unknown> =>
+      after.categories.find((row) => row.name === name)!;
+    expect(category('Groceries').parentId).toBe(category('Food').id);
+    expect(category('Food').parentId).toBe(category('Expenses').id);
+    // And a categorised transaction still points at a category that exists.
+    const shop = after.transactions.find((row) => row.description === 'Corner shop')!;
+    expect(shop.category).toBe(category('Groceries').id);
+    expect(after.categories.some((row) => row.id === shop.category)).toBe(true);
+
+    // ── The dismissal still matches the rows it was about ──
+    const dismissal = after.dismissals[0];
+    expect(dismissal.subjectIds).toEqual([shop.id, parent?.id]);
+    // Rebuilt from the restored rows the way a re-scan would rebuild it: if the
+    // key were not remapped AND re-sorted, every refused suggestion would come
+    // back on the next sweep.
+    expect(dismissal.subjectKey).toBe(canonicalSubjectKey([String(shop.id), String(parent?.id)]));
+
+    // ── And the report tells the truth ──
+    expect(outcome.restored).toEqual([
+      { label: 'Accounts', rows: 3 },
+      { label: 'Categories', rows: 4 },
+      { label: 'Transactions', rows: 4 },
+      { label: 'Transaction splits', rows: 2 },
+      { label: 'Budgets', rows: 1 },
+      { label: 'Goals', rows: 1 },
+      { label: 'Dismissed suggestions', rows: 1 },
+    ]);
+    expect(outcome.accountsRelinked).toBe(1);
+    expect(outcome.transactionsRelinked).toBe(2);
+    expect(outcome.notStoredLocally).toEqual([]);
+  });
+
+  it('survives a second trip — the restored data exports to the same file again', async () => {
+    await seedEverything();
+    const first = await collectLocalBackupBundle();
+
+    await wipeLocalFinancialData(LOCAL_WIPE_CONFIRMATION);
+    await restoreLocalBackupBundle(first, { newId: countingIds() });
+    const second = await collectLocalBackupBundle();
+
+    await wipeLocalFinancialData(LOCAL_WIPE_CONFIRMATION);
+    await restoreLocalBackupBundle(second, { newId: countingIds() });
+    const third = await collectLocalBackupBundle();
+
+    // Same ids (the generator restarts), same rows, same counts. A conversion
+    // that lost or invented a field would drift between generations.
+    expect(third.data).toEqual(second.data);
+    expect(third.counts).toEqual(second.counts);
+  });
+});
+
+// ── Restore behaviour ───────────────────────────────────────────────────────
+
+const bundleFrom = async (): Promise<BackupBundle> => {
+  const bundle = await collectLocalBackupBundle();
+  const validation = validateBackupBundle(JSON.parse(JSON.stringify(bundle)));
+  if (!validation.ok) throw new Error(validation.problem);
+  return validation.bundle;
+};
+
+describe('restoreLocalBackupBundle', () => {
+  it('refuses a device that still holds data, and changes nothing', async () => {
+    await seedEverything();
+    const bundle = await bundleFrom();
+
+    await expect(restoreLocalBackupBundle(bundle)).rejects.toBeInstanceOf(LocalRestoreRefusedError);
+    // The refusal is not a half-measure: storage is exactly as it was.
+    expect(await read(STORAGE_KEYS.ACCOUNTS)).toHaveLength(3);
+    expect(await read(STORAGE_KEYS.TRANSACTIONS)).toHaveLength(4);
+  });
+
+  it('empties a table the file has no rows for rather than leaving what was there', async () => {
+    await seedEverything();
+    const bundle = await bundleFrom();
+    await wipeLocalFinancialData(LOCAL_WIPE_CONFIRMATION);
+
+    // Something landed in goals between the wipe and the restore. A restore
+    // REPLACES; leaving it would silently merge two datasets.
+    await storageAdapter.set(STORAGE_KEYS.GOALS, seedGoals());
+    const stripped: BackupBundle = { ...bundle, data: { ...bundle.data, goals: [] } };
+    await restoreLocalBackupBundle(stripped, { newId: countingIds() });
+
+    expect(await read(STORAGE_KEYS.GOALS)).toEqual([]);
+  });
+
+  it('names what this device cannot keep instead of dropping it in silence', async () => {
+    const bundle = await bundleFrom();
+    const withInvestments: BackupBundle = {
+      ...bundle,
+      data: {
+        ...bundle.data,
+        investments: [{ id: 'inv-1', account_id: 'a-1', symbol: 'VWRL' }],
+        recurring_transactions: [{ id: 'rec-1', account_id: 'a-1', amount: -9.99 }],
+      },
+    };
+
+    const outcome = await restoreLocalBackupBundle(withInvestments, { newId: countingIds() });
+    expect(outcome.notStoredLocally).toEqual([
+      { label: 'Investments', rows: 1, absence: 'holdings are only tracked when you are signed in' },
+      {
+        label: 'Recurring transactions', rows: 1,
+        absence: 'repeating templates are only kept when you are signed in',
+      },
+    ]);
+  });
+
+  it('says nothing about tables the file is empty for', async () => {
+    const outcome = await restoreLocalBackupBundle(await bundleFrom(), { newId: countingIds() });
+    expect(outcome.notStoredLocally).toEqual([]);
+  });
+
+  it('reports a reference the file does not contain rather than blanking it', async () => {
+    await seedEverything();
+    const bundle = await bundleFrom();
+    await wipeLocalFinancialData(LOCAL_WIPE_CONFIRMATION);
+
+    const orphaned: BackupBundle = {
+      ...bundle,
+      data: {
+        ...bundle.data,
+        transactions: bundle.data.transactions.map((row) =>
+          row.id === TXN_SHOP ? { ...row, category: '11111111-2222-3333-4444-555555555555' } : row),
+      },
+    };
+    const outcome = await restoreLocalBackupBundle(orphaned, { newId: countingIds() });
+
+    expect(outcome.danglingRefs).toEqual([
+      expect.objectContaining({
+        entity: 'transactions', field: 'category',
+        value: '11111111-2222-3333-4444-555555555555',
+      }),
+    ]);
+    // Left as it was, not blanked — a value we cannot explain is not the same
+    // as one we know to be absent.
+    const restored = await read(STORAGE_KEYS.TRANSACTIONS);
+    expect(restored.some((row) => row.category === '11111111-2222-3333-4444-555555555555')).toBe(true);
+  });
+
+  it('leaves the previous data untouched when the write fails', async () => {
+    // Atomicity from the caller's side: everything is converted first and
+    // written last, in one go, so a failing write cannot leave half a dataset.
+    await seedEverything();
+    const bundle = await bundleFrom();
+    await wipeLocalFinancialData(LOCAL_WIPE_CONFIRMATION);
+    await storageAdapter.set(STORAGE_KEYS.ACCOUNTS, []);
+
+    const setMany = vi.fn().mockRejectedValue(new Error('QuotaExceededError'));
+    const store: LocalBackupStore = { get: (key) => storageAdapter.get(key), setMany };
+
+    await expect(restoreLocalBackupBundle(bundle, { store })).rejects.toThrow(/QuotaExceededError/);
+    expect(setMany).toHaveBeenCalledTimes(1);
+    for (const key of LOCAL_BACKUP_STORAGE_KEYS) {
+      expect(await read(key)).toEqual([]);
+    }
+  });
+
+  it('writes every table in ONE call, which is what makes it all-or-nothing', async () => {
+    const bundle = await bundleFrom();
+    const setMany = vi.fn().mockResolvedValue(undefined);
+    const store: LocalBackupStore = { get: (key) => storageAdapter.get(key), setMany };
+
+    await restoreLocalBackupBundle(bundle, { store, newId: countingIds() });
+
+    expect(setMany).toHaveBeenCalledTimes(1);
+    const written: Array<{ key: string }> = setMany.mock.calls[0][0];
+    expect(written.map((entry) => entry.key)).toEqual([...LOCAL_BACKUP_STORAGE_KEYS]);
+  });
+});
+
+// ── Do the two engines' files interchange? ──────────────────────────────────
+
+describe('cloud and local files', () => {
+  /** A file as the CLOUD export writes it: whole rows, user_id and all. */
+  const cloudTakenBundle = (): unknown => ({
+    format: BACKUP_FORMAT,
+    schemaVersion: '20260807083000',
+    exportedAt: '2026-08-07T09:30:00.000Z',
+    sourceUserId: '7d1f6e2a-0000-4000-8000-000000000001',
+    counts: {
+      accounts: 1, categories: 1, transactions: 1, transaction_splits: 0, budgets: 0,
+      goals: 0, goal_contributions: 0, investments: 0, investment_transactions: 0,
+      recurring_transactions: 0, notifications: 0, dashboard_layouts: 0,
+      widget_preferences: 0, suggestion_dismissals: 0,
+    },
+    data: {
+      accounts: [{
+        id: 'aaaaaaaa-0000-4000-8000-000000000001',
+        user_id: '7d1f6e2a-0000-4000-8000-000000000001',
+        name: 'Current', type: 'checking', currency: 'GBP', balance: 1234.56,
+        initial_balance: 1000, is_active: true, institution: 'HSBC',
+        parent_account_id: null, created_at: '2020-01-01T00:00:00.000Z',
+        updated_at: '2026-08-01T09:00:00.000Z', metadata: {},
+      }],
+      categories: [{
+        id: 'cccccccc-0000-4000-8000-000000000001',
+        user_id: '7d1f6e2a-0000-4000-8000-000000000001',
+        name: 'Groceries', type: 'expense', level: 'detail', parent_id: null,
+        is_system: false, is_active: true, created_at: '2020-01-01T00:00:00.000Z',
+      }],
+      transactions: [{
+        id: 'tttttttt-0000-4000-8000-000000000001'.replace(/t/g, 'b'),
+        user_id: '7d1f6e2a-0000-4000-8000-000000000001',
+        account_id: 'aaaaaaaa-0000-4000-8000-000000000001',
+        category: 'cccccccc-0000-4000-8000-000000000001',
+        category_id: 'cccccccc-0000-4000-8000-000000000001',
+        date: '2026-07-04', amount: -12.34, description: 'Corner shop', type: 'expense',
+        is_cleared: true, tags: ['weekly'], notes: 'milk',
+        created_at: '2026-07-04T10:00:00.000Z', updated_at: '2026-07-04T10:00:00.000Z',
+      }],
+    },
+    links: { account_parents: [], transaction_links: [] },
+  });
+
+  it('restores a cloud-taken file onto this device', async () => {
+    const validation = validateBackupBundle(cloudTakenBundle());
+    if (!validation.ok) throw new Error(validation.problem);
+
+    const outcome = await restoreLocalBackupBundle(validation.bundle, { newId: countingIds() });
+    expect(outcome.danglingRefs).toEqual([]);
+
+    const accounts = await read(STORAGE_KEYS.ACCOUNTS);
+    const categories = await read(STORAGE_KEYS.CATEGORIES);
+    const transactions = await read(STORAGE_KEYS.TRANSACTIONS);
+
+    // Read back in the app's own spelling, ready for the app to use.
+    expect(accounts[0]).toMatchObject({
+      name: 'Current', type: 'current', balance: 1234.56, openingBalance: 1000,
+      isActive: true, institution: 'HSBC',
+    });
+    expect(transactions[0]).toMatchObject({
+      description: 'Corner shop', amount: -12.34, cleared: true, tags: ['weekly'],
+    });
+    // Still filed under a category that exists here.
+    expect(transactions[0].category).toBe(categories[0].id);
+    expect(transactions[0].accountId).toBe(accounts[0].id);
+  });
+
+  it('does not carry the server-only columns back out again', async () => {
+    // Honest about the one-way loss: user_id, created_at on a category and the
+    // uuid category_id have no home in local storage, so a cloud file that goes
+    // local and comes back out has lost them. Everything the app reads survives.
+    const validation = validateBackupBundle(cloudTakenBundle());
+    if (!validation.ok) throw new Error(validation.problem);
+    await restoreLocalBackupBundle(validation.bundle, { newId: countingIds() });
+
+    const reExported = await collectLocalBackupBundle();
+    expect(reExported.data.categories[0]).not.toHaveProperty('created_at');
+    expect(reExported.data.transactions[0]).not.toHaveProperty('category_id');
+    expect(reExported.data.transactions[0]).not.toHaveProperty('user_id');
+    // But the money, the description and the category link did survive.
+    expect(reExported.data.transactions[0]).toMatchObject({
+      amount: -12.34, description: 'Corner shop',
+      category: reExported.data.categories[0].id,
+    });
+  });
+
+  it('writes a locally-taken file the cloud restore can consume', async () => {
+    await seedEverything();
+    const bundle = await collectLocalBackupBundle();
+
+    // restore_user_chunk hands rows to jsonb_populate_recordset, so a missing
+    // key arrives as SQL NULL and a NOT NULL column rejects it. These are the
+    // columns that would stop a cloud restore halfway through.
+    for (const row of bundle.data.accounts) {
+      expect(typeof row.name).toBe('string');
+      expect(typeof row.type).toBe('string');
+    }
+    for (const row of bundle.data.transactions) {
+      expect(typeof row.description).toBe('string');
+      expect(typeof row.account_id).toBe('string');
+      expect(typeof row.amount).toBe('number');
+      expect(row.date).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+    }
+    for (const row of bundle.data.transaction_splits) {
+      expect(typeof row.category).toBe('string');
+      expect(typeof row.sort_order).toBe('number');
+    }
+    for (const row of bundle.data.budgets) {
+      expect(typeof row.name).toBe('string');
+      expect(typeof row.start_date).toBe('string');
+    }
+    for (const row of bundle.data.categories) {
+      expect(['type', 'sub', 'detail']).toContain(row.level);
+    }
+    // And no globally-unique provider id that would collide on the way in.
+    const columns = new Set(bundle.data.accounts.flatMap((row) => Object.keys(row)));
+    expect(columns.has('plaid_account_id')).toBe(false);
+    expect(columns.has('plaid_connection_id')).toBe(false);
+  });
+});
+
+// ── The one deliberate lossy conversion ─────────────────────────────────────
+
+describe('a transaction date is a calendar day', () => {
+  it('truncates a time of day, because the column is a DATE on both engines', async () => {
+    await storageAdapter.set(STORAGE_KEYS.ACCOUNTS, seedAccounts());
+    await storageAdapter.set(STORAGE_KEYS.TRANSACTIONS, [{
+      id: TXN_SHOP, date: '2026-07-04T14:30:00.000Z', amount: -1, description: 'Late',
+      accountId: ACCOUNT_CURRENT, type: 'expense',
+    }]);
+
+    const bundle = await collectLocalBackupBundle();
+    expect(bundle.data.transactions[0].date).toBe('2026-07-04');
+  });
+
+  it('leaves a day that is already a day exactly alone', async () => {
+    // Never through `new Date('2026-07-04')`, which invents a UTC midnight and
+    // can move the day west of Greenwich.
+    await storageAdapter.set(STORAGE_KEYS.ACCOUNTS, seedAccounts());
+    await storageAdapter.set(STORAGE_KEYS.TRANSACTIONS, [{
+      id: TXN_SHOP, date: '2026-07-04', amount: -1, description: 'Shop',
+      accountId: ACCOUNT_CURRENT, type: 'expense',
+    }]);
+
+    const bundle = await collectLocalBackupBundle();
+    expect(bundle.data.transactions[0].date).toBe('2026-07-04');
+  });
+});
+
+// ── The trap the cloud remapper had ─────────────────────────────────────────
+
+describe('text ids that are not uuids', () => {
+  it('remaps a category id the app seeded as plain text', async () => {
+    // A signed-out user's categories are 'type-income', 'transfer-in' and so
+    // on. remapBackupIds used to skip any TEXT reference that did not LOOK like
+    // a uuid, so categories[].id changed and transactions.category did not.
+    await storageAdapter.set(STORAGE_KEYS.CATEGORIES, [
+      { id: 'type-expense', name: 'Expenses', type: 'expense', level: 'type', parentId: null },
+    ]);
+    await storageAdapter.set(STORAGE_KEYS.ACCOUNTS, [seedAccounts()[0]]);
+    await storageAdapter.set(STORAGE_KEYS.TRANSACTIONS, [{
+      id: TXN_SHOP, date: '2026-07-04', amount: -1, description: 'Shop',
+      category: 'type-expense', accountId: ACCOUNT_CURRENT, type: 'expense',
+    }]);
+
+    const bundle = await bundleFrom();
+    await wipeLocalFinancialData(LOCAL_WIPE_CONFIRMATION);
+    await restoreLocalBackupBundle(bundle, { newId: countingIds() });
+
+    const categories = await read(STORAGE_KEYS.CATEGORIES);
+    const transactions = await read(STORAGE_KEYS.TRANSACTIONS);
+    expect(categories[0].id).not.toBe('type-expense');
+    expect(transactions[0].category).toBe(categories[0].id);
+  });
+
+  it('leaves a free-text label alone and does not call it dangling', async () => {
+    // goals.category holds a word a person typed, not a reference.
+    await storageAdapter.set(STORAGE_KEYS.GOALS, [{
+      ...seedGoals()[0], accountId: undefined, linkedAccountIds: undefined, category: 'Holiday',
+    }]);
+
+    const bundle = await bundleFrom();
+    const outcome = await restoreLocalBackupBundle(bundle, { newId: countingIds() });
+
+    expect(outcome.danglingRefs).toEqual([]);
+    expect((await read(STORAGE_KEYS.GOALS))[0].category).toBe('Holiday');
+  });
+});
+
+// ── Rows the format cannot carry ────────────────────────────────────────────
+
+describe('a corrupted collection', () => {
+  it('refuses an entry that is not a record instead of quietly skipping it', async () => {
+    const rows: unknown[] = [...seedAccounts(), 'not a record'];
+    await storageAdapter.set(STORAGE_KEYS.ACCOUNTS, rows);
+    await expect(collectLocalBackupBundle()).rejects.toThrow(/not a record/);
+  });
+});

--- a/src/services/localBackupService.ts
+++ b/src/services/localBackupService.ts
@@ -1,0 +1,1048 @@
+import { storageAdapter, STORAGE_KEYS } from './storageAdapter';
+import { toDecimal } from '../utils/decimal';
+import {
+  BACKUP_ENTITIES,
+  MAX_EXACT_MONEY,
+  buildBackupBundle,
+  remapBackupIds,
+  type BackupBundle,
+  type BackupEntity,
+  type BackupRow,
+  type DanglingReference,
+  type ExportProgress,
+  type RestoreProgress,
+} from './backupService';
+
+/**
+ * Backup and restore for the browser's own copy — demo mode, local mode, and
+ * any session where the cloud is not configured.
+ *
+ * Until this existed a local user could not save their data AT ALL.
+ * backupService talks to Supabase from its first line (`import { supabase }`)
+ * and resolves `client ?? supabase`, so every entry point threw "Backup and
+ * restore need the cloud connection". storageAdapter.exportData/importData
+ * existed but nothing in the product ever called them.
+ *
+ * ── THE SEAM ────────────────────────────────────────────────────────────────
+ * `buildBackupBundle` is a pure function over rows, and `remapBackupIds`,
+ * `findUnsafeMoneyValues` and `validateBackupBundle` are pure over the bundle.
+ * Only the code that FETCHES rows was ever coupled to Supabase. So this module
+ * supplies rows from browser storage and hands them to the same builder: one
+ * format, one validator, one id remapper, two storage engines.
+ *
+ * ── WHY ROWS ARE CONVERTED RATHER THAN COPIED ───────────────────────────────
+ * Browser storage holds the APP's types — camelCase, `openingBalance`,
+ * `linkedTransferId`. The backup format holds DATABASE rows — snake_case,
+ * `initial_balance`, `linked_transfer_id`. Writing the app's shape into a file
+ * tagged `wealthtracker-backup-v2` would be a second format wearing the first
+ * one's name, and it would also be broken: `remapBackupIds` looks up
+ * `account_id`, `transfer_account_id`, `parent_account_id` and friends BY
+ * COLUMN NAME, so an app-shaped bundle would come back with every transaction
+ * still pointing at ids from the old dataset — silently, because nothing local
+ * enforces a foreign key. Converting is not tidiness; it is what makes the
+ * shared machinery work at all.
+ *
+ * The column names below are taken from the app's OWN cloud mappers
+ * (accountService.mapAccountToDb, planningService.budgetToDb/goalToDb/
+ * categoryToDb, transactionService.CAMEL_TO_DB, transactionService.mapSplitRow,
+ * suggestionDismissalService.toDismissal) rather than invented here, so a local
+ * backup carries exactly the columns the cloud path would have written.
+ *
+ * ── WHAT A LOCAL FILE DOES NOT CARRY ────────────────────────────────────────
+ * The same provider ids a cloud backup leaves behind: `plaid_account_id`,
+ * `plaid_connection_id`, `plaid_transaction_id`. They are globally unique and
+ * restore_user_chunk strips them anyway, so carrying them would only invite a
+ * collision with whoever exported them.
+ */
+
+// ── Storage port ────────────────────────────────────────────────────────────
+
+/**
+ * The slice of browser storage this module needs.
+ *
+ * `setMany` is the whole atomicity story: it is ONE IndexedDB readwrite
+ * transaction, so a restore either lands completely or leaves the previous
+ * contents untouched. A per-key loop could not promise that — a failure on the
+ * ninth key would leave eight tables from the file beside six from before.
+ */
+export interface LocalBackupStore {
+  get<T>(key: string): Promise<T | null>;
+  setMany(entries: ReadonlyArray<{ key: string; value: unknown }>): Promise<void>;
+}
+
+const defaultStore = (): LocalBackupStore => storageAdapter;
+
+// ── Small readers ───────────────────────────────────────────────────────────
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === 'object' && value !== null && !Array.isArray(value);
+
+/** A non-empty string, or undefined. Empty strings are absences, not values. */
+const text = (value: unknown): string | undefined =>
+  typeof value === 'string' && value.length > 0 ? value : undefined;
+
+const bool = (value: unknown): boolean | undefined =>
+  typeof value === 'boolean' ? value : undefined;
+
+const numeric = (value: unknown): number | undefined =>
+  typeof value === 'number' && Number.isFinite(value) ? value : undefined;
+
+const textArray = (value: unknown): string[] | undefined =>
+  Array.isArray(value) ? value.filter((entry): entry is string => typeof entry === 'string') : undefined;
+
+/**
+ * A `timestamptz` column: the full instant, as ISO 8601.
+ *
+ * Browser storage is JSON, so a Date written by the app is READ BACK as the
+ * string it serialised to. Both spellings therefore turn up here depending on
+ * whether the value has been through storage yet, and both must land on the
+ * same column value or an export would differ from itself.
+ */
+function timestampColumn(value: unknown): string | undefined {
+  if (value instanceof Date) {
+    return Number.isNaN(value.getTime()) ? undefined : value.toISOString();
+  }
+  const raw = text(value);
+  if (raw === undefined) return undefined;
+  const parsed = new Date(raw);
+  return Number.isNaN(parsed.getTime()) ? undefined : parsed.toISOString();
+}
+
+/**
+ * A `date` column: the calendar day alone, 'YYYY-MM-DD'.
+ *
+ * A day with a time on it is TRUNCATED, deliberately and visibly. These columns
+ * are Postgres DATEs; the cloud has always stored the day only, and a backup
+ * that claimed otherwise would restore differently on the two engines. A value
+ * that is already a day is passed through untouched rather than parsed, because
+ * `new Date('2026-01-15')` invents a UTC midnight and midnight belongs to a
+ * zone — which is how a transaction dated the 15th comes back as the 14th west
+ * of Greenwich.
+ */
+const DAY_ONLY = /^\d{4}-\d{2}-\d{2}$/;
+
+function dateColumn(value: unknown): string | undefined {
+  if (value instanceof Date) {
+    return Number.isNaN(value.getTime()) ? undefined : value.toISOString().slice(0, 10);
+  }
+  const raw = text(value);
+  if (raw === undefined) return undefined;
+  if (DAY_ONLY.test(raw)) return raw;
+  const parsed = new Date(raw);
+  return Number.isNaN(parsed.getTime()) ? undefined : parsed.toISOString().slice(0, 10);
+}
+
+/**
+ * Write a column only when the app holds something for it.
+ *
+ * `null` IS written: a parent_account_id of null says "this account hangs under
+ * nothing", which is not the same as a row that never mentioned the column.
+ */
+function put(row: BackupRow, column: string, value: unknown): void {
+  if (value !== undefined) row[column] = value;
+}
+
+// ── Fields the format has no column for ─────────────────────────────────────
+
+/**
+ * Where app fields with no column of their own ride.
+ *
+ * Namespaced under the `metadata` jsonb the four biggest tables already have,
+ * for the same reason goalToDb puts `type` and `linkedAccountIds` there: the
+ * alternative is dropping them, and for a LOCAL user browser storage is the
+ * only copy in existence. A cloud backup has no such key, so reading one back
+ * simply finds nothing — the hatch costs nothing in the other direction.
+ *
+ * NOT a licence to skip mapping: a field holding another row's ID must be given
+ * a real column, because remapBackupIds works from ENTITY_REFERENCES and never
+ * looks inside metadata. Anything parked here comes back pointing at the
+ * dataset it left.
+ */
+const LOCAL_ONLY_FIELDS = 'localOnlyFields';
+
+/** Everything on the app object that the column map above did not consume. */
+function localOnlyFields(
+  app: Record<string, unknown>,
+  carried: ReadonlySet<string>
+): Record<string, unknown> | undefined {
+  const rest: Record<string, unknown> = {};
+  let found = false;
+  for (const [key, value] of Object.entries(app)) {
+    if (carried.has(key) || value === undefined) continue;
+    rest[key] = value;
+    found = true;
+  }
+  return found ? rest : undefined;
+}
+
+/** Attach the leftovers to a row that has a `metadata` column. */
+function withLocalOnlyFields(row: BackupRow, rest: Record<string, unknown> | undefined): BackupRow {
+  if (rest === undefined) return row;
+  const existing = isRecord(row.metadata) ? row.metadata : {};
+  return { ...row, metadata: { ...existing, [LOCAL_ONLY_FIELDS]: rest } };
+}
+
+/** Read them back off a row this app wrote. Absent for every cloud-written row. */
+function readLocalOnlyFields(row: BackupRow): Record<string, unknown> {
+  if (!isRecord(row.metadata)) return {};
+  const parked = row.metadata[LOCAL_ONLY_FIELDS];
+  return isRecord(parked) ? parked : {};
+}
+
+/** Drop `undefined` entries so a restored object matches what storage held. */
+function compact(fields: Record<string, unknown>): Record<string, unknown> {
+  const out: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(fields)) {
+    if (value !== undefined) out[key] = value;
+  }
+  return out;
+}
+
+// ── accounts ────────────────────────────────────────────────────────────────
+
+/**
+ * App names this entity's columns account for, plus the two deliberately left
+ * behind. Anything not listed rides in metadata; see localOnlyFields.
+ */
+const ACCOUNT_CARRIED = new Set<string>([
+  'id', 'name', 'type', 'balance', 'currency', 'institution', 'lastUpdated',
+  'openingBalance', 'openingBalanceDate', 'archiveThroughDate', 'parentAccountId',
+  'notes', 'isActive', 'createdAt', 'sortCode', 'accountNumber', 'bankBalance',
+  'bankBalanceDate', 'lastReconciledDate', 'lowBalanceThreshold', 'lowBalanceAlertEnabled',
+  // Globally unique provider ids. restore_user_chunk strips both, so a file
+  // that carried them could only ever collide with the login it came from.
+  'plaidAccountId', 'plaidConnectionId',
+]);
+
+function accountToRow(app: Record<string, unknown>): BackupRow {
+  const row: BackupRow = {};
+  put(row, 'id', text(app.id));
+  put(row, 'name', text(app.name));
+  // The database calls a current account 'checking'; the UI calls it 'current'.
+  // The same swap accountService has made on every cloud write since day one.
+  const type = text(app.type);
+  put(row, 'type', type === 'current' ? 'checking' : type);
+  put(row, 'balance', app.balance);
+  put(row, 'currency', text(app.currency));
+  put(row, 'institution', app.institution ?? undefined);
+  put(row, 'initial_balance', app.openingBalance);
+  put(row, 'opening_balance_date', dateColumn(app.openingBalanceDate));
+  put(row, 'archive_through_date', app.archiveThroughDate === null ? null : dateColumn(app.archiveThroughDate));
+  put(row, 'parent_account_id', app.parentAccountId === null ? null : text(app.parentAccountId));
+  put(row, 'notes', app.notes ?? undefined);
+  put(row, 'is_active', bool(app.isActive));
+  put(row, 'sort_code', text(app.sortCode));
+  put(row, 'account_number', text(app.accountNumber));
+  put(row, 'bank_balance', app.bankBalance === null ? null : numeric(app.bankBalance));
+  put(row, 'bank_balance_date', app.bankBalanceDate === null ? null : dateColumn(app.bankBalanceDate));
+  put(row, 'last_reconciled_date', app.lastReconciledDate === null ? null : dateColumn(app.lastReconciledDate));
+  put(row, 'low_balance_threshold', numeric(app.lowBalanceThreshold));
+  put(row, 'low_balance_alert_enabled', bool(app.lowBalanceAlertEnabled));
+  put(row, 'created_at', timestampColumn(app.createdAt));
+  // `lastUpdated` is what the app calls updated_at — there is no `last_updated`
+  // column, however confidently ACCOUNT_CAMEL_TO_DB names one.
+  put(row, 'updated_at', timestampColumn(app.lastUpdated));
+  return withLocalOnlyFields(row, localOnlyFields(app, ACCOUNT_CARRIED));
+}
+
+function accountFromRow(row: BackupRow): Record<string, unknown> {
+  const type = text(row.type);
+  return compact({
+    ...readLocalOnlyFields(row),
+    id: text(row.id),
+    name: text(row.name),
+    type: type === 'checking' ? 'current' : type,
+    balance: row.balance,
+    currency: text(row.currency),
+    institution: text(row.institution),
+    openingBalance: row.initial_balance,
+    openingBalanceDate: text(row.opening_balance_date),
+    archiveThroughDate: row.archive_through_date === null ? null : text(row.archive_through_date),
+    parentAccountId: row.parent_account_id === null ? null : text(row.parent_account_id),
+    notes: text(row.notes),
+    isActive: bool(row.is_active),
+    sortCode: text(row.sort_code),
+    accountNumber: text(row.account_number),
+    bankBalance: row.bank_balance === null ? null : numeric(row.bank_balance),
+    bankBalanceDate: row.bank_balance_date === null ? null : text(row.bank_balance_date),
+    lastReconciledDate: row.last_reconciled_date === null ? null : text(row.last_reconciled_date),
+    lowBalanceThreshold: numeric(row.low_balance_threshold),
+    lowBalanceAlertEnabled: bool(row.low_balance_alert_enabled),
+    createdAt: text(row.created_at),
+    lastUpdated: text(row.updated_at),
+  });
+}
+
+// ── categories ──────────────────────────────────────────────────────────────
+
+/**
+ * No leftovers hatch here, and none is possible: categories has no `metadata`
+ * column. Every field of Category maps to a column except `description`, which
+ * has no column in the schema, no writer anywhere in the app and no reader —
+ * so it is not carried, and this comment is the only place anyone would find
+ * that out.
+ */
+function categoryToRow(app: Record<string, unknown>): BackupRow {
+  const row: BackupRow = {};
+  put(row, 'id', text(app.id));
+  put(row, 'name', text(app.name));
+  put(row, 'type', text(app.type));
+  put(row, 'level', text(app.level));
+  put(row, 'parent_id', app.parentId === null ? null : text(app.parentId));
+  put(row, 'color', text(app.color));
+  put(row, 'icon', text(app.icon));
+  put(row, 'is_system', bool(app.isSystem));
+  put(row, 'is_transfer_category', bool(app.isTransferCategory));
+  put(row, 'is_revaluation_category', bool(app.isRevaluationCategory));
+  put(row, 'is_unassigned_bucket', bool(app.isUnassignedBucket));
+  put(row, 'account_id', app.accountId === null ? null : text(app.accountId));
+  put(row, 'is_active', bool(app.isActive));
+  return row;
+}
+
+function categoryFromRow(row: BackupRow): Record<string, unknown> {
+  return compact({
+    id: text(row.id),
+    name: text(row.name),
+    type: text(row.type),
+    level: text(row.level),
+    parentId: row.parent_id === null ? null : text(row.parent_id),
+    color: text(row.color),
+    icon: text(row.icon),
+    isSystem: bool(row.is_system),
+    isTransferCategory: bool(row.is_transfer_category),
+    isRevaluationCategory: bool(row.is_revaluation_category),
+    isUnassignedBucket: bool(row.is_unassigned_bucket),
+    accountId: text(row.account_id),
+    isActive: bool(row.is_active),
+  });
+}
+
+// ── transactions ────────────────────────────────────────────────────────────
+
+const TRANSACTION_CARRIED = new Set<string>([
+  'id', 'date', 'amount', 'description', 'category', 'accountId', 'type', 'tags',
+  'notes', 'cleared', 'isRecurring', 'isSplit', 'archived', 'merchant',
+  'paymentChannel', 'transferAccountId', 'linkedTransferId', 'linkedTransferSplitId',
+  'createdAt', 'updatedAt',
+  // Globally unique; stripped by restore_user_chunk for the same reason.
+  'plaidTransactionId',
+]);
+
+function transactionToRow(app: Record<string, unknown>): BackupRow {
+  const row: BackupRow = {};
+  put(row, 'id', text(app.id));
+  put(row, 'account_id', text(app.accountId));
+  put(row, 'date', dateColumn(app.date));
+  put(row, 'amount', app.amount);
+  put(row, 'description', typeof app.description === 'string' ? app.description : undefined);
+  // `category` is TEXT holding a category's id. It is the field most easily
+  // forgotten and the most expensive to forget: miss it and every categorised
+  // transaction comes back filed under an id that no longer exists.
+  put(row, 'category', text(app.category));
+  put(row, 'type', text(app.type));
+  put(row, 'tags', textArray(app.tags));
+  put(row, 'notes', text(app.notes));
+  put(row, 'is_cleared', bool(app.cleared));
+  put(row, 'is_recurring', bool(app.isRecurring));
+  put(row, 'is_split', bool(app.isSplit));
+  put(row, 'archived', bool(app.archived));
+  put(row, 'merchant_name', text(app.merchant));
+  put(row, 'payment_channel', text(app.paymentChannel));
+  put(row, 'transfer_account_id', text(app.transferAccountId));
+  put(row, 'linked_transfer_id', text(app.linkedTransferId));
+  put(row, 'linked_transfer_split_id', text(app.linkedTransferSplitId));
+  put(row, 'created_at', timestampColumn(app.createdAt));
+  put(row, 'updated_at', timestampColumn(app.updatedAt));
+  return withLocalOnlyFields(row, localOnlyFields(app, TRANSACTION_CARRIED));
+}
+
+function transactionFromRow(row: BackupRow): Record<string, unknown> {
+  return compact({
+    ...readLocalOnlyFields(row),
+    id: text(row.id),
+    accountId: text(row.account_id),
+    date: text(row.date),
+    amount: row.amount,
+    description: typeof row.description === 'string' ? row.description : undefined,
+    category: text(row.category),
+    type: text(row.type),
+    tags: textArray(row.tags),
+    notes: text(row.notes),
+    cleared: bool(row.is_cleared),
+    isRecurring: bool(row.is_recurring),
+    isSplit: bool(row.is_split),
+    archived: bool(row.archived),
+    merchant: text(row.merchant_name),
+    paymentChannel: text(row.payment_channel),
+    transferAccountId: text(row.transfer_account_id),
+    linkedTransferId: text(row.linked_transfer_id),
+    linkedTransferSplitId: text(row.linked_transfer_split_id),
+    createdAt: text(row.created_at),
+    updatedAt: text(row.updated_at),
+  });
+}
+
+// ── transaction_splits ──────────────────────────────────────────────────────
+
+function splitToRow(app: Record<string, unknown>): BackupRow {
+  const row: BackupRow = {};
+  put(row, 'id', text(app.id));
+  put(row, 'transaction_id', text(app.transactionId));
+  put(row, 'category', text(app.category));
+  put(row, 'amount', app.amount);
+  put(row, 'memo', text(app.memo));
+  put(row, 'sort_order', numeric(app.sortOrder));
+  put(row, 'transfer_account_id', text(app.transferAccountId));
+  put(row, 'linked_transfer_id', text(app.linkedTransferId));
+  return row;
+}
+
+function splitFromRow(row: BackupRow): Record<string, unknown> {
+  return compact({
+    id: text(row.id),
+    transactionId: text(row.transaction_id),
+    category: text(row.category),
+    amount: row.amount,
+    memo: text(row.memo),
+    sortOrder: numeric(row.sort_order),
+    transferAccountId: text(row.transfer_account_id),
+    linkedTransferId: text(row.linked_transfer_id),
+  });
+}
+
+// ── budgets ─────────────────────────────────────────────────────────────────
+
+const BUDGET_CARRIED = new Set<string>([
+  'id', 'categoryId', 'amount', 'period', 'isActive', 'createdAt', 'updatedAt',
+  'name', 'spent', 'startDate', 'endDate', 'rollover', 'rolloverAmount',
+  'alertThreshold', 'notes',
+]);
+
+function budgetToRow(app: Record<string, unknown>): BackupRow {
+  const row: BackupRow = {};
+  put(row, 'id', text(app.id));
+  // budgets.name is NOT NULL, and budgetToDb has always filled it the same way.
+  // A row without it is one a cloud restore would refuse halfway through.
+  put(row, 'name', text(app.name) ?? text(app.categoryId) ?? 'Budget');
+  // The frontend's category id travels in the TEXT `category` column, not the
+  // uuid `category_id` — default category ids are not uuids.
+  put(row, 'category', text(app.categoryId));
+  put(row, 'amount', app.amount);
+  put(row, 'period', text(app.period));
+  put(row, 'is_active', bool(app.isActive));
+  put(row, 'spent', numeric(app.spent));
+  put(row, 'start_date', dateColumn(app.startDate));
+  put(row, 'end_date', dateColumn(app.endDate));
+  put(row, 'rollover', bool(app.rollover));
+  put(row, 'rollover_amount', numeric(app.rolloverAmount));
+  put(row, 'alert_threshold', numeric(app.alertThreshold));
+  put(row, 'notes', text(app.notes));
+  put(row, 'created_at', timestampColumn(app.createdAt));
+  put(row, 'updated_at', timestampColumn(app.updatedAt));
+  return withLocalOnlyFields(row, localOnlyFields(app, BUDGET_CARRIED));
+}
+
+function budgetFromRow(row: BackupRow): Record<string, unknown> {
+  return compact({
+    ...readLocalOnlyFields(row),
+    id: text(row.id),
+    categoryId: text(row.category),
+    amount: row.amount,
+    period: text(row.period),
+    isActive: bool(row.is_active),
+    name: text(row.name),
+    spent: numeric(row.spent),
+    startDate: text(row.start_date),
+    endDate: text(row.end_date),
+    rollover: bool(row.rollover),
+    rolloverAmount: numeric(row.rollover_amount),
+    alertThreshold: numeric(row.alert_threshold),
+    notes: text(row.notes),
+    createdAt: text(row.created_at),
+    updatedAt: text(row.updated_at),
+  });
+}
+
+// ── goals ───────────────────────────────────────────────────────────────────
+
+/**
+ * Three Goal fields have no column and ride in `metadata`, exactly as goalToDb
+ * puts them there on every cloud write: `type`, `linkedAccountIds` and
+ * `contributionAmount`. They are handled explicitly rather than left to the
+ * leftovers hatch so a goal written locally and a goal written by the cloud
+ * produce the same row.
+ */
+const GOAL_CARRIED = new Set<string>([
+  'id', 'name', 'description', 'targetAmount', 'currentAmount', 'progress',
+  'targetDate', 'isActive', 'achieved', 'status', 'completedAt', 'createdAt',
+  'updatedAt', 'category', 'priority', 'accountId', 'autoContribute',
+  'contributionFrequency', 'icon', 'color',
+  'type', 'linkedAccountIds', 'contributionAmount',
+]);
+
+function goalStatus(app: Record<string, unknown>): string | undefined {
+  const status = text(app.status);
+  if (status !== undefined) return status;
+  if (app.achieved === true) return 'completed';
+  const active = bool(app.isActive);
+  if (active === undefined) return undefined;
+  return active ? 'active' : 'paused';
+}
+
+function goalToRow(app: Record<string, unknown>): BackupRow {
+  const row: BackupRow = {};
+  put(row, 'id', text(app.id));
+  put(row, 'name', text(app.name));
+  put(row, 'description', text(app.description));
+  put(row, 'target_amount', app.targetAmount);
+  // `progress` is what the UI layer treats as the accumulated amount; goalToDb
+  // prefers it over currentAmount for exactly that reason.
+  put(row, 'current_amount', app.progress ?? app.currentAmount);
+  put(row, 'target_date', dateColumn(app.targetDate));
+  put(row, 'category', text(app.category));
+  put(row, 'priority', text(app.priority));
+  put(row, 'status', goalStatus(app));
+  put(row, 'completed_at', timestampColumn(app.completedAt));
+  put(row, 'account_id', text(app.accountId));
+  put(row, 'auto_contribute', bool(app.autoContribute));
+  put(row, 'contribution_frequency', text(app.contributionFrequency));
+  put(row, 'icon', text(app.icon));
+  put(row, 'color', text(app.color));
+  put(row, 'created_at', timestampColumn(app.createdAt));
+  put(row, 'updated_at', timestampColumn(app.updatedAt));
+
+  const metadata: Record<string, unknown> = {};
+  if (text(app.type) !== undefined) metadata.type = app.type;
+  if (textArray(app.linkedAccountIds) !== undefined) metadata.linkedAccountIds = app.linkedAccountIds;
+  if (numeric(app.contributionAmount) !== undefined) metadata.contributionAmount = app.contributionAmount;
+  if (Object.keys(metadata).length > 0) row.metadata = metadata;
+
+  return withLocalOnlyFields(row, localOnlyFields(app, GOAL_CARRIED));
+}
+
+function goalFromRow(row: BackupRow): Record<string, unknown> {
+  const metadata = isRecord(row.metadata) ? row.metadata : {};
+  const status = text(row.status);
+  const currentAmount = row.current_amount;
+  return compact({
+    ...readLocalOnlyFields(row),
+    id: text(row.id),
+    name: text(row.name),
+    description: text(row.description),
+    targetAmount: row.target_amount,
+    currentAmount,
+    progress: currentAmount,
+    targetDate: text(row.target_date),
+    category: text(row.category),
+    priority: text(row.priority),
+    status,
+    isActive: status === undefined ? undefined : status !== 'paused',
+    achieved: status === undefined ? undefined : status === 'completed',
+    completedAt: text(row.completed_at),
+    accountId: text(row.account_id),
+    autoContribute: bool(row.auto_contribute),
+    contributionFrequency: text(row.contribution_frequency),
+    icon: text(row.icon),
+    color: text(row.color),
+    createdAt: text(row.created_at),
+    updatedAt: text(row.updated_at),
+    type: text(metadata.type),
+    linkedAccountIds: textArray(metadata.linkedAccountIds),
+    contributionAmount: numeric(metadata.contributionAmount),
+  });
+}
+
+// ── suggestion_dismissals ───────────────────────────────────────────────────
+
+function dismissalToRow(app: Record<string, unknown>): BackupRow {
+  const row: BackupRow = {};
+  put(row, 'id', text(app.id));
+  put(row, 'kind', text(app.kind));
+  // subject_key is TEXT built out of row ids, and remapBackupIds rewrites and
+  // re-sorts it. Carrying it as-is is what keeps a refused suggestion refused.
+  put(row, 'subject_key', text(app.subjectKey));
+  put(row, 'subject_ids', textArray(app.subjectIds) ?? []);
+  put(row, 'dismissed_at', timestampColumn(app.dismissedAt));
+  return row;
+}
+
+function dismissalFromRow(row: BackupRow): Record<string, unknown> {
+  return compact({
+    id: text(row.id),
+    kind: text(row.kind),
+    subjectKey: text(row.subject_key),
+    subjectIds: textArray(row.subject_ids) ?? [],
+    dismissedAt: text(row.dismissed_at),
+  });
+}
+
+// ── The one mapping: table ↔ browser storage ────────────────────────────────
+
+interface StoredLocally {
+  readonly stored: true;
+  readonly storageKey: string;
+  readonly label: string;
+  readonly toRow: (app: Record<string, unknown>) => BackupRow;
+  readonly fromRow: (row: BackupRow) => Record<string, unknown>;
+}
+
+interface NotStoredLocally {
+  readonly stored: false;
+  readonly label: string;
+  /** Said back to the user when a file holds rows this device cannot keep. */
+  readonly absence: string;
+}
+
+export type LocalEntityBinding = StoredLocally | NotStoredLocally;
+
+/**
+ * THE single source of truth for what local backup and restore touch.
+ *
+ * Keyed by BackupEntity, so a table added to BACKUP_ENTITIES without a decision
+ * recorded here is a COMPILE error, not a table that quietly stops being backed
+ * up. The runtime check below covers the same ground for a build that reached
+ * production some other way — this is the one mapping where "silently absent"
+ * means a user loses data and finds out on the day they need the file.
+ *
+ * Every `stored: false` entry is a decision with a reason attached, not an
+ * omission: local mode has no screen, no writer and no reader for those tables,
+ * and inventing a storage key for data the app cannot use would produce a
+ * backup nobody could restore into anything.
+ */
+export const LOCAL_BACKUP_BINDINGS: Readonly<Record<BackupEntity, LocalEntityBinding>> = {
+  accounts: {
+    stored: true, storageKey: STORAGE_KEYS.ACCOUNTS, label: 'Accounts',
+    toRow: accountToRow, fromRow: accountFromRow,
+  },
+  categories: {
+    stored: true, storageKey: STORAGE_KEYS.CATEGORIES, label: 'Categories',
+    toRow: categoryToRow, fromRow: categoryFromRow,
+  },
+  transactions: {
+    stored: true, storageKey: STORAGE_KEYS.TRANSACTIONS, label: 'Transactions',
+    toRow: transactionToRow, fromRow: transactionFromRow,
+  },
+  transaction_splits: {
+    stored: true, storageKey: STORAGE_KEYS.TRANSACTION_SPLITS, label: 'Transaction splits',
+    toRow: splitToRow, fromRow: splitFromRow,
+  },
+  budgets: {
+    stored: true, storageKey: STORAGE_KEYS.BUDGETS, label: 'Budgets',
+    toRow: budgetToRow, fromRow: budgetFromRow,
+  },
+  goals: {
+    stored: true, storageKey: STORAGE_KEYS.GOALS, label: 'Goals',
+    toRow: goalToRow, fromRow: goalFromRow,
+  },
+  suggestion_dismissals: {
+    stored: true, storageKey: STORAGE_KEYS.SUGGESTION_DISMISSALS, label: 'Dismissed suggestions',
+    toRow: dismissalToRow, fromRow: dismissalFromRow,
+  },
+  goal_contributions: {
+    stored: false, label: 'Goal contributions',
+    absence: 'contributions towards a goal are only recorded when you are signed in',
+  },
+  investments: {
+    stored: false, label: 'Investments',
+    absence: 'holdings are only tracked when you are signed in',
+  },
+  investment_transactions: {
+    stored: false, label: 'Investment transactions',
+    absence: 'buys and sells are only recorded when you are signed in',
+  },
+  recurring_transactions: {
+    stored: false, label: 'Recurring transactions',
+    // wealthtracker_recurring is written by the demo seed and by nothing else,
+    // in a shape that is not a recurring_transactions row, and read by nothing
+    // at all. Backing that up would put rows in the file that no restore —
+    // local or cloud — could use.
+    absence: 'repeating templates are only kept when you are signed in',
+  },
+  notifications: {
+    stored: false, label: 'Notifications',
+    // NotificationContext keeps at most twenty of these for at most a week, in
+    // plain localStorage. They are alerts about the data, not the data.
+    absence: 'alerts are short-lived and are not part of a backup',
+  },
+  dashboard_layouts: {
+    stored: false, label: 'Dashboard layouts',
+    absence: 'dashboard arrangements are only saved when you are signed in',
+  },
+  widget_preferences: {
+    stored: false, label: 'Widget preferences',
+    absence: 'widget settings are only saved when you are signed in',
+  },
+};
+
+// A binding missing at runtime would mean an entity silently vanished from
+// every backup taken afterwards. Fail at import instead, where it cannot be
+// mistaken for an empty table.
+const unbound = BACKUP_ENTITIES.filter((entity) => LOCAL_BACKUP_BINDINGS[entity] === undefined);
+if (unbound.length > 0) {
+  throw new Error(
+    `Local backup has no decision recorded for: ${unbound.join(', ')}. ` +
+    'Every table in BACKUP_ENTITIES needs an entry in LOCAL_BACKUP_BINDINGS — ' +
+    'either the storage key it lives under, or the reason this device does not hold it.'
+  );
+}
+
+/** Storage keys a local backup reads and a local restore replaces, in order. */
+export const LOCAL_BACKUP_STORAGE_KEYS: readonly string[] = BACKUP_ENTITIES
+  .map((entity) => LOCAL_BACKUP_BINDINGS[entity])
+  .filter((binding): binding is StoredLocally => binding.stored)
+  .map((binding) => binding.storageKey);
+
+/**
+ * There is no account behind a browser-local backup, and pretending otherwise
+ * would put a made-up id in a field a reader might trust. Restore ignores it on
+ * both engines — every row is re-owned to whoever is restoring.
+ */
+export const LOCAL_SOURCE_USER_ID = 'local-device';
+
+// ── Reading rows out of browser storage ─────────────────────────────────────
+
+/** Money columns whose magnitude decides whether a backup can be exact. */
+const MONEY_COLUMNS = [
+  'amount', 'balance', 'initial_balance', 'bank_balance', 'target_amount',
+  'current_amount', 'low_balance_threshold', 'spent', 'rollover_amount',
+] as const;
+
+/**
+ * A money value stored as text that would not survive the round trip.
+ *
+ * buildBackupBundle already refuses numbers beyond MAX_EXACT_MONEY, but it can
+ * only see numbers — and browser storage is hand-editable JSON, so an amount
+ * can arrive as a string. Compared through Decimal, never through parseFloat:
+ * the comparison itself must not be the thing that loses the penny.
+ */
+function unsafeTextMoney(entity: BackupEntity, row: BackupRow): string | null {
+  for (const column of MONEY_COLUMNS) {
+    const value = row[column];
+    if (typeof value !== 'string' || value.length === 0) continue;
+    let magnitude;
+    try {
+      magnitude = toDecimal(value).abs();
+    } catch {
+      return `${entity} ${String(row.id ?? '(no id)')} has ${column} = "${value}", which is not a number at all.`;
+    }
+    if (magnitude.greaterThan(MAX_EXACT_MONEY)) {
+      return `${entity} ${String(row.id ?? '(no id)')} has ${column} = "${value}", which is larger than ${MAX_EXACT_MONEY} — beyond that, restoring it would change the amount.`;
+    }
+  }
+  return null;
+}
+
+async function readEntityRows(
+  store: LocalBackupStore,
+  entity: BackupEntity,
+  binding: StoredLocally
+): Promise<BackupRow[]> {
+  const stored = await store.get<unknown>(binding.storageKey);
+  if (stored === null || stored === undefined) return [];
+  if (!Array.isArray(stored)) {
+    throw new Error(
+      `Browser storage holds something other than a list under ${binding.storageKey}, ` +
+      `so ${binding.label} could not be backed up. Nothing has been written.`
+    );
+  }
+
+  const rows: BackupRow[] = [];
+  for (const entry of stored) {
+    // A non-object entry is corruption, and a backup that skipped it would be a
+    // backup that quietly held less than the app does.
+    if (!isRecord(entry)) {
+      throw new Error(
+        `${binding.label} in browser storage contains an entry that is not a record, ` +
+        'so this backup would not be a faithful copy. Nothing has been written.'
+      );
+    }
+    const row = binding.toRow(entry);
+    const problem = unsafeTextMoney(entity, row);
+    if (problem !== null) {
+      throw new Error(`This backup would lose precision and has not been written. ${problem}`);
+    }
+    rows.push(row);
+  }
+  return rows;
+}
+
+/**
+ * Read every table this device holds and build the file.
+ *
+ * The same builder the cloud export uses, so the money-precision guard, the
+ * empty-array-per-table rule and the links payload all come for free rather
+ * than being re-implemented slightly differently.
+ */
+export async function collectLocalBackupBundle(
+  options: {
+    onProgress?: (progress: ExportProgress) => void;
+    store?: LocalBackupStore;
+    now?: () => Date;
+  } = {}
+): Promise<BackupBundle> {
+  const store = options.store ?? defaultStore();
+  const data: Partial<Record<BackupEntity, BackupRow[]>> = {};
+
+  for (const [index, entity] of BACKUP_ENTITIES.entries()) {
+    const report = (rows: number): void => options.onProgress?.({
+      entity,
+      entityNumber: index + 1,
+      entityCount: BACKUP_ENTITIES.length,
+      rows,
+    });
+    report(0);
+
+    const binding = LOCAL_BACKUP_BINDINGS[entity];
+    const rows = binding.stored ? await readEntityRows(store, entity, binding) : [];
+    data[entity] = rows;
+    report(rows.length);
+  }
+
+  const now = options.now ?? (() => new Date());
+  return buildBackupBundle({
+    sourceUserId: LOCAL_SOURCE_USER_ID,
+    exportedAt: now().toISOString(),
+    data,
+  });
+}
+
+// ── Is there anything here? ─────────────────────────────────────────────────
+
+/**
+ * True when this device holds no accounts, categories or transactions — the
+ * same three tables user_financial_data_is_empty asks about, so "empty" means
+ * one thing across both engines.
+ */
+export async function localFinancialDataIsEmpty(
+  options: { store?: LocalBackupStore } = {}
+): Promise<boolean> {
+  const store = options.store ?? defaultStore();
+  for (const key of [STORAGE_KEYS.ACCOUNTS, STORAGE_KEYS.CATEGORIES, STORAGE_KEYS.TRANSACTIONS]) {
+    const stored = await store.get<unknown>(key);
+    if (Array.isArray(stored) && stored.length > 0) return false;
+  }
+  return true;
+}
+
+// ── Clearing it ─────────────────────────────────────────────────────────────
+
+/** The phrase wipe_user_financial_data demands, so both engines ask the same. */
+export const LOCAL_WIPE_CONFIRMATION = 'DELETE EVERYTHING';
+
+/**
+ * Erase this device's financial data.
+ *
+ * Replaces the old `wipeLocalData`, which wrote `'[]'` into `window.localStorage`
+ * while every reader in the app goes through storageAdapter → encryptedStorage →
+ * IndexedDB. The keys it cleared were not the keys anything read, so "Clear All
+ * Data" reported success and changed nothing; its test asserted on localStorage
+ * and passed for the same reason.
+ *
+ * One bulk write, so the clear either happens or does not — it cannot empty the
+ * accounts and leave the transactions behind. Returns what was actually thrown
+ * away, per table, the way wipe_user_financial_data returns its counts.
+ */
+export async function wipeLocalFinancialData(
+  confirmation: string,
+  options: { store?: LocalBackupStore } = {}
+): Promise<Record<string, number>> {
+  if (confirmation !== LOCAL_WIPE_CONFIRMATION) {
+    throw new Error(
+      'wipe_not_confirmed: this erases every account, transaction, budget and goal on this device — the caller must pass the exact confirmation phrase'
+    );
+  }
+
+  const store = options.store ?? defaultStore();
+  const counts: Record<string, number> = {};
+  const entries: Array<{ key: string; value: unknown }> = [];
+
+  for (const entity of BACKUP_ENTITIES) {
+    const binding = LOCAL_BACKUP_BINDINGS[entity];
+    if (!binding.stored) continue;
+    const stored = await store.get<unknown>(binding.storageKey);
+    counts[entity] = Array.isArray(stored) ? stored.length : 0;
+    entries.push({ key: binding.storageKey, value: [] });
+  }
+
+  await store.setMany(entries);
+  return counts;
+}
+
+// ── Putting a file back ─────────────────────────────────────────────────────
+
+export interface LocalRestoreOutcome {
+  /** Rows written, per table, in the order the file holds them. */
+  restored: { label: string; rows: number }[];
+  /**
+   * Rows the file carries that this device has nowhere to keep. Reported rather
+   * than dropped in silence: the file still holds them, and signing in and
+   * restoring the same file there would.
+   */
+  notStoredLocally: { label: string; rows: number; absence: string }[];
+  accountsRelinked: number;
+  transactionsRelinked: number;
+  danglingRefs: DanglingReference[];
+}
+
+export class LocalRestoreRefusedError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'LocalRestoreRefusedError';
+  }
+}
+
+/**
+ * Close the links the file records separately.
+ *
+ * The cloud NULLs these on insert and patches them in a second pass because
+ * their constraints form cycles and none is DEFERRABLE. Browser storage has no
+ * constraints at all, so nothing forces the two-step here — but the links
+ * payload is applied over the rows anyway, because it is what
+ * finalize_user_restore applies, and a file whose two copies disagree must
+ * restore the same way on both engines rather than differently.
+ */
+function applyLinks(bundle: BackupBundle): {
+  accounts: BackupRow[];
+  transactions: BackupRow[];
+  accountsRelinked: number;
+  transactionsRelinked: number;
+} {
+  const parents = new Map<string, string>();
+  for (const link of bundle.links.account_parents) {
+    if (link.parent_account_id) parents.set(link.id, link.parent_account_id);
+  }
+
+  const transfers = new Map<string, { transfer: string | null; split: string | null }>();
+  for (const link of bundle.links.transaction_links) {
+    if (link.linked_transfer_id || link.linked_transfer_split_id) {
+      transfers.set(link.id, { transfer: link.linked_transfer_id, split: link.linked_transfer_split_id });
+    }
+  }
+
+  let accountsRelinked = 0;
+  const accounts = bundle.data.accounts.map((row) => {
+    const id = typeof row.id === 'string' ? row.id : null;
+    const parent = id === null ? undefined : parents.get(id);
+    if (parent === undefined) return row;
+    accountsRelinked += 1;
+    return { ...row, parent_account_id: parent };
+  });
+
+  let transactionsRelinked = 0;
+  const transactions = bundle.data.transactions.map((row) => {
+    const id = typeof row.id === 'string' ? row.id : null;
+    const link = id === null ? undefined : transfers.get(id);
+    if (link === undefined) return row;
+    transactionsRelinked += 1;
+    return { ...row, linked_transfer_id: link.transfer, linked_transfer_split_id: link.split };
+  });
+
+  return { accounts, transactions, accountsRelinked, transactionsRelinked };
+}
+
+/**
+ * Restore a backup into browser storage.
+ *
+ * ── THE PRECONDITION ────────────────────────────────────────────────────────
+ * Refused unless this device is empty, the same rule the cloud enforces. None
+ * of the reasons the migration gives applies here — there are no triggers to
+ * mint a colliding transfer category, no unique constraints to trip, no
+ * updated_at stamps to preserve — so locally it is not a mechanical necessity.
+ * It is kept because it is a product rule worth having on its own: a restore
+ * REPLACES, replacing is destructive, and destruction gets its own
+ * confirmation rather than hiding inside the same click as "restore". Keeping
+ * it also means one sentence describes the feature on both engines, instead of
+ * the app quietly merging on one and refusing on the other.
+ *
+ * ── FAILURE ─────────────────────────────────────────────────────────────────
+ * Everything is converted first and written last, in ONE IndexedDB transaction.
+ * So a failure while reading, validating or converting writes nothing at all,
+ * and a failure during the write is rolled back by IndexedDB. There is no
+ * halfway state to be stranded in — which is strictly better than the cloud,
+ * where chunks are separate transactions and a mid-restore failure leaves the
+ * login partly populated.
+ *
+ * What CAN still leave a user with nothing is the sequence, not the operation:
+ * erasing a device (its own confirmed step) and then failing to restore leaves
+ * it empty. The file on disk is the way back, which is why the dialog says to
+ * keep it before erasing anything.
+ */
+export async function restoreLocalBackupBundle(
+  bundle: BackupBundle,
+  options: {
+    onProgress?: (progress: RestoreProgress) => void;
+    store?: LocalBackupStore;
+    newId?: () => string;
+  } = {}
+): Promise<LocalRestoreOutcome> {
+  const store = options.store ?? defaultStore();
+
+  if (!(await localFinancialDataIsEmpty({ store }))) {
+    throw new LocalRestoreRefusedError(
+      'restore_target_not_empty: this device already holds data — clear it first, because restoring on top would replace everything here with the file'
+    );
+  }
+
+  // Every id is replaced before anything is written, for the reason
+  // remapBackupIds sets out: primary keys are global rather than per user, so a
+  // file restored anywhere but where it came from would otherwise carry ids
+  // that belong to somebody else's rows.
+  const { bundle: remapped, danglingRefs } = options.newId
+    ? remapBackupIds(bundle, options.newId)
+    : remapBackupIds(bundle);
+
+  const { accounts, transactions, accountsRelinked, transactionsRelinked } = applyLinks(remapped);
+  const linked: Record<BackupEntity, BackupRow[]> = { ...remapped.data, accounts, transactions };
+
+  const restored: { label: string; rows: number }[] = [];
+  const notStoredLocally: { label: string; rows: number; absence: string }[] = [];
+  const entries: Array<{ key: string; value: unknown }> = [];
+
+  const stepCount = BACKUP_ENTITIES.length + 1;
+  for (const [index, entity] of BACKUP_ENTITIES.entries()) {
+    const binding = LOCAL_BACKUP_BINDINGS[entity];
+    const rows = linked[entity];
+
+    options.onProgress?.({
+      stepNumber: index + 1,
+      stepCount,
+      label: binding.label,
+      rowsDone: 0,
+      rowsTotal: rows.length,
+    });
+
+    if (!binding.stored) {
+      if (rows.length > 0) {
+        notStoredLocally.push({ label: binding.label, rows: rows.length, absence: binding.absence });
+      }
+      continue;
+    }
+
+    // Every stored table is written, empty ones included: a restore replaces,
+    // so a table the file has no rows for must end up empty rather than keeping
+    // whatever happened to be there.
+    entries.push({ key: binding.storageKey, value: rows.map(binding.fromRow) });
+    restored.push({ label: binding.label, rows: rows.length });
+
+    options.onProgress?.({
+      stepNumber: index + 1,
+      stepCount,
+      label: binding.label,
+      rowsDone: rows.length,
+      rowsTotal: rows.length,
+    });
+  }
+
+  options.onProgress?.({
+    stepNumber: stepCount,
+    stepCount,
+    label: 'Saving',
+    rowsDone: 0,
+    rowsTotal: entries.length,
+  });
+
+  await store.setMany(entries);
+
+  return { restored, notStoredLocally, accountsRelinked, transactionsRelinked, danglingRefs };
+}

--- a/src/services/ofxImportService.test.ts
+++ b/src/services/ofxImportService.test.ts
@@ -161,7 +161,8 @@ NEWFILEUID:NONE
         name: 'TESCO STORES',
         memo: 'Grocery shopping',
         checkNum: undefined,
-        refNum: undefined
+        refNum: undefined,
+        sequence: 0
       });
 
       // Second transaction - CREDIT
@@ -173,7 +174,8 @@ NEWFILEUID:NONE
         name: 'EMPLOYER PAYMENT',
         memo: 'Salary',
         checkNum: undefined,
-        refNum: undefined
+        refNum: undefined,
+        sequence: 1
       });
 
       // Third transaction - CHECK
@@ -185,7 +187,8 @@ NEWFILEUID:NONE
         name: 'Check #1234',
         memo: undefined,
         checkNum: '1234',
-        refNum: undefined
+        refNum: undefined,
+        sequence: 2
       });
     });
 
@@ -294,6 +297,64 @@ NEWFILEUID:NONE
 
       const result = ofxImportService.parseOFX(ofxWithoutLedger);
       expect(result.balance).toBeUndefined();
+    });
+
+    it('keeps the file position of each transaction — the bank\'s own order', () => {
+      // OFX lists <STMTTRN> in STATEMENT order, and that is the only record of
+      // which of a day's transactions came first. The parser used to throw it
+      // away, leaving the register to invent a same-day order; on an account
+      // swept back to zero each evening, the invented order showed balances the
+      // account never held.
+      const result = ofxImportService.parseOFX(validOFXContent);
+
+      // The fixture lists 15 Jan, then 20 Jan, then 10 Jan — file order, NOT
+      // date order, which is the point: position is recorded as found.
+      expect(result.transactions.map(t => t.sequence)).toEqual([0, 1, 2]);
+      expect(result.transactions.map(t => t.datePosted))
+        .toEqual(['2024-01-15', '2024-01-20', '2024-01-10']);
+    });
+
+    it('numbers the rows it keeps, leaving no gap for one it had to skip', () => {
+      // A block missing its FITID is dropped. Counting it would leave a hole in
+      // the sequence that reads like a transaction that went missing.
+      const withUnusableRow = validOFXContent.replace('<FITID>2024012001\n', '');
+
+      const result = ofxImportService.parseOFX(withUnusableRow);
+      expect(result.transactions).toHaveLength(2);
+      expect(result.transactions.map(t => t.sequence)).toEqual([0, 1]);
+    });
+
+    it('records a zero LEDGERBAL as a real closing balance of 0.00', () => {
+      // ABSENT and ZERO are different, and only one of them means "the file
+      // says nothing". A zero ledger balance is a statement of fact and is
+      // written like any other: accounts on a nightly two-way sweep — the
+      // balance moved to a linked savings account each night — legitimately
+      // close at exactly 0.00 every single day, as does a card paid off in
+      // full. Refusing to record those (on the theory that a bank publishing
+      // a non-zero AVAILBAL beside a zero LEDGERBAL must have left the ledger
+      // unfilled) would deny the swept account the one correct figure it has,
+      // for ever. AVAILBAL says nothing about whether the ledger is true; on a
+      // swept current account it is the overdraft headroom, which is non-zero
+      // precisely BECAUSE the balance is zero.
+      const sweptToZero = validOFXContent.replace(
+        /<LEDGERBAL>[\s\S]*?<\/LEDGERBAL>/g,
+        `<LEDGERBAL><BALAMT>0</BALAMT><DTASOF>20240131235959</DTASOF></LEDGERBAL>
+<AVAILBAL><BALAMT>250.00</BALAMT><DTASOF>20240131235959</DTASOF></AVAILBAL>`
+      );
+
+      expect(ofxImportService.parseOFX(sweptToZero).balance)
+        .toEqual({ amount: 0, dateAsOf: '2024-01-31' });
+    });
+
+    it('carries that zero through the import path to the caller', async () => {
+      const sweptToZero = validOFXContent.replace('<BALAMT>5000.00', '<BALAMT>0.00');
+
+      const result = await ofxImportService.importTransactions(sweptToZero, mockAccounts, []);
+
+      // Not undefined: the caller must be able to tell a zero balance from no
+      // balance, because planStatementBankBalance writes the first and skips
+      // the second.
+      expect(result.statementBalance).toEqual({ amount: 0, dateAsOf: '2024-01-31' });
     });
 
     it('survives an unreadable BALAMT instead of failing the whole import', () => {

--- a/src/services/ofxImportService.ts
+++ b/src/services/ofxImportService.ts
@@ -2,6 +2,12 @@ import type { Transaction, Account, Category } from '../types';
 import { smartCategorizationService } from './smartCategorizationService';
 import { parseMoneyInput, toDecimal, toNumber } from '../utils/decimal';
 import { findAccountByOfxIdentifiers } from '../utils/ofxAccountIdentifiers';
+import { isSelfTransferCategory } from '../utils/transferMatch';
+import {
+  findStatementDuplicates,
+  type IncomingStatementRow,
+  type StatementDuplicateMatch
+} from '../utils/statementDuplicates';
 import type { StatementBalance } from '../utils/statementBankBalance';
 
 interface OFXTransaction {
@@ -13,6 +19,13 @@ interface OFXTransaction {
   memo?: string;
   checkNum?: string;
   refNum?: string;
+  /**
+   * Position in the file, from 0. OFX lists <STMTTRN> in STATEMENT order, so
+   * this is the bank's own sequence — the only record of which of a day's
+   * transactions came first, and until now the one thing this parser threw
+   * away. See Transaction.statementSequence.
+   */
+  sequence: number;
 }
 
 export interface OFXAccount {
@@ -191,7 +204,11 @@ export class OFXImportService {
           name: this.cleanString(name),
           memo: memo ? this.cleanString(memo) : undefined,
           checkNum: checkNum || undefined,
-          refNum: refNum || undefined
+          refNum: refNum || undefined,
+          // Position among the rows KEPT, not among the <STMTTRN> blocks seen:
+          // a block missing a date, amount or FITID is skipped above, and
+          // counting it would leave a gap that reads as a lost transaction.
+          sequence: transactions.length
         });
       }
     }
@@ -410,6 +427,13 @@ export class OFXImportService {
       duplicateThreshold?: number;
       categories?: Category[];
       autoCategorize?: boolean;
+      /**
+       * FITIDs the user has looked at and decided to import anyway — rows the
+       * amount-and-date rule flagged as already held but which are genuinely
+       * new (two £20 withdrawals on one day). Never overrides a FITID match:
+       * there the bank itself says the two are the same transaction.
+       */
+      importAnywayFitIds?: readonly string[];
     } = {}
   ): Promise<{
     transactions: Omit<Transaction, 'id'>[];
@@ -441,6 +465,20 @@ export class OFXImportService {
      * the same way, and this importer already stores those verbatim.
      */
     statementBalance?: StatementBalance;
+    /**
+     * Every row in the file, in file order — including the ones this call
+     * decided not to import. The review list is built from these, and
+     * `duplicateMatches` indexes into them.
+     */
+    statementRows: IncomingStatementRow[];
+    /**
+     * What the register already holds, split by how sure the match is:
+     * `certain` is the bank's own FITID on both sides, `possible` is same
+     * account / exact amount / near date and wants a human. Reported whether
+     * or not `skipDuplicates` acted on them.
+     */
+    duplicateMatches: { certain: StatementDuplicateMatch[]; possible: StatementDuplicateMatch[] };
+    /** How many rows were left out as already held. */
     duplicates: number;
     newTransactions: number;
   }> {
@@ -457,43 +495,36 @@ export class OFXImportService {
       matchConfidence = match?.confidence ?? null;
     }
 
-    const transactions: Omit<Transaction, 'id'>[] = [];
-    let duplicates = 0;
-    
+    const destinationAccountId = matchedAccount?.id || 'default';
+
+    // Every row is drafted BEFORE anything is dropped, so the duplicate rule
+    // sees the same list the user is shown and the two cannot disagree about
+    // which row is which.
+    const drafts: Omit<Transaction, 'id'>[] = [];
+    const statementRows: IncomingStatementRow[] = [];
+
     for (const ofxTrx of parseResult.transactions) {
-      // Check for duplicates using FITID (Financial Institution Transaction ID)
-      if (options.skipDuplicates !== false) {
-        const isDuplicate = existingTransactions.some(existing => 
-          existing.notes && existing.notes.includes(`FITID: ${ofxTrx.fitId}`)
-        );
-        
-        if (isDuplicate) {
-          duplicates++;
-          continue;
-        }
-      }
-      
       // Signed convention: OFX TRNAMT is already signed at the source
       // (debits negative, credits positive), so store the signed value directly.
       const amount = ofxTrx.amount;
       const type = this.getTransactionType(ofxTrx.type, ofxTrx.amount);
-      
+
       // Build description
       const description = ofxTrx.memo || ofxTrx.name;
-      
+
       // Add notes with OFX metadata
       const notes = [
         `FITID: ${ofxTrx.fitId}`,
         ofxTrx.checkNum ? `Check #: ${ofxTrx.checkNum}` : null,
         ofxTrx.refNum ? `Ref: ${ofxTrx.refNum}` : null
       ].filter(Boolean).join('\n');
-      
+
       const transaction: Omit<Transaction, 'id'> = {
         date: new Date(ofxTrx.datePosted),
         description,
         amount,
         type,
-        accountId: matchedAccount?.id || 'default',
+        accountId: destinationAccountId,
         category: '',
         // Deliberately NOT cleared, despite the file coming from the bank.
         // "Cleared" here does not mean the bank has processed it — it means the
@@ -504,34 +535,76 @@ export class OFXImportService {
         // Every other file importer already defaults this false; OFX was alone.
         cleared: false,
         notes,
-        isRecurring: false
+        isRecurring: false,
+        // The bank's own order within the statement, kept so the register's
+        // running balance can walk a day the way the bank printed it instead of
+        // guessing. Duplicates are skipped above, so this stays the position in
+        // the FILE, not in this batch — re-importing an overlapping statement
+        // must not renumber the rows it shares with the last one.
+        statementSequence: ofxTrx.sequence
       };
-      
+
       // Auto-categorize if enabled
       if (options.autoCategorize && options.categories) {
         // Train the model if we have existing transactions
         if (existingTransactions.length > 0) {
           smartCategorizationService.learnFromTransactions(existingTransactions, options.categories);
         }
-        
+
         // Get category suggestions
         const suggestions = smartCategorizationService.suggestCategories(transaction as Transaction, 1);
-        
-        if (suggestions.length > 0 && suggestions[0].confidence >= 0.7) {
+
+        if (suggestions.length > 0 &&
+            suggestions[0].confidence >= 0.7 &&
+            // A transfer to the account the row is already in describes nothing
+            // — and it is exactly what the merchant key "immediate faster
+            // payment" produces on an account whose own sweeps share it.
+            !isSelfTransferCategory(options.categories, suggestions[0].categoryId, destinationAccountId)) {
           transaction.category = suggestions[0].categoryId;
         }
       }
-      
-      transactions.push(transaction);
+
+      drafts.push(transaction);
+      statementRows.push({
+        date: transaction.date,
+        amount,
+        description,
+        fitId: ofxTrx.fitId
+      });
     }
-    
+
+    const duplicateMatches = findStatementDuplicates(
+      statementRows,
+      existingTransactions,
+      destinationAccountId
+    );
+
+    // Which drafts to leave out. FITID matches are the bank's own word and are
+    // never overridden; an amount-and-date match is evidence a human may have
+    // already looked at and overruled.
+    const importAnyway = new Set(options.importAnywayFitIds ?? []);
+    const skipped = new Set<number>();
+    if (options.skipDuplicates !== false) {
+      for (const match of duplicateMatches.certain) {
+        skipped.add(match.incomingIndex);
+      }
+      for (const match of duplicateMatches.possible) {
+        if (match.fitId !== null && importAnyway.has(match.fitId)) continue;
+        skipped.add(match.incomingIndex);
+      }
+    }
+
+    const transactions = drafts.filter((_, index) => !skipped.has(index));
+
     return {
       transactions,
       matchedAccount,
       ofxAccount: parseResult.account,
       matchConfidence,
       statementBalance: parseResult.balance,
-      duplicates,
+      statementRows,
+      duplicateMatches,
+      duplicates: skipped.size,
       newTransactions: transactions.length
     };
   }

--- a/src/services/qifImportService.ts
+++ b/src/services/qifImportService.ts
@@ -1,6 +1,7 @@
 import type { Transaction, Category } from '../types';
 import { smartCategorizationService } from './smartCategorizationService';
 import { buildCategoryMatcher } from '../utils/qifCategoryMatch';
+import { isSelfTransferCategory } from '../utils/transferMatch';
 import { toDecimal, toNumber } from '../utils/decimal';
 
 export interface QIFTransaction {
@@ -397,8 +398,14 @@ export class QIFImportService {
         
         // Get category suggestions
         const suggestions = smartCategorizationService.suggestCategories(transaction as Transaction, 1);
-        
-        if (suggestions.length > 0 && suggestions[0].confidence >= 0.7) {
+
+        if (suggestions.length > 0 &&
+            suggestions[0].confidence >= 0.7 &&
+            // Never "transfer to the account this row is already in" — the same
+            // guard the OFX importer carries, for the same reason: the learned
+            // merchant key is often the payment channel, which an account's own
+            // internal transfers share with every third-party payment.
+            !isSelfTransferCategory(options.categories, suggestions[0].categoryId, targetAccountId)) {
           transaction.category = suggestions[0].categoryId;
         }
       }

--- a/src/services/storageAdapter.ts
+++ b/src/services/storageAdapter.ts
@@ -177,21 +177,37 @@ export class SecureStorageAdapter implements StorageAdapter {
     }
   }
 
+  /**
+   * Keys holding the user's own records rather than a cached or derived copy.
+   *
+   * Membership decides ONE thing that matters more than the encryption flag it
+   * is named for: everything outside this list is stored with a 30-day expiry
+   * and is deleted on the first read after it lapses. Categories, splits and
+   * dismissals were outside it, so a local dataset lost its category tree a
+   * month after the last write — and a restored backup would have evaporated
+   * the same way. They are the user's records; they do not expire.
+   */
+  private static readonly FINANCIAL_KEYS: readonly string[] = [
+    STORAGE_KEYS.ACCOUNTS,
+    STORAGE_KEYS.TRANSACTIONS,
+    STORAGE_KEYS.TRANSACTION_SPLITS,
+    STORAGE_KEYS.CATEGORIES,
+    STORAGE_KEYS.BUDGETS,
+    STORAGE_KEYS.GOALS,
+    STORAGE_KEYS.SUGGESTION_DISMISSALS,
+  ];
+
+  private isFinancialKey(key: string): boolean {
+    return SecureStorageAdapter.FINANCIAL_KEYS.includes(key) ||
+           key.includes('transaction') ||
+           key.includes('account') ||
+           key.includes('budget') ||
+           key.includes('financial');
+  }
+
   async set<T>(key: string, value: T): Promise<void> {
     try {
-      // Determine if this is sensitive data that should be encrypted
-      const sensitiveKeys = [
-        STORAGE_KEYS.ACCOUNTS,
-        STORAGE_KEYS.TRANSACTIONS,
-        STORAGE_KEYS.BUDGETS,
-        STORAGE_KEYS.GOALS,
-      ];
-      
-      const isFinancialData = (sensitiveKeys as readonly string[]).includes(key) ||
-                              key.includes('transaction') ||
-                              key.includes('account') ||
-                              key.includes('budget') ||
-                              key.includes('financial');
+      const isFinancialData = this.isFinancialKey(key);
 
       // Store in encrypted storage
       await encryptedStorage.setItem(key, value, {
@@ -207,6 +223,36 @@ export class SecureStorageAdapter implements StorageAdapter {
       this.logger.error(`Error setting ${key}:`, error);
       // Fallback to localStorage
       this.localStorageRef?.setItem(key, JSON.stringify(value));
+    }
+  }
+
+  /**
+   * Write several keys as ONE unit.
+   *
+   * Deliberately WITHOUT the localStorage fallback `set` has: falling back
+   * per-key is exactly what would break the promise this method exists to make.
+   * A caller that needs "all of these or none of them" — the local restore, the
+   * local wipe — must be told the write failed, not handed a storage layer that
+   * quietly did some of it somewhere else. Failure leaves storage untouched.
+   */
+  async setMany<T>(entries: ReadonlyArray<{ key: string; value: T }>): Promise<void> {
+    if (entries.length === 0) return;
+
+    await encryptedStorage.setItems(entries.map(({ key, value }) => {
+      const isFinancialData = this.isFinancialKey(key);
+      return {
+        key,
+        value,
+        options: { encrypted: isFinancialData, expiryDays: isFinancialData ? undefined : 30 },
+      };
+    }));
+
+    // The pre-migration copies would otherwise be read back the moment
+    // IndexedDB returns null for a key this just emptied.
+    if (this.migrationCompleted) {
+      for (const { key } of entries) {
+        this.localStorageRef?.removeItem?.(key);
+      }
     }
   }
 
@@ -281,7 +327,7 @@ export class SecureStorageAdapter implements StorageAdapter {
 
   // Import data from backup
   async importData(data: Record<string, unknown>): Promise<void> {
-    await encryptedStorage.importData(data as Record<string, import('../types/common').JsonValue>, { encrypted: true });
+    await encryptedStorage.importData(data, { encrypted: true });
   }
 
   // Get storage usage info

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -108,6 +108,21 @@ export interface Transaction {
   };
   goalId?: string;
   accountName?: string;
+  /**
+   * Position of this row within the statement it was imported from — the
+   * BANK's own order among transactions that share a date.
+   *
+   * `date` is a calendar day, so same-day rows carry no order of their own and
+   * the register has to invent one to run a balance down the page. This is the
+   * one honest answer: OFX lists <STMTTRN> in statement order, so the file
+   * position is the bank's sequence. An ordinal, never a time — a statement
+   * states sequence, and a fabricated clock time would be a worse lie.
+   *
+   * Null/undefined = unknown, which is the truth for every hand-entered row and
+   * every row imported before the column existed. See compareChronological for
+   * how those interleave with rows that do know their place.
+   */
+  statementSequence?: number | null;
   createdAt?: Date;
   updatedAt?: Date;
   recurringTransactionId?: string;

--- a/src/types/storage.ts
+++ b/src/types/storage.ts
@@ -21,9 +21,14 @@ export interface StorageItem<T = JsonValue> {
   options?: StorageOptions;
 }
 
+/**
+ * `StoredData<unknown>` rather than `StoredData<JsonValue>`: the value has
+ * already been through `encrypt` (a string) or is on its way to structured
+ * clone, so narrowing it here bought nothing except a cast at every call site.
+ */
 export interface BulkStorageItem {
   key: string;
-  value: StoredData<JsonValue>;
+  value: StoredData<unknown>;
 }
 
 export interface StorageEstimate {

--- a/src/utils/__tests__/currency-decimal.test.ts
+++ b/src/utils/__tests__/currency-decimal.test.ts
@@ -58,6 +58,22 @@ describe('currency-decimal', () => {
       expect(formatCurrency(0, 'EUR')).toBe('€0.00');
     });
 
+    it('never prints a minus in front of zero', () => {
+      // Zero has no sign to show, but Decimal keeps one: JS negative zero (which
+      // float arithmetic hands over from a running balance that nets out) and
+      // any amount small enough to round away both answer isNegative() while
+      // printing as 0.00. The account register showed "-£0.00" against a day
+      // whose payment and offsetting sweep cancelled, which reads to the user
+      // like a rounding error in their own money.
+      expect(formatCurrency(-0, 'GBP')).toBe('£0.00');
+      expect(formatCurrency(-0.001, 'GBP')).toBe('£0.00');
+      expect(formatCurrency(new Decimal('-0'), 'GBP')).toBe('£0.00');
+      expect(formatCurrency(new Decimal(75).minus(75), 'GBP')).toBe('£0.00');
+      expect(formatCurrency(-0, 'CHF')).toBe('0.00 CHF');
+      // A real negative still shows one — this must not silence the sign.
+      expect(formatCurrency(-0.01, 'GBP')).toBe('-£0.01');
+    });
+
     it('formats Decimal instances', () => {
       const decimal = new Decimal('1234.567');
       expect(formatCurrency(decimal, 'GBP')).toBe('£1,234.57');

--- a/src/utils/currency-decimal.ts
+++ b/src/utils/currency-decimal.ts
@@ -36,11 +36,24 @@ export function getCurrencySymbol(currency: string): string {
   return currencySymbols[currency] || currency;
 }
 
+/**
+ * Whether to print a minus sign — false for anything that has ROUNDED to zero.
+ *
+ * Zero has no sign to show. Decimal keeps one anyway: a JS negative zero (which
+ * float arithmetic produces from `2000 - 2000` in the wrong order, and which a
+ * float running balance produces all the time) and any small negative that
+ * rounds away both answer true to isNegative() while printing as 0.00. The
+ * account register showed "-£0.00" against a day that netted out, which reads
+ * like a rounding error in the user's own money.
+ */
+const showsMinus = (decimal: DecimalInstance): boolean =>
+  decimal.isNegative() && !decimal.isZero();
+
 // Format amount with currency (accepts Decimal or number)
 export function formatCurrency(amount: DecimalInstance | number, currency: string = 'GBP'): string {
   const decimal = toDecimal(amount).toDecimalPlaces(2, Decimal.ROUND_HALF_UP);
   const symbol = getCurrencySymbol(currency);
-  const isNegative = decimal.isNegative();
+  const isNegative = showsMinus(decimal);
   const absolute = decimal.abs();
   const formatted = formatDecimal(absolute, 2, { group: true });
 
@@ -58,7 +71,9 @@ export function formatCurrencyWhole(
 ): string {
   const decimal = toDecimal(amount);
   const rounded = decimal.toDecimalPlaces(0, Decimal.ROUND_DOWN);
-  const isNegative = rounded.isNegative();
+  // ROUND_DOWN takes -0.40 to zero, so this needs the same guard: a summary
+  // card reading "-£0" is the same lie in fewer digits.
+  const isNegative = showsMinus(rounded);
   const symbol = getCurrencySymbol(currency);
   const grouped = formatDecimal(rounded.abs(), 0, { group: true });
 

--- a/src/utils/statementBankBalance.test.ts
+++ b/src/utils/statementBankBalance.test.ts
@@ -96,6 +96,23 @@ describe('planStatementBankBalance', () => {
     expect(planStatementBankBalance(undefined, account(), CONFIRMED)).toEqual({ kind: 'none' });
   });
 
+  it('writes a closing balance of zero — absent and zero are not the same thing', () => {
+    // Zero is falsy, and every "does the file state a balance?" test here has
+    // to ask whether the BALANCE is absent, never whether the AMOUNT is truthy.
+    // An account on a nightly two-way sweep to a linked savings account closes
+    // at exactly 0.00 every day; skipping it would leave Reconciliation with
+    // nothing to check against on the one account that always states its
+    // position exactly.
+    const outcome = planStatementBankBalance(statement(0, '2026-03-31'), account(), CONFIRMED);
+
+    expect(outcome).toEqual({
+      kind: 'set',
+      updates: { bankBalance: 0, bankBalanceDate: '2026-03-31' },
+      amount: 0,
+      dateAsOf: '2026-03-31'
+    });
+  });
+
   it('does nothing when there is no account to write to', () => {
     expect(planStatementBankBalance(statement(900, '2026-03-31'), null, CONFIRMED))
       .toEqual({ kind: 'none' });

--- a/src/utils/statementDuplicates.test.ts
+++ b/src/utils/statementDuplicates.test.ts
@@ -1,0 +1,252 @@
+import { describe, it, expect } from 'vitest';
+import {
+  descriptionSimilarity,
+  findStatementDuplicates,
+  readFitId,
+  type HeldTransactionRow,
+  type IncomingStatementRow
+} from './statementDuplicates';
+
+const ACCOUNT = 'current-account';
+const OTHER_ACCOUNT = 'savings';
+
+const held = (overrides: Partial<HeldTransactionRow> & Pick<HeldTransactionRow, 'id' | 'amount'>): HeldTransactionRow => ({
+  accountId: ACCOUNT,
+  date: '2027-02-07',
+  description: '',
+  ...overrides
+});
+
+const incoming = (
+  overrides: Partial<IncomingStatementRow> & Pick<IncomingStatementRow, 'amount'>
+): IncomingStatementRow => ({
+  date: '2027-02-07',
+  description: '',
+  fitId: null,
+  ...overrides
+});
+
+/**
+ * The five shapes a re-imported statement produced in production, with invented
+ * names and figures. Every row is the same transaction on both sides, and not
+ * one has the same description twice: three were truncated by whatever imported
+ * them, one is written by a different system entirely, and one was renamed by
+ * hand to something the user would recognise later.
+ */
+const PAIR_SHAPES = [
+  {
+    heldDescription: 'Sweep Transfer from account 5566',
+    fileDescription: 'Sweep Transfer from account 55667788',
+    amount: 9876.54
+  },
+  {
+    heldDescription: 'Direct Debit - STREAMCO',
+    fileDescription: 'Direct Debit - STREAMCO  00110022330044',
+    amount: -63.2
+  },
+  {
+    heldDescription: 'SAMPLE PERSON A',
+    fileDescription: 'Standing Order to MISS A SAMPLE - A SAMPLE',
+    amount: -2500
+  },
+  {
+    heldDescription: 'Nadia',
+    fileDescription: 'Immediate Faster Payment (Online) to B EXAMPLE 07-FEB-2027',
+    amount: -410
+  },
+  {
+    heldDescription: 'Direct Debit - TELCO LTD  447',
+    fileDescription: 'Direct Debit - TELCO LTD  447221900-00007',
+    amount: -77.45
+  }
+];
+
+describe('readFitId', () => {
+  it('reads the id the OFX importer writes, and only a whole one', () => {
+    expect(readFitId('FITID: 2026060401\nCheck #: 1234')).toBe('2026060401');
+    expect(readFitId('Ref: 99\nFITID: ABC-123')).toBe('ABC-123');
+    // Anchored: a longer id must not answer to a shorter query, or every
+    // transaction in a bank's sequential range would match its neighbours.
+    expect(readFitId('FITID: 12345')).not.toBe('1234');
+    expect(readFitId('paid the FITID: 7 invoice')).toBeNull();
+    expect(readFitId(undefined)).toBeNull();
+    expect(readFitId('')).toBeNull();
+  });
+});
+
+describe('findStatementDuplicates', () => {
+  it('sees through truncated and user-edited descriptions', () => {
+    // THE BUG. Every one of these was imported a second time because the only
+    // test was "does the held row's notes contain this FITID", and rows that
+    // came from anywhere but this importer carry no FITID at all.
+    const heldRows = PAIR_SHAPES.map((pair, index) =>
+      held({ id: `held-${index}`, amount: pair.amount, description: pair.heldDescription, cleared: true })
+    );
+    const fileRows = PAIR_SHAPES.map((pair, index) =>
+      incoming({ amount: pair.amount, description: pair.fileDescription, fitId: `fit-${index}` })
+    );
+
+    const result = findStatementDuplicates(fileRows, heldRows, ACCOUNT);
+
+    expect(result.certain).toHaveLength(0);
+    expect(result.possible.map(match => match.incomingIndex)).toEqual([0, 1, 2, 3, 4]);
+    expect(result.possible.map(match => match.heldId)).toEqual([
+      'held-0', 'held-1', 'held-2', 'held-3', 'held-4'
+    ]);
+  });
+
+  it('matches a payee the user renamed, which shares not one word with the bank\'s wording', () => {
+    // "Nadia" vs "Immediate Faster Payment (Online) to B EXAMPLE": nothing
+    // in common. Any rule that required the descriptions to agree — or merely
+    // to be similar — would have missed this and doubled the payment.
+    expect(descriptionSimilarity('Nadia', 'Immediate Faster Payment (Online) to B EXAMPLE 07-FEB-2027')).toBe(0);
+
+    const result = findStatementDuplicates(
+      [incoming({ amount: -410, description: 'Immediate Faster Payment (Online) to B EXAMPLE 07-FEB-2027', fitId: 'fit-1' })],
+      [held({ id: 'renamed', amount: -410, description: 'Nadia', cleared: true })],
+      ACCOUNT
+    );
+
+    expect(result.possible).toHaveLength(1);
+    expect(result.possible[0].heldDescription).toBe('Nadia');
+    expect(result.possible[0].descriptionSimilarity).toBe(0);
+    expect(result.possible[0].heldCleared).toBe(true);
+  });
+
+  it('flags only as many rows as the register could actually account for', () => {
+    // Two £20 cash withdrawals on one day is a real thing. The register holds
+    // ONE; the file carries TWO. Exactly one is a duplicate, and dropping both
+    // would lose real spending.
+    const result = findStatementDuplicates(
+      [
+        incoming({ amount: -20, description: 'CASH ATM HIGH ST', fitId: 'fit-1' }),
+        incoming({ amount: -20, description: 'CASH ATM HIGH ST', fitId: 'fit-2' })
+      ],
+      [held({ id: 'withdrawal', amount: -20, description: 'Cash' })],
+      ACCOUNT
+    );
+
+    expect(result.possible).toHaveLength(1);
+    expect(result.possible[0].incomingIndex).toBe(0);
+  });
+
+  it('never pairs a row with a transaction in a different account', () => {
+    const result = findStatementDuplicates(
+      [incoming({ amount: -77.45, description: 'Direct Debit - TELCO LTD  447221900-00007', fitId: 'fit-1' })],
+      [held({ id: 'elsewhere', accountId: OTHER_ACCOUNT, amount: -77.45, description: 'Direct Debit - TELCO LTD  447' })],
+      ACCOUNT
+    );
+
+    expect(result.possible).toHaveLength(0);
+  });
+
+  it('compares amounts as exact pence, not as floats', () => {
+    // 0.1 + 0.2 is 0.30000000000000004: `===` says these are different
+    // transactions, Decimal says they are the same 30p.
+    const same = findStatementDuplicates(
+      [incoming({ amount: -(0.1 + 0.2), description: 'Card fee', fitId: 'fit-1' })],
+      [held({ id: 'fee', amount: -0.3, description: 'Fee' })],
+      ACCOUNT
+    );
+    expect(same.possible).toHaveLength(1);
+
+    // And a penny apart is a different transaction, however close it looks.
+    const apart = findStatementDuplicates(
+      [incoming({ amount: -77.46, description: 'Direct Debit - TELCO LTD  447221900-00007', fitId: 'fit-1' })],
+      [held({ id: 'telco', amount: -77.45, description: 'Direct Debit - TELCO LTD  447' })],
+      ACCOUNT
+    );
+    expect(apart.possible).toHaveLength(0);
+  });
+
+  it('allows the settlement-date gap, and stops', () => {
+    const fileRow = incoming({ date: '2027-02-07', amount: -63.2, description: 'Direct Debit - STREAMCO  00110022330044', fitId: 'fit-1' });
+
+    const withinWindow = findStatementDuplicates(
+      [fileRow],
+      [held({ id: 'streamco', date: '2027-02-10', amount: -63.2, description: 'Direct Debit - STREAMCO' })],
+      ACCOUNT
+    );
+    expect(withinWindow.possible).toHaveLength(1);
+    expect(withinWindow.possible[0].dayGap).toBe(3);
+
+    const outsideWindow = findStatementDuplicates(
+      [fileRow],
+      [held({ id: 'streamco', date: '2027-02-11', amount: -63.2, description: 'Direct Debit - STREAMCO' })],
+      ACCOUNT
+    );
+    expect(outsideWindow.possible).toHaveLength(0);
+  });
+
+  it('prefers the nearest date, and lets the description break a tie', () => {
+    const result = findStatementDuplicates(
+      [incoming({ date: '2027-02-07', amount: -50, description: 'CARD PAYMENT TO WAITROSE', fitId: 'fit-1' })],
+      [
+        held({ id: 'far', date: '2027-02-09', amount: -50, description: 'Waitrose' }),
+        held({ id: 'near-wrong-words', date: '2027-02-08', amount: -50, description: 'Petrol' }),
+        held({ id: 'near-right-words', date: '2027-02-08', amount: -50, description: 'Waitrose' })
+      ],
+      ACCOUNT
+    );
+
+    expect(result.possible).toHaveLength(1);
+    expect(result.possible[0].heldId).toBe('near-right-words');
+  });
+
+  it('reports a FITID pair as proof, and does not offer it for review', () => {
+    const result = findStatementDuplicates(
+      [incoming({ amount: -63.2, description: 'Direct Debit - STREAMCO  00110022330044', fitId: '2026060401' })],
+      [held({ id: 'streamco', amount: -63.2, description: 'Sky', notes: 'FITID: 2026060401' })],
+      ACCOUNT
+    );
+
+    expect(result.certain).toHaveLength(1);
+    expect(result.certain[0].basis).toBe('fitid');
+    expect(result.possible).toHaveLength(0);
+  });
+
+  it('lets the FITID pair claim its row before the weaker rule can take it', () => {
+    // Both held rows are -£20 on the day, so the amount rule would happily
+    // pair either one. The row the bank names must not be stolen from it.
+    const result = findStatementDuplicates(
+      [
+        incoming({ amount: -20, description: 'CASH', fitId: 'known' }),
+        incoming({ amount: -20, description: 'CASH', fitId: 'unknown' })
+      ],
+      [
+        held({ id: 'plain', amount: -20, description: 'Cash' }),
+        held({ id: 'identified', amount: -20, description: 'Cash', notes: 'FITID: known' })
+      ],
+      ACCOUNT
+    );
+
+    expect(result.certain.map(match => match.heldId)).toEqual(['identified']);
+    expect(result.possible.map(match => match.heldId)).toEqual(['plain']);
+  });
+
+  it('treats a row with an unreadable date as a duplicate of nothing', () => {
+    const unreadable = findStatementDuplicates(
+      [incoming({ date: 'not a date', amount: -20, description: 'Cash', fitId: 'fit-1' })],
+      [held({ id: 'held', amount: -20, description: 'Cash' })],
+      ACCOUNT
+    );
+    expect(unreadable.possible).toHaveLength(0);
+
+    const heldUnreadable = findStatementDuplicates(
+      [incoming({ amount: -20, description: 'Cash', fitId: 'fit-1' })],
+      [held({ id: 'held', date: 'not a date', amount: -20, description: 'Cash' })],
+      ACCOUNT
+    );
+    expect(heldUnreadable.possible).toHaveLength(0);
+  });
+
+  it('has nothing to compare against without a destination account', () => {
+    const result = findStatementDuplicates(
+      [incoming({ amount: -20, description: 'Cash', fitId: 'fit-1' })],
+      [held({ id: 'held', amount: -20, description: 'Cash' })],
+      ''
+    );
+    expect(result.certain).toHaveLength(0);
+    expect(result.possible).toHaveLength(0);
+  });
+});

--- a/src/utils/statementDuplicates.ts
+++ b/src/utils/statementDuplicates.ts
@@ -1,0 +1,295 @@
+/**
+ * "Is this statement row already in the register?" — for OFX/statement imports.
+ *
+ * THE PROBLEM
+ * -----------
+ * The OFX importer asked that question with
+ *
+ *     existing.notes?.includes(`FITID: ${fitId}`)
+ *
+ * and nothing else. FITID is the bank's own per-transaction id and it IS the
+ * right answer — but only when BOTH sides carry one, and the only rows that
+ * carry one are rows this same importer wrote (it puts `FITID: …` in `notes`).
+ * A row that arrived from the bank feed, from the MS Money import, from QIF or
+ * by hand has no FITID anywhere, so it matched nothing and every one of those
+ * transactions was imported a second time.
+ *
+ * Description cannot rescue it either. The two sides of a real pair look like
+ * this (shapes, not anyone's actual statement):
+ *
+ *     already held                    | in the file
+ *     --------------------------------+--------------------------------------
+ *     Sweep Transfer from account 5566| Sweep Transfer from account 55667788
+ *     Direct Debit - STREAMCO         | Direct Debit - STREAMCO  0011002233
+ *     Nadia                           | Immediate Faster Payment (Online) to…
+ *
+ * Held descriptions get truncated by whatever wrote them, and users rename
+ * payees to something they will recognise a year later ("Nadia"). Requiring the
+ * two to agree, or even to be similar, misses most true duplicates.
+ *
+ * The register's own duplicate sweep (utils/duplicateSweep) scores description
+ * similarity into a weighted total and needs 80: the truncated pairs clear it,
+ * the renamed ones cannot, and no threshold that would catch them is safe in a
+ * tool that DELETES. Here the consequence is "not added", which is why this
+ * rule can be the wider one — and why what it finds is offered for review.
+ *
+ * THE RULE
+ * --------
+ * Two tiers, and they are reported separately because they are not equally
+ * certain:
+ *
+ *   1. FITID on both sides — the bank saying "this is the same transaction".
+ *      Proof; no review needed.
+ *   2. Same ACCOUNT, same amount to the exact penny, date within
+ *      `dateToleranceDays`. Strong evidence, not proof, so it is offered for
+ *      review rather than acted on silently.
+ *
+ * Description is a RANKING signal for tier 2 and never a gate — see the table
+ * above for why. This mirrors `findFeedOverlap` (the MS Money ↔ bank feed
+ * problem solved the same way in July 2026) deliberately: same shape, same
+ * reasoning, one fewer thing to learn.
+ *
+ * WHY GENUINE SAME-DAY SAME-AMOUNT PAIRS SURVIVE
+ * ----------------------------------------------
+ * Two £20 cash withdrawals on one day are a real thing. Matching is strictly
+ * 1:1 and greedy: each held row is claimed by at most one file row and vice
+ * versa. So if the register holds ONE £20 withdrawal and the file carries TWO,
+ * exactly one is flagged and the other imports. The count of flagged rows can
+ * never exceed the count of held rows that could account for them.
+ */
+import { toDecimal } from './decimal';
+import { toDateMs } from './dateBoundary';
+
+/**
+ * Feeds post on the settlement date; a hand-entered or Money-sourced row
+ * carries the transaction date. Three days is what `findFeedOverlap` settled
+ * on for the same reason, and the 1:1 rule bounds what a wider window can cost.
+ */
+export const DEFAULT_STATEMENT_DATE_TOLERANCE_DAYS = 3;
+
+const MS_PER_DAY = 86_400_000;
+
+/** How the match was made. 'fitid' is proof; 'amount-and-date' is evidence. */
+export type StatementMatchBasis = 'fitid' | 'amount-and-date';
+
+/** A row arriving from the file. Identified by its position in the list. */
+export interface IncomingStatementRow {
+  date: Date | string | number | null | undefined;
+  amount: number;
+  description: string;
+  /**
+   * The file's FITID for this row. Read from `notes` by {@link readFitId} when
+   * the caller only has the drafted transaction.
+   */
+  fitId: string | null;
+}
+
+/** A transaction the register already holds. */
+export interface HeldTransactionRow {
+  id: string;
+  accountId: string;
+  date: Date | string | number | null | undefined;
+  amount: number;
+  description: string;
+  notes?: string;
+  /** Carried through only so the review list can say where the row came from. */
+  cleared?: boolean;
+}
+
+export interface StatementDuplicateMatch {
+  /** Index into the `incoming` array — the file row that is already held. */
+  incomingIndex: number;
+  /** The file's id for that row, when it has one. */
+  fitId: string | null;
+  /** The held row it matches. */
+  heldId: string;
+  heldDescription: string;
+  heldDate: Date;
+  heldAmount: number;
+  heldCleared: boolean;
+  basis: StatementMatchBasis;
+  /** Whole days between the two dates (0 = same day). */
+  dayGap: number;
+  /** 0–1 token overlap of the two descriptions. Ranking and display only. */
+  descriptionSimilarity: number;
+}
+
+export interface StatementDuplicateResult {
+  /** Proven duplicates — the bank's own id on both sides. */
+  certain: StatementDuplicateMatch[];
+  /** Same account, exact amount, near date. For a human to confirm. */
+  possible: StatementDuplicateMatch[];
+}
+
+/**
+ * The FITID this importer wrote into a transaction's notes, or null.
+ *
+ * `notes` is the ONLY place the OFX importer records it — there is no column
+ * for it, and the boot query does not fetch `bank_reference` or the feed's
+ * `external_transaction_id`, so notes is also the only place a running app can
+ * read one back from. Anchored to a line start and terminated by whitespace or
+ * end-of-line, so `FITID: 123` cannot match a row whose id is `1234`.
+ */
+export function readFitId(notes: string | null | undefined): string | null {
+  if (!notes) return null;
+  const match = /(?:^|\n)FITID:[ \t]*(\S+)[ \t]*(?:\r?$)/m.exec(notes);
+  return match ? match[1] : null;
+}
+
+/** Exact pence — Decimal in, integer out. No float arithmetic on money. */
+const pence = (amount: number): number => toDecimal(amount).times(100).round().toNumber();
+
+/** Midnight UTC of the row's calendar day, or NaN when the date is unusable. */
+const dayOf = (value: Date | string | number | null | undefined): number => {
+  const ms = toDateMs(value);
+  if (!Number.isFinite(ms)) return Number.NaN;
+  return Math.floor(ms / MS_PER_DAY) * MS_PER_DAY;
+};
+
+/** Alphanumeric word tokens, upper-cased; short noise words dropped. */
+const tokens = (text: string): Set<string> =>
+  new Set(
+    text
+      .toUpperCase()
+      .split(/[^A-Z0-9]+/)
+      .filter(token => token.length > 2)
+  );
+
+/** Jaccard overlap of the two token sets — 1 identical, 0 nothing in common. */
+export function descriptionSimilarity(a: string, b: string): number {
+  const left = tokens(a);
+  const right = tokens(b);
+  if (left.size === 0 || right.size === 0) return 0;
+  let shared = 0;
+  for (const token of left) if (right.has(token)) shared++;
+  return shared / (left.size + right.size - shared);
+}
+
+interface HeldCandidate {
+  row: HeldTransactionRow;
+  day: number;
+}
+
+/** Append into a bucketed index without re-reading it twice. */
+function push<T>(index: Map<string, T[]>, key: string, entry: T): void {
+  const list = index.get(key);
+  if (list) list.push(entry);
+  else index.set(key, [entry]);
+}
+
+function toMatch(
+  incomingIndex: number,
+  fitId: string | null,
+  held: HeldTransactionRow,
+  basis: StatementMatchBasis,
+  dayGap: number,
+  similarity: number
+): StatementDuplicateMatch {
+  return {
+    incomingIndex,
+    fitId,
+    heldId: held.id,
+    heldDescription: held.description,
+    heldDate: new Date(toDateMs(held.date)),
+    heldAmount: held.amount,
+    heldCleared: held.cleared === true,
+    basis,
+    dayGap,
+    descriptionSimilarity: similarity,
+  };
+}
+
+/**
+ * Which rows of an incoming statement the register already holds.
+ *
+ * `heldRows` may be the whole register; only rows in `accountId` are ever
+ * considered, because the same amount on the same day in a DIFFERENT account is
+ * a different transaction. An empty `accountId` matches nothing — an import
+ * with no destination has no register to compare against.
+ *
+ * Neither input is mutated, and nothing is decided here: the caller chooses
+ * what to do with each tier.
+ */
+export function findStatementDuplicates(
+  incoming: readonly IncomingStatementRow[],
+  heldRows: readonly HeldTransactionRow[],
+  accountId: string,
+  options: { dateToleranceDays?: number } = {}
+): StatementDuplicateResult {
+  const certain: StatementDuplicateMatch[] = [];
+  const possible: StatementDuplicateMatch[] = [];
+  if (!accountId) return { certain, possible };
+
+  const tolerance = Math.max(0, options.dateToleranceDays ?? DEFAULT_STATEMENT_DATE_TOLERANCE_DAYS);
+
+  const byFitId = new Map<string, HeldTransactionRow[]>();
+  const byAmount = new Map<string, HeldCandidate[]>();
+
+  for (const row of heldRows) {
+    if (row.accountId !== accountId) continue;
+    const heldFitId = readFitId(row.notes);
+    if (heldFitId !== null) push(byFitId, heldFitId, row);
+    const day = dayOf(row.date);
+    // A row whose date cannot be read is a duplicate of nothing: it has no
+    // position on the calendar to compare, and guessing one would pair it with
+    // whatever happened to share its amount.
+    if (Number.isFinite(day)) push(byAmount, String(pence(row.amount)), { row, day });
+  }
+
+  /** Held ids already accounted for. Each may explain at most one file row. */
+  const claimed = new Set<string>();
+
+  // ── Pass 1: the bank's own id, on both sides ───────────────────────────────
+  // First, so a FITID pair can never be broken up by the weaker rule below.
+  for (let index = 0; index < incoming.length; index++) {
+    const row = incoming[index];
+    if (row.fitId === null) continue;
+    const held = (byFitId.get(row.fitId) ?? []).find(candidate => !claimed.has(candidate.id));
+    if (!held) continue;
+    claimed.add(held.id);
+    const gap = Math.abs(dayOf(row.date) - dayOf(held.date)) / MS_PER_DAY;
+    certain.push(
+      toMatch(
+        index,
+        row.fitId,
+        held,
+        'fitid',
+        Number.isFinite(gap) ? gap : 0,
+        descriptionSimilarity(row.description, held.description)
+      )
+    );
+  }
+
+  const matchedIncoming = new Set(certain.map(match => match.incomingIndex));
+
+  // ── Pass 2: same account, exact pence, near date ───────────────────────────
+  for (let index = 0; index < incoming.length; index++) {
+    if (matchedIncoming.has(index)) continue;
+    const row = incoming[index];
+    const day = dayOf(row.date);
+    if (!Number.isFinite(day)) continue;
+
+    let best: HeldCandidate | null = null;
+    let bestGap = Number.POSITIVE_INFINITY;
+    let bestSimilarity = -1;
+    for (const candidate of byAmount.get(String(pence(row.amount))) ?? []) {
+      if (claimed.has(candidate.row.id)) continue;
+      const gap = Math.abs(candidate.day - day) / MS_PER_DAY;
+      if (gap > tolerance) continue;
+      const similarity = descriptionSimilarity(row.description, candidate.row.description);
+      // Nearest date wins; description breaks ties, so when several held rows
+      // are eligible the most plausible pairing is the one offered.
+      if (gap < bestGap || (gap === bestGap && similarity > bestSimilarity)) {
+        best = candidate;
+        bestGap = gap;
+        bestSimilarity = similarity;
+      }
+    }
+
+    if (!best) continue;
+    claimed.add(best.row.id);
+    possible.push(toMatch(index, row.fitId, best.row, 'amount-and-date', bestGap, bestSimilarity));
+  }
+
+  return { certain, possible };
+}

--- a/src/utils/transactionSort.test.ts
+++ b/src/utils/transactionSort.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { compareTransactions, transactionSortValue } from './transactionSort';
+import { compareChronological, compareTransactions, transactionSortValue } from './transactionSort';
 import type { Transaction, Category } from '../types';
 
 const cats: Category[] = [
@@ -56,15 +56,67 @@ describe('compareTransactions', () => {
     expect(orderedIds(list, 'tags', 'asc')).toEqual(['n', 'a', 'b']); // '', bills, work
   });
 
-  it('orders by date chronologically, tie-broken by type (income→transfer→expense)', () => {
+  it('orders by date chronologically, days newest-first under desc', () => {
     const list = [
-      t({ id: 'exp', date: new Date('2024-03-01'), type: 'expense' }),
-      t({ id: 'inc', date: new Date('2024-03-01'), type: 'income' }),
-      t({ id: 'old', date: new Date('2024-01-01'), type: 'expense' })
+      t({ id: 'newer', date: new Date('2024-03-01'), createdAt: new Date('2024-03-01T10:00:00Z') }),
+      t({ id: 'newest', date: new Date('2024-03-01'), createdAt: new Date('2024-03-01T11:00:00Z') }),
+      t({ id: 'old', date: new Date('2024-01-01') })
     ];
-    expect(orderedIds(list, 'date', 'asc')).toEqual(['old', 'inc', 'exp']);
-    // desc flips the day order but keeps the same-day income-before-expense tiebreak
-    expect(orderedIds(list, 'date', 'desc')).toEqual(['inc', 'exp', 'old']);
+    expect(orderedIds(list, 'date', 'asc')).toEqual(['old', 'newer', 'newest']);
+    // desc reverses the WHOLE order, tie-break included — it has to, because the
+    // running Balance beside each row is the balance AFTER it, so newest-first
+    // must be the exact reverse of the order the balances were accumulated in.
+    // Reversing only the day is what put a day's first transaction on top
+    // wearing the account's balance.
+    expect(orderedIds(list, 'date', 'desc')).toEqual(['newest', 'newer', 'old']);
+  });
+
+  it('reverses exactly under desc, so the first row is the last chronologically', () => {
+    const list = [
+      t({ id: 'a', date: new Date('2024-01-01'), type: 'income' }),
+      t({ id: 'b', date: new Date('2024-01-01'), type: 'expense' }),
+      t({ id: 'c', date: new Date('2024-01-01'), type: 'expense', createdAt: new Date('2024-01-01T09:00:00Z') }),
+      t({ id: 'd', date: new Date('2024-02-01'), type: 'transfer' })
+    ];
+    const ascending = orderedIds(list, 'date', 'asc');
+    expect(orderedIds(list, 'date', 'desc')).toEqual([...ascending].reverse());
+  });
+
+  it('does not order a day by transaction type', () => {
+    // On a swept account the payment OUT precedes the sweep IN that offsets it.
+    // Credits do not precede debits, so nothing here may claim they do — the
+    // type must not move a row at all. Both rows carry the same createdAt (one
+    // bulk-imported file shares one), leaving the id as the only separator:
+    // alphabetical, and identical whichever type is which.
+    const entered = new Date('2024-02-19T02:00:00Z');
+    const day = new Date('2024-02-19');
+    const asFiled = [
+      t({ id: 'aaa', date: day, type: 'income', amount: 450, createdAt: entered }),
+      t({ id: 'zzz', date: day, type: 'expense', amount: -450, createdAt: entered })
+    ];
+    const typesSwapped = [
+      t({ id: 'aaa', date: day, type: 'expense', amount: -450, createdAt: entered }),
+      t({ id: 'zzz', date: day, type: 'income', amount: 450, createdAt: entered })
+    ];
+
+    expect(orderedIds(asFiled, 'date', 'asc')).toEqual(['aaa', 'zzz']);
+    expect(orderedIds(typesSwapped, 'date', 'asc')).toEqual(['aaa', 'zzz']);
+  });
+
+  it('cannot be reordered by type when two transfers share a day', () => {
+    // The standing order and the evening sweep are BOTH transfers, and the sweep
+    // comes last. No type rule can express that — only the bank's own sequence
+    // can, and it must beat every other signal including a createdAt that says
+    // the opposite.
+    const day = new Date('2024-02-05');
+    const list = [
+      t({ id: 'sweep', date: day, type: 'transfer', amount: 312.75, statementSequence: 2, createdAt: new Date('2020-01-01') }),
+      t({ id: 'standing-order', date: day, type: 'transfer', amount: -300, statementSequence: 1, createdAt: new Date('2020-01-02') }),
+      t({ id: 'direct-debit', date: day, type: 'expense', amount: -12.75, statementSequence: 0, createdAt: new Date('2020-01-03') })
+    ];
+
+    expect(orderedIds(list, 'date', 'asc')).toEqual(['direct-debit', 'standing-order', 'sweep']);
+    expect(orderedIds(list, 'date', 'desc')).toEqual(['sweep', 'standing-order', 'direct-debit']);
   });
 
   it('exposes the comparable value via transactionSortValue', () => {
@@ -95,11 +147,117 @@ describe('compareTransactions', () => {
     expect(orderedIds(list, 'amount', 'asc')).toEqual(['c', 'a', 'b']); // -99, then the -10s oldest-first
   });
 
-  it('uses the same-day type order as the final tie-break', () => {
+  it('uses entry order as the final tie-break on a non-date column', () => {
     const list = [
-      t({ id: 'exp', description: 'O2', date: new Date('2024-01-05'), type: 'expense' }),
-      t({ id: 'inc', description: 'O2', date: new Date('2024-01-05'), type: 'income' })
+      t({ id: 'later', description: 'O2', date: new Date('2024-01-05'), createdAt: new Date('2024-01-06T12:00:00Z') }),
+      t({ id: 'earlier', description: 'O2', date: new Date('2024-01-05'), createdAt: new Date('2024-01-05T12:00:00Z') })
     ];
-    expect(orderedIds(list, 'description', 'asc')).toEqual(['inc', 'exp']);
+    expect(orderedIds(list, 'description', 'asc')).toEqual(['earlier', 'later']);
+  });
+});
+
+describe('compareChronological', () => {
+  const chronological = (txns: Transaction[]): string[] =>
+    [...txns].sort(compareChronological).map(x => x.id);
+
+  it('settles same-day rows the same way whatever order they arrive in', () => {
+    // The defect this replaces: two arrays filtered from the same source (the
+    // full history for the balances, the visible subset for the rows) were left
+    // to Array.prototype.sort's stability, which answers with whatever order it
+    // was handed.
+    const day = new Date('2024-05-01');
+    const list = [
+      t({ id: 'zzz', date: day, type: 'expense' }),
+      t({ id: 'aaa', date: day, type: 'income' }),
+      t({ id: 'mmm', date: day, type: 'transfer' })
+    ];
+    expect(chronological(list)).toEqual(['aaa', 'mmm', 'zzz']);
+    expect(chronological([...list].reverse())).toEqual(['aaa', 'mmm', 'zzz']);
+  });
+
+  it('orders same-day rows by when they were entered, ahead of the id', () => {
+    const day = new Date('2024-05-01');
+    const list = [
+      t({ id: 'aaa', date: day, type: 'expense', createdAt: new Date('2024-05-02T18:00:00Z') }),
+      t({ id: 'zzz', date: day, type: 'expense', createdAt: new Date('2024-05-01T09:00:00Z') })
+    ];
+    expect(chronological(list)).toEqual(['zzz', 'aaa']);
+  });
+
+  it('reads a createdAt that arrived from the wire as a string', () => {
+    // PostgREST sends created_at as text and nothing converts it, so the
+    // declared Date is not what is in memory. Comparing the two shapes has to
+    // work or the entry order silently stops applying to fetched rows.
+    const day = new Date('2024-05-01');
+    const wireRow = t({ id: 'aaa', date: day, type: 'expense' });
+    Object.assign(wireRow, { createdAt: '2024-05-01T09:00:00Z' });
+    const localRow = t({ id: 'zzz', date: day, type: 'expense', createdAt: new Date('2024-05-02T18:00:00Z') });
+
+    expect(chronological([localRow, wireRow])).toEqual(['aaa', 'zzz']);
+  });
+
+  it('places rows with no creation time after those that have one', () => {
+    const day = new Date('2024-05-01');
+    const list = [
+      t({ id: 'aaa', date: day, type: 'expense' }),
+      t({ id: 'zzz', date: day, type: 'expense', createdAt: new Date('2024-05-01T09:00:00Z') })
+    ];
+    // 'zzz' wins on entry order despite losing on id — an unknown moment cannot
+    // be placed among known ones, so it goes last, always.
+    expect(chronological(list)).toEqual(['zzz', 'aaa']);
+  });
+
+  it('puts the bank\'s own sequence ahead of entry order and id', () => {
+    const day = new Date('2024-02-05');
+    // Ids and createdAt both say the opposite of the statement; the sequence
+    // must win, or an imported day reads in an order the bank never printed.
+    const list = [
+      t({ id: 'aaa', date: day, statementSequence: 2, createdAt: new Date('2024-02-05T01:00:00Z') }),
+      t({ id: 'mmm', date: day, statementSequence: 1, createdAt: new Date('2024-02-05T02:00:00Z') }),
+      t({ id: 'zzz', date: day, statementSequence: 0, createdAt: new Date('2024-02-05T03:00:00Z') })
+    ];
+    expect(chronological(list)).toEqual(['zzz', 'mmm', 'aaa']);
+  });
+
+  it('sorts a row with no sequence after every row that has one', () => {
+    // Unknown cannot be placed among known, so it goes last within its day —
+    // which keeps the imported statement's own run contiguous, and it is that
+    // run the user is checking line by line against the bank.
+    const day = new Date('2024-02-05');
+    const list = [
+      t({ id: 'aaa-no-sequence', date: day, statementSequence: null }),
+      t({ id: 'zzz-first-on-statement', date: day, statementSequence: 0 })
+    ];
+    expect(chronological(list)).toEqual(['zzz-first-on-statement', 'aaa-no-sequence']);
+    // Two rows that both lack one fall through to the next tie-break, not to
+    // whichever order they arrived in.
+    const neither = [
+      t({ id: 'zzz', date: day }),
+      t({ id: 'aaa', date: day })
+    ];
+    expect(chronological(neither)).toEqual(['aaa', 'zzz']);
+    expect(chronological([...neither].reverse())).toEqual(['aaa', 'zzz']);
+  });
+
+  it('ignores a sequence that is not a usable number', () => {
+    // NaN would poison the comparator exactly as an unreadable date would.
+    const day = new Date('2024-02-05');
+    const broken = t({ id: 'broken', date: day, statementSequence: Number.NaN });
+    const good = t({ id: 'good', date: day, statementSequence: 5 });
+
+    expect(Number.isNaN(compareChronological(broken, good))).toBe(false);
+    expect(chronological([broken, good])).toEqual(['good', 'broken']);
+  });
+
+  it('never returns NaN for an unreadable date', () => {
+    // A NaN comparator is neither < 0 nor > 0, and sort is then free to return
+    // any order at all — the exact failure mode this module exists to remove.
+    const broken = t({ id: 'broken', date: new Date('not a date') });
+    const good = t({ id: 'good', date: new Date('2024-05-01') });
+
+    expect(Number.isNaN(compareChronological(broken, good))).toBe(false);
+    expect(Number.isNaN(compareChronological(good, broken))).toBe(false);
+    expect(compareChronological(broken, t({ ...broken, id: 'broken' }))).toBe(0);
+    expect(chronological([good, broken])).toEqual(['broken', 'good']);
   });
 });

--- a/src/utils/transactionSort.ts
+++ b/src/utils/transactionSort.ts
@@ -1,10 +1,139 @@
 import type { Transaction, Category } from '../types';
+import { toDateMs } from './dateBoundary';
 
 export type TransactionSortField =
   | 'date' | 'description' | 'amount' | 'category' | 'tags' | 'payment' | 'deposit' | 'notes';
 
-// Same-day ordering: income, then transfers, then expenses.
-const TYPE_ORDER: Record<string, number> = { income: 0, transfer: 1, expense: 2 };
+/**
+ * A transaction's day as a sortable instant, with an unreadable one sorting
+ * oldest. NaN would be worse than wrong: `NaN - NaN` is NaN, a comparator that
+ * returns NaN is neither `< 0` nor `> 0`, and Array.prototype.sort is then free
+ * to leave the rows in any order it likes — which is exactly the kind of
+ * order-by-accident this module exists to remove. Two -Infinity dates never
+ * reach the subtraction (the equality test above it stops them).
+ */
+const sortableTime = (value: unknown): number => {
+  const ms = toDateMs(value);
+  return Number.isFinite(ms) ? ms : Number.NEGATIVE_INFINITY;
+};
+
+/**
+ * The bank's own position for this row within its statement, or +Infinity when
+ * it has none.
+ *
+ * UNKNOWN SORTS LAST, and that is a decision worth stating. A row with no
+ * sequence is either hand-entered or imported before the column existed; either
+ * way nothing places it among rows that DO know their place. Sorting it last
+ * within its day keeps the imported statement's own run intact and contiguous —
+ * which is the run the user is checking line by line against the bank — and
+ * puts the unknown row at the end where the day's closing balance still lands
+ * on the account's true balance. Interleaving them by guesswork would corrupt
+ * the one sequence we actually know.
+ *
+ * +Infinity rather than a fall-through, because every value here must be
+ * comparable against every other or the composed order stops being transitive:
+ * a "compare sequence only when both have one" rule can order A before B, B
+ * before C and C before A.
+ */
+const statementPosition = (transaction: Transaction): number => {
+  const sequence = transaction.statementSequence;
+  return typeof sequence === 'number' && Number.isFinite(sequence)
+    ? sequence
+    : Number.POSITIVE_INFINITY;
+};
+
+/**
+ * When a transaction was ENTERED — the tie-break below the bank's own order.
+ *
+ * Its reach is narrow and worth knowing. `create_transaction_atomic` lets
+ * Postgres default `created_at` to now(), and now() is TRANSACTION start time,
+ * so rows written one awaited RPC at a time (hand entry) come out strictly
+ * increasing. It is NOT reliable for imports: `import_transactions_atomic`
+ * writes a whole file inside ONE transaction, giving every row of that file the
+ * same created_at, and the OFX modal's own loop fires its writes without
+ * awaiting them, so their arrival order is a race. That is precisely why
+ * statementSequence above exists — created_at cannot stand in for it.
+ *
+ * Rows with no creation time sort after those that have one, for the same
+ * transitivity reason as statementPosition.
+ *
+ * Read through toDateMs because `createdAt` is declared a Date but arrives from
+ * PostgREST as an ISO string — it is not one of the fields the date boundary
+ * converts. toDateMs takes `unknown` and reads either shape, so no cast.
+ */
+const enteredTime = (transaction: Transaction): number => {
+  const ms = toDateMs(transaction.createdAt);
+  return Number.isFinite(ms) ? ms : Number.POSITIVE_INFINITY;
+};
+
+/**
+ * THE chronological order of a register: the order a running balance is
+ * accumulated in, and the order every Date sort displays — forwards when
+ * ascending, exactly reversed when descending.
+ *
+ * WHY IT IS SHARED. A running balance only means anything against the order it
+ * was accumulated in. The register used to compute balances with one local sort
+ * and display rows with another, so two transactions on the same day made the
+ * Balance column read as nonsense and, newest-first, the TOP row showed the
+ * balance from before the day's last transaction instead of the account's
+ * current balance. There can only be one order.
+ *
+ * WHY IT IS TOTAL. Same-day transactions carry no order of their own in this
+ * database, so the tie-break is a convention — and a convention only works if
+ * it is complete. Anything left equal here is settled by Array.prototype.sort's
+ * stability, i.e. by whichever order the array happened to arrive in; the
+ * balances are built from the account's full history and the rows from a
+ * filtered view, so "whichever order it arrived in" is not the same answer
+ * twice.
+ *
+ * WHY THERE IS NO SEMANTIC TIE-BREAK. This used to order a day income →
+ * transfer → expense, on the theory that a day's pay must land before the
+ * payments it funds. A real bank statement disproves it, twice over. On an
+ * account that runs an automated two-way sweep with a linked savings account,
+ * the day's spending happens first and ONE sweep in the evening returns the
+ * balance to exactly zero — so a credit follows the debits, not the other way
+ * round. And on such a day the standing order and the sweep are BOTH transfers,
+ * with a real order between them that type cannot express at all.
+ *
+ * The invented order therefore showed intermediate balances the account never
+ * held: arithmetically self-consistent, and a description of a day that did not
+ * happen — on the screen whose entire job is agreeing with the statement line by
+ * line.
+ *
+ * "Transfers last" is the same mistake in a new coat: a transfer can equally
+ * fund a day's spending at its start. The fix is not a better guess, it is to
+ * record what the bank said — statementSequence.
+ *
+ * The convention, in order:
+ *  1. the day — the only ordering fact `transactions.date` can carry;
+ *  2. the bank's own position within its statement (statementPosition);
+ *  3. when the row was entered (enteredTime), which is real for hand entry and
+ *     meaningless within an imported file;
+ *  4. its id — arbitrary, but stable, and already what the data layer
+ *     tie-breaks on (see mergeTransactionDelta in api/transactionService).
+ *
+ * Step 2 needs `transactions.statement_sequence`, added by
+ * supabase/migrations/20260808090000_transaction_statement_sequence.sql — which
+ * is DRAFTED AND UNAPPLIED. Until it is applied every row answers +Infinity
+ * there, the step is inert, and the order falls through to 3 and 4 exactly as
+ * it does today. Nothing here needs changing when it lands.
+ */
+export function compareChronological(a: Transaction, b: Transaction): number {
+  const dateA = sortableTime(a.date);
+  const dateB = sortableTime(b.date);
+  if (dateA !== dateB) return dateA - dateB;
+
+  const positionA = statementPosition(a);
+  const positionB = statementPosition(b);
+  if (positionA !== positionB) return positionA - positionB;
+
+  const enteredA = enteredTime(a);
+  const enteredB = enteredTime(b);
+  if (enteredA !== enteredB) return enteredA - enteredB;
+
+  if (a.id === b.id) return 0;
+  return a.id < b.id ? -1 : 1;
+}
 
 /**
  * Comparable value for a transaction under a given sort field. Payment/Deposit
@@ -38,11 +167,14 @@ export function transactionSortValue(
 
 /**
  * Account-register sort comparator. Every column sorts through here EXCEPT the
- * running Balance, which is never sorted — it is computed in chronological order
- * and mapped back per transaction, so it stays correct under any sort.
+ * running Balance, which is never sorted — it is accumulated in
+ * compareChronological order and mapped back per transaction, so each row's
+ * figure stays true under any sort.
  *
- * Date sorts chronologically and is tie-broken by type so same-day rows keep a
- * stable order.
+ * Date IS compareChronological, negated for descending: the whole order flips,
+ * tie-break included, so newest-first reads as the exact reverse of the order
+ * the balances were accumulated in and the top row carries the account's
+ * current balance.
  */
 export function compareTransactions(
   a: Transaction,
@@ -52,12 +184,12 @@ export function compareTransactions(
   categories: Category[]
 ): number {
   if (field === 'date') {
-    const dateA = new Date(a.date).getTime();
-    const dateB = new Date(b.date).getTime();
-    if (dateA !== dateB) {
-      return direction === 'asc' ? dateA - dateB : dateB - dateA;
-    }
-    return (TYPE_ORDER[a.type] ?? 0) - (TYPE_ORDER[b.type] ?? 0);
+    // Negating the WHOLE comparator, not just the day. Reversing the day while
+    // leaving the same-day tie-break forwards is what put a day's deposit above
+    // its payments under a newest-first sort while the balances had it below
+    // them — every same-day balance out by that day's other transactions.
+    const chronological = compareChronological(a, b);
+    return direction === 'asc' ? chronological : -chronological;
   }
 
   const aValue = transactionSortValue(a, field, categories);
@@ -65,12 +197,9 @@ export function compareTransactions(
   if (aValue < bValue) return direction === 'asc' ? -1 : 1;
   if (aValue > bValue) return direction === 'asc' ? 1 : -1;
 
-  // Equal on the chosen column: tie-break chronologically (oldest first, then
-  // the same-day type order the Date sort uses). Sorting by Description
-  // therefore lists a payee's rows together in date order instead of leaving
-  // their relative order to chance.
-  const dateA = new Date(a.date).getTime();
-  const dateB = new Date(b.date).getTime();
-  if (dateA !== dateB) return dateA - dateB;
-  return (TYPE_ORDER[a.type] ?? 0) - (TYPE_ORDER[b.type] ?? 0);
+  // Equal on the chosen column: tie-break chronologically, oldest first, in the
+  // same order the balances run. Sorting by Description therefore lists a
+  // payee's rows together in date order instead of leaving their relative order
+  // to chance.
+  return compareChronological(a, b);
 }

--- a/src/utils/transferMatch.ts
+++ b/src/utils/transferMatch.ts
@@ -67,3 +67,28 @@ export function findTransferCandidates(
 export function transferCategoryFor(categories: Category[], accountId: string): Category | undefined {
   return categories.find(c => c.isTransferCategory === true && c.accountId === accountId);
 }
+
+/**
+ * Would filing this transaction under `categoryId` make it a transfer to the
+ * account it is ALREADY in?
+ *
+ * A transfer moves money between two accounts; "Current Account → Current
+ * Account" describes nothing, and the manual editor already refuses it
+ * ("That's this account's own transfer category — pick the OTHER account's
+ * To/From category", QuickEditTransactionPanel). The importers' automatic
+ * categoriser had no such guard, and its merchant key is the generic payment
+ * channel — "immediate faster payment", "direct debit" — which a swept account's
+ * own internal sweeps share with every third-party payment on the statement. So
+ * ordinary direct debits arrived filed as transfers to the very account they sat
+ * in. Suggestions are advice; this one is never right, whatever its confidence.
+ */
+export function isSelfTransferCategory(
+  categories: readonly Category[],
+  categoryId: string,
+  accountId: string
+): boolean {
+  if (!categoryId || !accountId) return false;
+  return categories.some(
+    c => c.id === categoryId && c.isTransferCategory === true && c.accountId === accountId
+  );
+}

--- a/src/utils/transferOtherSide.test.ts
+++ b/src/utils/transferOtherSide.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { resolveTransferOtherSide } from './transferOtherSide';
+import { describeDeleteStranding, resolveTransferOtherSide } from './transferOtherSide';
 import type { Account, Transaction } from '../types';
 
 const account = (id: string, name: string, isActive = true): Account => ({
@@ -93,5 +93,59 @@ describe('resolveTransferOtherSide', () => {
     // at a row that is not there, is worse than not offering the jump.
     const selfRef = leg({ id: 'y', accountId: 'acc-a', linkedTransferId: 'z', transferAccountId: 'acc-a' });
     expect(resolveTransferOtherSide(selfRef, [], OPEN)).toBeNull();
+  });
+});
+
+describe('describeDeleteStranding', () => {
+  it('says nothing for an ordinary transaction', () => {
+    // Zero counts render nothing: a plain expense loses nothing but itself, and
+    // a warning that fires on every delete is a warning nobody reads.
+    const ordinary = leg({
+      id: 'shopping',
+      accountId: 'acc-a',
+      type: 'expense',
+      transferAccountId: undefined,
+      linkedTransferId: undefined,
+    });
+    expect(describeDeleteStranding(ordinary, [ordinary], OPEN)).toBeNull();
+    expect(describeDeleteStranding(null, [], OPEN)).toBeNull();
+  });
+
+  it('names the account the survivor is left in, and what happens to it', () => {
+    const stranding = describeDeleteStranding(OUT, [OUT, IN], OPEN);
+
+    expect(stranding).not.toBeNull();
+    // The account by NAME: the whole point is that the damage lands somewhere
+    // the user is not looking.
+    expect(stranding?.message).toContain('Savings');
+    // The consequence, not the mechanism: the row survives and still counts.
+    expect(stranding?.message).toMatch(/still counted in that account's balance/);
+    expect(stranding?.message).toMatch(/no longer linked to anything/);
+    // And where to go and finish the job.
+    expect(stranding).toMatchObject({ accountId: 'acc-b', transactionId: 'in' });
+  });
+
+  it('works from the other leg too — both sides strand each other', () => {
+    expect(describeDeleteStranding(IN, [OUT, IN], OPEN)?.message).toContain('Current Account');
+  });
+
+  it('does not invent a name for an account that is closed', () => {
+    const stranding = describeDeleteStranding(OUT, [OUT], [account('acc-a', 'Current Account')]);
+
+    expect(stranding?.message).toContain('in the account it faces');
+    expect(stranding?.message).not.toContain('undefined');
+    expect(stranding?.accountId).toBe('acc-b');
+  });
+
+  it('says a split LINE is what survives, when that is what survives', () => {
+    // The counterpart is one line inside a split. Telling the user to "delete
+    // that side too" would be telling them to delete other people's spending:
+    // the rest of the split is unrelated, and it stays.
+    const facingASplitLine = { ...OUT, linkedTransferSplitId: 'split-line-1' };
+    const message = describeDeleteStranding(facingASplitLine, [facingASplitLine, IN], OPEN)?.message;
+
+    expect(message).toContain('a single line inside a split transaction in Savings');
+    expect(message).toMatch(/the split itself stays exactly as it is/);
+    expect(message).not.toMatch(/Delete that side too/);
   });
 });

--- a/src/utils/transferOtherSide.ts
+++ b/src/utils/transferOtherSide.ts
@@ -59,3 +59,66 @@ export function resolveTransferOtherSide(
     isOpen,
   };
 }
+
+/** What a delete would leave behind in the other account. */
+export interface DeleteStranding {
+  /** One paragraph, ready to render under "Delete Transaction?". */
+  message: string;
+  /** Where the survivor sits, so a caller can offer to go and deal with it. */
+  accountId: string;
+  /** The survivor's id, for the same reason. */
+  transactionId: string;
+}
+
+/**
+ * What deleting this row would do to the OTHER side of its transfer — or null
+ * when there is no other side and there is therefore nothing extra to say.
+ *
+ * WHY the confirmation needs this: `transactions_linked_transfer_id_fkey` is
+ * ON DELETE SET NULL, and `delete_transaction_atomic` removes one row and
+ * reverses one balance. So deleting one leg does not remove the movement; it
+ * removes half of it. The counterpart stays in its own account, still moving
+ * that account's balance, with its link quietly nulled — an orphan that looks
+ * like an ordinary transaction and reads as a real payment for as long as
+ * nobody reconciles that account. One such stranded leg went unnoticed for
+ * years and left an account out by five figures.
+ *
+ * The old confirmation said only "This action cannot be undone", which is true
+ * and beside the point: the thing the user cannot undo is happening in an
+ * account they are not looking at.
+ *
+ * Nothing is offered to delete on the user's behalf — cascading a delete into
+ * another account without being asked would be worse than stranding a row. This
+ * is consent, so it names the consequence and stops.
+ */
+export function describeDeleteStranding(
+  transaction: Transaction | null | undefined,
+  transactions: readonly Transaction[],
+  openAccounts: readonly Account[]
+): DeleteStranding | null {
+  const otherSide = resolveTransferOtherSide(transaction, transactions, openAccounts);
+  if (!otherSide || !transaction) {
+    return null;
+  }
+
+  // "the account it faces" rather than a blank: a closed account is not in the
+  // context's list, so its name genuinely is not available to print.
+  const where = otherSide.accountName ? `in ${otherSide.accountName}` : 'in the account it faces';
+
+  // The opposite side being one LINE of a split is worth saying, because what
+  // survives is not a whole transaction the user can go and delete — the rest
+  // of that split is other spending, and it stays.
+  if (transaction.linkedTransferSplitId) {
+    return {
+      message: `This is one half of a transfer. Its other half is a single line inside a split transaction ${where}, and deleting this will leave that line linked to nothing — the split itself stays exactly as it is, still counted in that account's balance. Open it there to put it right.`,
+      accountId: otherSide.accountId,
+      transactionId: otherSide.transactionId,
+    };
+  }
+
+  return {
+    message: `This is one half of a transfer. Deleting it will leave the other half ${where}, still counted in that account's balance but no longer linked to anything. Delete that side too if you mean to remove the whole movement — this only removes one of them.`,
+    accountId: otherSide.accountId,
+    transactionId: otherSide.transactionId,
+  };
+}

--- a/supabase/migrations/20260808090000_transaction_statement_sequence.sql
+++ b/supabase/migrations/20260808090000_transaction_statement_sequence.sql
@@ -1,0 +1,299 @@
+-- ============================================================================
+-- statement_sequence — keep the bank's own order within a day
+-- ============================================================================
+-- IMPORTANT: apply with `npm run db:migrate` (see supabase/migrations/README.md
+-- rule 1 — never the SQL editor). One new nullable column, and two existing
+-- functions redefined to carry it. No data is written, nothing is backfilled,
+-- no grants change.
+--
+-- ── WHY ─────────────────────────────────────────────────────────────────────
+-- transactions.date is a DATE. Transactions sharing a day therefore carry no
+-- order at all, and the account register has to invent one to run a balance
+-- down the page.
+--
+-- What it invented was income → transfer → expense, on the theory that a day's
+-- pay must land before the payments it funds. A real current account disproves
+-- it. The account runs an automated two-way sweep with a linked savings
+-- account: ordinary transactions happen through the day, then ONE sweep in the
+-- evening returns the balance to exactly zero. The shape of such a day, in the
+-- bank's own order (figures illustrative):
+--
+--     DIRECT DEBIT                            -12.75    balance   -12.75
+--     STANDING ORDER OUT                     -300.00    balance  -312.75
+--     TWO WAY SWEEP IN                       +312.75    balance     0.00
+--
+-- Two things no type rule can express. The credit comes LAST, after the debits.
+-- And the standing order and the sweep are BOTH transfers, with a real order
+-- between them. The invented order put the sweep in the middle and showed
+-- intermediate balances the account never held — arithmetically self-consistent,
+-- and a description of a day that did not happen. On a screen whose whole
+-- purpose is agreeing with a bank statement line by line, that is a real
+-- shortfall.
+--
+-- "Transfers last" would be the same mistake in a new coat: a transfer can
+-- equally fund a day's spending at its start. There is no rule to be had. The
+-- bank knows the order and states it, and OFX lists <STMTTRN> in it — the
+-- importer simply threw it away.
+--
+-- ── WHY NOTHING EXISTING WILL DO ────────────────────────────────────────────
+--   * created_at — defaults to now(), which is TRANSACTION start time.
+--     import_transactions_atomic writes a whole file inside ONE transaction, so
+--     every row of an imported statement shares a created_at; and the OFX modal
+--     fires its per-row writes without awaiting them, so even one-at-a-time
+--     arrival is a race. Reliable for hand entry, useless within a file.
+--   * external_transaction_id — the bank FEED's opaque provider id
+--     (TrueLayer/Plaid), never written by file imports, and not an order.
+--   * import_source / import_source_id — MS Money re-import provenance.
+--   * OFX FITID — reaches free-text `notes` only, and is an opaque id anyway.
+--   * id — a random uuid.
+--
+-- ── WHAT DOES NOT CHANGE ────────────────────────────────────────────────────
+-- Every row already in the table. The column is nullable and deliberately NOT
+-- backfilled: there is no honest sequence to invent for history, and writing a
+-- guess is the exact failure this migration exists to end. NULL means "unknown"
+-- and the register treats it as such — see compareChronological in
+-- src/utils/transactionSort.ts, where unknown sorts LAST within its day so an
+-- imported statement's own run stays contiguous and the day still closes on the
+-- account's true balance.
+--
+-- Also unchanged: both functions keep their signatures, their SECURITY INVOKER,
+-- their pinned search_path, their audit writes and their grants. A caller that
+-- sends no statement_sequence behaves exactly as before, which is what makes
+-- this safe to apply ahead of any application deploy.
+--
+-- ── BALANCE REASONING ───────────────────────────────────────────────────────
+-- Balance-neutral. statement_sequence is a presentation ordinal: no amount,
+-- sign, account_id or date is read or written by anything here, and the balance
+-- statements inside both functions are byte-for-byte the ones already in place
+-- (create_transaction_atomic: balance = balance + v_tx.amount;
+-- import_transactions_atomic: one balance = balance + v_sum for the batch). The
+-- invariant balance = initial_balance + Σ(amount) is untouched, and the
+-- register's running balance still sums the same rows — only the order it walks
+-- them in can change, which moves intermediate figures towards the statement
+-- and cannot move the total.
+--
+-- ── ORDINAL, NOT A TIMESTAMP ────────────────────────────────────────────────
+-- A statement gives sequence, not clock time. Storing a fabricated time would
+-- be the same class of lie as the type order this replaces, and would then be
+-- indistinguishable from a real one.
+-- ============================================================================
+
+BEGIN;
+
+ALTER TABLE public.transactions
+  ADD COLUMN IF NOT EXISTS statement_sequence integer;
+
+COMMENT ON COLUMN public.transactions.statement_sequence IS
+  'Position of this row within the statement/file it was imported from, giving the bank''s own order among transactions that share a date. NULL = unknown (hand-entered, or imported before this column existed); the register sorts unknown last within its day. An ordinal, not a time.';
+
+-- The register reads one account in date order and breaks ties on this, so the
+-- index matches that access path exactly. NULLS LAST mirrors the comparator: a
+-- row that knows its place sorts ahead of one that does not.
+CREATE INDEX IF NOT EXISTS idx_transactions_statement_order
+  ON public.transactions (account_id, date, statement_sequence NULLS LAST);
+
+-- ── create_transaction_atomic: carry the ordinal ────────────────────────────
+-- Identical to the definition in 20260610150000_financial_audit_log.sql except
+-- for the statement_sequence column and its cast. NULLIF so an absent or empty
+-- key stays NULL rather than failing the cast.
+CREATE OR REPLACE FUNCTION public.create_transaction_atomic(p jsonb)
+RETURNS public.transactions
+LANGUAGE plpgsql SECURITY INVOKER
+SET search_path = public
+AS $$
+DECLARE
+  v_tx public.transactions;
+BEGIN
+  INSERT INTO public.transactions (
+    id, user_id, account_id, description, amount, type, date,
+    category, notes, tags, is_recurring, transfer_account_id,
+    metadata, category_id, merchant_name, location_city,
+    location_country, payment_channel, statement_sequence
+  ) VALUES (
+    COALESCE(NULLIF(p->>'id', '')::uuid, gen_random_uuid()),
+    (p->>'user_id')::uuid,
+    (p->>'account_id')::uuid,
+    p->>'description',
+    (p->>'amount')::numeric,
+    p->>'type',
+    (p->>'date')::date,
+    p->>'category',
+    p->>'notes',
+    CASE WHEN p ? 'tags' AND jsonb_typeof(p->'tags') = 'array'
+         THEN ARRAY(SELECT jsonb_array_elements_text(p->'tags'))
+         ELSE NULL END,
+    COALESCE((p->>'is_recurring')::boolean, false),
+    NULLIF(p->>'transfer_account_id', '')::uuid,
+    COALESCE(p->'metadata', '{}'::jsonb),
+    NULLIF(p->>'category_id', '')::uuid,
+    p->>'merchant_name',
+    p->>'location_city',
+    p->>'location_country',
+    p->>'payment_channel',
+    NULLIF(p->>'statement_sequence', '')::integer
+  )
+  RETURNING * INTO v_tx;
+
+  UPDATE public.accounts
+     SET balance = balance + v_tx.amount,
+         updated_at = now()
+   WHERE id = v_tx.account_id
+     AND user_id = v_tx.user_id;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'account_not_found_or_not_owned'
+      USING ERRCODE = 'P0001',
+            HINT = 'The account does not exist or does not belong to this user.';
+  END IF;
+
+  PERFORM public.write_financial_audit(
+    v_tx.user_id, 'transaction', v_tx.id, 'create', NULL, to_jsonb(v_tx)
+  );
+
+  RETURN v_tx;
+END;
+$$;
+
+-- ── import_transactions_atomic: carry the ordinal ───────────────────────────
+-- Identical to 20260709120000_import_transactions_atomic.sql except for the
+-- statement_sequence column and its cast. This is the path that matters most:
+-- it is where a whole statement lands in one transaction, and therefore where
+-- created_at can say nothing about order.
+CREATE OR REPLACE FUNCTION public.import_transactions_atomic(
+  p_user_id uuid,
+  p_account_id uuid,
+  p_rows jsonb
+)
+RETURNS jsonb
+LANGUAGE plpgsql SECURITY INVOKER
+SET search_path = public
+AS $$
+DECLARE
+  r jsonb;
+  v_tx public.transactions;
+  v_sum numeric := 0;
+  v_inserted integer := 0;
+  v_before public.accounts;
+  v_after public.accounts;
+BEGIN
+  IF p_rows IS NULL OR jsonb_typeof(p_rows) <> 'array' THEN
+    RAISE EXCEPTION 'p_rows must be a jsonb array' USING ERRCODE = '22023';
+  END IF;
+
+  SELECT * INTO v_before
+    FROM public.accounts
+   WHERE id = p_account_id AND user_id = p_user_id
+   FOR UPDATE;
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'account_not_found_or_not_owned'
+      USING ERRCODE = 'P0001',
+            HINT = 'The account does not exist or does not belong to this user.';
+  END IF;
+
+  FOR r IN SELECT value FROM jsonb_array_elements(p_rows) LOOP
+    INSERT INTO public.transactions (
+      user_id, account_id, description, amount, type, date,
+      category, notes, tags, is_recurring, is_cleared, statement_sequence
+    ) VALUES (
+      p_user_id,
+      p_account_id,
+      r->>'description',
+      (r->>'amount')::numeric,
+      r->>'type',
+      (r->>'date')::date,
+      NULLIF(r->>'category', ''),
+      NULLIF(r->>'notes', ''),
+      CASE WHEN r ? 'tags' AND jsonb_typeof(r->'tags') = 'array'
+           THEN ARRAY(SELECT jsonb_array_elements_text(r->'tags'))
+           ELSE NULL END,
+      COALESCE((r->>'is_recurring')::boolean, false),
+      COALESCE((r->>'is_cleared')::boolean, false),
+      NULLIF(r->>'statement_sequence', '')::integer
+    )
+    RETURNING * INTO v_tx;
+
+    PERFORM public.write_financial_audit(
+      p_user_id, 'transaction', v_tx.id, 'create', NULL, to_jsonb(v_tx)
+    );
+
+    v_sum := v_sum + v_tx.amount;
+    v_inserted := v_inserted + 1;
+  END LOOP;
+
+  IF v_inserted > 0 THEN
+    UPDATE public.accounts
+       SET balance = balance + v_sum,
+           updated_at = now()
+     WHERE id = p_account_id AND user_id = p_user_id
+     RETURNING * INTO v_after;
+
+    PERFORM public.write_financial_audit(
+      p_user_id, 'account', p_account_id, 'update',
+      to_jsonb(v_before), to_jsonb(v_after)
+    );
+  END IF;
+
+  RETURN jsonb_build_object('inserted', v_inserted);
+END;
+$$;
+
+COMMIT;
+
+-- ============================================================================
+-- Verification — run after applying.
+-- ============================================================================
+
+-- 1. The column exists, is nullable, and is an ordinal.
+-- Expected: one row, data_type = integer, is_nullable = YES
+SELECT column_name, data_type, is_nullable
+  FROM information_schema.columns
+ WHERE table_schema = 'public'
+   AND table_name = 'transactions'
+   AND column_name = 'statement_sequence';
+
+-- 2. Nothing was backfilled — history is honestly "unknown".
+-- Expected: with_sequence = 0 immediately after applying. It rises only as
+-- statements are (re-)imported.
+SELECT count(*) FILTER (WHERE statement_sequence IS NOT NULL) AS with_sequence,
+       count(*) FILTER (WHERE statement_sequence IS NULL)     AS without_sequence
+  FROM public.transactions;
+
+-- 3. The index is there for the register's access path.
+-- Expected: one row, idx_transactions_statement_order
+SELECT indexname
+  FROM pg_indexes
+ WHERE schemaname = 'public'
+   AND tablename = 'transactions'
+   AND indexname = 'idx_transactions_statement_order';
+
+-- 4. Both functions are still INVOKER with a pinned search_path — redefining
+--    them must not have quietly changed their security posture.
+-- Expected: two rows, prosecdef = false, proconfig = {search_path=public}
+SELECT p.proname, p.prosecdef, p.proconfig
+  FROM pg_proc p
+  JOIN pg_namespace n ON n.oid = p.pronamespace
+ WHERE n.nspname = 'public'
+   AND p.proname IN ('create_transaction_atomic', 'import_transactions_atomic')
+ ORDER BY p.proname;
+
+-- 5. Grants unchanged: authenticated and service_role only; no anon, no PUBLIC.
+SELECT p.proname, a.grantee::regrole::text AS grantee, a.privilege_type
+  FROM pg_proc p
+  JOIN pg_namespace n ON n.oid = p.pronamespace
+ CROSS JOIN LATERAL aclexplode(p.proacl) AS a
+ WHERE n.nspname = 'public'
+   AND p.proname IN ('create_transaction_atomic', 'import_transactions_atomic')
+ ORDER BY p.proname, grantee;
+
+-- 6. Balance invariant still holds for every account: balance must equal
+--    initial_balance + Σ(amount). This migration cannot have moved it, and this
+--    is the check that proves it.
+-- Expected: zero rows
+SELECT a.id, a.name, a.balance, a.initial_balance + COALESCE(t.total, 0) AS expected
+  FROM public.accounts a
+  LEFT JOIN (
+    SELECT account_id, sum(amount) AS total
+      FROM public.transactions
+     GROUP BY account_id
+  ) t ON t.account_id = a.id
+ WHERE a.balance IS DISTINCT FROM a.initial_balance + COALESCE(t.total, 0);


### PR DESCRIPTION
Four fixes, all surfaced by importing one real statement and reading the register beside the bank's own.

> **Migration `20260808090000` is already applied to production.** Verified: column present (`integer`, nullable), **0 of 51,227 rows backfilled** as intended, and **zero accounts with ledger drift**. The code tolerates the column being absent either way — see below.

## An import could not see transactions it had not written itself

The OFX duplicate test was:

```ts
existing.notes && existing.notes.includes(`FITID: ${ofxTrx.fitId}`)
```

FITID is the right key, but the only rows carrying one are rows **this same importer wrote** — it stringifies the id into `notes`. A row from the bank feed, the Money import, QIF, or typed by hand has no FITID anywhere, so the test was false for every one of them and each was imported again. There was no account filter and no amount check at all: FITID or nothing.

**It stayed hidden because the duplicates net to zero.** On an account swept back to zero each evening, both a payment *and* its offsetting sweep get duplicated, so every day still balances and the account total stays correct while the register shows everything twice.

Matching is now two tiers, modelled on the existing feed-overlap fix:

| Tier | Rule | Behaviour |
|---|---|---|
| Certain | FITID on both sides | Skipped silently, not overridable |
| Possible | Same account, exact pence, ±3 days | Shown to the user, withheld unless they say otherwise |

Description **ranks** candidates and never gates them — the pairs it must bridge share no words, because payees get renamed and older rows arrived truncated. Matching is strictly 1:1 and greedy, so two genuine same-day payments of equal value cannot both be withheld against a single existing row.

## One sweep taught it to file every payment as a transfer

Ordinary third-party payments were being categorised as transfers to the very account they already sat in.

Smart categorisation learns from **all** categorised rows including transfers, and `extractMerchant` takes the first three words of a description. On a swept account the internal sweeps are described by their payment channel, so the learned merchant key was the channel itself — which every third-party payment on the statement shares. The merchant branch scores `min(0.9, 0.7 + count*0.02)`, i.e. **≥ 0.70 from a single example**, and the importer's gate is `>= 0.7`. One sweep was enough.

A suggestion that would file a row as a transfer to its own account is now refused **whatever its confidence**, in both the OFX and QIF paths — the same invariant the quick-edit panel already enforced by hand. A genuine to/from *another* account still applies.

## A day in the register was not the day at the bank

Balances were accumulated in one order and rows displayed in another, so the top row never carried the account's balance. Descending is now **the whole comparator negated**, making it the exact reverse of the accumulation.

The tie-break underneath it was transaction *type*, which cannot express a real day: two transfers can share a date, and an evening sweep belongs last rather than in the middle. Type ordering produced intermediate balances the account never held.

OFX lists transactions in statement order and the parser was discarding it, so that position is now kept and recorded, with a migration adding the column.

**Deploy order is no longer load-bearing.** `BOOT_TRANSACTION_COLUMNS` is an explicit select list and PostgREST fails the *entire* query on an unknown column — shipping ahead of the migration would have returned **zero transactions**, not a degraded sort. The fetch now catches Postgres `42703` (matched on the code, never the message), memoises it, and refetches without the column.

Deleting half a transfer now says which account keeps the other half. The foreign key is `ON DELETE SET NULL` rather than a cascade, which is the safer default, but nothing said so — and a leg orphaned that way is exactly the defect that can sit unnoticed for years.

## A backup for people with no cloud

`backupService` was hard-wired to Supabase, so a local-only or demo user had **no way to save their data at all**. Local export and restore now use the same format and the same id remapper, so a backup is a backup whichever engine wrote it, and the two interchange (tested both directions, with the one-way losses stated rather than hidden).

Restore is all-or-nothing: everything is read, validated and converted first, then written in a single IndexedDB transaction — stronger than the cloud path, where chunks are separate transactions.

Three defects fell out of building it:

- The id remapper **skipped ids that were not uuid-shaped**, so signed-out users' text category ids went unmapped and a restore would have left **every transaction uncategorised**
- Goal metadata holding account ids was never remapped — a cloud bug too
- Categories, splits and dismissals were being given a 30-day expiry, so **a restored backup would have evaporated a month later**

**Clear All Data also never worked outside the cloud** — it wrote to `localStorage` while every reader uses IndexedDB, and its test asserted the same wrong layer, which is why it survived. Restore needs a working wipe, so both are fixed.

Negative zero no longer renders with a minus sign, fixed at the formatter root.

## Verification

- Lint clean, strict typecheck clean
- **4,220 tests passing**; coverage 69.78% statements / 79.52% branches (floors 63 / 55)
- Every fix carries a break-it/watch-it-fail/restore proof
- No real financial data in any fixture — figures and dates re-invented, shapes preserved

🤖 Generated with [Claude Code](https://claude.com/claude-code)
