### PR TITLE
feat(seam): slice 7 — bulk imports through the port, credentials owned by the seam

### DIFF
--- a/src/components/CSVImportWizard.test.tsx
+++ b/src/components/CSVImportWizard.test.tsx
@@ -8,12 +8,9 @@ import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import CSVImportWizard from './CSVImportWizard';
 import { enhancedCsvImportService } from '../services/enhancedCsvImportService';
-import { transactionImportService } from '../services/transactionImportService';
-import { importTransactionsLocally } from '../services/localTransactionImportService';
+import { dataPort } from '../services/port';
 
 const mockRefreshAccountsAndTransactions = vi.fn().mockResolvedValue(undefined);
-/** Flipped per test to exercise the cloud path and the local one. */
-let mockIsUsingSupabase = false;
 
 // Mock all dependencies
 vi.mock('../contexts/AppContextSupabase', () => ({
@@ -28,29 +25,25 @@ vi.mock('../contexts/AppContextSupabase', () => ({
       { id: 'cat-1', name: 'Food', type: 'expense' },
       { id: 'cat-2', name: 'Income', type: 'income' },
     ],
-    isUsingSupabase: mockIsUsingSupabase,
     refreshAccountsAndTransactions: mockRefreshAccountsAndTransactions,
   }),
 }));
 
-vi.mock('@clerk/clerk-react', () => ({
-  useAuth: () => ({ getToken: vi.fn().mockResolvedValue('test-token') }),
-}));
-
 /**
- * Both write paths are mocked, because what these tests check is what the
- * wizard REPORTS about a write — which can only be checked by controlling what
- * the write says it did.
+ * THE WRITE, which is now one door rather than two.
+ *
+ * The wizard used to choose between the cloud client and the browser-storage
+ * importer itself, off `isUsingSupabase`, and these tests mocked both. It asks
+ * the seam once now; which store answers is the seam's business and is tested
+ * where that decision lives (dataService.test.ts). What is mocked here is the
+ * ANSWER, because what these tests check is what the wizard reports about a
+ * write — and that can only be checked by controlling what the write says it
+ * did.
  */
