### PR TITLE
fix: clear a card's sort code instead of writing it back

### DIFF
--- a/src/components/AccountSettingsModal.tsx
+++ b/src/components/AccountSettingsModal.tsx
@@ -4,7 +4,7 @@ import DatePicker from './common/DatePicker';
 import MoneyInput from './common/MoneyInput';
 import { useModalForm } from '../hooks/useModalForm';
 import { parseMoneyInput } from '../utils/decimal';
-import type { Account as BaseAccount } from '../types';
+import type { Account as BaseAccount, AccountUpdate } from '../types';
 import ToggleSwitch from './ui/ToggleSwitch';
 import CardNumberGuidance from './CardNumberGuidance';
 import {
@@ -27,7 +27,7 @@ interface AccountSettingsModalProps {
   isOpen: boolean;
   onClose: () => void;
   account: Account | null;
-  onSave: (accountId: string, updates: Partial<Account>) => void | Promise<void>;
+  onSave: (accountId: string, updates: AccountUpdate) => void | Promise<void>;
 }
 
 interface FormData {
@@ -78,7 +78,7 @@ export default function AccountSettingsModal({
       onSubmit: async (data) => {
         if (!account) return;
 
-        const updates: Partial<Account> = {
+        const updates: AccountUpdate = {
           type: data.type,
           institution: data.institution || undefined,
           // Display name only — bank-feed links key on connection/account ids
@@ -86,7 +86,13 @@ export default function AccountSettingsModal({
           // Never blank a name: an empty field leaves the current name as-is.
           ...(data.name.trim() !== '' ? { name: data.name.trim() } : {}),
           notes: data.notes || undefined,
-          sortCode: data.sortCode || undefined,
+          // A card has no sort code (see utils/accountNumberInput). The input is
+          // hidden for cards, so switching an account to Credit Card leaves the
+          // loaded value sitting in form state — send an explicit null to clear
+          // the stored one instead of writing it back. undefined would not do
+          // it: mapAccountToDb skips undefined fields, leaving the stale sort
+          // code in place, where findSmartMatch would still match on it.
+          sortCode: isCardAccountType(data.type) ? null : data.sortCode || undefined,
           // A card stores its last 4 digits and nothing else, whatever the
           // field was left holding — the trim happens here rather than while
           // typing so a pasted number loses its FIRST twelve, not its last four.

--- a/src/components/__tests__/AccountSettingsModal.test.tsx
+++ b/src/components/__tests__/AccountSettingsModal.test.tsx
@@ -131,6 +131,48 @@ describe('AccountSettingsModal', () => {
       });
     });
 
+    it('clears the stored sort code when the type is switched to credit card', async () => {
+      const onSave = vi.fn();
+      render(<AccountSettingsModal {...defaultProps} onSave={onSave} />);
+
+      const typeLabel = screen.getByText('Account Type');
+      const typeSelect = typeLabel.parentElement?.querySelector('select');
+      expect(typeSelect).toBeTruthy();
+
+      await userEvent.selectOptions(typeSelect!, 'credit');
+      await userEvent.click(screen.getByRole('button', { name: 'Save Changes' }));
+
+      // A card has no sort code, so the value loaded from the previous bank
+      // type must be cleared rather than written back. null, not undefined:
+      // mapAccountToDb skips undefined fields, which would leave the stale sort
+      // code on the card for findSmartMatch to match against.
+      await waitFor(() => {
+        expect(onSave).toHaveBeenCalledWith('acc-1', expect.objectContaining({
+          type: 'credit',
+          sortCode: null
+        }));
+      });
+    });
+
+    it('keeps the stored sort code for a bank account type', async () => {
+      const onSave = vi.fn();
+      render(<AccountSettingsModal {...defaultProps} onSave={onSave} />);
+
+      const typeLabel = screen.getByText('Account Type');
+      const typeSelect = typeLabel.parentElement?.querySelector('select');
+      expect(typeSelect).toBeTruthy();
+
+      await userEvent.selectOptions(typeSelect!, 'savings');
+      await userEvent.click(screen.getByRole('button', { name: 'Save Changes' }));
+
+      await waitFor(() => {
+        expect(onSave).toHaveBeenCalledWith('acc-1', expect.objectContaining({
+          type: 'savings',
+          sortCode: '12-34-56'
+        }));
+      });
+    });
+
     it('has sort code input with correct attributes', () => {
       render(<AccountSettingsModal {...defaultProps} />);
       

--- a/src/contexts/AppContextSupabase.tsx
+++ b/src/contexts/AppContextSupabase.tsx
@@ -36,6 +36,7 @@ import type { ServerAccountBalance } from '../utils/accountBalances';
 import type { DecimalTransaction, DecimalAccount, DecimalGoal } from '../types/decimal-types';
 import type {
   Account,
+  AccountUpdate,
   Transaction,
   TransactionSplit,
   TransactionSplitInput,
@@ -64,7 +65,7 @@ export interface Tag {
 export interface AppContextType extends AppState {
   // Account operations
   addAccount: (account: Omit<Account, 'id'> & { initialBalance?: number }) => Promise<Account>;
-  updateAccount: (id: string, updates: Partial<Account>) => Promise<void>;
+  updateAccount: (id: string, updates: AccountUpdate) => Promise<void>;
   deleteAccount: (id: string) => Promise<void>;
 
   // Transaction operations — async so callers can surface save failures.
@@ -697,7 +698,7 @@ export function AppProvider({ children }: { children: React.ReactNode }) {
     }
   }, [user]);
 
-  const updateAccount = useCallback(async (id: string, updates: Partial<Account>) => {
+  const updateAccount = useCallback(async (id: string, updates: AccountUpdate) => {
     try {
       recentLocalUpdateRef.current = Date.now();
       const updatedAccount = await DataService.updateAccount(id, updates);

--- a/src/services/api/accountService.ts
+++ b/src/services/api/accountService.ts
@@ -1,6 +1,6 @@
 
 import { supabase, isSupabaseConfigured, handleSupabaseError } from './supabaseClient';
-import type { Account } from '../../types';
+import type { Account, AccountUpdate } from '../../types';
 import { storageAdapter, STORAGE_KEYS } from '../storageAdapter';
 
 type StorageAdapterLike = Pick<typeof storageAdapter, 'get' | 'set'>;
@@ -238,7 +238,7 @@ class AccountServiceImpl {
     }
   }
 
-  async updateAccount(id: string, updates: Partial<Account>, userId?: string): Promise<Account> {
+  async updateAccount(id: string, updates: AccountUpdate, userId?: string): Promise<Account> {
     if (!this.isSupabaseReady()) {
       const accounts = await this.readAccounts();
       const index = accounts.findIndex(account => account.id === id);
@@ -441,7 +441,7 @@ export class AccountService {
     return this.service.createAccount(userId, account);
   }
 
-  static updateAccount(id: string, updates: Partial<Account>, userId?: string): Promise<Account> {
+  static updateAccount(id: string, updates: AccountUpdate, userId?: string): Promise<Account> {
     return this.service.updateAccount(id, updates, userId);
   }
 

--- a/src/services/api/dataService.ts
+++ b/src/services/api/dataService.ts
@@ -17,7 +17,7 @@ import { userIdService } from '../userIdService';
 import { toDecimal, type DecimalInstance } from '../../utils/decimal';
 import { normalizeTransactionDates, toDateValue } from '../../utils/dateBoundary';
 import { splitDeclaresTransferLeg } from '../../utils/transactionSplits';
-import type { Account, Transaction, TransactionSplit, TransactionSplitInput, SplitWriteResult, Budget, Goal, Category, CategoryMergeResult, DismissalKind, SuggestionDismissal } from '../../types';
+import type { Account, AccountUpdate, Transaction, TransactionSplit, TransactionSplitInput, SplitWriteResult, Budget, Goal, Category, CategoryMergeResult, DismissalKind, SuggestionDismissal } from '../../types';
 
 export interface AppData {
   accounts: Account[];
@@ -280,7 +280,7 @@ class DataServiceImpl {
     return newAccount;
   }
 
-  async updateAccount(id: string, updates: Partial<Account>): Promise<Account> {
+  async updateAccount(id: string, updates: AccountUpdate): Promise<Account> {
     const userId = this.userIdService.getCurrentDatabaseUserId();
     if (userId && this.supabaseChecker()) {
       return this.accountService.updateAccount(id, updates, userId);
@@ -1484,7 +1484,7 @@ export class DataService {
     return this.service.createAccount(account);
   }
 
-  static updateAccount(id: string, updates: Partial<Account>): Promise<Account> {
+  static updateAccount(id: string, updates: AccountUpdate): Promise<Account> {
     return this.service.updateAccount(id, updates);
   }
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -69,6 +69,19 @@ export interface Account {
   lowBalanceAlertEnabled?: boolean;
 }
 
+/**
+ * The fields an account update may write.
+ *
+ * Distinct from `Partial<Account>` because an update can CLEAR a field, which a
+ * stored Account never represents: `null` means "remove the stored value".
+ * `undefined` cannot express that — mapAccountToDb (services/api/accountService)
+ * skips undefined fields, so an undefined sortCode leaves the column untouched
+ * rather than emptying it. Any `Partial<Account>` is still a valid update.
+ */
+export type AccountUpdate = Partial<Omit<Account, 'sortCode'>> & {
+  sortCode?: string | null;
+};
+
 export interface Transaction {
   id: string;
   date: Date;


### PR DESCRIPTION
## The bug

Account Settings loaded an account's sort code and persisted it again on save regardless of type. The input is hidden for credit cards, so switching an account to Credit Card left a stale, invisible sort code on a record that cannot have one — `utils/accountNumberInput` states it plainly: *"A card has no sort code at all."*

It isn't only cosmetic. `findSmartMatch` in `LinkBankAccountsModal` matches accounts on sort code, so a stale value could mis-match a discovered bank account during re-linking.

## Why `null` and not `undefined`

`undefined` cannot express "clear this". `mapAccountToDb` in `services/api/accountService` does `if (value === undefined) continue`, so an undefined sortCode leaves the column exactly as it was — the stale value survives. Only an explicit `null` empties it.

## Why a new type rather than widening `Account`

`Partial<Account>` cannot carry that `null`, and widening `Account.sortCode` to `string | null` is the wrong fix — it breaks assignability against the `SelectableAccount` and `GroupableAccount` structural types in roughly twenty places.

So the update path gets its own type. `AccountUpdate` is `Partial<Account>` with a nullable `sortCode`: a *stored* Account never holds null, but an *update* may clear. Every `Partial<Account>` remains a valid `AccountUpdate`, so existing callers are untouched.

## Scope

Card **account numbers are deliberately unaffected** — a card has one, and re-linking matches on it via `findCardMaskMatch`. Only the sort code, and only for cards.

## Test plan

- New test: switching type to Credit Card and saving sends `sortCode: null`. Reverting the fix fails it with `sortCode: "12-34-56"`, reproducing the bug.
- New test: switching to a bank type still preserves the stored sort code, guarding against over-clearing.
- `npm run lint` — clean
- `npm run typecheck:strict` — clean
- `npm run build:check` — passes
- `npm run test:smoke` — 4123 passed, 0 failures
- Pre-push gates (Supabase smoke, realtime, coverage) all passed; coverage 69.34% statements / 79.49% branches

🤖 Generated with [Claude Code](https://claude.com/claude-code)