### PR TITLE
feat(seam): slice 8 — QIF through the port; nothing half-lands

### DIFF
--- a/src/components/QIFImportModal.test.tsx
+++ b/src/components/QIFImportModal.test.tsx
@@ -1,10 +1,13 @@
 import React from 'react';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import QIFImportModal from './QIFImportModal';
 import { qifImportService } from '../services/qifImportService';
 import type { QIFParseResult } from '../services/qifImportService';
+import { dataPort } from '../services/port';
 import { formatCurrency as formatCurrencyDecimal } from '../utils/currency-decimal';
+
+type QIFImportResult = Awaited<ReturnType<typeof qifImportService.importTransactions>>;
 
 // Mock icons
 vi.mock('./icons', () => ({
@@ -53,7 +56,7 @@ vi.mock('./loading/LoadingState', () => ({
 }));
 
 // Mock AppContext
-const mockAddTransaction = vi.fn();
+const mockRefreshAccountsAndTransactions = vi.fn().mockResolvedValue(undefined);
 const mockAccounts = [
   { id: 'acc1', name: 'Current Account', type: 'checking' },
   { id: 'acc2', name: 'Savings Account', type: 'savings' },
@@ -83,7 +86,7 @@ vi.mock('../contexts/AppContextSupabase', () => ({
     accounts: mockAccounts,
     transactions: mockTransactions,
     categories: mockCategories,
-    addTransaction: mockAddTransaction
+    refreshAccountsAndTransactions: mockRefreshAccountsAndTransactions
   })
 }));
 
@@ -91,6 +94,23 @@ vi.mock('../contexts/AppContextSupabase', () => ({
 vi.mock('../services/qifImportService', () => ({
   qifImportService: {
     parseQIF: vi.fn(),
+    importTransactions: vi.fn()
+  }
+}));
+
+/**
+ * THE WRITE, which is now one door rather than two.
+ *
+ * The dialog used to choose between the chunked cloud poster and a per-row
+ * loop through the context itself, off `isUsingSupabase`, and this file mocked
+ * both. It asks the seam once now; which store answers is the seam's business
+ * and is tested where that decision lives (dataService.test.ts). What is
+ * mocked here is the ANSWER, because what this file tests is what the modal
+ * REPORTS about a write — and the only way to test that honestly is to control
+ * what the write says it did.
+ */
+vi.mock('../services/port', () => ({
+  dataPort: {
     importTransactions: vi.fn()
   }
 }));
@@ -123,6 +143,16 @@ describe('QIFImportModal', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    // Default: the write does what it was asked. Tests that care about a
+    // failing or a partial write override this.
+    vi.mocked(dataPort.importTransactions).mockImplementation(
+      async (_accountId, rows) => ({
+        inserted: rows.length,
+        alreadyPresent: 0,
+        total: rows.length,
+        complete: true
+      })
+    );
   });
 
   /**
@@ -499,8 +529,12 @@ describe('QIFImportModal', () => {
         expect(screen.getByText('Imported 1 transactions to Current Account')).toBeInTheDocument();
         expect(screen.getByTestId('check-icon')).toBeInTheDocument();
       });
-      
-      expect(mockAddTransaction).toHaveBeenCalledWith({ id: 'trans1', amount: 100, description: 'Test' });
+
+      expect(dataPort.importTransactions).toHaveBeenCalledWith(
+        'acc1',
+        [{ id: 'trans1', amount: 100, description: 'Test' }],
+        { source: 'file', onProgress: expect.any(Function) }
+      );
     });
 
     /**
@@ -522,7 +556,10 @@ describe('QIFImportModal', () => {
         });
         let release: (() => void) | null = null;
         const finished = new Promise<void>(resolve => { release = resolve; });
-        mockAddTransaction.mockImplementationOnce(async () => { await finished; });
+        vi.mocked(dataPort.importTransactions).mockImplementationOnce(async (_accountId, rows) => {
+          await finished;
+          return { inserted: rows.length, alreadyPresent: 0, total: rows.length, complete: true };
+        });
         return { release: () => release?.() };
       };
 
@@ -562,7 +599,7 @@ describe('QIFImportModal', () => {
           expect(screen.getByText('Import Successful!')).toBeInTheDocument();
         });
         expect(qifImportService.importTransactions).toHaveBeenCalledTimes(1);
-        expect(mockAddTransaction).toHaveBeenCalledTimes(1);
+        expect(dataPort.importTransactions).toHaveBeenCalledTimes(1);
       });
     });
 
@@ -671,6 +708,247 @@ describe('QIFImportModal', () => {
         const callArgs = vi.mocked(qifImportService.importTransactions).mock.calls[0];
         expect(callArgs[1]).toBe('acc1'); // Selected account ID
         expect(callArgs[2]).toEqual([]); // Empty array when skip duplicates is off
+      });
+    });
+  });
+
+  /**
+   * THE WRITE — what reaches a store when Import is pressed, and what the
+   * dialog then tells the user about it.
+   *
+   * These tests were written against the two writers this dialog used to
+   * choose between itself, off `isUsingSupabase`: the chunked cloud poster,
+   * and a loop handing the context one row at a time. They are now one set,
+   * because there is now one call. The pair they replace is the change:
+   *
+   *   was — 'writes the file a row at a time, one context write per row'
+   *         (three rows, three separate writes through the context) and
+   *         'posts the whole file to the chunked client, holding its own
+   *         token' (the same file, one post, a Clerk token handed over by the
+   *         dialog);
+   *   is  — one call to the seam, with the same rows, either way.
+   *
+   *   was — 'leaves the rows written before a failure in the register'
+   *         (row three refuses; rows one and two stay in, and the screen says
+   *         only "Import Failed");
+   *   is  — 'nothing half-lands' (the store answers 0 of 3, and 0 is what is
+   *         in the register).
+   */
+  describe('The write', () => {
+    const draft = (
+      description: string,
+      amount: number,
+      day: string
+    ): QIFImportResult['transactions'][number] => ({
+      date: new Date(day),
+      description,
+      amount,
+      type: amount < 0 ? 'expense' : 'income',
+      accountId: 'acc1',
+      category: '',
+      cleared: false,
+      notes: '',
+      isRecurring: false
+    });
+
+    /** Three invented rows — a file's worth, in file order. */
+    const threeRows: QIFImportResult['transactions'] = [
+      draft('ACME SUPPLIES', -18.4, '2024-03-01'),
+      draft('RIVERSIDE CAFE', -6.25, '2024-03-02'),
+      draft('MONTHLY TRANSFER IN', 250, '2024-03-03')
+    ];
+
+    const importResultOf = (
+      transactions: QIFImportResult['transactions'],
+      overrides: Partial<QIFImportResult> = {}
+    ): QIFImportResult => ({
+      transactions,
+      duplicates: 0,
+      newTransactions: transactions.length,
+      invalidDates: 0,
+      matchedCategories: 0,
+      unmatchedCategories: [],
+      ...overrides
+    });
+
+    /** QIF rows for the preview — only their count is read by these tests. */
+    const parseRows = (count: number): QIFParseResult['transactions'] =>
+      Array.from({ length: count }, (_, index) => ({
+        date: `2024-03-${String(index + 1).padStart(2, '0')}`,
+        amount: -10,
+        payee: `PAYEE ${index + 1}`
+      }));
+
+    // These use mockReturnValue/mockResolvedValue rather than the ...Once form,
+    // and an implementation survives vi.clearAllMocks() — so it is dropped with
+    // the test that made it, or the next describe inherits this file's rows.
+    afterEach(() => {
+      vi.mocked(qifImportService.parseQIF).mockReset();
+      vi.mocked(qifImportService.importTransactions).mockReset();
+    });
+
+    /** Upload a file, choose the destination, press Import. */
+    const pressImport = async (
+      transactions: QIFImportResult['transactions'],
+      overrides: Partial<QIFImportResult> = {}
+    ): Promise<void> => {
+      vi.mocked(qifImportService.parseQIF).mockReturnValue(
+        createMockParseResult({ transactions: parseRows(transactions.length) })
+      );
+      vi.mocked(qifImportService.importTransactions).mockResolvedValue(
+        importResultOf(transactions, overrides)
+      );
+
+      render(<QIFImportModal {...defaultProps} />);
+      fireEvent.change(document.getElementById('qif-upload')!, {
+        target: { files: [new File(['QIF content'], 'quicken.qif', { type: 'application/qif' })] }
+      });
+      await waitFor(() => {
+        expect(screen.getByTestId('loading-button')).toBeInTheDocument();
+      });
+      chooseAccount(CURRENT_ACCOUNT);
+      fireEvent.click(screen.getByTestId('loading-button'));
+    };
+
+    it('hands the whole file to the seam in one call', async () => {
+      await pressImport(threeRows);
+
+      await waitFor(() => {
+        expect(screen.getByText('Import Successful!')).toBeInTheDocument();
+      });
+
+      // One call for the file, not one per row, into the account the user
+      // picked — a QIF names no account, so that choice is the whole
+      // destination and nothing else in the file can overrule it.
+      expect(dataPort.importTransactions).toHaveBeenCalledTimes(1);
+      expect(dataPort.importTransactions).toHaveBeenCalledWith(
+        'acc1',
+        threeRows,
+        // 'file', not 'ofx': a QIF row carries no id of its own, so no store
+        // can recognise a second copy of it. Saying so is what stops one from
+        // behaving as though it could.
+        { source: 'file', onProgress: expect.any(Function) }
+      );
+      expect(screen.getByText('Imported 3 transactions to Current Account')).toBeInTheDocument();
+    });
+
+    it('re-reads the register, so the screen shows what actually landed', async () => {
+      await pressImport(threeRows);
+
+      await waitFor(() => {
+        expect(screen.getByText('Import Successful!')).toBeInTheDocument();
+      });
+      expect(mockRefreshAccountsAndTransactions).toHaveBeenCalled();
+    });
+
+    it('reports what the write confirmed, not what the file offered', async () => {
+      // The file offers three rows and the store confirms three. The partial
+      // below is the same file with a different answer, and a different count.
+      vi.mocked(dataPort.importTransactions).mockResolvedValueOnce({
+        inserted: 3,
+        alreadyPresent: 0,
+        total: 3,
+        complete: true
+      });
+
+      await pressImport(threeRows);
+
+      await waitFor(() => {
+        expect(screen.getByText('Imported 3 transactions to Current Account')).toBeInTheDocument();
+      });
+    });
+
+    it('says how far it got when the write stops partway', async () => {
+      vi.mocked(dataPort.importTransactions).mockResolvedValueOnce({
+        inserted: 2,
+        alreadyPresent: 0,
+        total: 3,
+        complete: false,
+        error: 'QuotaExceededError'
+      });
+
+      await pressImport(threeRows);
+
+      await waitFor(() => {
+        expect(screen.getByText('Import Failed')).toBeInTheDocument();
+      });
+      expect(
+        screen.getByText('Imported 2 of 3 transactions before an error stopped the import.')
+      ).toBeInTheDocument();
+      // Whatever did land is read back before anything is said about it.
+      expect(mockRefreshAccountsAndTransactions).toHaveBeenCalled();
+    });
+
+    it('nothing half-lands: a device write that fails wrote no rows at all', async () => {
+      // THE DECLARED CHANGE. This used to be a loop, so a file that failed on
+      // its third row left the first two in the register with nothing on
+      // screen but "Import Failed". A device write is one transaction: its
+      // answer is 0 or all of them, and 0 is what the user is told.
+      vi.mocked(dataPort.importTransactions).mockResolvedValueOnce({
+        inserted: 0,
+        alreadyPresent: 0,
+        total: 3,
+        complete: false,
+        error: 'This device could not store the import.'
+      });
+
+      await pressImport(threeRows);
+
+      await waitFor(() => {
+        expect(screen.getByText('Import Failed')).toBeInTheDocument();
+      });
+      expect(
+        screen.getByText('Imported 0 of 3 transactions before an error stopped the import.')
+      ).toBeInTheDocument();
+    });
+
+    it('counts the rows as a chunked store reports them', async () => {
+      // A store that commits in pieces says so between them; the dialog puts
+      // those figures on screen as they arrive rather than jumping from
+      // nothing to done. A store whose write is one atomic transaction reports
+      // nothing, and the bar stays honestly indeterminate — the test below.
+      let release: (() => void) | null = null;
+      const held = new Promise<void>(resolve => { release = resolve; });
+      vi.mocked(dataPort.importTransactions).mockImplementationOnce(
+        async (_accountId, rows, options) => {
+          options?.onProgress?.({ inserted: 2, total: rows.length });
+          await held;
+          return { inserted: rows.length, alreadyPresent: 0, total: rows.length, complete: true };
+        }
+      );
+
+      await pressImport(threeRows);
+
+      await waitFor(() => {
+        expect(screen.getByRole('status')).toHaveTextContent('Importing… 2 of 3 transactions');
+      });
+      expect(screen.getByRole('progressbar')).toHaveAttribute('aria-valuenow', '67');
+
+      release?.();
+      await waitFor(() => {
+        expect(screen.getByText('Import Successful!')).toBeInTheDocument();
+      });
+    });
+
+    it('names the size of the job while a silent store is writing', async () => {
+      // Nothing is claimed as inserted until a write says so. "0 of 3" beside
+      // an empty bar reads as stuck, which is what the bar exists to remove.
+      let release: (() => void) | null = null;
+      const held = new Promise<void>(resolve => { release = resolve; });
+      vi.mocked(dataPort.importTransactions).mockImplementationOnce(async (_accountId, rows) => {
+        await held;
+        return { inserted: rows.length, alreadyPresent: 0, total: rows.length, complete: true };
+      });
+
+      await pressImport(threeRows);
+
+      const status = await screen.findByRole('status');
+      expect(status).toHaveTextContent('Importing 3 transactions…');
+      expect(screen.getByRole('progressbar')).not.toHaveAttribute('aria-valuenow');
+
+      release?.();
+      await waitFor(() => {
+        expect(screen.getByText('Import Successful!')).toBeInTheDocument();
       });
     });
   });

--- a/src/components/QIFImportModal.tsx
+++ b/src/components/QIFImportModal.tsx
@@ -1,8 +1,7 @@
 import React, { useState, useCallback, useMemo, useRef, useEffect } from 'react';
-import { useAuth } from '@clerk/clerk-react';
 import { useApp } from '../contexts/AppContextSupabase';
 import { qifImportService } from '../services/qifImportService';
-import { transactionImportService } from '../services/transactionImportService';
+import { dataPort, type BulkImportResult } from '../services/port';
 import type { Account } from '../types';
 import type { QIFParseResult } from '../services/qifImportService';
 import { Modal, ModalBody } from './common/Modal';
@@ -39,9 +38,6 @@ interface QIFImportModalProps {
 
 type QIFImportResult = Awaited<ReturnType<typeof qifImportService.importTransactions>>;
 
-/** How often the row-at-a-time local write refreshes the count on screen. */
-const PROGRESS_EVERY = 25;
-
 type ImportOutcome =
   | {
       success: true;
@@ -60,8 +56,7 @@ type ImportOutcome =
     };
 
 export default function QIFImportModal({ isOpen, onClose, initialFile }: QIFImportModalProps): React.JSX.Element {
-  const { accounts, transactions, categories, addTransaction, refreshAccountsAndTransactions, isUsingSupabase } = useApp();
-  const { getToken } = useAuth();
+  const { accounts, transactions, categories, refreshAccountsAndTransactions } = useApp();
   const { formatCurrency } = useCurrencyDecimal();
   const [file, setFile] = useState<File | null>(null);
   const [isProcessing, setIsProcessing] = useState(false);
@@ -69,7 +64,9 @@ export default function QIFImportModal({ isOpen, onClose, initialFile }: QIFImpo
    * What the WRITE has confirmed so far, never what was hoped for. `total` is
    * set the moment the rows to write are known (after duplicates are dropped),
    * so the dialog can name the size of the job before the first row lands;
-   * `inserted` only ever moves on a report from the writing path.
+   * `inserted` only ever moves on a report from the writing path (chunk by
+   * chunk in the cloud; a device write is one atomic transaction and reports
+   * nothing until it is done).
    */
   const [progress, setProgress] = useState<{ inserted: number; total: number } | null>(null);
   const [parseResult, setParseResult] = useState<QIFParseResult | null>(null);
@@ -178,48 +175,54 @@ export default function QIFImportModal({ isOpen, onClose, initialFile }: QIFImpo
         }
       );
 
-      let insertedCount = result.transactions.length;
-      let complete = true;
-
       // The size of the job, known now that duplicates have been dropped and
       // before a single row is written. Nothing is claimed as inserted yet.
       if (isMountedRef.current) {
         setProgress({ inserted: 0, total: result.transactions.length });
       }
 
-      if (isUsingSupabase) {
-        // Cloud: write via the chunked, awaited bulk endpoint (one atomic RPC
-        // per chunk) so a large statement can't flood the API and lose rows.
-        transactionImportService.setAuthTokenProvider(() => getToken());
-        const bulk = await transactionImportService.importInChunks(
-          selectedAccountId,
-          result.transactions,
-          // Fires between chunks, so it can also land after unmount.
-          { onProgress: p => { if (isMountedRef.current) setProgress(p); } }
+      // WRITE THE WHOLE FILE AS ONE UNIT.
+      //
+      // This dialog used to choose its own writer off `isUsingSupabase`: the
+      // chunked cloud poster, or `for (…) await addTransaction(row)` — a
+      // separate trip through the context for every row in the file. That loop
+      // is why a QIF that failed on row 400 of 900 left 399 rows in the
+      // register with nothing on screen but "Import Failed": there was no unit
+      // for the import to be all of, so it could be part of one.
+      //
+      // One call, through the seam, whichever store this app is holding. Both
+      // engines behind it are all-or-nothing per unit and both report what the
+      // write itself confirmed:
+      //   cloud — /api/data/import-transactions, one `import_transactions_atomic`
+      //           per chunk, each its own database transaction;
+      //   device — one IndexedDB `setMany` covering the rows AND the balance.
+      //
+      // `source: 'file'` is a statement about QIF rather than a default taken
+      // for want of anything better: unlike an OFX statement, a QIF row carries
+      // no id of its own, so there is nothing a store could key it by to
+      // recognise a second copy. Importing the same file twice imports it
+      // twice, and the duplicate check above the button is the only thing
+      // between the user and a doubled month.
+      const outcome: BulkImportResult = await dataPort.importTransactions(
+        selectedAccountId,
+        result.transactions,
+        {
+          source: 'file',
+          // Fires between chunks where the store commits in chunks; a single
+          // atomic write has no honest fraction and reports nothing until it
+          // is done. Either way it can land after unmount.
+          onProgress: p => { if (isMountedRef.current) setProgress(p); }
+        }
+      );
+
+      // Re-read from the store rather than trusting the drafts: after this the
+      // register shows what was actually written, including after a partial.
+      await refreshAccountsAndTransactions();
+
+      if (!outcome.complete) {
+        throw new Error(
+          `Imported ${outcome.inserted} of ${outcome.total} transactions before an error stopped the import.`
         );
-        insertedCount = bulk.inserted;
-        complete = bulk.complete;
-        // Pull the freshly-inserted rows + updated balance into the app.
-        await refreshAccountsAndTransactions();
-        if (!complete) {
-          throw new Error(
-            `Imported ${bulk.inserted} of ${bulk.total} transactions before an error stopped the import.`
-          );
-        }
-      } else {
-        // Local/demo mode: no cloud endpoint — write sequentially and awaited.
-        // Every row is its own write here, so the count on screen is a real
-        // count of rows in the register, not an estimate.
-        let written = 0;
-        for (const transaction of result.transactions) {
-          await addTransaction(transaction);
-          written += 1;
-          // Not per row: a 10,000-row file would be 10,000 renders, and the
-          // bar cannot show more steps than it has pixels anyway.
-          if (isMountedRef.current && (written % PROGRESS_EVERY === 0 || written === result.transactions.length)) {
-            setProgress({ inserted: written, total: result.transactions.length });
-          }
-        }
       }
 
       const account = accounts.find(a => a.id === selectedAccountId) ?? null;
@@ -227,12 +230,13 @@ export default function QIFImportModal({ isOpen, onClose, initialFile }: QIFImpo
       if (!isMountedRef.current) return;
       setImportResult({
         success: true,
-        imported: insertedCount,
+        // What the write confirmed, never the count the file offered.
+        imported: outcome.inserted,
         duplicates: result.duplicates,
         invalidDates: result.invalidDates,
         matchedCategories: result.matchedCategories,
         unmatchedCategories: result.unmatchedCategories,
-        complete,
+        complete: outcome.complete,
         account
       });
     } catch (error) {
@@ -249,7 +253,7 @@ export default function QIFImportModal({ isOpen, onClose, initialFile }: QIFImpo
         setProgress(null);
       }
     }
-  }, [accounts, addTransaction, categories, file, getToken, isUsingSupabase, parseResult, refreshAccountsAndTransactions, selectedAccountId, skipDuplicates, transactions, logger]);
+  }, [accounts, categories, file, parseResult, refreshAccountsAndTransactions, selectedAccountId, skipDuplicates, transactions, logger]);
   
   // Reset modal
   const resetModal = useCallback(() => {


### PR DESCRIPTION
Slice 8 of the write-paths plan, characterisation-first.

- The plan's "no QIF test file" was stale (#203 created one) — so step 1 characterised the **uncovered write fork**: seven tests pinning today's behaviour, run green against HEAD before any change.
- The declared behaviour change lives in the diff of exactly two tests: per-row context writes (rows 1–2 silently landing when row 3 failed) become **one atomic device write** — a failed import writes nothing and says "Imported 0 of 3 transactions before an error stopped the import."
- `source: 'file'` named explicitly (the port's type documents `'file'` as all a QIF can promise); Clerk leaves the dialog; the register re-reads on both paths; the success line counts the write's report, not the parser's offer.
- Both mutations red on cue (source omission; progress unwiring).
- Bundle: −0.2 KB gz total. `isUsingSupabase` production reads: QIF's three gone; nine remain for slices 9–11.
- Flagged for slice 12: `ImportOutcome.complete` is now provably-always-true dead weight — left for cosmetics rather than widening this diff.

Gate: lint · strict tsc · smoke 4,860 · realtime 204 · build · coverage 75.08/81.22 vs 63/55.

🤖 Generated with [Claude Code](https://claude.com/claude-code)