### PR TITLE
feat(seam): slice 9 — backup lifecycle through the port; the guard that never fired now does

### DIFF
--- a/src/components/RestoreBackupModal.tsx
+++ b/src/components/RestoreBackupModal.tsx
@@ -2,27 +2,24 @@ import React, { useCallback, useMemo, useState } from 'react';
 import { Modal, ModalBody, ModalFooter } from './common/Modal';
 import { useApp } from '../contexts/AppContextSupabase';
 import { DataService } from '../services/api/dataService';
+import { dataPort } from '../services/port';
+import type { BackupRestoreOutcome } from '../services/port';
 import { transactionCache } from '../services/transactionCache';
 import { createScopedLogger } from '../loggers/scopedLogger';
 import { AlertTriangleIcon, CheckCircleIcon, RefreshCwIcon, UploadIcon } from './icons';
 import {
   BACKUP_ENTITIES,
   RestoreFailedError,
-  restoreBackupBundle,
   preferenceCount,
   transactionDateRange,
-  userFinancialDataIsEmpty,
   validateBackupBundle,
   wipeUserFinancialData,
   type BackupBundle,
-  type DanglingReference,
   type RestoreProgress,
 } from '../services/backupService';
 import {
   LOCAL_BACKUP_BINDINGS,
   LocalRestoreRefusedError,
-  localFinancialDataIsEmpty,
-  restoreLocalBackupBundle,
   wipeLocalFinancialData,
 } from '../services/localBackupService';
 
@@ -86,31 +83,6 @@ const formatExportedAt = (iso: string): string => {
   return Number.isNaN(date.getTime()) ? iso : date.toLocaleString();
 };
 
