### PR TITLE
feat(seam): slice R — one subscription handle, and sockets that close

### DIFF
--- a/src/contexts/AppContextSupabase.tsx
+++ b/src/contexts/AppContextSupabase.tsx
@@ -589,10 +589,33 @@ export function AppProvider({ children }: { children: React.ReactNode }) {
             }, 200); // 200ms debounce
           };
           
-          // Use the simple account service for real-time updates
-          const unsubscribeAccountsPromise = SimpleAccountService.subscribeToAccountChanges(
-            user.id,
-            async (payload) => {
+          // ONE subscribe call and ONE handle: both channels — accounts and
+          // transactions — now come through the same door.
+          //
+          // The account channel used to be opened through a second service, and
+          // that service's version of the same subscription differed in ways
+          // that are declared here rather than discovered later:
+          //
+          //  · the channel is named `accounts:<id>`, not `accounts-<id>`;
+          //  · nothing logs the subscribe status any more. The retired call
+          //    passed a status callback that logged every transition and every
+          //    subscribe error; this one passes none, so a channel that fails to
+          //    join now does so silently. That is the one thing this change
+          //    costs, and it is a declared cost rather than an oversight;
+          //  · the await disappears. The retired call was async because it
+          //    resolved the login's database id itself before opening anything;
+          //    the seam uses the id the boot already resolved, so the channel
+          //    opens synchronously and there is no window between asking for it
+          //    and holding its handle;
+          //  · its "no database user for this Clerk id" warning goes with it —
+          //    behind this gate an id is resolved by definition;
+          //  · one registerTeardown instead of two, because there is one handle.
+          //
+          // What does NOT change: both callbacks below, the debounce above, and
+          // the recent-local-write suppression are the code that was already
+          // here, in the order it was already in.
+          const unsubscribeData = dataPort.subscribeToUpdates({
+            onAccountUpdate: async (payload) => {
               const realtimePayload = payload as { eventType: string; new?: { is_active?: boolean } };
               appLogger.debug('Real-time account update received', realtimePayload);
               appLogger.debug('Real-time account update type', { eventType: realtimePayload.eventType });
@@ -610,8 +633,30 @@ export function AppProvider({ children }: { children: React.ReactNode }) {
 
               debouncedUpdate('account', async () => {
                 appLogger.debug('Reloading accounts after real-time update');
-                // Reload accounts when any change happens
-                const updatedAccounts = await SimpleAccountService.getAccounts(user.id);
+                // Reload accounts when any change happens — through the seam.
+                //
+                // The same question, asked the same way: the port's cloud branch
+                // runs the same SELECT on `accounts` (user_id, is_active, ordered
+                // by created_at) through the same mapAccountFromDb, and falls back
+                // to the same stored list under the same storage key. What changes
+                // is WHOSE id it asks about.
+                //
+                // The retired call carried this login's Clerk id and re-resolved
+                // it to a database id on every event; the port reads the id the
+                // boot already resolved. Behind the gate this whole block sits
+                // behind — `isUsingSupabase()` is exactly "a database id is
+                // resolved AND Supabase is configured" — that id is warm, so on
+                // the path that matters the two agree.
+                //
+                // Where they stop agreeing is a DECLARED IMPROVEMENT rather than
+                // a preserved behaviour: if the id cache is cleared between the
+                // event and this reload (sign-out, or a switch of login), the old
+                // call would re-resolve the CAPTURED Clerk id and paint the
+                // previous login's accounts onto whatever is on screen now. The
+                // port has no captured id to re-resolve — it answers [] while a
+                // session is still connecting, and never reaches for another
+                // login's rows.
+                const updatedAccounts = await dataPort.getAccounts();
                 appLogger.debug('Accounts reloaded', { count: updatedAccounts.length });
                 setAccounts(updatedAccounts);
                 setLastSyncTime(new Date());
@@ -628,16 +673,7 @@ export function AppProvider({ children }: { children: React.ReactNode }) {
                   appLogger.error('Failed to refresh transaction splits', splitError);
                 }
               });
-            }
-          );
-          
-          // Wait for the subscription to be set up
-          const unsubscribeAccounts = await unsubscribeAccountsPromise;
-
-          // Subscribe to transaction updates only (accounts are handled above by SimpleAccountService)
-          const unsubscribeData = dataPort.subscribeToUpdates({
-            // Don't subscribe to accounts here - already handled by SimpleAccountService above
-            // This prevents duplicate subscriptions and duplicate real-time events
+            },
             onTransactionUpdate: async (payload) => {
               appLogger.debug('Transaction update received', payload);
               
@@ -663,11 +699,11 @@ export function AppProvider({ children }: { children: React.ReactNode }) {
           });
 
           // Handed to the effect rather than returned from here: this function
-          // is async, so a returned cleanup only ever reaches a promise. Both
-          // are registered as they become available — the account handle is
-          // awaited above, and if the effect was cleaned up during that await
-          // it is closed on arrival instead of being stored.
-          registerTeardown(unsubscribeAccounts);
+          // is async, so a returned cleanup only ever reaches a promise. The
+          // race it guards is still real even though this handle now arrives
+          // synchronously — everything ABOVE it is awaited, so a cleanup can
+          // still fire while the boot is in flight, and a handle that lands
+          // afterwards is closed on arrival instead of being stored.
           registerTeardown(unsubscribeData);
         }
       } catch (error) {

--- a/src/contexts/__tests__/AppContextRealtimeCleanup.test.tsx
+++ b/src/contexts/__tests__/AppContextRealtimeCleanup.test.tsx
@@ -1,23 +1,33 @@
 /**
- * The boot's realtime channels, and who closes them.
+ * The boot's realtime subscription, and who closes it.
  *
- * The provider opens two subscriptions at the end of a signed-in boot — the
- * account channel (SimpleAccountService) and the transaction channel
- * (DataService.subscribeToUpdates). They are opened inside an ASYNC function,
- * and React only accepts a cleanup returned SYNCHRONOUSLY from the effect
- * body, so the cleanup that used to be returned from inside that function went
- * into a promise nobody read. Nothing ever closed them: switching account left
- * the previous login's channels live, still calling setAccounts on a provider
- * that had moved on, and every re-mount added another pair.
+ * The provider opens ONE subscription at the end of a signed-in boot —
+ * `dataPort.subscribeToUpdates`, carrying both the account and the transaction
+ * callbacks behind a single handle. It used to open two, through two different
+ * services, and close them through two handles; the account half has been
+ * folded into the same call, so "how many handles are there" is itself part of
+ * what this suite pins.
  *
- * Two things are pinned here, and they are the two the fix has to get right:
+ * It is opened inside an ASYNC function, and React only accepts a cleanup
+ * returned SYNCHRONOUSLY from the effect body, so the cleanup that used to be
+ * returned from inside that function went into a promise nobody read. Nothing
+ * ever closed it: switching account left the previous login's channels live,
+ * still calling setAccounts on a provider that had moved on, and every re-mount
+ * added another one.
  *
- *  1. A user change closes the first login's channels EXACTLY once — not zero
- *     times (the leak), not twice (a double-invoked handle is a different bug
- *     wearing the same clothes).
+ * Three things are pinned here:
+ *
+ *  1. A signed-in boot subscribes ONCE, with both callbacks, and a user change
+ *     closes the first login's handle EXACTLY once — not zero times (the leak),
+ *     not twice (a double-invoked handle is a different bug wearing the same
+ *     clothes).
  *  2. A cleanup that fires while the boot is still in flight has no handle to
  *     call yet. It must not throw, and the subscription that lands a moment
- *     later must be closed on arrival rather than left open forever.
+ *     later must be closed on arrival rather than left open forever. The handle
+ *     arrives synchronously now, but everything BEFORE it in the boot is
+ *     awaited, so the race is exactly as reachable as it was.
+ *  3. An account change reloads the accounts through the seam — never through
+ *     the account service the subscription used to come from.
  *
  * The data layer is stubbed the way the sibling suites stub it (in-memory
  * storage, local-only ids, no network). Only `isUsingSupabase` is forced on,
@@ -28,30 +38,13 @@ import React, { ReactNode } from 'react';
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { act, renderHook, waitFor } from '@testing-library/react';
 import type { Account } from '../../types';
+import type { AccountBalanceSnapshot } from '../../services/port';
 
 // Restore the live module (setup.ts registers a global mock for it).
 vi.unmock('../AppContextSupabase');
 
-/** The handle the app is given to close a channel with. */
+/** The handle the app is given to close its subscription with. */
 type Unsubscribe = () => void;
-
-/** An account channel the app asked for, plus the test's grip on it. */
-interface OpenedAccountChannel {
-  /** Which login the channel belongs to — the leak is invisible without this. */
-  clerkId: string;
-  /** How many times the app has closed it. Exactly-once lives here. */
-  unsubscribeCalls: number;
-  /**
-   * Hands the app its unsubscribe handle, i.e. resolves the subscribe promise.
-   * Held back deliberately in the race test so the boot parks mid-flight.
-   */
-  open: () => void;
-}
-
-/** A transaction channel, which is handed over synchronously. */
-interface OpenedDataChannel {
-  unsubscribeCalls: number;
-}
 
 // Two logins, each a stable singleton: the boot effect depends on `user`, so a
 // fresh object per render would re-fire it forever.
@@ -77,34 +70,23 @@ vi.mock('@clerk/clerk-react', () => ({
   useSession: () => ({ session: null }),
 }));
 
-const accountChannels = vi.hoisted(() => ({
-  opened: [] as OpenedAccountChannel[],
-  /** False parks every subscribe promise so a boot can be caught mid-flight. */
-  autoOpen: true,
+/**
+ * The account service's own account read, counted rather than merely stubbed:
+ * half of "the reload goes through the seam" is proving this one was not
+ * called.
+ *
+ * `subscribeToAccountChanges` is deliberately NOT stubbed here any more. The
+ * provider has no business calling it, and a mocked module that does not export
+ * it fails loudly if that ever changes back.
+ */
+const simpleAccounts = vi.hoisted(() => ({
+  // Type-only reference to `Account`: annotations are erased, so naming the
+  // app's own type here costs nothing at the hoisted call site.
+  getAccounts: vi.fn(async (): Promise<Account[]> => []),
 }));
 
 vi.mock('../../services/api/simpleAccountService', () => ({
-  getAccounts: async (): Promise<Account[]> => [],
-  subscribeToAccountChanges: (
-    clerkId: string,
-    _onChange: (payload: unknown) => void
-  ): Promise<Unsubscribe> => {
-    let handOver!: (unsubscribe: Unsubscribe) => void;
-    const subscribed = new Promise<Unsubscribe>(resolve => {
-      handOver = resolve;
-    });
-    const channel: OpenedAccountChannel = {
-      clerkId,
-      unsubscribeCalls: 0,
-      open: () =>
-        handOver(() => {
-          channel.unsubscribeCalls += 1;
-        }),
-    };
-    accountChannels.opened.push(channel);
-    if (accountChannels.autoOpen) channel.open();
-    return subscribed;
-  },
+  getAccounts: simpleAccounts.getAccounts,
 }));
 
 // The in-memory store behind the local fallback.
@@ -166,6 +148,24 @@ vi.mock('../../services/autoSyncService', () => ({
 import { AppProvider, useApp } from '../AppContextSupabase';
 import { DataService } from '../../services/api/dataService';
 
+/** Exactly what the provider may pass — no second copy of the shape. */
+type UpdateCallbacks = Parameters<typeof DataService.subscribeToUpdates>[0];
+
+/** A subscription the app asked for, plus the test's grip on it. */
+interface OpenedSubscription {
+  /**
+   * Which login's boot opened it. The seam resolves its own owner, so the
+   * subscription no longer carries a login the way the retired call did — the
+   * test records the login whose boot asked for it, which is what that
+   * assertion always meant. Without it the leak is invisible.
+   */
+  openedFor: string;
+  /** What the provider subscribed with — one call must carry both. */
+  callbacks: UpdateCallbacks;
+  /** How many times the app has closed it. Exactly-once lives here. */
+  unsubscribeCalls: number;
+}
+
 const localUserIds = {
   ensureUserExists: vi.fn(),
   getCurrentDatabaseUserId: () => null,
@@ -174,14 +174,13 @@ const localUserIds = {
 
 const wrapper = ({ children }: { children: ReactNode }) => <AppProvider>{children}</AppProvider>;
 
-describe('the boot’s realtime channels', () => {
-  const dataChannels: OpenedDataChannel[] = [];
+describe('the boot’s realtime subscription', () => {
+  const subscriptions: OpenedSubscription[] = [];
 
   beforeEach(() => {
     memoryStore.clear();
-    accountChannels.opened.length = 0;
-    accountChannels.autoOpen = true;
-    dataChannels.length = 0;
+    subscriptions.length = 0;
+    simpleAccounts.getAccounts.mockClear();
     clerk.current = { user: clerk.userA, isLoaded: true };
 
     // Local-only data layer: storage-backed reads, no cloud client anywhere.
@@ -204,13 +203,19 @@ describe('the boot’s realtime channels', () => {
     // rest of the boot on the network for no gain to what is under test.
     vi.spyOn(DataService, 'isUsingSupabase').mockReturnValue(true);
 
-    vi.spyOn(DataService, 'subscribeToUpdates').mockImplementation((): Unsubscribe => {
-      const channel: OpenedDataChannel = { unsubscribeCalls: 0 };
-      dataChannels.push(channel);
-      return () => {
-        channel.unsubscribeCalls += 1;
-      };
-    });
+    vi.spyOn(DataService, 'subscribeToUpdates').mockImplementation(
+      (callbacks): Unsubscribe => {
+        const subscription: OpenedSubscription = {
+          openedFor: clerk.current.user.id,
+          callbacks,
+          unsubscribeCalls: 0,
+        };
+        subscriptions.push(subscription);
+        return () => {
+          subscription.unsubscribeCalls += 1;
+        };
+      }
+    );
   });
 
   afterEach(() => {
@@ -219,68 +224,103 @@ describe('the boot’s realtime channels', () => {
     vi.restoreAllMocks();
   });
 
-  it('closes the first login’s channels exactly once when the user changes', async () => {
+  it('subscribes once, and closes the first login’s handle exactly once when the user changes', async () => {
     const { rerender, unmount } = renderHook(() => useApp(), { wrapper });
 
-    // Both channels are open for the first login. Waiting on the transaction
-    // channel is enough: it is created last, and the handles are registered in
-    // the same synchronous step.
-    await waitFor(() => expect(dataChannels).toHaveLength(1));
-    const [firstAccountChannel] = accountChannels.opened;
-    const [firstDataChannel] = dataChannels;
-    expect(firstAccountChannel.clerkId).toBe('clerk-user-a');
-    expect(firstAccountChannel.unsubscribeCalls).toBe(0);
+    await waitFor(() => expect(subscriptions).toHaveLength(1));
+    const [first] = subscriptions;
+    expect(first.openedFor).toBe('clerk-user-a');
+    expect(first.unsubscribeCalls).toBe(0);
+
+    // ONE call carrying BOTH channels. Two calls would be the arrangement this
+    // slice removed: two handles, two teardowns, and two chances to leak one.
+    expect(typeof first.callbacks.onAccountUpdate).toBe('function');
+    expect(typeof first.callbacks.onTransactionUpdate).toBe('function');
 
     // Somebody else signs in. React re-runs the effect, and its cleanup is the
     // ONLY thing that can close what the previous boot opened.
     clerk.current = { user: clerk.userB, isLoaded: true };
     rerender();
 
-    await waitFor(() => expect(dataChannels).toHaveLength(2));
-    expect(accountChannels.opened[1].clerkId).toBe('clerk-user-b');
+    await waitFor(() => expect(subscriptions).toHaveLength(2));
+    expect(subscriptions[1].openedFor).toBe('clerk-user-b');
 
-    // The leak, stated: without a cleanup these are 0 and the first login's
+    // The leak, stated: without a cleanup this is 0 and the first login's
     // channels keep pushing rows into the second login's provider.
-    expect(firstAccountChannel.unsubscribeCalls).toBe(1);
-    expect(firstDataChannel.unsubscribeCalls).toBe(1);
-    // ...and the current login's channels are still open.
-    expect(accountChannels.opened[1].unsubscribeCalls).toBe(0);
-    expect(dataChannels[1].unsubscribeCalls).toBe(0);
+    expect(first.unsubscribeCalls).toBe(1);
+    // ...and the current login's subscription is still open.
+    expect(subscriptions[1].unsubscribeCalls).toBe(0);
 
-    // Unmounting closes the second pair, and must not touch the first again:
+    // Unmounting closes the second one, and must not touch the first again:
     // a handle invoked twice is its own bug.
     unmount();
-    expect(firstAccountChannel.unsubscribeCalls).toBe(1);
-    expect(firstDataChannel.unsubscribeCalls).toBe(1);
-    expect(accountChannels.opened[1].unsubscribeCalls).toBe(1);
-    expect(dataChannels[1].unsubscribeCalls).toBe(1);
+    expect(first.unsubscribeCalls).toBe(1);
+    expect(subscriptions[1].unsubscribeCalls).toBe(1);
   });
 
-  it('closes channels that arrive after the cleanup already ran', async () => {
-    // The account subscription is a round trip. Park it, so the cleanup fires
-    // at the one moment there is nothing yet to close.
-    accountChannels.autoOpen = false;
+  it('closes a subscription that arrives after the cleanup already ran', async () => {
+    // The handle is handed over synchronously now, so the race has to be staged
+    // where it actually lives: on the awaits BEFORE it. The balances round trip
+    // is the last one the boot waits for — park it, and the cleanup fires at
+    // the one moment there is nothing yet to close.
+    let releaseBalances!: () => void;
+    const parked = new Promise<void>(resolve => {
+      releaseBalances = resolve;
+    });
+    const balances = vi.spyOn(DataService, 'getAccountBalances').mockImplementation(async () => {
+      await parked;
+      return new Map<string, AccountBalanceSnapshot>();
+    });
 
     const { unmount } = renderHook(() => useApp(), { wrapper });
 
-    await waitFor(() => expect(accountChannels.opened).toHaveLength(1));
-    const [channel] = accountChannels.opened;
-    // The boot is parked on the await: the handle does not exist yet.
-    expect(dataChannels).toHaveLength(0);
+    // Parked, and provably so: the read the boot is waiting on has been asked
+    // and has not answered. Nothing has been subscribed yet.
+    await waitFor(() => expect(balances).toHaveBeenCalled());
+    expect(subscriptions).toHaveLength(0);
 
     unmount();
-    expect(channel.unsubscribeCalls).toBe(0);
 
-    // The subscription lands on a provider that has gone. Both channels are
-    // created — the boot resumes where it stopped — and both must be closed
-    // immediately rather than surviving the component that asked for them.
+    // The subscription lands on a provider that has gone. It is still created —
+    // the boot resumes where it stopped — and it must be closed immediately
+    // rather than surviving the component that asked for it.
     await act(async () => {
-      channel.open();
+      releaseBalances();
       await Promise.resolve();
     });
 
-    await waitFor(() => expect(dataChannels).toHaveLength(1));
-    expect(channel.unsubscribeCalls).toBe(1);
-    expect(dataChannels[0].unsubscribeCalls).toBe(1);
+    await waitFor(() => expect(subscriptions).toHaveLength(1));
+    await waitFor(() => expect(subscriptions[0].unsubscribeCalls).toBe(1));
+  });
+
+  it('reloads the accounts through the seam when a change arrives', async () => {
+    // WHICH door the reload goes through, stated as a test rather than left to
+    // the diff. The account service's version carried a captured Clerk id and
+    // re-resolved it on every event; the seam reads the id the boot resolved.
+    // Both answer the same question today — the point of pinning it is that
+    // only one of them can still be answering the PREVIOUS login's question.
+    const portAccounts = vi.spyOn(DataService, 'getAccounts');
+
+    renderHook(() => useApp(), { wrapper });
+    await waitFor(() => expect(subscriptions).toHaveLength(1));
+
+    // The boot has its own account read; this test is about the reload.
+    portAccounts.mockClear();
+    simpleAccounts.getAccounts.mockClear();
+
+    const [subscription] = subscriptions;
+    await act(async () => {
+      subscription.callbacks.onAccountUpdate?.({
+        eventType: 'UPDATE',
+        new: { is_active: true },
+      });
+      // The reload is debounced by 200ms inside the provider. Waited out in
+      // real time rather than with fake timers: the boot around it is a chain
+      // of awaits, and freezing the clock under it buys nothing here.
+      await new Promise(resolve => setTimeout(resolve, 300));
+    });
+
+    await waitFor(() => expect(portAccounts).toHaveBeenCalledTimes(1));
+    expect(simpleAccounts.getAccounts).not.toHaveBeenCalled();
   });
 });

--- a/src/services/__tests__/dataService.test.ts
+++ b/src/services/__tests__/dataService.test.ts
@@ -1,5 +1,7 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { createDataService, DataService } from '../api/dataService';
+import { AccountService } from '../api/accountService';
+import { TransactionService } from '../api/transactionService';
 import { createSimpleAccountService } from '../api/simpleAccountService';
 import type { Account, Budget, Category, Goal, Transaction, TransactionSplit } from '../../types';
 import { STORAGE_KEYS } from '../storageAdapter';
@@ -1485,5 +1487,103 @@ describe('DataService linkSplitLineTransfer (local mode)', () => {
       .rejects.toThrow(/split line no longer exists/);
     await expect(service.linkSplitLineTransfer('leg', 'nope'))
       .rejects.toThrow(/Transaction not found/);
+  });
+});
+
+/**
+ * The realtime block's one door.
+ *
+ * The provider used to open its account channel through a second service and
+ * hold two handles; it now passes `onAccountUpdate` to this method and holds
+ * one. That makes the routing below load-bearing in a way it was not before —
+ * nothing else proves the account channel is opened at all, because the suite
+ * that covers the provider stubs this method out entirely.
+ *
+ * The services are spied rather than injected: what is under test is the
+ * DEFAULT wiring the app runs with, not a double's ability to be called.
+ */
+describe('DataService.subscribeToUpdates', () => {
+  const logger = { error: vi.fn(), warn: vi.fn(), log: vi.fn() };
+
+  const cloudService = () => createDataService({
+    isSupabaseConfigured: () => true,
+    storageAdapter: createStorage(),
+    logger,
+    userIdService: {
+      ensureUserExists: vi.fn(),
+      getCurrentDatabaseUserId: vi.fn(() => 'db-user-1'),
+      getCurrentUserIds: vi.fn(() => ({ clerkId: 'clerk-1', databaseId: 'db-user-1' }))
+    }
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('opens both channels for the resolved owner, and one handle closes both', () => {
+    const closeAccounts = vi.fn();
+    const closeTransactions = vi.fn();
+    const accounts = vi.spyOn(AccountService, 'subscribeToAccounts').mockReturnValue(closeAccounts);
+    const transactions = vi.spyOn(TransactionService, 'subscribeToTransactions')
+      .mockReturnValue(closeTransactions);
+
+    const onAccountUpdate = vi.fn();
+    const onTransactionUpdate = vi.fn();
+    const stop = cloudService().subscribeToUpdates({ onAccountUpdate, onTransactionUpdate });
+
+    // The owner is the id the seam resolved for itself — never one a caller
+    // passed in — and each callback reaches its OWN channel. A swap here would
+    // reload the accounts on a transaction event and nothing on an account one.
+    expect(accounts).toHaveBeenCalledWith('db-user-1', onAccountUpdate);
+    expect(transactions).toHaveBeenCalledWith('db-user-1', onTransactionUpdate);
+
+    // One handle, both channels: the provider registers exactly this function
+    // as its teardown, and a channel it does not close outlives the login.
+    stop();
+    expect(closeAccounts).toHaveBeenCalledTimes(1);
+    expect(closeTransactions).toHaveBeenCalledTimes(1);
+  });
+
+  it('opens only what it was asked for', () => {
+    const accounts = vi.spyOn(AccountService, 'subscribeToAccounts').mockReturnValue(vi.fn());
+    const transactions = vi.spyOn(TransactionService, 'subscribeToTransactions')
+      .mockReturnValue(vi.fn());
+
+    cloudService().subscribeToUpdates({ onTransactionUpdate: vi.fn() });
+
+    expect(transactions).toHaveBeenCalledTimes(1);
+    expect(accounts).not.toHaveBeenCalled();
+  });
+
+  it('opens nothing, and still hands back a handle, when no owner is resolved', () => {
+    const accounts = vi.spyOn(AccountService, 'subscribeToAccounts').mockReturnValue(vi.fn());
+    const transactions = vi.spyOn(TransactionService, 'subscribeToTransactions')
+      .mockReturnValue(vi.fn());
+
+    // B-8: an engine with nothing to listen to answers with a no-op rather than
+    // with nothing at all. The provider stores it and calls it on cleanup.
+    const service = createDataService({
+      isSupabaseConfigured: () => true,
+      storageAdapter: createStorage(),
+      logger,
+      userIdService: {
+        ensureUserExists: vi.fn(),
+        getCurrentDatabaseUserId: vi.fn(() => null),
+        getCurrentUserIds: vi.fn(() => ({ clerkId: 'clerk-1', databaseId: null }))
+      }
+    });
+
+    const stop = service.subscribeToUpdates({
+      onAccountUpdate: vi.fn(),
+      onTransactionUpdate: vi.fn()
+    });
+
+    expect(accounts).not.toHaveBeenCalled();
+    expect(transactions).not.toHaveBeenCalled();
+    expect(typeof stop).toBe('function');
+    expect(() => {
+      stop();
+      stop();
+    }).not.toThrow();
   });
 });

--- a/src/services/api/accountService.ts
+++ b/src/services/api/accountService.ts
@@ -407,7 +407,19 @@ class AccountServiceImpl {
       .subscribe();
 
     return () => {
-      subscription.unsubscribe();
+      // removeChannel, not subscription.unsubscribe(). This is the one
+      // behaviour worth keeping from the sibling account subscription the
+      // context used to open instead of this one.
+      //
+      // What actually differs, in @supabase/realtime-js 2.77.0: removeChannel
+      // awaits the same leave push and then, if this was the client's LAST
+      // channel, disconnects the socket (RealtimeClient.removeChannel). A bare
+      // unsubscribe never disconnects, so a sign-out or an unmount leaves an
+      // idle websocket and its heartbeat timer running for the rest of the
+      // session. Deregistration is NOT the difference: the channel's own close
+      // hook calls socket._remove on either path — and on neither path when the
+      // leave push errors, which is a leak this change does not claim to fix.
+      client.removeChannel(subscription);
     };
   }
 }

--- a/src/services/api/transactionService.ts
+++ b/src/services/api/transactionService.ts
@@ -1635,7 +1635,12 @@ class TransactionServiceImpl {
       .subscribe();
 
     return () => {
-      subscription.unsubscribe();
+      // removeChannel, not unsubscribe: both deregister the channel on the
+      // normal path, but only removeChannel closes the websocket once the LAST
+      // channel leaves — and that only fires if every handle uses it. The
+      // account channel (accountService.subscribeToAccounts) already does; a
+      // signed-out app must not keep an idle socket and heartbeat alive.
+      void client.removeChannel(subscription);
     };
   }
 

--- a/src/services/port/__tests__/contract.ts
+++ b/src/services/port/__tests__/contract.ts
@@ -180,6 +180,41 @@ const PREPARE_CATEGORIES: Record<DataPortEngine, { describes: string; persists: 
   'local-core': { describes: 'seeds the defaults into the store', persists: true }
 };
 
+/**
+ * B-8 — what a subscription promises.
+ *
+ * `subscribeToUpdates` is a watch, not a read: the caller hands over callbacks
+ * and gets a handle back. WHAT arrives through those callbacks is the part the
+ * engines cannot agree on, so it is declared here rather than asserted equal.
+ *
+ * `delivers: 'never'` is not a gap to be filled in later. An engine with no
+ * other device to hear from has nothing to say: browser storage is one store in
+ * one tab, and a local core is one file on one machine. Its handle is a no-op,
+ * and the caller already treats a silent channel as normal.
+ *
+ * What EVERY engine is held to is in the test below, because the boot's cleanup
+ * depends on it: the handle is a function, calling it twice is safe (the
+ * cleanup drains its handles, and a fast user switch can reach the same one
+ * again), and once it has been called nothing further arrives.
+ */
+const SUBSCRIPTION_DELIVERY: Record<
+  DataPortEngine,
+  { describes: string; delivers: 'never' | 'at-least-once' }
+> = {
+  // One store, one tab. Nothing to hear from, so nothing ever fires.
+  'browser-storage': { describes: 'never delivers a change', delivers: 'never' },
+  // A realtime channel: an event may arrive more than once, events may arrive
+  // out of order, and an event may be THIS client's own write coming back —
+  // which is why the provider suppresses reloads for a moment after a local
+  // write and debounces whatever is left.
+  supabase: {
+    describes: 'delivers at least once, unordered, and may echo this client’s own writes',
+    delivers: 'at-least-once'
+  },
+  // One file on one machine: same silence, same reason.
+  'local-core': { describes: 'never delivers a change', delivers: 'never' }
+};
+
 // ── Fixture builders ────────────────────────────────────────────────────────
 // Invented data throughout: made-up account names, made-up amounts.
 
@@ -188,6 +223,13 @@ const ACCOUNT_B = 'acct-b';
 const ACCOUNT_C = 'acct-c';
 
 const AT = (day: string): Date => new Date(`${day}T12:00:00.000Z`);
+
+/**
+ * Let anything a write scheduled actually run. One macrotask: enough for a
+ * callback an engine dispatched for itself, deliberately not enough to wait on
+ * a network. See B-8 for what that buys and what it does not.
+ */
+const settle = (): Promise<void> => new Promise(resolve => setTimeout(resolve, 0));
 
 const anAccount = (id: string, name: string, rest: Partial<Account> = {}): Account => ({
   id,
@@ -1185,6 +1227,61 @@ export function runDataPortContract(name: string, harness: DataPortContractHarne
         await port.setTransactionArchived('txn-1', false);
         state = await read();
         expect(transactionOf(state, 'txn-1')?.archived).toBe(false);
+      });
+    });
+
+    describe('watching for changes made elsewhere', () => {
+      it(`B-8: the handle is callable, idempotent and final — and this engine ${SUBSCRIPTION_DELIVERY[engine].describes}`, async () => {
+        const { port } = await harness.create({ accounts: threeAccounts() });
+
+        const heard: string[] = [];
+        const stop = port.subscribeToUpdates({
+          onAccountUpdate: () => heard.push('account'),
+          onTransactionUpdate: () => heard.push('transaction')
+        });
+
+        // The caller stores this and calls it from a React cleanup. A handle
+        // that is not a function takes the whole provider down on unmount.
+        expect(typeof stop).toBe('function');
+
+        await port.createTransaction({
+          accountId: ACCOUNT_A,
+          amount: -12.5,
+          date: AT('2025-01-12'),
+          description: 'Heard or not',
+          category: 'cat-everyday',
+          type: 'expense'
+        });
+        await settle();
+
+        // An engine that never delivers must stay silent through a write it
+        // made itself. One that does deliver may say anything at all — twice,
+        // late, or in the wrong order — so nothing is asserted about it here.
+        if (SUBSCRIPTION_DELIVERY[engine].delivers === 'never') {
+          expect(heard).toEqual([]);
+        }
+
+        // Idempotent, and said twice on purpose: the boot's cleanup drains its
+        // handles, and a fast user switch can reach the same one again.
+        stop();
+        stop();
+
+        // Final. Whatever this engine had to say, it stops saying it. An engine
+        // that really delivers needs a wider window than `settle` to make this
+        // assertion mean anything — widening it is the harness's business, and
+        // the harness that delivers does not exist yet.
+        const heardBefore = heard.length;
+        await port.createTransaction({
+          accountId: ACCOUNT_A,
+          amount: -3.25,
+          date: AT('2025-01-13'),
+          description: 'After the handle was used',
+          category: 'cat-everyday',
+          type: 'expense'
+        });
+        await settle();
+
+        expect(heard.length).toBe(heardBefore);
       });
     });
 


### PR DESCRIPTION
Slice R of the write-paths plan: the realtime block's two decisions that could not be renames.

- The realtime account read goes through the port; the residual difference is an **improvement**, declared: no captured Clerk id means a mid-debounce sign-out can no longer paint the previous login's accounts.
- The two account subscriptions become **one** `subscribeToUpdates` call with one handle. Every N-3 difference is listed in the commit, including the one real cost (no subscribe-status logging — a channel that fails to join is now silent).
- **The plan's teardown rationale was corrected against the shipped SDK source**: `unsubscribe()` does deregister on the normal path; what it never does is close the websocket when the last channel leaves. `removeChannel` does — and only if every handle uses it, so both the account and transaction channels now use it. Neither fixes the error-path leak; the comments say so.
- Contract 45 → 46: **B-8, what a subscription promises per engine**, asserting only what's honestly assertable (callable, idempotent, silent after stop; never-delivering engines stay silent through their own writes).
- Four mutation checks all went red on cue (seam read reverted; cancellation guard dropped; silent engine made to fire; callback swapped for no-op).

Gate: lint · strict tsc · smoke 4,760 (+5 vs baseline) · realtime 11/11 · build · bundle delta **0.0 KB** vs the recorded Slice 0 baseline · coverage 74.58/80.98 vs 63/55.

🤖 Generated with [Claude Code](https://claude.com/claude-code)