### PR TITLE
feat(design)+perf(bundle): batch 2 de-amber, the bundle gate back to green, and honest coverage floors

### DIFF
--- a/.github/workflows/handoff-snapshot.yml
+++ b/.github/workflows/handoff-snapshot.yml
@@ -93,7 +93,7 @@ jobs:
         # Redux store removed ~6.5K lines of heavily-tested dead code, which had
         # inflated the global ratio; live-code coverage did not regress. Matches
         # the pre-push hook and verify:full. Raise as BLOCKER #4 testing lands.
-        run: node scripts/verify-coverage-threshold.mjs coverage/coverage-final.json --statements=63 --branches=55
+        run: node scripts/verify-coverage-threshold.mjs coverage/coverage-final.json --statements=75 --branches=80
 
       - name: Lint Supabase migrations
         continue-on-error: true

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,8 +14,8 @@
 | Strict types | `npm run typecheck:strict` | ✅ | TS 5.8 strict |
 | Smoke tests | `npm run test:smoke` | ✅ | JSdom + Vitest |
 | Realtime suite | `npm run test:realtime` | ✅ | Driven by `scripts/realtime-tests.json` |
-| Coverage | `npm run test:coverage` | ✅ | Enforced floor ≥63 % statements / ≥55 % branches |
-| Threshold | `node scripts/verify-coverage-threshold.mjs …` | ✅ | ≥63 % statements / ≥55 % branches (recalibrated 2026-06 after dead Redux removal) |
+| Coverage | `npm run test:coverage` | ✅ | Enforced floor ≥75 % statements / ≥80 % branches |
+| Threshold | `node scripts/verify-coverage-threshold.mjs …` | ✅ | ≥75 % statements / ≥80 % branches (raised 2026-08-12 from 63/55; measured 77.13/82.48) |
 | Supabase smoke | `npm run test:supabase-smoke` | ✅ | Logs saved to `logs/supabase-smoke/` |
 | Build parity | `npm run build` | ✅ | Mirrors Vercel’s `vite build` via `scripts/build-web.mjs` |
 | Desktop bundle | `npm run desktop:verify` | ✅ | Builds `src/desktop` → `apps/desktop/dist`, then PHASE3-PLAN §5’s two bundle greps, then the size ratchet. REFUSES rather than skips when there is no build |
@@ -115,7 +115,7 @@ npm run typecheck:strict
 npm run test:smoke
 npm run test:realtime
 npm run test:coverage
-node scripts/verify-coverage-threshold.mjs coverage/coverage-final.json --statements=63 --branches=55
+node scripts/verify-coverage-threshold.mjs coverage/coverage-final.json --statements=75 --branches=80
 
 # Supabase smoke (requires real creds)
 RUN_SUPABASE_REAL_TESTS=true npm run test:supabase-smoke

--- a/docs/bundle-optimization-plan.md
+++ b/docs/bundle-optimization-plan.md
@@ -1,46 +1,64 @@
-# Bundle Optimisation Plan – 2025-10-29
+# Bundle Optimisation Plan
 
-We captured Vercel build logs for deployment `wealthtracker-l514dsq11` (see `logs/deployments/20251029_2133_wealthtracker-web.log`). The largest emitted bundles are:
+**Rewritten 2026-08-12.** The original 2025-10-29 plan described a build that no
+longer exists — its top offender (a 4.6 MB Plotly chunk) has since been deleted
+from the product entirely, and every one of its "immediate targets" was found
+already implemented when the plan was picked back up. This file now records
+what is TRUE, so the next optimisation pass starts from measurement rather than
+archaeology. All sizes measured in one directory on one machine (chunk hashes
+change with absolute paths); the gate is `npm run bundle:check` (gzip -9).
 
-- `chunk-tBQuDGzl.js` – **4.6 MB** (gzip 1.37 MB): ships `react-plotly.js` + Plotly core.
-- `index-a-UlsUyK.js` – **1.1 MB** (gzip 311 KB): main vendor chunk with Redux + Supabase surface + data tooling.
-- `chunk-D8XJBbX3.js` – **0.58 MB** (gzip 167 KB): d3 utilities + chart helpers.
-- `xlsx-Bx0RsK1h.js` – **0.49 MB** (gzip 159 KB): SheetJS export stack.
-- `chunk-BKLdmH-G.js` – **0.43 MB** (gzip 114 KB): aggregation helpers (likely date-fns + analytics pipelines).
+## Current state (2026-08-12)
 
