### PR TITLE
feat(local): slice 24 — the C/R split crosses into the file, a3 green at last (NOT_YET=4, 94/101 contract rules on local-core)

### DIFF
--- a/crates/wealth-core/src/command.rs
+++ b/crates/wealth-core/src/command.rs
@@ -78,27 +78,32 @@ use crate::admission::{
 };
 use crate::error::CoreError;
 use crate::verbs::{
-    account_balances, apply_category_to_uncategorized, clear_transfer_links, close_account,
+    account_balances, apply_category_to_uncategorized, archive_transactions_before,
+    clear_transfer_links, close_account,
     confirm_transaction_categories, create_account, create_budget, create_categories,
     create_category, create_goal, create_transaction, create_transfer_counterpart, delete_budget,
     delete_category, delete_goal, delete_transaction,
-    delete_unused_categories, dismiss_suggestion, finalize_user_restore, import_bank_transactions,
+    delete_unused_categories, dismiss_suggestion, finalize_reconciliation, finalize_user_restore,
+    import_bank_transactions,
     import_transactions,
     link_bank_account_snap, link_split_line_transfer, link_transfer_pair, list_accounts,
     list_budgets, list_categories, list_closed_accounts, list_goals, list_suggestion_dismissals,
     list_transaction_splits, list_transactions, load_boot, merge_categories,
     repair_claimed_transfer, restore_suggestion, restore_user_chunk, seed_categories,
-    set_transaction_splits_with_legs, splits_for, update_account, update_budget, update_category,
+    set_transaction_splits_with_legs, set_transactions_archived, set_transactions_cleared,
+    splits_for, unarchive_account, update_account, update_budget, update_category,
     update_goal, update_transaction, user_financial_data_is_empty, verify_integrity,
     wipe_user_financial_data,
-    ApplyCategoryToUncategorized, ClearTransferLinks, CloseAccount, ConfirmTransactionCategories,
+    ApplyCategoryToUncategorized, ArchiveTransactionsBefore, ClearTransferLinks, CloseAccount,
+    ConfirmTransactionCategories,
     CreateAccount, CreateBudget, CreateCategories, CreateCategory, CreateGoal, CreateTransaction,
     CreateTransferCounterpart, DeleteBudget, DeleteCategory, DeleteGoal, DeleteTransaction,
-    DeleteUnusedCategories, DismissSuggestion, FinalizeUserRestore,
+    DeleteUnusedCategories, DismissSuggestion, FinalizeReconciliation, FinalizeUserRestore,
     ImportBankTransactions, ImportTransactions, LinkBankAccountSnap, LinkSplitLineTransfer,
     LinkTransferPair, MergeCategories, OwnedRead, RepairClaimedTransfer, RestoreSuggestion,
     RestoreUserChunk,
-    SeedCategories, SetTransactionSplitsWithLegs, SplitsFor, UpdateAccount, UpdateBudget,
+    SeedCategories, SetTransactionSplitsWithLegs, SetTransactionsArchived, SetTransactionsCleared,
+    SplitsFor, UnarchiveAccount, UpdateAccount, UpdateBudget,
     UpdateCategory, UpdateGoal, UpdateTransaction, UserFinancialDataIsEmpty, VerifyIntegrity,
     WipeUserFinancialData,
 };
