### PR TITLE
fix(cleanup): the five things that kept being someone else's job

### DIFF
--- a/src/components/BatchImportModal.tsx
+++ b/src/components/BatchImportModal.tsx
@@ -44,6 +44,12 @@ interface FileInfo {
   bankBalanceSet?: string;
   /** Set when that write failed — the transactions still landed. */
   bankBalanceWarning?: string;
+  /**
+   * Rows the file describes that the parser could not use. Nobody watches this
+   * screen while it runs, so an unreported one is a payment that vanishes
+   * between the bank's file and the register with nothing to explain it.
+   */
+  unreadableRows?: number;
 }
 
 export default function BatchImportModal({ isOpen, onClose }: BatchImportModalProps): React.JSX.Element {
@@ -185,6 +191,7 @@ export default function BatchImportModal({ isOpen, onClose }: BatchImportModalPr
       let accountMatched = '';
       let bankBalanceSet: string | undefined;
       let bankBalanceWarning: string | undefined;
+      let unreadableRows = 0;
 
       switch (fileInfo.type) {
         case 'csv': {
@@ -245,6 +252,7 @@ export default function BatchImportModal({ isOpen, onClose }: BatchImportModalPr
             imported++;
           }
           duplicates = result.duplicates;
+          unreadableRows = result.unreadableRows;
 
           const balanceOutcome = await applyStatementBankBalance(result, bankBalancesWrittenThisRun);
           bankBalanceSet = balanceOutcome.note;
@@ -278,7 +286,8 @@ export default function BatchImportModal({ isOpen, onClose }: BatchImportModalPr
           duplicates,
           accountMatched,
           bankBalanceSet,
-          bankBalanceWarning
+          bankBalanceWarning,
+          unreadableRows
         } : f
       ));
     } catch (error) {
@@ -506,6 +515,13 @@ export default function BatchImportModal({ isOpen, onClose }: BatchImportModalPr
                             {file.bankBalanceWarning && (
                               <span className="ml-2 text-yellow-600 dark:text-yellow-400">
                                 • {file.bankBalanceWarning}
+                              </span>
+                            )}
+                            {file.unreadableRows !== undefined && file.unreadableRows > 0 && (
+                              <span className="ml-2 text-yellow-600 dark:text-yellow-400">
+                                • {file.unreadableRows === 1
+                                  ? 'one row could not be read and is missing from the register'
+                                  : `${file.unreadableRows} rows could not be read and are missing from the register`}
                               </span>
                             )}
                           </p>

--- a/src/components/DuplicateSweepModal.test.tsx
+++ b/src/components/DuplicateSweepModal.test.tsx
@@ -4,7 +4,9 @@
  * What these pin is everything that makes a DELETE safe to hand to a user:
  * nothing is pre-selected, the consequence is on screen before the button
  * works, a row that is holding a transfer or a split together cannot be chosen
- * at all, and a refusal can be made to stick.
+ * at all, a refusal can be made to stick — and a pair the scan found only
+ * because the money and the day agree cannot reach the delete at all until the
+ * user has said, about that one pair, that they are the same payment.
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
@@ -60,6 +62,21 @@ const CATEGORIES: Category[] = [
 /** The commonest real case: a bank feed and an import of the same payment. */
 const FEED = txn({ id: 'feed', cleared: true });
 const IMPORTED = txn({ id: 'import', isImported: true });
+
+/**
+ * The pair the old scoring could never see: the user renamed the payee, so the
+ * two rows share not one word. Same account, same day, same money to the penny
+ * is all that is left of the evidence.
+ */
+const RENAMED = txn({ id: 'renamed', amount: -410, description: 'Nadia' });
+const AS_IMPORTED = txn({
+  id: 'as-imported',
+  amount: -410,
+  isImported: true,
+  description: 'Immediate Faster Payment (Online) to B EXAMPLE 07-FEB-2027',
+});
+
+const CONFIRMATION = 'I have read both rows and they are one payment recorded twice.';
 
 const renderModal = (): void => {
   render(<DuplicateSweepModal isOpen onClose={vi.fn()} />);
@@ -124,6 +141,201 @@ describe('DuplicateSweepModal — finding the same payment twice', () => {
 
     await waitFor(() => expect(deleteTransaction).toHaveBeenCalledTimes(1));
     expect(deleteTransaction).toHaveBeenCalledWith('import');
+  });
+});
+
+describe('DuplicateSweepModal — the pair whose payee was renamed', () => {
+  beforeEach(() => {
+    __setAppContextValue({ transactions: [RENAMED, AS_IMPORTED], categories: CATEGORIES });
+  });
+
+  it('lists it in its own section, and says what the evidence actually is', () => {
+    renderModal();
+
+    expect(screen.getByText('Same money, different wording — your call')).toBeInTheDocument();
+    // Not a percentage dressed up as certainty: the wording agreeing is the
+    // one thing this pair has NOT got, and the user is told so.
+    const row = screen.getByTitle('Look at both copies of this');
+    expect(within(row).getByText('Not one word in common')).toBeInTheDocument();
+    expect(within(row).getByText('£410.00')).toBeInTheDocument();
+  });
+
+  it('will not delete on a chosen copy alone — the pair has to be confirmed', () => {
+    renderModal();
+    openReview();
+
+    fireEvent.click(screen.getAllByRole('radio')[0]);
+
+    const deleteButton = screen.getByRole('button', { name: 'Delete the copy I chose' });
+    expect(deleteButton).toBeDisabled();
+    expect(screen.getByText(/Tick the box above to say these two really are one payment/))
+      .toBeInTheDocument();
+    // The consequence is not shown yet either: nothing is going to happen.
+    expect(screen.queryByText(/deleted for good/)).not.toBeInTheDocument();
+  });
+
+  it('enables the delete only once the user has said the two are one payment', () => {
+    renderModal();
+    openReview();
+
+    fireEvent.click(screen.getAllByRole('radio')[0]);
+    fireEvent.click(screen.getByLabelText(CONFIRMATION));
+
+    expect(screen.getByText(/deleted for good/)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Delete the copy I chose' })).toBeEnabled();
+  });
+
+  it('confirming without choosing a copy still deletes nothing', () => {
+    renderModal();
+    openReview();
+
+    fireEvent.click(screen.getByLabelText(CONFIRMATION));
+
+    expect(screen.getByRole('button', { name: 'Delete the copy I chose' })).toBeDisabled();
+    expect(screen.getByText(/Pick one and this will say exactly what deleting it does/))
+      .toBeInTheDocument();
+  });
+
+  it('deletes exactly the copy chosen, once both answers are in', async () => {
+    const deleteTransaction = vi.fn(async () => {});
+    __setAppContextValue({ deleteTransaction });
+    renderModal();
+    openReview();
+
+    // The imported copy goes and the renamed one — the row carrying the name
+    // its owner will recognise — stays. Which of the two the scan happened to
+    // call "first" is not the user's business.
+    const copies = screen.getByRole('group', { name: 'Choose the copy to delete' });
+    const importedCard = within(copies).getByText(AS_IMPORTED.description).closest('label');
+    if (!importedCard) throw new Error('the imported copy should be a choosable card');
+    fireEvent.click(within(importedCard).getByRole('radio'));
+    fireEvent.click(screen.getByLabelText(CONFIRMATION));
+    fireEvent.click(screen.getByRole('button', { name: 'Delete the copy I chose' }));
+
+    await waitFor(() => expect(deleteTransaction).toHaveBeenCalledTimes(1));
+    expect(deleteTransaction).toHaveBeenCalledWith('as-imported');
+  });
+
+  it('starts every pair unconfirmed — an answer about one pair is not an answer about the next', () => {
+    __setAppContextValue({
+      transactions: [
+        RENAMED,
+        AS_IMPORTED,
+        txn({ id: 'other-renamed', amount: -88.5, description: 'Gym' }),
+        txn({ id: 'other-imported', amount: -88.5, description: 'DD FITNESS GROUP 5521' }),
+      ],
+      categories: CATEGORIES,
+    });
+    renderModal();
+
+    expect(screen.getAllByTitle('Look at both copies of this')).toHaveLength(2);
+    fireEvent.click(screen.getAllByTitle('Look at both copies of this')[0]);
+    fireEvent.click(screen.getByLabelText(CONFIRMATION));
+    expect(screen.getByLabelText(CONFIRMATION)).toBeChecked();
+
+    // Leave that pair alone and open the next one.
+    fireEvent.click(screen.getByRole('button', { name: 'Not a duplicate — leave both' }));
+    fireEvent.click(screen.getByRole('button', { name: 'No — just this once' }));
+    fireEvent.click(screen.getByTitle('Look at both copies of this'));
+
+    expect(screen.getByLabelText(CONFIRMATION)).not.toBeChecked();
+    fireEvent.click(screen.getAllByRole('radio')[0]);
+    expect(screen.getByRole('button', { name: 'Delete the copy I chose' })).toBeDisabled();
+  });
+});
+
+describe('DuplicateSweepModal — the bar has not moved', () => {
+  it('a pair whose wording agrees deletes in exactly the steps it always did', async () => {
+    // THE SAFETY TEST. Widening what the scan can SEE must not widen what a
+    // user can destroy — and it must not put a new hoop in front of the pairs
+    // that were always safe either.
+    const deleteTransaction = vi.fn(async () => {});
+    __setAppContextValue({
+      transactions: [FEED, IMPORTED], categories: CATEGORIES, deleteTransaction,
+    });
+    renderModal();
+    openReview();
+
+    expect(screen.queryByLabelText(CONFIRMATION)).not.toBeInTheDocument();
+    fireEvent.click(screen.getAllByRole('radio')[0]);
+    fireEvent.click(screen.getByRole('button', { name: 'Delete the copy I chose' }));
+
+    await waitFor(() => expect(deleteTransaction).toHaveBeenCalledWith('feed'));
+  });
+
+  it('offers nothing that could delete a pair the user has not opened', () => {
+    // No select-all, no per-row tick, no "delete all duplicates". The only
+    // route to a delete is through one pair's review, and the wider tier adds
+    // a confirmation on top of that. A list-level control is how a widened
+    // scan would have turned into lost money.
+    __setAppContextValue({
+      transactions: [FEED, IMPORTED, RENAMED, AS_IMPORTED], categories: CATEGORIES,
+    });
+    renderModal();
+
+    expect(screen.getAllByTitle('Look at both copies of this')).toHaveLength(2);
+    expect(screen.queryAllByRole('checkbox')).toHaveLength(0);
+    expect(screen.queryAllByRole('radio')).toHaveLength(0);
+    for (const button of screen.getAllByRole('button')) {
+      expect(button.textContent ?? '').not.toMatch(/delete|remove|all/i);
+    }
+  });
+
+  it('will not delete a row the wider rule found once its copy is chosen and unconfirmed, however the button is pressed', async () => {
+    // The disabled attribute is a hint to a mouse. The handler asks the same
+    // gate again, so a click that reaches it anyway still does nothing.
+    const deleteTransaction = vi.fn(async () => {});
+    __setAppContextValue({
+      transactions: [RENAMED, AS_IMPORTED], categories: CATEGORIES, deleteTransaction,
+    });
+    renderModal();
+    openReview();
+    fireEvent.click(screen.getAllByRole('radio')[0]);
+
+    const deleteButton = screen.getByRole('button', { name: 'Delete the copy I chose' });
+    deleteButton.removeAttribute('disabled');
+    fireEvent.click(deleteButton);
+
+    await waitFor(() => expect(screen.getByText(/Tick the box above/)).toBeInTheDocument());
+    expect(deleteTransaction).not.toHaveBeenCalled();
+  });
+});
+
+describe('DuplicateSweepModal — every account in one sweep', () => {
+  it('sweeps accounts the user has not visited, and lets them take one at a time', () => {
+    __setAppContextValue({
+      transactions: [
+        FEED,
+        IMPORTED,
+        txn({ id: 'joint-a', accountId: 'acc-joint', amount: -410, description: 'Nadia' }),
+        txn({
+          id: 'joint-b',
+          accountId: 'acc-joint',
+          amount: -410,
+          description: 'Immediate Faster Payment (Online) to B EXAMPLE',
+        }),
+      ],
+      categories: CATEGORIES,
+    });
+    renderModal();
+
+    expect(screen.getAllByTitle('Look at both copies of this')).toHaveLength(2);
+    expect(screen.getByText('Current account')).toBeInTheDocument();
+    expect(screen.getByText('Joint account')).toBeInTheDocument();
+
+    fireEvent.change(screen.getByLabelText(/Account/), { target: { value: 'acc-joint' } });
+
+    const rows = screen.getAllByTitle('Look at both copies of this');
+    expect(rows).toHaveLength(1);
+    expect(within(rows[0]).getByText('Joint account')).toBeInTheDocument();
+  });
+
+  it('offers no account chooser when everything found is in one account', () => {
+    // Nothing to say, so nothing rendered.
+    __setAppContextValue({ transactions: [FEED, IMPORTED], categories: CATEGORIES });
+    renderModal();
+
+    expect(screen.queryByLabelText(/Account/)).not.toBeInTheDocument();
   });
 });
 

--- a/src/components/DuplicateSweepModal.tsx
+++ b/src/components/DuplicateSweepModal.tsx
@@ -6,7 +6,9 @@ import { useCurrencyDecimal } from '../hooks/useCurrencyDecimal';
 import { useAccountNames } from '../hooks/useAccountNames';
 import {
   deleteBlockOf,
+  deleteRefusalFor,
   findDuplicateCandidates,
+  needsConfirmation,
   type DeleteBlock,
   type DuplicateCandidate,
 } from '../utils/duplicateSweep';
@@ -29,6 +31,15 @@ import type { SuggestionDismissal, Transaction } from '../types';
  * user has to say which of the two copies goes. The scan cannot know which one
  * is the real one — one may be reconciled, categorised or carry a note the
  * other does not — so it never guesses.
+ *
+ * The scan finds in two tiers (see utils/duplicateSweep), and this screen keeps
+ * them apart on purpose. Pairs whose WORDING agrees as well as their money are
+ * near-certain. Pairs found only because the money and the day agree are
+ * evidence: a renamed payee looks exactly like that, and so do two separate
+ * payments of the same size. Those carry an extra confirmation that the user
+ * has to give pair by pair — and the button is gated by
+ * `deleteRefusalFor`, not by this component's opinion, so the rule holds
+ * wherever it is asked from.
  *
  * Three shapes of row are refused outright, with the reason said out loud
  * rather than the row being quietly hidden (see utils/duplicateSweep):
@@ -83,6 +94,11 @@ const shortDate = (date: Date | string): string =>
 const longDate = (date: Date | string): string =>
   new Date(date).toLocaleDateString('en-GB', { day: '2-digit', month: 'long', year: 'numeric' });
 
+const gapPhrase = (daysApart: number): string => {
+  const days = Math.round(daysApart);
+  return days === 0 ? 'on the same day' : `${days} day${days === 1 ? '' : 's'} apart`;
+};
+
 export default function DuplicateSweepModal({ isOpen, onClose }: Props): React.JSX.Element {
   const {
     transactions, categories, deleteTransaction,
@@ -94,9 +110,12 @@ export default function DuplicateSweepModal({ isOpen, onClose }: Props): React.J
   const accountName = useAccountNames();
 
   const [windowDays, setWindowDays] = useState<WindowDays>(3);
+  const [accountFilter, setAccountFilter] = useState('');
   const [reviewing, setReviewing] = useState<DuplicateCandidate | null>(null);
   /** Which copy the user has chosen to delete, inside the review. */
   const [chosenId, setChosenId] = useState<string | null>(null);
+  /** The answer to "these two are one payment" — for the weaker tier only. */
+  const [confirmedSame, setConfirmedSame] = useState(false);
   const [deleting, setDeleting] = useState(false);
   // A refusal that has not yet been answered "and never again?".
   const [dismissPrompt, setDismissPrompt] = useState<DuplicateCandidate | null>(null);
@@ -142,9 +161,33 @@ export default function DuplicateSweepModal({ isOpen, onClose }: Props): React.J
     const key = duplicateDismissalKey(candidate.a, candidate.b);
     return !dismissed.has(key) && !dismissedDuplicateKeys.has(key);
   });
-  const visible = live
-    .slice(0, CAP)
-    .sort((a, b) => sortDir * compareCandidates(a, b, sortKey, accountName));
+
+  /**
+   * Every account the sweep found something in. The scan already covers the
+   * whole history in one run; this is so a user who has cleaned one account can
+   * see at a glance which of the others still have work in them, and take one
+   * at a time without leaving the screen.
+   */
+  const accountsWithWork = (() => {
+    const counts = new Map<string, number>();
+    for (const candidate of live) {
+      counts.set(candidate.a.accountId, (counts.get(candidate.a.accountId) ?? 0) + 1);
+    }
+    return [...counts.entries()]
+      .map(([id, count]) => ({ id, name: accountName(id), count }))
+      .sort((a, b) => compareText(a.name, b.name));
+  })();
+  // A filter whose account has since been emptied would hide everything with no
+  // way back, so a stale choice falls back to showing all of them.
+  const scopedAccount = accountsWithWork.some(a => a.id === accountFilter) ? accountFilter : '';
+  const inScope = scopedAccount ? live.filter(c => c.a.accountId === scopedAccount) : live;
+
+  // Sort BEFORE the cap: sorting the first 300 of an arbitrary order just
+  // reshuffles the same 300, which is no use to someone working through a long
+  // list looking for the oldest or the largest.
+  const sorted = [...inScope].sort((a, b) => sortDir * compareCandidates(a, b, sortKey, accountName));
+  const wordingAgrees = sorted.filter(c => !needsConfirmation(c));
+  const needsYourEye = sorted.filter(c => needsConfirmation(c));
 
   const sortBy = (key: SortKey): void => {
     if (sortKey === key) {
@@ -161,11 +204,20 @@ export default function DuplicateSweepModal({ isOpen, onClose }: Props): React.J
     // Nothing is pre-selected, deliberately: the scan cannot tell which copy is
     // the real one, and a pre-ticked delete is how the wrong row goes.
     setChosenId(null);
+    setConfirmedSame(false);
   };
 
   /** The row the user has picked, when it is genuinely deletable. */
   const chosen = reviewing && chosenId
     ? [reviewing.a, reviewing.b].find(t => t.id === chosenId) ?? null
+    : null;
+
+  /**
+   * The single source of truth for whether this delete may happen. Asked here
+   * to draw the button, and asked again before the delete actually runs.
+   */
+  const refusal = reviewing && chosen
+    ? deleteRefusalFor(reviewing, chosen, confirmedSame)
     : null;
 
   /**
@@ -192,7 +244,10 @@ export default function DuplicateSweepModal({ isOpen, onClose }: Props): React.J
   };
 
   const handleDelete = async (): Promise<void> => {
-    if (!chosen) return;
+    if (!reviewing || !chosen) return;
+    // Asked again, not inherited from the disabled button: a disabled attribute
+    // is a hint to a mouse, and this is the last point before a row is gone.
+    if (deleteRefusalFor(reviewing, chosen, confirmedSame) !== null) return;
     setDeleting(true);
     try {
       const money = formatCurrency(Math.abs(chosen.amount));
@@ -204,6 +259,7 @@ export default function DuplicateSweepModal({ isOpen, onClose }: Props): React.J
       );
       setReviewing(null);
       setChosenId(null);
+      setConfirmedSame(false);
     } catch (error) {
       // Verbatim: the database's own refusal names the precondition that
       // failed, and a silent failure on a delete is the worst outcome here.
@@ -313,6 +369,102 @@ export default function DuplicateSweepModal({ isOpen, onClose }: Props): React.J
     );
   };
 
+  /** The likeness evidence, said in the terms of the tier the pair is in. */
+  const likeness = (candidate: DuplicateCandidate): string => {
+    if (!needsConfirmation(candidate)) return `${Math.round(candidate.score)}% alike`;
+    return candidate.descriptionOverlap === 0
+      ? 'Not one word in common'
+      : `${Math.round(candidate.descriptionOverlap * 100)}% of the words in common`;
+  };
+
+  const renderTable = (rows: DuplicateCandidate[], total: number): React.JSX.Element => (
+    <div className="overflow-x-auto">
+      <table className="w-full">
+        <thead>
+          <tr className="text-xs text-gray-500 dark:text-gray-400 border-b border-gray-100 dark:border-gray-700">
+            {([
+              ['date', 'Date', 'Sort by date'],
+              ['account', 'Account', 'Sort by account name'],
+              ['description', 'Description', 'Sort by description'],
+              ['amount', 'Amount', 'Sort by amount size'],
+            ] as const).map(([key, label, hint]) => (
+              <th key={key} className="text-center pb-2 font-medium">
+                <button
+                  type="button"
+                  onClick={() => sortBy(key)}
+                  className="hover:text-gray-800 dark:hover:text-gray-200 transition-colors"
+                  title={hint}
+                >
+                  {label}{arrow(key)}
+                </button>
+              </th>
+            ))}
+            <th className="pb-2 w-24"></th>
+          </tr>
+        </thead>
+        <tbody>
+          {rows.map(candidate => {
+            const first = earlier(candidate);
+            const sameWording = candidate.a.description === candidate.b.description;
+            return (
+              <tr
+                key={duplicateDismissalKey(candidate.a, candidate.b)}
+                onClick={() => review(candidate)}
+                className="border-b border-gray-50 dark:border-gray-700/50 cursor-pointer hover:bg-gray-50 dark:hover:bg-gray-700/40 transition-colors align-top"
+                title="Look at both copies of this"
+              >
+                <td className="py-2 text-sm text-gray-500 dark:text-gray-400 whitespace-nowrap">
+                  {shortDate(first.date)}
+                  {candidate.daysApart > 0 && (
+                    <span className="ml-1 text-xs text-gray-400">
+                      +{Math.round(candidate.daysApart)}d
+                    </span>
+                  )}
+                </td>
+                <td className="py-2 text-sm text-gray-700 dark:text-gray-300">
+                  <span className="block truncate max-w-[140px]">
+                    {accountName(candidate.a.accountId)}
+                  </span>
+                </td>
+                <td className="py-2 text-sm text-gray-600 dark:text-gray-400">
+                  <span className="block truncate max-w-[260px] text-gray-900 dark:text-white">
+                    {candidate.a.description}
+                  </span>
+                  {!sameWording && (
+                    <span className="block truncate max-w-[260px] text-xs">
+                      and “{candidate.b.description}”
+                    </span>
+                  )}
+                  <span className="block text-xs mt-0.5">{likeness(candidate)}</span>
+                </td>
+                <td className="py-2 text-sm font-medium text-right tabular-nums text-gray-900 dark:text-white whitespace-nowrap">
+                  {formatCurrency(Math.abs(candidate.a.amount))}
+                </td>
+                <td className="py-2 text-right" onClick={e => e.stopPropagation()}>
+                  <button
+                    type="button"
+                    onClick={() => review(candidate)}
+                    className="px-3 py-1.5 text-xs font-medium rounded-lg border border-gray-300 dark:border-gray-600 text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors"
+                  >
+                    Review
+                  </button>
+                </td>
+              </tr>
+            );
+          })}
+          {total > CAP && (
+            <tr>
+              <td colSpan={5} className="py-3 text-center text-xs text-gray-400 dark:text-gray-500">
+                Showing the first {CAP.toLocaleString()} of {total.toLocaleString()} —
+                settle these, then run this again for the rest.
+              </td>
+            </tr>
+          )}
+        </tbody>
+      </table>
+    </div>
+  );
+
   const bothBlocked = reviewing !== null
     && deleteBlockOf(reviewing.a) !== null
     && deleteBlockOf(reviewing.b) !== null;
@@ -329,10 +481,10 @@ export default function DuplicateSweepModal({ isOpen, onClose }: Props): React.J
 
         <div className="flex flex-wrap items-center gap-3 mb-3">
           <p className="text-sm text-gray-600 dark:text-gray-400 flex-1 min-w-[16rem]">
-            Rows in the <strong>same account</strong> for the same amount, to the penny, with the
-            same or nearly the same description, a few days apart — what a bank feed and an import
-            of the same payment look like. Two matching rows in <em>different</em> accounts are not
-            here: that is a transfer, and “Match transfers” is where it belongs.
+            Every account is swept at once. Rows in the <strong>same account</strong> for the same
+            amount, to the penny, a few days apart — what a bank feed and an import of the same
+            payment look like. Two matching rows in <em>different</em> accounts are not here: that
+            is a transfer, and “Match transfers” is where it belongs.
           </p>
           <label className="text-sm text-gray-600 dark:text-gray-400">
             Within{' '}
@@ -348,6 +500,26 @@ export default function DuplicateSweepModal({ isOpen, onClose }: Props): React.J
           </label>
         </div>
 
+        {/* Only worth a control when there is more than one account to choose
+            between — otherwise it is a menu with one thing on it. */}
+        {accountsWithWork.length > 1 && (
+          <label className="block mb-3 text-sm text-gray-600 dark:text-gray-400">
+            Account{' '}
+            <select
+              value={scopedAccount}
+              onChange={e => setAccountFilter(e.target.value)}
+              className="ml-1 px-2 py-1 rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 text-gray-900 dark:text-white max-w-full"
+            >
+              <option value="">All accounts</option>
+              {accountsWithWork.map(account => (
+                <option key={account.id} value={account.id}>
+                  {account.name} ({account.count.toLocaleString()})
+                </option>
+              ))}
+            </select>
+          </label>
+        )}
+
         {!dismissalsChecked ? (
           <p className="text-center py-10 text-gray-500 dark:text-gray-400">
             Checking which of these you have already dealt with…
@@ -359,93 +531,45 @@ export default function DuplicateSweepModal({ isOpen, onClose }: Props): React.J
             {duplicateDismissals.length > 0 ? ', or left out at your request below' : ''}.
           </p>
         ) : (
-          <div className="overflow-x-auto">
-            <table className="w-full">
-              <thead>
-                <tr className="text-xs text-gray-500 dark:text-gray-400 border-b border-gray-100 dark:border-gray-700">
-                  {([
-                    ['date', 'Date', 'Sort by date'],
-                    ['account', 'Account', 'Sort by account name'],
-                    ['description', 'Description', 'Sort by description'],
-                    ['amount', 'Amount', 'Sort by amount size'],
-                  ] as const).map(([key, label, hint]) => (
-                    <th key={key} className="text-center pb-2 font-medium">
-                      <button
-                        type="button"
-                        onClick={() => sortBy(key)}
-                        className="hover:text-gray-800 dark:hover:text-gray-200 transition-colors"
-                        title={hint}
-                      >
-                        {label}{arrow(key)}
-                      </button>
-                    </th>
-                  ))}
-                  <th className="pb-2 w-24"></th>
-                </tr>
-              </thead>
-              <tbody>
-                {visible.map(candidate => {
-                  const first = earlier(candidate);
-                  const sameWording = candidate.a.description === candidate.b.description;
-                  return (
-                    <tr
-                      key={duplicateDismissalKey(candidate.a, candidate.b)}
-                      onClick={() => review(candidate)}
-                      className="border-b border-gray-50 dark:border-gray-700/50 cursor-pointer hover:bg-gray-50 dark:hover:bg-gray-700/40 transition-colors align-top"
-                      title="Look at both copies of this"
-                    >
-                      <td className="py-2 text-sm text-gray-500 dark:text-gray-400 whitespace-nowrap">
-                        {shortDate(first.date)}
-                        {candidate.daysApart > 0 && (
-                          <span className="ml-1 text-xs text-gray-400">
-                            +{Math.round(candidate.daysApart)}d
-                          </span>
-                        )}
-                      </td>
-                      <td className="py-2 text-sm text-gray-700 dark:text-gray-300">
-                        <span className="block truncate max-w-[140px]">
-                          {accountName(candidate.a.accountId)}
-                        </span>
-                      </td>
-                      <td className="py-2 text-sm text-gray-600 dark:text-gray-400">
-                        <span className="block truncate max-w-[260px] text-gray-900 dark:text-white">
-                          {candidate.a.description}
-                        </span>
-                        {!sameWording && (
-                          <span className="block truncate max-w-[260px] text-xs">
-                            and “{candidate.b.description}”
-                          </span>
-                        )}
-                        <span className="block text-xs mt-0.5">
-                          {Math.round(candidate.score)}% alike
-                        </span>
-                      </td>
-                      <td className="py-2 text-sm font-medium text-right tabular-nums text-gray-900 dark:text-white whitespace-nowrap">
-                        {formatCurrency(Math.abs(candidate.a.amount))}
-                      </td>
-                      <td className="py-2 text-right" onClick={e => e.stopPropagation()}>
-                        <button
-                          type="button"
-                          onClick={() => review(candidate)}
-                          className="px-3 py-1.5 text-xs font-medium rounded-lg border border-gray-300 dark:border-gray-600 text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors"
-                        >
-                          Review
-                        </button>
-                      </td>
-                    </tr>
-                  );
-                })}
-                {live.length > CAP && (
-                  <tr>
-                    <td colSpan={5} className="py-3 text-center text-xs text-gray-400 dark:text-gray-500">
-                      Showing the first {CAP.toLocaleString()} of {live.length.toLocaleString()} —
-                      settle these, then run this again for the rest.
-                    </td>
-                  </tr>
-                )}
-              </tbody>
-            </table>
-          </div>
+          <>
+            {wordingAgrees.length > 0 && (
+              // Named regions, because the two tables carry the same column
+              // headings: without this a screen reader meets "Sort by date"
+              // twice with nothing to say which list it sorts.
+              <section className="mb-6" aria-labelledby="duplicates-wording-agrees">
+                <h3
+                  id="duplicates-wording-agrees"
+                  className="text-sm font-semibold text-gray-900 dark:text-white"
+                >
+                  Same money, same wording
+                </h3>
+                <p className="mb-2 text-xs text-gray-500 dark:text-gray-400">
+                  Same account, the same amount to the penny, and the two rows read as the same
+                  payee. Until one copy goes, that payment is counted twice in the balance.
+                </p>
+                {renderTable(wordingAgrees.slice(0, CAP), wordingAgrees.length)}
+              </section>
+            )}
+
+            {needsYourEye.length > 0 && (
+              <section aria-labelledby="duplicates-needs-your-eye">
+                <h3
+                  id="duplicates-needs-your-eye"
+                  className="text-sm font-semibold text-gray-900 dark:text-white"
+                >
+                  Same money, different wording — your call
+                </h3>
+                <p className="mb-2 text-xs text-gray-500 dark:text-gray-400">
+                  Same account and the same amount to the penny, but the two rows are worded
+                  differently. That is what a payee you renamed looks like — and it is also what
+                  two separate payments of the same size look like. Nothing here can tell them
+                  apart, so each pair has to be confirmed by you before either copy can be
+                  deleted.
+                </p>
+                {renderTable(needsYourEye.slice(0, CAP), needsYourEye.length)}
+              </section>
+            )}
+          </>
         )}
 
         <DismissedSuggestionsSection
@@ -465,7 +589,7 @@ export default function DuplicateSweepModal({ isOpen, onClose }: Props): React.J
               ? 'Checking…'
               : live.length === 0
                 ? 'Nothing to sort out here.'
-                : `${live.length.toLocaleString()} to look at — each one is decided on its own.`}
+                : 'Each one is decided on its own — nothing is deleted until you choose a copy.'}
           </p>
           <button
             type="button"
@@ -490,14 +614,22 @@ export default function DuplicateSweepModal({ isOpen, onClose }: Props): React.J
           <ModalBody>
             <p className="text-sm text-gray-600 dark:text-gray-400 mb-4">
               These two rows are in <strong>{accountName(reviewing.a.accountId)}</strong> for the
-              same amount,{' '}
-              {reviewing.daysApart === 0
-                ? 'on the same day'
-                : `${Math.round(reviewing.daysApart)} day${Math.round(reviewing.daysApart) === 1 ? '' : 's'} apart`}
-              , and read as the same payee. That is what an import landing on top of a bank feed
-              looks like — but it is also what a genuine repeat payment looks like, so{' '}
-              <strong>nothing here can tell which</strong>. Choose the copy to delete, or leave
-              them both alone.
+              same amount, {gapPhrase(reviewing.daysApart)}
+              {needsConfirmation(reviewing) ? (
+                <>
+                  , but they are worded differently. That is what a payee you renamed looks like —
+                  and also what two separate payments of the same size look like.{' '}
+                  <strong>Nothing here can tell which</strong>, so say so yourself before choosing
+                  a copy to delete.
+                </>
+              ) : (
+                <>
+                  , and read as the same payee. That is what an import landing on top of a bank
+                  feed looks like — but it is also what a genuine repeat payment looks like, so{' '}
+                  <strong>nothing here can tell which</strong>. Choose the copy to delete, or leave
+                  them both alone.
+                </>
+              )}
             </p>
 
             <fieldset>
@@ -508,6 +640,22 @@ export default function DuplicateSweepModal({ isOpen, onClose }: Props): React.J
               </div>
             </fieldset>
 
+            {/* The extra step the weaker tier costs. It is the user's own
+                statement about this one pair, which is exactly what no bulk
+                action could ever provide on their behalf. */}
+            {needsConfirmation(reviewing) && !bothBlocked && (
+              <label className="mt-4 flex items-start gap-2 text-sm text-gray-700 dark:text-gray-300 cursor-pointer">
+                <input
+                  type="checkbox"
+                  checked={confirmedSame}
+                  disabled={deleting}
+                  onChange={e => setConfirmedSame(e.target.checked)}
+                  className="mt-0.5 rounded border-gray-300"
+                />
+                <span>I have read both rows and they are one payment recorded twice.</span>
+              </label>
+            )}
+
             {bothBlocked ? (
               <div className="mt-4 flex items-start gap-2 rounded-lg px-3 py-2 bg-amber-50 dark:bg-amber-900/20 text-amber-800 dark:text-amber-300">
                 <AlertTriangleIcon size={16} className="mt-0.5 flex-shrink-0" />
@@ -516,6 +664,11 @@ export default function DuplicateSweepModal({ isOpen, onClose }: Props): React.J
                   together, as explained above. Unpick that first, then run this again.
                 </p>
               </div>
+            ) : refusal === 'not-confirmed' ? (
+              <p className="mt-4 text-sm text-gray-500 dark:text-gray-400">
+                Tick the box above to say these two really are one payment. Nothing is deleted
+                until you do.
+              </p>
             ) : chosen ? (
               <div className="mt-4 flex items-start gap-2 rounded-lg px-3 py-2 bg-red-50 dark:bg-red-900/20 text-red-800 dark:text-red-300">
                 <AlertTriangleIcon size={16} className="mt-0.5 flex-shrink-0" />
@@ -538,6 +691,7 @@ export default function DuplicateSweepModal({ isOpen, onClose }: Props): React.J
                   setDismissPrompt(reviewing);
                   setReviewing(null);
                   setChosenId(null);
+                  setConfirmedSame(false);
                 }}
                 className="px-4 py-2 text-sm font-medium rounded-lg border border-gray-300 dark:border-gray-600 text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors disabled:opacity-50"
               >
@@ -545,7 +699,7 @@ export default function DuplicateSweepModal({ isOpen, onClose }: Props): React.J
               </button>
               <button
                 type="button"
-                disabled={deleting || chosen === null}
+                disabled={deleting || chosen === null || refusal !== null}
                 onClick={() => void handleDelete()}
                 className="justify-center px-4 py-2 text-sm font-medium rounded-lg bg-red-700 text-white hover:bg-red-800 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
               >

--- a/src/components/EnhancedImportWizard.tsx
+++ b/src/components/EnhancedImportWizard.tsx
@@ -50,6 +50,12 @@ interface FileInfo {
   bankBalanceSet?: string;
   /** Set when that write failed — the transactions still landed. */
   bankBalanceWarning?: string;
+  /**
+   * Rows the file describes that the parser could not use. Reported because a
+   * payment that goes missing between the bank's file and the register, with
+   * nothing said about it, is a register that cannot be reconciled.
+   */
+  unreadableRows?: number;
 }
 
 interface ImportSummary {
@@ -217,6 +223,7 @@ export default function EnhancedImportWizard({ isOpen, onClose }: EnhancedImport
           let duplicates = 0;
           let bankBalanceSet: string | undefined;
           let bankBalanceWarning: string | undefined;
+          let unreadableRows = 0;
 
           switch (fileInfo.type) {
             case 'csv': {
@@ -277,6 +284,7 @@ export default function EnhancedImportWizard({ isOpen, onClose }: EnhancedImport
                 imported++;
               }
               duplicates = result.duplicates;
+              unreadableRows = result.unreadableRows;
 
               const balanceOutcome = await applyStatementBankBalance(result, bankBalancesWrittenThisRun);
               bankBalanceSet = balanceOutcome.note;
@@ -311,7 +319,8 @@ export default function EnhancedImportWizard({ isOpen, onClose }: EnhancedImport
               imported,
               duplicates,
               bankBalanceSet,
-              bankBalanceWarning
+              bankBalanceWarning,
+              unreadableRows
             } : f
           ));
           
@@ -587,6 +596,13 @@ export default function EnhancedImportWizard({ isOpen, onClose }: EnhancedImport
                           {file.bankBalanceWarning && (
                             <p className="text-xs text-yellow-600 dark:text-yellow-400">
                               {file.bankBalanceWarning}
+                            </p>
+                          )}
+                          {file.unreadableRows !== undefined && file.unreadableRows > 0 && (
+                            <p className="text-xs text-yellow-600 dark:text-yellow-400">
+                              {file.unreadableRows === 1
+                                ? 'one row could not be read and is missing from the register'
+                                : `${file.unreadableRows} rows could not be read and are missing from the register`}
                             </p>
                           )}
                         </div>

--- a/src/components/ImportDataModal.test.tsx
+++ b/src/components/ImportDataModal.test.tsx
@@ -11,6 +11,7 @@ import ImportDataModal from './ImportDataModal';
 import { useApp } from '../contexts/AppContextSupabase';
 import { parseMNY, parseMBF, applyMappingToData } from '../utils/mnyParser';
 import { parseQIF } from '../utils/qifParser';
+import type { Account, Transaction } from '../types';
 
 // Mock all icon components
 vi.mock('./icons/UploadIcon', () => ({
@@ -106,9 +107,30 @@ vi.mock('../utils/qifParser', () => ({
 // Mock AppContext
 const mockAddAccount = vi.fn();
 const mockAddTransaction = vi.fn();
-const mockAccounts = [
-  { id: '1', name: 'Checking', type: 'current', balance: 1000, currency: 'GBP', isActive: true }
+const mockAccounts: Account[] = [
+  {
+    id: '1',
+    name: 'Checking',
+    type: 'current',
+    balance: 1000,
+    currency: 'GBP',
+    isActive: true,
+    lastUpdated: new Date('2024-01-01')
+  }
 ];
+/** The register the importer checks incoming rows against. */
+let mockTransactions: Transaction[] = [];
+
+type AppContextValue = ReturnType<typeof useApp>;
+
+/**
+ * A stand-in for the app context that implements only the slice this modal
+ * touches. Asserted to the full type once, here, rather than at every call
+ * site — the modal reads five of its sixty-odd members and supplying the rest
+ * would say nothing about the import.
+ */
+const appContextDouble = (slice: Partial<AppContextValue>): AppContextValue =>
+  ({ ...slice }) as AppContextValue;
 
 vi.mock('../contexts/AppContextSupabase', () => ({
   useApp: vi.fn()
@@ -135,6 +157,7 @@ describe('ImportDataModal', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    mockTransactions = [];
     // addAccount's real contract is Promise<Account>: the modal awaits the
     // created account and uses its id to route imported transactions.
     mockAddAccount.mockImplementation(async (account: { name: string }) => ({
@@ -154,12 +177,17 @@ describe('ImportDataModal', () => {
       accounts: [],
       transactions: []
     });
-    // Set default mock for useApp
-    vi.mocked(useApp).mockReturnValue({
+    // Set default mock for useApp. The OFX path reads the register and the
+    // category tree too — it is the shared importer, which recognises rows the
+    // user already holds and files what it can. Read at CALL time, so a test
+    // can seed the register before rendering.
+    vi.mocked(useApp).mockImplementation(() => appContextDouble({
       addAccount: mockAddAccount,
       addTransaction: mockAddTransaction,
-      accounts: mockAccounts
-    } as any);
+      accounts: mockAccounts,
+      transactions: mockTransactions,
+      categories: []
+    }));
   });
 
   afterEach(() => {
@@ -294,32 +322,46 @@ describe('ImportDataModal', () => {
       });
     });
 
+    /**
+     * OFX now goes through ofxImportService — the one OFX reader the app has —
+     * rather than a second parser that lived in this component and had drifted
+     * away from it. These cover what routing it back through the service
+     * bought, and what it must not have cost.
+     */
+    const ofxStatement = (rows: string, ledger = '1000.00') => `
+      OFXHEADER:100
+      <OFX>
+        <BANKMSGSRSV1><STMTTRNRS><STMTRS>
+          <BANKACCTFROM>
+            <BANKID>112233</BANKID>
+            <ACCTID>99887766</ACCTID>
+            <ACCTTYPE>CHECKING</ACCTTYPE>
+          </BANKACCTFROM>
+          <BANKTRANLIST>${rows}</BANKTRANLIST>
+          <LEDGERBAL><BALAMT>${ledger}</BALAMT><DTASOF>20240131</DTASOF></LEDGERBAL>
+        </STMTRS></STMTTRNRS></BANKMSGSRSV1>
+      </OFX>
+    `;
+
+    const uploadOfx = async (content: string) => {
+      const file = createFile(content, 'statement.ofx');
+      const input = screen.getByText('Choose File').parentElement?.querySelector('input[type="file"]') as HTMLInputElement;
+      Object.defineProperty(input, 'files', { value: [file], writable: false });
+      fireEvent.change(input);
+    };
+
     it('parses OFX files', async () => {
       render(<ImportDataModal isOpen={true} onClose={mockOnClose} />);
-      
-      const ofxContent = `
-        <OFX>
-          <ACCTID>12345</ACCTID>
-          <ACCTTYPE>CHECKING</ACCTTYPE>
-          <BALAMT>1000.00</BALAMT>
-          <STMTTRN>
-            <TRNTYPE>DEBIT</TRNTYPE>
-            <DTPOSTED>20240115</DTPOSTED>
-            <TRNAMT>-50.00</TRNAMT>
-            <NAME>Store Purchase</NAME>
-          </STMTTRN>
-        </OFX>
-      `;
-      
-      const file = createFile(ofxContent, 'test.ofx');
-      const input = screen.getByText('Choose File').parentElement?.querySelector('input[type="file"]') as HTMLInputElement;
-      
-      Object.defineProperty(input, 'files', {
-        value: [file],
-        writable: false,
-      });
-      
-      fireEvent.change(input);
+
+      await uploadOfx(ofxStatement(`
+        <STMTTRN>
+          <TRNTYPE>DEBIT</TRNTYPE>
+          <DTPOSTED>20240115</DTPOSTED>
+          <TRNAMT>-50.00</TRNAMT>
+          <FITID>SEQ-0001</FITID>
+          <NAME>Store Purchase</NAME>
+        </STMTTRN>
+      `));
 
       await waitFor(() => {
         expect(screen.getByText('Found 1 accounts and 1 transactions')).toBeInTheDocument();
@@ -337,44 +379,218 @@ describe('ImportDataModal', () => {
       });
     });
 
-    it('skips OFX transactions with unparseable amounts instead of importing NaN', async () => {
+    it('describes a row the way the shared OFX reader does', async () => {
+      // Two things the in-file parser got wrong. It preferred <NAME>, so a row
+      // whose memo says what the payment WAS came in as the bank's generic
+      // channel label ("CARD PAYMENT"). And on an empty <MEMO></MEMO> the
+      // shared reader must return '' rather than falling through to a
+      // line-terminated read that captures the literal text "</MEMO>".
       render(<ImportDataModal isOpen={true} onClose={mockOnClose} />);
 
-      // One good row and one row whose TRNAMT cannot be parsed. Importing the
-      // bad row as NaN would poison every raw-sum balance downstream.
-      const ofxContent = `
-        <OFX>
-          <ACCTID>12345</ACCTID>
-          <ACCTTYPE>CHECKING</ACCTTYPE>
-          <BALAMT>1000.00</BALAMT>
-          <STMTTRN>
-            <TRNTYPE>DEBIT</TRNTYPE>
-            <DTPOSTED>20240115</DTPOSTED>
-            <TRNAMT>-50.00</TRNAMT>
-            <NAME>Store Purchase</NAME>
-          </STMTTRN>
-          <STMTTRN>
-            <TRNTYPE>DEBIT</TRNTYPE>
-            <DTPOSTED>20240116</DTPOSTED>
-            <TRNAMT>N/A</TRNAMT>
-            <NAME>Corrupt Row</NAME>
-          </STMTTRN>
-        </OFX>
-      `;
+      await uploadOfx(ofxStatement(`
+        <STMTTRN>
+          <TRNTYPE>DEBIT</TRNTYPE>
+          <DTPOSTED>20240115</DTPOSTED>
+          <TRNAMT>-12.00</TRNAMT>
+          <FITID>SEQ-0002</FITID>
+          <NAME>CARD PAYMENT</NAME>
+          <MEMO>Corner Shop</MEMO>
+        </STMTTRN>
+        <STMTTRN>
+          <TRNTYPE>DEBIT</TRNTYPE>
+          <DTPOSTED>20240116</DTPOSTED>
+          <TRNAMT>-3.20</TRNAMT>
+          <FITID>SEQ-0009</FITID>
+          <NAME>Newsagent</NAME>
+          <MEMO></MEMO>
+        </STMTTRN>
+      `));
 
-      const file = createFile(ofxContent, 'test.ofx');
-      const input = screen.getByText('Choose File').parentElement?.querySelector('input[type="file"]') as HTMLInputElement;
-
-      Object.defineProperty(input, 'files', {
-        value: [file],
-        writable: false,
-      });
-
-      fireEvent.change(input);
-
-      // The skipped row is surfaced as an import notice.
       await waitFor(() => {
-        expect(screen.getByText(/Skipped 1 transaction\(s\) with unreadable amounts/)).toBeInTheDocument();
+        expect(screen.getByText(/Found 1 accounts and 2 transactions/)).toBeInTheDocument();
+      });
+      fireEvent.click(screen.getByText('Import Data'));
+
+      await waitFor(() => {
+        expect(mockAddTransaction).toHaveBeenCalledTimes(2);
+      });
+      const descriptions = mockAddTransaction.mock.calls.map(call => call[0].description);
+      expect(descriptions).toEqual(['Corner Shop', 'Newsagent']);
+      expect(descriptions).not.toContain('</MEMO>');
+      expect(descriptions).not.toContain('CARD PAYMENT');
+    });
+
+    it('leaves out a row the register already holds', async () => {
+      // Same account, same day, same amount — importing it again is the same
+      // payment twice. The old in-file parser checked for nothing at all.
+      mockTransactions = [
+        {
+          id: 'existing-1',
+          accountId: '1',
+          date: new Date(2024, 0, 15),
+          amount: -50,
+          type: 'expense',
+          description: 'Store Purchase',
+          category: '',
+          notes: 'FITID: SEQ-0001'
+        }
+      ];
+
+      render(<ImportDataModal isOpen={true} onClose={mockOnClose} />);
+
+      await uploadOfx(ofxStatement(`
+        <STMTTRN>
+          <TRNTYPE>DEBIT</TRNTYPE>
+          <DTPOSTED>20240115</DTPOSTED>
+          <TRNAMT>-50.00</TRNAMT>
+          <FITID>SEQ-0001</FITID>
+          <NAME>Store Purchase</NAME>
+        </STMTTRN>
+        <STMTTRN>
+          <TRNTYPE>DEBIT</TRNTYPE>
+          <DTPOSTED>20240116</DTPOSTED>
+          <TRNAMT>-8.40</TRNAMT>
+          <FITID>SEQ-0003</FITID>
+          <NAME>Coffee Stand</NAME>
+        </STMTTRN>
+      `));
+
+      await waitFor(() => {
+        expect(screen.getByText(/1 already in this account, left out/)).toBeInTheDocument();
+      });
+      // And the note before the button says so rather than the opposite.
+      expect(screen.getByText(/will not record the same payment twice/)).toBeInTheDocument();
+
+      fireEvent.click(screen.getByText('Import Data'));
+
+      await waitFor(() => {
+        expect(mockAddTransaction).toHaveBeenCalledTimes(1);
+      });
+      expect(mockAddTransaction).toHaveBeenCalledWith(
+        expect.objectContaining({ description: 'Coffee Stand' })
+      );
+    });
+
+    it('files an OFX row as uncategorised rather than filing it under "DEBIT"', async () => {
+      // The old in-file parser put the OFX TRNTYPE into the category field, so
+      // every imported row was filed under a category id that does not exist.
+      render(<ImportDataModal isOpen={true} onClose={mockOnClose} />);
+
+      await uploadOfx(ofxStatement(`
+        <STMTTRN>
+          <TRNTYPE>DEBIT</TRNTYPE>
+          <DTPOSTED>20240115</DTPOSTED>
+          <TRNAMT>-50.00</TRNAMT>
+          <FITID>SEQ-0004</FITID>
+          <NAME>Store Purchase</NAME>
+        </STMTTRN>
+      `));
+
+      await waitFor(() => {
+        expect(screen.getByText(/Found 1 accounts/)).toBeInTheDocument();
+      });
+      fireEvent.click(screen.getByText('Import Data'));
+
+      await waitFor(() => {
+        expect(mockAddTransaction).toHaveBeenCalledTimes(1);
+      });
+      const imported = mockAddTransaction.mock.calls[0][0];
+      expect(imported.category).not.toBe('DEBIT');
+      expect(imported.category).toBe('');
+      // The bank's own order within the statement survives the import.
+      expect(imported.statementSequence).toBe(0);
+    });
+
+    it('routes the statement to the account it matched instead of inventing one', async () => {
+      render(<ImportDataModal isOpen={true} onClose={mockOnClose} />);
+
+      await uploadOfx(ofxStatement(`
+        <STMTTRN>
+          <TRNTYPE>DEBIT</TRNTYPE>
+          <DTPOSTED>20240115</DTPOSTED>
+          <TRNAMT>-50.00</TRNAMT>
+          <FITID>SEQ-0005</FITID>
+          <NAME>Store Purchase</NAME>
+        </STMTTRN>
+      `));
+
+      await waitFor(() => {
+        expect(screen.getByText(/Found 1 accounts/)).toBeInTheDocument();
+      });
+      fireEvent.click(screen.getByText('Import Data'));
+
+      await waitFor(() => {
+        expect(mockAddTransaction).toHaveBeenCalledWith(
+          expect.objectContaining({ accountId: '1' })
+        );
+      });
+      expect(mockAddAccount).not.toHaveBeenCalled();
+    });
+
+    it('still creates the account a statement describes when nothing matches it', async () => {
+      // The Legacy Import's reason to exist: bring a file in whether or not the
+      // account is already there.
+      vi.mocked(useApp).mockReturnValue(appContextDouble({
+        addAccount: mockAddAccount,
+        addTransaction: mockAddTransaction,
+        accounts: [],
+        transactions: [],
+        categories: []
+      }));
+      render(<ImportDataModal isOpen={true} onClose={mockOnClose} />);
+
+      await uploadOfx(ofxStatement(`
+        <STMTTRN>
+          <TRNTYPE>DEBIT</TRNTYPE>
+          <DTPOSTED>20240115</DTPOSTED>
+          <TRNAMT>-50.00</TRNAMT>
+          <FITID>SEQ-0006</FITID>
+          <NAME>Store Purchase</NAME>
+        </STMTTRN>
+      `));
+
+      await waitFor(() => {
+        expect(screen.getByText(/Found 1 accounts/)).toBeInTheDocument();
+      });
+      fireEvent.click(screen.getByText('Import Data'));
+
+      await waitFor(() => {
+        expect(mockAddAccount).toHaveBeenCalledWith(
+          expect.objectContaining({ name: 'Account 99887766', type: 'current', balance: 1000 })
+        );
+      });
+      expect(mockAddTransaction).toHaveBeenCalledWith(
+        expect.objectContaining({ accountId: 'created-Account 99887766' })
+      );
+    });
+
+    it('survives a row it cannot read instead of losing the whole statement', async () => {
+      render(<ImportDataModal isOpen={true} onClose={mockOnClose} />);
+
+      // `new Decimal('N/A')` THROWS. Reading TRNAMT through it would have cost
+      // the user every transaction in the file over one malformed tag.
+      await uploadOfx(ofxStatement(`
+        <STMTTRN>
+          <TRNTYPE>DEBIT</TRNTYPE>
+          <DTPOSTED>20240115</DTPOSTED>
+          <TRNAMT>-50.00</TRNAMT>
+          <FITID>SEQ-0007</FITID>
+          <NAME>Store Purchase</NAME>
+        </STMTTRN>
+        <STMTTRN>
+          <TRNTYPE>DEBIT</TRNTYPE>
+          <DTPOSTED>20240116</DTPOSTED>
+          <TRNAMT>N/A</TRNAMT>
+          <FITID>SEQ-0008</FITID>
+          <NAME>Corrupt Row</NAME>
+        </STMTTRN>
+      `));
+
+      // The lost row is named for its consequence, not merely counted.
+      await waitFor(() => {
+        expect(
+          screen.getByText('One row in this file could not be read and will be missing from the register.')
+        ).toBeInTheDocument();
       });
 
       fireEvent.click(screen.getByText('Import Data'));
@@ -386,7 +602,7 @@ describe('ImportDataModal', () => {
         );
       });
       // No NaN amount may ever reach the ledger.
-      const amounts = mockAddTransaction.mock.calls.map(([tx]: [{ amount: number }]) => tx.amount);
+      const amounts = mockAddTransaction.mock.calls.map(call => call[0].amount);
       expect(amounts.some(Number.isNaN)).toBe(false);
     });
 

--- a/src/components/ImportDataModal.tsx
+++ b/src/components/ImportDataModal.tsx
@@ -1,8 +1,6 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { useApp } from '../contexts/AppContextSupabase';
 import { UploadIcon } from './icons/UploadIcon';
-import { parseMoneyInput } from '../utils/decimal';
-import { signTransactionAmount } from '../utils/transactionAmount';
 import { FileTextIcon } from './icons/FileTextIcon';
 import { AlertCircleIcon } from './icons/AlertCircleIcon';
 import { CheckCircleIcon } from './icons/CheckCircleIcon';
@@ -10,6 +8,7 @@ import { InfoIcon } from './icons/InfoIcon';
 import { AlertTriangleIcon } from './icons/AlertTriangleIcon';
 import { parseMNY, parseMBF, applyMappingToData, type FieldMapping } from '../utils/mnyParser';
 import { parseQIF as enhancedParseQIF } from '../utils/qifParser';
+import { ofxImportService } from '../services/ofxImportService';
 import MnyMappingModal from './MnyMappingModal';
 import { Modal, ModalBody, ModalFooter } from './common/Modal';
 import { createScopedLogger } from '../loggers/scopedLogger';
@@ -28,6 +27,15 @@ interface ParsedTransaction {
   payee?: string;
   /** Parser-resolved source account; used to route the import to the right account. */
   accountName?: string;
+  /** Carried through from the file where the parser produced one (OFX FITID). */
+  notes?: string;
+  cleared?: boolean;
+  /**
+   * The bank's own position for this row within its statement. Kept because it
+   * is the only record of which of a day's payments came first. Null carries
+   * "the file had no order to give", exactly as Transaction stores it.
+   */
+  statementSequence?: number | null;
 }
 
 interface ParsedAccount {
@@ -42,10 +50,18 @@ interface ParsedData {
   warning?: string;
   rawData?: Array<Record<string, unknown>>;
   needsMapping?: boolean;
+  /**
+   * How many rows the register already held and this import left out.
+   *
+   * `undefined` means the format's parser does not look — which is a different
+   * statement from "it looked and found none", and the note shown before the
+   * Import button says the right one of those two.
+   */
+  duplicatesSkipped?: number;
 }
 
 export default function ImportDataModal({ isOpen, onClose }: ImportDataModalProps): React.JSX.Element {
-  const { addAccount, addTransaction, accounts } = useApp();
+  const { addAccount, addTransaction, accounts, transactions, categories } = useApp();
   const logger = useMemo(() => createScopedLogger('ImportDataModal'), []);
   const [file, setFile] = useState<File | null>(null);
   const [importing, setImporting] = useState(false);
@@ -63,76 +79,70 @@ export default function ImportDataModal({ isOpen, onClose }: ImportDataModalProp
     };
   }, []);
 
-  // Parse OFX file format
-  const parseOFX = (content: string): ParsedData => {
-    logger.info?.('Using OFX parser');
-    const transactions: ParsedTransaction[] = [];
-    const accountsMap = new Map<string, ParsedAccount>();
-    
-    // Extract account info
-    const accountMatch = content.match(/<ACCTID>([^<]+)/);
-    const accountTypeMatch = content.match(/<ACCTTYPE>([^<]+)/);
-    const balanceMatch = content.match(/<BALAMT>([^<]+)/);
-    
-    const accountName = accountMatch ? `Account ${accountMatch[1]}` : 'Imported Account';
-    const accountType = accountTypeMatch?.[1]?.toLowerCase() || 'checking';
-    const balance = balanceMatch ? parseMoneyInput(balanceMatch[1]) ?? 0 : 0;
-    
-    accountsMap.set(accountName, {
-      name: accountName,
-      type: accountType.includes('credit') ? 'credit' : 
-            accountType.includes('saving') ? 'savings' : 'checking',
-      balance
+  /**
+   * OFX, read by the one OFX reader the app has.
+   *
+   * This used to be a second, hand-rolled parser living in this file, and it
+   * had drifted badly: it read an EMPTY <MEMO></MEMO> as the literal text
+   * "</MEMO>" and described the transaction that way, it put the OFX TRNTYPE
+   * ("DEBIT") into the category field, it took the FIRST <BALAMT> in the file —
+   * which on a card statement is the remaining credit, not the debt — and it
+   * detected no duplicates at all, so the same statement twice was the same
+   * payment twice.
+   *
+   * The account behaviour is deliberately kept: this modal is the Legacy
+   * Import, and its job is to bring a file in whether or not the account
+   * already exists. So a statement that matches an account the user holds is
+   * routed to THAT account, and one that matches nothing still creates the
+   * account it describes, exactly as before.
+   */
+  const parseOFXFile = async (content: string): Promise<ParsedData> => {
+    logger.info?.('Using OFX import service');
+    const result = await ofxImportService.importTransactions(content, accounts, transactions, {
+      // This modal writes straight through with no review step, so a row the
+      // register already holds must not be written a second time.
+      skipDuplicates: true,
+      categories,
+      autoCategorize: true
     });
-    
-    // Extract transactions
-    const transactionRegex = /<STMTTRN>[\s\S]*?<\/STMTTRN>/g;
-    const transactionMatches = content.match(transactionRegex) || [];
-    let skippedCount = 0;
 
-    for (const trans of transactionMatches) {
-      const typeMatch = trans.match(/<TRNTYPE>([^<]+)/);
-      const dateMatch = trans.match(/<DTPOSTED>([^<]+)/);
-      const amountMatch = trans.match(/<TRNAMT>([^<]+)/);
-      const nameMatch = trans.match(/<NAME>([^<]+)/);
-      const memoMatch = trans.match(/<MEMO>([^<]+)/);
+    // A matched account is reused by name below; an unmatched one is created.
+    const accountName = result.matchedAccount?.name
+      ?? `Account ${result.ofxAccount.accountId}`;
+    const ofxType = result.ofxAccount.accountType.toLowerCase();
 
-      if (dateMatch && amountMatch) {
-        const dateStr = dateMatch[1];
-        const year = parseInt(dateStr.substring(0, 4));
-        const month = parseInt(dateStr.substring(4, 6));
-        const day = parseInt(dateStr.substring(6, 8));
+    const account: ParsedAccount = {
+      name: accountName,
+      type: ofxType.includes('credit') ? 'credit'
+        : ofxType.includes('saving') ? 'savings'
+        : 'checking',
+      // The statement's LEDGERBAL. Only ever used for an account being
+      // created — a matched account keeps the balance its ledger says.
+      balance: result.statementBalance?.amount ?? 0
+    };
 
-        const amount = parseMoneyInput(amountMatch[1]);
-        if (amount === null) {
-          // An unparseable TRNAMT would import as NaN and poison every
-          // raw-sum balance downstream — skip the row and report it.
-          skippedCount++;
-          logger.warn?.('Skipping OFX transaction with unparseable amount', { raw: amountMatch[1] });
-          continue;
-        }
-        const description = nameMatch?.[1] || memoMatch?.[1] || 'Imported transaction';
-        // SIGNED CONVENTION: store a signed amount (expense negative, income
-        // positive). OFX TRNAMT is already source-signed; signTransactionAmount
-        // re-derives the sign from the resolved type (idempotent here).
-        const type: 'income' | 'expense' = amount < 0 ? 'expense' : 'income';
-
-        transactions.push({
-          date: new Date(year, month - 1, day),
-          amount: signTransactionAmount(amount, type),
-          description,
-          type,
-          category: typeMatch?.[1] || 'Other',
-          accountName
-        });
-      }
-    }
-
+    const unreadable = result.unreadableRows;
     return {
-      accounts: Array.from(accountsMap.values()),
-      transactions,
-      ...(skippedCount > 0
-        ? { warning: `Skipped ${skippedCount} transaction(s) with unreadable amounts` }
+      accounts: [account],
+      transactions: result.transactions.map((t): ParsedTransaction => ({
+        date: t.date,
+        amount: t.amount,
+        description: t.description,
+        // The OFX reader only ever resolves income or expense.
+        type: t.type === 'income' ? 'income' : 'expense',
+        category: t.category,
+        accountName,
+        notes: t.notes,
+        cleared: t.cleared,
+        statementSequence: t.statementSequence
+      })),
+      duplicatesSkipped: result.duplicates,
+      ...(unreadable > 0
+        ? {
+            warning: unreadable === 1
+              ? 'One row in this file could not be read and will be missing from the register.'
+              : `${unreadable} rows in this file could not be read and will be missing from the register.`
+          }
         : {})
     };
   };
@@ -190,7 +200,7 @@ export default function ImportDataModal({ isOpen, onClose }: ImportDataModalProp
         logger.info?.('Detected OFX file');
         setMessage('Parsing OFX file...');
         const content = await selectedFile.text();
-        parsed = parseOFX(content);
+        parsed = await parseOFXFile(content);
       } else {
         throw new Error('Unsupported file format. Please use .mny, .mbf, .qif, or .ofx files.');
       }
@@ -202,7 +212,14 @@ export default function ImportDataModal({ isOpen, onClose }: ImportDataModalProp
           setMessage(parsed.warning);
           setStatus('error');
         } else {
-          setMessage(`Found ${parsed.accounts.length} accounts and ${parsed.transactions.length} transactions`);
+          // Rows the register already held are named for what happened to
+          // them, not merely counted: they are not in the number beside them.
+          const alreadyHeld = parsed.duplicatesSkipped
+            ? ` — ${parsed.duplicatesSkipped} already in this account, left out`
+            : '';
+          setMessage(
+            `Found ${parsed.accounts.length} accounts and ${parsed.transactions.length} transactions${alreadyHeld}`
+          );
           setStatus('idle');
         }
       }
@@ -410,19 +427,27 @@ export default function ImportDataModal({ isOpen, onClose }: ImportDataModalProp
             </div>
           )}
 
-          {/* The one thing worth saying before the button is pressed, and it is
-              true of every format here: this importer only ever ADDS. Accounts
-              already present by name are reused, every transaction in the file
-              is written, and nothing on this path checks for duplicates — so
-              the same file twice is the same payment twice. */}
+          {/* The one thing worth saying before the button is pressed: this
+              importer only ever ADDS, and accounts already present by name are
+              reused. Whether the same file twice records the same payment twice
+              now depends on the format — OFX goes through the shared reader,
+              which recognises a row the register already holds; the rest do
+              not look. Saying "duplicates are not detected" for all of them
+              would be telling one half of the users something untrue. */}
           {preview && preview.transactions.length > 0 && (
             <div className="mb-4 p-3 rounded-lg flex items-start gap-2 bg-amber-50 dark:bg-amber-900/20 text-amber-800 dark:text-amber-200 border border-amber-200 dark:border-amber-800">
               <AlertTriangleIcon size={20} className="mt-0.5 flex-shrink-0" />
               <div className="text-sm">
                 <p className="font-semibold mb-1">These are added to what you already have</p>
-                <p>Nothing is replaced or deleted. Duplicates are not detected on this
-                  path, so importing the same file twice records every payment twice —
-                  use Settings → Data Management → Find Duplicates afterwards if you are unsure.</p>
+                {preview.duplicatesSkipped === undefined ? (
+                  <p>Nothing is replaced or deleted. Duplicates are not detected on this
+                    path, so importing the same file twice records every payment twice —
+                    use Settings → Data Management → Find Duplicates afterwards if you are unsure.</p>
+                ) : (
+                  <p>Nothing is replaced or deleted. Rows this account already holds have
+                    been left out, so importing the same statement again will not record
+                    the same payment twice.</p>
+                )}
               </div>
             </div>
           )}

--- a/src/components/OFXImportModal.test.tsx
+++ b/src/components/OFXImportModal.test.tsx
@@ -26,6 +26,7 @@ const createMockImportResult = (
   duplicateMatches: { certain: [], possible: [] },
   duplicates: 0,
   newTransactions: 0,
+  unreadableRows: 0,
   ...overrides,
 });
 
@@ -363,6 +364,55 @@ describe('OFXImportModal', () => {
       // both of them say 2 here, and which is which is the whole point.
       expect(summaryTile('In this file')).toHaveTextContent('2');
       expect(summaryTile('Will be imported')).toHaveTextContent('2');
+    });
+
+    it('says when a row in the file could not be read', async () => {
+      // A row the parser could not use is a payment that will be missing from
+      // the register. Unsaid, the account simply would not reconcile and
+      // nothing would explain why.
+      const mockParseResult = createMockImportResult({
+        transactions: [sampleTransaction],
+        statementRows: [statementRow(sampleTransaction, 'fit-1')],
+        newTransactions: 1,
+        unreadableRows: 2
+      });
+
+      vi.mocked(ofxImportService.importTransactions).mockResolvedValueOnce(mockParseResult);
+
+      render(<OFXImportModal {...defaultProps} />);
+
+      const file = new File(['OFX content'], 'test.ofx', { type: 'application/ofx' });
+      const fileInput = document.getElementById('ofx-upload')!
+
+      fireEvent.change(fileInput, { target: { files: [file] } });
+
+      await waitFor(() => {
+        expect(
+          screen.getByText('2 rows in this file could not be read and will be missing from the register.')
+        ).toBeInTheDocument();
+      });
+    });
+
+    it('says nothing about unreadable rows when there are none', async () => {
+      const mockParseResult = createMockImportResult({
+        transactions: [sampleTransaction],
+        statementRows: [statementRow(sampleTransaction, 'fit-1')],
+        newTransactions: 1
+      });
+
+      vi.mocked(ofxImportService.importTransactions).mockResolvedValueOnce(mockParseResult);
+
+      render(<OFXImportModal {...defaultProps} />);
+
+      const file = new File(['OFX content'], 'test.ofx', { type: 'application/ofx' });
+      const fileInput = document.getElementById('ofx-upload')!
+
+      fireEvent.change(fileInput, { target: { files: [file] } });
+
+      await waitFor(() => {
+        expect(screen.getByText('1 transactions found')).toBeInTheDocument();
+      });
+      expect(screen.queryByText(/could not be read/)).not.toBeInTheDocument();
     });
 
     it('says a guessed match is a guess', async () => {

--- a/src/components/OFXImportModal.tsx
+++ b/src/components/OFXImportModal.tsx
@@ -463,9 +463,19 @@ export default function OFXImportModal({ isOpen, onClose }: OFXImportModalProps)
                 <p className="text-sm text-gray-600 dark:text-gray-400">
                   {parseResult.statementRows.length} transactions found
                 </p>
+                {/* A row the file describes and this import will not record.
+                    Left unsaid, the register simply would not reconcile and
+                    nothing would explain why. */}
+                {parseResult.unreadableRows > 0 && (
+                  <p className="text-sm text-amber-700 dark:text-amber-400 mt-1">
+                    {parseResult.unreadableRows === 1
+                      ? 'One row in this file could not be read and will be missing from the register.'
+                      : `${parseResult.unreadableRows} rows in this file could not be read and will be missing from the register.`}
+                  </p>
+                )}
               </div>
             </div>
-            
+
             {/* Account Selection */}
             <div>
               <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">

--- a/src/components/reconciliation/ReconciliationBalanceBar.tsx
+++ b/src/components/reconciliation/ReconciliationBalanceBar.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useRef } from 'react';
 import { parseMoneyInput, toDecimal } from '../../utils/decimal';
 import MoneyInput from '../common/MoneyInput';
 import { useCurrencyDecimal } from '../../hooks/useCurrencyDecimal';
@@ -10,8 +10,19 @@ interface ReconciliationBalanceBarProps {
   clearedBalance: number;
   currency?: string;
   clearedSummary?: ClearedSummary;
-  onBankBalanceChange?: (newBalance: number) => void;
+  /**
+   * `null` means "there is no bank balance" — the state the account was in
+   * before anyone typed one, and the only honest state when the recorded
+   * figure was wrong or was written by an import. Without it a balance could
+   * be overwritten but never withdrawn, so an account that has no statement
+   * figure to compare against was stuck asserting a stale one forever.
+   */
+  onBankBalanceChange?: (newBalance: number | null) => void;
 }
+
+/** What removing the figure costs, said in full wherever it is offered. */
+const REMOVE_CONSEQUENCE =
+  'Remove the bank balance. Difference goes back to N/A until you enter another.';
 
 export default function ReconciliationBalanceBar({
   bankBalance,
@@ -24,29 +35,40 @@ export default function ReconciliationBalanceBar({
   const { formatCurrency } = useCurrencyDecimal();
   const [isEditingBankBalance, setIsEditingBankBalance] = useState(false);
   const [editValue, setEditValue] = useState('');
-  const [optimisticBankBalance, setOptimisticBankBalance] = useState<number | null>(null);
+  // What was just asked for, shown while the write is in flight. Wrapped in an
+  // object because the value itself may legitimately be null (removed), so a
+  // bare null could not tell "nothing pending" from "pending removal" apart.
+  const [pendingBankBalance, setPendingBankBalance] = useState<{ value: number | null } | null>(null);
+  const editFormRef = useRef<HTMLFormElement>(null);
 
-  const displayBankBalance = bankBalance ?? optimisticBankBalance;
+  const displayBankBalance = pendingBankBalance ? pendingBankBalance.value : bankBalance;
   const difference = displayBankBalance != null
     ? toDecimal(displayBankBalance).minus(toDecimal(clearedBalance)).toNumber()
     : null;
 
-  // Clear optimistic value once the real prop arrives
+  // The write landed: the prop is the truth again.
   useEffect(() => {
-    if (bankBalance != null) {
-      setOptimisticBankBalance(null);
-    }
+    setPendingBankBalance(pending => (pending && bankBalance === pending.value ? null : pending));
   }, [bankBalance]);
+
+  const applyBankBalance = (value: number | null): void => {
+    setPendingBankBalance({ value });
+    onBankBalanceChange?.(value);
+    setIsEditingBankBalance(false);
+    setEditValue('');
+  };
 
   const handleBankBalanceSubmit = (e?: React.FormEvent) => {
     if (e) e.preventDefault();
-    const parsed = parseMoneyInput(editValue) ?? NaN;
-    if (!Number.isNaN(parsed) && onBankBalanceChange) {
-      setOptimisticBankBalance(parsed);
-      onBankBalanceChange(parsed);
+    const parsed = parseMoneyInput(editValue);
+    if (parsed === null) {
+      // Unreadable — leave whatever is recorded alone. Removing is deliberate
+      // (the Remove control), never something a mistyped figure does for you.
+      setIsEditingBankBalance(false);
+      setEditValue('');
+      return;
     }
-    setIsEditingBankBalance(false);
-    setEditValue('');
+    applyBankBalance(parsed);
   };
 
   return (
@@ -65,12 +87,12 @@ export default function ReconciliationBalanceBar({
                 setIsEditingBankBalance(true);
               }}
               className="text-lg font-bold text-gray-900 dark:text-white hover:text-primary transition-colors cursor-pointer"
-              title="Click to edit"
+              title="Click to change or remove"
             >
               {formatCurrency(displayBankBalance, currency)}
             </button>
           ) : isEditingBankBalance ? (
-            <form onSubmit={handleBankBalanceSubmit} className="flex gap-1">
+            <form ref={editFormRef} onSubmit={handleBankBalanceSubmit} className="flex flex-col gap-1">
               <MoneyInput
                 // An overdrawn account's statement balance is negative.
                 allowNegative
@@ -79,7 +101,10 @@ export default function ReconciliationBalanceBar({
                 className="w-full px-2 py-1 text-sm border rounded dark:bg-gray-700 dark:border-gray-600 dark:text-white"
                 aria-label="Bank balance"
                 autoFocus
-                onBlur={() => {
+                onBlur={event => {
+                  // Moving onto Remove is still inside the editor. Closing here
+                  // would unmount that button before its click ever landed.
+                  if (editFormRef.current?.contains(event.relatedTarget)) return;
                   if (editValue.trim()) {
                     handleBankBalanceSubmit();
                   } else {
@@ -88,6 +113,23 @@ export default function ReconciliationBalanceBar({
                   }
                 }}
               />
+              {/* Only ever offered against a figure that exists — and only from
+                  inside the editor, so it takes a deliberate click to reach.
+                  preventDefault on mousedown keeps focus in the field: Safari
+                  does not focus a button on click, so the blur above would
+                  otherwise close the form out from under this one. */}
+              {displayBankBalance != null && (
+                <button
+                  type="button"
+                  onMouseDown={event => event.preventDefault()}
+                  onClick={() => applyBankBalance(null)}
+                  title={REMOVE_CONSEQUENCE}
+                  aria-label={REMOVE_CONSEQUENCE}
+                  className="text-xs text-gray-500 dark:text-gray-400 hover:text-red-600 dark:hover:text-red-400 hover:underline"
+                >
+                  Remove
+                </button>
+              )}
             </form>
           ) : (
             <button

--- a/src/components/reconciliation/__tests__/ReconciliationBalanceBar.test.tsx
+++ b/src/components/reconciliation/__tests__/ReconciliationBalanceBar.test.tsx
@@ -1,0 +1,124 @@
+import React from 'react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { screen, fireEvent } from '@testing-library/react';
+import { renderWithProviders } from '../../../test/testUtils';
+import ReconciliationBalanceBar from '../ReconciliationBalanceBar';
+
+/**
+ * The bank balance is the only figure on this bar a person can type, and until
+ * now it was write-only: once any number existed there was no way back to "no
+ * bank balance" and a Difference of N/A. These tests hold the way back open.
+ */
+describe('ReconciliationBalanceBar', () => {
+  const onBankBalanceChange = vi.fn();
+
+  const renderBar = (bankBalance: number | null) =>
+    renderWithProviders(
+      <ReconciliationBalanceBar
+        bankBalance={bankBalance}
+        accountBalance={250}
+        clearedBalance={200}
+        onBankBalanceChange={onBankBalanceChange}
+      />
+    );
+
+  const openEditor = (): void => {
+    fireEvent.click(screen.getByTitle('Click to change or remove'));
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('shows the difference against a recorded bank balance', () => {
+    renderBar(220);
+    expect(screen.getByText('Difference')).toBeInTheDocument();
+    expect(screen.queryByText('N/A')).not.toBeInTheDocument();
+  });
+
+  it('shows N/A and an invitation to type one when there is no bank balance', () => {
+    renderBar(null);
+    expect(screen.getByText('N/A')).toBeInTheDocument();
+    expect(screen.getByText('Enter balance')).toBeInTheDocument();
+  });
+
+  it('reports a removal as null, not as a number', () => {
+    renderBar(220);
+    openEditor();
+    fireEvent.click(screen.getByRole('button', { name: /Remove the bank balance/ }));
+
+    expect(onBankBalanceChange).toHaveBeenCalledTimes(1);
+    expect(onBankBalanceChange).toHaveBeenCalledWith(null);
+  });
+
+  it('names the consequence of removing rather than counting anything', () => {
+    renderBar(220);
+    openEditor();
+    expect(
+      screen.getByRole('button', {
+        name: 'Remove the bank balance. Difference goes back to N/A until you enter another.'
+      })
+    ).toBeInTheDocument();
+  });
+
+  it('falls straight back to N/A on removal, before the write has landed', () => {
+    // The prop still says 220 — the parent has not saved yet. The bar must
+    // already show the state the user asked for, or the click looks ignored.
+    renderBar(220);
+    openEditor();
+    fireEvent.click(screen.getByRole('button', { name: /Remove the bank balance/ }));
+
+    expect(screen.getByText('N/A')).toBeInTheDocument();
+    expect(screen.getByText('Enter balance')).toBeInTheDocument();
+  });
+
+  it('offers no removal until there is something to remove', () => {
+    renderBar(null);
+    fireEvent.click(screen.getByText('Enter balance'));
+    expect(screen.queryByRole('button', { name: /Remove the bank balance/ })).not.toBeInTheDocument();
+  });
+
+  it('keeps the editor open while focus moves onto Remove', () => {
+    renderBar(220);
+    openEditor();
+    const input = screen.getByLabelText('Bank balance');
+    const remove = screen.getByRole('button', { name: /Remove the bank balance/ });
+
+    fireEvent.blur(input, { relatedTarget: remove });
+
+    expect(screen.getByRole('button', { name: /Remove the bank balance/ })).toBeInTheDocument();
+    expect(onBankBalanceChange).not.toHaveBeenCalled();
+  });
+
+  it('leaves the recorded figure alone when the field is emptied and abandoned', () => {
+    // Emptying the box is not removing: that is what Remove is for.
+    renderBar(220);
+    openEditor();
+    const input = screen.getByLabelText('Bank balance');
+    fireEvent.change(input, { target: { value: '' } });
+    fireEvent.blur(input);
+
+    expect(onBankBalanceChange).not.toHaveBeenCalled();
+    expect(screen.getByTitle('Click to change or remove')).toBeInTheDocument();
+  });
+
+  it('still writes an ordinary edit as a number', () => {
+    renderBar(220);
+    openEditor();
+    const input = screen.getByLabelText('Bank balance');
+    fireEvent.change(input, { target: { value: '180.55' } });
+    fireEvent.blur(input);
+
+    expect(onBankBalanceChange).toHaveBeenCalledWith(180.55);
+  });
+
+  it('accepts a negative balance for an overdrawn account', () => {
+    renderBar(null);
+    fireEvent.click(screen.getByText('Enter balance'));
+    const input = screen.getByLabelText('Bank balance');
+    fireEvent.change(input, { target: { value: '-42.10' } });
+    fireEvent.blur(input);
+
+    expect(onBankBalanceChange).toHaveBeenCalledWith(-42.1);
+  });
+});

--- a/src/pages/Reconciliation.tsx
+++ b/src/pages/Reconciliation.tsx
@@ -217,18 +217,31 @@ export default function Reconciliation() {
     void applyCleared(transactionIds, cleared);
   }, [applyCleared]);
 
-  const handleBankBalanceChange = useCallback((newBalance: number) => {
-    if (selectedAccountId) {
-      // Dated as well as set. A figure typed here is what the bank says TODAY,
-      // and recording that keeps bank_balance_date describing the balance it
-      // sits beside — otherwise a hand-typed correction would inherit the date
-      // of whatever statement was imported last, and a later import of that
-      // statement's successor could be judged stale against it.
-      updateAccount(selectedAccountId, {
-        bankBalance: newBalance,
-        bankBalanceDate: todayIsoDay()
-      });
+  const handleBankBalanceChange = useCallback((newBalance: number | null) => {
+    if (!selectedAccountId) {
+      return;
     }
+    if (newBalance === null) {
+      // The date goes with the figure it dated. A bank_balance_date describing
+      // no balance is a claim about nothing — and worse than nothing, because
+      // statementBankBalance judges an incoming statement stale against it, so
+      // a leftover date would go on refusing statements after the balance it
+      // belonged to was withdrawn.
+      updateAccount(selectedAccountId, {
+        bankBalance: null,
+        bankBalanceDate: null
+      });
+      return;
+    }
+    // Dated as well as set. A figure typed here is what the bank says TODAY,
+    // and recording that keeps bank_balance_date describing the balance it
+    // sits beside — otherwise a hand-typed correction would inherit the date
+    // of whatever statement was imported last, and a later import of that
+    // statement's successor could be judged stale against it.
+    updateAccount(selectedAccountId, {
+      bankBalance: newBalance,
+      bankBalanceDate: todayIsoDay()
+    });
   }, [selectedAccountId, updateAccount]);
 
   const handleFinalize = useCallback(async () => {

--- a/src/pages/__tests__/Reconciliation.bankBalance.test.tsx
+++ b/src/pages/__tests__/Reconciliation.bankBalance.test.tsx
@@ -1,0 +1,87 @@
+import React from 'react';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { PreferencesProvider } from '../../contexts/PreferencesContext';
+import { ToastProvider } from '../../contexts/ToastContext';
+import { NotificationProvider } from '../../contexts/NotificationContext';
+import Reconciliation from '../Reconciliation';
+import { __setAppContextValue, __resetAppContextValue } from '../../test/mocks/AppContextSupabase';
+import { todayIsoDay } from '../../utils/statementBankBalance';
+import type { Account } from '../../types';
+
+/**
+ * What the page WRITES when the bank balance is removed. The figure and the
+ * date it is true for have to go together: a bank_balance_date left behind
+ * describes nothing, and statementBankBalance judges an incoming statement
+ * stale against exactly that date — so a stray one would go on refusing
+ * statements after the balance it belonged to was withdrawn.
+ */
+describe('Reconciliation — removing a bank balance', () => {
+  const updateAccount = vi.fn();
+
+  const account: Account = {
+    id: 'acct-recon-1',
+    name: 'Everyday Account',
+    type: 'current',
+    balance: 250,
+    currency: 'GBP',
+    institution: 'Test Bank',
+    lastUpdated: new Date('2025-03-01'),
+    bankBalance: 220,
+    bankBalanceDate: '2025-03-01'
+  };
+
+  const renderPage = () =>
+    render(
+      <MemoryRouter initialEntries={[`/reconciliation?account=${account.id}`]}>
+        <PreferencesProvider>
+          <ToastProvider>
+            {/* The page opens EditTransactionModal, which reads the
+                notification context even while closed. */}
+            <NotificationProvider>
+              <Reconciliation />
+            </NotificationProvider>
+          </ToastProvider>
+        </PreferencesProvider>
+      </MemoryRouter>
+    );
+
+  beforeEach(() => {
+    updateAccount.mockReset();
+    __setAppContextValue({ accounts: [account], transactions: [], updateAccount });
+  });
+
+  afterEach(() => {
+    __resetAppContextValue();
+  });
+
+  it('clears the recorded date along with the balance', () => {
+    renderPage();
+
+    fireEvent.click(screen.getByTitle('Click to change or remove'));
+    fireEvent.click(screen.getByRole('button', { name: /Remove the bank balance/ }));
+
+    expect(updateAccount).toHaveBeenCalledTimes(1);
+    expect(updateAccount).toHaveBeenCalledWith(account.id, {
+      bankBalance: null,
+      bankBalanceDate: null
+    });
+  });
+
+  it('dates a typed figure today rather than leaving the old statement date on it', () => {
+    renderPage();
+
+    fireEvent.click(screen.getByTitle('Click to change or remove'));
+    const input = screen.getByLabelText('Bank balance');
+    fireEvent.change(input, { target: { value: '199.99' } });
+    fireEvent.blur(input);
+
+    expect(updateAccount).toHaveBeenCalledWith(account.id, {
+      bankBalance: 199.99,
+      bankBalanceDate: todayIsoDay()
+    });
+    // Not the date the account arrived carrying.
+    expect(todayIsoDay()).not.toBe(account.bankBalanceDate);
+  });
+});

--- a/src/services/import/msMoney/msMoneyImport.test.ts
+++ b/src/services/import/msMoney/msMoneyImport.test.ts
@@ -1,4 +1,8 @@
+// The local write path is tested against the real storage stack, not a
+// stand-in for it — see the importToLocalStorage suite at the foot of the file.
+import 'fake-indexeddb/auto';
 import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { storageAdapter, STORAGE_KEYS } from '../../storageAdapter';
 import {
   planCloudImport, importToLocalStorage, executeCloudPlan,
   MS_MONEY_IMPORT_SOURCE, IMPORT_PROVENANCE_CONFLICT, IMPORT_BATCH_SIZE,
@@ -752,23 +756,94 @@ describe('planCloudImport — opening balances on reused accounts', () => {
 // wipeLocalFinancialData, is covered in localBackupService.test.ts against real
 // storage.
 
+/**
+ * The LOCAL write path, against the REAL storage stack — storageAdapter →
+ * encryptedStorage → IndexedDB (fake-indexeddb) — because that is where every
+ * reader in the app looks.
+ *
+ * The old tests here asserted on `window.localStorage`, which is the wrong
+ * layer and is why the bug survived: the implementation wrote keys nothing
+ * reads, and the assertions read the keys nothing writes, so the two agreed
+ * with each other and with nobody else.
+ *
+ * The account already holding data is not incidental — it is the only state
+ * this import ever runs in. A total migration replaces what is there, and the
+ * moment IndexedDB holds ANY value for one of these keys (a demo seed, an
+ * earlier session, the empty arrays Clear All Data leaves behind) the adapter
+ * stops consulting its localStorage fallback. That is what turned the old
+ * implementation from "works on a virgin browser" into "does nothing, ever".
+ */
 describe('importToLocalStorage', () => {
-  const KEYS = { ACCOUNTS: 'a', TRANSACTIONS: 't', CATEGORIES: 'c', TRANSACTION_SPLITS: 's', BUDGETS: 'b', GOALS: 'g', RECURRING: 'r' };
-  beforeEach(() => { window.localStorage.clear(); });
+  const KEYS = {
+    ACCOUNTS: STORAGE_KEYS.ACCOUNTS,
+    TRANSACTIONS: STORAGE_KEYS.TRANSACTIONS,
+    CATEGORIES: STORAGE_KEYS.CATEGORIES,
+    TRANSACTION_SPLITS: STORAGE_KEYS.TRANSACTION_SPLITS,
+    BUDGETS: STORAGE_KEYS.BUDGETS,
+    GOALS: STORAGE_KEYS.GOALS,
+    RECURRING: STORAGE_KEYS.RECURRING,
+  };
 
-  it('writes the imported collections and clears the rest', async () => {
+  /** What the app reads back — never what some other layer happens to hold. */
+  const stored = async (key: string): Promise<unknown[]> =>
+    (await storageAdapter.get<unknown[]>(key)) ?? [];
+
+  beforeEach(async () => {
+    window.localStorage.clear();
+    await storageAdapter.clear();
+    // The data being replaced, written the way the app writes it.
+    await storageAdapter.set(KEYS.ACCOUNTS, [{ id: 'prior-acct', name: 'Everyday Account' }]);
+    await storageAdapter.set(KEYS.TRANSACTIONS, [{ id: 'prior-txn', description: 'Bus fare' }]);
+    await storageAdapter.set(KEYS.CATEGORIES, [{ id: 'prior-cat', name: 'Travel' }]);
+    await storageAdapter.set(KEYS.TRANSACTION_SPLITS, [{ id: 'prior-split' }]);
+    await storageAdapter.set(KEYS.BUDGETS, [{ id: 'prior-budget' }]);
+    await storageAdapter.set(KEYS.GOALS, [{ id: 'prior-goal' }]);
+    await storageAdapter.set(KEYS.RECURRING, [{ id: 'prior-recurring' }]);
+  });
+
+  it('writes the imported collections where the app reads them', async () => {
     const onProgress = vi.fn();
     await importToLocalStorage(sampleResult(), KEYS, { onProgress });
 
-    expect(JSON.parse(window.localStorage.getItem('a')!)).toHaveLength(4);
-    expect(JSON.parse(window.localStorage.getItem('t')!)).toHaveLength(4);
-    expect(JSON.parse(window.localStorage.getItem('c')!)).toHaveLength(5);
-    expect(JSON.parse(window.localStorage.getItem('s')!)).toHaveLength(1);
+    expect(await stored(KEYS.ACCOUNTS)).toHaveLength(4);
+    expect(await stored(KEYS.TRANSACTIONS)).toHaveLength(4);
+    expect(await stored(KEYS.CATEGORIES)).toHaveLength(5);
+    expect(await stored(KEYS.TRANSACTION_SPLITS)).toHaveLength(1);
     // A total migration replaces — the other collections are emptied.
-    expect(window.localStorage.getItem('b')).toBe('[]');
-    expect(window.localStorage.getItem('g')).toBe('[]');
-    expect(window.localStorage.getItem('r')).toBe('[]');
+    expect(await stored(KEYS.BUDGETS)).toEqual([]);
+    expect(await stored(KEYS.GOALS)).toEqual([]);
+    expect(await stored(KEYS.RECURRING)).toEqual([]);
     // progress reaches the terminal phase
     expect(onProgress).toHaveBeenLastCalledWith(expect.objectContaining({ phase: 'done', fraction: 1 }));
+  });
+
+  it('leaves nothing of the replaced data behind', async () => {
+    await importToLocalStorage(sampleResult(), KEYS);
+
+    const accounts = await stored(KEYS.ACCOUNTS);
+    expect(accounts.some(a => (a as { id?: string }).id === 'prior-acct')).toBe(false);
+    const transactions = await stored(KEYS.TRANSACTIONS);
+    expect(transactions.some(t => (t as { id?: string }).id === 'prior-txn')).toBe(false);
+  });
+
+  it('reads back as data, not as JSON text', async () => {
+    // The old implementation stringified into localStorage; a reader expecting
+    // objects got a string, or — after the adapter's fallback stopped being
+    // consulted — nothing at all.
+    await importToLocalStorage(sampleResult(), KEYS);
+
+    const accounts = await stored(KEYS.ACCOUNTS);
+    expect(accounts.map(a => (a as { name?: string }).name))
+      .toEqual(['Current', 'Savings', 'Broker', 'Broker (Cash)']);
+  });
+
+  it('writes every collection as one unit, so a failure leaves the previous data intact', async () => {
+    const store = { setMany: vi.fn(async () => { throw new Error('quota exceeded'); }) };
+
+    await expect(importToLocalStorage(sampleResult(), KEYS, { store })).rejects.toThrow('quota exceeded');
+
+    expect(store.setMany).toHaveBeenCalledTimes(1);
+    expect(await stored(KEYS.ACCOUNTS)).toEqual([{ id: 'prior-acct', name: 'Everyday Account' }]);
+    expect(await stored(KEYS.BUDGETS)).toEqual([{ id: 'prior-budget' }]);
   });
 });

--- a/src/services/import/msMoney/msMoneyImport.ts
+++ b/src/services/import/msMoney/msMoneyImport.ts
@@ -4,8 +4,9 @@
  * Takes the app-shaped collections produced by `transformMsMoneyExport` and
  * replaces ALL of the user's data with them. Two write paths share one plan:
  *
- *  - LOCAL (demo / signed-out): rewrites the wealthtracker_* storage keys, the
- *    same contract demo seeding uses.
+ *  - LOCAL (demo / signed-out): rewrites the wealthtracker_* storage keys
+ *    through `storageAdapter`, the same contract demo seeding uses — which is
+ *    also the only place the app's readers look.
  *  - CLOUD (signed in): wipes then batch-inserts through the authenticated
  *    Supabase client under RLS — the same ordered wipe + two-pass transfer
  *    linking + split-leg pinning proven by scripts/mnyCloudImport.mts, minus
@@ -18,6 +19,7 @@
 import type { SupabaseClient } from '@supabase/supabase-js';
 import type { Account, Category } from '../../../types';
 import { toDecimal } from '../../../utils/decimal';
+import { storageAdapter } from '../../storageAdapter';
 import type { TransferHandover } from './feedOverlap';
 import type { MsMoneyImportResult } from './transform';
 
@@ -116,27 +118,59 @@ export const IMPORT_PROVENANCE_CONFLICT = 'user_id,import_source,import_source_i
 // ── LOCAL path ───────────────────────────────────────────────────────────────
 
 /**
- * Replace local storage with the imported collections. Mirrors the demo-seed
- * storage contract so the app picks it up on the next load.
+ * The slice of browser storage this import writes through.
+ *
+ * `setMany` is one IndexedDB readwrite transaction, so the migration lands
+ * whole or not at all. A per-key loop could not promise that: a failure on the
+ * fifth key would leave the file's accounts beside the previous data's
+ * transactions, and no reconciliation could make sense of the result.
+ */
+export interface LocalImportStore {
+  setMany(entries: ReadonlyArray<{ key: string; value: unknown }>): Promise<void>;
+}
+
+export interface LocalImportOptions extends ImportOptions {
+  /** Defaults to the adapter the app itself reads through. */
+  store?: LocalImportStore;
+}
+
+/**
+ * Replace local storage with the imported collections.
+ *
+ * Written through `storageAdapter`, because that — storageAdapter →
+ * encryptedStorage → IndexedDB — is where every reader in the app looks. This
+ * used to call `window.localStorage.setItem` directly, which is the same defect
+ * `wipeLocalData` carried (see the note further down) and the same one
+ * mnyLocalImport documents for the dev seed: the keys it wrote were not the
+ * keys anything read, so a local-mode Money import reported success and left
+ * the app showing exactly what it showed before. Its test asserted on
+ * `window.localStorage` and passed for the same reason.
  */
 export async function importToLocalStorage(
   result: MsMoneyImportResult,
   storageKeys: { ACCOUNTS: string; TRANSACTIONS: string; CATEGORIES: string; TRANSACTION_SPLITS: string; BUDGETS: string; GOALS: string; RECURRING: string },
-  opts: ImportOptions = {}
+  opts: LocalImportOptions = {}
 ): Promise<void> {
   const { onProgress } = opts;
-  onProgress?.({ phase: 'accounts', fraction: 0.2, message: 'Writing accounts…' });
-  window.localStorage.setItem(storageKeys.ACCOUNTS, JSON.stringify(result.accounts));
-  onProgress?.({ phase: 'categories', fraction: 0.4, message: 'Writing categories…' });
-  window.localStorage.setItem(storageKeys.CATEGORIES, JSON.stringify(result.categories));
-  onProgress?.({ phase: 'transactions', fraction: 0.7, message: 'Writing transactions…' });
-  window.localStorage.setItem(storageKeys.TRANSACTIONS, JSON.stringify(result.transactions));
-  onProgress?.({ phase: 'splits', fraction: 0.9, message: 'Writing splits…' });
-  window.localStorage.setItem(storageKeys.TRANSACTION_SPLITS, JSON.stringify(result.transactionSplits));
-  // Everything else starts clean — a total migration replaces, never merges.
-  window.localStorage.setItem(storageKeys.BUDGETS, '[]');
-  window.localStorage.setItem(storageKeys.GOALS, '[]');
-  window.localStorage.setItem(storageKeys.RECURRING, '[]');
+  const store = opts.store ?? storageAdapter;
+
+  onProgress?.({ phase: 'accounts', fraction: 0.2, message: 'Preparing your data…' });
+  const entries: { key: string; value: unknown }[] = [
+    { key: storageKeys.ACCOUNTS, value: result.accounts },
+    { key: storageKeys.CATEGORIES, value: result.categories },
+    { key: storageKeys.TRANSACTIONS, value: result.transactions },
+    { key: storageKeys.TRANSACTION_SPLITS, value: result.transactionSplits },
+    // Everything else starts clean — a total migration replaces, never merges.
+    { key: storageKeys.BUDGETS, value: [] },
+    { key: storageKeys.GOALS, value: [] },
+    { key: storageKeys.RECURRING, value: [] },
+  ];
+
+  // One phase, because there is one write. Reporting "writing accounts…",
+  // "writing categories…" against a single atomic call would be inventing
+  // progress the import does not make.
+  onProgress?.({ phase: 'transactions', fraction: 0.5, message: 'Writing your data…' });
+  await store.setMany(entries);
   onProgress?.({ phase: 'done', fraction: 1, message: 'Import complete.' });
 }
 

--- a/src/services/ofxImportService.test.ts
+++ b/src/services/ofxImportService.test.ts
@@ -324,6 +324,37 @@ NEWFILEUID:NONE
       expect(result.transactions.map(t => t.sequence)).toEqual([0, 1]);
     });
 
+    it('counts the rows it had to skip rather than losing them in silence', () => {
+      // Dropping a row the file describes is a payment that will not be in the
+      // register. The caller has to be able to say so.
+      const withUnusableRow = validOFXContent.replace('<FITID>2024012001\n', '');
+
+      expect(ofxImportService.parseOFX(withUnusableRow).unreadableRows).toBe(1);
+      expect(ofxImportService.parseOFX(validOFXContent).unreadableRows).toBe(0);
+    });
+
+    it('survives an unreadable TRNAMT instead of failing the whole import', () => {
+      // `new Decimal('N/A')` THROWS, exactly as it does for a BALAMT of
+      // '5000.00CR'. Reading TRNAMT straight through Decimal cost the user
+      // every transaction in the file over one malformed tag.
+      const withJunkAmount = validOFXContent.replace('<TRNAMT>2500.00', '<TRNAMT>N/A');
+
+      const result = ofxImportService.parseOFX(withJunkAmount);
+      expect(result.transactions).toHaveLength(2);
+      expect(result.unreadableRows).toBe(1);
+      // Never NaN: a NaN amount poisons every balance downstream.
+      expect(result.transactions.some(t => Number.isNaN(t.amount))).toBe(false);
+      expect(result.transactions.map(t => t.sequence)).toEqual([0, 1]);
+    });
+
+    it('carries the unreadable count through the import path to the caller', async () => {
+      const withJunkAmount = validOFXContent.replace('<TRNAMT>2500.00', '<TRNAMT>N/A');
+
+      const result = await ofxImportService.importTransactions(withJunkAmount, mockAccounts, []);
+      expect(result.unreadableRows).toBe(1);
+      expect(result.transactions).toHaveLength(2);
+    });
+
     it('records a zero LEDGERBAL as a real closing balance of 0.00', () => {
       // ABSENT and ZERO are different, and only one of them means "the file
       // says nothing". A zero ledger balance is a statement of fact and is

--- a/src/services/ofxImportService.ts
+++ b/src/services/ofxImportService.ts
@@ -1,6 +1,6 @@
 import type { Transaction, Account, Category } from '../types';
 import { smartCategorizationService } from './smartCategorizationService';
-import { parseMoneyInput, toDecimal, toNumber } from '../utils/decimal';
+import { parseMoneyInput } from '../utils/decimal';
 import { findAccountByOfxIdentifiers } from '../utils/ofxAccountIdentifiers';
 import { isSelfTransferCategory } from '../utils/transferMatch';
 import {
@@ -65,6 +65,15 @@ interface OFXParseResult {
   currency?: string;
   startDate?: string;
   endDate?: string;
+  /**
+   * <STMTTRN> blocks the parser could not turn into a transaction — no date,
+   * no amount, an amount that is not a number, or no FITID to identify it by.
+   *
+   * Counted rather than merely skipped because each one is a payment the file
+   * describes and this import will not record. Silently dropping it leaves a
+   * register that cannot be reconciled and nothing to say why.
+   */
+  unreadableRows: number;
 }
 
 export class OFXImportService {
@@ -82,10 +91,10 @@ export class OFXImportService {
     
     // Parse account information
     const account = this.parseAccountInfo(ofxContent);
-    
+
     // Parse transactions
-    const transactions = this.parseTransactions(ofxContent);
-    
+    const { transactions, unreadableRows } = this.parseTransactions(ofxContent);
+
     // Parse balance
     const balance = this.parseBalance(ofxContent);
     
@@ -103,7 +112,8 @@ export class OFXImportService {
       balance,
       currency,
       startDate: startDate ? this.parseOFXDate(startDate) : undefined,
-      endDate: endDate ? this.parseOFXDate(endDate) : undefined
+      endDate: endDate ? this.parseOFXDate(endDate) : undefined,
+      unreadableRows
     };
   }
   
@@ -165,15 +175,23 @@ export class OFXImportService {
   }
   
   /**
-   * Parse transactions from OFX
+   * Parse transactions from OFX, and say how many rows were unreadable.
+   *
+   * The amount goes through parseMoneyInput for the same reason parseBalance
+   * does: `new Decimal('N/A')` THROWS, and a throw here would abort the whole
+   * import over one malformed tag — the user would lose an entire statement to
+   * a row their bank got wrong. A row whose TRNAMT cannot be read is left out
+   * and counted, never guessed at and never imported as NaN, which would
+   * poison every balance downstream.
    */
-  private parseTransactions(content: string): OFXTransaction[] {
+  private parseTransactions(content: string): { transactions: OFXTransaction[]; unreadableRows: number } {
     const transactions: OFXTransaction[] = [];
-    
+    let unreadableRows = 0;
+
     // Find all transaction blocks
     const transactionPattern = /<STMTTRN>([\s\S]*?)<\/STMTTRN>/g;
     let match;
-    
+
     while ((match = transactionPattern.exec(content)) !== null) {
       const transBlock = match[1];
       
@@ -195,25 +213,30 @@ export class OFXImportService {
       
       const refNum = this.readTag(transBlock, 'REFNUM');
       
-      if (datePosted && amountStr && fitId) {
-        transactions.push({
-          type,
-          datePosted: this.parseOFXDate(datePosted),
-          amount: toNumber(toDecimal(amountStr)),
-          fitId: fitId.trim(),
-          name: this.cleanString(name),
-          memo: memo ? this.cleanString(memo) : undefined,
-          checkNum: checkNum || undefined,
-          refNum: refNum || undefined,
-          // Position among the rows KEPT, not among the <STMTTRN> blocks seen:
-          // a block missing a date, amount or FITID is skipped above, and
-          // counting it would leave a gap that reads as a lost transaction.
-          sequence: transactions.length
-        });
+      const amount = amountStr === null ? null : parseMoneyInput(amountStr);
+
+      if (!datePosted || amount === null || !fitId) {
+        unreadableRows++;
+        continue;
       }
+
+      transactions.push({
+        type,
+        datePosted: this.parseOFXDate(datePosted),
+        amount,
+        fitId: fitId.trim(),
+        name: this.cleanString(name),
+        memo: memo ? this.cleanString(memo) : undefined,
+        checkNum: checkNum || undefined,
+        refNum: refNum || undefined,
+        // Position among the rows KEPT, not among the <STMTTRN> blocks seen:
+        // a block missing a date, amount or FITID is skipped above, and
+        // counting it would leave a gap that reads as a lost transaction.
+        sequence: transactions.length
+      });
     }
-    
-    return transactions;
+
+    return { transactions, unreadableRows };
   }
   
   /**
@@ -481,6 +504,12 @@ export class OFXImportService {
     /** How many rows were left out as already held. */
     duplicates: number;
     newTransactions: number;
+    /**
+     * Rows in the file this import could not read at all — see
+     * OFXParseResult.unreadableRows. Nothing was written for them, so a caller
+     * that does not surface this is losing payments in silence.
+     */
+    unreadableRows: number;
   }> {
     const parseResult = this.parseOFX(ofxContent);
 
@@ -605,7 +634,8 @@ export class OFXImportService {
       statementRows,
       duplicateMatches,
       duplicates: skipped.size,
-      newTransactions: transactions.length
+      newTransactions: transactions.length,
+      unreadableRows: parseResult.unreadableRows
     };
   }
 }

--- a/src/utils/duplicateSweep.test.ts
+++ b/src/utils/duplicateSweep.test.ts
@@ -1,13 +1,20 @@
 /**
- * The duplicate sweep's two rules: one account at a time, and never offer to
- * delete a row that is holding something else together.
+ * The duplicate sweep's rules: one account at a time, detect widely, delete
+ * narrowly, and never offer to delete a row that is holding something else
+ * together.
  *
  * The scoring itself belongs to duplicateScan and is tested there; what is
  * pinned here is the part that makes a delete tool safe to point at real money.
  */
 
 import { describe, it, expect } from 'vitest';
-import { deleteBlockOf, findDuplicateCandidates } from './duplicateSweep';
+import {
+  deleteBlockOf,
+  deleteRefusalFor,
+  findDuplicateCandidates,
+  needsConfirmation,
+  type DuplicateCandidate,
+} from './duplicateSweep';
 import type { Transaction } from '../types';
 
 const txn = (over: Partial<Transaction> & { id: string }): Transaction => ({
@@ -23,6 +30,11 @@ const txn = (over: Partial<Transaction> & { id: string }): Transaction => ({
 const keysOf = (candidates: ReturnType<typeof findDuplicateCandidates>): string[] =>
   candidates.map(c => [c.a.id, c.b.id].sort().join('+')).sort();
 
+const oneOf = (candidates: DuplicateCandidate[]): DuplicateCandidate => {
+  expect(candidates).toHaveLength(1);
+  return candidates[0];
+};
+
 describe('findDuplicateCandidates', () => {
   it('finds the same payment recorded twice in one account', () => {
     const found = findDuplicateCandidates(
@@ -32,6 +44,7 @@ describe('findDuplicateCandidates', () => {
     expect(keysOf(found)).toEqual(['feed+import']);
     expect(found[0].score).toBeGreaterThanOrEqual(80);
     expect(found[0].daysApart).toBe(0);
+    expect(found[0].basis).toBe('description-agrees');
   });
 
   it('never offers two DIFFERENT amounts, however alike they otherwise read', () => {
@@ -117,6 +130,301 @@ describe('findDuplicateCandidates', () => {
       { windowDays: 3 }
     );
     expect(keysOf(found)).toEqual(['one+three', 'one+two']);
+  });
+});
+
+/**
+ * The five shapes a real re-import left behind, with invented wording and
+ * figures. Every pair is one payment recorded twice in ONE account; not one of
+ * them has the same description on both sides. Three were truncated by whatever
+ * wrote them, one was written by a different system, and one was renamed by
+ * hand to something its owner would recognise a year later.
+ */
+const PAIR_SHAPES = [
+  {
+    id: 'truncated-tail',
+    first: 'Sweep Transfer from account 5566',
+    second: 'Sweep Transfer from account 55667788',
+    amount: 9876.54,
+  },
+  {
+    id: 'reference-appended',
+    first: 'Direct Debit - STREAMCO',
+    second: 'Direct Debit - STREAMCO  00110022330044',
+    amount: -63.2,
+  },
+  {
+    id: 'reference-extended',
+    first: 'Direct Debit - TELCO LTD  447',
+    second: 'Direct Debit - TELCO LTD  447221900-00007',
+    amount: -77.45,
+  },
+  {
+    id: 'name-reordered',
+    first: 'SAMPLE PERSON A',
+    second: 'Standing Order to MISS A SAMPLE - A SAMPLE',
+    amount: -2500,
+  },
+  {
+    id: 'renamed-payee',
+    first: 'Nadia',
+    second: 'Immediate Faster Payment (Online) to B EXAMPLE 07-FEB-2027',
+    amount: -410,
+  },
+];
+
+describe('findDuplicateCandidates — detecting through an edited description', () => {
+  it('finds every one of the five real shapes, in one sweep', () => {
+    // THE BUG. Scoring description similarity into the total and demanding 80
+    // meant the description had to supply 33 of the 100 on its own, so the two
+    // pairs whose wording was rewritten rather than truncated were invisible —
+    // and rewriting a payee's name is the commonest edit anyone makes to their
+    // own register.
+    const rows = PAIR_SHAPES.flatMap(shape => [
+      txn({ id: `${shape.id}-a`, amount: shape.amount, description: shape.first }),
+      txn({ id: `${shape.id}-b`, amount: shape.amount, description: shape.second }),
+    ]);
+
+    expect(keysOf(findDuplicateCandidates(rows, { windowDays: 3 }))).toEqual(
+      PAIR_SHAPES.map(shape => `${shape.id}-a+${shape.id}-b`).sort()
+    );
+  });
+
+  it('finds a pair with NOT ONE WORD in common — and calls it evidence, not proof', () => {
+    // The headline case. "Nadia" against the bank's own wording shares nothing
+    // at all, so no description rule of any kind could ever have reached it.
+    // Same account, same day, same money to the penny is what remains, and it
+    // is enough to SHOW the pair — never enough to delete one unasked.
+    const renamed = txn({ id: 'renamed', amount: -410, description: 'Nadia' });
+    const asTheBankWroteIt = txn({
+      id: 'as-imported',
+      amount: -410,
+      description: 'Immediate Faster Payment (Online) to B EXAMPLE 07-FEB-2027',
+    });
+
+    const found = oneOf(findDuplicateCandidates([renamed, asTheBankWroteIt], { windowDays: 3 }));
+
+    expect(keysOf([found])).toEqual(['as-imported+renamed']);
+    expect(found.basis).toBe('amount-and-date');
+    expect(found.descriptionOverlap).toBe(0);
+    expect(found.daysApart).toBe(0);
+    // Found DESPITE scoring nowhere near the bar a delete still has to clear.
+    expect(found.score).toBeLessThan(80);
+
+    expect(needsConfirmation(found)).toBe(true);
+    expect(deleteRefusalFor(found, renamed, false)).toBe('not-confirmed');
+    expect(deleteRefusalFor(found, asTheBankWroteIt, false)).toBe('not-confirmed');
+    expect(deleteRefusalFor(found, renamed, true)).toBeNull();
+  });
+
+  it('reports the wider rule separately from the pairs whose wording agrees', () => {
+    const found = findDuplicateCandidates(
+      [
+        txn({ id: 'feed', amount: -63.2, description: 'Direct Debit - STREAMCO' }),
+        txn({ id: 'file', amount: -63.2, description: 'Direct Debit - STREAMCO  00110022330044' }),
+        txn({ id: 'renamed', amount: -410, description: 'Nadia' }),
+        txn({
+          id: 'as-imported',
+          amount: -410,
+          description: 'Immediate Faster Payment (Online) to B EXAMPLE 07-FEB-2027',
+        }),
+      ],
+      { windowDays: 3 }
+    );
+
+    const byKey = new Map(found.map(c => [[c.a.id, c.b.id].sort().join('+'), c.basis]));
+    expect(byKey.get('feed+file')).toBe('description-agrees');
+    expect(byKey.get('as-imported+renamed')).toBe('amount-and-date');
+  });
+
+  it('leaves the rows the first tier paired off out of the second', () => {
+    // Two rows read alike and pair on wording; the third is the same money on
+    // the same day but worded differently. It is NOT argued about twice in one
+    // run — settle the pair in front of you, run it again, and it comes up.
+    const found = findDuplicateCandidates(
+      [
+        txn({ id: 'feed' }),
+        txn({ id: 'import' }),
+        txn({ id: 'renamed', description: 'Nadia' }),
+      ],
+      { windowDays: 3 }
+    );
+    expect(keysOf(found)).toEqual(['feed+import']);
+  });
+});
+
+describe('findDuplicateCandidates — what the wider rule refuses to do', () => {
+  it('still will not pair two different amounts, however close they look', () => {
+    // The pair that shipped, run past BOTH rules: the wider one buckets by
+    // exact pence, so a 48% gap does not even reach the comparison.
+    const found = findDuplicateCandidates(
+      [
+        txn({ id: 'a', amount: -24.99, description: 'Renamed by hand' }),
+        txn({ id: 'b', amount: -36.95, description: 'CARD PAYMENT 4409' }),
+      ],
+      { windowDays: 3 }
+    );
+    expect(found).toEqual([]);
+  });
+
+  it('will not pair amounts one penny apart', () => {
+    const found = findDuplicateCandidates(
+      [
+        txn({ id: 'a', amount: -24.99, description: 'Renamed by hand' }),
+        txn({ id: 'b', amount: -25, description: 'CARD PAYMENT 4409' }),
+      ],
+      { windowDays: 3 }
+    );
+    expect(found).toEqual([]);
+  });
+
+  it('will not pair equal and OPPOSITE amounts — the sign is part of the money', () => {
+    const found = findDuplicateCandidates(
+      [
+        txn({ id: 'out', amount: -410, description: 'Nadia' }),
+        txn({ id: 'in', amount: 410, description: 'Immediate Faster Payment (Online) from B' }),
+      ],
+      { windowDays: 3 }
+    );
+    expect(found).toEqual([]);
+  });
+
+  it('never reaches across accounts — that is a transfer, not a duplicate', () => {
+    const found = findDuplicateCandidates(
+      [
+        txn({ id: 'here', amount: -410, description: 'Nadia' }),
+        txn({ id: 'there', accountId: 'acc-joint', amount: -410, description: 'Standing Order' }),
+      ],
+      { windowDays: 3 }
+    );
+    expect(found).toEqual([]);
+  });
+
+  it('honours the date window it was given', () => {
+    const rows = [
+      txn({ id: 'first', amount: -410, description: 'Nadia' }),
+      txn({
+        id: 'later',
+        amount: -410,
+        date: new Date('2026-05-09'),
+        description: 'Immediate Faster Payment (Online) to B EXAMPLE',
+      }),
+    ];
+    expect(findDuplicateCandidates(rows, { windowDays: 3 })).toEqual([]);
+    expect(keysOf(findDuplicateCandidates(rows, { windowDays: 14 }))).toEqual(['first+later']);
+  });
+
+  it('flags only half of a set of equal payments — two coffees are two coffees', () => {
+    // Four £3.20 rows on one day, all worded differently. Matching is strictly
+    // 1:1, so at most two pairs come back: a rule that paired everything with
+    // everything would offer six and invite the loss of real spending.
+    const rows = ['CAFE ONE', 'Coffee', 'KIOSK 88', 'Morning cup'].map((description, i) =>
+      txn({ id: `cup-${i}`, amount: -3.2, description })
+    );
+    const found = findDuplicateCandidates(rows, { windowDays: 3 });
+
+    expect(found).toHaveLength(2);
+    expect(new Set(found.flatMap(c => [c.a.id, c.b.id])).size).toBe(4);
+  });
+
+  it('ignores archived rows in the wider rule too', () => {
+    const found = findDuplicateCandidates(
+      [
+        txn({ id: 'live', amount: -410, description: 'Nadia' }),
+        txn({ id: 'put-away', amount: -410, description: 'Standing Order', archived: true }),
+      ],
+      { windowDays: 3 }
+    );
+    expect(found).toEqual([]);
+  });
+
+  it('says nothing about two rows it could never offer to delete', () => {
+    // Two transfer legs of the same size a day apart is what a regular saver's
+    // register looks like. Neither can be deleted and their wording proves
+    // nothing, so there is no offer to make and nothing worth saying.
+    const found = findDuplicateCandidates(
+      [
+        txn({ id: 'leg-a', amount: -500, description: 'Transfer out', linkedTransferId: 'far-a' }),
+        txn({
+          id: 'leg-b',
+          amount: -500,
+          date: new Date('2026-05-02'),
+          description: 'Standing Order to SAVINGS',
+          linkedTransferId: 'far-b',
+        }),
+      ],
+      { windowDays: 3 }
+    );
+    expect(found).toEqual([]);
+  });
+
+  it('still offers a blocked row when the other copy CAN go', () => {
+    // The leg is not consumed by a partner it could never be judged against:
+    // it keeps looking, and pairs with the row that is actually deletable.
+    const found = findDuplicateCandidates(
+      [
+        txn({ id: 'leg-a', amount: -500, description: 'Transfer out', linkedTransferId: 'far-a' }),
+        txn({
+          id: 'leg-b',
+          amount: -500,
+          date: new Date('2026-05-02'),
+          description: 'Standing Order to SAVINGS',
+          linkedTransferId: 'far-b',
+        }),
+        txn({ id: 'plain', amount: -500, date: new Date('2026-05-03'), description: 'Nadia' }),
+      ],
+      { windowDays: 3 }
+    );
+    expect(keysOf(found)).toEqual(['leg-a+plain']);
+  });
+});
+
+describe('deleteRefusalFor — the gate every delete has to pass', () => {
+  const pairFoundByWording = (): DuplicateCandidate =>
+    oneOf(findDuplicateCandidates([txn({ id: 'feed' }), txn({ id: 'import' })], { windowDays: 3 }));
+
+  const pairFoundByMoneyAlone = (): DuplicateCandidate =>
+    oneOf(findDuplicateCandidates(
+      [
+        txn({ id: 'renamed', amount: -410, description: 'Nadia' }),
+        txn({
+          id: 'as-imported',
+          amount: -410,
+          description: 'Immediate Faster Payment (Online) to B EXAMPLE 07-FEB-2027',
+        }),
+      ],
+      { windowDays: 3 }
+    ));
+
+  it('lets a pair whose wording agrees through exactly as it always did', () => {
+    const pair = pairFoundByWording();
+    expect(needsConfirmation(pair)).toBe(false);
+    // No new hoop: the confirmation the weaker tier needs is not asked of this
+    // one, and was never asked of it before the weaker tier existed.
+    expect(deleteRefusalFor(pair, pair.a, false)).toBeNull();
+    expect(deleteRefusalFor(pair, pair.b, false)).toBeNull();
+  });
+
+  it('refuses a pair found only on money and date until someone says otherwise', () => {
+    const pair = pairFoundByMoneyAlone();
+    expect(deleteRefusalFor(pair, pair.a, false)).toBe('not-confirmed');
+    expect(deleteRefusalFor(pair, pair.b, false)).toBe('not-confirmed');
+  });
+
+  it('refuses a row that is holding something together, confirmed or not', () => {
+    // Confirmation is about which PAIR; it can never buy a row out of the
+    // blocks that exist because deleting it would strand something else.
+    const leg = txn({ id: 'leg', amount: -410, description: 'Nadia', linkedTransferId: 'far' });
+    const pair: DuplicateCandidate = { ...pairFoundByMoneyAlone(), a: leg };
+    expect(deleteRefusalFor(pair, leg, true)).toBe('linked-transfer');
+    expect(deleteRefusalFor(pair, leg, false)).toBe('linked-transfer');
+  });
+
+  it('refuses a row that is not one of the two on offer', () => {
+    // The confirmation is about THIS pair. A row that is not in it has not been
+    // looked at by anybody, so it cannot borrow the answer.
+    const pair = pairFoundByWording();
+    expect(deleteRefusalFor(pair, txn({ id: 'someone-else' }), true)).toBe('not-one-of-the-pair');
   });
 });
 

--- a/src/utils/duplicateSweep.ts
+++ b/src/utils/duplicateSweep.ts
@@ -1,21 +1,55 @@
 import type { Transaction } from '../types';
 import { calculateSimilarity, findDuplicateGroups, type DuplicateThresholds } from './duplicateScan';
+import { descriptionSimilarity, exactPence } from './statementDuplicates';
 import { toDecimal } from './decimal';
 
 /**
  * The duplicate sweep: which rows look like the same payment recorded twice,
  * and which of them it is SAFE to delete.
  *
- * The scanning itself is duplicateScan's (date-window indexing, Levenshtein
- * short-circuits — the reason a 16,000-row history does not freeze the main
- * thread). This module adds the two things the scanner deliberately does not
- * know about:
+ * ── DETECTING AND DELETING ARE TWO DIFFERENT DECISIONS ──────────────────────
+ *
+ * They used to be one number. A pair surfaced only if date, amount AND
+ * description together scored 80; same day plus the exact amount contributes
+ * 70, so the description had to supply 33 of the remaining 30 — the two rows
+ * had to read alike. Against real data that finds the pairs whose wording was
+ * merely truncated by whatever wrote them, and misses every pair whose payee
+ * was renamed by hand. Renaming a payee to something you will recognise a year
+ * later is the commonest edit a person makes to their own register, so those
+ * misses are systematic, not unlucky.
+ *
+ * The score could not simply be lowered. This tool DELETES, and the incident
+ * the amount gate below exists for — £24.99 offered as a duplicate of £36.95 —
+ * is exactly what a loosened threshold costs. So the two decisions are split:
+ *
+ *   DETECTION uses the signal that survives an edited description: same
+ *   account, the same money to the exact penny, inside the date window. That
+ *   is the rule utils/statementDuplicates settled on for the OFX importer, and
+ *   this module borrows it rather than inventing a third variant — its exact
+ *   pence arithmetic (`exactPence`), its ranking signal
+ *   (`descriptionSimilarity`) and its strictly 1:1 greedy matching, which is
+ *   the property that stops two genuine same-day payments of equal size both
+ *   being flagged against one row.
+ *
+ *   DELETION keeps the old bar. A pair found only by the wider rule carries
+ *   basis 'amount-and-date' and is EVIDENCE, not proof: `deleteRefusalFor`
+ *   refuses it outright until a human has said, for that one pair, that these
+ *   two really are one payment. That refusal lives here, not in the screen —
+ *   the screen asks this module, and so would anything else that ever wanted
+ *   to delete on the sweep's say-so.
+ *
+ * Description similarity survives as ranking and confidence. It is never a
+ * gate again.
+ *
+ * ── WHAT THE SCAN STILL KNOWS THAT THE SCORER DOES NOT ──────────────────────
  *
  *  1. ONE ACCOUNT AT A TIME. Two equal, same-day, same-payee rows in DIFFERENT
  *     accounts are not a duplicate, they are a transfer — somebody else's job
  *     (utils/transferSweep), and offering to delete one would destroy half of a
  *     movement of money. Scanning per account is also strictly cheaper: the
- *     index is rebuilt over a fraction of the history each time.
+ *     index is rebuilt over a fraction of the history each time. Every account
+ *     is swept in one run; per account is how it works inside, not how the
+ *     user has to drive it.
  *
  *  2. WHETHER THE ROW CAN BE DELETED AT ALL. delete_transaction_atomic removes
  *     the row and reverses its balance, and stops there — it does not chase the
@@ -54,6 +88,19 @@ function amountsMatch(a: Transaction, b: Transaction): boolean {
  */
 const SIMILARITY_THRESHOLD = 80;
 
+/**
+ * How the pair was found, and therefore how far it may be trusted.
+ *
+ * 'description-agrees' — date, amount and wording all line up. What an import
+ *   landing on top of a bank feed looks like; near-certain, and deletable on
+ *   the same terms as before this tier existed.
+ * 'amount-and-date' — same account, same money to the exact penny, inside the
+ *   window, and the wording does NOT agree. Also what two genuine payments of
+ *   the same size look like, so it is evidence for a person to weigh, never
+ *   something a button may act on unseen.
+ */
+export type DuplicateBasis = 'description-agrees' | 'amount-and-date';
+
 /** Two rows in one account that look like the same movement recorded twice. */
 export interface DuplicateCandidate {
   /** The row the scan seeded the group with. */
@@ -64,6 +111,10 @@ export interface DuplicateCandidate {
   score: number;
   /** Whole/fractional days between the two dates. */
   daysApart: number;
+  /** Which rule found it — and so what has to happen before a delete. */
+  basis: DuplicateBasis;
+  /** 0–1 word overlap of the two descriptions. Ranking and display only. */
+  descriptionOverlap: number;
 }
 
 /**
@@ -77,6 +128,17 @@ export type DeleteBlock =
   | 'split-line-counterpart'
   /** A split parent: its lines go with it, and any leg among them is a transfer. */
   | 'split-parent';
+
+/**
+ * Why a delete cannot go ahead. The three DeleteBlocks are properties of the
+ * ROW; the other two are properties of the request.
+ */
+export type DeleteRefusal =
+  | DeleteBlock
+  /** Found by the wider rule, and nobody has yet said the two are one payment. */
+  | 'not-confirmed'
+  /** The row asked for is not one of this pair's two copies. */
+  | 'not-one-of-the-pair';
 
 const DAY_MS = 1000 * 60 * 60 * 24;
 
@@ -95,7 +157,147 @@ export function deleteBlockOf(transaction: Transaction): DeleteBlock | null {
 }
 
 /**
- * Candidate duplicates across the whole history, account by account.
+ * True when the pair is evidence rather than proof, and a person has to say so
+ * before either copy can go.
+ */
+export function needsConfirmation(candidate: DuplicateCandidate): boolean {
+  return candidate.basis === 'amount-and-date';
+}
+
+/**
+ * THE DELETE GATE. Why deleting `chosen` out of this pair cannot go ahead, or
+ * null when it can.
+ *
+ * Everything that decides whether a row may be destroyed is in this one
+ * function, so a screen cannot widen it by forgetting a check and no future
+ * bulk action can route around it: `confirmed` has to be a deliberate answer
+ * about THIS pair, which is precisely what a bulk action cannot supply.
+ */
+export function deleteRefusalFor(
+  candidate: DuplicateCandidate,
+  chosen: Transaction,
+  confirmed: boolean
+): DeleteRefusal | null {
+  if (chosen.id !== candidate.a.id && chosen.id !== candidate.b.id) return 'not-one-of-the-pair';
+  const block = deleteBlockOf(chosen);
+  if (block !== null) return block;
+  if (needsConfirmation(candidate) && !confirmed) return 'not-confirmed';
+  return null;
+}
+
+/** One row of the wider pass, with its date and its delete block read once. */
+interface DatedRow {
+  txn: Transaction;
+  time: number;
+  deletable: boolean;
+}
+
+function candidateOf(
+  a: Transaction,
+  b: Transaction,
+  basis: DuplicateBasis,
+  thresholds: DuplicateThresholds
+): DuplicateCandidate {
+  return {
+    a,
+    b,
+    score: calculateSimilarity(a, b, thresholds).totalScore,
+    daysApart: Math.abs(new Date(a.date).getTime() - new Date(b.date).getTime()) / DAY_MS,
+    basis,
+    descriptionOverlap: descriptionSimilarity(a.description, b.description),
+  };
+}
+
+/**
+ * The wider rule, over one account: same money to the exact penny, dates
+ * within the window, whatever the two rows say.
+ *
+ * Strictly 1:1 and greedy, exactly as findStatementDuplicates is and for the
+ * same reason: two £20 cash withdrawals on one day are a real thing, and
+ * pairing every equal row with every other would flag both of them. Each row
+ * is claimed at most once, so n equal rows in a window yield at most n/2 pairs.
+ *
+ * A pair in which NEITHER row may be deleted is never formed. In the tier
+ * above, a refusal is still worth showing — the wording agreeing is itself
+ * evidence the user should see. Here there is no such evidence and no action
+ * to offer, so two regular equal transfers a few days apart would be pure
+ * noise burying the pairs that can actually be settled. A blocked row is still
+ * a perfectly good OTHER side, so it keeps looking for a deletable partner
+ * instead of being consumed by one it could never be judged against.
+ *
+ * Rows are bucketed by exact pence and each bucket sorted oldest-first, then
+ * scanned FORWARDS only. That is sound, not a shortcut: a row is reached
+ * unclaimed only if every earlier row in its bucket either paired off or had
+ * no eligible partner in its (symmetric) window, so the only partner that can
+ * lie behind it is one that was ineligible then and is ineligible now — a
+ * second blocked row, whose pair is exactly the one dropped above. The scan
+ * therefore costs what the window holds, not what the bucket holds: the same
+ * discipline that keeps duplicateScan off the main thread on a 16,000-row
+ * history.
+ */
+function pairOnAmountAndDate(
+  rows: Transaction[],
+  thresholds: DuplicateThresholds
+): DuplicateCandidate[] {
+  const dated: DatedRow[] = [];
+  for (const txn of rows) {
+    const time = new Date(txn.date).getTime();
+    // A row whose date cannot be read is a duplicate of nothing: it has no
+    // position on the calendar to compare, and guessing one would pair it with
+    // whatever happened to share its amount.
+    if (Number.isFinite(time)) dated.push({ txn, time, deletable: deleteBlockOf(txn) === null });
+  }
+  dated.sort((a, b) => a.time - b.time || a.txn.id.localeCompare(b.txn.id));
+
+  const byPence = new Map<number, DatedRow[]>();
+  for (const row of dated) {
+    const key = exactPence(row.txn.amount);
+    const bucket = byPence.get(key);
+    if (bucket) bucket.push(row);
+    else byPence.set(key, [row]);
+  }
+
+  const windowMs = thresholds.dateThreshold * DAY_MS;
+  const claimed = new Set<string>();
+  const pairs: DuplicateCandidate[] = [];
+
+  for (const bucket of byPence.values()) {
+    for (let i = 0; i < bucket.length; i++) {
+      const row = bucket[i];
+      if (claimed.has(row.txn.id)) continue;
+
+      let best: DatedRow | null = null;
+      let bestGap = Number.POSITIVE_INFINITY;
+      let bestOverlap = -1;
+      for (let j = i + 1; j < bucket.length && bucket[j].time - row.time <= windowMs; j++) {
+        const other = bucket[j];
+        if (claimed.has(other.txn.id)) continue;
+        if (!row.deletable && !other.deletable) continue;
+        const gap = other.time - row.time;
+        const overlap = descriptionSimilarity(row.txn.description, other.txn.description);
+        // Nearest date wins; wording breaks ties, so when several rows are
+        // eligible the most plausible pairing is the one offered.
+        if (gap < bestGap || (gap === bestGap && overlap > bestOverlap)) {
+          best = other;
+          bestGap = gap;
+          bestOverlap = overlap;
+        }
+      }
+      if (!best) continue;
+
+      claimed.add(row.txn.id);
+      claimed.add(best.txn.id);
+      pairs.push(candidateOf(row.txn, best.txn, 'amount-and-date', thresholds));
+    }
+  }
+
+  return pairs;
+}
+
+/**
+ * Candidate duplicates across the whole history, account by account, in both
+ * tiers: the pairs whose wording agrees first, then the pairs the wider rule
+ * found among the rows those left behind.
  *
  * Archived rows are excluded: they are out of the live register by the user's
  * own choice, still counted in every balance, and offering to delete one would
@@ -105,6 +307,11 @@ export function deleteBlockOf(transaction: Transaction): DeleteBlock | null {
  * A/B and A/C — not as three. Deleting A leaves B and C, and the next scan
  * offers B/C: one decision at a time, each with both of its rows in front of
  * the user.
+ *
+ * The wider pass runs only over rows the first tier did not pair off, the same
+ * way transferSweep's split-line pass runs over what its pair pass left. So
+ * every pair the sweep offered before this tier existed is exactly the pair it
+ * offers now, and no row is argued about twice in one run.
  */
 export function findDuplicateCandidates(
   transactions: Transaction[],
@@ -127,21 +334,23 @@ export function findDuplicateCandidates(
   const candidates: DuplicateCandidate[] = [];
   for (const rows of byAccount.values()) {
     if (rows.length < 2) continue;
+
+    const paired = new Set<string>();
     for (const group of findDuplicateGroups(rows, thresholds)) {
       for (const other of group.potential) {
         // The amount gate comes FIRST — before date, description or score. Two
         // rows that are not the same money are not the same payment, however
         // alike they read.
         if (!amountsMatch(group.original, other)) continue;
-        candidates.push({
-          a: group.original,
-          b: other,
-          score: calculateSimilarity(group.original, other, thresholds).totalScore,
-          daysApart: Math.abs(
-            new Date(group.original.date).getTime() - new Date(other.date).getTime()
-          ) / DAY_MS,
-        });
+        paired.add(group.original.id);
+        paired.add(other.id);
+        candidates.push(candidateOf(group.original, other, 'description-agrees', thresholds));
       }
+    }
+
+    const leftOver = paired.size > 0 ? rows.filter(row => !paired.has(row.id)) : rows;
+    if (leftOver.length > 1) {
+      candidates.push(...pairOnAmountAndDate(leftOver, thresholds));
     }
   }
   return candidates;

--- a/src/utils/statementDuplicates.ts
+++ b/src/utils/statementDuplicates.ts
@@ -27,11 +27,14 @@
  * payees to something they will recognise a year later ("Nadia"). Requiring the
  * two to agree, or even to be similar, misses most true duplicates.
  *
- * The register's own duplicate sweep (utils/duplicateSweep) scores description
- * similarity into a weighted total and needs 80: the truncated pairs clear it,
- * the renamed ones cannot, and no threshold that would catch them is safe in a
- * tool that DELETES. Here the consequence is "not added", which is why this
- * rule can be the wider one — and why what it finds is offered for review.
+ * The register's own duplicate sweep (utils/duplicateSweep) hit the same wall
+ * and now answers it the same way. Its weighted score needs 80: the truncated
+ * pairs clear that, the renamed ones never can, and no threshold that would
+ * catch them is safe in a tool that DELETES. So it runs the rule below as a
+ * second, wider pass over the rows the score left behind, and keeps what that
+ * finds in a separate tier — evidence for a human to confirm, never something
+ * a button can act on unseen. Here the consequence is only "not added", which
+ * is why this file can lead with the wider rule.
  *
  * THE RULE
  * --------
@@ -136,8 +139,17 @@ export function readFitId(notes: string | null | undefined): string | null {
   return match ? match[1] : null;
 }
 
-/** Exact pence — Decimal in, integer out. No float arithmetic on money. */
-const pence = (amount: number): number => toDecimal(amount).times(100).round().toNumber();
+/**
+ * Exact pence — Decimal in, integer out. No float arithmetic on money.
+ *
+ * Exported because the register's own sweep (utils/duplicateSweep) applies the
+ * same wider rule to a single account's history, and "the same money" has to
+ * mean bit-for-bit the same thing in both places: two modules each rounding
+ * their own way is how £10.005 becomes a duplicate in one tool and not the
+ * other.
+ */
+export const exactPence = (amount: number): number =>
+  toDecimal(amount).times(100).round().toNumber();
 
 /** Midnight UTC of the row's calendar day, or NaN when the date is unusable. */
 const dayOf = (value: Date | string | number | null | undefined): number => {
@@ -233,7 +245,7 @@ export function findStatementDuplicates(
     // A row whose date cannot be read is a duplicate of nothing: it has no
     // position on the calendar to compare, and guessing one would pair it with
     // whatever happened to share its amount.
-    if (Number.isFinite(day)) push(byAmount, String(pence(row.amount)), { row, day });
+    if (Number.isFinite(day)) push(byAmount, String(exactPence(row.amount)), { row, day });
   }
 
   /** Held ids already accounted for. Each may explain at most one file row. */
@@ -272,7 +284,7 @@ export function findStatementDuplicates(
     let best: HeldCandidate | null = null;
     let bestGap = Number.POSITIVE_INFINITY;
     let bestSimilarity = -1;
-    for (const candidate of byAmount.get(String(pence(row.amount))) ?? []) {
+    for (const candidate of byAmount.get(String(exactPence(row.amount))) ?? []) {
       if (claimed.has(candidate.row.id)) continue;
       const gap = Math.abs(candidate.day - day) / MS_PER_DAY;
       if (gap > tolerance) continue;

--- a/tsconfig.api.json
+++ b/tsconfig.api.json
@@ -1,0 +1,24 @@
+{
+  "compilerOptions": {
+    "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.api.tsbuildinfo",
+    "target": "ES2022",
+    "lib": ["ES2023"],
+    "module": "ESNext",
+    "skipLibCheck": true,
+
+    "moduleResolution": "bundler",
+    "verbatimModuleSyntax": false,
+    "moduleDetection": "force",
+    "noEmit": true,
+    "types": ["node"],
+
+    "strict": true,
+    "noUnusedLocals": false,
+    "noUnusedParameters": false,
+    "erasableSyntaxOnly": true,
+    "noFallthroughCasesInSwitch": true,
+    "noUncheckedSideEffectImports": false,
+    "esModuleInterop": true
+  },
+  "include": ["api"]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,6 +2,7 @@
   "files": [],
   "references": [
     { "path": "./tsconfig.app.json" },
-    { "path": "./tsconfig.node.json" }
+    { "path": "./tsconfig.node.json" },
+    { "path": "./tsconfig.api.json" }
   ]
 }


### PR DESCRIPTION
Five defects that had each been noticed, written down, and deferred as out of scope — which is how a list of known-broken things never becomes anyone's work. No migration in this batch.

## A duplicate the sweep could not see

The register's duplicate sweep scored date, amount and description together and needed **80** to surface a pair. Same day plus exact amount contributes 70, so the description had to supply a third of the total — which it cannot when a payee has been renamed or an older row arrived truncated. **Two of five real shapes were invisible, and they were the ones most worth finding.**

Detection and deletion were one decision and are now two:

- **Detection** uses what survives an edit — same account, exact pence, inside the date window
- **Deletion** keeps the bar it had

A pair found only by the wider rule is **evidence, not proof**. It sits in its own section stating what it actually knows (*"not one word in common"*), and neither copy can be deleted until someone confirms that specific pair. **The gate lives in the util, not the button** — a `disabled` attribute only stops a mouse, and there's a test that strips it, clicks, and asserts nothing was deleted. Another test fails if anyone ever adds a bulk control.

The threshold and the penny gate are untouched, and there's now a second test proving the wider rule cannot reach the pair that caused a past incident.

All five shapes are now found — the two new ones score **below 80**, proving detection no longer runs through the delete threshold.

## A statement lost to one unreadable row

Found while routing a second parser through the shared one. The OFX reader took the amount with `toDecimal`, which **throws** on anything it cannot parse — so a single malformed tag aborted the entire import and the statement was lost.

Ten lines below, the balance reader documents that exact hazard and avoids it. The amount reader never got the same treatment.

Amounts now go through the same forgiving reader, and rows that cannot be read are **skipped and counted**. They were previously dropped in silence, which for a statement import leaves a register that will not reconcile and nothing to explain why.

## A second OFX parser nobody had looked at

The legacy import had its own inline parser, so it got none of the recent work. Reading it turned up more than expected:

- It put the OFX **transaction type into the category field**, so every row it imported was filed under a category that does not exist
- It preferred the bank's channel label over the payment's own description
- It read the **first** balance in the file, which on a card is the remaining credit rather than the debt

It now uses the shared service. **The modal stays** — it is the only route to the old Money binary formats, and creating an account from the file is the point of a legacy importer. Its notice about duplicates is now conditional, because it is true for OFX and still true for the rest.

## An import that did nothing

MS Money import in local mode wrote to `localStorage` while every reader uses IndexedDB.

It survived because the adapter falls back to localStorage when IndexedDB holds nothing *and* migration has not completed — and nothing calls `init()`. So it worked on a virgin browser and did nothing forever after. Its tests asserted the same wrong layer, which is why nobody noticed.

Now one atomic write through the adapter: a migration that emptied the budgets and failed before the transactions landed would leave a ledger nobody could reconcile.

## Serverless handlers nobody type-checked

`api/` was in no tsconfig, so `tsc` never saw it and type errors surfaced at deploy. It is now its own project in the build, with **no DOM lib**, so a browser global in a handler fails the build instead of production.

**No pre-existing errors.** The handlers previously checked by hand really were correct — stated plainly rather than manufacturing findings. Proven by injecting a real type error and watching the old gate pass in silence.

## A figure you could not take back

A bank balance could be overwritten but never cleared, so anyone who recorded a wrong one was stuck asserting a stale comparison. It can now be removed, and **the recorded date goes with it** — a date describing a balance that no longer exists would go on refusing newer statements as stale.

## Verification

- Lint clean, strict typecheck clean **now covering `api/`**
- **4,273 tests passing**; coverage 69.71% statements / 79.65% branches (floors 63 / 55)
- Every fix carries a break-it/watch-it-fail/restore proof
- No real financial data in any fixture

**Not verified in a browser**: the new Remove control has Safari-specific focus handling (Safari does not focus buttons on click, so the blur would otherwise unmount it before the click landed). jsdom drives the real click/blur/`relatedTarget` paths but does not model that behaviour — worth a human eyeball in Safari.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
