### PR TITLE
feat(seam): slice 10 — wipe and Money migration through the port; no page holds Postgres

### DIFF
--- a/src/components/RestoreBackupModal.tsx
+++ b/src/components/RestoreBackupModal.tsx
@@ -13,14 +13,12 @@ import {
   preferenceCount,
   transactionDateRange,
   validateBackupBundle,
-  wipeUserFinancialData,
   type BackupBundle,
   type RestoreProgress,
 } from '../services/backupService';
 import {
   LOCAL_BACKUP_BINDINGS,
   LocalRestoreRefusedError,
-  wipeLocalFinancialData,
 } from '../services/localBackupService';
 
 /**
@@ -107,12 +105,17 @@ export default function RestoreBackupModal({ isOpen, onClose }: Props): React.JS
   /**
    * WHAT THIS IS STILL FOR, now that the seam resolves its own owner.
    *
-   * Three things, all of them owned by a later step and none of them a data
-   * operation: the wipe still forks between the two engines HERE (it joins the
-   * seam with `wipeAllFinancialData`); the copy on this dialog says "login" or
-   * "device" throughout; and a signed-in session whose id has not resolved is
-   * blocked from starting at all. The reads and the restore no longer touch it
-   * — `dataPort` answers those without being told whose data it is.
+   * WORDS, and one refusal — no data operation. This dialog is now the LAST
+   * consumer of `getUserIds` in the app, and all three of the things it reads
+   * from it are questions about this edition rather than about anybody's data:
+   * whether the copy says "login" or "device" throughout, whether a restore
+   * that failed halfway warns about a partly-populated store (a chunked cloud
+   * restore can be; one IndexedDB transaction cannot), and whether a signed-in
+   * session is still connecting and must be blocked from starting at all.
+   *
+   * All three leave with `capabilities()`, and the method goes with them. The
+   * emptiness check, the wipe and the restore no longer touch it — `dataPort`
+   * answers those without being told whose data it is.
    */
   const databaseUserId = DataService.getUserIds().databaseId;
   /**
@@ -205,13 +208,13 @@ export default function RestoreBackupModal({ isOpen, onClose }: Props): React.JS
     setPhase('wiping');
     setFailure(null);
     try {
-      // The typed phrase goes through untouched on both engines. Normalising it
-      // here would make the user's typing decoration rather than confirmation.
-      if (databaseUserId) {
-        await wipeUserFinancialData(wipeConfirmText, databaseUserId);
-      } else {
-        await wipeLocalFinancialData(wipeConfirmText);
-      }
+      // THE PHRASE IS THIS SCREEN'S, and it still has to be typed exactly: the
+      // button above is disabled until it is, character for character, and this
+      // dialog never wipes implicitly. What changed is that the phrase is no
+      // longer carried down to an engine — the seam's wipe supplies whatever
+      // its own store demands, which is what lets this file stop choosing
+      // between two of them (and stop holding the identity it chose with).
+      await dataPort.wipeAllFinancialData();
       // The local snapshot now describes history that no longer exists. Drop it
       // before anything reads it back and merges the dead rows in.
       await transactionCache.clear();
@@ -227,7 +230,7 @@ export default function RestoreBackupModal({ isOpen, onClose }: Props): React.JS
       });
       setPhase('failed');
     }
-  }, [databaseUserId, cloudSessionPending, targetName, wipeConfirmText]);
+  }, [cloudSessionPending, targetName]);
 
   const handleRestore = useCallback(async () => {
     if (!bundle || cloudSessionPending) return;

--- a/src/components/__tests__/RestoreBackupModal.test.tsx
+++ b/src/components/__tests__/RestoreBackupModal.test.tsx
@@ -4,14 +4,14 @@
  * The most destructive screen in the app: it erases a login or a device and
  * pours a file in over the top, and it had no test at all. So every assertion
  * here was first written against the behaviour as it stood BEFORE the seam took
- * the emptiness check and the restore, and run green against it. Only the mocks
- * changed afterwards — from the two engines this file used to choose between,
- * to the one door it knocks on now. That is what makes the suite evidence that
- * the routing changed nothing the user can see.
+ * the emptiness check, the restore and the wipe, and run green against it. Only
+ * the mocks changed afterwards — from the engines this file used to choose
+ * between, to the one door it knocks on now. That is what makes the suite
+ * evidence that the routing changed nothing the user can see.
  *
- * STILL THE PAGE'S OWN, and mocked as such: the wipe (it joins the seam with
- * slice 10) and the identity that decides whether the copy says "login" or
- * "device" (slice 11).
+ * STILL THE PAGE'S OWN, and mocked as such: only the identity that decides
+ * whether the copy says "login" or "device" (slice 11). No data operation on
+ * this screen picks an engine any more.
  */
 
 import React from 'react';
@@ -41,26 +41,11 @@ vi.mock('../../services/api/dataService', () => ({
   DataService: { getUserIds: () => userIds.value },
 }));
 
-/** The wipe is still this page's fork between two engines — slice 10 routes it. */
-const engines = vi.hoisted(() => ({
-  cloudWipe: vi.fn(async () => ({ transactions: 3 })),
-  localWipe: vi.fn(async () => ({ transactions: 3 })),
-}));
-
-vi.mock('../../services/backupService', async (importOriginal) => {
-  const actual = await importOriginal<typeof import('../../services/backupService')>();
-  return { ...actual, wipeUserFinancialData: engines.cloudWipe };
-});
-
-vi.mock('../../services/localBackupService', async (importOriginal) => {
-  const actual = await importOriginal<typeof import('../../services/localBackupService')>();
-  return { ...actual, wipeLocalFinancialData: engines.localWipe };
-});
-
 /** The seam. One door, whichever store is behind it. */
 const seam = vi.hoisted(() => ({
   financialDataIsEmpty: vi.fn<() => Promise<boolean>>(),
   restoreBackup: vi.fn(),
+  wipeAllFinancialData: vi.fn<() => Promise<void>>(),
 }));
 
 vi.mock('../../services/port', () => ({ dataPort: seam }));
