### PR TITLE
feat(design): batch 1 — a palette instrumented rather than believed

### DIFF
--- a/src/design-system/__tests__/semantic-contrast.test.ts
+++ b/src/design-system/__tests__/semantic-contrast.test.ts
@@ -1,0 +1,113 @@
+/**
+ * The semantic amount colours, instrumented — DESIGN_PASS_2026-08 §2.1.
+ *
+ * The design pass proposed new income/expense colours from CALCULATED ratios
+ * and asked for them to be measured in this repo's own harness before landing.
+ * This file is that instrument, kept as a gate. Two things are pinned:
+ *
+ * 1. AGREEMENT. The same colour lives in three files — `tailwind.config.js`
+ *    (the utility tokens), `src/index.css` (the CSS variables), and
+ *    `src/styles/accessibility-colors.css` (the !important remap that is what
+ *    actually paints `text-green-600` / `text-red-600` amounts today). Before
+ *    2026-08-12 they disagreed: the tokens said #0d9f6f/#d94052 while the
+ *    remap painted #047857/#b91c1c, so "measuring the token" measured nothing
+ *    on screen. Drift between the three is a failure here.
+ *
+ * 2. CONTRAST. Every text pair clears WCAG AA (4.5:1), measured — not
+ *    asserted from memory — on BOTH light surfaces (white cards and the
+ *    #f8f9fb page behind them) and, for the dark pair, on BOTH dark surfaces
+ *    (gray-900 page, gray-800 cards). The doc's own dark suggestion (#0d9f6f
+ *    as dark text) died on exactly that second surface: 5.24:1 on gray-900
+ *    but 4.34:1 on the cards where amounts actually sit.
+ *
+ * No hue is pinned — a future rebrand only has to keep measuring honest.
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { ColorContrastChecker } from '../../utils/color-contrast-checker';
+
+const read = (repoPath: string): string =>
+  readFileSync(resolve(process.cwd(), repoPath), 'utf8');
+
+const tailwindConfig = read('tailwind.config.js');
+const indexCss = read('src/index.css');
+const remapCss = read('src/styles/accessibility-colors.css');
+
+function extract(source: string, pattern: RegExp, where: string): string {
+  const match = source.match(pattern);
+  if (match === null) {
+    throw new Error(`No colour found for ${where} — has the declaration moved?`);
+  }
+  return match[1].toLowerCase();
+}
+
+const AA_TEXT = 4.5;
+const AA_GRAPHICS = 3.0;
+const SURFACES_LIGHT = ['#ffffff', '#f8f9fb'] as const;
+const SURFACES_DARK = ['#111827', '#1f2937'] as const;
+
+const token = {
+  income: extract(tailwindConfig, /\bincome: '(#[0-9a-f]{6})'/i, 'tailwind income'),
+  incomeFill: extract(tailwindConfig, /'income-fill': '(#[0-9a-f]{6})'/i, 'tailwind income-fill'),
+  expense: extract(tailwindConfig, /\bexpense: '(#[0-9a-f]{6})'/i, 'tailwind expense'),
+  accentText: extract(tailwindConfig, /'accent-text': '(#[0-9a-f]{6})'/i, 'tailwind accent-text'),
+};
+
+const cssVar = {
+  income: extract(indexCss, /--color-income: (#[0-9a-f]{6})/i, '--color-income'),
+  expense: extract(indexCss, /--color-expense: (#[0-9a-f]{6})/i, '--color-expense'),
+};
+
+const rendered = {
+  income: extract(remapCss, /\.text-green-600\s*\{[^}]*color:\s*(#[0-9a-f]{6})/i, '.text-green-600 remap'),
+  expense: extract(remapCss, /\.text-red-600\s*\{[^}]*color:\s*(#[0-9a-f]{6})/i, '.text-red-600 remap'),
+  darkIncome: extract(remapCss, /\.dark \.dark\\:text-green-400\s*\{[^}]*color:\s*(#[0-9a-f]{6})/i, 'dark income remap'),
+  darkExpense: extract(remapCss, /\.dark \.dark\\:text-red-400\s*\{[^}]*color:\s*(#[0-9a-f]{6})/i, 'dark expense remap'),
+};
+
+const ratio = (fg: string, bg: string): number =>
+  ColorContrastChecker.getContrastRatio(fg, bg);
+
+describe('semantic amount colours (DESIGN_PASS_2026-08 §2.1)', () => {
+  it('one income colour and one expense colour exist, not three of each', () => {
+    expect(cssVar.income).toBe(token.income);
+    expect(rendered.income).toBe(token.income);
+    expect(cssVar.expense).toBe(token.expense);
+    expect(rendered.expense).toBe(token.expense);
+  });
+
+  it('income and expense text clear AA on both light surfaces', () => {
+    for (const surface of SURFACES_LIGHT) {
+      expect(ratio(token.income, surface)).toBeGreaterThanOrEqual(AA_TEXT);
+      expect(ratio(token.expense, surface)).toBeGreaterThanOrEqual(AA_TEXT);
+    }
+  });
+
+  it('the dark-mode pair clears AA on the gray-900 page AND the gray-800 cards', () => {
+    for (const surface of SURFACES_DARK) {
+      expect(ratio(rendered.darkIncome, surface)).toBeGreaterThanOrEqual(AA_TEXT);
+      expect(ratio(rendered.darkExpense, surface)).toBeGreaterThanOrEqual(AA_TEXT);
+    }
+  });
+
+  it('gold is never text without the darkened accent-text', () => {
+    // The decorative gold itself measures ~2.2:1 — that is WHY accent-text
+    // exists. The doc's first proposal (#a37d1e) measured 3.81:1 here and was
+    // corrected; whatever value ships must actually pass.
+    for (const surface of SURFACES_LIGHT) {
+      expect(ratio(token.accentText, surface)).toBeGreaterThanOrEqual(AA_TEXT);
+    }
+  });
+
+  it('income-fill stays a chart colour: graphics contrast only', () => {
+    // 3:1 is the WCAG 1.4.11 bar for non-text. If someone promotes the fill
+    // to a text token this stops being the right test — see §2.1.
+    expect(ratio(token.incomeFill, '#ffffff')).toBeGreaterThanOrEqual(AA_GRAPHICS);
+    expect(ratio(token.incomeFill, '#ffffff')).toBeLessThan(AA_TEXT);
+  });
+
+  it('tabular figures are the app-wide default (P5)', () => {
+    expect(indexCss).toMatch(/body\s*\{[^}]*font-variant-numeric:\s*tabular-nums/);
+  });
+});

--- a/src/index.css
+++ b/src/index.css
@@ -131,8 +131,14 @@ input[type="range"] {
   --color-sidebar: #1a2332;
   --color-sidebar-active: #2d3a4d;
   --color-sidebar-border: #2d3a4d;
-  --color-income: #0d9f6f;
-  --color-expense: #d94052;
+  /* Amount colours, AA-instrumented (DESIGN_PASS_2026-08 §2.1, measured with
+     ColorContrastChecker 2026-08-12): income 5.14:1 / expense 5.24:1 on #fff,
+     4.88 / 4.98 on this file's #f8f9fb page bg. The old pair (#0d9f6f /
+     #d94052) measured 3.38 / 4.37 — text-sized amounts failed AA. #0d9f6f
+     survives as the chart-series green (income-fill in tailwind.config.js).
+     Pinned by src/design-system/__tests__/semantic-contrast.test.ts. */
+  --color-income: #0a7d57;
+  --color-expense: #c9304a;
   --color-accent: #d4a843;
   /* Keyboard-focus outline + interactive-control colour (consumed by
      accessibility-colors.css and Button.tsx).
@@ -154,6 +160,15 @@ input[type="range"] {
   /* Light enough to read against gray-900 panels; still the navy family. */
   --focus-ring-color: #94a3b8;
   --color-border-focus: #94a3b8;
