### PR TITLE
feat(seam): slice 5a — budget writes through the port, gated by the wrong-store tests

### DIFF
--- a/src/contexts/AppContextSupabase.tsx
+++ b/src/contexts/AppContextSupabase.tsx
@@ -1283,13 +1283,13 @@ export function AppProvider({ children }: { children: React.ReactNode }) {
     }
   }, [transactions]);
 
-  // Budget operations — persisted via PlanningService (Supabase or local)
+  // Budget operations — persisted through the seam, which resolves the owner
+  // itself (the id used to be resolved here and handed over; a null one wrote
+  // browser storage under a signed-in session, and the budget was gone at the
+  // next boot).
   const addBudget = useCallback(async (budget: Omit<Budget, 'id' | 'spent'>) => {
     try {
-      const created = await PlanningService.createBudget(
-        userIdService.getCurrentDatabaseUserId(),
-        budget
-      );
+      const created = await dataPort.createBudget(budget);
       setBudgets(prev => [...prev, created]);
     } catch (error) {
       appLogger.error('Failed to add budget', error);
@@ -1299,11 +1299,7 @@ export function AppProvider({ children }: { children: React.ReactNode }) {
 
   const updateBudget = useCallback(async (id: string, updates: Partial<Budget>) => {
     try {
-      const updated = await PlanningService.updateBudget(
-        userIdService.getCurrentDatabaseUserId(),
-        id,
-        updates
-      );
+      const updated = await dataPort.updateBudget(id, updates);
       setBudgets(prev => prev.map(b => b.id === id ? updated : b));
     } catch (error) {
       appLogger.error('Failed to update budget', error);
@@ -1313,7 +1309,7 @@ export function AppProvider({ children }: { children: React.ReactNode }) {
 
   const deleteBudget = useCallback(async (id: string) => {
     try {
-      await PlanningService.deleteBudget(userIdService.getCurrentDatabaseUserId(), id);
+      await dataPort.deleteBudget(id);
       setBudgets(prev => prev.filter(b => b.id !== id));
     } catch (error) {
       appLogger.error('Failed to delete budget', error);

--- a/src/contexts/__tests__/AppContextBootThroughPort.test.tsx
+++ b/src/contexts/__tests__/AppContextBootThroughPort.test.tsx
@@ -17,9 +17,14 @@
  *
  * This is deliberately the test Phase 3's local implementation boots against:
  * swap the stub for LocalDataPort, keep every assertion, and a green run says
- * the app came up on the local edition. The stub is typed `DataPort`, so the
- * day an operation joins the seam this file stops compiling until it is
- * answered — which is the point of writing it now rather than then.
+ * the app came up on the local edition.
+ *
+ * The stub is typed `DataPort`, and that annotation is NOT what keeps it
+ * complete: `tsc -b` never compiles this file (tsconfig.app.json excludes
+ * tests), so an operation could join the seam and leave the stub silently short
+ * of it. What keeps it complete is the last test in this file, which holds the
+ * stub's key set against `DATA_PORT_OPERATIONS` — the seam's own list, kept
+ * beside the contract suite.
  *
  * NOT through the door yet, and deliberately named so the silence is not read
  * as a claim: `isUsingSupabase` (still DataService's own answer — it is a
@@ -40,6 +45,7 @@ import type {
   TransactionSplit
 } from '../../types';
 import type { AccountBalanceSnapshot, DataPort } from '../../services/port/dataPort';
+import { DATA_PORT_OPERATIONS } from '../../services/port/__tests__/contract';
 
 // Restore the live module (setup.ts registers a global mock for it).
 vi.unmock('../AppContextSupabase');
@@ -176,9 +182,10 @@ vi.mock('../../services/port', () => {
     };
   };
 
-  // Typed as the interface on purpose: this is the compile-time half of the
-  // proof. An operation added to the seam breaks this file until it is
-  // answered here, which is how the local edition finds out what it owes.
+  // Typed as the interface for the reader's sake; held to it by the key-set
+  // test at the bottom of this file, which is the part that actually bites. An
+  // operation added to the seam and not answered here turns that test red, and
+  // that is how the local edition finds out what it owes.
   const dataPort: DataPort = {
     getAccounts: answer('getAccounts', seam.accounts),
     getClosedAccounts: answer('getClosedAccounts', [] as Account[]),
@@ -232,6 +239,9 @@ vi.mock('../../services/port', () => {
     repairClaimedTransfer: refuse('repairClaimedTransfer'),
     createTransferCounterpart: refuse('createTransferCounterpart'),
     setTransactionSplits: refuse('setTransactionSplits'),
+    createBudget: refuse('createBudget'),
+    updateBudget: refuse('updateBudget'),
+    deleteBudget: refuse('deleteBudget'),
     mergeCategories: refuse('mergeCategories'),
     dismissSuggestion: refuse('dismissSuggestion'),
     restoreSuggestion: refuse('restoreSuggestion'),
@@ -376,5 +386,23 @@ describe('the boot, through the seam and nothing else', () => {
     expect(result.current.goals.map(goal => goal.id)).toEqual(['goal-from-the-seam']);
 
     vi.restoreAllMocks();
+  });
+
+  it('stubs the whole seam — exactly the operations it names, no more and no fewer', async () => {
+    // What makes every assertion above mean what it says.
+    //
+    // This file's claim is "the app booted on nothing but the port". That claim
+    // is only as good as the stub: if an operation joined the seam and the stub
+    // never grew a door for it, the boot would reach a real implementation (or
+    // an `undefined`) and this file would go on passing while quietly testing
+    // something else. The type annotation cannot stop that — tests are not
+    // compiled — so the list is held against the keys instead.
+    //
+    // Both directions matter. FEWER than the list is the case above. MORE than
+    // the list is a stub that has drifted into answering a door the interface
+    // does not have, which is the same lie told the other way round.
+    const { dataPort } = await import('../../services/port');
+
+    expect(Object.keys(dataPort).sort()).toEqual([...DATA_PORT_OPERATIONS].sort());
   });
 });

--- a/src/services/__tests__/dataService.test.ts
+++ b/src/services/__tests__/dataService.test.ts
@@ -269,6 +269,170 @@ describe('DataService (deterministic fallback)', () => {
     expect(storage.get).not.toHaveBeenCalledWith(STORAGE_KEYS.GOALS);
   });
 
+  describe('budget writes', () => {
+    // THE tests of this slice. A read that resolves the wrong owner shows the
+    // wrong numbers until the next refresh; a WRITE that resolves the wrong
+    // owner puts a signed-in person's budget in browser storage, shows it to
+    // them as saved, and loses it at the next boot — because the read beside it
+    // goes to the cloud, where the row never landed. Nothing throws, nothing
+    // logs, and there is no way back. So each write gets the same two
+    // questions: with a cloud session, was the RESOLVED id passed on (and never
+    // a null)? With no cloud, did the browser's own store take it, without the
+    // cloud service being touched at all?
+
+    const budgetInput = (
+      overrides: Partial<Omit<Budget, 'id' | 'spent'>> = {}
+    ): Omit<Budget, 'id' | 'spent'> => ({
+      // The shape the budget modal actually submits.
+      categoryId: 'cat-everyday',
+      amount: 70.1,
+      period: 'monthly',
+      isActive: true,
+      createdAt: new Date('2025-08-01T00:00:00.000Z'),
+      updatedAt: new Date('2025-08-01T00:00:00.000Z'),
+      ...overrides
+    });
+
+    /** A stand-in for the cloud half, answering plausibly so the call SHAPE is what fails. */
+    const cloudPlanningService = () => ({
+      mergeCategories: vi.fn(),
+      createBudget: vi.fn(
+        async (_userId: string | null, budget: Omit<Budget, 'id' | 'spent'>): Promise<Budget> => ({
+          ...budget,
+          id: 'budget-from-the-cloud',
+          spent: 0
+        })
+      ),
+      updateBudget: vi.fn(
+        async (_userId: string | null, id: string, updates: Partial<Budget>): Promise<Budget> => ({
+          ...budgetInput(),
+          ...updates,
+          id,
+          spent: 0
+        })
+      ),
+      deleteBudget: vi.fn(async (): Promise<void> => {}),
+      getBudgets: vi.fn(async () => [] as Budget[]),
+      getGoals: vi.fn(async () => [] as Goal[]),
+      ensureCategories: vi.fn(async () => [] as Category[])
+    });
+
+    const signedIn = (planningService: ReturnType<typeof cloudPlanningService>, storage: ReturnType<typeof createStorage>) =>
+      createDataService({
+        isSupabaseConfigured: () => true,
+        hasCloudSession: () => true,
+        planningService,
+        storageAdapter: storage,
+        logger,
+        uuid,
+        now,
+        userIdService: {
+          ensureUserExists: vi.fn(),
+          getCurrentDatabaseUserId: vi.fn(() => 'db-user-1'),
+          getCurrentUserIds: vi.fn(() => ({ clerkId: 'clerk-user-1', databaseId: 'db-user-1' }))
+        }
+      });
+
+    it('creates a budget under the resolved database id, and never under null', async () => {
+      const planningService = cloudPlanningService();
+      const storage = createStorage({ [STORAGE_KEYS.BUDGETS]: [] });
+      const service = signedIn(planningService, storage);
+      const input = budgetInput();
+
+      const created = await service.createBudget(input);
+
+      expect(created.id).toBe('budget-from-the-cloud');
+      // The whole call log, not just "was called with": a SECOND call carrying
+      // null is exactly the bug, and `toHaveBeenCalledWith` alone would pass
+      // straight through it.
+      expect(planningService.createBudget.mock.calls).toEqual([['db-user-1', input]]);
+      // And it went to the cloud INSTEAD of the browser, not as well as.
+      expect(storage.set).not.toHaveBeenCalled();
+    });
+
+    it('updates a budget under the resolved database id, and never under null', async () => {
+      const planningService = cloudPlanningService();
+      const storage = createStorage({ [STORAGE_KEYS.BUDGETS]: [] });
+      const service = signedIn(planningService, storage);
+
+      const updated = await service.updateBudget('budget-1', { amount: 0.3 });
+
+      expect(updated.amount).toBe(0.3);
+      expect(planningService.updateBudget.mock.calls).toEqual([['db-user-1', 'budget-1', { amount: 0.3 }]]);
+      expect(storage.set).not.toHaveBeenCalled();
+    });
+
+    it('deletes a budget under the resolved database id, and never under null', async () => {
+      const planningService = cloudPlanningService();
+      const storage = createStorage({ [STORAGE_KEYS.BUDGETS]: [] });
+      const service = signedIn(planningService, storage);
+
+      await service.deleteBudget('budget-1');
+
+      expect(planningService.deleteBudget.mock.calls).toEqual([['db-user-1', 'budget-1']]);
+      expect(storage.set).not.toHaveBeenCalled();
+    });
+
+    it('hands the cloud failure back word for word', async () => {
+      // The budget modal renders `error.message` straight into the dialog. A
+      // wrapper here — "Failed to save budget" — would replace a sentence that
+      // says what went wrong with one that says only that something did, and
+      // the seam's rule 4 says the wording is part of the contract. So the
+      // cloud branch returns the promise unwrapped, and this is what proves it.
+      const planningService = cloudPlanningService();
+      planningService.createBudget.mockRejectedValueOnce(
+        new Error('duplicate key value violates unique constraint "budgets_user_category_period_key"')
+      );
+      const service = signedIn(planningService, createStorage({ [STORAGE_KEYS.BUDGETS]: [] }));
+
+      await expect(service.createBudget(budgetInput())).rejects.toThrow(
+        'duplicate key value violates unique constraint "budgets_user_category_period_key"'
+      );
+    });
+
+    it('writes to the browser store, and does not touch the cloud service, with no cloud session', async () => {
+      // The other half of every test above: with no cloud, the write is this
+      // class's own, and the fields it fills in mirror PlanningService's local
+      // half exactly (`spent` at zero, both timestamps stamped now, a generated
+      // id) — because the two halves write the SAME browser collection, and a
+      // budget that came out of one must be indistinguishable from a budget
+      // that came out of the other.
+      const planningService = cloudPlanningService();
+      const storage = createStorage({ [STORAGE_KEYS.BUDGETS]: [] });
+      const service = createDataService({
+        isSupabaseConfigured: () => false,
+        hasCloudSession: () => false,
+        planningService,
+        storageAdapter: storage,
+        logger,
+        uuid: () => 'budget-generated',
+        now,
+        userIdService: userId
+      });
+
+      const created = await service.createBudget(budgetInput({ amount: 0.3 }));
+      expect(created).toMatchObject({
+        id: 'budget-generated',
+        categoryId: 'cat-everyday',
+        amount: 0.3,
+        spent: 0,
+        createdAt: new Date('2025-09-01T00:00:00.000Z'),
+        updatedAt: new Date('2025-09-01T00:00:00.000Z')
+      });
+
+      const edited = await service.updateBudget('budget-generated', { amount: 70.1 });
+      expect(edited.amount).toBe(70.1);
+      expect(await service.getBudgets()).toEqual([edited]);
+
+      await service.deleteBudget('budget-generated');
+      expect(await service.getBudgets()).toEqual([]);
+
+      expect(planningService.createBudget).not.toHaveBeenCalled();
+      expect(planningService.updateBudget).not.toHaveBeenCalled();
+      expect(planningService.deleteBudget).not.toHaveBeenCalled();
+    });
+  });
+
   it('does not swallow an unreadable account list — exactly as the call it replaced did not', async () => {
     // The boot's two reads that promise never to reject (its transactions and
     // its split lines) resolve empty when the store will not open. The ACCOUNT

--- a/src/services/api/dataService.ts
+++ b/src/services/api/dataService.ts
@@ -48,15 +48,23 @@ type TransactionServiceLike = Pick<typeof TransactionService,
   getAccountBalances?: () => Promise<ReadonlyMap<string, AccountBalanceSnapshot>>;
 };
 /**
- * `mergeCategories` is required; the READS are optional, for the same reason
+ * The WRITES are required; the READS are optional, for the same reason
  * `loadTransactionsForBoot` above is — a partial test double that supplies no
  * cloud planning leaves the seam serving the browser-local collections, which
  * is the honest answer for a store with no cloud behind it.
  *
+ * A write has no such honest fallback. "Fall back to the browser's copy"
+ * describes, for a signed-in session, a budget that appears on the page and is
+ * gone at the next boot, because the read beside it goes to the cloud where the
+ * row never landed. So an optional write member would be a way for a double —
+ * or a future refactor that forgot one — to turn that loss on silently, and
+ * these stay required.
+ *
  * Derived from the real service rather than re-declared, so a signature that
  * changes there cannot silently drift from what is called here.
  */
-type PlanningServiceLike = Pick<typeof PlanningService, 'mergeCategories'> &
+type PlanningServiceLike = Pick<typeof PlanningService,
+  'mergeCategories' | 'createBudget' | 'updateBudget' | 'deleteBudget'> &
   Partial<Pick<typeof PlanningService, 'getBudgets' | 'getGoals' | 'ensureCategories'>>;
 type SuggestionDismissalServiceLike = Pick<typeof SuggestionDismissalService,
   'list' | 'dismiss' | 'restore'>;
@@ -1471,6 +1479,110 @@ class DataServiceImpl implements DataPort {
     return this.readCollection<Budget>(STORAGE_KEYS.BUDGETS);
   }
 
+  /**
+   * Create a budget.
+   *
+   * The branch is the one `getBudgets` above uses, and for the same reason —
+   * but a write is where getting the owner wrong stops being a wrong answer on
+   * screen and becomes a lost budget: `PlanningService.createBudget(null, …)`
+   * writes BROWSER storage and returns an ordinary Budget, so a signed-in
+   * person would see their new budget appear and find it gone at the next
+   * boot, when the cloud read it never reached answers instead. The id is
+   * resolved here, on the same tick, and only passed on when it is real. The
+   * full statement of that rule lives on `DataPortPlanningWrites.createBudget`.
+   *
+   * The cloud branch DELEGATES, and returns the promise unwrapped: whatever
+   * sentence a failed insert produces is what the budget modal puts in front of
+   * the user, and re-wrapping it here would replace it with a worse one.
+   *
+   * The local branch is this class's own, mirroring what PlanningService's
+   * local half does field for field: a generated id, `spent` at zero (it is
+   * recomputed from the ledger, never stored knowledge), and both timestamps
+   * stamped now. The id comes from this class's injected generator rather than
+   * a bare `crypto.randomUUID()` — the same one every other local write here
+   * uses, identical in a browser, and it has a fallback where that API is
+   * missing instead of throwing.
+   *
+   * ONE ASYMMETRY, PRESERVED DELIBERATELY: the cloud insert fills in a
+   * `start_date` and a `name` when the caller left them empty. That is a
+   * not-null column being satisfied, not a product decision, and the browser's
+   * copy has never carried either — inventing them here would change what
+   * every existing local budget looks like on the page.
+   *
+   * AND ONE OMISSION, ALSO DELIBERATE: the three budget writes do not yet
+   * refuse a session whose database id is still resolving, the way every other
+   * write on this class does. Today such a write goes to browser storage, and
+   * today is what this branch reproduces. Refusing it is the better behaviour
+   * and it is coming — as its own change, with its own tests and its own
+   * sentence for the user, because a behaviour change hidden inside a routing
+   * change is one nobody can review.
+   */
+  async createBudget(budget: Omit<Budget, 'id' | 'spent'>): Promise<Budget> {
+    const userId = this.userIdService.getCurrentDatabaseUserId();
+    if (userId && this.supabaseChecker()) {
+      return this.planningService.createBudget(userId, budget);
+    }
+
+    const created: Budget = {
+      ...budget,
+      id: this.generateId(),
+      spent: 0,
+      createdAt: this.nowProvider(),
+      updatedAt: this.nowProvider()
+    };
+    const budgets = await this.readCollection<Budget>(STORAGE_KEYS.BUDGETS);
+    await this.persistCollection(STORAGE_KEYS.BUDGETS, [...budgets, created]);
+    return created;
+  }
+
+  /**
+   * Change a budget, and hand back the whole budget as it now stands — the
+   * caller replaces its copy with this answer, so a partial one would blank
+   * whatever it left out.
+   *
+   * Same branch and same owner rule as `createBudget` above. A budget that is
+   * not there is refused by name rather than created, and because the lookup
+   * happens before the first write, the refusal leaves the store exactly as it
+   * was.
+   */
+  async updateBudget(id: string, updates: Partial<Budget>): Promise<Budget> {
+    const userId = this.userIdService.getCurrentDatabaseUserId();
+    if (userId && this.supabaseChecker()) {
+      return this.planningService.updateBudget(userId, id, updates);
+    }
+
+    const budgets = await this.readCollection<Budget>(STORAGE_KEYS.BUDGETS);
+    const index = budgets.findIndex(budget => budget.id === id);
+    if (index === -1) throw new Error('Budget not found');
+
+    const updated: Budget = { ...budgets[index], ...updates, updatedAt: this.nowProvider() };
+    await this.persistCollection(
+      STORAGE_KEYS.BUDGETS,
+      budgets.map((budget, position) => (position === index ? updated : budget))
+    );
+    return updated;
+  }
+
+  /**
+   * Remove a budget.
+   *
+   * Same branch and same owner rule as the two above. Deleting one that is not
+   * there is a silent no-op in both modes — a double-click, or a second device
+   * that got there first, must not turn a decision into an error message.
+   */
+  async deleteBudget(id: string): Promise<void> {
+    const userId = this.userIdService.getCurrentDatabaseUserId();
+    if (userId && this.supabaseChecker()) {
+      return this.planningService.deleteBudget(userId, id);
+    }
+
+    const budgets = await this.readCollection<Budget>(STORAGE_KEYS.BUDGETS);
+    await this.persistCollection(
+      STORAGE_KEYS.BUDGETS,
+      budgets.filter(budget => budget.id !== id)
+    );
+  }
+
   /** The owner's goals. Same branch, same null rule, as `getBudgets` above. */
   async getGoals(): Promise<Goal[]> {
     const userId = this.userIdService.getCurrentDatabaseUserId();
@@ -1732,6 +1844,18 @@ export class DataService {
 
   static getBudgets(): Promise<Budget[]> {
     return this.service.getBudgets();
+  }
+
+  static createBudget(budget: Omit<Budget, 'id' | 'spent'>): Promise<Budget> {
+    return this.service.createBudget(budget);
+  }
+
+  static updateBudget(id: string, updates: Partial<Budget>): Promise<Budget> {
+    return this.service.updateBudget(id, updates);
+  }
+
+  static deleteBudget(id: string): Promise<void> {
+    return this.service.deleteBudget(id);
   }
 
   static getGoals(): Promise<Goal[]> {

--- a/src/services/port/__tests__/contract.ts
+++ b/src/services/port/__tests__/contract.ts
@@ -20,6 +20,9 @@
  *  - the category-merge guards, source before target — the order decides which
  *    sentence the user sees;
  *  - every money movement lands on the penny;
+ *  - a budget survives a create and an edit to the penny, is refused by name
+ *    when it is not there, and is not an error to delete twice — and lands
+ *    under the owner the implementation resolved for itself, never another;
  *  - the reconcile-sweep, dismissal pruning and dismissal idempotence;
  *  - and the DECLARED divergences (D-7, M-1), asserted per engine so that a
  *    difference between implementations is recorded rather than discovered.
@@ -96,6 +99,82 @@ export interface DataPortContractHarness {
    */
   createUnreadable(): Promise<DataPort>;
 }
+
+/**
+ * Every operation the seam names, written out where a RUNTIME check can walk
+ * it.
+ *
+ * WHY A LIST AND NOT THE TYPE. `tsc -b` does not typecheck tests:
+ * tsconfig.app.json excludes every `__tests__` directory and every `.test.ts`
+ * and `.test.tsx` file, and eslint runs without a project. So the `DataPort`
+ * annotation on a test double is documentation, not a proof: a double that
+ * answers half the seam compiles, runs and passes, and the day a real
+ * implementation is swapped in behind those same tests the missing half is a
+ * `TypeError` in front of a user rather than a red line in a diff.
+ *
+ * What the list buys, in the two places it is used:
+ *
+ *  - here, that the engine under test really implements every operation it
+ *    claims to (a contract suite run against a partial port proves nothing);
+ *  - in AppContextBootThroughPort.test.tsx, that the stubbed seam the boot is
+ *    proved against has EXACTLY these keys — no fewer, so an operation cannot
+ *    join the seam while the one test that boots the app on a bare stub keeps
+ *    passing without answering it, and no more, so the stub cannot drift into
+ *    inventing a door the interface does not have.
+ *
+ * It is maintained by hand ON PURPOSE and in the same commit as the interface:
+ * the list is the one place a person adding an operation has to say out loud
+ * that they have added it. Grouped and ordered as `dataPort.ts` groups them, so
+ * the two files can be read side by side.
+ */
+export const DATA_PORT_OPERATIONS: readonly (keyof DataPort)[] = [
+  // Reads
+  'getAccounts',
+  'getClosedAccounts',
+  'getTransactions',
+  'loadBootTransactions',
+  'getAccountBalances',
+  'getAllTransactionSplits',
+  'getTransactionSplits',
+  'getBudgets',
+  'getGoals',
+  'getCategories',
+  'getSuggestionDismissals',
+  // Account writes
+  'createAccount',
+  'updateAccount',
+  'deleteAccount',
+  // Transaction writes
+  'createTransaction',
+  'updateTransaction',
+  'deleteTransaction',
+  'setTransactionsCleared',
+  'applyCategoryToUncategorized',
+  'confirmTransactionCategories',
+  'setTransactionArchived',
+  'archiveTransactionsBefore',
+  'unarchiveAccount',
+  // Transfer writes
+  'linkTransferPair',
+  'linkSplitLineTransfer',
+  'unlinkTransfers',
+  'repairClaimedTransfer',
+  'createTransferCounterpart',
+  // Split writes
+  'setTransactionSplits',
+  // Planning writes
+  'createBudget',
+  'updateBudget',
+  'deleteBudget',
+  'mergeCategories',
+  // Dismissal writes
+  'dismissSuggestion',
+  'restoreSuggestion',
+  // Lifecycle
+  'initialize',
+  'prepareCategories',
+  'subscribeToUpdates'
+];
 
 // ── Declared divergences ────────────────────────────────────────────────────
 // Written as tables rather than as `if (engine === …)` scattered through the
@@ -178,6 +257,22 @@ const PREPARE_CATEGORIES: Record<DataPortEngine, { describes: string; persists: 
   supabase: { describes: 'migrates a set into the account and keeps it', persists: true },
   // Seeds its defaults into the one store it has; nothing to remap, ever.
   'local-core': { describes: 'seeds the defaults into the store', persists: true }
+};
+
+/**
+ * B-3 — what "the owner" is, for an engine being asked to file a write under
+ * one.
+ *
+ * The phrase differs so much between engines that asserting it equal would be
+ * asserting a fiction: browser storage has no concept of an owner, the cloud
+ * has a column and a policy, a device edition has itself. What is asserted
+ * equal is the pair of rules underneath the phrase, and they are the ones that
+ * decide whether somebody's budget survives the night — see the test below.
+ */
+const OWNERSHIP: Record<DataPortEngine, string> = {
+  'browser-storage': 'one store and no owner at all',
+  supabase: 'an owner the implementation resolves, stamped on the row and enforced by RLS',
+  'local-core': 'the device itself'
 };
 
 /**
@@ -273,6 +368,26 @@ const aBudget = (id: string, categoryId: string, amount: number): Budget => ({
   updatedAt: AT('2025-01-01')
 });
 
+/**
+ * A budget as a CALLER supplies one — no id, and no `spent`: what has been
+ * spent against a category is summed from the ledger, so it is never the
+ * caller's to state. The two timestamps are the caller's own (the budget modal
+ * sends them), and every engine is free to stamp its own over them.
+ */
+const aNewBudget = (
+  categoryId: string,
+  amount: number,
+  rest: Partial<Omit<Budget, 'id' | 'spent'>> = {}
+): Omit<Budget, 'id' | 'spent'> => ({
+  categoryId,
+  amount,
+  period: 'monthly',
+  isActive: true,
+  createdAt: AT('2025-01-01'),
+  updatedAt: AT('2025-01-01'),
+  ...rest
+});
+
 const aGoal = (id: string, name: string, targetAmount: number): Goal => ({
   id,
   name,
@@ -310,6 +425,25 @@ export function runDataPortContract(name: string, harness: DataPortContractHarne
   const { engine } = harness;
 
   describe(name, () => {
+    describe('the surface itself', () => {
+      it('answers every operation the seam names', async () => {
+        // The floor under every rule below: a suite run against a port that is
+        // missing operations proves only that the operations it HAS behave.
+        // Nothing else here would notice the absence — an engine under
+        // construction would go green on the half it had finished.
+        //
+        // Not a type check, deliberately. Tests are not compiled by `tsc -b`,
+        // so `implements DataPort` is only checked where the implementation
+        // itself is production code; a harness that assembles its port out of
+        // parts (which a local edition, being two halves, will) gets no such
+        // check at all. This one runs.
+        const { port } = await harness.create({ accounts: threeAccounts() });
+
+        const missing = DATA_PORT_OPERATIONS.filter(operation => typeof port[operation] !== 'function');
+        expect(missing).toEqual([]);
+      });
+    });
+
     describe('accounts', () => {
       it('gives back every field it was given', async () => {
         // The seam's promise about accounts: what the app wrote is what the
@@ -689,6 +823,112 @@ export function runDataPortContract(name: string, harness: DataPortContractHarne
 
         expect((await port.getBudgets())[0].amount).toBe(70.1);
         expect((await port.getGoals())[0].targetAmount).toBe(0.3);
+      });
+    });
+
+    describe('writing a budget', () => {
+      it('round-trips the amount through a create and an edit, to the penny', async () => {
+        // A budget is a limit somebody set on purpose, and the page compares
+        // it against a Decimal sum of real transactions. An engine that stored
+        // it through a float column would put a limit a penny out and then
+        // announce it had been exceeded — 0.1 + 0.2 territory, in a place the
+        // user is watching. `spent` starts at zero in every engine because it
+        // is summed from the ledger, never stored knowledge.
+        const { port } = await harness.create({ accounts: threeAccounts() });
+
+        const created = await port.createBudget(aNewBudget('cat-everyday', 70.1));
+
+        expect(created.id).toBeTruthy();
+        expect(created.amount).toBe(70.1);
+        expect(created.spent).toBe(0);
+        expect((await port.getBudgets()).map(budget => [budget.id, budget.amount]))
+          .toEqual([[created.id, 70.1]]);
+
+        const edited = await port.updateBudget(created.id, { amount: 0.3 });
+
+        // The whole budget comes back, not just the field that moved: the
+        // caller replaces its copy with this answer.
+        expect(edited).toMatchObject({ id: created.id, categoryId: 'cat-everyday', amount: 0.3 });
+        expect((await port.getBudgets())[0].amount).toBe(0.3);
+      });
+
+      it(`B-3: a budget is filed under ${OWNERSHIP[engine]}`, async () => {
+        // Two rules, equal for every engine however it spells "owner".
+        //
+        // FIRST: no operation ACCEPTS an owner. Stated at runtime and not left
+        // to the interface because the interface is only compiled where the
+        // implementation is production code — and it is a partial, hand-built
+        // port that would grow a `(userId, budget)` signature and start
+        // trusting its caller for the one value that must never be trusted.
+        //
+        // SECOND: a write whose owner could not be resolved does not reach
+        // another owner's store. Two isolated stores is the cheapest way to
+        // ask, and it is not a hypothetical failure: the service behind the
+        // cloud branch treats a null owner as "write the browser's copy",
+        // which for a signed-in session is a budget that appears on the page
+        // and is gone by morning.
+        const mine = await harness.create({ accounts: threeAccounts() });
+        const theirs = await harness.create({ accounts: threeAccounts() });
+
+        expect(mine.port.createBudget.length).toBe(1);
+        expect(mine.port.updateBudget.length).toBe(2);
+        expect(mine.port.deleteBudget.length).toBe(1);
+
+        const created = await mine.port.createBudget(aNewBudget('cat-everyday', 200));
+
+        expect((await mine.read()).budgets.map(budget => budget.id)).toEqual([created.id]);
+        expect((await theirs.read()).budgets).toEqual([]);
+        expect(await theirs.port.getBudgets()).toEqual([]);
+      });
+
+      it('refuses to change a budget that is not there, and says which', async () => {
+        // Not created-on-the-fly: an id that names nothing is a bug upstream
+        // (a stale page, a double submit after a delete), and inventing a
+        // budget to satisfy it would put an amount somebody never set on the
+        // budgets page. Rule 4 of the seam — the message is what the user
+        // reads — so it is asserted, not merely the rejection.
+        const { port } = await harness.create({
+          accounts: threeAccounts(),
+          budgets: [aBudget('budget-1', 'cat-everyday', 200)]
+        });
+
+        await expect(port.updateBudget('budget-nowhere', { amount: 300 }))
+          .rejects.toThrow(/budget not found/i);
+      });
+
+      it('leaves the store exactly as it was when it refuses', async () => {
+        // The all-or-nothing rule the splits and the merge already keep, asked
+        // of a planning write: everything is judged before anything is
+        // written, so a refusal is never a half-applied edit.
+        const { port, read } = await harness.create({
+          accounts: threeAccounts(),
+          budgets: [aBudget('budget-1', 'cat-everyday', 200)],
+          goals: [aGoal('goal-1', 'New boiler', 1500)]
+        });
+        const before = asComparable(await read());
+
+        await expect(port.updateBudget('budget-nowhere', { amount: 300 })).rejects.toThrow();
+
+        expect(asComparable(await read())).toBe(before);
+      });
+
+      it('treats deleting a budget that has already gone as done, not as an error', async () => {
+        // Same rule as a dismissal: a double-click, or a second device that
+        // got there first, must not turn a decision into an error message.
+        // Idempotence is the point — the second call is not a test of the
+        // first, it is the case a slow network actually produces.
+        const { port, read } = await harness.create({
+          accounts: threeAccounts(),
+          budgets: [aBudget('budget-1', 'cat-everyday', 200)]
+        });
+
+        await expect(port.deleteBudget('budget-nowhere')).resolves.toBeUndefined();
+        expect((await read()).budgets.map(budget => budget.id)).toEqual(['budget-1']);
+
+        await port.deleteBudget('budget-1');
+        await port.deleteBudget('budget-1');
+
+        expect((await read()).budgets).toEqual([]);
       });
     });
 

--- a/src/services/port/__tests__/dataService.contract.test.ts
+++ b/src/services/port/__tests__/dataService.contract.test.ts
@@ -75,19 +75,28 @@ const createStore = (fixture: PortFixture) => {
  *
  * That is the whole point of it. The harness declares `engine:
  * 'browser-storage'`, and this is what makes the declaration checkable: if a
- * routing change ever sent one of these reads down the cloud branch, the
+ * routing change ever sent one of these operations down the cloud branch, the
  * contract suite would stop describing the engine it claims to describe. A
  * double that quietly answered would let that happen in silence; this one
- * fails, by name, on the read that strayed.
+ * fails, by name, on the call that strayed.
+ *
+ * The WRITES matter here more than the reads: a budget write that took the
+ * cloud branch under a harness with no cloud would not merely answer wrongly,
+ * it would leave the store this suite then asserts against untouched — a
+ * failure that reads like a broken assertion rather than a broken route. This
+ * makes it say which call went the wrong way.
  */
 const refusingPlanningService = () => {
   const refuse = async (): Promise<never> => {
     throw new Error(
-      'The browser-storage engine must not reach PlanningService — this read took the cloud branch'
+      'The browser-storage engine must not reach PlanningService — this call took the cloud branch'
     );
   };
   return {
     mergeCategories: vi.fn(refuse),
+    createBudget: vi.fn(refuse),
+    updateBudget: vi.fn(refuse),
+    deleteBudget: vi.fn(refuse),
     getBudgets: vi.fn(refuse),
     getGoals: vi.fn(refuse),
     ensureCategories: vi.fn(refuse)

--- a/src/services/port/dataPort.ts
+++ b/src/services/port/dataPort.ts
@@ -42,7 +42,7 @@
  *
  * This is the seam as it stands, not as it will end: the operations below are
  * exactly the ones DataService owns today, under the names it uses today.
- * Planning writes (budgets/goals/categories, which still bypass to
+ * The remaining planning writes (goals and categories, which still bypass to
  * PlanningService), bulk import, backup/restore/wipe, and the capability
  * descriptor that will retire `isUsingSupabase` all join this interface as
  * their consumers are routed through it. The names here are today's names
@@ -291,6 +291,57 @@ export interface DataPortSplitWrites {
 }
 
 export interface DataPortPlanningWrites {
+  /**
+   * Create a budget: an amount against a category, for a period.
+   *
+   * `spent` is not supplied because it is not stored knowledge — it is the sum
+   * of the rows filed under that category in the period, recomputed from the
+   * ledger — so a new budget starts at zero in every implementation.
+   *
+   * ── OWNERSHIP (divergence B-3) ──────────────────────────────────────────
+   *
+   * Rule 1 of this seam (no operation takes a user id) is load-bearing HERE in
+   * a way it is not for a read, and this is the paragraph that says why.
+   *
+   * The service the cloud branch delegates to takes `(userId, budget)` and
+   * treats a null id as "write the browser's copy instead". It does not throw,
+   * does not warn, and hands back an ordinary Budget. So a caller that let an
+   * unresolved id through would watch a signed-in person create a budget, see
+   * it appear on the page, and find it gone at the next boot — because the
+   * READ beside it goes to the cloud, where the row never landed. Nothing
+   * anywhere says a word. That is silent, permanent, user-visible data loss,
+   * and the only defence that actually holds is making the mistake
+   * unrepresentable: the owner is resolved INSIDE the implementation, on the
+   * same tick as the write.
+   *
+   * What "the owner" means is allowed to differ — browser storage has one
+   * store and no owner at all, the cloud stamps the row and RLS enforces it, a
+   * local core is the device — and that is declared as B-3 in the contract
+   * suite. What may NOT differ: no operation accepts an owner, and a write
+   * whose owner could not be resolved must never land in another owner's
+   * store.
+   */
+  createBudget(budget: Omit<Budget, 'id' | 'spent'>): Promise<Budget>;
+  /**
+   * Change a budget, and hand back the whole budget as it now stands (the
+   * caller replaces its copy with this, so a partial answer would blank the
+   * fields it left out).
+   *
+   * A budget that is not there is refused BY NAME rather than created, and the
+   * refusal leaves the store exactly as it was — the same all-or-nothing rule
+   * the splits and the merge keep.
+   */
+  updateBudget(id: string, updates: Partial<Budget>): Promise<Budget>;
+  /**
+   * Remove a budget.
+   *
+   * A real delete, not the soft close an account gets: a budget holds no money
+   * and nothing is filed against it, so removing one leaves no hole in the
+   * ledger. Removing one that is already gone is a NO-OP, not an error — a
+   * double-click, or a second device that got there first, must not turn a
+   * decision into an error message (the same rule `dismissSuggestion` keeps).
+   */
+  deleteBudget(id: string): Promise<void>;
   /**
    * Move every reference from one category to another, then remove the source.
    * All-or-nothing, and the refusals are ordered: the source is judged before


### PR DESCRIPTION
Slice 5a of the write-paths plan, plus its mandatory step 0.

- **Step 0 closes N-1**: `tsc -b` never typechecks tests, so the boot stub's "stops compiling" guarantee was false. `DATA_PORT_OPERATIONS` + two runtime assertions make the port's surface a runtime fact; mutation-proven (an operation added without teaching the stub goes red). Bonus fact surfaced by the mutation: production was already compile-guarded via the static class — the stub was the only hole.
- **Budget writes cross the seam**: cloud delegates to PlanningService with the resolved owner (error messages reach modals verbatim); local branch mirrors the original field-for-field on injected storage, preserving every asymmetry deliberately (cloud-only start-date default stays cloud-only). Context call sites change only their call expressions.
- **The gate test (W-1)**: each operation asserted called with the resolved database id and **never null** — the null mutation leaves `tsc` green and turns exactly this test red, which is why the test exists. Paired local-mode tests assert PlanningService is untouched and the local store took the write.
- Contract 46 → 52 (B-3 ownership divergence table; round-trip to the penny through create and edit; refused writes leave the store byte-identical; delete-missing is an idempotent no-op).
- **Browser-verified in demo mode on a clean store**: create → card renders; edit → survives at the new figure; delete → gone. (An earlier repro scare traced to cross-run IndexedDB pollution between baseline and slice runs, not to the slice.)
- No `guardCloudWrite` in this diff (that is 5d, reviewed as a change); fire-and-forget modal sites untouched (N-5).

Gate: lint · strict tsc · smoke 4,772 · realtime 11/11 · build · bundle +0.1 KB gz vs recorded baseline (ratchet red predates slice 1) · coverage 74.70/81.00 vs 63/55.

🤖 Generated with [Claude Code](https://claude.com/claude-code)