### PR TITLE
fix(budget): failed saves keep the modal open and say why

### DIFF
--- a/src/components/BudgetModal.tsx
+++ b/src/components/BudgetModal.tsx
@@ -73,7 +73,7 @@ export default function BudgetModal({ isOpen, onClose, budget, onEditExisting }:
     [budget?.categoryId, resolveCategoryId]
   );
 
-  const { formData, updateField, handleSubmit, setFormData } = useModalForm<FormData>(
+  const { formData, updateField, handleSubmit, setFormData, errors, isSubmitting } = useModalForm<FormData>(
     {
       categoryId: seededCategoryId,
       amount: budget?.amount?.toString() || '',
@@ -81,7 +81,7 @@ export default function BudgetModal({ isOpen, onClose, budget, onEditExisting }:
       isActive: budget?.isActive !== false
     },
     {
-      onSubmit: (data) => {
+      onSubmit: async (data) => {
         const now = new Date();
         const budgetData = {
           categoryId: data.categoryId,
@@ -92,10 +92,14 @@ export default function BudgetModal({ isOpen, onClose, budget, onEditExisting }:
           updatedAt: now
         };
 
+        // Awaited: a limit that failed to save must keep the modal open with
+        // the reason on screen. Unawaited, the save was assumed to have worked
+        // — the modal shut on a refusal that nobody saw, and the budget the
+        // user had just set simply was not there.
         if (budget) {
-          updateBudget(budget.id, budgetData);
+          await updateBudget(budget.id, budgetData);
         } else {
-          addBudget(budgetData);
+          await addBudget(budgetData);
         }
       },
       onClose
@@ -249,6 +253,11 @@ export default function BudgetModal({ isOpen, onClose, budget, onEditExisting }:
           </div>
         </ModalBody>
         <ModalFooter>
+          {errors?.submit && (
+            <div className="mb-3 p-3 bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-lg">
+              <p className="text-sm text-red-700 dark:text-red-300">{errors.submit}</p>
+            </div>
+          )}
           <div className="flex gap-3 w-full">
             <button
               type="button"
@@ -260,10 +269,12 @@ export default function BudgetModal({ isOpen, onClose, budget, onEditExisting }:
             {/* Disabled while the chosen category already has a budget: a
                 button that swallows the click and does nothing tells the user
                 less than one that visibly cannot be pressed, with the reason
-                sitting under the field. */}
+                sitting under the field. Disabled again while a save is in
+                flight, so a second press on a slow connection cannot ask for
+                the same budget twice. */}
             <button
               type="submit"
-              disabled={existingBudget !== null}
+              disabled={existingBudget !== null || isSubmitting}
               title={existingBudget ? `${existingBudgetName} already has a budget` : undefined}
               className="flex-1 justify-center px-4 py-2 bg-[#1a2332] text-white rounded-lg hover:bg-secondary disabled:opacity-40 disabled:cursor-not-allowed"
             >

--- a/src/components/__tests__/BudgetModal.test.tsx
+++ b/src/components/__tests__/BudgetModal.test.tsx
@@ -9,7 +9,7 @@
 
 import React from 'react';
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
-import { screen, fireEvent, cleanup } from '@testing-library/react';
+import { screen, fireEvent, cleanup, waitFor } from '@testing-library/react';
 import { renderWithProviders } from '../../test/testUtils';
 import { __setAppContextValue, __resetAppContextValue } from '../../test/mocks/AppContextSupabase';
 import BudgetModal from '../BudgetModal';
@@ -188,5 +188,79 @@ describe('BudgetModal', () => {
     expect(updateBudget).toHaveBeenCalledWith('b-1', expect.objectContaining({
       categoryId: 'det-groceries',
     }));
+  });
+
+  describe('a save that does not go through', () => {
+    /**
+     * The sentence the context uses when a signed-in session's database id has
+     * not resolved yet. Any refusal would do — this modal used to close on all
+     * of them, because it launched the write and never looked back.
+     */
+    const REFUSAL = 'Still connecting to your account — please try again in a moment.';
+
+    /** Choose a category and an amount, as a person would before saving. */
+    const fillForm = (): void => {
+      openCategoryPicker();
+      fireEvent.click(screen.getByText('Groceries'));
+      fireEvent.change(screen.getByPlaceholderText('0.00'), { target: { value: '250' } });
+    };
+
+    it('stays open and says why, in the words the write used', async () => {
+      __setAppContextValue({ addBudget: vi.fn().mockRejectedValue(new Error(REFUSAL)) });
+      renderWithProviders(<BudgetModal {...defaultProps} />);
+      fillForm();
+
+      fireEvent.click(screen.getByRole('button', { name: 'Add Budget' }));
+
+      const shown = await screen.findByText(REFUSAL);
+      // Exact equality, not "contains": a wrapper ("Error: …", "Could not save:
+      // …") is a different sentence from the one the write chose, and the user
+      // is owed that one.
+      expect(shown.textContent).toBe(REFUSAL);
+      // The modal is still here, with the work still in it — the whole point.
+      expect(screen.getByRole('dialog')).toBeInTheDocument();
+      expect(defaultProps.onClose).not.toHaveBeenCalled();
+      expect(screen.getByPlaceholderText('0.00')).toHaveValue('250');
+      // Nothing to retry from is worse than a failed save: the button comes back.
+      expect(screen.getByRole('button', { name: 'Add Budget' })).toBeEnabled();
+    });
+
+    it('closes as before when the save goes through', async () => {
+      __setAppContextValue({ addBudget: vi.fn().mockResolvedValue(undefined) });
+      renderWithProviders(<BudgetModal {...defaultProps} />);
+      fillForm();
+
+      fireEvent.click(screen.getByRole('button', { name: 'Add Budget' }));
+
+      await waitFor(() => expect(defaultProps.onClose).toHaveBeenCalledTimes(1));
+      expect(screen.queryByText(REFUSAL)).not.toBeInTheDocument();
+    });
+
+    it('cannot be asked for the same budget twice while the first save is in flight', async () => {
+      let settle = (): void => {};
+      const inFlight = vi.fn().mockImplementation(
+        () => new Promise<void>(resolve => { settle = () => resolve(); })
+      );
+      __setAppContextValue({ addBudget: inFlight });
+      renderWithProviders(<BudgetModal {...defaultProps} />);
+      fillForm();
+
+      fireEvent.click(screen.getByRole('button', { name: 'Add Budget' }));
+      expect(inFlight).toHaveBeenCalledTimes(1);
+      // The button says so…
+      expect(screen.getByRole('button', { name: 'Add Budget' })).toBeDisabled();
+
+      // …and the form refuses a second submit however it is reached, which is
+      // useModalForm's own re-entrancy guard rather than the disabled attribute.
+      const form = screen.getByRole('dialog').querySelector('form');
+      if (!form) throw new Error('No form rendered');
+      fireEvent.submit(form);
+
+      expect(inFlight).toHaveBeenCalledTimes(1);
+
+      settle();
+      await waitFor(() => expect(defaultProps.onClose).toHaveBeenCalledTimes(1));
+      expect(inFlight).toHaveBeenCalledTimes(1);
+    });
   });
 });

--- a/src/pages/Budget.tsx
+++ b/src/pages/Budget.tsx
@@ -2,6 +2,7 @@ import { useState, useMemo, useEffect, useCallback } from 'react';
 import { useApp } from '../contexts/AppContextSupabase';
 import { useCurrencyDecimal } from '../hooks/useCurrencyDecimal';
 import { useNotifications } from '../contexts/NotificationContext';
+import { useToast } from '../contexts/ToastContext';
 import { TrendingUpIcon, TrendingDownIcon, BanknoteIcon, RepeatIcon, PiggyBankIcon, ArrowRightIcon, BellIcon, CalculatorIcon } from '../components/icons';
 import { EditIcon, DeleteIcon } from '../components/icons';
 import { IconButton } from '../components/icons/IconButton';
@@ -41,6 +42,7 @@ export default function Budget() {
   // Get data from context
   const { budgets, updateBudget, deleteBudget, transactions, transactionSplits, categories, accounts } = useApp();
   const { checkEnhancedBudgetAlerts, checkBudgetAlerts, alertThreshold } = useNotifications();
+  const { showError } = useToast();
 
   // One evaluation instant for the whole page: every card, caption and total
   // describes the same "now".
@@ -197,8 +199,30 @@ export default function Budget() {
     setEditingBudget(null);
   };
 
-  const handleToggleActive = (budgetId: string, currentStatus: boolean | undefined) => {
-    updateBudget(budgetId, { isActive: !currentStatus });
+  /**
+   * Awaited, with the failure shown.
+   *
+   * These two are page actions rather than a form, so there is no modal to
+   * hold open — but the silence was the same: the write was launched and
+   * forgotten, and a refusal left the row looking exactly as it had before,
+   * with nothing said. The context leaves its own state alone when the write
+   * throws, so the card still shows the truth; the toast supplies the reason
+   * it did not change.
+   */
+  const handleToggleActive = async (budgetId: string, currentStatus: boolean | undefined): Promise<void> => {
+    try {
+      await updateBudget(budgetId, { isActive: !currentStatus });
+    } catch (error) {
+      showError(error);
+    }
+  };
+
+  const handleDelete = async (budgetId: string): Promise<void> => {
+    try {
+      await deleteBudget(budgetId);
+    } catch (error) {
+      showError(error);
+    }
   };
 
   const getProgressColor = (percentage: number) => {
@@ -402,7 +426,7 @@ export default function Budget() {
               </div>
               <div className="flex gap-3">
                 <button
-                  onClick={() => handleToggleActive(budget.id, budget.isActive)}
+                  onClick={() => void handleToggleActive(budget.id, budget.isActive)}
                   className={`px-3 py-1 text-sm rounded ${
                     budget.isActive !== false
                       ? 'bg-blue-100 dark:bg-blue-900/20 text-blue-700 dark:text-blue-300'
@@ -422,7 +446,7 @@ export default function Budget() {
                 <IconButton
                   onClick={() => {
                     if (confirm('Delete this budget?')) {
-                      deleteBudget(budget.id);
+                      void handleDelete(budget.id);
                     }
                   }}
                   icon={<DeleteIcon size={20} />}

--- a/src/pages/__tests__/Budget.test.tsx
+++ b/src/pages/__tests__/Budget.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import { render, screen, within } from '@testing-library/react';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { render, screen, within, fireEvent, waitFor } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import { PreferencesProvider } from '../../contexts/PreferencesContext';
 import { ToastProvider } from '../../contexts/ToastContext';
@@ -176,5 +176,81 @@ describe('Budget page — what a card says has been spent', () => {
 
       expect(within(card('Food')).getByText('£65.00 of £300.00')).toBeInTheDocument();
     });
+  });
+});
+
+/**
+ * The two page actions that write: the Active/Inactive toggle and Delete.
+ *
+ * Both used to be launched and forgotten. A refused write left the row looking
+ * exactly as it had, with nothing said — the card kept the truth (the context
+ * leaves its state alone when the write throws) while the person who pressed
+ * the button was told a budget had changed that had not.
+ */
+describe('Budget page — a write the server refuses', () => {
+  /** Any refusal would do; this is the sentence the live guard uses. */
+  const REFUSAL = 'Still connecting to your account — please try again in a moment.';
+
+  const seed = (overrides: { updateBudget?: () => Promise<void>; deleteBudget?: () => Promise<void> }): void => {
+    __setAppContextValue({
+      accounts: ACCOUNTS,
+      categories: CATEGORIES,
+      transactions: [txn({ id: 't-1', amount: -40 })],
+      transactionSplits: [],
+      budgets: [budget({ id: 'bud-groceries', categoryId: 'det-groceries', amount: 200 })],
+      ...overrides
+    });
+  };
+
+  afterEach(() => {
+    __resetAppContextValue();
+    vi.restoreAllMocks();
+  });
+
+  it('says so when the Active toggle is refused, and leaves the card alone', async () => {
+    seed({ updateBudget: vi.fn().mockRejectedValue(new Error(REFUSAL)) });
+    renderBudget();
+
+    fireEvent.click(within(card('Groceries')).getByRole('button', { name: 'Active' }));
+
+    const shown = await screen.findByText(REFUSAL);
+    expect(shown.textContent).toBe(REFUSAL);
+    // The toggle still reads what the stored budget actually is.
+    expect(within(card('Groceries')).getByRole('button', { name: 'Active' })).toBeInTheDocument();
+  });
+
+  it('says so when the delete is refused, and the budget is still there', async () => {
+    vi.spyOn(window, 'confirm').mockReturnValue(true);
+    seed({ deleteBudget: vi.fn().mockRejectedValue(new Error(REFUSAL)) });
+    renderBudget();
+
+    fireEvent.click(within(card('Groceries')).getByRole('button', { name: 'Delete Budget' }));
+
+    const shown = await screen.findByText(REFUSAL);
+    expect(shown.textContent).toBe(REFUSAL);
+    expect(card('Groceries')).toBeInTheDocument();
+  });
+
+  it('says nothing when the delete goes through', async () => {
+    vi.spyOn(window, 'confirm').mockReturnValue(true);
+    const deleteBudget = vi.fn().mockResolvedValue(undefined);
+    seed({ deleteBudget });
+    renderBudget();
+
+    fireEvent.click(within(card('Groceries')).getByRole('button', { name: 'Delete Budget' }));
+
+    await waitFor(() => expect(deleteBudget).toHaveBeenCalledWith('bud-groceries'));
+    expect(screen.queryByText(REFUSAL)).not.toBeInTheDocument();
+  });
+
+  it('does not delete at all when the confirmation is declined', () => {
+    vi.spyOn(window, 'confirm').mockReturnValue(false);
+    const deleteBudget = vi.fn().mockResolvedValue(undefined);
+    seed({ deleteBudget });
+    renderBudget();
+
+    fireEvent.click(within(card('Groceries')).getByRole('button', { name: 'Delete Budget' }));
+
+    expect(deleteBudget).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
The immediate follow-up promised in #213: the budget modal's fire-and-forget writes (the confirmed N-5 half) made 5d's refusal safe but silent — the modal closed and the budget just wasn't there.

- `BudgetModal` now matches `GoalModal`'s shape: async awaited writes, `errors.submit` rendered above the buttons verbatim (exact-equality tested, em dash and all), form intact for retry, submit disabled in flight.
- Double-submit proven at the hook level: the test bypasses the disabled attribute with a direct form submit and asserts exactly one write.
- `Budget.tsx`'s toggle-active and delete surface failures via the sibling pages' toast pattern; the confirm() flow is untouched.
- Declared render change (the point): a failed save keeps the modal mounted — one new in-flight render state, one failure state. The page's cards were already truthful on failure (context state mutates only after success); the only thing missing was the telling.
- Both mutation checks red on cue (de-await → stays-open test fails; fire-and-forget revert → toast test fails).

Remaining on the N-5 ledger: the Categories page's four fire-and-forget sites.

Gate: lint · strict tsc · targeted 22 · smoke 4,820.

🤖 Generated with [Claude Code](https://claude.com/claude-code)