+}
+
+/* Numbers line up or they lie (DESIGN_PASS_2026-08, P5). Fixed-width digits
+   app-wide: 96 call sites already asked for `tabular-nums` one class at a
+   time — this makes it the default every amount, date and count inherits, so
+   a right-aligned column of figures actually aligns. Inter ships the feature;
+   zero bundle cost. */
+body {
+  font-variant-numeric: tabular-nums;
 }
 
 /* The colour-theme variants (green/red/pink primary swaps) were retired

--- a/src/styles/accessibility-colors.css
+++ b/src/styles/accessibility-colors.css
@@ -10,7 +10,12 @@
 }
 
 .text-red-600 {
-  color: #b91c1c !important; /* red-700 - even better contrast */
+  /* The brand expense red, not a Tailwind stock red — this rule is what
+     actually paints every text-red-600 amount, so the semantic token lands
+     here or nowhere. 5.24:1 on #fff, 4.98:1 on the #f8f9fb page (instrumented;
+     pinned by src/design-system/__tests__/semantic-contrast.test.ts, and must
+     equal --color-expense in index.css + `expense` in tailwind.config.js). */
+  color: #c9304a !important;
 }
 
 /* Dark mode red colors */
@@ -28,7 +33,11 @@
 }
 
 .text-green-600 {
-  color: #047857 !important; /* green-700 - even better contrast */
+  /* The brand income green — same story as .text-red-600 above: this remap is
+     the rendered truth for amounts. 5.14:1 on #fff, 4.88:1 on #f8f9fb
+     (instrumented; pinned by semantic-contrast.test.ts, and must equal
+     --color-income in index.css + `income` in tailwind.config.js). */
+  color: #0a7d57 !important;
 }
 
 /* Dark mode green colors */

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -11,7 +11,12 @@ export default {
         // Wealth/finance brand palette
         primary: 'var(--color-primary, #1a2332)',
         secondary: 'var(--color-secondary, #2d3a4d)',
+        // Gold is a FILL colour only (chips, marks, the yellow thread's box).
+        // As text on white it measures 2.21:1 — that is what accent-text is
+        // for. (DESIGN_PASS_2026-08 §2.1, instrumented 2026-08-12.)
         accent: '#d4a843',
+        'accent-text': '#8a6a19', // 5.05:1 on #fff, 4.80:1 on #f8f9fb
+        'navy-400': '#6B86B3', // selection ring, R marker
 
         // Surface colors
         surface: {
@@ -33,12 +38,24 @@ export default {
           DEFAULT: '#1a2332',
         },
 
-        // Financial semantic colors
-        income: '#0d9f6f',
-        expense: '#d94052',
-        success: '#0d9f6f',
-        danger: '#d94052',
+        // Financial semantic colors — every text pair here is pinned ≥4.5:1 by
+        // src/design-system/__tests__/semantic-contrast.test.ts, measured with
+        // the repo's own harness, on BOTH light surfaces (#fff cards and the
+        // #f8f9fb page). income-fill is the brighter chart/series green; it is
+        // not a text colour (3.38:1 on white — passes only the 3:1 graphics
+        // bar, which is all a chart series needs).
+        income: '#0a7d57', // 5.14:1 on #fff (was #0d9f6f, 3.38:1)
+        'income-fill': '#0d9f6f', // chart series only
+        expense: '#c9304a', // 5.24:1 on #fff (was #d94052, 4.37:1)
+        success: '#0a7d57',
+        danger: '#c9304a',
         warning: '#e5a00d',
+
+        // Hairlines (DESIGN_PASS §2.2) — the border that replaces shadows.
+        line: {
+          DEFAULT: '#e2e6ed',
+          strong: '#cdd4e0',
+        },
 
         // Navigation
         nav: {
@@ -58,6 +75,40 @@ export default {
       },
       fontFamily: {
         sans: ['Inter', '-apple-system', 'BlinkMacSystemFont', 'Segoe UI', 'Roboto', 'sans-serif'],
+      },
+      // The design pass's six-step type scale (DESIGN_PASS §2.3). The named
+      // sizes are the vocabulary later batches adopt surface by surface; the
+      // 2xl/3xl/4xl redefinitions keep Tailwind's default sizes but add the
+      // optical tracking large Inter needs — that part lands everywhere now.
+      fontSize: {
+        label: ['11px', { lineHeight: '16px', letterSpacing: '0.07em' }],
+        dense: ['12px', { lineHeight: '16px' }],
+        body: ['14px', { lineHeight: '20px' }],
+        card: ['16px', { lineHeight: '22px' }],
+        page: ['24px', { lineHeight: '32px', letterSpacing: '-0.02em' }],
+        display: ['32px', { lineHeight: '36px', letterSpacing: '-0.03em' }],
+        '2xl': ['1.5rem', { lineHeight: '2rem', letterSpacing: '-0.02em' }],
+        '3xl': ['1.875rem', { lineHeight: '2.25rem', letterSpacing: '-0.03em' }],
+        '4xl': ['2.25rem', { lineHeight: '2.5rem', letterSpacing: '-0.03em' }],
+      },
+      // 6 controls · 8 cards · 10 modals (DESIGN_PASS §2.5). DEFAULT moves
+      // 4→6 and xl 12→10; md/lg restate Tailwind's own values so the whole
+      // scale reads in one place.
+      borderRadius: {
+        DEFAULT: '6px',
+        md: '6px',
+        lg: '8px',
+        xl: '10px',
+      },
+      // The only two shadows with a meaning: overlays float, the selected row
+      // lifts. Everything else is a hairline border's job.
+      boxShadow: {
+        overlay: '0 8px 24px -8px rgb(26 35 50 / 0.18)',
+        row: '0 1px 3px rgb(26 35 50 / 0.10)',
+      },
+      transitionDuration: {
+        state: '120ms',
+        enter: '200ms',
       },
       keyframes: {
         'fade-in': {


### PR DESCRIPTION
Batch 1 of DESIGN_PASS_2026-08 (§5 row 1): semantic colour AA fix + tabular numerals + radius/shadow tokens. Per the design brief, §2.1's calculated ratios were re-measured in the repo's own harness (`ColorContrastChecker`) before anything shipped, and the doc has been corrected where instrumentation disagreed.

## What measurement found that calculation couldn't

1. **The "today" tokens were unconsumed.** No component uses `text-income`/`text-expense`; amounts wear `text-green-600`/`text-red-600` (~50 files), which `accessibility-colors.css` remaps with `!important` to `#047857` (5.48:1) / `#b91c1c` (6.47:1). The rendered app already passed AA in light mode — the token layer just lied about what was on screen.
2. **The proposed accent-text `#a37d1e` fails AA**: 3.81:1, not the doc's ~4.9:1. Ships as `#8a6a19` (5.05:1 on `#fff`, 4.80:1 on `#f8f9fb`).
3. **`#0d9f6f` as dark-mode text fails where amounts sit**: 5.24:1 on the gray-900 page but 4.34:1 on gray-800 cards. The dark pair stays `#34d399`/`#f87171` (9.23/6.41 on gray-900; 7.64/5.31 on cards) — instrumented, unchanged. `income-fill` is charts only.

## What ships

- `income #0a7d57` (5.14:1) and `expense #c9304a` (5.24:1) as **one truth across three layers** — `tailwind.config.js`, `--color-*` vars in `index.css`, and the remap that actually paints amounts. Verified in a real browser: the rendered figures compute to exactly these values through the `text-green-600` path.
- `src/design-system/__tests__/semantic-contrast.test.ts` — the instrument, kept as a gate: cross-file agreement, ≥4.5:1 on both light and both dark surfaces, accent-text honest, chart green held to the 3:1 graphics bar.
- `font-variant-numeric: tabular-nums` as the body default (96 call sites had asked one class at a time; P5: numbers line up or they lie).
- Six-step type scale tokens + optical tracking on `2xl/3xl/4xl`; radius `6/6/8/10`; `shadow-overlay`/`shadow-row`; `duration-state`/`duration-enter`.

§6 of the pass is untouched. Batches 2–6 (de-amber, empty states, register chrome, accounts un-nesting, period bar) remain to be scheduled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)