### PR TITLE
feat(core): slice 15 — reads become verbs, and their plans are on the record (326 verb specs +17, 284 cargo tests)

### DIFF
--- a/crates/wealth-core/src/command.rs
+++ b/crates/wealth-core/src/command.rs
@@ -81,13 +81,14 @@ use crate::verbs::{
     apply_category_to_uncategorized, clear_transfer_links, confirm_transaction_categories,
     create_transaction, create_transfer_counterpart, delete_transaction, delete_unused_categories,
     finalize_user_restore, import_bank_transactions, import_transactions, link_bank_account_snap,
-    link_split_line_transfer, link_transfer_pair, merge_categories, repair_claimed_transfer,
-    restore_user_chunk, set_transaction_splits_with_legs, update_transaction,
-    user_financial_data_is_empty, verify_integrity, wipe_user_financial_data,
+    link_split_line_transfer, link_transfer_pair, list_accounts, list_budgets, list_categories,
+    list_closed_accounts, list_goals, list_suggestion_dismissals, merge_categories,
+    repair_claimed_transfer, restore_user_chunk, set_transaction_splits_with_legs,
+    update_transaction, user_financial_data_is_empty, verify_integrity, wipe_user_financial_data,
     ApplyCategoryToUncategorized, ClearTransferLinks, ConfirmTransactionCategories,
     CreateTransaction, CreateTransferCounterpart, DeleteTransaction, DeleteUnusedCategories,
     FinalizeUserRestore, ImportBankTransactions, ImportTransactions, LinkBankAccountSnap,
-    LinkSplitLineTransfer, LinkTransferPair, MergeCategories, RepairClaimedTransfer,
+    LinkSplitLineTransfer, LinkTransferPair, MergeCategories, OwnedRead, RepairClaimedTransfer,
     RestoreUserChunk, SetTransactionSplitsWithLegs, UpdateTransaction, UserFinancialDataIsEmpty,
     VerifyIntegrity, WipeUserFinancialData,
 };
@@ -180,6 +181,34 @@ pub enum Command {
     ImportTransactions(Box<ImportTransactions>),
     /// [`crate::verbs::import_bank_transactions`].
     ImportBankTransactions(Box<ImportBankTransactions>),
+    // ── The reads ────────────────────────────────────────────────────────────
+    //
+    // Six verbs that answer and write nothing. Each is named for the question
+    // it answers rather than for a function it ports, because there is no
+    // function to port: the cloud reads these tables over PostgREST, so what is
+    // ported is a QUERY — its filter and its ORDER BY, spelled out in
+    // [`crate::verbs::reads`] alongside the plan each one was measured to use.
+    //
+    // `list_closed_accounts` is a second verb rather than a flag on the first,
+    // and that is the naming discipline rather than an accident: two questions
+    // get two names, and a payload with `{"open": false}` in it is a payload
+    // that will one day be sent by mistake.
+    //
+    // All six share ONE payload type — an owner, and nothing else. The dispatch
+    // stays exhaustive over VARIANTS, so a seventh read still has to be armed
+    // below or the crate does not compile.
+    /// [`crate::verbs::list_accounts`].
+    ListAccounts(Box<OwnedRead>),
+    /// [`crate::verbs::list_closed_accounts`].
+    ListClosedAccounts(Box<OwnedRead>),
+    /// [`crate::verbs::list_categories`].
+    ListCategories(Box<OwnedRead>),
+    /// [`crate::verbs::list_budgets`].
+    ListBudgets(Box<OwnedRead>),
+    /// [`crate::verbs::list_goals`].
+    ListGoals(Box<OwnedRead>),
+    /// [`crate::verbs::list_suggestion_dismissals`].
+    ListSuggestionDismissals(Box<OwnedRead>),
     // The only verb here that is NOT a port: the cloud has no verify_integrity,
     // no view and no equivalent, and the verb's module documentation carries the
     // trace that establishes it. Its payload is `{}` — it takes not even an
@@ -371,6 +400,25 @@ pub fn dispatch(
         // first: it writes nothing.
         Command::VerifyIntegrity(payload) => {
             verify_integrity(&*connection, *payload).and_then(as_json)
+        }
+        // The reads, and every one of them takes `&*connection` for the same
+        // reason those two do: a read opens no transaction. Six arms rather
+        // than one `Command::List…(_) => list(…)` helper, because the enum's
+        // whole property is that each variant is spelled once here — an arm
+        // that dispatched several verbs through one function would be a place
+        // for two of them to become the same answer without the compiler
+        // noticing.
+        Command::ListAccounts(payload) => list_accounts(&*connection, *payload).and_then(as_json),
+        Command::ListClosedAccounts(payload) => {
+            list_closed_accounts(&*connection, *payload).and_then(as_json)
+        }
+        Command::ListCategories(payload) => {
+            list_categories(&*connection, *payload).and_then(as_json)
+        }
+        Command::ListBudgets(payload) => list_budgets(&*connection, *payload).and_then(as_json),
+        Command::ListGoals(payload) => list_goals(&*connection, *payload).and_then(as_json),
+        Command::ListSuggestionDismissals(payload) => {
+            list_suggestion_dismissals(&*connection, *payload).and_then(as_json)
         }
         // A self-check with a name, and the same shape as the split writer's
         // `split_write_inconsistent`: [`plan`] above answers every one of these

--- a/crates/wealth-core/src/money.rs
+++ b/crates/wealth-core/src/money.rs
@@ -228,21 +228,42 @@ impl Money {
     /// Render as the decimal string this type deserialises from. Exact: no
     /// float ever exists on this path.
     #[must_use]
-    // The divisor is the literal 100 and the dividend is a u64, so neither
-    // division can divide by zero nor overflow. Spelled out rather than
-    // switching the lint off, because the next person to add arithmetic here
-    // should have to justify it too.
-    #[allow(clippy::arithmetic_side_effects)]
     pub fn to_decimal_string(self) -> String {
-        let negative = self.0 < 0;
-        // i64::MIN has no positive counterpart; unsigned_abs is the only
-        // correct way to take the magnitude.
-        let magnitude = self.0.unsigned_abs();
-        let major = magnitude / 100;
-        let minor = magnitude % 100;
-        let sign = if negative { "-" } else { "" };
-        format!("{sign}{major}.{minor:02}")
+        hundredths_to_decimal_string(self.0)
     }
+}
+
+/// A count of hundredths, rendered as a two-place decimal string. Exact: no
+/// float ever exists on this path.
+///
+/// [`Money::to_decimal_string`] IS this function, and it is spelled separately
+/// for one reason: `budgets.alert_threshold_bp` is stored as hundredths of a
+/// percent (8000 meaning 80.00%) and the cloud stores the same quantity as
+/// `numeric(5,2)`, which casts to text as `"80.00"`. A read that hands the app
+/// the raw 8000 forces a division on the far side of the boundary — and
+/// `/ 100` under `src/services/local/` is exactly what R-7's grep exists to
+/// catch, whether or not the quantity is money.
+///
+/// So the rendering happens here, once, in the module whose entire purpose is
+/// that a fixed-point quantity never meets a float. What must NOT follow is a
+/// [`Money`] holding a percentage: the threshold is not money, `schema.sql`
+/// says so in capitals at the column, and giving it money's type would make it
+/// eligible for every arithmetic this crate reserves for amounts.
+#[must_use]
+// The divisor is the literal 100 and the dividend is a u64, so neither
+// division can divide by zero nor overflow. Spelled out rather than
+// switching the lint off, because the next person to add arithmetic here
+// should have to justify it too.
+#[allow(clippy::arithmetic_side_effects)]
+pub fn hundredths_to_decimal_string(hundredths: i64) -> String {
+    let negative = hundredths < 0;
+    // i64::MIN has no positive counterpart; unsigned_abs is the only
+    // correct way to take the magnitude.
+    let magnitude = hundredths.unsigned_abs();
+    let whole = magnitude / 100;
+    let fraction = magnitude % 100;
+    let sign = if negative { "-" } else { "" };
+    format!("{sign}{whole}.{fraction:02}")
 }
 
 impl fmt::Debug for Money {

--- a/crates/wealth-core/src/row.rs
+++ b/crates/wealth-core/src/row.rs
@@ -28,10 +28,38 @@
 //! write outside the transaction/account pair — and the first to audit a
 //! `category`, which is why [`category`] now carries a row type as well as the
 //! two *questions* the write verbs ask about one.
+//!
+//! # Reading is the second reason a module is here
+//!
+//! [`crate::verbs::reads`] answers with rows too, and it answers with THESE —
+//! there is no second reader with a mapping of its own, which is PHASE3-PLAN
+//! D-4's second reason for putting the reads in the crate at all: *"row mappers
+//! already exist … money already leaves as decimal strings"*.
+//!
+//! What a read projects is what the CLOUD's own query projects, so that the
+//! differential harness compares two answers to one question rather than two
+//! questions. `.select('*')` means the whole row; a query that names its
+//! columns (`suggestionDismissalService.list` names five) means those columns.
+//!
+//! Where that set is the set the audit already records, there is ONE type —
+//! [`category::CategoryRow`] serves both. Where it is not, there are two, and
+//! the module says which is which and why:
+//!
+//! * [`account`] — the audit entry is a deliberate eight-field projection whose
+//!   width is load-bearing in `link_bank_account_snap`'s differential
+//!   comparison; the reader needs the whole row.
+//! * [`budget`] — the audit entry keeps `alert_threshold_bp` as stored; the
+//!   reader gets it rendered, because the alternative is a division on the far
+//!   side of the boundary.
+//!
+//! And two entities are here for the reader alone, with no audit twin, because
+//! no verb in either engine audits one: [`goal`] and [`dismissal`].
 
 pub mod account;
 pub mod budget;
 pub mod category;
+pub mod dismissal;
+pub mod goal;
 pub mod recurring;
 pub mod split;
 

--- a/crates/wealth-core/src/row/account.rs
+++ b/crates/wealth-core/src/row/account.rs
@@ -19,6 +19,33 @@
 //! same decision [`crate::row::TransactionRow`] makes, and for the same reason:
 //! the audit payload is compared field by field by the differential harness, so
 //! every field in it is a field two engines have to agree about.
+//!
+//! # And a SECOND projection, because a reader needs a different account
+//!
+//! [`ListedAccount`] is the whole row, and the two types are not a duplication
+//! waiting to be merged. They answer different questions and the difference is
+//! load-bearing in both directions:
+//!
+//! * [`AccountRow`]'s eight fields are the fields
+//!   `link_bank_account_snap`'s answer is compared on, field by field, against
+//!   the live RPC (`lib/verb-postgres.mjs` builds exactly those eight). Widening
+//!   it would put `created_at` into that comparison — two clocks, two engines,
+//!   never equal — and turn a passing differential surface red for no gain.
+//! * [`ListedAccount`] cannot be narrower, because the app draws an account from
+//!   it: `mapAccountFromDb` (`src/services/api/accountMapping.ts`) is written
+//!   against `select('*')` and reads twenty of these columns, including the four
+//!   an account's identity depends on (sort code, account number, institution,
+//!   parent) and the three the reconciliation bar depends on.
+//!
+//! **Three columns the cloud has and this file does not**:
+//! `plaid_account_id`, `plaid_connection_id` (a local file has no bank feed to
+//! carry an id for) and `last_reconciled_balance` (added to the cloud by
+//! `20260810200000` and not yet mirrored in `scripts/local-sqlite/schema.sql`).
+//! The first two are an absence by design; the third is a gap, and it is named
+//! here rather than papered over because `mapAccountFromDb` reads
+//! `last_reconciled_balance` and treats a missing one as *never reconciled* —
+//! which is a true statement about a file that cannot store it, and a false one
+//! about an account that has been.
 
 use rusqlite::{params, Connection, OptionalExtension};
 use serde::Serialize;
@@ -85,6 +112,172 @@ pub fn read_owned(
             },
         )
         .optional()?)
+}
+
+/// An account as the app lists it: every column this file holds, in the
+/// serialised order.
+///
+/// Money leaves as a decimal string under the CLOUD's column name —
+/// `balance`, not `balance_minor` — because the value is no longer minor units
+/// once it is rendered, and because the one mapper on the far side
+/// (`accountMapping.ts`, itself the fix for an era with two of them) is written
+/// against those names. A local name on a rendered value would be a third
+/// spelling of one field.
+#[derive(Debug, Clone, Serialize)]
+// Two booleans, because the table has two boolean columns. The reasoning
+// `TransactionRow` gives: this is a row, not a designed API.
+#[allow(clippy::struct_excessive_bools)]
+pub struct ListedAccount {
+    /// Primary key.
+    pub id: String,
+    /// Owner.
+    pub user_id: String,
+    /// As shown, and as the To/From category is named after.
+    pub name: String,
+    /// `checking` | `savings` | … — enumerated by CHECK in both engines. The
+    /// app renames `checking` to `current` in its own mapper, not here.
+    #[serde(rename = "type")]
+    pub kind: String,
+    /// ISO 4217.
+    pub currency: String,
+    /// The ledger balance. B-1: `initial_balance + Σ(transactions.amount)`.
+    pub balance: Money,
+    /// What the account held before any transaction in this file.
+    pub initial_balance: Money,
+    /// The bank's own figure. COMPARED against, never added to.
+    pub bank_balance: Option<Money>,
+    /// `YYYY-MM-DD`: the day the bank's figure was true.
+    pub bank_balance_date: Option<String>,
+    /// `YYYY-MM-DD`: the last statement this account was reconciled against.
+    pub last_reconciled_date: Option<String>,
+    /// Does a low balance raise an alert?
+    pub low_balance_alert_enabled: bool,
+    /// The figure it raises one below.
+    pub low_balance_threshold: Option<Money>,
+    /// `YYYY-MM-DD`: the day `initial_balance` was true.
+    pub opening_balance_date: Option<String>,
+    /// `YYYY-MM-DD`: everything before this is archived out of the register.
+    pub archive_through_date: Option<String>,
+    /// The investment account this cash sleeve belongs to.
+    pub parent_account_id: Option<String>,
+    /// The bank, as shown.
+    pub institution: Option<String>,
+    /// Stored redacted for card types; the rule lives in the writer.
+    pub account_number: Option<String>,
+    /// Sterling sort code, when there is one.
+    pub sort_code: Option<String>,
+    /// Display only.
+    pub icon: Option<String>,
+    /// Display only.
+    pub color: Option<String>,
+    /// Free text.
+    pub notes: Option<String>,
+    /// Closed accounts stay in the file and out of the pickers.
+    pub is_active: bool,
+    /// Opaque labels. Money is banned from it by CHECK.
+    pub metadata: serde_json::Value,
+    /// When the row was made. The list's sort key.
+    pub created_at: String,
+    /// When it last changed. The app shows this as `lastUpdated`.
+    pub updated_at: String,
+}
+
+/// Every column [`ListedAccount`] carries, in its serialised order.
+const LISTED_COLUMNS: &str = "id, user_id, name, type, currency, balance_minor,
+        initial_balance_minor, bank_balance_minor, bank_balance_date,
+        last_reconciled_date, low_balance_alert_enabled, low_balance_threshold_minor,
+        opening_balance_date, archive_through_date, parent_account_id, institution,
+        account_number, sort_code, icon, color, notes, is_active, metadata,
+        created_at, updated_at";
+
+/// The accounts a login can put a transaction against.
+///
+/// The port of `accountService.getAccounts`: `.eq('user_id', …)`,
+/// `.eq('is_active', true)`, `.order('created_at', { ascending: true })`.
+///
+/// # Errors
+/// [`crate::error::CoreError`] if the read fails.
+pub fn list_open(connection: &Connection, user_id: &str) -> CoreResult<Vec<ListedAccount>> {
+    list_by_activity(connection, user_id, true)
+}
+
+/// The accounts that have been closed, and only those.
+///
+/// The port of `accountService.getClosedAccounts`, which is the same query with
+/// `.eq('is_active', false)`. Two functions rather than one flag, because the
+/// two VERBS are two verbs (PHASE3-PLAN §3: *"two verbs, not a boolean
+/// param — crate naming discipline"*) and a call site that reads
+/// `list_closed(…)` cannot be misread the way `list(…, false)` can.
+///
+/// # Errors
+/// [`crate::error::CoreError`] if the read fails.
+pub fn list_closed(connection: &Connection, user_id: &str) -> CoreResult<Vec<ListedAccount>> {
+    list_by_activity(connection, user_id, false)
+}
+
+/// The one query behind both, because the two differ by one bound value and a
+/// second copy of twenty-five columns is a second place to forget one.
+///
+/// `ORDER BY created_at, id` — the second key is this crate's own and is NOT a
+/// port of anything; [`crate::verbs::reads`] argues why every read here states
+/// one.
+fn list_by_activity(
+    connection: &Connection,
+    user_id: &str,
+    is_active: bool,
+) -> CoreResult<Vec<ListedAccount>> {
+    // EXPLAIN QUERY PLAN (measured against schema.sql):
+    //   SEARCH accounts USING INDEX idx_accounts_user (user_id=?)
+    //   USE TEMP B-TREE FOR ORDER BY
+    //
+    // The ONE thing interpolated into this statement is `LISTED_COLUMNS`, a
+    // crate constant. Both values a caller supplies are bound parameters. That
+    // distinction is DESIGN §6.4's whole point and it is worth spelling out
+    // here, because `format!` in the same expression as SQL is exactly what a
+    // reviewer should stop on.
+    let mut statement = connection.prepare(&format!(
+        "SELECT {LISTED_COLUMNS}
+           FROM accounts
+          WHERE user_id = ?1
+            AND is_active = ?2
+          ORDER BY created_at, id"
+    ))?;
+    let rows = statement.query_map(params![user_id, i64::from(is_active)], |record| {
+        let metadata_text: String = record.get(22)?;
+        Ok(ListedAccount {
+            id: record.get(0)?,
+            user_id: record.get(1)?,
+            name: record.get(2)?,
+            kind: record.get(3)?,
+            currency: record.get(4)?,
+            balance: Money::from_minor(record.get(5)?),
+            initial_balance: Money::from_minor(record.get(6)?),
+            bank_balance: record.get::<_, Option<i64>>(7)?.map(Money::from_minor),
+            bank_balance_date: record.get(8)?,
+            last_reconciled_date: record.get(9)?,
+            low_balance_alert_enabled: record.get::<_, i64>(10)? != 0,
+            low_balance_threshold: record.get::<_, Option<i64>>(11)?.map(Money::from_minor),
+            opening_balance_date: record.get(12)?,
+            archive_through_date: record.get(13)?,
+            parent_account_id: record.get(14)?,
+            institution: record.get(15)?,
+            account_number: record.get(16)?,
+            sort_code: record.get(17)?,
+            icon: record.get(18)?,
+            color: record.get(19)?,
+            notes: record.get(20)?,
+            is_active: record.get::<_, i64>(21)? != 0,
+            metadata: serde_json::from_str(&metadata_text).unwrap_or(serde_json::Value::Null),
+            created_at: record.get(23)?,
+            updated_at: record.get(24)?,
+        })
+    })?;
+
+    let mut accounts = Vec::new();
+    for account in rows {
+        accounts.push(account?);
+    }
+    Ok(accounts)
 }
 
 /// An account's name, for a refusal that has to say which account it means.