-## Immediate Targets
+Entry chunk **1,102.68 kB raw / 311.4 KB gz** against a 320 KB budget — green
+with 8.6 KB headroom. JS total 1,387.4 KB gz against 1,500 KB.
 
-1. **Plotly (Analytics / Chart Wizard)**
-   - `src/components/analytics/ChartWizard.tsx` lazy-loads `react-plotly.js`, but the chunk still embeds full Plotly.
-   - Action:
-     - Switch to `react-plotly.js/factory` with `plotly.js-dist-min` loaded via `import('plotly.js-dist-min')`.
-     - Evaluate using the `plotly.js-basic-dist` bundle (~1.3 MB) + feature-by-feature augmentations to shrink footprint.
-     - Gate heavy chart types (Sankey, Treemap, Funnel) behind dynamic `import()` so the default analytics dashboard only loads basic traces.
-     - Ensure `ChartWizard` and any saved chart renderers share a deferred loader (e.g., `importPlotly()` helper with caching).
+## Done (verified, not planned)
 
-2. **Export Stack (Data Management / EnhancedExportManager)**
-   - `src/components/EnhancedExportManager.tsx` statically imports `jspdf`, `jspdf-autotable`, and `xlsx`.
-   - Actions:
-     - Refactor to use existing async helpers in `src/utils/dynamic-imports.ts` (`importPDFLibraries`, `importXLSX`) so these packages load on first export interaction.
-     - Audit other export entry points (`services/exportService.ts`, `EnhancedExportModal.tsx`) to ensure they reuse the loaders and don’t re-introduce eager imports.
-     - Add loading states/spinners for PDF/XLSX actions to cover the async import delay.
+- **Plotly: deleted from the product.** Zero occurrences in `src/`. The chunk
+  the 2025 plan was written around is gone.
+- **Charting: one library.** recharts only (16 importers);
+  chart.js/react-chartjs-2 are out of `package.json` entirely. See
+  `src/components/charts/DashboardCharts.tsx` for the migration note.
+- **Export stack: lazy.** `xlsx` (162.9 KB gz), `jspdf` (118.9 KB gz),
+  `html2canvas` (47.4 KB gz), `jspdf-autotable` (9.7 KB gz) all arrive via
+  dynamic `import()` at the call sites and ship as their own chunks, loaded on
+  first export/import interaction.
+- **crypto-js: narrowed (2026-08-12, the change that turned the gate green).**
+  `import CryptoJS from 'crypto-js'` pulls every cipher the library ships;
+  242 KB sat in the entry chunk (eager — `encryptedStorageService` runs at
+  boot) and ~140 KB of it was algorithms no line of code calls.
+  `src/security/cryptoSuite.ts` now imports core + the five algorithms in use,
+  with a load-time guard against tree-shaking regressions and byte-for-byte
+  compatibility tests (`src/security/__tests__/cryptoSuite.test.ts`) proving
+  old ciphertext still decrypts. Adding an algorithm means adding its import
+  THERE — reaching for the `crypto-js` index again restores all 242 KB.
 
-3. **Data Management Route (`/settings/data-management`)**
-   - Lazily renders numerous import/export modals; confirm each modal defers heavy tooling:
-     - `CSVImportWizard`, `BatchImportModal`, `OFXImportModal`, `QIFImportModal`. (`ImportDataModal` — the Legacy Import dialog — was deleted on 2026-08-09 along with its `mnyParser`/`qifParser` byte scanners; `BatchImportModal` is now a queue that lazily loads whichever of the other three a file needs.)
-   - Action:
-     - Double-check these components rely on the dynamic import helpers (e.g., `enhancedCsvImportService` should not eagerly load parsing libs).
-     - Split the manager shell (`EnhancedExportManager`, rules UI, batch import tools) so modal code paths only load after corresponding buttons are clicked.
+## What remains in the entry chunk (structural — needs design, not tweaks)
 
-4. **Analytics Supporting Libraries**
-   - Chunks `chunk-D8XJBbX3.js` / `chunk-BKLdmH-G.js` include d3-like helpers and analytics engines.
-   - Actions:
-     - Trace imports for `analyticsEngine`, `dataVisualizationService`, and custom chart helpers to identify static references.
-     - Consider splitting advanced analytics (forecasting, anomaly detection) into on-demand modules triggered from the respective tabs.
+| Weight | What | Why it is hard |
+|---|---|---|
+| ~385 KB raw | `@supabase/*` | monolithic `createClient`; splitting it is an architecture decision |
+| ~132 KB raw | `react-dom` | the framework |
+| ~125 KB raw | `decimal.js` | the money core; non-negotiable at boot |
+| ~114 KB raw | `dompurify` | eager via GlobalSearch in the header |
+| ~117 KB raw | `services/dataService.ts` | the app's own data layer |
 
