### PR TITLE
refactor(core): slice 14 — the dispatch moves where both callers reach it (308+109+66 specs unchanged, 271 cargo tests, zero behaviour)

### DIFF
--- a/crates/wealth-core/src/bin/wealth_core_cli.rs
+++ b/crates/wealth-core/src/bin/wealth_core_cli.rs
@@ -6,6 +6,16 @@
 //! wealth-core-cli --version                    engine and crate versions, as JSON
 //! ```
 //!
+//! # What is here, and what is deliberately not
+//!
+//! Arguments, stdin, stdout, exit codes. That is the whole of it.
+//!
+//! The verb set, the dispatch over it and the envelope an answer travels in are
+//! [`wealth_core::command`], in the library, because the desktop shell's one
+//! `#[tauri::command]` runs the same match and a second copy of it would be a
+//! second verb set (PHASE3-PLAN D-3). This file is one caller of that module; it
+//! does not own the surface, and nothing about the wire is decided here.
+//!
 //! # Why a spawned binary and not a native Node addon
 //!
 //! `scripts/local-sqlite/lib/sqlite.mjs` states the constraint this repo already
@@ -25,7 +35,10 @@
 //! 16-spec suite including the Postgres side is 0.66 s wall clock. A long-lived
 //! JSON-lines daemon would save single-digit milliseconds in exchange for a
 //! failure mode — a hung child holding a write lock on the temp database — that
-//! is much worse than the latency it saves.
+//! is much worse than the latency it saves. It is also why the APP does not
+//! arrive this way: a spawn per call is fine for a spec and wrong for a rename
+//! of three thousand rows, which is the measurement behind D-3's in-process
+//! command for the shell.
 //!
 //! # Why the Node side owns the file and the Rust side only writes to it
 //!
@@ -35,201 +48,13 @@
 //! by the same code path that applies it for the existing 54 constraint specs —
 //! not against a copy this crate keeps. `--apply-schema` exists only for the
 //! crate's own integration tests, which have no Node runner to do it for them.
-//!
-//! # This is not a SQL surface
-//!
-//! DESIGN.md §6.4: *"There is no command that accepts a SQL string. You cannot
-//! bypass what does not exist."* This binary takes `{"verb": …, "payload": …}`,
-//! deserialised by serde into a typed command. A payload that is not a known
-//! verb is refused; a payload with an unrecognised field is refused. There is no
-//! branch here that concatenates anything into a statement.
 
 use std::io::Read;
 use std::path::PathBuf;
 use std::process::ExitCode;
 
-use serde::{Deserialize, Serialize};
-use wealth_core::admission::{
-    plan_account_identifier_match, plan_account_identifiers, plan_category_admission,
-    plan_cleared_flag, plan_feed_overlap, plan_statement_bank_balance, plan_statement_duplicates,
-    PlanAccountIdentifierMatch, PlanAccountIdentifiers, PlanCategoryAdmission, PlanClearedFlag,
-    PlanFeedOverlap, PlanStatementBankBalance, PlanStatementDuplicates,
-};
+use wealth_core::command::{dispatch, parse, plan, respond, Response};
 use wealth_core::db;
