### PR TITLE
fix(desktop): what the first launch found — five bugs no test could see

### DIFF
--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -59,7 +59,7 @@ wealth-core = { path = "../../../crates/wealth-core" }
 # on which one opened it.
 rusqlite = { version = "0.32", features = ["bundled"] }
 
-tauri = { version = "2", features = [] }
+tauri = { version = "2", features = ["devtools"] }
 # The NATIVE file chooser, and the reason the shell has file commands at all: a
 # path is not a payload. See `src/main.rs`.
 tauri-plugin-dialog = "2"
@@ -80,3 +80,14 @@ expect_used = "deny"
 panic = "deny"
 arithmetic_side_effects = "deny"
 float_arithmetic = "deny"
+
+[features]
+# custom-protocol is what makes a build serve the EMBEDDED dist instead of
+# devUrl. The tauri CLI turns it on for `tauri build` automatically — but this
+# workspace builds with plain `cargo build --release`, which does not, and the
+# first launch proved what that ships: a release window pointed at a dev
+# server that is not running. White, silent, and wrong. Default-on, because
+# every build this repo's scripts produce is meant to stand alone; a dev-server
+# window would be the deliberate exception, not the accident.
+default = ["custom-protocol"]
+custom-protocol = ["tauri/custom-protocol"]

--- a/src/desktop/desktop.css
+++ b/src/desktop/desktop.css
@@ -18,16 +18,18 @@
   font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', system-ui, sans-serif;
 }
 
