### PR TITLE
feat: preferences that travel with the account, and a delete that finishes

### DIFF
--- a/scripts/local-sqlite/schema.sql
+++ b/scripts/local-sqlite/schema.sql
@@ -82,6 +82,30 @@
 --                  <scratchpad>/local-core/schema.sql   -> no output
 --         (88 = this header is 85 lines and two blank ones.)
 --         Specs: verb-specs/integrity-*.
+--
+-- AMENDED 2026-08-09 (5), in THIS COPY ONLY, mirroring
+--         supabase/migrations/20260809160000_preferences_that_travel.sql:
+--         `user_preferences`, one row per user holding the settings that belong
+--         to the ACCOUNT rather than to the browser. A cloud backup carries the
+--         document (services/backupService writes it as a top-level
+--         `preferences` section), so a local file that could not hold it would
+--         restore the ledger and drop every choice about how to read it —
+--         which is the exact failure the cloud migration exists to fix.
+--
+--         THIS COPY ONLY, on amendment (2)'s precedent and for the same reason:
+--         the scratchpad draft predates the cloud migration, this file is what
+--         executes, and when the two are reconciled the change travels in this
+--         direction. This copy is now ahead of the draft by amendment (2)'s one
+--         column and by this one table.
+--
+--         NO OWNERSHIP PAIRING, and that is not an omission: the composite-FK
+--         pattern of 20260808170000 exists so that a row naming an ACCOUNT
+--         cannot name one belonging to somebody else. user_preferences names no
+--         account — it references users(id) alone, which is the anchor the
+--         pairing is built from, not a thing that needs pairing. Account ids do
+--         appear INSIDE the document (dashboardKeyAccounts, the archive
+--         overrides), and they are unreferencable text there by construction:
+--         see the note at the table.
 -- ============================================================================
 
 
@@ -1436,6 +1460,39 @@ CREATE TABLE widget_preferences (
   created_at     TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now')),
   updated_at     TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now')),
   UNIQUE (user_id, widget_type)
+) STRICT;
+
+-- Mirrors supabase/migrations/20260809160000_preferences_that_travel.sql. One
+-- row per user, one versioned document, holding every setting that belongs to
+-- the account rather than to the browser.
+--
+-- Differences from the cloud, both forced by SQLite and neither a change of
+-- meaning:
+--   * jsonb has no local equivalent, so the document is TEXT guarded by
+--     json_valid() plus json_type() = 'object' — the pair that reproduces the
+--     cloud's jsonb-plus-jsonb_typeof check. A caller must not be able to store
+--     an array here; every reader indexes into it by key.
+--   * the cloud's size ceiling is `length(prefs::text) <= 262144`; length() over
+--     the TEXT is literally the same measurement, so the number is carried
+--     across unchanged rather than re-derived.
+--
+-- Account ids DO appear inside the document (dashboardKeyAccounts, the archive
+-- overrides map). They are deliberately NOT foreign keys and cannot be: they sit
+-- inside JSON, one level below anything a key can address. Nothing depends on
+-- them resolving — a pinned account that no longer exists is skipped by the
+-- dashboard, exactly as it is today — and the restore rewrites them through the
+-- same id map every other reference goes through (see
+-- backupService.remapPreferenceIds). That is the only mechanism available and
+-- the only one needed; a preference is not a ledger entry.
+CREATE TABLE user_preferences (
+  id         TEXT PRIMARY KEY,
+  user_id    TEXT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  prefs      TEXT NOT NULL DEFAULT '{}'
+             CHECK (json_valid(prefs) AND json_type(prefs) = 'object'),
+  created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now')),
+  updated_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now')),
+  CHECK (length(prefs) <= 262144),
+  UNIQUE (user_id)
 ) STRICT;
 
 

--- a/src/components/ArchiveManager.tsx
+++ b/src/components/ArchiveManager.tsx
@@ -27,14 +27,40 @@ import {
   type AccountArchiveOverrides, type ArchivePreset,
 } from '../utils/archive';
 import { formatDate } from '../utils/dateFormatter';
+import { preferences } from '../services/preferencesService';
 import type { Account } from '../types';
 
 /** Which bands the user has folded away, remembered like the Accounts page's. */
 const COLLAPSED_STORAGE_KEY = 'archiveManager.collapsedGroups.v1';
 
