### PR TITLE
feat(local): slice 30 — the desktop gate: four jobs that make the promise a machine's problem

### DIFF
--- a/.github/workflows/handoff-snapshot.yml
+++ b/.github/workflows/handoff-snapshot.yml
@@ -113,3 +113,129 @@ jobs:
 
       - name: Run bundle check
         run: npm run bundle:check
+
+  # ────────────────────────────────────────────────────────────────────────────
+  # THE LOCAL EDITION, ON EVERY PR.
+  #
+  # Two jobs rather than one, because "which half broke" is the first question
+  # anybody asks a red build and a single job cannot answer it. The renderer half
+  # needs Node and two seconds; the core half needs a Rust toolchain and a couple
+  # of minutes. Splitting them also means the fast one reports while the slow one
+  # is still compiling.
+  #
+  # What is deliberately NOT here runs nightly — see local-edition-nightly.yml,
+  # which states the reason for each.
+  # ────────────────────────────────────────────────────────────────────────────
+
+  desktop-renderer:
+    name: Desktop renderer (cloud-free + size)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          # 22, not the 20 the web jobs use. The local edition's suites open
+          # SQLite files through `node:sqlite`, which does not exist before
+          # 22.5. This job does not itself need it; it is pinned to the same
+          # version as `local-core` so the two never drift apart and start
+          # disagreeing about what "the local edition's Node" is.
+          node-version: '22'
+          cache: 'npm'
+          cache-dependency-path: package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build the desktop renderer
+        run: npm run desktop:ui
+
+      # `npm run desktop:verify` is these three in order. They are separate steps
+      # on purpose: the Actions UI names the step that failed, and "the bundle
+      # reached the cloud" and "the bundle got fat" want different people.
+      - name: Bundle greps — the desktop build reaches no cloud
+        run: npm run desktop:greps
+
+      - name: Bundle size ratchet
+        run: npm run bundle:check:desktop
+
+  local-core:
+    name: Local core (Rust, contract, admission)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          # See desktop-renderer: `node:sqlite`, so 22 and not 20. The contract
+          # suite's fixtures open real ledger files with it.
+          node-version: '22'
+          cache: 'npm'
+          cache-dependency-path: package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      # No third-party action for either the toolchain or the cache, deliberately.
+      # `rustup`, `cargo` and a stable toolchain ship in the ubuntu runner image,
+      # and this repository is public: every extra action is another owner of a
+      # token that can see a finance codebase. `actions/cache` is first-party.
+      - name: Tool versions
+        run: |
+          rustup show active-toolchain || rustup default stable
+          cargo --version
+          rustc --version
+          node --version
+
+      # Registry and git checkouts only — NOT `crates/target`. Measured on an M4
+      # (2026-08-12): a cold `cargo test` plus a cold `cargo build --release
+      # --features cli` for this workspace is ~89 CPU-seconds over 65 packages,
+      # and the target directory it leaves behind is 726 MB. Round-tripping most
+      # of a gigabyte through the cache service to save a minute and a half of
+      # compilation is not obviously a saving, and it is definitely a bigger
+      # thing to go wrong. The registry cache is tens of MB and saves the
+      # downloads, which is the part that is pure latency.
+      - name: Cache cargo registry
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry/index
+            ~/.cargo/registry/cache
+            ~/.cargo/git/db
+          key: cargo-local-core-${{ runner.os }}-${{ hashFiles('crates/Cargo.lock') }}
+          restore-keys: cargo-local-core-${{ runner.os }}-
+
+      # The money lints live in crates/wealth-core/Cargo.toml — unwrap_used,
+      # expect_used, panic, arithmetic_side_effects and float_arithmetic all
+      # `deny`. Clippy is how they are enforced; without this step they are a
+      # comment.
+      - name: Clippy — the ledger core's money lints
+        run: cargo clippy --manifest-path crates/Cargo.toml --all-targets --all-features -- -D warnings
+
+      - name: Rust tests — the ledger core
+        run: cargo test --manifest-path crates/Cargo.toml --all-features
+
+      # `--release`, not debug. Both lanes below are dominated by process spawns
+      # rather than by CPU (the harness spawns the bridge once per spec, 236
+      # times between them), and a debug SQLite is slow enough to change the
+      # shape of the job. `--features cli` is what builds the bridge at all: it
+      # is `required-features`, so an ordinary `cargo build` does not produce it.
+      - name: Build the ledger bridge
+        run: cargo build --manifest-path crates/Cargo.toml --features cli --release
+
+      # Needs the binary above and nothing else — no Postgres, no browser, no
+      # cloud. It REFUSES to skip when the binary is missing (R-8), so a broken
+      # build step cannot present as a green suite.
+      - name: Local contract suite
+        env:
+          CI: true
+        run: npm run test:local-contract
+
+      # TypeScript against Rust: the shipping admission modules are the oracle,
+      # so this lane needs no database either.
+      - name: Admission parity (TypeScript vs Rust)
+        run: npm run test:local-admission