+/* The body must NOT centre or constrain anything: the full app mounts here,
+   and a centred grid item shrinks to fit — which put the whole product in a
+   34rem column on the first launch. The chooser centres ITSELF instead. */
 body {
   margin: 0;
-  display: grid;
-  place-items: center;
   min-height: 100vh;
 }
 
 .ledger-screen {
   max-width: 34rem;
   padding: 2rem;
+  margin: 18vh auto 0;
 }
 
 .ledger-screen h1 {

--- a/src/desktop/index.html
+++ b/src/desktop/index.html
@@ -20,6 +20,11 @@
   </head>
   <body>
     <div id="root"></div>
+    <!-- Loaded BEFORE the module entry: a module runs all its imports first,
+         which is exactly when early crashes happen, and a handler registered
+         inside the entry would arrive too late. Plain script, so CSP's
+         script-src 'self' admits it. -->
+    <script src="/boot-diagnostics.js"></script>
     <script type="module" src="/main.tsx"></script>
   </body>
 </html>

--- a/src/desktop/main.tsx
+++ b/src/desktop/main.tsx
@@ -39,6 +39,14 @@ import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
 import { DesktopApp } from './DesktopApp';
 import { tauriInvoke } from './tauriShell';
+// The app's OWN stylesheets, exactly as src/main.tsx imports them — the
+// mounted pages are built of Tailwind classes, and a class with no
+// stylesheet is invisible to every jsdom test and glaring in a real
+// WebView, which is precisely how the first launch found this line
+// missing. desktop.css stays last so the chooser's own rules win.
+import '../styles/borders.css';
+import '../styles/accessibility-colors.css';
+import '../index.css';
 import './desktop.css';
 
 const root = document.getElementById('root');

--- a/src/desktop/public/boot-diagnostics.js
+++ b/src/desktop/public/boot-diagnostics.js
@@ -1,0 +1,47 @@
+// Boot-error surface for the desktop shell. A white window is the worst
+// failure mode there is: if the renderer dies before first paint, NOTHING
+// says so. This file is a plain (non-module) script loaded before the entry,
+// so it is registered before any module evaluates — an ES module entry runs
+// all its imports first, which is exactly when early crashes happen, and a
+// handler registered inside the entry would arrive too late. CSP allows it
+// via script-src 'self'. It stands down the moment the app paints.
+(function () {
+  var painted = false;
+  var failed = false;
+  function show(kind, message, detail) {
+    if (painted || failed) return;
+    failed = true;
+    var pre = document.createElement('pre');
+    pre.style.cssText =
+      'margin:2rem;padding:1.5rem;font:13px/1.5 ui-monospace,monospace;' +
+      'white-space:pre-wrap;color:#7f1d1d;background:#fef2f2;' +
+      'border:1px solid #fecaca;border-radius:12px;';
+    pre.textContent =
+      'WealthTracker could not start.\n\n' + kind + ': ' + message +
+      (detail ? '\n\n' + detail : '') +
+      '\n\nPlease screenshot this window.';
+    document.body.replaceChildren(pre);
+  }
+  window.addEventListener('error', function (e) {
+    show('Error', e.message || String(e.error),
+      (e.filename || '') + (e.lineno ? ':' + e.lineno : ''));
+  });
+  window.addEventListener('unhandledrejection', function (e) {
+    var r = e.reason;
+    show('Unhandled rejection', (r && (r.message || String(r))) || 'unknown',
+      r && r.stack ? String(r.stack).slice(0, 800) : '');
+  });
+  // If nothing has painted after 6s and no error fired, say THAT too —
+  // a hang is as silent as a crash.
+  setTimeout(function () {
+    var root = document.getElementById('root');
+    if (!failed && (!root || root.childElementCount === 0)) {
+      show('Timeout', 'nothing rendered within 6 seconds and no error was thrown',
+        'The entry script may not have loaded at all.');
+    }
+  }, 6000);
+  new MutationObserver(function () {
+    var root = document.getElementById('root');
+    if (root && root.childElementCount > 0) painted = true;
+  }).observe(document.documentElement, { childList: true, subtree: true });
+})();

--- a/src/services/preferencesService.ts
+++ b/src/services/preferencesService.ts
@@ -304,8 +304,8 @@ export class PreferencesService implements PreferenceStorage {
   constructor(options: PreferencesServiceOptions = {}) {
     this.injectedMirror = options.mirror;
     this.transportOverride = options.transport;
-    this.setTimeoutFn = options.setTimeoutFn ?? setTimeout;
-    this.clearTimeoutFn = options.clearTimeoutFn ?? clearTimeout;
+    this.setTimeoutFn = options.setTimeoutFn ?? setTimeout.bind(globalThis);
+    this.clearTimeoutFn = options.clearTimeoutFn ?? clearTimeout.bind(globalThis);
     this.debounceMs = options.debounceMs ?? PREFERENCES_WRITE_DEBOUNCE_MS;
   }
 

--- a/src/services/realtimeService.ts
+++ b/src/services/realtimeService.ts
@@ -71,8 +71,8 @@ export class RealtimeService {
     this.supabaseClient = options.supabaseClient ?? supabase ?? null;
     this.userService = options.userIdService ?? userIdService;
     this.logger = options.logger ?? createScopedLogger('RealtimeService');
-    this.setTimeoutFn = options.setTimeoutFn ?? setTimeout;
-    this.clearTimeoutFn = options.clearTimeoutFn ?? clearTimeout;
+    this.setTimeoutFn = options.setTimeoutFn ?? setTimeout.bind(globalThis);
+    this.clearTimeoutFn = options.clearTimeoutFn ?? clearTimeout.bind(globalThis);
   }
 
   /**

--- a/src/services/storageAdapter.ts
+++ b/src/services/storageAdapter.ts
@@ -52,10 +52,10 @@ export class SecureStorageAdapter implements StorageAdapter {
 
     this.localStorageRef = options.localStorage ?? defaultLocalStorage;
     this.sessionStorageRef = options.sessionStorage ?? defaultSessionStorage;
-    this.setIntervalFn = options.setIntervalFn ?? setInterval;
-    this.clearIntervalFn = options.clearIntervalFn ?? clearInterval;
-    this.setTimeoutFn = options.setTimeoutFn ?? setTimeout;
-    this.clearTimeoutFn = options.clearTimeoutFn ?? clearTimeout;
+    this.setIntervalFn = options.setIntervalFn ?? setInterval.bind(globalThis);
+    this.clearIntervalFn = options.clearIntervalFn ?? clearInterval.bind(globalThis);
+    this.setTimeoutFn = options.setTimeoutFn ?? setTimeout.bind(globalThis);
+    this.clearTimeoutFn = options.clearTimeoutFn ?? clearTimeout.bind(globalThis);
     const defaultLogger = typeof console !== 'undefined'
       ? console
       : { log: () => {}, warn: () => {}, error: () => {} };

--- a/src/services/themeSchedulingService.ts
+++ b/src/services/themeSchedulingService.ts
@@ -95,8 +95,8 @@ export class ThemeSchedulingService {
 
     this.storage = options.localStorage ?? defaultStorage;
     this.documentRef = options.documentRef ?? defaultDocument;
-    this.setIntervalFn = options.setIntervalFn ?? setInterval;
-    this.clearIntervalFn = options.clearIntervalFn ?? clearInterval;
+    this.setIntervalFn = options.setIntervalFn ?? setInterval.bind(globalThis);
+    this.clearIntervalFn = options.clearIntervalFn ?? clearInterval.bind(globalThis);
     this.dateFactory = options.dateFactory ?? (() => new Date());
     const noop = () => {};
     const globalLogger = typeof console !== 'undefined' ? console : undefined;


### PR DESCRIPTION
The desktop app's first human launch, and its harvest: five real defects, every one invisible to the repo's 6,000+ tests, each fixed at its root. **The launch succeeded** — a ledger file created in Documents, 77 categories seeded by the Rust core, accounts added, transactions written, running balances penny-perfect on screen.

## The five
1. **The white window**: plain `cargo build` doesn't enable Tauri's `custom-protocol` feature (the CLI does it silently), so even release binaries pointed at a dev URL nobody was serving. Default-on now in the shell's own manifest — every build this repo produces is meant to stand alone. `devtools` joins as a feature while pre-distribution.
2. **The silence**: a renderer that dies before first paint said *nothing*. A plain script now loads before the module entry (modules run all imports first — exactly when early crashes happen) and paints any error, rejection, or six-second nothing as readable text. It stays in the product forever.
3. **The timers — a live Safari web bug**: five services stored bare `setTimeout` references and called them as methods. Blink tolerates detached timers; **WebKit enforces the binding** — the shell threw on first ledger-create, and every Safari user of the *web* app would have hit the same wall on their first preference write. All ten references now `.bind(globalThis)`.
4. **The clothes**: the desktop entry mounted the whole app and imported none of its stylesheets — every Tailwind class pointing at rules that didn't exist, glaring in a WebView, invisible in jsdom (which doesn't paint).
5. **The width**: the chooser-era `body { display:grid; place-items:center }` centred a grid whose items shrink to fit — politely rendering the entire product as a 34rem login card. The body constrains nothing now; the chooser centres itself.

Verified by the only instrument that could: a human at the screen, four rebuild-relaunch cycles, ending with the app working at full width with data flowing to the file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)