-vi.mock('../services/transactionImportService', () => ({
-  transactionImportService: {
-    setAuthTokenProvider: vi.fn(),
-    importInChunks: vi.fn(),
+vi.mock('../services/port', () => ({
+  dataPort: {
+    importTransactions: vi.fn(),
   },
-}));
-
-vi.mock('../services/localTransactionImportService', () => ({
-  importTransactionsLocally: vi.fn(),
 }));
 
 /**
@@ -196,13 +189,9 @@ describe('CSVImportWizard', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
-    mockIsUsingSupabase = false;
     // Default: the write does what it was asked. Tests about a failing write
     // override this.
-    vi.mocked(importTransactionsLocally).mockImplementation(
-      async (_accountId, rows) => ({ inserted: rows.length, alreadyPresent: 0, total: rows.length, complete: true })
-    );
-    vi.mocked(transactionImportService.importInChunks).mockImplementation(
+    vi.mocked(dataPort.importTransactions).mockImplementation(
       async (_accountId, rows) => ({ inserted: rows.length, alreadyPresent: 0, total: rows.length, complete: true })
     );
   });
@@ -661,13 +650,16 @@ describe('CSVImportWizard', () => {
       await waitFor(() => {
         expect(screen.getByText('Import Complete!')).toBeInTheDocument();
       });
-      expect(importTransactionsLocally).toHaveBeenCalledTimes(1);
-      expect(importTransactionsLocally).toHaveBeenCalledWith(
+      expect(dataPort.importTransactions).toHaveBeenCalledTimes(1);
+      expect(dataPort.importTransactions).toHaveBeenCalledWith(
         'acc-1',
         expect.arrayContaining([
           expect.objectContaining({ description: 'GROCERY STORE', accountId: 'acc-1' }),
           expect.objectContaining({ description: 'SALARY', accountId: 'acc-1' })
-        ])
+        ]),
+        // The destination the wizard resolved, the rows it routed there, and a
+        // way to hear about them landing. Nothing about which store answers.
+        { onProgress: expect.any(Function) }
       );
       expect(mockRefreshAccountsAndTransactions).toHaveBeenCalled();
     });
@@ -688,16 +680,20 @@ describe('CSVImportWizard', () => {
       await waitFor(() => {
         expect(screen.getByText('Import Complete!')).toBeInTheDocument();
       });
-      expect(importTransactionsLocally).toHaveBeenCalledWith('acc-1', [
-        expect.objectContaining({ description: 'GROCERY STORE', categoryConfirmed: false }),
-        expect.objectContaining({ description: 'SALARY', categoryConfirmed: true })
-      ]);
+      expect(dataPort.importTransactions).toHaveBeenCalledWith(
+        'acc-1',
+        [
+          expect.objectContaining({ description: 'GROCERY STORE', categoryConfirmed: false }),
+          expect.objectContaining({ description: 'SALARY', categoryConfirmed: true })
+        ],
+        { onProgress: expect.any(Function) }
+      );
     });
 
     it('shows the Imported tile as what LANDED, not what the file offered', async () => {
       // The file offers two; the write confirms one. The tile must say one.
       vi.mocked(enhancedCsvImportService.importTransactions).mockResolvedValueOnce(parsedAs(twoRows));
-      vi.mocked(importTransactionsLocally).mockResolvedValueOnce({
+      vi.mocked(dataPort.importTransactions).mockResolvedValueOnce({
         inserted: 1,
         alreadyPresent: 0,
         total: 2,
@@ -717,7 +713,7 @@ describe('CSVImportWizard', () => {
 
     it('names the row that never landed, and what its absence means', async () => {
       vi.mocked(enhancedCsvImportService.importTransactions).mockResolvedValueOnce(parsedAs(twoRows));
-      vi.mocked(importTransactionsLocally).mockResolvedValueOnce({
+      vi.mocked(dataPort.importTransactions).mockResolvedValueOnce({
         inserted: 1,
         alreadyPresent: 0,
         total: 2,
@@ -748,8 +744,8 @@ describe('CSVImportWizard', () => {
       await waitFor(() => {
         expect(screen.getByText('Import Complete!')).toBeInTheDocument();
       });
-      expect(importTransactionsLocally).toHaveBeenCalledTimes(2);
-      expect(vi.mocked(importTransactionsLocally).mock.calls.map(call => call[0]))
+      expect(dataPort.importTransactions).toHaveBeenCalledTimes(2);
+      expect(vi.mocked(dataPort.importTransactions).mock.calls.map(call => call[0]))
         .toEqual(['acc-1', 'acc-2']);
     });
 
@@ -759,7 +755,7 @@ describe('CSVImportWizard', () => {
       vi.mocked(enhancedCsvImportService.importTransactions).mockResolvedValueOnce(
         parsedAs([...twoRows, { ...twoRows[0], description: 'TRANSFER IN', accountId: 'acc-2' }])
       );
-      vi.mocked(importTransactionsLocally)
+      vi.mocked(dataPort.importTransactions)
         .mockResolvedValueOnce({ inserted: 2, alreadyPresent: 0, total: 2, complete: true })
         .mockResolvedValueOnce({ inserted: 0, alreadyPresent: 0, total: 1, complete: false, error: 'offline' });
 
@@ -788,9 +784,11 @@ describe('CSVImportWizard', () => {
       });
       expect(screen.getByText(/Barclays Everyday.*you have no account of that name/)).toBeInTheDocument();
       // One row routed, so one row landed — not the parser's two.
-      expect(importTransactionsLocally).toHaveBeenCalledWith('acc-1', [
-        expect.objectContaining({ description: 'GROCERY STORE' })
-      ]);
+      expect(dataPort.importTransactions).toHaveBeenCalledWith(
+        'acc-1',
+        [expect.objectContaining({ description: 'GROCERY STORE' })],
+        { onProgress: expect.any(Function) }
+      );
     });
 
     it('says when no Account column was mapped at all', async () => {
@@ -804,7 +802,7 @@ describe('CSVImportWizard', () => {
         expect(screen.getByText('Nothing was imported')).toBeInTheDocument();
       });
       expect(screen.getByText(/No column is mapped to/)).toBeInTheDocument();
-      expect(importTransactionsLocally).not.toHaveBeenCalled();
+      expect(dataPort.importTransactions).not.toHaveBeenCalled();
     });
 
     it('surfaces a thrown import instead of leaving a dead button', async () => {
@@ -833,7 +831,7 @@ describe('CSVImportWizard', () => {
       const heldWrite = () => {
         let release: (() => void) | null = null;
         const finished = new Promise<void>(resolve => { release = resolve; });
-        vi.mocked(importTransactionsLocally).mockImplementationOnce(async (_accountId, rows) => {
+        vi.mocked(dataPort.importTransactions).mockImplementationOnce(async (_accountId, rows) => {
           await finished;
           return { inserted: rows.length, alreadyPresent: 0, total: rows.length, complete: true };
         });
@@ -878,21 +876,35 @@ describe('CSVImportWizard', () => {
           expect(screen.getByText('Import Complete!')).toBeInTheDocument();
         });
         expect(enhancedCsvImportService.importTransactions).toHaveBeenCalledTimes(1);
-        expect(importTransactionsLocally).toHaveBeenCalledTimes(1);
+        expect(dataPort.importTransactions).toHaveBeenCalledTimes(1);
       });
     });
 
-    it('uses the cloud endpoint when signed in', async () => {
-      mockIsUsingSupabase = true;
+    it('counts the rows as a chunked store reports them, without waiting for the end', async () => {
+      // A signed-in import posts in chunks and says so between them. The
+      // wizard's job is to put those figures on screen as they arrive rather
+      // than jumping from nothing to done — which is what a 900-row statement
+      // looks like otherwise.
       vi.mocked(enhancedCsvImportService.importTransactions).mockResolvedValueOnce(parsedAs(twoRows));
+      let release: (() => void) | null = null;
+      const finished = new Promise<void>(resolve => { release = resolve; });
+      vi.mocked(dataPort.importTransactions).mockImplementationOnce(async (_accountId, rows, options) => {
+        options?.onProgress?.({ inserted: 1, total: rows.length });
+        await finished;
+        return { inserted: rows.length, alreadyPresent: 0, total: rows.length, complete: true };
+      });
 
       await runImport();
 
       await waitFor(() => {
+        expect(screen.getByRole('status')).toHaveTextContent('Importing… 1 of 2 transactions');
+      });
+      expect(screen.getByRole('progressbar')).toHaveAttribute('aria-valuenow', '50');
+
+      release?.();
+      await waitFor(() => {
         expect(screen.getByText('Import Complete!')).toBeInTheDocument();
       });
-      expect(transactionImportService.importInChunks).toHaveBeenCalledTimes(1);
-      expect(importTransactionsLocally).not.toHaveBeenCalled();
     });
   });
 
@@ -1190,8 +1202,8 @@ describe('CSVImportWizard', () => {
       // Not the result step, and not the write: a CSV names its columns in words
       // only its author knows, so nothing is imported before someone confirms.
       expect(screen.queryByText('Import Complete!')).not.toBeInTheDocument();
-      expect(transactionImportService.importInChunks).not.toHaveBeenCalled();
-      expect(importTransactionsLocally).not.toHaveBeenCalled();
+      expect(dataPort.importTransactions).not.toHaveBeenCalled();
+      expect(dataPort.importTransactions).not.toHaveBeenCalled();
     });
 
     /**

--- a/src/components/CSVImportWizard.tsx
+++ b/src/components/CSVImportWizard.tsx
@@ -1,12 +1,7 @@
 import React, { useState, useCallback, useMemo, useRef, useEffect } from 'react';
-import { useAuth } from '@clerk/clerk-react';
 import { useApp } from '../contexts/AppContextSupabase';
 import { enhancedCsvImportService, type ColumnMapping, type ImportProfile, type ImportResult } from '../services/enhancedCsvImportService';
-import {
-  transactionImportService,
-  type BulkImportResult
-} from '../services/transactionImportService';
-import { importTransactionsLocally } from '../services/localTransactionImportService';
+import { dataPort, type BulkImportResult } from '../services/port';
 import { summariseMissingRows, type MissingRowsSummary } from '../utils/partialImportSummary';
 import type { Account, Transaction } from '../types';
 import {
@@ -94,10 +89,8 @@ export default function CSVImportWizard({ isOpen, onClose, type, initialFile }: 
     accounts,
     transactions,
     categories,
-    isUsingSupabase,
     refreshAccountsAndTransactions
   } = useApp();
-  const { getToken } = useAuth();
   const [currentStep, setCurrentStep] = useState<WizardStep>('upload');
   const [csvContent, setCsvContent] = useState('');
   const [headers, setHeaders] = useState<string[]>([]);
@@ -313,10 +306,12 @@ export default function CSVImportWizard({ isOpen, onClose, type, initialFile }: 
 
         // ── Write, one account at a time, each batch all-or-nothing ────────
         //
-        // Cloud: one `import_transactions_atomic` per chunk. Local: one
-        // IndexedDB `setMany` covering the rows and the balance together.
-        // Awaited either way — the un-awaited per-row loop this replaces fired
-        // every write at once and dropped every promise.
+        // One call per account, through the seam: whichever store this app is
+        // holding decides for itself how to make a batch atomic (one
+        // `import_transactions_atomic` per chunk in the cloud, one IndexedDB
+        // write covering the rows and the balance on a device) and answers with
+        // the same shape either way. Awaited — the un-awaited per-row loop this
+        // replaces fired every write at once and dropped every promise.
         //
         // A failing account does NOT stop the rest: these are separate accounts
         // with nothing to do with each other, and refusing to file the Barclays
@@ -327,10 +322,6 @@ export default function CSVImportWizard({ isOpen, onClose, type, initialFile }: 
           const existing = byAccount.get(accountId);
           if (existing) existing.push(draft);
           else byAccount.set(accountId, [draft]);
-        }
-
-        if (isUsingSupabase && byAccount.size > 0) {
-          transactionImportService.setAuthTokenProvider(() => getToken());
         }
 
         let landed = 0;
@@ -348,20 +339,18 @@ export default function CSVImportWizard({ isOpen, onClose, type, initialFile }: 
         for (const [accountId, rows] of byAccount) {
           const account = accountsById.get(accountId);
           // A multi-account file writes one account at a time, so the count on
-          // screen is what has landed ACROSS accounts so far — the cloud path
-          // reports per chunk, the local one only when its single atomic write
-          // for that account is done.
+          // screen is what has landed ACROSS accounts so far — a store that
+          // commits in chunks reports each one, a store whose write is a single
+          // atomic transaction reports nothing until that account is done.
           const alreadyLanded = landed;
-          const outcome: BulkImportResult = isUsingSupabase
-            ? await transactionImportService.importInChunks(accountId, rows, {
-                // Fires between chunks, so it can also land after unmount.
-                onProgress: p => {
-                  if (isMountedRef.current) {
-                    setProgress({ inserted: alreadyLanded + p.inserted, total: rowsToWrite });
-                  }
-                }
-              })
-            : await importTransactionsLocally(accountId, rows);
+          const outcome: BulkImportResult = await dataPort.importTransactions(accountId, rows, {
+            // Fires between chunks, so it can also land after unmount.
+            onProgress: p => {
+              if (isMountedRef.current) {
+                setProgress({ inserted: alreadyLanded + p.inserted, total: rowsToWrite });
+              }
+            }
+          });
 
           landed += outcome.inserted;
           if (isMountedRef.current && rowsToWrite > 0) {

--- a/src/components/OFXImportModal.test.tsx
+++ b/src/components/OFXImportModal.test.tsx
@@ -3,8 +3,7 @@ import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import OFXImportModal from './OFXImportModal';
 import { ofxImportService } from '../services/ofxImportService';
-import { transactionImportService } from '../services/transactionImportService';
-import { importTransactionsLocally } from '../services/localTransactionImportService';
+import { dataPort } from '../services/port';
 import type { Account } from '../types';
 
 type ImportTransactionsResult = Awaited<ReturnType<typeof ofxImportService.importTransactions>>;
@@ -115,8 +114,6 @@ vi.mock('./loading/LoadingState', () => ({
 // Mock AppContext
 const mockUpdateAccount = vi.fn();
 const mockRefreshAccountsAndTransactions = vi.fn().mockResolvedValue(undefined);
-/** Flipped per test to exercise the cloud path and the local one. */
-let mockIsUsingSupabase = false;
 const mockAccount = (overrides: Partial<Account> & Pick<Account, 'id' | 'name' | 'type'>): Account => ({
   balance: 0,
   currency: 'GBP',
@@ -168,13 +165,8 @@ vi.mock('../contexts/AppContextSupabase', () => ({
     transactions: mockTransactions,
     categories: mockCategories,
     updateAccount: mockUpdateAccount,
-    isUsingSupabase: mockIsUsingSupabase,
     refreshAccountsAndTransactions: mockRefreshAccountsAndTransactions
   })
-}));
-
-vi.mock('@clerk/clerk-react', () => ({
-  useAuth: () => ({ getToken: vi.fn().mockResolvedValue('test-token') })
 }));
 
 // Mock OFX import service
@@ -185,19 +177,20 @@ vi.mock('../services/ofxImportService', () => ({
 }));
 
 /**
- * The two write paths. Both are mocked, because what this file tests is what
- * the modal REPORTS about a write — and the only way to test that honestly is
- * to control what the write says it did.
+ * THE WRITE, which is now one door rather than two.
+ *
+ * The dialog used to choose between the cloud client and the browser-storage
+ * importer itself, off `isUsingSupabase`, and this file mocked both. It asks
+ * the seam once now; which store answers is the seam's business and is tested
+ * where that decision lives (dataService.test.ts). What is mocked here is the
+ * ANSWER, because what this file tests is what the modal REPORTS about a write
+ * — and the only way to test that honestly is to control what the write says
+ * it did.
  */
-vi.mock('../services/transactionImportService', () => ({
-  transactionImportService: {
-    setAuthTokenProvider: vi.fn(),
-    importInChunks: vi.fn()
+vi.mock('../services/port', () => ({
+  dataPort: {
+    importTransactions: vi.fn()
   }
-}));
-
-vi.mock('../services/localTransactionImportService', () => ({
-  importTransactionsLocally: vi.fn()
 }));
 
 // Mock window methods
@@ -221,13 +214,9 @@ describe('OFXImportModal', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
-    mockIsUsingSupabase = false;
     // Default: the write does what it was asked. Tests that care about a
     // failing write override this.
-    vi.mocked(importTransactionsLocally).mockImplementation(
-      async (_accountId, rows) => ({ inserted: rows.length, alreadyPresent: 0, total: rows.length, complete: true })
-    );
-    vi.mocked(transactionImportService.importInChunks).mockImplementation(
+    vi.mocked(dataPort.importTransactions).mockImplementation(
       async (_accountId, rows) => ({ inserted: rows.length, alreadyPresent: 0, total: rows.length, complete: true })
     );
   });
@@ -741,11 +730,13 @@ describe('OFXImportModal', () => {
         expect(screen.getByTestId('check-icon')).toBeInTheDocument();
       });
 
-      // One awaited, atomic write for the whole file — not a row at a time.
-      expect(importTransactionsLocally).toHaveBeenCalledTimes(1);
-      expect(importTransactionsLocally).toHaveBeenCalledWith(
+      // One awaited, all-or-nothing write for the whole file — not a row at a
+      // time — into the account this dialog matched.
+      expect(dataPort.importTransactions).toHaveBeenCalledTimes(1);
+      expect(dataPort.importTransactions).toHaveBeenCalledWith(
         'acc1',
-        [{ id: 'trans1', amount: 100, description: 'Test' }]
+        [{ id: 'trans1', amount: 100, description: 'Test' }],
+        { source: 'ofx', onProgress: expect.any(Function) }
       );
       // And the register is re-read, so the screen shows what actually landed.
       expect(mockRefreshAccountsAndTransactions).toHaveBeenCalled();
@@ -832,7 +823,7 @@ describe('OFXImportModal', () => {
         );
         let release: (() => void) | null = null;
         const finished = new Promise<void>(resolve => { release = resolve; });
-        vi.mocked(importTransactionsLocally).mockImplementationOnce(async (_accountId, rows) => {
+        vi.mocked(dataPort.importTransactions).mockImplementationOnce(async (_accountId, rows) => {
           await finished;
           return { inserted: rows.length, alreadyPresent: 0, total: rows.length, complete: true };
         });
@@ -872,7 +863,7 @@ describe('OFXImportModal', () => {
         await waitFor(() => {
           expect(screen.getByText('Import Successful!')).toBeInTheDocument();
         });
-        expect(importTransactionsLocally).toHaveBeenCalledTimes(1);
+        expect(dataPort.importTransactions).toHaveBeenCalledTimes(1);
       });
     });
   });
@@ -920,7 +911,7 @@ describe('OFXImportModal', () => {
     };
 
     it('reports what LANDED, not what the file offered', async () => {
-      vi.mocked(importTransactionsLocally).mockResolvedValueOnce({
+      vi.mocked(dataPort.importTransactions).mockResolvedValueOnce({
         inserted: 2,
         alreadyPresent: 0,
         total: 3,
@@ -940,7 +931,7 @@ describe('OFXImportModal', () => {
     });
 
     it('names the payment that is missing, and what its absence means', async () => {
-      vi.mocked(importTransactionsLocally).mockResolvedValueOnce({
+      vi.mocked(dataPort.importTransactions).mockResolvedValueOnce({
         inserted: 2,
         alreadyPresent: 0,
         total: 3,
@@ -965,7 +956,7 @@ describe('OFXImportModal', () => {
     it('holds back the Bank Balance and says why', async () => {
       // Setting a statement's closing figure on a register that only holds part
       // of that statement produces an unexplained difference in Reconciliation.
-      vi.mocked(importTransactionsLocally).mockResolvedValueOnce({
+      vi.mocked(dataPort.importTransactions).mockResolvedValueOnce({
         inserted: 2,
         alreadyPresent: 0,
         total: 3,
@@ -983,7 +974,7 @@ describe('OFXImportModal', () => {
     });
 
     it('says plainly when nothing at all was written', async () => {
-      vi.mocked(importTransactionsLocally).mockResolvedValueOnce({
+      vi.mocked(dataPort.importTransactions).mockResolvedValueOnce({
         inserted: 0,
         alreadyPresent: 0,
         total: 3,
@@ -1018,8 +1009,9 @@ describe('OFXImportModal', () => {
       // already has under the bank's own id, looks like on screen. Adding the
       // two figures together would claim work that did not happen; leaving the
       // second out would report rows as missing when they are in the register.
-      mockIsUsingSupabase = true;
-      vi.mocked(transactionImportService.importInChunks).mockResolvedValueOnce({
+      // Only a store that can be asked twice ever answers this way; the modal
+      // reads the shape, not the store.
+      vi.mocked(dataPort.importTransactions).mockResolvedValueOnce({
         inserted: 3,
         alreadyPresent: 2,
         total: 3,
@@ -1051,8 +1043,7 @@ describe('OFXImportModal', () => {
       { ...sampleTransaction, description: 'TWO WAY SWEEP IN', amount: 312.75, date: day, statementSequence: 2 }
     ];
 
-    const importThrough = async (viaCloud: boolean): Promise<void> => {
-      mockIsUsingSupabase = viaCloud;
+    const importThrough = async (): Promise<void> => {
       const parsed = createMockImportResult({
         transactions: ordered,
         statementRows: ordered.map((t, i) => statementRow(t, `fit-${i}`)),
@@ -1076,32 +1067,68 @@ describe('OFXImportModal', () => {
       });
     };
 
-    it('hands the ordinal to the cloud write', async () => {
-      await importThrough(true);
+    it('hands the ordinal, and everything else about the rows, to the seam', async () => {
+      await importThrough();
 
-      expect(transactionImportService.importInChunks).toHaveBeenCalledWith(
+      expect(dataPort.importTransactions).toHaveBeenCalledTimes(1);
+      expect(dataPort.importTransactions).toHaveBeenCalledWith(
+        // The account this dialog matched or the user picked — the whole point
+        // of the matching work above is that the statement reaches THIS one.
         'acc2',
         expect.arrayContaining([
           expect.objectContaining({ description: 'DIRECT DEBIT', statementSequence: 0 }),
           expect.objectContaining({ description: 'STANDING ORDER OUT', statementSequence: 1 }),
           expect.objectContaining({ description: 'TWO WAY SWEEP IN', statementSequence: 2 })
         ]),
-        // And says these rows carry the bank's own FITID, which is what the
-        // database keys them by — see transactionImportService.provenanceFor.
+        // And says these rows carry the bank's own FITID, which is what a store
+        // able to key them by it will use — see dataPort.ImportSourceKind.
         // onProgress rides along so the dialog can count rows as they land.
         { source: 'ofx', onProgress: expect.any(Function) }
       );
     });
 
-    it('hands the ordinal to the local write', async () => {
-      await importThrough(false);
+    it('counts the rows as a chunked store reports them, without waiting for the end', async () => {
+      // A store that commits in pieces says so between them; the dialog puts
+      // those figures on screen as they arrive rather than jumping from
+      // nothing to done, which is what a 183-row statement looks like
+      // otherwise. A store with one atomic write reports nothing and the bar
+      // stays honestly indeterminate — the case the test above this covers.
+      let release: (() => void) | null = null;
+      const finished = new Promise<void>(resolve => { release = resolve; });
+      vi.mocked(dataPort.importTransactions).mockImplementationOnce(async (_accountId, rows, options) => {
+        options?.onProgress?.({ inserted: 2, total: rows.length });
+        await finished;
+        return { inserted: rows.length, alreadyPresent: 0, total: rows.length, complete: true };
+      });
 
-      expect(importTransactionsLocally).toHaveBeenCalledWith(
-        'acc2',
-        expect.arrayContaining([
-          expect.objectContaining({ description: 'TWO WAY SWEEP IN', statementSequence: 2 })
-        ])
-      );
+      const parsed = createMockImportResult({
+        transactions: ordered,
+        statementRows: ordered.map((t, i) => statementRow(t, `fit-${i}`)),
+        matchedAccount: mockAccounts[1],
+        newTransactions: 3
+      });
+      vi.mocked(ofxImportService.importTransactions)
+        .mockResolvedValueOnce(parsed)
+        .mockResolvedValueOnce(parsed);
+
+      render(<OFXImportModal {...defaultProps} />);
+      fireEvent.change(document.getElementById('ofx-upload')!, {
+        target: { files: [new File(['OFX content'], 'test.ofx', { type: 'application/ofx' })] }
+      });
+      await waitFor(() => {
+        expect(screen.getByTestId('loading-button')).toBeInTheDocument();
+      });
+      fireEvent.click(screen.getByTestId('loading-button'));
+
+      await waitFor(() => {
+        expect(screen.getByRole('status')).toHaveTextContent('Importing… 2 of 3 transactions');
+      });
+      expect(screen.getByRole('progressbar')).toHaveAttribute('aria-valuenow', '67');
+
+      release?.();
+      await waitFor(() => {
+        expect(screen.getByText('Import Successful!')).toBeInTheDocument();
+      });
     });
   });
 

--- a/src/components/OFXImportModal.tsx
+++ b/src/components/OFXImportModal.tsx
@@ -1,12 +1,7 @@
 import React, { useState, useCallback, useMemo, useRef, useEffect } from 'react';
-import { useAuth } from '@clerk/clerk-react';
 import { useApp } from '../contexts/AppContextSupabase';
 import { ofxImportService } from '../services/ofxImportService';
-import {
-  transactionImportService,
-  type BulkImportResult
-} from '../services/transactionImportService';
-import { importTransactionsLocally } from '../services/localTransactionImportService';
+import { dataPort, type BulkImportResult } from '../services/port';
 import { summariseMissingRows, type MissingRowsSummary } from '../utils/partialImportSummary';
 import {
   planAccountDetailsBackfill,
@@ -124,10 +119,8 @@ export default function OFXImportModal({ isOpen, onClose, initialFile }: OFXImpo
     transactions,
     categories,
     updateAccount,
-    isUsingSupabase,
     refreshAccountsAndTransactions
   } = useApp();
-  const { getToken } = useAuth();
   const [file, setFile] = useState<File | null>(null);
   const [isProcessing, setIsProcessing] = useState(false);
   /**
@@ -398,34 +391,36 @@ export default function OFXImportModal({ isOpen, onClose, initialFile }: OFXImpo
       // of rows sharing a day was a race (the other half of the same defect is
       // written up in src/utils/transactionSort.ts).
       //
-      // Both paths below are all-or-nothing and both report what the write
-      // itself confirmed:
+      // One call, through the seam, whichever store this app is holding. Both
+      // engines behind it are all-or-nothing per unit and both report what the
+      // write itself confirmed:
       //   cloud — /api/data/import-transactions, one `import_transactions_atomic`
       //           per chunk, each its own database transaction;
-      //   local — one IndexedDB `setMany` covering the rows AND the balance.
+      //   device — one IndexedDB `setMany` covering the rows AND the balance.
       //
-      // `source: 'ofx'` is not a label. It tells the importer that every row
+      // `source: 'ofx'` is not a label. It tells the store that every row
       // carries the bank's own FITID (this modal writes it into `notes`), so
-      // each one is keyed by it in the database — which is what lets a chunk
-      // whose response was lost be posted again without paying for the
-      // statement twice, and what makes "just import the file again" true of
-      // the register and not only of this screen.
+      // each one can be keyed by it — which is what lets a chunk whose response
+      // was lost be posted again without paying for the statement twice, and
+      // what makes "just import the file again" true of the register and not
+      // only of this screen.
       // The size of the job, known now that duplicates have been dropped and
       // before a single row is written. Nothing is claimed as inserted yet.
       if (isMountedRef.current) {
         setProgress({ inserted: 0, total: result.transactions.length });
       }
 
-      const outcome: BulkImportResult = isUsingSupabase
-        ? await (async () => {
-            transactionImportService.setAuthTokenProvider(() => getToken());
-            return transactionImportService.importInChunks(destinationId, result.transactions, {
-              source: 'ofx',
-              // Fires between chunks, so it can also land after unmount.
-              onProgress: p => { if (isMountedRef.current) setProgress(p); }
-            });
-          })()
-        : await importTransactionsLocally(destinationId, result.transactions);
+      const outcome: BulkImportResult = await dataPort.importTransactions(
+        destinationId,
+        result.transactions,
+        {
+          source: 'ofx',
+          // Fires between chunks where the store commits in chunks; a single
+          // atomic write has no honest fraction and reports nothing until it
+          // is done. Either way it can land after unmount.
+          onProgress: p => { if (isMountedRef.current) setProgress(p); }
+        }
+      );
 
       // Re-read from the store rather than trusting the drafts: after this the
       // register shows what was actually written, including on a partial.
@@ -549,7 +544,7 @@ export default function OFXImportModal({ isOpen, onClose, initialFile }: OFXImpo
         setProgress(null);
       }
     }
-  }, [accounts, file, getToken, importAnywayFitIds, isUsingSupabase, parseResult, refreshAccountsAndTransactions, saveDetails, selectedAccountId, skipDuplicates, transactions, categories, updateAccount]);
+  }, [accounts, file, importAnywayFitIds, parseResult, refreshAccountsAndTransactions, saveDetails, selectedAccountId, skipDuplicates, transactions, categories, updateAccount]);
 
   // Reset modal
   const resetModal = useCallback(() => {

--- a/src/components/common/ImportProgress.tsx
+++ b/src/components/common/ImportProgress.tsx
@@ -12,11 +12,11 @@ import React from 'react';
  *
  * ── HONESTY OVER DECORATION ─────────────────────────────────────────────────
  * A percentage is only drawn from a number the writing path actually reported.
- * The cloud path posts in chunks and reports after each one
- * (transactionImportService.importInChunks → onProgress), so it can be
- * measured. A local write is ONE all-or-nothing IndexedDB transaction: there is
- * no honest fraction of it, so nothing pretends there is — the bar is
- * indeterminate and the text names the size of the job instead. A bar creeping
+ * The cloud store posts in chunks and reports after each one
+ * (dataPort.importTransactions → onProgress), so it can be measured. A device
+ * write is ONE all-or-nothing IndexedDB transaction: there is no honest
+ * fraction of it, so nothing pretends there is — the bar is indeterminate and
+ * the text names the size of the job instead. A bar creeping
  * towards 90% on a timer is a lie, and the one time it matters it is the lie
  * that keeps somebody waiting on a write that already failed.
  *

--- a/src/contexts/__tests__/AppContextBootThroughPort.test.tsx
+++ b/src/contexts/__tests__/AppContextBootThroughPort.test.tsx
@@ -233,6 +233,7 @@ vi.mock('../../services/port', () => {
     setTransactionArchived: refuse('setTransactionArchived'),
     archiveTransactionsBefore: refuse('archiveTransactionsBefore'),
     unarchiveAccount: refuse('unarchiveAccount'),
+    importTransactions: refuse('importTransactions'),
     linkTransferPair: refuse('linkTransferPair'),
     linkSplitLineTransfer: refuse('linkSplitLineTransfer'),
     unlinkTransfers: refuse('unlinkTransfers'),

--- a/src/services/__tests__/dataService.test.ts
+++ b/src/services/__tests__/dataService.test.ts
@@ -3,15 +3,23 @@ import { createDataService, DataService } from '../api/dataService';
 import { AccountService } from '../api/accountService';
 import { TransactionService } from '../api/transactionService';
 import { createSimpleAccountService } from '../api/simpleAccountService';
+import { registerSupabaseTokenGetter } from '../../lib/supabaseToken';
 import type { Account, Budget, Category, Goal, Transaction, TransactionSplit } from '../../types';
 import { STORAGE_KEYS } from '../storageAdapter';
 
 const createStorage = (initial: Record<string, unknown> = {}) => {
   const store = new Map<string, unknown>(Object.entries(initial));
+  const put = (key: string, value: unknown): void => {
+    store.set(key, Array.isArray(value) ? [...value] : value);
+  };
   return {
     get: vi.fn(async (key: string) => store.get(key) ?? null),
     set: vi.fn(async (key: string, value: unknown) => {
-      store.set(key, Array.isArray(value) ? [...value] : value);
+      put(key, value);
+    }),
+    /** Several keys as one unit — what the real adapter promises the bulk import. */
+    setMany: vi.fn(async (entries: ReadonlyArray<{ key: string; value: unknown }>) => {
+      for (const { key, value } of entries) put(key, value);
     }),
     snapshot: (key: string) => store.get(key)
   };
@@ -2515,5 +2523,262 @@ describe('DataService.subscribeToUpdates', () => {
       stop();
       stop();
     }).not.toThrow();
+  });
+});
+
+/**
+ * Which writer a file goes to, and what it is given.
+ *
+ * This decision used to be made TWICE, in two React components, each reading
+ * `isUsingSupabase` off the context and each holding its own Clerk token to
+ * hand the cloud client. Both are now one call to the seam, so this is where
+ * the fork lives and this is where it is tested: the components no longer have
+ * an opinion to get wrong.
+ *
+ * Both writers are injected doubles. What they DO is already proved against
+ * real behaviour elsewhere (transactionImportService.test.ts,
+ * localTransactionImportService.test.ts, and the contract suite, which drives
+ * the real device importer through a real store); what is at stake here is the
+ * routing, the call shape, and the fact that a wrongly-routed statement is a
+ * register that disagrees with a bank.
+ */
+describe('DataService.importTransactions (which writer gets the file)', () => {
+  const logger = { error: vi.fn(), warn: vi.fn(), log: vi.fn() };
+
+  /** Two rows of an invented statement, as a parser hands them over. */
+  const statement = (): Array<Omit<Transaction, 'id'>> => [
+    {
+      accountId: 'acct-1',
+      amount: -12.75,
+      date: new Date('2025-02-03T00:00:00.000Z'),
+      description: 'DIRECT DEBIT THAMES WATER',
+      category: 'bills',
+      type: 'expense'
+    },
+    {
+      accountId: 'acct-1',
+      amount: 312.75,
+      date: new Date('2025-02-04T00:00:00.000Z'),
+      description: 'TWO WAY SWEEP IN',
+      category: 'transfer',
+      type: 'income'
+    }
+  ];
+
+  const landed = (rows: ReadonlyArray<unknown>) => ({
+    inserted: rows.length,
+    alreadyPresent: 0,
+    total: rows.length,
+    complete: true as const
+  });
+
+  const cloudClient = () => ({
+    setAuthTokenProvider: vi.fn(),
+    importInChunks: vi.fn(async (_accountId: string, rows: ReadonlyArray<unknown>) => landed(rows))
+  });
+
+  const deviceWriter = () =>
+    vi.fn(async (_accountId: string, rows: ReadonlyArray<unknown>) => landed(rows));
+
+  const resolvedOwner = {
+    ensureUserExists: vi.fn(),
+    getCurrentDatabaseUserId: vi.fn(() => 'db-user-1' as string | null),
+    getCurrentUserIds: vi.fn(() => ({ clerkId: 'clerk-1', databaseId: 'db-user-1' }))
+  };
+  const noOwner = {
+    ensureUserExists: vi.fn(),
+    getCurrentDatabaseUserId: vi.fn(() => null),
+    getCurrentUserIds: vi.fn(() => ({ clerkId: null, databaseId: null }))
+  };
+
+  afterEach(() => {
+    // The registry is module state shared with every other suite in this file.
+    registerSupabaseTokenGetter(null);
+  });
+
+  it('signed in: posts the file through the chunked cloud client, and nothing goes to the device', async () => {
+    const client = cloudClient();
+    const device = deviceWriter();
+    const service = createDataService({
+      isSupabaseConfigured: () => true,
+      userIdService: resolvedOwner,
+      storageAdapter: createStorage(),
+      logger,
+      bulkImportService: client,
+      localBulkImport: device
+    });
+    const rows = statement();
+
+    await service.importTransactions('acct-1', rows);
+
+    expect(client.importInChunks).toHaveBeenCalledTimes(1);
+    expect(client.importInChunks).toHaveBeenCalledWith('acct-1', rows, {});
+    expect(device).not.toHaveBeenCalled();
+  });
+
+  it('installs the session token on the client BEFORE the first chunk is posted', async () => {
+    // Order is the whole point: the client posts with whatever provider it is
+    // holding, so installing one after the call would authenticate the SECOND
+    // import of a session and 401 the first.
+    const order: string[] = [];
+    const client = {
+      setAuthTokenProvider: vi.fn(() => { order.push('token'); }),
+      importInChunks: vi.fn(async (_accountId: string, rows: ReadonlyArray<unknown>) => {
+        order.push('post');
+        return landed(rows);
+      })
+    };
+    const service = createDataService({
+      isSupabaseConfigured: () => true,
+      userIdService: resolvedOwner,
+      storageAdapter: createStorage(),
+      logger,
+      bulkImportService: client
+    });
+
+    await service.importTransactions('acct-1', statement());
+
+    expect(order).toEqual(['token', 'post']);
+  });
+
+  it('authenticates with the very token AuthContext registered for the session', async () => {
+    // The relocation, end to end. The CSV wizard used to pass Clerk's own
+    // `getToken` from a React hook; the seam takes the same session's token
+    // from the registry AuthContext fills, so nothing in the UI has to know
+    // that an import is authenticated at all.
+    registerSupabaseTokenGetter(async () => 'jwt-from-the-session');
+    const client = cloudClient();
+    const service = createDataService({
+      isSupabaseConfigured: () => true,
+      userIdService: resolvedOwner,
+      storageAdapter: createStorage(),
+      logger,
+      bulkImportService: client
+    });
+
+    await service.importTransactions('acct-1', statement());
+
+    const provider = client.setAuthTokenProvider.mock.calls[0][0];
+    expect(typeof provider).toBe('function');
+    expect(await provider()).toBe('jwt-from-the-session');
+  });
+
+  it('on a device: writes through the atomic store import, with this service\'s own store and ids', async () => {
+    // The store matters as much as the route. The device importer defaults to
+    // the app's real adapter when handed nothing, so a service told to use a
+    // different store must hand that store over — otherwise a demo import
+    // would write the signed-out user's encrypted store instead.
+    const client = cloudClient();
+    const device = deviceWriter();
+    const storage = createStorage();
+    const service = createDataService({
+      isSupabaseConfigured: () => false,
+      userIdService: noOwner,
+      storageAdapter: storage,
+      logger,
+      uuid: () => 'generated-id',
+      bulkImportService: client,
+      localBulkImport: device
+    });
+    const rows = statement();
+
+    await service.importTransactions('acct-1', rows);
+
+    expect(client.importInChunks).not.toHaveBeenCalled();
+    expect(device).toHaveBeenCalledTimes(1);
+    const [accountId, given, options] = device.mock.calls[0];
+    expect(accountId).toBe('acct-1');
+    expect(given).toBe(rows);
+    expect(options?.uuid?.()).toBe('generated-id');
+    await options?.store?.setMany?.([{ key: 'k', value: [1] }]);
+    expect(storage.setMany).toHaveBeenCalledWith([{ key: 'k', value: [1] }]);
+  });
+
+  it('carries what the caller said about the rows to the writer that ran', async () => {
+    // `source: 'ofx'` is what lets a re-posted chunk be refused instead of
+    // paid for twice, and `onProgress` is what the progress bar is drawn from.
+    // Both are the caller's statement about the rows, not the route's.
+    const client = cloudClient();
+    const service = createDataService({
+      isSupabaseConfigured: () => true,
+      userIdService: resolvedOwner,
+      storageAdapter: createStorage(),
+      logger,
+      bulkImportService: client
+    });
+    const onProgress = vi.fn();
+
+    await service.importTransactions('acct-1', statement(), { source: 'ofx', onProgress });
+
+    expect(client.importInChunks).toHaveBeenCalledWith(
+      'acct-1',
+      expect.any(Array),
+      { source: 'ofx', onProgress }
+    );
+  });
+
+  it('hands the writer\'s answer back exactly as it came, prefix count and all', async () => {
+    // B-9. The caller slices the rows it handed in at `inserted` to name the
+    // payments that are missing, so a route that rounded this up — or lost the
+    // sentence saying what stopped it — would report rows as landed that are
+    // not in the account.
+    const client = cloudClient();
+    client.importInChunks.mockResolvedValueOnce({
+      inserted: 1,
+      alreadyPresent: 0,
+      total: 2,
+      complete: false,
+      error: 'Import request failed (503)'
+    });
+    const service = createDataService({
+      isSupabaseConfigured: () => true,
+      userIdService: resolvedOwner,
+      storageAdapter: createStorage(),
+      logger,
+      bulkImportService: client
+    });
+
+    const outcome = await service.importTransactions('acct-1', statement());
+
+    expect(outcome).toEqual({
+      inserted: 1,
+      alreadyPresent: 0,
+      total: 2,
+      complete: false,
+      error: 'Import request failed (503)'
+    });
+  });
+
+  it('refuses rather than writing elsewhere when the store cannot write as one unit', async () => {
+    // Unreachable in the app — the real adapter writes many keys as one — and
+    // reachable from a test double that does not. Falling through to the
+    // importer's default would put the rows in the app's real store while the
+    // test watched an empty double.
+    const client = cloudClient();
+    const device = deviceWriter();
+    const partialAdapter = {
+      get: vi.fn(async () => null),
+      set: vi.fn(async () => {})
+    };
+    const service = createDataService({
+      isSupabaseConfigured: () => false,
+      userIdService: noOwner,
+      storageAdapter: partialAdapter,
+      logger,
+      bulkImportService: client,
+      localBulkImport: device
+    });
+
+    const outcome = await service.importTransactions('acct-1', statement());
+
+    expect(outcome).toEqual({
+      inserted: 0,
+      alreadyPresent: 0,
+      total: 2,
+      complete: false,
+      error: 'This device cannot store the import as one piece, so nothing was written.'
+    });
+    expect(device).not.toHaveBeenCalled();
+    expect(client.importInChunks).not.toHaveBeenCalled();
   });
 });

--- a/src/services/api/dataService.ts
+++ b/src/services/api/dataService.ts
@@ -11,7 +11,7 @@ import { TransactionService, type TransactionLoadResult } from './transactionSer
 import { PlanningService } from './planningService';
 import { SuggestionDismissalService } from './suggestionDismissalService';
 import { isSupabaseConfigured } from './supabaseClient';
-import { hasSupabaseTokenGetter } from '../../lib/supabaseToken';
+import { getSupabaseAccessToken, hasSupabaseTokenGetter } from '../../lib/supabaseToken';
 import { storageAdapter, STORAGE_KEYS } from '../storageAdapter';
 import { userIdService } from '../userIdService';
 import { toDecimal, type DecimalInstance } from '../../utils/decimal';
@@ -23,7 +23,21 @@ import {
 } from '../../utils/accountNumberInput';
 import { splitDeclaresTransferLeg } from '../../utils/transactionSplits';
 import { getDefaultCategories } from '../../data/defaultCategories';
-import type { AccountBalanceSnapshot, BootTransactionsResult, DataPort } from '../port/dataPort';
+import type {
+  AccountBalanceSnapshot,
+  BootTransactionsResult,
+  BulkImportProgress,
+  BulkImportResult,
+  DataPort,
+  ImportSourceKind
+} from '../port/dataPort';
+// Type-only, so the bulk importers themselves stay out of the boot chunk —
+// the values are fetched on demand (see `cloudBulkImportClient`).
+import type { TransactionImportService } from '../transactionImportService';
+import type {
+  LocalImportOptions,
+  LocalTransactionImportStore
+} from '../localTransactionImportService';
 import type { Account, AccountUpdate, Transaction, TransactionSplit, TransactionSplitInput, SplitWriteResult, Budget, Goal, Category, CategoryMergeResult, DismissalKind, SuggestionDismissal } from '../../types';
 
  type Logger = Pick<Console, 'log' | 'warn' | 'error'>;
@@ -73,7 +87,25 @@ type SuggestionDismissalServiceLike = Pick<typeof SuggestionDismissalService,
   'list' | 'dismiss' | 'restore'>;
 type UserIdServiceLike = Pick<typeof userIdService,
   'ensureUserExists' | 'getCurrentDatabaseUserId' | 'getCurrentUserIds'>;
-type StorageAdapterLike = Pick<typeof storageAdapter, 'get' | 'set'>;
+/**
+ * `setMany` is OPTIONAL for the same reason the reads above are: a partial
+ * double stays a usable stand-in. It is the "write these keys as one unit"
+ * promise, which only the bulk import needs — and an adapter that cannot make
+ * that promise is told so rather than worked around (see `localImportStore`).
+ */
+type StorageAdapterLike = Pick<typeof storageAdapter, 'get' | 'set'> &
+  Partial<Pick<typeof storageAdapter, 'setMany'>>;
+/** The chunked cloud import client, narrowed to what the seam asks of it. */
+type BulkImportClientLike = Pick<TransactionImportService,
+  'setAuthTokenProvider' | 'importInChunks'>;
+/** The device-side atomic import, in the shape the seam calls it. */
+type LocalBulkImporter = (
+  accountId: string,
+  transactions: ReadonlyArray<Omit<Transaction, 'id'>>,
+  options?: LocalImportOptions
+) => Promise<BulkImportResult>;
+/** The session token the cloud import posts with. Null when signed out. */
+type AuthTokenProvider = () => Promise<string | null>;
 type SupabaseChecker = () => boolean;
 type CloudSessionChecker = () => boolean;
 type DateProvider = () => Date;
@@ -93,6 +125,19 @@ export interface DataServiceOptions {
   isSupabaseConfigured?: SupabaseChecker;
   /** Whether a signed-in (Clerk) session exists right now. */
   hasCloudSession?: CloudSessionChecker;
+  /**
+   * The two bulk-import writers. Absent means "fetch the real one when an
+   * import runs" rather than "do without": there is no honest fallback for a
+   * write, and a bulk write is the largest one this class makes.
+   */
+  bulkImportService?: BulkImportClientLike;
+  localBulkImport?: LocalBulkImporter;
+  /**
+   * How the cloud import authenticates. Defaults to the registry AuthContext
+   * fills with the signed-in session's Clerk getToken — the same token every
+   * other cloud call on this class travels with.
+   */
+  authTokenProvider?: AuthTokenProvider;
 }
 
 class DataServiceImpl implements DataPort {
@@ -108,6 +153,9 @@ class DataServiceImpl implements DataPort {
   private readonly uuid: UuidGenerator;
   private readonly supabaseChecker: SupabaseChecker;
   private readonly hasCloudSession: CloudSessionChecker;
+  private readonly injectedBulkImportService: BulkImportClientLike | null;
+  private readonly injectedLocalBulkImport: LocalBulkImporter | null;
+  private readonly authTokenProvider: AuthTokenProvider;
 
   constructor(options: DataServiceOptions = {}) {
     this.accountService = options.accountService ?? AccountService;
@@ -134,6 +182,9 @@ class DataServiceImpl implements DataPort {
     });
     this.supabaseChecker = options.isSupabaseConfigured ?? isSupabaseConfigured;
     this.hasCloudSession = options.hasCloudSession ?? hasSupabaseTokenGetter;
+    this.injectedBulkImportService = options.bulkImportService ?? null;
+    this.injectedLocalBulkImport = options.localBulkImport ?? null;
+    this.authTokenProvider = options.authTokenProvider ?? getSupabaseAccessToken;
   }
 
   private isSupabaseReady(): boolean {
@@ -588,6 +639,118 @@ class DataServiceImpl implements DataPort {
     });
     await this.persistCollection(STORAGE_KEYS.TRANSACTIONS, updated);
     return count;
+  }
+
+  /**
+   * The chunked cloud import client, fetched the first time an import runs.
+   *
+   * DYNAMICALLY IMPORTED ON PURPOSE. This class is in the boot chunk — the
+   * context reaches it on the first paint — while the two importers are code
+   * only a person importing a file ever executes. A static import here was
+   * built and measured: it puts both of them in everyone's first load and
+   * takes the boot chunk from 323.8 KB gzipped to 326.1 KB, on a budget it is
+   * already over. Dynamic keeps them as their own chunks — 1.9 KB and 0.7 KB
+   * gzipped — fetched when Import is pressed, on a connection that has just
+   * served a dialog several times their size.
+   */
+  private async cloudBulkImportClient(): Promise<BulkImportClientLike> {
+    if (this.injectedBulkImportService) return this.injectedBulkImportService;
+    const { transactionImportService } = await import('../transactionImportService');
+    return transactionImportService;
+  }
+
+  /** The device-side atomic import. Loaded on demand for the reason above. */
+  private async deviceBulkImporter(): Promise<LocalBulkImporter> {
+    if (this.injectedLocalBulkImport) return this.injectedLocalBulkImport;
+    const { importTransactionsLocally } = await import('../localTransactionImportService');
+    return importTransactionsLocally;
+  }
+
+  /**
+   * This implementation's own store, in the shape the device importer takes.
+   *
+   * The importer defaults to the app's adapter when handed nothing, and that
+   * default is right in production — it IS this.storage — but wrong in a test
+   * that injected one: a write meant for a double's Map would land in the real
+   * encrypted store instead. So the store is passed explicitly, and an adapter
+   * that cannot write several keys as one unit gets `null` rather than a
+   * silent redirection (see the refusal in `importTransactions`).
+   *
+   * The wrappers exist because the adapter's methods use `this`; the generic
+   * arrow keeps `get` generic, which a `.bind()` would not.
+   */
+  private localImportStore(): LocalTransactionImportStore | null {
+    const storage = this.storage;
+    const setMany = storage.setMany;
+    if (typeof setMany !== 'function') return null;
+    return {
+      get: <T>(key: string): Promise<T | null> => storage.get<T>(key),
+      setMany: entries => setMany.call(storage, entries)
+    };
+  }
+
+  /**
+   * Add a file's worth of transactions to one account.
+   *
+   * THE ROUTE, AND ONLY THE ROUTE. Both halves of this already existed and are
+   * unchanged: the chunked poster to /api/data/import-transactions, and the
+   * one-IndexedDB-transaction writer. What changed is who decides between them
+   * — it was the CSV wizard and the OFX dialog, each reading `isUsingSupabase`
+   * off the context and each holding its own Clerk token, and it is now this
+   * one line. The predicate is the same one `DataService.isUsingSupabase()`
+   * answers with, evaluated at the moment of the write rather than at the boot
+   * that last set that state.
+   *
+   * THE TOKEN IS THE SEAM'S OWN. The dialogs used to hand the client a
+   * `() => getToken()` closure out of Clerk's React hook immediately before
+   * posting; it is installed here instead, at the same moment — on the same
+   * tick as the write, before the first chunk — from the registry AuthContext
+   * fills with the same session's getToken. A component asking a data layer to
+   * authenticate itself was the last thing keeping a token in the UI.
+   *
+   * NO PENDING-SESSION GUARD, DELIBERATELY. Every planning write on this class
+   * refuses while a signed-in session is still resolving its database id; this
+   * one keeps today's behaviour and writes the browser's store, because
+   * changing it is a decision about what an import does mid-connection and
+   * belongs in a change that says so rather than in a routing move.
+   */
+  async importTransactions(
+    accountId: string,
+    transactions: ReadonlyArray<Omit<Transaction, 'id'>>,
+    options: {
+      onProgress?: (progress: BulkImportProgress) => void;
+      source?: ImportSourceKind;
+    } = {}
+  ): Promise<BulkImportResult> {
+    if (this.isSupabaseReady()) {
+      const client = await this.cloudBulkImportClient();
+      client.setAuthTokenProvider(this.authTokenProvider);
+      return client.importInChunks(accountId, transactions, options);
+    }
+
+    const store = this.localImportStore();
+    if (!store) {
+      // Unreachable in the app: the real adapter writes many keys as one unit.
+      // Reachable from a test double that does not, and the honest answer
+      // there is to refuse rather than write to the store the double replaced.
+      return {
+        inserted: 0,
+        alreadyPresent: 0,
+        total: transactions.length,
+        complete: false,
+        error: 'This device cannot store the import as one piece, so nothing was written.'
+      };
+    }
+
+    const importLocally = await this.deviceBulkImporter();
+    // `source` says how the rows may be keyed against ones already held, and
+    // `onProgress` measures a write that commits in pieces. A single atomic
+    // write has neither an id space nor a fraction, so it is handed neither —
+    // the silence is declared on the seam (B-9) rather than papered over.
+    return importLocally(accountId, transactions, {
+      store,
+      uuid: () => this.generateId()
+    });
   }
 
   /** Every split line of the user's transactions (for category aggregation). */
@@ -2065,6 +2228,17 @@ export class DataService {
 
   static confirmTransactionCategories(ids: string[]): Promise<number> {
     return this.service.confirmTransactionCategories(ids);
+  }
+
+  static importTransactions(
+    accountId: string,
+    transactions: ReadonlyArray<Omit<Transaction, 'id'>>,
+    options?: {
+      onProgress?: (progress: BulkImportProgress) => void;
+      source?: ImportSourceKind;
+    }
+  ): Promise<BulkImportResult> {
+    return this.service.importTransactions(accountId, transactions, options);
   }
 
   static archiveTransactionsBefore(accountId: string, cutoff: Date): Promise<number> {

--- a/src/services/localTransactionImportService.ts
+++ b/src/services/localTransactionImportService.ts
@@ -1,13 +1,13 @@
 import type { Account, Transaction } from '../types';
-import type { BulkImportResult } from './transactionImportService';
+import type { BulkImportResult } from './port/dataPort';
 import { storageAdapter, STORAGE_KEYS } from './storageAdapter';
 import { normalizeTransactionDates, toDateValue } from '../utils/dateBoundary';
 import { toDecimal } from '../utils/decimal';
 import { createScopedLogger } from '../loggers/scopedLogger';
 
 /**
- * Bulk transaction import for local/demo mode — the no-cloud twin of
- * transactionImportService.
+ * Bulk transaction import for local/demo mode — the DEVICE half of the seam's
+ * `importTransactions`, and the no-cloud twin of transactionImportService.
  *
  * ── WHY IT EXISTS ───────────────────────────────────────────────────────────
  * Signed in, a file import goes to /api/data/import-transactions, which puts

--- a/src/services/port/__tests__/contract.ts
+++ b/src/services/port/__tests__/contract.ts
@@ -156,6 +156,8 @@ export const DATA_PORT_OPERATIONS: readonly (keyof DataPort)[] = [
   'setTransactionArchived',
   'archiveTransactionsBefore',
   'unarchiveAccount',
+  // Bulk writes
+  'importTransactions',
   // Transfer writes
   'linkTransferPair',
   'linkSplitLineTransfer',
@@ -322,6 +324,38 @@ const BULK_PRUNE: Record<DataPortEngine, { describes: string; reverifies: boolea
   'browser-storage': { describes: 'does what the plan says', reverifies: false },
   supabase: { describes: 're-judges every row and keeps the ones still in use', reverifies: true },
   'local-core': { describes: 're-judges every row and keeps the ones still in use', reverifies: true }
+};
+
+/**
+ * B-9 — how a bulk import can fail, and whether it can say how far it has got.
+ *
+ * The rule EVERY engine keeps, asserted below rather than declared: `inserted`
+ * is a PREFIX count. Rows [0, inserted) of the file are in the account, rows
+ * [inserted, total) are not, in file order. Both callers slice the array they
+ * handed in at that number to name the missing payments to somebody holding the
+ * statement, so a count that merely totalled the rows written — with the gaps
+ * anywhere else — would send them looking for the wrong transactions.
+ *
+ * `partial` is how far a failure can get, and it follows from the size of the
+ * unit each engine writes in: the cloud posts chunks that each commit on their
+ * own, so it can stop at any chunk boundary; a device write is ONE store
+ * transaction, so it is 0 or all of them. Both are prefixes.
+ *
+ * `reportsProgress` is whether `onProgress` can fire before the answer. An
+ * engine that commits in pieces can count them honestly; one atomic write has
+ * no fraction to report, and inventing one is the bar-creeping-to-90% lie that
+ * keeps somebody waiting on a write that already failed.
+ */
+const BULK_IMPORT: Record<
+  DataPortEngine,
+  { partial: 'all-or-nothing' | 'any prefix'; reportsProgress: boolean }
+> = {
+  // One IndexedDB transaction covering the rows and the balance together.
+  'browser-storage': { partial: 'all-or-nothing', reportsProgress: false },
+  // Chunks of a thousand, each its own database transaction.
+  supabase: { partial: 'any prefix', reportsProgress: true },
+  // One store transaction, same as the browser and for the same reason.
+  'local-core': { partial: 'all-or-nothing', reportsProgress: false }
 };
 
 /**
@@ -780,6 +814,138 @@ export function runDataPortContract(name: string, harness: DataPortContractHarne
         }
         expect(balances.get(ACCOUNT_A)?.balance).toBe(0.3);
         expect(balances.get(ACCOUNT_A)?.txnCount).toBe(1);
+      });
+    });
+
+    describe('importing a file', () => {
+      /**
+       * A statement as a parser hands one over: drafts, no ids — and every row
+       * naming the WRONG account, because that is what a real file does. A CSV
+       * says "Barclays" in a column and a parser guesses at it; the destination
+       * the user picked is the one that must win.
+       *
+       * The three amounts are another IEEE-754 trap: 10.1 + 20.2 + 0.3 is
+       * 30.599999999999998 in float, and this is the largest single balance
+       * movement anything in the app makes.
+       */
+      const statement = (): Array<Omit<Transaction, 'id'>> => [
+        {
+          accountId: ACCOUNT_A,
+          amount: 10.1,
+          date: AT('2025-02-03'),
+          description: 'CHEQUE PAID IN',
+          category: 'cat-everyday',
+          type: 'income'
+        },
+        {
+          accountId: ACCOUNT_A,
+          amount: 20.2,
+          date: AT('2025-02-04'),
+          description: 'REFUND FROM SHOP',
+          category: 'cat-everyday',
+          type: 'income'
+        },
+        {
+          accountId: ACCOUNT_A,
+          amount: 0.3,
+          date: AT('2025-02-05'),
+          description: 'INTEREST',
+          category: 'cat-everyday',
+          type: 'income'
+        }
+      ];
+
+      it('files every row into the account it was told, and moves that balance to the penny', async () => {
+        const { port, read } = await harness.create({ accounts: threeAccounts() });
+        const rows = statement();
+
+        const result = await port.importTransactions(ACCOUNT_C, rows);
+
+        expect(result.inserted).toBe(rows.length);
+        expect(result.total).toBe(rows.length);
+        expect(result.complete).toBe(true);
+        // Never more "already here" than "here": the second number is a subset
+        // of the first, not a separate pile added beside it.
+        expect(result.alreadyPresent).toBeLessThanOrEqual(result.inserted);
+
+        const state = await read();
+        const landed = state.transactions.filter(t => t.accountId === ACCOUNT_C);
+        expect(landed.map(t => t.description).sort()).toEqual(
+          rows.map(row => row.description).sort()
+        );
+        // Every row usable at once: an id of its own, and no two the same.
+        expect(new Set(landed.map(t => t.id)).size).toBe(rows.length);
+        expect(landed.every(t => Boolean(t.id))).toBe(true);
+
+        // The destination beat the parser's guess — for the rows AND for the
+        // money. A statement filed into the wrong account is a register that
+        // disagrees with the bank by whatever the file was worth.
+        expect(balanceOf(state, ACCOUNT_C)).toBe(30.6);
+        expect(balanceOf(state, ACCOUNT_A)).toBe(-70.1);
+        expect(state.transactions.some(t => t.accountId === ACCOUNT_A)).toBe(false);
+      });
+
+      it('B-9: what it says landed is a prefix of the file, and the rest really is absent', async () => {
+        // The rule both importers depend on LITERALLY: each slices the array it
+        // handed in at `inserted` and shows the remainder as "these payments
+        // are missing". So this asks the store what it holds and compares it
+        // against exactly that slice. An implementation that reported a count
+        // it had not written — or wrote rows it did not count — fails here
+        // rather than in front of somebody comparing a paper statement.
+        const { port, read } = await harness.create({ accounts: threeAccounts() });
+        const rows = statement();
+        const before = asComparable(await read());
+
+        // An account that is not there: the one refusal every engine makes for
+        // itself (the cloud RPC's account_not_found_or_not_owned, and the same
+        // judgement on a device), and the cheapest way to ask for a write that
+        // does not happen.
+        const result = await port.importTransactions('acct-that-is-not-there', rows);
+
+        expect(result.complete).toBe(false);
+        // Prose, because the caller renders it (rule 4 of the seam).
+        expect(typeof result.error).toBe('string');
+        expect(result.error).not.toBe('');
+        expect(result.total).toBe(rows.length);
+
+        const state = await read();
+        expect(state.transactions.map(t => t.description))
+          .toEqual(rows.slice(0, result.inserted).map(row => row.description));
+        // And a write that did not happen changed nothing else either.
+        expect(asComparable(state)).toBe(before);
+      });
+
+      it(`B-9: when the store fails mid-import, this engine lands ${BULK_IMPORT[engine].partial}`, async () => {
+        // REPORTED, NOT THROWN. "412 of 900 landed" is an outcome the caller
+        // has to render — the missing rows are named on screen — so a store
+        // that will not answer must come back as a result, not as a rejection
+        // the import dialog would turn into "Import failed" and nothing else.
+        const port = await harness.createUnreadable();
+        const rows = statement();
+
+        const result = await port.importTransactions(ACCOUNT_C, rows);
+
+        expect(result.complete).toBe(false);
+        expect(result.total).toBe(rows.length);
+        if (BULK_IMPORT[engine].partial === 'all-or-nothing') {
+          expect([0, rows.length]).toContain(result.inserted);
+        } else {
+          expect(result.inserted).toBeGreaterThanOrEqual(0);
+          expect(result.inserted).toBeLessThanOrEqual(rows.length);
+        }
+      });
+
+      it('writes nothing at all when the file has no rows', async () => {
+        // The ordinary case rather than a caller's mistake: a statement whose
+        // every row was already in the register arrives here empty, because the
+        // duplicate check ran before anyone knew what would be left.
+        const { port, read } = await harness.create({ accounts: threeAccounts() });
+        const before = asComparable(await read());
+
+        const result = await port.importTransactions(ACCOUNT_C, []);
+
+        expect(result).toMatchObject({ inserted: 0, alreadyPresent: 0, total: 0, complete: true });
+        expect(asComparable(await read())).toBe(before);
       });
     });
 

--- a/src/services/port/__tests__/dataService.contract.test.ts
+++ b/src/services/port/__tests__/dataService.contract.test.ts
@@ -45,11 +45,25 @@ const createStore = (fixture: PortFixture) => {
     return Array.isArray(stored) ? (stored as T[]) : [];
   };
 
+  const put = (key: string, value: unknown): void => {
+    data.set(key, Array.isArray(value) ? [...value] : value);
+  };
+
   return {
     adapter: {
       get: vi.fn(async (key: string) => data.get(key) ?? null),
       set: vi.fn(async (key: string, value: unknown) => {
-        data.set(key, Array.isArray(value) ? [...value] : value);
+        put(key, value);
+      }),
+      /**
+       * Several keys as ONE unit, which is what the real adapter promises and
+       * what the bulk import is built on: the rows and the balance move
+       * together or neither does. A Map cannot half-apply a loop that does not
+       * throw, so the promise holds here for the same reason it holds in an
+       * IndexedDB transaction — nothing else can see the middle of it.
+       */
+      setMany: vi.fn(async (entries: ReadonlyArray<{ key: string; value: unknown }>) => {
+        for (const { key, value } of entries) put(key, value);
       })
     },
     read: async (): Promise<PortStoreState> => ({
@@ -149,7 +163,7 @@ const createUnreadableBrowserStoragePort = async (): Promise<DataPort> => {
   return createDataService({
     isSupabaseConfigured: () => false,
     hasCloudSession: () => false,
-    storageAdapter: { get: vi.fn(refuse), set: vi.fn(refuse) },
+    storageAdapter: { get: vi.fn(refuse), set: vi.fn(refuse), setMany: vi.fn(refuse) },
     planningService: refusingPlanningService(),
     logger: { log: vi.fn(), warn: vi.fn(), error: vi.fn() },
     now: () => new Date('2025-06-01T09:00:00.000Z'),

--- a/src/services/port/dataPort.ts
+++ b/src/services/port/dataPort.ts
@@ -42,9 +42,10 @@
  *
  * This is the seam as it stands, not as it will end: the operations below are
  * exactly the ones DataService owns today, under the names it uses today.
- * Bulk import, backup/restore/wipe, and the capability descriptor that will
- * retire `isUsingSupabase` all join this interface as their consumers are
- * routed through it. The names here are today's names
+ * Bulk import has joined it (the CSV and OFX importers write through
+ * `importTransactions`); backup/restore/wipe and the capability descriptor that
+ * will retire `isUsingSupabase` join as their consumers are routed through it
+ * in turn. The names here are today's names
  * deliberately: renaming and re-routing in one step would make a rename
  * indistinguishable from a behaviour change in review.
  */
@@ -234,6 +235,135 @@ export interface DataPortTransactionWrites {
   archiveTransactionsBefore(accountId: string, cutoff: Date): Promise<number>;
   /** Bring an account's archived rows back into the register. Returns rows touched. */
   unarchiveAccount(accountId: string): Promise<number>;
+}
+
+/**
+ * How far a bulk import got, reported while it is still running.
+ *
+ * `inserted` is the same number `BulkImportResult.inserted` ends up holding,
+ * seen part-way: rows of THIS import that are in the account so far. It is what
+ * the progress bar is drawn from, so an implementation that cannot honestly
+ * measure its own progress must stay silent rather than estimate — see the
+ * divergence on `importTransactions` below.
+ */
+export interface BulkImportProgress {
+  /** Rows of the import that are in the account so far. */
+  inserted: number;
+  /** Total rows to import. */
+  total: number;
+}
+
+/**
+ * What a bulk import DID, as opposed to what the file offered.
+ *
+ * ── `inserted` IS A PREFIX COUNT (divergence B-9) ───────────────────────────
+ *
+ * Rows `[0, inserted)` of the array that was handed in are in the account; rows
+ * `[inserted, total)` are not, IN FILE ORDER. That is not a description of how
+ * one engine happens to work, it is the contract: both callers slice the
+ * original array at this number to name the payments that are missing, on
+ * screen, to somebody holding the statement they came from. A count that
+ * merely totalled the rows written — with the gaps anywhere else in the file —
+ * would have them looking for the wrong transactions.
+ *
+ * How far a partial can get differs, and is declared rather than asserted
+ * equal: the cloud posts in chunks that each commit on their own, so it can
+ * stop anywhere; a device write is one atomic transaction, so its answer is
+ * always 0 or all of them. Both keep the prefix rule — 0 and `total` are
+ * prefixes too.
+ */
+export interface BulkImportResult {
+  /**
+   * Rows of the import that are now IN THE ACCOUNT — written by this run, or
+   * refused by the store as a repeat of a row this same run had already
+   * written (see `alreadyPresent`). Always a PREFIX: rows [inserted, total)
+   * are the ones that are missing, in file order.
+   */
+  inserted: number;
+  /**
+   * How many of `inserted` the store already held under this import's own id
+   * and therefore did not write again — a re-posted chunk after a timeout, or
+   * a statement offering rows the account already has under the bank's own
+   * transaction id. Counted as landed because they ARE landed; reported
+   * separately because "we wrote 900 rows" and "800 of those were already
+   * here" are different sentences and the user is owed the true one.
+   *
+   * An engine with no request to re-send and no id to collide with answers 0,
+   * and that is a statement rather than a stub.
+   */
+  alreadyPresent: number;
+  /** Rows the caller asked to import. */
+  total: number;
+  /** True when the whole import landed. */
+  complete: boolean;
+  /** Why it stopped, in prose a user can act on, when it did not finish. */
+  error?: string;
+}
+
+/**
+ * What the rows carry with them, which decides what a store can key them by.
+ *
+ * 'ofx' says every row holds the bank's own transaction id (the OFX modal
+ * writes it into `notes`), which OFX guarantees unique within the account — so
+ * an engine can refuse a second copy of one it already has, and "just import
+ * the file again" becomes true of the register rather than only of the screen.
+ * 'file' says the rows have no identity of their own beyond their position,
+ * which is all a CSV or a QIF can promise.
+ */
+export type ImportSourceKind = 'ofx' | 'file';
+
+export interface DataPortBulkWrites {
+  /**
+   * Add a file's worth of transactions to one account.
+   *
+   * The rows are drafts, exactly as a create takes them, and the account they
+   * go into is the one named HERE — the destination the user chose wins over
+   * whatever a parser guessed for each row.
+   *
+   * ── WHAT IT PROMISES ────────────────────────────────────────────────────
+   *
+   * The account's balance moves by the sum of the rows that landed, to the
+   * penny, and it moves WITH them: no engine may leave a register holding rows
+   * a balance does not account for. Every engine writes in units that are
+   * all-or-nothing (one database transaction in the cloud, one store write on a
+   * device), so a failure leaves a whole unit unwritten rather than half of one.
+   *
+   * `inserted` is a PREFIX count. The rule, and why the callers depend on it
+   * literally, is written out on {@link BulkImportResult}.
+   *
+   * IT DOES NOT REJECT for a store that refused the write: a bulk import is
+   * reported, not thrown, because "412 of 900 landed" is an outcome a caller
+   * has to render rather than a failure it can retry blindly. It may reject for
+   * a caller error.
+   *
+   * ── DIVERGENCE B-9 ──────────────────────────────────────────────────────
+   *
+   * Two things differ and are declared rather than asserted equal:
+   *
+   *   HOW FAR A PARTIAL GETS — the cloud commits chunk by chunk and can stop
+   *   at any chunk boundary; a device write is one transaction, so its answer
+   *   is 0 or all of them.
+   *
+   *   WHETHER PROGRESS IS REPORTED — `onProgress` fires per committed chunk in
+   *   the cloud and never on a device, because one atomic write has no honest
+   *   fraction. A caller must therefore treat silence as normal and never wait
+   *   on a first report.
+   *
+   * IT DOES NOT TAKE AN OWNER, and the rule stated at length on
+   * `createBudget` applies here with the most money on it of anywhere in this
+   * seam: a statement filed into the wrong store is a register that disagrees
+   * with the bank by however much the file was worth.
+   */
+  importTransactions(
+    accountId: string,
+    transactions: ReadonlyArray<Omit<Transaction, 'id'>>,
+    options?: {
+      /** Called as rows land, where the engine can honestly measure it. */
+      onProgress?: (progress: BulkImportProgress) => void;
+      /** What the rows carry; defaults to 'file'. See {@link ImportSourceKind}. */
+      source?: ImportSourceKind;
+    }
+  ): Promise<BulkImportResult>;
 }
 
 export interface DataPortTransferWrites {
@@ -559,6 +689,7 @@ export interface DataPort extends
   DataPortReads,
   DataPortAccountWrites,
   DataPortTransactionWrites,
+  DataPortBulkWrites,
   DataPortTransferWrites,
   DataPortSplitWrites,
   DataPortPlanningWrites,

--- a/src/services/port/index.ts
+++ b/src/services/port/index.ts
@@ -17,8 +17,11 @@ export type {
   AccountBalanceSnapshot,
   BootTransactionStats,
   BootTransactionsResult,
+  BulkImportProgress,
+  BulkImportResult,
   DataPort,
   DataPortAccountWrites,
+  DataPortBulkWrites,
   DataPortDismissalWrites,
   DataPortLifecycle,
   DataPortPlanningWrites,
@@ -26,6 +29,7 @@ export type {
   DataPortSplitWrites,
   DataPortTransactionWrites,
   DataPortTransferWrites,
+  ImportSourceKind,
   MoneyNumber
 } from './dataPort';
 

--- a/src/services/transactionImportService.ts
+++ b/src/services/transactionImportService.ts
@@ -1,14 +1,26 @@
 import type { Transaction } from '../types';
+import type {
+  BulkImportProgress,
+  BulkImportResult,
+  ImportSourceKind
+} from './port/dataPort';
 import { readFitId } from '../utils/statementDuplicates';
 import { createScopedLogger } from '../loggers/scopedLogger';
 
 /**
- * Bulk transaction import client.
+ * Bulk transaction import client — the CLOUD half of the seam's
+ * `importTransactions`.
  *
  * File imports (QIF/CSV/OFX) used to write one row at a time from the browser,
  * un-awaited — a large statement fired thousands of concurrent writes that the
  * API rejected en masse. This posts the rows to /api/data/import-transactions in
  * awaited chunks, each of which the server inserts in a single atomic RPC.
+ *
+ * The shapes it answers with — {@link BulkImportProgress},
+ * {@link BulkImportResult} and {@link ImportSourceKind} — are declared on the
+ * seam rather than here, because they are the contract EVERY engine keeps, and
+ * this file is one engine. The prefix rule stated on `BulkImportResult` is the
+ * rule the chunk loop below is what enforces.
  */
 
 type FetchLike = typeof fetch;
@@ -22,37 +34,6 @@ interface TransactionImportServiceOptions {
   delay?: (ms: number) => Promise<void>;
   /** Injectable for the same reason ids are elsewhere: determinism in tests. */
   runId?: () => string;
-}
-
-export interface BulkImportProgress {
-  /** Rows of the import that are in the account so far. */
-  inserted: number;
-  /** Total rows to import. */
-  total: number;
-}
-
-export interface BulkImportResult {
-  /**
-   * Rows of `transactions` that are now IN THE ACCOUNT — written by this run,
-   * or refused by the database as a repeat of a row this same run had already
-   * written (see `alreadyPresent`). Always a PREFIX of `transactions`: rows
-   * [inserted, total) are the ones that are missing, in file order.
-   */
-  inserted: number;
-  /**
-   * How many of `inserted` the database already held under this import's own
-   * id and therefore did not write again — a re-posted chunk after a timeout,
-   * or an OFX statement offering rows the account already has under the bank's
-   * own FITID. Counted as landed because they ARE landed; reported separately
-   * because "we wrote 900 rows" and "800 of those were already here" are
-   * different sentences and the user is owed the true one.
-   */
-  alreadyPresent: number;
-  total: number;
-  /** True when every chunk succeeded. */
-  complete: boolean;
-  /** Message from the first chunk that failed, if any. */
-  error?: string;
 }
 
 // Must stay <= the endpoint's MAX_ROWS, and small enough to sit well under
@@ -111,9 +92,6 @@ const FILE_IMPORT_SOURCE = 'file-import';
 const MAX_FITID_LENGTH = 120;
 
 const logger = createScopedLogger('TransactionImportService');
-
-/** Which importer is calling, which decides what a row's id can be made of. */
-export type ImportSourceKind = 'ofx' | 'file';
 
 interface ImportRow {
   date: string;
@@ -298,7 +276,7 @@ const toRow = (
   };
 };
 
-const chunk = <T>(items: T[], size: number): T[][] => {
+const chunk = <T>(items: ReadonlyArray<T>, size: number): T[][] => {
   const out: T[][] = [];
   for (let i = 0; i < items.length; i += size) {
     out.push(items.slice(i, i + size));
@@ -437,7 +415,7 @@ export class TransactionImportService {
    */
   async importInChunks(
     accountId: string,
-    transactions: Omit<Transaction, 'id'>[],
+    transactions: ReadonlyArray<Omit<Transaction, 'id'>>,
     opts: {
       onProgress?: (progress: BulkImportProgress) => void;
       /**


### PR DESCRIPTION
Slice 7 of the write-paths plan.

- One port method, `importTransactions(accountId, rows, {onProgress, source})`; the CSV wizard and OFX dialog lose their engine forks and their **Clerk imports entirely** — the auth provider installs inside the seam, same tick as the write, with ordering and identity tests.
- **B-9 divergence table**: `inserted` is a prefix count everywhere (the wizard's retry slices on it); how far a partial gets is declared per engine (cloud chunk-boundary vs device all-or-nothing). Mutation check bit exactly the prefix test.
- The importers became on-demand chunks; the static alternative was **built and priced** (+2.3 KB gz) rather than assumed. Net this slice: +0.4 KB gz.
- The device branch takes the service's own store/uuid (identical in production; test doubles can no longer write into the real encrypted store); an adapter that can't write atomically is refused in words.
- Routing predicate evaluated at write time (slice R's declared pattern); no pending-session guard on bulk import, deliberately and visibly (5d-class decision, out of a routing slice).
- `isUsingSupabase` production reads 15 → 9; the remainder belong to slices 8–10.

Gate: lint · strict tsc · smoke 4,853 · realtime 11/11 · build · coverage 75.05/81.21 vs 63/55 · port-coverage byte-identical to HEAD.

🤖 Generated with [Claude Code](https://claude.com/claude-code)