@@ -129,6 +134,29 @@ pub enum Command {
     // verb string that will one day mean the wrong one.
     /// [`crate::verbs::set_transaction_splits_with_legs`].
     SetTransactionSplitsWithLegs(Box<SetTransactionSplitsWithLegs>),
+    // ── The reconciliation and archive family ────────────────────────────────
+    //
+    // Five verb strings, each spelled exactly as the RPC it ports — including
+    // the two PLURALS, `set_transactions_cleared` and `set_transactions_
+    // archived`, whose seam operations are singular (`setTransactionArchived`
+    // takes one id and the client sends `[id]`). The narrowing belongs to the
+    // port; the verb is the function.
+    //
+    // Three of the five were restated by 20260810200000_marking_is_not_
+    // reconciling.sql and the LIVE definitions are the ones ported: marking now
+    // resolves the committed flag, finalize is new, and the archive reads
+    // COALESCE(is_reconciled, is_cleared). `unarchive_account` is untouched by
+    // that migration and is ported from 20260721130000.
+    /// [`crate::verbs::set_transactions_cleared`].
+    SetTransactionsCleared(Box<SetTransactionsCleared>),
+    /// [`crate::verbs::finalize_reconciliation`].
+    FinalizeReconciliation(Box<FinalizeReconciliation>),
+    /// [`crate::verbs::set_transactions_archived`].
+    SetTransactionsArchived(Box<SetTransactionsArchived>),
+    /// [`crate::verbs::archive_transactions_before`].
+    ArchiveTransactionsBefore(Box<ArchiveTransactionsBefore>),
+    /// [`crate::verbs::unarchive_account`].
+    UnarchiveAccount(Box<UnarchiveAccount>),
     // The transfer family. Five RPCs, five verb strings, each spelled exactly as
     // the function it ports — including `clear_transfer_links`, which is what
     // the client's `clearTransferLinks` actually calls (it stopped being a table
@@ -491,6 +519,21 @@ pub fn dispatch(
         }
         Command::LinkSplitLineTransfer(payload) => {
             link_split_line_transfer(connection, *payload).and_then(as_json)
+        }
+        Command::SetTransactionsCleared(payload) => {
+            set_transactions_cleared(connection, *payload).and_then(as_json)
+        }
+        Command::FinalizeReconciliation(payload) => {
+            finalize_reconciliation(connection, *payload).and_then(as_json)
+        }
+        Command::SetTransactionsArchived(payload) => {
+            set_transactions_archived(connection, *payload).and_then(as_json)
+        }
+        Command::ArchiveTransactionsBefore(payload) => {
+            archive_transactions_before(connection, *payload).and_then(as_json)
+        }
+        Command::UnarchiveAccount(payload) => {
+            unarchive_account(connection, *payload).and_then(as_json)
         }
         Command::MergeCategories(payload) => {
             merge_categories(connection, *payload).and_then(as_json)

--- a/crates/wealth-core/src/row.rs
+++ b/crates/wealth-core/src/row.rs
@@ -128,8 +128,19 @@ pub struct TransactionRow {
     pub payment_channel: Option<String>,
     /// Part of a recurring series.
     pub is_recurring: bool,
-    /// Reconciled against a statement.
+    /// MARKED against a statement — Money's C, a working note. Not a
+    /// reconciliation: see [`TransactionRow::is_reconciled`].
     pub is_cleared: bool,
+    /// COMMITTED against a confirmed statement balance — Money's R.
+    ///
+    /// `Option`, because the column is three-valued in both engines and the
+    /// third value carries meaning: `None` is *"this row predates the split
+    /// between marking and committing; ask `is_cleared`"*
+    /// (`20260810200000:52-54`, and `transactionReconciliation.ts` for the app).
+    /// Reading it as `false` would report a whole reconciled history as
+    /// unreconciled work, which is the mistake the cloud's nullable column
+    /// exists to make impossible.
+    pub is_reconciled: Option<bool>,
     /// Is this row a split parent?
     pub is_split: bool,
     /// Archived out of the live register.
@@ -167,7 +178,8 @@ pub fn read_transaction(connection: &Connection, id: &str) -> CoreResult<Transac
                 location_country, payment_channel, is_recurring, is_cleared,
                 is_split, archived, statement_sequence, category_confirmed,
                 transfer_account_id, linked_transfer_id, linked_transfer_split_id,
-                import_source, import_source_id, external_transaction_id, metadata
+                import_source, import_source_id, external_transaction_id, metadata,
+                is_reconciled
            FROM transactions
           WHERE id = ?1",
         params![id],
@@ -190,6 +202,8 @@ pub fn read_transaction(connection: &Connection, id: &str) -> CoreResult<Transac
                 payment_channel: record.get(13)?,
                 is_recurring: record.get::<_, i64>(14)? != 0,
                 is_cleared: record.get::<_, i64>(15)? != 0,
+                // The NULL survives as `None`; see the field.
+                is_reconciled: record.get::<_, Option<i64>>(27)?.map(|value| value != 0),
                 is_split: record.get::<_, i64>(16)? != 0,
                 archived: record.get::<_, i64>(17)? != 0,
                 statement_sequence: record.get(18)?,
@@ -285,24 +299,25 @@ pub fn read_owned_transaction(
 /// redundant `user_id` we already filter on"*. It is a column the answer's own
 /// question already fixed.
 ///
-/// # `is_reconciled` is the column this file has not got
+/// # `is_reconciled` WAS the column this file had not got
 ///
-/// The cloud's boot list carries it (added by `20260810200000_marking_is_not_
-/// reconciling.sql`, which split "marked" from "reconciled") and
+/// It is here now, and the entry is kept rather than deleted because it is the
+/// record of what such a gap costs while it is open. It used to read: the
+/// cloud's boot list carries the column (added by `20260810200000_marking_is_
+/// not_reconciling.sql`, which split "marked" from "reconciled") and
 /// `scripts/local-sqlite/schema.sql` has no such column — the same kind of gap
-/// [`crate::row::account::ListedAccount`] records for `last_reconciled_balance`,
-/// and named here rather than papered over because it is named where it BITES:
+/// [`crate::row::account::ListedAccount`] recorded for `last_reconciled_balance`
+/// — so a local file *"does not lie about a row: it describes a ledger in which
+/// marking and reconciling are the same act, which is what a file without the
+/// column IS"*, exactly as the cloud's own fallback ladder
+/// (`BOOT_TRANSACTION_COLUMNS_NO_RECONCILED`) reads a database that has not had
+/// the migration. It ended with the condition for closing it: *"the day
+/// `schema.sql` grows the column, this struct and the harness's oracle must grow
+/// it together"*, and that is what this slice did.
 ///
-/// `src/utils/transactionReconciliation.ts` treats an absent `reconciled` as
-/// *"ask `cleared`"*, which is the one-flag behaviour this app had until that
-/// migration. So a local file does not lie about a row — it describes a ledger
-/// in which marking and reconciling are the same act, which is what a file
-/// without the column IS. The cloud's own fallback ladder
-/// (`BOOT_TRANSACTION_COLUMNS_NO_RECONCILED`) does exactly this for a database
-/// that has not had the migration applied yet. What is NOT true of a local file
-/// is that the feature *lights up by itself the moment the migration lands*:
-/// there is no migration to land until `schema.sql` grows the column, and the
-/// day it does, this struct and the harness's oracle must grow it together.
+/// `Option<bool>` for [`TransactionRow::is_reconciled`]'s reason: `None` means
+/// *"ask `is_cleared`"*, and `src/utils/transactionReconciliation.ts` is the one
+/// place that rule is written for the app.
 #[derive(Debug, Clone, Serialize)]
 // Six booleans, because six of the columns the boot reads are booleans. The
 // reasoning is `TransactionRow`'s: this is a row, not a designed API.
@@ -329,8 +344,10 @@ pub struct ListedTransaction {
     pub date: String,
     /// Payee or description, as entered or as the file stated it.
     pub description: String,
-    /// Marked against a statement.
+    /// Marked against a statement — Money's C, a working note.
     pub is_cleared: bool,
+    /// Committed by a finalize — Money's R. `None` means "ask `is_cleared`".
+    pub is_reconciled: Option<bool>,
     /// Part of a recurring series.
     pub is_recurring: bool,
     /// Is this row a split parent?
@@ -357,11 +374,12 @@ pub struct ListedTransaction {
 }
 
 /// Every column [`ListedTransaction`] carries, in its serialised order — which
-/// is `BOOT_TRANSACTION_COLUMNS`'s order, so the two lists can be read side by
-/// side and the one difference (`is_reconciled`) seen rather than searched for.
+/// is `BOOT_TRANSACTION_COLUMNS`'s order. The two lists can be read side by side
+/// and, since this slice, they hold the same names: the one difference used to
+/// be `is_reconciled`, and closing it is what the C/R split needed here.
 const LISTED_COLUMNS: &str = "id, account_id, amount_minor, archived, category,
         category_confirmed, category_id, created_at, date, description, is_cleared,
-        is_recurring, is_split, linked_transfer_id, linked_transfer_split_id,
+        is_reconciled, is_recurring, is_split, linked_transfer_id, linked_transfer_split_id,
         needs_review, notes, statement_sequence, type, updated_at, transfer_account_id";
 
 /// The statement [`list_owned`] prepares, and the ONLY copy of it.
@@ -445,17 +463,18 @@ pub fn list_owned(connection: &Connection, user_id: &str) -> CoreResult<Vec<List
             date: record.get(8)?,
             description: record.get(9)?,
             is_cleared: record.get::<_, i64>(10)? != 0,
-            is_recurring: record.get::<_, i64>(11)? != 0,
-            is_split: record.get::<_, i64>(12)? != 0,
-            linked_transfer_id: record.get(13)?,
-            linked_transfer_split_id: record.get(14)?,
-            needs_review: record.get::<_, i64>(15)? != 0,
-            notes: record.get(16)?,
-            statement_sequence: record.get(17)?,
+            is_reconciled: record.get::<_, Option<i64>>(11)?.map(|value| value != 0),
+            is_recurring: record.get::<_, i64>(12)? != 0,
+            is_split: record.get::<_, i64>(13)? != 0,
+            linked_transfer_id: record.get(14)?,
+            linked_transfer_split_id: record.get(15)?,
+            needs_review: record.get::<_, i64>(16)? != 0,
+            notes: record.get(17)?,
+            statement_sequence: record.get(18)?,
             tags: Vec::new(),
-            kind: record.get(18)?,
-            updated_at: record.get(19)?,
-            transfer_account_id: record.get(20)?,
+            kind: record.get(19)?,
+            updated_at: record.get(20)?,
+            transfer_account_id: record.get(21)?,
         })
     })?;
 

--- a/crates/wealth-core/src/verbs/archive_transactions_before.rs
+++ b/crates/wealth-core/src/verbs/archive_transactions_before.rs
@@ -1,0 +1,212 @@
+//! `archive_transactions_before` — hide an account's settled history, by date.
+//!
+//! # What it is a port OF
+//!
+//! `supabase/migrations/20260810200000_marking_is_not_reconciling.sql:290-329`,
+//! which is the LIVE definition and is byte-for-byte
+//! `20260721130000_soft_archive.sql:47-86` except for ONE predicate: the rows it
+//! flags are the RECONCILED ones, and "reconciled" now means committed. The
+//! client calls it at one place (`transactionService.archiveTransactionsBefore`),
+//! from the Archive manager.
+//!
+//! # `COALESCE(is_reconciled, is_cleared) = true`, AND WHY THE COALESCE STAYS
+//!
+//! The predicate reads the committed state with the pre-split fallback, which is
+//! `src/utils/transactionReconciliation.ts`'s `isReconciled` written in SQL. The
+//! migration's own sentence: *"what this archives today is exactly what it would
+//! have archived yesterday"* — a row written before the split carries NULL, and
+//! NULL is judged by `is_cleared`, which is what the archive was judging it by
+//! the day before the column existed.
+//!
+//! So three states, three answers:
+//!
+//! | `is_reconciled` | archived by this verb? |
+//! | --- | --- |
+//! | `1` | yes, if it is old enough |
+//! | `0` | **no** — marked but not committed is work in progress, and it stays in the register where it can still be unmarked |
+//! | NULL | ask `is_cleared`: pre-split history, judged as it always was |
+//!
+//! The middle row is the behaviour change this verb inherits from the split, and
+//! it is the one worth reading twice: an account whose whole statement has been
+//! ticked but never finished archives NOTHING, which is correct — nothing about
+//! it has been settled.
+//!
+//! # IT AUDITS NOTHING, AND THAT IS THE RPC'S SHAPE RATHER THAN AN OMISSION
+//!
+//! There is no `write_financial_audit` anywhere in the cloud function, and none
+//! here. The asymmetry with [`super::set_transactions_archived`] — the per-row
+//! archive, which audits every row it touches — is the CLOUD's, and the port
+//! reproduces it rather than tidying it: these two verbs are ports of RPCs, so
+//! the RPC is the specification, and a local edition that wrote an audit trail
+//! the cloud does not would make `auditShape` diverge on every archive and hide
+//! the difference that matters. Recorded here so the next reader can see it was
+//! traced rather than forgotten. (Contrast the account, category, planning and
+//! dismissal families, where there is NO RPC and the audit decision is genuinely
+//! the port's to make — [`crate::verbs`] carries those four tables.)
+//!
+//! # Balance-neutral, and the seeded register total that depends on it
+//!
+//! `archived` and `updated_at` on the rows, `archive_through_date` and
+//! `updated_at` on the account. Nothing else. The register seeds its running
+//! balance from the sum of the rows it is HIDING, so an archive that moved a
+//! balance would be double-counted on the very screen it was meant to tidy.
+//!
+//! # Investments are refused, in v1
+//!
+//! `IF v_acct.type = 'investment' THEN RAISE`. The soft-archive migration's
+//! reason: *"their transfers/cost-basis want special handling"*. Ported with the
+//! cloud's own sentence so both engines refuse with the same words.
+//!
+//! # The account is stamped even when nothing was old enough
+//!
+//! Both UPDATEs always run: the cutoff is recorded whether or not any row met
+//! it, because the cutoff is a statement about the ACCOUNT ("everything before
+//! this is archived") and the sweep in `schema.sql` reads it afterwards. An
+//! account with a cutoff and no archived rows is the normal state of an account
+//! whose old rows are not reconciled yet, and A-3 is what fills it in later, one
+//! row at a time, as each is committed.
+//!
+//! # Which guard it holds: none, and measured
+//!
+//! `archived`/`updated_at` on transactions and `archive_through_date`/
+//! `updated_at` on the account. No split protection watches any of them; C-4
+//! watches `name` and `is_active`; the reconcile sweep watches `is_reconciled`,
+//! which this verb reads and never writes.
+
+use rusqlite::{params, Connection, TransactionBehavior};
+use serde::{Deserialize, Serialize};
+
+use crate::db;
+use crate::error::{CoreError, CoreResult, Refusal};
+use crate::row::account::{self, ListedAccount};
+
+/// The command: `(p_user_id, p_account_id, p_cutoff)` as one object.
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ArchiveTransactionsBefore {
+    /// `p_user_id`. As [`super::finalize_reconciliation`]: no owner, no account.
+    #[serde(default)]
+    pub user_id: Option<String>,
+    /// `p_account_id`. Whose history is being tidied.
+    pub account_id: String,
+    /// `p_cutoff`. Everything on or before this day, `YYYY-MM-DD`.
+    pub cutoff: String,
+}
+
+/// What the verb hands back.
+#[derive(Debug, Serialize)]
+pub struct ArchiveTransactionsBeforeResult {
+    /// The projection both engines are compared on — the RPC's own
+    /// `jsonb_build_object`, key for key.
+    pub answer: ArchiveAnswer,
+    /// The account as stored afterwards. Local, and beside the answer rather
+    /// than in it: the cloud function returns no account, and a key one engine
+    /// has is a key the differential runner reports as a divergence.
+    pub account: ListedAccount,
+}
+
+/// The RPC's return value.
+#[derive(Debug, Serialize)]
+pub struct ArchiveAnswer {
+    /// How many rows were hidden by this call.
+    pub archived: i64,
+    /// The cutoff now recorded on the account.
+    pub cutoff: String,
+}
+
+/// Archive an account's committed history up to and including a cutoff.
+///
+/// # Errors
+/// [`CoreError::Refused`] for `account_not_found`, for an investment account and
+/// for a cutoff that is not a calendar day; [`CoreError::Storage`] for a fault.
+#[allow(clippy::needless_pass_by_value)]
+pub fn archive_transactions_before(
+    connection: &mut Connection,
+    command: ArchiveTransactionsBefore,
+) -> CoreResult<ArchiveTransactionsBeforeResult> {
+    // Before the transaction, and before the account is even looked for:
+    // Postgres casts `p_cutoff` to `date` at call time, so an impossible day is
+    // refused there before the function body runs. `LIKE '____-__-__'` would
+    // store 31 February, so the day is judged here instead — D-8, and the same
+    // local strengthening `create_transaction` applies to `date`.
+    let Some(cutoff) = super::create_account::calendar_day(&command.cutoff, "cutoff")? else {
+        return Err(CoreError::Refused(
+            Refusal::named(
+                "date_invalid",
+                "cutoff must be a real calendar date as YYYY-MM-DD",
+            )
+            .with_hint("An archive with no cutoff would be an archive of everything."),
+        ));
+    };
+
+    let write = connection.transaction_with_behavior(TransactionBehavior::Immediate)?;
+    let now = db::now(&write)?;
+
+    // `SELECT * INTO v_acct … WHERE id = p_account_id AND user_id = p_user_id;
+    //  IF NOT FOUND THEN RAISE EXCEPTION 'account_not_found'` — and the name is
+    // the RPC's own, which is NOT the `account_not_found_or_not_owned` the
+    // transaction RPCs raise. Two names for one shape of failure is the cloud's
+    // inconsistency; a port that unified them would refuse with a word no cloud
+    // caller has ever seen.
+    let owner = command.user_id.as_deref().ok_or_else(not_found)?;
+    let before = account::read_listed(&write, &command.account_id, owner)?.ok_or_else(not_found)?;
+
+    if before.kind == "investment" {
+        return Err(CoreError::refuse(
+            "investment_cannot_be_archived",
+            "investment accounts cannot be archived yet",
+        ));
+    }
+
+    let archived = write.execute(
+        // COALESCE(is_reconciled, is_cleared) = true — see the module docs. The
+        // date comparison is a TEXT one, which is exactly a date comparison for
+        // 'YYYY-MM-DD': the shape CHECK on the column is what makes that true.
+        "UPDATE transactions
+            SET archived   = 1,
+                updated_at = ?1
+          WHERE user_id = ?2
+            AND account_id = ?3
+            AND COALESCE(is_reconciled, is_cleared) = 1
+            AND archived = 0
+            AND date <= ?4",
+        params![now, before.user_id, command.account_id, cutoff],
+    )?;
+
+    let stamped = write.execute(
+        "UPDATE accounts
+            SET archive_through_date = ?1,
+                updated_at           = ?2
+          WHERE id = ?3
+            AND user_id = ?4",
+        params![cutoff, now, command.account_id, before.user_id],
+    )?;
+    if stamped != 1 {
+        return Err(CoreError::refuse(
+            "account_not_found",
+            "the account disappeared between finding it and recording the cutoff",
+        ));
+    }
+
+    let after = account::read_listed(&write, &command.account_id, &before.user_id)?
+        .ok_or_else(not_found)?;
+
+    let count = super::count(archived)?;
+
+    write.commit()?;
+
+    Ok(ArchiveTransactionsBeforeResult {
+        answer: ArchiveAnswer {
+            archived: count,
+            cutoff,
+        },
+        account: after,
+    })
+}
+
+fn not_found() -> CoreError {
+    CoreError::Refused(
+        Refusal::named("account_not_found", "account_not_found")
+            .with_hint("The account does not exist or does not belong to this user."),
+    )
+}

--- a/crates/wealth-core/src/verbs/finalize_reconciliation.rs
+++ b/crates/wealth-core/src/verbs/finalize_reconciliation.rs
@@ -1,0 +1,393 @@
+//! `finalize_reconciliation` — the only thing in the system that COMMITS a row.
+//!
+//! # What it is a port OF
+//!
+//! `supabase/migrations/20260810200000_marking_is_not_reconciling.sql:209-278`.
+//! It is the one function that migration CREATED rather than restated, and it
+//! is what turned Finalize from a button whose only visible effect was a date
+//! into the act that finishes a reconciliation. The client calls it at one place
+//! (`transactionService.finalizeReconciliation`), from the reconciliation
+//! screen's Finish.
+//!
+//! # IT CONVERTS EXACTLY THE WORKING SET
+//!
+//! `is_cleared = true AND is_reconciled IS NOT DISTINCT FROM false` — and the
+//! second half is `IS NOT DISTINCT FROM false` rather than `IS DISTINCT FROM
+//! true` ON PURPOSE. The migration argues it:
+//!
+//! > a NULL row is one the old world already called reconciled, and sweeping
+//! > those in would rewrite (and re-audit, and re-stamp `updated_at` on) the
+//! > entire history of the account the first time anybody finalized it, for no
+//! > change in what any screen shows.
+//!
+//! In SQLite `IS NOT DISTINCT FROM false` is spelled `is_reconciled IS 0`, which
+//! is NOT the same predicate as `is_reconciled = 0` (that one is NULL, and
+//! therefore false, for a pre-split row — the same answer here by luck rather
+//! than by statement, and a spelling that would silently start including NULLs
+//! the day it was written the other way round). It is spelled `IS 0`.
+//!
+//! # IT RECORDS THE FIGURE IT WAS SETTLED AGAINST
+//!
+//! Because the next reconciliation opens at last time's ending balance, and
+//! because *"reconciled on the 3rd" without "against what" is a claim nobody can
+//! check afterwards*. Both go on the account: `last_reconciled_date` and
+//! `last_reconciled_balance` (`last_reconciled_balance_minor` here — slice 20
+//! added the column for `AccountUpdate`'s sake, before there was a verb to write
+//! it).
+//!
+//! **ZERO IS A FIGURE.** A NULL ending balance is refused by name; `0` is
+//! accepted and recorded, because an account swept to zero every night closes on
+//! exactly that. The two must not share a representation and the column is
+//! nullable so that they do not.
+//!
+//! # ALL-OR-NOTHING, AND WHAT THE INTERMEDIATE STATE WOULD COST
+//!
+//! One transaction: the rows and the account's record of them land together or
+//! neither does. Rows committed against a statement the account has no memory of
+//! is the state that makes the NEXT reconciliation start from a figure that is
+//! not the one this one finished on.
+//!
+//! # BALANCE-NEUTRAL, AND THE ONE FIGURE THAT LOOKS LIKE MONEY
+//!
+//! It writes one flag per row and two records on the account, and never touches
+//! `balance` or `initial_balance`. `last_reconciled_balance` is a RECORD of a
+//! figure a person confirmed on a day: never added to, never compared against
+//! `balance` by anything here, and never reconciled TO — a difference between
+//! the two is the thing the screen exists to show, and closing it silently would
+//! be inventing money. It still crosses as a [`Money`] string, because a
+//! statement balance is money and a JSON number is a double.
+//!
+//! # THE OWNER IS REQUIRED, WHICH IS UNUSUAL IN THIS CRATE
+//!
+//! Every other verb here takes `Option<String>` and lets an absent owner stand
+//! the guard down — the local twin of the cloud falling back to RLS. This RPC's
+//! `p_user_id` has no default and its account lookup is `WHERE id = p_account_id
+//! AND user_id = p_user_id`, so a NULL owner matches nothing and the call is
+//! refused `account_not_found_or_not_owned`. The port keeps `Option` so that the
+//! shape of a payload is the same everywhere, and reproduces the SQL's answer:
+//! no owner, no account, refused.
+//!
+//! # The sweep fires here, and only here
+//!
+//! This verb writes `is_reconciled = 1`, so `trg_sweep_reconciled_into_archive`
+//! fires for every row it converts, and archives the ones dated on or before
+//! their account's cutoff. That is A-3 and it is the point of the split: a
+//! COMMITTED row may drop off the live register, a MARKED one may not.
+//!
+//! The cloud does it in a BEFORE trigger that assigns `NEW.archived := true`,
+//! which SQLite cannot do, so `schema.sql` issues a second UPDATE from an AFTER
+//! trigger. The end state is identical and the audit entry says so on both
+//! engines: this verb reads the row back AFTER the statement, so the `after` it
+//! records carries `archived` as the sweep left it rather than as the SET list
+//! wrote it.
+//!
+//! # Which guard it holds: none, and measured
+//!
+//! It writes `is_reconciled` and `updated_at` on transactions and three columns
+//! on the account. No split protection watches any of them; C-4 watches `name`
+//! and `is_active`, neither of which it writes; `trg_accounts_updated_at` stands
+//! down of its own accord because this writes `updated_at` itself.
+//! `tests/reconciliation_family.rs` asserts the guard table empty across a
+//! finalize.
+
+use rusqlite::{params, Connection, TransactionBehavior};
+use serde::{Deserialize, Serialize};
+
+use crate::audit::{self, Action};
+use crate::db;
+use crate::error::{CoreError, CoreResult, Refusal};
+use crate::money::Money;
+use crate::row::account::{self, ListedAccount};
+use crate::row::{self, TransactionRow};
+
+/// The command: `(p_user_id, p_account_id, p_ending_balance, p_reconciled_on)`.
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct FinalizeReconciliation {
+    /// `p_user_id`. See the module docs: no owner, no account.
+    #[serde(default)]
+    pub user_id: Option<String>,
+    /// `p_account_id`. Which account is being finished.
+    pub account_id: String,
+    /// `p_ending_balance`. The statement's closing figure, as a decimal string.
+    /// Absent is refused by name; `"0"` is a real answer.
+    #[serde(default)]
+    pub ending_balance: Option<Money>,
+    /// `p_reconciled_on`. The day it was settled. Absent means today, which is
+    /// the RPC's `COALESCE(p_reconciled_on, CURRENT_DATE)`.
+    #[serde(default)]
+    pub reconciled_on: Option<String>,
+}
+
+/// What the verb hands back.
+#[derive(Debug, Serialize)]
+pub struct FinalizeReconciliationResult {
+    /// The projection both engines are compared on — the RPC's own
+    /// `jsonb_build_object`, key for key. Everything below it is local.
+    pub answer: FinalizeAnswer,
+    /// The account as stored afterwards.
+    pub account: ListedAccount,
+    /// The rows converted, as stored, in the order they were written.
+    pub transactions: Vec<TransactionRow>,
+    /// Dense sequence number of the LAST audit row written — the account's,
+    /// which is always written, so this is never `None`.
+    pub audit_seq: i64,
+    /// Its chained hash.
+    pub audit_row_hash: String,
+}
+
+/// The RPC's return value.
+#[derive(Debug, Serialize)]
+pub struct FinalizeAnswer {
+    /// How many rows this call converted from marked to committed. Rows already
+    /// committed are not counted twice, and pre-split rows are not counted at
+    /// all.
+    pub reconciled: i64,
+    /// The figure the account now records. Echoed back because the screen shows
+    /// it, and because a caller must never have to re-read to learn what it just
+    /// wrote. A decimal STRING, as every figure that leaves this crate is.
+    pub ending_balance: Money,
+    /// The day the account now records.
+    pub reconciled_on: String,
+}
+
+/// Commit an account's marked rows and record the statement they were settled
+/// against, in one transaction.
+///
+/// # Errors
+/// [`CoreError::Refused`] for `ending_balance_required` and for
+/// `account_not_found_or_not_owned`; [`CoreError::Storage`] for a fault.
+#[allow(clippy::needless_pass_by_value)]
+pub fn finalize_reconciliation(
+    connection: &mut Connection,
+    command: FinalizeReconciliation,
+) -> CoreResult<FinalizeReconciliationResult> {
+    // First, and before the transaction opens: the ending balance is the whole
+    // point of finishing, and a NULL one would record "reconciled against
+    // nothing". The RPC checks it first too.
+    let Some(ending_balance) = command.ending_balance else {
+        return Err(CoreError::Refused(
+            Refusal::named(
+                "ending_balance_required",
+                "ending_balance_required",
+            )
+            .with_hint(
+                "A reconciliation is settled against a statement's closing figure. £0.00 is a \
+                 figure; no figure at all is not.",
+            ),
+        ));
+    };
+
+    let write = connection.transaction_with_behavior(TransactionBehavior::Immediate)?;
+    let now = db::now(&write)?;
+    let owner = command.user_id.as_deref();
+
+    // `COALESCE(p_reconciled_on, CURRENT_DATE)`. The day is validated rather
+    // than trusted: the column is TEXT here and `date` there, so 31 February
+    // would be refused by Postgres and stored by a `LIKE '____-__-__'` CHECK.
+    let reconciled_on = match command.reconciled_on.as_deref() {
+        Some(stated) => super::create_account::calendar_day(stated, "reconciled_on")?
+            .unwrap_or_else(|| today(&now)),
+        None => today(&now),
+    };
+
+    let before_account = read_owned_account(&write, &command.account_id, owner)?;
+    let converted = commit_the_working_set(
+        &write,
+        &before_account.user_id,
+        &command.account_id,
+        &now,
+    )?;
+
+    let changed = write.execute(
+        "UPDATE accounts
+            SET last_reconciled_date          = ?1,
+                last_reconciled_balance_minor = ?2,
+                updated_at                    = ?3
+          WHERE id = ?4
+            AND user_id = ?5",
+        params![
+            reconciled_on,
+            ending_balance.minor(),
+            now,
+            command.account_id,
+            before_account.user_id
+        ],
+    )?;
+    if changed != 1 {
+        return Err(CoreError::refuse(
+            Refusal::ACCOUNT_NOT_FOUND_OR_NOT_OWNED,
+            "the account disappeared between finding it and recording the reconciliation",
+        ));
+    }
+
+    let after_account = account::read_listed(&write, &command.account_id, &before_account.user_id)?
+        .ok_or_else(|| {
+            CoreError::refuse(
+                Refusal::ACCOUNT_NOT_FOUND_OR_NOT_OWNED,
+                "the account disappeared between recording the reconciliation and reading it back",
+            )
+        })?;
+
+    let entry = audit::write(
+        &write,
+        &after_account.user_id,
+        "account",
+        &command.account_id,
+        Action::Update,
+        Some(&super::json_of(&before_account)?),
+        Some(&super::json_of(&after_account)?),
+        &now,
+    )?;
+
+    let reconciled = super::count(converted.len())?;
+
+    write.commit()?;
+
+    Ok(FinalizeReconciliationResult {
+        answer: FinalizeAnswer {
+            reconciled,
+            ending_balance,
+            reconciled_on,
+        },
+        account: after_account,
+        transactions: converted,
+        audit_seq: entry.seq,
+        audit_row_hash: entry.row_hash,
+    })
+}
+
+/// Convert every marked-but-uncommitted row of one account, audited one by one.
+///
+/// The RPC's `FOR v_old IN SELECT … FOR UPDATE LOOP`, and the two halves of its
+/// WHERE clause are the whole selection rule: `is_cleared = 1` (this is the
+/// working set a person built up by ticking) and `is_reconciled IS 0` (NOT `= 0`
+/// — a pre-split NULL is history the old world already called reconciled, and
+/// sweeping it in would re-audit and re-stamp the whole account).
+///
+/// The ids are collected before the loop rather than iterated live, because the
+/// UPDATE inside it fires `trg_sweep_reconciled_into_archive`, and walking a
+/// cursor over a table being written through a trigger is a different question
+/// on every engine. The set cannot change under us: one verb, one IMMEDIATE
+/// transaction, one writer.
+fn commit_the_working_set(
+    write: &rusqlite::Transaction<'_>,
+    owner: &str,
+    account_id: &str,
+    now: &str,
+) -> CoreResult<Vec<TransactionRow>> {
+    let ids = {
+        let mut statement = write.prepare(
+            "SELECT id FROM transactions
+              WHERE user_id = ?1
+                AND account_id = ?2
+                AND is_cleared = 1
+                AND is_reconciled IS 0
+              ORDER BY id",
+        )?;
+        let rows = statement
+            .query_map(params![owner, account_id], |record| {
+                record.get::<_, String>(0)
+            })?;
+        let mut ids = Vec::new();
+        for id in rows {
+            ids.push(id?);
+        }
+        ids
+    };
+
+    let mut converted = Vec::new();
+    for id in &ids {
+        let before = row::read_transaction(write, id)?;
+        let changed = write.execute(
+            "UPDATE transactions
+                SET is_reconciled = 1,
+                    updated_at    = ?1
+              WHERE id = ?2",
+            params![now, id],
+        )?;
+        if changed != 1 {
+            return Err(CoreError::refuse(
+                "transaction_not_found",
+                "a transaction being committed disappeared between finding it and writing it",
+            ));
+        }
+        // Read back AFTER the statement, so the sweep's archive is in the
+        // `after` this audits — which is what the cloud's `RETURNING *` gives it
+        // from a BEFORE trigger.
+        let after = row::read_transaction(write, id)?;
+
+        audit::write(
+            write,
+            &after.user_id,
+            "transaction",
+            &after.id,
+            Action::Update,
+            Some(&super::json_of(&before)?),
+            Some(&super::json_of(&after)?),
+            now,
+        )?;
+        converted.push(after);
+    }
+    Ok(converted)
+}
+
+/// The account, scoped as the RPC scopes it: `id = p_account_id AND user_id =
+/// p_user_id`, with a NULL owner matching nothing.
+fn read_owned_account(
+    connection: &Connection,
+    account_id: &str,
+    user_id: Option<&str>,
+) -> CoreResult<ListedAccount> {
+    let owner = user_id.ok_or_else(not_found)?;
+    account::read_listed(connection, account_id, owner)?.ok_or_else(not_found)
+}
+
+fn not_found() -> CoreError {
+    CoreError::Refused(
+        Refusal::named(
+            Refusal::ACCOUNT_NOT_FOUND_OR_NOT_OWNED,
+            Refusal::ACCOUNT_NOT_FOUND_OR_NOT_OWNED,
+        )
+        .with_hint("The account does not exist or does not belong to this user."),
+    )
+}
+
+/// `CURRENT_DATE`, from the instant this call is stamping everything else with.
+///
+/// Taken from `now` rather than asked for separately, so that a finalize which
+/// runs across midnight cannot record one day on the account and another on the
+/// rows it wrote. `db::now` is an ISO instant, and its first ten characters are
+/// its UTC day — which is divergence D-9's answer for this engine.
+fn today(now: &str) -> String {
+    now.get(..10).unwrap_or(now).to_owned()
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
+mod tests {
+    use super::FinalizeReconciliation;
+
+    #[test]
+    fn an_ending_balance_may_not_arrive_as_a_json_number() {
+        // A statement's closing figure is money, and a JSON number is a double
+        // by the time any parser has read it.
+        let error = serde_json::from_str::<FinalizeReconciliation>(
+            r#"{"account_id":"a","ending_balance":142.5}"#,
+        )
+        .expect_err("money may not be a JSON number");
+        assert!(error.to_string().contains("amount_must_be_a_string"), "{error}");
+    }
+
+    #[test]
+    fn there_is_nowhere_to_name_the_rows() {
+        // The working set is a property of the account, not of the caller's
+        // list: a payload that could name rows could commit a row that was
+        // never marked.
+        let error = serde_json::from_str::<FinalizeReconciliation>(
+            r#"{"account_id":"a","ending_balance":"0","ids":["x"]}"#,
+        )
+        .expect_err("a finalize takes no row list");
+        assert!(error.to_string().contains("`ids`"), "{error}");
+    }
+}

--- a/crates/wealth-core/src/verbs/mod.rs
+++ b/crates/wealth-core/src/verbs/mod.rs
@@ -112,6 +112,42 @@
 //! | undoing a refusal | `.delete()`, never a flag — there is no UPDATE policy | a DELETE, never a flag — `trg_dismissals_no_update` would ABORT one |
 //! | the subjects on that delete | nothing to cascade: they were an array in the row | `ON DELETE CASCADE`, deliberately not walked — [`delete_goal`]'s decision, not [`delete_category`]'s |
 //!
+//! # THE C/R SPLIT, WHICH IS THE ONE PORT THAT NEEDED A COLUMN
+//!
+//! [`set_transactions_cleared`], [`finalize_reconciliation`],
+//! [`set_transactions_archived`], [`archive_transactions_before`] and
+//! [`unarchive_account`] are five ports of five REAL RPCs — no TypeScript-writer
+//! argument applies to any of them — and they arrived together because they read
+//! and write one flag between them: `transactions.is_reconciled`, Microsoft
+//! Money's R.
+//!
+//! `schema.sql` had no such column, and the mirror's sweep therefore fired on
+//! `is_cleared` while the cloud's had moved to `is_reconciled`
+//! (`20260810200000_marking_is_not_reconciling.sql`). The two engines disagreed
+//! about whether TICKING a row archives it, which is the A-3 constraint spec, and
+//! that spec failed on every run from the day the cloud migration landed until
+//! the column was ported. Two things follow that are worth having in one place:
+//!
+//! * **the split is not a preference, it is what the flags MEAN.** C is a
+//!   working note and R is a commitment; the sweep, the Accounts list's
+//!   unreconciled count and the archive all read the commitment, and everything
+//!   that ticks writes the note. A file with one flag describes a ledger in which
+//!   marking and reconciling are the same act — which is what this file WAS, and
+//!   what `transactionReconciliation.ts` still reads a `NULL` row as.
+//! * **only [`finalize_reconciliation`] writes `is_reconciled = 1`.** That is
+//!   what makes "leave the screen and those transactions are still yet to be
+//!   reconciled" true, and it is why the sweep hangs off that verb and no other.
+//!
+//! Two of the five audit and three do not, and the difference is the CLOUD's
+//! rather than a decision made here: `set_transactions_cleared`,
+//! `finalize_reconciliation` and `set_transactions_archived` call
+//! `write_financial_audit`; `archive_transactions_before` and
+//! `unarchive_account` contain no such call, twenty lines apart in the same
+//! migration. These are ports of RPCs, so the RPC is the specification — the
+//! audit argument in the four TypeScript-writer tables above does not apply,
+//! because there the alternative was no trail at all rather than a different
+//! trail from the cloud's.
+//!
 //! # `migrate_categories_atomic` — HALF of it is ported, and the half is B-4
 //!
 //! It was recorded here as *"needs a decision about what it would even do before
@@ -296,6 +332,18 @@
 //! | [`update_category`] | no — `trg_categories_updated_at` stands down of its own accord, and C-5 is `BEFORE DELETE` | no |
 //! | [`delete_category`] | no, and it must not — C-5 is the answer, exactly as it is for the prune | no |
 //! | [`seed_categories`] | no — an INSERT and an UPDATE of `categories`, same measurement as the two above | no |
+//! | [`set_transactions_cleared`] | no — it writes `is_cleared`, `is_reconciled` and `updated_at`, none of which any `BEFORE UPDATE OF` list holds | no |
+//! | [`finalize_reconciliation`] | no, same three columns plus the account's own two | no |
+//! | [`set_transactions_archived`] | no — `archived` and `updated_at` | no |
+//! | [`archive_transactions_before`] | no, the same two columns in bulk | no |
+//! | [`unarchive_account`] | no, likewise | no |
+//!
+//! The reconciliation family is the first group where "no guard" needed a
+//! sentence about a trigger that IS consulted: the sweep is `AFTER UPDATE OF
+//! is_reconciled`, and [`set_transactions_cleared`] writes that column on every
+//! row it touches. It stands down every time — the trigger fires only on a
+//! transition TO committed, and marking never writes one — which is precisely
+//! the property the C/R split exists to give the register.
 //!
 //! The restore family adds a **third** flag to the table, which the first twelve
 //! verbs never needed: `_rpc_guard('restore')`, held by
@@ -479,6 +527,7 @@
 //! contradicts its module's header is a verb somebody will read wrongly.
 
 mod apply_category_to_uncategorized;
+mod archive_transactions_before;
 mod clear_transfer_links;
 mod close_account;
 mod confirm_transaction_categories;
@@ -494,6 +543,7 @@ mod delete_goal;
 mod delete_transaction;
 mod delete_unused_categories;
 mod dismiss_suggestion;
+mod finalize_reconciliation;
 mod finalize_user_restore;
 mod import_bank_transactions;
 mod import_transactions;
@@ -508,7 +558,10 @@ mod restore_suggestion;
 mod restore_user_chunk;
 mod seed_categories;
 mod set_transaction_splits_with_legs;
+mod set_transactions_archived;
+mod set_transactions_cleared;
 mod transfer;
+mod unarchive_account;
 mod update_account;
 mod update_budget;
 mod update_category;
@@ -524,6 +577,26 @@ pub use apply_category_to_uncategorized::{
 };
 pub use clear_transfer_links::{
     clear_transfer_links, ClearTransferLinks, ClearTransferLinksResult,
+};
+// The reconciliation and archive family — five verbs, five RPCs, and the first
+// group in this crate that had to bring a COLUMN across with it. See "THE C/R
+// SPLIT" above.
+pub use archive_transactions_before::{
+    archive_transactions_before, ArchiveAnswer, ArchiveTransactionsBefore,
+    ArchiveTransactionsBeforeResult,
+};
+pub use finalize_reconciliation::{
+    finalize_reconciliation, FinalizeAnswer as FinalizeReconciliationAnswer,
+    FinalizeReconciliation, FinalizeReconciliationResult,
+};
+pub use set_transactions_archived::{
+    set_transactions_archived, SetTransactionsArchived, SetTransactionsArchivedResult,
+};
+pub use set_transactions_cleared::{
+    set_transactions_cleared, SetTransactionsCleared, SetTransactionsClearedResult,
+};
+pub use unarchive_account::{
+    unarchive_account, UnarchiveAccount, UnarchiveAccountResult, UnarchiveAnswer,
 };
 // The account family — three verbs, no RPC between them. See "A VERB WHOSE
 // ORACLE IS A TYPESCRIPT WRITER" above.

--- a/crates/wealth-core/src/verbs/set_transactions_archived.rs
+++ b/crates/wealth-core/src/verbs/set_transactions_archived.rs
@@ -1,0 +1,243 @@
+//! `set_transactions_archived` — the per-row archive, which is never a delete.
+//!
+//! # What it is a port OF
+//!
+//! `supabase/migrations/20260805145035_repair_claimed_transfer.sql:172-229`,
+//! the live definition. The client calls it at one place
+//! (`transactionService.setTransactionArchived`), which passes ONE id in the
+//! array — the seam's `setTransactionArchived(id, archived)` — and the two
+//! callers behind that are the register's own hide, and the transfer sweep's
+//! "file this away" (`strandedTransferActions.ts`).
+//!
+//! The verb keeps the RPC's plural name and its array argument. A verb string
+//! that differs from the function it ports is a verb string somebody will
+//! eventually map to the wrong function, and the seam's singular is a narrowing
+//! the PORT applies, not a different operation.
+//!
+//! # ARCHIVING IS A VIEW FLAG. IT IS NOT A DELETE AND IT IS NOT MONEY
+//!
+//! The row stays in the table, stays counted in the account's balance, stays in
+//! every report and every export, and is hidden only from the live register.
+//! That is why this verb is balance-neutral by construction: one boolean and a
+//! timestamp, no amount, no account, no sign.
+//!
+//! The Microsoft Money lesson the soft archive was built from
+//! (`20260721130000:5-8`): Money HARD-DELETED archived rows and adjusted each
+//! account's opening balance to compensate — *"a fragile, unrecoverable
+//! operation people were warned off"*. We do neither.
+//!
+//! # THE ONE REFUSAL, AND THE CASE IT KEEPS APART FROM ITSELF
+//!
+//! `count(DISTINCT p_ids)` against the number of rows found and owned; a
+//! mismatch raises `transaction_not_found`. So an id nobody has, and an id
+//! belonging to somebody else, are both refused — and the whole call is lost,
+//! not just that id.
+//!
+//! That is the OPPOSITE of the bulk-verb shape
+//! [`super::apply_category_to_uncategorized`] and
+//! [`super::set_transactions_cleared`] have, where a foreign row is skipped in
+//! silence, and the RPC's own comment says why the pair of behaviours is right:
+//! *"an 'archive this' that runs twice is a no-op, not an error, and the raise
+//! above is what still distinguishes 'the row was already archived' from 'the
+//! row is not there'."* A tick is a bulk gesture over a list a screen built; an
+//! archive is a decision about a named row, and silently archiving four of five
+//! would leave the fifth on screen with no explanation.
+//!
+//! `p_archived IS NULL` raises too, with the RPC's own wording. It is the only
+//! verb in this family whose boolean argument is guarded rather than simply
+//! required by the signature, and the port keeps that difference: on both
+//! engines the message is *"p_archived must be true or false"*.
+//!
+//! # ORDER BY id, and it is not decoration
+//!
+//! The RPC's cursor carries `ORDER BY id` with the comment *"concurrent calls
+//! walk the rows the same way"*. A local file has one writer at a time, so the
+//! deadlock argument does not apply — but the ORDER is also the order the audit
+//! entries are written in, and two engines that audited the same batch in
+//! different orders would produce different chains for the same call.
+//! [`super::distinct_ids`] gives the same walk from a `BTreeSet`.
+//!
+//! # Which guard it holds: none, and measured
+//!
+//! `archived` and `updated_at`. No split protection watches either
+//! (`BEFORE UPDATE OF` over `is_split`, `amount_minor`, `type`, `category`), and
+//! the reconcile sweep is `AFTER UPDATE OF is_reconciled`, which this verb does
+//! not write — so archiving a row cannot archive it twice or un-archive it by
+//! accident. `tests/reconciliation_family.rs` asserts the guard table empty.
+
+use rusqlite::{params, Connection, TransactionBehavior};
+use serde::{Deserialize, Serialize};
+
+use crate::audit::{self, Action};
+use crate::db;
+use crate::error::{CoreError, CoreResult, Refusal};
+use crate::row::{self, TransactionRow};
+use crate::wire::Flag;
+
+/// The command: `(p_ids, p_archived, p_user_id)` as one object.
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct SetTransactionsArchived {
+    /// `p_ids`. The rows being hidden, or brought back.
+    #[serde(default)]
+    pub ids: Option<Vec<String>>,
+    /// `p_archived`. Which way. Absent is refused by name, exactly as a NULL is
+    /// in the RPC — this argument has a DEFAULT of nothing there, and the
+    /// function's first act is to check it.
+    #[serde(default)]
+    pub archived: Option<Flag>,
+    /// `p_user_id`. Absent means "name no owner".
+    #[serde(default)]
+    pub user_id: Option<String>,
+}
+
+/// What the verb hands back. The RPC returns a bare integer.
+#[derive(Debug, Serialize)]
+pub struct SetTransactionsArchivedResult {
+    /// The FIRST row named, as stored after the call.
+    pub transaction: Option<TransactionRow>,
+    /// How many rows really changed. A row already in the requested state is
+    /// skipped and not counted.
+    pub changed: i64,
+    /// Those rows, as stored, in the order they were written (by id).
+    pub transactions: Vec<TransactionRow>,
+    /// Dense sequence number of the LAST audit row written, when any was.
+    pub audit_seq: Option<i64>,
+    /// Its chained hash.
+    pub audit_row_hash: Option<String>,
+}
+
+/// Hide rows from the live register, or bring them back.
+///
+/// # Errors
+/// [`CoreError::Refused`] for `p_archived must be true or false` and for
+/// `transaction_not_found`; [`CoreError::Storage`] for a fault.
+#[allow(clippy::needless_pass_by_value)]
+pub fn set_transactions_archived(
+    connection: &mut Connection,
+    command: SetTransactionsArchived,
+) -> CoreResult<SetTransactionsArchivedResult> {
+    let named = command.ids.clone().unwrap_or_default();
+    // `IF p_ids IS NULL OR array_length(p_ids, 1) IS NULL THEN RETURN 0` — and
+    // it is FIRST, before the NULL check on the flag, so an empty call with no
+    // direction is a nothing rather than a refusal. Ported in that order.
+    if named.is_empty() {
+        return Ok(SetTransactionsArchivedResult {
+            transaction: None,
+            changed: 0,
+            transactions: Vec::new(),
+            audit_seq: None,
+            audit_row_hash: None,
+        });
+    }
+
+    let Some(flag) = command.archived.as_ref() else {
+        return Err(CoreError::refuse(
+            "p_archived_must_be_true_or_false",
+            "p_archived must be true or false",
+        ));
+    };
+    let archived = flag
+        .resolve()
+        .map_err(|message| CoreError::InvalidCommand(format!("archived: {message}")))?;
+
+    let write = connection.transaction_with_behavior(TransactionBehavior::Immediate)?;
+    let now = db::now(&write)?;
+    let owner = command.user_id.as_deref();
+
+    // The count guard, before any write: every named id must be a row this
+    // owner has. `distinct_ids` is `count(DISTINCT x)`.
+    let wanted = super::distinct_ids(&named);
+    let mut rows = Vec::new();
+    for id in &wanted {
+        let Some(row) = row::read_owned_transaction(&write, id, owner)? else {
+            return Err(CoreError::Refused(
+                Refusal::named("transaction_not_found", "transaction_not_found").with_hint(
+                    "One of the transactions named for archiving no longer exists, or is not \
+                     yours.",
+                ),
+            ));
+        };
+        rows.push(row);
+    }
+
+    let mut written = Vec::new();
+    let mut entry = None;
+    for before in rows {
+        // `archived IS DISTINCT FROM p_archived`, in the cursor: a row already
+        // in the requested state is not written, not audited, and its
+        // `updated_at` does not move.
+        if before.archived == archived {
+            continue;
+        }
+
+        let changed = write.execute(
+            "UPDATE transactions
+                SET archived   = ?1,
+                    updated_at = ?2
+              WHERE id = ?3",
+            params![i64::from(archived), now, before.id],
+        )?;
+        if changed != 1 {
+            return Err(CoreError::refuse(
+                "transaction_not_found",
+                "a transaction being archived disappeared between finding it and writing it",
+            ));
+        }
+        let after = row::read_transaction(&write, &before.id)?;
+
+        entry = Some(audit::write(
+            &write,
+            &after.user_id,
+            "transaction",
+            &after.id,
+            Action::Update,
+            Some(&super::json_of(&before)?),
+            Some(&super::json_of(&after)?),
+            &now,
+        )?);
+        written.push(after);
+    }
+
+    let first = named
+        .first()
+        .map(|id| row::read_owned_transaction(&write, id, None))
+        .transpose()?
+        .flatten();
+
+    let count = super::count(written.len())?;
+
+    write.commit()?;
+
+    Ok(SetTransactionsArchivedResult {
+        transaction: first,
+        changed: count,
+        transactions: written,
+        audit_seq: entry.as_ref().map(|entry| entry.seq),
+        audit_row_hash: entry.map(|entry| entry.row_hash),
+    })
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
+mod tests {
+    use super::SetTransactionsArchived;
+
+    #[test]
+    fn a_direction_that_is_absent_is_not_a_direction() {
+        let command: SetTransactionsArchived =
+            serde_json::from_str(r#"{"ids":["a"]}"#).expect("an absent flag parses");
+        assert!(command.archived.is_none(), "the refusal is the verb's, not serde's");
+    }
+
+    #[test]
+    fn there_is_nowhere_to_delete_from() {
+        // Archiving is never a delete, and the safety is the absence of the
+        // argument: this command cannot be made to mean one.
+        let error = serde_json::from_str::<SetTransactionsArchived>(
+            r#"{"ids":["a"],"archived":true,"delete":true}"#,
+        )
+        .expect_err("there is no delete here");
+        assert!(error.to_string().contains("`delete`"), "{error}");
+    }
+}

--- a/crates/wealth-core/src/verbs/set_transactions_cleared.rs
+++ b/crates/wealth-core/src/verbs/set_transactions_cleared.rs
@@ -1,0 +1,268 @@
+//! `set_transactions_cleared` — the tick, which settles nothing.
+//!
+//! # What it is a port OF
+//!
+//! `supabase/migrations/20260810200000_marking_is_not_reconciling.sql:143-183`,
+//! which is the LIVE definition. It is a RESTATEMENT of
+//! `20260707120000_reconciliation_cleared_rpcs.sql`'s function, unchanged except
+//! for one `CASE`, and the `CASE` is the whole of the C/R split on the write
+//! side. The client calls it at one place
+//! (`transactionService.setTransactionsCleared`), from the reconciliation
+//! screen's checkbox, its "Mark all", and the register's Space key.
+//!
+//! # THE TWO STATES, AND WHY THIS VERB OWNS ONLY ONE OF THEM
+//!
+//! Microsoft Money kept both against a transaction while you balanced an
+//! account:
+//!
+//! | | what it is | what sets it |
+//! | --- | --- | --- |
+//! | **C** — `is_cleared` | a working note. Tick rows off the statement as you read it; the marks survive closing the window and coming back next week; nothing about the account has been settled | this verb, and every bank import |
+//! | **R** — `is_reconciled` | committed, against a statement ending balance stated up front | [`super::finalize_reconciliation`] and nothing else |
+//!
+//! This schema had ONE flag doing both jobs, so *"Mark all cleared" WAS the
+//! reconciliation*: leave the screen and the account showed nothing left to do.
+//! The migration's own summary of the owner's words: marking *"should just be a
+//! HOLDING state — leave the screen and those transactions are still yet to be
+//! reconciled. It is Finalize Reconciliation that should complete things."*
+//!
+//! # The CASE, and the one thing it is NOT free to do
+//!
+//! ```sql
+//! is_reconciled = CASE WHEN p_cleared THEN COALESCE(is_reconciled, is_cleared)
+//!                      ELSE false END
+//! ```
+//!
+//! Two rules in one expression, and `src/utils/transactionReconciliation.ts`
+//! (`reconciledAfterMarking`) is where the app states the same pair:
+//!
+//! * **marking KEEPS whatever the row said about commitment.** Marking a
+//!   committed row changes nothing about the commitment.
+//! * **UNMARKING CLEARS IT.** A row that is not ticked cannot be a row a
+//!   statement was balanced against, and the pair (committed, unmarked) would
+//!   put the cleared balance and the reconciled set permanently out of step.
+//!
+//! `COALESCE` rather than a bare read, and the migration says why: a NULL means
+//! *"ask `is_cleared`"*, and the rows this loop touches are BY DEFINITION the
+//! ones whose `is_cleared` is changing — so writing the resolved answer down is
+//! what stops the ambiguity outliving the change.
+//!
+//! **The right-hand side reads the row BEFORE the update, on both engines.** In
+//! Postgres an UPDATE's SET expressions see the old row; here the old row is
+//! [`row::TransactionRow`], read at the top of the loop, and the resolution is
+//! `before.is_reconciled.unwrap_or(before.is_cleared)`. Written as one
+//! expression in one place for the same reason the SQL is: two spellings of a
+//! three-valued rule is how the two drift.
+//!
+//! **What this file's own CHECK does to the marking branch, stated so the next
+//! reader does not think the branch is dead.** `transactions_reconciled_implies_
+//! cleared` means a local row with `is_cleared = 0` can only carry
+//! `is_reconciled` 0 or NULL, and the loop only selects rows whose `is_cleared`
+//! is about to change — so on a marking call the COALESCE always resolves to
+//! `false` HERE, while in the cloud it can resolve to `true` for a row the
+//! update RPC left committed-but-unmarked. The branch is not dead: it is what
+//! turns a pre-split NULL into an explicit `false`, which is the whole reason
+//! the migration wrote a CASE instead of `is_reconciled = false`.
+//!
+//! # Which rows it touches
+//!
+//! `is_cleared IS DISTINCT FROM p_cleared` is in the CURSOR, not in the update,
+//! so a row already in the requested state is not selected: no write, no audit
+//! entry, and — the part that matters for a file — no movement of `updated_at`,
+//! so re-ticking a ticked row cannot make it look freshly edited to a backup
+//! diff. The owner clause is in the cursor too, so a foreign row is skipped in
+//! silence rather than refused; that is the bulk-verb shape
+//! [`super::apply_category_to_uncategorized`] and
+//! [`super::confirm_transaction_categories`] already have, and it is deliberate
+//! — a stale list of ids must not fail a whole tick.
+//!
+//! # Balance-neutral, and the sweep it now consults without firing
+//!
+//! Two flags and a timestamp. No amount, no account, no sign.
+//!
+//! It writes `is_reconciled` on every row it touches, so
+//! `trg_sweep_reconciled_into_archive` IS consulted on every mark and every
+//! unmark — and stands down every time, because the trigger fires only on a
+//! transition TO 1 and this verb never writes 1. That is the fix the split
+//! bought: under the old trigger, ticking a row dated before its account's
+//! cutoff made the row VANISH from the very list the ticking happens on, and a
+//! row you cannot see is a row you cannot untick.
+//!
+//! # Which guard it holds: none, and measured
+//!
+//! `is_cleared`, `is_reconciled` and `updated_at`. Every split protection in
+//! `schema.sql` is `BEFORE UPDATE OF <column>` over a list of `is_split`,
+//! `amount_minor`, `type` and `category`; none of the three appears in any of
+//! them. `tests/reconciliation_family.rs` asserts the guard table empty across a
+//! marking call rather than reasoning about it.
+
+use rusqlite::{params, Connection, TransactionBehavior};
+use serde::{Deserialize, Serialize};
+
+use crate::audit::{self, Action};
+use crate::db;
+use crate::error::{CoreError, CoreResult};
+use crate::row::{self, TransactionRow};
+use crate::wire::Flag;
+
+/// The command: `(p_ids, p_cleared, p_user_id)` as one object.
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct SetTransactionsCleared {
+    /// `p_ids`. Every row being ticked, or unticked.
+    #[serde(default)]
+    pub ids: Option<Vec<String>>,
+    /// `p_cleared`. Which way. Required, because the RPC's argument has no
+    /// default and a call that did not say would be a call that could mean
+    /// either.
+    pub cleared: Flag,
+    /// `p_user_id`. Absent means "name no owner".
+    #[serde(default)]
+    pub user_id: Option<String>,
+}
+
+/// What the verb hands back.
+///
+/// The RPC returns a bare integer. The count is named `changed` rather than
+/// `cleared` on purpose: this verb also UNticks, and a key called `cleared`
+/// carrying "3" after an unmarking call would be read as three rows now ticked.
+#[derive(Debug, Serialize)]
+pub struct SetTransactionsClearedResult {
+    /// The FIRST row named, as stored after the call.
+    pub transaction: Option<TransactionRow>,
+    /// How many rows really changed. A row already in the requested state is
+    /// not written and is not counted.
+    pub changed: i64,
+    /// Those rows, as stored, in the order they were written (by id).
+    pub transactions: Vec<TransactionRow>,
+    /// Dense sequence number of the LAST audit row written, when any was.
+    pub audit_seq: Option<i64>,
+    /// Its chained hash.
+    pub audit_row_hash: Option<String>,
+}
+
+/// Mark rows off against a statement, or take the mark back.
+///
+/// # Errors
+/// [`CoreError::InvalidCommand`] if `cleared` is not a boolean;
+/// [`CoreError::Storage`] for a fault. There is no named refusal: an id nobody
+/// has, and an id belonging to somebody else, are both skipped, which is what
+/// makes the count the number of rows that really changed.
+#[allow(clippy::needless_pass_by_value)]
+pub fn set_transactions_cleared(
+    connection: &mut Connection,
+    command: SetTransactionsCleared,
+) -> CoreResult<SetTransactionsClearedResult> {
+    let cleared = command
+        .cleared
+        .resolve()
+        .map_err(|message| CoreError::InvalidCommand(format!("cleared: {message}")))?;
+
+    let named = command.ids.clone().unwrap_or_default();
+    if named.is_empty() {
+        return Ok(SetTransactionsClearedResult {
+            transaction: None,
+            changed: 0,
+            transactions: Vec::new(),
+            audit_seq: None,
+            audit_row_hash: None,
+        });
+    }
+
+    let write = connection.transaction_with_behavior(TransactionBehavior::Immediate)?;
+    let now = db::now(&write)?;
+    let owner = command.user_id.as_deref();
+
+    let mut written = Vec::new();
+    let mut entry = None;
+    for id in super::distinct_ids(&named) {
+        let Some(before) = row::read_owned_transaction(&write, id, owner)? else {
+            continue;
+        };
+        // `is_cleared IS DISTINCT FROM p_cleared`, in the cursor.
+        if before.is_cleared == cleared {
+            continue;
+        }
+
+        // The CASE, resolved against the row as it stands BEFORE the write —
+        // which is what the SQL does and why it is spelled with a COALESCE.
+        let reconciled = if cleared {
+            before.is_reconciled.unwrap_or(before.is_cleared)
+        } else {
+            false
+        };
+
+        let changed = write.execute(
+            "UPDATE transactions
+                SET is_cleared    = ?1,
+                    is_reconciled = ?2,
+                    updated_at    = ?3
+              WHERE id = ?4",
+            params![i64::from(cleared), i64::from(reconciled), now, before.id],
+        )?;
+        if changed != 1 {
+            return Err(CoreError::refuse(
+                "transaction_not_found",
+                "a transaction being marked disappeared between finding it and writing it",
+            ));
+        }
+        let after = row::read_transaction(&write, &before.id)?;
+
+        entry = Some(audit::write(
+            &write,
+            &after.user_id,
+            "transaction",
+            &after.id,
+            Action::Update,
+            Some(&super::json_of(&before)?),
+            Some(&super::json_of(&after)?),
+            &now,
+        )?);
+        written.push(after);
+    }
+
+    let first = named
+        .first()
+        .map(|id| row::read_owned_transaction(&write, id, None))
+        .transpose()?
+        .flatten();
+
+    let count = super::count(written.len())?;
+
+    write.commit()?;
+
+    Ok(SetTransactionsClearedResult {
+        transaction: first,
+        changed: count,
+        transactions: written,
+        audit_seq: entry.as_ref().map(|entry| entry.seq),
+        audit_row_hash: entry.map(|entry| entry.row_hash),
+    })
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
+mod tests {
+    use super::SetTransactionsCleared;
+
+    #[test]
+    fn which_way_is_not_optional() {
+        // The RPC's argument has no default, so a payload that does not say is
+        // a payload that could mean either — and silently marking would be the
+        // worse of the two guesses.
+        let error = serde_json::from_str::<SetTransactionsCleared>(r#"{"ids":["a"]}"#)
+            .expect_err("a marking call must say which way");
+        assert!(error.to_string().contains("cleared"), "{error}");
+    }
+
+    #[test]
+    fn the_committed_flag_is_not_an_argument() {
+        // Marking may never set the commitment directly: that is finalize's, and
+        // a verb that accepted it would be a second door to Money's R.
+        let error = serde_json::from_str::<SetTransactionsCleared>(
+            r#"{"ids":["a"],"cleared":true,"is_reconciled":true}"#,
+        )
+        .expect_err("there is nowhere to put a commitment");
+        assert!(error.to_string().contains("`is_reconciled`"), "{error}");
+    }
+}

--- a/crates/wealth-core/src/verbs/unarchive_account.rs
+++ b/crates/wealth-core/src/verbs/unarchive_account.rs
@@ -1,0 +1,146 @@
+//! `unarchive_account` — one click, because nothing ever left.
+//!
+//! # What it is a port OF
+//!
+//! `supabase/migrations/20260721130000_soft_archive.sql:92-114`, which is still
+//! the live definition — the marking migration restated its three neighbours and
+//! left this one alone, because it reads no flag that was split. The client
+//! calls it at one place (`transactionService.unarchiveAccount`), from the
+//! Archive manager's "Keep all".
+//!
+//! # THE VERB WITH NO REFUSAL AT ALL, AND IT IS TRACED RATHER THAN ASSUMED
+//!
+//! The RPC does not look the account up, does not check `FOUND`, and raises
+//! nothing. It issues two UPDATEs whose WHERE clauses carry the owner, and
+//! answers with a count. So:
+//!
+//! * an account nobody has → `{unarchived: 0}`, no error;
+//! * somebody else's account → `{unarchived: 0}`, no error, and nothing of
+//!   theirs is touched, because both statements are scoped by `user_id`;
+//! * an account with nothing archived → `{unarchived: 0}`, and the cutoff is
+//!   still cleared, which is the point: "Keep all" must be able to undo a cutoff
+//!   that has not caught anything up yet.
+//!
+//! This port keeps every one of those, including the silence. It is the opposite
+//! decision from [`super::archive_transactions_before`] beside it, which raises
+//! `account_not_found` — and the asymmetry is the cloud's, in one migration,
+//! twenty lines apart. Reproduced rather than smoothed over for the reason the
+//! whole crate reproduces refusal ORDER: a caller that branches on a refusal is
+//! branching on the cloud's behaviour, and a port that invented one here would
+//! turn a silent no-op into an error dialog nobody has ever seen.
+//!
+//! # IT NEVER TOUCHES THE COMMITMENT, AND A ROW THAT COMES BACK IS STILL R
+//!
+//! Two columns on the rows: `archived` and `updated_at`. `is_reconciled` is not
+//! among them and must not be. Unarchiving is a decision about what the register
+//! SHOWS; the commitment is a fact about a statement that was balanced, and
+//! bringing a row back into view does not un-settle the statement it was
+//! reconciled against. A port that cleared it would silently re-open every
+//! finished reconciliation the account has ever had, and the account's own
+//! `last_reconciled_balance` would then record a figure no set of rows agrees
+//! with.
+//!
+//! The reverse is guarded by the schema rather than by this verb: the rows come
+//! back with `is_reconciled = 1` untouched, so no `AFTER UPDATE OF is_reconciled`
+//! fires and A-3 cannot re-archive them in the same breath. That is what the
+//! soft archive's own comment means by *"never un-archives — unarchive is an
+//! explicit action"*, read from the other end.
+//!
+//! # IT AUDITS NOTHING
+//!
+//! As [`super::archive_transactions_before`], and for the same reason: there is
+//! no `write_financial_audit` in the function being ported. See that module for
+//! the argument, which applies to both.
+//!
+//! # Balance-neutral
+//!
+//! A view flag and a date. The rows never left the balance, which is the whole
+//! design of the soft archive.
+
+use rusqlite::{params, Connection, TransactionBehavior};
+use serde::{Deserialize, Serialize};
+
+use crate::db;
+use crate::error::CoreResult;
+use crate::row::account::{self, ListedAccount};
+
+/// The command: `(p_user_id, p_account_id)` as one object.
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct UnarchiveAccount {
+    /// `p_user_id`. Both statements are scoped by it; an absent one matches no
+    /// row and the answer is a truthful zero.
+    #[serde(default)]
+    pub user_id: Option<String>,
+    /// `p_account_id`. Which account comes back.
+    pub account_id: String,
+}
+
+/// What the verb hands back.
+#[derive(Debug, Serialize)]
+pub struct UnarchiveAccountResult {
+    /// The projection both engines are compared on — the RPC's own
+    /// `jsonb_build_object`, which has exactly one key.
+    pub answer: UnarchiveAnswer,
+    /// The account as stored afterwards, or `None` when the id named nothing
+    /// this owner has — which is not an error here. Local, and outside the
+    /// answer for [`super::archive_transactions_before`]'s reason.
+    pub account: Option<ListedAccount>,
+}
+
+/// The RPC's return value.
+#[derive(Debug, Serialize)]
+pub struct UnarchiveAnswer {
+    /// How many rows came back into the live register.
+    pub unarchived: i64,
+}
+
+/// Bring an account's archived rows back, and forget its cutoff.
+///
+/// # Errors
+/// [`crate::error::CoreError::Storage`] for a fault. There is no refusal: see
+/// the module documentation, which traces why the RPC has none either.
+#[allow(clippy::needless_pass_by_value)]
+pub fn unarchive_account(
+    connection: &mut Connection,
+    command: UnarchiveAccount,
+) -> CoreResult<UnarchiveAccountResult> {
+    let write = connection.transaction_with_behavior(TransactionBehavior::Immediate)?;
+    let now = db::now(&write)?;
+    let owner = command.user_id.as_deref();
+
+    let unarchived = write.execute(
+        "UPDATE transactions
+            SET archived   = 0,
+                updated_at = ?1
+          WHERE user_id = ?2
+            AND account_id = ?3
+            AND archived = 1",
+        params![now, owner, command.account_id],
+    )?;
+
+    write.execute(
+        "UPDATE accounts
+            SET archive_through_date = NULL,
+                updated_at           = ?1
+          WHERE id = ?2
+            AND user_id = ?3",
+        params![now, command.account_id, owner],
+    )?;
+
+    let account = match owner {
+        Some(owner) => account::read_listed(&write, &command.account_id, owner)?,
+        None => None,
+    };
+
+    let count = super::count(unarchived)?;
+
+    write.commit()?;
+
+    Ok(UnarchiveAccountResult {
+        answer: UnarchiveAnswer {
+            unarchived: count,
+        },
+        account,
+    })
+}

--- a/crates/wealth-core/tests/reconciliation_family.rs
+++ b/crates/wealth-core/tests/reconciliation_family.rs
@@ -1,0 +1,469 @@
+//! Integration tests for the reconciliation and archive family — the five verbs
+//! that read and write Money's C and R — against the real vendored schema.
+//!
+//! The differential proof for all five lives in `scripts/local-sqlite/verbs.mjs`,
+//! where the same payload runs against the live RPCs. What is here is the half
+//! with **no Postgres counterpart to compare against**:
+//!
+//! 1. **The three-valued column, from the Rust side.** `is_reconciled` is
+//!    `Option<bool>` in [`wealth_core::row::TransactionRow`], and the difference
+//!    between `None` and `Some(false)` is what `finalize_reconciliation`
+//!    selects on and what `archive_transactions_before` COALESCEs. A
+//!    differential spec compares two rendered strings; this compares the type.
+//! 2. **The guard table**, empty across all five, which is the claim
+//!    `verbs/mod.rs`'s table makes and measures rather than reasons about. The
+//!    marking verb is the interesting one: it WRITES the column the archive
+//!    sweep watches, so the trigger is consulted on every call and stands down
+//!    every time.
+//! 3. **The audit chain**, which is per-file and has no cross-engine twin: the
+//!    two verbs that audit write one entry per row they really change, and the
+//!    two bulk archive verbs write none at all — a claim about nothing being
+//!    there, which only a test can hold.
+//! 4. **The CHECK that committed implies marked**, reached through the file
+//!    rather than through a verb. Its differential spec goes through
+//!    `update_transaction` and declares the divergence; this is the same rule
+//!    asserted where it lives.
+//! 5. **The owner-less arity.** `finalize_reconciliation` is the one verb in the
+//!    crate where an absent owner is a refusal rather than a stand-down, and
+//!    what an absent owner REACHES is a property of this crate.
+//!
+//! All data is invented. This repo is public: no real payee, account number or
+//! figure appears anywhere in it.
+
+#![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
+
+use rusqlite::Connection;
+use wealth_core::db;
+use wealth_core::money::Money;
+use wealth_core::verbs::{
+    archive_transactions_before, finalize_reconciliation, set_transactions_archived,
+    set_transactions_cleared, unarchive_account, ArchiveTransactionsBefore,
+    FinalizeReconciliation, SetTransactionsArchived, SetTransactionsCleared, UnarchiveAccount,
+};
+use wealth_core::wire::Flag;
+
+const OWNER: &str = "11111111-1111-1111-1111-111111111111";
+const STRANGER: &str = "22222222-2222-2222-2222-222222222222";
+const EVERYDAY: &str = "a0000000-0000-0000-0000-000000000001";
+const THEIRS: &str = "a0000000-0000-0000-0000-000000000009";
+const MARKED: &str = "70000000-0000-0000-0000-0000000000c1";
+const COMMITTED: &str = "70000000-0000-0000-0000-0000000000c2";
+const PRE_SPLIT: &str = "70000000-0000-0000-0000-0000000000c3";
+const UNMARKED: &str = "70000000-0000-0000-0000-0000000000c4";
+
+/// Two logins, two accounts, and one row per state of the committed flag.
+///
+/// The pre-split row is planted as an explicit NULL: the column carries
+/// `DEFAULT 0`, so leaving it out would produce "explicitly not committed",
+/// which is the right answer for a new row and the wrong state for this test.
+fn fixture() -> Connection {
+    let connection = db::open_in_memory().expect("open");
+    wealth_core::apply_schema(&connection).expect("schema");
+    connection
+        .execute_batch(&format!(
+            "INSERT INTO users (id, email) VALUES
+               ('{OWNER}', 'harness@example.test'),
+               ('{STRANGER}', 'stranger@example.test');
+             INSERT INTO accounts (id, user_id, name, type, balance_minor, initial_balance_minor)
+               VALUES ('{EVERYDAY}', '{OWNER}',    'Everyday',  'checking', -400, 0),
+                      ('{THEIRS}',   '{STRANGER}', 'Not yours', 'checking',    0, 0);
+             INSERT INTO transactions
+                    (id, user_id, account_id, description, amount_minor, type, date,
+                     is_cleared, is_reconciled) VALUES
+               ('{MARKED}',    '{OWNER}', '{EVERYDAY}', 'Ticked',   -100, 'expense', '2024-01-15', 1, 0),
+               ('{COMMITTED}', '{OWNER}', '{EVERYDAY}', 'Settled',  -100, 'expense', '2024-01-16', 1, 1),
+               ('{PRE_SPLIT}', '{OWNER}', '{EVERYDAY}', 'Historic', -100, 'expense', '2024-01-17', 1, NULL),
+               ('{UNMARKED}',  '{OWNER}', '{EVERYDAY}', 'Pending',  -100, 'expense', '2024-03-01', 0, 0);"
+        ))
+        .expect("fixture");
+    connection
+}
+
+fn scalar(connection: &Connection, sql: &str) -> i64 {
+    connection.query_row(sql, [], |row| row.get(0)).expect(sql)
+}
+
+fn text(connection: &Connection, sql: &str) -> String {
+    connection.query_row(sql, [], |row| row.get(0)).expect(sql)
+}
+
+/// The committed flag as the FILE holds it, three-valued.
+fn committed(connection: &Connection, id: &str) -> Option<bool> {
+    connection
+        .query_row(
+            "SELECT is_reconciled FROM transactions WHERE id = ?1",
+            [id],
+            |row| row.get::<_, Option<i64>>(0),
+        )
+        .expect("read")
+        .map(|value| value != 0)
+}
+
+/// Every audit entry, as `entity/action` in write order.
+fn trail(connection: &Connection) -> String {
+    text(
+        connection,
+        "SELECT COALESCE((SELECT group_concat(entry, ',') FROM (
+           SELECT entity || '/' || action AS entry
+             FROM financial_audit_log ORDER BY seq)), 'NONE')",
+    )
+}
+
+/// The guard table, which must be empty after every verb in this family.
+fn guard_rows(connection: &Connection) -> i64 {
+    scalar(connection, "SELECT COUNT(*) FROM _rpc_guard")
+}
+
+/// B-1 for the Everyday account, in minor units. Every test asserts it: none of
+/// these five verbs may move a penny, including the ones that refuse.
+fn balance_drift(connection: &Connection) -> i64 {
+    scalar(
+        connection,
+        &format!(
+            "SELECT a.balance_minor - (a.initial_balance_minor
+                    + COALESCE((SELECT SUM(t.amount_minor) FROM transactions t
+                                 WHERE t.account_id = a.id), 0))
+               FROM accounts a WHERE a.id = '{EVERYDAY}'"
+        ),
+    )
+}
+
+fn marking(ids: &[&str], cleared: bool) -> SetTransactionsCleared {
+    SetTransactionsCleared {
+        ids: Some(ids.iter().map(|id| (*id).to_owned()).collect()),
+        cleared: Flag::Bool(cleared),
+        user_id: Some(OWNER.to_owned()),
+    }
+}
+
+fn finalize(ending_balance: Option<&str>, day: Option<&str>) -> FinalizeReconciliation {
+    FinalizeReconciliation {
+        user_id: Some(OWNER.to_owned()),
+        account_id: EVERYDAY.to_owned(),
+        ending_balance: ending_balance.map(|value| Money::parse(value).expect("a figure")),
+        reconciled_on: day.map(ToOwned::to_owned),
+    }
+}
+
+// ── set_transactions_cleared ────────────────────────────────────────────────
+
+#[test]
+fn marking_writes_an_explicit_answer_over_a_pre_split_null() {
+    // The COALESCE's whole purpose: the row's commitment was "ask is_cleared",
+    // and the tick it was being asked about is the one changing.
+    let mut connection = fixture();
+    assert_eq!(committed(&connection, PRE_SPLIT), None);
+
+    let answer = set_transactions_cleared(&mut connection, marking(&[PRE_SPLIT], false))
+        .expect("unmark");
+
+    assert_eq!(answer.changed, 1);
+    assert_eq!(committed(&connection, PRE_SPLIT), Some(false));
+    assert_eq!(guard_rows(&connection), 0);
+    assert_eq!(balance_drift(&connection), 0);
+}
+
+#[test]
+fn unmarking_a_committed_row_clears_both_flags_in_one_statement() {
+    // If it did not, `transactions_reconciled_implies_cleared` would refuse the
+    // write — which is exactly what the next test proves the file does.
+    let mut connection = fixture();
+
+    set_transactions_cleared(&mut connection, marking(&[COMMITTED], false)).expect("unmark");
+
+    assert_eq!(committed(&connection, COMMITTED), Some(false));
+    assert_eq!(
+        scalar(
+            &connection,
+            &format!("SELECT is_cleared FROM transactions WHERE id = '{COMMITTED}'")
+        ),
+        0
+    );
+    assert_eq!(trail(&connection), "transaction/update");
+    assert_eq!(balance_drift(&connection), 0);
+}
+
+#[test]
+fn the_file_refuses_a_row_that_is_committed_but_not_marked() {
+    // The CHECK, reached directly. Its differential spec goes through
+    // `update_transaction`, where the cloud accepts the same write; this is the
+    // rule asserted where it lives, so a schema that lost it fails here even if
+    // no verb path reached it.
+    let connection = fixture();
+    let refused = connection.execute(
+        &format!("UPDATE transactions SET is_cleared = 0 WHERE id = '{COMMITTED}'"),
+        [],
+    );
+    let message = refused.expect_err("committed implies marked").to_string();
+    assert!(
+        message.contains("transactions_reconciled_implies_cleared"),
+        "{message}"
+    );
+}
+
+#[test]
+fn a_tick_never_reaches_the_sweep_even_with_a_cutoff_in_place() {
+    // The sweep is `AFTER UPDATE OF is_reconciled` and this verb writes that
+    // column on every row it touches, so the trigger IS consulted here — and
+    // stands down, because marking never writes a 1. A row you cannot see is a
+    // row you cannot untick.
+    let mut connection = fixture();
+    connection
+        .execute_batch(&format!(
+            "UPDATE accounts SET archive_through_date = '2024-06-30' WHERE id = '{EVERYDAY}';"
+        ))
+        .expect("cutoff");
+
+    set_transactions_cleared(&mut connection, marking(&[UNMARKED], true)).expect("mark");
+
+    assert_eq!(
+        scalar(
+            &connection,
+            &format!("SELECT archived FROM transactions WHERE id = '{UNMARKED}'")
+        ),
+        0
+    );
+    assert_eq!(guard_rows(&connection), 0);
+}
+
+// ── finalize_reconciliation ─────────────────────────────────────────────────
+
+#[test]
+fn finalizing_commits_the_working_set_and_leaves_history_unanswered() {
+    let mut connection = fixture();
+
+    let answer = finalize_reconciliation(&mut connection, finalize(Some("-4.00"), Some("2024-03-31")))
+        .expect("finalize");
+
+    assert_eq!(answer.answer.reconciled, 1);
+    assert_eq!(committed(&connection, MARKED), Some(true));
+    assert_eq!(committed(&connection, COMMITTED), Some(true));
+    // The one that matters: a NULL row is history the old world already called
+    // reconciled, and sweeping it in would re-audit the whole account.
+    assert_eq!(committed(&connection, PRE_SPLIT), None);
+    assert_eq!(committed(&connection, UNMARKED), Some(false));
+    assert_eq!(trail(&connection), "transaction/update,account/update");
+    assert_eq!(guard_rows(&connection), 0);
+    assert_eq!(balance_drift(&connection), 0);
+}
+
+#[test]
+fn the_recorded_figure_is_a_record_and_never_the_balance() {
+    let mut connection = fixture();
+
+    finalize_reconciliation(&mut connection, finalize(Some("999.99"), Some("2024-03-31")))
+        .expect("finalize");
+
+    // A figure nothing in the ledger agrees with, recorded exactly as given —
+    // and the balance untouched beside it. The difference between the two is
+    // what the reconciliation screen exists to show.
+    assert_eq!(
+        scalar(
+            &connection,
+            &format!("SELECT last_reconciled_balance_minor FROM accounts WHERE id = '{EVERYDAY}'")
+        ),
+        99_999
+    );
+    assert_eq!(
+        scalar(
+            &connection,
+            &format!("SELECT balance_minor FROM accounts WHERE id = '{EVERYDAY}'")
+        ),
+        -400
+    );
+    assert_eq!(balance_drift(&connection), 0);
+}
+
+#[test]
+fn an_absent_day_is_the_day_the_call_is_stamped_with() {
+    // `COALESCE(p_reconciled_on, CURRENT_DATE)`, taken from the instant this
+    // call stamps everything else with — so a finalize running across midnight
+    // cannot record one day on the account and another on the rows.
+    let mut connection = fixture();
+
+    let answer =
+        finalize_reconciliation(&mut connection, finalize(Some("0"), None)).expect("finalize");
+
+    let stamped = text(
+        &connection,
+        &format!("SELECT last_reconciled_date FROM accounts WHERE id = '{EVERYDAY}'"),
+    );
+    assert_eq!(stamped, answer.answer.reconciled_on);
+    assert_eq!(stamped.len(), 10, "a calendar day, not an instant: {stamped}");
+    let row_day = text(
+        &connection,
+        &format!("SELECT substr(updated_at, 1, 10) FROM transactions WHERE id = '{MARKED}'"),
+    );
+    assert_eq!(row_day, stamped);
+}
+
+#[test]
+fn an_absent_owner_finds_no_account_to_finish() {
+    // The one verb in the crate where `user_id: None` is a refusal rather than a
+    // stand-down. See its module documentation.
+    let mut connection = fixture();
+    let mut command = finalize(Some("0"), Some("2024-03-31"));
+    command.user_id = None;
+
+    let error = finalize_reconciliation(&mut connection, command).expect_err("no owner");
+
+    assert_eq!(error.code(), "account_not_found_or_not_owned");
+    assert_eq!(trail(&connection), "NONE");
+    assert_eq!(committed(&connection, MARKED), Some(false));
+}
+
+#[test]
+fn a_finalize_with_no_figure_is_refused_before_anything_is_read() {
+    let mut connection = fixture();
+
+    let error = finalize_reconciliation(&mut connection, finalize(None, Some("2024-03-31")))
+        .expect_err("no figure");
+
+    assert_eq!(error.code(), "ending_balance_required");
+    assert_eq!(committed(&connection, MARKED), Some(false));
+    assert_eq!(trail(&connection), "NONE");
+}
+
+#[test]
+fn a_cutoff_that_is_not_a_calendar_day_is_refused() {
+    // 31 February passes `LIKE '____-__-__'` and is not a day. Postgres refuses
+    // it in the cast before the function body runs; this refuses it in the verb.
+    let mut connection = fixture();
+
+    let error = finalize_reconciliation(
+        &mut connection,
+        finalize(Some("0"), Some("2024-02-31")),
+    )
+    .expect_err("not a day");
+
+    assert_eq!(error.code(), "date_invalid");
+    assert_eq!(trail(&connection), "NONE");
+}
+
+// ── set_transactions_archived ───────────────────────────────────────────────
+
+#[test]
+fn archiving_one_row_writes_one_audit_entry_and_no_money() {
+    let mut connection = fixture();
+
+    let answer = set_transactions_archived(
+        &mut connection,
+        SetTransactionsArchived {
+            ids: Some(vec![MARKED.to_owned()]),
+            archived: Some(Flag::Bool(true)),
+            user_id: Some(OWNER.to_owned()),
+        },
+    )
+    .expect("archive");
+
+    assert_eq!(answer.changed, 1);
+    assert_eq!(trail(&connection), "transaction/update");
+    assert_eq!(balance_drift(&connection), 0);
+    assert_eq!(guard_rows(&connection), 0);
+}
+
+#[test]
+fn one_unknown_id_loses_the_whole_batch() {
+    let mut connection = fixture();
+
+    let error = set_transactions_archived(
+        &mut connection,
+        SetTransactionsArchived {
+            ids: Some(vec![MARKED.to_owned(), "70000000-0000-0000-0000-0000000000ff".to_owned()]),
+            archived: Some(Flag::Bool(true)),
+            user_id: Some(OWNER.to_owned()),
+        },
+    )
+    .expect_err("one bad id");
+
+    assert_eq!(error.code(), "transaction_not_found");
+    assert_eq!(
+        scalar(
+            &connection,
+            &format!("SELECT archived FROM transactions WHERE id = '{MARKED}'")
+        ),
+        0,
+        "the good id in the same call must not have been written"
+    );
+    assert_eq!(trail(&connection), "NONE");
+}
+
+#[test]
+fn an_empty_list_is_answered_before_the_direction_is_even_checked() {
+    // The RPC's order: `IF p_ids IS NULL … RETURN 0` comes FIRST, so an empty
+    // call with no direction is a nothing rather than a refusal.
+    let mut connection = fixture();
+
+    let answer = set_transactions_archived(
+        &mut connection,
+        SetTransactionsArchived {
+            ids: Some(Vec::new()),
+            archived: None,
+            user_id: Some(OWNER.to_owned()),
+        },
+    )
+    .expect("an empty list is not a refusal");
+
+    assert_eq!(answer.changed, 0);
+    assert_eq!(trail(&connection), "NONE");
+}
+
+// ── archive_transactions_before / unarchive_account ─────────────────────────
+
+#[test]
+fn the_bulk_archive_writes_no_audit_entry_at_all() {
+    // A claim about nothing being there, which only a test can hold: the cloud
+    // function contains no write_financial_audit call and neither does the port.
+    // A differential spec can only ever compare zero against zero here, and
+    // would go on passing if BOTH sides started writing entries.
+    let mut connection = fixture();
+
+    let answer = archive_transactions_before(
+        &mut connection,
+        ArchiveTransactionsBefore {
+            user_id: Some(OWNER.to_owned()),
+            account_id: EVERYDAY.to_owned(),
+            cutoff: "2024-02-28".to_owned(),
+        },
+    )
+    .expect("archive");
+
+    assert_eq!(answer.answer.archived, 2, "the committed one and the pre-split one");
+    assert_eq!(trail(&connection), "NONE");
+    assert_eq!(balance_drift(&connection), 0);
+    assert_eq!(guard_rows(&connection), 0);
+
+    let brought_back = unarchive_account(
+        &mut connection,
+        UnarchiveAccount {
+            user_id: Some(OWNER.to_owned()),
+            account_id: EVERYDAY.to_owned(),
+        },
+    )
+    .expect("unarchive");
+
+    assert_eq!(brought_back.answer.unarchived, 2);
+    assert_eq!(trail(&connection), "NONE");
+    // The commitment is untouched in both directions.
+    assert_eq!(committed(&connection, COMMITTED), Some(true));
+    assert_eq!(committed(&connection, PRE_SPLIT), None);
+    assert_eq!(balance_drift(&connection), 0);
+}
+
+#[test]
+fn unarchiving_an_account_that_is_not_yours_writes_nothing_and_refuses_nothing() {
+    let mut connection = fixture();
+
+    let answer = unarchive_account(
+        &mut connection,
+        UnarchiveAccount {
+            user_id: Some(OWNER.to_owned()),
+            account_id: THEIRS.to_owned(),
+        },
+    )
+    .expect("no refusal, by design");
+
+    assert_eq!(answer.answer.unarchived, 0);
+    assert!(answer.account.is_none(), "it is not this owner's account to report");
+    assert_eq!(trail(&connection), "NONE");
+}

--- a/scripts/local-sqlite/README.md
+++ b/scripts/local-sqlite/README.md
@@ -132,7 +132,7 @@ that quietly stops diverging is a failing spec, not a bonus).
 | R-8 optional links cleared, never cascaded | contribution and budget survive | identical | match |
 | R-9 account delete takes its holdings | 0 holdings left | identical | match |
 | R-11 deferred keys close the txn↔split cycle | **refused** `transactions_linked_transfer_split_id_fkey` | accepted, cycle closed in one transaction | divergent — local is better |
-| A-3 reconcile sweep archives | archived | archived (second statement, same transaction) | match |
+| A-3 reconcile sweep archives | archived | archived (second statement, same transaction) | match *(was a FINDING for two slices — see below)* |
 | X-4 restore preserves `updated_at` | 2019-01-01 | 2019-01-01 | match |
 | X-4 *control*: an ordinary edit still stamps | MOVED | MOVED | match |
 | MONEY-1 sub-penny amount | **accepted, silently rounded to −1235 minor** | refused: cannot store REAL in an INTEGER column | divergent |
@@ -152,7 +152,34 @@ that quietly stops diverging is a failing spec, not a bonus).
 | R-12 a holding in a stranger's account | refused `investments_account_id_user_fkey` | refused, same key | match |
 | R-12 deleting an account clears the reference, keeps the owner | accepted, four references cleared, `user_id` intact | identical — by a trigger, not by the key | match |
 
