### PR TITLE
feat(local-core+register): the ledger core complete, and the Money edit row

### DIFF
--- a/crates/wealth-core/src/backup.rs
+++ b/crates/wealth-core/src/backup.rs
@@ -1,0 +1,1157 @@
+//! The backup format, and how one of its rows becomes a row in this file.
+//!
+//! # What this module is a port of, and what it deliberately is not
+//!
+//! It is the translation half of `restore_user_chunk`
+//! (`supabase/migrations/20260807083000_user_data_restore.sql:230-374`) — the
+//! part that takes *whole rows* out of a backup and puts them in a table.
+//!
+//! It is **not** a port of `backupService.remapBackupIds`. That runs on the
+//! CLIENT, before a single row is sent, and the RPCs insert what they are handed
+//! verbatim (`:279-294` re-owns and strips columns; it never touches an `id`).
+//! The boundary matters enough to state twice: **ids arrive already remapped, or
+//! they do not arrive remapped at all.** Nothing here invents an id, rewrites a
+//! reference or resolves a dangling one, because the function it ports does none
+//! of those things — and a Rust copy of the remapper would be a second
+//! implementation of a rule the TypeScript already owns, drifting from it the
+//! first time a column is added.
+//!
+//! # The column list is not written twice
+//!
+//! The cloud hands each row to `jsonb_populate_recordset` against the table's own
+//! rowtype rather than naming columns, and the migration explains why at length:
+//! *"Naming them was the first draft and it was wrong within the hour"*. SQLite
+//! has no such facility, so the names are written down here — once, in one table
+//! per entity, with the cloud's key on the left and this schema's column on the
+//! right. That table IS the map between the two schemas, and it is the only
+//! place either name appears.
+//!
+//! Every column name in an INSERT built here comes from a `&'static str` in that
+//! table. No caller value is ever concatenated into SQL; values travel as bound
+//! parameters. DESIGN.md §6.4's *"you cannot bypass what does not exist"* holds
+//! through the one verb that takes arbitrary JSON.
+//!
+//! # Four things the cloud does that this must do differently
+//!
+//! 1. **Scale.** `numeric(20,2)` becomes `INTEGER` minor units, quantities and
+//!    prices become `_e8`, `alert_threshold` becomes basis points. Each is a
+//!    [`Kind`] and each is exact: a decimal string is scaled by integer
+//!    arithmetic and a value with more places than the column can hold is
+//!    REFUSED, never rounded ([`crate::money`] makes the same choice for the same
+//!    reason).
+//! 2. **Arrays.** `transactions.tags` and `suggestion_dismissals.subject_ids` are
+//!    `text[]` and `uuid[]` in the cloud and child tables here. They are written
+//!    after their parent row, in the same transaction.
+//! 3. **Money in `metadata`.** DESIGN.md §5 divergence 9, *"the one most likely
+//!    to bite: it is a hard failure on real data"*. `transactions_no_money_in_metadata`
+//!    refuses eleven keys that a cloud backup legitimately carries. Four have a
+//!    typed home and are PROMOTED into it; the other eight are dropped and every
+//!    drop is REPORTED. See [`strip_metadata_money`].
+//! 4. **Absent keys.** The cloud refuses a row missing any NOT NULL key, because
+//!    `jsonb_populate_recordset` supplies SQL NULL rather than the column's
+//!    default — MEASURED: a row with no `low_balance_alert_enabled` is refused
+//!    even though the column has a default. Here an absent (or JSON null) key
+//!    simply omits the column, so the local default applies where there is one
+//!    and the NOT NULL fires where there is not. The set of rows refused is
+//!    therefore SMALLER locally, and the difference is reachable only from a
+//!    hand-edited file: both exporters in this repo write whole rows, which is
+//!    the contract the migration states. The columns that carry meaning — `name`,
+//!    `amount`, `date`, `description`, `account_id` — have no default on either
+//!    engine and are refused on both.
+//!
+//! # Unknown keys are ignored, because they are ignored in the cloud
+//!
+//! MEASURED: `jsonb_populate_recordset` silently discards a key that is not a
+//! column. A row carrying `a_column_that_does_not_exist` inserts fine. So does
+//! one here. That is not a preference — a stricter local reading would refuse
+//! files the cloud accepts, including every backup taken before a column was
+//! dropped.
+//!
+//! All examples in this file are invented.
+
+use std::collections::BTreeSet;
+
+use rusqlite::types::Value as SqlValue;
+use rusqlite::{Connection, ToSql};
+use serde::{Deserialize, Serialize};
+use serde_json::{Map, Value};
+
+use crate::error::{CoreError, CoreResult};
+
+/// One row out of a backup file: the whole JSON object, keys as the cloud
+/// spells them.
+pub type BackupRow = Map<String, Value>;
+
+/// Something the file carried that this ledger has nowhere to keep.
+///
+/// Reported rather than lost in silence. The cloud produces none of these — it
+/// has the column, or it has no constraint — so a spec that provokes one
+/// declares the divergence.
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct Dropped {
+    /// Which table the row was going into.
+    pub entity: String,
+    /// The row's own id, as the file spells it.
+    pub id: String,
+    /// What was dropped, and why it had nowhere to go.
+    pub what: String,
+}
+
+// ── Scales ──────────────────────────────────────────────────────────────────
+
+/// How a JSON value becomes a column value.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Kind {
+    /// TEXT, verbatim. Ids, names, enumerations, currency codes.
+    Text,
+    /// `boolean` → `INTEGER` 0/1. Accepts what Postgres's boolean cast accepts,
+    /// through [`crate::wire::Flag`], so `"true"` works as well as `true`.
+    Flag,
+    /// `integer` → `INTEGER`. `statement_sequence`, `sort_order`, `role_order`.
+    Ordinal,
+    /// A decimal scaled by a power of ten: money (2), quantity and price (8),
+    /// `alert_threshold` as basis points (2). More places than the scale can
+    /// hold is a refusal, never a rounding.
+    Scaled(u32),
+    /// A calendar day, `YYYY-MM-DD`.
+    Date,
+    /// An instant, normalised to the shape this schema's column defaults use.
+    Timestamp,
+    /// A JSON document, stored as TEXT.
+    Json,
+}
+
+/// One column of one entity: the key the file uses, the column this file has,
+/// and how to get from one to the other.
+#[derive(Debug, Clone, Copy)]
+pub struct Column {
+    /// The key in the backup row — the cloud's column name.
+    pub key: &'static str,
+    /// The column in `schema.sql`.
+    pub column: &'static str,
+    /// The conversion.
+    pub kind: Kind,
+}
+
+const fn text(key: &'static str) -> Column {
+    Column { key, column: key, kind: Kind::Text }
+}
+const fn flag(key: &'static str) -> Column {
+    Column { key, column: key, kind: Kind::Flag }
+}
+const fn ordinal(key: &'static str) -> Column {
+    Column { key, column: key, kind: Kind::Ordinal }
+}
+const fn date(key: &'static str) -> Column {
+    Column { key, column: key, kind: Kind::Date }
+}
+const fn stamp(key: &'static str) -> Column {
+    Column { key, column: key, kind: Kind::Timestamp }
+}
+const fn json(key: &'static str) -> Column {
+    Column { key, column: key, kind: Kind::Json }
+}
+/// `numeric(20,2)` → `_minor`.
+const fn money(key: &'static str, column: &'static str) -> Column {
+    Column { key, column, kind: Kind::Scaled(2) }
+}
+/// `numeric(20,8)` → `_e8`.
+const fn eight(key: &'static str, column: &'static str) -> Column {
+    Column { key, column, kind: Kind::Scaled(8) }
+}
+
+// ── The column maps ─────────────────────────────────────────────────────────
+//
+// One `const` per entity, and each is the map between two schemas: the cloud's
+// key on the left of every entry, this file's column on the right. They are
+// items rather than array literals inside the match because a `const fn` cannot
+// hand out a reference to a temporary — and `columns()` stays `const` so the
+// match is exhaustive at compile time, which is canonical invariant #125: a new
+// backup entity without a recorded storage decision does not build.
+
+        // `plaid_account_id` and `plaid_connection_id` are absent on
+        // purpose: the RPC strips both (`:282`) because they are GLOBALLY
+        // unique and restoring them collides with whoever exported the file.
+        // This schema has no such columns at all, so the strip is structural.
+        // `parent_account_id` is absent for the other reason — it is
+        // deferred to `finalize_user_restore`, which is where the cycle
+        // closes.
+const ACCOUNTS: &[Column] = &[
+            text("id"),
+            text("name"),
+            text("type"),
+            text("currency"),
+            money("balance", "balance_minor"),
+            money("initial_balance", "initial_balance_minor"),
+            money("bank_balance", "bank_balance_minor"),
+            date("bank_balance_date"),
+            date("last_reconciled_date"),
+            flag("low_balance_alert_enabled"),
+            money("low_balance_threshold", "low_balance_threshold_minor"),
+            date("opening_balance_date"),
+            date("archive_through_date"),
+            text("institution"),
+            text("account_number"),
+            text("sort_code"),
+            text("icon"),
+            text("color"),
+            text("notes"),
+            flag("is_active"),
+            json("metadata"),
+            stamp("created_at"),
+            stamp("updated_at"),
+];
+
+const CATEGORIES: &[Column] = &[
+            text("id"),
+            text("name"),
+            text("type"),
+            text("level"),
+            text("parent_id"),
+            text("account_id"),
+            text("color"),
+            text("icon"),
+            flag("is_system"),
+            flag("is_transfer_category"),
+            flag("is_revaluation_category"),
+            flag("is_unassigned_bucket"),
+            flag("is_active"),
+            stamp("created_at"),
+            stamp("updated_at"),
+];
+
+        // `linked_transfer_id` and `linked_transfer_split_id` are absent:
+        // the RPC nulls both (`:288-289`) and finalize patches them.
+        // `connection_id`, `external_transaction_id` and `external_provider`
+        // are absent because the RPC strips them (`:285-286`) — this schema
+        // HAS those columns, kept so a cloud backup restores losslessly, and
+        // the strip is a decision rather than an accident of shape.
+        //
+        // `plaid_transaction_id` is stripped by the RPC and has no column
+        // here. `transactions.plaid_account_id` is the one the RPC does NOT
+        // strip — it survives a cloud restore and is dropped here for want of
+        // a column. Recorded because it is the only asymmetry in this list
+        // that is not deliberate on both sides.
+        //
+        // `fee_minor`, `original_amount_minor`, `original_currency` and
+        // `fx_rate_e10` are not here either: they have no key in the backup
+        // because the cloud keeps those figures in `metadata`. They are
+        // filled by [`strip_metadata_money`].
+const TRANSACTIONS: &[Column] = &[
+            text("id"),
+            text("account_id"),
+            text("description"),
+            money("amount", "amount_minor"),
+            text("type"),
+            date("date"),
+            text("category"),
+            text("category_id"),
+            text("notes"),
+            text("merchant_name"),
+            text("location_city"),
+            text("location_country"),
+            text("payment_channel"),
+            flag("is_recurring"),
+            flag("is_cleared"),
+            flag("is_split"),
+            flag("archived"),
+            ordinal("statement_sequence"),
+            flag("category_confirmed"),
+            text("transfer_account_id"),
+            text("import_source"),
+            text("import_source_id"),
+            json("metadata"),
+            stamp("created_at"),
+            stamp("updated_at"),
+];
+
+        // `linked_transfer_id` IS carried here, and that is the RPC's
+        // behaviour rather than an oversight: its re-owning CASE has no
+        // branch for `transaction_splits`, so the column travels. It
+        // resolves because splits are sent after transactions.
+const TRANSACTION_SPLITS: &[Column] = &[
+            text("id"),
+            text("transaction_id"),
+            text("category"),
+            money("amount", "amount_minor"),
+            text("memo"),
+            ordinal("sort_order"),
+            text("transfer_account_id"),
+            text("linked_transfer_id"),
+            stamp("created_at"),
+            stamp("updated_at"),
+];
+
+        // `alert_threshold` is numeric(5,2) meaning a percentage; this
+        // schema stores basis points of a percent, so 80.00% is 8000 —
+        // scale 2, the same integer arithmetic as money and not money.
+const BUDGETS: &[Column] = &[
+            text("id"),
+            text("name"),
+            money("amount", "amount_minor"),
+            text("period"),
+            text("category"),
+            text("category_id"),
+            date("start_date"),
+            date("end_date"),
+            money("spent", "spent_minor"),
+            flag("rollover"),
+            money("rollover_amount", "rollover_amount_minor"),
+            Column { key: "alert_threshold", column: "alert_threshold_bp", kind: Kind::Scaled(2) },
+            flag("is_active"),
+            text("notes"),
+            json("metadata"),
+            stamp("created_at"),
+            stamp("updated_at"),
+];
+
+const GOALS: &[Column] = &[
+            text("id"),
+            text("name"),
+            text("description"),
+            money("target_amount", "target_amount_minor"),
+            money("current_amount", "current_amount_minor"),
+            date("target_date"),
+            text("category"),
+            text("priority"),
+            text("status"),
+            text("account_id"),
+            text("contribution_frequency"),
+            flag("auto_contribute"),
+            text("icon"),
+            text("color"),
+            stamp("completed_at"),
+            json("metadata"),
+            stamp("created_at"),
+            stamp("updated_at"),
+];
+
+const GOAL_CONTRIBUTIONS: &[Column] = &[
+            text("id"),
+            text("goal_id"),
+            money("amount", "amount_minor"),
+            text("transaction_id"),
+            date("date"),
+            text("notes"),
+            stamp("created_at"),
+];
+
+        // THE PRICE FIX (DESIGN.md §3.2): the cloud stores unit prices at
+        // numeric(10,2) against quantities at numeric(20,8), so a fund
+        // priced at £12.345 cannot be written there. This schema stores them
+        // at 8 dp. A cloud→local restore is therefore EXACT and a local→cloud
+        // export would round — declared divergence 4.
+const INVESTMENTS: &[Column] = &[
+            text("id"),
+            text("account_id"),
+            text("symbol"),
+            text("name"),
+            text("asset_type"),
+            text("exchange"),
+            text("currency"),
+            eight("quantity", "quantity_e8"),
+            money("cost_basis", "cost_basis_minor"),
+            eight("current_price", "current_price_e8"),
+            money("market_value", "market_value_minor"),
+            date("purchase_date"),
+            eight("purchase_price", "purchase_price_e8"),
+            stamp("last_updated"),
+            text("notes"),
+            stamp("created_at"),
+            stamp("updated_at"),
+];
+
+        // `tax_minor` has no key: the cloud has nowhere to keep stamp duty
+        // except `transactions.metadata.investmentData.stampDuty`, which
+        // belongs to a different row. It takes this schema's default of 0,
+        // which is the honest value for "the file did not say".
+const INVESTMENT_TRANSACTIONS: &[Column] = &[
+            text("id"),
+            text("investment_id"),
+            text("transaction_type"),
+            eight("quantity", "quantity_e8"),
+            eight("price", "unit_price_e8"),
+            money("total_amount", "total_amount_minor"),
+            money("fees", "fee_minor"),
+            date("date"),
+            text("notes"),
+            stamp("created_at"),
+];
+
+        // R-10. In the cloud `user_id` is TEXT against
+        // `user_profiles(clerk_user_id)`, which is why the RPC has to
+        // overwrite it a SECOND time with a Clerk id (`:337-346`). There is
+        // no Clerk here and the column is a plain `users(id)` foreign key, so
+        // the special case disappears — this entity is re-owned exactly like
+        // every other one, and `clerk_identity_unknown` has no local twin.
+const RECURRING_TRANSACTIONS: &[Column] = &[
+            text("id"),
+            text("account_id"),
+            text("description"),
+            money("amount", "amount_minor"),
+            text("type"),
+            text("category"),
+            text("frequency"),
+            date("start_date"),
+            date("end_date"),
+            date("next_date"),
+            flag("is_active"),
+            flag("auto_create"),
+            stamp("created_at"),
+            stamp("updated_at"),
+];
+
+const NOTIFICATIONS: &[Column] = &[
+            text("id"),
+            text("type"),
+            text("title"),
+            text("message"),
+            flag("is_read"),
+            text("action_label"),
+            text("action_url"),
+            stamp("created_at"),
+            stamp("updated_at"),
+];
+
+const DASHBOARD_LAYOUTS: &[Column] = &[
+            text("id"),
+            text("name"),
+            json("widgets"),
+            flag("is_default"),
+            stamp("created_at"),
+            stamp("updated_at"),
+];
+
+const WIDGET_PREFERENCES: &[Column] = &[
+            text("id"),
+            text("widget_type"),
+            json("settings"),
+            flag("is_collapsed"),
+            stamp("last_refreshed"),
+            stamp("created_at"),
+            stamp("updated_at"),
+];
+
+        // `subject_ids` is a uuid[] in the cloud with a GIN index and a
+        // column comment PROMISING every id resolves. Here it is the child
+        // table `suggestion_dismissal_subjects`, where the promise is a
+        // foreign key — see [`insert_row`] for what happens to a subject the
+        // file names and the ledger does not have.
+const SUGGESTION_DISMISSALS: &[Column] = &[
+            text("id"),
+            text("kind"),
+            text("subject_key"),
+            stamp("dismissed_at"),
+];
+
+// ── The entities ────────────────────────────────────────────────────────────
+
+/// Everything `restore_user_chunk` will accept, spelled exactly as the RPC's
+/// `p_entity` branch list spells it.
+///
+/// The match in [`Entity::columns`] is exhaustive, which is canonical invariant
+/// #125 made structural: *"Every backup entity must have a recorded storage
+/// decision — a new table without one is a compile error."*
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum Entity {
+    /// Must be first in any restore: the emptiness precondition is checked here.
+    Accounts,
+    /// Sent level by level by the client, so `parent_id` always resolves.
+    Categories,
+    /// The ledger.
+    Transactions,
+    /// Split lines, after their parents.
+    TransactionSplits,
+    /// Budgets.
+    Budgets,
+    /// Goals.
+    Goals,
+    /// Contributions, after their goals.
+    GoalContributions,
+    /// Holdings.
+    Investments,
+    /// Holding movements, after their holdings.
+    InvestmentTransactions,
+    /// Templates. The cloud's odd one out; see [`Entity::columns`].
+    RecurringTransactions,
+    /// Carried so a cloud backup restores whole.
+    Notifications,
+    /// Carried so a cloud backup restores whole.
+    DashboardLayouts,
+    /// Carried so a cloud backup restores whole.
+    WidgetPreferences,
+    /// Carried so a cloud backup restores whole.
+    SuggestionDismissals,
+}
+
+impl Entity {
+    /// The table this entity is stored in.
+    #[must_use]
+    pub const fn table(self) -> &'static str {
+        match self {
+            Self::Accounts => "accounts",
+            Self::Categories => "categories",
+            Self::Transactions => "transactions",
+            Self::TransactionSplits => "transaction_splits",
+            Self::Budgets => "budgets",
+            Self::Goals => "goals",
+            Self::GoalContributions => "goal_contributions",
+            Self::Investments => "investments",
+            Self::InvestmentTransactions => "investment_transactions",
+            Self::RecurringTransactions => "recurring_transactions",
+            Self::Notifications => "notifications",
+            Self::DashboardLayouts => "dashboard_layouts",
+            Self::WidgetPreferences => "widget_preferences",
+            Self::SuggestionDismissals => "suggestion_dismissals",
+        }
+    }
+
+    /// The name `p_entity` carries. Same string on both engines.
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        self.table()
+    }
+
+    /// Resolve `p_entity`.
+    ///
+    /// # Errors
+    /// [`CoreError::Refused`] with the RPC's own `restore_entity_unknown`.
+    pub fn parse(name: &str) -> CoreResult<Self> {
+        let entity = match name {
+            "accounts" => Self::Accounts,
+            "categories" => Self::Categories,
+            "transactions" => Self::Transactions,
+            "transaction_splits" => Self::TransactionSplits,
+            "budgets" => Self::Budgets,
+            "goals" => Self::Goals,
+            "goal_contributions" => Self::GoalContributions,
+            "investments" => Self::Investments,
+            "investment_transactions" => Self::InvestmentTransactions,
+            "recurring_transactions" => Self::RecurringTransactions,
+            "notifications" => Self::Notifications,
+            "dashboard_layouts" => Self::DashboardLayouts,
+            "widget_preferences" => Self::WidgetPreferences,
+            "suggestion_dismissals" => Self::SuggestionDismissals,
+            other => {
+                return Err(CoreError::refuse(
+                    "restore_entity_unknown",
+                    &format!("\"{other}\" is not something this backup format carries"),
+                ))
+            }
+        };
+        Ok(entity)
+    }
+
+    /// Which columns this entity's rows land in, and how each is converted.
+    ///
+    /// Read off the two schemas side by side, not off memory. Where the two
+    /// disagree the disagreement is noted here rather than anywhere else.
+    #[must_use]
+    pub const fn columns(self) -> &'static [Column] {
+        match self {
+            Self::Accounts => ACCOUNTS,
+            Self::Categories => CATEGORIES,
+            Self::Transactions => TRANSACTIONS,
+            Self::TransactionSplits => TRANSACTION_SPLITS,
+            Self::Budgets => BUDGETS,
+            Self::Goals => GOALS,
+            Self::GoalContributions => GOAL_CONTRIBUTIONS,
+            Self::Investments => INVESTMENTS,
+            Self::InvestmentTransactions => INVESTMENT_TRANSACTIONS,
+            Self::RecurringTransactions => RECURRING_TRANSACTIONS,
+            Self::Notifications => NOTIFICATIONS,
+            Self::DashboardLayouts => DASHBOARD_LAYOUTS,
+            Self::WidgetPreferences => WIDGET_PREFERENCES,
+            Self::SuggestionDismissals => SUGGESTION_DISMISSALS,
+        }
+    }
+}
+
+// ── Reading a value ─────────────────────────────────────────────────────────
+
+/// The text of a JSON value, in the spelling `jsonb ->>` would produce.
+///
+/// Shares [`crate::wire::as_text`]'s decision so that a caller who has always
+/// sent `{"amount": -15}` keeps working: a number arrives as its own spelling,
+/// not as a float.
+fn as_text(value: &Value) -> Option<String> {
+    crate::wire::as_text(value)
+}
+
+/// Scale a decimal string by `10^places`, exactly.
+///
+/// `Money::parse` is the 2-place case and this is the same algorithm generalised,
+/// with the same three refusals. It is written here rather than in [`crate::money`]
+/// because quantities and prices are not money and must not acquire money's type.
+///
+/// # Errors
+/// A refusal code from [`crate::money::MoneyError`], so the codes a caller sees
+/// are the same whichever scale refused them.
+fn scale(text: &str, places: u32) -> Result<i64, crate::money::MoneyError> {
+    use crate::money::MoneyError;
+
+    let (negative, digits) = match text.strip_prefix('-') {
+        Some(rest) => (true, rest),
+        None => (false, text),
+    };
+    if digits.is_empty() || digits.matches('.').count() > 1 {
+        return Err(MoneyError::Malformed);
+    }
+    let mut parts = digits.splitn(2, '.');
+    let whole = parts.next().unwrap_or("");
+    let fraction = parts.next().unwrap_or("");
+    if whole.is_empty() && fraction.is_empty() {
+        return Err(MoneyError::Malformed);
+    }
+    if !whole.bytes().all(|b| b.is_ascii_digit()) || !fraction.bytes().all(|b| b.is_ascii_digit()) {
+        return Err(MoneyError::Malformed);
+    }
+    // Trailing zeros beyond the scale are not extra precision: "1.500" at scale 2
+    // is 150, and refusing it would refuse a value the file can express exactly.
+    let significant = fraction.trim_end_matches('0');
+    let width = usize::try_from(places).map_err(|_| MoneyError::OutOfRange)?;
+    if significant.len() > width {
+        return Err(MoneyError::SubMinorUnit);
+    }
+
+    let mut units: i64 = if whole.is_empty() {
+        0
+    } else {
+        whole.parse::<i64>().map_err(|_| MoneyError::OutOfRange)?
+    };
+    for _ in 0..places {
+        units = units.checked_mul(10).ok_or(MoneyError::OutOfRange)?;
+    }
+    let mut padded = String::from(significant);
+    while padded.len() < width {
+        padded.push('0');
+    }
+    if !padded.is_empty() {
+        let fractional = padded.parse::<i64>().map_err(|_| MoneyError::OutOfRange)?;
+        units = units.checked_add(fractional).ok_or(MoneyError::OutOfRange)?;
+    }
+    if negative {
+        units = units.checked_neg().ok_or(MoneyError::OutOfRange)?;
+    }
+    Ok(units)
+}
+
+/// A calendar day, `YYYY-MM-DD`.
+///
+/// Canonical invariant #124 / TS-X4, and its second sentence is the one that
+/// matters: *"a value already a day passes untouched"*. A day is passed through
+/// without being parsed, because `new Date('2026-01-15')` invents a UTC midnight
+/// and midnight belongs to a zone — which is how a transaction dated the 15th
+/// comes back as the 14th west of Greenwich. A longer value is truncated
+/// LEXICALLY, with no zone arithmetic at all, for the same reason.
+fn as_day(text: &str) -> Option<String> {
+    let day = text.get(..10)?;
+    if crate::wire::is_calendar_date(day) {
+        Some(day.to_owned())
+    } else {
+        None
+    }
+}
+
+/// An instant, in the exact shape this schema's column defaults produce.
+///
+/// SQLite does the conversion, not Rust, for the reason [`crate::db::now`] gives:
+/// a row written by a verb and a row written by a column default must be stamped
+/// by the same clock in the same format, and a second implementation would
+/// eventually drift from the first. MEASURED — `strftime('%Y-%m-%dT%H:%M:%fZ', ?)`
+/// against the shapes a backup can hold:
+///
+/// ```text
+/// 2019-01-01T00:00:00+00:00     -> 2019-01-01T00:00:00.000Z
+/// 2019-05-04T09:30:00.123+01:00 -> 2019-05-04T08:30:00.123Z
+/// 2019-01-01T00:00:00.000Z      -> 2019-01-01T00:00:00.000Z
+/// not a time                    -> NULL
+/// ```
+///
+/// The `+00:00` case is why this cannot be a string test: PostgREST renders
+/// `timestamptz` with a numeric offset, and `transactions_timestamps_shaped`
+/// requires the `Z`.
+fn as_instant(connection: &Connection, text: &str) -> CoreResult<Option<String>> {
+    Ok(connection.query_row(
+        "SELECT strftime('%Y-%m-%dT%H:%M:%fZ', ?1)",
+        [text],
+        |row| row.get::<_, Option<String>>(0),
+    )?)
+}
+
+// ── The metadata money strip ────────────────────────────────────────────────
+
+/// The eleven keys `transactions_no_money_in_metadata` refuses, and what becomes
+/// of each.
+///
+/// DESIGN.md §3.3 is the table this is a transcription of. Four have a typed home
+/// in this schema and are promoted into it; the rest are dropped, because the
+/// figures they carry belong to a row in another table entirely (a transaction
+/// carrying `investmentData.quantity` is an investment transaction written to the
+/// wrong table) or to a reconciliation design that `is_cleared` + `bank_balance`
+/// replaced.
+///
+/// **Every drop is reported.** The alternative — refusing the restore — was
+/// rejected: it would make a real cloud backup unrestorable with no way forward
+/// but hand-editing JSON, and DESIGN.md already decided these figures have no
+/// home. The alternative in the other direction — dropping them quietly — is the
+/// one thing a restore must never do with a number.
+const PROMOTED: [(&str, &str, u32); 4] = [
+    ("fees", "fee_minor", 2),
+    ("originalAmount", "original_amount_minor", 2),
+    ("exchangeRate", "fx_rate_e10", 10),
+    // Not money and not banned by the CHECK, but the FX triple is all-or-nothing
+    // (`transactions_fx_complete`), so the currency has to travel with the amount
+    // and the rate or none of the three can land.
+    ("originalCurrency", "original_currency", 0),
+];
+
+/// The banned keys with nowhere to go, and the sentence each drop reports.
+const DROPPED_KEYS: [(&str, &str); 7] = [
+    ("pricePerUnit", "a unit price belongs on the holding, not on a transaction"),
+    ("marketValue", "a market value belongs on the holding, not on a transaction"),
+    ("costBasis", "a cost basis belongs on the holding, not on a transaction"),
+    ("units", "a unit count belongs on the holding, not on a transaction"),
+    ("expectedAmount", "reconciliation is is_cleared and bank_balance now"),
+    ("actualAmount", "reconciliation is is_cleared and bank_balance now"),
+    ("discrepancy", "reconciliation is is_cleared and bank_balance now"),
+];
+
+/// What came out of one row's `metadata`.
+#[derive(Debug, Default)]
+pub struct MetadataStrip {
+    /// Column name → value, for the four promoted figures.
+    pub promoted: Vec<(&'static str, SqlValue)>,
+    /// What was thrown away, and why.
+    pub dropped: Vec<String>,
+}
+
+/// Lift the money out of a cloud `metadata` blob so the row can be stored.
+///
+/// Mutates the blob in place: after this returns, `metadata` contains none of the
+/// eleven keys and `transactions_no_money_in_metadata` is satisfied. Everything
+/// non-numeric — `transferType`, `reference`, `documentation`, the dates, the
+/// labels — is left exactly as the file had it.
+///
+/// # Errors
+/// [`CoreError::Refused`] if a promoted figure cannot be scaled: a rate with
+/// eleven decimal places, or an amount past `i64`. Those are refusals rather than
+/// drops because the figure DOES have a home and would be silently wrong in it.
+pub fn strip_metadata_money(metadata: &mut Value) -> CoreResult<MetadataStrip> {
+    let mut strip = MetadataStrip::default();
+
+    if let Some(investment) = metadata.get("investmentData") {
+        if !investment.is_null() {
+            strip.dropped.push(
+                "investmentData — a transaction carrying holding figures is an investment \
+                 transaction written to the wrong table"
+                    .to_owned(),
+            );
+        }
+    }
+    if let Some(object) = metadata.as_object_mut() {
+        object.remove("investmentData");
+    }
+
+    let Some(transfer) = metadata.get_mut("transferMetadata").and_then(Value::as_object_mut) else {
+        return Ok(strip);
+    };
+
+    for (key, column, places) in PROMOTED {
+        let Some(value) = transfer.remove(key) else { continue };
+        if value.is_null() {
+            continue;
+        }
+        let Some(text) = as_text(&value) else { continue };
+        if places == 0 {
+            strip.promoted.push((column, SqlValue::Text(text)));
+            continue;
+        }
+        let scaled = scale(&text, places).map_err(|error| {
+            CoreError::refuse(
+                error.code(),
+                &format!(
+                    "metadata.transferMetadata.{key} holds {text}, which this ledger stores in \
+                     {column} and cannot represent: {error}"
+                ),
+            )
+        })?;
+        strip.promoted.push((column, SqlValue::Integer(scaled)));
+    }
+
+    for (key, why) in DROPPED_KEYS {
+        if transfer.remove(key).is_some_and(|value| !value.is_null()) {
+            strip.dropped.push(format!("metadata.transferMetadata.{key} — {why}"));
+        }
+    }
+
+    Ok(strip)
+}
+
+// ── Writing a row ───────────────────────────────────────────────────────────
+
+/// The two child tables a backup row can carry inside an array column.
+fn child_array(entity: Entity, row: &BackupRow) -> Option<(&'static str, &[Value])> {
+    let key = match entity {
+        Entity::Transactions => "tags",
+        Entity::SuggestionDismissals => "subject_ids",
+        _ => return None,
+    };
+    row.get(key).and_then(Value::as_array).map(|values| (key, values.as_slice()))
+}
+
+/// Insert one backup row, re-owned to `owner`.
+///
+/// # Errors
+/// [`CoreError::Refused`] naming the entity and the row's id, always — a restore
+/// of fifty thousand rows that says only *"CHECK constraint failed"* has told the
+/// user nothing they can act on.
+#[allow(clippy::too_many_lines)]
+pub fn insert_row(
+    connection: &Connection,
+    entity: Entity,
+    row: &BackupRow,
+    owner: &str,
+    dropped: &mut Vec<Dropped>,
+) -> CoreResult<()> {
+    let id = row.get("id").and_then(Value::as_str).unwrap_or("(no id)").to_owned();
+    let named = |error: CoreError| -> CoreError { name_the_row(error, entity, &id) };
+
+    // X-6: the owner is supplied by the verb and never read from the file, so a
+    // bundle exported by another login lands owned by whoever restored it.
+    let mut columns: Vec<&'static str> = vec!["user_id"];
+    let mut values: Vec<SqlValue> = vec![SqlValue::Text(owner.to_owned())];
+
+    for column in entity.columns() {
+        let Some(value) = row.get(column.key) else { continue };
+        if value.is_null() {
+            continue;
+        }
+        let stored = match column.kind {
+            Kind::Json => SqlValue::Text(value.to_string()),
+            Kind::Flag => {
+                let flag: crate::wire::Flag = serde_json::from_value(value.clone())
+                    .map_err(|error| CoreError::InvalidCommand(error.to_string()))
+                    .map_err(&named)?;
+                let resolved = flag
+                    .resolve()
+                    .map_err(|message| CoreError::refuse("invalid_boolean", &message))
+                    .map_err(&named)?;
+                SqlValue::Integer(i64::from(resolved))
+            }
+            Kind::Ordinal => {
+                let Some(text) = as_text(value) else { continue };
+                if text.is_empty() {
+                    continue;
+                }
+                let number = text.parse::<i64>().map_err(|_| {
+                    named(CoreError::refuse(
+                        "invalid_integer",
+                        &format!("{} is not an integer: {text:?}", column.key),
+                    ))
+                })?;
+                SqlValue::Integer(number)
+            }
+            Kind::Scaled(places) => {
+                let Some(text) = as_text(value) else { continue };
+                let scaled = scale(&text, places)
+                    .map_err(|error| {
+                        CoreError::refuse(
+                            error.code(),
+                            &format!("{} holds {text}, which this ledger cannot store: {error}", column.key),
+                        )
+                    })
+                    .map_err(&named)?;
+                SqlValue::Integer(scaled)
+            }
+            Kind::Date => {
+                let Some(text) = as_text(value) else { continue };
+                let day = as_day(&text).ok_or_else(|| {
+                    named(CoreError::refuse(
+                        "date_invalid",
+                        &format!("{} is not a calendar day: {text:?}", column.key),
+                    ))
+                })?;
+                SqlValue::Text(day)
+            }
+            Kind::Timestamp => {
+                let Some(text) = as_text(value) else { continue };
+                let instant = as_instant(connection, &text)?.ok_or_else(|| {
+                    named(CoreError::refuse(
+                        "timestamp_unreadable",
+                        &format!("{} is not an instant this file can date: {text:?}", column.key),
+                    ))
+                })?;
+                SqlValue::Text(instant)
+            }
+            Kind::Text => SqlValue::Text(as_text(value).unwrap_or_default()),
+        };
+        columns.push(column.column);
+        values.push(stored);
+    }
+
+    // Divergence 9. Done after the column loop so the promoted figures join the
+    // same INSERT as the blob they came out of: a row whose fee landed and whose
+    // metadata did not would be a row that says the fee twice.
+    if entity == Entity::Transactions {
+        let mut metadata = row.get("metadata").cloned().unwrap_or(Value::Null);
+        if !metadata.is_null() {
+            let strip = strip_metadata_money(&mut metadata).map_err(&named)?;
+            for note in strip.dropped {
+                dropped.push(Dropped { entity: entity.as_str().to_owned(), id: id.clone(), what: note });
+            }
+            for (column, value) in strip.promoted {
+                columns.push(column);
+                values.push(value);
+            }
+            if let Some(position) = columns.iter().position(|name| *name == "metadata") {
+                if let Some(slot) = values.get_mut(position) {
+                    *slot = SqlValue::Text(metadata.to_string());
+                }
+            }
+        }
+    }
+
+    let placeholders = (1..=columns.len()).map(|n| format!("?{n}")).collect::<Vec<_>>().join(", ");
+    let sql = format!(
+        "INSERT INTO {} ({}) VALUES ({placeholders})",
+        entity.table(),
+        columns.join(", ")
+    );
+    let bound: Vec<&dyn ToSql> = values.iter().map(|value| value as &dyn ToSql).collect();
+    connection.execute(&sql, bound.as_slice()).map_err(|error| named(error.into()))?;
+
+    if let Some((key, members)) = child_array(entity, row) {
+        write_child_array(connection, entity, &id, key, members, owner, dropped).map_err(&named)?;
+    }
+
+    Ok(())
+}
+
+/// `text[]` and `uuid[]` become child tables here, so the array is written after
+/// its parent row.
+fn write_child_array(
+    connection: &Connection,
+    entity: Entity,
+    id: &str,
+    key: &str,
+    members: &[Value],
+    owner: &str,
+    dropped: &mut Vec<Dropped>,
+) -> CoreResult<()> {
+    match entity {
+        // A set, not a sequence: `PRIMARY KEY (transaction_id, tag)` is what
+        // makes the two engines agree about a duplicate, and `INSERT OR IGNORE`
+        // is how a duplicate in the file survives it — Postgres's `text[]` holds
+        // one happily, so refusing here would refuse a row the cloud stores.
+        Entity::Transactions => {
+            let mut seen = BTreeSet::new();
+            for member in members {
+                let Some(tag) = member.as_str() else { continue };
+                if tag.trim().is_empty() || !seen.insert(tag) {
+                    continue;
+                }
+                connection.execute(
+                    "INSERT OR IGNORE INTO transaction_tags (transaction_id, tag) VALUES (?1, ?2)",
+                    rusqlite::params![id, tag],
+                )?;
+            }
+            Ok(())
+        }
+        // The cloud's column comment PROMISES every subject id resolves in
+        // exactly one table; here it is a foreign key. A subject the file names
+        // and the ledger does not hold is therefore unstorable — and it is
+        // dropped rather than refused, because a dismissal is a suggestion the
+        // user has waved away, not money, and losing a whole restore over one
+        // would be absurd. The dismissal itself still lands: `subject_key` is
+        // what identifies it.
+        Entity::SuggestionDismissals => {
+            for (position, member) in members.iter().enumerate() {
+                let Some(subject) = member.as_str() else { continue };
+                let known: i64 = connection.query_row(
+                    "SELECT EXISTS (SELECT 1 FROM transactions WHERE id = ?1 AND user_id = ?2)",
+                    rusqlite::params![subject, owner],
+                    |row| row.get(0),
+                )?;
+                if known == 0 {
+                    dropped.push(Dropped {
+                        entity: entity.as_str().to_owned(),
+                        id: id.to_owned(),
+                        what: format!("{key}[{position}] names a transaction this ledger does not hold"),
+                    });
+                    continue;
+                }
+                let order = i64::try_from(position).map_err(|_| {
+                    CoreError::refuse("amount_out_of_range", "more subjects than a dismissal can hold")
+                })?;
+                connection.execute(
+                    "INSERT INTO suggestion_dismissal_subjects (dismissal_id, transaction_id, role_order)
+                     VALUES (?1, ?2, ?3)",
+                    rusqlite::params![id, subject, order],
+                )?;
+            }
+            Ok(())
+        }
+        _ => Ok(()),
+    }
+}
+
+/// Put the entity and the row's id in front of whatever refused, and say what a
+/// person can do about it.
+///
+/// The bounds in the hint are formatted from [`crate::money`]'s published
+/// constants rather than written out, because the CONSTRAINT is what enforces
+/// them and a second copy in prose would drift from it. MONEY-5: a cloud backup
+/// may legally hold a `numeric(20,2)` row the local bound refuses, and the
+/// obligation this discharges is that it is rejected *with a message*, never
+/// silently rescaled — rescaling money is inventing it.
+fn name_the_row(error: CoreError, entity: Entity, id: &str) -> CoreError {
+    match error {
+        CoreError::Storage(fault) => CoreError::Storage(fault),
+        other => {
+            let bound = crate::money::Money::from_minor(crate::money::Money::ROW_BOUND_MINOR);
+            let stock = crate::money::Money::from_minor(crate::money::Money::STOCK_BOUND_MINOR);
+            CoreError::Refused(
+                crate::error::Refusal::named(
+                    "restore_row_refused",
+                    &format!("{} {id}: {other}", entity.as_str()),
+                )
+                .with_hint(&format!(
+                    "This row is in the backup file but cannot be stored as it stands. If the \
+                     figure is the problem: a single amount is bounded at ±{bound} and a stored \
+                     balance at ±{stock}, because SQLite's integer sum RAISES at the int64 cliff \
+                     where Postgres widens — one absurd row would leave the account with no \
+                     computable balance at all rather than a wrong one. Correct the row in the \
+                     file and restore again.",
+                )),
+            )
+        }
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
+mod tests {
+    use super::{as_day, scale, strip_metadata_money, Entity};
+    use crate::money::MoneyError;
+    use serde_json::json;
+
+    #[test]
+    fn scaling_is_exact_at_every_scale_the_schema_uses() {
+        assert_eq!(scale("-12.34", 2), Ok(-1_234));
+        assert_eq!(scale("12", 2), Ok(1_200));
+        assert_eq!(scale("1.5", 2), Ok(150));
+        assert_eq!(scale("1.500", 2), Ok(150), "trailing zeros are not precision");
+        assert_eq!(scale("0.00000001", 8), Ok(1));
+        assert_eq!(scale("12.345", 8), Ok(1_234_500_000));
+        assert_eq!(scale("80", 2), Ok(8_000), "alert_threshold as basis points");
+        assert_eq!(scale("1.0000000001", 10), Ok(10_000_000_001));
+        assert_eq!(scale("-0", 2), Ok(0));
+    }
+
+    #[test]
+    fn a_value_finer_than_the_column_is_refused_rather_than_rounded() {
+        assert_eq!(scale("12.345", 2), Err(MoneyError::SubMinorUnit));
+        assert_eq!(scale("0.000000001", 8), Err(MoneyError::SubMinorUnit));
+        assert_eq!(MoneyError::SubMinorUnit.code(), "amount_not_representable");
+    }
+
+    #[test]
+    fn scaling_overflow_is_an_error_not_a_wrap() {
+        assert_eq!(scale("99999999999999999999", 2), Err(MoneyError::OutOfRange));
+        assert_eq!(scale("1000000000000", 8), Err(MoneyError::OutOfRange));
+    }
+
+    #[test]
+    fn scaling_refuses_everything_that_is_not_a_plain_decimal() {
+        for text in ["", "-", "1,000", "1e3", "£1", "1.2.3", "abc"] {
+            assert_eq!(scale(text, 2), Err(MoneyError::Malformed), "scaling {text:?}");
+        }
+    }
+
+    #[test]
+    fn a_day_passes_through_and_anything_longer_is_truncated_lexically() {
+        assert_eq!(as_day("2024-03-01").as_deref(), Some("2024-03-01"));
+        // No zone arithmetic: the 15th stays the 15th.
+        assert_eq!(as_day("2026-01-15T02:30:00+05:00").as_deref(), Some("2026-01-15"));
+        assert_eq!(as_day("2023-02-29"), None, "not a real day");
+        assert_eq!(as_day("2024-3-1"), None);
+        assert_eq!(as_day(""), None);
+    }
+
+    #[test]
+    fn the_metadata_strip_promotes_four_and_reports_the_rest() {
+        let mut metadata = json!({
+            "transferMetadata": {
+                "fees": 12.5,
+                "originalAmount": "-100.00",
+                "originalCurrency": "EUR",
+                "exchangeRate": "1.1234567891",
+                "marketValue": 9.99,
+                "discrepancy": 0.01,
+                "transferType": "wire"
+            },
+            "investmentData": { "stampDuty": 5 },
+            "reference": "kept"
+        });
+        let strip = strip_metadata_money(&mut metadata).unwrap();
+
+        assert_eq!(
+            strip.promoted.iter().map(|(column, _)| *column).collect::<Vec<_>>(),
+            ["fee_minor", "original_amount_minor", "fx_rate_e10", "original_currency"]
+        );
+        assert_eq!(strip.dropped.len(), 3, "{:?}", strip.dropped);
+        assert!(strip.dropped[0].contains("investmentData"));
+
+        // Everything non-numeric survives, and nothing the CHECK watches is left.
+        assert_eq!(metadata["reference"], json!("kept"));
+        assert_eq!(metadata["transferMetadata"]["transferType"], json!("wire"));
+        assert!(metadata["transferMetadata"].get("fees").is_none());
+        assert!(metadata.get("investmentData").is_none());
+    }
+
+    #[test]
+    fn a_rate_finer_than_ten_places_is_refused_not_dropped() {
+        // It HAS a home (fx_rate_e10), so silently losing it would be wrong in a
+        // way losing marketValue is not.
+        let mut metadata = json!({ "transferMetadata": { "exchangeRate": "1.00000000001" } });
+        let error = strip_metadata_money(&mut metadata).expect_err("eleven places");
+        assert_eq!(error.code(), "amount_not_representable", "{error}");
+    }
+
+    #[test]
+    fn a_blob_with_no_money_in_it_is_left_alone() {
+        let mut metadata = json!({ "transferMetadata": { "transferType": "wire" } });
+        let strip = strip_metadata_money(&mut metadata).unwrap();
+        assert!(strip.promoted.is_empty());
+        assert!(strip.dropped.is_empty());
+        assert_eq!(metadata, json!({ "transferMetadata": { "transferType": "wire" } }));
+    }
+
+    #[test]
+    fn every_entity_names_a_table_and_round_trips_its_own_name() {
+        for entity in [
+            Entity::Accounts, Entity::Categories, Entity::Transactions, Entity::TransactionSplits,
+            Entity::Budgets, Entity::Goals, Entity::GoalContributions, Entity::Investments,
+            Entity::InvestmentTransactions, Entity::RecurringTransactions, Entity::Notifications,
+            Entity::DashboardLayouts, Entity::WidgetPreferences, Entity::SuggestionDismissals,
+        ] {
+            assert_eq!(Entity::parse(entity.as_str()).unwrap(), entity);
+            assert!(!entity.columns().is_empty());
+            // user_id is supplied by the verb, never taken from the file: X-6.
+            assert!(
+                entity.columns().iter().all(|column| column.key != "user_id"),
+                "{} must not carry user_id from the file",
+                entity.as_str()
+            );
+        }
+    }
+
+    #[test]
+    fn an_unknown_entity_refuses_by_the_rpcs_own_name() {
+        let error = Entity::parse("not_a_table").expect_err("unknown");
+        assert_eq!(error.code(), "restore_entity_unknown");
+        assert!(error.to_string().contains("not_a_table"), "{error}");
+    }
+}

--- a/crates/wealth-core/src/bin/wealth_core_cli.rs
+++ b/crates/wealth-core/src/bin/wealth_core_cli.rs
@@ -53,12 +53,16 @@ use wealth_core::db;
 use wealth_core::error::CoreError;
 use wealth_core::verbs::{
     apply_category_to_uncategorized, clear_transfer_links, confirm_transaction_categories,
-    create_transaction, create_transfer_counterpart, delete_transaction, link_split_line_transfer,
-    link_transfer_pair, merge_categories, repair_claimed_transfer,
-    set_transaction_splits_with_legs, update_transaction, ApplyCategoryToUncategorized,
-    ClearTransferLinks, ConfirmTransactionCategories, CreateTransaction, CreateTransferCounterpart,
-    DeleteTransaction, LinkSplitLineTransfer, LinkTransferPair, MergeCategories,
-    RepairClaimedTransfer, SetTransactionSplitsWithLegs, UpdateTransaction,
+    create_transaction, create_transfer_counterpart, delete_transaction,
+    delete_unused_categories, finalize_user_restore, link_bank_account_snap,
+    link_split_line_transfer, link_transfer_pair, merge_categories, repair_claimed_transfer,
+    restore_user_chunk, set_transaction_splits_with_legs, update_transaction,
+    user_financial_data_is_empty, verify_integrity, wipe_user_financial_data,
+    ApplyCategoryToUncategorized, ClearTransferLinks, ConfirmTransactionCategories,
+    CreateTransaction, CreateTransferCounterpart, DeleteTransaction, DeleteUnusedCategories,
+    FinalizeUserRestore, LinkBankAccountSnap, LinkSplitLineTransfer, LinkTransferPair,
+    MergeCategories, RepairClaimedTransfer, RestoreUserChunk, SetTransactionSplitsWithLegs,
+    UpdateTransaction, UserFinancialDataIsEmpty, VerifyIntegrity, WipeUserFinancialData,
 };
 
 /// A command, as the harness sends it.
@@ -100,6 +104,29 @@ enum Command {
     MergeCategories(Box<MergeCategories>),
     ApplyCategoryToUncategorized(Box<ApplyCategoryToUncategorized>),
     ConfirmTransactionCategories(Box<ConfirmTransactionCategories>),
+    // The fourth category verb, and the one whose every protection is a WHERE
+    // clause rather than a RAISE. Same name as the RPC it ports; the count it
+    // returns is the RPC's, which is not the count SQLite's own single-statement
+    // spelling would give (see the verb's module documentation).
+    DeleteUnusedCategories(Box<DeleteUnusedCategories>),
+    // The restore family. Four verb strings, each spelled exactly as the
+    // function it ports — including `restore_user_chunk`, whose LOCAL payload
+    // carries a LIST of chunks because the whole restore is one transaction here
+    // (DESIGN.md §5 divergence 6). The name is kept singular because a verb
+    // string that differs from the function it ports is a verb string that will
+    // one day be mapped to the wrong function.
+    UserFinancialDataIsEmpty(Box<UserFinancialDataIsEmpty>),
+    WipeUserFinancialData(Box<WipeUserFinancialData>),
+    RestoreUserChunk(Box<RestoreUserChunk>),
+    FinalizeUserRestore(Box<FinalizeUserRestore>),
+    // The account snap: service-role only in the cloud, and the one function in
+    // the schema that assigns an absolute balance without breaking B-1.
+    LinkBankAccountSnap(Box<LinkBankAccountSnap>),
+    // The only verb here that is NOT a port: the cloud has no verify_integrity,
+    // no view and no equivalent, and the verb's module documentation carries the
+    // trace that establishes it. Its payload is `{}` — it takes not even an
+    // owner, because integrity is a property of the file.
+    VerifyIntegrity(Box<VerifyIntegrity>),
 }
 
 #[derive(Debug, Serialize)]
@@ -274,6 +301,31 @@ fn run() -> Result<Response, String> {
         }
         Command::ConfirmTransactionCategories(payload) => {
             confirm_transaction_categories(&mut connection, *payload).and_then(as_json)
+        }
+        Command::DeleteUnusedCategories(payload) => {
+            delete_unused_categories(&mut connection, *payload).and_then(as_json)
+        }
+        // The only verb that needs no `&mut`: it opens no transaction, because
+        // it writes nothing.
+        Command::UserFinancialDataIsEmpty(payload) => {
+            user_financial_data_is_empty(&connection, *payload).and_then(as_json)
+        }
+        Command::WipeUserFinancialData(payload) => {
+            wipe_user_financial_data(&mut connection, *payload).and_then(as_json)
+        }
+        Command::RestoreUserChunk(payload) => {
+            restore_user_chunk(&mut connection, *payload).and_then(as_json)
+        }
+        Command::FinalizeUserRestore(payload) => {
+            finalize_user_restore(&mut connection, *payload).and_then(as_json)
+        }
+        Command::LinkBankAccountSnap(payload) => {
+            link_bank_account_snap(&mut connection, *payload).and_then(as_json)
+        }
+        // The second verb that needs no `&mut`, and for the same reason as the
+        // first: it writes nothing.
+        Command::VerifyIntegrity(payload) => {
+            verify_integrity(&connection, *payload).and_then(as_json)
         }
     };
 

--- a/crates/wealth-core/src/lib.rs
+++ b/crates/wealth-core/src/lib.rs
@@ -114,9 +114,64 @@
 //! of. Two category RPCs that DO exist are named in [`verbs`] as deliberately not
 //! done.
 //!
+//! Then **the restore family** — four functions and the whole of
+//! `20260807083000_user_data_restore.sql`, ported together because none of them
+//! means anything alone: the emptiness question exists to gate the restore, the
+//! wipe exists to make the answer true, and the finalize exists to close what the
+//! restore had to leave open.
+//!
+//! * [`verbs::user_financial_data_is_empty`] — the only verb in the crate that
+//!   opens no transaction and writes nothing. Three tables, not "any data", and
+//!   the narrowness is the design.
+//! * [`verbs::wipe_user_financial_data`] — "delete everything", and the verb that
+//!   found a defect in `schema.sql`: two rules that are each individually right
+//!   combined to refuse an account deletion the cloud performs, which made a wipe
+//!   impossible on any file holding one linked transfer.
+//! * [`verbs::restore_user_chunk`] — the only verb that takes arbitrary JSON, and
+//!   therefore the only one with a translation layer ([`backup`]) between the
+//!   payload and the tables. Five refusals whose ORDER includes two measured
+//!   surprises, sixteen entities' worth of column mapping, and DESIGN.md's
+//!   divergence 9 — the money a cloud backup keeps in a JSON blob that this
+//!   schema bans by CHECK.
+//! * [`verbs::finalize_user_restore`] — the second pass, ported even though R-11
+//!   removes the need for one, because the links are a separate payload in the
+//!   file and both engines must apply them the same way. The one verb that holds
+//!   `_rpc_guard('restore')`, and the one whose audit row could not be written as
+//!   the cloud writes it.
+//!
+//! And **the account snap**, [`verbs::link_bank_account_snap`], which belongs
+//! with them for one reason: it is the only function in the schema that assigns
+//! an absolute balance, and understanding why that is not a contradiction of B-2
+//! is the same piece of reasoning a restore needs about `accounts.balance` being
+//! authoritative (X-8).
+//!
+//! Then the two that close the ledger core:
+//!
+//! * [`verbs::delete_unused_categories`] — the category family's fourth and last
+//!   verb, and the only one in the crate whose every protection is a `WHERE`
+//!   clause rather than a refusal. Porting it found the measured hole in the
+//!   promise its own migration makes (a referenced child dies with its named
+//!   parent, on BOTH engines), the one shape in which the FILE refuses on the
+//!   function's behalf, and the one place where the cloud's single statement
+//!   cannot be a single statement here without changing the number it answers
+//!   with.
+//! * [`verbs::verify_integrity`] — **the only verb in this crate that is not a
+//!   port of anything.** The cloud has no such function, no such view and no
+//!   equivalent; the local edition needs one because it has no second
+//!   implementation to be checked against. Seventeen checks, fifteen rules and
+//!   two suspicions, each one proved to fire by a spec that plants its violation.
+//!   Its specs are the first in the verb harness to run on one engine, because
+//!   there is no other engine to run them on.
+//!
 //! What is deliberately NOT here is as much of the design as what is: no
 //! absolute balance setter, no verb that accepts SQL, and no general-purpose
 //! writer for the columns that have dedicated verbs. See [`verbs`].
+//!
+//! One thing the restore family deliberately does not port, named here so nobody
+//! has to re-derive it: **`backupService.remapBackupIds`**. Ids are remapped on
+//! the CLIENT, before a single row is sent, and the RPCs insert what they are
+//! handed verbatim. [`backup`] says so at its head, and a Rust copy of that
+//! function would be a second implementation of a rule the TypeScript owns.
 
 #![deny(missing_docs)]
 #![warn(clippy::pedantic)]
@@ -128,6 +183,7 @@
 #![allow(clippy::doc_markdown)]
 
 pub mod audit;
+pub mod backup;
 pub mod db;
 pub mod error;
 pub mod money;

--- a/crates/wealth-core/src/verbs/delete_unused_categories.rs
+++ b/crates/wealth-core/src/verbs/delete_unused_categories.rs
@@ -1,0 +1,425 @@
+//! `delete_unused_categories` — the Money-set "replace" import's bulk prune.
+//!
+//! # What it is a port OF
+//!
+//! The **live** definition, `20260713100000:320-363`. Traced by grep across every
+//! migration: defined twice, and only the newer counts — `20260708160000:24-63`
+//! is the original and `20260713100000` recreates it verbatim with one addition,
+//! the `transaction_splits` guard, which its own comment explains
+//! (`:314-318`). Nothing after that redefines it; `20260725120000:323` only
+//! re-grants it. The client calls it at exactly one place,
+//! `planningService.ts:511`, from one caller, `AppContextSupabase.tsx:1370`.
+//!
+//! # It has NO refusal of its own, and that is the design
+//!
+//! Every protection is a `WHERE` clause, not a `RAISE`. A row that fails any
+//! check is skipped in silence and the function returns how many rows it actually
+//! removed. MEASURED across twenty cases on the reference cluster
+//! (`scratchpad/local-core/probe-prune1.sh`, `probe-prune2.sh`, 2026-08-08): not
+//! one of them produced an exception from the function itself.
+//!
+//! That is deliberate and the migration says so: the client *plans* the prune
+//! from a snapshot that may be stale, and the RPC re-verifies every row so *"a
+//! stale client can never destroy referenced data"*. A refusal would lose the
+//! whole batch because one category in it acquired a transaction while the user
+//! was looking at the dialog.
+//!
+//! ```text
+//! level = 'type'                       skipped
+//! is_transfer_category                 skipped
+//! referenced by a transaction          skipped
+//! referenced by a split line           skipped
+//! referenced by a budget               skipped
+//! referenced by a recurring template   skipped
+//! has a child OUTSIDE the batch        skipped
+//! ```
+//!
+//! ## Which is not to say it cannot refuse
+//!
+//! One shape makes it raise, and the refusal comes from the FILE rather than
+//! from the function. Name a prunable category AND a To/From category that sits
+//! under it: the To/From row is skipped by `is_transfer_category`, but being *in
+//! the batch* it no longer keeps its parent alive, so the parent is deleted and
+//! `parent_id ON DELETE CASCADE` takes the protected row with it — into C-5's
+//! `BEFORE DELETE` trigger, which raises.
+//!
+//! ```text
+//! postgres   parent + its To/From child, both named  -> ERROR transfer_category_protected
+//! sqlite     the same                                -> ERROR transfer_category_protected
+//! sqlite     the same, holding _rpc_guard('split')   -> ERROR transfer_category_protected
+//! ```
+//!
+//! (MEASURED: `probe-prune2.sh` `p2-parent-and-transfer-child-both-named`,
+//! `probe-prune-sqlite3.mjs` `c-parent-and-transfer-child`.) Both engines lose
+//! the whole call and nothing is deleted, which is the right outcome and the
+//! same outcome. The guard row in the third line is there to record that no flag
+//! in `_rpc_guard` stands C-5 down: it is a protection, not a nuisance, and the
+//! verb does not try.
+//!
+//! # THE HOLE, measured and reproduced rather than quietly fixed
+//!
+//! The migration's promise — *"a stale client can never destroy referenced
+//! data"* — is FALSE in one shape, on both engines, and the local port
+//! reproduces it exactly:
+//!
+//! ```text
+//! parent P and child C both named, C referenced by a transaction
+//!   postgres  -> returns 1, C is GONE, the transaction's category text dangles
+//!   sqlite    -> returns 1, C is GONE, the transaction's category text dangles
+//! ```
+//!
+//! C's own check skips it; P's "child outside the batch" check passes *because C
+//! is in the batch*; P is deleted; the cascade takes C. The same is true three
+//! generations deep (`p2-grandchild-referenced-parents-named` → 2, grandchild
+//! gone). It is not fixed here for the reason `merge_categories` gives about what
+//! it leaves behind: a local port that tidied it would do something the cloud
+//! does not, and the two would no longer be implementations of one verb. What the
+//! local edition does instead is REPORT it —
+//! [`super::verify_integrity`]'s `dangling_category_ref` is exactly this
+//! wreckage, and the spec that plants it says so.
+//!
+//! The same hole eats a *budget's* uuid reference
+//! (`p2-cascade-eats-a-budgeted-child`: `category` text dangles,
+//! `category_id` nulled by the key) and, without any cascade at all, a
+//! transaction filed through `category_id` alone
+//! (`p-used-by-transaction-uuid-only` → deleted, column nulled): the transaction
+//! check is on the TEXT column only, while the budget check reads both. That
+//! asymmetry is in the cloud's own WHERE clause and travels with it.
+//!
+//! # The one thing the port could NOT do the cloud's way
+//!
+//! The cloud is a single `DELETE … WHERE id = ANY(p_ids) AND …` and returns
+//! `ROW_COUNT`. Spelled that way locally it gives a DIFFERENT NUMBER for the same
+//! file:
+//!
+//! ```text
+//! parent + child, both named, both prunable
+//!   postgres        -> 2
+//!   sqlite, one DELETE -> 1     (same six categories left; different answer)
+//! three generations, all named
+//!   postgres        -> 3
+//!   sqlite, one DELETE -> 1
+//! ```
+//!
+//! (MEASURED, `probe-prune-sqlite.mjs`.) Postgres decides which rows to delete
+//! from one snapshot and counts each; SQLite scans, deletes the parent, the
+//! cascade removes the child, and by the time the scan reaches the child there is
+//! nothing there to count. The FILE ends up identical either way — this is a
+//! disagreement about the answer, not about the ledger — but the answer is what
+//! the import summary shows the user.
+//!
+//! So the port qualifies the rows FIRST (the cloud's WHERE, as a SELECT), then
+//! deletes them one at a time, **deepest first**, so no cascade can ever
+//! pre-empt a row this call is going to count. Every one of the twenty measured
+//! cases then matches the cloud, including the refusal
+//! (`probe-prune-sqlite3.mjs`).
+//!
+//! Deepest-first is safe rather than lucky: a named row can only be a descendant
+//! of another named row if every category between them is named too, because an
+//! unnamed intermediate would be a "child outside the batch" and would disqualify
+//! the ancestor. [`deepest_first`] carries the cycle guard anyway —
+//! `parent_id` has no constraint against a loop, and a topological walk that
+//! trusts the data is a hang waiting to happen.
+//!
+//! # It audits nothing, and that is a decision rather than an oversight
+//!
+//! The cloud writes no audit row here — MEASURED, `probe-prune1.sh`
+//! `p-plain-unused`: `financial_audit_log` is empty afterwards — and this port
+//! writes none either. The argument for adding one is real and is recorded so
+//! nobody has to reconstruct it: the cloud's own newer `merge_categories` audits
+//! a category delete (`20260805214322:382-384`, `entity 'category'`), so the
+//! event has an established shape, and PHASE1-PLAN §2.2 sets a precedent for the
+//! local edition FIXING an audit gap the cloud has.
+//!
+//! It is not taken here, for three reasons in increasing order of weight:
+//!
+//! 1. Every row this verb deletes is, by its own precondition, referenced by
+//!    nothing. No figure moved and nothing was re-filed; there is no "what
+//!    changed that number" for the entry to answer.
+//! 2. §2.2's precedent cost nothing because budgets and goals have no verb yet.
+//!    Here it would cost the differential comparison: every spec would carry a
+//!    declared divergence, and a family of divergences is how a real one gets
+//!    missed.
+//! 3. `merge_categories` audits its delete because that delete is the tail of a
+//!    chain of moves the entry's `before` explains. This one has no chain.
+//!
+//! If it is ever added, it must be a DECLARED divergence in DESIGN.md §5 and not
+//! a quiet improvement.
+//!
+//! # The guard: none, and measured so
+//!
+//! The verb touches `categories` only. The cascade reaches `categories` (children)
+//! and the two `ON DELETE SET NULL` keys on `transactions.category_id` and
+//! `budgets.category_id`. None of the four `trg_protect_split_*` triggers watches
+//! `category_id` — they watch `is_split`, `amount_minor`, `type` and `category` —
+//! so nulling a SPLIT PARENT's `category_id` is not examined at all. MEASURED
+//! (`probe-prune-sqlite3.mjs`, `c-split-parent-filed-by-uuid`: accepted, column
+//! nulled, no guard held).
+
+use rusqlite::{params, Connection, TransactionBehavior};
+use serde::{Deserialize, Serialize};
+
+use crate::error::CoreResult;
+
+/// The command. `(p_ids, p_user_id)` as one object.
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct DeleteUnusedCategories {
+    /// `p_ids`. Absent, null and empty are the same request and the same answer:
+    /// zero. MEASURED on the cloud (`p-null-array`, `p-empty-array`), where
+    /// `id = ANY(NULL)` and `id = ANY('{}')` both match nothing.
+    #[serde(default)]
+    pub ids: Option<Vec<String>>,
+    /// `p_user_id`. Absent means "name no owner", and the cloud then reaches
+    /// EVERY login's categories — MEASURED (`p-no-owner-named-reaches-everyone`:
+    /// a stranger's category deleted). Passed through rather than required, for
+    /// the reason [`super::user_financial_data_is_empty`] gives: in the cloud RLS
+    /// has already narrowed what the caller can see, and in a single-login file
+    /// the two readings are the same answer.
+    #[serde(default)]
+    pub user_id: Option<String>,
+}
+
+/// What the verb hands back.
+#[derive(Debug, Serialize)]
+pub struct DeleteUnusedCategoriesResult {
+    /// The projection both engines are compared on. The RPC returns a bare
+    /// integer; this is that integer, in the object shape the harness reads.
+    pub answer: PruneAnswer,
+}
+
+/// The RPC's return value.
+#[derive(Debug, Serialize)]
+pub struct PruneAnswer {
+    /// How many categories this call removed BY NAME. Rows that disappeared as
+    /// a cascade of one of them are not counted — that is what `ROW_COUNT`
+    /// counts in the cloud, and the module docs carry the measurement.
+    pub deleted: i64,
+}
+
+/// One row that qualifies for deletion, and the link that decides its turn.
+struct Doomed {
+    id: String,
+    parent_id: Option<String>,
+}
+
+/// Prune the categories that nothing refers to.
+///
+/// # Errors
+/// [`CoreError::Refused`] when the FILE refuses — the only reachable case is
+/// C-5's `transfer_category_protected`, through the cascade, and it loses the
+/// whole call on both engines. [`CoreError::Storage`] for a fault.
+#[allow(clippy::needless_pass_by_value)]
+pub fn delete_unused_categories(
+    connection: &mut Connection,
+    command: DeleteUnusedCategories,
+) -> CoreResult<DeleteUnusedCategoriesResult> {
+    let named = command.ids.clone().unwrap_or_default();
+    if named.is_empty() {
+        return Ok(DeleteUnusedCategoriesResult {
+            answer: PruneAnswer { deleted: 0 },
+        });
+    }
+
+    // BEGIN IMMEDIATE before the first read, as every writing verb here does:
+    // the qualifying set is read and then acted on, and nothing may change
+    // between the two. It is also what makes the C-5 refusal roll the whole
+    // batch back rather than half of it.
+    let write = connection.transaction_with_behavior(TransactionBehavior::Immediate)?;
+    let owner = command.user_id.as_deref();
+
+    let doomed = qualifying(&write, &named, owner)?;
+
+    let mut deleted = 0_i64;
+    for row in deepest_first(&doomed) {
+        // Scoped by owner again, not because the qualifying read left a gap —
+        // it did not — but because a DELETE that names one id and no owner is
+        // one edit away from being a DELETE that names none.
+        let removed = write.execute(
+            "DELETE FROM categories WHERE id = ?1 AND (?2 IS NULL OR user_id = ?2)",
+            params![row.id, owner],
+        )?;
+        // Counted, not asserted. Deepest-first means nothing should have taken
+        // the row first — but if some future shape breaks that reasoning, the
+        // count degrades to exactly what SQLite's own single-statement DELETE
+        // would have said, rather than reporting a deletion that did not happen.
+        deleted = deleted.saturating_add(super::count(removed)?);
+    }
+
+    write.commit()?;
+
+    Ok(DeleteUnusedCategoriesResult {
+        answer: PruneAnswer { deleted },
+    })
+}
+
+/// The cloud's `WHERE` clause, asked as a question instead of an instruction.
+///
+/// Every `NOT EXISTS` is the RPC's, in the RPC's order, and two of them are
+/// deliberately NOT scoped the way a reader expects:
+///
+/// * `recurring_transactions` is matched on the category id ALONE, because the
+///   cloud's is (`20260713100000:349-352`). MEASURED
+///   (`p-used-by-recurring-of-a-stranger`): another login's template saves the
+///   category. The migration's own reasoning is that a category id is a globally
+///   unique uuid, so matching on it can only reach rows that mean this category.
+/// * `transactions` and `transaction_splits` ARE scoped to the category's owner,
+///   so a stranger's row filed under it does NOT save it — MEASURED
+///   (`p2-strangers-transaction-does-not-save-it`, and the split twin). The
+///   asymmetry is the cloud's and it travels with the port.
+///
+/// The child check reads `NOT IN (the batch)`, which is `NOT (ch.id = ANY(p_ids))`
+/// spelled for SQLite. A NULL id cannot occur — `categories.id` is the primary
+/// key — so the three-valued trap `NOT IN` normally carries is unreachable here.
+fn qualifying(
+    write: &rusqlite::Transaction<'_>,
+    named: &[String],
+    owner: Option<&str>,
+) -> CoreResult<Vec<Doomed>> {
+    // The named set, once each, in id order. `id = ANY(p_ids)` matches each row
+    // once however many times its id appears — MEASURED (`p-same-id-twice` → 1) —
+    // which is what the shared `distinct_ids` reproduces.
+    let distinct: Vec<&str> = super::distinct_ids(named).into_iter().collect();
+    // `?1` is the owner, so the ids start at `?2`.
+    let placeholders = (2..=distinct.len().saturating_add(1))
+        .map(|position| format!("?{position}"))
+        .collect::<Vec<_>>()
+        .join(", ");
+
+    let sql = format!(
+        "SELECT c.id, c.parent_id
+           FROM categories c
+          WHERE c.id IN ({placeholders})
+            AND (?1 IS NULL OR c.user_id = ?1)
+            AND c.level <> 'type'
+            AND c.is_transfer_category <> 1
+            AND NOT EXISTS (SELECT 1 FROM transactions t
+                             WHERE t.user_id = c.user_id AND t.category = c.id)
+            AND NOT EXISTS (SELECT 1 FROM transaction_splits s
+                             WHERE s.user_id = c.user_id AND s.category = c.id)
+            AND NOT EXISTS (SELECT 1 FROM budgets b
+                             WHERE b.user_id = c.user_id
+                               AND (b.category = c.id OR b.category_id = c.id))
+            AND NOT EXISTS (SELECT 1 FROM recurring_transactions r
+                             WHERE r.category = c.id)
+            AND NOT EXISTS (SELECT 1 FROM categories ch
+                             WHERE ch.parent_id = c.id
+                               AND ch.id NOT IN ({placeholders}))
+          ORDER BY c.id"
+    );
+
+    let mut statement = write.prepare(&sql)?;
+    let mut bound: Vec<&dyn rusqlite::ToSql> = Vec::with_capacity(distinct.len().saturating_add(1));
+    bound.push(&owner);
+    for id in &distinct {
+        bound.push(id);
+    }
+
+    let rows = statement.query_map(bound.as_slice(), |record| {
+        Ok(Doomed {
+            id: record.get(0)?,
+            parent_id: record.get(1)?,
+        })
+    })?;
+
+    let mut doomed = Vec::new();
+    for row in rows {
+        doomed.push(row?);
+    }
+    Ok(doomed)
+}
+
+/// Descendants before ancestors, so a cascade never removes a row this call is
+/// about to delete and count.
+///
+/// Depth is measured WITHIN the qualifying set: a parent outside it cannot be
+/// deleted by this call, so it cannot pre-empt anything. Ties break on id, which
+/// is the order [`qualifying`] already returns and the order the cloud's own
+/// answer is insensitive to.
+///
+/// The `seen` set is a cycle guard. `categories.parent_id` has no constraint
+/// forbidding a loop in either engine — `parent_id <> id` is not even checked —
+/// and a walk that trusts the data would hang on a file somebody edited with a
+/// SQLite browser. A row in a cycle gets whatever depth the walk reached before
+/// it closed, which is arbitrary and harmless: every member of a cycle is
+/// mutually an ancestor, so no order is more correct than another.
+fn deepest_first(doomed: &[Doomed]) -> Vec<&Doomed> {
+    let depth_of = |start: &Doomed| -> usize {
+        let mut seen = std::collections::BTreeSet::from([start.id.as_str()]);
+        let mut steps = 0_usize;
+        let mut current = start;
+        while let Some(parent) = current.parent_id.as_deref() {
+            let Some(next) = doomed.iter().find(|row| row.id == parent) else {
+                break;
+            };
+            if !seen.insert(next.id.as_str()) {
+                break;
+            }
+            current = next;
+            steps = steps.saturating_add(1);
+        }
+        steps
+    };
+
+    let mut ordered: Vec<(usize, &Doomed)> = doomed.iter().map(|row| (depth_of(row), row)).collect();
+    ordered.sort_by(|left, right| right.0.cmp(&left.0).then_with(|| left.1.id.cmp(&right.1.id)));
+    ordered.into_iter().map(|(_, row)| row).collect()
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
+mod tests {
+    use super::{deepest_first, DeleteUnusedCategories, Doomed};
+
+    fn row(id: &str, parent: Option<&str>) -> Doomed {
+        Doomed {
+            id: id.to_owned(),
+            parent_id: parent.map(ToOwned::to_owned),
+        }
+    }
+
+    fn order(rows: &[Doomed]) -> Vec<String> {
+        deepest_first(rows)
+            .into_iter()
+            .map(|row| row.id.clone())
+            .collect()
+    }
+
+    #[test]
+    fn a_child_is_deleted_before_its_parent() {
+        assert_eq!(order(&[row("a", None), row("b", Some("a"))]), ["b", "a"]);
+    }
+
+    #[test]
+    fn three_generations_come_out_deepest_first() {
+        let rows = [row("a", None), row("b", Some("a")), row("c", Some("b"))];
+        assert_eq!(order(&rows), ["c", "b", "a"]);
+    }
+
+    #[test]
+    fn a_parent_outside_the_set_does_not_count_as_depth() {
+        // Both are leaves as far as this call is concerned, so id order stands.
+        let rows = [row("b", Some("nobody")), row("a", Some("nobody"))];
+        assert_eq!(order(&rows), ["a", "b"]);
+    }
+
+    #[test]
+    fn a_cycle_terminates_instead_of_hanging() {
+        let rows = [row("a", Some("b")), row("b", Some("a"))];
+        assert_eq!(order(&rows).len(), 2);
+    }
+
+    #[test]
+    fn the_command_refuses_a_key_it_does_not_know() {
+        let error = serde_json::from_str::<DeleteUnusedCategories>(r#"{"category_ids":["a"]}"#)
+            .expect_err("an unknown key must refuse");
+        assert!(error.to_string().contains("`category_ids`"), "{error}");
+    }
+
+    #[test]
+    fn an_absent_list_and_a_null_list_are_the_same_request() {
+        let absent: DeleteUnusedCategories = serde_json::from_str("{}").unwrap();
+        let null: DeleteUnusedCategories = serde_json::from_str(r#"{"ids":null}"#).unwrap();
+        assert!(absent.ids.is_none() && null.ids.is_none());
+    }
+}

--- a/crates/wealth-core/src/verbs/finalize_user_restore.rs
+++ b/crates/wealth-core/src/verbs/finalize_user_restore.rs
@@ -1,0 +1,265 @@
+//! `finalize_user_restore` — the second pass, and the one audit row a restore
+//! writes.
+//!
+//! # What it is a port OF
+//!
+//! The **live** definition,
+//! `supabase/migrations/20260807083000_user_data_restore.sql:384-441`. Defined
+//! once, never redefined.
+//!
+//! # Why it still exists locally, when the reason for it does not
+//!
+//! In the cloud this pass is a necessity: `accounts.parent_account_id` and the
+//! `transactions ↔ transaction_splits` pair form cycles, no constraint in that
+//! schema is DEFERRABLE, and so neither side can be inserted first. R-11. This
+//! schema declares both of the cycle's keys `DEFERRABLE INITIALLY DEFERRED` and
+//! `specs/r11-deferred-keys-close-the-transaction-split-cycle` proves one COMMIT
+//! closes it, so the necessity is gone.
+//!
+//! The verb is ported anyway, for a reason that has nothing to do with
+//! constraints: **the links are a separate payload in the backup file.**
+//! `backupService.buildBackupBundle` writes `links.account_parents` and
+//! `links.transaction_links` alongside the rows, and
+//! `localBackupService.applyLinks` — the browser edition, which has no
+//! constraints at all — applies them anyway *"because it is what
+//! finalize_user_restore applies, and a file whose two copies disagree must
+//! restore the same way on both engines rather than differently"*. That argument
+//! is the whole case here too.
+//!
+//! # `updated_at`, and the one guard this family needs
+//!
+//! X-4. These are UPDATEs, and every UPDATE re-dates the row it touches — which
+//! is why the cloud redefined `update_updated_at_column` in the same migration to
+//! stand down while `app.restore_in_progress` is set. Locally the same exemption
+//! is `_rpc_guard('restore')`, already in every `updated_at` trigger's WHEN
+//! clause. MEASURED, both ways, on this schema:
+//!
+//! ```text
+//! link update, no guard    -> updated_at 2026-08-08   (today)
+//! link update, with guard  -> updated_at 2019-01-01   (the row's own date)
+//! ```
+//!
+//! The consequence, in the migration's own words: *"a backup that returns a
+//! decade of transfers dated today is not a backup"*.
+//!
+//! The guard is held UNCONDITIONALLY here, which is the opposite of the choice
+//! [`super::delete_transaction`] and [`super::wipe_user_financial_data`] make
+//! about `leg`, and for a reason: those two stand a PROTECTION down, so holding
+//! it where it is not needed weakens a rule. This one stands a CONVENIENCE down —
+//! a trigger whose only job is to stamp a timestamp on a row the writer did not
+//! stamp — and every write this verb makes is a write that must keep its own
+//! timestamp. There is no case where holding it is wrong.
+//!
+//! # Which rows it will not touch
+//!
+//! `AND user_id = v_owner`, and MEASURED: a link naming a row this login does not
+//! have relinks nothing and refuses nothing — the count comes back 0. A NULL
+//! parent is skipped by the RPC's own `IS NOT NULL` filter, and a transaction
+//! link with both columns null by its `OR`, so neither is counted; both are
+//! reproduced, because the counts are what the client reports to the user.
+//!
+//! A parent owned by somebody else is a different matter: MEASURED, the cloud
+//! refuses it at `accounts_parent_account_id_user_fkey` — the composite key from
+//! `20260808170000` — and this schema's twin refuses it too, by a name SQLite does
+//! not give. Both refuse; only the wording differs.
+//!
+//! # The audit row, and the one place this deliberately does not match
+//!
+//! The cloud writes exactly one entry for the whole operation, and MEASURED it
+//! has this shape:
+//!
+//! ```text
+//! entity     account
+//! entity_id  <the USER's id, not an account's>
+//! action     update
+//! before     NULL
+//! after      {"event": "restore_completed", "accounts_relinked": n, "transactions_relinked": m}
+//! ```
+//!
+//! An `update` with no `before`. The cloud's `financial_audit_log` has no
+//! constraint on that pairing — MEASURED: its only CHECK is the action
+//! enumeration. This schema has three, and `audit_update_has_both` is one of them
+//! (U-6, listed in the canonical inventory as **local-only**): MEASURED, that
+//! exact row is refused here with `CHECK constraint failed: audit_update_has_both`.
+//!
+//! So the local entry records the same fact, with the same entity, the same
+//! entity_id and the same payload, under `create` instead of `update`. That is a
+//! DECLARED divergence and it is the stricter reading rather than a workaround:
+//! an audit entry claiming something was updated while refusing to say what it
+//! was before is an entry that cannot answer the question the log exists for. A
+//! restore completing is a fact that did not exist and now does, which is what
+//! `create` means, and `audit_create_has_no_before` is satisfied by the same NULL
+//! the cloud already writes.
+//!
+//! Recorded rather than fixed in the cloud, because changing a live audit row's
+//! action is a migration with its own reasoning and this is a port.
+
+use rusqlite::{params, Connection, TransactionBehavior};
+use serde::{Deserialize, Serialize};
+
+use crate::audit::{self, Action};
+use crate::db;
+use crate::error::{CoreError, CoreResult};
+
+/// One entry of `links.account_parents`.
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct AccountParent {
+    /// The child account.
+    pub id: String,
+    /// The account it nests under. A null is skipped, not written.
+    #[serde(default)]
+    pub parent_account_id: Option<String>,
+}
+
+/// One entry of `links.transaction_links`.
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct TransactionLink {
+    /// The row being relinked.
+    pub id: String,
+    /// Its counterpart transaction.
+    #[serde(default)]
+    pub linked_transfer_id: Option<String>,
+    /// Its counterpart split line.
+    #[serde(default)]
+    pub linked_transfer_split_id: Option<String>,
+}
+
+/// `p_links`, as the backup file spells it.
+#[derive(Debug, Default, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct RestoreLinks {
+    /// Nested-account pairings.
+    #[serde(default)]
+    pub account_parents: Vec<AccountParent>,
+    /// Transfer pairings, both kinds.
+    #[serde(default)]
+    pub transaction_links: Vec<TransactionLink>,
+}
+
+/// The command.
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct FinalizeUserRestore {
+    /// `p_links`. Absent is an empty object, exactly as `p_links = NULL` is in
+    /// the cloud — MEASURED: it relinks nothing and returns zeros.
+    #[serde(default)]
+    pub links: RestoreLinks,
+    /// `p_user_id`.
+    #[serde(default)]
+    pub user_id: Option<String>,
+}
+
+/// The RPC's return value, key for key.
+#[derive(Debug, Serialize)]
+pub struct FinalizeAnswer {
+    /// Accounts whose parent was patched.
+    pub accounts_relinked: i64,
+    /// Transactions whose transfer link was patched.
+    pub transactions_relinked: i64,
+}
+
+/// What the verb hands back.
+#[derive(Debug, Serialize)]
+pub struct FinalizeUserRestoreResult {
+    /// The projection both engines are compared on.
+    pub answer: FinalizeAnswer,
+    /// Dense sequence number of the single audit row.
+    pub audit_seq: i64,
+    /// Its chained hash.
+    pub audit_row_hash: String,
+}
+
+/// Close the links a restore left open, without re-dating a single row.
+///
+/// # Errors
+/// [`CoreError::Refused`] for `owner_unknown` or a rule the file enforced;
+/// [`CoreError::Storage`] for a fault.
+#[allow(clippy::needless_pass_by_value)]
+pub fn finalize_user_restore(
+    connection: &mut Connection,
+    command: FinalizeUserRestore,
+) -> CoreResult<FinalizeUserRestoreResult> {
+    let Some(owner) = command.user_id.clone() else {
+        return Err(CoreError::refuse(
+            "owner_unknown",
+            "could not establish which login to finalise",
+        ));
+    };
+
+    let transaction = connection.transaction_with_behavior(TransactionBehavior::Immediate)?;
+    let now = db::now(&transaction)?;
+
+    // X-4. Set before the first UPDATE, cleared before the commit, so a refusal
+    // anywhere below rolls the flag back with everything else.
+    transaction.execute("INSERT OR IGNORE INTO _rpc_guard VALUES ('restore')", [])?;
+
+    let mut accounts_relinked = 0_i64;
+    for link in &command.links.account_parents {
+        let Some(parent) = link.parent_account_id.as_deref() else { continue };
+        let moved = transaction.execute(
+            "UPDATE accounts
+                SET parent_account_id = ?1
+              WHERE id = ?2
+                AND user_id = ?3",
+            params![parent, link.id, owner],
+        )?;
+        accounts_relinked = accounts_relinked
+            .checked_add(super::count(moved)?)
+            .ok_or_else(too_many)?;
+    }
+
+    let mut transactions_relinked = 0_i64;
+    for link in &command.links.transaction_links {
+        if link.linked_transfer_id.is_none() && link.linked_transfer_split_id.is_none() {
+            continue;
+        }
+        let moved = transaction.execute(
+            "UPDATE transactions
+                SET linked_transfer_id       = ?1,
+                    linked_transfer_split_id = ?2
+              WHERE id = ?3
+                AND user_id = ?4",
+            params![link.linked_transfer_id, link.linked_transfer_split_id, link.id, owner],
+        )?;
+        transactions_relinked = transactions_relinked
+            .checked_add(super::count(moved)?)
+            .ok_or_else(too_many)?;
+    }
+
+    transaction.execute("DELETE FROM _rpc_guard WHERE flag = 'restore'", [])?;
+
+    let after = super::json_of(&serde_json::json!({
+        "event": "restore_completed",
+        "accounts_relinked": accounts_relinked,
+        "transactions_relinked": transactions_relinked,
+    }))?;
+    let entry = audit::write(
+        &transaction,
+        &owner,
+        "account",
+        // The cloud puts the USER's id in an entity_id column that names an
+        // account. Kept, because the entry is about the login rather than about
+        // any one account, and changing it would make the two logs disagree
+        // about which row a restore happened to.
+        &owner,
+        // The divergence, and its reasoning, is in this module's header.
+        Action::Create,
+        None,
+        Some(&after),
+        &now,
+    )?;
+
+    transaction.commit()?;
+
+    Ok(FinalizeUserRestoreResult {
+        answer: FinalizeAnswer { accounts_relinked, transactions_relinked },
+        audit_seq: entry.seq,
+        audit_row_hash: entry.row_hash,
+    })
+}
+
+fn too_many() -> CoreError {
+    CoreError::refuse("amount_out_of_range", "that is more rows than this ledger can count")
+}

--- a/crates/wealth-core/src/verbs/link_bank_account_snap.rs
+++ b/crates/wealth-core/src/verbs/link_bank_account_snap.rs
@@ -1,0 +1,232 @@
+//! `link_bank_account_snap` — the one write in this crate that sets an absolute
+//! balance, and the reason that is not a contradiction.
+//!
+//! # What it is a port OF
+//!
+//! The **live** definition,
+//! `supabase/migrations/20260613090000_bank_sync_atomic_import.sql:184-220`.
+//! Traced by grep across every migration: defined once, never redefined.
+//! `20260725120000:257` restates its grant and changes nothing.
+//!
+//! # The absent verb, and why this one is not it
+//!
+//! `verbs/mod.rs` opens by saying what is deliberately missing:
+//!
+//! > **`set_account_balance`.** DESIGN.md §6.5: *"Note what is absent:
+//! > `set_account_balance`. Deliberately. B-2."* Balance moves only as
+//! > `balance = balance ± delta` […] There is no way to set an absolute figure
+//! > because there is no function that takes one.
+//!
+//! This function takes an absolute figure. It is still not a balance setter,
+//! because it moves `initial_balance` by the same delta in the same statement:
+//!
+//! ```text
+//! initial_balance := initial_balance + (bank − balance)
+//! balance         := bank
+//! ```
+//!
+//! B-1 says `balance = initial_balance + Σ(transactions.amount)`. Adding the same
+//! delta to both sides leaves it true, which is what makes this a **rebase**
+//! rather than an override. MEASURED on the reference cluster, on an account
+//! holding −25.00 with one −25.00 row against it, snapped to 10.00:
+//!
+//! ```text
+//! balance          -25.00 -> 10.00
+//! initial_balance    0.00 -> 35.00
+//! bank_balance          — -> 10.00
+//! B-1 holds                 true
+//! ```
+//!
+//! Not one transaction was invented, moved or deleted to get there. The account
+//! is now saying "I started with 35.00 and have spent 25.00", which is exactly
+//! what a person means when they link an account that has history the app has
+//! never seen. `bankBalanceSnapshot.ts:292` gates when it may run; this is what
+//! it does when it does.
+//!
+//! # `bank_balance` is written here and compared against everywhere else
+//!
+//! B-6, and `20260807200000:50-58` states it: *"bank_balance is the
+//! reconciliation reference — what the bank says the account holds […] Writers of
+//! this column must set bank_balance (and now bank_balance_date) and NOTHING
+//! else"*. This function is the exception the invariant already knows about: it
+//! is the LINK moment, and the whole point of a link snap is that the ledger is
+//! being brought to the bank's number once, deliberately, with an audit row
+//! saying so.
+//!
+//! MEASURED: it does **not** set `bank_balance_date`, which is the column
+//! `20260807200000` added so an old statement cannot overwrite a newer figure.
+//! That is the live behaviour and it is ported unchanged; a snap that dated its
+//! own figure would be a change to the cloud, not a port of it.
+//!
+//! # Two refusals that are deliberately one
+//!
+//! MEASURED: an account that does not exist and an account owned by somebody
+//! else both refuse with `account_not_found_or_not_owned`. That is the shape
+//! every RPC in this schema uses and the reason is in
+//! [`crate::row::account::read_owned`]: telling the two apart confirms an id
+//! exists to a caller who may not see it.
+//!
+//! # A NULL bank balance, and a divergence that cannot be expressed here
+//!
+//! MEASURED, and it is worth writing down because it is a live cloud defect
+//! rather than a difference of design: `link_bank_account_snap(account, user,
+//! NULL)` is ACCEPTED, and it sets `balance`, `initial_balance` and
+//! `bank_balance` all to NULL — `COALESCE(initial_balance,0) + (NULL − balance)`
+//! is NULL, and so is the assignment to `balance`. An account's ledger is
+//! destroyed by a link that reported nothing.
+//!
+//! It cannot happen here, and not because this verb checks for it: the argument
+//! is a [`crate::money::Money`], which has no null, and `accounts.balance_minor`
+//! is `NOT NULL`. The state is unreachable by construction on both counts. A
+//! DECLARED divergence in the local edition's favour, with nothing to implement.
+//!
+//! # No guard, measured
+//!
+//! This is an UPDATE of `accounts`, and every `trg_protect_split_*` trigger is
+//! `BEFORE UPDATE OF` a column on `transactions`. MEASURED anyway, because the
+//! guard question is asked per verb and answered by running it: snapping an
+//! account whose transaction is a split parent is accepted, guard table empty
+//! throughout. What DOES fire is `trg_accounts_updated_at` — and it stands down
+//! of its own accord, because this verb writes `updated_at` itself and the
+//! trigger's WHEN is `NEW.updated_at IS OLD.updated_at`.
+
+use rusqlite::{params, Connection, TransactionBehavior};
+use serde::{Deserialize, Serialize};
+
+use crate::audit::{self, Action};
+use crate::db;
+use crate::error::{CoreError, CoreResult, Refusal};
+use crate::money::Money;
+use crate::row::account::{self, AccountRow};
+
+/// The command. The RPC's three arguments.
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct LinkBankAccountSnap {
+    /// `p_account_id`.
+    pub account_id: String,
+    /// `p_user_id`. Not optional, unlike the ledger verbs: this function is
+    /// service-role only in the cloud and its owner argument has no default.
+    pub user_id: String,
+    /// `p_bank_balance`. A decimal string; a JSON number is refused at the
+    /// boundary, because a JSON number is a binary float.
+    pub bank_balance: Money,
+}
+
+/// What the verb hands back.
+#[derive(Debug, Serialize)]
+pub struct LinkBankAccountSnapResult {
+    /// The account as it stands after the snap — the RPC returns the whole row.
+    pub answer: AccountRow,
+    /// Dense sequence number of the audit row written for this snap.
+    pub audit_seq: i64,
+    /// Its chained hash.
+    pub audit_row_hash: String,
+}
+
+/// Bring an account to the bank's figure without breaking the ledger identity.
+///
+/// # Errors
+/// [`CoreError::Refused`] for `account_not_found_or_not_owned` or a rule the file
+/// enforced — including `accounts_balance_bounded`, which is what stops a bank
+/// reporting a number this file cannot hold;
+/// [`CoreError::Storage`] for a fault.
+#[allow(clippy::needless_pass_by_value)]
+pub fn link_bank_account_snap(
+    connection: &mut Connection,
+    command: LinkBankAccountSnap,
+) -> CoreResult<LinkBankAccountSnapResult> {
+    let transaction = connection.transaction_with_behavior(TransactionBehavior::Immediate)?;
+    let now = db::now(&transaction)?;
+
+    // `SELECT … FOR UPDATE` in the cloud. SQLite has one writer and this is
+    // inside BEGIN IMMEDIATE, so the row cannot move between the read and the
+    // write; the lock has nothing to add.
+    let Some(before) = account::read_owned(&transaction, &command.account_id, &command.user_id)?
+    else {
+        return Err(CoreError::Refused(
+            Refusal::named(
+                Refusal::ACCOUNT_NOT_FOUND_OR_NOT_OWNED,
+                Refusal::ACCOUNT_NOT_FOUND_OR_NOT_OWNED,
+            )
+            .with_hint("The account does not exist or does not belong to this user."),
+        ));
+    };
+
+    // The delta, computed once and applied to both sides so B-1 survives it.
+    // Checked arithmetic: a bank figure at one end of the range against a balance
+    // at the other would overflow, and an overflow here would move the ledger by
+    // a plausible-looking wrong amount rather than failing.
+    let delta = command
+        .bank_balance
+        .minor()
+        .checked_sub(before.balance.minor())
+        .ok_or_else(out_of_range)?;
+    let rebased = before
+        .initial_balance
+        .minor()
+        .checked_add(delta)
+        .ok_or_else(out_of_range)?;
+
+    let moved = transaction.execute(
+        "UPDATE accounts
+            SET initial_balance_minor = ?1,
+                balance_minor         = ?2,
+                bank_balance_minor    = ?2,
+                updated_at            = ?3
+          WHERE id = ?4
+            AND user_id = ?5",
+        params![
+            rebased,
+            command.bank_balance.minor(),
+            now,
+            command.account_id,
+            command.user_id
+        ],
+    )?;
+    // Unreachable: the row was found a moment ago under the same predicate and
+    // nothing can interleave inside BEGIN IMMEDIATE. Asserted because SQLite
+    // reports zero changed rows and raises nothing at all, which is the failure
+    // mode this crate refuses to leave silent.
+    if moved != 1 {
+        return Err(CoreError::refuse(
+            Refusal::ACCOUNT_NOT_FOUND_OR_NOT_OWNED,
+            "the account disappeared between reading it and snapping it",
+        ));
+    }
+
+    let after = account::read_owned(&transaction, &command.account_id, &command.user_id)?
+        .ok_or_else(|| {
+            CoreError::refuse(
+                Refusal::ACCOUNT_NOT_FOUND_OR_NOT_OWNED,
+                "the account disappeared between snapping it and reading it back",
+            )
+        })?;
+
+    let entry = audit::write(
+        &transaction,
+        &command.user_id,
+        "account",
+        &command.account_id,
+        Action::Update,
+        Some(&super::json_of(&before)?),
+        Some(&super::json_of(&after)?),
+        &now,
+    )?;
+
+    transaction.commit()?;
+
+    Ok(LinkBankAccountSnapResult {
+        answer: after,
+        audit_seq: entry.seq,
+        audit_row_hash: entry.row_hash,
+    })
+}
+
+fn out_of_range() -> CoreError {
+    CoreError::refuse(
+        "amount_out_of_range",
+        "the distance between this account's balance and the bank's figure is more than this \
+         ledger can count",
+    )
+}

--- a/crates/wealth-core/src/verbs/mod.rs
+++ b/crates/wealth-core/src/verbs/mod.rs
@@ -21,19 +21,67 @@
 //!   (`20260708140000`) all `RETURN trigger`; nothing calls them as functions.
 //!   They are C-3, C-4 and C-5 in `schema.sql`.
 //!
+//! # `migrate_categories_atomic` — OUT OF SCOPE, and this is the decision
+//!
+//! It was recorded here as *"needs a decision about what it would even do before
+//! it needs a port"*. This is that decision: **it is not ported, and it should
+//! not be.** Traced first, because "vestigial" would have been a much easier
+//! answer and it is not the true one.
+//!
+//! **It is live.** `planningService.ts:446`, from `ensureCategories`, called
+//! whenever a signed-in user's cloud category table is empty. Its live definition
+//! is `20260724100000:48-136`, the third of three (`20260611100000:36`,
+//! `20260723190000:54`), each recreating the previous one with one more column.
+//!
+//! **What it does** is four passes over a category tree the CLIENT is holding:
+//! mint a fresh uuid for every incoming id (pass 1), insert every row under its
+//! new id with `parent_id` deliberately NULL (pass 2), wire the parents through
+//! the map (pass 3), and then rewrite `transactions.category` and
+//! `budgets.category` through the same map (pass 4). It refuses with
+//! `categories_already_migrated` if the user has any category at all.
+//!
+//! **Why it exists**: the localStorage era gave categories ids like `'food'` and
+//! `'transfer-out'`, and the cloud's `categories.id` is a uuid. The function is
+//! the one-way door between those two id spaces, and pass 4 is the whole point —
+//! the references have to move in the same transaction as the rows, or a
+//! half-migrated user has transactions filed under ids nothing answers to.
+//!
+//! **Why a local file never needs it**: there is no second id space. A local file
+//! mints its own uuids at creation, and the two ways a category tree can arrive
+//! in one are both already covered by verbs that exist and are proven:
+//!
+//! * a **restore** — [`restore_user_chunk`] inserts categories under the ids the
+//!   backup carries, verbatim, and X-9 puts any remapping on the client, before a
+//!   single row is sent (`crate::backup` carries that argument);
+//! * a **seed** — a brand-new file's default set is inserted under ids the local
+//!   edition generates, so there is nothing to remap and nothing to be atomic
+//!   about beyond the insert itself. `categories` has no create/update/delete
+//!   verb precisely because the cloud has none either; the table and its
+//!   constraints are the authority.
+//!
+//! Porting it anyway would put a **second** category-tree writer in the crate,
+//! one whose only distinguishing behaviour — the id remap — is a translation
+//! between two id spaces the local edition does not have. Its idempotency guard
+//! would then be the only part still doing work, and that guard is
+//! [`user_financial_data_is_empty`]'s question asked about one table.
+//!
+//! The one thing that WOULD change this: a cloud→local migration path, where a
+//! user's cloud tree is pulled into a fresh file. That is DESIGN.md §9.1's
+//! explicitly out-of-scope *"cloud↔local sync"*, and if it is ever built it wants
+//! `migrate_categories_atomic`'s shape rather than its code, because the
+//! direction of travel is reversed and the id space that needs remapping is the
+//! destination's.
+//!
 //! # Deliberately not done YET, and named so nobody has to re-derive it
 //!
-//! Two category RPCs the client really does call are outside this batch, both
-//! from `planningService.ts`:
-//!
-//! * `migrate_categories_atomic` (`:446`) — first-cloud-load seeding, which
-//!   remaps every transaction and budget reference in one transaction. It has no
-//!   meaning in a local file that was never on the cloud, so it needs a decision
-//!   about *what it would even do* before it needs a port.
-//! * `delete_unused_categories` (`:511`) — the Money-set "replace" import's bulk
-//!   prune. Its live definition is `20260713100000:319`, it re-verifies every row
-//!   server-side, and it is a straightforward port. It is simply not in this
-//!   batch.
+//! Nothing in the category family is now outstanding.
+//! [`delete_unused_categories`] — the Money-set "replace" import's bulk prune,
+//! `planningService.ts:511` — was the last of the two named here, and it is
+//! ported. What it found is worth reading before touching it: the RPC has no
+//! refusal of its own, the FILE has one anyway through C-5, the "a stale client
+//! can never destroy referenced data" promise has a measured hole in it that the
+//! port reproduces on purpose, and the cloud's single-statement DELETE cannot be
+//! spelled as a single statement locally without changing the number it returns.
 //!
 //! # An obligation recorded before the verb that needs it existed — now DONE
 //!
@@ -61,10 +109,9 @@
 //! so found the **second** direction the addendum had not seen — a split parent
 //! whose own line is a leg, where the cascade fires
 //! `trg_protect_linked_leg_delete` instead. Its module documentation is the
-//! record. The four remaining paths (the duplicate sweep, the wipe, the
-//! restore's pre-clear, the transfer-unlink repair) still owe the same guard,
-//! and `delete_transaction::touches_a_transfer_leg` is the condition they should
-//! reuse rather than re-derive.
+//! record. `delete_transaction::touches_a_transfer_leg` is the condition the
+//! other paths should reuse rather than re-derive — and the two paragraphs below
+//! are what became of the four that were still owing when it was written.
 //!
 //! `create_transaction` and `update_transaction` delete no transaction, so
 //! neither carries the guard — and `update_transaction` deliberately does not
@@ -75,8 +122,23 @@
 //! whole of that path, and neither deletes a transaction — the unlink is an
 //! UPDATE of `linked_transfer_id` and the repair is three UPDATEs. So the
 //! obligation does not apply to them, which is a better outcome than discharging
-//! it. Three paths still owe the guard: the duplicate sweep, the wipe, and the
-//! restore's pre-clear.
+//! it.
+//!
+//! **The wipe and the restore's pre-clear are the same path**, and it is now
+//! discharged too: [`wipe_user_financial_data`] IS the pre-clear a restore
+//! demands, and it holds `_rpc_guard('leg')` conditionally, on the same condition
+//! [`delete_transaction`] uses. Its module documentation carries the measurement.
+//! One path is left owing the guard: the duplicate sweep.
+//!
+//! Discharging it also found the half of the obligation that was about the
+//! SCHEMA rather than about a verb. `trg_unnest_account_references` nulls
+//! `transfer_account_id` in a BEFORE DELETE trigger — a workaround for SQLite
+//! having no `ON DELETE SET NULL (column)` — which leaves a linked row
+//! half-cleared for one statement, and `transactions_linked_has_target` (a CHECK
+//! this schema has and the cloud does not) refuses that state. No guard could
+//! have helped: the refusal is a CHECK, not a trigger. So "delete everything" was
+//! refused outright on any file holding one linked transfer, and the repair is in
+//! `schema.sql` rather than in a verb.
 //!
 //! # Which guard belongs to which verb — settled by measurement
 //!
@@ -97,6 +159,22 @@
 //! | [`merge_categories`] | no — the CASE keeps a split parent's category blank | **conditionally** — it re-files split lines |
 //! | [`apply_category_to_uncategorized`] | **no, and it must not** — see below | no |
 //! | [`confirm_transaction_categories`] | no, and structurally so | no |
+//! | [`user_financial_data_is_empty`] | no — it opens no transaction and writes nothing | no |
+//! | [`wipe_user_financial_data`] | no | **conditionally** — the pre-clear, R-5 |
+//! | [`restore_user_chunk`] | no, and proven so on BOTH engines | no |
+//! | [`finalize_user_restore`] | no | no |
+//! | [`link_bank_account_snap`] | no, and proven so | no |
+//! | [`delete_unused_categories`] | no, and proven so — it deletes a category, and the cascade's only writes are `category_id` columns nothing watches | no |
+//! | [`verify_integrity`] | no — it opens no transaction and writes nothing | no |
+//!
+//! The restore family adds a **third** flag to the table, which the first twelve
+//! verbs never needed: `_rpc_guard('restore')`, held by
+//! [`finalize_user_restore`] alone. It is the twin of the cloud's
+//! `app.restore_in_progress` session flag, and it is the only flag in the schema
+//! that stands down a *convenience* rather than a *protection* — the `updated_at`
+//! triggers exist to stamp a timestamp on a row whose writer did not, and a
+//! restore is precisely the writer that did. That difference is why it is the one
+//! flag held unconditionally.
 //!
 //! The split writer's own module documentation carries the proof: every write it
 //! makes to a *linked* line changes only `memo`, `sort_order` and `updated_at`,
@@ -164,6 +242,53 @@
 //! verb's own documentation carries the evidence), so the local refusal is a
 //! faithful port. `_rpc_guard('split')` would make the local edition silently
 //! succeed where the cloud fails, which is a divergence dressed as a fix.
+//!
+//! ## The restore family, and a guard the cloud appears to need and does not
+//!
+//! [`restore_user_chunk`] is the one that looks most like it should hold
+//! something: the RPC opens with `set_config('app.split_rpc', '1', true)` and its
+//! comment says *"whitelists the split guard for this transaction so restored
+//! split parents can carry is_split = true"*. MEASURED on the reference cluster,
+//! by listing the triggers rather than reading the comment: every split
+//! protection in the cloud is `BEFORE UPDATE` —
+//! `trg_protect_split_transaction_fields` and `trg_sweep_reconciled_into_archive`
+//! both — and a restore only ever INSERTs. The same is true here, where all four
+//! `trg_protect_split_*` triggers are `BEFORE UPDATE OF`. So the answer is
+//! *none*, on both engines, and the cloud's `set_config` is belt-and-braces
+//! rather than a rule this port would have missed. Copying it would have meant
+//! standing S-5 down for the largest INSERT in the product on the strength of a
+//! comment.
+//!
+//! [`wipe_user_financial_data`] is the opposite case and the reason the guard
+//! question is asked per verb: it holds nothing that a reading of its SQL would
+//! suggest — it issues ten DELETEs and touches no split column — and it needs
+//! `leg` anyway, because the cascade from `accounts` reaches
+//! `transaction_splits` and `trg_protect_linked_leg_delete` fires there.
+//!
+//! ## The prune, and a protection no guard may stand down
+//!
+//! [`delete_unused_categories`] is the third deleting verb, and the guard
+//! question has a new shape here: its cascade reaches a category the schema
+//! PROTECTS. Name a prunable parent and a To/From category sitting under it, and
+//! `parent_id ON DELETE CASCADE` walks the protected row straight into C-5's
+//! `BEFORE DELETE` trigger. MEASURED on both engines, and the local answer is
+//! `transfer_category_protected` on both — including with `_rpc_guard('split')`
+//! held, which changes nothing, because C-5 has no guard clause and must not
+//! acquire one. That is the difference between this and the R-5 leg trap: R-5's
+//! refusal blocked the remedy the error message itself recommended, so standing
+//! it down was the fix; here the refusal IS the answer, the cloud gives the same
+//! answer, and both engines lose the whole batch. The verb holds nothing.
+//!
+//! [`verify_integrity`] is outside the table's premise entirely — it is the
+//! second read-only verb in the crate — and it is the one place where the guard
+//! table itself is a subject rather than a tool: `schema.sql` records that a
+//! stray `_rpc_guard` row is impossible because the flag is set and cleared
+//! inside the transaction it authorises, "and verify_integrity() reports one
+//! anyway". It does not yet: no check in `v_integrity_violations` looks at
+//! `_rpc_guard`. Recorded here rather than fixed, because a check for a row that
+//! cannot exist needs a way to be planted before it can be proved, and every
+//! route to one goes through a crash mid-transaction that this harness has no
+//! way to stage.
 
 mod apply_category_to_uncategorized;
 mod clear_transfer_links;
@@ -171,13 +296,20 @@ mod confirm_transaction_categories;
 mod create_transaction;
 mod create_transfer_counterpart;
 mod delete_transaction;
+mod delete_unused_categories;
+mod finalize_user_restore;
+mod link_bank_account_snap;
 mod link_split_line_transfer;
 mod link_transfer_pair;
 mod merge_categories;
 mod repair_claimed_transfer;
+mod restore_user_chunk;
 mod set_transaction_splits_with_legs;
 mod transfer;
 mod update_transaction;
+mod user_financial_data_is_empty;
+mod verify_integrity;
+mod wipe_user_financial_data;
 
 pub use apply_category_to_uncategorized::{
     apply_category_to_uncategorized, ApplyCategoryToUncategorized,
@@ -197,6 +329,16 @@ pub use create_transfer_counterpart::{
 pub use delete_transaction::{
     delete_transaction, DeleteTransaction, DeleteTransactionResult,
 };
+pub use delete_unused_categories::{
+    delete_unused_categories, DeleteUnusedCategories, DeleteUnusedCategoriesResult, PruneAnswer,
+};
+pub use finalize_user_restore::{
+    finalize_user_restore, AccountParent, FinalizeAnswer, FinalizeUserRestore,
+    FinalizeUserRestoreResult, RestoreLinks, TransactionLink,
+};
+pub use link_bank_account_snap::{
+    link_bank_account_snap, LinkBankAccountSnap, LinkBankAccountSnapResult,
+};
 pub use link_split_line_transfer::{
     link_split_line_transfer, LinkSplitLineTransfer, LinkSplitLineTransferResult,
 };
@@ -205,12 +347,26 @@ pub use merge_categories::{merge_categories, MergeCategories, MergeCategoriesRes
 pub use repair_claimed_transfer::{
     repair_claimed_transfer, RepairClaimedTransfer, RepairClaimedTransferResult,
 };
+pub use restore_user_chunk::{
+    restore_user_chunk, Chunk, RestoreAnswer, RestoreUserChunk, RestoreUserChunkResult,
+};
 pub use set_transaction_splits_with_legs::{
     set_transaction_splits_with_legs, SetTransactionSplitsWithLegs,
     SetTransactionSplitsWithLegsResult,
 };
 pub use update_transaction::{
     update_transaction, TransactionPatch, UpdateTransaction, UpdateTransactionResult,
+};
+pub use user_financial_data_is_empty::{
+    user_financial_data_is_empty, IsEmptyAnswer, UserFinancialDataIsEmpty,
+    UserFinancialDataIsEmptyResult,
+};
+pub use verify_integrity::{
+    verify_integrity, Finding, IntegrityReport, VerifyIntegrity, VerifyIntegrityResult,
+};
+pub use wipe_user_financial_data::{
+    wipe_user_financial_data, WipeCounts, WipeUserFinancialData, WipeUserFinancialDataResult,
+    CONFIRMATION,
 };
 
 // ── Three things the category family needed three copies of ─────────────────

--- a/crates/wealth-core/src/verbs/restore_user_chunk.rs
+++ b/crates/wealth-core/src/verbs/restore_user_chunk.rs
@@ -1,0 +1,256 @@
+//! `restore_user_chunk` — the port of the verb that puts a backup back.
+//!
+//! # What it is a port OF
+//!
+//! The **live** definition,
+//! `supabase/migrations/20260807083000_user_data_restore.sql:230-374`. Defined
+//! once, never redefined. The column translation it needs is [`crate::backup`],
+//! which also records the one thing this verb must NOT become: a second copy of
+//! `backupService.remapBackupIds`, which runs on the client.
+//!
+//! # The refusal ORDER, measured
+//!
+//! Five outcomes, and four of them are decided before a row is looked at.
+//! MEASURED on the reference cluster:
+//!
+//! ```text
+//! owner absent                          -> owner_unknown
+//! rows is a JSON object                 -> rows_not_an_array
+//! rows is a JSON null                   -> rows_not_an_array
+//! rows is SQL NULL (the key is absent)  -> 0, no refusal          <- a hole, ported
+//! rows is [] , entity = accounts        -> 0, no refusal          <- beats the precondition
+//! rows is [] , entity = not_a_table     -> 0, no refusal          <- beats the whitelist
+//! rows is [row], target holds data      -> restore_target_not_empty  (accounts only)
+//! rows is [row], entity = not_a_table   -> restore_entity_unknown
+//! ```
+//!
+//! Two of those are surprises worth keeping rather than tidying:
+//!
+//! * **An empty chunk is always accepted**, whatever the entity is called. The
+//!   length test comes before both the precondition and the whitelist, so a
+//!   restore that sends no rows for a table it invented is not told about it.
+//! * **`rows_not_an_array` does not catch SQL NULL.** `jsonb_typeof(NULL)` is
+//!   NULL, `NULL <> 'array'` is NULL, and a plpgsql `IF` treats NULL as false —
+//!   so the guard is silently skipped and the function returns 0. [`Chunk::rows`]
+//!   is a [`crate::wire::Field`] precisely so that a Rust type can tell the three
+//!   states apart and reproduce this rather than accidentally improving it.
+//!
+//! # The precondition is checked on `accounts`, and only on `accounts`
+//!
+//! MEASURED: a `transactions` chunk sent into a login that already holds data is
+//! NOT refused. The precondition is therefore only as strong as the caller's
+//! ordering — which is why `backupService.RESTORE_STEPS` puts accounts first and
+//! says so, and why the entity name is compared as a **string** here, before
+//! [`crate::backup::Entity::parse`] runs. Resolving the entity earlier would make
+//! `restore_entity_unknown` fire ahead of `restore_target_not_empty`, and the
+//! order would silently stop matching.
+//!
+//! The rule bites in a second direction that is easy to miss: MEASURED, sending
+//! `categories` first and `accounts` second gets `restore_target_not_empty` on
+//! the accounts chunk, because the categories made the login non-empty. Accounts
+//! are not merely conventionally first; nothing else can go first.
+//!
+//! # One transaction, and why that is allowed to differ
+//!
+//! DESIGN.md §5 divergence 6: *"Restore is chunked, not atomic | Restore is one
+//! transaction | X-7. No request-size cliff locally."* The cloud chunks because a
+//! 50k-transaction dataset is tens of megabytes and a single request that size is
+//! a cliff waiting to be hit on the one operation a user cannot afford to have
+//! fail; its own comment calls the resulting non-atomicity *"honest"* and leans on
+//! the empty-login precondition to make a half-restore survivable.
+//!
+//! Locally there is no request. So this verb takes a LIST of chunks and applies
+//! them in ONE SQLite transaction. Three things make that the right call rather
+//! than a liberty:
+//!
+//! 1. R-11. `transactions.linked_transfer_split_id` and
+//!    `transaction_splits.linked_transfer_id` form a cycle that Postgres cannot
+//!    close in one pass — nothing in that schema is DEFERRABLE, which is what
+//!    `finalize_user_restore` exists for. This schema declares both keys
+//!    `DEFERRABLE INITIALLY DEFERRED`, and
+//!    `specs/r11-deferred-keys-close-the-transaction-split-cycle` proves the cycle
+//!    closes in one COMMIT. The second pass is a workaround for a thing that is
+//!    not true here.
+//! 2. `localBackupService.restoreLocalBackup` already promises all-or-nothing —
+//!    its store's `setMany` is one IndexedDB readwrite transaction *"so a restore
+//!    either lands completely or leaves the previous contents untouched"*. A
+//!    SQLite edition that could half-restore would be the weaker of the two local
+//!    engines.
+//! 3. The cloud's own fallback is *"recovery is wipe and retry"*. Not needing it
+//!    is strictly better and costs nothing.
+//!
+//! `finalize_user_restore` is still ported and still called, and that is
+//! deliberate: the links travel in the backup file as a separate payload, both
+//! engines must apply them the same way, and a local edition that reached the
+//! same rows by a different route would make the two files diverge in what they
+//! mean. See that verb for what it does that this one cannot.
+//!
+//! # No guard, and that is a fact about both engines
+//!
+//! The RPC opens with `set_config('app.split_rpc', '1', true)`, which reads like
+//! a restore needing the split guard. It does not. MEASURED on the reference
+//! cluster: every split protection in the cloud is `BEFORE UPDATE` —
+//! `trg_protect_split_transaction_fields` and `trg_sweep_reconciled_into_archive`
+//! both are — and a restore only ever INSERTs. The same is true here: all four
+//! `trg_protect_split_*` triggers are `BEFORE UPDATE OF`, and MEASURED, inserting
+//! a row with `is_split = 1` and no guard at all is accepted. So this verb holds
+//! nothing, and the cloud's `set_config` is belt-and-braces rather than a rule
+//! that was missed.
+//!
+//! The `restore` guard is not held here either, for a plainer reason: the
+//! `updated_at` triggers are `AFTER UPDATE`, and an INSERT does not fire one.
+//! `updated_at` survives because the write is an INSERT, which is exactly the
+//! argument the migration makes at `:35-38`.
+
+use rusqlite::{params, Connection, TransactionBehavior};
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+use crate::backup::{self, BackupRow, Dropped, Entity};
+use crate::error::{CoreError, CoreResult, Refusal};
+use crate::wire::Field;
+
+/// One entity's rows — the RPC's `(p_entity, p_rows)` pair.
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct Chunk {
+    /// `p_entity`. Matched against a fixed list; there is no dynamic SQL.
+    pub entity: String,
+    /// `p_rows`. Absent is the SQL-NULL hole above; JSON null is a refusal.
+    #[serde(default)]
+    pub rows: Field<Value>,
+}
+
+/// The command.
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct RestoreUserChunk {
+    /// One or more chunks, applied in the order given, in one transaction.
+    pub chunks: Vec<Chunk>,
+    /// `p_user_id`. Every restored row is re-owned to this login (X-6).
+    #[serde(default)]
+    pub user_id: Option<String>,
+}
+
+/// The RPC's return value, plus the one thing the cloud has no equivalent for.
+#[derive(Debug, Serialize)]
+pub struct RestoreAnswer {
+    /// Rows inserted, across every chunk. The RPC returns this as a bare bigint.
+    pub inserted: i64,
+    /// What the file carried and this ledger has nowhere to keep. Absent when
+    /// there was nothing, so an ordinary restore's answer is the RPC's answer and
+    /// nothing else.
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub dropped: Vec<Dropped>,
+}
+
+/// What the verb hands back.
+#[derive(Debug, Serialize)]
+pub struct RestoreUserChunkResult {
+    /// The projection both engines are compared on.
+    pub answer: RestoreAnswer,
+}
+
+/// Insert one or more entities' whole rows from a backup, re-owning each to the
+/// caller.
+///
+/// # Errors
+/// [`CoreError::Refused`] for the five named refusals above, or
+/// `restore_row_refused` naming the row a rule stopped;
+/// [`CoreError::Storage`] for a fault.
+#[allow(clippy::needless_pass_by_value)]
+pub fn restore_user_chunk(
+    connection: &mut Connection,
+    command: RestoreUserChunk,
+) -> CoreResult<RestoreUserChunkResult> {
+    let Some(owner) = command.user_id.clone() else {
+        return Err(CoreError::refuse(
+            "owner_unknown",
+            "could not establish which login to restore into",
+        ));
+    };
+
+    let transaction = connection.transaction_with_behavior(TransactionBehavior::Immediate)?;
+    let mut inserted = 0_i64;
+    let mut dropped: Vec<Dropped> = Vec::new();
+
+    for chunk in &command.chunks {
+        // The three states of p_rows, in the RPC's own order.
+        let rows: &[Value] = match &chunk.rows {
+            // SQL NULL. The guard below cannot see it in the cloud either.
+            Field::Absent => &[],
+            Field::Null => {
+                return Err(CoreError::refuse(
+                    "rows_not_an_array",
+                    "each chunk must be a JSON array of whole rows",
+                ))
+            }
+            Field::Value(value) => match value.as_array() {
+                Some(array) => array.as_slice(),
+                None => {
+                    return Err(CoreError::refuse(
+                        "rows_not_an_array",
+                        "each chunk must be a JSON array of whole rows",
+                    ))
+                }
+            },
+        };
+
+        // An empty chunk beats BOTH the precondition and the whitelist, because
+        // the length test comes before either. The entity is still a string at
+        // this point, and must be.
+        if rows.is_empty() {
+            continue;
+        }
+
+        if chunk.entity == Entity::Accounts.as_str() && !is_empty(&transaction, &owner)? {
+            return Err(CoreError::Refused(
+                Refusal::named(
+                    "restore_target_not_empty",
+                    "this login already holds data — clear it first, because restoring on top \
+                     would mix two datasets and silently re-date your history",
+                )
+                .with_hint("Erase everything first, or restore into a fresh login."),
+            ));
+        }
+
+        let entity = Entity::parse(&chunk.entity)?;
+        for row in rows {
+            let Some(object) = row.as_object() else {
+                return Err(CoreError::refuse(
+                    "rows_not_an_array",
+                    "each chunk must be a JSON array of whole rows",
+                ));
+            };
+            let row: &BackupRow = object;
+            backup::insert_row(&transaction, entity, row, &owner, &mut dropped)?;
+            inserted = inserted.checked_add(1).ok_or_else(|| {
+                CoreError::refuse("amount_out_of_range", "that is more rows than this ledger can count")
+            })?;
+        }
+    }
+
+    transaction.commit()?;
+
+    Ok(RestoreUserChunkResult { answer: RestoreAnswer { inserted, dropped } })
+}
+
+/// The precondition's own question, asked inside the restore's transaction.
+///
+/// Deliberately the same three tables [`super::user_financial_data_is_empty`]
+/// asks about, and deliberately not a call to it: that verb takes a `&Connection`
+/// and would be reading outside this transaction's view of the file.
+fn is_empty(transaction: &rusqlite::Transaction<'_>, owner: &str) -> CoreResult<bool> {
+    let found: i64 = transaction.query_row(
+        "SELECT EXISTS (
+           SELECT 1 FROM accounts     WHERE user_id = ?1
+            UNION ALL
+           SELECT 1 FROM categories   WHERE user_id = ?1
+            UNION ALL
+           SELECT 1 FROM transactions WHERE user_id = ?1
+         )",
+        params![owner],
+        |row| row.get(0),
+    )?;
+    Ok(found == 0)
+}

--- a/crates/wealth-core/src/verbs/user_financial_data_is_empty.rs
+++ b/crates/wealth-core/src/verbs/user_financial_data_is_empty.rs
@@ -1,0 +1,95 @@
+//! `user_financial_data_is_empty` — the port of the question a restore asks
+//! before it will do anything.
+//!
+//! # What it is a port OF
+//!
+//! The **live** definition,
+//! `supabase/migrations/20260807083000_user_data_restore.sql:107-130`. Traced by
+//! grep across every migration: defined once, never redefined.
+//!
+//! # The three tables, and why it is not "is there any data"
+//!
+//! `accounts`, `categories`, `transactions` — and nothing else. MEASURED on the
+//! reference cluster: a login holding only a budget answers **true**. That is
+//! not an oversight in the RPC, it is the precondition doing exactly the job the
+//! migration describes. The hazards the emptiness rule neutralises are all about
+//! those three tables:
+//!
+//! * inserting an account mints a To/From **category** with a fresh id, colliding
+//!   with the one the backup already carries under its original id;
+//! * `categories_user_id_name_parent_id_key` collides with a seeded default set;
+//! * `transactions_import_source_unique` collides with a previous import.
+//!
+//! A budget cannot cause any of them. So the question is the narrow one, and
+//! `localBackupService.localFinancialDataIsEmpty` asks the same narrow one *"so
+//! that 'empty' means one thing across both engines"*.
+//!
+//! # `p_user_id IS NULL` means "every row in the table"
+//!
+//! MEASURED: with no owner named, the RPC's `EXISTS` has no filter and reports on
+//! the whole table. In the cloud that is nearly always the same answer, because
+//! RLS has already narrowed what the caller can see. There is no RLS in a local
+//! file, so here it is literally every row — which for a single-login file is
+//! also the same answer, and is why the argument is passed through rather than
+//! quietly required.
+//!
+//! # It writes nothing, and audits nothing
+//!
+//! The only verb in this crate that opens no transaction: there is nothing to be
+//! atomic about, and an audit entry recording that somebody asked a question
+//! would be noise in a log whose whole value is that every line in it is a
+//! change.
+
+use rusqlite::{params, Connection};
+use serde::{Deserialize, Serialize};
+
+use crate::error::CoreResult;
+
+/// The command. The RPC's single argument.
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct UserFinancialDataIsEmpty {
+    /// `p_user_id`. Absent means "every row in the file".
+    #[serde(default)]
+    pub user_id: Option<String>,
+}
+
+/// The RPC returns a bare boolean; this is that boolean, in the object shape the
+/// differential harness compares two engines' answers in.
+#[derive(Debug, Serialize)]
+pub struct IsEmptyAnswer {
+    /// True when there is no account, no category and no transaction.
+    pub empty: bool,
+}
+
+/// The answer.
+#[derive(Debug, Serialize)]
+pub struct UserFinancialDataIsEmptyResult {
+    /// The projection both engines are compared on.
+    pub answer: IsEmptyAnswer,
+}
+
+/// Is this file empty enough to restore a backup into?
+///
+/// # Errors
+/// [`crate::error::CoreError::Storage`] if the read fails. This verb has no
+/// refusal: every question it can be asked has an answer.
+#[allow(clippy::needless_pass_by_value)]
+pub fn user_financial_data_is_empty(
+    connection: &Connection,
+    command: UserFinancialDataIsEmpty,
+) -> CoreResult<UserFinancialDataIsEmptyResult> {
+    let found: i64 = connection.query_row(
+        "SELECT EXISTS (
+           SELECT 1 FROM accounts     WHERE (?1 IS NULL OR user_id = ?1)
+            UNION ALL
+           SELECT 1 FROM categories   WHERE (?1 IS NULL OR user_id = ?1)
+            UNION ALL
+           SELECT 1 FROM transactions WHERE (?1 IS NULL OR user_id = ?1)
+         )",
+        params![command.user_id],
+        |row| row.get(0),
+    )?;
+
+    Ok(UserFinancialDataIsEmptyResult { answer: IsEmptyAnswer { empty: found == 0 } })
+}

--- a/crates/wealth-core/src/verbs/verify_integrity.rs
+++ b/crates/wealth-core/src/verbs/verify_integrity.rs
@@ -1,0 +1,214 @@
+//! `verify_integrity` — the file's own answer to *"is any of this wrong?"*.
+//!
+//! # This one is not a port, and that had to be established rather than assumed
+//!
+//! Every other verb in this crate names the migration it is a port of. This one
+//! cannot, because **there is no cloud counterpart at all**. TRACED, three ways,
+//! before a line of it was written:
+//!
+//! ```text
+//! grep -rn verify_integrity supabase/ api/ src/   -> nothing but schema.sql and its own specs
+//! grep -rn "CREATE VIEW"    supabase/migrations/  -> no rows
+//! grep -rln integrity       supabase/migrations/  -> two files, both prose in a comment
+//! ```
+//!
+//! The nearest Postgres relatives are two one-off verification SELECTs that a
+//! migration runs once and discards — `20260808090000:292-299` and
+//! `20260807200000:100-110` — and both are B-1 alone. `schema.sql`'s own section
+//! header used to claim *"each of these has a Postgres twin … so the differential
+//! harness can compare violation NAMES across engines"*; that claim was wrong and
+//! is corrected in the same change as this file.
+//!
+//! **So this verb is LOCAL-ONLY and has no differential oracle.** Its specs run
+//! on SQLite alone and say so — `parity: 'not-comparable'`, the same declaration
+//! the constraint harness already uses for a rule only one engine has. The design
+//! always intended it that way: DESIGN.md calls the view *"the single
+//! highest-leverage artifact in the local core"*, and the leverage comes from the
+//! local edition having no RLS, no service role and no second implementation to
+//! be checked against. The file has to be able to check itself.
+//!
+//! # Seventeen checks: fifteen rules and two suspicions
+//!
+//! `v_integrity_violations` is the whole implementation; this verb runs it,
+//! orders it and counts it. Fifteen checks report `severity = 'violation'` — a
+//! rule of the ledger that no constraint in either engine can hold — and two
+//! report `warning`:
+//!
+//! | severity | check |
+//! | --- | --- |
+//! | violation | `balance_identity` (B-1) |
+//! | violation | `split_sum`, `split_min_lines`, `orphan_split_lines` (S-1…S-3) |
+//! | violation | `transfer_link_not_mutual`, `transfer_amounts_not_opposite`, `transfer_same_account` (T-1…T-3) |
+//! | violation | `split_leg_amounts_not_opposite`, `split_leg_link_not_mutual` (T-4, T-5) |
+//! | violation | `dangling_category_ref`, `dangling_split_category_ref` (R-3) |
+//! | violation | `account_missing_transfer_category`, `account_multiple_transfer_categories` (C-3) |
+//! | violation | `audit_chain_broken` (A-1) |
+//! | violation | `account_nesting_too_deep` (I-1) |
+//! | **warning** | `card_account_sign_implausible` (TS-F1/TS-F2) |
+//! | **warning** | `bank_balance_implausible` (TS-I1/TS-I2) |
+//!
+//! The two warnings are PHASE1-PLAN §2.5's addendum, and they were added because
+//! the fifteen were MEASURED not to catch what they are for
+//! (`scratchpad/local-core/probe-integrity1.mjs`, cases 16 and 17: both ingest
+//! disasters planted, nothing fired). They are heuristics — a credit card
+//! genuinely can be in credit — which is why they are a separate severity rather
+//! than a sixteenth and seventeenth rule, and why [`IntegrityReport::ok`] ignores
+//! them.
+//!
+//! # Every check is proved to FIRE, and one of them can only be reached sideways
+//!
+//! A check nobody can plant is a check nobody can prove, so each of the
+//! seventeen has a spec that plants its violation and reads it back. Sixteen are
+//! plantable by ordinary SQL. `account_missing_transfer_category` is the
+//! exception and it is worth writing down, because the obvious plant is refused
+//! by the schema:
+//!
+//! ```text
+//! DELETE the Transfer anchor, then add an account   -> REFUSED transfer_category_protected
+//!   (the anchor's cascade reaches the EXISTING To/From rows, and C-5 stops it)
+//! add an account for a login that never had an anchor -> planted
+//! ```
+//!
+//! (MEASURED, `probe-integrity1.mjs`, cases `12` and `00 clean + a second
+//! login`.) So the violation is reachable only forwards — by creating an account
+//! whose owner has no Transfer anchor for C-3's trigger to hang the category
+//! from — never by removing a category that already exists. That is C-5 and C-3
+//! doing exactly their jobs, and it is why the spec for this check uses a second
+//! login rather than a delete.
+//!
+//! # It writes nothing, audits nothing and opens no transaction
+//!
+//! The second verb in the crate with that shape, after
+//! [`super::user_financial_data_is_empty`], and for the same reason: there is
+//! nothing to be atomic about, and an audit entry recording that somebody asked
+//! a question would be noise in a log whose whole value is that every line in it
+//! is a change.
+//!
+//! It also takes **no owner**. Every other verb here is scoped to a login;
+//! integrity is a property of the FILE. Three of the seventeen checks
+//! (`audit_chain_broken`, and both halves of the C-3 pair through their trigger)
+//! have no honest per-user reading at all, and a file whose stranger's rows are
+//! corrupt is a corrupt file. A `user_id` argument would have to be ignored by a
+//! third of the checks, which is worse than not having one.
+//!
+//! # The ORDER is part of the answer
+//!
+//! `UNION ALL` guarantees nothing about row order in either engine, and a report
+//! whose rows move between runs cannot be diffed by a human or asserted by a
+//! spec. The query orders by `check_name, entity, subject` — name first because
+//! that is how a reader groups them, and the id last because it is the only part
+//! that is arbitrary.
+
+use rusqlite::Connection;
+use serde::{Deserialize, Serialize};
+
+use crate::error::CoreResult;
+
+/// The severity a hard rule reports.
+const VIOLATION: &str = "violation";
+
+/// The command. It takes nothing, and the empty struct is the point — see the
+/// module docs on why there is no owner.
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct VerifyIntegrity {}
+
+/// One row of `v_integrity_violations`.
+///
+/// The field ORDER is the order the JSON carries, and specs assert against it;
+/// `check` first because it is what a reader groups by.
+#[derive(Debug, Serialize)]
+pub struct Finding {
+    /// `check_name` — the rule that fired, e.g. `balance_identity`.
+    pub check: String,
+    /// Which table [`Finding::id`] is a key of: `account`, `transaction`,
+    /// `split_line` or `audit_entry`.
+    pub entity: String,
+    /// The subject's id, in that table.
+    pub id: String,
+    /// `violation` for a rule of the ledger, `warning` for a heuristic.
+    pub severity: String,
+    /// The sentence a person is shown.
+    pub detail: String,
+}
+
+/// What the file says about itself.
+#[derive(Debug, Serialize)]
+pub struct IntegrityReport {
+    /// True when nothing of severity `violation` fired. Warnings do not count —
+    /// they are suspicions, and `v_integrity_ok` in `schema.sql` agrees.
+    pub ok: bool,
+    /// How many findings are rules.
+    pub violations: i64,
+    /// How many are suspicions.
+    pub warnings: i64,
+    /// Every finding, in `check_name, entity, subject` order.
+    pub findings: Vec<Finding>,
+}
+
+/// The answer.
+#[derive(Debug, Serialize)]
+pub struct VerifyIntegrityResult {
+    /// The projection the harness reads. `answer` rather than `transaction`
+    /// because this verb returns no row of the ledger — the same shape the
+    /// restore family uses.
+    pub answer: IntegrityReport,
+}
+
+/// Check this file.
+///
+/// # Errors
+/// [`crate::error::CoreError::Storage`] if the read fails. This verb has no
+/// refusal: every file has an answer, and a file with nothing wrong with it
+/// answers `ok`.
+#[allow(clippy::needless_pass_by_value)]
+pub fn verify_integrity(
+    connection: &Connection,
+    _command: VerifyIntegrity,
+) -> CoreResult<VerifyIntegrityResult> {
+    let mut statement = connection.prepare(
+        "SELECT check_name, entity, subject, severity, detail
+           FROM v_integrity_violations
+          ORDER BY check_name, entity, subject",
+    )?;
+
+    let rows = statement.query_map([], |row| {
+        Ok(Finding {
+            check: row.get(0)?,
+            entity: row.get(1)?,
+            id: row.get(2)?,
+            severity: row.get(3)?,
+            detail: row.get(4)?,
+        })
+    })?;
+
+    let mut findings = Vec::new();
+    for finding in rows {
+        findings.push(finding?);
+    }
+
+    // Counted here rather than by a second query: two queries could see two
+    // different files if anything wrote between them, and a report whose totals
+    // disagree with its own list is worse than no report.
+    let violations = super::count(
+        findings
+            .iter()
+            .filter(|finding| finding.severity == VIOLATION)
+            .count(),
+    )?;
+    let warnings = super::count(
+        findings
+            .iter()
+            .filter(|finding| finding.severity != VIOLATION)
+            .count(),
+    )?;
+
+    Ok(VerifyIntegrityResult {
+        answer: IntegrityReport {
+            ok: violations == 0,
+            violations,
+            warnings,
+            findings,
+        },
+    })
+}

--- a/crates/wealth-core/src/verbs/wipe_user_financial_data.rs
+++ b/crates/wealth-core/src/verbs/wipe_user_financial_data.rs
@@ -1,0 +1,307 @@
+//! `wipe_user_financial_data` — the port of "delete everything".
+//!
+//! # What it is a port OF
+//!
+//! The **live** definition,
+//! `supabase/migrations/20260807083000_user_data_restore.sql:143-211`. Defined
+//! once, never redefined.
+//!
+//! # The refusal order, measured rather than read
+//!
+//! Two refusals, and which one fires first is part of the contract because a
+//! caller with neither a phrase nor an owner must be told about the phrase — the
+//! thing they can fix — and not about an identity problem they cannot. MEASURED
+//! on the reference cluster:
+//!
+//! ```text
+//! confirm = NULL,   owner = named   -> wipe_not_confirmed
+//! confirm = wrong,  owner = named   -> wipe_not_confirmed
+//! confirm = right,  owner = none    -> owner_unknown
+//! confirm = wrong,  owner = none    -> wipe_not_confirmed     <- the order
+//! ```
+//!
+//! The phrase is compared with `IS DISTINCT FROM`, so it is exact: case, spacing
+//! and all. `localBackupService.LOCAL_WIPE_CONFIRMATION` holds the same literal
+//! *"so both engines ask the same"*.
+//!
+//! # Accounts first, and what the returned counts really say
+//!
+//! X-3. Deleting categories while their accounts are still there raises
+//! `transfer_category_protected` — MEASURED here too, on this schema:
+//! `DELETE FROM categories` first is REFUSED, and 5 categories are left standing.
+//! Accounts first means each To/From category arrives at C-5's trigger with its
+//! account row already gone, so the guard's `EXISTS` is false and it stands down.
+//!
+//! The consequence for the numbers this returns is worth stating, because they
+//! are not what a reader expects. MEASURED on the reference cluster, on a fixture
+//! holding two accounts, one transaction and five categories:
+//!
+//! ```text
+//! {"accounts": 2, "transactions": 0, "categories": 3, "budgets": 0, "goals": 0, "investments": 0}
+//! ```
+//!
+//! **Zero transactions**, because the account delete already cascaded them away,
+//! and **three** categories rather than five, because the two To/From rows went
+//! with their accounts. Each number is an honest report of what ITS OWN statement
+//! removed, and none of them is a report of what the operation removed. That is
+//! reproduced exactly rather than improved on — but not by `changes()`; see the
+//! measurement beside the delete helper for the one place SQLite and Postgres
+//! genuinely disagree about how many rows a statement took.
+//!
+//! # The guard, and the schema defect this verb found
+//!
+//! `verbs/mod.rs` recorded, before this verb existed, that the wipe owes
+//! `_rpc_guard('leg')`. It does, and MEASURED confirms it: without the guard,
+//! `DELETE FROM accounts` on a file holding one split transfer leg raises
+//! `split_leg_line_removed`, and `_rpc_guard('split')` does not help.
+//!
+//! What the obligation did not know is that the guard alone was not enough
+//! either. `trg_unnest_account_references` nulls `transfer_account_id` in a BEFORE
+//! DELETE trigger, which leaves the row half-cleared for one statement — and
+//! `transactions_linked_has_target`, a CHECK this schema has and the cloud does
+//! not, refuses that state. So "delete everything" was refused outright on any
+//! file containing a single linked transfer, which is every real file. The fix is
+//! in `schema.sql` (the trigger now clears the LINK before the target, exactly as
+//! Postgres's two independent key actions do a moment later) and is pinned by
+//! `specs/t8-deleting-an-account-unlinks-the-transfer-that-pointed-at-it` and
+//! `specs/r5-deleting-an-account-unlinks-the-split-leg-that-pointed-at-it`.
+//!
+//! # What it does NOT delete
+//!
+//! * **The audit log.** MEASURED on both engines: the rows this verb writes, and
+//!   every row written before it, survive. That is the point — the log is the only
+//!   thing that can still say what was there.
+//! * **The `users` row.** The login stays; only its financial data goes.
+//! * **`recurring_transactions`, in the cloud.** The RPC has no DELETE for them
+//!   and the cloud table has no foreign key on `account_id`, so MEASURED they
+//!   survive a cloud wipe. Locally `recurring_transactions.account_id` IS a
+//!   foreign key with ON DELETE CASCADE, so a template naming an account goes with
+//!   it and one naming no account stays. A DECLARED divergence, and the local
+//!   behaviour is the one that leaves less wreckage: a template pointing at an
+//!   account that no longer exists is a scheduled payment into nothing.
+
+use rusqlite::{params, Connection, TransactionBehavior};
+use serde::{Deserialize, Serialize};
+
+use crate::audit::{self, Action};
+use crate::db;
+use crate::error::{CoreError, CoreResult, Refusal};
+use crate::row;
+
+/// The exact phrase. `localBackupService.LOCAL_WIPE_CONFIRMATION` and the RPC's
+/// own literal, so all three ask for the same words.
+pub const CONFIRMATION: &str = "DELETE EVERYTHING";
+
+/// The command. The RPC's two arguments.
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct WipeUserFinancialData {
+    /// `p_confirm`. Compared exactly.
+    #[serde(default)]
+    pub confirm: Option<String>,
+    /// `p_user_id`.
+    #[serde(default)]
+    pub user_id: Option<String>,
+}
+
+/// Per-table counts, spelled and ordered as the RPC's jsonb spells them.
+#[derive(Debug, Serialize)]
+pub struct WipeCounts {
+    /// Accounts deleted. Their transactions, To/From categories and holdings go
+    /// with them and are counted by none of the fields below.
+    pub accounts: i64,
+    /// Transactions the account delete did NOT already take. Zero on any file
+    /// where every transaction belongs to an account, which is every file.
+    pub transactions: i64,
+    /// Categories left after the To/From rows cascaded.
+    pub categories: i64,
+    /// Budgets deleted.
+    pub budgets: i64,
+    /// Goals deleted. Their contributions cascade.
+    pub goals: i64,
+    /// Holdings deleted. Their movements cascade.
+    pub investments: i64,
+}
+
+/// What the verb hands back.
+#[derive(Debug, Serialize)]
+pub struct WipeUserFinancialDataResult {
+    /// The RPC's own return value.
+    pub answer: WipeCounts,
+    /// Dense sequence number of the LAST audit row written, or `None` when there
+    /// was nothing to audit.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub audit_seq: Option<i64>,
+}
+
+/// Erase this login's financial data so a backup can be restored into it.
+///
+/// # Errors
+/// [`CoreError::Refused`] for `wipe_not_confirmed`, `owner_unknown`, or a rule
+/// the file enforced; [`CoreError::Storage`] for a fault.
+// Long, and deliberately not split. The RPC is one function whose ORDER is its
+// whole contract — audit before deleting, accounts before categories, the guard
+// around all of it — and every extraction that has been tried moves one of those
+// statements somewhere a reader has to go and find it.
+#[allow(clippy::too_many_lines)]
+#[allow(clippy::needless_pass_by_value)]
+pub fn wipe_user_financial_data(
+    connection: &mut Connection,
+    command: WipeUserFinancialData,
+) -> CoreResult<WipeUserFinancialDataResult> {
+    // Both refusals are decided BEFORE a transaction is opened: neither depends
+    // on the file's contents, and the order between them is the measured one.
+    if command.confirm.as_deref() != Some(CONFIRMATION) {
+        return Err(CoreError::Refused(
+            Refusal::named(
+                "wipe_not_confirmed",
+                "this erases every account, transaction, budget and goal in this login — the \
+                 caller must pass the exact confirmation phrase",
+            )
+            .with_hint(&format!("The phrase is {CONFIRMATION}, exactly.")),
+        ));
+    }
+    let Some(owner) = command.user_id.clone() else {
+        return Err(CoreError::refuse(
+            "owner_unknown",
+            "could not establish which account to clear",
+        ));
+    };
+
+    let transaction = connection.transaction_with_behavior(TransactionBehavior::Immediate)?;
+    let now = db::now(&transaction)?;
+
+    // ── R-5. Held only where a split line is actually a transfer leg. ───────
+    // A guard that is always on is not a guard: this one stands two protection
+    // triggers down across the largest delete in the product, and it should do
+    // so only on the files that need it.
+    let guarded: i64 = transaction.query_row(
+        "SELECT EXISTS (
+           SELECT 1 FROM transaction_splits WHERE user_id = ?1 AND linked_transfer_id IS NOT NULL
+         )",
+        params![owner],
+        |row| row.get(0),
+    )?;
+    if guarded != 0 {
+        transaction.execute("INSERT OR IGNORE INTO _rpc_guard VALUES ('leg')", [])?;
+    }
+
+    // ── The per-row audit, BEFORE deleting, while the rows still exist to
+    //    describe. Transactions then accounts, the RPC's own order.
+    //
+    // ORDER BY id is a local strengthening: the cloud's cursors have no ORDER BY
+    // and the row order it writes in is whatever the executor picks. Here the
+    // order is part of the hash chain, so it has to be one somebody can
+    // reproduce.
+    let ids = |sql: &str| -> CoreResult<Vec<String>> {
+        let mut statement = transaction.prepare(sql)?;
+        let rows = statement.query_map(params![owner], |row| row.get::<_, String>(0))?;
+        let mut out = Vec::new();
+        for id in rows {
+            out.push(id?);
+        }
+        Ok(out)
+    };
+
+    let mut last_seq = None;
+    for id in ids("SELECT id FROM transactions WHERE user_id = ?1 ORDER BY id")? {
+        let before = row::read_transaction(&transaction, &id)?;
+        let payload = super::json_of(&before)?;
+        let entry = audit::write(
+            &transaction,
+            &owner,
+            "transaction",
+            &id,
+            Action::Delete,
+            Some(&payload),
+            None,
+            &now,
+        )?;
+        last_seq = Some(entry.seq);
+    }
+    for id in ids("SELECT id FROM accounts WHERE user_id = ?1 ORDER BY id")? {
+        let Some(before) = row::account::read_owned(&transaction, &id, &owner)? else {
+            continue;
+        };
+        let payload = super::json_of(&before)?;
+        let entry = audit::write(
+            &transaction,
+            &owner,
+            "account",
+            &id,
+            Action::Delete,
+            Some(&payload),
+            None,
+            &now,
+        )?;
+        last_seq = Some(entry.seq);
+    }
+
+    // ── The deletes, in the RPC's order. Accounts first is X-3. ─────────────
+    //
+    // The number reported is the count of rows the statement is ABOUT to remove,
+    // read a statement earlier under the same predicate — not `changes()`. That
+    // is a departure from this crate's usual discipline and it was forced by a
+    // measurement:
+    //
+    //   postgres  DELETE FROM categories WHERE user_id = …  ROW_COUNT 3
+    //   sqlite    the same statement                        changes()  2
+    //
+    // The fixture holds Outgoings and its child Weekly shop. SQLite deletes rows
+    // one at a time, so `categories.parent_id ON DELETE CASCADE` takes Weekly
+    // shop while the statement is still walking towards it, and the row is gone
+    // before it can be counted. Postgres computes the statement's row set first
+    // and counts all three. Both engines end with the same rows deleted; only the
+    // number differs, and SQLite's is an artifact of execution order rather than
+    // a fact about the data.
+    //
+    // Three was the honest answer: this number is shown to a user as "categories
+    // erased", and it is also what the cloud reports. The `changes()` assert this
+    // replaces is not lost — it is replaced by a STRONGER one, below, which
+    // checks that the table holds none of this login's rows afterwards. That
+    // catches everything a row count would and one thing it would not: a DELETE
+    // that removed the rows it counted while a trigger put one back.
+    let delete = |table: &str| -> CoreResult<i64> {
+        let counted: i64 = transaction.query_row(
+            &format!("SELECT COUNT(*) FROM {table} WHERE user_id = ?1"),
+            params![owner],
+            |row| row.get(0),
+        )?;
+        transaction.execute(&format!("DELETE FROM {table} WHERE user_id = ?1"), params![owner])?;
+        let left: i64 = transaction.query_row(
+            &format!("SELECT COUNT(*) FROM {table} WHERE user_id = ?1"),
+            params![owner],
+            |row| row.get(0),
+        )?;
+        if left != 0 {
+            return Err(CoreError::refuse(
+                "wipe_incomplete",
+                &format!("{left} row(s) of {table} survived a wipe that should have taken them"),
+            ));
+        }
+        Ok(counted)
+    };
+
+    let answer = WipeCounts {
+        accounts: delete("accounts")?,
+        transactions: delete("transactions")?,
+        categories: delete("categories")?,
+        budgets: delete("budgets")?,
+        goals: delete("goals")?,
+        investments: delete("investments")?,
+    };
+
+    // Counted by nothing, exactly as the RPC counts them by nothing: these are
+    // UI state, and a number telling a user how many dismissed suggestions they
+    // just lost is not a number anybody wants.
+    for table in ["suggestion_dismissals", "dashboard_layouts", "widget_preferences", "notifications"] {
+        delete(table)?;
+    }
+
+    if guarded != 0 {
+        transaction.execute("DELETE FROM _rpc_guard WHERE flag = 'leg'", [])?;
+    }
+    transaction.commit()?;
+
+    Ok(WipeUserFinancialDataResult { answer, audit_seq: last_seq })
+}

--- a/crates/wealth-core/tests/account_snap.rs
+++ b/crates/wealth-core/tests/account_snap.rs
@@ -1,0 +1,200 @@
+//! Integration tests for `link_bank_account_snap`, against the real vendored
+//! schema.
+//!
+//! The differential proof lives in `scripts/local-sqlite/verbs.mjs`: six specs
+//! running the same payload against the live RPC and this verb. What is here is
+//! the half with **no Postgres counterpart**:
+//!
+//! 1. **The audit payload**, field by field. The differential harness compares
+//!    stored rows, and the entry this verb writes is the only record of a rebase
+//!    — the one moment a balance is assigned rather than moved. What it holds is
+//!    what makes the rebase reconstructible, and that is a local shape (the hash
+//!    chain has no cloud twin).
+//! 2. **The arithmetic at the ends of the range.** The delta is `bank − balance`,
+//!    and both operands are bounded at ±1e15 minor, so their difference can be
+//!    2e15 — well inside `i64`, and the checked arithmetic is there for the case
+//!    where a caller has not yet met the CHECK.
+//! 3. **The NULL bank balance the cloud accepts.** MEASURED there: it sets
+//!    `balance`, `initial_balance` and `bank_balance` all to NULL and destroys the
+//!    account's ledger. It is unreachable here, by two independent constructions,
+//!    and a test that says which two is worth more than a note.
+//!
+//! All data is invented.
+
+#![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
+
+use rusqlite::Connection;
+use wealth_core::db;
+use wealth_core::money::Money;
+use wealth_core::verbs::{link_bank_account_snap, LinkBankAccountSnap};
+
+const OWNER: &str = "11111111-1111-1111-1111-111111111111";
+const EVERYDAY: &str = "a0000000-0000-0000-0000-000000000001";
+const CORNER_SHOP: &str = "70000000-0000-0000-0000-000000000001";
+
+/// One account at −25.00 with the one −25.00 row that justifies it, so B-1 holds
+/// before anything happens.
+fn fixture() -> Connection {
+    let connection = db::open_in_memory().expect("open");
+    wealth_core::apply_schema(&connection).expect("schema");
+    connection
+        .execute_batch(&format!(
+            "INSERT INTO users (id, email) VALUES ('{OWNER}', 'harness@example.test');
+             INSERT INTO accounts (id, user_id, name, type, balance_minor, initial_balance_minor)
+               VALUES ('{EVERYDAY}', '{OWNER}', 'Everyday', 'checking', -2500, 0);
+             INSERT INTO transactions (id, user_id, account_id, description, amount_minor, type, date)
+               VALUES ('{CORNER_SHOP}', '{OWNER}', '{EVERYDAY}', 'Corner shop', -2500, 'expense',
+                       '2024-03-01');"
+        ))
+        .expect("fixture");
+    connection
+}
+
+fn snap(connection: &mut Connection, bank: &str) -> wealth_core::verbs::LinkBankAccountSnapResult {
+    link_bank_account_snap(
+        connection,
+        LinkBankAccountSnap {
+            account_id: EVERYDAY.to_owned(),
+            user_id: OWNER.to_owned(),
+            bank_balance: Money::parse(bank).expect("a decimal"),
+        },
+    )
+    .expect("snap")
+}
+
+fn balances(connection: &Connection) -> (i64, i64, Option<i64>) {
+    connection
+        .query_row(
+            "SELECT balance_minor, initial_balance_minor, bank_balance_minor
+               FROM accounts WHERE id = ?1",
+            [EVERYDAY],
+            |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+        )
+        .expect("read")
+}
+
+#[test]
+fn the_audit_entry_records_both_sides_of_the_rebase() {
+    // This is the only record that a balance was ASSIGNED rather than moved, and
+    // it is the thing a person would go looking for when an account's opening
+    // balance is not what they remember.
+    let mut connection = fixture();
+    let result = snap(&mut connection, "10.00");
+
+    let (action, before, after): (String, Option<String>, Option<String>) = connection
+        .query_row(
+            "SELECT action, before_data, after_data FROM financial_audit_log WHERE seq = ?1",
+            [result.audit_seq],
+            |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+        )
+        .expect("the entry");
+
+    assert_eq!(action, "update");
+    let before: serde_json::Value =
+        serde_json::from_str(&before.expect("U-6: an update has a before")).expect("json");
+    let after: serde_json::Value =
+        serde_json::from_str(&after.expect("U-6: an update has an after")).expect("json");
+
+    // Money leaves this crate as a STRING at every boundary, the audit payload
+    // included: a JSON number is a binary float the moment any parser reads it,
+    // and an audit trail made of floats is not evidence of anything.
+    assert_eq!(before["balance"], serde_json::json!("-25.00"));
+    assert_eq!(before["initial_balance"], serde_json::json!("0.00"));
+    assert_eq!(after["balance"], serde_json::json!("10.00"));
+    assert_eq!(after["initial_balance"], serde_json::json!("35.00"));
+    assert_eq!(after["id"], serde_json::json!(EVERYDAY));
+}
+
+#[test]
+fn the_ledger_identity_survives_a_rebase_in_either_direction() {
+    // B-1: balance = initial_balance + Σ(amount). The one −25.00 row never moves,
+    // so initial_balance has to absorb the whole delta both ways.
+    for (bank, expected_initial) in [("10.00", 3_500_i64), ("-100.00", -7_500), ("-25.00", 0)] {
+        let mut connection = fixture();
+        snap(&mut connection, bank);
+        let (balance, initial, bank_balance) = balances(&connection);
+        assert_eq!(balance, Money::parse(bank).expect("decimal").minor(), "snapping to {bank}");
+        assert_eq!(initial, expected_initial, "snapping to {bank}");
+        assert_eq!(bank_balance, Some(balance), "bank_balance is the reference figure");
+
+        let sum: i64 = connection
+            .query_row(
+                "SELECT COALESCE(SUM(amount_minor), 0) FROM transactions WHERE account_id = ?1",
+                [EVERYDAY],
+                |row| row.get(0),
+            )
+            .expect("sum");
+        assert_eq!(balance, initial.saturating_add(sum), "B-1 broke snapping to {bank}");
+    }
+}
+
+#[test]
+fn a_second_snap_rebases_from_where_the_first_one_left_it() {
+    // The link handler can run twice — a reconnect, a re-authorisation — and each
+    // snap must be relative to the CURRENT balance, not to the original one.
+    let mut connection = fixture();
+    snap(&mut connection, "10.00");
+    snap(&mut connection, "40.00");
+    let (balance, initial, _) = balances(&connection);
+    assert_eq!(balance, 4_000);
+    assert_eq!(initial, 6_500, "0 + (10 − −25) + (40 − 10) = 65.00");
+
+    let entries: i64 = connection
+        .query_row("SELECT COUNT(*) FROM financial_audit_log", [], |row| row.get(0))
+        .expect("count");
+    assert_eq!(entries, 2, "each rebase is its own entry");
+}
+
+#[test]
+fn a_figure_the_file_cannot_hold_is_refused_and_nothing_moves() {
+    // The bound is the SCHEMA's, not this verb's: duplicating it here is how the
+    // two copies drift. What the verb owes is that the refusal leaves the account
+    // exactly as it was.
+    let mut connection = fixture();
+    let error = link_bank_account_snap(
+        &mut connection,
+        LinkBankAccountSnap {
+            account_id: EVERYDAY.to_owned(),
+            user_id: OWNER.to_owned(),
+            bank_balance: Money::from_minor(Money::STOCK_BOUND_MINOR.saturating_add(1)),
+        },
+    )
+    .expect_err("past the stock bound");
+    assert!(error.to_string().contains("accounts_balance_bounded"), "{error}");
+    assert_eq!(balances(&connection), (-2_500, 0, None));
+
+    let entries: i64 = connection
+        .query_row("SELECT COUNT(*) FROM financial_audit_log", [], |row| row.get(0))
+        .expect("count");
+    assert_eq!(entries, 0, "a refused snap leaves no evidence of a change that never happened");
+}
+
+#[test]
+fn money_cannot_reach_this_verb_as_a_json_number() {
+    // The cloud's NULL-bank-balance defect (MEASURED there: it nulls balance,
+    // initial_balance and bank_balance together and destroys the ledger) is
+    // unreachable here by TWO independent constructions, and this is the first:
+    // the argument is a Money, which has no null and no float.
+    let error = serde_json::from_str::<LinkBankAccountSnap>(&format!(
+        r#"{{"account_id":"{EVERYDAY}","user_id":"{OWNER}","bank_balance":10.0}}"#
+    ))
+    .expect_err("a JSON number is a float");
+    assert!(error.to_string().contains("amount_must_be_a_string"), "{error}");
+
+    // …and the second: the column itself. Even a caller reaching past the verb
+    // cannot leave the ledger with no balance at all.
+    let connection = fixture();
+    let refused = connection.execute_batch(&format!(
+        "UPDATE accounts SET balance_minor = NULL WHERE id = '{EVERYDAY}';"
+    ));
+    assert!(refused.is_err(), "accounts.balance_minor is NOT NULL for exactly this reason");
+}
+
+#[test]
+fn a_null_bank_balance_is_not_a_shape_the_command_has() {
+    let error = serde_json::from_str::<LinkBankAccountSnap>(&format!(
+        r#"{{"account_id":"{EVERYDAY}","user_id":"{OWNER}","bank_balance":null}}"#
+    ))
+    .expect_err("null is not a decimal string");
+    assert!(!error.to_string().is_empty());
+}

--- a/crates/wealth-core/tests/ledger_core_close.rs
+++ b/crates/wealth-core/tests/ledger_core_close.rs
@@ -1,0 +1,394 @@
+//! Integration tests for the two verbs that close the ledger core:
+//! `delete_unused_categories` and `verify_integrity`.
+//!
+//! The differential proof for the prune lives in `scripts/local-sqlite/verbs.mjs`
+//! — eighteen specs, each running one payload against the live Postgres RPC and
+//! against this crate. What is here is the half that has **no Postgres
+//! counterpart to compare against**:
+//!
+//! 1. **The ORDER the port imposes.** The cloud is one statement and its order is
+//!    the executor's; the local port deletes deepest-first *on purpose*, and the
+//!    reason is a SQLite execution detail with no cloud twin. `deepest_first`'s
+//!    unit tests cover the ordering function; these cover it against a file.
+//!    2. **That the refusal rolls the batch back.** The differential harness sees
+//!    the end state on both engines; what it cannot see is whether the local verb
+//!    left an audit row behind, and a rollback that keeps a record of a change it
+//!    undid is worse than no record at all.
+//! 3. **`verify_integrity` entire**, because there is no cloud verify_integrity —
+//!    the verb's own module documentation carries the trace. Its twenty-four
+//!    specs run on SQLite alone; what is here is the part a spec cannot reach:
+//!    that a clean file stays clean *through* a verb, and that the checker
+//!    notices the wreckage the prune's measured hole leaves.
+//!
+//! All data is invented. This repo is public: no real payee, account number or
+//! figure appears anywhere in it.
+
+#![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
+
+use rusqlite::Connection;
+use wealth_core::db;
+use wealth_core::error::CoreError;
+use wealth_core::verbs::{
+    delete_unused_categories, verify_integrity, DeleteUnusedCategories, VerifyIntegrity,
+};
+
+const OWNER: &str = "11111111-1111-1111-1111-111111111111";
+const EVERYDAY: &str = "a0000000-0000-0000-0000-000000000001";
+const TRANSFER_ROOT: &str = "c0000000-0000-0000-0000-000000000001";
+const OUTGOINGS: &str = "c0000000-0000-0000-0000-000000000002";
+const WEEKLY_SHOP: &str = "c0000000-0000-0000-0000-000000000003";
+const PARENT: &str = "c0000000-0000-0000-0000-0000000000e1";
+const CHILD: &str = "c0000000-0000-0000-0000-0000000000c1";
+const GRANDCHILD: &str = "c0000000-0000-0000-0000-0000000000c2";
+const CORNER_SHOP: &str = "70000000-0000-0000-0000-000000000001";
+
+/// One owner, one account (minting its own To/From category through C-3's
+/// trigger), a category tree three deep, and the −25.00 row Everyday's balance
+/// matches so B-1 holds before anything runs.
+fn fixture() -> Connection {
+    let connection = db::open_in_memory().expect("open");
+    wealth_core::apply_schema(&connection).expect("schema");
+    connection
+        .execute_batch(&format!(
+            "INSERT INTO users (id, email) VALUES ('{OWNER}', 'harness@example.test');
+             INSERT INTO categories (id, user_id, name, type, level) VALUES
+               ('{TRANSFER_ROOT}', '{OWNER}', 'Transfer', 'both', 'type'),
+               ('{OUTGOINGS}', '{OWNER}', 'Outgoings', 'expense', 'type');
+             INSERT INTO categories (id, user_id, name, type, level, parent_id) VALUES
+               ('{WEEKLY_SHOP}', '{OWNER}', 'Weekly shop', 'expense', 'sub', '{OUTGOINGS}'),
+               ('{PARENT}', '{OWNER}', 'Food shopping', 'expense', 'detail', '{OUTGOINGS}');
+             INSERT INTO accounts (id, user_id, name, type, balance_minor, initial_balance_minor)
+               VALUES ('{EVERYDAY}', '{OWNER}', 'Everyday', 'checking', -2500, 0);
+             INSERT INTO transactions (id, user_id, account_id, description, amount_minor, type, date, category)
+               VALUES ('{CORNER_SHOP}', '{OWNER}', '{EVERYDAY}', 'Corner shop', -2500, 'expense',
+                       '2024-03-01', '{WEEKLY_SHOP}');"
+        ))
+        .expect("fixture");
+    connection
+}
+
+/// A branch under [`PARENT`]: child, then grandchild.
+fn a_branch(connection: &Connection) {
+    connection
+        .execute_batch(&format!(
+            "INSERT INTO categories (id, user_id, name, type, level, parent_id) VALUES
+               ('{CHILD}', '{OWNER}', 'Child', 'expense', 'detail', '{PARENT}');
+             INSERT INTO categories (id, user_id, name, type, level, parent_id) VALUES
+               ('{GRANDCHILD}', '{OWNER}', 'Grandchild', 'expense', 'detail', '{CHILD}');"
+        ))
+        .expect("branch");
+}
+
+fn prune(connection: &mut Connection, ids: &[&str]) -> i64 {
+    delete_unused_categories(
+        connection,
+        DeleteUnusedCategories {
+            ids: Some(ids.iter().map(|id| (*id).to_owned()).collect()),
+            user_id: Some(OWNER.to_owned()),
+        },
+    )
+    .expect("prune")
+    .answer
+    .deleted
+}
+
+fn scalar(connection: &Connection, sql: &str) -> i64 {
+    connection.query_row(sql, [], |row| row.get(0)).expect("read")
+}
+
+fn report(connection: &Connection) -> wealth_core::verbs::IntegrityReport {
+    verify_integrity(connection, VerifyIntegrity {})
+        .expect("verify")
+        .answer
+}
+
+// ── delete_unused_categories ───────────────────────────────────────────────
+
+#[test]
+fn a_branch_named_whole_is_counted_whole() {
+    let mut connection = fixture();
+    a_branch(&connection);
+
+    // Three rows, three deletions — the number the cloud gives, and NOT the
+    // number SQLite's own single-statement DELETE gives (measured: 1, because
+    // the cascade removes the descendants before the scan reaches them).
+    assert_eq!(prune(&mut connection, &[PARENT, CHILD, GRANDCHILD]), 3);
+    assert_eq!(
+        scalar(
+            &connection,
+            &format!("SELECT COUNT(*) FROM categories WHERE id IN ('{PARENT}','{CHILD}','{GRANDCHILD}')")
+        ),
+        0
+    );
+}
+
+#[test]
+fn the_order_is_deepest_first_whatever_order_the_caller_names_them_in() {
+    // The caller's list is the WORST order for a naive port: parent first, so a
+    // single-statement DELETE would cascade the other two away and count one.
+    let mut connection = fixture();
+    a_branch(&connection);
+    assert_eq!(prune(&mut connection, &[PARENT, CHILD, GRANDCHILD]), 3);
+
+    // And the reverse list must give the same answer, because the order the verb
+    // uses is a fact about the tree, not about the request.
+    let mut reversed = fixture();
+    a_branch(&reversed);
+    assert_eq!(prune(&mut reversed, &[GRANDCHILD, CHILD, PARENT]), 3);
+}
+
+#[test]
+fn a_referenced_descendant_is_not_counted_even_though_it_is_gone() {
+    let mut connection = fixture();
+    a_branch(&connection);
+    connection
+        .execute_batch(&format!(
+            "UPDATE transactions SET category = '{GRANDCHILD}' WHERE id = '{CORNER_SHOP}';"
+        ))
+        .expect("file it");
+
+    // TWO, not three: the grandchild's own check skips it, and it is then
+    // removed by the cascade from its parent rather than by this call. Both
+    // engines answer 2 and both leave the transaction's category dangling.
+    assert_eq!(prune(&mut connection, &[PARENT, CHILD, GRANDCHILD]), 2);
+    assert_eq!(
+        scalar(
+            &connection,
+            &format!("SELECT COUNT(*) FROM categories WHERE id = '{GRANDCHILD}'")
+        ),
+        0
+    );
+    let filed: String = connection
+        .query_row(
+            &format!("SELECT category FROM transactions WHERE id = '{CORNER_SHOP}'"),
+            [],
+            |row| row.get(0),
+        )
+        .expect("read");
+    assert_eq!(filed, GRANDCHILD);
+}
+
+#[test]
+fn the_prune_writes_nothing_to_the_audit_log() {
+    let mut connection = fixture();
+    assert_eq!(prune(&mut connection, &[PARENT]), 1);
+    assert_eq!(
+        scalar(&connection, "SELECT COUNT(*) FROM financial_audit_log"),
+        0
+    );
+}
+
+#[test]
+fn the_transfer_protection_takes_the_whole_batch_with_it() {
+    let mut connection = fixture();
+    let transfer_category: String = connection
+        .query_row(
+            &format!(
+                "SELECT id FROM categories WHERE account_id = '{EVERYDAY}' AND is_transfer_category = 1"
+            ),
+            [],
+            |row| row.get(0),
+        )
+        .expect("the trigger minted one");
+    connection
+        .execute_batch(&format!(
+            "UPDATE categories SET parent_id = '{PARENT}' WHERE id = '{transfer_category}';"
+        ))
+        .expect("reparent");
+
+    let outcome = delete_unused_categories(
+        &mut connection,
+        DeleteUnusedCategories {
+            ids: Some(vec![PARENT.to_owned(), transfer_category.clone()]),
+            user_id: Some(OWNER.to_owned()),
+        },
+    );
+
+    match outcome {
+        Err(CoreError::Refused(refusal)) => {
+            assert!(
+                refusal.message().contains("transfer_category_protected"),
+                "{refusal}"
+            );
+        }
+        other => panic!("expected a refusal, got {other:?}"),
+    }
+
+    // The batch rolled back whole: the parent is still here, the protected row
+    // is still here, and nothing was audited on the way past.
+    assert_eq!(
+        scalar(
+            &connection,
+            &format!("SELECT COUNT(*) FROM categories WHERE id = '{PARENT}'")
+        ),
+        1
+    );
+    assert_eq!(
+        scalar(
+            &connection,
+            "SELECT COUNT(*) FROM categories WHERE is_transfer_category = 1"
+        ),
+        1
+    );
+    assert_eq!(
+        scalar(&connection, "SELECT COUNT(*) FROM financial_audit_log"),
+        0
+    );
+    // And the guard table is empty, because the verb never touched it.
+    assert_eq!(scalar(&connection, "SELECT COUNT(*) FROM _rpc_guard"), 0);
+}
+
+#[test]
+fn no_flag_in_the_guard_table_stands_the_transfer_protection_down() {
+    // `verbs/mod.rs` says C-5 is a protection rather than a nuisance and the
+    // verb does not try to suppress it. This is that claim, tested from the
+    // other side: even with every guard flag held, the refusal is the same.
+    let connection = fixture();
+    let transfer_category: String = connection
+        .query_row(
+            &format!(
+                "SELECT id FROM categories WHERE account_id = '{EVERYDAY}' AND is_transfer_category = 1"
+            ),
+            [],
+            |row| row.get(0),
+        )
+        .expect("minted");
+    connection
+        .execute_batch(&format!(
+            "UPDATE categories SET parent_id = '{PARENT}' WHERE id = '{transfer_category}';
+             INSERT INTO _rpc_guard VALUES ('split');
+             INSERT INTO _rpc_guard VALUES ('leg');
+             INSERT INTO _rpc_guard VALUES ('restore');"
+        ))
+        .expect("reparent and guard");
+
+    let refused = connection
+        .execute_batch(&format!("DELETE FROM categories WHERE id = '{PARENT}'"))
+        .expect_err("C-5 must still fire");
+    assert!(
+        refused.to_string().contains("transfer_category_protected"),
+        "{refused}"
+    );
+}
+
+// ── verify_integrity ───────────────────────────────────────────────────────
+
+#[test]
+fn a_clean_file_stays_clean_through_a_prune() {
+    let mut connection = fixture();
+    a_branch(&connection);
+    assert!(report(&connection).ok);
+
+    assert_eq!(prune(&mut connection, &[GRANDCHILD]), 1);
+
+    let after = report(&connection);
+    assert!(after.ok, "{:?}", after.findings);
+    assert_eq!(after.violations, 0);
+    assert_eq!(after.warnings, 0);
+}
+
+#[test]
+fn the_checker_sees_the_wreckage_the_prune_leaves_behind() {
+    // The two halves of the family, joined: the prune's measured hole produces
+    // exactly the state verify_integrity's dangling_category_ref reports, and
+    // this is the only place both are exercised in one file.
+    let mut connection = fixture();
+    a_branch(&connection);
+    connection
+        .execute_batch(&format!(
+            "UPDATE transactions SET category = '{GRANDCHILD}' WHERE id = '{CORNER_SHOP}';"
+        ))
+        .expect("file it");
+    assert!(report(&connection).ok);
+
+    assert_eq!(prune(&mut connection, &[PARENT, CHILD, GRANDCHILD]), 2);
+
+    let after = report(&connection);
+    assert!(!after.ok);
+    assert_eq!(after.violations, 1);
+    assert_eq!(after.findings[0].check, "dangling_category_ref");
+    assert_eq!(after.findings[0].entity, "transaction");
+    assert_eq!(after.findings[0].id, CORNER_SHOP);
+    assert_eq!(after.findings[0].severity, "violation");
+}
+
+#[test]
+fn a_warning_never_makes_the_file_not_ok() {
+    let connection = fixture();
+    connection
+        .execute_batch(&format!(
+            "INSERT INTO accounts (id, user_id, name, type, balance_minor, initial_balance_minor)
+               VALUES ('a0000000-0000-0000-0000-0000000000ca', '{OWNER}', 'Card', 'credit', 5000, 0);
+             INSERT INTO transactions (id, user_id, account_id, description, amount_minor, type,
+                                       date, import_source, import_source_id)
+               VALUES ('70000000-0000-0000-0000-0000000000f0', '{OWNER}',
+                       'a0000000-0000-0000-0000-0000000000ca', 'Shop', 5000, 'income',
+                       '2024-04-01', 'ofx', 'ofx-1');"
+        ))
+        .expect("card");
+
+    let answer = report(&connection);
+    assert!(answer.ok, "a heuristic must not condemn a file");
+    assert_eq!(answer.violations, 0);
+    assert_eq!(answer.warnings, 1);
+    assert_eq!(answer.findings.len(), 1);
+    assert_eq!(answer.findings[0].severity, "warning");
+
+    // And the view's own one-line verdict agrees with the verb's.
+    assert_eq!(scalar(&connection, "SELECT ok FROM v_integrity_ok"), 1);
+}
+
+#[test]
+fn the_report_is_ordered_by_check_then_entity_then_id() {
+    // Two checks and three findings in one file, planted in the order that would
+    // come out wrong if the verb trusted UNION ALL.
+    let connection = fixture();
+    connection
+        .execute_batch(&format!(
+            "UPDATE accounts SET balance_minor = balance_minor + 1 WHERE id = '{EVERYDAY}';
+             INSERT INTO accounts (id, user_id, name, type, balance_minor, initial_balance_minor,
+                                   bank_balance_minor, bank_balance_date)
+               VALUES ('a0000000-0000-0000-0000-0000000000ca', '{OWNER}', 'Card', 'credit',
+                       -1000, 0, 400000, '2024-04-01');
+             INSERT INTO transactions (id, user_id, account_id, description, amount_minor, type, date)
+               VALUES ('70000000-0000-0000-0000-0000000000f0', '{OWNER}',
+                       'a0000000-0000-0000-0000-0000000000ca', 'Shop', -1000, 'expense', '2024-04-01');"
+        ))
+        .expect("two kinds of wrong");
+
+    let answer = report(&connection);
+    let names: Vec<&str> = answer
+        .findings
+        .iter()
+        .map(|finding| finding.check.as_str())
+        .collect();
+    assert_eq!(names, ["balance_identity", "bank_balance_implausible"]);
+    assert_eq!(answer.violations, 1);
+    assert_eq!(answer.warnings, 1);
+    assert!(!answer.ok);
+}
+
+#[test]
+fn the_totals_always_add_up_to_the_list() {
+    // The report's two counts and its own findings are read once, from one
+    // query, so they cannot disagree. Asserted rather than assumed because a
+    // second query for the counts is the obvious "tidier" refactor.
+    let connection = fixture();
+    connection
+        .execute_batch(&format!(
+            "UPDATE accounts SET balance_minor = balance_minor + 1 WHERE id = '{EVERYDAY}';
+             INSERT INTO accounts (id, user_id, name, type, balance_minor, initial_balance_minor)
+               VALUES ('a0000000-0000-0000-0000-0000000000ca', '{OWNER}', 'Card', 'credit', 5000, 0);
+             INSERT INTO transactions (id, user_id, account_id, description, amount_minor, type,
+                                       date, import_source, import_source_id)
+               VALUES ('70000000-0000-0000-0000-0000000000f0', '{OWNER}',
+                       'a0000000-0000-0000-0000-0000000000ca', 'Shop', 5000, 'income',
+                       '2024-04-01', 'ofx', 'ofx-1');"
+        ))
+        .expect("one of each");
+
+    let answer = report(&connection);
+    let total = i64::try_from(answer.findings.len()).expect("small");
+    assert_eq!(answer.violations + answer.warnings, total);
+    assert_eq!(answer.ok, answer.violations == 0);
+}

--- a/crates/wealth-core/tests/restore_family.rs
+++ b/crates/wealth-core/tests/restore_family.rs
@@ -1,0 +1,853 @@
+//! Integration tests for the restore family, against the real vendored schema.
+//!
+//! The differential proof lives in `scripts/local-sqlite/verbs.mjs`: thirty-nine
+//! specs running the same payload against the live Postgres RPCs and these verbs.
+//! What is here is the half that has **no Postgres counterpart to compare
+//! against**, and there are six kinds of it:
+//!
+//! 1. **The whole round trip.** Seed, snapshot, wipe, restore, snapshot again,
+//!    compare. The cloud cannot be asked this question in one call — its restore
+//!    is chunked across separate transactions and its wipe is a different request
+//!    — so the one assertion that matters most to a person ("is my data the same
+//!    afterwards?") can only be made here.
+//! 2. **One transaction.** DESIGN.md §5 divergence 6. A multi-chunk restore is a
+//!    local-only shape; the harness's Postgres driver refuses such a spec by name
+//!    rather than comparing the wrong thing.
+//! 3. **R-11 in anger.** The `transactions ↔ transaction_splits` cycle, closed in
+//!    one COMMIT with no second pass. Postgres cannot do it at all, which is what
+//!    `finalize_user_restore` exists for.
+//! 4. **The guards, both halves.** That `_rpc_guard('leg')` is HELD across a wipe
+//!    that touches a split leg (or the wipe is refused) and RELEASED before the
+//!    call returns (or every later write in the file has S-9 and S-10 standing
+//!    down). Both are claims about a SQLite trigger with no cloud twin.
+//! 5. **The audit chain.** Whether the hashes actually chain across a wipe that
+//!    writes one row per transaction and one per account. There is no cloud hash
+//!    to compare to.
+//! 6. **The column maps.** Fourteen entities, each with its own scale conversions.
+//!    The differential specs exercise four of them; this exercises all fourteen,
+//!    which is the only way a mapping typo in `investment_transactions` gets
+//!    found before somebody's holdings do.
+//!
+//! All data is invented. This repo is public: no real payee, account number or
+//! figure appears anywhere in it.
+
+#![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
+
+use rusqlite::Connection;
+use serde_json::{json, Value};
+use wealth_core::db;
+use wealth_core::verbs::{
+    finalize_user_restore, restore_user_chunk, user_financial_data_is_empty,
+    wipe_user_financial_data, FinalizeUserRestore, RestoreUserChunk, UserFinancialDataIsEmpty,
+    WipeUserFinancialData,
+};
+
+const OWNER: &str = "11111111-1111-1111-1111-111111111111";
+const STRANGER: &str = "22222222-2222-2222-2222-222222222222";
+const EVERYDAY: &str = "a0000000-0000-0000-0000-000000000001";
+const RAINY_DAY: &str = "a0000000-0000-0000-0000-000000000002";
+const TRANSFER_ROOT: &str = "c0000000-0000-0000-0000-000000000001";
+const OUTGOINGS: &str = "c0000000-0000-0000-0000-000000000002";
+const WEEKLY_SHOP: &str = "c0000000-0000-0000-0000-000000000003";
+const TO_FROM_RAINY: &str = "c0000000-0000-0000-0000-0000000000fa";
+const TO_FROM_EVERYDAY: &str = "c0000000-0000-0000-0000-0000000000fb";
+const CORNER_SHOP: &str = "70000000-0000-0000-0000-000000000001";
+const COUNTERPART: &str = "70000000-0000-0000-0000-000000000009";
+const LEG_LINE: &str = "50000000-0000-0000-0000-000000000001";
+const PLAIN_LINE: &str = "50000000-0000-0000-0000-000000000002";
+
+/// An empty file with one login in it. Every test builds its own world on top.
+fn blank() -> Connection {
+    let connection = db::open_in_memory().expect("open");
+    wealth_core::apply_schema(&connection).expect("schema");
+    connection
+        .execute_batch(&format!(
+            "INSERT INTO users (id, email) VALUES ('{OWNER}', 'harness@example.test');
+             INSERT INTO users (id, email) VALUES ('{STRANGER}', 'stranger@example.test');"
+        ))
+        .expect("users");
+    connection
+}
+
+fn wipe(connection: &mut Connection) -> wealth_core::verbs::WipeUserFinancialDataResult {
+    wipe_user_financial_data(
+        connection,
+        WipeUserFinancialData {
+            confirm: Some("DELETE EVERYTHING".to_owned()),
+            user_id: Some(OWNER.to_owned()),
+        },
+    )
+    .expect("wipe")
+}
+
+fn restore(connection: &mut Connection, chunks: Value) -> wealth_core::verbs::RestoreUserChunkResult {
+    let command: RestoreUserChunk =
+        serde_json::from_value(json!({ "chunks": chunks, "user_id": OWNER })).expect("command");
+    restore_user_chunk(connection, command).expect("restore")
+}
+
+/// One value, as text, whatever SQLite's affinity made of it.
+///
+/// A count comes back INTEGER and a `group_concat` comes back TEXT, so the read
+/// has to go through the dynamic type or half the assertions in this file would
+/// be about column affinity rather than about the ledger.
+fn scalar(connection: &Connection, sql: &str) -> String {
+    connection
+        .query_row(sql, [], |row| row.get::<_, rusqlite::types::Value>(0))
+        .map(|value| match value {
+            rusqlite::types::Value::Null => "NULL".to_owned(),
+            rusqlite::types::Value::Integer(number) => number.to_string(),
+            rusqlite::types::Value::Real(number) => number.to_string(),
+            rusqlite::types::Value::Text(text) => text,
+            rusqlite::types::Value::Blob(_) => "BLOB".to_owned(),
+        })
+        .unwrap_or_else(|error| format!("ERROR {error}"))
+}
+
+// ── The dataset every round-trip test uses ──────────────────────────────────
+
+/// Two accounts, a category tree, an ordinary expense, and a transfer whose far
+/// side is a SPLIT LINE — the shape that exercises R-11, R-5 and the guard all
+/// at once.
+///
+/// Balances are hand-maintained so B-1 holds before the wipe: Everyday is
+/// −25.00 (one −25.00 split parent) and Rainy day is 15.00 (the counterpart).
+fn seeded() -> Connection {
+    let connection = blank();
+    connection
+        .execute_batch(&format!(
+            "INSERT INTO categories (id, user_id, name, type, level) VALUES
+               ('{TRANSFER_ROOT}', '{OWNER}', 'Transfer', 'both', 'type'),
+               ('{OUTGOINGS}', '{OWNER}', 'Outgoings', 'expense', 'type');
+             INSERT INTO categories (id, user_id, name, type, level, parent_id) VALUES
+               ('{WEEKLY_SHOP}', '{OWNER}', 'Weekly shop', 'expense', 'sub', '{OUTGOINGS}');
+             INSERT INTO accounts (id, user_id, name, type, balance_minor, initial_balance_minor,
+                                   updated_at) VALUES
+               ('{EVERYDAY}', '{OWNER}', 'Everyday', 'checking', -2500, 0, '2019-01-01T00:00:00.000Z'),
+               ('{RAINY_DAY}', '{OWNER}', 'Rainy day', 'savings', 1500, 0, '2019-01-01T00:00:00.000Z');
+             -- Both To/From rows are minted by C-3's trigger with generated ids.
+             -- Renamed to ids the bundle below can name, which is the only way a
+             -- round trip can be compared at all: a spec that could not predict
+             -- them would have to exclude them from the snapshot, and they are
+             -- exactly the rows the emptiness precondition exists to protect.
+             UPDATE categories SET id = '{TO_FROM_RAINY}'
+              WHERE account_id = '{RAINY_DAY}' AND is_transfer_category = 1;
+             UPDATE categories SET id = '{TO_FROM_EVERYDAY}'
+              WHERE account_id = '{EVERYDAY}' AND is_transfer_category = 1;
+             INSERT INTO _rpc_guard VALUES ('split');
+             INSERT INTO transactions (id, user_id, account_id, description, amount_minor, type, date,
+                                       is_split, category, updated_at) VALUES
+               ('{CORNER_SHOP}', '{OWNER}', '{EVERYDAY}', 'Corner shop', -2500, 'expense',
+                '2019-05-04', 1, '', '2019-05-04T00:00:00.000Z');
+             INSERT INTO transactions (id, user_id, account_id, description, amount_minor, type, date,
+                                       transfer_account_id, updated_at) VALUES
+               ('{COUNTERPART}', '{OWNER}', '{RAINY_DAY}', 'Counterpart', 1500, 'transfer',
+                '2019-05-04', '{EVERYDAY}', '2019-05-04T00:00:00.000Z');
+             INSERT INTO transaction_splits (id, transaction_id, user_id, category, amount_minor,
+                                             sort_order, transfer_account_id, linked_transfer_id) VALUES
+               ('{LEG_LINE}', '{CORNER_SHOP}', '{OWNER}', '{TO_FROM_RAINY}', -1500, 0,
+                '{RAINY_DAY}', '{COUNTERPART}'),
+               ('{PLAIN_LINE}', '{CORNER_SHOP}', '{OWNER}', '{WEEKLY_SHOP}', -1000, 1, NULL, NULL);
+             -- The link is closed under _rpc_guard('restore'), the same flag
+             -- finalize_user_restore holds, so the SEED does not re-date the row
+             -- it is about to ask a restore to reproduce. Writing updated_at
+             -- explicitly does NOT work here and it is worth saying why: the
+             -- trigger's WHEN is `NEW.updated_at IS OLD.updated_at`, and writing
+             -- the value the row already had satisfies it.
+             INSERT INTO _rpc_guard VALUES ('restore');
+             UPDATE transactions SET linked_transfer_split_id = '{LEG_LINE}'
+              WHERE id = '{COUNTERPART}';
+             DELETE FROM _rpc_guard;"
+        ))
+        .expect("seed");
+    connection
+}
+
+/// Everything about the login that a restore has to bring back, as one string.
+///
+/// A single comparable value rather than a list of assertions, deliberately: the
+/// question is *"is it the same afterwards"*, and a snapshot that has to be kept
+/// in step with a list of expectations is a snapshot that stops asking it.
+/// `updated_at` is IN here, because X-4 is exactly the thing a round trip is
+/// most likely to break silently.
+fn snapshot(connection: &Connection) -> String {
+    let parts = [
+        scalar(connection, "SELECT group_concat(s, ' | ') FROM (
+            SELECT id || '/' || name || '/' || type || '/' || balance_minor || '/'
+                || initial_balance_minor || '/' || COALESCE(parent_account_id, '-') || '/'
+                || substr(updated_at, 1, 10) AS s
+              FROM accounts ORDER BY id)"),
+        scalar(connection, "SELECT group_concat(s, ' | ') FROM (
+            SELECT id || '/' || name || '/' || level || '/' || COALESCE(parent_id, '-') || '/'
+                || COALESCE(account_id, '-') || '/' || is_transfer_category AS s
+              FROM categories ORDER BY id)"),
+        scalar(connection, "SELECT group_concat(s, ' | ') FROM (
+            SELECT id || '/' || account_id || '/' || description || '/' || amount_minor || '/'
+                || type || '/' || date || '/' || COALESCE(category, '-') || '/' || is_split || '/'
+                || is_cleared || '/' || category_confirmed || '/'
+                || COALESCE(transfer_account_id, '-') || '/' || COALESCE(linked_transfer_id, '-')
+                || '/' || COALESCE(linked_transfer_split_id, '-') || '/' || substr(updated_at, 1, 10) AS s
+              FROM transactions ORDER BY id)"),
+        scalar(connection, "SELECT group_concat(s, ' | ') FROM (
+            SELECT id || '/' || transaction_id || '/' || category || '/' || amount_minor || '/'
+                || sort_order || '/' || COALESCE(transfer_account_id, '-') || '/'
+                || COALESCE(linked_transfer_id, '-') AS s
+              FROM transaction_splits ORDER BY id)"),
+    ];
+    parts.join("\n")
+}
+
+/// The same dataset, as a backup file holds it: cloud column names, cloud scales,
+/// money as decimal strings, links stripped into the separate payload the file
+/// carries them in.
+fn bundle() -> (Value, Value) {
+    let chunks = json!([
+        { "entity": "accounts", "rows": [
+            { "id": EVERYDAY, "user_id": STRANGER, "name": "Everyday", "type": "checking",
+              "currency": "GBP", "balance": "-25.00", "initial_balance": "0.00",
+              "is_active": true, "low_balance_alert_enabled": false, "metadata": {},
+              "created_at": "2019-01-01T00:00:00+00:00", "updated_at": "2019-01-01T00:00:00+00:00" },
+            { "id": RAINY_DAY, "user_id": STRANGER, "name": "Rainy day", "type": "savings",
+              "currency": "GBP", "balance": "15.00", "initial_balance": "0.00",
+              "is_active": true, "low_balance_alert_enabled": false, "metadata": {},
+              "created_at": "2019-01-01T00:00:00+00:00", "updated_at": "2019-01-01T00:00:00+00:00" },
+        ]},
+        { "entity": "categories", "rows": [
+            { "id": TRANSFER_ROOT, "user_id": STRANGER, "name": "Transfer", "type": "both",
+              "level": "type", "is_system": false, "is_transfer_category": false,
+              "is_revaluation_category": false, "is_unassigned_bucket": false, "is_active": true,
+              "created_at": "2019-01-01T00:00:00+00:00", "updated_at": "2019-01-01T00:00:00+00:00" },
+            { "id": OUTGOINGS, "user_id": STRANGER, "name": "Outgoings", "type": "expense",
+              "level": "type", "is_system": false, "is_transfer_category": false,
+              "is_revaluation_category": false, "is_unassigned_bucket": false, "is_active": true,
+              "created_at": "2019-01-01T00:00:00+00:00", "updated_at": "2019-01-01T00:00:00+00:00" },
+        ]},
+        { "entity": "categories", "rows": [
+            { "id": WEEKLY_SHOP, "user_id": STRANGER, "name": "Weekly shop", "type": "expense",
+              "level": "sub", "parent_id": OUTGOINGS, "is_system": false,
+              "is_transfer_category": false, "is_revaluation_category": false,
+              "is_unassigned_bucket": false, "is_active": true,
+              "created_at": "2019-01-01T00:00:00+00:00", "updated_at": "2019-01-01T00:00:00+00:00" },
+        ]},
+        { "entity": "categories", "rows": [
+            // The To/From row, under its ORIGINAL id — the whole reason the
+            // target has to be empty.
+            { "id": TO_FROM_RAINY, "user_id": STRANGER, "name": "To/From Rainy day", "type": "both",
+              "level": "detail", "parent_id": TRANSFER_ROOT, "account_id": RAINY_DAY,
+              "is_system": false, "is_transfer_category": true,
+              "is_revaluation_category": false, "is_unassigned_bucket": false, "is_active": true,
+              "created_at": "2019-01-01T00:00:00+00:00", "updated_at": "2019-01-01T00:00:00+00:00" },
+            { "id": TO_FROM_EVERYDAY, "user_id": STRANGER,
+              "name": "To/From Everyday", "type": "both", "level": "detail",
+              "parent_id": TRANSFER_ROOT, "account_id": EVERYDAY, "is_system": false,
+              "is_transfer_category": true, "is_revaluation_category": false,
+              "is_unassigned_bucket": false, "is_active": true,
+              "created_at": "2019-01-01T00:00:00+00:00", "updated_at": "2019-01-01T00:00:00+00:00" },
+        ]},
+        { "entity": "transactions", "rows": [
+            { "id": CORNER_SHOP, "user_id": STRANGER, "account_id": EVERYDAY,
+              "description": "Corner shop", "amount": "-25.00", "type": "expense",
+              "date": "2019-05-04", "category": "", "is_cleared": false, "is_split": true,
+              "archived": false, "category_confirmed": true, "is_recurring": false, "metadata": {},
+              "created_at": "2019-05-04T00:00:00+00:00", "updated_at": "2019-05-04T00:00:00+00:00" },
+            { "id": COUNTERPART, "user_id": STRANGER, "account_id": RAINY_DAY,
+              "description": "Counterpart", "amount": "15.00", "type": "transfer",
+              "date": "2019-05-04", "transfer_account_id": EVERYDAY,
+              "linked_transfer_split_id": LEG_LINE,
+              "is_cleared": false, "is_split": false, "archived": false,
+              "category_confirmed": true, "is_recurring": false, "metadata": {},
+              "created_at": "2019-05-04T00:00:00+00:00", "updated_at": "2019-05-04T00:00:00+00:00" },
+        ]},
+        { "entity": "transaction_splits", "rows": [
+            { "id": LEG_LINE, "transaction_id": CORNER_SHOP, "user_id": STRANGER,
+              "category": TO_FROM_RAINY, "amount": "-15.00", "sort_order": 0,
+              "transfer_account_id": RAINY_DAY, "linked_transfer_id": COUNTERPART,
+              "created_at": "2019-05-04T00:00:00+00:00", "updated_at": "2019-05-04T00:00:00+00:00" },
+            { "id": PLAIN_LINE, "transaction_id": CORNER_SHOP, "user_id": STRANGER,
+              "category": WEEKLY_SHOP, "amount": "-10.00", "sort_order": 1,
+              "created_at": "2019-05-04T00:00:00+00:00", "updated_at": "2019-05-04T00:00:00+00:00" },
+        ]},
+    ]);
+    let links = json!({
+        "account_parents": [],
+        "transaction_links": [
+            { "id": COUNTERPART, "linked_transfer_id": null, "linked_transfer_split_id": LEG_LINE },
+        ],
+    });
+    (chunks, links)
+}
+
+// ── The headline ────────────────────────────────────────────────────────────
+
+#[test]
+fn a_wipe_and_a_restore_leave_the_file_exactly_as_it_was() {
+    let mut connection = seeded();
+    let before = snapshot(&connection);
+
+    let counts = wipe(&mut connection).answer;
+    assert_eq!(counts.accounts, 2);
+    // Zero, because the account delete already cascaded them: the number reports
+    // its own statement, not the operation. Both engines say so.
+    assert_eq!(counts.transactions, 0);
+    // Three, not five: the two To/From rows cascaded with their accounts a
+    // statement earlier, so by the time the categories statement runs there are
+    // three left to count. Postgres reports the same three, for the same reason.
+    assert_eq!(counts.categories, 3);
+
+    let empty = user_financial_data_is_empty(
+        &connection,
+        UserFinancialDataIsEmpty { user_id: Some(OWNER.to_owned()) },
+    )
+    .expect("is empty");
+    assert!(empty.answer.empty, "the wipe must satisfy the precondition it exists for");
+
+    let (chunks, links) = bundle();
+    let restored = restore(&mut connection, chunks);
+    assert_eq!(restored.answer.inserted, 11);
+    assert!(restored.answer.dropped.is_empty(), "{:?}", restored.answer.dropped);
+
+    let command: FinalizeUserRestore =
+        serde_json::from_value(json!({ "links": links, "user_id": OWNER })).expect("links");
+    let finalized = finalize_user_restore(&mut connection, command).expect("finalize");
+    assert_eq!(finalized.answer.transactions_relinked, 1);
+
+    assert_eq!(
+        snapshot(&connection),
+        before,
+        "a backup is defined by its restore; if these differ the file is not a backup"
+    );
+}
+
+#[test]
+fn the_round_trip_keeps_every_balance_and_the_identity_that_ties_them_together() {
+    let mut connection = seeded();
+    wipe(&mut connection);
+    let (chunks, links) = bundle();
+    restore(&mut connection, chunks);
+    let command: FinalizeUserRestore =
+        serde_json::from_value(json!({ "links": links, "user_id": OWNER })).expect("links");
+    finalize_user_restore(&mut connection, command).expect("finalize");
+
+    // X-8: the file's own balances, verbatim. Not recomputed from the rows —
+    // recomputing would discard any balance reconciled against a statement.
+    assert_eq!(
+        scalar(&connection, "SELECT group_concat(balance_minor, ',') FROM (
+            SELECT balance_minor FROM accounts ORDER BY id)"),
+        "-2500,1500"
+    );
+    // B-1 anyway, because this dataset happens to satisfy it and a restore that
+    // broke it would be restoring something else.
+    assert_eq!(
+        scalar(&connection, "SELECT COUNT(*) FROM accounts a
+             WHERE a.balance_minor <> a.initial_balance_minor
+                 + COALESCE((SELECT SUM(t.amount_minor) FROM transactions t
+                              WHERE t.account_id = a.id), 0)"),
+        "0"
+    );
+}
+
+// ── One transaction, and the cycle it can close ─────────────────────────────
+
+#[test]
+fn the_whole_restore_is_one_transaction_so_a_refusal_leaves_nothing_behind() {
+    // DESIGN.md §5 divergence 6. The cloud's own comment calls its
+    // non-atomicity "honest" and survivable because the login had to be empty;
+    // not needing that argument is strictly better.
+    let mut connection = seeded();
+    wipe(&mut connection);
+
+    let (chunks, _) = bundle();
+    let mut broken = chunks.as_array().expect("chunks").clone();
+    // A last chunk that cannot land: a split line naming a transaction the file
+    // does not carry.
+    broken.push(json!({ "entity": "transaction_splits", "rows": [
+        { "id": "50000000-0000-0000-0000-0000000000ff",
+          "transaction_id": "70000000-0000-0000-0000-0000000000ff",
+          "user_id": OWNER, "category": WEEKLY_SHOP, "amount": "-1.00", "sort_order": 0,
+          "created_at": "2019-05-04T00:00:00+00:00", "updated_at": "2019-05-04T00:00:00+00:00" }
+    ]}));
+
+    let command: RestoreUserChunk =
+        serde_json::from_value(json!({ "chunks": broken, "user_id": OWNER })).expect("command");
+    let error = restore_user_chunk(&mut connection, command).expect_err("the last chunk cannot land");
+    assert_eq!(error.code(), "restore_row_refused", "{error}");
+
+    // Ten rows landed before the eleventh refused, and every one of them is gone.
+    for table in ["accounts", "categories", "transactions", "transaction_splits"] {
+        assert_eq!(
+            scalar(&connection, &format!("SELECT COUNT(*) FROM {table}")),
+            "0",
+            "{table} survived a refused restore"
+        );
+    }
+    let empty = user_financial_data_is_empty(
+        &connection,
+        UserFinancialDataIsEmpty { user_id: Some(OWNER.to_owned()) },
+    )
+    .expect("is empty");
+    assert!(empty.answer.empty, "a refused restore must leave the login restorable");
+}
+
+#[test]
+fn a_split_line_may_name_a_transaction_that_has_not_been_restored_yet() {
+    // R-11, and the reason one transaction is possible here at all.
+    //
+    // `transaction_splits.linked_transfer_id` is DEFERRABLE INITIALLY DEFERRED
+    // in this schema and is not deferrable in the cloud, where nothing is
+    // (20260807083000:488-493 verifies that as a premise of its two-pass design).
+    // So this order — a leg line naming a counterpart that arrives in a LATER
+    // chunk — is one Postgres cannot accept in any arrangement of its calls, and
+    // one this file resolves at COMMIT.
+    //
+    // It is what makes DESIGN.md §5 divergence 6 true rather than aspirational:
+    // the local restore does not need its chunks to be separate transactions,
+    // because it does not need any of them to have committed before the next.
+    let mut connection = seeded();
+    wipe(&mut connection);
+
+    let result = restore(
+        &mut connection,
+        json!([
+            { "entity": "accounts", "rows": [
+                { "id": EVERYDAY, "name": "Everyday", "type": "checking", "balance": "-25.00",
+                  "created_at": "2019-01-01T00:00:00+00:00", "updated_at": "2019-01-01T00:00:00+00:00" },
+                { "id": RAINY_DAY, "name": "Rainy day", "type": "savings", "balance": "15.00",
+                  "created_at": "2019-01-01T00:00:00+00:00", "updated_at": "2019-01-01T00:00:00+00:00" }]},
+            { "entity": "categories", "rows": [
+                { "id": WEEKLY_SHOP, "name": "Weekly shop", "type": "expense", "level": "sub",
+                  "created_at": "2019-01-01T00:00:00+00:00", "updated_at": "2019-01-01T00:00:00+00:00" }]},
+            { "entity": "transactions", "rows": [
+                { "id": CORNER_SHOP, "account_id": EVERYDAY, "description": "Corner shop",
+                  "amount": "-25.00", "type": "expense", "date": "2019-05-04", "is_split": true,
+                  "category": "",
+                  "created_at": "2019-05-04T00:00:00+00:00", "updated_at": "2019-05-04T00:00:00+00:00" }]},
+            // The line points FORWARD, at a row the next chunk brings.
+            { "entity": "transaction_splits", "rows": [
+                { "id": LEG_LINE, "transaction_id": CORNER_SHOP, "category": WEEKLY_SHOP,
+                  "amount": "-15.00", "sort_order": 0, "transfer_account_id": RAINY_DAY,
+                  "linked_transfer_id": COUNTERPART,
+                  "created_at": "2019-05-04T00:00:00+00:00", "updated_at": "2019-05-04T00:00:00+00:00" },
+                { "id": PLAIN_LINE, "transaction_id": CORNER_SHOP, "category": WEEKLY_SHOP,
+                  "amount": "-10.00", "sort_order": 1,
+                  "created_at": "2019-05-04T00:00:00+00:00", "updated_at": "2019-05-04T00:00:00+00:00" }]},
+            { "entity": "transactions", "rows": [
+                { "id": COUNTERPART, "account_id": RAINY_DAY, "description": "Counterpart",
+                  "amount": "15.00", "type": "transfer", "date": "2019-05-04",
+                  "transfer_account_id": EVERYDAY,
+                  "created_at": "2019-05-04T00:00:00+00:00", "updated_at": "2019-05-04T00:00:00+00:00" }]},
+        ]),
+    );
+    assert_eq!(result.answer.inserted, 7);
+    assert_eq!(
+        scalar(&connection, "SELECT COUNT(*) FROM transaction_splits s
+             JOIN transactions t ON t.id = s.linked_transfer_id"),
+        "1",
+        "the forward reference should have resolved at COMMIT"
+    );
+}
+
+// ── The guards ──────────────────────────────────────────────────────────────
+
+#[test]
+fn the_wipe_holds_the_leg_guard_and_puts_it_back() {
+    let mut connection = seeded();
+    wipe(&mut connection);
+    assert_eq!(
+        scalar(&connection, "SELECT COUNT(*) FROM _rpc_guard"),
+        "0",
+        "a stray flag leaves S-9 and S-10 standing down for every later write"
+    );
+    assert_eq!(scalar(&connection, "SELECT COUNT(*) FROM transaction_splits"), "0");
+}
+
+#[test]
+fn the_wipe_does_not_hold_the_leg_guard_when_no_line_is_a_leg() {
+    // A guard that is always on is not a guard. The condition is the same one
+    // delete_transaction uses, and this is the half that proves it is a
+    // CONDITION rather than a formality.
+    let mut connection = seeded();
+    connection
+        .execute_batch(&format!(
+            "INSERT INTO _rpc_guard VALUES ('leg');
+             UPDATE transaction_splits SET linked_transfer_id = NULL WHERE id = '{LEG_LINE}';
+             UPDATE transactions SET linked_transfer_split_id = NULL WHERE id = '{COUNTERPART}';
+             DELETE FROM _rpc_guard;"
+        ))
+        .expect("unlink the leg");
+
+    // With no leg anywhere, the wipe must still succeed — and it must do so
+    // WITHOUT the guard, which is unobservable from outside except that the
+    // whole thing works and the table is clean.
+    wipe(&mut connection);
+    assert_eq!(scalar(&connection, "SELECT COUNT(*) FROM _rpc_guard"), "0");
+    assert_eq!(scalar(&connection, "SELECT COUNT(*) FROM transactions"), "0");
+}
+
+#[test]
+fn finalize_puts_the_restore_guard_back_before_it_returns() {
+    let mut connection = seeded();
+    wipe(&mut connection);
+    let (chunks, links) = bundle();
+    restore(&mut connection, chunks);
+    let command: FinalizeUserRestore =
+        serde_json::from_value(json!({ "links": links, "user_id": OWNER })).expect("links");
+    finalize_user_restore(&mut connection, command).expect("finalize");
+
+    assert_eq!(scalar(&connection, "SELECT COUNT(*) FROM _rpc_guard"), "0");
+
+    // …and the exemption really is off again: an ordinary edit now re-dates.
+    connection
+        .execute_batch(&format!(
+            "UPDATE transactions SET description = 'Corner shop (edited)' WHERE id = '{CORNER_SHOP}';"
+        ))
+        .expect("edit");
+    let day = scalar(
+        &connection,
+        &format!("SELECT substr(updated_at, 1, 10) FROM transactions WHERE id = '{CORNER_SHOP}'"),
+    );
+    assert_ne!(day, "2019-05-04", "the restore exemption outlived the restore");
+}
+
+// ── The audit ───────────────────────────────────────────────────────────────
+
+#[test]
+fn the_wipe_audits_every_row_and_the_hashes_chain() {
+    let mut connection = seeded();
+    let result = wipe(&mut connection);
+    assert_eq!(result.audit_seq, Some(4), "two transactions and two accounts");
+
+    /// One stored audit row, in the order `chain_hash` absorbs its fields.
+    struct Entry {
+        seq: i64,
+        entity: String,
+        entity_id: String,
+        action: String,
+        before: Option<String>,
+        after: Option<String>,
+        created_at: String,
+        prev_hash: Option<String>,
+        row_hash: String,
+    }
+
+    let mut statement = connection
+        .prepare(
+            "SELECT seq, entity, entity_id, action, before_data, after_data, created_at,
+                    prev_hash, row_hash
+               FROM financial_audit_log ORDER BY seq",
+        )
+        .expect("prepare");
+    let rows: Vec<Entry> = statement
+        .query_map([], |row| {
+            Ok(Entry {
+                seq: row.get(0)?,
+                entity: row.get(1)?,
+                entity_id: row.get(2)?,
+                action: row.get(3)?,
+                before: row.get(4)?,
+                after: row.get(5)?,
+                created_at: row.get(6)?,
+                prev_hash: row.get(7)?,
+                row_hash: row.get(8)?,
+            })
+        })
+        .expect("query")
+        .map(|row| row.expect("row"))
+        .collect();
+
+    assert_eq!(rows.len(), 4);
+    let mut previous: Option<String> = None;
+    for Entry { seq, entity, entity_id, action, before, after, created_at, prev_hash, row_hash } in rows {
+        assert_eq!(action, "delete");
+        assert!(before.is_some(), "a delete records what was there");
+        assert!(after.is_none(), "U-6: a delete has no after");
+        assert!(entity == "transaction" || entity == "account", "{entity}");
+        assert_eq!(prev_hash, previous, "seq {seq} does not chain");
+        let expected = wealth_core::audit::chain_hash(
+            previous.as_deref(),
+            seq,
+            &entity,
+            &entity_id,
+            &action,
+            before.as_deref(),
+            after.as_deref(),
+            &created_at,
+        );
+        assert_eq!(row_hash, expected, "seq {seq} hash does not verify");
+        previous = Some(row_hash);
+    }
+
+    // The log survives the wipe. It is the only thing left that can say what
+    // was there, which is the point of writing it before deleting.
+    assert_eq!(scalar(&connection, "SELECT COUNT(*) FROM financial_audit_log"), "4");
+}
+
+// ── The column maps ─────────────────────────────────────────────────────────
+
+#[test]
+fn every_entity_the_format_carries_can_be_restored() {
+    // The differential specs exercise four entities. This exercises all
+    // fourteen, because a scale typo in `investment_transactions` is not
+    // something anybody should find out about from their own holdings.
+    let mut connection = seeded();
+    wipe(&mut connection);
+
+    let chunks = json!([
+        { "entity": "accounts", "rows": [{
+            "id": EVERYDAY, "name": "Everyday", "type": "checking", "balance": "-25.00",
+            "initial_balance": "0.00", "bank_balance": "-24.50", "bank_balance_date": "2019-06-01",
+            "low_balance_threshold": "10.00", "low_balance_alert_enabled": true,
+            "account_number": "1234", "sort_code": "00-00-00", "institution": "A bank",
+            "opening_balance_date": "2019-01-01", "archive_through_date": "2018-12-31",
+            "last_reconciled_date": "2019-05-31", "notes": "a note", "metadata": { "k": 1 },
+            "created_at": "2019-01-01T00:00:00+00:00", "updated_at": "2019-01-01T00:00:00+00:00" }]},
+        { "entity": "categories", "rows": [{
+            "id": OUTGOINGS, "name": "Outgoings", "type": "expense", "level": "type",
+            "is_system": false, "is_transfer_category": false, "is_revaluation_category": false,
+            "is_unassigned_bucket": false, "is_active": true,
+            "created_at": "2019-01-01T00:00:00+00:00", "updated_at": "2019-01-01T00:00:00+00:00" }]},
+        { "entity": "transactions", "rows": [{
+            "id": CORNER_SHOP, "account_id": EVERYDAY, "description": "Corner shop",
+            "amount": "-25.00", "type": "expense", "date": "2019-05-04", "category": OUTGOINGS,
+            "tags": ["one", "two", "one"], "is_cleared": true, "is_split": false, "archived": false,
+            "category_confirmed": false, "statement_sequence": 7, "is_recurring": false,
+            "import_source": "qif", "import_source_id": "row-1", "merchant_name": "A shop",
+            "metadata": {}, "created_at": "2019-05-04T00:00:00+00:00",
+            "updated_at": "2019-05-04T00:00:00+00:00" }]},
+        { "entity": "transaction_splits", "rows": [{
+            "id": PLAIN_LINE, "transaction_id": CORNER_SHOP, "category": OUTGOINGS,
+            "amount": "-25.00", "sort_order": 0, "memo": "a memo",
+            "created_at": "2019-05-04T00:00:00+00:00", "updated_at": "2019-05-04T00:00:00+00:00" }]},
+        { "entity": "budgets", "rows": [{
+            "id": "b0000000-0000-0000-0000-000000000001", "name": "Food", "amount": "100.00",
+            "period": "monthly", "start_date": "2019-01-01", "spent": "42.50", "rollover": true,
+            "rollover_amount": "7.25", "alert_threshold": "80.00", "is_active": true,
+            "category": OUTGOINGS, "notes": "a note", "metadata": {},
+            "created_at": "2019-01-01T00:00:00+00:00", "updated_at": "2019-01-01T00:00:00+00:00" }]},
+        { "entity": "goals", "rows": [{
+            "id": "90000000-0000-0000-0000-000000000001", "name": "Holiday",
+            "target_amount": "500.00", "current_amount": "125.00", "status": "active",
+            "priority": "high", "account_id": EVERYDAY, "contribution_frequency": "monthly",
+            "auto_contribute": true, "target_date": "2020-06-01",
+            "completed_at": "2019-12-31T00:00:00+00:00", "metadata": {},
+            "created_at": "2019-01-01T00:00:00+00:00", "updated_at": "2019-01-01T00:00:00+00:00" }]},
+        { "entity": "goal_contributions", "rows": [{
+            "id": "91000000-0000-0000-0000-000000000001",
+            "goal_id": "90000000-0000-0000-0000-000000000001", "amount": "125.00",
+            "date": "2019-03-01", "transaction_id": CORNER_SHOP, "notes": "first",
+            "created_at": "2019-03-01T00:00:00+00:00" }]},
+        { "entity": "investments", "rows": [{
+            "id": "e0000000-0000-0000-0000-000000000001", "account_id": EVERYDAY, "symbol": "ABC",
+            "name": "A fund", "asset_type": "etf", "currency": "GBP", "quantity": "10.50000000",
+            "cost_basis": "1000.00", "current_price": "12.34500000", "market_value": "129.62",
+            "purchase_date": "2019-02-01", "purchase_price": "9.87650000",
+            "last_updated": "2019-06-01T00:00:00+00:00", "notes": "held",
+            "created_at": "2019-02-01T00:00:00+00:00", "updated_at": "2019-06-01T00:00:00+00:00" }]},
+        { "entity": "investment_transactions", "rows": [{
+            "id": "e1000000-0000-0000-0000-000000000001",
+            "investment_id": "e0000000-0000-0000-0000-000000000001", "transaction_type": "buy",
+            "quantity": "10.50000000", "price": "9.87650000", "total_amount": "103.70",
+            "fees": "1.50", "date": "2019-02-01", "notes": "bought",
+            "created_at": "2019-02-01T00:00:00+00:00" }]},
+        { "entity": "recurring_transactions", "rows": [{
+            "id": "d0000000-0000-0000-0000-000000000001", "account_id": EVERYDAY,
+            "description": "Rent", "amount": "-500.00", "type": "expense", "category": OUTGOINGS,
+            "frequency": "monthly", "start_date": "2019-01-01", "next_date": "2019-07-01",
+            "end_date": "2020-01-01", "is_active": true, "auto_create": false,
+            "created_at": "2019-01-01T00:00:00+00:00", "updated_at": "2019-01-01T00:00:00+00:00" }]},
+        { "entity": "notifications", "rows": [{
+            "id": "f0000000-0000-0000-0000-000000000001", "type": "info", "title": "Hello",
+            "message": "A message", "is_read": true, "action_label": "Open", "action_url": "/x",
+            "created_at": "2019-01-01T00:00:00+00:00", "updated_at": "2019-01-01T00:00:00+00:00" }]},
+        { "entity": "dashboard_layouts", "rows": [{
+            "id": "f0000000-0000-0000-0000-000000000002", "name": "Mine",
+            "widgets": [{ "w": "net-worth" }], "is_default": true,
+            "created_at": "2019-01-01T00:00:00+00:00", "updated_at": "2019-01-01T00:00:00+00:00" }]},
+        { "entity": "widget_preferences", "rows": [{
+            "id": "f0000000-0000-0000-0000-000000000003", "widget_type": "net-worth",
+            "settings": { "s": true }, "is_collapsed": true,
+            "last_refreshed": "2019-06-01T09:30:00+01:00",
+            "created_at": "2019-01-01T00:00:00+00:00", "updated_at": "2019-01-01T00:00:00+00:00" }]},
+        { "entity": "suggestion_dismissals", "rows": [{
+            "id": "f0000000-0000-0000-0000-000000000004", "kind": "duplicate",
+            "subject_key": "a-key", "subject_ids": [CORNER_SHOP],
+            "dismissed_at": "2019-06-01T00:00:00+00:00" }]},
+    ]);
+
+    let result = restore(&mut connection, chunks);
+    assert_eq!(result.answer.inserted, 14, "one row per entity");
+    assert!(result.answer.dropped.is_empty(), "{:?}", result.answer.dropped);
+
+    // The scale conversions, each read back as the integer the column holds.
+    assert_eq!(
+        scalar(&connection, "SELECT bank_balance_minor || '/' || low_balance_threshold_minor
+                 FROM accounts"),
+        "-2450/1000"
+    );
+    assert_eq!(
+        scalar(&connection, "SELECT amount_minor || '/' || spent_minor || '/'
+                 || rollover_amount_minor || '/' || alert_threshold_bp FROM budgets"),
+        "10000/4250/725/8000",
+        "alert_threshold is a PERCENTAGE stored as basis points of a percent, not money"
+    );
+    assert_eq!(
+        scalar(&connection, "SELECT target_amount_minor || '/' || current_amount_minor FROM goals"),
+        "50000/12500"
+    );
+    assert_eq!(
+        scalar(&connection, "SELECT quantity_e8 || '/' || cost_basis_minor || '/'
+                 || current_price_e8 || '/' || market_value_minor || '/' || purchase_price_e8
+                 FROM investments"),
+        "1050000000/100000/1234500000/12962/987650000",
+        "prices are 8dp here and 2dp in the cloud — DESIGN.md §5 divergence 4"
+    );
+    assert_eq!(
+        scalar(&connection, "SELECT quantity_e8 || '/' || unit_price_e8 || '/'
+                 || total_amount_minor || '/' || fee_minor || '/' || tax_minor
+                 FROM investment_transactions"),
+        "1050000000/987650000/10370/150/0",
+        "tax_minor has no key in the backup format and takes this schema's default"
+    );
+
+    // The two array columns, which are child tables here.
+    assert_eq!(
+        scalar(&connection, "SELECT group_concat(tag, ',') FROM (
+            SELECT tag FROM transaction_tags ORDER BY tag)"),
+        "one,two",
+        "tags are a SET: the duplicate in the file lands once"
+    );
+    assert_eq!(
+        scalar(&connection, "SELECT transaction_id || '/' || role_order
+                 FROM suggestion_dismissal_subjects"),
+        format!("{CORNER_SHOP}/0")
+    );
+
+    // A timestamp with an offset, normalised by SQLite to the shape the column
+    // defaults use — PostgREST renders timestamptz with a numeric offset and
+    // `transactions_timestamps_shaped` requires the Z.
+    assert_eq!(
+        scalar(&connection, "SELECT last_refreshed FROM widget_preferences"),
+        "2019-06-01T08:30:00.000Z"
+    );
+    // Every row re-owned, including the ones whose file rows named nobody.
+    assert_eq!(
+        scalar(&connection, "SELECT COUNT(DISTINCT user_id) || '/' || MIN(user_id) FROM (
+            SELECT user_id FROM accounts UNION ALL SELECT user_id FROM budgets
+             UNION ALL SELECT user_id FROM goals UNION ALL SELECT user_id FROM investments
+             UNION ALL SELECT user_id FROM recurring_transactions
+             UNION ALL SELECT user_id FROM suggestion_dismissals)"),
+        format!("1/{OWNER}")
+    );
+}
+
+#[test]
+fn a_dismissal_naming_a_transaction_nobody_has_keeps_the_dismissal_and_reports_the_subject() {
+    // The cloud's subject_ids is a uuid[] with a column comment PROMISING every
+    // id resolves; here that promise is a foreign key. A restore cannot store an
+    // id nothing matches — and refusing the whole file over a suggestion the
+    // user waved away would be absurd, so the subject is dropped and SAID.
+    let mut connection = seeded();
+    wipe(&mut connection);
+    let result = restore(
+        &mut connection,
+        json!([{ "entity": "suggestion_dismissals", "rows": [{
+            "id": "f0000000-0000-0000-0000-000000000004", "kind": "duplicate",
+            "subject_key": "a-key", "subject_ids": ["70000000-0000-0000-0000-0000000000ff"],
+            "dismissed_at": "2019-06-01T00:00:00+00:00" }]}]),
+    );
+
+    assert_eq!(result.answer.inserted, 1, "the dismissal itself lands");
+    assert_eq!(result.answer.dropped.len(), 1);
+    assert!(
+        result.answer.dropped[0].what.contains("does not hold"),
+        "{:?}",
+        result.answer.dropped[0]
+    );
+    assert_eq!(scalar(&connection, "SELECT COUNT(*) FROM suggestion_dismissals"), "1");
+    assert_eq!(scalar(&connection, "SELECT COUNT(*) FROM suggestion_dismissal_subjects"), "0");
+}
+
+#[test]
+fn an_unknown_key_in_a_row_is_ignored_exactly_as_the_cloud_ignores_it() {
+    let mut connection = seeded();
+    wipe(&mut connection);
+    let result = restore(
+        &mut connection,
+        json!([{ "entity": "accounts", "rows": [{
+            "id": EVERYDAY, "name": "Everyday", "type": "checking",
+            "a_column_that_does_not_exist": "x",
+            "created_at": "2019-01-01T00:00:00+00:00", "updated_at": "2019-01-01T00:00:00+00:00" }]}]),
+    );
+    assert_eq!(result.answer.inserted, 1);
+    // …and the columns it did not mention took this schema's defaults, where the
+    // cloud would have refused the row for the NOT NULL it left NULL. The
+    // difference is reachable only from a hand-edited file; both exporters in
+    // this repo write whole rows.
+    assert_eq!(
+        scalar(&connection, "SELECT balance_minor || '/' || currency || '/' || is_active FROM accounts"),
+        "0/GBP/1"
+    );
+}
+
+#[test]
+fn a_figure_past_the_bound_names_the_row_it_came_from() {
+    // MONEY-5. The refusal has to say WHICH row: a restore of fifty thousand
+    // rows that says only "CHECK constraint failed" has told the user nothing
+    // they can act on.
+    let mut connection = seeded();
+    wipe(&mut connection);
+    let command: RestoreUserChunk = serde_json::from_value(json!({
+        "chunks": [
+            { "entity": "accounts", "rows": [{
+                "id": EVERYDAY, "name": "Everyday", "type": "checking", "balance": "0.00",
+                "initial_balance": "0.00",
+                "created_at": "2019-01-01T00:00:00+00:00", "updated_at": "2019-01-01T00:00:00+00:00" }]},
+            { "entity": "transactions", "rows": [{
+                "id": CORNER_SHOP, "account_id": EVERYDAY, "description": "Absurd",
+                "amount": "1000000000000.00", "type": "income", "date": "2019-05-04",
+                "created_at": "2019-05-04T00:00:00+00:00", "updated_at": "2019-05-04T00:00:00+00:00" }]},
+        ],
+        "user_id": OWNER
+    }))
+    .expect("command");
+
+    let error = restore_user_chunk(&mut connection, command).expect_err("out of bounds");
+    let message = error.to_string();
+    assert_eq!(error.code(), "restore_row_refused", "{message}");
+    assert!(message.contains("transactions"), "{message}");
+    assert!(message.contains(CORNER_SHOP), "the refusal must name the row: {message}");
+    assert!(message.contains("transactions_amount_bounded"), "{message}");
+    // And the account that landed first went with it: one transaction.
+    assert_eq!(scalar(&connection, "SELECT COUNT(*) FROM accounts"), "0");
+}
+
+#[test]
+fn a_sub_penny_figure_is_refused_rather_than_rounded() {
+    let mut connection = seeded();
+    wipe(&mut connection);
+    let command: RestoreUserChunk = serde_json::from_value(json!({
+        "chunks": [{ "entity": "accounts", "rows": [{
+            "id": EVERYDAY, "name": "Everyday", "type": "checking", "balance": "-25.005",
+            "created_at": "2019-01-01T00:00:00+00:00", "updated_at": "2019-01-01T00:00:00+00:00" }]}],
+        "user_id": OWNER
+    }))
+    .expect("command");
+    let error = restore_user_chunk(&mut connection, command).expect_err("sub-penny");
+    let message = error.to_string();
+    assert!(message.contains("amount_not_representable"), "{message}");
+    assert!(message.contains(EVERYDAY), "{message}");
+}
+
+#[test]
+fn a_timestamp_nothing_can_read_is_refused_rather_than_stored_as_now() {
+    let mut connection = seeded();
+    wipe(&mut connection);
+    let command: RestoreUserChunk = serde_json::from_value(json!({
+        "chunks": [{ "entity": "accounts", "rows": [{
+            "id": EVERYDAY, "name": "Everyday", "type": "checking",
+            "created_at": "2019-01-01T00:00:00+00:00", "updated_at": "the day before yesterday" }]}],
+        "user_id": OWNER
+    }))
+    .expect("command");
+    let error = restore_user_chunk(&mut connection, command).expect_err("unreadable");
+    assert!(error.to_string().contains("timestamp_unreadable"), "{error}");
+}

--- a/scripts/local-sqlite/README.md
+++ b/scripts/local-sqlite/README.md
@@ -588,6 +588,31 @@ it. Two things in there are worth knowing before writing a spec:
 5. **Observed parity**, computed from 1/3/4 with the label ignored. A divergence
    that quietly stops diverging is a FAILURE.
 
+### One engine, when there is only one to run
+
+`parity: 'not-comparable'` plus `skip: { postgres: '<why>' }` says the other
+engine has no counterpart to compare against. It is the same declaration
+`lib/specs.mjs` has always carried for a constraint only one schema has, and it
+arrived in the VERB harness on 2026-08-08 for `verify_integrity`, which is **not
+a port of anything**: the cloud has no such function, no such view and no
+equivalent (traced in `crates/wealth-core/src/verbs/verify_integrity.rs`; the
+only Postgres relatives are two throwaway verification SELECTs inside
+migrations).
+
+Three things stop it becoming a way to duck a comparison:
+
+* the loader refuses `skip` without `not-comparable` and refuses
+  `not-comparable` without exactly one skip, so the two declarations cannot
+  disagree;
+* a skipped engine must state WHY, in prose, in the spec file;
+* the runner reports it in the parity table as `not-comparable` and counts it
+  separately in the summary line, so a family of single-engine specs cannot be
+  read as a family of passes.
+
+A verb that HAS a cloud counterpart cannot use it, because the Postgres driver
+maps verbs by name and a spec that skipped Postgres for a mapped verb would be
+declaring a comparison it could have made.
+
 ## The bridge
 
 `crates/wealth-core` exposes `wealth-core-cli` behind `--features cli`: JSON
@@ -670,12 +695,33 @@ Each of these was executed, then reverted.
 | swap the source and target guard blocks | **every one of the twenty-eight merge specs passed**, and only `tests/category_family.rs::the_source_guards_run_in_the_order_the_cloud_checks_them` failed. That is a finding, not a pass: no spec made a source guard and a target guard true at the same time. `merge-the-source-is-judged-before-the-target` was written for it, and with that spec present the same break fails differentially — SQLite says `merge_target_is_group`, Postgres says `merge_source_has_children`, both engines refuse, and only the **named** expectation catches it |
 | disable the confirm verb's blank-category guard | three specs fail and all three go `MISDECLARED (divergent)`: blank, NULL and whitespace rows are all marked vouched-for, `audit_shape` goes from `NONE` to three `transaction/update` rows, and the split-parent spec's flag flips. One crate test fails with them. The three-shapes-of-blank fixture is what makes this catch a port that only checked `IS NULL` |
 
+**From the ledger-core close — the prune and the checker (2026-08-08, 259 specs):**
+
+| break | result |
+| --- | --- |
+| neuter one integrity check (`WHERE 1 = 0 AND …` on `dangling_category_ref`) | `integrity-r3-a-transaction-filed-under-a-category-nothing-answers-to` fails three ways: `ok` flips to true, `violations` to 0, and `findings` to `[]`. The spec asserts the whole finding — check, entity, id, severity and the sentence a person is shown — so a check that stops firing cannot be mistaken for a file that got better |
+| break C-5 (`WHEN 0 AND OLD.is_transfer_category = 1`) | `prune-a-to-from-category-reached-by-cascade-refuses-the-whole-batch` fails four ways — SQLite **accepts** where Postgres refuses, the parent AND the protected To/From category are both GONE, and the transfer-category count drops to 1 — with `MISDECLARED (divergent)`. Two crate tests fail with it. This is the C-5 interplay reproduced on demand: without the trigger the cascade quietly deletes an account's transfer bookkeeping through a category the caller never named |
+| remove the deepest-first ordering (sort by id alone) | `prune-three-generations-named-together-are-counted-as-three` fails: `deleted` is 2, not 3, and parity goes `MISDECLARED (divergent)`. **The two-row spec beside it still passed** — the child's id happens to sort before the parent's, so id order IS deepest-first for that pair, by luck. Recorded because a family that only tested the pair would have been asserting an accident; the three-generation spec is the one that bites |
+
 `cargo test` fails alongside every one of these; the counts are in the table.
 
-### Current run, and what became of the five failures
+### Current run
 
-**172 verb specs · 172 pass · 3 declared divergences**, 2026-08-08, against a
-reference cluster rebuilt from the full migration history.
+**259 verb specs · 259 pass · 7 declared divergences · 24 single-engine**,
+2026-08-08, against a reference cluster rebuilt from the full migration history.
+`npm run test:local-sqlite` is 66/66 and `cargo test` is 203.
+
+The count in this section has been behind twice, and the drift is worth one
+line rather than a quiet edit: it read **172** while the suite had already grown
+to 217 with the restore family, and this batch adds 42 (18 for
+`delete_unused_categories`, 24 for `verify_integrity`). The 24 are all
+single-engine, so the number of specs that actually COMPARE two engines is 235.
+
+### What became of five failures, 2026-08-08
+
+**172 verb specs · 172 pass · 3 declared divergences** was the state at the time
+this was written, against a reference cluster rebuilt from the full migration
+history.
 
 It was 167/5 for most of that day. All five were specs of the "a row filed
 against an account it does not own" family, and all five failed because
@@ -934,3 +980,69 @@ mutation table above is where it earned its keep.
   accepted set is now enumerated in `wire::Flag`, measured one `psql` cast per
   value, and it is also what makes `is_cleared: ''` refuse **by name** instead of
   as a deserialiser error.
+- **`delete_unused_categories` promises something it does not deliver, on BOTH
+  engines.** `20260708160000`'s header says the RPC re-checks everything
+  server-side so *"a stale client can never destroy referenced data"*. Measured
+  (`scratchpad/local-core/probe-prune1.sh` `p-cascade-eats-a-referenced-child`,
+  `probe-prune2.sh` `p2-grandchild-referenced-parents-named`): name a parent and
+  a child together, with the CHILD referenced by a transaction, and the child's
+  own check skips it — while the parent's "child outside the batch" check passes
+  *because the child is in the batch*. The parent is deleted and
+  `parent_id ON DELETE CASCADE` takes the referenced child with it, leaving the
+  transaction filed under an id nothing answers to. The same route eats a
+  budget's `category_id` (nulled by the key) and a budget's `category` text
+  (left dangling). It is REPRODUCED in the local port rather than fixed — a port
+  that tidied it would refuse a prune the cloud performs — and the local edition
+  reports the wreckage instead, through `verify_integrity`'s
+  `dangling_category_ref`.
+- **The same function has a second, smaller hole one clause wide.** Its
+  transaction check reads `t.category = c.id::text` and nothing else, while its
+  budget check two clauses later reads `b.category` **and** `b.category_id`. So a
+  transaction filed only through the uuid column does not save its category:
+  measured, the category is deleted and the column is nulled by the foreign key,
+  leaving nothing behind — the one case in this family where even
+  `verify_integrity` has nothing to report, because a NULL is not a dangler.
+- **A function with no `RAISE` in it can still refuse, and this one does.**
+  Twenty measured cases produced no exception from `delete_unused_categories`
+  itself; every protection in it is a `WHERE` clause. But name a prunable
+  category together with a To/From category sitting under it and the cascade
+  walks the protected row into C-5's `BEFORE DELETE` trigger:
+  `transfer_category_protected`, whole batch lost, on both engines. Worth
+  recording because "this RPC never refuses" is exactly the kind of summary that
+  gets written into a client's error handling.
+- **The cloud's single-statement `DELETE` cannot be a single statement locally
+  without changing the number it returns.** Postgres decides which rows to delete
+  from one snapshot and counts each; SQLite scans, deletes the parent, the
+  cascade removes the child, and by the time the scan reaches the child there is
+  nothing left to count. Measured: parent + child answers **2** in the cloud and
+  **1** in SQLite, and three generations answers **3** against **1** — with the
+  same six categories left in the file either way. A disagreement about the
+  answer, not about the ledger, and the answer is what the import summary shows.
+  The port qualifies the rows first and deletes them deepest-first, which makes
+  all twenty cases match.
+- **`verify_integrity` has no cloud counterpart at all**, and `schema.sql` said
+  it did. The section header claimed *"each of these has a Postgres twin …  so
+  the differential harness can compare violation NAMES across engines"*. Traced
+  three ways — `grep -rn verify_integrity` over `supabase/`, `api/` and `src/`;
+  no `CREATE VIEW` anywhere in `supabase/migrations/`; the only relatives are two
+  throwaway verification SELECTs inside migrations, both of B-1 alone — and
+  corrected in place. The consequence is structural rather than cosmetic: the
+  checker is the local edition's only defence against a rule silently ceasing to
+  hold, its specs are the first in this harness that cannot be differential, and
+  `parity: 'not-comparable'` exists in the verb harness because of it.
+- **Fifteen checks caught none of the two commonest ingest disasters.** Planted a
+  card statement with inverted signs and an `<AVAILBAL>` stored where a
+  `<LEDGERBAL>` belongs (`probe-integrity1.mjs`, cases 16 and 17): the view
+  reported **nothing** for either, because both produce data that is internally
+  consistent and entirely wrong. PHASE1-PLAN §2.5's two addendum checks are now
+  in the view as `warning`s, with `v_integrity_ok` counting only violations so a
+  heuristic can never condemn a file.
+- **One integrity check cannot be reached backwards.** The obvious way to plant
+  `account_missing_transfer_category` is to delete a To/From category — and C-5
+  refuses, so deleting the Transfer anchor to force it aborts the whole statement
+  with `transfer_category_protected`. It is reachable only forwards, by creating
+  an account whose owner has no Transfer anchor for C-3's trigger to hang a
+  category from. Which means the fixture every ownership spec in this harness has
+  used since the transfer family — a second login with one account — has been
+  carrying an integrity violation all along, and nothing until now could report
+  it.

--- a/scripts/local-sqlite/lib/verb-postgres.mjs
+++ b/scripts/local-sqlite/lib/verb-postgres.mjs
@@ -259,6 +259,26 @@ const VERBS = {
        FROM public.transactions t
       WHERE t.id = (${payloadLiteral}::jsonb->'ids'->>0)::uuid;`,
 
+  // The prune returns a bare integer and touches no transaction, so — like the
+  // restore family — it is compared on its OWN answer, wrapped in an object so
+  // the shape matches the Rust side's `answer`. Everything the count cannot
+  // carry (which categories survived, which references were left dangling by the
+  // cascade, that nothing was audited) is asserted through `state` SELECTs.
+  //
+  // `p_ids` is rebuilt as a real uuid[] for the reason clear_transfer_links
+  // gives: the signature takes an array. A NULL `ids` and an absent one both
+  // arrive as the empty array, and MEASURED (`probe-prune1.sh` `p-null-array`,
+  // `p-empty-array`) the RPC answers 0 to both and to NULL, so nothing is lost.
+  delete_unused_categories: (payloadLiteral) =>
+    `SELECT jsonb_build_object(
+              'deleted',
+              public.delete_unused_categories(
+                ARRAY(SELECT x::uuid
+                        FROM jsonb_array_elements_text(
+                               COALESCE(${payloadLiteral}::jsonb->'ids', '[]'::jsonb)) AS x),
+                NULLIF(${payloadLiteral}::jsonb->>'user_id', '')::uuid))
+       INTO v_row;`,
+
   confirm_transaction_categories: (payloadLiteral) =>
     `PERFORM public.confirm_transaction_categories(
                ARRAY(SELECT x::uuid
@@ -269,6 +289,85 @@ const VERBS = {
      SELECT ${ROW_JSON} INTO v_row
        FROM public.transactions t
       WHERE t.id = (${payloadLiteral}::jsonb->'ids'->>0)::uuid;`,
+
+  // THE RESTORE FAMILY IS COMPARED ON ITS OWN ANSWER
+  // ------------------------------------------------
+  // None of these four returns a transaction, so there is no row for the
+  // runner's field-by-field comparison to bite on and nothing to project out of
+  // storage either — a wipe's whole subject is rows that no longer exist. What
+  // IS comparable is the value each function returns, so that is what `v_row`
+  // carries: `user_financial_data_is_empty`'s boolean and `restore_user_chunk`'s
+  // bigint are wrapped in an object so the shape matches the Rust side's
+  // `answer`, and the other two already return jsonb and are passed through
+  // key for key.
+  //
+  // Everything a return value cannot carry — the rows that survived, the
+  // balances, the audit trail, the dates that did or did not move — is asserted
+  // through `state` SELECTs written per engine, which is where cross-engine
+  // comparisons of rows belong.
+  user_financial_data_is_empty: (payloadLiteral) =>
+    `SELECT jsonb_build_object(
+              'empty',
+              public.user_financial_data_is_empty(
+                NULLIF(${payloadLiteral}::jsonb->>'user_id', '')::uuid))
+       INTO v_row;`,
+
+  // `p_confirm` is read with `->>` and NOT coalesced: a missing key must arrive
+  // as SQL NULL so the RPC's `IS DISTINCT FROM` refusal is reachable from a
+  // payload rather than smoothed over by the driver.
+  wipe_user_financial_data: (payloadLiteral) =>
+    `SELECT public.wipe_user_financial_data(
+              ${payloadLiteral}::jsonb->>'confirm',
+              NULLIF(${payloadLiteral}::jsonb->>'user_id', '')::uuid)
+       INTO v_row;`,
+
+  // THE CHUNK LIST, UNPACKED
+  // ------------------------
+  // The local verb takes a LIST of chunks and applies them in one transaction,
+  // because DESIGN.md §5 divergence 6 says a local restore has no request-size
+  // cliff to chunk around and R-11 says the deferred keys let it be atomic. The
+  // cloud RPC takes exactly one. So a spec that wants the two compared sends ONE
+  // chunk and this unpacks it — the same honest unpacking the update and delete
+  // verbs already do for their positional arguments.
+  //
+  // A spec sending more than one chunk is asserting the local atomicity, which
+  // has no cloud counterpart; those live in the crate's own integration tests.
+  //
+  // `->'rows'` is NOT coalesced, so an absent key arrives as SQL NULL and the
+  // measured hole in `rows_not_an_array` stays reachable from a payload.
+  restore_user_chunk: (payloadLiteral) =>
+    `SELECT jsonb_build_object(
+              'inserted',
+              public.restore_user_chunk(
+                ${payloadLiteral}::jsonb->'chunks'->0->>'entity',
+                ${payloadLiteral}::jsonb->'chunks'->0->'rows',
+                NULLIF(${payloadLiteral}::jsonb->>'user_id', '')::uuid))
+       INTO v_row;`,
+
+  finalize_user_restore: (payloadLiteral) =>
+    `SELECT public.finalize_user_restore(
+              COALESCE(${payloadLiteral}::jsonb->'links', '{}'::jsonb),
+              NULLIF(${payloadLiteral}::jsonb->>'user_id', '')::uuid)
+       INTO v_row;`,
+
+  // The snap returns the whole accounts row. Projected into the same eight
+  // fields crate::row::account::AccountRow serialises, money as a decimal string
+  // on both sides — numeric::text is exact and involves no rounding function.
+  link_bank_account_snap: (payloadLiteral) =>
+    `SELECT jsonb_build_object(
+              'id', a.id,
+              'user_id', a.user_id,
+              'name', a.name,
+              'type', a.type,
+              'currency', a.currency,
+              'balance', a.balance::text,
+              'initial_balance', a.initial_balance::text,
+              'is_active', a.is_active)
+       INTO v_row
+       FROM public.link_bank_account_snap(
+              (${payloadLiteral}::jsonb->>'account_id')::uuid,
+              (${payloadLiteral}::jsonb->>'user_id')::uuid,
+              (${payloadLiteral}::jsonb->>'bank_balance')::numeric) a;`,
 };
 
 /**
@@ -361,6 +460,19 @@ export class PostgresVerbEngine {
   run(spec) {
     const build = VERBS[spec.command.verb];
     if (!build) throw new Error(`no Postgres RPC is mapped for verb "${spec.command.verb}"`);
+
+    // The local restore takes a LIST of chunks and the cloud RPC takes one, so
+    // the driver above unpacks chunks[0]. A spec sending more than one is
+    // asserting the LOCAL atomicity, which has no cloud counterpart — and if the
+    // driver quietly ran the first chunk anyway, that spec would compare two
+    // different operations and report whichever answer it happened to get. Say
+    // so instead. Those assertions belong in crates/wealth-core/tests.
+    if (spec.command.verb === 'restore_user_chunk' && (spec.command.payload.chunks?.length ?? 0) > 1) {
+      throw new Error(
+        'a restore spec sending more than one chunk has no Postgres counterpart: the RPC takes ' +
+        'one entity per call. Assert the one-transaction property in the crate\'s own tests.',
+      );
+    }
 
     const payload = quote(JSON.stringify(spec.command.payload));
     const lines = [

--- a/scripts/local-sqlite/lib/verb-specs.mjs
+++ b/scripts/local-sqlite/lib/verb-specs.mjs
@@ -10,6 +10,17 @@
 //
 // Everything else keeps the house rules: one file, one invariant; a refusal must
 // be NAMED; a declared divergence that stops diverging is a FAILURE, not a bonus.
+//
+// ONE ENGINE, AND WHY THAT IS ALLOWED HERE
+// ----------------------------------------
+// `parity: 'not-comparable'` plus `skip: { postgres: '<why>' }` says the other
+// engine has no counterpart to compare against. It is the same declaration
+// lib/specs.mjs has always had for a constraint only one schema carries, and it
+// arrived here for `verify_integrity`, which is not a port of anything: the
+// cloud has no such function, no such view and no equivalent (traced in the
+// verb's own module documentation). A spec cannot use it to duck a comparison —
+// the runner refuses to map a skipped engine's verb at all, so the only way to
+// skip Postgres is for the verb to have no Postgres side.
 
 import { readdir } from 'node:fs/promises';
 import { pathToFileURL } from 'node:url';
@@ -17,11 +28,15 @@ import path from 'node:path';
 
 const ENGINES = ['sqlite', 'postgres'];
 const OUTCOMES = ['ok', 'refused'];
-const PARITIES = ['match', 'divergent'];
+// match          — both engines run and must agree
+// divergent      — both engines run and MUST differ (a divergence that stops
+//                  diverging is a failure: the spec has gone vacuous)
+// not-comparable — one engine is skipped, with a stated reason
+const PARITIES = ['match', 'divergent', 'not-comparable'];
 
 const SPEC_KEYS = new Set([
   'invariant', 'title', 'design', 'consequence', 'parity', 'reason',
-  'setup', 'command', 'expect', 'result', 'rowDivergence', 'state',
+  'setup', 'command', 'expect', 'result', 'rowDivergence', 'state', 'skip',
 ]);
 
 function fail(file, message) {
@@ -69,11 +84,32 @@ function validate(file, spec) {
     }
   }
   if (!PARITIES.includes(spec.parity)) fail(file, `parity must be one of ${PARITIES.join(', ')}`);
-  if (spec.parity === 'divergent' && (typeof spec.reason !== 'string' || spec.reason.trim() === '')) {
-    fail(file, 'parity "divergent" must state its reason');
+  if (spec.parity !== 'match' && (typeof spec.reason !== 'string' || spec.reason.trim() === '')) {
+    fail(file, `parity "${spec.parity}" must state its reason`);
   }
   if (spec.parity === 'match' && spec.reason !== undefined) {
     fail(file, 'reason belongs to a divergence; a match needs no excuse');
+  }
+
+  // A skipped engine states why, in prose, and the two declarations have to
+  // agree: a skip without "not-comparable" hides a comparison that was never
+  // made, and "not-comparable" without a skip claims one engine was left out
+  // when both ran.
+  if (spec.skip !== undefined) {
+    if (typeof spec.skip !== 'object' || spec.skip === null) fail(file, 'skip must be an object');
+    for (const key of Object.keys(spec.skip)) {
+      if (!ENGINES.includes(key)) fail(file, `skip.${key} is not an engine`);
+      if (typeof spec.skip[key] !== 'string' || spec.skip[key].trim() === '') {
+        fail(file, `skip.${key} must say WHY that engine has nothing to run`);
+      }
+    }
+  }
+  const skipped = ENGINES.filter((engine) => typeof spec.skip?.[engine] === 'string');
+  if (spec.parity === 'not-comparable' && skipped.length !== 1) {
+    fail(file, 'parity "not-comparable" means exactly one engine is skipped');
+  }
+  if (spec.parity !== 'not-comparable' && skipped.length > 0) {
+    fail(file, `${skipped[0]} is skipped, so parity cannot be "${spec.parity}" — say "not-comparable" and why`);
   }
 
   const command = spec.command;
@@ -130,7 +166,10 @@ function validate(file, spec) {
         fail(file, `two state entries are both called "${entry.name}" — the second would silently replace the first`);
       }
       seen.add(entry.name);
-      for (const engine of ENGINES) {
+      // A skipped engine needs no SELECT: there is nothing to run it against,
+      // and demanding one would mean writing Postgres SQL for a table shape the
+      // comparison has already been declared unable to use.
+      for (const engine of ENGINES.filter((name) => spec.skip?.[name] === undefined)) {
         if (typeof entry[engine] !== 'string' || entry[engine].trim() === '') {
           fail(file, `state "${entry.name}" needs a ${engine} SELECT`);
         }

--- a/scripts/local-sqlite/lib/verb-sqlite.mjs
+++ b/scripts/local-sqlite/lib/verb-sqlite.mjs
@@ -137,7 +137,20 @@ export class SqliteVerbEngine {
       }
 
       const outcome = parsed.ok ? 'ok' : 'refused';
-      const row = parsed.ok ? (parsed.result?.transaction ?? null) : null;
+      // THE ROW THE TWO ENGINES ARE COMPARED ON
+      // ---------------------------------------
+      // Twelve verbs return a transaction, and that is what `transaction`
+      // carries. The restore family and the account snap return no transaction
+      // at all — counts, a boolean, an accounts row — so each projects the
+      // RPC's OWN return value under `answer`, and the Postgres driver builds
+      // the same object with jsonb_build_object.
+      //
+      // `answer` is an explicit key rather than "the whole result when there is
+      // no transaction", deliberately: a result also carries `audit_seq` and
+      // `audit_row_hash`, which are local-only and would be compared against a
+      // Postgres side that has neither. A verb decides what it is comparable ON;
+      // the harness does not guess.
+      const row = parsed.ok ? (parsed.result?.transaction ?? parsed.result?.answer ?? null) : null;
 
       // Re-open on a FRESH connection: the assertions must read the file, not
       // the writer's view of it.

--- a/scripts/local-sqlite/schema.sql
+++ b/scripts/local-sqlite/schema.sql
@@ -66,6 +66,22 @@
 --          original, verbatim, minus the one column amendment (2) declared
 --          this copy ahead by.)
 --         Specs: specs/r12-*.
+--
+-- AMENDED 2026-08-08 (4), in BOTH copies together, by the verb harness again:
+--         v_integrity_violations gained `entity` and `severity` columns and the
+--         TWO INGEST CHECKS PHASE1-PLAN §2.5 owes it — fifteen checks become
+--         seventeen, fifteen hard and two advisory — and v_integrity_ok now
+--         counts only the hard ones. The section's own header comment was also
+--         CORRECTED: it claimed every check had a Postgres twin the differential
+--         harness could compare names against, and there is no such twin; the
+--         correction carries the trace that establishes it.
+--         Both copies were edited in the same change and diffed to prove they
+--         differ by this header and by amendment (2)'s one column alone:
+--             diff <(tail -n +88 scripts/local-sqlite/schema.sql |
+--                      sed '/-- Has a human vouched/,/^$/d') \
+--                  <scratchpad>/local-core/schema.sql   -> no output
+--         (88 = this header is 85 lines and two blank ones.)
+--         Specs: verb-specs/integrity-*.
 -- ============================================================================
 
 
@@ -1120,9 +1136,70 @@ CREATE INDEX idx_goal_contributions_goal ON goal_contributions(goal_id, date);
 -- no column list, so the declaration still says it, and this trigger must not
 -- pre-empt it. Deleting an account still takes its transactions (R-1), its
 -- To/From category (C-3/C-5) and its holdings (R-9) exactly as before.
+--
+-- ── THE LINK CLEAR, AND WHY IT IS PART OF THE SAME TRIGGER ──────────────────
+-- ADDED 2026-08-08, by the wipe port, which could not wipe. Two things that are
+-- each individually right combine into a refusal the cloud does not have:
+--
+--   * `transactions_linked_has_target` — a LOCAL CHECK ("a linked transfer must
+--     name the other account"). The cloud has no such constraint; the rule lives
+--     procedurally inside its RPCs. MEASURED on the reference cluster: the only
+--     CHECKs on public.transactions are the type enum, the provider enum and the
+--     import-provenance pair.
+--   * the two `transfer_account_id = NULL` statements above, which exist ONLY
+--     because SQLite has no `ON DELETE SET NULL (column)`.
+--
+-- The trigger is BEFORE DELETE, so it nulls `transfer_account_id` while
+-- `linked_transfer_id` is still set — a state that lasts one statement and that
+-- the CHECK refuses. MEASURED, both engines, on a linked pair whose far side is
+-- deleted:
+--
+--   postgres  ok       — 2 rows survive; the survivor reads transfer_account_id
+--                        NULL, linked_transfer_id NULL
+--   sqlite    REFUSED  — CHECK constraint failed: transactions_linked_has_target
+--   sqlite    REFUSED  — the same, for a split leg:
+--                        transaction_splits_linked_has_target
+--
+-- Postgres reaches BOTH nulls because the two are independent foreign-key
+-- actions: `transfer_account_id` is SET NULL by the account key, and
+-- `linked_transfer_id` is SET NULL by the transactions key when the counterpart
+-- row — which lives IN the account being deleted — cascades away. It never sees
+-- the half-nulled row because it never has to evaluate a constraint that would
+-- object to one.
+--
+-- So the three UPDATEs below do the SAME work Postgres's own keys do, in the one
+-- order that never produces a row the CHECK can object to: clear the LINKS whose
+-- counterpart is about to cascade FIRST, then clear the targets. Note the
+-- condition — a link is cleared only when the row (or split line) it names lives
+-- in the account going away, which is exactly the set the cascade would have
+-- nulled. A link pointing somewhere else is left alone.
+--
+-- The consequence if this is ever removed: `wipe_user_financial_data` — "delete
+-- everything" — is REFUSED outright on any file containing one linked transfer,
+-- which is every real file. The refusal names a CHECK about transfer targets
+-- while the user is trying to erase the whole ledger, and there is no way
+-- through it from the UI.
+--
+-- The verb still owes `_rpc_guard('leg')` on top of this: clearing a linked
+-- leg's `linked_transfer_id` is an UPDATE of a watched column and
+-- `trg_protect_linked_leg` raises `split_leg_locked` for it. MEASURED: with the
+-- widened trigger and NO guard the split-leg case still refuses, and with the
+-- guard it succeeds and the surviving line reads NULL/NULL. That is R-5 working
+-- as designed, not a second defect — the guard is the caller's to hold.
 CREATE TRIGGER trg_unnest_account_references
 BEFORE DELETE ON accounts
 BEGIN
+  UPDATE transactions
+     SET linked_transfer_id       = NULL,
+         linked_transfer_split_id = NULL
+   WHERE user_id = OLD.user_id
+     AND (linked_transfer_id IN (SELECT id FROM transactions WHERE account_id = OLD.id)
+       OR linked_transfer_split_id IN (SELECT s.id FROM transaction_splits s
+                                         JOIN transactions t ON t.id = s.transaction_id
+                                        WHERE t.account_id = OLD.id));
+  UPDATE transaction_splits SET linked_transfer_id = NULL
+   WHERE user_id = OLD.user_id
+     AND linked_transfer_id IN (SELECT id FROM transactions WHERE account_id = OLD.id);
   UPDATE transactions       SET transfer_account_id = NULL
    WHERE transfer_account_id = OLD.id AND user_id = OLD.user_id;
   UPDATE transaction_splits SET transfer_account_id = NULL
@@ -1371,16 +1448,36 @@ CREATE TABLE widget_preferences (
 -- single highest-leverage artifact in the local core: every procedural
 -- invariant that a future code path might drop is caught here.
 --
--- Each of these has a Postgres twin, textually different but semantically
--- identical, so the differential harness can compare violation NAMES across
--- engines. The Postgres twin of B-1 already exists as the verification query
--- at 20260808090000:292-299 and 20260807200000:100-110.
+-- CORRECTED 2026-08-08. This comment used to say *"each of these has a Postgres
+-- twin, textually different but semantically identical, so the differential
+-- harness can compare violation NAMES across engines"*. It does not. TRACED:
+-- `grep -rn verify_integrity` over `supabase/`, `api/` and `src/` returns
+-- nothing but this file and its own specs; there is no `CREATE VIEW` anywhere in
+-- `supabase/migrations/`; and the only Postgres relatives of any of these are two
+-- one-off verification SELECTs a migration runs once and discards
+-- (20260808090000:292-299 and 20260807200000:100-110, both of B-1 alone). So
+-- verify_integrity is a LOCAL-ONLY facility with no differential oracle, and the
+-- specs that prove it say so — `crates/wealth-core/src/verbs/verify_integrity.rs`
+-- carries the whole argument.
+--
+-- Two columns beyond the original three, added 2026-08-08 with the two ingest
+-- checks (PHASE1-PLAN §2.5):
+--
+--   entity    which table the subject lives in, so a caller can resolve the id
+--             without knowing every check by name
+--   severity  'violation' (a rule of the ledger is broken) or 'warning' (a
+--             HEURISTIC — see the two ingest checks at the foot). v_integrity_ok
+--             counts only 'violation', so adding advisory checks cannot make the
+--             existing "must be empty" assertion flaky.
 
 CREATE VIEW v_integrity_violations AS
 
   -- B-1: balance = initial_balance + SUM(amount). Not enforceable by any
   --      constraint in either engine.
-  SELECT 'balance_identity' AS check_name, a.id AS subject,
+  SELECT 'balance_identity' AS check_name,
+         'account'          AS entity,
+         a.id               AS subject,
+         'violation'        AS severity,
          'account balance is not initial_balance + sum(transactions)' AS detail
     FROM accounts a
     LEFT JOIN (SELECT account_id, SUM(amount_minor) AS total
@@ -1389,7 +1486,8 @@ CREATE VIEW v_integrity_violations AS
 
 UNION ALL
   -- S-1: split lines sum exactly to their parent.
-  SELECT 'split_sum', t.id, 'split lines do not sum to the parent amount'
+  SELECT 'split_sum', 'transaction', t.id, 'violation',
+         'split lines do not sum to the parent amount'
     FROM transactions t
     JOIN (SELECT transaction_id, SUM(amount_minor) AS total, COUNT(*) AS n
             FROM transaction_splits GROUP BY transaction_id) s
@@ -1398,14 +1496,16 @@ UNION ALL
 
 UNION ALL
   -- S-2: a split parent has at least two lines (20260713100000:185).
-  SELECT 'split_min_lines', t.id, 'a split has fewer than two lines'
+  SELECT 'split_min_lines', 'transaction', t.id, 'violation',
+         'a split has fewer than two lines'
     FROM transactions t
    WHERE t.is_split = 1
      AND (SELECT COUNT(*) FROM transaction_splits s WHERE s.transaction_id = t.id) < 2
 
 UNION ALL
   -- S-3: an unsplit transaction has no lines.
-  SELECT 'orphan_split_lines', s.transaction_id, 'split lines on a transaction that is not split'
+  SELECT 'orphan_split_lines', 'transaction', s.transaction_id, 'violation',
+         'split lines on a transaction that is not split'
     FROM transaction_splits s
     JOIN transactions t ON t.id = s.transaction_id
    WHERE t.is_split = 0
@@ -1414,7 +1514,8 @@ UNION ALL
 UNION ALL
   -- T-1: transfer links are MUTUAL. Enforced nowhere in the cloud; only
   --      repair_claimed_transfer even checks it (20260805145035:327-331).
-  SELECT 'transfer_link_not_mutual', a.id, 'this row links to one that does not link back'
+  SELECT 'transfer_link_not_mutual', 'transaction', a.id, 'violation',
+         'this row links to one that does not link back'
     FROM transactions a
     LEFT JOIN transactions b ON b.id = a.linked_transfer_id
    WHERE a.linked_transfer_id IS NOT NULL
@@ -1424,7 +1525,8 @@ UNION ALL
 UNION ALL
   -- T-2: the two sides of a transfer are exactly opposite and non-zero
   --      (20260716100000:108-111).
-  SELECT 'transfer_amounts_not_opposite', a.id, 'linked transfer sides are not exact opposites'
+  SELECT 'transfer_amounts_not_opposite', 'transaction', a.id, 'violation',
+         'linked transfer sides are not exact opposites'
     FROM transactions a
     JOIN transactions b ON b.id = a.linked_transfer_id
    WHERE a.linked_transfer_split_id IS NULL
@@ -1432,7 +1534,8 @@ UNION ALL
 
 UNION ALL
   -- T-3: a transfer's two sides are in different accounts.
-  SELECT 'transfer_same_account', a.id, 'both sides of this transfer are in one account'
+  SELECT 'transfer_same_account', 'transaction', a.id, 'violation',
+         'both sides of this transfer are in one account'
     FROM transactions a
     JOIN transactions b ON b.id = a.linked_transfer_id
    WHERE a.account_id = b.account_id
@@ -1440,14 +1543,16 @@ UNION ALL
 UNION ALL
   -- T-4: a split-line leg is opposite to the LINE, never the parent
   --      (20260720120000:15-17).
-  SELECT 'split_leg_amounts_not_opposite', s.id, 'a split leg and its counterpart are not exact opposites'
+  SELECT 'split_leg_amounts_not_opposite', 'split_line', s.id, 'violation',
+         'a split leg and its counterpart are not exact opposites'
     FROM transaction_splits s
     JOIN transactions c ON c.id = s.linked_transfer_id
    WHERE s.amount_minor = 0 OR c.amount_minor <> -s.amount_minor
 
 UNION ALL
   -- T-5: a counterpart that names a split line must be named back by it.
-  SELECT 'split_leg_link_not_mutual', c.id, 'this row names a split line that does not name it back'
+  SELECT 'split_leg_link_not_mutual', 'transaction', c.id, 'violation',
+         'this row names a split line that does not name it back'
     FROM transactions c
     LEFT JOIN transaction_splits s ON s.id = c.linked_transfer_split_id
    WHERE c.linked_transfer_split_id IS NOT NULL
@@ -1457,7 +1562,8 @@ UNION ALL
   -- R-3: transactions.category and transaction_splits.category are TEXT with
   --      no FK, in BOTH engines. Danglers are reported, not rejected — the
   --      legacy 'transfer-in'/'transfer-out' sentinels are legal values.
-  SELECT 'dangling_category_ref', t.id, 'category text names no category of this user'
+  SELECT 'dangling_category_ref', 'transaction', t.id, 'violation',
+         'category text names no category of this user'
     FROM transactions t
    WHERE t.category IS NOT NULL
      AND trim(t.category) <> ''
@@ -1465,25 +1571,29 @@ UNION ALL
      AND NOT EXISTS (SELECT 1 FROM categories c WHERE c.id = t.category AND c.user_id = t.user_id)
 
 UNION ALL
-  SELECT 'dangling_split_category_ref', s.id, 'split line category names no category of this user'
+  SELECT 'dangling_split_category_ref', 'split_line', s.id, 'violation',
+         'split line category names no category of this user'
     FROM transaction_splits s
    WHERE NOT EXISTS (SELECT 1 FROM categories c WHERE c.id = s.category AND c.user_id = s.user_id)
 
 UNION ALL
   -- C-3: every account has exactly one transfer category
   --      (20260708140000:57-78).
-  SELECT 'account_missing_transfer_category', a.id, 'this account has no To/From category'
+  SELECT 'account_missing_transfer_category', 'account', a.id, 'violation',
+         'this account has no To/From category'
     FROM accounts a
    WHERE NOT EXISTS (SELECT 1 FROM categories c WHERE c.account_id = a.id AND c.is_transfer_category = 1)
 
 UNION ALL
-  SELECT 'account_multiple_transfer_categories', a.id, 'this account has more than one To/From category'
+  SELECT 'account_multiple_transfer_categories', 'account', a.id, 'violation',
+         'this account has more than one To/From category'
     FROM accounts a
    WHERE (SELECT COUNT(*) FROM categories c WHERE c.account_id = a.id AND c.is_transfer_category = 1) > 1
 
 UNION ALL
   -- A-1: the audit chain is dense and links.
-  SELECT 'audit_chain_broken', l.id, 'this audit row does not chain to its predecessor'
+  SELECT 'audit_chain_broken', 'audit_entry', l.id, 'violation',
+         'this audit row does not chain to its predecessor'
     FROM financial_audit_log l
     LEFT JOIN financial_audit_log p ON p.seq = l.seq - 1
    WHERE (l.seq > (SELECT MIN(seq) FROM financial_audit_log))
@@ -1492,11 +1602,64 @@ UNION ALL
 UNION ALL
   -- I-1: an account nested under another must not itself be a parent
   --      (one level only — the (Cash) pairing, 20260722090000).
-  SELECT 'account_nesting_too_deep', a.id, 'a nested account is itself a parent'
+  SELECT 'account_nesting_too_deep', 'account', a.id, 'violation',
+         'a nested account is itself a parent'
     FROM accounts a
    WHERE a.parent_account_id IS NOT NULL
-     AND EXISTS (SELECT 1 FROM accounts c WHERE c.parent_account_id = a.id);
+     AND EXISTS (SELECT 1 FROM accounts c WHERE c.parent_account_id = a.id)
 
--- The one-line answer.
+-- ── The two INGEST checks (PHASE1-PLAN §2.5) ────────────────────────────────
+--
+-- Everything above catches a ledger that contradicts itself. Neither of the two
+-- commonest ingest disasters does that: a card statement imported with inverted
+-- signs, and an <AVAILBAL> stored where a <LEDGERBAL> belongs, both produce data
+-- that is internally consistent and entirely wrong. MEASURED before these were
+-- written (`scratchpad/local-core/probe-integrity1.mjs`, cases 16 and 17): both
+-- shapes were planted and the fifteen checks above reported NOTHING.
+--
+-- They are HEURISTICS and are labelled as such: a credit card genuinely can be
+-- in credit, and a bank figure genuinely can disagree with an unreconciled
+-- ledger. They report `severity = 'warning'`, v_integrity_ok ignores warnings,
+-- and the app is expected to phrase them as a question rather than a verdict.
+--
+-- Both are narrowed to `type = 'credit'` deliberately. That is the whole card
+-- population — accounts_type_check has no 'card' — and it is the only kind where
+-- "positive means you are owed money" is the wrong reading. A loan or a mortgage
+-- carries the same sign convention but is never fed by a statement importer
+-- making this decision per row, so widening them would buy false positives
+-- without buying a catch.
+
+UNION ALL
+  -- TS-F1/TS-F2. A card's stored balance is -current; a positive one means
+  -- either a genuine credit balance or an importer that got the sign backwards.
+  -- The provenance test is what makes it worth reporting: a hand-typed positive
+  -- balance is a decision, an imported one is a guess.
+  SELECT 'card_account_sign_implausible', 'account', a.id, 'warning',
+         'a credit account is in credit and its rows were imported — the statement''s signs may be inverted'
+    FROM accounts a
+   WHERE a.type = 'credit'
+     AND a.balance_minor > 0
+     AND EXISTS (SELECT 1 FROM transactions t
+                  WHERE t.account_id = a.id
+                    AND (t.import_source IS NOT NULL OR t.external_transaction_id IS NOT NULL))
+
+UNION ALL
+  -- TS-I1/TS-I2. <AVAILBAL> is remaining credit: positive, and larger than the
+  -- balance it was mistaken for. The predicate is PHASE1-PLAN §2.5's, spelled
+  -- without sign(): SQLite's sign() needs SQLITE_ENABLE_MATH_FUNCTIONS, and
+  -- `bank_balance_minor * balance_minor < 0` would overflow int64 at the bounded
+  -- extremes and silently become a float. Two comparisons say the same thing
+  -- exactly.
+  SELECT 'bank_balance_implausible', 'account', a.id, 'warning',
+         'the bank figure disagrees with the ledger by more than the ledger itself — an available balance may have been stored as a bank balance'
+    FROM accounts a
+   WHERE a.type = 'credit'
+     AND a.bank_balance_minor IS NOT NULL
+     AND ((a.bank_balance_minor > 0 AND a.balance_minor < 0)
+       OR (a.bank_balance_minor < 0 AND a.balance_minor > 0))
+     AND abs(a.bank_balance_minor - a.balance_minor) > abs(a.balance_minor);
+
+-- The one-line answer. WARNINGS ARE NOT COUNTED: the two ingest checks are
+-- heuristics, and a file that trips one is not thereby corrupt.
 CREATE VIEW v_integrity_ok AS
-  SELECT (SELECT COUNT(*) FROM v_integrity_violations) = 0 AS ok;
+  SELECT (SELECT COUNT(*) FROM v_integrity_violations WHERE severity = 'violation') = 0 AS ok;

--- a/scripts/local-sqlite/specs/r5-deleting-an-account-unlinks-the-split-leg-that-pointed-at-it.spec.mjs
+++ b/scripts/local-sqlite/specs/r5-deleting-an-account-unlinks-the-split-leg-that-pointed-at-it.spec.mjs
@@ -1,0 +1,60 @@
+import { splitWithTransferLeg } from './_setups.mjs';
+
+export default {
+  invariant: 'R-5',
+  title: 'deleting an account unlinks the split line that pointed at it — with the leg guard held',
+  design:
+    'PHASE1-PLAN addendum §A (the R-5 leg guard) plus schema.sql\'s trg_unnest_account_references. ' +
+    'The cloud reaches the same end state through transaction_splits_transfer_account_id_user_fkey ' +
+    'ON DELETE SET NULL (20260808170000:470-474) and the split key\'s own SET NULL when the ' +
+    'counterpart cascades',
+  consequence:
+    'a split line is the shape 86 of the owner\'s 364 imported split lines have; if deleting an ' +
+    'account cannot pass one, neither the wipe nor an ordinary account deletion can run on a real file',
+  parity: 'match',
+
+  sqlite: {
+    setup: splitWithTransferLeg.sqlite,
+    // R-5: SQLite applies the clear as an UPDATE of the line, and
+    // trg_protect_linked_leg watches every column being cleared. The guard is
+    // the CALLER's to hold — the same block delete_transaction holds — and this
+    // spec holds it because the wipe verb does.
+    action: `
+      INSERT OR IGNORE INTO _rpc_guard VALUES ('leg');
+      DELETE FROM accounts WHERE id = 'a0000000-0000-0000-0000-000000000002';
+      DELETE FROM _rpc_guard WHERE flag = 'leg';`,
+    expect: { outcome: 'accepted' },
+  },
+
+  postgres: {
+    setup: splitWithTransferLeg.postgres,
+    action: `DELETE FROM public.accounts WHERE id = 'a0000000-0000-0000-0000-000000000002';`,
+    expect: { outcome: 'accepted' },
+  },
+
+  verify: [
+    {
+      // Both lines survive: they belong to a transaction in the OTHER account.
+      name: 'lines_survive',
+      sqlite: `SELECT COUNT(*) FROM transaction_splits`,
+      postgres: `SELECT COUNT(*) FROM public.transaction_splits`,
+      expect: '2',
+    },
+    {
+      name: 'leg_is_unlinked',
+      sqlite: `SELECT COALESCE(transfer_account_id, 'CLEARED') || '/' || COALESCE(linked_transfer_id, 'CLEARED')
+                 FROM transaction_splits WHERE id = '50000000-0000-0000-0000-000000000001'`,
+      postgres: `SELECT COALESCE(transfer_account_id::text, 'CLEARED') || '/' || COALESCE(linked_transfer_id::text, 'CLEARED')
+                   FROM public.transaction_splits WHERE id = '50000000-0000-0000-0000-000000000001'`,
+      expect: 'CLEARED/CLEARED',
+    },
+    {
+      // The counterpart lived in the deleted account, so it goes (R-1). The
+      // parent survives with its lines; nothing points at a ghost.
+      name: 'counterpart_is_gone',
+      sqlite: `SELECT COUNT(*) FROM transactions WHERE id = '70000000-0000-0000-0000-000000000009'`,
+      postgres: `SELECT COUNT(*) FROM public.transactions WHERE id = '70000000-0000-0000-0000-000000000009'`,
+      expect: '0',
+    },
+  ],
+};

--- a/scripts/local-sqlite/specs/t8-deleting-an-account-unlinks-the-transfer-that-pointed-at-it.spec.mjs
+++ b/scripts/local-sqlite/specs/t8-deleting-an-account-unlinks-the-transfer-that-pointed-at-it.spec.mjs
@@ -1,0 +1,50 @@
+import { transferPair } from './_setups.mjs';
+
+export default {
+  invariant: 'T-8',
+  title: 'deleting an account leaves the transfer that pointed at it unlinked, not refused',
+  design:
+    'DESIGN.md §1.3 T-8; the local half is schema.sql\'s trg_unnest_account_references, which exists ' +
+    'only because SQLite has no ON DELETE SET NULL (column). Postgres reaches the same end state ' +
+    'through two independent key actions (20260808170000:456-460 nulls the target, the transactions ' +
+    'key nulls the link when the counterpart cascades)',
+  consequence:
+    'without the link clear, "delete everything" is refused outright on any file holding one linked ' +
+    'transfer — the wipe stops on a CHECK about transfer targets while the user is trying to erase ' +
+    'the whole ledger, and nothing in the UI can get past it',
+  parity: 'match',
+
+  // Deleting Rainy day takes the +15.00 row that lives in it (R-1) and leaves
+  // the −15.00 row in Everyday behind, pointing at neither.
+  sqlite: {
+    setup: transferPair.sqlite,
+    action: `DELETE FROM accounts WHERE id = 'a0000000-0000-0000-0000-000000000002';`,
+    expect: { outcome: 'accepted' },
+  },
+
+  postgres: {
+    setup: transferPair.postgres,
+    action: `DELETE FROM public.accounts WHERE id = 'a0000000-0000-0000-0000-000000000002';`,
+    expect: { outcome: 'accepted' },
+  },
+
+  verify: [
+    {
+      name: 'survivor_count',
+      sqlite: `SELECT COUNT(*) FROM transactions`,
+      postgres: `SELECT COUNT(*) FROM public.transactions`,
+      expect: '2',
+    },
+    {
+      // Both columns, in one string, because the whole finding is that they
+      // must be cleared TOGETHER: a row with the link kept and the target
+      // nulled is the state transactions_linked_has_target refuses.
+      name: 'survivor_is_unlinked',
+      sqlite: `SELECT COALESCE(transfer_account_id, 'CLEARED') || '/' || COALESCE(linked_transfer_id, 'CLEARED')
+                 FROM transactions WHERE id = '70000000-0000-0000-0000-000000000004'`,
+      postgres: `SELECT COALESCE(transfer_account_id::text, 'CLEARED') || '/' || COALESCE(linked_transfer_id::text, 'CLEARED')
+                   FROM public.transactions WHERE id = '70000000-0000-0000-0000-000000000004'`,
+      expect: 'CLEARED/CLEARED',
+    },
+  ],
+};

--- a/scripts/local-sqlite/verb-specs/_shared.mjs
+++ b/scripts/local-sqlite/verb-specs/_shared.mjs
@@ -732,6 +732,12 @@ export function balanceOf(accountId, expect) {
  * Asserted on EVERY verb spec, including the refusals, because B-1 is the
  * invariant the whole application rests on and neither schema enforces it. A
  * verb that refuses must leave it holding just as much as one that accepts.
+ *
+ * ONE FAMILY IS EXEMPT, and it is the family that proves the rule: the
+ * `integrity-*` specs plant violations on purpose, and one of them plants a
+ * broken B-1. Asserting B-1 there would be asserting that the fixture failed to
+ * do its job. They assert `v_integrity_ok` instead, which is the same question
+ * asked by the thing under test.
  */
 export function balanceIdentityHolds(accountId) {
   return {
@@ -1354,6 +1360,537 @@ export function storedAmount(transactionId, expect) {
         FROM transactions WHERE id = '${transactionId}'), 'ABSENT')`,
     postgres: `SELECT COALESCE((SELECT amount::text FROM public.transactions
         WHERE id = '${transactionId}'), 'ABSENT')`,
+    expect,
+  };
+}
+
+// ── The restore family's fixtures ──────────────────────────────────────────
+//
+// A restore refuses unless the login is empty (X-1), and the base fixture is
+// not, so almost every spec in this family clears it first.
+
+/**
+ * The login, emptied — by hand, not by the wipe verb.
+ *
+ * Deliberately plain DELETEs on both engines rather than a call to
+ * `wipe_user_financial_data`, for two reasons. The wipe WRITES AUDIT ROWS, and a
+ * restore spec that then counts the audit log would be counting the setup; and
+ * the SQLite side has no way to call a Rust verb from a setup string, so the two
+ * engines would be cleared by different code doing different amounts of work.
+ *
+ * Accounts first is X-3 and it is not optional on either engine: deleting the
+ * categories while their accounts stand raises `transfer_category_protected`.
+ */
+export const wiped = {
+  sqlite: `
+    DELETE FROM accounts     WHERE user_id = '${USER}';
+    DELETE FROM transactions WHERE user_id = '${USER}';
+    DELETE FROM categories   WHERE user_id = '${USER}';`,
+  postgres: `
+    DELETE FROM public.accounts     WHERE user_id = '${USER}';
+    DELETE FROM public.transactions WHERE user_id = '${USER}';
+    DELETE FROM public.categories   WHERE user_id = '${USER}';`,
+};
+
+/** Ids for the rows a backup file puts back. Nothing in the fixture uses them. */
+export const RESTORED_ACCOUNT = 'a0000000-0000-0000-0000-0000000000f1';
+export const RESTORED_SAVINGS = 'a0000000-0000-0000-0000-0000000000f2';
+export const RESTORED_ROW = '70000000-0000-0000-0000-0000000000f1';
+export const RESTORED_OTHER = '70000000-0000-0000-0000-0000000000f2';
+export const RESTORED_TRANSFER_ROOT = 'c0000000-0000-0000-0000-0000000000f8';
+export const RESTORED_TO_FROM = 'c0000000-0000-0000-0000-0000000000f9';
+
+/**
+ * A whole `accounts` row, as a backup file holds one.
+ *
+ * "Whole" is the contract, not a courtesy: `jsonb_populate_recordset` does not
+ * apply column defaults, so the cloud REFUSES a row missing any NOT NULL key —
+ * MEASURED, on `low_balance_alert_enabled`, which has a default and is refused
+ * anyway. Every NOT NULL column of `public.accounts` is therefore present here.
+ *
+ * `user_id` is deliberately the STRANGER's: X-6 says every restored row is
+ * re-owned to the caller, and a fixture that already had the right owner could
+ * not tell a re-owning from a copy.
+ *
+ * Money is a STRING. A JSON number is an IEEE-754 double by the time any parser
+ * has read it, and a spec for a ledger should not contain one.
+ */
+export function backupAccount(overrides = {}) {
+  return {
+    id: RESTORED_ACCOUNT,
+    user_id: STRANGER,
+    name: 'Everyday',
+    type: 'checking',
+    currency: 'GBP',
+    balance: '-25.00',
+    initial_balance: '0.00',
+    is_active: true,
+    low_balance_alert_enabled: false,
+    metadata: {},
+    created_at: '2019-01-01T00:00:00+00:00',
+    updated_at: '2019-01-01T00:00:00+00:00',
+    ...overrides,
+  };
+}
+
+/** A whole `transactions` row, same contract. */
+export function backupTransaction(overrides = {}) {
+  return {
+    id: RESTORED_ROW,
+    user_id: STRANGER,
+    account_id: RESTORED_ACCOUNT,
+    description: 'Corner shop',
+    amount: '-25.00',
+    type: 'expense',
+    date: '2019-05-04',
+    is_cleared: false,
+    is_split: false,
+    archived: false,
+    category_confirmed: true,
+    is_recurring: false,
+    metadata: {},
+    created_at: '2019-05-04T00:00:00+00:00',
+    updated_at: '2019-05-04T00:00:00+00:00',
+    ...overrides,
+  };
+}
+
+/** A whole `categories` row, same contract. */
+export function backupCategory(overrides = {}) {
+  return {
+    id: RESTORED_TRANSFER_ROOT,
+    user_id: STRANGER,
+    name: 'Transfer',
+    type: 'both',
+    level: 'type',
+    is_system: false,
+    is_transfer_category: false,
+    is_revaluation_category: false,
+    is_unassigned_bucket: false,
+    is_active: true,
+    created_at: '2019-01-01T00:00:00+00:00',
+    updated_at: '2019-01-01T00:00:00+00:00',
+    ...overrides,
+  };
+}
+
+/** One chunk of a restore, in the shape both engines are handed. */
+export function chunk(entity, rows) {
+  return { entity, rows };
+}
+
+/** How many rows one table holds for the fixture's login. */
+export function rowCount(name, table, expect, where = '') {
+  const clause = where ? ` AND ${where}` : '';
+  return {
+    name,
+    sqlite: `SELECT COUNT(*) FROM ${table} WHERE user_id = '${USER}'${clause}`,
+    postgres: `SELECT COUNT(*) FROM public.${table} WHERE user_id = '${USER}'${clause}`,
+    expect,
+  };
+}
+
+/** One restored account's stored balance and initial balance, as decimals. */
+export function storedBalances(accountId, expect) {
+  const decimal = (column) =>
+    `(CASE WHEN ${column} < 0 THEN '-' ELSE '' END || CAST(abs(${column}) / 100 AS TEXT)
+      || '.' || substr('0' || CAST(abs(${column}) % 100 AS TEXT), -2, 2))`;
+  return {
+    name: `stored_balances_${accountId.slice(-4)}`,
+    sqlite: `SELECT COALESCE((SELECT ${decimal('balance_minor')} || '/' || ${decimal('initial_balance_minor')}
+              FROM accounts WHERE id = '${accountId}'), 'ABSENT')`,
+    postgres: `SELECT COALESCE((SELECT balance::text || '/' || initial_balance::text
+                FROM public.accounts WHERE id = '${accountId}'), 'ABSENT')`,
+    expect,
+  };
+}
+
+/** The day one row's updated_at falls on — X-4's whole subject. */
+export function updatedDay(table, id, expect) {
+  return {
+    name: `updated_day_${id.slice(-4)}`,
+    sqlite: `SELECT COALESCE((SELECT substr(updated_at, 1, 10) FROM ${table} WHERE id = '${id}'), 'ABSENT')`,
+    postgres: `SELECT COALESCE((SELECT to_char(updated_at AT TIME ZONE 'UTC', 'YYYY-MM-DD')
+                FROM public.${table} WHERE id = '${id}'), 'ABSENT')`,
+    expect,
+  };
+}
+
+/**
+ * An emptied login with ONE account back in it, planted directly.
+ *
+ * The restore verb takes one chunk per differential spec (the cloud RPC takes
+ * one entity per call), so a spec about restoring TRANSACTIONS needs their
+ * account to be there already. Planted rather than restored, so that the spec
+ * asserts one thing.
+ *
+ * The account is deliberately at −25.00 with no transactions against it, which is
+ * the state a real restore reaches between the accounts chunk and the
+ * transactions chunk: B-1 does not hold in the middle of a restore and is not
+ * expected to.
+ */
+export const wipedWithOneAccount = {
+  sqlite: `${wiped.sqlite}
+    INSERT INTO accounts (id, user_id, name, type, balance_minor, initial_balance_minor, updated_at)
+      VALUES ('${RESTORED_ACCOUNT}', '${USER}', 'Everyday', 'checking', -2500, 0, '2019-01-01T00:00:00.000Z');`,
+  postgres: `${wiped.postgres}
+    INSERT INTO public.accounts (id, user_id, name, type, balance, initial_balance, updated_at)
+      VALUES ('${RESTORED_ACCOUNT}', '${USER}', 'Everyday', 'checking', -25.00, 0.00, '2019-01-01T00:00:00Z');`,
+};
+
+// ── The prune's fixtures ───────────────────────────────────────────────────
+//
+// `delete_unused_categories` starts from exactly what `merge_categories` starts
+// from: an ordinary expense leaf under Outgoings that nothing refers to. Rather
+// than mint a second identical pair, the prune specs name the merge pair's ids
+// through these aliases, so a reader of either family sees a name that means
+// something in it.
+
+/** The leaf a prune is asked to remove. */
+export const PRUNABLE = MERGE_SOURCE;
+/** A second one, for the batch cases. */
+export const SECOND_PRUNABLE = MERGE_TARGET;
+/** Both of them. */
+export const prunablePair = mergeablePair;
+
+/**
+ * Corner shop filed under [`PRUNABLE`] through the UUID column ALONE.
+ *
+ * The measured hole in the prune's transaction check: it reads
+ * `t.category = c.id::text` and nothing else, so a row filed only through
+ * `category_id` does not save its category and has the column nulled out from
+ * under it by the foreign key (`probe-prune1.sh`,
+ * `p-used-by-transaction-uuid-only`). The budget check reads BOTH columns; this
+ * one does not, and the asymmetry is the cloud's own.
+ */
+export const filedUnderThePrunableByUuidAlone = {
+  sqlite: `
+    UPDATE transactions SET category = NULL, category_id = '${PRUNABLE}'
+     WHERE id = '${CORNER_SHOP}';`,
+  postgres: `
+    UPDATE public.transactions SET category = NULL, category_id = '${PRUNABLE}'::uuid
+     WHERE id = '${CORNER_SHOP}';`,
+};
+
+/** A budget naming [`PRUNABLE`] through the uuid column alone — which DOES save it. */
+export const budgetOnThePrunableByUuidAlone = {
+  sqlite: `
+    INSERT INTO budgets (id, user_id, name, amount_minor, period, category_id, start_date)
+      VALUES ('${BUDGET}', '${USER}', 'Food', 10000, 'monthly', '${PRUNABLE}', '2024-01-01');`,
+  postgres: `
+    INSERT INTO public.budgets (id, user_id, name, amount, period, category_id, start_date)
+      VALUES ('${BUDGET}', '${USER}', 'Food', 100.00, 'monthly', '${PRUNABLE}'::uuid, '2024-01-01');`,
+};
+
+/** A leaf under [`PRUNABLE`], so the batch has a parent and a child in it. */
+export const PRUNABLE_CHILD = 'c0000000-0000-0000-0000-0000000000c1';
+/** And one under THAT, for the three-generation case. */
+export const PRUNABLE_GRANDCHILD = 'c0000000-0000-0000-0000-0000000000c2';
+
+export const prunableChild = childOf(PRUNABLE, PRUNABLE_CHILD);
+export const prunableGrandchild = childOf(PRUNABLE_CHILD, PRUNABLE_GRANDCHILD);
+
+/**
+ * Move an account's To/From category UNDER a prunable one.
+ *
+ * The only route to the one refusal this verb can produce, and it is a refusal
+ * the FILE raises rather than the function: naming both the parent and the
+ * To/From child means the child no longer keeps its parent alive, the parent is
+ * deleted, and `parent_id ON DELETE CASCADE` walks the protected row into C-5's
+ * trigger. The category's id is minted by a trigger on both engines, so it is
+ * reached through its ACCOUNT here and named through a sub-SELECT in the payload
+ * nowhere — which is why the spec that uses this also needs
+ * [`namedTransferCategories`] to give it an id a payload can carry.
+ */
+export function transferCategoryUnder(parentId, accountId) {
+  return {
+    sqlite: `UPDATE categories SET parent_id = '${parentId}'
+              WHERE account_id = '${accountId}' AND is_transfer_category = 1;`,
+    postgres: `UPDATE public.categories SET parent_id = '${parentId}'
+                WHERE account_id = '${accountId}' AND is_transfer_category;`,
+  };
+}
+
+/** Is this category still in the file? `GONE` when the prune took it. */
+export function categoryPresent(categoryId, expect) {
+  return {
+    name: `category_present_${categoryId.slice(-4)}`,
+    sqlite: `SELECT CASE WHEN EXISTS (SELECT 1 FROM categories WHERE id = '${categoryId}')
+                    THEN 'HERE' ELSE 'GONE' END`,
+    postgres: `SELECT CASE WHEN EXISTS (SELECT 1 FROM public.categories WHERE id = '${categoryId}')
+                      THEN 'HERE' ELSE 'GONE' END`,
+    expect,
+  };
+}
+
+/** How many To/From categories the file holds, whoever they belong to. */
+export function transferCategoryCount(expect) {
+  return {
+    name: 'transfer_categories',
+    sqlite: 'SELECT COUNT(*) FROM categories WHERE is_transfer_category = 1',
+    postgres: 'SELECT COUNT(*) FROM public.categories WHERE is_transfer_category',
+    expect,
+  };
+}
+
+// ── verify_integrity's fixtures: seventeen ways to break a file ────────────
+//
+// Every other fixture in this file builds a state the ledger is happy with.
+// These build states it is NOT, because a check nobody can plant is a check
+// nobody can prove. They are SQLITE-ONLY — `verify_integrity` has no cloud
+// counterpart at all, so there is no second engine to plant anything on, and
+// the specs that use them declare `parity: 'not-comparable'`.
+//
+// Each plant was measured before it was written
+// (`scratchpad/local-core/probe-integrity1.mjs`): it must fire the check it is
+// for, and every other check it fires is named in the spec that uses it.
+
+/** A card, for the two ingest checks. `credit` is the schema's only card type. */
+export const CARD = 'a0000000-0000-0000-0000-0000000000ca';
+/** One row against it, provenance set or not depending on the plant. */
+export const IMPORTED_ROW = '70000000-0000-0000-0000-0000000000f0';
+/** The Transfer type root the base fixture seeds — a second To/From hangs here. */
+export const TRANSFER_ROOT = 'c0000000-0000-0000-0000-000000000001';
+/** Two audit rows, planted to break the chain between them. */
+export const AUDIT_FIRST = 'e0000000-0000-0000-0000-000000000001';
+export const AUDIT_SECOND = 'e0000000-0000-0000-0000-000000000002';
+
+/** B-1, broken by one penny — the smallest lie a balance can tell. */
+export const aBalanceThatIsOneOut = {
+  sqlite: `UPDATE accounts SET balance_minor = balance_minor + 1 WHERE id = '${EVERYDAY}';`,
+};
+
+/** S-1: two lines that add up to less than their parent. */
+export const aSplitThatDoesNotSum = {
+  sqlite: `
+    INSERT INTO _rpc_guard VALUES ('split');
+    UPDATE transactions SET is_split = 1, category = '' WHERE id = '${CORNER_SHOP}';
+    INSERT INTO transaction_splits (id, transaction_id, user_id, category, amount_minor, sort_order) VALUES
+      ('${LEG_LINE}',   '${CORNER_SHOP}', '${USER}', '${WEEKLY_SHOP}', -1000, 0),
+      ('${PLAIN_LINE}', '${CORNER_SHOP}', '${USER}', '${WEEKLY_SHOP}', -1000, 1);
+    DELETE FROM _rpc_guard;`,
+};
+
+/**
+ * S-2: a split with ONE line, and that line summing exactly to the parent — so
+ * `split_min_lines` fires alone and `split_sum` has nothing to say.
+ */
+export const aSplitWithOneLine = {
+  sqlite: `
+    INSERT INTO _rpc_guard VALUES ('split');
+    UPDATE transactions SET is_split = 1, category = '' WHERE id = '${CORNER_SHOP}';
+    INSERT INTO transaction_splits (id, transaction_id, user_id, category, amount_minor, sort_order)
+      VALUES ('${LEG_LINE}', '${CORNER_SHOP}', '${USER}', '${WEEKLY_SHOP}', -2500, 0);
+    DELETE FROM _rpc_guard;`,
+};
+
+/** S-3: a line hanging off a row that is not split at all. */
+export const linesOnARowThatIsNotSplit = {
+  sqlite: `
+    INSERT INTO transaction_splits (id, transaction_id, user_id, category, amount_minor, sort_order)
+      VALUES ('${LEG_LINE}', '${CORNER_SHOP}', '${USER}', '${WEEKLY_SHOP}', -2500, 0);`,
+};
+
+/** T-1: one side names the other and is not named back. Amounts opposite, so T-2 stays quiet. */
+export const aLinkNobodyReturns = {
+  sqlite: `
+    INSERT INTO transactions (id, user_id, account_id, description, amount_minor, type, date,
+                              transfer_account_id) VALUES
+      ('${OTHER_LEG}', '${USER}', '${EVERYDAY}',  'To savings',    -1500, 'transfer', '2024-04-01', '${RAINY_DAY}'),
+      ('${THIS_LEG}',  '${USER}', '${RAINY_DAY}', 'From everyday',  1500, 'transfer', '2024-04-01', '${EVERYDAY}');
+    UPDATE accounts SET balance_minor = balance_minor - 1500 WHERE id = '${EVERYDAY}';
+    UPDATE accounts SET balance_minor = balance_minor + 1500 WHERE id = '${RAINY_DAY}';
+    UPDATE transactions SET linked_transfer_id = '${THIS_LEG}' WHERE id = '${OTHER_LEG}';`,
+};
+
+/**
+ * T-2: a mutual pair whose amounts are not opposites.
+ *
+ * It fires TWICE — once per side — because the check reads every row that names
+ * another and compares. That is the honest answer: both rows are wrong about the
+ * same movement, and a report naming one of them would leave the other looking
+ * innocent.
+ */
+export const linkedSidesThatAreNotOpposites = {
+  sqlite: `
+    INSERT INTO transactions (id, user_id, account_id, description, amount_minor, type, date,
+                              transfer_account_id) VALUES
+      ('${OTHER_LEG}', '${USER}', '${EVERYDAY}',  'To savings',    -1500, 'transfer', '2024-04-01', '${RAINY_DAY}'),
+      ('${THIS_LEG}',  '${USER}', '${RAINY_DAY}', 'From everyday',  2000, 'transfer', '2024-04-01', '${EVERYDAY}');
+    UPDATE accounts SET balance_minor = balance_minor - 1500 WHERE id = '${EVERYDAY}';
+    UPDATE accounts SET balance_minor = balance_minor + 2000 WHERE id = '${RAINY_DAY}';
+    UPDATE transactions SET linked_transfer_id = '${THIS_LEG}'  WHERE id = '${OTHER_LEG}';
+    UPDATE transactions SET linked_transfer_id = '${OTHER_LEG}' WHERE id = '${THIS_LEG}';`,
+};
+
+/**
+ * T-3: both sides of one transfer sitting in the same account.
+ *
+ * `transactions_transfer_two_accounts` forbids a row pointing at its OWN
+ * account, so both rows point at a third one — which is the only shape the
+ * schema will hold, and exactly the shape a bad import produces.
+ */
+export const bothSidesInOneAccount = {
+  sqlite: `
+    INSERT INTO accounts (id, user_id, name, type, balance_minor, initial_balance_minor)
+      VALUES ('${HOLIDAY_FUND}', '${USER}', 'Holiday fund', 'savings', 0, 0);
+    INSERT INTO transactions (id, user_id, account_id, description, amount_minor, type, date,
+                              transfer_account_id) VALUES
+      ('${OTHER_LEG}', '${USER}', '${EVERYDAY}', 'Out', -1000, 'transfer', '2024-04-01', '${HOLIDAY_FUND}'),
+      ('${THIS_LEG}',  '${USER}', '${EVERYDAY}', 'In',   1000, 'transfer', '2024-04-01', '${HOLIDAY_FUND}');
+    UPDATE transactions SET linked_transfer_id = '${THIS_LEG}'  WHERE id = '${OTHER_LEG}';
+    UPDATE transactions SET linked_transfer_id = '${OTHER_LEG}' WHERE id = '${THIS_LEG}';`,
+};
+
+/** T-4: a leg and its counterpart that do not cancel — compared against the LINE. */
+export const aLegAndACounterpartThatDisagree = {
+  sqlite: `
+    INSERT INTO _rpc_guard VALUES ('split');
+    UPDATE transactions SET is_split = 1, category = '' WHERE id = '${CORNER_SHOP}';
+    INSERT INTO transactions (id, user_id, account_id, description, amount_minor, type, date,
+                              transfer_account_id)
+      VALUES ('${LEG_COUNTERPART}', '${USER}', '${RAINY_DAY}', 'Counterpart', 2000, 'transfer',
+              '2024-03-01', '${EVERYDAY}');
+    UPDATE accounts SET balance_minor = balance_minor + 2000 WHERE id = '${RAINY_DAY}';
+    INSERT INTO transaction_splits (id, transaction_id, user_id, category, amount_minor, sort_order,
+                                    transfer_account_id, linked_transfer_id)
+      VALUES ('${LEG_LINE}', '${CORNER_SHOP}', '${USER}', '${WEEKLY_SHOP}', -1500, 0,
+              '${RAINY_DAY}', '${LEG_COUNTERPART}');
+    INSERT INTO transaction_splits (id, transaction_id, user_id, category, amount_minor, sort_order)
+      VALUES ('${PLAIN_LINE}', '${CORNER_SHOP}', '${USER}', '${WEEKLY_SHOP}', -1000, 1);
+    UPDATE transactions SET linked_transfer_split_id = '${LEG_LINE}' WHERE id = '${LEG_COUNTERPART}';
+    DELETE FROM _rpc_guard;`,
+};
+
+/** T-5: a counterpart naming a split line that does not name it back. */
+export const aCounterpartTheLineIgnores = {
+  sqlite: `
+    INSERT INTO _rpc_guard VALUES ('split');
+    UPDATE transactions SET is_split = 1, category = '' WHERE id = '${CORNER_SHOP}';
+    INSERT INTO transactions (id, user_id, account_id, description, amount_minor, type, date,
+                              transfer_account_id)
+      VALUES ('${LEG_COUNTERPART}', '${USER}', '${RAINY_DAY}', 'Counterpart', 1500, 'transfer',
+              '2024-03-01', '${EVERYDAY}');
+    UPDATE accounts SET balance_minor = balance_minor + 1500 WHERE id = '${RAINY_DAY}';
+    INSERT INTO transaction_splits (id, transaction_id, user_id, category, amount_minor, sort_order) VALUES
+      ('${LEG_LINE}',   '${CORNER_SHOP}', '${USER}', '${WEEKLY_SHOP}', -1500, 0),
+      ('${PLAIN_LINE}', '${CORNER_SHOP}', '${USER}', '${WEEKLY_SHOP}', -1000, 1);
+    UPDATE transactions SET linked_transfer_split_id = '${LEG_LINE}' WHERE id = '${LEG_COUNTERPART}';
+    DELETE FROM _rpc_guard;`,
+};
+
+/** The id no category in this file has. */
+export const NO_SUCH_CATEGORY = 'c0000000-0000-0000-0000-0000000000ff';
+
+/** R-3: a transaction filed under a category id nothing answers to. */
+export const aTransactionFiledUnderNothing = {
+  sqlite: `UPDATE transactions SET category = '${NO_SUCH_CATEGORY}' WHERE id = '${CORNER_SHOP}';`,
+};
+
+/** R-3, the legacy sentinel — a legal value, and the control for the check above. */
+export const aTransactionFiledUnderTheSentinel = {
+  sqlite: `UPDATE transactions SET category = 'transfer-out' WHERE id = '${CORNER_SHOP}';`,
+};
+
+/** R-3 for a split LINE, whose category has no sentinel exemption at all. */
+export const aSplitLineFiledUnderNothing = {
+  sqlite: `
+    INSERT INTO _rpc_guard VALUES ('split');
+    UPDATE transactions SET is_split = 1, category = '' WHERE id = '${CORNER_SHOP}';
+    INSERT INTO transaction_splits (id, transaction_id, user_id, category, amount_minor, sort_order) VALUES
+      ('${LEG_LINE}',   '${CORNER_SHOP}', '${USER}', '${NO_SUCH_CATEGORY}', -1500, 0),
+      ('${PLAIN_LINE}', '${CORNER_SHOP}', '${USER}', '${WEEKLY_SHOP}',      -1000, 1);
+    DELETE FROM _rpc_guard;`,
+};
+
+/** C-3, the second one: a second To/From category for an account that has one. */
+export const aSecondToFromCategory = {
+  sqlite: `
+    INSERT INTO categories (id, user_id, name, type, level, parent_id, is_transfer_category, account_id)
+      VALUES ('${NO_SUCH_CATEGORY}', '${USER}', 'To/From Everyday (again)', 'both', 'detail',
+              '${TRANSFER_ROOT}', 1, '${EVERYDAY}');`,
+};
+
+/** A-1: two audit rows where the second does not carry the first's hash. */
+export const anAuditChainThatDoesNotChain = {
+  sqlite: `
+    INSERT INTO financial_audit_log (id, user_id, entity, entity_id, action, after_data, seq, prev_hash, row_hash)
+      VALUES ('${AUDIT_FIRST}', '${USER}', 'transaction', '${CORNER_SHOP}', 'create', '{}', 1, NULL, 'aaaa');
+    INSERT INTO financial_audit_log (id, user_id, entity, entity_id, action, after_data, seq, prev_hash, row_hash)
+      VALUES ('${AUDIT_SECOND}', '${USER}', 'transaction', '${CORNER_SHOP}', 'create', '{}', 2, 'not-aaaa', 'bbbb');`,
+};
+
+/** A-1, the other half: a hole where a sequence number should be. */
+export const anAuditChainWithAHoleInIt = {
+  sqlite: `
+    INSERT INTO financial_audit_log (id, user_id, entity, entity_id, action, after_data, seq, prev_hash, row_hash)
+      VALUES ('${AUDIT_FIRST}', '${USER}', 'transaction', '${CORNER_SHOP}', 'create', '{}', 1, NULL, 'aaaa');
+    INSERT INTO financial_audit_log (id, user_id, entity, entity_id, action, after_data, seq, prev_hash, row_hash)
+      VALUES ('${AUDIT_SECOND}', '${USER}', 'transaction', '${CORNER_SHOP}', 'create', '{}', 3, 'aaaa', 'cccc');`,
+};
+
+/** I-1: three accounts in a chain, so the middle one is nested AND a parent. */
+export const anAccountNestedTwoDeep = {
+  sqlite: `
+    INSERT INTO accounts (id, user_id, name, type, balance_minor, initial_balance_minor)
+      VALUES ('${HOLIDAY_FUND}', '${USER}', 'Holiday fund', 'savings', 0, 0);
+    UPDATE accounts SET parent_account_id = '${EVERYDAY}'   WHERE id = '${RAINY_DAY}';
+    UPDATE accounts SET parent_account_id = '${RAINY_DAY}'  WHERE id = '${HOLIDAY_FUND}';`,
+};
+
+/** INGEST-1: a card in credit whose rows came out of a file. */
+export const aCardWhoseSignsWereInverted = {
+  sqlite: `
+    INSERT INTO accounts (id, user_id, name, type, balance_minor, initial_balance_minor)
+      VALUES ('${CARD}', '${USER}', 'Card', 'credit', 5000, 0);
+    INSERT INTO transactions (id, user_id, account_id, description, amount_minor, type, date,
+                              import_source, import_source_id)
+      VALUES ('${IMPORTED_ROW}', '${USER}', '${CARD}', 'Shop', 5000, 'income', '2024-04-01', 'ofx', 'ofx-1');`,
+};
+
+/** INGEST-1's control: the same balance, typed in by a person. */
+export const aCardInCreditNobodyImported = {
+  sqlite: `
+    INSERT INTO accounts (id, user_id, name, type, balance_minor, initial_balance_minor)
+      VALUES ('${CARD}', '${USER}', 'Card', 'credit', 5000, 0);
+    INSERT INTO transactions (id, user_id, account_id, description, amount_minor, type, date)
+      VALUES ('${IMPORTED_ROW}', '${USER}', '${CARD}', 'Refund', 5000, 'income', '2024-04-01');`,
+};
+
+/** INGEST-2: remaining credit stored where the bank's own figure belongs. */
+export const anAvailableBalanceStoredAsABankBalance = {
+  sqlite: `
+    INSERT INTO accounts (id, user_id, name, type, balance_minor, initial_balance_minor,
+                          bank_balance_minor, bank_balance_date)
+      VALUES ('${CARD}', '${USER}', 'Card', 'credit', -1000, 0, 400000, '2024-04-01');
+    INSERT INTO transactions (id, user_id, account_id, description, amount_minor, type, date)
+      VALUES ('${IMPORTED_ROW}', '${USER}', '${CARD}', 'Shop', -1000, 'expense', '2024-04-01');`,
+};
+
+/** INGEST-2's control: a card and a bank that agree. */
+export const aBankBalanceThatAgrees = {
+  sqlite: `
+    INSERT INTO accounts (id, user_id, name, type, balance_minor, initial_balance_minor,
+                          bank_balance_minor, bank_balance_date)
+      VALUES ('${CARD}', '${USER}', 'Card', 'credit', -1000, 0, -1000, '2024-04-01');
+    INSERT INTO transactions (id, user_id, account_id, description, amount_minor, type, date)
+      VALUES ('${IMPORTED_ROW}', '${USER}', '${CARD}', 'Shop', -1000, 'expense', '2024-04-01');`,
+};
+
+/** The file's own one-line verdict, which must agree with the verb's. */
+export function integrityOk(expect) {
+  return {
+    name: 'v_integrity_ok',
+    sqlite: "SELECT CASE WHEN (SELECT ok FROM v_integrity_ok) = 1 THEN 'ok' ELSE 'not-ok' END",
+    expect,
+  };
+}
+
+/** How many rows the view reports, of either severity. */
+export function violationRows(expect) {
+  return {
+    name: 'rows_in_the_view',
+    sqlite: 'SELECT COUNT(*) FROM v_integrity_violations',
     expect,
   };
 }

--- a/scripts/local-sqlite/verb-specs/empty-a-budget-on-its-own-does-not-count.spec.mjs
+++ b/scripts/local-sqlite/verb-specs/empty-a-budget-on-its-own-does-not-count.spec.mjs
@@ -1,0 +1,21 @@
+import { USER, wiped } from './_shared.mjs';
+
+export default {
+  invariant: 'X-1',
+  title: 'a budget on its own leaves the login empty, and that is the design',
+  design: '20260807083000:117-126 names three tables and stops. MEASURED on the reference cluster: a login holding only a budget answers true',
+  consequence: 'widening this to "is there any data" would refuse restores that are perfectly safe — none of the four hazards the precondition kills can be caused by a budget',
+  parity: 'match',
+
+  setup: {
+    sqlite: `${wiped.sqlite}
+      INSERT INTO budgets (id, user_id, name, amount_minor, period, start_date)
+        VALUES ('b0000000-0000-0000-0000-0000000000f1', '${USER}', 'Food', 10000, 'monthly', '2024-01-01');`,
+    postgres: `${wiped.postgres}
+      INSERT INTO public.budgets (id, user_id, name, amount, period, start_date)
+        VALUES ('b0000000-0000-0000-0000-0000000000f1', '${USER}', 'Food', 100.00, 'monthly', '2024-01-01');`,
+  },
+  command: { verb: 'user_financial_data_is_empty', payload: { user_id: USER } },
+  expect: { outcome: 'ok' },
+  result: { empty: true },
+};

--- a/scripts/local-sqlite/verb-specs/empty-a-cleared-login-says-so.spec.mjs
+++ b/scripts/local-sqlite/verb-specs/empty-a-cleared-login-says-so.spec.mjs
@@ -1,0 +1,14 @@
+import { USER, wiped } from './_shared.mjs';
+
+export default {
+  invariant: 'X-1',
+  title: 'a login with nothing in it answers yes',
+  design: '20260807083000:107-130 — the precondition restore_user_chunk enforces, exposed so the UI can say so BEFORE the user picks a file',
+  consequence: 'a user who is told to clear their login and then still cannot restore has been sent round a loop with no exit',
+  parity: 'match',
+
+  setup: wiped,
+  command: { verb: 'user_financial_data_is_empty', payload: { user_id: USER } },
+  expect: { outcome: 'ok' },
+  result: { empty: true },
+};

--- a/scripts/local-sqlite/verb-specs/empty-categories-alone-are-enough-to-say-no.spec.mjs
+++ b/scripts/local-sqlite/verb-specs/empty-categories-alone-are-enough-to-say-no.spec.mjs
@@ -1,0 +1,28 @@
+import { USER } from './_shared.mjs';
+
+export default {
+  invariant: 'X-1',
+  title: 'categories alone are enough to say no, because they are the collision',
+  design: '20260807083000:117-126 asks about accounts, categories and transactions — and categories are the reason: inserting an account mints a To/From category with a FRESH uuid, which the backup already carries under its original one',
+  consequence: 'let a restore run with categories present and every transfer in the file points at a category that no longer exists, or the insert dies on the unique key',
+  parity: 'match',
+
+  // Accounts and transactions gone, the five categories left standing.
+  setup: {
+    sqlite: `DELETE FROM transactions WHERE user_id = '${USER}';
+             DELETE FROM accounts WHERE user_id = '${USER}';`,
+    postgres: `DELETE FROM public.transactions WHERE user_id = '${USER}';
+               DELETE FROM public.accounts WHERE user_id = '${USER}';`,
+  },
+  command: { verb: 'user_financial_data_is_empty', payload: { user_id: USER } },
+  expect: { outcome: 'ok' },
+  result: { empty: false },
+  state: [
+    {
+      name: 'categories_left',
+      sqlite: `SELECT COUNT(*) FROM categories WHERE user_id = '${USER}'`,
+      postgres: `SELECT COUNT(*) FROM public.categories WHERE user_id = '${USER}'`,
+      expect: '3',
+    },
+  ],
+};

--- a/scripts/local-sqlite/verb-specs/empty-the-fixture-holds-data-and-says-no.spec.mjs
+++ b/scripts/local-sqlite/verb-specs/empty-the-fixture-holds-data-and-says-no.spec.mjs
@@ -1,0 +1,13 @@
+import { USER } from './_shared.mjs';
+
+export default {
+  invariant: 'X-1',
+  title: 'a login holding anything at all answers no',
+  design: '20260807083000:107-130',
+  consequence: 'restoring on top of a live login would mix two datasets and silently re-date the history of one of them',
+  parity: 'match',
+
+  command: { verb: 'user_financial_data_is_empty', payload: { user_id: USER } },
+  expect: { outcome: 'ok' },
+  result: { empty: false },
+};

--- a/scripts/local-sqlite/verb-specs/finalize-a-link-naming-a-row-that-is-not-yours-relinks-nothing.spec.mjs
+++ b/scripts/local-sqlite/verb-specs/finalize-a-link-naming-a-row-that-is-not-yours-relinks-nothing.spec.mjs
@@ -1,0 +1,31 @@
+import { USER, CORNER_SHOP, OTHER_LEG } from './_shared.mjs';
+
+export default {
+  invariant: 'X-6',
+  title: 'a link naming a row this login does not have relinks nothing and refuses nothing',
+  design: '20260807083000:419-429 — every UPDATE carries AND user_id = v_owner, and the count comes from ROW_COUNT. MEASURED: 0 relinked, no exception',
+  consequence: 'a bundle can carry a link to a row the restore skipped or the file lost; refusing the whole finalize over one would strand every OTHER link in the same call',
+  parity: 'match',
+
+  command: {
+    verb: 'finalize_user_restore',
+    payload: {
+      links: {
+        transaction_links: [
+          { id: '70000000-0000-0000-0000-0000000000ff', linked_transfer_id: OTHER_LEG },
+        ],
+      },
+      user_id: USER,
+    },
+  },
+  expect: { outcome: 'ok' },
+  result: { accounts_relinked: 0, transactions_relinked: 0 },
+  state: [
+    {
+      name: 'the_fixture_row_is_untouched',
+      sqlite: `SELECT COALESCE(linked_transfer_id, 'NONE') FROM transactions WHERE id = '${CORNER_SHOP}'`,
+      postgres: `SELECT COALESCE(linked_transfer_id::text, 'NONE') FROM public.transactions WHERE id = '${CORNER_SHOP}'`,
+      expect: 'NONE',
+    },
+  ],
+};

--- a/scripts/local-sqlite/verb-specs/finalize-a-null-parent-is-skipped-rather-than-written.spec.mjs
+++ b/scripts/local-sqlite/verb-specs/finalize-a-null-parent-is-skipped-rather-than-written.spec.mjs
@@ -1,0 +1,32 @@
+import { USER, EVERYDAY, RAINY_DAY } from './_shared.mjs';
+
+export default {
+  invariant: 'X-9',
+  title: 'a null parent is skipped, so only rows that genuinely carry a link are touched',
+  design: '20260807083000:415 — AND l.parent_account_id IS NOT NULL, and the comment at :381-383 says why: these are UPDATEs, "so only rows that genuinely carry a link are updated, rather than the whole table"',
+  consequence: 'writing NULL over NULL still counts as an update, which would re-date every account in the file and inflate the number the client reports back to the user',
+  parity: 'match',
+
+  command: {
+    verb: 'finalize_user_restore',
+    payload: {
+      links: {
+        account_parents: [
+          { id: EVERYDAY, parent_account_id: null },
+          { id: RAINY_DAY, parent_account_id: EVERYDAY },
+        ],
+      },
+      user_id: USER,
+    },
+  },
+  expect: { outcome: 'ok' },
+  result: { accounts_relinked: 1, transactions_relinked: 0 },
+  state: [
+    {
+      name: 'the_nesting',
+      sqlite: `SELECT COALESCE(parent_account_id, 'NONE') FROM accounts WHERE id = '${RAINY_DAY}'`,
+      postgres: `SELECT COALESCE(parent_account_id::text, 'NONE') FROM public.accounts WHERE id = '${RAINY_DAY}'`,
+      expect: EVERYDAY,
+    },
+  ],
+};

--- a/scripts/local-sqlite/verb-specs/finalize-a-parent-owned-by-somebody-else-is-refused.spec.mjs
+++ b/scripts/local-sqlite/verb-specs/finalize-a-parent-owned-by-somebody-else-is-refused.spec.mjs
@@ -1,0 +1,39 @@
+import { USER, EVERYDAY, SOMEONE_ELSES_ACCOUNT, secondUser } from './_shared.mjs';
+
+export default {
+  invariant: 'R-12',
+  title: 'nesting an account under a stranger\'s account is refused by the ownership key',
+  design: '20260808170000:486-490 pairs accounts.parent_account_id with user_id; schema.sql carries the twin. MEASURED on the reference cluster: accounts_parent_account_id_user_fkey refuses it',
+  consequence: 'the investment/cash pairing is a private arrangement between two of one person\'s accounts; a restore that could nest one under a stranger\'s would put a figure in somebody else\'s portfolio roll-up',
+  parity: 'match',
+
+  setup: secondUser,
+  command: {
+    verb: 'finalize_user_restore',
+    payload: {
+      links: { account_parents: [{ id: EVERYDAY, parent_account_id: SOMEONE_ELSES_ACCOUNT }] },
+      user_id: USER,
+    },
+  },
+  // Both refuse. Postgres names the key; SQLite does not name keys in its
+  // message at all, which is why the whole family of foreign-key refusals reads
+  // the same there.
+  expect: {
+    sqlite: { outcome: 'refused', error: 'FOREIGN KEY constraint failed' },
+    postgres: { outcome: 'refused', error: 'accounts_parent_account_id_user_fkey' },
+  },
+  state: [
+    {
+      name: 'nothing_was_nested',
+      sqlite: `SELECT COALESCE(parent_account_id, 'NONE') FROM accounts WHERE id = '${EVERYDAY}'`,
+      postgres: `SELECT COALESCE(parent_account_id::text, 'NONE') FROM public.accounts WHERE id = '${EVERYDAY}'`,
+      expect: 'NONE',
+    },
+    {
+      name: 'and_nothing_was_audited',
+      sqlite: `SELECT COUNT(*) FROM financial_audit_log WHERE user_id = '${USER}'`,
+      postgres: `SELECT COUNT(*) FROM public.financial_audit_log WHERE user_id = '${USER}'`,
+      expect: '0',
+    },
+  ],
+};

--- a/scripts/local-sqlite/verb-specs/finalize-the-links-close-without-re-dating-the-history.spec.mjs
+++ b/scripts/local-sqlite/verb-specs/finalize-the-links-close-without-re-dating-the-history.spec.mjs
@@ -1,0 +1,49 @@
+import { USER, OTHER_LEG, THIS_LEG, transferPair, updatedDay } from './_shared.mjs';
+
+export default {
+  invariant: 'X-4',
+  title: 'the second pass relinks a decade-old transfer and leaves it dated when it happened',
+  design: '20260807083000:87-99 redefines update_updated_at_column to stand down while app.restore_in_progress is set; schema.sql puts the same exemption in each updated_at trigger\'s WHEN clause as _rpc_guard(\'restore\'). MEASURED both ways on both engines: without the flag the row is dated today, with it the row keeps 2019',
+  consequence: 'the migration says it in one line: a backup that returns a decade of transfers dated today is not a backup',
+  parity: 'match',
+
+  setup: {
+    // The pair, unlinked and back-dated — the state the first pass leaves.
+    sqlite: `${transferPair.sqlite}
+      UPDATE transactions SET linked_transfer_id = NULL WHERE id IN ('${OTHER_LEG}', '${THIS_LEG}');
+      UPDATE transactions SET updated_at = '2019-01-01T00:00:00.000Z'
+       WHERE id IN ('${OTHER_LEG}', '${THIS_LEG}');`,
+    postgres: `${transferPair.postgres}
+      UPDATE public.transactions SET linked_transfer_id = NULL WHERE id IN ('${OTHER_LEG}', '${THIS_LEG}');
+      SELECT set_config('app.restore_in_progress', '1', true);
+      UPDATE public.transactions SET updated_at = '2019-01-01T00:00:00Z'
+       WHERE id IN ('${OTHER_LEG}', '${THIS_LEG}');
+      SELECT set_config('app.restore_in_progress', '0', true);`,
+  },
+  command: {
+    verb: 'finalize_user_restore',
+    payload: {
+      links: {
+        transaction_links: [
+          { id: OTHER_LEG, linked_transfer_id: THIS_LEG, linked_transfer_split_id: null },
+          { id: THIS_LEG, linked_transfer_id: OTHER_LEG, linked_transfer_split_id: null },
+        ],
+      },
+      user_id: USER,
+    },
+  },
+  expect: { outcome: 'ok' },
+  result: { accounts_relinked: 0, transactions_relinked: 2 },
+  state: [
+    {
+      name: 'the_pair_is_mutual_again',
+      sqlite: `SELECT COUNT(*) FROM transactions a JOIN transactions b ON b.id = a.linked_transfer_id
+                WHERE b.linked_transfer_id = a.id`,
+      postgres: `SELECT COUNT(*) FROM public.transactions a JOIN public.transactions b ON b.id = a.linked_transfer_id
+                  WHERE b.linked_transfer_id = a.id`,
+      expect: '2',
+    },
+    updatedDay('transactions', OTHER_LEG, '2019-01-01'),
+    updatedDay('transactions', THIS_LEG, '2019-01-01'),
+  ],
+};

--- a/scripts/local-sqlite/verb-specs/finalize-the-one-entry-it-writes-cannot-carry-the-cloud-s-action.spec.mjs
+++ b/scripts/local-sqlite/verb-specs/finalize-the-one-entry-it-writes-cannot-carry-the-cloud-s-action.spec.mjs
@@ -1,0 +1,35 @@
+import { USER } from './_shared.mjs';
+
+export default {
+  invariant: 'U-6',
+  title: 'the restore-completed entry is a create locally and an update in the cloud',
+  design: '20260807083000:432-436 writes action = update with before_data NULL. MEASURED: the cloud\'s financial_audit_log has exactly one CHECK, the action enumeration, so nothing there objects. This schema has three, and audit_update_has_both is one of them — MEASURED, that exact row is refused with "CHECK constraint failed: audit_update_has_both"',
+  consequence: 'an entry claiming something was updated while refusing to say what it was before cannot answer the question the log exists for. A restore completing is a fact that did not exist and now does, which is what create means',
+  parity: 'divergent',
+  reason: 'U-6 is a LOCAL-ONLY rule (canonical #100 lists it as such): the local schema enforces "create has no before, delete has no after, update has both" and the cloud enforces none of it. The entity, the entity_id and the payload are identical on both engines; only the action differs, and it differs because one engine will not store the other\'s shape. Recorded rather than fixed in the cloud, because changing a live audit row\'s action is a migration with its own reasoning and this is a port.',
+
+  command: { verb: 'finalize_user_restore', payload: { links: {}, user_id: USER } },
+  expect: { outcome: 'ok' },
+  result: { accounts_relinked: 0, transactions_relinked: 0 },
+  state: [
+    {
+      name: 'the_entrys_action_and_before',
+      sqlite: `SELECT action || '/' || CASE WHEN before_data IS NULL THEN 'no-before' ELSE 'before' END
+                 FROM financial_audit_log WHERE json_extract(after_data, '$.event') = 'restore_completed'`,
+      postgres: `SELECT action || '/' || CASE WHEN before_data IS NULL THEN 'no-before' ELSE 'before' END
+                   FROM public.financial_audit_log WHERE after_data->>'event' = 'restore_completed'`,
+      expect: { sqlite: 'create/no-before', postgres: 'update/no-before' },
+    },
+    {
+      name: 'the_payload_is_the_same_either_way',
+      sqlite: `SELECT json_extract(after_data, '$.event') || '/'
+                 || CAST(json_extract(after_data, '$.accounts_relinked') AS TEXT) || '/'
+                 || CAST(json_extract(after_data, '$.transactions_relinked') AS TEXT)
+                 FROM financial_audit_log WHERE json_extract(after_data, '$.event') = 'restore_completed'`,
+      postgres: `SELECT (after_data->>'event') || '/' || (after_data->>'accounts_relinked') || '/'
+                   || (after_data->>'transactions_relinked')
+                   FROM public.financial_audit_log WHERE after_data->>'event' = 'restore_completed'`,
+      expect: 'restore_completed/0/0',
+    },
+  ],
+};

--- a/scripts/local-sqlite/verb-specs/finalize-with-no-owner-is-refused-by-name.spec.mjs
+++ b/scripts/local-sqlite/verb-specs/finalize-with-no-owner-is-refused-by-name.spec.mjs
@@ -1,0 +1,10 @@
+export default {
+  invariant: 'X-6',
+  title: 'a finalize that cannot say which login it is for is refused',
+  design: '20260807083000:397-401',
+  consequence: 'the second pass writes into whichever rows the links name; with no owner it would write into anybody\'s',
+  parity: 'match',
+
+  command: { verb: 'finalize_user_restore', payload: { links: {} } },
+  expect: { outcome: 'refused', error: 'owner_unknown' },
+};

--- a/scripts/local-sqlite/verb-specs/finalize-with-nothing-to-do-still-records-that-a-restore-happened.spec.mjs
+++ b/scripts/local-sqlite/verb-specs/finalize-with-nothing-to-do-still-records-that-a-restore-happened.spec.mjs
@@ -1,0 +1,35 @@
+import { USER } from './_shared.mjs';
+
+export default {
+  invariant: 'U-1',
+  title: 'a finalize with no links relinks nothing and still writes its one entry',
+  design: '20260807083000:432-439 — the audit write is unconditional, because the fact it records is that a restore COMPLETED, not that a link moved',
+  consequence: 'a restore that left no trace in the log would be the one operation in the product that can replace every row a person owns and say nothing about it',
+  parity: 'match',
+
+  command: { verb: 'finalize_user_restore', payload: { links: {}, user_id: USER } },
+  expect: { outcome: 'ok' },
+  result: { accounts_relinked: 0, transactions_relinked: 0 },
+  state: [
+    {
+      name: 'the_entry_exists',
+      sqlite: `SELECT COUNT(*) FROM financial_audit_log
+                WHERE user_id = '${USER}' AND json_extract(after_data, '$.event') = 'restore_completed'`,
+      postgres: `SELECT COUNT(*) FROM public.financial_audit_log
+                  WHERE user_id = '${USER}' AND after_data->>'event' = 'restore_completed'`,
+      expect: '1',
+    },
+    {
+      // The cloud files it against `account`, with the USER's id in a column
+      // that names an account. Kept: the entry is about the login rather than
+      // about any one account, and changing it would make the two logs disagree
+      // about which row a restore happened to.
+      name: 'what_it_is_filed_against',
+      sqlite: `SELECT entity || '/' || entity_id FROM financial_audit_log
+                WHERE json_extract(after_data, '$.event') = 'restore_completed'`,
+      postgres: `SELECT entity || '/' || entity_id::text FROM public.financial_audit_log
+                  WHERE after_data->>'event' = 'restore_completed'`,
+      expect: `account/${USER}`,
+    },
+  ],
+};

--- a/scripts/local-sqlite/verb-specs/integrity-a-file-with-nothing-wrong-with-it-says-so.spec.mjs
+++ b/scripts/local-sqlite/verb-specs/integrity-a-file-with-nothing-wrong-with-it-says-so.spec.mjs
@@ -1,0 +1,16 @@
+export default {
+  invariant: 'V',
+  title: 'the fixture every other spec starts from reports nothing at all',
+  design: 'schema.sql v_integrity_violations — seventeen checks, and the only interesting answer is the empty one',
+  consequence: 'a checker that reports something about a healthy file is a checker nobody reads, and the one time it matters it will be scrolled past',
+  parity: 'not-comparable',
+  reason: 'the cloud has no verify_integrity, no view and no equivalent — traced in the verb module: grep over supabase/, api/ and src/ finds nothing, and supabase/migrations/ contains no CREATE VIEW at all',
+  skip: { postgres: 'there is no cloud counterpart to compare against' },
+
+  command: { verb: 'verify_integrity', payload: {} },
+  expect: { outcome: 'ok' },
+  result: { ok: true, violations: 0, warnings: 0, findings: [] },
+  state: [
+    { name: 'v_integrity_ok', sqlite: "SELECT CASE WHEN (SELECT ok FROM v_integrity_ok) = 1 THEN 'ok' ELSE 'not-ok' END", expect: 'ok' },
+  ],
+};

--- a/scripts/local-sqlite/verb-specs/integrity-a-warning-and-a-violation-are-counted-apart.spec.mjs
+++ b/scripts/local-sqlite/verb-specs/integrity-a-warning-and-a-violation-are-counted-apart.spec.mjs
@@ -1,0 +1,44 @@
+import { CARD, EVERYDAY, setups, aBalanceThatIsOneOut, aCardWhoseSignsWereInverted } from './_shared.mjs';
+
+export default {
+  invariant: 'V',
+  title: 'one broken rule and one suspicion, counted apart and reported in check order',
+  design: 'schema.sql\'s severity column and v_integrity_ok, which counts only violations. PHASE1-PLAN §2.5 requires exactly this: adding advisory checks must not make the existing "must be empty" assertion flaky',
+  consequence: 'if a heuristic could turn ok false, the first credit card in credit would make every file look corrupt — and the fix somebody reached for would be deleting the check, taking the two real ingest catches with it',
+  parity: 'not-comparable',
+  reason: 'verify_integrity is local-only — see the verb module for the trace',
+  skip: { postgres: 'there is no cloud counterpart to compare against' },
+
+  // Also the ordering proof across checks: ORDER BY check_name first, so
+  // balance_identity comes before card_account_sign_implausible whatever order
+  // the UNION ALL happens to produce them in. The T-2 spec proves the tie-break
+  // on subject within one check.
+  setup: setups(aBalanceThatIsOneOut, aCardWhoseSignsWereInverted),
+  command: { verb: 'verify_integrity', payload: {} },
+  expect: { outcome: 'ok' },
+  result: {
+    ok: false,
+    violations: 1,
+    warnings: 1,
+    findings: [
+      {
+        check: 'balance_identity',
+        entity: 'account',
+        id: EVERYDAY,
+        severity: 'violation',
+        detail: 'account balance is not initial_balance + sum(transactions)',
+      },
+      {
+        check: 'card_account_sign_implausible',
+        entity: 'account',
+        id: CARD,
+        severity: 'warning',
+        detail: "a credit account is in credit and its rows were imported — the statement's signs may be inverted",
+      },
+    ],
+  },
+  state: [
+    { name: 'v_integrity_ok', sqlite: "SELECT CASE WHEN (SELECT ok FROM v_integrity_ok) = 1 THEN 'ok' ELSE 'not-ok' END", expect: 'not-ok' },
+    { name: 'rows_in_the_view', sqlite: 'SELECT COUNT(*) FROM v_integrity_violations', expect: '2' },
+  ],
+};

--- a/scripts/local-sqlite/verb-specs/integrity-a1-a-hole-where-a-sequence-number-should-be.spec.mjs
+++ b/scripts/local-sqlite/verb-specs/integrity-a1-a-hole-where-a-sequence-number-should-be.spec.mjs
@@ -1,0 +1,32 @@
+import { AUDIT_SECOND, anAuditChainWithAHoleInIt } from './_shared.mjs';
+
+export default {
+  invariant: 'A-1',
+  title: 'a missing seq — a row removed from the middle rather than rewritten',
+  design: 'schema.sql audit_chain_broken\'s other half: seq is dense, so a predecessor that is not there is as much a break as a hash that does not match',
+  consequence: 'deleting is the easier tamper. Without the density half, a row could be lifted out of the middle of the log and every remaining hash would still chain to the row before the hole',
+  parity: 'not-comparable',
+  reason: 'verify_integrity is local-only — see the verb module for the trace',
+  skip: { postgres: 'there is no cloud counterpart to compare against' },
+
+  // The purge exemption (trg_audit_no_delete stands down for
+  // _rpc_guard('audit_purge')) deletes from the OLD end only, which moves MIN(seq)
+  // and leaves the survivors dense. This plants the other thing: a hole in the
+  // middle, which the check separates from a purge by comparing against MIN(seq)
+  // rather than against 1.
+  setup: anAuditChainWithAHoleInIt,
+  command: { verb: 'verify_integrity', payload: {} },
+  expect: { outcome: 'ok' },
+  result: {
+    ok: false,
+    violations: 1,
+    warnings: 0,
+    findings: [{
+      check: 'audit_chain_broken',
+      entity: 'audit_entry',
+      id: AUDIT_SECOND,
+      severity: 'violation',
+      detail: 'this audit row does not chain to its predecessor',
+    }],
+  },
+};

--- a/scripts/local-sqlite/verb-specs/integrity-a1-an-audit-row-that-does-not-chain.spec.mjs
+++ b/scripts/local-sqlite/verb-specs/integrity-a1-an-audit-row-that-does-not-chain.spec.mjs
@@ -1,0 +1,27 @@
+import { AUDIT_SECOND, anAuditChainThatDoesNotChain } from './_shared.mjs';
+
+export default {
+  invariant: 'A-1',
+  title: 'an audit row whose prev_hash is not its predecessor\'s hash',
+  design: 'schema.sql audit_chain_broken. The local log is TAMPER-EVIDENT, not tamper-proof — the user owns the file and can open it with any SQLite tool — and this check is the whole of the evidence half',
+  consequence: 'the audit log is the only thing that can still say what a wiped or restored file used to hold. A chain nobody verifies is a list of claims, and an edit made outside the app would be indistinguishable from history',
+  parity: 'not-comparable',
+  reason: 'verify_integrity is local-only — see the verb module for the trace',
+  skip: { postgres: 'there is no cloud counterpart to compare against' },
+
+  setup: anAuditChainThatDoesNotChain,
+  command: { verb: 'verify_integrity', payload: {} },
+  expect: { outcome: 'ok' },
+  result: {
+    ok: false,
+    violations: 1,
+    warnings: 0,
+    findings: [{
+      check: 'audit_chain_broken',
+      entity: 'audit_entry',
+      id: AUDIT_SECOND,
+      severity: 'violation',
+      detail: 'this audit row does not chain to its predecessor',
+    }],
+  },
+};

--- a/scripts/local-sqlite/verb-specs/integrity-b1-a-balance-that-is-one-penny-out.spec.mjs
+++ b/scripts/local-sqlite/verb-specs/integrity-b1-a-balance-that-is-one-penny-out.spec.mjs
@@ -1,0 +1,30 @@
+import { EVERYDAY, aBalanceThatIsOneOut } from './_shared.mjs';
+
+export default {
+  invariant: 'B-1',
+  title: 'a balance that does not equal initial_balance plus its rows',
+  design: 'schema.sql balance_identity. B-1 is the identity the whole application rests on and NEITHER engine can enforce it — there is no constraint that can, in Postgres or in SQLite',
+  consequence: 'every figure the user sees is derived from this one. A penny out here is a penny out on the dashboard, in every report and in the reconciliation screen, with nothing anywhere to say which is right',
+  parity: 'not-comparable',
+  reason: 'verify_integrity is local-only; the cloud checks B-1 in two throwaway migration SELECTs (20260808090000:292-299, 20260807200000:100-110) and nowhere a caller can reach',
+  skip: { postgres: 'there is no cloud counterpart to compare against' },
+
+  setup: aBalanceThatIsOneOut,
+  command: { verb: 'verify_integrity', payload: {} },
+  expect: { outcome: 'ok' },
+  result: {
+    ok: false,
+    violations: 1,
+    warnings: 0,
+    findings: [{
+      check: 'balance_identity',
+      entity: 'account',
+      id: EVERYDAY,
+      severity: 'violation',
+      detail: 'account balance is not initial_balance + sum(transactions)',
+    }],
+  },
+  state: [
+    { name: 'v_integrity_ok', sqlite: "SELECT CASE WHEN (SELECT ok FROM v_integrity_ok) = 1 THEN 'ok' ELSE 'not-ok' END", expect: 'not-ok' },
+  ],
+};

--- a/scripts/local-sqlite/verb-specs/integrity-c3-an-account-with-no-to-from-category.spec.mjs
+++ b/scripts/local-sqlite/verb-specs/integrity-c3-an-account-with-no-to-from-category.spec.mjs
@@ -1,0 +1,36 @@
+import { SOMEONE_ELSES_ACCOUNT, secondUser } from './_shared.mjs';
+
+export default {
+  invariant: 'C-3',
+  title: 'an account that never got a To/From category, because its owner had no Transfer anchor',
+  design: 'schema.sql account_missing_transfer_category, and C-3\'s trigger, which SKIPS when the user has no type-level Transfer root — a documented behaviour the restore path depends on (20260807083000 inserts accounts before categories)',
+  consequence: 'nothing can be transferred into or out of that account: the category every transfer verb resolves through does not exist, so the money has nowhere to be filed and the whole account is an island',
+  parity: 'not-comparable',
+  reason: 'verify_integrity is local-only — see the verb module for the trace',
+  skip: { postgres: 'there is no cloud counterpart to compare against' },
+
+  // This violation cannot be planted by REMOVING a category. MEASURED
+  // (probe-integrity1.mjs, case 12): deleting the Transfer anchor cascades into
+  // the existing To/From rows and C-5's trigger refuses the whole statement with
+  // transfer_category_protected. It is reachable only FORWARDS — by creating an
+  // account whose owner has no anchor for C-3's trigger to hang a category from —
+  // which is C-3 and C-5 both doing exactly their jobs. `secondUser` is that
+  // shape and has been in this file since the transfer family; it turns out to
+  // have carried an integrity violation all along, which nothing until now could
+  // report.
+  setup: secondUser,
+  command: { verb: 'verify_integrity', payload: {} },
+  expect: { outcome: 'ok' },
+  result: {
+    ok: false,
+    violations: 1,
+    warnings: 0,
+    findings: [{
+      check: 'account_missing_transfer_category',
+      entity: 'account',
+      id: SOMEONE_ELSES_ACCOUNT,
+      severity: 'violation',
+      detail: 'this account has no To/From category',
+    }],
+  },
+};

--- a/scripts/local-sqlite/verb-specs/integrity-c3-an-account-with-two-to-from-categories.spec.mjs
+++ b/scripts/local-sqlite/verb-specs/integrity-c3-an-account-with-two-to-from-categories.spec.mjs
@@ -1,0 +1,27 @@
+import { EVERYDAY, aSecondToFromCategory } from './_shared.mjs';
+
+export default {
+  invariant: 'C-3',
+  title: 'two To/From categories for one account',
+  design: 'schema.sql account_multiple_transfer_categories. C-3 says exactly one; the trigger guarantees at least one and nothing guarantees at most one',
+  consequence: 'transfer_category_for takes whichever LIMIT 1 finds, so the same account transfers into two different categories depending on nothing the user can see, and the category report splits one account\'s transfers across two lines',
+  parity: 'not-comparable',
+  reason: 'verify_integrity is local-only — see the verb module for the trace',
+  skip: { postgres: 'there is no cloud counterpart to compare against' },
+
+  setup: aSecondToFromCategory,
+  command: { verb: 'verify_integrity', payload: {} },
+  expect: { outcome: 'ok' },
+  result: {
+    ok: false,
+    violations: 1,
+    warnings: 0,
+    findings: [{
+      check: 'account_multiple_transfer_categories',
+      entity: 'account',
+      id: EVERYDAY,
+      severity: 'violation',
+      detail: 'this account has more than one To/From category',
+    }],
+  },
+};

--- a/scripts/local-sqlite/verb-specs/integrity-i1-an-account-nested-two-deep.spec.mjs
+++ b/scripts/local-sqlite/verb-specs/integrity-i1-an-account-nested-two-deep.spec.mjs
@@ -1,0 +1,27 @@
+import { RAINY_DAY, anAccountNestedTwoDeep } from './_shared.mjs';
+
+export default {
+  invariant: 'I-1',
+  title: 'a nested account that is itself a parent',
+  design: 'schema.sql account_nesting_too_deep. The (Cash) pairing (20260722090000) is ONE level: an investment account and its cash sibling. Neither engine constrains the depth',
+  consequence: 'every reader of the pairing walks exactly one link. A second level means the third account is invisible to the account list and its balance is counted once, twice or not at all depending on which screen is asking',
+  parity: 'not-comparable',
+  reason: 'verify_integrity is local-only — see the verb module for the trace',
+  skip: { postgres: 'there is no cloud counterpart to compare against' },
+
+  setup: anAccountNestedTwoDeep,
+  command: { verb: 'verify_integrity', payload: {} },
+  expect: { outcome: 'ok' },
+  result: {
+    ok: false,
+    violations: 1,
+    warnings: 0,
+    findings: [{
+      check: 'account_nesting_too_deep',
+      entity: 'account',
+      id: RAINY_DAY,
+      severity: 'violation',
+      detail: 'a nested account is itself a parent',
+    }],
+  },
+};

--- a/scripts/local-sqlite/verb-specs/integrity-ingest-a-card-whose-statement-signs-were-inverted.spec.mjs
+++ b/scripts/local-sqlite/verb-specs/integrity-ingest-a-card-whose-statement-signs-were-inverted.spec.mjs
@@ -1,0 +1,33 @@
+import { CARD, aCardWhoseSignsWereInverted } from './_shared.mjs';
+
+export default {
+  invariant: 'INGEST-1',
+  title: 'a credit card in credit, whose rows came out of an import',
+  design: "PHASE1-PLAN §2.5's first addendum check, card_account_sign_implausible. A card's stored balance is -current (TS-F1/TS-F2); a positive one is either a genuine credit balance or an importer that got the sign backwards",
+  consequence: 'an inverted card import produces data that is INTERNALLY CONSISTENT and entirely wrong — the balance matches the rows, the rows match the file, and every total in the product is the wrong way round. MEASURED before this check was written (probe-integrity1.mjs case 16): the other fifteen reported nothing at all',
+  parity: 'not-comparable',
+  reason: 'verify_integrity is local-only — see the verb module for the trace',
+  skip: { postgres: 'there is no cloud counterpart to compare against' },
+
+  // A WARNING, not a violation: a credit card genuinely can be in credit. It is
+  // therefore counted separately, v_integrity_ok ignores it, and `ok` stays true.
+  setup: aCardWhoseSignsWereInverted,
+  command: { verb: 'verify_integrity', payload: {} },
+  expect: { outcome: 'ok' },
+  result: {
+    ok: true,
+    violations: 0,
+    warnings: 1,
+    findings: [{
+      check: 'card_account_sign_implausible',
+      entity: 'account',
+      id: CARD,
+      severity: 'warning',
+      detail: "a credit account is in credit and its rows were imported — the statement's signs may be inverted",
+    }],
+  },
+  state: [
+    { name: 'v_integrity_ok', sqlite: "SELECT CASE WHEN (SELECT ok FROM v_integrity_ok) = 1 THEN 'ok' ELSE 'not-ok' END", expect: 'ok' },
+    { name: 'rows_in_the_view', sqlite: 'SELECT COUNT(*) FROM v_integrity_violations', expect: '1' },
+  ],
+};

--- a/scripts/local-sqlite/verb-specs/integrity-ingest-an-available-balance-stored-as-a-bank-balance.spec.mjs
+++ b/scripts/local-sqlite/verb-specs/integrity-ingest-an-available-balance-stored-as-a-bank-balance.spec.mjs
@@ -1,0 +1,27 @@
+import { CARD, anAvailableBalanceStoredAsABankBalance } from './_shared.mjs';
+
+export default {
+  invariant: 'INGEST-2',
+  title: 'remaining credit stored where the bank\'s own figure belongs',
+  design: "PHASE1-PLAN §2.5's second addendum check, bank_balance_implausible. <AVAILBAL> is remaining credit — positive, and larger than the <LEDGERBAL> it gets mistaken for (TS-I1/TS-I2)",
+  consequence: 'bank_balance is what reconciliation compares against. Fill it with available credit and the account is permanently, hugely out — and the user is invited to "fix" a ledger that was right by adjusting it to a number that was never a balance',
+  parity: 'not-comparable',
+  reason: 'verify_integrity is local-only — see the verb module for the trace',
+  skip: { postgres: 'there is no cloud counterpart to compare against' },
+
+  setup: anAvailableBalanceStoredAsABankBalance,
+  command: { verb: 'verify_integrity', payload: {} },
+  expect: { outcome: 'ok' },
+  result: {
+    ok: true,
+    violations: 0,
+    warnings: 1,
+    findings: [{
+      check: 'bank_balance_implausible',
+      entity: 'account',
+      id: CARD,
+      severity: 'warning',
+      detail: 'the bank figure disagrees with the ledger by more than the ledger itself — an available balance may have been stored as a bank balance',
+    }],
+  },
+};

--- a/scripts/local-sqlite/verb-specs/integrity-ingest-control-a-bank-balance-that-agrees.spec.mjs
+++ b/scripts/local-sqlite/verb-specs/integrity-ingest-control-a-bank-balance-that-agrees.spec.mjs
@@ -1,0 +1,16 @@
+import { aBankBalanceThatAgrees } from './_shared.mjs';
+
+export default {
+  invariant: 'INGEST-2',
+  title: 'a card and a bank that agree are not suspicious',
+  design: 'bank_balance_implausible\'s two conditions together: the signs must DIFFER and the gap must exceed the ledger itself. Either one alone would fire on ordinary unreconciled data',
+  consequence: 'an unreconciled card is normally a little out and always the same sign. A check that fired on that would fire on every card in every file, every day',
+  parity: 'not-comparable',
+  reason: 'verify_integrity is local-only — see the verb module for the trace',
+  skip: { postgres: 'there is no cloud counterpart to compare against' },
+
+  setup: aBankBalanceThatAgrees,
+  command: { verb: 'verify_integrity', payload: {} },
+  expect: { outcome: 'ok' },
+  result: { ok: true, violations: 0, warnings: 0, findings: [] },
+};

--- a/scripts/local-sqlite/verb-specs/integrity-ingest-control-a-card-in-credit-nobody-imported.spec.mjs
+++ b/scripts/local-sqlite/verb-specs/integrity-ingest-control-a-card-in-credit-nobody-imported.spec.mjs
@@ -1,0 +1,16 @@
+import { aCardInCreditNobodyImported } from './_shared.mjs';
+
+export default {
+  invariant: 'INGEST-1',
+  title: 'the same balance, typed in by a person, is nobody\'s business',
+  design: 'card_account_sign_implausible\'s provenance test: at least one feed- or file-sourced row against the account',
+  consequence: 'without the provenance half the check fires on every card a user has overpaid, which is a real and ordinary thing to do — and a warning that fires on ordinary data is a warning that gets ignored on the day it is right',
+  parity: 'not-comparable',
+  reason: 'verify_integrity is local-only — see the verb module for the trace',
+  skip: { postgres: 'there is no cloud counterpart to compare against' },
+
+  setup: aCardInCreditNobodyImported,
+  command: { verb: 'verify_integrity', payload: {} },
+  expect: { outcome: 'ok' },
+  result: { ok: true, violations: 0, warnings: 0, findings: [] },
+};

--- a/scripts/local-sqlite/verb-specs/integrity-it-refuses-an-owner-because-integrity-is-not-a-per-login-question.spec.mjs
+++ b/scripts/local-sqlite/verb-specs/integrity-it-refuses-an-owner-because-integrity-is-not-a-per-login-question.spec.mjs
@@ -1,0 +1,20 @@
+import { USER, secondUser } from './_shared.mjs';
+
+export default {
+  invariant: 'V',
+  title: 'naming an owner is refused, not ignored',
+  design: 'The command struct is empty and carries deny_unknown_fields. Every other verb in the crate is scoped to a login; this one is a question about the FILE',
+  consequence: 'three of the seventeen checks have no per-user reading at all — the audit chain is one sequence for the whole file — so an owner argument would have to be silently ignored by a third of them. A caller who passed one and got a filtered answer for some checks and an unfiltered one for others would have no way to know which was which',
+  parity: 'not-comparable',
+  reason: 'verify_integrity is local-only — see the verb module for the trace',
+  skip: { postgres: 'there is no cloud counterpart to compare against' },
+
+  // The second login is here to make the refusal mean something: this file
+  // genuinely holds another login's rows, and one of them is a violation
+  // (C-3, its account has no To/From category). A scoped verb would have hidden
+  // it. The refusal is what says the scoping does not exist rather than that it
+  // was not asked for.
+  setup: secondUser,
+  command: { verb: 'verify_integrity', payload: { user_id: USER } },
+  expect: { outcome: 'refused', error: 'unknown_field' },
+};

--- a/scripts/local-sqlite/verb-specs/integrity-r3-a-split-line-filed-under-a-category-nothing-answers-to.spec.mjs
+++ b/scripts/local-sqlite/verb-specs/integrity-r3-a-split-line-filed-under-a-category-nothing-answers-to.spec.mjs
@@ -1,0 +1,27 @@
+import { LEG_LINE, aSplitLineFiledUnderNothing } from './_shared.mjs';
+
+export default {
+  invariant: 'R-3',
+  title: 'a split line whose category names nothing — and it has no sentinel exemption',
+  design: 'schema.sql dangling_split_category_ref. The transaction check exempts transfer-in/transfer-out and this one does not, because a split line has never been allowed to carry them',
+  consequence: 'a split line must carry a non-blank category by CHECK, so the corruption cannot be seen as a blank — it is a line filed under an id, rendering as that id, belonging to no group anywhere',
+  parity: 'not-comparable',
+  reason: 'verify_integrity is local-only — see the verb module for the trace',
+  skip: { postgres: 'there is no cloud counterpart to compare against' },
+
+  setup: aSplitLineFiledUnderNothing,
+  command: { verb: 'verify_integrity', payload: {} },
+  expect: { outcome: 'ok' },
+  result: {
+    ok: false,
+    violations: 1,
+    warnings: 0,
+    findings: [{
+      check: 'dangling_split_category_ref',
+      entity: 'split_line',
+      id: LEG_LINE,
+      severity: 'violation',
+      detail: 'split line category names no category of this user',
+    }],
+  },
+};

--- a/scripts/local-sqlite/verb-specs/integrity-r3-a-transaction-filed-under-a-category-nothing-answers-to.spec.mjs
+++ b/scripts/local-sqlite/verb-specs/integrity-r3-a-transaction-filed-under-a-category-nothing-answers-to.spec.mjs
@@ -1,0 +1,27 @@
+import { CORNER_SHOP, aTransactionFiledUnderNothing } from './_shared.mjs';
+
+export default {
+  invariant: 'R-3',
+  title: 'a category id on a transaction that names no category',
+  design: 'schema.sql dangling_category_ref. transactions.category is TEXT with NO foreign key in BOTH engines, on purpose — the legacy transfer-in/transfer-out sentinels are legal values — so danglers are REPORTED, never rejected',
+  consequence: 'this is the wreckage delete_unused_categories leaves behind when the cascade eats a referenced child, measured on both engines. The row shows a blank category in the register and counts under nothing in every report, and no amount of re-filing elsewhere will surface it',
+  parity: 'not-comparable',
+  reason: 'verify_integrity is local-only — see the verb module for the trace',
+  skip: { postgres: 'there is no cloud counterpart to compare against' },
+
+  setup: aTransactionFiledUnderNothing,
+  command: { verb: 'verify_integrity', payload: {} },
+  expect: { outcome: 'ok' },
+  result: {
+    ok: false,
+    violations: 1,
+    warnings: 0,
+    findings: [{
+      check: 'dangling_category_ref',
+      entity: 'transaction',
+      id: CORNER_SHOP,
+      severity: 'violation',
+      detail: 'category text names no category of this user',
+    }],
+  },
+};

--- a/scripts/local-sqlite/verb-specs/integrity-r3-control-the-legacy-sentinel-is-a-legal-value.spec.mjs
+++ b/scripts/local-sqlite/verb-specs/integrity-r3-control-the-legacy-sentinel-is-a-legal-value.spec.mjs
@@ -1,0 +1,16 @@
+import { aTransactionFiledUnderTheSentinel } from './_shared.mjs';
+
+export default {
+  invariant: 'R-3',
+  title: "'transfer-out' names no category and is not a dangler",
+  design: "schema.sql dangling_category_ref's exemption list. The sentinels predate the To/From lifecycle and transfer_category_for still falls back to them (20260716100000:43-61)",
+  consequence: 'without the exemption the checker would report every pre-lifecycle transfer in a real file as corrupt, which is how a checker gets switched off',
+  parity: 'not-comparable',
+  reason: 'verify_integrity is local-only — see the verb module for the trace',
+  skip: { postgres: 'there is no cloud counterpart to compare against' },
+
+  setup: aTransactionFiledUnderTheSentinel,
+  command: { verb: 'verify_integrity', payload: {} },
+  expect: { outcome: 'ok' },
+  result: { ok: true, violations: 0, warnings: 0, findings: [] },
+};

--- a/scripts/local-sqlite/verb-specs/integrity-s1-split-lines-that-do-not-sum-to-their-parent.spec.mjs
+++ b/scripts/local-sqlite/verb-specs/integrity-s1-split-lines-that-do-not-sum-to-their-parent.spec.mjs
@@ -1,0 +1,27 @@
+import { CORNER_SHOP, aSplitThatDoesNotSum } from './_shared.mjs';
+
+export default {
+  invariant: 'S-1',
+  title: 'split lines that add up to less than the transaction they belong to',
+  design: 'schema.sql split_sum, the check the covering index idx_splits_sum_cover exists for',
+  consequence: 'the parent says one figure and its lines say another, so the account total and the category totals disagree by the difference and no screen shows both',
+  parity: 'not-comparable',
+  reason: 'verify_integrity is local-only — see the verb module for the trace',
+  skip: { postgres: 'there is no cloud counterpart to compare against' },
+
+  setup: aSplitThatDoesNotSum,
+  command: { verb: 'verify_integrity', payload: {} },
+  expect: { outcome: 'ok' },
+  result: {
+    ok: false,
+    violations: 1,
+    warnings: 0,
+    findings: [{
+      check: 'split_sum',
+      entity: 'transaction',
+      id: CORNER_SHOP,
+      severity: 'violation',
+      detail: 'split lines do not sum to the parent amount',
+    }],
+  },
+};

--- a/scripts/local-sqlite/verb-specs/integrity-s2-a-split-with-only-one-line.spec.mjs
+++ b/scripts/local-sqlite/verb-specs/integrity-s2-a-split-with-only-one-line.spec.mjs
@@ -1,0 +1,27 @@
+import { CORNER_SHOP, aSplitWithOneLine } from './_shared.mjs';
+
+export default {
+  invariant: 'S-2',
+  title: 'a split with one line — which is not a split, it is a category',
+  design: 'schema.sql split_min_lines, the port of 20260713100000:185',
+  consequence: 'a one-line split renders as a split in the register and edits as one in the panel, so the user is shown a breakdown of one thing into itself and cannot get out of it without deleting the line',
+  parity: 'not-comparable',
+  reason: 'verify_integrity is local-only — see the verb module for the trace',
+  skip: { postgres: 'there is no cloud counterpart to compare against' },
+
+  setup: aSplitWithOneLine,
+  command: { verb: 'verify_integrity', payload: {} },
+  expect: { outcome: 'ok' },
+  result: {
+    ok: false,
+    violations: 1,
+    warnings: 0,
+    findings: [{
+      check: 'split_min_lines',
+      entity: 'transaction',
+      id: CORNER_SHOP,
+      severity: 'violation',
+      detail: 'a split has fewer than two lines',
+    }],
+  },
+};

--- a/scripts/local-sqlite/verb-specs/integrity-s3-lines-hanging-off-a-row-that-is-not-split.spec.mjs
+++ b/scripts/local-sqlite/verb-specs/integrity-s3-lines-hanging-off-a-row-that-is-not-split.spec.mjs
@@ -1,0 +1,27 @@
+import { CORNER_SHOP, linesOnARowThatIsNotSplit } from './_shared.mjs';
+
+export default {
+  invariant: 'S-3',
+  title: 'split lines on a transaction that is not split',
+  design: 'schema.sql orphan_split_lines. is_split and the presence of lines are two facts that must agree, and no constraint pairs them',
+  consequence: 'the lines are invisible — every reader keys off is_split — while still counting in any query that walks transaction_splits, so category reports and the register disagree and neither is obviously wrong',
+  parity: 'not-comparable',
+  reason: 'verify_integrity is local-only — see the verb module for the trace',
+  skip: { postgres: 'there is no cloud counterpart to compare against' },
+
+  setup: linesOnARowThatIsNotSplit,
+  command: { verb: 'verify_integrity', payload: {} },
+  expect: { outcome: 'ok' },
+  result: {
+    ok: false,
+    violations: 1,
+    warnings: 0,
+    findings: [{
+      check: 'orphan_split_lines',
+      entity: 'transaction',
+      id: CORNER_SHOP,
+      severity: 'violation',
+      detail: 'split lines on a transaction that is not split',
+    }],
+  },
+};

--- a/scripts/local-sqlite/verb-specs/integrity-t1-a-link-nobody-returns.spec.mjs
+++ b/scripts/local-sqlite/verb-specs/integrity-t1-a-link-nobody-returns.spec.mjs
@@ -1,0 +1,27 @@
+import { OTHER_LEG, aLinkNobodyReturns } from './_shared.mjs';
+
+export default {
+  invariant: 'T-1',
+  title: 'one side names the other and is not named back',
+  design: 'schema.sql transfer_link_not_mutual. Mutual linkage is enforced NOWHERE in the cloud — only repair_claimed_transfer even looks at it (20260805145035:327-331)',
+  consequence: 'the half-linked row shows a transfer badge and a target the other row has never heard of, so deleting either one leaves the survivor pointing at nothing and the transfer sweep re-offers a pair it already made',
+  parity: 'not-comparable',
+  reason: 'verify_integrity is local-only — see the verb module for the trace',
+  skip: { postgres: 'there is no cloud counterpart to compare against' },
+
+  setup: aLinkNobodyReturns,
+  command: { verb: 'verify_integrity', payload: {} },
+  expect: { outcome: 'ok' },
+  result: {
+    ok: false,
+    violations: 1,
+    warnings: 0,
+    findings: [{
+      check: 'transfer_link_not_mutual',
+      entity: 'transaction',
+      id: OTHER_LEG,
+      severity: 'violation',
+      detail: 'this row links to one that does not link back',
+    }],
+  },
+};

--- a/scripts/local-sqlite/verb-specs/integrity-t2-two-sides-that-do-not-cancel.spec.mjs
+++ b/scripts/local-sqlite/verb-specs/integrity-t2-two-sides-that-do-not-cancel.spec.mjs
@@ -1,0 +1,41 @@
+import { OTHER_LEG, THIS_LEG, linkedSidesThatAreNotOpposites } from './_shared.mjs';
+
+export default {
+  invariant: 'T-2',
+  title: 'a transfer whose two sides are not exact opposites — reported on BOTH rows',
+  design: 'schema.sql transfer_amounts_not_opposite, the port of 20260716100000:108-111',
+  consequence: 'money appears or vanishes between two accounts the user believes are joined, and because both balances are individually consistent with their own rows, nothing else in the product can notice',
+  parity: 'not-comparable',
+  reason: 'verify_integrity is local-only — see the verb module for the trace',
+  skip: { postgres: 'there is no cloud counterpart to compare against' },
+
+  setup: linkedSidesThatAreNotOpposites,
+  command: { verb: 'verify_integrity', payload: {} },
+  expect: { outcome: 'ok' },
+  // TWO findings, and deliberately so: the check reads every row that names
+  // another, and both of these are wrong about the same movement. Naming one
+  // would leave the other looking innocent. The order is the ORDER BY's: same
+  // check, same entity, so the id decides, and OTHER_LEG (…0004) sorts before
+  // THIS_LEG (…0005).
+  result: {
+    ok: false,
+    violations: 2,
+    warnings: 0,
+    findings: [
+      {
+        check: 'transfer_amounts_not_opposite',
+        entity: 'transaction',
+        id: OTHER_LEG,
+        severity: 'violation',
+        detail: 'linked transfer sides are not exact opposites',
+      },
+      {
+        check: 'transfer_amounts_not_opposite',
+        entity: 'transaction',
+        id: THIS_LEG,
+        severity: 'violation',
+        detail: 'linked transfer sides are not exact opposites',
+      },
+    ],
+  },
+};

--- a/scripts/local-sqlite/verb-specs/integrity-t3-both-sides-of-a-transfer-in-one-account.spec.mjs
+++ b/scripts/local-sqlite/verb-specs/integrity-t3-both-sides-of-a-transfer-in-one-account.spec.mjs
@@ -1,0 +1,36 @@
+import { OTHER_LEG, THIS_LEG, bothSidesInOneAccount } from './_shared.mjs';
+
+export default {
+  invariant: 'T-3',
+  title: 'both sides of one transfer sitting in the same account',
+  design: 'schema.sql transfer_same_account. transactions_transfer_two_accounts forbids a row pointing at its OWN account, which is a different rule and does not catch this',
+  consequence: 'the account shows a payment out and a payment in that cancel, described as a transfer to somewhere else — so a reconciliation against the statement finds two rows the bank never saw and no way to tell which to remove',
+  parity: 'not-comparable',
+  reason: 'verify_integrity is local-only — see the verb module for the trace',
+  skip: { postgres: 'there is no cloud counterpart to compare against' },
+
+  setup: bothSidesInOneAccount,
+  command: { verb: 'verify_integrity', payload: {} },
+  expect: { outcome: 'ok' },
+  result: {
+    ok: false,
+    violations: 2,
+    warnings: 0,
+    findings: [
+      {
+        check: 'transfer_same_account',
+        entity: 'transaction',
+        id: OTHER_LEG,
+        severity: 'violation',
+        detail: 'both sides of this transfer are in one account',
+      },
+      {
+        check: 'transfer_same_account',
+        entity: 'transaction',
+        id: THIS_LEG,
+        severity: 'violation',
+        detail: 'both sides of this transfer are in one account',
+      },
+    ],
+  },
+};

--- a/scripts/local-sqlite/verb-specs/integrity-t4-a-leg-and-its-counterpart-that-disagree.spec.mjs
+++ b/scripts/local-sqlite/verb-specs/integrity-t4-a-leg-and-its-counterpart-that-disagree.spec.mjs
@@ -1,0 +1,30 @@
+import { LEG_LINE, aLegAndACounterpartThatDisagree } from './_shared.mjs';
+
+export default {
+  invariant: 'T-4',
+  title: 'a split leg compared against its LINE, never against its parent',
+  design: 'schema.sql split_leg_amounts_not_opposite, the port of 20260720120000:15-17 — the rule the whole split-leg feature turns on',
+  consequence: 'a leg that does not cancel its counterpart moves money the split does not account for, and it does it inside a transaction whose own lines still sum correctly, so S-1 reports nothing',
+  parity: 'not-comparable',
+  reason: 'verify_integrity is local-only — see the verb module for the trace',
+  skip: { postgres: 'there is no cloud counterpart to compare against' },
+
+  // The subject is the LINE, not the transaction: this is the one check whose
+  // entity is `split_line`, and the whole point of T-4 is which of the two the
+  // amount is compared against.
+  setup: aLegAndACounterpartThatDisagree,
+  command: { verb: 'verify_integrity', payload: {} },
+  expect: { outcome: 'ok' },
+  result: {
+    ok: false,
+    violations: 1,
+    warnings: 0,
+    findings: [{
+      check: 'split_leg_amounts_not_opposite',
+      entity: 'split_line',
+      id: LEG_LINE,
+      severity: 'violation',
+      detail: 'a split leg and its counterpart are not exact opposites',
+    }],
+  },
+};

--- a/scripts/local-sqlite/verb-specs/integrity-t5-a-counterpart-the-line-ignores.spec.mjs
+++ b/scripts/local-sqlite/verb-specs/integrity-t5-a-counterpart-the-line-ignores.spec.mjs
@@ -1,0 +1,27 @@
+import { LEG_COUNTERPART, aCounterpartTheLineIgnores } from './_shared.mjs';
+
+export default {
+  invariant: 'T-5',
+  title: 'a row naming a split line that does not name it back',
+  design: 'schema.sql split_leg_link_not_mutual — the split-line half of T-1, and the pair legPairsAreMutual asserts on every split spec',
+  consequence: 'the counterpart renders as half of a split leg and the split renders as if nothing were linked, so the split writer will happily mint a SECOND counterpart for money that already moved once',
+  parity: 'not-comparable',
+  reason: 'verify_integrity is local-only — see the verb module for the trace',
+  skip: { postgres: 'there is no cloud counterpart to compare against' },
+
+  setup: aCounterpartTheLineIgnores,
+  command: { verb: 'verify_integrity', payload: {} },
+  expect: { outcome: 'ok' },
+  result: {
+    ok: false,
+    violations: 1,
+    warnings: 0,
+    findings: [{
+      check: 'split_leg_link_not_mutual',
+      entity: 'transaction',
+      id: LEG_COUNTERPART,
+      severity: 'violation',
+      detail: 'this row names a split line that does not name it back',
+    }],
+  },
+};

--- a/scripts/local-sqlite/verb-specs/prune-a-category-a-budget-measures-through-its-uuid-survives.spec.mjs
+++ b/scripts/local-sqlite/verb-specs/prune-a-category-a-budget-measures-through-its-uuid-survives.spec.mjs
@@ -1,0 +1,18 @@
+import {
+  EVERYDAY, PRUNABLE, budgetOnThePrunableByUuidAlone, prunablePair, setups,
+  balanceIdentityHolds, categoryPresent,
+} from './_shared.mjs';
+
+export default {
+  invariant: 'C-7',
+  title: 'a budget measuring the category through the uuid column alone DOES save it',
+  design: '20260713100000:344-348, `b.category = c.id::text OR b.category_id = c.id` — two columns, where the transaction check one clause earlier reads one',
+  consequence: 'a budget whose category is gone measures nothing and reports zero spent for ever, which reads exactly like an underspend. The pair of specs on either side of this one is what pins which reference kinds are protected and which are not',
+  parity: 'match',
+
+  setup: setups(prunablePair, budgetOnThePrunableByUuidAlone),
+  command: { verb: 'delete_unused_categories', payload: { ids: [PRUNABLE], user_id: null } },
+  expect: { outcome: 'ok' },
+  result: { deleted: 0 },
+  state: [categoryPresent(PRUNABLE, 'HERE'), balanceIdentityHolds(EVERYDAY)],
+};

--- a/scripts/local-sqlite/verb-specs/prune-a-category-a-schedule-still-names-survives.spec.mjs
+++ b/scripts/local-sqlite/verb-specs/prune-a-category-a-schedule-still-names-survives.spec.mjs
@@ -1,0 +1,24 @@
+import {
+  EVERYDAY, PRUNABLE, prunablePair, recurringOnTheSource, setups,
+  balanceIdentityHolds, categoryPresent,
+} from './_shared.mjs';
+
+export default {
+  invariant: 'C-7',
+  title: 'a recurring template saves its category — whoever owns the template',
+  design: '20260713100000:349-352. This clause has NO user filter, where the transaction and split clauses either side of it do. The migration\'s reasoning: a category id is a globally unique uuid, so matching on it alone can only reach rows that mean this category',
+  consequence: 'a scheduled payment whose category is gone would create rows filed under nothing, every month, silently, for as long as the schedule runs',
+  parity: 'match',
+
+  // MEASURED (probe-prune1.sh p-used-by-recurring-of-a-stranger): a template
+  // belonging to ANOTHER login still saves the category. The two engines
+  // genuinely disagree about what recurring_transactions.user_id IS — a Clerk id
+  // in the cloud, a users(id) uuid locally — which is exactly why the cloud
+  // matches on the category and not on the owner, and why this fixture's owner
+  // value is not load-bearing on either side.
+  setup: setups(prunablePair, recurringOnTheSource),
+  command: { verb: 'delete_unused_categories', payload: { ids: [PRUNABLE], user_id: null } },
+  expect: { outcome: 'ok' },
+  result: { deleted: 0 },
+  state: [categoryPresent(PRUNABLE, 'HERE'), balanceIdentityHolds(EVERYDAY)],
+};

--- a/scripts/local-sqlite/verb-specs/prune-a-category-a-split-line-is-filed-under-survives.spec.mjs
+++ b/scripts/local-sqlite/verb-specs/prune-a-category-a-split-line-is-filed-under-survives.spec.mjs
@@ -1,0 +1,22 @@
+import {
+  EVERYDAY, PRUNABLE, bothLinesUnderTheSource, prunablePair, setups,
+  balanceIdentityHolds, categoryPresent, splitSumHolds, CORNER_SHOP,
+} from './_shared.mjs';
+
+export default {
+  invariant: 'C-7',
+  title: 'a category a split LINE names is left alone — the clause 20260713100000 was written to add',
+  design: '20260713100000:340-343, and its own comment at :314-318: "the only change is the transaction_splits NOT EXISTS … deleting a category a split references would orphan that split line\'s categorisation permanently"',
+  consequence: 'a split line must carry a non-blank category by CHECK, so an orphaned one cannot even show as blank — it renders as a raw id belonging to no group, in a panel whose whole purpose is showing where the money went',
+  parity: 'match',
+
+  setup: setups(prunablePair, bothLinesUnderTheSource),
+  command: { verb: 'delete_unused_categories', payload: { ids: [PRUNABLE], user_id: null } },
+  expect: { outcome: 'ok' },
+  result: { deleted: 0 },
+  state: [
+    categoryPresent(PRUNABLE, 'HERE'),
+    splitSumHolds(CORNER_SHOP),
+    balanceIdentityHolds(EVERYDAY),
+  ],
+};

--- a/scripts/local-sqlite/verb-specs/prune-a-category-a-transaction-is-filed-under-survives.spec.mjs
+++ b/scripts/local-sqlite/verb-specs/prune-a-category-a-transaction-is-filed-under-survives.spec.mjs
@@ -1,0 +1,22 @@
+import {
+  CORNER_SHOP, EVERYDAY, PRUNABLE, filedUnderTheSource, prunablePair, setups,
+  balanceIdentityHolds, categoryPresent, filedAs,
+} from './_shared.mjs';
+
+export default {
+  invariant: 'C-7',
+  title: 'a category a transaction still names is left alone',
+  design: "20260713100000:336-339. The whole reason the RPC exists: the client plans from a snapshot that can be stale, and transactions.category is TEXT with no foreign key, so deleting a referenced category orphans that transaction's categorisation permanently",
+  consequence: 'a row filed under a category that no longer exists shows blank in the register and counts under nothing in every report, and nothing in the product can tell the user what it used to be',
+  parity: 'match',
+
+  setup: setups(prunablePair, filedUnderTheSource),
+  command: { verb: 'delete_unused_categories', payload: { ids: [PRUNABLE], user_id: null } },
+  expect: { outcome: 'ok' },
+  result: { deleted: 0 },
+  state: [
+    categoryPresent(PRUNABLE, 'HERE'),
+    filedAs(CORNER_SHOP, 'Food shopping/Food shopping'),
+    balanceIdentityHolds(EVERYDAY),
+  ],
+};

--- a/scripts/local-sqlite/verb-specs/prune-a-category-nothing-refers-to-goes.spec.mjs
+++ b/scripts/local-sqlite/verb-specs/prune-a-category-nothing-refers-to-goes.spec.mjs
@@ -1,0 +1,27 @@
+import {
+  EVERYDAY, PRUNABLE, prunablePair,
+  auditRowsInTotal, balanceIdentityHolds, categoryPresent, rowCount,
+} from './_shared.mjs';
+
+export default {
+  invariant: 'C-7',
+  title: 'an ordinary leaf nothing refers to is removed, and counted',
+  design: '20260713100000:320-363, the live definition. Recreated from 20260708160000 with one addition, the transaction_splits guard',
+  consequence: 'this is the "make my categories BE the Money set" import. If the prune does not work the user is left with two category trees merged into one list and no way to tell which half is theirs',
+  parity: 'match',
+
+  setup: prunablePair,
+  command: { verb: 'delete_unused_categories', payload: { ids: [PRUNABLE], user_id: null } },
+  expect: { outcome: 'ok' },
+  result: { deleted: 1 },
+  state: [
+    categoryPresent(PRUNABLE, 'GONE'),
+    rowCount('categories_left', 'categories', '6'),
+    // It audits NOTHING, on both engines. MEASURED (probe-prune1.sh
+    // p-plain-unused): the cloud writes no audit row here, and the port's module
+    // documentation carries the argument for why the local edition does not
+    // "fix" that.
+    auditRowsInTotal('0'),
+    balanceIdentityHolds(EVERYDAY),
+  ],
+};

--- a/scripts/local-sqlite/verb-specs/prune-a-category-only-the-uuid-column-names-is-not-saved.spec.mjs
+++ b/scripts/local-sqlite/verb-specs/prune-a-category-only-the-uuid-column-names-is-not-saved.spec.mjs
@@ -1,0 +1,26 @@
+import {
+  CORNER_SHOP, EVERYDAY, PRUNABLE, filedUnderThePrunableByUuidAlone, prunablePair, setups,
+  balanceIdentityHolds, categoryPresent, filedAs,
+} from './_shared.mjs';
+
+export default {
+  invariant: 'C-7',
+  title: 'the transaction check reads the TEXT column only — a uuid-only reference does not save it',
+  design: '20260713100000:336-339 reads `t.category = c.id::text` and nothing else, while the budget check two clauses later reads BOTH `b.category` and `b.category_id`. The asymmetry is in the cloud\'s own WHERE clause',
+  consequence: 'the category is deleted and the foreign key nulls the uuid column, so the row loses its filing silently and with no text left behind to say what it was — the one case in this family where even verify_integrity has nothing to report, because a NULL is not a dangler',
+  parity: 'match',
+
+  // MEASURED on both engines (probe-prune1.sh p-used-by-transaction-uuid-only,
+  // probe-prune-sqlite3.mjs c-used-by-transaction-uuid-only). Reproduced rather
+  // than fixed: a local port that also checked category_id would refuse a prune
+  // the cloud performs.
+  setup: setups(prunablePair, filedUnderThePrunableByUuidAlone),
+  command: { verb: 'delete_unused_categories', payload: { ids: [PRUNABLE], user_id: null } },
+  expect: { outcome: 'ok' },
+  result: { deleted: 1 },
+  state: [
+    categoryPresent(PRUNABLE, 'GONE'),
+    filedAs(CORNER_SHOP, 'NULL/NULL'),
+    balanceIdentityHolds(EVERYDAY),
+  ],
+};

--- a/scripts/local-sqlite/verb-specs/prune-a-child-outside-the-batch-keeps-its-parent-alive.spec.mjs
+++ b/scripts/local-sqlite/verb-specs/prune-a-child-outside-the-batch-keeps-its-parent-alive.spec.mjs
@@ -1,0 +1,22 @@
+import {
+  EVERYDAY, PRUNABLE, PRUNABLE_CHILD, prunableChild, prunablePair, setups,
+  balanceIdentityHolds, categoryPresent,
+} from './_shared.mjs';
+
+export default {
+  invariant: 'C-7',
+  title: 'a parent with a child the caller did not name is left where it is',
+  design: '20260713100000:353-358 — "a child that is NOT part of this batch keeps its parent alive", which blocks the parent_id CASCADE from killing rows the client never saw',
+  consequence: 'without it, one id in a stale plan takes an entire unseen subtree with it, and the user is left wondering where half their categories went',
+  parity: 'match',
+
+  setup: setups(prunablePair, prunableChild),
+  command: { verb: 'delete_unused_categories', payload: { ids: [PRUNABLE], user_id: null } },
+  expect: { outcome: 'ok' },
+  result: { deleted: 0 },
+  state: [
+    categoryPresent(PRUNABLE, 'HERE'),
+    categoryPresent(PRUNABLE_CHILD, 'HERE'),
+    balanceIdentityHolds(EVERYDAY),
+  ],
+};

--- a/scripts/local-sqlite/verb-specs/prune-a-parent-and-its-child-are-counted-as-two.spec.mjs
+++ b/scripts/local-sqlite/verb-specs/prune-a-parent-and-its-child-are-counted-as-two.spec.mjs
@@ -1,0 +1,33 @@
+import {
+  EVERYDAY, PRUNABLE, PRUNABLE_CHILD, prunableChild, prunablePair, setups,
+  balanceIdentityHolds, categoryPresent, rowCount,
+} from './_shared.mjs';
+
+export default {
+  invariant: 'C-7',
+  title: 'naming a parent and its child deletes two, and SAYS two',
+  design: '20260713100000:360-361, `GET DIAGNOSTICS v_count = ROW_COUNT`. Postgres decides which rows to delete from one snapshot and counts each of them',
+  consequence: 'the count is what the import summary shows the user. The same file, the same two rows gone, and a different number on the screen is the difference between "pruned 2" and a user counting their categories by hand to see what happened',
+  parity: 'match',
+
+  // THE ONE THING THE PORT COULD NOT DO THE CLOUD'S WAY. Spelled as SQLite's own
+  // single DELETE this answers 1, not 2: SQLite deletes the parent, the cascade
+  // removes the child, and the scan then finds the child already gone. MEASURED
+  // (probe-prune-sqlite.mjs s-child-inside-the-batch → 1, against the cloud's 2,
+  // with SIX categories left on both). The port qualifies the rows first and
+  // deletes them deepest-first so no cascade can pre-empt a row it is going to
+  // count — which is what makes this spec a match rather than a divergence.
+  setup: setups(prunablePair, prunableChild),
+  command: {
+    verb: 'delete_unused_categories',
+    payload: { ids: [PRUNABLE, PRUNABLE_CHILD], user_id: null },
+  },
+  expect: { outcome: 'ok' },
+  result: { deleted: 2 },
+  state: [
+    categoryPresent(PRUNABLE, 'GONE'),
+    categoryPresent(PRUNABLE_CHILD, 'GONE'),
+    rowCount('categories_left', 'categories', '6'),
+    balanceIdentityHolds(EVERYDAY),
+  ],
+};

--- a/scripts/local-sqlite/verb-specs/prune-a-to-from-category-named-on-its-own-is-skipped.spec.mjs
+++ b/scripts/local-sqlite/verb-specs/prune-a-to-from-category-named-on-its-own-is-skipped.spec.mjs
@@ -1,0 +1,27 @@
+import {
+  EVERYDAY, TO_FROM_EVERYDAY, namedTransferCategories, prunablePair,
+  balanceIdentityHolds, categoryPresent, transferCategoryCount,
+} from './_shared.mjs';
+
+export default {
+  invariant: 'C-7',
+  title: 'an account\'s To/From category is skipped before C-5 ever hears about it',
+  design: '20260713100000:335, `c.is_transfer_category IS NOT TRUE`, and C-5\'s protect trigger behind it (20260708140000:127-146)',
+  consequence: 'losing an account\'s To/From category takes the transfer bookkeeping for that account with it — the category every transfer verb resolves through is simply gone, and verify_integrity reports the account as unable to transfer at all',
+  parity: 'match',
+
+  // The interesting half is that C-5 is never consulted: the WHERE clause
+  // filters the row out before any DELETE is attempted, so the trigger stands
+  // down by not being reached. The spec that reaches it is the one where the
+  // To/From row arrives through a CASCADE instead.
+  setup: { sqlite: `${prunablePair.sqlite}\n${namedTransferCategories.sqlite}`,
+           postgres: `${prunablePair.postgres}\n${namedTransferCategories.postgres}` },
+  command: { verb: 'delete_unused_categories', payload: { ids: [TO_FROM_EVERYDAY], user_id: null } },
+  expect: { outcome: 'ok' },
+  result: { deleted: 0 },
+  state: [
+    categoryPresent(TO_FROM_EVERYDAY, 'HERE'),
+    transferCategoryCount('2'),
+    balanceIdentityHolds(EVERYDAY),
+  ],
+};

--- a/scripts/local-sqlite/verb-specs/prune-a-to-from-category-reached-by-cascade-refuses-the-whole-batch.spec.mjs
+++ b/scripts/local-sqlite/verb-specs/prune-a-to-from-category-reached-by-cascade-refuses-the-whole-batch.spec.mjs
@@ -1,0 +1,37 @@
+import {
+  EVERYDAY, PRUNABLE, TO_FROM_EVERYDAY, namedTransferCategories, prunablePair,
+  transferCategoryUnder, balanceIdentityHolds, categoryPresent, transferCategoryCount,
+} from './_shared.mjs';
+
+export default {
+  invariant: 'C-5',
+  title: 'the one shape that makes this verb raise — and the refusal is the FILE\'s, not the function\'s',
+  design: 'C-5 (20260708140000:127-146) meeting `parent_id ON DELETE CASCADE`. The To/From row is skipped by the function\'s own filter, but being IN the batch it no longer keeps its parent alive — so the parent is deleted and the cascade walks the protected row into a BEFORE DELETE trigger',
+  consequence: 'the alternative is worse in both directions: a cascade that succeeded would delete an account\'s transfer bookkeeping through a category the user never named, and a local port that swallowed the refusal would delete rows the cloud keeps',
+  parity: 'match',
+
+  // MEASURED on both engines before the port was written
+  // (probe-prune2.sh p2-parent-and-transfer-child-both-named,
+  // probe-prune-sqlite3.mjs c-parent-and-transfer-child). Both lose the WHOLE
+  // batch — the parent survives too — which is why the verb opens a transaction
+  // it can roll back rather than deleting row by row and hoping.
+  //
+  // No _rpc_guard flag stands C-5 down, and the port does not try: measured with
+  // the split guard held, the refusal is identical. It is a protection, not a
+  // nuisance.
+  setup: {
+    sqlite: `${prunablePair.sqlite}\n${namedTransferCategories.sqlite}\n${transferCategoryUnder(PRUNABLE, EVERYDAY).sqlite}`,
+    postgres: `${prunablePair.postgres}\n${namedTransferCategories.postgres}\n${transferCategoryUnder(PRUNABLE, EVERYDAY).postgres}`,
+  },
+  command: {
+    verb: 'delete_unused_categories',
+    payload: { ids: [PRUNABLE, TO_FROM_EVERYDAY], user_id: null },
+  },
+  expect: { outcome: 'refused', error: 'transfer_category_protected' },
+  state: [
+    categoryPresent(PRUNABLE, 'HERE'),
+    categoryPresent(TO_FROM_EVERYDAY, 'HERE'),
+    transferCategoryCount('2'),
+    balanceIdentityHolds(EVERYDAY),
+  ],
+};

--- a/scripts/local-sqlite/verb-specs/prune-a-type-root-is-skipped-rather-than-refused.spec.mjs
+++ b/scripts/local-sqlite/verb-specs/prune-a-type-root-is-skipped-rather-than-refused.spec.mjs
@@ -1,0 +1,15 @@
+import { EVERYDAY, OUTGOINGS, prunablePair, balanceIdentityHolds, categoryPresent } from './_shared.mjs';
+
+export default {
+  invariant: 'C-7',
+  title: 'a top-level heading is left where it is, and the call still succeeds',
+  design: "20260713100000:334, `c.level <> 'type'`. Every protection in this function is a WHERE clause; there is no RAISE in it at all",
+  consequence: 'a stale client plans a prune from a snapshot taken minutes ago. Refusing the batch because one id in it turned out to be a heading would lose the other two hundred deletions the user asked for and leave them to do it by hand',
+  parity: 'match',
+
+  setup: prunablePair,
+  command: { verb: 'delete_unused_categories', payload: { ids: [OUTGOINGS], user_id: null } },
+  expect: { outcome: 'ok' },
+  result: { deleted: 0 },
+  state: [categoryPresent(OUTGOINGS, 'HERE'), balanceIdentityHolds(EVERYDAY)],
+};

--- a/scripts/local-sqlite/verb-specs/prune-an-empty-list-is-an-answer-not-an-error.spec.mjs
+++ b/scripts/local-sqlite/verb-specs/prune-an-empty-list-is-an-answer-not-an-error.spec.mjs
@@ -1,0 +1,15 @@
+import { EVERYDAY, prunablePair, balanceIdentityHolds, rowCount } from './_shared.mjs';
+
+export default {
+  invariant: 'C-7',
+  title: 'nothing named, nothing deleted, nothing wrong',
+  design: '`id = ANY(\'{}\')` matches nothing and the function returns 0. MEASURED that a NULL array behaves identically (probe-prune1.sh p-null-array), which is why the local command takes an Option and treats absent, null and empty as one request',
+  consequence: 'the client already guards this (planningService.ts:506 returns 0 for an empty list) — and a verb whose behaviour depends on a caller remembering to guard it is a verb with a bug waiting for a second caller',
+  parity: 'match',
+
+  setup: prunablePair,
+  command: { verb: 'delete_unused_categories', payload: { ids: [], user_id: null } },
+  expect: { outcome: 'ok' },
+  result: { deleted: 0 },
+  state: [rowCount('categories_left', 'categories', '7'), balanceIdentityHolds(EVERYDAY)],
+};

--- a/scripts/local-sqlite/verb-specs/prune-naming-the-same-category-twice-removes-it-once.spec.mjs
+++ b/scripts/local-sqlite/verb-specs/prune-naming-the-same-category-twice-removes-it-once.spec.mjs
@@ -1,0 +1,15 @@
+import { EVERYDAY, PRUNABLE, prunablePair, balanceIdentityHolds, categoryPresent } from './_shared.mjs';
+
+export default {
+  invariant: 'C-7',
+  title: 'a repeated id is one deletion, not two',
+  design: '`id = ANY(p_ids)` matches each row once however many times its id appears in the array. The local port builds the same set through the shared distinct_ids',
+  consequence: 'the count is a promise about rows, not about the caller\'s list. A planner that emits a category twice — a detail reached through two groups, say — must not make the summary claim two deletions',
+  parity: 'match',
+
+  setup: prunablePair,
+  command: { verb: 'delete_unused_categories', payload: { ids: [PRUNABLE, PRUNABLE], user_id: null } },
+  expect: { outcome: 'ok' },
+  result: { deleted: 1 },
+  state: [categoryPresent(PRUNABLE, 'GONE'), balanceIdentityHolds(EVERYDAY)],
+};

--- a/scripts/local-sqlite/verb-specs/prune-somebody-elses-category-is-skipped-when-an-owner-is-named.spec.mjs
+++ b/scripts/local-sqlite/verb-specs/prune-somebody-elses-category-is-skipped-when-an-owner-is-named.spec.mjs
@@ -1,0 +1,18 @@
+import {
+  EVERYDAY, THEIR_CATEGORY, USER, prunablePair, secondUser, setups, strangersCategory,
+  balanceIdentityHolds, categoryPresent,
+} from './_shared.mjs';
+
+export default {
+  invariant: 'C-7',
+  title: 'with an owner named, another login\'s category is not this call\'s business',
+  design: '20260713100000:333, `p_user_id IS NULL OR c.user_id = p_user_id`. In the cloud RLS has already narrowed what the caller can see; the argument is the second lock',
+  consequence: 'a local file can hold more than one login — a restored backup, a shared machine — and a prune that reached across them would delete a category out of a tree its owner is still using',
+  parity: 'match',
+
+  setup: setups(prunablePair, secondUser, strangersCategory),
+  command: { verb: 'delete_unused_categories', payload: { ids: [THEIR_CATEGORY], user_id: USER } },
+  expect: { outcome: 'ok' },
+  result: { deleted: 0 },
+  state: [categoryPresent(THEIR_CATEGORY, 'HERE'), balanceIdentityHolds(EVERYDAY)],
+};

--- a/scripts/local-sqlite/verb-specs/prune-the-cascade-eats-a-child-the-check-would-have-saved.spec.mjs
+++ b/scripts/local-sqlite/verb-specs/prune-the-cascade-eats-a-child-the-check-would-have-saved.spec.mjs
@@ -1,0 +1,41 @@
+import {
+  CORNER_SHOP, EVERYDAY, PRUNABLE, PRUNABLE_CHILD, prunableChild, prunablePair, setups,
+  balanceIdentityHolds, categoryPresent, filedAs,
+} from './_shared.mjs';
+
+export default {
+  invariant: 'C-7',
+  title: 'the measured hole: a REFERENCED child dies with the parent that was named beside it',
+  design: 'the interaction of 20260713100000:336-339 (a referenced row is skipped) with :353-358 (a child IN the batch does not keep its parent alive) and `categories.parent_id ON DELETE CASCADE`',
+  consequence: '20260708160000\'s header promises that "a stale client can never destroy referenced data". It is FALSE in this shape, on BOTH engines: the child\'s own check skips it, the parent\'s check passes because the child is in the batch, and the cascade takes it anyway — leaving the transaction filed under an id nothing answers to',
+  parity: 'match',
+
+  // MEASURED on both engines (probe-prune1.sh p-cascade-eats-a-referenced-child,
+  // probe-prune-sqlite3.mjs c-cascade-eats-a-referenced-child) and reproduced
+  // rather than fixed, for the reason merge_categories gives about what it
+  // leaves behind: a port that tidied this would refuse a prune the cloud
+  // performs. What the local edition does instead is REPORT it —
+  // integrity-r3-a-transaction-filed-under-a-category-nothing-answers-to plants
+  // exactly this wreckage and reads it back.
+  //
+  // Note the count: ONE, not two. The child was removed by the cascade rather
+  // than by the statement, and neither engine counts it.
+  setup: {
+    sqlite: `${setups(prunablePair, prunableChild).sqlite}
+      UPDATE transactions SET category = '${PRUNABLE_CHILD}' WHERE id = '${CORNER_SHOP}';`,
+    postgres: `${setups(prunablePair, prunableChild).postgres}
+      UPDATE public.transactions SET category = '${PRUNABLE_CHILD}' WHERE id = '${CORNER_SHOP}';`,
+  },
+  command: {
+    verb: 'delete_unused_categories',
+    payload: { ids: [PRUNABLE, PRUNABLE_CHILD], user_id: null },
+  },
+  expect: { outcome: 'ok' },
+  result: { deleted: 1 },
+  state: [
+    categoryPresent(PRUNABLE, 'GONE'),
+    categoryPresent(PRUNABLE_CHILD, 'GONE'),
+    filedAs(CORNER_SHOP, `${PRUNABLE_CHILD}/NULL`),
+    balanceIdentityHolds(EVERYDAY),
+  ],
+};

--- a/scripts/local-sqlite/verb-specs/prune-the-flags-that-stop-a-merge-do-not-stop-this.spec.mjs
+++ b/scripts/local-sqlite/verb-specs/prune-the-flags-that-stop-a-merge-do-not-stop-this.spec.mjs
@@ -1,0 +1,24 @@
+import { EVERYDAY, PRUNABLE, prunablePair, balanceIdentityHolds, categoryPresent } from './_shared.mjs';
+
+export default {
+  invariant: 'C-7',
+  title: 'a revaluation category — which merge_categories refuses outright — is pruned without comment',
+  design: 'the protection list at 20260713100000:334-358 has TWO flag tests, level and is_transfer_category, and no more. merge_categories has five (20260805214322): system, revaluation, unassigned-bucket, transfer, type root',
+  consequence: 'the two verbs disagree about what a "built-in" category is, and only one of them is right. Recording the disagreement is what stops a future reader "fixing" the prune to match the merge and quietly refusing a Money-set import that has always worked',
+  parity: 'match',
+
+  // MEASURED for all three flags (probe-prune1.sh p-system-category,
+  // p-revaluation-category, p-unassigned-bucket): each is deleted. One spec
+  // rather than three, because the invariant is "the semantic flags are not part
+  // of this verb's protection list" and one flag proves it.
+  setup: {
+    sqlite: `${prunablePair.sqlite}
+      UPDATE categories SET is_revaluation_category = 1 WHERE id = '${PRUNABLE}';`,
+    postgres: `${prunablePair.postgres}
+      UPDATE public.categories SET is_revaluation_category = true WHERE id = '${PRUNABLE}';`,
+  },
+  command: { verb: 'delete_unused_categories', payload: { ids: [PRUNABLE], user_id: null } },
+  expect: { outcome: 'ok' },
+  result: { deleted: 1 },
+  state: [categoryPresent(PRUNABLE, 'GONE'), balanceIdentityHolds(EVERYDAY)],
+};

--- a/scripts/local-sqlite/verb-specs/prune-three-generations-named-together-are-counted-as-three.spec.mjs
+++ b/scripts/local-sqlite/verb-specs/prune-three-generations-named-together-are-counted-as-three.spec.mjs
@@ -1,0 +1,37 @@
+import {
+  EVERYDAY, PRUNABLE, PRUNABLE_CHILD, PRUNABLE_GRANDCHILD,
+  prunableChild, prunableGrandchild, prunablePair, setups,
+  balanceIdentityHolds, categoryPresent, rowCount,
+} from './_shared.mjs';
+
+export default {
+  invariant: 'C-7',
+  title: 'a whole branch named at once is counted branch, twig and leaf',
+  design: 'the same ROW_COUNT, one level deeper. The deepest-first ordering the local port uses has to hold for a chain, not just for a pair',
+  consequence: 'this is the shape a real "replace my categories" prune has — a group, its subs and their details, all named together — and the two-row case would pass a port that only handled one level',
+  parity: 'match',
+
+  // SQLite's own single DELETE answers 1 here (probe-prune-sqlite.mjs
+  // s-three-generations-all-named), against the cloud's 3.
+  //
+  // THIS is the spec that bites, and the two-row one beside it is not. Measured
+  // by breaking the port on purpose: with the depth sort removed and the
+  // qualifying rows deleted in plain id order, the parent-and-child spec still
+  // passes — the child's id happens to sort before the parent's, so id order IS
+  // deepest-first for that pair, by luck. Three generations answered 2 instead
+  // of 3 and failed loudly. A family that only tested the pair would have been
+  // asserting an accident.
+  setup: setups(prunablePair, prunableChild, prunableGrandchild),
+  command: {
+    verb: 'delete_unused_categories',
+    payload: { ids: [PRUNABLE, PRUNABLE_CHILD, PRUNABLE_GRANDCHILD], user_id: null },
+  },
+  expect: { outcome: 'ok' },
+  result: { deleted: 3 },
+  state: [
+    categoryPresent(PRUNABLE, 'GONE'),
+    categoryPresent(PRUNABLE_GRANDCHILD, 'GONE'),
+    rowCount('categories_left', 'categories', '6'),
+    balanceIdentityHolds(EVERYDAY),
+  ],
+};

--- a/scripts/local-sqlite/verb-specs/prune-with-no-owner-named-it-reaches-every-login.spec.mjs
+++ b/scripts/local-sqlite/verb-specs/prune-with-no-owner-named-it-reaches-every-login.spec.mjs
@@ -1,0 +1,18 @@
+import {
+  EVERYDAY, THEIR_CATEGORY, prunablePair, secondUser, setups, strangersCategory,
+  balanceIdentityHolds, categoryPresent,
+} from './_shared.mjs';
+
+export default {
+  invariant: 'C-7',
+  title: 'with NO owner named it reaches every login, and that is the cloud\'s behaviour too',
+  design: 'the same clause with p_user_id NULL: the guard stands down entirely. MEASURED on the reference cluster (probe-prune1.sh p-no-owner-named-reaches-everyone), where a stranger\'s category is deleted',
+  consequence: 'ported rather than tightened, for the reason user_financial_data_is_empty gives: in the cloud RLS makes the unscoped reading the same answer, and a local port that quietly required an owner would refuse calls the cloud performs. The lock is that the caller has to leave the argument out on purpose',
+  parity: 'match',
+
+  setup: setups(prunablePair, secondUser, strangersCategory),
+  command: { verb: 'delete_unused_categories', payload: { ids: [THEIR_CATEGORY] } },
+  expect: { outcome: 'ok' },
+  result: { deleted: 1 },
+  state: [categoryPresent(THEIR_CATEGORY, 'GONE'), balanceIdentityHolds(EVERYDAY)],
+};

--- a/scripts/local-sqlite/verb-specs/restore-a-figure-the-cloud-holds-and-this-file-cannot.spec.mjs
+++ b/scripts/local-sqlite/verb-specs/restore-a-figure-the-cloud-holds-and-this-file-cannot.spec.mjs
@@ -1,0 +1,34 @@
+import { USER, RESTORED_ROW, backupTransaction, chunk, wipedWithOneAccount } from './_shared.mjs';
+
+export default {
+  invariant: 'MONEY-5',
+  title: 'a backup may legally hold an amount this file refuses, and it is rejected with a message',
+  design: 'PHASE1-PLAN addendum §C. The cloud stores numeric(20,2) and goes to 1e18; schema.sql bounds a single amount at ±1e11 minor. MEASURED both ways: Postgres stores 1,000,000,000,000.00 without comment, SQLite raises transactions_amount_bounded',
+  consequence: 'the bound is not fussiness. SQLite\'s sum(INTEGER) RAISES at the int64 cliff where Postgres widens to numeric, so one absurd row leaves the account with NO computable balance rather than a wrong one — the whole aggregate is lost, not one number',
+  parity: 'divergent',
+  reason: 'The cloud has no per-row money bound and needs none; the local file has one and needs it. This is the import-path half of MONEY-5, and the obligation it discharges is that such a row is REJECTED WITH A MESSAGE naming it, never silently rescaled — rescaling money is inventing it.',
+
+  setup: wipedWithOneAccount,
+  command: {
+    verb: 'restore_user_chunk',
+    payload: {
+      chunks: [chunk('transactions', [backupTransaction({ amount: '1000000000000.00', type: 'income' })])],
+      user_id: USER,
+    },
+  },
+  expect: {
+    sqlite: { outcome: 'refused', error: 'restore_row_refused' },
+    postgres: { outcome: 'ok' },
+  },
+  state: [
+    {
+      name: 'the_absurd_row',
+      sqlite: `SELECT COALESCE((SELECT CAST(amount_minor / 100 AS TEXT) || '.'
+                 || substr('0' || CAST(abs(amount_minor) % 100 AS TEXT), -2, 2)
+                 FROM transactions WHERE id = '${RESTORED_ROW}'), 'REFUSED')`,
+      postgres: `SELECT COALESCE((SELECT amount::text FROM public.transactions
+                   WHERE id = '${RESTORED_ROW}'), 'REFUSED')`,
+      expect: { sqlite: 'REFUSED', postgres: '1000000000000.00' },
+    },
+  ],
+};

--- a/scripts/local-sqlite/verb-specs/restore-a-json-null-for-rows-is-refused.spec.mjs
+++ b/scripts/local-sqlite/verb-specs/restore-a-json-null-for-rows-is-refused.spec.mjs
@@ -1,0 +1,16 @@
+import { USER, wiped } from './_shared.mjs';
+
+export default {
+  invariant: 'X-7',
+  title: 'a JSON null for rows is refused, where an absent key is not',
+  design: '20260807083000:251-254. jsonb_typeof(\'null\'::jsonb) is the text \'null\', which is not \'array\'. MEASURED',
+  consequence: 'this is the case its sibling spec is contrasted against; the two together are what makes the hole in that guard visible rather than theoretical',
+  parity: 'match',
+
+  setup: wiped,
+  command: {
+    verb: 'restore_user_chunk',
+    payload: { chunks: [{ entity: 'accounts', rows: null }], user_id: USER },
+  },
+  expect: { outcome: 'refused', error: 'rows_not_an_array' },
+};

--- a/scripts/local-sqlite/verb-specs/restore-a-login-that-still-holds-data-is-refused.spec.mjs
+++ b/scripts/local-sqlite/verb-specs/restore-a-login-that-still-holds-data-is-refused.spec.mjs
@@ -1,0 +1,16 @@
+import { USER, backupAccount, chunk, rowCount } from './_shared.mjs';
+
+export default {
+  invariant: 'X-1',
+  title: 'a restore into a login that still holds data is refused before a row lands',
+  design: '20260807083000:260-266 — the precondition, checked when the entity is accounts, and accounts always lead the order',
+  consequence: 'the migration says it in one sentence: restoring on top would mix two datasets and silently re-date your history. It also kills three more hazards for free — the To/From category collision, the seeded default-category clash, and a repeated import',
+  parity: 'match',
+
+  command: {
+    verb: 'restore_user_chunk',
+    payload: { chunks: [chunk('accounts', [backupAccount()])], user_id: USER },
+  },
+  expect: { outcome: 'refused', error: 'restore_target_not_empty' },
+  state: [rowCount('accounts_now', 'accounts', '2')],
+};

--- a/scripts/local-sqlite/verb-specs/restore-a-missing-rows-key-slips-past-that-guard.spec.mjs
+++ b/scripts/local-sqlite/verb-specs/restore-a-missing-rows-key-slips-past-that-guard.spec.mjs
@@ -1,0 +1,17 @@
+import { USER, wiped } from './_shared.mjs';
+
+export default {
+  invariant: 'X-7',
+  title: 'a chunk with no rows key at all slips past the array guard and returns nothing',
+  design: '20260807083000:251-254. An absent key reaches the RPC as SQL NULL; jsonb_typeof(NULL) is NULL, NULL <> \'array\' is NULL, and plpgsql treats NULL as false — so the guard is skipped. MEASURED, into an emptied login: 0, no refusal',
+  consequence: 'a HOLE, ported rather than closed. Closing it locally would make the local edition refuse a call the cloud accepts, and a client that stopped sending a key would then fail on one engine only — which is worse than a call that quietly does nothing on both',
+  parity: 'match',
+
+  setup: wiped,
+  command: {
+    verb: 'restore_user_chunk',
+    payload: { chunks: [{ entity: 'accounts' }], user_id: USER },
+  },
+  expect: { outcome: 'ok' },
+  result: { inserted: 0 },
+};

--- a/scripts/local-sqlite/verb-specs/restore-a-row-whose-account-is-not-in-the-file-is-refused.spec.mjs
+++ b/scripts/local-sqlite/verb-specs/restore-a-row-whose-account-is-not-in-the-file-is-refused.spec.mjs
@@ -1,0 +1,23 @@
+import { USER, backupTransaction, chunk, wiped } from './_shared.mjs';
+
+export default {
+  invariant: 'R-12',
+  title: 'a transaction naming an account the file did not bring is refused by the ownership key',
+  design: '20260808170000 replaced transactions_account_id_fkey with a two-column key on (account_id, user_id), and schema.sql carries the twin. A restore inserts accounts before transactions precisely so that key resolves',
+  consequence: 'a ledger row filed against an account nobody has is a row whose money is in no balance — the exact defect the composite key was written to make impossible',
+  parity: 'match',
+
+  setup: wiped,
+  command: {
+    verb: 'restore_user_chunk',
+    payload: { chunks: [chunk('transactions', [backupTransaction()])], user_id: USER },
+  },
+  // Both engines refuse; only the wording differs. Postgres names
+  // transactions_account_id_user_fkey, SQLite says "FOREIGN KEY constraint
+  // failed" — SQLite does not name a key in its message, which is why the local
+  // refusal is wrapped with the entity and the row's own id instead.
+  expect: {
+    sqlite: { outcome: 'refused', error: 'restore_row_refused' },
+    postgres: { outcome: 'refused', error: 'transactions_account_id_user_fkey' },
+  },
+};

--- a/scripts/local-sqlite/verb-specs/restore-an-account-brings-its-own-transfer-category.spec.mjs
+++ b/scripts/local-sqlite/verb-specs/restore-an-account-brings-its-own-transfer-category.spec.mjs
@@ -1,0 +1,36 @@
+import { USER, RESTORED_ACCOUNT, backupAccount, chunk, wiped } from './_shared.mjs';
+
+export default {
+  invariant: 'C-3',
+  title: 'restoring an account mints no To/From category, because there is no anchor to hang one on',
+  design: '20260807083000:17-33 — the decision the whole file turns on. Inserting an account fires create_transfer_category_for_account, which mints a To/From category with a FRESH id; the backup already carries that category under its ORIGINAL id. The trigger returns early when there is no level=\'type\' Transfer anchor (20260708140000:53), and an empty login has none, so the collision class disappears rather than being worked around',
+  consequence: 'let the trigger fire and every transfer in the file points at a category that no longer exists — or the insert dies on categories_user_id_name_parent_id_key. No ordering avoids it while categories already exist, which is why the emptiness precondition is load-bearing rather than cautious',
+  parity: 'match',
+
+  setup: wiped,
+  command: {
+    verb: 'restore_user_chunk',
+    payload: { chunks: [chunk('accounts', [backupAccount()])], user_id: USER },
+  },
+  expect: { outcome: 'ok' },
+  result: { inserted: 1 },
+  state: [
+    {
+      // NONE, on both engines. The account is in, and the ground is clear for the
+      // categories chunk that follows to put the file's own To/From row back
+      // under the id every transaction already names.
+      name: 'transfer_categories_minted',
+      sqlite: `SELECT COALESCE((SELECT group_concat(id, ',') FROM categories
+                 WHERE account_id = '${RESTORED_ACCOUNT}'), 'NONE')`,
+      postgres: `SELECT COALESCE(string_agg(id::text, ','), 'NONE') FROM public.categories
+                   WHERE account_id = '${RESTORED_ACCOUNT}'`,
+      expect: 'NONE',
+    },
+    {
+      name: 'categories_anywhere',
+      sqlite: `SELECT COUNT(*) FROM categories WHERE user_id = '${USER}'`,
+      postgres: `SELECT COUNT(*) FROM public.categories WHERE user_id = '${USER}'`,
+      expect: '0',
+    },
+  ],
+};

--- a/scripts/local-sqlite/verb-specs/restore-an-empty-chunk-beats-the-emptiness-check.spec.mjs
+++ b/scripts/local-sqlite/verb-specs/restore-an-empty-chunk-beats-the-emptiness-check.spec.mjs
@@ -1,0 +1,17 @@
+import { USER, chunk, rowCount } from './_shared.mjs';
+
+export default {
+  invariant: 'X-1',
+  title: 'an empty chunk of accounts is accepted even though the login is full',
+  design: '20260807083000:256-266 — the length test comes BEFORE the precondition. MEASURED on the reference cluster',
+  consequence: 'a restore of a backup that happens to hold no accounts would otherwise be refused for a precondition it cannot violate',
+  parity: 'match',
+
+  command: {
+    verb: 'restore_user_chunk',
+    payload: { chunks: [chunk('accounts', [])], user_id: USER },
+  },
+  expect: { outcome: 'ok' },
+  result: { inserted: 0 },
+  state: [rowCount('accounts_now', 'accounts', '2')],
+};

--- a/scripts/local-sqlite/verb-specs/restore-an-empty-chunk-beats-the-entity-whitelist-too.spec.mjs
+++ b/scripts/local-sqlite/verb-specs/restore-an-empty-chunk-beats-the-entity-whitelist-too.spec.mjs
@@ -1,0 +1,16 @@
+import { USER, chunk } from './_shared.mjs';
+
+export default {
+  invariant: 'X-7',
+  title: 'an empty chunk of a table nobody has is accepted in silence',
+  design: '20260807083000:256-258 returns before the ELSIF ladder is reached. MEASURED: p_entity = "not_a_table" with [] returns 0 and raises nothing',
+  consequence: 'a surprise worth pinning rather than tidying: a client that invents an entity name is told nothing as long as it sends no rows, so the whitelist is not a spelling check',
+  parity: 'match',
+
+  command: {
+    verb: 'restore_user_chunk',
+    payload: { chunks: [chunk('not_a_table', [])], user_id: USER },
+  },
+  expect: { outcome: 'ok' },
+  result: { inserted: 0 },
+};

--- a/scripts/local-sqlite/verb-specs/restore-an-entity-nobody-has-is-refused-by-name.spec.mjs
+++ b/scripts/local-sqlite/verb-specs/restore-an-entity-nobody-has-is-refused-by-name.spec.mjs
@@ -1,0 +1,16 @@
+import { USER, chunk, wiped } from './_shared.mjs';
+
+export default {
+  invariant: 'X-7',
+  title: 'a table nobody has, with a row in it, is refused by name',
+  design: '20260807083000:366-368. p_entity is matched against a fixed list; there is no dynamic SQL on either engine',
+  consequence: 'a backup written by a newer version of the app, carrying a table this one does not have, must say so rather than dropping the rows',
+  parity: 'match',
+
+  setup: wiped,
+  command: {
+    verb: 'restore_user_chunk',
+    payload: { chunks: [chunk('not_a_table', [{ id: 'x' }])], user_id: USER },
+  },
+  expect: { outcome: 'refused', error: 'restore_entity_unknown' },
+};

--- a/scripts/local-sqlite/verb-specs/restore-every-row-is-re-owned-to-the-caller.spec.mjs
+++ b/scripts/local-sqlite/verb-specs/restore-every-row-is-re-owned-to-the-caller.spec.mjs
@@ -1,0 +1,31 @@
+import {
+  USER, STRANGER, RESTORED_ACCOUNT, backupAccount, chunk, wiped, storedBalances, updatedDay,
+} from './_shared.mjs';
+
+export default {
+  invariant: 'X-6',
+  title: 'a row exported by one login is restored owned by another',
+  design: '20260807083000:279-292 — every branch overwrites user_id with the caller. That is the whole point of a backup: "my account is gone, I made a new one, put my file back"',
+  consequence: 'a restored row still owned by the login that exported it is invisible to the person who restored it, and counted by every service-role aggregate over the account',
+  parity: 'match',
+
+  setup: wiped,
+  command: {
+    verb: 'restore_user_chunk',
+    payload: { chunks: [chunk('accounts', [backupAccount({ user_id: STRANGER })])], user_id: USER },
+  },
+  expect: { outcome: 'ok' },
+  result: { inserted: 1 },
+  state: [
+    {
+      name: 'stored_owner',
+      sqlite: `SELECT user_id FROM accounts WHERE id = '${RESTORED_ACCOUNT}'`,
+      postgres: `SELECT user_id::text FROM public.accounts WHERE id = '${RESTORED_ACCOUNT}'`,
+      expect: USER,
+    },
+    // X-8: the backup's own balance is restored verbatim and is authoritative.
+    storedBalances(RESTORED_ACCOUNT, '-25.00/0.00'),
+    // X-4, on the INSERT path: nothing re-dates a row nobody updated.
+    updatedDay('accounts', RESTORED_ACCOUNT, '2019-01-01'),
+  ],
+};

--- a/scripts/local-sqlite/verb-specs/restore-money-in-the-metadata-blob-is-lifted-into-its-own-column.spec.mjs
+++ b/scripts/local-sqlite/verb-specs/restore-money-in-the-metadata-blob-is-lifted-into-its-own-column.spec.mjs
@@ -1,0 +1,75 @@
+import { USER, RESTORED_ROW, backupTransaction, chunk, wipedWithOneAccount } from './_shared.mjs';
+
+export default {
+  invariant: 'MONEY-4',
+  title: 'the money a cloud backup keeps in a JSON blob is lifted into typed columns',
+  design: 'DESIGN.md §3.3 and §5 divergence 9 — "the one most likely to bite: it is a hard failure on real data". src/types/index.ts declares ten untyped `number` fields inside transferMetadata and six inside investmentData; transactions_no_money_in_metadata refuses eleven of them outright. MEASURED: the blob below is accepted by Postgres and raises that CHECK on SQLite unless the money comes out first',
+  consequence: 'without the lift, a real cloud backup cannot be restored at all — every wire transfer and every cross-currency row the MS Money importer wrote carries one of these keys',
+  parity: 'divergent',
+  reason: 'The cloud has no constraint on its metadata blob, so it stores the floats untouched and the figures stay untyped, unbounded and invisible to every report. The local file bans them by CHECK, so the restore promotes the four that have a typed home (fees, originalAmount, originalCurrency, exchangeRate) and REPORTS every one it drops. Nothing is lost in silence, which is the only part of this that is not negotiable.',
+
+  setup: wipedWithOneAccount,
+  command: {
+    verb: 'restore_user_chunk',
+    payload: {
+      chunks: [chunk('transactions', [backupTransaction({
+        description: 'Wire out',
+        metadata: {
+          transferMetadata: {
+            fees: '12.50',
+            originalAmount: '-30.00',
+            originalCurrency: 'EUR',
+            exchangeRate: '1.1234567891',
+            marketValue: '9.99',
+            transferType: 'wire',
+          },
+          reference: 'kept',
+        },
+      })])],
+      user_id: USER,
+    },
+  },
+  expect: { outcome: 'ok' },
+  result: { inserted: 1 },
+  rowDivergence: {
+    dropped: 'The cloud stores the blob whole, so it drops nothing and reports nothing. Locally marketValue belongs on the holding rather than on a transaction and has no column here, so it is thrown away — and said so, which is what this key is for.',
+  },
+  state: [
+    {
+      // The promoted figures, as integers this file can add up.
+      name: 'promoted_columns',
+      sqlite: `SELECT COALESCE(CAST(fee_minor AS TEXT), 'NONE') || '/'
+                 || COALESCE(CAST(original_amount_minor AS TEXT), 'NONE') || '/'
+                 || COALESCE(original_currency, 'NONE') || '/'
+                 || COALESCE(CAST(fx_rate_e10 AS TEXT), 'NONE')
+                 FROM transactions WHERE id = '${RESTORED_ROW}'`,
+      // The cloud has no such columns at all, which is the divergence stated as
+      // a value rather than as prose.
+      postgres: `SELECT 'NO SUCH COLUMNS' FROM public.transactions WHERE id = '${RESTORED_ROW}'`,
+      expect: { sqlite: '1250/-3000/EUR/11234567891', postgres: 'NO SUCH COLUMNS' },
+    },
+    {
+      // Everything non-numeric survives untouched on both engines: labels and
+      // references are not money and nothing here is entitled to lose them.
+      name: 'the_labels_survive',
+      sqlite: `SELECT json_extract(metadata, '$.reference') || '/'
+                 || json_extract(metadata, '$.transferMetadata.transferType')
+                 FROM transactions WHERE id = '${RESTORED_ROW}'`,
+      postgres: `SELECT (metadata->>'reference') || '/' || (metadata->'transferMetadata'->>'transferType')
+                   FROM public.transactions WHERE id = '${RESTORED_ROW}'`,
+      expect: 'kept/wire',
+    },
+    {
+      name: 'no_money_left_in_the_blob',
+      sqlite: `SELECT CASE WHEN json_extract(metadata, '$.transferMetadata.fees') IS NULL
+                            AND json_extract(metadata, '$.transferMetadata.marketValue') IS NULL
+                       THEN 'CLEAN' ELSE 'STILL THERE' END
+                 FROM transactions WHERE id = '${RESTORED_ROW}'`,
+      postgres: `SELECT CASE WHEN metadata->'transferMetadata'->'fees' IS NULL
+                              AND metadata->'transferMetadata'->'marketValue' IS NULL
+                         THEN 'CLEAN' ELSE 'STILL THERE' END
+                   FROM public.transactions WHERE id = '${RESTORED_ROW}'`,
+      expect: { sqlite: 'CLEAN', postgres: 'STILL THERE' },
+    },
+  ],
+};

--- a/scripts/local-sqlite/verb-specs/restore-rows-that-are-not-an-array-are-refused.spec.mjs
+++ b/scripts/local-sqlite/verb-specs/restore-rows-that-are-not-an-array-are-refused.spec.mjs
@@ -1,0 +1,16 @@
+import { USER, wiped } from './_shared.mjs';
+
+export default {
+  invariant: 'X-7',
+  title: 'a chunk whose rows are an object rather than an array is refused',
+  design: '20260807083000:251-254 — jsonb_typeof(p_rows) <> \'array\'',
+  consequence: 'a client that sends one row instead of a list of one would otherwise be answered with a type error from deep inside the insert',
+  parity: 'match',
+
+  setup: wiped,
+  command: {
+    verb: 'restore_user_chunk',
+    payload: { chunks: [{ entity: 'accounts', rows: {} }], user_id: USER },
+  },
+  expect: { outcome: 'refused', error: 'rows_not_an_array' },
+};

--- a/scripts/local-sqlite/verb-specs/restore-the-balance-in-the-file-is-the-balance-restored.spec.mjs
+++ b/scripts/local-sqlite/verb-specs/restore-the-balance-in-the-file-is-the-balance-restored.spec.mjs
@@ -1,0 +1,25 @@
+import {
+  USER, RESTORED_ACCOUNT, backupTransaction, chunk, wipedWithOneAccount, storedBalances,
+} from './_shared.mjs';
+
+export default {
+  invariant: 'X-8',
+  title: 'restoring a transaction moves no balance — the file\'s own figure is authoritative',
+  design: '20260807083000:54-61 — "Not balance-neutral, deliberately. No trigger maintains accounts.balance; it is a stored column written explicitly by each RPC, and inserting transactions moves nothing"',
+  consequence: 'recomputing from transactions would discard any balance reconciled against a statement, and would differ from the source wherever archived history sits behind an opening balance',
+  parity: 'match',
+
+  setup: wipedWithOneAccount,
+  command: {
+    verb: 'restore_user_chunk',
+    payload: { chunks: [chunk('transactions', [backupTransaction()])], user_id: USER },
+  },
+  expect: { outcome: 'ok' },
+  result: { inserted: 1 },
+  state: [
+    // −25.00 was already the account's balance and the restored row is −25.00.
+    // A balance-moving restore would leave −50.00 here, and B-1 would then be
+    // broken in the direction that looks like the user spent it twice.
+    storedBalances(RESTORED_ACCOUNT, '-25.00/0.00'),
+  ],
+};

--- a/scripts/local-sqlite/verb-specs/restore-the-flags-a-later-migration-added-travel-too.spec.mjs
+++ b/scripts/local-sqlite/verb-specs/restore-the-flags-a-later-migration-added-travel-too.spec.mjs
@@ -1,0 +1,38 @@
+import { USER, RESTORED_ROW, backupTransaction, chunk, wipedWithOneAccount } from './_shared.mjs';
+
+export default {
+  invariant: 'X-7',
+  title: 'is_cleared, category_confirmed and the statement ordinal all survive the round trip',
+  design: '20260807083000:40-52 — the restore takes WHOLE rows through jsonb_populate_recordset rather than a hand-kept column list, precisely so that a column added later is carried without anybody remembering to add it. These three arrived after the restore did: 20260807180000, 20260808100000, 20260808090000',
+  consequence: 'a restore that silently drops a column is worse than one that fails: reconciliation state, who vouched for a category, and the bank\'s own order within a day would all come back as defaults, and nothing would say so',
+  parity: 'match',
+
+  setup: wipedWithOneAccount,
+  command: {
+    verb: 'restore_user_chunk',
+    payload: {
+      chunks: [chunk('transactions', [backupTransaction({
+        is_cleared: true,
+        category_confirmed: false,
+        statement_sequence: 7,
+      })])],
+      user_id: USER,
+    },
+  },
+  expect: { outcome: 'ok' },
+  result: { inserted: 1 },
+  state: [
+    {
+      name: 'carried_columns',
+      sqlite: `SELECT CASE WHEN is_cleared = 1 THEN 'cleared' ELSE 'uncleared' END || '/'
+                 || CASE WHEN category_confirmed = 1 THEN 'vouched' ELSE 'guess' END || '/'
+                 || COALESCE(CAST(statement_sequence AS TEXT), 'NONE')
+                 FROM transactions WHERE id = '${RESTORED_ROW}'`,
+      postgres: `SELECT CASE WHEN is_cleared THEN 'cleared' ELSE 'uncleared' END || '/'
+                   || CASE WHEN category_confirmed THEN 'vouched' ELSE 'guess' END || '/'
+                   || COALESCE(statement_sequence::text, 'NONE')
+                   FROM public.transactions WHERE id = '${RESTORED_ROW}'`,
+      expect: 'cleared/guess/7',
+    },
+  ],
+};

--- a/scripts/local-sqlite/verb-specs/restore-the-ownership-pairing-holds-without-being-asked.spec.mjs
+++ b/scripts/local-sqlite/verb-specs/restore-the-ownership-pairing-holds-without-being-asked.spec.mjs
@@ -1,0 +1,50 @@
+import {
+  USER, STRANGER, RESTORED_ACCOUNT, RESTORED_ROW, backupTransaction, chunk, wipedWithOneAccount,
+} from './_shared.mjs';
+
+export default {
+  invariant: 'R-12',
+  title: 'a bundle exported by another login satisfies the new composite key trivially, and it is proved rather than assumed',
+  design: '20260808170000:439-443 — (account_id, user_id) REFERENCES accounts(id, user_id). The chunked restore predates that key, so whether its insert order still satisfies it was an open question. It does, for one reason: every branch re-owns EVERY row to the same caller (20260807083000:279-292), so the account and the transaction carry the same user_id by construction',
+  consequence: 'if a restore could land a row whose account belongs to somebody else, the composite key would refuse it mid-file and leave a half-restored login — and if it could NOT be refused, the key would be a rule the one bulk writer in the product routinely broke',
+  parity: 'match',
+
+  setup: wipedWithOneAccount,
+  command: {
+    verb: 'restore_user_chunk',
+    payload: {
+      // The row insists it belongs to the STRANGER; the account it names belongs
+      // to USER. Nothing in the payload pairs them.
+      chunks: [chunk('transactions', [backupTransaction({ user_id: STRANGER })])],
+      user_id: USER,
+    },
+  },
+  expect: { outcome: 'ok' },
+  result: { inserted: 1 },
+  state: [
+    {
+      name: 'the_pairing',
+      sqlite: `SELECT CASE WHEN t.user_id = a.user_id THEN 'PAIRED' ELSE 'CROSSED' END
+                 FROM transactions t JOIN accounts a ON a.id = t.account_id
+                WHERE t.id = '${RESTORED_ROW}'`,
+      postgres: `SELECT CASE WHEN t.user_id = a.user_id THEN 'PAIRED' ELSE 'CROSSED' END
+                   FROM public.transactions t JOIN public.accounts a ON a.id = t.account_id
+                  WHERE t.id = '${RESTORED_ROW}'`,
+      expect: 'PAIRED',
+    },
+    {
+      name: 'no_crossed_rows_anywhere',
+      sqlite: `SELECT COUNT(*) FROM transactions t JOIN accounts a ON a.id = t.account_id
+                WHERE t.user_id <> a.user_id`,
+      postgres: `SELECT COUNT(*) FROM public.transactions t JOIN public.accounts a ON a.id = t.account_id
+                  WHERE t.user_id <> a.user_id`,
+      expect: '0',
+    },
+    {
+      name: 'the_account_still_belongs_to_the_caller',
+      sqlite: `SELECT user_id FROM accounts WHERE id = '${RESTORED_ACCOUNT}'`,
+      postgres: `SELECT user_id::text FROM public.accounts WHERE id = '${RESTORED_ACCOUNT}'`,
+      expect: USER,
+    },
+  ],
+};

--- a/scripts/local-sqlite/verb-specs/restore-the-precondition-guards-accounts-and-nothing-else.spec.mjs
+++ b/scripts/local-sqlite/verb-specs/restore-the-precondition-guards-accounts-and-nothing-else.spec.mjs
@@ -1,0 +1,34 @@
+import { USER, EVERYDAY, RESTORED_ROW, backupTransaction, chunk } from './_shared.mjs';
+
+export default {
+  invariant: 'X-1',
+  title: 'a transactions chunk into a login that is full is NOT refused',
+  design: '20260807083000:262 — the precondition is `IF p_entity = \'accounts\' AND NOT …`, and nothing else consults it. MEASURED on the reference cluster: a transactions chunk sent into the base fixture gets past the check',
+  consequence: 'the precondition is only as strong as the CALLER\'S ORDERING. backupService.RESTORE_STEPS puts accounts first and says the migration depends on it; if it ever stopped doing so, every other entity would pour into a live login unopposed and this spec is what would say so',
+  parity: 'match',
+
+  // No wipe: the base fixture's two accounts, five categories and one
+  // transaction are all still there.
+  command: {
+    verb: 'restore_user_chunk',
+    payload: {
+      chunks: [chunk('transactions', [backupTransaction({
+        account_id: EVERYDAY,
+        description: 'Snuck in',
+        amount: '-1.00',
+        date: '2024-03-02',
+      })])],
+      user_id: USER,
+    },
+  },
+  expect: { outcome: 'ok' },
+  result: { inserted: 1 },
+  state: [
+    {
+      name: 'it_landed',
+      sqlite: `SELECT COUNT(*) FROM transactions WHERE id = '${RESTORED_ROW}'`,
+      postgres: `SELECT COUNT(*) FROM public.transactions WHERE id = '${RESTORED_ROW}'`,
+      expect: '1',
+    },
+  ],
+};

--- a/scripts/local-sqlite/verb-specs/restore-the-provider-ids-do-not-travel.spec.mjs
+++ b/scripts/local-sqlite/verb-specs/restore-the-provider-ids-do-not-travel.spec.mjs
@@ -1,0 +1,39 @@
+import { USER, RESTORED_ROW, backupTransaction, chunk, wipedWithOneAccount } from './_shared.mjs';
+
+export default {
+  invariant: 'X-5',
+  title: 'a restored transaction arrives with no feed identity at all',
+  design: '20260807083000:284-286 strips plaid_transaction_id, connection_id, external_transaction_id and external_provider. The first is GLOBALLY unique, so restoring it collides with whoever exported the file; connection_id points at bank_connections, which a backup deliberately does not carry because it holds credentials',
+  consequence: 'a restored row that still claims a feed identity would be deduped against a live feed it has no connection to, and would collide with the login the file came from',
+  parity: 'match',
+
+  setup: wipedWithOneAccount,
+  command: {
+    verb: 'restore_user_chunk',
+    payload: {
+      chunks: [chunk('transactions', [backupTransaction({
+        connection_id: 'c0ffee00-0000-0000-0000-000000000001',
+        external_transaction_id: 'feed-1',
+        external_provider: 'truelayer',
+        plaid_transaction_id: 'plaid-1',
+      })])],
+      user_id: USER,
+    },
+  },
+  expect: { outcome: 'ok' },
+  result: { inserted: 1 },
+  state: [
+    {
+      name: 'feed_identity',
+      sqlite: `SELECT COALESCE(external_transaction_id, 'STRIPPED') || '/'
+                 || COALESCE(external_provider, 'STRIPPED') || '/'
+                 || COALESCE(connection_id, 'STRIPPED')
+                 FROM transactions WHERE id = '${RESTORED_ROW}'`,
+      postgres: `SELECT COALESCE(external_transaction_id, 'STRIPPED') || '/'
+                   || COALESCE(external_provider, 'STRIPPED') || '/'
+                   || COALESCE(connection_id::text, 'STRIPPED')
+                   FROM public.transactions WHERE id = '${RESTORED_ROW}'`,
+      expect: 'STRIPPED/STRIPPED/STRIPPED',
+    },
+  ],
+};

--- a/scripts/local-sqlite/verb-specs/restore-the-transfer-links-wait-for-the-second-pass.spec.mjs
+++ b/scripts/local-sqlite/verb-specs/restore-the-transfer-links-wait-for-the-second-pass.spec.mjs
@@ -1,0 +1,35 @@
+import { USER, RESTORED_ROW, backupTransaction, chunk, wipedWithOneAccount } from './_shared.mjs';
+
+export default {
+  invariant: 'R-11',
+  title: 'a restored transaction arrives unlinked, whatever the file said',
+  design: '20260807083000:288-289 nulls linked_transfer_id and linked_transfer_split_id on the way in, because their constraints form cycles and none is DEFERRABLE in the cloud. finalize_user_restore puts them back',
+  consequence: 'without the deferral neither side of the cycle can be inserted first, so the restore would refuse the first transfer it met',
+  parity: 'match',
+
+  setup: wipedWithOneAccount,
+  command: {
+    verb: 'restore_user_chunk',
+    payload: {
+      chunks: [chunk('transactions', [backupTransaction({
+        linked_transfer_id: '70000000-0000-0000-0000-0000000000f2',
+        linked_transfer_split_id: '50000000-0000-0000-0000-0000000000f2',
+      })])],
+      user_id: USER,
+    },
+  },
+  expect: { outcome: 'ok' },
+  result: { inserted: 1 },
+  state: [
+    {
+      name: 'links_on_arrival',
+      sqlite: `SELECT COALESCE(linked_transfer_id, 'DEFERRED') || '/'
+                 || COALESCE(linked_transfer_split_id, 'DEFERRED')
+                 FROM transactions WHERE id = '${RESTORED_ROW}'`,
+      postgres: `SELECT COALESCE(linked_transfer_id::text, 'DEFERRED') || '/'
+                   || COALESCE(linked_transfer_split_id::text, 'DEFERRED')
+                   FROM public.transactions WHERE id = '${RESTORED_ROW}'`,
+      expect: 'DEFERRED/DEFERRED',
+    },
+  ],
+};

--- a/scripts/local-sqlite/verb-specs/restore-with-no-owner-is-refused-by-name.spec.mjs
+++ b/scripts/local-sqlite/verb-specs/restore-with-no-owner-is-refused-by-name.spec.mjs
@@ -1,0 +1,16 @@
+import { backupAccount, chunk, wiped } from './_shared.mjs';
+
+export default {
+  invariant: 'X-6',
+  title: 'a restore that cannot say which login it is for is refused first of all',
+  design: '20260807083000:245-249 — before the array test, before the precondition, before anything is read',
+  consequence: 'every row a restore writes is re-owned to the caller, so a caller with no identity would own the whole file',
+  parity: 'match',
+
+  setup: wiped,
+  command: {
+    verb: 'restore_user_chunk',
+    payload: { chunks: [chunk('accounts', [backupAccount()])] },
+  },
+  expect: { outcome: 'refused', error: 'owner_unknown' },
+};

--- a/scripts/local-sqlite/verb-specs/restore-writes-nothing-to-the-audit-log.spec.mjs
+++ b/scripts/local-sqlite/verb-specs/restore-writes-nothing-to-the-audit-log.spec.mjs
@@ -1,0 +1,25 @@
+import { USER, backupTransaction, chunk, wipedWithOneAccount } from './_shared.mjs';
+
+export default {
+  invariant: 'U-1',
+  title: 'a restore writes no per-row audit entry, and that is the departure it argues for',
+  design: '20260807083000:63-71 — "Restore writes ONE audit row for the whole operation, not one per transaction, departing from the per-row rule set out in 20260805214322 […] the honest answer for every row is identical and is a property of the operation, not the row". MEASURED: restore_user_chunk writes nothing at all; the single entry comes from finalize_user_restore',
+  consequence: 'fifty thousand rows each saying "a restore created me" would bury the entries that carry real information — which is the log\'s entire value',
+  parity: 'match',
+
+  setup: wipedWithOneAccount,
+  command: {
+    verb: 'restore_user_chunk',
+    payload: { chunks: [chunk('transactions', [backupTransaction()])], user_id: USER },
+  },
+  expect: { outcome: 'ok' },
+  result: { inserted: 1 },
+  state: [
+    {
+      name: 'audit_entries',
+      sqlite: `SELECT COUNT(*) FROM financial_audit_log WHERE user_id = '${USER}'`,
+      postgres: `SELECT COUNT(*) FROM public.financial_audit_log WHERE user_id = '${USER}'`,
+      expect: '0',
+    },
+  ],
+};

--- a/scripts/local-sqlite/verb-specs/snap-a-split-parent-in-the-account-is-irrelevant.spec.mjs
+++ b/scripts/local-sqlite/verb-specs/snap-a-split-parent-in-the-account-is-irrelevant.spec.mjs
@@ -1,0 +1,32 @@
+import { USER, EVERYDAY, splitWithTransferLeg, storedBalances } from './_shared.mjs';
+
+export default {
+  invariant: 'S-5',
+  title: 'a split parent in the account does not need a guard, and is proved not to',
+  design: 'The guard question is asked per verb and answered by running it. Every trg_protect_split_* trigger is BEFORE UPDATE OF a column on transactions; this is an UPDATE of accounts, so none of them is even consulted. MEASURED on both engines',
+  consequence: 'holding _rpc_guard(\'split\') here "just in case" would stand S-5 down for a write that never touches a split row — a protection weakened by a verb that had no use for it',
+  parity: 'match',
+
+  setup: splitWithTransferLeg,
+  command: {
+    verb: 'link_bank_account_snap',
+    payload: { account_id: EVERYDAY, user_id: USER, bank_balance: '10.00' },
+  },
+  expect: { outcome: 'ok' },
+  result: { balance: '10.00', initial_balance: '35.00' },
+  state: [
+    storedBalances(EVERYDAY, '10.00/35.00'),
+    {
+      name: 'the_guard_was_never_held',
+      sqlite: 'SELECT COUNT(*) FROM _rpc_guard',
+      postgres: "SELECT CASE WHEN current_setting('app.split_rpc', true) IN ('', '0') THEN 0 ELSE 1 END",
+      expect: '0',
+    },
+    {
+      name: 'the_split_is_untouched',
+      sqlite: `SELECT COUNT(*) FROM transaction_splits WHERE user_id = '${USER}'`,
+      postgres: `SELECT COUNT(*) FROM public.transaction_splits WHERE user_id = '${USER}'`,
+      expect: '2',
+    },
+  ],
+};

--- a/scripts/local-sqlite/verb-specs/snap-an-account-that-does-not-exist-is-refused-by-name.spec.mjs
+++ b/scripts/local-sqlite/verb-specs/snap-an-account-that-does-not-exist-is-refused-by-name.spec.mjs
@@ -1,0 +1,19 @@
+import { USER } from './_shared.mjs';
+
+export default {
+  invariant: 'B-4',
+  title: 'snapping an account nobody has is refused before anything is written',
+  design: '20260613090000:197-203',
+  consequence: 'the link handler passes an id straight from the provider\'s payload; an unmatched one must stop there rather than reaching an UPDATE that silently matches no rows',
+  parity: 'match',
+
+  command: {
+    verb: 'link_bank_account_snap',
+    payload: {
+      account_id: 'a0000000-0000-0000-0000-0000000000ee',
+      user_id: USER,
+      bank_balance: '100.00',
+    },
+  },
+  expect: { outcome: 'refused', error: 'account_not_found_or_not_owned' },
+};

--- a/scripts/local-sqlite/verb-specs/snap-an-account-that-is-not-yours-is-refused-by-name.spec.mjs
+++ b/scripts/local-sqlite/verb-specs/snap-an-account-that-is-not-yours-is-refused-by-name.spec.mjs
@@ -1,0 +1,26 @@
+import { USER, SOMEONE_ELSES_ACCOUNT, secondUser } from './_shared.mjs';
+
+export default {
+  invariant: 'B-4',
+  title: 'snapping somebody else\'s account is refused by the same name as one that does not exist',
+  design: '20260613090000:197-203 — SELECT … WHERE id = p_account_id AND user_id = p_user_id, then IF NOT FOUND. MEASURED: both cases give account_not_found_or_not_owned',
+  consequence: 'telling the two apart confirms an id exists to a caller who may not see it; and the snap is the one write in the schema that assigns an absolute balance, so it is the last place to be helpful about ids',
+  parity: 'match',
+
+  setup: secondUser,
+  command: {
+    verb: 'link_bank_account_snap',
+    payload: { account_id: SOMEONE_ELSES_ACCOUNT, user_id: USER, bank_balance: '100.00' },
+  },
+  expect: { outcome: 'refused', error: 'account_not_found_or_not_owned' },
+  state: [
+    {
+      name: 'their_balance_is_untouched',
+      sqlite: `SELECT (CAST(balance_minor / 100 AS TEXT) || '.'
+                 || substr('0' || CAST(abs(balance_minor) % 100 AS TEXT), -2, 2))
+                 FROM accounts WHERE id = '${SOMEONE_ELSES_ACCOUNT}'`,
+      postgres: `SELECT balance::text FROM public.accounts WHERE id = '${SOMEONE_ELSES_ACCOUNT}'`,
+      expect: '0.00',
+    },
+  ],
+};

--- a/scripts/local-sqlite/verb-specs/snap-money-may-not-arrive-as-a-json-number.spec.mjs
+++ b/scripts/local-sqlite/verb-specs/snap-money-may-not-arrive-as-a-json-number.spec.mjs
@@ -1,0 +1,29 @@
+import { USER, EVERYDAY } from './_shared.mjs';
+
+export default {
+  invariant: 'MONEY-1',
+  title: 'the bank\'s figure may not arrive as a JSON number',
+  design: 'crate::money — a JSON number is an IEEE-754 double by the time any parser has read it, so Money refuses one at the boundary. The cloud casts (p->>\'bank_balance\')::numeric, and ->> renders a JSON number as its own spelling, so it accepts either',
+  consequence: 'this figure is assigned to a balance ABSOLUTELY and shifts the opening balance by the same delta; a value that has been through a binary float on the way in would rebase the account to a number nobody sent',
+  parity: 'divergent',
+  reason: 'A DECLARED local strengthening, the same one crate::money makes everywhere else: the cloud accepts a JSON number because Postgres\'s ->> hands it to a numeric cast as text, and the local edition refuses it because there is no honest way to tell a double that has already lost a digit from one that has not. Both engines agree on the string form, which is what every caller in the product sends.',
+
+  command: {
+    verb: 'link_bank_account_snap',
+    payload: { account_id: EVERYDAY, user_id: USER, bank_balance: 10.0 },
+  },
+  expect: {
+    sqlite: { outcome: 'refused', error: 'amount_must_be_a_string' },
+    postgres: { outcome: 'ok' },
+  },
+  state: [
+    {
+      name: 'the_balance_afterwards',
+      sqlite: `SELECT ('-' || CAST(abs(balance_minor) / 100 AS TEXT) || '.'
+                 || substr('0' || CAST(abs(balance_minor) % 100 AS TEXT), -2, 2))
+                 FROM accounts WHERE id = '${EVERYDAY}'`,
+      postgres: `SELECT balance::text FROM public.accounts WHERE id = '${EVERYDAY}'`,
+      expect: { sqlite: '-25.00', postgres: '10.00' },
+    },
+  ],
+};

--- a/scripts/local-sqlite/verb-specs/snap-snapping-to-the-figure-it-already-has-moves-nothing.spec.mjs
+++ b/scripts/local-sqlite/verb-specs/snap-snapping-to-the-figure-it-already-has-moves-nothing.spec.mjs
@@ -1,0 +1,30 @@
+import { USER, EVERYDAY, storedBalances } from './_shared.mjs';
+
+export default {
+  invariant: 'B-1',
+  title: 'a snap to the balance the account already holds shifts nothing, and is still audited',
+  design: '20260613090000:205-216 — the arithmetic is unconditional and so is the audit write. MEASURED: initial_balance stays 0.00 and one audit row is still written',
+  consequence: 'the audit entry is what makes a rebase reconstructible later; making it conditional on movement would lose the record of the link itself, which is the event a person would be looking for',
+  parity: 'match',
+
+  command: {
+    verb: 'link_bank_account_snap',
+    payload: { account_id: EVERYDAY, user_id: USER, bank_balance: '-25.00' },
+  },
+  expect: { outcome: 'ok' },
+  result: { balance: '-25.00', initial_balance: '0.00' },
+  state: [
+    storedBalances(EVERYDAY, '-25.00/0.00'),
+    {
+      name: 'audited_anyway',
+      sqlite: `SELECT COUNT(*) || '/' || COALESCE(MIN(action), '-') || '/'
+                 || SUM(before_data IS NOT NULL) || '/' || SUM(after_data IS NOT NULL)
+                 FROM financial_audit_log WHERE user_id = '${USER}'`,
+      postgres: `SELECT COUNT(*) || '/' || COALESCE(MIN(action), '-') || '/'
+                   || COUNT(*) FILTER (WHERE before_data IS NOT NULL) || '/'
+                   || COUNT(*) FILTER (WHERE after_data IS NOT NULL)
+                   FROM public.financial_audit_log WHERE user_id = '${USER}'`,
+      expect: '1/update/1/1',
+    },
+  ],
+};

--- a/scripts/local-sqlite/verb-specs/snap-the-ledger-identity-survives-the-rebase.spec.mjs
+++ b/scripts/local-sqlite/verb-specs/snap-the-ledger-identity-survives-the-rebase.spec.mjs
@@ -1,0 +1,52 @@
+import { USER, EVERYDAY, storedBalances } from './_shared.mjs';
+
+export default {
+  invariant: 'B-1',
+  title: 'a snap moves the balance to the bank\'s figure and shifts the opening balance by the same delta',
+  design: '20260613090000:17-21 — "snap balance to the bank\'s figure and shift initial_balance by the same delta, so the invariant holds through the snap". MEASURED on the reference cluster: an account at −25.00 with one −25.00 row, snapped to 10.00, ends at balance 10.00 / initial 35.00, and B-1 holds',
+  consequence: 'this is why verbs/mod.rs can say set_account_balance does not exist while this function takes an absolute figure: it is a REBASE, not an override. Adding the same delta to both sides of balance = initial_balance + Σ(amount) leaves it true, and not one transaction is invented, moved or deleted to get there',
+  parity: 'match',
+
+  command: {
+    verb: 'link_bank_account_snap',
+    payload: { account_id: EVERYDAY, user_id: USER, bank_balance: '10.00' },
+  },
+  expect: { outcome: 'ok' },
+  result: { id: EVERYDAY, user_id: USER, name: 'Everyday', balance: '10.00', initial_balance: '35.00' },
+  state: [
+    storedBalances(EVERYDAY, '10.00/35.00'),
+    {
+      name: 'bank_balance_is_the_reference',
+      // Rendered as a decimal on the SQLite side so the two engines are compared
+      // on the FIGURE rather than on how each stores it — minor units against
+      // numeric(20,2) is a difference in scale, not in money.
+      sqlite: `SELECT (CASE WHEN bank_balance_minor < 0 THEN '-' ELSE '' END
+                 || CAST(abs(bank_balance_minor) / 100 AS TEXT) || '.'
+                 || substr('0' || CAST(abs(bank_balance_minor) % 100 AS TEXT), -2, 2))
+                 FROM accounts WHERE id = '${EVERYDAY}'`,
+      postgres: `SELECT bank_balance::text FROM public.accounts WHERE id = '${EVERYDAY}'`,
+      expect: '10.00',
+    },
+    {
+      // B-1 itself, computed rather than asserted: initial_balance + Σ(amount).
+      name: 'b1_holds',
+      sqlite: `SELECT CASE WHEN a.balance_minor = a.initial_balance_minor
+                      + COALESCE((SELECT SUM(t.amount_minor) FROM transactions t WHERE t.account_id = a.id), 0)
+                    THEN 'HOLDS' ELSE 'BROKEN' END FROM accounts a WHERE a.id = '${EVERYDAY}'`,
+      postgres: `SELECT CASE WHEN a.balance = a.initial_balance
+                        + COALESCE((SELECT SUM(t.amount) FROM public.transactions t WHERE t.account_id = a.id), 0)
+                      THEN 'HOLDS' ELSE 'BROKEN' END FROM public.accounts a WHERE a.id = '${EVERYDAY}'`,
+      expect: 'HOLDS',
+    },
+    {
+      // 20260807200000 added bank_balance_date so an old statement cannot
+      // overwrite a newer figure. The snap does not set it, MEASURED — that is
+      // the live behaviour, and a snap that dated its own figure would be a
+      // change to the cloud rather than a port of it.
+      name: 'the_snap_does_not_date_its_own_figure',
+      sqlite: `SELECT COALESCE(bank_balance_date, 'UNDATED') FROM accounts WHERE id = '${EVERYDAY}'`,
+      postgres: `SELECT COALESCE(bank_balance_date::text, 'UNDATED') FROM public.accounts WHERE id = '${EVERYDAY}'`,
+      expect: 'UNDATED',
+    },
+  ],
+};

--- a/scripts/local-sqlite/verb-specs/wipe-a-linked-transfer-does-not-stop-it.spec.mjs
+++ b/scripts/local-sqlite/verb-specs/wipe-a-linked-transfer-does-not-stop-it.spec.mjs
@@ -1,0 +1,21 @@
+import { USER, transferPair, rowCount } from './_shared.mjs';
+
+export default {
+  invariant: 'X-2',
+  title: 'a linked transfer pair does not stop a wipe — the defect this verb found',
+  design: 'schema.sql trg_unnest_account_references, widened 2026-08-08. It nulls transfer_account_id in a BEFORE DELETE trigger (SQLite has no ON DELETE SET NULL (column)), which left a linked row half-cleared for one statement — a state transactions_linked_has_target, a CHECK this schema has and the cloud does not, refuses',
+  consequence: 'before the fix, "delete everything" was refused outright on any file holding one linked transfer, which is every real file. No guard could have helped: the refusal was a CHECK, not a trigger',
+  parity: 'match',
+
+  setup: transferPair,
+  command: {
+    verb: 'wipe_user_financial_data',
+    payload: { confirm: 'DELETE EVERYTHING', user_id: USER },
+  },
+  expect: { outcome: 'ok' },
+  result: { accounts: 2, transactions: 0, categories: 3, budgets: 0, goals: 0, investments: 0 },
+  state: [
+    rowCount('accounts_left', 'accounts', '0'),
+    rowCount('transactions_left', 'transactions', '0'),
+  ],
+};

--- a/scripts/local-sqlite/verb-specs/wipe-a-split-transfer-leg-does-not-stop-it-either.spec.mjs
+++ b/scripts/local-sqlite/verb-specs/wipe-a-split-transfer-leg-does-not-stop-it-either.spec.mjs
@@ -1,0 +1,30 @@
+import { USER, splitWithTransferLeg, rowCount } from './_shared.mjs';
+
+export default {
+  invariant: 'R-5',
+  title: 'a split transfer leg does not stop a wipe — the guard the obligation predicted',
+  design: 'PHASE1-PLAN addendum §A named the wipe as one of the paths owing _rpc_guard(\'leg\'), before the verb existed. MEASURED: without it, DELETE FROM accounts raises split_leg_line_removed through the cascade into transaction_splits, and _rpc_guard(\'split\') does not help',
+  consequence: 'the commonest split shape in the owner\'s own imported data — 86 of 364 lines — would make the login unclearable, and therefore unrestorable',
+  parity: 'match',
+
+  setup: splitWithTransferLeg,
+  command: {
+    verb: 'wipe_user_financial_data',
+    payload: { confirm: 'DELETE EVERYTHING', user_id: USER },
+  },
+  expect: { outcome: 'ok' },
+  state: [
+    rowCount('accounts_left', 'accounts', '0'),
+    rowCount('splits_left', 'transaction_splits', '0'),
+    rowCount('transactions_left', 'transactions', '0'),
+    {
+      // The guard is the caller's, held for the length of one call and released
+      // before it returns. A stray flag would leave S-9 and S-10 standing down
+      // for every later write in the file.
+      name: 'the_guard_was_put_back',
+      sqlite: 'SELECT COUNT(*) FROM _rpc_guard',
+      postgres: "SELECT CASE WHEN current_setting('app.split_rpc', true) IN ('', '0') THEN 0 ELSE 1 END",
+      expect: '0',
+    },
+  ],
+};

--- a/scripts/local-sqlite/verb-specs/wipe-a-stranger-keeps-everything.spec.mjs
+++ b/scripts/local-sqlite/verb-specs/wipe-a-stranger-keeps-everything.spec.mjs
@@ -1,0 +1,30 @@
+import { USER, STRANGER, SOMEONE_ELSES_ACCOUNT, secondUser } from './_shared.mjs';
+
+export default {
+  invariant: 'X-6',
+  title: 'a wipe reaches exactly one login',
+  design: '20260807083000:180-207 — every DELETE is scoped by user_id. In the cloud RLS is a second gate; in a local file this predicate is the only one, which is why it is worth a spec of its own',
+  consequence: 'a household file, or a restored bundle that still carries another login\'s rows, would lose data belonging to somebody who did not ask for it',
+  parity: 'match',
+
+  setup: secondUser,
+  command: {
+    verb: 'wipe_user_financial_data',
+    payload: { confirm: 'DELETE EVERYTHING', user_id: USER },
+  },
+  expect: { outcome: 'ok' },
+  state: [
+    {
+      name: 'their_account_survives',
+      sqlite: `SELECT COUNT(*) FROM accounts WHERE id = '${SOMEONE_ELSES_ACCOUNT}'`,
+      postgres: `SELECT COUNT(*) FROM public.accounts WHERE id = '${SOMEONE_ELSES_ACCOUNT}'`,
+      expect: '1',
+    },
+    {
+      name: 'nothing_was_audited_against_them',
+      sqlite: `SELECT COUNT(*) FROM financial_audit_log WHERE user_id = '${STRANGER}'`,
+      postgres: `SELECT COUNT(*) FROM public.financial_audit_log WHERE user_id = '${STRANGER}'`,
+      expect: '0',
+    },
+  ],
+};

--- a/scripts/local-sqlite/verb-specs/wipe-accounts-go-first-so-the-categories-can-follow.spec.mjs
+++ b/scripts/local-sqlite/verb-specs/wipe-accounts-go-first-so-the-categories-can-follow.spec.mjs
@@ -1,0 +1,41 @@
+import { USER, rowCount } from './_shared.mjs';
+
+export default {
+  invariant: 'X-3',
+  title: 'accounts go first, and the counts report statements rather than consequences',
+  design: '20260807083000:179-207. Deleting categories while their accounts stand raises transfer_category_protected — MEASURED on both engines — so accounts lead and the To/From rows arrive at the protection with their account already gone',
+  consequence: 'the other order stalls the wipe half-done: some tables cleared, the categories refused, and no way through it from the UI',
+  parity: 'match',
+
+  command: {
+    verb: 'wipe_user_financial_data',
+    payload: { confirm: 'DELETE EVERYTHING', user_id: USER },
+  },
+  expect: { outcome: 'ok' },
+  // The numbers are the surprising part and they are surprising on BOTH engines,
+  // which is the point of asserting them: `transactions` is 0 because the account
+  // delete already cascaded the one row away, and `categories` is 3 rather than 5
+  // because the two To/From rows went with their accounts. Each field is an
+  // honest report of what ITS OWN statement deleted. SQLite's changes() and
+  // Postgres's ROW_COUNT both exclude rows moved by foreign keys and triggers, so
+  // neither engine had to be asked to agree.
+  result: {
+    accounts: 2,
+    transactions: 0,
+    categories: 3,
+    budgets: 0,
+    goals: 0,
+    investments: 0,
+  },
+  state: [
+    rowCount('accounts_left', 'accounts', '0'),
+    rowCount('transactions_left', 'transactions', '0'),
+    rowCount('categories_left', 'categories', '0'),
+    {
+      name: 'the_login_itself_survives',
+      sqlite: `SELECT COUNT(*) FROM users WHERE id = '${USER}'`,
+      postgres: `SELECT COUNT(*) FROM public.users WHERE id = '${USER}'`,
+      expect: '1',
+    },
+  ],
+};

--- a/scripts/local-sqlite/verb-specs/wipe-every-transaction-and-account-is-audited-before-it-goes.spec.mjs
+++ b/scripts/local-sqlite/verb-specs/wipe-every-transaction-and-account-is-audited-before-it-goes.spec.mjs
@@ -1,0 +1,38 @@
+import { USER } from './_shared.mjs';
+
+export default {
+  invariant: 'U-1',
+  title: 'a wipe is audited row by row, before the rows stop existing to describe',
+  design: '20260807083000:168-177 and its own reasoning at :70-71 — the restore writes ONE entry for the whole operation and the wipe writes one PER ROW, because here the per-row answer differs and it is the thing a user would later need to reconstruct',
+  consequence: 'a delete with no before-image is a delete nobody can undo or explain; the audit log is the only thing left that can say what was there',
+  parity: 'match',
+
+  command: {
+    verb: 'wipe_user_financial_data',
+    payload: { confirm: 'DELETE EVERYTHING', user_id: USER },
+  },
+  expect: { outcome: 'ok' },
+  state: [
+    {
+      // One transaction and two accounts, every one a delete, every one carrying
+      // what the row held. U-6: a delete has no `after`.
+      name: 'audit_shape',
+      sqlite: `SELECT COUNT(*) || '/' || SUM(action = 'delete') || '/'
+                 || SUM(before_data IS NOT NULL) || '/' || SUM(after_data IS NOT NULL)
+                 FROM financial_audit_log WHERE user_id = '${USER}'`,
+      postgres: `SELECT COUNT(*) || '/' || COUNT(*) FILTER (WHERE action = 'delete') || '/'
+                   || COUNT(*) FILTER (WHERE before_data IS NOT NULL) || '/'
+                   || COUNT(*) FILTER (WHERE after_data IS NOT NULL)
+                   FROM public.financial_audit_log WHERE user_id = '${USER}'`,
+      expect: '3/3/3/0',
+    },
+    {
+      name: 'audited_entities',
+      sqlite: `SELECT group_concat(entity, ',') FROM (
+                 SELECT entity FROM financial_audit_log WHERE user_id = '${USER}' ORDER BY entity, entity_id)`,
+      postgres: `SELECT string_agg(entity, ',' ORDER BY entity, entity_id::text)
+                   FROM public.financial_audit_log WHERE user_id = '${USER}'`,
+      expect: 'account,account,transaction',
+    },
+  ],
+};

--- a/scripts/local-sqlite/verb-specs/wipe-the-phrase-is-checked-before-the-owner.spec.mjs
+++ b/scripts/local-sqlite/verb-specs/wipe-the-phrase-is-checked-before-the-owner.spec.mjs
@@ -1,0 +1,10 @@
+export default {
+  invariant: 'X-2',
+  title: 'no phrase and no owner is told about the phrase, which is the half they can fix',
+  design: '20260807083000:157-166 — the confirmation test is the first statement in the function and the owner is resolved after it. MEASURED, all four pairs, on the reference cluster',
+  consequence: 'told about an identity problem instead, a user retypes their password; told about the phrase, they type the phrase',
+  parity: 'match',
+
+  command: { verb: 'wipe_user_financial_data', payload: { confirm: 'nope' } },
+  expect: { outcome: 'refused', error: 'wipe_not_confirmed' },
+};

--- a/scripts/local-sqlite/verb-specs/wipe-the-phrase-must-be-exact.spec.mjs
+++ b/scripts/local-sqlite/verb-specs/wipe-the-phrase-must-be-exact.spec.mjs
@@ -1,0 +1,16 @@
+import { USER, rowCount } from './_shared.mjs';
+
+export default {
+  invariant: 'X-2',
+  title: 'the confirmation phrase is compared exactly, and nothing goes without it',
+  design: '20260807083000:157-160 — IS DISTINCT FROM the literal DELETE EVERYTHING. localBackupService.LOCAL_WIPE_CONFIRMATION holds the same string "so both engines ask the same"',
+  consequence: 'a wipe erases every account, transaction, budget and goal in the login; a phrase the caller could supply on the user\'s behalf would make the user\'s typing theatre',
+  parity: 'match',
+
+  command: {
+    verb: 'wipe_user_financial_data',
+    payload: { confirm: 'delete everything', user_id: USER },
+  },
+  expect: { outcome: 'refused', error: 'wipe_not_confirmed' },
+  state: [rowCount('accounts_left', 'accounts', '2'), rowCount('transactions_left', 'transactions', '1')],
+};

--- a/scripts/local-sqlite/verb-specs/wipe-the-right-phrase-with-no-owner-is-refused-by-name.spec.mjs
+++ b/scripts/local-sqlite/verb-specs/wipe-the-right-phrase-with-no-owner-is-refused-by-name.spec.mjs
@@ -1,0 +1,10 @@
+export default {
+  invariant: 'X-2',
+  title: 'the right phrase and no owner is refused for the owner',
+  design: '20260807083000:162-166. In the cloud the owner falls back to requesting_user_id(); in a local file there is no session to ask, so the argument is the only source and its absence is the same refusal',
+  consequence: 'a wipe that could not establish whose data it was clearing would clear somebody\'s',
+  parity: 'match',
+
+  command: { verb: 'wipe_user_financial_data', payload: { confirm: 'DELETE EVERYTHING' } },
+  expect: { outcome: 'refused', error: 'owner_unknown' },
+};

--- a/scripts/local-sqlite/verbs.mjs
+++ b/scripts/local-sqlite/verbs.mjs
@@ -74,6 +74,24 @@ function canonicalise(row) {
   return canonical;
 }
 
+/**
+ * JSON with object keys in a stable order, arrays left alone.
+ *
+ * `judge` compares an expected value against a returned one by string equality,
+ * which for a nested object makes KEY ORDER load-bearing — and key order is not
+ * semantic in JSON. Without this, a spec asserting a `verify_integrity` finding
+ * fails with a diff whose two sides read identically, which is the worst kind of
+ * failure message. Arrays are NOT sorted: the order of `findings` is part of
+ * that verb's contract and a spec that gets it wrong must say so.
+ */
+function stableJson(value) {
+  if (Array.isArray(value)) return `[${value.map(stableJson).join(',')}]`;
+  if (value !== null && typeof value === 'object') {
+    return `{${Object.keys(value).sort().map((key) => `${JSON.stringify(key)}:${stableJson(value[key])}`).join(',')}}`;
+  }
+  return JSON.stringify(value);
+}
+
 function show(value) {
   return value === undefined ? '(absent)' : JSON.stringify(value);
 }
@@ -99,7 +117,7 @@ function judge(spec, engine, result) {
     for (const [field, expected] of Object.entries(spec.result ?? {})) {
       const wanted = forEngine(expected, engine);
       const got = result.row?.[field];
-      if (JSON.stringify(got) !== JSON.stringify(wanted)) {
+      if (stableJson(got) !== stableJson(wanted)) {
         problems.push(`result.${field}: expected ${show(wanted)}, got ${show(got)}`);
       }
     }
@@ -219,6 +237,10 @@ for (const spec of specs) {
   const problems = { sqlite: [], postgres: [] };
 
   for (const engine of ENGINES) {
+    // A DECLARED skip is not a failure and not a pass: the engine has nothing to
+    // run, said so in prose, and the spec's parity says "not-comparable". The
+    // loader has already refused any other combination.
+    if (spec.skip?.[engine] !== undefined) continue;
     try {
       results[engine] = (engine === 'sqlite' ? sqlite : postgres).run(spec);
     } catch (error) {
@@ -233,7 +255,14 @@ for (const spec of specs) {
   let parityOk = false;
   let parityNote = 'one engine only — parity not established';
   let parityLabel = 'n/a';
-  if (results.sqlite && results.postgres) {
+  if (spec.parity === 'not-comparable') {
+    // The one case where running a single engine is the whole point. It is
+    // still reported as what it is: an assertion about one engine, contributing
+    // nothing to the parity table.
+    parityOk = true;
+    parityLabel = 'not-comparable';
+    parityNote = `not-comparable (as declared) — ${spec.reason}`;
+  } else if (results.sqlite && results.postgres) {
     const observed = observedParity(spec, results);
     parityOk = observed.verdict === spec.parity;
     parityLabel = parityOk ? observed.verdict : `MISDECLARED (${observed.verdict})`;
@@ -250,7 +279,8 @@ for (const spec of specs) {
   out(`   ${spec.title}`);
   for (const engine of ENGINES) {
     const result = results[engine];
-    out(`   ${pad(engine, 10)} ${result ? summarise(result) : 'not run'}`);
+    const skipped = spec.skip?.[engine];
+    out(`   ${pad(engine, 10)} ${skipped ? `skipped   ${skipped}` : (result ? summarise(result) : 'not run')}`);
     for (const problem of problems[engine]) out(`   ${pad('', 10)} ✗ ${problem}`);
   }
   out(`   ${pad('parity', 10)} ${parityNote}`);
@@ -260,8 +290,8 @@ for (const spec of specs) {
   rows.push({
     invariant: spec.invariant,
     id: spec.id,
-    postgres: describe(results.postgres),
-    sqlite: describe(results.sqlite),
+    postgres: spec.skip?.postgres ? 'skipped: no counterpart' : describe(results.postgres),
+    sqlite: spec.skip?.sqlite ? 'skipped: no counterpart' : describe(results.sqlite),
     parity: parityLabel,
     ok: !specFailed,
   });
@@ -295,7 +325,12 @@ for (const row of rows) {
 }
 out('');
 const divergences = rows.filter((r) => r.parity === 'divergent').length;
-out(`${rows.length} verb specs · ${rows.length - failures} passed · ${failures} failed · ${errors} harness errors · ${divergences} declared divergences`);
+const singleEngine = rows.filter((r) => r.parity === 'not-comparable').length;
+out(
+  `${rows.length} verb specs · ${rows.length - failures} passed · ${failures} failed · ` +
+  `${errors} harness errors · ${divergences} declared divergences · ` +
+  `${singleEngine} single-engine (a verb the cloud does not have)`,
+);
 
 sqlite.close();
 process.exit(failures > 0 || errors > 0 ? 1 : 0);

--- a/src/components/QuickEditTransactionPanel.provenance.test.tsx
+++ b/src/components/QuickEditTransactionPanel.provenance.test.tsx
@@ -87,7 +87,7 @@ describe('QuickEditTransactionPanel — suggested categories', () => {
   });
 
   it('says "Suggested" in words, not only in colour', () => {
-    render(<QuickEditTransactionPanel transaction={suggested} onClose={vi.fn()} />);
+    render(<QuickEditTransactionPanel transaction={suggested} onDismiss={vi.fn()} />);
 
     // Colour alone would say nothing to anyone who cannot see it, and nothing
     // at all in a screenshot pasted into an email.
@@ -95,7 +95,7 @@ describe('QuickEditTransactionPanel — suggested categories', () => {
   });
 
   it('offers a one-click confirm that changes nothing but who vouched for it', async () => {
-    render(<QuickEditTransactionPanel transaction={suggested} onClose={vi.fn()} />);
+    render(<QuickEditTransactionPanel transaction={suggested} onDismiss={vi.fn()} />);
 
     fireEvent.click(screen.getByRole('button', { name: 'Confirm' }));
 
@@ -112,7 +112,7 @@ describe('QuickEditTransactionPanel — suggested categories', () => {
     render(
       <QuickEditTransactionPanel
         transaction={{ ...suggested, categoryConfirmed: true }}
-        onClose={vi.fn()}
+        onDismiss={vi.fn()}
       />
     );
 
@@ -129,13 +129,13 @@ describe('QuickEditTransactionPanel — suggested categories', () => {
     const noFlag: Transaction = { ...suggested };
     delete noFlag.categoryConfirmed;
 
-    render(<QuickEditTransactionPanel transaction={noFlag} onClose={vi.fn()} />);
+    render(<QuickEditTransactionPanel transaction={noFlag} onDismiss={vi.fn()} />);
 
     expect(screen.queryByText('Suggested')).not.toBeInTheDocument();
   });
 
   it('records a plain Save as confirmation — the user looked and let it stand', async () => {
-    render(<QuickEditTransactionPanel transaction={suggested} onClose={vi.fn()} />);
+    render(<QuickEditTransactionPanel transaction={suggested} onDismiss={vi.fn()} />);
 
     fireEvent.click(screen.getByRole('button', { name: 'Save' }));
 
@@ -148,7 +148,7 @@ describe('QuickEditTransactionPanel — suggested categories', () => {
   });
 
   it('drops the suggested styling the moment the user picks something else', () => {
-    render(<QuickEditTransactionPanel transaction={suggested} onClose={vi.fn()} />);
+    render(<QuickEditTransactionPanel transaction={suggested} onDismiss={vi.fn()} />);
 
     expect(screen.getByText('Suggested')).toBeInTheDocument();
 

--- a/src/components/QuickEditTransactionPanel.transfer.test.tsx
+++ b/src/components/QuickEditTransactionPanel.transfer.test.tsx
@@ -99,7 +99,7 @@ vi.mock('../hooks/useCurrencyDecimal', () => ({
 
 /** File the panel's transaction under the To/From Savings category and save. */
 async function fileUnderToFromSavings() {
-  render(<QuickEditTransactionPanel transaction={source} onClose={vi.fn()} />);
+  render(<QuickEditTransactionPanel transaction={source} onDismiss={vi.fn()} />);
 
   // Open the category picker and choose "To/From Savings"
   fireEvent.click(screen.getByRole('combobox', { name: 'Category' }));
@@ -151,7 +151,7 @@ describe('QuickEditTransactionPanel — transfer flow', () => {
   });
 
   it("rejects the source account's own To/From category", async () => {
-    render(<QuickEditTransactionPanel transaction={source} onClose={vi.fn()} />);
+    render(<QuickEditTransactionPanel transaction={source} onDismiss={vi.fn()} />);
 
     fireEvent.click(screen.getByRole('combobox', { name: 'Category' }));
     fireEvent.click(screen.getByText('To/From Current Account'));

--- a/src/components/QuickEditTransactionPanel.tsx
+++ b/src/components/QuickEditTransactionPanel.tsx
@@ -15,7 +15,15 @@ interface QuickEditTransactionPanelProps {
   transaction: Transaction;
   /** Advance the selection to the next transaction in the visible list. */
   onNext?: () => void;
-  onClose: () => void;
+  /**
+   * Close the box — Escape, or the × — leaving the row itself highlighted.
+   *
+   * The register hands the keyboard back to the grid when this fires, so the
+   * arrow keys carry on from the row that was being edited. Any unsaved
+   * keystrokes go with it: Escape means discard, and the box re-reads the
+   * stored transaction when it next opens.
+   */
+  onDismiss: () => void;
   /**
    * A request from the register — F2 — to put the cursor in the first field.
    *
@@ -26,27 +34,34 @@ interface QuickEditTransactionPanelProps {
   focusFirstField?: boolean;
   /** Called once the cursor has landed, so the caller can drop the request. */
   onFocusFirstFieldHandled?: () => void;
-  /**
-   * Escape in this bar hands the keyboard back to the register, which is
-   * still highlighting the row being edited. Without it, F2 is a one-way
-   * door: the way back to the arrow keys would be a mouse.
-   */
-  onReturnToGrid?: () => void;
 }
 
 /**
- * One-click batch editor: single-clicking a row in the account register pins
- * this condensed editor under the table — date, description, category, save —
- * so a fresh bank import can be categorised without opening the full modal
- * for every transaction. "Save & Next" walks straight down the list.
+ * The height of the whole box, in pixels — and the register's row maths
+ * depends on it being the truth.
+ *
+ * The box is drawn inside the virtualised transaction list, which positions
+ * rows by arithmetic rather than by measuring them: the row it belongs to is
+ * made exactly this much taller, and every row below is pushed down by exactly
+ * this much. So the box declares a fixed height and lays its one row of fields
+ * out inside it, rather than sizing to its content and hoping.
+ */
+export const QUICK_EDIT_BOX_HEIGHT = 88;
+
+/**
+ * Microsoft Money's inline transaction form: clicking a row in the register
+ * opens this box directly beneath THAT row — the rows below move down — with
+ * date, description, category and the actions on one line, so a fresh bank
+ * import can be worked through without opening the full editor for every
+ * transaction. Enter saves it, Escape closes it, "Save & Next" walks straight
+ * down the list.
  */
 export default function QuickEditTransactionPanel({
   transaction,
   onNext,
-  onClose,
+  onDismiss,
   focusFirstField = false,
   onFocusFirstFieldHandled,
-  onReturnToGrid,
 }: QuickEditTransactionPanelProps): React.JSX.Element {
   const {
     transactions,
@@ -68,6 +83,9 @@ export default function QuickEditTransactionPanel({
   // this is how F2 reaches it without the page reaching across into another
   // component's DOM by id.
   const dateFieldRef = useRef<HTMLDivElement>(null);
+  // Where the cursor goes once a category has been chosen; see the comment on
+  // handleCategoryChange.
+  const saveButtonRef = useRef<HTMLButtonElement>(null);
   // Money-style transfer flow: filing under a "To/From <account>" category
   // opens a match-or-create confirmation instead of a plain category write.
   const [transferPrompt, setTransferPrompt] = useState<{
@@ -102,20 +120,57 @@ export default function QuickEditTransactionPanel({
   }, [focusFirstField, onFocusFirstFieldHandled]);
 
   /**
-   * Escape gives the register its keys back.
+   * The two keys the box answers to.
    *
-   * defaultPrevented is the guard that makes Escape peel back one layer at a
-   * time: an open category menu or calendar answers its own Escape first (and
-   * says so by preventing the default), and only an Escape nothing else wanted
-   * means "I'm done down here".
+   * ENTER SAVES. That is the whole point of editing in the register rather
+   * than in a modal: change the category, press Enter, move on. Three things
+   * own Enter before this does, and each says so in its own way —
+   *
+   *   - an OPEN category list, where Enter chooses the highlighted option (it
+   *     prevents the default, so `defaultPrevented` catches it);
+   *   - the DATE field with its calendar open or a half-typed date, where
+   *     Enter settles it (likewise);
+   *   - a BUTTON, where Enter is the press. Save, Save & Next and Confirm all
+   *     do their own thing with it, and running this handler as well would
+   *     write the transaction twice in one keystroke.
+   *
+   * ESCAPE closes the box, one layer at a time. An open menu or calendar
+   * answers its own Escape first and stops it here; only an Escape nothing
+   * else wanted means "I'm done with this row" — and the register then takes
+   * the layer after that (a stretched selection, then the highlight itself).
    */
   const handleKeyDown = (e: React.KeyboardEvent<HTMLDivElement>): void => {
-    if (e.key !== 'Escape' || e.defaultPrevented) return;
-    // The transfer confirmation is a dialog of its own and owns its Escape.
+    if (e.key !== 'Escape' && e.key !== 'Enter') return;
+    if (e.defaultPrevented) return;
+    // The transfer confirmation is a dialog of its own and owns both keys.
     if (transferPrompt) return;
+
+    if (e.key === 'Escape') {
+      e.preventDefault();
+      e.stopPropagation();
+      onDismiss();
+      return;
+    }
+
+    if (e.target instanceof HTMLElement && e.target.closest('button')) return;
     e.preventDefault();
     e.stopPropagation();
-    onReturnToGrid?.();
+    void save(false);
+  };
+
+  /**
+   * A chosen category hands the cursor to Save.
+   *
+   * Without it the keyboard is simply LOST: the category box closes by
+   * unmounting its search field, and focus falls back to the document body,
+   * where neither Enter nor Escape reaches this box at all. Save is where it
+   * belongs anyway — it is what the user is about to do, it says so on the
+   * button, and it makes the owner's sentence true: pick a category, press
+   * Enter, saved.
+   */
+  const handleCategoryChange = (categoryId: string): void => {
+    setCategory(categoryId);
+    saveButtonRef.current?.focus();
   };
 
   const isTransfer = transaction.type === 'transfer';
@@ -274,18 +329,26 @@ export default function QuickEditTransactionPanel({
   return (
     // data-quick-edit-panel: the register's click-outside-to-deselect handler
     // treats clicks inside this panel as "keep the selection".
+    //
+    // The height is declared once (QUICK_EDIT_BOX_HEIGHT) and reserved by the
+    // register, because the virtualised list makes room by arithmetic rather
+    // than by measuring; the box then fills what it was given.
+    //
+    // It is drawn as the bottom half of the highlighted row's card: the same
+    // #6B86B3 border the register wears, square at the top and rounded at the
+    // foot, and pulled up by the 4px vertical margin the selected row carries
+    // (.selected-transaction-row) so the two meet rather than float apart.
     <div
       data-quick-edit-panel
       onKeyDown={handleKeyDown}
-      className="mt-3 bg-white dark:bg-gray-800 rounded-xl shadow-md border border-gray-100 dark:border-gray-700 px-4 py-3"
+      // h-full, not the constant again: the register hands this box a space of
+      // exactly QUICK_EDIT_BOX_HEIGHT and the box fills it, so there is one
+      // number in one place and no way for the two to disagree.
+      className="relative z-20 -mt-1 h-full flex items-center px-4 rounded-b-xl border-x border-b border-[#6B86B3]/60 bg-blue-50/80 dark:bg-blue-900/30 shadow-[0_10px_15px_-3px_rgba(0,0,0,0.12)]"
     >
-      <div className="flex flex-col lg:flex-row lg:items-end gap-3">
-        <div className="flex items-center gap-2 lg:hidden">
-          <span className="text-xs font-semibold text-gray-600 dark:text-gray-300">Quick edit</span>
-        </div>
-
+      <div className="flex w-full min-w-0 items-end gap-3">
         {/* Date */}
-        <div ref={dateFieldRef} className="w-full lg:w-40">
+        <div ref={dateFieldRef} className="w-40 shrink-0">
           <label htmlFor="quick-edit-date" className="block text-xs text-gray-500 dark:text-gray-400 mb-1">
             Date
           </label>
@@ -298,12 +361,17 @@ export default function QuickEditTransactionPanel({
             onChange={setDate}
             className="h-[42px] text-sm bg-white dark:bg-gray-700 border border-gray-300 dark:border-gray-600 rounded-xl dark:text-white"
             aria-label="Transaction date"
+            // The box sits INSIDE the transaction list, which clips what
+            // overflows it: an in-flow calendar would be cut off at the edge of
+            // the table, and worst of all near the foot — where the register
+            // opens, and where most of this work is done.
+            usePortal
           />
         </div>
 
         {/* Description — flex-1 like Category, so the two split the row's
             slack EQUALLY instead of Description hogging it. */}
-        <div className="w-full lg:flex-1 lg:min-w-0">
+        <div className="flex-1 min-w-0">
           <label htmlFor="quick-edit-description" className="block text-xs text-gray-500 dark:text-gray-400 mb-1">
             Description
           </label>
@@ -321,7 +389,7 @@ export default function QuickEditTransactionPanel({
             browse the full list. Both directions are offered (Money-style
             cross-type filing — a refund can file under the expense it refunds).
             flex-1 to match Description — the pair share the slack equally. */}
-        <div className="w-full lg:flex-1 lg:min-w-0">
+        <div className="flex-1 min-w-0">
           <span className="block text-xs text-gray-500 dark:text-gray-400 mb-1">
             Category
             {/* The shared badge (see SuggestedCategoryBadge): amber, the colour
@@ -353,55 +421,69 @@ export default function QuickEditTransactionPanel({
           ) : (
             <CategorySelector
               selectedCategory={category}
-              onCategoryChange={setCategory}
+              onCategoryChange={handleCategoryChange}
               transactionType={transaction.type}
               includeAllTypes
               showHelperText={false}
               placeholder="Search or select category…"
               allowClear
+              // Same reason as the calendar above: the list would be clipped by
+              // the table it is drawn inside.
+              usePortal
             />
           )}
         </div>
 
         {/* Actions */}
-        <div className="flex items-center gap-2">
-          {/* "Confirm" only appears when there is a guess to agree with, and it
-              sits FIRST because on a freshly imported row it is the action the
-              user wants nine times in ten. */}
-          {showingSuggestion && (
+        <div className="flex flex-col items-end gap-1">
+          <div className="flex items-center gap-2">
+            {/* "Confirm" only appears when there is a guess to agree with, and it
+                sits FIRST because on a freshly imported row it is the action the
+                user wants nine times in ten. */}
+            {showingSuggestion && (
+              <button
+                onClick={() => void confirmSuggestion()}
+                disabled={isSaving}
+                className="px-4 h-[42px] inline-flex items-center justify-center text-sm font-medium bg-amber-600 text-white rounded-xl hover:bg-amber-700 disabled:opacity-50 disabled:cursor-not-allowed whitespace-nowrap"
+                title="Agree with the suggested category — nothing else about the transaction changes"
+              >
+                Confirm
+              </button>
+            )}
             <button
-              onClick={() => void confirmSuggestion()}
+              ref={saveButtonRef}
+              onClick={() => void save(false)}
               disabled={isSaving}
-              className="px-4 h-[42px] inline-flex items-center justify-center text-sm font-medium bg-amber-600 text-white rounded-xl hover:bg-amber-700 disabled:opacity-50 disabled:cursor-not-allowed whitespace-nowrap"
-              title="Agree with the suggested category — nothing else about the transaction changes"
+              className="px-4 h-[42px] inline-flex items-center justify-center text-sm font-medium bg-[#1a2332] text-white rounded-xl hover:bg-secondary disabled:opacity-50 disabled:cursor-not-allowed whitespace-nowrap"
+              title="Save this transaction (Enter)"
             >
-              Confirm
+              {isSaving ? 'Saving…' : 'Save'}
             </button>
-          )}
-          <button
-            onClick={() => void save(false)}
-            disabled={isSaving}
-            className="px-4 h-[42px] inline-flex items-center justify-center text-sm font-medium bg-[#1a2332] text-white rounded-xl hover:bg-secondary disabled:opacity-50 disabled:cursor-not-allowed whitespace-nowrap"
-          >
-            {isSaving ? 'Saving…' : 'Save'}
-          </button>
-          {onNext && (
+            {onNext && (
+              <button
+                onClick={() => void save(true)}
+                disabled={isSaving}
+                className="px-4 h-[42px] inline-flex items-center justify-center text-sm font-medium bg-[#2d3a4d] text-white rounded-xl hover:bg-[#3a4a5f] disabled:opacity-50 disabled:cursor-not-allowed whitespace-nowrap"
+                title="Save and move to the next transaction in the list"
+              >
+                Save &amp; Next
+              </button>
+            )}
             <button
-              onClick={() => void save(true)}
-              disabled={isSaving}
-              className="px-4 h-[42px] inline-flex items-center justify-center text-sm font-medium bg-[#2d3a4d] text-white rounded-xl hover:bg-[#3a4a5f] disabled:opacity-50 disabled:cursor-not-allowed whitespace-nowrap"
-              title="Save and move to the next transaction in the list"
+              onClick={onDismiss}
+              className="p-1.5 text-gray-400 hover:text-gray-600 dark:hover:text-gray-300"
+              aria-label="Close quick edit"
+              title="Close this box (Esc) — the row stays highlighted"
             >
-              Save &amp; Next
+              <XIcon size={16} />
             </button>
-          )}
-          <button
-            onClick={onClose}
-            className="p-1.5 text-gray-400 hover:text-gray-600 dark:hover:text-gray-300"
-            aria-label="Close quick edit"
-          >
-            <XIcon size={16} />
-          </button>
+          </div>
+          {/* The two keys nobody would guess, said where they are used. The
+              printed shortcut list (? or View ▸ Keyboard shortcuts) carries the
+              rest; this is the one line that earns its width. */}
+          <span className="text-[11px] leading-none text-gray-500 dark:text-gray-400 pr-1">
+            Enter saves · Esc closes
+          </span>
         </div>
       </div>
 

--- a/src/components/RegisterShortcutsDialog.tsx
+++ b/src/components/RegisterShortcutsDialog.tsx
@@ -35,8 +35,9 @@ export default function RegisterShortcutsDialog({
       <ModalBody>
         <p className="text-sm text-gray-600 dark:text-gray-400 mb-5">
           These work while the transaction list itself has the keyboard — click any row
-          once, and it does. Typing in the search box, the add bar or the quick edit bar
-          is never interrupted.
+          once, and it does. Typing in the search box or the add bar is never
+          interrupted, and the quick edit box that opens under a clicked row keeps its
+          own two keys (below).
         </p>
 
         <div className="space-y-6">

--- a/src/components/VirtualizedList.tsx
+++ b/src/components/VirtualizedList.tsx
@@ -91,6 +91,15 @@ export const VirtualizedList = memo(function VirtualizedList<T>({
   onItemsRendered
 }: VirtualizedListProps<T>) {
   const listRef = useRef<List | VariableSizeList | null>(null);
+  /**
+   * The same list again, but only when it is the VARIABLE-height one.
+   *
+   * react-window caches every row's offset the first time it measures it, and
+   * only VariableSizeList can be told to forget (resetAfterIndex). Kept as its
+   * own typed ref rather than narrowing listRef, so the reset below is a plain
+   * call on a known type instead of a cast.
+   */
+  const variableListRef = useRef<VariableSizeList | null>(null);
   const plainContainerRef = useRef<HTMLDivElement | null>(null);
   const itemHeightMap = useRef<Map<number, number>>(new Map());
   
@@ -134,12 +143,25 @@ export const VirtualizedList = memo(function VirtualizedList<T>({
     return itemHeight;
   }, [itemHeight]);
   
-  // Reset height cache when items change
+  /**
+   * Forget every measured height when the heights themselves could have moved.
+   *
+   * Two things can move them: a different list of items, and a different
+   * itemHeight function (the register hands us a new one the moment its
+   * quick-edit box opens under a different row). Clearing the local cache is
+   * only half of it — react-window keeps its OWN offset table, and without
+   * resetAfterIndex the rows below a newly-taller row keep their old positions
+   * and paint on top of each other.
+   *
+   * Declared ABOVE the scroll effects on purpose: a render that both moves the
+   * box and asks for a row to be scrolled into view must re-measure first, or
+   * the scroll is computed against yesterday's geometry.
+   */
   useEffect(() => {
-    if (isVariableHeight) {
-      itemHeightMap.current.clear();
-    }
-  }, [items, isVariableHeight]);
+    if (!isVariableHeight) return;
+    itemHeightMap.current.clear();
+    variableListRef.current?.resetAfterIndex(0, true);
+  }, [items, isVariableHeight, itemHeight]);
   
   // Determine if we should enable virtual scrolling
   const shouldVirtualize = items.length > threshold;
@@ -252,6 +274,7 @@ export const VirtualizedList = memo(function VirtualizedList<T>({
                     // Handle both refs
                     if (list) {
                       listRef.current = list;
+                      variableListRef.current = list;
                       if (typeof ref === 'function') {
                         ref(list);
                       } else if (ref && 'current' in ref) {

--- a/src/components/VirtualizedTable.rowDetail.test.tsx
+++ b/src/components/VirtualizedTable.rowDetail.test.tsx
@@ -1,0 +1,150 @@
+import React from 'react';
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, within } from '@testing-library/react';
+import { VirtualizedTable, type Column, type RowDetail } from './VirtualizedTable';
+
+/**
+ * A row that carries something underneath it, in a list that is VIRTUALISED.
+ *
+ * This is the half of the inline quick-edit box that nothing else can prove.
+ * Above fifty rows — which is every real account — the register hands its rows
+ * to react-window, which positions them by arithmetic rather than by measuring
+ * the DOM: every row's top is the sum of the heights above it, cached the
+ * first time it is worked out. So there are exactly two ways to get this
+ * wrong, and both are silent:
+ *
+ *   1. not making the expanded row taller, so the box is painted over by the
+ *      row below it;
+ *   2. making it taller but never telling react-window to forget the offsets
+ *      it already cached, so the rows below keep their old positions — the box
+ *      overlaps them, and moving it to another row leaves a hole where it was.
+ *
+ * Both are read off here as the `top` react-window writes on each row.
+ *
+ * WHAT IS STOOD IN FOR: AutoSizer measures its parent, and jsdom performs no
+ * layout at all, so it would report 0×0 and react-window would render nothing.
+ * It is replaced with a fixed 800×400 viewport — the browser API, not any of
+ * the behaviour under test. What jsdom still cannot show is what the result
+ * LOOKS like; that is named in the handover as a browser check.
+ */
+
+vi.mock('react-virtualized-auto-sizer', () => ({
+  default: ({ children }: { children: (size: { height: number; width: number }) => React.ReactNode }) =>
+    children({ height: 400, width: 800 }),
+}));
+
+interface Row {
+  id: string;
+  label: string;
+}
+
+const ROW_HEIGHT = 40;
+const DETAIL_HEIGHT = 100;
+
+/** Sixty rows — comfortably over the register's own fifty-row threshold. */
+const ROWS: Row[] = Array.from({ length: 60 }, (_, i) => ({
+  id: `row-${String(i).padStart(2, '0')}`,
+  label: `Synthetic row ${String(i).padStart(2, '0')}`,
+}));
+
+const COLUMNS: Column<Row>[] = [
+  { key: 'label', header: 'Label', accessor: (row) => <span>{row.label}</span> },
+];
+
+const rowDomId = (key: string): string => `test-row-${key}`;
+
+const detailFor = (index: number): RowDetail<Row> => ({
+  key: ROWS[index].id,
+  height: DETAIL_HEIGHT,
+  render: () => <div data-testid="row-detail">the box</div>,
+});
+
+const renderTable = (rowDetail: RowDetail<Row> | null) =>
+  render(
+    <VirtualizedTable
+      items={ROWS}
+      columns={COLUMNS}
+      getItemKey={(row: Row) => row.id}
+      rowDomId={rowDomId}
+      rowHeight={ROW_HEIGHT}
+      threshold={50}
+      rowDetail={rowDetail}
+    />
+  );
+
+/** Where react-window has placed the row with this index, in px from the top. */
+const topOf = (index: number): number => {
+  const row = document.getElementById(rowDomId(ROWS[index].id));
+  if (!row) throw new Error(`row ${index} is not rendered`);
+  // A row carrying a detail is wrapped (the wrapper owns react-window's slot),
+  // so the positioned element is the row's parent in that one case.
+  const positioned = row.style.top === '' ? row.parentElement : row;
+  const top = positioned?.style.top ?? '';
+  if (!top.endsWith('px')) throw new Error(`row ${index} has no position: "${top}"`);
+  return Number.parseFloat(top);
+};
+
+describe('VirtualizedTable — a row with an editor under it, virtualised', () => {
+  it('renders no detail, and evenly spaced rows, when nothing is expanded', () => {
+    renderTable(null);
+
+    expect(screen.queryByTestId('row-detail')).not.toBeInTheDocument();
+    expect(topOf(0)).toBe(0);
+    expect(topOf(1)).toBe(ROW_HEIGHT);
+    expect(topOf(4)).toBe(4 * ROW_HEIGHT);
+  });
+
+  it('pushes every row below the expanded one down by exactly the detail height', () => {
+    renderTable(detailFor(2));
+
+    expect(screen.getByTestId('row-detail')).toBeInTheDocument();
+    // Everything above is untouched…
+    expect(topOf(1)).toBe(ROW_HEIGHT);
+    expect(topOf(2)).toBe(2 * ROW_HEIGHT);
+    // …and everything below has moved down by the box, not by a guess at it.
+    expect(topOf(3)).toBe(3 * ROW_HEIGHT + DETAIL_HEIGHT);
+    expect(topOf(4)).toBe(4 * ROW_HEIGHT + DETAIL_HEIGHT);
+  });
+
+  it('moves the gap with the box when the box moves to another row', () => {
+    const { rerender } = renderTable(detailFor(2));
+    expect(topOf(3)).toBe(3 * ROW_HEIGHT + DETAIL_HEIGHT);
+
+    // Save & Next, in effect: the same list, the box one row further down.
+    rerender(
+      <VirtualizedTable
+        items={ROWS}
+        columns={COLUMNS}
+        getItemKey={(row: Row) => row.id}
+        rowDomId={rowDomId}
+        rowHeight={ROW_HEIGHT}
+        threshold={50}
+        rowDetail={detailFor(5)}
+      />
+    );
+
+    // The hole where the box WAS has closed…
+    expect(topOf(3)).toBe(3 * ROW_HEIGHT);
+    expect(topOf(4)).toBe(4 * ROW_HEIGHT);
+    expect(topOf(5)).toBe(5 * ROW_HEIGHT);
+    // …and opened where the box now is. Without react-window being told to
+    // forget its cached offsets, these two are the assertions that fail.
+    expect(topOf(6)).toBe(6 * ROW_HEIGHT + DETAIL_HEIGHT);
+    expect(topOf(7)).toBe(7 * ROW_HEIGHT + DETAIL_HEIGHT);
+  });
+
+  it('keeps the detail out of the row it belongs to, and next to it', () => {
+    renderTable(detailFor(2));
+
+    const rows = screen.getAllByRole('row');
+    const transactionRow = document.getElementById(rowDomId(ROWS[2].id));
+    const detailRow = screen.getByTestId('row-detail').closest('[role="row"]');
+
+    // Two rows, not one: the transaction's cells stay the transaction's, and
+    // the box gets a row of its own holding a single cell. A form nested
+    // inside a row of gridcells would be a structure nothing can read.
+    expect(detailRow).not.toBe(transactionRow);
+    expect(rows.indexOf(detailRow as HTMLElement)).toBe(rows.indexOf(transactionRow as HTMLElement) + 1);
+    expect(within(detailRow as HTMLElement).getByRole('gridcell')).toBeInTheDocument();
+  });
+});

--- a/src/components/VirtualizedTable.tsx
+++ b/src/components/VirtualizedTable.tsx
@@ -13,6 +13,26 @@ export interface Column<T> {
   resizable?: boolean;
 }
 
+/**
+ * An editor (or anything else) drawn immediately BENEATH one row, inside the
+ * list, displacing every row below it — Microsoft Money's inline transaction
+ * form, and the shape the register's quick edit takes.
+ *
+ * The three fields travel together on purpose: a key with no height would leave
+ * the virtualised list doing its row maths against a row it cannot measure.
+ * `height` is therefore a NUMBER of pixels, and the detail must honour it —
+ * react-window positions rows by arithmetic, not by measuring the DOM, so a
+ * detail that grew taller than it declared would be painted over by the row
+ * beneath it.
+ */
+export interface RowDetail<T> {
+  /** The key (see getItemKey) of the row the detail hangs beneath. */
+  key: string;
+  /** Exactly how tall the detail is, in px. */
+  height: number;
+  render: (item: T) => ReactNode;
+}
+
 export interface VirtualizedTableProps<T> {
   items: T[];
   columns: Column<T>[];
@@ -52,6 +72,8 @@ export interface VirtualizedTableProps<T> {
    * markup is byte-for-byte what it was.
    */
   rowDomId?: (rowKey: string) => string;
+  /** See RowDetail — an editor drawn under one row, pushing the rest down. */
+  rowDetail?: RowDetail<T> | null;
 }
 
 // Table header component
@@ -250,7 +272,8 @@ const VirtualizedTableComponent = memo(function VirtualizedTable<T>({
   scrollToKey,
   scrollToAlign,
   scrollToBottomToken,
-  rowDomId
+  rowDomId,
+  rowDetail
 }: VirtualizedTableProps<T>) {
   // Resolve the deep-link key to its position in the CURRENT row order, so
   // the list can centre it regardless of sort or filters.
@@ -259,6 +282,31 @@ const VirtualizedTableComponent = memo(function VirtualizedTable<T>({
     const index = items.findIndex((item, i) => getItemKey(item, i) === scrollToKey);
     return index >= 0 ? index : undefined;
   }, [items, getItemKey, scrollToKey]);
+
+  // Which row is carrying the detail right now, or -1 for none. Resolved
+  // against the CURRENT order, like the scroll target above, so a re-sort moves
+  // the detail with its row rather than stranding it on whatever now sits at
+  // that position.
+  const detailIndex = useMemo(() => {
+    if (!rowDetail) return -1;
+    return items.findIndex((item, i) => getItemKey(item, i) === rowDetail.key);
+  }, [items, getItemKey, rowDetail]);
+
+  /**
+   * The height of each row: the ordinary one, plus the detail on the one row
+   * that carries it.
+   *
+   * A plain number while nothing is expanded, so the list stays on
+   * react-window's FixedSizeList — cheaper, and the path every other table
+   * here uses. A new function identity whenever the expanded row moves, which
+   * is what tells VirtualizedList to make react-window forget its cached row
+   * offsets.
+   */
+  const itemHeight = useMemo<number | ((index: number) => number)>(() => {
+    if (detailIndex < 0 || !rowDetail) return rowHeight;
+    const detailHeight = rowDetail.height;
+    return (index: number): number => (index === detailIndex ? rowHeight + detailHeight : rowHeight);
+  }, [detailIndex, rowDetail, rowHeight]);
 
   // Memoize row renderer
   const renderRow = useCallback((item: T, index: number, style: React.CSSProperties) => {
@@ -288,6 +336,8 @@ const VirtualizedTableComponent = memo(function VirtualizedTable<T>({
       ? rowClassName(item, index) 
       : rowClassName || '';
 
+    const detail = rowDetail && index === detailIndex ? rowDetail.render(item) : null;
+
     const baseRowClass = 'flex items-center border-b border-gray-200 dark:border-gray-700 transition-colors duration-150';
     const clickableClass = onRowClick ? 'cursor-pointer select-none' : '';
     // Only apply hover effects if not selected. No scale: these rows sit in
@@ -297,9 +347,16 @@ const VirtualizedTableComponent = memo(function VirtualizedTable<T>({
     // Don't apply stripe classes to selected rows
     const stripeClass = !isSelected && index % 2 === 1 ? 'bg-gray-100 dark:bg-gray-800/50' : !isSelected ? 'bg-white dark:bg-gray-900' : '';
 
-    return (
+    // With a detail below it the row no longer owns react-window's slot: the
+    // wrapper does, and the row keeps exactly its own height so the detail gets
+    // the rest. On the non-virtualised path there is no slot and no height in
+    // the style at all — rows size to their content there, and forcing one
+    // would resize every table in the app.
+    const lineHeight = style.height === undefined ? undefined : rowHeight;
+
+    const rowLine = (
       <div
-        style={{...style, overflow: 'visible'}}
+        style={detail ? { height: lineHeight, overflow: 'visible' } : { ...style, overflow: 'visible' }}
         id={rowDomId?.(itemKey)}
         role={rowDomId ? 'row' : undefined}
         aria-selected={rowDomId ? isSelected : undefined}
@@ -317,7 +374,7 @@ const VirtualizedTableComponent = memo(function VirtualizedTable<T>({
             />
           </div>
         )}
-        
+
         {columns.map((column) => (
           <div
             key={column.key}
@@ -330,6 +387,35 @@ const VirtualizedTableComponent = memo(function VirtualizedTable<T>({
         ))}
       </div>
     );
+
+    if (!detail || !rowDetail) return rowLine;
+
+    // grid → rowgroup → row → gridcell: the detail is a row of the grid in its
+    // own right, holding one cell that spans the table. Anything looser (a bare
+    // div between the grid and its rows) is a structure a screen reader is
+    // entitled to ignore, and it would take the transaction row with it.
+    //
+    // No onClick on the wrapper: clicking inside the editor must never count as
+    // clicking the row, which would open the full modal over the box the user
+    // is typing in.
+    return (
+      <div
+        style={{ ...style, overflow: 'visible' }}
+        role={rowDomId ? 'rowgroup' : undefined}
+        className="flex flex-col"
+      >
+        {rowLine}
+        <div
+          role={rowDomId ? 'row' : undefined}
+          style={{ height: rowDetail.height }}
+          className="shrink-0"
+        >
+          <div role={rowDomId ? 'gridcell' : undefined} className="h-full">
+            {detail}
+          </div>
+        </div>
+      </div>
+    );
   }, [
     columns,
     getItemKey,
@@ -338,7 +424,10 @@ const VirtualizedTableComponent = memo(function VirtualizedTable<T>({
     selectedItems,
     onSelectionChange,
     showCheckbox,
-    rowDomId
+    rowDomId,
+    rowDetail,
+    detailIndex,
+    rowHeight
   ]);
 
   
@@ -390,7 +479,7 @@ const VirtualizedTableComponent = memo(function VirtualizedTable<T>({
         items={items}
         renderItem={renderRow as (item: unknown, index: number, style: React.CSSProperties) => React.ReactElement}
         getItemKey={getItemKey as (item: unknown, index: number) => string}
-        itemHeight={rowHeight}
+        itemHeight={itemHeight}
         onLoadMore={onLoadMore}
         hasMore={hasMore}
         isLoading={isLoading}

--- a/src/components/common/DatePicker.tsx
+++ b/src/components/common/DatePicker.tsx
@@ -1,4 +1,5 @@
-import { useState, useRef, useEffect, useCallback, type KeyboardEvent } from 'react';
+import { useState, useRef, useEffect, useLayoutEffect, useCallback, type KeyboardEvent } from 'react';
+import { createPortal } from 'react-dom';
 import { ChevronLeftIcon, ChevronRightIcon, CalendarIcon } from '../icons';
 
 interface DatePickerProps {
@@ -21,7 +22,21 @@ interface DatePickerProps {
    * the order they appear in the class attribute.
    */
   size?: 'sm' | 'md';
+  /**
+   * Render the calendar in a fixed-position portal on document.body instead of
+   * absolutely inside this field.
+   *
+   * For a field that sits inside a scroll container which CLIPS its overflow —
+   * the register's quick-edit box lives inside the virtualised transaction
+   * list, where an in-flow calendar is cut off at the edge of the table. Off by
+   * default, so every existing field renders byte-for-byte as it did.
+   */
+  usePortal?: boolean;
 }
+
+/** The calendar's own size, needed to decide whether it fits below the field. */
+const CALENDAR_WIDTH = 280;
+const CALENDAR_HEIGHT = 340;
 
 const SIZES = {
   sm: { field: 'px-2 py-1.5 pr-8', icon: 'right-2', iconSize: 14 },
@@ -93,10 +108,16 @@ export default function DatePicker({
   'aria-invalid': ariaInvalid,
   'aria-describedby': ariaDescribedBy,
   size = 'md',
+  usePortal = false,
 }: DatePickerProps) {
   const [isOpen, setIsOpen] = useState(false);
   const containerRef = useRef<HTMLDivElement>(null);
   const inputRef = useRef<HTMLInputElement>(null);
+  // The portaled calendar lives outside containerRef, so the outside-click
+  // check has to know about it separately — otherwise clicking a day would
+  // count as "outside", close the calendar, and the day's own click would
+  // never land.
+  const menuRef = useRef<HTMLDivElement>(null);
   // What the user is currently typing, or null when the field just mirrors
   // `value`. Holding the raw string means we never reformat under the caret
   // half-way through "14/4/2025".
@@ -133,13 +154,53 @@ export default function DatePicker({
   useEffect(() => {
     if (!isOpen) return;
     const handleClick = (e: MouseEvent) => {
-      if (containerRef.current && !containerRef.current.contains(e.target as Node)) {
+      const target = e.target as Node;
+      const inField = containerRef.current?.contains(target) ?? false;
+      const inCalendar = menuRef.current?.contains(target) ?? false;
+      if (!inField && !inCalendar) {
         setIsOpen(false);
       }
     };
     document.addEventListener('mousedown', handleClick);
     return () => document.removeEventListener('mousedown', handleClick);
   }, [isOpen]);
+
+  // Where the portaled calendar sits: below the field, or above it when there
+  // is not room below. Recomputed on scroll (capture phase, so a scrolling
+  // container counts, not just the window) and on resize, so it tracks the
+  // field it belongs to rather than hanging in mid-air.
+  const [menuPos, setMenuPos] = useState<{ left: number; top?: number; bottom?: number } | null>(null);
+  const computeMenuPosition = useCallback(() => {
+    const el = containerRef.current;
+    if (!el) return;
+    const rect = el.getBoundingClientRect();
+    const gap = 4;
+    const spaceBelow = window.innerHeight - rect.bottom;
+    const openUp = spaceBelow < CALENDAR_HEIGHT + gap && rect.top > spaceBelow;
+    setMenuPos({
+      // Kept on screen: a field near the right edge would otherwise put the
+      // calendar half outside the window.
+      left: Math.max(8, Math.min(rect.left, window.innerWidth - CALENDAR_WIDTH - 8)),
+      ...(openUp
+        ? { bottom: window.innerHeight - rect.top + gap }
+        : { top: rect.bottom + gap }),
+    });
+  }, []);
+
+  useLayoutEffect(() => {
+    if (!usePortal || !isOpen) {
+      setMenuPos(null);
+      return;
+    }
+    computeMenuPosition();
+    const onReflow = (): void => computeMenuPosition();
+    window.addEventListener('scroll', onReflow, true);
+    window.addEventListener('resize', onReflow);
+    return () => {
+      window.removeEventListener('scroll', onReflow, true);
+      window.removeEventListener('resize', onReflow);
+    };
+  }, [usePortal, isOpen, computeMenuPosition]);
 
   const prevMonth = useCallback(() => {
     setViewMonth(m => {
@@ -326,8 +387,23 @@ export default function DatePicker({
         />
       </div>
 
-      {isOpen && (
-        <div className="absolute z-50 mt-1 bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-600 rounded-xl shadow-lg p-3 w-[280px]">
+      {isOpen && (() => {
+        const calendar = (
+        <div
+          ref={usePortal ? menuRef : undefined}
+          // data-datepicker-panel: a portaled calendar is no longer inside the
+          // field's DOM, so anything that asks "was that click inside my
+          // component?" — the register's click-outside-to-deselect handler —
+          // needs a way to recognise it.
+          data-datepicker-panel
+          style={usePortal && menuPos ? {
+            position: 'fixed',
+            left: menuPos.left,
+            zIndex: 9999,
+            ...(menuPos.top !== undefined ? { top: menuPos.top } : { bottom: menuPos.bottom }),
+          } : undefined}
+          className={`${usePortal ? '' : 'absolute z-50 mt-1'} bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-600 rounded-xl shadow-lg p-3 w-[280px]`}
+        >
           {/* Header — the arrows step within the current view (month / year /
               12-year block) and the label drills UP a level (day→month→year). */}
           <div className="flex items-center justify-between mb-2">
@@ -477,7 +553,12 @@ export default function DatePicker({
             </button>
           </div>
         </div>
-      )}
+        );
+        if (!usePortal) return calendar;
+        // Nothing is drawn until the position is known — a calendar painted at
+        // 0,0 for one frame and then moved is a visible jump.
+        return menuPos ? createPortal(calendar, document.body) : null;
+      })()}
     </div>
   );
 }

--- a/src/pages/AccountTransactions.tsx
+++ b/src/pages/AccountTransactions.tsx
@@ -13,13 +13,13 @@ import BulkDeleteTransactionsConfirm from '../components/BulkDeleteTransactionsC
 import RegisterSelectionBar from '../components/RegisterSelectionBar';
 import RegisterShortcutsDialog from '../components/RegisterShortcutsDialog';
 import AccountSettingsModal from '../components/AccountSettingsModal';
-import QuickEditTransactionPanel from '../components/QuickEditTransactionPanel';
+import QuickEditTransactionPanel, { QUICK_EDIT_BOX_HEIGHT } from '../components/QuickEditTransactionPanel';
 import SuggestedCategoryBadge from '../components/SuggestedCategoryBadge';
 import CategorySelector from '../components/CategorySelector';
 import PageTip from '../components/PageTip';
 import { usePreferences } from '../contexts/PreferencesContext';
 import { useToast } from '../contexts/ToastContext';
-import { VirtualizedTable, Column } from '../components/VirtualizedTable';
+import { VirtualizedTable, type Column, type RowDetail } from '../components/VirtualizedTable';
 import { InfiniteScrollTransactionList } from '../components/InfiniteScrollTransactionList';
 import { LoadingState } from '../components/loading/LoadingState';
 import { compareChronological, compareTransactions, type TransactionSortField } from '../utils/transactionSort';
@@ -336,6 +336,11 @@ export default function AccountTransactions() {
     pendingTxnRef.current = null;
     setSelectedTransaction(target);
     setSelectedTransactionId(txn);
+    // …with its quick-edit box already open. A ?txn= link is someone being
+    // sent to a particular transaction to DO something about it (the
+    // categorisation drill sends them), so the row arrives ready to edit
+    // rather than merely pointed at.
+    setQuickEditOpen(true);
     setRowScroll({ rowId: txn, align: 'center' });
   }, [transactions, location.search]);
 
@@ -366,10 +371,21 @@ export default function AccountTransactions() {
   const [bulkBusy, setBulkBusy] = useState(false);
   const [showShortcuts, setShowShortcuts] = useState(false);
   /**
-   * F2's request for the quick-edit bar to take the cursor. A boolean, and
+   * Whether the quick-edit box is open under the highlighted row.
+   *
+   * Separate from the highlight itself, because Escape peels the two apart:
+   * the first one closes the box and leaves the row highlighted (the register
+   * is legible again), the second lets go of the row. It follows the highlight
+   * while it is open — arrowing down moves the box down with it, which is what
+   * Money's register does — and stays shut while it is shut, so someone who
+   * closed it to READ the list can arrow through it undisturbed.
+   */
+  const [quickEditOpen, setQuickEditOpen] = useState(false);
+  /**
+   * F2's request for the quick-edit box to take the cursor. A boolean, and
    * handed straight back when honoured, so a re-mount can never replay it.
    */
-  const [dockFocusRequested, setDockFocusRequested] = useState(false);
+  const [quickEditFocusRequested, setQuickEditFocusRequested] = useState(false);
   /** Which quick-add field to put the cursor in once the bar is on screen. */
   const [quickAddFocus, setQuickAddFocus] = useState<'date' | 'description' | null>(null);
   /** A pulse asking the search box for the cursor once the filter panel opens. */
@@ -642,6 +658,19 @@ export default function AccountTransactions() {
     setFootScrollToken(token => token + 1);
   }, [accountId, accountIsOpen, displayRows.length, rowScroll]);
 
+  /**
+   * Open the full editor on a row — splits, tags, everything the quick-edit
+   * box has no room for.
+   *
+   * One function for both ways in (a second click on an open box, and Enter on
+   * the highlighted row) so the two can never drift apart.
+   */
+  const openFullEditor = useCallback((row: TransactionWithBalance): void => {
+    setSelectedTransaction(row);
+    setSelectedTransactionId(row.id);
+    setIsEditModalOpen(true);
+  }, []);
+
   // Handle transaction row click
   const handleTransactionClick = useCallback((item: DisplayRow) => {
     if (isOpeningBalanceRow(item)) return;
@@ -656,18 +685,26 @@ export default function AccountTransactions() {
     // and it ends any type-ahead search: the user has found their row by hand.
     setSelectionAnchorId(null);
     typeAheadRef.current = { buffer: '', at: 0 };
-    // The user has taken over — a later sort or filter must not snap the
-    // viewport back to the deep-linked row.
-    setRowScroll(null);
 
-    if (selectedTransactionId === item.id) {
-      // Second click on already selected transaction - open edit modal
-      setIsEditModalOpen(true);
-    } else {
-      // First click - select and pin the quick-edit panel under the table
-      setSelectedTransactionId(item.id);
+    if (selectedTransactionId === item.id && quickEditOpen) {
+      // A second click on a row already showing its box means "give me
+      // everything" — the full editor, with splits, tags and the rest.
+      setRowScroll(null);
+      openFullEditor(item);
+      return;
     }
-  }, [selectedTransactionId]);
+    // Otherwise: highlight it and open the quick-edit box directly beneath it,
+    // which is what a click on a transaction has always meant here — the box
+    // has simply moved from the foot of the page to the row it is about.
+    setSelectedTransactionId(item.id);
+    setQuickEditOpen(true);
+    // The row grows by the height of the box, so the box can open below the
+    // fold on a row that was itself perfectly visible. 'nearest' scrolls the
+    // least amount that shows the WHOLE row — box included — and does nothing
+    // at all when it already fits, so a click in the middle of the register
+    // never yanks the viewport.
+    setRowScroll({ rowId: item.id, align: 'nearest' });
+  }, [selectedTransactionId, quickEditOpen, openFullEditor]);
 
   const quickEditTarget = useMemo(
     () => transactionsWithBalance.find(t => t.id === selectedTransactionId) ?? null,
@@ -713,6 +750,12 @@ export default function AccountTransactions() {
       if (
         target.closest('[data-transaction-table]') ||
         target.closest('[data-quick-edit-panel]') ||
+        // The quick-edit box's calendar is drawn in a PORTAL on document.body
+        // (the transaction list would clip it), so a click on the 14th is
+        // nowhere near the table in the DOM. Without this, picking a date
+        // would deselect the row and unmount the box mid-click — the same trap
+        // the listbox guard below covers for the category menu.
+        target.closest('[data-datepicker-panel]') ||
         // The bulk-action bar acts ON the selection — a mousedown there is
         // the opposite of clicking away from it, and deselecting first would
         // unmount the very button being pressed.
@@ -902,12 +945,14 @@ export default function AccountTransactions() {
 
   // ── What the keys actually do ──────────────────────────────────────────────
 
-  /** Let go of the whole selection: no highlight, and the add bar back. */
+  /** Let go of the whole selection: no highlight, and no quick-edit box. */
   const clearSelection = useCallback((): void => {
     setSelectionAnchorId(null);
     setSelectedTransactionId(null);
     setSelectedTransaction(null);
     setRowScroll(null);
+    // The box is about a row. With no row, there is nothing for it to be.
+    setQuickEditOpen(false);
   }, []);
 
   /**
@@ -1013,11 +1058,11 @@ export default function AccountTransactions() {
    * £4 more" takes one keystroke and one edit, and still ends with the user
    * pressing Add.
    *
-   * Two consequences worth knowing, both of them the dock's existing rules
-   * rather than anything invented here: the add bar and the quick editor share
-   * one slot, so revealing the add bar drops the row's highlight; and a SPLIT
-   * row copies as a plain draft, because its categorisation lives in lines
-   * this form has no way to hold.
+   * Two consequences worth knowing. The highlight is let go of — the user has
+   * moved on to a new transaction, and leaving a quick-edit box open on the
+   * old row while they type into the add bar would be two half-finished edits
+   * on one screen. And a SPLIT row copies as a plain draft, because its
+   * categorisation lives in lines this form has no way to hold.
    */
   const duplicateIntoQuickAdd = useCallback((row: TransactionWithBalance): void => {
     setTableExpanded(false);
@@ -1077,19 +1122,66 @@ export default function AccountTransactions() {
     setQuickAddFocus(null);
   }, [quickAddFocus]);
 
-  const handleDockFocusHandled = useCallback(() => setDockFocusRequested(false), []);
-  const handleReturnToGrid = useCallback(() => {
+  const handleQuickEditFocusHandled = useCallback(() => setQuickEditFocusRequested(false), []);
+  /**
+   * Escape (or the ×) in the quick-edit box: close it, keep the row
+   * highlighted, and hand the keyboard back to the list.
+   *
+   * Both halves matter. Without the close, Escape would not do what the box
+   * plainly looks like it should; without the focus, F2 would be a one-way
+   * door and the way back to the arrow keys would be a mouse.
+   */
+  const handleQuickEditDismiss = useCallback(() => {
+    setQuickEditOpen(false);
     tableWrapRef.current?.focus({ preventScroll: true });
   }, []);
 
   /**
+   * The quick-edit box, as the register draws it: inside the list, attached to
+   * the underside of the row it is about, with every row below pushed down by
+   * exactly its height. Microsoft Money's shape, and the reason the register
+   * can be worked down without the eye ever leaving the line being edited.
+   *
+   * Null — no box at all — in the three cases where a box would be a lie:
+   * nothing is highlighted, a RUN of rows is (the box edits one transaction),
+   * or the full editor is open over the top of it.
+   */
+  const quickEditRowDetail = useMemo<RowDetail<DisplayRow> | null>(() => {
+    if (!quickEditOpen || hasMultiSelection || isEditModalOpen || !quickEditTarget) return null;
+    const target = quickEditTarget;
+    return {
+      key: target.id,
+      height: QUICK_EDIT_BOX_HEIGHT,
+      render: () => (
+        <QuickEditTransactionPanel
+          transaction={target}
+          onNext={
+            getNextTransactionId(target.id)
+              ? () => { advanceToNextTransaction(target.id); }
+              : undefined
+          }
+          focusFirstField={quickEditFocusRequested}
+          onFocusFirstFieldHandled={handleQuickEditFocusHandled}
+          onDismiss={handleQuickEditDismiss}
+        />
+      ),
+    };
+  }, [
+    quickEditOpen, hasMultiSelection, isEditModalOpen, quickEditTarget,
+    getNextTransactionId, advanceToNextTransaction,
+    quickEditFocusRequested, handleQuickEditFocusHandled, handleQuickEditDismiss,
+  ]);
+
+  /**
    * Keys the register claims while the table has focus.
    *
-   * Scoped to the table's own keydown rather than the window: the search box,
-   * the quick-add bar and the quick-edit dock all sit OUTSIDE it, so typing in
-   * them is untouched by construction rather than by a list of exceptions. The
-   * typing guard below is for anything that might one day be edited inside a
-   * cell.
+   * Scoped to the table's own keydown rather than the window: the search box
+   * and the quick-add bar sit OUTSIDE it, so typing in them is untouched by
+   * construction rather than by a list of exceptions.
+   *
+   * The quick-edit box is the one thing that is INSIDE it — that is the whole
+   * point of the box — so it gets the two guards at the top: nothing typed
+   * anywhere, and nothing at all from within the box, reaches these keys.
    *
    * preventDefault is called only when the register actually handled the key,
    * so an empty register still scrolls the page as it always did.
@@ -1112,6 +1204,13 @@ export default function AccountTransactions() {
    */
   const handleRegisterKeyDown = useCallback((e: React.KeyboardEvent<HTMLDivElement>): void => {
     if (isTextEntryTarget(e.target)) return;
+    // The quick-edit box now sits INSIDE this grid, so its keys bubble through
+    // here. It owns every one of them: Space on its Save button must press the
+    // button, not reconcile the row; Delete on its category picker must clear
+    // the category, not offer to delete the transaction. The typing guard above
+    // covers its text fields; this covers its buttons and its comboboxes, which
+    // are not text at all.
+    if (e.target instanceof HTMLElement && e.target.closest('[data-quick-edit-panel]')) return;
     // A dialog owns the keyboard while it is open, and all of these render
     // over this.
     if (isEditModalOpen || deleteConfirmTransaction || bulkDeletePlan || showShortcuts) return;
@@ -1188,19 +1287,25 @@ export default function AccountTransactions() {
       case 'Enter': {
         if (!activeRow) return;
         claim();
-        // Deliberately the click path: for an already-selected row that is
-        // exactly "open the editor", so Enter and the second click can never
-        // drift apart.
-        handleTransactionClick(activeRow);
+        // The FULL editor, whatever the quick-edit box is doing — the same
+        // openFullEditor a second click reaches, so the two cannot drift.
+        // (Enter INSIDE the box saves instead; the box handles its own keys
+        // and this handler never sees them — see the guard at the top.)
+        openFullEditor(activeRow);
         break;
       }
       case 'F2': {
-        // Straight into the quick editor. Never over a multi-row selection —
-        // that bar edits ONE transaction, and it is not on screen then.
+        // Straight into the quick-edit box, opening it if Escape had closed
+        // it. Never over a multi-row selection — the box edits ONE
+        // transaction, and it is not on screen then.
         if (!activeRow || hasMultiSelection) return;
         claim();
-        setTableExpanded(false);
-        setDockFocusRequested(true);
+        setQuickEditOpen(true);
+        setQuickEditFocusRequested(true);
+        // The box lives in the register itself now, so an expanded table is no
+        // obstacle: it is on screen either way, and collapsing it would undo
+        // something the user asked for.
+        setRowScroll({ rowId: activeRow.id, align: 'nearest' });
         break;
       }
       case ' ': {
@@ -1241,6 +1346,12 @@ export default function AccountTransactions() {
         typeAheadRef.current = { buffer: '', at: 0 };
         // One layer at a time: the multi-row selection first, the highlight
         // second. Anything left over belongs to whatever is above us.
+        //
+        // The quick-edit box is a layer of its own, but it is peeled from
+        // INSIDE the box — an Escape with the cursor in the box closes it and
+        // leaves the row highlighted (see the box's own handler). An Escape
+        // aimed at the LIST is about the list: it lets go of the row, and the
+        // box, being about that row, goes with it.
         if (hasMultiSelection) {
           claim();
           setSelectionAnchorId(null);
@@ -1275,7 +1386,7 @@ export default function AccountTransactions() {
   }, [
     isEditModalOpen, deleteConfirmTransaction, bulkDeletePlan, showShortcuts,
     moveSelection, moveSelectionTo, pageStep, selectedTransactionId, navigableRows,
-    activeRowIndex, handleTransactionClick, hasMultiSelection, selectedRows,
+    activeRowIndex, openFullEditor, hasMultiSelection, selectedRows,
     transactions, accounts, toggleClearedOnSelection, clearSelection,
     duplicateIntoQuickAdd, openSearch, jumpToTransferOtherSide, startNewTransaction,
   ]);
@@ -2157,8 +2268,10 @@ export default function AccountTransactions() {
         role="grid"
         aria-label={`${account.name} transactions`}
         // The header row counts, which is what puts the first transaction on
-        // row 2 — the same numbering the user sees.
-        aria-rowcount={displayRows.length + 1}
+        // row 2 — the same numbering the user sees. The open quick-edit box is
+        // a row of the grid too (one cell, holding the form), so it counts as
+        // one while it is there rather than leaving the total short.
+        aria-rowcount={displayRows.length + 1 + (quickEditRowDetail ? 1 : 0)}
         tabIndex={0}
         // Shift+arrow stretches the highlight over a run of rows, so a screen
         // reader is told up front that more than one row can be selected —
@@ -2177,6 +2290,7 @@ export default function AccountTransactions() {
           scrollToKey={rowScroll?.rowId ?? null}
           scrollToAlign={rowScroll?.align}
           scrollToBottomToken={footScrollToken}
+          rowDetail={quickEditRowDetail}
           selectedItems={selectedIdSet}
           onSort={(column, direction) => {
             // Every header sorts except the running Balance (which stays in its
@@ -2210,10 +2324,11 @@ export default function AccountTransactions() {
         />
       </div>
 
-      {/* Bottom dock — ONE always-visible bar (hidden only in expanded mode),
-          in whichever of its three modes fits what is selected: what you can
-          do with a RUN of rows, the quick editor for a single one, or the add
-          bar when nothing is highlighted. */}
+      {/* Bottom dock — ONE always-visible bar (hidden only in expanded mode).
+          Editing a transaction happens up in the register now, on the row
+          itself; what is left down here is what a RUN of rows can be done to,
+          and otherwise the add bar — which stays put whether or not a row is
+          highlighted, so "add one more" never costs you your place. */}
       {!tableExpanded && hasMultiSelection && (
         <RegisterSelectionBar
           count={selectedRows.length}
@@ -2228,33 +2343,19 @@ export default function AccountTransactions() {
         />
       )}
 
-      {!tableExpanded && !hasMultiSelection && quickEditTarget && !isEditModalOpen && (
-        <QuickEditTransactionPanel
-          transaction={quickEditTarget}
-          onNext={
-            getNextTransactionId(quickEditTarget.id)
-              ? () => { advanceToNextTransaction(quickEditTarget.id); }
-              : undefined
-          }
-          focusFirstField={dockFocusRequested}
-          onFocusFirstFieldHandled={handleDockFocusHandled}
-          onReturnToGrid={handleReturnToGrid}
-          onClose={() => {
-            setSelectedTransactionId(null);
-            setSelectedTransaction(null);
-          }}
-        />
-      )}
-
       {/* Quick Add Transaction (the dock's default mode) */}
-      {!tableExpanded && !hasMultiSelection && !(quickEditTarget && !isEditModalOpen) && (
+      {!tableExpanded && !hasMultiSelection && (
       <div className="bg-white dark:bg-gray-800 rounded-xl shadow-md border border-gray-100 dark:border-gray-700 px-4 py-3">
         {/* max-w: the dock is as wide as the register, and a description box
             stretched across it left Amount and Add squeezed into the corner.
             Capping the form makes both rows end at the same edge, so the wide
             fields stop hogging and the small ones get room. flex-wrap keeps
             the fields stacking instead of overflowing on narrow screens. */}
-        <form onSubmit={handleQuickAdd}>
+        {/* Named, so it is a landmark a screen reader can jump to and — now
+            that the quick-EDIT box sits up in the register — so "Description"
+            down here and "Description" up there are heard in their own
+            contexts rather than as two identical fields on one screen. */}
+        <form onSubmit={handleQuickAdd} aria-label="Add a transaction">
           {/* One line across the full width — Date, Type, Description,
               Category, Amount, Add — wrapping only when the window is too
               narrow to hold it. Capping the form instead (an earlier attempt)
@@ -2266,19 +2367,28 @@ export default function AccountTransactions() {
               produced a different ragged layout at every width. From sm up
               it is the same single wrapping row as before. */}
           <div className="grid grid-cols-2 items-end gap-3 sm:flex sm:flex-wrap">
+            {/* Every label down here is tied to the field it names — htmlFor
+                where the control has an id of its own, and the control's own
+                aria-label where it does not (the pickers). A <label> attached
+                to nothing is invisible to a screen reader, which is the one
+                reader that needs it. */}
             <div ref={quickAddDateRef} className="w-full sm:w-[150px] sm:shrink-0">
-              <label className="text-xs text-gray-500 dark:text-gray-400 mb-0.5 block">Date</label>
+              <label htmlFor="quick-add-date" className="text-xs text-gray-500 dark:text-gray-400 mb-0.5 block">Date</label>
               <DatePicker
+                id="quick-add-date"
                 value={quickAddForm.date}
                 onChange={(val) => { setQuickAddError(''); setQuickAddForm({ ...quickAddForm, date: val }); }}
                 className="h-auto sm:h-[32px] bg-white dark:bg-gray-700 border border-gray-300 dark:border-gray-600 rounded-lg focus:outline-none focus:ring-1 focus:ring-primary dark:text-white text-xs"
-                aria-label="Transaction date"
               />
             </div>
 
             <div className="sm:shrink-0">
-              <label className="text-xs text-gray-500 dark:text-gray-400 mb-0.5 block">Type</label>
-              <div className="grid grid-flow-col auto-cols-fr sm:flex gap-0.5 items-center h-[38px] sm:h-[32px] bg-gray-100 dark:bg-gray-700 rounded-lg p-0.5">
+              <span className="text-xs text-gray-500 dark:text-gray-400 mb-0.5 block">Type</span>
+              <div
+                role="group"
+                aria-label="Transaction type"
+                className="grid grid-flow-col auto-cols-fr sm:flex gap-0.5 items-center h-[38px] sm:h-[32px] bg-gray-100 dark:bg-gray-700 rounded-lg p-0.5"
+              >
                 {([
                   { value: 'expense', label: 'Exp', activeColor: 'text-red-600 dark:text-red-400' },
                   { value: 'income', label: 'Inc', activeColor: 'text-green-600 dark:text-green-400' },
@@ -2287,6 +2397,9 @@ export default function AccountTransactions() {
                   <button
                     key={value}
                     type="button"
+                    // Which one is on, said out loud — the white pill says it
+                    // to the eye and nothing said it to anyone else.
+                    aria-pressed={quickAddForm.type === value}
                     onClick={() => {
                       // Clearing the category is not tidiness: it may belong to
                       // the tree the picker no longer shows, and on 'transfer'
@@ -2308,8 +2421,9 @@ export default function AccountTransactions() {
             </div>
 
             <div className="col-span-2 min-w-0 sm:flex-1 sm:min-w-[180px]">
-              <label className="text-xs text-gray-500 dark:text-gray-400 mb-0.5 block">Description</label>
+              <label htmlFor="quick-add-description" className="text-xs text-gray-500 dark:text-gray-400 mb-0.5 block">Description</label>
               <input
+                id="quick-add-description"
                 ref={quickAddDescriptionRef}
                 type="text"
                 placeholder="Description"
@@ -2321,9 +2435,12 @@ export default function AccountTransactions() {
             </div>
 
             <div className="col-span-2 min-w-0 sm:flex-1 sm:min-w-[180px]">
-              <label className="text-xs text-gray-500 dark:text-gray-400 mb-0.5 block">
+              {/* A span, not a label: both controls below are comboboxes that
+                  carry their own aria-label, and a <label> pointing at nothing
+                  is worse than no label at all. */}
+              <span className="text-xs text-gray-500 dark:text-gray-400 mb-0.5 block">
                 {quickAddForm.type === 'transfer' ? 'To Account' : 'Category'}
-              </label>
+              </span>
               {quickAddForm.type === 'transfer' ? (
                 /* The account and category pickers take turns in this one
                    slot, so they are the same control at the same size — and
@@ -2371,13 +2488,13 @@ export default function AccountTransactions() {
             {/* Wide enough for a five-figure sum with its pennies without the
                 digits scrolling out of view. */}
             <div className="w-full sm:w-[150px] sm:shrink-0">
-              <label className="text-xs text-gray-500 dark:text-gray-400 mb-0.5 block">Amount</label>
+              <label htmlFor="quick-add-amount" className="text-xs text-gray-500 dark:text-gray-400 mb-0.5 block">Amount</label>
               <MoneyInput
+                id="quick-add-amount"
                 value={quickAddForm.amount}
                 // The type buttons carry the sign; this field holds the size.
                 onChange={(value) => { setQuickAddError(''); setQuickAddForm({ ...quickAddForm, amount: value }); }}
                 className="w-full px-2.5 py-1.5 h-auto sm:h-[32px] text-xs text-right bg-white dark:bg-gray-700 border border-gray-300 dark:border-gray-600 rounded-lg focus:outline-none focus:ring-1 focus:ring-primary dark:text-white"
-                aria-label="Amount"
                 required
               />
             </div>
@@ -2510,7 +2627,7 @@ export default function AccountTransactions() {
       <PageTip
         id="register-keyboard"
         title="This register runs on the keyboard"
-        description="Click any row, then use the arrow keys to move, Enter to open it, Space to reconcile it and Delete to remove it. Press ? for the whole list — or find it under View ▸ Keyboard shortcuts."
+        description="Click any row and a quick edit box opens under it — Enter saves, Esc closes it again. The arrow keys move the highlight (and the box with it), Enter on the list opens the full editor, Space reconciles and Delete removes. Press ? for the whole list — or find it under View ▸ Keyboard shortcuts."
       />
     </div>
   );

--- a/src/pages/__tests__/AccountTransactions.inlineEdit.test.tsx
+++ b/src/pages/__tests__/AccountTransactions.inlineEdit.test.tsx
@@ -1,0 +1,372 @@
+import React from 'react';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { render, screen, fireEvent, waitFor, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { PreferencesProvider } from '../../contexts/PreferencesContext';
+import { ToastProvider } from '../../contexts/ToastContext';
+import { NotificationProvider } from '../../contexts/NotificationContext';
+import { __setAppContextValue, __resetAppContextValue } from '../../test/mocks/AppContextSupabase';
+import { DataService } from '../../services/api/dataService';
+import AccountTransactions from '../AccountTransactions';
+import type { Account, Category, Transaction } from '../../types';
+
+/**
+ * The quick-edit box where Microsoft Money puts it: in the register, under the
+ * row it is about, with Enter to save and Escape to be rid of it.
+ *
+ * The owner's words: "when you click on a transaction, that kind of box appears
+ * sort of in the transaction list, directly below the transaction line itself…
+ * if I enter a category and then press 'enter' it could save automatically… I
+ * could also press 'escape' to hide that quick edit box and just see the
+ * transaction list."
+ *
+ * So four things have to hold, and each has a test here:
+ *   1. the box opens BELOW the clicked row, inside the list, not at the foot
+ *      of the page;
+ *   2. Enter saves — from the description, and from a category just chosen;
+ *   3. Enter belongs to whatever already wants it: an open category list
+ *      chooses with it, a button is pressed by it, and neither also saves;
+ *   4. Escape closes the box and leaves the row highlighted; the next Escape
+ *      lets go of the row.
+ *
+ * WHAT JSDOM CANNOT DO: no layout. That the rows below visibly move down, that
+ * nothing jumps when the box opens, and that the box's calendar and category
+ * list escape the table rather than being clipped by it, are browser checks —
+ * named as such in the handover. The geometry of the virtualised path is held
+ * to account separately, in VirtualizedTable.rowDetail.test.tsx.
+ *
+ * Every name, date and figure below is invented: this repo is public.
+ */
+
+const ACCOUNT: Account = {
+  id: 'acc-register', name: 'Synthetic Register', type: 'current', balance: 0,
+  currency: 'GBP', lastUpdated: new Date('2026-01-01'), openingBalance: 100, isActive: true,
+};
+
+const CATEGORIES: Category[] = [
+  { id: 'type-expense', name: 'Expenses', type: 'expense', level: 'type', isSystem: true },
+  { id: 'grp-food', name: 'Food', type: 'expense', level: 'sub', parentId: 'type-expense' },
+  { id: 'det-groceries', name: 'Groceries', type: 'expense', level: 'detail', parentId: 'grp-food' },
+  { id: 'det-takeaway', name: 'Takeaway', type: 'expense', level: 'detail', parentId: 'grp-food' },
+];
+
+const ROWS: Transaction[] = [
+  {
+    id: 'txn-0', date: new Date(Date.UTC(2026, 0, 4)), description: 'Aldwych Bakery',
+    amount: -4.2, type: 'expense', category: 'det-groceries', accountId: ACCOUNT.id, cleared: false,
+  },
+  {
+    id: 'txn-1', date: new Date(Date.UTC(2026, 0, 6)), description: 'Sandpiper Foods',
+    amount: -31.15, type: 'expense', category: 'det-groceries', accountId: ACCOUNT.id, cleared: false,
+  },
+  {
+    id: 'txn-2', date: new Date(Date.UTC(2026, 0, 9)), description: 'Cobblestone Cafe',
+    amount: -6.8, type: 'expense', category: 'det-groceries', accountId: ACCOUNT.id, cleared: false,
+  },
+  {
+    id: 'txn-3', date: new Date(Date.UTC(2026, 0, 12)), description: 'Thistledown Books',
+    amount: -12, type: 'expense', category: 'det-groceries', accountId: ACCOUNT.id, cleared: false,
+  },
+];
+
+const updateTransaction = vi.fn(async () => {});
+const applyCategoryToUncategorized = vi.fn(async () => 0);
+
+const renderRegister = (): void => {
+  render(
+    <MemoryRouter initialEntries={[`/accounts/${ACCOUNT.id}`]}>
+      <PreferencesProvider>
+        <ToastProvider>
+          <NotificationProvider>
+            <Routes>
+              <Route path="/accounts" element={<div>Accounts page</div>} />
+              <Route path="/accounts/:accountId" element={<AccountTransactions />} />
+            </Routes>
+          </NotificationProvider>
+        </ToastProvider>
+      </PreferencesProvider>
+    </MemoryRouter>
+  );
+};
+
+const grid = (): HTMLElement => screen.getByRole('grid', { name: 'Synthetic Register transactions' });
+
+const addBar = (): HTMLElement => screen.getByRole('form', { name: 'Add a transaction' });
+
+const quickEditBox = (): HTMLElement => {
+  const el = document.querySelector('[data-quick-edit-panel]');
+  if (!(el instanceof HTMLElement)) throw new Error('no quick-edit box is showing');
+  return el;
+};
+
+const boxIsShowing = (): boolean => document.querySelector('[data-quick-edit-panel]') !== null;
+
+const descriptionField = (): HTMLElement => within(quickEditBox()).getByLabelText('Description');
+
+/** The transaction the register says is active, by its description. */
+const activeRowText = (): string => {
+  const id = grid().getAttribute('aria-activedescendant');
+  if (!id) return '';
+  return document.getElementById(id)?.textContent ?? '';
+};
+
+const openRegister = async (): Promise<void> => {
+  renderRegister();
+  await screen.findByRole('heading', { level: 1, name: 'Synthetic Register' });
+};
+
+/** Click a row the way a user would. */
+const clickRow = (description: string): void => {
+  fireEvent.click(within(grid()).getByText(description));
+};
+
+beforeEach(() => {
+  localStorage.clear();
+  updateTransaction.mockClear();
+  applyCategoryToUncategorized.mockClear();
+  __setAppContextValue({
+    accounts: [ACCOUNT],
+    transactions: ROWS,
+    categories: CATEGORIES,
+    isLoading: false,
+    updateTransaction,
+    applyCategoryToUncategorized,
+    getSubCategories: (parentId?: string) => CATEGORIES.filter(c => c.level === 'sub' && c.parentId === parentId),
+    getDetailCategories: (parentId?: string) => CATEGORIES.filter(c => c.level === 'detail' && c.parentId === parentId),
+  });
+  vi.spyOn(DataService, 'getClosedAccounts').mockResolvedValue([]);
+});
+
+afterEach(() => {
+  vi.mocked(DataService.getClosedAccounts).mockRestore();
+  __resetAppContextValue();
+});
+
+describe('Account register — the quick-edit box opens under the row', () => {
+  it('is in the list itself, on the line below the transaction clicked', async () => {
+    await openRegister();
+
+    clickRow('Sandpiper Foods');
+
+    // Inside the register, not underneath the whole page — the difference the
+    // owner asked for, and the reason the eye never leaves the line.
+    expect(grid().contains(quickEditBox())).toBe(true);
+
+    // And on the very next line: the rows below it are what move down.
+    const rows = within(grid()).getAllByRole('row');
+    const clicked = within(grid()).getByText('Sandpiper Foods').closest('[role="row"]');
+    const box = quickEditBox().closest('[role="row"]');
+    expect(rows.indexOf(box as HTMLElement)).toBe(rows.indexOf(clicked as HTMLElement) + 1);
+    expect(descriptionField()).toHaveValue('Sandpiper Foods');
+  });
+
+  it('leaves the add bar exactly where it was', async () => {
+    await openRegister();
+
+    clickRow('Sandpiper Foods');
+
+    // Editing a row no longer costs you the way to add one. Both are on
+    // screen, and each says which it is.
+    expect(addBar()).toBeInTheDocument();
+    expect(within(addBar()).getByLabelText('Description')).toHaveValue('');
+    expect(grid().contains(addBar())).toBe(false);
+  });
+
+  it('counts the box as the row of the grid that it is', async () => {
+    await openRegister();
+    // Header + the Opening Balance line + the transactions.
+    expect(grid()).toHaveAttribute('aria-rowcount', String(ROWS.length + 2));
+
+    clickRow('Sandpiper Foods');
+
+    expect(grid()).toHaveAttribute('aria-rowcount', String(ROWS.length + 3));
+  });
+
+  it('opens the full editor only on a SECOND click, and re-opens a closed box on the first', async () => {
+    await openRegister();
+
+    clickRow('Sandpiper Foods');
+    expect(screen.queryByText('Edit Transaction')).not.toBeInTheDocument();
+
+    // Escape puts the box away but keeps the row…
+    fireEvent.keyDown(descriptionField(), { key: 'Escape' });
+    expect(boxIsShowing()).toBe(false);
+
+    // …so the next click is asking for the box back, not for the full editor.
+    clickRow('Sandpiper Foods');
+    expect(boxIsShowing()).toBe(true);
+    expect(screen.queryByText('Edit Transaction')).not.toBeInTheDocument();
+
+    // With the box open, a second click means "everything else about this row".
+    clickRow('Sandpiper Foods');
+    const dialog = await screen.findByRole('dialog');
+    expect(within(dialog).getByText('Edit Transaction')).toBeInTheDocument();
+  });
+});
+
+describe('Account register — Enter in the quick-edit box saves', () => {
+  it('saves the edited description without a button being pressed', async () => {
+    await openRegister();
+    clickRow('Sandpiper Foods');
+
+    fireEvent.change(descriptionField(), { target: { value: 'Sandpiper Foods Ltd' } });
+    fireEvent.keyDown(descriptionField(), { key: 'Enter' });
+
+    await waitFor(() => {
+      expect(updateTransaction).toHaveBeenCalledTimes(1);
+    });
+    expect(updateTransaction).toHaveBeenCalledWith('txn-1', expect.objectContaining({
+      description: 'Sandpiper Foods Ltd',
+      category: 'det-groceries',
+      categoryConfirmed: true,
+    }));
+    // Saving is not leaving: the row stays put, the box stays open on it, and
+    // the full editor was never in the way.
+    expect(screen.queryByText('Edit Transaction')).not.toBeInTheDocument();
+    expect(boxIsShowing()).toBe(true);
+  });
+
+  it('picks the category on the first Enter and saves on the next', async () => {
+    const user = userEvent.setup();
+    await openRegister();
+    clickRow('Sandpiper Foods');
+
+    // Open the category list and type, exactly as the owner described. Typed
+    // with fireEvent rather than user.type: the picker's trigger toggles the
+    // list on any click inside it, so a synthetic click aimed at the search
+    // box would shut the very list it opened.
+    fireEvent.click(within(quickEditBox()).getByRole('combobox', { name: 'Category' }));
+    const search = within(quickEditBox()).getByPlaceholderText('Search or select category…');
+    fireEvent.change(search, { target: { value: 'Takeaway' } });
+    fireEvent.keyDown(search, { key: 'ArrowDown' });
+
+    // The first Enter belongs to the open list: it chooses, and saves nothing.
+    fireEvent.keyDown(search, { key: 'Enter' });
+    expect(updateTransaction).not.toHaveBeenCalled();
+    expect(within(quickEditBox()).getByRole('combobox', { name: 'Category' })).toHaveTextContent('Takeaway');
+
+    // The cursor is on Save, where the next Enter presses it — "enter a
+    // category and then press enter" ends with the row saved.
+    expect(document.activeElement).toBe(within(quickEditBox()).getByRole('button', { name: 'Save' }));
+    await user.keyboard('{Enter}');
+
+    await waitFor(() => {
+      expect(updateTransaction).toHaveBeenCalledTimes(1);
+    });
+    expect(updateTransaction).toHaveBeenCalledWith('txn-1', expect.objectContaining({
+      category: 'det-takeaway',
+      categoryConfirmed: true,
+    }));
+  });
+
+  it('writes the transaction ONCE when Enter presses a button', async () => {
+    const user = userEvent.setup();
+    await openRegister();
+    clickRow('Sandpiper Foods');
+
+    const saveAndNext = within(quickEditBox()).getByRole('button', { name: 'Save & Next' });
+    saveAndNext.focus();
+    await user.keyboard('{Enter}');
+
+    // The button's own Enter is the press. The box must not ALSO save on the
+    // way past, or one keystroke would write the same row twice — once moving
+    // on, once not.
+    await waitFor(() => {
+      expect(updateTransaction).toHaveBeenCalledTimes(1);
+    });
+    // …and it was the Save & Next that ran: the box has walked on to the next
+    // transaction, still open, ready for the next one.
+    await waitFor(() => {
+      expect(descriptionField()).toHaveValue('Cobblestone Cafe');
+    });
+    expect(activeRowText()).toContain('Cobblestone Cafe');
+  });
+
+  it('says what is wrong instead of saving an empty description', async () => {
+    await openRegister();
+    clickRow('Sandpiper Foods');
+
+    fireEvent.change(descriptionField(), { target: { value: '   ' } });
+    fireEvent.keyDown(descriptionField(), { key: 'Enter' });
+
+    // The same complaint the Save button makes — Enter is that button, not a
+    // quieter way past it. (The wording is the app's shared error map's, which
+    // generalises "Description is required" to the field-agnostic line.)
+    expect(await screen.findByText('This field is required')).toBeInTheDocument();
+    expect(updateTransaction).not.toHaveBeenCalled();
+  });
+});
+
+describe('Account register — the pickers inside a box inside a list', () => {
+  it('draws the calendar outside the table, and picking a date does not lose the row', async () => {
+    await openRegister();
+    clickRow('Sandpiper Foods');
+
+    const dateField = within(quickEditBox()).getByLabelText('Transaction date');
+    fireEvent.focus(dateField);
+
+    const calendar = document.querySelector('[data-datepicker-panel]');
+    if (!(calendar instanceof HTMLElement)) throw new Error('the calendar did not open');
+    // Outside the register entirely: an in-flow calendar would be cut off by
+    // the table, which clips what overflows it.
+    expect(grid().contains(calendar)).toBe(false);
+
+    // The click that matters. The register deselects on a mousedown outside
+    // the table — and this one IS outside the table — so without the
+    // calendar being recognised, the box would unmount underneath the finger
+    // and the date would never be set.
+    fireEvent.mouseDown(within(calendar).getByRole('button', { name: '15' }));
+    fireEvent.click(within(calendar).getByRole('button', { name: '15' }));
+
+    expect(within(quickEditBox()).getByLabelText('Transaction date')).toHaveValue('15/01/2026');
+    expect(activeRowText()).toContain('Sandpiper Foods');
+  });
+});
+
+describe('Account register — Escape peels the box off first', () => {
+  it('closes the box, keeps the row, and only then lets go of the row', async () => {
+    await openRegister();
+    clickRow('Sandpiper Foods');
+    expect(boxIsShowing()).toBe(true);
+
+    // One: the box goes, the highlight stays — "just see the transaction list".
+    fireEvent.keyDown(descriptionField(), { key: 'Escape' });
+    expect(boxIsShowing()).toBe(false);
+    expect(activeRowText()).toContain('Sandpiper Foods');
+    // …and the keyboard is back on the list, so the arrows carry straight on.
+    expect(document.activeElement).toBe(grid());
+    fireEvent.keyDown(grid(), { key: 'ArrowDown' });
+    expect(activeRowText()).toContain('Cobblestone Cafe');
+
+    // Two: the existing layer underneath — the highlight itself.
+    fireEvent.keyDown(grid(), { key: 'Escape' });
+    expect(grid().getAttribute('aria-activedescendant')).toBeNull();
+  });
+
+  it('drops what was typed and not saved, rather than keeping a phantom edit', async () => {
+    await openRegister();
+    clickRow('Sandpiper Foods');
+
+    fireEvent.change(descriptionField(), { target: { value: 'Typed but never saved' } });
+    fireEvent.keyDown(descriptionField(), { key: 'Escape' });
+    clickRow('Sandpiper Foods');
+
+    expect(updateTransaction).not.toHaveBeenCalled();
+    expect(descriptionField()).toHaveValue('Sandpiper Foods');
+  });
+
+  it('leaves the register alone when the box is the one taking the key', async () => {
+    await openRegister();
+    clickRow('Sandpiper Foods');
+
+    // Keys aimed at the box's own controls are the box's: Delete on its
+    // category picker clears the category, and must not offer to delete the
+    // transaction; Space on a button presses it rather than reconciling.
+    const combobox = within(quickEditBox()).getByRole('combobox', { name: 'Category' });
+    combobox.focus();
+    fireEvent.keyDown(combobox, { key: 'Delete' });
+
+    expect(screen.queryByRole('alertdialog')).not.toBeInTheDocument();
+  });
+});

--- a/src/pages/__tests__/AccountTransactions.keyboard.test.tsx
+++ b/src/pages/__tests__/AccountTransactions.keyboard.test.tsx
@@ -82,6 +82,23 @@ const renderRegister = (path: string): void => {
 /** The register itself — the focusable grid, not the phone card list. */
 const grid = (): HTMLElement => screen.getByRole('grid', { name: 'Synthetic Register transactions' });
 
+/**
+ * The add bar at the foot of the page.
+ *
+ * Named rather than reached by label text: the quick-edit box now sits INSIDE
+ * the register with its own Date and Description, so "the description box"
+ * needs saying which one — exactly the question a screen reader user has, and
+ * the reason the add bar is a landmark of its own.
+ */
+const addBar = (): HTMLElement => screen.getByRole('form', { name: 'Add a transaction' });
+
+/** The quick-edit box, wherever the register has drawn it. */
+const quickEditBox = (): HTMLElement => {
+  const el = document.querySelector('[data-quick-edit-panel]');
+  if (!(el instanceof HTMLElement)) throw new Error('no quick-edit box is showing');
+  return el;
+};
+
 /** The element that scrolls on the non-virtualised path. */
 const listViewport = (): HTMLElement => {
   const el = grid().querySelector('[data-virtualized-list]');
@@ -174,9 +191,9 @@ describe('Account register — opening on the newest transaction', () => {
     const target = ROWS[4];
     await openRegister(`/accounts/${ACCOUNT.id}?txn=${target.id}`);
 
-    // The deep-linked row arrives selected and docked in the quick-edit panel…
+    // The deep-linked row arrives selected, with its quick-edit box open…
     await waitFor(() => {
-      expect(screen.getByLabelText('Description')).toHaveValue(target.description);
+      expect(within(quickEditBox()).getByLabelText('Description')).toHaveValue(target.description);
     });
     // …and the register never asked for the foot, so the centring stands.
     expect(listViewport().scrollTop).not.toBe(STUB_SCROLL_HEIGHT);
@@ -227,17 +244,34 @@ describe('Account register — the highlighted row under the arrow keys', () => 
     expect(activeRowText()).toContain(OLDEST.description);
   });
 
-  it('docks the row it lands on, exactly as a click would', async () => {
+  it('takes the open quick-edit box with it, row by row', async () => {
+    await openRegister();
+
+    // Click first, because that is what opens the box; the arrows then move
+    // the box down the register with the highlight, which is what makes a
+    // categorising run continuous.
+    fireEvent.click(within(grid()).getByText(ROWS[0].description));
+    await waitFor(() => {
+      expect(within(quickEditBox()).getByLabelText('Description')).toHaveValue(ROWS[0].description);
+    });
+
+    fireEvent.keyDown(grid(), { key: 'ArrowDown' });
+
+    await waitFor(() => {
+      expect(within(quickEditBox()).getByLabelText('Description')).toHaveValue(ROWS[1].description);
+    });
+  });
+
+  it('leaves the box shut while the arrows are just browsing', async () => {
     await openRegister();
 
     fireEvent.keyDown(grid(), { key: 'ArrowDown' });
     fireEvent.keyDown(grid(), { key: 'ArrowDown' });
 
-    // The bottom dock follows the highlight — the same quick editor a click
-    // pins there.
-    await waitFor(() => {
-      expect(screen.getByLabelText('Description')).toHaveValue(ROWS[1].description);
-    });
+    // Nothing opened the box, so the register is a list of transactions and
+    // nothing else — the state someone reading their history wants.
+    expect(document.querySelector('[data-quick-edit-panel]')).toBeNull();
+    expect(activeRowText()).toContain(ROWS[1].description);
   });
 
   it('stops at both ends instead of wrapping', async () => {
@@ -302,11 +336,12 @@ describe('Account register — the highlighted row under the arrow keys', () => 
     fireEvent.keyDown(grid(), { key: 'ArrowDown' });
     const highlighted = activeRowText();
 
-    // The bottom dock's own description box — the field the user is most
-    // likely to be typing in WHILE a row is highlighted.
-    const dockDescription = screen.getByLabelText('Description');
-    expect(fireEvent.keyDown(dockDescription, { key: 'ArrowDown' })).toBe(true);
-    expect(fireEvent.keyDown(dockDescription, { key: 'Enter' })).toBe(true);
+    // The add bar's own description box — the field the user is most likely to
+    // be typing in WHILE a row is highlighted, and one the register must not
+    // reach into: an arrow key there moves the caret, not the highlight.
+    const addDescription = within(addBar()).getByLabelText('Description');
+    expect(fireEvent.keyDown(addDescription, { key: 'ArrowDown' })).toBe(true);
+    expect(fireEvent.keyDown(addDescription, { key: 'Enter' })).toBe(true);
 
     fireEvent.click(screen.getByRole('button', { name: /Search & filters/ }));
     const search = screen.getByPlaceholderText(/Search by description/);

--- a/src/pages/__tests__/AccountTransactions.provenance.test.tsx
+++ b/src/pages/__tests__/AccountTransactions.provenance.test.tsx
@@ -115,6 +115,13 @@ const row = (description: string): HTMLElement => {
   return found;
 };
 
+/** The quick-edit box the register opens under a clicked row. */
+const quickEditBox = (): HTMLElement => {
+  const el = document.querySelector('[data-quick-edit-panel]');
+  if (!(el instanceof HTMLElement)) throw new Error('no quick-edit box is showing');
+  return el;
+};
+
 const openRegister = async (): Promise<void> => {
   renderRegister();
   await screen.findByRole('heading', { level: 1, name: 'Synthetic Register' });
@@ -184,13 +191,12 @@ describe('Account register — a category the app guessed', () => {
     // Clicking the CATEGORY of a guessed row — the thing the user is querying.
     fireEvent.click(within(row('Synthetic guessed row')).getByText('Food > Groceries'));
 
-    // The register's existing behaviour docks the quick-edit panel, and the
-    // panel is where confirm-or-edit lives. No second mechanism was invented
-    // for the register, and nothing else stands between the click and the
-    // answer.
-    const confirm = screen.getByRole('button', { name: 'Confirm' });
+    // The click opens the quick-edit box under that very row, and the box is
+    // where confirm-or-edit lives. No second mechanism was invented for the
+    // register, and nothing else stands between the click and the answer.
+    const confirm = within(quickEditBox()).getByRole('button', { name: 'Confirm' });
     expect(confirm).toBeInTheDocument();
-    expect(screen.getByLabelText('Description')).toHaveValue('Synthetic guessed row');
+    expect(within(quickEditBox()).getByLabelText('Description')).toHaveValue('Synthetic guessed row');
   });
 
   it('offers no Confirm when the row clicked is one the user already vouched for', async () => {
@@ -198,7 +204,7 @@ describe('Account register — a category the app guessed', () => {
 
     fireEvent.click(within(row('Synthetic vouched row')).getByText('Synthetic vouched row'));
 
-    expect(screen.getByLabelText('Description')).toHaveValue('Synthetic vouched row');
+    expect(within(quickEditBox()).getByLabelText('Description')).toHaveValue('Synthetic vouched row');
     expect(screen.queryByRole('button', { name: 'Confirm' })).not.toBeInTheDocument();
   });
 });

--- a/src/pages/__tests__/AccountTransactions.shortcuts.test.tsx
+++ b/src/pages/__tests__/AccountTransactions.shortcuts.test.tsx
@@ -129,6 +129,20 @@ const renderRegister = (path: string): void => {
 
 const grid = (): HTMLElement => screen.getByRole('grid', { name: 'Synthetic Register transactions' });
 
+/**
+ * The add bar at the foot of the page — a landmark of its own, because the
+ * quick-edit box up in the register has a Date and a Description too, and
+ * "the description box" has to say which.
+ */
+const addBar = (): HTMLElement => screen.getByRole('form', { name: 'Add a transaction' });
+
+/** The quick-edit box, wherever the register has drawn it. */
+const quickEditBox = (): HTMLElement => {
+  const el = document.querySelector('[data-quick-edit-panel]');
+  if (!(el instanceof HTMLElement)) throw new Error('no quick-edit box is showing');
+  return el;
+};
+
 /** The transaction the register says is active, by its description. */
 const activeRowText = (): string => {
   const id = grid().getAttribute('aria-activedescendant');
@@ -565,18 +579,22 @@ describe('Account register — copying a row into the add bar', () => {
 
     fireEvent.keyDown(grid(), { key: 'd', ctrlKey: true });
 
-    // The add bar is back (the quick editor and it share one slot), carrying
-    // the row's description and the size of its amount…
-    const description = await screen.findByPlaceholderText('Description');
+    // The add bar carries the row's description and the size of its amount…
+    const description = within(addBar()).getByLabelText('Description');
     expect(description).toHaveValue('Sandpiper Fuel');
-    expect(screen.getByLabelText('Amount')).toHaveValue('52.00');
+    expect(within(addBar()).getByLabelText('Amount')).toHaveValue('52.00');
     // …dated today, not the row's own date.
     const today = new Date();
     const dd = String(today.getDate()).padStart(2, '0');
     const mm = String(today.getMonth() + 1).padStart(2, '0');
-    expect(screen.getByLabelText('Transaction date')).toHaveValue(`${dd}/${mm}/${today.getFullYear()}`);
+    expect(within(addBar()).getByLabelText('Date')).toHaveValue(`${dd}/${mm}/${today.getFullYear()}`);
     // Nothing has been saved, and the cursor is where the edit will be made.
     expect(document.activeElement).toBe(description);
+    // And the row was let go of: two half-finished edits on one screen — a
+    // quick-edit box still open up in the register, a draft down here — is
+    // exactly the confusion this avoids.
+    expect(grid().getAttribute('aria-activedescendant')).toBeNull();
+    expect(document.querySelector('[data-quick-edit-panel]')).toBeNull();
   });
 });
 
@@ -587,10 +605,13 @@ describe('Account register — starting a new transaction', () => {
 
     expect(fireEvent.keyDown(grid(), { key: '+' })).toBe(false);
 
-    const date = await screen.findByLabelText('Transaction date');
-    expect(document.activeElement).toBe(date);
-    // The highlight let go, because the add bar took the quick editor's place.
+    const date = within(addBar()).getByLabelText('Date');
+    await waitFor(() => {
+      expect(document.activeElement).toBe(date);
+    });
+    // The highlight let go, and the quick-edit box with it.
     expect(grid().getAttribute('aria-activedescendant')).toBeNull();
+    expect(document.querySelector('[data-quick-edit-panel]')).toBeNull();
   });
 });
 
@@ -626,6 +647,13 @@ describe('Account register — the shortcut list', () => {
     expect(within(dialog).getByText(/Jump to the first or the last transaction/)).toBeInTheDocument();
     expect(within(dialog).getByText(/the same tick the R column shows/)).toBeInTheDocument();
     expect(within(dialog).getByText(/Open the other half of a transfer/)).toBeInTheDocument();
+    // The quick-edit box's own two keys, which is where most of the work in
+    // this register actually happens. A printed list that stops at the row
+    // level would be describing half the register.
+    expect(within(dialog).getByText(/The quick edit box under a row/)).toBeInTheDocument();
+    expect(within(dialog).getByText(/the first Enter picks the highlighted category/)).toBeInTheDocument();
+    expect(within(dialog).getByText(/Close the box and go back to the list/)).toBeInTheDocument();
+    expect(within(dialog).getByText(/Put the cursor in the quick edit box under the row/)).toBeInTheDocument();
     // And says out loud which keys the browser would not let it have.
     expect(within(dialog).getByText(/keeps those for opening its own windows and tabs/)).toBeInTheDocument();
   });
@@ -655,40 +683,63 @@ describe('Account register — the shortcut list', () => {
 });
 
 describe('Account register — F2 and the way back', () => {
-  it('puts the cursor in the quick edit bar, and Escape brings it back to the list', async () => {
+  it('puts the cursor in the quick edit box, and Escape brings it back to the list', async () => {
     await openRegister();
     highlight('Marigold Insurance');
 
     expect(fireEvent.keyDown(grid(), { key: 'F2' })).toBe(false);
 
-    const dockDate = screen.getByLabelText('Transaction date');
+    const boxDate = within(quickEditBox()).getByLabelText('Transaction date');
     await waitFor(() => {
-      expect(document.activeElement).toBe(dockDate);
+      expect(document.activeElement).toBe(boxDate);
     });
 
     // The date field opens its calendar on focus and answers the first Escape
-    // itself; the second reaches the bar and hands the keyboard back.
-    fireEvent.keyDown(dockDate, { key: 'Escape' });
-    fireEvent.keyDown(dockDate, { key: 'Escape' });
+    // itself; the second reaches the box and hands the keyboard back.
+    fireEvent.keyDown(boxDate, { key: 'Escape' });
+    fireEvent.keyDown(boxDate, { key: 'Escape' });
 
     expect(document.activeElement).toBe(grid());
-    // Still on the same row, so the next arrow key carries on where it was.
+    // Still on the same row, so the next arrow key carries on where it was —
+    // but the box itself has gone, which is the whole of what Escape promised.
     expect(activeRowText()).toContain('Marigold Insurance');
+    expect(document.querySelector('[data-quick-edit-panel]')).toBeNull();
   });
 
-  it('does not fire again when the bar comes back for another row', async () => {
+  it('opens the box again on a row whose box had been closed', async () => {
+    await openRegister();
+    highlight('Marigold Insurance');
+    fireEvent.keyDown(grid(), { key: 'Escape' }); // let go of the row entirely
+    highlight('Marigold Insurance');             // …and take it again
+
+    within(quickEditBox()).getByLabelText('Transaction date');
+
+    // Esc closes the box, leaving the row where it was…
+    fireEvent.keyDown(within(quickEditBox()).getByLabelText('Description'), { key: 'Escape' });
+    expect(document.querySelector('[data-quick-edit-panel]')).toBeNull();
+    expect(activeRowText()).toContain('Marigold Insurance');
+
+    // …and F2 brings it straight back, rather than being a dead key on a row
+    // that is plainly still selected.
+    expect(fireEvent.keyDown(grid(), { key: 'F2' })).toBe(false);
+    await waitFor(() => {
+      expect(document.activeElement).toBe(within(quickEditBox()).getByLabelText('Transaction date'));
+    });
+  });
+
+  it('does not fire again when the box comes back for another row', async () => {
     await openRegister();
     highlight('Marigold Insurance');
     fireEvent.keyDown(grid(), { key: 'F2' });
     await waitFor(() => {
-      expect(document.activeElement).toBe(screen.getByLabelText('Transaction date'));
+      expect(document.activeElement).toBe(within(quickEditBox()).getByLabelText('Transaction date'));
     });
 
-    // Clear the highlight (the bar unmounts) and pick a row again.
+    // Clear the highlight (the box unmounts) and pick a row again.
     fireEvent.keyDown(grid(), { key: 'Escape' });
     highlight('Thistledown Books');
 
-    await screen.findByLabelText('Transaction date');
+    within(quickEditBox()).getByLabelText('Transaction date');
     // The cursor stays with the register — a stale F2 must not steal it back.
     expect(document.activeElement).toBe(grid());
   });

--- a/src/pages/__tests__/AccountTransactions.test.tsx
+++ b/src/pages/__tests__/AccountTransactions.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor, within } from '@testing-library/react';
 import { MemoryRouter, Route, Routes } from 'react-router-dom';
 import { PreferencesProvider } from '../../contexts/PreferencesContext';
 import { ToastProvider } from '../../contexts/ToastContext';
@@ -216,10 +216,13 @@ describe('Account register — open, closed, and gone', () => {
     fireEvent.mouseDown(button);
     fireEvent.click(button);
 
-    // The deep-linked row arrives selected, docked in the quick-edit panel.
-    const description = await screen.findByLabelText('Description');
-    expect(description).toHaveValue('Synthetic closed row');
-    expect(document.querySelector('[data-quick-edit-panel]')).not.toBeNull();
+    // The deep-linked row arrives selected, with its quick-edit box open on it.
+    const box = await waitFor(() => {
+      const el = document.querySelector('[data-quick-edit-panel]');
+      if (!(el instanceof HTMLElement)) throw new Error('no quick-edit box is showing');
+      return el;
+    });
+    expect(within(box).getByLabelText('Description')).toHaveValue('Synthetic closed row');
   });
 
   it('leaves the account closed when the re-open fails', async () => {

--- a/src/utils/registerShortcuts.ts
+++ b/src/utils/registerShortcuts.ts
@@ -191,14 +191,20 @@ export const REGISTER_SHORTCUT_GROUPS: readonly RegisterShortcutGroup[] = [
         keys: ['a', 'b', 'c', '…'],
         what: 'Type a few letters to jump to the next transaction whose description starts with them. Keep pressing one letter to walk through every payee beginning with it.',
       },
-      { keys: ['Esc'], what: 'Clear the highlight, and put the add bar back at the bottom.' },
+      { keys: ['Esc'], what: 'Let go of the highlighted row — and the quick edit box under it.' },
     ],
   },
   {
     title: 'The highlighted transaction',
     shortcuts: [
-      { keys: ['Enter'], what: 'Open it in the full editor.' },
-      { keys: ['F2'], what: 'Jump down into the quick edit bar. Esc brings you back to the list.' },
+      {
+        keys: ['Enter'],
+        what: 'Open it in the full editor — splits, tags and everything the quick edit box has no room for.',
+      },
+      {
+        keys: ['F2'],
+        what: 'Put the cursor in the quick edit box under the row, opening it if it was closed.',
+      },
       {
         keys: ['Space'],
         what: 'Reconcile it, or un-reconcile it if it already is — the same tick the R column shows. Mid-way through typing a payee it types a space instead, so two-word names still find their row.',
@@ -211,6 +217,23 @@ export const REGISTER_SHORTCUT_GROUPS: readonly RegisterShortcutGroup[] = [
       {
         keys: ['Mod', 'D'],
         what: "Copy it into the add bar as a new transaction dated today — nothing is saved until you press Add.",
+      },
+    ],
+  },
+  {
+    // The box that opens under a clicked row: date, description, category,
+    // Save. Its two keys are worth printing because they are what make a
+    // categorising run continuous — the alternative is reaching for the mouse
+    // on every transaction.
+    title: 'The quick edit box under a row',
+    shortcuts: [
+      {
+        keys: ['Enter'],
+        what: 'Save the row. In the Category box the first Enter picks the highlighted category and the next one saves.',
+      },
+      {
+        keys: ['Esc'],
+        what: 'Close the box and go back to the list, leaving the row highlighted. Anything you had typed and not saved is dropped.',
       },
     ],
   },
@@ -236,7 +259,10 @@ export const REGISTER_SHORTCUT_GROUPS: readonly RegisterShortcutGroup[] = [
   {
     title: 'The rest of the page',
     shortcuts: [
-      { keys: ['+'], what: 'Start a new transaction — the cursor lands in the Date box of the add bar.' },
+      {
+        keys: ['+'],
+        what: 'Start a new transaction — the cursor lands in the Date box of the add bar, and the highlighted row is let go of.',
+      },
       { keys: ['Mod', 'F'], what: 'Open Search & filters with the cursor already in the search box.' },
       { keys: ['?'], what: 'Show this list.' },
     ],


### PR DESCRIPTION
Two halves, one batch: **the local edition's ledger core is complete**, and the register gains the interaction MS Money was loved for. No migrations.

## The edit box lives in the list now

Click a row → the quick-edit box appears **stuck to its underside**; rows beneath move down. Type to find a category, **Enter chooses it and lands the cursor on Save, Enter again saves** — the whole edit is two keystrokes. Escape closes the box (row stays highlighted, edits discarded silently — Money's rule); F2 opens it; **Save & Next walks it down the register** with the scroll following. The bottom dock keeps only Quick Add and the bulk-selection bar.

Engineering shape: the box is part of the row's **own height** in the virtualised list (`VariableSizeList`, one `rowDetail` prop), which is why every existing scroll behaviour — open-at-foot, deep-link centring, the whole keyboard suite — works on it **unmodified**. Pickers are portaled out of the clipping container. The suggested-category badge and Confirm come along because it is the *same* panel component, not a fork. The shortcuts dialog updated itself (it renders from the same module the keys read).

Needs a browser eye (jsdom cannot): the seam between row and box reading as one card; no jump on open; the floating calendar/category list near the register's foot; narrow widths and dark mode.

## The ledger core: nineteen verbs, complete

This closes the Rust money core's write surface: the restore family (`is_empty` / `wipe` / `restore_user_chunk` / `finalize`), `link_bank_account_snap`, `verify_integrity`, and `delete_unused_categories`, joining the twelve already merged.

- **Porting the wipe found a real schema defect**: the SQLite stand-in for a column-targeted `SET NULL` left a linked transfer half-cleared for one statement, and a local CHECK refused it — so "delete everything" failed on **any file holding a single linked transfer**, i.e. every real file. Fixed by clearing the link before the target, exactly as Postgres's key actions do.
- **Restore is one transaction** — provably better than the cloud's two passes (a split leg may name a counterpart in a later chunk, which Postgres cannot accept in any arrangement); the divergence is declared, not hidden.
- **Money bounds REFUSE by name.** The not-vacuous proof for this one: breaking it made restore silently store a thousand-fold smaller figure. That spec is the difference between a restore you trust and one you audit by hand.
- **`verify_integrity` is the local edition's self-check** — seventeen checks, every one proven to fire, including two new ingest checks (implausible card signs, implausible bank balance) that catch internally-consistent-but-wrong data nothing else can see. The cloud has no equivalent; its 24 specs are honestly counted as single-engine so they can never read as parity.
- **The category prune had to diverge to tell the truth**: SQLite's cascade removes a child before the delete scan reaches it, so the identical statement returns a different count than Postgres — and the count is what the user sees. The port qualifies-then-deletes deepest-first; all twenty probe cases agree. One cloud defect (a pruned child leaving a dangling category reference) is reproduced deliberately with a spec naming it — and locally, `verify_integrity` now reports what the cloud cannot.
- One decision recorded rather than ported: `migrate_categories_atomic` translates between two id spaces a local file never has.

## Verification

- **203 crate tests**, clippy clean under the crate's denies
- **259/259 differential verb specs** (7 declared divergences, 24 single-engine, counted separately)
- **66/66 constraint specs**; coverage gate PASS
- `npm run lint`, `npm run typecheck:strict`, `npm run test:smoke` (**4,551**) — clean
- Every behaviour carries a break-it/watch-it-fail/restore proof; the verifier additionally caught and fixed one schema-copy lockstep violation and one four-test overcount in an agent report — recorded, because claims-versus-observed is the method
- No real financial data anywhere

Remaining in Phase 1: the ingest command surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
