### PR TITLE
feat(core): slice 16 — read verbs II: the ledger, its lines, and the money verb that never trusts the stored balance (347 verb specs +21, 300 cargo tests)

### DIFF
--- a/crates/wealth-core/src/command.rs
+++ b/crates/wealth-core/src/command.rs
@@ -78,19 +78,20 @@ use crate::admission::{
 };
 use crate::error::CoreError;
 use crate::verbs::{
-    apply_category_to_uncategorized, clear_transfer_links, confirm_transaction_categories,
-    create_transaction, create_transfer_counterpart, delete_transaction, delete_unused_categories,
-    finalize_user_restore, import_bank_transactions, import_transactions, link_bank_account_snap,
-    link_split_line_transfer, link_transfer_pair, list_accounts, list_budgets, list_categories,
-    list_closed_accounts, list_goals, list_suggestion_dismissals, merge_categories,
-    repair_claimed_transfer, restore_user_chunk, set_transaction_splits_with_legs,
+    account_balances, apply_category_to_uncategorized, clear_transfer_links,
+    confirm_transaction_categories, create_transaction, create_transfer_counterpart,
+    delete_transaction, delete_unused_categories, finalize_user_restore, import_bank_transactions,
+    import_transactions, link_bank_account_snap, link_split_line_transfer, link_transfer_pair,
+    list_accounts, list_budgets, list_categories, list_closed_accounts, list_goals,
+    list_suggestion_dismissals, list_transaction_splits, list_transactions, merge_categories,
+    repair_claimed_transfer, restore_user_chunk, set_transaction_splits_with_legs, splits_for,
     update_transaction, user_financial_data_is_empty, verify_integrity, wipe_user_financial_data,
     ApplyCategoryToUncategorized, ClearTransferLinks, ConfirmTransactionCategories,
     CreateTransaction, CreateTransferCounterpart, DeleteTransaction, DeleteUnusedCategories,
     FinalizeUserRestore, ImportBankTransactions, ImportTransactions, LinkBankAccountSnap,
     LinkSplitLineTransfer, LinkTransferPair, MergeCategories, OwnedRead, RepairClaimedTransfer,
-    RestoreUserChunk, SetTransactionSplitsWithLegs, UpdateTransaction, UserFinancialDataIsEmpty,
-    VerifyIntegrity, WipeUserFinancialData,
+    RestoreUserChunk, SetTransactionSplitsWithLegs, SplitsFor, UpdateTransaction,
+    UserFinancialDataIsEmpty, VerifyIntegrity, WipeUserFinancialData,
 };
 
 /// A command, as a caller sends it.
