### PR TITLE
test(a11y): stop an aria-label from hiding the visible label it replaces

### DIFF
--- a/src/test/a11y/label-in-name.test.ts
+++ b/src/test/a11y/label-in-name.test.ts
@@ -1,0 +1,159 @@
+/**
+ * WCAG 2.5.3 "Label in Name", enforced across every component.
+ *
+ * An `aria-label` REPLACES the visible <label> as a control's accessible name.
+ * Speech-input users say what they can see, so the visible text must still
+ * appear inside that name — otherwise saying the visible label does not reach
+ * the field.
+ *
+ * This exists because the two names drift. AddAccountModal's card field was
+ * labelled "Card Number — last 4 digits only" but announced as "Last four
+ * digits of the card number": each was reasonable on its own, and nothing
+ * connected them. A per-component test cannot catch that class of bug, because
+ * the next one will appear in a component nobody thought to check.
+ *
+ * Parsed with the TypeScript compiler rather than regex: an arrow function in a
+ * JSX attribute (`onChange={(e) => ...}`) contains '>', which silently
+ * truncates any regex-based tag matcher and yields a false all-clear.
+ */
+import { describe, it, expect } from 'vitest';
+import { readdirSync, statSync, readFileSync } from 'node:fs';
+import path from 'node:path';
+import ts from 'typescript';
+
+const SRC = path.resolve(__dirname, '../..');
+
+function componentFiles(dir: string, out: string[] = []): string[] {
+  for (const entry of readdirSync(dir)) {
+    if (entry === 'node_modules' || entry === 'dist' || entry.startsWith('.')) continue;
+    const p = path.join(dir, entry);
+    if (statSync(p).isDirectory()) componentFiles(p, out);
+    else if (entry.endsWith('.tsx') && !/\.(test|spec)\./.test(entry)) out.push(p);
+  }
+  return out;
+}
+
+const normalise = (s: string): string => s.replace(/\s+/g, ' ').trim();
+
+/** Every string literal reachable from an attribute value, including ternaries. */
+function literalsOf(node: ts.Node | undefined): string[] {
+  if (!node) return [];
+  const out: string[] = [];
+  const visit = (n: ts.Node): void => {
+    if (ts.isStringLiteral(n) || ts.isNoSubstitutionTemplateLiteral(n)) out.push(n.text);
+    ts.forEachChild(n, visit);
+  };
+  visit(node);
+  return out;
+}
+
+function attribute(el: ts.JsxOpeningLikeElement, name: string): ts.Node | undefined {
+  for (const prop of el.attributes.properties) {
+    if (ts.isJsxAttribute(prop) && prop.name.getText() === name) return prop.initializer ?? undefined;
+  }
+  return undefined;
+}
+
+/** A visually hidden label carries no visible text, so 2.5.3 does not apply. */
+function isScreenReaderOnly(el: ts.JsxOpeningLikeElement): boolean {
+  return literalsOf(attribute(el, 'className')).some((c) => /\bsr-only\b/.test(c));
+}
+
+/** Visible text of a <label>: JSX text plus literals in expression children. */
+function visibleText(label: ts.JsxElement): string[] {
+  const parts: string[] = [];
+  const visit = (n: ts.Node): void => {
+    if (ts.isJsxText(n)) {
+      const t = normalise(n.text);
+      if (t) parts.push(t);
+    } else if (
+      (ts.isStringLiteral(n) || ts.isNoSubstitutionTemplateLiteral(n)) &&
+      n.parent &&
+      (ts.isJsxExpression(n.parent) || ts.isConditionalExpression(n.parent))
+    ) {
+      parts.push(n.text);
+    }
+    ts.forEachChild(n, visit);
+  };
+  label.children.forEach(visit);
+  // "(Optional)" is a hint, not part of what a user would speak.
+  return parts.filter((t) => !/^\(?optional\)?$/i.test(t));
+}
+
+interface Violation {
+  file: string;
+  line: number;
+  id: string;
+  visible: string;
+  aria: string;
+}
+
+function scan(): Violation[] {
+  const violations: Violation[] = [];
+
+  for (const file of componentFiles(SRC)) {
+    const source = ts.createSourceFile(
+      file,
+      readFileSync(file, 'utf8'),
+      ts.ScriptTarget.Latest,
+      true,
+      ts.ScriptKind.TSX
+    );
+
+    const visibleLabels = new Map<string, string[]>();
+    const named: Array<{ ids: string[]; arias: string[]; line: number }> = [];
+
+    const visit = (node: ts.Node): void => {
+      if (ts.isJsxElement(node) && node.openingElement.tagName.getText() === 'label') {
+        if (!isScreenReaderOnly(node.openingElement)) {
+          for (const id of literalsOf(attribute(node.openingElement, 'htmlFor'))) {
+            const texts = visibleText(node);
+            if (texts.length) visibleLabels.set(id, texts);
+          }
+        }
+      }
+      if (ts.isJsxSelfClosingElement(node) || ts.isJsxOpeningElement(node)) {
+        const ids = literalsOf(attribute(node, 'id'));
+        const arias = literalsOf(attribute(node, 'aria-label'));
+        if (ids.length && arias.length) {
+          named.push({ ids, arias, line: source.getLineAndCharacterOfPosition(node.getStart()).line + 1 });
+        }
+      }
+      ts.forEachChild(node, visit);
+    };
+    visit(source);
+
+    for (const control of named) {
+      for (const id of control.ids) {
+        const visible = visibleLabels.get(id);
+        if (!visible) continue; // aria-label with no visible label is legitimate
+        for (const aria of control.arias) {
+          if (visible.some((v) => aria.toLowerCase().includes(v.toLowerCase()))) continue;
+          violations.push({
+            file: path.relative(SRC, file),
+            line: control.line,
+            id,
+            visible: visible.join(' | '),
+            aria
+          });
+        }
+      }
+    }
+  }
+
+  return violations;
+}
+
+describe('WCAG 2.5.3 Label in Name', () => {
+  it('never lets an aria-label hide the visible label it replaces', () => {
+    const violations = scan().map(
+      (v) => `${v.file}:${v.line} #${v.id} — visible "${v.visible}" is not contained in aria-label "${v.aria}"`
+    );
+    expect(violations).toEqual([]);
+  });
+
+  it('actually inspects the component tree', () => {
+    // Guards the guard: a broken walker would report zero violations forever.
+    expect(componentFiles(SRC).length).toBeGreaterThan(100);
+  });
+});


