### PR TITLE
fix(a11y): give the account modal fields the names screen readers announce

### DIFF
--- a/src/components/AccountSettingsModal.test.tsx
+++ b/src/components/AccountSettingsModal.test.tsx
@@ -260,7 +260,7 @@ describe('AccountSettingsModal', () => {
       const onSave = vi.fn();
       render(<AccountSettingsModal {...defaultProps} account={creditAccount} onSave={onSave} />);
 
-      fireEvent.change(screen.getByLabelText('Last four digits of the card number'), {
+      fireEvent.change(screen.getByLabelText(/Card Number/), {
         target: { value: '4929 1234 5678 9012' }
       });
       fireEvent.click(screen.getByText('Save Changes'));
@@ -275,7 +275,7 @@ describe('AccountSettingsModal', () => {
     it('keeps the whole entry in the field so the right four survive the save', () => {
       render(<AccountSettingsModal {...defaultProps} account={creditAccount} />);
 
-      const field = screen.getByLabelText('Last four digits of the card number');
+      const field = screen.getByLabelText(/Card Number/);
       fireEvent.change(field, { target: { value: '4929123456789012' } });
 
       // Capping the input would have left '4929' — the wrong four.
@@ -302,7 +302,7 @@ describe('AccountSettingsModal', () => {
     it('tells the user what will be stored rather than offering them a choice', () => {
       render(<AccountSettingsModal {...defaultProps} account={creditAccount} />);
 
-      fireEvent.change(screen.getByLabelText('Last four digits of the card number'), {
+      fireEvent.change(screen.getByLabelText(/Card Number/), {
         target: { value: '4929123456789012' }
       });
 
@@ -316,7 +316,7 @@ describe('AccountSettingsModal', () => {
       const onSave = vi.fn();
       render(<AccountSettingsModal {...defaultProps} account={creditAccount} onSave={onSave} />);
 
-      fireEvent.change(screen.getByLabelText('Last four digits of the card number'), {
+      fireEvent.change(screen.getByLabelText(/Card Number/), {
         target: { value: '' }
       });
       fireEvent.click(screen.getByText('Save Changes'));

--- a/src/components/AccountSettingsModal.tsx
+++ b/src/components/AccountSettingsModal.tsx
@@ -191,10 +191,11 @@ export default function AccountSettingsModal({
 
           {/* Account Type */}
           <div>
-            <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+            <label htmlFor="account-type" className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
               Account Type
             </label>
             <select
+              id="account-type"
               value={formData.type}
               onChange={(e) => updateField('type', e.target.value as Account['type'])}
               className="w-full px-3 py-2 bg-white dark:bg-gray-800-sm border border-gray-300/50 dark:border-gray-600/50 rounded-xl focus:outline-none focus:ring-2 focus:ring-primary focus:border-transparent dark:text-white"
@@ -266,7 +267,10 @@ export default function AccountSettingsModal({
                 value={formData.accountNumber}
                 onChange={handleAccountNumberChange}
                 placeholder={isCreditCard ? '1234' : '12345678'}
-                aria-label={isCreditCard ? 'Last four digits of the card number' : 'Bank account number'}
+                // See AddAccountModal: an aria-label here would override the
+                // visible card label with wording that does not contain it
+                // (WCAG 2.5.3 Label in Name).
+                aria-label={isCreditCard ? undefined : 'Bank account number'}
                 {...(isBankAccount ? { maxLength: BANK_ACCOUNT_NUMBER_LENGTH } : {})}
                 className="w-full px-3 py-2 bg-white dark:bg-gray-800-sm border border-gray-300/50 dark:border-gray-600/50 rounded-xl focus:outline-none focus:ring-2 focus:ring-primary focus:border-transparent dark:text-white"
               />
@@ -276,10 +280,11 @@ export default function AccountSettingsModal({
 
           {/* Institution */}
           <div>
-            <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+            <label htmlFor="account-institution" className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
               Institution
             </label>
             <input
+              id="account-institution"
               type="text"
               value={formData.institution}
               onChange={(e) => updateField('institution', e.target.value)}
@@ -312,9 +317,10 @@ export default function AccountSettingsModal({
           {/* Low Balance Alert */}
           <div>
             <div className="flex items-center justify-between mb-2">
-              <label className="block text-sm font-medium text-gray-700 dark:text-gray-300">
+              {/* Not a <label>: the control is a switch button, named via aria-labelledby */}
+              <span id="low-balance-alert-label" className="block text-sm font-medium text-gray-700 dark:text-gray-300">
                 Low Balance Alert
-              </label>
+              </span>
               <ToggleSwitch
                 checked={!!formData.lowBalanceAlertEnabled}
                 onChange={v => updateField('lowBalanceAlertEnabled', v)}
@@ -323,7 +329,7 @@ export default function AccountSettingsModal({
                 // which a closed account has left. Say so rather than let the
                 // user arm an alert that can never fire.
                 disabled={!formData.isActive}
-                aria-label="Toggle low balance alert"
+                aria-labelledby="low-balance-alert-label"
               />
             </div>
             {!formData.isActive && (
@@ -342,7 +348,6 @@ export default function AccountSettingsModal({
                   onChange={(value) => updateField('lowBalanceThreshold', value)}
                   placeholder="e.g. 500"
                   className="w-full px-3 py-2 bg-white dark:bg-gray-800-sm border border-gray-300/50 dark:border-gray-600/50 rounded-xl focus:outline-none focus:ring-2 focus:ring-primary focus:border-transparent dark:text-white"
-                  aria-label="Low balance threshold amount"
                 />
               </div>
             )}
@@ -350,10 +355,11 @@ export default function AccountSettingsModal({
 
           {/* Notes */}
           <div>
-            <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+            <label htmlFor="account-notes" className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
               Notes
             </label>
             <textarea
+              id="account-notes"
               value={formData.notes}
               onChange={(e) => updateField('notes', e.target.value)}
               rows={3}

--- a/src/components/AddAccountModal.test.tsx
+++ b/src/components/AddAccountModal.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor, within } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import AddAccountModal from './AddAccountModal';
 import { PreferencesProvider } from '../contexts/PreferencesContext';
@@ -6,6 +6,7 @@ import { __resetAppContextValue, __setAppContextValue } from '../test/mocks/AppC
 import type { Account } from '../types';
 
 type NewAccountPayload = Omit<Account, 'id'> & { initialBalance?: number };
+type AddAccountModalProps = React.ComponentProps<typeof AddAccountModal>;
 
 // Optional parameter on purpose: the context's own mock types addAccount as a
 // no-arg callback, and a required parameter would not fit it.
@@ -15,40 +16,52 @@ const addAccount = vi.fn((account?: NewAccountPayload) =>
 
 const lastPayload = (): NewAccountPayload | undefined => addAccount.mock.calls[0]?.[0];
 
-const renderModal = () =>
+const renderModal = (props: Partial<AddAccountModalProps> = {}) =>
   render(
     <PreferencesProvider>
-      <AddAccountModal isOpen onClose={vi.fn()} />
+      <AddAccountModal isOpen onClose={vi.fn()} {...props} />
     </PreferencesProvider>
   );
 
+/**
+ * Fields are addressed by accessible role + name throughout, never by
+ * placeholder. That is itself an assertion: a label that loses its `htmlFor`,
+ * or a control that loses its `id`, has no accessible name and these queries
+ * fail — whereas a placeholder query would keep passing while a screen reader
+ * announced the field as unlabelled.
+ *
+ * The balance is a MoneyInput, which renders `type="text"` + `inputMode="decimal"`,
+ * so it is a `textbox` rather than a `spinbutton`.
+ */
+const nameField = () => screen.getByRole('textbox', { name: /Account Name/ });
+const balanceField = () => screen.getByRole('textbox', { name: /Current Balance/ });
+const submitButton = () => screen.getByRole('button', { name: 'Add Account' });
+
 /** Fill in the name and balance the form requires, then choose Credit Card. */
 const startACard = () => {
-  fireEvent.change(screen.getByPlaceholderText('e.g., Main Checking Account'), {
-    target: { value: 'Amex' }
-  });
-  fireEvent.change(screen.getByPlaceholderText('0.00'), { target: { value: '-250' } });
-  fireEvent.click(screen.getByText('Credit Card'));
+  fireEvent.change(nameField(), { target: { value: 'Amex' } });
+  fireEvent.change(balanceField(), { target: { value: '-250' } });
+  fireEvent.click(screen.getByRole('button', { name: /Credit Card/ }));
 };
 
+beforeEach(() => {
+  addAccount.mockClear();
+  __setAppContextValue({ addAccount });
+});
+
+afterEach(() => {
+  __resetAppContextValue();
+});
+
 describe('AddAccountModal — a card is created holding its last 4 digits only', () => {
-  beforeEach(() => {
-    addAccount.mockClear();
-    __setAppContextValue({ addAccount });
-  });
-
-  afterEach(() => {
-    __resetAppContextValue();
-  });
-
   it('stores the LAST four of a pasted card number, not the first', async () => {
     renderModal();
     startACard();
 
-    fireEvent.change(screen.getByLabelText('Last four digits of the card number'), {
+    fireEvent.change(screen.getByRole('textbox', { name: /Card Number/ }), {
       target: { value: '4929 1234 5678 9012' }
     });
-    fireEvent.click(screen.getByText('Add Account'));
+    fireEvent.click(submitButton());
 
     await waitFor(() => expect(addAccount).toHaveBeenCalledTimes(1));
     expect(lastPayload()?.accountNumber).toBe('9012');
@@ -58,7 +71,7 @@ describe('AddAccountModal — a card is created holding its last 4 digits only',
     renderModal();
     startACard();
 
-    const field = screen.getByLabelText('Last four digits of the card number');
+    const field = screen.getByRole('textbox', { name: /Card Number/ });
     fireEvent.change(field, { target: { value: '4929123456789012' } });
 
     // Capping the input would have left '4929' — the wrong four.
@@ -69,7 +82,7 @@ describe('AddAccountModal — a card is created holding its last 4 digits only',
     renderModal();
     startACard();
 
-    fireEvent.change(screen.getByLabelText('Last four digits of the card number'), {
+    fireEvent.change(screen.getByRole('textbox', { name: /Card Number/ }), {
       target: { value: '4929123456789012' }
     });
 
@@ -81,14 +94,12 @@ describe('AddAccountModal — a card is created holding its last 4 digits only',
   it('leaves a bank account number whole', async () => {
     renderModal();
 
-    fireEvent.change(screen.getByPlaceholderText('e.g., Main Checking Account'), {
-      target: { value: 'HSBC Current' }
-    });
-    fireEvent.change(screen.getByPlaceholderText('0.00'), { target: { value: '1000' } });
-    fireEvent.change(screen.getByLabelText('Bank account number'), {
+    fireEvent.change(nameField(), { target: { value: 'HSBC Current' } });
+    fireEvent.change(balanceField(), { target: { value: '1000' } });
+    fireEvent.change(screen.getByRole('textbox', { name: 'Bank account number' }), {
       target: { value: '12345678' }
     });
-    fireEvent.click(screen.getByText('Add Account'));
+    fireEvent.click(submitButton());
 
     await waitFor(() => expect(addAccount).toHaveBeenCalledTimes(1));
     expect(lastPayload()?.accountNumber).toBe('12345678');
@@ -98,9 +109,181 @@ describe('AddAccountModal — a card is created holding its last 4 digits only',
     renderModal();
     startACard();
 
-    fireEvent.click(screen.getByText('Add Account'));
+    fireEvent.click(submitButton());
 
     await waitFor(() => expect(addAccount).toHaveBeenCalledTimes(1));
     expect(lastPayload()?.accountNumber).toBeUndefined();
+  });
+});
+
+describe('AddAccountModal — every field is announced by its visible label', () => {
+  /** Asserts the control's accessible name comes from a visible <label for=...>. */
+  const expectVisibleLabel = (control: HTMLElement, text: RegExp): void => {
+    expect(control.id).not.toBe('');
+    const label = document.querySelector<HTMLLabelElement>(`label[for="${control.id}"]`);
+    expect(label).not.toBeNull();
+    expect(label?.textContent ?? '').toMatch(text);
+  };
+
+  it('exposes every field by role and accessible name', () => {
+    renderModal();
+
+    expect(nameField()).toBeInTheDocument();
+    expect(balanceField()).toBeInTheDocument();
+    expect(screen.getByRole('combobox', { name: /Currency/ })).toBeInTheDocument();
+    expect(screen.getByRole('textbox', { name: /Financial Institution/ })).toBeInTheDocument();
+    // These two carry an explicit aria-label, which wins over the visible
+    // label, so they are named by it rather than by the label text.
+    expect(screen.getByRole('textbox', { name: 'Bank sort code' })).toBeInTheDocument();
+    expect(screen.getByRole('textbox', { name: 'Bank account number' })).toBeInTheDocument();
+  });
+
+  it('derives each accessible name from a visible label, not an aria-label', () => {
+    renderModal();
+
+    expectVisibleLabel(nameField(), /Account Name/);
+    expectVisibleLabel(balanceField(), /Current Balance/);
+    expectVisibleLabel(screen.getByRole('combobox', { name: /Currency/ }), /Currency/);
+    expectVisibleLabel(screen.getByRole('textbox', { name: /Financial Institution/ }), /Financial Institution/);
+  });
+
+  /** Every currently-mounted control whose aria-label hides its visible label. */
+  const labelInNameViolations = (): string[] => {
+    const controls = Array.from(
+      screen.getByRole('dialog').querySelectorAll<HTMLElement>('input, select, textarea')
+    );
+    return controls.flatMap((control) => {
+      const ariaLabel = control.getAttribute('aria-label');
+      if (ariaLabel === null || control.id === '') return [];
+      const label = document.querySelector<HTMLLabelElement>(`label[for="${control.id}"]`);
+      const visible = (label?.textContent ?? '').replace(/\(Optional\)/i, '').trim();
+      if (visible === '') return [];
+      return ariaLabel.toLowerCase().includes(visible.toLowerCase())
+        ? []
+        : [`visible "${visible}" is not contained in accessible name "${ariaLabel}"`];
+    });
+  };
+
+  // WCAG 2.5.3: an aria-label replaces the visible label as the accessible
+  // name, so speaking the visible label must still reach the field. Checked in
+  // both states — the card fields are not mounted for a bank account, so a
+  // single default render would miss them entirely.
+  it('never overrides a visible label with an aria-label that omits it', () => {
+    renderModal();
+    expect(labelInNameViolations()).toEqual([]);
+  });
+
+  it('never overrides a visible label once the card fields are showing', () => {
+    renderModal();
+    startACard();
+    expect(labelInNameViolations()).toEqual([]);
+  });
+
+  it('lets the card number field be reached by its visible label', () => {
+    renderModal();
+    startACard();
+
+    // Was named "Last four digits of the card number", which does not contain
+    // the visible "Card Number — last 4 digits only".
+    expectVisibleLabel(screen.getByRole('textbox', { name: /Card Number/ }), /Card Number/);
+  });
+
+  it('leaves no form control relying on placeholder text for its name', () => {
+    renderModal();
+
+    const controls = Array.from(
+      screen.getByRole('dialog').querySelectorAll<HTMLElement>('input, select, textarea')
+    );
+    expect(controls.length).toBeGreaterThan(0);
+
+    const unnamed = controls.filter((control) => {
+      const labelled = control.id !== '' && document.querySelector(`label[for="${control.id}"]`) !== null;
+      return !labelled && !control.getAttribute('aria-label') && !control.getAttribute('aria-labelledby');
+    });
+    expect(unnamed.map((control) => control.outerHTML)).toEqual([]);
+  });
+});
+
+describe('AddAccountModal — the account type buttons are a labelled group', () => {
+  it('labels the group and reports the selected type', () => {
+    renderModal();
+
+    const group = screen.getByRole('group', { name: /Account Type/ });
+    expect(within(group).getByRole('button', { name: /Current Account/ })).toHaveAttribute('aria-pressed', 'true');
+    expect(within(group).getByRole('button', { name: /Savings Account/ })).toHaveAttribute('aria-pressed', 'false');
+  });
+
+  it('moves the pressed state when another type is chosen', () => {
+    renderModal();
+
+    const group = screen.getByRole('group', { name: /Account Type/ });
+    fireEvent.click(within(group).getByRole('button', { name: /Savings Account/ }));
+
+    expect(within(group).getByRole('button', { name: /Savings Account/ })).toHaveAttribute('aria-pressed', 'true');
+    expect(within(group).getByRole('button', { name: /Current Account/ })).toHaveAttribute('aria-pressed', 'false');
+  });
+
+  it('swaps the bank fields for card fields on a credit card', () => {
+    renderModal();
+    startACard();
+
+    expect(screen.queryByRole('textbox', { name: 'Bank sort code' })).not.toBeInTheDocument();
+    expect(screen.getByRole('textbox', { name: /Card Number/ })).toBeInTheDocument();
+  });
+});
+
+describe('AddAccountModal — submission', () => {
+  it('submits values entered through role-based queries', async () => {
+    const onAccountCreated = vi.fn();
+    renderModal({ onAccountCreated });
+
+    fireEvent.change(nameField(), { target: { value: 'Everyday Current' } });
+    fireEvent.change(balanceField(), { target: { value: '250.75' } });
+    fireEvent.change(screen.getByRole('combobox', { name: /Currency/ }), { target: { value: 'USD' } });
+    fireEvent.change(screen.getByRole('textbox', { name: /Financial Institution/ }), {
+      target: { value: 'HSBC' }
+    });
+
+    fireEvent.click(submitButton());
+
+    await waitFor(() => expect(addAccount).toHaveBeenCalledTimes(1));
+    expect(lastPayload()).toMatchObject({
+      name: 'Everyday Current',
+      type: 'current',
+      balance: 250.75,
+      currency: 'USD',
+      institution: 'HSBC'
+    });
+    await waitFor(() => expect(onAccountCreated).toHaveBeenCalledWith('new-account'));
+  });
+
+  it('strips sort code formatting before saving', async () => {
+    renderModal();
+
+    fireEvent.change(nameField(), { target: { value: 'Joint Savings' } });
+    fireEvent.change(balanceField(), { target: { value: '10' } });
+    fireEvent.change(screen.getByRole('textbox', { name: 'Bank sort code' }), {
+      target: { value: '123456' }
+    });
+
+    expect(screen.getByRole('textbox', { name: 'Bank sort code' })).toHaveValue('12-34-56');
+
+    fireEvent.click(submitButton());
+
+    await waitFor(() => expect(addAccount).toHaveBeenCalledTimes(1));
+    expect(lastPayload()?.sortCode).toBe('123456');
+  });
+
+  // The balance is `required`, so native constraint validation blocks the
+  // submit before the component's own "valid balance" check ever runs.
+  it('does not save when the balance is blank', () => {
+    renderModal();
+
+    fireEvent.change(nameField(), { target: { value: 'No Balance' } });
+    fireEvent.click(submitButton());
+
+    expect(balanceField()).toBeRequired();
+    expect(balanceField()).toBeInvalid();
+    expect(addAccount).not.toHaveBeenCalled();
   });
 });

--- a/src/components/AddAccountModal.tsx
+++ b/src/components/AddAccountModal.tsx
@@ -203,10 +203,11 @@ export default function AddAccountModal({ isOpen, onClose, prefill, onAccountCre
 
             {/* Account Name */}
             <div>
-              <label className="block text-sm font-semibold text-gray-700 dark:text-gray-200 mb-2">
+              <label htmlFor="add-account-name" className="block text-sm font-semibold text-gray-700 dark:text-gray-200 mb-2">
                 Account Name *
               </label>
               <input
+                id="add-account-name"
                 type="text"
                 value={formData.name}
                 onChange={(e) => updateField('name', e.target.value)}
@@ -220,10 +221,11 @@ export default function AddAccountModal({ isOpen, onClose, prefill, onAccountCre
 
             {/* Account Type */}
             <div>
-              <label className="block text-sm font-semibold text-gray-700 dark:text-gray-200 mb-2">
+              {/* Not a <label>: the control is a group of buttons, not a single input */}
+              <span id="add-account-type-label" className="block text-sm font-semibold text-gray-700 dark:text-gray-200 mb-2">
                 Account Type *
-              </label>
-              <div className="grid grid-cols-2 gap-3">
+              </span>
+              <div role="group" aria-labelledby="add-account-type-label" className="grid grid-cols-2 gap-3">
                 {accountTypes.map((type) => {
                   const Icon = type.icon;
                   const isSelected = formData.type === type.value;
@@ -233,6 +235,8 @@ export default function AddAccountModal({ isOpen, onClose, prefill, onAccountCre
                       type="button"
                       onClick={() => updateField('type', type.value as AccountFormData['type'])}
                       disabled={isSubmitting}
+                      // Selection is otherwise conveyed by colour alone.
+                      aria-pressed={isSelected}
                       className={`p-3 rounded-xl border-2 transition-all duration-200 ${
                         isSelected
                           ? 'border-primary bg-[#1a2332]/10 dark:bg-primary/20'
@@ -265,7 +269,7 @@ export default function AddAccountModal({ isOpen, onClose, prefill, onAccountCre
             <div className="grid grid-cols-2 gap-4">
               {/* Current Balance */}
               <div>
-                <label className="block text-sm font-semibold text-gray-700 dark:text-gray-200 mb-2">
+                <label htmlFor="add-account-balance" className="block text-sm font-semibold text-gray-700 dark:text-gray-200 mb-2">
                   Current Balance *
                 </label>
                 <div className="relative">
@@ -273,6 +277,7 @@ export default function AddAccountModal({ isOpen, onClose, prefill, onAccountCre
                     {selectedCurrency?.symbol}
                   </span>
                   <MoneyInput
+                    id="add-account-balance"
                     // Credit cards and loans start negative.
                     allowNegative
                     value={formData.balance}
@@ -286,10 +291,11 @@ export default function AddAccountModal({ isOpen, onClose, prefill, onAccountCre
 
               {/* Currency */}
               <div>
-                <label className="block text-sm font-semibold text-gray-700 dark:text-gray-200 mb-2">
+                <label htmlFor="add-account-currency" className="block text-sm font-semibold text-gray-700 dark:text-gray-200 mb-2">
                   Currency *
                 </label>
                 <select
+                  id="add-account-currency"
                   value={formData.currency}
                   onChange={(e) => updateField('currency', e.target.value)}
                   disabled={isSubmitting}
@@ -313,13 +319,14 @@ export default function AddAccountModal({ isOpen, onClose, prefill, onAccountCre
 
             {/* Institution */}
             <div>
-              <label className="block text-sm font-semibold text-gray-700 dark:text-gray-200 mb-2">
+              <label htmlFor="add-account-institution" className="block text-sm font-semibold text-gray-700 dark:text-gray-200 mb-2">
                 Financial Institution
                 <span className="text-xs font-normal text-gray-500 dark:text-gray-400 ml-2">(Optional)</span>
               </label>
               <div className="relative">
                 <Building2Icon size={18} className="absolute left-4 top-1/2 -translate-y-1/2 text-gray-400" />
                 <input
+                  id="add-account-institution"
                   type="text"
                   value={formData.institution}
                   onChange={(e) => updateField('institution', e.target.value)}
@@ -369,7 +376,11 @@ export default function AddAccountModal({ isOpen, onClose, prefill, onAccountCre
                     onChange={(e) => updateField('accountNumber', nextAccountNumberValue(e.target.value, isCreditCard))}
                     className="w-full px-4 py-3 bg-white dark:bg-gray-800 border-2 border-gray-200 dark:border-gray-700 rounded-xl focus:outline-none focus:ring-3 focus:ring-primary/20 focus:border-primary dark:text-white transition-all duration-200"
                     placeholder={isCreditCard ? '1234' : '12345678'}
-                    aria-label={isCreditCard ? 'Last four digits of the card number' : 'Bank account number'}
+                    // No aria-label for a card: it would override the visible
+                    // "Card Number — last 4 digits only" with wording that does
+                    // not contain it, so speaking the visible label would not
+                    // reach the field (WCAG 2.5.3 Label in Name).
+                    aria-label={isCreditCard ? undefined : 'Bank account number'}
                     {...(isBankAccount ? { maxLength: BANK_ACCOUNT_NUMBER_LENGTH } : {})}
                     disabled={isSubmitting}
                   />


### PR DESCRIPTION
The visible labels for **name, balance, currency and institution** carried no `htmlFor`, and their inputs no `id`, so nothing tied them together. Those fields had **no accessible name at all** — a screen reader announced them as unlabelled, and tests could only reach them by placeholder. WCAG 2.1 AA **1.3.1** and **4.1.2**.

`MoneyInput` and `ToggleSwitch` already forward `id` / `aria-label` / `aria-labelledby`, so nothing had to be threaded through them.

### Two labels that pointed at nothing

- **Account type** sat above a grid of six buttons — a `<label>` cannot describe that. Now a `role="group"` with `aria-labelledby`, and the buttons carry `aria-pressed`: which type was selected had been conveyed by **colour alone**.
- **Low balance alert** wrapped no control whatsoever. The switch now takes its name from it via `aria-labelledby`, so the visible text *is* the accessible name.

### Three Label in Name failures (2.5.3)

An `aria-label` replaced the visible label with wording that did not contain it, so speaking the visible label would not reach the field:

| Field | Visible | Was announced as |
| --- | --- | --- |
| Card number (both modals) | `Card Number — last 4 digits only` | `Last four digits of the card number` |
| Low balance threshold | `Alert when balance falls below` | `Low balance threshold amount` |

The redundant `aria-label`s that **do** contain their visible label (sort code, bank account number, opening balance, account name) are left alone — removing them is tidier but touches 61 test references for no conformance gain.

### Tests

Selectors moved from placeholder to accessible role + name, which is what proves the fix: **removing a single `htmlFor` fails six of them.**

The Label in Name check runs in **both** the bank and card states. My first version only rendered the default bank state — where the card fields are not mounted — so it passed while the bug was still present.

### Verification

- `npm run lint` — silent
- `npm run typecheck:strict` — clean
- `npm run test:smoke` — 261 files, 4133 tests passed, 0 failed
- Pre-push gate passed in full: Supabase smoke, realtime suite, coverage 69.33% statements / 79.54% branches (floors 63/55)
- No `as any`, no `@ts-ignore`

🤖 Generated with [Claude Code](https://claude.com/claude-code)