### PR TITLE
chore(smoke): make absent Supabase credentials fatal in CI, skippable locally

### DIFF
--- a/docs/development-workflow.md
+++ b/docs/development-workflow.md
@@ -55,6 +55,19 @@ npm run test:supabase-smoke
 
 The helper loads `.env.test.local` / `.env.test` / `.env.local`, validates the required keys, and runs the Supabase Vitest battery under the Node environment. If no smoke suites are present it logs a warning and exits gracefully.
 
+### When the credentials are absent
+
+Behaviour depends on where it runs, because the two cases mean different things:
+
+| | Missing credentials |
+| --- | --- |
+| **CI** (`CI` is set) | **Hard failure, exit 1.** The live-infra safety net must never degrade quietly to green — this job once reported success for months with no service-role key. |
+| **Local** | **Skipped, exit 0**, with a prominent warning and `Status: SKIPPED` in the run log. |
+
+Credentials are optional locally on purpose. `.env.test.local` is git-ignored, so it does **not** exist in a fresh clone or in any new `git worktree`; hard-failing there blocked every push from those checkouts, which pushed people towards `--no-verify` or towards copying live keys between directories. Both are worse than skipping a check the nightly workflow runs against real infrastructure anyway.
+
+The skip is never silent: it prints on every push and is recorded in the log, so it cannot masquerade as a pass. To run the suite locally, create `.env.test.local` using the key names in `.env.example`. To reproduce the CI behaviour, set `CI=true`.
+
 Each run writes a timestamped log to `logs/supabase-smoke/<ISO>_supabase-smoke.log` (plus `latest.log`), and the nightly GitHub workflow uploads the artifact so failures can be audited without digging through Actions logs.
 
 **Status**: ✅ **Operational** (2025-10-29) – `src/test/supabase/supabase-smoke.test.ts` seeds a profile + account, writes a transaction via the service role, verifies it via the anon client, asserts anon deletes are blocked by RLS, and cleans up. A dedicated workflow (`.github/workflows/supabase-smoke.yml`) runs nightly and on demand when the following repository secrets are present:

--- a/scripts/run-supabase-smoke.mjs
+++ b/scripts/run-supabase-smoke.mjs
@@ -10,6 +10,11 @@ const matcher = /supabase/i;
 const logDir = path.join(rootDir, 'logs', 'supabase-smoke');
 const timestamp = new Date();
 