--- a/crates/wealth-core/src/row/budget.rs
+++ b/crates/wealth-core/src/row/budget.rs
@@ -27,12 +27,29 @@
 //! `spent_minor` and `rollover_amount_minor` are money and go through [`Money`];
 //! `schema.sql` records that both are `numeric(10,2)` in the cloud against
 //! `numeric(20,2)` here, which is a widening this crate does not narrow.
+//!
+//! # And a second projection, for the reader
+//!
+//! [`ListedBudget`] is the same eighteen columns with ONE difference, and the
+//! difference is the threshold:
+//!
+//! * the AUDIT entry keeps `alert_threshold_bp`, the stored integer, for the
+//!   reason two paragraphs up — an entry records what was stored, not a
+//!   rendering of it;
+//! * the READ hands over `alert_threshold`, `"80.00"`, because that is the
+//!   column the cloud has and the field the app reads, and because rendering it
+//!   on the far side would put a `/ 100` under `src/services/local/` — the one
+//!   shape R-7's grep exists to catch.
+//!
+//! Two projections of one row, then, differing in one field, and the field is
+//! the one nobody would think to check. That is why they are spelled out
+//! separately rather than one being derived from the other.
 
 use rusqlite::{params, Connection};
 use serde::Serialize;
 
 use crate::error::CoreResult;
-use crate::money::Money;
+use crate::money::{hundredths_to_decimal_string, Money};
 
 /// A budget as stored, in the serialised order.
 #[derive(Debug, Clone, Serialize)]
@@ -76,6 +93,104 @@ pub struct BudgetRow {
     pub created_at: String,
     /// When it last changed.
     pub updated_at: String,
+}
+
+/// A budget as the app lists it: the same row, with the threshold rendered.
+#[derive(Debug, Clone, Serialize)]
+pub struct ListedBudget {
+    /// Primary key.
+    pub id: String,
+    /// Owner.
+    pub user_id: String,
+    /// As shown.
+    pub name: String,
+    /// The limit.
+    pub amount: Money,
+    /// `weekly` | `monthly` | … — enumerated by CHECK in both engines.
+    pub period: String,
+    /// The category id the app actually files a budget against: TEXT, because
+    /// the default category ids were never uuids.
+    pub category: Option<String>,
+    /// The uuid twin, `ON DELETE SET NULL`.
+    pub category_id: Option<String>,
+    /// First day covered.
+    pub start_date: String,
+    /// Last day covered, when the budget ends.
+    pub end_date: Option<String>,
+    /// What has been spent against it.
+    pub spent: Money,
+    /// Does an unspent remainder carry forward?
+    pub rollover: bool,
+    /// How much did.
+    pub rollover_amount: Money,
+    /// Percent, as a two-place decimal string (`"80.00"`). NOT money — see the
+    /// module docs, and [`hundredths_to_decimal_string`].
+    pub alert_threshold: String,
+    /// Hidden budgets stay in the file and out of the reports — but they stay
+    /// in this list, or a paused budget could never be un-paused.
+    pub is_active: bool,
+    /// Free text.
+    pub notes: Option<String>,
+    /// Opaque labels. Money is banned from it by CHECK.
+    pub metadata: serde_json::Value,
+    /// When the row was made. The list's sort key.
+    pub created_at: String,
+    /// When it last changed.
+    pub updated_at: String,
+}
+
+/// Every budget this login has, oldest first.
+///
+/// The port of `planningService.getBudgets`: `.select('*')`,
+/// `.eq('user_id', …)`, `.order('created_at', { ascending: true })`. Its own
+/// comment carries the rule that is easiest to get wrong here — *"Inactive
+/// budgets load too: pausing a budget greys it out on the page … it must not
+/// make the budget vanish with no way to reactivate it"* — so there is no
+/// `is_active` filter, deliberately.
+///
+/// # Errors
+/// [`crate::error::CoreError`] if the read fails.
+pub fn list_all(connection: &Connection, user_id: &str) -> CoreResult<Vec<ListedBudget>> {
+    // EXPLAIN QUERY PLAN (measured against schema.sql):
+    //   SEARCH budgets USING INDEX idx_budgets_user (user_id=?)
+    //   USE TEMP B-TREE FOR ORDER BY
+    let mut statement = connection.prepare(
+        "SELECT id, user_id, name, amount_minor, period, category, category_id,
+                start_date, end_date, spent_minor, rollover, rollover_amount_minor,
+                alert_threshold_bp, is_active, notes, metadata, created_at, updated_at
+           FROM budgets
+          WHERE user_id = ?1
+          ORDER BY created_at, id",
+    )?;
+    let rows = statement.query_map(params![user_id], |record| {
+        let metadata_text: String = record.get(15)?;
+        Ok(ListedBudget {
+            id: record.get(0)?,
+            user_id: record.get(1)?,
+            name: record.get(2)?,
+            amount: Money::from_minor(record.get(3)?),
+            period: record.get(4)?,
+            category: record.get(5)?,
+            category_id: record.get(6)?,
+            start_date: record.get(7)?,
+            end_date: record.get(8)?,
+            spent: Money::from_minor(record.get(9)?),
+            rollover: record.get::<_, i64>(10)? != 0,
+            rollover_amount: Money::from_minor(record.get(11)?),
+            alert_threshold: hundredths_to_decimal_string(record.get(12)?),
+            is_active: record.get::<_, i64>(13)? != 0,
+            notes: record.get(14)?,
+            metadata: serde_json::from_str(&metadata_text).unwrap_or(serde_json::Value::Null),
+            created_at: record.get(16)?,
+            updated_at: record.get(17)?,
+        })
+    })?;
+
+    let mut budgets = Vec::new();
+    for budget in rows {
+        budgets.push(budget?);
+    }
+    Ok(budgets)
 }
 
 /// Read one budget, whole.

--- a/crates/wealth-core/src/row/category.rs
+++ b/crates/wealth-core/src/row/category.rs
@@ -186,6 +186,68 @@ pub fn read_owned(
         .optional()?)
 }
 
+/// Every category this login has, in the order the app reads them.
+///
+/// The port of `planningService.ensureCategories`' query, which is where a
+/// signed-in boot's category list actually comes from: `.eq('user_id', …)`,
+/// `.order('level')`, `.order('name')`. Three things about it are worth stating
+/// because none of them is a guess:
+///
+/// * **There is no `is_active` filter, and that is deliberate.** A hidden
+///   category still has to be in the list: it is what the register's category
+///   column resolves an old row's id through, and a closed account's To/From
+///   category is hidden by C-4 while its transactions stay exactly where they
+///   are. The pickers filter; the read does not.
+/// * **`level` sorts as TEXT**, so the order is `detail`, `sub`, `type` —
+///   alphabetical, not hierarchical. That is what PostgREST's `.order('level')`
+///   does on a text column and therefore what the app has always received; a
+///   port that "corrected" it to a hierarchy would be a different list.
+/// * **The one type serves both readers.** Unlike an account, a category's
+///   audit entry and its listed form want the same sixteen columns — the whole
+///   row — so there is one type here and not two. See [`CategoryRow`].
+///
+/// # Errors
+/// [`crate::error::CoreError`] if the read fails.
+pub fn list_all(connection: &Connection, user_id: &str) -> CoreResult<Vec<CategoryRow>> {
+    // EXPLAIN QUERY PLAN (measured against schema.sql):
+    //   SEARCH categories USING INDEX idx_categories_user (user_id=?)
+    //   USE TEMP B-TREE FOR ORDER BY
+    let mut statement = connection.prepare(
+        "SELECT id, user_id, name, type, level, parent_id, account_id, color, icon,
+                is_system, is_transfer_category, is_revaluation_category,
+                is_unassigned_bucket, is_active, created_at, updated_at
+           FROM categories
+          WHERE user_id = ?1
+          ORDER BY level, name, id",
+    )?;
+    let rows = statement.query_map(params![user_id], |record| {
+        Ok(CategoryRow {
+            id: record.get(0)?,
+            user_id: record.get(1)?,
+            name: record.get(2)?,
+            kind: record.get(3)?,
+            level: record.get(4)?,
+            parent_id: record.get(5)?,
+            account_id: record.get(6)?,
+            color: record.get(7)?,
+            icon: record.get(8)?,
+            is_system: record.get::<_, i64>(9)? != 0,
+            is_transfer_category: record.get::<_, i64>(10)? != 0,
+            is_revaluation_category: record.get::<_, i64>(11)? != 0,
+            is_unassigned_bucket: record.get::<_, i64>(12)? != 0,
+            is_active: record.get::<_, i64>(13)? != 0,
+            created_at: record.get(14)?,
+            updated_at: record.get(15)?,
+        })
+    })?;
+
+    let mut categories = Vec::new();
+    for category in rows {
+        categories.push(category?);
+    }
+    Ok(categories)
+}
+
 /// Does anything sit under this category?
 ///
 /// The port of `EXISTS (SELECT 1 FROM public.categories WHERE parent_id = …)`,

--- a/crates/wealth-core/src/row/dismissal.rs
+++ b/crates/wealth-core/src/row/dismissal.rs
@@ -1,0 +1,121 @@
+//! A suggestion the user has told the sweeps to stop offering.
+//!
+//! # The array that is a table here
+//!
+//! `subject_ids` is `uuid[]` in the cloud with a GIN index; locally it is the
+//! child table `suggestion_dismissal_subjects`, and `schema.sql` argues that
+//! the child table is the better shape (the prune trigger becomes an indexed
+//! join, and *"every id resolves in exactly one table"* becomes a foreign key
+//! rather than a promise). Neither of those is visible from outside, and it must
+//! stay that way: the app is handed an ARRAY, in the order the array was
+//! written, because `SuggestionDismissal.subjectIds` is an array and a reader
+//! that had to know about a child table would be a reader that knows about
+//! SQLite.
+//!
+//! `role_order` is what makes that reassembly honest. The positions in a
+//! dismissal's id list are ROLES — for a transfer pair, which row was the out
+//! and which the in — so a set with no order would be a different fact.
+//!
+//! # Five columns, because the cloud's own read names five
+//!
+//! `suggestionDismissalService.list` does not `select('*')`: it names
+//! `id, kind, subject_key, subject_ids, dismissed_at`, and `toDismissal` reads
+//! exactly those. So this projects those, and not `user_id` — the owner is what
+//! the caller asked WITH, and echoing it back would be one more field two
+//! engines have to agree about for no reader's benefit.
+//!
+//! # A gap this read found, named rather than papered over
+//!
+//! The cloud's `suggestion_dismissals_kind_known` CHECK admits seven kinds
+//! (`transfer-pair`, `transfer-leg`, `stranded`, `duplicate`, `payee-merchant`,
+//! `payee-line`, `payee-hidden`) and `scripts/local-sqlite/schema.sql` admits
+//! the first four — the three payee kinds arrived in the cloud after the local
+//! mirror was written. Nothing in THIS module is affected (a read returns what
+//! is stored, and a payee dismissal cannot be stored), but a restore of a cloud
+//! backup carrying one would be refused by the CHECK, whole, which is
+//! `restore_user_chunk`'s all-or-nothing rule doing exactly what it says.
+//! Recorded here because a read of a table is where the table's admissible
+//! values get looked up, and this is the note the next person needs.
+
+use rusqlite::{params, Connection};
+use serde::Serialize;
+
+use crate::error::CoreResult;
+
+/// A dismissal as the app lists it, with its subjects back in an array.
+#[derive(Debug, Clone, Serialize)]
+pub struct DismissalRow {
+    /// Primary key.
+    pub id: String,
+    /// `transfer-pair` | `transfer-leg` | `stranded` | `duplicate` — the four
+    /// this file admits. See the module docs about the cloud's seven.
+    pub kind: String,
+    /// What was refused, as the sweep names it. Unique per (owner, kind).
+    pub subject_key: String,
+    /// The rows the refusal was about, in role order.
+    pub subject_ids: Vec<String>,
+    /// When it was refused. The list's sort key, newest first.
+    pub dismissed_at: String,
+}
+
+/// Every dismissal this login has, newest first.
+///
+/// The port of `suggestionDismissalService.list`: the five named columns,
+/// `.eq('user_id', …)`, `.order('dismissed_at', { ascending: false })`.
+///
+/// # Errors
+/// [`crate::error::CoreError`] if the read fails.
+pub fn list_all(connection: &Connection, user_id: &str) -> CoreResult<Vec<DismissalRow>> {
+    // EXPLAIN QUERY PLAN (measured against schema.sql):
+    //   SEARCH suggestion_dismissals USING INDEX
+    //          sqlite_autoindex_suggestion_dismissals_2 (user_id=?)
+    //   USE TEMP B-TREE FOR ORDER BY
+    //
+    // That index is not one this file writes: it is the automatic index behind
+    // `suggestion_dismissals_unique_subject UNIQUE (user_id, kind, subject_key)`,
+    // whose leading column happens to be the one this read filters on. Worth
+    // knowing before anybody reorders that constraint's columns for tidiness —
+    // the day `user_id` stops leading it, this read becomes a full scan and
+    // nothing else in the schema will say so.
+    let mut statement = connection.prepare(
+        "SELECT id, kind, subject_key, dismissed_at
+           FROM suggestion_dismissals
+          WHERE user_id = ?1
+          ORDER BY dismissed_at DESC, id",
+    )?;
+    let rows = statement.query_map(params![user_id], |record| {
+        Ok(DismissalRow {
+            id: record.get(0)?,
+            kind: record.get(1)?,
+            subject_key: record.get(2)?,
+            subject_ids: Vec::new(),
+            dismissed_at: record.get(3)?,
+        })
+    })?;
+
+    let mut dismissals = Vec::new();
+    for dismissal in rows {
+        dismissals.push(dismissal?);
+    }
+
+    // The subjects, one prepared statement re-bound per dismissal — the shape
+    // `read_transaction` already uses for tags, and for the same reason: the
+    // child rows are a handful per parent and the alternative is a join whose
+    // result has to be un-flattened by hand.
+    //
+    // EXPLAIN QUERY PLAN:
+    //   SEARCH suggestion_dismissal_subjects USING PRIMARY KEY (dismissal_id=?)
+    let mut subjects = connection.prepare(
+        "SELECT transaction_id
+           FROM suggestion_dismissal_subjects
+          WHERE dismissal_id = ?1
+          ORDER BY role_order",
+    )?;
+    for dismissal in &mut dismissals {
+        let found = subjects.query_map(params![dismissal.id], |record| record.get::<_, String>(0))?;
+        for id in found {
+            dismissal.subject_ids.push(id?);
+        }
+    }
+    Ok(dismissals)
+}

