### PR TITLE
feat(reconciliation+navigation+transactions): one yellow that means blocked, pages that start at the top, and a global list with the register's manners

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -16,6 +16,7 @@ import { ToastProvider } from './contexts/ToastContext';
 import { ActivityLoggerProvider } from './components/ActivityLoggerProvider';
 import Layout from './components/Layout';
 import PageLoader from './components/PageLoader';
+import ScrollResetOnNavigate from './components/ScrollResetOnNavigate';
 // NOTE: performanceService is dynamically imported in the startup effect
 // below — a static import would pull it (and its dependency graph) into the
 // main chunk for code that only runs after first paint.
@@ -140,6 +141,15 @@ function App(): React.JSX.Element {
                       <SupabaseDataLoader>
                             <ActivityLoggerProvider>
                               <Router>
+                                {/* First child of the router, deliberately: it
+                                    is what makes a new page open at its own
+                                    heading instead of at the offset the last
+                                    one was left at, and being first is what
+                                    puts its reset ahead of every arrival scroll
+                                    below it in the same commit. Outside
+                                    <Routes> so the pages that have no Layout —
+                                    login, the legal pages — are covered too. */}
+                                <ScrollResetOnNavigate />
                                 <SafariWarning />
                                 <ConsentBanner />
                         <Routes>

--- a/src/components/ScrollResetOnNavigate.tsx
+++ b/src/components/ScrollResetOnNavigate.tsx
@@ -1,0 +1,94 @@
+import { useLayoutEffect, useRef } from 'react';
+import { NavigationType, useLocation, useNavigationType } from 'react-router-dom';
+
+/**
+ * Arriving at a page at the top of it.
+ *
+ * ─ WHAT WAS WRONG ──────────────────────────────────────────────────────────
+ * Nothing in the app ever reset the scroll position, and a client-side
+ * navigation does not do it for you: React Router swaps the routed subtree and
+ * leaves the window exactly where it was. Leave a long register two thousand
+ * pixels down, click Reports, and Reports opens two thousand pixels down —
+ * below its own heading, so the first thing the new page asks of the reader is
+ * to scroll UP to find out where they are.
+ *
+ * ─ WHAT ACTUALLY SCROLLS ───────────────────────────────────────────────────
+ * The WINDOW. There is no inner scrolling container to reset instead: #root is
+ * `min-height:100vh` with no cap (index.html), Layout's root is `min-h-screen`,
+ * and its <main> is a plain block with no height and no overflow of its own —
+ * so the document itself is what grows past the viewport. Inner scrollers do
+ * exist (the virtualised register, the comboboxes), but each mounts with its
+ * page and starts at the top already; none of them is the offset that survives
+ * a navigation.
+ *
+ * The two-argument call is an INSTANT jump, which this depends on: no rule in
+ * the app sets `scroll-behavior: smooth` (index.css mentions it only to force
+ * `auto` under prefers-reduced-motion). Add one and this must become an
+ * explicit `behavior: 'instant'` — an animated reset would still be travelling
+ * when the arrival scrolls described below run, and would land on top of them.
+ *
+ * ─ THE THREE BOUNDARIES ────────────────────────────────────────────────────
+ * 1. PUSH and REPLACE reset. Going somewhere new means starting at the top of
+ *    it. useLayoutEffect rather than useEffect so the reset is part of the same
+ *    paint as the new page: with useEffect the browser is free to show one
+ *    frame of the new page at the old offset first, which is a visible jolt.
+ *
+ * 2. POP does NOT. Back and Forward belong to the browser, which already
+ *    restores the offset of the entry it is returning to — `scrollRestoration`
+ *    is left at its default of 'auto', because nothing in this app touches it.
+ *    Going back to a list should return you to where you were in it.
+ *    THE HONEST LIMIT: native restoration is best-effort in a code-split SPA.
+ *    The browser restores as soon as the document is tall enough, and a lazily
+ *    loaded page that is still a skeleton at that moment may not be tall enough
+ *    yet, so a deep offset can come back short. What this component guarantees
+ *    is that nothing here FIGHTS it. Storing an offset per history entry and
+ *    replaying it once the page has its height is a different piece of work,
+ *    and pretending otherwise here would be the wrong place for it.
+ *
+ * 3. Only a change of PATHNAME counts. Query parameters are how pages talk to
+ *    themselves: filters write to them, and the arrival deep links consume
+ *    themselves with a same-pathname replace (the reports hub's drill
+ *    parameters, the register's ?txn=). Firing on those would yank a reader who
+ *    is mid-page back to the top for something they never navigated. The
+ *    previous pathname is held in a ref rather than inferred from the
+ *    dependency list, because the navigation type changes on its own — POP to
+ *    REPLACE on that very first consume — and would otherwise re-run this for a
+ *    pathname that never moved.
+ *
+ *    The cost of that rule, stated plainly: clicking the nav item for the page
+ *    you are already on does not jump to the top either. Nothing can tell that
+ *    apart from a filter rewriting the address bar, and of the two mistakes,
+ *    moving a reader who did not ask to be moved is much the worse.
+ *
+ * ─ WHAT STILL WINS ─────────────────────────────────────────────────────────
+ * The deliberate arrival scrolls — useArrivalRowFocus's callback ref, the
+ * register's ?txn= row centring, the accounts list centring the row you came
+ * back from, the duplicate sweep resuming — all run after their page has
+ * mounted, and a code-split page mounts in a later commit than this one. Where
+ * they do share a commit this still goes first: it is rendered as the router's
+ * first child, and React commits layout effects and refs in tree order. Reset,
+ * then land on the target.
+ *
+ * Fragment links (the skip links at the top of Layout) are untouched: they
+ * change the hash only, the pathname is unmoved, and so this does nothing.
+ */
+export default function ScrollResetOnNavigate(): null {
+  const { pathname } = useLocation();
+  const navigationType = useNavigationType();
+
+  /**
+   * The pathname this last ran for. Null until the first run, which makes the
+   * opening page of a session count as a change — harmless, because the
+   * opening navigation type is POP and returns below without scrolling.
+   */
+  const lastPathname = useRef<string | null>(null);
+
+  useLayoutEffect(() => {
+    if (lastPathname.current === pathname) return;
+    lastPathname.current = pathname;
+    if (navigationType === NavigationType.Pop) return;
+    window.scrollTo(0, 0);
+  }, [pathname, navigationType]);
+
+  return null;
+}

--- a/src/components/SwipeableTransactionRow.tsx
+++ b/src/components/SwipeableTransactionRow.tsx
@@ -26,12 +26,17 @@ interface SwipeableTransactionRowProps {
    * Should a row that has arrived and not been dealt with be drawn as new?
    *
    * OFF BY DEFAULT, and asked for explicitly by the caller, because "new" is a
-   * fact about a job rather than about a transaction: it means something in the
-   * account register, where there is a To Review counter above the list and a
-   * filter that narrows to exactly these rows, and it means nothing on the
-   * Transactions page, which is a search over everything and offers neither.
-   * Marking a row where there is nothing to do about it as a SET is how people
-   * learn to ignore the marking on the screen where it matters.
+   * fact about a job rather than about a transaction: it means something on a
+   * screen that carries a To Review counter and a filter narrowing to exactly
+   * these rows, and it means nothing on a screen that offers neither. Marking a
+   * row where there is nothing to do about it as a SET is how people learn to
+   * ignore the marking on the screen where it matters.
+   *
+   * Two callers pass it, and both earn it: the account register, and the
+   * Transactions page — which grew the same counter and the same filter when it
+   * was brought up to the register's manners, so its rows now lead somewhere
+   * too. Anything else that lists transactions (a report, a search result, a
+   * dashboard card) still gets the default and still says nothing.
    */
   markNewArrivals?: boolean;
 }

--- a/src/components/TransactionRow.test.tsx
+++ b/src/components/TransactionRow.test.tsx
@@ -183,19 +183,49 @@ describe('TransactionRow', () => {
       expect(screen.getByTestId('trending-down-icon')).toBeInTheDocument();
     });
 
-    it('shows check icon for cleared transactions', () => {
+    /**
+     * The C/R column — Money's two letters, and the register's.
+     *
+     * A tick could only ever say one thing, and the thing it said was "settled"
+     * about rows that were merely ticked off against a statement. The letters
+     * come from the shared predicates, which is what keeps this column and the
+     * register's saying the same word about the same row.
+     */
+    it('shows R for a row that has been through a reconciliation', () => {
       render(
         <table>
           <tbody>
+            {/* cleared, with nothing said about `reconciled` — the
+                pre-migration shape, which isReconciled reads as committed. */}
             <TransactionRow {...defaultProps} />
           </tbody>
         </table>
       );
 
-      expect(screen.getByTestId('check-icon')).toBeInTheDocument();
+      expect(screen.getByTitle('Reconciled')).toHaveTextContent('R');
+      expect(screen.queryByText('C')).not.toBeInTheDocument();
     });
 
-    it('does not show check icon for uncleared transactions', () => {
+    it('shows C for a row that is only marked, not reconciled', () => {
+      const markedTransaction = {
+        ...mockTransaction,
+        cleared: true,
+        reconciled: false
+      };
+
+      render(
+        <table>
+          <tbody>
+            <TransactionRow {...defaultProps} transaction={markedTransaction} />
+          </tbody>
+        </table>
+      );
+
+      expect(screen.getByTitle(/not reconciled until you finalize/)).toHaveTextContent('C');
+      expect(screen.queryByTitle('Reconciled')).not.toBeInTheDocument();
+    });
+
+    it('shows no letter at all for an unmarked transaction', () => {
       const unclearedTransaction = {
         ...mockTransaction,
         cleared: false
@@ -209,7 +239,59 @@ describe('TransactionRow', () => {
         </table>
       );
 
-      expect(screen.queryByTestId('check-icon')).not.toBeInTheDocument();
+      expect(screen.queryByTitle('Reconciled')).not.toBeInTheDocument();
+      expect(screen.queryByTitle(/not reconciled until you finalize/)).not.toBeInTheDocument();
+    });
+
+    /**
+     * The row is memoised on a hand-written comparator, so every fact it draws
+     * has to be named in it. These two are the ones that change WITHOUT
+     * anything else about the row changing — a Finalize, and a save — which is
+     * exactly the shape a comparator forgets.
+     */
+    it('turns C into R the moment a reconciliation finishes', () => {
+      const marked = { ...mockTransaction, cleared: true, reconciled: false };
+      const { rerender } = render(
+        <table>
+          <tbody>
+            <TransactionRow {...defaultProps} transaction={marked} />
+          </tbody>
+        </table>
+      );
+      expect(screen.getByTitle(/not reconciled until you finalize/)).toHaveTextContent('C');
+
+      rerender(
+        <table>
+          <tbody>
+            <TransactionRow {...defaultProps} transaction={{ ...marked, reconciled: true }} />
+          </tbody>
+        </table>
+      );
+
+      expect(screen.getByTitle('Reconciled')).toHaveTextContent('R');
+    });
+
+    it('stops bolding a row the moment its review flag clears', () => {
+      const arrived = { ...mockTransaction, needsReview: true };
+      const { rerender } = render(
+        <table>
+          <tbody>
+            <TransactionRow {...defaultProps} transaction={arrived} />
+          </tbody>
+        </table>
+      );
+      expect(screen.getByText('Grocery Store Purchase')).toHaveClass('font-semibold');
+
+      rerender(
+        <table>
+          <tbody>
+            <TransactionRow {...defaultProps} transaction={{ ...arrived, needsReview: false }} />
+          </tbody>
+        </table>
+      );
+
+      expect(screen.getByText('Grocery Store Purchase')).not.toHaveClass('font-semibold');
+      expect(screen.queryByText(/new, not reviewed yet/)).not.toBeInTheDocument();
     });
   });
 
@@ -227,8 +309,8 @@ describe('TransactionRow', () => {
       const trendingIcon = screen.getByTestId('trending-down-icon');
       expect(trendingIcon).toHaveAttribute('data-size', '16');
 
-      const checkIcon = screen.getByTestId('check-icon');
-      expect(checkIcon).toHaveAttribute('data-size', '14');
+      // The C/R letter is text, not an icon, so it shrinks by type scale.
+      expect(screen.getByTitle('Reconciled')).toHaveClass('text-sm');
 
       // Check button icon sizes
       const editIcon = screen.getByTestId('edit-icon');
@@ -248,8 +330,7 @@ describe('TransactionRow', () => {
       const trendingIcon = screen.getByTestId('trending-down-icon');
       expect(trendingIcon).toHaveAttribute('data-size', '20');
 
-      const checkIcon = screen.getByTestId('check-icon');
-      expect(checkIcon).toHaveAttribute('data-size', '16');
+      expect(screen.getByTitle('Reconciled')).not.toHaveClass('text-sm');
     });
   });
 
@@ -433,7 +514,7 @@ describe('TransactionRow', () => {
       );
 
       // Should not show reconciled, account, category, or actions
-      expect(screen.queryByTestId('check-icon')).not.toBeInTheDocument();
+      expect(screen.queryByTitle('Reconciled')).not.toBeInTheDocument();
       expect(screen.queryByText('Checking Account')).not.toBeInTheDocument();
       expect(screen.queryByText('Food & Dining > Groceries')).not.toBeInTheDocument();
       expect(screen.queryByTestId('edit-button')).not.toBeInTheDocument();

--- a/src/components/TransactionRow.tsx
+++ b/src/components/TransactionRow.tsx
@@ -1,12 +1,50 @@
 import React, { memo, useCallback, useMemo, useState } from 'react';
 import type { Transaction, Account } from '../types';
-import { TrendingUpIcon, TrendingDownIcon, CheckIcon, EditIcon, DeleteIcon } from './icons';
+import { TrendingUpIcon, TrendingDownIcon, EditIcon, DeleteIcon } from './icons';
 import { IconButton } from './icons/IconButton';
 import MarkdownNote from './MarkdownNote';
 import MoneyInput from './common/MoneyInput';
 import SuggestedCategoryBadge from './SuggestedCategoryBadge';
 import { isConfirmableSuggestion } from '../utils/categoryProvenance';
+import { isReconciled, isMarkedAwaitingFinalize } from '../utils/transactionReconciliation';
+import { isAwaitingReview } from '../utils/transactionReview';
+import { clickedOwnControl, useRowClickGesture } from '../hooks/useRowClickGesture';
+import { transactionRowDomId } from './transactionRowDomId';
 import { useFormattedDate } from '../hooks/useFormattedValues';
+
+/**
+ * The look of the row the keyboard is on, echoing the register's own active row
+ * (.selected-transaction-row in index.css): the same blue wash, the same
+ * #6B86B3 ring.
+ *
+ * ─ WHY UTILITIES AND NOT THAT CLASS ────────────────────────────────────────
+ * The register's rows are DIVs (VirtualizedTable), and three of that class's
+ * declarations only work on one: `margin: 4px 0` and `border-radius: 12px` do
+ * nothing at all on a `<tr>` in the CSS table model, and its `box-shadow` — the
+ * "lift" — is not painted on a table row while borders are collapsing, which
+ * Tailwind's preflight makes the default for every table in the app. The
+ * Accounts page reached the same conclusion from the other direction and
+ * echoed the look in utilities (ACCOUNT_ROW_SELECTED_CLASS); this is that
+ * pattern again, for a real table row.
+ *
+ * ─ THE RING IS DRAWN ON THE CELLS ──────────────────────────────────────────
+ * For the same reason: in the collapsing model a border on a `<tr>` is what the
+ * row separators already use, and the cell's border wins the collapse — so
+ * bordering the cells is the only way to draw one unbroken outline round the
+ * whole row, and it is the way that survives the row above being selected too.
+ *
+ * ─ AND WHY NOT font-weight: 600 ────────────────────────────────────────────
+ * The register's class emboldens the selected row. It cannot here, because on
+ * this page weight already says something else: a row that has arrived and not
+ * been reviewed is bold (see isAwaitingReview below), and emboldening the
+ * selected row would erase the only mark that says "this one is new" exactly
+ * when the user is looking straight at it. The register can afford the weight
+ * because it also has the lift; this row has to spend it on one fact only.
+ */
+export const TRANSACTION_ROW_SELECTED_CLASS =
+  'bg-blue-50/80 dark:bg-blue-900/30 ' +
+  '[&>td]:border-y [&>td]:border-[#6B86B3]/50 dark:[&>td]:border-[#6B86B3]/70 ' +
+  '[&>td:first-child]:border-l [&>td:last-child]:border-r';
 
 interface TransactionRowProps {
   transaction: Transaction;
@@ -22,6 +60,24 @@ interface TransactionRowProps {
   isSelected?: boolean;
   onToggleSelection?: (id: string) => void;
   enableBulkSelection?: boolean;
+  /**
+   * True for the ONE row the keyboard is on — the register's highlight, on this
+   * table. Distinct from `isSelected`, which is the bulk-selection checkbox:
+   * one says "where am I", the other says "what will the next bulk action act
+   * on". `enableBulkSelection` wins the row's click when it is on, because a
+   * row wearing a checkbox is a row whose click means "tick me".
+   */
+  isCurrentRow?: boolean;
+  /**
+   * Roving tabindex: exactly one row of a table is the tab stop, and the rest
+   * are reached with the arrows. A table of two hundred rows that made each one
+   * its own tab stop would take two hundred presses to get past.
+   */
+  isTabStop?: boolean;
+  /** A click on the row itself — never on one of its own controls. */
+  onRowClick?: (transaction: Transaction) => void;
+  /** A key pressed on the row itself — never inside one of its boxes. */
+  onRowKeyDown?: (event: React.KeyboardEvent<HTMLTableRowElement>, transaction: Transaction) => void;
   runningBalance?: number;
   onContextMenu?: (e: React.MouseEvent, transaction: Transaction) => void;
   categories?: Array<{ id: string; name: string }>;
@@ -63,6 +119,10 @@ export const TransactionRow = memo(function TransactionRow({
   isSelected = false,
   onToggleSelection,
   enableBulkSelection = false,
+  isCurrentRow = false,
+  isTabStop = false,
+  onRowClick,
+  onRowKeyDown,
   runningBalance,
   onContextMenu,
   categories: availableCategories,
@@ -74,7 +134,23 @@ export const TransactionRow = memo(function TransactionRow({
   const [editAmount, setEditAmount] = useState('');
   // Memoize formatted date
   const formattedDate = useFormattedDate(transaction.date, 'en-GB');
-  
+
+  /**
+   * Has this row arrived from an import with nobody having saved it since?
+   *
+   * The register's convention, and the ONE predicate every surface asks (see
+   * transactionReview): the date and description carry the weight, at opposite
+   * ends of the line, so the whole row reads as bold at a glance.
+   */
+  const awaitingReview = isAwaitingReview(transaction);
+
+  // Where the mouse went DOWN, so a click the browser synthesised on this row
+  // from a drag that began in one of its own boxes — the category picker, the
+  // amount box — is not mistaken for someone clicking the row. Per row rather
+  // than per table: a drag that starts in one row and ends in another has the
+  // TABLE as its common ancestor, so no row's onClick fires for it at all.
+  const { rowGestureProps, isSelectionTail } = useRowClickGesture();
+
   // Memoize formatted amount — accounting style: parentheses for expenses
   const formattedAmount = useMemo(() => {
     const isExpense = transaction.type === 'expense' || (transaction.type === 'transfer' && transaction.amount < 0);
@@ -128,25 +204,43 @@ export const TransactionRow = memo(function TransactionRow({
           >
             <div className="flex items-center gap-2">
               <TypeIcon type={transaction.type} amount={transaction.amount} compactView={compactView} />
-              <span className={compactView ? 'text-sm' : ''}>
+              <span className={`${compactView ? 'text-sm' : ''} ${awaitingReview ? 'font-semibold' : ''}`}>
                 {formattedDate}
               </span>
             </div>
           </td>
         );
-      
+
       case 'reconciled':
         return (
-          <td 
+          <td
             className={`${compactView ? 'py-1.5' : 'py-3'} px-2 text-center`}
             style={{ width: columnWidths.reconciled }}
           >
-            {transaction.cleared && (
-              <CheckIcon className="text-blue-600 mx-auto" size={compactView ? 14 : 16} data-testid="check-icon" />
-            )}
+            {/* Microsoft Money's own two letters, and the register's — C is a
+                mark made while balancing, R is a reconciliation that was
+                finished. One tick for both was what let a working mark pass for
+                settled work, and a cross-account list that disagreed with the
+                register about which is which would be worse than either.
+
+                Both branches go through the shared predicates
+                (transactionReconciliation), never `cleared` on its own: an
+                unanswered `reconciled` is judged by `cleared`, and that
+                fallback is the whole reason a pre-migration history does not
+                light up as unreconciled. */}
+            {isReconciled(transaction) ? (
+              <span className={`text-blue-600 dark:text-blue-400 font-semibold ${compactView ? 'text-sm' : ''}`} title="Reconciled">R</span>
+            ) : isMarkedAwaitingFinalize(transaction) ? (
+              <span
+                className={`text-gray-500 dark:text-gray-400 font-semibold ${compactView ? 'text-sm' : ''}`}
+                title="Marked while balancing — not reconciled until you finalize"
+              >
+                C
+              </span>
+            ) : null}
           </td>
         );
-      
+
       case 'account':
         return (
           <td 
@@ -167,12 +261,20 @@ export const TransactionRow = memo(function TransactionRow({
           >
             <div className="flex items-start gap-3">
               <div className="flex flex-col flex-1 min-w-0">
-                <span 
-                  className={`${compactView ? 'text-sm' : ''} truncate ${onView ? 'cursor-pointer hover:text-primary' : ''}`}
+                <span
+                  className={`${compactView ? 'text-sm' : ''} truncate ${awaitingReview ? 'font-semibold' : ''} ${onView ? 'cursor-pointer hover:text-primary' : ''}`}
                   onClick={onView ? handleView : undefined}
                 >
                   {transaction.description}
                 </span>
+                {/* WEIGHT IS A VISUAL CUE AND NOTHING ELSE (WCAG 1.4.1). Bold is
+                    invisible to a screen reader and to anyone reading the list
+                    one row at a time in a magnifier, so the fact is also stated
+                    in words — off-screen, because on-screen it would be a second
+                    marker for one fact and the whole point of the bold is that
+                    it costs the row no space. The register says it the same way,
+                    in the same words. */}
+                {awaitingReview && <span className="sr-only">— new, not reviewed yet</span>}
                 {transaction.notes && (
                   <div className={`${compactView ? 'text-xs' : 'text-sm'} text-gray-500 dark:text-gray-400`}>
                     <MarkdownNote content={transaction.notes} />
@@ -391,17 +493,67 @@ export const TransactionRow = memo(function TransactionRow({
     onUpdateCategory,
     isEditingAmount,
     editAmount,
-    onUpdateAmount
+    onUpdateAmount,
+    awaitingReview
   ]);
 
+  /**
+   * A click on the row — which is not the same thing as a click that merely
+   * ENDED on the row.
+   *
+   * Two guards, and they answer different questions. `isSelectionTail` is about
+   * where the gesture BEGAN: a drag that started in the amount box and was let
+   * go a few pixels outside it arrives here as a click on the row, and it must
+   * change nothing at all, or the re-render collapses the very text the user
+   * was selecting. `clickedOwnControl` is about where the click LANDED: Edit,
+   * Delete, the category button and the amount button are each a request to do
+   * that thing, never a request to pick the row out.
+   */
+  const handleRowClick = useCallback((event: React.MouseEvent<HTMLTableRowElement>): void => {
+    if (isSelectionTail()) return;
+    if (enableBulkSelection) {
+      // A row wearing a checkbox has already said what its click means.
+      handleToggleSelection();
+      return;
+    }
+    if (!onRowClick) return;
+    if (clickedOwnControl(event.target, event.currentTarget)) return;
+    onRowClick(transaction);
+  }, [isSelectionTail, enableBulkSelection, handleToggleSelection, onRowClick, transaction]);
+
+  const handleRowKeyDown = useCallback((event: React.KeyboardEvent<HTMLTableRowElement>): void => {
+    // A key pressed inside one of the row's own boxes belongs to that box:
+    // ArrowDown in the category picker must open its list, not walk the table,
+    // and Enter on the Edit button must press the button. Comparing target with
+    // currentTarget is the whole guard — the row hears only its own keys —
+    // which is why nothing here needs a list of exceptions for text entry.
+    if (event.target !== event.currentTarget) return;
+    onRowKeyDown?.(event, transaction);
+  }, [onRowKeyDown, transaction]);
+
+  // Selectable rows are drawn `select-none`, the same answer VirtualizedTable
+  // gives its clickable rows: a row whose own text can be dragged over would
+  // make a text-selection out of what was meant to be a click.
+  const isSelectable = !!onRowClick && !enableBulkSelection;
+
   return (
-    <tr 
+    <tr
+      id={transactionRowDomId(transaction.id)}
       className={`
-        ${isSelected ? 'bg-blue-50 dark:bg-blue-900/20' : 'hover:bg-gray-50 dark:hover:bg-gray-800'} 
-        ${enableBulkSelection ? 'cursor-pointer' : ''} 
+        ${isCurrentRow ? TRANSACTION_ROW_SELECTED_CLASS : isSelected ? 'bg-blue-50 dark:bg-blue-900/20' : 'hover:bg-gray-50 dark:hover:bg-gray-800'}
+        ${enableBulkSelection || isSelectable ? 'cursor-pointer' : ''}
+        ${isSelectable ? 'select-none focus:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-blue-500' : ''}
         transition-colors
       `}
-      onClick={enableBulkSelection ? handleToggleSelection : undefined}
+      // The row itself takes the focus as the selection moves, so a screen
+      // reader announces the whole line rather than relying on the marker
+      // alone — the same choice the Accounts list made, and the reason
+      // aria-current is enough here without giving the table grid semantics.
+      tabIndex={isSelectable ? (isTabStop ? 0 : -1) : undefined}
+      aria-current={isCurrentRow ? 'true' : undefined}
+      {...(isSelectable ? rowGestureProps : {})}
+      onClick={enableBulkSelection || isSelectable ? handleRowClick : undefined}
+      onKeyDown={isSelectable ? handleRowKeyDown : undefined}
       onContextMenu={onContextMenu ? (e) => { e.preventDefault(); onContextMenu(e, transaction); } : undefined}
     >
       {enableBulkSelection && (
@@ -434,11 +586,23 @@ export const TransactionRow = memo(function TransactionRow({
     prevProps.transaction.categoryConfirmed === nextProps.transaction.categoryConfirmed &&
     prevProps.transaction.isSplit === nextProps.transaction.isSplit &&
     prevProps.transaction.cleared === nextProps.transaction.cleared &&
+    // Both halves of the C/R column, because they are two different facts: a
+    // Finalize moves a row from C to R without touching `cleared`, and a row
+    // left out of this comparison would keep drawing the letter it had.
+    prevProps.transaction.reconciled === nextProps.transaction.reconciled &&
+    // Saving an imported row clears its bold and nothing else about it — same
+    // description, same amount, same category. Left out, the row would stay
+    // bold until something unrelated forced a re-render.
+    prevProps.transaction.needsReview === nextProps.transaction.needsReview &&
     prevProps.account?.id === nextProps.account?.id &&
     prevProps.categoryPath === nextProps.categoryPath &&
     prevProps.compactView === nextProps.compactView &&
     prevProps.isSelected === nextProps.isSelected &&
     prevProps.enableBulkSelection === nextProps.enableBulkSelection &&
+    // The highlight and the tab stop both move between two rows at a time. Left
+    // out, the arrow keys would change the state and repaint nothing.
+    prevProps.isCurrentRow === nextProps.isCurrentRow &&
+    prevProps.isTabStop === nextProps.isTabStop &&
     // Check if column order or widths have changed
     JSON.stringify(prevProps.columnOrder) === JSON.stringify(nextProps.columnOrder) &&
     JSON.stringify(prevProps.columnWidths) === JSON.stringify(nextProps.columnWidths)

--- a/src/components/__tests__/ScrollResetOnNavigate.test.tsx
+++ b/src/components/__tests__/ScrollResetOnNavigate.test.tsx
@@ -1,0 +1,202 @@
+/**
+ * A new page opens at its own heading — and the three navigations that must be
+ * left alone.
+ *
+ * ─ WHAT JSDOM CAN AND CANNOT SAY ───────────────────────────────────────────
+ * It does not lay anything out and it does not scroll, so `window.scrollY` is
+ * always 0 and asserting an offset here would assert nothing. src/test/setup.ts
+ * already replaces window.scrollTo with a no-op to keep jsdom quiet; these
+ * tests watch that no-op instead. The REQUEST is the observable behaviour, and
+ * the request is what the component is responsible for.
+ *
+ * The ordering test is the one that matters most, and it is real: it asserts
+ * that the reset is asked for BEFORE the arriving page's callback ref brings
+ * its row into view, using the order the two mocks were actually called in.
+ * Move this component after <Routes> and that test fails, which is exactly the
+ * regression it exists to catch — a reset that lands on top of a deep link is
+ * worse than no reset at all.
+ *
+ * Every account id below is invented: this repo is public.
+ */
+import React from 'react';
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { MemoryRouter, Route, Routes, useLocation, useNavigate } from 'react-router-dom';
+import ScrollResetOnNavigate from '../ScrollResetOnNavigate';
+
+const REGISTER_PATH = '/accounts/acc-synthetic';
+
+/**
+ * Every navigation the app actually performs, as buttons: a link to another
+ * page, a redirect, a deep link consuming itself with a same-pathname replace,
+ * a filter writing itself into the address bar, and Back.
+ */
+function Page({ name }: { name: string }): React.JSX.Element {
+  const location = useLocation();
+  const navigate = useNavigate();
+  return (
+    <div>
+      <h1>{name}</h1>
+      <span data-testid="where">{`${location.pathname}${location.search}`}</span>
+      <button type="button" onClick={() => navigate(REGISTER_PATH)}>
+        open the register
+      </button>
+      <button type="button" onClick={() => navigate('/reports', { replace: true })}>
+        redirect to reports
+      </button>
+      <button
+        type="button"
+        onClick={() => navigate({ pathname: location.pathname, search: '' }, { replace: true })}
+      >
+        consume the parameter
+      </button>
+      <button
+        type="button"
+        onClick={() => navigate({ pathname: location.pathname, search: '?payee=synthetic' })}
+      >
+        filter in place
+      </button>
+      <button type="button" onClick={() => navigate(-1)}>
+        back
+      </button>
+    </div>
+  );
+}
+
+const renderAt = (entry: string): void => {
+  render(
+    <MemoryRouter initialEntries={[entry]}>
+      <ScrollResetOnNavigate />
+      <Routes>
+        <Route path="/accounts" element={<Page name="Accounts" />} />
+        <Route path={REGISTER_PATH} element={<Page name="Register" />} />
+        <Route path="/reports" element={<Page name="Reports" />} />
+      </Routes>
+    </MemoryRouter>
+  );
+};
+
+const where = (): string => screen.getByTestId('where').textContent ?? '';
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('ScrollResetOnNavigate — going somewhere new', () => {
+  it('lands at the top when a link opens another page', () => {
+    renderAt('/accounts');
+    const scrolls = vi.spyOn(window, 'scrollTo');
+
+    fireEvent.click(screen.getByRole('button', { name: 'open the register' }));
+
+    expect(where()).toBe(REGISTER_PATH);
+    expect(scrolls).toHaveBeenCalledWith(0, 0);
+  });
+
+  it('lands at the top when a redirect replaces one page with another', () => {
+    renderAt('/accounts');
+    const scrolls = vi.spyOn(window, 'scrollTo');
+
+    fireEvent.click(screen.getByRole('button', { name: 'redirect to reports' }));
+
+    expect(where()).toBe('/reports');
+    expect(scrolls).toHaveBeenCalledWith(0, 0);
+  });
+
+  it('leaves the opening page of a session where the browser put it', () => {
+    const scrolls = vi.spyOn(window, 'scrollTo');
+
+    renderAt('/accounts');
+
+    expect(where()).toBe('/accounts');
+    expect(scrolls).not.toHaveBeenCalled();
+  });
+});
+
+describe('ScrollResetOnNavigate — the navigations it must not touch', () => {
+  /**
+   * Back is the browser's, and the browser restores the offset of the entry it
+   * is returning to on its own. Forcing the top here would mean coming back to
+   * a two-hundred-row list at row one, every time.
+   */
+  it('does not scroll on Back — native restoration is left to do its job', () => {
+    renderAt('/accounts');
+    fireEvent.click(screen.getByRole('button', { name: 'open the register' }));
+    const scrolls = vi.spyOn(window, 'scrollTo');
+
+    fireEvent.click(screen.getByRole('button', { name: 'back' }));
+
+    expect(where()).toBe('/accounts');
+    expect(scrolls).not.toHaveBeenCalled();
+  });
+
+  /**
+   * The reports hub, the register's ?txn= link and the duplicate sweep all
+   * consume their arrival parameters with a replace onto the SAME pathname.
+   * That is not a navigation the reader made, and it must not move them.
+   */
+  it('does not scroll when a deep link consumes its own parameter in place', () => {
+    renderAt('/reports?period=this-month&focus=synthetic');
+    const scrolls = vi.spyOn(window, 'scrollTo');
+
+    fireEvent.click(screen.getByRole('button', { name: 'consume the parameter' }));
+
+    expect(where()).toBe('/reports');
+    expect(scrolls).not.toHaveBeenCalled();
+  });
+
+  it('does not scroll when a filter writes itself into the address bar', () => {
+    renderAt('/accounts');
+    const scrolls = vi.spyOn(window, 'scrollTo');
+
+    fireEvent.click(screen.getByRole('button', { name: 'filter in place' }));
+
+    expect(where()).toBe('/accounts?payee=synthetic');
+    expect(scrolls).not.toHaveBeenCalled();
+  });
+});
+
+describe('ScrollResetOnNavigate — composing with the arrival scrolls', () => {
+  /**
+   * The register's ?txn= row, the accounts row you came back from, a drilled
+   * report's point: each is delivered by a callback ref or a retry once the
+   * page has mounted. The reset has to have happened FIRST, or it wipes out the
+   * very thing the navigation was for.
+   *
+   * `invocationCallOrder` is a global counter across all vitest mocks, so
+   * comparing the two is a genuine "which happened first" and not a proxy.
+   */
+  it('resets before the arriving page brings its row into view', () => {
+    const arrived = vi.fn();
+
+    /** The shape of every arrival in the app: a row that scrolls itself in. */
+    function ArrivalPage(): React.JSX.Element {
+      return (
+        <div
+          ref={(node) => {
+            if (node !== null) arrived();
+          }}
+        >
+          the row the link pointed at
+        </div>
+      );
+    }
+
+    const scrolls = vi.spyOn(window, 'scrollTo');
+    render(
+      <MemoryRouter initialEntries={['/accounts']}>
+        <ScrollResetOnNavigate />
+        <Routes>
+          <Route path="/accounts" element={<Page name="Accounts" />} />
+          <Route path={REGISTER_PATH} element={<ArrivalPage />} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'open the register' }));
+
+    expect(scrolls).toHaveBeenCalledWith(0, 0);
+    expect(arrived).toHaveBeenCalled();
+    expect(scrolls.mock.invocationCallOrder[0]).toBeLessThan(arrived.mock.invocationCallOrder[0]);
+  });
+});

--- a/src/components/__tests__/TransactionRow.test.tsx
+++ b/src/components/__tests__/TransactionRow.test.tsx
@@ -110,9 +110,9 @@ describe('TransactionRow', () => {
 
     renderInTable(<TransactionRow {...defaultProps} transaction={transaction} />);
 
-    // Look for the CheckIcon in the reconciled column
-    const checkIcon = screen.getByTestId('check-icon');
-    expect(checkIcon).toBeInTheDocument();
+    // Money's letters, not a tick: cleared with nothing said about `reconciled`
+    // is the pre-migration shape, which isReconciled reads as committed.
+    expect(screen.getByTitle('Reconciled')).toHaveTextContent('R');
   });
 
   it('does not show cleared indicator when transaction is not cleared', () => {
@@ -122,7 +122,7 @@ describe('TransactionRow', () => {
 
     renderInTable(<TransactionRow {...defaultProps} transaction={transaction} />);
 
-    expect(screen.queryByTestId('check-icon')).not.toBeInTheDocument();
+    expect(screen.queryByTitle('Reconciled')).not.toBeInTheDocument();
   });
 
   it('calls onEdit when edit button is clicked', () => {

--- a/src/components/reconciliation/ReconciliationBalanceBar.tsx
+++ b/src/components/reconciliation/ReconciliationBalanceBar.tsx
@@ -3,9 +3,22 @@ import { parseMoneyInput, toDecimal } from '../../utils/decimal';
 import MoneyInput from '../common/MoneyInput';
 import { useCurrencyDecimal } from '../../hooks/useCurrencyDecimal';
 import { formatDate } from '../../utils/dateFormatter';
+import { UNCONFIRMED_YELLOW, CONFIRM_BALANCE_HINT_ID } from './unconfirmedYellow';
 import type { ClearedSummary } from '../../hooks/useReconciliation';
 
 interface ReconciliationBalanceBarProps {
+  /**
+   * The figure this reconciliation is settled against — the statement's
+   * CLOSING balance, in Money's vocabulary, which is what every label on this
+   * bar calls it.
+   *
+   * The prop keeps the account field's name because that is the field
+   * `onBankBalanceChange` writes back to. The two are not the same fact: the
+   * account's `bankBalance` is what the feed last said, while what arrives
+   * here may instead be the balance the last reconciliation ended on (the
+   * parent falls back to it), and either way it is only a PROPOSED closing
+   * balance until the user confirms it.
+   */
   bankBalance: number | null;
   accountBalance: number;
   clearedBalance: number;
@@ -49,9 +62,9 @@ interface ReconciliationBalanceBarProps {
  * different screen.
  */
 const REMOVE_CONSEQUENCE =
-  'Remove the bank balance. Difference goes back to N/A until you enter another.';
+  'Remove the closing balance. Difference goes back to N/A until you enter another.';
 const REMOVE_CONSEQUENCE_WITH_FALLBACK =
-  'Remove the bank balance. Difference falls back to the balance your last reconciliation ended on, which you would then have to confirm.';
+  'Remove the closing balance. Difference falls back to the balance your last reconciliation ended on, which you would then have to confirm.';
 
 /**
  * Why Finalize is refusing, said beside the box that is refusing it — the
@@ -60,7 +73,7 @@ const REMOVE_CONSEQUENCE_WITH_FALLBACK =
  * looked at.
  */
 export const CONFIRM_BALANCE_CONSEQUENCE =
-  'Confirm the bank balance to finish. Until you do, your marks stay a working list and nothing is reconciled.';
+  'Confirm the closing balance to finish. Until you do, your marks stay a working list and nothing is reconciled.';
 
 export default function ReconciliationBalanceBar({
   bankBalance,
@@ -85,6 +98,16 @@ export default function ReconciliationBalanceBar({
   const editFormRef = useRef<HTMLFormElement>(null);
 
   const displayBankBalance = pendingBankBalance ? pendingBankBalance.value : bankBalance;
+  /**
+   * The one fact the yellow stands for: this figure has not been agreed to.
+   *
+   * Every control on this bar that wears UNCONFIRMED_YELLOW branches on THIS
+   * single boolean — and it is the negation of the gate Finalize is disabled
+   * by — so the two yellows are one fact shown twice rather than two that
+   * happen to agree today. There is no state in which one of them resolves
+   * without the other.
+   */
+  const awaitingConfirmation = !balanceConfirmed;
   const removeConsequence = lastReconciledBalance != null
     ? REMOVE_CONSEQUENCE_WITH_FALLBACK
     : REMOVE_CONSEQUENCE;
@@ -126,9 +149,12 @@ export default function ReconciliationBalanceBar({
       {/* Four figures side by side needs ~90px each; a 375px phone has room
           for two. */}
       <div className="grid grid-cols-2 gap-3 md:grid-cols-4 md:gap-4">
-        {/* Bank Balance */}
+        {/* Closing Balance — the statement's ending figure, Money's own name
+            for it, and the one this reconciliation is settled against. Not the
+            account's live "Bank Bal" on the Accounts page: that is whatever the
+            feed last said, a different fact that nobody has to agree to. */}
         <div className="text-center">
-          <p className="text-xs text-gray-500 dark:text-gray-400 mb-1">Bank Balance</p>
+          <p className="text-xs text-gray-500 dark:text-gray-400 mb-1">Closing Balance</p>
           {displayBankBalance != null && !isEditingBankBalance ? (
             <button
               type="button"
@@ -136,7 +162,16 @@ export default function ReconciliationBalanceBar({
                 setEditValue(String(displayBankBalance));
                 setIsEditingBankBalance(true);
               }}
-              className="text-lg font-bold text-gray-900 dark:text-white hover:text-primary transition-colors cursor-pointer"
+              /* Colour is never the only signal: the reason is spoken here too,
+                 and only while the paragraph holding it is actually rendered. */
+              aria-describedby={awaitingConfirmation ? CONFIRM_BALANCE_HINT_ID : undefined}
+              /* The border width is carried in BOTH branches (transparent once
+                 confirmed) so resolving the yellow does not move the figure. */
+              className={`text-lg font-bold border rounded-lg px-2 py-0.5 transition-colors cursor-pointer ${
+                awaitingConfirmation
+                  ? UNCONFIRMED_YELLOW
+                  : 'border-transparent text-gray-900 dark:text-white hover:text-primary'
+              }`}
               title="Click to change or remove"
             >
               {formatCurrency(displayBankBalance, currency)}
@@ -154,8 +189,19 @@ export default function ReconciliationBalanceBar({
                   setEditValue(value);
                   onBalanceEdited?.();
                 }}
-                className="w-full px-2 py-1 text-sm border rounded dark:bg-gray-700 dark:border-gray-600 dark:text-white"
-                aria-label="Bank balance"
+                /* The editor is the affordance in its open state, so it wears
+                   the same yellow — the first keystroke that withdraws a
+                   confirmation turns the box and Finalize together. Swapped,
+                   never appended: the dark surface classes below and the
+                   token's would otherwise both apply and Tailwind would settle
+                   it by CSS source order. */
+                className={`w-full px-2 py-1 text-sm border rounded ${
+                  awaitingConfirmation
+                    ? UNCONFIRMED_YELLOW
+                    : 'dark:bg-gray-700 dark:border-gray-600 dark:text-white'
+                }`}
+                aria-label="Closing balance"
+                aria-describedby={awaitingConfirmation ? CONFIRM_BALANCE_HINT_ID : undefined}
                 autoFocus
                 onKeyDown={event => {
                   // Enter commits AND confirms. Written out rather than left to
@@ -198,8 +244,14 @@ export default function ReconciliationBalanceBar({
             </form>
           ) : (
             <button
+              type="button"
               onClick={() => setIsEditingBankBalance(true)}
-              className="text-sm text-primary hover:underline"
+              aria-describedby={awaitingConfirmation ? CONFIRM_BALANCE_HINT_ID : undefined}
+              className={`text-sm font-medium border rounded-lg px-2 py-0.5 transition-colors ${
+                awaitingConfirmation
+                  ? UNCONFIRMED_YELLOW
+                  : 'border-transparent text-primary hover:underline'
+              }`}
             >
               Enter balance
             </button>
@@ -263,9 +315,9 @@ export default function ReconciliationBalanceBar({
       {/* Why Finalize is refusing, beside the box that is refusing it. Said as
           the consequence — what the marks are worth until it is done — rather
           than as an instruction with no reason attached. */}
-      {!balanceConfirmed && (
+      {awaitingConfirmation && (
         <p
-          id="reconciliation-confirm-hint"
+          id={CONFIRM_BALANCE_HINT_ID}
           className="mt-3 text-xs text-amber-700 dark:text-amber-400 text-center"
         >
           {CONFIRM_BALANCE_CONSEQUENCE}

--- a/src/components/reconciliation/ReconciliationFinalizationModal.tsx
+++ b/src/components/reconciliation/ReconciliationFinalizationModal.tsx
@@ -10,7 +10,8 @@ import { deriveAdjustment } from '../../utils/reconciliation';
 interface ReconciliationFinalizationModalProps {
   isOpen: boolean;
   /**
-   * The ending balance the user CONFIRMED, never a bare bank balance.
+   * The closing balance the user CONFIRMED — never a figure merely proposed by
+   * a feed or an import.
    *
    * A number, not `number | null`, and that is the type doing the work: this
    * modal cannot be opened without one (the Finalize button is disabled until
@@ -160,14 +161,16 @@ export default function ReconciliationFinalizationModal({
           /* Unbalanced — create adjustment(s) until the difference is zero */
           <div>
             <div className="bg-red-50 dark:bg-red-900/20 rounded-lg p-4 mb-4">
+              {/* Named exactly as the balance bar names it — the figure the
+                  user confirmed there is the figure being subtracted here. */}
               <p className="text-sm text-red-600 dark:text-red-400 mb-1">
-                Difference between bank balance and cleared balance:
+                Difference between closing balance and cleared balance:
               </p>
               <p className="text-2xl font-bold text-red-600 dark:text-red-400">
                 {formatCurrency(difference, currency)}
               </p>
               <div className="mt-2 text-xs text-red-500 dark:text-red-400 space-y-1">
-                <p>Bank Balance: {formatCurrency(confirmedBalance, currency)}</p>
+                <p>Closing Balance: {formatCurrency(confirmedBalance, currency)}</p>
                 <p>Cleared Balance: {formatCurrency(clearedBalance, currency)}</p>
               </div>
             </div>

--- a/src/components/reconciliation/__tests__/ReconciliationBalanceBar.test.tsx
+++ b/src/components/reconciliation/__tests__/ReconciliationBalanceBar.test.tsx
@@ -3,11 +3,15 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { screen, fireEvent } from '@testing-library/react';
 import { renderWithProviders } from '../../../test/testUtils';
 import ReconciliationBalanceBar from '../ReconciliationBalanceBar';
+import { UNCONFIRMED_YELLOW, CONFIRM_BALANCE_HINT_ID } from '../unconfirmedYellow';
 
 /**
- * The bank balance is the only figure on this bar a person can type, and until
- * now it was write-only: once any number existed there was no way back to "no
- * bank balance" and a Difference of N/A. These tests hold the way back open.
+ * The closing balance — the statement's ending figure — is the only number on
+ * this bar a person can type, and until recently it was write-only: once any
+ * number existed there was no way back to "no closing balance" and a Difference
+ * of N/A. These tests hold the way back open.
+ *
+ * Every figure here is invented: this repo is public.
  */
 describe('ReconciliationBalanceBar', () => {
   const onBankBalanceChange = vi.fn();
@@ -53,7 +57,7 @@ describe('ReconciliationBalanceBar', () => {
   it('reports a removal as null, not as a number', () => {
     renderBar(220);
     openEditor();
-    fireEvent.click(screen.getByRole('button', { name: /Remove the bank balance/ }));
+    fireEvent.click(screen.getByRole('button', { name: /Remove the closing balance/ }));
 
     expect(onBankBalanceChange).toHaveBeenCalledTimes(1);
     expect(onBankBalanceChange).toHaveBeenCalledWith(null);
@@ -64,7 +68,7 @@ describe('ReconciliationBalanceBar', () => {
     openEditor();
     expect(
       screen.getByRole('button', {
-        name: 'Remove the bank balance. Difference goes back to N/A until you enter another.'
+        name: 'Remove the closing balance. Difference goes back to N/A until you enter another.'
       })
     ).toBeInTheDocument();
   });
@@ -74,7 +78,7 @@ describe('ReconciliationBalanceBar', () => {
     // already show the state the user asked for, or the click looks ignored.
     renderBar(220);
     openEditor();
-    fireEvent.click(screen.getByRole('button', { name: /Remove the bank balance/ }));
+    fireEvent.click(screen.getByRole('button', { name: /Remove the closing balance/ }));
 
     expect(screen.getByText('N/A')).toBeInTheDocument();
     expect(screen.getByText('Enter balance')).toBeInTheDocument();
@@ -83,18 +87,18 @@ describe('ReconciliationBalanceBar', () => {
   it('offers no removal until there is something to remove', () => {
     renderBar(null);
     fireEvent.click(screen.getByText('Enter balance'));
-    expect(screen.queryByRole('button', { name: /Remove the bank balance/ })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /Remove the closing balance/ })).not.toBeInTheDocument();
   });
 
   it('keeps the editor open while focus moves onto Remove', () => {
     renderBar(220);
     openEditor();
-    const input = screen.getByLabelText('Bank balance');
-    const remove = screen.getByRole('button', { name: /Remove the bank balance/ });
+    const input = screen.getByLabelText('Closing balance');
+    const remove = screen.getByRole('button', { name: /Remove the closing balance/ });
 
     fireEvent.blur(input, { relatedTarget: remove });
 
-    expect(screen.getByRole('button', { name: /Remove the bank balance/ })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Remove the closing balance/ })).toBeInTheDocument();
     expect(onBankBalanceChange).not.toHaveBeenCalled();
   });
 
@@ -102,7 +106,7 @@ describe('ReconciliationBalanceBar', () => {
     // Emptying the box is not removing: that is what Remove is for.
     renderBar(220);
     openEditor();
-    const input = screen.getByLabelText('Bank balance');
+    const input = screen.getByLabelText('Closing balance');
     fireEvent.change(input, { target: { value: '' } });
     fireEvent.blur(input);
 
@@ -113,7 +117,7 @@ describe('ReconciliationBalanceBar', () => {
   it('still writes an ordinary edit as a number', () => {
     renderBar(220);
     openEditor();
-    const input = screen.getByLabelText('Bank balance');
+    const input = screen.getByLabelText('Closing balance');
     fireEvent.change(input, { target: { value: '180.55' } });
     fireEvent.blur(input);
 
@@ -123,7 +127,7 @@ describe('ReconciliationBalanceBar', () => {
   it('accepts a negative balance for an overdrawn account', () => {
     renderBar(null);
     fireEvent.click(screen.getByText('Enter balance'));
-    const input = screen.getByLabelText('Bank balance');
+    const input = screen.getByLabelText('Closing balance');
     fireEvent.change(input, { target: { value: '-42.10' } });
     fireEvent.blur(input);
 
@@ -135,7 +139,7 @@ describe('ReconciliationBalanceBar', () => {
       renderBar(220);
       expect(screen.getByRole('button', { name: 'Confirm' })).toBeInTheDocument();
       expect(
-        screen.getByText(/Confirm the bank balance to finish\. Until you do, your marks stay a working list/)
+        screen.getByText(/Confirm the closing balance to finish\. Until you do, your marks stay a working list/)
       ).toBeInTheDocument();
     });
 
@@ -149,20 +153,20 @@ describe('ReconciliationBalanceBar', () => {
       renderBar(220, { balanceConfirmed: true });
       expect(screen.getByText('Confirmed')).toBeInTheDocument();
       expect(screen.queryByRole('button', { name: 'Confirm' })).not.toBeInTheDocument();
-      expect(screen.queryByText(/Confirm the bank balance to finish/)).not.toBeInTheDocument();
+      expect(screen.queryByText(/Confirm the closing balance to finish/)).not.toBeInTheDocument();
     });
 
     it('reports an edit so the confirmation can lapse', () => {
       renderBar(220, { balanceConfirmed: true });
       openEditor();
-      fireEvent.change(screen.getByLabelText('Bank balance'), { target: { value: '221' } });
+      fireEvent.change(screen.getByLabelText('Closing balance'), { target: { value: '221' } });
       expect(onBalanceEdited).toHaveBeenCalled();
     });
 
     it('Enter records the typed figure AND confirms it', () => {
       renderBar(220);
       openEditor();
-      const input = screen.getByLabelText('Bank balance');
+      const input = screen.getByLabelText('Closing balance');
       fireEvent.change(input, { target: { value: '199.99' } });
       fireEvent.keyDown(input, { key: 'Enter' });
 
@@ -192,6 +196,106 @@ describe('ReconciliationBalanceBar', () => {
           name: /Difference falls back to the balance your last reconciliation ended on/
         })
       ).toBeInTheDocument();
+    });
+  });
+
+  /**
+   * Money's own word for the figure. It is the statement's CLOSING balance —
+   * what the account ended the period on — and not the account's live "Bank
+   * Bal" on the Accounts page, which is whatever the feed last said and which
+   * nobody is asked to agree to.
+   */
+  describe('the name of the figure', () => {
+    it('calls it the Closing Balance', () => {
+      renderBar(220);
+      expect(screen.getByText('Closing Balance')).toBeInTheDocument();
+      expect(screen.queryByText('Bank Balance')).not.toBeInTheDocument();
+    });
+
+    it('calls the box the same thing when it is open', () => {
+      renderBar(220);
+      openEditor();
+      expect(screen.getByLabelText('Closing balance')).toBeInTheDocument();
+    });
+
+    it('says it in the consequences too, so one word is used throughout', () => {
+      renderBar(220);
+      expect(screen.getByText(/Confirm the closing balance to finish/)).toBeInTheDocument();
+      openEditor();
+      expect(screen.getByRole('button', { name: /Remove the closing balance/ })).toBeInTheDocument();
+    });
+  });
+
+  /**
+   * The yellow that means "not yet", on the bar's side of the thread. That it
+   * is the SAME yellow as the Finalize button's is asserted where both are on
+   * screen at once — src/pages/__tests__/Reconciliation.yellowThread.test.tsx.
+   */
+  describe('the yellow that means "not yet"', () => {
+    /** Every amber utility an element carries, order-insensitive. */
+    const amber = (el: Element): string[] =>
+      el.className.split(/\s+/).filter(cls => cls.includes('amber-')).sort();
+
+    const TOKEN = UNCONFIRMED_YELLOW.split(/\s+/).filter(Boolean).sort();
+
+    it('the unconfirmed figure wears the shared token, whole', () => {
+      renderBar(220);
+      expect(amber(screen.getByTitle('Click to change or remove'))).toEqual(TOKEN);
+    });
+
+    it('so does the invitation to type one, because that is unconfirmed too', () => {
+      renderBar(null);
+      expect(amber(screen.getByRole('button', { name: 'Enter balance' }))).toEqual(TOKEN);
+    });
+
+    it('so does the open editor while nothing has been agreed to', () => {
+      renderBar(220);
+      openEditor();
+      expect(amber(screen.getByLabelText('Closing balance'))).toEqual(TOKEN);
+    });
+
+    it('leaves the open editor alone while the figure in it still stands agreed', () => {
+      // Opening the box is not editing it. The lapse belongs to the first
+      // keystroke, and the parent is what reports it back as unconfirmed.
+      renderBar(220, { balanceConfirmed: true });
+      openEditor();
+      expect(amber(screen.getByLabelText('Closing balance'))).toEqual([]);
+    });
+
+    it('settles to the bar’s ordinary styling once confirmed', () => {
+      renderBar(220, { balanceConfirmed: true });
+      const figure = screen.getByTitle('Click to change or remove');
+      expect(amber(figure)).toEqual([]);
+      expect(figure).toHaveClass('text-gray-900');
+    });
+
+    it('carries a border width while it is yellow, so resolving cannot move it', () => {
+      renderBar(220);
+      expect(screen.getByTitle('Click to change or remove')).toHaveClass('border');
+    });
+
+    it('carries the same border width once resolved, in transparent', () => {
+      // Without this the figure would jump two pixels the instant it was
+      // agreed to, and the whole four-up row would shuffle with it.
+      renderBar(220, { balanceConfirmed: true });
+      expect(screen.getByTitle('Click to change or remove'))
+        .toHaveClass('border', 'border-transparent');
+    });
+
+    it('never leaves the colour to carry the message on its own', () => {
+      renderBar(220);
+      expect(screen.getByTitle('Click to change or remove'))
+        .toHaveAttribute('aria-describedby', CONFIRM_BALANCE_HINT_ID);
+      expect(document.getElementById(CONFIRM_BALANCE_HINT_ID))
+        .toHaveTextContent(/Confirm the closing balance to finish/);
+    });
+
+    it('stops describing a reason once there is none to describe', () => {
+      // A dangling aria-describedby is worse than none: it promises an
+      // explanation the screen reader will not find.
+      renderBar(220, { balanceConfirmed: true });
+      expect(screen.getByTitle('Click to change or remove')).not.toHaveAttribute('aria-describedby');
+      expect(document.getElementById(CONFIRM_BALANCE_HINT_ID)).toBeNull();
     });
   });
 });

--- a/src/components/reconciliation/unconfirmedYellow.ts
+++ b/src/components/reconciliation/unconfirmedYellow.ts
@@ -1,0 +1,43 @@
+/**
+ * The yellow that means "not yet".
+ *
+ * ONE constant, worn by every control that is waiting on the same fact: the
+ * closing balance has not been confirmed. That is the closing-balance
+ * affordance on the balance bar (the figure, the invitation to type one, the
+ * editor) and the Finalize Reconciliation button in the page header. Sharing
+ * the literal string is the whole point — the eye is meant to read "this
+ * yellow is why that yellow", and two hand-copied class lists drift the first
+ * time either is touched. A thread that has drifted is worse than no thread,
+ * because the colours then claim a relationship that is no longer true.
+ *
+ * These eight utilities are exactly the amber vocabulary the Finalize button
+ * already shipped with — border, text and wash, in both themes — lifted out
+ * rather than re-picked, so nothing was approximated in the move.
+ *
+ * CONSTRAINT: swap this in, never append it. Every utility here sets a colour
+ * (background, text, border), and Tailwind resolves two utilities for the same
+ * property by CSS source order, not by their order in a className — so emitting
+ * this alongside `text-gray-900` or `dark:bg-gray-700` would leave the winner
+ * to whichever the compiler happened to write last. Callers pick one branch or
+ * the other.
+ *
+ * CONSTRAINT: colour only. Border WIDTH, radius, padding and typography stay
+ * with each element, because a header button and a figure in a four-up grid do
+ * not share those. Keeping this list purely `amber-*` is also what lets the
+ * structural test compare two elements' yellow exactly, and catch a hardcoded
+ * near-miss.
+ */
+export const UNCONFIRMED_YELLOW =
+  'bg-amber-100 text-amber-800 border-amber-300 hover:bg-amber-200 ' +
+  'dark:bg-amber-900/30 dark:text-amber-300 dark:border-amber-600 dark:hover:bg-amber-900/50';
+
+/**
+ * The id of the paragraph that says, in words, why the yellow is there.
+ *
+ * Lives here because the balance bar prints it and both the bar's affordance
+ * and the page's Finalize button point at it with `aria-describedby` — colour
+ * is never the only signal, and a hardcoded id in three files is a dangling
+ * reference waiting to happen. Referenced ONLY while that paragraph is
+ * rendered (i.e. while unconfirmed), so it never points at nothing.
+ */
+export const CONFIRM_BALANCE_HINT_ID = 'reconciliation-confirm-hint';

--- a/src/components/transactionRowDomId.ts
+++ b/src/components/transactionRowDomId.ts
@@ -1,0 +1,17 @@
+/**
+ * A transaction row's element id — the one string the row and the list that
+ * holds it must agree on.
+ *
+ * The row writes it; the list spends it, handing a row the focus by name as the
+ * selection moves (`document.getElementById`). It is the same mechanism the
+ * Accounts list uses for its own rows, and it lives in a module of its own for
+ * a mechanical reason: a file that exports components may not also export
+ * functions without breaking fast refresh, and this is a function.
+ *
+ * ─ CONSTRAINTS ─────────────────────────────────────────────────────────────
+ * Transaction ids are UUIDs, so the result is safe as an HTML id and as a
+ * getElementById argument, both of which take the string literally. It is never
+ * interpolated into a CSS selector — the one place where a stray character in
+ * an id would need escaping — and it should not start being.
+ */
+export const transactionRowDomId = (transactionId: string): string => `transaction-row-${transactionId}`;

--- a/src/hooks/useRowClickGesture.ts
+++ b/src/hooks/useRowClickGesture.ts
@@ -102,6 +102,40 @@ export function beganInEditingControl(target: EventTarget | null, boundary: Elem
   return match !== null && boundary.contains(match);
 }
 
+/**
+ * The controls a row can hold whose CLICK is their own, not the row's.
+ *
+ * Wider than EDITING_CONTROL_SELECTOR above and asking a different question.
+ * That one is about where a DRAG began; this one is about where a click LANDED,
+ * and a click that landed on the Edit button is a request to edit — never a
+ * request to pick the row out from its neighbours.
+ */
+const OWN_CONTROL_SELECTOR = 'a, button, input, select, textarea';
+
+/**
+ * Did this click land on one of the row's own controls?
+ *
+ * Bounded by the row (`row`), the way beganInEditingControl bounds its own
+ * search: only this row's subtree can speak for this row. A button anywhere
+ * else — the column header above it, say — says nothing about a click inside
+ * this row.
+ *
+ * Shared by every list whose rows can be picked out with a click: the Accounts
+ * list and the Transactions table both ask it, and one rule in one place is
+ * what stops "a click on a button also selects the row" from being true on one
+ * page and false on the other.
+ *
+ * NOT a replacement for the gesture hook below, and the two are not
+ * interchangeable: a click the browser SYNTHESISED on the row from a drag that
+ * began in one of its boxes has the ROW as its target, so this predicate says
+ * no about it, quite correctly. Rows that hold text boxes need both guards.
+ */
+export function clickedOwnControl(target: EventTarget | null, row: Element): boolean {
+  if (!(target instanceof Element)) return false;
+  const control = target.closest(OWN_CONTROL_SELECTOR);
+  return control !== null && row.contains(control);
+}
+
 export interface RowClickGesture {
   /**
    * Spread onto the clickable row, alongside its own onClick.

--- a/src/pages/AccountTransactions.tsx
+++ b/src/pages/AccountTransactions.tsx
@@ -2883,8 +2883,10 @@ export default function AccountTransactions() {
           categories={categories}
           // A phone is still looking at the REGISTER, with the same To Review
           // box above it and the same filter, so it gets the same bold. The
-          // Transactions page renders this identical list and does not ask for
-          // it, because there is no counter and no filter there to act on.
+          // Transactions page renders this identical list and now asks for it
+          // too — it grew the same counter and the same filter when it was
+          // brought up to this register's manners. A list that offers neither
+          // still gets the default and still says nothing.
           markNewArrivals
           formatCurrency={(n) => formatCurrency(n, account.currency)}
           onEdit={(t) => { setSelectedTransaction(t); setSelectedTransactionId(t.id); setIsEditModalOpen(true); }}

--- a/src/pages/Accounts.tsx
+++ b/src/pages/Accounts.tsx
@@ -58,6 +58,9 @@ import {
   ACCOUNT_ROW_SELECTED_CLASS,
 } from '../components/AccountRowColumns';
 import { useArrivalRowFocus } from '../hooks/useArrivalFocus';
+// The same predicate the Transactions table asks, kept in one place: a click on
+// a row's own button belongs to the button, on both pages.
+import { clickedOwnControl } from '../hooks/useRowClickGesture';
 import {
   currentPageProvenance,
   readResumeCrumbs,
@@ -87,22 +90,6 @@ function readStoredGrouping(): AccountGroupingOptions {
 
 /** A row's element id, so the arrow keys can hand it the focus by name. */
 const rowDomId = (accountId: string): string => `account-row-${accountId}`;
-
-/**
- * Did this click land on one of the row's own controls?
- *
- * Bounded by the row, the way useRowClickGesture bounds its own search: only
- * this row's subtree can speak for this row. A control anywhere else — the
- * section heading above it, say — says nothing about a click inside a card.
- *
- * `a` as well as `button`: the account NAME is a link now, and a click on it is
- * a request to open the account, not to pick the row out.
- */
-const clickedOwnControl = (target: EventTarget | null, row: Element): boolean => {
-  if (!(target instanceof Element)) return false;
-  const control = target.closest('a, button, input');
-  return control !== null && row.contains(control);
-};
 
 const isRecord = (value: unknown): value is Record<string, unknown> =>
   typeof value === 'object' && value !== null;

--- a/src/pages/Reconciliation.tsx
+++ b/src/pages/Reconciliation.tsx
@@ -7,6 +7,7 @@ import { useReconciliation } from '../hooks/useReconciliation';
 import ReconciliationAccountList, { type ReconciliationGroup } from '../components/reconciliation/ReconciliationAccountList';
 import { ALL_ACCOUNT_SECTIONS, sectionTypeForAccount } from '../utils/accountSections';
 import ReconciliationBalanceBar, { CONFIRM_BALANCE_CONSEQUENCE } from '../components/reconciliation/ReconciliationBalanceBar';
+import { UNCONFIRMED_YELLOW, CONFIRM_BALANCE_HINT_ID } from '../components/reconciliation/unconfirmedYellow';
 import ReconciliationTransactionList from '../components/reconciliation/ReconciliationTransactionList';
 import ReconciliationFinalizationModal from '../components/reconciliation/ReconciliationFinalizationModal';
 import EditTransactionModal from '../components/EditTransactionModal';
@@ -74,7 +75,8 @@ export default function Reconciliation() {
   // write is in flight, and reverts (with an error toast) if it fails.
   const [pendingCleared, setPendingCleared] = useState<Map<string, boolean>>(new Map());
   /**
-   * The bank balance the user has AGREED to, for this account, in this session.
+   * The closing balance the user has AGREED to, for this account, in this
+   * session.
    *
    * Deliberately in memory and deliberately per account. The owner asked to be
    * made to confirm a figure "each time", so next week's reconciliation must
@@ -174,7 +176,10 @@ export default function Reconciliation() {
   const clearedBalance = selectedAccountId ? computeClearedBalance(selectedAccountId) : 0;
   const clearedSummary = selectedAccountId ? computeClearedSummary(selectedAccountId) : undefined;
   /**
-   * The figure the balance bar shows, and the order it is looked for in:
+   * The closing balance the balance bar PROPOSES, and the order it is looked
+   * for in. Note that none of these sources is itself a closing balance: they
+   * are the best guesses at one, which is why the user has to agree before any
+   * of them can settle a reconciliation.
    *
    *  1. what the bank most recently said (a feed sync or an imported statement
    *     writes `bankBalance`) — the closest thing to the statement in hand;
@@ -556,14 +561,30 @@ export default function Reconciliation() {
           {/* Disabled with the reason attached, and the reason itself is printed
               on the balance bar right under the box that has to be confirmed —
               a disabled button that will not say why is how people conclude the
-              app is broken. */}
+              app is broken.
+              The yellow is the same constant the closing-balance affordance
+              wears, so the two are legible as one refusal: that figure is
+              unconfirmed, therefore this will not press. Confirm it and both
+              settle together — this becomes the app's ordinary primary action.
+              Deliberately NOT dimmed with disabled:opacity-50 any more: a
+              half-strength amber is not the same yellow as the bar's, which
+              would break the very thread this draws. Nothing was lost, because
+              the refusal was never carried by colour — the disabled attribute,
+              the not-allowed cursor, the title and the described-by hint all
+              still say it, and none of them are visual. */}
           <button
             type="button"
             onClick={() => setShowFinalizationModal(true)}
             disabled={!balanceConfirmed}
-            aria-describedby={balanceConfirmed ? undefined : 'reconciliation-confirm-hint'}
+            aria-describedby={balanceConfirmed ? undefined : CONFIRM_BALANCE_HINT_ID}
             title={balanceConfirmed ? undefined : CONFIRM_BALANCE_CONSEQUENCE}
-            className="flex items-center gap-2 px-4 py-2 bg-amber-100 text-amber-800 border border-amber-300 rounded-lg hover:bg-amber-200 transition-colors font-medium disabled:opacity-50 disabled:cursor-not-allowed dark:bg-amber-900/30 dark:text-amber-300 dark:border-amber-600 dark:hover:bg-amber-900/50"
+            /* Border width in both branches (transparent when ready) so the
+               button does not resize as the gate opens. */
+            className={`flex items-center gap-2 px-4 py-2 border rounded-lg transition-colors font-medium disabled:cursor-not-allowed ${
+              balanceConfirmed
+                ? 'border-transparent bg-[#1a2332] dark:bg-blue-600 text-white hover:bg-[#2d3a4d] dark:hover:bg-blue-700'
+                : UNCONFIRMED_YELLOW
+            }`}
           >
             <CheckCircleIcon size={18} />
             Finalize Reconciliation

--- a/src/pages/Transactions.tsx
+++ b/src/pages/Transactions.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useMemo, useCallback } from 'react';
+import React, { useState, useEffect, useMemo, useCallback, useRef } from 'react';
 import { useSearchParams , useNavigate, useLocation } from 'react-router-dom';
 import { useApp } from '../contexts/AppContextSupabase';
 import { usePreferences } from '../contexts/PreferencesContext';
@@ -23,6 +23,8 @@ import PageTip from '../components/PageTip';
 import TransactionContextMenu from '../components/TransactionContextMenu';
 import { useToast } from '../contexts/ToastContext';
 import { TransactionRow } from '../components/TransactionRow';
+import { transactionRowDomId } from '../components/transactionRowDomId';
+import { countAwaitingReview, isAwaitingReview } from '../utils/transactionReview';
 // Lazy load list components that are conditionally rendered
 const InfiniteScrollTransactionList = lazyWithRecovery(() => import('../components/InfiniteScrollTransactionList').then(m => ({ default: m.InfiniteScrollTransactionList })));
 import { useTransactionFilters } from '../hooks/useTransactionFilters';
@@ -59,11 +61,28 @@ const Transactions = React.memo(function Transactions() {
   const [transactionsPerPage, setTransactionsPerPage] = useState(20); // Increased for better UX
   const [sortField, setSortField] = useState<'date' | 'account' | 'description' | 'category' | 'amount'>('date');
   const [sortDirection, setSortDirection] = useState<'asc' | 'desc'>('desc');
-  const [bulkSelectMode, _setBulkSelectMode] = useState(false);
-  const [selectedTransactions, setSelectedTransactions] = useState<Set<string>>(new Set());
+  /**
+   * The ONE row the keyboard is on — the register's highlight, on this table.
+   *
+   * There is no bulk-selection mode here to fight with, and that is a fact
+   * rather than a hope: the page carried a `bulkSelectMode` flag whose setter
+   * was never called and a selected-id set that nothing could ever add to, so
+   * the desktop row's click did nothing at all and the phone list's checkboxes
+   * could never appear. Both are gone; the click was free, and this is what
+   * now has it. If a bulk mode is ever wanted here, TransactionRow still has
+   * the props for it and states which of the two wins the click.
+   */
+  const [selectedTransactionId, setSelectedTransactionId] = useState<string | null>(null);
+  /**
+   * "Show me only what has arrived and not been dealt with" — the register's
+   * To Review box, pressed.
+   */
+  const [reviewOnly, setReviewOnly] = useState(false);
   const [columnWidths, setColumnWidths] = useState({
     date: 110,
-    reconciled: 40,
+    // Room for the header word: this column is headed C/R, not R, because it
+    // now draws both of Money's letters.
+    reconciled: 56,
     account: 140,
     description: 260,
     category: 160,
@@ -109,6 +128,45 @@ const Transactions = React.memo(function Transactions() {
     categories,
     filterOptions,
     sortOptions
+  );
+
+  /**
+   * How many of the rows in front of the user have arrived and not been dealt
+   * with — the figure in the To Review box.
+   *
+   * COUNTED OVER THE ROWS THIS PAGE IS SHOWING, deliberately, and not over the
+   * whole book. The box is a button: pressing it must produce exactly this many
+   * rows, or the number is a lie the moment it is believed. The register counts
+   * the same predicate over its own filtered list for the same reason.
+   *
+   * `reviewOnly` is deliberately NOT a dependency: this counts the list BEFORE
+   * the review filter, so pressing the button cannot change the number the
+   * button is showing.
+   */
+  const toReviewCount = useMemo(
+    () => countAwaitingReview(filteredAndSortedTransactions),
+    [filteredAndSortedTransactions]
+  );
+
+  /**
+   * Nothing left to review ends the filter, rather than leaving somebody
+   * looking at an empty list with the button that got them there gone (the box
+   * hides itself at zero — the house rule that a zero count renders nothing).
+   *
+   * Cannot loop: toReviewCount is computed from the list above, without it.
+   */
+  useEffect(() => {
+    if (toReviewCount === 0) setReviewOnly(false);
+  }, [toReviewCount]);
+
+  /**
+   * The rows the page actually lists. One more filter on the end of the chain,
+   * applied here rather than inside the hook so the count above can be taken
+   * from the list without it.
+   */
+  const visibleTransactions = useMemo(
+    () => (reviewOnly ? filteredAndSortedTransactions.filter(isAwaitingReview) : filteredAndSortedTransactions),
+    [filteredAndSortedTransactions, reviewOnly]
   );
 
   // Get account ID from URL params
@@ -160,7 +218,11 @@ const Transactions = React.memo(function Transactions() {
       hidden: ''
     },
     reconciled: {
-      label: 'R',
+      // The register's own header, because the column now draws the register's
+      // own two letters: C is a mark made while balancing, R is a
+      // reconciliation that was finished. A column headed R that showed both
+      // would be naming one of the two states it holds.
+      label: 'C/R',
       sortable: false,
       className: 'text-center',
       cellClassName: 'px-2',
@@ -313,10 +375,10 @@ const Transactions = React.memo(function Transactions() {
 
   // Pagination logic - show all transactions if account is selected
   const showAllTransactions = !!accountIdFromUrl;
-  const totalPages = showAllTransactions ? 1 : Math.ceil(filteredAndSortedTransactions.length / transactionsPerPage);
+  const totalPages = showAllTransactions ? 1 : Math.ceil(visibleTransactions.length / transactionsPerPage);
   const startIndex = showAllTransactions ? 0 : (currentPage - 1) * transactionsPerPage;
-  const endIndex = showAllTransactions ? filteredAndSortedTransactions.length : startIndex + transactionsPerPage;
-  const paginatedTransactions = filteredAndSortedTransactions.slice(startIndex, endIndex);
+  const endIndex = showAllTransactions ? visibleTransactions.length : startIndex + transactionsPerPage;
+  const paginatedTransactions = visibleTransactions.slice(startIndex, endIndex);
 
   // Reset to page 1 when filters change
   const resetPagination = useCallback(() => {
@@ -346,6 +408,152 @@ const Transactions = React.memo(function Transactions() {
     setIsDetailsViewOpen(true);
   }, []);
 
+  // ── Picking a row out, and walking the list ────────────────────────────────
+  //
+  // The register's idiom, on this table: a click highlights the row, the arrows
+  // move the highlight, Enter opens whatever a click opens, Escape lets go.
+  //
+  // ─ WHY THE ROWS ARE READ THROUGH A REF ────────────────────────────────────
+  // TransactionRow is memoised on a hand-written comparator, so a handler whose
+  // identity changed with the selection would be either stale in every row or
+  // the cause of every row re-rendering on each arrow key — and this table has
+  // an "All transactions" page size. The two handlers below therefore keep ONE
+  // identity for the life of the page and read what they need from here.
+  //
+  // The rows are the ones ON SCREEN. The ends stop rather than wrap and rather
+  // than turning the page: the highlight can only ever be somewhere the user
+  // can see it, which is also why a row hidden by a filter or left on another
+  // page simply stops being the highlight without anything having to notice.
+  const navigationRef = useRef<{ rows: Transaction[]; selectedId: string | null }>({
+    rows: [],
+    selectedId: null
+  });
+  useEffect(() => {
+    navigationRef.current = { rows: paginatedTransactions, selectedId: selectedTransactionId };
+  }, [paginatedTransactions, selectedTransactionId]);
+
+  /**
+   * Highlight `id` and hand it the focus.
+   *
+   * The row is already rendered — only its tabindex changes — so it can be
+   * given the focus by name. `preventScroll` with `scrollIntoView({ block:
+   * 'nearest' })` after it: browsing wants the least scroll that shows the row,
+   * and none at all while it is already on screen. (The register centres
+   * instead, but only while a row is being EDITED, and no row is edited here.)
+   */
+  const selectRow = useCallback((id: string): void => {
+    setSelectedTransactionId(id);
+    const node = document.getElementById(transactionRowDomId(id));
+    node?.focus({ preventScroll: true });
+    node?.scrollIntoView?.({ block: 'nearest' });
+  }, []);
+
+  /**
+   * A click on a row: the first one picks it out, a second on the same row
+   * opens it.
+   *
+   * The second click is the register's own idiom (there, a click on the row it
+   * is already editing asks for the full editor), and it opens exactly what
+   * clicking the description has always opened here — one destination, so the
+   * two cannot drift.
+   */
+  const handleRowClick = useCallback((transaction: Transaction): void => {
+    if (navigationRef.current.selectedId === transaction.id) {
+      handleView(transaction);
+      return;
+    }
+    selectRow(transaction.id);
+  }, [handleView, selectRow]);
+
+  /**
+   * The keys, on the row that has the focus.
+   *
+   * On the ROW rather than on the page or the window, which is what keeps them
+   * out of everything else's way: the search box, a filter, a sortable column
+   * header or one of the row's own buttons has the focus while it is being
+   * used, so the arrows never reach this at all — by construction, not by a
+   * list of exceptions. The row's own handler has already refused any key that
+   * was pressed inside one of its boxes.
+   *
+   * Everything claimed is also stopped: the app carries a window-level shortcut
+   * listener, and an Escape or an Enter it sees after this page has answered it
+   * would be one gesture doing two things.
+   */
+  const handleRowKeyDown = useCallback((
+    event: React.KeyboardEvent<HTMLTableRowElement>,
+    transaction: Transaction
+  ): void => {
+    const { rows, selectedId } = navigationRef.current;
+    const claim = (): void => {
+      event.preventDefault();
+      event.stopPropagation();
+    };
+    /**
+     * Walk by `delta`, or land on the row the key was pressed on.
+     *
+     * -1 covers both "nothing is highlighted" and "the highlight is on a row
+     * this page no longer shows" — in either case the key is an arrival on the
+     * row under the user's hand, and jumping to a neighbour of nowhere would be
+     * a surprise.
+     */
+    const move = (delta: number): void => {
+      if (rows.length === 0) return;
+      const currentIndex = selectedId === null ? -1 : rows.findIndex(row => row.id === selectedId);
+      const next = currentIndex === -1
+        ? transaction
+        : rows[Math.min(rows.length - 1, Math.max(0, currentIndex + delta))];
+      if (next === undefined) return;
+      selectRow(next.id);
+    };
+
+    switch (event.key) {
+      case 'ArrowDown':
+        claim();
+        move(1);
+        break;
+      case 'ArrowUp':
+        claim();
+        move(-1);
+        break;
+      case 'Home':
+        claim();
+        if (rows[0]) selectRow(rows[0].id);
+        break;
+      case 'End':
+        claim();
+        if (rows[rows.length - 1]) selectRow(rows[rows.length - 1].id);
+        break;
+      case 'Enter':
+        claim();
+        // Whatever a click opens — the transaction's details. One call, so
+        // the keyboard and the mouse cannot end up at different screens.
+        handleView(transaction);
+        break;
+      case 'Escape':
+        // Claimed ONLY when there is something to let go of. Escape belongs to
+        // whatever layer is outermost, and a list holding nothing is not a
+        // layer — the register and the Accounts list keep the same rule.
+        if (selectedId === null) return;
+        claim();
+        // The focus stays where it is: the user is still standing here, they
+        // have simply stopped pointing at anything.
+        setSelectedTransactionId(null);
+        break;
+      default:
+        break;
+    }
+  }, [handleView, selectRow]);
+
+  /**
+   * The single tab stop for the whole table (see TransactionRow's isTabStop):
+   * the highlighted row while it is on screen, and otherwise the first row, so
+   * Tab always lands somewhere the arrows can start from.
+   */
+  const tabStopRowId = selectedTransactionId !== null
+    && paginatedTransactions.some(t => t.id === selectedTransactionId)
+    ? selectedTransactionId
+    : paginatedTransactions[0]?.id;
+
   const handleCloseModal = useCallback(() => {
     setIsModalOpen(false);
     setEditingTransaction(null);
@@ -359,7 +567,7 @@ const Transactions = React.memo(function Transactions() {
   // Calculate totals using decimal arithmetic
   const totals = useMemo(() => {
     const decimalTransactions = getDecimalTransactions();
-    const filteredIds = new Set(filteredAndSortedTransactions.map(t => t.id));
+    const filteredIds = new Set(visibleTransactions.map(t => t.id));
     
     return decimalTransactions
       .filter((t: DecimalTransaction) => filteredIds.has(t.id))
@@ -375,7 +583,7 @@ const Transactions = React.memo(function Transactions() {
         expense: toDecimal(0),
         get net() { return this.income.plus(this.expense); } // expenses are already negative
       });
-  }, [filteredAndSortedTransactions, getDecimalTransactions]);
+  }, [visibleTransactions, getDecimalTransactions]);
 
   // Each transaction's running balance for ITS account.
   //
@@ -716,6 +924,49 @@ const Transactions = React.memo(function Transactions() {
             </div>
           </div>
 
+          {/* To Review — how many rows have arrived and not been dealt with,
+              and the switch that narrows the list to exactly them. The
+              register's box, in the same words and the same colours.
+
+              NOTHING AT ZERO. Not a greyed-out button, not "To Review 0" — the
+              house rule is that a zero count renders nothing, because a
+              permanent box reading 0 is a box the eye learns to skip, and then
+              it says nothing on the day it reads 40.
+
+              It is here rather than nowhere because the bold in the list has to
+              lead somewhere: marking rows as new on a page that offered no way
+              to work through them was the reason this page did not mark them at
+              all (see SwipeableTransactionRow's markNewArrivals). Not redundant
+              with the filters above it either — none of type, account, date or
+              search can express "arrived and not dealt with". */}
+          {toReviewCount > 0 && (
+            <div className="pt-1">
+              <button
+                type="button"
+                onClick={() => { setReviewOnly(prev => !prev); resetPagination(); }}
+                aria-pressed={reviewOnly}
+                className={`flex w-full sm:w-auto items-center justify-center gap-2 px-3 py-1.5 text-sm border rounded-lg transition-colors ${
+                  reviewOnly
+                    ? 'border-[#1a2332] dark:border-blue-500 text-[#1a2332] dark:text-blue-400 bg-gray-50 dark:bg-gray-700'
+                    : 'border-gray-300 dark:border-gray-600 text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700'
+                }`}
+                title={
+                  reviewOnly
+                    ? 'Showing only transactions that have arrived and not been dealt with. Click to show them all again.'
+                    : 'Transactions that arrived from an import and have not been saved yet. Click to show only those.'
+                }
+              >
+                To Review
+                {/* Amber, the colour this app already uses for "this wants your
+                    attention". The number is the point, so it carries the
+                    colour rather than the whole button. */}
+                <span className="inline-flex items-center px-1.5 py-0 rounded-full text-xs font-semibold tabular-nums bg-amber-100 text-amber-800 dark:bg-amber-900/40 dark:text-amber-300">
+                  {toReviewCount}
+                </span>
+              </button>
+            </div>
+          )}
+
           {/* Archived transactions toggle — only shown when some exist */}
           {archivedCount > 0 && (
             <div className="flex items-center gap-2 pt-1">
@@ -736,7 +987,7 @@ const Transactions = React.memo(function Transactions() {
         </div>
 
         {/* Transactions List */}
-        {filteredAndSortedTransactions.length === 0 ? (
+        {visibleTransactions.length === 0 ? (
         <div className="bg-white dark:bg-gray-800 rounded-2xl shadow-lg p-6 border border-gray-100 dark:border-gray-700">
           <p className="text-gray-500 dark:text-gray-400 text-center py-8">
             {transactions.length === 0 
@@ -755,15 +1006,17 @@ const Transactions = React.memo(function Transactions() {
             ) : (
               <Suspense fallback={<SkeletonList items={5} className="p-4" />}>
                 <InfiniteScrollTransactionList
-                  transactions={filteredAndSortedTransactions} // Use all filtered transactions, not paginated
+                  transactions={visibleTransactions} // Use all filtered transactions, not paginated
                   accounts={accounts}
                   categories={categories}
                   formatCurrency={formatCurrency}
                   onEdit={handleEdit}
                   onDelete={handleDelete}
                   onView={handleView}
-                  selectedTransactions={selectedTransactions}
-                  onSelectionChange={bulkSelectMode ? setSelectedTransactions : undefined}
+                  // The phone gets the mark too, now that this page carries the
+                  // To Review counter and filter that make it a job rather than
+                  // a decoration — see the prop's own note.
+                  markNewArrivals
                   itemsPerBatch={20}
                 />
               </Suspense>
@@ -796,7 +1049,15 @@ const Transactions = React.memo(function Transactions() {
             ) : (
               <div className={isWideView ? '' : 'overflow-x-auto'} role="region" aria-label="Transactions table">
                 <table className="w-full" style={{ tableLayout: 'fixed' }} role="table" aria-label="Financial transactions">
-                <caption className="sr-only">List of financial transactions with sortable columns. Use arrow keys to navigate and Enter to sort.</caption>
+                {/* Says what the keys actually do now. It used to promise
+                    "Enter to sort", which was only ever true with a column
+                    header focused — a screen-reader user who took it at its
+                    word on a row got a transaction opened instead. */}
+                <caption className="sr-only">
+                  List of financial transactions. Tab into the list, then use the up and down arrow keys to move between
+                  transactions, Enter to open the highlighted one, and Escape to let go of it. On a column header, Enter
+                  sorts by that column.
+                </caption>
                 <thead className="bg-[#1a2332] dark:bg-gray-700 border-b border-[#2d3a4d] dark:border-gray-600 sticky top-0 z-10">
                   <tr role="row">
                     {columnOrder.map(renderHeaderCell)}
@@ -820,6 +1081,10 @@ const Transactions = React.memo(function Transactions() {
                         onView={handleView}
                         columnOrder={columnOrder}
                         columnWidths={columnWidths}
+                        isCurrentRow={selectedTransactionId === transaction.id}
+                        isTabStop={tabStopRowId === transaction.id}
+                        onRowClick={handleRowClick}
+                        onRowKeyDown={handleRowKeyDown}
                         runningBalance={runningBalances.get(transaction.id)}
                         onContextMenu={(e, t) => setContextMenu({ x: e.clientX, y: e.clientY, transaction: t })}
                         categories={flatCategories}
@@ -842,8 +1107,8 @@ const Transactions = React.memo(function Transactions() {
                 <div className="flex items-center gap-2">
                   <span className="text-sm text-gray-700 dark:text-gray-300">
                     {showAllTransactions 
-                      ? `Showing all ${filteredAndSortedTransactions.length} transactions`
-                      : `Showing ${startIndex + 1} to ${Math.min(endIndex, filteredAndSortedTransactions.length)} of ${filteredAndSortedTransactions.length} transactions`
+                      ? `Showing all ${visibleTransactions.length} transactions`
+                      : `Showing ${startIndex + 1} to ${Math.min(endIndex, visibleTransactions.length)} of ${visibleTransactions.length} transactions`
                     }
                   </span>
                   <label htmlFor="per-page-desktop" className="sr-only">Items per page</label>
@@ -851,7 +1116,7 @@ const Transactions = React.memo(function Transactions() {
                     id="per-page-desktop"
                     value={transactionsPerPage}
                     onChange={(e) => {
-                      const value = e.target.value === 'all' ? filteredAndSortedTransactions.length : Number(e.target.value);
+                      const value = e.target.value === 'all' ? visibleTransactions.length : Number(e.target.value);
                       setTransactionsPerPage(value);
                       setCurrentPage(1);
                     }}
@@ -944,8 +1209,8 @@ const Transactions = React.memo(function Transactions() {
                 <div className="flex items-center justify-between">
                   <span className="text-xs text-gray-700 dark:text-gray-300">
                     {showAllTransactions 
-                      ? `All ${filteredAndSortedTransactions.length}`
-                      : `${startIndex + 1}-${Math.min(endIndex, filteredAndSortedTransactions.length)} of ${filteredAndSortedTransactions.length}`
+                      ? `All ${visibleTransactions.length}`
+                      : `${startIndex + 1}-${Math.min(endIndex, visibleTransactions.length)} of ${visibleTransactions.length}`
                     }
                   </span>
                   <label htmlFor="per-page-mobile" className="sr-only">Items per page</label>
@@ -953,7 +1218,7 @@ const Transactions = React.memo(function Transactions() {
                     id="per-page-mobile"
                     value={transactionsPerPage}
                     onChange={(e) => {
-                      const value = e.target.value === 'all' ? filteredAndSortedTransactions.length : Number(e.target.value);
+                      const value = e.target.value === 'all' ? visibleTransactions.length : Number(e.target.value);
                       setTransactionsPerPage(value);
                       setCurrentPage(1);
                     }}
@@ -1057,7 +1322,7 @@ const Transactions = React.memo(function Transactions() {
             </thead>
             <tbody>
               {(() => {
-                const txns = filteredAndSortedTransactions
+                const txns = visibleTransactions
                   .filter(t => {
                     if (breakdownType === 'income') return t.type === 'income';
                     if (breakdownType === 'expense') return t.type === 'expense';
@@ -1133,7 +1398,7 @@ const Transactions = React.memo(function Transactions() {
       <PageTip
         id="transactions-intro"
         title="Your transactions"
-        description="Filter by account, date range, or search by description. Right-click any transaction for quick actions. The Balance column shows your running account balance."
+        description="Filter by account, date range, or search by description. Click a transaction to pick it out, then use the arrow keys to move and Enter to open it — the same as in an account register. Right-click any transaction for quick actions. The Balance column shows your running account balance."
       />
     </PageWrapper>
   );

--- a/src/pages/__tests__/Reconciliation.bankBalance.test.tsx
+++ b/src/pages/__tests__/Reconciliation.bankBalance.test.tsx
@@ -11,13 +11,17 @@ import { todayIsoDay } from '../../utils/statementBankBalance';
 import type { Account } from '../../types';
 
 /**
- * What the page WRITES when the bank balance is removed. The figure and the
- * date it is true for have to go together: a bank_balance_date left behind
- * describes nothing, and statementBankBalance judges an incoming statement
- * stale against exactly that date — so a stray one would go on refusing
- * statements after the balance it belonged to was withdrawn.
+ * What the page WRITES when the closing balance is removed. The screen calls it
+ * the closing balance; the field it lands in is still the account's
+ * `bankBalance`, because that is where the reconciliation's figure is kept.
+ *
+ * The figure and the date it is true for have to go together: a
+ * bank_balance_date left behind describes nothing, and statementBankBalance
+ * judges an incoming statement stale against exactly that date — so a stray one
+ * would go on refusing statements after the balance it belonged to was
+ * withdrawn.
  */
-describe('Reconciliation — removing a bank balance', () => {
+describe('Reconciliation — removing a closing balance', () => {
   const updateAccount = vi.fn();
 
   const account: Account = {
@@ -60,7 +64,7 @@ describe('Reconciliation — removing a bank balance', () => {
     renderPage();
 
     fireEvent.click(screen.getByTitle('Click to change or remove'));
-    fireEvent.click(screen.getByRole('button', { name: /Remove the bank balance/ }));
+    fireEvent.click(screen.getByRole('button', { name: /Remove the closing balance/ }));
 
     expect(updateAccount).toHaveBeenCalledTimes(1);
     expect(updateAccount).toHaveBeenCalledWith(account.id, {
@@ -73,7 +77,7 @@ describe('Reconciliation — removing a bank balance', () => {
     renderPage();
 
     fireEvent.click(screen.getByTitle('Click to change or remove'));
-    const input = screen.getByLabelText('Bank balance');
+    const input = screen.getByLabelText('Closing balance');
     fireEvent.change(input, { target: { value: '199.99' } });
     fireEvent.blur(input);
 

--- a/src/pages/__tests__/Reconciliation.holdingState.test.tsx
+++ b/src/pages/__tests__/Reconciliation.holdingState.test.tsx
@@ -229,7 +229,7 @@ describe('Reconciliation — finalizing is gated on a confirmed balance', () => 
     expect(finalize).toBeDisabled();
     // Named as a consequence, beside the box that has to be confirmed.
     expect(
-      screen.getByText(/Confirm the bank balance to finish\. Until you do, your marks stay a working list/)
+      screen.getByText(/Confirm the closing balance to finish\. Until you do, your marks stay a working list/)
     ).toBeInTheDocument();
     // And the escape hatch is gone for good.
     expect(screen.queryByText('Finalize Anyway')).not.toBeInTheDocument();
@@ -281,7 +281,7 @@ describe('Reconciliation — finalizing is gated on a confirmed balance', () => 
     expect(screen.getByRole('button', { name: /Finalize Reconciliation/ })).toBeEnabled();
 
     fireEvent.click(screen.getByTitle('Click to change or remove'));
-    fireEvent.change(screen.getByLabelText('Bank balance'), { target: { value: '55' } });
+    fireEvent.change(screen.getByLabelText('Closing balance'), { target: { value: '55' } });
 
     expect(screen.getByRole('button', { name: /Finalize Reconciliation/ })).toBeDisabled();
   });
@@ -298,7 +298,7 @@ describe('Reconciliation — finalizing is gated on a confirmed balance', () => 
     renderReconciliation();
 
     fireEvent.click(screen.getByTitle('Click to change or remove'));
-    const input = screen.getByLabelText('Bank balance');
+    const input = screen.getByLabelText('Closing balance');
     fireEvent.change(input, { target: { value: '61.25' } });
     fireEvent.keyDown(input, { key: 'Enter' });
 

--- a/src/pages/__tests__/Reconciliation.yellowThread.test.tsx
+++ b/src/pages/__tests__/Reconciliation.yellowThread.test.tsx
@@ -1,0 +1,219 @@
+/**
+ * "This yellow is why that yellow."
+ *
+ * The balance bar's closing-balance affordance and the header's Finalize
+ * Reconciliation button are refusing for ONE reason: the figure has not been
+ * confirmed. The design says the eye should be able to follow that from one to
+ * the other, which only works if they are literally the same yellow.
+ *
+ * So these tests are structural, not cosmetic. They do not check that either
+ * control is amber-100; they check that the amber vocabulary on each is
+ * EXACTLY the shared token's, which is a claim two hand-maintained class lists
+ * cannot satisfy for long. Hardcode a near-miss on either side and the
+ * comparison goes red before anyone has to notice the shades drifting apart on
+ * screen.
+ *
+ * Every name and figure here is invented: this repo is public.
+ */
+
+import React from 'react';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { PreferencesProvider } from '../../contexts/PreferencesContext';
+import { ToastProvider } from '../../contexts/ToastContext';
+import { NotificationProvider } from '../../contexts/NotificationContext';
+import Reconciliation from '../Reconciliation';
+import {
+  UNCONFIRMED_YELLOW,
+  CONFIRM_BALANCE_HINT_ID,
+} from '../../components/reconciliation/unconfirmedYellow';
+import { __setAppContextValue, __resetAppContextValue } from '../../test/mocks/AppContextSupabase';
+import type { Account, Transaction } from '../../types';
+
+const ACCOUNT: Account = {
+  id: 'acc-thread',
+  name: 'Everyday Invented',
+  type: 'current',
+  balance: 0,
+  currency: 'GBP',
+  institution: 'Invented Bank',
+  lastUpdated: new Date('2026-05-01'),
+  openingBalance: 0,
+  isActive: true,
+  bankBalance: 40,
+  bankBalanceDate: '2026-05-01',
+};
+
+const MARKED_ROW: Transaction = {
+  id: 'txn-thread-1',
+  accountId: ACCOUNT.id,
+  date: new Date('2026-05-04'),
+  amount: 40,
+  description: 'Invented deposit',
+  category: 'det-sundries',
+  type: 'income',
+  cleared: true,
+  reconciled: false,
+};
+
+const openAccount = (account: Account = ACCOUNT): void => {
+  __setAppContextValue({
+    accounts: [account],
+    transactions: [MARKED_ROW],
+    updateAccount: vi.fn(),
+    finalizeReconciliation: vi.fn(async () => 1),
+    isLoading: false,
+  });
+  render(
+    <MemoryRouter initialEntries={[`/reconciliation?account=${account.id}`]}>
+      <PreferencesProvider>
+        <ToastProvider>
+          {/* The page mounts EditTransactionModal, which reads the notification
+              context even while closed. */}
+          <NotificationProvider>
+            <Reconciliation />
+          </NotificationProvider>
+        </ToastProvider>
+      </PreferencesProvider>
+    </MemoryRouter>
+  );
+};
+
+/** Every amber utility an element carries, order-insensitive. */
+const amber = (el: Element): string[] =>
+  el.className.split(/\s+/).filter(cls => cls.includes('amber-')).sort();
+
+const TOKEN = UNCONFIRMED_YELLOW.split(/\s+/).filter(Boolean).sort();
+
+const finalizeButton = (): HTMLElement =>
+  screen.getByRole('button', { name: /Finalize Reconciliation/ });
+const figure = (): HTMLElement => screen.getByTitle('Click to change or remove');
+
+beforeEach(() => {
+  localStorage.clear();
+});
+
+afterEach(() => {
+  __resetAppContextValue();
+});
+
+describe('Reconciliation — the yellow thread', () => {
+  it('the shared token is a real treatment: border, text and wash, in both themes', () => {
+    // Without this guard the comparisons below could be satisfied by emptying
+    // the token — two elements agreeing that neither is yellow at all.
+    const has = (pattern: RegExp): boolean => TOKEN.some(cls => pattern.test(cls));
+    expect(has(/^bg-amber-/)).toBe(true);
+    expect(has(/^text-amber-/)).toBe(true);
+    expect(has(/^border-amber-/)).toBe(true);
+    expect(has(/^dark:bg-amber-/)).toBe(true);
+    expect(has(/^dark:text-amber-/)).toBe(true);
+    expect(has(/^dark:border-amber-/)).toBe(true);
+  });
+
+  it('HEADLINE: the unconfirmed figure and the refusing Finalize wear the SAME yellow', () => {
+    openAccount();
+
+    expect(amber(figure())).toEqual(TOKEN);
+    expect(amber(finalizeButton())).toEqual(TOKEN);
+    // Said the other way round as well, because THAT is the design: not "both
+    // happen to be amber" but "both are the one yellow".
+    expect(amber(figure())).toEqual(amber(finalizeButton()));
+    expect(finalizeButton()).toBeDisabled();
+  });
+
+  it('confirming resolves both yellows together, and opens the gate', () => {
+    openAccount();
+    fireEvent.click(screen.getByRole('button', { name: 'Confirm' }));
+
+    expect(amber(figure())).toEqual([]);
+    expect(amber(finalizeButton())).toEqual([]);
+    expect(finalizeButton()).toBeEnabled();
+  });
+
+  it('Enter in the box resolves both in one keystroke', () => {
+    // The commonest path: read the statement, type the figure, press Enter.
+    openAccount();
+    fireEvent.click(figure());
+    const box = screen.getByLabelText('Closing balance');
+    fireEvent.change(box, { target: { value: '61.25' } });
+    fireEvent.keyDown(box, { key: 'Enter' });
+
+    expect(amber(figure())).toEqual([]);
+    expect(amber(finalizeButton())).toEqual([]);
+    expect(finalizeButton()).toBeEnabled();
+  });
+
+  it('editing after confirming brings both yellows back', () => {
+    openAccount();
+    fireEvent.click(screen.getByRole('button', { name: 'Confirm' }));
+    expect(amber(finalizeButton())).toEqual([]);
+
+    fireEvent.click(figure());
+    fireEvent.change(screen.getByLabelText('Closing balance'), { target: { value: '55' } });
+
+    // The box the user is typing in is the affordance now, and it is yellow
+    // again alongside Finalize — the agreement lapsed with the keystroke.
+    expect(amber(screen.getByLabelText('Closing balance'))).toEqual(TOKEN);
+    expect(amber(finalizeButton())).toEqual(TOKEN);
+    expect(amber(screen.getByLabelText('Closing balance'))).toEqual(amber(finalizeButton()));
+    expect(finalizeButton()).toBeDisabled();
+  });
+
+  it('an account with no figure at all invites one in the same yellow', () => {
+    openAccount({ ...ACCOUNT, bankBalance: null, bankBalanceDate: null });
+
+    const invitation = screen.getByRole('button', { name: 'Enter balance' });
+    expect(amber(invitation)).toEqual(TOKEN);
+    expect(amber(finalizeButton())).toEqual(TOKEN);
+    expect(finalizeButton()).toBeDisabled();
+  });
+
+  it('the yellow is never the only signal: both controls point at the same printed reason', () => {
+    openAccount();
+
+    expect(figure()).toHaveAttribute('aria-describedby', CONFIRM_BALANCE_HINT_ID);
+    expect(finalizeButton()).toHaveAttribute('aria-describedby', CONFIRM_BALANCE_HINT_ID);
+    expect(document.getElementById(CONFIRM_BALANCE_HINT_ID))
+      .toHaveTextContent(/Confirm the closing balance to finish/);
+    // And the refusal itself is carried by the disabled attribute, not by paint.
+    expect(finalizeButton()).toBeDisabled();
+  });
+
+  it('drops the description when the reason is gone, rather than dangling', () => {
+    openAccount();
+    fireEvent.click(screen.getByRole('button', { name: 'Confirm' }));
+
+    expect(figure()).not.toHaveAttribute('aria-describedby');
+    expect(finalizeButton()).not.toHaveAttribute('aria-describedby');
+    expect(document.getElementById(CONFIRM_BALANCE_HINT_ID)).toBeNull();
+  });
+
+  it('Finalize keeps its border width in both states, so the gate opening cannot resize it', () => {
+    openAccount();
+    expect(finalizeButton()).toHaveClass('border');
+
+    fireEvent.click(screen.getByRole('button', { name: 'Confirm' }));
+    expect(finalizeButton()).toHaveClass('border', 'border-transparent');
+  });
+});
+
+describe('Reconciliation — Money’s word for the figure', () => {
+  it('the bar labels it Closing Balance, and the reconciling screen never says Bank Balance', () => {
+    openAccount();
+    expect(screen.getByText('Closing Balance')).toBeInTheDocument();
+    expect(screen.queryByText('Bank Balance')).not.toBeInTheDocument();
+  });
+
+  it('the finalize dialog uses the same word for the same figure', () => {
+    // 40 marked against a closing balance of 100 leaves 60 to explain, which is
+    // the branch of the dialog that names both figures.
+    openAccount({ ...ACCOUNT, bankBalance: 100 });
+    fireEvent.click(screen.getByRole('button', { name: 'Confirm' }));
+    fireEvent.click(screen.getByRole('button', { name: /Finalize Reconciliation/ }));
+
+    expect(screen.getByText(/Difference between closing balance and cleared balance/))
+      .toBeInTheDocument();
+    expect(screen.getByText(/Closing Balance: £100\.00/)).toBeInTheDocument();
+  });
+});

--- a/src/pages/__tests__/Transactions.parity.test.tsx
+++ b/src/pages/__tests__/Transactions.parity.test.tsx
@@ -1,0 +1,437 @@
+/**
+ * The global Transactions page, brought up to the account register's manners.
+ *
+ * The owner, on the two lists: "I want the experience to be familiar, between
+ * the two." So this file is the parity table, as tests — one describe block per
+ * thing a user switching pages would otherwise miss:
+ *
+ *   selection   a click picks a row out and it floats; the arrows move the
+ *               highlight; Enter opens exactly what a click opens; Escape lets
+ *               go; and the arrows stand aside while a row's own box has the
+ *               cursor;
+ *   C/R         Money's two letters, from the shared predicates — R for a
+ *               reconciliation that finished, C for a mark made while
+ *               balancing, and nothing at all for a row that is neither;
+ *   review      a row that arrived and has not been saved is bold, and the To
+ *               Review box counts them and narrows to them;
+ *   arrival     the ?account= deep link this page has always honoured still
+ *               lands on the right account.
+ *
+ * Every name, date and figure below is invented: this repo is public.
+ */
+
+import React from 'react';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { render, screen, fireEvent, within, waitFor } from '@testing-library/react';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { PreferencesProvider } from '../../contexts/PreferencesContext';
+import { ToastProvider } from '../../contexts/ToastContext';
+import { LayoutProvider } from '../../contexts/LayoutContext';
+import { NotificationProvider } from '../../contexts/NotificationContext';
+import { __setAppContextValue, __resetAppContextValue } from '../../test/mocks/AppContextSupabase';
+import { TRANSACTION_ROW_SELECTED_CLASS } from '../../components/TransactionRow';
+import Transactions from '../Transactions';
+import type { Account, Category, Transaction } from '../../types';
+
+const CURRENT: Account = {
+  id: 'acc-current', name: 'Everyday Current', type: 'current', balance: 0,
+  currency: 'GBP', lastUpdated: new Date('2026-01-01'), openingBalance: 0, isActive: true,
+};
+
+const SAVINGS: Account = {
+  id: 'acc-savings', name: 'Rainy Day Savings', type: 'savings', balance: 0,
+  currency: 'GBP', lastUpdated: new Date('2026-01-01'), openingBalance: 0, isActive: true,
+};
+
+const CATEGORIES: Category[] = [
+  { id: 'type-expense', name: 'Expenses', type: 'expense', level: 'type', isSystem: true },
+  { id: 'grp-home', name: 'Home', type: 'expense', level: 'sub', parentId: 'type-expense' },
+  { id: 'det-repairs', name: 'Repairs', type: 'expense', level: 'detail', parentId: 'grp-home' },
+];
+
+const base = {
+  amount: -24.5,
+  type: 'expense' as const,
+  category: 'det-repairs',
+  accountId: CURRENT.id,
+};
+
+/** Through a finalized reconciliation: the committed state. */
+const RECONCILED_ROW: Transaction = {
+  ...base, id: 'txn-reconciled', description: 'Halberd Ironmongers',
+  date: new Date(Date.UTC(2026, 3, 1)), cleared: true, reconciled: true,
+};
+
+/** Ticked off against a statement, but nobody has pressed Finish. */
+const MARKED_ROW: Transaction = {
+  ...base, id: 'txn-marked', description: 'Pellam Tyres',
+  date: new Date(Date.UTC(2026, 3, 2)), cleared: true, reconciled: false,
+  accountId: SAVINGS.id,
+};
+
+/** Neither marked nor reconciled. */
+const UNMARKED_ROW: Transaction = {
+  ...base, id: 'txn-unmarked', description: 'Wexford Bakery',
+  date: new Date(Date.UTC(2026, 3, 3)), cleared: false, reconciled: false,
+};
+
+const ROWS = [RECONCILED_ROW, MARKED_ROW, UNMARKED_ROW];
+
+const renderPage = (entry = '/transactions') =>
+  render(
+    <MemoryRouter initialEntries={[entry]}>
+      <PreferencesProvider>
+        <LayoutProvider>
+          <ToastProvider>
+            {/* The lazily-loaded transaction editor this page keeps mounted
+                asks for notifications the moment its chunk resolves. */}
+            <NotificationProvider>
+              <Routes>
+                <Route path="/transactions" element={<Transactions />} />
+              </Routes>
+            </NotificationProvider>
+          </ToastProvider>
+        </LayoutProvider>
+      </PreferencesProvider>
+    </MemoryRouter>
+  );
+
+const seed = (transactions: Transaction[]): void => {
+  __setAppContextValue({
+    accounts: [CURRENT, SAVINGS],
+    transactions,
+    categories: CATEGORIES,
+    isLoading: false,
+  });
+};
+
+/**
+ * The desktop table. Scoped deliberately: jsdom applies no media queries, so
+ * the phone card list is in the document too, and this file is about the table.
+ */
+const table = (): HTMLElement => screen.getByRole('table', { name: 'Financial transactions' });
+
+/** The table line showing `description`. */
+const row = (description: string): HTMLElement => {
+  const cell = within(table()).getByText(description);
+  const found = cell.closest('tr');
+  if (!(found instanceof HTMLElement)) throw new Error(`no table row for "${description}"`);
+  return found;
+};
+
+/** Is this row wearing the picked-out look? */
+const isPickedOut = (line: HTMLElement): boolean =>
+  TRANSACTION_ROW_SELECTED_CLASS.split(' ')
+    .filter(Boolean)
+    .every(utility => line.classList.contains(utility));
+
+const openPage = async (entry?: string): Promise<void> => {
+  renderPage(entry);
+  await screen.findByRole('table', { name: 'Financial transactions' });
+};
+
+beforeEach(() => {
+  localStorage.clear();
+  seed(ROWS);
+});
+
+afterEach(() => {
+  __resetAppContextValue();
+});
+
+describe('Transactions page — picking a row out', () => {
+  it('highlights the row a click lands on, and says so to a screen reader', async () => {
+    await openPage();
+
+    const line = row('Wexford Bakery');
+    expect(isPickedOut(line)).toBe(false);
+
+    fireEvent.click(line);
+
+    expect(isPickedOut(line)).toBe(true);
+    // Bold is not the marker here — weight already says "this arrived and has
+    // not been reviewed" — so the fact is carried in the markup as well.
+    expect(line).toHaveAttribute('aria-current', 'true');
+    // And the click hands the keyboard to the row it picked out, so the arrows
+    // are live on it without a second gesture. (jsdom does not focus on click
+    // of its own accord, so this is asserting the page's own call.)
+    expect(line).toHaveFocus();
+  });
+
+  it('holds the highlight on ONE row at a time', async () => {
+    await openPage();
+
+    fireEvent.click(row('Wexford Bakery'));
+    fireEvent.click(row('Pellam Tyres'));
+
+    expect(isPickedOut(row('Pellam Tyres'))).toBe(true);
+    expect(isPickedOut(row('Wexford Bakery'))).toBe(false);
+  });
+
+  it('moves the highlight down and up with the arrow keys', async () => {
+    await openPage();
+
+    // Newest first, which is this page's default sort: Wexford, Pellam,
+    // Halberd. So down from the first is Pellam.
+    const first = row('Wexford Bakery');
+    fireEvent.click(first);
+
+    fireEvent.keyDown(first, { key: 'ArrowDown' });
+    expect(isPickedOut(row('Pellam Tyres'))).toBe(true);
+
+    fireEvent.keyDown(row('Pellam Tyres'), { key: 'ArrowUp' });
+    expect(isPickedOut(row('Wexford Bakery'))).toBe(true);
+  });
+
+  it('stops at the ends rather than wrapping', async () => {
+    await openPage();
+
+    const first = row('Wexford Bakery');
+    fireEvent.click(first);
+    fireEvent.keyDown(first, { key: 'ArrowUp' });
+
+    // Still the first row: a list that wrapped would teleport the user to the
+    // far end of a statement they were reading down.
+    expect(isPickedOut(row('Wexford Bakery'))).toBe(true);
+  });
+
+  /**
+   * The mouse's destination and the keyboard's, asserted apart so that neither
+   * can be the other's leftovers.
+   *
+   * They are one call in the page (handleView), and these two tests are what
+   * says so: the same panel, naming the same transaction, reached both ways.
+   */
+  it('opens the transaction when its description is clicked', async () => {
+    await openPage();
+
+    fireEvent.click(within(row('Wexford Bakery')).getByText('Wexford Bakery'));
+
+    const panel = (await screen.findByRole('heading', { name: 'Transaction Details' })).closest('div.fixed');
+    expect(panel).not.toBeNull();
+    expect(within(panel as HTMLElement).getByText('Wexford Bakery')).toBeInTheDocument();
+  });
+
+  it('opens the same transaction when Enter is pressed on the highlighted row', async () => {
+    await openPage();
+
+    const line = row('Wexford Bakery');
+    fireEvent.click(line);
+    // Nothing is open yet: picking a row out is not opening it.
+    expect(screen.queryByRole('heading', { name: 'Transaction Details' })).not.toBeInTheDocument();
+
+    fireEvent.keyDown(line, { key: 'Enter' });
+
+    const panel = (await screen.findByRole('heading', { name: 'Transaction Details' })).closest('div.fixed');
+    expect(panel).not.toBeNull();
+    expect(within(panel as HTMLElement).getByText('Wexford Bakery')).toBeInTheDocument();
+  });
+
+  it('opens the row on a second click, the way the register does', async () => {
+    await openPage();
+
+    const line = row('Wexford Bakery');
+    fireEvent.click(line);
+    expect(screen.queryByRole('heading', { name: 'Transaction Details' })).not.toBeInTheDocument();
+
+    fireEvent.click(line);
+
+    expect(await screen.findByRole('heading', { name: 'Transaction Details' })).toBeInTheDocument();
+  });
+
+  it('lets go of the row on Escape', async () => {
+    await openPage();
+
+    const line = row('Wexford Bakery');
+    fireEvent.click(line);
+    expect(isPickedOut(line)).toBe(true);
+
+    fireEvent.keyDown(line, { key: 'Escape' });
+
+    expect(isPickedOut(row('Wexford Bakery'))).toBe(false);
+    expect(row('Wexford Bakery')).not.toHaveAttribute('aria-current');
+  });
+
+  it('leaves the arrows alone while a row is being typed in', async () => {
+    await openPage();
+
+    const line = row('Wexford Bakery');
+    fireEvent.click(line);
+
+    // Turn the category cell into its picker — the row now holds a control
+    // with the cursor in it.
+    fireEvent.click(within(line).getByRole('button', { name: /Change category/ }));
+    const picker = within(row('Wexford Bakery')).getByRole('combobox');
+
+    fireEvent.keyDown(picker, { key: 'ArrowDown' });
+
+    // The highlight has not moved: ArrowDown in a picker belongs to the picker.
+    expect(isPickedOut(row('Wexford Bakery'))).toBe(true);
+    expect(isPickedOut(row('Pellam Tyres'))).toBe(false);
+  });
+
+  it('leaves the row alone when the click was on one of its own buttons', async () => {
+    await openPage();
+
+    const line = row('Wexford Bakery');
+    fireEvent.click(within(line).getByTestId('edit-button'));
+
+    // Edit means edit. A button that also picked its row out would make every
+    // action a two-part gesture.
+    expect(isPickedOut(row('Wexford Bakery'))).toBe(false);
+  });
+
+  it('offers the keyboard exactly one way in, however many rows there are', async () => {
+    await openPage();
+
+    // Roving tabindex: one tab stop for the whole table, the rest reached with
+    // the arrows.
+    const stops = within(table()).getAllByRole('row').filter(line => line.getAttribute('tabindex') === '0');
+    expect(stops).toHaveLength(1);
+  });
+});
+
+describe('Transactions page — the C/R column', () => {
+  it('heads the column with both letters', async () => {
+    await openPage();
+
+    expect(within(table()).getByRole('columnheader', { name: /C\/R column/ })).toBeInTheDocument();
+  });
+
+  it('shows R for a row a reconciliation finished', async () => {
+    await openPage();
+
+    expect(within(row('Halberd Ironmongers')).getByTitle('Reconciled')).toHaveTextContent('R');
+  });
+
+  it('shows C for a row that is marked but not reconciled', async () => {
+    await openPage();
+
+    // The discrimination this column exists for: a working mark must not read
+    // as settled work. One tick for both was the bug.
+    const marked = within(row('Pellam Tyres'));
+    expect(marked.getByTitle(/not reconciled until you finalize/)).toHaveTextContent('C');
+    expect(marked.queryByTitle('Reconciled')).not.toBeInTheDocument();
+  });
+
+  it('shows nothing at all for a row that is neither', async () => {
+    await openPage();
+
+    const untouched = within(row('Wexford Bakery'));
+    expect(untouched.queryByTitle('Reconciled')).not.toBeInTheDocument();
+    expect(untouched.queryByTitle(/not reconciled until you finalize/)).not.toBeInTheDocument();
+  });
+});
+
+describe('Transactions page — rows that have just arrived', () => {
+  const NEW_ROW: Transaction = {
+    ...base, id: 'txn-new', description: 'Calder Street Market',
+    date: new Date(Date.UTC(2026, 3, 4)), cleared: false, needsReview: true,
+  };
+  const SAVED_ROW: Transaction = {
+    ...base, id: 'txn-saved', description: 'Ordsall Fuel',
+    date: new Date(Date.UTC(2026, 3, 5)), cleared: false, needsReview: false,
+  };
+
+  /**
+   * Read off the two cells that carry the weight — the ones at opposite ends of
+   * the line, which is what makes the whole row read as bold at a glance — and
+   * they must agree. A row bold in one and not the other is a half-applied rule.
+   */
+  const isBold = (description: string): boolean => {
+    const line = row(description);
+    const descriptionSpan = within(line).getByText(description);
+    const dateSpan = line.querySelector('td span');
+    const dateBold = dateSpan?.className.includes('font-semibold') ?? false;
+    const descriptionBold = descriptionSpan.className.includes('font-semibold');
+    if (dateBold !== descriptionBold) {
+      throw new Error(`"${description}": date and description disagree about being new`);
+    }
+    return descriptionBold;
+  };
+
+  it('prints a new row in bold, date and description together', async () => {
+    seed([NEW_ROW, SAVED_ROW, UNMARKED_ROW]);
+    await openPage();
+
+    expect(isBold('Calder Street Market')).toBe(true);
+  });
+
+  it('leaves a row somebody has already saved alone', async () => {
+    seed([NEW_ROW, SAVED_ROW, UNMARKED_ROW]);
+    await openPage();
+
+    // A list that marks every row marks nothing.
+    expect(isBold('Ordsall Fuel')).toBe(false);
+  });
+
+  it('treats a row with no review flag at all as already dealt with', async () => {
+    seed([NEW_ROW, SAVED_ROW, UNMARKED_ROW]);
+    await openPage();
+
+    // The load-bearing asymmetry: only `true` means new. A database without the
+    // migration returns no such key, and reading that as new would print a
+    // whole imported history in bold on the day of the deploy.
+    expect(isBold('Wexford Bakery')).toBe(false);
+  });
+
+  it('says it in words as well, for anyone who cannot see weight', async () => {
+    seed([NEW_ROW, SAVED_ROW, UNMARKED_ROW]);
+    await openPage();
+
+    expect(within(row('Calder Street Market')).getByText(/new, not reviewed yet/)).toBeInTheDocument();
+  });
+
+  it('counts them in a To Review box, and narrows the list to them', async () => {
+    seed([NEW_ROW, SAVED_ROW, UNMARKED_ROW]);
+    await openPage();
+
+    const box = screen.getByRole('button', { name: /To Review/ });
+    expect(box).toHaveTextContent('1');
+    expect(box).toHaveAttribute('aria-pressed', 'false');
+
+    fireEvent.click(box);
+
+    await waitFor(() => {
+      expect(within(table()).queryByText('Ordsall Fuel')).not.toBeInTheDocument();
+    });
+    expect(within(table()).getByText('Calder Street Market')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /To Review/ })).toHaveAttribute('aria-pressed', 'true');
+  });
+
+  it('gives the whole list back when the box is pressed again', async () => {
+    seed([NEW_ROW, SAVED_ROW, UNMARKED_ROW]);
+    await openPage();
+
+    fireEvent.click(screen.getByRole('button', { name: /To Review/ }));
+    fireEvent.click(screen.getByRole('button', { name: /To Review/ }));
+
+    await waitFor(() => {
+      expect(within(table()).getByText('Ordsall Fuel')).toBeInTheDocument();
+    });
+  });
+
+  it('renders nothing at all when there is nothing to review', async () => {
+    seed([SAVED_ROW, UNMARKED_ROW]);
+    await openPage();
+
+    // A permanent box reading 0 is a box the eye learns to skip, and then it
+    // says nothing on the day it reads 40. Its absence is the "all done".
+    expect(screen.queryByRole('button', { name: /To Review/ })).not.toBeInTheDocument();
+  });
+});
+
+describe('Transactions page — arriving from somewhere else', () => {
+  it('still lands filtered to the account a deep link named', async () => {
+    await openPage(`/transactions?account=${SAVINGS.id}`);
+
+    // The only arrival this page has ever honoured, and it has to survive the
+    // selection work: ?txn= deep links go to the account register (see
+    // utils/transactionDeepLink), never here.
+    await waitFor(() => {
+      expect(within(table()).getByText('Pellam Tyres')).toBeInTheDocument();
+    });
+    expect(within(table()).queryByText('Wexford Bakery')).not.toBeInTheDocument();
+    expect(screen.getByText(/Showing transactions for/)).toHaveTextContent(SAVINGS.name);
+  });
+});


### PR DESCRIPTION
Three commits from live testing.

## 1 · The closing balance wears the button's yellow (`feat(reconciliation)`)
"Bank Balance" becomes **Closing Balance** — Money's own name for the figure being agreed to. While unconfirmed it wears the exact amber of the disabled Finalize button, from one shared token both controls consume, so the eye reads "this yellow is why that yellow" and the two cannot drift apart (the mutation check catches even a near-miss amber). Confirming resolves both at once; Finalize's half-opacity dimming went with it, so yellow means exactly one thing on the page: blocked. The rename stops at the fact's boundary — the Accounts page's Bank Bal and the feed surfaces keep their name, because a feed's live balance is a different fact from a statement figure proposed for agreement.

## 2 · Pages open at the top (`fix(navigation)`)
Nothing ever said "on route change, go to the top," so any page you left mid-scroll handed its offset to the next one. One component, first child of the Router — first because React commits layout effects in tree order, which is what guarantees every deliberate arrival scroll (deep-linked rows, Back-to-Accounts centring, report drills — all verdicted individually) runs after the reset and wins. Back/Forward keeps the browser's native restoration; a same-pathname URL rewrite never moves a mid-page reader (guarded by a previous-pathname ref, because the router's navigation type lies on exactly that case); and the modal's open-time scroll capture now records the reset offset — closing a modal can no longer teleport the reader to the previous page's offset.

## 3 · The global list learns the register's manners (`feat(transactions)`)
Measured first: a 34-capability parity table, every row verdicted **port** / **already** / **does-not-travel** with reasons. Ported: the selection idiom (click floats, arrows walk and stand aside for inputs, Enter opens, Escape releases, Home/End, second-click-goes-deeper, the selection-tail guard), **C/R letters** replacing the bare tick (driven by the reconciliation predicates), needs-review bolding with a To Review counter and filter — which the mobile row's own doc had banned on this page until there was a way to act on it. Refused with reasons: bulk statement verbs (one-account acts a cross-account list can't honestly offer), type-ahead on a paginated list, the shortcuts sheet, the inline row editor (named as its own future stream). Found en route: the page's bulk-select mode was unreachable — a flag with no setter, a prop never passed, row clicks doing nothing — so the dead state is deleted and the click given to selection, with checkbox-wins precedence stated where both live.

## Verification
Each stream mutation-checked (one mutation initially surviving exposed a bad test, which was fixed until it bit), full gate green at every commit, `port:coverage`'s pre-existing 13-file list byte-identical throughout. Coverage 76.8% / 82.1%. No migrations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)