@@ -114,6 +99,7 @@ describe('RestoreBackupModal', () => {
     appValue.isUsingSupabase = false;
     seam.financialDataIsEmpty.mockResolvedValue(true);
     seam.restoreBackup.mockResolvedValue({ ...outcome });
+    seam.wipeAllFinancialData.mockResolvedValue(undefined);
   });
 
   const open = (): void => {
@@ -180,7 +166,12 @@ describe('RestoreBackupModal', () => {
       expect(erase).toBeEnabled();
     });
 
-    it('passes the typed phrase through untouched and re-checks emptiness after erasing', async () => {
+    it('erases through the one door, and re-checks emptiness afterwards', async () => {
+      // The phrase gates the BUTTON (above) and is not carried any further: the
+      // seam supplies whatever its own store demands, which is what stopped this
+      // file from having to know there is more than one. What is asserted here
+      // is that erasing happens exactly once, without an owner, and that the
+      // dialog then asks the store again rather than assuming it worked.
       seam.financialDataIsEmpty.mockResolvedValueOnce(false).mockResolvedValueOnce(true);
       open();
       await pickFile(bundleWith());
@@ -191,10 +182,32 @@ describe('RestoreBackupModal', () => {
       });
       fireEvent.click(screen.getByRole('button', { name: /Erase everything in this device/i }));
 
-      await waitFor(() => expect(engines.localWipe).toHaveBeenCalledWith('DELETE EVERYTHING'));
-      expect(engines.cloudWipe).not.toHaveBeenCalled();
+      await waitFor(() => expect(seam.wipeAllFinancialData).toHaveBeenCalledTimes(1));
+      expect(seam.wipeAllFinancialData).toHaveBeenCalledWith();
       await screen.findByText(/is empty, so the backup can go straight in/i);
       expect(emptinessChecks()).toBe(2);
+    });
+
+    it('keeps the store’s own sentence when erasing fails, and does not go on', async () => {
+      // A wipe that stopped is the one moment this dialog must not carry on:
+      // the restore behind it only ever writes into an empty store, and a
+      // half-erased one is neither empty nor untouched.
+      seam.financialDataIsEmpty.mockResolvedValueOnce(false);
+      seam.wipeAllFinancialData.mockRejectedValueOnce(
+        new Error('canceling statement due to statement timeout')
+      );
+      open();
+      await pickFile(bundleWith());
+      await screen.findByText(/already holds data/i);
+
+      fireEvent.change(screen.getByLabelText('Type DELETE EVERYTHING to confirm'), {
+        target: { value: 'DELETE EVERYTHING' },
+      });
+      fireEvent.click(screen.getByRole('button', { name: /Erase everything in this device/i }));
+
+      await screen.findByText(/Stopped at:/);
+      expect(screen.getByText('canceling statement due to statement timeout')).toBeInTheDocument();
+      expect(restoreCalls()).toBe(0);
     });
   });
 

--- a/src/contexts/__tests__/AppContextBootThroughPort.test.tsx
+++ b/src/contexts/__tests__/AppContextBootThroughPort.test.tsx
@@ -260,6 +260,11 @@ vi.mock('../../services/port', () => {
     financialDataIsEmpty: refuse('financialDataIsEmpty'),
     collectBackup: refuse('collectBackup'),
     restoreBackup: refuse('restoreBackup'),
+    // Nor is erasing the ledger, nor replacing it with somebody's .mny file.
+    // A boot that reached either of these would be the loudest bug in the app,
+    // so each refuses by name rather than resolving quietly.
+    wipeAllFinancialData: refuse('wipeAllFinancialData'),
+    importMsMoney: refuse('importMsMoney'),
   };
 
   return { dataPort };

--- a/src/pages/EnhancedImport.tsx
+++ b/src/pages/EnhancedImport.tsx
@@ -5,11 +5,7 @@ import { importRulesService } from '../services/importRulesService';
 import PageWrapper from '../components/PageWrapper';
 import PageTip from '../components/PageTip';
 import { LoadingState } from '../components/loading/LoadingState';
-import { DataService } from '../services/api/dataService';
-import { supabase } from '../lib/supabase';
-import { STORAGE_KEYS } from '../services/storageAdapter';
-import type { MsMoneyImportResult } from '../services/import/msMoney/transform';
-import type { ImportProgress } from '../services/import/msMoney/msMoneyImport';
+import { dataPort, type ImportProgress, type MsMoneyImportResult } from '../services/port';
 import {
   UploadIcon,
   FolderIcon,
@@ -49,7 +45,7 @@ const bankFormats = [
 ];
 
 export default function EnhancedImport(): React.JSX.Element {
-  const { exportData, isUsingSupabase } = useApp();
+  const { exportData } = useApp();
 
   const [showBatchImport, setShowBatchImport] = useState(false);
   const [showRulesManager, setShowRulesManager] = useState(false);
@@ -77,21 +73,22 @@ export default function EnhancedImport(): React.JSX.Element {
     URL.revokeObjectURL(url);
   }, [exportData]);
 
-  // Run the destructive MS Money import against the right backend: Supabase for
-  // signed-in users (batched inserts under RLS), local storage otherwise. The
-  // modal owns the confirmation + backup gate; this only executes.
+  // Run the destructive MS Money import. WHICH store it lands in is no longer
+  // this page's question: it used to hold a Postgres client and read
+  // `isUsingSupabase` off the context to answer it, and a page that gets that
+  // wrong writes somebody's whole financial history into a browser their
+  // signed-in app will never read again — and says it worked. The seam resolves
+  // its own owner on the same tick as the write.
+  //
+  // The modal still owns the confirmation and the backup gate; this only
+  // executes, and lets the importer's own message through untouched so the
+  // dialog can show it.
   const executeMsMoneyImport = useCallback(async (
     result: MsMoneyImportResult,
     onProgress: (p: ImportProgress) => void
   ) => {
-    const { importToCloud, importToLocalStorage } = await import('../services/import/msMoney/msMoneyImport');
-    const databaseUserId = DataService.getUserIds().databaseId;
-    if (isUsingSupabase && supabase && databaseUserId) {
-      await importToCloud(result, supabase, databaseUserId, () => crypto.randomUUID(), { onProgress });
-    } else {
-      await importToLocalStorage(result, STORAGE_KEYS, { onProgress });
-    }
-  }, [isUsingSupabase]);
+    await dataPort.importMsMoney(result, { onProgress });
+  }, []);
 
   // A total migration replaces everything — reload so the app re-reads the new
   // dataset cleanly rather than reconciling against stale in-memory state.

--- a/src/pages/__tests__/EnhancedImport.msMoney.test.tsx
+++ b/src/pages/__tests__/EnhancedImport.msMoney.test.tsx
@@ -1,0 +1,179 @@
+import React from 'react';
+import { describe, it, expect, afterEach, beforeEach, vi } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { __setAppContextValue, __resetAppContextValue } from '../../test/mocks/AppContextSupabase';
+import type { MsMoneyImportResult } from '../../services/import/msMoney/transform';
+import type { ImportProgress } from '../../services/import/msMoney/msMoneyImport';
+
+/**
+ * The Microsoft Money migration, as the Import page executes it.
+ *
+ * THE MOST DESTRUCTIVE IMPORT IN THE APP — it wipes the store and writes a whole
+ * .mny file over the top — and it had no test at all. So this suite was written
+ * FIRST, against the page exactly as it stood while it still chose between two
+ * engines with a Postgres client of its own, and run green against it. Only the
+ * mock changed afterwards, from the engine to the one door the page now knocks
+ * on, which is what makes it evidence that the routing changed nothing.
+ *
+ * What it pins now is what the page still owns: it hands the parsed file and
+ * the progress channel to the seam, ONCE, without naming a store or an owner —
+ * and lets the importer's own failure through to the dialog that renders it.
+ *
+ * Why the store is worth pinning rather than assuming: a migration routed to
+ * the wrong one is not a wrong number on a screen. It is a person's entire
+ * financial history written into a browser their signed-in app will never read
+ * again, reported to them as a success. That decision now belongs to the seam,
+ * which resolves its owner on the same tick as the write — and the two engines
+ * are covered where they live (msMoneyImport.test, and the port's own suite).
+ */
+
+/** What the modal handed over, and what came back. */
+const run: {
+  result: MsMoneyImportResult;
+  reports: ImportProgress[];
+  outcome: Promise<void> | null;
+} = { result: emptyMigration(), reports: [], outcome: null };
+
+/** The modal, reduced to the one thing this page owns: the execute callback. */
+vi.mock('../../components/MsMoneyImportModal', () => ({
+  default: ({ isOpen, onExecute }: {
+    isOpen: boolean;
+    onExecute: (result: MsMoneyImportResult, onProgress: (p: ImportProgress) => void) => Promise<void>;
+  }) => isOpen
+    ? (
+      <button
+        type="button"
+        onClick={() => {
+          // Held rather than floated: the page's rejection is the modal's error
+          // message, so the test has to be able to wait for it.
+          run.outcome = onExecute(run.result, (progress) => run.reports.push(progress));
+          run.outcome.catch(() => {});
+        }}
+      >
+        run the migration
+      </button>
+    )
+    : null,
+}));
+
+/** The seam. One door, whichever store is behind it. */
+const seam = vi.hoisted(() => ({
+  importMsMoney: vi.fn<
+    (
+      result: unknown,
+      options?: { onProgress?: (p: { phase: string; fraction: number; message: string }) => void }
+    ) => Promise<void>
+  >(),
+}));
+
+vi.mock('../../services/port', () => ({ dataPort: seam }));
+
+const { default: EnhancedImport } = await import('../EnhancedImport');
+
+/**
+ * A parsed .mny file, invented. The importer is what reads a real one; this is
+ * only the payload the page routes, so it carries nothing that has to be true
+ * of Money's own format.
+ */
+function emptyMigration(): MsMoneyImportResult {
+  return {
+    accounts: [],
+    categories: [],
+    transactions: [],
+    transactionSplits: [],
+    summary: {
+      accounts: { total: 0, open: 0, closed: 0, investmentCashPairs: 0 },
+      categories: { subs: 0, details: 0, hidden: 0 },
+      transactions: { imported: 0, standalone: 0, transfers: 0, splitTransactions: 0, splitLines: 0 },
+      simplifications: [],
+    },
+  };
+}
+
+const renderPage = () => render(
+  <MemoryRouter initialEntries={['/enhanced-import']}>
+    <EnhancedImport />
+  </MemoryRouter>
+);
+
+/** Open the Money flow and execute it, exactly as the modal would. */
+const runTheMigration = async (): Promise<void> => {
+  fireEvent.click(screen.getByRole('button', { name: /Import from Microsoft Money/i }));
+  fireEvent.click(await screen.findByRole('button', { name: 'run the migration' }));
+};
+
+describe('EnhancedImport — where a Microsoft Money migration lands', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    run.result = emptyMigration();
+    run.reports = [];
+    run.outcome = null;
+    seam.importMsMoney.mockResolvedValue(undefined);
+    __setAppContextValue({ isUsingSupabase: false });
+  });
+
+  afterEach(() => {
+    __resetAppContextValue();
+  });
+
+  it('hands the parsed file to the seam once, and names no store to put it in', async () => {
+    // The page used to answer "which store?" for itself, out of a Postgres
+    // client and a boot-time flag. The absence of an owner in this call IS the
+    // change: two arguments, the file and a way to report progress.
+    renderPage();
+    await runTheMigration();
+
+    await waitFor(() => expect(seam.importMsMoney).toHaveBeenCalledTimes(1));
+    const [result, options] = seam.importMsMoney.mock.calls[0];
+    expect(result).toBe(run.result);
+    expect(typeof options?.onProgress).toBe('function');
+    expect(seam.importMsMoney.mock.calls[0]).toHaveLength(2);
+  });
+
+  it('does the same when nobody is signed in — the page no longer asks', async () => {
+    // The same call, under the condition the page used to branch on. Kept as a
+    // separate test rather than deleted with the branch: the point of the slice
+    // is that this makes no difference here, and a test that says so is how
+    // that stays true.
+    __setAppContextValue({ isUsingSupabase: true });
+
+    renderPage();
+    await runTheMigration();
+
+    await waitFor(() => expect(seam.importMsMoney).toHaveBeenCalledTimes(1));
+    expect(seam.importMsMoney.mock.calls[0][0]).toBe(run.result);
+  });
+
+  it('passes the importer’s progress straight back to the dialog', async () => {
+    seam.importMsMoney.mockImplementationOnce(async (
+      _result: unknown,
+      options?: { onProgress?: (p: ImportProgress) => void }
+    ) => {
+      options?.onProgress?.({ phase: 'transactions', fraction: 0.5, message: 'Writing your data…' });
+    });
+
+    renderPage();
+    await runTheMigration();
+
+    await waitFor(() => expect(run.reports).toHaveLength(1));
+    expect(run.reports[0]).toEqual({
+      phase: 'transactions',
+      fraction: 0.5,
+      message: 'Writing your data…',
+    });
+  });
+
+  it('reports the importer’s own failure rather than swallowing it', async () => {
+    // The modal renders whatever this rejects with, so the sentence has to
+    // survive the page untouched — a total migration that stopped part-way is
+    // the one time somebody needs the real message.
+    seam.importMsMoney.mockRejectedValueOnce(new Error('quota exceeded'));
+
+    renderPage();
+    await runTheMigration();
+
+    await waitFor(() => expect(run.outcome).not.toBeNull());
+    await expect(run.outcome).rejects.toThrow('quota exceeded');
+  });
+});

