### PR TITLE
feat(design): batches 3–6 — empty/loading patterns, the register diet, accounts un-nested, one period clock — plus the borders.css surgery

### DIFF
--- a/src/components/EmptyState.tsx
+++ b/src/components/EmptyState.tsx
@@ -1,22 +1,49 @@
 import React from 'react';
 import { PlusIcon } from './icons';
 
-interface EmptyStateProps {
+/**
+ * A remedy the user can actually press. Two of them at most: past two, the
+ * state is a menu and the writing has stopped saying which one to choose.
+ */
+interface EmptyStateAction {
+  label: string;
+  onClick: () => void;
   icon?: React.ReactNode;
-  title: string;
-  description?: string;
-  action?: {
-    label: string;
-    onClick: () => void;
-    icon?: React.ReactNode;
-  };
-  secondaryAction?: {
-    label: string;
-    onClick: () => void;
-  };
+}
+
+interface EmptyStateProps {
+  /**
+   * Kept for callers that still pass one, and passed by nothing in the app:
+   * DESIGN_PASS §4 rules out illustrations, and a decorative tile above a
+   * sentence is the "friendly" register of a consumer app rather than the
+   * plain one this product uses.
+   */
+  icon?: React.ReactNode;
+  /** Sentence 1 — WHAT IS ABSENT. A node, so a count can be emphasised. */
+  title: React.ReactNode;
+  /** Sentence 2 — THE CONSEQUENCE of it being absent. */
+  description?: React.ReactNode;
+  action?: EmptyStateAction;
+  secondaryAction?: EmptyStateAction;
   className?: string;
 }
 
+/**
+ * The empty state, in the one shape the app uses everywhere (DESIGN_PASS §4).
+ *
+ * LEFT-ALIGNED, never centred with an icon. A centred block with a picture is
+ * a greeting; what somebody looking at an empty register needs is the same
+ * thing a warning gives them — P6, say the consequence, then the remedy — and
+ * that reads down the left edge like the rest of the page.
+ *
+ *   No transactions in this account yet
+ *   Its balance will read £0.00 and it won't appear in reports until
+ *   something lands here.
+ *   [Add transaction] [Import a statement]
+ *
+ * The remedy is a REAL CONTROL, not a sentence telling the user where to find
+ * one: the whole cost of an empty state is the trip it saves.
+ */
 export default function EmptyState({
   icon,
   title,
@@ -26,40 +53,53 @@ export default function EmptyState({
   className = ''
 }: EmptyStateProps): React.JSX.Element {
   return (
-    <div className={`flex flex-col items-center justify-center py-16 px-8 text-center ${className}`}>
+    <div className={`flex flex-col items-start px-6 py-10 ${className}`}>
       {icon && (
-        <div className="mb-6 w-16 h-16 rounded-2xl bg-gray-50 dark:bg-gray-700 flex items-center justify-center text-gray-400 dark:text-gray-500">
+        <div className="mb-4 text-gray-400 dark:text-gray-500">
           {icon}
         </div>
       )}
 
-      <h3 className="text-lg font-semibold text-gray-900 dark:text-white mb-2">
+      <h3 className="text-card font-semibold text-gray-900 dark:text-white">
         {title}
       </h3>
 
       {description && (
-        <p className="text-sm text-gray-500 dark:text-gray-400 max-w-sm mb-8 leading-relaxed">
+        <p className="mt-1 max-w-2xl text-body text-gray-600 dark:text-gray-400">
           {description}
         </p>
       )}
 
-      {action && (
-        <button
-          onClick={action.onClick}
-          className="inline-flex items-center gap-2 px-5 py-2.5 bg-[#1a2332] text-white text-sm font-medium rounded-lg hover:bg-[#2d3a4d] transition-colors shadow-sm"
-        >
-          {action.icon || <PlusIcon size={18} />}
-          {action.label}
-        </button>
-      )}
+      {(action || secondaryAction) && (
+        <div className="mt-4 flex flex-wrap items-center gap-2">
+          {action && (
+            <button
+              type="button"
+              onClick={action.onClick}
+              className="inline-flex items-center gap-2 px-4 py-2 rounded bg-[#1a2332] text-white text-body font-medium hover:bg-[#2d3a4d] transition-colors duration-state"
+            >
+              {/* undefined is "no opinion", and gets the default plus; null is
+                  "this remedy is not an add" — Clear filters takes something
+                  away, and a + in front of it says the opposite. */}
+              {action.icon === undefined ? <PlusIcon size={16} /> : action.icon}
+              {action.label}
+            </button>
+          )}
 
-      {secondaryAction && (
-        <button
-          onClick={secondaryAction.onClick}
-          className="mt-3 text-sm text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-300 transition-colors"
-        >
-          {secondaryAction.label}
-        </button>
+          {/* The second remedy is the SAME rank of thing as the first — per P7
+              a secondary outline, beside it, not a quiet link underneath it
+              that reads as an afterthought. */}
+          {secondaryAction && (
+            <button
+              type="button"
+              onClick={secondaryAction.onClick}
+              className="inline-flex items-center gap-2 px-4 py-2 rounded border border-line-strong dark:border-gray-600 text-body font-medium text-gray-700 dark:text-gray-300 hover:bg-surface-secondary dark:hover:bg-gray-700 transition-colors duration-state"
+            >
+              {secondaryAction.icon}
+              {secondaryAction.label}
+            </button>
+          )}
+        </div>
       )}
     </div>
   );

--- a/src/components/FilteredEmptyState.test.tsx
+++ b/src/components/FilteredEmptyState.test.tsx
@@ -1,0 +1,72 @@
+import React from 'react';
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import FilteredEmptyState from './FilteredEmptyState';
+
+/**
+ * Filtered-empty is the state a finance app must never get wrong: it looks
+ * exactly like data loss, and it is not (DESIGN_PASS §4). Two facts make it
+ * survivable — HOW MANY are hidden and WHAT is hiding them — so both are
+ * pinned here rather than left to the copy of whichever screen renders it.
+ */
+describe('FilteredEmptyState', () => {
+  it('says how many rows still exist, grouped, so the count reads at a glance', () => {
+    render(<FilteredEmptyState hiddenCount={1284} filters={['Category: Travel']} onClear={vi.fn()} />);
+
+    expect(screen.getByText('1,284')).toBeInTheDocument();
+    expect(screen.getByText(/in this account are hidden by/)).toBeInTheDocument();
+  });
+
+  it('names every filter responsible, not just the first', () => {
+    render(
+      <FilteredEmptyState
+        hiddenCount={12}
+        filters={['Category: Travel', 'This month', 'To Review only']}
+        onClear={vi.fn()}
+      />
+    );
+
+    expect(screen.getByText('Category: Travel')).toBeInTheDocument();
+    expect(screen.getByText('This month')).toBeInTheDocument();
+    expect(screen.getByText('To Review only')).toBeInTheDocument();
+    // Read as a sentence: "A, B and C".
+    expect(document.body.textContent).toContain('This month and To Review only');
+  });
+
+  it('agrees with itself about one hidden row', () => {
+    render(<FilteredEmptyState hiddenCount={1} filters={['Search: Ferrier']} onClear={vi.fn()} />);
+
+    expect(document.body.textContent).toContain('1 in this account is hidden by');
+  });
+
+  it('offers exactly one control, and it lets go of the filters', () => {
+    const onClear = vi.fn();
+    render(<FilteredEmptyState hiddenCount={9} filters={['This month']} onClear={onClear} />);
+
+    const buttons = screen.getAllByRole('button');
+    expect(buttons).toHaveLength(1);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Clear filters' }));
+    expect(onClear).toHaveBeenCalledTimes(1);
+  });
+
+  it('wears no plus: the remedy takes something away rather than adding one', () => {
+    render(<FilteredEmptyState hiddenCount={9} filters={['This month']} onClear={vi.fn()} />);
+
+    expect(screen.getByRole('button', { name: 'Clear filters' }).querySelector('svg')).toBeNull();
+  });
+
+  it('still says something true when the filters cannot be named', () => {
+    render(<FilteredEmptyState hiddenCount={4} filters={[]} onClear={vi.fn()} />);
+
+    expect(document.body.textContent).toContain('4 in this account are hidden by the filters you have set');
+  });
+
+  it('takes the scope it is given, for a list that is not one account', () => {
+    render(
+      <FilteredEmptyState hiddenCount={7} filters={['This month']} onClear={vi.fn()} scope="across your accounts" />
+    );
+
+    expect(document.body.textContent).toContain('7 across your accounts are hidden by');
+  });
+});

--- a/src/components/FilteredEmptyState.tsx
+++ b/src/components/FilteredEmptyState.tsx
@@ -1,0 +1,74 @@
+import React from 'react';
+import EmptyState from './EmptyState';
+
+interface FilteredEmptyStateProps {
+  /** How many rows exist here that the filters are currently hiding. */
+  hiddenCount: number;
+  /**
+   * The filters responsible, named the way the user set them
+   * ("Category: Travel", "This month"). One phrase each — this is the list
+   * that turns "gone" back into "hidden".
+   */
+  filters: string[];
+  /** Puts every one of them away. */
+  onClear: () => void;
+  /** Where the hidden rows are, for the sentence. */
+  scope?: string;
+  className?: string;
+}
+
+/** "A, B and C" — the filters read as a sentence, not a comma-separated dump. */
+function joinFilters(names: string[]): React.ReactNode {
+  return names.map((name, index) => (
+    <React.Fragment key={name}>
+      {index > 0 && (index === names.length - 1 ? ' and ' : ', ')}
+      <span className="font-medium text-gray-900 dark:text-gray-100">{name}</span>
+    </React.Fragment>
+  ));
+}
+
+/**
+ * FILTERED-EMPTY IS NOT EMPTY (DESIGN_PASS §4).
+ *
+ * The most alarming bug a finance app can fake is "my transactions are gone",
+ * and a filter that hides every row fakes it perfectly: the register goes
+ * white and says nothing about why. So this state always names the two facts
+ * that make it survivable — HOW MANY are hidden, and WHICH FILTERS are hiding
+ * them — and then offers the one control that undoes it.
+ *
+ *   No transactions match these filters
+ *   1,284 in this account are hidden by Category: Travel and This month.
+ *   [Clear filters]
+ *
+ * The count is deliberately of rows that EXIST: it is the sentence that says
+ * the data is still there.
+ */
+export default function FilteredEmptyState({
+  hiddenCount,
+  filters,
+  onClear,
+  scope = 'in this account',
+  className = ''
+}: FilteredEmptyStateProps): React.JSX.Element {
+  return (
+    <EmptyState
+      className={className}
+      title="No transactions match these filters"
+      description={
+        <>
+          <span className="font-medium text-gray-900 dark:text-gray-100 tabular-nums">
+            {hiddenCount.toLocaleString()}
+          </span>
+          {` ${scope} ${hiddenCount === 1 ? 'is' : 'are'} hidden by `}
+          {filters.length > 0 ? joinFilters(filters) : 'the filters you have set'}.
+        </>
+      }
+      action={{
+        label: 'Clear filters',
+        onClick: onClear,
+        // No plus: this remedy takes something away.
+        icon: null
+      }}
+    />
+  );
+}

--- a/src/components/NetWorthSummary.tsx
+++ b/src/components/NetWorthSummary.tsx
@@ -1,0 +1,124 @@
+import React from 'react';
+
+/**
+ * Net worth and its two components, as ONE card.
+ *
+ * ─ WHY IT IS ONE CARD ──────────────────────────────────────────────────────
+ * Both surfaces that show these three figures used to draw them as a navy slab
+ * plus two white cards — one important thing and two afterthoughts, when what
+ * is actually on screen is one figure and the two halves it is made of
+ * (DESIGN_PASS_2026-08 §3.3, §3.4). Assets minus liabilities IS net worth, so
+ * the three sit in one card, three columns, separated by hairlines rather than
+ * by gaps between separate boxes.
+ *
+ * The dark slab went with it. A full-bleed navy panel under a navy nav bar puts
+ * two heavy horizontals at the top of the page, and it forces a second
+ * text-colour system (white-on-navy) to exist for one card. The figure is
+ * already the largest thing on the page — per P1 it does not need a panel
+ * behind it to say so.
+ *
+ * ─ WHY IT IS SHARED ────────────────────────────────────────────────────────
+ * The Accounts list and the Dashboard show the same three numbers. Two copies
+ * of this markup is two things to keep in step, and they had already drifted
+ * into different colours, sizes and shapes. One definition means the two
+ * surfaces cannot disagree about what net worth looks like.
+ *
+ * ─ CURRENCY ────────────────────────────────────────────────────────────────
+ * All three values are formatted by the caller in the DISPLAY currency (the
+ * preference), never in any one account's own — a total over accounts that do
+ * not share a currency belongs to none of them. Individual account rows keep
+ * showing their own currency; that split is deliberate and is what settles the
+ * mismatch between the summary and the rows below it.
+ */
+
+export type NetWorthFigure = 'net' | 'assets' | 'liabilities';
+
+interface NetWorthSummaryProps {
+  /** Already formatted, in the display currency. */
+  netWorth: string;
+  assets: string;
+  liabilities: string;
+  /**
+   * Drill-down, if this surface has one — the Accounts list opens the accounts
+   * behind a figure. Omitted, the cells are plain text rather than dead
+   * buttons.
+   */
+  onSelect?: (figure: NetWorthFigure) => void;
+}
+
+/** The column heading over each figure. */
+const LABEL_CLASS = 'text-label uppercase font-medium text-gray-500 dark:text-gray-400';
+
+export default function NetWorthSummary({
+  netWorth,
+  assets,
+  liabilities,
+  onSelect,
+}: NetWorthSummaryProps): React.JSX.Element {
+  const cells: ReadonlyArray<{
+    figure: NetWorthFigure;
+    label: string;
+    value: string;
+    /**
+     * Net worth is the headline, at `display`; its two components read one
+     * step down at `page`, which is the hierarchy the old navy slab was using
+     * a background colour to state.
+     */
+    figureClass: string;
+  }> = [
+    {
+      figure: 'net',
+      label: 'Net worth',
+      value: netWorth,
+      // Navy, not green/red: net worth is the answer, not a direction of
+      // travel, and the sign in front of it says which way it went (P2).
+      figureClass: 'text-display font-semibold text-primary dark:text-white',
+    },
+    {
+      figure: 'assets',
+      label: 'Assets',
+      value: assets,
+      figureClass: 'text-page font-semibold text-income dark:text-green-400',
+    },
+    {
+      figure: 'liabilities',
+      label: 'Liabilities',
+      value: liabilities,
+      figureClass: 'text-page font-semibold text-expense dark:text-red-400',
+    },
+  ];
+
+  return (
+    <div className="overflow-hidden rounded-lg border border-line dark:border-gray-700 bg-white dark:bg-gray-800">
+      {/* Hairlines between the columns, not gaps between cards: one border for
+          the whole thing rather than three. They stack on a phone, where three
+          eight-digit figures abreast force the page to scroll sideways. */}
+      <div className="grid grid-cols-1 sm:grid-cols-3 divide-y divide-line dark:divide-gray-700 sm:divide-y-0 sm:divide-x sm:divide-line">
+        {cells.map(({ figure, label, value, figureClass }) => {
+          const content = (
+            <>
+              <p className={LABEL_CLASS}>{label}</p>
+              <p className={`mt-1 ${figureClass}`}>{value}</p>
+            </>
+          );
+
+          return onSelect ? (
+            <button
+              key={figure}
+              type="button"
+              onClick={() => onSelect(figure)}
+              className="flex flex-col items-start p-4 text-left transition-colors duration-state hover:bg-surface-secondary dark:hover:bg-gray-700/50 focus:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-blue-500 !shadow-none"
+              title="See the accounts behind this figure"
+            >
+              {content}
+            </button>
+          ) : (
+            <div key={figure} className="p-4">
+              {content}
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/src/components/OnboardingModal.tsx
+++ b/src/components/OnboardingModal.tsx
@@ -66,12 +66,19 @@ export default function OnboardingModal({ isOpen, onComplete }: OnboardingModalP
       >
         <div className="flex justify-between items-center mb-6">
           <h2 className="text-xl font-semibold text-gray-900 dark:text-white">
-            Welcome to WealthTracker!
+            Welcome to WealthTracker
           </h2>
         </div>
 
+        {/* The one moment to say what this is. The copy here used to be
+            friendly-generic ("let's personalize your experience"), which
+            describes any app at all — so the first thing a new user read told
+            them nothing about the one they had just opened
+            (DESIGN_PASS_2026-08 §3.4). Each field now also says what the app
+            DOES with the answer. */}
         <p className="text-gray-600 dark:text-gray-400 mb-6">
-          Let's personalize your experience with a few quick settings.
+          Two answers and you're in. This is a dense, keyboard-driven ledger:
+          your figures stay yours, and every report says what it leaves out.
         </p>
 
         <form onSubmit={handleSubmit} className="space-y-4">
@@ -89,7 +96,7 @@ export default function OnboardingModal({ isOpen, onComplete }: OnboardingModalP
               autoFocus
             />
             <p className="text-xs text-gray-500 dark:text-gray-400 mt-1">
-              This will be used to personalize your dashboard
+              It greets you on the dashboard. That is all it is used for.
             </p>
           </div>
 
@@ -110,7 +117,8 @@ export default function OnboardingModal({ isOpen, onComplete }: OnboardingModalP
               ))}
             </select>
             <p className="text-xs text-gray-500 dark:text-gray-400 mt-1">
-              Choose your preferred base currency to display your net worth in
+              Every total is shown in this currency — net worth, group totals,
+              reports. Individual accounts keep their own.
             </p>
           </div>
 
@@ -126,7 +134,7 @@ export default function OnboardingModal({ isOpen, onComplete }: OnboardingModalP
 
         <div className="mt-4 p-3 bg-blue-50 dark:bg-blue-900/20 border border-blue-200 dark:border-blue-800 rounded-lg">
           <p className="text-xs text-blue-800 dark:text-blue-200">
-            💡 You can change these settings anytime in Settings → App Settings
+            Both can be changed later in Settings → App Settings.
           </p>
         </div>
       </div>

--- a/src/components/PeriodBar.tsx
+++ b/src/components/PeriodBar.tsx
@@ -1,0 +1,36 @@
+import React from 'react';
+import { CalendarIcon } from './icons';
+import PeriodPicker from './PeriodPicker';
+import type { UsePeriodResult } from '../hooks/usePeriod';
+
+/**
+ * The page-level period bar: the ONE control that says what window a whole
+ * page is being read over.
+ *
+ * ─ WHY IT IS NOT A CARD ────────────────────────────────────────────────────
+ * The Reports hub used to wrap this in a full-width white card — about 90px of
+ * chrome around a 36px control, which per P1 is decoration charged against the
+ * figures below it. The pills sit directly under the page heading instead: the
+ * position is what says "this governs the page", and a box around it adds
+ * nothing to that (DESIGN_PASS_2026-08 §3.5).
+ *
+ * ─ WHY IT IS SHARED ────────────────────────────────────────────────────────
+ * The Dashboard used to carry period pickers of its own, in the same style but
+ * governing only the section they sat in, so neither declared its scope
+ * (§3.4). Both pages now render THIS, in the same place relative to the
+ * heading, so the rule the user learns on one page holds on the other.
+ *
+ * `label` is required, unlike PeriodPicker's own: a control this far from what
+ * it governs has to say so out loud for anyone who cannot see the layout.
+ */
+export default function PeriodBar({ picker, label }: {
+  picker: UsePeriodResult;
+  label: string;
+}): React.JSX.Element {
+  return (
+    <div data-period-bar className="flex items-center gap-2">
+      <CalendarIcon className="text-gray-500 flex-shrink-0" size={18} aria-hidden="true" />
+      <PeriodPicker picker={picker} label={label} />
+    </div>
+  );
+}

--- a/src/components/VirtualizedTable.tsx
+++ b/src/components/VirtualizedTable.tsx
@@ -72,6 +72,13 @@ export interface VirtualizedTableProps<T> {
   sortColumn?: string;
   sortDirection?: 'asc' | 'desc';
   emptyMessage?: string;
+  /**
+   * What stands where the rows would be when there are none. Richer than
+   * emptyMessage, which stays for callers that only want a line of text: an
+   * empty state that names a consequence and offers the remedy is a block, not
+   * a sentence (DESIGN_PASS §4).
+   */
+  emptyContent?: ReactNode;
   isLoading?: boolean;
   onLoadMore?: () => void;
   hasMore?: boolean;
@@ -103,6 +110,30 @@ export interface VirtualizedTableProps<T> {
   rowDomId?: (rowKey: string) => string;
   /** See RowDetail — an editor drawn under one row, pushing the rest down. */
   rowDetail?: RowDetail<T> | null;
+
+  /* ── How the table is DRESSED ───────────────────────────────────────────
+   * Four opt-ins, each defaulting to exactly what this component drew before
+   * they existed. A table that is a card on a page keeps the card; a table
+   * that IS the page's content can now say so, which is what the register's
+   * chrome reduction needed (DESIGN_PASS §3.1) and what a list of rows on a
+   * white page needs generally. */
+
+  /**
+   * 'card' (default) — the rounded, shadowed panel.
+   * 'flat' — no radius, no shadow: the table is the content, and the page
+   * around it is the surface. Per §2.5, one hairline does what a shadow was
+   * doing.
+   */
+  surface?: 'card' | 'flat';
+  /** Alternating row backgrounds. Default true. */
+  striped?: boolean;
+  /** The 1px rule between rows. */
+  rowBorderClassName?: string;
+  /** The header cell's own type — size and weight. */
+  headerCellClassName?: string;
+  /** Hover colour for a sortable header's button, when the default (which
+   * assumes a dark header wherever headerClassName is set) is wrong. */
+  headerSortHoverClassName?: string;
 }
 
 // Table header component
@@ -119,10 +150,14 @@ const TableHeader = memo(function TableHeader<T>({
   sortDirection,
   onColumnReorder,
   onColumnResize,
-  gridSemantics = false
+  gridSemantics = false,
+  headerCellClassName = 'font-medium text-sm',
+  headerSortHoverClassName
 }: {
   columns: Column<T>[];
   headerClassName?: string;
+  headerCellClassName?: string;
+  headerSortHoverClassName?: string;
   showCheckbox?: boolean;
   selectedItems?: Set<string>;
   items: T[];
@@ -240,13 +275,18 @@ const TableHeader = memo(function TableHeader<T>({
               setOverKey(null);
             } : undefined}
             onDragEnd={reorderable ? () => { setDragKey(null); setOverKey(null); } : undefined}
-            className={`relative px-3 py-2 font-medium text-sm ${headerClassName ? '' : 'text-gray-700 dark:text-gray-300'} ${column.headerClassName || ''} ${reorderable ? 'cursor-move select-none' : ''} ${isDropTarget ? 'border-l-2 border-blue-400' : ''} ${dragKey === column.key ? 'opacity-50' : ''}`}
+            className={`relative px-3 py-2 ${headerCellClassName} ${headerClassName ? '' : 'text-gray-700 dark:text-gray-300'} ${column.headerClassName || ''} ${reorderable ? 'cursor-move select-none' : ''} ${isDropTarget ? 'border-l-2 border-blue-400' : ''} ${dragKey === column.key ? 'opacity-50' : ''}`}
             style={{ width: column.width }}
           >
             {column.sortable && onSort ? (
               <button
                 onClick={() => handleSort(column.key)}
-                className={`inline-flex items-center gap-1 ${headerClassName ? 'hover:text-gray-100' : 'hover:text-gray-900 dark:hover:text-gray-100'}`}
+                // The button IS the header's text, so it wears the header's
+                // type: a <button> does not inherit text-transform from its
+                // cell (the UA stylesheet resets it), which had the sortable
+                // columns reading in sentence case beside a capitalised
+                // Balance — one header row in two voices.
+                className={`inline-flex items-center gap-1 ${headerCellClassName} ${headerSortHoverClassName ?? (headerClassName ? 'hover:text-gray-100' : 'hover:text-gray-900 dark:hover:text-gray-100')}`}
               >
                 {column.header}
                 {sortColumn === column.key && (
@@ -292,6 +332,7 @@ const VirtualizedTableComponent = memo(function VirtualizedTable<T>({
   sortColumn,
   sortDirection,
   emptyMessage = 'No data available',
+  emptyContent,
   isLoading = false,
   onLoadMore,
   hasMore = false,
@@ -303,8 +344,17 @@ const VirtualizedTableComponent = memo(function VirtualizedTable<T>({
   scrollToToken,
   scrollToBottomToken,
   rowDomId,
-  rowDetail
+  rowDetail,
+  surface = 'card',
+  striped = true,
+  rowBorderClassName = 'border-gray-200 dark:border-gray-700',
+  headerCellClassName,
+  headerSortHoverClassName
 }: VirtualizedTableProps<T>) {
+  // 'card' is what this component has always drawn; 'flat' is the opt-out.
+  const shellClass = surface === 'flat'
+    ? 'bg-white dark:bg-gray-900 overflow-hidden flex flex-col'
+    : 'bg-white dark:bg-gray-900 rounded-2xl shadow-lg overflow-hidden flex flex-col';
   // Resolve the deep-link key to its position in the CURRENT row order, so
   // the list can centre it regardless of sort or filters.
   const scrollToIndex = useMemo(() => {
@@ -405,14 +455,16 @@ const VirtualizedTableComponent = memo(function VirtualizedTable<T>({
     const isEditorRow = !!rowDetail && index === detailIndex;
     const detail = isEditorRow && rowDetail ? rowDetail.render(item) : null;
 
-    const baseRowClass = 'flex items-center border-b border-gray-200 dark:border-gray-700 transition-colors duration-150';
+    const baseRowClass = `flex items-center border-b ${rowBorderClassName} transition-colors duration-150`;
     const clickableClass = onRowClick ? 'cursor-pointer select-none' : '';
     // Only apply hover effects if not selected. No scale: these rows sit in
     // an overflow-clipped table, and a 1.01 scale pushed the rightmost
     // column's digits past the edge — the shadow and z-lift suffice.
     const hoverClass = onRowClick && !isSelected ? 'hover:shadow-[0_-6px_10px_-2px_rgba(0,0,0,0.15),0_6px_10px_-2px_rgba(0,0,0,0.15)] hover:z-10 hover:bg-gray-50 dark:hover:bg-gray-800' : '';
-    // Don't apply stripe classes to selected rows
-    const stripeClass = !isSelected && index % 2 === 1 ? 'bg-gray-100 dark:bg-gray-800/50' : !isSelected ? 'bg-white dark:bg-gray-900' : '';
+    // Don't apply stripe classes to selected rows. Unstriped, every unselected
+    // row wears the plain background the even ones already wore — the stripe
+    // is what goes, not the surface.
+    const stripeClass = !isSelected && striped && index % 2 === 1 ? 'bg-gray-100 dark:bg-gray-800/50' : !isSelected ? 'bg-white dark:bg-gray-900' : '';
 
     // With a detail below it the row no longer owns react-window's slot: the
     // wrapper does, and the row keeps exactly its own height so the detail gets
@@ -514,17 +566,21 @@ const VirtualizedTableComponent = memo(function VirtualizedTable<T>({
     detailIndex,
     rowHeight,
     rowGestureProps,
-    isSelectionTail
+    isSelectionTail,
+    striped,
+    rowBorderClassName
   ]);
 
   
   // Empty state
   if (items.length === 0 && !isLoading) {
     return (
-      <div className={`bg-white dark:bg-gray-900 rounded-lg shadow ${className}`}>
+      <div className={`${surface === 'flat' ? 'bg-white dark:bg-gray-900' : 'bg-white dark:bg-gray-900 rounded-lg shadow'} ${className}`}>
         <TableHeader
           columns={columns as Column<unknown>[]}
           headerClassName={headerClassName}
+          headerCellClassName={headerCellClassName}
+          headerSortHoverClassName={headerSortHoverClassName}
           showCheckbox={showCheckbox}
           selectedItems={selectedItems}
           items={items as unknown[]}
@@ -537,18 +593,22 @@ const VirtualizedTableComponent = memo(function VirtualizedTable<T>({
           onColumnResize={onColumnResize}
           gridSemantics={!!rowDomId}
         />
-        <div className="text-center py-12 text-gray-500 dark:text-gray-400">
-          {emptyMessage}
-        </div>
+        {emptyContent ?? (
+          <div className="text-center py-12 text-gray-500 dark:text-gray-400">
+            {emptyMessage}
+          </div>
+        )}
       </div>
     );
   }
 
   return (
-    <div className={`bg-white dark:bg-gray-900 rounded-2xl shadow-lg overflow-hidden flex flex-col ${className}`}>
+    <div className={`${shellClass} ${className}`}>
       <TableHeader
         columns={columns as Column<unknown>[]}
         headerClassName={headerClassName}
+        headerCellClassName={headerCellClassName}
+        headerSortHoverClassName={headerSortHoverClassName}
         showCheckbox={showCheckbox}
         selectedItems={selectedItems}
         items={items as unknown[]}

--- a/src/components/dashboard/ImprovedDashboard.test.tsx
+++ b/src/components/dashboard/ImprovedDashboard.test.tsx
@@ -5,7 +5,7 @@
  *    reader, in the same words (they used to be written by two different rules,
  *    and the on-screen half went blank for any threshold but £500);
  *  - the account picker can start from everything or from nothing;
- *  - the two halves of "Your Reports" keep their own clocks;
+ *  - the whole page reads over ONE period, declared once under the heading;
  *  - it ends in figures, not in a second copy of the navigation.
  *
  * Every account name, figure and institution here is invented.
@@ -233,51 +233,74 @@ describe('Key Account Balances — select all / clear all', () => {
   });
 });
 
-describe('Your Reports — two columns, two clocks', () => {
+/**
+ * ONE clock for the page.
+ *
+ * This block used to be called "two columns, two clocks" and pinned the
+ * opposite arrangement: a period control per column of the reports box, plus a
+ * third on Performance, each governing only what it sat beside. Three
+ * identically-styled controls meant none of them declared its scope, so the
+ * design pass collapsed them into a single page-level bar under the heading
+ * (DESIGN_PASS_2026-08 §3.4, whose stated test exposure is exactly this).
+ *
+ * What is asserted here is therefore the inverse of what it was, and
+ * deliberately so: the page has one period, everything below the bar obeys it,
+ * and the storage key it remembers survived the merge.
+ */
+describe('the dashboard reads over one period', () => {
   beforeEach(() => {
     mocks.app.accounts = [account({ id: 'acc-a', name: 'Feed Account A', openingBalance: 100 })];
     localStorage.setItem('dashboardPinnedReports', JSON.stringify(['net-worth', 'expense-categories']));
   });
 
-  const assetsPills = (): HTMLElement => screen.getByRole('group', { name: 'Period for net worth reports' });
-  const flowsPills = (): HTMLElement => screen.getByRole('group', { name: 'Period for income and spending reports' });
+  const periodBar = (): HTMLElement => screen.getByRole('group', { name: 'Period for this dashboard' });
 
-  it('gives each column its own period, and leaves the other one alone', () => {
+  it('is the only period control on the page', () => {
     render(<ImprovedDashboard />);
 
-    fireEvent.click(within(assetsPills()).getByRole('button', { name: 'All time' }));
-    const netWorthWindow = screen.getByTestId('net-worth-widget').textContent;
-    expect(netWorthWindow).toBe('none..none');
-
-    fireEvent.click(within(flowsPills()).getByRole('button', { name: 'Last month' }));
-
-    // The left column is untouched by the right column's choice.
-    expect(screen.getByTestId('net-worth-widget').textContent).toBe(netWorthWindow);
-    expect(screen.getByTestId('expense-categories-widget').textContent).not.toBe('none..none');
-
-    expect(within(assetsPills()).getByRole('button', { name: 'All time' })).toHaveAttribute('aria-pressed', 'true');
-    expect(within(flowsPills()).getByRole('button', { name: 'Last month' })).toHaveAttribute('aria-pressed', 'true');
+    // One control, not one per section. The two the reports box carried were
+    // feet apart and identical in style to Performance's.
+    expect(screen.getAllByRole('group', { name: /period/i })).toHaveLength(1);
+    expect(screen.queryByRole('group', { name: 'Period for net worth reports' })).toBeNull();
+    expect(screen.queryByRole('group', { name: 'Period for income and spending reports' })).toBeNull();
   });
 
-  it('remembers the two choices under separate keys', () => {
+  it('moves every report on the page together', () => {
     render(<ImprovedDashboard />);
 
-    fireEvent.click(within(assetsPills()).getByRole('button', { name: 'All time' }));
-    fireEvent.click(within(flowsPills()).getByRole('button', { name: 'Last month' }));
+    fireEvent.click(within(periodBar()).getByRole('button', { name: 'All time' }));
+
+    // Both halves of the reports box, on the one window the bar declares.
+    expect(screen.getByTestId('net-worth-widget').textContent).toBe('none..none');
+    expect(screen.getByTestId('expense-categories-widget').textContent).toBe('none..none');
+
+    fireEvent.click(within(periodBar()).getByRole('button', { name: 'Last month' }));
+
+    const lastMonth = screen.getByTestId('net-worth-widget').textContent;
+    expect(lastMonth).not.toBe('none..none');
+    expect(screen.getByTestId('expense-categories-widget').textContent).toBe(lastMonth);
+    expect(within(periodBar()).getByRole('button', { name: 'Last month' })).toHaveAttribute('aria-pressed', 'true');
+  });
+
+  it('remembers the choice under the key the page has always used', () => {
+    render(<ImprovedDashboard />);
+
+    fireEvent.click(within(periodBar()).getByRole('button', { name: 'All time' }));
 
     expect(localStorage.getItem('dashboardReports')).toBe('all');
-    expect(localStorage.getItem('dashboardReportsFlows')).toBe('last-month');
   });
 
-  it('carries an existing choice over to the column that used to share it', () => {
-    // The split must not silently reset half of what the user had chosen.
+  it('opens on a choice made before the three controls became one', () => {
+    // The merge keeps the original storage key rather than minting a new one,
+    // so nobody's stored dashboard moves underneath them.
     localStorage.setItem('dashboardReports', 'all');
     localStorage.setItem('dashboardReportsExplicit', 'true');
 
     render(<ImprovedDashboard />);
 
-    expect(within(assetsPills()).getByRole('button', { name: 'All time' })).toHaveAttribute('aria-pressed', 'true');
-    expect(within(flowsPills()).getByRole('button', { name: 'All time' })).toHaveAttribute('aria-pressed', 'true');
+    expect(within(periodBar()).getByRole('button', { name: 'All time' })).toHaveAttribute('aria-pressed', 'true');
+    expect(screen.getByTestId('net-worth-widget').textContent).toBe('none..none');
+    expect(screen.getByTestId('expense-categories-widget').textContent).toBe('none..none');
   });
 
   it('keeps the account distribution beside the reports, on today’s figures', () => {

--- a/src/components/dashboard/ImprovedDashboard.tsx
+++ b/src/components/dashboard/ImprovedDashboard.tsx
@@ -6,14 +6,11 @@ import { useNavigate, useLocation } from 'react-router-dom';
 // last cloud root a walk from this page could find once `@session` took the
 // state layer's preamble away.
 import { useIdentityKey } from '@identity';
-import { 
-  TrendingUpIcon, 
-  TrendingDownIcon, 
-  BanknoteIcon, 
+import {
+  TrendingUpIcon,
+  TrendingDownIcon,
   AlertCircleIcon,
   ChevronRightIcon,
-  ArrowUpIcon,
-  ArrowDownIcon,
   WalletIcon,
   PieChartIcon,
   SettingsIcon,
@@ -27,8 +24,9 @@ import { preserveDemoParam } from '../../utils/navigation';
 import EditTransactionModal from '../EditTransactionModal';
 import IncomeExpenseBreakdownModal from '../IncomeExpenseBreakdownModal';
 import { Modal, ModalBody } from '../common/Modal';
-import PeriodPicker from '../../components/PeriodPicker';
-import { PERIOD_LABELS, seedPeriodSelection, usePeriod } from '../../hooks/usePeriod';
+import PeriodBar from '../../components/PeriodBar';
+import NetWorthSummary from '../../components/NetWorthSummary';
+import { PERIOD_LABELS, usePeriod } from '../../hooks/usePeriod';
 import { customReportService } from '../../services/customReportService';
 import {
   NetWorthWidget,
@@ -54,9 +52,18 @@ import { buildAccountBankLinks } from '../../hooks/accountBankLinks';
 import { useBankConnectionSnapshot } from '@service';
 import { preferences } from '../../services/preferencesService';
 
-/** Where each half of the reports box remembers its period. */
-const ASSETS_PERIOD_KEY = 'dashboardReports';
-const FLOWS_PERIOD_KEY = 'dashboardReportsFlows';
+/**
+ * Where this page remembers the window it is being read over.
+ *
+ * The ORIGINAL key, deliberately. The dashboard has had three period controls
+ * at various times — one for Performance, one for each half of the reports box
+ * — and this is the one that predates all of them, so collapsing back to a
+ * single page-level control keeps the choice the user already made rather than
+ * starting them somewhere new. (`dashboardReportsFlows` and
+ * `dashboardPerformance` are no longer read; a stored value under either is
+ * simply ignored.)
+ */
+const DASHBOARD_PERIOD_KEY = 'dashboardReports';
 
 /**
  * Improved Dashboard with better information hierarchy
@@ -90,20 +97,22 @@ export function ImprovedDashboard() {
     return ['net-worth'];
   });
   const [showReportPicker, setShowReportPicker] = useState(false);
-  // Two clocks, because the two halves of the reports box answer different
-  // questions: what a life is worth is read over years, what a month cost is
-  // read over a month. One control for both forced net worth into last
-  // month's window to see last month's spending.
-  //
-  // The assets side keeps the original storage key, and the flows side is
-  // seeded from it once (before usePeriod reads storage below), so splitting
-  // the control does not quietly reset half of an existing choice.
-  useMemo(() => seedPeriodSelection(ASSETS_PERIOD_KEY, FLOWS_PERIOD_KEY), []);
-  const assetsPeriod = usePeriod(ASSETS_PERIOD_KEY, 'last-12-months');
-  const flowsPeriod = usePeriod(FLOWS_PERIOD_KEY, 'last-12-months');
-  // Performance keeps its OWN period (and storage key) so changing what the
-  // pinned reports cover never silently rewrites the headline income figure.
-  const performancePeriod = usePeriod('dashboardPerformance', 'this-month');
+  /**
+   * ONE clock for the whole page.
+   *
+   * There were three, in the same style, each governing only the section it
+   * happened to sit in — so none of them declared what it covered and two of
+   * them were feet apart on screen (DESIGN_PASS_2026-08 §3.4). A page-level bar
+   * under the heading says what it governs by WHERE IT IS, which is the thing
+   * the section-local pickers could not do at any size.
+   *
+   * Twelve months is the default because it is the window that reads on every
+   * figure below: net worth over a single month is a dot, while income and
+   * spending over a year is a perfectly ordinary question to ask. It is also
+   * the default this storage key already had, so nobody's stored dashboard
+   * moves underneath them.
+   */
+  const period = usePeriod(DASHBOARD_PERIOD_KEY, 'last-12-months');
   // The Account Distribution card lives here rather than in
   // DashboardReportWidgets, so it reaches for the same click-through as its
   // neighbours instead of growing a second one that drifts.
@@ -213,9 +222,7 @@ export function ImprovedDashboard() {
       budgetStatus,
       totalBudgeted,
       totalSpentOnBudgets,
-      overallBudgetPercent,
-      netWorthChange: 0, // Will be calculated from actual historical data when available
-      netWorthChangePercent: 0 // Will be calculated from actual historical data when available
+      overallBudgetPercent
     };
   }, [accounts, accountBalanceMap, transactions, transactionSplits, budgets]);
 
@@ -225,7 +232,7 @@ export function ImprovedDashboard() {
   // movement never decides the bucket. The cards and the breakdown modal read
   // these same totals, so both always describe one and the same window.
   const performance = useMemo(() => {
-    const { from, to } = performancePeriod.range;
+    const { from, to } = period.range;
     const flows = computeIncomeExpense(transactions, transactionSplits, categories, {
       from: from ?? undefined,
       to: to ?? undefined,
@@ -236,7 +243,7 @@ export function ImprovedDashboard() {
       incomeRows: flows.incomeRows,
       expenseRows: flows.expenseRows,
     };
-  }, [transactions, transactionSplits, categories, performancePeriod.range]);
+  }, [transactions, transactionSplits, categories, period.range]);
 
   // Generate net worth data for chart - ONLY REAL DATA
   const netWorthData = useMemo(() => {
@@ -341,8 +348,9 @@ export function ImprovedDashboard() {
   );
   const clearAllAccounts = useCallback(() => persistSelection([]), [persistSelection]);
 
-  // Which pinned reports belong to which column. Assets read over years,
-  // spending over months — see the two period keys above.
+  // Which pinned reports belong to which column: what you are worth on the
+  // left, what moved on the right. A layout split, not a period one — both
+  // columns read over the page's period.
   const assetsReports = pinnedReports.filter(id => id === 'net-worth');
   const flowsReports = pinnedReports.filter(
     id => id === 'income-expense-trend' || id === 'expense-categories'
@@ -355,62 +363,24 @@ export function ImprovedDashboard() {
 
   return (
     <div className="space-y-4 max-w-[1400px] mx-auto">
-      {/* Primary Focus: Net Worth Hero Card */}
-      <section 
-        aria-labelledby="net-worth-heading"
-        className="bg-[#1a2332] rounded-2xl p-6 sm:p-8 text-white shadow-xl"
+      {/* The one control that says what window this page is being read over.
+          Directly under the page heading, so its position states its scope. */}
+      <PeriodBar picker={period} label="Period for this dashboard" />
+
+      {/* Net worth and the two figures it is made of — one card, three
+          columns. The navy slab this replaces put a second heavy horizontal
+          under the nav bar and needed a whole white-on-navy text system to
+          itself; the figure was already the largest thing on the page without
+          it. See components/NetWorthSummary. */}
+      <section
+        data-testid="dashboard-grid"
+        aria-label="Net worth, assets and liabilities"
       >
-        <div className="flex items-start justify-between">
-          <div className="flex-1">
-            <h2 id="net-worth-heading" className="text-lg sm:text-xl opacity-90 font-medium">Your Net Worth</h2>
-            <div className="mt-2 flex items-baseline gap-3">
-              <span className="text-3xl sm:text-4xl lg:text-5xl font-bold">
-                {formatCurrencyWithSymbol(metrics.netWorth)}
-              </span>
-              {/* Only show change when we have historical data */}
-              {metrics.netWorthChange !== 0 && (
-                metrics.netWorthChange > 0 ? (
-                  <span className="flex items-center gap-1 text-green-300 text-sm sm:text-base">
-                    <ArrowUpIcon size={16} />
-                    +{formatDecimal(metrics.netWorthChangePercent, 1)}%
-                  </span>
-                ) : (
-                  <span className="flex items-center gap-1 text-red-300 text-sm sm:text-base">
-                    <ArrowDownIcon size={16} />
-                    {formatDecimal(metrics.netWorthChangePercent, 1)}%
-                  </span>
-                )
-              )}
-            </div>
-            {metrics.netWorthChange !== 0 && (
-              <p className="mt-3 opacity-80 text-sm sm:text-base">
-                vs last month: {formatCurrencyWithSymbol(metrics.netWorthChange)}
-              </p>
-            )}
-          </div>
-          <BanknoteIcon size={48} className="opacity-50 hidden sm:block" />
-        </div>
-        
-        {/* Quick stats */}
-        <div 
-          data-testid="dashboard-grid" 
-          className="grid grid-cols-2 gap-4 mt-6 pt-6 border-t border-white/20"
-          role="group"
-          aria-label="Assets and liabilities summary"
-        >
-          <div>
-            <p className="text-sm opacity-70">Assets</p>
-            <p className="text-xl font-semibold text-green-300">
-              {formatCurrencyWithSymbol(metrics.totalAssets)}
-            </p>
-          </div>
-          <div>
-            <p className="text-sm opacity-70">Liabilities</p>
-            <p className="text-xl font-semibold text-red-300">
-              {formatCurrencyWithSymbol(metrics.totalLiabilities)}
-            </p>
-          </div>
-        </div>
+        <NetWorthSummary
+          netWorth={formatCurrencyWithSymbol(metrics.netWorth)}
+          assets={formatCurrencyWithSymbol(metrics.totalAssets)}
+          liabilities={formatCurrencyWithSymbol(metrics.totalLiabilities)}
+        />
       </section>
 
       {/* Secondary Focus: Performance over the chosen period */}
@@ -418,13 +388,15 @@ export function ImprovedDashboard() {
         aria-labelledby="performance-heading"
         className="bg-white dark:bg-gray-800 rounded-xl shadow-sm border border-gray-100 dark:border-gray-700 p-6"
       >
+        {/* No picker of its own: this card reads over the page's period, like
+            everything else below the bar at the top. */}
         <div className="flex flex-wrap items-center gap-3 mb-4">
           <h3 id="performance-heading" className="text-lg font-semibold text-gray-900 dark:text-white">
             Performance
           </h3>
-          <div className="ml-auto">
-            <PeriodPicker picker={performancePeriod} />
-          </div>
+          <span className="text-body text-gray-500 dark:text-gray-400">
+            {PERIOD_LABELS[period.period]}
+          </span>
         </div>
 
         <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
@@ -462,17 +434,16 @@ export function ImprovedDashboard() {
           Same shared maths as the full Reports hub — the glance and the full
           view can never disagree.
 
-          Two columns, two clocks: what a life is worth on the left, what a
-          month cost on the right, each with its own period. They were one
-          control, which meant reading last month's spending dragged net worth
-          down to a single month with it. */}
-      <section
-        aria-labelledby="pinned-reports-heading"
-        className="bg-white dark:bg-gray-800 rounded-xl shadow-sm border border-gray-100 dark:border-gray-700 p-6"
-      >
-        {/* The gear lives on the title row so the period pickers below get
-            the card's full width — beside a picker it was stealing the exact
-            space the wrapped pill needed on a phone. */}
+          NOT A CARD. "Your Reports" is a section heading, and the report cards
+          below are cards — wrapping them in one more card put two borders and
+          two shadows around every chart (P7, §3.4). It stays a <section> with
+          an accessible name, which is what makes it a landmark; only the box
+          around it is gone.
+
+          Both columns read over the page's period now. They used to carry a
+          picker each, feet apart and identical in style to the one on
+          Performance above them. */}
+      <section aria-labelledby="pinned-reports-heading">
         <div className="flex items-center justify-between gap-3 mb-3">
           <h3 id="pinned-reports-heading" className="text-lg font-semibold text-gray-900 dark:text-white flex items-center gap-2">
             <BarChart3Icon size={24} className="text-gray-500" />
@@ -494,12 +465,7 @@ export function ImprovedDashboard() {
         <div className={`grid grid-cols-1 gap-6 ${showAssetsColumn && showFlowsColumn ? 'lg:grid-cols-2' : ''}`}>
           {showAssetsColumn && (
             <div className="space-y-4">
-              {assetsReports.length > 0 && (
-                <>
-                  <PeriodPicker picker={assetsPeriod} label="Period for net worth reports" />
-                  {assetsReports.map(id => <NetWorthWidget key={id} picker={assetsPeriod} />)}
-                </>
-              )}
+              {assetsReports.map(id => <NetWorthWidget key={id} picker={period} />)}
 
               {/* Account distribution: a snapshot of TODAY, sitting under a
                   period control it deliberately ignores — so it says so.
@@ -586,11 +552,10 @@ export function ImprovedDashboard() {
 
           {showFlowsColumn && (
             <div className="space-y-4">
-              <PeriodPicker picker={flowsPeriod} label="Period for income and spending reports" />
               {flowsReports.map(id => (
                 id === 'income-expense-trend'
-                  ? <IncomeExpenseTrendWidget key={id} picker={flowsPeriod} />
-                  : <ExpenseCategoriesWidget key={id} picker={flowsPeriod} />
+                  ? <IncomeExpenseTrendWidget key={id} picker={period} />
+                  : <ExpenseCategoriesWidget key={id} picker={period} />
               ))}
             </div>
           )}
@@ -662,7 +627,7 @@ export function ImprovedDashboard() {
       <IncomeExpenseBreakdownModal
         isOpen={breakdownType !== null}
         onClose={() => setBreakdownType(null)}
-        title={`${breakdownType === 'income' ? 'Income' : 'Expenses'} — ${PERIOD_LABELS[performancePeriod.period]}`}
+        title={`${breakdownType === 'income' ? 'Income' : 'Expenses'} — ${PERIOD_LABELS[period.period]}`}
         bucket={breakdownType ?? 'income'}
         rows={breakdownType === 'income' ? performance.incomeRows : performance.expenseRows}
         total={breakdownType === 'income' ? performance.income : performance.expenses}

--- a/src/components/loading/TableSkeleton.tsx
+++ b/src/components/loading/TableSkeleton.tsx
@@ -1,0 +1,74 @@
+import React from 'react';
+
+/**
+ * The shape of one column, exactly as the table itself declares it — a
+ * `Column<T>` satisfies this structurally, so the placeholder is measured off
+ * the real column list rather than a second copy of it that can drift.
+ */
+export interface TableSkeletonColumn {
+  key: string;
+  width?: string | number;
+  className?: string;
+}
+
+interface TableSkeletonProps {
+  columns: TableSkeletonColumn[];
+  /** The REAL row height of the table this stands in for, in px. */
+  rowHeight: number;
+  /** Three is the maximum that says "rows are coming" (DESIGN_PASS §4). */
+  rows?: number;
+  className?: string;
+}
+
+/** Row 1 solid, then away — "fading down", so it reads as a hint, not data. */
+const ROW_OPACITY = [1, 0.66, 0.33];
+
+/**
+ * SHAPE, NOT SPINNER (DESIGN_PASS §4).
+ *
+ * Skeleton rows at the real row height and the real column widths, so nothing
+ * moves when the figures arrive — a placeholder of the wrong size is a layout
+ * shift with extra steps.
+ *
+ * AND NO PULSING. Every skeleton in the wild breathes; a twenty-row register
+ * that breathes is nauseating, and on a virtualised list it burns a repaint of
+ * every visible row, every frame, on rows that are about to be thrown away.
+ * One 200ms fade-in when it appears is the whole of the animation budget.
+ */
+export function TableSkeleton({
+  columns,
+  rowHeight,
+  rows = 3,
+  className = ''
+}: TableSkeletonProps): React.JSX.Element {
+  const count = Math.min(rows, ROW_OPACITY.length);
+
+  return (
+    <div
+      role="status"
+      aria-label="Loading transactions"
+      className={`animate-fade-in motion-reduce:animate-none ${className}`}
+    >
+      {Array.from({ length: count }, (_, rowIndex) => (
+        <div
+          key={rowIndex}
+          style={{ height: rowHeight, opacity: ROW_OPACITY[rowIndex] }}
+          // The same hairline the real table rules its rows with, so nothing
+          // shifts when the data arrives.
+          className="flex items-center border-b border-line-soft dark:border-gray-700"
+          aria-hidden="true"
+        >
+          {columns.map(column => (
+            <div
+              key={column.key}
+              style={{ width: column.width }}
+              className={`px-3 overflow-hidden ${column.className || ''}`}
+            >
+              <span className="inline-block h-3 w-2/3 rounded bg-gray-200 dark:bg-gray-700" />
+            </div>
+          ))}
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/src/hooks/__tests__/useDelayedFlag.test.ts
+++ b/src/hooks/__tests__/useDelayedFlag.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useDelayedFlag, LOADING_REVEAL_DELAY_MS } from '../useDelayedFlag';
+
+/**
+ * "Under 200ms: show nothing" (DESIGN_PASS §4), as a rule rather than a habit.
+ *
+ * The failure this prevents is a fast load that LOOKS slow: a skeleton drawn
+ * for 80ms and thrown away is a flash of grey where the figures were about to
+ * be, and the eye reads a flash as a fault.
+ */
+describe('useDelayedFlag', () => {
+  beforeEach(() => {
+    // The shared setup file has already mocked the clock with setSystemTime
+    // (src/test/browserShims.ts); faking timers over the top of that throws,
+    // so this hands the real clock back first.
+    vi.useRealTimers();
+    vi.useFakeTimers();
+  });
+  afterEach(() => vi.useRealTimers());
+
+  it('is false for the whole of the delay, however busy the render', () => {
+    const { result } = renderHook(() => useDelayedFlag(true));
+
+    expect(result.current).toBe(false);
+    act(() => { vi.advanceTimersByTime(LOADING_REVEAL_DELAY_MS - 1); });
+    expect(result.current).toBe(false);
+  });
+
+  it('turns true once the wait has actually gone on that long', () => {
+    const { result } = renderHook(() => useDelayedFlag(true));
+
+    act(() => { vi.advanceTimersByTime(LOADING_REVEAL_DELAY_MS); });
+    expect(result.current).toBe(true);
+  });
+
+  it('shows NOTHING at all for a load that finishes inside the delay', () => {
+    const { result, rerender } = renderHook(({ active }) => useDelayedFlag(active), {
+      initialProps: { active: true }
+    });
+
+    act(() => { vi.advanceTimersByTime(120); });
+    rerender({ active: false });
+
+    // The timer that was running must not fire behind the answer's back.
+    act(() => { vi.advanceTimersByTime(1000); });
+    expect(result.current).toBe(false);
+  });
+
+  it('falls back to false the moment the wait ends, without waiting again', () => {
+    const { result, rerender } = renderHook(({ active }) => useDelayedFlag(active), {
+      initialProps: { active: true }
+    });
+
+    act(() => { vi.advanceTimersByTime(LOADING_REVEAL_DELAY_MS); });
+    expect(result.current).toBe(true);
+
+    rerender({ active: false });
+    expect(result.current).toBe(false);
+  });
+
+  it('starts the wait again for a second load rather than staying on', () => {
+    const { result, rerender } = renderHook(({ active }) => useDelayedFlag(active), {
+      initialProps: { active: true }
+    });
+
+    act(() => { vi.advanceTimersByTime(LOADING_REVEAL_DELAY_MS); });
+    rerender({ active: false });
+    rerender({ active: true });
+
+    expect(result.current).toBe(false);
+    act(() => { vi.advanceTimersByTime(LOADING_REVEAL_DELAY_MS); });
+    expect(result.current).toBe(true);
+  });
+});

--- a/src/hooks/useDelayedFlag.ts
+++ b/src/hooks/useDelayedFlag.ts
@@ -1,0 +1,31 @@
+import { useEffect, useState } from 'react';
+
+/** DESIGN_PASS §4: "Under 200ms: show nothing." */
+export const LOADING_REVEAL_DELAY_MS = 200;
+
+/**
+ * True only once `active` has been true for `delayMs` without interruption —
+ * the rule that keeps a fast load SILENT.
+ *
+ * A skeleton that appears for 80ms and vanishes is a flash of grey bars where
+ * the figures were about to be, and it makes a fast app look like a slow one.
+ * So the placeholder is not "what we show while loading", it is "what we show
+ * once loading has gone on long enough to need explaining".
+ *
+ * Falling back to false is IMMEDIATE and unconditional: the moment the data
+ * arrives the placeholder goes, with no timer left holding it on screen.
+ */
+export function useDelayedFlag(active: boolean, delayMs: number = LOADING_REVEAL_DELAY_MS): boolean {
+  const [elapsed, setElapsed] = useState(false);
+
+  useEffect(() => {
+    if (!active) {
+      setElapsed(false);
+      return;
+    }
+    const timer = setTimeout(() => setElapsed(true), delayMs);
+    return () => clearTimeout(timer);
+  }, [active, delayMs]);
+
+  return active && elapsed;
+}

--- a/src/hooks/usePeriod.ts
+++ b/src/hooks/usePeriod.ts
@@ -130,31 +130,16 @@ interface PeriodSelection {
   explicit: boolean;
 }
 
-/**
- * Carry a stored selection over to a second key, once.
- *
- * When one control is split into two, the half that keeps the old key keeps
- * the user's choice and the new half would silently start from its default —
- * so a dashboard set to "All time" would come back half on "All time" and half
- * on twelve months, with nothing said. Copying the selection (and its explicit
- * flag and custom bounds) the first time the new key is read means the split
- * changes the layout and nothing else. A no-op once the new key exists.
+/*
+ * `seedPeriodSelection` was here: it carried a stored selection over to a
+ * second key the first time that key was read, so SPLITTING one period control
+ * into two did not silently reset half of an existing choice. Its only caller
+ * was the Dashboard, whose three period controls have since been collapsed back
+ * into one page-level bar (DESIGN_PASS_2026-08 §3.4) — and that merge keeps the
+ * original storage key rather than introducing a new one, so there is nothing
+ * left to seed. Deleted with its caller rather than left as an export nobody
+ * imports.
  */
-export function seedPeriodSelection(
-  fromKey: string,
-  toKey: string,
-  storage: PeriodStorage = preferences
-): void {
-  if (storage.getItem(toKey) !== null) return;
-  const stored = storage.getItem(fromKey);
-  if (stored === null) return;
-
-  storage.setItem(toKey, stored);
-  for (const suffix of ['Explicit', 'CustomStart', 'CustomEnd']) {
-    const value = storage.getItem(`${fromKey}${suffix}`);
-    if (value !== null) storage.setItem(`${toKey}${suffix}`, value);
-  }
-}
 
 function readStoredSelection(
   storageKey: string,

--- a/src/pages/AccountTransactions.tsx
+++ b/src/pages/AccountTransactions.tsx
@@ -6,6 +6,7 @@ import { useParams, useNavigate, useLocation } from 'react-router-dom';
 import { useIdentityKey } from '@identity';
 import { useApp } from '../contexts/AppContextSupabase';
 import { parseMoneyInput, toDecimal } from '../utils/decimal';
+import type { DecimalInstance } from '../utils/decimal';
 import { isReconciled } from '../utils/transactionReconciliation';
 import { preserveDemoParam } from '../utils/navigation';
 import { useCurrencyDecimal } from '../hooks/useCurrencyDecimal';
@@ -35,7 +36,10 @@ import { usePreferences } from '../contexts/PreferencesContext';
 import { useToast } from '../contexts/ToastContext';
 import { VirtualizedTable, type Column, type RowDetail } from '../components/VirtualizedTable';
 import { InfiniteScrollTransactionList } from '../components/InfiniteScrollTransactionList';
-import { LoadingState } from '../components/loading/LoadingState';
+import { TableSkeleton } from '../components/loading/TableSkeleton';
+import { useDelayedFlag } from '../hooks/useDelayedFlag';
+import EmptyState from '../components/EmptyState';
+import FilteredEmptyState from '../components/FilteredEmptyState';
 import { compareChronological, compareTransactions, type TransactionSortField } from '../utils/transactionSort';
 import { createCategoryLabeller } from '../utils/categoryLabel';
 import { orderColumnKeys, moveColumnKey } from '../utils/columnLayout';
@@ -193,6 +197,25 @@ const QUICK_EDIT_COLUMN_FIELDS: Readonly<Record<string, QuickEditField>> = {
 
 // Friendly labels for the View dropdown's column checkboxes.
 const COLUMN_LABELS: Record<string, string> = { reconciled: 'Reconciled (R)' };
+
+/**
+ * ONE quiet outline for every toolbar control that is not the primary action
+ * (DESIGN_PASS §3.1 QUIET, and P7: four button roles in the building, a fifth
+ * is a bug report).
+ *
+ * Search & filters, View, Expand table and the two toggles were four different
+ * outlines with three border colours between them, which made the row read as
+ * four ranks of thing when it is one rank of thing and one primary. Written
+ * once, here, so the next control added to this toolbar has nowhere else to
+ * get its clothes from.
+ */
+const TOOLBAR_QUIET_BUTTON =
+  'flex w-full sm:w-auto items-center justify-center gap-2 px-3 py-1.5 text-sm border rounded transition-colors duration-state';
+const TOOLBAR_QUIET_IDLE =
+  'border-line-strong dark:border-gray-600 text-gray-700 dark:text-gray-300 hover:bg-surface-tertiary dark:hover:bg-gray-700';
+/** The same button, switched on. A state of the one style, not a second style. */
+const TOOLBAR_QUIET_ACTIVE =
+  'border-[#1a2332] dark:border-blue-500 text-[#1a2332] dark:text-blue-400 bg-surface-secondary dark:bg-gray-700';
 
 /** The sortable columns, named as their headers name them. */
 const SORT_FIELD_LABELS: Record<TransactionSortField, string> = {
@@ -354,10 +377,41 @@ export default function AccountTransactions() {
   const account = accounts.find(acc => acc.id === accountId);
   const accountIsOpen = account !== undefined;
 
+  /**
+   * ONE CURRENCY FOR THIS REGISTER, resolved once, before anything is drawn.
+   *
+   * A register is a column of figures that add up: the header total, the
+   * running balance and every payment in between are the same money, so a
+   * table that prints two symbols in one column is not a formatting slip, it
+   * is an arithmetic claim that cannot be true. It happened because the
+   * currency was passed at each call site — some with the account's, some with
+   * none at all, which silently means the user's display currency
+   * (see useCurrencyDecimal) — so agreement was a thing to remember rather
+   * than a thing that held. (DESIGN_PASS §3.1 FIX.)
+   *
+   * Everything the register prints about THIS account now goes through here.
+   * Figures about OTHER accounts — the transfer picker's list of balances —
+   * deliberately do not: they wear their own account's currency, because that
+   * is what they are.
+   */
+  const registerCurrency = account?.currency;
+  const formatRegisterMoney = useCallback(
+    (amount: DecimalInstance | number) => formatCurrency(amount, registerCurrency),
+    [formatCurrency, registerCurrency]
+  );
+
   // Asked for only on a miss, and only once the open list has arrived, so an
   // ordinary register costs no extra request.
   const [closedLookup, setClosedLookup] = useState<ClosedAccountLookup>({ status: 'idle' });
   const [reopening, setReopening] = useState(false);
+
+  /**
+   * Whether the wait has gone on long enough to be worth showing. Under 200ms
+   * the register shows NOTHING rather than a flash of grey bars — see
+   * useDelayedFlag, and DESIGN_PASS §4.
+   */
+  const registerIsResolving = !account && (isLoading || closedLookup.status !== 'done');
+  const showRegisterSkeleton = useDelayedFlag(registerIsResolving);
 
   useEffect(() => {
     if (isLoading || accountIsOpen) return;
@@ -865,6 +919,47 @@ export default function AccountTransactions() {
     [accountTransactions, reviewOnly]
   );
 
+  /**
+   * EVERY FILTER CURRENTLY HOLDING SOMETHING BACK, named the way the user set
+   * it — the list that turns "my transactions are gone" back into "they are
+   * hidden, by these" (DESIGN_PASS §4).
+   *
+   * Named from the same state the controls are bound to, so a filter that
+   * cannot be seen in the toolbar (the View menu's date window, the archive
+   * toggle) is still accounted for. A filtered-empty register that omitted one
+   * would be worse than saying nothing: it would send the user looking in the
+   * wrong place.
+   */
+  const activeFilterNames = useMemo<string[]>(() => {
+    const names: string[] = [];
+    if (searchTerm) names.push(`Search: ${searchTerm}`);
+    if (typeFilter !== 'all') {
+      names.push(`Type: ${typeFilter.charAt(0).toUpperCase()}${typeFilter.slice(1)}`);
+    }
+    if (dateFrom || dateTo) names.push('the date range');
+    if (archive.range !== 'all') {
+      const preset = ARCHIVE_PRESETS.find(p => p.value === archive.range);
+      names.push(`Show: ${preset?.label ?? archive.range}`);
+    }
+    if (reviewOnly) names.push('To Review only');
+    if (hasArchivedHere && !showArchived) names.push('archived rows being hidden');
+    return names;
+  }, [searchTerm, typeFilter, dateFrom, dateTo, archive.range, reviewOnly, hasArchivedHere, showArchived]);
+
+  /** Puts every one of the above away — the remedy the filtered-empty offers. */
+  const clearAllFilters = useCallback((): void => {
+    setSearchTerm('');
+    setTypeFilter('all');
+    setDateFrom('');
+    setDateTo('');
+    setArchive(prev => ({ ...prev, range: 'all' }));
+    setReviewOnly(false);
+    // "Clear filters" has to mean it: if archived rows are among what is
+    // hidden, a button that left them hidden would empty the register again
+    // and read as broken.
+    if (hasArchivedHere) setShowArchived(true);
+  }, [hasArchivedHere]);
+
   // Calculate running balance
   const transactionsWithBalance = useMemo<TransactionWithBalance[]>(() => {
     if (!account) return [] as TransactionWithBalance[];
@@ -902,6 +997,12 @@ export default function AccountTransactions() {
   // Build display rows with virtual Opening Balance as first entry
   const displayRows = useMemo<DisplayRow[]>(() => {
     if (!account) return [];
+
+    // Nothing visible means nothing for a lead line to lead. A register whose
+    // only row is "Brought forward" is the shape that made "my transactions
+    // are gone" plausible — it looks like a register that lost its contents.
+    // Empty, the table can say what is actually true instead (DESIGN_PASS §4).
+    if (transactionsWithBalance.length === 0) return [];
 
     const openingBalance = account.openingBalance ?? 0;
 
@@ -1005,11 +1106,11 @@ export default function AccountTransactions() {
       balanceOf: () => computedAccountBalance,
       linkOf: (id) => links.get(id),
       autoSyncMode: identityKey ? loadAutoSyncPrefs(identityKey).mode : 'off',
-      formatMoney: formatCurrency,
+      formatMoney: formatRegisterMoney,
       now: new Date(),
     });
     return item?.reason ?? null;
-  }, [account, bankConnections, computedAccountBalance, identityKey, formatCurrency]);
+  }, [account, bankConnections, computedAccountBalance, identityKey, formatRegisterMoney]);
 
   /**
    * What to say when the register is not in date order.
@@ -2406,7 +2507,17 @@ export default function AccountTransactions() {
           >
             C
           </span>
-        ) : null
+        ) : (
+          // THE COLUMN'S BASELINE. Unmarked used to be nothing at all, which
+          // left a law-bearing column reading as an empty gutter — and with
+          // nothing to change FROM, a C or an R arriving in it registered as
+          // "something in the gap" rather than as a state changing. A dimmed
+          // dot gives the column a floor: the eye learns where the marks live
+          // before there are any. Decorative, so it is hidden from a screen
+          // reader, which is told the truth by the absence of C or R.
+          // (DESIGN_PASS §3.1 FIX, TEST-GATED.)
+          <span aria-hidden="true" className="text-line-strong dark:text-gray-600">·</span>
+        )
       ),
       className: 'text-center',
       headerClassName: 'text-center'
@@ -2505,11 +2616,15 @@ export default function AccountTransactions() {
       // 130px fits a 7-figure amount with pennies; Description is the flex
       // column, so the extra width comes out of it automatically.
       width: '130px',
-      // Money out — the magnitude (no sign), in red, like MS Money's Payment column.
+      // Money out — the magnitude (no sign), in red, like MS Money's Payment
+      // column. WEIGHT 400: colour already says which direction this is, and
+      // the column that carries the weight is Balance (DESIGN_PASS §3.1
+      // PROMOTE). The token, not text-red-600, so the AA-instrumented value is
+      // the one on screen.
       accessor: (transaction) => (
         transaction.amount < 0 ? (
-          <span className="text-sm font-medium text-red-600 dark:text-red-400">
-            {formatCurrency(Math.abs(transaction.amount), account?.currency)}
+          <span className="text-sm font-normal text-expense dark:text-red-400">
+            {formatRegisterMoney(Math.abs(transaction.amount))}
           </span>
         ) : null
       ),
@@ -2521,11 +2636,12 @@ export default function AccountTransactions() {
       key: 'deposit',
       header: 'Deposit',
       width: '130px',
-      // Money in — in green, like MS Money's Deposit column.
+      // Money in — in green, like MS Money's Deposit column. Weight 400, as
+      // Payment above.
       accessor: (transaction) => (
         transaction.amount > 0 ? (
-          <span className="text-sm font-medium text-green-600 dark:text-green-400">
-            {formatCurrency(transaction.amount, account?.currency)}
+          <span className="text-sm font-normal text-income dark:text-green-400">
+            {formatRegisterMoney(transaction.amount)}
           </span>
         ) : null
       ),
@@ -2539,14 +2655,14 @@ export default function AccountTransactions() {
       header: 'Amount',
       width: '120px',
       accessor: (transaction) => (
-        <span className={`text-sm font-medium ${
+        <span className={`text-sm font-normal ${
           transaction.amount > 0
-            ? 'text-green-600 dark:text-green-400'
+            ? 'text-income dark:text-green-400'
             : transaction.amount < 0
-            ? 'text-red-600 dark:text-red-400'
+            ? 'text-expense dark:text-red-400'
             : 'text-gray-900 dark:text-gray-100'
         }`}>
-          {formatCurrency(transaction.amount, account?.currency)}
+          {formatRegisterMoney(transaction.amount)}
         </span>
       ),
       className: 'text-right',
@@ -2581,19 +2697,25 @@ export default function AccountTransactions() {
         // account is to read the figures off in rendered order.
         <span
           data-testid="register-balance"
+          // THE LINE PEOPLE ACTUALLY TRACK, and until now the hardest of the
+          // three money columns to find: all of them shared one weight, so
+          // the running balance was just more figures. 500 in the navy-900
+          // family — colour says direction, weight says "this is the line"
+          // (DESIGN_PASS §3.1 PROMOTE). Negative still reads red, because an
+          // overdrawn balance is a fact about the money and not a decoration.
           className={`text-sm font-medium ${
             transaction.balance < 0
-              ? 'text-red-600 dark:text-red-400'
-              : 'text-gray-900 dark:text-gray-100'
+              ? 'text-expense dark:text-red-400'
+              : 'text-primary dark:text-gray-100'
           }`}
         >
-          {formatCurrency(transaction.balance, account?.currency)}
+          {formatRegisterMoney(transaction.balance)}
         </span>
       ),
       className: 'text-right',
       headerClassName: 'text-right'
     }
-  ], [formatCurrency, account?.currency, categoryLabel]);
+  ], [formatRegisterMoney, categoryLabel]);
 
   // Apply the persisted order + widths on top of the base definitions.
   const columns: Column<DisplayRow>[] = useMemo(() => {
@@ -2660,8 +2782,19 @@ export default function AccountTransactions() {
     // Still finding out which of the three it is — the open list may not have
     // arrived, or the closed lookup may be in flight. Saying "not found" here
     // would flash an error at an account that exists.
+    // Spelled out rather than read off registerIsResolving, which carries the
+    // same answer but does not narrow closedLookup for the branches below it.
     if (isLoading || closedLookup.status !== 'done') {
-      return <LoadingState message="Loading account…" />;
+      // SHAPE, NOT SPINNER — and only once the wait has earned it. The rows
+      // are drawn at the height and the column widths the real ones will
+      // have, so the register does not jump when they arrive (DESIGN_PASS §4).
+      return showRegisterSkeleton
+        ? (
+          <div className="hidden lg:block">
+            <TableSkeleton columns={columns} rowHeight={compactView ? 36 : 44} />
+          </div>
+        )
+        : null;
     }
 
     // Closed: an honest page, not an error. Its history is intact; what it
@@ -2733,6 +2866,34 @@ export default function AccountTransactions() {
     ? formatCardNumberForDisplay(storedAccountNumber)
     : storedAccountNumber;
 
+  /**
+   * What stands where the rows would be — and the two cases are NOT the same
+   * state (DESIGN_PASS §4).
+   *
+   * An account with nothing in it is a beginning, and wants the two ways of
+   * putting something in it. An account whose rows are all behind a filter is
+   * an alarm — the register looks exactly like one that has lost its contents
+   * — and wants the count that proves they still exist, the filters holding
+   * them back by name, and the one control that lets go.
+   */
+  const registerEmptyState = fullAccountTransactions.length === 0 ? (
+    <EmptyState
+      title="No transactions in this account yet"
+      description={`Its balance stays at ${formatRegisterMoney(computedAccountBalance)}, and this account adds nothing to your reports until something lands here.`}
+      action={{ label: 'Add transaction', onClick: () => setShowAddTransaction(true) }}
+      secondaryAction={{
+        label: 'Import a statement',
+        onClick: () => navigate(preserveDemoParam('/enhanced-import', location.search))
+      }}
+    />
+  ) : (
+    <FilteredEmptyState
+      hiddenCount={fullAccountTransactions.length}
+      filters={activeFilterNames}
+      onClear={clearAllFilters}
+    />
+  );
+
   return (
     <div className="flex flex-col h-full">
       {/* The way back.
@@ -2794,7 +2955,7 @@ export default function AccountTransactions() {
                 ? 'text-green-600 dark:text-green-400'
                 : 'text-red-600 dark:text-red-400'
             }`}>
-              {formatCurrency(computedAccountBalance, account.currency)}
+              {formatRegisterMoney(computedAccountBalance)}
             </span>
           </div>
 
@@ -2807,14 +2968,14 @@ export default function AccountTransactions() {
                   : 'text-red-600 dark:text-red-400'
                 : 'text-gray-400 dark:text-gray-500'
             }`}>
-              {bankBalance != null ? formatCurrency(bankBalance, account.currency) : 'N/A'}
+              {bankBalance != null ? formatRegisterMoney(bankBalance) : 'N/A'}
             </span>
           </div>
 
           <div className="bg-white/90 dark:bg-gray-800/90 backdrop-blur-xl rounded-lg border border-gray-100 dark:border-gray-700 px-3 py-1.5 flex items-center gap-3 justify-between lg:justify-normal">
             <span className="text-xs text-gray-500 dark:text-gray-400 whitespace-nowrap">Unreconciled</span>
             <span className="text-sm font-bold text-gray-900 dark:text-white whitespace-nowrap">
-              {formatCurrency(unreconciledTotal, account.currency)}
+              {formatRegisterMoney(unreconciledTotal)}
             </span>
           </div>
 
@@ -2828,7 +2989,7 @@ export default function AccountTransactions() {
                     ? 'text-blue-600 dark:text-blue-400'
                     : 'text-red-600 dark:text-red-400'
                 }`}>
-                  {formatCurrency(difference, account.currency)}
+                  {formatRegisterMoney(difference)}
                 </span>
               );
             })() : (
@@ -2854,10 +3015,13 @@ export default function AccountTransactions() {
       <div className="flex flex-col gap-3">
       {/* Toolbar: what the register SHOWS on the left, what it DOES on the
           right — Add last, in the rightmost seat, the way every other page in
-          the app puts its primary action. On a phone the buttons share the row
-          in equal thirds with short labels — the full wording wrapped inside
-          the buttons and gave each a different height — and a fourth wraps to
-          the next line, exactly as Show archived already does. */}
+          the app puts its primary action, and since DESIGN_PASS §3.1 the only
+          thing in that seat. Everything else is one quiet outline (see
+          TOOLBAR_QUIET_BUTTON), grouped left at 8px. On a phone the buttons
+          share the row in equal thirds with short labels — the full wording
+          wrapped inside the buttons and gave each a different height — and a
+          fourth wraps to the next line, exactly as Show archived already
+          does. */}
       <div className="grid grid-cols-3 items-stretch gap-2 sm:flex sm:flex-wrap sm:items-center sm:justify-between">
         {/* display:contents on phones dissolves this wrapper so every button
             inside it is an equal grid cell of the row above; from sm it is the
@@ -2865,7 +3029,7 @@ export default function AccountTransactions() {
         <div className="contents sm:flex sm:items-center sm:gap-2">
         <button
           onClick={() => setShowFilters(prev => !prev)}
-          className="flex w-full sm:w-auto items-center justify-center gap-2 px-3 py-1.5 text-sm border border-gray-300 dark:border-gray-600 rounded-lg text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors"
+          className={`${TOOLBAR_QUIET_BUTTON} ${TOOLBAR_QUIET_IDLE}`}
         >
           <FilterIcon size={14} />
           <span className="sm:hidden">Filters</span>
@@ -2880,11 +3044,7 @@ export default function AccountTransactions() {
         {hasArchivedHere && (
           <button
             onClick={() => setShowArchived(prev => !prev)}
-            className={`flex items-center gap-2 px-3 py-1.5 text-sm border rounded-lg transition-colors ${
-              showArchived
-                ? 'border-[#1a2332] dark:border-blue-500 text-[#1a2332] dark:text-blue-400 bg-gray-50 dark:bg-gray-700'
-                : 'border-gray-300 dark:border-gray-600 text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700'
-            }`}
+            className={`${TOOLBAR_QUIET_BUTTON} ${showArchived ? TOOLBAR_QUIET_ACTIVE : TOOLBAR_QUIET_IDLE}`}
             title="Archived transactions are hidden from the live list but never deleted"
           >
             <EyeIcon size={14} />
@@ -2896,7 +3056,7 @@ export default function AccountTransactions() {
         <div className="relative flex" ref={viewRef}>
           <button
             onClick={() => setShowView(prev => !prev)}
-            className="flex w-full sm:w-auto items-center justify-center gap-2 px-3 py-1.5 text-sm border border-gray-300 dark:border-gray-600 rounded-lg text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors"
+            className={`${TOOLBAR_QUIET_BUTTON} ${TOOLBAR_QUIET_IDLE}`}
           >
             <EyeIcon size={14} />
             View
@@ -2998,11 +3158,7 @@ export default function AccountTransactions() {
             type="button"
             onClick={() => setReviewOnly(prev => !prev)}
             aria-pressed={reviewOnly}
-            className={`flex w-full sm:w-auto items-center justify-center gap-2 px-3 py-1.5 text-sm border rounded-lg transition-colors ${
-              reviewOnly
-                ? 'border-[#1a2332] dark:border-blue-500 text-[#1a2332] dark:text-blue-400 bg-gray-50 dark:bg-gray-700'
-                : 'border-gray-300 dark:border-gray-600 text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700'
-            }`}
+            className={`${TOOLBAR_QUIET_BUTTON} ${reviewOnly ? TOOLBAR_QUIET_ACTIVE : TOOLBAR_QUIET_IDLE}`}
             title={
               reviewOnly
                 ? 'Showing only transactions that have arrived and not been dealt with. Click to show them all again.'
@@ -3022,21 +3178,25 @@ export default function AccountTransactions() {
             </span>
           </button>
         )}
-        </div>
-        {/* The right cluster: the same `contents` trick as the left one, so on
-            a phone these two are grid cells like the rest and from sm they are
-            a pair pushed to the right edge by the container's
-            justify-between. */}
-        <div className="contents sm:flex sm:items-center sm:gap-2">
+
+        {/* Expand table sits with the other quiet controls rather than in the
+            right-hand seat: it changes what the register SHOWS, which is what
+            this whole cluster does. The right-hand seat is for the one thing
+            that changes the ledger. (DESIGN_PASS §3.1 QUIET.) */}
         <button
           onClick={() => setTableExpanded(prev => !prev)}
-          className="flex w-full sm:w-auto items-center justify-center gap-2 px-3 py-1.5 text-sm border border-gray-300 dark:border-gray-600 rounded-lg text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors"
+          className={`${TOOLBAR_QUIET_BUTTON} ${tableExpanded ? TOOLBAR_QUIET_ACTIVE : TOOLBAR_QUIET_IDLE}`}
           title={tableExpanded ? 'Shrink the table and show the add/edit bar' : 'Expand the table over the add/edit bar'}
         >
           {tableExpanded ? <MinimizeIcon size={14} /> : <MaximizeIcon size={14} />}
           <span className="sm:hidden">{tableExpanded ? 'Shrink' : 'Expand'}</span>
           <span className="hidden sm:inline">{tableExpanded ? 'Standard view' : 'Expand table'}</span>
         </button>
+        </div>
+        {/* The right cluster: the same `contents` trick as the left one, so on
+            a phone Add is a grid cell like the rest and from sm it is pushed to
+            the right edge by the container's justify-between. */}
+        <div className="contents sm:flex sm:items-center sm:gap-2">
         {/* THE FULL ADD, on this account. The dock at the foot of the page is
             deliberately six fields wide — date, type, payee, category, amount —
             and there was no way at all from this page to reach the rest of a
@@ -3051,7 +3211,7 @@ export default function AccountTransactions() {
         <button
           type="button"
           onClick={() => setShowAddTransaction(true)}
-          className="flex w-full sm:w-auto items-center justify-center gap-2 px-3 py-1.5 text-sm font-medium bg-[#1a2332] text-white rounded-lg hover:bg-[#2d3a4d] transition-colors shadow-sm"
+          className="flex w-full sm:w-auto items-center justify-center gap-2 px-3 py-1.5 text-sm font-medium bg-[#1a2332] text-white rounded hover:bg-[#2d3a4d] transition-colors duration-state"
           title={`Add a transaction to ${account.name} on the full form — notes, the whole category tree, and a transfer's other side. The bar at the foot of the register is the quick way in.`}
         >
           <PlusIcon size={14} />
@@ -3185,7 +3345,7 @@ export default function AccountTransactions() {
           // that offers neither — a report, a Find result — gets the default
           // and says nothing.
           markNewArrivals
-          formatCurrency={(n) => formatCurrency(n, account.currency)}
+          formatCurrency={formatRegisterMoney}
           onEdit={(t) => { setSelectedTransaction(t); setSelectedTransactionId(t.id); setIsEditModalOpen(true); }}
           onView={(t) => { setSelectedTransaction(t); setSelectedTransactionId(t.id); setIsEditModalOpen(true); }}
           onDelete={(id) => {
@@ -3236,7 +3396,18 @@ export default function AccountTransactions() {
         ref={tableWrapRef}
         data-transaction-table
         style={{ height: tableHeight }}
-        className="hidden lg:block overflow-hidden rounded-2xl focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2 dark:focus-visible:ring-offset-gray-900"
+        // No radius here any more: the table is the page's content, not a card
+        // sitting on it, and the corner was only ever there to clip the ring
+        // that has gone (DESIGN_PASS §3.1 QUIET). The focus ring stays — it is
+        // the one border with a meaning.
+        //
+        // A REFETCH DIMS, IT NEVER BLANKS: figures already on screen stay put
+        // at 60% while the same figures are fetched again. Blanking a register
+        // to reload it is indistinguishable, for the half-second it lasts,
+        // from losing the data (DESIGN_PASS §4).
+        className={`hidden lg:block overflow-hidden focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2 dark:focus-visible:ring-offset-gray-900 ${
+          isLoading ? 'opacity-60 transition-opacity duration-enter' : ''
+        }`}
         role="grid"
         aria-label={`${account.name} transactions`}
         // The header row counts, which is what puts the first transaction on
@@ -3280,9 +3451,25 @@ export default function AccountTransactions() {
           onColumnReorder={handleColumnReorder}
           onColumnResize={handleColumnResize}
           emptyMessage="No transactions found"
+          // Where the rows would be, when there are none: what is absent, what
+          // follows from that, and the control that fixes it — never a blank
+          // table (DESIGN_PASS §4).
+          emptyContent={registerEmptyState}
           threshold={50}
-          className="virtualized-table bg-white dark:bg-gray-800 rounded-2xl shadow-lg border-2 border-[#6B86B3] h-full"
-          headerClassName="bg-[#1a2332] dark:bg-gray-700 text-white"
+          /* ONE TREATMENT, not four. The navy fill, the blue-grey ring, the
+             drop shadow and the zebra were four ways of saying "this is a
+             table" over the top of each other, and every one of them cost
+             either contrast or a row. What is left is a hairline under a
+             label-sized header and a hairline between rows — the table reads
+             as the page's content, which is what it is (DESIGN_PASS §3.1
+             QUIET, P1/P4). */
+          surface="flat"
+          striped={false}
+          rowBorderClassName="border-b border-line-soft dark:border-gray-700"
+          className="virtualized-table bg-white dark:bg-gray-800 h-full border-0"
+          headerClassName="bg-surface-secondary dark:bg-gray-700 text-gray-600 dark:text-gray-300 border-b border-line"
+          headerCellClassName="font-medium text-label uppercase"
+          headerSortHoverClassName="hover:text-gray-900 dark:hover:text-gray-100"
           rowClassName={(row: DisplayRow) => {
             if (isOpeningBalanceRow(row)) {
               return 'bg-blue-50/60 dark:bg-blue-900/20 italic';
@@ -3472,7 +3659,7 @@ export default function AccountTransactions() {
                   onAccountChange={(accountId) => { clearQuickAddError(); setQuickAddForm({ ...quickAddForm, category: accountId }); }}
                   placeholder="Account..."
                   searchPlaceholder="Search accounts…"
-                  formatLabel={(acc) => `${acc.name} (${formatCurrency(acc.balance)})`}
+                  formatLabel={(acc) => `${acc.name} (${formatCurrency(acc.balance, acc.currency)})`}
                   size="compact"
                   usePortal
                   ariaLabel="To Account"

--- a/src/pages/Accounts.tsx
+++ b/src/pages/Accounts.tsx
@@ -7,6 +7,8 @@ import { preserveDemoParam } from '../utils/navigation';
 import AddAccountModal from '../components/AddAccountModal';
 import AccountSettingsModal from '../components/AccountSettingsModal';
 import AccountBreakdownModal, { type AccountBreakdownView } from '../components/AccountBreakdownModal';
+import NetWorthSummary from '../components/NetWorthSummary';
+import { formatDate } from '../utils/dateFormatter';
 import PortfolioView from '../components/PortfolioView';
 // No longer importing from lucide-react - all icons are now custom
 import { ArchiveIcon, SettingsIcon, WalletIcon, CheckCircleIcon, PieChartIcon, BankIcon, RefreshCwIcon, AlertTriangleIcon, ChevronRightIcon, ChevronDownIcon, XCircleIcon, SearchIcon } from '../components/icons';
@@ -788,6 +790,41 @@ export default function Accounts() {
     selectedAccountId === accountId ? ACCOUNT_ROW_SELECTED_CLASS : unselected;
 
   /**
+   * A row's ROUTINE actions, out of the way until they are wanted.
+   *
+   * Twelve outlined icon boxes on a four-account screen is a wall of chrome in
+   * front of the figures the page exists to show, and the destructive one was
+   * drawn as loudly as the routine ones (DESIGN_PASS_2026-08 §3.3). They are
+   * revealed on hover or when anything in the row takes the focus.
+   *
+   * ─ WHY NOT display:none ────────────────────────────────────────────────────
+   * A hidden button is not reachable by Tab. These stay in the DOM and in the
+   * tab order at all times, at zero opacity; tabbing to one puts the focus
+   * inside the row, which is what `group-focus-within/row` is reading, so it
+   * fades in as it is reached. Nothing is removed from anybody — it is only
+   * quiet until it is asked for.
+   *
+   * ─ WHY THE MEDIA QUERY ─────────────────────────────────────────────────────
+   * A touch screen has no hover. Gated on `hover: hover`, so where hovering is
+   * impossible the buttons never fade at all and a phone shows the row exactly
+   * as it always did. (Tailwind's own `hover:` is a plain `:hover` here —
+   * `hoverOnlyWhenSupported` is not enabled — so the query is written out.)
+   *
+   * ─ WHY ONE RULE AND NOT TWO ────────────────────────────────────────────────
+   * The obvious spelling is "hide, then reveal on hover/focus": an `opacity-0`
+   * plus `group-hover/row:opacity-100`. It was measured in the browser and it
+   * does NOT work here — the reveal is the more specific selector of the two
+   * and still loses to the hider, so a keyboard user tabbed to a control that
+   * stayed invisible. Rather than escalate a cascade fight nobody can read
+   * later, the hidden state is expressed as the only declaration: opacity is
+   * left alone (1) and zeroed ONLY while the row is neither hovered nor holding
+   * the focus. One rule, nothing to outrank, and the keyboard case falls out of
+   * it for free.
+   */
+  const ROW_ACTION_REVEAL_CLASS =
+    'transition-opacity duration-state [@media(hover:hover)]:group-[:not(:hover):not(:focus-within)]/row:opacity-0';
+
+  /**
    * "Agree this account with the bank" — the same control for every row.
    *
    * One function rather than one per row type, because a nested cash account
@@ -804,7 +841,7 @@ export default function Accounts() {
     <button
       type="button"
       onClick={() => navigate(preserveDemoParam(`/reconciliation?account=${account.id}&from=accounts`, location.search))}
-      className="p-3 min-w-[48px] min-h-[48px] flex items-center justify-center text-blue-500 hover:text-blue-700 dark:text-blue-400 dark:hover:text-blue-200 hover:bg-blue-100/50 dark:hover:bg-blue-900/30 rounded-lg transition-all duration-200 relative group backdrop-blur-sm"
+      className={`p-3 min-w-[48px] min-h-[48px] flex items-center justify-center text-gray-500 hover:text-blue-700 dark:text-gray-400 dark:hover:text-blue-300 hover:bg-blue-100/50 dark:hover:bg-blue-900/30 rounded-lg relative group ${ROW_ACTION_REVEAL_CLASS}`}
       title={`Reconcile ${account.name}`}
       aria-label={`Reconcile ${account.name}`}
     >
@@ -823,14 +860,27 @@ export default function Accounts() {
     const syncing = isAccountSyncing(account.id);
     const TypeIcon = getAccountTypeIcon(account.type);
     const typeColor = getAccountTypeColor(account.type);
+    // '' when the date is absent or unparseable — formatDate answers that way
+    // rather than throwing or handing back "Invalid Date".
+    const lastUpdated = formatDate(account.lastUpdated);
                   return (
                   <div
                     key={account.id}
                     ref={isArrivalRow(account.id) ? arrivalRowRef : undefined}
                     {...rowProps(account.id)}
-                    className={`p-3 sm:p-4 rounded-2xl border transition-all duration-300 cursor-pointer select-none focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 ${rowSkin(
+                    // `group/row` is what reveals the row's action buttons on
+                    // hover and on focus — named, because each button already
+                    // owns an unnamed `group` for its tooltip.
+                    //
+                    // A ROW, NOT A CARD, when it is not selected: no shadow and
+                    // no visible border, so the ONLY lifted thing on the page is
+                    // the selected row, which is what makes that lift read
+                    // (§3.3). The rounding stays and is simply invisible while
+                    // the row is white on white — it is there for the selected
+                    // state, whose wash and ring do show it.
+                    className={`group/row p-3 sm:p-4 rounded-2xl border border-b-line dark:border-b-gray-700 last:border-b-transparent transition-all duration-300 cursor-pointer select-none focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 ${rowSkin(
                       account.id,
-                      'bg-white dark:bg-gray-800 shadow-lg border-gray-100 dark:border-gray-700 hover:shadow-xl hover:border-gray-200'
+                      'bg-white dark:bg-gray-800 border-transparent hover:bg-surface-secondary dark:hover:bg-gray-700/40'
                     )}`}
                   >
                     <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3">
@@ -879,8 +929,23 @@ export default function Accounts() {
                             {account.institution}
                           </p>
                         )}
+                        {/* This line read "Last updated: Invalid Date" for any
+                            account whose date was absent — a raw
+                            `new Date(x).toLocaleDateString()` printing the
+                            parser's failure straight onto a page about money
+                            (§3.3). Two things were wrong with it, and both are
+                            fixed here: it never went through formatDate(), the
+                            app's own formatter, which is null-safe AND pins the
+                            UK dd/mm/yyyy this app formats every other date in
+                            (a bare toLocaleDateString takes the BROWSER's
+                            locale); and an absent date has a plain-English
+                            answer, so it gets one instead of a parser artefact.
+
+                            `Account.lastUpdated` is typed as a required Date but
+                            is not one at runtime on every path — see the note in
+                            utils/demoData, where the field was simply missing. */}
                         <p className="text-xs text-gray-500 dark:text-gray-300">
-                          Last updated: {new Date(account.lastUpdated).toLocaleDateString()}
+                          {lastUpdated ? `Last updated: ${lastUpdated}` : 'Not yet synced'}
                         </p>
                         {bankLink && (
                           <p className="text-xs text-gray-500 dark:text-gray-300">
@@ -946,7 +1011,7 @@ export default function Accounts() {
                                 {account.type === 'investment' && account.holdings && account.holdings.length > 0 && (
                                 <button
                                   onClick={() => setPortfolioAccountId(account.id)}
-                                  className="p-3 min-w-[44px] min-h-[44px] flex items-center justify-center text-purple-500 hover:text-purple-700 dark:text-purple-400 dark:hover:text-purple-200 hover:bg-purple-100/50 dark:hover:bg-purple-900/30 rounded-lg transition-all duration-200 relative group backdrop-blur-sm"
+                                  className={`p-3 min-w-[44px] min-h-[44px] flex items-center justify-center text-gray-500 hover:text-purple-700 dark:text-gray-400 dark:hover:text-purple-300 hover:bg-purple-100/50 dark:hover:bg-purple-900/30 rounded-lg relative group ${ROW_ACTION_REVEAL_CLASS}`}
                                   title="View Portfolio"
                                 >
                                   <PieChartIcon size={16} />
@@ -974,14 +1039,18 @@ export default function Accounts() {
                                     </span>
                                   </div>
                                 ) : (
-                                  <div className="relative group">
+                                  // Routine, so it fades with the rest. A sync
+                                  // in flight is not routine — it is something
+                                  // happening to this account right now, so a
+                                  // spinning icon stays visible.
+                                  <div className={`relative group ${syncing ? '' : ROW_ACTION_REVEAL_CLASS}`}>
                                     <IconButton
                                       onClick={() => void syncAccount(account.id)}
                                       icon={<RefreshCwIcon size={20} className={syncing ? 'animate-spin' : ''} />}
                                       variant="ghost"
                                       size="md"
                                       disabled={syncing}
-                                      className="text-blue-600 hover:text-blue-700 dark:text-blue-400 dark:hover:text-blue-200 hover:bg-blue-100/50 dark:hover:bg-blue-900/30 min-w-[48px] min-h-[48px]"
+                                      className="text-gray-500 hover:text-blue-700 dark:text-gray-400 dark:hover:text-blue-300 hover:bg-blue-100/50 dark:hover:bg-blue-900/30 min-w-[48px] min-h-[48px]"
                                       title="Sync bank data"
                                     />
                                     <span className="absolute bottom-full left-1/2 transform -translate-x-1/2 mb-2 px-3 py-1.5 text-xs text-white bg-gray-900/90 dark:bg-gray-700/90 backdrop-blur-sm rounded-lg opacity-0 group-hover:opacity-100 transition-all duration-200 whitespace-nowrap pointer-events-none shadow-lg border border-white/10">
@@ -991,7 +1060,7 @@ export default function Accounts() {
                                 ))}
                               </AccountRowActionSlot>
                               <AccountRowActionSlot>
-                                <div className="relative group">
+                                <div className={`relative group ${ROW_ACTION_REVEAL_CLASS}`}>
                                   <IconButton
                                     onClick={() => setSettingsAccountId(account.id)}
                                     icon={<SettingsIcon size={20} />}
@@ -1007,13 +1076,18 @@ export default function Accounts() {
                               </AccountRowActionSlot>
                               <AccountRowActionSlot>{renderReconcileButton(account)}</AccountRowActionSlot>
                               <AccountRowActionSlot>
-                                <div className="relative group">
+                                {/* Neutral until it is hovered. It is the
+                                    destructive one, and drawing it permanently
+                                    red made it the loudest thing on a row of
+                                    routine controls — the colour belongs to
+                                    the moment the pointer is actually on it. */}
+                                <div className={`relative group ${ROW_ACTION_REVEAL_CLASS}`}>
                                   <IconButton
                                     onClick={() => handleClose(account.id)}
                                     icon={<ArchiveIcon size={20} />}
                                     variant="ghost"
                                     size="md"
-                                    className="text-red-500 hover:text-red-700 dark:text-red-400 dark:hover:text-red-300 hover:bg-red-100/50 dark:hover:bg-red-900/30 min-w-[48px] min-h-[48px]"
+                                    className="text-gray-500 hover:text-expense dark:text-gray-400 dark:hover:text-red-300 hover:bg-red-100/50 dark:hover:bg-red-900/30 min-w-[48px] min-h-[48px]"
                                     title={`Close ${account.name}`}
                                   />
                                   <span className="absolute bottom-full right-0 mb-2 px-3 py-1.5 text-xs text-white bg-gray-900/90 dark:bg-gray-700/90 backdrop-blur-sm rounded-lg opacity-0 group-hover:opacity-100 transition-all duration-200 whitespace-nowrap pointer-events-none shadow-lg border border-white/10">
@@ -1052,7 +1126,7 @@ export default function Accounts() {
                           key={child.id}
                           ref={isArrivalRow(child.id) ? arrivalRowRef : undefined}
                           {...rowProps(child.id)}
-                          className={`mt-3 ml-6 sm:ml-9 flex flex-col sm:flex-row sm:items-center sm:justify-between gap-2 sm:gap-3 rounded-xl border border-dashed pl-3 pr-3 sm:pr-0 py-2.5 cursor-pointer select-none transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 ${rowSkin(
+                          className={`group/row mt-3 ml-6 sm:ml-9 flex flex-col sm:flex-row sm:items-center sm:justify-between gap-2 sm:gap-3 rounded-xl border border-dashed pl-3 pr-3 sm:pr-0 py-2.5 cursor-pointer select-none transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 ${rowSkin(
                             child.id,
                             'border-gray-300 dark:border-gray-500 bg-gray-100 dark:bg-gray-700/60 hover:border-gray-400 dark:hover:border-gray-400'
                           )}`}
@@ -1150,13 +1224,21 @@ export default function Accounts() {
     const regionId = groupRegionId(group.kind, group.label);
 
     return (
-      <div key={`${group.kind}:${group.label}`} className="bg-white dark:bg-gray-800 rounded-xl shadow-sm border border-gray-100 dark:border-gray-700 overflow-hidden">
+      // NOT A CARD. This used to be a white bordered, shadowed box containing a
+      // grey band containing white rows — three nested containers to say one
+      // thing (DESIGN_PASS_2026-08 §3.3). Per P4 a group is separated by WEIGHT
+      // and SPACE before it is separated by a box: the heading is a quiet caps
+      // label on #f8f9fb with the band's total opposite it, the rows sit
+      // directly on white below, and the 24px between one band and the next is
+      // the `gap-6` of the grid this returns into. One border and one shadow
+      // fewer per group.
+      <div key={`${group.kind}:${group.label}`}>
         <button
           type="button"
           onClick={() => toggleGroupCollapsed(collapseKeyFor(group.kind, group.label))}
           aria-expanded={isExpanded}
           aria-controls={regionId}
-          className="w-full bg-gray-100 dark:bg-gray-700/70 border-b border-gray-300 dark:border-gray-500 px-4 sm:px-6 py-3 sm:py-4 text-left hover:bg-gray-200/70 dark:hover:bg-gray-700 transition-colors"
+          className="w-full bg-surface-secondary dark:bg-gray-700/50 border-b border-line dark:border-gray-700 px-4 sm:px-6 py-2.5 text-left transition-colors duration-state hover:bg-surface-tertiary dark:hover:bg-gray-700"
         >
           <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-2">
             <div className="flex items-center gap-2 md:gap-3">
@@ -1165,19 +1247,23 @@ export default function Accounts() {
                 className={`flex-shrink-0 text-gray-400 transition-transform duration-200 ${isExpanded ? 'rotate-90' : ''}`}
               />
               {bandHeadingIcon(group)}
-              <h2 className="text-base md:text-lg font-semibold text-gray-900 dark:text-white">{group.title}</h2>
-              <span className="text-xs md:text-sm text-gray-500 dark:text-gray-400">
+              {/* Caps label, not a heading-sized title: the band's name is a
+                  label for the figure beside it, and the figure is the thing
+                  worth reading (P1). Still an h2 — the outline, and the way a
+                  screen-reader user walks this page, are unchanged. */}
+              <h2 className="text-label uppercase font-semibold text-gray-600 dark:text-gray-300">{group.title}</h2>
+              <span className="text-dense text-gray-400 dark:text-gray-500">
                 ({group.accounts.length} {group.accounts.length === 1 ? 'account' : 'accounts'})
               </span>
             </div>
-            <p className="text-base md:text-lg font-semibold text-gray-900 dark:text-white">
+            <p className="text-card font-semibold text-primary dark:text-white">
               {formatDisplayCurrency(totalForBand(group.accounts))}
             </p>
           </div>
         </button>
 
         {isExpanded && (
-          <div id={regionId} className="p-3 sm:p-4 space-y-3">
+          <div id={regionId} className="bg-white dark:bg-gray-800">
             {subBands
               ? subBands.map(sub => {
                   // Count and total describe the WHOLE sub-band, as the section
@@ -1192,16 +1278,17 @@ export default function Accounts() {
                       key={sub.label}
                       role="group"
                       aria-label={`${sub.title}, ${countLabel}, total ${subTotal}`}
-                      className="space-y-3"
                     >
-                      <div className="flex items-center justify-between gap-2 rounded-lg bg-gray-50 dark:bg-gray-700/40 border border-gray-100 dark:border-gray-700 px-3 py-1.5">
-                        <p className="text-xs font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-400 truncate">
+                      {/* The same treatment as the band above it, one step
+                          quieter: a line, not a pill with a border of its own. */}
+                      <div className="flex items-center justify-between gap-2 border-b border-line dark:border-gray-700 bg-surface-secondary/60 dark:bg-gray-700/30 px-4 sm:px-6 py-1.5">
+                        <p className="text-label uppercase font-semibold text-gray-500 dark:text-gray-400 truncate">
                           {sub.title}
                           <span className="ml-2 font-normal normal-case tracking-normal text-gray-400 dark:text-gray-500">
                             ({countLabel})
                           </span>
                         </p>
-                        <p className="shrink-0 text-xs font-semibold tabular-nums text-gray-600 dark:text-gray-300">
+                        <p className="shrink-0 text-dense font-semibold text-gray-600 dark:text-gray-300">
                           {subTotal}
                         </p>
                       </div>
@@ -1301,39 +1388,27 @@ export default function Accounts() {
           })
           .reduce((sum, a) => sum + Math.abs(computeAccountBalance(a.id)), 0);
 
-        // One column on a phone: these are eight-digit figures at text-2xl,
-        // and a grid cell will not shrink below an unbreakable number — three
-        // abreast forced the whole page to scroll sideways at 375px.
-        // Each figure drills into the accounts behind it.
+        // ONE card, three columns, hairline dividers — not a navy slab and two
+        // white cards, which read as one important thing and two afterthoughts
+        // when it is one figure and the two halves it is made of
+        // (DESIGN_PASS_2026-08 §3.3). The same component draws the Dashboard's,
+        // so the two surfaces cannot disagree about what net worth looks like.
+        //
+        // All three are formatted WITHOUT an account currency, i.e. in the
+        // display currency: a total over accounts that need not share a
+        // currency belongs to none of them in particular. The rows below keep
+        // showing each account's own — which is what settles the mismatch the
+        // two rows of cards used to have between them.
+        //
+        // Each figure still drills into the accounts behind it.
         return (
-          <div className="grid grid-cols-1 sm:grid-cols-3 gap-3 sm:gap-4 mb-6">
-            <button
-              type="button"
-              onClick={() => setBreakdownView('net')}
-              className="flex flex-col items-start bg-[#1a2332] dark:bg-gray-700 rounded-xl p-4 text-white text-left hover:bg-[#2d3a4d] dark:hover:bg-gray-600 transition-colors"
-              title="See the accounts behind this figure"
-            >
-              <p className="text-xs text-white/60 uppercase tracking-wider font-medium">Net Worth</p>
-              <p className="text-2xl font-bold mt-1">{formatDisplayCurrency(totalBalance)}</p>
-            </button>
-            <button
-              type="button"
-              onClick={() => setBreakdownView('assets')}
-              className="flex flex-col items-start bg-white dark:bg-gray-800 rounded-xl p-4 border border-gray-100 dark:border-gray-700 text-left hover:border-gray-300 dark:hover:border-gray-500 hover:shadow-md transition-all"
-              title="See the accounts behind this figure"
-            >
-              <p className="text-xs text-gray-500 uppercase tracking-wider font-medium">Assets</p>
-              <p className="text-2xl font-bold mt-1 text-green-600 dark:text-green-400">{formatDisplayCurrency(totalAssets)}</p>
-            </button>
-            <button
-              type="button"
-              onClick={() => setBreakdownView('liabilities')}
-              className="flex flex-col items-start bg-white dark:bg-gray-800 rounded-xl p-4 border border-gray-100 dark:border-gray-700 text-left hover:border-gray-300 dark:hover:border-gray-500 hover:shadow-md transition-all"
-              title="See the accounts behind this figure"
-            >
-              <p className="text-xs text-gray-500 uppercase tracking-wider font-medium">Liabilities</p>
-              <p className="text-2xl font-bold mt-1 text-red-600">{formatDisplayCurrency(totalLiabilities)}</p>
-            </button>
+          <div className="mb-6">
+            <NetWorthSummary
+              netWorth={formatDisplayCurrency(totalBalance)}
+              assets={formatDisplayCurrency(totalAssets)}
+              liabilities={formatDisplayCurrency(totalLiabilities)}
+              onSelect={figure => setBreakdownView(figure)}
+            />
           </div>
         );
       })()}
@@ -1504,8 +1579,9 @@ export default function Accounts() {
             <SkeletonCard className="h-48" />
           </>
         ) : displayedList.mode === 'flat' ? (
-          /* Both switches off: one list, no band chrome at all. */
-          <div className="space-y-3">
+          /* Both switches off: one list, no band chrome at all — the rows on
+             white, separated by the same hairline the banded views use. */
+          <div className="bg-white dark:bg-gray-800">
             {displayedList.accounts.map(renderAccountCard)}
           </div>
         ) : (

--- a/src/pages/ReportsHub.tsx
+++ b/src/pages/ReportsHub.tsx
@@ -1,9 +1,9 @@
 import React, { Suspense, useEffect, useMemo, useState } from 'react';
 import { Link, Navigate, useLocation, useNavigate, useParams } from 'react-router-dom';
-import { ArrowLeftIcon, CalendarIcon } from '../components/icons';
+import { ArrowLeftIcon } from '../components/icons';
 import PageTip from '../components/PageTip';
 import PageWrapper from '../components/PageWrapper';
-import PeriodPicker from '../components/PeriodPicker';
+import PeriodBar from '../components/PeriodBar';
 import { SkeletonCard } from '../components/loading/Skeleton';
 import { usePeriod, type PeriodKey } from '../hooks/usePeriod';
 import { preserveDemoParam } from '../utils/navigation';
@@ -141,15 +141,13 @@ export default function ReportsHub(): React.JSX.Element {
         }
         contentClassName="space-y-6"
       >
+        {/* Named for a screen reader even though it is the only period control
+            on the page: out of the header it is no longer read straight after
+            the report's title, so it has to say what it governs on its own.
+
+            No card around it any more — see components/PeriodBar. */}
         {(report?.usesPeriod ?? true) && (
-          <div className="bg-white dark:bg-gray-800 rounded-2xl shadow-lg border border-gray-100 dark:border-gray-700 p-4 flex items-center gap-2">
-            <CalendarIcon className="text-gray-500 flex-shrink-0" size={18} />
-            {/* Named for a screen reader even though it is the only period
-                control on the page: out of the header it is no longer read
-                straight after the report's title, so it has to say what it
-                governs on its own. */}
-            <PeriodPicker picker={picker} label="Reporting period" />
-          </div>
+          <PeriodBar picker={picker} label="Reporting period" />
         )}
 
         {ReportView ? (
@@ -160,13 +158,17 @@ export default function ReportsHub(): React.JSX.Element {
           <ReportGallery />
         )}
 
-        {/* One tip per page is the pattern, so the gallery's tip also carries the
-            rule people otherwise read as missing money. id bumped from
-            `reports-gallery` because that second half is new. */}
+        {/* What this tip used to carry in its second half — that uncategorised
+            rows are left out of the totals — is no longer here. A rule that
+            decides whether the figures are the whole story cannot live behind a
+            dismiss button, so it is now a permanent line under the Spending
+            heading in the gallery (§3.5). The id is deliberately NOT bumped:
+            this content is a strict subset of what it already said, so anyone
+            who dismissed it has read all of it. */}
         <PageTip
           id="reports-gallery-2"
-          title="Reports, and what they leave out"
-          description="Pick a report — net worth, balances, spending by category or payee, period comparisons — and the period you choose follows you from one to the next. A transaction with no category is left out of income and expense totals altogether, so nothing is counted under the wrong heading; the amber band on each report lists those rows for filing."
+          title="The period follows you"
+          description="Pick a report — net worth, balances, spending by category or payee, period comparisons — and the period you choose follows you from one to the next."
         />
       </PageWrapper>
     </>

--- a/src/pages/__tests__/AccountTransactions.addTransaction.test.tsx
+++ b/src/pages/__tests__/AccountTransactions.addTransaction.test.tsx
@@ -21,8 +21,9 @@ import type { Account, Category, Transaction } from '../../types';
  * editor the Transactions page opens, opened on THIS account.
  *
  * So the four things asserted here are the four things that make it that:
- *   1. it sits in the rightmost seat of the toolbar, with Expand table beside
- *      it — the seat every other page in the app gives its primary action;
+ *   1. it sits in the rightmost seat of the toolbar, on its own — the seat
+ *      every other page in the app gives its primary action, and since
+ *      DESIGN_PASS §3.1 the only button in it;
  *   2. it opens the app's one full add editor, already pointed at this account
  *      (the prefill: drop it and tests 2 and 3 both go red);
  *   3. what it saves is in the register a moment later, without a reload;
@@ -198,12 +199,20 @@ afterEach(() => {
 });
 
 describe('Account register — the toolbar has an Add', () => {
-  it('puts it in the rightmost seat, with Expand table beside it', async () => {
+  it('puts it in the rightmost seat, alone, with the quiet controls grouped left', async () => {
     await openRegister();
 
-    // Beside it, and to its LEFT: Expand table is the element immediately
-    // before Add, in the same cluster.
-    expect(addButton().previousElementSibling).toBe(expandButton());
+    // Expand table has moved in with the other controls that change what the
+    // register SHOWS: per DESIGN_PASS §3.1 the quiet outlines are grouped
+    // left, and the right-hand seat belongs to the one control that changes
+    // the ledger. So Add now stands alone in its cluster…
+    expect(addButton().previousElementSibling).toBeNull();
+    expect(expandButton().parentElement).not.toBe(addButton().parentElement);
+    // …and the register still offers exactly one Expand table, beside Search &
+    // filters rather than beside Add.
+    expect(expandButton().parentElement).toBe(
+      screen.getByRole('button', { name: /Search & filters/ }).parentElement
+    );
 
     // Nothing to the right of it: Add ends its cluster, and that cluster ends
     // the toolbar row.

--- a/src/pages/__tests__/AccountTransactions.registerChrome.test.tsx
+++ b/src/pages/__tests__/AccountTransactions.registerChrome.test.tsx
@@ -1,0 +1,245 @@
+import React from 'react';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { render, screen, fireEvent, within } from '@testing-library/react';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { PreferencesProvider } from '../../contexts/PreferencesContext';
+import { ToastProvider } from '../../contexts/ToastContext';
+import { NotificationProvider } from '../../contexts/NotificationContext';
+import { __setAppContextValue, __resetAppContextValue } from '../../test/mocks/AppContextSupabase';
+import { DataService } from '../../services/api/dataService';
+import AccountTransactions from '../AccountTransactions';
+import type { Account, Transaction } from '../../types';
+
+/**
+ * What the register LOOKS like — the four claims of DESIGN_PASS §3.1 and the
+ * two empty states of §4, each pinned where it is actually visible.
+ *
+ * These are structural, not cosmetic. Every one of them is a claim about
+ * meaning that a later "tidy-up" could quietly reverse:
+ *
+ *   · the C/R column has a baseline, so C and R read as CHANGE;
+ *   · the table prints ONE currency, so the column can be added up;
+ *   · Balance outweighs Payment/Deposit, so the line people track is findable;
+ *   · a register emptied BY A FILTER says so, with the count and the filter,
+ *     rather than looking like a register that lost its transactions.
+ *
+ * The account is deliberately in USD while the app's display currency is its
+ * GBP default: that is the exact condition under which the old code printed a
+ * £ total over $ rows, and a test in GBP would have passed throughout.
+ *
+ * Every name, date and figure here is invented: this repo is public.
+ */
+
+const ACCOUNT: Account = {
+  id: 'acc-chrome', name: 'Synthetic Chrome', type: 'current', balance: 0,
+  currency: 'USD', lastUpdated: new Date('2026-01-01'), openingBalance: 100, isActive: true,
+};
+
+const row = (over: Partial<Transaction> & Pick<Transaction, 'id' | 'date' | 'description'>): Transaction => ({
+  amount: -10,
+  type: 'expense',
+  accountId: ACCOUNT.id,
+  category: '',
+  cleared: false,
+  ...over,
+});
+
+const ROWS: Transaction[] = [
+  row({ id: 'r-unmarked', date: new Date(Date.UTC(2024, 0, 9)), description: 'Halberd Ironmongers', amount: -40 }),
+  // A mark made while balancing and NOT yet finalised. Both flags are stated
+  // on purpose: reconciled left undefined falls back to `cleared`, which is
+  // the register's existing three-valued rule (transactionReconciliation), and
+  // would make this row an R.
+  row({
+    id: 'r-cleared', date: new Date(Date.UTC(2024, 0, 15)), description: 'Wexford Bakery',
+    amount: -25, cleared: true, reconciled: false,
+  }),
+  row({
+    id: 'r-reconciled', date: new Date(Date.UTC(2024, 0, 21)), description: 'Marlow Deposit',
+    amount: 300, type: 'income', cleared: true, reconciled: true,
+  }),
+];
+
+const renderRegister = (transactions: Transaction[] = ROWS): void => {
+  __setAppContextValue({
+    accounts: [ACCOUNT],
+    transactions,
+    categories: [],
+    isLoading: false,
+    getSubCategories: () => [],
+    getDetailCategories: () => [],
+  });
+  render(
+    <MemoryRouter initialEntries={[`/accounts/${ACCOUNT.id}`]}>
+      <PreferencesProvider>
+        <ToastProvider>
+          <NotificationProvider>
+            <Routes>
+              <Route path="/accounts" element={<div>Accounts page</div>} />
+              <Route path="/accounts/:accountId" element={<AccountTransactions />} />
+            </Routes>
+          </NotificationProvider>
+        </ToastProvider>
+      </PreferencesProvider>
+    </MemoryRouter>
+  );
+};
+
+const grid = (): HTMLElement => screen.getByRole('grid', { name: 'Synthetic Chrome transactions' });
+
+/** Which cell of a row holds the named column, read off the header itself. */
+const columnIndex = (header: string): number => {
+  const headers = Array.from(grid().querySelectorAll('[role="columnheader"]'));
+  const index = headers.findIndex(cell => (cell.textContent ?? '').trim().startsWith(header));
+  if (index === -1) throw new Error(`the register has no ${header} column`);
+  return index;
+};
+
+const dataRows = (): HTMLElement[] =>
+  Array.from(grid().querySelectorAll<HTMLElement>('[role="row"][id]'))
+    .filter(el => !el.id.endsWith('-row-opening-balance'));
+
+const cellOf = (description: string, column: string): HTMLElement => {
+  const rowEl = dataRows().find(el => (el.textContent ?? '').includes(description));
+  if (!rowEl) throw new Error(`no row for ${description}`);
+  const cell = rowEl.querySelectorAll<HTMLElement>('[role="gridcell"]')[columnIndex(column)];
+  if (!cell) throw new Error(`no ${column} cell on ${description}`);
+  return cell;
+};
+
+beforeEach(() => {
+  localStorage.clear();
+  vi.spyOn(DataService, 'listClosedAccounts').mockResolvedValue([]);
+});
+
+afterEach(() => {
+  __resetAppContextValue();
+  // NOT restoreAllMocks: the shared setup file installs the window.matchMedia
+  // every haptics-aware component reads, and restoring it takes that with it.
+  vi.clearAllMocks();
+});
+
+describe('the register’s C/R column has a baseline', () => {
+  it('gives an unmarked row a dimmed dot rather than an empty gutter', async () => {
+    renderRegister();
+    await screen.findByRole('heading', { level: 1, name: 'Synthetic Chrome' });
+
+    const unmarked = cellOf('Halberd Ironmongers', 'C/R');
+    expect(unmarked).toHaveTextContent('·');
+    // Not a letter, and not mistakable for one.
+    expect(within(unmarked).queryByTitle('Reconciled')).not.toBeInTheDocument();
+  });
+
+  it('says nothing to a screen reader, which is told by the absence of C and R', async () => {
+    renderRegister();
+    await screen.findByRole('heading', { level: 1, name: 'Synthetic Chrome' });
+
+    const dot = cellOf('Halberd Ironmongers', 'C/R').querySelector('span');
+    expect(dot).toHaveAttribute('aria-hidden', 'true');
+  });
+
+  it('still marks C and R, which is what the dot exists to be a change FROM', async () => {
+    renderRegister();
+    await screen.findByRole('heading', { level: 1, name: 'Synthetic Chrome' });
+
+    expect(cellOf('Wexford Bakery', 'C/R')).toHaveTextContent('C');
+    expect(cellOf('Wexford Bakery', 'C/R')).not.toHaveTextContent('·');
+    expect(cellOf('Marlow Deposit', 'C/R')).toHaveTextContent('R');
+    expect(cellOf('Marlow Deposit', 'C/R')).not.toHaveTextContent('·');
+  });
+});
+
+describe('the register prints one currency', () => {
+  it('gives the header total and every row the ACCOUNT’s currency, not the display default', async () => {
+    renderRegister();
+    await screen.findByRole('heading', { level: 1, name: 'Synthetic Chrome' });
+
+    // The account is USD; the app's display currency is the GBP default. Every
+    // figure the register prints about this account must be in dollars, or the
+    // Balance column is not a column of anything.
+    const headerTotal = screen.getByText('Account Balance').parentElement;
+    expect(headerTotal?.textContent).toContain('$');
+    expect(headerTotal?.textContent).not.toContain('£');
+
+    for (const description of ['Halberd Ironmongers', 'Wexford Bakery', 'Marlow Deposit']) {
+      expect(cellOf(description, 'Balance').textContent).toContain('$');
+      expect(cellOf(description, 'Balance').textContent).not.toContain('£');
+    }
+    expect(cellOf('Halberd Ironmongers', 'Payment').textContent).toContain('$');
+    expect(cellOf('Marlow Deposit', 'Deposit').textContent).toContain('$');
+  });
+});
+
+describe('the register’s weights say which column is the line', () => {
+  it('carries the running Balance at 500 and Payment/Deposit at 400', async () => {
+    renderRegister();
+    await screen.findByRole('heading', { level: 1, name: 'Synthetic Chrome' });
+
+    const balance = cellOf('Halberd Ironmongers', 'Balance').querySelector('[data-testid="register-balance"]');
+    expect(balance).toHaveClass('font-medium');
+
+    // Colour still says direction; weight is what Balance has and these do not.
+    expect(cellOf('Halberd Ironmongers', 'Payment').querySelector('span')).toHaveClass('font-normal');
+    expect(cellOf('Marlow Deposit', 'Deposit').querySelector('span')).toHaveClass('font-normal');
+  });
+
+  it('draws no zebra: the hairline separates the rows, not a second background', async () => {
+    renderRegister();
+    await screen.findByRole('heading', { level: 1, name: 'Synthetic Chrome' });
+
+    for (const rowEl of dataRows()) {
+      expect(rowEl.className).not.toContain('bg-gray-100');
+    }
+  });
+});
+
+describe('a register with nothing in it', () => {
+  it('says what is absent, what follows from it, and offers both ways in', async () => {
+    renderRegister([]);
+    await screen.findByRole('heading', { level: 1, name: 'Synthetic Chrome' });
+
+    expect(screen.getByRole('heading', { level: 3, name: 'No transactions in this account yet' })).toBeInTheDocument();
+    // The consequence, in the account's own currency.
+    expect(screen.getByText(/Its balance stays at \$100\.00/)).toBeInTheDocument();
+    expect(screen.getByText(/adds nothing to your reports/)).toBeInTheDocument();
+    // Remedies as real controls, not directions to find one — and IN THE
+    // TABLE, where the rows are missing, rather than only in the toolbar the
+    // user has just failed to notice.
+    expect(within(grid()).getByRole('button', { name: 'Add transaction' })).toBeInTheDocument();
+    expect(within(grid()).getByRole('button', { name: 'Import a statement' })).toBeInTheDocument();
+  });
+});
+
+describe('a register emptied by a filter is not an empty register', () => {
+  const searchFor = (term: string): void => {
+    fireEvent.click(screen.getByRole('button', { name: /Search & filters/ }));
+    fireEvent.change(screen.getByPlaceholderText('Search by description, amount, category...'), {
+      target: { value: term }
+    });
+  };
+
+  it('names how many are hidden and which filter is hiding them', async () => {
+    renderRegister();
+    await screen.findByRole('heading', { level: 1, name: 'Synthetic Chrome' });
+
+    searchFor('Quenchless');
+
+    expect(screen.getByRole('heading', { level: 3, name: 'No transactions match these filters' })).toBeInTheDocument();
+    // THE COUNT IS THE POINT: it is the sentence that says the rows still exist.
+    expect(screen.getByText('3')).toBeInTheDocument();
+    expect(screen.getByText('Search: Quenchless')).toBeInTheDocument();
+  });
+
+  it('offers one control that gives them back, and it gives them back', async () => {
+    renderRegister();
+    await screen.findByRole('heading', { level: 1, name: 'Synthetic Chrome' });
+
+    searchFor('Quenchless');
+    expect(dataRows()).toHaveLength(0);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Clear filters' }));
+
+    expect(dataRows()).toHaveLength(3);
+    expect(screen.queryByRole('heading', { name: 'No transactions match these filters' })).not.toBeInTheDocument();
+  });
+});

--- a/src/pages/__tests__/AccountTransactions.test.tsx
+++ b/src/pages/__tests__/AccountTransactions.test.tsx
@@ -165,22 +165,27 @@ describe('Account register — open, closed, and gone', () => {
 
     renderRegister('/accounts/acc-closed');
 
-    // In flight: no verdict either way.
-    expect(await screen.findByText('Loading account…')).toBeInTheDocument();
+    // In flight: no verdict either way. The wait is now the register's own
+    // skeleton rather than a spinner with a caption — and it is deliberately
+    // not there for the first 200ms, so this waits for it (DESIGN_PASS §4,
+    // useDelayedFlag). What matters to this test is unchanged: while the
+    // question is open, neither answer is on screen.
+    expect(screen.queryByText('This account no longer exists')).not.toBeInTheDocument();
+    expect(await screen.findByRole('status', { name: 'Loading transactions' })).toBeInTheDocument();
     expect(screen.queryByText('This account no longer exists')).not.toBeInTheDocument();
     expect(screen.queryByRole('button', { name: 'Re-open and view' })).not.toBeInTheDocument();
 
     release([CLOSED_ACCOUNT]);
 
     expect(await screen.findByRole('heading', { level: 1, name: 'Retired Savings' })).toBeInTheDocument();
-    expect(screen.queryByText('Loading account…')).not.toBeInTheDocument();
+    expect(screen.queryByRole('status', { name: 'Loading transactions' })).not.toBeInTheDocument();
   });
 
   it('waits while the open list is still arriving', async () => {
     __setAppContextValue({ accounts: [], isLoading: true });
     renderRegister('/accounts/acc-open');
 
-    expect(await screen.findByText('Loading account…')).toBeInTheDocument();
+    expect(await screen.findByRole('status', { name: 'Loading transactions' })).toBeInTheDocument();
     // Nothing is decided yet, so nothing is asked of the server either.
     expect(DataService.listClosedAccounts).not.toHaveBeenCalled();
   });

--- a/src/pages/__tests__/ReportsHub.anatomy.test.tsx
+++ b/src/pages/__tests__/ReportsHub.anatomy.test.tsx
@@ -150,15 +150,20 @@ describe('the Reports heading is the app’s heading', () => {
   });
 });
 
-describe('the period control is a control, in a box of its own', () => {
-  it('sits below the heading, in a card, and still governs the report', () => {
+describe('the period control is a control, directly under the heading', () => {
+  it('sits below the heading with no card around it, and still governs the report', () => {
     renderHub('/reports');
 
     const group = screen.getByRole('group', { name: 'Reporting period' });
-    // A content card, like everything else stacked under a page heading.
-    const card = group.closest('.rounded-2xl');
-    expect(card).not.toBeNull();
-    expect(card?.className).toContain('bg-white');
+
+    // It used to be wrapped in a full-width white card: about 90px of chrome
+    // around a 36px control, which is decoration charged against the reports
+    // below it (DESIGN_PASS_2026-08 §3.5, P1). The pills sit directly under the
+    // heading now — the POSITION is what says this governs the page, and a box
+    // around it added nothing to that. The Dashboard borrows the same bar, so
+    // this assertion is what keeps the card from creeping back on either page.
+    expect(group.closest('.rounded-2xl')).toBeNull();
+    expect(group.closest('.bg-white')).toBeNull();
 
     // Below the heading, not beside it inside the header.
     const heading = screen.getByRole('heading', { level: 1, name: 'Reports' });

--- a/src/pages/reports/ReportGallery.tsx
+++ b/src/pages/reports/ReportGallery.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import { Link, useLocation } from 'react-router-dom';
-import { ChevronRightIcon } from '../../components/icons';
 import { preserveDemoParam } from '../../utils/navigation';
 import { REPORT_GROUPS, reportsInGroup } from './reportRegistry';
 
@@ -10,54 +9,81 @@ import { REPORT_GROUPS, reportsInGroup } from './reportRegistry';
  * Real links, not buttons — each report has its own URL, so it can be
  * bookmarked, opened in a new tab, and pinned to the Dashboard.
  */
+
+/**
+ * How many columns a section of `count` reports is laid out in.
+ *
+ * A four-item section in a 3-up grid leaves one card stranded on a row of its
+ * own, which reads as "and this one is different" about a report that is not
+ * (DESIGN_PASS_2026-08 §3.5). Four splits evenly two ways, so it takes the
+ * 2-up track; everything else keeps the 3-up it had.
+ *
+ * Whole class strings, not interpolation: Tailwind scans this file as text and
+ * only emits classes it can actually see written down.
+ */
+const gridColumnsClass = (count: number): string =>
+  count === 4
+    ? 'md:grid-cols-2'
+    : 'md:grid-cols-2 xl:grid-cols-3';
+
 export default function ReportGallery(): React.JSX.Element {
   const location = useLocation();
 
   return (
     <div className="space-y-8">
-      {REPORT_GROUPS.map(group => (
-        <section key={group.id} aria-labelledby={`report-group-${group.id}`}>
-          <div className="mb-3">
-            <h2
-              id={`report-group-${group.id}`}
-              className="text-lg font-semibold text-gray-900 dark:text-white"
-            >
-              {group.title}
-            </h2>
-            <p className="text-sm text-gray-500 dark:text-gray-400">{group.description}</p>
-          </div>
+      {REPORT_GROUPS.map(group => {
+        const reports = reportsInGroup(group.id);
+        return (
+          <section key={group.id} aria-labelledby={`report-group-${group.id}`}>
+            <div className="mb-3">
+              <h2
+                id={`report-group-${group.id}`}
+                className="text-card font-semibold text-gray-900 dark:text-white"
+              >
+                {group.title}
+              </h2>
+              <p className="text-body text-gray-500 dark:text-gray-400">{group.description}</p>
+              {/* Permanent, not dismissible, and deliberately quiet: it is a
+                  caveat on every figure below it, not a warning about any one
+                  of them. */}
+              {group.note && (
+                <p className="mt-1 text-dense text-gray-500 dark:text-gray-400">{group.note}</p>
+              )}
+            </div>
 
-          <ul className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-4">
-            {reportsInGroup(group.id).map(report => {
-              const Icon = report.icon;
-              return (
-                <li key={report.id}>
-                  <Link
-                    to={preserveDemoParam(`/reports/${report.id}`, location.search)}
-                    className="group h-full flex items-start gap-3 bg-white dark:bg-gray-800 rounded-2xl shadow-sm border border-gray-100 dark:border-gray-700 p-5 hover:border-[#1a2332] dark:hover:border-blue-500 hover:shadow-md transition-all focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
-                  >
-                    <span className="mt-0.5 flex-shrink-0 rounded-lg bg-gray-100 dark:bg-gray-700 p-2 text-gray-600 dark:text-gray-300">
-                      <Icon size={20} />
-                    </span>
-                    <span className="min-w-0 flex-1">
-                      <span className="block text-sm font-semibold text-gray-900 dark:text-white group-hover:text-[#1a2332] dark:group-hover:text-blue-400">
-                        {report.title}
+            <ul className={`grid grid-cols-1 ${gridColumnsClass(reports.length)} gap-4`}>
+              {reports.map(report => {
+                const Icon = report.icon;
+                return (
+                  <li key={report.id}>
+                    {/* No chevron: the whole card is the link, and an arrow
+                        announcing that is chrome charged against the words that
+                        say what the report is (P1). No tile behind the icon
+                        either — a 20px glyph does not need a box to be found. */}
+                    <Link
+                      to={preserveDemoParam(`/reports/${report.id}`, location.search)}
+                      className="group h-full flex items-start gap-3 bg-white dark:bg-gray-800 rounded-lg border border-line dark:border-gray-700 p-4 hover:border-primary dark:hover:border-blue-500 transition-colors duration-state focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
+                    >
+                      <Icon
+                        size={20}
+                        className="mt-0.5 flex-shrink-0 text-gray-500 dark:text-gray-400 group-hover:text-primary dark:group-hover:text-blue-400"
+                      />
+                      <span className="min-w-0 flex-1">
+                        <span className="block text-body font-semibold text-gray-900 dark:text-white group-hover:text-primary dark:group-hover:text-blue-400">
+                          {report.title}
+                        </span>
+                        <span className="mt-1 block text-body text-gray-500 dark:text-gray-400">
+                          {report.description}
+                        </span>
                       </span>
-                      <span className="mt-1 block text-sm text-gray-500 dark:text-gray-400">
-                        {report.description}
-                      </span>
-                    </span>
-                    <ChevronRightIcon
-                      size={16}
-                      className="mt-1 flex-shrink-0 text-gray-300 dark:text-gray-600 group-hover:text-gray-500 dark:group-hover:text-gray-400"
-                    />
-                  </Link>
-                </li>
-              );
-            })}
-          </ul>
-        </section>
-      ))}
+                    </Link>
+                  </li>
+                );
+              })}
+            </ul>
+          </section>
+        );
+      })}
     </div>
   );
 }

--- a/src/pages/reports/reportRegistry.ts
+++ b/src/pages/reports/reportRegistry.ts
@@ -30,6 +30,16 @@ export interface ReportGroup {
   id: ReportGroupId;
   title: string;
   description: string;
+  /**
+   * What these reports LEAVE OUT, stated permanently under the heading.
+   *
+   * This lived in the gallery's dismissible tip. A rule that decides whether
+   * the totals below are the whole story is not a tip — someone who dismissed
+   * it once would read every spending figure afterwards as complete, and the
+   * honesty about uncategorised rows is the thing this product is built on
+   * (DESIGN_PASS_2026-08 §3.5).
+   */
+  note?: string;
 }
 
 export const REPORT_GROUPS: ReportGroup[] = [
@@ -42,6 +52,7 @@ export const REPORT_GROUPS: ReportGroup[] = [
     id: 'spending',
     title: 'Spending',
     description: 'Where the money goes, when it goes, and who it goes to.',
+    note: 'A transaction with no category is left out of these totals, so nothing is counted under the wrong heading. Each report lists those rows for filing.',
   },
   {
     id: 'custom',

--- a/src/styles/borders.css
+++ b/src/styles/borders.css
@@ -1,90 +1,21 @@
-/* Enhanced borders and shadows for better visual definition */
-
-/* Card and container borders */
-.bg-white,
-.dark\:bg-gray-800,
-.bg-white\/70,
-.dark\:bg-gray-800\/70,
-.bg-white\/50,
-.dark\:bg-gray-800\/50 {
-  border-width: 2px !important;
-}
-
-/* Enhanced shadows for all elements */
-.shadow-sm {
-  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1), 0 1px 2px rgba(0, 0, 0, 0.06) !important;
-}
-
-.shadow {
-  box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1), 0 2px 4px rgba(0, 0, 0, 0.06) !important;
-}
-
-.shadow-md {
-  box-shadow: 0 6px 10px rgba(0, 0, 0, 0.15), 0 3px 6px rgba(0, 0, 0, 0.1) !important;
-}
-
-.shadow-lg {
-  box-shadow: 0 10px 15px rgba(0, 0, 0, 0.2), 0 4px 6px rgba(0, 0, 0, 0.1) !important;
-}
-
-.shadow-xl {
-  box-shadow: 0 20px 25px rgba(0, 0, 0, 0.25), 0 10px 10px rgba(0, 0, 0, 0.12) !important;
-}
-
-/* Dark mode shadow adjustments */
-.dark .shadow-sm {
-  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.3), 0 1px 2px rgba(0, 0, 0, 0.2) !important;
-}
-
-.dark .shadow {
-  box-shadow: 0 4px 6px rgba(0, 0, 0, 0.3), 0 2px 4px rgba(0, 0, 0, 0.2) !important;
-}
-
-.dark .shadow-md {
-  box-shadow: 0 6px 10px rgba(0, 0, 0, 0.4), 0 3px 6px rgba(0, 0, 0, 0.3) !important;
-}
-
-.dark .shadow-lg {
-  box-shadow: 0 10px 15px rgba(0, 0, 0, 0.5), 0 4px 6px rgba(0, 0, 0, 0.3) !important;
-}
-
-.dark .shadow-xl {
-  box-shadow: 0 20px 25px rgba(0, 0, 0, 0.6), 0 10px 10px rgba(0, 0, 0, 0.4) !important;
-}
-
-/* Border width enhancements */
-.border {
-  border-width: 2px !important;
-}
-
-.border-t {
-  border-top-width: 2px !important;
-}
-
-.border-b {
-  border-bottom-width: 2px !important;
-}
-
-.border-l {
-  border-left-width: 2px !important;
-}
-
-.border-r {
-  border-right-width: 2px !important;
-}
-
-/* Enhance specific components */
-.rounded-lg,
-.rounded-xl,
-.rounded-2xl {
-  box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1), 0 2px 4px rgba(0, 0, 0, 0.06);
-}
-
-.dark .rounded-lg,
-.dark .rounded-xl,
-.dark .rounded-2xl {
-  box-shadow: 0 4px 6px rgba(0, 0, 0, 0.3), 0 2px 4px rgba(0, 0, 0, 0.2);
-}
+/* Overlay shadows and a few components that genuinely float.
+ *
+ * This file used to be the opposite of what it is now: an "enhanced borders
+ * and shadows" layer that forced border-width: 2px !important onto every
+ * .border*, every white/gray-800 surface, every input and every .divide-y
+ * row, amplified every Tailwind shadow, and painted an ambient shadow onto
+ * every rounded-lg/xl/2xl and every non-circular button in the product.
+ * DESIGN_PASS_2026-08 §2.5 is one sentence and it is the whole argument
+ * against all of that: "Shadows come off; one hairline border does the work.
+ * Shadow survives in exactly two places: overlays and the floating selected
+ * row, where lift IS the meaning." A 1px hairline was literally impossible
+ * to render anywhere in the app while the forcings stood — both design-pass
+ * implementation agents hit the same wall from different surfaces.
+ *
+ * What remains below is only what §2.5 protects: overlays (modals,
+ * dropdowns, tooltips), the draggable grid items whose lift signals
+ * drag-ability, and the collapsed-sidebar reset. Everything else now renders
+ * exactly the borders and shadows its component declares. */
 
 /* Modal and dropdown shadows - only for specific components */
 .fixed.inset-0 + div {
@@ -106,23 +37,6 @@
 .dark .tooltip-shadow,
 .dark .modal-shadow {
   box-shadow: 0 10px 15px rgba(0, 0, 0, 0.5), 0 4px 6px rgba(0, 0, 0, 0.3);
-}
-
-/* Button shadows - excluding rounded-full buttons */
-button:not(.rounded-full) {
-  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
-}
-
-button:not(.rounded-full):hover {
-  box-shadow: 0 4px 6px rgba(0, 0, 0, 0.15);
-}
-
-.dark button:not(.rounded-full) {
-  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.3);
-}
-
-.dark button:not(.rounded-full):hover {
-  box-shadow: 0 4px 6px rgba(0, 0, 0, 0.4);
 }
 
 /* Circular button shadows - use drop-shadow to respect border radius */
@@ -148,18 +62,6 @@ button.rounded-full:hover {
   filter: drop-shadow(0 4px 6px rgba(0, 0, 0, 0.4));
   border: none !important;
   outline: none !important;
-}
-
-/* Input and form field borders */
-input,
-textarea,
-select {
-  border-width: 2px !important;
-}
-
-/* Table borders */
-.divide-y > * {
-  border-width: 2px !important;
 }
 
 /* Grid item shadows (for draggable components) */

--- a/src/utils/demoData.ts
+++ b/src/utils/demoData.ts
@@ -44,6 +44,17 @@ export const isDemoMode = (): boolean => {
 // bookmarked /accounts/:id links) silently pointed at an account that no
 // longer existed. Demo sessions should behave like real ones, where an
 // account keeps its identity.
+// ─ WHY EVERY ACCOUNT CARRIES BOTH `updatedAt` AND `lastUpdated` ─────────────
+// `updatedAt` is the database column's name; `lastUpdated` is the name the app's
+// own Account type uses, and it is the one the Accounts list renders. The cloud
+// mapper (services/api/accountMapping) derives one from the other, but demo
+// accounts never go through a mapper — they are written to local storage and
+// read back by dataService.readCollection, which is a bare cast with no date
+// rehydration (transactions get normalizeTransactionDates; accounts were never
+// given the equivalent). So the field was simply absent, `new Date(undefined)`
+// gave Invalid Date, and every demo account read "Last updated: Invalid Date".
+// The list no longer prints a parser artefact whatever arrives, but the missing
+// field was the thing actually producing it, so it is filled in here too.
 export const demoAccounts = [
   {
     id: 'demo-account-checking',
@@ -56,6 +67,7 @@ export const demoAccounts = [
     isActive: true,
     createdAt: new Date('2024-01-01').toISOString(),
     updatedAt: new Date().toISOString(),
+    lastUpdated: new Date().toISOString(),
   },
   {
     id: 'demo-account-savings',
@@ -68,6 +80,7 @@ export const demoAccounts = [
     isActive: true,
     createdAt: new Date('2024-01-01').toISOString(),
     updatedAt: new Date().toISOString(),
+    lastUpdated: new Date().toISOString(),
   },
   {
     id: 'demo-account-investment',
@@ -80,6 +93,7 @@ export const demoAccounts = [
     isActive: true,
     createdAt: new Date('2024-01-01').toISOString(),
     updatedAt: new Date().toISOString(),
+    lastUpdated: new Date().toISOString(),
     holdings: [
       {
         id: 'demo-holding-aapl',
@@ -166,6 +180,7 @@ export const demoAccounts = [
     isActive: true,
     createdAt: new Date('2024-01-01').toISOString(),
     updatedAt: new Date().toISOString(),
+    lastUpdated: new Date().toISOString(),
   },
 ];
 

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -55,6 +55,10 @@ export default {
         line: {
           DEFAULT: '#e2e6ed',
           strong: '#cdd4e0',
+          // The quietest of the three, for a rule REPEATED down a dense list:
+          // forty of #e2e6ed between register rows reads as a grid, which is
+          // the chrome the register is losing. (DESIGN_PASS §3.1.)
+          soft: '#eef1f6',
         },
 
         // Navigation
@@ -126,6 +130,10 @@ export default {
       },
       animation: {
         'in': 'fade-in 0.2s ease-out, zoom-in-95 0.2s ease-out, slide-in-from-bottom-4 0.2s ease-out',
+        // The ONLY animation a skeleton gets (DESIGN_PASS §4): it fades in
+        // once and then holds still. Named rather than written inline so the
+        // 200ms is the same 200ms as the delay that decides to show it.
+        'fade-in': 'fade-in 200ms ease-out',
       },
     },
   },


### PR DESCRIPTION
The remaining four batches of DESIGN_PASS_2026-08, three commits, all browser-verified together at the end.

## Commit 1 — the borders.css surgery (the capstone both agents demanded)
A legacy "enhanced borders and shadows" sheet forced 2px `!important` borders and ambient shadows onto essentially every surface — making §2.5's 1px hairline literally unrenderable anywhere. Both implementation agents hit it independently. It now keeps only what §2.5 protects (overlay shadows, draggable-grid lift, sidebar reset). Verified: register rows measure a true 1px, buttons are flat, and the floating selected row still lifts — with **its own** shadow, which is the point.

## Commit 2 — batches 3+4 (§4 + §3.1)
- Shared **empty / filtered-empty / loading** patterns: consequence-then-remedy empties; filtered-empty names the hidden count and the responsible filters ("1,284 hidden by…") with Clear filters; skeletons at real row geometry, one 200ms fade, no pulse, nothing under 200ms, refetch dims instead of blanking.
- **Register**: caps label-strip header, 1px hairlines, no ring/zebra/shadow (+1 visible row, measured honestly — the doc's ~2 doesn't survive 44px row arithmetic); Balance at 500 navy over Payment/Deposit at 400 in the semantic tokens; toolbar collapsed to quiet outlines + one primary; dimmed `·` baseline in the C/R column (aria-hidden; the structural test moves with it per the doc's authorization).
- **Two real currency bugs fixed** that the doc's audit mis-located: the quick-add transfer picker and attention banner printed other accounts' balances in the display currency. New register tests run a USD account against the GBP default — the only fixture that can see this class of bug.

## Commit 3 — batches 5+6 (§3.3 + §3.4/§3.5)
- Accounts: groups un-nested to weight+space; **one** three-column summary card (`NetWorthSummary`, shared with Dashboard so the two cannot drift); hover/focus-revealed row actions that never leave the tab order (and stay visible on touch); "Invalid Date" fixed at both real sources → "Not yet synced".
- Dashboard: **three** period pickers (one more than audited) → one `PeriodBar` under the heading, original storage key preserved; hero slab retired into the shared card; report cards directly on the page.
- Reports: pills out of their 90px card; chevrons and icon tiles dropped; four-item sections 2-up; the uncategorised-rows caveat now a permanent line under Spending. First-run copy states the product's personality.
- Test exposure exactly as the doc names it: 3 period-state tests re-pinned to one clock, 1 anatomy assertion inverted. Row-selection snapshots pass **unchanged**.

## §6 compliance
Yellow thread untouched (verified: on Reconciliation the thread remains the only amber); C/R semantics untouched (only the default glyph changed, as authorized); floating selected row verified lifting; density, keyboard editing, w-fit links, bold imported rows all untouched. The Accounts amber UNRECONCILED count remains frozen pending a Claude Design ruling.

Known and deliberately parked: the Accounts group-total £-over-$ (needs real FX conversion — next batch, already specced); Find.tsx's mirrored C/R column default glyph; wiring the new empty/loading patterns into Accounts/Dashboard/Find/phone list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)