-64 specs, 64 passing, 16 declared divergences, 0 harness errors.
+67 specs, 67 passing, 16 declared divergences, 0 harness errors.
+
+### The row that was red for two slices, and what it was saying
+
+**A-3 is a match again as of 2026-08-11, and it had not been one since
+`20260810200000_marking_is_not_reconciling.sql` landed in the cloud.** The spec
+ticked a row dated before its account's cutoff and expected the archive sweep to
+fire. Postgres stopped archiving it — the migration moved the sweep from
+`is_cleared` to `is_reconciled`, because a working mark must never make a row
+vanish from the screen the ticking happens on — while this schema went on firing
+on the mark. Every run said so, in the only way it can:
+
+```
+── a3-reconciling-an-old-row-archives-it          [A-3] FAIL
+   sqlite     accepted archived_by_the_sweep=1
+   postgres   accepted archived_by_the_sweep=0
+   parity     DECLARED match, OBSERVED divergent
+```
+
+That is a schema gap reported as a behavioural one, which is exactly what the
+harness is for: the two engines disagreed about whether TICKING a row archives
+it, and the disagreement stood in the file rather than in any verb. The fix is
+`transactions.is_reconciled` (schema amendment 7), the sweep moved onto it, and
+the spec now MARKS in its setup and COMMITS in its action — so it asserts the new
+rule rather than yesterday's question. Its other half is a verb spec,
+`cleared-marking-an-old-row-does-not-archive-it`: neither is worth much alone,
+because one passes against a trigger that never fires and the other against a
+trigger that always does.
 
 ### Reading a divergence
 