-/**
- * What a finished restore looks like, whichever engine did it.
- *
- * `notStoredLocally` is the one field the cloud never fills: a browser has no
- * investments, goal contributions or repeating templates, so a cloud-taken file
- * restored onto a device genuinely cannot keep some of what it holds. Saying so
- * is the difference between a restore and a restore that quietly lost things.
- */
-interface Outcome {
-  restored: { label: string; rows: number }[];
-  notStoredLocally: { label: string; rows: number; absence: string }[];
-  accountsRelinked: number;
-  transactionsRelinked: number;
-  /**
-   * Settings put back, and the reason if they could not be. Reported beside the
-   * row counts rather than thrown, because preferences go in AFTER every
-   * financial row: a complete ledger with default toggles is a good outcome
-   * that happens to be missing something, and calling it a failed restore would
-   * send the user to wipe and start again for no reason.
-   */
-  preferencesRestored: number;
-  preferencesFailure: string | null;
-  danglingRefs: DanglingReference[];
-}
-
 export default function RestoreBackupModal({ isOpen, onClose }: Props): React.JSX.Element {
   const { refreshAccountsAndTransactions, refreshCategories, isUsingSupabase } = useApp();
 
@@ -121,9 +93,27 @@ export default function RestoreBackupModal({ isOpen, onClose }: Props): React.JS
   const [targetIsEmpty, setTargetIsEmpty] = useState<boolean | null>(null);
   const [wipeConfirmText, setWipeConfirmText] = useState('');
   const [progress, setProgress] = useState<RestoreProgress | null>(null);
-  const [outcome, setOutcome] = useState<Outcome | null>(null);
+  /**
+   * What a finished restore looks like is the SEAM's shape, not a description
+   * this file keeps beside it. The two were identical, and a second copy here
+   * would have been free to drift from the one both engines actually answer
+   * with — including `notStoredLocally`, the field that names what a device
+   * could not keep, which is the difference between a restore and a restore
+   * that quietly lost things.
+   */
+  const [outcome, setOutcome] = useState<BackupRestoreOutcome | null>(null);
   const [failure, setFailure] = useState<{ step: string; message: string; partiallyRestored: boolean } | null>(null);
 
+  /**
+   * WHAT THIS IS STILL FOR, now that the seam resolves its own owner.
+   *
+   * Three things, all of them owned by a later step and none of them a data
+   * operation: the wipe still forks between the two engines HERE (it joins the
+   * seam with `wipeAllFinancialData`); the copy on this dialog says "login" or
+   * "device" throughout; and a signed-in session whose id has not resolved is
+   * blocked from starting at all. The reads and the restore no longer touch it
+   * — `dataPort` answers those without being told whose data it is.
+   */
   const databaseUserId = DataService.getUserIds().databaseId;
   /**
    * Which store this restore is aimed at. A signed-in session whose database id
@@ -202,15 +192,13 @@ export default function RestoreBackupModal({ isOpen, onClose }: Props): React.JS
 
     setBundle(validation.bundle);
     try {
-      setTargetIsEmpty(databaseUserId
-        ? await userFinancialDataIsEmpty(databaseUserId)
-        : await localFinancialDataIsEmpty());
+      setTargetIsEmpty(await dataPort.financialDataIsEmpty());
       setPhase('ready');
     } catch (error) {
       restoreLogger.error('Preflight emptiness check failed', error);
       setFileProblem(error instanceof Error ? error.message : `Could not check whether this ${targetName} is empty.`);
     }
-  }, [databaseUserId, cloudSessionPending, targetName]);
+  }, [cloudSessionPending, targetName]);
 
   const handleWipe = useCallback(async () => {
     if (cloudSessionPending) return;
@@ -227,9 +215,7 @@ export default function RestoreBackupModal({ isOpen, onClose }: Props): React.JS
       // The local snapshot now describes history that no longer exists. Drop it
       // before anything reads it back and merges the dead rows in.
       await transactionCache.clear();
-      setTargetIsEmpty(databaseUserId
-        ? await userFinancialDataIsEmpty(databaseUserId)
-        : await localFinancialDataIsEmpty());
+      setTargetIsEmpty(await dataPort.financialDataIsEmpty());
       setWipeConfirmText('');
       setPhase('ready');
     } catch (error) {
@@ -249,9 +235,7 @@ export default function RestoreBackupModal({ isOpen, onClose }: Props): React.JS
     setFailure(null);
     setProgress(null);
     try {
-      const result = databaseUserId
-        ? { ...await restoreBackupBundle(bundle, databaseUserId, { onProgress: setProgress }), notStoredLocally: [] }
-        : await restoreLocalBackupBundle(bundle, { onProgress: setProgress });
+      const result = await dataPort.restoreBackup(bundle, { onProgress: setProgress });
       await transactionCache.clear();
       await refreshAccountsAndTransactions();
       await refreshCategories();

--- a/src/components/__tests__/RestoreBackupModal.test.tsx
+++ b/src/components/__tests__/RestoreBackupModal.test.tsx
@@ -1,0 +1,293 @@
+/**
+ * Restore from backup — the dialog.
+ *
+ * The most destructive screen in the app: it erases a login or a device and
+ * pours a file in over the top, and it had no test at all. So every assertion
+ * here was first written against the behaviour as it stood BEFORE the seam took
+ * the emptiness check and the restore, and run green against it. Only the mocks
+ * changed afterwards — from the two engines this file used to choose between,
+ * to the one door it knocks on now. That is what makes the suite evidence that
+ * the routing changed nothing the user can see.
+ *
+ * STILL THE PAGE'S OWN, and mocked as such: the wipe (it joins the seam with
+ * slice 10) and the identity that decides whether the copy says "login" or
+ * "device" (slice 11).
+ */
+
+import React from 'react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { buildBackupBundle, type BackupBundle } from '../../services/backupService';
+
+const appValue = {
+  refreshAccountsAndTransactions: vi.fn(async () => {}),
+  refreshCategories: vi.fn(async () => {}),
+  isUsingSupabase: false,
+};
+
+vi.mock('../../contexts/AppContextSupabase', () => ({
+  useApp: () => appValue,
+}));
+
+vi.mock('../../services/transactionCache', () => ({
+  transactionCache: { clear: vi.fn(async () => {}) },
+}));
+
+const userIds = vi.hoisted(() => ({
+  value: { clerkId: null as string | null, databaseId: null as string | null },
+}));
+
+vi.mock('../../services/api/dataService', () => ({
+  DataService: { getUserIds: () => userIds.value },
+}));
+
+/** The wipe is still this page's fork between two engines — slice 10 routes it. */
+const engines = vi.hoisted(() => ({
+  cloudWipe: vi.fn(async () => ({ transactions: 3 })),
+  localWipe: vi.fn(async () => ({ transactions: 3 })),
+}));
+
+vi.mock('../../services/backupService', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../services/backupService')>();
+  return { ...actual, wipeUserFinancialData: engines.cloudWipe };
+});
+
+vi.mock('../../services/localBackupService', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../services/localBackupService')>();
+  return { ...actual, wipeLocalFinancialData: engines.localWipe };
+});
+
+/** The seam. One door, whichever store is behind it. */
+const seam = vi.hoisted(() => ({
+  financialDataIsEmpty: vi.fn<() => Promise<boolean>>(),
+  restoreBackup: vi.fn(),
+}));
+
+vi.mock('../../services/port', () => ({ dataPort: seam }));
+
+import RestoreBackupModal from '../RestoreBackupModal';
+
+const bundleWith = (over: Partial<Record<string, Record<string, unknown>[]>> = {}): BackupBundle =>
+  buildBackupBundle({
+    sourceUserId: 'source-login',
+    exportedAt: '2026-03-04T10:00:00.000Z',
+    data: {
+      accounts: [{ id: 'acct-1', name: 'Everyday', type: 'current', balance: '10.00' }],
+      categories: [{ id: 'cat-1', name: 'Food', level: 'detail', type: 'expense' }],
+      transactions: [
+        { id: 'txn-1', account_id: 'acct-1', amount: '-10.00', date: '2026-02-01', description: 'Shop' },
+      ],
+      ...over,
+    },
+    preferences: null,
+  });
+
+const outcome = {
+  restored: [{ label: 'Accounts', rows: 1 }, { label: 'Transactions', rows: 1 }],
+  notStoredLocally: [] as { label: string; rows: number; absence: string }[],
+  accountsRelinked: 0,
+  transactionsRelinked: 0,
+  preferencesRestored: 0,
+  preferencesFailure: null as string | null,
+  danglingRefs: [] as { entity: string; field: string; value: string }[],
+};
+
+const emptinessChecks = (): number => seam.financialDataIsEmpty.mock.calls.length;
+const restoreCalls = (): number => seam.restoreBackup.mock.calls.length;
+
+const handOver = (bundle: BackupBundle, name = 'backup.json'): void => {
+  const json = JSON.stringify(bundle);
+  const file = new File([json], name, { type: 'application/json' });
+  Object.defineProperty(file, 'text', { value: async () => json });
+  fireEvent.change(screen.getByLabelText('Backup file'), { target: { files: [file] } });
+};
+
+const pickFile = async (bundle: BackupBundle, name = 'backup.json'): Promise<void> => {
+  handOver(bundle, name);
+  await waitFor(() => expect(emptinessChecks()).toBeGreaterThan(0));
+};
+
+describe('RestoreBackupModal', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    userIds.value = { clerkId: null, databaseId: null };
+    appValue.isUsingSupabase = false;
+    seam.financialDataIsEmpty.mockResolvedValue(true);
+    seam.restoreBackup.mockResolvedValue({ ...outcome });
+  });
+
+  const open = (): void => {
+    render(<RestoreBackupModal isOpen onClose={vi.fn()} />);
+  };
+
+  describe('reading the file', () => {
+    it('says what the file holds before anything is committed', async () => {
+      open();
+      await pickFile(bundleWith());
+
+      expect(screen.getByText('backup.json')).toBeInTheDocument();
+      expect(screen.getByText('2026-02-01 to 2026-02-01')).toBeInTheDocument();
+    });
+
+    it('refuses a file that is not valid JSON, and asks the store nothing', async () => {
+      open();
+      const file = new File(['not json'], 'broken.json', { type: 'application/json' });
+      Object.defineProperty(file, 'text', { value: async () => 'not json' });
+      fireEvent.change(screen.getByLabelText('Backup file'), { target: { files: [file] } });
+
+      await screen.findByText(/is not valid JSON/i);
+      expect(emptinessChecks()).toBe(0);
+    });
+
+    it('shows the reason when the emptiness check refuses, and does not offer to restore', async () => {
+      seam.financialDataIsEmpty.mockRejectedValue(new Error('The store could not be opened'));
+      open();
+      handOver(bundleWith());
+
+      await screen.findByText('The store could not be opened');
+      expect(screen.getByRole('button', { name: /Restore this backup/i })).toBeDisabled();
+    });
+  });
+
+  describe('the empty-target rule', () => {
+    it('lets a backup straight in when the target is empty', async () => {
+      open();
+      await pickFile(bundleWith());
+
+      expect(await screen.findByText(/is empty, so the backup can go straight in/i)).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: /Restore this backup/i })).toBeEnabled();
+    });
+
+    it('refuses to restore over data, and demands the phrase before erasing', async () => {
+      seam.financialDataIsEmpty.mockResolvedValue(false);
+      open();
+      await pickFile(bundleWith());
+
+      expect(await screen.findByText(/already holds data/i)).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: /Restore this backup/i })).toBeDisabled();
+
+      const erase = screen.getByRole('button', { name: /Erase everything in this device/i });
+      expect(erase).toBeDisabled();
+
+      fireEvent.change(screen.getByLabelText('Type DELETE EVERYTHING to confirm'), {
+        target: { value: 'delete everything' },
+      });
+      expect(erase).toBeDisabled();
+
+      fireEvent.change(screen.getByLabelText('Type DELETE EVERYTHING to confirm'), {
+        target: { value: 'DELETE EVERYTHING' },
+      });
+      expect(erase).toBeEnabled();
+    });
+
+    it('passes the typed phrase through untouched and re-checks emptiness after erasing', async () => {
+      seam.financialDataIsEmpty.mockResolvedValueOnce(false).mockResolvedValueOnce(true);
+      open();
+      await pickFile(bundleWith());
+      await screen.findByText(/already holds data/i);
+
+      fireEvent.change(screen.getByLabelText('Type DELETE EVERYTHING to confirm'), {
+        target: { value: 'DELETE EVERYTHING' },
+      });
+      fireEvent.click(screen.getByRole('button', { name: /Erase everything in this device/i }));
+
+      await waitFor(() => expect(engines.localWipe).toHaveBeenCalledWith('DELETE EVERYTHING'));
+      expect(engines.cloudWipe).not.toHaveBeenCalled();
+      await screen.findByText(/is empty, so the backup can go straight in/i);
+      expect(emptinessChecks()).toBe(2);
+    });
+  });
+
+  describe('restoring', () => {
+    it('hands over the file it validated, and reports what came back', async () => {
+      open();
+      await pickFile(bundleWith());
+      await screen.findByText(/is empty, so the backup can go straight in/i);
+      fireEvent.click(screen.getByRole('button', { name: /Restore this backup/i }));
+
+      await screen.findByText('Restore finished');
+      expect(restoreCalls()).toBe(1);
+      const [bundle, options] = seam.restoreBackup.mock.calls[0];
+      expect(bundle.format).toBe('wealthtracker-backup-v2');
+      expect(bundle.counts.transactions).toBe(1);
+      expect(typeof options.onProgress).toBe('function');
+
+      expect(screen.getByText('Accounts')).toBeInTheDocument();
+      expect(appValue.refreshAccountsAndTransactions).toHaveBeenCalled();
+      expect(appValue.refreshCategories).toHaveBeenCalled();
+    });
+
+    it('names what this device could not keep instead of leaving it to be discovered', async () => {
+      seam.restoreBackup.mockResolvedValue({
+        ...outcome,
+        notStoredLocally: [
+          { label: 'Investments', rows: 3, absence: 'holdings are only tracked when you are signed in' },
+        ],
+      });
+      open();
+      await pickFile(bundleWith());
+      await screen.findByText(/is empty, so the backup can go straight in/i);
+      fireEvent.click(screen.getByRole('button', { name: /Restore this backup/i }));
+
+      await screen.findByText('Restore finished');
+      expect(screen.getByText(/This device does not hold investments/i)).toBeInTheDocument();
+      expect(screen.getByText(/holdings are only tracked when you are signed in/i)).toBeInTheDocument();
+    });
+
+    it('says a device restore changed nothing at all when it fails', async () => {
+      seam.restoreBackup.mockRejectedValue(new Error('restore_target_not_empty: this device already holds data'));
+      open();
+      await pickFile(bundleWith());
+      await screen.findByText(/is empty, so the backup can go straight in/i);
+      fireEvent.click(screen.getByRole('button', { name: /Restore this backup/i }));
+
+      await screen.findByText(/Stopped at:/);
+      expect(screen.getByText(/restore_target_not_empty/)).toBeInTheDocument();
+      expect(screen.getByText(/Nothing on this device was changed/i)).toBeInTheDocument();
+      expect(screen.queryByText(/partly populated/i)).not.toBeInTheDocument();
+    });
+
+    it('warns that a login is partly populated when a cloud restore fails halfway', async () => {
+      userIds.value = { clerkId: 'clerk_1', databaseId: 'db-user-1' };
+      seam.restoreBackup.mockRejectedValue(new Error('duplicate key value violates unique constraint'));
+      open();
+      await pickFile(bundleWith());
+      await screen.findByText(/is empty, so the backup can go straight in/i);
+      fireEvent.click(screen.getByRole('button', { name: /Restore this backup/i }));
+
+      await screen.findByText(/Stopped at:/);
+      expect(screen.getByText(/partly populated/i)).toBeInTheDocument();
+    });
+  });
+
+  describe('a session that has not resolved its login yet', () => {
+    it('refuses the file rather than aiming a restore at the browser', async () => {
+      appValue.isUsingSupabase = true;
+      userIds.value = { clerkId: 'clerk_1', databaseId: null };
+      open();
+      handOver(bundleWith());
+
+      await screen.findByText(/no database identity yet/i);
+      expect(emptinessChecks()).toBe(0);
+      expect(restoreCalls()).toBe(0);
+    });
+  });
+
+  describe('what a device cannot keep, said before the user commits', () => {
+    it('warns about the tables this device has nowhere to put', async () => {
+      open();
+      await pickFile(bundleWith({ investments: [{ id: 'inv-1', symbol: 'ABC' }] }));
+
+      expect(await screen.findByText(/Part of this backup cannot be kept on this device/i)).toBeInTheDocument();
+    });
+
+    it('says nothing about them when the target is a login', async () => {
+      userIds.value = { clerkId: 'clerk_1', databaseId: 'db-user-1' };
+      open();
+      await pickFile(bundleWith({ investments: [{ id: 'inv-1', symbol: 'ABC' }] }));
+
+      await screen.findByText(/is empty, so the backup can go straight in/i);
+      expect(screen.queryByText(/cannot be kept on this device/i)).not.toBeInTheDocument();
+    });
+  });
+});