--- a/.github/workflows/local-edition-nightly.yml
+++ b/.github/workflows/local-edition-nightly.yml
@@ -1,0 +1,191 @@
+# THE LOCAL EDITION'S NIGHTLY — the two lanes that cannot justify a slot on
+# every pull request, and the reason each one cannot.
+#
+# The per-PR half lives in handoff-snapshot.yml (`desktop-renderer`,
+# `local-core`). The split is by COST AND ENVIRONMENT, never by importance: the
+# differential harness is the most load-bearing thing in the local edition and
+# it is here because it needs a PostgreSQL cluster with 51 migrations applied to
+# it, not because anybody thinks it is optional.
+#
+#   differential   two harness lanes, 541 specs, against a throwaway Postgres
+#                  built from the full migration history. ~2 minutes of cluster
+#                  setup before a single spec runs, and the cluster is the whole
+#                  point: the cloud's own schema is the oracle.
+#
+#   desktop-shell  cargo clippy + cargo test + a release build of the Tauri
+#                  shell. Measured cold on an M4 (2026-08-12): 45 s wall, 262
+#                  CPU-seconds, 454 packages, a 991 MB target directory and a
+#                  16.1 MB binary — and on Linux it needs webkit2gtk and five
+#                  more -dev packages installed first. What it proves is that
+#                  the shell LINKS; it does not open a window (nothing in CI
+#                  can), and apps/desktop/README.md has always said so. A
+#                  two-to-four minute job proving a link step is a nightly.
+#
+# The precedent for the shape is supabase-smoke.yml, and so is the rule it
+# carries: NOT continue-on-error anywhere, and no step that degrades to green
+# when its environment is missing. A nightly that cannot go red is theatre.
+#
+# FIRST RUN. Nothing here has executed on GitHub's runners — it could not, it
+# did not exist until now. What HAS been done is the equivalent locally: a
+# from-scratch cluster (`WT_PGDATA=/tmp/wtpg-ci`, a different port, initdb up)
+# applied the entire migration history with zero failures, and both lanes were
+# 67/67 and 474/474 against it. The two things that can still surprise this
+# workflow are Linux-specific and named where they occur: where Debian keeps
+# initdb, and Tauri's -dev packages.
+
+name: Local Edition Nightly
+
+on:
+  workflow_dispatch:
+  schedule:
+    # 03:15 UTC — after supabase-smoke's 02:30 so the two never contend for a
+    # runner, and their logs stay separable by timestamp.
+    - cron: "15 3 * * *"
+
+permissions:
+  contents: read
+
+jobs:
+  differential:
+    name: Differential harness (SQLite vs the cloud's Postgres)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          # `node:sqlite` — the SQLite side of every spec here is the runtime's
+          # own binding, which does not exist before 22.5.
+          node-version: '22'
+          cache: 'npm'
+          cache-dependency-path: package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      # Debian keeps the SERVER binaries — initdb, pg_ctl — out of PATH, under
+      # /usr/lib/postgresql/<major>/bin. scripts/local-db/pgbin.sh knows both
+      # that layout and homebrew's and picks whichever exists, so nothing here
+      # hardcodes a version. The runner image usually ships PostgreSQL already;
+      # this installs it only when it does not, and fails loudly if it still
+      # cannot be found afterwards rather than letting up.sh discover that.
+      - name: Ensure PostgreSQL server binaries
+        run: |
+          latest_pgbin() { printf '%s\n' /usr/lib/postgresql/*/bin | sort -V | tail -1; }
+          if [ ! -x "$(latest_pgbin)/initdb" ]; then
+            sudo apt-get update
+            sudo apt-get install -y postgresql
+          fi
+          printf 'server binaries: %s\n' "$(latest_pgbin)"
+          "$(latest_pgbin)/initdb" --version
+
+      - name: Cache cargo registry
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry/index
+            ~/.cargo/registry/cache
+            ~/.cargo/git/db
+          key: cargo-local-core-${{ runner.os }}-${{ hashFiles('crates/Cargo.lock') }}
+          restore-keys: cargo-local-core-${{ runner.os }}-
+
+      # The verb lane drives the real Rust command layer against the real
+      # Postgres RPC. Release for the same reason as the PR job: 474 specs is
+      # 474 process spawns.
+      - name: Build the ledger bridge
+        run: cargo build --manifest-path crates/Cargo.toml --features cli --release
+
+      # initdb + start + the whole migration history, three passes, into a
+      # throwaway cluster under $WT_PGDATA. Verified from scratch locally on
+      # 2026-08-12: every migration applies, "unapplied: 0".
+      #
+      # This step exits 0 even if some migration does not apply, and that is
+      # deliberate — it is not the gate. The GATE is the two lanes below: a
+      # missing migration shows up as a spec whose Postgres column stops
+      # matching, naming the constraint it expected. That is a better error than
+      # any count this script could print.
+      - name: Bring up the throwaway Postgres
+        run: bash scripts/local-db/up.sh
+
+      # Both lanes exit non-zero if the cluster is absent rather than running
+      # the SQLite half alone and reporting a green half-table. Nothing needs to
+      # be added here to make that true; it is worth knowing that it is.
+      - name: Constraint parity (67 specs)
+        run: npm run test:local-sqlite
+
+      - name: Verb parity (474 specs)
+        run: npm run test:local-verbs
+
+      # NOT RUN HERE, and this is the note that stops it being re-added by
+      # accident: `bash scripts/local-db/test.sh` greps psql output and ends
+      # with a hardcoded `exit 0`. It cannot fail, so putting it in a gate would
+      # add a green tick that means nothing. Give it a real exit code first.
+
+      - name: Tear down the cluster
+        if: always()
+        run: bash scripts/local-db/down.sh
+
+  desktop-shell:
+    name: Desktop shell (clippy, tests, release build)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'npm'
+          cache-dependency-path: package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      # Tauri 2's Linux prerequisites. This is the single biggest reason the
+      # shell is not on the PR path: none of it is needed to prove anything
+      # about money, and all of it has to be installed before cargo can even
+      # type-check the crate.
+      - name: Tauri's Linux system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            libwebkit2gtk-4.1-dev \
+            libgtk-3-dev \
+            libayatana-appindicator3-dev \
+            librsvg2-dev \
+            libxdo-dev \
+            libssl-dev \
+            build-essential \
+            file
+
+      - name: Cache cargo registry
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry/index
+            ~/.cargo/registry/cache
+            ~/.cargo/git/db
+          key: cargo-desktop-${{ runner.os }}-${{ hashFiles('apps/desktop/src-tauri/Cargo.lock') }}
+          restore-keys: cargo-desktop-${{ runner.os }}-
+
+      # `tauri::generate_context!` embeds apps/desktop/dist at COMPILE time, so
+      # the renderer has to exist before cargo runs. A missing dist is a build
+      # error inside a proc macro, which is a poor way to find out.
+      - name: Build the desktop renderer
+        run: npm run desktop:ui
+
+      - name: Clippy and the shell's own tests
+        run: npm run desktop:check
+
+      - name: Release build
+        run: npm run desktop:build
+
+      # Runs last here, unlike on the PR path, because by now there is a binary
+      # on disk and the ratchet records its size. On Linux that number is a
+      # different artefact from a developer's macOS one, which is exactly why
+      # the ratchet reports it and never gates on it.
+      - name: Bundle size ratchet (records the Linux binary too)
+        run: npm run bundle:check:desktop

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,9 +18,39 @@
 | Threshold | `node scripts/verify-coverage-threshold.mjs …` | ✅ | ≥63 % statements / ≥55 % branches (recalibrated 2026-06 after dead Redux removal) |
 | Supabase smoke | `npm run test:supabase-smoke` | ✅ | Logs saved to `logs/supabase-smoke/` |
 | Build parity | `npm run build` | ✅ | Mirrors Vercel’s `vite build` via `scripts/build-web.mjs` |
-| Desktop bundle | `npm run desktop:verify` | ✅ | Builds `src/desktop` → `apps/desktop/dist`, then runs PHASE3-PLAN §5’s two bundle greps. REFUSES rather than skips when there is no build |
-| Desktop shell | `npm run desktop:check` | ✅ | clippy `-D warnings` + the shell crate's own tests (`apps/desktop/src-tauri`) |
-| Desktop build | `npm run desktop:build` | ✅ | `vite` → `apps/desktop/dist`, then `cargo build --release`. The renderer must be built first: `generate_context!` embeds it |
+| Desktop bundle | `npm run desktop:verify` | ✅ | Builds `src/desktop` → `apps/desktop/dist`, then PHASE3-PLAN §5’s two bundle greps, then the size ratchet. REFUSES rather than skips when there is no build |
+| Desktop size | `npm run bundle:check:desktop` | ✅ | 259.3 KiB raw / 86.7 KiB gz over 3 files; budgets 285 / 96 KiB. **Raw** is the gate — nothing is downloaded, the bytes are embedded in the binary. Binary size recorded, never gated |
+| Desktop shell | `npm run desktop:check` | ✅ | clippy `-D warnings` + the shell crate's own 12 tests (`apps/desktop/src-tauri`) |
+| Desktop build | `npm run desktop:build` | ✅ | `vite` → `apps/desktop/dist`, then `cargo build --release` → 16.1 MB. The renderer must be built first: `generate_context!` embeds it |
+
+### The local edition's lanes
+
+Node **22+** (they open ledger files with `node:sqlite`), and a release bridge
+binary: `cargo build --manifest-path crates/Cargo.toml --features cli --release`.
+Every one of them refuses to run without what it needs rather than skipping.
+
+| Check | Command | Status | Notes |
+| --- | --- | --- | --- |
+| Ledger core | `cargo test --manifest-path crates/Cargo.toml --all-features` | ✅ | 468 tests, 24 suites. The money lints (`unwrap_used`, `panic`, `float_arithmetic`, …) are `deny` in `Cargo.toml`; clippy is what enforces them |
+| Contract | `npm run test:local-contract` | ✅ | 127 checks, 5 files — the real crate against real SQLite files through `DataPort` |
+| Admission | `npm run test:local-admission` | ✅ | 109 specs: the shipping TypeScript against the Rust port of it |
+| Constraint parity | `npm run test:local-sqlite` | ✅ | 67 specs, 16 declared divergences. **Needs `bash scripts/local-db/up.sh`** |
+| Verb parity | `npm run test:local-verbs` | ✅ | 474 specs, 26 declared divergences, 24 single-engine. Same cluster |
+
+**Where they run.** The desktop renderer trio, the Rust core suites, contract
+and admission are on **every PR**. The two differential lanes and
+`desktop:check`/`desktop:build` are **nightly** — the first pair needs a
+PostgreSQL cluster with the migration history applied, the second needs
+webkit2gtk and 262 CPU-seconds to link 454 crates. The split is by cost, never
+by importance; `docs/edition-gating.md` argues it out, and
+`src/desktop/__tests__/desktopIsGated.test.ts` fails if a step is dropped from
+either workflow.
+
+⚠️ **A type error in `src/desktop` fails none of the desktop commands.** Vite hands
+TypeScript to esbuild, which strips types without reading them — measured,
+`desktop:ui` exits 0 on a renderer that does not typecheck. Only
+`typecheck:strict` catches it, through the root `tsconfig.json`'s reference to
+`tsconfig.desktop.json`.
 
 Latest Vercel preview: `wealthtracker-l514dsq11` (2025‑10‑29 21:33 UTC). Build chunk warnings (Plotly/XLSX) tracked in `docs/bundle-optimization-plan.md`.
 
@@ -29,7 +59,8 @@ Latest Vercel preview: `wealthtracker-l514dsq11` (2025‑10‑29 21:33 UTC). B
 ## 2. Guardrails & Tooling
 
 ### Quality Gates
-1. **Lint** → **Strict TS** → **Smoke** → **Realtime Suite** → **Coverage** → **Coverage Threshold** → **Bundle Check** → **Build** (see `.github/workflows/handoff-snapshot.yml`).
+1. **Lint** → **Strict TS** → **Smoke** → **Realtime Suite** → **Coverage** → **Coverage Threshold** → **Bundle Check** → **Build** (see `.github/workflows/handoff-snapshot.yml`, job `quality-gates`).
+   Two more jobs run beside it on every PR: **`desktop-renderer`** (build, cloud greps, size ratchet) and **`local-core`** (clippy, 468 Rust tests, contract, admission). The environment-heavy lanes are nightly in `.github/workflows/local-edition-nightly.yml`.
 2. `scripts/realtime-tests.json` enumerates every deterministic/timer-heavy service test. `npm run test:realtime` calls `scripts/run-realtime-suite.mjs` so adding coverage is a manifest edit.
 3. Coverage enforcement runs through `scripts/verify-coverage-threshold.mjs` (loads `coverage/coverage-final.json`, merges shards automatically).
 
@@ -50,6 +81,9 @@ Latest Vercel preview: `wealthtracker-l514dsq11` (2025‑10‑29 21:33 UTC). B
 - A desktop-reachable module may not import Supabase, Clerk, Sentry, Stripe, the banking
   service or the web's choosing line. Checked at three altitudes: lint, two import-graph
   walks, and the bundle greps.
+- The renderer also has a **size** ratchet, because growth that is perfectly cloud-free
+  passes all three of those. 259.3 KiB raw today; the 144-module `components/Layout`
+  graph is what it is guarding against.
 - `src/desktop/routes.ts` must have an answer for every `path=` in `src/App.tsx`. Adding a
   route to the web router without one fails `desktopRouter.test.tsx`.
 
@@ -88,6 +122,19 @@ RUN_SUPABASE_REAL_TESTS=true npm run test:supabase-smoke
 
 # Deploy parity
 npm run build
+
+# The local edition (Node 22+)
+cargo build --manifest-path crates/Cargo.toml --features cli --release
+cargo test  --manifest-path crates/Cargo.toml --all-features
+npm run test:local-contract
+npm run test:local-admission
+npm run desktop:verify
+
+# …and the two that need the throwaway Postgres
+bash scripts/local-db/up.sh
+npm run test:local-sqlite
+npm run test:local-verbs
+bash scripts/local-db/down.sh
 ```
 
 ---
@@ -99,5 +146,9 @@ npm run build
 - `logs/supabase-smoke/` – timestamped nightly smoke logs.
 - `docs/development-workflow.md` – environment setup & guardrails.
 - `docs/regression-audit-*.md` – latest dashboard/import regression runs.
+- `docs/edition-gating.md` – how one source tree makes two editions, and which gate runs where.
+- `scripts/local-db/` – the throwaway Postgres the differential lanes need (`up`/`test`/`down`, `pgbin.sh`).
+- `scripts/local-sqlite/README.md` – the three differential lanes and every declared divergence.
+- `apps/desktop/README.md` – the shell, what is verified in it and what needs a GUI session.
 
 Update this file whenever guardrails, workflows, or focus areas change.

--- a/apps/desktop/README.md
+++ b/apps/desktop/README.md
@@ -63,20 +63,51 @@ other and why the kernel holds the second rather than a row in the file.
 ## Building it
 
 ```bash
-npm run desktop:ui       # vite → apps/desktop/dist  (the binary embeds this)
-npm run desktop:greps    # PHASE3-PLAN §5's two bundle greps, over that build
-npm run desktop:verify   # the two above, in that order
-npm run desktop:build    # desktop:ui, then cargo build --release
-npm run desktop:check    # clippy -D warnings, and the shell's own tests
+npm run desktop:ui             # vite → apps/desktop/dist  (the binary embeds this)
+npm run desktop:greps          # PHASE3-PLAN §5's two bundle greps, over that build
+npm run bundle:check:desktop   # the renderer's size ratchet, over the same build
+npm run desktop:verify         # the three above, in that order
+npm run desktop:build          # desktop:ui, then cargo build --release
+npm run desktop:check          # clippy -D warnings, and the shell's own tests
 ```
 
 `cargo build` needs `dist/` to exist first: `tauri::generate_context!` embeds the
 renderer at compile time.
 
-`desktop:greps` REFUSES rather than skips when there is no build to look at. A
-grep that passes because it found nothing to read is the kind of gate that stops
-meaning anything, and this repository has ruled on that once already (R-8, in
-the local contract suite).
+`desktop:greps` and `bundle:check:desktop` both REFUSE rather than skip when
+there is no build to look at. A gate that passes because it found nothing to
+read is the kind of gate that stops meaning anything, and this repository has
+ruled on that once already (R-8, in the local contract suite).
+
+**The ratchet gates RAW bytes, not gzip**, which is the opposite of the web's
+`bundle:check` and for a reason: nothing here is downloaded. These bytes are
+embedded in the binary and parsed when the window opens, so compression never
+enters it. Gzip is measured too, because this README quotes it and because it is
+the only figure directly comparable with the web bundle's.
+
+The binary's size is **recorded and never gated** — CI's Linux binary and this
+arm64 macOS one are different artefacts and neither is the other's regression.
+
+## Where these run
+
+| | on every PR | nightly |
+| --- | --- | --- |
+| `desktop:ui`, `desktop:greps`, `bundle:check:desktop` | ✅ | |
+| `cargo test` / `clippy` on `crates/wealth-core` | ✅ | |
+| `test:local-contract`, `test:local-admission` | ✅ | |
+| `test:local-sqlite`, `test:local-verbs` | | needs the Postgres cluster |
+| `desktop:check`, `desktop:build` | | needs webkit2gtk + 262 CPU-seconds |
+
+`.github/workflows/handoff-snapshot.yml` and `local-edition-nightly.yml`.
+`docs/edition-gating.md` argues the split; `src/desktop/__tests__/
+desktopIsGated.test.ts` fails if a step is dropped from either.
+
+**A type error in `src/desktop` does not fail any of the desktop commands.**
+Vite hands TypeScript to esbuild, which strips types without checking them —
+measured, exit 0 on a renderer that does not typecheck. `npm run
+typecheck:strict` is what catches it, via the root `tsconfig.json`'s reference
+to `tsconfig.desktop.json`, and that reference is now asserted by a test because
+it is the only thing standing between this renderer and being untyped.
 
 ## What has been verified, and what has not
 
@@ -84,12 +115,12 @@ Verified on this machine, at this commit:
 
 | | |
 | --- | --- |
-| the shell crate compiles | `cargo build --release` → a 16 MB arm64 binary |
+| the shell crate compiles | `cargo build --release` → a 16.1 MB arm64 binary (15.3 MiB). Cold, from an empty target directory: 45 s wall, 262 CPU-seconds, 454 packages, 991 MB of build artefacts |
 | the shell's own tests | 12 pass: both locks, the identity flow, the refusals |
 | clippy | clean at `--all-targets`, pedantic on |
-| the renderer builds | 263.7 kB raw / 87.8 kB gzipped — React, React DOM and the router, mounted (slice 29). It was 81.8 kB / 28.0 kB when it was one screen of vanilla DOM |
+| the renderer builds | 259.3 KiB raw / 86.7 KiB gzipped over three files — React, React DOM and the router, mounted (slice 29). It was 81.8 kB / 28.0 kB when it was one screen of vanilla DOM. `npm run bundle:check:desktop` is that measurement as a command, with budgets ~10 % above it |
 | the renderer is cloud-free | zero occurrences of `supabase`, `storageAdapter` — PHASE3-PLAN §5's two bundle greps — and of `indexedDB`, `clerk`, `sentry`, `stripe`. `npm run desktop:greps` is that check, as a command, over the built bundle; two import-graph walks assert the same on every test run, from the data root and from the entry |
-| the ledger path end to end | the contract suite drives all 113 rules through the real crate against real files |
+| the ledger path end to end | the contract suite drives 127 checks in five files through the real crate against real files (`npm run test:local-contract`) |
 | the settings path end to end | `localCore.preferences.test.ts` writes a document into a real file, closes it, reads it back, and follows a preference's account ids through a real backup and restore |
 
 **NOT verified here, because it needs a GUI session:**

--- a/docs/development-workflow.md
+++ b/docs/development-workflow.md
@@ -76,7 +76,7 @@ Each run writes a timestamped log to `logs/supabase-smoke/<ISO>_supabase-smoke.l
 - `VITE_SUPABASE_ANON_KEY`
 - `SUPABASE_SERVICE_ROLE_KEY` (no `VITE_` prefix — server-side only)
 
-The workflow is guarded so it silently skips when any secret is missing. Coordinate with DevOps before enabling it in production to manage costs and rate limits.
+**The workflow does not skip when a secret is missing — it fails, loudly, exit 1.** (This paragraph said the opposite until 2026-08-12, contradicting both the table above it and the workflow itself.) Silent skipping is precisely what went wrong before: the job reported success for months with no service-role key, which is the comment now standing at the top of `supabase-smoke.yml`. A nightly that cannot go red is theatre. The local behaviour in the table above is the deliberate exception, and it is never silent either.
 
 ## Supabase migrations
 
@@ -125,20 +125,77 @@ Only skip the hook for critical hotfixes. Preferred options:
 
 Follow up every bypass with the full lint + smoke suite before merging.
 
+## The local edition's lanes
+
+The desktop/local edition has its own commands, its own test-runner config and
+its own CI jobs. They are separate from everything above because they share no
+infrastructure with the web app: no browser, no Supabase, no Clerk.
+
+| command | what it is | what it needs |
+| --- | --- | --- |
+| `npm run test:local-contract` | 127 checks in five files, driving the real Rust ledger against real SQLite files through the `DataPort` contract | the release bridge binary |
+| `npm run test:local-admission` | 109 specs: the shipping TypeScript admission modules against the Rust port of them | the bridge binary |
+| `npm run test:local-sqlite` | 67 constraint specs — does the local schema refuse a write the way the cloud's does? | the bridge **and** a Postgres cluster |
+| `npm run test:local-verbs` | 474 verb specs — do the Rust command layer and the live Postgres RPC agree on the answer *and* on the rows left behind? | the bridge **and** a Postgres cluster |
+| `npm run desktop:verify` | build the renderer, grep it for the cloud, weigh it against its ratchet | Node only |
+| `npm run desktop:check` | clippy (`-D warnings`) and the shell's 12 tests | a Rust toolchain |
+| `npm run desktop:build` | the renderer, then a release build of the Tauri shell | a Rust toolchain, plus webkit2gtk on Linux |
+| `cargo test --manifest-path crates/Cargo.toml --all-features` | 468 tests, the ledger core itself | a Rust toolchain |
+
+Two prerequisites, both of which the lanes **refuse to run without** rather than
+skipping to green:
+
+```sh
+# the bridge binary (release: these lanes are dominated by process spawns)
+cargo build --manifest-path crates/Cargo.toml --features cli --release
+
+# the throwaway Postgres, for the two differential lanes only
+bash scripts/local-db/up.sh     # …/down.sh to remove it
+```
+
+**Node 22 or newer.** The SQLite side of every one of these is `node:sqlite`,
+the runtime's own binding, which does not exist before 22.5. The web app's own
+jobs still run Node 20, deliberately: their version is a build-parity question
+with Vercel and has nothing to do with this.
+
+Which of these run on a pull request and which run nightly — and why — is in
+`docs/edition-gating.md`. `scripts/local-sqlite/README.md` and
+`scripts/local-db/README.md` document the two harnesses.
+
 ## CI gate coverage
 
-- `ci.yml` quality job now runs `npm run typecheck:strict` before the baseline `tsc --noEmit`.
-- Unit test job executes the focused LoadingScreen suite (`npm run test -- --run src/components/LoadingScreen.test.tsx`) alongside the broader mocks.
-- Build stage runs `npm run bundle:check` immediately after producing `dist/` to surface bundle regressions.
-- Optional Supabase job triggers `npm run test:supabase-smoke` under `continue-on-error` until the RLS policy fixes ship.
+The workflows are `.github/workflows/handoff-snapshot.yml` (every PR, and push
+to `main`), `supabase-smoke.yml` and `local-edition-nightly.yml` (nightly), plus
+`dependency-audit.yml`, `gitleaks.yml` and `nightly-backup.yml`. There is no
+`ci.yml`; an earlier version of this section described one.
+
+`handoff-snapshot.yml` runs four jobs:
+
+- **`check-snapshots`** — `npm run handoff:update` must leave the tree clean.
+- **`quality-gates`** — `typecheck:strict` (`tsc -b`, which is also the only
+  thing that typechecks the desktop renderer), lint, smoke, realtime, coverage
+  and its threshold, Supabase migration lint, `build:check`, `bundle:check`.
+- **`desktop-renderer`** — the renderer built, grepped for the cloud, weighed.
+- **`local-core`** — clippy and 468 Rust tests on the ledger core, then the
+  contract and admission lanes.
+
+Only one step in the whole file is `continue-on-error`: the Supabase migration
+lint, which needs a secret. Nothing else may become one —
+`src/desktop/__tests__/desktopIsGated.test.ts` fails if a second appears.
 
 ### Coverage thresholds
 
-Unit coverage is now treated as a gate. After `npm run test:coverage`, CI executes:
+Unit coverage is a gate. After `npm run test:coverage`, CI executes:
 
 ```sh
-  node scripts/verify-coverage-threshold.mjs coverage/coverage-final.json --statements=75 --branches=55
+  node scripts/verify-coverage-threshold.mjs coverage/coverage-final.json --statements=63 --branches=55
   # The script autogenerates coverage/coverage-final.json by merging Vitest shards from coverage/.tmp
 ```
 
-If either percentage drops below the threshold the workflow fails. Run the same command locally whenever you touch shared services to confirm you're still above **75 % statements / 55 % branches** before pushing.
+If either percentage drops below the threshold the workflow fails. The floor is
+**63 % statements / 55 % branches**, not the 75 % this document claimed until
+2026-08-12. It was recalibrated in June 2026, when deleting the dead Redux store
+removed ~6.5K lines of heavily-tested dead code that had been inflating the
+global ratio; live-code coverage did not regress. The number here, in
+`package.json`'s `verify:full`, in the pre-push hook and in the workflow is one
+number, and must stay one number.

--- a/docs/edition-gating.md
+++ b/docs/edition-gating.md
@@ -99,11 +99,109 @@ Four instruments, on purpose. Each catches what the others structurally cannot.
 | `deviceDocument.cloudFree.test.ts` | the import graph from the DATA root | every test run | a cloud module pulled in through the object graph |
 | `desktopEntry.cloudFree.test.ts` | the import graph from `src/desktop/main.tsx` | every test run | a cloud module pulled in through the component tree, and a mis-pointed alias |
 | `scripts/desktop-bundle-greps.mjs` | the built bundle | `npm run desktop:verify` | anything a *dependency* drags in, and anything a plugin injects |
+| `scripts/desktop-bundle-size.mjs` | the built bundle's weight | the same | growth that is **perfectly cloud-free** — 144 modules of shared UI arriving at once, which every row above passes |
 
 The lint rule can only see specifiers it was told about. The graph walks read
 the source the way a bundler *would* have. The greps read what a bundler *did*.
-None of them is redundant, and the last one refuses rather than skips when there
-is no build to look at.
+The ratchet reads how much of it there is, which is the one question the other
+four cannot be made to answer: a renderer that doubled in size without importing
+a single forbidden module satisfies all of them. None is redundant, and the last
+two refuse rather than skip when there is no build to look at.
+
+---
+
+## What runs in CI, where, and why
+
+Everything above was enforced only on whichever machine happened to run it.
+Slice 30 wired it. Two workflows, four jobs, and one rule for deciding which
+job a check belongs in: **cost and environment, never importance.**
+
+### On every pull request — `.github/workflows/handoff-snapshot.yml`
+
+| job | runs | needs |
+| --- | --- | --- |
+| `desktop-renderer` | `desktop:ui`, `desktop:greps`, `bundle:check:desktop` | Node |
+| `local-core` | `cargo clippy`, `cargo test` (468), the release bridge, `test:local-contract` (127), `test:local-admission` (109) | Node + a Rust toolchain |
+
+Two jobs and not one, because *"which half broke"* is the first question anyone
+asks a red build and a single job cannot answer it. The renderer half also
+finishes in seconds while the core half is still compiling.
+
+**Node 22, not the 20 the web jobs use.** `node:sqlite` is how both the harness
+and the contract fixtures open a ledger file, and it does not exist before 22.5.
+The web jobs are left on 20 deliberately: their version is a build-parity
+question with Vercel and has nothing to do with this.
+
+**No third-party actions.** `rustup` and a stable toolchain ship in the runner
+image, and `actions/cache` is first-party. This repository is public; every
+extra action is another owner of a token that can read a finance codebase.
+
+**The cargo cache holds the registry, not `target/`.** Measured on an M4
+(2026-08-12): a cold `cargo test` plus a cold `cargo build --release --features
+cli` over this workspace's 65 packages is ~89 CPU-seconds and leaves a 726 MB
+target directory. Round-tripping most of a gigabyte through the cache service to
+save that is not obviously a saving, and it is a much bigger thing to go wrong.
+
+### Nightly — `.github/workflows/local-edition-nightly.yml`
+
+| job | runs | why not on a PR |
+| --- | --- | --- |
+| `differential` | `test:local-sqlite` (67), `test:local-verbs` (474) | needs a PostgreSQL cluster with 51 migrations applied — minutes of setup before one spec runs |
+| `desktop-shell` | `desktop:check`, `desktop:build`, the ratchet again | Tauri needs webkit2gtk and five more `-dev` packages on Linux, then 262 CPU-seconds to link 454 crates |
+
+The differential harness is the most load-bearing thing in the local edition and
+it is nightly anyway. It is the clearest case for the rule: the cloud's own
+schema is its oracle, and standing that oracle up costs more than everything on
+a pull request put together.
+
+The shell build proves the shell **links**. It does not open a window — nothing
+in CI can, and `apps/desktop/README.md` has always said so. A three-minute job
+proving a link step is a nightly.
+
+### Why a service container is not how the Postgres lanes get their database
+
+The obvious wiring is `services: postgres:17` and it does not fit, for three
+reasons that are all in the harness rather than in the container:
+
+* the engines connect with `-h $WT_PGDATA`, a **unix socket directory**, under
+  trust auth. A service container offers TCP with a password.
+* the cluster is not an empty Postgres. It is the **whole migration history**,
+  applied in three passes, plus three roles and the `auth.uid`/`auth.role`/
+  `auth.jwt` stand-ins that every RLS policy calls. `up.sh` is the only thing
+  that knows that recipe.
+* `up.sh` would then need a second mode, and the harness a second connection
+  shape, so that CI could use a Postgres it configures *less* well.
+
+The runner already has `initdb`. Letting the existing script do exactly what it
+does on a developer's machine is both less code and a closer match to what is
+being tested. What that needed was one real change — `pgbin.sh`, because Debian
+keeps the server binaries off `PATH` — and it is the same script either way.
+
+### What has and has not actually been run
+
+**Verified locally, 2026-08-12:** a cluster built from scratch under a separate
+`WT_PGDATA` on a separate port applied every migration (`unapplied: 0`), and
+both lanes were **67/67** and **474/474** against it. That is the nightly's
+riskiest step, done by hand.
+
+**Not verified:** these workflows have never executed on GitHub's runners, and
+cannot be from here. `actionlint` passes on both files. **Their first real run
+is the pull request that introduces them**, and the two things that can still
+surprise them are Linux-specific and commented where they occur: where Debian
+puts `initdb`, and Tauri's `-dev` package list. Both fail loudly at a named
+step rather than degrading to green.
+
+### The one thing none of the desktop jobs catches
+
+`npm run desktop:ui` **builds a renderer with type errors in it.** Measured:
+planting `const x: number = 'string'` in `src/desktop/tauriShell.ts` leaves
+`desktop:ui` at exit 0 and every check in this section green — Vite hands
+TypeScript to esbuild, which strips types without reading them.
+
+What catches it is `tsc -b` in the *web* `quality-gates` job, which reaches the
+renderer through one `references` line in the root `tsconfig.json`. Delete that
+line and `src/desktop` stops being typechecked by anything at all.
+`src/desktop/__tests__/desktopIsGated.test.ts` is that line, asserted.
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -85,7 +85,9 @@
     "prepare": "husky",
     "desktop:ui": "vite build --config apps/desktop/vite.config.ts",
     "desktop:greps": "node scripts/desktop-bundle-greps.mjs",
-    "desktop:verify": "npm run desktop:ui && npm run desktop:greps",
+    "bundle:check:desktop": "node scripts/desktop-bundle-size.mjs",
+    "bundle:report:desktop": "node scripts/desktop-bundle-size.mjs --report",
+    "desktop:verify": "npm run desktop:ui && npm run desktop:greps && npm run bundle:check:desktop",
     "desktop:build": "npm run desktop:ui && cargo build --manifest-path apps/desktop/src-tauri/Cargo.toml --release",
     "desktop:check": "cargo clippy --manifest-path apps/desktop/src-tauri/Cargo.toml --all-targets -- -D warnings && cargo test --manifest-path apps/desktop/src-tauri/Cargo.toml"
   },

--- a/scripts/desktop-bundle-size.mjs
+++ b/scripts/desktop-bundle-size.mjs
@@ -1,0 +1,213 @@
+#!/usr/bin/env node
+
+/**
+ * THE DESKTOP RENDERER'S SIZE RATCHET.
+ *
+ *   npm run bundle:check:desktop     (build first: npm run desktop:ui)
+ *
+ * `scripts/bundle-size-check.mjs` does this for the web build. This is the same
+ * instrument with the same shape — budgets as constants, a measured baseline
+ * recorded beside them, an env override for experiments, non-zero exit when a
+ * budget is passed — pointed at `apps/desktop/dist` and answering to different
+ * numbers, for a different reason.
+ *
+ * ── WHY RAW BYTES ARE THE GATE HERE, AND GZIP IS NOT THE HEADLINE ───────────
+ *
+ * The web gate measures gzip because gzip is what a browser downloads: it is
+ * the number a person waits for. NOTHING IS DOWNLOADED HERE. `tauri.conf.json`
+ * names `apps/desktop/dist` as `frontendDist` and `tauri::generate_context!`
+ * embeds those files into the binary at compile time, so the bytes this build
+ * emits are bytes on the user's disk and bytes the WebView parses when the
+ * window opens. Compression never enters it.
+ *
+ * So RAW is the number with a consequence and it is the one that fails a build.
+ * Gzip is measured and budgeted anyway, two reasons: `apps/desktop/README.md`
+ * has been quoting a gzip figure since slice 29 and a quoted number nobody runs
+ * is a number that decays, and it is the only figure directly comparable with
+ * the web bundle's — the two editions ship the same components eventually, and
+ * the day that comparison matters it should not have to be re-derived.
+ *
+ * ── WHAT THIS IS ACTUALLY GUARDING AGAINST ──────────────────────────────────
+ *
+ * One specific future event. The renderer is 259 KiB today because it mounts a
+ * chooser and a ledger screen. `docs/edition-gating.md` records the measurement
+ * that says what happens next: a runtime import walk from `components/Layout`
+ * reaches 144 modules and five independent cloud roots. When the app's screens
+ * are mounted in the window — the next programme of work — they arrive through
+ * that graph, and they arrive all at once.
+ *
+ * `desktop:greps` catches the part of that arrival which is a broken promise (a
+ * Supabase client, browser storage, Clerk). It cannot catch the part which is
+ * merely enormous: a renderer that doubled in size while staying perfectly
+ * cloud-free passes every check this repository had before this file. That is
+ * the gap, and 25 KiB of headroom is how wide it is allowed to be before
+ * somebody has to make the growth a deliberate decision rather than a diff.
+ *
+ * ── IT REFUSES RATHER THAN SKIPS ────────────────────────────────────────────
+ *
+ * No build, no answer, non-zero exit — the same ruling `desktop:greps` and the
+ * local contract suite already carry (R-8). A size gate that passes because it
+ * measured an empty directory is a gate that reports green on a failed build.
+ *
+ * ── THE BINARY IS RECORDED AND NEVER GATED ──────────────────────────────────
+ *
+ * The 16 MB figure in `apps/desktop/README.md` was measured by hand once. This
+ * prints it when there is a binary to read, so it stops being a claim. It is
+ * NOT a budget, and must not become one here, because its size is a function of
+ * the toolchain, the platform and the profile: CI's Linux binary and a
+ * developer's arm64 macOS binary are different artefacts and neither is the
+ * other's regression. A binary budget belongs to a release job that builds one
+ * target, not to a check that runs wherever it is run.
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+import zlib from 'node:zlib';
+import { fileURLToPath } from 'node:url';
+
+const REPO = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const DIST = path.join(REPO, 'apps', 'desktop', 'dist');
+const BINARY = path.join(REPO, 'apps', 'desktop', 'src-tauri', 'target', 'release', 'wealthtracker-desktop');
+
+/**
+ * BASELINE, measured 2026-08-12 at slice 30 on `npm run desktop:ui`:
+ *
+ *   assets/index-*.js    263,715 raw   87,730 gzip
+ *   assets/index-*.css       721 raw      412 gzip
+ *   index.html             1,127 raw      631 gzip
+ *   ──────────────────────────────────────────────
+ *   total                265,563 raw   88,773 gzip
+ *                       (259.3 KiB)   (86.7 KiB)
+ *
+ * React, React DOM and the router, mounted (slice 29). It was 81.8 kB raw when
+ * it was one screen of vanilla DOM, which is the last time this number moved
+ * for a reason anybody would recognise a year later.
+ *
+ * Budgets are ~10% above that. Lower them if the renderer ever gets smaller;
+ * raising them is allowed, but it is a decision that belongs in a commit
+ * message — not a number quietly nudged until the build goes green.
+ */
+const BASELINE_TOTAL_RAW_KIB = 259.3;
+const BASELINE_TOTAL_GZIP_KIB = 86.7;
+
+const MAX_TOTAL_RAW_KIB = Number(process.env.DESKTOP_MAX_TOTAL_RAW_KIB ?? 285);
+const MAX_TOTAL_GZIP_KIB = Number(process.env.DESKTOP_MAX_TOTAL_GZIP_KIB ?? 96);
+
+const isReport = process.argv.includes('--report');
+
+const say = message => process.stdout.write(`${message}\n`);
+const kib = bytes => `${(bytes / 1024).toFixed(1)} KiB`;
+
+const filesUnder = (dir, out = []) => {
+  for (const entry of fs.readdirSync(dir)) {
+    const full = path.join(dir, entry);
+    if (fs.statSync(full).isDirectory()) filesUnder(full, out);
+    else out.push(full);
+  }
+  return out;
+};
+
+if (!fs.existsSync(DIST)) {
+  say('');
+  say('desktop bundle size — REFUSED');
+  say('');
+  say(`  There is no build to measure: ${path.relative(REPO, DIST)} does not exist.`);
+  say('  Run `npm run desktop:ui` first. This does not skip, because a size gate');
+  say('  that passes when there is nothing to weigh reports green on a failed build.');
+  say('');
+  process.exit(1);
+}
+
+const assets = filesUnder(DIST)
+  .map(file => {
+    const bytes = fs.readFileSync(file);
+    return {
+      name: path.relative(DIST, file),
+      raw: bytes.length,
+      gzip: zlib.gzipSync(bytes, { level: 9 }).length
+    };
+  })
+  .sort((a, b) => b.raw - a.raw);
+
+if (assets.length === 0) {
+  say('');
+  say('desktop bundle size — REFUSED');
+  say('');
+  say(`  ${path.relative(REPO, DIST)} exists but is empty. The build did not emit anything.`);
+  say('');
+  process.exit(1);
+}
+
+const totalRaw = assets.reduce((sum, asset) => sum + asset.raw, 0);
+const totalGzip = assets.reduce((sum, asset) => sum + asset.gzip, 0);
+const largest = assets[0];
+
+const drift = (measuredKib, baselineKib) => {
+  const delta = measuredKib - baselineKib;
+  if (Math.abs(delta) < 0.05) return 'on baseline';
+  return `${delta > 0 ? '+' : ''}${delta.toFixed(1)} KiB vs baseline ${baselineKib} KiB`;
+};
+
+say('');
+say('desktop renderer size — the bytes the binary embeds');
+say('');
+say(`  bundle            ${path.relative(REPO, DIST)}`);
+say(`  files             ${assets.length}`);
+say(`  largest           ${kib(largest.raw)} raw  ${largest.name}`);
+say('');
+say(`  total raw         ${kib(totalRaw).padStart(10)}   budget ${MAX_TOTAL_RAW_KIB} KiB   ${drift(totalRaw / 1024, BASELINE_TOTAL_RAW_KIB)}`);
+say(`  total gzip        ${kib(totalGzip).padStart(10)}   budget ${MAX_TOTAL_GZIP_KIB} KiB   ${drift(totalGzip / 1024, BASELINE_TOTAL_GZIP_KIB)}`);
+
+if (isReport) {
+  say('');
+  say('  per file (raw / gzip)');
+  for (const asset of assets) {
+    say(`    ${kib(asset.raw).padStart(10)}  ${kib(asset.gzip).padStart(10)}  ${asset.name}`);
+  }
+}
+
+say('');
+if (fs.existsSync(BINARY)) {
+  const bytes = fs.statSync(BINARY).size;
+  // MiB, to match the KiB above. The README's "16 MB" was the same bytes in
+  // decimal units; both are printed so neither reading looks like a regression.
+  say(
+    `  binary            ${(bytes / 1024 / 1024).toFixed(1)} MiB ` +
+      `(${(bytes / 1e6).toFixed(1)} MB)  ${path.relative(REPO, BINARY)}`
+  );
+  say('                    recorded, never gated — its size is a function of the');
+  say('                    toolchain and the platform, so two machines disagree');
+  say('                    without either of them having regressed.');
+} else {
+  say('  binary            not built here (npm run desktop:build) — nothing to record.');
+  say('                    This is not a failure: the renderer is what this gate weighs.');
+}
+
+const failures = [];
+if (totalRaw > MAX_TOTAL_RAW_KIB * 1024) {
+  failures.push(
+    `total raw ${kib(totalRaw)} exceeds budget ${MAX_TOTAL_RAW_KIB} KiB.\n` +
+      '    Raw is the gate here because nothing is downloaded: these bytes are\n' +
+      '    embedded in the binary and parsed when the window opens.'
+  );
+}
+if (totalGzip > MAX_TOTAL_GZIP_KIB * 1024) {
+  failures.push(`total gzip ${kib(totalGzip)} exceeds budget ${MAX_TOTAL_GZIP_KIB} KiB.`);
+}
+
+say('');
+if (failures.length > 0) {
+  say('FAIL  the desktop renderer grew past its ratchet');
+  say('');
+  for (const failure of failures) say(`  - ${failure}`);
+  say('');
+  say('  If a module arrived by accident, `npm run desktop:ui` names it: build with');
+  say('  the renderer config and read what the 59-module graph turned into.');
+  say('  If the growth is intended, raise the budget in this file deliberately and');
+  say('  say why in the commit — that is the whole difference between a ratchet and');
+  say('  a number that drifts.');
+  say('');
+  process.exit(1);
+}
+say('PASS  the desktop renderer is within its ratchet');
+say('');

--- a/scripts/local-db/README.md
+++ b/scripts/local-db/README.md
@@ -14,11 +14,24 @@ discovered in production.
 ## Use
 
 ```bash
-brew install postgresql@17     # once
+brew install postgresql@17     # once, on macOS
 bash scripts/local-db/up.sh    # init + start + apply every migration
 bash scripts/local-db/test.sh  # run the SQL tests
 bash scripts/local-db/down.sh  # stop and delete the cluster
 ```
+
+`WT_PGDATA` (default `/tmp/wtpg`) and `WT_PGPORT` (default `55432`) pick the
+cluster, so a second one can be stood up beside the first without disturbing it
+— which is how the from-scratch run below was checked.
+
+**Finding the binaries.** `pgbin.sh` is sourced by all three scripts and locates
+`initdb`/`pg_ctl` itself: `WT_PGBIN` if set, then homebrew's
+`postgresql@17`, then Debian's `/usr/lib/postgresql/<major>/bin` (highest
+version). This used to be one hardcoded homebrew path in three places, which was
+true on one machine. CI runs on Linux, where those are *server* binaries and
+Debian deliberately keeps them off `PATH`. `up.sh` refuses with instructions if
+none is found; `down.sh` does not, because it must still be able to clean up on
+a machine where Postgres has since been removed.
 
 ## Caveats, so the harness is not mistaken for the real thing
 
@@ -28,8 +41,25 @@ bash scripts/local-db/down.sh  # stop and delete the cluster
 - **RLS is created but never exercised** — psql connects as superuser, which
   bypasses it. These tests prove logic, not isolation. Row-level isolation is
   still only provable against a real Supabase (`npm run test:supabase-smoke`).
-- **Four migrations do not apply**: two early subscription files and two RLS
-  files that depend on Supabase-managed roles. They do not affect the tables
-  under test. `up.sh` reports them rather than hiding them.
 - Migrations are applied in **three passes** because filename order is not
-  dependency order — the baseline dump sorts after some files it contains.
+  dependency order — the baseline dump sorts after some files it contains, so a
+  file can fail on pass 1 for want of something a later file creates.
+- **Every migration applies.** Measured 2026-08-12 on a cluster built from
+  scratch: `unapplied: 0`.
+
+  This README said "four migrations do not apply" for months and the script
+  agreed with it, reporting seven. **Both were an accounting bug.** A migration
+  that succeeded on pass 1 was re-run on passes 2 and 3, where it failed with
+  *"already exists"* on its own work, and the number printed was the last pass's
+  failures — so every non-idempotent migration in the history counted as
+  unapplied. Three of the seven were the local edition's own
+  (`rows_cannot_name_a_foreign_account`, `preferences_that_travel`,
+  `repoint_transfer`) and all three were present in the catalog the whole time.
+  `up.sh` now skips what has already succeeded, so *unapplied* means unapplied.
+
+  The reason this mattered enough to fix: a nightly builds this cluster from
+  nothing every run, and a line reading `unapplied: 7` in a CI log is one that
+  has to be investigated by hand before anyone can tell whether it is a problem.
+- **`up.sh` exits 0 even so, on purpose.** It is not the gate. If a migration
+  that matters ever fails, a spec in `scripts/local-sqlite` goes red and names
+  the constraint it wanted — a better error than any count printed here.

--- a/scripts/local-db/down.sh
+++ b/scripts/local-db/down.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
-export PATH="/opt/homebrew/opt/postgresql@17/bin:$PATH"
+# shellcheck source=scripts/local-db/pgbin.sh
+. "$(cd "$(dirname "$0")" && pwd)/pgbin.sh"
 D=${WT_PGDATA:-/tmp/wtpg}
 pg_ctl -D "$D" stop >/dev/null 2>&1
 rm -rf "$D"

--- a/scripts/local-db/pgbin.sh
+++ b/scripts/local-db/pgbin.sh
@@ -1,0 +1,46 @@
+# shellcheck shell=bash
+# WHERE THE POSTGRES BINARIES ARE. Sourced by up.sh, test.sh and down.sh.
+# (No shebang: this file is sourced, never executed. The directive above is how
+# shellcheck is told which shell to assume for a fragment.)
+#
+# This was one hardcoded homebrew path in three scripts, which was true on the
+# machine it was written on and nowhere else. CI runs the harness on Linux,
+# where the tools live under /usr/lib/postgresql/<major>/bin and are NOT on PATH
+# — `initdb` and `pg_ctl` are server binaries and Debian keeps them out of it on
+# purpose, so a script that assumes PATH finds the client and not the server.
+#
+# `WT_PGBIN` overrides everything, then the two known layouts, then whatever
+# PATH already has. Nothing here fails: `down.sh` must still be able to run when
+# there is no Postgres left to find. up.sh does the refusing, because it is the
+# one that cannot proceed.
+#
+# LC_ALL=C is set here too, on every platform, deliberately. macOS aborts the
+# postmaster ("became multithreaded during startup") without it, and the
+# harness's collation caveat — scripts/local-sqlite/README.md, spec x1-* — is
+# written against an SQL_ASCII cluster. Letting Linux default to UTF8 would make
+# the two platforms disagree about case folding and quietly flip that spec from
+# a declared match to an unnoticed divergence.
+
+export LC_ALL=C
+
+if [ -z "${WT_PGBIN:-}" ]; then
+  # `printf` over the glob rather than `ls`: if nothing matches, the pattern
+  # comes back unexpanded and simply fails the -x test below, which is the
+  # behaviour wanted on a machine with no Debian-layout Postgres at all.
+  for _pg_candidate in \
+    /opt/homebrew/opt/postgresql@17/bin \
+    /usr/local/opt/postgresql@17/bin \
+    "$(printf '%s\n' /usr/lib/postgresql/*/bin | sort -V | tail -1)"
+  do
+    if [ -x "$_pg_candidate/pg_ctl" ]; then
+      WT_PGBIN="$_pg_candidate"
+      break
+    fi
+  done
+  unset _pg_candidate
+fi
+
+if [ -n "${WT_PGBIN:-}" ]; then
+  export WT_PGBIN
+  export PATH="$WT_PGBIN:$PATH"
+fi

--- a/scripts/local-db/test.sh
+++ b/scripts/local-db/test.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
 set -u
-export PATH="/opt/homebrew/opt/postgresql@17/bin:$PATH"
-export LC_ALL=C
-D=${WT_PGDATA:-/tmp/wtpg}; PORT=${WT_PGPORT:-55432}
 here="$(cd "$(dirname "$0")" && pwd)"
+# shellcheck source=scripts/local-db/pgbin.sh
+. "$here/pgbin.sh"
+D=${WT_PGDATA:-/tmp/wtpg}; PORT=${WT_PGPORT:-55432}
 rc=0
 for t in "$here"/*.test.sql; do
   echo "── $(basename "$t")"

--- a/scripts/local-db/up.sh
+++ b/scripts/local-db/up.sh
@@ -1,8 +1,21 @@
 #!/bin/bash
 # Throwaway local Postgres with the full migration history applied.
 set -u
-export PATH="/opt/homebrew/opt/postgresql@17/bin:$PATH"
-export LC_ALL=C
+
+# shellcheck source=scripts/local-db/pgbin.sh
+. "$(cd "$(dirname "$0")" && pwd)/pgbin.sh"
+
+# It REFUSES rather than continuing without initdb: the failure from carrying on
+# is "command not found" three lines into a cluster that half exists, which
+# reads like a broken script rather than a missing dependency.
+if ! command -v initdb >/dev/null 2>&1; then
+  echo "no PostgreSQL server binaries found (initdb)." >&2
+  echo "  macOS:         brew install postgresql@17" >&2
+  echo "  Debian/Ubuntu: apt-get install postgresql  (lands in /usr/lib/postgresql/<major>/bin)" >&2
+  echo "  or set WT_PGBIN to the directory holding initdb/pg_ctl." >&2
+  exit 1
+fi
+
 D=${WT_PGDATA:-/tmp/wtpg}
 PORT=${WT_PGPORT:-55432}
 MIG="$(cd "$(dirname "$0")/../../supabase/migrations" && pwd)"
@@ -40,16 +53,39 @@ BASE=20251030003814__initial-schema.sql
 run -v ON_ERROR_STOP=1 -f "$BASE" >/tmp/wt-base.log 2>&1 || { echo "baseline FAILED"; tail -5 /tmp/wt-base.log; exit 1; }
 
 # Three passes: filename order is not dependency order (the baseline dump sorts
-# after files it already contains), and most migrations are idempotent.
+# after files it already contains), so a migration can fail on pass 1 for want
+# of something a later file creates, and succeed on pass 2.
+#
+# A MIGRATION THAT HAS ALREADY SUCCEEDED IS NEVER RE-RUN. It used to be, and the
+# count this script printed was therefore the LAST pass's failures — which is
+# every non-idempotent migration in the history, each failing with "already
+# exists" on work it had itself done a pass earlier. A fresh cluster reported
+# "unapplied: 7" while holding all seven, three of them the local edition's own
+# (`rows_cannot_name_a_foreign_account`, `preferences_that_travel`,
+# `repoint_transfer`). Anyone reading that line had to go and check the catalog
+# by hand to find out whether it mattered, which is the same as not printing it.
+# Now "unapplied" means unapplied.
+applied=""
 for pass in 1 2 3; do
   fail=0; fails=""
   for f in $(ls *.sql | sort); do
     [[ "$f" == "$BASE" ]] && continue
     [[ "${f:0:14}" < "20251030003814" ]] && continue
-    run -v ON_ERROR_STOP=1 -f "$f" >/tmp/wt-mig.log 2>&1 || { fail=$((fail+1)); fails="$fails $f"; }
+    case " $applied " in *" $f "*) continue ;; esac
+    if run -v ON_ERROR_STOP=1 -f "$f" >/tmp/wt-mig.log 2>&1; then
+      applied="$applied $f"
+    else
+      fail=$((fail+1)); fails="$fails $f"
+    fi
   done
   [ "$fail" -eq 0 ] && break
 done
 echo "local db ready on port $PORT (unapplied: ${fail:-0})"
 [ "${fail:-0}" -gt 0 ] && echo "  not applied:$fails" | tr ' ' '\n' | grep -v '^$'
+
+# Exit 0 even with unapplied files, on purpose. Four of them cannot apply here
+# by design (two early subscription files, two RLS files needing Supabase-managed
+# roles) and none of them touches a table under test. The GATE is not this
+# script — it is the specs: if a migration that matters is missing, a spec in
+# scripts/local-sqlite goes red and names the constraint it wanted.
 exit 0

--- a/scripts/local-sqlite/README.md
+++ b/scripts/local-sqlite/README.md
@@ -2,7 +2,7 @@
 
 Applies the proposed local-edition SQLite schema and the cloud's Postgres schema
 side by side, runs the same operation against both, and records what each one
-does with it. Sixty-six specs, one declarative invariant each.
+does with it. Sixty-seven specs, one declarative invariant each.
 
 **Three lanes live in this directory now**, and they ask three different
 questions. `run.mjs` asks whether a SCHEMA refuses a write; `verbs.mjs` asks
@@ -515,7 +515,7 @@ in `src/` or `api/` calls them, and `schema.sql` already carries them as C-3, C-
 and C-5. And there is **no create/update/delete-category verb because the cloud
 has no such RPC** — `PlanningService` writes the table directly
 (`planningService.ts:479`, `:567`, `:638`), so the authority for those operations
-is the table plus its constraints, which the 64 constraint specs already cover.
+is the table plus its constraints, which the 67 constraint specs already cover.
 One category RPC that DOES exist is deliberately not ported and the decision is
 written down in `verbs/mod.rs`: `migrate_categories_atomic`, the one-way door
 between the localStorage id space and the cloud's uuids, which has no meaning in
@@ -788,11 +788,17 @@ Each of these was executed, then reverted.
 
 ### Current run
 
-**459 verb specs · 459 pass · 25 declared divergences · 24 single-engine**,
-2026-08-11, against a reference cluster rebuilt from the full migration history.
-`npm run test:local-sqlite` is **67/67 for the first time since
-20260810200000 landed in the cloud** (see A-3 above),
-`npm run test:local-admission` is 109/109 and `cargo test` is **420**.
+**474 verb specs · 474 pass · 26 declared divergences · 24 single-engine**,
+2026-08-12, against a reference cluster rebuilt from the full migration history.
+`npm run test:local-sqlite` is **67/67**, `npm run test:local-admission` is
+109/109 and `cargo test` is **468**.
+
+Re-measured at slice 30 on a cluster built **from scratch** — `initdb`, then the
+whole migration history — rather than on the one that had been accumulating on
+this machine since slice 18. That distinction had never been tested before and
+it is the one CI depends on: a nightly gets a fresh cluster every time. Both
+lanes give the same numbers on both, which is the result that made the nightly
+in `.github/workflows/local-edition-nightly.yml` worth wiring.
 
 The reconciliation and archive family adds 26 — six for `set_transactions_cleared`,
 eight for `finalize_reconciliation`, four for `set_transactions_archived`, four
@@ -1550,18 +1556,30 @@ and both are places the port says MORE than its oracle.
 path and the admission surface all exist, all have executable proofs, and the
 proofs run in three lanes in this directory:
 
-| | count | oracle |
-| --- | --- | --- |
-| constraint specs (`run.mjs`) | 66 | the cloud's Postgres schema |
-| verb specs (`verbs.mjs`) | 308 | the live Postgres RPCs |
-| admission specs (`admission.mjs`) | 109 | the TypeScript modules that ship today |
-| crate tests (`cargo test`) | 270 | — |
+Counts re-measured 2026-08-12 (slice 30). They had drifted — this table said
+66 / 308 / 270 and the "current run" section above said 459 and 420 — which is
+the ordinary fate of a number typed into prose. Every figure below is now also
+printed by the command beside it, so the next drift is one `npm run` away from
+being visible.
 
-**483 specs and 29 declared divergences, every divergence pinned from both
-sides.** Of the 483, **459 actually compare two implementations**: the other 24
+| | count | oracle | where it runs |
+| --- | --- | --- | --- |
+| constraint specs (`run.mjs`) | 67 | the cloud's Postgres schema | nightly (needs the cluster) |
+| verb specs (`verbs.mjs`) | 474 | the live Postgres RPCs | nightly (needs the cluster) |
+| admission specs (`admission.mjs`) | 109 | the TypeScript modules that ship today | **every PR** |
+| crate tests (`cargo test`) | 468 | — | **every PR** |
+
+**650 specs and 30 declared divergences, every divergence pinned from both
+sides.** Of the 650, **626 actually compare two implementations**: the other 24
 are `verify_integrity`'s, which run on one engine because the cloud has no such
 function, and they are counted separately by their own runner for exactly that
 reason.
+
+The fourth column is slice 30's, and the split in it is by COST, never by
+importance — `docs/edition-gating.md` argues it out. The two lanes that need a
+PostgreSQL cluster with 51 migrations applied are the most load-bearing thing
+here and they are nightly because standing that cluster up takes longer than
+everything else on a pull request put together.
 
 That is what closed means. Here is what it does not.
 

--- a/scripts/local-sqlite/lib/postgres.mjs
+++ b/scripts/local-sqlite/lib/postgres.mjs
@@ -5,8 +5,8 @@
 // harness is a shell script that runs *.test.sql files and greps their output,
 // which is the right shape for a hand-written SQL test and the wrong shape for a
 // spec that has to report accepted-vs-refused per statement. So this file talks
-// to the same cluster with the same conventions (WT_PGDATA, WT_PGPORT, LC_ALL=C,
-// the homebrew postgresql@17 PATH) and drives psql itself.
+// to the same cluster with the same conventions (WT_PGBIN, WT_PGDATA, WT_PGPORT,
+// LC_ALL=C) and drives psql itself.
 //
 // NOTHING under scripts/local-db is modified. The two harnesses share a cluster
 // and nothing else.
@@ -20,12 +20,21 @@ const SETUP_OK = '__SETUP_OK__';
 const ACTION_OK = '__ACTION_OK__';
 const VERIFY = '__V__';
 
+/**
+ * `WT_PGBIN` first, because it is what scripts/local-db/pgbin.sh exports after
+ * finding the cluster's own binaries — on Linux those are under
+ * /usr/lib/postgresql/<major>/bin and not on PATH at all. The homebrew path
+ * stays as the macOS default so a developer who never sets anything is
+ * unaffected, and PATH last so a psql already there still wins over nothing.
+ */
 function psqlEnv() {
+  const prefix = [process.env.WT_PGBIN, '/opt/homebrew/opt/postgresql@17/bin'].filter(Boolean);
   return {
     ...process.env,
-    PATH: `/opt/homebrew/opt/postgresql@17/bin:${process.env.PATH ?? ''}`,
-    // scripts/local-db/up.sh sets this and says why: without it macOS aborts the
-    // server with "postmaster became multithreaded during startup".
+    PATH: [...prefix, process.env.PATH ?? ''].join(':'),
+    // scripts/local-db/pgbin.sh sets this and says why: without it macOS aborts
+    // the server with "postmaster became multithreaded during startup", and the
+    // resulting SQL_ASCII cluster is what spec x1-* is written against.
     LC_ALL: 'C',
   };
 }

--- a/scripts/local-sqlite/lib/verb-postgres.mjs
+++ b/scripts/local-sqlite/lib/verb-postgres.mjs
@@ -1812,10 +1812,12 @@ END
 $wtblock$;`;
 }
 
+/** `WT_PGBIN` first — see lib/postgres.mjs's copy for why. */
 function psqlEnv() {
+  const prefix = [process.env.WT_PGBIN, '/opt/homebrew/opt/postgresql@17/bin'].filter(Boolean);
   return {
     ...process.env,
-    PATH: `/opt/homebrew/opt/postgresql@17/bin:${process.env.PATH ?? ''}`,
+    PATH: [...prefix, process.env.PATH ?? ''].join(':'),
     LC_ALL: 'C',
   };
 }

--- a/scripts/local-sqlite/lib/verb-sqlite.mjs
+++ b/scripts/local-sqlite/lib/verb-sqlite.mjs
@@ -18,7 +18,7 @@
 // WHO OWNS THE FILE
 // -----------------
 // Node creates the temp database, applies scripts/local-sqlite/schema.sql and
-// the shared fixture through node:sqlite — the same code path the 54 constraint
+// the shared fixture through node:sqlite — the same code path the 67 constraint
 // specs use — then hands the *path* to Rust, then re-opens the file on a fresh
 // connection to run the state assertions. So:
 //

--- a/scripts/local-sqlite/verbs.mjs
+++ b/scripts/local-sqlite/verbs.mjs
@@ -13,7 +13,7 @@
 //
 // SIBLING, NOT AN EXTENSION, OF run.mjs
 // -------------------------------------
-// The 54 constraint specs prove that a schema refuses a write. A verb spec
+// The 67 constraint specs prove that a schema refuses a write. A verb spec
 // proves that two implementations of one operation agree — on what they return,
 // on what they refuse, AND on the rows they leave behind. Those are different
 // questions with different spec shapes (a constraint spec carries SQL per
@@ -21,7 +21,10 @@
 // would mean a spec file that can be either, which is a spec file that has to be
 // read twice before you know what it is.
 //
-// `npm run test:local-sqlite` is unchanged and still 54/54.
+// `npm run test:local-sqlite` is unchanged and still passes whole: 67/67 as of
+// 2026-08-12. (It said "54/54" here for eleven slices after the constraint lane
+// grew past 54, which is the argument for the sentence above this one being the
+// durable claim and the number being the perishable one.)
 
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';

--- a/src/desktop/__tests__/desktopIsGated.test.ts
+++ b/src/desktop/__tests__/desktopIsGated.test.ts
@@ -1,0 +1,169 @@
+/**
+ * THE DESKTOP'S GATES ARE WIRED — the wiring itself, asserted.
+ *
+ * Every other check in this directory asks something about the renderer. This
+ * one asks whether the checks are connected to anything, because slice 30
+ * measured what happens when one of them is not, and the answer was silence.
+ *
+ * ── THE MEASUREMENT THIS FILE EXISTS BECAUSE OF ─────────────────────────────
+ *
+ * A type error was planted in `src/desktop/tauriShell.ts` (2026-08-12):
+ *
+ *     npm run desktop:ui          exit 0   — BUILT IT ANYWAY
+ *     npm run typecheck:strict    exit 2   — src/desktop/tauriShell.ts(27,9)
+ *
+ * Vite hands TypeScript to esbuild, which strips types and never checks them.
+ * So the desktop renderer's type safety rests entirely on `tsc -b` reaching
+ * `tsconfig.desktop.json`, and `tsc -b` reaches it through one line in the root
+ * `tsconfig.json`. Delete that line and the renderer stops being typechecked by
+ * anything at all — while `npm run desktop:ui`, `desktop:greps`,
+ * `bundle:check:desktop` and every suite in this directory stay green, because
+ * not one of them reads a type.
+ *
+ * `apps/desktop/README.md` puts the general form of this well: *"a wiring
+ * decision that nothing checks is a wiring decision that drifts"*. That
+ * sentence was written about which directory the renderer lives in. It is just
+ * as true of the four lines below it.
+ *
+ * ── AND THE SAME ARGUMENT, ONE LEVEL OUT ────────────────────────────────────
+ *
+ * `scripts/desktop-bundle-greps.mjs` exists because slice 27's README claimed
+ * a bundle was cloud-free and nothing re-checked the claim. A CI workflow is
+ * the same kind of object: a step quietly dropped from a YAML file removes a
+ * gate without removing anything that looks like a gate. So the workflows are
+ * read here too — by the npm script they invoke, not by line or by order, so
+ * that rearranging a job is free and deleting a check is not.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import ts from 'typescript';
+
+const REPO = path.resolve(__dirname, '..', '..', '..');
+const read = (relative: string): string => readFileSync(path.join(REPO, relative), 'utf8');
+
+/**
+ * JSON with comments — every tsconfig in this repo has them, and they are the
+ * good kind, so nothing here is going to ask for them to be removed.
+ *
+ * The compiler's own parser rather than a regex that strips `/* … *\/` and
+ * `//`. That regex was written first and it got this wrong: these files contain
+ * multi-line block comments inside object literals, and a stripper that does
+ * not track whether it is inside a string produces JSON that fails to parse for
+ * reasons having nothing to do with what is being asserted. Using the tool that
+ * defines the format is both shorter and correct.
+ */
+const readJsonc = (relative: string): unknown => {
+  const parsed = ts.parseConfigFileTextToJson(relative, read(relative));
+  if (parsed.error !== undefined) {
+    throw new Error(
+      `${relative} is not valid tsconfig JSON: ${ts.flattenDiagnosticMessageText(parsed.error.messageText, ' ')}`
+    );
+  }
+  return parsed.config;
+};
+
+interface TsConfig {
+  readonly references?: ReadonlyArray<{ readonly path?: string }>;
+  readonly include?: readonly string[];
+  readonly exclude?: readonly string[];
+}
+
+const asTsConfig = (value: unknown): TsConfig => {
+  if (typeof value !== 'object' || value === null) throw new Error('tsconfig is not an object');
+  return value as TsConfig;
+};
+
+describe('the desktop renderer is actually typechecked', () => {
+  it('is a referenced project of the root tsconfig, which is the only thing that checks it', () => {
+    const root = asTsConfig(readJsonc('tsconfig.json'));
+    const referenced = (root.references ?? []).map(reference => reference.path);
+
+    // Measured, not assumed: `npm run desktop:ui` exits 0 on a renderer with a
+    // type error in it. If this reference goes, nothing replaces it.
+    expect(referenced).toContain('./tsconfig.desktop.json');
+  });
+
+  it('claims src/desktop, and the web project disclaims it', () => {
+    const desktop = asTsConfig(readJsonc('tsconfig.desktop.json'));
+    const app = asTsConfig(readJsonc('tsconfig.app.json'));
+
+    expect(desktop.include ?? []).toContain('src/desktop');
+    // Both projects owning the same files is what `tsc -b` composite builds
+    // forbid; stating it here means the failure names the overlap rather than
+    // arriving as "file is not listed within the file list of project".
+    expect(app.exclude ?? []).toContain('src/desktop/**');
+  });
+});
+
+describe('the desktop gates are connected to CI', () => {
+  const packageJson: unknown = JSON.parse(read('package.json'));
+  const scripts = ((): Readonly<Record<string, string>> => {
+    if (typeof packageJson !== 'object' || packageJson === null) throw new Error('no package.json');
+    const found = (packageJson as { scripts?: unknown }).scripts;
+    if (typeof found !== 'object' || found === null) throw new Error('no scripts');
+    return found as Readonly<Record<string, string>>;
+  })();
+
+  const PR_WORKFLOW = '.github/workflows/handoff-snapshot.yml';
+  const NIGHTLY_WORKFLOW = '.github/workflows/local-edition-nightly.yml';
+
+  /**
+   * Each gate, where it runs, and what only it can catch. The third column is
+   * not decoration: it is the reason a future reader may not move a row to the
+   * nightly column to make a pull request faster.
+   */
+  const ON_EVERY_PR = [
+    { script: 'desktop:ui', catches: 'the renderer no longer builds' },
+    { script: 'desktop:greps', catches: 'a cloud SDK reached the built bundle' },
+    { script: 'bundle:check:desktop', catches: 'the renderer grew past its ratchet' },
+    { script: 'test:local-contract', catches: 'the ledger stopped honouring the port contract' },
+    { script: 'test:local-admission', catches: 'the Rust and TypeScript admission rules diverged' }
+  ] as const;
+
+  const NIGHTLY = [
+    { script: 'test:local-sqlite', needs: 'a Postgres cluster with the migration history' },
+    { script: 'test:local-verbs', needs: 'the same cluster, and the release bridge' },
+    { script: 'desktop:check', needs: "the Rust toolchain and Tauri's Linux -dev packages" },
+    { script: 'desktop:build', needs: 'the same, plus a release link of 454 crates' }
+  ] as const;
+
+  it.each([...ON_EVERY_PR, ...NIGHTLY])('package.json defines $script', ({ script }) => {
+    expect(Object.keys(scripts)).toContain(script);
+  });
+
+  it('runs every per-PR gate on every pull request', () => {
+    const workflow = read(PR_WORKFLOW);
+    // Matched on the invocation rather than on a step name, so a job can be
+    // renamed or reordered freely and only a DELETED check fails this.
+    const missing = ON_EVERY_PR.filter(gate => !workflow.includes(`npm run ${gate.script}`)).map(
+      gate => `${gate.script} — nothing else catches: ${gate.catches}`
+    );
+    expect(missing).toEqual([]);
+  });
+
+  it('runs every environment-heavy gate nightly', () => {
+    const workflow = read(NIGHTLY_WORKFLOW);
+    const missing = NIGHTLY.filter(gate => !workflow.includes(`npm run ${gate.script}`)).map(
+      gate => `${gate.script} — it is nightly because it needs ${gate.needs}`
+    );
+    expect(missing).toEqual([]);
+  });
+
+  it('never lets a desktop or local gate degrade to green', () => {
+    // supabase-smoke.yml's ruling, applied here: a nightly that cannot go red
+    // is theatre. `continue-on-error` is how a gate stops being one without
+    // anybody deleting it.
+    for (const workflow of [NIGHTLY_WORKFLOW, PR_WORKFLOW]) {
+      const jobs = read(workflow);
+      const offending = jobs
+        .split('\n')
+        .filter(line => line.includes('continue-on-error') && line.includes('true'));
+      // The web half of handoff-snapshot.yml has one, on the Supabase migration
+      // lint, which predates this and is not a desktop gate. Anything beyond
+      // that count is new and has to be argued for rather than inherited.
+      expect(offending.length).toBeLessThanOrEqual(workflow === PR_WORKFLOW ? 1 : 0);
+    }
+  });
+});

--- a/src/services/local/localDataPort.ts
+++ b/src/services/local/localDataPort.ts
@@ -320,7 +320,7 @@ import {
  * needs to know which preference keys hold ids, and that constant lived beside a
  * Supabase transport). `backupService.ts` re-exports both, so no existing caller
  * moved. The shell's `openLedgerDocument` supplies `BackupFormat` out of the
- * lifted module, and `desktopBundleIsCloudFree.test.ts` walks the import graph
+ * lifted module, and `deviceDocument.cloudFree.test.ts` walks the import graph
  * from there and fails if a Supabase client is reachable — which is that bundle
  * grep, executed rather than described.
  *


### PR DESCRIPTION
Phase 3, slice 30 — **the plan's final slice.** The desktop joins CI.

## What runs where, split by cost never importance
**On every PR**: `desktop-renderer` (UI build + cloud-free greps + size ratchet — seconds) and `local-core` (clippy, 468 cargo tests, the release bridge, contract 127, admission 109 — ~90 CPU-seconds, zero system dependencies). **Nightly**: the differential lanes (their cluster is 51 migrations + three auth stand-ins over a unix socket — a stock Postgres service container cannot serve them) and the Tauri link (webkit + 262 CPU-seconds to prove the shell links). Node 22 for the local lanes — `node:sqlite` doesn't exist before it; CI's Node 20 would have failed the first run. No third-party actions (public repo); the cache holds the registry, never `target/`.

## The ratchet
`bundle:check:desktop` gates **raw** bytes (nothing is downloaded — they embed in the binary): 259.3 KiB against 285, gzip informational, binary size recorded never gated (a Linux artefact and an arm64 one are not each other's regression). Refuses rather than skips with no build.

## Two findings closed, one accounting bug fixed
Mutation 2 exposed that **Vite doesn't typecheck** — a broken renderer *built* (esbuild strips types); only `tsc` refused it. Closed: `desktopIsGated.test.ts` asserts the typecheck reference exists and that no gate is dropped or made `continue-on-error` in either workflow. And `up.sh`'s "unapplied: 7" was an accounting bug — it re-ran already-applied migrations and reported the last pass's failures; a fresh cluster held all seven all along. Docs trued throughout: the harness README's counts were eleven slices stale; the workflow doc claimed a 75% coverage floor that is actually 63%.

## Flagged for decisions, deliberately not made here
The web bundle sits 2.75% over its budget (pre-existing, proven by identical content-hash on a reverted build — nudging the number until green is the anti-pattern the ratchet script itself argues against), and the coverage floor sits fourteen points under the measured 77.5%. Both are owner decisions.

## Gate
smoke 5,732 · realtime 240 · contract 127 · admission 109 · constraint 67/67 · verbs 474/474 · cargo 468 + shell 12 · clippy clean · desktop:build 16 MB binary · actionlint clean on both workflows · coverage 77.5/82.5 · web bundle **byte-identical**. Two mutations + a bonus on the new test, all red on cue. First real Actions run is this PR itself — the riskiest step (a from-scratch cluster applying every migration) was verified by hand; the two Linux-specific unknowns fail at named steps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)