@@ -183,9 +184,9 @@ pub enum Command {
     ImportBankTransactions(Box<ImportBankTransactions>),
     // ── The reads ────────────────────────────────────────────────────────────
     //
-    // Six verbs that answer and write nothing. Each is named for the question
-    // it answers rather than for a function it ports, because there is no
-    // function to port: the cloud reads these tables over PostgREST, so what is
+    // Ten verbs that answer and write nothing. Nine are named for the question
+    // they answer rather than for a function they port, because there is no
+    // function to port: the cloud reads those tables over PostgREST, so what is
     // ported is a QUERY — its filter and its ORDER BY, spelled out in
     // [`crate::verbs::reads`] alongside the plan each one was measured to use.
     //
@@ -194,9 +195,9 @@ pub enum Command {
     // get two names, and a payload with `{"open": false}` in it is a payload
     // that will one day be sent by mistake.
     //
-    // All six share ONE payload type — an owner, and nothing else. The dispatch
-    // stays exhaustive over VARIANTS, so a seventh read still has to be armed
-    // below or the crate does not compile.
+    // Nine of the ten share ONE payload type — an owner, and nothing else. The
+    // dispatch stays exhaustive over VARIANTS, so an eleventh read still has to
+    // be armed below or the crate does not compile.
     /// [`crate::verbs::list_accounts`].
     ListAccounts(Box<OwnedRead>),
     /// [`crate::verbs::list_closed_accounts`].
@@ -209,6 +210,28 @@ pub enum Command {
     ListGoals(Box<OwnedRead>),
     /// [`crate::verbs::list_suggestion_dismissals`].
     ListSuggestionDismissals(Box<OwnedRead>),
+    // The heavy four. They differ from the six above in what they run over —
+    // one person's whole history rather than a page of settings — which is why
+    // their plans are measured at 50k rows in [`crate::verbs::reads`] rather
+    // than argued from the size of a list of accounts.
+    //
+    // `account_balances` is the only read here that IS a port of a function
+    // (`20260722160000`), and the only verb in the crate that answers with money
+    // it computed rather than money it stored. Its four properties are in
+    // [`crate::row::balance`].
+    //
+    // `splits_for` is the one read with a payload of its own, because it names a
+    // PARENT. The seam spells the distinction with a suffix —
+    // `listTransactionSplits` against `listTransactionSplitsFor` — and the verb
+    // strings keep it.
+    /// [`crate::verbs::list_transactions`].
+    ListTransactions(Box<OwnedRead>),
+    /// [`crate::verbs::list_transaction_splits`].
+    ListTransactionSplits(Box<OwnedRead>),
+    /// [`crate::verbs::splits_for`].
+    SplitsFor(Box<SplitsFor>),
+    /// [`crate::verbs::account_balances`].
+    AccountBalances(Box<OwnedRead>),
     // The only verb here that is NOT a port: the cloud has no verify_integrity,
     // no view and no equivalent, and the verb's module documentation carries the
     // trace that establishes it. Its payload is `{}` — it takes not even an
@@ -402,7 +425,7 @@ pub fn dispatch(
             verify_integrity(&*connection, *payload).and_then(as_json)
         }
         // The reads, and every one of them takes `&*connection` for the same
-        // reason those two do: a read opens no transaction. Six arms rather
+        // reason those two do: a read opens no transaction. Ten arms rather
         // than one `Command::List…(_) => list(…)` helper, because the enum's
         // whole property is that each variant is spelled once here — an arm
         // that dispatched several verbs through one function would be a place
@@ -419,6 +442,16 @@ pub fn dispatch(
         Command::ListGoals(payload) => list_goals(&*connection, *payload).and_then(as_json),
         Command::ListSuggestionDismissals(payload) => {
             list_suggestion_dismissals(&*connection, *payload).and_then(as_json)
+        }
+        Command::ListTransactions(payload) => {
+            list_transactions(&*connection, *payload).and_then(as_json)
+        }
+        Command::ListTransactionSplits(payload) => {
+            list_transaction_splits(&*connection, *payload).and_then(as_json)
+        }
+        Command::SplitsFor(payload) => splits_for(&*connection, *payload).and_then(as_json),
+        Command::AccountBalances(payload) => {
+            account_balances(&*connection, *payload).and_then(as_json)
         }
         // A self-check with a name, and the same shape as the split writer's
         // `split_write_inconsistent`: [`plan`] above answers every one of these

--- a/crates/wealth-core/src/row.rs
+++ b/crates/wealth-core/src/row.rs
@@ -51,17 +51,32 @@
 //! * [`budget`] — the audit entry keeps `alert_threshold_bp` as stored; the
 //!   reader gets it rendered, because the alternative is a division on the far
 //!   side of the boundary.
+//! * **the transaction** — [`TransactionRow`] is what the audit log records and
+//!   [`ListedTransaction`] is what the boot reads, and the two are different
+//!   sets in BOTH directions: the audit carries NINE columns the boot never asks
+//!   for (the owner it has already filtered on, the feed's merchant, location
+//!   and channel fields, the two file-import provenance ids, the feed's own id,
+//!   and the metadata blob) and the boot carries THREE the audit has not got
+//!   (`needs_review`, `created_at`, `updated_at`). Neither is a subset, so
+//!   neither could serve as the other narrowed.
+//! * [`split`] — the same shape again, and for the same two reasons at once:
+//!   `SplitRow` is the line set the split writer embeds in its audit entry, and
+//!   widening it to the reader's would put `created_at` into a payload two
+//!   engines compare field by field.
 //!
 //! And two entities are here for the reader alone, with no audit twin, because
 //! no verb in either engine audits one: [`goal`] and [`dismissal`].
 
 pub mod account;
+pub mod balance;
 pub mod budget;
 pub mod category;
 pub mod dismissal;
 pub mod goal;
 pub mod recurring;
 pub mod split;
+
+use std::collections::HashMap;
 
 use rusqlite::{params, Connection, OptionalExtension};
 use serde::Serialize;
@@ -243,4 +258,264 @@ pub fn read_owned_transaction(
         return Ok(None);
     }
     read_transaction(connection, id).map(Some)
+}
+
+/// A transaction as the boot reads it: the twenty-two columns the signed-in
+/// load actually fetches, in the order it names them.
+///
+/// # This is not `SELECT *`, and the narrowing is the cloud's
+///
+/// `transactionService.ts`'s `BOOT_TRANSACTION_COLUMNS` is an EXPLICIT column
+/// list with a measurement behind it: the wide table is thirty-two columns,
+/// PostgREST sends a key for every one of them even when null, and across 51k
+/// rows that was ~46 MB of which ~38% was columns nothing reads. The fields left
+/// out — the metadata blob, `merchant_name`, `location_*`, `payment_channel`,
+/// `external_transaction_id` and the two MS-Money provenance columns — *"have no
+/// consumer"*, and the importer that does want the provenance re-queries it
+/// rather than taking it from this array.
+///
+/// A local file has no bandwidth to save. It is narrowed anyway, and for a
+/// better reason than bytes: what a read projects is what the cloud's own query
+/// projects, so that the differential harness compares two answers to one
+/// question. Widening this to `SELECT *` would make every spec assert seven
+/// fields the app has never seen and would put the metadata blob — whose money
+/// CHECK is a per-engine rule — into a cross-engine row comparison.
+///
+/// `user_id` is not here either, and that is the cloud's list too: *"the
+/// redundant `user_id` we already filter on"*. It is a column the answer's own
+/// question already fixed.
+///
+/// # `is_reconciled` is the column this file has not got
+///
+/// The cloud's boot list carries it (added by `20260810200000_marking_is_not_
+/// reconciling.sql`, which split "marked" from "reconciled") and
+/// `scripts/local-sqlite/schema.sql` has no such column — the same kind of gap
+/// [`crate::row::account::ListedAccount`] records for `last_reconciled_balance`,
+/// and named here rather than papered over because it is named where it BITES:
+///
+/// `src/utils/transactionReconciliation.ts` treats an absent `reconciled` as
+/// *"ask `cleared`"*, which is the one-flag behaviour this app had until that
+/// migration. So a local file does not lie about a row — it describes a ledger
+/// in which marking and reconciling are the same act, which is what a file
+/// without the column IS. The cloud's own fallback ladder
+/// (`BOOT_TRANSACTION_COLUMNS_NO_RECONCILED`) does exactly this for a database
+/// that has not had the migration applied yet. What is NOT true of a local file
+/// is that the feature *lights up by itself the moment the migration lands*:
+/// there is no migration to land until `schema.sql` grows the column, and the
+/// day it does, this struct and the harness's oracle must grow it together.
+#[derive(Debug, Clone, Serialize)]
+// Six booleans, because six of the columns the boot reads are booleans. The
+// reasoning is `TransactionRow`'s: this is a row, not a designed API.
+#[allow(clippy::struct_excessive_bools)]
+pub struct ListedTransaction {
+    /// Primary key.
+    pub id: String,
+    /// The account whose balance this row moved.
+    pub account_id: String,
+    /// Signed amount, as a decimal string.
+    pub amount: Money,
+    /// Out of the live register, still in every total. See
+    /// [`crate::row::balance`] for the half of that sentence that is money.
+    pub archived: bool,
+    /// Category id or legacy sentinel. TEXT with no foreign key (R-3).
+    pub category: Option<String>,
+    /// Has a human vouched for `category`?
+    pub category_confirmed: bool,
+    /// The category foreign key.
+    pub category_id: Option<String>,
+    /// When the row was made.
+    pub created_at: String,
+    /// `YYYY-MM-DD`. The list's first sort key.
+    pub date: String,
+    /// Payee or description, as entered or as the file stated it.
+    pub description: String,
+    /// Marked against a statement.
+    pub is_cleared: bool,
+    /// Part of a recurring series.
+    pub is_recurring: bool,
+    /// Is this row a split parent?
+    pub is_split: bool,
+    /// The counterpart row, when the pair is linked.
+    pub linked_transfer_id: Option<String>,
+    /// The counterpart split line, when the leg lives on one.
+    pub linked_transfer_split_id: Option<String>,
+    /// Did this row arrive from an import nobody has looked at yet?
+    pub needs_review: bool,
+    /// Free text.
+    pub notes: Option<String>,
+    /// The bank's own order within a day.
+    pub statement_sequence: Option<i64>,
+    /// Tags, which are a child table locally and a `text[]` in the cloud.
+    pub tags: Vec<String>,
+    /// `income` | `expense` | `transfer`.
+    #[serde(rename = "type")]
+    pub kind: String,
+    /// When it last changed.
+    pub updated_at: String,
+    /// The other account, when this row is a transfer.
+    pub transfer_account_id: Option<String>,
+}
+
+/// Every column [`ListedTransaction`] carries, in its serialised order — which
+/// is `BOOT_TRANSACTION_COLUMNS`'s order, so the two lists can be read side by
+/// side and the one difference (`is_reconciled`) seen rather than searched for.
+const LISTED_COLUMNS: &str = "id, account_id, amount_minor, archived, category,
+        category_confirmed, category_id, created_at, date, description, is_cleared,
+        is_recurring, is_split, linked_transfer_id, linked_transfer_split_id,
+        needs_review, notes, statement_sequence, type, updated_at, transfer_account_id";
+
+/// The statement [`list_owned`] prepares, and the ONLY copy of it.
+///
+/// Public because `tests/reads_at_scale.rs` asserts this read's query plan at
+/// 50,000 rows, and a plan assertion written against a *copy* of the query is
+/// exactly how such an assertion goes on passing after the query it was written
+/// for has changed. R-12 says a read that full-scans must turn a test red; that
+/// is only true while the test and the reader are looking at one string.
+///
+/// It is not a door of the kind DESIGN §6.4 closes. That rule forbids a command
+/// which ACCEPTS a SQL string from a caller; this takes no argument, touches no
+/// connection and returns a constant.
+#[must_use]
+pub fn list_owned_sql() -> String {
+    format!(
+        "SELECT {LISTED_COLUMNS}
+           FROM transactions
+          WHERE user_id = ?1
+          ORDER BY date DESC, id DESC"
+    )
+}
+
+/// The statement [`owned_tags`] prepares. Public for [`list_owned_sql`]'s
+/// reason: the tag pass is half of what a boot's transaction read costs, so its
+/// plan is asserted too.
+#[must_use]
+pub fn owned_tags_sql() -> String {
+    "SELECT tt.transaction_id, tt.tag
+       FROM transaction_tags tt
+       JOIN transactions t ON t.id = tt.transaction_id
+      WHERE t.user_id = ?1
+      ORDER BY tt.transaction_id, tt.tag"
+        .to_owned()
+}
+
+/// Every transaction this login has, newest first.
+///
+/// # The order is a port, tie-break and all
+///
+/// `.order('date', {ascending: false}).order('id', {ascending: false})`, and the
+/// second key carries the cloud's own comment: *"stable tiebreak for paging"*.
+/// This is the one read in the crate whose tie-break needed no local decision —
+/// the cloud states it, because without it a fetch spread over fifty-two pages
+/// can hand the same row over twice and lose another.
+///
+/// # ARCHIVED ROWS ARE IN THIS ANSWER
+///
+/// The boot query filters on `user_id` and nothing else. Archiving is a VIEW
+/// flag: the register hides an archived row, every total still counts it, and
+/// the flag rides back as a column so the app can do the hiding in memory. A
+/// port that "helpfully" added `AND archived = 0` here would take the rows out
+/// of the client's own sum while [`crate::verbs::account_balances`] kept them in
+/// its aggregate, and the two figures on the dashboard would stop agreeing —
+/// which is R-1 arriving through the other door.
+///
+/// # Errors
+/// [`crate::error::CoreError::Storage`] if the read fails.
+pub fn list_owned(connection: &Connection, user_id: &str) -> CoreResult<Vec<ListedTransaction>> {
+    // EXPLAIN QUERY PLAN (measured against schema.sql, 50k rows):
+    //   SEARCH transactions USING INDEX idx_txn_user_page (user_id=?)
+    //
+    // No temp B-tree: `idx_txn_user_page (user_id, date DESC, id DESC)` IS this
+    // query's ORDER BY, which is why the index is spelled with both DESCs. At
+    // 50k rows a sort here is not the tens of rows slice 15's five reads argued
+    // about — see [`crate::verbs::reads`] for the measurement.
+    //
+    // The ONE thing interpolated is `LISTED_COLUMNS`, a crate constant; the
+    // owner is a bound parameter (DESIGN §6.4).
+    let mut statement = connection.prepare(&list_owned_sql())?;
+    let rows = statement.query_map(params![user_id], |record| {
+        Ok(ListedTransaction {
+            id: record.get(0)?,
+            account_id: record.get(1)?,
+            amount: Money::from_minor(record.get(2)?),
+            archived: record.get::<_, i64>(3)? != 0,
+            category: record.get(4)?,
+            category_confirmed: record.get::<_, i64>(5)? != 0,
+            category_id: record.get(6)?,
+            created_at: record.get(7)?,
+            date: record.get(8)?,
+            description: record.get(9)?,
+            is_cleared: record.get::<_, i64>(10)? != 0,
+            is_recurring: record.get::<_, i64>(11)? != 0,
+            is_split: record.get::<_, i64>(12)? != 0,
+            linked_transfer_id: record.get(13)?,
+            linked_transfer_split_id: record.get(14)?,
+            needs_review: record.get::<_, i64>(15)? != 0,
+            notes: record.get(16)?,
+            statement_sequence: record.get(17)?,
+            tags: Vec::new(),
+            kind: record.get(18)?,
+            updated_at: record.get(19)?,
+            transfer_account_id: record.get(20)?,
+        })
+    })?;
+
+    let mut transactions = Vec::new();
+    let mut at = HashMap::new();
+    for transaction in rows {
+        let transaction = transaction?;
+        at.insert(transaction.id.clone(), transactions.len());
+        transactions.push(transaction);
+    }
+
+    for (transaction_id, tag) in owned_tags(connection, user_id)? {
+        if let Some(index) = at.get(&transaction_id) {
+            if let Some(transaction) = transactions.get_mut(*index) {
+                transaction.tags.push(tag);
+            }
+        }
+    }
+    Ok(transactions)
+}
+
+/// Every tag on every row of one login's, in ONE pass.
+///
+/// [`read_transaction`] reads a single row's tags with a query per row, which is
+/// right for one row and catastrophic for fifty thousand: 50k round trips
+/// through the same prepared statement is the N+1 that makes a read that should
+/// take milliseconds take minutes. This is the same answer in one query, folded
+/// into the list by the caller.
+///
+/// The ORDER matters and is the same one [`read_transaction`] uses — by tag —
+/// because `transaction_tags` is a SET locally and a `text[]` in the cloud, and
+/// a set has no order of its own to report. Both keys come free: the table is
+/// `WITHOUT ROWID` with `PRIMARY KEY (transaction_id, tag)`, so its rows ARE
+/// stored in this order and the plan below is a scan of the primary key rather
+/// than a sort.
+fn owned_tags(connection: &Connection, user_id: &str) -> CoreResult<Vec<(String, String)>> {
+    // EXPLAIN QUERY PLAN (measured against schema.sql):
+    //   SCAN transaction_tags
+    //   SEARCH transactions USING INDEX sqlite_autoindex_transactions_1 (id=?)
+    //
+    // A SCAN, and this is the one place in the read family where a scan is the
+    // right plan rather than a bug report. `transaction_tags` holds one row per
+    // TAG, not per transaction — a ledger of 50k rows carries a few thousand at
+    // the very most, because a tag is something a person types — and the scan is
+    // of a WITHOUT ROWID table, so it is a walk of the b-tree that is already in
+    // the order this query wants. The alternative plan (drive from
+    // `transactions`, search the tag table per row) does 50k index seeks to
+    // avoid walking a few thousand rows.
+    //
+    // What would change that: a tag table that grew with the LEDGER rather than
+    // with the user's vocabulary. It does not — see the measurement in
+    // [`crate::verbs::reads`].
+    let mut statement = connection.prepare(&owned_tags_sql())?;
+    let rows = statement.query_map(params![user_id], |record| {
+        Ok((record.get::<_, String>(0)?, record.get::<_, String>(1)?))
+    })?;
+
+    let mut tags = Vec::new();
+    for tag in rows {
+        tags.push(tag?);
+    }
+    Ok(tags)
 }

--- a/crates/wealth-core/src/row/balance.rs
+++ b/crates/wealth-core/src/row/balance.rs
@@ -1,0 +1,163 @@
+//! What every account is actually worth, DERIVED — the money read.
+//!
+//! This is the port of `account_balances()`
+//! (`20260722160000_account_balances_rpc.sql:26-42`), the one function in the
+//! cloud schema whose whole purpose is to answer a question the client could
+//! answer for itself, faster. The client's answer is a sum over the full
+//! transaction set; on a Money-era history that is 50k+ rows arriving in ~52
+//! pages, *"measured at 2.7s of a 3.6s boot, with the user watching a skeleton
+//! the whole time"*. The aggregate is one round trip.
+//!
+//! # Why a derived figure lives beside the row mappers
+//!
+//! Nothing in this file reads a stored row: a balance here is computed. It sits
+//! in [`crate::row`] anyway because of what it computes WITH. Every figure it
+//! produces leaves through [`Money`], the same one integer-to-decimal conversion
+//! every other reader uses, and PHASE3-PLAN D-4's decisive argument is that a
+//! second implementation of that conversion is *"one careless line in the
+//! numbers on screen"*. A module that put this arithmetic anywhere else would be
+//! the beginning of the second one.
+//!
+//! # THE FOUR PROPERTIES
+//!
+//! PHASE3-PLAN §3 names four, each of which is a named money bug if got wrong,
+//! and each of which has a mutation and a spec that goes red for it. They are
+//! listed here, at the SQL, because this is where somebody would break one.
+//!
+//! **1. It AGGREGATES. It never reads `accounts.balance`.** (R-2.) The stored
+//! balance is a cache that every write verb maintains, and B-1 says it must
+//! equal `initial_balance + Σ amounts` — but *no constraint in either engine
+//! enforces that*, which is exactly why `v_integrity_violations` opens with
+//! `balance_identity` (`schema.sql:1578-1586`). The two are siblings and the
+//! relationship runs one way: **this verb derives what `verify_integrity`
+//! checks.** A port that read `a.balance_minor` would answer with the cache, so
+//! a file whose cache had drifted would report the drift AS MONEY on the
+//! dashboard, and the one instrument that could have caught it —
+//! `verify_integrity` naming `balance_identity` — would still be reporting the
+//! violation nobody's figures showed. The whole value of having two independent
+//! numbers is that they are independent.
+//!
+//! **2. The sum spans ALL rows, ARCHIVED INCLUDED.** (R-1, contract rule 82 —
+//! THE money bug.) The RPC says it in as many words: *"The sum deliberately
+//! spans ALL transactions, archived included: archiving is a view flag (see
+//! 20260721130000_soft_archive.sql) and never moves a balance."* An `AND NOT
+//! t.archived` here is one token, reads like a tidy-up, and silently removes the
+//! whole of a user's archived history from every balance in the app. Note that
+//! `balance_identity` does not filter archived either — so a port that filtered
+//! here would ALSO make `verify_integrity` report every account with an archived
+//! row as broken, which is the sibling check earning its keep.
+//!
+//! **3. `LEFT JOIN`, so an account with no transactions still answers.** An
+//! inner join drops it from the result entirely, and a missing key in the map is
+//! not "£0.00" to the caller — `computeAccountBalances` falls back to its own
+//! sum for an account the map does not name, so the account would flicker from
+//! its opening balance to its opening balance. Worse when it is not zero: a
+//! newly opened account whose opening balance is its whole content would show
+//! nothing at all until the rows arrived.
+//!
+//! **4. `COUNT(t.id)`, never `COUNT(*)`.** Under a LEFT JOIN with no matching
+//! row, `COUNT(*)` counts the manufactured null row and answers 1. The count is
+//! not decoration: it is how a caller tells "this account has no transactions"
+//! from "this account's transactions have not arrived yet", and one is a fact
+//! while the other is a loading state.
+//!
+//! # What is local, and declared
+//!
+//! The cloud RPC takes NO ARGUMENT: it is `SECURITY DEFINER` and gets its
+//! identity from the verified JWT through `requesting_user_id()`, *"so there is
+//! no parameter to spoof"*. A file has no JWT and no RLS, so the owner arrives
+//! in the payload like every other read's — and the reason it is required rather
+//! than optional is [`crate::verbs::reads`]'s: a read that named no owner would
+//! answer for every login in the file.
+//!
+//! `COALESCE(a.initial_balance, 0)` is in the cloud's SQL because that column is
+//! nullable there. `initial_balance_minor` is `NOT NULL DEFAULT 0` locally
+//! (`schema.sql:356`), so the COALESCE would be dead code and is left out; the
+//! COALESCE around the SUM stays, because SUM over no rows is NULL in both
+//! engines and that is property 3's other half.
+
+use rusqlite::{params, Connection};
+use serde::Serialize;
+
+use crate::error::CoreResult;
+use crate::money::Money;
+
+/// One account's derived balance, in the three keys the RPC returns.
+///
+/// The names are the CLOUD's — `account_id`, `balance`, `txn_count` — because
+/// `toAccountBalanceMap` (`transactionService.ts`) reads exactly those three off
+/// the wire, and a local spelling would be a second name for one field.
+#[derive(Debug, Clone, Serialize)]
+pub struct AccountBalance {
+    /// The account this figure belongs to.
+    pub account_id: String,
+    /// `initial_balance + Σ(transactions.amount)`, as a decimal string.
+    pub balance: Money,
+    /// How many transactions went into it. Zero is a real answer.
+    pub txn_count: i64,
+}
+
+/// The statement [`for_owner`] prepares, and the ONLY copy of it.
+///
+/// Public for the reason [`crate::row::list_owned_sql`] gives, and with more at
+/// stake than the others: every one of the four properties above is visible in
+/// this string, so a reviewer checking that a port did not quietly filter the
+/// archive is reading the same characters the connection is.
+pub const FOR_OWNER_SQL: &str = "SELECT a.id,
+                a.initial_balance_minor + COALESCE(SUM(t.amount_minor), 0),
+                COUNT(t.id)
+           FROM accounts a
+           LEFT JOIN transactions t
+                  ON t.account_id = a.id
+                 AND t.user_id = a.user_id
+          WHERE a.user_id = ?1
+          GROUP BY a.id, a.initial_balance_minor
+          ORDER BY a.id";
+
+/// Every account's balance, derived, in one pass.
+///
+/// # The order is stated, because the cloud states none at all
+///
+/// The RPC has no `ORDER BY` — it is `GROUP BY a.id, a.initial_balance` and
+/// nothing else, so its answer is a SET and the row order is whatever the plan
+/// produced. That is fine in the cloud, where the client turns it into a `Map`
+/// the moment it arrives. It is not fine here, for the reason every read in this
+/// crate states an order: an unrepeatable answer is an unrepeatable spec.
+///
+/// So `ORDER BY a.id` is this crate's own, stated rather than ported, and `id`
+/// alone is enough — it is the group key, so no tie is possible.
+///
+/// # Errors
+/// [`crate::error::CoreError`] if the read fails. There is no refusal: an owner
+/// with no accounts has an empty list, which is an answer.
+pub fn for_owner(connection: &Connection, user_id: &str) -> CoreResult<Vec<AccountBalance>> {
+    // EXPLAIN QUERY PLAN (measured against schema.sql, 12 accounts / 50k rows):
+    //   SCAN accounts USING INDEX idx_accounts_user (user_id=?)
+    //   SEARCH transactions USING COVERING INDEX idx_txn_balance_cover
+    //          (account_id=? AND user_id=?)
+    //
+    // COVERING is the word that matters, and it is why `idx_txn_balance_cover
+    // (account_id, user_id, amount_minor, id)` carries two columns it does not
+    // filter on: the aggregate is answered out of the index without touching the
+    // table at all. DESIGN §4 measured the difference on this very query — 106ms
+    // unindexed against 3.46ms with it — and it is the measurement behind
+    // *"index design carries ~640× the leverage of transport design"*.
+    //
+    // The outer SCAN of `accounts` is a scan of one login's accounts, which is a
+    // dozen rows, and it is what a LEFT JOIN driven from the left side has to
+    // be. Nothing to fix.
+    let mut statement = connection.prepare(FOR_OWNER_SQL)?;
+    let rows = statement.query_map(params![user_id], |record| {
+        Ok(AccountBalance {
+            account_id: record.get(0)?,
+            balance: Money::from_minor(record.get(1)?),
+            txn_count: record.get(2)?,
+        })
+    })?;
+
+    let mut balances = Vec::new();
+    for balance in rows {
+        balances.push(balance?);
+    }
+    Ok(balances)
+}

--- a/crates/wealth-core/src/row/split.rs
+++ b/crates/wealth-core/src/row/split.rs
@@ -91,3 +91,182 @@ pub fn read_lines(connection: &Connection, transaction_id: &str) -> CoreResult<V
     }
     Ok(lines)
 }
+
+/// A split line as the app lists it: every column this table holds.
+///
+/// # Why this is not [`SplitRow`] widened
+///
+/// The same decision [`crate::row::account`] makes, for the same reason, and it
+/// is worth repeating because a reviewer's first instinct is to merge them.
+/// [`SplitRow`] is the line set the split writer embeds in its AUDIT entry —
+/// `jsonb_agg(...)` in the cloud, a serialised `Vec<SplitRow>` here — and that
+/// payload is compared field by field across two engines. `created_at` and
+/// `updated_at` are two clocks in two processes and never equal, so putting them
+/// in that comparison would turn a passing surface red for no gain.
+///
+/// A READER cannot be narrower, because what a read projects is what the cloud's
+/// own query projects and both split reads are `.select('*')` — the whole row,
+/// eleven columns, timestamps included. The app's own mapper
+/// (`transactionService.mapSplitRow`) reads eight of them and ignores three; that
+/// is the app's business, not the port's. Answering with less than the query
+/// answers with would be this crate deciding, on the app's behalf, that a column
+/// will never be wanted.
+#[derive(Debug, Clone, Serialize)]
+pub struct ListedSplit {
+    /// Primary key.
+    pub id: String,
+    /// The split parent. The whole-store read's first sort key.
+    pub transaction_id: String,
+    /// Owner. The line's OWN owner — see [`list_owned`].
+    pub user_id: String,
+    /// A category id as text, or a legacy sentinel (R-3).
+    pub category: String,
+    /// Signed, by its own category's direction rather than the parent's.
+    pub amount: Money,
+    /// Free text for this line.
+    pub memo: Option<String>,
+    /// Display position. The second sort key, and NOT unique.
+    pub sort_order: i64,
+    /// The account on the other side, when this line is a transfer leg.
+    pub transfer_account_id: Option<String>,
+    /// The counterpart transaction, when the leg is linked.
+    pub linked_transfer_id: Option<String>,
+    /// When the line was made.
+    pub created_at: String,
+    /// When it last changed.
+    pub updated_at: String,
+}
+
+/// Every column [`ListedSplit`] carries, in its serialised order.
+const LISTED_COLUMNS: &str = "id, transaction_id, user_id, category, amount_minor, memo,
+        sort_order, transfer_account_id, linked_transfer_id, created_at, updated_at";
+
+/// The statement [`list_owned`] prepares, and the ONLY copy of it. Public for
+/// the reason [`crate::row::list_owned_sql`] gives: a plan assertion written
+/// against a copy of a query is an assertion that survives the query changing.
+#[must_use]
+pub fn list_owned_sql() -> String {
+    format!(
+        "SELECT {LISTED_COLUMNS}
+           FROM transaction_splits
+          WHERE user_id = ?1
+          ORDER BY transaction_id, sort_order, id"
+    )
+}
+
+/// The statement [`list_for_parent`] prepares.
+#[must_use]
+pub fn list_for_parent_sql() -> String {
+    format!(
+        "SELECT {LISTED_COLUMNS}
+           FROM transaction_splits
+          WHERE transaction_id = ?1
+            AND user_id = ?2
+          ORDER BY sort_order, id"
+    )
+}
+
+/// Every split line this login owns, parent by parent, in display order.
+///
+/// The port of `transactionService.getAllTransactionSplits`:
+/// `.select('*').eq('user_id', …).order('transaction_id').order('sort_order')`,
+/// paged only because PostgREST caps a response at 1,000 rows — a cap a file
+/// does not have, and the reason DESIGN calls a local boot ONE crossing.
+///
+/// # The owner is the LINE's owner, which is not always the parent's
+///
+/// `.eq('user_id', userId)` names `transaction_splits.user_id`, and so does the
+/// cloud's RLS policy on this table. Those two are usually the same person as
+/// the parent's owner and the schema does not require it — the harness has a
+/// fixture, `myLineOnTheirParent`, built precisely because `merge_categories`
+/// walks parents by one and lines by the other. Filtering on the parent instead
+/// would be a different question with the same name.
+///
+/// # The tie-break is this crate's own
+///
+/// `sort_order` is not unique — two lines can share one, and the pre-split
+/// fixtures in this repo start at 0 — so the cloud's two keys leave ties, and in
+/// Postgres a tie is resolved by whatever the executor felt like. `id` goes
+/// behind them for the reason [`crate::verbs::reads`] gives for all of them: a
+/// list that is drawn is a list that gets re-drawn.
+///
+/// # Errors
+/// [`crate::error::CoreError`] if the read fails.
+pub fn list_owned(connection: &Connection, user_id: &str) -> CoreResult<Vec<ListedSplit>> {
+    // EXPLAIN QUERY PLAN (measured against schema.sql, 50k lines):
+    //   SEARCH transaction_splits USING INDEX idx_splits_user_display (user_id=?)
+    //
+    // No temp B-tree. `idx_splits_user_display (user_id, transaction_id,
+    // sort_order, id)` was ADDED for this read and the measurement that bought
+    // it is in [`crate::verbs::reads`]: without it the plan is a search on
+    // `idx_splits_user_cat` followed by USE TEMP B-TREE FOR ORDER BY, which is a
+    // sort of the whole line set on every boot.
+    let mut statement = connection.prepare(&list_owned_sql())?;
+    collect(&mut statement, params![user_id])
+}
+
+/// One parent's lines, in display order, and only if they are this login's.
+///
+/// The port of `transactionService.getTransactionSplits(transactionId)`:
+/// `.select('*').eq('transaction_id', …).order('sort_order')`.
+///
+/// # The owner is a LOCAL addition, and it is not optional
+///
+/// That query names no owner at all — the cloud has RLS underneath it, and the
+/// policy on this table is `user_id = requesting_user_id()`, so the filter is
+/// there, it is simply not written in the client. A file has no RLS and can hold
+/// more than one login's rows (a restore from an account that had two, or the
+/// harness's own second user), so the same guard has to be written down. It is
+/// the same argument [`crate::verbs::reads`] makes for every read taking a
+/// required owner, and here it is not defence in depth: it is the only gate.
+///
+/// # Errors
+/// [`crate::error::CoreError`] if the read fails.
+pub fn list_for_parent(
+    connection: &Connection,
+    user_id: &str,
+    transaction_id: &str,
+) -> CoreResult<Vec<ListedSplit>> {
+    // EXPLAIN QUERY PLAN (measured against schema.sql):
+    //   SEARCH transaction_splits USING INDEX idx_splits_user_display
+    //          (user_id=? AND transaction_id=?)
+    //
+    // The index added for [`list_owned`] serves this read better than the one
+    // written for it: `idx_splits_user_display (user_id, transaction_id,
+    // sort_order, id)` is this query's two bound columns followed by its two
+    // sort keys, so nothing is sorted at all. Before it, the plan was
+    // `idx_splits_transaction` plus `USE TEMP B-TREE FOR LAST TERM OF ORDER BY`
+    // — the tie-break sorted within each run of equal `sort_order`, which is
+    // lines inside one parent and was accepted on slice 15's argument.
+    let mut statement = connection.prepare(&list_for_parent_sql())?;
+    collect(&mut statement, params![transaction_id, user_id])
+}
+
+/// The one mapper both reads share, because they differ by a WHERE clause and a
+/// second copy of eleven columns is a second place to forget one.
+fn collect(
+    statement: &mut rusqlite::Statement<'_>,
+    bound: impl rusqlite::Params,
+) -> CoreResult<Vec<ListedSplit>> {
+    let rows = statement.query_map(bound, |record| {
+        Ok(ListedSplit {
+            id: record.get(0)?,
+            transaction_id: record.get(1)?,
+            user_id: record.get(2)?,
+            category: record.get(3)?,
+            amount: Money::from_minor(record.get(4)?),
+            memo: record.get(5)?,
+            sort_order: record.get(6)?,
+            transfer_account_id: record.get(7)?,
+            linked_transfer_id: record.get(8)?,
+            created_at: record.get(9)?,
+            updated_at: record.get(10)?,
+        })
+    })?;
+
+    let mut lines = Vec::new();
+    for line in rows {
+        lines.push(line?);
+    }
+    Ok(lines)
+}

--- a/crates/wealth-core/src/verbs/mod.rs
+++ b/crates/wealth-core/src/verbs/mod.rs
@@ -418,9 +418,10 @@ pub use merge_categories::{merge_categories, MergeCategories, MergeCategoriesRes
 // same whether it is asking or writing; the module stays `pub` as well, because
 // its documentation is where the ordering and the query plans live.
 pub use reads::{
-    list_accounts, list_budgets, list_categories, list_closed_accounts, list_goals,
-    list_suggestion_dismissals, Accounts, Answered, Budgets, Categories, ClosedAccounts, Goals,
-    OwnedRead, SuggestionDismissals,
+    account_balances, list_accounts, list_budgets, list_categories, list_closed_accounts,
+    list_goals, list_suggestion_dismissals, list_transaction_splits, list_transactions, splits_for,
+    AccountBalances, Accounts, Answered, Budgets, Categories, ClosedAccounts, Goals, OwnedRead,
+    Splits, SplitsFor, SuggestionDismissals, TransactionSplits, Transactions,
 };
 pub use repair_claimed_transfer::{
     repair_claimed_transfer, RepairClaimedTransfer, RepairClaimedTransferResult,

--- a/crates/wealth-core/src/verbs/reads.rs
+++ b/crates/wealth-core/src/verbs/reads.rs
@@ -1,8 +1,10 @@
 //! The reads — the questions the app asks a file it has already opened.
 //!
-//! Six of them here: the accounts, the closed accounts, the categories, the
-//! budgets, the goals and the suggestion dismissals. They write nothing, they
-//! audit nothing, and they open no transaction, for the reason
+//! Ten of them here. Six are light — the accounts, the closed accounts, the
+//! categories, the budgets, the goals and the suggestion dismissals — and four
+//! are the ones that run over a person's whole history: the transactions, every
+//! split line, one parent's split lines, and the balances. They write nothing,
+//! they audit nothing, and they open no transaction, for the reason
 //! [`super::user_financial_data_is_empty`] gives: there is nothing to be atomic
 //! about, and a log line recording that somebody asked a question is noise in a
 //! log whose whole value is that every line in it is a change.
@@ -43,21 +45,47 @@
 //! also §6.4's absence from the other side — a verb that took a predicate would
 //! be a verb that took SQL eventually.
 //!
-//! The one thing that looks like a filter and is not: closed accounts are a
-//! SECOND VERB rather than a flag on the first. Two questions, two names, and a
-//! call site that cannot be misread.
+//! Two things look like a filter and are not. Closed accounts are a SECOND VERB
+//! rather than a flag on the first: two questions, two names, and a call site
+//! that cannot be misread. And [`splits_for`] takes a `transaction_id`, which is
+//! not a predicate over a set but the NAME OF A PARENT — the seam's own `…For`
+//! suffix, which exists so that `listTransactionSplits` (all of them) and
+//! `listTransactionSplitsFor` (one row's) are *"told apart by more than their
+//! arity at the call site"*.
+//!
+//! # ARCHIVED ROWS ARE IN BOTH ANSWERS, AND THAT IS THE POINT
+//!
+//! Two of the four verbs here touch the archive, and the trap is that the right
+//! answer is the SAME on both sides while the instinct is different:
+//!
+//! * [`list_transactions`] returns archived rows, with the flag as a column. The
+//!   boot query filters on `user_id` and nothing else; the register hides an
+//!   archived row in memory.
+//! * [`account_balances`] COUNTS archived rows. The RPC says so in its own
+//!   comment — *"archiving is a view flag and never moves a balance"*.
+//!
+//! R-1 is the second of those going wrong, and contract rule 82 is the test that
+//! catches it. But a port that "fixed" the FIRST one instead — filtering the
+//! list — would produce the same disagreement from the other end, because the
+//! client sums the list it was given. Two figures, one ledger: the only safe
+//! answer is that neither read has heard of the archive.
 //!
 //! # The order is part of the answer, and the last key is this crate's own
 //!
 //! Each read takes its ORDER BY from the query it is a port of:
 //!
 //! ```text
-//! list_accounts               created_at            accountService.getAccounts
-//! list_closed_accounts        created_at            accountService.getClosedAccounts
-//! list_categories             level, name           planningService.ensureCategories
-//! list_budgets                created_at            planningService.getBudgets
-//! list_goals                  created_at            planningService.getGoals
-//! list_suggestion_dismissals  dismissed_at DESC     suggestionDismissalService.list
+//! list_accounts               created_at              accountService.getAccounts
+//! list_closed_accounts        created_at              accountService.getClosedAccounts
+//! list_categories             level, name             planningService.ensureCategories
+//! list_budgets                created_at              planningService.getBudgets
+//! list_goals                  created_at              planningService.getGoals
+//! list_suggestion_dismissals  dismissed_at DESC       suggestionDismissalService.list
+//! list_transactions           date DESC, id DESC      transactionService.fetchTransactionPage
+//! list_transaction_splits     transaction_id, sort_order
+//!                                                     transactionService.getAllTransactionSplits
+//! splits_for                  sort_order              transactionService.getTransactionSplits
+//! account_balances            (none — see below)      account_balances() RPC
 //! ```
 //!
 //! and then adds `id` behind it, which **is not a port of anything**. The cloud
@@ -71,6 +99,24 @@
 //! and "nothing at all" in SQLite means whatever the sorter did last time —
 //! which is a visible reshuffle on a page nobody touched, and an unrepeatable
 //! differential spec.
+//!
+//! **Two of this slice's four are exceptions, in opposite directions.**
+//!
+//! [`list_transactions`] is the only read in the crate whose tie-break needed no
+//! decision: the cloud already states `.order('id', {ascending: false})` and
+//! calls it, in its own comment, a *"stable tiebreak for paging"*. Fifty-two
+//! pages of an unstably-ordered query hand the same row over twice and lose
+//! another, so the cloud had to settle what the others could leave open. Its
+//! whole ORDER BY is ported, tie-break included, and nothing here is this
+//! crate's own.
+//!
+//! [`account_balances`] is the other end: the RPC states NO order whatsoever —
+//! `GROUP BY` and nothing after it — because the client turns the answer into a
+//! `Map` the moment it lands. `ORDER BY a.id` is therefore entirely this crate's
+//! own, and it is enough by itself, `id` being the group key. It also changes
+//! what the differential harness may do: where the other reads compare an
+//! ordered list against an ordered list, the oracle for this one has to impose
+//! an order on a set to compare it at all, and says so.
 //!
 //! # EXPLAIN QUERY PLAN, measured against `scripts/local-sqlite/schema.sql`
 //!
@@ -100,39 +146,120 @@
 //! step with the cloud for a sort of fifty rows. What would change the answer:
 //! a read over `transactions` or `transaction_splits`, where the row counts are
 //! five orders of magnitude larger — which is why `idx_txn_balance_cover`
-//! exists and why slice 16's reads must be measured again rather than assumed
-//! to be like these.
+//! exists, and it is why the four below were MEASURED rather than assumed to be
+//! like these.
 //!
-//! # What is deliberately not here yet
+//! # THE HEAVY FOUR, MEASURED
 //!
-//! `list_transactions`, `list_transaction_splits`, `splits_for` and
-//! `account_balances` are the next slice's, and they are separated from these
-//! six by more than a queue: they are the reads whose plans have to be argued,
-//! and `account_balances` carries four properties that are each a named money
-//! bug if got wrong (PHASE3-PLAN §3). `load_boot` composes six reads into one
-//! transaction after that, and `collect_backup` is the backup group's.
+//! `crates/wealth-core/tests/reads_at_scale.rs` builds a ledger the size of a
+//! real one — 50,000 transactions across 12 accounts, 6,000 tags, 8,000 split
+//! lines, 1,000 of the transactions archived — and asserts every plan below. It
+//! is a test rather than a note because a note goes stale in silence, and it is
+//! R-12 made real: *"read verb full-scans → EXPLAIN assertion red"*.
+//!
+//! ```text
+//! list_transactions       SEARCH transactions USING INDEX idx_txn_user_page
+//!                                (user_id=?)                    53ms / 175ms
+//!   its tag pass          SCAN tt
+//!                         SEARCH t USING INDEX
+//!                                sqlite_autoindex_transactions_1 (id=?)
+//! list_transaction_splits SEARCH transaction_splits USING INDEX
+//!                                idx_splits_user_display (user_id=?)
+//!                                                              4.6ms / 12.8ms
+//! splits_for              SEARCH transaction_splits USING INDEX
+//!                                idx_splits_user_display
+//!                                (user_id=? AND transaction_id=?)
+//!                                                              0.9ms / 1.8ms
+//! account_balances        SEARCH a USING INDEX idx_accounts_user (user_id=?)
+//!                         SEARCH t USING COVERING INDEX idx_txn_balance_cover
+//!                                (account_id=? AND user_id=?) LEFT-JOIN
+//!                         USE TEMP B-TREE FOR GROUP BY
+//!                         USE TEMP B-TREE FOR ORDER BY        18.7ms / 34.8ms
+//! ```
+//!
+//! Times are whole verbs — SQL, mapping, `Money` rendering and all — as
+//! release / debug, on the author's machine. They are recorded, not asserted: a
+//! time bound is a bound on whichever machine runs it, and a flaky test teaches
+//! people to re-run tests until they pass. Three of the four are boot reads
+//! (`splits_for` is asked per row, when a split is opened), and together they
+//! come to ~76ms of release time — against the 2.7s of paged fetches the cloud
+//! RPC's own commentary measured for the transactions alone.
+//!
+//! **Three things in that table were decided by the measurement.**
+//!
+//! *A new index, `idx_splits_user_display (user_id, transaction_id, sort_order,
+//! id)`.* Without it, `list_transaction_splits` plans as `SCAN
+//! transaction_splits USING INDEX idx_splits_transaction` plus `USE TEMP B-TREE
+//! FOR LAST TERM OF ORDER BY` (8.9ms against 4.5ms, debug). The 2× is the lesser
+//! half: the word is SCAN, so the read walks every login's lines and discards
+//! the ones that are not the caller's, and a restored two-login file is exactly
+//! what the required owner exists for. The reasoning is written at the index in
+//! `schema.sql`. It also, unplanned, took the temp B-tree off `splits_for`.
+//!
+//! *An index NOT added.* `accounts(user_id, id)` was tried, to see whether
+//! ordering the outer loop of `account_balances` by the group key would let
+//! SQLite group without a sorter. MEASURED: 33.9ms → 32.9ms, which is noise.
+//! Not added — an index that buys nothing is write cost and one more thing to
+//! keep in step with the cloud.
+//!
+//! *A faster query NOT adopted.* `account_balances`'s two temp B-trees are what
+//! its SHAPE costs: a `LEFT JOIN` grouped per account puts 50k joined rows
+//! through a sorter, and two correlated subqueries do the same work in 3.4ms
+//! against 16.5ms (release). The port keeps the join anyway, and not out of
+//! conservatism: PHASE3-PLAN §3's fourth property is `COUNT(t.id)` and **not**
+//! `COUNT(*)`, and that property exists ONLY under a LEFT JOIN — rewritten, the
+//! two spellings become the same expression and the mutation that has to turn a
+//! named spec red stops being a mutation. Three properties survive the rewrite
+//! and one dies, on the one verb whose job is to be the independent check on a
+//! stored balance. Thirteen milliseconds is not the price of that. The test
+//! asserts the temp B-trees are PRESENT, so the day somebody rewrites this for
+//! speed they are sent to this paragraph.
+//!
+//! # What is still not here
+//!
+//! `load_boot` composes six reads into one transaction, and `collect_backup` is
+//! the backup group's.
 
 use rusqlite::Connection;
 use serde::{Deserialize, Serialize};
 
 use crate::error::CoreResult;
 use crate::row::account::{self, ListedAccount};
+use crate::row::balance::{self, AccountBalance};
 use crate::row::budget::{self, ListedBudget};
 use crate::row::category::{self, CategoryRow};
 use crate::row::dismissal::{self, DismissalRow};
 use crate::row::goal::{self, GoalRow};
+use crate::row::split::{self, ListedSplit};
+use crate::row::{self as transaction, ListedTransaction};
 
-/// The payload every read in this slice takes: one owner, and nothing else.
+/// The payload nine of the ten reads take: one owner, and nothing else.
 ///
-/// One type for six verbs because it is one argument for six verbs, and six
-/// identical struct definitions would be six places for the next person to add
-/// a filter to. The VERBS stay six — the enum's exhaustive dispatch is over
+/// One type for nine verbs because it is one argument for nine verbs, and nine
+/// identical struct definitions would be nine places for the next person to add
+/// a filter to. The VERBS stay nine — the enum's exhaustive dispatch is over
 /// variants, not over payload types.
 #[derive(Debug, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct OwnedRead {
     /// Whose rows. Required — see the module docs.
     pub user_id: String,
+}
+
+/// [`splits_for`]'s payload: an owner, and the parent whose lines are wanted.
+///
+/// The tenth read, and the only one that names anything narrower than a login.
+/// A second field rather than a second use of [`OwnedRead`] plus a filter,
+/// because `transaction_id` is not a predicate the caller composed — it is the
+/// subject of the question, and `deny_unknown_fields` is what keeps it the only
+/// one that can be sent.
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct SplitsFor {
+    /// Whose lines. Required, and locally it is the ONLY gate — see the verb.
+    pub user_id: String,
+    /// The split parent.
+    pub transaction_id: String,
 }
 
 /// A read's answer, in the shape the differential harness compares on.
@@ -187,6 +314,34 @@ pub struct Goals {
 pub struct SuggestionDismissals {
     /// Every dismissal, newest first, each with its subjects in role order.
     pub suggestion_dismissals: Vec<DismissalRow>,
+}
+
+/// The ledger itself.
+#[derive(Debug, Serialize)]
+pub struct Transactions {
+    /// Every transaction, newest first, ARCHIVED ONES INCLUDED.
+    pub transactions: Vec<ListedTransaction>,
+}
+
+/// Every split line in the file, for the reports that aggregate by category.
+#[derive(Debug, Serialize)]
+pub struct TransactionSplits {
+    /// Every line this login owns, parent by parent, in display order.
+    pub transaction_splits: Vec<ListedSplit>,
+}
+
+/// One transaction's split lines.
+#[derive(Debug, Serialize)]
+pub struct Splits {
+    /// The parent's lines in display order — empty when it is not a split.
+    pub splits: Vec<ListedSplit>,
+}
+
+/// What every account is worth, derived.
+#[derive(Debug, Serialize)]
+pub struct AccountBalances {
+    /// One entry per account, by id, including accounts with no transactions.
+    pub account_balances: Vec<AccountBalance>,
 }
 
 /// Every open account this login has.
@@ -268,6 +423,86 @@ pub fn list_suggestion_dismissals(
     Ok(Answered {
         answer: SuggestionDismissals {
             suggestion_dismissals: dismissal::list_all(connection, &command.user_id)?,
+        },
+    })
+}
+
+/// Every transaction this login has, newest first, **archived ones included**.
+///
+/// The port of the query the signed-in boot actually runs. See
+/// [`crate::row::ListedTransaction`] for the column set and the one column this
+/// file has not got, and this module's header for why the archive is not
+/// filtered here or anywhere else.
+///
+/// # Errors
+/// [`crate::error::CoreError::Storage`] if the read fails.
+#[allow(clippy::needless_pass_by_value)]
+pub fn list_transactions(
+    connection: &Connection,
+    command: OwnedRead,
+) -> CoreResult<Answered<Transactions>> {
+    Ok(Answered {
+        answer: Transactions {
+            transactions: transaction::list_owned(connection, &command.user_id)?,
+        },
+    })
+}
+
+/// Every split line this login owns, parent by parent, in display order.
+///
+/// # Errors
+/// [`crate::error::CoreError::Storage`] if the read fails.
+#[allow(clippy::needless_pass_by_value)]
+pub fn list_transaction_splits(
+    connection: &Connection,
+    command: OwnedRead,
+) -> CoreResult<Answered<TransactionSplits>> {
+    Ok(Answered {
+        answer: TransactionSplits {
+            transaction_splits: split::list_owned(connection, &command.user_id)?,
+        },
+    })
+}
+
+/// One transaction's split lines, in display order.
+///
+/// # An unsplit row and a stranger's row answer the same way
+///
+/// Both are `[]`, and that is deliberate rather than lazy. The cloud's query is
+/// `.eq('transaction_id', …)` under RLS: a row belonging to somebody else
+/// matches the filter and is then removed by the policy, so the caller gets an
+/// empty array and cannot tell it from a row with no lines. Answering
+/// differently here would tell a caller that an id they cannot see exists — the
+/// same reasoning [`crate::row::account::read_owned`] gives for not
+/// distinguishing "no such account" from "not your account".
+///
+/// # Errors
+/// [`crate::error::CoreError::Storage`] if the read fails.
+#[allow(clippy::needless_pass_by_value)]
+pub fn splits_for(connection: &Connection, command: SplitsFor) -> CoreResult<Answered<Splits>> {
+    Ok(Answered {
+        answer: Splits {
+            splits: split::list_for_parent(connection, &command.user_id, &command.transaction_id)?,
+        },
+    })
+}
+
+/// Every account's balance, DERIVED — never read off `accounts.balance`.
+///
+/// The port of `account_balances()`. Its four properties, each of which is a
+/// named money bug if got wrong, are documented at the SQL in
+/// [`crate::row::balance`], because that is where somebody would break one.
+///
+/// # Errors
+/// [`crate::error::CoreError::Storage`] if the read fails.
+#[allow(clippy::needless_pass_by_value)]
+pub fn account_balances(
+    connection: &Connection,
+    command: OwnedRead,
+) -> CoreResult<Answered<AccountBalances>> {
+    Ok(Answered {
+        answer: AccountBalances {
+            account_balances: balance::for_owner(connection, &command.user_id)?,
         },
     })
 }

--- a/crates/wealth-core/tests/reads.rs
+++ b/crates/wealth-core/tests/reads.rs
@@ -1,9 +1,10 @@
-//! Integration tests for the six read verbs.
+//! Integration tests for the ten read verbs.
 //!
-//! The differential proof lives in `scripts/local-sqlite/verbs.mjs`: seventeen
+//! The differential proof lives in `scripts/local-sqlite/verbs.mjs`: thirty-eight
 //! specs, each running one payload against the query the cloud actually issues
-//! and against this crate, and comparing the two answers element by element.
-//! What is here is the half with **no cloud counterpart to compare against**:
+//! — or, for `account_balances`, against the cloud FUNCTION itself — and
+//! comparing the two answers element by element. What is here is the half with
+//! **no cloud counterpart to compare against**:
 //!
 //! 1. **The tie-break.** Every read orders by the cloud's key and then by `id`,
 //!    and the second key is this crate's own — the cloud states none, so its
@@ -16,8 +17,16 @@
 //! 3. **The refusals that happen before a connection is touched** — an unknown
 //!    field, and a missing owner. Both are serde's, and both are the reason the
 //!    owner is a `String` rather than an `Option<String>` here.
-//! 4. **An empty file**, on all six verbs at once, which is a shape assertion:
+//! 4. **An empty file**, on all ten verbs at once, which is a shape assertion:
 //!    `[]` and not `null`, under the key the app reads.
+//!
+//! Slice 16's four added a fifth thing to the first item, and it is worth
+//! naming: `account_balances` has no ORDER BY AT ALL in the cloud —
+//! `GROUP BY` and nothing after it, because the client turns the answer into a
+//! `Map` the moment it arrives. So the whole of its order, not just a tie-break,
+//! is this crate's own, and there is nothing differential to say about it.
+//! The plans and the wall times at fifty thousand rows are a separate file,
+//! `reads_at_scale.rs`.
 //!
 //! All data is invented. This repo is public: no real payee, account number or
 //! figure appears anywhere in it.
@@ -28,8 +37,9 @@ use rusqlite::Connection;
 use wealth_core::command::{parse, Command};
 use wealth_core::db;
 use wealth_core::verbs::{
-    list_accounts, list_budgets, list_categories, list_closed_accounts, list_goals,
-    list_suggestion_dismissals, OwnedRead,
+    account_balances, list_accounts, list_budgets, list_categories, list_closed_accounts,
+    list_goals, list_suggestion_dismissals, list_transaction_splits, list_transactions, splits_for,
+    OwnedRead, SplitsFor,
 };
 
 const OWNER: &str = "11111111-1111-1111-1111-111111111111";
@@ -372,4 +382,254 @@ fn the_threshold_crosses_as_a_percentage_and_the_money_beside_it_as_money() {
     assert_eq!(budget.alert_threshold, "42.50");
     assert_eq!(budget.amount.to_decimal_string(), "123.45");
     assert_eq!(budget.spent.to_decimal_string(), "67.89");
+}
+
+// ── Slice 16: the heavy four ────────────────────────────────────────────────
+
+/// Two accounts, one row each, and a split whose two lines share a `sort_order`.
+///
+/// Everything a heavy read needs that the light ones did not: money to sum, a
+/// parent to hang lines off, and a tie the cloud states no rule for.
+fn a_small_ledger(connection: &Connection) {
+    connection
+        .execute_batch(&format!(
+            "INSERT INTO accounts (id, user_id, name, type, balance_minor,
+                                   initial_balance_minor, created_at, updated_at) VALUES
+               ('{RAINY_DAY}', '{OWNER}', 'Rainy day', 'savings', 1000, 1000,
+                '{SAME_INSTANT}', '{SAME_INSTANT}'),
+               ('{EVERYDAY}',  '{OWNER}', 'Everyday', 'checking', -2500, 0,
+                '{SAME_INSTANT}', '{SAME_INSTANT}');
+             INSERT INTO transactions (id, user_id, account_id, description, amount_minor,
+                                       type, date, category, is_split)
+               VALUES ('{CORNER_SHOP}', '{OWNER}', '{EVERYDAY}', 'Corner shop', -2500,
+                       'expense', '2024-03-01', '', 1);
+             INSERT INTO transaction_splits (id, transaction_id, user_id, category,
+                                             amount_minor, sort_order) VALUES
+               ('50000000-0000-0000-0000-0000000000b2', '{CORNER_SHOP}', '{OWNER}',
+                '{TRANSFER_ROOT}', -1000, 0),
+               ('50000000-0000-0000-0000-0000000000b1', '{CORNER_SHOP}', '{OWNER}',
+                '{TRANSFER_ROOT}', -1500, 0);"
+        ))
+        .expect("ledger");
+}
+
+#[test]
+fn two_split_lines_sharing_a_sort_order_come_back_in_id_order() {
+    let connection = fixture();
+    a_small_ledger(&connection);
+
+    let answered = list_transaction_splits(&connection, owner(OWNER)).expect("read");
+    let ids: Vec<&str> = answered
+        .answer
+        .transaction_splits
+        .iter()
+        .map(|line| line.id.as_str())
+        .collect();
+
+    // `sort_order` is not unique — the pre-split fixtures in this repo start
+    // every line at 0 — so the cloud's two keys leave this pair unordered, and
+    // in Postgres the answer under a tie is whatever the executor felt like.
+    // The `id` behind them is this crate's own; the b2 line was written FIRST
+    // and must come back second.
+    assert_eq!(
+        ids,
+        vec![
+            "50000000-0000-0000-0000-0000000000b1",
+            "50000000-0000-0000-0000-0000000000b2"
+        ]
+    );
+}
+
+#[test]
+fn one_parents_lines_break_the_same_tie_the_same_way() {
+    let connection = fixture();
+    a_small_ledger(&connection);
+
+    let answered = splits_for(
+        &connection,
+        SplitsFor { user_id: OWNER.to_owned(), transaction_id: CORNER_SHOP.to_owned() },
+    )
+    .expect("read");
+    let ids: Vec<&str> = answered.answer.splits.iter().map(|line| line.id.as_str()).collect();
+
+    // The two split reads share a tie-break because they share a table and an
+    // idea of display order. A parent whose lines came back one way in the edit
+    // modal and the other way in a report would be one bug reported twice.
+    assert_eq!(
+        ids,
+        vec![
+            "50000000-0000-0000-0000-0000000000b1",
+            "50000000-0000-0000-0000-0000000000b2"
+        ]
+    );
+}
+
+#[test]
+fn the_balances_come_back_by_account_id_because_the_cloud_states_no_order_at_all() {
+    let connection = fixture();
+    a_small_ledger(&connection);
+
+    let answered = account_balances(&connection, owner(OWNER)).expect("read");
+    let ids: Vec<&str> = answered
+        .answer
+        .account_balances
+        .iter()
+        .map(|balance| balance.account_id.as_str())
+        .collect();
+
+    // Rainy day is INSERTed first and Everyday's id sorts first. The RPC has no
+    // ORDER BY whatsoever, so unlike every other read there is no cloud key with
+    // a crate tie-break behind it: the whole order is stated here, and `id`
+    // alone is enough because it is the group key.
+    assert_eq!(ids, vec![EVERYDAY, RAINY_DAY]);
+}
+
+#[test]
+fn a_second_logins_rows_are_in_the_file_and_not_in_any_of_the_heavy_answers() {
+    let connection = fixture();
+    a_small_ledger(&connection);
+    connection
+        .execute_batch(&format!(
+            "INSERT INTO users (id, email) VALUES ('{STRANGER}', 'stranger@example.test');
+             INSERT INTO accounts (id, user_id, name, type, balance_minor, initial_balance_minor)
+               VALUES ('a0000000-0000-0000-0000-0000000000f9', '{STRANGER}', 'Not yours',
+                       'checking', -100, 0);
+             INSERT INTO transactions (id, user_id, account_id, description, amount_minor,
+                                       type, date)
+               VALUES ('70000000-0000-0000-0000-0000000000f9', '{STRANGER}',
+                       'a0000000-0000-0000-0000-0000000000f9', 'Theirs', -100, 'expense',
+                       '2024-03-01');"
+        ))
+        .expect("stranger");
+
+    // There is no RLS in a file, so each of these is the whole gate. The balance
+    // read is the one that would be noticed: a stranger's account in this answer
+    // is a stranger's money in the dashboard's net worth.
+    let listed = list_transactions(&connection, owner(OWNER)).expect("read");
+    assert_eq!(listed.answer.transactions.len(), 1);
+    assert_eq!(listed.answer.transactions[0].id, CORNER_SHOP);
+
+    let balances = account_balances(&connection, owner(OWNER)).expect("read");
+    let ids: Vec<&str> = balances
+        .answer
+        .account_balances
+        .iter()
+        .map(|balance| balance.account_id.as_str())
+        .collect();
+    assert_eq!(ids, vec![EVERYDAY, RAINY_DAY]);
+}
+
+#[test]
+fn a_parent_of_mine_asked_for_by_a_stranger_answers_with_nothing() {
+    let connection = fixture();
+    a_small_ledger(&connection);
+    connection
+        .execute_batch(&format!(
+            "INSERT INTO users (id, email) VALUES ('{STRANGER}', 'stranger@example.test');"
+        ))
+        .expect("stranger");
+
+    let answered = splits_for(
+        &connection,
+        SplitsFor { user_id: STRANGER.to_owned(), transaction_id: CORNER_SHOP.to_owned() },
+    )
+    .expect("read");
+
+    // `splits_for`'s owner is a LOCAL addition — the cloud's query names no
+    // owner because RLS is underneath it. An empty answer rather than a refusal,
+    // for the reason the account reader gives: telling "no such row" from "not
+    // your row" confirms an id exists to a caller who may not see it.
+    assert!(answered.answer.splits.is_empty());
+}
+
+#[test]
+fn the_heavy_reads_of_an_empty_file_are_empty_arrays_under_their_own_keys() {
+    let connection = fixture();
+
+    // Four shapes, and the far side maps all four by name. `null` under any of
+    // them is a different bug from `[]`: one says "nothing here" and the other
+    // says "this read does not work".
+    let transactions = list_transactions(&connection, owner(OWNER)).expect("read");
+    assert_eq!(
+        serde_json::to_string(&transactions).expect("json"),
+        r#"{"answer":{"transactions":[]}}"#
+    );
+    let splits = list_transaction_splits(&connection, owner(OWNER)).expect("read");
+    assert_eq!(
+        serde_json::to_string(&splits).expect("json"),
+        r#"{"answer":{"transaction_splits":[]}}"#
+    );
+    let one = splits_for(
+        &connection,
+        SplitsFor { user_id: OWNER.to_owned(), transaction_id: CORNER_SHOP.to_owned() },
+    )
+    .expect("read");
+    assert_eq!(serde_json::to_string(&one).expect("json"), r#"{"answer":{"splits":[]}}"#);
+    let balances = account_balances(&connection, owner(OWNER)).expect("read");
+    assert_eq!(
+        serde_json::to_string(&balances).expect("json"),
+        r#"{"answer":{"account_balances":[]}}"#
+    );
+}
+
+#[test]
+fn the_heavy_reads_parse_to_their_own_variants_and_only_splits_for_takes_a_parent() {
+    let parsed = |verb: &str| {
+        parse(&format!(r#"{{"verb":"{verb}","payload":{{"user_id":"{OWNER}"}}}}"#)).expect(verb)
+    };
+    assert!(matches!(parsed("list_transactions"), Command::ListTransactions(_)));
+    assert!(matches!(parsed("list_transaction_splits"), Command::ListTransactionSplits(_)));
+    assert!(matches!(parsed("account_balances"), Command::AccountBalances(_)));
+
+    let one = parse(&format!(
+        r#"{{"verb":"splits_for","payload":{{"user_id":"{OWNER}","transaction_id":"{CORNER_SHOP}"}}}}"#
+    ))
+    .expect("splits_for");
+    assert!(matches!(one, Command::SplitsFor(_)));
+}
+
+#[test]
+fn splits_for_without_its_parent_is_refused_before_a_file_is_opened() {
+    // The seam's `…For` suffix names a parent, and the payload requires one:
+    // a `splits_for` that fell back to the whole store on a missing id would put
+    // another transaction's money in the edit modal's box.
+    let refusal =
+        parse(&format!(r#"{{"verb":"splits_for","payload":{{"user_id":"{OWNER}"}}}}"#))
+            .expect_err("refused");
+    let json = serde_json::to_string(&refusal).expect("json");
+    assert!(json.contains("missing field"), "{json}");
+    assert!(json.contains("transaction_id"), "{json}");
+}
+
+#[test]
+fn a_balance_read_carrying_a_date_filter_is_refused_by_name() {
+    // `deny_unknown_fields` on the shared payload is what makes "none of them
+    // takes a filter" a fact rather than a claim — and on THIS verb it is worth
+    // a test of its own, because "balances as at a date" is the most plausible
+    // thing anybody will one day try to send.
+    let refusal = parse(&format!(
+        r#"{{"verb":"account_balances","payload":{{"user_id":"{OWNER}","as_at":"2024-01-01"}}}}"#
+    ))
+    .expect_err("refused");
+    let json = serde_json::to_string(&refusal).expect("json");
+    assert!(json.contains("unknown_field"), "{json}");
+    assert!(json.contains("as_at"), "{json}");
+}
+
+#[test]
+fn a_balance_is_money_and_a_count_is_not() {
+    let connection = fixture();
+    a_small_ledger(&connection);
+
+    let answered = account_balances(&connection, owner(OWNER)).expect("read");
+    let json = serde_json::to_string(&answered.answer.account_balances[0]).expect("json");
+
+    // The two numbers in this answer are different KINDS of number, and the
+    // serialisation has to say so: the balance is a decimal string because it is
+    // money and money.rs is the one place minor units become text, and the count
+    // is a JSON number because it is a count. A port that rendered the count as
+    // "1" would be inventing a currency for it; one that rendered the balance as
+    // -2500 would be handing the client an integer to divide.
+    assert!(json.contains(r#""balance":"-25.00""#), "{json}");
+    assert!(json.contains(r#""txn_count":1"#), "{json}");
 }

--- a/crates/wealth-core/tests/reads_at_scale.rs
+++ b/crates/wealth-core/tests/reads_at_scale.rs
@@ -1,0 +1,430 @@
+//! What the four heavy reads do to a ledger the size of a real one.
+//!
+//! Slice 15's six reads accepted `USE TEMP B-TREE FOR ORDER BY` and wrote down
+//! why: *"the sort happens after the index has cut the table down to one owner's
+//! rows, and on these five tables that is tens to low hundreds"*. It also wrote
+//! down the condition under which that argument stops holding — *"a read over
+//! `transactions` or `transaction_splits`, where the row counts are five orders
+//! of magnitude larger"* — and said slice 16's reads *"must be measured again
+//! rather than assumed to be like these"*.
+//!
+//! This is that measurement, and it is a TEST rather than a note because a note
+//! goes stale in silence. R-12: a read verb that full-scans must turn something
+//! red. Every plan below is asserted, not printed and hoped over, and each
+//! assertion is made against the query the reader itself prepares — the SQL
+//! comes from the crate, never from a copy in this file, because a plan
+//! assertion written against a copy is one that survives the query changing.
+//!
+//! The wall times ARE printed rather than asserted. A time bound is a bound on
+//! whichever machine happens to run it, and a flaky test that fails on a busy
+//! laptop teaches people to re-run tests until they pass. Run it with
+//! `cargo test --test reads_at_scale -- --nocapture` to see them; the figures
+//! recorded in `crate::verbs::reads` came from that.
+//!
+//! The ledger built here is 50,000 transactions across 12 accounts, with 6,000
+//! tags, 8,000 split lines and 1,000 archived rows. All of it is invented: this
+//! repo is public, and no real payee, account number or figure appears in it.
+
+#![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
+// The fixture builder counts rows and spreads them over accounts and dates.
+// `arithmetic_side_effects` is denied crate-wide because MONEY arithmetic must
+// be checked; loop indices are not money, and writing `checked_rem` around a
+// modulo of a loop counter would make this file harder to read without making
+// any figure in the app safer. Every amount below is a literal.
+#![allow(clippy::arithmetic_side_effects)]
+
+use std::path::PathBuf;
+use std::sync::OnceLock;
+use std::time::Instant;
+
+use rusqlite::Connection;
+use tempfile::TempDir;
+use wealth_core::db;
+use wealth_core::row;
+use wealth_core::verbs::{
+    account_balances, list_transaction_splits, list_transactions, splits_for, OwnedRead, SplitsFor,
+};
+
+const OWNER: &str = "11111111-1111-1111-1111-111111111111";
+const TRANSFER_ROOT: &str = "c0000000-0000-0000-0000-000000000001";
+
+/// Big enough to be the thing the plan says it is. The owner's own MS Money
+/// history is ~51k rows; the RPC this slice ports was written for *"50k+"*.
+const TRANSACTIONS: usize = 50_000;
+const ACCOUNTS: usize = 12;
+const TAGGED: usize = 3_000;
+const SPLIT_PARENTS: usize = 4_000;
+const ARCHIVED: usize = 1_000;
+
+/// The ledger, built ONCE and opened per test.
+///
+/// Built into a real file rather than memory, and shared, for two reasons that
+/// happen to point the same way: fifty thousand rows take a moment to write and
+/// six tests should not each pay for it, and a plan measured on a file is a plan
+/// measured on the thing the app will actually open. Every test here only reads,
+/// so several connections to one file is exactly the situation SQLite is for.
+static LEDGER: OnceLock<(TempDir, PathBuf)> = OnceLock::new();
+
+fn a_real_sized_ledger() -> Connection {
+    let (_directory, path) = LEDGER.get_or_init(build_the_ledger);
+    db::open(path).expect("open")
+}
+
+/// A ledger of the size the RPC was written for, built in one transaction.
+fn build_the_ledger() -> (TempDir, PathBuf) {
+    let directory = tempfile::tempdir().expect("tempdir");
+    let path = directory.path().join("scale.db");
+    // `Connection::open` to CREATE it and `db::configure` to put it in the state
+    // the schema's guarantees hold in — the same two steps `wealth-core-cli
+    // --apply-schema` takes, because `db::open` deliberately refuses to create a
+    // file that is not there.
+    let connection = Connection::open(&path).expect("create");
+    db::configure(&connection).expect("configure");
+    wealth_core::apply_schema(&connection).expect("schema");
+    connection
+        .execute_batch(&format!(
+            "INSERT INTO users (id, email) VALUES ('{OWNER}', 'harness@example.test');
+             INSERT INTO categories (id, user_id, name, type, level)
+               VALUES ('{TRANSFER_ROOT}', '{OWNER}', 'Transfer', 'both', 'type'),
+                      ('c0000000-0000-0000-0000-000000000002', '{OWNER}', 'Outgoings',
+                       'expense', 'type');"
+        ))
+        .expect("seed");
+
+    connection.execute_batch("BEGIN").expect("begin");
+    {
+        let mut account = connection
+            .prepare(
+                "INSERT INTO accounts (id, user_id, name, type, balance_minor,
+                                       initial_balance_minor)
+                 VALUES (?1, ?2, ?3, 'checking', 0, ?4)",
+            )
+            .expect("prepare account");
+        for index in 0..ACCOUNTS {
+            account
+                .execute(rusqlite::params![
+                    account_id(index),
+                    OWNER,
+                    format!("Account {index}"),
+                    i64::try_from(index).unwrap() * 100,
+                ])
+                .expect("account");
+        }
+
+        let mut transaction = connection
+            .prepare(
+                "INSERT INTO transactions (id, user_id, account_id, description, amount_minor,
+                                           type, date, category, archived)
+                 VALUES (?1, ?2, ?3, ?4, ?5, 'expense', ?6, 'c0000000-0000-0000-0000-000000000002',
+                         ?7)",
+            )
+            .expect("prepare transaction");
+        for index in 0..TRANSACTIONS {
+            transaction
+                .execute(rusqlite::params![
+                    transaction_id(index),
+                    OWNER,
+                    account_id(index % ACCOUNTS),
+                    format!("Payee {}", index % 400),
+                    -100_i64 - i64::try_from(index % 900).unwrap(),
+                    a_date(index),
+                    i64::from(index < ARCHIVED),
+                ])
+                .expect("transaction");
+        }
+
+        let mut tag = connection
+            .prepare("INSERT INTO transaction_tags (transaction_id, tag) VALUES (?1, ?2)")
+            .expect("prepare tag");
+        for index in 0..TAGGED {
+            // Two tags apiece, so the fold has something to fold rather than a
+            // one-to-one map that any implementation would get right.
+            for name in ["holiday", "receipted"] {
+                tag.execute(rusqlite::params![transaction_id(index), name]).expect("tag");
+            }
+        }
+
+        // A split parent's lines must sum to it (S-1) and there must be at least
+        // two (S-2), so each parent takes its own amount split in two. Written
+        // behind the guard the schema's own protections require.
+        connection.execute_batch("INSERT INTO _rpc_guard VALUES ('split')").expect("guard");
+        let mut parent = connection
+            .prepare("UPDATE transactions SET is_split = 1, category = '' WHERE id = ?1")
+            .expect("prepare parent");
+        let mut line = connection
+            .prepare(
+                "INSERT INTO transaction_splits (id, transaction_id, user_id, category,
+                                                 amount_minor, sort_order)
+                 VALUES (?1, ?2, ?3, 'c0000000-0000-0000-0000-000000000002', ?4, ?5)",
+            )
+            .expect("prepare line");
+        for index in 0..SPLIT_PARENTS {
+            let amount = -100_i64 - i64::try_from(index % 900).unwrap();
+            parent.execute(rusqlite::params![transaction_id(index)]).expect("parent");
+            line.execute(rusqlite::params![
+                format!("50000000-0000-0000-0000-{index:012}"),
+                transaction_id(index),
+                OWNER,
+                amount + 50,
+                0,
+            ])
+            .expect("line");
+            line.execute(rusqlite::params![
+                format!("51000000-0000-0000-0000-{index:012}"),
+                transaction_id(index),
+                OWNER,
+                -50,
+                // A SHARED sort_order on the second line of every fourth parent,
+                // because `sort_order` is not unique and the tie-break is what
+                // keeps the answer repeatable.
+                if index % 4 == 0 { 0 } else { 1 },
+            ])
+            .expect("line");
+        }
+        connection.execute_batch("DELETE FROM _rpc_guard").expect("guard off");
+
+        // B-1 on every account, so the file this measures against is a file the
+        // ledger would accept. `verify_integrity` would otherwise open with
+        // twelve `balance_identity` violations.
+        connection
+            .execute_batch(
+                "UPDATE accounts SET balance_minor = initial_balance_minor + COALESCE(
+                   (SELECT SUM(amount_minor) FROM transactions t WHERE t.account_id = accounts.id),
+                   0)",
+            )
+            .expect("balances");
+    }
+    connection.execute_batch("COMMIT").expect("commit");
+    // ANALYZE, because a plan the planner chose WITHOUT statistics is a plan the
+    // app will not get: `db::open` reads `sqlite_stat1` if it is there, and a
+    // real file that has been written to for a year has it.
+    connection.execute_batch("ANALYZE").expect("analyze");
+    drop(connection);
+    (directory, path)
+}
+
+fn account_id(index: usize) -> String {
+    format!("a0000000-0000-0000-0000-{index:012}")
+}
+
+fn transaction_id(index: usize) -> String {
+    format!("70000000-0000-0000-0000-{index:012}")
+}
+
+/// Four years of dates, many rows to a day — which is what makes `date DESC`
+/// alone an ambiguous order and the ported `id DESC` tie-break load-bearing.
+fn a_date(index: usize) -> String {
+    let day = index % 28 + 1;
+    let month = (index / 28) % 12 + 1;
+    let year = 2021 + (index / (28 * 12)) % 4;
+    format!("{year:04}-{month:02}-{day:02}")
+}
+
+/// `EXPLAIN QUERY PLAN`, as the lines SQLite reports.
+///
+/// The bound values are the REAL ones, not placeholders: SQLite's planner is
+/// allowed to choose differently for a value it can see, so explaining a query
+/// with unbound parameters would be explaining a query nobody runs.
+fn plan(connection: &Connection, sql: &str, bound: &[&str]) -> Vec<String> {
+    let mut statement = connection.prepare(&format!("EXPLAIN QUERY PLAN {sql}")).expect("explain");
+    statement
+        .query_map(rusqlite::params_from_iter(bound), |record| record.get::<_, String>(3))
+        .expect("explain rows")
+        .map(|line| line.expect("line"))
+        .collect::<Vec<_>>()
+}
+
+fn report(name: &str, elapsed: std::time::Duration, rows: usize, plan: &[String]) {
+    println!("── {name}: {rows} rows in {:?}", elapsed);
+    for line in plan {
+        println!("     {line}");
+    }
+}
+
+// ── The plans ──────────────────────────────────────────────────────────────
+
+#[test]
+fn the_transaction_read_searches_an_index_and_never_sorts() {
+    let connection = a_real_sized_ledger();
+
+    let started = Instant::now();
+    let answered = list_transactions(&connection, OwnedRead { user_id: OWNER.to_owned() })
+        .expect("read");
+    let elapsed = started.elapsed();
+    let plan = plan(&connection, &row::list_owned_sql(), &[OWNER]);
+    report("list_transactions", elapsed, answered.answer.transactions.len(), &plan);
+
+    assert_eq!(answered.answer.transactions.len(), TRANSACTIONS);
+    let plan = plan.join(" | ");
+    // The whole of R-12 for this read. `idx_txn_user_page (user_id, date DESC,
+    // id DESC)` IS the query's WHERE and ORDER BY, so there is nothing to sort
+    // afterwards; a plan carrying either of the other two words is a bug report
+    // rather than a merge.
+    assert!(plan.contains("SEARCH transactions USING INDEX idx_txn_user_page"), "{plan}");
+    assert!(!plan.contains("SCAN transactions"), "{plan}");
+    assert!(!plan.contains("TEMP B-TREE"), "{plan}");
+}
+
+#[test]
+fn the_tag_pass_walks_the_child_table_once_and_never_sorts() {
+    let connection = a_real_sized_ledger();
+
+    let plan = plan(&connection, &row::owned_tags_sql(), &[OWNER]).join(" | ");
+    // A SCAN, and the one place in the read family where a scan is the right
+    // plan: `transaction_tags` grows with a person's VOCABULARY, not with their
+    // ledger, and it is `WITHOUT ROWID` so the walk is already in the order the
+    // query asks for. What must not appear is a sort — that would mean the
+    // planner drove from `transactions` and had to re-order 50k rows' worth of
+    // tags afterwards.
+    //
+    // The plan names the query's ALIASES (`tt`, `t`), not the tables. That is
+    // SQLite reporting what the statement said, and asserting on the alias is
+    // asserting on the statement rather than on a name that happens to match.
+    assert!(plan.contains("SCAN tt"), "{plan}");
+    assert!(plan.contains("SEARCH t USING INDEX sqlite_autoindex_transactions_1"), "{plan}");
+    assert!(!plan.contains("TEMP B-TREE"), "{plan}");
+}
+
+#[test]
+fn the_whole_store_split_read_searches_an_index_and_never_sorts() {
+    let connection = a_real_sized_ledger();
+
+    let started = Instant::now();
+    let answered = list_transaction_splits(&connection, OwnedRead { user_id: OWNER.to_owned() })
+        .expect("read");
+    let elapsed = started.elapsed();
+    let plan = plan(&connection, &row::split::list_owned_sql(), &[OWNER]);
+    report("list_transaction_splits", elapsed, answered.answer.transaction_splits.len(), &plan);
+
+    assert_eq!(answered.answer.transaction_splits.len(), SPLIT_PARENTS * 2);
+    let plan = plan.join(" | ");
+    // `idx_splits_user_display` exists BECAUSE of this assertion — see the
+    // measurement in `crate::verbs::reads`. Without it the plan is a search on
+    // `idx_splits_user_cat` plus USE TEMP B-TREE FOR ORDER BY.
+    assert!(
+        plan.contains("SEARCH transaction_splits USING INDEX idx_splits_user_display"),
+        "{plan}"
+    );
+    assert!(!plan.contains("SCAN transaction_splits"), "{plan}");
+    assert!(!plan.contains("TEMP B-TREE"), "{plan}");
+}
+
+#[test]
+fn one_parents_lines_are_found_by_the_parent_index() {
+    let connection = a_real_sized_ledger();
+
+    let parent = transaction_id(7);
+    let started = Instant::now();
+    let answered = splits_for(
+        &connection,
+        SplitsFor { user_id: OWNER.to_owned(), transaction_id: parent.clone() },
+    )
+    .expect("read");
+    let elapsed = started.elapsed();
+    let plan = plan(&connection, &row::split::list_for_parent_sql(), &[&parent, OWNER]);
+    report("splits_for", elapsed, answered.answer.splits.len(), &plan);
+
+    assert_eq!(answered.answer.splits.len(), 2);
+    let plan = plan.join(" | ");
+    // `idx_splits_user_display` was added for the WHOLE-STORE read above, and it
+    // turns out to serve this one better than the index written for it: both of
+    // this query's bound columns are the new index's first two, and its last two
+    // are this query's ORDER BY. Before it, the plan was
+    //
+    //   SEARCH … USING INDEX idx_splits_transaction (transaction_id=?)
+    //   USE TEMP B-TREE FOR LAST TERM OF ORDER BY
+    //
+    // — the `id` tie-break sorted inside each run of equal `sort_order`. That
+    // was accepted (a run is lines within one parent) and is now simply gone.
+    assert!(
+        plan.contains("SEARCH transaction_splits USING INDEX idx_splits_user_display"),
+        "{plan}"
+    );
+    assert!(!plan.contains("SCAN transaction_splits"), "{plan}");
+    assert!(!plan.contains("TEMP B-TREE"), "{plan}");
+}
+
+#[test]
+fn the_balance_aggregate_is_answered_out_of_a_covering_index() {
+    let connection = a_real_sized_ledger();
+
+    let started = Instant::now();
+    let answered = account_balances(&connection, OwnedRead { user_id: OWNER.to_owned() })
+        .expect("read");
+    let elapsed = started.elapsed();
+    let plan = plan(&connection, row::balance::FOR_OWNER_SQL, &[OWNER]);
+    report("account_balances", elapsed, answered.answer.account_balances.len(), &plan);
+
+    assert_eq!(answered.answer.account_balances.len(), ACCOUNTS);
+    let plan = plan.join(" | ");
+    // COVERING is the word that matters: the sum is answered without touching
+    // the transactions table at all, which is what `idx_txn_balance_cover
+    // (account_id, user_id, amount_minor, id)` carries its last two columns for.
+    // The plan names the aliases the statement uses.
+    assert!(plan.contains("SEARCH t USING COVERING INDEX idx_txn_balance_cover"), "{plan}");
+    assert!(plan.contains("SEARCH a USING INDEX idx_accounts_user"), "{plan}");
+    assert!(!plan.contains("SCAN t"), "{plan}");
+    // This verb's two temp B-trees ARE asserted — present, and deliberately so.
+    // They are what the RPC's SHAPE costs: a LEFT JOIN grouped by the account is
+    // 50k joined rows through a sorter, and rewriting it as two correlated
+    // subqueries removes both (MEASURED: 16.5ms → 3.4ms, release profile).
+    //
+    // The port keeps the shape anyway, and the reason is not conservatism.
+    // PHASE3-PLAN §3's fourth property is `COUNT(t.id)` and NOT `COUNT(*)`, and
+    // that property EXISTS ONLY UNDER A LEFT JOIN — in the subquery form the two
+    // spellings are the same expression, so the mutation that must turn a named
+    // spec red would stop being a mutation at all. Three properties survive the
+    // rewrite and one dies, on a verb whose whole job is to be the independent
+    // check on the stored balance. Thirteen milliseconds is not the price of
+    // that.
+    //
+    // Asserting their PRESENCE rather than their absence is what makes the
+    // trade-off visible: the day somebody rewrites this query for speed, this
+    // line fails and sends them to the paragraph above.
+    assert!(plan.contains("USE TEMP B-TREE FOR GROUP BY"), "{plan}");
+}
+
+// ── The answers, at this size ──────────────────────────────────────────────
+
+#[test]
+fn the_balances_agree_with_the_ledger_the_client_would_sum() {
+    let connection = a_real_sized_ledger();
+
+    let balances = account_balances(&connection, OwnedRead { user_id: OWNER.to_owned() })
+        .expect("read")
+        .answer
+        .account_balances;
+    let listed = list_transactions(&connection, OwnedRead { user_id: OWNER.to_owned() })
+        .expect("read")
+        .answer
+        .transactions;
+
+    // The two figures the dashboard shows at once: the aggregate that lands
+    // first and the client's own sum over the rows that land second. They have
+    // to agree to the penny at 50,000 rows, or the page visibly changes its mind
+    // about how much money there is. Both are read as decimal STRINGS and
+    // compared as minor units through the ledger's own parser — nothing here
+    // parses money as a float.
+    for balance in &balances {
+        let opening: i64 = connection
+            .query_row(
+                "SELECT initial_balance_minor FROM accounts WHERE id = ?1",
+                rusqlite::params![balance.account_id],
+                |record| record.get(0),
+            )
+            .expect("opening");
+        let summed: i64 = listed
+            .iter()
+            .filter(|row| row.account_id == balance.account_id)
+            .map(|row| row.amount.minor())
+            .sum::<i64>()
+            + opening;
+        assert_eq!(balance.balance.minor(), summed, "account {}", balance.account_id);
+    }
+
+    // And the archived thousand are in BOTH of those sums, which is R-1 stated
+    // at the size it would actually be noticed.
+    assert_eq!(listed.iter().filter(|row| row.archived).count(), ARCHIVED);
+    let counted: i64 = balances.iter().map(|balance| balance.txn_count).sum();
+    assert_eq!(counted, i64::try_from(TRANSACTIONS).unwrap());
+}

--- a/scripts/local-sqlite/lib/verb-postgres.mjs
+++ b/scripts/local-sqlite/lib/verb-postgres.mjs
@@ -80,6 +80,18 @@ const ROW_JSON = `jsonb_build_object(
 // this oracle would make the harness agree with the port about a thing the cloud
 // never said. So these queries carry exactly the client's ORDER BY, and every
 // spec that compares them uses a fixture whose sort key is distinct.
+//
+// ONE READ IS AN EXCEPTION AND IT IS WRITTEN IN: `list_transactions` orders by
+// `date DESC, id DESC`, and the second key is the CLOUD's — the client states it
+// and calls it, in its own comment, a "stable tiebreak for paging". Fifty-two
+// pages of an unstably-ordered query hand the same row over twice and lose
+// another, so the cloud had to settle what the other reads could leave open.
+// Leaving it out here would be the harness pretending the cloud is vaguer than
+// it is.
+//
+// AND ONE VERB IS NOT A QUERY AT ALL: `account_balances` IS a Postgres function,
+// so its oracle is that function, called for real — see its entry below for how
+// the identity it takes from a JWT is supplied.
 
 /** A numeric(_,2) column as the decimal string both engines must agree on. */
 const money = (expr) => `(${expr})::text`;
@@ -223,6 +235,74 @@ const DISMISSAL_JSON = `jsonb_build_object(
   'subject_key', d.subject_key,
   'subject_ids', COALESCE(to_jsonb(d.subject_ids), '[]'::jsonb),
   'dismissed_at', ${stamp('d.dismissed_at')}
+)`;
+
+/**
+ * One `transactions` row, in the twenty-two keys
+ * `crate::row::ListedTransaction` serialises — which are
+ * `BOOT_TRANSACTION_COLUMNS` minus one, and NOT `select('*')`.
+ *
+ * The boot's column list is explicit and measured (~38% of the payload was
+ * columns nothing reads), so the ten columns it omits are omitted here too:
+ * `user_id`, the metadata blob, `merchant_name`, `location_city`,
+ * `location_country`, `payment_channel`, `external_transaction_id`,
+ * `import_source`, `import_source_id`, and the feed's `plaid_transaction_id`.
+ *
+ * ONE CLOUD COLUMN IS IN THE BOOT LIST AND DELIBERATELY NOT PROJECTED:
+ * `is_reconciled`, added by `20260810200000_marking_is_not_reconciling.sql` and
+ * not yet in `scripts/local-sqlite/schema.sql`. Projecting a key the local
+ * answer cannot have would report a schema gap as a per-spec divergence; the gap
+ * is recorded in the crate's `row.rs`, where a reader of the read will meet it,
+ * together with what it costs (a local file cannot tell a marked row from a
+ * reconciled one — the same degradation the cloud's own fallback ladder accepts
+ * for a database that has not had the migration applied).
+ */
+const TRANSACTION_JSON = `jsonb_build_object(
+  'id', t.id,
+  'account_id', t.account_id,
+  'amount', ${money('t.amount')},
+  'archived', t.archived,
+  'category', t.category,
+  'category_confirmed', t.category_confirmed,
+  'category_id', t.category_id,
+  'created_at', ${stamp('t.created_at')},
+  'date', t.date::text,
+  'description', t.description,
+  'is_cleared', t.is_cleared,
+  'is_recurring', t.is_recurring,
+  'is_split', t.is_split,
+  'linked_transfer_id', t.linked_transfer_id,
+  'linked_transfer_split_id', t.linked_transfer_split_id,
+  'needs_review', t.needs_review,
+  'notes', t.notes,
+  'statement_sequence', t.statement_sequence,
+  'tags', COALESCE(to_jsonb(t.tags), '[]'::jsonb),
+  'type', t.type,
+  'updated_at', ${stamp('t.updated_at')},
+  'transfer_account_id', t.transfer_account_id
+)`;
+
+/**
+ * One `transaction_splits` row, in the eleven keys `ListedSplit` serialises —
+ * the whole row, because both split reads are `.select('*')`.
+ *
+ * The app's own mapper reads eight of the eleven and ignores `user_id`,
+ * `created_at` and `updated_at`. That is the app's business: what a read
+ * projects is what the query projects, and narrowing it here would be the
+ * harness deciding on the app's behalf that a column will never be wanted.
+ */
+const SPLIT_JSON = `jsonb_build_object(
+  'id', s.id,
+  'transaction_id', s.transaction_id,
+  'user_id', s.user_id,
+  'category', s.category,
+  'amount', ${money('s.amount')},
+  'memo', s.memo,
+  'sort_order', s.sort_order,
+  'transfer_account_id', s.transfer_account_id,
+  'linked_transfer_id', s.linked_transfer_id,
+  'created_at', ${stamp('s.created_at')},
+  'updated_at', ${stamp('s.updated_at')}
 )`;
 
 /** A read's answer: one named key holding the list, or an empty list. */
@@ -637,6 +717,112 @@ const VERBS = {
         WHERE d.user_id = (${payloadLiteral}::jsonb->>'user_id')::uuid`,
       'd.dismissed_at DESC',
     ),
+
+  // ── The heavy four ─────────────────────────────────────────────────────────
+
+  // transactionService.fetchTransactionPage — the query the signed-in boot
+  // actually runs:
+  //   .from('transactions').select(BOOT_TRANSACTION_COLUMNS)
+  //   .eq('user_id', userId)
+  //   .order('date', { ascending: false })
+  //   .order('id', { ascending: false })    // stable tiebreak for paging
+  //   .range(from, to)
+  //
+  // NO ARCHIVED FILTER, and that is the query rather than an omission here: the
+  // archive is a VIEW flag, the flag rides back as a column, and the register
+  // does its hiding in memory. It is the same fact `account_balances` below
+  // states from the other end, and R-1 is what happens when one of the two
+  // forgets it.
+  //
+  // The `.range()` is not transcribed because it is not part of the question: it
+  // is PostgREST's 1,000-row response cap, which the client walks ~52 times to
+  // ask ONE thing. A file answers it once (DESIGN's "one crossing"), and a
+  // harness that paged would be comparing the transport rather than the read.
+  list_transactions: (payloadLiteral) =>
+    listed(
+      'transactions',
+      TRANSACTION_JSON,
+      `public.transactions t
+        WHERE t.user_id = (${payloadLiteral}::jsonb->>'user_id')::uuid`,
+      't.date DESC, t.id DESC',
+    ),
+
+  // transactionService.getAllTransactionSplits:
+  //   .from('transaction_splits').select('*').eq('user_id', userId)
+  //   .order('transaction_id').order('sort_order')
+  //
+  // `user_id` here is the LINE's owner and not the parent's. The two are usually
+  // one person and the schema does not require it — `myLineOnTheirParent` in the
+  // shared fixtures exists because `merge_categories` walks parents by one and
+  // lines by the other — so filtering on the parent instead would be a different
+  // question with the same name.
+  list_transaction_splits: (payloadLiteral) =>
+    listed(
+      'transaction_splits',
+      SPLIT_JSON,
+      `public.transaction_splits s
+        WHERE s.user_id = (${payloadLiteral}::jsonb->>'user_id')::uuid`,
+      's.transaction_id, s.sort_order',
+    ),
+
+  // transactionService.getTransactionSplits(transactionId):
+  //   .from('transaction_splits').select('*')
+  //   .eq('transaction_id', transactionId).order('sort_order')
+  //
+  // THE OWNER FILTER BELOW IS TRANSCRIBED FROM THE RLS POLICY, NOT THE CLIENT.
+  // That query names no owner at all, because it does not have to: the policy on
+  // this table is `user_id = requesting_user_id()` (20260713100000:57-60), so in
+  // production every row this returns has already been through it. The harness
+  // runs as a superuser with RLS out of the way, so leaving the filter out would
+  // make the oracle answer a question production never asks — and would report
+  // the local edition's only-gate owner check as a divergence. Both halves of
+  // the cloud's real behaviour, written down.
+  splits_for: (payloadLiteral) =>
+    listed(
+      'splits',
+      SPLIT_JSON,
+      `public.transaction_splits s
+        WHERE s.transaction_id = (${payloadLiteral}::jsonb->>'transaction_id')::uuid
+          AND s.user_id = (${payloadLiteral}::jsonb->>'user_id')::uuid`,
+      's.sort_order',
+    ),
+
+  // account_balances() — 20260722160000:26-42, and the only read in this table
+  // whose oracle is a FUNCTION rather than a transcribed query.
+  //
+  // It takes no argument: it is SECURITY DEFINER and reads its identity from the
+  // verified JWT through requesting_user_id(), "so there is no parameter to
+  // spoof". The harness therefore supplies the identity the way production does
+  // — by setting the claim — rather than by rewriting the function's body with a
+  // parameter in it. `request.jwt.claims` is transaction-local, and the whole
+  // spec already runs inside a transaction that is rolled back.
+  //
+  // An owner the file does not know produces a claim of JSON null, which
+  // requesting_clerk_id() turns into SQL NULL and requesting_user_id() matches
+  // nothing with: no rows, which is the same answer an unauthenticated caller
+  // gets in production.
+  //
+  // THE ORDER IS THE HARNESS'S, AND HAS TO BE. The RPC states none at all —
+  // GROUP BY and nothing after it — so its answer is a SET, and two sets cannot
+  // be compared element by element without one. This is NOT the tie-break
+  // exception the block above forbids: there the cloud states a key and the
+  // crate adds one behind it, and copying that would make the oracle agree about
+  // something unsaid. Here there is no key to leave alone, and the crate's own
+  // `ORDER BY a.id` is proved separately in crates/wealth-core/tests/reads.rs.
+  account_balances: (payloadLiteral) =>
+    `PERFORM set_config('request.jwt.claims',
+               json_build_object('sub',
+                 (SELECT u.clerk_id FROM public.users u
+                   WHERE u.id = (${payloadLiteral}::jsonb->>'user_id')::uuid))::text,
+               true);
+     SELECT jsonb_build_object(
+              'account_balances',
+              COALESCE(jsonb_agg(jsonb_build_object(
+                'account_id', b.account_id,
+                'balance', ${money('b.balance')},
+                'txn_count', b.txn_count) ORDER BY b.account_id), '[]'::jsonb))
+       INTO v_row
+       FROM public.account_balances() b;`,
 
   // The snap returns the whole accounts row. Projected into the same eight
   // fields crate::row::account::AccountRow serialises, money as a decimal string

--- a/scripts/local-sqlite/schema.sql
+++ b/scripts/local-sqlite/schema.sql
@@ -792,6 +792,28 @@ CREATE INDEX idx_splits_linked      ON transaction_splits(linked_transfer_id) WH
 -- Covering index for the sum-check verify_integrity() runs after every split write.
 CREATE INDEX idx_splits_sum_cover   ON transaction_splits(transaction_id, amount_minor);
 
+-- The boot's whole-store split read: `list_transaction_splits`, which is
+-- `.eq('user_id', …).order('transaction_id').order('sort_order')` plus this
+-- crate's `id` tie-break. LOCAL-ONLY — the cloud has no counterpart, and needs
+-- none: PostgREST pages that query 1,000 rows at a time behind RLS, while a file
+-- answers it whole, once, on every boot.
+--
+-- MEASURED (crates/wealth-core/tests/reads_at_scale.rs, 50k transactions /
+-- 8k split lines, debug profile):
+--
+--   without: SCAN transaction_splits USING INDEX idx_splits_transaction
+--            + USE TEMP B-TREE FOR LAST TERM OF ORDER BY      8.9ms
+--   with:    SEARCH transaction_splits USING INDEX idx_splits_user_display
+--                                                             4.5ms
+--
+-- The 2× is the smaller half of the reason. The larger half is the word SCAN:
+-- without this index the read walks EVERY login's lines and discards the ones
+-- that are not the caller's, so the cost is a property of the file rather than
+-- of the answer — and a restored two-login file (B-3) is exactly the case the
+-- reads were given a required owner for. The write cost is four columns on a
+-- table written a line set at a time.
+CREATE INDEX idx_splits_user_display ON transaction_splits(user_id, transaction_id, sort_order, id);
+
 
 -- ============================================================================
 -- 6. THE RPC GUARD

--- a/scripts/local-sqlite/verb-specs/_shared.mjs
+++ b/scripts/local-sqlite/verb-specs/_shared.mjs
@@ -2577,3 +2577,312 @@ export function listedDismissal(fields) {
     ...fields,
   };
 }
+
+// ── The heavy reads' fixtures ──────────────────────────────────────────────
+//
+// Everything the six light reads needed applies here too — pinned timestamps,
+// distinct sort keys — with one addition of their own: these reads answer with
+// whole ROWS OF THE LEDGER, so their fixtures move money, and every one of them
+// still has B-1 asserted on it. A fixture that archives a row or breaks a
+// balance says which of the two it is doing.
+
+/** The instant every transaction and split line in these fixtures was made. */
+export const MADE_AT = '2024-01-04T00:00:00.000Z';
+
+/**
+ * Fixed `created_at`/`updated_at` on every one of this login's transactions and
+ * split lines.
+ *
+ * COMPOSE IT LAST. Both engines stamp `updated_at` on an UPDATE, so a fragment
+ * that touches a transaction after this one has undone it. The asymmetry
+ * between the two halves is [`pinnedReadTimes`]'s and has the same cause: naming
+ * the column stands the local trigger down, while the cloud's assigns NOW()
+ * unconditionally unless `app.restore_in_progress` is raised.
+ */
+export const pinnedLedgerTimes = {
+  sqlite: `
+    UPDATE transactions SET created_at = '${MADE_AT}', updated_at = '${MADE_AT}'
+     WHERE user_id = '${USER}';
+    UPDATE transaction_splits SET created_at = '${MADE_AT}', updated_at = '${MADE_AT}'
+     WHERE user_id = '${USER}';`,
+  postgres: `
+    SELECT set_config('app.restore_in_progress', '1', true);
+    UPDATE public.transactions SET created_at = '${MADE_AT}', updated_at = '${MADE_AT}'
+     WHERE user_id = '${USER}';
+    UPDATE public.transaction_splits SET created_at = '${MADE_AT}', updated_at = '${MADE_AT}'
+     WHERE user_id = '${USER}';
+    SELECT set_config('app.restore_in_progress', '0', true);`,
+};
+
+/** Three more rows in Everyday, two of them sharing the Corner shop's date. */
+export const SAME_DAY_EARLIER = '70000000-0000-0000-0000-0000000000f1';
+export const SAME_DAY_LATER = '70000000-0000-0000-0000-0000000000f3';
+export const A_LATER_DAY = '70000000-0000-0000-0000-0000000000f2';
+
+/**
+ * The shape that proves the ORDER: one row on a later date, and two more on the
+ * SAME date as the Corner shop row.
+ *
+ * `date DESC` alone cannot separate three rows on one day, and the cloud's own
+ * second key — `id DESC`, which it calls a stable tiebreak for paging — is what
+ * settles them. The ids are chosen so that id order and insertion order
+ * disagree: `…f3` is written second and must come out first.
+ *
+ * Each row is −1.00 and Everyday's balance moves by −3.00, so B-1 holds.
+ */
+export const rowsOnOneDay = {
+  sqlite: `
+    INSERT INTO transactions (id, user_id, account_id, description, amount_minor, type, date) VALUES
+      ('${A_LATER_DAY}',     '${USER}', '${EVERYDAY}', 'A later day', -100, 'expense', '2024-03-02'),
+      ('${SAME_DAY_LATER}',  '${USER}', '${EVERYDAY}', 'Second in',   -100, 'expense', '2024-03-01'),
+      ('${SAME_DAY_EARLIER}','${USER}', '${EVERYDAY}', 'First in',    -100, 'expense', '2024-03-01');
+    UPDATE accounts SET balance_minor = balance_minor - 300 WHERE id = '${EVERYDAY}';`,
+  postgres: `
+    INSERT INTO public.transactions (id, user_id, account_id, description, amount, type, date) VALUES
+      ('${A_LATER_DAY}',     '${USER}', '${EVERYDAY}', 'A later day', -1.00, 'expense', '2024-03-02'),
+      ('${SAME_DAY_LATER}',  '${USER}', '${EVERYDAY}', 'Second in',   -1.00, 'expense', '2024-03-01'),
+      ('${SAME_DAY_EARLIER}','${USER}', '${EVERYDAY}', 'First in',    -1.00, 'expense', '2024-03-01');
+    UPDATE public.accounts SET balance = balance - 3.00 WHERE id = '${EVERYDAY}';`,
+};
+
+/**
+ * The Corner shop row, archived.
+ *
+ * Balance-neutral by definition — that IS the rule (20260721130000: "archiving
+ * is a view flag and never moves a balance") — so B-1 still holds on Everyday at
+ * −25.00 afterwards, and `account_balances` must still answer −25.00.
+ */
+export const anArchivedRow = {
+  sqlite: `UPDATE transactions SET archived = 1 WHERE id = '${CORNER_SHOP}';`,
+  postgres: `UPDATE public.transactions SET archived = true WHERE id = '${CORNER_SHOP}';`,
+};
+
+/**
+ * The Everyday account's STORED balance, set to a figure that is not
+ * `initial_balance + Σ amounts`, with no transaction touched.
+ *
+ * The only fixture in the whole harness that plants a B-1 violation outside the
+ * `integrity-*` family, and it is planted for the same reason those are: the
+ * thing under test is what happens when it is there. R-2 says a port that read
+ * `accounts.balance` would report this drift AS MONEY; the answer must be the
+ * derived −25.00 and not the stored 999.99, on both engines.
+ *
+ * Specs using it assert `violationRows`/`integrityOk` instead of
+ * `balanceIdentityHolds`, because asserting B-1 here would be asserting that the
+ * fixture failed to do its job.
+ */
+export const aStoredBalanceThatDrifted = {
+  sqlite: `UPDATE accounts SET balance_minor = 99999 WHERE id = '${EVERYDAY}';`,
+  postgres: `UPDATE public.accounts SET balance = 999.99 WHERE id = '${EVERYDAY}';`,
+};
+
+/**
+ * Rainy day given an opening balance and left with no transactions.
+ *
+ * The LEFT JOIN's whole subject. B-1 holds trivially — an account with no rows
+ * has `balance = initial_balance` — so both are moved together.
+ */
+export const anAccountNobodyHasUsed = {
+  sqlite: `
+    UPDATE accounts SET initial_balance_minor = 4200, balance_minor = 4200
+     WHERE id = '${RAINY_DAY}';`,
+  postgres: `
+    UPDATE public.accounts SET initial_balance = 42.00, balance = 42.00
+     WHERE id = '${RAINY_DAY}';`,
+};
+
+/**
+ * The Corner shop row with every column the boot reads filled in with something
+ * that is not its default.
+ *
+ * [`enriched`] does this for the WRITE verbs and stops short of three columns
+ * the boot list carries — `needs_review`, `statement_sequence` and
+ * `linked_transfer_split_id` — because no write verb sets them. On a bare
+ * fixture each of those is a default, and a default is the one value that cannot
+ * tell a working mapping from a missing one.
+ *
+ * ONE tag, not two, and that is deliberate: a `text[]` is an ordered list and a
+ * child table is a set, so two tags is a question about ORDER rather than about
+ * carrying them. That question has its own spec, declared as the divergence it
+ * is.
+ *
+ * Nothing here moves an amount, so B-1 still holds on both accounts.
+ */
+export const everyColumnTheBootReads = {
+  sqlite: `
+    UPDATE transactions SET
+      category_id = '${WEEKLY_SHOP}',
+      notes = 'a note',
+      is_cleared = 1,
+      is_recurring = 1,
+      category_confirmed = 0,
+      needs_review = 1,
+      statement_sequence = 7,
+      transfer_account_id = '${RAINY_DAY}'
+     WHERE id = '${CORNER_SHOP}';
+    INSERT INTO transaction_tags (transaction_id, tag) VALUES ('${CORNER_SHOP}', 'zebra');`,
+  postgres: `
+    UPDATE public.transactions SET
+      category_id = '${WEEKLY_SHOP}'::uuid,
+      notes = 'a note',
+      is_cleared = true,
+      is_recurring = true,
+      category_confirmed = false,
+      needs_review = true,
+      statement_sequence = 7,
+      transfer_account_id = '${RAINY_DAY}'::uuid,
+      tags = ARRAY['zebra']
+     WHERE id = '${CORNER_SHOP}';`,
+};
+
+/**
+ * A second split parent, so the whole-store split read has more than one to put
+ * in order.
+ *
+ * Sits on [`plainSplitParent`], which makes Corner shop a split of −15.00 and
+ * −10.00. This adds a −30.00 row in Everyday with two lines of its own, and its
+ * id sorts BEFORE the Corner shop's, so a read that came back in insertion order
+ * rather than in `transaction_id` order would be caught.
+ */
+export const SECOND_PARENT = '60000000-0000-0000-0000-0000000000b1';
+export const SECOND_PARENT_FIRST_LINE = '50000000-0000-0000-0000-0000000000b1';
+export const SECOND_PARENT_SECOND_LINE = '50000000-0000-0000-0000-0000000000b2';
+
+export const aSecondSplitParent = {
+  sqlite: `
+    INSERT INTO _rpc_guard VALUES ('split');
+    INSERT INTO transactions (id, user_id, account_id, description, amount_minor, type, date,
+                              is_split, category)
+      VALUES ('${SECOND_PARENT}', '${USER}', '${EVERYDAY}', 'Big shop', -3000, 'expense',
+              '2024-03-05', 1, '');
+    UPDATE accounts SET balance_minor = balance_minor - 3000 WHERE id = '${EVERYDAY}';
+    INSERT INTO transaction_splits (id, transaction_id, user_id, category, amount_minor, memo,
+                                    sort_order) VALUES
+      ('${SECOND_PARENT_FIRST_LINE}',  '${SECOND_PARENT}', '${USER}', '${WEEKLY_SHOP}', -2000,
+       'the food half', 0),
+      ('${SECOND_PARENT_SECOND_LINE}', '${SECOND_PARENT}', '${USER}', '${OUTGOINGS}',  -1000,
+       NULL, 1);
+    DELETE FROM _rpc_guard;`,
+  postgres: `
+    SELECT set_config('app.split_rpc', '1', true);
+    INSERT INTO public.transactions (id, user_id, account_id, description, amount, type, date,
+                                     is_split, category)
+      VALUES ('${SECOND_PARENT}', '${USER}', '${EVERYDAY}', 'Big shop', -30.00, 'expense',
+              '2024-03-05', true, '');
+    UPDATE public.accounts SET balance = balance - 30.00 WHERE id = '${EVERYDAY}';
+    INSERT INTO public.transaction_splits (id, transaction_id, user_id, category, amount, memo,
+                                           sort_order) VALUES
+      ('${SECOND_PARENT_FIRST_LINE}',  '${SECOND_PARENT}', '${USER}', '${WEEKLY_SHOP}', -20.00,
+       'the food half', 0),
+      ('${SECOND_PARENT_SECOND_LINE}', '${SECOND_PARENT}', '${USER}', '${OUTGOINGS}',  -10.00,
+       NULL, 1);
+    SELECT set_config('app.split_rpc', '0', true);`,
+};
+
+/** Everything of this login's, gone — the empty-file answer, on a real file. */
+export const nothingOfMine = {
+  sqlite: `
+    DELETE FROM transaction_splits WHERE user_id = '${USER}';
+    DELETE FROM transactions WHERE user_id = '${USER}';
+    UPDATE accounts SET balance_minor = initial_balance_minor WHERE user_id = '${USER}';`,
+  postgres: `
+    DELETE FROM public.transaction_splits WHERE user_id = '${USER}';
+    DELETE FROM public.transactions WHERE user_id = '${USER}';
+    UPDATE public.accounts SET balance = initial_balance WHERE user_id = '${USER}';`,
+};
+
+// ── The rows the heavy reads expect ────────────────────────────────────────
+
+/**
+ * One transaction, as both engines must answer with it.
+ *
+ * Twenty-two keys: `BOOT_TRANSACTION_COLUMNS` minus `is_reconciled`, which the
+ * cloud has had since 20260810200000 and scripts/local-sqlite/schema.sql has
+ * not. The gap is recorded in the crate's `row.rs` and in the harness oracle;
+ * it is NOT hidden here, it is simply not a key either side can answer with.
+ *
+ * The defaults below are the Corner shop row's, checked against the column
+ * defaults in both schemas — `category_confirmed` is true by default in both
+ * (a writer that does not know about provenance produces a confirmed row) and
+ * `needs_review` false in both (one that does not know about review produces a
+ * reviewed row).
+ */
+export function listedTransaction(fields) {
+  return {
+    id: CORNER_SHOP,
+    account_id: EVERYDAY,
+    amount: '-25.00',
+    archived: false,
+    category: WEEKLY_SHOP,
+    category_confirmed: true,
+    category_id: null,
+    created_at: MADE_AT,
+    date: '2024-03-01',
+    description: 'Corner shop',
+    is_cleared: false,
+    is_recurring: false,
+    is_split: false,
+    linked_transfer_id: null,
+    linked_transfer_split_id: null,
+    needs_review: false,
+    notes: null,
+    statement_sequence: null,
+    tags: [],
+    type: 'expense',
+    updated_at: MADE_AT,
+    transfer_account_id: null,
+    ...fields,
+  };
+}
+
+/** One split line — eleven keys, because both split reads are `select('*')`. */
+export function listedSplit(fields) {
+  return {
+    id: '',
+    transaction_id: CORNER_SHOP,
+    user_id: USER,
+    category: WEEKLY_SHOP,
+    amount: '0.00',
+    memo: null,
+    sort_order: 0,
+    transfer_account_id: null,
+    linked_transfer_id: null,
+    created_at: MADE_AT,
+    updated_at: MADE_AT,
+    ...fields,
+  };
+}
+
+/**
+ * One account's derived balance — the three keys the RPC returns.
+ *
+ * Named `derivedBalance` and not `accountBalance` on purpose: `accountBalance`
+ * is already imported at the top of this file from `lib/money-sql.mjs`, and it
+ * reads `accounts.balance` — the STORED figure. Two helpers one letter apart,
+ * one reading the cache and one reading the derivation, is precisely R-2's
+ * mistake with a shorter fuse.
+ */
+export function derivedBalance(fields) {
+  return {
+    account_id: EVERYDAY,
+    balance: '0.00',
+    txn_count: 0,
+    ...fields,
+  };
+}
+
+/**
+ * Two tags on the Corner shop row, written in an order that is NOT tag order.
+ *
+ * The one shape where the two engines legitimately answer differently, and the
+ * whole point of the fixture is that the difference is visible: `text[]` in the
+ * cloud remembers that `zebra` was written first, and a child table keyed
+ * `(transaction_id, tag)` has no insertion order to remember. Written in this
+ * order so a spec asserting sorted output on both sides would fail on one.
+ */
+export const twoTagsInTheWrongOrder = {
+  sqlite: `
+    INSERT INTO transaction_tags (transaction_id, tag) VALUES
+      ('${CORNER_SHOP}', 'zebra'), ('${CORNER_SHOP}', 'apple');`,
+  postgres: `UPDATE public.transactions SET tags = ARRAY['zebra','apple'] WHERE id = '${CORNER_SHOP}';`,
+};

--- a/scripts/local-sqlite/verb-specs/balances-an-account-nobody-has-used-still-reports-its-opening-balance.spec.mjs
+++ b/scripts/local-sqlite/verb-specs/balances-an-account-nobody-has-used-still-reports-its-opening-balance.spec.mjs
@@ -1,0 +1,27 @@
+import {
+  USER, EVERYDAY, RAINY_DAY,
+  anAccountNobodyHasUsed, derivedBalance, balanceIdentityHolds, auditRowsInTotal,
+} from './_shared.mjs';
+
+export default {
+  invariant: 'BAL-3',
+  title: 'an account with no transactions is in the answer, carrying the money it opened with',
+  design: '20260722160000 spells the reason at the join: "LEFT JOIN so an account with no transactions still reports its opening balance instead of dropping out of the result"',
+  consequence: 'an inner join drops the account entirely, and a missing key in this map is not £0.00 to the caller — computeAccountBalances falls back to its own sum for an account the map does not name. For an account whose opening balance IS its whole content, that means showing nothing at all until the rows arrive, which for this account is never',
+  parity: 'match',
+
+  setup: anAccountNobodyHasUsed,
+  command: { verb: 'account_balances', payload: { user_id: USER } },
+  expect: { outcome: 'ok' },
+  result: {
+    account_balances: [
+      derivedBalance({ account_id: EVERYDAY, balance: '-25.00', txn_count: 1 }),
+      derivedBalance({ account_id: RAINY_DAY, balance: '42.00', txn_count: 0 }),
+    ],
+  },
+  state: [
+    balanceIdentityHolds(EVERYDAY),
+    balanceIdentityHolds(RAINY_DAY),
+    auditRowsInTotal('0'),
+  ],
+};

--- a/scripts/local-sqlite/verb-specs/balances-an-archived-row-still-counts-towards-the-balance.spec.mjs
+++ b/scripts/local-sqlite/verb-specs/balances-an-archived-row-still-counts-towards-the-balance.spec.mjs
@@ -1,0 +1,28 @@
+import {
+  USER, EVERYDAY, RAINY_DAY,
+  anArchivedRow, derivedBalance, balanceIdentityHolds, auditRowsInTotal,
+} from './_shared.mjs';
+
+export default {
+  invariant: 'BAL-2',
+  title: 'archiving a row hides it and does not spend it: the balance and the count are unchanged',
+  design: '20260722160000:15-16, in the RPC\'s own words: "The sum deliberately spans ALL transactions, archived included: archiving is a view flag and never moves a balance." The soft-archive migration is the Microsoft Money lesson written down — Money HARD-DELETED archived rows and the totals went with them',
+  consequence: 'THE money bug (R-1, contract rule 82). `AND NOT t.archived` is one token, reads like a tidy-up, and silently removes a user\'s whole archived history from every balance in the app. It would also make verify_integrity report every account with an archived row as broken, because balance_identity does not filter the archive either — which is the sibling check earning its keep',
+  parity: 'match',
+
+  setup: anArchivedRow,
+  command: { verb: 'account_balances', payload: { user_id: USER } },
+  expect: { outcome: 'ok' },
+  result: {
+    account_balances: [
+      // −25.00 and ONE row, both unchanged by the archiving.
+      derivedBalance({ account_id: EVERYDAY, balance: '-25.00', txn_count: 1 }),
+      derivedBalance({ account_id: RAINY_DAY, balance: '0.00', txn_count: 0 }),
+    ],
+  },
+  state: [
+    balanceIdentityHolds(EVERYDAY),
+    balanceIdentityHolds(RAINY_DAY),
+    auditRowsInTotal('0'),
+  ],
+};

--- a/scripts/local-sqlite/verb-specs/balances-an-owner-the-file-does-not-know-answers-with-nothing.spec.mjs
+++ b/scripts/local-sqlite/verb-specs/balances-an-owner-the-file-does-not-know-answers-with-nothing.spec.mjs
@@ -1,0 +1,24 @@
+import {
+  USER, EVERYDAY, RAINY_DAY,
+  balanceIdentityHolds, auditRowsInTotal,
+} from './_shared.mjs';
+
+export default {
+  invariant: 'BAL-5',
+  title: 'an owner with no accounts gets an empty list, not a refusal and not a page of zeros',
+  design: 'dataPort.ts: getAccountBalances "NEVER REJECTS, AND NEVER GUESSES. An empty map means I don\'t know and the app falls back to its own sum. Returning zeros instead would be a guess, and a wrong one: the seeding rule keys off the map being non-empty, so a map of zeros would paint every account at £0.00 and call it real money"',
+  consequence: 'in the cloud this is literally what an unauthenticated caller gets — requesting_user_id() matches nothing and the aggregate returns no rows. The local read has to answer the same way for an owner the file does not hold, because the alternative shapes are both worse: a refusal breaks the boot\'s never-rejects floor, and zeros are money that is not there',
+  parity: 'match',
+
+  command: {
+    verb: 'account_balances',
+    payload: { user_id: '33333333-3333-3333-3333-333333333333' },
+  },
+  expect: { outcome: 'ok' },
+  result: { account_balances: [] },
+  state: [
+    balanceIdentityHolds(EVERYDAY),
+    balanceIdentityHolds(RAINY_DAY),
+    auditRowsInTotal('0'),
+  ],
+};

--- a/scripts/local-sqlite/verb-specs/balances-an-untouched-accounts-count-is-zero-and-not-the-one-a-count-star-would-report.spec.mjs
+++ b/scripts/local-sqlite/verb-specs/balances-an-untouched-accounts-count-is-zero-and-not-the-one-a-count-star-would-report.spec.mjs
@@ -1,0 +1,27 @@
+import {
+  USER, EVERYDAY, RAINY_DAY,
+  anAccountNobodyHasUsed, derivedBalance, balanceIdentityHolds, auditRowsInTotal,
+} from './_shared.mjs';
+
+export default {
+  invariant: 'BAL-4',
+  title: 'the count is COUNT(t.id), so an account with no rows answers zero rather than one',
+  design: '20260722160000 counts t.id and not *. Under a LEFT JOIN with nothing on the right, COUNT(*) counts the manufactured null row and answers 1 — the two spellings differ by one character and by one row per empty account',
+  consequence: 'the count is how a caller tells "this account has no transactions" from "this account\'s transactions have not arrived yet". One of those is a fact and the other is a loading state, and a balance verb that reports the loading state as a fact is a dashboard that stops waiting too early. It is also the property that would EVAPORATE if this query were rewritten as correlated subqueries for speed — see crate::verbs::reads on why it was not',
+  parity: 'match',
+
+  setup: anAccountNobodyHasUsed,
+  command: { verb: 'account_balances', payload: { user_id: USER } },
+  expect: { outcome: 'ok' },
+  result: {
+    account_balances: [
+      derivedBalance({ account_id: EVERYDAY, balance: '-25.00', txn_count: 1 }),
+      derivedBalance({ account_id: RAINY_DAY, balance: '42.00', txn_count: 0 }),
+    ],
+  },
+  state: [
+    balanceIdentityHolds(EVERYDAY),
+    balanceIdentityHolds(RAINY_DAY),
+    auditRowsInTotal('0'),
+  ],
+};

--- a/scripts/local-sqlite/verb-specs/balances-every-account-answers-and-the-money-crosses-as-a-decimal-string.spec.mjs
+++ b/scripts/local-sqlite/verb-specs/balances-every-account-answers-and-the-money-crosses-as-a-decimal-string.spec.mjs
@@ -1,0 +1,27 @@
+import {
+  USER, EVERYDAY, RAINY_DAY,
+  transferPair, derivedBalance, balanceIdentityHolds, auditRowsInTotal,
+} from './_shared.mjs';
+
+export default {
+  invariant: 'BAL-1',
+  title: 'a ledger with money on both sides of a transfer answers to the penny, as text',
+  design: 'money.rs\'s to_decimal_string is the ONE place minor units become the text the app parses, and toAccountBalanceMap on the far side takes whatever arrives through Decimal — "PostgREST renders numeric as a JSON number or a string depending on the value", so a port that answered with a JSON number would be handing the client a float to round',
+  consequence: 'PHASE3-PLAN D-4\'s decisive argument for putting reads in the crate at all: a second layer\'s `minor as f64 / 100.0` is one careless line in the numbers on screen. This is that line\'s absence, asserted — −40.00 out of one account and 15.00 into the other, from an integer column on one engine and a numeric on the other, compared as the same text',
+  parity: 'match',
+
+  setup: transferPair,
+  command: { verb: 'account_balances', payload: { user_id: USER } },
+  expect: { outcome: 'ok' },
+  result: {
+    account_balances: [
+      derivedBalance({ account_id: EVERYDAY, balance: '-40.00', txn_count: 2 }),
+      derivedBalance({ account_id: RAINY_DAY, balance: '15.00', txn_count: 1 }),
+    ],
+  },
+  state: [
+    balanceIdentityHolds(EVERYDAY),
+    balanceIdentityHolds(RAINY_DAY),
+    auditRowsInTotal('0'),
+  ],
+};

--- a/scripts/local-sqlite/verb-specs/balances-somebody-elses-account-is-not-in-the-answer.spec.mjs
+++ b/scripts/local-sqlite/verb-specs/balances-somebody-elses-account-is-not-in-the-answer.spec.mjs
@@ -1,0 +1,28 @@
+import {
+  USER, EVERYDAY, RAINY_DAY, SOMEONE_ELSES_ACCOUNT,
+  setups, secondUser, strangersRow, derivedBalance, balanceIdentityHolds, auditRowsInTotal,
+} from './_shared.mjs';
+
+export default {
+  invariant: 'BAL-5',
+  title: 'a second login\'s account and its spending are in the file and not in these figures',
+  design: 'the cloud takes NO argument here: account_balances() is SECURITY DEFINER and reads its identity from the verified JWT through requesting_user_id(), "so there is no parameter to spoof and an unauthenticated caller matches nothing and gets no rows". A file has no JWT, so the owner arrives in the payload like every other read\'s — and this spec is where the harness proves the two narrow to the same set, by setting the claim rather than by rewriting the function',
+  consequence: 'the dashboard\'s headline figure is the sum of this answer. A stranger\'s account leaking into it would put their money in this login\'s net worth, and their spending in the count beside it',
+  parity: 'match',
+
+  setup: setups(secondUser, strangersRow),
+  command: { verb: 'account_balances', payload: { user_id: USER } },
+  expect: { outcome: 'ok' },
+  result: {
+    account_balances: [
+      derivedBalance({ account_id: EVERYDAY, balance: '-25.00', txn_count: 1 }),
+      derivedBalance({ account_id: RAINY_DAY, balance: '0.00', txn_count: 0 }),
+    ],
+  },
+  state: [
+    balanceIdentityHolds(EVERYDAY),
+    balanceIdentityHolds(RAINY_DAY),
+    balanceIdentityHolds(SOMEONE_ELSES_ACCOUNT),
+    auditRowsInTotal('0'),
+  ],
+};

--- a/scripts/local-sqlite/verb-specs/balances-the-figure-is-derived-and-never-the-stored-one.spec.mjs
+++ b/scripts/local-sqlite/verb-specs/balances-the-figure-is-derived-and-never-the-stored-one.spec.mjs
@@ -1,0 +1,31 @@
+import {
+  USER, EVERYDAY, RAINY_DAY,
+  aStoredBalanceThatDrifted, derivedBalance, balanceOf, auditRowsInTotal,
+} from './_shared.mjs';
+
+export default {
+  invariant: 'BAL-1',
+  title: 'a stored balance that has drifted is ignored: the answer is initial_balance + the rows',
+  design: '20260722160000:26-42 aggregates. accounts.balance is a CACHE that every write verb maintains, and B-1 says it must equal initial_balance + SUM(amount) — but no constraint in either engine enforces that, which is why v_integrity_violations opens with balance_identity. The two are siblings and the relationship runs one way: this verb DERIVES what verify_integrity CHECKS',
+  consequence: 'R-2. A port that read accounts.balance would report the drift AS MONEY on the dashboard, and the one instrument that could have caught it would still be quietly naming balance_identity in a report nobody\'s figures contradicted. Two numbers are only worth having while they are arrived at independently',
+  parity: 'match',
+
+  // THE ONE FIXTURE OUTSIDE THE integrity-* FAMILY THAT PLANTS A B-1 VIOLATION,
+  // and it is planted because the violation IS the subject. balanceIdentityHolds
+  // is therefore not asserted here — it would be asserting that the fixture
+  // failed to do its job — and the stored figure is asserted instead, which
+  // proves the fixture did it and the verb ignored it.
+  setup: aStoredBalanceThatDrifted,
+  command: { verb: 'account_balances', payload: { user_id: USER } },
+  expect: { outcome: 'ok' },
+  result: {
+    account_balances: [
+      derivedBalance({ account_id: EVERYDAY, balance: '-25.00', txn_count: 1 }),
+      derivedBalance({ account_id: RAINY_DAY, balance: '0.00', txn_count: 0 }),
+    ],
+  },
+  state: [
+    balanceOf(EVERYDAY, '999.99'),
+    auditRowsInTotal('0'),
+  ],
+};

--- a/scripts/local-sqlite/verb-specs/read-splits-a-file-with-no-splits-answers-with-an-empty-list.spec.mjs
+++ b/scripts/local-sqlite/verb-specs/read-splits-a-file-with-no-splits-answers-with-an-empty-list.spec.mjs
@@ -1,0 +1,21 @@
+import {
+  USER, EVERYDAY, RAINY_DAY,
+  balanceIdentityHolds, auditRowsInTotal,
+} from './_shared.mjs';
+
+export default {
+  invariant: 'READ-11',
+  title: 'a ledger with no split lines in it answers with an empty list',
+  design: 'dataService.loadBoot reads this one inside its own try/catch and falls back to [], because splits are the one boot read the app can genuinely do without: they feed category aggregation, not the register. The answer for a person who has never split a transaction is the commonest answer this verb gives',
+  consequence: 'the shape again: the far side maps answer.transaction_splits, and null there would be read as a store that does not work rather than as a person who does not split things',
+  parity: 'match',
+
+  command: { verb: 'list_transaction_splits', payload: { user_id: USER } },
+  expect: { outcome: 'ok' },
+  result: { transaction_splits: [] },
+  state: [
+    balanceIdentityHolds(EVERYDAY),
+    balanceIdentityHolds(RAINY_DAY),
+    auditRowsInTotal('0'),
+  ],
+};

--- a/scripts/local-sqlite/verb-specs/read-splits-a-line-of-mine-on-somebody-elses-parent-is-still-mine.spec.mjs
+++ b/scripts/local-sqlite/verb-specs/read-splits-a-line-of-mine-on-somebody-elses-parent-is-still-mine.spec.mjs
@@ -1,0 +1,31 @@
+import {
+  USER, EVERYDAY, SOMEONE_ELSES_ACCOUNT, THEIR_SPLIT_PARENT, MERGE_SOURCE,
+  setups, secondUser, mergeablePair, myLineOnTheirParent, pinnedLedgerTimes, listedSplit,
+  balanceIdentityHolds, auditRowsInTotal,
+} from './_shared.mjs';
+
+export default {
+  invariant: 'READ-11',
+  title: 'the owner this read filters on is the LINE\'s owner, which is not always the parent\'s',
+  design: '.eq(\'user_id\', userId) names transaction_splits.user_id, and so does the RLS policy on that table. The two are usually the same person as the parent\'s owner and neither schema requires it — this fixture exists because merge_categories walks parents by one column and lines by the other, and the gap between them is a real refusal it can reach',
+  consequence: 'filtering on the parent instead would be a different question with the same name, and the difference only shows up on files where the two disagree — which is to say, in production and never in a fixture written without this one in mind',
+  parity: 'match',
+
+  setup: setups(secondUser, mergeablePair, myLineOnTheirParent, pinnedLedgerTimes),
+  command: { verb: 'list_transaction_splits', payload: { user_id: USER } },
+  expect: { outcome: 'ok' },
+  result: {
+    transaction_splits: [
+      listedSplit({
+        id: '50000000-0000-0000-0000-0000000000aa',
+        transaction_id: THEIR_SPLIT_PARENT,
+        category: MERGE_SOURCE, amount: '-10.00', sort_order: 0,
+      }),
+    ],
+  },
+  state: [
+    balanceIdentityHolds(EVERYDAY),
+    balanceIdentityHolds(SOMEONE_ELSES_ACCOUNT),
+    auditRowsInTotal('0'),
+  ],
+};

--- a/scripts/local-sqlite/verb-specs/read-splits-a-transfer-legs-line-carries-its-target-and-its-link.spec.mjs
+++ b/scripts/local-sqlite/verb-specs/read-splits-a-transfer-legs-line-carries-its-target-and-its-link.spec.mjs
@@ -1,0 +1,39 @@
+import {
+  USER, EVERYDAY, RAINY_DAY, CORNER_SHOP, WEEKLY_SHOP,
+  LEG_LINE, PLAIN_LINE, LEG_COUNTERPART, TO_FROM_RAINY_DAY,
+  setups, namedTransferCategories, splitWithTransferLeg, pinnedLedgerTimes, listedSplit,
+  balanceIdentityHolds, auditRowsInTotal,
+} from './_shared.mjs';
+
+export default {
+  invariant: 'READ-11',
+  title: 'a line that is half of a transfer answers with the account it points at and the row it is paired with',
+  design: '20260720120000 added transfer_account_id and linked_transfer_id to transaction_splits, so select(\'*\') carries them. A line with a target and no link is an UNMATCHED leg — the other side exists somewhere and nobody has recognised it — and a line with both is a movement of money that has already happened twice',
+  consequence: 'these two columns are how the app draws a split line as a transfer rather than as spending, and how the matching sweep knows which legs are still looking for a partner. A reader that dropped them would turn every transfer leg in every split into an ordinary expense on screen, in the right amount and against the wrong story',
+  parity: 'match',
+
+  // namedTransferCategories first, so the To/From category the leg is filed
+  // under has an id a spec can name: both engines mint it from a trigger with a
+  // generated one, and no spec may assume it.
+  setup: setups(namedTransferCategories, splitWithTransferLeg, pinnedLedgerTimes),
+  command: { verb: 'list_transaction_splits', payload: { user_id: USER } },
+  expect: { outcome: 'ok' },
+  result: {
+    transaction_splits: [
+      listedSplit({
+        id: LEG_LINE, transaction_id: CORNER_SHOP,
+        category: TO_FROM_RAINY_DAY, amount: '-15.00', sort_order: 0,
+        transfer_account_id: RAINY_DAY, linked_transfer_id: LEG_COUNTERPART,
+      }),
+      listedSplit({
+        id: PLAIN_LINE, transaction_id: CORNER_SHOP,
+        category: WEEKLY_SHOP, amount: '-10.00', sort_order: 1,
+      }),
+    ],
+  },
+  state: [
+    balanceIdentityHolds(EVERYDAY),
+    balanceIdentityHolds(RAINY_DAY),
+    auditRowsInTotal('0'),
+  ],
+};

--- a/scripts/local-sqlite/verb-specs/read-splits-arrive-parent-by-parent-in-display-order.spec.mjs
+++ b/scripts/local-sqlite/verb-specs/read-splits-arrive-parent-by-parent-in-display-order.spec.mjs
@@ -1,0 +1,42 @@
+import {
+  USER, EVERYDAY, CORNER_SHOP, WEEKLY_SHOP, OUTGOINGS,
+  LEG_LINE, PLAIN_LINE, SECOND_PARENT, SECOND_PARENT_FIRST_LINE, SECOND_PARENT_SECOND_LINE,
+  setups, plainSplitParent, aSecondSplitParent, pinnedLedgerTimes, listedSplit,
+  balanceIdentityHolds, auditRowsInTotal,
+} from './_shared.mjs';
+
+export default {
+  invariant: 'READ-11',
+  title: 'every line in the file, parent by parent, each parent in the order its lines are drawn',
+  design: 'transactionService.getAllTransactionSplits: .select(\'*\').eq(\'user_id\', …).order(\'transaction_id\').order(\'sort_order\'), paged only because PostgREST caps a response at 1,000 rows — a cap a file does not have. The whole row, eleven columns, because the query is select(\'*\') and what a read projects is what the query projects',
+  consequence: 'this is the answer split-aware reporting aggregates by category, so a line in the wrong place is a figure in the wrong category. The second parent\'s id sorts BEFORE the Corner shop\'s and is written AFTER it, so a read that came back in insertion order — which is what SQLite gives for free — is caught here',
+  parity: 'match',
+
+  setup: setups(plainSplitParent, aSecondSplitParent, pinnedLedgerTimes),
+  command: { verb: 'list_transaction_splits', payload: { user_id: USER } },
+  expect: { outcome: 'ok' },
+  result: {
+    transaction_splits: [
+      listedSplit({
+        id: SECOND_PARENT_FIRST_LINE, transaction_id: SECOND_PARENT,
+        category: WEEKLY_SHOP, amount: '-20.00', memo: 'the food half', sort_order: 0,
+      }),
+      listedSplit({
+        id: SECOND_PARENT_SECOND_LINE, transaction_id: SECOND_PARENT,
+        category: OUTGOINGS, amount: '-10.00', sort_order: 1,
+      }),
+      listedSplit({
+        id: LEG_LINE, transaction_id: CORNER_SHOP,
+        category: WEEKLY_SHOP, amount: '-15.00', sort_order: 0,
+      }),
+      listedSplit({
+        id: PLAIN_LINE, transaction_id: CORNER_SHOP,
+        category: WEEKLY_SHOP, amount: '-10.00', sort_order: 1,
+      }),
+    ],
+  },
+  state: [
+    balanceIdentityHolds(EVERYDAY),
+    auditRowsInTotal('0'),
+  ],
+};

--- a/scripts/local-sqlite/verb-specs/read-splits-for-a-parent-that-is-not-there-answers-with-nothing-rather-than-a-refusal.spec.mjs
+++ b/scripts/local-sqlite/verb-specs/read-splits-for-a-parent-that-is-not-there-answers-with-nothing-rather-than-a-refusal.spec.mjs
@@ -1,0 +1,27 @@
+import {
+  USER, EVERYDAY,
+  setups, plainSplitParent, pinnedLedgerTimes,
+  balanceIdentityHolds, auditRowsInTotal,
+} from './_shared.mjs';
+
+export default {
+  invariant: 'READ-12',
+  title: 'an id that names no transaction of yours answers with an empty list, and says nothing about why',
+  design: 'the cloud\'s query is .eq(\'transaction_id\', …) under RLS: a row belonging to somebody else matches the filter and is then removed by the policy, so the caller gets an empty array and cannot tell it from a row with no lines. The local read reproduces both halves — the id and the owner — and therefore reproduces the silence',
+  consequence: 'this is row/account.rs\'s reasoning for not distinguishing "no such account" from "not your account", applied to lines: an answer that told the two apart would confirm that an id the caller cannot see exists',
+  parity: 'match',
+
+  // A real split IS in the file, so the empty answer is the id\'s doing rather
+  // than the file\'s.
+  setup: setups(plainSplitParent, pinnedLedgerTimes),
+  command: {
+    verb: 'splits_for',
+    payload: { user_id: USER, transaction_id: '70000000-0000-0000-0000-00000000dead' },
+  },
+  expect: { outcome: 'ok' },
+  result: { splits: [] },
+  state: [
+    balanceIdentityHolds(EVERYDAY),
+    auditRowsInTotal('0'),
+  ],
+};

--- a/scripts/local-sqlite/verb-specs/read-splits-for-a-row-that-is-not-split-answers-with-an-empty-list.spec.mjs
+++ b/scripts/local-sqlite/verb-specs/read-splits-for-a-row-that-is-not-split-answers-with-an-empty-list.spec.mjs
@@ -1,0 +1,20 @@
+import {
+  USER, EVERYDAY, CORNER_SHOP,
+  balanceIdentityHolds, auditRowsInTotal,
+} from './_shared.mjs';
+
+export default {
+  invariant: 'READ-12',
+  title: 'a transaction that is not split has no lines, and that is an answer rather than a refusal',
+  design: 'dataPort.ts: "Splits for one transaction, in display order (empty when not split)." Every ordinary transaction in a ledger answers this way, so it is the common case and not an edge one',
+  consequence: 'the edit modal asks this before it knows whether a row is split. A refusal here would be an error dialog for opening an ordinary transaction',
+  parity: 'match',
+
+  command: { verb: 'splits_for', payload: { user_id: USER, transaction_id: CORNER_SHOP } },
+  expect: { outcome: 'ok' },
+  result: { splits: [] },
+  state: [
+    balanceIdentityHolds(EVERYDAY),
+    auditRowsInTotal('0'),
+  ],
+};

--- a/scripts/local-sqlite/verb-specs/read-splits-for-one-parents-lines-come-back-in-display-order.spec.mjs
+++ b/scripts/local-sqlite/verb-specs/read-splits-for-one-parents-lines-come-back-in-display-order.spec.mjs
@@ -1,0 +1,29 @@
+import {
+  USER, EVERYDAY, CORNER_SHOP, WEEKLY_SHOP, LEG_LINE, PLAIN_LINE,
+  setups, plainSplitParent, aSecondSplitParent, pinnedLedgerTimes, listedSplit,
+  balanceIdentityHolds, auditRowsInTotal,
+} from './_shared.mjs';
+
+export default {
+  invariant: 'READ-12',
+  title: 'asking for one parent answers with that parent\'s lines, in the order they are drawn',
+  design: 'transactionService.getTransactionSplits(transactionId): .select(\'*\').eq(\'transaction_id\', …).order(\'sort_order\'). The seam names it listTransactionSplitsFor and says why the suffix exists — so that "all of them" and "one row\'s" are told apart by more than their arity at the call site',
+  consequence: 'this is what the edit modal draws when a split is opened, so the order is the order the lines are typed in and the sum is checked in. A read that answered with every parent\'s lines would put another transaction\'s money in the box',
+  parity: 'match',
+
+  // A SECOND parent is in the file on purpose: a port that ignored the id and
+  // answered with the whole store would pass a fixture with only one.
+  setup: setups(plainSplitParent, aSecondSplitParent, pinnedLedgerTimes),
+  command: { verb: 'splits_for', payload: { user_id: USER, transaction_id: CORNER_SHOP } },
+  expect: { outcome: 'ok' },
+  result: {
+    splits: [
+      listedSplit({ id: LEG_LINE, category: WEEKLY_SHOP, amount: '-15.00', sort_order: 0 }),
+      listedSplit({ id: PLAIN_LINE, category: WEEKLY_SHOP, amount: '-10.00', sort_order: 1 }),
+    ],
+  },
+  state: [
+    balanceIdentityHolds(EVERYDAY),
+    auditRowsInTotal('0'),
+  ],
+};

--- a/scripts/local-sqlite/verb-specs/read-transactions-a-login-with-nothing-in-it-answers-with-an-empty-list.spec.mjs
+++ b/scripts/local-sqlite/verb-specs/read-transactions-a-login-with-nothing-in-it-answers-with-an-empty-list.spec.mjs
@@ -1,0 +1,22 @@
+import {
+  USER, EVERYDAY, RAINY_DAY,
+  nothingOfMine, balanceIdentityHolds, auditRowsInTotal,
+} from './_shared.mjs';
+
+export default {
+  invariant: 'READ-8',
+  title: 'a ledger with nothing in it answers with an empty list, not with a refusal',
+  design: 'dataPort.ts holds loadBootTransactions to a floor: it NEVER REJECTS, because the boot effect has one outer catch and reaching it replaces the whole app with "Failed to load data" for somebody whose ledger is fine. An empty ledger is the state every new login starts in',
+  consequence: 'the shape matters as much as the emptiness: the far side maps answer.transactions, and null there is a different bug from [] — one says "no transactions" and the other says "this read does not work"',
+  parity: 'match',
+
+  setup: nothingOfMine,
+  command: { verb: 'list_transactions', payload: { user_id: USER } },
+  expect: { outcome: 'ok' },
+  result: { transactions: [] },
+  state: [
+    balanceIdentityHolds(EVERYDAY),
+    balanceIdentityHolds(RAINY_DAY),
+    auditRowsInTotal('0'),
+  ],
+};

--- a/scripts/local-sqlite/verb-specs/read-transactions-a-split-parents-blank-category-is-blank-and-not-null.spec.mjs
+++ b/scripts/local-sqlite/verb-specs/read-transactions-a-split-parents-blank-category-is-blank-and-not-null.spec.mjs
@@ -1,0 +1,27 @@
+import {
+  USER, EVERYDAY,
+  setups, plainSplitParent, pinnedLedgerTimes, listedTransaction,
+  balanceIdentityHolds, auditRowsInTotal,
+} from './_shared.mjs';
+
+export default {
+  invariant: 'READ-9',
+  title: 'a split parent files under nothing, and "nothing" is the empty string rather than NULL',
+  design: 'S-4: a split parent\'s own category is blanked when its lines take over the filing, and both schemas store the empty string rather than NULL — trg_protect_split_category and its cloud twin depend on telling the two apart, and so does every screen that asks whether a row is categorised (category IS NULL OR btrim(category) = \'\' is the predicate two verbs turn on)',
+  consequence: 'a mapper that folded "" into null, or null into "", would be a difference no assertion about a category id could see. The register would show a split parent as uncategorised in one engine and as filed-under-nothing in the other, and the review sweep would offer to categorise it in exactly one of them',
+  parity: 'match',
+
+  setup: setups(plainSplitParent, pinnedLedgerTimes),
+  command: { verb: 'list_transactions', payload: { user_id: USER } },
+  expect: { outcome: 'ok' },
+  result: {
+    transactions: [
+      listedTransaction({ category: '', is_split: true, category_confirmed: false }),
+    ],
+  },
+  state: [
+    // The lines sum to the parent, so nothing moved.
+    balanceIdentityHolds(EVERYDAY),
+    auditRowsInTotal('0'),
+  ],
+};

--- a/scripts/local-sqlite/verb-specs/read-transactions-an-archived-row-is-still-in-the-answer.spec.mjs
+++ b/scripts/local-sqlite/verb-specs/read-transactions-an-archived-row-is-still-in-the-answer.spec.mjs
@@ -1,0 +1,25 @@
+import {
+  USER, EVERYDAY, WEEKLY_SHOP,
+  setups, anArchivedRow, pinnedLedgerTimes, listedTransaction,
+  balanceIdentityHolds, auditRowsInTotal,
+} from './_shared.mjs';
+
+export default {
+  invariant: 'READ-10',
+  title: 'the archive is a view flag, so an archived row is in this answer with its flag set',
+  design: '20260721130000_soft_archive.sql: "A transaction is archived purely as a VIEW flag. It stays in the transactions table." The boot query filters on user_id and NOTHING else — it selects `archived` as a column and the register does its hiding in memory',
+  consequence: 'R-1 from the other end. The client sums the list it is given, so a read that filtered the archive would take a user\'s archived history out of every client-side total while account_balances kept it in — two figures on one dashboard, disagreeing by however much history was archived, with nothing on screen to explain it',
+  parity: 'match',
+
+  setup: setups(anArchivedRow, pinnedLedgerTimes),
+  command: { verb: 'list_transactions', payload: { user_id: USER } },
+  expect: { outcome: 'ok' },
+  result: {
+    transactions: [listedTransaction({ archived: true, category: WEEKLY_SHOP })],
+  },
+  state: [
+    // Archiving moved no money, which is the rule it exists to keep.
+    balanceIdentityHolds(EVERYDAY),
+    auditRowsInTotal('0'),
+  ],
+};

--- a/scripts/local-sqlite/verb-specs/read-transactions-arrive-newest-first-and-the-tie-is-broken-by-id.spec.mjs
+++ b/scripts/local-sqlite/verb-specs/read-transactions-arrive-newest-first-and-the-tie-is-broken-by-id.spec.mjs
@@ -1,0 +1,42 @@
+import {
+  USER, EVERYDAY, CORNER_SHOP, WEEKLY_SHOP,
+  A_LATER_DAY, SAME_DAY_EARLIER, SAME_DAY_LATER,
+  setups, rowsOnOneDay, pinnedLedgerTimes, listedTransaction,
+  balanceIdentityHolds, auditRowsInTotal,
+} from './_shared.mjs';
+
+export default {
+  invariant: 'READ-8',
+  title: 'the ledger comes back newest first, and rows sharing a day are settled by id',
+  design: 'transactionService.fetchTransactionPage: .eq(\'user_id\', …).order(\'date\', { ascending: false }).order(\'id\', { ascending: false }). The second key is the CLOUD\'s own and its comment says why — "stable tiebreak for paging" — so unlike every other read in this crate the tie-break here is ported rather than stated: a fetch spread over ~52 pages of an unstably-ordered query hands the same row over twice and loses another',
+  consequence: 'the register draws in the order this answer arrives. Three rows on one day that swapped places between boots would be a page that reshuffles itself for no reason, and a running balance drawn down a column would be arithmetic nobody could check',
+  parity: 'match',
+
+  // The ids are chosen so id order and INSERTION order disagree: …f3 is written
+  // second and must come out first. They also settle a cross-engine question
+  // nothing else here asks — SQLite compares these as 36 characters of
+  // lower-case hex and Postgres as sixteen bytes, and the two orders agree only
+  // because hex digits sort the same way in ASCII as their nibble values do.
+  setup: setups(rowsOnOneDay, pinnedLedgerTimes),
+  command: { verb: 'list_transactions', payload: { user_id: USER } },
+  expect: { outcome: 'ok' },
+  result: {
+    transactions: [
+      listedTransaction({
+        id: A_LATER_DAY, description: 'A later day', amount: '-1.00',
+        date: '2024-03-02', category: null,
+      }),
+      listedTransaction({
+        id: SAME_DAY_LATER, description: 'Second in', amount: '-1.00', category: null,
+      }),
+      listedTransaction({
+        id: SAME_DAY_EARLIER, description: 'First in', amount: '-1.00', category: null,
+      }),
+      listedTransaction({ category: WEEKLY_SHOP }),
+    ],
+  },
+  state: [
+    balanceIdentityHolds(EVERYDAY),
+    auditRowsInTotal('0'),
+  ],
+};

--- a/scripts/local-sqlite/verb-specs/read-transactions-every-column-the-boot-reads-crosses-with-its-own-value.spec.mjs
+++ b/scripts/local-sqlite/verb-specs/read-transactions-every-column-the-boot-reads-crosses-with-its-own-value.spec.mjs
@@ -1,0 +1,41 @@
+import {
+  USER, EVERYDAY, RAINY_DAY, WEEKLY_SHOP,
+  setups, everyColumnTheBootReads, pinnedLedgerTimes, listedTransaction,
+  balanceIdentityHolds, auditRowsInTotal,
+} from './_shared.mjs';
+
+export default {
+  invariant: 'READ-9',
+  title: 'the twenty-two columns the boot asks for come back, money as a decimal string and tags as an array',
+  design: 'BOOT_TRANSACTION_COLUMNS is an EXPLICIT list, not select(\'*\'): the wide table is 32 columns, PostgREST sends a key for every one even when null, and across 51k rows ~38% of the payload was columns nothing reads. What a read projects is what the cloud\'s own query projects, so the port carries that list and not the table',
+  consequence: 'a column dropped here is a field silently undefined in app state — the transactionService comment says exactly that. The one this fixture exists for is the DEFAULT: on a bare row needs_review, statement_sequence and category_confirmed are all at their defaults, and a default is the one value that cannot tell a working mapping from a missing one',
+  parity: 'match',
+
+  // ONE tag: this spec is about the columns being CARRIED. Whether two of them
+  // come back in the same order is a different question with a different answer
+  // on each engine, and it has its own spec.
+  setup: setups(everyColumnTheBootReads, pinnedLedgerTimes),
+  command: { verb: 'list_transactions', payload: { user_id: USER } },
+  expect: { outcome: 'ok' },
+  result: {
+    transactions: [
+      listedTransaction({
+        category: WEEKLY_SHOP,
+        category_id: WEEKLY_SHOP,
+        category_confirmed: false,
+        needs_review: true,
+        notes: 'a note',
+        is_cleared: true,
+        is_recurring: true,
+        statement_sequence: 7,
+        transfer_account_id: RAINY_DAY,
+        tags: ['zebra'],
+      }),
+    ],
+  },
+  state: [
+    balanceIdentityHolds(EVERYDAY),
+    balanceIdentityHolds(RAINY_DAY),
+    auditRowsInTotal('0'),
+  ],
+};

--- a/scripts/local-sqlite/verb-specs/read-transactions-somebody-elses-row-is-not-in-the-answer.spec.mjs
+++ b/scripts/local-sqlite/verb-specs/read-transactions-somebody-elses-row-is-not-in-the-answer.spec.mjs
@@ -1,0 +1,25 @@
+import {
+  USER, EVERYDAY, SOMEONE_ELSES_ACCOUNT, WEEKLY_SHOP,
+  setups, secondUser, strangersRow, pinnedLedgerTimes, listedTransaction,
+  balanceIdentityHolds, auditRowsInTotal,
+} from './_shared.mjs';
+
+export default {
+  invariant: 'READ-8',
+  title: 'a second login\'s rows are in the file and not in the answer',
+  design: 'the cloud narrows this twice — .eq(\'user_id\', userId) in the query and RLS underneath it. A file has neither underneath, so the owner in the payload is the WHOLE gate, which is why every read verb takes a required String rather than an Option',
+  consequence: 'a file really can hold two logins\' rows — a backup restored from an account that had two, or this harness\'s own second user — and a read that left the owner off would put a stranger\'s spending in this login\'s register and this login\'s totals',
+  parity: 'match',
+
+  setup: setups(secondUser, strangersRow, pinnedLedgerTimes),
+  command: { verb: 'list_transactions', payload: { user_id: USER } },
+  expect: { outcome: 'ok' },
+  result: {
+    transactions: [listedTransaction({ category: WEEKLY_SHOP })],
+  },
+  state: [
+    balanceIdentityHolds(EVERYDAY),
+    balanceIdentityHolds(SOMEONE_ELSES_ACCOUNT),
+    auditRowsInTotal('0'),
+  ],
+};

--- a/scripts/local-sqlite/verb-specs/read-transactions-tags-are-a-list-in-the-cloud-and-a-set-here.spec.mjs
+++ b/scripts/local-sqlite/verb-specs/read-transactions-tags-are-a-list-in-the-cloud-and-a-set-here.spec.mjs
@@ -1,0 +1,28 @@
+import {
+  USER, EVERYDAY, WEEKLY_SHOP,
+  setups, twoTagsInTheWrongOrder, pinnedLedgerTimes, listedTransaction,
+  balanceIdentityHolds, auditRowsInTotal,
+} from './_shared.mjs';
+
+export default {
+  invariant: 'READ-9',
+  title: 'both engines answer with the same two tags, and only one of them can say which was typed first',
+  design: 'the cloud stores tags as text[] — an ORDERED list, which remembers that "zebra" was written before "apple". schema.sql stores them as transaction_tags with PRIMARY KEY (transaction_id, tag), which is a SET and has no insertion order to remember, so the local read answers in tag order. Neither is wrong; they are two data structures, and only one of them holds the fact',
+  consequence: 'this is the divergence lib/verb-sqlite.mjs already sorts around for the WRITE verbs ("a child table is a SET; sorting both is the only comparison that is not an accident"). It is declared here rather than sorted, because a read answers with rows and the sorting the runner does at the top level does not reach a field inside one — and because the alternative, sorting every nested array of strings, would make list_suggestion_dismissals\' role-order proof vacuous: THAT array\'s order is a fact and this one\'s is not',
+  parity: 'divergent',
+  reason: 'tag ORDER only. Both engines answer with exactly the same two tags on the same row; the cloud gives them back as written and the local file gives them back in tag order, because a set has no other order to give',
+
+  setup: setups(twoTagsInTheWrongOrder, pinnedLedgerTimes),
+  command: { verb: 'list_transactions', payload: { user_id: USER } },
+  expect: { outcome: 'ok' },
+  result: {
+    transactions: {
+      sqlite: [listedTransaction({ category: WEEKLY_SHOP, tags: ['apple', 'zebra'] })],
+      postgres: [listedTransaction({ category: WEEKLY_SHOP, tags: ['zebra', 'apple'] })],
+    },
+  },
+  state: [
+    balanceIdentityHolds(EVERYDAY),
+    auditRowsInTotal('0'),
+  ],
+};


### PR DESCRIPTION
Phase 3, slice 16 — the heavyweight reads: `list_transactions`, `list_transaction_splits`, `splits_for`, and `account_balances`, the money verb.

## The money properties (each with its mutation, each red on cue — 8/8)
1. **Derived, never stored** (R-2): balance = initial + Σ amounts; mutating to read `accounts.balance` reddens its named spec.
2. **Archived included** (R-1): archived money still moved. The slice corrected its own brief with evidence — the signed-in boot has *no* archived filter (the flag rides back as a column; the register hides in memory), so the trap has **two doors**, ledger and balance, both specced.
3. **LEFT JOIN**: an untouched account still reports its opening balance.
4. **COUNT(t.id), not COUNT(*)**: an untouched account's count is zero.
Plus the slice-15 standards (ordering, minor-units leak) and the split-scoping trap (a line of mine on somebody else's parent is still mine).

## Performance, measured
50k-row `ANALYZE`'d fixture; plans asserted, times printed. The three boot reads total **~76ms** release vs the **2.7s** the cloud RPC's own commentary records for the paged fetches they replace. One index earned by measurement (SCAN → SEARCH — a scan walks every login's lines, and restored multi-login files are why the owner column exists); one rejected as noise; one **5× faster rewrite of the money verb rejected** because it made property 4 unprovable — a test now asserts the plan's shape and points the next optimiser at the reasoning. Each heavy read's SQL is a named constant so plan assertions bind *the* query, not a copy.

## Honesty in the harness
The differential oracle calls the **live** balances RPC with production identity plumbing (`request.jwt.claims`), not a parameterised rewrite. One declared divergence with its reason: cloud tag arrays remember insertion order, a child table cannot — sorting it away in the runner would make the dismissals role-order proof vacuous.

## Counts
Cargo 284 → **300** · verb lane 326 → **347** (all green, 11 declared divergences) · admission 109 · constraint 65/66 (known a3 C/R-split parity gap, byte-identical) · app smoke untouched-green · zero app TS changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)