### PR TITLE
feat(seam): slice 5d — pending-session writes are refused, not quietly lost

### DIFF
--- a/src/contexts/AppContextSupabase.tsx
+++ b/src/contexts/AppContextSupabase.tsx
@@ -1393,9 +1393,9 @@ export function AppProvider({ children }: { children: React.ReactNode }) {
   // a sign-out in another tab, a token that expired between the groups insert
   // and the details insert. The old shape carried on writing under the id it
   // captured, into a login that is no longer signed in. The new one resolves
-  // nothing, and the write goes to browser storage instead; once the pending-
-  // session guard lands it refuses outright, which is the answer this import
-  // wants — half a tree in the right account beats a whole one in the wrong.
+  // nothing, and the pending-session guard refuses the rest of the import
+  // outright — which is the answer this import wants: half a tree in the right
+  // account beats a whole one in the wrong.
   const importCategoryTree = useCallback(async (
     tree: CategoryTreeGroup[],
     options?: { pruneOthers?: boolean }

--- a/src/services/__tests__/dataService.test.ts
+++ b/src/services/__tests__/dataService.test.ts
@@ -29,6 +29,47 @@ const baseAccount = (overrides: Partial<Account> = {}): Account => ({
   ...overrides
 });
 
+/**
+ * The sentence a write refuses with while a signed-in session is still
+ * resolving its database id — the one every other write on the class already
+ * uses.
+ *
+ * Written out in full, and compared in full, because it is what the person
+ * reads. `rejects.toThrow('…')` matches a SUBSTRING, so it would stay green on
+ * "Failed to save budget: Still connecting…" — exactly the wrapping the seam
+ * forbids, since a sentence that says only that something went wrong is not
+ * one anybody can act on.
+ */
+const STILL_CONNECTING = 'Still connecting to your account — please try again in a moment.';
+
+/** The whole refusal, or a sentence saying there wasn't one. */
+const refusalMessage = async (write: Promise<unknown>): Promise<string> => {
+  try {
+    await write;
+    return 'the write was not refused';
+  } catch (error) {
+    return error instanceof Error ? error.message : String(error);
+  }
+};
+
+/**
+ * A signed-in (Clerk) session whose database user id has not resolved yet —
+ * still connecting, or resolution failed. The state the guard is about.
+ */
+const pendingUserIdService = () => ({
+  ensureUserExists: vi.fn(),
+  getCurrentDatabaseUserId: vi.fn(() => null),
+  getCurrentUserIds: vi.fn(() => ({ clerkId: 'clerk-user-1', databaseId: null }))
+});
+
+/**
+ * A comparable picture of one stored collection, for "the refusal changed
+ * nothing at all" — the contract suite's `asComparable`, narrowed to the store
+ * a planning write could have touched.
+ */
+const asComparable = (storage: ReturnType<typeof createStorage>, key: string): string =>
+  JSON.stringify(storage.snapshot(key) ?? null);
+
 const baseTransaction = (overrides: Partial<Transaction> = {}): Transaction => ({
   id: 'txn-1',
   accountId: 'acct-1',
@@ -333,6 +374,25 @@ describe('DataService (deterministic fallback)', () => {
         }
       });
 
+    /** The same session one step earlier: signed in, database id not resolved. */
+    const stillConnecting = (
+      planningService: ReturnType<typeof cloudPlanningService>,
+      storage: ReturnType<typeof createStorage>
+    ) =>
+      createDataService({
+        isSupabaseConfigured: () => true,
+        hasCloudSession: () => true,
+        planningService,
+        storageAdapter: storage,
+        logger,
+        uuid,
+        now,
+        userIdService: pendingUserIdService()
+      });
+
+    /** A budget already in the browser's copy, so "nothing changed" has something to say. */
+    const storedBudget = { id: 'budget-already-here', categoryId: 'cat-everyday', amount: 200, spent: 0 };
+
     it('creates a budget under the resolved database id, and never under null', async () => {
       const planningService = cloudPlanningService();
       const storage = createStorage({ [STORAGE_KEYS.BUDGETS]: [] });
@@ -431,6 +491,66 @@ describe('DataService (deterministic fallback)', () => {
       expect(planningService.updateBudget).not.toHaveBeenCalled();
       expect(planningService.deleteBudget).not.toHaveBeenCalled();
     });
+
+    // THE DELIBERATE BEHAVIOUR CHANGE, one test per operation, here and in the
+    // goal and category blocks below.
+    //
+    // A signed-in session whose database id has not resolved yet — the seconds
+    // after a boot, or a resolution that failed outright — used to fall through
+    // to the local branch, because neither half of `userId && configured` is a
+    // refusal on its own. The budget landed in browser storage, the modal
+    // showed it as saved, and it was gone at the next boot: the read beside it
+    // goes to the cloud, where the row never was. Nothing threw and nothing
+    // logged, so there was no way to even know it had happened.
+    //
+    // Now the write refuses, in words the person can act on twenty seconds
+    // later — and refuses BEFORE reading or writing the store, so there is
+    // nothing half-done left behind either. That second half is what the
+    // byte-identical check below is for.
+
+    it('refuses to create a budget while the session is still resolving, and writes nothing', async () => {
+      const planningService = cloudPlanningService();
+      const storage = createStorage({ [STORAGE_KEYS.BUDGETS]: [storedBudget] });
+      const service = stillConnecting(planningService, storage);
+      const before = asComparable(storage, STORAGE_KEYS.BUDGETS);
+
+      expect(await refusalMessage(service.createBudget(budgetInput()))).toBe(STILL_CONNECTING);
+
+      // Refused, not re-routed: neither store was asked to take it.
+      expect(planningService.createBudget).not.toHaveBeenCalled();
+      expect(storage.set).not.toHaveBeenCalled();
+      expect(asComparable(storage, STORAGE_KEYS.BUDGETS)).toBe(before);
+    });
+
+    it('refuses to update a budget while the session is still resolving, and writes nothing', async () => {
+      const planningService = cloudPlanningService();
+      const storage = createStorage({ [STORAGE_KEYS.BUDGETS]: [storedBudget] });
+      const service = stillConnecting(planningService, storage);
+      const before = asComparable(storage, STORAGE_KEYS.BUDGETS);
+
+      expect(await refusalMessage(service.updateBudget('budget-already-here', { amount: 70.1 })))
+        .toBe(STILL_CONNECTING);
+
+      expect(planningService.updateBudget).not.toHaveBeenCalled();
+      expect(storage.set).not.toHaveBeenCalled();
+      expect(asComparable(storage, STORAGE_KEYS.BUDGETS)).toBe(before);
+    });
+
+    it('refuses to delete a budget while the session is still resolving, and writes nothing', async () => {
+      // The delete is the one where falling through was worst: the local branch
+      // would have removed a budget from the browser's copy that the cloud —
+      // the store this session is about to read from — still has.
+      const planningService = cloudPlanningService();
+      const storage = createStorage({ [STORAGE_KEYS.BUDGETS]: [storedBudget] });
+      const service = stillConnecting(planningService, storage);
+      const before = asComparable(storage, STORAGE_KEYS.BUDGETS);
+
+      expect(await refusalMessage(service.deleteBudget('budget-already-here'))).toBe(STILL_CONNECTING);
+
+      expect(planningService.deleteBudget).not.toHaveBeenCalled();
+      expect(storage.set).not.toHaveBeenCalled();
+      expect(asComparable(storage, STORAGE_KEYS.BUDGETS)).toBe(before);
+    });
   });
 
   describe('goal writes', () => {
@@ -499,6 +619,30 @@ describe('DataService (deterministic fallback)', () => {
           getCurrentUserIds: vi.fn(() => ({ clerkId: 'clerk-user-1', databaseId: 'db-user-1' }))
         }
       });
+
+    /** The same session one step earlier: signed in, database id not resolved. */
+    const stillConnecting = (
+      planningService: ReturnType<typeof cloudPlanningService>,
+      storage: ReturnType<typeof createStorage>
+    ) =>
+      createDataService({
+        isSupabaseConfigured: () => true,
+        hasCloudSession: () => true,
+        planningService,
+        storageAdapter: storage,
+        logger,
+        uuid,
+        now,
+        userIdService: pendingUserIdService()
+      });
+
+    /** A goal already in the browser's copy, so "nothing changed" has something to say. */
+    const storedGoal = {
+      id: 'goal-already-here',
+      name: 'New boiler',
+      targetAmount: 1500,
+      progress: 250.05
+    };
 
     it('creates a goal under the resolved database id, and never under null', async () => {
       const planningService = cloudPlanningService();
@@ -603,6 +747,55 @@ describe('DataService (deterministic fallback)', () => {
       expect(planningService.updateGoal).not.toHaveBeenCalled();
       expect(planningService.deleteGoal).not.toHaveBeenCalled();
     });
+
+    // The behaviour change, operation for operation. The budget block above
+    // argues it; a goal loses the same way, and the update carries a
+    // contribution, so a fall-through would bank real money in a store the next
+    // boot never reads.
+
+    it('refuses to create a goal while the session is still resolving, and writes nothing', async () => {
+      const planningService = cloudPlanningService();
+      const storage = createStorage({ [STORAGE_KEYS.GOALS]: [storedGoal] });
+      const service = stillConnecting(planningService, storage);
+      const before = asComparable(storage, STORAGE_KEYS.GOALS);
+
+      expect(await refusalMessage(service.createGoal(goalInput()))).toBe(STILL_CONNECTING);
+
+      expect(planningService.createGoal).not.toHaveBeenCalled();
+      expect(storage.set).not.toHaveBeenCalled();
+      expect(asComparable(storage, STORAGE_KEYS.GOALS)).toBe(before);
+    });
+
+    it('refuses to update a goal while the session is still resolving, and writes nothing', async () => {
+      // Including the update that IS a contribution: £250 put towards the
+      // boiler, banked in the browser's copy and gone by morning, is money the
+      // person believes they have set aside.
+      const planningService = cloudPlanningService();
+      const storage = createStorage({ [STORAGE_KEYS.GOALS]: [storedGoal] });
+      const service = stillConnecting(planningService, storage);
+      const before = asComparable(storage, STORAGE_KEYS.GOALS);
+
+      expect(await refusalMessage(
+        service.updateGoal('goal-already-here', { progress: 500.05, currentAmount: 500.05 })
+      )).toBe(STILL_CONNECTING);
+
+      expect(planningService.updateGoal).not.toHaveBeenCalled();
+      expect(storage.set).not.toHaveBeenCalled();
+      expect(asComparable(storage, STORAGE_KEYS.GOALS)).toBe(before);
+    });
+
+    it('refuses to delete a goal while the session is still resolving, and writes nothing', async () => {
+      const planningService = cloudPlanningService();
+      const storage = createStorage({ [STORAGE_KEYS.GOALS]: [storedGoal] });
+      const service = stillConnecting(planningService, storage);
+      const before = asComparable(storage, STORAGE_KEYS.GOALS);
+
+      expect(await refusalMessage(service.deleteGoal('goal-already-here'))).toBe(STILL_CONNECTING);
+
+      expect(planningService.deleteGoal).not.toHaveBeenCalled();
+      expect(storage.set).not.toHaveBeenCalled();
+      expect(asComparable(storage, STORAGE_KEYS.GOALS)).toBe(before);
+    });
   });
 
   describe('category writes', () => {
@@ -683,6 +876,35 @@ describe('DataService (deterministic fallback)', () => {
         now,
         userIdService: ids
       });
+
+    /** The same session one step earlier: signed in, database id not resolved. */
+    const stillConnecting = (
+      planningService: ReturnType<typeof cloudPlanningService>,
+      storage: ReturnType<typeof createStorage>
+    ) =>
+      createDataService({
+        isSupabaseConfigured: () => true,
+        hasCloudSession: () => true,
+        planningService,
+        storageAdapter: storage,
+        logger,
+        uuid,
+        now,
+        userIdService: pendingUserIdService()
+      });
+
+    /** A group and its child, already in the browser's copy. */
+    const storedCategories = [
+      { id: 'cat-group', name: 'Motoring', type: 'expense', level: 'sub', isActive: true },
+      {
+        id: 'cat-child',
+        name: 'Fuel',
+        type: 'expense',
+        level: 'detail',
+        parentId: 'cat-group',
+        isActive: true
+      }
+    ];
 
     it('creates a category under the resolved database id, and never under null', async () => {
       const planningService = cloudPlanningService();
@@ -869,6 +1091,95 @@ describe('DataService (deterministic fallback)', () => {
       // One asked for, and it took its child with it: two actually went.
       await expect(service.deleteUnusedCategories(['cat-group'])).resolves.toBe(2);
       expect(await service.getCategories()).toEqual([]);
+    });
+
+    // The behaviour change on all five category writes — and the asymmetry that
+    // has to survive review. `prepareCategories` deliberately has NO pending
+    // gate, because a category list is not money: serving the browser's copy of
+    // the NAMES to a session still resolving its id costs nothing, and
+    // withholding them would blank the register's category column for no gain.
+    // That argument does not reach a WRITE. A write mints an id in a store the
+    // cloud will never hear about; the person names "Fuel", files three
+    // transactions under that id, and finds all three uncategorised in the
+    // morning. Reading names and writing rows are different questions, and
+    // making the two "consistent" in either direction breaks one of them.
+
+    it('refuses to create a category while the session is still resolving, and writes nothing', async () => {
+      const planningService = cloudPlanningService();
+      const storage = createStorage({ [STORAGE_KEYS.CATEGORIES]: storedCategories });
+      const service = stillConnecting(planningService, storage);
+      const before = asComparable(storage, STORAGE_KEYS.CATEGORIES);
+
+      expect(await refusalMessage(service.createCategory(categoryInput()))).toBe(STILL_CONNECTING);
+
+      expect(planningService.createCategory).not.toHaveBeenCalled();
+      expect(storage.set).not.toHaveBeenCalled();
+      expect(asComparable(storage, STORAGE_KEYS.CATEGORIES)).toBe(before);
+    });
+
+    it('refuses a bulk create while the session is still resolving, and writes nothing', async () => {
+      const planningService = cloudPlanningService();
+      const storage = createStorage({ [STORAGE_KEYS.CATEGORIES]: storedCategories });
+      const service = stillConnecting(planningService, storage);
+      const before = asComparable(storage, STORAGE_KEYS.CATEGORIES);
+
+      expect(await refusalMessage(
+        service.createCategories([categoryInput({ name: 'Parking' })])
+      )).toBe(STILL_CONNECTING);
+
+      expect(planningService.createCategories).not.toHaveBeenCalled();
+      expect(storage.set).not.toHaveBeenCalled();
+      expect(asComparable(storage, STORAGE_KEYS.CATEGORIES)).toBe(before);
+
+      // And the empty case still asks nobody and refuses nobody: there is no
+      // write to lose, so an error message here would be about nothing.
+      await expect(service.createCategories([])).resolves.toEqual([]);
+      await expect(service.deleteUnusedCategories([])).resolves.toBe(0);
+    });
+
+    it('refuses to update a category while the session is still resolving, and writes nothing', async () => {
+      const planningService = cloudPlanningService();
+      const storage = createStorage({ [STORAGE_KEYS.CATEGORIES]: storedCategories });
+      const service = stillConnecting(planningService, storage);
+      const before = asComparable(storage, STORAGE_KEYS.CATEGORIES);
+
+      expect(await refusalMessage(service.updateCategory('cat-child', { name: 'Petrol' })))
+        .toBe(STILL_CONNECTING);
+
+      expect(planningService.updateCategory).not.toHaveBeenCalled();
+      expect(storage.set).not.toHaveBeenCalled();
+      expect(asComparable(storage, STORAGE_KEYS.CATEGORIES)).toBe(before);
+    });
+
+    it('refuses to delete a category while the session is still resolving, and writes nothing', async () => {
+      // A delete that fell through took the group's children with it — out of
+      // the browser's copy only, while the cloud kept all three. The next boot
+      // would put them straight back, so the person deletes twice and believes
+      // the app is ignoring them.
+      const planningService = cloudPlanningService();
+      const storage = createStorage({ [STORAGE_KEYS.CATEGORIES]: storedCategories });
+      const service = stillConnecting(planningService, storage);
+      const before = asComparable(storage, STORAGE_KEYS.CATEGORIES);
+
+      expect(await refusalMessage(service.deleteCategory('cat-group'))).toBe(STILL_CONNECTING);
+
+      expect(planningService.deleteCategory).not.toHaveBeenCalled();
+      expect(storage.set).not.toHaveBeenCalled();
+      expect(asComparable(storage, STORAGE_KEYS.CATEGORIES)).toBe(before);
+    });
+
+    it('refuses a prune while the session is still resolving, and writes nothing', async () => {
+      const planningService = cloudPlanningService();
+      const storage = createStorage({ [STORAGE_KEYS.CATEGORIES]: storedCategories });
+      const service = stillConnecting(planningService, storage);
+      const before = asComparable(storage, STORAGE_KEYS.CATEGORIES);
+
+      expect(await refusalMessage(service.deleteUnusedCategories(['cat-group', 'cat-child'])))
+        .toBe(STILL_CONNECTING);
+
+      expect(planningService.deleteUnusedCategories).not.toHaveBeenCalled();
+      expect(storage.set).not.toHaveBeenCalled();
+      expect(asComparable(storage, STORAGE_KEYS.CATEGORIES)).toBe(before);
     });
   });
 

--- a/src/services/api/dataService.ts
+++ b/src/services/api/dataService.ts
@@ -1512,19 +1512,22 @@ class DataServiceImpl implements DataPort {
    * copy has never carried either — inventing them here would change what
    * every existing local budget looks like on the page.
    *
-   * AND ONE OMISSION, ALSO DELIBERATE: the three budget writes do not yet
-   * refuse a session whose database id is still resolving, the way every other
-   * write on this class does. Today such a write goes to browser storage, and
-   * today is what this branch reproduces. Refusing it is the better behaviour
-   * and it is coming — as its own change, with its own tests and its own
-   * sentence for the user, because a behaviour change hidden inside a routing
-   * change is one nobody can review.
+   * AND BETWEEN THE TWO BRANCHES, A REFUSAL RATHER THAN A ROUTE. A signed-in
+   * session whose database id has not resolved yet belongs to neither: the
+   * cloud branch has no owner to write under, and the local branch would put
+   * this budget in the browser's copy, show it as saved, and lose it at the
+   * next boot — when the cloud read beside it answers instead, from a store the
+   * row never reached. Nothing throws, nothing logs, and there is no way back.
+   * So the guard refuses, in the same sentence every other write on this class
+   * already uses: still connecting is both true and something the person can
+   * act on twenty seconds later, which silent loss never was.
    */
   async createBudget(budget: Omit<Budget, 'id' | 'spent'>): Promise<Budget> {
     const userId = this.userIdService.getCurrentDatabaseUserId();
     if (userId && this.supabaseChecker()) {
       return this.planningService.createBudget(userId, budget);
     }
+    this.guardCloudWrite();
 
     const created: Budget = {
       ...budget,
@@ -1543,16 +1546,17 @@ class DataServiceImpl implements DataPort {
    * caller replaces its copy with this answer, so a partial one would blank
    * whatever it left out.
    *
-   * Same branch and same owner rule as `createBudget` above. A budget that is
-   * not there is refused by name rather than created, and because the lookup
-   * happens before the first write, the refusal leaves the store exactly as it
-   * was.
+   * Same branch, same owner rule and same pending-session refusal as
+   * `createBudget` above. A budget that is not there is refused by name rather
+   * than created, and because the lookup happens before the first write, the
+   * refusal leaves the store exactly as it was.
    */
   async updateBudget(id: string, updates: Partial<Budget>): Promise<Budget> {
     const userId = this.userIdService.getCurrentDatabaseUserId();
     if (userId && this.supabaseChecker()) {
       return this.planningService.updateBudget(userId, id, updates);
     }
+    this.guardCloudWrite();
 
     const budgets = await this.readCollection<Budget>(STORAGE_KEYS.BUDGETS);
     const index = budgets.findIndex(budget => budget.id === id);
@@ -1569,15 +1573,19 @@ class DataServiceImpl implements DataPort {
   /**
    * Remove a budget.
    *
-   * Same branch and same owner rule as the two above. Deleting one that is not
-   * there is a silent no-op in both modes — a double-click, or a second device
-   * that got there first, must not turn a decision into an error message.
+   * Same branch, same owner rule and same pending-session refusal as the two
+   * above. Deleting one that is not there is a silent no-op in both modes — a
+   * double-click, or a second device that got there first, must not turn a
+   * decision into an error message. A session still resolving its id is a
+   * different thing entirely: the delete has not happened yet, so saying so is
+   * the honest answer rather than a noise.
    */
   async deleteBudget(id: string): Promise<void> {
     const userId = this.userIdService.getCurrentDatabaseUserId();
     if (userId && this.supabaseChecker()) {
       return this.planningService.deleteBudget(userId, id);
     }
+    this.guardCloudWrite();
 
     const budgets = await this.readCollection<Budget>(STORAGE_KEYS.BUDGETS);
     await this.persistCollection(
@@ -1614,16 +1622,17 @@ class DataServiceImpl implements DataPort {
    * differently in each half (banked in the browser's copy, thrown away in the
    * cloud), which is precisely the kind of difference this seam exists to stop.
    *
-   * The pending-session omission noted on `createBudget` is deliberate here
-   * too, and for the same reason: a write whose database id is still resolving
-   * still goes to browser storage today, and a behaviour change hidden inside a
-   * routing change is one nobody can review.
+   * The pending-session refusal argued on `createBudget` applies here word for
+   * word: a session whose database id has not resolved yet reaches neither
+   * branch, because the browser's copy is a place this goal would be shown as
+   * saved and then lost.
    */
   async createGoal(goal: Omit<Goal, 'id' | 'progress'>): Promise<Goal> {
     const userId = this.userIdService.getCurrentDatabaseUserId();
     if (userId && this.supabaseChecker()) {
       return this.planningService.createGoal(userId, goal);
     }
+    this.guardCloudWrite();
 
     const created: Goal = {
       ...goal,
@@ -1640,10 +1649,10 @@ class DataServiceImpl implements DataPort {
   /**
    * Change a goal, and hand back the whole goal as it now stands.
    *
-   * Same branch and same owner rule as `createGoal` above. A goal that is not
-   * there is refused by name rather than created, and because the lookup
-   * happens before the first write, the refusal leaves the store exactly as it
-   * was.
+   * Same branch, same owner rule and same pending-session refusal as
+   * `createGoal` above. A goal that is not there is refused by name rather than
+   * created, and because the lookup happens before the first write, the refusal
+   * leaves the store exactly as it was.
    *
    * This is also how money is put towards a goal: the contribution arrives as
    * an update carrying the new `progress`, already summed and already capped
@@ -1656,6 +1665,7 @@ class DataServiceImpl implements DataPort {
     if (userId && this.supabaseChecker()) {
       return this.planningService.updateGoal(userId, id, updates);
     }
+    this.guardCloudWrite();
 
     const goals = await this.readCollection<Goal>(STORAGE_KEYS.GOALS);
     const index = goals.findIndex(goal => goal.id === id);
@@ -1672,15 +1682,17 @@ class DataServiceImpl implements DataPort {
   /**
    * Remove a goal.
    *
-   * Same branch and same owner rule as the two above, and the same silence when
-   * it is already gone. The goal's trophy is forgotten by the caller that owns
-   * the celebration, not here.
+   * Same branch, same owner rule and same pending-session refusal as the two
+   * above, and the same silence when it is already gone. The goal's trophy is
+   * forgotten by the caller that owns the celebration, not here — and because a
+   * refused delete rejects, that caller never gets as far as forgetting it.
    */
   async deleteGoal(id: string): Promise<void> {
     const userId = this.userIdService.getCurrentDatabaseUserId();
     if (userId && this.supabaseChecker()) {
       return this.planningService.deleteGoal(userId, id);
     }
+    this.guardCloudWrite();
 
     const goals = await this.readCollection<Goal>(STORAGE_KEYS.GOALS);
     await this.persistCollection(
@@ -1717,16 +1729,34 @@ class DataServiceImpl implements DataPort {
    * other local write here uses, identical in a browser, with a fallback where
    * that API is missing instead of a throw.
    *
-   * The pending-session omission noted on `createBudget` is deliberate here too:
-   * a write whose database id is still resolving goes to browser storage today,
-   * and a behaviour change hidden inside a routing change is one nobody can
-   * review.
+   * The pending-session refusal argued on `createBudget` applies to all five
+   * category writes, and the comment beside the guard below says why the one
+   * exception on this class does not reach them.
    */
   async createCategory(category: Omit<Category, 'id'>): Promise<Category> {
     const userId = this.userIdService.getCurrentDatabaseUserId();
     if (userId && this.supabaseChecker()) {
       return this.planningService.createCategory(userId, category);
     }
+    // THIS GUARD IS NOT THE ASYMMETRY IT LOOKS LIKE, and it is here on all five
+    // category writes even though `prepareCategories` below deliberately has no
+    // gate at all. Reading names and writing rows are different questions.
+    //
+    // What that exception says is that a category LIST is not money: serving
+    // the browser's copy of the names to a session still resolving its id costs
+    // nothing, because that copy is the very list the account's own was
+    // migrated from, and withholding it would blank the register's category
+    // column for no gain.
+    //
+    // A category WRITE is the opposite trade. It does not read a list that
+    // already agrees with the cloud's — it MINTS AN ID, in a store the cloud
+    // will never hear about. The person names "Fuel", files three transactions
+    // under the id the browser's copy just gave them, and at the next boot the
+    // cloud's category list answers instead: the category is not there, and
+    // neither is the filing of those three rows. That is money mis-filed, by a
+    // list of words. So the read stays ungated and the writes refuse, and
+    // making the two "consistent" in either direction breaks one of them.
+    this.guardCloudWrite();
 
     const created: Category = { ...category, id: this.generateId() };
     const categories = await this.readCollection<Category>(STORAGE_KEYS.CATEGORIES);
@@ -1743,8 +1773,10 @@ class DataServiceImpl implements DataPort {
    * anyway, because the plan is computed before it is known to be empty. Nothing
    * is written, nothing is read, and no insert with no rows is sent.
    *
-   * Otherwise the same branch as `createCategory` above, and the same reason the
-   * cloud half is delegated rather than copied.
+   * Otherwise the same branch as `createCategory` above, the same reason the
+   * cloud half is delegated rather than copied, and the same pending-session
+   * refusal — which the empty check still precedes, because refusing to write
+   * nothing would be an error message about a write nobody asked for.
    */
   async createCategories(newCategories: Array<Omit<Category, 'id'>>): Promise<Category[]> {
     if (newCategories.length === 0) {
@@ -1755,6 +1787,7 @@ class DataServiceImpl implements DataPort {
     if (userId && this.supabaseChecker()) {
       return this.planningService.createCategories(userId, newCategories);
     }
+    this.guardCloudWrite();
 
     const created: Category[] = newCategories.map(category => ({
       ...category,
@@ -1770,9 +1803,10 @@ class DataServiceImpl implements DataPort {
    * caller replaces its copy with this answer, so a partial one would blank
    * whatever it left out.
    *
-   * Same branch and same owner rule as `createCategory` above. A category that
-   * is not there is refused by name, and because the lookup happens before the
-   * first write the refusal leaves the store exactly as it was.
+   * Same branch, same owner rule and same pending-session refusal as
+   * `createCategory` above. A category that is not there is refused by name,
+   * and because the lookup happens before the first write the refusal leaves
+   * the store exactly as it was.
    *
    * No timestamp is stamped, unlike the budget and goal updates beside it: a
    * Category carries none. Inventing one here would put a field on half the
@@ -1783,6 +1817,7 @@ class DataServiceImpl implements DataPort {
     if (userId && this.supabaseChecker()) {
       return this.planningService.updateCategory(userId, id, updates);
     }
+    this.guardCloudWrite();
 
     const categories = await this.readCollection<Category>(STORAGE_KEYS.CATEGORIES);
     const index = categories.findIndex(category => category.id === id);
@@ -1799,10 +1834,11 @@ class DataServiceImpl implements DataPort {
   /**
    * Remove a category and the categories under it.
    *
-   * Same branch and same owner rule as the writes above. THE CASCADE IS THE
-   * BEHAVIOUR, not a detail of the cloud's foreign key: the local branch drops
-   * children by `parentId` exactly as `ON DELETE CASCADE` does server-side, so a
-   * group cannot outlive itself as a set of orphans whose parent is gone.
+   * Same branch, same owner rule and same pending-session refusal as the writes
+   * above. THE CASCADE IS THE BEHAVIOUR, not a detail of the cloud's foreign
+   * key: the local branch drops children by `parentId` exactly as `ON DELETE
+   * CASCADE` does server-side, so a group cannot outlive itself as a set of
+   * orphans whose parent is gone.
    *
    * Deleting one that is already gone writes the list back unchanged, which is
    * the same silence the budget and goal deletes keep.
@@ -1812,6 +1848,7 @@ class DataServiceImpl implements DataPort {
     if (userId && this.supabaseChecker()) {
       return this.planningService.deleteCategory(userId, id);
     }
+    this.guardCloudWrite();
 
     const categories = await this.readCollection<Category>(STORAGE_KEYS.CATEGORIES);
     await this.persistCollection(
@@ -1823,11 +1860,12 @@ class DataServiceImpl implements DataPort {
   /**
    * Prune a batch of categories nothing is filed against.
    *
-   * Empty first, for the reason `createCategories` above gives. Then the same
-   * branch, and the same delegation of the cloud half — which here is doing
-   * more than caching: the RPC re-judges every row against the ledger as it is
-   * NOW, so a plan computed from a stale snapshot can never destroy referenced
-   * data, and it may therefore delete FEWER rows than it was handed.
+   * Empty first, for the reason `createCategories` above gives — and the
+   * pending-session refusal sits after it there for the same reason. Then the
+   * same branch, and the same delegation of the cloud half — which here is
+   * doing more than caching: the RPC re-judges every row against the ledger as
+   * it is NOW, so a plan computed from a stale snapshot can never destroy
+   * referenced data, and it may therefore delete FEWER rows than it was handed.
    *
    * THE COUNT IS WHAT ACTUALLY WENT, in both modes. Locally that is the size of
    * the list before minus the size after — which is not the same as the number
@@ -1845,6 +1883,7 @@ class DataServiceImpl implements DataPort {
     if (userId && this.supabaseChecker()) {
       return this.planningService.deleteUnusedCategories(userId, ids);
     }
+    this.guardCloudWrite();
 
     const categories = await this.readCollection<Category>(STORAGE_KEYS.CATEGORIES);
     const doomed = new Set(ids);
@@ -1899,6 +1938,11 @@ class DataServiceImpl implements DataPort {
     // of words. The retired boot called `ensureCategories(null)` at exactly
     // this point and got exactly this behaviour; keeping it is the reason this
     // routing change is invisible to the person using it.
+    //
+    // AND IT STOPS HERE. This exception covers this READ and nothing else: the
+    // five category WRITES all refuse a pending session, and the comment beside
+    // `createCategory`'s guard says why serving a name is not the same trade as
+    // minting an id. The asymmetry is the point, not an oversight to tidy.
     const local = await this.readCollection<Category>(STORAGE_KEYS.CATEGORIES);
     return local.length > 0 ? local : getDefaultCategories();
   }


### PR DESCRIPTION
The write-paths arc's **one deliberate behaviour change**, shipped alone so it is reviewed as one.

- All 11 planning writes gain `guardCloudWrite()` (the shape every other write on the class has): a signed-in session whose identity is still resolving used to write into browser storage, show the item optimistically, and lose it silently on the next boot. It now refuses with the standard actionable sentence. Empty-input bulk ops still return before the guard.
- The W-4 comment guards both ends of the tempting "fix the asymmetry" mistake — beside the category-write guard *and* appended to `prepareCategories`' deliberate no-guard block.
- 11 exact-equality tests (message-wrapping fails them) each assert refusal + byte-identical store; mutation check red on cue.
- **Message-path verification in lieu of pending-state screenshots** (a genuinely pending Clerk session can't be staged in a preview): goal modal renders `errors.submit` (GoalModal.tsx:315-318); category toast delivers the sentence verbatim — proven by executing the real `formatErrorNotification`. **The budget modal swallows it** — the known N-5 fire-and-forget confirmed live (`BudgetModal.tsx:84-98`: not async, no await, no errors rendering). 5d still closes the data loss there (refused ≠ written-and-lost); the silent-refusal UX is fixed in the immediately following PR using GoalModal's own pattern, kept out of this diff per the plan.
- Bundle delta: −0.1/+0.1 KB (noise). Contract suite unchanged at 64 (its harness has no cloud session, so the guard is a no-op there — as designed).

Gate: lint · strict tsc · smoke 4,813 · realtime 198 · build · coverage 74.78/81.09 vs 63/55.

🤖 Generated with [Claude Code](https://claude.com/claude-code)