--- a/crates/wealth-core/src/row/goal.rs
+++ b/crates/wealth-core/src/row/goal.rs
@@ -1,0 +1,136 @@
+//! A goal, as the app lists it.
+//!
+//! # The first entity here with no audit twin
+//!
+//! Every other module under [`crate::row`] arrived because a verb had to write
+//! an audit entry about that row. This one arrives because a verb has to
+//! ANSWER with it, and no verb audits a goal: nothing in the cloud schema
+//! writes `financial_audit_log` for one, `PlanningService` inserts, updates and
+//! deletes `goals` directly (`planningService.ts:558`, `:588`, `:614`), and the
+//! local edition ports the absence rather than inventing a log the cloud does
+//! not keep.
+//!
+//! So there is one type here and it is the whole row — which is also what
+//! `.select('*')` returns, which is what `goalFromDb` is written against.
+//!
+//! # The two fields that are not columns
+//!
+//! `goalFromDb` reads three of the app's `Goal` fields out of `metadata`
+//! (`type`, `linkedAccountIds`, `contributionAmount`) because they never got
+//! columns of their own, and it reads two more — `isActive` and `achieved` —
+//! out of `status`. Neither is this crate's business: the column is carried
+//! whole and the far side derives what it derives. A crate that unpacked
+//! `metadata.type` into a field of its own would be deciding what the app's
+//! goal *is*, which is DESIGN §6.3's other side of the line.
+//!
+//! `metadata` is `jsonb` in the cloud and TEXT-with-`json_valid` here, and money
+//! is banned from it by CHECK in both — which is why `contributionAmount`
+//! riding in it is a fact worth knowing and not one this module has to defend
+//! against: an amount that reached `metadata` would have been refused at the
+//! write.
+
+use rusqlite::{params, Connection};
+use serde::Serialize;
+
+use crate::error::CoreResult;
+use crate::money::Money;
+
+/// A goal as stored, in the serialised order.
+#[derive(Debug, Clone, Serialize)]
+pub struct GoalRow {
+    /// Primary key.
+    pub id: String,
+    /// Owner.
+    pub user_id: String,
+    /// As shown.
+    pub name: String,
+    /// Free text.
+    pub description: Option<String>,
+    /// What is being saved towards.
+    pub target_amount: Money,
+    /// What has been put by. The app calls this `progress` as well as
+    /// `currentAmount`; they are one figure and this is it.
+    pub current_amount: Money,
+    /// `YYYY-MM-DD`, when there is a date.
+    pub target_date: Option<String>,
+    /// A category id as text, when the goal is filed under one.
+    pub category: Option<String>,
+    /// `low` | `medium` | `high`.
+    pub priority: Option<String>,
+    /// `active` | `completed` | `paused` | `canceled`. The app's `isActive` and
+    /// `achieved` are both derived from this, on the far side.
+    pub status: String,
+    /// The account this goal counts.
+    pub account_id: Option<String>,
+    /// `daily` | `weekly` | … , when the goal contributes automatically.
+    pub contribution_frequency: Option<String>,
+    /// Does it?
+    pub auto_contribute: bool,
+    /// Display only.
+    pub icon: Option<String>,
+    /// Display only.
+    pub color: Option<String>,
+    /// When it was reached. Cleared if the goal is ever reopened.
+    pub completed_at: Option<String>,
+    /// Opaque labels, and the three app fields that never got columns. Money is
+    /// banned from it by CHECK.
+    pub metadata: serde_json::Value,
+    /// When the row was made. The list's sort key.
+    pub created_at: String,
+    /// When it last changed.
+    pub updated_at: String,
+}
+
+/// Every goal this login has, oldest first.
+///
+/// The port of `planningService.getGoals`: `.select('*')`, `.eq('user_id', …)`,
+/// `.order('created_at', { ascending: true })`. Like the budgets read, there is
+/// no `status` filter — a paused or completed goal stays in the list, or the
+/// page could not show a person what they have finished.
+///
+/// # Errors
+/// [`crate::error::CoreError`] if the read fails.
+pub fn list_all(connection: &Connection, user_id: &str) -> CoreResult<Vec<GoalRow>> {
+    // EXPLAIN QUERY PLAN (measured against schema.sql):
+    //   SEARCH goals USING INDEX idx_goals_user (user_id=?)
+    //   USE TEMP B-TREE FOR ORDER BY
+    let mut statement = connection.prepare(
+        "SELECT id, user_id, name, description, target_amount_minor, current_amount_minor,
+                target_date, category, priority, status, account_id,
+                contribution_frequency, auto_contribute, icon, color, completed_at,
+                metadata, created_at, updated_at
+           FROM goals
+          WHERE user_id = ?1
+          ORDER BY created_at, id",
+    )?;
+    let rows = statement.query_map(params![user_id], |record| {
+        let metadata_text: String = record.get(16)?;
+        Ok(GoalRow {
+            id: record.get(0)?,
+            user_id: record.get(1)?,
+            name: record.get(2)?,
+            description: record.get(3)?,
+            target_amount: Money::from_minor(record.get(4)?),
+            current_amount: Money::from_minor(record.get(5)?),
+            target_date: record.get(6)?,
+            category: record.get(7)?,
+            priority: record.get(8)?,
+            status: record.get(9)?,
+            account_id: record.get(10)?,
+            contribution_frequency: record.get(11)?,
+            auto_contribute: record.get::<_, i64>(12)? != 0,
+            icon: record.get(13)?,
+            color: record.get(14)?,
+            completed_at: record.get(15)?,
+            metadata: serde_json::from_str(&metadata_text).unwrap_or(serde_json::Value::Null),
+            created_at: record.get(17)?,
+            updated_at: record.get(18)?,
+        })
+    })?;
+
+    let mut goals = Vec::new();
+    for goal in rows {
+        goals.push(goal?);
+    }
+    Ok(goals)
+}

--- a/crates/wealth-core/src/verbs/mod.rs
+++ b/crates/wealth-core/src/verbs/mod.rs
@@ -329,6 +329,27 @@
 //! route to one goes through a crash mid-transaction that this harness has no
 //! way to stage.
 
+//! # And then the reads, which are verbs too
+//!
+//! [`reads`] holds the first six: the accounts, the closed accounts, the
+//! categories, the budgets, the goals and the suggestion dismissals. None of
+//! them is a port of a Postgres FUNCTION — the cloud reads these tables over
+//! PostgREST — so what each one ports is a *query*, `.eq()` for `.eq()` and
+//! `.order()` for `.order()`, and its oracle in the differential harness is
+//! that query written out.
+//!
+//! They are in this crate rather than beside it because of what leaves with
+//! them: money, as the decimal string [`crate::money`] renders once. The whole
+//! argument is PHASE3-PLAN D-4 and it is restated at the head of [`reads`],
+//! along with the ordering contracts, the tie-break this crate states for
+//! itself, and the EXPLAIN QUERY PLAN line each read was measured against.
+//!
+//! That module is `pub` where every other verb module here is private, and the
+//! reason is those docs: a private module's documentation is not rendered, and
+//! the plan requires the plans to be readable — *"a plan saying SCAN is a bug
+//! report, not a merge"* is not a rule anybody can apply to a table they cannot
+//! see.
+
 mod apply_category_to_uncategorized;
 mod clear_transfer_links;
 mod confirm_transaction_categories;
@@ -343,6 +364,7 @@ mod link_bank_account_snap;
 mod link_split_line_transfer;
 mod link_transfer_pair;
 mod merge_categories;
+pub mod reads;
 mod repair_claimed_transfer;
 mod restore_user_chunk;
 mod set_transaction_splits_with_legs;
@@ -392,6 +414,14 @@ pub use link_split_line_transfer::{
 };
 pub use link_transfer_pair::{link_transfer_pair, LinkTransferPair, LinkTransferPairResult};
 pub use merge_categories::{merge_categories, MergeCategories, MergeCategoriesResult};
+// The read family. Re-exported like every other verb so a call site reads the
+// same whether it is asking or writing; the module stays `pub` as well, because
+// its documentation is where the ordering and the query plans live.
+pub use reads::{
+    list_accounts, list_budgets, list_categories, list_closed_accounts, list_goals,
+    list_suggestion_dismissals, Accounts, Answered, Budgets, Categories, ClosedAccounts, Goals,
+    OwnedRead, SuggestionDismissals,
+};
 pub use repair_claimed_transfer::{
     repair_claimed_transfer, RepairClaimedTransfer, RepairClaimedTransferResult,
 };

--- a/crates/wealth-core/src/verbs/reads.rs
+++ b/crates/wealth-core/src/verbs/reads.rs
@@ -1,0 +1,273 @@
+//! The reads — the questions the app asks a file it has already opened.
+//!
+//! Six of them here: the accounts, the closed accounts, the categories, the
+//! budgets, the goals and the suggestion dismissals. They write nothing, they
+//! audit nothing, and they open no transaction, for the reason
+//! [`super::user_financial_data_is_empty`] gives: there is nothing to be atomic
+//! about, and a log line recording that somebody asked a question is noise in a
+//! log whose whole value is that every line in it is a change.
+//!
+//! # Why a read is a verb here at all
+//!
+//! PHASE3-PLAN D-4 decides it, and the decisive reason is money. `money.rs`'s
+//! [`crate::money::Money::to_decimal_string`] is the ONE place minor units
+//! become the text the app parses. A read implemented anywhere else — a query
+//! layer beside the command surface, a `SELECT` in the shell — is a second
+//! implementation of that conversion, and *"a second layer's `minor as f64 /
+//! 100.0` is one careless line in the numbers on screen"*. Three lesser reasons
+//! stand behind it: the row mappers already exist ([`crate::row`]), `db::open`'s
+//! read-back assertions would have a second opener to be forgotten by, and a
+//! query layer has no differential oracle — `scripts/local-sqlite/verbs.mjs`
+//! drives THIS surface and nothing else.
+//!
+//! # Every read is scoped to one owner, and the owner is REQUIRED
+//!
+//! The write verbs take `user_id` as an `Option`, because the RPCs they port
+//! spell their guard `p_user_id IS NULL OR user_id = p_user_id` and a NULL
+//! stands it down. A read has no such shape to port: every cloud read is
+//! `.eq('user_id', userId)` with an id `DataService` resolved on the same tick
+//! and refuses to proceed without.
+//!
+//! Locally the difference matters more, not less. There is no RLS to narrow the
+//! answer afterwards, and a file CAN hold more than one login's rows — a backup
+//! restored from an account that had two, or the harness's own second user. A
+//! read with the owner left off would answer with all of them. So it is a
+//! `String` and not an `Option<String>`, and the refusal for leaving it out is
+//! serde's, before a connection is touched.
+//!
+//! # None of them takes a filter
+//!
+//! `dataPort.ts` states it: *"None of them take a filter: the app loads its
+//! ledger and does its own filtering in memory, and pretending otherwise here
+//! would invent a query language that no implementation actually has."* That is
+//! also §6.4's absence from the other side — a verb that took a predicate would
+//! be a verb that took SQL eventually.
+//!
+//! The one thing that looks like a filter and is not: closed accounts are a
+//! SECOND VERB rather than a flag on the first. Two questions, two names, and a
+//! call site that cannot be misread.
+//!
+//! # The order is part of the answer, and the last key is this crate's own
+//!
+//! Each read takes its ORDER BY from the query it is a port of:
+//!
+//! ```text
+//! list_accounts               created_at            accountService.getAccounts
+//! list_closed_accounts        created_at            accountService.getClosedAccounts
+//! list_categories             level, name           planningService.ensureCategories
+//! list_budgets                created_at            planningService.getBudgets
+//! list_goals                  created_at            planningService.getGoals
+//! list_suggestion_dismissals  dismissed_at DESC     suggestionDismissalService.list
+//! ```
+//!
+//! and then adds `id` behind it, which **is not a port of anything**. The cloud
+//! states no tie-break, so its answer below its last key is an artefact of a
+//! query plan — the same thing `apply_category_to_uncategorized`'s payee-memory
+//! ordering found, and the same answer: state one, and say out loud that it is
+//! stated rather than ported.
+//!
+//! It is stated because a list that is drawn is a list that gets re-drawn. Two
+//! accounts created in the same second are ordered by nothing at all otherwise,
+//! and "nothing at all" in SQLite means whatever the sorter did last time —
+//! which is a visible reshuffle on a page nobody touched, and an unrepeatable
+//! differential spec.
+//!
+//! # EXPLAIN QUERY PLAN, measured against `scripts/local-sqlite/schema.sql`
+//!
+//! ```text
+//! list_accounts              SEARCH accounts USING INDEX idx_accounts_user (user_id=?)
+//! list_closed_accounts       SEARCH accounts USING INDEX idx_accounts_user (user_id=?)
+//! list_categories            SEARCH categories USING INDEX idx_categories_user (user_id=?)
+//! list_budgets               SEARCH budgets USING INDEX idx_budgets_user (user_id=?)
+//! list_goals                 SEARCH goals USING INDEX idx_goals_user (user_id=?)
+//! list_suggestion_dismissals SEARCH suggestion_dismissals USING INDEX
+//!                                   sqlite_autoindex_suggestion_dismissals_2 (user_id=?)
+//!   its subjects             SEARCH suggestion_dismissal_subjects USING PRIMARY KEY
+//!                                   (dismissal_id=?)
+//! ```
+//!
+//! Every one is a SEARCH. DESIGN §4's rule is that a plan saying SCAN is a bug
+//! report rather than a merge, and the measurement behind it is 106ms unindexed
+//! against 3.46ms indexed on the transactions table — *"index design carries
+//! ~640× the leverage of transport design"*.
+//!
+//! **Each of the six also reports `USE TEMP B-TREE FOR ORDER BY`, and that is
+//! accepted rather than overlooked.** The sort happens after the index has cut
+//! the table down to one owner's rows, and on these five tables that is tens to
+//! low hundreds — a person has a dozen accounts, a few hundred categories, a
+//! handful of budgets and goals. Adding `(user_id, created_at, id)` covering
+//! indexes to remove it would trade write cost and four more indexes to keep in
+//! step with the cloud for a sort of fifty rows. What would change the answer:
+//! a read over `transactions` or `transaction_splits`, where the row counts are
+//! five orders of magnitude larger — which is why `idx_txn_balance_cover`
+//! exists and why slice 16's reads must be measured again rather than assumed
+//! to be like these.
+//!
+//! # What is deliberately not here yet
+//!
+//! `list_transactions`, `list_transaction_splits`, `splits_for` and
+//! `account_balances` are the next slice's, and they are separated from these
+//! six by more than a queue: they are the reads whose plans have to be argued,
+//! and `account_balances` carries four properties that are each a named money
+//! bug if got wrong (PHASE3-PLAN §3). `load_boot` composes six reads into one
+//! transaction after that, and `collect_backup` is the backup group's.
+
+use rusqlite::Connection;
+use serde::{Deserialize, Serialize};
+
+use crate::error::CoreResult;
+use crate::row::account::{self, ListedAccount};
+use crate::row::budget::{self, ListedBudget};
+use crate::row::category::{self, CategoryRow};
+use crate::row::dismissal::{self, DismissalRow};
+use crate::row::goal::{self, GoalRow};
+
+/// The payload every read in this slice takes: one owner, and nothing else.
+///
+/// One type for six verbs because it is one argument for six verbs, and six
+/// identical struct definitions would be six places for the next person to add
+/// a filter to. The VERBS stay six — the enum's exhaustive dispatch is over
+/// variants, not over payload types.
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct OwnedRead {
+    /// Whose rows. Required — see the module docs.
+    pub user_id: String,
+}
+
+/// A read's answer, in the shape the differential harness compares on.
+///
+/// `answer` rather than the bare list, because `lib/verb-sqlite.mjs` reads
+/// `result.transaction ?? result.answer` and a verb decides what it is
+/// comparable ON. The named field inside it (`accounts`, `categories`, …) is
+/// what makes a spec's expectation readable as the question it answers.
+#[derive(Debug, Serialize)]
+pub struct Answered<T: Serialize> {
+    /// The projection both engines are compared on.
+    pub answer: T,
+}
+
+/// The accounts a login can file a transaction against.
+#[derive(Debug, Serialize)]
+pub struct Accounts {
+    /// Open accounts, oldest first.
+    pub accounts: Vec<ListedAccount>,
+}
+
+/// The accounts a login has closed.
+#[derive(Debug, Serialize)]
+pub struct ClosedAccounts {
+    /// Closed accounts, oldest first.
+    pub closed_accounts: Vec<ListedAccount>,
+}
+
+/// The names rows are filed under.
+#[derive(Debug, Serialize)]
+pub struct Categories {
+    /// Every category, by level then name.
+    pub categories: Vec<CategoryRow>,
+}
+
+/// The limits a login has set.
+#[derive(Debug, Serialize)]
+pub struct Budgets {
+    /// Every budget, oldest first, paused ones included.
+    pub budgets: Vec<ListedBudget>,
+}
+
+/// What a login is saving towards.
+#[derive(Debug, Serialize)]
+pub struct Goals {
+    /// Every goal, oldest first, finished ones included.
+    pub goals: Vec<GoalRow>,
+}
+
+/// What a login has told the sweeps to stop offering.
+#[derive(Debug, Serialize)]
+pub struct SuggestionDismissals {
+    /// Every dismissal, newest first, each with its subjects in role order.
+    pub suggestion_dismissals: Vec<DismissalRow>,
+}
+
+/// Every open account this login has.
+///
+/// # Errors
+/// [`crate::error::CoreError::Storage`] if the read fails. This verb has no
+/// refusal: an owner with no accounts has an empty list, which is an answer.
+#[allow(clippy::needless_pass_by_value)]
+pub fn list_accounts(
+    connection: &Connection,
+    command: OwnedRead,
+) -> CoreResult<Answered<Accounts>> {
+    Ok(Answered {
+        answer: Accounts { accounts: account::list_open(connection, &command.user_id)? },
+    })
+}
+
+/// Every closed account this login has.
+///
+/// # Errors
+/// [`crate::error::CoreError::Storage`] if the read fails.
+#[allow(clippy::needless_pass_by_value)]
+pub fn list_closed_accounts(
+    connection: &Connection,
+    command: OwnedRead,
+) -> CoreResult<Answered<ClosedAccounts>> {
+    Ok(Answered {
+        answer: ClosedAccounts {
+            closed_accounts: account::list_closed(connection, &command.user_id)?,
+        },
+    })
+}
+
+/// Every category this login has, hidden ones included.
+///
+/// # Errors
+/// [`crate::error::CoreError::Storage`] if the read fails.
+#[allow(clippy::needless_pass_by_value)]
+pub fn list_categories(
+    connection: &Connection,
+    command: OwnedRead,
+) -> CoreResult<Answered<Categories>> {
+    Ok(Answered {
+        answer: Categories { categories: category::list_all(connection, &command.user_id)? },
+    })
+}
+
+/// Every budget this login has, paused ones included.
+///
+/// # Errors
+/// [`crate::error::CoreError::Storage`] if the read fails.
+#[allow(clippy::needless_pass_by_value)]
+pub fn list_budgets(connection: &Connection, command: OwnedRead) -> CoreResult<Answered<Budgets>> {
+    Ok(Answered {
+        answer: Budgets { budgets: budget::list_all(connection, &command.user_id)? },
+    })
+}
+
+/// Every goal this login has, finished ones included.
+///
+/// # Errors
+/// [`crate::error::CoreError::Storage`] if the read fails.
+#[allow(clippy::needless_pass_by_value)]
+pub fn list_goals(connection: &Connection, command: OwnedRead) -> CoreResult<Answered<Goals>> {
+    Ok(Answered {
+        answer: Goals { goals: goal::list_all(connection, &command.user_id)? },
+    })
+}
+
+/// Every suggestion this login has refused.
+///
+/// # Errors
+/// [`crate::error::CoreError::Storage`] if the read fails.
+#[allow(clippy::needless_pass_by_value)]
+pub fn list_suggestion_dismissals(
+    connection: &Connection,
+    command: OwnedRead,
+) -> CoreResult<Answered<SuggestionDismissals>> {
+    Ok(Answered {
+        answer: SuggestionDismissals {
+            suggestion_dismissals: dismissal::list_all(connection, &command.user_id)?,
+        },
+    })
+}