+// Whether absent credentials are fatal. GitHub Actions and effectively every
+// other runner set CI=true; set it by hand to reproduce the CI behaviour
+// locally. Anything other than an explicit 'false' counts as CI.
+const isCI = Boolean(process.env.CI) && process.env.CI !== 'false';
+
 function loadEnvFile(filePath) {
   try {
     const content = readFileSync(filePath, 'utf8');
@@ -101,16 +106,53 @@ if (!process.env.SUPABASE_SERVICE_ROLE_KEY && !process.env.VITE_SUPABASE_SERVICE
   missingKeys.push('SUPABASE_SERVICE_ROLE_KEY');
 }
 if (missingKeys.length > 0) {
-  console.error('[supabase-smoke] Missing required env vars:', missingKeys.join(', '));
-  console.error('[supabase-smoke] Provide them in your shell or .env.test.local before running.');
+  // In CI, absent credentials are a real failure and must stay loud. This job
+  // once silently skipped for months because SUPABASE_SERVICE_ROLE_KEY was
+  // unset, reporting success the whole time — see .github/workflows/supabase-smoke.yml.
+  if (isCI) {
+    console.error('[supabase-smoke] Missing required env vars:', missingKeys.join(', '));
+    console.error('[supabase-smoke] Running in CI, where this is a hard failure — the live-infra');
+    console.error('[supabase-smoke] safety net cannot silently degrade to green.');
+    await writeLog({
+      status: 'FAILED',
+      note: `Missing env vars in CI: ${missingKeys.join(', ')}`,
+      stdout: '',
+      stderr: '',
+      tests: []
+    });
+    process.exit(1);
+  }
+
+  // Locally, these credentials are optional. Hard-failing here blocked every
+  // push from any checkout without .env.test.local — including every fresh git
+  // worktree — which pushed people towards `--no-verify` or towards copying
+  // live keys between directories. Both are worse than skipping a check that
+  // the nightly workflow runs against real infrastructure anyway.
+  //
+  // Skipped, not silent: this prints on every push and is recorded as SKIPPED
+  // in the log, so it can never masquerade as a passing run.
+  console.warn('');
+  console.warn('  ┌─────────────────────────────────────────────────────────────────┐');
+  console.warn('  │  SUPABASE SMOKE SKIPPED — no credentials in this checkout        │');
+  console.warn('  └─────────────────────────────────────────────────────────────────┘');
+  console.warn(`  Missing: ${missingKeys.join(', ')}`);
+  console.warn('  These tests run against live Supabase, so they need real values.');
+  console.warn('');
+  console.warn('  To run them here, create .env.test.local in this directory');
+  console.warn('  (git-ignored) using the key names in .env.example.');
+  console.warn('');
+  console.warn('  Skipping locally. The nightly Supabase Smoke workflow still runs');
+  console.warn('  this against real infrastructure with CI secrets, and fails loudly');
+  console.warn('  if they are absent.');
+  console.warn('');
   await writeLog({
-    status: 'FAILED',
-    note: `Missing env vars: ${missingKeys.join(', ')}`,
+    status: 'SKIPPED',
+    note: `Missing env vars locally (not CI): ${missingKeys.join(', ')}`,
     stdout: '',
     stderr: '',
     tests: []
   });
-  process.exit(1);
+  process.exit(0);
 }
 
 process.env.RUN_SUPABASE_REAL_TESTS = 'true';


### PR DESCRIPTION
The pre-push hook runs the Supabase smoke, which hard-failed whenever credentials were missing. `.env.test.local` is git-ignored, so it does **not** exist in a fresh clone or in any new `git worktree` — meaning **those checkouts could not push at all**.

The two ways out were `--no-verify`, or copying live keys between directories. The second is the habit that leaked keys in the first place.

### Absent credentials now mean different things in different places

| | Behaviour |
| --- | --- |
| **CI** (`CI` set) | Unchanged **hard failure**, exit 1 |
| **Local** | **Skipped**, exit 0 |

CI stays loud on purpose: per the comment in `supabase-smoke.yml`, this job once reported success for months with no service-role key. The live-infra safety net must never quietly go green.

### The skip is not silent

It prints a boxed warning on every push and records `Status: SKIPPED` plus the missing keys in the run log, so it cannot be mistaken for a pass. `CI=true` reproduces the CI behaviour locally.

```
  ┌─────────────────────────────────────────────────────────────────┐
  │  SUPABASE SMOKE SKIPPED — no credentials in this checkout        │
  └─────────────────────────────────────────────────────────────────┘
  Missing: VITE_SUPABASE_URL, VITE_SUPABASE_ANON_KEY, SUPABASE_SERVICE_ROLE_KEY
```

### No PR coverage is lost

The smoke only ever runs **nightly** and from this hook — the required `quality-gates` check does not include it. So skipping locally does not remove coverage that existed on PRs.

### Verified — all four combinations

| Environment | Credentials | Result |
| --- | --- | --- |
| local | absent | skipped, exit 0, log `Status: SKIPPED` |
| `CI=true` | absent | failed, exit 1 |
| local | present | ran, 2 tests passed, exit 0 |
| `CI=true` | present | ran, exit 0 |

**This PR was pushed from a worktree with no credentials** — which was impossible before it.

- `npm run lint` — silent
- `npm run typecheck:strict` — clean
- `npm run test:smoke` — 267 files, 4236 tests passed, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)