-## Tooling & Follow-Up
+Known-but-parked items:
 
-- Integrate `rollup-plugin-visualizer` or `vite-bundle-visualizer` in a local-only script (`npm run bundle:report`) to track changes.
-- Add CI guardrail: persist `dist/stats/bundle-report.html` artefact for manual review when bundle thresholds are exceeded.
-- Document the new lazy-loading patterns in `docs/performance.md` (to be created) and update component guidelines so new features keep exports & heavy charts deferred.
-- After converting the top offenders, re-run Vercel build and capture updated chunk sizes for comparison.
+- `src/security/index.ts` re-exports (`export *`) defeat that file's own
+  dynamic imports — real defect, but worth only ~3 KB gz while `dompurify`
+  stays eager anyway. Separate ticket.
+- `EnhancedConflictResolutionModal` (16 KB) sits in the eager chunk via
+  `Layout.tsx` — but `Layout` is desktop-reachable, so lazy-loading it moves
+  the desktop renderer's size ratchet. Do it, if ever, as a deliberate desktop
+  change, not a web tweak.
+
+## Discipline
+
+- The gate (`npm run bundle:check`) runs in CI on every PR; headroom is thin
+  (8.6 KB), so treat any entry-chunk growth as a review question.
+- New heavy libraries: dynamic `import()` at the call site, `import type` for
+  types, loading states on the async path, and an error surfaced to the user
+  if the import fails — a silent no-op export button is not acceptable in a
+  finance app.

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "env:doctor": "node --loader ts-node/esm scripts/env-doctor.ts",
     "setup": "npm run env:doctor",
     "verify:pre-commit": "npm run build:check && npm run lint && npm run test:unit",
-    "verify:full": "npm run typecheck:strict && npm run build:check && npm run lint && npm run test:unit && npm run test:realtime && npm run test:coverage && node scripts/verify-coverage-threshold.mjs coverage/coverage-final.json --statements=63 --branches=55",
+    "verify:full": "npm run typecheck:strict && npm run build:check && npm run lint && npm run test:unit && npm run test:realtime && npm run test:coverage && node scripts/verify-coverage-threshold.mjs coverage/coverage-final.json --statements=75 --branches=80",
     "audit:data": "node scripts/audit-data-integrity.mjs",
     "backup:db": "node scripts/backup-database.mjs",
     "restore:db": "node scripts/restore-database.mjs",

