### PR TITLE
feat(seam): slice 12 — the port's vocabulary tells the truth (campaign complete)

### DIFF
--- a/src/components/QIFImportModal.tsx
+++ b/src/components/QIFImportModal.tsx
@@ -46,8 +46,6 @@ type ImportOutcome =
       invalidDates: number;
       matchedCategories: number;
       unmatchedCategories: { name: string; count: number }[];
-      /** False when a chunk failed partway — imported < intended. */
-      complete: boolean;
       account: Account | null;
     }
   | {
@@ -219,6 +217,12 @@ export default function QIFImportModal({ isOpen, onClose, initialFile }: QIFImpo
       // register shows what was actually written, including after a partial.
       await refreshAccountsAndTransactions();
 
+      // A partial import is a FAILURE on this screen, not a qualified success:
+      // whatever landed is already in the register (the refresh above put it
+      // there), so what the user needs is the number that did not. Everything
+      // past this line therefore describes a whole file — which is why the
+      // outcome below has no "complete" flag of its own to carry a value it
+      // could only ever hold.
       if (!outcome.complete) {
         throw new Error(
           `Imported ${outcome.inserted} of ${outcome.total} transactions before an error stopped the import.`
@@ -236,7 +240,6 @@ export default function QIFImportModal({ isOpen, onClose, initialFile }: QIFImpo
         invalidDates: result.invalidDates,
         matchedCategories: result.matchedCategories,
         unmatchedCategories: result.unmatchedCategories,
-        complete: outcome.complete,
         account
       });
     } catch (error) {

--- a/src/contexts/AppContextSupabase.tsx
+++ b/src/contexts/AppContextSupabase.tsx
@@ -75,7 +75,7 @@ export interface AppContextType extends AppState {
   // Account operations
   addAccount: (account: Omit<Account, 'id'> & { initialBalance?: number }) => Promise<Account>;
   updateAccount: (id: string, updates: AccountUpdate) => Promise<void>;
-  deleteAccount: (id: string) => Promise<void>;
+  closeAccount: (id: string) => Promise<void>;
 
   // Transaction operations — async so callers can surface save failures.
   addTransaction: (transaction: Omit<Transaction, 'id'>) => Promise<void>;
@@ -474,7 +474,7 @@ export function AppProvider({ children }: { children: React.ReactNode }) {
             // itself (ensureUserExists sets it), so this asks the same
             // question of the same table through the same row mapper — and it
             // stops the boot naming a service, which is the point.
-            const accounts = await dataPort.getAccounts();
+            const accounts = await dataPort.listAccounts();
             appLogger.info('Accounts loaded', { count: accounts.length });
             setAccounts(accounts);
             markPhase('accounts');
@@ -528,7 +528,7 @@ export function AppProvider({ children }: { children: React.ReactNode }) {
         // the boot's transactions, this read has no "empty is an honest answer"
         // story to tell, and the refresh sites below share the same handling.
         try {
-          setTransactionSplitsState(await dataPort.getAllTransactionSplits());
+          setTransactionSplitsState(await dataPort.listTransactionSplits());
         } catch (splitError) {
           appLogger.error('Failed to load transaction splits', splitError);
           setTransactionSplitsState([]);
@@ -547,7 +547,7 @@ export function AppProvider({ children }: { children: React.ReactNode }) {
         // unread. A signed-in boot never evaluates the await below, so its
         // sequence of awaits is exactly what it was.
         if (!user) {
-          const localAccounts = await dataPort.getAccounts();
+          const localAccounts = await dataPort.listAccounts();
           if (localAccounts.length > 0) {
             setAccounts(localAccounts);
           }
@@ -562,8 +562,8 @@ export function AppProvider({ children }: { children: React.ReactNode }) {
         // served the browser's budgets in a signed-in session with no error to
         // show for it.
         const [loadedBudgets, loadedGoals] = await Promise.all([
-          dataPort.getBudgets(),
-          dataPort.getGoals()
+          dataPort.listBudgets(),
+          dataPort.listGoals()
         ]);
         setBudgets(loadedBudgets);
         setGoals(loadedGoals);
@@ -701,19 +701,19 @@ export function AppProvider({ children }: { children: React.ReactNode }) {
                 // port has no captured id to re-resolve — it answers [] while a
                 // session is still connecting, and never reaches for another
                 // login's rows.
-                const updatedAccounts = await dataPort.getAccounts();
+                const updatedAccounts = await dataPort.listAccounts();
                 appLogger.debug('Accounts reloaded', { count: updatedAccounts.length });
                 setAccounts(updatedAccounts);
                 setLastSyncTime(new Date());
 
                 // Also refresh transactions to update account balances
-                const updatedTransactions = await dataPort.getTransactions();
+                const updatedTransactions = await dataPort.listTransactions();
                 setTransactions(updatedTransactions);
 
                 // Splits ride along — without this, a split edited on another
                 // device leaves this device's category views stale.
                 try {
-                  setTransactionSplitsState(await dataPort.getAllTransactionSplits());
+                  setTransactionSplitsState(await dataPort.listTransactionSplits());
                 } catch (splitError) {
                   appLogger.error('Failed to refresh transaction splits', splitError);
                 }
@@ -724,19 +724,19 @@ export function AppProvider({ children }: { children: React.ReactNode }) {
               
               debouncedUpdate('transaction', async () => {
                 // Reload transactions when any change happens
-                const updatedTransactions = await dataPort.getTransactions();
+                const updatedTransactions = await dataPort.listTransactions();
                 setTransactions(updatedTransactions);
 
                 // Splits ride along — without this, a split edited on another
                 // device leaves this device's category views stale.
                 try {
-                  setTransactionSplitsState(await dataPort.getAllTransactionSplits());
+                  setTransactionSplitsState(await dataPort.listTransactionSplits());
                 } catch (splitError) {
                   appLogger.error('Failed to refresh transaction splits', splitError);
                 }
 
                 // Also refresh accounts to update balances
-                const updatedAccounts = await dataPort.getAccounts();
+                const updatedAccounts = await dataPort.listAccounts();
                 setAccounts(updatedAccounts);
                 setLastSyncTime(new Date());
               });
@@ -802,13 +802,13 @@ export function AppProvider({ children }: { children: React.ReactNode }) {
   }, []);
 
   // Narrow refresh for the bank-sync path: only accounts + transactions come from
-  // Supabase here (getAccounts/getTransactions route to the cloud services), so we
+  // Supabase here (listAccounts/listTransactions route to the cloud services), so we
   // never touch budgets/goals/categories which load from a different source.
   const refreshAccountsAndTransactions = useCallback(async () => {
     try {
       const [updatedAccounts, updatedTransactions] = await Promise.all([
-        dataPort.getAccounts(),
-        dataPort.getTransactions()
+        dataPort.listAccounts(),
+        dataPort.listTransactions()
       ]);
       setAccounts(updatedAccounts);
       setTransactions(updatedTransactions);
@@ -872,14 +872,14 @@ export function AppProvider({ children }: { children: React.ReactNode }) {
     }
   }, []);
 
-  const deleteAccount = useCallback(async (id: string) => {
+  const closeAccount = useCallback(async (id: string) => {
     try {
-      await dataPort.deleteAccount(id);
+      await dataPort.closeAccount(id);
       setAccounts(prev => prev.filter(a => a.id !== id));
       // Also remove related transactions
       setTransactions(prev => prev.filter(t => t.accountId !== id));
     } catch (error) {
-      appLogger.error('Failed to delete account', error);
+      appLogger.error('Failed to close account', error);
       throw error;
     }
   }, []);
@@ -1082,7 +1082,7 @@ export function AppProvider({ children }: { children: React.ReactNode }) {
 
   const getTransactionSplits = useCallback(async (transactionId: string) => {
     try {
-      return await dataPort.getTransactionSplits(transactionId);
+      return await dataPort.listTransactionSplitsFor(transactionId);
     } catch (error) {
       appLogger.error('Failed to load transaction splits', error);
       throw error;
@@ -1102,7 +1102,7 @@ export function AppProvider({ children }: { children: React.ReactNode }) {
       // (rather than synthesising them) so ids match the server's; a failed
       // re-read only staleness-es this transaction's lines until next load.
       try {
-        const freshSplits = result.isSplit ? await dataPort.getTransactionSplits(transactionId) : [];
+        const freshSplits = result.isSplit ? await dataPort.listTransactionSplitsFor(transactionId) : [];
         setTransactionSplitsState(prev => [
           ...prev.filter(s => s.transactionId !== transactionId),
           ...freshSplits,
@@ -1268,7 +1268,7 @@ export function AppProvider({ children }: { children: React.ReactNode }) {
   const refreshSuggestionDismissals = useCallback(async () => {
     setSuggestionDismissalsStatus('loading');
     try {
-      setSuggestionDismissals(await dataPort.getSuggestionDismissals());
+      setSuggestionDismissals(await dataPort.listSuggestionDismissals());
       setSuggestionDismissalsStatus('ready');
     } catch (error) {
       // Never thrown on: a sweep that cannot read the dismissals still has to
@@ -1868,8 +1868,8 @@ export function AppProvider({ children }: { children: React.ReactNode }) {
       await refreshCategories();
     }
     const [reloadedBudgets, reloadedGoals] = await Promise.all([
-      dataPort.getBudgets(),
-      dataPort.getGoals()
+      dataPort.listBudgets(),
+      dataPort.listGoals()
     ]);
     setBudgets(reloadedBudgets);
     setGoals(reloadedGoals);
@@ -1900,7 +1900,7 @@ export function AppProvider({ children }: { children: React.ReactNode }) {
     // Account operations
     addAccount,
     updateAccount,
-    deleteAccount,
+    closeAccount,
     
     // Transaction operations
     addTransaction,

--- a/src/contexts/__tests__/AppContextBootThroughPort.test.tsx
+++ b/src/contexts/__tests__/AppContextBootThroughPort.test.tsx
@@ -187,9 +187,9 @@ vi.mock('../../services/port', () => {
   // operation added to the seam and not answered here turns that test red, and
   // that is how the local edition finds out what it owes.
   const dataPort: DataPort = {
-    getAccounts: answer('getAccounts', seam.accounts),
-    getClosedAccounts: answer('getClosedAccounts', [] as Account[]),
-    getTransactions: answer('getTransactions', seam.transactions),
+    listAccounts: answer('listAccounts', seam.accounts),
+    listClosedAccounts: answer('listClosedAccounts', [] as Account[]),
+    listTransactions: answer('listTransactions', seam.transactions),
     loadBootTransactions: async () => {
       seam.calls.push('loadBootTransactions');
       return {
@@ -203,12 +203,12 @@ vi.mock('../../services/port', () => {
       };
     },
     getAccountBalances: answer('getAccountBalances', seam.balances),
-    getAllTransactionSplits: answer('getAllTransactionSplits', seam.splits),
-    getTransactionSplits: async () => seam.splits,
-    getBudgets: answer('getBudgets', seam.budgets),
-    getGoals: answer('getGoals', seam.goals),
-    getCategories: answer('getCategories', seam.categories),
-    getSuggestionDismissals: answer('getSuggestionDismissals', []),
+    listTransactionSplits: answer('listTransactionSplits', seam.splits),
+    listTransactionSplitsFor: async () => seam.splits,
+    listBudgets: answer('listBudgets', seam.budgets),
+    listGoals: answer('listGoals', seam.goals),
+    listCategories: answer('listCategories', seam.categories),
+    listSuggestionDismissals: answer('listSuggestionDismissals', []),
     prepareCategories: async () => {
       seam.calls.push('prepareCategories');
       if (seam.hold) {
@@ -235,7 +235,7 @@ vi.mock('../../services/port', () => {
     // quietly succeeding. A boot that wrote anything would fail by name here.
     createAccount: refuse('createAccount'),
     updateAccount: refuse('updateAccount'),
-    deleteAccount: refuse('deleteAccount'),
+    closeAccount: refuse('closeAccount'),
     createTransaction: refuse('createTransaction'),
     updateTransaction: refuse('updateTransaction'),
     deleteTransaction: refuse('deleteTransaction'),
@@ -340,14 +340,14 @@ describe('the boot, through the seam and nothing else', () => {
 
     // And the door was actually the door — every boot read went through it.
     expect(new Set(seam.calls)).toEqual(new Set([
-      'getAccounts',
+      'listAccounts',
       'getAccountBalances',
       'prepareCategories',
       'prepareCategories:resolved',
       'loadBootTransactions',
-      'getAllTransactionSplits',
-      'getBudgets',
-      'getGoals',
+      'listTransactionSplits',
+      'listBudgets',
+      'listGoals',
     ]));
   });
 
@@ -396,13 +396,13 @@ describe('the boot, through the seam and nothing else', () => {
     });
 
     const { dataPort } = await import('../../services/port');
-    vi.spyOn(dataPort, 'getBudgets').mockImplementation(async () => {
-      started.push('getBudgets');
+    vi.spyOn(dataPort, 'listBudgets').mockImplementation(async () => {
+      started.push('listBudgets');
       await budgetsInFlight;
       return seam.budgets;
     });
-    vi.spyOn(dataPort, 'getGoals').mockImplementation(async () => {
-      started.push('getGoals');
+    vi.spyOn(dataPort, 'listGoals').mockImplementation(async () => {
+      started.push('listGoals');
       return seam.goals;
     });
 
@@ -410,7 +410,7 @@ describe('the boot, through the seam and nothing else', () => {
 
     // Goals started while budgets were still outstanding: that is what "one
     // Promise.all" means, and two sequential awaits could not produce it.
-    await waitFor(() => expect(started).toEqual(['getBudgets', 'getGoals']));
+    await waitFor(() => expect(started).toEqual(['listBudgets', 'listGoals']));
 
     landBudgets();
     await waitFor(() => expect(result.current.isLoading).toBe(false));

--- a/src/contexts/__tests__/AppContextCategoryTreeImport.test.tsx
+++ b/src/contexts/__tests__/AppContextCategoryTreeImport.test.tsx
@@ -142,9 +142,9 @@ vi.mock('../../services/port', () => {
 
   const dataPort: DataPort = {
     // Boot reads. Empty on purpose: this test is about the categories.
-    getAccounts: async (): Promise<Account[]> => [],
-    getClosedAccounts: async (): Promise<Account[]> => [],
-    getTransactions: async (): Promise<Transaction[]> => seam.transactions,
+    listAccounts: async (): Promise<Account[]> => [],
+    listClosedAccounts: async (): Promise<Account[]> => [],
+    listTransactions: async (): Promise<Transaction[]> => seam.transactions,
     loadBootTransactions: async (): Promise<BootTransactionsResult> => ({
       transactions: seam.transactions,
       stats: {
@@ -155,12 +155,12 @@ vi.mock('../../services/port', () => {
       },
     }),
     getAccountBalances: async (): Promise<ReadonlyMap<string, AccountBalanceSnapshot>> => new Map(),
-    getAllTransactionSplits: async (): Promise<TransactionSplit[]> => [],
-    getTransactionSplits: async (): Promise<TransactionSplit[]> => [],
-    getBudgets: async (): Promise<Budget[]> => [],
-    getGoals: async (): Promise<Goal[]> => [],
-    getCategories: async (): Promise<Category[]> => seam.bootCategories,
-    getSuggestionDismissals: async (): Promise<SuggestionDismissal[]> => [],
+    listTransactionSplits: async (): Promise<TransactionSplit[]> => [],
+    listTransactionSplitsFor: async (): Promise<TransactionSplit[]> => [],
+    listBudgets: async (): Promise<Budget[]> => [],
+    listGoals: async (): Promise<Goal[]> => [],
+    listCategories: async (): Promise<Category[]> => seam.bootCategories,
+    listSuggestionDismissals: async (): Promise<SuggestionDismissal[]> => [],
 
     // The lifecycle read the import finishes on — and the one the boot starts
     // on. Which answer it gives depends on which it is, and that is exactly the
@@ -206,7 +206,7 @@ vi.mock('../../services/port', () => {
     // these would be doing something nobody asked it to.
     createAccount: refuse('createAccount'),
     updateAccount: refuse('updateAccount'),
-    deleteAccount: refuse('deleteAccount'),
+    closeAccount: refuse('closeAccount'),
     createTransaction: refuse('createTransaction'),
     updateTransaction: refuse('updateTransaction'),
     deleteTransaction: refuse('deleteTransaction'),

--- a/src/contexts/__tests__/AppContextRealtimeCleanup.test.tsx
+++ b/src/contexts/__tests__/AppContextRealtimeCleanup.test.tsx
@@ -311,7 +311,7 @@ describe('the boot’s realtime subscription', () => {
     // re-resolved it on every event; the seam reads the id the boot resolved.
     // Both answer the same question today — the point of pinning it is that
     // only one of them can still be answering the PREVIOUS login's question.
-    const portAccounts = vi.spyOn(DataService, 'getAccounts');
+    const portAccounts = vi.spyOn(DataService, 'listAccounts');
 
     renderHook(() => useApp(), { wrapper });
     await waitFor(() => expect(subscriptions).toHaveLength(1));

--- a/src/contexts/__tests__/AppContextSupabase.test.tsx
+++ b/src/contexts/__tests__/AppContextSupabase.test.tsx
@@ -253,7 +253,7 @@ describe('AppContextSupabase live provider', () => {
       expect(result.current.accounts[0].balance).toBe(1000);
     });
 
-    it('deleteAccount removes the account and its transactions', async () => {
+    it('closeAccount takes the account and its transactions out of the live lists', async () => {
       const { result } = await renderApp();
 
       let doomed!: Account;
@@ -277,12 +277,13 @@ describe('AppContextSupabase live provider', () => {
       expect(result.current.transactions).toHaveLength(2);
 
       await act(async () => {
-        await result.current.deleteAccount(doomed.id);
+        await result.current.closeAccount(doomed.id);
       });
 
       expect(result.current.accounts).toHaveLength(1);
       expect(result.current.accounts[0].id).toBe(kept.id);
-      // The deleted account's transactions go with it; others survive.
+      // The closed account's transactions go out of view with it (they are
+      // still in the store — a close is not a delete); others survive.
       expect(result.current.transactions).toHaveLength(1);
       expect(result.current.transactions[0].accountId).toBe(kept.id);
     });

--- a/src/hooks/useAccountNames.ts
+++ b/src/hooks/useAccountNames.ts
@@ -19,7 +19,7 @@ export function useAccountNames(): (id: string) => string {
 
   useEffect(() => {
     let cancelled = false;
-    dataPort.getClosedAccounts()
+    dataPort.listClosedAccounts()
       .then(list => { if (!cancelled) setClosed(list); })
       .catch(() => { /* names fall back to "Unknown account"; nothing breaks */ });
     return () => { cancelled = true; };

--- a/src/pages/AccountTransactions.tsx
+++ b/src/pages/AccountTransactions.tsx
@@ -320,7 +320,7 @@ export default function AccountTransactions() {
     }
     let cancelled = false;
     setClosedLookup({ status: 'loading' });
-    dataPort.getClosedAccounts()
+    dataPort.listClosedAccounts()
       .then(list => {
         if (!cancelled) {
           setClosedLookup({ status: 'done', account: list.find(a => a.id === accountId) ?? null });

--- a/src/pages/Accounts.tsx
+++ b/src/pages/Accounts.tsx
@@ -70,7 +70,7 @@ function readStoredGrouping(): AccountGroupingOptions {
 }
 
 export default function Accounts({ onAccountClick }: { onAccountClick?: (accountId: string) => void }) {
-  const { accounts, transactions, serverBalances, updateAccount, deleteAccount, refreshAccountsAndTransactions, refreshCategories } = useApp();
+  const { accounts, transactions, serverBalances, updateAccount, closeAccount, refreshAccountsAndTransactions, refreshCategories } = useApp();
   const { showError } = useToast();
   const { formatCurrency: formatDisplayCurrency } = useCurrencyDecimal();
   const navigate = useNavigate();
@@ -168,7 +168,7 @@ export default function Accounts({ onAccountClick }: { onAccountClick?: (account
 
   const loadClosedAccounts = useCallback(async () => {
     try {
-      setClosedAccounts(await dataPort.getClosedAccounts());
+      setClosedAccounts(await dataPort.listClosedAccounts());
     } catch {
       // Non-fatal: the section simply shows empty; a retry happens on next open.
       setClosedAccounts([]);
@@ -342,7 +342,7 @@ export default function Accounts({ onAccountClick }: { onAccountClick?: (account
     if (window.confirm('Close this account? It moves to the Closed Accounts section — every transaction is preserved and you can reopen it at any time. Its transfer category is hidden from transaction dropdowns while closed.')) {
       void (async () => {
         try {
-          await deleteAccount(accountId);
+          await closeAccount(accountId);
           // The DB trigger deactivated the account's transfer category —
           // refresh categories so it leaves dropdowns without a reload.
           await refreshCategories();

--- a/src/pages/__tests__/AccountTransactions.asyncSizing.test.tsx
+++ b/src/pages/__tests__/AccountTransactions.asyncSizing.test.tsx
@@ -289,13 +289,13 @@ beforeEach(() => {
     getSubCategories: (parentId?: string) => CATEGORIES.filter(c => c.level === 'sub' && c.parentId === parentId),
     getDetailCategories: (parentId?: string) => CATEGORIES.filter(c => c.level === 'detail' && c.parentId === parentId),
   });
-  vi.spyOn(DataService, 'getClosedAccounts').mockResolvedValue([]);
+  vi.spyOn(DataService, 'listClosedAccounts').mockResolvedValue([]);
   stubLayout();
 });
 
 afterEach(() => {
   restoreLayout();
-  vi.mocked(DataService.getClosedAccounts).mockRestore();
+  vi.mocked(DataService.listClosedAccounts).mockRestore();
   __resetAppContextValue();
 });
 

--- a/src/pages/__tests__/AccountTransactions.categorySort.test.tsx
+++ b/src/pages/__tests__/AccountTransactions.categorySort.test.tsx
@@ -160,11 +160,11 @@ beforeEach(() => {
     getSubCategories: (parentId?: string) => CATEGORIES.filter(c => c.level === 'sub' && c.parentId === parentId),
     getDetailCategories: (parentId?: string) => CATEGORIES.filter(c => c.level === 'detail' && c.parentId === parentId),
   });
-  vi.spyOn(DataService, 'getClosedAccounts').mockResolvedValue([]);
+  vi.spyOn(DataService, 'listClosedAccounts').mockResolvedValue([]);
 });
 
 afterEach(() => {
-  vi.mocked(DataService.getClosedAccounts).mockRestore();
+  vi.mocked(DataService.listClosedAccounts).mockRestore();
   __resetAppContextValue();
 });
 

--- a/src/pages/__tests__/AccountTransactions.centreOnEdit.test.tsx
+++ b/src/pages/__tests__/AccountTransactions.centreOnEdit.test.tsx
@@ -260,13 +260,13 @@ beforeEach(() => {
     getSubCategories: (parentId?: string) => CATEGORIES.filter(c => c.level === 'sub' && c.parentId === parentId),
     getDetailCategories: (parentId?: string) => CATEGORIES.filter(c => c.level === 'detail' && c.parentId === parentId),
   });
-  vi.spyOn(DataService, 'getClosedAccounts').mockResolvedValue([]);
+  vi.spyOn(DataService, 'listClosedAccounts').mockResolvedValue([]);
   stubLayout();
 });
 
 afterEach(() => {
   restoreLayout();
-  vi.mocked(DataService.getClosedAccounts).mockRestore();
+  vi.mocked(DataService.listClosedAccounts).mockRestore();
   __resetAppContextValue();
 });
 

--- a/src/pages/__tests__/AccountTransactions.inlineEdit.test.tsx
+++ b/src/pages/__tests__/AccountTransactions.inlineEdit.test.tsx
@@ -199,11 +199,11 @@ beforeEach(() => {
     getSubCategories: (parentId?: string) => CATEGORIES.filter(c => c.level === 'sub' && c.parentId === parentId),
     getDetailCategories: (parentId?: string) => CATEGORIES.filter(c => c.level === 'detail' && c.parentId === parentId),
   });
-  vi.spyOn(DataService, 'getClosedAccounts').mockResolvedValue([]);
+  vi.spyOn(DataService, 'listClosedAccounts').mockResolvedValue([]);
 });
 
 afterEach(() => {
-  vi.mocked(DataService.getClosedAccounts).mockRestore();
+  vi.mocked(DataService.listClosedAccounts).mockRestore();
   __resetAppContextValue();
 });
 

--- a/src/pages/__tests__/AccountTransactions.keyboard.test.tsx
+++ b/src/pages/__tests__/AccountTransactions.keyboard.test.tsx
@@ -158,13 +158,13 @@ beforeEach(() => {
     isLoading: false,
     deleteTransaction,
   });
-  vi.spyOn(DataService, 'getClosedAccounts').mockResolvedValue([]);
+  vi.spyOn(DataService, 'listClosedAccounts').mockResolvedValue([]);
   stubLayout();
 });
 
 afterEach(() => {
   restoreLayout();
-  vi.mocked(DataService.getClosedAccounts).mockRestore();
+  vi.mocked(DataService.listClosedAccounts).mockRestore();
   __resetAppContextValue();
 });
 

--- a/src/pages/__tests__/AccountTransactions.polish.test.tsx
+++ b/src/pages/__tests__/AccountTransactions.polish.test.tsx
@@ -130,11 +130,11 @@ beforeEach(() => {
     getSubCategories: (parentId?: string) => CATEGORIES.filter(c => c.level === 'sub' && c.parentId === parentId),
     getDetailCategories: (parentId?: string) => CATEGORIES.filter(c => c.level === 'detail' && c.parentId === parentId),
   });
-  vi.spyOn(DataService, 'getClosedAccounts').mockResolvedValue([]);
+  vi.spyOn(DataService, 'listClosedAccounts').mockResolvedValue([]);
 });
 
 afterEach(() => {
-  vi.mocked(DataService.getClosedAccounts).mockRestore();
+  vi.mocked(DataService.listClosedAccounts).mockRestore();
   __resetAppContextValue();
 });
 

--- a/src/pages/__tests__/AccountTransactions.provenance.test.tsx
+++ b/src/pages/__tests__/AccountTransactions.provenance.test.tsx
@@ -135,11 +135,11 @@ beforeEach(() => {
     categories: CATEGORIES,
     isLoading: false,
   });
-  vi.spyOn(DataService, 'getClosedAccounts').mockResolvedValue([]);
+  vi.spyOn(DataService, 'listClosedAccounts').mockResolvedValue([]);
 });
 
 afterEach(() => {
-  vi.mocked(DataService.getClosedAccounts).mockRestore();
+  vi.mocked(DataService.listClosedAccounts).mockRestore();
   __resetAppContextValue();
 });
 

--- a/src/pages/__tests__/AccountTransactions.saveNextScroll.test.tsx
+++ b/src/pages/__tests__/AccountTransactions.saveNextScroll.test.tsx
@@ -264,13 +264,13 @@ beforeEach(() => {
     getSubCategories: (parentId?: string) => CATEGORIES.filter(c => c.level === 'sub' && c.parentId === parentId),
     getDetailCategories: (parentId?: string) => CATEGORIES.filter(c => c.level === 'detail' && c.parentId === parentId),
   });
-  vi.spyOn(DataService, 'getClosedAccounts').mockResolvedValue([]);
+  vi.spyOn(DataService, 'listClosedAccounts').mockResolvedValue([]);
   stubLayout();
 });
 
 afterEach(() => {
   restoreLayout();
-  vi.mocked(DataService.getClosedAccounts).mockRestore();
+  vi.mocked(DataService.listClosedAccounts).mockRestore();
   __resetAppContextValue();
 });
 

--- a/src/pages/__tests__/AccountTransactions.shortcuts.test.tsx
+++ b/src/pages/__tests__/AccountTransactions.shortcuts.test.tsx
@@ -214,11 +214,11 @@ beforeEach(() => {
     setTransactionsCleared,
     setTransactionArchived,
   });
-  vi.spyOn(DataService, 'getClosedAccounts').mockResolvedValue([]);
+  vi.spyOn(DataService, 'listClosedAccounts').mockResolvedValue([]);
 });
 
 afterEach(() => {
-  vi.mocked(DataService.getClosedAccounts).mockRestore();
+  vi.mocked(DataService.listClosedAccounts).mockRestore();
   __resetAppContextValue();
 });
 

--- a/src/pages/__tests__/AccountTransactions.test.tsx
+++ b/src/pages/__tests__/AccountTransactions.test.tsx
@@ -20,7 +20,7 @@ import type { Account, Category, Transaction } from '../../types';
  * three states now: open (the register), closed (an honest page offering the
  * re-open, the Accounts-page rule), and genuinely gone.
  *
- * Closed accounts load from DataService.getClosedAccounts — not the context —
+ * Closed accounts load from DataService.listClosedAccounts — not the context —
  * so they are injected by spying on that call. Every figure and name here is
  * synthetic (this repo is public).
  */
@@ -108,14 +108,14 @@ describe('Account register — open, closed, and gone', () => {
       refreshCategories,
       refreshAccountsAndTransactions,
     });
-    vi.spyOn(DataService, 'getClosedAccounts').mockResolvedValue([CLOSED_ACCOUNT]);
+    vi.spyOn(DataService, 'listClosedAccounts').mockResolvedValue([CLOSED_ACCOUNT]);
   });
 
   afterEach(() => {
     // Only the closed-accounts spy is restored. vi.restoreAllMocks() would
     // also strip the shared setup's window.matchMedia implementation, and the
     // register's row components read prefers-reduced-motion through it.
-    vi.mocked(DataService.getClosedAccounts).mockRestore();
+    vi.mocked(DataService.listClosedAccounts).mockRestore();
     __resetAppContextValue();
   });
 
@@ -127,7 +127,7 @@ describe('Account register — open, closed, and gone', () => {
     expect(screen.getAllByText('Synthetic open row').length).toBeGreaterThan(0);
     expect(screen.queryByRole('button', { name: 'Re-open and view' })).not.toBeInTheDocument();
     // An ordinary register costs no extra request: the lookup only fires on a miss.
-    expect(DataService.getClosedAccounts).not.toHaveBeenCalled();
+    expect(DataService.listClosedAccounts).not.toHaveBeenCalled();
   });
 
   it('meets a closed account with its name and the re-open offer, not its transactions', async () => {
@@ -149,7 +149,7 @@ describe('Account register — open, closed, and gone', () => {
   });
 
   it('says an account is gone only when it is in neither list', async () => {
-    vi.spyOn(DataService, 'getClosedAccounts').mockResolvedValue([]);
+    vi.spyOn(DataService, 'listClosedAccounts').mockResolvedValue([]);
     renderRegister('/accounts/acc-vanished');
 
     expect(await screen.findByText('This account no longer exists')).toBeInTheDocument();
@@ -159,7 +159,7 @@ describe('Account register — open, closed, and gone', () => {
 
   it('waits for the closed list rather than flashing an error at an account that exists', async () => {
     let release: (accounts: Account[]) => void = () => {};
-    vi.spyOn(DataService, 'getClosedAccounts').mockReturnValue(
+    vi.spyOn(DataService, 'listClosedAccounts').mockReturnValue(
       new Promise<Account[]>(resolve => { release = resolve; })
     );
 
@@ -182,7 +182,7 @@ describe('Account register — open, closed, and gone', () => {
 
     expect(await screen.findByText('Loading account…')).toBeInTheDocument();
     // Nothing is decided yet, so nothing is asked of the server either.
-    expect(DataService.getClosedAccounts).not.toHaveBeenCalled();
+    expect(DataService.listClosedAccounts).not.toHaveBeenCalled();
   });
 
   it('re-opens the account through the context, then renders its register in place', async () => {
@@ -382,11 +382,11 @@ describe('Account register — the running Balance column', () => {
       categories: CATEGORIES,
       isLoading: false,
     });
-    vi.spyOn(DataService, 'getClosedAccounts').mockResolvedValue([]);
+    vi.spyOn(DataService, 'listClosedAccounts').mockResolvedValue([]);
   });
 
   afterEach(() => {
-    vi.mocked(DataService.getClosedAccounts).mockRestore();
+    vi.mocked(DataService.listClosedAccounts).mockRestore();
     __resetAppContextValue();
   });
 

--- a/src/pages/__tests__/Accounts.test.tsx
+++ b/src/pages/__tests__/Accounts.test.tsx
@@ -440,7 +440,7 @@ describe('Accounts page — no account type vanishes', () => {
 /**
  * Closed accounts are the archive (the Microsoft Money model: closing hides an
  * account and keeps its history, never deletes it). They load from
- * DataService.getClosedAccounts — NOT the app-context accounts list, which
+ * DataService.listClosedAccounts — NOT the app-context accounts list, which
  * carries only the open ones — so the synthetic closed accounts are injected by
  * spying on that call rather than through __setAppContextValue. They used to
  * arrive in no order at all; now they group exactly like the open list (by
@@ -469,7 +469,7 @@ describe('Accounts page — closed accounts ordering', () => {
 
   beforeEach(() => {
     localStorage.clear();
-    vi.spyOn(DataService, 'getClosedAccounts').mockResolvedValue(closed);
+    vi.spyOn(DataService, 'listClosedAccounts').mockResolvedValue(closed);
   });
   afterEach(() => {
     vi.restoreAllMocks();
@@ -593,7 +593,7 @@ describe('Accounts page — closed account settings', () => {
   beforeEach(() => {
     localStorage.clear();
     updateAccount.mockClear();
-    vi.spyOn(DataService, 'getClosedAccounts').mockResolvedValue(closed);
+    vi.spyOn(DataService, 'listClosedAccounts').mockResolvedValue(closed);
     __setAppContextValue({ updateAccount });
   });
   afterEach(() => {
@@ -648,7 +648,7 @@ describe('Accounts page — closed account settings', () => {
     });
     // …and the closed list is re-pulled, so the row shows the new name at once.
     await waitFor(() => {
-      expect(DataService.getClosedAccounts).toHaveBeenCalledTimes(2);
+      expect(DataService.listClosedAccounts).toHaveBeenCalledTimes(2);
     });
   });
 

--- a/src/services/__tests__/dataService.test.ts
+++ b/src/services/__tests__/dataService.test.ts
@@ -222,9 +222,9 @@ describe('DataService (deterministic fallback)', () => {
     });
 
     // The boot's own read sequence, in the order AppContext runs it.
-    await service.getAccounts();
+    await service.listAccounts();
     await service.loadBootTransactions();
-    await service.getAllTransactionSplits();
+    await service.listTransactionSplits();
 
     const accountReads = storage.get.mock.calls.filter(
       ([key]) => key === STORAGE_KEYS.ACCOUNTS
@@ -259,7 +259,7 @@ describe('DataService (deterministic fallback)', () => {
       }
     });
 
-    await expect(service.getAccounts()).resolves.toHaveLength(1);
+    await expect(service.listAccounts()).resolves.toHaveLength(1);
     expect(accountService.getAccounts).toHaveBeenCalledTimes(1);
     expect(accountService.getAccounts).toHaveBeenCalledWith('db-user-1');
   });
@@ -303,8 +303,8 @@ describe('DataService (deterministic fallback)', () => {
       }
     });
 
-    await expect(service.getBudgets()).resolves.toEqual([]);
-    await expect(service.getGoals()).resolves.toEqual([]);
+    await expect(service.listBudgets()).resolves.toEqual([]);
+    await expect(service.listGoals()).resolves.toEqual([]);
 
     expect(planningService.getBudgets).toHaveBeenCalledTimes(1);
     expect(planningService.getBudgets).toHaveBeenCalledWith('db-user-1');
@@ -492,7 +492,7 @@ describe('DataService (deterministic fallback)', () => {
 
       const edited = await service.updateBudget('budget-generated', { amount: 70.1 });
       expect(edited.amount).toBe(70.1);
-      expect(await service.getBudgets()).toEqual([edited]);
+      expect(await service.listBudgets()).toEqual([edited]);
 
       // A budget that is not there is refused by name rather than created, and
       // the refusal leaves the store exactly as it was — the lookup happens
@@ -501,10 +501,10 @@ describe('DataService (deterministic fallback)', () => {
       // rule now lives on this class, so this is where it is held.)
       await expect(service.updateBudget('budget-nowhere', { amount: 1 }))
         .rejects.toThrow('Budget not found');
-      expect(await service.getBudgets()).toEqual([edited]);
+      expect(await service.listBudgets()).toEqual([edited]);
 
       await service.deleteBudget('budget-generated');
-      expect(await service.getBudgets()).toEqual([]);
+      expect(await service.listBudgets()).toEqual([]);
 
       expect(planningService.createBudget).not.toHaveBeenCalled();
       expect(planningService.updateBudget).not.toHaveBeenCalled();
@@ -757,17 +757,17 @@ describe('DataService (deterministic fallback)', () => {
 
       const edited = await service.updateGoal('goal-generated', { progress: 1500, currentAmount: 1500 });
       expect(edited.progress).toBe(1500);
-      expect(await service.getGoals()).toEqual([edited]);
+      expect(await service.listGoals()).toEqual([edited]);
 
       // Same refusal as the budget block above, for the same reason, and the
       // same reason it is asserted here: the rule moved onto this class when
       // PlanningService's local half was retired.
       await expect(service.updateGoal('goal-nowhere', { progress: 1 }))
         .rejects.toThrow('Goal not found');
-      expect(await service.getGoals()).toEqual([edited]);
+      expect(await service.listGoals()).toEqual([edited]);
 
       await service.deleteGoal('goal-generated');
-      expect(await service.getGoals()).toEqual([]);
+      expect(await service.listGoals()).toEqual([]);
 
       expect(planningService.createGoal).not.toHaveBeenCalled();
       expect(planningService.updateGoal).not.toHaveBeenCalled();
@@ -1081,7 +1081,7 @@ describe('DataService (deterministic fallback)', () => {
 
       // The cascade: the group goes and takes its children with it.
       await service.deleteCategory('category-1');
-      expect(await service.getCategories()).toEqual([]);
+      expect(await service.listCategories()).toEqual([]);
 
       expect(planningService.createCategory).not.toHaveBeenCalled();
       expect(planningService.createCategories).not.toHaveBeenCalled();
@@ -1116,7 +1116,7 @@ describe('DataService (deterministic fallback)', () => {
       await expect(service.deleteUnusedCategories(['cat-keep', 'cat-nowhere'])).resolves.toBe(1);
       // One asked for, and it took its child with it: two actually went.
       await expect(service.deleteUnusedCategories(['cat-group'])).resolves.toBe(2);
-      expect(await service.getCategories()).toEqual([]);
+      expect(await service.listCategories()).toEqual([]);
     });
 
     // The behaviour change on all five category writes — and the asymmetry that
@@ -1242,7 +1242,7 @@ describe('DataService (deterministic fallback)', () => {
       now,
       userIdService: userId
     });
-    await expect(throughTheSeam.getAccounts()).rejects.toThrow(/could not be opened/);
+    await expect(throughTheSeam.listAccounts()).rejects.toThrow(/could not be opened/);
   });
 
   it('refuses an edit that would drop a linked transfer line, and refuses to un-split', async () => {
@@ -1326,15 +1326,15 @@ describe('DataService (deterministic fallback)', () => {
       userIdService: userId // getCurrentDatabaseUserId → null
     });
 
-    expect(await service.getAccounts()).toEqual([]);
-    expect(await service.getClosedAccounts()).toEqual([]);
-    expect(await service.getTransactions()).toEqual([]);
-    expect(await service.getAllTransactionSplits()).toEqual([]);
-    expect(await service.getBudgets()).toEqual([]);
-    expect(await service.getCategories()).toEqual([]);
+    expect(await service.listAccounts()).toEqual([]);
+    expect(await service.listClosedAccounts()).toEqual([]);
+    expect(await service.listTransactions()).toEqual([]);
+    expect(await service.listTransactionSplits()).toEqual([]);
+    expect(await service.listBudgets()).toEqual([]);
+    expect(await service.listCategories()).toEqual([]);
     await expect(service.createTransaction(baseTransaction({ id: undefined as never })))
       .rejects.toThrow(/Still connecting/);
-    await expect(service.deleteAccount('demo-open')).rejects.toThrow(/Still connecting/);
+    await expect(service.closeAccount('demo-open')).rejects.toThrow(/Still connecting/);
     expect(storage.set).not.toHaveBeenCalled();
 
     // No session at all (demo / local-only mode): the local fallback still works.
@@ -1347,8 +1347,8 @@ describe('DataService (deterministic fallback)', () => {
       now,
       userIdService: userId
     });
-    expect(await localService.getAccounts()).toHaveLength(2);
-    expect(await localService.getClosedAccounts()).toHaveLength(1);
+    expect(await localService.listAccounts()).toHaveLength(2);
+    expect(await localService.listClosedAccounts()).toHaveLength(1);
   });
 
   it('still names the categories while a signed-in session is resolving — the one read without the gate', async () => {
@@ -1385,7 +1385,7 @@ describe('DataService (deterministic fallback)', () => {
     });
 
     // The gated read says nothing, as it must.
-    expect(await service.getCategories()).toEqual([]);
+    expect(await service.listCategories()).toEqual([]);
     // The boot's read still names them.
     expect((await service.prepareCategories()).map(category => category.id))
       .toEqual(['cat-everyday']);
@@ -1473,7 +1473,7 @@ describe('DataService (deterministic fallback)', () => {
       userIdService: userId
     });
 
-    const accounts = await DataService.getAccounts();
+    const accounts = await DataService.listAccounts();
     expect(accounts[0].id).toBe('static-account');
   });
 });

--- a/src/services/__tests__/suggestionDismissals.dataService.test.ts
+++ b/src/services/__tests__/suggestionDismissals.dataService.test.ts
@@ -76,7 +76,7 @@ describe('DataService suggestion dismissals (local/demo)', () => {
 
     // A second service instance reading the same storage is what "close the
     // sweep and come back later" actually looks like.
-    const reloaded = await localService(storage).getSuggestionDismissals();
+    const reloaded = await localService(storage).listSuggestionDismissals();
     expect(reloaded).toHaveLength(1);
     expect(reloaded[0]).toMatchObject({
       kind: 'duplicate',
@@ -95,7 +95,7 @@ describe('DataService suggestion dismissals (local/demo)', () => {
     const again = await service.dismissSuggestion('transfer-pair', 'a|b', ['a', 'b']);
 
     expect(again.id).toBe(first.id);
-    expect(await service.getSuggestionDismissals()).toHaveLength(1);
+    expect(await service.listSuggestionDismissals()).toHaveLength(1);
   });
 
   it('keeps the four kinds apart, even for the same rows', async () => {
@@ -106,7 +106,7 @@ describe('DataService suggestion dismissals (local/demo)', () => {
     await service.dismissSuggestion('transfer-pair', 'a|b', ['a', 'b']);
     await service.dismissSuggestion('duplicate', 'a|b', ['a', 'b']);
 
-    const stored = await service.getSuggestionDismissals();
+    const stored = await service.listSuggestionDismissals();
     expect(stored.map(d => d.kind).sort()).toEqual(['duplicate', 'transfer-pair']);
   });
 
@@ -119,7 +119,7 @@ describe('DataService suggestion dismissals (local/demo)', () => {
     await service.dismissSuggestion('duplicate', 'c|d', ['c', 'd']);
     await service.restoreSuggestion('duplicate', 'a|b');
 
-    const stored = await service.getSuggestionDismissals();
+    const stored = await service.listSuggestionDismissals();
     expect(stored.map(d => d.subjectKey)).toEqual(['c|d']);
   });
 
@@ -137,7 +137,7 @@ describe('DataService suggestion dismissals (local/demo)', () => {
 
     await service.deleteTransaction('import');
 
-    const survivors = await service.getSuggestionDismissals();
+    const survivors = await service.listSuggestionDismissals();
     expect(survivors.map(d => d.id)).toEqual(['d2']);
     // And the delete still did its own job: the balance is reversed.
     expect(storage.snapshot(STORAGE_KEYS.ACCOUNTS)).toEqual([

--- a/src/services/api/dataService.ts
+++ b/src/services/api/dataService.ts
@@ -332,7 +332,7 @@ class DataServiceImpl implements DataPort {
   }
 
   /**
-   * The boot's transaction read. Unlike getTransactions (used by the bank-sync
+   * The boot's transaction read. Unlike listTransactions (used by the bank-sync
    * and real-time refreshes, which always want a straight re-pull) this goes
    * through the local snapshot + delta path, and reports which it used.
    *
@@ -405,7 +405,7 @@ class DataServiceImpl implements DataPort {
     }
   }
 
-  async getAccounts(): Promise<Account[]> {
+  async listAccounts(): Promise<Account[]> {
     const userId = this.userIdService.getCurrentDatabaseUserId();
     if (userId && this.supabaseChecker()) {
       return this.accountService.getAccounts(userId);
@@ -415,7 +415,7 @@ class DataServiceImpl implements DataPort {
   }
 
   /** Closed accounts for the Accounts page's Closed Accounts section. */
-  async getClosedAccounts(): Promise<Account[]> {
+  async listClosedAccounts(): Promise<Account[]> {
     const userId = this.userIdService.getCurrentDatabaseUserId();
     if (userId && this.supabaseChecker()) {
       return this.accountService.getClosedAccounts(userId);
@@ -469,7 +469,7 @@ class DataServiceImpl implements DataPort {
     return accounts[index];
   }
 
-  async deleteAccount(id: string): Promise<void> {
+  async closeAccount(id: string): Promise<void> {
     const userId = this.userIdService.getCurrentDatabaseUserId();
     if (userId && this.supabaseChecker()) {
       return this.accountService.deleteAccount(id, userId);
@@ -485,7 +485,7 @@ class DataServiceImpl implements DataPort {
     await this.persistCollection(STORAGE_KEYS.ACCOUNTS, updated);
   }
 
-  async getTransactions(): Promise<Transaction[]> {
+  async listTransactions(): Promise<Transaction[]> {
     const userId = this.userIdService.getCurrentDatabaseUserId();
     if (userId && this.supabaseChecker()) {
       return this.transactionService.getTransactions(userId);
@@ -1127,7 +1127,7 @@ class DataServiceImpl implements DataPort {
   }
 
   /** Every split line of the user's transactions (for category aggregation). */
-  async getAllTransactionSplits(): Promise<TransactionSplit[]> {
+  async listTransactionSplits(): Promise<TransactionSplit[]> {
     const userId = this.userIdService.getCurrentDatabaseUserId();
     if (userId && this.supabaseChecker()) {
       return this.transactionService.getAllTransactionSplits(userId);
@@ -1138,7 +1138,7 @@ class DataServiceImpl implements DataPort {
   }
 
   /** Splits for one transaction, in display order (empty when not split). */
-  async getTransactionSplits(transactionId: string): Promise<TransactionSplit[]> {
+  async listTransactionSplitsFor(transactionId: string): Promise<TransactionSplit[]> {
     const userId = this.userIdService.getCurrentDatabaseUserId();
     if (userId && this.supabaseChecker()) {
       return this.transactionService.getTransactionSplits(transactionId);
@@ -1919,7 +1919,7 @@ class DataServiceImpl implements DataPort {
    * like the cloud: refuse a suggestion, close the sweep, re-open it, and the
    * suggestion is still gone.
    */
-  async getSuggestionDismissals(): Promise<SuggestionDismissal[]> {
+  async listSuggestionDismissals(): Promise<SuggestionDismissal[]> {
     const userId = this.userIdService.getCurrentDatabaseUserId();
     if (userId && this.supabaseChecker()) {
       return this.suggestionDismissalService.list(userId);
@@ -1993,7 +1993,7 @@ class DataServiceImpl implements DataPort {
    *
    * PlanningService owns the cloud query and this class owns the browser-local
    * collection, so the seam's answer is one branch over the other — the shape
-   * `getAccounts` above already has.
+   * `listAccounts` above already has.
    *
    * THE ID IS RESOLVED HERE AND ONLY PASSED ON WHEN IT IS REAL.
    * `PlanningService.getBudgets(null)` does not fail and does not complain: it
@@ -2009,7 +2009,7 @@ class DataServiceImpl implements DataPort {
    * exception — see `prepareCategories`, which explains why names are not
    * money.)
    */
-  async getBudgets(): Promise<Budget[]> {
+  async listBudgets(): Promise<Budget[]> {
     const userId = this.userIdService.getCurrentDatabaseUserId();
     if (userId && this.supabaseChecker() && this.planningService.getBudgets) {
       return this.planningService.getBudgets(userId);
@@ -2021,7 +2021,7 @@ class DataServiceImpl implements DataPort {
   /**
    * Create a budget.
    *
-   * The branch is the one `getBudgets` above uses, and for the same reason —
+   * The branch is the one `listBudgets` above uses, and for the same reason —
    * but a write is where getting the owner wrong stops being a wrong answer on
    * screen and becomes a lost budget: `PlanningService.createBudget(null, …)`
    * writes BROWSER storage and returns an ordinary Budget, so a signed-in
@@ -2130,8 +2130,8 @@ class DataServiceImpl implements DataPort {
     );
   }
 
-  /** The owner's goals. Same branch, same null rule, as `getBudgets` above. */
-  async getGoals(): Promise<Goal[]> {
+  /** The owner's goals. Same branch, same null rule, as `listBudgets` above. */
+  async listGoals(): Promise<Goal[]> {
     const userId = this.userIdService.getCurrentDatabaseUserId();
     if (userId && this.supabaseChecker() && this.planningService.getGoals) {
       return this.planningService.getGoals(userId);
@@ -2436,7 +2436,7 @@ class DataServiceImpl implements DataPort {
    * one stays local-only and gated because it answers "what is in the browser's
    * copy", which is a question the cloud has no part in.
    */
-  async getCategories(): Promise<Category[]> {
+  async listCategories(): Promise<Category[]> {
     if (this.isCloudSessionPending()) return [];
     return this.readCollection<Category>(STORAGE_KEYS.CATEGORIES);
   }
@@ -2581,12 +2581,12 @@ export class DataService {
     return this.service.initialize(clerkId, email, firstName, lastName);
   }
 
-  static getClosedAccounts(): Promise<Account[]> {
-    return this.service.getClosedAccounts();
+  static listClosedAccounts(): Promise<Account[]> {
+    return this.service.listClosedAccounts();
   }
 
-  static getAccounts(): Promise<Account[]> {
-    return this.service.getAccounts();
+  static listAccounts(): Promise<Account[]> {
+    return this.service.listAccounts();
   }
 
   static createAccount(account: Omit<Account, 'id'>): Promise<Account> {
@@ -2597,12 +2597,12 @@ export class DataService {
     return this.service.updateAccount(id, updates);
   }
 
-  static deleteAccount(id: string): Promise<void> {
-    return this.service.deleteAccount(id);
+  static closeAccount(id: string): Promise<void> {
+    return this.service.closeAccount(id);
   }
 
-  static getTransactions(): Promise<Transaction[]> {
-    return this.service.getTransactions();
+  static listTransactions(): Promise<Transaction[]> {
+    return this.service.listTransactions();
   }
 
   static loadBootTransactions(): Promise<BootTransactionsResult> {
@@ -2686,8 +2686,8 @@ export class DataService {
     return this.service.unarchiveAccount(accountId);
   }
 
-  static getAllTransactionSplits(): Promise<TransactionSplit[]> {
-    return this.service.getAllTransactionSplits();
+  static listTransactionSplits(): Promise<TransactionSplit[]> {
+    return this.service.listTransactionSplits();
   }
 
   static linkTransferPair(idA: string, idB: string): Promise<{ a: Transaction; b: Transaction }> {
@@ -2727,8 +2727,8 @@ export class DataService {
     return this.service.createTransferCounterpart(id, targetAccountId);
   }
 
-  static getTransactionSplits(transactionId: string): Promise<TransactionSplit[]> {
-    return this.service.getTransactionSplits(transactionId);
+  static listTransactionSplitsFor(transactionId: string): Promise<TransactionSplit[]> {
+    return this.service.listTransactionSplitsFor(transactionId);
   }
 
   static setTransactionSplits(
@@ -2743,8 +2743,8 @@ export class DataService {
     return this.service.mergeCategories(sourceId, targetId);
   }
 
-  static getSuggestionDismissals(): Promise<SuggestionDismissal[]> {
-    return this.service.getSuggestionDismissals();
+  static listSuggestionDismissals(): Promise<SuggestionDismissal[]> {
+    return this.service.listSuggestionDismissals();
   }
 
   static dismissSuggestion(
@@ -2759,8 +2759,8 @@ export class DataService {
     return this.service.restoreSuggestion(kind, subjectKey);
   }
 
-  static getBudgets(): Promise<Budget[]> {
-    return this.service.getBudgets();
+  static listBudgets(): Promise<Budget[]> {
+    return this.service.listBudgets();
   }
 
   static createBudget(budget: Omit<Budget, 'id' | 'spent'>): Promise<Budget> {
@@ -2775,8 +2775,8 @@ export class DataService {
     return this.service.deleteBudget(id);
   }
 
-  static getGoals(): Promise<Goal[]> {
-    return this.service.getGoals();
+  static listGoals(): Promise<Goal[]> {
+    return this.service.listGoals();
   }
 
   static createGoal(goal: Omit<Goal, 'id' | 'progress'>): Promise<Goal> {
@@ -2811,8 +2811,8 @@ export class DataService {
     return this.service.deleteUnusedCategories(ids);
   }
 
-  static getCategories(): Promise<Category[]> {
-    return this.service.getCategories();
+  static listCategories(): Promise<Category[]> {
+    return this.service.listCategories();
   }
 
   static prepareCategories(): Promise<Category[]> {

--- a/src/services/port/__tests__/contract.ts
+++ b/src/services/port/__tests__/contract.ts
@@ -131,21 +131,21 @@ export interface DataPortContractHarness {
  */
 export const DATA_PORT_OPERATIONS: readonly (keyof DataPort)[] = [
   // Reads
-  'getAccounts',
-  'getClosedAccounts',
-  'getTransactions',
+  'listAccounts',
+  'listClosedAccounts',
+  'listTransactions',
   'loadBootTransactions',
   'getAccountBalances',
-  'getAllTransactionSplits',
-  'getTransactionSplits',
-  'getBudgets',
-  'getGoals',
-  'getCategories',
-  'getSuggestionDismissals',
+  'listTransactionSplits',
+  'listTransactionSplitsFor',
+  'listBudgets',
+  'listGoals',
+  'listCategories',
+  'listSuggestionDismissals',
   // Account writes
   'createAccount',
   'updateAccount',
-  'deleteAccount',
+  'closeAccount',
   // Transaction writes
   'createTransaction',
   'updateTransaction',
@@ -703,7 +703,7 @@ export function runDataPortContract(name: string, harness: DataPortContractHarne
         });
         expect(stored.id).toBeTruthy();
 
-        const listed = await port.getAccounts();
+        const listed = await port.listAccounts();
         expect(listed.find(account => account.id === stored.id)).toMatchObject({
           lowBalanceAlertEnabled: true,
           accountNumber: '12345678',
@@ -789,13 +789,13 @@ export function runDataPortContract(name: string, harness: DataPortContractHarne
           transactions: [aTransaction('txn-1')]
         });
 
-        await port.deleteAccount(ACCOUNT_A);
+        await port.closeAccount(ACCOUNT_A);
 
         const state = await read();
         expect(state.accounts.find(account => account.id === ACCOUNT_A)?.isActive).toBe(false);
         expect(transactionOf(state, 'txn-1')).toBeDefined();
 
-        const closed = await port.getClosedAccounts();
+        const closed = await port.listClosedAccounts();
         expect(closed.map(account => account.id)).toContain(ACCOUNT_A);
       });
     });
@@ -1200,7 +1200,7 @@ export function runDataPortContract(name: string, harness: DataPortContractHarne
           .forEach(transaction => {
             expect(preparedIds.has(transaction.category)).toBe(true);
           });
-        expect((await port.getCategories()).map(category => category.id).sort())
+        expect((await port.listCategories()).map(category => category.id).sort())
           .toEqual([...preparedIds].sort());
       });
     });
@@ -1225,10 +1225,10 @@ export function runDataPortContract(name: string, harness: DataPortContractHarne
           goals: [aGoal('goal-theirs', 'Someone else’s holiday', 900)]
         });
 
-        expect((await mine.port.getBudgets()).map(budget => budget.id)).toEqual(['budget-mine']);
-        expect((await mine.port.getGoals()).map(goal => goal.id)).toEqual(['goal-mine']);
-        expect((await theirs.port.getBudgets()).map(budget => budget.id)).toEqual(['budget-theirs']);
-        expect((await theirs.port.getGoals()).map(goal => goal.id)).toEqual(['goal-theirs']);
+        expect((await mine.port.listBudgets()).map(budget => budget.id)).toEqual(['budget-mine']);
+        expect((await mine.port.listGoals()).map(goal => goal.id)).toEqual(['goal-mine']);
+        expect((await theirs.port.listBudgets()).map(budget => budget.id)).toEqual(['budget-theirs']);
+        expect((await theirs.port.listGoals()).map(goal => goal.id)).toEqual(['goal-theirs']);
       });
 
       it('hands back the amounts it was given, to the penny', async () => {
@@ -1241,8 +1241,8 @@ export function runDataPortContract(name: string, harness: DataPortContractHarne
           goals: [aGoal('goal-1', 'Rainy day', 0.3)]
         });
 
-        expect((await port.getBudgets())[0].amount).toBe(70.1);
-        expect((await port.getGoals())[0].targetAmount).toBe(0.3);
+        expect((await port.listBudgets())[0].amount).toBe(70.1);
+        expect((await port.listGoals())[0].targetAmount).toBe(0.3);
       });
     });
 
@@ -1261,7 +1261,7 @@ export function runDataPortContract(name: string, harness: DataPortContractHarne
         expect(created.id).toBeTruthy();
         expect(created.amount).toBe(70.1);
         expect(created.spent).toBe(0);
-        expect((await port.getBudgets()).map(budget => [budget.id, budget.amount]))
+        expect((await port.listBudgets()).map(budget => [budget.id, budget.amount]))
           .toEqual([[created.id, 70.1]]);
 
         const edited = await port.updateBudget(created.id, { amount: 0.3 });
@@ -1269,7 +1269,7 @@ export function runDataPortContract(name: string, harness: DataPortContractHarne
         // The whole budget comes back, not just the field that moved: the
         // caller replaces its copy with this answer.
         expect(edited).toMatchObject({ id: created.id, categoryId: 'cat-everyday', amount: 0.3 });
-        expect((await port.getBudgets())[0].amount).toBe(0.3);
+        expect((await port.listBudgets())[0].amount).toBe(0.3);
       });
 
       it(`B-3: a budget is filed under ${OWNERSHIP[engine]}`, async () => {
@@ -1298,7 +1298,7 @@ export function runDataPortContract(name: string, harness: DataPortContractHarne
 
         expect((await mine.read()).budgets.map(budget => budget.id)).toEqual([created.id]);
         expect((await theirs.read()).budgets).toEqual([]);
-        expect(await theirs.port.getBudgets()).toEqual([]);
+        expect(await theirs.port.listBudgets()).toEqual([]);
       });
 
       it('refuses to change a budget that is not there, and says which', async () => {
@@ -1364,7 +1364,7 @@ export function runDataPortContract(name: string, harness: DataPortContractHarne
 
         expect(created.id).toBeTruthy();
         expect(created.targetAmount).toBe(1500.05);
-        expect((await port.getGoals()).map(goal => [goal.id, goal.targetAmount]))
+        expect((await port.listGoals()).map(goal => [goal.id, goal.targetAmount]))
           .toEqual([[created.id, 1500.05]]);
 
         const edited = await port.updateGoal(created.id, { targetAmount: 0.3 });
@@ -1372,7 +1372,7 @@ export function runDataPortContract(name: string, harness: DataPortContractHarne
         // The whole goal comes back, not just the field that moved: the caller
         // replaces its copy with this answer.
         expect(edited).toMatchObject({ id: created.id, name: 'New boiler', targetAmount: 0.3 });
-        expect((await port.getGoals())[0].targetAmount).toBe(0.3);
+        expect((await port.listGoals())[0].targetAmount).toBe(0.3);
       });
 
       it('starts a goal at the money already put by, not at zero', async () => {
@@ -1394,7 +1394,7 @@ export function runDataPortContract(name: string, harness: DataPortContractHarne
         );
 
         expect(partway.progress).toBe(250.05);
-        const stored = (await port.getGoals()).find(goal => goal.id === partway.id);
+        const stored = (await port.listGoals()).find(goal => goal.id === partway.id);
         expect(stored?.progress).toBe(250.05);
       });
 
@@ -1422,7 +1422,7 @@ export function runDataPortContract(name: string, harness: DataPortContractHarne
         // And again, which is what a second click on a full goal produces.
         const again = await port.updateGoal(created.id, { progress: 1500, currentAmount: 1500 });
         expect(again.progress).toBe(1500);
-        expect((await port.getGoals())[0].progress).toBe(1500);
+        expect((await port.listGoals())[0].progress).toBe(1500);
       });
 
       it(`B-3 for goals: a goal is filed under ${OWNERSHIP[engine]}`, async () => {
@@ -1444,7 +1444,7 @@ export function runDataPortContract(name: string, harness: DataPortContractHarne
 
         expect((await mine.read()).goals.map(goal => goal.id)).toEqual([created.id]);
         expect((await theirs.read()).goals).toEqual([]);
-        expect(await theirs.port.getGoals()).toEqual([]);
+        expect(await theirs.port.listGoals()).toEqual([]);
       });
 
       it('refuses to change a goal that is not there, and leaves the store exactly as it was', async () => {
@@ -1706,7 +1706,7 @@ export function runDataPortContract(name: string, harness: DataPortContractHarne
           ]
         });
 
-        const lines = await port.getTransactionSplits('txn-1');
+        const lines = await port.listTransactionSplitsFor('txn-1');
         expect(lines.map(line => line.id)).toEqual(['line-1', 'line-2']);
       });
 
@@ -2128,7 +2128,7 @@ export function runDataPortContract(name: string, harness: DataPortContractHarne
 
         expect(second.id).toBe(first.id);
         expect((await read()).dismissals).toHaveLength(1);
-        expect(await port.getSuggestionDismissals()).toHaveLength(1);
+        expect(await port.listSuggestionDismissals()).toHaveLength(1);
       });
 
       it('forgets a refusal about a row that no longer exists', async () => {
@@ -2170,7 +2170,7 @@ export function runDataPortContract(name: string, harness: DataPortContractHarne
 
         await port.restoreSuggestion('duplicate', 'subject-key');
 
-        expect(await port.getSuggestionDismissals()).toHaveLength(0);
+        expect(await port.listSuggestionDismissals()).toHaveLength(0);
       });
     });
 

--- a/src/services/port/dataPort.ts
+++ b/src/services/port/dataPort.ts
@@ -41,15 +41,34 @@
  * ── Scope ────────────────────────────────────────────────────────────────
  *
  * This is the seam as it stands, not as it will end: the operations below are
- * exactly the ones DataService owns today, under the names it uses today.
- * Bulk import has joined it (the CSV and OFX importers write through
- * `importTransactions`), and so have the backup, the emptiness check, the
- * restore, the wipe and the Microsoft Money migration. The capability
- * descriptor has joined too, and with it went the last question the app asked
- * about its engine BY NAME: nothing above this file says `isUsingSupabase` any
- * more. The names here are today's names deliberately: renaming and re-routing
- * in one step would make a rename indistinguishable from a behaviour change in
- * review.
+ * exactly the ones DataService owns today. Bulk import has joined it (the CSV
+ * and OFX importers write through `importTransactions`), and so have the
+ * backup, the emptiness check, the restore, the wipe and the Microsoft Money
+ * migration. The capability descriptor has joined too, and with it went the
+ * last question the app asked about its engine BY NAME: nothing above this
+ * file says `isUsingSupabase` any more.
+ *
+ * ── The names ────────────────────────────────────────────────────────────
+ *
+ * Every operation carried DataService's own name while the app was being moved
+ * onto this file, deliberately: renaming and re-routing in one step would have
+ * made a rename indistinguishable from a behaviour change in review. The
+ * re-routing is finished, so the names below are the seam's own, and they
+ * follow two rules an implementation is expected to keep:
+ *
+ * `list…` ENUMERATES — every row of one kind this store holds, or every row of
+ * one kind belonging to one parent, and then `…For` names the parent. That
+ * suffix is what stops `listTransactionSplits` (all of them, for category
+ * aggregation) and `listTransactionSplitsFor` (one transaction's lines) from
+ * being told apart only by their arity at the call site. A read that answers
+ * something other than an enumeration keeps `get…`: `getAccountBalances` hands
+ * back a lookup table with an "I don't know" state rather than a list of
+ * balances, and `prepareCategories` is not a read at all.
+ *
+ * AN OPERATION IS NAMED FOR WHAT IT DOES, not for the button that calls it.
+ * `closeAccount` is the one that had to be renamed for that rule: it was
+ * `deleteAccount`, it has never deleted an account in any implementation, and
+ * the screen that calls it already asks "Close this account?".
  */
 
 import type {
@@ -181,13 +200,13 @@ export interface AccountBalanceSnapshot {
  * language that no implementation actually has.
  */
 export interface DataPortReads {
-  getAccounts(): Promise<Account[]>;
-  /** Closed accounts are excluded from `getAccounts` and read on demand. */
-  getClosedAccounts(): Promise<Account[]>;
-  getTransactions(): Promise<Transaction[]>;
+  listAccounts(): Promise<Account[]>;
+  /** Closed accounts are excluded from `listAccounts` and read on demand. */
+  listClosedAccounts(): Promise<Account[]>;
+  listTransactions(): Promise<Transaction[]>;
   /**
    * The boot's transaction read, which is a different question from
-   * `getTransactions`: that one always wants a straight re-pull (bank sync,
+   * `listTransactions`: that one always wants a straight re-pull (bank sync,
    * real-time refresh), this one is allowed to serve a local snapshot and ask
    * only for what changed, and must report which it did.
    *
@@ -229,13 +248,13 @@ export interface DataPortReads {
    */
   getAccountBalances(): Promise<ReadonlyMap<string, AccountBalanceSnapshot>>;
   /** Every split line the owner has, for category aggregation. */
-  getAllTransactionSplits(): Promise<TransactionSplit[]>;
+  listTransactionSplits(): Promise<TransactionSplit[]>;
   /** One transaction's lines, in display order (`sortOrder`), empty when not split. */
-  getTransactionSplits(transactionId: string): Promise<TransactionSplit[]>;
-  getBudgets(): Promise<Budget[]>;
-  getGoals(): Promise<Goal[]>;
-  getCategories(): Promise<Category[]>;
-  getSuggestionDismissals(): Promise<SuggestionDismissal[]>;
+  listTransactionSplitsFor(transactionId: string): Promise<TransactionSplit[]>;
+  listBudgets(): Promise<Budget[]>;
+  listGoals(): Promise<Goal[]>;
+  listCategories(): Promise<Category[]>;
+  listSuggestionDismissals(): Promise<SuggestionDismissal[]>;
 }
 
 export interface DataPortAccountWrites {
@@ -246,7 +265,7 @@ export interface DataPortAccountWrites {
    * and its transactions stay exactly where they are. Nothing in this seam
    * hard-deletes an account, because a deleted account is a hole in a ledger.
    */
-  deleteAccount(id: string): Promise<void>;
+  closeAccount(id: string): Promise<void>;
 }
 
 export interface DataPortTransactionWrites {
@@ -896,7 +915,7 @@ export interface DataPortLifecycle {
    * implementation needs one, the one-time migration that has to finish first.
    *
    * Lifecycle rather than a read, and the distinction is the whole point:
-   * `getCategories` asks what is stored, this one is allowed to CHANGE what is
+   * `listCategories` asks what is stored, this one is allowed to CHANGE what is
    * stored.
    *
    * **ORDERING IS LOAD-BEARING. This must resolve before any transaction or

--- a/src/test/mocks/AppContextSupabase.ts
+++ b/src/test/mocks/AppContextSupabase.ts
@@ -70,7 +70,7 @@ const baseValue = {
   }),
   addAccount: noop,
   updateAccount: noop,
-  deleteAccount: noop,
+  closeAccount: noop,
   addTransaction: noop,
   updateTransaction: noop,
   deleteTransaction: noop,


### PR DESCRIPTION
The write-paths campaign's final slice — rename-only, deliberately last.

- `deleteAccount` → `closeAccount` (the interface documented a soft close all along; the name and its log line now agree with it).
- Collection reads → `list…`; the splits collision resolved by scope, not arity (`listTransactionSplits()` / `listTransactionSplitsFor(id)`). Non-enumerations keep `get` with one-line justifications. Below-the-seam engine names untouched — the adapter maps names, which is its job.
- `getCategories` → `listCategories` as a declared judgement call beyond the brief (the only remaining `get`-prefixed enumeration would have reinstated the inconsistency).
- QIF's provably-always-true `ImportOutcome.complete` removed.
- The port's scope header keeps its own old promise and replaces it with the naming rules it establishes.
- Runtime closure test run first as the safety net; bundle delta +40 B gz (property-name characters minus the dead field).

**With this, slices 0–12 are complete**: every financial read, write, import, backup, wipe and migration in the application flows through one contracted door — 77 contract rules, 47 operations with a runtime-enforced surface, identity internal with zero exceptions.

Gate: lint · strict tsc · smoke 4,918 · realtime 11/11 · build · coverage 75.34/81.29 vs 63/55.

🤖 Generated with [Claude Code](https://claude.com/claude-code)