--- a/src/pages/settings/DataManagement.tsx
+++ b/src/pages/settings/DataManagement.tsx
@@ -3,12 +3,10 @@ import { lazyWithRecovery } from '../../utils/lazyWithRecovery';
 import { Link } from 'react-router-dom';
 import { useApp } from '../../contexts/AppContextSupabase';
 import { DownloadIcon, DeleteIcon, AlertCircleIcon, UploadIcon, DatabaseIcon, SearchIcon, XCircleIcon, RefreshCwIcon, type IconProps } from '../../components/icons';
-import type { WipeProgress } from '../../services/import/msMoney/msMoneyImport';
 import { LoadingState } from '../../components/loading/LoadingState';
 import { createScopedLogger } from '../../loggers/scopedLogger';
 import { parseBankingOpsUrlState, replaceBrowserSearch, withBankingOpsUrlState } from '../../utils/bankingOpsUrlState';
-import { DataService } from '../../services/api/dataService';
-import { supabase } from '../../lib/supabase';
+import { dataPort, type WipeProgress } from '../../services/port';
 
 const ArchiveManager = lazyWithRecovery(() => import('../../components/ArchiveManager'));
 
@@ -121,9 +119,15 @@ export default function DataManagementSettings() {
 
   // ACTUALLY delete everything. The store has to be wiped first — the context's
   // resetLoadedData only forgets the loaded copy, so on cloud the data all came
-  // back on the next load, which made the button a lie. The same proven wipe the
-  // MS Money migration uses runs first, then the loaded snapshot is dropped, then
-  // the app reloads to re-read the (empty) truth.
+  // back on the next load, which made the button a lie. The seam's wipe runs
+  // first, then the loaded snapshot is dropped, then the app reloads to re-read
+  // the (empty) truth.
+  //
+  // This page used to choose the engine itself, and held a Postgres client to do
+  // it with. It no longer knows there is more than one store: `dataPort` decides,
+  // and supplies whatever confirmation phrase the engine behind it demands. The
+  // dialog below is the confirmation (its button will not enable until DELETE is
+  // typed), which is where a phrase somebody types belongs.
   //
   // The local branch used to call wipeLocalData, which wrote to localStorage
   // while the app reads encrypted IndexedDB — so on a demo or local session this
@@ -140,23 +144,12 @@ export default function DataManagementSettings() {
     // nothing about a half-finished wipe.
     let sawProgress = false;
     try {
-      const databaseUserId = DataService.getUserIds().databaseId;
-      if (isUsingSupabase && supabase && databaseUserId) {
-        const { wipeCloudData } = await import('../../services/import/msMoney/msMoneyImport');
-        await wipeCloudData(supabase, databaseUserId, {
-          onProgress: (progress) => {
-            sawProgress = true;
-            setClearProgress(progress);
-          },
-        });
-      } else {
-        const { wipeLocalFinancialData, LOCAL_WIPE_CONFIRMATION } =
-          await import('../../services/localBackupService');
-        // The dialog behind this button is the confirmation (it will not enable
-        // until DELETE is typed), exactly as it is for the cloud branch above —
-        // wipeCloudData asks for no phrase either.
-        await wipeLocalFinancialData(LOCAL_WIPE_CONFIRMATION);
-      }
+      await dataPort.wipeAllFinancialData({
+        onProgress: (progress) => {
+          sawProgress = true;
+          setClearProgress(progress);
+        },
+      });
       await resetLoadedData();
       setShowDeleteConfirm(false);
       window.location.reload();

--- a/src/pages/settings/__tests__/DataManagement.deleteAll.test.tsx
+++ b/src/pages/settings/__tests__/DataManagement.deleteAll.test.tsx
@@ -3,7 +3,7 @@ import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import { ToastProvider } from '../../../contexts/ToastContext';
 import { __setAppContextValue, __resetAppContextValue } from '../../../test/mocks/AppContextSupabase';
-import type { WipeOptions, WipeProgress } from '../../../services/import/msMoney/msMoneyImport';
+import type { WipeProgress } from '../../../services/port';
 
 /**
  * "Delete All Data" as the user meets it.
@@ -14,18 +14,16 @@ import type { WipeOptions, WipeProgress } from '../../../services/import/msMoney
  * deleted. The user was left with a half-wiped login, an error about a
  * statement, and no idea that running it again would finish the job.
  *
- * So these cover the three things the dialog now has to do: SAY what it is
- * doing while it does it, REFUSE to be clicked mid-run, and on failure say the
- * one thing that helps — run it again.
+ * So these cover the three things the dialog has to do: SAY what it is doing
+ * while it does it, REFUSE to be clicked mid-run, and on failure say the one
+ * thing that helps — run it again.
+ *
+ * Every assertion below was written against the page while it still chose
+ * between two engines with a Postgres client of its own, and run green against
+ * it. Only the mock changed afterwards — from the engine to the one door the
+ * page now knocks on — which is what makes this suite evidence that the routing
+ * changed nothing the user can see.
  */
-
-/** Whoever is signed in, so the page takes the cloud branch. */
-vi.mock('../../../services/api/dataService', () => ({
-  DataService: { getUserIds: () => ({ clerkId: 'clerk_1', databaseId: 'db-user-1' }) },
-}));
-
-/** A configured cloud, so `isUsingSupabase && supabase && databaseUserId` holds. */
-vi.mock('../../../lib/supabase', () => ({ supabase: { from: () => ({}) } }));
 
 /** The wipe itself is covered in wipeCloudData.test; here it is a script. */
 const wipeScript: {
@@ -36,16 +34,18 @@ const wipeScript: {
   hold: Promise<void> | null;
 } = { steps: [], failWith: null, calls: 0, hold: null };
 
-vi.mock('../../../services/import/msMoney/msMoneyImport', () => ({
-  wipeCloudData: async (_client: unknown, _userId: string, options: WipeOptions = {}) => {
-    wipeScript.calls += 1;
-    for (const step of wipeScript.steps) {
-      options.onProgress?.(step);
-      // Let React paint between steps, the way a real round trip does.
-      await Promise.resolve();
-    }
-    if (wipeScript.hold !== null) await wipeScript.hold;
-    if (wipeScript.failWith !== null) throw new Error(wipeScript.failWith);
+vi.mock('../../../services/port', () => ({
+  dataPort: {
+    wipeAllFinancialData: async (options: { onProgress?: (p: WipeProgress) => void } = {}) => {
+      wipeScript.calls += 1;
+      for (const step of wipeScript.steps) {
+        options.onProgress?.(step);
+        // Let React paint between steps, the way a real round trip does.
+        await Promise.resolve();
+      }
+      if (wipeScript.hold !== null) await wipeScript.hold;
+      if (wipeScript.failWith !== null) throw new Error(wipeScript.failWith);
+    },
   },
 }));
 
@@ -74,8 +74,8 @@ describe('Delete All Data — while it runs', () => {
     wipeScript.failWith = null;
     wipeScript.calls = 0;
     wipeScript.hold = null;
-    // Signed in with a working cloud, so the page takes the branch that calls
-    // wipeCloudData rather than the browser-local one.
+    // Signed in with a working cloud. The page no longer picks an engine — the
+    // seam does — but this is still what decides the copy on the cards above.
     __setAppContextValue({ isUsingSupabase: true });
   });
 
@@ -138,8 +138,8 @@ describe('Delete All Data — when it stops part-way', () => {
     wipeScript.failWith = null;
     wipeScript.calls = 0;
     wipeScript.hold = null;
-    // Signed in with a working cloud, so the page takes the branch that calls
-    // wipeCloudData rather than the browser-local one.
+    // Signed in with a working cloud. The page no longer picks an engine — the
+    // seam does — but this is still what decides the copy on the cards above.
     __setAppContextValue({ isUsingSupabase: true });
   });
 

--- a/src/services/__tests__/dataService.test.ts
+++ b/src/services/__tests__/dataService.test.ts
@@ -5,6 +5,7 @@ import { TransactionService } from '../api/transactionService';
 import { createSimpleAccountService } from '../api/simpleAccountService';
 import { registerSupabaseTokenGetter } from '../../lib/supabaseToken';
 import { buildBackupBundle } from '../backupService';
+import { LOCAL_WIPE_CONFIRMATION } from '../localBackupService';
 import type { Account, Budget, Category, Goal, Transaction, TransactionSplit } from '../../types';
 import { STORAGE_KEYS } from '../storageAdapter';
 
@@ -2818,13 +2819,15 @@ describe('DataService backup and restore (which store the file comes from, and g
   const cloudEngine = () => ({
     userFinancialDataIsEmpty: vi.fn(async () => true),
     collectBackupBundle: vi.fn(async () => bundle()),
-    restoreBackupBundle: vi.fn(async () => cloudOutcome)
+    restoreBackupBundle: vi.fn(async () => cloudOutcome),
+    wipeUserFinancialData: vi.fn(async () => ({ accounts: 3, transactions: 51_000 }))
   });
 
   const deviceEngine = () => ({
     localFinancialDataIsEmpty: vi.fn(async () => true),
     collectLocalBackupBundle: vi.fn(async () => bundle()),
-    restoreLocalBackupBundle: vi.fn(async () => deviceOutcome)
+    restoreLocalBackupBundle: vi.fn(async () => deviceOutcome),
+    wipeLocalFinancialData: vi.fn(async () => ({ accounts: 3, transactions: 12 }))
   });
 
   const signedIn = {
@@ -3000,5 +3003,312 @@ describe('DataService backup and restore (which store the file comes from, and g
       expect(cloud.restoreBackupBundle).not.toHaveBeenCalled();
       expect(device.restoreLocalBackupBundle).not.toHaveBeenCalled();
     });
+  });
+});
+
+describe('DataService.wipeAllFinancialData (which store gets erased, and how much of it)', () => {
+  const logger = { error: vi.fn(), warn: vi.fn(), log: vi.fn() };
+
+  const cloudBackup = () => ({
+    userFinancialDataIsEmpty: vi.fn(async () => true),
+    collectBackupBundle: vi.fn(),
+    restoreBackupBundle: vi.fn(),
+    wipeUserFinancialData: vi.fn(async () => ({ accounts: 0, transactions: 0 }))
+  });
+
+  const deviceBackup = () => ({
+    localFinancialDataIsEmpty: vi.fn(async () => true),
+    collectLocalBackupBundle: vi.fn(),
+    restoreLocalBackupBundle: vi.fn(),
+    wipeLocalFinancialData: vi.fn(async () => ({ accounts: 3, transactions: 12 }))
+  });
+
+  const moneyEngine = () => ({
+    wipeCloudData: vi.fn(async () => {}),
+    importToCloud: vi.fn(async () => {}),
+    importToLocalStorage: vi.fn(async () => {})
+  });
+
+  const signedIn = {
+    ensureUserExists: vi.fn(),
+    getCurrentDatabaseUserId: vi.fn(() => 'db-user-1' as string | null),
+    getCurrentUserIds: vi.fn(() => ({ clerkId: 'clerk-1', databaseId: 'db-user-1' }))
+  };
+  const signedOut = {
+    ensureUserExists: vi.fn(),
+    getCurrentDatabaseUserId: vi.fn(() => null),
+    getCurrentUserIds: vi.fn(() => ({ clerkId: null, databaseId: null }))
+  };
+
+  /** A client the wipe is pointed at. Never called here — the engines are doubles. */
+  const client = { from: vi.fn() };
+
+  const service = (options: {
+    signedIn: boolean;
+    cloud: ReturnType<typeof cloudBackup>;
+    device: ReturnType<typeof deviceBackup>;
+    money: ReturnType<typeof moneyEngine>;
+    storage?: ReturnType<typeof createStorage>;
+  }) => createDataService({
+    isSupabaseConfigured: () => options.signedIn,
+    hasCloudSession: () => options.signedIn,
+    userIdService: options.signedIn ? signedIn : signedOut,
+    storageAdapter: options.storage ?? createStorage(),
+    logger,
+    uuid: () => 'generated-1',
+    cloudBackup: options.cloud,
+    deviceBackup: options.device,
+    msMoneyEngine: options.money,
+    cloudClient: client
+  });
+
+  it('signed in: erases in chunks FIRST, then sweeps the tables the chunks cannot reach', async () => {
+    // THE ORDER IS THE TEST. The chunked pass is the one with the rows in it,
+    // and it is chunked because one `DELETE FROM transactions` over 51,000 rows
+    // is cancelled by the database's own statement timeout. The RPC's deletes
+    // are one statement per table — exactly that shape — so it has to run when
+    // there is nothing large left to do. Reversed, this is the original bug.
+    //
+    // And it has to run at all: the chunked pass leaves the four tables keyed
+    // only by the user (dismissed suggestions, dashboard layouts, widget
+    // preferences, notifications), nothing cascades them away, and a backup
+    // carries every one of them — so a restore onto the survivors collides
+    // part-way through, in front of somebody who has just erased their login.
+    const order: string[] = [];
+    const cloud = cloudBackup();
+    const device = deviceBackup();
+    const money = moneyEngine();
+    money.wipeCloudData.mockImplementation(async () => { order.push('chunked'); });
+    cloud.wipeUserFinancialData.mockImplementation(async () => {
+      order.push('sweep');
+      return { accounts: 0, transactions: 0 };
+    });
+
+    await service({ signedIn: true, cloud, device, money }).wipeAllFinancialData();
+
+    expect(order).toEqual(['chunked', 'sweep']);
+    expect(device.wipeLocalFinancialData).not.toHaveBeenCalled();
+  });
+
+  it('points the chunked pass at the authenticated client and the owner it resolved itself', async () => {
+    const cloud = cloudBackup();
+    const device = deviceBackup();
+    const money = moneyEngine();
+    const onProgress = vi.fn();
+
+    await service({ signedIn: true, cloud, device, money }).wipeAllFinancialData({ onProgress });
+
+    expect(money.wipeCloudData).toHaveBeenCalledTimes(1);
+    expect(money.wipeCloudData).toHaveBeenCalledWith(client, 'db-user-1', { onProgress });
+    // The phrase is the implementation's, not the caller's: the screen holds
+    // the confirmation and will not enable its button without it.
+    expect(cloud.wipeUserFinancialData).toHaveBeenCalledWith('DELETE EVERYTHING', 'db-user-1');
+  });
+
+  it('says the phrase the database and the device engine both demand — the same one', async () => {
+    // Three copies of one string live in this codebase: the literal on this
+    // class, the SQL function's own check, and LOCAL_WIPE_CONFIRMATION. That is
+    // safe ONLY because both of the others CHECK it, so a drift refuses every
+    // wipe rather than quietly weakening one. Proved here against the constant
+    // the device engine exports, on both branches, rather than assumed.
+    const onDevice = deviceBackup();
+    const onLogin = cloudBackup();
+
+    await service({ signedIn: false, cloud: cloudBackup(), device: onDevice, money: moneyEngine() })
+      .wipeAllFinancialData();
+    await service({ signedIn: true, cloud: onLogin, device: deviceBackup(), money: moneyEngine() })
+      .wipeAllFinancialData();
+
+    expect(onDevice.wipeLocalFinancialData.mock.calls[0][0]).toBe(LOCAL_WIPE_CONFIRMATION);
+    expect(onLogin.wipeUserFinancialData.mock.calls[0][0]).toBe(LOCAL_WIPE_CONFIRMATION);
+  });
+
+  it('on a device: erases through this service\'s own store, and asks the cloud nothing', async () => {
+    // The store matters as much as the route, for the reason the bulk import
+    // sets out: the engine defaults to the app's real adapter when handed
+    // nothing, so a demo session told to use a different store must hand that
+    // store over or it erases the wrong one.
+    const cloud = cloudBackup();
+    const device = deviceBackup();
+    const money = moneyEngine();
+    const storage = createStorage();
+
+    await service({ signedIn: false, cloud, device, money, storage }).wipeAllFinancialData();
+
+    expect(money.wipeCloudData).not.toHaveBeenCalled();
+    expect(cloud.wipeUserFinancialData).not.toHaveBeenCalled();
+    expect(device.wipeLocalFinancialData).toHaveBeenCalledTimes(1);
+    const [, options] = device.wipeLocalFinancialData.mock.calls[0];
+    await options?.store?.setMany?.([{ key: 'k', value: [] }]);
+    expect(storage.setMany).toHaveBeenCalledWith([{ key: 'k', value: [] }]);
+  });
+
+  it('lets the failure through with its own sentence, so "run it again" can be offered', async () => {
+    // The dialog prints this verbatim and adds the recovery beside it. A route
+    // that wrapped it would replace the database's own words with its own.
+    const cloud = cloudBackup();
+    const device = deviceBackup();
+    const money = moneyEngine();
+    money.wipeCloudData.mockRejectedValueOnce(
+      new Error('Failed while clearing transactions: canceling statement due to statement timeout')
+    );
+
+    expect(await refusalMessage(service({ signedIn: true, cloud, device, money }).wipeAllFinancialData()))
+      .toBe('Failed while clearing transactions: canceling statement due to statement timeout');
+    // And it stopped: the sweep must not run over a half-finished chunked pass
+    // and report success.
+    expect(cloud.wipeUserFinancialData).not.toHaveBeenCalled();
+  });
+
+  it('refuses while a signed-in session is still resolving, rather than erasing the browser', async () => {
+    // Before the seam, this state fell through to the browser's store: the
+    // button reported success, the login was untouched, and the person was
+    // told their data was gone when it was not.
+    const cloud = cloudBackup();
+    const device = deviceBackup();
+    const money = moneyEngine();
+    const pending = createDataService({
+      isSupabaseConfigured: () => true,
+      hasCloudSession: () => true,
+      userIdService: pendingUserIdService(),
+      storageAdapter: createStorage(),
+      logger,
+      cloudBackup: cloud,
+      deviceBackup: device,
+      msMoneyEngine: money,
+      cloudClient: client
+    });
+
+    expect(await refusalMessage(pending.wipeAllFinancialData())).toBe(
+      'This session has no database identity yet, so there is nothing here that can safely be erased. Reload the page and try again.'
+    );
+    expect(money.wipeCloudData).not.toHaveBeenCalled();
+    expect(cloud.wipeUserFinancialData).not.toHaveBeenCalled();
+    expect(device.wipeLocalFinancialData).not.toHaveBeenCalled();
+  });
+});
+
+describe('DataService.importMsMoney (where a whole .mny file lands)', () => {
+  const logger = { error: vi.fn(), warn: vi.fn(), log: vi.fn() };
+
+  /**
+   * A parsed .mny file, invented. Nothing here is read by the routing — it is
+   * handed straight to whichever writer answers — but the real shape keeps the
+   * test honest about what crosses the seam.
+   */
+  const migration = () => ({
+    accounts: [],
+    categories: [],
+    transactions: [],
+    transactionSplits: [],
+    summary: {
+      accounts: { total: 0, open: 0, closed: 0, investmentCashPairs: 0 },
+      categories: { subs: 0, details: 0, hidden: 0 },
+      transactions: { imported: 0, standalone: 0, transfers: 0, splitTransactions: 0, splitLines: 0 },
+      simplifications: []
+    }
+  });
+
+  const moneyEngine = () => ({
+    wipeCloudData: vi.fn(async () => {}),
+    importToCloud: vi.fn(async () => {}),
+    importToLocalStorage: vi.fn(async () => {})
+  });
+
+  const signedIn = {
+    ensureUserExists: vi.fn(),
+    getCurrentDatabaseUserId: vi.fn(() => 'db-user-1' as string | null),
+    getCurrentUserIds: vi.fn(() => ({ clerkId: 'clerk-1', databaseId: 'db-user-1' }))
+  };
+  const signedOut = {
+    ensureUserExists: vi.fn(),
+    getCurrentDatabaseUserId: vi.fn(() => null),
+    getCurrentUserIds: vi.fn(() => ({ clerkId: null, databaseId: null }))
+  };
+
+  const client = { from: vi.fn() };
+
+  const service = (options: {
+    signedIn: boolean;
+    money: ReturnType<typeof moneyEngine>;
+    storage?: ReturnType<typeof createStorage>;
+  }) => createDataService({
+    isSupabaseConfigured: () => options.signedIn,
+    hasCloudSession: () => options.signedIn,
+    userIdService: options.signedIn ? signedIn : signedOut,
+    storageAdapter: options.storage ?? createStorage(),
+    logger,
+    uuid: () => 'generated-1',
+    msMoneyEngine: options.money,
+    cloudClient: client
+  });
+
+  it('signed in: writes the file into the login, with the owner it resolved itself', async () => {
+    const money = moneyEngine();
+    const file = migration();
+    const onProgress = vi.fn();
+
+    await service({ signedIn: true, money }).importMsMoney(file, { onProgress });
+
+    expect(money.importToLocalStorage).not.toHaveBeenCalled();
+    expect(money.importToCloud).toHaveBeenCalledTimes(1);
+    const [given, handedClient, userId, newId, options] = money.importToCloud.mock.calls[0];
+    expect(given).toBe(file);
+    expect(handedClient).toBe(client);
+    expect(userId).toBe('db-user-1');
+    // An id MAKER, and this service's own: the plan mints one per row, and a
+    // test that cannot hold them still cannot assert on a plan.
+    expect(newId()).toBe('generated-1');
+    expect(options).toEqual({ onProgress });
+  });
+
+  it('signed out: writes it into this browser, through this service\'s own store', async () => {
+    const money = moneyEngine();
+    const storage = createStorage();
+    const file = migration();
+
+    await service({ signedIn: false, money, storage }).importMsMoney(file);
+
+    expect(money.importToCloud).not.toHaveBeenCalled();
+    expect(money.importToLocalStorage).toHaveBeenCalledTimes(1);
+    const [given, keys, options] = money.importToLocalStorage.mock.calls[0];
+    expect(given).toBe(file);
+    // The keys the app's own readers look under. The version of this that
+    // wrote its own key names reported success and changed nothing anybody saw.
+    expect(keys).toBe(STORAGE_KEYS);
+    await options?.store?.setMany?.([{ key: 'k', value: [] }]);
+    expect(storage.setMany).toHaveBeenCalledWith([{ key: 'k', value: [] }]);
+  });
+
+  it('refuses while a signed-in session is still resolving, rather than migrating into the browser', async () => {
+    // The worst version of the wrong-store bug in the whole app: thirty years
+    // of somebody's history written where their signed-in app will never read
+    // it again, the page reloading, and nothing of it there. It said it worked.
+    const money = moneyEngine();
+    const pending = createDataService({
+      isSupabaseConfigured: () => true,
+      hasCloudSession: () => true,
+      userIdService: pendingUserIdService(),
+      storageAdapter: createStorage(),
+      logger,
+      msMoneyEngine: money,
+      cloudClient: client
+    });
+
+    expect(await refusalMessage(pending.importMsMoney(migration()))).toBe(
+      'This session has no database identity yet, so a migration cannot be written to your login. Reload the page and try again.'
+    );
+    expect(money.importToCloud).not.toHaveBeenCalled();
+    expect(money.importToLocalStorage).not.toHaveBeenCalled();
+  });
+
+  it('lets the importer\'s own failure through, because the dialog renders it', async () => {
+    const money = moneyEngine();
+    money.importToCloud.mockRejectedValueOnce(
+      new Error('Import failed while writing transactions: duplicate key value violates unique constraint')
+    );
+
+    expect(await refusalMessage(service({ signedIn: true, money }).importMsMoney(migration())))
+      .toBe('Import failed while writing transactions: duplicate key value violates unique constraint');
   });
 });

--- a/src/services/api/dataService.ts
+++ b/src/services/api/dataService.ts
@@ -5,12 +5,18 @@
  * and handles the switch between Supabase (cloud) and localStorage (fallback)
  */
 
+import type { SupabaseClient } from '@supabase/supabase-js';
 import { UserService } from './userService';
 import { AccountService } from './accountService';
 import { TransactionService, type TransactionLoadResult } from './transactionService';
 import { PlanningService } from './planningService';
 import { SuggestionDismissalService } from './suggestionDismissalService';
-import { isSupabaseConfigured } from './supabaseClient';
+// The client itself, not only the "is it configured?" question. The chunked
+// wipe and the Money migration are handed a client rather than reaching for
+// one, and this module is already in this file's chunk — so naming the export
+// beside the checker costs nothing and is what lets the two React pages that
+// used to hold a Postgres client stop holding one.
+import { isSupabaseConfigured, supabase } from './supabaseClient';
 import { getSupabaseAccessToken, hasSupabaseTokenGetter } from '../../lib/supabaseToken';
 import { storageAdapter, STORAGE_KEYS } from '../storageAdapter';
 import { userIdService } from '../userIdService';
@@ -32,8 +38,11 @@ import type {
   BulkImportResult,
   DataPort,
   ExportProgress,
+  ImportProgress,
   ImportSourceKind,
-  RestoreProgress
+  MsMoneyImportResult,
+  RestoreProgress,
+  WipeProgress
 } from '../port/dataPort';
 // Type-only, so the bulk importers themselves stay out of the boot chunk —
 // the values are fetched on demand (see `cloudBulkImportClient`).
@@ -48,6 +57,11 @@ import type {
 // user on first paint for a feature most of them press once a year.
 import type * as CloudBackupService from '../backupService';
 import type * as DeviceBackupService from '../localBackupService';
+// Type-only for the third time, and for the strongest version of the reason:
+// this module carries the whole Microsoft Money migration — the planner, the
+// two-pass transfer linking, the chunked writer — and exactly the people who
+// press Import once ever should be the people who download it.
+import type * as MsMoneyImportService from '../import/msMoney/msMoneyImport';
 import type { Account, AccountUpdate, Transaction, TransactionSplit, TransactionSplitInput, SplitWriteResult, Budget, Goal, Category, CategoryMergeResult, DismissalKind, SuggestionDismissal } from '../../types';
 
  type Logger = Pick<Console, 'log' | 'warn' | 'error'>;
@@ -119,9 +133,22 @@ type BulkImportClientLike = Pick<TransactionImportService,
  * editing this file.
  */
 type CloudBackupLike = Pick<typeof CloudBackupService,
-  'userFinancialDataIsEmpty' | 'collectBackupBundle' | 'restoreBackupBundle'>;
+  'userFinancialDataIsEmpty' | 'collectBackupBundle' | 'restoreBackupBundle'
+  | 'wipeUserFinancialData'>;
 type DeviceBackupLike = Pick<typeof DeviceBackupService,
-  'localFinancialDataIsEmpty' | 'collectLocalBackupBundle' | 'restoreLocalBackupBundle'>;
+  'localFinancialDataIsEmpty' | 'collectLocalBackupBundle' | 'restoreLocalBackupBundle'
+  | 'wipeLocalFinancialData'>;
+/**
+ * The Microsoft Money engine, narrowed to the three entry points the seam
+ * routes to: the chunked wipe, the cloud writer and the device writer.
+ *
+ * Derived from the real module for the reason the backup engines above are —
+ * the FORMAT and the write path stay theirs. This class decides which one
+ * answers; it does not know what a .mny file contains, and adding a phase to
+ * the import must never mean editing this file.
+ */
+type MsMoneyEngineLike = Pick<typeof MsMoneyImportService,
+  'wipeCloudData' | 'importToCloud' | 'importToLocalStorage'>;
 /** The device-side atomic import, in the shape the seam calls it. */
 type LocalBulkImporter = (
   accountId: string,
@@ -164,6 +191,19 @@ export interface DataServiceOptions {
   cloudBackup?: CloudBackupLike;
   deviceBackup?: DeviceBackupLike;
   /**
+   * The Microsoft Money engine. Absent means "fetch the real one when a
+   * migration runs", exactly as the four above — and for the sharpest version
+   * of the reason: a total migration replaces every row a person has.
+   */
+  msMoneyEngine?: MsMoneyEngineLike;
+  /**
+   * The authenticated Postgres client the chunked wipe and the cloud migration
+   * are handed. Defaults to the app's own. Injectable so a test can watch what
+   * a wipe is pointed at without a network — never so a caller can choose a
+   * different login.
+   */
+  cloudClient?: SupabaseClient | null;
+  /**
    * How the cloud import authenticates. Defaults to the registry AuthContext
    * fills with the signed-in session's Clerk getToken — the same token every
    * other cloud call on this class travels with.
@@ -188,6 +228,8 @@ class DataServiceImpl implements DataPort {
   private readonly injectedLocalBulkImport: LocalBulkImporter | null;
   private readonly injectedCloudBackup: CloudBackupLike | null;
   private readonly injectedDeviceBackup: DeviceBackupLike | null;
+  private readonly injectedMsMoneyEngine: MsMoneyEngineLike | null;
+  private readonly cloudClient: SupabaseClient | null;
   private readonly authTokenProvider: AuthTokenProvider;
 
   constructor(options: DataServiceOptions = {}) {
@@ -219,6 +261,8 @@ class DataServiceImpl implements DataPort {
     this.injectedLocalBulkImport = options.localBulkImport ?? null;
     this.injectedCloudBackup = options.cloudBackup ?? null;
     this.injectedDeviceBackup = options.deviceBackup ?? null;
+    this.injectedMsMoneyEngine = options.msMoneyEngine ?? null;
+    this.cloudClient = options.cloudClient !== undefined ? options.cloudClient : supabase;
     this.authTokenProvider = options.authTokenProvider ?? getSupabaseAccessToken;
   }
 
@@ -919,6 +963,164 @@ class DataServiceImpl implements DataPort {
       // operation still — the engine's own default is crypto.randomUUID, which
       // is exactly what this resolves to in the app.
       newId: () => this.generateId()
+    });
+  }
+
+  // ── Erasing it, and replacing it ──────────────────────────────────────────
+  //
+  // ROUTING, AND ONLY ROUTING, again. The chunked wipe and the Money migration
+  // are unchanged, still covered by their own suites, and still the only code
+  // that knows how either job is done. What changed is who chooses between the
+  // engines: it was the Danger Zone page and the Import page, each holding a
+  // Postgres client of its own and each reading `isUsingSupabase` off the
+  // context to decide — a React page importing a database client to erase
+  // somebody's ledger with is the seam's rule 1 broken in the two places where
+  // getting it wrong costs the most.
+
+  /** The Microsoft Money engine, fetched the first time a wipe or import runs. */
+  private async msMoneyEngine(): Promise<MsMoneyEngineLike> {
+    if (this.injectedMsMoneyEngine) return this.injectedMsMoneyEngine;
+    return import('../import/msMoney/msMoneyImport');
+  }
+
+  /**
+   * The authenticated client the cloud engines are handed.
+   *
+   * Unreachable in the app while `isSupabaseReady()` is true — that predicate
+   * IS `supabase !== null` plus a resolved owner — so this refusal exists for
+   * the one case a type cannot rule out: a test that injected `cloudClient:
+   * null` and a configured checker. Refusing names the contradiction; carrying
+   * on would ask an engine to erase a login through a client that is not there.
+   */
+  private requireCloudClient(): SupabaseClient {
+    if (!this.cloudClient) {
+      throw new Error(
+        'There is no connection to your account right now, so nothing was changed. Reload the page and try again.'
+      );
+    }
+    return this.cloudClient;
+  }
+
+  /**
+   * The phrase both destructive engines demand before they will do anything.
+   *
+   * Supplied by the implementation rather than carried across the seam, because
+   * the CONFIRMATION is the screen's job and it already does it: the Danger Zone
+   * will not enable its button until DELETE is typed, and the restore dialog
+   * will not enable its own until this exact phrase is. Neither ever wiped
+   * implicitly, and neither starts now.
+   *
+   * Stated here as a literal, which makes it the third copy — the SQL function's
+   * own check and `LOCAL_WIPE_CONFIRMATION` are the other two. That is safe
+   * precisely because both of those CHECK it: a copy that drifted would refuse
+   * every wipe on the first run rather than weaken one, and the contract suite
+   * asks for a wipe that works.
+   */
+  private static readonly WIPE_CONFIRMATION = 'DELETE EVERYTHING';
+
+  /**
+   * Erase everything this store holds.
+   *
+   * ── WHY THE CLOUD BRANCH IS TWO CALLS ───────────────────────────────────
+   *
+   * Not belt and braces — they empty different things, and neither on its own
+   * satisfies what the seam promises.
+   *
+   * The CHUNKED pass is the one with the rows in it. It deletes in pieces small
+   * enough that no single statement can be cancelled by the database's own
+   * timeout, which is the failure it exists because of: one `DELETE FROM
+   * transactions` over 51,000 rows died half-way, after the transfer links had
+   * been nulled and the splits deleted, and left a login in a state nothing in
+   * the app produces. It also reports as it goes, which is what stops a wipe
+   * that legitimately takes minutes from reading as one that has hung.
+   *
+   * The RPC is the one with the REST of the tables in it — investments, and the
+   * four keyed only by the user (dismissed suggestions, dashboard layouts,
+   * widget preferences, notifications). Nothing cascades those away, so the
+   * chunked pass leaves them, and a backup carries every one of them. Restoring
+   * a file onto the survivors collides with `widget_preferences_user_id_widget_type_key`
+   * part-way through, in front of somebody who has just deliberately erased
+   * their own login. That is the failure a restore must never have, so "wiped"
+   * has to mean every table the file carries. It also writes the per-row audit
+   * for anything still standing.
+   *
+   * THE ORDER IS LOAD-BEARING. Chunked first: the RPC's own deletes are one
+   * statement per table, which is exactly what timed out, so by the time it runs
+   * there must be nothing large left for it to do. It leaves `user_preferences`
+   * alone in both directions — erasing a ledger is not a request to forget that
+   * somebody prefers twelve-month charts.
+   *
+   * On a device it is one write, so there is no fraction to report and none is
+   * invented.
+   */
+  async wipeAllFinancialData(options: {
+    onProgress?: (progress: WipeProgress) => void;
+  } = {}): Promise<void> {
+    const userId = this.userIdService.getCurrentDatabaseUserId();
+    if (userId && this.supabaseChecker()) {
+      const client = this.requireCloudClient();
+      const { wipeCloudData } = await this.msMoneyEngine();
+      await wipeCloudData(client, userId, { onProgress: options.onProgress });
+      const { wipeUserFinancialData } = await this.cloudBackupEngine();
+      await wipeUserFinancialData(DataServiceImpl.WIPE_CONFIRMATION, userId);
+      return;
+    }
+
+    this.guardBackupIdentity(
+      'This session has no database identity yet, so there is nothing here that can safely be erased. Reload the page and try again.'
+    );
+    const { wipeLocalFinancialData } = await this.deviceBackupEngine();
+    await wipeLocalFinancialData(DataServiceImpl.WIPE_CONFIRMATION, {
+      store: this.requireDeviceBackupStore()
+    });
+  }
+
+  /**
+   * Replace everything with a parsed Microsoft Money file.
+   *
+   * The wipe in front of it is the importer's own — it reports through the same
+   * progress channel as the rest of the migration, and reads the surviving state
+   * afterwards so that a partial wipe cannot become a double import. That is why
+   * this does not call `wipeAllFinancialData` first: the migration is one
+   * operation with a wipe inside it, not two operations in a row, and taking the
+   * wipe out here would leave the plan built against the wrong picture.
+   *
+   * A PENDING SESSION IS REFUSED, and this is the one place that refusal is
+   * unarguable. Before this, a signed-in session whose database id had not
+   * resolved yet fell through to the browser's store — so a person's whole
+   * financial history was written where their signed-in app will never read it
+   * again, the page reloaded, and everything they had migrated was simply not
+   * there. The screen said it worked.
+   */
+  async importMsMoney(
+    result: MsMoneyImportResult,
+    options: { onProgress?: (progress: ImportProgress) => void } = {}
+  ): Promise<void> {
+    const userId = this.userIdService.getCurrentDatabaseUserId();
+    const engine = await this.msMoneyEngine();
+    if (userId && this.supabaseChecker()) {
+      await engine.importToCloud(
+        result,
+        this.requireCloudClient(),
+        userId,
+        // The engine's own default is crypto.randomUUID, which is what this
+        // resolves to in the app; handing it this service's generator is what
+        // lets a test hold a whole migration still.
+        () => this.generateId(),
+        { onProgress: options.onProgress }
+      );
+      return;
+    }
+
+    this.guardBackupIdentity(
+      'This session has no database identity yet, so a migration cannot be written to your login. Reload the page and try again.'
+    );
+    await engine.importToLocalStorage(result, STORAGE_KEYS, {
+      onProgress: options.onProgress,
+      // Passed explicitly for the reason `localImportStore` sets out: the
+      // engine defaults to the app's real adapter when handed nothing, which is
+      // right in production and wrong in a test that injected a store.
+      store: this.requireDeviceBackupStore()
     });
   }
 
@@ -2323,6 +2525,23 @@ class DataServiceImpl implements DataPort {
     return this.isSupabaseReady();
   }
 
+  /**
+   * NEVER JOINS THE SEAM, and is down to its last consumer.
+   *
+   * Identity is internal to an implementation (rule 1 of the port), so this is
+   * the opposite of what the seam promises — it exists only because two screens
+   * still choose their own WORDS from it. The data operations that used to
+   * branch on it are all gone: the export, the emptiness check, the restore,
+   * the wipe and the Money migration each resolve their own owner now.
+   *
+   * What is left is one file. RestoreBackupModal reads it to decide whether the
+   * dialog says "login" or "device", whether a failed restore warns about a
+   * partly-populated store, and whether a signed-in session is still connecting
+   * and must be blocked from starting. All three are capability questions, and
+   * they leave with `capabilities()` — at which point this method and its static
+   * twin are deleted, and the fact that nothing calls them IS the proof the
+   * seam closed.
+   */
   getUserIds(): { clerkId: string | null; databaseId: string | null } {
     return this.userIdService.getCurrentUserIds();
   }
@@ -2425,6 +2644,19 @@ export class DataService {
     options?: { onProgress?: (progress: RestoreProgress) => void }
   ): Promise<BackupRestoreOutcome> {
     return this.service.restoreBackup(bundle, options);
+  }
+
+  static wipeAllFinancialData(
+    options?: { onProgress?: (progress: WipeProgress) => void }
+  ): Promise<void> {
+    return this.service.wipeAllFinancialData(options);
+  }
+
+  static importMsMoney(
+    result: MsMoneyImportResult,
+    options?: { onProgress?: (progress: ImportProgress) => void }
+  ): Promise<void> {
+    return this.service.importMsMoney(result, options);
   }
 
   static archiveTransactionsBefore(accountId: string, cutoff: Date): Promise<number> {

--- a/src/services/port/__tests__/contract.ts
+++ b/src/services/port/__tests__/contract.ts
@@ -186,6 +186,9 @@ export const DATA_PORT_OPERATIONS: readonly (keyof DataPort)[] = [
   'financialDataIsEmpty',
   'collectBackup',
   'restoreBackup',
+  'wipeAllFinancialData',
+  // Migration
+  'importMsMoney',
   // Lifecycle
   'initialize',
   'prepareCategories',
@@ -2269,7 +2272,18 @@ export function runDataPortContract(name: string, harness: DataPortContractHarne
     // the ledger it came from, and anything the store cannot keep comes back
     // named instead of vanishing.
     describe('backup and restore', () => {
-      /** A ledger with something in every table this suite can seed. */
+      /**
+       * A ledger with something in every table this suite can seed.
+       *
+       * The SPLIT and the DISMISSAL are not padding. They are the two tables a
+       * partial job is most likely to miss and least likely to be noticed
+       * missing: a split hangs off a transaction rather than off the store, and
+       * a dismissal hangs off nothing at all — no account to cascade from, no
+       * screen that would look empty if it survived. Both are carried by a
+       * backup file, so both decide whether "wiped" is true enough for the
+       * restore that follows. A fixture without them lets an engine that clears
+       * the obvious five pass every assertion below.
+       */
       const aWholeLedger = (): PortFixture => ({
         accounts: threeAccounts(),
         categories: [aCategory('cat-everyday', 'Everyday spending')],
@@ -2280,10 +2294,29 @@ export function runDataPortContract(name: string, harness: DataPortContractHarne
             amount: 500,
             description: 'Payday',
             type: 'income'
+          }),
+          aTransaction('txn-3', {
+            amount: -30,
+            description: 'Weekly shop',
+            isSplit: true,
+            category: ''
           })
         ],
+        splits: [
+          { id: 'line-1', transactionId: 'txn-3', category: 'cat-everyday', amount: -10, sortOrder: 1 },
+          { id: 'line-2', transactionId: 'txn-3', category: 'cat-bills', amount: -20, sortOrder: 2 }
+        ],
         budgets: [aBudget('budget-1', 'cat-everyday', 200)],
-        goals: [aGoal('goal-1', 'New boiler', 1500)]
+        goals: [aGoal('goal-1', 'New boiler', 1500)],
+        dismissals: [
+          {
+            id: 'dismissal-1',
+            kind: 'duplicate',
+            subjectKey: 'corner-shop-10-10',
+            subjectIds: ['txn-1'],
+            dismissedAt: AT('2025-01-05')
+          }
+        ]
       });
 
       /**
@@ -2311,6 +2344,83 @@ export function runDataPortContract(name: string, harness: DataPortContractHarne
 
         const holding = await harness.create({ accounts: threeAccounts() });
         expect(await holding.port.financialDataIsEmpty()).toBe(false);
+      });
+
+      it('empties the store, and then agrees that it is empty', async () => {
+        // The two operations have to answer the same question about one store.
+        // A wipe that emptied what it felt like and an emptiness check that
+        // asked about something else would give the restore dialog two
+        // different answers about the same login — and the one it acts on is
+        // the one that unlocks the button.
+        const { port, read } = await harness.create(aWholeLedger());
+        expect(await port.financialDataIsEmpty()).toBe(false);
+
+        await port.wipeAllFinancialData();
+
+        expect(await port.financialDataIsEmpty()).toBe(true);
+        const after = await read();
+        expect(after.accounts).toEqual([]);
+        expect(after.transactions).toEqual([]);
+        expect(after.categories).toEqual([]);
+        expect(after.budgets).toEqual([]);
+        expect(after.goals).toEqual([]);
+        // The two that hang off something other than the store, and are
+        // therefore the two an incomplete wipe leaves behind in silence.
+        expect(after.splits).toEqual([]);
+        expect(after.dismissals).toEqual([]);
+      });
+
+      it('is safe to run twice, because that is the recovery when it stops', async () => {
+        // Idempotence is not tidiness here, it is the whole repair. An engine
+        // that erases in pieces cannot avoid stopping part-way (one statement
+        // over 51,000 rows is cancelled by the database's own timeout, which is
+        // why it is in pieces at all), so it makes that state SAFE instead:
+        // deleting rows that have already gone is a no-op, and the dialog's
+        // advice — run it again — has to be true rather than hopeful.
+        const { port, read } = await harness.create(aWholeLedger());
+
+        await port.wipeAllFinancialData();
+        const afterFirst = asComparable(await read());
+
+        await expect(port.wipeAllFinancialData()).resolves.toBeUndefined();
+
+        expect(asComparable(await read())).toBe(afterFirst);
+        expect(await port.financialDataIsEmpty()).toBe(true);
+      });
+
+      it('erases a store a file can then be poured straight back into', async () => {
+        // THE ROUND TRIP, closed: collect → wipe → restore → collect. Slice 9
+        // could prove the middle two against a store that started empty; this
+        // is the journey a real person makes, which always begins with a login
+        // that already holds their life.
+        //
+        // It is also what pins how much a wipe has to delete. "Empty" for the
+        // flag is three tables; a file carries fourteen. An engine that cleared
+        // the three and left one the file also holds would pass every
+        // assertion above and then fail HERE — which is exactly where it fails
+        // in real life, half-way through a restore, in front of somebody who
+        // has just deliberately erased their own login.
+        const store = await harness.create(aWholeLedger());
+        const file = await store.port.collectBackup();
+
+        await store.port.wipeAllFinancialData();
+        await store.port.restoreBackup(file);
+
+        const again = await store.port.collectBackup();
+
+        // Row for row and penny for penny, matched by name because every id is
+        // minted anew on the way in.
+        expect(again.counts).toEqual(file.counts);
+        const namesOf = (bundle: BackupBundle, entity: BackupEntity, field: string): string[] =>
+          bundle.data[entity].map(row => String(row[field])).sort();
+        expect(namesOf(again, 'accounts', 'name')).toEqual(namesOf(file, 'accounts', 'name'));
+        expect(namesOf(again, 'transactions', 'description'))
+          .toEqual(namesOf(file, 'transactions', 'description'));
+        expect(namesOf(again, 'transactions', 'amount'))
+          .toEqual(namesOf(file, 'transactions', 'amount'));
+        expect(namesOf(again, 'categories', 'name')).toEqual(namesOf(file, 'categories', 'name'));
+        expect(namesOf(again, 'budgets', 'amount')).toEqual(namesOf(file, 'budgets', 'amount'));
+        expect(namesOf(again, 'goals', 'name')).toEqual(namesOf(file, 'goals', 'name'));
       });
 
       it('pours a file into an empty store and gets the same ledger back, to the penny', async () => {

--- a/src/services/port/dataPort.ts
+++ b/src/services/port/dataPort.ts
@@ -43,10 +43,10 @@
  * This is the seam as it stands, not as it will end: the operations below are
  * exactly the ones DataService owns today, under the names it uses today.
  * Bulk import has joined it (the CSV and OFX importers write through
- * `importTransactions`), and so have the backup, the emptiness check and the
- * restore. The wipe and the capability descriptor that will retire
- * `isUsingSupabase` join as their consumers are routed through it in turn. The
- * names here are today's names
+ * `importTransactions`), and so have the backup, the emptiness check, the
+ * restore, the wipe and the Microsoft Money migration. The capability
+ * descriptor that will retire `isUsingSupabase` joins as its consumers are
+ * routed through it in turn. The names here are today's names
  * deliberately: renaming and re-routing in one step would make a rename
  * indistinguishable from a behaviour change in review.
  */
@@ -86,6 +86,25 @@ import type {
   RestoreOutcome,
   RestoreProgress
 } from '../backupService';
+/**
+ * The wipe's progress, and the migration's — imported for the same reason the
+ * backup format above is, and erased at build for the same reason too.
+ *
+ * `WipeProgress` describes a chunked, table-by-table erase: which table, how
+ * many rows have gone, how many there were, which step of how many. Nothing in
+ * that shape is about Microsoft Money or about PostgREST — it is where the one
+ * chunked wipe in the app happens to live, because the total migration is what
+ * first needed it and "Delete All Data" then shared it rather than growing a
+ * second one. Restating it here would give the dialog's progress bar a second
+ * definition free to drift from the one the engine actually reports.
+ *
+ * `MsMoneyImportResult` is a parsed .mny file, and it is emphatically NOT
+ * app state: it is the transform's output, and the transform is what a second
+ * implementation would reuse unchanged. A local edition reads the same file
+ * through the same parser and differs only in where the rows land.
+ */
+import type { ImportProgress, WipeProgress } from '../import/msMoney/msMoneyImport';
+import type { MsMoneyImportResult } from '../import/msMoney/transform';
 
 export type {
   BackupBundle,
@@ -93,7 +112,10 @@ export type {
   BackupRow,
   DanglingReference,
   ExportProgress,
-  RestoreProgress
+  ImportProgress,
+  MsMoneyImportResult,
+  RestoreProgress,
+  WipeProgress
 };
 
 /**
@@ -771,6 +793,95 @@ export interface DataPortBackupLifecycle {
       onProgress?: (progress: RestoreProgress) => void;
     }
   ): Promise<BackupRestoreOutcome>;
+  /**
+   * Erase everything this store holds.
+   *
+   * ── A WIPE IS DEFINED BY THE RESTORE THAT FOLLOWS IT ────────────────────
+   *
+   * The same sentence the backup is defined by, and it is what decides how much
+   * an implementation has to delete. Two things are promised, and neither is
+   * negotiable:
+   *
+   *   `financialDataIsEmpty()` is true afterwards — the emptiness check and the
+   *   wipe answer the same question, or the dialog that erases a login and then
+   *   asks whether it is empty gets two different answers about one store.
+   *
+   *   `restoreBackup()` of any well-formed file SUCCEEDS afterwards. A store
+   *   that emptied the three tables the emptiness check asks about, and left a
+   *   table the FILE also carries, has not wiped: the restore lands on top of
+   *   the survivors and stops halfway, in front of somebody who has just erased
+   *   their own login on purpose. So "everything" means every table a backup
+   *   carries, not the three that decide the flag.
+   *
+   * ── AND IT IS IDEMPOTENT ────────────────────────────────────────────────
+   *
+   * Running it twice is safe, and that is a working recovery rather than a
+   * tidiness rule. An engine that erases in pieces (the cloud does, because one
+   * statement over 51,000 rows is cancelled by the database's own statement
+   * timeout — the failure this chunking exists because of) leaves some rows gone
+   * and some there when it stops. It cannot avoid that state, so it makes it
+   * SAFE instead: deleting rows that have already gone is a no-op, so running it
+   * again carries on from wherever it stopped, and the dialog says exactly that
+   * rather than showing a bare error.
+   *
+   * IT TAKES NO CONFIRMATION PHRASE, and takes no owner either (rule 1). The
+   * screen in front of it holds the confirmation — both of today's callers
+   * refuse to enable the button until the phrase is typed exactly — and the
+   * implementation supplies whatever phrase its own engine demands. A
+   * confirmation that travelled through here would be a string an implementation
+   * could get wrong; the screen's is one the user typed.
+   *
+   * Progress is reported per table because a real dataset is 50k+ rows and
+   * minutes of work, and a button that says "Deleting…" for four minutes reads
+   * exactly like one that has hung. An engine that erases in one atomic write
+   * has no honest fraction and stays silent, which the callers already handle.
+   */
+  wipeAllFinancialData(options?: {
+    onProgress?: (progress: WipeProgress) => void;
+  }): Promise<void>;
+}
+
+/**
+ * Coming from another money manager.
+ *
+ * Its own group rather than a bulk write, because it is not one: `importTransactions`
+ * ADDS a statement to an account somebody chose, and this REPLACES the whole
+ * store — every account, every category, every transaction and every transfer
+ * between them, in place of whatever was there.
+ */
+export interface DataPortMigration {
+  /**
+   * Replace everything with a parsed Microsoft Money file.
+   *
+   * DESTRUCTIVE BY DEFINITION. It wipes first and writes second, and the caller
+   * that reaches it has already taken the user through a confirmation and an
+   * offer to download the current data as a file. This operation does not
+   * re-ask: a second confirmation invented down here would be one the screen
+   * above cannot word properly, and one an implementation could forget.
+   *
+   * IT TAKES NO OWNER (rule 1), and this is the operation with the most on it
+   * of anything in this seam. Getting the store wrong here does not mislay a
+   * row — it writes somebody's entire financial history, thirty years of it,
+   * into a place their app will never read again, and reports it as a success.
+   *
+   * IT REJECTS, unlike `importTransactions`. A bulk import is REPORTED because
+   * "412 of 900 landed" is an outcome a caller renders; a total migration has no
+   * such halfway answer to render, so a failure comes back as an error with the
+   * engine's own sentence on it — which is what the dialog puts on screen, and
+   * what somebody needs when a migration has stopped part-way through replacing
+   * everything they own.
+   *
+   * Progress crosses as the importer's own phases (wiping, accounts, categories,
+   * transactions, links, splits, verifying) with a fraction and a sentence,
+   * because the operation is minutes long on a real file and the wipe alone can
+   * be most of it.
+   */
+  importMsMoney(
+    result: MsMoneyImportResult,
+    options?: {
+      onProgress?: (progress: ImportProgress) => void;
+    }
+  ): Promise<void>;
 }
 
 export interface DataPortLifecycle {
@@ -831,4 +942,5 @@ export interface DataPort extends
   DataPortPlanningWrites,
   DataPortDismissalWrites,
   DataPortBackupLifecycle,
+  DataPortMigration,
   DataPortLifecycle {}

--- a/src/services/port/index.ts
+++ b/src/services/port/index.ts
@@ -30,15 +30,19 @@ export type {
   DataPortBulkWrites,
   DataPortDismissalWrites,
   DataPortLifecycle,
+  DataPortMigration,
   DataPortPlanningWrites,
   DataPortReads,
   DataPortSplitWrites,
   DataPortTransactionWrites,
   DataPortTransferWrites,
   ExportProgress,
+  ImportProgress,
   ImportSourceKind,
   MoneyNumber,
-  RestoreProgress
+  MsMoneyImportResult,
+  RestoreProgress,
+  WipeProgress
 } from './dataPort';
 
 export const dataPort: DataPort = DataService;


### PR DESCRIPTION
Slice 10 of the write-paths plan — the named deliverable delivered: `DataManagement` and `EnhancedImport` import `dataPort` and nothing else from the data layer (grep-proven; the Money importer stays lazy, loaded by the seam).

- **Divergence ruled on and accepted**: the cloud wipe is two passes — chunked (heavy tables, progress, re-runnable) then the RPC (the five user-scoped tables nothing cascades) — because the chunked pass alone leaves rows that unique-violate a subsequent restore part-way through an erased login. Both surfaces improve: the restore modal's wipe gains timeout-safety; "Clear All Data" now actually clears everything its button promises.
- The typed confirmation phrase centralises with drift-refuses-not-weakens semantics, pinned on both branches.
- `importMsMoney` refuses the pending session — the old fall-through wrote a whole `.mny` history into a store the signed-in app never reads, then reported success.
- Mutation M2 initially stayed green and exposed a thin fixture (no splits, no dismissals in "a whole ledger") — strengthened until red by name. The full destructive round-trip contract closes: collect → wipe → restore → collect identical.
- `EnhancedImport` had zero coverage — characterised at HEAD first, then re-pointed.
- Flagged for slice 11: `getUserIds` is at one consumer/three feeds (all capabilities'), and `Dashboard.tsx:5` is the last React page importing the Postgres client (outside the plan — will be swept in 11 or reported).

Gate: lint · strict tsc · smoke 4,909 · realtime 223 · contract 77 · build · +0.3 KB gz main, JS total unchanged · coverage 75.27/81.29 vs 63/55.

🤖 Generated with [Claude Code](https://claude.com/claude-code)