### PR TITLE
feat(seam): slice 11 — capabilities replaces the flags; the seal holds

### DIFF
--- a/src/components/RestoreBackupModal.tsx
+++ b/src/components/RestoreBackupModal.tsx
@@ -1,7 +1,6 @@
 import React, { useCallback, useMemo, useState } from 'react';
 import { Modal, ModalBody, ModalFooter } from './common/Modal';
 import { useApp } from '../contexts/AppContextSupabase';
-import { DataService } from '../services/api/dataService';
 import { dataPort } from '../services/port';
 import type { BackupRestoreOutcome } from '../services/port';
 import { transactionCache } from '../services/transactionCache';
@@ -82,7 +81,7 @@ const formatExportedAt = (iso: string): string => {
 };
 
 export default function RestoreBackupModal({ isOpen, onClose }: Props): React.JSX.Element {
-  const { refreshAccountsAndTransactions, refreshCategories, isUsingSupabase } = useApp();
+  const { refreshAccountsAndTransactions, refreshCategories, capabilities } = useApp();
 
   const [phase, setPhase] = useState<Phase>('pick');
   const [fileName, setFileName] = useState('');
@@ -103,28 +102,25 @@ export default function RestoreBackupModal({ isOpen, onClose }: Props): React.JS
   const [failure, setFailure] = useState<{ step: string; message: string; partiallyRestored: boolean } | null>(null);
 
   /**
-   * WHAT THIS IS STILL FOR, now that the seam resolves its own owner.
+   * WHAT THIS DIALOG STILL ASKS THE STORE, now that the seam resolves its own
+   * owner: three capability questions, and no identity at all.
    *
-   * WORDS, and one refusal — no data operation. This dialog is now the LAST
-   * consumer of `getUserIds` in the app, and all three of the things it reads
-   * from it are questions about this edition rather than about anybody's data:
-   * whether the copy says "login" or "device" throughout, whether a restore
-   * that failed halfway warns about a partly-populated store (a chunked cloud
-   * restore can be; one IndexedDB transaction cannot), and whether a signed-in
-   * session is still connecting and must be blocked from starting at all.
+   * It used to read `DataService.getUserIds()` — the app's last consumer of it,
+   * and the last place a screen held somebody's database id in order to decide
+   * anything. All three of the things it decided are properties of the STORE
+   * rather than facts about a person: where a backup goes, whether a failure
+   * can leave a half-filled target, and whether the target is nameable yet.
    *
-   * All three leave with `capabilities()`, and the method goes with them. The
-   * emptiness check, the wipe and the restore no longer touch it — `dataPort`
-   * answers those without being told whose data it is.
+   * `backupTarget` carries the first two. A restore aimed at a login is chunked
+   * and can therefore stop halfway; one aimed at a device is a single IndexedDB
+   * transaction and cannot. `session === 'connecting'` carries the third, and
+   * it is the one with the data loss behind it: a signed-in session whose
+   * database id has not resolved yet is NOT a device, and a restore started
+   * there would pour the file into browser storage the signed-in app will never
+   * read again.
    */
-  const databaseUserId = DataService.getUserIds().databaseId;
-  /**
-   * Which store this restore is aimed at. A signed-in session whose database id
-   * has not resolved yet is NOT local — restoring into browser storage there
-   * would put the file somewhere the app will never read it from again.
-   */
-  const isCloudRestore = Boolean(databaseUserId);
-  const cloudSessionPending = isUsingSupabase && !databaseUserId;
+  const isCloudRestore = capabilities.backupTarget === 'login';
+  const cloudSessionPending = capabilities.session === 'connecting';
   const targetName = isCloudRestore ? 'login' : 'device';
 
   const dateRange = useMemo(() => (bundle ? transactionDateRange(bundle) : null), [bundle]);
@@ -255,11 +251,11 @@ export default function RestoreBackupModal({ isOpen, onClose }: Props): React.JS
       setFailure({
         step,
         message,
-        partiallyRestored: Boolean(databaseUserId) && !(error instanceof LocalRestoreRefusedError),
+        partiallyRestored: isCloudRestore && !(error instanceof LocalRestoreRefusedError),
       });
       setPhase('failed');
     }
-  }, [bundle, databaseUserId, cloudSessionPending, refreshAccountsAndTransactions, refreshCategories]);
+  }, [bundle, isCloudRestore, cloudSessionPending, refreshAccountsAndTransactions, refreshCategories]);
 
   const percent = progress && progress.rowsTotal > 0
     ? Math.round((progress.rowsDone / progress.rowsTotal) * 100)

--- a/src/components/__tests__/RestoreBackupModal.test.tsx
+++ b/src/components/__tests__/RestoreBackupModal.test.tsx
@@ -9,20 +9,56 @@
  * between, to the one door it knocks on now. That is what makes the suite
  * evidence that the routing changed nothing the user can see.
  *
- * STILL THE PAGE'S OWN, and mocked as such: only the identity that decides
- * whether the copy says "login" or "device" (slice 11). No data operation on
- * this screen picks an engine any more.
+ * STILL THE PAGE'S OWN, and mocked as such: the two CAPABILITIES that decide
+ * whether the copy says "login" or "device", whether a failure can have left a
+ * half-filled target, and whether the target is nameable at all. It used to
+ * read a database id off DataService to answer those three — the app's last
+ * consumer of `getUserIds`, and a screen holding somebody's identity in order
+ * to choose a word. No data operation on this screen picks an engine any more,
+ * and now no part of it knows who is signed in.
  */
 
 import React from 'react';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { buildBackupBundle, type BackupBundle } from '../../services/backupService';