--- a/src/contexts/__tests__/AppContextBootThroughPort.test.tsx
+++ b/src/contexts/__tests__/AppContextBootThroughPort.test.tsx
@@ -254,6 +254,12 @@ vi.mock('../../services/port', () => {
     mergeCategories: refuse('mergeCategories'),
     dismissSuggestion: refuse('dismissSuggestion'),
     restoreSuggestion: refuse('restoreSuggestion'),
+    // Backup and restore are not a boot either — the export page and the
+    // restore dialog reach them, and a boot that read somebody's whole ledger
+    // out to build a file would be a very loud bug worth failing by name for.
+    financialDataIsEmpty: refuse('financialDataIsEmpty'),
+    collectBackup: refuse('collectBackup'),
+    restoreBackup: refuse('restoreBackup'),
   };
 
   return { dataPort };

--- a/src/pages/ExportManager.tsx
+++ b/src/pages/ExportManager.tsx
@@ -22,9 +22,8 @@ import PageTip from '../components/PageTip';
 import PeriodPicker from '../components/PeriodPicker';
 import { LoadingState } from '../components/loading/LoadingState';
 import { createScopedLogger } from '../loggers/scopedLogger';
-import { DataService } from '../services/api/dataService';
-import { collectBackupBundle, downloadBackupBundle, type ExportProgress } from '../services/backupService';
-import { collectLocalBackupBundle } from '../services/localBackupService';
+import { dataPort } from '../services/port';
+import { downloadBackupBundle, type ExportProgress } from '../services/backupService';
 import { selectExportData, describeExportRange, type AccountsScope } from '../utils/exportSelection';
 import { generateDataExportPDF } from '../utils/pdfExport';
 import {
@@ -190,25 +189,20 @@ export default function ExportManager(): React.JSX.Element {
   // backupService resolves a Supabase client and threw without one — which is
   // an odd thing to offer a person and then refuse. Same format, same file,
   // same restore; only where the rows come from differs.
+  //
+  // WHICH of those two reads this file is no longer decided here. This page
+  // used to ask `DataService.getUserIds()`, branch on whether a database id
+  // came back, and hand the owner to the cloud collector itself — so the one
+  // question a backup must never get wrong ("whose data is in this file?") was
+  // being answered by a screen. The seam resolves its own owner now, and
+  // refuses in words when it cannot; all that is left here is the file and the
+  // sentence to show if it could not be written.
   const handleExportEverything = async (): Promise<void> => {
-    const { databaseId, clerkId } = DataService.getUserIds();
-    // Signed in but the database identity has not resolved yet. Falling through
-    // to the local path here would hand a signed-in user a file made of
-    // whatever demo or imported data their browser happens to hold.
-    if (isUsingSupabase && !databaseId) {
-      setBackupError('This session has no database identity yet, so there is nothing to read. Reload the page and try again.');
-      return;
-    }
     setBackupError('');
     setIsBackingUp(true);
     setBackupProgress(null);
     try {
-      const bundle = databaseId
-        ? await collectBackupBundle(
-            { databaseUserId: databaseId, clerkUserId: clerkId },
-            { onProgress: setBackupProgress }
-          )
-        : await collectLocalBackupBundle({ onProgress: setBackupProgress });
+      const bundle = await dataPort.collectBackup({ onProgress: setBackupProgress });
       downloadBackupBundle(bundle);
     } catch (error) {
       exportManagerLogger.error('Full backup failed', error);

--- a/src/pages/__tests__/ExportManager.test.tsx
+++ b/src/pages/__tests__/ExportManager.test.tsx
@@ -11,6 +11,7 @@ import React from 'react';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { MemoryRouter } from 'react-router-dom';
+import { buildBackupBundle } from '../../services/backupService';
 import type { Account, Category, Transaction } from '../../types';
 
 const accounts: Account[] = [
@@ -96,6 +97,21 @@ vi.mock('../../contexts/AppContextSupabase', () => ({
   useApp: () => appValue
 }));
 
+/**
+ * The seam, mocked as ONE door.
+ *
+ * These assertions were first written against the page as it stood — reading
+ * `DataService.getUserIds()`, branching on the database id, and calling one of
+ * two collectors itself — and run green there. Only the mock changed: which
+ * store a backup is read out of is the seam's business now, and it is pinned
+ * where that decision lives (dataService.test.ts, "which store the backup comes
+ * from"). What this file still owns is the FILE: that what the seam handed back
+ * is what landed on disk, and that a refusal is shown rather than swallowed.
+ */
+const seam = vi.hoisted(() => ({ collectBackup: vi.fn() }));
+
+vi.mock('../../services/port', () => ({ dataPort: seam }));
+
 describe('Export Data page', () => {
   // Every module under src/ is re-imported per test (see beforeEach), so the
   // providers have to come from the SAME graph as the page — a React context
@@ -118,6 +134,8 @@ describe('Export Data page', () => {
   beforeEach(async () => {
     localStorage.clear();
     downloads.length = 0;
+    appValue.isUsingSupabase = false;
+    seam.collectBackup.mockReset();
 
     // A fresh module graph per test, so each one gets the exportService
     // singleton a newly-opened browser would get: it caches its templates in
@@ -283,6 +301,87 @@ describe('Export Data page', () => {
     it('has no History tab promising a feature that records nothing', () => {
       renderPage();
       expect(screen.queryByRole('button', { name: /History/i })).not.toBeInTheDocument();
+    });
+  });
+
+  /**
+   * The full backup — the only export that can be restored, and the only one
+   * that reads whole rows out of the store rather than the app's React state.
+   */
+  describe('the full backup', () => {
+    const bundle = buildBackupBundle({
+      sourceUserId: 'source-login',
+      exportedAt: '2026-03-04T10:00:00.000Z',
+      data: {
+        accounts: [{ id: 'acct-1', name: 'Everyday', type: 'current', balance: '10.00' }],
+        transactions: [
+          { id: 'txn-1', account_id: 'acct-1', amount: '-10.00', date: '2026-02-01', description: 'Shop' }
+        ]
+      },
+      preferences: null
+    });
+
+    const download = (): void => {
+      fireEvent.click(screen.getByRole('button', { name: /Download full backup/i }));
+    };
+
+    it('writes the file the seam handed back, named for the day it was taken', async () => {
+      seam.collectBackup.mockResolvedValue(bundle);
+      renderPage();
+      download();
+
+      await waitFor(() => expect(downloads).toHaveLength(1));
+      expect(downloads[0].filename).toBe('wealthtracker-backup-2026-03-04.json');
+      expect(JSON.parse(downloads[0].text)).toEqual(JSON.parse(JSON.stringify(bundle)));
+    });
+
+    it('asks the seam once, and gives it somewhere to report progress', async () => {
+      // A real dataset is 50k+ rows and 50+ round trips. The page has to hand
+      // over a reporter or the button sits silent long enough to look broken.
+      seam.collectBackup.mockImplementation(async (options: { onProgress?: (p: unknown) => void }) => {
+        options.onProgress?.({
+          entity: 'transaction_splits',
+          entityNumber: 4,
+          entityCount: 14,
+          rows: 1234
+        });
+        return bundle;
+      });
+      renderPage();
+      download();
+
+      await waitFor(() => expect(downloads).toHaveLength(1));
+      expect(seam.collectBackup).toHaveBeenCalledTimes(1);
+      const [options] = seam.collectBackup.mock.calls[0];
+      expect(typeof options.onProgress).toBe('function');
+      // No owner, ever: the page does not know whose data this is, which is the
+      // whole point of the operation living behind the seam.
+      expect(Object.keys(options)).toEqual(['onProgress']);
+    });
+
+    it('says what the store said and writes no file when the read fails', async () => {
+      seam.collectBackup.mockRejectedValue(new Error('Could not read transactions for the backup: timeout'));
+      renderPage();
+      download();
+
+      await screen.findByText(/The backup stopped and no file was written/i);
+      expect(screen.getByText(/Could not read transactions for the backup: timeout/)).toBeInTheDocument();
+      expect(downloads).toHaveLength(0);
+    });
+
+    it('shows the seam\'s refusal rather than writing a file made of the wrong data', async () => {
+      // This page used to make this judgement itself, from a database id it had
+      // asked for. The sentence is now the seam's, and it is REACHED — a
+      // refusal that never reached the screen would leave the button looking
+      // like it had done nothing.
+      seam.collectBackup.mockRejectedValue(new Error(
+        'This session has no database identity yet, so there is nothing to read. Reload the page and try again.'
+      ));
+      renderPage();
+      download();
+
+      await screen.findByText(/no database identity yet/i);
+      expect(downloads).toHaveLength(0);
     });
   });
 

--- a/src/services/__tests__/dataService.test.ts
+++ b/src/services/__tests__/dataService.test.ts
@@ -4,6 +4,7 @@ import { AccountService } from '../api/accountService';
 import { TransactionService } from '../api/transactionService';
 import { createSimpleAccountService } from '../api/simpleAccountService';
 import { registerSupabaseTokenGetter } from '../../lib/supabaseToken';
+import { buildBackupBundle } from '../backupService';
 import type { Account, Budget, Category, Goal, Transaction, TransactionSplit } from '../../types';
 import { STORAGE_KEYS } from '../storageAdapter';
 
@@ -2780,5 +2781,224 @@ describe('DataService.importTransactions (which writer gets the file)', () => {
     });
     expect(device).not.toHaveBeenCalled();
     expect(client.importInChunks).not.toHaveBeenCalled();
+  });
+});
+
+describe('DataService backup and restore (which store the file comes from, and goes to)', () => {
+  const logger = { error: vi.fn(), warn: vi.fn(), log: vi.fn() };
+
+  /**
+   * A file, in the shape the format actually has. Nothing here is read by the
+   * routing — it is handed straight to whichever engine answers — but a real
+   * bundle keeps the test honest about what crosses the seam.
+   */
+  const bundle = () => buildBackupBundle({
+    sourceUserId: 'source-login',
+    exportedAt: '2026-03-04T10:00:00.000Z',
+    data: {
+      accounts: [{ id: 'acct-1', name: 'Everyday', type: 'current', balance: '10.00' }],
+      transactions: [
+        { id: 'txn-1', account_id: 'acct-1', amount: '-10.00', date: '2026-02-01', description: 'Shop' }
+      ]
+    },
+    preferences: null
+  });
+
+  const cloudOutcome = {
+    restored: [{ label: 'Accounts', rows: 1 }],
+    accountsRelinked: 0,
+    transactionsRelinked: 0,
+    preferencesRestored: 0,
+    preferencesFailure: null,
+    danglingRefs: []
+  };
+
+  const deviceOutcome = { ...cloudOutcome, notStoredLocally: [] };
+
+  const cloudEngine = () => ({
+    userFinancialDataIsEmpty: vi.fn(async () => true),
+    collectBackupBundle: vi.fn(async () => bundle()),
+    restoreBackupBundle: vi.fn(async () => cloudOutcome)
+  });
+
+  const deviceEngine = () => ({
+    localFinancialDataIsEmpty: vi.fn(async () => true),
+    collectLocalBackupBundle: vi.fn(async () => bundle()),
+    restoreLocalBackupBundle: vi.fn(async () => deviceOutcome)
+  });
+
+  const signedIn = {
+    ensureUserExists: vi.fn(),
+    getCurrentDatabaseUserId: vi.fn(() => 'db-user-1' as string | null),
+    getCurrentUserIds: vi.fn(() => ({ clerkId: 'clerk-1', databaseId: 'db-user-1' }))
+  };
+  const signedOut = {
+    ensureUserExists: vi.fn(),
+    getCurrentDatabaseUserId: vi.fn(() => null),
+    getCurrentUserIds: vi.fn(() => ({ clerkId: null, databaseId: null }))
+  };
+
+  const service = (
+    options: { signedIn: boolean; cloud: ReturnType<typeof cloudEngine>; device: ReturnType<typeof deviceEngine> }
+  ) => createDataService({
+    isSupabaseConfigured: () => options.signedIn,
+    hasCloudSession: () => options.signedIn,
+    userIdService: options.signedIn ? signedIn : signedOut,
+    storageAdapter: createStorage(),
+    logger,
+    uuid: () => 'generated-1',
+    cloudBackup: options.cloud,
+    deviceBackup: options.device
+  });
+
+  describe('signed in', () => {
+    it('asks the login whether it is empty, and never asks the browser', async () => {
+      const cloud = cloudEngine();
+      const device = deviceEngine();
+
+      await expect(service({ signedIn: true, cloud, device }).financialDataIsEmpty()).resolves.toBe(true);
+
+      expect(cloud.userFinancialDataIsEmpty).toHaveBeenCalledWith('db-user-1');
+      expect(device.localFinancialDataIsEmpty).not.toHaveBeenCalled();
+    });
+
+    it('reads the backup out of the login, with BOTH ids the fourteen tables are keyed by', async () => {
+      // Thirteen tables hang off the database id; recurring_transactions hangs
+      // off the Clerk id. Resolving only one of them writes a file that is
+      // missing a table and says nothing about it.
+      const cloud = cloudEngine();
+      const device = deviceEngine();
+      const onProgress = vi.fn();
+
+      await service({ signedIn: true, cloud, device }).collectBackup({ onProgress });
+
+      expect(cloud.collectBackupBundle).toHaveBeenCalledTimes(1);
+      expect(cloud.collectBackupBundle).toHaveBeenCalledWith(
+        { databaseUserId: 'db-user-1', clerkUserId: 'clerk-1' },
+        { onProgress }
+      );
+      expect(device.collectLocalBackupBundle).not.toHaveBeenCalled();
+    });
+
+    it('restores into the login, and says nothing was left behind', async () => {
+      const cloud = cloudEngine();
+      const device = deviceEngine();
+      const onProgress = vi.fn();
+      const file = bundle();
+
+      const outcome = await service({ signedIn: true, cloud, device }).restoreBackup(file, { onProgress });
+
+      expect(cloud.restoreBackupBundle).toHaveBeenCalledWith(file, 'db-user-1', { onProgress });
+      expect(device.restoreLocalBackupBundle).not.toHaveBeenCalled();
+      // A login holds every table the format carries. The empty list is that
+      // statement — the dialog renders a warning when it is NOT empty.
+      expect(outcome.notStoredLocally).toEqual([]);
+      expect(outcome.restored).toEqual(cloudOutcome.restored);
+    });
+  });
+
+  describe('on a device', () => {
+    it('asks the browser, through THIS service\'s store', async () => {
+      // The store matters as much as the route: the engine defaults to the
+      // app's real adapter when handed nothing, so a service told to use
+      // another store must hand that store over or it reads the wrong device.
+      const cloud = cloudEngine();
+      const device = deviceEngine();
+
+      await expect(service({ signedIn: false, cloud, device }).financialDataIsEmpty()).resolves.toBe(true);
+
+      expect(cloud.userFinancialDataIsEmpty).not.toHaveBeenCalled();
+      const [options] = device.localFinancialDataIsEmpty.mock.calls[0];
+      expect(typeof options.store.get).toBe('function');
+      expect(typeof options.store.setMany).toBe('function');
+    });
+
+    it('reads the backup out of the browser, with no owner anywhere in sight', async () => {
+      const cloud = cloudEngine();
+      const device = deviceEngine();
+      const onProgress = vi.fn();
+
+      await service({ signedIn: false, cloud, device }).collectBackup({ onProgress });
+
+      expect(cloud.collectBackupBundle).not.toHaveBeenCalled();
+      const [options] = device.collectLocalBackupBundle.mock.calls[0];
+      expect(options.onProgress).toBe(onProgress);
+      expect(typeof options.store.setMany).toBe('function');
+    });
+
+    it('restores into the browser with this service\'s own id generator', async () => {
+      // THE REMAP. Every row in a backup gets a fresh id on the way in, because
+      // the primary keys in the file are unique across the whole store rather
+      // than per owner — so a file restored anywhere but where it came from
+      // carries ids belonging to somebody else's rows. Handing the engine this
+      // service's generator is what makes that operation reproducible; the
+      // engine's own default is crypto.randomUUID, which is what this resolves
+      // to in the app.
+      const cloud = cloudEngine();
+      const device = deviceEngine();
+      const onProgress = vi.fn();
+      const file = bundle();
+
+      const outcome = await service({ signedIn: false, cloud, device }).restoreBackup(file, { onProgress });
+
+      expect(cloud.restoreBackupBundle).not.toHaveBeenCalled();
+      expect(device.restoreLocalBackupBundle).toHaveBeenCalledTimes(1);
+      const [restored, options] = device.restoreLocalBackupBundle.mock.calls[0];
+      expect(restored).toBe(file);
+      expect(options.onProgress).toBe(onProgress);
+      expect(typeof options.store.setMany).toBe('function');
+      expect(typeof options.newId).toBe('function');
+      expect(options.newId()).toBe('generated-1');
+      expect(outcome.notStoredLocally).toEqual([]);
+    });
+  });
+
+  describe('a signed-in session whose database id has not resolved yet', () => {
+    const pending = (cloud: ReturnType<typeof cloudEngine>, device: ReturnType<typeof deviceEngine>) =>
+      createDataService({
+        isSupabaseConfigured: () => true,
+        hasCloudSession: () => true,
+        userIdService: pendingUserIdService(),
+        storageAdapter: createStorage(),
+        logger,
+        cloudBackup: cloud,
+        deviceBackup: device
+      });
+
+    const NOTHING_TO_READ =
+      'This session has no database identity yet, so there is nothing to read. Reload the page and try again.';
+    const NOT_SCOPED =
+      'This session has no database identity yet, so a restore cannot be scoped to your login. Reload the page and try again.';
+
+    it('refuses to build a file out of whatever the browser happens to hold', async () => {
+      // The failure this closes is not an error message, it is a person keeping
+      // a file they believe holds their ledger and finding demo data in it.
+      const cloud = cloudEngine();
+      const device = deviceEngine();
+
+      expect(await refusalMessage(pending(cloud, device).collectBackup())).toBe(NOTHING_TO_READ);
+      expect(cloud.collectBackupBundle).not.toHaveBeenCalled();
+      expect(device.collectLocalBackupBundle).not.toHaveBeenCalled();
+    });
+
+    it('refuses to answer "is it empty" rather than saying yes about the wrong store', async () => {
+      // `true` here unlocks the restore button. Over a login full of data that
+      // is the worst answer available.
+      const cloud = cloudEngine();
+      const device = deviceEngine();
+
+      expect(await refusalMessage(pending(cloud, device).financialDataIsEmpty())).toBe(NOT_SCOPED);
+      expect(cloud.userFinancialDataIsEmpty).not.toHaveBeenCalled();
+      expect(device.localFinancialDataIsEmpty).not.toHaveBeenCalled();
+    });
+
+    it('refuses to pour a file into browser storage the app will never read again', async () => {
+      const cloud = cloudEngine();
+      const device = deviceEngine();
+
+      expect(await refusalMessage(pending(cloud, device).restoreBackup(bundle()))).toBe(NOT_SCOPED);
+      expect(cloud.restoreBackupBundle).not.toHaveBeenCalled();
+      expect(device.restoreLocalBackupBundle).not.toHaveBeenCalled();
+    });
   });
 });

--- a/src/services/api/dataService.ts
+++ b/src/services/api/dataService.ts
@@ -25,11 +25,15 @@ import { splitDeclaresTransferLeg } from '../../utils/transactionSplits';
 import { getDefaultCategories } from '../../data/defaultCategories';
 import type {
   AccountBalanceSnapshot,
+  BackupBundle,
+  BackupRestoreOutcome,
   BootTransactionsResult,
   BulkImportProgress,
   BulkImportResult,
   DataPort,
-  ImportSourceKind
+  ExportProgress,
+  ImportSourceKind,
+  RestoreProgress
 } from '../port/dataPort';
 // Type-only, so the bulk importers themselves stay out of the boot chunk —
 // the values are fetched on demand (see `cloudBulkImportClient`).
@@ -38,6 +42,12 @@ import type {
   LocalImportOptions,
   LocalTransactionImportStore
 } from '../localTransactionImportService';
+// Type-only for the same reason, and it matters more here: backupService
+// reaches for a Supabase client in its first lines, so a static import would
+// put the whole backup/restore machinery — and that client — in front of every
+// user on first paint for a feature most of them press once a year.
+import type * as CloudBackupService from '../backupService';
+import type * as DeviceBackupService from '../localBackupService';
 import type { Account, AccountUpdate, Transaction, TransactionSplit, TransactionSplitInput, SplitWriteResult, Budget, Goal, Category, CategoryMergeResult, DismissalKind, SuggestionDismissal } from '../../types';
 
  type Logger = Pick<Console, 'log' | 'warn' | 'error'>;
@@ -98,6 +108,20 @@ type StorageAdapterLike = Pick<typeof storageAdapter, 'get' | 'set'> &
 /** The chunked cloud import client, narrowed to what the seam asks of it. */
 type BulkImportClientLike = Pick<TransactionImportService,
   'setAuthTokenProvider' | 'importInChunks'>;
+/**
+ * The two backup engines, each narrowed to the three entry points the seam
+ * routes to.
+ *
+ * Derived from the real modules rather than re-declared, so a signature that
+ * changes there cannot silently drift from what is called here — and so the
+ * FORMAT stays theirs. This class decides which engine answers; it does not
+ * know what a bundle contains, and adding a table to a backup must never mean
+ * editing this file.
+ */
+type CloudBackupLike = Pick<typeof CloudBackupService,
+  'userFinancialDataIsEmpty' | 'collectBackupBundle' | 'restoreBackupBundle'>;
+type DeviceBackupLike = Pick<typeof DeviceBackupService,
+  'localFinancialDataIsEmpty' | 'collectLocalBackupBundle' | 'restoreLocalBackupBundle'>;
 /** The device-side atomic import, in the shape the seam calls it. */
 type LocalBulkImporter = (
   accountId: string,
@@ -133,6 +157,13 @@ export interface DataServiceOptions {
   bulkImportService?: BulkImportClientLike;
   localBulkImport?: LocalBulkImporter;
   /**
+   * The two backup engines. Absent means "fetch the real one when a backup
+   * runs", exactly as the importers above: there is no honest fallback for
+   * reading somebody's whole ledger out, and none at all for putting it back.
+   */
+  cloudBackup?: CloudBackupLike;
+  deviceBackup?: DeviceBackupLike;
+  /**
    * How the cloud import authenticates. Defaults to the registry AuthContext
    * fills with the signed-in session's Clerk getToken — the same token every
    * other cloud call on this class travels with.
@@ -155,6 +186,8 @@ class DataServiceImpl implements DataPort {
   private readonly hasCloudSession: CloudSessionChecker;
   private readonly injectedBulkImportService: BulkImportClientLike | null;
   private readonly injectedLocalBulkImport: LocalBulkImporter | null;
+  private readonly injectedCloudBackup: CloudBackupLike | null;
+  private readonly injectedDeviceBackup: DeviceBackupLike | null;
   private readonly authTokenProvider: AuthTokenProvider;
 
   constructor(options: DataServiceOptions = {}) {
@@ -184,6 +217,8 @@ class DataServiceImpl implements DataPort {
     this.hasCloudSession = options.hasCloudSession ?? hasSupabaseTokenGetter;
     this.injectedBulkImportService = options.bulkImportService ?? null;
     this.injectedLocalBulkImport = options.localBulkImport ?? null;
+    this.injectedCloudBackup = options.cloudBackup ?? null;
+    this.injectedDeviceBackup = options.deviceBackup ?? null;
     this.authTokenProvider = options.authTokenProvider ?? getSupabaseAccessToken;
   }
 
@@ -750,6 +785,140 @@ class DataServiceImpl implements DataPort {
     return importLocally(accountId, transactions, {
       store,
       uuid: () => this.generateId()
+    });
+  }
+
+  // ── Backup, emptiness and restore ─────────────────────────────────────────
+  //
+  // ROUTING, AND ONLY ROUTING. Both engines already existed, are already
+  // covered by suites of their own, and are not touched here: backupService
+  // reads whole rows out of the database and restores them chunk by chunk;
+  // localBackupService reads browser storage and writes the restore back as ONE
+  // IndexedDB transaction. What changed is who chooses between them. It was the
+  // export page and the restore dialog, each calling `DataService.getUserIds()`
+  // and branching on whether a database id came back — which is the seam's rule
+  // 1 (identity is internal) being broken in the two places where getting it
+  // wrong costs a person their whole ledger rather than one row.
+
+  /** The cloud backup engine, fetched the first time a backup runs. */
+  private async cloudBackupEngine(): Promise<CloudBackupLike> {
+    if (this.injectedCloudBackup) return this.injectedCloudBackup;
+    return import('../backupService');
+  }
+
+  /** The device backup engine. Loaded on demand for the same reason. */
+  private async deviceBackupEngine(): Promise<DeviceBackupLike> {
+    if (this.injectedDeviceBackup) return this.injectedDeviceBackup;
+    return import('../localBackupService');
+  }
+
+  /**
+   * This implementation's own store, in the shape the device backup takes.
+   *
+   * The same "several keys as one unit" slice the bulk import writes through —
+   * one IndexedDB transaction is what makes a local restore all-or-nothing, and
+   * it is the same promise for the same reason, so it is the same helper rather
+   * than a second one free to drift from it. Passed explicitly for the reason
+   * `localImportStore` sets out: the engine defaults to the app's real adapter
+   * when handed nothing, which is right in production and wrong in a test that
+   * injected a store.
+   */
+  private requireDeviceBackupStore(): LocalTransactionImportStore {
+    const store = this.localImportStore();
+    if (!store) {
+      // Unreachable in the app: the real adapter writes many keys as one unit.
+      throw new Error(
+        'This device cannot write several records as one piece, so a backup cannot be put back safely here.'
+      );
+    }
+    return store;
+  }
+
+  /**
+   * A signed-in session whose database id has not resolved yet.
+   *
+   * Reads elsewhere on this class answer `[]` in that state and writes refuse.
+   * Neither is available here: an empty BUNDLE is a file a person would keep
+   * believing it held their ledger, and `true` from the emptiness check would
+   * unlock the restore button over a login full of data. So both refuse, in the
+   * sentence the screen used to supply for itself.
+   */
+  private guardBackupIdentity(refusal: string): void {
+    if (this.isCloudSessionPending()) {
+      throw new Error(refusal);
+    }
+  }
+
+  /** True when this store holds no accounts, categories or transactions. */
+  async financialDataIsEmpty(): Promise<boolean> {
+    const userId = this.userIdService.getCurrentDatabaseUserId();
+    if (userId && this.supabaseChecker()) {
+      const { userFinancialDataIsEmpty } = await this.cloudBackupEngine();
+      return userFinancialDataIsEmpty(userId);
+    }
+
+    this.guardBackupIdentity(
+      'This session has no database identity yet, so a restore cannot be scoped to your login. Reload the page and try again.'
+    );
+    const { localFinancialDataIsEmpty } = await this.deviceBackupEngine();
+    return localFinancialDataIsEmpty({ store: this.requireDeviceBackupStore() });
+  }
+
+  /** Read every table whole and build the file the user downloads. */
+  async collectBackup(options: {
+    onProgress?: (progress: ExportProgress) => void;
+  } = {}): Promise<BackupBundle> {
+    const { databaseId, clerkId } = this.userIdService.getCurrentUserIds();
+    if (databaseId && this.supabaseChecker()) {
+      const { collectBackupBundle } = await this.cloudBackupEngine();
+      // The Clerk id travels beside the database id because ONE of the fourteen
+      // tables is keyed by it (recurring_transactions). Resolving both here is
+      // the whole of what the export page used to do for itself.
+      return collectBackupBundle(
+        { databaseUserId: databaseId, clerkUserId: clerkId },
+        { onProgress: options.onProgress }
+      );
+    }
+
+    this.guardBackupIdentity(
+      'This session has no database identity yet, so there is nothing to read. Reload the page and try again.'
+    );
+    const { collectLocalBackupBundle } = await this.deviceBackupEngine();
+    return collectLocalBackupBundle({
+      onProgress: options.onProgress,
+      store: this.requireDeviceBackupStore()
+    });
+  }
+
+  /** Pour a file back into an empty store. */
+  async restoreBackup(
+    bundle: BackupBundle,
+    options: { onProgress?: (progress: RestoreProgress) => void } = {}
+  ): Promise<BackupRestoreOutcome> {
+    const userId = this.userIdService.getCurrentDatabaseUserId();
+    if (userId && this.supabaseChecker()) {
+      const { restoreBackupBundle } = await this.cloudBackupEngine();
+      const outcome = await restoreBackupBundle(bundle, userId, {
+        onProgress: options.onProgress
+      });
+      // A login holds every table the format carries, so nothing in the file
+      // was left behind. An empty list here is that statement, not a stub.
+      return { ...outcome, notStoredLocally: [] };
+    }
+
+    this.guardBackupIdentity(
+      'This session has no database identity yet, so a restore cannot be scoped to your login. Reload the page and try again.'
+    );
+    const { restoreLocalBackupBundle } = await this.deviceBackupEngine();
+    return restoreLocalBackupBundle(bundle, {
+      onProgress: options.onProgress,
+      store: this.requireDeviceBackupStore(),
+      // The id remap is the part of a restore that makes a file usable in a
+      // store it did not come from, and it mints one id per row. Handing it
+      // this service's own generator is what lets a test hold the whole
+      // operation still — the engine's own default is crypto.randomUUID, which
+      // is exactly what this resolves to in the app.
+      newId: () => this.generateId()
     });
   }
 
@@ -2239,6 +2408,23 @@ export class DataService {
     }
   ): Promise<BulkImportResult> {
     return this.service.importTransactions(accountId, transactions, options);
+  }
+
+  static financialDataIsEmpty(): Promise<boolean> {
+    return this.service.financialDataIsEmpty();
+  }
+
+  static collectBackup(options?: {
+    onProgress?: (progress: ExportProgress) => void;
+  }): Promise<BackupBundle> {
+    return this.service.collectBackup(options);
+  }
+
+  static restoreBackup(
+    bundle: BackupBundle,
+    options?: { onProgress?: (progress: RestoreProgress) => void }
+  ): Promise<BackupRestoreOutcome> {
+    return this.service.restoreBackup(bundle, options);
   }
 
   static archiveTransactionsBefore(accountId: string, cutoff: Date): Promise<number> {

--- a/src/services/port/__tests__/contract.ts
+++ b/src/services/port/__tests__/contract.ts
@@ -34,7 +34,7 @@
  */
 
 import { describe, it, expect } from 'vitest';
-import type { DataPort } from '../dataPort';
+import type { BackupBundle, BackupEntity, BackupRow, DataPort } from '../dataPort';
 import type {
   Account,
   Budget,
@@ -182,6 +182,10 @@ export const DATA_PORT_OPERATIONS: readonly (keyof DataPort)[] = [
   // Dismissal writes
   'dismissSuggestion',
   'restoreSuggestion',
+  // Backup lifecycle
+  'financialDataIsEmpty',
+  'collectBackup',
+  'restoreBackup',
   // Lifecycle
   'initialize',
   'prepareCategories',
@@ -356,6 +360,48 @@ const BULK_IMPORT: Record<
   supabase: { partial: 'any prefix', reportsProgress: true },
   // One store transaction, same as the browser and for the same reason.
   'local-core': { partial: 'all-or-nothing', reportsProgress: false }
+};
+
+/**
+ * B-11 — WHAT THIS ENGINE CANNOT KEEP.
+ *
+ * A backup file carries every table the format knows about, and not every
+ * engine has somewhere to put all of them: a browser has no investments, no
+ * goal contributions and no repeating templates, because local mode has no
+ * screen, no writer and no reader for any of them. Restoring a login's file
+ * onto a device therefore genuinely loses part of it.
+ *
+ * That is a fact about the product, so it is written down HERE rather than
+ * inferred from a mapping inside one engine. Two things follow from it, and
+ * both are asserted below: the rows are never dropped in silence — they come
+ * back NAMED, with a reason a person can read and act on — and an engine that
+ * holds everything says so with an empty list rather than by staying quiet.
+ *
+ * A table added to the format with nowhere to live on a device must appear in
+ * this row on the same day, or the restore that skips it will say nothing.
+ */
+const BACKUP_COVERAGE: Record<
+  DataPortEngine,
+  { notStored: readonly { entity: BackupEntity; label: string }[] }
+> = {
+  'browser-storage': {
+    notStored: [
+      { entity: 'goal_contributions', label: 'Goal contributions' },
+      { entity: 'investments', label: 'Investments' },
+      { entity: 'investment_transactions', label: 'Investment transactions' },
+      { entity: 'recurring_transactions', label: 'Recurring transactions' },
+      { entity: 'notifications', label: 'Notifications' },
+      { entity: 'dashboard_layouts', label: 'Dashboard layouts' },
+      { entity: 'widget_preferences', label: 'Widget preferences' }
+    ]
+  },
+  // Every table in the format is a table in the database — the format was read
+  // off it.
+  supabase: { notStored: [] },
+  // A claim the local edition has to meet, not a description of something that
+  // exists: it is meant to hold the whole ledger. The day it cannot hold a
+  // table, this row says which, and the restore starts saying so too.
+  'local-core': { notStored: [] }
 };
 
 /**
@@ -2213,6 +2259,174 @@ export function runDataPortContract(name: string, harness: DataPortContractHarne
             break;
         }
       });
+    });
+
+    // ── The whole ledger out, and back in ─────────────────────────────────
+    //
+    // The only operations here whose failure costs a person everything rather
+    // than one row. The rules are the same three in every engine: "empty"
+    // means the same question, a file poured into an empty store reproduces
+    // the ledger it came from, and anything the store cannot keep comes back
+    // named instead of vanishing.
+    describe('backup and restore', () => {
+      /** A ledger with something in every table this suite can seed. */
+      const aWholeLedger = (): PortFixture => ({
+        accounts: threeAccounts(),
+        categories: [aCategory('cat-everyday', 'Everyday spending')],
+        transactions: [
+          aTransaction('txn-1', { amount: -10.1, description: 'Corner shop' }),
+          aTransaction('txn-2', {
+            accountId: ACCOUNT_B,
+            amount: 500,
+            description: 'Payday',
+            type: 'income'
+          })
+        ],
+        budgets: [aBudget('budget-1', 'cat-everyday', 200)],
+        goals: [aGoal('goal-1', 'New boiler', 1500)]
+      });
+
+      /**
+       * Everything about a file except WHEN it was taken.
+       *
+       * Two backups of the same untouched ledger are the same backup; the
+       * timestamp is a note about the act of exporting, not about the data,
+       * and comparing it would only ever assert that a clock moved.
+       */
+      const contents = (bundle: BackupBundle) => ({
+        format: bundle.format,
+        schemaVersion: bundle.schemaVersion,
+        counts: bundle.counts,
+        data: bundle.data,
+        links: bundle.links,
+        preferences: bundle.preferences
+      });
+
+      it('says a fresh store is empty, and says otherwise the moment it holds anything', async () => {
+        // The question the restore dialog asks before it offers the button, so
+        // a wrong answer either refuses a restore that was safe or allows one
+        // over a login full of data.
+        const fresh = await harness.create({});
+        expect(await fresh.port.financialDataIsEmpty()).toBe(true);
+
+        const holding = await harness.create({ accounts: threeAccounts() });
+        expect(await holding.port.financialDataIsEmpty()).toBe(false);
+      });
+
+      it('pours a file into an empty store and gets the same ledger back, to the penny', async () => {
+        const source = await harness.create(aWholeLedger());
+        const file = await source.port.collectBackup();
+
+        const target = await harness.create({});
+        const outcome = await target.port.restoreBackup(file);
+
+        const before = await source.read();
+        const after = await target.read();
+
+        expect(after.accounts.map(account => account.name).sort())
+          .toEqual(before.accounts.map(account => account.name).sort());
+        expect(after.transactions.map(transaction => transaction.description).sort())
+          .toEqual(before.transactions.map(transaction => transaction.description).sort());
+        expect(after.categories.map(category => category.name).sort())
+          .toEqual(before.categories.map(category => category.name).sort());
+        expect(after.budgets.map(budget => budget.amount)).toEqual(before.budgets.map(budget => budget.amount));
+        expect(after.goals.map(goal => goal.name)).toEqual(before.goals.map(goal => goal.name));
+
+        // Money survives a trip through the file as money — matched by NAME,
+        // because every id is new (see below). -70.1 is the figure that goes
+        // wrong in float if anything on the way in or out re-adds the rows.
+        const balanceByName = (state: PortStoreState, name: string): number | undefined =>
+          state.accounts.find(account => account.name === name)?.balance;
+        expect(balanceByName(after, 'Everyday')).toBe(balanceByName(before, 'Everyday'));
+        expect(balanceByName(after, 'Rainy day')).toBe(balanceByName(before, 'Rainy day'));
+        expect(balanceByName(after, 'Everyday')).toBe(-70.1);
+
+        // Nothing the file held was left unaccounted for, and the store now
+        // answers the emptiness question the other way.
+        expect(outcome.restored.some(entry => entry.rows > 0)).toBe(true);
+        expect(await target.port.financialDataIsEmpty()).toBe(false);
+
+        // EVERY ID IS NEW. The primary keys in a backup are unique across the
+        // whole store rather than per owner, so a restore that kept them would
+        // collide with the rows of whoever exported the file — which is the
+        // main case a backup exists for.
+        const oldIds = new Set(before.accounts.map(account => account.id));
+        expect(after.accounts.every(account => !oldIds.has(account.id))).toBe(true);
+        // And the rows that pointed at those accounts followed them.
+        const byName = new Map(after.accounts.map(account => [account.name, account.id]));
+        const everyday = after.transactions.find(t => t.description === 'Corner shop');
+        expect(everyday?.accountId).toBe(byName.get('Everyday'));
+      });
+
+      it('a restored ledger exports to the same file again, and again', async () => {
+        // Generation 2 against generation 3, because generation 1 carries the
+        // ids the fixture invented and every restore mints new ones. Two
+        // restores from a store that starts fresh produce the same ids in the
+        // same order, so a conversion that lost or invented a field on the way
+        // through the file drifts between generations and shows up here.
+        const source = await harness.create(aWholeLedger());
+        const first = await source.port.collectBackup();
+
+        const secondStore = await harness.create({});
+        await secondStore.port.restoreBackup(first);
+        const second = await secondStore.port.collectBackup();
+
+        const thirdStore = await harness.create({});
+        await thirdStore.port.restoreBackup(second);
+        const third = await thirdStore.port.collectBackup();
+
+        expect(contents(third)).toEqual(contents(second));
+      });
+
+      it('refuses to restore over a store that still holds something, and changes nothing', async () => {
+        // A restore REPLACES; it does not merge. Refusing is what makes it safe
+        // to attempt at all — nothing the user already has can be mixed with
+        // the file, re-dated, or half-overwritten.
+        const source = await harness.create(aWholeLedger());
+        const file = await source.port.collectBackup();
+
+        const occupied = await harness.create({ accounts: threeAccounts() });
+        const before = asComparable(await occupied.read());
+
+        await expect(occupied.port.restoreBackup(file)).rejects.toThrow();
+        expect(asComparable(await occupied.read())).toBe(before);
+      });
+
+      it(
+        BACKUP_COVERAGE[engine].notStored.length === 0
+          ? 'holds every table the format carries, and says so'
+          : `names the ${BACKUP_COVERAGE[engine].notStored.length} tables it cannot keep instead of dropping them in silence`,
+        async () => {
+          // B-11. "3 investments were skipped" tells somebody nothing they can
+          // act on; knowing the file still holds them, and where they would
+          // come back, does. So the answer is a list of names with reasons.
+          const source = await harness.create(aWholeLedger());
+          const file = await source.port.collectBackup();
+
+          const unstorable = BACKUP_COVERAGE[engine].notStored;
+          const row: BackupRow = { id: 'row-the-file-carries', user_id: 'source-login' };
+          const carried: BackupBundle = {
+            ...file,
+            data: { ...file.data },
+            counts: { ...file.counts }
+          };
+          for (const { entity } of unstorable) {
+            carried.data[entity] = [row];
+            carried.counts[entity] = 1;
+          }
+
+          const target = await harness.create({});
+          const outcome = await target.port.restoreBackup(carried);
+
+          expect(outcome.notStoredLocally.map(entry => entry.label).sort())
+            .toEqual(unstorable.map(entry => entry.label).sort());
+          // Every one of them carries a sentence, not a count.
+          for (const entry of outcome.notStoredLocally) {
+            expect(entry.rows).toBe(1);
+            expect(entry.absence.length).toBeGreaterThan(0);
+          }
+        }
+      );
     });
   });
 }

--- a/src/services/port/dataPort.ts
+++ b/src/services/port/dataPort.ts
@@ -43,9 +43,10 @@
  * This is the seam as it stands, not as it will end: the operations below are
  * exactly the ones DataService owns today, under the names it uses today.
  * Bulk import has joined it (the CSV and OFX importers write through
- * `importTransactions`); backup/restore/wipe and the capability descriptor that
- * will retire `isUsingSupabase` join as their consumers are routed through it
- * in turn. The names here are today's names
+ * `importTransactions`), and so have the backup, the emptiness check and the
+ * restore. The wipe and the capability descriptor that will retire
+ * `isUsingSupabase` join as their consumers are routed through it in turn. The
+ * names here are today's names
  * deliberately: renaming and re-routing in one step would make a rename
  * indistinguishable from a behaviour change in review.
  */
@@ -64,6 +65,36 @@ import type {
   TransactionSplit,
   TransactionSplitInput
 } from '../../types';
+/**
+ * The backup FILE format, imported rather than restated.
+ *
+ * `import type` is erased at build, so this costs nothing and keeps the "emits
+ * nothing" promise above. It is imported rather than re-declared because these
+ * types describe a file on the user's disk, not an engine: `buildBackupBundle`,
+ * `validateBackupBundle` and `remapBackupIds` are pure functions over rows that
+ * BOTH of today's engines already share, and a second declaration of the same
+ * shape here would be free to drift from the one the file is actually written
+ * and validated against. A local edition inherits the format for the same
+ * reason it inherits the seam.
+ */
+import type {
+  BackupBundle,
+  BackupEntity,
+  BackupRow,
+  DanglingReference,
+  ExportProgress,
+  RestoreOutcome,
+  RestoreProgress
+} from '../backupService';
+
+export type {
+  BackupBundle,
+  BackupEntity,
+  BackupRow,
+  DanglingReference,
+  ExportProgress,
+  RestoreProgress
+};
 
 /**
  * An amount of money, exactly representable at two decimal places.
@@ -637,6 +668,111 @@ export interface DataPortDismissalWrites {
   restoreSuggestion(kind: DismissalKind, subjectKey: string): Promise<void>;
 }
 
+/**
+ * What a finished restore looks like, whichever engine did it.
+ *
+ * Derived from the outcome the restore already reports rather than restated, so
+ * a field added there joins the seam instead of quietly failing to.
+ */
+export interface BackupRestoreOutcome extends RestoreOutcome {
+  /**
+   * Rows the file carries that this store has nowhere to keep, named with the
+   * reason why.
+   *
+   * The one field a login never fills. A browser has no investments, no goal
+   * contributions and no repeating templates, so a file taken from a login and
+   * restored onto a device genuinely cannot keep some of what it holds — and
+   * saying so is the difference between a restore and a restore that quietly
+   * lost things. An engine that holds every table the format carries answers
+   * with an empty list, and that is a statement rather than a stub.
+   */
+  notStoredLocally: { label: string; rows: number; absence: string }[];
+}
+
+/**
+ * Getting the whole ledger out, and putting it back.
+ *
+ * The one group whose failure mode is not "a wrong number on a screen" but "the
+ * only copy of somebody's financial life". Every rule below exists because the
+ * alternative loses data silently.
+ */
+export interface DataPortBackupLifecycle {
+  /**
+   * Is there anything here at all?
+   *
+   * "Empty" means the same three tables in every implementation — accounts,
+   * categories and transactions — because it is asked for exactly one reason:
+   * a restore only ever writes into an empty store, and the dialog has to know
+   * before it offers the button. An engine that answered a broader or narrower
+   * question would refuse restores that are safe, or allow ones that are not.
+   *
+   * REJECTS rather than guessing. Unlike the boot reads, there is no honest
+   * fallback: `true` from a store that could not be reached would unlock the
+   * restore button in front of a login full of data.
+   */
+  financialDataIsEmpty(): Promise<boolean>;
+  /**
+   * Read every table whole and build the file the user downloads.
+   *
+   * WHOLE ROWS, NOT APP STATE. The file has to be restorable, and app state is
+   * a lossy picture of the store by design — it drops columns, skips tables
+   * with no screen behind them, and renames what is left. A file built from it
+   * could never be poured back in.
+   *
+   * IT DOES NOT TAKE AN OWNER (rule 1), and this is the operation where that
+   * matters most sharply: a backup taken against an unresolved identity would
+   * hand a signed-in person a file made of whatever demo or imported data their
+   * browser happens to hold, and they would find out on the day they needed it.
+   * An implementation that cannot resolve its owner refuses in words rather
+   * than reading the nearest store it can find.
+   *
+   * Progress is reported per table because a real dataset is 50k+ rows and 50+
+   * round trips, and a button that says nothing for that long reads as broken.
+   * An engine with nothing to report stays silent rather than estimating.
+   */
+  collectBackup(options?: {
+    onProgress?: (progress: ExportProgress) => void;
+  }): Promise<BackupBundle>;
+  /**
+   * Pour a file back in.
+   *
+   * ── ONLY INTO AN EMPTY STORE ────────────────────────────────────────────
+   *
+   * A restore REPLACES; it does not merge. So it is refused unless
+   * `financialDataIsEmpty()` is true, and emptying is a separate decision with
+   * its own confirmation. That is not caution, it is what makes the operation
+   * safe to attempt at all: nothing the user already has can be mixed with the
+   * file, re-dated or half-overwritten.
+   *
+   * ── EVERY ID IS REPLACED ON THE WAY IN ──────────────────────────────────
+   *
+   * Not an optimisation and not conditional on a collision being detected. The
+   * primary keys in a backup are unique across the whole store rather than per
+   * owner, so a file restored anywhere but where it came from carries ids that
+   * belong to somebody else's rows — which is the MAIN case a backup exists
+   * for ("my account is gone, I made a new one, put my file back"). Every
+   * reference to a remapped id is rewritten with it, and a reference the file
+   * does not contain is left exactly as it was and REPORTED in `danglingRefs`
+   * rather than blanked: a restore that silently detaches data is the one
+   * failure a backup must never have.
+   *
+   * ── HOW FAR A FAILURE GETS (divergence B-10) ────────────────────────────
+   *
+   * Declared rather than asserted equal. The cloud restores in chunks that each
+   * commit on their own, so a failure halfway leaves the login PARTLY
+   * POPULATED — survivable, because the login had to be empty first, but it
+   * must be said rather than smoothed over. A device write is one transaction,
+   * so it either landed or it did not. Callers render whichever is true of the
+   * engine that answered; no caller may assume one of them.
+   */
+  restoreBackup(
+    bundle: BackupBundle,
+    options?: {
+      onProgress?: (progress: RestoreProgress) => void;
+    }
+  ): Promise<BackupRestoreOutcome>;
+}
+
 export interface DataPortLifecycle {
   /**
    * Make sure the signed-in person has a store to read. A no-op for an
@@ -694,4 +830,5 @@ export interface DataPort extends
   DataPortSplitWrites,
   DataPortPlanningWrites,
   DataPortDismissalWrites,
+  DataPortBackupLifecycle,
   DataPortLifecycle {}

--- a/src/services/port/index.ts
+++ b/src/services/port/index.ts
@@ -15,12 +15,18 @@ import type { DataPort } from './dataPort';
 
 export type {
   AccountBalanceSnapshot,
+  BackupBundle,
+  BackupEntity,
+  BackupRestoreOutcome,
+  BackupRow,
   BootTransactionStats,
   BootTransactionsResult,
   BulkImportProgress,
   BulkImportResult,
+  DanglingReference,
   DataPort,
   DataPortAccountWrites,
+  DataPortBackupLifecycle,
   DataPortBulkWrites,
   DataPortDismissalWrites,
   DataPortLifecycle,
@@ -29,8 +35,10 @@ export type {
   DataPortSplitWrites,
   DataPortTransactionWrites,
   DataPortTransferWrites,
+  ExportProgress,
   ImportSourceKind,
-  MoneyNumber
+  MoneyNumber,
+  RestoreProgress
 } from './dataPort';
 
 export const dataPort: DataPort = DataService;


### PR DESCRIPTION
Slice 9 of the write-paths plan — destructive paths, characterisation-first.

- `collectBackup` / `restoreBackup` / `financialDataIsEmpty` join the port as **routing** over the proven backup engines (the verified export/restore logic is untouched); the pages stop resolving identity and picking engines; `DataService` leaves ExportManager entirely.
- **Real find**: the export page's pending-session guard read a flag set only *after* identity resolution — it could never be true in the window it guarded, so a signed-in-but-connecting user was handed a backup of browser demo data. The seam's guard closes it; same sentence, actually protective (5d's reasoning applied to backups).
- Contract 69 → 74: the B-11 device-coverage table (seven entities a device cannot keep, with reasons), empty-store round-trip identity (file → restore → identical file, every id new), refusal-leaves-store-identical. The wipe-variant round-trip completes with slice 10.
- Both page suites had **zero** coverage here — written against HEAD first, run green, then re-pointed to the port. Mutation red in both layers; engine-level remap coverage cited (30 existing tests), not duplicated.
- `getUserIds` survives in exactly one file for exactly the three feeds slices 10/11 own — documented at the declaration; ExportManager's session consumer is gone outright (one fewer for slice 11 than planned).
- Bundle +0.6 KB gz main (the routing itself); both engines verified absent from the boot chunk by string search.

Gate: lint · strict tsc · smoke 4,891 · realtime 213 · build · coverage 75.22/81.30 vs 63/55.

🤖 Generated with [Claude Code](https://claude.com/claude-code)