-use wealth_core::error::CoreError;
-use wealth_core::verbs::{
-    apply_category_to_uncategorized, clear_transfer_links, confirm_transaction_categories,
-    create_transaction, create_transfer_counterpart, delete_transaction,
-    delete_unused_categories, finalize_user_restore, import_bank_transactions,
-    import_transactions, link_bank_account_snap, link_split_line_transfer, link_transfer_pair,
-    merge_categories, repair_claimed_transfer, restore_user_chunk,
-    set_transaction_splits_with_legs, update_transaction, user_financial_data_is_empty,
-    verify_integrity, wipe_user_financial_data, ApplyCategoryToUncategorized, ClearTransferLinks,
-    ConfirmTransactionCategories, CreateTransaction, CreateTransferCounterpart, DeleteTransaction,
-    DeleteUnusedCategories, FinalizeUserRestore, ImportBankTransactions, ImportTransactions,
-    LinkBankAccountSnap, LinkSplitLineTransfer, LinkTransferPair, MergeCategories,
-    RepairClaimedTransfer, RestoreUserChunk, SetTransactionSplitsWithLegs, UpdateTransaction,
-    UserFinancialDataIsEmpty, VerifyIntegrity, WipeUserFinancialData,
-};
-
-/// A command, as the harness sends it.
-///
-/// One JSON object per verb, and the object is the same one the Postgres side
-/// receives — the update and delete RPCs take their arguments positionally
-/// (`(p_id, p, p_user_id)`), so `lib/verb-postgres.mjs` unpacks the same object
-/// into that call rather than either side getting a payload of its own.
-// The shared postfix is the point: `serde(rename_all = "snake_case")` turns
-// these names into the wire's verb strings, so `CreateTransaction` IS
-// `"create_transaction"`. Shortening them to please the lint would rename the
-// protocol.
-#[allow(clippy::enum_variant_names)]
-#[derive(Debug, Deserialize)]
-#[serde(tag = "verb", content = "payload", rename_all = "snake_case")]
-enum Command {
-    CreateTransaction(Box<CreateTransaction>),
-    UpdateTransaction(Box<UpdateTransaction>),
-    DeleteTransaction(Box<DeleteTransaction>),
-    // Named for the RPC it ports, not for the older `set_transaction_splits`
-    // that is deliberately left alone in the cloud. The two are different write
-    // paths with different rules, and a verb string that could mean either is a
-    // verb string that will one day mean the wrong one.
-    SetTransactionSplitsWithLegs(Box<SetTransactionSplitsWithLegs>),
-    // The transfer family. Five RPCs, five verb strings, each spelled exactly as
-    // the function it ports — including `clear_transfer_links`, which is what
-    // the client's `clearTransferLinks` actually calls (it stopped being a table
-    // UPDATE in 20260805145035, and the verb's docs record how that was
-    // established rather than assumed).
-    LinkTransferPair(Box<LinkTransferPair>),
-    CreateTransferCounterpart(Box<CreateTransferCounterpart>),
-    ClearTransferLinks(Box<ClearTransferLinks>),
-    RepairClaimedTransfer(Box<RepairClaimedTransfer>),
-    LinkSplitLineTransfer(Box<LinkSplitLineTransfer>),
-    // The category family. Three verb strings, each spelled exactly as the
-    // function it ports — including the two from 20260808100000, whose LIVE
-    // definitions are the ones ported (`apply_category_to_uncategorized` has
-    // three definitions across three migrations and only the newest counts).
-    MergeCategories(Box<MergeCategories>),
-    ApplyCategoryToUncategorized(Box<ApplyCategoryToUncategorized>),
-    ConfirmTransactionCategories(Box<ConfirmTransactionCategories>),
-    // The fourth category verb, and the one whose every protection is a WHERE
-    // clause rather than a RAISE. Same name as the RPC it ports; the count it
-    // returns is the RPC's, which is not the count SQLite's own single-statement
-    // spelling would give (see the verb's module documentation).
-    DeleteUnusedCategories(Box<DeleteUnusedCategories>),
-    // The restore family. Four verb strings, each spelled exactly as the
-    // function it ports — including `restore_user_chunk`, whose LOCAL payload
-    // carries a LIST of chunks because the whole restore is one transaction here
-    // (DESIGN.md §5 divergence 6). The name is kept singular because a verb
-    // string that differs from the function it ports is a verb string that will
-    // one day be mapped to the wrong function.
-    UserFinancialDataIsEmpty(Box<UserFinancialDataIsEmpty>),
-    WipeUserFinancialData(Box<WipeUserFinancialData>),
-    RestoreUserChunk(Box<RestoreUserChunk>),
-    FinalizeUserRestore(Box<FinalizeUserRestore>),
-    // The account snap: service-role only in the cloud, and the one function in
-    // the schema that assigns an absolute balance without breaking B-1.
-    LinkBankAccountSnap(Box<LinkBankAccountSnap>),
-    // The ingest surface. Two verb strings, each spelled as the function it
-    // ports minus the `_atomic` every verb in this crate drops.
-    //
-    // PHASE1-PLAN §3.2 also lists an `import_transactions`, and it is NOT this
-    // one: that is the admission-control verb over `RawRow`, which decides what
-    // a file's text MEANS before anything is stored. This is the write path such
-    // a verb would end in — the port of the RPC that exists today. Named here
-    // rather than left to be discovered, because two things called
-    // `import_transactions` is exactly how the wrong one gets called.
-    ImportTransactions(Box<ImportTransactions>),
-    ImportBankTransactions(Box<ImportBankTransactions>),
-    // The only verb here that is NOT a port: the cloud has no verify_integrity,
-    // no view and no equivalent, and the verb's module documentation carries the
-    // trace that establishes it. Its payload is `{}` — it takes not even an
-    // owner, because integrity is a property of the file.
-    VerifyIntegrity(Box<VerifyIntegrity>),
-    // ── The admission surface ────────────────────────────────────────────────
-    //
-    // Seven commands that decide what a parsed row MEANS, and write nothing.
-    // They are dispatched by `plan` below, BEFORE the database is opened, and
-    // sending one with `--db` is a fault: see that function for why the refusal
-    // is worth more than the convenience.
-    //
-    // None of these is a port of a Postgres function — there is none to port.
-    // Their oracle is the TypeScript module each one names, executed side by
-    // side with this binary by `scripts/local-sqlite/admission.mjs`.
-    PlanStatementDuplicates(Box<PlanStatementDuplicates>),
-    PlanStatementBankBalance(Box<PlanStatementBankBalance>),
-    PlanFeedOverlap(Box<PlanFeedOverlap>),
-    PlanClearedFlag(Box<PlanClearedFlag>),
-    PlanAccountIdentifiers(Box<PlanAccountIdentifiers>),
-    PlanAccountIdentifierMatch(Box<PlanAccountIdentifierMatch>),
-    PlanCategoryAdmission(Box<PlanCategoryAdmission>),
-}
-
-/// The admission commands, answered without a database.
-///
-/// `Err(command)` hands a write verb back untouched, so the write dispatch
-/// below stays exhaustive: a verb added to `Command` and forgotten here falls
-/// through to that match and fails to compile, which is the failure everybody
-/// wants and nobody gets from a catch-all on both sides.
-fn plan(command: Command) -> Result<Result<serde_json::Value, CoreError>, Command> {
-    match command {
-        Command::PlanStatementDuplicates(payload) => {
-            Ok(as_json(plan_statement_duplicates(&payload)))
-        }
-        Command::PlanStatementBankBalance(payload) => {
-            Ok(as_json(plan_statement_bank_balance(&payload)))
-        }
-        Command::PlanFeedOverlap(payload) => Ok(as_json(plan_feed_overlap(&payload))),
-        Command::PlanClearedFlag(payload) => Ok(as_json(plan_cleared_flag(&payload))),
-        Command::PlanAccountIdentifiers(payload) => Ok(as_json(plan_account_identifiers(&payload))),
-        Command::PlanAccountIdentifierMatch(payload) => {
-            Ok(as_json(plan_account_identifier_match(&payload)))
-        }
-        Command::PlanCategoryAdmission(payload) => Ok(as_json(plan_category_admission(&payload))),
-        other => Err(other),
-    }
-}
-
-/// One verb's outcome, as the wire's response.
-///
-/// A storage fault is `Err`: the runner must be able to tell "the verb refused"
-/// from "the harness is broken", and the two leave by different doors.
-fn respond(outcome: Result<serde_json::Value, CoreError>) -> Result<Response, String> {
-    Ok(match outcome {
-        Ok(result) => Response::Ok { ok: true, result },
-        Err(CoreError::Storage(error)) => return Err(format!("storage fault: {error}")),
-        Err(CoreError::Refused(refusal)) => Response::Error {
-            ok: false,
-            error: ErrorBody {
-                code: refusal.code().to_owned(),
-                message: refusal.message().to_owned(),
-                hint: refusal.hint().map(ToOwned::to_owned),
-            },
-        },
-        Err(error @ CoreError::InvalidCommand(_)) => Response::Error {
-            ok: false,
-            error: ErrorBody {
-                code: error.code().to_owned(),
-                message: error.to_string(),
-                hint: None,
-            },
-        },
-    })
-}
-
-#[derive(Debug, Serialize)]
-#[serde(untagged)]
-enum Response {
-    Ok { ok: bool, result: serde_json::Value },
-    Error { ok: bool, error: ErrorBody },
-}
-
-#[derive(Debug, Serialize)]
-struct ErrorBody {
-    code: String,
-    message: String,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    hint: Option<String>,
-}
 
 fn main() -> ExitCode {
     match run() {
@@ -246,42 +71,6 @@ fn main() -> ExitCode {
             ExitCode::FAILURE
         }
     }
-}
-
-/// Recover the machine code from a serde error message.
-///
-/// A `Deserialize` implementation can only fail with prose, so `Money`'s
-/// refusals arrive here as text with their code embedded. Without this, a
-/// sub-penny amount — a named, decided, tested refusal — would be reported as
-/// a generic `invalid_command`, and a spec could not tell it from a typo.
-///
-/// `unknown_field` is here for the same reason and is the local edition's
-/// DECLARED divergence from `update_transaction_atomic`, which discards a key it
-/// does not know. A divergence that reports as `invalid_command` is
-/// indistinguishable from a malformed request, and the whole point of it is that
-/// the caller can tell the difference.
-fn boundary_code(message: &str) -> String {
-    if let Some(code) = wealth_core::money::BOUNDARY_CODES
-        .iter()
-        .find(|code| message.contains(*code))
-    {
-        return (*code).to_owned();
-    }
-    // serde's own wording for `deny_unknown_fields`. Matched on the prefix
-    // rather than reconstructed, because the rest of the message names the key
-    // and lists the ones that were expected, and that is the useful half.
-    if message.starts_with("unknown field") {
-        return "unknown_field".to_owned();
-    }
-    "invalid_command".to_owned()
-}
-
-/// Every verb's result serialises the same way, and every one of them carries a
-/// `transaction` key the harness reads. One function so a fourth verb cannot
-/// invent a third shape.
-fn as_json<T: Serialize>(result: T) -> Result<serde_json::Value, CoreError> {
-    serde_json::to_value(&result)
-        .map_err(|error| CoreError::InvalidCommand(format!("result: {error}")))
 }
 
 fn print(response: &Response) {
@@ -336,19 +125,9 @@ fn run() -> Result<Response, String> {
 
     // A malformed command is a REFUSAL, not a fault: the harness asked for
     // something and is being told no. Only the transport is a fault.
-    let command: Command = match serde_json::from_str(&input) {
+    let command = match parse(&input) {
         Ok(command) => command,
-        Err(error) => {
-            let message = error.to_string();
-            return Ok(Response::Error {
-                ok: false,
-                error: ErrorBody {
-                    code: boundary_code(&message),
-                    message,
-                    hint: None,
-                },
-            });
-        }
+        Err(refusal) => return Ok(refusal),
     };
 
     // THE ADMISSION SURFACE IS ANSWERED BEFORE A FILE EXISTS
@@ -376,91 +155,5 @@ fn run() -> Result<Response, String> {
     let path = database.ok_or_else(|| "--db <path> is required".to_owned())?;
     let mut connection = db::open(&path).map_err(|error| error.to_string())?;
 
-    let outcome: Result<serde_json::Value, CoreError> = match command {
-        Command::CreateTransaction(payload) => {
-            create_transaction(&mut connection, *payload).and_then(as_json)
-        }
-        Command::UpdateTransaction(payload) => {
-            update_transaction(&mut connection, *payload).and_then(as_json)
-        }
-        Command::DeleteTransaction(payload) => {
-            delete_transaction(&mut connection, *payload).and_then(as_json)
-        }
-        Command::SetTransactionSplitsWithLegs(payload) => {
-            set_transaction_splits_with_legs(&mut connection, *payload).and_then(as_json)
-        }
-        Command::LinkTransferPair(payload) => {
-            link_transfer_pair(&mut connection, *payload).and_then(as_json)
-        }
-        Command::CreateTransferCounterpart(payload) => {
-            create_transfer_counterpart(&mut connection, *payload).and_then(as_json)
-        }
-        Command::ClearTransferLinks(payload) => {
-            clear_transfer_links(&mut connection, *payload).and_then(as_json)
-        }
-        Command::RepairClaimedTransfer(payload) => {
-            repair_claimed_transfer(&mut connection, *payload).and_then(as_json)
-        }
-        Command::LinkSplitLineTransfer(payload) => {
-            link_split_line_transfer(&mut connection, *payload).and_then(as_json)
-        }
-        Command::MergeCategories(payload) => {
-            merge_categories(&mut connection, *payload).and_then(as_json)
-        }
-        Command::ApplyCategoryToUncategorized(payload) => {
-            apply_category_to_uncategorized(&mut connection, *payload).and_then(as_json)
-        }
-        Command::ConfirmTransactionCategories(payload) => {
-            confirm_transaction_categories(&mut connection, *payload).and_then(as_json)
-        }
-        Command::DeleteUnusedCategories(payload) => {
-            delete_unused_categories(&mut connection, *payload).and_then(as_json)
-        }
-        // The only verb that needs no `&mut`: it opens no transaction, because
-        // it writes nothing.
-        Command::UserFinancialDataIsEmpty(payload) => {
-            user_financial_data_is_empty(&connection, *payload).and_then(as_json)
-        }
-        Command::WipeUserFinancialData(payload) => {
-            wipe_user_financial_data(&mut connection, *payload).and_then(as_json)
-        }
-        Command::RestoreUserChunk(payload) => {
-            restore_user_chunk(&mut connection, *payload).and_then(as_json)
-        }
-        Command::FinalizeUserRestore(payload) => {
-            finalize_user_restore(&mut connection, *payload).and_then(as_json)
-        }
-        Command::LinkBankAccountSnap(payload) => {
-            link_bank_account_snap(&mut connection, *payload).and_then(as_json)
-        }
-        Command::ImportTransactions(payload) => {
-            import_transactions(&mut connection, *payload).and_then(as_json)
-        }
-        Command::ImportBankTransactions(payload) => {
-            import_bank_transactions(&mut connection, *payload).and_then(as_json)
-        }
-        // The second verb that needs no `&mut`, and for the same reason as the
-        // first: it writes nothing.
-        Command::VerifyIntegrity(payload) => {
-            verify_integrity(&connection, *payload).and_then(as_json)
-        }
-        // A self-check with a name, and the same shape as the split writer's
-        // `split_write_inconsistent`: `plan` above answers every one of these
-        // and returns before a file is ever opened, so nothing can arrive here.
-        // Spelling the seven names out rather than writing `_` is what makes
-        // the compiler refuse a NEW verb that nobody dispatched — and if a plan
-        // verb is ever added to this arm and forgotten in `plan`, the caller is
-        // told so by name instead of being handed a connection.
-        Command::PlanStatementDuplicates(_)
-        | Command::PlanStatementBankBalance(_)
-        | Command::PlanFeedOverlap(_)
-        | Command::PlanClearedFlag(_)
-        | Command::PlanAccountIdentifiers(_)
-        | Command::PlanAccountIdentifierMatch(_)
-        | Command::PlanCategoryAdmission(_) => Err(CoreError::InvalidCommand(
-            "plan_dispatch_missed: an admission command reached the write dispatch".to_owned(),
-        )),
-    };
-
-    respond(outcome)
+    respond(dispatch(&mut connection, command))
 }

--- a/crates/wealth-core/src/command.rs
+++ b/crates/wealth-core/src/command.rs
@@ -1,0 +1,459 @@
+//! The command surface itself: every verb this crate answers to, the one
+//! dispatch that answers them, and the envelope the answer travels in.
+//!
+//! Four functions, in the order a command meets them: [`parse`] turns text into
+//! a typed [`Command`], [`plan`] answers the ones that need no database,
+//! [`dispatch`] runs the rest against a connection, and [`respond`] puts the
+//! outcome in the envelope.
+//!
+//! # Why this is in the library and not in the bin that used to hold it
+//!
+//! Two callers need this match and there must not be two matches.
+//!
+//! The first is `bin/wealth_core_cli.rs`, the differential harness's bridge:
+//! `scripts/local-sqlite/verbs.mjs` drives it once per spec and compares every
+//! answer against the live Postgres RPC. The second is the desktop shell, whose
+//! whole Rust surface is ONE `#[tauri::command] wealth_core_invoke(verb,
+//! payload)` over this same enum — PHASE3-PLAN D-3, which rejected forty
+//! separate Tauri commands for precisely this reason: it *"duplicates the
+//! exhaustive dispatch"*, and a verb set that exists twice is a verb set whose
+//! two halves agree until the day they do not.
+//!
+//! The bin cannot be that shared home. `Cargo.toml` puts it behind
+//! `required-features = ["cli"]` so the shell cannot ship it, and Cargo never
+//! builds a dependency's bin targets in any case. A library module is reachable
+//! from both; a bin is reachable from neither the other way round.
+//!
+//! What stays in the bin is what is genuinely the command line's: argument
+//! parsing, stdin and stdout, and the exit code.
+//!
+//! # The property that must stay singular
+//!
+//! [`dispatch`] is ONE match with no catch-all arm. Add a variant to [`Command`]
+//! and forget to arm it and the crate does not compile — the compiler refusing a
+//! verb nobody dispatched. That is the whole of R-10, and it is only a property
+//! while there is one match to hold it: a second dispatch elsewhere would each
+//! be exhaustive over its own arms and neither would notice the other's gap.
+//!
+//! # This is not a SQL surface
+//!
+//! DESIGN.md §6.4: *"There is no command that accepts a SQL string. You cannot
+//! bypass what does not exist."* A command is `{"verb": …, "payload": …}`,
+//! deserialised by serde into a typed payload. A payload that is not a known
+//! verb is refused; a payload with an unrecognised field is refused. Neither
+//! refusal touches a connection — [`parse`] runs before anything is opened —
+//! and there is no branch anywhere below that concatenates a caller's text into
+//! a statement.
+//!
+//! # The envelope
+//!
+//! ```text
+//! {"ok":true,  "result": …}
+//! {"ok":false, "error": {"code": …, "message": …, "hint": …}}
+//! ```
+//!
+//! A refusal is an ANSWER and rides in that second shape with `ok:false`. A
+//! storage fault is not an answer: [`respond`] returns `Err` for it, and each
+//! caller shows it out by its own door — a non-zero exit and a line on stderr
+//! for the CLI, a rejected promise for the shell. The harness relies on the
+//! distinction (`lib/verb-sqlite.mjs`: *"A non-zero exit is a FAULT, never a
+//! refusal"*) and so does the seam: a refusal's `message` is the prose the user
+//! reads, so it must not be prefixed, wrapped or re-worded on its way out.
+//!
+//! # Why [`parse`] takes text rather than a `serde_json::Value`
+//!
+//! Because the two are not the same refusal. `from_str` reports the line and
+//! column of the offending byte and `from_value` cannot, so a second entry
+//! point would put two different `message` strings on the wire for one mistake.
+//! Which one the shell sends is a decision about the wire rather than a
+//! convenience, and it belongs to the commit that gives the shell a caller.
+
+use serde::{Deserialize, Serialize};
+
+use crate::admission::{
+    plan_account_identifier_match, plan_account_identifiers, plan_category_admission,
+    plan_cleared_flag, plan_feed_overlap, plan_statement_bank_balance, plan_statement_duplicates,
+    PlanAccountIdentifierMatch, PlanAccountIdentifiers, PlanCategoryAdmission, PlanClearedFlag,
+    PlanFeedOverlap, PlanStatementBankBalance, PlanStatementDuplicates,
+};
+use crate::error::CoreError;
+use crate::verbs::{
+    apply_category_to_uncategorized, clear_transfer_links, confirm_transaction_categories,
+    create_transaction, create_transfer_counterpart, delete_transaction, delete_unused_categories,
+    finalize_user_restore, import_bank_transactions, import_transactions, link_bank_account_snap,
+    link_split_line_transfer, link_transfer_pair, merge_categories, repair_claimed_transfer,
+    restore_user_chunk, set_transaction_splits_with_legs, update_transaction,
+    user_financial_data_is_empty, verify_integrity, wipe_user_financial_data,
+    ApplyCategoryToUncategorized, ClearTransferLinks, ConfirmTransactionCategories,
+    CreateTransaction, CreateTransferCounterpart, DeleteTransaction, DeleteUnusedCategories,
+    FinalizeUserRestore, ImportBankTransactions, ImportTransactions, LinkBankAccountSnap,
+    LinkSplitLineTransfer, LinkTransferPair, MergeCategories, RepairClaimedTransfer,
+    RestoreUserChunk, SetTransactionSplitsWithLegs, UpdateTransaction, UserFinancialDataIsEmpty,
+    VerifyIntegrity, WipeUserFinancialData,
+};
+
+/// A command, as a caller sends it.
+///
+/// One JSON object per verb, and the object is the same one the Postgres side
+/// receives — the update and delete RPCs take their arguments positionally
+/// (`(p_id, p, p_user_id)`), so `lib/verb-postgres.mjs` unpacks the same object
+/// into that call rather than either side getting a payload of its own.
+// The shared postfix is the point: `serde(rename_all = "snake_case")` turns
+// these names into the wire's verb strings, so `CreateTransaction` IS
+// `"create_transaction"`. Shortening them to please the lint would rename the
+// protocol.
+#[allow(clippy::enum_variant_names)]
+#[derive(Debug, Deserialize)]
+#[serde(tag = "verb", content = "payload", rename_all = "snake_case")]
+pub enum Command {
+    /// [`crate::verbs::create_transaction`].
+    CreateTransaction(Box<CreateTransaction>),
+    /// [`crate::verbs::update_transaction`].
+    UpdateTransaction(Box<UpdateTransaction>),
+    /// [`crate::verbs::delete_transaction`].
+    DeleteTransaction(Box<DeleteTransaction>),
+    // Named for the RPC it ports, not for the older `set_transaction_splits`
+    // that is deliberately left alone in the cloud. The two are different write
+    // paths with different rules, and a verb string that could mean either is a
+    // verb string that will one day mean the wrong one.
+    /// [`crate::verbs::set_transaction_splits_with_legs`].
+    SetTransactionSplitsWithLegs(Box<SetTransactionSplitsWithLegs>),
+    // The transfer family. Five RPCs, five verb strings, each spelled exactly as
+    // the function it ports — including `clear_transfer_links`, which is what
+    // the client's `clearTransferLinks` actually calls (it stopped being a table
+    // UPDATE in 20260805145035, and the verb's docs record how that was
+    // established rather than assumed).
+    /// [`crate::verbs::link_transfer_pair`].
+    LinkTransferPair(Box<LinkTransferPair>),
+    /// [`crate::verbs::create_transfer_counterpart`].
+    CreateTransferCounterpart(Box<CreateTransferCounterpart>),
+    /// [`crate::verbs::clear_transfer_links`].
+    ClearTransferLinks(Box<ClearTransferLinks>),
+    /// [`crate::verbs::repair_claimed_transfer`].
+    RepairClaimedTransfer(Box<RepairClaimedTransfer>),
+    /// [`crate::verbs::link_split_line_transfer`].
+    LinkSplitLineTransfer(Box<LinkSplitLineTransfer>),
+    // The category family. Three verb strings, each spelled exactly as the
+    // function it ports — including the two from 20260808100000, whose LIVE
+    // definitions are the ones ported (`apply_category_to_uncategorized` has
+    // three definitions across three migrations and only the newest counts).
+    /// [`crate::verbs::merge_categories`].
+    MergeCategories(Box<MergeCategories>),
+    /// [`crate::verbs::apply_category_to_uncategorized`].
+    ApplyCategoryToUncategorized(Box<ApplyCategoryToUncategorized>),
+    /// [`crate::verbs::confirm_transaction_categories`].
+    ConfirmTransactionCategories(Box<ConfirmTransactionCategories>),
+    // The fourth category verb, and the one whose every protection is a WHERE
+    // clause rather than a RAISE. Same name as the RPC it ports; the count it
+    // returns is the RPC's, which is not the count SQLite's own single-statement
+    // spelling would give (see the verb's module documentation).
+    /// [`crate::verbs::delete_unused_categories`].
+    DeleteUnusedCategories(Box<DeleteUnusedCategories>),
+    // The restore family. Four verb strings, each spelled exactly as the
+    // function it ports — including `restore_user_chunk`, whose LOCAL payload
+    // carries a LIST of chunks because the whole restore is one transaction here
+    // (DESIGN.md §5 divergence 6). The name is kept singular because a verb
+    // string that differs from the function it ports is a verb string that will
+    // one day be mapped to the wrong function.
+    /// [`crate::verbs::user_financial_data_is_empty`].
+    UserFinancialDataIsEmpty(Box<UserFinancialDataIsEmpty>),
+    /// [`crate::verbs::wipe_user_financial_data`].
+    WipeUserFinancialData(Box<WipeUserFinancialData>),
+    /// [`crate::verbs::restore_user_chunk`].
+    RestoreUserChunk(Box<RestoreUserChunk>),
+    /// [`crate::verbs::finalize_user_restore`].
+    FinalizeUserRestore(Box<FinalizeUserRestore>),
+    // The account snap: service-role only in the cloud, and the one function in
+    // the schema that assigns an absolute balance without breaking B-1.
+    /// [`crate::verbs::link_bank_account_snap`].
+    LinkBankAccountSnap(Box<LinkBankAccountSnap>),
+    // The ingest surface. Two verb strings, each spelled as the function it
+    // ports minus the `_atomic` every verb in this crate drops.
+    //
+    // PHASE1-PLAN §3.2 also lists an `import_transactions`, and it is NOT this
+    // one: that is the admission-control verb over `RawRow`, which decides what
+    // a file's text MEANS before anything is stored. This is the write path such
+    // a verb would end in — the port of the RPC that exists today. Named here
+    // rather than left to be discovered, because two things called
+    // `import_transactions` is exactly how the wrong one gets called.
+    /// [`crate::verbs::import_transactions`].
+    ImportTransactions(Box<ImportTransactions>),
+    /// [`crate::verbs::import_bank_transactions`].
+    ImportBankTransactions(Box<ImportBankTransactions>),
+    // The only verb here that is NOT a port: the cloud has no verify_integrity,
+    // no view and no equivalent, and the verb's module documentation carries the
+    // trace that establishes it. Its payload is `{}` — it takes not even an
+    // owner, because integrity is a property of the file.
+    /// [`crate::verbs::verify_integrity`].
+    VerifyIntegrity(Box<VerifyIntegrity>),
+    // ── The admission surface ────────────────────────────────────────────────
+    //
+    // Seven commands that decide what a parsed row MEANS, and write nothing.
+    // They are dispatched by `plan` below, BEFORE the database is opened, and
+    // handing one a database is a fault: see that function for why the refusal
+    // is worth more than the convenience.
+    //
+    // None of these is a port of a Postgres function — there is none to port.
+    // Their oracle is the TypeScript module each one names, executed side by
+    // side with this crate by `scripts/local-sqlite/admission.mjs`.
+    /// [`crate::admission::plan_statement_duplicates`].
+    PlanStatementDuplicates(Box<PlanStatementDuplicates>),
+    /// [`crate::admission::plan_statement_bank_balance`].
+    PlanStatementBankBalance(Box<PlanStatementBankBalance>),
+    /// [`crate::admission::plan_feed_overlap`].
+    PlanFeedOverlap(Box<PlanFeedOverlap>),
+    /// [`crate::admission::plan_cleared_flag`].
+    PlanClearedFlag(Box<PlanClearedFlag>),
+    /// [`crate::admission::plan_account_identifiers`].
+    PlanAccountIdentifiers(Box<PlanAccountIdentifiers>),
+    /// [`crate::admission::plan_account_identifier_match`].
+    PlanAccountIdentifierMatch(Box<PlanAccountIdentifierMatch>),
+    /// [`crate::admission::plan_category_admission`].
+    PlanCategoryAdmission(Box<PlanCategoryAdmission>),
+}
+
+/// Read one command out of its JSON text.
+///
+/// # Errors
+/// The refusal to send back, ready-made: a malformed command is a REFUSAL, not
+/// a fault. The caller asked for something and is being told no, in the same
+/// envelope every other no arrives in — and it is told before a file is opened,
+/// which is what makes "an unknown verb never reaches a connection" a fact
+/// about the code rather than a claim about it.
+pub fn parse(input: &str) -> Result<Command, Response> {
+    serde_json::from_str(input).map_err(|error| {
+        let message = error.to_string();
+        Response::Error {
+            ok: false,
+            error: ErrorBody {
+                code: boundary_code(&message),
+                message,
+                hint: None,
+            },
+        }
+    })
+}
+
+/// Recover the machine code from a serde error message.
+///
+/// A `Deserialize` implementation can only fail with prose, so `Money`'s
+/// refusals arrive here as text with their code embedded. Without this, a
+/// sub-penny amount — a named, decided, tested refusal — would be reported as
+/// a generic `invalid_command`, and a spec could not tell it from a typo.
+///
+/// `unknown_field` is here for the same reason and is the local edition's
+/// DECLARED divergence from `update_transaction_atomic`, which discards a key it
+/// does not know. A divergence that reports as `invalid_command` is
+/// indistinguishable from a malformed request, and the whole point of it is that
+/// the caller can tell the difference.
+fn boundary_code(message: &str) -> String {
+    if let Some(code) = crate::money::BOUNDARY_CODES
+        .iter()
+        .find(|code| message.contains(*code))
+    {
+        return (*code).to_owned();
+    }
+    // serde's own wording for `deny_unknown_fields`. Matched on the prefix
+    // rather than reconstructed, because the rest of the message names the key
+    // and lists the ones that were expected, and that is the useful half.
+    if message.starts_with("unknown field") {
+        return "unknown_field".to_owned();
+    }
+    "invalid_command".to_owned()
+}
+
+/// The admission commands, answered without a database.
+///
+/// # Errors
+/// `Err(command)` hands a write verb back untouched, so the write dispatch
+/// below stays exhaustive: a verb added to [`Command`] and forgotten here falls
+/// through to that match and fails to compile, which is the failure everybody
+/// wants and nobody gets from a catch-all on both sides.
+///
+/// The `Ok` is itself a result, because a planner can refuse.
+pub fn plan(command: Command) -> Result<Result<serde_json::Value, CoreError>, Command> {
+    match command {
+        Command::PlanStatementDuplicates(payload) => {
+            Ok(as_json(plan_statement_duplicates(&payload)))
+        }
+        Command::PlanStatementBankBalance(payload) => {
+            Ok(as_json(plan_statement_bank_balance(&payload)))
+        }
+        Command::PlanFeedOverlap(payload) => Ok(as_json(plan_feed_overlap(&payload))),
+        Command::PlanClearedFlag(payload) => Ok(as_json(plan_cleared_flag(&payload))),
+        Command::PlanAccountIdentifiers(payload) => Ok(as_json(plan_account_identifiers(&payload))),
+        Command::PlanAccountIdentifierMatch(payload) => {
+            Ok(as_json(plan_account_identifier_match(&payload)))
+        }
+        Command::PlanCategoryAdmission(payload) => Ok(as_json(plan_category_admission(&payload))),
+        other => Err(other),
+    }
+}
+
+/// Run one write verb against an open ledger.
+///
+/// THE match, and the one place a verb string becomes a call. Spelling every
+/// variant out rather than writing `_` is what makes the compiler refuse a NEW
+/// verb that nobody dispatched; see this module's documentation for why that
+/// property only holds while there is exactly one of these.
+///
+/// # Errors
+/// [`CoreError`] as the verb returns it: a [`CoreError::Refused`] is the ledger
+/// declining and the file is intact, a [`CoreError::Storage`] is a fault.
+pub fn dispatch(
+    connection: &mut rusqlite::Connection,
+    command: Command,
+) -> Result<serde_json::Value, CoreError> {
+    match command {
+        Command::CreateTransaction(payload) => {
+            create_transaction(connection, *payload).and_then(as_json)
+        }
+        Command::UpdateTransaction(payload) => {
+            update_transaction(connection, *payload).and_then(as_json)
+        }
+        Command::DeleteTransaction(payload) => {
+            delete_transaction(connection, *payload).and_then(as_json)
+        }
+        Command::SetTransactionSplitsWithLegs(payload) => {
+            set_transaction_splits_with_legs(connection, *payload).and_then(as_json)
+        }
+        Command::LinkTransferPair(payload) => {
+            link_transfer_pair(connection, *payload).and_then(as_json)
+        }
+        Command::CreateTransferCounterpart(payload) => {
+            create_transfer_counterpart(connection, *payload).and_then(as_json)
+        }
+        Command::ClearTransferLinks(payload) => {
+            clear_transfer_links(connection, *payload).and_then(as_json)
+        }
+        Command::RepairClaimedTransfer(payload) => {
+            repair_claimed_transfer(connection, *payload).and_then(as_json)
+        }
+        Command::LinkSplitLineTransfer(payload) => {
+            link_split_line_transfer(connection, *payload).and_then(as_json)
+        }
+        Command::MergeCategories(payload) => {
+            merge_categories(connection, *payload).and_then(as_json)
+        }
+        Command::ApplyCategoryToUncategorized(payload) => {
+            apply_category_to_uncategorized(connection, *payload).and_then(as_json)
+        }
+        Command::ConfirmTransactionCategories(payload) => {
+            confirm_transaction_categories(connection, *payload).and_then(as_json)
+        }
+        Command::DeleteUnusedCategories(payload) => {
+            delete_unused_categories(connection, *payload).and_then(as_json)
+        }
+        // The only verb that needs no `&mut`: it opens no transaction, because
+        // it writes nothing.
+        Command::UserFinancialDataIsEmpty(payload) => {
+            user_financial_data_is_empty(&*connection, *payload).and_then(as_json)
+        }
+        Command::WipeUserFinancialData(payload) => {
+            wipe_user_financial_data(connection, *payload).and_then(as_json)
+        }
+        Command::RestoreUserChunk(payload) => {
+            restore_user_chunk(connection, *payload).and_then(as_json)
+        }
+        Command::FinalizeUserRestore(payload) => {
+            finalize_user_restore(connection, *payload).and_then(as_json)
+        }
+        Command::LinkBankAccountSnap(payload) => {
+            link_bank_account_snap(connection, *payload).and_then(as_json)
+        }
+        Command::ImportTransactions(payload) => {
+            import_transactions(connection, *payload).and_then(as_json)
+        }
+        Command::ImportBankTransactions(payload) => {
+            import_bank_transactions(connection, *payload).and_then(as_json)
+        }
+        // The second verb that needs no `&mut`, and for the same reason as the
+        // first: it writes nothing.
+        Command::VerifyIntegrity(payload) => {
+            verify_integrity(&*connection, *payload).and_then(as_json)
+        }
+        // A self-check with a name, and the same shape as the split writer's
+        // `split_write_inconsistent`: [`plan`] above answers every one of these
+        // and returns before a file is ever opened, so nothing can arrive here.
+        // Spelling the seven names out rather than writing `_` is what makes
+        // the compiler refuse a NEW verb that nobody dispatched — and if a plan
+        // verb is ever added to this arm and forgotten in [`plan`], the caller
+        // is told so by name instead of being handed a connection.
+        Command::PlanStatementDuplicates(_)
+        | Command::PlanStatementBankBalance(_)
+        | Command::PlanFeedOverlap(_)
+        | Command::PlanClearedFlag(_)
+        | Command::PlanAccountIdentifiers(_)
+        | Command::PlanAccountIdentifierMatch(_)
+        | Command::PlanCategoryAdmission(_) => Err(CoreError::InvalidCommand(
+            "plan_dispatch_missed: an admission command reached the write dispatch".to_owned(),
+        )),
+    }
+}
+
+/// One verb's outcome, as the wire's response.
+///
+/// # Errors
+/// A storage fault is `Err`: the caller must be able to tell "the verb refused"
+/// from "the harness is broken", and the two leave by different doors.
+pub fn respond(outcome: Result<serde_json::Value, CoreError>) -> Result<Response, String> {
+    Ok(match outcome {
+        Ok(result) => Response::Ok { ok: true, result },
+        Err(CoreError::Storage(error)) => return Err(format!("storage fault: {error}")),
+        Err(CoreError::Refused(refusal)) => Response::Error {
+            ok: false,
+            error: ErrorBody {
+                code: refusal.code().to_owned(),
+                message: refusal.message().to_owned(),
+                hint: refusal.hint().map(ToOwned::to_owned),
+            },
+        },
+        Err(error @ CoreError::InvalidCommand(_)) => Response::Error {
+            ok: false,
+            error: ErrorBody {
+                code: error.code().to_owned(),
+                message: error.to_string(),
+                hint: None,
+            },
+        },
+    })
+}
+
+/// The envelope. `ok` is a field rather than a tag because it is read by
+/// callers that never learn Rust exists.
+#[derive(Debug, Serialize)]
+#[serde(untagged)]
+pub enum Response {
+    /// The verb answered. `ok` is always `true`.
+    Ok {
+        /// Always `true`.
+        ok: bool,
+        /// What the verb returned, serialised.
+        result: serde_json::Value,
+    },
+    /// The verb, or the parse before it, said no. `ok` is always `false`.
+    Error {
+        /// Always `false`.
+        ok: bool,
+        /// The refusal.
+        error: ErrorBody,
+    },
+}
+
+/// A refusal on the wire: a name to match on, a sentence to show, and
+/// sometimes a second sentence saying what to do about it.
+#[derive(Debug, Serialize)]
+pub struct ErrorBody {
+    code: String,
+    message: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    hint: Option<String>,
+}
+
+/// Every verb's result serialises the same way, and every one of them carries a
+/// `transaction` key the harness reads. One function so a fourth verb cannot
+/// invent a third shape.
+fn as_json<T: Serialize>(result: T) -> Result<serde_json::Value, CoreError> {
+    serde_json::to_value(&result)
+        .map_err(|error| CoreError::InvalidCommand(format!("result: {error}")))
+}

--- a/crates/wealth-core/src/lib.rs
+++ b/crates/wealth-core/src/lib.rs
@@ -21,6 +21,15 @@
 //! drift from the first, and the drift would be invisible until a constraint
 //! that fires in the harness did not fire in the app.
 //!
+//! # The surface, and who reaches it
+//!
+//! [`command`] holds the verb set, the one dispatch over it and the envelope an
+//! answer travels in. It is a library module rather than part of the CLI bin
+//! that first held it because two callers need that dispatch and there must not
+//! be two of it: the differential harness's bridge, and the desktop shell's
+//! single Tauri command (PHASE3-PLAN D-3). The bin keeps what is the command
+//! line's own — arguments, stdin, stdout, exit codes.
+//!
 //! # Phase 1 scope
 //!
 //! Nine verbs, in the order they were ported and for the reasons they were
@@ -230,6 +239,7 @@
 pub mod admission;
 pub mod audit;
 pub mod backup;
+pub mod command;
 pub mod db;
 pub mod error;
 pub mod money;

--- a/crates/wealth-core/src/verbs/link_transfer_pair.rs
+++ b/crates/wealth-core/src/verbs/link_transfer_pair.rs
@@ -121,7 +121,7 @@ pub struct LinkTransferPair {
 ///
 /// The RPC returns `{a, b}`. Here side A is called `transaction` because every
 /// verb result in this crate carries a `transaction` key the harness compares
-/// field by field (`bin/wealth_core_cli.rs`), and side B keeps a name that says
+/// field by field ([`crate::command`]), and side B keeps a name that says
 /// what it is rather than which argument it was.
 #[derive(Debug, Serialize)]
 pub struct LinkTransferPairResult {

--- a/crates/wealth-core/src/verbs/mod.rs
+++ b/crates/wealth-core/src/verbs/mod.rs
@@ -486,7 +486,7 @@ fn is_blank_category(category: Option<&str>) -> bool {
 /// A row inside a batch that serde could not read, as a refusal with a NAME.
 ///
 /// The two ingest verbs deserialise their rows one at a time inside the loop, so
-/// the row's own errors never pass through the CLI's top-level `boundary_code`
+/// the row's own errors never pass through [`crate::command`]'s `boundary_code`
 /// and would otherwise all arrive as `invalid_command`. That matters for exactly
 /// one of them: `deny_unknown_fields` is this crate's DECLARED divergence from
 /// both import RPCs — the cloud discards a key it does not know, the local


### PR DESCRIPTION
Phase 3, slice 14 — the plan calls it the highest-value hour: a pure extraction so the future desktop shell's single Tauri command and the CLI binary run **the same exhaustive dispatch match**.

## What moved
The `Command` enum (28 variants), `parse`/`plan`/`dispatch`/`respond`, and the `{ok, error:{code,message,hint}}` envelope lift from the CLI bin into `crates/wealth-core/src/command.rs` (459 lines). The bin shrinks 466 → 159: argument parsing, stdio, exit codes — a caller, not a surface. Public API is seven items; `parse` takes text (not a `Value`) so one mistake can't put two different messages on the wire.

## Zero behaviour, measured
- Every suite identical before/after with zero test files touched: 271 cargo tests across 14 targets, 109/109 admission, 66-spec constraint lane (same single pre-existing Postgres-side red), 308-spec verb lane (same ten pre-existing reds, by name), app smoke 5,620 unchanged.
- Eleven CLI invocations captured **byte-for-byte** (stdout + stderr + exit code) before and after: success, hinted refusal, constraint refusal, serde refusing an unknown verb before any connection exists, unknown field, sub-penny money, `plan` with and without `--db`, storage fault, unknown argument.
- Structural mutation: an unarmed enum variant fails the build on the non-exhaustive match — and the lift makes the guarantee stronger: it previously fired only under `--features cli`; it now fires on a plain library build, i.e. the shell's build.

## Found, named, deliberately not smuggled in
The verb lane's ten pre-existing reds trace to a **live cloud defect**: `restore_user_chunk` materialises backups via `jsonb_populate_recordset`, which emits *explicit NULLs* for keys a backup omits — and `needs_review` became NOT NULL on 2026-08-10. Restoring any backup written before that column existed would fail in production. Next PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)