@@ -447,10 +474,17 @@ stop being comparable.
 
 ### The verbs, and what each one is for
 
-Twenty-one, and the list is the order they were ported in. The first twelve are
+Twenty-six, and the list is the order they were ported in. The first twelve are
 the ledger and its families; the restore family, the prune and the checker close
 the ledger core; the ingest pair opens the surface through which every
-transaction that nobody typed arrives.
+transaction that nobody typed arrives; and the last five are the reconciliation
+and archive family, which is the only group so far that could not be ported at
+all until `schema.sql` grew a COLUMN.
+
+(This table lists the verbs whose oracle is a Postgres FUNCTION. The account,
+category, planning and dismissal families — sixteen more verbs whose oracle is a
+TypeScript writer — are documented in `crates/wealth-core/src/verbs/mod.rs`,
+which is where the argument for their existence lives.)
 
 | verb | ported from | why it is in Phase 1 |
 | --- | --- | --- |
@@ -468,6 +502,11 @@ transaction that nobody typed arrives.
 | `confirm_transaction_categories` | `20260808100000:440-478` | the smallest verb in the crate, and the only one whose safety comes from an argument that is **not there**: it takes no category, so it cannot change one |
 | `import_transactions` | `20260808140000:234-402` (four definitions deep: `20260709120000:20` → `20260808090000:162` → `20260808100000:183`) | every file import in the app, and the one verb whose headline is a thing that must not happen **twice**. Five refusals whose ORDER is measured — including a genuine surprise, a malformed request being named before the caller is told the account is not theirs — and an `idempotent` flag that describes THE REQUEST rather than the function |
 | `import_bank_transactions` | `20260808100000:552-724` (over `20260807180000` over `20260722140000:53` over `20260708100000` over `20260613090000`) | the bank feed's whole write path, ported for a local edition that will probably never have a feed — because a restored cloud backup carries feed-written rows, and because **B-4's first-import rebase lives here and nowhere else**: the only place in the schema where an import moves `initial_balance` instead of `balance` |