--- a/crates/wealth-core/tests/reads.rs
+++ b/crates/wealth-core/tests/reads.rs
@@ -1,0 +1,375 @@
+//! Integration tests for the six read verbs.
+//!
+//! The differential proof lives in `scripts/local-sqlite/verbs.mjs`: seventeen
+//! specs, each running one payload against the query the cloud actually issues
+//! and against this crate, and comparing the two answers element by element.
+//! What is here is the half with **no cloud counterpart to compare against**:
+//!
+//! 1. **The tie-break.** Every read orders by the cloud's key and then by `id`,
+//!    and the second key is this crate's own — the cloud states none, so its
+//!    answer under a tie is an artefact of a query plan and there is nothing to
+//!    be differential about. It still has to be true, because a list that is
+//!    drawn is a list that gets re-drawn.
+//! 2. **A file holding two logins.** The cloud has RLS; a local file has
+//!    nothing but the owner in the payload, and a restore can genuinely leave a
+//!    second login's rows in one. The reads must not see them.
+//! 3. **The refusals that happen before a connection is touched** — an unknown
+//!    field, and a missing owner. Both are serde's, and both are the reason the
+//!    owner is a `String` rather than an `Option<String>` here.
+//! 4. **An empty file**, on all six verbs at once, which is a shape assertion:
+//!    `[]` and not `null`, under the key the app reads.
+//!
+//! All data is invented. This repo is public: no real payee, account number or
+//! figure appears anywhere in it.
+
+#![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
+
+use rusqlite::Connection;
+use wealth_core::command::{parse, Command};
+use wealth_core::db;
+use wealth_core::verbs::{
+    list_accounts, list_budgets, list_categories, list_closed_accounts, list_goals,
+    list_suggestion_dismissals, OwnedRead,
+};
+
+const OWNER: &str = "11111111-1111-1111-1111-111111111111";
+const STRANGER: &str = "22222222-2222-2222-2222-222222222222";
+const TRANSFER_ROOT: &str = "c0000000-0000-0000-0000-000000000001";
+const EVERYDAY: &str = "a0000000-0000-0000-0000-000000000001";
+const RAINY_DAY: &str = "a0000000-0000-0000-0000-000000000002";
+const CORNER_SHOP: &str = "70000000-0000-0000-0000-000000000001";
+const SAME_INSTANT: &str = "2024-01-01T00:00:00.000Z";
+
+fn owner(user_id: &str) -> OwnedRead {
+    OwnedRead { user_id: user_id.to_owned() }
+}
+
+/// An empty file with one login in it, and the Transfer root C-3's trigger
+/// looks for.
+fn fixture() -> Connection {
+    let connection = db::open_in_memory().expect("open");
+    wealth_core::apply_schema(&connection).expect("schema");
+    connection
+        .execute_batch(&format!(
+            "INSERT INTO users (id, email) VALUES ('{OWNER}', 'harness@example.test');
+             INSERT INTO categories (id, user_id, name, type, level)
+               VALUES ('{TRANSFER_ROOT}', '{OWNER}', 'Transfer', 'both', 'type');"
+        ))
+        .expect("fixture");
+    connection
+}
+
+/// A second login, with one of everything, all of it created at the same
+/// instant as this login's so a read that ignored the owner would interleave.
+fn a_stranger_with_everything(connection: &Connection) {
+    connection
+        .execute_batch(&format!(
+            "INSERT INTO users (id, email) VALUES ('{STRANGER}', 'stranger@example.test');
+             INSERT INTO accounts (id, user_id, name, type, created_at, updated_at)
+               VALUES ('a0000000-0000-0000-0000-0000000000f9', '{STRANGER}', 'Not yours',
+                       'checking', '{SAME_INSTANT}', '{SAME_INSTANT}');
+             INSERT INTO categories (id, user_id, name, type, level, created_at, updated_at)
+               VALUES ('c0000000-0000-0000-0000-0000000000f9', '{STRANGER}', 'Not yours',
+                       'expense', 'detail', '{SAME_INSTANT}', '{SAME_INSTANT}');
+             INSERT INTO budgets (id, user_id, name, amount_minor, period, start_date,
+                                  created_at, updated_at)
+               VALUES ('b0000000-0000-0000-0000-0000000000f9', '{STRANGER}', 'Not yours', 100,
+                       'monthly', '2024-01-01', '{SAME_INSTANT}', '{SAME_INSTANT}');
+             INSERT INTO goals (id, user_id, name, target_amount_minor, created_at, updated_at)
+               VALUES ('90000000-0000-0000-0000-0000000000f9', '{STRANGER}', 'Not yours', 100,
+                       '{SAME_INSTANT}', '{SAME_INSTANT}');
+             INSERT INTO suggestion_dismissals (id, user_id, kind, subject_key, dismissed_at)
+               VALUES ('d0000000-0000-0000-0000-0000000000f9', '{STRANGER}', 'duplicate',
+                       'theirs', '{SAME_INSTANT}');"
+        ))
+        .expect("stranger");
+}
+
+/// Two accounts of this login's, opened in the same recorded instant.
+fn two_accounts_at_one_instant(connection: &Connection) {
+    connection
+        .execute_batch(&format!(
+            "INSERT INTO accounts (id, user_id, name, type, created_at, updated_at) VALUES
+               ('{RAINY_DAY}', '{OWNER}', 'Rainy day', 'savings', '{SAME_INSTANT}', '{SAME_INSTANT}'),
+               ('{EVERYDAY}',  '{OWNER}', 'Everyday', 'checking', '{SAME_INSTANT}', '{SAME_INSTANT}');"
+        ))
+        .expect("accounts");
+}
+
+// ── The tie-break ───────────────────────────────────────────────────────────
+
+#[test]
+fn two_accounts_opened_in_the_same_instant_come_back_in_id_order() {
+    let connection = fixture();
+    two_accounts_at_one_instant(&connection);
+
+    let answered = list_accounts(&connection, owner(OWNER)).expect("read");
+    let ids: Vec<&str> = answered.answer.accounts.iter().map(|a| a.id.as_str()).collect();
+
+    // Inserted Rainy day first and Everyday second; `created_at` cannot separate
+    // them, so the answer is by id — which is Everyday's, ending 0001.
+    assert_eq!(ids, vec![EVERYDAY, RAINY_DAY]);
+}
+
+#[test]
+fn the_same_file_read_twice_answers_in_the_same_order() {
+    let connection = fixture();
+    two_accounts_at_one_instant(&connection);
+
+    let first = list_accounts(&connection, owner(OWNER)).expect("read");
+    let again = list_accounts(&connection, owner(OWNER)).expect("read");
+    let ids = |answered: &wealth_core::verbs::Answered<wealth_core::verbs::Accounts>| {
+        answered.answer.accounts.iter().map(|a| a.id.clone()).collect::<Vec<_>>()
+    };
+
+    // The property the tie-break exists for: a list that is drawn is a list that
+    // gets re-drawn, and two accounts created in one second must not swap places
+    // between renders.
+    assert_eq!(ids(&first), ids(&again));
+}
+
+#[test]
+fn two_categories_at_one_level_with_one_name_are_still_ordered() {
+    let connection = fixture();
+    // `ux_categories_user_name_parent` makes two identical names impossible
+    // under one parent, so the tie is reached the only way it can be: same
+    // level, same name, different parents.
+    connection
+        .execute_batch(&format!(
+            "INSERT INTO categories (id, user_id, name, type, level) VALUES
+               ('c0000000-0000-0000-0000-0000000000b2', '{OWNER}', 'Bills', 'expense', 'type');
+             INSERT INTO categories (id, user_id, name, type, level, parent_id) VALUES
+               ('c0000000-0000-0000-0000-0000000000d2', '{OWNER}', 'Water', 'expense', 'detail',
+                'c0000000-0000-0000-0000-0000000000b2'),
+               ('c0000000-0000-0000-0000-0000000000d1', '{OWNER}', 'Water', 'expense', 'detail',
+                '{TRANSFER_ROOT}');"
+        ))
+        .expect("categories");
+
+    let answered = list_categories(&connection, owner(OWNER)).expect("read");
+    let waters: Vec<&str> = answered
+        .answer
+        .categories
+        .iter()
+        .filter(|c| c.name == "Water")
+        .map(|c| c.id.as_str())
+        .collect();
+
+    assert_eq!(
+        waters,
+        vec![
+            "c0000000-0000-0000-0000-0000000000d1",
+            "c0000000-0000-0000-0000-0000000000d2"
+        ]
+    );
+}
+
+// ── A file holding two logins ───────────────────────────────────────────────
+
+#[test]
+fn a_second_logins_rows_are_in_the_file_and_not_in_the_answer() {
+    let connection = fixture();
+    a_stranger_with_everything(&connection);
+
+    // Every one of these is empty, and every one of them would be non-empty if
+    // the owner were left off the WHERE clause. There is no RLS in a file.
+    assert!(list_accounts(&connection, owner(OWNER)).expect("read").answer.accounts.is_empty());
+    assert!(list_budgets(&connection, owner(OWNER)).expect("read").answer.budgets.is_empty());
+    assert!(list_goals(&connection, owner(OWNER)).expect("read").answer.goals.is_empty());
+    assert!(list_suggestion_dismissals(&connection, owner(OWNER))
+        .expect("read")
+        .answer
+        .suggestion_dismissals
+        .is_empty());
+
+    // Categories are the one table this fixture starts non-empty (C-3's trigger
+    // needs the Transfer root), so the assertion is that the stranger's is not
+    // among them rather than that there are none.
+    let categories = list_categories(&connection, owner(OWNER)).expect("read");
+    let owners: Vec<&str> = categories.answer.categories.iter().map(|c| c.user_id.as_str()).collect();
+    assert_eq!(owners, vec![OWNER]);
+}
+
+#[test]
+fn the_strangers_own_read_answers_with_the_strangers_rows() {
+    let connection = fixture();
+    a_stranger_with_everything(&connection);
+
+    // The other half of the same property: scoping is a filter, not a refusal,
+    // and a file with two logins in it answers each of them correctly.
+    let accounts = list_accounts(&connection, owner(STRANGER)).expect("read");
+    assert_eq!(accounts.answer.accounts.len(), 1);
+    assert_eq!(accounts.answer.accounts[0].name, "Not yours");
+}
+
+// ── An empty file ───────────────────────────────────────────────────────────
+
+#[test]
+fn a_file_with_nothing_in_it_answers_with_empty_lists() {
+    let connection = fixture();
+    connection
+        .execute_batch(&format!("DELETE FROM categories WHERE user_id = '{OWNER}';"))
+        .expect("empty");
+
+    assert!(list_accounts(&connection, owner(OWNER)).expect("read").answer.accounts.is_empty());
+    assert!(list_closed_accounts(&connection, owner(OWNER))
+        .expect("read")
+        .answer
+        .closed_accounts
+        .is_empty());
+    assert!(list_categories(&connection, owner(OWNER)).expect("read").answer.categories.is_empty());
+    assert!(list_budgets(&connection, owner(OWNER)).expect("read").answer.budgets.is_empty());
+    assert!(list_goals(&connection, owner(OWNER)).expect("read").answer.goals.is_empty());
+    assert!(list_suggestion_dismissals(&connection, owner(OWNER))
+        .expect("read")
+        .answer
+        .suggestion_dismissals
+        .is_empty());
+}
+
+#[test]
+fn an_empty_answer_serialises_as_an_empty_array_under_its_own_key() {
+    let connection = fixture();
+    let answered = list_budgets(&connection, owner(OWNER)).expect("read");
+
+    // The shape matters as much as the emptiness: the far side maps
+    // `answer.budgets`, and `null` there is a different bug from `[]` — one is
+    // "no budgets" and the other is "this read does not work".
+    assert_eq!(
+        serde_json::to_string(&answered).expect("json"),
+        r#"{"answer":{"budgets":[]}}"#
+    );
+}
+
+// ── The refusals that never reach a connection ──────────────────────────────
+
+#[test]
+fn a_read_with_no_owner_is_refused_before_a_file_is_opened() {
+    // The reads take a `String`, not an `Option<String>`: a read with the owner
+    // left off would answer with every login in the file, and locally there is
+    // no RLS behind it to narrow the answer afterwards.
+    let refusal = parse(r#"{"verb":"list_accounts","payload":{}}"#).expect_err("refused");
+    let json = serde_json::to_string(&refusal).expect("json");
+    assert!(json.contains("missing field"), "{json}");
+    assert!(json.contains("user_id"), "{json}");
+}
+
+#[test]
+fn a_read_carrying_a_filter_is_refused_by_name() {
+    // `deny_unknown_fields` is what makes "none of them takes a filter" a fact
+    // about the code rather than a claim about it: the day somebody sends
+    // `{"is_active": true}`, they are told, rather than quietly served
+    // everything.
+    let refusal =
+        parse(r#"{"verb":"list_accounts","payload":{"user_id":"x","is_active":true}}"#)
+            .expect_err("refused");
+    let json = serde_json::to_string(&refusal).expect("json");
+    assert!(json.contains("unknown_field"), "{json}");
+    assert!(json.contains("is_active"), "{json}");
+}
+
+#[test]
+fn every_read_in_this_slice_parses_to_its_own_variant() {
+    // Six verb strings, six variants. The dispatch's exhaustiveness is the
+    // compiler's business; what the compiler cannot check is that the STRINGS
+    // are the ones the port will send.
+    let parsed = |verb: &str| {
+        parse(&format!(r#"{{"verb":"{verb}","payload":{{"user_id":"{OWNER}"}}}}"#)).expect(verb)
+    };
+    assert!(matches!(parsed("list_accounts"), Command::ListAccounts(_)));
+    assert!(matches!(parsed("list_closed_accounts"), Command::ListClosedAccounts(_)));
+    assert!(matches!(parsed("list_categories"), Command::ListCategories(_)));
+    assert!(matches!(parsed("list_budgets"), Command::ListBudgets(_)));
+    assert!(matches!(parsed("list_goals"), Command::ListGoals(_)));
+    assert!(matches!(
+        parsed("list_suggestion_dismissals"),
+        Command::ListSuggestionDismissals(_)
+    ));
+}
+
+// ── The two shapes SQLite spells differently from the cloud ─────────────────
+
+#[test]
+fn a_dismissals_subjects_come_back_in_role_order_not_insertion_order() {
+    let connection = fixture();
+    connection
+        .execute_batch(&format!(
+            "INSERT INTO accounts (id, user_id, name, type) VALUES
+               ('{EVERYDAY}', '{OWNER}', 'Everyday', 'checking');
+             INSERT INTO transactions (id, user_id, account_id, description, amount_minor,
+                                       type, date) VALUES
+               ('{CORNER_SHOP}', '{OWNER}', '{EVERYDAY}', 'Corner shop', 0, 'expense', '2024-03-01'),
+               ('70000000-0000-0000-0000-000000000002', '{OWNER}', '{EVERYDAY}', 'Other', 0,
+                'expense', '2024-03-02'),
+               ('70000000-0000-0000-0000-000000000003', '{OWNER}', '{EVERYDAY}', 'Third', 0,
+                'expense', '2024-03-03');
+             INSERT INTO suggestion_dismissals (id, user_id, kind, subject_key, dismissed_at)
+               VALUES ('d0000000-0000-0000-0000-0000000000d1', '{OWNER}', 'transfer-pair',
+                       'a|b', '{SAME_INSTANT}');
+             -- Two things are deliberately wrong with this order, because a
+             -- fixture that got either right would pass on a port that read the
+             -- child table as a set: the rows are WRITTEN middle, last, first,
+             -- and the roles run OPPOSITE to the ids. An earlier version of this
+             -- test had roles ascending with ids, and a mutation that ordered by
+             -- transaction_id passed it.
+             INSERT INTO suggestion_dismissal_subjects (dismissal_id, transaction_id, role_order)
+               VALUES ('d0000000-0000-0000-0000-0000000000d1',
+                       '70000000-0000-0000-0000-000000000002', 1),
+                      ('d0000000-0000-0000-0000-0000000000d1', '{CORNER_SHOP}', 2),
+                      ('d0000000-0000-0000-0000-0000000000d1',
+                       '70000000-0000-0000-0000-000000000003', 0);"
+        ))
+        .expect("dismissal");
+
+    let answered = list_suggestion_dismissals(&connection, owner(OWNER)).expect("read");
+    assert_eq!(
+        answered.answer.suggestion_dismissals[0].subject_ids,
+        vec![
+            "70000000-0000-0000-0000-000000000003".to_owned(),
+            "70000000-0000-0000-0000-000000000002".to_owned(),
+            CORNER_SHOP.to_owned(),
+        ],
+    );
+}
+
+#[test]
+fn a_dismissal_with_no_subjects_carries_an_empty_array_not_a_null() {
+    let connection = fixture();
+    connection
+        .execute_batch(&format!(
+            "INSERT INTO suggestion_dismissals (id, user_id, kind, subject_key, dismissed_at)
+               VALUES ('d0000000-0000-0000-0000-0000000000d1', '{OWNER}', 'stranded',
+                       'nothing', '{SAME_INSTANT}');"
+        ))
+        .expect("dismissal");
+
+    let answered = list_suggestion_dismissals(&connection, owner(OWNER)).expect("read");
+    let json = serde_json::to_string(&answered.answer.suggestion_dismissals[0]).expect("json");
+    // The cloud's column is `uuid[] NOT NULL DEFAULT '{}'`, so an empty list is
+    // what a reader gets there; a child table with no rows must say the same.
+    assert!(json.contains(r#""subject_ids":[]"#), "{json}");
+}
+
+#[test]
+fn the_threshold_crosses_as_a_percentage_and_the_money_beside_it_as_money() {
+    let connection = fixture();
+    connection
+        .execute_batch(&format!(
+            "INSERT INTO budgets (id, user_id, name, amount_minor, period, start_date,
+                                  spent_minor, alert_threshold_bp)
+               VALUES ('b0000000-0000-0000-0000-000000000001', '{OWNER}', 'Food', 12345,
+                       'monthly', '2024-01-01', 6789, 4250);"
+        ))
+        .expect("budget");
+
+    let answered = list_budgets(&connection, owner(OWNER)).expect("read");
+    let budget = &answered.answer.budgets[0];
+
+    // 4250 basis points of a percent is 42.50%, which is what `numeric(5,2)`
+    // holds in the cloud and casts to. The rendering is money.rs's, and the two
+    // beside it are money — proving that one integer scale did not leak into
+    // the other.
+    assert_eq!(budget.alert_threshold, "42.50");
+    assert_eq!(budget.amount.to_decimal_string(), "123.45");
+    assert_eq!(budget.spent.to_decimal_string(), "67.89");
+}

--- a/scripts/local-sqlite/lib/verb-postgres.mjs
+++ b/scripts/local-sqlite/lib/verb-postgres.mjs
@@ -59,6 +59,178 @@ const ROW_JSON = `jsonb_build_object(
   'tags', COALESCE(to_jsonb(t.tags), '[]'::jsonb)
 )`;
 
+// ── The reads, whose oracle is a QUERY and not a function ────────────────────
+//
+// Every other verb in this file names a Postgres function. The six reads cannot:
+// the cloud reads these tables over PostgREST, so the thing being ported is the
+// query the client BUILDS — its `.eq()`s and its `.order()` — and the oracle has
+// to be that query written out. Each entry below names the TypeScript it is
+// transcribed from, and the transcription is deliberately literal: same filter,
+// same ORDER BY, same column list.
+//
+// This is the same hazard `merge_categories` above declares, and it has the same
+// answer: a query repeated in the harness can silently agree with a wrong
+// implementation, so what makes it safe is that a disagreement is LOUD. The two
+// sides are compared element by element and key by key, and the array's ORDER is
+// part of what is compared (`stableJson` sorts object keys and never arrays).
+//
+// THE TIE-BREAK IS DELIBERATELY ABSENT HERE. The Rust side orders by `…, id`
+// behind the cloud's key, states in its own module docs that the second key is
+// not a port of anything, and is proved by a single-engine spec. Copying it into
+// this oracle would make the harness agree with the port about a thing the cloud
+// never said. So these queries carry exactly the client's ORDER BY, and every
+// spec that compares them uses a fixture whose sort key is distinct.
+
+/** A numeric(_,2) column as the decimal string both engines must agree on. */
+const money = (expr) => `(${expr})::text`;
+
+/**
+ * A timestamptz as the local edition spells a timestamp.
+ *
+ * Both engines store the same instant; they render it differently (PostgREST
+ * would send `+00:00`, SQLite stores `…Z`) and the app parses either through
+ * `new Date()`. Rendering the cloud's in the local spelling keeps the comparison
+ * about the INSTANT rather than about two spellings of it — the same decision
+ * `numeric::text` makes for money.
+ */
+const stamp = (expr) => `to_char(${expr} AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"')`;
+
+/**
+ * One `accounts` row, in the twenty-five keys `crate::row::account::ListedAccount`
+ * serialises.
+ *
+ * THREE CLOUD COLUMNS ARE DELIBERATELY NOT PROJECTED: `plaid_account_id` and
+ * `plaid_connection_id` (a local file has no bank feed) and
+ * `last_reconciled_balance` (in the cloud since 20260810200000, not yet in
+ * scripts/local-sqlite/schema.sql). Projecting a key the local answer cannot
+ * have would report a schema gap as a per-spec divergence; the gap is recorded
+ * in the crate's `row/account.rs` where a reader of the read will meet it.
+ */
+const ACCOUNT_JSON = `jsonb_build_object(
+  'id', a.id,
+  'user_id', a.user_id,
+  'name', a.name,
+  'type', a.type,
+  'currency', a.currency,
+  'balance', ${money('a.balance')},
+  'initial_balance', ${money('a.initial_balance')},
+  'bank_balance', ${money('a.bank_balance')},
+  'bank_balance_date', a.bank_balance_date::text,
+  'last_reconciled_date', a.last_reconciled_date::text,
+  'low_balance_alert_enabled', a.low_balance_alert_enabled,
+  'low_balance_threshold', ${money('a.low_balance_threshold')},
+  'opening_balance_date', a.opening_balance_date::text,
+  'archive_through_date', a.archive_through_date::text,
+  'parent_account_id', a.parent_account_id,
+  'institution', a.institution,
+  'account_number', a.account_number,
+  'sort_code', a.sort_code,
+  'icon', a.icon,
+  'color', a.color,
+  'notes', a.notes,
+  'is_active', a.is_active,
+  'metadata', a.metadata,
+  'created_at', ${stamp('a.created_at')},
+  'updated_at', ${stamp('a.updated_at')}
+)`;
+
+/** One `categories` row, in the sixteen keys `CategoryRow` serialises. */
+const CATEGORY_JSON = `jsonb_build_object(
+  'id', c.id,
+  'user_id', c.user_id,
+  'name', c.name,
+  'type', c.type,
+  'level', c.level,
+  'parent_id', c.parent_id,
+  'account_id', c.account_id,
+  'color', c.color,
+  'icon', c.icon,
+  'is_system', c.is_system,
+  'is_transfer_category', c.is_transfer_category,
+  'is_revaluation_category', c.is_revaluation_category,
+  'is_unassigned_bucket', c.is_unassigned_bucket,
+  'is_active', c.is_active,
+  'created_at', ${stamp('c.created_at')},
+  'updated_at', ${stamp('c.updated_at')}
+)`;
+
+/**
+ * One `budgets` row, in the eighteen keys `ListedBudget` serialises.
+ *
+ * `alert_threshold` is the interesting one and it is NOT translated here: the
+ * cloud stores numeric(5,2) and casts to `"80.00"`, the local file stores 8000
+ * basis points of a percent and the crate renders `"80.00"` from it. Comparing
+ * the two texts is what proves the encoding round-trips; converting either side
+ * would be the harness agreeing with itself.
+ */
+const BUDGET_JSON = `jsonb_build_object(
+  'id', b.id,
+  'user_id', b.user_id,
+  'name', b.name,
+  'amount', ${money('b.amount')},
+  'period', b.period,
+  'category', b.category,
+  'category_id', b.category_id,
+  'start_date', b.start_date::text,
+  'end_date', b.end_date::text,
+  'spent', ${money('b.spent')},
+  'rollover', b.rollover,
+  'rollover_amount', ${money('b.rollover_amount')},
+  'alert_threshold', ${money('b.alert_threshold')},
+  'is_active', b.is_active,
+  'notes', b.notes,
+  'metadata', b.metadata,
+  'created_at', ${stamp('b.created_at')},
+  'updated_at', ${stamp('b.updated_at')}
+)`;
+
+/** One `goals` row, in the nineteen keys `GoalRow` serialises. */
+const GOAL_JSON = `jsonb_build_object(
+  'id', g.id,
+  'user_id', g.user_id,
+  'name', g.name,
+  'description', g.description,
+  'target_amount', ${money('g.target_amount')},
+  'current_amount', ${money('g.current_amount')},
+  'target_date', g.target_date::text,
+  'category', g.category,
+  'priority', g.priority,
+  'status', g.status,
+  'account_id', g.account_id,
+  'contribution_frequency', g.contribution_frequency,
+  'auto_contribute', g.auto_contribute,
+  'icon', g.icon,
+  'color', g.color,
+  'completed_at', ${stamp('g.completed_at')},
+  'metadata', g.metadata,
+  'created_at', ${stamp('g.created_at')},
+  'updated_at', ${stamp('g.updated_at')}
+)`;
+
+/**
+ * One `suggestion_dismissals` row, in the five keys `DismissalRow` serialises —
+ * which are the five `suggestionDismissalService.list` names in its own
+ * `.select()`, and `user_id` is not among them.
+ *
+ * `subject_ids` is a `uuid[]` here and a child table locally, so the array's
+ * ORDER is the whole comparison: `to_jsonb` preserves the stored order, and the
+ * local side rebuilds it from `role_order`. A port that read the child table as
+ * a set would come back in a different order and be caught here.
+ */
+const DISMISSAL_JSON = `jsonb_build_object(
+  'id', d.id,
+  'kind', d.kind,
+  'subject_key', d.subject_key,
+  'subject_ids', COALESCE(to_jsonb(d.subject_ids), '[]'::jsonb),
+  'dismissed_at', ${stamp('d.dismissed_at')}
+)`;
+
+/** A read's answer: one named key holding the list, or an empty list. */
+const listed = (key, json, from, order) =>
+  `SELECT jsonb_build_object('${key}', COALESCE(jsonb_agg(${json} ORDER BY ${order}), '[]'::jsonb))
+     INTO v_row
+     FROM ${from};`;
+
 /**
  * The RPC each verb maps onto, and how its result is projected.
  *
@@ -375,6 +547,96 @@ const VERBS = {
               COALESCE(${payloadLiteral}::jsonb->'links', '{}'::jsonb),
               NULLIF(${payloadLiteral}::jsonb->>'user_id', '')::uuid)
        INTO v_row;`,
+
+  // ── THE READS ──────────────────────────────────────────────────────────────
+  // Transcribed from the client query each one ports; see the block above the
+  // VERBS table for why a query is a legitimate oracle and what keeps it honest.
+
+  // accountService.getAccounts:
+  //   .from('accounts').select('*')
+  //   .eq('user_id', userId).eq('is_active', true)
+  //   .order('created_at', { ascending: true })
+  list_accounts: (payloadLiteral) =>
+    listed(
+      'accounts',
+      ACCOUNT_JSON,
+      `public.accounts a
+        WHERE a.user_id = (${payloadLiteral}::jsonb->>'user_id')::uuid
+          AND a.is_active`,
+      'a.created_at',
+    ),
+
+  // accountService.getClosedAccounts — the same query with `.eq('is_active',
+  // false)`, which is why the local edition makes it a second VERB rather than a
+  // flag: the two questions are asked from two different places in the app.
+  list_closed_accounts: (payloadLiteral) =>
+    listed(
+      'closed_accounts',
+      ACCOUNT_JSON,
+      `public.accounts a
+        WHERE a.user_id = (${payloadLiteral}::jsonb->>'user_id')::uuid
+          AND NOT a.is_active`,
+      'a.created_at',
+    ),
+
+  // planningService.ensureCategories:
+  //   .from('categories').select('*').eq('user_id', userId)
+  //   .order('level', { ascending: true }).order('name', { ascending: true })
+  //
+  // NOT `dataService.listCategories`, which reads browser storage and never
+  // touches the cloud — the signed-in boot's category list comes from here. No
+  // `is_active` filter: a hidden category still has to resolve for the rows
+  // already filed under it.
+  //
+  // `level` is a text column, so ascending means detail, sub, type. Collation
+  // could in principle differ from SQLite's BINARY; these three values are
+  // lower-case ASCII, where every collation agrees, and the harness prints a
+  // warning if the cluster is not UTF8.
+  list_categories: (payloadLiteral) =>
+    listed(
+      'categories',
+      CATEGORY_JSON,
+      `public.categories c
+        WHERE c.user_id = (${payloadLiteral}::jsonb->>'user_id')::uuid`,
+      'c.level, c.name',
+    ),
+
+  // planningService.getBudgets:
+  //   .from('budgets').select('*').eq('user_id', userId)
+  //   .order('created_at', { ascending: true })
+  // Inactive budgets load too — the service says why in its own comment.
+  list_budgets: (payloadLiteral) =>
+    listed(
+      'budgets',
+      BUDGET_JSON,
+      `public.budgets b
+        WHERE b.user_id = (${payloadLiteral}::jsonb->>'user_id')::uuid`,
+      'b.created_at',
+    ),
+
+  // planningService.getGoals — the same shape as budgets, same order, no status
+  // filter.
+  list_goals: (payloadLiteral) =>
+    listed(
+      'goals',
+      GOAL_JSON,
+      `public.goals g
+        WHERE g.user_id = (${payloadLiteral}::jsonb->>'user_id')::uuid`,
+      'g.created_at',
+    ),
+
+  // suggestionDismissalService.list:
+  //   .from('suggestion_dismissals')
+  //   .select('id, kind, subject_key, subject_ids, dismissed_at')
+  //   .eq('user_id', userId).order('dismissed_at', { ascending: false })
+  list_suggestion_dismissals: (payloadLiteral) =>
+    listed(
+      'suggestion_dismissals',
+      DISMISSAL_JSON,
+      `public.suggestion_dismissals d
+        WHERE d.user_id = (${payloadLiteral}::jsonb->>'user_id')::uuid`,
+      'd.dismissed_at DESC',
+    ),
 
   // The snap returns the whole accounts row. Projected into the same eight
   // fields crate::row::account::AccountRow serialises, money as a decimal string

--- a/scripts/local-sqlite/verb-specs/_shared.mjs
+++ b/scripts/local-sqlite/verb-specs/_shared.mjs
@@ -2232,3 +2232,348 @@ export function fedRow(externalId, expect) {
     expect,
   };
 }
+
+// ── The reads' fixtures ────────────────────────────────────────────────────
+//
+// A read spec asserts the WHOLE row of everything it gets back, which means two
+// things every other family here could ignore:
+//
+//  1. **Every timestamp has to be pinned.** `created_at` and `updated_at`
+//     default to "now" on both engines, and the two nows are two clocks in two
+//     processes: left alone, every read spec would compare '…04:43:49.862Z'
+//     against '…04:43:50.117Z' and fail on a difference that means nothing. Pin
+//     them and the comparison is about the columns that carry meaning.
+//  2. **Every sort key has to be DISTINCT.** The Rust side breaks a tie with
+//     `id` and the Postgres oracle deliberately does not (a tie-break the cloud
+//     never stated must not be transcribed into its own oracle), so a fixture
+//     that ties is a fixture whose two answers may legitimately differ. The
+//     tie-break has its own proof in `crates/wealth-core/tests/reads.rs`.
+
+/** The instant Everyday was opened; Rainy day is a day later. */
+export const OPENED_FIRST = '2024-01-01T00:00:00.000Z';
+export const OPENED_SECOND = '2024-01-02T00:00:00.000Z';
+/** The instant every category in the fixture was named. */
+export const NAMED_AT = '2024-01-03T00:00:00.000Z';
+
+/**
+ * Fixed `created_at`/`updated_at` on the base fixture's accounts and
+ * categories.
+ *
+ * THE TWO HALVES ARE NOT SYMMETRIC, and the asymmetry is the engines':
+ *
+ * * locally, `trg_accounts_updated_at` fires only `WHEN NEW.updated_at IS
+ *   OLD.updated_at` — naming the column stands the trigger down, which is the
+ *   same mechanism every write verb relies on;
+ * * in the cloud, `update_updated_at_column` ASSIGNS `NEW.updated_at = NOW()`
+ *   unconditionally unless `app.restore_in_progress` is set, so the flag has to
+ *   be raised or the pin is silently overwritten by the trigger.
+ *
+ * Categories are pinned LAST on purpose: an UPDATE of an account fires the
+ * cloud's `sync_transfer_category_on_account_update` (no column list there, one
+ * `AFTER UPDATE` for the whole row), and anything that touches a category bumps
+ * its timestamp again.
+ */
+export const pinnedReadTimes = {
+  sqlite: `
+    UPDATE accounts SET created_at = '${OPENED_FIRST}', updated_at = '${OPENED_FIRST}'
+     WHERE id = '${EVERYDAY}';
+    UPDATE accounts SET created_at = '${OPENED_SECOND}', updated_at = '${OPENED_SECOND}'
+     WHERE id = '${RAINY_DAY}';
+    UPDATE categories SET created_at = '${NAMED_AT}', updated_at = '${NAMED_AT}'
+     WHERE user_id = '${USER}';`,
+  postgres: `
+    SELECT set_config('app.restore_in_progress', '1', true);
+    UPDATE public.accounts SET created_at = '${OPENED_FIRST}', updated_at = '${OPENED_FIRST}'
+     WHERE id = '${EVERYDAY}';
+    UPDATE public.accounts SET created_at = '${OPENED_SECOND}', updated_at = '${OPENED_SECOND}'
+     WHERE id = '${RAINY_DAY}';
+    UPDATE public.categories SET created_at = '${NAMED_AT}', updated_at = '${NAMED_AT}'
+     WHERE user_id = '${USER}';
+    SELECT set_config('app.restore_in_progress', '0', true);`,
+};
+
+/**
+ * Rainy day, closed — the Microsoft Money model: the account leaves the pickers
+ * and every transaction stays exactly where it is.
+ *
+ * Applied BEFORE [`pinnedReadTimes`], because closing an account is an UPDATE
+ * and both engines stamp `updated_at` for one.
+ */
+export const closedRainyDay = {
+  sqlite: `UPDATE accounts SET is_active = 0 WHERE id = '${RAINY_DAY}';`,
+  postgres: `UPDATE public.accounts SET is_active = false WHERE id = '${RAINY_DAY}';`,
+};
+
+/**
+ * Everyday, with every optional figure on an account filled in.
+ *
+ * Four money columns and four date columns, none of which the base fixture
+ * exercises: on a bare account they are all NULL, and NULL is the one value
+ * that cannot tell a working conversion from a missing one.
+ */
+export const accountWithEveryFigure = {
+  sqlite: `
+    UPDATE accounts SET
+      initial_balance_minor = -1000,
+      bank_balance_minor = 12345,
+      bank_balance_date = '2024-02-29',
+      last_reconciled_date = '2024-02-01',
+      low_balance_alert_enabled = 1,
+      low_balance_threshold_minor = -5000,
+      opening_balance_date = '2023-12-31',
+      archive_through_date = '2023-06-30',
+      institution = 'A Bank',
+      account_number = '12345678',
+      sort_code = '00-00-00',
+      icon = 'wallet',
+      color = '#123456',
+      notes = 'the everyday one',
+      currency = 'GBP',
+      metadata = '{"k":1}'
+     WHERE id = '${EVERYDAY}';
+    UPDATE transactions SET amount_minor = -1500 WHERE id = '${CORNER_SHOP}';`,
+  postgres: `
+    UPDATE public.accounts SET
+      initial_balance = -10.00,
+      bank_balance = 123.45,
+      bank_balance_date = '2024-02-29',
+      last_reconciled_date = '2024-02-01',
+      low_balance_alert_enabled = true,
+      low_balance_threshold = -50.00,
+      opening_balance_date = '2023-12-31',
+      archive_through_date = '2023-06-30',
+      institution = 'A Bank',
+      account_number = '12345678',
+      sort_code = '00-00-00',
+      icon = 'wallet',
+      color = '#123456',
+      notes = 'the everyday one',
+      currency = 'GBP',
+      metadata = '{"k":1}'::jsonb
+     WHERE id = '${EVERYDAY}';
+    UPDATE public.transactions SET amount = -15.00 WHERE id = '${CORNER_SHOP}';`,
+};
+
+/** Two budgets: one paused, one live, a day apart, with different thresholds. */
+export const FOOD_BUDGET = 'b0000000-0000-0000-0000-00000000b001';
+export const FUEL_BUDGET = 'b0000000-0000-0000-0000-00000000b002';
+
+export const twoBudgets = {
+  sqlite: `
+    INSERT INTO budgets (id, user_id, name, amount_minor, period, category, start_date,
+                         end_date, spent_minor, rollover, rollover_amount_minor,
+                         alert_threshold_bp, is_active, notes, created_at, updated_at) VALUES
+      ('${FOOD_BUDGET}', '${USER}', 'Food', 12345, 'monthly', '${WEEKLY_SHOP}', '2024-01-01',
+       '2024-12-31', 6789, 1, 250, 4250, 1, 'the food one', '${OPENED_FIRST}', '${OPENED_FIRST}'),
+      ('${FUEL_BUDGET}', '${USER}', 'Fuel', 5000, 'weekly', NULL, '2024-02-01',
+       NULL, 0, 0, 0, 8000, 0, NULL, '${OPENED_SECOND}', '${OPENED_SECOND}');`,
+  postgres: `
+    SELECT set_config('app.restore_in_progress', '1', true);
+    INSERT INTO public.budgets (id, user_id, name, amount, period, category, start_date,
+                                end_date, spent, rollover, rollover_amount,
+                                alert_threshold, is_active, notes, created_at, updated_at) VALUES
+      ('${FOOD_BUDGET}', '${USER}', 'Food', 123.45, 'monthly', '${WEEKLY_SHOP}', '2024-01-01',
+       '2024-12-31', 67.89, true, 2.50, 42.50, true, 'the food one', '${OPENED_FIRST}', '${OPENED_FIRST}'),
+      ('${FUEL_BUDGET}', '${USER}', 'Fuel', 50.00, 'weekly', NULL, '2024-02-01',
+       NULL, 0.00, false, 0.00, 80.00, false, NULL, '${OPENED_SECOND}', '${OPENED_SECOND}');
+    SELECT set_config('app.restore_in_progress', '0', true);`,
+};
+
+/** Two goals: one running, one finished, a day apart. */
+export const HOLIDAY_GOAL = '90000000-0000-0000-0000-000000009001';
+export const ROOF_GOAL = '90000000-0000-0000-0000-000000009002';
+
+export const twoGoals = {
+  sqlite: `
+    INSERT INTO goals (id, user_id, name, description, target_amount_minor,
+                       current_amount_minor, target_date, category, priority, status,
+                       account_id, contribution_frequency, auto_contribute, icon, color,
+                       completed_at, metadata, created_at, updated_at) VALUES
+      ('${HOLIDAY_GOAL}', '${USER}', 'Holiday', 'somewhere warm', 250000, 12345, '2025-06-01',
+       '${WEEKLY_SHOP}', 'high', 'active', '${RAINY_DAY}', 'monthly', 1, 'sun', '#ffcc00',
+       NULL, '{"type":"savings"}', '${OPENED_FIRST}', '${OPENED_FIRST}'),
+      ('${ROOF_GOAL}', '${USER}', 'New roof', NULL, 500000, 500000, NULL, NULL, NULL,
+       'completed', NULL, NULL, 0, NULL, NULL, '2024-03-04T05:06:07.000Z', '{}',
+       '${OPENED_SECOND}', '${OPENED_SECOND}');`,
+  postgres: `
+    SELECT set_config('app.restore_in_progress', '1', true);
+    INSERT INTO public.goals (id, user_id, name, description, target_amount,
+                              current_amount, target_date, category, priority, status,
+                              account_id, contribution_frequency, auto_contribute, icon, color,
+                              completed_at, metadata, created_at, updated_at) VALUES
+      ('${HOLIDAY_GOAL}', '${USER}', 'Holiday', 'somewhere warm', 2500.00, 123.45, '2025-06-01',
+       '${WEEKLY_SHOP}', 'high', 'active', '${RAINY_DAY}', 'monthly', true, 'sun', '#ffcc00',
+       NULL, '{"type":"savings"}'::jsonb, '${OPENED_FIRST}', '${OPENED_FIRST}'),
+      ('${ROOF_GOAL}', '${USER}', 'New roof', NULL, 5000.00, 5000.00, NULL, NULL, NULL,
+       'completed', NULL, NULL, false, NULL, NULL, '2024-03-04T05:06:07.000Z', '{}'::jsonb,
+       '${OPENED_SECOND}', '${OPENED_SECOND}');
+    SELECT set_config('app.restore_in_progress', '0', true);`,
+};
+
+/**
+ * Two dismissals a day apart, and a second transaction for the older one to
+ * name.
+ *
+ * The extra row is zero-amount on purpose: a dismissal's subjects are foreign
+ * keys to `transactions` locally, so the fixture has to have rows to point at,
+ * and a zero amount adds one without moving a balance B-1 is asserted on.
+ *
+ * The newer dismissal names TWO rows, in an order that is not their id order —
+ * `subject_ids` positions are ROLES (which row was the out and which the in),
+ * so a reader that came back with a set would be answering a different
+ * question.
+ */
+export const PAIR_DISMISSAL = 'd0000000-0000-0000-0000-0000000000d1';
+export const STRANDED_DISMISSAL = 'd0000000-0000-0000-0000-0000000000d2';
+export const SECOND_ROW = '70000000-0000-0000-0000-0000000000d9';
+export const DISMISSED_FIRST = '2024-04-01T09:00:00.000Z';
+export const DISMISSED_LATER = '2024-04-02T09:00:00.000Z';
+
+export const twoDismissals = {
+  sqlite: `
+    INSERT INTO transactions (id, user_id, account_id, description, amount_minor, type, date)
+      VALUES ('${SECOND_ROW}', '${USER}', '${EVERYDAY}', 'Nothing at all', 0, 'expense', '2024-03-02');
+    INSERT INTO suggestion_dismissals (id, user_id, kind, subject_key, dismissed_at) VALUES
+      ('${STRANDED_DISMISSAL}', '${USER}', 'stranded', 'the stranded one', '${DISMISSED_FIRST}'),
+      ('${PAIR_DISMISSAL}', '${USER}', 'transfer-pair', 'the pair', '${DISMISSED_LATER}');
+    INSERT INTO suggestion_dismissal_subjects (dismissal_id, transaction_id, role_order) VALUES
+      ('${STRANDED_DISMISSAL}', '${CORNER_SHOP}', 0),
+      ('${PAIR_DISMISSAL}', '${SECOND_ROW}', 0),
+      ('${PAIR_DISMISSAL}', '${CORNER_SHOP}', 1);`,
+  postgres: `
+    INSERT INTO public.transactions (id, user_id, account_id, description, amount, type, date)
+      VALUES ('${SECOND_ROW}', '${USER}', '${EVERYDAY}', 'Nothing at all', 0.00, 'expense', '2024-03-02');
+    INSERT INTO public.suggestion_dismissals (id, user_id, kind, subject_key, subject_ids, dismissed_at) VALUES
+      ('${STRANDED_DISMISSAL}', '${USER}', 'stranded', 'the stranded one',
+       ARRAY['${CORNER_SHOP}']::uuid[], '${DISMISSED_FIRST}'),
+      ('${PAIR_DISMISSAL}', '${USER}', 'transfer-pair', 'the pair',
+       ARRAY['${SECOND_ROW}','${CORNER_SHOP}']::uuid[], '${DISMISSED_LATER}');`,
+};
+
+// ── The rows a read spec expects, with the fixture's defaults filled in ─────
+//
+// A read returns whole rows, and a spec that spelled all twenty-five keys of
+// every account would bury the one field it is about. These builders carry the
+// value a bare fixture row actually has — every one of them checked against the
+// column defaults in schema.sql — so a spec states its DIFFERENCE and the
+// builder states the rest. Nothing here is derived from the crate's answer: the
+// defaults are the schema's, and a port that changed one would be caught by
+// every spec at once rather than by none.
+
+/** One account, as both engines must answer with it. */
+export function listedAccount(fields) {
+  return {
+    id: EVERYDAY,
+    user_id: USER,
+    name: 'Everyday',
+    type: 'checking',
+    currency: 'GBP',
+    balance: '0.00',
+    initial_balance: '0.00',
+    bank_balance: null,
+    bank_balance_date: null,
+    last_reconciled_date: null,
+    low_balance_alert_enabled: false,
+    low_balance_threshold: null,
+    opening_balance_date: null,
+    archive_through_date: null,
+    parent_account_id: null,
+    institution: null,
+    account_number: null,
+    sort_code: null,
+    icon: null,
+    color: null,
+    notes: null,
+    is_active: true,
+    metadata: {},
+    created_at: OPENED_FIRST,
+    updated_at: OPENED_FIRST,
+    ...fields,
+  };
+}
+
+/** One category. `level` and `name` together are the sort key. */
+export function listedCategory(fields) {
+  return {
+    id: '',
+    user_id: USER,
+    name: '',
+    type: 'expense',
+    level: 'detail',
+    parent_id: null,
+    account_id: null,
+    color: null,
+    icon: null,
+    is_system: false,
+    is_transfer_category: false,
+    is_revaluation_category: false,
+    is_unassigned_bucket: false,
+    is_active: true,
+    created_at: NAMED_AT,
+    updated_at: NAMED_AT,
+    ...fields,
+  };
+}
+
+/** One budget. `alert_threshold` is a percentage, not money — see the verb. */
+export function listedBudget(fields) {
+  return {
+    id: '',
+    user_id: USER,
+    name: '',
+    amount: '0.00',
+    period: 'monthly',
+    category: null,
+    category_id: null,
+    start_date: '2024-01-01',
+    end_date: null,
+    spent: '0.00',
+    rollover: false,
+    rollover_amount: '0.00',
+    alert_threshold: '80.00',
+    is_active: true,
+    notes: null,
+    metadata: {},
+    created_at: OPENED_FIRST,
+    updated_at: OPENED_FIRST,
+    ...fields,
+  };
+}
+
+/** One goal. */
+export function listedGoal(fields) {
+  return {
+    id: '',
+    user_id: USER,
+    name: '',
+    description: null,
+    target_amount: '0.00',
+    current_amount: '0.00',
+    target_date: null,
+    category: null,
+    priority: null,
+    status: 'active',
+    account_id: null,
+    contribution_frequency: null,
+    auto_contribute: false,
+    icon: null,
+    color: null,
+    completed_at: null,
+    metadata: {},
+    created_at: OPENED_FIRST,
+    updated_at: OPENED_FIRST,
+    ...fields,
+  };
+}
+
+/** One dismissal — five keys, because the cloud's own read names five. */
+export function listedDismissal(fields) {
+  return {
+    id: '',
+    kind: 'transfer-pair',
+    subject_key: '',
+    subject_ids: [],
+    dismissed_at: DISMISSED_LATER,
+    ...fields,
+  };
+}

--- a/scripts/local-sqlite/verb-specs/read-accounts-a-closed-account-is-not-in-the-open-list.spec.mjs
+++ b/scripts/local-sqlite/verb-specs/read-accounts-a-closed-account-is-not-in-the-open-list.spec.mjs
@@ -1,0 +1,26 @@
+import {
+  USER, EVERYDAY, RAINY_DAY,
+  setups, closedRainyDay, pinnedReadTimes, listedAccount, balanceIdentityHolds, auditRowsInTotal,
+} from './_shared.mjs';
+
+export default {
+  invariant: 'READ-2',
+  title: 'closing an account takes it out of this answer and leaves its money exactly where it was',
+  design: 'dataPort.ts: "Closed accounts are excluded from listAccounts and read on demand." The cloud does it with .eq(\'is_active\', true); closing is a SOFT close in every implementation, because a deleted account is a hole in a ledger',
+  consequence: 'if a closed account stayed in this list it would keep appearing in every picker, every total and every transfer target — which is the whole of what closing an account is for',
+  parity: 'match',
+
+  setup: setups(closedRainyDay, pinnedReadTimes),
+  command: { verb: 'list_accounts', payload: { user_id: USER } },
+  expect: { outcome: 'ok' },
+  result: {
+    accounts: [
+      listedAccount({ id: EVERYDAY, name: 'Everyday', type: 'checking', balance: '-25.00' }),
+    ],
+  },
+  state: [
+    balanceIdentityHolds(EVERYDAY),
+    balanceIdentityHolds(RAINY_DAY),
+    auditRowsInTotal('0'),
+  ],
+};

--- a/scripts/local-sqlite/verb-specs/read-accounts-a-login-with-nothing-in-it-answers-with-an-empty-list.spec.mjs
+++ b/scripts/local-sqlite/verb-specs/read-accounts-a-login-with-nothing-in-it-answers-with-an-empty-list.spec.mjs
@@ -1,0 +1,15 @@
+import { USER, wiped, auditRowsInTotal } from './_shared.mjs';
+
+export default {
+  invariant: 'READ-3',
+  title: 'a login with no accounts gets an empty list, which is an answer and not a failure',
+  design: 'accountService.getAccounts returns `(data || []).map(…)`; the seam types it Promise<Account[]> with no null in it. A brand-new file is exactly this state, and so is every file the moment before its first account exists',
+  consequence: 'the difference between [] and a rejected promise is the difference between an empty Accounts page with an "add one" button and a full-page "Failed to load data" in front of somebody whose file is perfectly fine',
+  parity: 'match',
+
+  setup: wiped,
+  command: { verb: 'list_accounts', payload: { user_id: USER } },
+  expect: { outcome: 'ok' },
+  result: { accounts: [] },
+  state: [auditRowsInTotal('0')],
+};

--- a/scripts/local-sqlite/verb-specs/read-accounts-arrive-in-the-order-the-accounts-were-opened.spec.mjs
+++ b/scripts/local-sqlite/verb-specs/read-accounts-arrive-in-the-order-the-accounts-were-opened.spec.mjs
@@ -1,0 +1,30 @@
+import {
+  USER, EVERYDAY, RAINY_DAY, OPENED_SECOND,
+  pinnedReadTimes, listedAccount, balanceIdentityHolds, auditRowsInTotal,
+} from './_shared.mjs';
+
+export default {
+  invariant: 'READ-1',
+  title: 'the accounts come back oldest first, and every column comes back with them',
+  design: 'accountService.getAccounts: .select(\'*\').eq(\'user_id\', …).eq(\'is_active\', true).order(\'created_at\', { ascending: true }). The order is not decoration — the Accounts page draws its sections in the order this answer arrives',
+  consequence: 'a read that returned the same accounts in a different order would reshuffle the page on every boot, and one that returned a narrower row would blank whatever it left out: mapAccountFromDb reads the whole row, and the last time two mappers disagreed about it the dashboard silently lost its low-balance alert',
+  parity: 'match',
+
+  setup: pinnedReadTimes,
+  command: { verb: 'list_accounts', payload: { user_id: USER } },
+  expect: { outcome: 'ok' },
+  result: {
+    accounts: [
+      listedAccount({ id: EVERYDAY, name: 'Everyday', type: 'checking', balance: '-25.00' }),
+      listedAccount({
+        id: RAINY_DAY, name: 'Rainy day', type: 'savings', balance: '0.00',
+        created_at: OPENED_SECOND, updated_at: OPENED_SECOND,
+      }),
+    ],
+  },
+  state: [
+    balanceIdentityHolds(EVERYDAY),
+    balanceIdentityHolds(RAINY_DAY),
+    auditRowsInTotal('0'),
+  ],
+};

--- a/scripts/local-sqlite/verb-specs/read-accounts-every-figure-on-an-account-crosses-as-a-decimal-string.spec.mjs
+++ b/scripts/local-sqlite/verb-specs/read-accounts-every-figure-on-an-account-crosses-as-a-decimal-string.spec.mjs
@@ -1,0 +1,51 @@
+import {
+  USER, EVERYDAY, RAINY_DAY, OPENED_SECOND,
+  setups, accountWithEveryFigure, pinnedReadTimes, listedAccount,
+  balanceIdentityHolds, auditRowsInTotal,
+} from './_shared.mjs';
+
+export default {
+  invariant: 'READ-4',
+  title: 'all four money columns on an account leave as decimal strings, and the dates beside them as days',
+  design: 'PHASE3-PLAN D-4, the decisive reason reads are verbs in this crate at all: money.rs is the ONE place minor units become the text the app parses, and "a second layer\'s `minor as f64 / 100.0` is one careless line in the numbers on screen". A bare fixture cannot prove it — every optional figure is NULL, and NULL cannot tell a working conversion from a missing one',
+  consequence: 'a JSON number is a double the moment any parser touches it. £123.45 through a float is the class of defect this whole edition exists to make structurally impossible, and the balance is only one of four figures on this row that would go through it',
+  parity: 'match',
+
+  setup: setups(accountWithEveryFigure, pinnedReadTimes),
+  command: { verb: 'list_accounts', payload: { user_id: USER } },
+  expect: { outcome: 'ok' },
+  result: {
+    accounts: [
+      listedAccount({
+        id: EVERYDAY,
+        name: 'Everyday',
+        type: 'checking',
+        // balance = initial_balance + Σ amounts = −10.00 + −15.00.
+        balance: '-25.00',
+        initial_balance: '-10.00',
+        bank_balance: '123.45',
+        bank_balance_date: '2024-02-29',
+        last_reconciled_date: '2024-02-01',
+        low_balance_alert_enabled: true,
+        low_balance_threshold: '-50.00',
+        opening_balance_date: '2023-12-31',
+        archive_through_date: '2023-06-30',
+        institution: 'A Bank',
+        account_number: '12345678',
+        sort_code: '00-00-00',
+        icon: 'wallet',
+        color: '#123456',
+        notes: 'the everyday one',
+        metadata: { k: 1 },
+      }),
+      listedAccount({
+        id: RAINY_DAY, name: 'Rainy day', type: 'savings',
+        created_at: OPENED_SECOND, updated_at: OPENED_SECOND,
+      }),
+    ],
+  },
+  state: [
+    balanceIdentityHolds(EVERYDAY),
+    auditRowsInTotal('0'),
+  ],
+};

--- a/scripts/local-sqlite/verb-specs/read-accounts-somebody-elses-account-is-not-in-the-answer.spec.mjs
+++ b/scripts/local-sqlite/verb-specs/read-accounts-somebody-elses-account-is-not-in-the-answer.spec.mjs
@@ -1,0 +1,26 @@
+import {
+  USER, EVERYDAY, RAINY_DAY, OPENED_SECOND,
+  setups, secondUser, pinnedReadTimes, listedAccount, auditRowsInTotal,
+} from './_shared.mjs';
+
+export default {
+  invariant: 'READ-5',
+  title: 'a second login\'s account is in the file and not in the answer',
+  design: 'every cloud read is .eq(\'user_id\', userId) with an id DataService resolved on the same tick. The cloud has RLS behind that filter; a local file has nothing behind it at all, and a restore can genuinely leave a second login\'s rows in one',
+  consequence: 'this is the only thing standing between two logins in one file and one of them seeing the other\'s money. It is why the read\'s owner is a required String and not an Option',
+  parity: 'match',
+
+  setup: setups(secondUser, pinnedReadTimes),
+  command: { verb: 'list_accounts', payload: { user_id: USER } },
+  expect: { outcome: 'ok' },
+  result: {
+    accounts: [
+      listedAccount({ id: EVERYDAY, name: 'Everyday', type: 'checking', balance: '-25.00' }),
+      listedAccount({
+        id: RAINY_DAY, name: 'Rainy day', type: 'savings',
+        created_at: OPENED_SECOND, updated_at: OPENED_SECOND,
+      }),
+    ],
+  },
+  state: [auditRowsInTotal('0')],
+};

--- a/scripts/local-sqlite/verb-specs/read-budgets-a-paused-budget-is-still-in-the-list.spec.mjs
+++ b/scripts/local-sqlite/verb-specs/read-budgets-a-paused-budget-is-still-in-the-list.spec.mjs
@@ -1,0 +1,24 @@
+import { USER, FUEL_BUDGET, twoBudgets, auditRowsInTotal } from './_shared.mjs';
+
+export default {
+  invariant: 'READ-6',
+  title: 'a paused budget is greyed out on the page, not missing from the answer',
+  design: 'getBudgets says it in its own comment: "Inactive budgets load too: pausing a budget greys it out on the page (which filters on isActive where it matters), it must not make the budget vanish with no way to reactivate it." There is no is_active filter in the query',
+  consequence: 'filter here and pausing a budget deletes it as far as the user can tell — the row is in the file, the page cannot show it, and there is no control anywhere that would bring it back',
+  parity: 'match',
+
+  setup: twoBudgets,
+  command: { verb: 'list_budgets', payload: { user_id: USER } },
+  expect: { outcome: 'ok' },
+  state: [
+    auditRowsInTotal('0'),
+    {
+      name: 'the_paused_budget_is_stored_paused',
+      sqlite: `SELECT CASE WHEN is_active = 1 THEN 'live' ELSE 'paused' END
+                 FROM budgets WHERE id = '${FUEL_BUDGET}'`,
+      postgres: `SELECT CASE WHEN is_active THEN 'live' ELSE 'paused' END
+                   FROM public.budgets WHERE id = '${FUEL_BUDGET}'`,
+      expect: 'paused',
+    },
+  ],
+};

--- a/scripts/local-sqlite/verb-specs/read-budgets-arrive-oldest-first-with-every-figure-as-a-decimal-string.spec.mjs
+++ b/scripts/local-sqlite/verb-specs/read-budgets-arrive-oldest-first-with-every-figure-as-a-decimal-string.spec.mjs
@@ -1,0 +1,31 @@
+import {
+  USER, EVERYDAY, WEEKLY_SHOP, FOOD_BUDGET, FUEL_BUDGET, OPENED_SECOND,
+  twoBudgets, listedBudget, balanceIdentityHolds, auditRowsInTotal,
+} from './_shared.mjs';
+
+export default {
+  invariant: 'READ-1',
+  title: 'the budgets come back oldest first, and their three money columns come back as decimal strings',
+  design: 'planningService.getBudgets: .select(\'*\').eq(\'user_id\', …).order(\'created_at\', { ascending: true }). Three of the eighteen columns are money — amount, spent, rollover_amount — and schema.sql records that the last two are numeric(10,2) in the cloud against numeric(20,2) here',
+  consequence: 'a budget is an amount against a category. Through a float it is an amount that nearly matches, and the number on the page stops agreeing with the number in the file',
+  parity: 'match',
+
+  setup: twoBudgets,
+  command: { verb: 'list_budgets', payload: { user_id: USER } },
+  expect: { outcome: 'ok' },
+  result: {
+    budgets: [
+      listedBudget({
+        id: FOOD_BUDGET, name: 'Food', amount: '123.45', category: WEEKLY_SHOP,
+        end_date: '2024-12-31', spent: '67.89', rollover: true, rollover_amount: '2.50',
+        alert_threshold: '42.50', notes: 'the food one',
+      }),
+      listedBudget({
+        id: FUEL_BUDGET, name: 'Fuel', amount: '50.00', period: 'weekly',
+        start_date: '2024-02-01', is_active: false,
+        created_at: OPENED_SECOND, updated_at: OPENED_SECOND,
+      }),
+    ],
+  },
+  state: [balanceIdentityHolds(EVERYDAY), auditRowsInTotal('0')],
+};

--- a/scripts/local-sqlite/verb-specs/read-budgets-the-alert-threshold-crosses-as-a-percentage-not-as-basis-points.spec.mjs
+++ b/scripts/local-sqlite/verb-specs/read-budgets-the-alert-threshold-crosses-as-a-percentage-not-as-basis-points.spec.mjs
@@ -1,0 +1,40 @@
+import {
+  USER, WEEKLY_SHOP, FOOD_BUDGET, FUEL_BUDGET, OPENED_SECOND,
+  twoBudgets, listedBudget, auditRowsInTotal,
+} from './_shared.mjs';
+
+export default {
+  invariant: 'READ-4',
+  title: 'a threshold stored as 4250 basis points arrives as "42.50" — the same text the cloud\'s numeric(5,2) casts to',
+  design: 'schema.sql shouts NOT MONEY at this column and stores hundredths of a percent (8000 = 80.00%) because the file keeps every fractional quantity out of floating point; the cloud stores numeric(5,2). Two encodings, one value, and money.rs renders the local one — because the alternative is a `/ 100` on the far side of the boundary, which is exactly the shape R-7\'s grep exists to catch',
+  consequence: 'get it wrong by a factor of a hundred and every budget alerts at 0.8% of its limit — on the first pound spent, for ever, on every budget in the file',
+  parity: 'divergent',
+  reason: 'THE STORED VALUES DIVERGE AND THE ANSWERS DO NOT, which is the whole spec. The state assertion reads what each file HOLDS — 4250 against 42.50 — while the result assertion reads what each engine ANSWERS with, and that is "42.50" on both. If the storage encodings ever stop diverging (a local column holding a percentage), this spec must go red and be re-thought rather than quietly keep passing.',
+
+  setup: twoBudgets,
+  command: { verb: 'list_budgets', payload: { user_id: USER } },
+  expect: { outcome: 'ok' },
+  result: {
+    budgets: [
+      listedBudget({
+        id: FOOD_BUDGET, name: 'Food', amount: '123.45', category: WEEKLY_SHOP,
+        end_date: '2024-12-31', spent: '67.89', rollover: true, rollover_amount: '2.50',
+        alert_threshold: '42.50', notes: 'the food one',
+      }),
+      listedBudget({
+        id: FUEL_BUDGET, name: 'Fuel', amount: '50.00', period: 'weekly',
+        start_date: '2024-02-01', is_active: false, alert_threshold: '80.00',
+        created_at: OPENED_SECOND, updated_at: OPENED_SECOND,
+      }),
+    ],
+  },
+  state: [
+    auditRowsInTotal('0'),
+    {
+      name: 'the_threshold_as_the_file_stores_it',
+      sqlite: `SELECT CAST(alert_threshold_bp AS TEXT) FROM budgets WHERE id = '${FOOD_BUDGET}'`,
+      postgres: `SELECT alert_threshold::text FROM public.budgets WHERE id = '${FOOD_BUDGET}'`,
+      expect: { sqlite: '4250', postgres: '42.50' },
+    },
+  ],
+};

--- a/scripts/local-sqlite/verb-specs/read-categories-a-hidden-category-is-still-in-the-list.spec.mjs
+++ b/scripts/local-sqlite/verb-specs/read-categories-a-hidden-category-is-still-in-the-list.spec.mjs
@@ -1,0 +1,37 @@
+import {
+  USER, EVERYDAY, RAINY_DAY, OUTGOINGS, WEEKLY_SHOP,
+  TO_FROM_EVERYDAY, TO_FROM_RAINY_DAY,
+  setups, namedTransferCategories, closedRainyDay, pinnedReadTimes, listedCategory, auditRowsInTotal,
+} from './_shared.mjs';
+
+const TRANSFER_ROOT = 'c0000000-0000-0000-0000-000000000001';
+
+export default {
+  invariant: 'READ-6',
+  title: 'closing an account hides its To/From category and does not remove it from this answer',
+  design: 'C-4 mirrors an account\'s is_active onto its transfer category, and ensureCategories\' query has NO is_active filter. The pickers filter; the read does not',
+  consequence: 'every transaction ever filed under a closed account\'s To/From category resolves through this list. Drop the hidden rows here and a closed account\'s history comes back with a blank category column — the rows are fine, the file is fine, and the register lies about it',
+  parity: 'match',
+
+  setup: setups(namedTransferCategories, closedRainyDay, pinnedReadTimes),
+  command: { verb: 'list_categories', payload: { user_id: USER } },
+  expect: { outcome: 'ok' },
+  result: {
+    categories: [
+      listedCategory({
+        id: TO_FROM_EVERYDAY, name: 'To/From Everyday', type: 'both',
+        parent_id: TRANSFER_ROOT, account_id: EVERYDAY, is_transfer_category: true,
+      }),
+      listedCategory({
+        id: TO_FROM_RAINY_DAY, name: 'To/From Rainy day', type: 'both',
+        parent_id: TRANSFER_ROOT, account_id: RAINY_DAY, is_transfer_category: true,
+        // C-4, and the whole point of this spec.
+        is_active: false,
+      }),
+      listedCategory({ id: WEEKLY_SHOP, name: 'Weekly shop', level: 'sub', parent_id: OUTGOINGS }),
+      listedCategory({ id: OUTGOINGS, name: 'Outgoings', level: 'type' }),
+      listedCategory({ id: TRANSFER_ROOT, name: 'Transfer', type: 'both', level: 'type' }),
+    ],
+  },
+  state: [auditRowsInTotal('0')],
+};

--- a/scripts/local-sqlite/verb-specs/read-categories-arrive-by-level-and-then-by-name.spec.mjs
+++ b/scripts/local-sqlite/verb-specs/read-categories-arrive-by-level-and-then-by-name.spec.mjs
@@ -1,0 +1,38 @@
+import {
+  USER, EVERYDAY, RAINY_DAY, OUTGOINGS, WEEKLY_SHOP,
+  TO_FROM_EVERYDAY, TO_FROM_RAINY_DAY,
+  setups, namedTransferCategories, pinnedReadTimes, listedCategory, auditRowsInTotal,
+} from './_shared.mjs';
+
+const TRANSFER_ROOT = 'c0000000-0000-0000-0000-000000000001';
+
+export default {
+  invariant: 'READ-1',
+  title: 'the categories come back by level and then by name — which is alphabetical, not hierarchical',
+  design: 'planningService.ensureCategories: .select(\'*\').eq(\'user_id\', …).order(\'level\').order(\'name\'). NOT dataService.listCategories, which reads browser storage: a signed-in boot\'s category list comes from this query. `level` is a text column, so ascending means detail, sub, type',
+  consequence: 'this is the list the register\'s category column and every picker resolve an id through, so a port that dropped a row — or invented a hierarchical order the app has never received — changes what a filed transaction looks like on screen',
+  parity: 'match',
+
+  setup: setups(namedTransferCategories, pinnedReadTimes),
+  command: { verb: 'list_categories', payload: { user_id: USER } },
+  expect: { outcome: 'ok' },
+  result: {
+    categories: [
+      // detail, by name: the two To/From categories C-3's trigger minted.
+      listedCategory({
+        id: TO_FROM_EVERYDAY, name: 'To/From Everyday', type: 'both',
+        parent_id: TRANSFER_ROOT, account_id: EVERYDAY, is_transfer_category: true,
+      }),
+      listedCategory({
+        id: TO_FROM_RAINY_DAY, name: 'To/From Rainy day', type: 'both',
+        parent_id: TRANSFER_ROOT, account_id: RAINY_DAY, is_transfer_category: true,
+      }),
+      // sub
+      listedCategory({ id: WEEKLY_SHOP, name: 'Weekly shop', level: 'sub', parent_id: OUTGOINGS }),
+      // type, by name
+      listedCategory({ id: OUTGOINGS, name: 'Outgoings', level: 'type' }),
+      listedCategory({ id: TRANSFER_ROOT, name: 'Transfer', type: 'both', level: 'type' }),
+    ],
+  },
+  state: [auditRowsInTotal('0')],
+};

--- a/scripts/local-sqlite/verb-specs/read-closed-accounts-a-file-with-nothing-closed-answers-with-an-empty-list.spec.mjs
+++ b/scripts/local-sqlite/verb-specs/read-closed-accounts-a-file-with-nothing-closed-answers-with-an-empty-list.spec.mjs
@@ -1,0 +1,15 @@
+import { USER, EVERYDAY, pinnedReadTimes, balanceIdentityHolds, auditRowsInTotal } from './_shared.mjs';
+
+export default {
+  invariant: 'READ-3',
+  title: 'a file where nothing has been closed answers with an empty list, not with the open accounts',
+  design: 'the two account reads are complementary halves of one table — .eq(\'is_active\', true) and .eq(\'is_active\', false) — so the fixture\'s two OPEN accounts are exactly what this answer must not contain',
+  consequence: 'the Closed Accounts section is drawn from this answer, and a read that fell back to "all accounts" when there were no closed ones would put every live account under a heading saying it was closed',
+  parity: 'match',
+
+  setup: pinnedReadTimes,
+  command: { verb: 'list_closed_accounts', payload: { user_id: USER } },
+  expect: { outcome: 'ok' },
+  result: { closed_accounts: [] },
+  state: [balanceIdentityHolds(EVERYDAY), auditRowsInTotal('0')],
+};

--- a/scripts/local-sqlite/verb-specs/read-closed-accounts-only-the-closed-ones-are-in-this-answer.spec.mjs
+++ b/scripts/local-sqlite/verb-specs/read-closed-accounts-only-the-closed-ones-are-in-this-answer.spec.mjs
@@ -1,0 +1,29 @@
+import {
+  USER, EVERYDAY, RAINY_DAY, OPENED_SECOND,
+  setups, closedRainyDay, pinnedReadTimes, listedAccount, balanceIdentityHolds, auditRowsInTotal,
+} from './_shared.mjs';
+
+export default {
+  invariant: 'READ-2',
+  title: 'the closed list holds the closed account and nothing else',
+  design: 'accountService.getClosedAccounts — the same query as getAccounts with .eq(\'is_active\', false), for the Accounts page\'s Closed Accounts section. Two questions, and the local edition gives them two verb names rather than one verb and a boolean',
+  consequence: 'this is the only way back: closing is soft and reversible, and an account that fell out of both lists would be money nobody could reach from the page it lives on',
+  parity: 'match',
+
+  setup: setups(closedRainyDay, pinnedReadTimes),
+  command: { verb: 'list_closed_accounts', payload: { user_id: USER } },
+  expect: { outcome: 'ok' },
+  result: {
+    closed_accounts: [
+      listedAccount({
+        id: RAINY_DAY, name: 'Rainy day', type: 'savings', is_active: false,
+        created_at: OPENED_SECOND, updated_at: OPENED_SECOND,
+      }),
+    ],
+  },
+  state: [
+    balanceIdentityHolds(EVERYDAY),
+    balanceIdentityHolds(RAINY_DAY),
+    auditRowsInTotal('0'),
+  ],
+};

--- a/scripts/local-sqlite/verb-specs/read-dismissals-a-login-that-has-refused-nothing-answers-with-an-empty-list.spec.mjs
+++ b/scripts/local-sqlite/verb-specs/read-dismissals-a-login-that-has-refused-nothing-answers-with-an-empty-list.spec.mjs
@@ -1,0 +1,14 @@
+import { USER, EVERYDAY, balanceIdentityHolds, auditRowsInTotal } from './_shared.mjs';
+
+export default {
+  invariant: 'READ-3',
+  title: 'a login that has never refused a suggestion gets an empty list',
+  design: 'the base fixture holds no dismissals at all, which is the state of every file until somebody says "stop offering me this". suggestionDismissalService.list builds its result from `data ?? []`',
+  consequence: 'the sweeps subtract this list from what they offer. An answer that failed instead of coming back empty would take the transfer, duplicate and stranded sweeps down with it on a brand-new file',
+  parity: 'match',
+
+  command: { verb: 'list_suggestion_dismissals', payload: { user_id: USER } },
+  expect: { outcome: 'ok' },
+  result: { suggestion_dismissals: [] },
+  state: [balanceIdentityHolds(EVERYDAY), auditRowsInTotal('0')],
+};

--- a/scripts/local-sqlite/verb-specs/read-dismissals-the-newest-refusal-comes-first.spec.mjs
+++ b/scripts/local-sqlite/verb-specs/read-dismissals-the-newest-refusal-comes-first.spec.mjs
@@ -1,0 +1,30 @@
+import {
+  USER, EVERYDAY, CORNER_SHOP, SECOND_ROW,
+  PAIR_DISMISSAL, STRANDED_DISMISSAL, DISMISSED_FIRST,
+  twoDismissals, listedDismissal, balanceIdentityHolds, auditRowsInTotal,
+} from './_shared.mjs';
+
+export default {
+  invariant: 'READ-1',
+  title: 'the dismissals come back newest first — the one direction none of the other reads uses',
+  design: 'suggestionDismissalService.list: .select(\'id, kind, subject_key, subject_ids, dismissed_at\').eq(\'user_id\', …).order(\'dismissed_at\', { ascending: false }). Five named columns rather than *, so the answer carries five and user_id is not among them',
+  consequence: 'every other read here is oldest-first, so a port written by pattern-matching the one beside it would reverse this list. It is what the "restore a dismissed suggestion" screen is drawn from, and the most recently refused suggestion is the one somebody is most likely to want back',
+  parity: 'match',
+
+  setup: twoDismissals,
+  command: { verb: 'list_suggestion_dismissals', payload: { user_id: USER } },
+  expect: { outcome: 'ok' },
+  result: {
+    suggestion_dismissals: [
+      listedDismissal({
+        id: PAIR_DISMISSAL, kind: 'transfer-pair', subject_key: 'the pair',
+        subject_ids: [SECOND_ROW, CORNER_SHOP],
+      }),
+      listedDismissal({
+        id: STRANDED_DISMISSAL, kind: 'stranded', subject_key: 'the stranded one',
+        subject_ids: [CORNER_SHOP], dismissed_at: DISMISSED_FIRST,
+      }),
+    ],
+  },
+  state: [balanceIdentityHolds(EVERYDAY), auditRowsInTotal('0')],
+};

--- a/scripts/local-sqlite/verb-specs/read-dismissals-the-subjects-come-back-as-an-array-in-role-order.spec.mjs
+++ b/scripts/local-sqlite/verb-specs/read-dismissals-the-subjects-come-back-as-an-array-in-role-order.spec.mjs
@@ -1,0 +1,33 @@
+import {
+  USER, CORNER_SHOP, SECOND_ROW, PAIR_DISMISSAL,
+  twoDismissals, auditRowsInTotal,
+} from './_shared.mjs';
+
+export default {
+  invariant: 'READ-7',
+  title: 'a uuid[] in the cloud and a child table here answer with the same array in the same order',
+  design: 'schema.sql turns subject_ids into suggestion_dismissal_subjects because SQLite has neither arrays nor a GIN index, and argues the child table is the better shape. role_order is what keeps the reassembly honest: the positions in the list are ROLES — for a transfer pair, which row was the out and which the in',
+  consequence: 'a reader that rebuilt the array as a SET would answer a different question. The rows come back in an order that is deliberately NOT their id order, so a port that sorted them, or that let SQLite return them in rowid order, is caught here rather than by a sweep offering the wrong suggestion back',
+  parity: 'match',
+
+  setup: twoDismissals,
+  command: { verb: 'list_suggestion_dismissals', payload: { user_id: USER } },
+  expect: { outcome: 'ok' },
+  state: [
+    auditRowsInTotal('0'),
+    {
+      name: 'the_subjects_as_each_engine_stores_them',
+      // Deliberately in the stored order on both sides, not sorted: the child
+      // table is read by role_order and the array by its own position, and if
+      // either engine started answering in id order this would say so.
+      sqlite: `SELECT group_concat(substr(transaction_id, -4), ',') FROM (
+                 SELECT transaction_id FROM suggestion_dismissal_subjects
+                  WHERE dismissal_id = '${PAIR_DISMISSAL}' ORDER BY role_order)`,
+      postgres: `SELECT string_agg(right(id::text, 4), ',')
+                   FROM (SELECT unnest(subject_ids) AS id
+                           FROM public.suggestion_dismissals
+                          WHERE id = '${PAIR_DISMISSAL}') s`,
+      expect: `${SECOND_ROW.slice(-4)},${CORNER_SHOP.slice(-4)}`,
+    },
+  ],
+};

--- a/scripts/local-sqlite/verb-specs/read-goals-a-finished-goal-is-still-in-the-list.spec.mjs
+++ b/scripts/local-sqlite/verb-specs/read-goals-a-finished-goal-is-still-in-the-list.spec.mjs
@@ -1,0 +1,23 @@
+import { USER, ROOF_GOAL, twoGoals, auditRowsInTotal } from './_shared.mjs';
+
+export default {
+  invariant: 'READ-6',
+  title: 'a completed goal stays in the answer, because reaching one is the thing worth showing',
+  design: 'getGoals has no status filter, and goalFromDb derives BOTH isActive (status !== \'paused\') and achieved (status === \'completed\') from the column this answer carries. completed_at is the achievement itself rather than a per-device flag — "a goal reached on the laptop shows as reached on the phone"',
+  consequence: 'filter completed goals out here and finishing one erases it, along with the date it was finished on — the single most satisfying row in the file',
+  parity: 'match',
+
+  setup: twoGoals,
+  command: { verb: 'list_goals', payload: { user_id: USER } },
+  expect: { outcome: 'ok' },
+  state: [
+    auditRowsInTotal('0'),
+    {
+      name: 'the_finished_goal_is_stored_finished',
+      sqlite: `SELECT status || ' at ' || completed_at FROM goals WHERE id = '${ROOF_GOAL}'`,
+      postgres: `SELECT status || ' at ' || to_char(completed_at AT TIME ZONE 'UTC',
+                        'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"') FROM public.goals WHERE id = '${ROOF_GOAL}'`,
+      expect: 'completed at 2024-03-04T05:06:07.000Z',
+    },
+  ],
+};

--- a/scripts/local-sqlite/verb-specs/read-goals-arrive-oldest-first-with-their-money-as-decimal-strings.spec.mjs
+++ b/scripts/local-sqlite/verb-specs/read-goals-arrive-oldest-first-with-their-money-as-decimal-strings.spec.mjs
@@ -1,0 +1,33 @@
+import {
+  USER, EVERYDAY, RAINY_DAY, WEEKLY_SHOP, HOLIDAY_GOAL, ROOF_GOAL, OPENED_SECOND,
+  twoGoals, listedGoal, balanceIdentityHolds, auditRowsInTotal,
+} from './_shared.mjs';
+
+export default {
+  invariant: 'READ-1',
+  title: 'the goals come back oldest first, whole, with both amounts as decimal strings',
+  design: 'planningService.getGoals: .select(\'*\').eq(\'user_id\', …).order(\'created_at\', { ascending: true }). goalFromDb reads three of the app\'s fields out of the metadata blob and two more out of status, so the crate carries both columns untouched and decides neither',
+  consequence: 'currentAmount IS progress — the same figure under two names — so a goal whose amount arrived through a float would show a bar that does not match the money that was put by',
+  parity: 'match',
+
+  setup: twoGoals,
+  command: { verb: 'list_goals', payload: { user_id: USER } },
+  expect: { outcome: 'ok' },
+  result: {
+    goals: [
+      listedGoal({
+        id: HOLIDAY_GOAL, name: 'Holiday', description: 'somewhere warm',
+        target_amount: '2500.00', current_amount: '123.45', target_date: '2025-06-01',
+        category: WEEKLY_SHOP, priority: 'high', account_id: RAINY_DAY,
+        contribution_frequency: 'monthly', auto_contribute: true, icon: 'sun', color: '#ffcc00',
+        metadata: { type: 'savings' },
+      }),
+      listedGoal({
+        id: ROOF_GOAL, name: 'New roof', target_amount: '5000.00', current_amount: '5000.00',
+        status: 'completed', completed_at: '2024-03-04T05:06:07.000Z',
+        created_at: OPENED_SECOND, updated_at: OPENED_SECOND,
+      }),
+    ],
+  },
+  state: [balanceIdentityHolds(EVERYDAY), auditRowsInTotal('0')],
+};

--- a/scripts/local-sqlite/verbs.mjs
+++ b/scripts/local-sqlite/verbs.mjs
@@ -64,12 +64,21 @@ function locateBridge() {
 // ordering: `tags` is a `text[]` in the cloud and a child table locally, and a
 // child table is a SET. Sorting both is the only comparison that is not an
 // accident, and it is a real (small) divergence, recorded in the parity notes.
+//
+// ONLY ARRAYS OF PRIMITIVES ARE SORTED, and the restriction arrived with the
+// read verbs. Their answer is an array of ROWS, whose order is the whole point
+// of the read — `list_accounts` is oldest-first and `list_suggestion_dismissals`
+// is newest-first — so sorting it would throw away the thing being compared.
+// (A bare `.sort()` on an array of objects happens to leave it alone, because
+// every element stringifies to the same thing and the sort is stable. Relying
+// on that would be relying on an accident, so the rule is spelled out.)
 function canonicalise(row) {
   if (!row) return null;
   const canonical = {};
   for (const key of Object.keys(row).sort()) {
     const value = row[key];
-    canonical[key] = Array.isArray(value) ? [...value].sort() : value;
+    const sortable = Array.isArray(value) && value.every((entry) => entry === null || typeof entry !== 'object');
+    canonical[key] = sortable ? [...value].sort() : value;
   }
   return canonical;
 }
@@ -158,7 +167,13 @@ function observedParity(spec, results) {
     const fields = new Set([...Object.keys(left), ...Object.keys(right)]);
     for (const field of fields) {
       if (declared.has(field)) continue;
-      if (JSON.stringify(left[field]) !== JSON.stringify(right[field])) {
+      // `stableJson`, not `JSON.stringify`, for the reason stated where it is
+      // defined: key order is not semantic in JSON and the two engines do not
+      // agree about it — serde emits a struct's declaration order, jsonb sorts
+      // by key length then bytes. Comparing the raw text reported every read of
+      // a whole row as a divergence whose two sides were the same object.
+      // Arrays are still compared IN ORDER, which is what a read's answer is.
+      if (stableJson(left[field]) !== stableJson(right[field])) {
         notes.push(`row.${field}: ${show(left[field])} vs ${show(right[field])}`);
       }
     }


### PR DESCRIPTION
Phase 3, slice 15 — the first read-verb batch. Six reads join the crate as `Command` variants: `list_accounts`, `list_closed_accounts`, `list_categories`, `list_budgets`, `list_goals`, `list_suggestion_dismissals`.

## The discipline
- **Every plan on the record**: each verb's EXPLAIN line lives in the family's contract — zero table scans, every read cut to one owner by its index before sorting. The temp-B-tree sorts are accepted *and argued* (tens-to-hundreds of rows post-index), with a written warning that slice 16's transaction reads must be re-measured, not assumed similar.
- **One money conversion each way**: the crate emits snake_case rows with decimal-string money — deliberately *not* the app shape, because `accountMapping.ts` declares itself the ONE translation and an app-shaped Rust read would be the second mapper that file exists to prevent. Crate renders once; the TS mapper parses once.
- **Ordering is contract**: each list carries its ported query's own sort; the id tiebreak is stated as belonging to no oracle, so the differential harness never agrees with the port about something the cloud never said. No `is_active`/`status` filtering — paused budgets, completed goals, and hidden To/From categories all stay listed.

## Verification
Cargo 271 → **284** (13 new integration tests); verb lane 309 → **326**, all green against the throwaway Postgres cluster; admission 109/109; constraint 65/66 (the known C/R-split parity gap, byte-identical). Three mutations, each reverted red-on-cue — the third caught its own weak fixture (roles ascending with ids) and was strengthened until it bit. The harness comparator gained honesty en route: object key order no longer reads as divergence, row order still does.

## Ledgered
Two local-schema parity obligations recorded beside `is_reconciled`'s: the dismissals `kind` enum admits 4 of the cloud's 7 (a cloud backup carrying the others is refused whole), and `last_reconciled_balance` has no local column yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)