+import type { DataPortCapabilities } from '../../services/port';
+
+/** A device with nobody signed in — this suite's default target. */
+const DEVICE: DataPortCapabilities = {
+  edition: 'device',
+  session: 'anonymous',
+  realtime: false,
+  maxConcurrentWrites: 1,
+  backupTarget: 'device',
+};
+
+/** A resolved login: chunked restore, so a failure can leave it partly full. */
+const LOGIN: DataPortCapabilities = {
+  edition: 'cloud',
+  session: 'ready',
+  realtime: true,
+  maxConcurrentWrites: 8,
+  backupTarget: 'login',
+};
+
+/**
+ * Signing in, but not there yet. The state with the data loss behind it: the
+ * store is NOT a device, and a restore started here would pour the file into
+ * browser storage the signed-in app will never read again.
+ */
+const CONNECTING: DataPortCapabilities = {
+  edition: 'device',
+  session: 'connecting',
+  realtime: false,
+  maxConcurrentWrites: 1,
+  backupTarget: 'device',
+};
 
 const appValue = {
   refreshAccountsAndTransactions: vi.fn(async () => {}),
   refreshCategories: vi.fn(async () => {}),
-  isUsingSupabase: false,
+  capabilities: DEVICE,
 };
 
 vi.mock('../../contexts/AppContextSupabase', () => ({
@@ -31,14 +67,6 @@ vi.mock('../../contexts/AppContextSupabase', () => ({
 
 vi.mock('../../services/transactionCache', () => ({
   transactionCache: { clear: vi.fn(async () => {}) },
-}));
-
-const userIds = vi.hoisted(() => ({
-  value: { clerkId: null as string | null, databaseId: null as string | null },
-}));
-
-vi.mock('../../services/api/dataService', () => ({
-  DataService: { getUserIds: () => userIds.value },
 }));
 
 /** The seam. One door, whichever store is behind it. */
@@ -95,8 +123,7 @@ const pickFile = async (bundle: BackupBundle, name = 'backup.json'): Promise<voi
 describe('RestoreBackupModal', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    userIds.value = { clerkId: null, databaseId: null };
-    appValue.isUsingSupabase = false;
+    appValue.capabilities = DEVICE;
     seam.financialDataIsEmpty.mockResolvedValue(true);
     seam.restoreBackup.mockResolvedValue({ ...outcome });
     seam.wipeAllFinancialData.mockResolvedValue(undefined);
@@ -261,7 +288,7 @@ describe('RestoreBackupModal', () => {
     });
 
     it('warns that a login is partly populated when a cloud restore fails halfway', async () => {
-      userIds.value = { clerkId: 'clerk_1', databaseId: 'db-user-1' };
+      appValue.capabilities = LOGIN;
       seam.restoreBackup.mockRejectedValue(new Error('duplicate key value violates unique constraint'));
       open();
       await pickFile(bundleWith());
@@ -275,8 +302,7 @@ describe('RestoreBackupModal', () => {
 
   describe('a session that has not resolved its login yet', () => {
     it('refuses the file rather than aiming a restore at the browser', async () => {
-      appValue.isUsingSupabase = true;
-      userIds.value = { clerkId: 'clerk_1', databaseId: null };
+      appValue.capabilities = CONNECTING;
       open();
       handOver(bundleWith());
 
@@ -295,7 +321,7 @@ describe('RestoreBackupModal', () => {
     });
 
     it('says nothing about them when the target is a login', async () => {
-      userIds.value = { clerkId: 'clerk_1', databaseId: 'db-user-1' };
+      appValue.capabilities = LOGIN;
       open();
       await pickFile(bundleWith({ investments: [{ id: 'inv-1', symbol: 'ABC' }] }));
 

--- a/src/contexts/AppContextSupabase.tsx
+++ b/src/contexts/AppContextSupabase.tsx
@@ -1,21 +1,27 @@
 /* eslint-disable react-refresh/only-export-components */
 /**
- * AppContext with Supabase Integration
- * This version uses the DataService layer to work with either Supabase or localStorage
+ * The app's state, and the one door it reads and writes through.
+ *
+ * This file no longer names an engine. Every ledger operation goes through
+ * `dataPort` — the seam — and the last two questions it asked about the engine
+ * itself (how many writes may be in flight, and whether to open a realtime
+ * subscription) are answered by that seam's capability descriptor rather than
+ * by a Supabase client and a database id read from here. What is left of the
+ * old identity plumbing is one call: resolving the signed-in person's database
+ * id at boot, which is an AUTH concern rather than a data one.
  */
 
 import React, { createContext, useContext, useState, useEffect, useCallback, useRef } from 'react';
 import { useUser } from '@clerk/clerk-react';
-import { DataService } from '../services/api/dataService';
-// The boot's ledger reads go through the seam. `dataPort` IS the DataService
-// above, typed as the interface — no wrapper, no second copy, no extra bytes —
-// so this import is a statement about WHICH DOOR the boot uses, not about which
-// engine answers. That is what lets a local implementation be dropped in.
+// The ledger goes through the seam. `dataPort` IS the DataService singleton,
+// typed as the interface — no wrapper, no second copy, no extra bytes — so this
+// import is a statement about WHICH DOOR the app uses, not about which engine
+// answers. That is what lets a local implementation be dropped in.
 import { dataPort } from '../services/port';
+import type { DataPortCapabilities } from '../services/port';
 import AutoSyncService from '../services/autoSyncService';
 import { transactionCache } from '../services/transactionCache';
 import { userIdService } from '../services/userIdService';
-import { isSupabaseConfigured } from '../services/api/supabaseClient';
 import { goalAchievementService } from '../services/goalAchievementService';
 import { getDefaultCategories } from '../data/defaultCategories';
 // formatCurrency import removed - not used in this context
@@ -129,10 +135,24 @@ export interface AppContextType extends AppState {
   
   // Sync status
   isLoading: boolean;
-  isSyncing: boolean;
   lastSyncTime: Date | null;
   syncError: string | null;
-  isUsingSupabase: boolean;
+  /**
+   * What the store behind this app can do — the seam's own descriptor, surfaced
+   * here so a component can read it without importing the seam.
+   *
+   * It replaced `isUsingSupabase`, which was a boolean four unrelated questions
+   * were being answered from: how many writes may be in flight, whether to open
+   * a realtime subscription, where a backup goes, and whether a sentence says
+   * "login" or "device". Each of those is now a field that says what it governs
+   * (see DataPortCapabilities), which is what lets an engine that is neither of
+   * today's two answer them independently instead of being forced to claim it
+   * is Supabase.
+   *
+   * `edition` is WORDS ONLY and no code here may branch on it — a test greps
+   * for that. The routing questions are the other four fields.
+   */
+  capabilities: DataPortCapabilities;
   /**
    * Re-pull ONLY accounts + transactions from Supabase (e.g. after a bank sync).
    * Deliberately narrow — budgets/goals are a separate read, so a whole-app
@@ -329,14 +349,29 @@ export function AppProvider({ children }: { children: React.ReactNode }) {
     useState<'idle' | 'loading' | 'ready' | 'error'>('idle');
 
   const [isLoading, setIsLoading] = useState(true);
-  // Read-only on purpose: the whole-app refresh that used to flip this was
-  // unreachable and has been removed. The flag stays on the context surface
-  // (consumers still type against it) and is honestly always false.
-  const [isSyncing] = useState(false);
   const [lastSyncTime, setLastSyncTime] = useState<Date | null>(null);
   const [syncError, setSyncError] = useState<string | null>(null);
-  const [isUsingSupabase, setIsUsingSupabase] = useState(false);
-  
+  /**
+   * What the store can do, asked ONCE PER BOOT and held in state.
+   *
+   * State rather than a call in the render body, because the answer changing is
+   * something React has to be told about: a sign-in that completes moves
+   * `session` from 'connecting' to 'ready' and `backupTarget` from 'device' to
+   * 'login', and a component that had merely called the seam during its last
+   * render would keep showing the old sentence until something unrelated
+   * re-rendered it.
+   *
+   * Seeded on the first render rather than defaulted, so the value is the
+   * store's own answer from the very first paint instead of a placeholder that
+   * happens to be wrong for a signed-in session. The re-ask sits in the boot's
+   * `finally`, which is what makes it once per boot on EVERY path — including
+   * the one where the boot failed, where the retired flag simply stayed false
+   * and left a signed-in app describing itself as a device.
+   */
+  const [capabilities, setCapabilities] =
+    useState<DataPortCapabilities>(() => dataPort.capabilities());
+
+
   // Refs to prevent duplicate updates and manage debouncing
   const lastUpdateRef = useRef<{ type: string; timestamp: number } | null>(null);
   const updateDebounceRef = useRef<NodeJS.Timeout | null>(null);
@@ -397,7 +432,8 @@ export function AppProvider({ children }: { children: React.ReactNode }) {
         // came up empty and stayed empty. A no-op outside demo mode.
         await initializeDemoData();
 
-        // Initialize DataService with user info
+        // Resolve who is signed in, then hand the seam its own chance to make
+        // sure they have a store to read.
         if (user) {
           appLogger.info('User found, initializing services');
           
@@ -533,7 +569,6 @@ export function AppProvider({ children }: { children: React.ReactNode }) {
         setGoals(loadedGoals);
         markPhase('planning');
 
-        setIsUsingSupabase(DataService.isUsingSupabase());
         setLastSyncTime(new Date());
         // Settled long ago in practice (it started before the slowest phase) —
         // awaited only so the summary line below can report its timing.
@@ -562,8 +597,20 @@ export function AppProvider({ children }: { children: React.ReactNode }) {
           ` (${txnSummary})`
         );
 
-        // Subscribe to real-time updates if using Supabase
-        if (DataService.isUsingSupabase() && user) {
+        // Subscribe to real-time updates — but only where there is something to
+        // hear from. `subscribeToUpdates` is safe to call either way (an engine
+        // with no other device hands back a no-op unsubscribe), so this gate is
+        // not protecting the call: it skips the MACHINERY around it — the
+        // debounce timer, the recent-local-write suppression window and the
+        // teardown bookkeeping below — all of which exist solely to cope with
+        // events that a store with no realtime will never send.
+        //
+        // It asks the seam what it can do rather than which product it is. The
+        // predicate is unchanged (`realtime` is the same "a database id is
+        // resolved AND a client is configured" the retired flag answered), but
+        // an engine that gains a sync peer without becoming a login can now say
+        // so, instead of having to claim it is Supabase to be heard.
+        if (dataPort.capabilities().realtime && user) {
           // Helper function to debounce updates
           const debouncedUpdate = (updateType: string, updateFn: () => Promise<void>) => {
             // Check if this is a duplicate update (within 1 second)
@@ -642,9 +689,9 @@ export function AppProvider({ children }: { children: React.ReactNode }) {
                 // The retired call carried this login's Clerk id and re-resolved
                 // it to a database id on every event; the port reads the id the
                 // boot already resolved. Behind the gate this whole block sits
-                // behind — `isUsingSupabase()` is exactly "a database id is
-                // resolved AND Supabase is configured" — that id is warm, so on
-                // the path that matters the two agree.
+                // behind — `capabilities().realtime` is exactly "a database id
+                // is resolved AND Supabase is configured" — that id is warm, so
+                // on the path that matters the two agree.
                 //
                 // Where they stop agreeing is a DECLARED IMPROVEMENT rather than
                 // a preserved behaviour: if the id cache is cleared between the
@@ -712,6 +759,16 @@ export function AppProvider({ children }: { children: React.ReactNode }) {
         });
         setSyncError('Failed to load data. Using offline mode.');
       } finally {
+        // ONE re-ask per boot, on every path.
+        //
+        // In the `finally` rather than beside the other post-load state,
+        // because a boot that threw is precisely when getting this wrong is
+        // worst: the login is resolved, the data read failed, and the retired
+        // flag — which was set only on the success path — left the app
+        // describing itself as a device. The Export page then offered "the only
+        // copy there is" to somebody whose data was in a database, and the
+        // restore dialog aimed at the wrong store.
+        setCapabilities(dataPort.capabilities());
         setIsLoading(false);
       }
     };
@@ -976,13 +1033,19 @@ export function AppProvider({ children }: { children: React.ReactNode }) {
       return 0;
     }
 
-    // In the cloud each write is an independent RPC, so a handful in flight
-    // keeps a few thousand renames tolerable without opening a few thousand
-    // sockets. In local/demo mode every write re-reads and re-persists the
-    // WHOLE browser-local collection, so two in flight is a lost-update race —
-    // there the writes go strictly one at a time.
-    const isCloudSession = Boolean(userIdService.getCurrentDatabaseUserId()) && isSupabaseConfigured();
-    const BATCH_SIZE = isCloudSession ? 8 : 1;
+    // How many of these may be in flight at once is the STORE's answer, not
+    // this loop's. In the cloud each write is an independent RPC, so a handful
+    // in flight keeps a few thousand renames tolerable without opening a few
+    // thousand sockets; a store that re-reads and re-persists a whole
+    // collection per write has no such freedom, because two in flight is a
+    // lost-update race and the second silently overwrites the first.
+    //
+    // The reasoning is unchanged and the numbers are unchanged (8 and 1). What
+    // changed is who holds them: this file used to resolve a database id and
+    // check a Supabase client to work out which engine it was writing to — the
+    // last place in the context that named either — and an engine that is
+    // neither had no way to be safe here. Now it states its own limit.
+    const BATCH_SIZE = dataPort.capabilities().maxConcurrentWrites;
     const renamed = new Set<string>();
     let failures = 0;
 
@@ -1594,6 +1657,22 @@ export function AppProvider({ children }: { children: React.ReactNode }) {
     if (data.recurringTransactions) setRecurringTransactions(data.recurringTransactions);
   }, []);
 
+  /**
+   * The snapshot the Money migration offers to download before it replaces
+   * everything. Data only.
+   *
+   * DECLARED FORMAT CHANGE: two keys have gone from the file — `isSyncing`,
+   * which was always false, and `isUsingSupabase`, which was hardcoded TRUE and
+   * therefore a lie in every browser-storage session that ever downloaded one.
+   * Neither described the data beside it, and `importData` reads neither (it
+   * takes accounts, transactions, budgets, goals, categories, tags and
+   * recurring templates and ignores the rest), so an older file with the keys
+   * still restores exactly as it did. What is gone is a file claiming to know
+   * where its rows came from while getting it wrong.
+   *
+   * `isLoading: false` stays: it is honest — a snapshot is by definition taken
+   * once the data is loaded — and it is part of the shape older tooling reads.
+   */
   const exportData = useCallback((): string => {
     const data = {
       accounts,
@@ -1603,9 +1682,7 @@ export function AppProvider({ children }: { children: React.ReactNode }) {
       categories,
       tags,
       recurringTransactions,
-      isLoading: false,
-      isSyncing: false,
-      isUsingSupabase: true
+      isLoading: false
     };
     return JSON.stringify(data, null, 2);
   }, [accounts, transactions, budgets, goals, categories, tags, recurringTransactions]);
@@ -1890,10 +1967,9 @@ export function AppProvider({ children }: { children: React.ReactNode }) {
     
     // Sync status
     isLoading,
-    isSyncing,
     lastSyncTime,
     syncError,
-    isUsingSupabase,
+    capabilities,
     refreshAccountsAndTransactions,
     refreshCategories,
     loadTestData

--- a/src/contexts/__tests__/AppContextBootThroughPort.test.tsx
+++ b/src/contexts/__tests__/AppContextBootThroughPort.test.tsx
@@ -27,10 +27,10 @@
  * beside the contract suite.
  *
  * NOT through the door yet, and deliberately named so the silence is not read
- * as a claim: `isUsingSupabase` (still DataService's own answer — it is a
- * capability question, and retiring it is its own slice), the real-time
- * subscriptions, and the suggestion dismissals, which are not a boot read at
- * all (they load on demand).
+ * as a claim: the real-time subscriptions, and the suggestion dismissals, which
+ * are not a boot read at all (they load on demand). `isUsingSupabase` used to
+ * be on this list; it is gone from the app entirely, and the stub answers the
+ * capability descriptor that replaced it.
  */
 
 import React, { ReactNode } from 'react';
@@ -219,6 +219,18 @@ vi.mock('../../services/port', () => {
     },
     initialize: async () => {},
     subscribeToUpdates: () => () => {},
+    // A device, with nobody signed in — which is what the rest of this file
+    // arranges (the id service below hands back a null CURRENT id, so every
+    // service that is not the seam stays off the network). Realtime false keeps
+    // the boot's subscription block shut, which is this stub's whole interest in
+    // the descriptor: the block is proved in AppContextRealtimeCleanup.test.
+    capabilities: () => ({
+      edition: 'device' as const,
+      session: 'anonymous' as const,
+      realtime: false,
+      maxConcurrentWrites: 1,
+      backupTarget: 'device' as const,
+    }),
     // Writes: none of them belong to a boot, so each one says so rather than
     // quietly succeeding. A boot that wrote anything would fail by name here.
     createAccount: refuse('createAccount'),

--- a/src/contexts/__tests__/AppContextCategoryTreeImport.test.tsx
+++ b/src/contexts/__tests__/AppContextCategoryTreeImport.test.tsx
@@ -45,7 +45,8 @@ import type {
 import type {
   AccountBalanceSnapshot,
   BootTransactionsResult,
-  DataPort
+  DataPort,
+  DataPortCapabilities
 } from '../../services/port/dataPort';
 import type { CategoryTreeGroup } from '../../utils/categoryTreeImport';
 
@@ -171,6 +172,15 @@ vi.mock('../../services/port', () => {
     },
     initialize: async (): Promise<void> => {},
     subscribeToUpdates: (): (() => void) => () => {},
+    // A device with nobody signed in: realtime off keeps the boot's
+    // subscription block shut, which is all this suite wants from it.
+    capabilities: (): DataPortCapabilities => ({
+      edition: 'device',
+      session: 'anonymous',
+      realtime: false,
+      maxConcurrentWrites: 1,
+      backupTarget: 'device',
+    }),
 
     // The operations under test.
     createCategories: async (categories: Array<Omit<Category, 'id'>>): Promise<Category[]> => {

--- a/src/contexts/__tests__/AppContextRealtimeCleanup.test.tsx
+++ b/src/contexts/__tests__/AppContextRealtimeCleanup.test.tsx
@@ -30,8 +30,10 @@
  *     the account service the subscription used to come from.
  *
  * The data layer is stubbed the way the sibling suites stub it (in-memory
- * storage, local-only ids, no network). Only `isUsingSupabase` is forced on,
- * because that flag is the sole gate on the realtime block.
+ * storage, local-only ids, no network). Only the seam's `realtime` capability
+ * is forced on, because it is the sole gate on the realtime block — it was a
+ * boolean called `isUsingSupabase` when this suite was written, and the same
+ * predicate under a name that says what it governs now.
  */
 
 import React, { ReactNode } from 'react';
@@ -201,7 +203,17 @@ describe('the boot’s realtime subscription', () => {
     // The one gate on the realtime block. Forced rather than arranged, because
     // arranging it (a real database id + a configured client) would put the
     // rest of the boot on the network for no gain to what is under test.
-    vi.spyOn(DataService, 'isUsingSupabase').mockReturnValue(true);
+    //
+    // The whole descriptor is answered rather than just the gate: it is one
+    // object, the context reads other fields of it elsewhere in the same boot,
+    // and a stub that returned only `realtime` would be a shape no engine has.
+    vi.spyOn(DataService, 'capabilities').mockReturnValue({
+      edition: 'cloud',
+      session: 'ready',
+      realtime: true,
+      maxConcurrentWrites: 8,
+      backupTarget: 'login',
+    });
 
     vi.spyOn(DataService, 'subscribeToUpdates').mockImplementation(
       (callbacks): Unsubscribe => {

--- a/src/contexts/__tests__/AppContextSupabase.test.tsx
+++ b/src/contexts/__tests__/AppContextSupabase.test.tsx
@@ -215,12 +215,24 @@ describe('AppContextSupabase live provider', () => {
   });
 
   describe('initialisation (local fallback in jsdom)', () => {
-    it('mounts with empty data and Supabase off', async () => {
+    it('mounts with empty data, and describes itself as the device it is', async () => {
       const { result } = await renderApp();
 
       expect(result.current.accounts).toEqual([]);
       expect(result.current.transactions).toEqual([]);
-      expect(result.current.isUsingSupabase).toBe(false);
+      // This suite arranges exactly the engine the descriptor should report:
+      // no database id, no cloud session. Asserted as the WHOLE descriptor
+      // rather than one field of it, because the boot surfaces it in one go and
+      // a single field would let the other four rot — `maxConcurrentWrites`
+      // above all, which the payee rename divides its work by. The retired
+      // `isUsingSupabase: false` this replaced is the `edition`/`realtime` pair.
+      expect(result.current.capabilities).toEqual({
+        edition: 'device',
+        session: 'anonymous',
+        realtime: false,
+        maxConcurrentWrites: 1,
+        backupTarget: 'device',
+      });
       // Default categories are seeded even with empty storage.
       expect(result.current.categories.length).toBeGreaterThan(0);
     });
@@ -273,6 +285,65 @@ describe('AppContextSupabase live provider', () => {
       // The deleted account's transactions go with it; others survive.
       expect(result.current.transactions).toHaveLength(1);
       expect(result.current.transactions[0].accountId).toBe(kept.id);
+    });
+  });
+
+  describe('the payee rename, and how many writes it puts in flight', () => {
+    it('writes strictly one at a time on a store that says one at a time', async () => {
+      // WHY THIS IS A TEST AND NOT AN OBSERVATION. The rename divides its work
+      // by `capabilities().maxConcurrentWrites`, and this suite's engine is the
+      // browser store — where a write re-reads and re-persists the WHOLE
+      // collection. Two in flight there is a lost-update race: the second write
+      // was built from a snapshot taken before the first landed, so it puts the
+      // first one's row back the way it was and the rename silently un-happens
+      // for that transaction.
+      //
+      // The number itself is pinned beside the engine (dataService.test.ts,
+      // "what this engine says it can do"). What is pinned HERE is the wiring:
+      // that the loop actually obeys the limit rather than merely being handed
+      // it. Concurrency is measured rather than inferred — a spy that counts
+      // how many calls are in flight at their peak.
+      const { result } = await renderApp();
+
+      let account!: Account;
+      await act(async () => {
+        account = await result.current.addAccount(createAccountInput());
+      });
+
+      await act(async () => {
+        for (const description of ['TESCO 1234', 'TESCO 5678', 'TESCO 9012']) {
+          await result.current.addTransaction(
+            createTransactionInput(account.id, { description })
+          );
+        }
+      });
+      const ids = result.current.transactions.map(transaction => transaction.id);
+      expect(ids).toHaveLength(3);
+
+      let inFlight = 0;
+      let peak = 0;
+      const realUpdate = DataService.updateTransaction.bind(DataService);
+      vi.spyOn(DataService, 'updateTransaction').mockImplementation(async (id, updates) => {
+        inFlight += 1;
+        peak = Math.max(peak, inFlight);
+        // A real await between entry and exit, so two overlapping calls would
+        // genuinely overlap rather than run to completion synchronously.
+        await Promise.resolve();
+        try {
+          return await realUpdate(id, updates);
+        } finally {
+          inFlight -= 1;
+        }
+      });
+
+      let renamed = 0;
+      await act(async () => {
+        renamed = await result.current.renameTransactionDescriptions(ids, 'Tesco');
+      });
+
+      expect(renamed).toBe(3);
+      expect(peak).toBe(1);
+      expect(result.current.transactions.map(t => t.description)).toEqual(['Tesco', 'Tesco', 'Tesco']);
     });
   });
 

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -1,9 +1,6 @@
 import { useState, useEffect, Suspense } from 'react';
 import { lazyWithRecovery } from '../utils/lazyWithRecovery';
-import { useApp } from '../contexts/AppContextSupabase';
 import { usePreferences } from '../contexts/PreferencesContext';
-import { supabase } from '../lib/supabase';
-import { useAuth } from '../contexts/AuthContext';
 import PageWrapper from '../components/PageWrapper';
 import { SkeletonCard } from '../components/loading/Skeleton';
 import LazyErrorBoundary from '../components/LazyErrorBoundary';
@@ -20,41 +17,25 @@ const ImprovedDashboard = lazyWithRecovery(() => import('../components/dashboard
 
 
 export default function Dashboard() {
-  const { accounts } = useApp();
   const { firstName, setFirstName, setCurrency } = usePreferences();
-  const { user } = useAuth();
-  const [_supabaseConnected, setSupabaseConnected] = useState(false);
   const [showOnboarding, setShowOnboarding] = useState(false);
-  
-  // Check Supabase connection and migration status
-  useEffect(() => {
-    const checkSupabase = async () => {
-      if (supabase && user) {
-        try {
-          // Simple test query to check connection
-          const { error } = await supabase
-            .from('user_profiles')
-            .select('id')
-            .limit(1);
-          
-          setSupabaseConnected(!error);
-          if (!error) {
-            // Silent auto-migration - no user interaction needed
-            // Migration happens automatically in AppContextSupabase
-          } else {
-            // Supabase connection issue - handled silently
-          }
-        } catch {
-          // Supabase connection failed - handled silently
-          setSupabaseConnected(false);
-        }
-      } else {
-        setSupabaseConnected(false);
-      }
-    };
-    
-    checkSupabase();
-  }, [user, accounts.length, showOnboarding]);
+
+  // Retired 2026-08-10: the Supabase "connection check".
+  //
+  // It was the last direct Postgres client in a React page, and it was not a
+  // read at all — it selected one id out of `user_profiles`, put the result in
+  // a state variable named `_supabaseConnected` that NOTHING read, and
+  // re-rendered the dashboard to store it. It re-ran on every change of user,
+  // account count and onboarding flag, so every account added fired another
+  // query whose answer was discarded. Its own comment said the migration it was
+  // watching for "happens automatically in AppContextSupabase", which is true:
+  // the boot prepares categories and runs the id migration through the seam,
+  // and it is the seam that reports a store it cannot reach.
+  //
+  // Nothing observable goes with it — an unread state variable has no screen —
+  // so there is no capability to route this through. It is deleted rather than
+  // ported, and with it go this page's imports of the database client, the auth
+  // context and the app context, none of which it used for anything else.
 
   // Check if onboarding should be shown
   useEffect(() => {

--- a/src/pages/ExportManager.tsx
+++ b/src/pages/ExportManager.tsx
@@ -68,7 +68,10 @@ const isoDay = (date: Date): string => {
 };
 
 export default function ExportManager(): React.JSX.Element {
-  const { transactions, transactionSplits, accounts, categories, isUsingSupabase } = useApp();
+  // `capabilities` is here for ONE SENTENCE of copy on the full-backup card:
+  // whether the file about to be downloaded is a second copy of rows a database
+  // holds, or the only copy that exists. Nothing on this page branches on it.
+  const { transactions, transactionSplits, accounts, categories, capabilities } = useApp();
   const { showError, showSuccess } = useToast();
   const { displayCurrency } = useCurrencyDecimal();
   // The app-wide period control, so "last month" here means what it means on
@@ -466,7 +469,7 @@ export default function ExportManager(): React.JSX.Element {
               <div className="bg-white dark:bg-gray-800 rounded-lg shadow-sm p-6">
                 <h3 className="text-lg font-semibold text-gray-900 dark:text-white">Full backup</h3>
                 <p className="text-sm text-gray-600 dark:text-gray-400 mt-1 mb-4">
-                  {isUsingSupabase
+                  {capabilities.edition === 'cloud'
                     ? 'Every record we hold for you, straight from the database — accounts, transactions, splits, categories, budgets, goals, investments and the rest.'
                     : 'Everything this browser is holding — accounts, transactions, splits, categories, budgets and goals. Nothing here has been sent anywhere, so this file is the only copy that exists.'}
                   {' '}This is the only export that can be restored: Settings &rarr; Data Management

--- a/src/pages/__tests__/EnhancedImport.msMoney.test.tsx
+++ b/src/pages/__tests__/EnhancedImport.msMoney.test.tsx
@@ -110,7 +110,15 @@ describe('EnhancedImport — where a Microsoft Money migration lands', () => {
     run.reports = [];
     run.outcome = null;
     seam.importMsMoney.mockResolvedValue(undefined);
-    __setAppContextValue({ isUsingSupabase: false });
+    __setAppContextValue({
+      capabilities: {
+        edition: 'device',
+        session: 'anonymous',
+        realtime: false,
+        maxConcurrentWrites: 1,
+        backupTarget: 'device',
+      },
+    });
   });
 
   afterEach(() => {
@@ -135,8 +143,17 @@ describe('EnhancedImport — where a Microsoft Money migration lands', () => {
     // The same call, under the condition the page used to branch on. Kept as a
     // separate test rather than deleted with the branch: the point of the slice
     // is that this makes no difference here, and a test that says so is how
-    // that stays true.
-    __setAppContextValue({ isUsingSupabase: true });
+    // that stays true. The condition is spelled as the seam's descriptor now —
+    // the flag it used to be read from is gone.
+    __setAppContextValue({
+      capabilities: {
+        edition: 'cloud',
+        session: 'ready',
+        realtime: true,
+        maxConcurrentWrites: 8,
+        backupTarget: 'login',
+      },
+    });
 
     renderPage();
     await runTheMigration();

--- a/src/pages/__tests__/ExportManager.test.tsx
+++ b/src/pages/__tests__/ExportManager.test.tsx
@@ -90,7 +90,17 @@ const appValue = {
   transactionSplits: [],
   categories,
   budgets: [],
-  isUsingSupabase: false
+  // The seam's capability descriptor, as a device answers it. This page reads
+  // exactly one field of it, for one sentence of copy on the full-backup card;
+  // it is here because the page would throw without it, not because anything
+  // below asserts on it.
+  capabilities: {
+    edition: 'device' as const,
+    session: 'anonymous' as const,
+    realtime: false,
+    maxConcurrentWrites: 1,
+    backupTarget: 'device' as const
+  }
 };
 
 vi.mock('../../contexts/AppContextSupabase', () => ({
@@ -134,7 +144,13 @@ describe('Export Data page', () => {
   beforeEach(async () => {
     localStorage.clear();
     downloads.length = 0;
-    appValue.isUsingSupabase = false;
+    appValue.capabilities = {
+      edition: 'device',
+      session: 'anonymous',
+      realtime: false,
+      maxConcurrentWrites: 1,
+      backupTarget: 'device'
+    };
     seam.collectBackup.mockReset();
 
     // A fresh module graph per test, so each one gets the exportService

--- a/src/pages/settings/DataManagement.tsx
+++ b/src/pages/settings/DataManagement.tsx
@@ -67,7 +67,11 @@ const wipePercent = (progress: WipeProgress): number => {
 };
 
 export default function DataManagementSettings() {
-  const { accounts, transactions, budgets, resetLoadedData, isUsingSupabase } = useApp();
+  // `capabilities` is here for TWO SENTENCES of copy on the backup cards below:
+  // whether a backup is a second copy of rows a database holds or the only copy
+  // there is, and whether a restore goes into a login or into this device.
+  // Nothing on this page branches on it — the wipe and the restore ask the seam.
+  const { accounts, transactions, budgets, resetLoadedData, capabilities } = useApp();
   const initialBankingOpsUrlState = useMemo(
     () => parseBankingOpsUrlState(typeof window !== 'undefined' ? window.location.search : ''),
     []
@@ -214,14 +218,14 @@ export default function DataManagementSettings() {
             to="/export-manager"
             icon={DownloadIcon}
             title="Download a backup"
-            description={isUsingSupabase
+            description={capabilities.edition === 'cloud'
               ? 'Every record, straight from the database, as plain JSON'
               : 'Everything this browser holds, as plain JSON — the only copy there is'}
           />
           <ActionButton
             icon={UploadIcon}
             title="Restore from backup"
-            description={isUsingSupabase
+            description={capabilities.edition === 'cloud'
               ? 'Read a backup file back in — only into an empty login'
               : 'Read a backup file back in — only into an empty device'}
             onClick={() => setShowRestoreBackup(true)}

--- a/src/pages/settings/__tests__/DataManagement.deleteAll.test.tsx
+++ b/src/pages/settings/__tests__/DataManagement.deleteAll.test.tsx
@@ -76,7 +76,15 @@ describe('Delete All Data — while it runs', () => {
     wipeScript.hold = null;
     // Signed in with a working cloud. The page no longer picks an engine — the
     // seam does — but this is still what decides the copy on the cards above.
-    __setAppContextValue({ isUsingSupabase: true });
+    __setAppContextValue({
+      capabilities: {
+        edition: 'cloud',
+        session: 'ready',
+        realtime: true,
+        maxConcurrentWrites: 8,
+        backupTarget: 'login',
+      },
+    });
   });
 
   afterEach(() => {
@@ -140,7 +148,15 @@ describe('Delete All Data — when it stops part-way', () => {
     wipeScript.hold = null;
     // Signed in with a working cloud. The page no longer picks an engine — the
     // seam does — but this is still what decides the copy on the cards above.
-    __setAppContextValue({ isUsingSupabase: true });
+    __setAppContextValue({
+      capabilities: {
+        edition: 'cloud',
+        session: 'ready',
+        realtime: true,
+        maxConcurrentWrites: 8,
+        backupTarget: 'login',
+      },
+    });
   });
 
   afterEach(() => {

--- a/src/services/__tests__/dataService.test.ts
+++ b/src/services/__tests__/dataService.test.ts
@@ -3312,3 +3312,97 @@ describe('DataService.importMsMoney (where a whole .mny file lands)', () => {
       .toBe('Import failed while writing transactions: duplicate key value violates unique constraint');
   });
 });
+
+/**
+ * What the engine says it can do — the descriptor that retired the flag.
+ *
+ * `isUsingSupabase` was one boolean answering four unrelated questions: how
+ * many writes may be in flight (the payee rename divides its work by it),
+ * whether to open a realtime subscription, where a backup goes, and whether a
+ * sentence says "login" or "device". Every one of those readings is now a named
+ * field, and this is where the mapping from THIS engine's state to those fields
+ * is pinned.
+ *
+ * The contract suite already asserts the SHAPE against the browser-storage
+ * harness — five fields, a batch size of at least one, a session that is one of
+ * three things. What it cannot reach is the cloud arrangement or the pending
+ * one, because that harness has no cloud by construction. Those are the two
+ * that matter most: 8 concurrent writes against a store that would lose updates
+ * at 2, and the "still connecting" state that must not be mistaken for a
+ * device.
+ */
+describe('DataService.capabilities (what this engine says it can do)', () => {
+  const logger = { error: vi.fn(), warn: vi.fn(), log: vi.fn() };
+
+  const owner = (databaseId: string | null) => ({
+    ensureUserExists: vi.fn(),
+    getCurrentDatabaseUserId: vi.fn(() => databaseId),
+    getCurrentUserIds: vi.fn(() => ({ clerkId: databaseId ? 'clerk-1' : null, databaseId }))
+  });
+
+  const service = (options: { configured: boolean; clerkSession: boolean; databaseId: string | null }) =>
+    createDataService({
+      isSupabaseConfigured: () => options.configured,
+      hasCloudSession: () => options.clerkSession,
+      userIdService: owner(options.databaseId),
+      logger
+    });
+
+  it('reports a login that is resolved as a cloud edition, eight writes wide', () => {
+    const capabilities = service({ configured: true, clerkSession: true, databaseId: 'db-user-1' })
+      .capabilities();
+
+    expect(capabilities).toEqual({
+      edition: 'cloud',
+      session: 'ready',
+      realtime: true,
+      maxConcurrentWrites: 8,
+      backupTarget: 'login'
+    });
+  });
+
+  it('reports a session that is still connecting, and refuses to call it a device', () => {
+    // The state with the data loss behind it: signed in, no database id yet.
+    // 'anonymous' here would tell the restore dialog it was looking at a device
+    // and let a file be poured into browser storage the signed-in app will
+    // never read again. The backup target stays 'device' — there is no login to
+    // name — which is why the dialog checks the SESSION before the target.
+    const capabilities = service({ configured: true, clerkSession: true, databaseId: null })
+      .capabilities();
+
+    expect(capabilities.session).toBe('connecting');
+    expect(capabilities.backupTarget).toBe('device');
+    expect(capabilities.realtime).toBe(false);
+  });
+
+  it('reports one write at a time when there is no cloud behind it', () => {
+    // Not a slow default — a correct one. Browser storage re-reads and
+    // re-persists a whole collection per write, so two in flight is a
+    // lost-update race in which the second silently overwrites the first.
+    const capabilities = service({ configured: false, clerkSession: false, databaseId: null })
+      .capabilities();
+
+    expect(capabilities).toEqual({
+      edition: 'device',
+      session: 'anonymous',
+      realtime: false,
+      maxConcurrentWrites: 1,
+      backupTarget: 'device'
+    });
+  });
+
+  it('is not a login when the id is stale and the client is gone', () => {
+    // A cached database id with no configured client is not a login: nothing
+    // can be read from or written to one. Every field follows `isSupabaseReady`
+    // rather than the id alone, so the backup target cannot say 'login' while
+    // the store behind it is a browser.
+    const capabilities = service({ configured: false, clerkSession: false, databaseId: 'db-user-1' })
+      .capabilities();
+
+    expect(capabilities.edition).toBe('device');
+    expect(capabilities.backupTarget).toBe('device');
+    // The owner IS resolved, and the session says so — it is the store that is
+    // not a cloud one.
+    expect(capabilities.session).toBe('ready');
+  });
+});

--- a/src/services/api/dataService.ts
+++ b/src/services/api/dataService.ts
@@ -37,6 +37,7 @@ import type {
   BulkImportProgress,
   BulkImportResult,
   DataPort,
+  DataPortCapabilities,
   ExportProgress,
   ImportProgress,
   ImportSourceKind,
@@ -776,9 +777,10 @@ class DataServiceImpl implements DataPort {
    * one-IndexedDB-transaction writer. What changed is who decides between them
    * — it was the CSV wizard and the OFX dialog, each reading `isUsingSupabase`
    * off the context and each holding its own Clerk token, and it is now this
-   * one line. The predicate is the same one `DataService.isUsingSupabase()`
-   * answers with, evaluated at the moment of the write rather than at the boot
-   * that last set that state.
+   * one line. The predicate is `isSupabaseReady()` — the one the retired
+   * `isUsingSupabase` answered with, and the one `capabilities()` reports —
+   * evaluated at the moment of the write rather than at the boot that last set
+   * that state.
    *
    * THE TOKEN IS THE SEAM'S OWN. The dialogs used to hand the client a
    * `() => getToken()` closure out of Clerk's React hook immediately before
@@ -2521,29 +2523,46 @@ class DataServiceImpl implements DataPort {
     };
   }
 
-  isUsingSupabase(): boolean {
-    return this.isSupabaseReady();
-  }
-
   /**
-   * NEVER JOINS THE SEAM, and is down to its last consumer.
+   * What this implementation can do — the answer that replaced four separate
+   * readings of one boolean.
    *
-   * Identity is internal to an implementation (rule 1 of the port), so this is
-   * the opposite of what the seam promises — it exists only because two screens
-   * still choose their own WORDS from it. The data operations that used to
-   * branch on it are all gone: the export, the emptiness check, the restore,
-   * the wipe and the Money migration each resolve their own owner now.
+   * Every field below is computed from `isSupabaseReady()` (a database id is
+   * resolved AND a client is configured) or from the pending state beside it,
+   * which is why one descriptor could retire `isUsingSupabase` without changing
+   * a single answer: the batch size, the realtime gate, the backup target and
+   * the copy on two screens were all asking that same predicate in four
+   * different vocabularies. What changes is that each now says what it is FOR,
+   * so an implementation that is neither Supabase nor a browser can answer them
+   * independently — a device edition with a sync peer says `realtime: true`
+   * without claiming to be a login.
    *
-   * What is left is one file. RestoreBackupModal reads it to decide whether the
-   * dialog says "login" or "device", whether a failed restore warns about a
-   * partly-populated store, and whether a signed-in session is still connecting
-   * and must be blocked from starting. All three are capability questions, and
-   * they leave with `capabilities()` — at which point this method and its static
-   * twin are deleted, and the fact that nothing calls them IS the proof the
-   * seam closed.
+   * SYNCHRONOUS AND UNCACHED. Every caller is a render or the tick of a write,
+   * and `session` in particular changes underneath them as a sign-in completes;
+   * a cached descriptor would be a boot-time photograph of a value that moves.
+   * Nothing here does I/O — two booleans and an in-memory id — so re-asking is
+   * cheaper than remembering.
    */
-  getUserIds(): { clerkId: string | null; databaseId: string | null } {
-    return this.userIdService.getCurrentUserIds();
+  capabilities(): DataPortCapabilities {
+    const ready = this.isSupabaseReady();
+    return {
+      edition: ready ? 'cloud' : 'device',
+      // The pending state is checked FIRST because it is the one that is not
+      // safe to work in: a signed-in session with no database id yet is not
+      // 'anonymous' — treating it as such is exactly how a write ends up in a
+      // browser store the signed-in app will never read again.
+      session: this.isCloudSessionPending()
+        ? 'connecting'
+        : (this.userIdService.getCurrentDatabaseUserId() ? 'ready' : 'anonymous'),
+      realtime: ready,
+      // 8 in the cloud, where each write is an independent request; 1 on a
+      // store that re-reads and re-persists a whole collection per write, where
+      // two in flight is a lost-update race. Stated on the seam so the caller
+      // no longer has to know which engine it is talking to in order to loop
+      // safely over a few thousand rows.
+      maxConcurrentWrites: ready ? 8 : 1,
+      backupTarget: ready ? 'login' : 'device'
+    };
   }
 }
 
@@ -2807,12 +2826,8 @@ export class DataService {
     return this.service.subscribeToUpdates(callbacks);
   }
 
-  static isUsingSupabase(): boolean {
-    return this.service.isUsingSupabase();
-  }
-
-  static getUserIds(): { clerkId: string | null; databaseId: string | null } {
-    return this.service.getUserIds();
+  static capabilities(): DataPortCapabilities {
+    return this.service.capabilities();
   }
 }
 

--- a/src/services/port/__tests__/contract.ts
+++ b/src/services/port/__tests__/contract.ts
@@ -192,7 +192,9 @@ export const DATA_PORT_OPERATIONS: readonly (keyof DataPort)[] = [
   // Lifecycle
   'initialize',
   'prepareCategories',
-  'subscribeToUpdates'
+  'subscribeToUpdates',
+  // What the engine can do
+  'capabilities'
 ];
 
 // ── Declared divergences ────────────────────────────────────────────────────
@@ -613,6 +615,50 @@ export function runDataPortContract(name: string, harness: DataPortContractHarne
 
         const missing = DATA_PORT_OPERATIONS.filter(operation => typeof port[operation] !== 'function');
         expect(missing).toEqual([]);
+      });
+
+      it('describes what it can do, synchronously and completely', async () => {
+        // The capability descriptor is the one answer every OTHER answer in
+        // this suite is allowed to differ on — it is how an engine declares its
+        // own divergences instead of the app guessing them. So its shape is a
+        // contract in a way none of the data shapes are: a missing field is not
+        // a wrong number on a screen, it is `undefined` flowing into a batch
+        // size, a subscription gate, or the sentence that tells somebody
+        // whether the file they just downloaded is their only copy.
+        const { port } = await harness.create({ accounts: [] });
+
+        const capabilities = port.capabilities();
+
+        // Synchronous, and that is load-bearing rather than stylistic: every
+        // consumer is a render or the tick of a write. A promise here would put
+        // a loading state in front of a sentence.
+        expect(capabilities).not.toBeInstanceOf(Promise);
+
+        expect(Object.keys(capabilities).sort()).toEqual([
+          'backupTarget',
+          'edition',
+          'maxConcurrentWrites',
+          'realtime',
+          'session'
+        ]);
+        expect(['cloud', 'device']).toContain(capabilities.edition);
+        expect(['ready', 'connecting', 'anonymous']).toContain(capabilities.session);
+        expect(typeof capabilities.realtime).toBe('boolean');
+        expect(['login', 'device']).toContain(capabilities.backupTarget);
+
+        // AT LEAST ONE, ALWAYS. Callers divide work into batches of this
+        // number: a 0 is an infinite loop over somebody's transactions, and a
+        // fraction is a slice() that never advances. An engine that is unsure
+        // says 1 — one write at a time is slow, never wrong.
+        expect(Number.isInteger(capabilities.maxConcurrentWrites)).toBe(true);
+        expect(capabilities.maxConcurrentWrites).toBeGreaterThanOrEqual(1);
+
+        // A store whose owner has not resolved is not a login. Backups are the
+        // operation where naming the wrong store costs the most — the file is
+        // the only copy — so the implication is asserted rather than assumed.
+        if (capabilities.backupTarget === 'login') {
+          expect(capabilities.session).toBe('ready');
+        }
       });
     });
 

--- a/src/services/port/__tests__/editionIsCopyOnly.test.ts
+++ b/src/services/port/__tests__/editionIsCopyOnly.test.ts
@@ -1,0 +1,132 @@
+/**
+ * `capabilities.edition` IS COPY. Enforced with a grep, on purpose.
+ *
+ * The descriptor exists because one boolean — "are we on Supabase?" — was being
+ * asked four unrelated questions: how many writes may be in flight, whether to
+ * open a realtime subscription, where a backup goes, and whether a sentence
+ * says "login" or "device". Splitting it into four named capabilities only
+ * helps if the fifth field does not quietly become the fifth version of the old
+ * boolean. `edition` is that fifth field: it is the app's WORD for which
+ * edition somebody is using, and the moment production code writes
+ * `if (edition === 'cloud')` the flag is back, an engine that is neither of
+ * today's two is unrepresentable again, and the seam has bought nothing.
+ *
+ * WHY A GREP AND NOT A TYPE. There is no type that says "this value may be
+ * rendered but not branched on" — a string union is a string union, and TypeScript
+ * cannot tell an `if` from a ternary between two literals. The rule is about
+ * WHERE a value may appear in the source, so the check reads the source. Crude,
+ * and exactly the right size: it takes ten lines, it cannot be argued with, and
+ * it fails on the diff that introduces the branch rather than in an audit two
+ * years later.
+ *
+ * The rule, stated precisely: in production code (no tests, no type
+ * declarations), every reference to `capabilities.edition` must be preceded by
+ * `{`. In TSX that is a JSX expression container — `{capabilities.edition === …}`
+ * as a child, or `attr={capabilities.edition === …}` as an attribute. Every other
+ * position fails: `if (capabilities.edition` is preceded by a space,
+ * `const e = capabilities.edition` by a space, `fn(capabilities.edition)` by a
+ * parenthesis. Destructuring is barred separately, since `const { edition } = …`
+ * would smuggle the value out to any position at all.
+ *
+ * What the rule deliberately does NOT police: the other four fields. Those are
+ * capabilities rather than words, and branching on them is the entire point.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { readdirSync, statSync, readFileSync } from 'node:fs';
+import path from 'node:path';
+
+const SRC = path.resolve(__dirname, '../../..');
+
+/** Where the seam DECLARES and BUILDS the field, as opposed to reading it. */
+const DEFINITION_FILES = new Set([
+  path.join(SRC, 'services', 'port', 'dataPort.ts'),
+  path.join(SRC, 'services', 'api', 'dataService.ts')
+]);
+
+const isTestPath = (file: string): boolean =>
+  /(^|[\\/])__tests__[\\/]/.test(file) ||
+  /\.(test|spec)\.tsx?$/.test(file) ||
+  /(^|[\\/])src[\\/]test[\\/]/.test(file);
+
+function productionFiles(dir: string, out: string[] = []): string[] {
+  for (const entry of readdirSync(dir)) {
+    if (entry === 'node_modules' || entry === 'dist' || entry.startsWith('.')) continue;
+    const full = path.join(dir, entry);
+    if (statSync(full).isDirectory()) {
+      productionFiles(full, out);
+    } else if (/\.tsx?$/.test(entry) && !isTestPath(full) && !DEFINITION_FILES.has(full)) {
+      out.push(full);
+    }
+  }
+  return out;
+}
+
+interface Reference {
+  file: string;
+  line: number;
+  text: string;
+  /** The character immediately before the reference, or '' at line start. */
+  precededBy: string;
+}
+
+const references = (): Reference[] => {
+  const found: Reference[] = [];
+  for (const file of productionFiles(SRC)) {
+    const source = readFileSync(file, 'utf8');
+    if (!source.includes('capabilities.edition')) continue;
+    source.split('\n').forEach((text, index) => {
+      let at = text.indexOf('capabilities.edition');
+      while (at !== -1) {
+        found.push({
+          file: path.relative(SRC, file),
+          line: index + 1,
+          text: text.trim(),
+          precededBy: at === 0 ? '' : text[at - 1]
+        });
+        at = text.indexOf('capabilities.edition', at + 1);
+      }
+    });
+  }
+  return found;
+};
+
+describe('capabilities().edition is copy, and only copy', () => {
+  it('appears in production only inside a JSX expression', () => {
+    const outsideJsx = references().filter(reference => reference.precededBy !== '{');
+
+    // Named rather than counted: a failure here has to tell whoever wrote the
+    // line WHICH line, because the fix is never "delete the assertion" — it is
+    // "the thing you wanted is one of the other four capabilities".
+    expect(
+      outsideJsx.map(reference => `${reference.file}:${reference.line} — ${reference.text}`)
+    ).toEqual([]);
+  });
+
+  it('is still rendered somewhere, so this file cannot pass by describing nothing', () => {
+    // The companion assertion, and not a formality: the rule above is
+    // vacuously true of a codebase that stopped saying "login" or "device"
+    // altogether. It is satisfied today by the Export page's full-backup card
+    // and the two backup cards in Data Management — the three sentences that
+    // tell somebody whether the file they are about to download is a second
+    // copy or the only one.
+    expect(references().length).toBeGreaterThanOrEqual(3);
+  });
+
+  it('is never destructured out of the descriptor', () => {
+    // `const { edition } = capabilities` would hand the value to a plain
+    // identifier, and every position rule above is about the text
+    // `capabilities.edition`. This is the one hole worth closing by hand.
+    const smuggled: string[] = [];
+    for (const file of productionFiles(SRC)) {
+      const source = readFileSync(file, 'utf8');
+      if (!source.includes('edition')) continue;
+      source.split('\n').forEach((text, index) => {
+        if (/\{[^}]*\bedition\b[^}]*\}\s*=/.test(text)) {
+          smuggled.push(`${path.relative(SRC, file)}:${index + 1} — ${text.trim()}`);
+        }
+      });
+    }
+    expect(smuggled).toEqual([]);
+  });
+});

--- a/src/services/port/dataPort.ts
+++ b/src/services/port/dataPort.ts
@@ -45,10 +45,11 @@
  * Bulk import has joined it (the CSV and OFX importers write through
  * `importTransactions`), and so have the backup, the emptiness check, the
  * restore, the wipe and the Microsoft Money migration. The capability
- * descriptor that will retire `isUsingSupabase` joins as its consumers are
- * routed through it in turn. The names here are today's names
- * deliberately: renaming and re-routing in one step would make a rename
- * indistinguishable from a behaviour change in review.
+ * descriptor has joined too, and with it went the last question the app asked
+ * about its engine BY NAME: nothing above this file says `isUsingSupabase` any
+ * more. The names here are today's names deliberately: renaming and re-routing
+ * in one step would make a rename indistinguishable from a behaviour change in
+ * review.
  */
 
 import type {
@@ -931,6 +932,111 @@ export interface DataPortLifecycle {
   }): () => void;
 }
 
+/**
+ * WHICH EDITION IS ANSWERING — for words, and for nothing else.
+ *
+ * The one field on this descriptor that exists purely so a screen can say
+ * "login" or "device" in a sentence a person reads. It is NOT a routing
+ * question and no production code may branch on it: every decision that used to
+ * be taken from `isUsingSupabase` is a named capability below, and each of those
+ * says what it actually governs (can this store push changes to me? how many
+ * writes may be in flight? where does a backup go?). The moment a caller writes
+ * `if (edition === 'cloud')` it has re-invented the flag this descriptor
+ * retired, and the next engine — one that is neither of these two — is back to
+ * being unrepresentable.
+ *
+ * That rule is enforced rather than requested: a test greps the source tree and
+ * fails on any production reference to `capabilities.edition` outside a JSX
+ * expression. Crude on purpose. A rule about where a word may appear is exactly
+ * the kind a grep can hold and a type cannot.
+ */
+export type Edition = 'cloud' | 'device';
+
+/**
+ * Whether this implementation knows WHOSE data it is holding, right now.
+ *
+ * - 'ready' — an owner is resolved; reads and writes land where they should.
+ * - 'connecting' — a sign-in is in progress and the owner has NOT resolved yet.
+ *   The dangerous state, and the reason this is on the descriptor at all: a
+ *   write attempted here has no owner to stamp, and an implementation that
+ *   quietly fell back to a device-local store would put a signed-in person's
+ *   data somewhere their app will never read again. Screens that start
+ *   irreversible work (a restore, a wipe) refuse while this is the answer.
+ * - 'anonymous' — nobody is signing in. Demo mode, a signed-out browser, a
+ *   device edition that has no logins at all. This is a perfectly good state to
+ *   work in, and is not a degraded 'ready'.
+ */
+export type SessionState = 'ready' | 'connecting' | 'anonymous';
+
+/**
+ * What this implementation can do, answered SYNCHRONOUSLY.
+ *
+ * Synchronous is a requirement rather than a convenience: every consumer is a
+ * render — copy on a card, a batch size chosen on the tick of a write, a gate
+ * on opening a subscription — and an async capability check would put a
+ * loading state in front of a sentence, or a promise in the middle of a for
+ * loop. An implementation that cannot answer these five without I/O is being
+ * asked the wrong question; each one is a property of the engine, not of the
+ * data in it.
+ *
+ * It is also a SNAPSHOT. Nothing here is a subscription: `session` in particular
+ * changes as a sign-in completes, and a caller that cached this descriptor at
+ * boot and read it an hour later would be reading history. Callers re-ask.
+ */
+export interface DataPortCapabilities {
+  /** WORDS ONLY. See {@link Edition} — no production code may branch on this. */
+  edition: Edition;
+  /** Whether an owner is resolved. See {@link SessionState}. */
+  session: SessionState;
+  /**
+   * Whether changes made somewhere else arrive here on their own.
+   *
+   * `subscribeToUpdates` is safe to call either way — an implementation with
+   * nothing to listen to hands back a no-op unsubscribe — so this is not a
+   * guard against calling it. It is what lets a caller skip the machinery
+   * AROUND a subscription (debounce timers, suppression windows, teardown
+   * bookkeeping) that exists solely to cope with events that will never arrive.
+   */
+  realtime: boolean;
+  /**
+   * How many writes a caller may have in flight at once, ALWAYS at least 1.
+   *
+   * Not a performance hint — a correctness one, and the number is the engine's
+   * to state because only the engine knows what its writes cost each other. In
+   * the cloud each write is an independent request that lands on its own row, so
+   * a handful at a time keeps a few thousand renames tolerable without opening a
+   * few thousand sockets. A store that re-reads and re-persists a whole
+   * collection per write has no such freedom: two in flight is a lost-update
+   * race, and the second write silently overwrites the first from a snapshot
+   * taken before it. So the safe answer is 1, and 1 is what every engine that is
+   * not sure must say.
+   */
+  maxConcurrentWrites: number;
+  /**
+   * Where a backup taken now would come FROM, and be restored INTO.
+   *
+   * 'login' means an account somewhere else holds the rows and a file is a
+   * second copy of them; 'device' means the file is the ONLY copy that exists,
+   * which is a materially different thing to tell somebody before they close the
+   * tab. The two screens that offer backups say exactly that, and this is what
+   * they say it from.
+   *
+   * 'login' implies `session === 'ready'`: a store whose owner has not resolved
+   * is not a login, and offering to read somebody's whole ledger out of one that
+   * cannot be named is how a backup ends up full of the wrong data. The contract
+   * suite asserts the implication.
+   */
+  backupTarget: 'login' | 'device';
+}
+
+export interface DataPortCapabilityDescriptor {
+  /**
+   * What this implementation can do. Cheap, synchronous, and safe to call in a
+   * render — see {@link DataPortCapabilities}.
+   */
+  capabilities(): DataPortCapabilities;
+}
+
 /** The whole seam as it stands. */
 export interface DataPort extends
   DataPortReads,
@@ -943,4 +1049,5 @@ export interface DataPort extends
   DataPortDismissalWrites,
   DataPortBackupLifecycle,
   DataPortMigration,
-  DataPortLifecycle {}
+  DataPortLifecycle,
+  DataPortCapabilityDescriptor {}

--- a/src/services/port/index.ts
+++ b/src/services/port/index.ts
@@ -28,6 +28,8 @@ export type {
   DataPortAccountWrites,
   DataPortBackupLifecycle,
   DataPortBulkWrites,
+  DataPortCapabilities,
+  DataPortCapabilityDescriptor,
   DataPortDismissalWrites,
   DataPortLifecycle,
   DataPortMigration,
@@ -36,12 +38,14 @@ export type {
   DataPortSplitWrites,
   DataPortTransactionWrites,
   DataPortTransferWrites,
+  Edition,
   ExportProgress,
   ImportProgress,
   ImportSourceKind,
   MoneyNumber,
   MsMoneyImportResult,
   RestoreProgress,
+  SessionState,
   WipeProgress
 } from './dataPort';
 

--- a/src/test/mocks/AppContextSupabase.ts
+++ b/src/test/mocks/AppContextSupabase.ts
@@ -7,6 +7,7 @@ import {
 } from '../../data/defaultTestData';
 import { getDefaultCategories } from '../../data/defaultCategories';
 import type { Category, DismissalKind, SuggestionDismissal } from '../../types';
+import type { DataPortCapabilities } from '../../services/port';
 import type { TestDataSeedResult } from '../../utils/testDataset';
 import type {
   DecimalAccount,
@@ -24,6 +25,29 @@ const categories = getDefaultCategories();
 const noop = () => {};
 const asyncNoop = async () => {};
 
+/**
+ * The seam's capability descriptor, as a device answers it.
+ *
+ * Device rather than cloud on purpose: this stands in for the value the real
+ * context surfaces, and every suite that renders against this mock without
+ * saying otherwise used to read a boot flag that was plainly false. Keeping the
+ * default falsy-equivalent means a page's copy reads the same here as it did
+ * before the descriptor existed, and the two suites that care about the other
+ * edition say so explicitly (`__setAppContextValue({ capabilities: … })`).
+ *
+ * Present at all because of what happens when it is not: every consumer reads
+ * `capabilities.session` / `.backupTarget` on its FIRST render, and an
+ * undefined descriptor is not a wrong answer on screen — it is a TypeError
+ * thrown out of a component that has nothing to do with capabilities.
+ */
+const deviceCapabilities: DataPortCapabilities = {
+  edition: 'device',
+  session: 'anonymous',
+  realtime: false,
+  maxConcurrentWrites: 1,
+  backupTarget: 'device',
+};
+
 const baseValue = {
   accounts,
   transactions,
@@ -32,6 +56,7 @@ const baseValue = {
   goals,
   tags: [],
   isLoading: false,
+  capabilities: deviceCapabilities,
   resetLoadedData: asyncNoop,
   exportData: () => JSON.stringify({ accounts, transactions, budgets, goals, categories }),
   // Async and counting, like the real thing: callers await it and read the

--- a/src/types/app-state.ts
+++ b/src/types/app-state.ts
@@ -26,9 +26,13 @@ export interface AppState {
   investments?: Investment[]; // Optional for backward compatibility
 
   // State flags
+  //
+  // Two used to live here. `isSyncing` was read by nothing and set by nothing —
+  // a whole-app refresh that once flipped it had been removed — and
+  // `isUsingSupabase` was the app asking which product was behind its data,
+  // which the seam's capability descriptor now answers per question rather than
+  // as one boolean (see DataPortCapabilities).
   isLoading: boolean;
-  isSyncing: boolean;
-  isUsingSupabase: boolean;
 
   // Sync metadata
   lastSyncTime: Date | null;


### PR DESCRIPTION
The write-paths campaign's finale (slice 12 cosmetics excepted).

- **`capabilities()`** answers what storage can do: `edition` (copy-only, enforced by a grep-shaped test with an anti-vacuity floor and a destructuring ban), `session`, `realtime`, `maxConcurrentWrites` (a new test measures peak in-flight writes — the batching had zero real coverage), `backupTarget`. Cross-field contract: `backupTarget==='login' ⟹ session==='ready'`.
- Surfaced from the boot's **finally**, not the success path — the old flag stayed false when a boot resolved a login then threw, describing a signed-in app as a device and pointing the restore dialog at browser storage. Boot-frozen by design; every reachable transition re-runs the boot, and the one divergent case (failed identity) now reads `connecting` and refuses — the safe answer.
- **Deleted**: `isUsingSupabase` (everywhere), `isSyncing` (zero readers), `getUserIds` — with the grep proving zero code references, which is the plan's own success criterion: nothing above the seam needs a database id. Export snapshots drop two keys, one a hardcoded lie; old files restore unchanged (verified).
- **Dashboard's Postgres import deleted**: it fed a boolean read by nothing, re-querying on every account change.
- Three mutations red on cue (edition-as-logic; batch-size 8 on a device; capabilities dropped from the boot stub).
- Owed: six copy screenshots (both editions × three cards) — the ternary branches are byte-identical, only predicates changed; citations in the trail.

Gate: lint · strict tsc · smoke 4,918 · realtime 227 · build · bundle ±0.0/−0.1 KB gz · coverage 75.22/81.30 vs 63/55.

🤖 Generated with [Claude Code](https://claude.com/claude-code)