+| `set_transactions_cleared` | `20260810200000:143-183` (restates `20260707120000`) | the tick, and the whole of the C/R split on the write side. One `CASE` separates Microsoft Money's C from its R: marking KEEPS a commitment, unmarking CLEARS it, and a pre-split NULL is resolved rather than left to outlive the change |
+| `finalize_reconciliation` | `20260810200000:209-278` | the only thing in the system that COMMITS a row, and the one verb here where an absent owner is a refusal rather than a stand-down. `IS NOT DISTINCT FROM false` is the predicate the whole feature turns on — a NULL row is history the old world already called reconciled, and sweeping it in would re-audit an entire account on the first finalize |
+| `set_transactions_archived` | `20260805145035:172-229` | the per-row archive, and the OPPOSITE refusal shape to the tick beside it: one unknown id loses the whole call. Never a delete — the Money original hard-deleted archived rows and adjusted the opening balance to compensate |
+| `archive_transactions_before` | `20260810200000:290-329` (restates `20260721130000:47-86`) | the bulk archive, whose predicate became `COALESCE(is_reconciled, is_cleared)`: settled history is hidden, work in progress stays in the register where it can still be unmarked, and pre-split rows are judged exactly as they were the day before the column existed |
+| `unarchive_account` | `20260721130000:92-114` | the verb with NO refusal at all — no lookup, no `FOUND` check, no `RAISE` — twenty lines from one that raises `account_not_found`. Ported with the silence, because a port that invented a refusal would turn a no-op into an error dialog nobody has ever seen |
 
 **Not ported, and neither is an omission.** The transfer-category lifecycle
 (`create_transfer_category_for_account`, `sync_transfer_category_for_account`,
@@ -735,22 +774,40 @@ Each of these was executed, then reverted.
 | put back the rule `20260722140000` replaced: `ORDER BY MAX(date) DESC` alone, without `COUNT(*) DESC` | 2 verb specs fail, both `MISDECLARED (divergent)`: `fed_row_n_1` comes back `Fuel` where both engines say `Groceries`. **`cargo test` still passes**, and that is the finding rather than a gap — the crate tests cover the tie the CLOUD has no rule for, which is unaffected by dropping the count. The habit rule has no local-only half, so the differential harness is the only thing that can catch it, and it does |
 | disable B-4's first-import branch (`backfill: false && …`) | **6 verb specs fail**, all `MISDECLARED (divergent)`, and every one of them on `stored_balances`: `100.00/112.00` becomes `88.00/100.00`, `100.00/120.00` becomes `80.00/100.00`, and the two-account sync moves both accounts' `balance` instead of both accounts' opening figures. 3 of the 18 crate tests fail with them. Note which specs failed: four of the six are not B-4 specs at all — they are dedupe and provenance specs that happen to assert the balances afterwards, which is what asserting state on every spec buys |
 
+**From the reconciliation and archive family (2026-08-11, 459 specs):**
+
+| break | result |
+| --- | --- |
+| put the sweep back on the mark: `AFTER UPDATE OF is_cleared` in `schema.sql` | `cleared-marking-an-old-row-does-not-archive-it` fails four ways — SQLite archives the row it was only asked to tick (`stored_archived` yes vs no, `archived_rows_in` 1 vs 0) and goes `MISDECLARED (divergent)`. **The constraint spec `a3-…` PASSED, and that is a finding rather than a pass**: its setup planted the cutoff before the mark, so the mark archived the row during the setup and the verify — which runs only after the action — could not see which statement did it. The spec now marks BEFORE the account has a cutoff, and with that order the same break fails it: `archived_by_the_sweep` 0 vs 1 |
+| drop the working-set filter: `AND is_cleared = 1` out of `finalize_reconciliation` | **5 of the 11 finalize specs fail**, all `MISDECLARED (divergent)`, and every one of them on the SAME refusal: SQLite raises `constraint_violated` where Postgres commits, because committing an unticked row breaks `transactions_reconciled_implies_cleared`. The whole call is then lost, so the account records nothing either (`last_reconciled_date` NULL vs 2024-03-31). The CHECK catching a control-flow mistake is the argument for making the rule structural, executed |
+| stop stamping the figure: `last_reconciled_balance_minor = last_reconciled_balance_minor` | 3 specs fail on `account_last_reconciled_balance` — `NULL vs 0.00`, `NULL vs -28.00` and, in the finalize-twice spec, `-28.00 vs -30.50`, which is the one that matters: the account keeps LAST time's figure, so the next reconciliation opens at a statement that has already been settled. `tests/reconciliation_family.rs::the_recorded_figure_is_a_record_and_never_the_balance` fails with them |
+| make `unarchive_account` clear the commitment too | `unarchive-a-row-that-comes-back-is-still-committed` fails twice and goes `MISDECLARED (divergent)`: `stored_is_reconciled` reads `no` where Postgres says `yes`, and — the assertion the three-valued helper exists for — `no` where Postgres says `NULL`. A `storedFlag` could not have told those two apart. One crate test fails with it. What the break costs is not cosmetic: every finished reconciliation in the account is re-opened by a click that was only meant to show the rows again |
+| filter the archive out of the balances aggregate (`AND t.archived = 0`) — R-1's own mutation, re-run because this family puts archived rows back in play | `balances-an-archived-row-still-counts-towards-the-balance` fails: the account answers `0.00` with `txn_count` 0 where both the cloud and the ledger say `-25.00` and 1. 2 crate tests fail with it. **The contract suite does NOT catch it**, and that is worth writing down: its balances rule uses an unarchived row, and its money assertions read the store directly rather than through `getAccountBalances`. The differential harness and the crate are what stand between this schema and a dashboard whose two figures disagree |
+
 `cargo test` fails alongside every one of these; the counts are in the table.
 
 ### Current run
 
-**308 verb specs · 308 pass · 9 declared divergences · 24 single-engine**,
-2026-08-08, against a reference cluster rebuilt from the full migration history.
-`npm run test:local-sqlite` is 66/66, `npm run test:local-admission` is 109/109
-and `cargo test` is **270** (it was 237 before the admission surface).
+**459 verb specs · 459 pass · 25 declared divergences · 24 single-engine**,
+2026-08-11, against a reference cluster rebuilt from the full migration history.
+`npm run test:local-sqlite` is **67/67 for the first time since
+20260810200000 landed in the cloud** (see A-3 above),
+`npm run test:local-admission` is 109/109 and `cargo test` is **420**.
 
-The count in this section has been behind twice, and the drift is worth one
-line rather than a quiet edit: it read **172** while the suite had already grown
-to 217 with the restore family, then 259 with the prune and the checker. The
-ingest pair adds 49 — 22 for `import_transactions` and 27 for
-`import_bank_transactions`, all of them two-engine — so 284 of the 308 actually
-COMPARE two engines and 24 (`verify_integrity`, which is not a port of anything)
-run on one.
+The reconciliation and archive family adds 26 — six for `set_transactions_cleared`,
+eight for `finalize_reconciliation`, four for `set_transactions_archived`, four
+for `archive_transactions_before`, three for `unarchive_account`, and one for
+`update_transaction` which is the DIVERGENCE the C/R split creates: unticking a
+committed row is accepted by the cloud, whose own migration ships a query to go
+and find the rows that leaves behind, and refused by this file, which makes
+"committed implies marked" a CHECK.
+
+The count in this section has been behind three times, and the drift is worth
+one line rather than a quiet edit: it read **172** while the suite had already
+grown to 217 with the restore family, then 259 with the prune and the checker,
+then 308 while the account, category, planning and dismissal families had taken
+it to 433. 435 of the 459 actually COMPARE two engines and 24
+(`verify_integrity`, which is not a port of anything) run on one.
 
 ### What became of five failures, 2026-08-08
 
@@ -803,7 +860,9 @@ PostgreSQL 17.10 with the full migration history applied — **including**
 picks up on its next run because that script replays the whole history from the
 baseline rather than tracking what it applied last time.
 
-**67 specs · 67 pass · 3 declared divergences.**
+**67 specs · 67 pass · 3 declared divergences** — a SNAPSHOT of the first four
+families, kept because the per-spec tables below are what it documents. The
+suite is 459 now; the current figures are in "Current run" above.
 
 ### create (16 specs)
 

--- a/scripts/local-sqlite/lib/verb-postgres.mjs
+++ b/scripts/local-sqlite/lib/verb-postgres.mjs
@@ -28,6 +28,18 @@ const STATE = '__STATE__';
 // (numeric(20,2)::text is exact and involves no rounding function), date as
 // text, tags as a JSON array. The Rust side produces the same key set from its
 // own storage, and the runner compares the two objects field by field.
+//
+// `is_reconciled` is projected as ITSELF and not through a COALESCE, and that is
+// the point of it being here: the column is three-valued on both engines — NULL
+// means "this row predates the split between marking and committing; ask
+// is_cleared" — and the three states are exactly what the two implementations
+// have to agree about. A projection that resolved the NULL would pass whether or
+// not the port had kept it.
+//
+// Unlike `needs_review` (schema.sql amendment 6, which records why that one is
+// deliberately NOT here), this column IS in the reference cluster:
+// 20260810200000_marking_is_not_reconciling.sql is applied there, verified by
+// reading information_schema before this line was written rather than assumed.
 const ROW_JSON = `jsonb_build_object(
   'id', t.id,
   'user_id', t.user_id,
@@ -45,6 +57,7 @@ const ROW_JSON = `jsonb_build_object(
   'payment_channel', t.payment_channel,
   'is_recurring', t.is_recurring,
   'is_cleared', t.is_cleared,
+  'is_reconciled', t.is_reconciled,
   'is_split', t.is_split,
   'archived', t.archived,
   'statement_sequence', t.statement_sequence,
@@ -254,8 +267,8 @@ const DISMISSAL_JSON = `jsonb_build_object(
 
 /**
  * One `transactions` row, in the twenty-two keys
- * `crate::row::ListedTransaction` serialises — which are
- * `BOOT_TRANSACTION_COLUMNS` minus one, and NOT `select('*')`.
+ * `crate::row::ListedTransaction` serialises — which are now
+ * `BOOT_TRANSACTION_COLUMNS` exactly, and NOT `select('*')`.
  *
  * The boot's column list is explicit and measured (~38% of the payload was
  * columns nothing reads), so the ten columns it omits are omitted here too:
@@ -263,14 +276,14 @@ const DISMISSAL_JSON = `jsonb_build_object(
  * `location_country`, `payment_channel`, `external_transaction_id`,
  * `import_source`, `import_source_id`, and the feed's `plaid_transaction_id`.
  *
- * ONE CLOUD COLUMN IS IN THE BOOT LIST AND DELIBERATELY NOT PROJECTED:
+ * ONE CLOUD COLUMN USED TO BE IN THE BOOT LIST AND DELIBERATELY NOT PROJECTED:
  * `is_reconciled`, added by `20260810200000_marking_is_not_reconciling.sql` and
- * not yet in `scripts/local-sqlite/schema.sql`. Projecting a key the local
- * answer cannot have would report a schema gap as a per-spec divergence; the gap
- * is recorded in the crate's `row.rs`, where a reader of the read will meet it,
- * together with what it costs (a local file cannot tell a marked row from a
- * reconciled one — the same degradation the cloud's own fallback ladder accepts
- * for a database that has not had the migration applied).
+ * not then in `scripts/local-sqlite/schema.sql`. The note said that projecting a
+ * key the local answer cannot have would report a schema gap as a per-spec
+ * divergence, and that the gap was recorded in the crate's `row.rs` together
+ * with what it cost — a local file that cannot tell a marked row from a
+ * reconciled one. The column is in both schemas now and is projected here, so
+ * every read spec compares Money's C and R rather than only C.
  */
 const TRANSACTION_JSON = `jsonb_build_object(
   'id', t.id,
@@ -284,6 +297,7 @@ const TRANSACTION_JSON = `jsonb_build_object(
   'date', t.date::text,
   'description', t.description,
   'is_cleared', t.is_cleared,
+  'is_reconciled', t.is_reconciled,
   'is_recurring', t.is_recurring,
   'is_split', t.is_split,
   'linked_transfer_id', t.linked_transfer_id,
@@ -607,6 +621,88 @@ const VERBS = {
      SELECT ${ROW_JSON} INTO v_row
        FROM public.transactions t
       WHERE t.id = (${payloadLiteral}::jsonb->'ids'->>0)::uuid;`,
+
+  // ── THE RECONCILIATION AND ARCHIVE FAMILY ──────────────────────────────────
+  //
+  // Five RPCs, and they split two ways in how they are compared:
+  //
+  //   * the two `set_transactions_*` return a bare integer and DO change a
+  //     transaction, so they are PERFORMed and the row the caller named first is
+  //     projected — the clear_transfer_links shape, and the projected row is
+  //     `ids[0]` for the same reason: it is the row the Rust side answers with
+  //     under its own `transaction` key;
+  //   * the other three return jsonb objects of their own, so like the restore
+  //     family they are compared on that object and everything it cannot carry
+  //     (which rows moved, what the account now records, the audit trail) is
+  //     asserted through `state` SELECTs.
+  //
+  // `finalize_reconciliation` is the one whose ANSWER is not passed through
+  // verbatim: its `ending_balance` comes back as a jsonb number from
+  // `jsonb_build_object('ending_balance', p_ending_balance)`, and money crosses
+  // this boundary as a decimal STRING on the Rust side. `::text` on the numeric
+  // is exact and involves no rounding function, so the two agree without either
+  // going through a float — the same rule ROW_JSON follows for `amount`.
+  //
+  // THE RE-RENDER IS A SECOND STATEMENT, AND IT HAS TO BE. The first draft
+  // wrapped the call — `jsonb_set(finalize_reconciliation(…), '{ending_balance}',
+  // to_jsonb(<the payload's figure>::text))` — and the spec for an absent ending
+  // balance came back `ok` from a function whose first act is to raise. MEASURED
+  // in psql: `jsonb_set` is STRICT, so when one of its arguments is NULL
+  // Postgres skips evaluating the others and NEVER CALLS the RPC at all. A
+  // wrapper that can stop the function under test from running is a driver that
+  // reports on a call that did not happen, which is the worst thing this harness
+  // could do. So the RPC is called on its own line, and the figure is re-rendered
+  // out of ITS OWN answer afterwards.
+  //
+  // `p_ending_balance` is passed with `->>` and NULLIF'd, deliberately: an
+  // absent key must arrive as SQL NULL so the RPC's first refusal —
+  // `ending_balance_required` — stays reachable from a payload.
+  set_transactions_cleared: (payloadLiteral) =>
+    `PERFORM public.set_transactions_cleared(
+               ARRAY(SELECT x::uuid
+                       FROM jsonb_array_elements_text(
+                              COALESCE(${payloadLiteral}::jsonb->'ids', '[]'::jsonb)) AS x),
+               (${payloadLiteral}::jsonb->>'cleared')::boolean,
+               NULLIF(${payloadLiteral}::jsonb->>'user_id', '')::uuid
+             );
+     SELECT ${ROW_JSON} INTO v_row
+       FROM public.transactions t
+      WHERE t.id = (${payloadLiteral}::jsonb->'ids'->>0)::uuid;`,
+
+  set_transactions_archived: (payloadLiteral) =>
+    `PERFORM public.set_transactions_archived(
+               ARRAY(SELECT x::uuid
+                       FROM jsonb_array_elements_text(
+                              COALESCE(${payloadLiteral}::jsonb->'ids', '[]'::jsonb)) AS x),
+               (${payloadLiteral}::jsonb->>'archived')::boolean,
+               NULLIF(${payloadLiteral}::jsonb->>'user_id', '')::uuid
+             );
+     SELECT ${ROW_JSON} INTO v_row
+       FROM public.transactions t
+      WHERE t.id = (${payloadLiteral}::jsonb->'ids'->>0)::uuid;`,
+
+  finalize_reconciliation: (payloadLiteral) =>
+    `SELECT public.finalize_reconciliation(
+              NULLIF(${payloadLiteral}::jsonb->>'user_id', '')::uuid,
+              (${payloadLiteral}::jsonb->>'account_id')::uuid,
+              NULLIF(${payloadLiteral}::jsonb->>'ending_balance', '')::numeric,
+              NULLIF(${payloadLiteral}::jsonb->>'reconciled_on', '')::date)
+       INTO v_row;
+     v_row := jsonb_set(v_row, '{ending_balance}',
+                        to_jsonb((v_row->>'ending_balance')::numeric::text));`,
+
+  archive_transactions_before: (payloadLiteral) =>
+    `SELECT public.archive_transactions_before(
+              NULLIF(${payloadLiteral}::jsonb->>'user_id', '')::uuid,
+              (${payloadLiteral}::jsonb->>'account_id')::uuid,
+              NULLIF(${payloadLiteral}::jsonb->>'cutoff', '')::date)
+       INTO v_row;`,
+
+  unarchive_account: (payloadLiteral) =>
+    `SELECT public.unarchive_account(
+              NULLIF(${payloadLiteral}::jsonb->>'user_id', '')::uuid,
+              (${payloadLiteral}::jsonb->>'account_id')::uuid)
+       INTO v_row;`,
 
   repair_claimed_transfer: (payloadLiteral) =>
     `PERFORM public.repair_claimed_transfer(

--- a/scripts/local-sqlite/schema.sql
+++ b/scripts/local-sqlite/schema.sql
@@ -124,14 +124,47 @@
 --         rewritten. The two IMPORT verbs are what set it to 1; the create verb
 --         deliberately does not, so a row a person typed is born reviewed.
 --
---         PARITY OBLIGATION, RECORDED RATHER THAN DISCHARGED: the cloud
---         migration is UNAPPLIED at the time of writing (the owner applies
---         migrations himself). scripts/local-sqlite/lib/verb-postgres.mjs
---         therefore does NOT project needs_review in ROW_JSON, because the
---         differential harness runs against a live Postgres and would fail on
---         every row for a column that database does not yet have. Add it there
---         — and to the TS oracle's import verbs — in the same change that
---         confirms 20260810090000 is applied.
+--         PARITY OBLIGATION — RETIRED 2026-08-11, by ruling rather than by
+--         edit. 20260810090000 is now confirmed applied in the reference
+--         cluster, which is the condition this note originally waited on. But
+--         the obligation as written predates slice 19's ruling and conflicts
+--         with it: ROW_JSON is the Postgres twin of the crate's audit
+--         projection, and that projection deliberately excludes needs_review —
+--         the audit payload is hash-chained and compared field by field across
+--         engines, so widening it re-chains history to say what the review
+--         flag already says elsewhere. The field's read-back home is the
+--         RESULT projection, which belongs to the commit that gives the port
+--         a caller (slice 27, recorded in localDataPort.ts's header). Until
+--         then the boot read (BOOT columns) is where needs_review crosses,
+--         and it does.
+--
+-- AMENDED 2026-08-11 (7), in THIS COPY ONLY, mirroring
+--         supabase/migrations/20260810200000_marking_is_not_reconciling.sql:
+--         `transactions.is_reconciled`, Microsoft Money's R — the committed
+--         state only a finalize produces — and with it the reconcile-sweep moved
+--         onto that flag and a new CHECK that committed implies marked. Added on
+--         amendment (2)'s precedent and for the same reason. This copy is now
+--         ahead of the draft by amendment (2)'s one column, amendment (5)'s one
+--         table, amendment (6)'s one column and this one column.
+--
+--         THE CLOUD'S NULL STORY, TRANSLATED AND MEASURED. The migration adds
+--         the column bare and sets the default in a SECOND statement, so that
+--         history keeps the honest NULL ("ask is_cleared") and only new rows get
+--         false. Neither half of that is available or needed here: MEASURED
+--         (probe-addcolumn.mjs), SQLite's ADD COLUMN with a DEFAULT gives rows
+--         written before the alter that default — attmissingval by another name
+--         — and `ALTER COLUMN … SET DEFAULT` is a syntax error, so the two-step
+--         cannot be written. A file created from this schema has no pre-split
+--         rows, so DEFAULT 0 is right for every INSERT and matches the cloud's
+--         answer for one. The column stays NULLABLE because a restored cloud
+--         backup's rows really are pre-split, and the obligation that leaves is
+--         recorded at the column: `crate::backup` currently turns a JSON null
+--         into "column omitted", which the default then fills.
+--
+--         The accounts side of the same migration was already here: slice 20
+--         added last_reconciled_balance_minor for AccountUpdate's sake.
+--         Specs: specs/a3-*, verb-specs/cleared-*, verb-specs/finalize-*,
+--         verb-specs/archive-*, verb-specs/unarchive-*.
 -- ============================================================================
 
 
@@ -545,6 +578,45 @@ CREATE TABLE transactions (
 
   is_recurring  INTEGER NOT NULL DEFAULT 0 CHECK (is_recurring IN (0,1)),
   is_cleared    INTEGER NOT NULL DEFAULT 0 CHECK (is_cleared IN (0,1)),
+
+  -- Microsoft Money's R, and the ONLY thing a finalize produces
+  -- (20260810200000_marking_is_not_reconciling.sql:107-114). `is_cleared` above
+  -- is the C beside it: a working mark, kept, settling nothing.
+  --
+  -- THREE-VALUED, and the third value is the point. NULL means "this row
+  -- predates the split between marking and committing; ask is_cleared", which is
+  -- the rule src/utils/transactionReconciliation.ts holds for the app and
+  -- COALESCE(is_reconciled, is_cleared) holds in SQL. 0 means marked or not but
+  -- explicitly NOT committed; 1 means committed by a finalize.
+  --
+  -- DEFAULT 0, and the cloud's own two-statement trick is BOTH unavailable here
+  -- and unnecessary. The cloud added the column bare and then set the default,
+  -- because a column added WITH one gives existing rows that default through
+  -- attmissingval and would silently answer "not committed" for the whole of
+  -- history. MEASURED (probe-addcolumn.mjs, node:sqlite 3.50.0): SQLite does
+  -- exactly the same — after `ALTER TABLE t ADD COLUMN c INTEGER DEFAULT 0`, a
+  -- row written BEFORE the alter reads 0 and not NULL, with no rewrite — and
+  -- SQLite has no `ALTER COLUMN … SET DEFAULT` at all (`near "ALTER": syntax
+  -- error`), so the two-step cannot be spelled. It is not needed: this file is
+  -- CREATEd rather than migrated, so it has no pre-split rows of its own, and
+  -- the default is what every INSERT that says nothing about the column gets —
+  -- which is the cloud's answer too, and the migration's rule that "a
+  -- transaction is born uncommitted whether it was typed, imported or
+  -- downloaded". A bank-feed row still arrives is_cleared = 1; that is a mark.
+  --
+  -- WHERE A NULL CAN STILL ARRIVE, AND THE OBLIGATION THAT LEAVES: a restored
+  -- cloud backup. Those rows carry NULL for the whole of a user's history, and
+  -- `crate::backup`'s rule is that an absent or JSON-null key OMITS the column —
+  -- so the default fills it and the honest NULL is lost, where the cloud's
+  -- jsonb_populate_recordset stores the NULL. RECORDED rather than closed here:
+  -- the restore round trip is the backup group's slice (collect_backup is not
+  -- written yet, so nothing can produce the file this would be measured on), and
+  -- the fix is one Kind in `crate::backup` that tells absent from null. Until
+  -- then a restored pre-split history reads as "marked, never committed" rather
+  -- than as reconciled, which is a display of work outstanding rather than a
+  -- money error.
+  is_reconciled INTEGER DEFAULT 0 CHECK (is_reconciled IN (0,1)),
+
   is_split      INTEGER NOT NULL DEFAULT 0 CHECK (is_split IN (0,1)),
   archived      INTEGER NOT NULL DEFAULT 0 CHECK (archived IN (0,1)),
 
@@ -666,6 +738,32 @@ CREATE TABLE transactions (
   -- A transfer cannot be split (20260713100000:153-155). NEW as a constraint.
   CONSTRAINT transactions_transfer_not_split
     CHECK (NOT (is_split = 1 AND type = 'transfer')),
+
+  -- Committed implies marked (20260810200000:130-136, and the migration's own
+  -- verification 7, which is a SELECT looking for rows in this state).
+  --
+  -- The cloud keeps it in ONE function — set_transactions_cleared's CASE, whose
+  -- unmark branch writes `is_reconciled = false` — and nowhere else, so its
+  -- update RPC can leave a row committed-but-unmarked and the migration ships a
+  -- query to go and find them. Here it is a property of the file, which is
+  -- DESIGN.md §6's argument applied to the newest column in it: the pair
+  -- (committed, unmarked) puts the cleared balance and the reconciled set
+  -- permanently out of step, and a rule enforced in one writer is a rule the
+  -- next writer skips.
+  --
+  -- `IS NOT 1` rather than `<> 1`, because the third value has to pass: a NULL
+  -- row is pre-split history whose commitment nobody has answered, and `NULL <>
+  -- 1` is NULL, which a CHECK treats as satisfied — true here by luck rather
+  -- than by statement. Written as `IS NOT` so it is true by statement.
+  --
+  -- DECLARED DIVERGENCE, with a spec: update_transaction's `is_cleared` field
+  -- can reach this. Unticking a committed row is accepted by the cloud (leaving
+  -- exactly the pair verification 7 hunts for) and refused by this file. There
+  -- is no `unreconcile` operation in the seam on either engine, so the local
+  -- answer is "a committed row stays ticked", which is Money's behaviour and
+  -- what the register must be told before it offers the tick.
+  CONSTRAINT transactions_reconciled_implies_cleared
+    CHECK (is_reconciled IS NOT 1 OR is_cleared = 1),
 
   -- A linked transfer must name the other account (20260716100000:121-137).
   CONSTRAINT transactions_linked_has_target
@@ -1096,9 +1194,12 @@ END;
 
 
 -- ── The reconcile-sweep ────────────────────────────────────────────────────
--- Port of sweep_reconciled_into_archive (20260721130000:123-148). The cloud's
--- version is a BEFORE trigger that ASSIGNS NEW.archived := true. That cannot be
--- done in SQLite, so it becomes an AFTER trigger issuing an UPDATE.
+-- Port of sweep_reconciled_into_archive as RESTATED by
+-- 20260810200000_marking_is_not_reconciling.sql:336-361, which is the live
+-- definition; the original (20260721130000:123-148) hung off is_cleared because
+-- that was the only flag there was. The cloud's version is a BEFORE trigger
+-- that ASSIGNS NEW.archived := true. That cannot be done in SQLite, so it
+-- becomes an AFTER trigger issuing an UPDATE.
 --
 -- This is a REAL behavioural difference, not just a syntactic one: the cloud
 -- archives the row in the same statement that clears it, while this fires a
@@ -1106,9 +1207,17 @@ END;
 -- sees two here. It is safe because recursive_triggers is OFF (the inner UPDATE
 -- does not re-fire this trigger) and because both statements are inside the
 -- caller's transaction.
+--
+-- IT HANGS OFF THE COMMITTED FLAG, AND THAT IS THE WHOLE OF THE C/R SPLIT HERE.
+-- A working mark must never make a row vanish from the screen the ticking
+-- happens on: a mark is reversible, and a row you cannot see is a row you cannot
+-- unmark. Only finalizing is final, so only finalizing sweeps. This mirror kept
+-- firing on is_cleared for two slices after the cloud moved, and
+-- specs/a3-reconciling-an-old-row-archives-it is what said so on every run —
+-- the two engines disagreed about whether ticking a row archives it.
 CREATE TRIGGER trg_sweep_reconciled_into_archive
-AFTER UPDATE OF is_cleared ON transactions
-WHEN NEW.is_cleared = 1 AND OLD.is_cleared IS NOT NEW.is_cleared AND NEW.archived = 0
+AFTER UPDATE OF is_reconciled ON transactions
+WHEN NEW.is_reconciled = 1 AND OLD.is_reconciled IS NOT NEW.is_reconciled AND NEW.archived = 0
  AND EXISTS (
    SELECT 1 FROM accounts a
     WHERE a.id = NEW.account_id

--- a/scripts/local-sqlite/specs/a3-reconciling-an-old-row-archives-it.spec.mjs
+++ b/scripts/local-sqlite/specs/a3-reconciling-an-old-row-archives-it.spec.mjs
@@ -1,21 +1,54 @@
+// The row is MARKED in the setup and COMMITTED in the action, and the split
+// between those two statements is the whole spec.
+//
+// It used to tick the row and expect the archive, because one flag did both
+// jobs. 20260810200000_marking_is_not_reconciling.sql separated them and moved
+// the sweep onto is_reconciled; this mirror went on firing on is_cleared, and
+// from that day the spec FAILED — Postgres archived nothing, SQLite archived the
+// row, and the declared `match` was observed `divergent`. That failure is what
+// the C/R port was measured against, so the fix is in schema.sql and this file
+// only stops asking yesterday's question.
+//
+// The setup half is not incidental either: it MARKS a row dated before the
+// cutoff, and the sweep must not fire on it. A tick is reversible and a row you
+// cannot see is a row you cannot untick, so a sweep hanging off the mark took
+// rows out of the very list the ticking happens on. This harness verifies only
+// after the action, so the "a mark alone archives nothing" half is asserted
+// where it can be asserted between two statements — the verb harness's
+// `cleared-marking-an-old-row-does-not-archive-it`.
 export default {
   invariant: 'A-3',
   title: 'reconciling a row that is older than its account cutoff archives it',
-  design: 'DESIGN.md §1.6 A-3 ("T"); cloud sweep_reconciled_into_archive, 20260721130000:123-148. §2.3 records the shape change: the cloud assigns NEW.archived in a BEFORE trigger, which SQLite cannot do, so the port issues a second UPDATE. The end state is the same; anything watching for a single-statement change sees two',
+  design: 'DESIGN.md §1.6 A-3 ("T"); cloud sweep_reconciled_into_archive as RESTATED by 20260810200000:336-361 (was 20260721130000:123-148, keyed on is_cleared). §2.3 records the shape change: the cloud assigns NEW.archived in a BEFORE trigger, which SQLite cannot do, so the port issues a second UPDATE. The end state is the same; anything watching for a single-statement change sees two',
   consequence: 'old reconciled items linger in the live register forever, and the register the user scrolls stops matching the period they think they are looking at',
   parity: 'match',
 
+  // THE ORDER OF THE TWO SETUP STATEMENTS IS THE WHOLE DISCRIMINATOR, and it was
+  // measured rather than reasoned: written the other way round (cutoff first,
+  // then the mark) this spec PASSED with the sweep moved back onto `is_cleared`,
+  // because the mark archived the row during the setup and the verify — which
+  // runs only after the action — cannot see which statement did it.
+  //
+  // Marking BEFORE the account has a cutoff separates them: a sweep on the mark
+  // has nothing to act on when the tick happens, and nothing to act on at the
+  // action either, so the row comes out live and the spec fails. It is also the
+  // truthful sequence — an account is archived through a date and then goes on
+  // being reconciled.
   sqlite: {
-    setup: `UPDATE accounts SET archive_through_date = '2024-06-30'
+    setup: `UPDATE transactions SET is_cleared = 1
+             WHERE id = '70000000-0000-0000-0000-000000000001';
+            UPDATE accounts SET archive_through_date = '2024-06-30'
              WHERE id = 'a0000000-0000-0000-0000-000000000001';`,
-    action: `UPDATE transactions SET is_cleared = 1 WHERE id = '70000000-0000-0000-0000-000000000001';`,
+    action: `UPDATE transactions SET is_reconciled = 1 WHERE id = '70000000-0000-0000-0000-000000000001';`,
     expect: { outcome: 'accepted' },
   },
 
   postgres: {
-    setup: `UPDATE public.accounts SET archive_through_date = '2024-06-30'
+    setup: `UPDATE public.transactions SET is_cleared = true
+             WHERE id = '70000000-0000-0000-0000-000000000001';
+            UPDATE public.accounts SET archive_through_date = '2024-06-30'
              WHERE id = 'a0000000-0000-0000-0000-000000000001';`,
-    action: `UPDATE public.transactions SET is_cleared = true WHERE id = '70000000-0000-0000-0000-000000000001';`,
+    action: `UPDATE public.transactions SET is_reconciled = true WHERE id = '70000000-0000-0000-0000-000000000001';`,
     expect: { outcome: 'accepted' },
   },
 

--- a/scripts/local-sqlite/verb-specs/_shared.mjs
+++ b/scripts/local-sqlite/verb-specs/_shared.mjs
@@ -2847,16 +2847,21 @@ export const nothingOfMine = {
 /**
  * One transaction, as both engines must answer with it.
  *
- * Twenty-two keys: `BOOT_TRANSACTION_COLUMNS` minus `is_reconciled`, which the
- * cloud has had since 20260810200000 and scripts/local-sqlite/schema.sql has
- * not. The gap is recorded in the crate's `row.rs` and in the harness oracle;
- * it is NOT hidden here, it is simply not a key either side can answer with.
+ * Twenty-three keys, which is `BOOT_TRANSACTION_COLUMNS` exactly. It was
+ * twenty-two until the C/R split was ported: `is_reconciled` was the one boot
+ * column the cloud had (since 20260810200000) and scripts/local-sqlite/schema.sql
+ * had not, and the gap was recorded here, in the crate's `row.rs` and in the
+ * harness oracle rather than hidden. Both schemas hold it now, so every read
+ * spec in this directory compares Money's R as well as its C.
  *
  * The defaults below are the Corner shop row's, checked against the column
  * defaults in both schemas — `category_confirmed` is true by default in both
- * (a writer that does not know about provenance produces a confirmed row) and
+ * (a writer that does not know about provenance produces a confirmed row),
  * `needs_review` false in both (one that does not know about review produces a
- * reviewed row).
+ * reviewed row), and `is_reconciled` FALSE in both, which is the third of the
+ * same shape: a transaction is born uncommitted whether it was typed, imported
+ * or downloaded. Not NULL — that value belongs to rows written before the split,
+ * and a file created from this schema has none.
  */
 export function listedTransaction(fields) {
   return {
@@ -2871,6 +2876,7 @@ export function listedTransaction(fields) {
     date: '2024-03-01',
     description: 'Corner shop',
     is_cleared: false,
+    is_reconciled: false,
     is_recurring: false,
     is_split: false,
     linked_transfer_id: null,
@@ -3541,3 +3547,149 @@ export function subjectRowsInTotal(expect) {
     expect,
   };
 }
+
+// ── The reconciliation and archive family ──────────────────────────────────
+//
+// Five verbs about two flags and a date, and everything below exists because
+// those flags are THREE-valued and a date has to be planted before an archive
+// has anything to bite on. All data is invented.
+
+/**
+ * One THREE-valued boolean column of one transaction: `yes` / `no` / `NULL`.
+ *
+ * {@link storedFlag} cannot serve, and the difference is the whole C/R split:
+ * it renders anything that is not 1 as `no`, so a pre-split NULL — the row that
+ * means "ask is_cleared" — and an explicit "not committed" would read the same.
+ * Those two are exactly what `finalize_reconciliation` distinguishes with
+ * `IS NOT DISTINCT FROM false` and what `archive_transactions_before`
+ * distinguishes with its COALESCE, so a spec that could not tell them apart
+ * would pass against a port that had lost the distinction.
+ */
+export function storedTriFlag(transactionId, column, expect) {
+  const wrap = (yes) => `CASE WHEN ${column} IS NULL THEN 'NULL'
+                              WHEN ${yes} THEN 'yes' ELSE 'no' END`;
+  return {
+    name: `stored_${column}_${transactionId.slice(-4)}`,
+    sqlite: `SELECT COALESCE((SELECT ${wrap(`${column} = 1`)}
+        FROM transactions WHERE id = '${transactionId}'), 'ABSENT')`,
+    postgres: `SELECT COALESCE((SELECT ${wrap(column)}
+        FROM public.transactions WHERE id = '${transactionId}'), 'ABSENT')`,
+    expect,
+  };
+}
+
+/**
+ * One MONEY column of one account, as an exact decimal string, with `NULL` kept
+ * apart from zero.
+ *
+ * Written for `last_reconciled_balance`, where the two are different facts and
+ * the column is nullable for that reason alone: £0.00 is a real statement
+ * balance — an account swept to zero every night closes on exactly that — and
+ * "no reconciliation has ever been finalized" is not a figure. A helper that
+ * rendered NULL as `0.00` would make the spec that proves it pass by accident.
+ *
+ * The column is named ONCE, in the cloud's spelling, and the local `_minor`
+ * suffix is added here — the same correspondence `storedBalances` writes out for
+ * `balance`/`balance_minor`, and the same one `schema.sql` states as a rule
+ * ("scale is per column, and the column NAME says which").
+ */
+export function accountMoney(accountId, column, expect) {
+  const local = `${column}_minor`;
+  const wrap = (col, decimal) => `CASE WHEN ${col} IS NULL THEN 'NULL' ELSE ${decimal} END`;
+  return {
+    name: `account_${column}_${accountId.slice(-4)}`,
+    sqlite: `SELECT COALESCE((SELECT ${wrap(local, minorToDecimal(local))} FROM accounts
+        WHERE id = '${accountId}'), 'ABSENT')`,
+    postgres: `SELECT COALESCE((SELECT ${wrap(column, numericToDecimal(column))}
+        FROM public.accounts WHERE id = '${accountId}'), 'ABSENT')`,
+    expect,
+  };
+}
+
+/**
+ * How many rows of one account are hidden from the live register.
+ *
+ * The archive's headline, asked as a count rather than row by row so that a
+ * verb which archived MORE than it was asked to cannot pass by having the one
+ * row a spec thought to name come out right.
+ */
+export function archivedRowsIn(accountId, expect) {
+  return {
+    name: `archived_rows_in_${accountId.slice(-4)}`,
+    sqlite: `SELECT COUNT(*) FROM transactions WHERE account_id = '${accountId}' AND archived = 1`,
+    postgres: `SELECT COUNT(*) FROM public.transactions
+                WHERE account_id = '${accountId}' AND archived`,
+    expect,
+  };
+}
+
+/** The three ids the reconciliation fixtures plant, beside the base row. */
+export const MARKED_ROW = '70000000-0000-0000-0000-0000000000c1';
+export const COMMITTED_ROW = '70000000-0000-0000-0000-0000000000c2';
+export const PRE_SPLIT_ROW = '70000000-0000-0000-0000-0000000000c3';
+
+/**
+ * Three rows in Everyday, one per state of the committed flag, and the base
+ * fixture's Corner shop left unmarked as the fourth.
+ *
+ * | row | `is_cleared` | `is_reconciled` | what it is |
+ * | --- | --- | --- | --- |
+ * | MARKED_ROW | 1 | 0 | ticked this session; the working set a finalize converts |
+ * | COMMITTED_ROW | 1 | 1 | already through a finalize |
+ * | PRE_SPLIT_ROW | 1 | NULL | written before the split; "ask is_cleared" |
+ * | CORNER_SHOP | 0 | 0 | not ticked at all |
+ *
+ * Dated 2024-01-15, 2024-01-16 and 2024-01-17 — all BEFORE the base row's
+ * 2024-03-01 — so one cutoff can separate them from it. Every row is −1.00 and
+ * both balances are moved, so B-1 holds before the verb runs.
+ *
+ * The NULL row is planted as an EXPLICIT NULL rather than by leaving the column
+ * out, and that is not belt and braces: the local column carries `DEFAULT 0`, so
+ * an INSERT that says nothing gets 0 — the right answer for a row being born and
+ * the wrong state for this fixture, which needs the one value only history can
+ * hold.
+ *
+ * `updated_at` is planted at 2019-01-01 ON THE INSERT, and it has to be on the
+ * insert: the cloud's `update_transactions_updated_at` is a BEFORE UPDATE
+ * trigger, so a fixture that planted the stamp with an UPDATE would have it
+ * overwritten with `now()` before the spec ever ran — MEASURED, by writing it
+ * that way first and watching Postgres answer today's date. That is what makes
+ * "this verb did not touch the row" observable at all.
+ */
+export const everyStateOfCommitment = {
+  sqlite: `
+    INSERT INTO transactions (id, user_id, account_id, description, amount_minor, type, date,
+                              category, is_cleared, is_reconciled, updated_at) VALUES
+      ('${MARKED_ROW}',    '${USER}', '${EVERYDAY}', 'Ticked',    -100, 'expense', '2024-01-15', '${WEEKLY_SHOP}', 1, 0,    '2019-01-01T00:00:00.000Z'),
+      ('${COMMITTED_ROW}', '${USER}', '${EVERYDAY}', 'Settled',   -100, 'expense', '2024-01-16', '${WEEKLY_SHOP}', 1, 1,    '2019-01-01T00:00:00.000Z'),
+      ('${PRE_SPLIT_ROW}', '${USER}', '${EVERYDAY}', 'Historic',  -100, 'expense', '2024-01-17', '${WEEKLY_SHOP}', 1, NULL, '2019-01-01T00:00:00.000Z');
+    UPDATE accounts SET balance_minor = balance_minor - 300 WHERE id = '${EVERYDAY}';`,
+  postgres: `
+    INSERT INTO public.transactions (id, user_id, account_id, description, amount, type, date,
+                                     category, is_cleared, is_reconciled, updated_at) VALUES
+      ('${MARKED_ROW}',    '${USER}', '${EVERYDAY}', 'Ticked',   -1.00, 'expense', '2024-01-15', '${WEEKLY_SHOP}', true, false, '2019-01-01T00:00:00Z'),
+      ('${COMMITTED_ROW}', '${USER}', '${EVERYDAY}', 'Settled',  -1.00, 'expense', '2024-01-16', '${WEEKLY_SHOP}', true, true,  '2019-01-01T00:00:00Z'),
+      ('${PRE_SPLIT_ROW}', '${USER}', '${EVERYDAY}', 'Historic', -1.00, 'expense', '2024-01-17', '${WEEKLY_SHOP}', true, NULL,  '2019-01-01T00:00:00Z');
+    UPDATE public.accounts SET balance = balance - 3.00 WHERE id = '${EVERYDAY}';`,
+};
+
+/**
+ * Everyday archived through 2024-02-28 — after the three planted rows and
+ * before the base fixture's Corner shop.
+ *
+ * A cutoff on its own archives nothing: it is the ACCOUNT saying "everything
+ * before this is archived", and A-3's sweep is what fills it in one row at a
+ * time as each is committed. That is why this fragment is separate from the
+ * rows: several specs need the cutoff without needing anything already hidden.
+ */
+export const archivedThroughFebruary = {
+  sqlite: `UPDATE accounts SET archive_through_date = '2024-02-28' WHERE id = '${EVERYDAY}';`,
+  postgres: `UPDATE public.accounts SET archive_through_date = '2024-02-28'
+              WHERE id = '${EVERYDAY}';`,
+};
+
+/** Everyday, re-typed as an investment account. Nothing else changes. */
+export const everydayIsAnInvestment = {
+  sqlite: `UPDATE accounts SET type = 'investment' WHERE id = '${EVERYDAY}';`,
+  postgres: `UPDATE public.accounts SET type = 'investment' WHERE id = '${EVERYDAY}';`,
+};

--- a/scripts/local-sqlite/verb-specs/archive-an-account-that-is-not-yours-is-refused-by-its-own-name.spec.mjs
+++ b/scripts/local-sqlite/verb-specs/archive-an-account-that-is-not-yours-is-refused-by-its-own-name.spec.mjs
@@ -1,0 +1,35 @@
+import { USER, THEIR_ROW, SOMEONE_ELSES_ACCOUNT, secondUser, strangersRow, setups,
+  storedFlag, accountText, balanceIdentityHolds } from './_shared.mjs';
+
+// `account_not_found`, and NOT `account_not_found_or_not_owned`.
+//
+// Two names for one shape of failure, in one schema: the transaction RPCs and
+// `finalize_reconciliation` raise the second, the two archive functions raise
+// the first. That is the cloud's inconsistency and the port keeps it, because a
+// port that unified them would refuse with a word no cloud caller has ever seen
+// — and a caller that branches on a refusal code is branching on the cloud's
+// behaviour.
+export default {
+  invariant: 'X-6',
+  title: 'archiving an account that is not yours is refused by the archive\'s own name for it',
+  design: 'archive_transactions_before 20260810200000:303-309 — RAISE account_not_found',
+  consequence: 'a mis-routed owner id hides another login\'s history from their register',
+  parity: 'match',
+
+  setup: setups(secondUser, strangersRow, {
+    sqlite: `UPDATE transactions SET is_cleared = 1, is_reconciled = 1 WHERE id = '${THEIR_ROW}';`,
+    postgres: `UPDATE public.transactions SET is_cleared = true, is_reconciled = true
+                WHERE id = '${THEIR_ROW}';`,
+  }),
+  command: {
+    verb: 'archive_transactions_before',
+    payload: { account_id: SOMEONE_ELSES_ACCOUNT, cutoff: '2025-01-01', user_id: USER },
+  },
+  expect: { outcome: 'refused', error: 'account_not_found' },
+
+  state: [
+    storedFlag(THEIR_ROW, 'archived', 'no'),
+    accountText(SOMEONE_ELSES_ACCOUNT, 'archive_through_date', 'NULL'),
+    balanceIdentityHolds(SOMEONE_ELSES_ACCOUNT),
+  ],
+};

--- a/scripts/local-sqlite/verb-specs/archive-an-investment-account-is-refused.spec.mjs
+++ b/scripts/local-sqlite/verb-specs/archive-an-investment-account-is-refused.spec.mjs
@@ -1,0 +1,33 @@
+import { USER, EVERYDAY, COMMITTED_ROW, everyStateOfCommitment, everydayIsAnInvestment,
+  setups, storedFlag, archivedRowsIn, accountText, balanceIdentityHolds } from './_shared.mjs';
+
+// v1 excludes investment accounts, and the soft-archive migration says why:
+// "their transfers/cost-basis want special handling". Both engines refuse with
+// the cloud's own sentence, so a person reading the message gets the same words
+// either way.
+//
+// The refusal comes BEFORE both writes, which is what the state assertions here
+// are for: the committed row is still live and the account has no cutoff, so a
+// port that archived first and checked the type second would fail this even
+// while naming the right refusal.
+export default {
+  invariant: 'A-4',
+  title: 'an investment account cannot be archived yet, and nothing of it moves',
+  design: 'archive_transactions_before 20260810200000:310-312 (from 20260721130000:67-69)',
+  consequence: 'an investment account\'s cost basis is hidden from the register with no handling for its transfers',
+  parity: 'match',
+
+  setup: setups(everyStateOfCommitment, everydayIsAnInvestment),
+  command: {
+    verb: 'archive_transactions_before',
+    payload: { account_id: EVERYDAY, cutoff: '2024-02-28', user_id: USER },
+  },
+  expect: { outcome: 'refused', error: 'investment accounts cannot be archived yet' },
+
+  state: [
+    storedFlag(COMMITTED_ROW, 'archived', 'no'),
+    archivedRowsIn(EVERYDAY, '0'),
+    accountText(EVERYDAY, 'archive_through_date', 'NULL'),
+    balanceIdentityHolds(EVERYDAY),
+  ],
+};

--- a/scripts/local-sqlite/verb-specs/archive-only-committed-rows-are-hidden.spec.mjs
+++ b/scripts/local-sqlite/verb-specs/archive-only-committed-rows-are-hidden.spec.mjs
@@ -1,0 +1,48 @@
+import { USER, EVERYDAY, CORNER_SHOP, MARKED_ROW, COMMITTED_ROW, PRE_SPLIT_ROW,
+  everyStateOfCommitment, storedFlag, archivedRowsIn, accountText,
+  balanceOf, balanceIdentityHolds } from './_shared.mjs';
+
+// FOUR ROWS, FOUR ANSWERS, and the count is 2.
+//
+//   COMMITTED_ROW  committed, 2024-01-16  -> hidden.
+//   PRE_SPLIT_ROW  NULL, ticked, 01-17    -> hidden. COALESCE(is_reconciled,
+//                                            is_cleared): pre-split history is
+//                                            judged by its mark, exactly as the
+//                                            archive judged it the day before
+//                                            the column existed.
+//   MARKED_ROW     ticked only, 01-15     -> LEFT LIVE. Marked but not committed
+//                                            is work in progress, and it stays
+//                                            where it can still be unmarked.
+//                                            This is the behaviour change the
+//                                            split brought to this verb.
+//   CORNER_SHOP    unticked, 2024-03-01   -> left live, and twice over: not
+//                                            committed, and after the cutoff.
+//
+// The cutoff is 2024-02-28 and it is passed to the VERB rather than planted, so
+// the account's stamp below is this call's own work.
+export default {
+  invariant: 'A-4',
+  title: 'archiving by cutoff hides only the committed rows',
+  design: 'archive_transactions_before as restated by 20260810200000:290-329 — the predicate is COALESCE(is_reconciled, is_cleared)',
+  consequence: 'work in progress disappears from the register mid-reconciliation, or settled history never leaves it',
+  parity: 'match',
+
+  setup: everyStateOfCommitment,
+  command: {
+    verb: 'archive_transactions_before',
+    payload: { account_id: EVERYDAY, cutoff: '2024-02-28', user_id: USER },
+  },
+  expect: { outcome: 'ok' },
+  result: { archived: 2, cutoff: '2024-02-28' },
+
+  state: [
+    storedFlag(COMMITTED_ROW, 'archived', 'yes'),
+    storedFlag(PRE_SPLIT_ROW, 'archived', 'yes'),
+    storedFlag(MARKED_ROW, 'archived', 'no'),
+    storedFlag(CORNER_SHOP, 'archived', 'no'),
+    archivedRowsIn(EVERYDAY, '2'),
+    accountText(EVERYDAY, 'archive_through_date', '2024-02-28'),
+    balanceOf(EVERYDAY, '-28.00'),
+    balanceIdentityHolds(EVERYDAY),
+  ],
+};

--- a/scripts/local-sqlite/verb-specs/archive-the-cutoff-is-recorded-even-when-nothing-was-old-enough.spec.mjs
+++ b/scripts/local-sqlite/verb-specs/archive-the-cutoff-is-recorded-even-when-nothing-was-old-enough.spec.mjs
@@ -1,0 +1,36 @@
+import { USER, EVERYDAY, CORNER_SHOP, storedFlag, archivedRowsIn, accountText,
+  auditShape, balanceIdentityHolds } from './_shared.mjs';
+
+// Both UPDATEs always run. The cutoff is a statement about the ACCOUNT —
+// "everything before this is archived" — and A-3's sweep is what fills it in
+// afterwards, one row at a time, as each is committed. An account with a cutoff
+// and nothing hidden is the normal state of an account whose old rows are not
+// reconciled yet.
+//
+// `audit_shape` is NONE and that is the RPC's shape rather than an omission
+// here: there is no write_financial_audit anywhere in
+// archive_transactions_before, while the per-row set_transactions_archived
+// audits every row it touches. The asymmetry is the cloud's, twenty lines apart
+// in one migration, and this spec is where it is measured rather than argued.
+export default {
+  invariant: 'A-4',
+  title: 'the cutoff is recorded even when nothing was old enough to hide',
+  design: 'archive_transactions_before 20260810200000:314-325 — the account UPDATE is not conditional on the row count',
+  consequence: 'the archive silently forgets what it was asked to do, and the sweep has no cutoff to read',
+  parity: 'match',
+
+  command: {
+    verb: 'archive_transactions_before',
+    payload: { account_id: EVERYDAY, cutoff: '2024-01-01', user_id: USER },
+  },
+  expect: { outcome: 'ok' },
+  result: { archived: 0, cutoff: '2024-01-01' },
+
+  state: [
+    storedFlag(CORNER_SHOP, 'archived', 'no'),
+    archivedRowsIn(EVERYDAY, '0'),
+    accountText(EVERYDAY, 'archive_through_date', '2024-01-01'),
+    auditShape('NONE'),
+    balanceIdentityHolds(EVERYDAY),
+  ],
+};

--- a/scripts/local-sqlite/verb-specs/archived-a-direction-that-is-not-stated-is-refused.spec.mjs
+++ b/scripts/local-sqlite/verb-specs/archived-a-direction-that-is-not-stated-is-refused.spec.mjs
@@ -1,0 +1,30 @@
+import { USER, EVERYDAY, CORNER_SHOP, storedFlag, auditShape,
+  balanceIdentityHolds } from './_shared.mjs';
+
+// The only verb in this family whose boolean is GUARDED rather than merely
+// required by the signature: `IF p_archived IS NULL THEN RAISE`. Both engines
+// refuse with the RPC's own sentence, so a caller reading the message gets the
+// same words either way.
+//
+// Note what it is NOT: a default. Defaulting an absent direction to `true` would
+// make "archive" the answer to a question the caller failed to ask, on a verb
+// whose whole subject is what the register shows.
+export default {
+  invariant: 'A-4',
+  title: 'an archive that does not say which way is refused, in the cloud\'s own words',
+  design: 'set_transactions_archived 20260805145035:191-193',
+  consequence: 'a malformed call hides rows nobody asked to hide',
+  parity: 'match',
+
+  command: {
+    verb: 'set_transactions_archived',
+    payload: { ids: [CORNER_SHOP], user_id: USER },
+  },
+  expect: { outcome: 'refused', error: 'p_archived must be true or false' },
+
+  state: [
+    storedFlag(CORNER_SHOP, 'archived', 'no'),
+    auditShape('NONE'),
+    balanceIdentityHolds(EVERYDAY),
+  ],
+};

--- a/scripts/local-sqlite/verb-specs/archived-a-row-already-archived-is-a-successful-nothing.spec.mjs
+++ b/scripts/local-sqlite/verb-specs/archived-a-row-already-archived-is-a-successful-nothing.spec.mjs
@@ -1,0 +1,38 @@
+import { USER, EVERYDAY, CORNER_SHOP, storedFlag, auditShape,
+  balanceIdentityHolds } from './_shared.mjs';
+
+// "An 'archive this' that runs twice is a no-op, not an error" — the RPC's own
+// words, and the reason `archived IS DISTINCT FROM p_archived` is in the cursor
+// rather than in the WHERE of the update. The row is not written, so it is not
+// audited and its `updated_at` does not move.
+//
+// The "not written" half is asserted here as `audit_shape` NONE rather than as
+// an unmoved `updated_at`, and the reason is worth one line: the setup archives
+// the row with a plain UPDATE, and on the cloud that fires
+// `update_transactions_updated_at` (BEFORE UPDATE), so the stamp is today's on
+// both engines before the verb runs and "it did not move" would be unobservable.
+// `cleared-a-row-already-in-that-state-is-not-written` is where that half is
+// proved, on a fixture that plants the stamp on the INSERT.
+export default {
+  invariant: 'A-4',
+  title: 'archiving a row that is already archived is a successful nothing',
+  design: 'set_transactions_archived 20260805145035:206-212 and its comment at :169-171',
+  consequence: 'an archive that runs twice reports an error the user cannot act on',
+  parity: 'match',
+
+  setup: {
+    sqlite: `UPDATE transactions SET archived = 1 WHERE id = '${CORNER_SHOP}';`,
+    postgres: `UPDATE public.transactions SET archived = true WHERE id = '${CORNER_SHOP}';`,
+  },
+  command: {
+    verb: 'set_transactions_archived',
+    payload: { ids: [CORNER_SHOP], archived: true, user_id: USER },
+  },
+  expect: { outcome: 'ok' },
+
+  state: [
+    storedFlag(CORNER_SHOP, 'archived', 'yes'),
+    auditShape('NONE'),
+    balanceIdentityHolds(EVERYDAY),
+  ],
+};

--- a/scripts/local-sqlite/verb-specs/archived-an-id-nobody-has-loses-the-whole-call.spec.mjs
+++ b/scripts/local-sqlite/verb-specs/archived-an-id-nobody-has-loses-the-whole-call.spec.mjs
@@ -1,0 +1,40 @@
+import { USER, EVERYDAY, CORNER_SHOP, MARKED_ROW, everyStateOfCommitment,
+  storedFlag, auditShape, archivedRowsIn, balanceIdentityHolds } from './_shared.mjs';
+
+// THE OPPOSITE SHAPE FROM THE TICK, in the same schema, and both are ported.
+//
+// `count(DISTINCT p_ids)` against the rows found and owned: one bad id loses the
+// WHOLE call, including the good ids beside it. `set_transactions_cleared` skips
+// a bad id in silence. The RPC's own comment says why the pair is right: an
+// archive is a decision about a named row, and silently archiving four of five
+// would leave the fifth on screen with no explanation.
+//
+// The good id in this payload is what makes the spec discriminate: a port that
+// refused AFTER writing what it could would still name the right refusal, and
+// `stored_archived` on CORNER_SHOP is what catches it.
+export default {
+  invariant: 'A-4',
+  title: 'one id nobody has loses the whole call, including the rows beside it',
+  design: 'set_transactions_archived 20260805145035:195-204',
+  consequence: 'a stale list half-archives a register and reports success',
+  parity: 'match',
+
+  setup: everyStateOfCommitment,
+  command: {
+    verb: 'set_transactions_archived',
+    payload: {
+      ids: [CORNER_SHOP, '70000000-0000-0000-0000-0000000000ff'],
+      archived: true,
+      user_id: USER,
+    },
+  },
+  expect: { outcome: 'refused', error: 'transaction_not_found' },
+
+  state: [
+    storedFlag(CORNER_SHOP, 'archived', 'no'),
+    storedFlag(MARKED_ROW, 'archived', 'no'),
+    archivedRowsIn(EVERYDAY, '0'),
+    auditShape('NONE'),
+    balanceIdentityHolds(EVERYDAY),
+  ],
+};

--- a/scripts/local-sqlite/verb-specs/archived-one-row-is-hidden-and-never-deleted.spec.mjs
+++ b/scripts/local-sqlite/verb-specs/archived-one-row-is-hidden-and-never-deleted.spec.mjs
@@ -1,0 +1,33 @@
+import { USER, EVERYDAY, CORNER_SHOP, storedFlag, rowExists, rowsInAccount,
+  auditRowsForUpdate, balanceOf, balanceIdentityHolds } from './_shared.mjs';
+
+// ARCHIVING IS A VIEW FLAG. The row stays in the table, stays counted in the
+// balance, stays in every report — and is hidden only from the live register.
+//
+// `balance_of` is the assertion that matters and it is not a formality: the
+// Microsoft Money original HARD-DELETED archived rows and adjusted each
+// account's opening balance to compensate, which is the "fragile, unrecoverable
+// operation people were warned off" the soft archive exists to avoid. An engine
+// that deleted, or that moved the opening balance, fails here.
+export default {
+  invariant: 'A-4',
+  title: 'archiving one row hides it and never deletes it',
+  design: 'set_transactions_archived 20260805145035:172-229',
+  consequence: 'tidying the register loses the money the row moved',
+  parity: 'match',
+
+  command: {
+    verb: 'set_transactions_archived',
+    payload: { ids: [CORNER_SHOP], archived: true, user_id: USER },
+  },
+  expect: { outcome: 'ok' },
+
+  state: [
+    storedFlag(CORNER_SHOP, 'archived', 'yes'),
+    rowExists(CORNER_SHOP, '1'),
+    rowsInAccount(EVERYDAY, '1'),
+    auditRowsForUpdate(CORNER_SHOP, '1'),
+    balanceOf(EVERYDAY, '-25.00'),
+    balanceIdentityHolds(EVERYDAY),
+  ],
+};

--- a/scripts/local-sqlite/verb-specs/cleared-a-mark-is-a-working-note-and-settles-nothing.spec.mjs
+++ b/scripts/local-sqlite/verb-specs/cleared-a-mark-is-a-working-note-and-settles-nothing.spec.mjs
@@ -1,0 +1,29 @@
+import { USER, CORNER_SHOP, EVERYDAY, storedFlag, storedTriFlag, auditRowsForUpdate,
+  balanceOf, balanceIdentityHolds } from './_shared.mjs';
+
+// THE RULE THE WHOLE FEATURE RESTS ON. Before 20260810200000 one flag did both
+// jobs, so "Mark all cleared" WAS the reconciliation: leave the screen and the
+// account showed nothing left to do. A tick now says only that the row appeared
+// on a statement somebody is reading.
+//
+// The assertion that matters is `stored_is_reconciled`, and it is `no` rather
+// than `NULL`: the CASE resolves the committed flag on every row it writes, so
+// the ambiguity does not outlive the tick.
+export default {
+  invariant: 'A-1',
+  title: 'a mark is a working note, and it settles nothing',
+  design: 'set_transactions_cleared 20260810200000:143-183 — the CASE is the whole of the C/R split on the write side',
+  consequence: 'ticking rows off a statement silently reconciles the account, and Finalize becomes a button whose only visible effect is a date',
+  parity: 'match',
+
+  command: { verb: 'set_transactions_cleared', payload: { ids: [CORNER_SHOP], cleared: true, user_id: USER } },
+  expect: { outcome: 'ok' },
+
+  state: [
+    storedFlag(CORNER_SHOP, 'is_cleared', 'yes'),
+    storedTriFlag(CORNER_SHOP, 'is_reconciled', 'no'),
+    auditRowsForUpdate(CORNER_SHOP, '1'),
+    balanceOf(EVERYDAY, '-25.00'),
+    balanceIdentityHolds(EVERYDAY),
+  ],
+};

--- a/scripts/local-sqlite/verb-specs/cleared-a-row-already-in-that-state-is-not-written.spec.mjs
+++ b/scripts/local-sqlite/verb-specs/cleared-a-row-already-in-that-state-is-not-written.spec.mjs
@@ -1,0 +1,34 @@
+import { USER, EVERYDAY, MARKED_ROW, everyStateOfCommitment,
+  storedFlag, storedTriFlag, auditShape, updatedDay, balanceIdentityHolds } from './_shared.mjs';
+
+// `is_cleared IS DISTINCT FROM p_cleared` is in the CURSOR, not in the UPDATE,
+// so a row already ticked is not selected at all: no write, no audit entry, and
+// no movement of `updated_at`. The last one is what matters to a file — a
+// re-tick that stamped the row would make it look freshly edited to every backup
+// diff and every future sync.
+//
+// The row's `updated_at` is planted in 2019 by `everyStateOfCommitment` so that
+// "did not move" is observable rather than a matter of clock resolution — and
+// planted ON THE INSERT, because the cloud's BEFORE UPDATE stamp would overwrite
+// a planted UPDATE with today. That was measured here, by writing it the other
+// way first: Postgres answered `2026-08-11` for a verb that had not touched the
+// row.
+export default {
+  invariant: 'U-1',
+  title: 'ticking a row that is already ticked writes nothing at all',
+  design: 'set_transactions_cleared 20260810200000:157-162 — the cursor, not the update',
+  consequence: 'every re-tick rewrites the row and its audit trail to say the value did not change',
+  parity: 'match',
+
+  setup: everyStateOfCommitment,
+  command: { verb: 'set_transactions_cleared', payload: { ids: [MARKED_ROW], cleared: true, user_id: USER } },
+  expect: { outcome: 'ok' },
+
+  state: [
+    storedFlag(MARKED_ROW, 'is_cleared', 'yes'),
+    storedTriFlag(MARKED_ROW, 'is_reconciled', 'no'),
+    updatedDay('transactions', MARKED_ROW, '2019-01-01'),
+    auditShape('NONE'),
+    balanceIdentityHolds(EVERYDAY),
+  ],
+};

--- a/scripts/local-sqlite/verb-specs/cleared-a-row-from-before-the-split-is-given-an-explicit-answer.spec.mjs
+++ b/scripts/local-sqlite/verb-specs/cleared-a-row-from-before-the-split-is-given-an-explicit-answer.spec.mjs
@@ -1,0 +1,29 @@
+import { USER, EVERYDAY, PRE_SPLIT_ROW, everyStateOfCommitment,
+  storedFlag, storedTriFlag, balanceIdentityHolds } from './_shared.mjs';
+
+// COALESCE(is_reconciled, is_cleared), and the migration's reason for it: a NULL
+// means "ask is_cleared", and the rows this loop touches are BY DEFINITION the
+// ones whose is_cleared is changing — so writing the resolved answer down is
+// what stops the ambiguity outliving the change.
+//
+// The row starts (cleared, NULL) — history, which every screen reads as
+// reconciled. Un-ticking it must therefore leave it explicitly NOT committed,
+// not still-unanswered: `no`, and the difference between `no` and `NULL` here is
+// exactly what `storedTriFlag` exists to see.
+export default {
+  invariant: 'A-1',
+  title: 'un-ticking a row from before the split answers the question it never answered',
+  design: 'set_transactions_cleared 20260810200000:138-141 — "writing the resolved answer down is what stops the ambiguity outliving the change"',
+  consequence: 'pre-split rows keep answering "ask the tick" after the tick has gone, so the same row reads reconciled or not depending on which screen asks',
+  parity: 'match',
+
+  setup: everyStateOfCommitment,
+  command: { verb: 'set_transactions_cleared', payload: { ids: [PRE_SPLIT_ROW], cleared: false, user_id: USER } },
+  expect: { outcome: 'ok' },
+
+  state: [
+    storedFlag(PRE_SPLIT_ROW, 'is_cleared', 'no'),
+    storedTriFlag(PRE_SPLIT_ROW, 'is_reconciled', 'no'),
+    balanceIdentityHolds(EVERYDAY),
+  ],
+};

--- a/scripts/local-sqlite/verb-specs/cleared-marking-an-old-row-does-not-archive-it.spec.mjs
+++ b/scripts/local-sqlite/verb-specs/cleared-marking-an-old-row-does-not-archive-it.spec.mjs
@@ -1,0 +1,38 @@
+import { USER, EVERYDAY, CORNER_SHOP,
+  storedFlag, storedTriFlag, archivedRowsIn, balanceIdentityHolds } from './_shared.mjs';
+
+// A-3 FROM THE OTHER END, and the reason the sweep moved.
+//
+// The row is dated 2024-03-01 and the cutoff planted here is 2024-06-30, so it
+// is inside the archived period. Under the old trigger — `AFTER UPDATE OF
+// is_cleared` — ticking it made it VANISH from the very list the ticking happens
+// on, and a working mark is reversible: a row you cannot see is a row you cannot
+// untick. The trigger now fires on the committed flag, which only a finalize
+// writes.
+//
+// Its twin is `specs/a3-reconciling-an-old-row-archives-it`, which asserts the
+// sweep DOES fire when the same row is committed. Neither is meaningful without
+// the other: one alone passes against a trigger that never fires, the other
+// alone against a trigger that always does.
+export default {
+  invariant: 'A-3',
+  title: 'marking an old row does not archive it',
+  design: 'sweep_reconciled_into_archive as restated by 20260810200000:331-361 — "ticking a row must never make it disappear from the screen the ticking happens on"',
+  consequence: 'rows vanish from the reconciliation list as they are ticked, and a mistaken tick cannot be taken back',
+  parity: 'match',
+
+  setup: {
+    sqlite: `UPDATE accounts SET archive_through_date = '2024-06-30' WHERE id = '${EVERYDAY}';`,
+    postgres: `UPDATE public.accounts SET archive_through_date = '2024-06-30' WHERE id = '${EVERYDAY}';`,
+  },
+  command: { verb: 'set_transactions_cleared', payload: { ids: [CORNER_SHOP], cleared: true, user_id: USER } },
+  expect: { outcome: 'ok' },
+
+  state: [
+    storedFlag(CORNER_SHOP, 'is_cleared', 'yes'),
+    storedTriFlag(CORNER_SHOP, 'is_reconciled', 'no'),
+    storedFlag(CORNER_SHOP, 'archived', 'no'),
+    archivedRowsIn(EVERYDAY, '0'),
+    balanceIdentityHolds(EVERYDAY),
+  ],
+};

--- a/scripts/local-sqlite/verb-specs/cleared-somebody-elses-row-is-skipped-in-silence.spec.mjs
+++ b/scripts/local-sqlite/verb-specs/cleared-somebody-elses-row-is-skipped-in-silence.spec.mjs
@@ -1,0 +1,27 @@
+import { USER, THEIR_ROW, SOMEONE_ELSES_ACCOUNT, secondUser, strangersRow, setups,
+  storedFlag, auditShape, balanceIdentityHolds } from './_shared.mjs';
+
+// The owner clause is inside the cursor, so a foreign row is not selected: no
+// error, no count, no audit row. That is the bulk-verb shape — the same one
+// `apply_category_to_uncategorized` has — and it is the OPPOSITE of
+// `set_transactions_archived` beside it, which raises `transaction_not_found`
+// for exactly this case. Both behaviours are the cloud's and both are ported:
+// a tick is a bulk gesture over a list a screen built, and an archive is a
+// decision about a named row.
+export default {
+  invariant: 'X-6',
+  title: 'a row belonging to somebody else is not ticked and not mentioned',
+  design: 'set_transactions_cleared 20260810200000:160 — (p_user_id IS NULL OR user_id = p_user_id) inside the cursor',
+  consequence: 'a mis-routed owner id marks another login\'s statement off',
+  parity: 'match',
+
+  setup: setups(secondUser, strangersRow),
+  command: { verb: 'set_transactions_cleared', payload: { ids: [THEIR_ROW], cleared: true, user_id: USER } },
+  expect: { outcome: 'ok' },
+
+  state: [
+    storedFlag(THEIR_ROW, 'is_cleared', 'no'),
+    auditShape('NONE'),
+    balanceIdentityHolds(SOMEONE_ELSES_ACCOUNT),
+  ],
+};

--- a/scripts/local-sqlite/verb-specs/cleared-unmarking-takes-any-commitment-with-it.spec.mjs
+++ b/scripts/local-sqlite/verb-specs/cleared-unmarking-takes-any-commitment-with-it.spec.mjs
@@ -1,0 +1,31 @@
+import { USER, EVERYDAY, COMMITTED_ROW, everyStateOfCommitment,
+  storedFlag, storedTriFlag, auditRowsForUpdate, balanceIdentityHolds } from './_shared.mjs';
+
+// The other half of the CASE, and the reason it is a CASE. `is_reconciled`
+// IMPLIES `is_cleared`: a row that is not ticked cannot be a row a statement was
+// balanced against, and the pair (committed, unmarked) would put the cleared
+// balance and the reconciled set permanently out of step.
+//
+// The local file makes that a CHECK as well
+// (`transactions_reconciled_implies_cleared`), so this call has to write both
+// columns in ONE statement — which it does, and which is why the constraint does
+// not fire here. A port that unticked first and cleared the commitment second
+// would be refused by its own file, and this spec is what would say so.
+export default {
+  invariant: 'A-1',
+  title: 'unmarking takes any commitment with it',
+  design: 'set_transactions_cleared 20260810200000:130-136 and :166-169 — the ELSE branch',
+  consequence: 'a row stays committed while un-ticked, so the cleared balance and the reconciled set drift apart for good',
+  parity: 'match',
+
+  setup: everyStateOfCommitment,
+  command: { verb: 'set_transactions_cleared', payload: { ids: [COMMITTED_ROW], cleared: false, user_id: USER } },
+  expect: { outcome: 'ok' },
+
+  state: [
+    storedFlag(COMMITTED_ROW, 'is_cleared', 'no'),
+    storedTriFlag(COMMITTED_ROW, 'is_reconciled', 'no'),
+    auditRowsForUpdate(COMMITTED_ROW, '1'),
+    balanceIdentityHolds(EVERYDAY),
+  ],
+};

--- a/scripts/local-sqlite/verb-specs/reconcile-a-zero-ending-balance-is-a-figure.spec.mjs
+++ b/scripts/local-sqlite/verb-specs/reconcile-a-zero-ending-balance-is-a-figure.spec.mjs
@@ -1,0 +1,46 @@
+import { USER, EVERYDAY, everyStateOfCommitment, accountMoney,
+  balanceOf, balanceIdentityHolds } from './_shared.mjs';
+
+// A real account in this product is swept to zero every night, so its correct
+// statement balance is exactly £0.00. An engine that treated 0 as "nothing was
+// confirmed" would refuse to finish that reconciliation for ever — which is why
+// the column is nullable and why `ending_balance_required` fires on absence
+// rather than on falsiness.
+//
+// The stored figure is asserted as `0.00` and not as `NULL`, which is the whole
+// distinction: `accountMoney` renders the two differently on purpose.
+export default {
+  invariant: 'A-2',
+  title: 'a zero ending balance is a figure, not "none"',
+  design: 'finalize_reconciliation 20260810200000:117-121 — "£0.00 is a real statement balance … so the two cannot share a representation"',
+  consequence: 'an account that really closes at zero can never be finished, and its last statement balance reads as "never reconciled"',
+  parity: 'match',
+
+  setup: everyStateOfCommitment,
+  command: {
+    verb: 'finalize_reconciliation',
+    payload: { account_id: EVERYDAY, ending_balance: '0', reconciled_on: '2024-03-31', user_id: USER },
+  },
+  expect: { outcome: 'ok' },
+  result: { reconciled: 1 },
+
+  // The RPC ECHOES its own argument — `jsonb_build_object('ending_balance',
+  // p_ending_balance)` — and `p_ending_balance` is an unconstrained `numeric`,
+  // so a payload of "0" comes back `0` and a payload of "-28.00" comes back
+  // `-28.00`: the scale is the caller's literal's. The crate answers through
+  // `Money`, which is minor units and always renders two places, so it says
+  // "0.00". MEASURED here rather than assumed, and it is a difference in the
+  // ECHO alone: `account_last_reconciled_balance` below is `0.00` on both
+  // engines, because that value went through numeric(20,2) on one side and
+  // INTEGER minor units on the other. Excluded from the row comparison for this
+  // spec only, where the two spellings of zero really do differ.
+  rowDivergence: {
+    ending_balance: 'the cloud echoes the caller\'s own numeric literal, so "0" keeps its scale; Money always renders pennies. The STORED figure agrees to the penny and is asserted below.',
+  },
+
+  state: [
+    accountMoney(EVERYDAY, 'last_reconciled_balance', '0.00'),
+    balanceOf(EVERYDAY, '-28.00'),
+    balanceIdentityHolds(EVERYDAY),
+  ],
+};

--- a/scripts/local-sqlite/verb-specs/reconcile-an-account-that-is-not-yours-is-refused.spec.mjs
+++ b/scripts/local-sqlite/verb-specs/reconcile-an-account-that-is-not-yours-is-refused.spec.mjs
@@ -1,0 +1,39 @@
+import { USER, THEIR_ROW, SOMEONE_ELSES_ACCOUNT, secondUser, strangersRow, setups,
+  storedTriFlag, storedFlag, accountText, auditShape, balanceIdentityHolds } from './_shared.mjs';
+
+// The account lookup is `id = p_account_id AND user_id = p_user_id`, so another
+// login's account is not found rather than found-and-refused — one refusal for
+// two cases, which is the cloud's own shape and the reason its message says "or
+// not owned".
+//
+// What makes this spec discriminate rather than pass on any refusal at all: the
+// stranger's row is ticked in the setup and asserted UNCOMMITTED afterwards, and
+// their account is asserted to have no reconciliation date. A verb that
+// committed the working set first and checked ownership second would refuse with
+// exactly the right word and still have settled somebody else's statement.
+export default {
+  invariant: 'X-6',
+  title: 'finalizing an account that is not yours is refused, and settles nothing of theirs',
+  design: 'finalize_reconciliation 20260810200000:232-238',
+  consequence: 'a mis-routed owner id finishes a reconciliation in another login\'s account',
+  parity: 'match',
+
+  setup: setups(secondUser, strangersRow, {
+    sqlite: `UPDATE transactions SET is_cleared = 1, is_reconciled = 0 WHERE id = '${THEIR_ROW}';`,
+    postgres: `UPDATE public.transactions SET is_cleared = true, is_reconciled = false
+                WHERE id = '${THEIR_ROW}';`,
+  }),
+  command: {
+    verb: 'finalize_reconciliation',
+    payload: { account_id: SOMEONE_ELSES_ACCOUNT, ending_balance: '0', user_id: USER },
+  },
+  expect: { outcome: 'refused', error: 'account_not_found_or_not_owned' },
+
+  state: [
+    storedFlag(THEIR_ROW, 'is_cleared', 'yes'),
+    storedTriFlag(THEIR_ROW, 'is_reconciled', 'no'),
+    accountText(SOMEONE_ELSES_ACCOUNT, 'last_reconciled_date', 'NULL'),
+    auditShape('NONE'),
+    balanceIdentityHolds(SOMEONE_ELSES_ACCOUNT),
+  ],
+};

--- a/scripts/local-sqlite/verb-specs/reconcile-committing-an-old-row-archives-it.spec.mjs
+++ b/scripts/local-sqlite/verb-specs/reconcile-committing-an-old-row-archives-it.spec.mjs
@@ -1,0 +1,47 @@
+import { USER, EVERYDAY, MARKED_ROW, COMMITTED_ROW, PRE_SPLIT_ROW, CORNER_SHOP,
+  everyStateOfCommitment, archivedThroughFebruary, setups,
+  storedFlag, storedTriFlag, archivedRowsIn, balanceOf, balanceIdentityHolds } from './_shared.mjs';
+
+// A-3 THROUGH THE VERB, which is where a person actually meets it.
+//
+// The account is archived through 2024-02-28. MARKED_ROW is dated 2024-01-15,
+// inside that period, so committing it drops it off the live register in the
+// same call — which is what "reconciling old items keeps them from lingering"
+// means. CORNER_SHOP is dated 2024-03-01, outside it, and stays live even after
+// it is committed... except that it is not ticked, so it is not committed at
+// all: the working set is what the sweep can reach.
+//
+// The two engines get here differently and the end state is identical: the cloud
+// assigns `NEW.archived` in a BEFORE trigger, SQLite issues a second UPDATE from
+// an AFTER trigger. `archived_rows_in` is asserted as a COUNT so a port that
+// archived MORE than the sweep should cannot pass by having the named row come
+// out right.
+export default {
+  invariant: 'A-3',
+  title: 'committing a row that is older than the account cutoff archives it',
+  design: 'finalize_reconciliation 20260810200000:248-252 writing is_reconciled, and sweep_reconciled_into_archive :336-361 reading it',
+  consequence: 'old reconciled items linger in the live register for ever, and the register stops matching the period the user thinks they are looking at',
+  parity: 'match',
+
+  setup: setups(everyStateOfCommitment, archivedThroughFebruary),
+  command: {
+    verb: 'finalize_reconciliation',
+    payload: { account_id: EVERYDAY, ending_balance: '-28.00', reconciled_on: '2024-03-31', user_id: USER },
+  },
+  expect: { outcome: 'ok' },
+  result: { reconciled: 1 },
+
+  state: [
+    storedFlag(MARKED_ROW, 'archived', 'yes'),
+    storedTriFlag(MARKED_ROW, 'is_reconciled', 'yes'),
+    // Already committed before this call, so no transition happened and the
+    // sweep — which fires on the CHANGE — never looked at it.
+    storedFlag(COMMITTED_ROW, 'archived', 'no'),
+    // Pre-split history: not in the working set, so not committed and not swept.
+    storedFlag(PRE_SPLIT_ROW, 'archived', 'no'),
+    storedFlag(CORNER_SHOP, 'archived', 'no'),
+    archivedRowsIn(EVERYDAY, '1'),
+    balanceOf(EVERYDAY, '-28.00'),
+    balanceIdentityHolds(EVERYDAY),
+  ],
+};

--- a/scripts/local-sqlite/verb-specs/reconcile-finalizing-twice-commits-nothing-the-second-time.spec.mjs
+++ b/scripts/local-sqlite/verb-specs/reconcile-finalizing-twice-commits-nothing-the-second-time.spec.mjs
@@ -1,0 +1,45 @@
+import { USER, EVERYDAY, MARKED_ROW, everyStateOfCommitment, storedTriFlag,
+  accountMoney, accountText, balanceIdentityHolds } from './_shared.mjs';
+
+// The second call has an empty working set — everything ticked was committed by
+// the first — so it converts nothing and says so. What it DOES do is re-state
+// the account's record: a reconciliation finished against a new statement
+// records that statement's figure and day even when no row changed hands.
+//
+// Both halves matter. A verb that counted the rows it had already committed
+// would tell the user it had done work it had not; one that refused to re-stamp
+// an account with nothing left to convert would leave the next reconciliation
+// opening at a stale figure.
+export default {
+  invariant: 'A-2',
+  title: 'finalizing twice commits nothing the second time, and re-states the figure',
+  design: 'finalize_reconciliation 20260810200000:240-266 — the loop and the account UPDATE are independent',
+  consequence: 'a repeated finish either double-counts the work or refuses to record the newest statement',
+  parity: 'match',
+
+  setup: {
+    sqlite: `${everyStateOfCommitment.sqlite}
+      UPDATE transactions SET is_reconciled = 1 WHERE id = '${MARKED_ROW}';
+      UPDATE accounts SET last_reconciled_date = '2024-03-31',
+                          last_reconciled_balance_minor = -2800
+       WHERE id = '${EVERYDAY}';`,
+    postgres: `${everyStateOfCommitment.postgres}
+      UPDATE public.transactions SET is_reconciled = true WHERE id = '${MARKED_ROW}';
+      UPDATE public.accounts SET last_reconciled_date = '2024-03-31',
+                                 last_reconciled_balance = -28.00
+       WHERE id = '${EVERYDAY}';`,
+  },
+  command: {
+    verb: 'finalize_reconciliation',
+    payload: { account_id: EVERYDAY, ending_balance: '-30.50', reconciled_on: '2024-04-30', user_id: USER },
+  },
+  expect: { outcome: 'ok' },
+  result: { reconciled: 0, ending_balance: '-30.50', reconciled_on: '2024-04-30' },
+
+  state: [
+    storedTriFlag(MARKED_ROW, 'is_reconciled', 'yes'),
+    accountText(EVERYDAY, 'last_reconciled_date', '2024-04-30'),
+    accountMoney(EVERYDAY, 'last_reconciled_balance', '-30.50'),
+    balanceIdentityHolds(EVERYDAY),
+  ],
+};

--- a/scripts/local-sqlite/verb-specs/reconcile-it-commits-exactly-the-working-set.spec.mjs
+++ b/scripts/local-sqlite/verb-specs/reconcile-it-commits-exactly-the-working-set.spec.mjs
@@ -1,0 +1,52 @@
+import { USER, EVERYDAY, CORNER_SHOP, MARKED_ROW, COMMITTED_ROW, PRE_SPLIT_ROW,
+  everyStateOfCommitment, storedTriFlag, storedFlag, auditRowsForUpdate,
+  balanceOf, balanceIdentityHolds } from './_shared.mjs';
+
+// FOUR ROWS, FOUR ANSWERS, and the count is 1.
+//
+//   MARKED_ROW    ticked, not committed  -> converted. This is the working set.
+//   COMMITTED_ROW already committed      -> left alone, and NOT counted again:
+//                                           a second count for it would overstate
+//                                           the work the person just did.
+//   PRE_SPLIT_ROW ticked, NULL           -> LEFT ALONE. `IS NOT DISTINCT FROM
+//                                           false` and not `IS DISTINCT FROM
+//                                           true`: a NULL row is one the old
+//                                           world already called reconciled, and
+//                                           sweeping those in would rewrite,
+//                                           re-audit and re-stamp the whole
+//                                           history of the account the first
+//                                           time anybody finalized it.
+//   CORNER_SHOP   not ticked             -> left alone. Only what was marked is
+//                                           settled.
+//
+// The audit assertion is per row for the same reason: three of the four must
+// have no entry at all, and a count of one across the table would not say which.
+export default {
+  invariant: 'A-2',
+  title: 'finalizing commits exactly the marked rows, and nothing else',
+  design: 'finalize_reconciliation 20260810200000:240-259, and :186-193 for why a NULL row is not in the working set',
+  consequence: 'the first finalize of an account rewrites its entire history, or commits rows nobody ticked',
+  parity: 'match',
+
+  setup: everyStateOfCommitment,
+  command: {
+    verb: 'finalize_reconciliation',
+    payload: { account_id: EVERYDAY, ending_balance: '-28.00', reconciled_on: '2024-03-31', user_id: USER },
+  },
+  expect: { outcome: 'ok' },
+  result: { reconciled: 1 },
+
+  state: [
+    storedTriFlag(MARKED_ROW, 'is_reconciled', 'yes'),
+    storedTriFlag(COMMITTED_ROW, 'is_reconciled', 'yes'),
+    storedTriFlag(PRE_SPLIT_ROW, 'is_reconciled', 'NULL'),
+    storedTriFlag(CORNER_SHOP, 'is_reconciled', 'no'),
+    storedFlag(CORNER_SHOP, 'is_cleared', 'no'),
+    auditRowsForUpdate(MARKED_ROW, '1'),
+    auditRowsForUpdate(COMMITTED_ROW, '0'),
+    auditRowsForUpdate(PRE_SPLIT_ROW, '0'),
+    auditRowsForUpdate(CORNER_SHOP, '0'),
+    balanceOf(EVERYDAY, '-28.00'),
+    balanceIdentityHolds(EVERYDAY),
+  ],
+};

--- a/scripts/local-sqlite/verb-specs/reconcile-it-records-the-figure-it-was-settled-against.spec.mjs
+++ b/scripts/local-sqlite/verb-specs/reconcile-it-records-the-figure-it-was-settled-against.spec.mjs
@@ -1,0 +1,36 @@
+import { USER, EVERYDAY, everyStateOfCommitment, accountText, accountMoney,
+  balanceOf, balanceIdentityHolds } from './_shared.mjs';
+
+// "Reconciled on the 3rd" without "against what" is a claim nobody can check
+// afterwards, and the next reconciliation has to open at the figure this one
+// finished on. Both go on the ACCOUNT, in the same transaction as the rows.
+//
+// `balance` is asserted UNMOVED beside them, which is the point of the whole
+// pairing: `last_reconciled_balance` is a RECORD of what a person confirmed, not
+// an amount added to anything and not a figure the ledger is reconciled TO. A
+// difference between the two is what the screen exists to show, and an engine
+// that closed it silently would be inventing money.
+export default {
+  invariant: 'A-2',
+  title: 'it records the day and the figure the reconciliation was settled against',
+  design: 'finalize_reconciliation 20260810200000:261-266, and :195-199 for why the figure is recorded at all',
+  consequence: 'the next reconciliation opens at a figure that is not the one this one finished on, and nobody can check what was agreed',
+  parity: 'match',
+
+  setup: everyStateOfCommitment,
+  command: {
+    verb: 'finalize_reconciliation',
+    payload: { account_id: EVERYDAY, ending_balance: '-28.00', reconciled_on: '2024-03-31', user_id: USER },
+  },
+  expect: { outcome: 'ok' },
+  result: { ending_balance: '-28.00', reconciled_on: '2024-03-31' },
+
+  state: [
+    accountText(EVERYDAY, 'last_reconciled_date', '2024-03-31'),
+    accountMoney(EVERYDAY, 'last_reconciled_balance', {
+      sqlite: '-28.00', postgres: '-28.00',
+    }),
+    balanceOf(EVERYDAY, '-28.00'),
+    balanceIdentityHolds(EVERYDAY),
+  ],
+};

--- a/scripts/local-sqlite/verb-specs/reconcile-with-no-ending-balance-is-refused.spec.mjs
+++ b/scripts/local-sqlite/verb-specs/reconcile-with-no-ending-balance-is-refused.spec.mjs
@@ -1,0 +1,29 @@
+import { USER, EVERYDAY, MARKED_ROW, everyStateOfCommitment, storedTriFlag,
+  accountText, accountMoney, auditShape, balanceIdentityHolds } from './_shared.mjs';
+
+// The ending balance is the whole point of finishing, and a NULL one would
+// record "reconciled against nothing". Refused FIRST, before the account is even
+// looked up, so a finalize that cannot say what it settled against changes
+// nothing at all — no row committed, no date stamped, no audit entry.
+export default {
+  invariant: 'A-2',
+  title: 'finalizing against no figure at all is refused, and changes nothing',
+  design: 'finalize_reconciliation 20260810200000:226-230',
+  consequence: 'an account records a reconciliation nobody can check, and the next one opens at nothing',
+  parity: 'match',
+
+  setup: everyStateOfCommitment,
+  command: {
+    verb: 'finalize_reconciliation',
+    payload: { account_id: EVERYDAY, reconciled_on: '2024-03-31', user_id: USER },
+  },
+  expect: { outcome: 'refused', error: 'ending_balance_required' },
+
+  state: [
+    storedTriFlag(MARKED_ROW, 'is_reconciled', 'no'),
+    accountText(EVERYDAY, 'last_reconciled_date', 'NULL'),
+    accountMoney(EVERYDAY, 'last_reconciled_balance', 'NULL'),
+    auditShape('NONE'),
+    balanceIdentityHolds(EVERYDAY),
+  ],
+};

--- a/scripts/local-sqlite/verb-specs/reconcile-with-no-owner-there-is-no-account-to-finish.spec.mjs
+++ b/scripts/local-sqlite/verb-specs/reconcile-with-no-owner-there-is-no-account-to-finish.spec.mjs
@@ -1,0 +1,32 @@
+import { EVERYDAY, MARKED_ROW, everyStateOfCommitment, storedTriFlag,
+  accountText, auditShape, balanceIdentityHolds } from './_shared.mjs';
+
+// THE ONE VERB IN THIS CRATE WHERE AN ABSENT OWNER IS NOT A STAND-DOWN.
+//
+// Everywhere else `p_user_id IS NULL` means "name no owner" — defence in depth
+// on top of RLS, deliberately optional. `finalize_reconciliation`'s first
+// argument has no default and its lookup is a plain equality, so a NULL owner
+// matches no account and the call is refused. Ported as the SQL behaves rather
+// than as the family reads: a port that let an absent owner through here would
+// finalize an account belonging to whoever the id happened to name.
+export default {
+  invariant: 'X-6',
+  title: 'with no owner named there is no account to finish, and it is refused',
+  design: 'finalize_reconciliation 20260810200000:209-238 — p_user_id has no DEFAULT and the lookup is an equality',
+  consequence: 'a call that forgot to say whose ledger it is finishes somebody\'s reconciliation anyway',
+  parity: 'match',
+
+  setup: everyStateOfCommitment,
+  command: {
+    verb: 'finalize_reconciliation',
+    payload: { account_id: EVERYDAY, ending_balance: '-28.00' },
+  },
+  expect: { outcome: 'refused', error: 'account_not_found_or_not_owned' },
+
+  state: [
+    storedTriFlag(MARKED_ROW, 'is_reconciled', 'no'),
+    accountText(EVERYDAY, 'last_reconciled_date', 'NULL'),
+    auditShape('NONE'),
+    balanceIdentityHolds(EVERYDAY),
+  ],
+};

--- a/scripts/local-sqlite/verb-specs/unarchive-a-row-that-comes-back-is-still-committed.spec.mjs
+++ b/scripts/local-sqlite/verb-specs/unarchive-a-row-that-comes-back-is-still-committed.spec.mjs
@@ -1,0 +1,47 @@
+import { USER, EVERYDAY, COMMITTED_ROW, PRE_SPLIT_ROW,
+  everyStateOfCommitment, archivedThroughFebruary, setups,
+  storedFlag, storedTriFlag, archivedRowsIn, balanceIdentityHolds } from './_shared.mjs';
+
+// UNARCHIVING IS A DECISION ABOUT WHAT THE REGISTER SHOWS, AND NOTHING ELSE.
+//
+// The commitment is a fact about a statement that was balanced; bringing a row
+// back into view does not un-settle the statement it was reconciled against. A
+// verb that cleared `is_reconciled` here would silently re-open every finished
+// reconciliation the account has ever had, and the account's own
+// `last_reconciled_balance` would then record a figure no set of rows agrees
+// with.
+//
+// The three-valued assertion is what makes this bite: `yes` for the committed
+// row and `NULL` for the pre-split one. A port that wrote 0 across the rows it
+// touched would leave both reading "explicitly not committed", which
+// `storedFlag` could not tell from the second case at all.
+//
+// The reverse direction is the schema's rather than this verb's: the rows come
+// back with `is_reconciled` untouched, so no `AFTER UPDATE OF is_reconciled`
+// fires and the sweep cannot re-archive them in the same breath.
+export default {
+  invariant: 'A-4',
+  title: 'a row that comes back out of the archive is still committed',
+  design: 'unarchive_account 20260721130000:103-106 — two columns, and is_reconciled is not one of them',
+  consequence: 'every finished reconciliation in the account is silently re-opened by a click that was only meant to show the rows again',
+  parity: 'match',
+
+  setup: setups(everyStateOfCommitment, archivedThroughFebruary, {
+    sqlite: `UPDATE transactions SET archived = 1
+              WHERE id IN ('${COMMITTED_ROW}', '${PRE_SPLIT_ROW}');`,
+    postgres: `UPDATE public.transactions SET archived = true
+                WHERE id IN ('${COMMITTED_ROW}', '${PRE_SPLIT_ROW}');`,
+  }),
+  command: { verb: 'unarchive_account', payload: { account_id: EVERYDAY, user_id: USER } },
+  expect: { outcome: 'ok' },
+  result: { unarchived: 2 },
+
+  state: [
+    storedTriFlag(COMMITTED_ROW, 'is_reconciled', 'yes'),
+    storedTriFlag(PRE_SPLIT_ROW, 'is_reconciled', 'NULL'),
+    storedFlag(COMMITTED_ROW, 'is_cleared', 'yes'),
+    storedFlag(COMMITTED_ROW, 'archived', 'no'),
+    archivedRowsIn(EVERYDAY, '0'),
+    balanceIdentityHolds(EVERYDAY),
+  ],
+};

--- a/scripts/local-sqlite/verb-specs/unarchive-an-account-that-is-not-yours-is-a-silent-nothing.spec.mjs
+++ b/scripts/local-sqlite/verb-specs/unarchive-an-account-that-is-not-yours-is-a-silent-nothing.spec.mjs
@@ -1,0 +1,46 @@
+import { USER, THEIR_ROW, SOMEONE_ELSES_ACCOUNT, secondUser, strangersRow, setups,
+  storedFlag, accountText, auditShape, balanceIdentityHolds } from './_shared.mjs';
+
+// THE VERB WITH NO REFUSAL AT ALL, and it is traced rather than assumed: the RPC
+// does not look the account up, does not check FOUND, and raises nothing. It
+// issues two UPDATEs whose WHERE clauses carry the owner, and answers with a
+// count.
+//
+// So somebody else's account is `{unarchived: 0}` and no error — the OPPOSITE
+// decision from `archive_transactions_before` beside it, which raises
+// `account_not_found`, twenty lines apart in the same migration. Reproduced
+// rather than smoothed over, because a port that invented a refusal here would
+// turn a silent no-op into an error dialog nobody has ever seen.
+//
+// The stranger's row is archived in the setup and asserted STILL archived: the
+// answer is zero because the WHERE clause matched nothing, not because the verb
+// declined to run.
+export default {
+  invariant: 'X-6',
+  title: 'unarchiving an account that is not yours is a silent nothing',
+  design: 'unarchive_account 20260721130000:100-112 — no lookup, no FOUND check, no RAISE',
+  consequence: 'a mis-routed owner id brings another login\'s archived history back into their register',
+  parity: 'match',
+
+  setup: setups(secondUser, strangersRow, {
+    sqlite: `UPDATE transactions SET archived = 1 WHERE id = '${THEIR_ROW}';
+             UPDATE accounts SET archive_through_date = '2025-01-01'
+              WHERE id = '${SOMEONE_ELSES_ACCOUNT}';`,
+    postgres: `UPDATE public.transactions SET archived = true WHERE id = '${THEIR_ROW}';
+               UPDATE public.accounts SET archive_through_date = '2025-01-01'
+                WHERE id = '${SOMEONE_ELSES_ACCOUNT}';`,
+  }),
+  command: {
+    verb: 'unarchive_account',
+    payload: { account_id: SOMEONE_ELSES_ACCOUNT, user_id: USER },
+  },
+  expect: { outcome: 'ok' },
+  result: { unarchived: 0 },
+
+  state: [
+    storedFlag(THEIR_ROW, 'archived', 'yes'),
+    accountText(SOMEONE_ELSES_ACCOUNT, 'archive_through_date', '2025-01-01'),
+    auditShape('NONE'),
+    balanceIdentityHolds(SOMEONE_ELSES_ACCOUNT),
+  ],
+};

--- a/scripts/local-sqlite/verb-specs/unarchive-it-brings-the-rows-back-and-forgets-the-cutoff.spec.mjs
+++ b/scripts/local-sqlite/verb-specs/unarchive-it-brings-the-rows-back-and-forgets-the-cutoff.spec.mjs
@@ -1,0 +1,41 @@
+import { USER, EVERYDAY, COMMITTED_ROW, PRE_SPLIT_ROW, MARKED_ROW,
+  everyStateOfCommitment, archivedThroughFebruary, setups,
+  storedFlag, archivedRowsIn, accountText, auditShape,
+  balanceOf, balanceIdentityHolds } from './_shared.mjs';
+
+// "One click, because nothing ever left." The rows come back and the account's
+// cutoff is cleared in the same call — both halves matter, because a cutoff left
+// behind would have the sweep re-hide every row the next time one was committed.
+//
+// The setup archives two rows by hand rather than by calling the archive verb,
+// so this spec measures ONE operation. `audit_shape` is NONE for
+// `archive_transactions_before`'s reason: neither of the two bulk archive RPCs
+// writes an audit row, and the port reproduces the RPC rather than tidying it.
+export default {
+  invariant: 'A-4',
+  title: 'unarchiving brings the rows back and forgets the cutoff',
+  design: 'unarchive_account 20260721130000:92-114 — untouched by the marking migration',
+  consequence: 'history stays hidden, or comes back only to be swept away again by a cutoff nobody cleared',
+  parity: 'match',
+
+  setup: setups(everyStateOfCommitment, archivedThroughFebruary, {
+    sqlite: `UPDATE transactions SET archived = 1
+              WHERE id IN ('${COMMITTED_ROW}', '${PRE_SPLIT_ROW}');`,
+    postgres: `UPDATE public.transactions SET archived = true
+                WHERE id IN ('${COMMITTED_ROW}', '${PRE_SPLIT_ROW}');`,
+  }),
+  command: { verb: 'unarchive_account', payload: { account_id: EVERYDAY, user_id: USER } },
+  expect: { outcome: 'ok' },
+  result: { unarchived: 2 },
+
+  state: [
+    storedFlag(COMMITTED_ROW, 'archived', 'no'),
+    storedFlag(PRE_SPLIT_ROW, 'archived', 'no'),
+    storedFlag(MARKED_ROW, 'archived', 'no'),
+    archivedRowsIn(EVERYDAY, '0'),
+    accountText(EVERYDAY, 'archive_through_date', 'NULL'),
+    auditShape('NONE'),
+    balanceOf(EVERYDAY, '-28.00'),
+    balanceIdentityHolds(EVERYDAY),
+  ],
+};

--- a/scripts/local-sqlite/verb-specs/update-transaction-unticking-a-committed-row.spec.mjs
+++ b/scripts/local-sqlite/verb-specs/update-transaction-unticking-a-committed-row.spec.mjs
@@ -1,0 +1,48 @@
+import { USER, EVERYDAY, COMMITTED_ROW, everyStateOfCommitment,
+  storedFlag, storedTriFlag, balanceIdentityHolds } from './_shared.mjs';
+
+// THE DIVERGENCE THE C/R SPLIT CREATES, measured rather than discovered later.
+//
+// `is_reconciled` implies `is_cleared`. The cloud keeps that rule in ONE
+// function — set_transactions_cleared's CASE — and its own migration ships a
+// verification query (7) whose whole job is to go and find rows in the state
+// nothing stops the update RPC from producing. `update_transaction_atomic` sets
+// is_cleared from the patch and never touches is_reconciled, so unticking a
+// committed row leaves exactly that pair behind.
+//
+// The local file makes the rule structural, so the same call is refused by
+// `transactions_reconciled_implies_cleared` and the row is left as it was. That
+// is DESIGN.md §6's argument applied to the newest column in the schema: a rule
+// enforced in one writer is a rule the next writer skips.
+//
+// WHAT IT MEANS FOR THE REGISTER, recorded here because slice 27 is what will
+// meet it: there is no `unreconcile` operation in the seam on EITHER engine, so
+// the local answer is "a committed row stays ticked" — which is Money's own
+// behaviour, and which the tick affordance has to know before it offers itself.
+// The way to un-tick a committed row locally is to unmark it through
+// `set_transactions_cleared`, which clears both flags in one statement and is
+// accepted.
+export default {
+  invariant: 'A-1',
+  title: 'unticking a committed row: the cloud stores the pair its own verification hunts for, the file refuses it',
+  design: '20260810200000:130-136 states the rule and :428-433 is the query that looks for breaches of it; update_transaction_atomic 20260808100000:282-375 does not carry it',
+  consequence: 'the cleared balance and the reconciled set drift apart permanently, and no screen can tell which is right',
+  parity: 'divergent',
+  reason: 'the cloud enforces "committed implies marked" inside set_transactions_cleared alone, so an ordinary edit can break it and the migration ships a query to find the rows afterwards; schema.sql makes it a CHECK, so the same edit is refused and the row is unchanged',
+
+  setup: everyStateOfCommitment,
+  command: {
+    verb: 'update_transaction',
+    payload: { id: COMMITTED_ROW, patch: { is_cleared: false }, user_id: USER },
+  },
+  expect: {
+    sqlite: { outcome: 'refused', error: 'transactions_reconciled_implies_cleared' },
+    postgres: { outcome: 'ok' },
+  },
+
+  state: [
+    storedFlag(COMMITTED_ROW, 'is_cleared', { sqlite: 'yes', postgres: 'no' }),
+    storedTriFlag(COMMITTED_ROW, 'is_reconciled', 'yes'),
+    balanceIdentityHolds(EVERYDAY),
+  ],
+};

--- a/src/services/local/localDataPort.ts
+++ b/src/services/local/localDataPort.ts
@@ -146,10 +146,17 @@ import type {
   DataPortTransactionWrites,
   DataPortSplitWrites,
   DataPortTransferWrites,
-  MoneyNumber
+  MoneyNumber,
+  ReconciliationOutcome
 } from '../port/dataPort';
 import type { CoreTransport } from './coreTransport';
-import { countOf, field, listOf, money, rowOf, rowsOf, textOf } from './mappers/values';
+// The ONE encoder, for the two arguments this port sends that are not part of a
+// column table's payload: a finalize's ending balance and the two cutoff days.
+// `encode` is where "money crosses as the number's own decimal text" and "a Date
+// names its UTC day" are written down, and a second spelling of either here is
+// exactly the drift `columns.ts` exists to prevent.
+import { encode } from './mappers/columns';
+import { countOf, day, field, listOf, money, moneyOr, rowOf, rowsOf, textOf } from './mappers/values';
 import {
   toAccount,
   toBalance,
@@ -186,7 +193,9 @@ import {
  * the compiler checks all fifty-six.
  *
  * The planning group is whole, and so is the dismissal group beside it — which
- * this slice had to ADD, because it was never here.
+ * slice 23 had to ADD, because it was never here. The TRANSACTION group is whole
+ * as of this slice: the five reconciliation and archive operations were the last
+ * five names in its `Omit`, and the line is now the bare interface.
  *
  * WORTH READING BEFORE TRUSTING AN `Omit` AGAIN. Until slice 23 this line said
  * `Omit<DataPortPlanningWrites, 'dismissSuggestion' | 'restoreSuggestion'>`, and
@@ -200,9 +209,9 @@ import {
  * a name that is not there and says nothing, so an `Omit` naming operations is a
  * comment that TypeScript does not check — which is the same class of thing
  * `contract.ts`'s `NOT_YET` list exists to replace, and the reason the ratchet is
- * a runtime list rather than a type. The two `Omit`s left above are real: their
- * names are keys of the interfaces they narrow, and the day one stops being one
- * this note is what says how to notice.
+ * a runtime list rather than a type. The one `Omit` left above is real: its name
+ * is a key of the interface it narrows, and the day it stops being one this note
+ * is what says how to notice.
  */
 export type LocalDataPortSurface =
   DataPortReads &
@@ -211,14 +220,7 @@ export type LocalDataPortSurface =
   DataPortBulkWrites &
   DataPortSplitWrites &
   DataPortCapabilityDescriptor &
-  Omit<
-    DataPortTransactionWrites,
-    | 'setTransactionsCleared'
-    | 'finalizeReconciliation'
-    | 'setTransactionArchived'
-    | 'archiveTransactionsBefore'
-    | 'unarchiveAccount'
-  > &
+  DataPortTransactionWrites &
   Omit<DataPortTransferWrites, 'repointTransfer'> &
   DataPortPlanningWrites &
   DataPortDismissalWrites &
@@ -666,6 +668,126 @@ export class LocalDataPort implements LocalDataPortSurface {
   async confirmTransactionCategories(ids: string[]): Promise<number> {
     const answer = await this.#ask('confirm_transaction_categories', { ids });
     return countOf(answer, 'confirm_transaction_categories', 'confirmed');
+  }
+
+  // ── Marking, committing, and hiding ───────────────────────────────────────
+
+  /**
+   * Tick rows off against a statement, or take the tick back.
+   *
+   * A MARK IS NOT A RECONCILIATION. This is Microsoft Money's C — a working
+   * flag, persisted immediately so eight hundred ticks survive walking away from
+   * the screen, and settling nothing on its own. The seam says the rule about
+   * the committed flag that travels with it — marking LEAVES it alone, unmarking
+   * CLEARS it — and the verb keeps it in the same statement, which is what stops
+   * the file's own `transactions_reconciled_implies_cleared` from refusing an
+   * untick.
+   *
+   * The count is the verb's `changed` rather than the length of the list: a row
+   * already in the requested state is not written and not counted, which is what
+   * makes a re-tick free.
+   */
+  async setTransactionsCleared(ids: string[], cleared: boolean): Promise<number> {
+    const answer = await this.#ask('set_transactions_cleared', { ids, cleared });
+    return countOf(answer, 'set_transactions_cleared', 'changed');
+  }
+
+  /**
+   * Finish a reconciliation: commit this account's marked rows and record the
+   * day and the ending balance they were settled against, in one transaction.
+   *
+   * ── WHAT CROSSES, AND IN WHAT SHAPE ─────────────────────────────────────
+   *
+   * `endingBalance` is a number on this side of the seam and a decimal STRING on
+   * the wire, through the same `money` encoder every other figure uses — never
+   * `toFixed(2)` and never `* 100`. £0.00 is a real statement balance and the
+   * verb refuses an ABSENT one by name, so a caller can tell "settled at zero"
+   * from "settled against nothing".
+   *
+   * `reconciledOn` is a `Date` here and a calendar day on the wire — divergence
+   * D-9, and this engine's answer to it is the UTC day, which is what `asDay`
+   * takes.
+   *
+   * ── THE OUTCOME IS THE VERB'S, NOT THE CALLER'S ─────────────────────────
+   *
+   * All three fields come back from the answer rather than being echoed from the
+   * arguments. `reconciled` is the number of rows this call converted — not how
+   * many were ticked, and not how many the account holds — because the screen
+   * reports it and "Reconciliation complete" with no number is the sentence the
+   * old flow ended on.
+   */
+  async finalizeReconciliation(
+    accountId: string,
+    endingBalance: number,
+    reconciledOn: Date
+  ): Promise<ReconciliationOutcome> {
+    const answer = await this.#ask('finalize_reconciliation', {
+      account_id: accountId,
+      ending_balance: encode('money', endingBalance),
+      reconciled_on: encode('day', reconciledOn)
+    });
+    const result = rowOf(answer, 'finalize_reconciliation', 'answer');
+    return {
+      reconciled: countOf(result, 'finalize_reconciliation', 'reconciled'),
+      endingBalance: moneyOr(field(result, 'ending_balance'), endingBalance),
+      reconciledOn: day(field(result, 'reconciled_on')) ?? reconciledOn
+    };
+  }
+
+  /**
+   * Hide ONE row from the live register, or bring it back.
+   *
+   * Never a delete: the row stays in the file, stays counted in the account's
+   * balance and in every report, and is hidden only from the register. The verb
+   * is the RPC's plural `set_transactions_archived` and the seam's operation is
+   * singular, so the narrowing happens here — one id in an array of one.
+   *
+   * Answers `void`, and the verb answers with a count anyway. Discarded here for
+   * `closeAccount`'s reason: an id nobody has is a REFUSAL rather than a zero
+   * (this verb is the one in its family that raises), so there is no outcome a
+   * caller could learn from the number that it does not already have from the
+   * absence of a rejection.
+   */
+  async setTransactionArchived(id: string, archived: boolean): Promise<void> {
+    await this.#ask('set_transactions_archived', { ids: [id], archived });
+  }
+
+  /**
+   * Archive an account's committed rows up to and including a cutoff day, and
+   * stamp the account with it.
+   *
+   * Only COMMITTED rows are hidden — marked-but-not-committed is work in
+   * progress and stays in the register where it can still be unmarked — with the
+   * pre-split fallback the cloud keeps: a row whose commitment was never
+   * answered is judged by its mark, exactly as the archive judged it before the
+   * two flags were separated.
+   *
+   * **Divergence D-8**: the cutoff is a `Date` here and a calendar day on the
+   * wire, and which day an instant belongs to is answered differently per
+   * engine. This one takes the UTC day.
+   */
+  async archiveTransactionsBefore(accountId: string, cutoff: Date): Promise<number> {
+    const answer = await this.#ask('archive_transactions_before', {
+      account_id: accountId,
+      cutoff: encode('day', cutoff)
+    });
+    const result = rowOf(answer, 'archive_transactions_before', 'answer');
+    return countOf(result, 'archive_transactions_before', 'archived');
+  }
+
+  /**
+   * Bring an account's archived rows back into the register, and forget its
+   * cutoff.
+   *
+   * One click, because nothing ever left. It answers zero rather than refusing
+   * for an account this owner has not got — the verb has no refusal at all, and
+   * that is the RPC's shape rather than an omission in the port; the verb's own
+   * documentation traces it.
+   */
+  async unarchiveAccount(accountId: string): Promise<number> {
+    const answer = await this.#ask('unarchive_account', { account_id: accountId });
+    const result = rowOf(answer, 'unarchive_account', 'answer');
+    return countOf(result, 'unarchive_account', 'unarchived');
   }
 
   // ── A file's worth of rows ────────────────────────────────────────────────

--- a/src/services/local/mappers/columns.ts
+++ b/src/services/local/mappers/columns.ts
@@ -133,6 +133,25 @@ export type Kind =
   | 'dayText'
   | 'instant'
   | 'flag'
+  /**
+   * A boolean the store is allowed to have NO ANSWER for — `is_reconciled`, and
+   * so far only that.
+   *
+   * `flag` is total: it answers `false` for a key that is absent, which is right
+   * for every other boolean the seam carries because every one of them is NOT
+   * NULL in both schemas. This column is nullable in both, and the third value
+   * MEANS something: *"this row predates the split between marking and
+   * committing; ask `cleared`"*
+   * (`20260810200000_marking_is_not_reconciling.sql`, and
+   * `utils/transactionReconciliation.ts` for the app's half of the same rule).
+   *
+   * So it decodes to `undefined` rather than to `false`, and `Transaction.
+   * reconciled` is typed `boolean | null | undefined` for exactly this. Reading
+   * an unanswered row as "not reconciled" would light up a whole imported
+   * history as unreconciled work on the day a file was restored — which is the
+   * mistake the cloud's nullable column exists to make impossible.
+   */
+  | 'answeredFlag'
   | 'whole'
   /**
    * A list of strings, in the order it is in — `Transaction.tags` and, since
@@ -198,6 +217,9 @@ export const TRANSACTION_COLUMNS: readonly Column[] = [
   { key: 'tags', field: 'tags', kind: 'strings' },
   { key: 'notes', field: 'notes', kind: 'text' },
   { key: 'is_cleared', field: 'cleared', kind: 'flag' },
+  // Money's R beside its C, and the one boolean here that is allowed to say
+  // nothing. See the `answeredFlag` kind.
+  { key: 'is_reconciled', field: 'reconciled', kind: 'answeredFlag' },
   { key: 'is_recurring', field: 'isRecurring', kind: 'flag' },
   { key: 'is_split', field: 'isSplit', kind: 'flag' },
   { key: 'archived', field: 'archived', kind: 'flag' },
@@ -441,6 +463,12 @@ const decode = (kind: Kind, value: unknown): unknown => {
       // `rows.ts` documents for the columns a WRITE verb's projection leaves
       // out. See `localDataPort.ts` on what the write projection does not carry.
       return flag(value);
+    case 'answeredFlag':
+      // The opposite decision, for the one column that is allowed no answer:
+      // `true`/`false` pass through and ANYTHING else — a JSON null, an absent
+      // key — becomes `undefined`, which `transactionReconciliation.ts` reads as
+      // "ask `cleared`".
+      return typeof value === 'boolean' ? value : undefined;
     case 'whole':
       return whole(value);
     case 'strings':
@@ -496,6 +524,11 @@ export const encode = (kind: Kind, value: unknown): unknown => {
     case 'instant':
       return value instanceof Date ? value.toISOString() : value;
     case 'flag':
+    case 'answeredFlag':
+      // The same encoder for both, and the `null`/`undefined` split above is
+      // what makes it correct for the three-valued one: an app object holding
+      // `reconciled: null` sends a null (the store's "no answer"), one holding
+      // `undefined` sends nothing at all, and the verb's own default decides.
       return value;
     case 'whole':
       return value;

--- a/src/services/local/mappers/rows.ts
+++ b/src/services/local/mappers/rows.ts
@@ -39,16 +39,22 @@
  * contract suite, which asks both engines the same questions and compares
  * app-shaped answers.
  *
- * ── THREE THINGS THE FILE CANNOT ANSWER, STATED RATHER THAN GUESSED ─────────
+ * ── WHAT THE FILE CANNOT ANSWER, STATED RATHER THAN GUESSED ────────────────
  *
- * `Transaction.reconciled`, `Account.lastReconciledBalance` and
- * `Transaction.metadata`-derived fields have no column in
- * `scripts/local-sqlite/schema.sql`: the mirror predates
- * `20260810200000_marking_is_not_reconciling.sql`. They therefore read as
- * `undefined`, which `utils/transactionReconciliation.ts` defines as "ask
- * `cleared`" — the one-flag behaviour, which is exactly what such a file is
- * still describing. Inventing `false` would report a whole reconciled history
- * as unreconciled work.
+ * This paragraph named three fields and is down to one. `Transaction.reconciled`
+ * and `Account.lastReconciledBalance` had no column in
+ * `scripts/local-sqlite/schema.sql` — the mirror predated
+ * `20260810200000_marking_is_not_reconciling.sql` — and both are ported now
+ * (the account's in slice 20, the transaction's with the reconciliation verbs).
+ * What is left is `Transaction.metadata`-derived fields, which read as
+ * `undefined` because the blob is not projected by any read here.
+ *
+ * The rule the ported column brought with it stands, and it is why `reconciled`
+ * is mapped through `answeredFlag` rather than through `flag`: the column is
+ * NULLABLE, and a NULL means "ask `cleared`"
+ * (`utils/transactionReconciliation.ts`), which is the one-flag behaviour a row
+ * written before the split is still describing. Inventing `false` for one would
+ * report a whole reconciled history as unreconciled work.
  */
 
 import { mapAccountFromDb } from '../../api/accountMapping';
@@ -181,6 +187,12 @@ export const toTransaction = (row: Record<string, unknown>): Transaction => {
     tags: strings(value.tags),
     notes: text(value.notes),
     cleared: value.cleared === true,
+    // NOT `=== true`, and that is the whole of the C/R split on this side: the
+    // column is three-valued, and `undefined` means "ask `cleared`" rather than
+    // "not committed". `answeredFlag` is what keeps the three apart on the way
+    // in; flattening them here would undo it in the last line that touches the
+    // value.
+    reconciled: typeof value.reconciled === 'boolean' ? value.reconciled : undefined,
     isRecurring: value.isRecurring === true,
     isSplit: value.isSplit === true,
     archived: value.archived === true,

--- a/src/services/port/__tests__/contract.ts
+++ b/src/services/port/__tests__/contract.ts
@@ -277,7 +277,12 @@ export const NOT_YET: Partial<Record<DataPortEngine, readonly (keyof DataPort)[]
    * than skipped as a result; slice 23 did it a fourth time for the two
    * dismissal writes, which also closed the local schema's `kind` CHECK — it
    * admitted four of the seven `DismissalKind` values, so Payee cleanup's three
-   * would have been refused by a file while the cloud stored them.
+   * would have been refused by a file while the cloud stored them; slice 24 did
+   * the five reconciliation and archive operations, which are ports of five REAL
+   * RPCs and which needed a COLUMN before any of them could be written —
+   * `transactions.is_reconciled`, Microsoft Money's R. Until it existed this
+   * mirror's archive sweep fired on the mark rather than on the commitment, and
+   * the A-3 constraint spec failed on every run saying so.
    *
    * What is left needs new Rust, in the order the plan sets out.
    *
@@ -288,14 +293,13 @@ export const NOT_YET: Partial<Record<DataPortEngine, readonly (keyof DataPort)[]
    * B-4's row is now asserted rather than excused.
    */
   'local-core': [
-    // Transaction writes — the five with no verb. All four are live cloud RPCs
-    // with no port yet, and they land together in slice 24 with a differential
-    // spec each; `finalizeReconciliation` is the fifth.
-    'setTransactionsCleared',
-    'finalizeReconciliation',
-    'setTransactionArchived',
-    'archiveTransactionsBefore',
-    'unarchiveAccount',
+    // The transaction group is WHOLE. The five that were here — the four live
+    // RPCs with no port and `finalizeReconciliation`, which was the fifth —
+    // landed together in slice 24 with a differential spec each, and they had to
+    // land together: they read and write one column between them, and porting
+    // that column is what closed the last gap between `BOOT_TRANSACTION_COLUMNS`
+    // and what a file can answer with.
+    //
     // Transfers — `repointTransfer` has no verb in either engine's crate half.
     'repointTransfer',
     // Planning and dismissals are BOTH whole now: the category half went in
@@ -349,7 +353,7 @@ export const NOT_YET: Partial<Record<DataPortEngine, readonly (keyof DataPort)[]
  * on a line that exists for no other purpose.
  */
 export const NOT_YET_CEILING: Partial<Record<DataPortEngine, number>> = {
-  'local-core': 9
+  'local-core': 4
 };
 
 // ── Declared divergences ────────────────────────────────────────────────────

--- a/src/services/port/__tests__/localCore.fixtureFile.ts
+++ b/src/services/port/__tests__/localCore.fixtureFile.ts
@@ -107,6 +107,20 @@ type Kind =
   | 'percent'
   | 'int'
   | 'bool'
+  /**
+   * A boolean the file is allowed to have NO ANSWER for — `is_reconciled`, and
+   * only that.
+   *
+   * `bool` is total in both directions (`value === true ? 1 : 0` out, `=== 1`
+   * back), which is right for every other flag in this table because every one
+   * of them is NOT NULL. This column is nullable and its third value MEANS
+   * something: "this row predates the split between marking and committing; ask
+   * `cleared`". A fixture that said nothing must therefore write NULL and not 0,
+   * and a NULL must read back as `undefined` and not as `false` — otherwise the
+   * two states `finalizeReconciliation` distinguishes would be one state here,
+   * and the rule that a pre-split row is left alone could not be tested at all.
+   */
+  | 'answeredBool'
   | 'day'
   | 'dayText'
   | 'instant'
@@ -208,6 +222,11 @@ const toColumn = (kind: Kind, value: unknown, where: string): string | number | 
       return typeof value === 'number' && Number.isInteger(value) ? value : null;
     case 'bool':
       return value === true ? 1 : 0;
+    case 'answeredBool':
+      // Unreachable for `undefined` — the guard above turns that into NULL,
+      // which is exactly the "no answer" this kind exists for. A stated `false`
+      // still lands as 0.
+      return value === true ? 1 : 0;
     case 'day':
     case 'dayText':
       return toDay(value, where);
@@ -231,6 +250,10 @@ const fromColumn = (kind: Kind, value: unknown): unknown => {
       return typeof value === 'number' ? value : undefined;
     case 'bool':
       return value === 1;
+    case 'answeredBool':
+      // A NULL has already returned `undefined` above, so reaching here means
+      // the file answered.
+      return value === 1;
     case 'day':
       return typeof value === 'string' ? fromDay(value) : undefined;
     case 'dayText':
@@ -248,18 +271,21 @@ const fromColumn = (kind: Kind, value: unknown): unknown => {
 // invent them.
 //
 // Columns the APP has and this schema has not are absent for the opposite
-// reason. There were three. `lastReconciledBalance` is no longer one of them —
-// slice 20 gave `schema.sql` the column, because `AccountUpdate` names the field
-// and the account write verb would otherwise have had to refuse an edit the
-// cloud accepts, and the line below is the whole of the change it needed here.
+// reason. There were three, and there is now ONE.
 //
-// The other two stand, and they are not the same kind of absence.
-// `Transaction.reconciled` is a real gap: the mirror predates
-// `20260810200000`, and a file that cannot tell a marked row from a reconciled
-// one is a file the reconciliation bar cannot start from. `creditLimit` is NOT a
-// gap — no migration has ever created `accounts.credit_limit`, in the cloud or
-// here, and `contract.ts`'s `CREDIT_LIMIT_STORAGE` declares that as a fact about
-// the product rather than about this mirror.
+// `lastReconciledBalance` stopped being one in slice 20, because `AccountUpdate`
+// names the field and the account write verb would otherwise have had to refuse
+// an edit the cloud accepts. `Transaction.reconciled` stopped being one here:
+// the mirror predated `20260810200000`, and a file that cannot tell a marked row
+// from a reconciled one is a file the reconciliation bar cannot start from — so
+// the reconciliation verbs brought the column with them, and it is the row below
+// with the `answeredBool` kind, which is the only three-valued flag in this
+// table.
+//
+// `creditLimit` is the one left, and it is NOT a gap — no migration has ever
+// created `accounts.credit_limit`, in the cloud or here, and `contract.ts`'s
+// `CREDIT_LIMIT_STORAGE` declares that as a fact about the product rather than
+// about this mirror.
 
 const ENTITIES = {
   accounts: [
@@ -297,6 +323,7 @@ const ENTITIES = {
     { column: 'notes', field: 'notes', kind: 'text' },
     { column: 'is_recurring', field: 'isRecurring', kind: 'bool' },
     { column: 'is_cleared', field: 'cleared', kind: 'bool' },
+    { column: 'is_reconciled', field: 'reconciled', kind: 'answeredBool' },
     { column: 'is_split', field: 'isSplit', kind: 'bool' },
     { column: 'archived', field: 'archived', kind: 'bool' },
     { column: 'statement_sequence', field: 'statementSequence', kind: 'int' },
@@ -627,6 +654,12 @@ export function readBack(file: string): PortStoreState {
         notes: typeof value.notes === 'string' ? value.notes : undefined,
         tags: tagsByTransaction.get(id) ?? [],
         cleared: asFlag(value.cleared),
+        // NOT `asFlag`, which is total: the column is three-valued and an
+        // unanswered row must come back `undefined`, which
+        // `transactionReconciliation.ts` reads as "ask `cleared`". Flattening it
+        // here would make the independent witness unable to see the difference
+        // the reconciliation rules turn on.
+        reconciled: typeof value.reconciled === 'boolean' ? value.reconciled : undefined,
         isRecurring: asFlag(value.isRecurring),
         isSplit: asFlag(value.isSplit),
         archived: asFlag(value.archived),


### PR DESCRIPTION
Phase 3, slice 24 — the reconciliation family: `setTransactionsCleared`, `finalizeReconciliation`, `setTransactionArchived`, `archiveTransactionsBefore`, `unarchiveAccount`, and the schema work they needed first. Ratchet 9 → **4**; contract **94/101** green; and the constraint suite reads **67/67 for the first time since the C/R split shipped**.

## The column, measured
SQLite's ADD COLUMN semantics were probed, not assumed: a with-default column fills existing rows exactly as `attmissingval` does, and the cloud's two-step cannot be spelled — but a CREATEd schema has no pre-split rows, so `DEFAULT 0` keeps both engines' *insert* semantics identical, which the differential comparison rests on. The honest NULL survives where it can genuinely arrive (a restored pre-split backup) — recorded as slice 25's obligation with its cost stated: work-outstanding display, never a money error.

## One declared behavioural divergence
`reconciled ⇒ cleared` is a CHECK (spelled `IS NOT 1` so the third value passes by statement, not NULL-luck). Unticking a committed row: the cloud *accepts* it — leaving exactly the pair its own migration ships verification-7 to hunt — the file *refuses*. Money's answer, specced and recorded for slice 27's register.

## Fidelity over tidiness
The five verbs reproduce the cloud's asymmetries: bulk archive audits nothing while per-row archive audits (twenty lines apart in the same migration); `unarchive_account` has no refusal at all — somebody else's account is a silent `{unarchived: 0}`.

## The a3 flip, and mutation 1's finding
The long-red spec **passed under the broken sweep**: its setup planted the cutoff before the mark, so the archive happened during setup. Reordered to the truthful sequence, the same break fails it by name — then the fix turns it green. Two harness traps recorded en route: `jsonb_set` is STRICT (a NULL argument silently skipped the RPC a refusal-spec meant to call), and a BEFORE UPDATE stamp trigger overwrote a fixture's planted timestamp. One stale schema obligation retired by plan-owner ruling (the audit projection stays clean of `needs_review`; the field's read-back home is slice 27's result projection).

## Counts
cargo 399 → **420** · verb lane 433 → **459** (25 declared divergences) · constraint **67/67** · admission 109 · contract 94/101, NOT_YET=4 (`repointTransfer`, `collectBackup`, `restoreBackup`, `importMsMoney`) · smoke 5,640 · coverage 77.5/82.5 · bundle byte-identical (one-directory measurement) · port-coverage byte-identical. Five mutations red on cue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)