### PR TITLE
feat(core): slice 17 — the boot becomes one question of one file (354 verb specs +7, 313 cargo tests)

### DIFF
--- a/crates/wealth-core/src/command.rs
+++ b/crates/wealth-core/src/command.rs
@@ -83,9 +83,10 @@ use crate::verbs::{
     delete_transaction, delete_unused_categories, finalize_user_restore, import_bank_transactions,
     import_transactions, link_bank_account_snap, link_split_line_transfer, link_transfer_pair,
     list_accounts, list_budgets, list_categories, list_closed_accounts, list_goals,
-    list_suggestion_dismissals, list_transaction_splits, list_transactions, merge_categories,
-    repair_claimed_transfer, restore_user_chunk, set_transaction_splits_with_legs, splits_for,
-    update_transaction, user_financial_data_is_empty, verify_integrity, wipe_user_financial_data,
+    list_suggestion_dismissals, list_transaction_splits, list_transactions, load_boot,
+    merge_categories, repair_claimed_transfer, restore_user_chunk,
+    set_transaction_splits_with_legs, splits_for, update_transaction, user_financial_data_is_empty,
+    verify_integrity, wipe_user_financial_data,
     ApplyCategoryToUncategorized, ClearTransferLinks, ConfirmTransactionCategories,
     CreateTransaction, CreateTransferCounterpart, DeleteTransaction, DeleteUnusedCategories,
     FinalizeUserRestore, ImportBankTransactions, ImportTransactions, LinkBankAccountSnap,
@@ -184,7 +185,8 @@ pub enum Command {
     ImportBankTransactions(Box<ImportBankTransactions>),
     // ── The reads ────────────────────────────────────────────────────────────
     //
-    // Ten verbs that answer and write nothing. Nine are named for the question
+    // Ten verbs that answer and write nothing, and then an eleventh below them
+    // that is all ten of the boot's at once. Nine are named for the question
     // they answer rather than for a function they port, because there is no
     // function to port: the cloud reads those tables over PostgREST, so what is
     // ported is a QUERY — its filter and its ORDER BY, spelled out in
@@ -232,6 +234,17 @@ pub enum Command {
     SplitsFor(Box<SplitsFor>),
     /// [`crate::verbs::account_balances`].
     AccountBalances(Box<OwnedRead>),
+    // The composite, and the eleventh thing that answers without writing. It
+    // takes the same owner-only payload the reads take, because it is the same
+    // question asked six times at once — and NOT a payload of its own with
+    // `include_balances` or `since` in it, which is what a composite grows if
+    // its payload is a place things can be added to.
+    //
+    // The name is the seam's method, `loadBoot`, in this crate's spelling. It is
+    // a port of no SQL: the thing it ports is `DataServiceImpl.loadBoot`, whose
+    // body IS the six reads above.
+    /// [`crate::verbs::load_boot`].
+    LoadBoot(Box<OwnedRead>),
     // The only verb here that is NOT a port: the cloud has no verify_integrity,
     // no view and no equivalent, and the verb's module documentation carries the
     // trace that establishes it. Its payload is `{}` — it takes not even an
@@ -453,6 +466,11 @@ pub fn dispatch(
         Command::AccountBalances(payload) => {
             account_balances(&*connection, *payload).and_then(as_json)
         }
+        // The one answering verb that takes the connection by `&mut`, and the
+        // only place in this match where that is not a sign of a write: it
+        // opens a DEFERRED read transaction so its six answers are one
+        // snapshot, and a transaction needs the connection to itself.
+        Command::LoadBoot(payload) => load_boot(connection, *payload).and_then(as_json),
         // A self-check with a name, and the same shape as the split writer's
         // `split_write_inconsistent`: [`plan`] above answers every one of these
         // and returns before a file is ever opened, so nothing can arrive here.

--- a/crates/wealth-core/src/verbs/load_boot.rs
+++ b/crates/wealth-core/src/verbs/load_boot.rs
@@ -1,0 +1,276 @@
+//! The boot, as ONE question asked of an open file.
+//!
+//! Every other verb in this crate answers something a caller thought of. This
+//! one answers what the application asks the moment it starts: what accounts
+//! are there, what names can things be filed under, what is in the ledger, what
+//! its split lines are, and what the budgets and the goals say. Six answers,
+//! one call, one transaction.
+//!
+//! # The question is the seam's, and the seam already wrote it down
+//!
+//! `dataPort.ts` declares `loadBoot(): Promise<BootSnapshot>` and says why it
+//! is one call rather than six: *"the ORDER between them is a rule rather than
+//! an accident (categories before transactions; budgets and goals together,
+//! never one after the other), and a rule spread over six call-site awaits can
+//! only be kept by the one call site that happens to read it."*
+//!
+//! The cloud keeps that rule by OBEYING it — `DataServiceImpl.loadBoot` is the
+//! boot effect's old sequence moved behind the seam, six network crossings in
+//! the order the app depended on. A file has no such sequence to keep, and the
+//! contract suite says so in its own vocabulary: `BOOT_COMPOSITION`'s
+//! `'local-core'` row is `{ describes: 'one crossing, one transaction, one
+//! snapshot', fansOut: false }`, and the note above it explains what that buys
+//! — *"Ordering is not kept there, it is unable to be broken there, which is a
+//! stronger property"*. This verb is what makes that row true.
+//!
+//! # What is in the answer, key by key
+//!
+//! ```text
+//! BootSnapshot field   this answer's key     the read it composes
+//! ──────────────────   ───────────────────   ─────────────────────────────
+//! accounts             accounts              list_accounts
+//! categories           categories            list_categories
+//! transactions         transactions          list_transactions
+//! splits               transaction_splits    list_transaction_splits
+//! budgets              budgets               list_budgets
+//! goals                goals                 list_goals
+//! transactionStats     — the port's          (see below)
+//! phases               — the port's          (see below)
+//! ```
+//!
+//! Five of the six keys are the seam's own field names. The sixth is not:
+//! `splits` there is `transaction_splits` here, because this crate names a read
+//! after the QUESTION it answers and there are two split reads — `splits_for`
+//! already owns the bare word for *one parent's* lines. A key that meant "all
+//! of them" in one answer and "one row's" in another is the kind of thing that
+//! is read wrongly once and then believed. The port maps the name where every
+//! other snake-to-camel mapping already happens.
+//!
+//! # What is NOT in the answer, and each absence is a decision
+//!
+//! **The balances (R-4).** `account_balances` is the seam's parallel seventh
+//! read and it stays outside this answer, exactly as it stays outside
+//! `BootSnapshot`. The seam's own paragraph is the argument and it applies
+//! verbatim to a file: those figures *"exist for exactly the seconds a long
+//! history is in flight"*, the seeding rule that uses them fires only while
+//! `transactions.length === 0`, and *"a read whose entire purpose is to be early
+//! cannot be bundled with the thing it is early for"*. Folding them in here
+//! would not merely make the answer bigger — it would make the early answer
+//! arrive at the same instant as the thing it was early for, which is the same
+//! as not having it. The map is a separate verb precisely so a caller can start
+//! it FIRST and await it LAST.
+//!
+//! There is a second half to R-4 that a file makes easy to get wrong. The
+//! accounts in this answer carry `accounts.balance`, the STORED figure, because
+//! that is the column the read they come from projects. A composite that
+//! "helpfully" replaced it with the derived total would be answering
+//! [`crate::verbs::account_balances`]'s question under another verb's name, and
+//! the one instrument that exists to catch a drifted cache
+//! ([`crate::verbs::verify_integrity`]'s `balance_identity`) would be reporting
+//! a disagreement nobody's figures could contradict. Two numbers are only worth
+//! having while they are arrived at independently. Both halves have a named
+//! spec.
+//!
+//! **The transaction stats.** `BootSnapshot.transactionStats` says how the rows
+//! were obtained — how many came from a cache, how many from a delta, and in
+//! words why no snapshot was served. Every one of those is a fact about a
+//! FETCH STRATEGY, and a file has none: it has rows. The port answers them the
+//! way divergence B-1 already says browser storage does, with `'local mode'`,
+//! and it is the port rather than this verb for a reason that decides it: the
+//! OTHER sentence in that vocabulary is `'load failed'`, which is what the boot
+//! must say when this crate could not be reached at all. A verb cannot answer
+//! for the case where the verb did not run. One vocabulary, one owner.
+//!
+//! **The phases.** `BootSnapshot.phases` is a duration per phase, and an answer
+//! that carries a duration is an answer that is never twice the same — which is
+//! precisely what the differential harness compares. The caller times the one
+//! crossing there is; a per-read breakdown is what
+//! `crates/wealth-core/tests/reads_at_scale.rs` records, on a ledger the size of
+//! a real one, where a measurement means something.
+//!
+//! **The closed accounts and the suggestion dismissals.** Neither is a boot
+//! read in the application either: `listClosedAccounts` is asked by the three
+//! surfaces that show closed accounts (`Accounts.tsx`, `AccountTransactions.tsx`,
+//! `useAccountNames.ts`), and `listSuggestionDismissals` by
+//! `refreshSuggestionDismissals`, when a sweep opens. Putting them here would
+//! make every boot pay for two answers most boots never look at, and would make
+//! this verb something other than a port of `loadBoot`.
+//!
+//! **Anything that WRITES.** The cloud's composite may change the store on its
+//! way past — `prepareCategories` runs `migrate_categories_atomic` on a first
+//! signed-in load — and that is the whole reason the cloud's category read must
+//! be awaited before its transaction read. A local file has no second id space
+//! to migrate from ([`super`]'s own argument for not porting that function), so
+//! the category answer here is [`crate::verbs::list_categories`] and nothing
+//! more. Seeding a brand-new file's defaults is `seed_categories`' job, once,
+//! before this verb has anything to answer with.
+//!
+//! # ONE BEGIN … COMMIT, and it is a READ transaction
+//!
+//! PHASE3-PLAN §3 specifies it — *"load_boot (ONE BEGIN..COMMIT around six
+//! reads)"* — and the reason is worth stating rather than citing, because every
+//! other read in this crate deliberately opens no transaction at all.
+//!
+//! A statement outside a transaction gets its own snapshot. Six of them get
+//! six, and between any two of them another connection's write can commit. The
+//! damage that does is not an abstract inconsistency: it is a boot whose
+//! `transactions` include a row whose account is not in its `accounts`, or a
+//! split parent whose lines were read a moment before they were written. The
+//! application then draws a register filed against an account it does not know
+//! about, and nothing anywhere reports an error. A transaction makes the six
+//! answers ONE snapshot of ONE file, which is what "one crossing" has to mean
+//! if it is to mean anything.
+//!
+//! It is `DEFERRED`, spelled out rather than defaulted, because the difference
+//! matters: `IMMEDIATE` would take a write lock to do no writing, and this verb
+//! must never be the reason an import cannot start. What a deferred read
+//! transaction does hold, in this schema's journal mode, is a SHARED lock for
+//! its duration — measured at the fifty-thousand-row size in
+//! `tests/reads_at_scale.rs` — so a writer arriving mid-boot waits that long
+//! rather than tearing the answer in half. That is the trade, and it is the
+//! right way round: the boot is the one moment when nothing else is happening
+//! yet, and `db::configure`'s `busy_timeout` of five seconds is an order of
+//! magnitude more than the wait.
+//!
+//! **The desktop is single-writer, and that is not the reason this is safe.**
+//! One connection behind a mutex means the application cannot race itself; it
+//! says nothing about the second process the two locks in PHASE3-PLAN §5 exist
+//! to refuse, about a backup tool, or about the differential harness, which
+//! opens the file from Node and from Rust in the same breath. A consistency
+//! story that depends on nobody else ever opening the file is a story that is
+//! true until it is not, and it would be untrue silently.
+//!
+//! What a test can prove about this is less than one would like, and it is
+//! worth being honest about which is which. Provable, and proved below: the
+//! transaction is finished rather than leaked (a leaked read transaction would
+//! hold that shared lock for the life of the document, and the next call would
+//! fail outright). Not provable without a second thread whose timing decides
+//! the result: that a write cannot land in the middle. A flaky test that fails
+//! on a busy laptop teaches people to re-run tests until they pass, so what is
+//! here is the assertion that holds every time, and this paragraph is the rest.
+//!
+//! # It composes the reads; it does not re-implement them
+//!
+//! Every list below comes from the same `crate::row` function the verb of the
+//! same name calls. There is no SQL in this file, and that is structural rather
+//! than tidy: those functions hold the ONE copy of each query, the plan
+//! assertions in `tests/reads_at_scale.rs` are made against those same strings,
+//! and a second copy here would be a second query that could drift while every
+//! plan assertion went on passing.
+//!
+//! It is also what makes the two ordering rules survive the composite (R-5).
+//! `list_transactions` orders by `date DESC, id DESC` — the cloud's own key and
+//! the cloud's own tie-break — and the ledger inside this answer is that answer,
+//! not a re-sorted copy of it. Contract rule 79 is asserted THROUGH this call on
+//! both engines, and the crate's own tie-breaks are asserted through it too, so
+//! a composite that sorted, filtered or de-duplicated anything on its way out
+//! has a named spec waiting for it. The archive keeps both its doors open the
+//! same way: [`crate::verbs::reads`] explains why neither the ledger read nor
+//! the balance read has heard of it (R-1), and a composite is not a third place
+//! to have an opinion about it.
+//!
+//! # EXPLAIN QUERY PLAN, and what the whole thing costs
+//!
+//! No plan of its own: it runs no query of its own. The six plans are the six
+//! reads', recorded in [`crate::verbs::reads`] and asserted at fifty thousand
+//! rows in `tests/reads_at_scale.rs` — which also measures this verb whole, on
+//! the same ledger, in the same run:
+//!
+//! ```text
+//! load_boot                            64.3–65.6ms / 206ms
+//!   of which, measured beside it:
+//!   list_transactions (50,000 rows)    59.5–60.7ms / 193ms
+//!   list_transaction_splits (8,000)      5.3–5.7ms /  14ms
+//!   accounts + categories + budgets + goals
+//!                                      under 1ms in both
+//! ```
+//!
+//! Release / debug, serially (`--test-threads=1`), over four runs on the
+//! author's machine, and recorded rather than asserted for the reason that whole
+//! file gives: a time bound is a bound on whichever machine runs it. A RANGE
+//! rather than one figure because four runs gave four, and the spread is bigger
+//! than the thing being measured. The two heavy reads' numbers also differ from
+//! the table in [`crate::verbs::reads`], taken in an earlier run — which is
+//! exactly why the parts are re-measured here beside the whole rather than
+//! subtracted from a table.
+//!
+//! **The composite costs the sum of its parts and nothing over.** One `BEGIN`
+//! and one `COMMIT` around work already being done is, at this size, below the
+//! noise floor of the measurement. What it replaces is not the six reads — those
+//! are the work — but the ~2.7 seconds of paged fetches the cloud RPC's own
+//! commentary records for the transactions alone, and five further crossings
+//! behind them.
+
+use rusqlite::{Connection, TransactionBehavior};
+use serde::Serialize;
+
+use crate::error::CoreResult;
+use crate::row::account::{self, ListedAccount};
+use crate::row::budget::{self, ListedBudget};
+use crate::row::category::{self, CategoryRow};
+use crate::row::goal::{self, GoalRow};
+use crate::row::split::{self, ListedSplit};
+use crate::row::{self as transaction, ListedTransaction};
+use crate::verbs::reads::{Answered, OwnedRead};
+
+/// Everything the application boots with, from one snapshot of one file.
+///
+/// The field ORDER is the cloud sequence's — accounts, categories, the ledger,
+/// its lines, then the planning pair — so this struct can be read beside
+/// `DataServiceImpl.loadBoot` and the two seen to be answering the same
+/// question. Here it is presentation only: nothing inside one transaction
+/// happens before anything else in a way a caller can observe, which is the
+/// `fansOut: false` half of the divergence table.
+#[derive(Debug, Serialize)]
+pub struct Boot {
+    /// Open accounts, oldest first. Their `balance` is the STORED figure.
+    pub accounts: Vec<ListedAccount>,
+    /// Every category, by level then name, hidden ones included.
+    pub categories: Vec<CategoryRow>,
+    /// The whole ledger, newest first, ARCHIVED ROWS INCLUDED.
+    pub transactions: Vec<ListedTransaction>,
+    /// Every split line this login owns, parent by parent, in display order.
+    pub transaction_splits: Vec<ListedSplit>,
+    /// Every budget, oldest first, paused ones included.
+    pub budgets: Vec<ListedBudget>,
+    /// Every goal, oldest first, finished ones included.
+    pub goals: Vec<GoalRow>,
+}
+
+/// The boot, in one answer, from one snapshot.
+///
+/// Takes `&mut Connection` where every other read takes `&Connection`, and the
+/// difference is the point rather than an inconvenience: this verb opens a
+/// transaction, so it holds the connection for its duration, and the type says
+/// so before the body does.
+///
+/// # Errors
+/// [`crate::error::CoreError::Storage`] if the file cannot be read. It is NOT
+/// softened into an empty answer here: six empty lists is what a NEW FILE
+/// legitimately answers with, and a verb that said the same thing about a file
+/// it could not open would make the two indistinguishable. Contract rule 81 —
+/// *"loadBoot never rejects"* — is kept one layer out, in `LocalDataPort`,
+/// which is the same place the sentence it must say (`'load failed'`) is
+/// written, and the only place that can answer for a call that did not happen.
+#[allow(clippy::needless_pass_by_value)]
+pub fn load_boot(connection: &mut Connection, command: OwnedRead) -> CoreResult<Answered<Boot>> {
+    let owner = command.user_id;
+    // DEFERRED: a read transaction. See the module docs for what it holds, for
+    // how long, and for what tearing the six answers apart would cost.
+    let snapshot = connection.transaction_with_behavior(TransactionBehavior::Deferred)?;
+
+    let answer = Boot {
+        accounts: account::list_open(&snapshot, &owner)?,
+        categories: category::list_all(&snapshot, &owner)?,
+        transactions: transaction::list_owned(&snapshot, &owner)?,
+        transaction_splits: split::list_owned(&snapshot, &owner)?,
+        budgets: budget::list_all(&snapshot, &owner)?,
+        goals: goal::list_all(&snapshot, &owner)?,
+    };
+
+    // Committed rather than left to drop. Dropping a rusqlite `Transaction`
+    // rolls it back, which for six SELECTs is the same released lock and a
+    // different sentence: this one ended because it was finished.
+    snapshot.commit()?;
+    Ok(Answered { answer })
+}

--- a/crates/wealth-core/src/verbs/mod.rs
+++ b/crates/wealth-core/src/verbs/mod.rs
@@ -349,6 +349,24 @@
 //! the plan requires the plans to be readable — *"a plan saying SCAN is a bug
 //! report, not a merge"* is not a rule anybody can apply to a table they cannot
 //! see.
+//!
+//! # And then the composite, which is the reads asked once
+//!
+//! [`load_boot`] is the first verb in the crate that is a port of no SQL at all:
+//! the thing it ports is a TypeScript method (`DataServiceImpl.loadBoot`) whose
+//! whole body is six of the reads above in the order the boot depended on. It
+//! composes the same `crate::row` functions those reads call — no query of its
+//! own, so no plan of its own — inside ONE deferred read transaction, which is
+//! what makes the contract suite's `BOOT_COMPOSITION` row for this engine (*"one
+//! crossing, one transaction, one snapshot"*) true rather than aspirational.
+//!
+//! It lives in its own module rather than beside them in [`reads`] because it
+//! disagrees with that module's opening claim in one respect that matters: the
+//! reads *"open no transaction, for the reason
+//! [`user_financial_data_is_empty`] gives: there is nothing to be atomic
+//! about"*. A composite has something to be atomic about — six statements are
+//! six snapshots unless something makes them one — and a verb whose behaviour
+//! contradicts its module's header is a verb somebody will read wrongly.
 
 mod apply_category_to_uncategorized;
 mod clear_transfer_links;
@@ -363,6 +381,7 @@ mod import_transactions;
 mod link_bank_account_snap;
 mod link_split_line_transfer;
 mod link_transfer_pair;
+mod load_boot;
 mod merge_categories;
 pub mod reads;
 mod repair_claimed_transfer;
@@ -413,6 +432,10 @@ pub use link_split_line_transfer::{
     link_split_line_transfer, LinkSplitLineTransfer, LinkSplitLineTransferResult,
 };
 pub use link_transfer_pair::{link_transfer_pair, LinkTransferPair, LinkTransferPairResult};
+// The composite. Its payload is the reads' own `OwnedRead` — one owner and
+// nothing else — because that is exactly what it takes; a struct of its own
+// would be a second place for somebody to add a filter to.
+pub use load_boot::{load_boot, Boot};
 pub use merge_categories::{merge_categories, MergeCategories, MergeCategoriesResult};
 // The read family. Re-exported like every other verb so a call site reads the
 // same whether it is asking or writing; the module stays `pub` as well, because

--- a/crates/wealth-core/src/verbs/reads.rs
+++ b/crates/wealth-core/src/verbs/reads.rs
@@ -215,10 +215,22 @@
 //! asserts the temp B-trees are PRESENT, so the day somebody rewrites this for
 //! speed they are sent to this paragraph.
 //!
+//! # The composite is next door, and it is the exception to two of these rules
+//!
+//! [`super::load_boot`] answers six of these ten at once — the accounts, the
+//! categories, the ledger, its lines, the budgets and the goals — and it is in
+//! its own module because it breaks this one's opening claim on purpose: it
+//! DOES open a transaction, a deferred read one, so that its six answers are
+//! one snapshot of one file rather than six snapshots of a file somebody else
+//! may be writing to in between. It also carries no plan of its own, because it
+//! runs no query of its own: it calls the same [`crate::row`] functions the six
+//! verbs below call, which is what keeps their ordering contracts true through
+//! it (R-5) and what stops a second copy of any query from existing.
+//!
 //! # What is still not here
 //!
-//! `load_boot` composes six reads into one transaction, and `collect_backup` is
-//! the backup group's.
+//! `collect_backup`, the backup group's — every table whole, in
+//! `BACKUP_ENTITIES` order.
 
 use rusqlite::Connection;
 use serde::{Deserialize, Serialize};
@@ -233,11 +245,12 @@ use crate::row::goal::{self, GoalRow};
 use crate::row::split::{self, ListedSplit};
 use crate::row::{self as transaction, ListedTransaction};
 
-/// The payload nine of the ten reads take: one owner, and nothing else.
+/// The payload every read but [`splits_for`] takes: one owner, and nothing
+/// else. Nine of the ten here, and [`super::load_boot`] makes it ten.
 ///
-/// One type for nine verbs because it is one argument for nine verbs, and nine
-/// identical struct definitions would be nine places for the next person to add
-/// a filter to. The VERBS stay nine — the enum's exhaustive dispatch is over
+/// One type for ten verbs because it is one argument for ten verbs, and ten
+/// identical struct definitions would be ten places for the next person to add
+/// a filter to. The VERBS stay ten — the enum's exhaustive dispatch is over
 /// variants, not over payload types.
 #[derive(Debug, Deserialize)]
 #[serde(deny_unknown_fields)]

--- a/crates/wealth-core/tests/load_boot.rs
+++ b/crates/wealth-core/tests/load_boot.rs
@@ -1,0 +1,432 @@
+//! Integration tests for the composite — the half of it that has no cloud
+//! counterpart to be differential about.
+//!
+//! `scripts/local-sqlite/verb-specs/boot-*.spec.mjs` holds the other half: seven
+//! specs running one `load_boot` payload against the six queries
+//! `DataServiceImpl.loadBoot` composes, and comparing the two answers list by
+//! list. What is here is what that comparison cannot reach:
+//!
+//! 1. **The SHAPE of the answer** — which keys it has, and, more to the point,
+//!    which it has not. The harness compares the keys both engines produce; only
+//!    a test on this side can say that a key which appears in NEITHER answer is
+//!    absent on purpose. That is where R-4 lives: a balance map folded into this
+//!    verb would close the seeding window the seam keeps open on purpose, and
+//!    the harness would report it as a divergence rather than as the money bug
+//!    it is.
+//! 2. **The two figures side by side** — the stored balance this answer carries
+//!    and the derived one [`account_balances`] computes, asked of the same file
+//!    in the same test, which is the only place their independence is visible.
+//! 3. **The crate's own tie-breaks, through the composite.** The cloud states no
+//!    order under a tie for the accounts, so its oracle deliberately does not
+//!    either; the tie-break is this crate's and R-5 says it must survive being
+//!    composed.
+//! 4. **A file holding two logins**, which is a local possibility with no cloud
+//!    equivalent: there is no RLS behind a file, and the owner in the payload is
+//!    the whole gate — six times over in this verb.
+//! 5. **The transaction**, in the one respect a single-threaded test can prove:
+//!    that it is finished rather than leaked.
+//!
+//! All data is invented. This repo is public: no real payee, account number or
+//! figure appears anywhere in it.
+
+#![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
+
+use rusqlite::Connection;
+use wealth_core::command::{parse, Command};
+use wealth_core::db;
+use wealth_core::verbs::{
+    account_balances, list_accounts, list_budgets, list_categories, list_goals, list_transactions,
+    list_transaction_splits, load_boot, OwnedRead,
+};
+
+const OWNER: &str = "11111111-1111-1111-1111-111111111111";
+const STRANGER: &str = "22222222-2222-2222-2222-222222222222";
+const TRANSFER_ROOT: &str = "c0000000-0000-0000-0000-000000000001";
+const EVERYDAY: &str = "a0000000-0000-0000-0000-000000000001";
+const RAINY_DAY: &str = "a0000000-0000-0000-0000-000000000002";
+const CORNER_SHOP: &str = "70000000-0000-0000-0000-000000000001";
+const SAME_DAY: &str = "70000000-0000-0000-0000-0000000000f1";
+const A_LATER_DAY: &str = "70000000-0000-0000-0000-0000000000f2";
+const SAME_INSTANT: &str = "2024-01-01T00:00:00.000Z";
+
+fn owner(user_id: &str) -> OwnedRead {
+    OwnedRead { user_id: user_id.to_owned() }
+}
+
+/// An empty file with one login in it, and the Transfer root C-3 looks for.
+fn fixture() -> Connection {
+    let connection = db::open_in_memory().expect("open");
+    wealth_core::apply_schema(&connection).expect("schema");
+    connection
+        .execute_batch(&format!(
+            "INSERT INTO users (id, email) VALUES ('{OWNER}', 'harness@example.test');
+             INSERT INTO categories (id, user_id, name, type, level)
+               VALUES ('{TRANSFER_ROOT}', '{OWNER}', 'Transfer', 'both', 'type');"
+        ))
+        .expect("fixture");
+    connection
+}
+
+/// One of everything the boot answers with, so no list is empty by accident.
+///
+/// Two accounts opened in the SAME instant (the tie the crate's own key
+/// settles), three transactions on TWO days (so the ledger's order is
+/// observable and its tie-break is exercised), one of them a split parent with
+/// two lines, a budget and a goal. Every balance is what B-1 says it should be.
+///
+/// The two days matter more than they look. With every row on one date, Rust's
+/// stable sort makes a mutation that re-orders the ledger by date alone a
+/// NO-OP, and the composition test below passes on a composite that sorts. It
+/// was written that way first and the mutation walked straight through it.
+fn a_whole_ledger(connection: &Connection) {
+    connection
+        .execute_batch(&format!(
+            "INSERT INTO accounts (id, user_id, name, type, balance_minor,
+                                   initial_balance_minor, created_at, updated_at) VALUES
+               ('{RAINY_DAY}', '{OWNER}', 'Rainy day', 'savings', 1000, 1000,
+                '{SAME_INSTANT}', '{SAME_INSTANT}'),
+               ('{EVERYDAY}',  '{OWNER}', 'Everyday', 'checking', -2700, 0,
+                '{SAME_INSTANT}', '{SAME_INSTANT}');
+             INSERT INTO transactions (id, user_id, account_id, description, amount_minor,
+                                       type, date, category, is_split) VALUES
+               ('{CORNER_SHOP}', '{OWNER}', '{EVERYDAY}', 'Corner shop', -2500,
+                'expense', '2024-03-01', '', 1),
+               ('{SAME_DAY}', '{OWNER}', '{EVERYDAY}', 'Same day', -100,
+                'expense', '2024-03-01', '{TRANSFER_ROOT}', 0),
+               ('{A_LATER_DAY}', '{OWNER}', '{EVERYDAY}', 'A later day', -100,
+                'expense', '2024-03-02', '{TRANSFER_ROOT}', 0);
+             INSERT INTO transaction_splits (id, transaction_id, user_id, category,
+                                             amount_minor, sort_order) VALUES
+               ('50000000-0000-0000-0000-0000000000b1', '{CORNER_SHOP}', '{OWNER}',
+                '{TRANSFER_ROOT}', -1000, 0),
+               ('50000000-0000-0000-0000-0000000000b2', '{CORNER_SHOP}', '{OWNER}',
+                '{TRANSFER_ROOT}', -1500, 1);
+             INSERT INTO budgets (id, user_id, name, amount_minor, period, start_date)
+               VALUES ('b0000000-0000-0000-0000-000000000001', '{OWNER}', 'Food', 12345,
+                       'monthly', '2024-01-01');
+             INSERT INTO goals (id, user_id, name, target_amount_minor)
+               VALUES ('90000000-0000-0000-0000-000000000001', '{OWNER}', 'New boiler', 150000);"
+        ))
+        .expect("ledger");
+}
+
+// ── The shape of the answer, which is where R-4 lives ───────────────────────
+
+#[test]
+fn the_boot_answers_with_six_lists_and_no_balance_map() {
+    let mut connection = fixture();
+    a_whole_ledger(&connection);
+
+    let answered = load_boot(&mut connection, owner(OWNER)).expect("boot");
+    let json = serde_json::to_value(&answered).expect("json");
+    let keys: Vec<&str> = json["answer"]
+        .as_object()
+        .expect("an object")
+        .keys()
+        .map(String::as_str)
+        .collect();
+
+    // R-4, as a key set. `account_balances` is the seam's parallel SEVENTH read
+    // and the whole value of it is that it arrives BEFORE the ledger does: the
+    // seeding rule fires only while `transactions.length === 0`, so a map that
+    // arrives WITH the transactions has nothing left to seed and every account
+    // reads zero for the whole boot. Folding it in here is not a bigger answer,
+    // it is the loss of the answer that mattered.
+    //
+    // The other three absences are decisions too, argued at the verb:
+    // `transaction_stats` and `phases` are the port's vocabulary (one of those
+    // sentences is `'load failed'`, which only the port can say), and the closed
+    // accounts and the dismissals are not boot reads in the application either.
+    assert_eq!(
+        keys,
+        vec![
+            "accounts",
+            "categories",
+            "transactions",
+            "transaction_splits",
+            "budgets",
+            "goals"
+        ]
+    );
+}
+
+#[test]
+fn the_stored_balance_crosses_the_boot_untouched_while_the_derived_one_is_asked_separately() {
+    let mut connection = fixture();
+    a_whole_ledger(&connection);
+    // A cache that has drifted: the rows say −27.00, the column says 999.99.
+    // The only fixture in this file that plants a B-1 violation, planted for the
+    // reason `aStoredBalanceThatDrifted` gives — the violation IS the subject.
+    connection
+        .execute_batch(&format!(
+            "UPDATE accounts SET balance_minor = 99999 WHERE id = '{EVERYDAY}';"
+        ))
+        .expect("drift");
+
+    let boot = load_boot(&mut connection, owner(OWNER)).expect("boot");
+    let everyday = boot
+        .answer
+        .accounts
+        .iter()
+        .find(|account| account.id == EVERYDAY)
+        .expect("the account");
+    let derived = account_balances(&connection, owner(OWNER)).expect("balances");
+    let aggregate = derived
+        .answer
+        .account_balances
+        .iter()
+        .find(|balance| balance.account_id == EVERYDAY)
+        .expect("the balance");
+
+    // The second half of R-4, and the half a key set cannot catch. The boot
+    // carries the STORED figure because that is the column its accounts read
+    // projects; the money verb DERIVES its own. A composite that quietly
+    // corrected one with the other would make the two agree always — and two
+    // numbers are only worth having while they are arrived at independently.
+    // `verify_integrity`'s `balance_identity` is the instrument that would then
+    // be reporting a disagreement nobody's figures could contradict.
+    assert_eq!(everyday.balance.to_decimal_string(), "999.99");
+    assert_eq!(aggregate.balance.to_decimal_string(), "-27.00");
+}
+
+#[test]
+fn a_new_file_answers_with_six_empty_arrays_and_not_six_nulls() {
+    let mut connection = fixture();
+    connection
+        .execute_batch(&format!("DELETE FROM categories WHERE user_id = '{OWNER}';"))
+        .expect("empty");
+
+    let answered = load_boot(&mut connection, owner(OWNER)).expect("boot");
+
+    // The far side maps all six by name, and `null` under any of them is a
+    // different bug from `[]`: one says "nothing here yet", which is what a file
+    // on the day it is made legitimately says, and the other says "this read
+    // does not work".
+    assert_eq!(
+        serde_json::to_string(&answered).expect("json"),
+        r#"{"answer":{"accounts":[],"categories":[],"transactions":[],"transaction_splits":[],"budgets":[],"goals":[]}}"#
+    );
+}
+
+// ── It composes the reads; it does not re-implement them ────────────────────
+
+#[test]
+fn every_list_in_the_boot_is_the_read_of_the_same_name_asked_on_its_own() {
+    let mut connection = fixture();
+    a_whole_ledger(&connection);
+
+    let boot = load_boot(&mut connection, owner(OWNER)).expect("boot");
+    fn value<T: serde::Serialize>(rows: &T) -> serde_json::Value {
+        serde_json::to_value(rows).expect("json")
+    }
+
+    // Six assertions of the same shape, and together they are the claim the
+    // module makes structurally: this verb runs no query of its own. A composite
+    // that grew one — for speed, for a join, for a column somebody wanted —
+    // would drift from the read it was copied from while every EXPLAIN
+    // assertion in `reads_at_scale.rs` went on passing, because those are
+    // asserted against the READS' SQL.
+    assert_eq!(
+        value(&boot.answer.accounts),
+        value(&list_accounts(&connection, owner(OWNER)).expect("read").answer.accounts)
+    );
+    assert_eq!(
+        value(&boot.answer.categories),
+        value(&list_categories(&connection, owner(OWNER)).expect("read").answer.categories)
+    );
+    assert_eq!(
+        value(&boot.answer.transactions),
+        value(&list_transactions(&connection, owner(OWNER)).expect("read").answer.transactions)
+    );
+    assert_eq!(
+        value(&boot.answer.transaction_splits),
+        value(
+            &list_transaction_splits(&connection, owner(OWNER))
+                .expect("read")
+                .answer
+                .transaction_splits
+        )
+    );
+    assert_eq!(
+        value(&boot.answer.budgets),
+        value(&list_budgets(&connection, owner(OWNER)).expect("read").answer.budgets)
+    );
+    assert_eq!(
+        value(&boot.answer.goals),
+        value(&list_goals(&connection, owner(OWNER)).expect("read").answer.goals)
+    );
+}
+
+#[test]
+fn the_ledger_in_the_boot_is_newest_first_with_the_clouds_own_tie_break_behind_it() {
+    let mut connection = fixture();
+    a_whole_ledger(&connection);
+
+    let boot = load_boot(&mut connection, owner(OWNER)).expect("boot");
+    let ids: Vec<&str> = boot.answer.transactions.iter().map(|row| row.id.as_str()).collect();
+
+    // R-5 stated where the app actually receives it. `date DESC, id DESC` — and
+    // here the second key is not this crate's own: the cloud states it and calls
+    // it, in its own comment, a "stable tiebreak for paging". Two rows share
+    // 2024-03-01, and …f1 sorts above …001.
+    assert_eq!(ids, vec![A_LATER_DAY, SAME_DAY, CORNER_SHOP]);
+}
+
+#[test]
+fn two_accounts_opened_in_the_same_instant_are_in_the_boot_in_id_order() {
+    let mut connection = fixture();
+    a_whole_ledger(&connection);
+
+    let boot = load_boot(&mut connection, owner(OWNER)).expect("boot");
+    let ids: Vec<&str> = boot.answer.accounts.iter().map(|a| a.id.as_str()).collect();
+
+    // R-5 for a key the cloud never stated. Rainy day is INSERTed first and
+    // `created_at` cannot separate the two, so the answer is by id — Everyday's,
+    // ending 0001. The harness cannot prove this one: its oracle deliberately
+    // omits a tie-break the cloud never said, so a composite that re-sorted its
+    // accounts would still match Postgres and be caught only here.
+    assert_eq!(ids, vec![EVERYDAY, RAINY_DAY]);
+}
+
+#[test]
+fn the_same_file_booted_twice_answers_in_the_same_order() {
+    let mut connection = fixture();
+    a_whole_ledger(&connection);
+
+    let first = serde_json::to_value(load_boot(&mut connection, owner(OWNER)).expect("boot"))
+        .expect("json");
+    let again = serde_json::to_value(load_boot(&mut connection, owner(OWNER)).expect("boot"))
+        .expect("json");
+
+    // The property every tie-break in the crate exists for, asked of the whole
+    // boot at once: a page that reshuffles itself between two loads nobody
+    // changed anything between is a page whose running balance cannot be
+    // checked by eye. It also proves the first call left nothing behind — a
+    // leaked read transaction would make this second one fail outright.
+    assert_eq!(first, again);
+}
+
+// ── A file holding two logins ───────────────────────────────────────────────
+
+#[test]
+fn a_second_logins_rows_are_in_the_file_and_in_none_of_the_boots_six_lists() {
+    let mut connection = fixture();
+    a_whole_ledger(&connection);
+    connection
+        .execute_batch(&format!(
+            "INSERT INTO users (id, email) VALUES ('{STRANGER}', 'stranger@example.test');
+             INSERT INTO accounts (id, user_id, name, type, balance_minor, initial_balance_minor)
+               VALUES ('a0000000-0000-0000-0000-0000000000f9', '{STRANGER}', 'Not yours',
+                       'checking', -100, 0);
+             INSERT INTO categories (id, user_id, name, type, level)
+               VALUES ('c0000000-0000-0000-0000-0000000000f9', '{STRANGER}', 'Not yours',
+                       'expense', 'detail');
+             INSERT INTO transactions (id, user_id, account_id, description, amount_minor,
+                                       type, date)
+               VALUES ('70000000-0000-0000-0000-0000000000f9', '{STRANGER}',
+                       'a0000000-0000-0000-0000-0000000000f9', 'Theirs', -100, 'expense',
+                       '2024-03-01');
+             INSERT INTO transaction_splits (id, transaction_id, user_id, category,
+                                             amount_minor, sort_order)
+               VALUES ('50000000-0000-0000-0000-0000000000f9',
+                       '70000000-0000-0000-0000-0000000000f9', '{STRANGER}',
+                       'c0000000-0000-0000-0000-0000000000f9', -100, 0);
+             INSERT INTO budgets (id, user_id, name, amount_minor, period, start_date)
+               VALUES ('b0000000-0000-0000-0000-0000000000f9', '{STRANGER}', 'Not yours', 100,
+                       'monthly', '2024-01-01');
+             INSERT INTO goals (id, user_id, name, target_amount_minor)
+               VALUES ('90000000-0000-0000-0000-0000000000f9', '{STRANGER}', 'Not yours', 100);"
+        ))
+        .expect("stranger");
+
+    let boot = load_boot(&mut connection, owner(OWNER)).expect("boot");
+
+    // Six chances to forget the owner, which is the composite's own new risk:
+    // each list below would be one row longer if this verb had passed the owner
+    // to five reads and not the sixth. There is no RLS in a file to narrow the
+    // answer afterwards, and a restored two-login file is exactly what the
+    // required owner exists for.
+    assert!(boot.answer.accounts.iter().all(|row| row.user_id == OWNER));
+    assert!(boot.answer.categories.iter().all(|row| row.user_id == OWNER));
+    assert_eq!(boot.answer.transactions.len(), 3);
+    assert!(boot.answer.transaction_splits.iter().all(|row| row.user_id == OWNER));
+    assert!(boot.answer.budgets.iter().all(|row| row.user_id == OWNER));
+    assert!(boot.answer.goals.iter().all(|row| row.user_id == OWNER));
+
+    // And the other half of the same property: a file with two logins answers
+    // each of them correctly. Scoping is a filter, not a refusal.
+    let theirs = load_boot(&mut connection, owner(STRANGER)).expect("boot");
+    assert_eq!(theirs.answer.accounts.len(), 1);
+    assert_eq!(theirs.answer.transactions.len(), 1);
+    assert_eq!(theirs.answer.transaction_splits.len(), 1);
+}
+
+// ── The transaction ─────────────────────────────────────────────────────────
+
+#[test]
+fn the_boot_finishes_its_transaction_instead_of_leaving_one_open() {
+    let mut connection = fixture();
+    a_whole_ledger(&connection);
+    assert!(connection.is_autocommit(), "the fixture left a transaction open");
+
+    load_boot(&mut connection, owner(OWNER)).expect("boot");
+
+    // The half of "one transaction" a single-threaded test can prove. A leaked
+    // read transaction holds a SHARED lock for the life of the document — every
+    // later write on any connection would wait out `busy_timeout` and then fail
+    // — so this assertion is worth more than its length. What it cannot prove is
+    // that a write cannot land in the MIDDLE of the six reads; that needs a
+    // second thread whose timing decides the result, and a flaky test teaches
+    // people to re-run tests until they pass. The verb's module documentation
+    // says which is which rather than leaving the gap to be discovered.
+    assert!(connection.is_autocommit(), "the boot left its read transaction open");
+
+    // A write still works afterwards, which is the same fact from the side that
+    // would actually be noticed.
+    connection
+        .execute_batch(&format!(
+            "UPDATE accounts SET name = 'Everyday account' WHERE id = '{EVERYDAY}';"
+        ))
+        .expect("the file is still writable");
+}
+
+// ── The refusals that never reach a connection ──────────────────────────────
+
+#[test]
+fn the_composite_parses_to_its_own_variant() {
+    let parsed = parse(&format!(
+        r#"{{"verb":"load_boot","payload":{{"user_id":"{OWNER}"}}}}"#
+    ))
+    .expect("load_boot");
+
+    // The dispatch's exhaustiveness is the compiler's business; what the
+    // compiler cannot check is that the STRING is the one the port will send.
+    assert!(matches!(parsed, Command::LoadBoot(_)));
+}
+
+#[test]
+fn a_boot_with_no_owner_is_refused_before_a_file_is_opened() {
+    let refusal = parse(r#"{"verb":"load_boot","payload":{}}"#).expect_err("refused");
+    let json = serde_json::to_string(&refusal).expect("json");
+
+    // Six reads with the owner left off would answer with every login in the
+    // file — the reads' own reasoning, multiplied by six.
+    assert!(json.contains("missing field"), "{json}");
+    assert!(json.contains("user_id"), "{json}");
+}
+
+#[test]
+fn a_boot_asking_for_the_balances_as_well_is_refused_by_name() {
+    let refusal = parse(&format!(
+        r#"{{"verb":"load_boot","payload":{{"user_id":"{OWNER}","include_balances":true}}}}"#
+    ))
+    .expect_err("refused");
+    let json = serde_json::to_string(&refusal).expect("json");
+
+    // The most plausible thing anybody will one day try to send, and the reason
+    // this verb shares the reads' payload rather than owning one: a composite
+    // with a payload of its own is a composite whose payload grows options, and
+    // the first option anybody would add is the one R-4 exists to keep out.
+    assert!(json.contains("unknown_field"), "{json}");
+    assert!(json.contains("include_balances"), "{json}");
+}

--- a/crates/wealth-core/tests/reads_at_scale.rs
+++ b/crates/wealth-core/tests/reads_at_scale.rs
@@ -42,7 +42,8 @@ use tempfile::TempDir;
 use wealth_core::db;
 use wealth_core::row;
 use wealth_core::verbs::{
-    account_balances, list_transaction_splits, list_transactions, splits_for, OwnedRead, SplitsFor,
+    account_balances, list_transaction_splits, list_transactions, load_boot, splits_for, OwnedRead,
+    SplitsFor,
 };
 
 const OWNER: &str = "11111111-1111-1111-1111-111111111111";
@@ -427,4 +428,50 @@ fn the_balances_agree_with_the_ledger_the_client_would_sum() {
     assert_eq!(listed.iter().filter(|row| row.archived).count(), ARCHIVED);
     let counted: i64 = balances.iter().map(|balance| balance.txn_count).sum();
     assert_eq!(counted, i64::try_from(TRANSACTIONS).unwrap());
+}
+
+// ── The composite, at the same size ────────────────────────────────────────
+
+#[test]
+fn the_whole_boot_costs_about_the_sum_of_its_parts() {
+    let mut connection = a_real_sized_ledger();
+
+    let started = Instant::now();
+    let boot = load_boot(&mut connection, OwnedRead { user_id: OWNER.to_owned() }).expect("boot");
+    let elapsed = started.elapsed();
+    let answer = &boot.answer;
+    println!(
+        "── load_boot: {} accounts · {} categories · {} transactions · {} lines · \
+         {} budgets · {} goals in {elapsed:?}",
+        answer.accounts.len(),
+        answer.categories.len(),
+        answer.transactions.len(),
+        answer.transaction_splits.len(),
+        answer.budgets.len(),
+        answer.goals.len(),
+    );
+
+    // The whole boot in one call, and every part of it whole. There is no plan
+    // to assert here because there is no query here: the six plans are the six
+    // reads' own, asserted above against the SQL those reads prepare. What this
+    // measures is the composite's own overhead — one BEGIN and one COMMIT
+    // around work that was already being done — and the figure recorded in
+    // `crate::verbs::load_boot` says what it came to.
+    assert_eq!(answer.transactions.len(), TRANSACTIONS);
+    assert_eq!(answer.transaction_splits.len(), SPLIT_PARENTS * 2);
+    assert_eq!(answer.accounts.len(), ACCOUNTS);
+    // Two categories, and neither is a To/From: this ledger's accounts are
+    // created inside one transaction with the trigger's root present, so C-3
+    // mints one per account — twelve of them — beside the two the fixture
+    // names.
+    assert_eq!(answer.categories.len(), 2 + ACCOUNTS);
+    // Nothing in the fixture plans or saves, and empty is an answer: a boot
+    // that invented a budget would be a boot that read something else.
+    assert!(answer.budgets.is_empty());
+    assert!(answer.goals.is_empty());
+
+    // The transaction is finished, not leaked. At this size a leaked read lock
+    // is the difference between an app that opens and an app that cannot write
+    // again until it is restarted.
+    assert!(connection.is_autocommit());
 }

--- a/scripts/local-sqlite/lib/verb-postgres.mjs
+++ b/scripts/local-sqlite/lib/verb-postgres.mjs
@@ -61,12 +61,17 @@ const ROW_JSON = `jsonb_build_object(
 
 // ── The reads, whose oracle is a QUERY and not a function ────────────────────
 //
-// Every other verb in this file names a Postgres function. The six reads cannot:
-// the cloud reads these tables over PostgREST, so the thing being ported is the
-// query the client BUILDS — its `.eq()`s and its `.order()` — and the oracle has
-// to be that query written out. Each entry below names the TypeScript it is
-// transcribed from, and the transcription is deliberately literal: same filter,
-// same ORDER BY, same column list.
+// Every other verb in this file names a Postgres function. The nine list reads
+// cannot: the cloud reads these tables over PostgREST, so the thing being ported
+// is the query the client BUILDS — its `.eq()`s and its `.order()` — and the
+// oracle has to be that query written out. Each entry in the READS table below
+// names the TypeScript it is transcribed from, and the transcription is
+// deliberately literal: same filter, same ORDER BY, same column list.
+//
+// They live in a TABLE rather than one query per verb because `load_boot` asks
+// six of them at once. Two copies of the transactions query — one for the read
+// and one for the composite — would be two queries that agree until somebody
+// edits the one they happened to find.
 //
 // This is the same hazard `merge_categories` above declares, and it has the same
 // answer: a query repeated in the harness can silently agree with a wrong
@@ -92,6 +97,12 @@ const ROW_JSON = `jsonb_build_object(
 // AND ONE VERB IS NOT A QUERY AT ALL: `account_balances` IS a Postgres function,
 // so its oracle is that function, called for real — see its entry below for how
 // the identity it takes from a JWT is supplied.
+//
+// AND ONE IS NOT A QUERY EITHER, THE OTHER WAY ROUND: `load_boot`'s cloud side
+// is a TypeScript method, `DataServiceImpl.loadBoot`, whose body is six of these
+// reads in the order the boot depended on. Its oracle is therefore those same
+// six entries, gathered into one object — see its entry for what the cloud's
+// snapshot carries that no database can answer with.
 
 /** A numeric(_,2) column as the decimal string both engines must agree on. */
 const money = (expr) => `(${expr})::text`;
@@ -305,11 +316,175 @@ const SPLIT_JSON = `jsonb_build_object(
   'updated_at', ${stamp('s.updated_at')}
 )`;
 
+/** The owner every read is scoped to, as the payload spells it. */
+const ownerOf = (payloadLiteral) => `(${payloadLiteral}::jsonb->>'user_id')::uuid`;
+
+/**
+ * Every list read, as the (projection, source, order) triple the client's own
+ * query is transcribed into. Each entry names the TypeScript it comes from.
+ *
+ * ONE TABLE RATHER THAN ONE ENTRY PER VERB, because the composite below asks
+ * six of these at once and a second copy of any of these queries would be a
+ * second query that could drift while the single-read spec it was copied from
+ * went on passing. It is the harness-side twin of the rule the crate keeps by
+ * calling its own row mappers: there is one copy of each read, and both callers
+ * use it.
+ */
+const READS = {
+  // accountService.getAccounts:
+  //   .from('accounts').select('*')
+  //   .eq('user_id', userId).eq('is_active', true)
+  //   .order('created_at', { ascending: true })
+  accounts: {
+    json: ACCOUNT_JSON,
+    from: (p) => `public.accounts a WHERE a.user_id = ${ownerOf(p)} AND a.is_active`,
+    order: 'a.created_at',
+  },
+
+  // accountService.getClosedAccounts — the same query with `.eq('is_active',
+  // false)`, which is why the local edition makes it a second VERB rather than a
+  // flag: the two questions are asked from two different places in the app.
+  closed_accounts: {
+    json: ACCOUNT_JSON,
+    from: (p) => `public.accounts a WHERE a.user_id = ${ownerOf(p)} AND NOT a.is_active`,
+    order: 'a.created_at',
+  },
+
+  // planningService.ensureCategories:
+  //   .from('categories').select('*').eq('user_id', userId)
+  //   .order('level', { ascending: true }).order('name', { ascending: true })
+  //
+  // NOT `dataService.listCategories`, which reads browser storage and never
+  // touches the cloud — the signed-in boot's category list comes from here. No
+  // `is_active` filter: a hidden category still has to resolve for the rows
+  // already filed under it.
+  //
+  // `level` is a text column, so ascending means detail, sub, type. Collation
+  // could in principle differ from SQLite's BINARY; these three values are
+  // lower-case ASCII, where every collation agrees, and the harness prints a
+  // warning if the cluster is not UTF8.
+  categories: {
+    json: CATEGORY_JSON,
+    from: (p) => `public.categories c WHERE c.user_id = ${ownerOf(p)}`,
+    order: 'c.level, c.name',
+  },
+
+  // planningService.getBudgets:
+  //   .from('budgets').select('*').eq('user_id', userId)
+  //   .order('created_at', { ascending: true })
+  // Inactive budgets load too — the service says why in its own comment.
+  budgets: {
+    json: BUDGET_JSON,
+    from: (p) => `public.budgets b WHERE b.user_id = ${ownerOf(p)}`,
+    order: 'b.created_at',
+  },
+
+  // planningService.getGoals — the same shape as budgets, same order, no status
+  // filter.
+  goals: {
+    json: GOAL_JSON,
+    from: (p) => `public.goals g WHERE g.user_id = ${ownerOf(p)}`,
+    order: 'g.created_at',
+  },
+
+  // suggestionDismissalService.list:
+  //   .from('suggestion_dismissals')
+  //   .select('id, kind, subject_key, subject_ids, dismissed_at')
+  //   .eq('user_id', userId).order('dismissed_at', { ascending: false })
+  suggestion_dismissals: {
+    json: DISMISSAL_JSON,
+    from: (p) => `public.suggestion_dismissals d WHERE d.user_id = ${ownerOf(p)}`,
+    order: 'd.dismissed_at DESC',
+  },
+
+  // transactionService.fetchTransactionPage — the query the signed-in boot
+  // actually runs:
+  //   .from('transactions').select(BOOT_TRANSACTION_COLUMNS)
+  //   .eq('user_id', userId)
+  //   .order('date', { ascending: false })
+  //   .order('id', { ascending: false })    // stable tiebreak for paging
+  //   .range(from, to)
+  //
+  // NO ARCHIVED FILTER, and that is the query rather than an omission here: the
+  // archive is a VIEW flag, the flag rides back as a column, and the register
+  // does its hiding in memory. It is the same fact `account_balances` below
+  // states from the other end, and R-1 is what happens when one of the two
+  // forgets it.
+  //
+  // The `.range()` is not transcribed because it is not part of the question: it
+  // is PostgREST's 1,000-row response cap, which the client walks ~52 times to
+  // ask ONE thing. A file answers it once (DESIGN's "one crossing"), and a
+  // harness that paged would be comparing the transport rather than the read.
+  transactions: {
+    json: TRANSACTION_JSON,
+    from: (p) => `public.transactions t WHERE t.user_id = ${ownerOf(p)}`,
+    order: 't.date DESC, t.id DESC',
+  },
+
+  // transactionService.getAllTransactionSplits:
+  //   .from('transaction_splits').select('*').eq('user_id', userId)
+  //   .order('transaction_id').order('sort_order')
+  //
+  // `user_id` here is the LINE's owner and not the parent's. The two are usually
+  // one person and the schema does not require it — `myLineOnTheirParent` in the
+  // shared fixtures exists because `merge_categories` walks parents by one and
+  // lines by the other — so filtering on the parent instead would be a different
+  // question with the same name.
+  transaction_splits: {
+    json: SPLIT_JSON,
+    from: (p) => `public.transaction_splits s WHERE s.user_id = ${ownerOf(p)}`,
+    order: 's.transaction_id, s.sort_order',
+  },
+
+  // transactionService.getTransactionSplits(transactionId):
+  //   .from('transaction_splits').select('*')
+  //   .eq('transaction_id', transactionId).order('sort_order')
+  //
+  // THE OWNER FILTER BELOW IS TRANSCRIBED FROM THE RLS POLICY, NOT THE CLIENT.
+  // That query names no owner at all, because it does not have to: the policy on
+  // this table is `user_id = requesting_user_id()` (20260713100000:57-60), so in
+  // production every row this returns has already been through it. The harness
+  // runs as a superuser with RLS out of the way, so leaving the filter out would
+  // make the oracle answer a question production never asks — and would report
+  // the local edition's only-gate owner check as a divergence. Both halves of
+  // the cloud's real behaviour, written down.
+  splits: {
+    json: SPLIT_JSON,
+    from: (p) => `public.transaction_splits s
+        WHERE s.transaction_id = (${p}::jsonb->>'transaction_id')::uuid
+          AND s.user_id = ${ownerOf(p)}`,
+    order: 's.sort_order',
+  },
+};
+
+/** One read's rows, aggregated into a JSON array in the order it states. */
+const aggregated = (key, payloadLiteral) =>
+  `(SELECT COALESCE(jsonb_agg(${READS[key].json} ORDER BY ${READS[key].order}), '[]'::jsonb)
+      FROM ${READS[key].from(payloadLiteral)})`;
+
 /** A read's answer: one named key holding the list, or an empty list. */
-const listed = (key, json, from, order) =>
-  `SELECT jsonb_build_object('${key}', COALESCE(jsonb_agg(${json} ORDER BY ${order}), '[]'::jsonb))
-     INTO v_row
-     FROM ${from};`;
+const listed = (key, payloadLiteral) =>
+  `SELECT jsonb_build_object('${key}', ${aggregated(key, payloadLiteral)}) INTO v_row;`;
+
+/**
+ * The six reads `DataServiceImpl.loadBoot` composes, in the order it makes them.
+ *
+ * The order is carried here for readability only: this oracle asks them in one
+ * statement and the crate asks them in one transaction, so neither side has a
+ * "before" inside the composite for anything to observe. That is exactly what
+ * the contract suite's BOOT_COMPOSITION table declares — `fansOut: true` for the
+ * cloud, where the ordering rules are proved by holding one read and watching
+ * whether the next starts, and `fansOut: false` for the local core, where they
+ * cannot be broken.
+ */
+const BOOT_READS = [
+  'accounts',
+  'categories',
+  'transactions',
+  'transaction_splits',
+  'budgets',
+  'goals',
+];
 
 /**
  * The RPC each verb maps onto, and how its result is projected.
@@ -629,163 +804,60 @@ const VERBS = {
        INTO v_row;`,
 
   // ── THE READS ──────────────────────────────────────────────────────────────
-  // Transcribed from the client query each one ports; see the block above the
-  // VERBS table for why a query is a legitimate oracle and what keeps it honest.
+  // Each one is an entry in the READS table above, which is where the client
+  // query it transcribes is written down. One line apiece here, because a verb
+  // that has to repeat its own query in two places is a verb whose two copies
+  // will one day disagree — the same rule the crate keeps by calling its row
+  // mappers rather than re-writing their SQL.
 
-  // accountService.getAccounts:
-  //   .from('accounts').select('*')
-  //   .eq('user_id', userId).eq('is_active', true)
-  //   .order('created_at', { ascending: true })
-  list_accounts: (payloadLiteral) =>
-    listed(
-      'accounts',
-      ACCOUNT_JSON,
-      `public.accounts a
-        WHERE a.user_id = (${payloadLiteral}::jsonb->>'user_id')::uuid
-          AND a.is_active`,
-      'a.created_at',
-    ),
+  list_accounts: (payloadLiteral) => listed('accounts', payloadLiteral),
 
-  // accountService.getClosedAccounts — the same query with `.eq('is_active',
-  // false)`, which is why the local edition makes it a second VERB rather than a
-  // flag: the two questions are asked from two different places in the app.
-  list_closed_accounts: (payloadLiteral) =>
-    listed(
-      'closed_accounts',
-      ACCOUNT_JSON,
-      `public.accounts a
-        WHERE a.user_id = (${payloadLiteral}::jsonb->>'user_id')::uuid
-          AND NOT a.is_active`,
-      'a.created_at',
-    ),
+  list_closed_accounts: (payloadLiteral) => listed('closed_accounts', payloadLiteral),
 
-  // planningService.ensureCategories:
-  //   .from('categories').select('*').eq('user_id', userId)
-  //   .order('level', { ascending: true }).order('name', { ascending: true })
-  //
-  // NOT `dataService.listCategories`, which reads browser storage and never
-  // touches the cloud — the signed-in boot's category list comes from here. No
-  // `is_active` filter: a hidden category still has to resolve for the rows
-  // already filed under it.
-  //
-  // `level` is a text column, so ascending means detail, sub, type. Collation
-  // could in principle differ from SQLite's BINARY; these three values are
-  // lower-case ASCII, where every collation agrees, and the harness prints a
-  // warning if the cluster is not UTF8.
-  list_categories: (payloadLiteral) =>
-    listed(
-      'categories',
-      CATEGORY_JSON,
-      `public.categories c
-        WHERE c.user_id = (${payloadLiteral}::jsonb->>'user_id')::uuid`,
-      'c.level, c.name',
-    ),
+  list_categories: (payloadLiteral) => listed('categories', payloadLiteral),
 
-  // planningService.getBudgets:
-  //   .from('budgets').select('*').eq('user_id', userId)
-  //   .order('created_at', { ascending: true })
-  // Inactive budgets load too — the service says why in its own comment.
-  list_budgets: (payloadLiteral) =>
-    listed(
-      'budgets',
-      BUDGET_JSON,
-      `public.budgets b
-        WHERE b.user_id = (${payloadLiteral}::jsonb->>'user_id')::uuid`,
-      'b.created_at',
-    ),
+  list_budgets: (payloadLiteral) => listed('budgets', payloadLiteral),
 
-  // planningService.getGoals — the same shape as budgets, same order, no status
-  // filter.
-  list_goals: (payloadLiteral) =>
-    listed(
-      'goals',
-      GOAL_JSON,
-      `public.goals g
-        WHERE g.user_id = (${payloadLiteral}::jsonb->>'user_id')::uuid`,
-      'g.created_at',
-    ),
+  list_goals: (payloadLiteral) => listed('goals', payloadLiteral),
 
-  // suggestionDismissalService.list:
-  //   .from('suggestion_dismissals')
-  //   .select('id, kind, subject_key, subject_ids, dismissed_at')
-  //   .eq('user_id', userId).order('dismissed_at', { ascending: false })
   list_suggestion_dismissals: (payloadLiteral) =>
-    listed(
-      'suggestion_dismissals',
-      DISMISSAL_JSON,
-      `public.suggestion_dismissals d
-        WHERE d.user_id = (${payloadLiteral}::jsonb->>'user_id')::uuid`,
-      'd.dismissed_at DESC',
-    ),
+    listed('suggestion_dismissals', payloadLiteral),
 
   // ── The heavy four ─────────────────────────────────────────────────────────
 
-  // transactionService.fetchTransactionPage — the query the signed-in boot
-  // actually runs:
-  //   .from('transactions').select(BOOT_TRANSACTION_COLUMNS)
-  //   .eq('user_id', userId)
-  //   .order('date', { ascending: false })
-  //   .order('id', { ascending: false })    // stable tiebreak for paging
-  //   .range(from, to)
-  //
-  // NO ARCHIVED FILTER, and that is the query rather than an omission here: the
-  // archive is a VIEW flag, the flag rides back as a column, and the register
-  // does its hiding in memory. It is the same fact `account_balances` below
-  // states from the other end, and R-1 is what happens when one of the two
-  // forgets it.
-  //
-  // The `.range()` is not transcribed because it is not part of the question: it
-  // is PostgREST's 1,000-row response cap, which the client walks ~52 times to
-  // ask ONE thing. A file answers it once (DESIGN's "one crossing"), and a
-  // harness that paged would be comparing the transport rather than the read.
-  list_transactions: (payloadLiteral) =>
-    listed(
-      'transactions',
-      TRANSACTION_JSON,
-      `public.transactions t
-        WHERE t.user_id = (${payloadLiteral}::jsonb->>'user_id')::uuid`,
-      't.date DESC, t.id DESC',
-    ),
+  list_transactions: (payloadLiteral) => listed('transactions', payloadLiteral),
 
-  // transactionService.getAllTransactionSplits:
-  //   .from('transaction_splits').select('*').eq('user_id', userId)
-  //   .order('transaction_id').order('sort_order')
-  //
-  // `user_id` here is the LINE's owner and not the parent's. The two are usually
-  // one person and the schema does not require it — `myLineOnTheirParent` in the
-  // shared fixtures exists because `merge_categories` walks parents by one and
-  // lines by the other — so filtering on the parent instead would be a different
-  // question with the same name.
-  list_transaction_splits: (payloadLiteral) =>
-    listed(
-      'transaction_splits',
-      SPLIT_JSON,
-      `public.transaction_splits s
-        WHERE s.user_id = (${payloadLiteral}::jsonb->>'user_id')::uuid`,
-      's.transaction_id, s.sort_order',
-    ),
+  list_transaction_splits: (payloadLiteral) => listed('transaction_splits', payloadLiteral),
 
-  // transactionService.getTransactionSplits(transactionId):
-  //   .from('transaction_splits').select('*')
-  //   .eq('transaction_id', transactionId).order('sort_order')
+  splits_for: (payloadLiteral) => listed('splits', payloadLiteral),
+
+  // ── THE COMPOSITE, WHOSE ORACLE IS A TYPESCRIPT METHOD ─────────────────────
   //
-  // THE OWNER FILTER BELOW IS TRANSCRIBED FROM THE RLS POLICY, NOT THE CLIENT.
-  // That query names no owner at all, because it does not have to: the policy on
-  // this table is `user_id = requesting_user_id()` (20260713100000:57-60), so in
-  // production every row this returns has already been through it. The harness
-  // runs as a superuser with RLS out of the way, so leaving the filter out would
-  // make the oracle answer a question production never asks — and would report
-  // the local edition's only-gate owner check as a divergence. Both halves of
-  // the cloud's real behaviour, written down.
-  splits_for: (payloadLiteral) =>
-    listed(
-      'splits',
-      SPLIT_JSON,
-      `public.transaction_splits s
-        WHERE s.transaction_id = (${payloadLiteral}::jsonb->>'transaction_id')::uuid
-          AND s.user_id = (${payloadLiteral}::jsonb->>'user_id')::uuid`,
-      's.sort_order',
-    ),
+  // `load_boot` is the first verb here whose cloud side is neither a function
+  // nor a single query: it is `DataServiceImpl.loadBoot`, whose body is six of
+  // the reads above made one after another. So the oracle is those six queries,
+  // gathered into one object — the same transcription rule the reads follow,
+  // applied to a method instead of to a `.select()`.
+  //
+  // WHAT THE CLOUD'S SNAPSHOT CARRIES THAT THIS DOES NOT, and why neither is a
+  // divergence to declare: `BootSnapshot` also has `transactionStats` and
+  // `phases`. The first describes a FETCH — how many rows came from the local
+  // cache, how many from a delta, and in words why no snapshot was served — and
+  // the second is a duration per phase. Neither is a fact about a database, so
+  // neither engine's verb answers with one: the cloud's come from the client's
+  // paging layer and the local edition's from `LocalDataPort`, which times the
+  // one crossing it makes and says `'local mode'` for the same reason browser
+  // storage does (divergence B-1). An oracle that invented them here would be
+  // comparing the harness against itself.
+  //
+  // WHAT IS COMPARED IS THE SIX LISTS, and comparing them is the point: the
+  // composite is where a port can quietly re-order a ledger, drop the archived
+  // rows, lose a login's scoping on one read out of six, or answer with five
+  // lists and an empty sixth. Every one of those is a difference in this object.
+  load_boot: (payloadLiteral) =>
+    `SELECT jsonb_build_object(
+              ${BOOT_READS.map((key) => `'${key}', ${aggregated(key, payloadLiteral)}`).join(',\n              ')})
+       INTO v_row;`,
 
   // account_balances() — 20260722160000:26-42, and the only read in this table
   // whose oracle is a FUNCTION rather than a transcribed query.

--- a/scripts/local-sqlite/verb-specs/_shared.mjs
+++ b/scripts/local-sqlite/verb-specs/_shared.mjs
@@ -2248,6 +2248,21 @@ export function fedRow(externalId, expect) {
 //     never stated must not be transcribed into its own oracle), so a fixture
 //     that ties is a fixture whose two answers may legitimately differ. The
 //     tie-break has its own proof in `crates/wealth-core/tests/reads.rs`.
+//
+// A `load_boot` spec has to obey BOTH RULES ON ALL SIX LISTS AT ONCE, and that
+// is not a detail of writing one — it is what the composite is for. The runner
+// compares every key of the answer, whether or not the spec asserts it, so a
+// boot spec that pins only the table it is about fails on the ones it is not:
+// unpinned accounts differ by a millisecond, and the two To/From categories are
+// minted by a TRIGGER with a generated id on each engine, so they differ always.
+// MEASURED, by writing four such specs and watching them go MISDECLARED:
+// `namedTransferCategories` and BOTH pinning fragments belong in every one, and
+// the fragment order is the usual one — whatever moves a row goes before the pin
+// that fixes its timestamp.
+//
+// This is a feature rather than a tax. A composite that quietly re-ordered the
+// accounts nobody's spec was looking at, or lost a login's scoping on the one
+// list that spec ignored, is caught by the spec next door.
 
 /** The instant Everyday was opened; Rainy day is a day later. */
 export const OPENED_FIRST = '2024-01-01T00:00:00.000Z';

--- a/scripts/local-sqlite/verb-specs/boot-a-file-with-nothing-in-it-answers-with-six-empty-lists.spec.mjs
+++ b/scripts/local-sqlite/verb-specs/boot-a-file-with-nothing-in-it-answers-with-six-empty-lists.spec.mjs
@@ -1,0 +1,22 @@
+import { USER, wiped, auditRowsInTotal } from './_shared.mjs';
+
+export default {
+  invariant: 'BOOT-1',
+  title: 'a brand-new file boots on six empty lists, which is an answer and not a failure',
+  design: 'BootSnapshot types every one of its six as an array with no null in it, and DataServiceImpl.loadBoot builds the snapshot empty before it reads anything. A file on the day it is made is exactly this state, and so is every file the moment before its first account exists',
+  consequence: 'the difference between six empty lists and a rejected promise is the difference between an app that opens on its "add an account" page and a full-page "Failed to load data" in front of somebody whose file is perfectly fine. It also has to be six EMPTY LISTS rather than five and a null: the app maps each one by name, and a null there is a crash on the first render rather than an empty page',
+  parity: 'match',
+
+  setup: wiped,
+  command: { verb: 'load_boot', payload: { user_id: USER } },
+  expect: { outcome: 'ok' },
+  result: {
+    accounts: [],
+    categories: [],
+    transactions: [],
+    transaction_splits: [],
+    budgets: [],
+    goals: [],
+  },
+  state: [auditRowsInTotal('0')],
+};

--- a/scripts/local-sqlite/verb-specs/boot-a-second-login-in-the-same-file-is-in-none-of-the-boots-lists.spec.mjs
+++ b/scripts/local-sqlite/verb-specs/boot-a-second-login-in-the-same-file-is-in-none-of-the-boots-lists.spec.mjs
@@ -1,0 +1,61 @@
+import {
+  USER, EVERYDAY, RAINY_DAY, OUTGOINGS, WEEKLY_SHOP,
+  TO_FROM_EVERYDAY, TO_FROM_RAINY_DAY, OPENED_SECOND,
+  setups, secondUser, strangersRow, namedTransferCategories, pinnedReadTimes, pinnedLedgerTimes,
+  listedAccount, listedCategory, listedTransaction,
+  balanceIdentityHolds, auditRowsInTotal,
+} from './_shared.mjs';
+
+const TRANSFER_ROOT = 'c0000000-0000-0000-0000-000000000001';
+
+export default {
+  invariant: 'BOOT-7',
+  title: 'a file holding two logins boots one of them: the owner is passed to every read, not to five of six',
+  design: 'every cloud read is .eq(\'user_id\', userId) with RLS underneath it. A file has neither — the owner in the payload is the whole gate — and the composite is the one verb that has to apply it SIX times. A second login\'s rows are a real local state: a backup restored from an account that had two, or the harness\'s own',
+  consequence: 'the composite is where this goes wrong quietly. Five reads scoped and one not gives a boot that mostly looks right: a stranger\'s account in the sidebar and their money in net worth, or a stranger\'s categories in the register\'s picker. Each read has its own scoping spec; none of them can prove the composite passed the owner along',
+  parity: 'match',
+
+  setup: setups(
+    secondUser,
+    strangersRow,
+    namedTransferCategories,
+    pinnedReadTimes,
+    pinnedLedgerTimes,
+  ),
+  command: { verb: 'load_boot', payload: { user_id: USER } },
+  expect: { outcome: 'ok' },
+  result: {
+    // The stranger's account is in the file and not in this list.
+    accounts: [
+      listedAccount({ id: EVERYDAY, name: 'Everyday', type: 'checking', balance: '-25.00' }),
+      listedAccount({
+        id: RAINY_DAY, name: 'Rainy day', type: 'savings', balance: '0.00',
+        created_at: OPENED_SECOND, updated_at: OPENED_SECOND,
+      }),
+    ],
+    // So is the To/From category C-3's trigger minted for it — which is why the
+    // categories are spelled out rather than counted: an unscoped read would add
+    // a sixth row here, and its timestamps are not pinned because it is not this
+    // login's to pin.
+    categories: [
+      listedCategory({
+        id: TO_FROM_EVERYDAY, name: 'To/From Everyday', type: 'both',
+        parent_id: TRANSFER_ROOT, account_id: EVERYDAY, is_transfer_category: true,
+      }),
+      listedCategory({
+        id: TO_FROM_RAINY_DAY, name: 'To/From Rainy day', type: 'both',
+        parent_id: TRANSFER_ROOT, account_id: RAINY_DAY, is_transfer_category: true,
+      }),
+      listedCategory({ id: WEEKLY_SHOP, name: 'Weekly shop', level: 'sub', parent_id: OUTGOINGS }),
+      listedCategory({ id: OUTGOINGS, name: 'Outgoings', level: 'type' }),
+      listedCategory({ id: TRANSFER_ROOT, name: 'Transfer', type: 'both', level: 'type' }),
+    ],
+    // And their transaction: same date as this login's, so an unscoped read
+    // would interleave it rather than append it.
+    transactions: [listedTransaction({ category: WEEKLY_SHOP })],
+  },
+  state: [
+    balanceIdentityHolds(EVERYDAY),
+    auditRowsInTotal('0'),
+  ],
+};

--- a/scripts/local-sqlite/verb-specs/boot-an-archived-row-boots-with-the-rest-and-carries-its-flag.spec.mjs
+++ b/scripts/local-sqlite/verb-specs/boot-an-archived-row-boots-with-the-rest-and-carries-its-flag.spec.mjs
@@ -1,0 +1,28 @@
+import {
+  USER, EVERYDAY, WEEKLY_SHOP,
+  setups, namedTransferCategories, anArchivedRow, pinnedReadTimes, pinnedLedgerTimes,
+  listedTransaction, balanceIdentityHolds, auditRowsInTotal,
+} from './_shared.mjs';
+
+export default {
+  invariant: 'BOOT-4',
+  title: 'the boot carries an archived row like any other, with its flag set',
+  design: '20260721130000_soft_archive.sql: "A transaction is archived purely as a VIEW flag. It stays in the transactions table." The boot query filters on user_id and nothing else, and the composite is that query — so the archive has no third place to be filtered in',
+  consequence: 'R-1, arriving through the door the composite opens. The client sums the list the boot gave it; account_balances counts archived rows on purpose. A composite that hid them would put two figures on one dashboard that disagree by however much history was archived, with nothing on screen to explain it — and it would do it while the read it was built from still answered correctly, so the read\'s own spec would stay green',
+  parity: 'match',
+
+  // Named and pinned throughout: a boot spec compares all six lists, so the
+  // categories, the accounts and the ledger all have to be comparable even
+  // though this one is about a single flag.
+  setup: setups(namedTransferCategories, anArchivedRow, pinnedReadTimes, pinnedLedgerTimes),
+  command: { verb: 'load_boot', payload: { user_id: USER } },
+  expect: { outcome: 'ok' },
+  result: {
+    transactions: [listedTransaction({ archived: true, category: WEEKLY_SHOP })],
+  },
+  state: [
+    // Archiving moved no money, which is the rule it exists to keep.
+    balanceIdentityHolds(EVERYDAY),
+    auditRowsInTotal('0'),
+  ],
+};

--- a/scripts/local-sqlite/verb-specs/boot-every-figure-the-boot-carries-crosses-as-a-decimal-string.spec.mjs
+++ b/scripts/local-sqlite/verb-specs/boot-every-figure-the-boot-carries-crosses-as-a-decimal-string.spec.mjs
@@ -1,0 +1,61 @@
+import {
+  USER, EVERYDAY, RAINY_DAY, WEEKLY_SHOP, OPENED_SECOND,
+  setups, namedTransferCategories, accountWithEveryFigure, pinnedReadTimes, pinnedLedgerTimes,
+  listedAccount, listedTransaction,
+  balanceIdentityHolds, auditRowsInTotal,
+} from './_shared.mjs';
+
+export default {
+  invariant: 'BOOT-6',
+  title: 'money crosses the composite as text: four figures on an account and the amount on the row, all decimal strings',
+  design: 'PHASE3-PLAN D-4 is the reason reads are verbs in this crate at all — money.rs is the ONE place minor units become the text the app parses — and a composite is the most likely place for a second conversion to appear, because it is the one verb that gathers money from four tables at once and could be tempted to total something on the way past',
+  consequence: 'a JSON number is a double the moment any parser touches it, and this call is the app\'s FIRST sight of every figure it will show. £123.45 arriving through a float on the boot is wrong on the dashboard, wrong in the register and wrong in the reports, all from one line',
+  parity: 'match',
+
+  // The account with every optional figure filled in: on a bare fixture they are
+  // all NULL, and NULL is the one value that cannot tell a working conversion
+  // from a missing one. `initial_balance −10.00` and the row at −15.00 keep B-1
+  // holding at the same −25.00 the fixture started with.
+  setup: setups(
+    namedTransferCategories,
+    accountWithEveryFigure,
+    pinnedReadTimes,
+    pinnedLedgerTimes,
+  ),
+  command: { verb: 'load_boot', payload: { user_id: USER } },
+  expect: { outcome: 'ok' },
+  result: {
+    accounts: [
+      listedAccount({
+        id: EVERYDAY,
+        name: 'Everyday',
+        type: 'checking',
+        balance: '-25.00',
+        initial_balance: '-10.00',
+        bank_balance: '123.45',
+        bank_balance_date: '2024-02-29',
+        last_reconciled_date: '2024-02-01',
+        low_balance_alert_enabled: true,
+        low_balance_threshold: '-50.00',
+        opening_balance_date: '2023-12-31',
+        archive_through_date: '2023-06-30',
+        institution: 'A Bank',
+        account_number: '12345678',
+        sort_code: '00-00-00',
+        icon: 'wallet',
+        color: '#123456',
+        notes: 'the everyday one',
+        metadata: { k: 1 },
+      }),
+      listedAccount({
+        id: RAINY_DAY, name: 'Rainy day', type: 'savings',
+        created_at: OPENED_SECOND, updated_at: OPENED_SECOND,
+      }),
+    ],
+    transactions: [listedTransaction({ amount: '-15.00', category: WEEKLY_SHOP })],
+  },
+  state: [
+    balanceIdentityHolds(EVERYDAY),
+    auditRowsInTotal('0'),
+  ],
+};

--- a/scripts/local-sqlite/verb-specs/boot-every-part-of-the-boot-arrives-in-one-answer.spec.mjs
+++ b/scripts/local-sqlite/verb-specs/boot-every-part-of-the-boot-arrives-in-one-answer.spec.mjs
@@ -1,0 +1,106 @@
+import {
+  USER, EVERYDAY, RAINY_DAY, CORNER_SHOP, OUTGOINGS, WEEKLY_SHOP,
+  LEG_LINE, PLAIN_LINE, TO_FROM_EVERYDAY, TO_FROM_RAINY_DAY,
+  FOOD_BUDGET, FUEL_BUDGET, HOLIDAY_GOAL, ROOF_GOAL, OPENED_SECOND,
+  setups, namedTransferCategories, pinnedReadTimes, twoBudgets, twoGoals,
+  plainSplitParent, pinnedLedgerTimes,
+  listedAccount, listedCategory, listedTransaction, listedSplit, listedBudget, listedGoal,
+  balanceIdentityHolds, splitSumHolds, auditRowsInTotal,
+} from './_shared.mjs';
+
+const TRANSFER_ROOT = 'c0000000-0000-0000-0000-000000000001';
+
+export default {
+  invariant: 'BOOT-2',
+  title: 'every one of the six things the app boots with comes back from one call',
+  design: 'BootSnapshot { accounts, categories, transactions, splits, budgets, goals } — the six awaits the boot effect used to make, moved behind the seam so the rules between them are the implementation\'s rather than one call site\'s. The cloud answers it with six crossings in that order; a file answers it from one transaction, which is the BOOT_COMPOSITION table\'s local-core row',
+  consequence: 'an engine that answered a partial snapshot would leave the app deciding which of its own pages to open empty, and it would do it silently — no page reports "my list was not in the boot", it just draws nothing. Every list here is a page: the accounts sidebar, the register\'s category column, the register, split-aware reporting, the budgets page and the goals page',
+  parity: 'match',
+
+  // Everything at once, and the ORDER of these fragments is load-bearing on
+  // both engines: renaming a category and re-shaping a transaction both stamp
+  // `updated_at`, so the two pinning fragments come after the things they pin.
+  setup: setups(
+    namedTransferCategories,
+    pinnedReadTimes,
+    twoBudgets,
+    twoGoals,
+    plainSplitParent,
+    pinnedLedgerTimes,
+  ),
+  command: { verb: 'load_boot', payload: { user_id: USER } },
+  expect: { outcome: 'ok' },
+  result: {
+    // Oldest first, and the whole row — the boot's account list is the one the
+    // sidebar and every picker are built from.
+    accounts: [
+      listedAccount({ id: EVERYDAY, name: 'Everyday', type: 'checking', balance: '-25.00' }),
+      listedAccount({
+        id: RAINY_DAY, name: 'Rainy day', type: 'savings', balance: '0.00',
+        created_at: OPENED_SECOND, updated_at: OPENED_SECOND,
+      }),
+    ],
+    // By level then name, which is alphabetical rather than hierarchical, and
+    // with the two To/From categories C-3's trigger minted.
+    categories: [
+      listedCategory({
+        id: TO_FROM_EVERYDAY, name: 'To/From Everyday', type: 'both',
+        parent_id: TRANSFER_ROOT, account_id: EVERYDAY, is_transfer_category: true,
+      }),
+      listedCategory({
+        id: TO_FROM_RAINY_DAY, name: 'To/From Rainy day', type: 'both',
+        parent_id: TRANSFER_ROOT, account_id: RAINY_DAY, is_transfer_category: true,
+      }),
+      listedCategory({ id: WEEKLY_SHOP, name: 'Weekly shop', level: 'sub', parent_id: OUTGOINGS }),
+      listedCategory({ id: OUTGOINGS, name: 'Outgoings', level: 'type' }),
+      listedCategory({ id: TRANSFER_ROOT, name: 'Transfer', type: 'both', level: 'type' }),
+    ],
+    // The ledger, whole. A split parent's own category is blank BY DESIGN, and
+    // blank means the empty string rather than NULL on both engines.
+    transactions: [
+      listedTransaction({ is_split: true, category: '', category_confirmed: false }),
+    ],
+    // Its lines, in display order — the answer split-aware reporting aggregates
+    // by category, and the reason the boot carries them at all.
+    transaction_splits: [
+      listedSplit({ id: LEG_LINE, transaction_id: CORNER_SHOP, amount: '-15.00', sort_order: 0 }),
+      listedSplit({ id: PLAIN_LINE, transaction_id: CORNER_SHOP, amount: '-10.00', sort_order: 1 }),
+    ],
+    // The planning pair, which the cloud fetches in ONE Promise.all and a file
+    // reads in the same transaction as everything else. Contract rule 80 is the
+    // same fact from the app's side.
+    budgets: [
+      listedBudget({
+        id: FOOD_BUDGET, name: 'Food', amount: '123.45', category: WEEKLY_SHOP,
+        end_date: '2024-12-31', spent: '67.89', rollover: true, rollover_amount: '2.50',
+        alert_threshold: '42.50', notes: 'the food one',
+      }),
+      listedBudget({
+        id: FUEL_BUDGET, name: 'Fuel', amount: '50.00', period: 'weekly',
+        start_date: '2024-02-01', is_active: false,
+        created_at: OPENED_SECOND, updated_at: OPENED_SECOND,
+      }),
+    ],
+    goals: [
+      listedGoal({
+        id: HOLIDAY_GOAL, name: 'Holiday', description: 'somewhere warm',
+        target_amount: '2500.00', current_amount: '123.45', target_date: '2025-06-01',
+        category: WEEKLY_SHOP, priority: 'high', account_id: RAINY_DAY,
+        contribution_frequency: 'monthly', auto_contribute: true, icon: 'sun', color: '#ffcc00',
+        metadata: { type: 'savings' },
+      }),
+      listedGoal({
+        id: ROOF_GOAL, name: 'New roof', target_amount: '5000.00', current_amount: '5000.00',
+        status: 'completed', completed_at: '2024-03-04T05:06:07.000Z',
+        created_at: OPENED_SECOND, updated_at: OPENED_SECOND,
+      }),
+    ],
+  },
+  state: [
+    // A read moves nothing and records nothing, however many tables it touches.
+    balanceIdentityHolds(EVERYDAY),
+    balanceIdentityHolds(RAINY_DAY),
+    splitSumHolds(CORNER_SHOP),
+    auditRowsInTotal('0'),
+  ],
+};

--- a/scripts/local-sqlite/verb-specs/boot-the-balance-in-the-boot-is-the-stored-one-and-the-derived-figure-is-a-separate-question.spec.mjs
+++ b/scripts/local-sqlite/verb-specs/boot-the-balance-in-the-boot-is-the-stored-one-and-the-derived-figure-is-a-separate-question.spec.mjs
@@ -1,0 +1,46 @@
+import {
+  USER, EVERYDAY, RAINY_DAY, OPENED_SECOND,
+  setups, namedTransferCategories, aStoredBalanceThatDrifted, pinnedReadTimes, pinnedLedgerTimes,
+  listedAccount, balanceOf, auditRowsInTotal,
+} from './_shared.mjs';
+
+export default {
+  invariant: 'BOOT-5',
+  title: 'the boot carries the stored balance and no derived one: the money verb is a separate question, asked earlier',
+  design: 'dataPort.ts states it at length — getAccountBalances is DELIBERATELY OUT of BootSnapshot, because "those figures exist for exactly the seconds a long history is in flight" and the seeding rule that uses them fires only while transactions.length === 0. The accounts in this answer therefore carry accounts.balance, the column the accounts read projects, and nothing in this call computes a total',
+  consequence: 'R-4, in both of its halves. Fold the map INTO the boot and it arrives WITH the transactions it was meant to cover for, so the seeding window closes and every account reads £0.00 for the whole boot instead of for none of it. Correct the stored column WITH the derived figure and the two numbers stop being independent — verify_integrity\'s balance_identity would then be reporting a drift that no figure on screen contradicts, which is the one instrument for the one bug it exists to find',
+  parity: 'match',
+
+  // The one fixture outside the integrity-* family that plants a B-1 violation,
+  // planted because the violation IS the subject: the rows say −25.00 and the
+  // column says 999.99. balanceIdentityHolds is therefore not asserted below —
+  // it would be asserting that the fixture failed to do its job — and the stored
+  // figure is asserted instead, which proves it did.
+  setup: setups(
+    namedTransferCategories,
+    aStoredBalanceThatDrifted,
+    pinnedReadTimes,
+    pinnedLedgerTimes,
+  ),
+  command: { verb: 'load_boot', payload: { user_id: USER } },
+  expect: { outcome: 'ok' },
+  result: {
+    accounts: [
+      listedAccount({ id: EVERYDAY, name: 'Everyday', type: 'checking', balance: '999.99' }),
+      listedAccount({
+        id: RAINY_DAY, name: 'Rainy day', type: 'savings', balance: '0.00',
+        created_at: OPENED_SECOND, updated_at: OPENED_SECOND,
+      }),
+    ],
+    // ABSENT, and asserted absent. `undefined` here means "no such key in the
+    // answer", and the runner says so in as many words when one appears:
+    // `result.account_balances: expected (absent), got […]`. That is the first
+    // half of R-4 as a test — a composite that folded the map in fails here on
+    // both engines, because the oracle has no such key either.
+    account_balances: undefined,
+  },
+  state: [
+    balanceOf(EVERYDAY, '999.99'),
+    auditRowsInTotal('0'),
+  ],
+};

--- a/scripts/local-sqlite/verb-specs/boot-the-ledger-inside-the-boot-is-newest-first-and-the-tie-is-broken-by-id.spec.mjs
+++ b/scripts/local-sqlite/verb-specs/boot-the-ledger-inside-the-boot-is-newest-first-and-the-tie-is-broken-by-id.spec.mjs
@@ -1,0 +1,44 @@
+import {
+  USER, EVERYDAY, WEEKLY_SHOP,
+  A_LATER_DAY, SAME_DAY_EARLIER, SAME_DAY_LATER,
+  setups, namedTransferCategories, rowsOnOneDay, pinnedReadTimes, pinnedLedgerTimes,
+  listedTransaction, balanceIdentityHolds, auditRowsInTotal,
+} from './_shared.mjs';
+
+export default {
+  invariant: 'BOOT-3',
+  title: 'the ledger inside the boot is the ledger the read answers with — newest first, ties settled by id',
+  design: 'the composite is built from the reads, so its transactions come back through the same query — .order(\'date\', {ascending: false}).order(\'id\', {ascending: false}), the cloud\'s own "stable tiebreak for paging". R-5 says that proof must not evaporate when the read is composed: an ordering asserted only where it is DEFINED is an ordering nothing checks at the one place the app actually receives it',
+  consequence: 'this list IS the register on the first paint. A composite that sorted its own answer — for a join, for a grouping, for a de-duplication somebody thought was tidy — would draw the ledger in an order no read ever produces, and the running balance down the column would be arithmetic nobody could check. The same three rows are asserted through list_transactions; if only that spec existed, the composite could reverse them and stay green',
+  parity: 'match',
+
+  // The same fixture the read's own ordering spec uses: one row on a later day
+  // and two on the Corner shop's, with ids chosen so id order and INSERTION
+  // order disagree — …f3 is written second and must come out first.
+  //
+  // Everything else is pinned and named because a boot spec compares all six
+  // lists (see the reads' fixture block): `rowsOnOneDay` moves the Everyday
+  // balance, which stamps the account, so the account pin goes after it.
+  setup: setups(namedTransferCategories, rowsOnOneDay, pinnedReadTimes, pinnedLedgerTimes),
+  command: { verb: 'load_boot', payload: { user_id: USER } },
+  expect: { outcome: 'ok' },
+  result: {
+    transactions: [
+      listedTransaction({
+        id: A_LATER_DAY, description: 'A later day', amount: '-1.00',
+        date: '2024-03-02', category: null,
+      }),
+      listedTransaction({
+        id: SAME_DAY_LATER, description: 'Second in', amount: '-1.00', category: null,
+      }),
+      listedTransaction({
+        id: SAME_DAY_EARLIER, description: 'First in', amount: '-1.00', category: null,
+      }),
+      listedTransaction({ category: WEEKLY_SHOP }),
+    ],
+  },
+  state: [
+    balanceIdentityHolds(EVERYDAY),
+    auditRowsInTotal('0'),
+  ],
+};


### PR DESCRIPTION
Phase 3, slice 17 — `load_boot`, the composite. The crate now answers the entire boot in one verb, inside **one deferred read transaction**: six statements outside one get six snapshots, and a commit landing between two of them draws a ledger referencing an account the boot never heard of. The honest limit is documented in place — a single-threaded test proves the transaction *finishes*, not that a write can't land mid-read; the control mutation turns nothing red, and the module says so.

## Ownership rulings (the slice's real work)
- **The fetch-strategy vocabulary stays with the port**: the crate cannot say `'load failed'` for a call that did not happen, and one vocabulary must have one owner. `'local mode'` lands beside it in slice 18's `LocalDataPort`.
- **Timings stay out of the answer**: a duration is never twice the same — fatal to a differential comparison. The caller times the crossing; the breakdown lives in the scale tests.
- **Balances stay a separate crossing started first** (R-4, both halves proved): the answer carries no balance map (serde refuses `include_balances` before touching a connection), and the boot's stored `accounts.balance` crosses untouched — proved on a deliberately drifted cache where stored (999.99) and derived (−27.00) disagree by design.
- **Categories become a plain read**: the cloud's boot may *write* categories on the way in; a file has no second id space to migrate, so seeding is slice 21's verb, not a side effect of looking.

## Verification
Cargo 300 → **313** · verb lane 347 → **354** (BOOT-1…7) · admission 109 · constraint 65/66 (known gap, byte-identical) · smoke untouched-green · zero `src/` changes. Five mutations red on cue — the ordering one initially walked through a one-date fixture + stable sort and was strengthened until it bit. Perf at 50k: the composite costs the sum of its parts (~65ms release; BEGIN/COMMIT below the noise floor). A harness lesson graduated to doctrine: the runner compares every key of a composite answer, so each boot spec pins the lists it isn't about.

Slice 18 inherits two named obligations: map `transaction_splits → splits`, and own the stats vocabulary plus the one `phases` entry it times itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)