--- a/src/components/DemoModeIndicator.tsx
+++ b/src/components/DemoModeIndicator.tsx
@@ -54,7 +54,13 @@ export const DemoModeIndicator: React.FC = () => {
       // them. Now the header is offset clear of the banner instead of fighting
       // it for the same strip of screen, so the two no longer overlap at all
       // and the stacking order is just a belt-and-braces tiebreak.
-      className="fixed top-0 left-0 right-0 z-30 bg-yellow-500 text-black text-center py-2 px-4"
+      //
+      // Navy with a 3px gold mark, not a gold bar: this is ENVIRONMENT STATUS,
+      // and a full-bleed gold strip above every screen was the loudest amber
+      // in the product — including on Reconciliation, where amber is a
+      // reserved word meaning "your next move". The gold survives as a sliver
+      // of identity; the banner itself joins the app's own chrome.
+      className="fixed top-0 left-0 right-0 z-30 bg-secondary text-white border-l-[3px] border-accent text-center py-2 px-4"
     >
       <div className="flex items-center justify-center gap-2">
         <span className="text-xl">🎭</span>

--- a/src/components/reconciliation/ReconciliationAccountList.tsx
+++ b/src/components/reconciliation/ReconciliationAccountList.tsx
@@ -75,7 +75,13 @@ export default function ReconciliationAccountList({
 
                     <div className="basis-full md:basis-auto md:min-w-[120px]">
                       {unreconciledCount > 0 ? (
-                        <span className="inline-flex items-center px-2.5 py-1 rounded-full text-xs font-medium bg-amber-100 text-amber-700 dark:bg-amber-900/30 dark:text-amber-400">
+                        // Neutral, deliberately: this is a COUNT, not an
+                        // action. It wore amber until the design pass pointed
+                        // out that four amber chips on this page competed with
+                        // the one amber that means "your next move" — the
+                        // travelling yellow on the balance bar. The thread
+                        // works because amber is otherwise absent (P3).
+                        <span className="inline-flex items-center px-2.5 py-1 rounded-full text-xs font-medium bg-surface-tertiary text-slate-600 dark:bg-gray-700 dark:text-gray-300">
                           {unreconciledCount} unreconciled
                         </span>
                       ) : (

--- a/src/security/__tests__/cryptoSuite.test.ts
+++ b/src/security/__tests__/cryptoSuite.test.ts
@@ -1,0 +1,115 @@
+/**
+ * `cryptoSuite` narrows crypto-js from its full index down to the five
+ * algorithms this codebase actually calls, which removed ~140 KB of unused
+ * ciphers from the entry chunk. The saving is only worth having if the object
+ * it produces is INDISTINGUISHABLE from the one the index produced — a stored
+ * ledger encrypted by a previous build must still open under this one, or the
+ * optimisation has cost a user their data.
+ *
+ * So these tests deliberately import the full `crypto-js` barrel alongside the
+ * narrowed suite and assert the two agree: ciphertext crosses in both
+ * directions and every digest matches. Importing the barrel here is safe —
+ * test files are never bundled.
+ */
+
+import { describe, it, expect } from 'vitest';
+import FullCryptoJS from 'crypto-js';
+import cryptoSuite from '../cryptoSuite';
+
+// Deliberately not financial: this repo is public, and a fixture only needs to
+// be a string that survives a round trip.
+const PLAINTEXT = 'the quick brown fox jumps over the lazy dog';
+const PASSPHRASE = 'test-passphrase-not-a-real-secret';
+
+describe('cryptoSuite — the narrowed crypto-js surface', () => {
+  describe('exposes every algorithm the application calls', () => {
+    it.each([
+      ['AES', () => cryptoSuite.AES],
+      ['SHA256', () => cryptoSuite.SHA256],
+      ['HmacSHA256', () => cryptoSuite.HmacSHA256],
+      ['PBKDF2', () => cryptoSuite.PBKDF2],
+      ['algo.SHA256', () => cryptoSuite.algo.SHA256],
+      ['enc.Base64', () => cryptoSuite.enc.Base64],
+      ['enc.Utf8', () => cryptoSuite.enc.Utf8],
+      ['lib.WordArray', () => cryptoSuite.lib.WordArray],
+      ['lib.CipherParams', () => cryptoSuite.lib.CipherParams],
+      ['mode.CBC', () => cryptoSuite.mode.CBC],
+      ['pad.Pkcs7', () => cryptoSuite.pad.Pkcs7]
+    ])('%s is present', (_name, read) => {
+      expect(read()).toBeDefined();
+    });
+  });
+
+  describe('is byte-compatible with the full crypto-js index', () => {
+    it('decrypts AES ciphertext produced by the full library', () => {
+      // This is the compatibility that matters: the "old build" wrote this.
+      const legacyCiphertext = FullCryptoJS.AES.encrypt(PLAINTEXT, PASSPHRASE).toString();
+
+      const recovered = cryptoSuite.AES
+        .decrypt(legacyCiphertext, PASSPHRASE)
+        .toString(cryptoSuite.enc.Utf8);
+
+      expect(recovered).toBe(PLAINTEXT);
+    });
+
+    it('produces AES ciphertext the full library can still read', () => {
+      const ciphertext = cryptoSuite.AES.encrypt(PLAINTEXT, PASSPHRASE).toString();
+
+      const recovered = FullCryptoJS.AES
+        .decrypt(ciphertext, PASSPHRASE)
+        .toString(FullCryptoJS.enc.Utf8);
+
+      expect(recovered).toBe(PLAINTEXT);
+    });
+
+    it('round-trips through an explicit CBC/Pkcs7 configuration', () => {
+      // encryption-enhanced.ts pins mode and padding explicitly rather than
+      // relying on the defaults, so pin them here too.
+      const key = cryptoSuite.enc.Utf8.parse('0123456789abcdef0123456789abcdef');
+      const iv = cryptoSuite.enc.Utf8.parse('0123456789abcdef');
+
+      const encrypted = cryptoSuite.AES.encrypt(PLAINTEXT, key, {
+        iv,
+        mode: cryptoSuite.mode.CBC,
+        padding: cryptoSuite.pad.Pkcs7
+      });
+
+      const recovered = FullCryptoJS.AES
+        .decrypt(
+          FullCryptoJS.lib.CipherParams.create({ ciphertext: encrypted.ciphertext }),
+          key,
+          { iv, mode: FullCryptoJS.mode.CBC, padding: FullCryptoJS.pad.Pkcs7 }
+        )
+        .toString(FullCryptoJS.enc.Utf8);
+
+      expect(recovered).toBe(PLAINTEXT);
+    });
+
+    it('yields identical SHA256, HmacSHA256 and PBKDF2 output', () => {
+      expect(cryptoSuite.SHA256(PLAINTEXT).toString())
+        .toBe(FullCryptoJS.SHA256(PLAINTEXT).toString());
+
+      expect(cryptoSuite.HmacSHA256(PLAINTEXT, PASSPHRASE).toString())
+        .toBe(FullCryptoJS.HmacSHA256(PLAINTEXT, PASSPHRASE).toString());
+
+      const salt = cryptoSuite.enc.Utf8.parse('a-fixed-salt');
+      const derive = (lib: typeof FullCryptoJS): string =>
+        lib.PBKDF2(PASSPHRASE, salt, { keySize: 256 / 32, iterations: 100, hasher: lib.algo.SHA256 }).toString();
+
+      expect(derive(cryptoSuite)).toBe(derive(FullCryptoJS));
+    });
+
+    it('encodes Base64 identically', () => {
+      const words = cryptoSuite.enc.Utf8.parse(PLAINTEXT);
+      expect(words.toString(cryptoSuite.enc.Base64))
+        .toBe(words.toString(FullCryptoJS.enc.Base64));
+    });
+  });
+
+  it('generates random WordArrays of the requested length', () => {
+    const random = cryptoSuite.lib.WordArray.random(256 / 8);
+    // 32 bytes rendered as hex.
+    expect(random.toString()).toHaveLength(64);
+    expect(random.toString()).not.toBe(cryptoSuite.lib.WordArray.random(256 / 8).toString());
+  });
+});

--- a/src/security/cryptoSuite.ts
+++ b/src/security/cryptoSuite.ts
@@ -1,0 +1,66 @@
+/**
+ * The crypto-js surface this application actually uses — and nothing else.
+ *
+ * `import CryptoJS from 'crypto-js'` pulls the package index, and that index
+ * requires every cipher and digest the library ships: TripleDES, Blowfish, RC4,
+ * Rabbit, SHA-3, SHA-512, RIPEMD-160, six block modes and seven padding
+ * schemes. Measured on the 2026-08-12 build, 242 KB of crypto-js sat in the
+ * entry chunk and roughly 140 KB of it was algorithms no line of this codebase
+ * calls. It was eager, too: `encryptedStorageService` runs at boot, so every
+ * user downloaded all of it before the first screen painted.
+ *
+ * crypto-js is built so that each algorithm module augments one shared `core`
+ * singleton. Importing core plus only the algorithms we call therefore yields
+ * exactly the same `CryptoJS` object the index would have — same AES, same
+ * OpenSSL-compatible key derivation, same defaults (CBC, Pkcs7). The bytes on
+ * disk are unchanged, so anything encrypted by a previous build still decrypts.
+ *
+ * The algorithms below are the complete set used across
+ * `encryptedStorageService`, `csrf-protection` and `encryption-enhanced`:
+ *
+ *   AES        — encryptedStorageService, encryption-enhanced
+ *   SHA256     — csrf-protection, encryption-enhanced (also `algo.SHA256`)
+ *   HmacSHA256 — encryption-enhanced
+ *   PBKDF2     — encryption-enhanced
+ *   enc.Base64 — encryption-enhanced
+ *
+ * `enc.Utf8`, `enc.Hex` and `lib.WordArray` live in core itself; `mode.CBC`,
+ * `pad.Pkcs7` and `lib.CipherParams` arrive with `cipher-core`, which `aes`
+ * requires. Adding a new algorithm means adding its import HERE — reaching for
+ * the `crypto-js` index again would quietly restore all 242 KB.
+ */
+
+import CryptoJS from 'crypto-js/core';
+import AES from 'crypto-js/aes';
+import SHA256 from 'crypto-js/sha256';
+import HmacSHA256 from 'crypto-js/hmac-sha256';
+import PBKDF2 from 'crypto-js/pbkdf2';
+import Base64 from 'crypto-js/enc-base64';
+
+// This build declares node_modules side-effect free (`treeshake.moduleSideEffects:
+// 'no-external'` in vite.config.ts), so a bare `import 'crypto-js/aes'` would be
+// dropped from the bundle and `CryptoJS.AES` would be undefined at runtime —
+// silently, at the first attempt to read a user's encrypted data. Reading the
+// bindings here is what keeps them: the check below is a genuine use, so the
+// imports cannot be elided, and a packaging regression fails loudly at module
+// load rather than as an unreadable ledger later on.
+const requiredAlgorithms: ReadonlyArray<readonly [string, unknown]> = [
+  ['AES', AES],
+  ['SHA256', SHA256],
+  ['HmacSHA256', HmacSHA256],
+  ['PBKDF2', PBKDF2],
+  ['enc.Base64', Base64]
+];
+
+const missingAlgorithms = requiredAlgorithms
+  .filter(([, implementation]) => implementation == null)
+  .map(([name]) => name);
+
+if (missingAlgorithms.length > 0) {
+  throw new Error(
+    `crypto-js algorithms missing from the bundle: ${missingAlgorithms.join(', ')}. ` +
+    'This is a build/packaging fault, not a user error — encrypted storage cannot be read.'
+  );
+}
+
+export default CryptoJS;

--- a/src/security/csrf-protection.ts
+++ b/src/security/csrf-protection.ts
@@ -3,7 +3,7 @@
  * Implements token-based CSRF protection for the application
  */
 
-import CryptoJS from 'crypto-js';
+import CryptoJS from './cryptoSuite';
 
 /**
  * CSRF Token Manager

--- a/src/security/encryption-enhanced.ts
+++ b/src/security/encryption-enhanced.ts
@@ -3,7 +3,7 @@
  * Provides secure encryption for sensitive financial data with key management
  */
 
-import CryptoJS from 'crypto-js';
+import CryptoJS from './cryptoSuite';
 
 // Types for encryption configuration
 interface EncryptionConfig {

--- a/src/services/encryptedStorageService.ts
+++ b/src/services/encryptedStorageService.ts
@@ -1,4 +1,4 @@
-import CryptoJS from 'crypto-js';
+import CryptoJS from '../security/cryptoSuite';
 import { indexedDBService } from './indexedDBService';
 import type { JsonValue } from '../types/common';
 import type { StorageOptions, StoredData, StorageItem, BulkStorageItem, StorageEstimate, ExportedData } from '../types/storage';


### PR DESCRIPTION
Two verified workstreams, one commit each.

## Commit 1 — Design pass batch 2: the de-amber (§3.2/§3.4)

The pass's highest-value-per-risk change. The Reconciliation page's "N unreconciled" chips were amber ×4 on the one page whose premise is that amber means "your next move"; they go neutral (`surface-tertiary`/slate) because they are a **count, not an action**. The demo banner stops being a full-bleed gold bar above every screen and becomes environment status: the app's own navy with a 3px gold mark.

- The yellow thread is untouched (§6): all 26 yellow-thread + holding-state tests pass unchanged.
- Browser-verified: with an account open, the Closing Balance affordance is now the **only amber on the screen** — the batch makes the thread's premise true at page level.
- Deliberately not touched: the needs-attention difference-border (doc keeps it) and the Accounts page's own amber count (a third component the doc didn't scope into this batch).

## Commit 2 — The bundle gate red → green + coverage floors raised

The web gate was failing at 329.9 KB gz vs the 320 KB budget. The documented plan targets were **already implemented** (Plotly deleted from the product, charting consolidated to recharts, export stack already lazy) — the real weight was `import CryptoJS from 'crypto-js'` pulling every cipher the library ships: 242 KB eager in the entry chunk, ~140 KB never called.

- `src/security/cryptoSuite.ts`: core + the five algorithms in use, with a load-time guard (this build declares node_modules side-effect-free, so a silent tree-shake of a cipher would otherwise surface as an unreadable ledger) and 17 byte-compatibility tests — old ciphertext decrypts under the new suite and vice versa. Three import lines change.
- **Entry chunk 1,151 → 1,103 kB raw / 329.9 → 311.4 KB gz; gate green with 8.6 KB headroom.** Independently reproduced after the agent's run.
- Desktop renderer provably untouched (zero crypto-js strings in its bundle); `desktop:verify` green.
- Coverage floor 63/55 → **75/80** (measured 77.13/82.48) in the workflow, `verify:full`, and CLAUDE.md.
- `docs/bundle-optimization-plan.md` rewritten to describe the build that exists, including the parked structural items (@supabase monolith, dompurify-via-GlobalSearch, the Layout modal that belongs to the desktop ratchet's jurisdiction).

🤖 Generated with [Claude Code](https://claude.com/claude-code)