+/**
+ * The global cutoff, and the custom date behind it.
+ *
+ * NOT STORED AT ALL until now — a plain `useState('12m')` — so the owner set a
+ * range, archived one account, and found the page back on twelve months the
+ * next time he opened it. His per-account overrides were remembered and the
+ * choice they override was not, which is the worst of both: the page came back
+ * saying something he had not said. It is a preference about HIS accounts, so
+ * it travels with the account like the overrides beside it.
+ */
+const PRESET_STORAGE_KEY = 'archiveManager.preset.v1';
+const CUSTOM_DATE_STORAGE_KEY = 'archiveManager.customDate.v1';
+
+/** Membership of the one list the picker is built from, so the two cannot drift. */
+const isArchivePreset = (value: string | null): value is ArchivePreset =>
+  value !== null && ARCHIVE_PRESETS.some(preset => preset.value === value);
+
+const readPreset = (): ArchivePreset => {
+  const stored = preferences.getItem(PRESET_STORAGE_KEY);
+  return isArchivePreset(stored) ? stored : '12m';
+};
+
+/** 'YYYY-MM-DD', or empty. Only read when the preset is 'custom'. */
+const readCustomDate = (): string => preferences.getItem(CUSTOM_DATE_STORAGE_KEY) ?? '';
+
 const readCollapsedGroups = (): Set<string> => {
   try {
-    const stored = localStorage.getItem(COLLAPSED_STORAGE_KEY);
+    const stored = preferences.getItem(COLLAPSED_STORAGE_KEY);
     const parsed: unknown = stored ? JSON.parse(stored) : null;
     return Array.isArray(parsed)
       ? new Set(parsed.filter((key): key is string => typeof key === 'string'))
@@ -47,7 +73,7 @@ const readCollapsedGroups = (): Set<string> => {
 
 const readOverrides = (): AccountArchiveOverrides => {
   try {
-    return parseAccountArchiveOverrides(localStorage.getItem(ARCHIVE_OVERRIDES_STORAGE_KEY));
+    return parseAccountArchiveOverrides(preferences.getItem(ARCHIVE_OVERRIDES_STORAGE_KEY));
   } catch {
     return {};
   }
@@ -59,8 +85,8 @@ export default function ArchiveManager() {
   const navigate = useNavigate();
   const location = useLocation();
 
-  const [preset, setPreset] = useState<ArchivePreset>('12m');
-  const [customDate, setCustomDate] = useState('');
+  const [preset, setPresetState] = useState<ArchivePreset>(readPreset);
+  const [customDate, setCustomDateState] = useState(readCustomDate);
   const [busyAccountId, setBusyAccountId] = useState<string | null>(null);
   const [collapsedGroups, setCollapsedGroups] = useState<Set<string>>(readCollapsedGroups);
   const [overrides, setOverrides] = useState<AccountArchiveOverrides>(readOverrides);
@@ -71,12 +97,30 @@ export default function ArchiveManager() {
 
   useEffect(() => {
     try {
-      localStorage.setItem(ARCHIVE_OVERRIDES_STORAGE_KEY, serializeAccountArchiveOverrides(overrides));
+      preferences.setItem(ARCHIVE_OVERRIDES_STORAGE_KEY, serializeAccountArchiveOverrides(overrides));
     } catch {
       // Storage may be unavailable (private mode); the override still works
       // for this visit, it just will not be remembered.
     }
   }, [overrides]);
+
+  /**
+   * Written on the click that made the choice, not in an effect.
+   *
+   * An effect would also fire on the first render and write the default back —
+   * harmless here, but it makes "12m because you chose it" and "12m because
+   * nobody has chosen" the same stored value, and this page has already been
+   * confusing about exactly that.
+   */
+  const setPreset = useCallback((next: ArchivePreset) => {
+    setPresetState(next);
+    preferences.setItem(PRESET_STORAGE_KEY, next);
+  }, []);
+
+  const setCustomDate = useCallback((next: string) => {
+    setCustomDateState(next);
+    preferences.setItem(CUSTOM_DATE_STORAGE_KEY, next);
+  }, []);
 
   // Archivable accounts: open, non-investment (investments excluded in v1),
   // alphabetical — the bands preserve input order, so sorting once here sorts
@@ -115,7 +159,7 @@ export default function ArchiveManager() {
       const next = new Set(prev);
       if (next.has(key)) next.delete(key); else next.add(key);
       try {
-        localStorage.setItem(COLLAPSED_STORAGE_KEY, JSON.stringify([...next]));
+        preferences.setItem(COLLAPSED_STORAGE_KEY, JSON.stringify([...next]));
       } catch {
         // Unwritable storage costs the memory of the fold, not the fold itself.
       }
@@ -342,6 +386,11 @@ export default function ArchiveManager() {
             {ARCHIVE_PRESETS.map(p => (
               <button
                 key={p.value}
+                type="button"
+                // A segmented control is a group of toggles, and until now the
+                // only thing saying which one was chosen was a background
+                // colour — invisible to a screen reader and to a test.
+                aria-pressed={preset === p.value}
                 onClick={() => setPreset(p.value)}
                 className={`px-3 py-1.5 text-sm font-medium rounded-md transition-colors ${
                   preset === p.value

--- a/src/components/MonthlyIncomeExpenseMatrix.tsx
+++ b/src/components/MonthlyIncomeExpenseMatrix.tsx
@@ -2,6 +2,7 @@ import React, { useState } from 'react';
 import { useCurrencyDecimal } from '../hooks/useCurrencyDecimal';
 import { CalendarIcon } from './icons';
 import type { MatrixGroup, MonthlyCategoryMatrix } from '../utils/monthlyCategoryMatrix';
+import { preferences } from '../services/preferencesService';
 
 /**
  * "Monthly income and expenses" — the Microsoft Money report: every category
@@ -67,11 +68,11 @@ export default function MonthlyIncomeExpenseMatrix({
   // Group subtotals only, or every category beneath them — persisted like the
   // page's other view preferences. Groups-only keeps a deep tree readable.
   const [showDetail, setShowDetail] = useState<boolean>(
-    () => localStorage.getItem(DETAIL_KEY) !== '0'
+    () => preferences.getItem(DETAIL_KEY) !== '0'
   );
   const toggleDetail = (): void => {
     setShowDetail(prev => {
-      localStorage.setItem(DETAIL_KEY, prev ? '0' : '1');
+      preferences.setItem(DETAIL_KEY, prev ? '0' : '1');
       return !prev;
     });
   };

--- a/src/components/RestoreBackupModal.tsx
+++ b/src/components/RestoreBackupModal.tsx
@@ -9,6 +9,7 @@ import {
   BACKUP_ENTITIES,
   RestoreFailedError,
   restoreBackupBundle,
+  preferenceCount,
   transactionDateRange,
   userFinancialDataIsEmpty,
   validateBackupBundle,
@@ -98,6 +99,15 @@ interface Outcome {
   notStoredLocally: { label: string; rows: number; absence: string }[];
   accountsRelinked: number;
   transactionsRelinked: number;
+  /**
+   * Settings put back, and the reason if they could not be. Reported beside the
+   * row counts rather than thrown, because preferences go in AFTER every
+   * financial row: a complete ledger with default toggles is a good outcome
+   * that happens to be missing something, and calling it a failed restore would
+   * send the user to wipe and start again for no reason.
+   */
+  preferencesRestored: number;
+  preferencesFailure: string | null;
   danglingRefs: DanglingReference[];
 }
 
@@ -347,6 +357,16 @@ export default function RestoreBackupModal({ isOpen, onClose }: Props): React.JS
                   ))}
                 </ul>
               )}
+              {/* Only when the file actually carries some. A line reading
+                  "Preferences 0" on a file written before they were carried
+                  would suggest the user had none, which is a different and
+                  wrong statement. */}
+              {preferenceCount(bundle) > 0 && (
+                <p className="text-sm text-gray-600 dark:text-gray-400 mt-3">
+                  Plus {formatCount(preferenceCount(bundle))} saved settings — pinned accounts and
+                  reports, periods, grouping, hidden columns, archive cutoffs.
+                </p>
+              )}
             </div>
 
             {targetIsEmpty === false && (
@@ -470,7 +490,27 @@ export default function RestoreBackupModal({ isOpen, onClose }: Props): React.JS
                 <span className="text-gray-600 dark:text-gray-400">Nested accounts reconnected</span>
                 <span className="text-gray-900 dark:text-white tabular-nums">{formatCount(outcome.accountsRelinked)}</span>
               </li>
+              <li className="flex justify-between gap-4 px-4 py-2 text-sm">
+                <span className="text-gray-600 dark:text-gray-400">Preferences</span>
+                <span className="text-gray-900 dark:text-white tabular-nums">{formatCount(outcome.preferencesRestored)}</span>
+              </li>
             </ul>
+            {/* Said plainly, and with what to do about it: the ledger is whole,
+                so this is a small, separately fixable disappointment rather
+                than a reason to start the restore again. */}
+            {outcome.preferencesFailure !== null && (
+              <div className="rounded-xl border border-amber-200 dark:border-amber-800 bg-amber-50 dark:bg-amber-900/20 p-3">
+                <p className="text-sm text-amber-900 dark:text-amber-200">
+                  Your saved settings could not be put back, so the app will open with its defaults —
+                  pinned accounts, periods, grouping and archive cutoffs will need setting again.
+                  Everything financial is in. Your backup file still holds them, so restoring it again
+                  later will bring them back.
+                </p>
+                <p className="text-xs text-amber-800 dark:text-amber-300 mt-2 font-mono break-words">
+                  {outcome.preferencesFailure}
+                </p>
+              </div>
+            )}
             {/* Named, not counted: "3 investments were skipped" tells someone
                 nothing they can act on, whereas knowing the file still holds
                 them and where they would come back does. */}

--- a/src/components/__tests__/ArchiveManager.preset.test.tsx
+++ b/src/components/__tests__/ArchiveManager.preset.test.tsx
@@ -1,0 +1,85 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { ToastProvider } from '../../contexts/ToastContext';
+import ArchiveManager from '../ArchiveManager';
+import { preferences } from '../../services/preferencesService';
+
+/**
+ * The bug, as the owner reported it: he set the archive range, came back to the
+ * page, and it was on twelve months again. The per-account overrides beside it
+ * WERE remembered, so the page came back saying something he had not said —
+ * the worst of both.
+ *
+ * It was a plain `useState('12m')` with nothing behind it. It is a preference
+ * about HIS accounts now, which means it survives a refresh AND travels to the
+ * next machine, like the overrides it overrides.
+ *
+ * The app context is the shared synthetic double from src/test/setup.ts — this
+ * repo is public, so no real figures appear anywhere.
+ */
+
+const renderArchiveManager = () =>
+  render(
+    <MemoryRouter initialEntries={['/settings/data']}>
+      <ToastProvider>
+        <ArchiveManager />
+      </ToastProvider>
+    </MemoryRouter>
+  );
+
+const presetButton = (label: string) => screen.getByRole('button', { name: label });
+
+describe('ArchiveManager — the range it opens on', () => {
+  beforeEach(() => {
+    preferences.detach();
+    localStorage.clear();
+  });
+
+  it('starts on twelve months when nothing has been chosen', () => {
+    renderArchiveManager();
+    expect(presetButton('12 months')).toHaveAttribute('aria-pressed', 'true');
+    expect(preferences.getItem('archiveManager.preset.v1')).toBeNull();
+  });
+
+  it('remembers the range across a remount — the reported bug', () => {
+    const first = renderArchiveManager();
+    fireEvent.click(presetButton('24 months'));
+    expect(presetButton('24 months')).toHaveAttribute('aria-pressed', 'true');
+    first.unmount();
+
+    renderArchiveManager();
+    expect(presetButton('24 months')).toHaveAttribute('aria-pressed', 'true');
+    expect(presetButton('12 months')).toHaveAttribute('aria-pressed', 'false');
+  });
+
+  it('stores the choice as a preference, so it follows the account', () => {
+    renderArchiveManager();
+    fireEvent.click(presetButton('6 months'));
+    expect(preferences.getItem('archiveManager.preset.v1')).toBe('6m');
+  });
+
+  it('remembers a custom date, not just the fact that it was custom', () => {
+    const first = renderArchiveManager();
+    fireEvent.click(presetButton('Custom date'));
+    // Typed the way the field is read — dd/mm/yyyy everywhere, because a native
+    // date input would render in the browser's locale rather than the app's.
+    fireEvent.change(screen.getByLabelText('Custom archive cutoff date'), {
+      target: { value: '06/04/2019' },
+    });
+    expect(preferences.getItem('archiveManager.customDate.v1')).toBe('2019-04-06');
+    first.unmount();
+
+    renderArchiveManager();
+    expect(presetButton('Custom date')).toHaveAttribute('aria-pressed', 'true');
+    expect(screen.getByLabelText('Custom archive cutoff date')).toHaveValue('06/04/2019');
+  });
+
+  it('ignores a stored value that is not one of the ranges offered', () => {
+    // Storage is hand-editable and travels through a JSON document; a value the
+    // picker cannot show must not leave the page with no range selected.
+    preferences.setItem('archiveManager.preset.v1', 'since-the-dawn-of-time');
+    renderArchiveManager();
+    expect(presetButton('12 months')).toHaveAttribute('aria-pressed', 'true');
+  });
+});

--- a/src/components/dashboard/ImprovedDashboard.tsx
+++ b/src/components/dashboard/ImprovedDashboard.tsx
@@ -49,6 +49,7 @@ import { buildAttentionItems } from '../../utils/attentionItems';
 import { loadAutoSyncPrefs } from '../../utils/bankAutoSync';
 import { buildAccountBankLinks } from '../../hooks/useAccountBankSync';
 import { useBankConnectionSnapshot } from '../../hooks/useBankConnectionSnapshot';
+import { preferences } from '../../services/preferencesService';
 
 /** Where each half of the reports box remembers its period. */
 const ASSETS_PERIOD_KEY = 'dashboardReports';
@@ -81,7 +82,7 @@ export function ImprovedDashboard() {
   // to different users.
   const [pinnedReports, setPinnedReports] = useState<PinnableReportId[]>(() => {
     try {
-      const stored = JSON.parse(localStorage.getItem('dashboardPinnedReports') ?? 'null');
+      const stored = JSON.parse(preferences.getItem('dashboardPinnedReports') ?? 'null');
       if (Array.isArray(stored)) return stored as PinnableReportId[];
     } catch { /* fall through to the default */ }
     return ['net-worth'];
@@ -105,22 +106,23 @@ export function ImprovedDashboard() {
   const togglePinnedReport = (id: PinnableReportId): void => {
     setPinnedReports(prev => {
       const next = prev.includes(id) ? prev.filter(p => p !== id) : [...prev, id];
-      localStorage.setItem('dashboardPinnedReports', JSON.stringify(next));
+      preferences.setItem('dashboardPinnedReports', JSON.stringify(next));
       return next;
     });
   };
   
-  // Load saved preferences from localStorage
+  // Which accounts the owner put on his own front page. A statement about HIS
+  // accounts, so it travels with the account rather than with this browser.
   useEffect(() => {
     try {
-      const saved = localStorage.getItem('dashboardKeyAccounts');
+      const saved = preferences.getItem('dashboardKeyAccounts');
       const parsed = saved ? JSON.parse(saved) : null;
       if (Array.isArray(parsed)) {
         setSelectedAccountIds(parsed);
         return;
       }
     } catch {
-      localStorage.removeItem('dashboardKeyAccounts');
+      preferences.removeItem('dashboardKeyAccounts');
     }
     // Default to showing first 4 accounts
     setSelectedAccountIds(accounts.slice(0, 4).map(a => a.id));
@@ -300,7 +302,7 @@ export function ImprovedDashboard() {
   }), [isDarkMode]);
 
   const persistSelection = useCallback((ids: string[]) => {
-    localStorage.setItem('dashboardKeyAccounts', JSON.stringify(ids));
+    preferences.setItem('dashboardKeyAccounts', JSON.stringify(ids));
     setSelectedAccountIds(ids);
   }, []);
 
@@ -310,8 +312,7 @@ export function ImprovedDashboard() {
         ? prev.filter(id => id !== accountId)
         : [...prev, accountId];
 
-      // Save to localStorage
-      localStorage.setItem('dashboardKeyAccounts', JSON.stringify(newSelection));
+      preferences.setItem('dashboardKeyAccounts', JSON.stringify(newSelection));
       return newSelection;
     });
   };

--- a/src/components/reports/TopTransactionsTable.tsx
+++ b/src/components/reports/TopTransactionsTable.tsx
@@ -5,6 +5,7 @@ import { buildCategoryNameLookup } from '../../utils/categoryNames';
 import { selectTopTransactions } from '../../utils/topTransactions';
 import type { Category } from '../../types';
 import type { SplitExpandedTransaction } from '../../utils/transactionSplits';
+import { preferences } from '../../services/preferencesService';
 
 /**
  * The biggest real money movements of the period, on the "Monthly income and
@@ -50,7 +51,7 @@ export default function TopTransactionsTable({
   const { formatCurrency } = useCurrencyDecimal();
   // A curiosity next to the matrix, so it starts hidden; the choice is
   // persisted like the report's other view preferences.
-  const [show, setShow] = useState<boolean>(() => localStorage.getItem(SHOW_KEY) === '1');
+  const [show, setShow] = useState<boolean>(() => preferences.getItem(SHOW_KEY) === '1');
   const [sortKey, setSortKey] = useState<SortKey>('date');
   const [sortDir, setSortDir] = useState<1 | -1>(-1);
 
@@ -60,7 +61,7 @@ export default function TopTransactionsTable({
 
   const toggle = (): void => {
     setShow(prev => {
-      localStorage.setItem(SHOW_KEY, prev ? '0' : '1');
+      preferences.setItem(SHOW_KEY, prev ? '0' : '1');
       return !prev;
     });
   };

--- a/src/contexts/AppContextSupabase.tsx
+++ b/src/contexts/AppContextSupabase.tsx
@@ -52,6 +52,7 @@ import type {
 } from '../types';
 import { createScopedLogger } from '../loggers/scopedLogger';
 import { planCategoryTreeImport, planCategoryPrune, type CategoryTreeGroup } from '../utils/categoryTreeImport';
+import { preferences as preferencesService } from '../services/preferencesService';
 
 export interface Tag {
   id: string;
@@ -382,7 +383,16 @@ export function AppProvider({ children }: { children: React.ReactNode }) {
           markPhase('auth');
           if (databaseId) {
             appLogger.info('Database user ID resolved', { databaseId });
-            
+
+            // Bind the preferences document to this login. Deliberately NOT
+            // awaited: it is one small read that nothing on the critical path
+            // depends on, every surface already has this browser's copy to
+            // start from, and the service notifies its subscribers when the
+            // account's own settings land a moment later. Awaiting it would put
+            // a round trip in front of the first account query for no gain, and
+            // a slow or missing preferences table would delay the ledger.
+            void preferencesService.attach(databaseId);
+
             // Initialize AutoSync with the database ID ready
             await AutoSyncService.initialize(user.id);
             
@@ -423,6 +433,10 @@ export function AppProvider({ children }: { children: React.ReactNode }) {
           // the sign-out was triggered): the cached history belongs to whoever
           // was signed in and must not survive on a shared browser.
           void transactionCache.clear();
+          // Stop writing this browser's copy up to a login that is no longer
+          // here. The mirror stays: it is what the next signed-out session
+          // reads, and it belongs to the browser rather than to the account.
+          preferencesService.detach();
         }
         
         // Categories MUST resolve before transactions/budgets are read:

--- a/src/contexts/NotificationContext.test.tsx
+++ b/src/contexts/NotificationContext.test.tsx
@@ -66,6 +66,7 @@ vi.mock('../services/notificationService', () => ({
 }));
 
 import { notificationService } from '../services/notificationService';
+import { preferences } from '../services/preferencesService';
 
 describe('NotificationContext', () => {
   beforeEach(() => {
@@ -264,14 +265,18 @@ describe('NotificationContext', () => {
       // Two mounts of the same browser: the second must not write the flags
       // again, or a user who switched alerts off between them would be
       // overruled on their next page load.
-      const store = primeStorage({ 'money_management_budget_alerts_enabled': 'false' });
+      primeStorage({ 'money_management_budget_alerts_enabled': 'false' });
 
       const first = renderHook(() => useNotifications(), { wrapper });
       expect(first.result.current.budgetAlertsEnabled).toBe(true);
       first.unmount();
 
-      // The user now deliberately switches budget alerts off.
-      store['money_management_budget_alerts_enabled'] = 'false';
+      // The user now deliberately switches budget alerts off. Written through
+      // the preferences document, because that is where an alert preference
+      // lives — it belongs to the account, so "warn me over £500" does not have
+      // to be said again on the next machine. The one-time repair MARKER stays
+      // in this browser's storage, since it records a fix applied here.
+      preferences.setItem('money_management_budget_alerts_enabled', 'false');
       mockLocalStorage.setItem.mockClear();
 
       const second = renderHook(() => useNotifications(), { wrapper });

--- a/src/contexts/NotificationContext.tsx
+++ b/src/contexts/NotificationContext.tsx
@@ -5,6 +5,7 @@ import { notificationService, type BudgetAlertContext } from '../services/notifi
 import type { Goal, Budget, Transaction, Category } from '../types';
 import { useCurrencyDecimal } from '../hooks/useCurrencyDecimal';
 import { logActivity } from '../hooks/useActivityTracking';
+import { preferences } from '../services/preferencesService';
 
 const NOTIFICATION_TYPES = ['info', 'success', 'warning', 'error'] as const;
 export type NotificationType = (typeof NOTIFICATION_TYPES)[number];
@@ -118,8 +119,8 @@ const ALERT_PREFS_MIGRATION_KEY = 'wt_alert_prefs_migrated_v1';
 function migrateAlertPreferencesOnce(): void {
   try {
     if (localStorage.getItem(ALERT_PREFS_MIGRATION_KEY) !== null) return;
-    localStorage.setItem(BUDGET_ALERTS_ENABLED_KEY, String(DEFAULT_BUDGET_ALERTS_ENABLED));
-    localStorage.setItem(
+    preferences.setItem(BUDGET_ALERTS_ENABLED_KEY, String(DEFAULT_BUDGET_ALERTS_ENABLED));
+    preferences.setItem(
       LARGE_TRANSACTION_ALERTS_ENABLED_KEY,
       String(DEFAULT_LARGE_TRANSACTION_ALERTS_ENABLED)
     );
@@ -130,10 +131,20 @@ function migrateAlertPreferencesOnce(): void {
   }
 }
 
-/** A stored on/off preference, or `fallback` when none has been saved. */
+/**
+ * A stored on/off preference, or `fallback` when none has been saved.
+ *
+ * The four alert preferences below read and write the PREFERENCES DOCUMENT,
+ * which travels with the account: "warn me when a transaction is over £500" is
+ * a statement about the user's money, and having to say it again on every
+ * machine is exactly the reset the restore exposed. The one-time repair marker
+ * above stays in localStorage — it records a fix applied to THIS browser's
+ * wrongly-stored `false`, and re-applying it elsewhere would overwrite a real
+ * choice with a default.
+ */
 function readStoredFlag(key: string, fallback: boolean): boolean {
   try {
-    const saved = localStorage.getItem(key);
+    const saved = preferences.getItem(key);
     if (saved === null) return fallback;
     return saved === 'true';
   } catch {
@@ -144,7 +155,7 @@ function readStoredFlag(key: string, fallback: boolean): boolean {
 /** A stored numeric preference, or `fallback` when none has been saved. */
 function readStoredNumber(key: string, fallback: number): number {
   try {
-    const saved = localStorage.getItem(key);
+    const saved = preferences.getItem(key);
     if (saved === null) return fallback;
     const parsed = parseInt(saved, 10);
     return Number.isFinite(parsed) ? parsed : fallback;
@@ -388,19 +399,19 @@ export function NotificationProvider({ children }: { children: ReactNode }): Rea
   }, [notifications]);
 
   useEffect((): void => {
-    localStorage.setItem(BUDGET_ALERTS_ENABLED_KEY, budgetAlertsEnabled.toString());
+    preferences.setItem(BUDGET_ALERTS_ENABLED_KEY, budgetAlertsEnabled.toString());
   }, [budgetAlertsEnabled]);
 
   useEffect((): void => {
-    localStorage.setItem('money_management_alert_threshold', alertThreshold.toString());
+    preferences.setItem('money_management_alert_threshold', alertThreshold.toString());
   }, [alertThreshold]);
 
   useEffect((): void => {
-    localStorage.setItem(LARGE_TRANSACTION_ALERTS_ENABLED_KEY, largeTransactionAlertsEnabled.toString());
+    preferences.setItem(LARGE_TRANSACTION_ALERTS_ENABLED_KEY, largeTransactionAlertsEnabled.toString());
   }, [largeTransactionAlertsEnabled]);
 
   useEffect((): void => {
-    localStorage.setItem('money_management_large_transaction_threshold', largeTransactionThreshold.toString());
+    preferences.setItem('money_management_large_transaction_threshold', largeTransactionThreshold.toString());
   }, [largeTransactionThreshold]);
 
   const addNotification = useCallback((notification: Omit<Notification, 'id' | 'timestamp' | 'read'>): void => {

--- a/src/contexts/PreferencesContext.test.tsx
+++ b/src/contexts/PreferencesContext.test.tsx
@@ -1,26 +1,30 @@
 /**
- * PreferencesContext Tests
- * Context provider and consumer behavior
+ * PreferencesContext — context provider and consumer behaviour.
+ *
+ * These read and write through `preferences` (services/preferencesService)
+ * rather than through `localStorage`, because that is where the context now
+ * keeps its values: the point of the change is that a currency or a theme
+ * belongs to the ACCOUNT and follows it, instead of living in one browser and
+ * vanishing from every backup.
+ *
+ * The store is used for real, not mocked. It is a plain in-memory document with
+ * an injectable browser mirror, so there is nothing to fake — and a mock would
+ * only prove that the context calls a function, whereas these prove the value
+ * comes back.
  */
 
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { renderHook, act } from '@testing-library/react';
 import { PreferencesProvider, usePreferences } from './PreferencesContext';
-
-// Mock localStorage
-const mockLocalStorage = {
-  getItem: vi.fn(),
-  setItem: vi.fn(),
-  removeItem: vi.fn(),
-  clear: vi.fn(),
-};
-global.localStorage = mockLocalStorage as any;
+import { preferences } from '../services/preferencesService';
 
 describe('PreferencesContext', () => {
   beforeEach(() => {
-    vi.clearAllMocks();
-    // Mock localStorage to return null initially
-    mockLocalStorage.getItem.mockReturnValue(null);
+    // Empties the in-memory document the way signing out does. The service is a
+    // module-level singleton shared with every other suite in the process, so
+    // without this a value set here would leak into the next case.
+    preferences.detach();
+    localStorage.clear();
   });
 
   it('provides default preferences values', () => {
@@ -34,21 +38,11 @@ describe('PreferencesContext', () => {
     expect(result.current.firstName).toBe('');
   });
 
-  it('loads preferences from localStorage', () => {
-    mockLocalStorage.getItem.mockImplementation((key) => {
-      switch (key) {
-        case 'money_management_compact_view':
-          return 'true';
-        case 'money_management_currency':
-          return 'USD';
-        case 'money_management_theme':
-          return 'dark';
-        case 'money_management_first_name':
-          return 'John';
-        default:
-          return null;
-      }
-    });
+  it('loads preferences from the stored document', () => {
+    preferences.setItem('money_management_compact_view', 'true');
+    preferences.setItem('money_management_currency', 'USD');
+    preferences.setItem('money_management_theme', 'dark');
+    preferences.setItem('money_management_first_name', 'John');
 
     const { result } = renderHook(() => usePreferences(), {
       wrapper: PreferencesProvider,
@@ -60,39 +54,54 @@ describe('PreferencesContext', () => {
     expect(result.current.firstName).toBe('John');
   });
 
-  it('saves preferences to localStorage when changed', async () => {
+  it('reads a preference this browser holds but the document has not seen yet', () => {
+    // The first boot after this shipped: every setting the user already has is
+    // in browser storage under exactly these keys, and must not be forgotten in
+    // the window before the account's document arrives.
+    localStorage.setItem('money_management_currency', 'USD');
+
     const { result } = renderHook(() => usePreferences(), {
       wrapper: PreferencesProvider,
     });
 
-    // Clear the initial calls to setItem
-    mockLocalStorage.setItem.mockClear();
+    expect(result.current.currency).toBe('USD');
+  });
+
+  it('saves preferences when changed', async () => {
+    const { result } = renderHook(() => usePreferences(), {
+      wrapper: PreferencesProvider,
+    });
 
     act(() => {
       result.current.setCurrency('EUR');
     });
 
-    // Wait for the debounced save (300ms + buffer)
+    // The context batches its write-through by 300ms.
     await act(async () => {
       await new Promise(resolve => setTimeout(resolve, 400));
     });
 
-    expect(mockLocalStorage.setItem).toHaveBeenCalledWith(
-      'money_management_currency',
-      'EUR'
-    );
+    expect(preferences.getItem('money_management_currency')).toBe('EUR');
+    // …and into the browser mirror as well, which is what makes the setting
+    // survive a reload with no network.
+    expect(localStorage.getItem('money_management_currency')).toBe('EUR');
   });
 
-  it('handles invalid localStorage data gracefully', () => {
-    mockLocalStorage.getItem.mockReturnValue(null);
+  it('falls back to defaults when a stored value is unusable', () => {
+    preferences.setItem('money_management_theme', 'chartreuse');
+    preferences.setItem('money_management_theme_schedule', '{not json');
 
     const { result } = renderHook(() => usePreferences(), {
       wrapper: PreferencesProvider,
     });
 
-    // Should fall back to defaults
     expect(result.current.currency).toBe('GBP');
     expect(result.current.theme).toBe('light');
+    expect(result.current.themeSchedule).toEqual({
+      enabled: false,
+      lightStartTime: '06:00',
+      darkStartTime: '18:00',
+    });
   });
 
   it('provides actualTheme based on system preference', () => {

--- a/src/contexts/PreferencesContext.tsx
+++ b/src/contexts/PreferencesContext.tsx
@@ -1,6 +1,28 @@
 /* eslint-disable react-refresh/only-export-components */
 import { createContext, useContext, useState, useEffect, useCallback } from 'react';
 import type { ReactNode } from 'react';
+import { preferences } from '../services/preferencesService';
+
+/**
+ * App-wide display preferences.
+ *
+ * These used to be read from and written to `window.localStorage` directly, and
+ * that is why a restored backup came up in the wrong currency with the wrong
+ * name and the wrong theme: they were never in the database, so they were never
+ * in the file. They now go through the preferences document, which travels with
+ * the account (services/preferencesService).
+ *
+ * The VALUES are stored exactly as before — `'true'`, `'GBP'`, the schedule as
+ * JSON — so nothing about the format changed and an existing browser is read
+ * back unchanged. Only the home moved.
+ *
+ * This provider mounts ABOVE AppProvider, so the signed-in identity does not
+ * exist when it first renders. It therefore reads the service's synchronous
+ * snapshot (which starts from this browser's own copy) and SUBSCRIBES: when the
+ * account's document arrives a moment later, every value here corrects itself
+ * once. Without that subscription a new machine would show defaults for the
+ * whole session and then save them over the real ones.
+ */
 
 interface PreferencesContextType {
   compactView: boolean;
@@ -29,94 +51,98 @@ interface PreferencesContextType {
 
 const PreferencesContext = createContext<PreferencesContextType | undefined>(undefined);
 
+type ThemeChoice = 'light' | 'dark' | 'auto' | 'scheduled';
+type ThemeSchedule = { enabled: boolean; lightStartTime: string; darkStartTime: string };
+
+const DEFAULT_THEME_SCHEDULE: ThemeSchedule = {
+  enabled: false,
+  lightStartTime: '06:00',
+  darkStartTime: '18:00',
+};
+
+const isThemeChoice = (value: string | null): value is ThemeChoice =>
+  value === 'light' || value === 'dark' || value === 'auto' || value === 'scheduled';
+
+/**
+ * Each reader keeps its own defence against a bad stored value, exactly as it
+ * did when the store was localStorage: these strings are hand-editable there
+ * and travel through a JSON document here, so neither is a place to assume a
+ * shape. A value that cannot be read costs that one preference.
+ */
+function readThemeSchedule(): ThemeSchedule {
+  const saved = preferences.getItem('money_management_theme_schedule');
+  if (!saved) return DEFAULT_THEME_SCHEDULE;
+  try {
+    const parsed: unknown = JSON.parse(saved);
+    if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) return DEFAULT_THEME_SCHEDULE;
+    const record: Record<string, unknown> = { ...parsed };
+    return {
+      enabled: record.enabled === true,
+      lightStartTime: typeof record.lightStartTime === 'string' ? record.lightStartTime : DEFAULT_THEME_SCHEDULE.lightStartTime,
+      darkStartTime: typeof record.darkStartTime === 'string' ? record.darkStartTime : DEFAULT_THEME_SCHEDULE.darkStartTime,
+    };
+  } catch {
+    return DEFAULT_THEME_SCHEDULE;
+  }
+}
+
 export function PreferencesProvider({ children }: { children: ReactNode }): React.JSX.Element {
-  const [compactView, setCompactView] = useState((): boolean => {
-    try {
-      const saved = localStorage.getItem('money_management_compact_view');
-      // Default to true (compact view) if no saved preference
-      return saved !== null ? saved === 'true' : true;
-    } catch (error) {
-      console.error('Error reading compactView from localStorage:', error);
-      return true; // Default to compact view
-    }
+  // Compact view defaults ON: `null` means "never chosen", which is not the
+  // same as having chosen the roomy one.
+  const [compactView, setCompactView] = useState(
+    (): boolean => preferences.getItem('money_management_compact_view') !== 'false'
+  );
+
+  const [currency, setCurrency] = useState(
+    (): string => preferences.getItem('money_management_currency') || 'GBP'
+  );
+
+  const [theme, setTheme] = useState<ThemeChoice>((): ThemeChoice => {
+    const saved = preferences.getItem('money_management_theme');
+    return isThemeChoice(saved) ? saved : 'light';
   });
 
-  const [currency, setCurrency] = useState((): string => {
-    try {
-      return localStorage.getItem('money_management_currency') || 'GBP';
-    } catch (error) {
-      console.error('Error reading currency from localStorage:', error);
-      return 'GBP';
-    }
-  });
+  const [firstName, setFirstName] = useState(
+    (): string => preferences.getItem('money_management_first_name') || ''
+  );
 
-  const [theme, setTheme] = useState<'light' | 'dark' | 'auto' | 'scheduled'>((): 'light' | 'dark' | 'auto' | 'scheduled' => {
-    try {
-      const saved = localStorage.getItem('money_management_theme');
-      if (!saved) {
-        localStorage.setItem('money_management_theme', 'light');
-        return 'light';
-      }
-      if (!['light', 'dark', 'auto', 'scheduled'].includes(saved)) {
-        return 'light';
-      }
-      return saved as 'light' | 'dark' | 'auto' | 'scheduled';
-    } catch (error) {
-      console.error('Error reading theme from localStorage:', error);
-      return 'light';
-    }
-  });
-
-  const [firstName, setFirstName] = useState((): string => {
-    try {
-      return localStorage.getItem('money_management_first_name') || '';
-    } catch (error) {
-      console.error('Error reading firstName from localStorage:', error);
-      return '';
-    }
-  });
-
-  const [enableGoalCelebrations, setEnableGoalCelebrations] = useState((): boolean => {
-    try {
-      const saved = localStorage.getItem('money_management_goal_celebrations');
-      return saved !== 'false'; // Default to true
-    } catch (error) {
-      console.error('Error reading enableGoalCelebrations from localStorage:', error);
-      return true;
-    }
-  });
+  const [enableGoalCelebrations, setEnableGoalCelebrations] = useState(
+    (): boolean => preferences.getItem('money_management_goal_celebrations') !== 'false'
+  );
 
   // Page visibility settings
-  const [showInvestments, setShowInvestments] = useState((): boolean => {
-    try {
-      const saved = localStorage.getItem('money_management_show_investments');
-      return saved !== 'false'; // Default to true
-    } catch (error) {
-      console.error('Error reading showInvestments from localStorage:', error);
-      return true;
-    }
-  });
+  const [showInvestments, setShowInvestments] = useState(
+    (): boolean => preferences.getItem('money_management_show_investments') !== 'false'
+  );
 
-  const [themeSchedule, setThemeSchedule] = useState((): { enabled: boolean; lightStartTime: string; darkStartTime: string } => {
-    try {
-      const saved = localStorage.getItem('money_management_theme_schedule');
-      if (saved) {
-        return JSON.parse(saved);
-      }
-      return {
-        enabled: false,
-        lightStartTime: '06:00',
-        darkStartTime: '18:00'
-      };
-    } catch (error) {
-      console.error('Error reading theme schedule from localStorage:', error);
-      return {
-        enabled: false,
-        lightStartTime: '06:00',
-        darkStartTime: '18:00'
-      };
-    }
-  });
+  const [themeSchedule, setThemeSchedule] = useState<ThemeSchedule>(readThemeSchedule);
+
+  /**
+   * Adopt the account's document when it lands.
+   *
+   * Only for values the user has NOT changed since this component mounted:
+   * `hydrated` flips on the first notification, and after that the state here is
+   * the truth and the service is downstream of it. Re-reading on every
+   * notification would fight the write-through — a click would set the value,
+   * schedule a save, and be overwritten by the notification the save itself
+   * caused.
+   */
+  const [hydrated, setHydrated] = useState(false);
+  useEffect(() => {
+    if (hydrated) return;
+    const unsubscribe = preferences.subscribe(() => {
+      setHydrated(true);
+      setCompactView(preferences.getItem('money_management_compact_view') !== 'false');
+      setCurrency(preferences.getItem('money_management_currency') || 'GBP');
+      const storedTheme = preferences.getItem('money_management_theme');
+      setTheme(isThemeChoice(storedTheme) ? storedTheme : 'light');
+      setFirstName(preferences.getItem('money_management_first_name') || '');
+      setEnableGoalCelebrations(preferences.getItem('money_management_goal_celebrations') !== 'false');
+      setShowInvestments(preferences.getItem('money_management_show_investments') !== 'false');
+      setThemeSchedule(readThemeSchedule());
+    });
+    return unsubscribe;
+  }, [hydrated]);
 
   const [actualTheme, setActualTheme] = useState<'light' | 'dark'>('light');
 
@@ -208,21 +234,22 @@ export function PreferencesProvider({ children }: { children: ReactNode }): Reac
     }
   }, []);
 
-  // Consolidate all localStorage updates into a single effect for better performance
+  // One write-through for all seven. The service does its own debouncing of the
+  // network write, so the 300ms here is only about not re-serialising the theme
+  // schedule on every keystroke of a name.
   useEffect(() => {
     const savePreferences = (): void => {
-      localStorage.setItem('money_management_compact_view', compactView.toString());
-      localStorage.setItem('money_management_currency', currency);
-      localStorage.setItem('money_management_theme', theme);
-      localStorage.setItem('money_management_first_name', firstName);
-      localStorage.setItem('money_management_show_investments', showInvestments.toString());
-      localStorage.setItem('money_management_theme_schedule', JSON.stringify(themeSchedule));
-      localStorage.setItem('money_management_goal_celebrations', enableGoalCelebrations.toString());
+      preferences.setItem('money_management_compact_view', compactView.toString());
+      preferences.setItem('money_management_currency', currency);
+      preferences.setItem('money_management_theme', theme);
+      preferences.setItem('money_management_first_name', firstName);
+      preferences.setItem('money_management_show_investments', showInvestments.toString());
+      preferences.setItem('money_management_theme_schedule', JSON.stringify(themeSchedule));
+      preferences.setItem('money_management_goal_celebrations', enableGoalCelebrations.toString());
     };
 
-    // Debounce the save to avoid excessive localStorage writes
     const timeoutId = setTimeout(savePreferences, 300);
-    
+
     return (): void => clearTimeout(timeoutId);
   }, [compactView, currency, theme, firstName, showInvestments, themeSchedule, enableGoalCelebrations]);
 

--- a/src/hooks/useCumulativeReport.ts
+++ b/src/hooks/useCumulativeReport.ts
@@ -1,4 +1,5 @@
 import { useCallback, useState } from 'react';
+import { preferences } from '../services/preferencesService';
 
 export interface CumulativeReportToggle {
   /** True when the report should read as running totals for the period. */
@@ -13,12 +14,12 @@ export interface CumulativeReportToggle {
  */
 export function useCumulativeReport(storageKey: string): CumulativeReportToggle {
   const [cumulative, setCumulativeState] = useState<boolean>(
-    () => localStorage.getItem(storageKey) === '1'
+    () => preferences.getItem(storageKey) === '1'
   );
 
   const setCumulative = useCallback((next: boolean) => {
     setCumulativeState(next);
-    localStorage.setItem(storageKey, next ? '1' : '0');
+    preferences.setItem(storageKey, next ? '1' : '0');
   }, [storageKey]);
 
   return { cumulative, setCumulative };

--- a/src/hooks/usePeriod.test.ts
+++ b/src/hooks/usePeriod.test.ts
@@ -53,12 +53,23 @@ describe('resolvePeriod', () => {
 describe('usePeriod defaults vs the user’s own choice', () => {
   const KEY = 'testPeriod';
 
+  /**
+   * A period lives in the PREFERENCES document in the running app, so that the
+   * dashboard opens on the window the user chose whichever machine they are at.
+   * These tests hand the hook plain localStorage instead — the adapter exists
+   * exactly so they can — because what is under test is the default-versus-
+   * choice rule, not where the answer is filed. Injecting it also keeps each
+   * case starting from a genuinely empty store, which a module-level service
+   * shared with every other suite cannot promise.
+   */
+  const store = localStorage;
+
   beforeEach(() => {
     localStorage.clear();
   });
 
   it('starts on the surface’s default, unchosen', () => {
-    const { result } = renderHook(() => usePeriod(KEY, 'all'));
+    const { result } = renderHook(() => usePeriod(KEY, 'all', store));
 
     expect(result.current.period).toBe('all');
     expect(result.current.isExplicit).toBe(false);
@@ -67,7 +78,7 @@ describe('usePeriod defaults vs the user’s own choice', () => {
   });
 
   it('applies another surface’s default while nothing has been chosen', () => {
-    const { result } = renderHook(() => usePeriod(KEY));
+    const { result } = renderHook(() => usePeriod(KEY, 'this-month', store));
 
     act(() => result.current.applyDefaultPeriod('last-12-months'));
 
@@ -76,7 +87,7 @@ describe('usePeriod defaults vs the user’s own choice', () => {
   });
 
   it('never overrides a choice the user made', () => {
-    const { result } = renderHook(() => usePeriod(KEY));
+    const { result } = renderHook(() => usePeriod(KEY, 'this-month', store));
 
     act(() => result.current.setPeriod('tax-year'));
     expect(result.current.isExplicit).toBe(true);
@@ -88,19 +99,19 @@ describe('usePeriod defaults vs the user’s own choice', () => {
   });
 
   it('remembers the choice across a remount, defaults do not', () => {
-    const first = renderHook(() => usePeriod(KEY, 'this-month'));
+    const first = renderHook(() => usePeriod(KEY, 'this-month', store));
     act(() => first.result.current.applyDefaultPeriod('all'));
     first.unmount();
 
     // A default is a suggestion, so the next surface's own default wins.
-    const second = renderHook(() => usePeriod(KEY, 'last-12-months'));
+    const second = renderHook(() => usePeriod(KEY, 'last-12-months', store));
     expect(second.result.current.period).toBe('last-12-months');
     expect(second.result.current.isExplicit).toBe(false);
 
     act(() => second.result.current.setPeriod('tax-year'));
     second.unmount();
 
-    const third = renderHook(() => usePeriod(KEY, 'all'));
+    const third = renderHook(() => usePeriod(KEY, 'all', store));
     expect(third.result.current.period).toBe('tax-year');
     expect(third.result.current.isExplicit).toBe(true);
   });
@@ -113,7 +124,7 @@ describe('usePeriod defaults vs the user’s own choice', () => {
     // feature. So it seeds nothing and the caller's default wins.
     localStorage.setItem(KEY, 'last-month');
 
-    const { result } = renderHook(() => usePeriod(KEY, 'all'));
+    const { result } = renderHook(() => usePeriod(KEY, 'all', store));
 
     expect(result.current.period).toBe('all');
     expect(result.current.isExplicit).toBe(false);
@@ -122,10 +133,10 @@ describe('usePeriod defaults vs the user’s own choice', () => {
   it('honours the very next choice the user makes after that reset', () => {
     localStorage.setItem(KEY, 'last-month');
 
-    const first = renderHook(() => usePeriod(KEY, 'all'));
+    const first = renderHook(() => usePeriod(KEY, 'all', store));
     act(() => first.result.current.setPeriod('tax-year'));
 
-    const second = renderHook(() => usePeriod(KEY, 'all'));
+    const second = renderHook(() => usePeriod(KEY, 'all', store));
     expect(second.result.current.period).toBe('tax-year');
     expect(second.result.current.isExplicit).toBe(true);
 
@@ -136,14 +147,14 @@ describe('usePeriod defaults vs the user’s own choice', () => {
   it('ignores a stored value that is not a period', () => {
     localStorage.setItem(KEY, 'last-fortnight');
 
-    const { result } = renderHook(() => usePeriod(KEY, 'all'));
+    const { result } = renderHook(() => usePeriod(KEY, 'all', store));
 
     expect(result.current.period).toBe('all');
     expect(result.current.isExplicit).toBe(false);
   });
 
   it('counts editing a custom range as choosing one', () => {
-    const { result } = renderHook(() => usePeriod(KEY));
+    const { result } = renderHook(() => usePeriod(KEY, 'this-month', store));
 
     act(() => result.current.setCustomStart('2026-01-10'));
 

--- a/src/hooks/usePeriod.ts
+++ b/src/hooks/usePeriod.ts
@@ -1,4 +1,5 @@
 import { useCallback, useMemo, useState } from 'react';
+import { preferences, type PreferenceStorage } from '../services/preferencesService';
 
 /**
  * The app-wide reporting period — ONE definition of every window so no two
@@ -91,6 +92,22 @@ export interface UsePeriodResult {
   applyDefaultPeriod: (key: PeriodKey) => void;
 }
 
+/**
+ * Where a period selection is kept.
+ *
+ * An adapter rather than `localStorage` directly, because the answer to "which
+ * window does the dashboard open on?" belongs to the USER, not to the machine
+ * they happen to be sitting at — a restored backup that brought the accounts
+ * back but reset every period to this-month is the complaint this exists to
+ * fix. The default is the preferences document, which travels; the parameter is
+ * here so a test can hold it still without touching global storage.
+ *
+ * `Storage`-shaped on purpose: the four keys per surface are written as the
+ * same strings they always were, so nothing about the stored VALUES changed —
+ * only where they live.
+ */
+export type PeriodStorage = PreferenceStorage;
+
 /** Where the "the user picked this themselves" flag lives, per surface. */
 const explicitStorageKey = (storageKey: string): string => `${storageKey}Explicit`;
 
@@ -112,20 +129,28 @@ interface PeriodSelection {
  * flag and custom bounds) the first time the new key is read means the split
  * changes the layout and nothing else. A no-op once the new key exists.
  */
-export function seedPeriodSelection(fromKey: string, toKey: string): void {
-  if (localStorage.getItem(toKey) !== null) return;
-  const stored = localStorage.getItem(fromKey);
+export function seedPeriodSelection(
+  fromKey: string,
+  toKey: string,
+  storage: PeriodStorage = preferences
+): void {
+  if (storage.getItem(toKey) !== null) return;
+  const stored = storage.getItem(fromKey);
   if (stored === null) return;
 
-  localStorage.setItem(toKey, stored);
+  storage.setItem(toKey, stored);
   for (const suffix of ['Explicit', 'CustomStart', 'CustomEnd']) {
-    const value = localStorage.getItem(`${fromKey}${suffix}`);
-    if (value !== null) localStorage.setItem(`${toKey}${suffix}`, value);
+    const value = storage.getItem(`${fromKey}${suffix}`);
+    if (value !== null) storage.setItem(`${toKey}${suffix}`, value);
   }
 }
 
-function readStoredSelection(storageKey: string, defaultKey: PeriodKey): PeriodSelection {
-  const stored = localStorage.getItem(storageKey);
+function readStoredSelection(
+  storageKey: string,
+  defaultKey: PeriodKey,
+  storage: PeriodStorage
+): PeriodSelection {
+  const stored = storage.getItem(storageKey);
   if (stored === null || !isPeriodKey(stored)) return { period: defaultKey, explicit: false };
 
   // Only a value this build flagged is a choice this build can trust.
@@ -143,7 +168,7 @@ function readStoredSelection(storageKey: string, defaultKey: PeriodKey): PeriodS
   // So an unflagged value is treated as a default, not a decision: the report's
   // window applies, and the next period the user picks is flagged and honoured
   // for good. The cost is one reset, once, for someone who had chosen before.
-  const flag = localStorage.getItem(explicitStorageKey(storageKey));
+  const flag = storage.getItem(explicitStorageKey(storageKey));
   if (flag !== 'true') return { period: defaultKey, explicit: false };
   return { period: stored, explicit: true };
 }
@@ -156,16 +181,20 @@ function readStoredSelection(storageKey: string, defaultKey: PeriodKey): PeriodS
  * afterwards — as the reports hub does when a report with its own preferred
  * window opens — call `applyDefaultPeriod`.
  */
-export function usePeriod(storageKey: string, defaultKey: PeriodKey = 'this-month'): UsePeriodResult {
-  const [selection, setSelection] = useState<PeriodSelection>(() => readStoredSelection(storageKey, defaultKey));
-  const [customStart, setCustomStart] = useState<string>(() => localStorage.getItem(`${storageKey}CustomStart`) ?? '');
-  const [customEnd, setCustomEnd] = useState<string>(() => localStorage.getItem(`${storageKey}CustomEnd`) ?? '');
+export function usePeriod(
+  storageKey: string,
+  defaultKey: PeriodKey = 'this-month',
+  storage: PeriodStorage = preferences
+): UsePeriodResult {
+  const [selection, setSelection] = useState<PeriodSelection>(() => readStoredSelection(storageKey, defaultKey, storage));
+  const [customStart, setCustomStart] = useState<string>(() => storage.getItem(`${storageKey}CustomStart`) ?? '');
+  const [customEnd, setCustomEnd] = useState<string>(() => storage.getItem(`${storageKey}CustomEnd`) ?? '');
   const { period, explicit } = selection;
 
   const persist = useCallback((key: PeriodKey, isExplicit: boolean) => {
-    localStorage.setItem(storageKey, key);
-    localStorage.setItem(explicitStorageKey(storageKey), String(isExplicit));
-  }, [storageKey]);
+    storage.setItem(storageKey, key);
+    storage.setItem(explicitStorageKey(storageKey), String(isExplicit));
+  }, [storageKey, storage]);
 
   const setPeriod = useCallback((key: PeriodKey) => {
     setSelection({ period: key, explicit: true });
@@ -183,17 +212,17 @@ export function usePeriod(storageKey: string, defaultKey: PeriodKey = 'this-mont
   // Editing the bounds of a custom range is as deliberate as picking one.
   const setCustomStartPersisted = useCallback((v: string) => {
     setCustomStart(v);
-    localStorage.setItem(`${storageKey}CustomStart`, v);
+    storage.setItem(`${storageKey}CustomStart`, v);
     setSelection({ period, explicit: true });
     persist(period, true);
-  }, [storageKey, persist, period]);
+  }, [storageKey, storage, persist, period]);
 
   const setCustomEndPersisted = useCallback((v: string) => {
     setCustomEnd(v);
-    localStorage.setItem(`${storageKey}CustomEnd`, v);
+    storage.setItem(`${storageKey}CustomEnd`, v);
     setSelection({ period, explicit: true });
     persist(period, true);
-  }, [storageKey, persist, period]);
+  }, [storageKey, storage, persist, period]);
 
   const range = useMemo(
     () => resolvePeriod(period, customStart, customEnd),

--- a/src/hooks/useReportAccountSelection.ts
+++ b/src/hooks/useReportAccountSelection.ts
@@ -1,5 +1,6 @@
 import { useCallback, useMemo, useState } from 'react';
 import { useApp } from '../contexts/AppContextSupabase';
+import { preferences } from '../services/preferencesService';
 import type { ReportAccountScope } from './useReportDataset';
 
 /** Where every report remembers which accounts it covers: a JSON array of ids. */
@@ -39,7 +40,7 @@ export interface ReportAccountSelection {
 
 /** Storage holds whatever an older build (or the user) put there. */
 function readStoredIds(): ReadonlySet<string> | null {
-  const stored = localStorage.getItem(STORAGE_KEY);
+  const stored = preferences.getItem(STORAGE_KEY);
   if (stored === null) return null;
   try {
     const parsed: unknown = JSON.parse(stored);
@@ -57,6 +58,8 @@ function readStoredSelection(): Selection {
   if (stored !== null) return stored;
   // Nothing of this control's own — honour the retired dropdown's last answer
   // rather than silently widening the report back out to every account.
+  // The retired key is read from the BROWSER: it was written before preferences
+  // travelled, so the one-time carry-over has to look where it was left.
   const legacy = localStorage.getItem(LEGACY_STORAGE_KEY);
   return legacy !== null && legacy !== 'all' ? new Set([legacy]) : 'all';
 }
@@ -81,10 +84,10 @@ export function useReportAccountSelection(): ReportAccountSelection {
     // Whatever the retired dropdown left behind is now answered for.
     localStorage.removeItem(LEGACY_STORAGE_KEY);
     if (next === 'all') {
-      localStorage.removeItem(STORAGE_KEY);
+      preferences.removeItem(STORAGE_KEY);
       return;
     }
-    localStorage.setItem(STORAGE_KEY, JSON.stringify([...next]));
+    preferences.setItem(STORAGE_KEY, JSON.stringify([...next]));
   }, []);
 
   const toggle = useCallback((accountId: string) => {

--- a/src/pages/AccountTransactions.tsx
+++ b/src/pages/AccountTransactions.tsx
@@ -56,6 +56,7 @@ import { useBankConnectionSnapshot } from '../hooks/useBankConnectionSnapshot';
 import { DataService } from '../services/api/dataService';
 import AccountSelector from '../components/common/AccountSelector';
 import type { Account, Transaction } from '../types';
+import { preferences, type PreferenceStorage } from '../services/preferencesService';
 
 type TransactionWithBalance = Transaction & { balance: number };
 
@@ -265,9 +266,19 @@ const isTextEntryTarget = (target: EventTarget | null): boolean => {
   );
 };
 
-const readStored = <T,>(key: string, fallback: T): T => {
+/**
+ * A stored JSON value, from whichever store the key belongs in.
+ *
+ * The register's layout is deliberately split across the two. Column ORDER and
+ * which columns are HIDDEN are decisions about what matters in a statement, so
+ * they follow the account; column WIDTHS are pixels, and pixels belong to the
+ * screen they were dragged on. Carrying a 13-inch laptop's widths onto a
+ * 32-inch monitor would make the register worse on the bigger screen, which is
+ * the opposite of what "my settings followed me" is supposed to mean.
+ */
+const readStored = <T,>(store: PreferenceStorage, key: string, fallback: T): T => {
   try {
-    const raw = localStorage.getItem(key);
+    const raw = store.getItem(key);
     return raw ? (JSON.parse(raw) as T) : fallback;
   } catch {
     return fallback;
@@ -376,11 +387,11 @@ export default function AccountTransactions() {
     return () => window.removeEventListener('resize', measureTableHeight);
   }, [measureTableHeight, showFilters, sortField]);
   // Column layout (order + widths), drag-controlled and persisted per browser.
-  const [columnOrder, setColumnOrder] = useState<string[]>(() => readStored<string[]>(COLUMN_ORDER_KEY, []));
-  const [columnWidths, setColumnWidths] = useState<Record<string, number>>(() => readStored<Record<string, number>>(COLUMN_WIDTHS_KEY, {}));
+  const [columnOrder, setColumnOrder] = useState<string[]>(() => readStored<string[]>(preferences, COLUMN_ORDER_KEY, []));
+  const [columnWidths, setColumnWidths] = useState<Record<string, number>>(() => readStored<Record<string, number>>(localStorage, COLUMN_WIDTHS_KEY, {}));
 
   useEffect(() => {
-    try { localStorage.setItem(COLUMN_ORDER_KEY, JSON.stringify(columnOrder)); } catch { /* storage may be unavailable */ }
+    try { preferences.setItem(COLUMN_ORDER_KEY, JSON.stringify(columnOrder)); } catch { /* storage may be unavailable */ }
   }, [columnOrder]);
   useEffect(() => {
     try { localStorage.setItem(COLUMN_WIDTHS_KEY, JSON.stringify(columnWidths)); } catch { /* storage may be unavailable */ }
@@ -391,8 +402,8 @@ export default function AccountTransactions() {
   }, []);
 
   // View dropdown: which columns are hidden, and how far back to show.
-  const [hiddenColumns, setHiddenColumns] = useState<string[]>(() => readStored<string[]>(HIDDEN_COLUMNS_KEY, DEFAULT_HIDDEN_COLUMNS));
-  const [archive, setArchive] = useState<ArchiveState>(() => readStored<ArchiveState>(ARCHIVE_KEY, { range: 'all', from: '', to: '' }));
+  const [hiddenColumns, setHiddenColumns] = useState<string[]>(() => readStored<string[]>(preferences, HIDDEN_COLUMNS_KEY, DEFAULT_HIDDEN_COLUMNS));
+  const [archive, setArchive] = useState<ArchiveState>(() => readStored<ArchiveState>(preferences, ARCHIVE_KEY, { range: 'all', from: '', to: '' }));
   const [showView, setShowView] = useState(false);
   // Soft archive (persistent, server-side) — distinct from the date-window
   // "archive" dropdown above. Off by default; the toggle appears only when the
@@ -408,10 +419,10 @@ export default function AccountTransactions() {
   const viewRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
-    try { localStorage.setItem(HIDDEN_COLUMNS_KEY, JSON.stringify(hiddenColumns)); } catch { /* storage may be unavailable */ }
+    try { preferences.setItem(HIDDEN_COLUMNS_KEY, JSON.stringify(hiddenColumns)); } catch { /* storage may be unavailable */ }
   }, [hiddenColumns]);
   useEffect(() => {
-    try { localStorage.setItem(ARCHIVE_KEY, JSON.stringify(archive)); } catch { /* storage may be unavailable */ }
+    try { preferences.setItem(ARCHIVE_KEY, JSON.stringify(archive)); } catch { /* storage may be unavailable */ }
   }, [archive]);
 
   // Close the View dropdown on outside click.

--- a/src/pages/Accounts.tsx
+++ b/src/pages/Accounts.tsx
@@ -14,6 +14,7 @@ import { ArchiveIcon, SettingsIcon, WalletIcon, CheckCircleIcon, PieChartIcon, B
 import BankingCriticalIncidentBadge from '../components/BankingCriticalIncidentBadge';
 import { LoadingState } from '../components/loading/LoadingState';
 import { TRUELAYER_JWKS_CIRCUIT_EVENT_PREFIX } from '../constants/bankingOps';
+import { preferences } from '../services/preferencesService';
 
 // Bank connection management lives on this page (the natural home for it);
 // the Data Management page keeps only its URL-driven deep links for ops alerts.
@@ -58,7 +59,9 @@ import { SkeletonCard } from '../components/loading/Skeleton';
 function readStoredGrouping(): AccountGroupingOptions {
   try {
     return parseAccountGroupingPreference(
-      localStorage.getItem(ACCOUNT_GROUPING_STORAGE_KEY),
+      preferences.getItem(ACCOUNT_GROUPING_STORAGE_KEY),
+      // The pre-toggle key is read from the BROWSER: it was written before
+      // preferences travelled, so this migration has to look where it was left.
       localStorage.getItem(LEGACY_ACCOUNT_GROUPING_STORAGE_KEY)
     );
   } catch {
@@ -85,7 +88,7 @@ export default function Accounts({ onAccountClick }: { onAccountClick?: (account
   // off is a single flat list.
   const [grouping, setGrouping] = useState<AccountGroupingOptions>(readStoredGrouping);
   const [sortMode, setSortMode] = useState<AccountSortMode>(() => {
-    const stored = localStorage.getItem('accountsSortMode');
+    const stored = preferences.getItem('accountsSortMode');
     return stored === 'name' || stored === 'balance-desc' || stored === 'balance-asc'
       ? stored
       : 'default';
@@ -101,7 +104,7 @@ export default function Accounts({ onAccountClick }: { onAccountClick?: (account
   // folded when the Institution switch is flipped alongside it.
   const [collapsedGroups, setCollapsedGroups] = useState<Set<string>>(() => {
     try {
-      const stored = localStorage.getItem('accountsCollapsedGroups');
+      const stored = preferences.getItem('accountsCollapsedGroups');
       const parsed: unknown = stored ? JSON.parse(stored) : null;
       return Array.isArray(parsed)
         ? new Set(parsed.filter((key): key is string => typeof key === 'string'))
@@ -281,7 +284,7 @@ export default function Accounts({ onAccountClick }: { onAccountClick?: (account
   const handleGroupingChange = (next: AccountGroupingOptions) => {
     setGrouping(next);
     try {
-      localStorage.setItem(ACCOUNT_GROUPING_STORAGE_KEY, serializeAccountGroupingPreference(next));
+      preferences.setItem(ACCOUNT_GROUPING_STORAGE_KEY, serializeAccountGroupingPreference(next));
     } catch {
       // Storage unavailable — the choice still applies for this session.
     }
@@ -289,7 +292,7 @@ export default function Accounts({ onAccountClick }: { onAccountClick?: (account
 
   const handleSortChange = (value: AccountSortMode) => {
     setSortMode(value);
-    localStorage.setItem('accountsSortMode', value);
+    preferences.setItem('accountsSortMode', value);
   };
 
   // Fold a group open/closed and persist the whole collapsed set, so the choice
@@ -299,7 +302,7 @@ export default function Accounts({ onAccountClick }: { onAccountClick?: (account
       const next = new Set(prev);
       if (next.has(key)) next.delete(key);
       else next.add(key);
-      localStorage.setItem('accountsCollapsedGroups', JSON.stringify([...next]));
+      preferences.setItem('accountsCollapsedGroups', JSON.stringify([...next]));
       return next;
     });
   }, []);

--- a/src/pages/NetWorthReport.tsx
+++ b/src/pages/NetWorthReport.tsx
@@ -21,6 +21,7 @@ import { buildNetWorthSnapshots } from '../utils/netWorthSeries';
 import { resolveEffectiveOpeningDates } from '../utils/openingDates';
 import { TrendingUpIcon, ChevronRightIcon } from '../components/icons';
 import type { ReportViewProps } from './reports/types';
+import { preferences } from '../services/preferencesService';
 
 /**
  * Net worth over time — the Microsoft Money report, rebuilt on real data.
@@ -51,20 +52,20 @@ export default function NetWorthReport({ picker }: ReportViewProps): React.JSX.E
   const [drillDate, setDrillDate] = useState<Date | null>(null);
   // Line or bar presentation — same data, same drill-in; persisted.
   const [chartType, setChartType] = useState<'line' | 'bar'>(() =>
-    localStorage.getItem('netWorthChartType') === 'bar' ? 'bar' : 'line'
+    preferences.getItem('netWorthChartType') === 'bar' ? 'bar' : 'line'
   );
   const handleChartType = (type: 'line' | 'bar'): void => {
     setChartType(type);
-    localStorage.setItem('netWorthChartType', type);
+    preferences.setItem('netWorthChartType', type);
   };
   // Assets/liabilities context series are OFF by default — the chart is the
   // net worth line; the detail is an opt-in (persisted).
   const [showDetail, setShowDetail] = useState<boolean>(() =>
-    localStorage.getItem('netWorthShowDetail') === '1'
+    preferences.getItem('netWorthShowDetail') === '1'
   );
   const toggleDetail = (): void => {
     setShowDetail(prev => {
-      localStorage.setItem('netWorthShowDetail', prev ? '0' : '1');
+      preferences.setItem('netWorthShowDetail', prev ? '0' : '1');
       return !prev;
     });
   };

--- a/src/pages/Reconciliation.tsx
+++ b/src/pages/Reconciliation.tsx
@@ -13,6 +13,7 @@ import EditTransactionModal from '../components/EditTransactionModal';
 import { preserveRuntimeControlParams } from '../utils/runtimeMode';
 import { todayIsoDay } from '../utils/statementBankBalance';
 import type { Transaction } from '../types';
+import { preferences } from '../services/preferencesService';
 
 export default function Reconciliation() {
   const { transactions, accounts, categories, addTransaction, updateAccount, setTransactionsCleared } = useApp();
@@ -31,30 +32,30 @@ export default function Reconciliation() {
   // Group + sort for the account list — the same controls (and persistence
   // keys pattern) as the Accounts page, so the two pages always feel the same.
   const [groupBy, setGroupBy] = useState<'type' | 'institution'>(() =>
-    (localStorage.getItem('reconciliationGroupBy') as 'type' | 'institution') || 'type'
+    (preferences.getItem('reconciliationGroupBy') as 'type' | 'institution') || 'type'
   );
   const [sortMode, setSortMode] = useState<'default' | 'name' | 'balance-desc' | 'balance-asc'>(() => {
-    const stored = localStorage.getItem('reconciliationSortMode');
+    const stored = preferences.getItem('reconciliationSortMode');
     return stored === 'name' || stored === 'balance-desc' || stored === 'balance-asc' ? stored : 'default';
   });
   const handleGroupByChange = useCallback((value: 'type' | 'institution') => {
     setGroupBy(value);
-    try { localStorage.setItem('reconciliationGroupBy', value); } catch { /* storage unavailable */ }
+    try { preferences.setItem('reconciliationGroupBy', value); } catch { /* storage unavailable */ }
   }, []);
   const handleSortChange = useCallback((value: 'default' | 'name' | 'balance-desc' | 'balance-asc') => {
     setSortMode(value);
-    try { localStorage.setItem('reconciliationSortMode', value); } catch { /* storage unavailable */ }
+    try { preferences.setItem('reconciliationSortMode', value); } catch { /* storage unavailable */ }
   }, []);
   // Hide the accounts that are already done — everything cleared AND no bank
   // balance difference — so the list is only the work. Grouping still applies:
   // the filter drops accounts within each section, never the sections shape.
   const [onlyAttention, setOnlyAttention] = useState<boolean>(() =>
-    localStorage.getItem('reconciliationOnlyAttention') === 'true'
+    preferences.getItem('reconciliationOnlyAttention') === 'true'
   );
   const handleOnlyAttentionToggle = useCallback(() => {
     setOnlyAttention(prev => {
       const next = !prev;
-      try { localStorage.setItem('reconciliationOnlyAttention', String(next)); } catch { /* storage unavailable */ }
+      try { preferences.setItem('reconciliationOnlyAttention', String(next)); } catch { /* storage unavailable */ }
       return next;
     });
   }, []);

--- a/src/pages/Reports.tsx
+++ b/src/pages/Reports.tsx
@@ -15,6 +15,7 @@ import { toCumulativeMatrix } from '../utils/cumulativeSeries';
 import { useCumulativeReport } from '../hooks/useCumulativeReport';
 import { PERIOD_LABELS } from '../hooks/usePeriod';
 import type { ReportViewProps } from './reports/types';
+import { preferences } from '../services/preferencesService';
 
 /**
  * "Monthly income and expenses" — the Microsoft Money report, and the
@@ -43,11 +44,11 @@ export default function Reports({ picker }: ReportViewProps): React.JSX.Element 
   // controls VISIBILITY only: the classifier keeps revaluations out of the
   // income/expense/net totals unconditionally, toggle or not.
   const [showRevaluations, setShowRevaluations] = useState<boolean>(
-    () => localStorage.getItem('reportsShowRevaluations') === '1'
+    () => preferences.getItem('reportsShowRevaluations') === '1'
   );
   const toggleRevaluations = (): void => {
     setShowRevaluations(prev => {
-      localStorage.setItem('reportsShowRevaluations', prev ? '0' : '1');
+      preferences.setItem('reportsShowRevaluations', prev ? '0' : '1');
       return !prev;
     });
   };

--- a/src/pages/reports/IncomeSpendingOverTimeReport.tsx
+++ b/src/pages/reports/IncomeSpendingOverTimeReport.tsx
@@ -26,6 +26,7 @@ import { useCumulativeReport } from '../../hooks/useCumulativeReport';
 import { PERIOD_LABELS } from '../../hooks/usePeriod';
 import type { ReportViewProps } from './types';
 import type { SplitExpandedTransaction } from '../../utils/transactionSplits';
+import { preferences } from '../../services/preferencesService';
 
 /**
  * "Income and spending over time" — month by month, what came in against what
@@ -55,11 +56,11 @@ export default function IncomeSpendingOverTimeReport({ picker }: ReportViewProps
   const chartRef = useRef<HTMLDivElement>(null);
   // Lines or bars — same data, same drill-in; the choice is persisted.
   const [chartType, setChartType] = useState<'line' | 'bar'>(() =>
-    localStorage.getItem('reportsTrendChartType') === 'bar' ? 'bar' : 'line'
+    preferences.getItem('reportsTrendChartType') === 'bar' ? 'bar' : 'line'
   );
   const handleChartType = (type: 'line' | 'bar'): void => {
     setChartType(type);
-    localStorage.setItem('reportsTrendChartType', type);
+    preferences.setItem('reportsTrendChartType', type);
   };
   // Month on its own, or the period to date — the chart and the table below it
   // always agree, because both read the same series.

--- a/src/pages/reports/PeriodComparisonReport.tsx
+++ b/src/pages/reports/PeriodComparisonReport.tsx
@@ -19,6 +19,7 @@ import {
 import { formatDecimal } from '../../utils/decimal-format';
 import { PERIOD_LABELS } from '../../hooks/usePeriod';
 import type { ReportViewProps } from './types';
+import { preferences } from '../../services/preferencesService';
 
 /**
  * "This period vs last" — Money's comparison report.
@@ -55,7 +56,7 @@ export default function PeriodComparisonReport({ picker }: ReportViewProps): Rea
   const [drill, setDrill] = useState<ReportDrillTarget | null>(null);
   const chartRef = useRef<HTMLDivElement>(null);
   const [basis, setBasis] = useState<ComparisonBasis>(() =>
-    localStorage.getItem(BASIS_KEY) === 'same-period-last-year' ? 'same-period-last-year' : 'previous-period'
+    preferences.getItem(BASIS_KEY) === 'same-period-last-year' ? 'same-period-last-year' : 'previous-period'
   );
 
   /**
@@ -73,7 +74,7 @@ export default function PeriodComparisonReport({ picker }: ReportViewProps): Rea
 
   const handleBasis = (next: ComparisonBasis): void => {
     setBasis(next);
-    localStorage.setItem(BASIS_KEY, next);
+    preferences.setItem(BASIS_KEY, next);
   };
 
   const ranges = useMemo(

--- a/src/pages/reports/SpendingByPayeeReport.tsx
+++ b/src/pages/reports/SpendingByPayeeReport.tsx
@@ -11,6 +11,7 @@ import { buildPayeeTotals, payeeKeyOf, NO_PAYEE_KEY, type PayeeTotalRow } from '
 import { formatDecimal } from '../../utils/decimal-format';
 import { PERIOD_LABELS } from '../../hooks/usePeriod';
 import type { ReportViewProps } from './types';
+import { preferences } from '../../services/preferencesService';
 
 /**
  * "Spending by payee" — who the money actually went to.
@@ -38,11 +39,11 @@ export default function SpendingByPayeeReport({ picker }: ReportViewProps): Reac
   const [drill, setDrill] = useState<ReportDrillTarget | null>(null);
   const chartRef = useRef<HTMLDivElement>(null);
   const [side, setSide] = useState<'expense' | 'income'>(() =>
-    localStorage.getItem(SIDE_KEY) === 'income' ? 'income' : 'expense'
+    preferences.getItem(SIDE_KEY) === 'income' ? 'income' : 'expense'
   );
   const handleSide = (next: 'expense' | 'income'): void => {
     setSide(next);
-    localStorage.setItem(SIDE_KEY, next);
+    preferences.setItem(SIDE_KEY, next);
   };
 
   const sideRows = side === 'income' ? flows.incomeRows : flows.expenseRows;

--- a/src/pages/settings/DataManagement.tsx
+++ b/src/pages/settings/DataManagement.tsx
@@ -2,7 +2,8 @@ import { useState, Suspense, useMemo } from 'react';
 import { lazyWithRecovery } from '../../utils/lazyWithRecovery';
 import { Link } from 'react-router-dom';
 import { useApp } from '../../contexts/AppContextSupabase';
-import { DownloadIcon, DeleteIcon, AlertCircleIcon, UploadIcon, DatabaseIcon, SearchIcon, XCircleIcon, type IconProps } from '../../components/icons';
+import { DownloadIcon, DeleteIcon, AlertCircleIcon, UploadIcon, DatabaseIcon, SearchIcon, XCircleIcon, RefreshCwIcon, type IconProps } from '../../components/icons';
+import type { WipeProgress } from '../../services/import/msMoney/msMoneyImport';
 import { LoadingState } from '../../components/loading/LoadingState';
 import { createScopedLogger } from '../../loggers/scopedLogger';
 import { parseBankingOpsUrlState, replaceBrowserSearch, withBankingOpsUrlState } from '../../utils/bankingOpsUrlState';
@@ -38,6 +39,35 @@ const RestoreBackupModal = lazyWithRecovery(() => import('../../components/Resto
 const LoadTestDataModal = lazyWithRecovery(() => import('../../components/LoadTestDataModal'));
 const dataManagementLogger = createScopedLogger('DataManagementPage');
 
+/**
+ * Table names as a person would say them. The wipe reports the names the
+ * database uses, and "transaction_splits" on a confirmation dialog is the app
+ * talking to itself.
+ */
+const TABLE_LABELS: Record<string, string> = {
+  'transfer links': 'Disconnecting transfers',
+  transaction_splits: 'Split lines',
+  transactions: 'Transactions',
+  budgets: 'Budgets',
+  goals: 'Goals',
+  accounts: 'Accounts',
+  categories: 'Categories',
+};
+
+/**
+ * How full the bar is: the steps already finished, plus this step's own share.
+ *
+ * A step with no total contributes nothing beyond the steps behind it rather
+ * than jumping to full — a bar that reaches 100% and then keeps working is
+ * worse than one that moves in stages.
+ */
+const wipePercent = (progress: WipeProgress): number => {
+  const within = progress.total && progress.total > 0
+    ? Math.min(1, progress.deleted / progress.total)
+    : 0;
+  return Math.round(((progress.step - 1 + within) / progress.stepCount) * 100);
+};
+
 export default function DataManagementSettings() {
   const { accounts, transactions, budgets, resetLoadedData, isUsingSupabase } = useApp();
   const initialBankingOpsUrlState = useMemo(
@@ -68,6 +98,26 @@ export default function DataManagementSettings() {
   const [isClearing, setIsClearing] = useState(false);
   const [clearConfirmText, setClearConfirmText] = useState('');
   const [clearError, setClearError] = useState('');
+  /**
+   * What the wipe is doing right now.
+   *
+   * The delete used to be one statement per table, and on the owner's 51,000
+   * transactions the database gave up with "canceling statement due to
+   * statement timeout" — after the transfer links had been nulled and the
+   * splits deleted, so the login was left in a state nothing in the app
+   * produces. It is chunked now, which means it also TAKES time, and a button
+   * that says "Deleting…" for four minutes reads exactly like one that has
+   * hung. So it reports per table and per row, the way the restore dialog the
+   * owner liked does.
+   */
+  const [clearProgress, setClearProgress] = useState<WipeProgress | null>(null);
+  /**
+   * True when the failure happened part-way through, so some rows are gone and
+   * some are not. Every step is idempotent, so the recovery is to run it again
+   * — which is a far more useful thing to be told than the server's message
+   * alone.
+   */
+  const [clearPartial, setClearPartial] = useState(false);
 
   // ACTUALLY delete everything. The store has to be wiped first — the context's
   // resetLoadedData only forgets the loaded copy, so on cloud the data all came
@@ -81,11 +131,24 @@ export default function DataManagementSettings() {
   const handleClearData = async () => {
     setIsClearing(true);
     setClearError('');
+    setClearPartial(false);
+    setClearProgress(null);
+    // A local flag, not the state above: this function is read again after
+    // several awaits, and `clearProgress` there is the value from the render
+    // that created it — always null. The bug that would produce is the exact
+    // one this whole change exists to fix, in miniature: the user is told
+    // nothing about a half-finished wipe.
+    let sawProgress = false;
     try {
       const databaseUserId = DataService.getUserIds().databaseId;
       if (isUsingSupabase && supabase && databaseUserId) {
         const { wipeCloudData } = await import('../../services/import/msMoney/msMoneyImport');
-        await wipeCloudData(supabase, databaseUserId);
+        await wipeCloudData(supabase, databaseUserId, {
+          onProgress: (progress) => {
+            sawProgress = true;
+            setClearProgress(progress);
+          },
+        });
       } else {
         const { wipeLocalFinancialData, LOCAL_WIPE_CONFIRMATION } =
           await import('../../services/localBackupService');
@@ -100,6 +163,11 @@ export default function DataManagementSettings() {
     } catch (error) {
       dataManagementLogger.error('Clear all data failed', error);
       setClearError(error instanceof Error ? error.message : 'Failed to delete data.');
+      // Chunks commit as they go, so anything already reported is already gone.
+      // A local wipe is one IndexedDB transaction and cannot be half-done, and
+      // a cloud wipe that failed before its first report deleted nothing —
+      // telling either of them their data is half-gone would be its own harm.
+      setClearPartial(sawProgress);
       setIsClearing(false);
     }
   };
@@ -236,16 +304,65 @@ export default function DataManagementSettings() {
               <input
                 value={clearConfirmText}
                 onChange={(e) => setClearConfirmText(e.target.value)}
+                disabled={isClearing}
                 placeholder="DELETE"
-                className="w-full px-3 py-2 rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-900 text-gray-900 dark:text-white focus:outline-none focus:ring-2 focus:ring-red-500"
+                className="w-full px-3 py-2 rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-900 text-gray-900 dark:text-white focus:outline-none focus:ring-2 focus:ring-red-500 disabled:opacity-40"
               />
             </div>
+
+            {/* Per table and per row, so a wipe that takes minutes on a large
+                register never looks like one that has hung. */}
+            {isClearing && clearProgress && (
+              <div className="mb-4" role="status" aria-live="polite">
+                <div className="flex items-center gap-2 mb-2">
+                  <RefreshCwIcon size={16} className="animate-spin text-red-600 dark:text-red-400" />
+                  <p className="text-sm font-medium text-gray-900 dark:text-white">
+                    {TABLE_LABELS[clearProgress.table] ?? clearProgress.table}
+                  </p>
+                </div>
+                <div className="h-2 rounded-full bg-gray-200 dark:bg-gray-700 overflow-hidden">
+                  <div
+                    className="h-full bg-red-600 transition-all duration-200"
+                    style={{ width: `${wipePercent(clearProgress)}%` }}
+                  />
+                </div>
+                <p className="text-xs text-gray-500 dark:text-gray-400 mt-2 tabular-nums">
+                  Step {clearProgress.step} of {clearProgress.stepCount}
+                  {' — '}
+                  {clearProgress.total === undefined
+                    ? `${clearProgress.deleted.toLocaleString()} rows removed`
+                    : `${clearProgress.deleted.toLocaleString()} of ${clearProgress.total.toLocaleString()} rows`}
+                </p>
+                <p className="text-xs text-gray-500 dark:text-gray-400 mt-2">
+                  Leave this tab open until it finishes.
+                </p>
+              </div>
+            )}
+
             {clearError && (
-              <p className="text-sm text-red-600 dark:text-red-400 mb-4">{clearError}</p>
+              <div className="mb-4 rounded-xl border border-red-200 dark:border-red-800 bg-red-50 dark:bg-red-900/20 p-3">
+                <p className="text-sm text-red-800 dark:text-red-300 font-mono break-words">{clearError}</p>
+                {/* The recovery, not just the failure. Every step of the wipe is
+                    idempotent — deleting rows that have already gone is a no-op
+                    — so running it again carries on from where it stopped. */}
+                {clearPartial && (
+                  <p className="text-sm text-red-800 dark:text-red-300 mt-2">
+                    Some data was deleted before this stopped, and the rest is still there. Nothing is
+                    broken by that and nothing needs undoing — <strong>run it again to finish</strong>.
+                    It will pick up where it left off.
+                  </p>
+                )}
+              </div>
             )}
             <div className="flex gap-3">
               <button
-                onClick={() => { setShowDeleteConfirm(false); setClearConfirmText(''); setClearError(''); }}
+                onClick={() => {
+                  setShowDeleteConfirm(false);
+                  setClearConfirmText('');
+                  setClearError('');
+                  setClearPartial(false);
+                  setClearProgress(null);
+                }}
                 disabled={isClearing}
                 className="flex-1 justify-center px-4 py-2 border border-gray-300 dark:border-gray-600 text-gray-700 dark:text-gray-300 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-700 disabled:opacity-40"
               >
@@ -256,7 +373,7 @@ export default function DataManagementSettings() {
                 disabled={isClearing || clearConfirmText.trim().toUpperCase() !== 'DELETE'}
                 className="flex-1 justify-center px-4 py-2 bg-red-700 text-white rounded-lg hover:bg-red-800 disabled:opacity-40 disabled:cursor-not-allowed"
               >
-                {isClearing ? 'Deleting…' : 'Delete All Data'}
+                {isClearing ? 'Deleting…' : clearPartial ? 'Run it again' : 'Delete All Data'}
               </button>
             </div>
           </div>

--- a/src/pages/settings/__tests__/DataManagement.deleteAll.test.tsx
+++ b/src/pages/settings/__tests__/DataManagement.deleteAll.test.tsx
@@ -1,0 +1,194 @@
+import { describe, it, expect, afterEach, beforeEach, vi } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { ToastProvider } from '../../../contexts/ToastContext';
+import { __setAppContextValue, __resetAppContextValue } from '../../../test/mocks/AppContextSupabase';
+import type { WipeOptions, WipeProgress } from '../../../services/import/msMoney/msMoneyImport';
+
+/**
+ * "Delete All Data" as the user meets it.
+ *
+ * The live failure: on 51,000 transactions the one-statement delete hit
+ * `canceling statement due to statement timeout`, and the dialog showed nothing
+ * but that sentence — after the transfer links had been nulled and the splits
+ * deleted. The user was left with a half-wiped login, an error about a
+ * statement, and no idea that running it again would finish the job.
+ *
+ * So these cover the three things the dialog now has to do: SAY what it is
+ * doing while it does it, REFUSE to be clicked mid-run, and on failure say the
+ * one thing that helps — run it again.
+ */
+
+/** Whoever is signed in, so the page takes the cloud branch. */
+vi.mock('../../../services/api/dataService', () => ({
+  DataService: { getUserIds: () => ({ clerkId: 'clerk_1', databaseId: 'db-user-1' }) },
+}));
+
+/** A configured cloud, so `isUsingSupabase && supabase && databaseUserId` holds. */
+vi.mock('../../../lib/supabase', () => ({ supabase: { from: () => ({}) } }));
+
+/** The wipe itself is covered in wipeCloudData.test; here it is a script. */
+const wipeScript: {
+  steps: WipeProgress[];
+  failWith: string | null;
+  calls: number;
+  /** Set to keep the wipe genuinely in flight while assertions run. */
+  hold: Promise<void> | null;
+} = { steps: [], failWith: null, calls: 0, hold: null };
+
+vi.mock('../../../services/import/msMoney/msMoneyImport', () => ({
+  wipeCloudData: async (_client: unknown, _userId: string, options: WipeOptions = {}) => {
+    wipeScript.calls += 1;
+    for (const step of wipeScript.steps) {
+      options.onProgress?.(step);
+      // Let React paint between steps, the way a real round trip does.
+      await Promise.resolve();
+    }
+    if (wipeScript.hold !== null) await wipeScript.hold;
+    if (wipeScript.failWith !== null) throw new Error(wipeScript.failWith);
+  },
+}));
+
+const { default: DataManagementSettings } = await import('../DataManagement');
+
+const renderPage = () =>
+  render(
+    <MemoryRouter initialEntries={['/settings/data']}>
+      {/* The page's Archive section reports through the app's toasts, exactly
+          as it does inside the real provider stack. */}
+      <ToastProvider>
+        <DataManagementSettings />
+      </ToastProvider>
+    </MemoryRouter>
+  );
+
+/** Open the dialog and type the phrase, leaving the button armed. */
+const armTheButton = () => {
+  fireEvent.click(screen.getByRole('button', { name: /Clear All Data/ }));
+  fireEvent.change(screen.getByPlaceholderText('DELETE'), { target: { value: 'DELETE' } });
+};
+
+describe('Delete All Data — while it runs', () => {
+  beforeEach(() => {
+    wipeScript.steps = [];
+    wipeScript.failWith = null;
+    wipeScript.calls = 0;
+    wipeScript.hold = null;
+    // Signed in with a working cloud, so the page takes the branch that calls
+    // wipeCloudData rather than the browser-local one.
+    __setAppContextValue({ isUsingSupabase: true });
+  });
+
+  afterEach(() => {
+    __resetAppContextValue();
+  });
+
+  it('names the table it is on and counts the rows, rather than saying "Deleting…" for four minutes', async () => {
+    wipeScript.steps = [
+      { table: 'transactions', deleted: 2_000, total: 51_000, step: 2, stepCount: 7 },
+    ];
+    // Held open so the assertion lands mid-run.
+    wipeScript.failWith = 'stopped for the test';
+
+    renderPage();
+    armTheButton();
+    fireEvent.click(screen.getByRole('button', { name: 'Delete All Data' }));
+
+    const running = await screen.findByRole('status');
+    expect(running).toHaveTextContent('Transactions');
+    expect(running).toHaveTextContent('Step 2 of 7 — 2,000 of 51,000 rows');
+  });
+
+  it('says "rows removed" rather than inventing a denominator it does not have', async () => {
+    wipeScript.steps = [
+      { table: 'transactions', deleted: 400, total: undefined, step: 2, stepCount: 7 },
+    ];
+    wipeScript.failWith = 'stopped for the test';
+
+    renderPage();
+    armTheButton();
+    fireEvent.click(screen.getByRole('button', { name: 'Delete All Data' }));
+
+    expect(await screen.findByRole('status')).toHaveTextContent('400 rows removed');
+  });
+
+  it('will not take a second click while it is running', async () => {
+    wipeScript.steps = [{ table: 'accounts', deleted: 0, total: 3, step: 6, stepCount: 7 }];
+    // Held open, so the assertions land while the wipe is genuinely in flight.
+    let release: () => void = () => {};
+    wipeScript.hold = new Promise<void>((resolve) => { release = resolve; });
+
+    renderPage();
+    armTheButton();
+    fireEvent.click(screen.getByRole('button', { name: 'Delete All Data' }));
+
+    expect(await screen.findByRole('status')).toHaveTextContent('Accounts');
+    expect(screen.getByRole('button', { name: 'Deleting…' })).toBeDisabled();
+    expect(screen.getByRole('button', { name: 'Cancel' })).toBeDisabled();
+    expect(screen.getByPlaceholderText('DELETE')).toBeDisabled();
+
+    release();
+    await wipeScript.hold;
+  });
+});
+
+describe('Delete All Data — when it stops part-way', () => {
+  beforeEach(() => {
+    wipeScript.steps = [];
+    wipeScript.failWith = null;
+    wipeScript.calls = 0;
+    wipeScript.hold = null;
+    // Signed in with a working cloud, so the page takes the branch that calls
+    // wipeCloudData rather than the browser-local one.
+    __setAppContextValue({ isUsingSupabase: true });
+  });
+
+  afterEach(() => {
+    __resetAppContextValue();
+  });
+
+  it('keeps the database\'s own sentence AND says to run it again', async () => {
+    wipeScript.steps = [{ table: 'transactions', deleted: 2_000, total: 51_000, step: 2, stepCount: 7 }];
+    wipeScript.failWith = 'canceling statement due to statement timeout';
+
+    renderPage();
+    armTheButton();
+    fireEvent.click(screen.getByRole('button', { name: 'Delete All Data' }));
+
+    // The message the user actually saw, unparaphrased.
+    expect(await screen.findByText('canceling statement due to statement timeout')).toBeInTheDocument();
+    // …and the recovery, which is the half that was missing.
+    expect(screen.getByText(/run it again to finish/i)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Run it again' })).toBeEnabled();
+  });
+
+  it('re-runs from the same dialog, without retyping the phrase', async () => {
+    wipeScript.steps = [{ table: 'transactions', deleted: 2_000, total: 51_000, step: 2, stepCount: 7 }];
+    wipeScript.failWith = 'canceling statement due to statement timeout';
+
+    renderPage();
+    armTheButton();
+    fireEvent.click(screen.getByRole('button', { name: 'Delete All Data' }));
+    await screen.findByRole('button', { name: 'Run it again' });
+
+    wipeScript.failWith = null;
+    fireEvent.click(screen.getByRole('button', { name: 'Run it again' }));
+
+    await waitFor(() => expect(wipeScript.calls).toBe(2));
+  });
+
+  it('does not claim a half-wipe when nothing had started', async () => {
+    // A failure before the first progress report is not a partial state, and
+    // telling someone their data is half-deleted when it is not is its own
+    // kind of harm.
+    wipeScript.steps = [];
+    wipeScript.failWith = 'permission denied for table transactions';
+
+    renderPage();
+    armTheButton();
+    fireEvent.click(screen.getByRole('button', { name: 'Delete All Data' }));
+
+    expect(await screen.findByText('permission denied for table transactions')).toBeInTheDocument();
+    expect(screen.queryByText(/run it again to finish/i)).not.toBeInTheDocument();
+  });
+});

--- a/src/services/backupService.test.ts
+++ b/src/services/backupService.test.ts
@@ -10,7 +10,9 @@ import {
   chunkRows,
   extractAccountParents,
   extractTransactionLinks,
+  preferenceCount,
   remapBackupIds,
+  remapPreferenceIds,
   rowsForStep,
   transactionDateRange,
   validateBackupBundle,
@@ -967,5 +969,127 @@ describe('remapBackupIds', () => {
     expect(shop.tags).toEqual(['food', 'weekly']);
     expect(shop.created_at).toBe('2021-06-06T00:00:00.000Z');
     expect(shop.updated_at).toBe('2021-06-06T00:00:00.000Z');
+  });
+});
+
+// ── Preferences, the half a restore used to lose ─────────────────────────────
+
+describe('preferences in a backup', () => {
+  it('an old file with no preferences section restores as carrying none', () => {
+    // Not as "this user had none" — as "this file does not say". The difference
+    // matters, because the restore must not overwrite a real document with an
+    // empty one on the strength of an older file's silence.
+    const parsed = goodBundle();
+    delete parsed.preferences;
+    const validation = validateBackupBundle(parsed);
+    expect(validation.ok).toBe(true);
+    if (!validation.ok) return;
+    expect(validation.bundle.preferences).toBeNull();
+    expect(preferenceCount(validation.bundle)).toBe(0);
+  });
+
+  it('carries a document through the file and back out', () => {
+    const parsed = goodBundle({
+      preferences: {
+        version: 1,
+        values: { accountsSortMode: 'balance-desc', 'a.key.from.a.newer.build': 'on' },
+      },
+    });
+    const validation = validateBackupBundle(parsed);
+    expect(validation.ok).toBe(true);
+    if (!validation.ok) return;
+    expect(validation.bundle.preferences?.values.accountsSortMode).toBe('balance-desc');
+    // A key this build has never heard of survives the round trip.
+    expect(validation.bundle.preferences?.values['a.key.from.a.newer.build']).toBe('on');
+    expect(preferenceCount(validation.bundle)).toBe(2);
+  });
+
+  it('refuses nothing over a preference it cannot parse', () => {
+    // A toggle must never be able to cost someone their transactions.
+    const validation = validateBackupBundle(goodBundle({ preferences: 'not a document' }));
+    expect(validation.ok).toBe(true);
+    if (!validation.ok) return;
+    expect(validation.bundle.preferences?.values).toEqual({});
+  });
+});
+
+describe('remapPreferenceIds', () => {
+  const lookup = (id: string): string | undefined => (id === 'a-1' ? 'a-1-new' : undefined);
+
+  it('rewrites the account ids in a pinned-accounts list', () => {
+    // Left as they were, these would name accounts belonging to the login the
+    // file came from — and fail silently, because nothing constrains a string
+    // inside a jsonb document.
+    const next = remapPreferenceIds(
+      { version: 1, values: { dashboardKeyAccounts: '["a-1"]' } },
+      lookup,
+      () => {}
+    );
+    expect(JSON.parse(next.values.dashboardKeyAccounts)).toEqual(['a-1-new']);
+  });
+
+  it('rewrites the account ids a per-account archive cutoff is keyed BY', () => {
+    const next = remapPreferenceIds(
+      { version: 1, values: { 'archiveManager.overrides.v1': '{"a-1":{"date":"2020-01-01","acknowledged":true}}' } },
+      lookup,
+      () => {}
+    );
+    expect(JSON.parse(next.values['archiveManager.overrides.v1'])).toEqual({
+      'a-1-new': { date: '2020-01-01', acknowledged: true },
+    });
+  });
+
+  it('leaves a preference it cannot parse exactly as it found it', () => {
+    // It may be a newer client's key. A preference we cannot read is still a
+    // preference somebody set.
+    const next = remapPreferenceIds(
+      { version: 1, values: { dashboardKeyAccounts: 'not json at all' } },
+      lookup,
+      () => {}
+    );
+    expect(next.values.dashboardKeyAccounts).toBe('not json at all');
+  });
+
+  it('leaves preferences that hold no ids completely alone', () => {
+    const values = { accountsSortMode: 'name', netWorthChartType: 'bar' };
+    expect(remapPreferenceIds({ version: 1, values }, lookup, () => {}).values).toEqual(values);
+  });
+
+  it('reports an id that names no row in the file, and leaves it in place', () => {
+    const dangling: string[] = [];
+    const next = remapPreferenceIds(
+      { version: 1, values: { dashboardKeyAccounts: `["${uid('9', 1)}"]` } },
+      lookup,
+      (_key, value) => dangling.push(value)
+    );
+    expect(dangling).toEqual([uid('9', 1)]);
+    expect(JSON.parse(next.values.dashboardKeyAccounts)).toEqual([uid('9', 1)]);
+  });
+});
+
+describe('remapBackupIds — preferences', () => {
+  it('rewrites the preference ids with the same map every row gets', () => {
+    const source = buildBackupBundle({
+      sourceUserId: uid('0', 1),
+      exportedAt: '2026-08-07T09:30:00.000Z',
+      data: { accounts: [account({ id: A_CURRENT })] },
+      preferences: { version: 1, values: { dashboardKeyAccounts: `["${A_CURRENT}"]` } },
+    });
+
+    const { bundle, idMap } = remapBackupIds(source, sequentialIds());
+
+    const pinned: unknown = JSON.parse(bundle.preferences?.values.dashboardKeyAccounts ?? '[]');
+    expect(pinned).toEqual([idMap.get(A_CURRENT)]);
+    // …and it is the account actually restored, not a stale id.
+    expect(pinned).toEqual([bundle.data.accounts[0].id]);
+  });
+
+  it('leaves a file with no preferences with none', () => {
+    const source = buildBackupBundle({
+      sourceUserId: uid('0', 1),
+      exportedAt: '2026-08-07T09:30:00.000Z',
+      data: { accounts: [account()] },
+    });
+    expect(remapBackupIds(source, sequentialIds()).bundle.preferences).toBeNull();
   });
 });

--- a/src/services/backupService.ts
+++ b/src/services/backupService.ts
@@ -1,4 +1,12 @@
 import { supabase } from './api/supabaseClient';
+import { createScopedLogger } from '../loggers/scopedLogger';
+import {
+  PREFERENCE_KEYS_HOLDING_IDS,
+  parsePreferencesDocument,
+  supabasePreferencesTransport,
+  type PreferencesDocument,
+  type PreferencesTransport,
+} from './preferencesService';
 
 /**
  * Backup and restore — the client half of migration 20260807083000.
@@ -20,20 +28,27 @@ import { supabase } from './api/supabaseClient';
  * needed the file. Whole rows drift automatically; a mapping does not.
  */
 
+const backupLogger = createScopedLogger('BackupService');
+
 /** The format tag written into every file, and the only one restore accepts. */
 export const BACKUP_FORMAT = 'wealthtracker-backup-v2';
 
 /**
  * The newest migration timestamp at the moment this format was written —
- * 20260807083000_user_data_restore.sql, the migration that created the RPCs
- * this file calls.
+ * 20260809160000_preferences_that_travel.sql, which added the one table a
+ * backup carries outside the fourteen below.
  *
  * It is stamped into the file so a restore can be told which schema the rows
  * were shaped by. Bump it when a migration changes what a backed-up row looks
  * like, not on every migration: its job is to date the ROW SHAPE, and a file
  * claiming a shape it does not have is worse than one claiming an old one.
+ *
+ * Bumped from 20260807083000 because a backup now carries something it did not
+ * before. Informational only — nothing gates on it, and a file stamped with the
+ * older value restores exactly as it always did (its `preferences` section is
+ * simply absent, which reads as "this file has none").
  */
-export const BACKUP_SCHEMA_VERSION = '20260807083000';
+export const BACKUP_SCHEMA_VERSION = '20260809160000';
 
 /** Rows travel exactly as the database returned them. No mapping, no reshaping. */
 export type BackupRow = Record<string, unknown>;
@@ -126,6 +141,27 @@ export interface BackupBundle {
    * two copies could disagree with no way to tell which was right.
    */
   links: BackupLinks;
+  /**
+   * Every setting that belongs to the account rather than to the browser, as
+   * one document. `null` means the file carries none — either an older file, or
+   * a user who has expressed no preference at all.
+   *
+   * A SECTION of its own rather than a fifteenth entry in `data`, for three
+   * reasons that are all about the restore rather than about the export:
+   *
+   *  • it is one row, replaced, where every entity in `data` is many rows,
+   *    inserted. restore_user_chunk's whole shape is "insert whole rows into an
+   *    empty login";
+   *  • it must go in LAST and must never be able to block a financial row. In
+   *    `data` it would be one more step in a loop that stops dead on the first
+   *    refusal, so a preferences failure could cost someone their transactions;
+   *  • the empty-login precondition does not apply to it. A login always has a
+   *    preferences row by the time a restore runs — the app writes one at boot
+   *    — so an INSERT-only path would refuse every time.
+   *
+   * Old files have no such key. `undefined` reads as `null`; nothing breaks.
+   */
+  preferences: PreferencesDocument | null;
 }
 
 // ── Reading whole rows out of the database ──────────────────────────────────
@@ -212,6 +248,7 @@ export interface BuildBundleInput {
   data: Partial<Record<BackupEntity, BackupRow[]>>;
   /** Overridable only so a test can pin it; production always uses the constant. */
   schemaVersion?: string;
+  preferences?: PreferencesDocument | null;
 }
 
 /**
@@ -298,7 +335,13 @@ export function buildBackupBundle(input: BuildBundleInput): BackupBundle {
       account_parents: extractAccountParents(data.accounts),
       transaction_links: extractTransactionLinks(data.transactions),
     },
+    preferences: input.preferences ?? null,
   };
+}
+
+/** How many settings a file's preferences section actually carries. */
+export function preferenceCount(bundle: BackupBundle): number {
+  return bundle.preferences === null ? 0 : Object.keys(bundle.preferences.values).length;
 }
 
 export interface ExportProgress {
@@ -324,7 +367,13 @@ export interface ExportOwner {
  */
 export async function collectBackupBundle(
   owner: ExportOwner,
-  options: { onProgress?: (progress: ExportProgress) => void; client?: BackupClient | null; now?: () => Date } = {}
+  options: {
+    onProgress?: (progress: ExportProgress) => void;
+    client?: BackupClient | null;
+    /** Overridable so a test can supply a document without a database. */
+    preferences?: PreferencesTransport | null;
+    now?: () => Date;
+  } = {}
 ): Promise<BackupBundle> {
   const client = requireClient(options.client);
   const data: Partial<Record<BackupEntity, BackupRow[]>> = {};
@@ -350,11 +399,24 @@ export async function collectBackupBundle(
     data[entity] = await fetchAllRows(client, entity, ownerId, report);
   }
 
+  // Read LAST and allowed to fail without taking the file with it. A database
+  // that has not had 20260809160000 applied yet has no such table, and a backup
+  // of a decade of transactions must not be refused over a missing toggle — but
+  // it must SAY it carries none rather than pretending the user had none.
+  let preferences: PreferencesDocument | null = null;
+  const transport = options.preferences ?? supabasePreferencesTransport();
+  try {
+    preferences = transport === null ? null : await transport.read(owner.databaseUserId);
+  } catch (error) {
+    backupLogger.warn('Preferences could not be read; this backup carries none', error);
+  }
+
   const now = options.now ?? (() => new Date());
   return buildBackupBundle({
     sourceUserId: owner.databaseUserId,
     exportedAt: now().toISOString(),
     data,
+    preferences,
   });
 }
 
@@ -552,6 +614,14 @@ export function validateBackupBundle(parsed: unknown): BackupValidation {
       counts: Object.fromEntries(BACKUP_ENTITIES.map((entity) => [entity, rows[entity].length])),
       data: rows,
       links: links.links,
+      // Absent in every file written before 20260809160000, and parsed rather
+      // than validated: a preference this build cannot make sense of costs that
+      // one preference, whereas refusing the FILE over it would cost the user
+      // their entire history to protect a toggle. Unknown keys travel through
+      // untouched (see parsePreferencesDocument).
+      preferences: parsed.preferences === undefined || parsed.preferences === null
+        ? null
+        : parsePreferencesDocument(parsed.preferences),
     },
   };
 }
@@ -781,6 +851,72 @@ function remapDismissalKey(
 }
 
 /**
+ * Rewrite the account ids a preferences document holds.
+ *
+ * The preferences that mention rows all mention ACCOUNTS: which ones the
+ * dashboard pins, which ones a report is filtered to, which ones have their own
+ * archive cutoff. Restored verbatim into a login whose rows have been given
+ * fresh ids, every one of them would name accounts that no longer exist — and
+ * would do it SILENTLY, because nothing constrains a string inside a jsonb
+ * document. The dashboard would come up with no key accounts and no explanation;
+ * the per-account cutoffs the owner set would apply to nothing.
+ *
+ * A value that is not the JSON this build expects is left EXACTLY as it was
+ * rather than dropped or blanked: it may be a newer client's key, and a
+ * preference we cannot parse is still a preference somebody set. An id inside
+ * one that names no row in the file is likewise left alone and reported, the
+ * same rule every other dangling reference gets.
+ */
+export function remapPreferenceIds(
+  document: PreferencesDocument,
+  lookup: (id: string) => string | undefined,
+  onDangling: (key: string, value: string) => void
+): PreferencesDocument {
+  const values: Record<string, string> = { ...document.values };
+
+  const remapOne = (value: string, key: string): string => {
+    const replacement = lookup(value);
+    if (replacement !== undefined) return replacement;
+    if (UUID_PATTERN.test(value)) onDangling(key, value);
+    return value;
+  };
+
+  for (const key of PREFERENCE_KEYS_HOLDING_IDS.idArray) {
+    const raw = values[key];
+    if (raw === undefined) continue;
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(raw);
+    } catch {
+      continue; // Not JSON this build wrote. Leave the user's value alone.
+    }
+    if (!Array.isArray(parsed)) continue;
+    values[key] = JSON.stringify(
+      parsed.map((element) => (typeof element === 'string' ? remapOne(element, key) : element))
+    );
+  }
+
+  for (const key of PREFERENCE_KEYS_HOLDING_IDS.idKeyedObject) {
+    const raw = values[key];
+    if (raw === undefined) continue;
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(raw);
+    } catch {
+      continue;
+    }
+    if (!isPlainObject(parsed)) continue;
+    const rekeyed: Record<string, unknown> = {};
+    for (const [id, entry] of Object.entries(parsed)) {
+      rekeyed[remapOne(id, key)] = entry;
+    }
+    values[key] = JSON.stringify(rekeyed);
+  }
+
+  return { ...document, values };
+}
+
+/**
  * Give every row in the bundle a fresh id and rewrite every reference to match.
  *
  * Pure: the only impurity is id generation, and that is injectable so a test can
@@ -922,8 +1058,14 @@ export function remapBackupIds(
     };
   });
 
+  const preferences = bundle.preferences === null
+    ? null
+    : remapPreferenceIds(bundle.preferences, lookup, (key, value) => {
+        danglingRefs.push({ entity: 'preferences', rowId: key, field: key, value });
+      });
+
   return {
-    bundle: { ...bundle, data, links: { account_parents, transaction_links } },
+    bundle: { ...bundle, data, links: { account_parents, transaction_links }, preferences },
     idMap,
     danglingRefs,
   };
@@ -1016,6 +1158,14 @@ export interface RestoreOutcome {
   accountsRelinked: number;
   transactionsRelinked: number;
   /**
+   * Settings put back, and whether that succeeded. `failed` carries the reason
+   * rather than throwing: preferences are restored after every financial row is
+   * safely in, and a restore that threw away a complete, correct ledger because
+   * a toggle could not be saved would be the wrong trade by an enormous margin.
+   */
+  preferencesRestored: number;
+  preferencesFailure: string | null;
+  /**
    * References in the file that named a row the file does not contain. Left as
    * they were, and reported rather than swallowed — a restore that silently
    * detaches data is the one failure a backup must never have.
@@ -1086,7 +1236,11 @@ export async function wipeUserFinancialData(
 export async function restoreBackupBundle(
   bundle: BackupBundle,
   databaseUserId: string,
-  options: { onProgress?: (progress: RestoreProgress) => void; client?: BackupClient | null } = {}
+  options: {
+    onProgress?: (progress: RestoreProgress) => void;
+    client?: BackupClient | null;
+    preferences?: PreferencesTransport | null;
+  } = {}
 ): Promise<RestoreOutcome> {
   const client = requireClient(options.client);
   const restored: { label: string; rows: number }[] = [];
@@ -1143,11 +1297,43 @@ export async function restoreBackupBundle(
     throw new RestoreFailedError('Reconnecting transfers and nested accounts', finalizeError.message);
   }
 
+  // ── Preferences, LAST ─────────────────────────────────────────────────────
+  // After the links are closed, because nothing financial depends on them and
+  // everything about them can fail without costing the user a row. The login
+  // already has a preferences document by now — the app writes one at boot — so
+  // this REPLACES rather than inserts, which is also why it is not one more
+  // restore_user_chunk step.
+  let preferencesRestored = 0;
+  let preferencesFailure: string | null = null;
+  if (remapped.preferences !== null) {
+    const settings = Object.keys(remapped.preferences.values).length;
+    options.onProgress?.({
+      stepNumber: RESTORE_STEPS.length + 1,
+      stepCount: RESTORE_STEPS.length + 1,
+      label: 'Preferences',
+      rowsDone: 0,
+      rowsTotal: settings,
+    });
+    const transport = options.preferences ?? supabasePreferencesTransport();
+    try {
+      if (transport === null) {
+        throw new Error('This session has no cloud connection, so preferences could not be saved.');
+      }
+      await transport.write(databaseUserId, remapped.preferences);
+      preferencesRestored = settings;
+    } catch (error) {
+      preferencesFailure = error instanceof Error ? error.message : String(error);
+      backupLogger.warn('Preferences could not be restored; every financial row is in', error);
+    }
+  }
+
   const summary = isPlainObject(finalized) ? finalized : {};
   return {
     restored,
     accountsRelinked: asCount(typeof summary.accounts_relinked === 'number' ? summary.accounts_relinked : 0),
     transactionsRelinked: asCount(typeof summary.transactions_relinked === 'number' ? summary.transactions_relinked : 0),
+    preferencesRestored,
+    preferencesFailure,
     danglingRefs,
   };
 }

--- a/src/services/exportService.ts
+++ b/src/services/exportService.ts
@@ -3,6 +3,7 @@ import type { PeriodKey } from '../hooks/usePeriod';
 import { formatDecimal } from '../utils/decimal-format';
 import { buildCategoryNameLookup } from '../utils/categoryNames';
 import { createScopedLogger, type ScopedLogger } from '../loggers/scopedLogger';
+import { preferences } from './preferencesService';
 
 type StorageLike = Pick<Storage, 'getItem' | 'setItem'>;
 
@@ -503,4 +504,14 @@ NEWFILEUID:${now}
   }
 }
 
-export const exportService = new ExportService();
+/**
+ * Templates travel with the account.
+ *
+ * A saved export ("Monthly Summary, CSV, transactions only") is a statement
+ * about how this user reports on their own money, not about the browser they
+ * built it in — and until now it existed on exactly one machine and was absent
+ * from every backup. The store is the preferences document; the VALUES are the
+ * same JSON they always were, so an existing browser's templates are read back
+ * unchanged and then follow the user from there.
+ */
+export const exportService = new ExportService({ storage: preferences });

--- a/src/services/import/msMoney/msMoneyImport.ts
+++ b/src/services/import/msMoney/msMoneyImport.ts
@@ -920,25 +920,220 @@ export async function fetchExistingImportState(
 }
 
 /**
- * Delete ALL of the user's financial data under the authenticated client.
- * Wipe order matters: accounts BEFORE categories (the
- * protect_transfer_category trigger only lets a To/From category go once its
- * account row is gone), and self-referential transfer links are cleared
- * before the transaction wipe. Bank-account links cascade away with their
- * accounts; bank connections themselves are kept.
+ * The tables a wipe empties, in the order it must empty them.
  *
- * Used by the MS Money total migration AND the Danger Zone "Clear All Data".
+ * Not a preference — the database enforces it. accounts goes BEFORE categories
+ * because the protect_transfer_category trigger only lets a To/From category go
+ * once its account row has gone, and splits go before transactions because they
+ * hang off them. Bank-account links cascade away with their accounts; bank
+ * connections themselves are kept.
  */
-export async function wipeCloudData(supabase: SupabaseClient, userId: string): Promise<void> {
+export const WIPE_TABLE_ORDER: readonly string[] = [
+  'transaction_splits', 'transactions', 'budgets', 'goals', 'accounts', 'categories',
+];
+
+/**
+ * Rows touched per statement.
+ *
+ * The number exists because of a real failure: "Delete All Data" issued
+ * `DELETE FROM transactions WHERE user_id = …` against 51,000 rows and the
+ * database gave up with `canceling statement due to statement timeout`. The
+ * damage was not the error — it was WHERE it stopped. The unlink pass and the
+ * splits delete had already committed, so the login was left with its transfer
+ * links nulled and its splits gone and every transaction still there: a state
+ * nothing in the app produces and nothing in the app expects.
+ *
+ * 2,000 keeps each statement to a fraction of a second on the largest real
+ * dataset while keeping the number of round trips sane (26 for 51k rows). It is
+ * also below PostgREST's own 1,000-row read cap doubled, so the SELECT that
+ * feeds each DELETE is one request.
+ */
+export const WIPE_CHUNK_SIZE = 2000;
+
+/** What a wipe is doing right now, for a caller with a progress bar. */
+export interface WipeProgress {
+  table: string;
+  /** Rows deleted from this table so far. */
+  deleted: number;
+  /**
+   * What this table held when the wipe started, where the count succeeded.
+   * `undefined` rather than 0 when it did not: "of unknown" is honest, "0 of 0"
+   * beside a running spinner is not.
+   */
+  total?: number;
+  /** 1-based, for "3 of 7". Includes the transfer-unlink pass as step 1. */
+  step: number;
+  stepCount: number;
+}
+
+/**
+ * The five reads and writes a wipe performs, as a PORT.
+ *
+ * Not "the slice of the Supabase client we use". A structural interface
+ * describing the PostgREST builder chain has to be checked against
+ * `SupabaseClient`'s generics at every call site, and `tsc -b` gives up on that
+ * with "Type instantiation is excessively deep" — the compiler saying the
+ * abstraction is drawn in the wrong place. Five verbs are also what the loop
+ * below actually needs, and they are what a test can implement honestly:
+ * a real in-memory store, not a fake query builder that would only prove the
+ * chain was called in the order the test expected.
+ */
+export interface WipeStore {
+  /** How many rows this user has in `table`, or undefined when it cannot be told. */
+  count(table: string, userId: string): Promise<number | undefined>;
+  /** Up to `limit` ids of this user's rows in `table`. */
+  idsFor(table: string, userId: string, limit: number): Promise<string[]>;
+  /** Up to `limit` ids of this user's transactions that still carry a transfer link. */
+  linkedTransferIds(userId: string, limit: number): Promise<string[]>;
+  /** Null both transfer-link columns on exactly these rows. */
+  unlinkTransfers(ids: string[]): Promise<void>;
+  /** Delete exactly these rows from `table`. */
+  deleteByIds(table: string, ids: string[]): Promise<void>;
+}
+
+export interface WipeOptions {
+  onProgress?: (progress: WipeProgress) => void;
+  chunkSize?: number;
+  /** Overridable so a test can run the loop against a store it can inspect. */
+  store?: WipeStore;
+}
+
+/**
+ * The production store. The client is used INLINE and never assigned to a
+ * declared interface, which is what keeps its generics out of every signature
+ * in this file.
+ */
+export function supabaseWipeStore(supabase: SupabaseClient): WipeStore {
+  const ids = (rows: { id: string }[] | null): string[] => (rows ?? []).map(row => row.id);
+  return {
+    async count(table, userId) {
+      const { count, error } = await supabase
+        .from(table)
+        .select('id', { count: 'exact', head: true })
+        .eq('user_id', userId);
+      // A failed count is not a failed wipe. The delete loop decides when a
+      // table is empty by reading it, never by trusting this number, so the
+      // only thing lost here is the denominator in "3,000 of 51,000".
+      return error || count === null ? undefined : count;
+    },
+    async idsFor(table, userId, limit) {
+      const { data, error } = await supabase
+        .from(table).select('id').eq('user_id', userId).limit(limit);
+      if (error) throw new Error(error.message);
+      return ids(data);
+    },
+    async linkedTransferIds(userId, limit) {
+      const { data, error } = await supabase
+        .from('transactions').select('id')
+        .eq('user_id', userId)
+        .not('linked_transfer_id', 'is', null)
+        .limit(limit);
+      if (error) throw new Error(error.message);
+      return ids(data);
+    },
+    async unlinkTransfers(rowIds) {
+      const { error } = await supabase
+        .from('transactions')
+        .update({ linked_transfer_id: null, linked_transfer_split_id: null })
+        .in('id', rowIds);
+      if (error) throw new Error(error.message);
+    },
+    async deleteByIds(table, rowIds) {
+      const { error } = await supabase.from(table).delete().in('id', rowIds);
+      if (error) throw new Error(error.message);
+    },
+  };
+}
+
+/**
+ * Delete ALL of the user's financial data under the authenticated client, in
+ * chunks small enough that no single statement can time out.
+ *
+ * ── WHY CHUNKED ─────────────────────────────────────────────────────────────
+ * See WIPE_CHUNK_SIZE. One statement per table died on a real 51k-row account
+ * and left the login half-wiped.
+ *
+ * ── WHAT A FAILURE LEAVES BEHIND ────────────────────────────────────────────
+ * Chunks commit as they go, so a failure part-way through leaves the user with
+ * some rows gone and some still there. That is not a state this function tries
+ * to avoid — it CANNOT, without a transaction that would reintroduce the very
+ * timeout it exists to dodge — so it is a state it makes safe instead: every
+ * step is idempotent (deleting rows that are already gone is a no-op, and the
+ * unlink pass only touches rows that still carry a link), so running it again
+ * simply carries on from wherever it stopped. The dialog says so rather than
+ * showing a bare error, because "run it again" is the whole recovery.
+ *
+ * Used by the MS Money total migration AND the Danger Zone "Delete All Data".
+ */
+export async function wipeCloudData(
+  supabase: SupabaseClient,
+  userId: string,
+  options: WipeOptions = {}
+): Promise<void> {
+  return runWipe(options.store ?? supabaseWipeStore(supabase), userId, options);
+}
+
+/**
+ * The wipe itself, over the port.
+ *
+ * Split from `wipeCloudData` so the loop can be exercised against a real
+ * in-memory store rather than a stand-in for a query builder — and so that
+ * nothing about chunking, ordering or resumability is expressed in terms of
+ * PostgREST. The separation is also what lets the test avoid inventing a client
+ * it does not have.
+ */
+export async function runWipe(
+  store: WipeStore,
+  userId: string,
+  options: Omit<WipeOptions, 'store'> = {}
+): Promise<void> {
+  const chunkSize = Math.max(1, options.chunkSize ?? WIPE_CHUNK_SIZE);
+  const stepCount = WIPE_TABLE_ORDER.length + 1; // +1 for the unlink pass
+
+  // ── Step 1: break the transfer links ──────────────────────────────────────
+  // Self-references between transactions. They have to go before the rows do,
+  // and this UPDATE touched 13,000 rows on the real dataset — big enough to
+  // time out on its own, so it is chunked like everything else.
+  //
+  // The loop terminates because each pass clears the very column it selects on:
+  // a row updated here can never be returned by the next read.
   {
-    const { error } = await supabase.from('transactions')
-      .update({ linked_transfer_id: null, linked_transfer_split_id: null })
-      .eq('user_id', userId).not('linked_transfer_id', 'is', null);
-    if (error) throw new Error(`Failed while unlinking transfers: ${error.message}`);
+    const total = await store.count('transactions', userId);
+    let unlinked = 0;
+    options.onProgress?.({ table: 'transfer links', deleted: 0, total, step: 1, stepCount });
+    for (;;) {
+      let ids: string[];
+      try {
+        ids = await store.linkedTransferIds(userId, chunkSize);
+        if (ids.length === 0) break;
+        await store.unlinkTransfers(ids);
+      } catch (error) {
+        throw new Error(`Failed while unlinking transfers: ${error instanceof Error ? error.message : String(error)}`);
+      }
+      unlinked += ids.length;
+      options.onProgress?.({ table: 'transfer links', deleted: unlinked, total, step: 1, stepCount });
+    }
   }
-  for (const table of ['transaction_splits', 'transactions', 'budgets', 'goals', 'accounts', 'categories']) {
-    const { error } = await supabase.from(table).delete().eq('user_id', userId);
-    if (error) throw new Error(`Failed while clearing ${table}: ${error.message}`);
+
+  // ── Steps 2..n: empty each table, in the order the database allows ────────
+  for (const [index, table] of WIPE_TABLE_ORDER.entries()) {
+    const step = index + 2;
+    const total = await store.count(table, userId);
+    let deleted = 0;
+    options.onProgress?.({ table, deleted, total, step, stepCount });
+
+    for (;;) {
+      let ids: string[];
+      try {
+        ids = await store.idsFor(table, userId, chunkSize);
+        if (ids.length === 0) break;
+        await store.deleteByIds(table, ids);
+      } catch (error) {
+        throw new Error(`Failed while clearing ${table}: ${error instanceof Error ? error.message : String(error)}`);
+      }
+      deleted += ids.length;
+      options.onProgress?.({ table, deleted, total, step, stepCount });
+    }
   }
 }
 
@@ -962,7 +1157,22 @@ export async function importToCloud(
   const { onProgress } = opts;
 
   onProgress?.({ phase: 'wiping', fraction: 0.02, message: 'Backing out existing data…' });
-  await wipeCloudData(supabase, userId);
+  // The wipe is chunked, and on a 51k-row login it is minutes rather than
+  // seconds — so it reports through the SAME progress channel the rest of the
+  // import uses instead of sitting silently on one sentence. The first 15% of
+  // the bar is the wipe; the write passes below start from there.
+  await wipeCloudData(supabase, userId, {
+    onProgress: ({ table, deleted, total, step, stepCount }) => {
+      const within = total && total > 0 ? Math.min(1, deleted / total) : 0;
+      onProgress?.({
+        phase: 'wiping',
+        fraction: 0.02 + 0.13 * ((step - 1 + within) / stepCount),
+        message: total === undefined
+          ? `Backing out existing data — ${table}: ${deleted.toLocaleString()} removed…`
+          : `Backing out existing data — ${table}: ${deleted.toLocaleString()} of ${total.toLocaleString()}…`,
+      });
+    },
+  });
 
   // Read the existing state AFTER the wipe: whatever survived it (a partial
   // failure, a narrower wipe) must not be inserted a second time, and the

--- a/src/services/import/msMoney/wipeCloudData.test.ts
+++ b/src/services/import/msMoney/wipeCloudData.test.ts
@@ -1,0 +1,262 @@
+import { describe, it, expect } from 'vitest';
+import {
+  WIPE_CHUNK_SIZE,
+  WIPE_TABLE_ORDER,
+  runWipe,
+  type WipeProgress,
+  type WipeStore,
+} from './msMoneyImport';
+
+/**
+ * The bug these exist for, in the owner's words: "Delete All Data" reported
+ * `canceling statement due to statement timeout` on 51,000 transactions and
+ * left the login with its transfer links nulled and its splits gone and every
+ * transaction still there.
+ *
+ * The store below is a REAL in-memory implementation of the five verbs a wipe
+ * uses, not a fake query builder. A mock that recorded calls would only prove
+ * the chain was invoked in the order the test expected; this one can be asked
+ * what is actually left.
+ */
+
+interface Row {
+  id: string;
+  user_id: string;
+  linked: boolean;
+}
+
+/** Every table, populated with `counts[table]` rows belonging to `user`. */
+function memoryStore(
+  counts: Partial<Record<string, number>>,
+  options: {
+    user?: string;
+    linkedTransfers?: number;
+    /** Someone else's rows, which a wipe must not touch. */
+    otherUser?: Partial<Record<string, number>>;
+    /** Fail the nth call to this table's delete (1-based). */
+    failDelete?: { table: string; onCall: number; message: string };
+    countFails?: boolean;
+  } = {}
+): WipeStore & { tables: Map<string, Row[]>; calls: { verb: string; table: string; rows: number }[] } {
+  const user = options.user ?? 'u-1';
+  const tables = new Map<string, Row[]>();
+  for (const table of WIPE_TABLE_ORDER) {
+    const mine = Array.from({ length: counts[table] ?? 0 }, (_, n) => ({
+      id: `${table}-${n}`,
+      user_id: user,
+      linked: table === 'transactions' && n < (options.linkedTransfers ?? 0),
+    }));
+    const theirs = Array.from({ length: options.otherUser?.[table] ?? 0 }, (_, n) => ({
+      id: `${table}-other-${n}`,
+      user_id: 'someone-else',
+      linked: false,
+    }));
+    tables.set(table, [...mine, ...theirs]);
+  }
+
+  const calls: { verb: string; table: string; rows: number }[] = [];
+  const deletesSeen = new Map<string, number>();
+
+  return {
+    tables,
+    calls,
+    async count(table, userId) {
+      if (options.countFails) return undefined;
+      return (tables.get(table) ?? []).filter(row => row.user_id === userId).length;
+    },
+    async idsFor(table, userId, limit) {
+      const ids = (tables.get(table) ?? [])
+        .filter(row => row.user_id === userId)
+        .slice(0, limit)
+        .map(row => row.id);
+      calls.push({ verb: 'select', table, rows: ids.length });
+      return ids;
+    },
+    async linkedTransferIds(userId, limit) {
+      const ids = (tables.get('transactions') ?? [])
+        .filter(row => row.user_id === userId && row.linked)
+        .slice(0, limit)
+        .map(row => row.id);
+      calls.push({ verb: 'select-linked', table: 'transactions', rows: ids.length });
+      return ids;
+    },
+    async unlinkTransfers(ids) {
+      calls.push({ verb: 'unlink', table: 'transactions', rows: ids.length });
+      const set = new Set(ids);
+      for (const row of tables.get('transactions') ?? []) {
+        if (set.has(row.id)) row.linked = false;
+      }
+    },
+    async deleteByIds(table, ids) {
+      const seen = (deletesSeen.get(table) ?? 0) + 1;
+      deletesSeen.set(table, seen);
+      if (options.failDelete && options.failDelete.table === table && options.failDelete.onCall === seen) {
+        throw new Error(options.failDelete.message);
+      }
+      calls.push({ verb: 'delete', table, rows: ids.length });
+      const set = new Set(ids);
+      tables.set(table, (tables.get(table) ?? []).filter(row => !set.has(row.id)));
+    },
+  };
+}
+
+describe('the wipe — chunking', () => {
+  it('never issues one statement for the whole table', async () => {
+    // The failure: DELETE FROM transactions WHERE user_id = … over 51k rows.
+    const store = memoryStore({ transactions: 5_000 });
+
+    await runWipe(store, 'u-1', { chunkSize: 2_000 });
+
+    const deletes = store.calls.filter(call => call.verb === 'delete' && call.table === 'transactions');
+    expect(deletes.map(call => call.rows)).toEqual([2_000, 2_000, 1_000]);
+    expect(store.tables.get('transactions')).toEqual([]);
+  });
+
+  it('terminates on an empty database without deleting anything', async () => {
+    const store = memoryStore({});
+    await runWipe(store, 'u-1');
+    expect(store.calls.filter(call => call.verb === 'delete')).toHaveLength(0);
+  });
+
+  it('terminates when a table holds exactly one chunk', async () => {
+    // The off-by-one that would loop forever or stop one chunk early.
+    const store = memoryStore({ budgets: 10 });
+    await runWipe(store, 'u-1', { chunkSize: 10 });
+    expect(store.tables.get('budgets')).toEqual([]);
+    expect(store.calls.filter(call => call.verb === 'delete' && call.table === 'budgets')).toHaveLength(1);
+  });
+
+  it('leaves other people\'s rows exactly where they were', async () => {
+    const store = memoryStore({ transactions: 30 }, { otherUser: { transactions: 7 } });
+    await runWipe(store, 'u-1', { chunkSize: 10 });
+    expect(store.tables.get('transactions')).toHaveLength(7);
+    expect(store.tables.get('transactions')?.every(row => row.user_id === 'someone-else')).toBe(true);
+  });
+
+  it('ships a chunk size small enough to have avoided the timeout', () => {
+    // Not a magic number check — a floor. The failing statement was 51,000 rows
+    // in one go; anything of that order would reproduce it.
+    expect(WIPE_CHUNK_SIZE).toBeLessThanOrEqual(5_000);
+    expect(WIPE_CHUNK_SIZE).toBeGreaterThan(0);
+  });
+});
+
+describe('the wipe — the order the database demands', () => {
+  it('unlinks transfers first, then empties the tables in dependency order', async () => {
+    const store = memoryStore(
+      { transaction_splits: 2, transactions: 4, budgets: 1, goals: 1, accounts: 1, categories: 1 },
+      { linkedTransfers: 3 }
+    );
+
+    await runWipe(store, 'u-1', { chunkSize: 100 });
+
+    const mutations = store.calls
+      .filter(call => call.verb === 'unlink' || call.verb === 'delete')
+      .map(call => `${call.verb}:${call.table}`);
+
+    expect(mutations).toEqual([
+      'unlink:transactions',
+      'delete:transaction_splits',
+      'delete:transactions',
+      'delete:budgets',
+      'delete:goals',
+      'delete:accounts',
+      'delete:categories',
+    ]);
+    // accounts BEFORE categories — the protect_transfer_category trigger only
+    // lets a To/From category go once its account row has gone.
+    expect(WIPE_TABLE_ORDER.indexOf('accounts')).toBeLessThan(WIPE_TABLE_ORDER.indexOf('categories'));
+  });
+
+  it('chunks the transfer-unlink pass too — it touched 13,000 rows for real', async () => {
+    const store = memoryStore({ transactions: 5_000 }, { linkedTransfers: 5_000 });
+
+    await runWipe(store, 'u-1', { chunkSize: 2_000 });
+
+    const unlinks = store.calls.filter(call => call.verb === 'unlink');
+    expect(unlinks.map(call => call.rows)).toEqual([2_000, 2_000, 1_000]);
+  });
+});
+
+describe('the wipe — progress', () => {
+  it('reports every table by name, with a running count and a denominator', async () => {
+    const store = memoryStore({ transactions: 3_000, accounts: 2 });
+    const seen: WipeProgress[] = [];
+
+    await runWipe(store, 'u-1', { chunkSize: 2_000, onProgress: p => seen.push(p) });
+
+    const transactions = seen.filter(p => p.table === 'transactions');
+    expect(transactions.map(p => p.deleted)).toEqual([0, 2_000, 3_000]);
+    expect(transactions.every(p => p.total === 3_000)).toBe(true);
+
+    // Every step announces itself, including the ones with nothing to do — a
+    // step that stays silent reads as a step that hung.
+    expect(new Set(seen.map(p => p.table))).toEqual(
+      new Set(['transfer links', ...WIPE_TABLE_ORDER])
+    );
+    expect(seen.every(p => p.stepCount === WIPE_TABLE_ORDER.length + 1)).toBe(true);
+    expect(seen.map(p => p.step)).toEqual([...seen.map(p => p.step)].sort((a, b) => a - b));
+  });
+
+  it('says "unknown" rather than "0" when the count could not be taken', async () => {
+    // A failed count must not fail the wipe, and must not be reported as zero
+    // beside a spinner that is plainly still working.
+    const store = memoryStore({ transactions: 3 }, { countFails: true });
+    const seen: WipeProgress[] = [];
+
+    await runWipe(store, 'u-1', { chunkSize: 2, onProgress: p => seen.push(p) });
+
+    expect(seen.every(p => p.total === undefined)).toBe(true);
+    expect(store.tables.get('transactions')).toEqual([]);
+  });
+});
+
+describe('the wipe — failure part-way through', () => {
+  it('names the table it stopped on and keeps the database\'s own message', async () => {
+    const store = memoryStore(
+      { transactions: 6_000 },
+      { failDelete: { table: 'transactions', onCall: 2, message: 'canceling statement due to statement timeout' } }
+    );
+
+    await expect(runWipe(store, 'u-1', { chunkSize: 2_000 }))
+      .rejects.toThrow(/Failed while clearing transactions: canceling statement due to statement timeout/);
+  });
+
+  it('leaves a state the same call can finish — deleting what has already gone is a no-op', async () => {
+    const failing = memoryStore(
+      { transaction_splits: 10, transactions: 6_000, accounts: 1 },
+      { failDelete: { table: 'transactions', onCall: 2, message: 'canceling statement due to statement timeout' } }
+    );
+
+    await expect(runWipe(failing, 'u-1', { chunkSize: 2_000 })).rejects.toThrow();
+
+    // Part-way: the splits went, 2,000 transactions went, the rest are there.
+    expect(failing.tables.get('transaction_splits')).toEqual([]);
+    expect(failing.tables.get('transactions')).toHaveLength(4_000);
+    expect(failing.tables.get('accounts')).toHaveLength(1);
+
+    // Run it again — the recovery the dialog tells the user about — against the
+    // same store, now without the injected failure.
+    const resumed: WipeStore = { ...failing, deleteByIds: async (table, ids) => {
+      const set = new Set(ids);
+      failing.tables.set(table, (failing.tables.get(table) ?? []).filter(row => !set.has(row.id)));
+    } };
+
+    await runWipe(resumed, 'u-1', { chunkSize: 2_000 });
+
+    for (const table of WIPE_TABLE_ORDER) {
+      expect(failing.tables.get(table)).toEqual([]);
+    }
+  });
+
+  it('reports the unlink pass under its own name when it is the pass that fails', async () => {
+    const store = memoryStore({ transactions: 10 }, { linkedTransfers: 10 });
+    const failingUnlink: WipeStore = {
+      ...store,
+      unlinkTransfers: () => Promise.reject(new Error('statement timeout')),
+    };
+
+    await expect(runWipe(failingUnlink, 'u-1', { chunkSize: 5 }))
+      .rejects.toThrow(/Failed while unlinking transfers: statement timeout/);
+  });
+});

--- a/src/services/localBackupService.test.ts
+++ b/src/services/localBackupService.test.ts
@@ -21,6 +21,7 @@ import {
 import { storageAdapter, STORAGE_KEYS } from './storageAdapter';
 import { canonicalSubjectKey } from '../utils/suggestionDismissals';
 import { toDecimal } from '../utils/decimal';
+import { PreferencesService } from './preferencesService';
 
 /**
  * These run against the REAL storage stack — storageAdapter → encryptedStorage
@@ -839,5 +840,123 @@ describe('a corrupted collection', () => {
     const rows: unknown[] = [...seedAccounts(), 'not a record'];
     await storageAdapter.set(STORAGE_KEYS.ACCOUNTS, rows);
     await expect(collectLocalBackupBundle()).rejects.toThrow(/not a record/);
+  });
+});
+
+// ── Preferences travel with a local file too ─────────────────────────────────
+
+/**
+ * A local device has no account to store preferences against, so the file IS
+ * the only copy of them there will ever be — which makes carrying them more
+ * important here than in the cloud, not less.
+ */
+describe('preferences in a local backup', () => {
+  /** A service with its own in-memory browser, so no suite leaks into another. */
+  const isolated = (initial: Record<string, string> = {}): PreferencesService => {
+    const values = { ...initial };
+    return new PreferencesService({
+      mirror: {
+        getItem: (key) => (key in values ? values[key] : null),
+        setItem: (key, value) => { values[key] = value; },
+        removeItem: (key) => { delete values[key]; },
+      },
+      transport: null,
+      debounceMs: 0,
+    });
+  };
+
+  const port = (service: PreferencesService) => ({
+    read: () => service.getDocument(),
+    write: (document: Parameters<PreferencesService['replaceAll']>[0]) => service.replaceAll(document),
+  });
+
+  it('exports what the device holds and restores it onto a device that has none', async () => {
+    await seedEverything();
+    const source = isolated();
+    source.setItem('accountsSortMode', 'balance-desc');
+    source.setItem('netWorthChartType', 'bar');
+
+    const exported = await collectLocalBackupBundle({ preferences: port(source) });
+    const onDisk = JSON.stringify(exported, null, 2);
+
+    await wipeLocalFinancialData(LOCAL_WIPE_CONFIRMATION);
+    const validation = validateBackupBundle(JSON.parse(onDisk));
+    if (!validation.ok) throw new Error(validation.problem);
+
+    const target = isolated();
+    const outcome = await restoreLocalBackupBundle(validation.bundle, {
+      newId: countingIds(),
+      preferences: port(target),
+    });
+
+    expect(outcome.preferencesRestored).toBe(2);
+    expect(outcome.preferencesFailure).toBeNull();
+    expect(target.getItem('accountsSortMode')).toBe('balance-desc');
+    expect(target.getItem('netWorthChartType')).toBe('bar');
+  });
+
+  it('brings the pinned accounts back pointing at the accounts that were restored', async () => {
+    // The silent failure this guards: ids inside a preference are not
+    // constrained by anything, so a verbatim restore leaves the dashboard
+    // pinning accounts belonging to the login the file came from.
+    await seedEverything();
+    const accountsBefore = await read(STORAGE_KEYS.ACCOUNTS);
+    const pinned = accountsBefore.slice(0, 2).map((account) => String(account.id));
+
+    const source = isolated();
+    source.setItem('dashboardKeyAccounts', JSON.stringify(pinned));
+
+    const onDisk = JSON.stringify(await collectLocalBackupBundle({ preferences: port(source) }), null, 2);
+    await wipeLocalFinancialData(LOCAL_WIPE_CONFIRMATION);
+    const validation = validateBackupBundle(JSON.parse(onDisk));
+    if (!validation.ok) throw new Error(validation.problem);
+
+    const target = isolated();
+    await restoreLocalBackupBundle(validation.bundle, { newId: countingIds(), preferences: port(target) });
+
+    const accountsAfter = await read(STORAGE_KEYS.ACCOUNTS);
+    const restoredPins: unknown = JSON.parse(target.getItem('dashboardKeyAccounts') ?? '[]');
+    const liveIds = new Set(accountsAfter.map((account) => String(account.id)));
+
+    expect(restoredPins).toHaveLength(2);
+    expect((restoredPins as string[]).every((id) => liveIds.has(id))).toBe(true);
+    // …and specifically NOT the ids the file carried.
+    expect(restoredPins).not.toEqual(pinned);
+  });
+
+  it('does not fail the restore when the settings cannot be saved', async () => {
+    // Preferences go in after every financial row. A complete ledger with
+    // default toggles is a good outcome that happens to be missing something.
+    await seedEverything();
+    const source = isolated();
+    source.setItem('accountsSortMode', 'name');
+    const onDisk = JSON.stringify(await collectLocalBackupBundle({ preferences: port(source) }), null, 2);
+
+    await wipeLocalFinancialData(LOCAL_WIPE_CONFIRMATION);
+    const validation = validateBackupBundle(JSON.parse(onDisk));
+    if (!validation.ok) throw new Error(validation.problem);
+
+    const outcome = await restoreLocalBackupBundle(validation.bundle, {
+      newId: countingIds(),
+      preferences: {
+        read: () => ({ version: 1, values: {} }),
+        write: () => Promise.reject(new Error('storage is full')),
+      },
+    });
+
+    expect(outcome.preferencesRestored).toBe(0);
+    expect(outcome.preferencesFailure).toBe('storage is full');
+    // The rows are all there regardless.
+    expect(await read(STORAGE_KEYS.TRANSACTIONS)).not.toHaveLength(0);
+  });
+
+  it('is not emptied by a wipe — deleting your data is not forgetting how you read it', async () => {
+    await seedEverything();
+    const service = isolated();
+    service.setItem('accountsSortMode', 'name');
+
+    await wipeLocalFinancialData(LOCAL_WIPE_CONFIRMATION);
+
+    expect(service.getItem('accountsSortMode')).toBe('name');
   });
 });

--- a/src/services/localBackupService.ts
+++ b/src/services/localBackupService.ts
@@ -1,5 +1,6 @@
 import { storageAdapter, STORAGE_KEYS } from './storageAdapter';
 import { toDecimal } from '../utils/decimal';
+import { preferences, type PreferencesDocument } from './preferencesService';
 import {
   BACKUP_ENTITIES,
   MAX_EXACT_MONEY,
@@ -71,6 +72,25 @@ export interface LocalBackupStore {
 }
 
 const defaultStore = (): LocalBackupStore => storageAdapter;
+
+/**
+ * The preferences half of the file, on a device.
+ *
+ * Its own port rather than another storage key, because on this engine the
+ * preferences document does not live in the encrypted store at all — it lives
+ * in the same service the cloud path reads, whose browser mirror IS the store
+ * when nobody is signed in. Injecting it keeps the test honest and keeps this
+ * module from reaching for a singleton mid-function.
+ */
+export interface LocalPreferencesPort {
+  read(): PreferencesDocument;
+  write(document: PreferencesDocument): Promise<void>;
+}
+
+const defaultPreferences = (): LocalPreferencesPort => ({
+  read: () => preferences.getDocument(),
+  write: (document) => preferences.replaceAll(document),
+});
 
 // ── Small readers ───────────────────────────────────────────────────────────
 
@@ -780,10 +800,12 @@ export async function collectLocalBackupBundle(
   options: {
     onProgress?: (progress: ExportProgress) => void;
     store?: LocalBackupStore;
+    preferences?: LocalPreferencesPort;
     now?: () => Date;
   } = {}
 ): Promise<BackupBundle> {
   const store = options.store ?? defaultStore();
+  const preferencesPort = options.preferences ?? defaultPreferences();
   const data: Partial<Record<BackupEntity, BackupRow[]>> = {};
 
   for (const [index, entity] of BACKUP_ENTITIES.entries()) {
@@ -806,6 +828,10 @@ export async function collectLocalBackupBundle(
     sourceUserId: LOCAL_SOURCE_USER_ID,
     exportedAt: now().toISOString(),
     data,
+    // For a signed-out user this is the ONLY copy of their settings that will
+    // ever exist anywhere, which makes carrying it more important here than in
+    // the cloud file, not less.
+    preferences: preferencesPort.read(),
   });
 }
 
@@ -884,6 +910,9 @@ export interface LocalRestoreOutcome {
   notStoredLocally: { label: string; rows: number; absence: string }[];
   accountsRelinked: number;
   transactionsRelinked: number;
+  /** Settings put back. Locally this cannot fail separately — see below. */
+  preferencesRestored: number;
+  preferencesFailure: string | null;
   danglingRefs: DanglingReference[];
 }
 
@@ -975,10 +1004,12 @@ export async function restoreLocalBackupBundle(
   options: {
     onProgress?: (progress: RestoreProgress) => void;
     store?: LocalBackupStore;
+    preferences?: LocalPreferencesPort;
     newId?: () => string;
   } = {}
 ): Promise<LocalRestoreOutcome> {
   const store = options.store ?? defaultStore();
+  const preferencesPort = options.preferences ?? defaultPreferences();
 
   if (!(await localFinancialDataIsEmpty({ store }))) {
     throw new LocalRestoreRefusedError(
@@ -1046,5 +1077,36 @@ export async function restoreLocalBackupBundle(
 
   await store.setMany(entries);
 
-  return { restored, notStoredLocally, accountsRelinked, transactionsRelinked, danglingRefs };
+  // After the one atomic write, and deliberately not inside it: the settings
+  // live in a different store from the financial rows, so they cannot join that
+  // transaction however they are ordered. Last is therefore the only safe place
+  // — a device with its ledger back and its toggles at defaults is recoverable,
+  // the other way round is not.
+  let preferencesRestored = 0;
+  let preferencesFailure: string | null = null;
+  if (remapped.preferences !== null) {
+    options.onProgress?.({
+      stepNumber: stepCount,
+      stepCount,
+      label: 'Preferences',
+      rowsDone: 0,
+      rowsTotal: Object.keys(remapped.preferences.values).length,
+    });
+    try {
+      await preferencesPort.write(remapped.preferences);
+      preferencesRestored = Object.keys(remapped.preferences.values).length;
+    } catch (error) {
+      preferencesFailure = error instanceof Error ? error.message : String(error);
+    }
+  }
+
+  return {
+    restored,
+    notStoredLocally,
+    accountsRelinked,
+    transactionsRelinked,
+    preferencesRestored,
+    preferencesFailure,
+    danglingRefs,
+  };
 }

--- a/src/services/preferencesService.test.ts
+++ b/src/services/preferencesService.test.ts
@@ -1,0 +1,374 @@
+import { describe, it, expect, vi } from 'vitest';
+import {
+  PREFERENCES_DOCUMENT_VERSION,
+  PORTABLE_PREFERENCE_KEYS,
+  PreferencesService,
+  parsePreferencesDocument,
+  periodPreferenceKeys,
+  type LocalMirror,
+  type PreferencesDocument,
+  type PreferencesTransport,
+} from './preferencesService';
+
+/**
+ * Every value here is invented. The keys are the app's real ones because the
+ * behaviour under test is about WHICH keys travel, and a made-up key would let
+ * a registry mistake pass.
+ */
+
+/** A browser mirror that can be inspected, and made to fail like Safari's does. */
+function mirror(initial: Record<string, string> = {}): LocalMirror & { values: Record<string, string> } {
+  const values = { ...initial };
+  return {
+    values,
+    getItem: (key) => (key in values ? values[key] : null),
+    setItem: (key, value) => { values[key] = value; },
+    removeItem: (key) => { delete values[key]; },
+  };
+}
+
+/** A store standing in for the row, with every call recorded. */
+function transport(initial: PreferencesDocument | null = null): PreferencesTransport & {
+  row: PreferencesDocument | null;
+  writes: PreferencesDocument[];
+  reads: string[];
+} {
+  const state = {
+    row: initial,
+    writes: [] as PreferencesDocument[],
+    reads: [] as string[],
+    read: async (userId: string) => { state.reads.push(userId); return state.row; },
+    write: async (_userId: string, document: PreferencesDocument) => {
+      state.writes.push(document);
+      state.row = document;
+    },
+  };
+  return state;
+}
+
+/** No timers: every scheduled write fires at once, so `flush` is enough. */
+const immediate = { debounceMs: 0 };
+
+describe('parsePreferencesDocument', () => {
+  it('keeps a key this build has never heard of', () => {
+    // The property that makes one document safe for two client versions at
+    // once: an older client must not be able to drop a newer one's preference.
+    const parsed = parsePreferencesDocument({
+      version: 1,
+      values: { 'something.from.2027': 'on', dashboardKeyAccounts: '["a-1"]' },
+    });
+    expect(parsed.values['something.from.2027']).toBe('on');
+  });
+
+  it('keeps a version it does not recognise, rather than resetting the document', () => {
+    expect(parsePreferencesDocument({ version: 9, values: {} }).version).toBe(9);
+  });
+
+  it('drops a value that is not a string, because nothing could consume it', () => {
+    const parsed = parsePreferencesDocument({ version: 1, values: { a: 'x', b: 42, c: null } });
+    expect(parsed.values).toEqual({ a: 'x' });
+  });
+
+  it('reads junk as an empty document instead of throwing', () => {
+    expect(parsePreferencesDocument(null).values).toEqual({});
+    expect(parsePreferencesDocument('nonsense').values).toEqual({});
+    expect(parsePreferencesDocument([1, 2, 3]).values).toEqual({});
+    expect(parsePreferencesDocument({ version: 1, values: 'not an object' }).values).toEqual({});
+  });
+});
+
+describe('the registry', () => {
+  it('covers all four keys of every period surface', () => {
+    // usePeriod writes four keys per surface and all four have to travel, or a
+    // restored custom range comes back as an empty one nobody asked for.
+    for (const key of periodPreferenceKeys('dashboardReports')) {
+      expect(PORTABLE_PREFERENCE_KEYS).toContain(key);
+    }
+  });
+
+  it('leaves device state out — column widths and the last sync stay put', () => {
+    expect(PORTABLE_PREFERENCE_KEYS).not.toContain('accountRegister.columnWidths.v1');
+    expect(PORTABLE_PREFERENCE_KEYS.some(key => key.startsWith('bankAutoSync:lastRun'))).toBe(false);
+    expect(PORTABLE_PREFERENCE_KEYS).not.toContain('onboardingCompleted');
+  });
+
+  it('lists no key twice', () => {
+    expect(new Set(PORTABLE_PREFERENCE_KEYS).size).toBe(PORTABLE_PREFERENCE_KEYS.length);
+  });
+});
+
+describe('reading before the account has spoken', () => {
+  it('answers from this browser, so nothing is forgotten on the first boot', () => {
+    // The whole point of the fall-through: every setting the user already has
+    // is in browser storage under exactly these keys.
+    const service = new PreferencesService({
+      mirror: mirror({ accountsSortMode: 'balance-desc' }),
+      transport: null,
+      ...immediate,
+    });
+    expect(service.getItem('accountsSortMode')).toBe('balance-desc');
+  });
+
+  it('stops answering from this browser once the account has', async () => {
+    // A key absent from the stored document is absent — the user removed that
+    // preference, possibly elsewhere — and resurrecting this browser's leftover
+    // copy every boot is exactly the bug "my settings follow me" must not have.
+    const browser = mirror({ accountsSortMode: 'balance-desc' });
+    const store = transport({ version: 1, values: { accountsGroupBy: 'type' } });
+    const service = new PreferencesService({ mirror: browser, transport: store, ...immediate });
+
+    await service.attach('user-1');
+
+    expect(service.getItem('accountsGroupBy')).toBe('type');
+    expect(service.getItem('accountsSortMode')).toBeNull();
+  });
+});
+
+describe('the one-time lift', () => {
+  it('writes this browser\'s existing settings up as the row\'s first content', async () => {
+    const browser = mirror({
+      dashboardKeyAccounts: '["a-1","a-2"]',
+      money_management_currency: 'GBP',
+      // Not registered, so the lift does not carry it. It would still travel if
+      // something wrote it THROUGH the service; the registry only drives this.
+      'some.device.thing': 'x',
+    });
+    const store = transport(null);
+    const service = new PreferencesService({ mirror: browser, transport: store, ...immediate });
+
+    await service.attach('user-1');
+    await service.flush();
+
+    expect(store.writes).toHaveLength(1);
+    expect(store.writes[0].values.dashboardKeyAccounts).toBe('["a-1","a-2"]');
+    expect(store.writes[0].values.money_management_currency).toBe('GBP');
+    expect(store.writes[0].values['some.device.thing']).toBeUndefined();
+    expect(store.writes[0].version).toBe(PREFERENCES_DOCUMENT_VERSION);
+  });
+
+  it('does not lift over a value changed while the read was in flight', async () => {
+    const browser = mirror({ accountsSortMode: 'name' });
+    const store = transport(null);
+    const service = new PreferencesService({ mirror: browser, transport: store, ...immediate });
+
+    // The user clicks before the row comes back. Their click is newer.
+    service.setItem('accountsSortMode', 'balance-asc');
+    await service.attach('user-1');
+    await service.flush();
+
+    expect(service.getItem('accountsSortMode')).toBe('balance-asc');
+    expect(store.row?.values.accountsSortMode).toBe('balance-asc');
+  });
+
+  it('lifts nothing from an empty browser, and still creates the row', async () => {
+    const store = transport(null);
+    const service = new PreferencesService({ mirror: mirror(), transport: store, ...immediate });
+
+    await service.attach('user-1');
+    await service.flush();
+
+    expect(store.writes).toHaveLength(1);
+    expect(store.writes[0].values).toEqual({});
+  });
+});
+
+describe('loading an existing row', () => {
+  it('lets the account outrank this browser, and refreshes the browser to match', async () => {
+    // A machine not opened for a month must not push its month-old toggles over
+    // the ones set since.
+    const browser = mirror({ money_management_currency: 'USD' });
+    const store = transport({ version: 1, values: { money_management_currency: 'EUR' } });
+    const service = new PreferencesService({ mirror: browser, transport: store, ...immediate });
+
+    await service.attach('user-1');
+
+    expect(service.getItem('money_management_currency')).toBe('EUR');
+    expect(browser.values.money_management_currency).toBe('EUR');
+  });
+
+  it('keeps this browser\'s copy when the row cannot be read', async () => {
+    // A database without the migration applied yet, or an offline boot. Both
+    // survivable: the mirror is where all of this lived until now.
+    const browser = mirror({ accountsSortMode: 'name' });
+    const failing: PreferencesTransport = {
+      read: () => Promise.reject(new Error('relation "user_preferences" does not exist')),
+      write: () => Promise.resolve(),
+    };
+    const service = new PreferencesService({ mirror: browser, transport: failing, ...immediate });
+
+    await service.attach('user-1');
+
+    expect(service.getItem('accountsSortMode')).toBe('name');
+  });
+});
+
+describe('write-through', () => {
+  it('reaches the browser at once and the account after the debounce', async () => {
+    const browser = mirror();
+    const store = transport({ version: 1, values: {} });
+    const service = new PreferencesService({
+      mirror: browser,
+      transport: store,
+      debounceMs: 5_000,
+    });
+    await service.attach('user-1');
+
+    service.setItem('netWorthChartType', 'bar');
+
+    // Immediately: the browser has it, so a reload with no network keeps it.
+    expect(browser.values.netWorthChartType).toBe('bar');
+    expect(store.writes).toHaveLength(0);
+
+    await service.flush();
+    expect(store.writes.at(-1)?.values.netWorthChartType).toBe('bar');
+  });
+
+  it('collapses a burst of changes into one write', async () => {
+    const store = transport({ version: 1, values: {} });
+    const service = new PreferencesService({ mirror: mirror(), transport: store, debounceMs: 5_000 });
+    await service.attach('user-1');
+
+    // Ticking six accounts in the dashboard picker is six setItems.
+    for (const value of ['a', 'b', 'c', 'd', 'e', 'f']) {
+      service.setItem('dashboardKeyAccounts', JSON.stringify([value]));
+    }
+    await service.flush();
+
+    expect(store.writes).toHaveLength(1);
+    expect(store.writes[0].values.dashboardKeyAccounts).toBe('["f"]');
+  });
+
+  it('writes nothing when the value has not actually changed', async () => {
+    const store = transport({ version: 1, values: { netWorthShowDetail: '1' } });
+    const service = new PreferencesService({ mirror: mirror(), transport: store, debounceMs: 5_000 });
+    await service.attach('user-1');
+
+    service.setItem('netWorthShowDetail', '1');
+    await service.flush();
+
+    expect(store.writes).toHaveLength(0);
+  });
+
+  it('keeps the setting for this session when the account write fails', async () => {
+    const failing: PreferencesTransport = {
+      read: () => Promise.resolve({ version: 1, values: {} }),
+      write: () => Promise.reject(new Error('offline')),
+    };
+    const browser = mirror();
+    const service = new PreferencesService({ mirror: browser, transport: failing, ...immediate });
+    await service.attach('user-1');
+
+    service.setItem('reportsPayeeSide', 'income');
+    await service.flush();
+
+    expect(service.getItem('reportsPayeeSide')).toBe('income');
+    expect(browser.values.reportsPayeeSide).toBe('income');
+  });
+
+  it('survives a browser that refuses to store anything', async () => {
+    // Safari private browsing throws on setItem. The preference must still hold
+    // for this visit and still reach the account.
+    const throwing: LocalMirror = {
+      getItem: () => { throw new Error('SecurityError'); },
+      setItem: () => { throw new Error('QuotaExceededError'); },
+      removeItem: () => { throw new Error('SecurityError'); },
+    };
+    const store = transport({ version: 1, values: {} });
+    const service = new PreferencesService({ mirror: throwing, transport: store, ...immediate });
+    await service.attach('user-1');
+
+    service.setItem('reportsTrendChartType', 'bar');
+    await service.flush();
+
+    expect(service.getItem('reportsTrendChartType')).toBe('bar');
+    expect(store.writes.at(-1)?.values.reportsTrendChartType).toBe('bar');
+  });
+
+  it('removes a preference from the account as well as the browser', async () => {
+    const browser = mirror({ reportsAccountFilterIds: '["a-1"]' });
+    const store = transport({ version: 1, values: { reportsAccountFilterIds: '["a-1"]' } });
+    const service = new PreferencesService({ mirror: browser, transport: store, ...immediate });
+    await service.attach('user-1');
+
+    service.removeItem('reportsAccountFilterIds');
+    await service.flush();
+
+    expect(service.getItem('reportsAccountFilterIds')).toBeNull();
+    expect(browser.values.reportsAccountFilterIds).toBeUndefined();
+    expect(store.row?.values.reportsAccountFilterIds).toBeUndefined();
+  });
+
+  it('does not write at all before a user is attached', async () => {
+    const store = transport(null);
+    const service = new PreferencesService({ mirror: mirror(), transport: store, ...immediate });
+
+    service.setItem('accountsSortMode', 'name');
+    await service.flush();
+
+    expect(store.writes).toHaveLength(0);
+  });
+});
+
+describe('signing out', () => {
+  it('forgets the previous user, so their settings cannot be written into the next one\'s row', async () => {
+    // The shared-browser case. attach() merges what is in memory on top of the
+    // document it reads, so a document left over from user A would end up in
+    // user B's row.
+    const store = transport({ version: 1, values: { dashboardKeyAccounts: '["a-of-user-a"]' } });
+    const service = new PreferencesService({ mirror: mirror(), transport: store, ...immediate });
+    await service.attach('user-a');
+    expect(service.getItem('dashboardKeyAccounts')).toBe('["a-of-user-a"]');
+
+    service.detach();
+
+    store.row = { version: 1, values: { dashboardKeyAccounts: '["a-of-user-b"]' } };
+    await service.attach('user-b');
+    await service.flush();
+
+    expect(service.getItem('dashboardKeyAccounts')).toBe('["a-of-user-b"]');
+    expect(store.row.values.dashboardKeyAccounts).toBe('["a-of-user-b"]');
+  });
+});
+
+describe('subscribers', () => {
+  it('are told when a value changes and when the account\'s document lands', async () => {
+    const store = transport({ version: 1, values: { accountsSortMode: 'name' } });
+    const service = new PreferencesService({ mirror: mirror(), transport: store, ...immediate });
+    const listener = vi.fn();
+    const unsubscribe = service.subscribe(listener);
+
+    await service.attach('user-1');
+    expect(listener).toHaveBeenCalledTimes(1);
+
+    service.setItem('accountsSortMode', 'balance-asc');
+    expect(listener).toHaveBeenCalledTimes(2);
+
+    unsubscribe();
+    service.setItem('accountsSortMode', 'name');
+    expect(listener).toHaveBeenCalledTimes(2);
+  });
+
+  it('hand out a new document object on every change, so React can compare it', () => {
+    const service = new PreferencesService({ mirror: mirror(), transport: null, ...immediate });
+    const before = service.getDocument();
+    service.setItem('netWorthChartType', 'bar');
+    expect(service.getDocument()).not.toBe(before);
+  });
+});
+
+describe('replaceAll', () => {
+  it('takes the whole document, mirrors it, and saves it at once', async () => {
+    // The restore path. No debounce: the user is watching a progress dialog and
+    // the next thing that happens is a reload.
+    const browser = mirror({ accountsSortMode: 'name' });
+    const store = transport({ version: 1, values: {} });
+    const service = new PreferencesService({ mirror: browser, transport: store, debounceMs: 5_000 });
+    await service.attach('user-1');
+
+    await service.replaceAll({ version: 1, values: { accountsSortMode: 'balance-desc' } });
+
+    expect(service.getItem('accountsSortMode')).toBe('balance-desc');
+    expect(browser.values.accountsSortMode).toBe('balance-desc');
+    expect(store.row?.values.accountsSortMode).toBe('balance-desc');
+  });
+});

--- a/src/services/preferencesService.ts
+++ b/src/services/preferencesService.ts
@@ -1,0 +1,663 @@
+import { supabase } from './api/supabaseClient';
+import { createScopedLogger } from '../loggers/scopedLogger';
+
+/**
+ * Preferences that travel with the ACCOUNT rather than with the browser.
+ *
+ * ── WHY THIS EXISTS ─────────────────────────────────────────────────────────
+ *
+ * A full backup was restored into a fresh login and the app came up
+ * factory-reset: right accounts, right transactions, and every choice the owner
+ * had ever made about how to LOOK at them gone. Which accounts the dashboard
+ * pins, which reports are pinned beside them, the period each surface opens on,
+ * how the Accounts page is banded and sorted, which register columns are
+ * hidden, the archive cutoffs he had set per account — a whole tier of
+ * personalisation lived in `window.localStorage` and nowhere else. It did not
+ * back up, it did not follow him to a second machine, and nothing said so.
+ *
+ * The fix is not "back up localStorage". localStorage holds two different kinds
+ * of thing side by side: statements about the USER ("show me twelve months",
+ * "these six accounts matter") and statements about the DEVICE ("this browser
+ * has shown you the import tip", "this screen fits a 240px description
+ * column"). Carrying the second kind across machines makes the app worse, not
+ * better. So each key is classified once, and only the first kind lives here.
+ *
+ * ── THE DOCUMENT ────────────────────────────────────────────────────────────
+ *
+ * One row per user holding ONE jsonb document, not a row per key. Preferences
+ * are read as a SET exactly once (at boot, before the first paint that depends
+ * on them), written rarely, and have to travel whole into a backup file. A row
+ * per key would turn one round trip into fifty, and would let a restore land
+ * half a user's settings.
+ *
+ * Values are stored as the SAME STRINGS localStorage held — not as a typed
+ * object graph. That is deliberate:
+ *
+ *   * every call site already serialises to a string, so rewiring one is
+ *     `localStorage.` → `preferences.` and nothing else. The point of this work
+ *     is where the data LIVES, not renaming it;
+ *   * a key this build has never heard of is preserved untouched. An older
+ *     client cannot drop a newer client's preference, because it never parses
+ *     it — which is the property that makes a shared document safe to roll out
+ *     to two versions at once;
+ *   * a corrupt value costs exactly one preference. Each call site already
+ *     guards its own parse (they had to: localStorage is hand-editable), so a
+ *     bad value falls back to that key's default instead of failing the load.
+ *
+ * ── WHAT IS NOT HERE ────────────────────────────────────────────────────────
+ *
+ * Anything that grows with the size of the dataset. Everything registered below
+ * is a toggle, an enum, a short list of account ids, or a handful of column
+ * names. The database backs this up with a hard CHECK on the document's size
+ * (see migration 20260809160000): preferences are small, and a table that lets
+ * them stop being small would become a second, unindexed copy of the ledger.
+ */
+
+const preferencesLogger = createScopedLogger('PreferencesService');
+
+// ── The document ────────────────────────────────────────────────────────────
+
+/**
+ * The version this build writes.
+ *
+ * Bump it only when the MEANING of the values map changes, never for a new key
+ * — new keys are the normal case and need no version at all. A document
+ * claiming a version this build does not know is read anyway, values and all:
+ * refusing it would lose every setting rather than the one that changed.
+ */
+export const PREFERENCES_DOCUMENT_VERSION = 1;
+
+export interface PreferencesDocument {
+  version: number;
+  /** Preference key → the exact string the call site stored. */
+  values: Record<string, string>;
+}
+
+export const EMPTY_PREFERENCES: PreferencesDocument = { version: PREFERENCES_DOCUMENT_VERSION, values: {} };
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === 'object' && value !== null && !Array.isArray(value);
+
+/**
+ * Read a document off the wire.
+ *
+ * Deliberately forgiving in one direction and strict in the other: a `values`
+ * entry that is not a string is DROPPED (nothing can consume it, and keeping it
+ * would put a shape into the document that a later write would echo back to the
+ * database), while an unrecognised VERSION is kept as it is. The first is
+ * corruption; the second is a newer client, and a newer client's document must
+ * come back out of an older one unharmed.
+ */
+export function parsePreferencesDocument(raw: unknown): PreferencesDocument {
+  if (!isRecord(raw)) return { ...EMPTY_PREFERENCES, values: {} };
+
+  const version = typeof raw.version === 'number' && Number.isFinite(raw.version)
+    ? raw.version
+    : PREFERENCES_DOCUMENT_VERSION;
+
+  const values: Record<string, string> = {};
+  if (isRecord(raw.values)) {
+    for (const [key, value] of Object.entries(raw.values)) {
+      if (typeof value === 'string') values[key] = value;
+    }
+  }
+
+  return { version, values };
+}
+
+// ── The registry ────────────────────────────────────────────────────────────
+
+/**
+ * A surface whose period picker is remembered. `usePeriod` writes four keys per
+ * surface — the period itself, the "the user chose this" flag, and the two
+ * custom bounds — and all four have to travel together or a restored custom
+ * range comes back as an empty one the user never asked for.
+ */
+export function periodPreferenceKeys(base: string): string[] {
+  return [base, `${base}Explicit`, `${base}CustomStart`, `${base}CustomEnd`];
+}
+
+/**
+ * Every key that travels with the account.
+ *
+ * This list does TWO jobs, and only the first is load-bearing at runtime:
+ *
+ *  1. it is what the one-time lift copies out of an existing browser, so the
+ *     owner's real account keeps the settings he already has rather than
+ *     starting from defaults on the day this ships;
+ *  2. it is the written inventory. A key not here is a key somebody decided
+ *     stays on the device, and the decision is recorded in the classification
+ *     table beside this list rather than left to be inferred from a diff.
+ *
+ * Writing a key through this service is what makes it portable — the registry
+ * is not a gate. That is on purpose: a call site added after this list stops
+ * being maintained still travels correctly, it just misses the one-time lift,
+ * which matters for exactly one boot in the lifetime of one browser.
+ */
+export const PORTABLE_PREFERENCE_KEYS: readonly string[] = [
+  // ── Dashboard ────────────────────────────────────────────────────────────
+  // Which accounts the owner put on his own front page, and which reports he
+  // pinned beside them. Statements about HIS data, not about this screen.
+  'dashboardKeyAccounts',
+  'dashboardPinnedReports',
+  ...periodPreferenceKeys('dashboardReports'),
+  ...periodPreferenceKeys('dashboardReportsFlows'),
+  ...periodPreferenceKeys('dashboardPerformance'),
+
+  // ── Reports ──────────────────────────────────────────────────────────────
+  ...periodPreferenceKeys('reportsPeriod'),
+  ...periodPreferenceKeys('exportPeriod'),
+  'reportsAccountFilterIds',
+  'reportsShowRevaluations',
+  'reportsMatrixSubcategories',
+  'reportsShowTopTransactions',
+  'reportsComparisonBasis',
+  'reportsTrendChartType',
+  'reportsPayeeSide',
+  'reports.monthlyIncomeExpenses.cumulative.v1',
+  'reports.incomeSpendingOverTime.cumulative.v1',
+  'netWorthChartType',
+  'netWorthShowDetail',
+
+  // ── Accounts page ────────────────────────────────────────────────────────
+  'accountsGroupBy.v2',
+  'accountsSortMode',
+  'accountsCollapsedGroups',
+
+  // ── Reconciliation ───────────────────────────────────────────────────────
+  'reconciliationGroupBy',
+  'reconciliationSortMode',
+  'reconciliationOnlyAttention',
+
+  // ── Register (per-account transaction list) ──────────────────────────────
+  // Order and visibility travel; WIDTHS do not — see the classification note.
+  'accountRegister.columnOrder.v1',
+  'accountRegister.hiddenColumns.v1',
+  'accountRegister.archive.v1',
+
+  // ── Archive ──────────────────────────────────────────────────────────────
+  'archiveManager.preset.v1',
+  'archiveManager.customDate.v1',
+  'archiveManager.overrides.v1',
+  'archiveManager.collapsedGroups.v1',
+
+  // ── App-wide preferences (PreferencesContext) ────────────────────────────
+  'money_management_compact_view',
+  'money_management_currency',
+  'money_management_theme',
+  'money_management_theme_schedule',
+  'money_management_first_name',
+  'money_management_show_investments',
+  'money_management_goal_celebrations',
+
+  // ── Alerts (NotificationContext) ─────────────────────────────────────────
+  'money_management_budget_alerts_enabled',
+  'money_management_alert_threshold',
+  'money_management_large_transaction_alerts_enabled',
+  'money_management_large_transaction_threshold',
+
+  // ── Export templates ─────────────────────────────────────────────────────
+  'export-templates',
+  'export-templates-initialised',
+
+  // ── Bank auto-sync ───────────────────────────────────────────────────────
+  // The PREFERENCE only. `bankAutoSync:lastRun:<user>` stays on the device:
+  // it records when THIS browser last ran a sync, and a fresh machine that
+  // inherited it would believe it had already synced today and skip.
+  'bankAutoSync.prefs.v1',
+
+  // ── Formatting ───────────────────────────────────────────────────────────
+  'preferredLocale',
+] as const;
+
+/**
+ * Keys the preferences document holds that name ROWS in the user's data.
+ *
+ * They matter to exactly one caller — the restore, which mints a fresh id for
+ * every row it puts back (see backupService.remapBackupIds and the reason it
+ * remaps unconditionally). A preference naming accounts by id and restored
+ * verbatim would come back pointing at the accounts of the login the file came
+ * from: the dashboard's key accounts would silently be six accounts that no
+ * longer exist, and the archive cutoffs the owner set per account would apply
+ * to nothing. Both fail SILENTLY, which is what makes this worth spelling out.
+ */
+export const PREFERENCE_KEYS_HOLDING_IDS = {
+  /** JSON array of account ids. */
+  idArray: [
+    'dashboardKeyAccounts',
+    'reportsAccountFilterIds',
+  ] as readonly string[],
+  /** JSON object whose KEYS are account ids. */
+  idKeyedObject: [
+    'archiveManager.overrides.v1',
+  ] as readonly string[],
+} as const;
+
+// ── Where a preference lives while the app runs ─────────────────────────────
+
+/**
+ * The shape every rewired call site talks to — deliberately `Storage`'s own, so
+ * a call site changes by one word and its error handling stays exactly as it
+ * was. `getItem` is synchronous because the surfaces reading it are `useState`
+ * initialisers: a promise here would mean every remembered toggle flashed its
+ * default first.
+ */
+export interface PreferenceStorage {
+  getItem(key: string): string | null;
+  setItem(key: string, value: string): void;
+  removeItem(key: string): void;
+}
+
+/**
+ * WHAT SYNCHRONOUS READING COSTS, stated rather than hidden.
+ *
+ * On a machine the user has NEVER opened, the browser mirror is empty and the
+ * account's document lands a few hundred milliseconds into boot. A surface that
+ * read its preference in a `useState` initialiser before then shows the default
+ * for the rest of that session — one session, on one machine, once.
+ *
+ * That is the deliberate trade against the alternative, which is worse in the
+ * other 99% of visits: making every remembered toggle asynchronous means every
+ * returning user watches the dashboard paint the DEFAULT and then correct
+ * itself, on every load, for ever. The app-wide values (theme, currency, name)
+ * do not pay even the one-session cost, because PreferencesContext subscribes
+ * and corrects itself the moment the document arrives; anything else that turns
+ * out to matter can do the same through `subscribe`.
+ */
+
+/** The browser storage the cache mirrors into. Injectable for tests. */
+export interface LocalMirror {
+  getItem(key: string): string | null;
+  setItem(key: string, value: string): void;
+  removeItem(key: string): void;
+}
+
+/**
+ * The stored copy, as two verbs.
+ *
+ * A PORT rather than "the slice of the Supabase client we use", and that is not
+ * only taste. A structural interface describing the PostgREST builder chain has
+ * to be checked against `SupabaseClient<Database>`'s generics every time the
+ * real client is assigned to it, and `tsc -b` gives up on that with
+ * "Type instantiation is excessively deep" — the compiler's way of saying the
+ * abstraction is drawn in the wrong place. Two verbs are also what a caller
+ * actually needs: read this user's document, replace it. Nothing above cares
+ * that it is a table.
+ */
+export interface PreferencesTransport {
+  read(userId: string): Promise<PreferencesDocument | null>;
+  write(userId: string, document: PreferencesDocument): Promise<void>;
+}
+
+export const USER_PREFERENCES_TABLE = 'user_preferences';
+
+/** How long a burst of changes is collected before one write goes out. */
+export const PREFERENCES_WRITE_DEBOUNCE_MS = 800;
+
+/**
+ * The transport the app uses: the `user_preferences` table over Supabase, or
+ * `null` when this session has no cloud at all (local mode, demo mode, a build
+ * with no credentials). Null is not an error — it is the honest answer, and the
+ * service treats the browser mirror as the store in that case.
+ *
+ * The client is used INLINE and never assigned to a declared interface, which
+ * is what keeps its generics out of every signature in this file.
+ */
+export function supabasePreferencesTransport(): PreferencesTransport | null {
+  const client = supabase;
+  if (!client) return null;
+  return {
+    async read(userId: string): Promise<PreferencesDocument | null> {
+      const { data, error } = await client
+        .from(USER_PREFERENCES_TABLE)
+        .select('prefs')
+        .eq('user_id', userId)
+        .maybeSingle();
+      if (error) {
+        // Thrown rather than swallowed: a backup that quietly recorded "no
+        // preferences" for a user who has fifty is the failure this whole
+        // change exists to end. Callers decide what to do about it.
+        throw new Error(`Could not read your preferences: ${error.message}`);
+      }
+      return data === null ? null : parsePreferencesDocument(data.prefs);
+    },
+    async write(userId: string, document: PreferencesDocument): Promise<void> {
+      const { error } = await client
+        .from(USER_PREFERENCES_TABLE)
+        .upsert({ user_id: userId, prefs: document }, { onConflict: 'user_id' });
+      if (error) {
+        throw new Error(`Could not save your preferences: ${error.message}`);
+      }
+    },
+  };
+}
+
+export interface PreferencesServiceOptions {
+  mirror?: LocalMirror | null;
+  transport?: PreferencesTransport | null;
+  setTimeoutFn?: typeof setTimeout;
+  clearTimeoutFn?: typeof clearTimeout;
+  debounceMs?: number;
+}
+
+/**
+ * The live preferences of whoever is signed in.
+ *
+ * ── THE THREE STORES, AND WHY ───────────────────────────────────────────────
+ *
+ *   memory   authoritative while the tab is open, and the only one anything
+ *            reads. Synchronous, so a `useState` initialiser gets the real
+ *            answer rather than a default it has to correct a frame later.
+ *   browser  a mirror, written on every change. It is what makes the app work
+ *            signed-out, offline, and during the boot before the row arrives —
+ *            and it is where the one-time lift finds the settings the owner
+ *            already has.
+ *   database the copy that travels. Written debounced, because dragging a
+ *            column width or ticking six accounts is a burst of changes and
+ *            each one does not deserve a round trip.
+ *
+ * ── WHAT HAPPENS ON A CONFLICT ──────────────────────────────────────────────
+ *
+ * The server row wins on load, per key, and the browser mirror is refreshed
+ * from it. That is the only rule that makes "my settings follow me" true: a
+ * machine that has not been opened for a month must not push its month-old
+ * toggles over the ones set since. The exception is a server row that does not
+ * exist yet, which is the lift — see `attach`.
+ */
+export class PreferencesService implements PreferenceStorage {
+  private document: PreferencesDocument = { version: PREFERENCES_DOCUMENT_VERSION, values: {} };
+  private readonly listeners = new Set<() => void>();
+  private readonly injectedMirror: LocalMirror | null | undefined;
+  private readonly transportOverride: PreferencesTransport | null | undefined;
+  private readonly setTimeoutFn: typeof setTimeout;
+  private readonly clearTimeoutFn: typeof clearTimeout;
+  private readonly debounceMs: number;
+
+  private userId: string | null = null;
+  private pendingWrite: ReturnType<typeof setTimeout> | undefined;
+  /** Resolves when nothing is queued — the whole reason tests need not sleep. */
+  private inFlight: Promise<void> = Promise.resolve();
+  private loaded = false;
+
+  constructor(options: PreferencesServiceOptions = {}) {
+    this.injectedMirror = options.mirror;
+    this.transportOverride = options.transport;
+    this.setTimeoutFn = options.setTimeoutFn ?? setTimeout;
+    this.clearTimeoutFn = options.clearTimeoutFn ?? clearTimeout;
+    this.debounceMs = options.debounceMs ?? PREFERENCES_WRITE_DEBOUNCE_MS;
+  }
+
+  /**
+   * The browser's own storage, resolved on EVERY use rather than captured in the
+   * constructor.
+   *
+   * This module is imported at boot, and a reference taken then outlives
+   * anything that replaces `window.localStorage` afterwards — which is not a
+   * hypothetical: the test harness installs its own implementation after the
+   * module graph is loaded, and a service holding the original would quietly be
+   * reading a different store from the one every test writes to. Resolving late
+   * also means no assumption that `window` exists at import time.
+   */
+  private get mirror(): LocalMirror | null {
+    if (this.injectedMirror !== undefined) return this.injectedMirror;
+    return typeof window !== 'undefined' ? window.localStorage : null;
+  }
+
+  private resolveTransport(): PreferencesTransport | null {
+    if (this.transportOverride !== undefined) return this.transportOverride;
+    return supabasePreferencesTransport();
+  }
+
+  /**
+   * Everything the browser already holds for a registered key.
+   *
+   * Read WITHOUT the server, before sign-in resolves, so the very first paint
+   * of a returning user shows their own settings instead of the defaults they
+   * would then watch get corrected.
+   */
+  private readMirror(): Record<string, string> {
+    const values: Record<string, string> = {};
+    if (!this.mirror) return values;
+    for (const key of PORTABLE_PREFERENCE_KEYS) {
+      try {
+        const stored = this.mirror.getItem(key);
+        if (stored !== null) values[key] = stored;
+      } catch {
+        // Safari private browsing throws on read. A preference nobody can read
+        // is a default, which is survivable; a page that will not render is not.
+        return values;
+      }
+    }
+    return values;
+  }
+
+  // ── The Storage-shaped face every call site uses ──────────────────────────
+
+  /**
+   * The document first, then the browser.
+   *
+   * The fall-through is what makes this a drop-in replacement for
+   * `localStorage.getItem` on the very first boot after it ships: every setting
+   * the user already has is sitting in browser storage under exactly these
+   * keys, and reading it there means nothing is forgotten in the window between
+   * the app starting and the account's document arriving.
+   *
+   * It STOPS once a stored document has been loaded, and that is deliberate.
+   * After the server has spoken, a key absent from its document is absent — the
+   * user removed that preference, possibly on another machine — and falling
+   * back to this browser's leftover copy would resurrect it every boot.
+   */
+  getItem(key: string): string | null {
+    const value = this.document.values[key];
+    if (value !== undefined) return value;
+    if (this.loaded) return null;
+    try {
+      return this.mirror?.getItem(key) ?? null;
+    } catch {
+      return null;
+    }
+  }
+
+  setItem(key: string, value: string): void {
+    if (this.document.values[key] === value) return;
+    this.document = { ...this.document, values: { ...this.document.values, [key]: value } };
+    this.writeMirror(key, value);
+    this.scheduleWrite();
+    this.notify();
+  }
+
+  removeItem(key: string): void {
+    if (!(key in this.document.values)) return;
+    const values = { ...this.document.values };
+    delete values[key];
+    this.document = { ...this.document, values };
+    try {
+      this.mirror?.removeItem(key);
+    } catch {
+      // Unwritable storage costs the mirror, never the in-memory truth.
+    }
+    this.scheduleWrite();
+    this.notify();
+  }
+
+  private writeMirror(key: string, value: string): void {
+    try {
+      this.mirror?.setItem(key, value);
+    } catch {
+      // Quota or private browsing. The setting still holds for this visit and
+      // still reaches the server; only the offline copy is lost.
+    }
+  }
+
+  // ── Subscription (useSyncExternalStore) ───────────────────────────────────
+
+  subscribe = (listener: () => void): (() => void) => {
+    this.listeners.add(listener);
+    return () => { this.listeners.delete(listener); };
+  };
+
+  /** The identity React compares. A new object per change, stable between them. */
+  getDocument = (): PreferencesDocument => this.document;
+
+  private notify(): void {
+    for (const listener of this.listeners) listener();
+  }
+
+  // ── Boot ──────────────────────────────────────────────────────────────────
+
+  /**
+   * Bind the service to a signed-in user and load their row.
+   *
+   * THE LIFT: a user whose row does not exist yet has their current browser
+   * settings written up as the row's first content. Without it, shipping this
+   * would read as the app forgetting everything on the day it learned to
+   * remember — the owner has years of choices in `window.localStorage` and no
+   * intention of making them again.
+   *
+   * The lift is once per login, not once per device, and that is the right
+   * grain: the row exists after the first machine writes it, so a second
+   * machine loads the first's settings rather than overwriting them with its
+   * own. Whichever machine gets there first wins, which is the only outcome
+   * available without a merge policy nobody asked for.
+   */
+  async attach(userId: string): Promise<void> {
+    if (this.userId === userId && this.loaded) return;
+    this.userId = userId;
+
+    const transport = this.resolveTransport();
+    if (!transport) {
+      // Local or demo mode. The mirror IS the store; nothing more to do.
+      this.loaded = true;
+      return;
+    }
+
+    let stored: PreferencesDocument | null;
+    try {
+      stored = await transport.read(userId);
+    } catch (error) {
+      // A database that has not had 20260809160000 applied yet lands here, and
+      // so does an offline boot. Both are survivable: the browser mirror holds
+      // exactly what this machine held before, which is where every one of
+      // these settings lived until today.
+      preferencesLogger.warn('Could not read stored preferences; using this browser\'s copy', error);
+      return;
+    }
+
+    if (stored === null) {
+      // No row yet. THE LIFT: everything this browser holds becomes the row's
+      // first content, merged UNDER anything already set this session — a
+      // toggle flipped while the read was in flight is newer than the stored
+      // copy it came from. An empty browser lifts an empty document, which is
+      // correct and costs one insert.
+      this.document = {
+        version: PREFERENCES_DOCUMENT_VERSION,
+        values: { ...this.readMirror(), ...this.document.values },
+      };
+      this.loaded = true;
+      this.scheduleWrite();
+      this.notify();
+      return;
+    }
+
+    // Server wins per key, and the browser mirror is refreshed to match: this
+    // machine's month-old toggles must not outrank the ones set since. Values
+    // set during THIS session stay on top — they postdate the read.
+    this.document = { ...stored, values: { ...stored.values, ...this.document.values } };
+    for (const [key, value] of Object.entries(this.document.values)) this.writeMirror(key, value);
+    this.loaded = true;
+    this.notify();
+  }
+
+  /**
+   * Forget the signed-in user, and everything held for them.
+   *
+   * The in-memory document is CLEARED, not kept, and that matters on a shared
+   * browser: `attach` merges whatever is in memory on top of the document it
+   * reads, so a session that signed out of one account and into another would
+   * otherwise write the first user's pinned accounts and archive cutoffs into
+   * the second user's row. The browser mirror is left alone — it is the
+   * browser's own copy, it is what a signed-out or local session reads, and it
+   * has always survived sign-out.
+   */
+  detach(): void {
+    this.cancelPendingWrite();
+    this.userId = null;
+    this.loaded = false;
+    this.document = { version: PREFERENCES_DOCUMENT_VERSION, values: {} };
+    this.notify();
+  }
+
+  // ── Writing back ──────────────────────────────────────────────────────────
+
+  private cancelPendingWrite(): void {
+    if (this.pendingWrite !== undefined) {
+      this.clearTimeoutFn(this.pendingWrite);
+      this.pendingWrite = undefined;
+    }
+  }
+
+  private scheduleWrite(): void {
+    if (this.userId === null) return;
+    this.cancelPendingWrite();
+    this.pendingWrite = this.setTimeoutFn(() => {
+      this.pendingWrite = undefined;
+      this.inFlight = this.write();
+    }, this.debounceMs);
+  }
+
+  private async write(): Promise<void> {
+    const userId = this.userId;
+    const transport = this.resolveTransport();
+    if (userId === null || !transport) return;
+
+    // Snapshot before awaiting: a change made while the request is in flight
+    // must schedule its own write rather than silently ride on this one.
+    const document = this.document;
+    try {
+      await transport.write(userId, document);
+    } catch (error) {
+      // Offline, or the row was refused. The browser mirror already holds it,
+      // so the setting survives this session and the next write retries.
+      preferencesLogger.warn('Preferences could not be saved to your account', error);
+    }
+  }
+
+  /**
+   * Send anything queued NOW and wait for it.
+   *
+   * Exists for two callers with the same problem: a test that must not sleep,
+   * and an export that would otherwise read a row the user's last click has not
+   * reached yet.
+   */
+  async flush(): Promise<void> {
+    if (this.pendingWrite !== undefined) {
+      this.cancelPendingWrite();
+      this.inFlight = this.write();
+    }
+    await this.inFlight;
+  }
+
+  /** Replace the whole document — the restore path, and nothing else. */
+  async replaceAll(document: PreferencesDocument): Promise<void> {
+    this.document = parsePreferencesDocument(document);
+    for (const [key, value] of Object.entries(this.document.values)) this.writeMirror(key, value);
+    this.notify();
+    if (this.userId !== null) {
+      this.cancelPendingWrite();
+      this.inFlight = this.write();
+      await this.inFlight;
+    }
+  }
+}
+
+/**
+ * The one instance the app talks to.
+ *
+ * A singleton rather than context state because the readers are `useState`
+ * initialisers scattered across pages that mount at different times, and
+ * because `PreferencesProvider` sits ABOVE `AppProvider` in the tree — the
+ * database identity it needs does not exist when it mounts. The service is
+ * bound to a user when that identity resolves (see AppContextSupabase), and
+ * everything below re-renders through `subscribe`.
+ */
+export const preferences = new PreferencesService();

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -2,6 +2,7 @@ import '@testing-library/jest-dom';
 import { cleanup } from '@testing-library/react';
 import React from 'react';
 import { afterEach, beforeEach, vi } from 'vitest';
+import { preferences } from '../services/preferencesService';
 
 vi.mock('@clerk/clerk-react', () => ({
   useUser: () => ({ user: null, isLoaded: true }),
@@ -59,6 +60,19 @@ afterEach(() => {
 // Reset mocks before each test
 beforeEach(() => {
   vi.clearAllMocks();
+  // Empty the preferences document too.
+  //
+  // A tier of settings that used to live in `localStorage` — pinned accounts,
+  // per-surface periods, grouping and sort choices, hidden register columns,
+  // archive cutoffs — now lives in a module-level service so that it can travel
+  // with the account (services/preferencesService). That service outlives an
+  // individual test the way a page reload does not, so without this a value set
+  // in one case would still be there in the next, and a suite's own
+  // `localStorage.clear()` would no longer mean "start from nothing".
+  //
+  // `detach` is the app's own sign-out path, not a test-only hatch: it forgets
+  // the signed-in user and everything held for them.
+  preferences.detach();
 });
 
 // Mock window.matchMedia

--- a/src/utils/__tests__/bankAutoSync.test.ts
+++ b/src/utils/__tests__/bankAutoSync.test.ts
@@ -8,6 +8,7 @@ import {
   DEFAULT_AUTO_SYNC_PREFS,
   type AutoSyncPrefs,
 } from '../bankAutoSync';
+import { preferences } from '../../services/preferencesService';
 
 const at = (iso: string): Date => new Date(iso);
 
@@ -56,25 +57,53 @@ describe('shouldAutoSync', () => {
   });
 });
 
-describe('per-user storage', () => {
-  beforeEach(() => localStorage.clear());
+/**
+ * The two values are stored differently ON PURPOSE. The SCHEDULE is a
+ * preference and travels with the account, so it lives in the preferences
+ * document — already per-user, which is why the user-id keying it used to need
+ * has gone. The LAST RUN says when THIS browser last called the bank and stays
+ * keyed by user in localStorage, because carrying it to a second machine would
+ * make that machine believe it had already synced.
+ */
+describe('storage', () => {
+  beforeEach(() => {
+    preferences.detach();
+    localStorage.clear();
+  });
 
-  it('prefs are keyed by user — one user\'s schedule never leaks onto another', () => {
+  it('the schedule is remembered, and belongs to whoever is signed in', () => {
     saveAutoSyncPrefs('user_a', { mode: 'daily', dailyTime: '07:30' });
 
     expect(loadAutoSyncPrefs('user_a')).toEqual({ mode: 'daily', dailyTime: '07:30' });
-    expect(loadAutoSyncPrefs('user_b')).toEqual(DEFAULT_AUTO_SYNC_PREFS);
+    // The preferences document IS the signed-in user's, so the same document
+    // answers for any id passed here; the isolation lives one layer up, in the
+    // row RLS scopes to the login.
+    expect(preferences.getItem('bankAutoSync.prefs.v1')).toBe('{"mode":"daily","dailyTime":"07:30"}');
   });
 
-  it('last-run stamps are keyed by user too', () => {
+  it('a schedule set before it travelled is still honoured, and then moved', () => {
+    // The one-time carry-over: nobody who had already chosen a schedule should
+    // find it silently back to Off on the first boot after this shipped.
+    localStorage.setItem('bankAutoSync:prefs:user_a', '{"mode":"daily","dailyTime":"06:15"}');
+
+    expect(loadAutoSyncPrefs('user_a')).toEqual({ mode: 'daily', dailyTime: '06:15' });
+
+    saveAutoSyncPrefs('user_a', { mode: 'daily', dailyTime: '06:15' });
+    // …and the pre-move copy is cleared, so an older tab on the same machine
+    // cannot write it back over the one that now travels.
+    expect(localStorage.getItem('bankAutoSync:prefs:user_a')).toBeNull();
+  });
+
+  it('last-run stamps are keyed by user, and stay on the device', () => {
     recordAutoSyncRun('user_a', at('2026-07-30T08:00:00Z'));
 
     expect(loadLastAutoSyncRun('user_a')?.toISOString()).toBe('2026-07-30T08:00:00.000Z');
     expect(loadLastAutoSyncRun('user_b')).toBeNull();
+    expect(localStorage.getItem('bankAutoSync:lastRun:user_a')).toBe('2026-07-30T08:00:00.000Z');
   });
 
   it('garbage in storage degrades to the defaults', () => {
-    localStorage.setItem('bankAutoSync:prefs:user_a', '{not json');
+    preferences.setItem('bankAutoSync.prefs.v1', '{not json');
     localStorage.setItem('bankAutoSync:lastRun:user_a', 'yesterday-ish');
 
     expect(loadAutoSyncPrefs('user_a')).toEqual(DEFAULT_AUTO_SYNC_PREFS);

--- a/src/utils/bankAutoSync.ts
+++ b/src/utils/bankAutoSync.ts
@@ -3,11 +3,22 @@
  * one decision that matters — "is a refresh due right now?".
  *
  * The decision is a pure function so the scheduling rules live under test,
- * not inside a hook. Storage is localStorage keyed BY USER ID: this device
- * setting controls actions on the signed-in user's data, and an unkeyed entry
- * would leak one user's schedule onto another's session on a shared machine —
- * the exact mistake the notification feed made.
+ * not inside a hook.
+ *
+ * ── WHERE THE TWO VALUES LIVE, AND WHY THEY DIFFER ──────────────────────────
+ *
+ * The PREFERENCE ("refresh daily at 08:00") belongs to the user and travels
+ * with the account, so it goes in the preferences document — which is already
+ * per-user, so the user-id keying the old localStorage entry needed disappears
+ * along with the shared-machine leak it existed to prevent.
+ *
+ * The LAST RUN belongs to the DEVICE and stays keyed by user in localStorage.
+ * It records when THIS browser last called the bank; carried to a second
+ * machine it would say "already synced today" on a machine that has never
+ * synced at all, and the refresh the user asked for would silently not happen.
  */
+
+import { preferences } from '../services/preferencesService';
 
 export type AutoSyncMode = 'off' | 'signin' | 'daily';
 
@@ -26,7 +37,13 @@ export const DEFAULT_AUTO_SYNC_PREFS: AutoSyncPrefs = { mode: 'off', dailyTime: 
  */
 export const SIGNIN_MODE_MIN_GAP_MS = 60 * 60 * 1000;
 
-const prefsKey = (userId: string): string => `bankAutoSync:prefs:${userId}`;
+/**
+ * One key, not one per user: the preferences document is already the signed-in
+ * user's own. The old `bankAutoSync:prefs:<userId>` entries are read once, on
+ * the first boot after this ships, so nobody's schedule is forgotten.
+ */
+const PREFS_KEY = 'bankAutoSync.prefs.v1';
+const legacyPrefsKey = (userId: string): string => `bankAutoSync:prefs:${userId}`;
 const lastRunKey = (userId: string): string => `bankAutoSync:lastRun:${userId}`;
 
 const isValidTime = (t: unknown): t is string =>
@@ -34,7 +51,7 @@ const isValidTime = (t: unknown): t is string =>
 
 export function loadAutoSyncPrefs(userId: string): AutoSyncPrefs {
   try {
-    const raw = localStorage.getItem(prefsKey(userId));
+    const raw = preferences.getItem(PREFS_KEY) ?? localStorage.getItem(legacyPrefsKey(userId));
     if (!raw) return DEFAULT_AUTO_SYNC_PREFS;
     const parsed: unknown = JSON.parse(raw);
     const mode = (parsed as AutoSyncPrefs).mode;
@@ -49,7 +66,10 @@ export function loadAutoSyncPrefs(userId: string): AutoSyncPrefs {
 }
 
 export function saveAutoSyncPrefs(userId: string, prefs: AutoSyncPrefs): void {
-  localStorage.setItem(prefsKey(userId), JSON.stringify(prefs));
+  preferences.setItem(PREFS_KEY, JSON.stringify(prefs));
+  // The pre-move copy would otherwise be read back by an older tab still open
+  // on the same machine, which would then write it back over this one.
+  try { localStorage.removeItem(legacyPrefsKey(userId)); } catch { /* storage may be unavailable */ }
 }
 
 export function loadLastAutoSyncRun(userId: string): Date | null {

--- a/src/utils/dateFormatter.ts
+++ b/src/utils/dateFormatter.ts
@@ -2,6 +2,7 @@
  * Date formatting utilities with locale detection
  * Automatically detects user's locale and formats dates accordingly
  */
+import { preferences } from '../services/preferencesService';
 
 // Detect user's locale from browser settings
 export function getUserLocale(): string {
@@ -10,19 +11,21 @@ export function getUserLocale(): string {
     (navigator.languages && navigator.languages[0]) || 
     'en-US';
   
-  // Store the preference in localStorage for consistency
-  const storedLocale = localStorage.getItem('preferredLocale');
+  // A chosen locale travels with the account: it decides how every date and
+  // amount in the app reads, and someone who set it once should not have to
+  // set it again on the next machine.
+  const storedLocale = preferences.getItem('preferredLocale');
   if (storedLocale) {
     return storedLocale;
   }
-  
-  localStorage.setItem('preferredLocale', browserLocale);
+
+  preferences.setItem('preferredLocale', browserLocale);
   return browserLocale;
 }
 
 // Set user's preferred locale
 export function setUserLocale(locale: string): void {
-  localStorage.setItem('preferredLocale', locale);
+  preferences.setItem('preferredLocale', locale);
 }
 
 // Determine if the user prefers UK date format (dd/mm/yyyy)

--- a/supabase/migrations/20260809160000_preferences_that_travel.sql
+++ b/supabase/migrations/20260809160000_preferences_that_travel.sql
@@ -1,0 +1,301 @@
+-- ============================================================================
+-- PREFERENCES THAT TRAVEL — the settings a restore used to lose
+-- ============================================================================
+-- IMPORTANT: apply with `npm run db:migrate` (see supabase/migrations/README.md
+-- rule 1 — never the SQL editor).
+--
+-- ORDERING: either order is safe, and that is by design rather than by luck.
+-- Everything here is NEW — one table, one trigger, four policies — and nothing
+-- existing is redefined, so a database with this applied and the OLD client
+-- running behaves exactly as it does now. A NEW client meeting a database
+-- without it logs one warning per session and falls back to this browser's own
+-- copy, which is precisely where every one of these settings lives today. The
+-- only thing that does not work until both sides are in place is the thing that
+-- does not work at all right now.
+--
+-- ── WHY ─────────────────────────────────────────────────────────────────────
+--
+-- The owner restored a full backup into a test login to prove the restore
+-- worked. The rows all arrived. The app came up factory-reset.
+--
+-- Right accounts, right transactions, right balances — and every choice he had
+-- ever made about how to LOOK at them gone: which accounts the dashboard pins,
+-- which reports sit beside them, the period each surface opens on, how the
+-- Accounts page is banded and sorted, which register columns he had hidden, the
+-- archive cutoffs he had set account by account. None of it was in the backup,
+-- because none of it was in the database. It lived in `window.localStorage` on
+-- one machine, so it did not back up, did not restore, and did not follow him
+-- to a second computer. Nothing anywhere said so.
+--
+-- A backup is defined by its restore, and a restore that returns the ledger
+-- while silently discarding the way the owner reads it has not put him back
+-- where he was.
+--
+-- ── WHY ONE ROW PER USER, NOT ONE ROW PER SETTING ───────────────────────────
+--
+-- Preferences are read as a SET, exactly once, at boot — before the first paint
+-- that depends on any of them. A row per key would turn that one round trip
+-- into fifty, on the critical path, to store perhaps two kilobytes. They are
+-- also written rarely (a toggle, a drag, a tick) and have to travel WHOLE into
+-- a backup file: a per-key table lets a restore land half a user's settings and
+-- leave the other half at defaults, which is a worse failure than losing all of
+-- them, because it looks deliberate.
+--
+-- So: one row, one jsonb document, `{ "version": 1, "values": { … } }`, whose
+-- values are the exact strings each call site already stored. Schema-in-code
+-- (src/services/preferencesService.ts) rather than schema-in-columns, for the
+-- property that matters while two client versions are live at once: a key this
+-- database's readers have never heard of is carried through untouched instead
+-- of being dropped by whichever client saw it last.
+--
+-- ── WHY THE SIZE IS A CONSTRAINT AND NOT A CONVENTION ───────────────────────
+--
+-- Everything meant to be here is a toggle, an enum, a short list of account ids
+-- or a handful of column names. A jsonb column with no ceiling is an invitation
+-- to park a cache in it, and the day something does, this table becomes a
+-- second unindexed copy of the ledger that every boot downloads in full. The
+-- CHECK below makes "preferences are small" a rule the database enforces rather
+-- than a sentence in a comment nobody reads. 256 KiB is roughly a hundred times
+-- the realistic maximum, so it can only ever fire on a mistake.
+--
+-- ── WHAT DOES NOT CHANGE ────────────────────────────────────────────────────
+--
+--  * No existing table gains, loses or alters a column.
+--  * No existing function is redefined — in particular NOT restore_user_chunk.
+--    Preferences are restored by an ordinary RLS-scoped upsert from the client,
+--    because their restore semantics genuinely differ from every financial
+--    table's: one row rather than many, replace rather than insert, and it must
+--    run AFTER the financial rows and must never be able to block them. Adding
+--    a fifteenth branch to a function whose every other branch is "insert whole
+--    rows into an empty login" would have made all three of those differences
+--    invisible.
+--  * wipe_user_financial_data does NOT touch this table, and neither does the
+--    client's own wipe (src/services/import/msMoney/msMoneyImport.wipeCloudData).
+--    Deleting your transactions is not a request to forget that you prefer
+--    twelve-month charts — and the .mny total migration runs that same wipe, so
+--    including preferences would mean re-importing a file factory-reset the UI.
+--  * No policy on any other table is touched. The four created here are the
+--    same shape every per-user table has used since 20260610130000:
+--    requesting_user_id() (SECURITY DEFINER, maps the JWT's clerk_id to
+--    users.id), scoped TO authenticated, so anon matches no policy and is
+--    denied everything.
+--
+-- ── SAFE TO RUN TWICE? ──────────────────────────────────────────────────────
+-- No, and it says so out loud: guard 2 refuses a second run BY NAME rather than
+-- letting CREATE TABLE IF NOT EXISTS quietly leave an older definition in place
+-- while the policies below are recreated around it. If you need to change
+-- something here, write a new migration for it.
+-- ============================================================================
+
+BEGIN;
+
+-- ── Guard 1: this is the database this migration was written against ────────
+-- The policies below are written in terms of public.requesting_user_id(), and
+-- the FK in terms of public.users(id). Both arrived in 20260610130000. Against
+-- a database that predates it, CREATE POLICY would fail with "function does not
+-- exist" halfway through the file — true, but it names the symptom rather than
+-- the cause. Fail first, naming the migration that has not been applied.
+DO $$
+BEGIN
+  IF to_regprocedure('public.requesting_user_id()') IS NULL THEN
+    RAISE EXCEPTION 'wrong_base_missing_requesting_user_id: public.requesting_user_id() does not exist, so this database predates 20260610130000_restore_rls_data_isolation and cannot express owner-only policies.'
+      USING ERRCODE = 'P0001',
+            HINT = 'Apply the migrations in order with `npm run db:migrate`. Do not apply this file to an older base.';
+  END IF;
+
+  IF to_regclass('public.users') IS NULL THEN
+    RAISE EXCEPTION 'wrong_base_missing_users_table: public.users does not exist, so user_preferences has nothing to hang off.'
+      USING ERRCODE = 'P0001',
+            HINT = 'Apply 20251030003814__initial-schema.sql first.';
+  END IF;
+END;
+$$;
+
+-- ── Guard 2: refuse a double-run, by name ───────────────────────────────────
+-- A second run must not silently succeed: the table would already exist with
+-- whatever definition it has now (possibly amended by a later migration), and
+-- everything below it would be recreated around that older shape as if it were
+-- this file's own.
+DO $$
+BEGIN
+  IF to_regclass('public.user_preferences') IS NOT NULL THEN
+    RAISE EXCEPTION 'user_preferences_already_exists: public.user_preferences is already present — this migration has already been applied and must not run twice.'
+      USING ERRCODE = 'P0001',
+            HINT = 'The verification queries at the foot of this file show the current state. If something needs changing, write a new migration for it.';
+  END IF;
+END;
+$$;
+
+-- ── Guard 3: the trigger function this table reuses is the one expected ─────
+-- update_updated_at_column() is shared by every table with an updated_at, and
+-- it is attached below by name. If it is absent, the trigger creation fails
+-- with a message about a function; if it were ever replaced by something that
+-- does NOT set updated_at, this table would silently stop stamping and nobody
+-- would notice until two devices disagreed about whose preferences were newer.
+-- Check that it exists AND that it still mentions the column it is named for.
+DO $$
+DECLARE
+  v_body text;
+BEGIN
+  IF to_regprocedure('public.update_updated_at_column()') IS NULL THEN
+    RAISE EXCEPTION 'wrong_base_missing_update_updated_at_column: public.update_updated_at_column() does not exist, so user_preferences.updated_at would never be stamped.'
+      USING ERRCODE = 'P0001',
+            HINT = 'It is created by 20251030003814__initial-schema.sql and reasserted by 20260807083000_user_data_restore.sql.';
+  END IF;
+
+  SELECT pg_get_functiondef(to_regprocedure('public.update_updated_at_column()')) INTO v_body;
+  IF v_body !~* 'updated_at' THEN
+    RAISE EXCEPTION 'update_updated_at_column_not_recognised: the shared trigger function no longer mentions updated_at, so attaching it here would produce rows whose timestamp never moves.'
+      USING ERRCODE = 'P0001',
+            HINT = 'Read its current definition before continuing: SELECT pg_get_functiondef(to_regprocedure(''public.update_updated_at_column()''));';
+  END IF;
+END;
+$$;
+
+-- ── The table ───────────────────────────────────────────────────────────────
+
+CREATE TABLE public.user_preferences (
+  id         uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id    uuid NOT NULL REFERENCES public.users(id) ON DELETE CASCADE,
+  -- The whole document. NOT NULL with a default so a row can be created before
+  -- there is anything to put in it, and so no reader ever has to tell "no
+  -- preferences" apart from "preferences unknown".
+  prefs      jsonb NOT NULL DEFAULT '{}'::jsonb,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now(),
+
+  -- One row per user, and the conflict target every write upserts on. Without
+  -- it two tabs racing at boot would each insert a row and the app would then
+  -- read whichever one PostgREST happened to return.
+  CONSTRAINT user_preferences_one_row_per_user UNIQUE (user_id),
+
+  -- A document, not a list. jsonb_typeof rather than a shape check: the shape
+  -- is versioned in the client (see preferencesService.PreferencesDocument) and
+  -- must be free to gain keys without a migration. What must NOT vary is that
+  -- it is an object, because every reader indexes into it.
+  CONSTRAINT user_preferences_prefs_is_object
+    CHECK (jsonb_typeof(prefs) = 'object'),
+
+  -- See "WHY THE SIZE IS A CONSTRAINT" above. The cast jsonb -> text is
+  -- IMMUTABLE, which is what makes this legal in a CHECK.
+  CONSTRAINT user_preferences_prefs_is_small
+    CHECK (length(prefs::text) <= 262144)
+);
+
+-- No further index: the unique constraint's own index has user_id as its
+-- leading (and only) column, which is the one lookup this table ever does.
+
+COMMENT ON TABLE public.user_preferences IS
+  'One row per user holding every setting that belongs to the ACCOUNT rather than to the browser: pinned accounts and reports, per-surface periods, grouping and sort choices, hidden register columns, archive cutoffs, theme and currency. Holds no financial data and changes no figure. Deliberately excluded from wipe_user_financial_data and from the client wipe: erasing your transactions is not a request to forget how you like to read them.';
+
+COMMENT ON COLUMN public.user_preferences.prefs IS
+  'Versioned document: {"version": 1, "values": {"<preference key>": "<the exact string the client stored>"}}. Values are strings because every call site already serialises to one, which means a key this database''s readers have never heard of survives a round trip through an older client untouched instead of being dropped. Schema lives in src/services/preferencesService.ts.';
+
+-- updated_at is the only way two devices can be compared, so it is stamped by
+-- the shared trigger rather than by whichever client remembered to send it.
+CREATE TRIGGER update_user_preferences_updated_at
+  BEFORE UPDATE ON public.user_preferences
+  FOR EACH ROW EXECUTE FUNCTION public.update_updated_at_column();
+
+-- ── RLS: the owner, and nobody else ─────────────────────────────────────────
+-- All four commands, unlike suggestion_dismissals: a preferences row is created
+-- once and then UPDATEd for the rest of its life, and DELETE exists so that
+-- "start my settings again" is expressible without a service key.
+ALTER TABLE public.user_preferences ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS user_preferences_select_own ON public.user_preferences;
+CREATE POLICY user_preferences_select_own ON public.user_preferences
+  FOR SELECT TO authenticated
+  USING (user_id = public.requesting_user_id());
+
+DROP POLICY IF EXISTS user_preferences_insert_own ON public.user_preferences;
+CREATE POLICY user_preferences_insert_own ON public.user_preferences
+  FOR INSERT TO authenticated
+  WITH CHECK (user_id = public.requesting_user_id());
+
+DROP POLICY IF EXISTS user_preferences_update_own ON public.user_preferences;
+CREATE POLICY user_preferences_update_own ON public.user_preferences
+  FOR UPDATE TO authenticated
+  USING (user_id = public.requesting_user_id())
+  WITH CHECK (user_id = public.requesting_user_id());
+
+DROP POLICY IF EXISTS user_preferences_delete_own ON public.user_preferences;
+CREATE POLICY user_preferences_delete_own ON public.user_preferences
+  FOR DELETE TO authenticated
+  USING (user_id = public.requesting_user_id());
+
+-- ── Grants ──────────────────────────────────────────────────────────────────
+-- FROM PUBLIC, anon — naming anon explicitly, because REVOKE ... FROM PUBLIC
+-- alone does NOT remove Supabase's named default grant to anon (the trap
+-- documented at length in 20260725120000). RLS already denies anon every row;
+-- this removes the privilege as well, so both layers say no.
+REVOKE ALL ON TABLE public.user_preferences FROM PUBLIC, anon;
+GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE public.user_preferences TO authenticated;
+GRANT ALL ON TABLE public.user_preferences TO service_role;
+
+COMMIT;
+
+-- ============================================================================
+-- VERIFICATION — read this output after applying
+-- ============================================================================
+-- 1. The table exists with RLS on and every one of the four commands covered.
+--    Expected: one row, rls_enabled = true, commands = 'DELETE, INSERT, SELECT,
+--    UPDATE'.
+SELECT
+  c.relname,
+  c.relrowsecurity AS rls_enabled,
+  (SELECT string_agg(p.cmd, ', ' ORDER BY p.cmd) FROM pg_policies p
+    WHERE p.schemaname = 'public' AND p.tablename = 'user_preferences') AS commands
+FROM pg_class c
+JOIN pg_namespace n ON n.oid = c.relnamespace
+WHERE n.nspname = 'public' AND c.relname = 'user_preferences';
+
+-- 2. Every policy scopes to the owner and to `authenticated` alone. Expected:
+--    four rows, roles = {authenticated}, and requesting_user_id() named in
+--    every qualifier. A policy reading USING (true) here is the June 2026
+--    isolation failure returning; there must be none.
+SELECT policyname, cmd, roles::text, qual, with_check
+  FROM pg_policies
+ WHERE schemaname = 'public' AND tablename = 'user_preferences'
+ ORDER BY cmd, policyname;
+
+-- 3. Privileges. Expected: exactly `authenticated` and `service_role`; neither
+--    PUBLIC nor anon.
+SELECT
+  'public.user_preferences' AS relation,
+  string_agg(DISTINCT grantee::text, ', ' ORDER BY grantee::text) AS granted_to
+FROM information_schema.role_table_grants
+WHERE table_schema = 'public'
+  AND table_name = 'user_preferences';
+
+-- 4. The constraints that keep this table what it says it is. Expected: three
+--    rows — the one-row-per-user unique key, the object check and the size
+--    check.
+SELECT conname, pg_get_constraintdef(oid) AS definition
+  FROM pg_constraint
+ WHERE conrelid = 'public.user_preferences'::regclass
+   AND conname LIKE 'user_preferences_%'
+ ORDER BY conname;
+
+-- 5. Nothing has been written yet. Expected: zero rows immediately after
+--    applying. Afterwards this is one row per user who has opened the app since,
+--    and `settings` is how many preferences that user has expressed — the number
+--    a restore would have put back and, until today, did not.
+SELECT
+  u.email,
+  jsonb_array_length(COALESCE(jsonb_path_query_array(p.prefs, '$.values.keyvalue()'), '[]'::jsonb)) AS settings,
+  length(p.prefs::text) AS document_bytes,
+  p.updated_at
+FROM public.user_preferences p
+JOIN public.users u ON u.id = p.user_id
+ORDER BY p.updated_at DESC;
+
+-- 6. The wipe still leaves preferences alone. Expected: zero rows — the text of
+--    wipe_user_financial_data must not mention this table. If this ever returns
+--    a row, "Delete all data" has quietly become "and forget how I read it".
+SELECT p.proname
+  FROM pg_proc p
+  JOIN pg_namespace n ON n.oid = p.pronamespace
+ WHERE n.nspname = 'public'
+   AND p.proname = 'wipe_user_financial_data'
+   AND pg_get_functiondef(p.oid) ILIKE '%user_preferences%';


### PR DESCRIPTION
Two owner-reported findings from live backup/restore testing, fixed at the root.

## Preferences portability
Restoring a backup produced a factory-reset app: ~30 personalisation keys lived only in browser localStorage. Every localStorage key is now inventoried and classified — portable **user preferences** (pinned reports, report periods, key accounts, group/sort modes, alert thresholds, export templates, register columns, the archive preset) move into a `user_preferences` row (one jsonb document per user, RLS owner-only, debounced write-through service, browser store as offline cache); **device state** (pixel widths, tip dismissals, consent, sync bookkeeping) deliberately stays local with a one-line justification each.

- First boot lifts existing browser values into the row — nobody loses settings they've already made.
- Backups carry the document (restored last, with its own count row); account ids inside are remapped like every other id.
- Sign-out detaches the in-memory document — a shared browser cannot write one user's preferences into the next user's row.
- The archive preset (previously never stored anywhere — it forgot itself on refresh) is fixed by becoming a preference.

## Chunked wipe with progress
"Delete All Data" died live on a 51k-row single DELETE ("canceling statement due to statement timeout"), leaving a half-wiped account. The wipe now walks each table in 2,000-row chunks with per-table progress in the dialog (the restore dialog's pattern), keeps the existing deletion order and transfer-unlink step (also chunked), and a mid-run failure honestly says "run it again to finish" — true, because chunked deletes are re-runnable. The .mny total migration's wipe step inherits everything. A stale-closure bug that would have silently suppressed the half-wipe warning was caught and fixed in review.

## Migration (UNAPPLIED)
`20260809160000_preferences_that_travel.sql` — house pattern, five named fingerprint guards, six verification SELECTs, SQLite mirror updated in lockstep. Owner applies via `npm run db:migrate` after merge.

## Verification
lint / strict tsc / targeted 288 tests / full smoke 4,808 / local-SQLite 66 specs — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)