### PR DESCRIPTION
Follow-up to #191. Swept **every** component for WCAG 2.5.3 Label in Name.

### Outcome: the three failures fixed in #191 were the only real ones

| | count |
| --- | --- |
| Controls with both a visible `<label htmlFor>` and an `aria-label` | 17 |
| Genuine violations remaining | **0** |
| Conforming but redundant | 14 |

Four selects in `Transactions.tsx` (`type-filter`, `account-filter`, `per-page-desktop`, `per-page-mobile`) look like violations and are **not**: their labels are `sr-only`, so there is no visible text for a speech-input user to say, and 2.5.3 does not apply. The check skips `sr-only` labels for that reason.

### Why a test rather than a one-off audit

The bug in #191 was **drift**. `Card Number — last 4 digits only` was announced as `Last four digits of the card number` — each reasonable on its own, with nothing tying them together. A per-component test cannot catch that class, because the next one appears in a component nobody thought to check. This walks the whole tree and fails with file, line, and both names.

### Parsed, not regex-matched

An arrow function in a JSX attribute (`onChange={(e) => ...}`) contains `>`, which truncates any regex tag matcher mid-attributes. **My first version of this scan reported a clean sweep while missing every control whose `onChange` used an arrow — including the two that prompted the work.** It now uses the TypeScript compiler. A second assertion guards the walker itself, since a broken one would report zero violations forever.

### Deliberately not done

Removing the 14 redundant-but-conforming `aria-label`s. Measured: ~58 references across 7 test files, for no conformance or user-visible gain. This guard addresses the actual failure mode — drift — at zero churn. Happy to do the cleanup separately if you want it.

### Verification

- `npm run lint` — silent
- `npm run typecheck:strict` — clean
- `npm run test:smoke` — 267 files, 4236 tests passed, 0 failed
- Guard verified load-bearing: reintroducing the #191 card-number `aria-label` fails it
- Runs in ~0.6s over 400 files

🤖 Generated with [Claude Code](https://claude.com/claude-code)