### PR TITLE
feat(fx): cross-currency transfers — the engine learns what a boundary is, and the app asks instead of inventing

### DIFF
--- a/crates/wealth-core/src/verbs/link_transfer_pair.rs
+++ b/crates/wealth-core/src/verbs/link_transfer_pair.rs
@@ -43,6 +43,10 @@
 //! 7  transaction is already part of a linked transfer
 //! ```
 //!
+//! Refusal **5 now has two wordings** and the position is shared between them:
+//! see "Refusal 5 is currency-aware" below. Nothing moved, so every measured
+//! adjacency above still holds.
+//!
 //! Two of those are worth naming because reading the *source* rather than
 //! *running* it gets them wrong in the plausible direction:
 //!
@@ -66,6 +70,40 @@
 //! | two accounts in **different currencies** | linked. T-9 guards *minting* a counterpart (`create_transfer_counterpart`), where an amount is copied into another ledger; joining two rows that already exist moves nothing, so there is nothing to convert |
 //! | a row whose `linked_transfer_split_id` points at a split line | linked, and T-11 quietly broken — the line does not point back |
 //! | a row already **typed** `transfer` with some other `transfer_account_id` | overwritten |
+//!
+//! # Refusal 5 is currency-aware, and why that is a LOOSENING
+//!
+//! DECLARED BEHAVIOUR CHANGE, approved 2026-08-12, made in all three engines at
+//! once (this file, the linking RPC via a new migration, and the demo mirror in
+//! `src/services/api/dataService.ts`).
+//!
+//! Read the currency row of the table above beside the old refusal 5 and the two
+//! do not survive contact. "Different currencies are linked" was true only of the
+//! *currency check*, which never existed; refusal 5 then demanded the two amounts
+//! sum to zero, and two amounts in different currencies do that only at a rate of
+//! exactly 1. So the measured statement "the live RPC links them" was measured
+//! with a fixture whose two sides were ±30.00 — a pair no conversion produces.
+//! **Every arithmetically real cross-currency pair was refused, by an engine that
+//! believed it was allowing them.**
+//!
+//! What made this a defect rather than a curiosity is that the data disagreed
+//! first: the ledger this crate was written for already holds 70 legal
+//! cross-currency pairs, bulk-inserted by the MS Money importer, which writes
+//! rows directly and never calls a verb. No runtime path in either engine could
+//! have produced one of them, and none could re-link one after an unlink.
+//!
+//! So refusal 5 splits by whether the two accounts share a currency:
+//!
+//! * **same currency** — unchanged, to the penny. `are_opposite`, same message.
+//! * **different currencies** — both sides non-zero and OPPOSITE IN SIGN, with no
+//!   constraint on magnitude, because the ratio between the magnitudes *is* the
+//!   achieved rate and this engine holds no opinion about FX (see
+//!   `transfer::are_opposite_in_sign`).
+//!
+//! The counterpart MINT guard is untouched and stays a flat refusal: that verb
+//! *copies a number* into the other ledger, and copying across a currency
+//! boundary is wrong at any rate. Joining two rows that already exist copies
+//! nothing, which is the whole distinction and always was.
 //!
 //! The third is a real gap and it is recorded rather than fixed here: T-7 and
 //! T-11 are enforced *nowhere* in the cloud (DESIGN.md §1.3), and a local port
@@ -97,7 +135,7 @@ use crate::audit::{self, Action};
 use crate::db;
 use crate::error::{CoreError, CoreResult, Refusal};
 use crate::row::category::transfer_category_for;
-use crate::row::{self, TransactionRow, WrittenTransaction};
+use crate::row::{self, account, TransactionRow, WrittenTransaction};
 
 use super::transfer;
 
@@ -178,8 +216,27 @@ pub fn link_transfer_pair(
     if side_a.account_id == side_b.account_id {
         return Err(transfer::needs_two_accounts());
     }
-    if !transfer::are_opposite(side_a.amount, side_b.amount) {
-        return Err(transfer::amounts_not_opposite(side_a.amount, side_b.amount));
+    // Refusal 5, in two versions. Which one applies turns on the two ACCOUNTS,
+    // so the currencies are read here and not sooner: every earlier refusal
+    // must still fire first, and refusal 4 has just guaranteed the two account
+    // ids differ. `crossed_currencies` returns the pair only when it is a real
+    // boundary, so the branch that names them cannot be reached without them.
+    match crossed_currencies(&write, &side_a, &side_b)? {
+        Some((from, to)) => {
+            if !transfer::are_opposite_in_sign(side_a.amount, side_b.amount) {
+                return Err(transfer::amounts_not_opposite_across_currencies(
+                    side_a.amount,
+                    &from,
+                    side_b.amount,
+                    &to,
+                ));
+            }
+        }
+        None => {
+            if !transfer::are_opposite(side_a.amount, side_b.amount) {
+                return Err(transfer::amounts_not_opposite(side_a.amount, side_b.amount));
+            }
+        }
     }
     if side_a.is_split || side_b.is_split {
         return Err(transfer::split_cannot_become_transfer());
@@ -215,6 +272,44 @@ pub fn link_transfer_pair(
         audit_seq: entry.seq,
         audit_row_hash: entry.row_hash,
     })
+}
+
+/// The two accounts' currencies, but **only when they form a real boundary**:
+/// `Some((a, b))` when both are known and differ, `None` otherwise.
+///
+/// # Why a missing currency counts as "not a boundary"
+///
+/// Ported from the counterpart guard's own rule (`20260721090000:63-74`,
+/// *"NULL currencies are treated as unspecified and never block (legacy rows);
+/// the guard fires only when BOTH currencies are set and differ"*). The cloud's
+/// `accounts.currency` is nullable and legacy rows have nothing in it; the local
+/// column is `NOT NULL DEFAULT 'GBP'` (`schema.sql:443`), so locally the `None`
+/// arm is reachable only through a missing or unowned ACCOUNT ROW, not a missing
+/// value.
+///
+/// The consequence of the choice is worth being explicit about, because it is
+/// the safe direction and not the permissive one: unknown currency falls back to
+/// the STRICT rule, so a pair whose currencies cannot be established must still
+/// sum to zero. Guessing the other way would let an unreadable account admit an
+/// unbalanced pair, which is the one outcome nobody could later account for.
+///
+/// # Errors
+/// [`CoreError::Storage`] if either read fails.
+fn crossed_currencies(
+    read: &rusqlite::Transaction<'_>,
+    side_a: &TransactionRow,
+    side_b: &TransactionRow,
+) -> CoreResult<Option<(String, String)>> {
+    let Some(account_a) = account::read_owned(read, &side_a.account_id, &side_a.user_id)? else {
+        return Ok(None);
+    };
+    let Some(account_b) = account::read_owned(read, &side_b.account_id, &side_b.user_id)? else {
+        return Ok(None);
+    };
+    if account_a.currency == account_b.currency {
+        return Ok(None);
+    }
+    Ok(Some((account_a.currency, account_b.currency)))
 }
 
 /// Deliberately the same refusal for "no such row" and "somebody else's row":

--- a/crates/wealth-core/src/verbs/transfer.rs
+++ b/crates/wealth-core/src/verbs/transfer.rs
@@ -109,6 +109,72 @@ pub fn are_opposite(first: Money, second: Money) -> bool {
         .is_some_and(|negated| first.minor() == negated)
 }
 
+/// T-1 across a currency boundary: opposite in SIGN, both non-zero, and no
+/// opinion whatsoever about magnitude.
+///
+/// # Why the magnitude test is dropped rather than loosened
+///
+/// [`are_opposite`] asks the two amounts to sum to zero. Two amounts in
+/// different currencies never do, except by the coincidence of a rate that
+/// happens to be exactly 1 — so applied across a boundary it is not a strict
+/// rule, it is a rule that refuses **every** legal pair. That is the whole of
+/// the defect: the owner's ledger already holds 70 cross-currency pairs the MS
+/// Money importer bulk-inserted directly, and no runtime verb in either engine
+/// could have created a single one of them. An engine stricter than the data it
+/// guards is not enforcing an invariant, it is only failing to notice.
+///
+/// What survives is the part that was ever about money: the two sides must move
+/// in OPPOSITE DIRECTIONS. One account is down, the other is up. Two sides that
+/// both fall are not one movement seen twice, whatever the currencies.
+///
+/// What is deliberately NOT reintroduced anywhere is an opinion about the rate.
+/// The ratio between the two magnitudes IS the achieved rate — spread, fee and
+/// all — and the engine has no way to know what it should have been and no
+/// business guessing. A tolerance band here would refuse a real bank's real
+/// conversion on a volatile day. So: sign, and nothing else.
+///
+/// # Both arguments are tested for zero, unlike [`are_opposite`]
+///
+/// That function leans on `0 <> -0` being false to catch a zero second side.
+/// There is no such arithmetic here — `signum` says nothing about magnitude and
+/// `0.signum() == 0` compares unequal to both `1` and `-1`, so a zero side would
+/// slip through a bare sign comparison as "different". Spelled out instead of
+/// relied upon, because the reader should not have to derive it.
+pub fn are_opposite_in_sign(first: Money, second: Money) -> bool {
+    if first == Money::ZERO || second == Money::ZERO {
+        return false;
+    }
+    // signum, not negation: i64::MIN has no positive counterpart but it does
+    // have a sign, so this branch has nothing to check and cannot panic.
+    first.minor().signum() != second.minor().signum()
+}
+
+/// T-1's cross-currency wording — the refusal a same-sign pair earns.
+///
+/// Carries the CURRENCY beside each figure, which the same-currency message
+/// ([`amounts_not_opposite`]) has no need to: there, two bare numbers are
+/// comparable and the reader can see the rule broken. Here "−30.00 vs −38.00"
+/// with no codes invites exactly the wrong correction — the reader reaches for
+/// the magnitudes, which this rule does not care about, instead of the signs,
+/// which are the entire complaint.
+///
+/// The argument order is `(a, b)` as the caller passes them, matching the
+/// sibling message's contract.
+pub fn amounts_not_opposite_across_currencies(
+    first: Money,
+    first_currency: &str,
+    second: Money,
+    second_currency: &str,
+) -> CoreError {
+    CoreError::refuse(
+        "transfer_amounts_not_opposite_sign",
+        &format!(
+            "transfer sides in different currencies must be opposite in sign and non-zero \
+             ({first_currency} {first} vs {second_currency} {second})"
+        ),
+    )
+}
+
 /// T-5. `20260716100000:112-115` and three copies.
 pub fn split_cannot_become_transfer() -> CoreError {
     CoreError::refuse(
@@ -161,7 +227,10 @@ pub fn vanished(what: &str) -> CoreError {
 #[cfg(test)]
 #[allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
 mod tests {
-    use super::{amounts_not_opposite, are_opposite};
+    use super::{
+        amounts_not_opposite, amounts_not_opposite_across_currencies, are_opposite,
+        are_opposite_in_sign,
+    };
     use crate::money::Money;
 
     #[test]
@@ -182,6 +251,74 @@ mod tests {
         assert_eq!(
             error.to_string(),
             "transfer_amounts_not_opposite: transfer sides must have exactly opposite non-zero amounts (-30.00 vs 29.99)"
+        );
+    }
+
+    #[test]
+    fn across_a_currency_boundary_only_the_sign_is_asked_about() {
+        // The shape every real cross-currency pair has, and the shape
+        // are_opposite refuses: opposite ways, magnitudes that do not cancel.
+        assert!(are_opposite_in_sign(
+            Money::from_minor(-3000),
+            Money::from_minor(3800)
+        ));
+        assert!(are_opposite_in_sign(
+            Money::from_minor(3800),
+            Money::from_minor(-3000)
+        ));
+        // A rate of exactly 1 is not special-cased into a refusal.
+        assert!(are_opposite_in_sign(
+            Money::from_minor(-3000),
+            Money::from_minor(3000)
+        ));
+        // …and the same pair is what the strict rule accepts, so the loosened
+        // rule is a superset rather than a different rule.
+        assert!(are_opposite(Money::from_minor(-3000), Money::from_minor(3000)));
+    }
+
+    #[test]
+    fn a_same_sign_pair_is_refused_however_far_apart_the_magnitudes_are() {
+        assert!(!are_opposite_in_sign(
+            Money::from_minor(-3000),
+            Money::from_minor(-3800)
+        ));
+        assert!(!are_opposite_in_sign(
+            Money::from_minor(3000),
+            Money::from_minor(3800)
+        ));
+    }
+
+    #[test]
+    fn a_zero_side_is_refused_from_either_position() {
+        // Neither argument may lean on the other's non-zeroness: are_opposite
+        // tests only the first because its negation test catches the second,
+        // and there is no negation test here to catch anything.
+        assert!(!are_opposite_in_sign(Money::ZERO, Money::from_minor(3800)));
+        assert!(!are_opposite_in_sign(Money::from_minor(-3000), Money::ZERO));
+        assert!(!are_opposite_in_sign(Money::ZERO, Money::ZERO));
+    }
+
+    #[test]
+    fn i64_min_has_a_sign_even_though_it_has_no_negation() {
+        // are_opposite reports "not opposite" here because checked_neg fails.
+        // This rule never negates, so it answers the question actually asked.
+        assert!(are_opposite_in_sign(
+            Money::from_minor(1),
+            Money::from_minor(i64::MIN)
+        ));
+    }
+
+    #[test]
+    fn the_cross_currency_message_names_the_currency_beside_each_figure() {
+        let error = amounts_not_opposite_across_currencies(
+            Money::from_minor(-3000),
+            "USD",
+            Money::from_minor(-3800),
+            "GBP",
+        );
+        assert_eq!(
+            error.to_string(),
+            "transfer_amounts_not_opposite_sign: transfer sides in different currencies must be opposite in sign and non-zero (USD -30.00 vs GBP -38.00)"
         );
     }
 }

--- a/crates/wealth-core/tests/transfer_family.rs
+++ b/crates/wealth-core/tests/transfer_family.rs
@@ -634,6 +634,153 @@ fn a_pair_that_is_only_a_penny_apart_is_not_a_pair() {
     assert_eq!(refusal.code(), "transfer_amounts_not_opposite");
 }
 
+/// Move `PAIR_IN` into a USD account and set it to `minor`, keeping B-1 true on
+/// every account it touches.
+///
+/// The dollar account is created here rather than in `fixture()` because every
+/// other test in this file is single-currency and a second currency in the base
+/// fixture would silently change which branch of refusal 5 they all take.
+fn with_the_far_side_in_dollars(connection: &Connection, minor: i64) {
+    const DOLLARS: &str = "a0000000-0000-0000-0000-00000000000d";
+    connection
+        .execute_batch(&format!(
+            "INSERT INTO accounts (id, user_id, name, type, currency, balance_minor, initial_balance_minor)
+               VALUES ('{DOLLARS}', '{OWNER}', 'Dollars', 'checking', 'USD', 0, 0);
+             UPDATE accounts SET balance_minor = balance_minor - 3000 WHERE id = '{RAINY_DAY}';
+             UPDATE transactions SET account_id = '{DOLLARS}', amount_minor = {minor}
+               WHERE id = '{PAIR_IN}';
+             UPDATE accounts SET balance_minor = balance_minor + {minor} WHERE id = '{DOLLARS}';"
+        ))
+        .expect("a far side in another currency");
+}
+
+#[test]
+fn across_a_currency_boundary_the_two_sides_need_only_move_opposite_ways() {
+    // The DECLARED BEHAVIOUR CHANGE of 2026-08-12, through the verb rather than
+    // through the predicate — which is the half `are_opposite_in_sign`'s unit
+    // tests cannot reach, because getting the currencies IN FRONT OF the
+    // predicate is the actual work and a unit test assumes it done.
+    //
+    // MEASURED: with the currency branch removed from the verb (`match None`),
+    // this test fails and the three differential specs fail with it. Without
+    // this test, `cargo test` passed that break in full.
+    let mut connection = fixture();
+    with_pairable_rows(&connection);
+    // −30.00 GBP out against +38.00 USD in: a rate no strict rule admits.
+    with_the_far_side_in_dollars(&connection, 3800);
+
+    let linked = link_transfer_pair(
+        &mut connection,
+        LinkTransferPair {
+            id_a: PAIR_OUT.into(),
+            id_b: PAIR_IN.into(),
+            user_id: Some(OWNER.into()),
+        },
+    )
+    .expect("a real conversion is a real transfer");
+
+    assert_eq!(linked.transaction.kind, "transfer");
+    assert_eq!(linked.other_side.kind, "transfer");
+    assert_eq!(
+        linked.transaction.linked_transfer_id.as_deref(),
+        Some(PAIR_IN)
+    );
+    assert_eq!(
+        linked.other_side.linked_transfer_id.as_deref(),
+        Some(PAIR_OUT)
+    );
+
+    // Balance-neutral in two currencies exactly as in one: neither figure is
+    // the other converted, and neither moved. Nothing here converts anything,
+    // which is the whole reason the join is allowed to cross the boundary.
+    assert_eq!(balance(&connection, EVERYDAY), -5500);
+    assert!(identity_holds(&connection, EVERYDAY));
+}
+
+#[test]
+fn across_a_currency_boundary_the_sign_is_still_law() {
+    // The floor under the loosening. Magnitude is given up; DIRECTION is not.
+    let mut connection = fixture();
+    with_pairable_rows(&connection);
+    with_the_far_side_in_dollars(&connection, -3800);
+    connection
+        .execute_batch(&format!(
+            "UPDATE transactions SET type = 'expense' WHERE id = '{PAIR_IN}';"
+        ))
+        .expect("a negative income is a shape no importer writes");
+
+    let refusal = link_transfer_pair(
+        &mut connection,
+        LinkTransferPair {
+            id_a: PAIR_OUT.into(),
+            id_b: PAIR_IN.into(),
+            user_id: Some(OWNER.into()),
+        },
+    )
+    .expect_err("two spends are not one movement, whatever the currencies");
+    assert_eq!(refusal.code(), "transfer_amounts_not_opposite_sign");
+    assert!(
+        refusal.to_string().contains("(GBP -30.00 vs USD -38.00)"),
+        "the currency belongs beside each figure, or the reader reaches for \
+         the magnitudes this rule does not care about: {refusal}"
+    );
+}
+
+#[test]
+fn a_zero_far_side_is_refused_across_a_currency_boundary_too() {
+    // The SECOND position specifically. The same-currency rule leans on
+    // `0 <> -0` to catch a zero far side; there is no negation in the
+    // cross-currency rule, so it must say so itself. A port that copied the
+    // same-currency shape would link this and give the ledger a transfer that
+    // moves 30.00 out of one account and nothing into the other.
+    let mut connection = fixture();
+    with_pairable_rows(&connection);
+    with_the_far_side_in_dollars(&connection, 0);
+
+    let refusal = link_transfer_pair(
+        &mut connection,
+        LinkTransferPair {
+            id_a: PAIR_OUT.into(),
+            id_b: PAIR_IN.into(),
+            user_id: Some(OWNER.into()),
+        },
+    )
+    .expect_err("zero is neither leaving nor arriving");
+    assert_eq!(refusal.code(), "transfer_amounts_not_opposite_sign");
+}
+
+#[test]
+fn one_currency_is_still_held_to_the_penny() {
+    // The other half of the change, and the half that matters most: the
+    // same-currency rule was not weakened. Same fixture as the penny test
+    // above, asserted here as a REGRESSION on the loosening rather than as a
+    // statement of T-1 — if the currency branch ever widened to cover accounts
+    // that share a currency, this is what would notice.
+    let mut connection = fixture();
+    with_pairable_rows(&connection);
+    connection
+        .execute_batch(&format!(
+            "UPDATE transactions SET amount_minor = 3800 WHERE id = '{PAIR_IN}';
+             UPDATE accounts SET balance_minor = balance_minor + 800 WHERE id = '{RAINY_DAY}';"
+        ))
+        .expect("a far side that does not cancel");
+
+    let refusal = link_transfer_pair(
+        &mut connection,
+        LinkTransferPair {
+            id_a: PAIR_OUT.into(),
+            id_b: PAIR_IN.into(),
+            user_id: Some(OWNER.into()),
+        },
+    )
+    .expect_err("two GBP accounts still have to cancel exactly");
+    assert_eq!(refusal.code(), "transfer_amounts_not_opposite");
+    assert!(
+        refusal.to_string().contains("(-30.00 vs 38.00)"),
+        "the same-currency message, unchanged: {refusal}"
+    );
+}
+
 // ── 5. The re-point, and the flag it must never touch ───────────────────────
 //
 // `repoint_transfer` is the family's sixth verb and the newest RPC in the

--- a/scripts/local-sqlite/README.md
+++ b/scripts/local-sqlite/README.md
@@ -786,12 +786,49 @@ Each of these was executed, then reverted.
 
 `cargo test` fails alongside every one of these; the counts are in the table.
 
+**From the cross-currency link — a DECLARED BEHAVIOUR CHANGE (2026-08-12, 491 specs):**
+
+Refusal 5 of `link_transfer_pair` became currency-aware in all three engines at
+once — same currency, exactly opposite as ever; different currencies, non-zero
+and opposite in SIGN with no constraint on magnitude. Cloud side:
+`20260812100000_transfer_linking_across_currencies.sql`. Because both engines
+moved together it is a `match`, not a divergence; the count below is unchanged.
+
+The change was made because the DATA disagreed with the rule first: the ledger
+holds 70 legal cross-currency pairs the MS Money importer wrote directly, and no
+runtime verb in either engine could have created one. The old spec certified
+"different currencies are linked" using a fixture of ±30.00 — a rate of exactly
+1 — so it passed under the strict rule and the loosened one alike and could
+never say which was in force. `convertedRows` exists to make that impossible
+again: its two sides are −30.00 GBP against +38.00 USD.
+
+| break | result |
+| --- | --- |
+| remove the currency branch from the verb (`match None::<(String, String)>`), leaving the strict rule unconditional — i.e. put back exactly what shipped before | **3 verb specs fail.** `transfer-pair-two-currencies-are-linked-because-nothing-is-converted` goes `MISDECLARED (divergent)` — Postgres **accepts** where SQLite refuses `transfer_amounts_not_opposite`, the cloud/local split in its purest form. The other two still refuse on BOTH engines and fail on the **name** alone (`transfer_amounts_not_opposite` for `…_sign`), which is the argument for named expectations restated. 3 crate tests fail with them, and `one_currency_is_still_held_to_the_penny` **passes throughout** — which is what proves the break is confined to the branch it was aimed at. **Measured first WITHOUT the crate tests, and `cargo test` passed the break in full**: the three integration tests in `tests/transfer_family.rs` were written because of that measurement, not before it |
+| drop the far-side zero test (`first == ZERO \|\| second == ZERO` → `first == ZERO`), the shape a port would get by copying the same-currency rule | `transfer-pair-a-zero-side-is-refused-across-a-currency-boundary-too` goes `MISDECLARED (divergent)`: SQLite **accepts** and hands the ledger a transfer that moves 30.00 out of one account and nothing into the other, while Postgres refuses. The unit test `a_zero_side_is_refused_from_either_position` and the integration test of the same name fail with it. The same-currency rule leans on `0 <> -0` being false to catch this; there is no negation in the cross-currency rule, so nothing catches it implicitly — which is the entire reason both zero tests are spelled out |
+
+T-2 in `v_integrity_violations` moved with the verb, and had to: a check that
+calls every converted pair "money appearing from nowhere" would have reported
+all 70 of those pairs as broken the first time anybody ran it, and a violation
+report nobody can act on is a violation report nobody reads.
+`integrity-t2-a-converted-pair-is-not-money-appearing-from-nowhere` is the proof
+it stopped, and `integrity-t2-two-currencies-moving-the-same-way` the proof it
+did not stop caring about direction.
+
 ### Current run
 
-**474 verb specs · 474 pass · 26 declared divergences · 24 single-engine**,
-2026-08-12, against a reference cluster rebuilt from the full migration history.
+**491 verb specs · 491 pass · 29 declared divergences · 26 single-engine**,
+2026-08-12, against a reference cluster rebuilt from the full migration history
+(now including `20260812100000`, which the harness applies itself).
 `npm run test:local-sqlite` is **67/67**, `npm run test:local-admission` is
-109/109 and `cargo test` is **468**.
+109/109 and `cargo test` is **505**.
+
+Re-counted at the cross-currency slice. The previous figures recorded here
+(474 / 26 / 24, `cargo test` 468) were stale by more than this slice added: of
+the 17 new verb specs, 4 are this slice's and 13 predate it, and the divergence
+count had drifted by 3 with no entry to explain it. Recorded rather than quietly
+corrected, because a count nobody re-measures is how the ±30.00 fixture survived
+for a year.
 
 Re-measured at slice 30 on a cluster built **from scratch** — `initdb`, then the
 whole migration history — rather than on the one that had been accumulating on

--- a/scripts/local-sqlite/schema.sql
+++ b/scripts/local-sqlite/schema.sql
@@ -1909,14 +1909,40 @@ UNION ALL
      AND (b.id IS NULL OR b.linked_transfer_id IS NOT a.id)
 
 UNION ALL
-  -- T-2: the two sides of a transfer are exactly opposite and non-zero
-  --      (20260716100000:108-111).
+  -- T-2: the two sides of a transfer move OPPOSITE WAYS and neither is zero.
+  --
+  --      Same currency — exactly opposite, as ever (20260716100000:108-111).
+  --      Different currencies — opposite in SIGN only: two amounts in two
+  --      currencies cancel only at a rate of exactly 1, so demanding it here
+  --      would report every legitimately converted pair in the file as money
+  --      appearing from nowhere. The verb was loosened in the same direction
+  --      and for the same reason (20260812100000); a check stricter than the
+  --      verb that writes the rows is a check that only ever cries wolf.
+  --
+  --      A missing account row falls to the STRICT branch, matching
+  --      link_transfer_pair's `crossed_currencies`: a currency nobody can
+  --      establish is not evidence of a conversion.
   SELECT 'transfer_amounts_not_opposite', 'transaction', a.id, 'violation',
-         'linked transfer sides are not exact opposites'
+         CASE WHEN aa.currency IS NOT NULL AND ba.currency IS NOT NULL
+                   AND aa.currency <> ba.currency
+              THEN 'linked transfer sides in different currencies both move the same way'
+              ELSE 'linked transfer sides are not exact opposites'
+         END
     FROM transactions a
     JOIN transactions b ON b.id = a.linked_transfer_id
+    LEFT JOIN accounts aa ON aa.id = a.account_id
+    LEFT JOIN accounts ba ON ba.id = b.account_id
    WHERE a.linked_transfer_split_id IS NULL
-     AND (a.amount_minor = 0 OR a.amount_minor <> -b.amount_minor)
+     AND CASE
+           WHEN aa.currency IS NOT NULL AND ba.currency IS NOT NULL
+                AND aa.currency <> ba.currency
+             -- `> 0` rather than sign(): both sides are known non-zero by the
+             -- time it is evaluated, and sign() is newer than the oldest
+             -- SQLite this file is expected to open on.
+             THEN a.amount_minor = 0 OR b.amount_minor = 0
+                  OR (a.amount_minor > 0) = (b.amount_minor > 0)
+           ELSE a.amount_minor = 0 OR a.amount_minor <> -b.amount_minor
+         END
 
 UNION ALL
   -- T-3: a transfer's two sides are in different accounts.

--- a/scripts/local-sqlite/verb-specs/_shared.mjs
+++ b/scripts/local-sqlite/verb-specs/_shared.mjs
@@ -343,6 +343,43 @@ export const pairableRows = {
     UPDATE public.accounts SET balance = balance + 30.00 WHERE id = '${RAINY_DAY}';`,
 };
 
+/**
+ * `pairableRows`' cross-currency twin: −30.00 out of Everyday (GBP) against a
+ * DIFFERENT magnitude in Dollars (USD).
+ *
+ * ── WHY THIS EXISTS SEPARATELY ──────────────────────────────────────────────
+ *
+ * Until 2026-08-12 the only cross-currency fixture in the suite was
+ * `pairableRows` with `PAIR_IN` repointed onto Dollars — which left the two
+ * sides at ±30.00, i.e. a rate of exactly 1. That pair passes the strict rule
+ * and the loosened one alike, so it could never say which was in force, and
+ * for a year it certified as "linked" a shape no conversion produces.
+ *
+ * Every amount here is stated twice, in minor units and as a decimal, rather
+ * than divided by 100 in JavaScript. A fixture generator that does float
+ * arithmetic on money is the one place in this suite nobody would think to
+ * look for a rounding bug.
+ *
+ * Requires `dollarAccount`. Everyday lands at −55.00, Dollars at the
+ * destination amount, so B-1 holds on both before the verb runs.
+ *
+ * @param {{minor: number, decimal: string}} destination what arrived in Dollars
+ */
+export const convertedRows = (destination) => ({
+  sqlite: `
+    INSERT INTO transactions (id, user_id, account_id, description, amount_minor, type, date, category) VALUES
+      ('${PAIR_OUT}', '${USER}', '${EVERYDAY}', 'Moved out', -3000, 'expense', '2024-04-02', '${WEEKLY_SHOP}'),
+      ('${PAIR_IN}',  '${USER}', '${DOLLARS}',  'Moved in',  ${destination.minor}, 'income', '2024-04-02', NULL);
+    UPDATE accounts SET balance_minor = balance_minor - 3000 WHERE id = '${EVERYDAY}';
+    UPDATE accounts SET balance_minor = balance_minor + ${destination.minor} WHERE id = '${DOLLARS}';`,
+  postgres: `
+    INSERT INTO public.transactions (id, user_id, account_id, description, amount, type, date, category) VALUES
+      ('${PAIR_OUT}', '${USER}', '${EVERYDAY}', 'Moved out', -30.00, 'expense', '2024-04-02', '${WEEKLY_SHOP}'),
+      ('${PAIR_IN}',  '${USER}', '${DOLLARS}',  'Moved in',  ${destination.decimal}, 'income', '2024-04-02', NULL);
+    UPDATE public.accounts SET balance = balance - 30.00 WHERE id = '${EVERYDAY}';
+    UPDATE public.accounts SET balance = balance + ${destination.decimal} WHERE id = '${DOLLARS}';`,
+});
+
 /** The user's own 'Account Adjustment' category — a leaf, active, not To/From. */
 export const ADJUSTMENT = 'c0000000-0000-0000-0000-0000000000a1';
 
@@ -1751,6 +1788,35 @@ export const linkedSidesThatAreNotOpposites = {
     UPDATE transactions SET linked_transfer_id = '${THIS_LEG}'  WHERE id = '${OTHER_LEG}';
     UPDATE transactions SET linked_transfer_id = '${OTHER_LEG}' WHERE id = '${THIS_LEG}';`,
 };
+
+/**
+ * A LINKED pair straddling a currency boundary, for the T-2 integrity check.
+ *
+ * The companion to `convertedRows`, one step further on: these two are already
+ * joined, which is the state the file is in after a link or after the MS Money
+ * importer has written a pair directly. −30.00 GBP out of Everyday against
+ * whatever arrived in Dollars.
+ *
+ * T-2 has to move with the verb or the two contradict: a check that calls
+ * every converted pair "money appearing from nowhere" reports the whole of a
+ * real ledger as broken, and a violation report nobody can act on is a
+ * violation report nobody reads.
+ *
+ * @param {{minor: number}} destination what arrived in Dollars, in minor units
+ */
+export const linkedSidesInTwoCurrencies = (destination) => ({
+  sqlite: `
+    INSERT INTO accounts (id, user_id, name, type, currency, balance_minor, initial_balance_minor)
+      VALUES ('${DOLLARS}', '${USER}', 'Dollars', 'checking', 'USD', 0, 0);
+    INSERT INTO transactions (id, user_id, account_id, description, amount_minor, type, date,
+                              transfer_account_id) VALUES
+      ('${OTHER_LEG}', '${USER}', '${EVERYDAY}', 'To dollars',    -3000, 'transfer', '2024-04-01', '${DOLLARS}'),
+      ('${THIS_LEG}',  '${USER}', '${DOLLARS}',  'From everyday', ${destination.minor}, 'transfer', '2024-04-01', '${EVERYDAY}');
+    UPDATE accounts SET balance_minor = balance_minor - 3000 WHERE id = '${EVERYDAY}';
+    UPDATE accounts SET balance_minor = balance_minor + ${destination.minor} WHERE id = '${DOLLARS}';
+    UPDATE transactions SET linked_transfer_id = '${THIS_LEG}'  WHERE id = '${OTHER_LEG}';
+    UPDATE transactions SET linked_transfer_id = '${OTHER_LEG}' WHERE id = '${THIS_LEG}';`,
+});
 
 /**
  * T-3: both sides of one transfer sitting in the same account.

--- a/scripts/local-sqlite/verb-specs/integrity-t2-a-converted-pair-is-not-money-appearing-from-nowhere.spec.mjs
+++ b/scripts/local-sqlite/verb-specs/integrity-t2-a-converted-pair-is-not-money-appearing-from-nowhere.spec.mjs
@@ -1,0 +1,38 @@
+import { linkedSidesInTwoCurrencies } from './_shared.mjs';
+
+// The other half of the 2026-08-12 change, and the half that is easy to forget.
+//
+// Loosening the VERB without loosening the CHECK would have been worse than
+// leaving both alone: every pair the new dialog created would have been written
+// happily and then reported by verify_integrity as "linked transfer sides are
+// not exact opposites" — money appearing from nowhere — for the rest of the
+// file's life. The owner's ledger already holds 70 importer-written pairs that
+// would have been flagged the first time anybody ran it.
+//
+// So T-2 now asks the same question the verb asks: same currency, exact
+// opposites; different currencies, opposite in sign. This spec is the proof it
+// asks it, and it uses a pair whose magnitudes are genuinely unequal — the only
+// shape that can tell the old check from the new one.
+//
+// The refusal side of the same rule is covered by
+// `integrity-t2-two-sides-that-do-not-cancel` (same currency, still strict) and
+// `integrity-t2-two-currencies-moving-the-same-way` (the direction rule).
+export default {
+  invariant: 'T-2',
+  title: 'a linked pair in two currencies at a real rate is not a violation',
+  design: 'schema.sql transfer_amounts_not_opposite — the CASE on currency, matching link_transfer_pair 20260812100000',
+  consequence: 'every legitimately converted transfer in the file is reported as money appearing from nowhere, so the integrity report becomes noise and the real violations in it stop being read',
+  parity: 'not-comparable',
+  reason: 'verify_integrity is local-only — see the verb module for the trace',
+  skip: { postgres: 'there is no cloud counterpart to compare against' },
+
+  setup: linkedSidesInTwoCurrencies({ minor: 3800 }),
+  command: { verb: 'verify_integrity', payload: {} },
+  expect: { outcome: 'ok' },
+  result: {
+    ok: true,
+    violations: 0,
+    warnings: 0,
+    findings: [],
+  },
+};

--- a/scripts/local-sqlite/verb-specs/integrity-t2-two-currencies-moving-the-same-way.spec.mjs
+++ b/scripts/local-sqlite/verb-specs/integrity-t2-two-currencies-moving-the-same-way.spec.mjs
@@ -1,0 +1,47 @@
+import { OTHER_LEG, THIS_LEG, linkedSidesInTwoCurrencies } from './_shared.mjs';
+
+// T-2 keeps its teeth across the boundary: it gave up magnitude, not direction.
+//
+// Both sides here fall. Whatever the rate was, that is not one movement seen
+// from two ends — it is two spends wearing a link, and the two accounts between
+// them really did lose money that the ledger says went from one to the other.
+//
+// Reported on BOTH rows, for the reason the same-currency spec gives: the check
+// reads every row that names another, and naming one would leave the other
+// looking innocent. The detail differs from the same-currency wording because
+// the complaint differs — "not exact opposites" would send a reader to compare
+// the magnitudes, which is precisely what this rule no longer cares about.
+export default {
+  invariant: 'T-2',
+  title: 'a linked pair in two currencies that both move the same way — reported on BOTH rows',
+  design: 'schema.sql transfer_amounts_not_opposite — (a.amount_minor > 0) = (b.amount_minor > 0) across a currency boundary',
+  consequence: 'two separate spends are recorded as one movement, and because each account is individually consistent with its own rows, nothing else in the product can notice',
+  parity: 'not-comparable',
+  reason: 'verify_integrity is local-only — see the verb module for the trace',
+  skip: { postgres: 'there is no cloud counterpart to compare against' },
+
+  setup: linkedSidesInTwoCurrencies({ minor: -3800 }),
+  command: { verb: 'verify_integrity', payload: {} },
+  expect: { outcome: 'ok' },
+  result: {
+    ok: false,
+    violations: 2,
+    warnings: 0,
+    findings: [
+      {
+        check: 'transfer_amounts_not_opposite',
+        entity: 'transaction',
+        id: OTHER_LEG,
+        severity: 'violation',
+        detail: 'linked transfer sides in different currencies both move the same way',
+      },
+      {
+        check: 'transfer_amounts_not_opposite',
+        entity: 'transaction',
+        id: THIS_LEG,
+        severity: 'violation',
+        detail: 'linked transfer sides in different currencies both move the same way',
+      },
+    ],
+  },
+};

--- a/scripts/local-sqlite/verb-specs/transfer-pair-a-zero-side-is-refused-across-a-currency-boundary-too.spec.mjs
+++ b/scripts/local-sqlite/verb-specs/transfer-pair-a-zero-side-is-refused-across-a-currency-boundary-too.spec.mjs
@@ -1,0 +1,42 @@
+import { USER, EVERYDAY, DOLLARS, PAIR_OUT, PAIR_IN, dollarAccount, convertedRows,
+  setups, balanceOf, balanceIdentityHolds, transferShape, transferLinksAreMutual,
+  auditRowsInTotal } from './_shared.mjs';
+
+// Zero is neither leaving nor arriving, so it fails the direction rule in both
+// currencies and in one.
+//
+// Worth a spec of its own because of HOW the two rules reach that answer. The
+// same-currency rule tests only `v_a.amount = 0` and lets `v_a.amount <>
+// -v_b.amount` catch a zero on the far side — `0 <> -0` is false, so the
+// negation does the second half of the work. The cross-currency rule has no
+// negation in it, so it must test BOTH sides explicitly, and this spec drives
+// the SECOND one specifically. An engine that ported the loosening by copying
+// the same-currency shape (one zero test, then a sign comparison) would admit a
+// pair here: `0.signum()` is neither `1` nor `-1`, so a zero side reads as
+// "different sign" and links happily, giving the ledger a transfer that moves
+// 30.00 out of one account and nothing into the other.
+export default {
+  invariant: 'T-1',
+  title: 'a zero side is refused across a currency boundary, from the far position',
+  design: 'link_transfer_pair 20260812100000 — v_a.amount = 0 OR v_b.amount = 0, both stated, because no negation catches the second',
+  consequence: 'money leaves one account and arrives in none, under a link that says the two are one movement',
+  parity: 'match',
+
+  setup: setups(dollarAccount, convertedRows({ minor: 0, decimal: '0.00' })),
+  command: { verb: 'link_transfer_pair', payload: { id_a: PAIR_OUT, id_b: PAIR_IN, user_id: USER } },
+  expect: {
+    outcome: 'refused',
+    error: 'transfer sides in different currencies must be opposite in sign and non-zero (GBP -30.00 vs USD 0.00)',
+  },
+
+  state: [
+    transferShape(PAIR_OUT, 'expense:Weekly shop:-:-:-'),
+    transferShape(PAIR_IN, 'income:-:-:-:-'),
+    transferLinksAreMutual(),
+    balanceOf(EVERYDAY, '-55.00'),
+    balanceOf(DOLLARS, '0.00'),
+    balanceIdentityHolds(EVERYDAY),
+    balanceIdentityHolds(DOLLARS),
+    auditRowsInTotal('0'),
+  ],
+};

--- a/scripts/local-sqlite/verb-specs/transfer-pair-two-currencies-are-linked-because-nothing-is-converted.spec.mjs
+++ b/scripts/local-sqlite/verb-specs/transfer-pair-two-currencies-are-linked-because-nothing-is-converted.spec.mjs
@@ -1,37 +1,44 @@
-import { USER, EVERYDAY, DOLLARS, PAIR_OUT, PAIR_IN, dollarAccount, pairableRows,
+import { USER, EVERYDAY, DOLLARS, PAIR_OUT, PAIR_IN, dollarAccount, convertedRows,
   setups, balanceOf, balanceIdentityHolds, transferShape, transferLinksAreMutual,
   auditShape } from './_shared.mjs';
 
 // The second DELIBERATE ABSENCE, and this one has a reason rather than being an
-// oversight. T-9 refuses a cross-currency COUNTERPART
-// (`20260721090000`) because that RPC copies an amount into another ledger with
-// no conversion, and a USD −1,336.25 would move a GBP account by £1,336.25.
+// oversight. T-9 refuses a cross-currency COUNTERPART (`20260721090000`)
+// because that RPC copies an amount into another ledger with no conversion.
 //
 // Joining two rows that already exist copies nothing. Each side already counts
 // against its own account in its own currency, and the link only says they are
-// one movement. So there is nothing to convert and nothing to refuse — MEASURED
-// (probe-transfers.sh, `ltp-cross-currency`): the live RPC links them.
+// one movement. So there is nothing to convert and nothing to refuse.
 //
-// Both balances are asserted below in their own currencies, which is what makes
-// this spec a proof rather than an assertion: neither ledger moved, so neither
-// was converted.
+// ── DECLARED BEHAVIOUR CHANGE, 2026-08-12 ───────────────────────────────────
+//
+// This spec used to prove that claim with a pair of ±30.00, and it proved
+// nothing. A pair that sums to zero passes the strict rule and the loosened one
+// alike; ±30.00 across a currency boundary is a rate of exactly 1, which is not
+// a shape any conversion produces. Meanwhile refusal 5 — `v_a.amount <>
+// -v_b.amount`, applied unconditionally — refused every pair that WAS a
+// conversion. The suite therefore certified "different currencies are linked"
+// while the engine refused all of them, for a year, and the fixture is the
+// reason nobody noticed.
+//
+// The rule changed in all three engines at once (this is a `match`, not a
+// divergence): across a currency boundary the two sides must be non-zero and
+// OPPOSITE IN SIGN, with no constraint on magnitude, because the ratio between
+// the magnitudes IS the achieved rate and no engine has an opinion about FX.
+// Cloud side: `20260812100000_transfer_linking_across_currencies.sql`.
+//
+// The fixture now differs on both sides of the boundary — −30.00 GBP against
+// +38.00 USD — so it can only pass under the new rule. Both balances are
+// asserted below in their own currencies, which is what makes this a proof
+// rather than an assertion: neither ledger moved, so neither was converted.
 export default {
   invariant: 'T-9',
-  title: 'two accounts in different currencies can be linked, because a link converts nothing',
-  design: 'link_transfer_pair 20260716100000 — no currency guard; contrast create_transfer_counterpart 20260721090000:63-74',
-  consequence: 'either a legitimate cross-currency pairing is refused, or a raw magnitude is copied into the wrong ledger — depending on which side of the line the guard is put',
+  title: 'two accounts in different currencies are linked at a real rate, because a link converts nothing',
+  design: 'link_transfer_pair 20260812100000 — refusal 5 splits on currency; contrast create_transfer_counterpart 20260721090000:63-74, which still refuses outright because it COPIES an amount',
+  consequence: 'either every legitimate cross-currency pairing is refused — as it was until 2026-08-12, while 70 importer-written pairs sat in the ledger proving the rule wrong — or a raw magnitude is copied into the wrong ledger',
   parity: 'match',
 
-  setup: setups(dollarAccount, {
-    sqlite: `${pairableRows.sqlite}
-      UPDATE transactions SET account_id = '${DOLLARS}' WHERE id = '${PAIR_IN}';
-      UPDATE accounts SET balance_minor = balance_minor - 3000 WHERE id = 'a0000000-0000-0000-0000-000000000002';
-      UPDATE accounts SET balance_minor = balance_minor + 3000 WHERE id = '${DOLLARS}';`,
-    postgres: `${pairableRows.postgres}
-      UPDATE public.transactions SET account_id = '${DOLLARS}' WHERE id = '${PAIR_IN}';
-      UPDATE public.accounts SET balance = balance - 30.00 WHERE id = 'a0000000-0000-0000-0000-000000000002';
-      UPDATE public.accounts SET balance = balance + 30.00 WHERE id = '${DOLLARS}';`,
-  }),
+  setup: setups(dollarAccount, convertedRows({ minor: 3800, decimal: '38.00' })),
   command: { verb: 'link_transfer_pair', payload: { id_a: PAIR_OUT, id_b: PAIR_IN, user_id: USER } },
   expect: { outcome: 'ok' },
   result: { id: PAIR_OUT, amount: '-30.00', type: 'transfer' },
@@ -44,8 +51,11 @@ export default {
     transferShape(PAIR_OUT, `transfer:To/From Dollars:000d:${PAIR_IN.slice(-4)}:-`),
     transferShape(PAIR_IN, `transfer:To/From Everyday:0001:${PAIR_OUT.slice(-4)}:-`),
     transferLinksAreMutual(),
+    // Neither figure is the other converted, and neither moved. That is the
+    // whole property: a link is balance-neutral in two currencies exactly as
+    // it is in one.
     balanceOf(EVERYDAY, '-55.00'),
-    balanceOf(DOLLARS, '30.00'),
+    balanceOf(DOLLARS, '38.00'),
     balanceIdentityHolds(EVERYDAY),
     balanceIdentityHolds(DOLLARS),
     auditShape('transaction/update,transaction/update'),

--- a/scripts/local-sqlite/verb-specs/transfer-pair-two-currencies-moving-the-same-way-are-refused.spec.mjs
+++ b/scripts/local-sqlite/verb-specs/transfer-pair-two-currencies-moving-the-same-way-are-refused.spec.mjs
@@ -1,0 +1,47 @@
+import { USER, EVERYDAY, DOLLARS, PAIR_OUT, PAIR_IN, dollarAccount, convertedRows,
+  setups, balanceOf, balanceIdentityHolds, transferShape, transferLinksAreMutual,
+  auditRowsInTotal } from './_shared.mjs';
+
+// The floor under the 2026-08-12 loosening, and the reason it is a loosening
+// rather than a removal.
+//
+// Across a currency boundary the engine gives up its opinion about MAGNITUDE —
+// the ratio between the two figures is the achieved rate, and no engine can
+// know what it should have been. It does not give up its opinion about
+// DIRECTION. A transfer is one movement seen from both ends: one account goes
+// down, the other goes up. Two sides that both fall are two spends that happen
+// to be near each other, and calling them a transfer would net −30.00 and
+// −38.00 into a movement of nothing while both accounts really did lose money.
+//
+// This is the assertion that would fail if an engine ported the loosening as
+// "stop checking the amounts", which is the plausible wrong reading of it.
+export default {
+  invariant: 'T-1',
+  title: 'two sides in different currencies that both move the same way are refused',
+  design: 'link_transfer_pair 20260812100000 — sign(v_a.amount) = sign(v_b.amount) across a currency boundary',
+  consequence: 'two separate spends are recorded as one movement, so both accounts show money leaving and the ledger shows none of it going anywhere',
+  parity: 'match',
+
+  setup: setups(dollarAccount, convertedRows({ minor: -3800, decimal: '-38.00' }), {
+    // The row arrived as an 'income' from the fixture; a negative income is a
+    // shape no importer writes, and the refusal must not depend on the type.
+    sqlite: `UPDATE transactions SET type = 'expense' WHERE id = '${PAIR_IN}';`,
+    postgres: `UPDATE public.transactions SET type = 'expense' WHERE id = '${PAIR_IN}';`,
+  }),
+  command: { verb: 'link_transfer_pair', payload: { id_a: PAIR_OUT, id_b: PAIR_IN, user_id: USER } },
+  expect: {
+    outcome: 'refused',
+    error: 'transfer sides in different currencies must be opposite in sign and non-zero (GBP -30.00 vs USD -38.00)',
+  },
+
+  state: [
+    transferShape(PAIR_OUT, 'expense:Weekly shop:-:-:-'),
+    transferShape(PAIR_IN, 'expense:-:-:-:-'),
+    transferLinksAreMutual(),
+    balanceOf(EVERYDAY, '-55.00'),
+    balanceOf(DOLLARS, '-38.00'),
+    balanceIdentityHolds(EVERYDAY),
+    balanceIdentityHolds(DOLLARS),
+    auditRowsInTotal('0'),
+  ],
+};

--- a/src/components/AccountRowColumns.tsx
+++ b/src/components/AccountRowColumns.tsx
@@ -158,8 +158,16 @@ export function AccountBalanceCell({
 }
 
 /**
- * A count of outstanding work: amber while there is some, blue when there is
- * none.
+ * A count of outstanding work: quiet slate while there is some, blue when
+ * there is none.
+ *
+ * It wore amber until DESIGN_RULINGS_2026-08-12 (ruling A): amber marks the
+ * CONTROL you should touch next — a single, clickable next action — and this
+ * is a count, which reports a quantity and does nothing when clicked. Two
+ * ambers on one screen where one is actionable and one is not teaches the eye
+ * that amber means "look here-ish", eroding the one signal the yellow thread
+ * depends on. If the row should invite the work, the invitation belongs on
+ * the row's reconcile control, which already exists.
  *
  * A QUIET 0 RATHER THAN A BLANK, unlike the register's own counters, and the
  * difference is the surface rather than an inconsistency: this is a COLUMN, and
@@ -179,7 +187,7 @@ export function AccountCountCell({
       <p className={CELL_LABEL_CLASS}>{label}</p>
       <p
         className={`${CELL_FIGURE_CLASS} ${
-          count > 0 ? 'text-amber-600 dark:text-amber-400' : 'text-blue-600 dark:text-blue-400'
+          count > 0 ? 'text-slate-600 dark:text-gray-300' : 'text-blue-600 dark:text-blue-400'
         }`}
       >
         {count}

--- a/src/components/AccountSettingsModal.currency.test.tsx
+++ b/src/components/AccountSettingsModal.currency.test.tsx
@@ -1,0 +1,127 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import AccountSettingsModal from './AccountSettingsModal';
+import type { Account, AccountUpdate } from '../types';
+
+/**
+ * The CURRENCY field in Account Settings.
+ *
+ * The rule it enforces is not a UI preference: an account's currency says what
+ * every stored figure in it MEANS, so changing it on an account with history
+ * re-labels the whole register without touching a single number. It is
+ * therefore shown always and editable only while the account is empty — the
+ * rule Microsoft Money applies to the same field for the same reason.
+ *
+ * These render the real Modal and the real useModalForm; the only stand-in is
+ * `onSave`, because what is under test is precisely WHAT reaches it.
+ */
+
+const account: Account = {
+  id: 'acc-1',
+  name: 'Everyday',
+  type: 'current',
+  balance: 1000,
+  currency: 'GBP',
+  lastUpdated: new Date('2026-01-01'),
+};
+
+function renderModal(props: Partial<React.ComponentProps<typeof AccountSettingsModal>> = {}) {
+  const onSave = vi.fn<(id: string, updates: AccountUpdate) => Promise<void>>(
+    () => Promise.resolve()
+  );
+  render(
+    <AccountSettingsModal
+      isOpen
+      onClose={vi.fn()}
+      account={account}
+      onSave={onSave}
+      {...props}
+    />
+  );
+  return { onSave };
+}
+
+/** The Currency control when it is editable — a real select, by its label. */
+const currencySelect = (): HTMLSelectElement | null =>
+  screen.queryByLabelText<HTMLSelectElement>('Currency', { selector: 'select' });
+
+describe('AccountSettingsModal — currency', () => {
+  it('always shows the account currency, whatever the history', () => {
+    renderModal({ hasTransactions: true });
+    expect(screen.getByText('Currency')).toBeInTheDocument();
+    // Named in full, and always with the code: the code is what the account
+    // stores and what every export will show.
+    expect(screen.getByText('£ British Pound (GBP)')).toBeInTheDocument();
+  });
+
+  it('offers the currency for editing while the account holds nothing', () => {
+    renderModal({ hasTransactions: false });
+
+    const select = currencySelect();
+    expect(select).not.toBeNull();
+    expect(select).toHaveValue('GBP');
+    // The same three the creation form offers — one shared list, not two.
+    expect(
+      Array.from(select?.options ?? []).map(option => option.value)
+    ).toEqual(['GBP', 'USD', 'EUR']);
+  });
+
+  it('locks the currency once the account has transactions, and says what changing it would do', () => {
+    renderModal({ hasTransactions: true });
+
+    expect(currencySelect()).toBeNull();
+    // The consequence, not the count.
+    expect(
+      screen.getByText(/changing it now would leave every recorded figure at the same number while quietly re-labelling what that number is worth/i)
+    ).toBeInTheDocument();
+  });
+
+  it('locks the currency when the caller could not establish whether there is history', () => {
+    // The prop is omitted. "Cannot tell" must behave like "has history": a
+    // read-only field on an empty account is a nuisance, an editable one on a
+    // full account is a re-denomination.
+    renderModal();
+    expect(currencySelect()).toBeNull();
+  });
+
+  it('persists a changed currency through the ordinary save', async () => {
+    const { onSave } = renderModal({ hasTransactions: false });
+
+    const select = currencySelect();
+    expect(select).not.toBeNull();
+    fireEvent.change(select as HTMLSelectElement, { target: { value: 'USD' } });
+    fireEvent.click(screen.getByRole('button', { name: /save changes/i }));
+
+    await waitFor(() => expect(onSave).toHaveBeenCalled());
+    expect(onSave.mock.calls[0][0]).toBe('acc-1');
+    expect(onSave.mock.calls[0][1].currency).toBe('USD');
+  });
+
+  it('sends no currency at all when the field was locked', async () => {
+    const { onSave } = renderModal({ hasTransactions: true });
+
+    fireEvent.click(screen.getByRole('button', { name: /save changes/i }));
+
+    await waitFor(() => expect(onSave).toHaveBeenCalled());
+    // Not "sends the unchanged value": an account that gains its first
+    // transaction while this modal is open must not be re-denominated by a
+    // save that was only ever meant to rename it.
+    expect('currency' in onSave.mock.calls[0][1]).toBe(false);
+  });
+
+  it('keeps an unsupported stored currency in the list rather than silently swapping it', () => {
+    // A restored backup or an MS Money import can hold anything. A select whose
+    // value is absent from its own options displays the first option instead,
+    // and saving that would re-denominate the account to GBP.
+    renderModal({
+      hasTransactions: false,
+      account: { ...account, currency: 'JPY' },
+    });
+
+    const select = currencySelect();
+    expect(select).toHaveValue('JPY');
+    expect(
+      Array.from(select?.options ?? []).map(option => option.value)
+    ).toContain('JPY');
+  });
+});

--- a/src/components/AccountSettingsModal.tsx
+++ b/src/components/AccountSettingsModal.tsx
@@ -8,6 +8,7 @@ import type { Account as BaseAccount, AccountUpdate } from '../types';
 import ToggleSwitch from './ui/ToggleSwitch';
 import CardNumberGuidance from './CardNumberGuidance';
 import GroupedAccountOptions from './common/GroupedAccountOptions';
+import { accountCurrencyOptions, describeAccountCurrency } from '../constants/accountCurrencies';
 import {
   BANK_ACCOUNT_NUMBER_LENGTH,
   CARD_NUMBER_LABEL,
@@ -35,11 +36,24 @@ interface AccountSettingsModalProps {
    * the field then never appears, and no pairing is written either way.
    */
   accounts?: readonly BaseAccount[];
+  /**
+   * Does this account already hold recorded money? It decides one thing only:
+   * whether CURRENCY may still be edited (see the field itself for why).
+   *
+   * Established by the caller with {@link accountHasHistory}, because the pages
+   * that open this modal already hold the transactions and this modal holds
+   * none. OMITTING IT LOCKS THE FIELD: a caller that cannot tell whether there
+   * is history must not be the reason a user re-denominates their ledger, and
+   * "read-only with an explanation" is a harmless answer for an empty account
+   * while "editable" is a destructive one for a full account.
+   */
+  hasTransactions?: boolean;
 }
 
 interface FormData {
   name: string;
   type: Account['type'];
+  currency: string;
   openingBalance: string;
   openingBalanceDate: string;
   sortCode: string;
@@ -119,12 +133,22 @@ export default function AccountSettingsModal({
   onClose,
   account,
   onSave,
-  accounts = []
+  accounts = [],
+  hasTransactions
 }: AccountSettingsModalProps) {
+  /**
+   * Editable only on an account with NO history, and only when the caller said
+   * so out loud — `undefined` means "could not establish it", which locks.
+   */
+  const currencyEditable = hasTransactions === false;
+
   const { formData, updateField, handleSubmit, setFormData, errors, isSubmitting } = useModalForm<FormData>(
     {
       name: '',
       type: 'current',
+      // Matches mapAccountFromDb's fallback and the accounts.currency column
+      // default; overwritten from the account itself before anything renders.
+      currency: 'GBP',
       openingBalance: '',
       openingBalanceDate: '',
       sortCode: '',
@@ -168,7 +192,14 @@ export default function AccountSettingsModal({
           // clears it — mapAccountToDb drops undefined fields.
           ...(resolvePairing(account, accounts, data.type).offered
             ? { parentAccountId: data.parentAccountId || null }
-            : {})
+            : {}),
+          // Same rule, and for a much sharper reason: only ever written when
+          // the field was EDITABLE. On an account with history the value on
+          // screen is the stored one, so writing it back would be a no-op —
+          // right up until the account gains its first transaction between the
+          // modal opening and Save, when it would silently re-denominate a
+          // ledger that had just stopped being empty.
+          ...(currencyEditable && data.currency ? { currency: data.currency } : {})
         };
 
         if (data.openingBalance !== '') {
@@ -189,6 +220,7 @@ export default function AccountSettingsModal({
       setFormData({
         name: account.name || '',
         type: account.type || 'current',
+        currency: account.currency || 'GBP',
         openingBalance: account.openingBalance != null ? account.openingBalance.toFixed(2) : '',
         openingBalanceDate: account.openingBalanceDate
           ? new Date(account.openingBalanceDate).toISOString().split('T')[0]
@@ -286,6 +318,64 @@ export default function AccountSettingsModal({
             <p className="mt-1 text-xs text-gray-500 dark:text-gray-400">
               Changing the type will relocate this account to the appropriate section
             </p>
+          </div>
+
+          {/* Currency — always shown, editable only while the account is empty.
+              An account's currency was chosen once in AddAccountModal and then
+              never displayed again anywhere, so the one figure that says what
+              every other figure MEANS was invisible. */}
+          <div>
+            {currencyEditable ? (
+              <>
+                <label htmlFor="account-currency" className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+                  Currency
+                </label>
+                <select
+                  id="account-currency"
+                  value={formData.currency}
+                  onChange={(e) => updateField('currency', e.target.value)}
+                  className="w-full px-3 py-2 bg-white dark:bg-gray-800-sm border border-gray-300/50 dark:border-gray-600/50 rounded-xl focus:outline-none focus:ring-2 focus:ring-primary focus:border-transparent dark:text-white"
+                >
+                  {/* The account's own code is always among these, even if the
+                      app does not support it — see accountCurrencyOptions. */}
+                  {accountCurrencyOptions(formData.currency).map(option => (
+                    <option key={option.value} value={option.value}>
+                      {option.symbol} {option.label}
+                    </option>
+                  ))}
+                </select>
+                <p className="mt-1 text-xs text-gray-500 dark:text-gray-400">
+                  Nothing has been recorded in this account yet, so its currency
+                  can still be changed. It is fixed as soon as the first
+                  transaction lands here.
+                </p>
+              </>
+            ) : (
+              <>
+                {/* Not a disabled <select>: there is no control here to reach,
+                    and a greyed-out dropdown says "unavailable" where the
+                    account needs to say "settled". */}
+                <span id="account-currency-label" className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+                  Currency
+                </span>
+                <p
+                  aria-labelledby="account-currency-label"
+                  className="w-full px-3 py-2 rounded-xl border border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-800/60 text-gray-700 dark:text-gray-200"
+                >
+                  {describeAccountCurrency(formData.currency)}
+                </p>
+                {/* The consequence, not the rule: changing the denomination
+                    would leave every stored figure at its own number while
+                    changing what that number means — the same re-labelling
+                    Microsoft Money refuses once an account has a register. */}
+                <p className="mt-1 text-xs text-gray-500 dark:text-gray-400">
+                  This account already has transactions, so its currency is
+                  fixed — changing it now would leave every recorded figure at
+                  the same number while quietly re-labelling what that number
+                  is worth.
+                </p>
+              </>
+            )}
           </div>
 
           {/* Opening Balance */}

--- a/src/components/AddAccountModal.tsx
+++ b/src/components/AddAccountModal.tsx
@@ -8,6 +8,7 @@ import type { Account } from '../types';
 import { createScopedLogger } from '../loggers/scopedLogger';
 import { parseMoneyInput } from '../utils/decimal';
 import CardNumberGuidance from './CardNumberGuidance';
+import { ACCOUNT_CURRENCIES } from '../constants/accountCurrencies';
 import {
   BANK_ACCOUNT_NUMBER_LENGTH,
   CARD_NUMBER_LABEL,
@@ -53,11 +54,10 @@ const accountTypes = [
   { value: 'assets', label: 'Other Assets', icon: PackageIcon, description: 'Property, valuables' },
 ];
 
-const currencies = [
-  { value: 'GBP', label: 'British Pound', symbol: '£' },
-  { value: 'USD', label: 'US Dollar', symbol: '$' },
-  { value: 'EUR', label: 'Euro', symbol: '€' },
-];
+// The supported list, shared with Account Settings — which now SHOWS an
+// account's currency, and must offer exactly what this form offered when the
+// account was made. See constants/accountCurrencies.
+const currencies = ACCOUNT_CURRENCIES;
 
 export default function AddAccountModal({ isOpen, onClose, prefill, onAccountCreated }: AddAccountModalProps): React.JSX.Element {
   const { addAccount } = useApp();

--- a/src/components/AddInvestmentModal.test.tsx
+++ b/src/components/AddInvestmentModal.test.tsx
@@ -377,15 +377,7 @@ describe('AddInvestmentModal', () => {
         category: 'cat-27',
         accountId: '1',
         notes: expect.stringContaining('Investment Type: share'),
-        tags: ['investment', 'share', 'AAPL'],
-        investmentData: {
-          symbol: 'AAPL',
-          quantity: 10,
-          pricePerShare: 150,
-          transactionFee: 5,
-          stampDuty: 0,
-          totalCost: 1505
-        }
+        tags: ['investment', 'share', 'AAPL']
       });
     });
 

--- a/src/components/AddInvestmentModal.tsx
+++ b/src/components/AddInvestmentModal.tsx
@@ -92,15 +92,7 @@ export default function AddInvestmentModal({ isOpen, onClose, accountId }: AddIn
           category: 'cat-27', // Investment category
           accountId: data.selectedAccountId,
           notes: data.notes ? `${structuredNotes}\n\nAdditional Notes: ${data.notes}` : structuredNotes,
-          tags: ['investment', data.investmentType, data.stockCode].filter(Boolean),
-          investmentData: {
-            symbol: data.stockCode,
-            quantity: unitsNum,
-            pricePerShare: priceNum,
-            transactionFee: feesNum,
-            stampDuty: stampDutyNum,
-            totalCost: total
-          }
+          tags: ['investment', data.investmentType, data.stockCode].filter(Boolean)
         });
       },
       onClose

--- a/src/components/AddTransactionModal.tsx
+++ b/src/components/AddTransactionModal.tsx
@@ -13,6 +13,13 @@ import { useTransactionNotifications } from '../hooks/useTransactionNotification
 import { parseMoneyInput } from '../utils/decimal';
 import { transferCategoryIdFor } from '../utils/transferRepoint';
 import { isTransferFiling } from '../utils/transferCoherence';
+import CrossCurrencyTransferDialog from './CrossCurrencyTransferDialog';
+import { buildFxRecord } from '../utils/fx';
+import {
+  crossedCurrencies,
+  destinationLegAmount,
+  type ConfirmedConversion,
+} from '../utils/crossCurrencyTransfer';
 import MarkdownEditor from './MarkdownEditor';
 import { ValidationService } from '../services/validationService';
 import { z } from 'zod';
@@ -51,6 +58,34 @@ interface AddTransactionModalProps {
  */
 class DraftRefused extends Error {}
 
+/**
+ * Not a refusal — a QUESTION. The draft is good and nothing is wrong with it,
+ * but it crosses a currency boundary and the figure that lands in the other
+ * account is not one this form can know.
+ *
+ * Thrown for the same mechanical reason as {@link DraftRefused}: useModalForm
+ * reads a clean return as success and would close the modal and discard the
+ * draft, which is exactly what must not happen while a dialog is asking about
+ * it. The draft is stashed first; the dialog's confirm handler finishes the
+ * write. Nothing has been written to the ledger at this point — the question is
+ * asked BEFORE the first row exists, so cancelling costs nothing and leaves
+ * nothing behind.
+ */
+class ConversionPending extends Error {}
+
+/** A validated draft, held while the dialog asks what the other side is worth. */
+interface PendingConversion {
+  description: string;
+  /** The source leg's SIGNED amount — negative, a transfer leaves. */
+  amount: number;
+  accountId: string;
+  targetAccountId: string;
+  date: string;
+  notes: string | undefined;
+  from: string;
+  to: string;
+}
+
 interface FormData {
   description: string;
   amount: string;
@@ -68,6 +103,9 @@ export default function AddTransactionModal({ isOpen, onClose, initialAccountId 
     // The two writes that turn one row into a linked pair, and undo it if the
     // second half cannot be made. See onSubmit.
     createTransferCounterpart, deleteTransaction,
+    // The cross-currency route, which mints nothing: two explicit legs joined
+    // by the one verb that converts nothing. See confirmConversion.
+    linkTransferPair,
   } = useApp();
   // Adds through the same path the edit modal uses, so the user's Large
   // Transaction Warnings actually fire. This is the main way a transaction
@@ -76,6 +114,8 @@ export default function AddTransactionModal({ isOpen, onClose, initialAccountId 
   const { addTransaction } = useTransactionNotifications();
   const [showCategoryModal, setShowCategoryModal] = useState(false);
   const [validationErrors, setValidationErrors] = useState<Record<string, string>>({});
+  const [pendingConversion, setPendingConversion] = useState<PendingConversion | null>(null);
+  const [conversionBusy, setConversionBusy] = useState(false);
   const { showSuccess, showError } = useToast();
   const logger = useMemo(() => createScopedLogger('AddTransactionModal'), []);
   
@@ -121,17 +161,6 @@ export default function AddTransactionModal({ isOpen, onClose, initialAccountId 
               });
               throw new DraftRefused();
             }
-            // The counterpart is −amount with no conversion, so both accounts
-            // must share a currency. Refused here rather than after the first
-            // write, so a knowable failure never puts a row in the ledger.
-            const from = accounts.find(a => a.id === data.accountId)?.currency;
-            const to = accounts.find(a => a.id === targetAccountId)?.currency;
-            if (from && to && from !== to) {
-              setValidationErrors({
-                category: `Transfers between accounts in different currencies aren’t supported yet (${from} and ${to}).`,
-              });
-              throw new DraftRefused();
-            }
           }
 
           // Validate the transaction data
@@ -154,6 +183,37 @@ export default function AddTransactionModal({ isOpen, onClose, initialAccountId 
           // A transfer LEAVES the account it is entered on, so it is signed like
           // an expense. It used to be signed like income.
           const finalAmount = data.type === 'income' ? Math.abs(amount) : -Math.abs(amount);
+
+          /**
+           * THE CURRENCY BOUNDARY, ASKED ABOUT BEFORE ANYTHING IS WRITTEN.
+           *
+           * This used to be a flat refusal, because `createTransferCounterpart`
+           * copies −amount into the other ledger with no conversion and a
+           * USD source would have moved a GBP account by the same digits. That
+           * guard is right and is untouched; what was wrong was having no other
+           * route. Now the person is asked what arrived, and the flow writes
+           * BOTH legs explicitly and links them — which needs no mint and so
+           * needs no guess.
+           *
+           * Nothing is in the ledger yet at this point, and that is deliberate:
+           * a cancelled dialog leaves no orphan row to clean up.
+           */
+          const crossed = isTransfer
+            ? crossedCurrencies(accounts, validatedData.accountId, targetAccountId)
+            : null;
+          if (crossed) {
+            setPendingConversion({
+              description: validatedData.description,
+              amount: finalAmount,
+              accountId: validatedData.accountId,
+              targetAccountId,
+              date: validatedData.date,
+              notes: validatedData.notes,
+              from: crossed.from,
+              to: crossed.to,
+            });
+            throw new ConversionPending();
+          }
 
           // Awaited so a failed write lands in the catch below rather than
           // announcing success for a transaction that was never saved.
@@ -195,6 +255,9 @@ export default function AddTransactionModal({ isOpen, onClose, initialAccountId 
             // The reason is already printed at the field that caused it. Adding
             // a general message would say the same thing twice, in the wrong
             // place.
+          } else if (error instanceof ConversionPending) {
+            // Not an error at all — the dialog is now asking. Saying anything
+            // here would put a message under a form the user is not looking at.
           } else if (error instanceof z.ZodError) {
             // Show validation errors in the form
             setValidationErrors(ValidationService.formatErrors(error));
@@ -228,12 +291,112 @@ export default function AddTransactionModal({ isOpen, onClose, initialAccountId 
   );
 
 
+  /**
+   * Both legs, at the figures the person just confirmed, then the link.
+   *
+   * ── WHY THREE WRITES AND NOT ONE RPC ────────────────────────────────────
+   *
+   * `createTransferCounterpart` — the one-call route every same-currency
+   * transfer takes — mints the far side by copying −amount, and refuses across
+   * a currency boundary for exactly the right reason. So this composes the two
+   * verbs that ARE legal here: two ordinary inserts, each into its own account
+   * in its own currency, and then `link_transfer_pair`, which is balance-
+   * neutral and converts nothing. Nothing in this sequence invents a figure —
+   * both came off the dialog.
+   *
+   * ── ALL THREE, OR NONE ───────────────────────────────────────────────────
+   *
+   * Two unlinked rows are not a transfer: neither carries `linkedTransferId`
+   * and nothing ties them together, so the register would show two mystery
+   * entries and the reports would double-count the movement. Each failure
+   * therefore unwinds what came before it, in reverse.
+   */
+  const confirmConversion = async (conversion: ConfirmedConversion): Promise<void> => {
+    if (!pendingConversion) return;
+    const pending = pendingConversion;
+    const fx = buildFxRecord(conversion.rate, conversion.source, conversion.asOf);
+    const destinationAmount = destinationLegAmount(pending.amount, conversion.destinationAmount);
+
+    setConversionBusy(true);
+    let sourceId: string | null = null;
+    try {
+      // The source leg. `metadata.fx` is written at INSERT rather than patched
+      // on afterwards, so no window exists in which a converted row is in the
+      // ledger with no record of the rate that made it.
+      const source = await addTransaction({
+        description: pending.description,
+        amount: pending.amount,
+        type: 'transfer',
+        category: transferCategoryIdFor(categories, pending.targetAccountId, pending.amount),
+        accountId: pending.accountId,
+        transferAccountId: pending.targetAccountId,
+        date: new Date(pending.date),
+        notes: pending.notes,
+        metadata: { fx },
+      });
+      sourceId = source.id;
+
+      const destination = await addTransaction({
+        description: pending.description,
+        // Decimal all the way to the boundary: `toNumber` happens once, here,
+        // against a value already rounded to the penny.
+        amount: destinationAmount.toNumber(),
+        type: 'transfer',
+        category: transferCategoryIdFor(categories, pending.accountId, destinationAmount.toNumber()),
+        accountId: pending.targetAccountId,
+        transferAccountId: pending.accountId,
+        date: new Date(pending.date),
+        notes: pending.notes,
+        metadata: { fx },
+      });
+
+      try {
+        await linkTransferPair(source.id, destination.id);
+      } catch (linkError) {
+        await deleteTransaction(destination.id);
+        await deleteTransaction(source.id);
+        throw linkError;
+      }
+
+      setPendingConversion(null);
+      showSuccess('Transfer added — both sides recorded at the rate you confirmed');
+      onClose();
+    } catch (error) {
+      if (sourceId) {
+        // The destination insert failed; the source is a lone row for a
+        // movement that never happened.
+        try {
+          await deleteTransaction(sourceId);
+        } catch (rollbackError) {
+          logger.error('Could not remove the half-written transfer', rollbackError as Error);
+        }
+      }
+      showError(error);
+      logger.error('Failed to record a cross-currency transfer', error as Error);
+    } finally {
+      setConversionBusy(false);
+    }
+  };
+
   return (
     <>
-      <ResponsiveModal 
-        isOpen={isOpen} 
-        onClose={onClose} 
-        title="Add Transaction" 
+      {pendingConversion && (
+        <CrossCurrencyTransferDialog
+          isOpen
+          sourceAmount={pendingConversion.amount}
+          sourceCurrency={pendingConversion.from}
+          sourceAccountName={accounts.find(a => a.id === pendingConversion.accountId)?.name ?? 'this account'}
+          destinationCurrency={pendingConversion.to}
+          destinationAccountName={accounts.find(a => a.id === pendingConversion.targetAccountId)?.name ?? 'the other account'}
+          busy={conversionBusy}
+          onConfirm={(conversion) => { void confirmConversion(conversion); }}
+          onCancel={() => setPendingConversion(null)}
+        />
+      )}
+      <ResponsiveModal
+        isOpen={isOpen}
+        onClose={onClose}
+        title="Add Transaction"
         size="md"
         mobileSnapPoints={[0.5, 0.9]}
         mobileInitialSnapPoint={1}

--- a/src/components/ConvertedTotalNote.test.tsx
+++ b/src/components/ConvertedTotalNote.test.tsx
@@ -1,0 +1,136 @@
+import React from 'react';
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import ConvertedTotalNote from './ConvertedTotalNote';
+
+const at = (iso: string) => new Date(iso);
+
+describe('ConvertedTotalNote', () => {
+  describe('the single-currency user sees NOTHING', () => {
+    it('renders nothing when no conversion was needed', () => {
+      // provenance === null means no rates were used at all. Most people hold
+      // one currency and must never read a word about exchange rates.
+      const { container } = render(<ConvertedTotalNote provenance={null} />);
+      expect(container).toBeEmptyDOMElement();
+    });
+
+    it('renders nothing rather than an empty box or a reassurance', () => {
+      const { container } = render(<ConvertedTotalNote provenance={null} unconverted={[]} />);
+      expect(container).toBeEmptyDOMElement();
+      expect(screen.queryByTestId('converted-total-note')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('the everyday case — converted at a live quote', () => {
+    it('states the time the rates were taken', () => {
+      render(
+        <ConvertedTotalNote
+          provenance={{ source: 'api', asOf: at('2026-08-12T14:02:00.000Z') }}
+        />
+      );
+
+      // The clock time is rendered in the reader's own locale, so the assertion
+      // is on the sentence rather than on a hard-coded 14:02, which would fail
+      // in any timezone but one.
+      expect(screen.getByTestId('converted-total-note')).toHaveTextContent(
+        /^Converted at rates as of \d{1,2}:\d{2}/
+      );
+    });
+
+    it('does not shout — it is quiet text, not a chip', () => {
+      render(
+        <ConvertedTotalNote provenance={{ source: 'api', asOf: at('2026-08-12T14:02:00.000Z') }} />
+      );
+
+      const note = screen.getByTestId('converted-total-note');
+      expect(note.className).toContain('text-gray-500');
+      expect(note.className).not.toContain('font-medium');
+    });
+  });
+
+  describe('the fallback case — approximate rates', () => {
+    it('says the consequence before the reason', () => {
+      render(
+        <ConvertedTotalNote
+          provenance={{ source: 'fallback', asOf: at('2026-08-12T14:02:00.000Z') }}
+        />
+      );
+
+      const note = screen.getByTestId('converted-total-note');
+      // P6: what is wrong with the NUMBER comes first; the server's problem
+      // comes second.
+      expect(note).toHaveTextContent(/^Approximate/);
+      expect(note).toHaveTextContent(/could not be reached/);
+    });
+
+    it('is visibly distinct from the quiet state', () => {
+      const { rerender } = render(
+        <ConvertedTotalNote provenance={{ source: 'api', asOf: at('2026-08-12T14:02:00.000Z') }} />
+      );
+      const quiet = screen.getByTestId('converted-total-note').className;
+
+      rerender(
+        <ConvertedTotalNote
+          provenance={{ source: 'fallback', asOf: at('2026-08-12T14:02:00.000Z') }}
+        />
+      );
+      const loud = screen.getByTestId('converted-total-note').className;
+
+      expect(loud).not.toBe(quiet);
+      expect(loud).toContain('font-medium');
+      expect(loud).toContain('border');
+    });
+
+    it('spends no amber — the yellow thread keeps its exclusivity', () => {
+      // DESIGN_PASS_2026-08 P3: one amber in the building, and this is not it.
+      render(
+        <ConvertedTotalNote
+          provenance={{ source: 'fallback', asOf: at('2026-08-12T14:02:00.000Z') }}
+        />
+      );
+
+      const note = screen.getByTestId('converted-total-note');
+      for (const amber of ['amber', 'yellow', 'accent', 'warning']) {
+        expect(note.className).not.toContain(amber);
+      }
+    });
+  });
+
+  describe('the serious case — amounts added without conversion', () => {
+    it('says the total is WRONG, not merely approximate', () => {
+      // These amounts were summed into the figure at face value, so the total
+      // is out by however much they were worth. That is a different and worse
+      // claim than "converted at stale rates".
+      render(
+        <ConvertedTotalNote
+          provenance={{ source: 'api', asOf: at('2026-08-12T14:02:00.000Z') }}
+          unconverted={['ZZZ']}
+          displayCurrency="GBP"
+        />
+      );
+
+      const note = screen.getByTestId('converted-total-note');
+      expect(note).toHaveTextContent(/This total is wrong/);
+      expect(note).toHaveTextContent(/ZZZ/);
+    });
+
+    it('beats the approximate-rates state to the line', () => {
+      // Both are true at once here. The one that changes the figure wins.
+      render(
+        <ConvertedTotalNote
+          provenance={{ source: 'fallback', asOf: at('2026-08-12T14:02:00.000Z') }}
+          unconverted={['ZZZ']}
+        />
+      );
+
+      const note = screen.getByTestId('converted-total-note');
+      expect(note).toHaveTextContent(/This total is wrong/);
+      expect(note).not.toHaveTextContent(/^Approximate/);
+    });
+
+    it('reports even when there is no provenance at all', () => {
+      render(<ConvertedTotalNote provenance={null} unconverted={['ZZZ']} />);
+      expect(screen.getByTestId('converted-total-note')).toHaveTextContent(/This total is wrong/);
+    });
+  });
+});

--- a/src/components/ConvertedTotalNote.tsx
+++ b/src/components/ConvertedTotalNote.tsx
@@ -1,0 +1,112 @@
+import React from 'react';
+import type { RatesProvenance } from '../utils/currency-decimal';
+import { RATES_PROVIDER } from '../utils/currency-decimal';
+
+/**
+ * What a converted total was built from, said under the total itself.
+ *
+ * ── THE GAP THIS CLOSES ─────────────────────────────────────────────────────
+ *
+ * `utils/currency-decimal.ts` fetches live rates and, when the provider cannot
+ * be reached, falls back to a hardcoded table of approximations — silently. A
+ * net worth converted at a real quote and a net worth converted at a guess
+ * printed identically. This is the line that tells them apart.
+ *
+ * ── IT COSTS A SINGLE-CURRENCY USER NOTHING ─────────────────────────────────
+ *
+ * `provenance` is null when no conversion was needed, because every amount was
+ * already in the display currency (see `convertMultipleCurrenciesWithProvenance`).
+ * This component then renders NOTHING — not an empty box, not a reassuring
+ * "rates OK", nothing. Most people hold one currency and must never see a word
+ * about exchange rates on their dashboard. That is the data-health rule the app
+ * already follows for warnings: a zero count renders nothing at all.
+ *
+ * ── WHY THE ALARMED STATE IS NOT AMBER ──────────────────────────────────────
+ *
+ * DESIGN_PASS_2026-08 P3: there is ONE amber in the building and the yellow
+ * thread owns it. P2 reserves green/red/amber for what a NUMBER means, and
+ * "these rates are stale" is a statement about provenance, not about the
+ * figure's direction. So the fallback state is made distinct by WEIGHT and a
+ * hairline chip instead of by spending a colour signal — P4, weight before
+ * boxes, before colour.
+ *
+ * ── IT SAYS THE CONSEQUENCE FIRST ───────────────────────────────────────────
+ *
+ * P6, and the app's standing rule for warnings: name what is WRONG WITH THE
+ * NUMBER, not the machinery. "Live rates unavailable" is a fact about a server;
+ * "this total is approximate" is a fact about the figure the person is reading,
+ * which is the one that changes what they do next.
+ */
+
+interface ConvertedTotalNoteProps {
+  /**
+   * Where the rates came from, or null when no conversion was needed. Null
+   * renders nothing.
+   */
+  provenance: RatesProvenance | null;
+  /**
+   * Currencies that had no rate at all. Their amounts were added to the total
+   * UNCONVERTED, which makes it wrong by however much they were worth — so this
+   * is the more serious of the two states and is reported even when the rates
+   * themselves were live.
+   */
+  unconverted?: readonly string[];
+  /** The currency the total is expressed in, for the unconverted sentence. */
+  displayCurrency?: string;
+}
+
+/** 14:02 — a wall-clock time, in the reader's own locale. */
+function atTime(when: Date): string {
+  return when.toLocaleTimeString(undefined, { hour: '2-digit', minute: '2-digit' });
+}
+
+export default function ConvertedTotalNote({
+  provenance,
+  unconverted = [],
+  displayCurrency,
+}: ConvertedTotalNoteProps): React.JSX.Element | null {
+  const hasUnconverted = unconverted.length > 0;
+
+  // Nothing was converted and nothing was missed: there is nothing to say.
+  if (provenance === null && !hasUnconverted) return null;
+
+  const isApproximate = provenance?.source === 'fallback';
+
+  // The worse of the two states wins the line. A total that silently ABSORBED
+  // foreign amounts is wrong by a real quantity, where one converted at stale
+  // rates is merely imprecise — so it is stated first and on its own.
+  if (hasUnconverted) {
+    const names = unconverted.join(', ');
+    return (
+      <p
+        className="mt-2 text-dense font-medium text-primary dark:text-gray-200"
+        data-testid="converted-total-note"
+      >
+        {`This total is wrong: it includes ${names} amounts added without conversion, because no rate for ${names} was available.`}
+        {displayCurrency ? ` Everything else is in ${displayCurrency}.` : ''}
+      </p>
+    );
+  }
+
+  if (isApproximate) {
+    return (
+      <p
+        className="mt-2 inline-flex items-center gap-2 rounded border border-line-strong dark:border-gray-600 bg-surface-tertiary dark:bg-gray-700/50 px-2 py-1 text-dense font-medium text-primary dark:text-gray-200"
+        data-testid="converted-total-note"
+      >
+        {/* Consequence, then the reason — P6. */}
+        {`Approximate — converted at stored rates, not live ones. ${RATES_PROVIDER} could not be reached.`}
+      </p>
+    );
+  }
+
+  // The quiet, everyday case: converted, at a live quote, at a stated time.
+  return (
+    <p
+      className="mt-2 text-dense text-gray-500 dark:text-gray-400"
+      data-testid="converted-total-note"
+    >
+      {provenance ? `Converted at rates as of ${atTime(provenance.asOf)}` : null}
+    </p>
+  );
+}

--- a/src/components/CrossCurrencyTransferDialog.test.tsx
+++ b/src/components/CrossCurrencyTransferDialog.test.tsx
@@ -1,0 +1,183 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import CrossCurrencyTransferDialog from './CrossCurrencyTransferDialog';
+import type { ConfirmedConversion } from '../utils/crossCurrencyTransfer';
+
+/**
+ * The dialog, driven the way a person drives it.
+ *
+ * `fetch` is the ONLY thing stubbed here, and it is stubbed rather than mocked
+ * out: it is a browser API and the boundary the rates provider sits behind (the
+ * repo's testing rule mocks browser APIs and nothing else). Everything below it
+ * — the cache, the provenance, `fx.ts`'s arithmetic, the two-way recalculation
+ * — is the real code, because the arithmetic is the thing worth testing.
+ */
+
+const RATES_URL = 'https://api.exchangerate-api.com/v4/latest/GBP';
+
+/** The provider's shape: units of each currency per one GBP. */
+const quoteResponds = (rates: Record<string, number>): void => {
+  vi.stubGlobal('fetch', vi.fn(async (url: string) => {
+    if (String(url) !== RATES_URL) throw new Error(`unexpected fetch: ${url}`);
+    return { ok: true, json: async () => ({ rates }) } as unknown as Response;
+  }));
+};
+
+const quoteFails = (): void => {
+  vi.stubGlobal('fetch', vi.fn(async () => { throw new Error('offline'); }));
+};
+
+const props = {
+  isOpen: true as const,
+  sourceAmount: -100,
+  sourceCurrency: 'GBP',
+  sourceAccountName: 'Everyday',
+  destinationCurrency: 'USD',
+  destinationAccountName: 'Dollars',
+  busy: false,
+};
+
+// Found by their accessible names, which is also the assertion that they HAVE
+// accessible names: two unlabelled boxes that recalculate each other would be
+// unusable with a screen reader.
+const rateBox = (to = 'USD'): HTMLInputElement =>
+  screen.getByLabelText(new RegExp(`^Rate, ${to} per 1 GBP$`)) as HTMLInputElement;
+const arrivesBox = (to = 'USD'): HTMLInputElement =>
+  screen.getByLabelText(new RegExp(`^Amount arriving in Dollars, in ${to}$`)) as HTMLInputElement;
+
+beforeEach(() => {
+  // The rates cache is module-level and would otherwise carry one test's quote
+  // into the next.
+  vi.resetModules();
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.useRealTimers();
+});
+
+describe('CrossCurrencyTransferDialog', () => {
+  it('prefills both boxes from a live quote and says who quoted it', async () => {
+    quoteResponds({ GBP: 1, USD: 1.25 });
+    render(<CrossCurrencyTransferDialog {...props} onConfirm={vi.fn()} onCancel={vi.fn()} />);
+
+    await waitFor(() => expect(rateBox().value).toBe('1.25'));
+    // 100 × 1.25, to the penny.
+    expect(arrivesBox().value).toBe('125.00');
+    expect(screen.getByText(/exchangerate-api\.com/)).toBeInTheDocument();
+  });
+
+  it('recalculates the amount when the rate is edited', async () => {
+    quoteResponds({ GBP: 1, USD: 1.25 });
+    render(<CrossCurrencyTransferDialog {...props} onConfirm={vi.fn()} onCancel={vi.fn()} />);
+    await waitFor(() => expect(rateBox().value).toBe('1.25'));
+
+    fireEvent.change(rateBox(), { target: { value: '1.3' } });
+
+    expect(arrivesBox().value).toBe('130.00');
+    // The box being typed in is never rewritten under the cursor.
+    expect(rateBox().value).toBe('1.3');
+  });
+
+  it('recalculates the rate when the amount is edited', async () => {
+    quoteResponds({ GBP: 1, USD: 1.25 });
+    render(<CrossCurrencyTransferDialog {...props} onConfirm={vi.fn()} onCancel={vi.fn()} />);
+    await waitFor(() => expect(rateBox().value).toBe('1.25'));
+
+    // What a statement says actually arrived, spread and fee included.
+    fireEvent.change(arrivesBox(), { target: { value: '123.47' } });
+
+    expect(rateBox().value).toBe('1.2347');
+    expect(arrivesBox().value).toBe('123.47');
+  });
+
+  it('confirms an untouched live quote as api, carrying the quote’s own timestamp', async () => {
+    quoteResponds({ GBP: 1, USD: 1.25 });
+    const onConfirm = vi.fn();
+    render(<CrossCurrencyTransferDialog {...props} onConfirm={onConfirm} onCancel={vi.fn()} />);
+    await waitFor(() => expect(rateBox().value).toBe('1.25'));
+
+    fireEvent.click(screen.getByRole('button', { name: /Record both sides/ }));
+
+    const conversion = onConfirm.mock.calls[0][0] as ConfirmedConversion;
+    expect(conversion.source).toBe('api');
+    expect(conversion.rate.toString()).toBe('1.25');
+    expect(conversion.destinationAmount.toString()).toBe('125');
+  });
+
+  it('confirms an EDITED rate as manual', async () => {
+    quoteResponds({ GBP: 1, USD: 1.25 });
+    const onConfirm = vi.fn();
+    render(<CrossCurrencyTransferDialog {...props} onConfirm={onConfirm} onCancel={vi.fn()} />);
+    await waitFor(() => expect(rateBox().value).toBe('1.25'));
+
+    fireEvent.change(arrivesBox(), { target: { value: '123.47' } });
+    fireEvent.click(screen.getByRole('button', { name: /Record both sides/ }));
+
+    const conversion = onConfirm.mock.calls[0][0] as ConfirmedConversion;
+    // One keystroke makes the figure theirs, and the record says so.
+    expect(conversion.source).toBe('manual');
+    expect(conversion.destinationAmount.toString()).toBe('123.47');
+  });
+
+  it('degrades to the manual box when no rate can be had, and never blocks', async () => {
+    // The desktop edition opens a ledger file with no network behind it. A
+    // transfer between two of the owner's own accounts must not wait on a
+    // provider in another country.
+    quoteFails();
+    const onConfirm = vi.fn();
+    render(
+      <CrossCurrencyTransferDialog
+        {...props}
+        destinationCurrency="XYZ"
+        onConfirm={onConfirm}
+        onCancel={vi.fn()}
+      />
+    );
+
+    await waitFor(() => expect(screen.getByText(/No rate available offline/)).toBeInTheDocument());
+    // Consequence, then remedy (P6): what is missing, then the way through.
+    expect(screen.getByText(/Enter the rate or the amount that arrived/)).toBeInTheDocument();
+
+    // Nothing to confirm yet — but the controls work.
+    expect(screen.getByRole('button', { name: /Record both sides/ })).toBeDisabled();
+
+    fireEvent.change(rateBox('XYZ'), { target: { value: '1.1' } });
+    expect(arrivesBox('XYZ').value).toBe('110.00');
+
+    fireEvent.click(screen.getByRole('button', { name: /Record both sides/ }));
+    const conversion = onConfirm.mock.calls[0][0] as ConfirmedConversion;
+    expect(conversion.source).toBe('manual');
+    expect(conversion.rate.toString()).toBe('1.1');
+  });
+
+  it('cannot be confirmed on a half-typed box', async () => {
+    quoteResponds({ GBP: 1, USD: 1.25 });
+    render(<CrossCurrencyTransferDialog {...props} onConfirm={vi.fn()} onCancel={vi.fn()} />);
+    await waitFor(() => expect(rateBox().value).toBe('1.25'));
+
+    fireEvent.change(rateBox(), { target: { value: '' } });
+    expect(screen.getByRole('button', { name: /Record both sides/ })).toBeDisabled();
+
+    // A zero rate is not a value to be corrected — it is an entry that is not
+    // finished, and the local schema's `fx_rate_e10 > 0` would refuse it.
+    fireEvent.change(rateBox(), { target: { value: '0' } });
+    expect(screen.getByRole('button', { name: /Record both sides/ })).toBeDisabled();
+  });
+
+  it('spends no amber — the yellow thread is the only one in the building', async () => {
+    quoteResponds({ GBP: 1, USD: 1.25 });
+    const { container } = render(
+      <CrossCurrencyTransferDialog {...props} onConfirm={vi.fn()} onCancel={vi.fn()} />
+    );
+    await waitFor(() => expect(rateBox().value).toBe('1.25'));
+
+    // DESIGN_PASS_2026-08 P3. A dialog that borrowed the thread's colour would
+    // read as the next action on a page where something else is.
+    const classes = Array.from(container.querySelectorAll('*'))
+      .map(node => node.className)
+      .filter((name): name is string => typeof name === 'string')
+      .join(' ');
+    expect(classes).not.toMatch(/amber|yellow/);
+  });
+});

--- a/src/components/CrossCurrencyTransferDialog.tsx
+++ b/src/components/CrossCurrencyTransferDialog.tsx
@@ -1,0 +1,321 @@
+import React, { useEffect, useMemo, useRef, useState } from 'react';
+import { createPortal } from 'react-dom';
+import { ArrowRightLeftIcon } from './icons';
+import { formatCurrency } from '../utils/currency-decimal';
+import { toDecimal, type DecimalInstance } from '../utils/decimal';
+import {
+  AMOUNT_DP,
+  RATE_DP,
+  destinationForRate,
+  rateForDestination,
+  rateToStorageString,
+} from '../utils/fx';
+import { useFxQuote } from '../hooks/useFxQuote';
+import type { ConfirmedConversion } from '../utils/crossCurrencyTransfer';
+
+/**
+ * The one question a cross-currency transfer has to ask, asked once.
+ *
+ * ── WHY THIS DIALOG EXISTS AT ALL ───────────────────────────────────────────
+ *
+ * Writing the other leg of a transfer means writing a figure into a second
+ * account. Within one currency that figure is known — it is the same number,
+ * negated — and the app writes it without asking. Across a currency boundary it
+ * is NOT known: what a bank actually gave includes a spread and possibly a fee,
+ * and no mid-market quote is that number. The engines refuse to guess it (the
+ * counterpart mint guard, which this feature does not touch and never will), so
+ * the only honest source is the person who has the statement in front of them.
+ *
+ * So: prefill from a quote, show where the quote came from and when, and let
+ * either box be the one they edit. Whatever they confirm is what gets written,
+ * and `metadata.fx` records which of those two things happened.
+ *
+ * ── THE TWO BOXES ARE ONE FACT ──────────────────────────────────────────────
+ *
+ * Rate and destination amount are not independent fields; they are two views of
+ * the same conversion, and each is derived from the other through `fx.ts`.
+ * Typing in one recomputes the other, and the box being typed in is never
+ * rewritten under the cursor — `lastEdited` exists for that alone. A field that
+ * reformats what you are halfway through typing is the classic money-input bug
+ * and it is worse here, where the two fields would fight each other.
+ *
+ * ── DESIGN ──────────────────────────────────────────────────────────────────
+ *
+ * DESIGN_PASS_2026-08: modal radius 10 (`rounded-xl`), controls radius 6
+ * (`rounded`), one hairline `border-line` doing the separating work, and
+ * `shadow-overlay` — the one place §2.5 still allows a shadow, because an
+ * overlay floating IS the meaning. No amber anywhere (P3: the yellow thread is
+ * the only amber in the building, and this dialog is not it). The unavailable-
+ * quote line is consequence then remedy (P6). Amounts are tabular (P5).
+ */
+interface CrossCurrencyTransferDialogProps {
+  isOpen: boolean;
+  /** The leg the money leaves, ABSOLUTE, as the person entered it. */
+  sourceAmount: DecimalInstance | number | string;
+  sourceCurrency: string;
+  sourceAccountName: string;
+  destinationCurrency: string;
+  destinationAccountName: string;
+  busy: boolean;
+  onConfirm: (conversion: ConfirmedConversion) => void;
+  onCancel: () => void;
+}
+
+/** Two decimal places for money, and nothing clever about a half-typed box. */
+const asMoneyText = (value: DecimalInstance): string => value.toFixed(AMOUNT_DP);
+
+/**
+ * A box's contents as a positive finite Decimal, or `null`.
+ *
+ * Everything typed here is a magnitude — direction belongs to the legs, and
+ * `destinationLegAmount` applies it. A negative or zero entry is therefore not
+ * a value to be corrected but an entry that is not finished, which is why this
+ * returns `null` rather than clamping.
+ */
+function readPositive(text: string): DecimalInstance | null {
+  const trimmed = text.trim();
+  if (trimmed === '') return null;
+  try {
+    const value = toDecimal(trimmed);
+    if (!value.isFinite() || value.isNaN() || value.isZero() || value.isNegative()) return null;
+    return value;
+  } catch {
+    return null;
+  }
+}
+
+export default function CrossCurrencyTransferDialog({
+  isOpen,
+  sourceAmount,
+  sourceCurrency,
+  sourceAccountName,
+  destinationCurrency,
+  destinationAccountName,
+  busy,
+  onConfirm,
+  onCancel,
+}: CrossCurrencyTransferDialogProps): React.JSX.Element | null {
+  const quote = useFxQuote(isOpen ? sourceCurrency : null, isOpen ? destinationCurrency : null);
+
+  const [rateText, setRateText] = useState('');
+  const [destinationText, setDestinationText] = useState('');
+  /**
+   * Which box the person last typed in — and therefore which one must not be
+   * rewritten, and which provenance the record carries.
+   *
+   * `null` means they have touched neither, which is the only state in which a
+   * quote may still be accepted as `'api'`. One keystroke in either box makes
+   * the figure theirs.
+   */
+  const [lastEdited, setLastEdited] = useState<'rate' | 'destination' | null>(null);
+  const rateBoxRef = useRef<HTMLInputElement>(null);
+
+  const magnitude = useMemo(() => toDecimal(sourceAmount).abs(), [sourceAmount]);
+
+  // Seed both boxes from the quote, but only while the person has typed
+  // nothing. A quote that resolves late must not overwrite a rate they have
+  // already entered — on a slow connection that is a figure changing under a
+  // confirmed decision.
+  useEffect(() => {
+    if (!isOpen || lastEdited !== null) return;
+    if (quote.status !== 'ready') return;
+    setRateText(rateToStorageString(quote.rate));
+    const destination = destinationForRate(magnitude, quote.rate);
+    setDestinationText(destination.ok ? asMoneyText(destination.value) : '');
+  }, [isOpen, quote, magnitude, lastEdited]);
+
+  // Nothing to accept and nothing prefilled: put the cursor where the only
+  // usable control is, rather than making them find it.
+  useEffect(() => {
+    if (isOpen && quote.status === 'unavailable') rateBoxRef.current?.focus();
+  }, [isOpen, quote.status]);
+
+  // A fresh open is a fresh conversion. Without this a second transfer inherits
+  // the first one's rate AND its `lastEdited`, so the new quote never lands.
+  useEffect(() => {
+    if (!isOpen) {
+      setRateText('');
+      setDestinationText('');
+      setLastEdited(null);
+    }
+  }, [isOpen]);
+
+  if (!isOpen) return null;
+
+  const handleRateChange = (next: string): void => {
+    setRateText(next);
+    setLastEdited('rate');
+    const rate = readPositive(next);
+    if (!rate) return;
+    const destination = destinationForRate(magnitude, rate);
+    if (destination.ok) setDestinationText(asMoneyText(destination.value));
+  };
+
+  const handleDestinationChange = (next: string): void => {
+    setDestinationText(next);
+    setLastEdited('destination');
+    const destination = readPositive(next);
+    if (!destination) return;
+    const rate = rateForDestination(magnitude, destination);
+    if (rate.ok) setRateText(rateToStorageString(rate.value));
+  };
+
+  const destinationAmount = readPositive(destinationText);
+  const rate = readPositive(rateText);
+  const canConfirm = destinationAmount !== null && rate !== null && !busy;
+
+  /**
+   * `'api'` only if a LIVE quote was accepted with no edit at all.
+   *
+   * A fallback rate comes from the hardcoded table in `currency-decimal.ts`,
+   * which is wrong the day after it was written. Stamping that `'api'` would
+   * put the provider's name on a figure it never quoted. Accepting it is still
+   * allowed — the person is told, right under the box — but the record then
+   * says `'manual'`, because they are the one answering for it.
+   */
+  const provenance = lastEdited === null && quote.status === 'ready' && quote.source === 'api'
+    ? 'api' as const
+    : 'manual' as const;
+
+  const handleConfirm = (): void => {
+    if (!destinationAmount || !rate) return;
+    onConfirm({
+      destinationAmount: destinationAmount.toDecimalPlaces(AMOUNT_DP),
+      rate: rate.toDecimalPlaces(RATE_DP),
+      source: provenance,
+      // A quote's own timestamp when it is still the quote; otherwise now,
+      // which is when the person's figure became true.
+      asOf: provenance === 'api' && quote.status === 'ready' ? quote.asOf : new Date(),
+    });
+  };
+
+  const quotedAt = quote.status === 'ready'
+    ? quote.asOf.toLocaleTimeString(undefined, { hour: '2-digit', minute: '2-digit' })
+    : '';
+
+  const controlClass =
+    'w-full px-3 py-2 h-[42px] text-right tabular-nums bg-white dark:bg-gray-800 ' +
+    'border border-line dark:border-gray-600 rounded ' +
+    'focus:outline-none focus:ring-2 focus:ring-primary focus:border-transparent ' +
+    'text-gray-900 dark:text-white';
+
+  // Portalled to document.body for the reason TransferMatchDialog gives: a
+  // transformed ancestor re-anchors position:fixed and traps the z-index under
+  // the modal that opened this.
+  return createPortal(
+    <div
+      className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-[70] p-4"
+      onClick={(e) => { if (e.target === e.currentTarget) onCancel(); }}
+    >
+      <div
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="cross-currency-title"
+        className="bg-white dark:bg-gray-800 rounded-xl shadow-overlay p-6 w-full max-w-lg mx-4"
+      >
+        <div className="flex items-center gap-3 mb-2">
+          <ArrowRightLeftIcon size={20} className="text-primary dark:text-blue-400" />
+          <h3 id="cross-currency-title" className="text-card font-semibold text-gray-900 dark:text-white">
+            These accounts hold different currencies
+          </h3>
+        </div>
+        {/* Consequence, then remedy (P6): what is about to be written, and the
+            fact that the second figure is the one nobody knows yet. */}
+        <p className="text-body text-gray-600 dark:text-gray-400 mb-5">
+          <span className="tabular-nums">{formatCurrency(magnitude, sourceCurrency)}</span>
+          {' '}leaves {sourceAccountName}. {destinationAccountName} is in {destinationCurrency},
+          so what arrives there is a different figure — confirm it and both sides will be
+          recorded exactly as you enter them.
+        </p>
+
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-4 mb-2">
+          <div>
+            <label
+              htmlFor="cross-currency-rate"
+              className="block text-label uppercase text-gray-500 dark:text-gray-400 mb-1"
+            >
+              Rate
+            </label>
+            <div className="flex items-center gap-2">
+              <span className="text-body text-gray-500 dark:text-gray-400 whitespace-nowrap">
+                1 {sourceCurrency} =
+              </span>
+              <input
+                id="cross-currency-rate"
+                ref={rateBoxRef}
+                type="text"
+                inputMode="decimal"
+                value={rateText}
+                onChange={(e) => handleRateChange(e.target.value)}
+                disabled={busy}
+                aria-label={`Rate, ${destinationCurrency} per 1 ${sourceCurrency}`}
+                className={controlClass}
+              />
+            </div>
+          </div>
+
+          <div>
+            <label
+              htmlFor="cross-currency-destination"
+              className="block text-label uppercase text-gray-500 dark:text-gray-400 mb-1"
+            >
+              Arrives in {destinationAccountName}
+            </label>
+            <div className="flex items-center gap-2">
+              <span className="text-body text-gray-500 dark:text-gray-400">{destinationCurrency}</span>
+              <input
+                id="cross-currency-destination"
+                type="text"
+                inputMode="decimal"
+                value={destinationText}
+                onChange={(e) => handleDestinationChange(e.target.value)}
+                disabled={busy}
+                aria-label={`Amount arriving in ${destinationAccountName}, in ${destinationCurrency}`}
+                className={controlClass}
+              />
+            </div>
+          </div>
+        </div>
+
+        {/* Provenance, in the sentence the design pass asks for: who quoted it
+            and when. Neutral grey — a rate that is merely old is not a warning,
+            and an amber here would spend the one the yellow thread owns. */}
+        <p className="text-dense text-gray-500 dark:text-gray-400 mb-5 min-h-[16px]">
+          {quote.status === 'loading' && 'Fetching a rate…'}
+          {quote.status === 'ready' && quote.source === 'api' && (
+            <>1 {sourceCurrency} = <span className="tabular-nums">{rateToStorageString(quote.rate)}</span>{' '}
+            {destinationCurrency} — {quote.provider}, {quotedAt}</>
+          )}
+          {quote.status === 'ready' && quote.source === 'fallback' && (
+            <>No live rate right now, so this one is approximate — check it against your
+            statement before confirming.</>
+          )}
+          {quote.status === 'unavailable' && (
+            <>No rate available offline. Enter the rate or the amount that arrived — either
+            one fills in the other.</>
+          )}
+        </p>
+
+        <div className="flex flex-wrap gap-3 justify-end items-center">
+          <button
+            type="button"
+            onClick={onCancel}
+            disabled={busy}
+            className="px-4 py-2 border border-line dark:border-gray-600 text-gray-700 dark:text-gray-300 rounded hover:bg-gray-50 dark:hover:bg-gray-700 disabled:opacity-50"
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            onClick={handleConfirm}
+            disabled={!canConfirm}
+            className="px-4 py-2 bg-primary text-white rounded hover:bg-secondary disabled:opacity-50 disabled:cursor-not-allowed"
+          >
+            {busy ? 'Recording…' : 'Record both sides'}
+          </button>
+        </div>
+      </div>
+    </div>,
+    document.body
+  );
+}

--- a/src/components/EditTransactionModal.tsx
+++ b/src/components/EditTransactionModal.tsx
@@ -291,7 +291,13 @@ export default function EditTransactionModal({ isOpen, onClose, transaction, def
                   date: new Date(validatedData.date),
                   description: validatedData.description,
                 },
-                conversionTargetId
+                conversionTargetId,
+                undefined,
+                // The accounts are what let this see the other side of a
+                // CONVERTED transfer: opposite in sign, any magnitude, because
+                // the ratio between the magnitudes is the rate that was
+                // achieved. Without them the exact-amount rule stands.
+                { accounts }
               ),
             });
             return;

--- a/src/components/NetWorthSummary.tsx
+++ b/src/components/NetWorthSummary.tsx
@@ -1,4 +1,6 @@
 import React from 'react';
+import ConvertedTotalNote from './ConvertedTotalNote';
+import type { RatesProvenance } from '../utils/currency-decimal';
 
 /**
  * Net worth and its two components, as ONE card.
@@ -44,6 +46,22 @@ interface NetWorthSummaryProps {
    * buttons.
    */
   onSelect?: (figure: NetWorthFigure) => void;
+  /**
+   * Where the rates that produced these three figures came from, or null when
+   * no conversion was needed because the whole ledger is in one currency.
+   *
+   * Null is the common case and it renders NOTHING — see ConvertedTotalNote.
+   * The card gains no height, no border and no words for the many people who
+   * never touch a second currency.
+   */
+  provenance?: RatesProvenance | null;
+  /**
+   * Currencies with no available rate, whose amounts are nevertheless inside
+   * these totals. Reported because it makes the figures wrong by that much.
+   */
+  unconverted?: readonly string[];
+  /** The currency the three figures are expressed in. */
+  displayCurrency?: string;
 }
 
 /** The column heading over each figure. */
@@ -54,6 +72,9 @@ export default function NetWorthSummary({
   assets,
   liabilities,
   onSelect,
+  provenance = null,
+  unconverted = [],
+  displayCurrency,
 }: NetWorthSummaryProps): React.JSX.Element {
   const cells: ReadonlyArray<{
     figure: NetWorthFigure;
@@ -89,6 +110,7 @@ export default function NetWorthSummary({
   ];
 
   return (
+    <>
     <div className="overflow-hidden rounded-lg border border-line dark:border-gray-700 bg-white dark:bg-gray-800">
       {/* Hairlines between the columns, not gaps between cards: one border for
           the whole thing rather than three. They stack on a phone, where three
@@ -120,5 +142,14 @@ export default function NetWorthSummary({
         })}
       </div>
     </div>
+    {/* Directly under the figures it is about — the app's standing rule is that
+        a warning belongs where the error shows, not in a banner at the top of
+        the page. Renders nothing when there was nothing to convert. */}
+    <ConvertedTotalNote
+      provenance={provenance}
+      unconverted={unconverted}
+      displayCurrency={displayCurrency}
+    />
+    </>
   );
 }

--- a/src/components/QuickEditRow.tsx
+++ b/src/components/QuickEditRow.tsx
@@ -24,6 +24,16 @@ import { isInsideQuickEdit } from '../utils/quickEditScope';
 // The strip's arrow keys. The rule lives with the rest of the register's
 // keyboard so the printed shortcut list and the handler cannot drift apart.
 import { nextStripButtonIndex } from '../utils/registerShortcuts';
+import CrossCurrencyTransferDialog from './CrossCurrencyTransferDialog';
+import { transferCategoryIdFor } from '../utils/transferRepoint';
+import {
+  crossedCurrencies,
+  destinationLegAmount,
+  recordConvertedCounterpart,
+  type ConfirmedConversion,
+  type CrossCurrency,
+} from '../utils/crossCurrencyTransfer';
+import { amountWithCurrencyCode } from '../utils/crossCurrencyLabel';
 import type { Account, Transaction } from '../types';
 
 /**
@@ -276,6 +286,10 @@ export function QuickEditRowProvider({
     confirmTransactionCategories,
     linkTransferPair,
     createTransferCounterpart,
+    // The cross-currency route: the far side is written explicitly at a
+    // confirmed figure rather than minted, and unwound if the link fails.
+    addTransaction,
+    deleteTransaction,
   } = useApp();
   const { showError, showSuccess } = useToast();
   const { propagateCategory } = usePayeeMemory();
@@ -347,6 +361,18 @@ export function QuickEditRowProvider({
   // rather than writing blindly — in the strip, not a dialog. See TRANSFER
   // PROMPT on QuickEditActionStrip.
   const [transferPrompt, setTransferPrompt] = useState<QuickEditTransferPrompt | null>(null);
+  /**
+   * The currency pair being asked about, or null when nothing is.
+   *
+   * A DIALOG rather than the strip, unlike match-or-create above, and the
+   * difference is what is being asked for. The strip asks the user to CHOOSE
+   * between two things it can name; this asks them to supply a figure the app
+   * does not have, with two linked inputs and a provenance line — which does
+   * not fit in a row, and should not, because it is the one moment in the flow
+   * where a number nobody has verified is about to enter the ledger.
+   */
+  const [conversionPrompt, setConversionPrompt] = useState<CrossCurrency | null>(null);
+  const [conversionBusy, setConversionBusy] = useState(false);
   const advanceAfterTransferRef = useRef(false);
 
   const isTransfer = transaction?.type === 'transfer';
@@ -544,7 +570,16 @@ export function QuickEditRowProvider({
           candidates: findTransferCandidates(
             transactions,
             { ...transaction, date: parsedDate, description: description.trim() },
-            targetAccountId
+            targetAccountId,
+            undefined,
+            // With the accounts in hand this also finds the other side of a
+            // CONVERTED transfer — opposite in sign, any magnitude — which the
+            // exact-amount rule could never see. Before this, a real
+            // counterpart already sitting in a foreign-currency account was
+            // invisible and the only offer was "create the other side", which
+            // would have written a second row for money that had already
+            // arrived.
+            { accounts }
           ),
         });
       } catch (error) {
@@ -821,21 +856,68 @@ export function QuickEditRowProvider({
 
   const createTransfer = useCallback((): void => {
     if (!transaction || !transferPrompt) return;
-    // Pre-flight the RPC's cross-currency guard so the user gets a clear
-    // message without a failed server round-trip.
-    const sourceCurrency = accounts.find(a => a.id === transaction.accountId)?.currency;
-    const targetCurrency = accounts.find(a => a.id === transferPrompt.targetAccountId)?.currency;
-    if (sourceCurrency && targetCurrency && sourceCurrency !== targetCurrency) {
-      showError(new Error(
-        `Transfers between accounts in different currencies aren't supported yet (${sourceCurrency} and ${targetCurrency}).`
-      ));
+    /**
+     * Across a currency boundary the far side cannot be MINTED — the RPC would
+     * copy this row's digits into an account that counts in another currency —
+     * so the person is asked what actually arrived, and the confirmed figure is
+     * written explicitly. This used to be a flat refusal with nowhere to go.
+     */
+    const crossed = crossedCurrencies(
+      accounts,
+      transaction.accountId,
+      transferPrompt.targetAccountId
+    );
+    if (crossed) {
+      setConversionPrompt(crossed);
       return;
     }
     void completeTransfer(
       () => createTransferCounterpart(transaction.id, transferPrompt.targetAccountId),
       `Transfer created — the other side was added to ${transferPrompt.targetAccountName}.`
     );
-  }, [transaction, transferPrompt, accounts, completeTransfer, createTransferCounterpart, showError]);
+  }, [transaction, transferPrompt, accounts, completeTransfer, createTransferCounterpart]);
+
+  /**
+   * The far side, at the rate the person just confirmed, then the link, then
+   * the source's own stamp. `completeTransfer` carries the same success/dismiss
+   * behaviour every other transfer completion here gets, so a converted
+   * transfer leaves the dock exactly as an ordinary one does.
+   */
+  const confirmConversion = useCallback((conversion: ConfirmedConversion): void => {
+    if (!transaction || !transferPrompt) return;
+    setConversionBusy(true);
+    void completeTransfer(
+      () => recordConvertedCounterpart(
+        { addTransaction, updateTransaction, linkTransferPair, deleteTransaction },
+        transaction,
+        {
+          accountId: transferPrompt.targetAccountId,
+          // Each side files under the OTHER account's To/From category; the
+          // link re-files both anyway, and this is what the row names if it
+          // somehow cannot.
+          category: transferCategoryIdFor(
+            categories,
+            transaction.accountId,
+            destinationLegAmount(transaction.amount, conversion.destinationAmount).toNumber()
+          ),
+        },
+        conversion
+      ),
+      `Transfer created — ${transferPrompt.targetAccountName} received the converted amount.`
+    ).finally(() => {
+      setConversionBusy(false);
+      setConversionPrompt(null);
+    });
+  }, [
+    transaction, transferPrompt, categories, completeTransfer,
+    addTransaction, updateTransaction, linkTransferPair, deleteTransaction,
+  ]);
+
+  const cancelConversion = useCallback((): void => {
+    // Only the conversion is abandoned. The match-or-create strip stays up, so
+    // the same row can still be linked to an existing far side instead.
+    setConversionPrompt(null);
+  }, []);
 
   const cancelTransferPrompt = useCallback((): void => {
     setTransferPrompt(null);
@@ -893,6 +975,24 @@ export function QuickEditRowProvider({
   return (
     <QuickEditRowContext.Provider value={value}>
       {children}
+      {/* Portalled, so it floats over the register rather than inside a table
+          row — and rendered here rather than in the strip so it survives the
+          strip's own re-renders while a write is in flight. */}
+      {conversionPrompt && transaction && transferPrompt && (
+        <CrossCurrencyTransferDialog
+          isOpen
+          sourceAmount={transaction.amount}
+          sourceCurrency={conversionPrompt.from}
+          sourceAccountName={
+            accounts.find(a => a.id === transaction.accountId)?.name ?? 'this account'
+          }
+          destinationCurrency={conversionPrompt.to}
+          destinationAccountName={transferPrompt.targetAccountName}
+          busy={conversionBusy}
+          onConfirm={confirmConversion}
+          onCancel={cancelConversion}
+        />
+      )}
     </QuickEditRowContext.Provider>
   );
 }
@@ -1144,6 +1244,10 @@ export function QuickEditActionStrip(): React.JSX.Element {
     showingSuggestion, savingAction, hasNext, saveButtonRef, saveAndNextButtonRef,
     handleKeyDown, requestSave, confirmSuggestion, dismiss,
     transferPrompt, linkTransfer, createTransfer, cancelTransferPrompt,
+    // The row itself, for the one sentence that has to name BOTH figures: a
+    // converted pair's two amounts differ, and the strip is where the user
+    // agrees to that.
+    transaction,
   } = useQuickEditRow();
   const isSaving = savingAction !== null;
   const stripRef = useRef<HTMLDivElement>(null);
@@ -1247,9 +1351,15 @@ export function QuickEditActionStrip(): React.JSX.Element {
             className="min-w-0 truncate text-[11px] font-normal text-gray-700 dark:text-gray-300"
             aria-live="polite"
           >
-            {transferPrompt.candidates.length > 0
-              ? `Found the matching transaction in ${transferPrompt.targetAccountName} — link the two sides?`
-              : `Nothing matching in ${transferPrompt.targetAccountName} — create the other side there?`}
+            {transferPrompt.candidates.length === 0
+              ? `Nothing matching in ${transferPrompt.targetAccountName} — create the other side there?`
+              : transferPrompt.candidates[0].crossCurrency
+                /* A converted pair: the two figures WILL NOT match, and the
+                   strip has to say why before the user presses Link. Both
+                   currencies are named beside their own amount — see
+                   utils/crossCurrencyLabel. */
+                ? `${amountWithCurrencyCode(transaction.amount, transferPrompt.candidates[0].crossCurrency.from)} here against ${amountWithCurrencyCode(transferPrompt.candidates[0].transaction.amount, transferPrompt.candidates[0].crossCurrency.to)} in ${transferPrompt.targetAccountName} — different currencies; link the two sides?`
+                : `Found the matching transaction in ${transferPrompt.targetAccountName} — link the two sides?`}
           </span>
           <div
             className="flex shrink-0 items-center gap-2"

--- a/src/components/TransferMatchDialog.tsx
+++ b/src/components/TransferMatchDialog.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import { createPortal } from 'react-dom';
 import { useCurrencyDecimal } from '../hooks/useCurrencyDecimal';
+import { amountWithCurrencyCode } from '../utils/crossCurrencyLabel';
 import { ArrowRightLeftIcon } from './icons';
 import type { Transaction } from '../types';
 import type { TransferCandidate } from '../utils/transferMatch';
@@ -57,7 +58,19 @@ export default function TransferMatchDialog({
   if (!isOpen) return null;
 
   const isOutgoing = source.amount < 0;
-  const magnitude = formatCurrency(Math.abs(source.amount));
+  /**
+   * The currency boundary, when there is one. Every candidate in this list
+   * comes from the SAME account — the one the user filed this row against — so
+   * either they all cross a boundary or none does, and the first one answers
+   * for the list.
+   */
+  const crossed = candidates[0]?.crossCurrency ?? null;
+  // Across a boundary the source is shown in ITS OWN currency, not the display
+  // preference: this sentence is about to be read beside a figure in another
+  // currency, and two amounts converted to a third would explain nothing.
+  const magnitude = crossed
+    ? amountWithCurrencyCode(source.amount, crossed.from)
+    : formatCurrency(Math.abs(source.amount));
   const directionText = isOutgoing
     ? `${magnitude} from ${sourceAccountName} to ${targetAccountName}`
     : `${magnitude} from ${targetAccountName} to ${sourceAccountName}`;
@@ -85,9 +98,17 @@ export default function TransferMatchDialog({
         {candidates.length > 0 ? (
           <>
             <p className="text-sm text-gray-700 dark:text-gray-300 mb-2">
-              {candidates.length === 1
-                ? `Found the matching transaction in ${targetAccountName} — link the two sides?`
-                : `Found ${candidates.length} possible matches in ${targetAccountName} — pick the other side:`}
+              {crossed
+                /* Said before the figures are read, because the reader's first
+                   reaction to two amounts that do not match is that the app has
+                   matched the wrong rows. The difference between them IS the
+                   rate — recorded as `metadata.fx` when the link is made. */
+                ? (candidates.length === 1
+                    ? `${targetAccountName} counts in ${crossed.to}, so the two figures will not match — the difference between them is the rate this conversion got. Link the two sides?`
+                    : `${targetAccountName} counts in ${crossed.to}, so the two figures will not match — the difference between them is the rate this conversion got. Pick the other side:`)
+                : (candidates.length === 1
+                    ? `Found the matching transaction in ${targetAccountName} — link the two sides?`
+                    : `Found ${candidates.length} possible matches in ${targetAccountName} — pick the other side:`)}
             </p>
             <div className="space-y-2 mb-4 max-h-56 overflow-y-auto" role="radiogroup" aria-label="Matching transactions">
               {candidates.slice(0, 6).map(candidate => {
@@ -115,7 +136,13 @@ export default function TransferMatchDialog({
                         </p>
                       </div>
                       <span className={`shrink-0 font-medium ${t.amount >= 0 ? 'text-green-600 dark:text-green-400' : 'text-red-600 dark:text-red-400'}`}>
-                        {t.amount >= 0 ? '+' : '-'}{formatCurrency(Math.abs(t.amount))}
+                        {/* In the CANDIDATE's own currency, named. The display
+                            preference is right for a register, where every row
+                            shares one currency; here it would convert the one
+                            figure whose denomination is the point. */}
+                        {candidate.crossCurrency
+                          ? amountWithCurrencyCode(t.amount, candidate.crossCurrency.to)
+                          : `${t.amount >= 0 ? '+' : '-'}${formatCurrency(Math.abs(t.amount))}`}
                       </span>
                     </div>
                   </button>

--- a/src/components/TransferSweepModal.tsx
+++ b/src/components/TransferSweepModal.tsx
@@ -4,6 +4,8 @@ import { Modal, ModalBody, ModalFooter } from './common/Modal';
 import { useApp } from '../contexts/AppContextSupabase';
 import { useToast } from '../contexts/ToastContext';
 import { useCurrencyDecimal } from '../hooks/useCurrencyDecimal';
+import { useReferenceRates } from '../hooks/useReferenceRates';
+import { amountWithCurrencyCode } from '../utils/crossCurrencyLabel';
 import { sweepTransferPairs, type SplitLegSuggestion, type TransferPairSuggestion } from '../utils/transferSweep';
 import {
   findStrandedTransfers,
@@ -281,6 +283,10 @@ export default function TransferSweepModal({ isOpen, onClose }: Props): React.JS
     dismissSuggestion, restoreSuggestion,
   } = useApp();
   const { formatCurrency } = useCurrencyDecimal();
+  // Asked for only while the sweep is open, and used for nothing but ORDER —
+  // see useReferenceRates. If it never arrives the same rows are offered, sorted
+  // by date and wording alone.
+  const rateLookup = useReferenceRates(isOpen);
   const { showSuccess, showError } = useToast();
   const navigate = useNavigate();
   const location = useLocation();
@@ -370,8 +376,14 @@ export default function TransferSweepModal({ isOpen, onClose }: Props): React.JS
       onlyUncategorised: true,
       categoryIds: new Set(categories.map(c => c.id)),
       splits: transactionSplits,
+      // The accounts turn on the third pass: pairs that cross a CURRENCY
+      // boundary, which no amount bucket could ever have found. The rate table
+      // only orders them — a pair is never withheld because a mid-market quote
+      // disagrees with what the bank actually did.
+      accounts,
+      ...(rateLookup ? { rateLookup } : {}),
     });
-  }, [isOpen, transactions, categories, transactionSplits]);
+  }, [isOpen, transactions, categories, transactionSplits, accounts, rateLookup]);
 
   /**
    * The residue the clean sweep cannot pair. Composed with the suggestions
@@ -380,8 +392,15 @@ export default function TransferSweepModal({ isOpen, onClose }: Props): React.JS
    */
   const findings = useMemo(() => {
     if (!isOpen) return [] as StrandedFinding[];
-    return findStrandedTransfers(transactions, categories, { sweepSuggestions: suggestions }).findings;
-  }, [isOpen, transactions, categories, suggestions]);
+    return findStrandedTransfers(transactions, categories, {
+      sweepSuggestions: suggestions,
+      // So a twin that is merely in another currency is recognised as a twin,
+      // instead of the row being called one-sided and offered the Account
+      // Adjustment filing — which for a real transfer leg is a misfiling.
+      accounts,
+      ...(rateLookup ? { rateLookup } : {}),
+    }).findings;
+  }, [isOpen, transactions, categories, suggestions, accounts, rateLookup]);
 
   /** Split lines with no other side anywhere — reported, never acted on. */
   const legFindings = useMemo(() => {
@@ -762,7 +781,15 @@ export default function TransferSweepModal({ isOpen, onClose }: Props): React.JS
                           checked={effectiveSelected.has(row.key)}
                           onChange={() => toggle(row.key)}
                           disabled={applying}
-                          aria-label={`Link ${formatCurrency(Math.abs(row.pair.outgoing.amount))} transfer`}
+                          aria-label={
+                            row.pair.crossCurrency
+                              // Both figures, because they differ and the
+                              // checkbox is the whole confirmation — a label
+                              // naming one of them would understate what is
+                              // being agreed to.
+                              ? `Link ${amountWithCurrencyCode(row.pair.outgoing.amount, row.pair.crossCurrency.from)} to ${amountWithCurrencyCode(row.pair.incoming.amount, row.pair.crossCurrency.to)} transfer`
+                              : `Link ${formatCurrency(Math.abs(row.pair.outgoing.amount))} transfer`
+                          }
                           className="rounded border-gray-300"
                         />
                       </td>
@@ -778,6 +805,17 @@ export default function TransferSweepModal({ isOpen, onClose }: Props): React.JS
                           <ArrowRightIcon size={12} className="text-gray-400 flex-shrink-0" />
                           <span className="truncate max-w-[140px]">{accountName(row.pair.incoming.accountId)}</span>
                         </span>
+                        {row.pair.crossCurrency && (
+                          /* The boundary, said on the row itself. Without it
+                             two figures that do not match read as a mistake
+                             the sweep made rather than as a conversion. */
+                          <span
+                            className="ml-2 inline-flex items-center gap-1 rounded px-1.5 py-0.5 text-xs text-indigo-700 dark:text-indigo-300 bg-indigo-50 dark:bg-indigo-900/30 whitespace-nowrap"
+                            title={`These accounts count in different currencies, so the two amounts differ by whatever rate this conversion got. Linking records that rate; it creates nothing and moves no balance.`}
+                          >
+                            {row.pair.crossCurrency.from} → {row.pair.crossCurrency.to}
+                          </span>
+                        )}
                         {row.pair.ambiguous && (
                           <span
                             className="ml-2 inline-flex items-center gap-1 text-xs text-amber-700 dark:text-amber-400 underline decoration-dotted underline-offset-2"
@@ -794,7 +832,21 @@ export default function TransferSweepModal({ isOpen, onClose }: Props): React.JS
                         </span>
                       </td>
                       <td className="py-2 text-sm font-medium text-right tabular-nums text-gray-900 dark:text-white whitespace-nowrap">
-                        {formatCurrency(Math.abs(row.pair.outgoing.amount))}
+                        {row.pair.crossCurrency ? (
+                          /* BOTH sides, stacked. A converted pair has two
+                             different magnitudes and showing one of them —
+                             which is all a same-currency pair ever needs —
+                             would hide the figure being written into the other
+                             account. */
+                          <span className="flex flex-col items-end leading-tight">
+                            <span>{amountWithCurrencyCode(row.pair.outgoing.amount, row.pair.crossCurrency.from)}</span>
+                            <span className="text-xs text-gray-500 dark:text-gray-400">
+                              {amountWithCurrencyCode(row.pair.incoming.amount, row.pair.crossCurrency.to)}
+                            </span>
+                          </span>
+                        ) : (
+                          formatCurrency(Math.abs(row.pair.outgoing.amount))
+                        )}
                       </td>
                     </tr>
                   ) : (

--- a/src/constants/accountCurrencies.ts
+++ b/src/constants/accountCurrencies.ts
@@ -1,0 +1,67 @@
+/**
+ * The currencies an account may be denominated in — ONE list, offered by every
+ * form that asks.
+ *
+ * It used to live inside AddAccountModal, which was the only form that asked:
+ * an account's currency was chosen once at creation and then never shown again,
+ * anywhere. Account Settings now displays it too, and a second copy of this
+ * array is exactly how the two forms would come to disagree about what a user
+ * may pick — the failure `services/api/accountMapping` was written to end, in
+ * miniature.
+ *
+ * ── WHY THIS LIST IS SHORT, AND WHY THAT IS NOT THE WHOLE STORY ──────────────
+ *
+ * Three entries, because these are the three the product supports end to end
+ * (rates, formatting, the cross-currency transfer flow). But a STORED currency
+ * need not be one of them — an account can arrive from a backup restore or an
+ * MS Money import holding anything at all — so no form may assume its account's
+ * currency is in here. {@link accountCurrencyOptions} is the function that
+ * settles that: it always includes the account's own code, because a `<select>`
+ * whose value is missing from its own option list silently displays something
+ * else, and saving that would re-denominate the account to whatever happened to
+ * be first.
+ */
+
+export interface AccountCurrencyOption {
+  /** ISO 4217 code, as stored on the account. */
+  value: string;
+  /** The currency's name, for the option's text. */
+  label: string;
+  symbol: string;
+}
+
+export const ACCOUNT_CURRENCIES: readonly AccountCurrencyOption[] = [
+  { value: 'GBP', label: 'British Pound', symbol: '£' },
+  { value: 'USD', label: 'US Dollar', symbol: '$' },
+  { value: 'EUR', label: 'Euro', symbol: '€' },
+];
+
+/**
+ * The options a form should offer for an account that currently holds `code`.
+ *
+ * The supported list, plus `code` itself when it is not already in it. An
+ * unknown code is offered under its own name — there is nothing else truthful
+ * to call it, and hiding it would be the silent re-denomination described
+ * above.
+ *
+ * `code` is optional so a creation form, which has no account yet, gets the
+ * plain supported list.
+ */
+export function accountCurrencyOptions(code?: string): readonly AccountCurrencyOption[] {
+  if (!code) return ACCOUNT_CURRENCIES;
+  if (ACCOUNT_CURRENCIES.some(option => option.value === code)) return ACCOUNT_CURRENCIES;
+  return [...ACCOUNT_CURRENCIES, { value: code, label: code, symbol: code }];
+}
+
+/**
+ * How a currency reads when it is being SHOWN rather than chosen: "£ British
+ * Pound (GBP)", or just the code when the app has no name for it.
+ *
+ * The code is always present, even for a currency this list knows, because the
+ * code is what the account actually stores and what every other screen and
+ * every export will show.
+ */
+export function describeAccountCurrency(code: string): string {
+  const option = ACCOUNT_CURRENCIES.find(entry => entry.value === code);
+  return option ? `${option.symbol} ${option.label} (${option.value})` : code;
+}

--- a/src/contexts/AppContextSupabase.tsx
+++ b/src/contexts/AppContextSupabase.tsx
@@ -95,6 +95,7 @@ import {
   BULK_TRANSFER_FILING_REFUSAL,
   categoryIdIsTransferFiling,
 } from '../utils/transferCoherence';
+import { fxForLinkedPair, withFxRecord } from '../utils/crossCurrencyTransfer';
 import {
   releaseUpdatesFor,
   survivorsOfDeletedLeg,
@@ -476,6 +477,19 @@ export function AppProvider({ children }: { children: React.ReactNode }) {
   const updateDebounceRef = useRef<NodeJS.Timeout | null>(null);
   // Suppress real-time reloads shortly after a local write to prevent overwriting optimistic updates
   const recentLocalUpdateRef = useRef<number>(0);
+  /**
+   * The accounts as they are right now, for callbacks that must not be rebuilt
+   * every time a balance moves.
+   *
+   * `linkTransferPair` needs two accounts' CURRENCIES to know whether the pair
+   * it just joined was a conversion. Taking `accounts` as a dependency would
+   * give that callback a new identity on every balance change — and it is
+   * handed to memoised children — so it reads the ref instead.
+   */
+  const accountsRef = useRef<Account[]>([]);
+  useEffect(() => {
+    accountsRef.current = accounts;
+  }, [accounts]);
 
   // Initialize data service and load data
   useEffect(() => {
@@ -1307,11 +1321,52 @@ export function AppProvider({ children }: { children: React.ReactNode }) {
   const linkTransferPair = useCallback(async (idA: string, idB: string) => {
     try {
       const result = await dataPort.linkTransferPair(idA, idB);
+
+      /**
+       * THE DERIVED RATE, RECORDED HERE AND NOWHERE ELSE.
+       *
+       * Every link in the product comes through this one function — the
+       * register, the quick-edit dock, the sweep, the coherence repair — so
+       * this is the only place the stamp cannot be forgotten by a new call
+       * site. Deriving it in each caller was the alternative and it is how
+       * three of the four end up without it.
+       *
+       * Nothing is ASKED here, deliberately. Both amounts already existed and
+       * their ratio is the rate that was really achieved, spread and fees
+       * included. A dialog at this point would invite someone to overwrite a
+       * fact with an opinion. `fxForLinkedPair` returns null when the accounts
+       * share a currency, and — importantly — when either leg already carries
+       * an `fx` record, so the confirmed provenance the creation flow wrote is
+       * never downgraded to 'derived'.
+       */
+      let { a, b } = result;
+      const fx = fxForLinkedPair(accountsRef.current, a, b, new Date());
+      if (fx) {
+        // Written to BOTH legs unchanged: the rate is a property of the
+        // CONVERSION, not of either row.
+        const metadataA = withFxRecord(a.metadata, fx);
+        const metadataB = withFxRecord(b.metadata, fx);
+        try {
+          await Promise.all([
+            dataPort.updateTransaction(a.id, { metadata: metadataA }),
+            dataPort.updateTransaction(b.id, { metadata: metadataB }),
+          ]);
+          a = { ...a, metadata: metadataA };
+          b = { ...b, metadata: metadataB };
+        } catch (stampError) {
+          // The LINK succeeded and is what the user asked for. Losing the
+          // provenance stamp costs a figure its receipt, which is worth
+          // logging; failing the whole operation over it would unlink two rows
+          // the ledger has correctly joined, which is worse.
+          appLogger.error('Linked the pair but could not record its rate', stampError);
+        }
+      }
+
       // Balance-neutral: both rows existed with these amounts already.
       setTransactions(prev => prev.map(t =>
-        t.id === result.a.id ? result.a : t.id === result.b.id ? result.b : t
+        t.id === a.id ? a : t.id === b.id ? b : t
       ));
-      return result;
+      return { a, b };
     } catch (error) {
       appLogger.error('Failed to link transfer pair', error);
       throw error;

--- a/src/contexts/__tests__/AppContextSupabase.test.tsx
+++ b/src/contexts/__tests__/AppContextSupabase.test.tsx
@@ -21,6 +21,8 @@ import { renderHook, act, waitFor } from '@testing-library/react';
 import type { Account, Transaction } from '../../types';
 import { toDecimal } from '../../utils/decimal';
 import { signTransactionAmount } from '../../utils/transactionAmount';
+import { sweepTransferPairs } from '../../utils/transferSweep';
+import { readFxRecord } from '../../utils/fx';
 
 // Restore the live module (setup.ts registers a global mock for it).
 vi.unmock('../AppContextSupabase');
@@ -647,6 +649,124 @@ describe('AppContextSupabase live provider', () => {
       expect(result.current.accounts[0].balance).toBe(
         signedBalance(1000, result.current.transactions)
       );
+    });
+  });
+
+  /**
+   * ── THE WHOLE CHAIN, FROM MATCHER TO RECEIPT ──────────────────────────────
+   *
+   * The cross-currency matcher's output is only worth anything if ACCEPTING it
+   * records the rate. That is not a property of the matcher and not a property
+   * of the UI: every link in the product goes through this provider's
+   * `linkTransferPair`, which derives the rate from the two amounts and stamps
+   * `metadata.fx` on both legs.
+   *
+   * So this test runs the real matcher over the real provider's state, feeds
+   * its suggestion straight back into the real `linkTransferPair`, and reads
+   * the stamp out of the resulting state. Nothing between the sweep and the
+   * receipt is stubbed, which is the only way to know the two ends are actually
+   * joined — reading the code and finding a call to the right function proves
+   * that the code says so, not that it happens.
+   */
+  describe('accepting a cross-currency suggestion', () => {
+    it('links the pair the sweep offers and records the rate it implies', async () => {
+      const { result } = await renderApp();
+
+      let sterling!: Account;
+      let dollars!: Account;
+      await act(async () => {
+        sterling = await result.current.addAccount(createAccountInput({
+          name: 'Everyday Current', currency: 'GBP',
+        }));
+        dollars = await result.current.addAccount(createAccountInput({
+          name: 'Dollar Savings', currency: 'USD',
+        }));
+      });
+
+      // The two sides of one conversion: opposite in sign, magnitudes that no
+      // amount bucket could ever have matched, a day apart.
+      let out!: Transaction;
+      let into!: Transaction;
+      await act(async () => {
+        out = await result.current.addTransaction(createTransactionInput(sterling.id, {
+          description: 'Transfer to dollar savings',
+          amount: -100,
+          category: '',
+          date: new Date('2025-02-10T00:00:00Z'),
+        }));
+        into = await result.current.addTransaction(createTransactionInput(dollars.id, {
+          description: 'Incoming transfer',
+          amount: 136.25,
+          type: 'income',
+          category: '',
+          date: new Date('2025-02-11T00:00:00Z'),
+        }));
+      });
+
+      // The matcher, on the state the app actually holds.
+      const { suggestions } = sweepTransferPairs(result.current.transactions, {
+        accounts: result.current.accounts,
+      });
+      expect(suggestions).toHaveLength(1);
+      expect(suggestions[0].crossCurrency).toEqual({ from: 'GBP', to: 'USD' });
+      expect(suggestions[0].outgoing.id).toBe(out.id);
+      expect(suggestions[0].incoming.id).toBe(into.id);
+
+      // Accepted exactly as the sweep's Apply accepts one.
+      await act(async () => {
+        await result.current.linkTransferPair(
+          suggestions[0].outgoing.id,
+          suggestions[0].incoming.id
+        );
+      });
+
+      const linkedOut = result.current.transactions.find(t => t.id === out.id);
+      const linkedIn = result.current.transactions.find(t => t.id === into.id);
+      expect(linkedOut?.linkedTransferId).toBe(into.id);
+      expect(linkedIn?.linkedTransferId).toBe(out.id);
+
+      const fxOut = readFxRecord(linkedOut?.metadata);
+      const fxIn = readFxRecord(linkedIn?.metadata);
+
+      // 'derived', never 'api' or 'manual': nobody was asked and nobody had to
+      // be. Both amounts were already real, so their ratio is the rate the
+      // money actually got, spread and fees included.
+      expect(fxOut?.source).toBe('derived');
+      // 136.25 / 100 — destination units per one source unit, exact.
+      expect(fxOut?.rate).toBe('1.3625');
+      // The rate is a property of the CONVERSION, not of either row, so two
+      // legs disagreeing about it would have no correct reading.
+      expect(fxIn).toEqual(fxOut);
+    });
+
+    it('records nothing when the two accounts share a currency', async () => {
+      const { result } = await renderApp();
+
+      let one!: Account;
+      let two!: Account;
+      await act(async () => {
+        one = await result.current.addAccount(createAccountInput({ name: 'A', currency: 'GBP' }));
+        two = await result.current.addAccount(createAccountInput({ name: 'B', currency: 'GBP' }));
+      });
+
+      let out!: Transaction;
+      let into!: Transaction;
+      await act(async () => {
+        out = await result.current.addTransaction(createTransactionInput(one.id, {
+          amount: -100, category: '', date: new Date('2025-02-10T00:00:00Z'),
+        }));
+        into = await result.current.addTransaction(createTransactionInput(two.id, {
+          amount: 100, type: 'income', category: '', date: new Date('2025-02-10T00:00:00Z'),
+        }));
+      });
+
+      await act(async () => {
+        await result.current.linkTransferPair(out.id, into.id);
+      });
+
+      // Nothing was converted, so a rate of 1 would be a fact about arithmetic
+      // rather than about money.
+      expect(readFxRecord(result.current.transactions.find(t => t.id === out.id)?.metadata)).toBeNull();
     });
   });
 });

--- a/src/data/defaultTestData.ts
+++ b/src/data/defaultTestData.ts
@@ -502,15 +502,7 @@ export const getDefaultTestTransactions = (): Transaction[] => {
       type: 'expense',
       category: 'Investments',
       accountId: inv.accountId,
-      cleared: true,
-      investmentData: {
-        symbol: inv.symbol,
-        quantity: inv.quantity,
-        pricePerShare: inv.purchasePrice,
-        transactionFee: transactionFee,
-        stampDuty: stampDuty,
-        totalCost: totalCost
-      }
+      cleared: true
     });
   });
   

--- a/src/design-system/__tests__/semantic-contrast.test.ts
+++ b/src/design-system/__tests__/semantic-contrast.test.ts
@@ -21,6 +21,13 @@
  *    but 4.34:1 on the cards where amounts actually sit.
  *
  * No hue is pinned — a future rebrand only has to keep measuring honest.
+ *
+ * THE RULE THIS FILE EXISTS TO ENFORCE (pinned at Claude Design's own request,
+ * after its calculated figures failed here twice): contrast is measured
+ * against the SURFACE the text sits on, not the page it sits in. A colour
+ * that clears the gray-900 page can fail the gray-800 card two pixels away —
+ * which is exactly how #0d9f6f died as a dark-mode text candidate. Every pair
+ * below therefore measures against BOTH surfaces of its mode.
  */
 import { describe, it, expect } from 'vitest';
 import { readFileSync } from 'node:fs';

--- a/src/hooks/useConvertedNetWorth.test.ts
+++ b/src/hooks/useConvertedNetWorth.test.ts
@@ -1,0 +1,170 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+import { useConvertedNetWorth } from './useConvertedNetWorth';
+
+/**
+ * The net-worth card's three figures, summed across currencies.
+ *
+ * Every balance here is invented — the repo is public.
+ */
+describe('useConvertedNetWorth', () => {
+  const mockFetch = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    global.fetch = mockFetch;
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ base: 'GBP', rates: { GBP: 1, USD: 1.25, EUR: 1.2 } }),
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe('a single-currency ledger pays nothing', () => {
+    const entries = [
+      { balance: 1000, currency: 'GBP' },
+      { balance: 250, currency: 'GBP' },
+      { balance: -400, currency: 'GBP' },
+    ];
+
+    it('answers on the FIRST render, with no request and no loading state', () => {
+      const { result } = renderHook(() => useConvertedNetWorth(entries, 'GBP'));
+
+      // No await anywhere: the figures are arithmetic and are available now.
+      expect(result.current.isReady).toBe(true);
+      expect(result.current.assets.toString()).toBe('1250');
+      expect(result.current.liabilities.toString()).toBe('400');
+      expect(result.current.netWorth.toString()).toBe('850');
+      expect(mockFetch).not.toHaveBeenCalled();
+    });
+
+    it('reports no provenance, so the card says nothing about rates', () => {
+      const { result } = renderHook(() => useConvertedNetWorth(entries, 'GBP'));
+
+      expect(result.current.provenance).toBeNull();
+      expect(result.current.unconverted).toEqual([]);
+    });
+
+    it('treats a zero balance as neither an asset nor a liability', () => {
+      const { result } = renderHook(() =>
+        useConvertedNetWorth([{ balance: 0, currency: 'GBP' }, { balance: 100, currency: 'GBP' }], 'GBP')
+      );
+
+      expect(result.current.assets.toString()).toBe('100');
+      expect(result.current.liabilities.toString()).toBe('0');
+    });
+  });
+
+  describe('a mixed-currency ledger is converted', () => {
+    it('converts each balance before summing', async () => {
+      const { result } = renderHook(() =>
+        useConvertedNetWorth(
+          [
+            { balance: 1000, currency: 'GBP' },
+            // 250 USD at 1.25 per GBP is 200 GBP.
+            { balance: 250, currency: 'USD' },
+          ],
+          'GBP'
+        )
+      );
+
+      await waitFor(() => expect(result.current.isReady).toBe(true));
+
+      expect(result.current.assets.toString()).toBe('1200');
+      expect(result.current.netWorth.toString()).toBe('1200');
+    });
+
+    it('does NOT show the raw cross-currency sum while converting', () => {
+      // The figure that would appear if the totals were rendered before the
+      // conversion landed is 1250 — a dollar counted as a pound. It must never
+      // reach the screen, not even briefly.
+      const { result } = renderHook(() =>
+        useConvertedNetWorth(
+          [{ balance: 1000, currency: 'GBP' }, { balance: 250, currency: 'USD' }],
+          'GBP'
+        )
+      );
+
+      expect(result.current.isReady).toBe(false);
+      expect(result.current.netWorth.toString()).not.toBe('1250');
+      expect(result.current.netWorth.toString()).toBe('0');
+    });
+
+    it('converts liabilities as well as assets', async () => {
+      const { result } = renderHook(() =>
+        useConvertedNetWorth(
+          [
+            { balance: 1000, currency: 'GBP' },
+            // -500 USD is -400 GBP.
+            { balance: -500, currency: 'USD' },
+          ],
+          'GBP'
+        )
+      );
+
+      await waitFor(() => expect(result.current.isReady).toBe(true));
+
+      expect(result.current.assets.toString()).toBe('1000');
+      expect(result.current.liabilities.toString()).toBe('400');
+      expect(result.current.netWorth.toString()).toBe('600');
+    });
+
+    it('reports the provenance of the rates it used', async () => {
+      const { result } = renderHook(() =>
+        useConvertedNetWorth(
+          [{ balance: 1000, currency: 'GBP' }, { balance: 250, currency: 'USD' }],
+          'GBP'
+        )
+      );
+
+      await waitFor(() => expect(result.current.isReady).toBe(true));
+
+      expect(result.current.provenance?.source).toBe('api');
+    });
+
+    it('reports the fallback when the provider cannot be reached', async () => {
+      const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+      mockFetch.mockReset().mockRejectedValue(new Error('offline'));
+
+      // A COLD module graph. The rates cache is module state and an earlier
+      // test in this file already cached a live quote for the hour — without
+      // this the hook would answer from that cache and never attempt the fetch
+      // this test is about.
+      vi.resetModules();
+      const { useConvertedNetWorth: coldHook } = await import('./useConvertedNetWorth');
+
+      const { result } = renderHook(() =>
+        coldHook(
+          [{ balance: 1000, currency: 'GBP' }, { balance: 250, currency: 'USD' }],
+          'GBP'
+        )
+      );
+
+      await waitFor(() => expect(result.current.isReady).toBe(true));
+
+      // An offline desktop still gets its totals — they just say what they are.
+      expect(result.current.provenance?.source).toBe('fallback');
+      expect(result.current.netWorth.isZero()).toBe(false);
+      consoleErrorSpy.mockRestore();
+    });
+
+    it('names a currency it had no rate for', async () => {
+      const consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+      const { result } = renderHook(() =>
+        useConvertedNetWorth(
+          [{ balance: 1000, currency: 'GBP' }, { balance: 250, currency: 'ZZZ' }],
+          'GBP'
+        )
+      );
+
+      await waitFor(() => expect(result.current.isReady).toBe(true));
+
+      expect(result.current.unconverted).toEqual(['ZZZ']);
+      consoleWarnSpy.mockRestore();
+    });
+  });
+});

--- a/src/hooks/useConvertedNetWorth.ts
+++ b/src/hooks/useConvertedNetWorth.ts
@@ -1,0 +1,172 @@
+import { useEffect, useMemo, useState } from 'react';
+import { Decimal, toDecimal } from '../utils/decimal';
+import type { DecimalInstance } from '../utils/decimal';
+import {
+  convertMultipleCurrenciesWithProvenance,
+  type RatesProvenance,
+} from '../utils/currency-decimal';
+
+/**
+ * Net worth, assets and liabilities summed ACROSS currencies — properly.
+ *
+ * ── WHAT WAS WRONG ──────────────────────────────────────────────────────────
+ *
+ * The net-worth card's three figures were a raw sum of every account's balance
+ * with no conversion anywhere in the path (`calculateTotalBalance` adds the
+ * numbers; `toDecimal` changes their TYPE, not their currency), and the result
+ * was then formatted in the DISPLAY currency. A dollar balance was therefore
+ * added to sterling balances one-for-one and the answer was printed with a "£".
+ *
+ * The app had already written down why that is not allowed, in
+ * `calculations-decimal.ts`: adding two currencies "would report a number that
+ * is true in no currency at all". Budgets obey it by setting foreign rows aside
+ * and disclosing them. The net-worth card did not.
+ *
+ * ── A SINGLE-CURRENCY USER PAYS NOTHING ─────────────────────────────────────
+ *
+ * When every account is already in the display currency there is no rate to
+ * fetch and nothing to disclose, so this hook computes the three figures
+ * SYNCHRONOUSLY on the first render and reports `provenance: null`. No request,
+ * no effect, no loading state, no flicker from a raw total to a converted one —
+ * and `ConvertedTotalNote` renders nothing at all. That is the common case and
+ * it must stay free.
+ */
+
+export interface AccountBalanceEntry {
+  /** The account's balance, already computed by the caller's own rules. */
+  balance: number | DecimalInstance;
+  /** The currency that balance is held in. */
+  currency: string;
+}
+
+export interface ConvertedNetWorth {
+  netWorth: DecimalInstance;
+  assets: DecimalInstance;
+  liabilities: DecimalInstance;
+  /** Null when no conversion was needed. See {@link ConvertedTotalNote}. */
+  provenance: RatesProvenance | null;
+  /** Currencies with no rate; their amounts are in the totals unconverted. */
+  unconverted: readonly string[];
+  /**
+   * False only while a genuine cross-currency conversion is in flight. Never
+   * false for a single-currency ledger, which resolves on the first render.
+   */
+  isReady: boolean;
+}
+
+/** Assets are the positive balances, liabilities the magnitude of the negative. */
+function split(entries: readonly AccountBalanceEntry[]) {
+  const assets: Array<{ amount: DecimalInstance; currency: string }> = [];
+  const liabilities: Array<{ amount: DecimalInstance; currency: string }> = [];
+
+  for (const { balance, currency } of entries) {
+    const amount = toDecimal(balance);
+    // A zero balance is neither an asset nor a liability, and is skipped by
+    // both branches rather than counted as one.
+    if (amount.isZero()) continue;
+    if (amount.isNegative()) {
+      liabilities.push({ amount: amount.abs(), currency });
+    } else {
+      assets.push({ amount, currency });
+    }
+  }
+
+  return { assets, liabilities };
+}
+
+const sum = (amounts: ReadonlyArray<{ amount: DecimalInstance }>): DecimalInstance =>
+  amounts.reduce((total, { amount }) => total.plus(amount), new Decimal(0));
+
+export function useConvertedNetWorth(
+  entries: readonly AccountBalanceEntry[],
+  displayCurrency: string
+): ConvertedNetWorth {
+  const { assets, liabilities } = useMemo(() => split(entries), [entries]);
+
+  /**
+   * The whole ledger already reads in one currency. Nothing to convert, so the
+   * answer is arithmetic and is available now — see the header.
+   */
+  const isSingleCurrency = useMemo(
+    () => entries.every(entry => entry.currency === displayCurrency),
+    [entries, displayCurrency]
+  );
+
+  const synchronous = useMemo<ConvertedNetWorth>(() => {
+    const assetTotal = sum(assets);
+    const liabilityTotal = sum(liabilities);
+    return {
+      netWorth: assetTotal.minus(liabilityTotal),
+      assets: assetTotal,
+      liabilities: liabilityTotal,
+      provenance: null,
+      unconverted: [],
+      isReady: true,
+    };
+  }, [assets, liabilities]);
+
+  const [converted, setConverted] = useState<ConvertedNetWorth | null>(null);
+
+  useEffect(() => {
+    if (isSingleCurrency) {
+      setConverted(null);
+      return;
+    }
+
+    // Guards against a slow response landing after the accounts changed and
+    // overwriting the newer figures with older ones.
+    let cancelled = false;
+
+    const run = async (): Promise<void> => {
+      const [assetResult, liabilityResult] = await Promise.all([
+        convertMultipleCurrenciesWithProvenance(assets, displayCurrency),
+        convertMultipleCurrenciesWithProvenance(liabilities, displayCurrency),
+      ]);
+      if (cancelled) return;
+
+      // One list may be empty (a ledger with no debts), and an empty list
+      // reports no provenance — so the disclosure comes from whichever side
+      // actually used rates.
+      const provenance = assetResult.provenance ?? liabilityResult.provenance;
+      const unconverted = [
+        ...new Set([...assetResult.unconverted, ...liabilityResult.unconverted]),
+      ];
+
+      setConverted({
+        netWorth: assetResult.total.minus(liabilityResult.total),
+        assets: assetResult.total,
+        liabilities: liabilityResult.total,
+        provenance,
+        unconverted,
+        isReady: true,
+      });
+    };
+
+    void run();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [assets, liabilities, displayCurrency, isSingleCurrency]);
+
+  if (isSingleCurrency) return synchronous;
+
+  /**
+   * Mixed currencies, conversion still in flight.
+   *
+   * The totals read ZERO rather than the raw cross-currency sum. Showing the
+   * unconverted figure first would put a number on screen that is true in no
+   * currency — briefly, and then correct itself, which is the worst of both:
+   * long enough to be read, short enough not to be questioned.
+   */
+  return (
+    converted ?? {
+      netWorth: new Decimal(0),
+      assets: new Decimal(0),
+      liabilities: new Decimal(0),
+      provenance: null,
+      unconverted: [],
+      isReady: false,
+    }
+  );
+}

--- a/src/hooks/useFxQuote.ts
+++ b/src/hooks/useFxQuote.ts
@@ -1,0 +1,134 @@
+import { useEffect, useState } from 'react';
+import { Decimal, type DecimalInstance } from '../utils/decimal';
+import { RATE_DP } from '../utils/fx';
+import {
+  RATES_PROVIDER,
+  getExchangeRatesWithProvenance,
+  type RatesSource,
+} from '../utils/currency-decimal';
+import { createScopedLogger } from '../loggers/scopedLogger';
+
+const logger = createScopedLogger('useFxQuote');
+
+/**
+ * What the rate box opens with, and how much the app is prepared to say for it.
+ *
+ * ── THE STATE THAT MATTERS IS `unavailable`, NOT `ready` ────────────────────
+ *
+ * The desktop edition opens a ledger file with no network behind it, and a
+ * transfer between two of the owner's own accounts is not a thing that should
+ * wait on a rates provider in another country. So a failed quote is a NORMAL
+ * state here, not an error path: the dialog stays open, the manual box is the
+ * one control that always works, and nothing about the flow is blocked. That is
+ * the whole reason this is a discriminated union rather than
+ * `rate: Decimal | null` — "we have not asked yet" and "we asked and there is
+ * no answer" want different sentences on screen, and `null` cannot tell them
+ * apart.
+ */
+export type FxQuote =
+  /** The request is in flight. Nothing is shown but the manual box. */
+  | { status: 'loading' }
+  /** A figure, and enough provenance to account for it. */
+  | {
+      status: 'ready';
+      rate: DecimalInstance;
+      /** Where the underlying table came from — see {@link RatesSource}. */
+      source: RatesSource;
+      /** When the rate was true. */
+      asOf: Date;
+      /** Who quoted it, for the sentence under the box. */
+      provider: string;
+    }
+  /**
+   * No usable figure. Either the provider could not be reached and the fallback
+   * table does not carry the pair, or one of the two codes is not in it at all.
+   * The person types the rate; the flow continues.
+   */
+  | { status: 'unavailable' };
+
+/**
+ * A live-ish quote for one currency pair, or an honest admission that there
+ * isn't one.
+ *
+ * ── WHY THE DIVISION HAPPENS HERE AND NOT IN `fx.ts` ────────────────────────
+ *
+ * `fx.ts` is deliberately "the arithmetic of one cross-currency transfer, and
+ * nothing else" — it knows about two amounts and a rate. This knows about the
+ * rates TABLE, which is a different fact: `getExchangeRates` returns units of
+ * each currency per one GBP, so the rate from A to B is `rates[B] / rates[A]`
+ * and GBP is only the pivot. Putting that in `fx.ts` would give that file a
+ * base currency, which is exactly the thing it has no opinion about.
+ *
+ * The provider's numbers arrive as JSON, so they are IEEE doubles by the time
+ * any parser has seen them — there is no representation to preserve, only one
+ * to stop losing. They become Decimals at the first opportunity, before the
+ * division, and the quotient is rounded once to {@link RATE_DP}. Every
+ * subsequent figure in this feature is exact decimal arithmetic from here.
+ *
+ * @param from source currency code, or `null` to ask nothing
+ * @param to destination currency code, or `null` to ask nothing
+ */
+export function useFxQuote(from: string | null, to: string | null): FxQuote {
+  const [quote, setQuote] = useState<FxQuote>({ status: 'loading' });
+
+  useEffect(() => {
+    if (!from || !to || from === to) {
+      setQuote({ status: 'unavailable' });
+      return;
+    }
+
+    // Guards the two awaits below: a dialog closed mid-flight, or a pair
+    // changed under it, must not have its answer written into the new state.
+    let live = true;
+    setQuote({ status: 'loading' });
+
+    void (async () => {
+      try {
+        const { rates, provenance } = await getExchangeRatesWithProvenance();
+        if (!live) return;
+
+        const fromRate = rates[from];
+        const toRate = rates[to];
+        // A pair the table does not carry is `unavailable`, not an error and
+        // not a rate of 1. Silently treating a missing code as parity is how a
+        // transfer gets written at the wrong figure with nobody told.
+        if (!fromRate || !toRate) {
+          setQuote({ status: 'unavailable' });
+          return;
+        }
+
+        const rate = new Decimal(toRate)
+          .dividedBy(new Decimal(fromRate))
+          .toDecimalPlaces(RATE_DP, Decimal.ROUND_HALF_UP);
+        if (!rate.isFinite() || rate.isZero() || rate.isNegative()) {
+          // A non-positive rate would be refused by the local schema's
+          // `fx_rate_e10 > 0` CHECK if it ever reached storage. Refused here
+          // instead, where there is still a person to ask.
+          setQuote({ status: 'unavailable' });
+          return;
+        }
+
+        setQuote({
+          status: 'ready',
+          rate,
+          source: provenance.source,
+          asOf: provenance.asOf,
+          provider: RATES_PROVIDER,
+        });
+      } catch (error) {
+        if (!live) return;
+        // Not rethrown and not shown as a failure: see the type's header. The
+        // logger is so an offline desktop is diagnosable, not so anybody is
+        // interrupted.
+        logger.warn('No exchange-rate quote available; the rate will be typed', error);
+        setQuote({ status: 'unavailable' });
+      }
+    })();
+
+    return () => {
+      live = false;
+    };
+  }, [from, to]);
+
+  return quote;
+}

--- a/src/hooks/useReferenceRates.ts
+++ b/src/hooks/useReferenceRates.ts
@@ -1,0 +1,83 @@
+import { useCallback, useEffect, useState } from 'react';
+import { Decimal } from '../utils/decimal';
+import { RATE_DP } from '../utils/fx';
+import { getExchangeRatesWithProvenance } from '../utils/currency-decimal';
+import type { CrossCurrencyRateLookup } from '../utils/crossCurrencyMatch';
+import { createScopedLogger } from '../loggers/scopedLogger';
+
+const logger = createScopedLogger('useReferenceRates');
+
+/**
+ * The rate table's own shape, read off the function that produces it rather
+ * than re-declared. `ExchangeRates` is private to currency-decimal, and a
+ * hand-written copy here would be a second declaration free to drift from the
+ * one that is actually returned.
+ */
+type RateTable = Awaited<ReturnType<typeof getExchangeRatesWithProvenance>>['rates'];
+
+/**
+ * A whole rate TABLE, for sorting cross-currency suggestions — not for judging
+ * any one of them.
+ *
+ * `useFxQuote` answers one pair because a dialog asks about one transfer. The
+ * bulk sweep asks about a list, and each row may cross a different boundary, so
+ * what it needs is a lookup rather than a quote. What both share is the pivot
+ * arithmetic: `getExchangeRates` returns units of each currency per one GBP, so
+ * the rate from A to B is `rates[B] / rates[A]` and GBP is only the pivot.
+ *
+ * ── THIS RESULT CAN NEVER REMOVE A ROW FROM THE LIST ────────────────────────
+ *
+ * The only consumer is `compareCrossCurrencyCandidates`, which SORTS. That is a
+ * deliberate ceiling and the reason this hook returns a lookup rather than, say,
+ * a filter predicate: a real bank conversion on a volatile day, or one with a
+ * large fee, implies a rate that a mid-market table disagrees with — and the
+ * pair is still real. If this hook is offline, wrong, or never resolves, the
+ * suggestions are identical in membership and merely ordered by date and
+ * wording alone. Nothing the user can act on depends on a rate having arrived.
+ *
+ * @param enabled false to ask nothing at all — a closed modal has no list to sort
+ */
+export function useReferenceRates(enabled: boolean): CrossCurrencyRateLookup | undefined {
+  const [rates, setRates] = useState<RateTable | null>(null);
+
+  useEffect(() => {
+    if (!enabled || rates) return;
+
+    // Guards the await: a modal closed mid-flight must not set state.
+    let live = true;
+    void (async () => {
+      try {
+        const { rates: table } = await getExchangeRatesWithProvenance();
+        if (live) setRates(table);
+      } catch (error) {
+        // Not surfaced. There is nothing for the user to do about it and
+        // nothing they lose: see the header. The log is so an offline desktop
+        // is diagnosable.
+        logger.warn('No exchange-rate table; cross-currency suggestions will sort by date alone', error);
+      }
+    })();
+
+    return () => {
+      live = false;
+    };
+  }, [enabled, rates]);
+
+  const lookup = useCallback<CrossCurrencyRateLookup>((from, to) => {
+    if (!rates) return null;
+    const fromRate = rates[from];
+    const toRate = rates[to];
+    // A pair the table does not carry is `null`, never a rate of 1. Treating a
+    // missing code as parity would rank every pair in that currency as though
+    // it converted one-for-one, which is an opinion the app does not hold.
+    if (!fromRate || !toRate) return null;
+
+    const rate = new Decimal(toRate)
+      .dividedBy(new Decimal(fromRate))
+      .toDecimalPlaces(RATE_DP, Decimal.ROUND_HALF_UP);
+    return rate.isFinite() && !rate.isZero() && !rate.isNegative() ? rate : null;
+  }, [rates]);
+
+  // `undefined` until a table exists, which is what the matchers read as "no
+  // quote available" — distinct from a lookup that answers null for one pair.
+  return rates ? lookup : undefined;
+}

--- a/src/pages/AccountTransactions.tsx
+++ b/src/pages/AccountTransactions.tsx
@@ -19,6 +19,7 @@ import BulkDeleteTransactionsConfirm from '../components/BulkDeleteTransactionsC
 import RegisterSelectionBar from '../components/RegisterSelectionBar';
 import RegisterShortcutsDialog from '../components/RegisterShortcutsDialog';
 import AccountSettingsModal from '../components/AccountSettingsModal';
+import { accountHasHistory } from '../utils/accountHistory';
 import {
   QuickEditRowProvider,
   QuickEditFieldCell,
@@ -60,6 +61,14 @@ import {
 import { isConfirmableSuggestion } from '../utils/categoryProvenance';
 import { classifyTransferCategoryChoice } from '../utils/transferCoherence';
 import { transferCategoryIdFor } from '../utils/transferRepoint';
+import CrossCurrencyTransferDialog from '../components/CrossCurrencyTransferDialog';
+import { buildFxRecord } from '../utils/fx';
+import {
+  crossedCurrencies,
+  destinationLegAmount,
+  recordConvertedCounterpart,
+  type ConfirmedConversion,
+} from '../utils/crossCurrencyTransfer';
 import {
   buildPayeeCompletionIndex,
   rememberedCategoryForPayee,
@@ -358,10 +367,13 @@ export default function AccountTransactions() {
   const backTo = readProvenance(location.state);
   const {
     accounts, transactions, categories, isLoading,
-    deleteTransaction, addTransaction, updateAccount,
+    deleteTransaction, addTransaction, updateAccount, updateTransaction,
     // The dock's Txfr path writes BOTH legs: the row, then the one operation
     // that turns it into a linked pair. See commitQuickAdd.
     createTransferCounterpart,
+    // …except across a currency boundary, where the far side cannot be minted
+    // and is written explicitly at a confirmed figure instead.
+    linkTransferPair,
     refreshCategories, refreshAccountsAndTransactions,
     // The reconcile and archive writes the register's keyboard uses are the
     // SAME ones the reconciliation screen and the archive manager use — a key
@@ -747,6 +759,19 @@ export default function AccountTransactions() {
    * because Cancel has to leave every keystroke exactly where it was.
    */
   const [confirmUncategorised, setConfirmUncategorised] = useState<{ description: string } | null>(null);
+  /**
+   * The draft waiting on a confirmed conversion, held for the same reason as
+   * the one above: Cancel must leave every keystroke exactly where it was, and
+   * nothing may reach the ledger until the figure is settled.
+   *
+   * `draft` is the override `submitQuickAdd` had already computed (a transfer
+   * CATEGORY may have been turned into a target account on the way here), so
+   * confirming replays the same add rather than re-deriving it.
+   */
+  const [pendingConversion, setPendingConversion] = useState<
+    { target: string; draft: Partial<typeof quickAddForm>; from: string; to: string } | null
+  >(null);
+  const [conversionBusy, setConversionBusy] = useState(false);
   // Money-style cross-type filing, the same affordance the edit modal offers:
   // browse the OTHER direction's categories (a refund is money IN but belongs
   // under the expense category it refunds). The type toggle still decides which
@@ -785,6 +810,19 @@ export default function AccountTransactions() {
     [account, transactions]
   );
   const hasArchivedHere = useMemo(() => fullAccountTransactions.some(t => t.archived), [fullAccountTransactions]);
+
+  /**
+   * Whether Account Settings may still offer the CURRENCY field for editing.
+   *
+   * Asked through the shared rule rather than off `fullAccountTransactions`
+   * above, even though the two lists are the same rows: what counts as
+   * "history" for a re-denomination is a decision with one home, and reading a
+   * list's length here would make this page a second place that decides it.
+   */
+  const accountHoldsHistory = useMemo(
+    () => (account ? accountHasHistory(transactions, account.id) : undefined),
+    [account, transactions]
+  );
 
   // When the opening balance takes effect, via the SAME resolver the net-worth
   // walks and the drill use — so the register can never disagree with them.
@@ -2063,7 +2101,15 @@ export default function AccountTransactions() {
    * than reading state back is what makes "what the guard decided" and "what
    * gets written" the same thing.
    */
-  const commitQuickAdd = async (override: Partial<typeof quickAddForm> = {}): Promise<void> => {
+  const commitQuickAdd = async (
+    override: Partial<typeof quickAddForm> = {},
+    /**
+     * Present only when the two accounts hold different currencies and the
+     * person has confirmed what arrives. Its presence switches the second leg
+     * from MINTED to WRITTEN: see the branch at the counterpart step.
+     */
+    conversion?: ConfirmedConversion
+  ): Promise<void> => {
     if (!account) return;
     const draft = { ...quickAddForm, ...override };
     // One row per gesture. Now that Enter adds — a key that repeats while it is
@@ -2111,7 +2157,12 @@ export default function AccountTransactions() {
       // account it was meant to face.
       category: isTransfer && targetAccountId
         ? transferCategoryIdFor(categories, targetAccountId, amount)
-        : draft.category
+        : draft.category,
+      // The confirmed rate rides with the row from its INSERT, so a converted
+      // leg is never in the ledger without the record of what made it.
+      ...(conversion
+        ? { metadata: { fx: buildFxRecord(conversion.rate, conversion.source, conversion.asOf) } }
+        : {}),
     };
 
     try {
@@ -2140,7 +2191,39 @@ export default function AccountTransactions() {
        */
       if (isTransfer && targetAccountId) {
         try {
-          await createTransferCounterpart(newTransaction.id, targetAccountId);
+          if (conversion) {
+            /**
+             * ACROSS A CURRENCY BOUNDARY THE FAR SIDE IS WRITTEN, NOT MINTED.
+             *
+             * `createTransferCounterpart` copies −amount into the other ledger
+             * and refuses when the currencies differ, which is right and is
+             * untouched: copying digits across a boundary is wrong at any rate.
+             * So the two verbs that ARE legal here are composed instead — an
+             * ordinary insert into the target account in the target's own
+             * currency, then `link_transfer_pair`, which is balance-neutral and
+             * converts nothing. Both figures came off the dialog; neither was
+             * invented by the app.
+             *
+             * The rollback below is shared with the minted path deliberately:
+             * whichever way the second leg failed to appear, the first leg is
+             * a one-sided transfer and must not survive.
+             */
+            await recordConvertedCounterpart(
+              { addTransaction, updateTransaction, linkTransferPair, deleteTransaction },
+              newTransaction,
+              {
+                accountId: targetAccountId,
+                category: transferCategoryIdFor(
+                  categories,
+                  account.id,
+                  destinationLegAmount(amount, conversion.destinationAmount).toNumber()
+                ),
+              },
+              conversion
+            );
+          } else {
+            await createTransferCounterpart(newTransaction.id, targetAccountId);
+          }
         } catch (counterpartError) {
           // The other side could not be made, so the row that would have been
           // its first leg must not survive: a one-sided transfer reads as a
@@ -2266,23 +2349,24 @@ export default function AccountTransactions() {
     }
 
     /**
-     * The cross-currency refusal, BEFORE the first write rather than after it.
+     * The currency boundary, asked about BEFORE the first write.
      *
-     * createTransferCounterpart refuses this too — the counterpart is −amount
-     * with no conversion, so two currencies cannot make one pair — and the add
-     * would undo itself cleanly. But a create-then-delete leaves two entries in
-     * the audit trail for a transfer that never existed, and the message is one
-     * the dock can give instantly from what is already on screen. The quick-edit
-     * editor pre-flights the same rule for the same reason.
+     * This was a refusal until 2026-08-12, and the reason it could not simply
+     * be dropped is that `createTransferCounterpart` — the one-call route the
+     * same-currency dock takes — mints the far side by copying −amount, so a
+     * dollar row would have moved a sterling account by the same digits. That
+     * guard is right and stays. What changes is that there is now somewhere to
+     * go: the person is asked what arrived, and the confirmed pair is written
+     * explicitly by `commitQuickAdd`'s conversion branch.
+     *
+     * Still before the first write, and for the reason the refusal was: a
+     * create-then-delete would leave two audit entries for a transfer that
+     * never existed, and a cancelled dialog should cost nothing at all.
      */
     if (target) {
-      const sourceCurrency = account.currency;
-      const targetCurrency = accounts.find(a => a.id === target)?.currency;
-      if (sourceCurrency && targetCurrency && sourceCurrency !== targetCurrency) {
-        setQuickAddError({
-          field: 'category',
-          message: `Transfers between accounts in different currencies aren’t supported yet (${sourceCurrency} and ${targetCurrency}).`,
-        });
+      const crossed = crossedCurrencies(accounts, account.id, target);
+      if (crossed) {
+        setPendingConversion({ target, draft: convertedDraft, ...crossed });
         return;
       }
     }
@@ -3806,6 +3890,33 @@ export default function AccountTransactions() {
         />
       )}
 
+      {/* "These accounts hold different currencies" — the other guard that asks
+          rather than blocks, and the newer of the two. Same discipline as the
+          one above: the draft is held, nothing is written until the figure is
+          confirmed, and Cancel leaves every keystroke where it was. */}
+      {pendingConversion && account && (
+        <CrossCurrencyTransferDialog
+          isOpen
+          sourceAmount={parseMoneyInput(quickAddForm.amount) ?? 0}
+          sourceCurrency={pendingConversion.from}
+          sourceAccountName={account.name}
+          destinationCurrency={pendingConversion.to}
+          destinationAccountName={
+            accounts.find(a => a.id === pendingConversion.target)?.name ?? 'the other account'
+          }
+          busy={conversionBusy}
+          onConfirm={(conversion) => {
+            const { draft } = pendingConversion;
+            setConversionBusy(true);
+            void commitQuickAdd(draft, conversion).finally(() => {
+              setConversionBusy(false);
+              setPendingConversion(null);
+            });
+          }}
+          onCancel={() => setPendingConversion(null)}
+        />
+      )}
+
       {/* The toolbar's Add — the app's one full add editor, opened on THIS
           account. Mounted only while it is open, which is what makes the
           prefill work at all (the form freezes its opening values on mount;
@@ -3900,6 +4011,7 @@ export default function AccountTransactions() {
         onClose={() => setShowAccountSettings(false)}
         account={account}
         accounts={accounts}
+        hasTransactions={accountHoldsHistory}
         onSave={async (accountId, updates) => {
           await updateAccount(accountId, updates);
           // Rename/close also updates the account's transfer category via the

--- a/src/pages/Accounts.tsx
+++ b/src/pages/Accounts.tsx
@@ -9,6 +9,7 @@ import AccountSettingsModal from '../components/AccountSettingsModal';
 import AccountBreakdownModal, { type AccountBreakdownView } from '../components/AccountBreakdownModal';
 import NetWorthSummary from '../components/NetWorthSummary';
 import { formatDate } from '../utils/dateFormatter';
+import { accountHasHistory } from '../utils/accountHistory';
 import PortfolioView from '../components/PortfolioView';
 // No longer importing from lucide-react - all icons are now custom
 import { ArchiveIcon, SettingsIcon, WalletIcon, CheckCircleIcon, PieChartIcon, BankIcon, RefreshCwIcon, AlertTriangleIcon, ChevronRightIcon, ChevronDownIcon, XCircleIcon, SearchIcon } from '../components/icons';
@@ -40,6 +41,7 @@ import {
 type AccountSortMode = 'default' | 'name' | 'balance-desc' | 'balance-asc';
 import { IconButton } from '../components/icons/IconButton';
 import { useCurrencyDecimal } from '../hooks/useCurrencyDecimal';
+import { useConvertedNetWorth } from '../hooks/useConvertedNetWorth';
 import { useReconciliation } from '../hooks/useReconciliation';
 import { countAwaitingReviewByAccount } from '../utils/transactionReview';
 import { useAccountBankSync } from '@service';
@@ -148,7 +150,7 @@ type DisplayedList =
 export default function Accounts() {
   const { accounts, transactions, serverBalances, updateAccount, closeAccount, refreshAccountsAndTransactions, refreshCategories } = useApp();
   const { showError } = useToast();
-  const { formatCurrency: formatDisplayCurrency } = useCurrencyDecimal();
+  const { formatCurrency: formatDisplayCurrency, displayCurrency } = useCurrencyDecimal();
   const navigate = useNavigate();
   const location = useLocation();
   const [isAddModalOpen, setIsAddModalOpen] = useState(false);
@@ -340,6 +342,38 @@ export default function Accounts() {
       costBasis: h.costBasis ? toDecimal(h.costBasis) : undefined
     })) : undefined
   })), [openAccounts]);
+
+  /**
+   * Every open account's balance beside the currency it is HELD in.
+   *
+   * The input to the net-worth card's three figures. Until this existed the
+   * card added balances across currencies one-for-one and printed the answer in
+   * the display currency — a dollar counted as a pound. The app had already
+   * written the rule down for budgets ("a number that is true in no currency at
+   * all"); the summary above the account list was the surface still breaking it.
+   */
+  const netWorthEntries = useMemo(
+    () => openAccounts.map(a => ({
+      balance: computeAccountBalance(a.id),
+      currency: a.currency || displayCurrency,
+    })),
+    [openAccounts, computeAccountBalance, displayCurrency]
+  );
+
+  /**
+   * Whether any account is held in something other than the display currency.
+   *
+   * The switch that keeps this change free for the people it does not concern.
+   * False — the overwhelmingly common case — and the three figures below are
+   * computed exactly as they have always been, by exactly the same functions,
+   * to exactly the same number. No conversion, no request, no disclosure.
+   */
+  const spansCurrencies = useMemo(
+    () => netWorthEntries.some(entry => entry.currency !== displayCurrency),
+    [netWorthEntries, displayCurrency]
+  );
+
+  const convertedNetWorth = useConvertedNetWorth(netWorthEntries, displayCurrency);
 
   // The open list's bands, straight from the two switches — type sections,
   // institution bands, type sections with institution sub-bands, or one flat
@@ -1404,10 +1438,17 @@ export default function Accounts() {
         return (
           <div className="mb-6">
             <NetWorthSummary
-              netWorth={formatDisplayCurrency(totalBalance)}
-              assets={formatDisplayCurrency(totalAssets)}
-              liabilities={formatDisplayCurrency(totalLiabilities)}
+              // Converted figures ONLY when a second currency is actually in
+              // play. A single-currency ledger keeps the exact arithmetic it
+              // had — same functions, same number — so this change is invisible
+              // to everyone it does not concern.
+              netWorth={formatDisplayCurrency(spansCurrencies ? convertedNetWorth.netWorth : totalBalance)}
+              assets={formatDisplayCurrency(spansCurrencies ? convertedNetWorth.assets : totalAssets)}
+              liabilities={formatDisplayCurrency(spansCurrencies ? convertedNetWorth.liabilities : totalLiabilities)}
               onSelect={figure => setBreakdownView(figure)}
+              provenance={spansCurrencies ? convertedNetWorth.provenance : null}
+              unconverted={spansCurrencies ? convertedNetWorth.unconverted : []}
+              displayCurrency={displayCurrency}
             />
           </div>
         );
@@ -1766,6 +1807,10 @@ export default function Accounts() {
         // The open accounts, which is what the pairing field pairs with: a
         // closed investment account is not somewhere money can be filed.
         accounts={openAccounts}
+        // Whether the CURRENCY field is still editable. Asked of the whole
+        // transaction list rather than this page's balance views, because
+        // archived rows count as history and those views hide them.
+        hasTransactions={settingsAccountId ? accountHasHistory(transactions, settingsAccountId) : undefined}
         onSave={async (accountId, updates) => {
           // A closed account isn't in context state, so the context's in-place
           // patch lands on nothing — reopening one from here only reaches the

--- a/src/pages/__tests__/Accounts.toReview.test.tsx
+++ b/src/pages/__tests__/Accounts.toReview.test.tsx
@@ -154,7 +154,7 @@ describe('Accounts list — the To Review column', () => {
     expect(within(columns).getByText('To Review')).toBeInTheDocument();
   });
 
-  it('reads amber while there is work and blue when there is none — the same language as Unreconciled', async () => {
+  it('reads quiet slate while there is work and blue when there is none — a count is not a next action (ruling A)', async () => {
     __setAppContextValue({
       accounts: [NATWEST, MONZO],
       transactions: [
@@ -169,7 +169,7 @@ describe('Accounts list — the To Review column', () => {
 
     const waiting = within(card('Synthetic Natwest')).getByText('To Review').nextElementSibling;
     const clear = within(card('Synthetic Monzo')).getByText('To Review').nextElementSibling;
-    expect(waiting?.className).toContain('text-amber-600');
+    expect(waiting?.className).toContain('text-slate-600');
     expect(clear?.className).toContain('text-blue-600');
   });
 });

--- a/src/services/__tests__/accountMapping.test.tsx
+++ b/src/services/__tests__/accountMapping.test.tsx
@@ -332,6 +332,73 @@ describe('Account Settings and an alert the user did not touch', () => {
   });
 });
 
+describe('the currency Account Settings now shows', () => {
+  /**
+   * `mapAccountToDb` has no entry for `currency` — it falls through the
+   * identity branch, which is correct only because the column happens to be
+   * spelled the same. That is exactly the kind of thing that is true until it
+   * is not, so it is asserted through the real modal, the real mapper and the
+   * real service rather than read off the map.
+   */
+  const renderSettings = (account: Account, table: AccountsTable, hasTransactions: boolean) => {
+    const service = refreshService(table);
+    render(
+      <AccountSettingsModal
+        isOpen
+        onClose={() => {}}
+        account={account}
+        hasTransactions={hasTransactions}
+        onSave={(id: string, updates: AccountUpdate) => service.updateAccount(id, updates, USER_ID)}
+      />
+    );
+  };
+
+  it('reaches the currency column and survives the round trip', async () => {
+    const table = createAccountsTable();
+    const [account] = await bootService(table).getAccounts(USER_ID);
+    expect(account.currency).toBe('GBP');
+
+    renderSettings(account, table, false);
+
+    fireEvent.change(screen.getByLabelText('Currency'), { target: { value: 'USD' } });
+    fireEvent.click(screen.getByText('Save Changes'));
+
+    await waitFor(() => expect(table.writes).toHaveLength(1));
+
+    // The column, not the camelCase field name: PostgREST rejects the whole
+    // update if one key is not a column, taking the rest of the edit with it.
+    expect(table.writes[0]).toMatchObject({ currency: 'USD' });
+    expect(table.stored().currency).toBe('USD');
+
+    // And the app reads back what was stored, so the field the modal shows next
+    // time is the one the database holds.
+    const [reloaded] = await bootService(table).getAccounts(USER_ID);
+    expect(reloaded.currency).toBe('USD');
+  });
+
+  it('leaves the stored currency alone when the account has history', async () => {
+    const table = createAccountsTable();
+    const [account] = await bootService(table).getAccounts(USER_ID);
+
+    renderSettings(account, table, true);
+
+    fireEvent.change(screen.getByLabelText('Account name'), {
+      target: { value: 'Everyday Current — joint' }
+    });
+    fireEvent.click(screen.getByText('Save Changes'));
+
+    await waitFor(() => expect(table.writes).toHaveLength(1));
+
+    // Unlike the bank details above, currency is NOT written back on an
+    // unrelated save. The value on screen is the stored one, so re-sending it
+    // would normally be a no-op — but the account is one insert away from
+    // having a register, and a no-op that becomes a re-denomination is not a
+    // no-op worth keeping.
+    expect(table.writes[0]).not.toHaveProperty('currency');
+    expect(table.stored().currency).toBe('GBP');
+  });
+});
+
 describe('matching a statement to the account it came from', () => {
   const statement = {
     accountId: '87654321',

--- a/src/services/__tests__/transactionService.test.ts
+++ b/src/services/__tests__/transactionService.test.ts
@@ -792,6 +792,73 @@ describe('TransactionService (deterministic fallback)', () => {
       expect(updated.date).toBeInstanceOf(Date);
     });
 
+    /**
+     * `metadata` reaches the database, and the mapper does not eat it.
+     *
+     * This is asserted rather than assumed because THIS mapper has form. It
+     * carries an explicit skip list for nested objects, and `transferMetadata`
+     * sat on that list while also being declared on `Transaction` — so every
+     * value ever assigned to it was dropped between the caller and the wire,
+     * silently, for as long as it existed. `metadata` is a real jsonb column in
+     * both editions and must not join it.
+     *
+     * The fx object is the payload that matters: a rate held as an exact
+     * decimal STRING. If it arrived as a number it would be a float the moment
+     * it was serialised, which is the thing the local edition's schema bans by
+     * CHECK constraint.
+     */
+    const fx = {
+      fx: { rate: '0.79', source: 'derived' as const, asOf: '2026-08-12T14:02:00.000Z' }
+    };
+
+    it('sends metadata through to the create RPC, unflattened', async () => {
+      const rpc = vi.fn(async () => ({ data: dbRow('2026-08-01'), error: null }));
+      const service = createTransactionService({
+        isSupabaseConfigured: () => true,
+        storageAdapter: createStorage(),
+        logger,
+        now,
+        uuid,
+        supabaseClient: { rpc } as unknown as never
+      });
+
+      const { id: _id, createdAt: _createdAt, updatedAt: _updatedAt, ...input } = baseTransaction();
+      await service.createTransaction(
+        'user-1',
+        { ...input, metadata: fx } as Omit<Transaction, 'id' | 'createdAt' | 'updatedAt'>
+      );
+
+      const [fnName, args] = rpc.mock.calls[0] as [string, { p: Record<string, unknown> }];
+      expect(fnName).toBe('create_transaction_atomic');
+      // Under its own name — `metadata` has no CAMEL_TO_DB entry because the
+      // column is already called that.
+      expect(args.p.metadata).toEqual(fx);
+      // The rate crossed as a string, not a float.
+      expect(typeof (args.p.metadata as typeof fx).fx.rate).toBe('string');
+    });
+
+    it('sends metadata through to the update RPC', async () => {
+      const rpc = vi.fn(async () => ({ data: dbRow('2026-08-01'), error: null }));
+      const service = createTransactionService({
+        isSupabaseConfigured: () => true,
+        storageAdapter: createStorage(),
+        logger,
+        now,
+        uuid,
+        supabaseClient: { rpc } as unknown as never
+      });
+
+      await service.updateTransaction('db-1', { metadata: fx }, 'user-1');
+
+      const [fnName, args] = rpc.mock.calls[0] as [string, Record<string, unknown>];
+      expect(fnName).toBe('update_transaction_atomic');
+      // The RPC reads `p ? 'metadata'` to tell "set it" from "leave it alone",
+      // so the key must be PRESENT, not merely defined somewhere in the object.
+      const patch = (args.p ?? args) as Record<string, unknown>;
+      expect(Object.keys(patch)).toContain('metadata');
+      expect(patch.metadata).toEqual(fx);
+    });
+
     it('converts both sides of a linked transfer pair', async () => {
       const rpc = vi.fn(async () => ({
         data: { a: dbRow('2026-08-01'), b: dbRow('2026-08-02') },

--- a/src/services/api/dataService.ts
+++ b/src/services/api/dataService.ts
@@ -1711,8 +1711,33 @@ class DataServiceImpl implements DataPort {
     if (a.accountId === b.accountId) {
       throw new Error('A transfer needs two different accounts');
     }
+    // Refusal 5, in two versions, the third copy of one rule. Which one applies
+    // turns on the two ACCOUNTS, so they are read here and not sooner: the
+    // check above has just guaranteed the two ids differ.
+    //
+    // Across a currency boundary the sides are asked only to move OPPOSITE
+    // WAYS. Two amounts in two currencies sum to zero only at a rate of exactly
+    // 1, so the strict rule applied there refuses every legitimate pair — see
+    // supabase/migrations/20260812100000_transfer_linking_across_currencies.sql
+    // for the whole argument and the 70 importer-written pairs that made it.
+    // No magnitude rule: the ratio IS the achieved rate and this layer holds no
+    // opinion about FX.
+    //
+    // An unknown currency falls to the STRICT branch, matching the RPC and the
+    // Rust core: a currency nobody can establish is not evidence of a
+    // conversion.
+    const accounts = await this.readCollection<Account>(STORAGE_KEYS.ACCOUNTS);
+    const currencyA = accounts.find(account => account.id === a.accountId)?.currency;
+    const currencyB = accounts.find(account => account.id === b.accountId)?.currency;
     const amountA = toDecimal(a.amount);
-    if (amountA.isZero() || !toDecimal(b.amount).equals(amountA.negated())) {
+    const amountB = toDecimal(b.amount);
+    if (currencyA && currencyB && currencyA !== currencyB) {
+      // Both zero tests spelled out: there is no negation here for a zero
+      // second side to fall foul of, unlike the same-currency rule below.
+      if (amountA.isZero() || amountB.isZero() || amountA.isNegative() === amountB.isNegative()) {
+        throw new Error('Transfer sides in different currencies must be opposite in sign and non-zero');
+      }
+    } else if (amountA.isZero() || !amountB.equals(amountA.negated())) {
       throw new Error('Transfer sides must have exactly opposite non-zero amounts');
     }
     if (a.isSplit || b.isSplit) {

--- a/src/services/api/transactionService.ts
+++ b/src/services/api/transactionService.ts
@@ -356,8 +356,26 @@ export function toAccountBalanceMap(rows: unknown): Map<string, ServerAccountBal
 function mapToDbFields(obj: Record<string, unknown>): Record<string, unknown> {
   const result: Record<string, unknown> = {};
   for (const [key, value] of Object.entries(obj)) {
-    // Skip complex nested objects that don't map to DB columns
-    if (key === 'transferMetadata' || key === 'investmentData' || key === 'location') {
+    // Skip complex nested objects that don't map to DB columns.
+    //
+    // `transferMetadata` used to head this list and no longer exists: it was
+    // declared on Transaction, skipped here, and therefore silently discarded
+    // on every save. The field is gone from the type; see the note where
+    // `metadata` now stands in src/types/index.ts.
+    //
+    // `metadata` is deliberately NOT skipped. It is a real jsonb column in both
+    // editions, it is one of the sixteen fields updateTransaction's contract
+    // says the engines honour, and it has no entry in CAMEL_TO_DB — so it
+    // passes through under its own name, which is the column's name.
+    // `investmentData` also used to be skipped here — set by the Add
+    // Investment modal, dropped on save, read by nothing. The truth it
+    // duplicated lives in public.investments (the machine's copy) and in the
+    // transaction's structured notes (the human's); the field and its float
+    // money values were removed with it. Only `location` remains: the type's
+    // plaid-era location object does not match the location_city/
+    // location_country columns, so it may never pass through under its own
+    // shape.
+    if (key === 'location') {
       continue;
     }
     result[CAMEL_TO_DB[key] ?? key] = value;

--- a/src/services/port/__tests__/contract.ts
+++ b/src/services/port/__tests__/contract.ts
@@ -2838,7 +2838,12 @@ export function runDataPortContract(name: string, harness: DataPortContractHarne
           .rejects.toThrow(/two different accounts/i);
       });
 
-      rule(['linkTransferPair'], 'refuses amounts that are not exact opposites', async () => {
+      // `threeAccounts()` is entirely GBP, which is load-bearing here rather
+      // than incidental: this rule states the SAME-CURRENCY guard, and the
+      // four rules after it state the cross-currency one. A cross-currency
+      // fixture reaching this rule would silently turn it into a test of the
+      // other branch — and it would still pass, which is the dangerous part.
+      rule(['linkTransferPair'], 'refuses amounts that are not exact opposites, in one currency', async () => {
         const { port } = await harness.create({
           accounts: threeAccounts(),
           transactions: [
@@ -2850,6 +2855,79 @@ export function runDataPortContract(name: string, harness: DataPortContractHarne
         await expect(port.linkTransferPair('txn-out', 'txn-in'))
           .rejects.toThrow(/opposite non-zero amounts/i);
       });
+
+      /**
+       * Two accounts that do not share a currency, and a pair whose magnitudes
+       * therefore do NOT cancel — the shape every real conversion has, and the
+       * shape the old unconditional guard refused every single time.
+       *
+       * The rate here is deliberately not a round number: a fixture of ±25
+       * across a boundary would pass under both the old rule and the new one
+       * and prove nothing about which is in force.
+       */
+      const acrossACurrencyBoundary = (
+        outAmount: number,
+        inAmount: number,
+        inType: Transaction['type'] = 'income'
+      ): Parameters<typeof harness.create>[0] => ({
+        accounts: [
+          anAccount(ACCOUNT_A, 'Everyday', { balance: -70.1 }),
+          anAccount(ACCOUNT_B, 'Dollars', { type: 'savings', balance: 500, currency: 'USD' }),
+          anAccount(ACCOUNT_C, 'Spare', { type: 'savings', balance: 0 })
+        ],
+        categories: filingCategories(),
+        transactions: [
+          aTransaction('txn-out', { accountId: ACCOUNT_A, amount: outAmount }),
+          aTransaction('txn-in', { accountId: ACCOUNT_B, amount: inAmount, type: inType })
+        ]
+      });
+
+      rule(['linkTransferPair'], 'links two rows in different currencies whose magnitudes differ', async () => {
+        const { port, read } = await harness.create(acrossACurrencyBoundary(-25, 31.75));
+
+        const { a, b } = await port.linkTransferPair('txn-out', 'txn-in');
+
+        expect(a.type).toBe('transfer');
+        expect(b.type).toBe('transfer');
+        expect(a.linkedTransferId).toBe('txn-in');
+        expect(b.linkedTransferId).toBe('txn-out');
+
+        // The point of the whole feature, asserted rather than argued: each
+        // side still counts against its own account in its own currency, and
+        // linking converted nothing. Neither balance moved.
+        const state = await read();
+        expect(balanceOf(state, ACCOUNT_A)).toBe(-70.1);
+        expect(balanceOf(state, ACCOUNT_B)).toBe(500);
+      });
+
+      rule(['linkTransferPair'], 'refuses two rows in different currencies that move the same way', async () => {
+        const { port } = await harness.create(acrossACurrencyBoundary(-25, -31.75, 'expense'));
+
+        await expect(port.linkTransferPair('txn-out', 'txn-in'))
+          .rejects.toThrow(/opposite in sign/i);
+      });
+
+      rule(['linkTransferPair'], 'refuses a zero side across a currency boundary', async () => {
+        // Zero is neither leaving nor arriving. Asserted from the SECOND
+        // position specifically: the same-currency rule catches a zero second
+        // side through its negation test, and there is no negation in the
+        // cross-currency rule to catch it — so this is the assertion that
+        // would fail if an engine ported the loosening by deleting a clause.
+        const { port } = await harness.create(acrossACurrencyBoundary(-25, 0));
+
+        await expect(port.linkTransferPair('txn-out', 'txn-in'))
+          .rejects.toThrow(/opposite in sign and non-zero/i);
+      });
+
+      // NOT A RULE HERE: "an unknown currency falls to the strict branch".
+      //
+      // All three engines implement it and the reasoning is written at each
+      // one, but it cannot be a shared rule, because the local engine cannot
+      // hold the fixture: `accounts_currency_shaped` (schema.sql:525) is
+      // `length(currency) = 3`, so an absent currency is unstorable there by
+      // construction, and the cloud's column is nullable only for legacy rows.
+      // A rule one engine can never satisfy is not a contract — it is a
+      // permanent red, or worse, an excuse list.
 
       rule(['linkTransferPair'], 'refuses a split transaction', async () => {
         // `category: ''` beside `isSplit`, like every other split fixture in

--- a/src/styles/borders.css
+++ b/src/styles/borders.css
@@ -39,29 +39,39 @@
   box-shadow: 0 10px 15px rgba(0, 0, 0, 0.5), 0 4px 6px rgba(0, 0, 0, 0.3);
 }
 
-/* Circular button shadows - use drop-shadow to respect border radius */
+/* Circular button shadows - use drop-shadow to respect border radius.
+   The `outline: none !important` these blocks carried is gone (DESIGN_RULINGS
+   2026-08-12, ruling B) and its replacement ships in the same change below —
+   never remove a focus suppression without landing the ring that takes its
+   place. */
 button.rounded-full {
   filter: drop-shadow(0 2px 4px rgba(0, 0, 0, 0.1));
   border: none !important;
-  outline: none !important;
 }
 
 button.rounded-full:hover {
   filter: drop-shadow(0 4px 6px rgba(0, 0, 0, 0.15));
   border: none !important;
-  outline: none !important;
 }
 
 .dark button.rounded-full {
   filter: drop-shadow(0 2px 4px rgba(0, 0, 0, 0.3));
   border: none !important;
-  outline: none !important;
 }
 
 .dark button.rounded-full:hover {
   filter: drop-shadow(0 4px 6px rgba(0, 0, 0, 0.4));
   border: none !important;
-  outline: none !important;
+}
+
+/* The replacement: circular buttons get the app's one focus ring at the app's
+   one offset, from the same variable every other control uses (see
+   accessibility-colors.css). Light mode resolves it to the brand navy, dark
+   mode to the slate the .dark block in index.css chooses — one system, no
+   special case. */
+button.rounded-full:focus-visible {
+  outline: 2px solid var(--focus-ring-color, #94a3b8);
+  outline-offset: 2px;
 }
 
 /* Grid item shadows (for draggable components) */

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -233,56 +233,42 @@ export interface Transaction {
    */
   linkedTransferSplitId?: string;
 
-  // Transfer-specific metadata for wealth management
-  transferMetadata?: {
-    // Core transfer info
-    transferType?: 'internal' | 'wire' | 'ach' | 'crypto' | 'asset_sale' | 'dividend' | 'rebalance';
-    transferPurpose?: string; // "Quarterly rebalancing", "Tax payment", "Investment funding", etc.
-    
-    // Financial details
-    fees?: number; // Transfer fees charged
-    feesCurrency?: string; // Currency of fees if different
-    exchangeRate?: number; // For cross-currency transfers
-    originalAmount?: number; // Amount before conversion
-    originalCurrency?: string; // Original currency
-    
-    // Asset-specific
-    assetType?: 'cash' | 'stock' | 'bond' | 'crypto' | 'real_estate' | 'commodity' | 'other';
-    units?: number; // Number of units transferred (shares, coins, etc.)
-    pricePerUnit?: number; // Price at time of transfer
-    marketValue?: number; // Total market value at transfer time
-    costBasis?: number; // For tax purposes
-    
-    // Timing and scheduling
-    initiatedDate?: Date; // When transfer was initiated
-    settlementDate?: Date; // When transfer actually settles
-    isScheduled?: boolean; // Is this a scheduled/recurring transfer
-    scheduleId?: string; // Link to transfer schedule
-    
-    // Compliance and audit
-    approvedBy?: string; // For transfers requiring approval
-    approvalDate?: Date;
-    reference?: string; // External reference number
-    documentation?: string[]; // Links to supporting documents
-    taxImplications?: string; // Notes on tax impact
-    
-    // Reconciliation
-    expectedAmount?: number; // What we expected to receive
-    actualAmount?: number; // What actually arrived
-    discrepancy?: number; // Difference if any
-    reconciliationStatus?: 'pending' | 'matched' | 'discrepancy' | 'resolved';
-    reconciliationNotes?: string;
-  };
-  
-  // Investment-specific fields
-  investmentData?: {
-    symbol?: string;
-    quantity?: number;
-    pricePerShare?: number;
-    transactionFee?: number;
-    stampDuty?: number;
-    totalCost?: number;
-  };
+  /**
+   * The row's open jsonb blob — `transactions.metadata` in both editions.
+   *
+   * ── WHAT REPLACED `transferMetadata`, AND WHY ───────────────────────────
+   *
+   * A `transferMetadata` object used to sit here: about twenty fields, of
+   * which `fees`, `exchangeRate`, `originalAmount`, `pricePerUnit`,
+   * `marketValue`, `costBasis`, `units`, `expectedAmount`, `actualAmount` and
+   * `discrepancy` were declared `number` — that is, money and rates held as
+   * floats. Nothing ever read it and nothing ever stored it: `mapToDbFields`
+   * in services/api/transactionService.ts skipped the key outright, so every
+   * value assigned to it was dropped on the way to the database.
+   *
+   * It was not merely dead, it was a trap: the obvious place for a future
+   * implementer to put an exchange rate, in the one representation this
+   * codebase forbids for money. The local edition had already reached the same
+   * verdict from the other side — `scripts/local-sqlite/schema.sql` promotes
+   * that money into typed integer columns and then BANS all ten keys from the
+   * blob by CHECK constraint, naming each one.
+   *
+   * ── WHAT GOES IN HERE INSTEAD ───────────────────────────────────────────
+   *
+   * Opaque labels and references — never money, never a float. A cross-currency
+   * transfer records its conversion under `fx` as an exact decimal STRING; see
+   * `utils/fx.ts` for the shape and for why a string rather than a number.
+   *
+   * Declaring it is also what makes `DataPortTransactionWrites.updateTransaction`
+   * honest: its contract lists `metadata` among the sixteen fields the engines
+   * honour, and until this field existed that list named something
+   * `Partial<Transaction>` could not carry.
+   *
+   * Not selected by either edition's BOOT projection, deliberately — see
+   * BOOT_TRANSACTION_COLUMNS and the Rust `ListedTransaction`. What is written
+   * here is held for the record, not for the register's hot path.
+   */
+  metadata?: Record<string, unknown>;
 }
 
 /**

--- a/src/utils/__tests__/crossCurrencyCandidates.test.ts
+++ b/src/utils/__tests__/crossCurrencyCandidates.test.ts
@@ -1,0 +1,387 @@
+import { describe, it, expect } from 'vitest';
+import { Decimal } from '../decimal';
+import {
+  accountCurrencyIndex,
+  compareCrossCurrencyCandidates,
+  crossCurrencyCandidate,
+  hasMultipleCurrencies,
+  oppositeInSign,
+  type CrossCurrencyRateLookup,
+} from '../crossCurrencyMatch';
+import { findTransferCandidates } from '../transferMatch';
+import { sweepTransferPairs } from '../transferSweep';
+import { findStrandedTransfers } from '../strandedTransfers';
+import type { Account, Category, Transaction } from '../../types';
+
+/**
+ * Offering a pair that crosses a currency boundary.
+ *
+ * The matchers used to bucket by exact penny amount, so −$100.00 and the
+ * +£74.20 that is its other side landed in buckets that never met. The engines
+ * now accept such a link — opposite in sign, both non-zero, no constraint on
+ * magnitude — and these are the tests that the matchers ask the same question
+ * the engines answer, and that they still ask the OLD question, unchanged, of
+ * everything else.
+ */
+
+const txn = (over: Partial<Transaction> & { id: string }): Transaction => ({
+  date: new Date('2026-07-10'),
+  amount: -100,
+  description: 'Transfer',
+  category: '',
+  accountId: 'acc-gbp',
+  type: 'expense',
+  ...over,
+});
+
+const account = (id: string, currency: string): Account => ({
+  id,
+  name: id,
+  type: 'current',
+  balance: 0,
+  currency,
+  lastUpdated: new Date('2026-07-01'),
+});
+
+/** A sterling account and a dollar one — the boundary under test. */
+const TWO_CURRENCIES: Account[] = [account('acc-gbp', 'GBP'), account('acc-usd', 'USD')];
+/** The same two accounts, both in sterling — the control. */
+const ONE_CURRENCY: Account[] = [account('acc-gbp', 'GBP'), account('acc-usd', 'GBP')];
+
+/** A quote of 1.36 USD per GBP, in the shape the matchers accept. */
+const quoteUsdPerGbp: CrossCurrencyRateLookup = (from, to) =>
+  from === 'GBP' && to === 'USD' ? new Decimal('1.36') : null;
+
+describe('the cross-currency candidate rule', () => {
+  it('is opposite in sign and non-zero — the engine\'s own test', () => {
+    expect(oppositeInSign(-100, 136.25)).toBe(true);
+    expect(oppositeInSign(136.25, -100)).toBe(true);
+    // Same money in both directions is two receipts, not a transfer.
+    expect(oppositeInSign(-100, -136.25)).toBe(false);
+    expect(oppositeInSign(100, 136.25)).toBe(false);
+    // There is no rate at which zero becomes something.
+    expect(oppositeInSign(0, 136.25)).toBe(false);
+    expect(oppositeInSign(-100, 0)).toBe(false);
+  });
+
+  it('imposes NO magnitude constraint — the ratio is the rate', () => {
+    const index = accountCurrencyIndex(TWO_CURRENCIES);
+    // Absurd on its face, and still offered: every threshold that would exclude
+    // it is a claim about an exchange rate.
+    const match = crossCurrencyCandidate(
+      { amount: -10, accountId: 'acc-gbp' },
+      { amount: 14000, accountId: 'acc-usd' },
+      index
+    );
+    expect(match?.pair).toEqual({ from: 'GBP', to: 'USD' });
+  });
+
+  it('declines a pair that shares a currency, or whose currency is unknown', () => {
+    expect(crossCurrencyCandidate(
+      { amount: -100, accountId: 'acc-gbp' },
+      { amount: 100, accountId: 'acc-usd' },
+      accountCurrencyIndex(ONE_CURRENCY)
+    )).toBeNull();
+
+    // An unknown currency is not evidence that a conversion happened, so the
+    // strict same-amount rule stays in force.
+    expect(crossCurrencyCandidate(
+      { amount: -100, accountId: 'acc-gbp' },
+      { amount: 136.25, accountId: 'acc-unknown' },
+      accountCurrencyIndex(TWO_CURRENCIES)
+    )).toBeNull();
+  });
+
+  it('declines two rows in the same account whatever the currencies say', () => {
+    expect(crossCurrencyCandidate(
+      { amount: -100, accountId: 'acc-gbp' },
+      { amount: 136.25, accountId: 'acc-gbp' },
+      accountCurrencyIndex(TWO_CURRENCIES)
+    )).toBeNull();
+  });
+
+  it('measures divergence from a quote only when one is offered', () => {
+    const index = accountCurrencyIndex(TWO_CURRENCIES);
+    const pair = { amount: -100, accountId: 'acc-gbp' };
+
+    expect(crossCurrencyCandidate(pair, { amount: 136, accountId: 'acc-usd' }, index)
+      ?.rateDivergence).toBeUndefined();
+
+    // 136 / 100 = 1.36, exactly the quote.
+    expect(crossCurrencyCandidate(pair, { amount: 136, accountId: 'acc-usd' }, index, quoteUsdPerGbp)
+      ?.rateDivergence).toBeCloseTo(1, 10);
+    // 272 / 100 = 2.72 — twice the quote.
+    expect(crossCurrencyCandidate(pair, { amount: 272, accountId: 'acc-usd' }, index, quoteUsdPerGbp)
+      ?.rateDivergence).toBeCloseTo(2, 10);
+    // 68 / 100 = 0.68 — HALF the quote, which is wrong by the same factor and
+    // must score the same. A plain difference would rank one of them better.
+    expect(crossCurrencyCandidate(pair, { amount: 68, accountId: 'acc-usd' }, index, quoteUsdPerGbp)
+      ?.rateDivergence).toBeCloseTo(2, 10);
+  });
+
+  it('short-circuits a single-currency book', () => {
+    expect(hasMultipleCurrencies(accountCurrencyIndex(ONE_CURRENCY))).toBe(false);
+    expect(hasMultipleCurrencies(accountCurrencyIndex(TWO_CURRENCIES))).toBe(true);
+    expect(hasMultipleCurrencies(accountCurrencyIndex([]))).toBe(false);
+  });
+
+  it('ranks by date first, then plausibility, then wording', () => {
+    const near = { daysApart: 0, rateDivergence: 9, descriptionScore: 0 };
+    const far = { daysApart: 3, rateDivergence: 1, descriptionScore: 100 };
+    // Date leads: it is the only evidence about the two ROWS rather than about
+    // a market.
+    expect(compareCrossCurrencyCandidates(near, far)).toBeLessThan(0);
+
+    const plausible = { daysApart: 1, rateDivergence: 1.01, descriptionScore: 0 };
+    const wild = { daysApart: 1, rateDivergence: 40, descriptionScore: 100 };
+    expect(compareCrossCurrencyCandidates(plausible, wild)).toBeLessThan(0);
+
+    const wordy = { daysApart: 1, descriptionScore: 90 };
+    const terse = { daysApart: 1, descriptionScore: 10 };
+    expect(compareCrossCurrencyCandidates(wordy, terse)).toBeLessThan(0);
+  });
+});
+
+describe('findTransferCandidates across a currency boundary', () => {
+  const source = txn({ id: 'src', amount: -100, accountId: 'acc-gbp' });
+  const converted = txn({
+    id: 'usd', amount: 136.25, accountId: 'acc-usd', type: 'income',
+    date: new Date('2026-07-11'), description: 'Incoming transfer',
+  });
+
+  it('offers a candidate whose amount matches nothing, within the SAME window', () => {
+    const result = findTransferCandidates([source, converted], source, 'acc-usd', undefined, {
+      accounts: TWO_CURRENCIES,
+    });
+    expect(result.map(c => c.transaction.id)).toEqual(['usd']);
+    expect(result[0].crossCurrency).toEqual({ from: 'GBP', to: 'USD' });
+  });
+
+  it('offers nothing for a row of the same sign', () => {
+    const sameSign = txn({ id: 'usd', amount: -136.25, accountId: 'acc-usd' });
+    expect(findTransferCandidates([source, sameSign], source, 'acc-usd', undefined, {
+      accounts: TWO_CURRENCIES,
+    })).toHaveLength(0);
+  });
+
+  it('offers nothing for a zero on either side', () => {
+    const zero = txn({ id: 'usd', amount: 0, accountId: 'acc-usd' });
+    expect(findTransferCandidates([source, zero], source, 'acc-usd', undefined, {
+      accounts: TWO_CURRENCIES,
+    })).toHaveLength(0);
+
+    const zeroSource = txn({ id: 'src0', amount: 0, accountId: 'acc-gbp' });
+    expect(findTransferCandidates([zeroSource, converted], zeroSource, 'acc-usd', undefined, {
+      accounts: TWO_CURRENCIES,
+    })).toHaveLength(0);
+  });
+
+  it('uses the window it already had, not a new one', () => {
+    const late = txn({
+      id: 'usd', amount: 136.25, accountId: 'acc-usd', date: new Date('2026-07-20'),
+    });
+    expect(findTransferCandidates([source, late], source, 'acc-usd', undefined, {
+      accounts: TWO_CURRENCIES,
+    })).toHaveLength(0);
+    // …and the caller's own window still reaches it.
+    expect(findTransferCandidates([source, late], source, 'acc-usd', 30, {
+      accounts: TWO_CURRENCIES,
+    })).toHaveLength(1);
+  });
+
+  it('sorts plausible conversions above wild ones on the same day', () => {
+    const plausible = txn({
+      id: 'plausible', amount: 136, accountId: 'acc-usd', type: 'income',
+      description: 'Nothing alike',
+    });
+    const wild = txn({
+      id: 'wild', amount: 5400, accountId: 'acc-usd', type: 'income',
+      description: 'Transfer',
+    });
+
+    const ranked = findTransferCandidates([source, wild, plausible], source, 'acc-usd', undefined, {
+      accounts: TWO_CURRENCIES,
+      rateLookup: quoteUsdPerGbp,
+    });
+    // `wild` wins on wording and ties on date; the quote is what separates them.
+    expect(ranked.map(c => c.transaction.id)).toEqual(['plausible', 'wild']);
+
+    // And WITHOUT a quote both are still offered — a rate may sort, never filter.
+    const unranked = findTransferCandidates([source, wild, plausible], source, 'acc-usd', undefined, {
+      accounts: TWO_CURRENCIES,
+    });
+    expect(unranked).toHaveLength(2);
+  });
+
+  describe('the same-currency matcher, unchanged', () => {
+    const exact = txn({
+      id: 'exact', amount: 100, accountId: 'acc-usd', type: 'income',
+      date: new Date('2026-07-11'),
+    });
+    const inexact = txn({
+      id: 'inexact', amount: 136.25, accountId: 'acc-usd', type: 'income',
+      date: new Date('2026-07-11'),
+    });
+
+    it('still demands the exact opposite amount when the currencies match', () => {
+      const result = findTransferCandidates([source, exact, inexact], source, 'acc-usd', undefined, {
+        accounts: ONE_CURRENCY,
+      });
+      expect(result.map(c => c.transaction.id)).toEqual(['exact']);
+      expect(result[0].crossCurrency).toBeUndefined();
+    });
+
+    it('is byte-identical with the accounts supplied and without them', () => {
+      const withAccounts = findTransferCandidates(
+        [source, exact, inexact], source, 'acc-usd', undefined, { accounts: ONE_CURRENCY }
+      );
+      const without = findTransferCandidates([source, exact, inexact], source, 'acc-usd');
+      expect(withAccounts).toEqual(without);
+    });
+  });
+});
+
+describe('sweepTransferPairs across a currency boundary', () => {
+  const out = txn({
+    id: 'out', amount: -100, accountId: 'acc-gbp', description: 'Transfer to dollars',
+  });
+  const into = txn({
+    id: 'in', amount: 136.25, accountId: 'acc-usd', type: 'income',
+    date: new Date('2026-07-11'), description: 'Faster payment received',
+  });
+
+  it('pairs a converted transfer, orienting out/in and naming the boundary', () => {
+    const { suggestions } = sweepTransferPairs([out, into], { accounts: TWO_CURRENCIES });
+    expect(suggestions).toHaveLength(1);
+    expect(suggestions[0].outgoing.id).toBe('out');
+    expect(suggestions[0].incoming.id).toBe('in');
+    // Oriented outgoing → incoming: `from` is the currency the money LEFT.
+    expect(suggestions[0].crossCurrency).toEqual({ from: 'GBP', to: 'USD' });
+  });
+
+  it('names the boundary the same way round when the sweep meets the incoming side first', () => {
+    // The incoming row is the older one here, so the sweep reaches it first —
+    // an accident of ordering that must not flip what `from` means.
+    const earlyIn = txn({
+      id: 'in', amount: 136.25, accountId: 'acc-usd', type: 'income',
+      date: new Date('2026-07-09'),
+    });
+    const { suggestions } = sweepTransferPairs([out, earlyIn], { accounts: TWO_CURRENCIES });
+    expect(suggestions[0].outgoing.id).toBe('out');
+    expect(suggestions[0].crossCurrency).toEqual({ from: 'GBP', to: 'USD' });
+  });
+
+  it('finds nothing without the accounts, and nothing in a single-currency book', () => {
+    expect(sweepTransferPairs([out, into]).suggestions).toHaveLength(0);
+    expect(sweepTransferPairs([out, into], { accounts: ONE_CURRENCY }).suggestions).toHaveLength(0);
+  });
+
+  it('refuses a same-sign pair and a zero side', () => {
+    const sameSign = txn({ id: 'in', amount: 136.25, accountId: 'acc-usd', type: 'income' });
+    const alsoOut = txn({ id: 'out2', amount: -100, accountId: 'acc-gbp' });
+    expect(
+      sweepTransferPairs([alsoOut, sameSign], { accounts: TWO_CURRENCIES }).suggestions
+    ).toHaveLength(1);
+    // …but two rows of the SAME sign never pair.
+    const bothOut = txn({ id: 'in', amount: -136.25, accountId: 'acc-usd' });
+    expect(
+      sweepTransferPairs([out, bothOut], { accounts: TWO_CURRENCIES }).suggestions
+    ).toHaveLength(0);
+
+    const zero = txn({ id: 'in', amount: 0, accountId: 'acc-usd' });
+    expect(sweepTransferPairs([out, zero], { accounts: TWO_CURRENCIES }).suggestions).toHaveLength(0);
+  });
+
+  it('respects the window it already had', () => {
+    const late = txn({
+      id: 'in', amount: 136.25, accountId: 'acc-usd', type: 'income',
+      date: new Date('2026-07-20'),
+    });
+    expect(sweepTransferPairs([out, late], { accounts: TWO_CURRENCIES }).suggestions).toHaveLength(0);
+    expect(
+      sweepTransferPairs([out, late], { accounts: TWO_CURRENCIES, windowDays: 30 }).suggestions
+    ).toHaveLength(1);
+  });
+
+  describe('the exact-amount pass, unchanged', () => {
+    // A book where an exact same-currency pair and a converted pair both exist.
+    const accounts = [...TWO_CURRENCIES, account('acc-gbp2', 'GBP')];
+    const rows = [
+      txn({ id: 'exact-out', amount: -500, accountId: 'acc-gbp', description: 'Transfer to 5755' }),
+      txn({ id: 'exact-in', amount: 500, accountId: 'acc-gbp2', type: 'income', description: 'Received' }),
+      out,
+      into,
+    ];
+
+    it('produces the same same-currency suggestions with the accounts as without', () => {
+      const before = sweepTransferPairs(rows).suggestions;
+      const after = sweepTransferPairs(rows, { accounts }).suggestions;
+
+      expect(before).toHaveLength(1);
+      // Identical objects, in the same positions: the cross-currency pass is
+      // APPENDED, and takes only rows nothing else wanted.
+      expect(after.slice(0, before.length)).toEqual(before);
+      expect(after).toHaveLength(2);
+      expect(after[1].crossCurrency).toEqual({ from: 'GBP', to: 'USD' });
+    });
+
+    it('never takes a row the exact pass had already claimed', () => {
+      // `steal` would be a fine cross-currency partner for exact-out, but
+      // exact-out is spoken for by the penny-perfect pass that runs first.
+      const steal = txn({
+        id: 'steal', amount: 680, accountId: 'acc-usd', type: 'income',
+      });
+      const { suggestions } = sweepTransferPairs([...rows, steal], { accounts });
+      const exact = suggestions.find(s => s.outgoing.id === 'exact-out');
+      expect(exact?.incoming.id).toBe('exact-in');
+      expect(exact?.crossCurrency).toBeUndefined();
+    });
+  });
+});
+
+describe('findStrandedTransfers across a currency boundary', () => {
+  const categories: Category[] = [
+    { id: 'cat-dental', name: 'Dental', type: 'expense', level: 'detail' },
+  ];
+
+  const stranded = txn({
+    id: 'stranded', amount: -100, accountId: 'acc-gbp', description: 'Transfer to dollars',
+  });
+  const filedTwin = txn({
+    id: 'twin', amount: 136.25, accountId: 'acc-usd', type: 'income',
+    category: 'cat-dental', date: new Date('2026-07-11'), description: 'Payment in',
+  });
+
+  it('offers a filed twin in another currency once nothing exact exists', () => {
+    const { findings } = findStrandedTransfers([stranded, filedTwin], categories, {
+      accounts: TWO_CURRENCIES,
+    });
+    const finding = findings.find(f => f.row.id === 'stranded');
+    expect(finding?.kind).toBe('categorised');
+    expect(finding).toMatchObject({
+      counterpart: expect.objectContaining({ id: 'twin' }),
+      counterpartCategoryName: 'Dental',
+      crossCurrency: { from: 'GBP', to: 'USD' },
+    });
+  });
+
+  it('says nothing about it without the accounts — the old answer, unchanged', () => {
+    const { findings } = findStrandedTransfers([stranded, filedTwin], categories);
+    // Transfer-shaped with no exact opposite anywhere: one-sided, as before.
+    expect(findings.find(f => f.row.id === 'stranded')?.kind).toBe('one-sided');
+  });
+
+  it('still prefers the exact twin when there is one', () => {
+    const exactTwin = txn({
+      id: 'exact', amount: 100, accountId: 'acc-usd', type: 'income',
+      category: 'cat-dental', date: new Date('2026-07-10'),
+    });
+    const { findings } = findStrandedTransfers([stranded, exactTwin, filedTwin], categories, {
+      accounts: TWO_CURRENCIES,
+    });
+    const finding = findings.find(f => f.row.id === 'stranded');
+    expect(finding).toMatchObject({ kind: 'categorised', counterpart: expect.objectContaining({ id: 'exact' }) });
+    // The exact match is not a conversion, so it carries no boundary.
+    expect(finding && 'crossCurrency' in finding ? finding.crossCurrency : undefined).toBeUndefined();
+  });
+});

--- a/src/utils/__tests__/crossCurrencyTransfer.test.ts
+++ b/src/utils/__tests__/crossCurrencyTransfer.test.ts
@@ -1,0 +1,151 @@
+import { describe, it, expect } from 'vitest';
+import {
+  crossedCurrencies,
+  destinationLegAmount,
+  fxForLinkedPair,
+  withFxRecord,
+} from '../crossCurrencyTransfer';
+import { readFxRecord } from '../fx';
+import { toDecimal } from '../decimal';
+import type { Account, Transaction } from '../../types';
+
+const anAccount = (id: string, currency: string): Account => ({
+  id,
+  name: id,
+  type: 'checking',
+  balance: 0,
+  currency,
+  isActive: true,
+  lastUpdated: new Date('2026-08-12'),
+});
+
+const aTransaction = (id: string, accountId: string, amount: number, rest: Partial<Transaction> = {}): Transaction => ({
+  id,
+  accountId,
+  amount,
+  date: new Date('2026-08-12'),
+  description: 'Moved',
+  category: 'cat',
+  type: 'transfer',
+  ...rest,
+});
+
+const GBP = anAccount('gbp', 'GBP');
+const USD = anAccount('usd', 'USD');
+const ACCOUNTS = [GBP, USD];
+const AT = new Date('2026-08-12T14:02:00.000Z');
+
+describe('crossedCurrencies', () => {
+  it('names the pair only when it is a real boundary', () => {
+    expect(crossedCurrencies(ACCOUNTS, 'gbp', 'usd')).toEqual({ from: 'GBP', to: 'USD' });
+    expect(crossedCurrencies(ACCOUNTS, 'usd', 'gbp')).toEqual({ from: 'USD', to: 'GBP' });
+    expect(crossedCurrencies(ACCOUNTS, 'gbp', 'gbp')).toBeNull();
+  });
+
+  it('reads an unknown account as NOT a boundary, so the strict rules apply', () => {
+    // The engines make the same choice (link_transfer_pair's crossed_currencies
+    // and the RPC's `IS NOT NULL` tests). Getting it backwards here would open
+    // a dialog for a pair the engines are about to refuse.
+    expect(crossedCurrencies(ACCOUNTS, 'gbp', 'nobody')).toBeNull();
+    expect(crossedCurrencies(ACCOUNTS, 'nobody', 'usd')).toBeNull();
+  });
+});
+
+describe('destinationLegAmount', () => {
+  it('gives the far side the opposite sign, and the confirmed magnitude untouched', () => {
+    expect(destinationLegAmount(-30, toDecimal('38.17')).toString()).toBe('38.17');
+    expect(destinationLegAmount(30, toDecimal('38.17')).toString()).toBe('-38.17');
+  });
+
+  it('ignores the sign the person typed, because direction is not theirs to give', () => {
+    // Every box in the dialog is a magnitude; the legs carry the direction.
+    expect(destinationLegAmount(-30, toDecimal('-38.17')).toString()).toBe('38.17');
+  });
+});
+
+describe('fxForLinkedPair', () => {
+  it('derives the rate the two REAL amounts imply', () => {
+    const fx = fxForLinkedPair(
+      ACCOUNTS,
+      aTransaction('a', 'gbp', -30),
+      aTransaction('b', 'usd', 38.17),
+      AT
+    );
+
+    // 38.17 / 30 — what the money actually did, not what a quote said it
+    // should have done.
+    expect(fx).toEqual({
+      rate: '1.2723333333',
+      source: 'derived',
+      asOf: AT.toISOString(),
+    });
+  });
+
+  it('is positive whichever way round the legs are given', () => {
+    const forward = fxForLinkedPair(ACCOUNTS, aTransaction('a', 'gbp', -30), aTransaction('b', 'usd', 38.17), AT);
+    const backward = fxForLinkedPair(ACCOUNTS, aTransaction('b', 'usd', 38.17), aTransaction('a', 'gbp', -30), AT);
+    expect(forward?.rate).toBe('1.2723333333');
+    // The reciprocal, and still positive: a signed ratio would be negative
+    // every time and would mean nothing.
+    // Ten places, the fx_rate_e10 scale — not the nine a trailing-zero strip
+    // would leave. 30 ÷ 38.17 does not terminate, so this is the rounding.
+    expect(backward?.rate).toBe('0.7859575583');
+  });
+
+  it('records nothing when the accounts share a currency', () => {
+    const sameCurrency = [GBP, anAccount('gbp2', 'GBP')];
+    expect(
+      fxForLinkedPair(sameCurrency, aTransaction('a', 'gbp', -30), aTransaction('b', 'gbp2', 30), AT)
+    ).toBeNull();
+  });
+
+  it('never downgrades a CONFIRMED rate to a derived one', () => {
+    // The creation flow stamps both legs before linking. Re-deriving here
+    // would produce the same number wearing the wrong provenance — a stored
+    // 'manual' quietly becoming 'derived' is a lie about who is answerable for
+    // the figure, which is the whole point of storing a source at all.
+    const confirmed = { fx: { rate: '1.27', source: 'manual', asOf: AT.toISOString() } };
+    expect(
+      fxForLinkedPair(
+        ACCOUNTS,
+        aTransaction('a', 'gbp', -30, { metadata: confirmed }),
+        aTransaction('b', 'usd', 38.17),
+        AT
+      )
+    ).toBeNull();
+    // …from either leg.
+    expect(
+      fxForLinkedPair(
+        ACCOUNTS,
+        aTransaction('a', 'gbp', -30),
+        aTransaction('b', 'usd', 38.17, { metadata: confirmed }),
+        AT
+      )
+    ).toBeNull();
+  });
+
+  it('records nothing rather than throwing when the arithmetic cannot go through', () => {
+    // Unreachable behind a successful link — the engines refuse a zero side —
+    // and a metadata stamp is not worth failing a link that already worked.
+    expect(
+      fxForLinkedPair(ACCOUNTS, aTransaction('a', 'gbp', 0), aTransaction('b', 'usd', 38.17), AT)
+    ).toBeNull();
+  });
+
+  it('produces a record readFxRecord accepts, with the rate as a STRING', () => {
+    const fx = fxForLinkedPair(ACCOUNTS, aTransaction('a', 'gbp', -30), aTransaction('b', 'usd', 38.17), AT);
+    expect(fx).not.toBeNull();
+    // The round trip that matters: readFxRecord rejects a number-typed rate,
+    // so this proves the stored shape survives its own reader.
+    expect(readFxRecord({ fx })).toEqual(fx);
+    expect(typeof fx?.rate).toBe('string');
+  });
+});
+
+describe('withFxRecord', () => {
+  it('merges rather than replaces, because metadata is a shared blob', () => {
+    const fx = { rate: '1.27', source: 'manual' as const, asOf: AT.toISOString() };
+    expect(withFxRecord({ importedFrom: 'qif' }, fx)).toEqual({ importedFrom: 'qif', fx });
+    expect(withFxRecord(undefined, fx)).toEqual({ fx });
+  });
+});

--- a/src/utils/__tests__/currency-provenance.test.ts
+++ b/src/utils/__tests__/currency-provenance.test.ts
@@ -1,0 +1,226 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+/**
+ * Where a converted figure's rates came from.
+ *
+ * The gap this closes: a failed fetch fell back to a hardcoded table of
+ * approximate rates and said nothing, so a total built on a guess was
+ * indistinguishable from one built on a live quote.
+ *
+ * Every test re-imports the module through `vi.resetModules()` because the
+ * rates cache is module state, and a test that inherited another's cache would
+ * be asserting on the wrong fetch.
+ */
+
+const mockRates = {
+  GBP: 1,
+  USD: 1.25,
+  EUR: 1.2,
+};
+
+const freshModule = async () => {
+  vi.resetModules();
+  return import('../currency-decimal');
+};
+
+const okResponse = () => ({
+  ok: true,
+  json: () => Promise.resolve({ base: 'GBP', rates: mockRates }),
+});
+
+describe('rates provenance', () => {
+  const mockFetch = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    global.fetch = mockFetch;
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe('getRatesProvenance', () => {
+    it('is null before anything has been fetched', async () => {
+      const { getRatesProvenance } = await freshModule();
+      // A surface that has converted nothing has no provenance to show,
+      // because it has used no rates.
+      expect(getRatesProvenance()).toBeNull();
+    });
+
+    it('reports a live quote as api', async () => {
+      const { getExchangeRates, getRatesProvenance } = await freshModule();
+      mockFetch.mockResolvedValueOnce(okResponse());
+
+      await getExchangeRates();
+
+      const provenance = getRatesProvenance();
+      expect(provenance?.source).toBe('api');
+      expect(provenance?.asOf).toBeInstanceOf(Date);
+    });
+
+    it('reports a failed fetch as fallback', async () => {
+      const { getExchangeRates, getRatesProvenance } = await freshModule();
+      const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+      mockFetch.mockRejectedValueOnce(new Error('offline'));
+
+      await getExchangeRates();
+
+      expect(getRatesProvenance()?.source).toBe('fallback');
+      consoleErrorSpy.mockRestore();
+    });
+
+    it('reports a non-ok response as fallback too', async () => {
+      const { getExchangeRates, getRatesProvenance } = await freshModule();
+      const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+      mockFetch.mockResolvedValueOnce({ ok: false, status: 500 });
+
+      await getExchangeRates();
+
+      expect(getRatesProvenance()?.source).toBe('fallback');
+      consoleErrorSpy.mockRestore();
+    });
+  });
+
+  describe('a fallback is retried sooner than a live quote is refreshed', () => {
+    it('holds a live quote for the full hour', async () => {
+      const { getExchangeRates } = await freshModule();
+      mockFetch.mockResolvedValue(okResponse());
+
+      await getExchangeRates();
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+
+      // 30 minutes later: still inside the hour, so no second request.
+      const realNow = Date.now();
+      vi.spyOn(Date, 'now').mockReturnValue(realNow + 30 * 60 * 1000);
+      await getExchangeRates();
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+    });
+
+    it('retries a fallback after five minutes, not after an hour', async () => {
+      // Caching a failure for a full hour leaves every total labelled
+      // "approximate" long after the network came back, which turns a real
+      // warning into furniture.
+      const { getExchangeRates, getRatesProvenance } = await freshModule();
+      const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+      mockFetch.mockRejectedValueOnce(new Error('offline'));
+
+      await getExchangeRates();
+      expect(getRatesProvenance()?.source).toBe('fallback');
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+
+      // Six minutes later the provider is reachable again.
+      const realNow = Date.now();
+      vi.spyOn(Date, 'now').mockReturnValue(realNow + 6 * 60 * 1000);
+      mockFetch.mockResolvedValueOnce(okResponse());
+
+      await getExchangeRates();
+
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+      expect(getRatesProvenance()?.source).toBe('api');
+      consoleErrorSpy.mockRestore();
+    });
+  });
+
+  describe('convertMultipleCurrenciesWithProvenance', () => {
+    it('reports NO provenance when nothing needed converting', async () => {
+      const { convertMultipleCurrenciesWithProvenance } = await freshModule();
+
+      const result = await convertMultipleCurrenciesWithProvenance(
+        [{ amount: 100, currency: 'GBP' }, { amount: 250, currency: 'GBP' }],
+        'GBP'
+      );
+
+      // The single-currency case, and the whole reason provenance is nullable:
+      // no rates were used, so there is nothing to disclose and the surfaces
+      // that read this render nothing at all.
+      expect(result.provenance).toBeNull();
+      expect(result.total.toString()).toBe('350');
+      expect(result.unconverted).toEqual([]);
+      // It did not even ask for rates.
+      expect(mockFetch).not.toHaveBeenCalled();
+    });
+
+    it('reports live provenance when a conversion did happen', async () => {
+      const { convertMultipleCurrenciesWithProvenance } = await freshModule();
+      mockFetch.mockResolvedValueOnce(okResponse());
+
+      const result = await convertMultipleCurrenciesWithProvenance(
+        [{ amount: 100, currency: 'GBP' }, { amount: 125, currency: 'USD' }],
+        'GBP'
+      );
+
+      // 125 USD at 1.25 per GBP is 100 GBP, plus the 100 already in GBP.
+      expect(result.total.toString()).toBe('200');
+      expect(result.provenance?.source).toBe('api');
+      expect(result.unconverted).toEqual([]);
+    });
+
+    it('reports fallback provenance when the provider could not be reached', async () => {
+      const { convertMultipleCurrenciesWithProvenance } = await freshModule();
+      const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+      mockFetch.mockRejectedValueOnce(new Error('offline'));
+
+      const result = await convertMultipleCurrenciesWithProvenance(
+        [{ amount: 100, currency: 'GBP' }, { amount: 127, currency: 'USD' }],
+        'GBP'
+      );
+
+      // The figure is still produced — an offline app still shows a total —
+      // but it now says what it was built from.
+      expect(result.provenance?.source).toBe('fallback');
+      expect(result.total.isZero()).toBe(false);
+      consoleErrorSpy.mockRestore();
+    });
+
+    it('names a currency it had no rate for instead of only logging it', async () => {
+      const { convertMultipleCurrenciesWithProvenance } = await freshModule();
+      const consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      mockFetch.mockResolvedValueOnce(okResponse());
+
+      const result = await convertMultipleCurrenciesWithProvenance(
+        [{ amount: 100, currency: 'GBP' }, { amount: 50, currency: 'ZZZ' }],
+        'GBP'
+      );
+
+      // Pre-existing behaviour: the unconvertible amount is still added, which
+      // makes the total wrong by exactly that much. Now it is reported rather
+      // than only written to a console nobody is reading.
+      expect(result.unconverted).toEqual(['ZZZ']);
+      expect(result.total.toString()).toBe('150');
+      consoleWarnSpy.mockRestore();
+    });
+
+    it('lists each missing currency once, however many rows carry it', async () => {
+      const { convertMultipleCurrenciesWithProvenance } = await freshModule();
+      const consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      mockFetch.mockResolvedValueOnce(okResponse());
+
+      const result = await convertMultipleCurrenciesWithProvenance(
+        [
+          { amount: 10, currency: 'ZZZ' },
+          { amount: 20, currency: 'ZZZ' },
+          { amount: 30, currency: 'QQQ' },
+        ],
+        'GBP'
+      );
+
+      expect(result.unconverted).toEqual(['ZZZ', 'QQQ']);
+      consoleWarnSpy.mockRestore();
+    });
+  });
+
+  describe('convertMultipleCurrencies still answers exactly as it did', () => {
+    it('returns the same total the provenance version computes', async () => {
+      const { convertMultipleCurrencies, convertMultipleCurrenciesWithProvenance } =
+        await freshModule();
+      mockFetch.mockResolvedValue(okResponse());
+
+      const amounts = [{ amount: 100, currency: 'GBP' }, { amount: 125, currency: 'USD' }];
+      const plain = await convertMultipleCurrencies(amounts, 'GBP');
+      const withProvenance = await convertMultipleCurrenciesWithProvenance(amounts, 'GBP');
+
+      expect(plain.toString()).toBe(withProvenance.total.toString());
+    });
+  });
+});

--- a/src/utils/__tests__/fx.test.ts
+++ b/src/utils/__tests__/fx.test.ts
@@ -1,0 +1,258 @@
+import { describe, it, expect } from 'vitest';
+import { Decimal } from 'decimal.js';
+import {
+  AMOUNT_DP,
+  RATE_DP,
+  buildFxRecord,
+  deriveRate,
+  describeRate,
+  destinationForRate,
+  rateForDestination,
+  rateToStorageString,
+  readFxRecord,
+} from '../fx';
+
+/**
+ * The arithmetic behind a cross-currency transfer.
+ *
+ * Every figure here is invented. The repo is public, so no test in it carries a
+ * real balance, a real payee or a real institution.
+ */
+describe('fx', () => {
+  describe('deriveRate — the rate two real amounts imply', () => {
+    it('divides destination by source', () => {
+      // 200 of one currency became 158 of another.
+      const result = deriveRate(-200, 158);
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+      expect(result.value.toString()).toBe('0.79');
+    });
+
+    it('ignores the signs, because a transfer\'s legs are always opposite', () => {
+      // Money leaves one account and arrives in the other, so the raw ratio of
+      // the signed amounts would be negative every time and would mean nothing.
+      const signed = deriveRate(-200, 158);
+      const unsigned = deriveRate(200, 158);
+      expect(signed.ok && unsigned.ok).toBe(true);
+      if (!signed.ok || !unsigned.ok) return;
+      expect(signed.value.toString()).toBe(unsigned.value.toString());
+      expect(signed.value.isPositive()).toBe(true);
+    });
+
+    it('holds ten decimal places, matching the local edition\'s fx_rate_e10 scale', () => {
+      expect(RATE_DP).toBe(10);
+      // 1 / 3 is the standard witness for a ratio that does not terminate.
+      const result = deriveRate(3, 1);
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+      expect(result.value.toString()).toBe('0.3333333333');
+    });
+
+    it('rounds the tenth place HALF_UP, not toward zero', () => {
+      // 2/3 = 0.6666666666|66… — the eleventh digit is 6, so the tenth goes up.
+      const result = deriveRate(3, 2);
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+      expect(result.value.toString()).toBe('0.6666666667');
+    });
+
+    it('refuses a zero source rather than dividing by it', () => {
+      const result = deriveRate(0, 158);
+      expect(result.ok).toBe(false);
+      if (result.ok) return;
+      expect(result.reason).toBe('zero-source');
+    });
+
+    it('refuses input that is not a number', () => {
+      const result = deriveRate('not a number', 158);
+      expect(result.ok).toBe(false);
+      if (result.ok) return;
+      expect(result.reason).toBe('not-a-number');
+    });
+
+    it('accepts Decimal, number and string alike', () => {
+      const fromDecimal = deriveRate(new Decimal('-200'), new Decimal('158'));
+      const fromNumber = deriveRate(-200, 158);
+      const fromString = deriveRate('-200', '158');
+      expect(fromDecimal.ok && fromNumber.ok && fromString.ok).toBe(true);
+      if (!fromDecimal.ok || !fromNumber.ok || !fromString.ok) return;
+      expect(fromDecimal.value.toString()).toBe('0.79');
+      expect(fromNumber.value.toString()).toBe('0.79');
+      expect(fromString.value.toString()).toBe('0.79');
+    });
+  });
+
+  describe('destinationForRate — the dialog typing left to right', () => {
+    it('multiplies the source by the rate, to the penny', () => {
+      expect(AMOUNT_DP).toBe(2);
+      const result = destinationForRate(-200, '0.79');
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+      expect(result.value.toString()).toBe('158');
+    });
+
+    it('rounds the penny HALF_UP', () => {
+      // 100 x 0.795 = 79.5 exactly at the half-penny; HALF_UP takes it to 79.5,
+      // and a third place that lands on 5 goes up rather than to even.
+      const result = destinationForRate(100, '0.7955');
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+      expect(result.value.toString()).toBe('79.55');
+
+      const halfPenny = destinationForRate(100, '0.79555');
+      expect(halfPenny.ok).toBe(true);
+      if (!halfPenny.ok) return;
+      expect(halfPenny.value.toString()).toBe('79.56');
+    });
+
+    it('returns a positive amount — the caller applies the leg\'s sign', () => {
+      const result = destinationForRate(-200, '0.79');
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+      expect(result.value.isPositive()).toBe(true);
+    });
+
+    it('does not lose pounds to a rate rounded too early', () => {
+      // The reason a rate is not held at 2dp. A rate truncated to 0.79 against
+      // a five-figure amount differs from the full quote by real money.
+      const full = destinationForRate(50000, '0.7912345678');
+      const truncated = destinationForRate(50000, '0.79');
+      expect(full.ok && truncated.ok).toBe(true);
+      if (!full.ok || !truncated.ok) return;
+      const difference = full.value.minus(truncated.value).abs();
+      expect(difference.greaterThan(60)).toBe(true);
+    });
+
+    it('refuses input that is not a number', () => {
+      const result = destinationForRate(200, 'abc');
+      expect(result.ok).toBe(false);
+      if (result.ok) return;
+      expect(result.reason).toBe('not-a-number');
+    });
+  });
+
+  describe('the two directions agree', () => {
+    it('round-trips a rate through an amount and back', () => {
+      const destination = destinationForRate(-200, '0.79');
+      expect(destination.ok).toBe(true);
+      if (!destination.ok) return;
+
+      const back = rateForDestination(-200, destination.value);
+      expect(back.ok).toBe(true);
+      if (!back.ok) return;
+      expect(back.value.toString()).toBe('0.79');
+    });
+
+    it('round-trips an amount through a rate and back', () => {
+      const rate = rateForDestination(-320, 250);
+      expect(rate.ok).toBe(true);
+      if (!rate.ok) return;
+
+      const back = destinationForRate(-320, rate.value);
+      expect(back.ok).toBe(true);
+      if (!back.ok) return;
+      expect(back.value.toString()).toBe('250');
+    });
+
+    it('comes back to the SAME PENNY even when the ratio does not terminate', () => {
+      // This is what ten places buys, stated as an assertion. 100/300 has no
+      // terminating decimal, so the stored rate is an approximation — but at
+      // RATE_DP it is close enough that multiplying back lands on the original
+      // amount exactly: 300 x 0.3333333333 = 99.99999999, which is 100.00 to
+      // the penny. Held at 2dp the same round-trip would return 99.00, and the
+      // person would watch their own figure change after they typed it.
+      const rate = rateForDestination(-300, 100);
+      expect(rate.ok).toBe(true);
+      if (!rate.ok) return;
+      expect(rate.value.toString()).toBe('0.3333333333');
+
+      const back = destinationForRate(-300, rate.value);
+      expect(back.ok).toBe(true);
+      if (!back.ok) return;
+      expect(back.value.toString()).toBe('100');
+
+      // The 2dp counterfactual the comment above claims.
+      const coarse = destinationForRate(-300, '0.33');
+      expect(coarse.ok).toBe(true);
+      if (!coarse.ok) return;
+      expect(coarse.value.toString()).toBe('99');
+    });
+  });
+
+  describe('rateToStorageString — an exact decimal string, never a float', () => {
+    it('drops trailing zeros rather than padding to ten places', () => {
+      expect(rateToStorageString(new Decimal('0.79'))).toBe('0.79');
+      expect(rateToStorageString(new Decimal('2'))).toBe('2');
+    });
+
+    it('keeps every digit of a long rate', () => {
+      expect(rateToStorageString(new Decimal('0.3333333333'))).toBe('0.3333333333');
+    });
+
+    it('is exact where a float is not', () => {
+      // 0.1 + 0.2 is the canonical float failure. The stored string is the
+      // decimal value, so it never acquires the tail a float would.
+      const rate = new Decimal('0.1').plus('0.2');
+      expect(rateToStorageString(rate)).toBe('0.3');
+      expect(rateToStorageString(rate)).not.toContain('0.30000000');
+    });
+  });
+
+  describe('buildFxRecord / readFxRecord', () => {
+    const asOf = new Date('2026-08-12T14:02:00.000Z');
+
+    it('records the rate as a string, with its source and timestamp', () => {
+      const record = buildFxRecord(new Decimal('0.79'), 'api', asOf);
+      expect(record).toEqual({
+        rate: '0.79',
+        source: 'api',
+        asOf: '2026-08-12T14:02:00.000Z',
+      });
+      expect(typeof record.rate).toBe('string');
+    });
+
+    it('reads back what it wrote, through a metadata blob', () => {
+      const record = buildFxRecord(new Decimal('0.3333333333'), 'derived', asOf);
+      expect(readFxRecord({ fx: record })).toEqual(record);
+    });
+
+    it('survives other writers sharing the blob', () => {
+      const record = buildFxRecord(new Decimal('0.79'), 'manual', asOf);
+      expect(readFxRecord({ fx: record, somethingElse: { a: 1 } })).toEqual(record);
+    });
+
+    it('reads anything shaped wrong as absent rather than throwing', () => {
+      // metadata is an open jsonb blob; a render must not crash on a stranger's
+      // key. Each of these is a plausible way for the shape to be wrong.
+      expect(readFxRecord(null)).toBeNull();
+      expect(readFxRecord(undefined)).toBeNull();
+      expect(readFxRecord('a string')).toBeNull();
+      expect(readFxRecord({})).toBeNull();
+      expect(readFxRecord({ fx: null })).toBeNull();
+      expect(readFxRecord({ fx: {} })).toBeNull();
+      expect(readFxRecord({ fx: { rate: '0.79' } })).toBeNull();
+      expect(readFxRecord({ fx: { rate: '0.79', source: 'api' } })).toBeNull();
+      expect(readFxRecord({ fx: { rate: 0.79, source: 'api', asOf: 'x' } })).toBeNull();
+      expect(readFxRecord({ fx: { rate: '0.79', source: 'guess', asOf: 'x' } })).toBeNull();
+      expect(readFxRecord({ fx: { rate: '', source: 'api', asOf: 'x' } })).toBeNull();
+      expect(readFxRecord({ fx: { rate: 'abc', source: 'api', asOf: 'x' } })).toBeNull();
+    });
+
+    it('refuses a rate stored as a number, because that is a float', () => {
+      // The local schema banned the old float `transferMetadata.exchangeRate`
+      // from the blob for exactly this reason. A number here is that mistake
+      // returning under a new key, so it does not read as a valid record.
+      expect(readFxRecord({ fx: { rate: 0.79, source: 'api', asOf: '2026-08-12T14:02:00.000Z' } })).toBeNull();
+    });
+  });
+
+  describe('describeRate', () => {
+    it('quotes the rate as a sentence naming both currencies', () => {
+      expect(describeRate('0.79', { from: 'USD', to: 'GBP' })).toBe('1 USD = 0.79 GBP');
+    });
+
+    it('takes a Decimal and prints it without padding', () => {
+      expect(describeRate(new Decimal('2'), { from: 'GBP', to: 'USD' })).toBe('1 GBP = 2 USD');
+    });
+  });
+});

--- a/src/utils/accountHistory.test.ts
+++ b/src/utils/accountHistory.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect } from 'vitest';
+import { accountHasHistory } from './accountHistory';
+import type { Transaction } from '../types';
+
+const row = (overrides: Partial<Transaction> & { accountId: string }): Transaction => ({
+  id: 't1',
+  date: new Date('2026-03-01'),
+  amount: -25,
+  description: 'Tesco',
+  category: 'cat-1',
+  type: 'expense',
+  ...overrides,
+});
+
+describe('accountHasHistory', () => {
+  it('is false for an account nothing has been recorded in', () => {
+    expect(accountHasHistory([row({ id: 'a', accountId: 'other' })], 'empty')).toBe(false);
+  });
+
+  it('is true as soon as one row names the account', () => {
+    expect(accountHasHistory([row({ id: 'a', accountId: 'acc-1' })], 'acc-1')).toBe(true);
+  });
+
+  it('counts ARCHIVED rows as history', () => {
+    // Archiving hides a row from the live register; it does not un-record the
+    // money. Treating an archived-away account as empty would licence exactly
+    // the re-denomination this guards.
+    expect(
+      accountHasHistory([row({ id: 'a', accountId: 'acc-1', archived: true })], 'acc-1')
+    ).toBe(true);
+  });
+
+  it('counts a split parent, which is how split history reaches an account', () => {
+    expect(
+      accountHasHistory([row({ id: 'a', accountId: 'acc-1', isSplit: true })], 'acc-1')
+    ).toBe(true);
+  });
+
+  it('is false for no account at all rather than matching a blank accountId', () => {
+    expect(accountHasHistory([row({ id: 'a', accountId: '' })], '')).toBe(false);
+  });
+});

--- a/src/utils/accountHistory.ts
+++ b/src/utils/accountHistory.ts
@@ -1,0 +1,41 @@
+import type { Transaction } from '../types';
+
+/**
+ * Has an account any recorded money in it at all?
+ *
+ * Asked before offering an edit that would re-interpret every figure already
+ * stored — today that is exactly one edit, the account's CURRENCY, which
+ * changes what recorded numbers MEAN rather than what they are.
+ *
+ * ── WHY TRANSACTIONS ALONE ANSWER IT, SPLITS INCLUDED ───────────────────────
+ *
+ * A split is not a separate kind of history that could hide from this count:
+ * `TransactionSplit.transactionId` names a parent transaction, and that parent
+ * sits in an account like any other row — so an account whose only history is a
+ * split still has the parent here. The other direction holds too: a split LINE
+ * that names a transfer target has a real counterpart TRANSACTION written into
+ * that target account (see the `linkedTransferId` note on TransactionSplit and
+ * `set_transaction_splits_with_legs`), never a bare line floating in an account
+ * with no row. There is no arrangement of splits that puts money in an account
+ * without putting a transaction in it, which is why this takes no splits
+ * argument rather than taking one and ignoring it.
+ *
+ * ── ARCHIVED ROWS COUNT ─────────────────────────────────────────────────────
+ *
+ * Deliberately not filtered. Archiving hides a row from the live register; it
+ * does not un-record the money (`setTransactionArchived` flips a flag and is
+ * balance-neutral, and `unarchiveAccount` brings them all back). An account
+ * whose history has been archived away would otherwise read as empty here and
+ * license a re-denomination of the very figures the user still owns — the
+ * quietest possible version of the bug this function exists to prevent.
+ *
+ * Context state carries archived rows exactly like any other, so this is a
+ * plain scan with nothing excluded.
+ */
+export function accountHasHistory(
+  transactions: readonly Transaction[],
+  accountId: string
+): boolean {
+  if (!accountId) return false;
+  return transactions.some(transaction => transaction.accountId === accountId);
+}

--- a/src/utils/crossCurrencyLabel.ts
+++ b/src/utils/crossCurrencyLabel.ts
@@ -1,0 +1,36 @@
+import { toDecimal } from './decimal';
+import { formatCurrency } from './currency-decimal';
+
+/**
+ * A figure that must not be read in the wrong currency: "USD -$100.00".
+ *
+ * ── WHY THE CODE IS PRINTED BESIDE A SYMBOL THAT ALREADY IMPLIES IT ─────────
+ *
+ * Everywhere else in the app a figure is shown with its symbol alone, and that
+ * is right: a register belongs to one account, so its currency is a fact about
+ * the whole page rather than about each row. A cross-currency SUGGESTION is the
+ * one place that stops being true — two figures sit side by side, they will not
+ * match, and the reason is the very thing the symbols cannot say. "$" is the
+ * dollar of at least four countries the app's own rate table carries, and "-£"
+ * beside "-$" reads as a broken match rather than a conversion.
+ *
+ * So the code is spelled out, in the same shape the engines use when they
+ * refuse a pair — `({first_currency} {first} vs {second_currency} {second})` in
+ * `transfer::amounts_not_opposite_across_currencies`. A user who meets both the
+ * refusal and the offer meets one notation.
+ *
+ * This is the ONLY place that notation is written down, because it appears in
+ * three unrelated surfaces (the match dialog, the register dock's strip and the
+ * bulk sweep's table) and three spellings of it would drift.
+ *
+ * The SIGN is always explicit, including the leading "+", which the app's
+ * display rules reserve for income. Here it is not decoration: opposite-in-sign
+ * is the entire test these two rows passed to be shown together, so a reader
+ * comparing them is reading the signs as the evidence.
+ */
+export function amountWithCurrencyCode(amount: number, currency: string): string {
+  const decimal = toDecimal(amount);
+  // The magnitude is formatted, and the sign written beside it, so a negative
+  // never renders as "USD --$100.00".
+  return `${currency} ${decimal.isNegative() ? '-' : '+'}${formatCurrency(decimal.abs(), currency)}`;
+}

--- a/src/utils/crossCurrencyMatch.ts
+++ b/src/utils/crossCurrencyMatch.ts
@@ -1,0 +1,227 @@
+import { Decimal, toDecimal, type DecimalInstance } from './decimal';
+import { deriveRate } from './fx';
+import { crossedCurrencyPair, type CrossCurrency } from './crossCurrencyTransfer';
+import type { Account, Transaction } from '../types';
+
+/**
+ * When two rows in DIFFERENT currencies may be offered as the two sides of one
+ * transfer — and in what order the offers should be listed.
+ *
+ * ── WHY THE MATCHERS NEEDED CHANGING AT ALL ─────────────────────────────────
+ *
+ * Every candidate matcher in the product buckets rows by exact penny amount:
+ * `byAmount.get(-pennies(row.amount))` in transferSweep, `allByAmount` in
+ * strandedTransfers, an exact negated Decimal compare in transferMatch. A
+ * −$100.00 row and the +£74.20 that is its other side land in buckets that
+ * never meet, so no matcher could offer that pair — not because anything
+ * refused it, but because nothing ever looked.
+ *
+ * The engines now DO accept it. `link_transfer_pair` splits its refusal 5 by
+ * whether the two accounts share a currency: same currency is unchanged to the
+ * penny, different currencies need only both sides non-zero and OPPOSITE IN
+ * SIGN, "with no constraint on magnitude, because the ratio between the
+ * magnitudes *is* the achieved rate and this engine holds no opinion about FX".
+ * That sentence is the whole specification of {@link crossCurrencyCandidate},
+ * and it is deliberately copied rather than paraphrased: a matcher that offered
+ * a pair the engine then refused would be a dialog that fails on confirm.
+ *
+ * ── THE WINDOW IS NOT A NEW ONE ─────────────────────────────────────────────
+ *
+ * Nothing here has a window of its own. Each caller passes the window it was
+ * already using (SWEEP_WINDOW_DAYS, TRANSFER_MATCH_WINDOW_DAYS — both 4), so a
+ * currency boundary changes WHICH rows may pair, never HOW LONG a bank is
+ * allowed to take. A conversion clears no slower than a domestic payment.
+ *
+ * ── A MARKET RATE MAY SORT. IT MAY NEVER FILTER. ────────────────────────────
+ *
+ * This is the rule that governs {@link CrossCurrencyRateLookup} and it is not a
+ * style preference. A real conversion happens at the rate the BANK gave on the
+ * day, including its spread, its fees, and whatever the market did that
+ * afternoon; a mid-market quote from a free API is an opinion about what that
+ * should have been. On a volatile day — or for a currency the provider tracks
+ * badly, or a transfer whose fee was a third of the amount — the two disagree
+ * wildly, and the pair is still real. So a divergent rate may push a candidate
+ * DOWN a list the user is reading, and may never remove it from one. There is
+ * no threshold constant in this file, and adding one would be the bug.
+ */
+
+/** How a caller answers "what is one unit of `from` worth in `to`?", if it can. */
+export type CrossCurrencyRateLookup = (from: string, to: string) => DecimalInstance | null;
+
+/**
+ * A pair that crosses a currency boundary, and how far its implied rate sits
+ * from a quoted one.
+ */
+export interface CrossCurrencyMatch {
+  /** The boundary itself: the source's currency and the candidate's. */
+  pair: CrossCurrency;
+  /**
+   * How many TIMES off the rate these two amounts imply is from the quoted
+   * rate for the pair — 1 exactly when they agree, 2 when the implied rate is
+   * double or half the quote. Symmetric, so being 2× out is ranked the same
+   * whichever way round it is wrong.
+   *
+   * `undefined` when no quote was available (offline, an untracked pair, or a
+   * caller that passed no lookup at all). Undefined divergence never demotes a
+   * candidate: it means the app has nothing to say, not that the pair is
+   * suspect. See the header — this figure sorts, and only sorts.
+   */
+  rateDivergence?: number;
+}
+
+/** Account id → the currency it counts in, built once per sweep. */
+export type AccountCurrencyIndex = ReadonlyMap<string, string>;
+
+export function accountCurrencyIndex(accounts: readonly Account[]): AccountCurrencyIndex {
+  const index = new Map<string, string>();
+  for (const account of accounts) {
+    if (account.currency) index.set(account.id, account.currency);
+  }
+  return index;
+}
+
+/**
+ * Does this book have more than one currency in it at all?
+ *
+ * The short circuit every caller checks first. A single-currency ledger — which
+ * is nearly every ledger, and certainly the owner's for most of its history —
+ * can produce no cross-currency candidate by definition, so the extra pass is
+ * skipped outright rather than run to find nothing. Without this the sweep
+ * would pay for a feature that cannot apply to it on every run.
+ */
+export function hasMultipleCurrencies(index: AccountCurrencyIndex): boolean {
+  let first: string | undefined;
+  for (const currency of index.values()) {
+    if (first === undefined) first = currency;
+    else if (currency !== first) return true;
+  }
+  return false;
+}
+
+/**
+ * Both non-zero and pointing opposite ways — the engine's
+ * `transfer::are_opposite_in_sign`, in Decimal.
+ *
+ * Same money in both directions is not a transfer, it is two receipts; and a
+ * zero side is refused across a currency boundary exactly as it is within one
+ * (there is no rate at which zero becomes something).
+ */
+export function oppositeInSign(
+  first: DecimalInstance | number,
+  second: DecimalInstance | number
+): boolean {
+  const a = toDecimal(first);
+  const b = toDecimal(second);
+  if (a.isZero() || b.isZero()) return false;
+  return a.isNegative() !== b.isNegative();
+}
+
+/**
+ * Whether `candidate` may be offered as the other side of `source`, when the
+ * two sit in accounts that count in different currencies.
+ *
+ * Returns `null` — not offered — when the two accounts share a currency or
+ * either currency is unknown. That last case is the conservative half of
+ * `crossedCurrencyPair` doing its job: a currency nobody can establish is not
+ * evidence that a conversion happened, so the strict same-amount rules stay in
+ * force and this pass declines to speak.
+ *
+ * NO AMOUNT TEST BEYOND SIGN. It is tempting to want one — a −£10 row matching
+ * a +$14,000 row looks absurd — but every threshold that would exclude it is a
+ * claim about an exchange rate, and this module is not allowed to make one. The
+ * absurd pair is offered LAST instead, which is what {@link compareCrossCurrencyCandidates}
+ * is for.
+ */
+export function crossCurrencyCandidate(
+  source: Pick<Transaction, 'amount' | 'accountId'>,
+  candidate: Pick<Transaction, 'amount' | 'accountId'>,
+  index: AccountCurrencyIndex,
+  rateLookup?: CrossCurrencyRateLookup
+): CrossCurrencyMatch | null {
+  if (source.accountId === candidate.accountId) return null;
+  const pair = crossedCurrencyPair(
+    index.get(source.accountId),
+    index.get(candidate.accountId)
+  );
+  if (!pair) return null;
+  if (!oppositeInSign(source.amount, candidate.amount)) return null;
+
+  return { pair, rateDivergence: rateDivergenceOf(source.amount, candidate.amount, pair, rateLookup) };
+}
+
+/**
+ * Where a candidate with no quote sits among candidates that have one.
+ *
+ * A divergence of 1 is a perfect match and the floor of the scale, so any
+ * figure above this is a pair the quote positively disagrees with, and anything
+ * below it is one the quote broadly supports. Ranking the unquoted here is the
+ * only choice that treats "we could not ask" as neither evidence for nor
+ * against — and it costs nothing on the common path, where either every
+ * candidate has a quote or none does.
+ */
+const NEUTRAL_DIVERGENCE = 1.5;
+
+/**
+ * How far the rate these two amounts imply sits from the quoted one.
+ *
+ * Both directions of the ratio are considered and the larger is returned, so
+ * "half the quoted rate" and "twice the quoted rate" score identically — a
+ * plain difference would rank one of them as the better match purely because
+ * division is not symmetric.
+ *
+ * Every intermediate step is Decimal: the implied rate comes from
+ * {@link deriveRate}, which is the same function the linking seam uses to stamp
+ * `metadata.fx`, so a pair's rank and its eventual receipt cannot disagree
+ * about what rate it implied. The single `toNumber` at the end is on a
+ * dimensionless ranking scalar, never on money.
+ */
+function rateDivergenceOf(
+  sourceAmount: number,
+  candidateAmount: number,
+  pair: CrossCurrency,
+  rateLookup?: CrossCurrencyRateLookup
+): number | undefined {
+  if (!rateLookup) return undefined;
+
+  const quoted = rateLookup(pair.from, pair.to);
+  if (!quoted || !quoted.isFinite() || quoted.isZero() || quoted.isNegative()) return undefined;
+
+  const implied = deriveRate(sourceAmount, candidateAmount);
+  if (!implied.ok || implied.value.isZero()) return undefined;
+
+  const ratio = implied.value.dividedBy(quoted);
+  if (ratio.isZero()) return undefined;
+  const divergence = ratio.lessThan(1) ? new Decimal(1).dividedBy(ratio) : ratio;
+  return divergence.toNumber();
+}
+
+/**
+ * The order cross-currency candidates are offered in: DATE FIRST.
+ *
+ * Date proximity leads because it is the only evidence here that is a fact
+ * about the two rows rather than an opinion about a market. A conversion that
+ * cleared the same day is a better candidate than one four days out, whatever
+ * either implies about the rate.
+ *
+ * Rate divergence breaks the tie, and this is where a quote earns its keep: on
+ * a day with several opposite-signed rows in a foreign account, the one whose
+ * magnitude actually looks like a conversion should be the one preselected. A
+ * candidate with no divergence figure at all sorts as neutral — after those
+ * that match the quote, before those that plainly do not — because "no quote"
+ * is not evidence in either direction.
+ *
+ * Description similarity comes last, as it does in every other matcher here:
+ * two banks almost never describe the same movement the same way.
+ */
+export function compareCrossCurrencyCandidates(
+  a: { daysApart: number; rateDivergence?: number; descriptionScore: number },
+  b: { daysApart: number; rateDivergence?: number; descriptionScore: number }
+): number {
+  if (a.daysApart !== b.daysApart) return a.daysApart - b.daysApart;
+
+  const divergenceA = a.rateDivergence ?? NEUTRAL_DIVERGENCE;
+  const divergenceB = b.rateDivergence ?? NEUTRAL_DIVERGENCE;
+  if (divergenceA !== divergenceB) return divergenceA - divergenceB;
+
+  return b.descriptionScore - a.descriptionScore;
+}

--- a/src/utils/crossCurrencyTransfer.ts
+++ b/src/utils/crossCurrencyTransfer.ts
@@ -1,0 +1,222 @@
+import { toDecimal, type DecimalInstance } from './decimal';
+import { buildFxRecord, deriveRate, readFxRecord, type FxRecord, type FxRateSource } from './fx';
+import type { Account, Transaction } from '../types';
+
+/**
+ * What a cross-currency transfer needs on top of an ordinary one, in the two
+ * places the app can produce one.
+ *
+ * ── WHY THERE ARE EXACTLY TWO PATHS, AND ONLY ONE OF THEM ASKS ──────────────
+ *
+ * **Creating** a pair means the app is about to write a figure into an account
+ * nobody has quoted yet. There is no honest way to invent it — the mid-market
+ * rate is not what a bank gave, and the engine refuses to copy the number
+ * across (`create_transfer_counterpart`'s guard, untouched and permanent). So
+ * the person is asked, and what they confirm is what gets written. Provenance:
+ * `'api'` if they accepted a live quote untouched, `'manual'` if they typed or
+ * edited anything.
+ *
+ * **Linking** two rows that already exist asks nothing, and must not. Both
+ * figures are already real — they came from two banks, or from the MS Money
+ * importer — and their ratio is the rate that was actually achieved, spread and
+ * fees included. A dialog here would invite the user to "correct" a fact.
+ * Provenance: `'derived'`.
+ *
+ * The second is the truer number of the two, which is why it is never
+ * overwritten by the first: see {@link fxForLinkedPair}.
+ */
+
+/** A currency pair, once both sides are known to differ. */
+export interface CrossCurrency {
+  from: string;
+  to: string;
+}
+
+/**
+ * The two accounts' currencies when they form a real boundary, `null` when they
+ * do not.
+ *
+ * Mirrors `link_transfer_pair`'s `crossed_currencies` in the Rust core and the
+ * `v_a_currency IS NOT NULL AND …` test in the RPC: a currency nobody can
+ * establish is not evidence that a conversion happened, so an unknown one reads
+ * as "same" and the strict rules apply. Getting this backwards in the UI would
+ * open a dialog for a pair the engines will then refuse.
+ */
+export function crossedCurrencies(
+  accounts: readonly Account[],
+  sourceAccountId: string,
+  destinationAccountId: string
+): CrossCurrency | null {
+  return crossedCurrencyPair(
+    accounts.find(account => account.id === sourceAccountId)?.currency,
+    accounts.find(account => account.id === destinationAccountId)?.currency
+  );
+}
+
+/**
+ * The same rule, given the two currencies rather than the two accounts.
+ *
+ * Extracted so the CANDIDATE matchers can apply it too (utils/crossCurrencyMatch):
+ * they ask it once per row against an index, and looking two accounts up in an
+ * array for every row of a long history is a different cost entirely. What
+ * matters is that both spellings cannot drift — "unknown reads as same" is the
+ * conservative half of this rule and the half that would be easy to get
+ * backwards in a second copy, so there is no second copy.
+ */
+export function crossedCurrencyPair(
+  from: string | undefined,
+  to: string | undefined
+): CrossCurrency | null {
+  if (!from || !to || from === to) return null;
+  return { from, to };
+}
+
+/**
+ * The `metadata.fx` a freshly LINKED pair earns, or `null` if it earns none.
+ *
+ * `null` in three cases, and each one matters:
+ *
+ * 1. **The accounts share a currency.** Nothing was converted, so a rate of 1
+ *    would be a fact about arithmetic rather than about money.
+ * 2. **Either leg already carries an `fx` record.** The creation flow writes
+ *    the CONFIRMED rate onto both legs before linking them, and that record
+ *    says whether a person accepted a quote or typed one. Re-deriving it here
+ *    would produce the same number — it is derived from the very amounts they
+ *    confirmed — wearing the wrong provenance. A stored `'manual'` silently
+ *    becoming `'derived'` is a small lie about who is answerable for the
+ *    figure, and provenance exists precisely so that question has an answer.
+ * 3. **The arithmetic will not go through** — a zero source. The engines
+ *    refuse such a pair, so this is unreachable behind a successful link, and
+ *    it returns `null` rather than throwing because a metadata stamp is not
+ *    worth failing a link that already succeeded.
+ */
+export function fxForLinkedPair(
+  accounts: readonly Account[],
+  a: Transaction,
+  b: Transaction,
+  asOf: Date
+): FxRecord | null {
+  if (!crossedCurrencies(accounts, a.accountId, b.accountId)) return null;
+  if (readFxRecord(a.metadata) || readFxRecord(b.metadata)) return null;
+
+  const rate = deriveRate(a.amount, b.amount);
+  if (!rate.ok) return null;
+  return buildFxRecord(rate.value, 'derived', asOf);
+}
+
+/**
+ * A leg's metadata with an `fx` record added, leaving everything else alone.
+ *
+ * `metadata` is an open jsonb blob other writers share, so this merges rather
+ * than replaces. Written as a free function because both the creation flow and
+ * the link seam need it and a second spelling of "spread the old keys" is how
+ * one of them eventually forgets to.
+ */
+export function withFxRecord(
+  metadata: Record<string, unknown> | undefined,
+  fx: FxRecord
+): Record<string, unknown> {
+  return { ...(metadata ?? {}), fx };
+}
+
+/** What the dialog hands back once the person has confirmed a conversion. */
+export interface ConfirmedConversion {
+  /** The destination amount, ABSOLUTE and to the penny. */
+  destinationAmount: DecimalInstance;
+  /** The rate that produced it, destination units per one source unit. */
+  rate: DecimalInstance;
+  /** Whether they accepted the quote or authored it. */
+  source: Extract<FxRateSource, 'api' | 'manual'>;
+  /** When the rate was true. */
+  asOf: Date;
+}
+
+/**
+ * The destination leg's SIGNED amount, given the source leg's.
+ *
+ * The one piece of arithmetic in the creation flow, and it is about sign rather
+ * than about money: the confirmed magnitude is used exactly as confirmed, and
+ * only its direction is decided here. Opposite to the source, always — which is
+ * the rule the engines now enforce across a currency boundary and the only rule
+ * they enforce there.
+ */
+export function destinationLegAmount(
+  sourceAmount: DecimalInstance | number | string,
+  destinationMagnitude: DecimalInstance
+): DecimalInstance {
+  const magnitude = destinationMagnitude.abs();
+  return toDecimal(sourceAmount).isNegative() ? magnitude : magnitude.negated();
+}
+
+/** The writes {@link recordConvertedCounterpart} needs, named rather than imported. */
+export interface CrossCurrencyWriteOps {
+  addTransaction: (transaction: Omit<Transaction, 'id'>) => Promise<Transaction>;
+  updateTransaction: (id: string, updates: Partial<Transaction>) => Promise<void>;
+  linkTransferPair: (idA: string, idB: string) => Promise<unknown>;
+  deleteTransaction: (id: string) => Promise<unknown>;
+}
+
+/**
+ * Give an EXISTING row its converted other side, and join the two.
+ *
+ * The register's route, where one leg is already in the ledger and only the far
+ * side has to be written. (The add form's route writes both, because at that
+ * point neither exists — see `AddTransactionModal.confirmConversion`. The two
+ * sequences differ because the situations differ; what they share, and what
+ * would actually be dangerous to duplicate, is the RULES, and those are the
+ * functions above.)
+ *
+ * `create_transfer_counterpart` is not used and cannot be: it mints the far
+ * side by copying −amount and refuses across a currency boundary, correctly.
+ * This composes the two verbs that are legal here instead — one ordinary insert
+ * into the target account in the target's own currency, and `link_transfer_pair`,
+ * which converts nothing.
+ *
+ * ── ORDER, AND WHY THE SOURCE IS STAMPED LAST ───────────────────────────────
+ *
+ * The far side carries `metadata.fx` from its INSERT, so it is never in the
+ * ledger without the rate that made it. The source is stamped only after the
+ * link SUCCEEDS: stamping it first would leave a row claiming a conversion that
+ * no second row and no link back it up, if the join then failed.
+ *
+ * A failed stamp is logged by the caller rather than unwound. The link is what
+ * the user asked for and it happened; undoing a correct join to preserve a
+ * receipt would be the wrong trade.
+ *
+ * @throws whatever the insert or the link threw, after unwinding the insert
+ */
+export async function recordConvertedCounterpart(
+  ops: CrossCurrencyWriteOps,
+  source: Transaction,
+  target: { accountId: string; category: string },
+  conversion: ConfirmedConversion
+): Promise<void> {
+  const fx = buildFxRecord(conversion.rate, conversion.source, conversion.asOf);
+  const amount = destinationLegAmount(source.amount, conversion.destinationAmount);
+
+  const counterpart = await ops.addTransaction({
+    description: source.description,
+    // Decimal to the boundary: one `toNumber`, on a value already at the penny.
+    amount: amount.toNumber(),
+    type: 'transfer',
+    category: target.category,
+    accountId: target.accountId,
+    transferAccountId: source.accountId,
+    date: source.date,
+    notes: source.notes,
+    metadata: { fx },
+  });
+
+  try {
+    await ops.linkTransferPair(source.id, counterpart.id);
+  } catch (linkError) {
+    // Two unlinked rows are not a transfer — they are one real movement shown
+    // twice, which double-counts in every report.
+    await ops.deleteTransaction(counterpart.id);
+    throw linkError;
+  }
+
+  await ops.updateTransaction(source.id, {
+    metadata: withFxRecord(source.metadata, fx),
+  });
+}

--- a/src/utils/currency-decimal.ts
+++ b/src/utils/currency-decimal.ts
@@ -9,13 +9,69 @@ interface ExchangeRates {
   [key: string]: number;
 }
 
+/**
+ * Where the rates in hand came from.
+ *
+ * This used to be unknowable from outside, and that was the honesty gap: a
+ * failed fetch fell back to a hardcoded table of approximate rates and every
+ * converted total went on reading exactly as if it were live. A figure derived
+ * from a guess and a figure derived from a quote looked identical.
+ */
+export type RatesSource =
+  /** A live quote from the provider named in {@link RATES_PROVIDER}. */
+  | 'api'
+  /** The hardcoded approximations below. The provider could not be reached. */
+  | 'fallback';
+
+export interface RatesProvenance {
+  source: RatesSource;
+  /** When these rates were obtained. */
+  asOf: Date;
+}
+
+/** Named, because a converted figure should be able to say who quoted it. */
+export const RATES_PROVIDER = 'exchangerate-api.com';
+
 // Cache exchange rates for 1 hour
 let ratesCache: {
   rates: ExchangeRates;
   timestamp: number;
+  source: RatesSource;
 } | null = null;
 
 const CACHE_DURATION = 60 * 60 * 1000; // 1 hour in milliseconds
+
+/**
+ * How long a FALLBACK is held before trying the provider again.
+ *
+ * Deliberately far shorter than {@link CACHE_DURATION}. Caching a failure for a
+ * full hour means one dropped request leaves every total in the app labelled
+ * "approximate" long after the network came back — the warning stops being
+ * information and becomes furniture, which is how a real one gets ignored. Five
+ * minutes retries soon enough to clear itself, and rarely enough that a genuinely
+ * offline desktop is not retrying on every render.
+ */
+const FALLBACK_CACHE_DURATION = 5 * 60 * 1000;
+
+/**
+ * Approximate rates, used only when the provider cannot be reached.
+ *
+ * These are a fixed table. They are wrong the day after they were written and
+ * they get wronger; the only thing that makes them acceptable is that every
+ * total computed from them says so. See {@link getRatesProvenance}.
+ */
+const FALLBACK_RATES: ExchangeRates = {
+  GBP: 1,
+  USD: 1.27,
+  EUR: 1.17,
+  CAD: 1.71,
+  AUD: 1.92,
+  JPY: 189.50,
+  CHF: 1.12,
+  CNY: 9.19,
+  INR: 105.85,
+  NZD: 2.09,
+};
 
 // Currency symbols
 export const currencySymbols: Record<string, string> = {
@@ -85,53 +141,78 @@ export function formatCurrencyWhole(
 }
 
 // Fetch exchange rates from a free API
-async function fetchExchangeRates(): Promise<ExchangeRates> {
+async function fetchExchangeRates(): Promise<{ rates: ExchangeRates; source: RatesSource }> {
   try {
     // Using exchangerate-api.com free tier
     const response = await fetch('https://api.exchangerate-api.com/v4/latest/GBP');
-    
+
     if (!response.ok) {
       throw new Error('Failed to fetch exchange rates');
     }
-    
+
     const data = await response.json();
-    return data.rates;
+    return { rates: data.rates, source: 'api' };
   } catch (error) {
     currencyLogger.error('Error fetching exchange rates:', error);
-    
-    // Fallback to approximate rates if API fails
-    return {
-      GBP: 1,
-      USD: 1.27,
-      EUR: 1.17,
-      CAD: 1.71,
-      AUD: 1.92,
-      JPY: 189.50,
-      CHF: 1.12,
-      CNY: 9.19,
-      INR: 105.85,
-      NZD: 2.09,
-    };
+
+    // Fallback to approximate rates if API fails. The caller is TOLD it is a
+    // fallback — this is the one branch that used to be silent, and a total
+    // built on a guess that cannot say so is the thing this reports.
+    return { rates: { ...FALLBACK_RATES }, source: 'fallback' };
   }
 }
 
 // Get cached or fresh exchange rates
 export async function getExchangeRates(): Promise<ExchangeRates> {
+  return (await getExchangeRatesWithProvenance()).rates;
+}
+
+/**
+ * The rates, and where they came from.
+ *
+ * The same fetch and the same cache as {@link getExchangeRates} — that function
+ * is now this one with the provenance dropped, so there is exactly one cache and
+ * no way for the two to disagree about which rates are in hand.
+ */
+export async function getExchangeRatesWithProvenance(): Promise<{
+  rates: ExchangeRates;
+  provenance: RatesProvenance;
+}> {
   const now = Date.now();
-  
-  // Return cached rates if still valid
-  if (ratesCache && (now - ratesCache.timestamp) < CACHE_DURATION) {
-    return ratesCache.rates;
+
+  // A fallback is held for minutes, a live quote for an hour: see
+  // FALLBACK_CACHE_DURATION for why the two differ.
+  if (ratesCache) {
+    const ttl = ratesCache.source === 'api' ? CACHE_DURATION : FALLBACK_CACHE_DURATION;
+    if ((now - ratesCache.timestamp) < ttl) {
+      return {
+        rates: ratesCache.rates,
+        provenance: { source: ratesCache.source, asOf: new Date(ratesCache.timestamp) },
+      };
+    }
   }
-  
+
   // Fetch fresh rates
-  const rates = await fetchExchangeRates();
+  const { rates, source } = await fetchExchangeRates();
   ratesCache = {
     rates,
     timestamp: now,
+    source,
   };
-  
-  return rates;
+
+  return { rates, provenance: { source, asOf: new Date(now) } };
+}
+
+/**
+ * Where the rates currently in hand came from, WITHOUT fetching.
+ *
+ * `null` means nothing has been fetched yet in this session, which is the
+ * honest answer for a surface that has not converted anything: it has no
+ * provenance to show because it has used no rates.
+ */
+export function getRatesProvenance(): RatesProvenance | null {
+  if (!ratesCache) return null;
+  return { source: ratesCache.source, asOf: new Date(ratesCache.timestamp) };
 }
 
 // Convert amount from one currency to another using Decimal
@@ -180,57 +261,114 @@ export async function convertCurrency(
   }
 }
 
+/**
+ * A total summed across currencies, and everything a reader needs to judge it.
+ *
+ * The point of the extra fields: a single number cannot say whether it was
+ * converted at live rates, converted at approximations, or partly not converted
+ * at all — and those three deserve different amounts of trust.
+ */
+export interface ConvertedTotal {
+  total: DecimalInstance;
+  /**
+   * Where the rates came from, or `null` when NO conversion was needed because
+   * every amount was already in the target currency.
+   *
+   * The null is load-bearing. A person with one currency has no rates involved
+   * in their totals, so there is nothing to disclose to them and the surfaces
+   * that read this render nothing at all.
+   */
+  provenance: RatesProvenance | null;
+  /**
+   * Currencies whose rate was missing. Their amounts were added UNCONVERTED,
+   * which is the pre-existing behaviour — reported now instead of only being
+   * written to the console, because it makes the total wrong by however much
+   * those rows were worth.
+   */
+  unconverted: string[];
+}
+
 // Convert multiple amounts with different currencies to a single currency
 export async function convertMultipleCurrencies(
   amounts: Array<{ amount: DecimalInstance | number; currency: string }>,
   toCurrency: string
 ): Promise<DecimalInstance> {
+  return (await convertMultipleCurrenciesWithProvenance(amounts, toCurrency)).total;
+}
+
+/**
+ * {@link convertMultipleCurrencies}, with the provenance kept rather than
+ * discarded. That function is now this one with the answer narrowed, so the two
+ * cannot compute a total differently.
+ */
+export async function convertMultipleCurrenciesWithProvenance(
+  amounts: Array<{ amount: DecimalInstance | number; currency: string }>,
+  toCurrency: string
+): Promise<ConvertedTotal> {
+  // Nothing to convert: every amount is already in the target currency. No
+  // rates are fetched and no provenance is reported, because none was used.
+  if (amounts.every(({ currency }) => currency === toCurrency)) {
+    return {
+      total: amounts.reduce((sum, { amount }) => sum.plus(toDecimal(amount)), new Decimal(0)),
+      provenance: null,
+      unconverted: [],
+    };
+  }
+
   try {
-    const rates = await getExchangeRates();
-    
+    const { rates, provenance } = await getExchangeRatesWithProvenance();
+
     let total = new Decimal(0);
-    
+    const unconverted = new Set<string>();
+
     for (const { amount, currency } of amounts) {
       const decimalAmount = toDecimal(amount);
-      
+
       if (currency === toCurrency) {
         total = total.plus(decimalAmount);
         continue;
       }
-      
+
       // Check if we have rates for the currency
       if (!rates[currency] || !rates[toCurrency]) {
         currencyLogger.warn(`Missing exchange rate for ${currency} or ${toCurrency}`);
+        unconverted.add(currency);
         total = total.plus(decimalAmount); // Add unconverted amount
         continue;
       }
-      
+
       // Convert to GBP first, then to target currency
       const fromRate = new Decimal(rates[currency]);
       const toRate = new Decimal(rates[toCurrency]);
-      
+
       let inGBP: DecimalInstance;
       if (currency === 'GBP') {
         inGBP = decimalAmount;
       } else {
         inGBP = decimalAmount.dividedBy(fromRate);
       }
-      
+
       let converted: DecimalInstance;
       if (toCurrency === 'GBP') {
         converted = inGBP;
       } else {
         converted = inGBP.times(toRate);
       }
-      
+
       total = total.plus(converted);
     }
-    
-    return total;
+
+    return { total, provenance, unconverted: [...unconverted] };
   } catch (error) {
     currencyLogger.error('Currency conversion error:', error);
-    // Fallback: just sum amounts without conversion
-    return amounts.reduce((sum, { amount }) => sum.plus(toDecimal(amount)), new Decimal(0));
+    // Fallback: just sum amounts without conversion. Every foreign currency in
+    // the set is reported as unconverted, because that is exactly what happened
+    // — the total is a sum of figures in currencies that were never reconciled.
+    return {
+      total: amounts.reduce((sum, { amount }) => sum.plus(toDecimal(amount)), new Decimal(0)),
+      provenance: getRatesProvenance(),
+      unconverted: [...new Set(amounts.map(a => a.currency).filter(c => c !== toCurrency))],
+    };
   }
 }
 

--- a/src/utils/fx.ts
+++ b/src/utils/fx.ts
@@ -1,0 +1,258 @@
+import { Decimal, toDecimal } from './decimal';
+import type { DecimalInstance } from './decimal';
+
+/**
+ * The arithmetic of one cross-currency transfer, and nothing else.
+ *
+ * ── WHY THIS IS A FILE AND NOT A COUPLE OF LINES IN THE DIALOG ──────────────
+ *
+ * The engine REFUSES to mint a transfer counterpart across a currency boundary,
+ * and the refusal is right: `create_transfer_counterpart` writes −amount into
+ * the other ledger with no conversion, so a $1,336.25 source would move a
+ * sterling account by £1,336.25 (see the guard's own words in
+ * `supabase/migrations/20260721090000_transfer_counterpart_currency_guard.sql`
+ * and its local twin `crates/wealth-core/src/verbs/create_transfer_counterpart.rs`).
+ *
+ * This module does not work around that. It is the arithmetic behind a dialog
+ * that asks the PERSON what the other side was worth, so that by the time two
+ * rows exist neither of them was invented by the app. Joining two rows that
+ * already exist is explicitly allowed in every engine — `link_transfer_pair`
+ * lists "two accounts in different currencies | linked" among the things it
+ * does NOT refuse, because "joining two rows that already exist moves nothing,
+ * so there is nothing to convert". That is the seam this feature uses.
+ *
+ * ── A RATE IS A RATIO, NOT MONEY ────────────────────────────────────────────
+ *
+ * Every function here keeps money and rates apart, because they round
+ * differently and the difference is the whole point. Money is exact to the
+ * penny; a rate is a ratio that carries as many places as we can hold. Rounding
+ * a rate to 2dp then multiplying by a five-figure amount loses pounds.
+ *
+ * Amounts round to {@link AMOUNT_DP}. Rates round to {@link RATE_DP} — ten
+ * places, chosen to match the local edition's `fx_rate_e10` column
+ * (`scripts/local-sqlite/schema.sql`), which stores a rate as an integer scaled
+ * by 10^10. A rate produced here can therefore move into that typed column
+ * later without losing a digit.
+ *
+ * ── EVERY RATE HERE IS POSITIVE ─────────────────────────────────────────────
+ *
+ * Rates are computed from ABSOLUTE amounts. A transfer's two legs are signed
+ * oppositely — money leaves one account and arrives in the other — so a signed
+ * ratio would be negative every time and would mean nothing. The sign belongs
+ * to the legs, and the caller applies it. This also matches the local schema's
+ * `fx_rate_e10 > 0` CHECK, which would refuse a negative rate outright.
+ */
+
+/** Places a money amount is held to. Pennies, like every other amount. */
+export const AMOUNT_DP = 2;
+
+/**
+ * Places a RATE is held to.
+ *
+ * Ten, because the local edition's `fx_rate_e10` column scales a rate by 10^10
+ * and a rate that survives this module should survive that column unchanged. It
+ * is also far more than any published rate carries, so no real quote is
+ * truncated by it.
+ */
+export const RATE_DP = 10;
+
+/** Where a rate came from. Stored, so a figure can always be accounted for. */
+export type FxRateSource =
+  /** A live quote from the rates provider. */
+  | 'api'
+  /** The person typed it, or edited what the provider offered. */
+  | 'manual'
+  /**
+   * Neither — computed from two amounts that were ALREADY REAL, by dividing
+   * one by the other. The truest of the three: it is what the money actually
+   * did, spread and fees included, rather than what a mid-market quote says it
+   * should have done.
+   */
+  | 'derived';
+
+/**
+ * What a linked cross-currency pair records about its own conversion, stored on
+ * BOTH legs under `metadata.fx`.
+ *
+ * `rate` is a STRING and that is deliberate: JSON has one number type and it is
+ * a float, so a rate written as a number is a float the moment it is
+ * serialised. The local edition's schema makes the same judgement in the
+ * opposite direction — it BANS the old float `transferMetadata.exchangeRate`
+ * from the metadata blob by CHECK constraint, having promoted it out into a
+ * scaled integer column. An exact decimal string is the representation both
+ * editions can hold losslessly.
+ */
+export interface FxRecord {
+  /** Destination units per ONE source unit, as an exact decimal string. */
+  rate: string;
+  source: FxRateSource;
+  /** When the rate was true, ISO 8601. */
+  asOf: string;
+}
+
+/** The currency pair a rate belongs to, so a stored rate reads unambiguously. */
+export interface FxPair {
+  from: string;
+  to: string;
+}
+
+/**
+ * A rate could not be computed, and why.
+ *
+ * Returned rather than thrown: every caller here is a keystroke handler, and a
+ * half-typed box is not an exceptional condition. `null` alone would not say
+ * which of the two impossible things happened.
+ */
+export type FxFailure =
+  /** The source amount is zero — every rate divides by it. */
+  | 'zero-source'
+  /** One of the amounts was not a number at all. */
+  | 'not-a-number';
+
+export type FxResult<T> = { ok: true; value: T } | { ok: false; reason: FxFailure };
+
+const ok = <T,>(value: T): FxResult<T> => ({ ok: true, value });
+const fail = <T,>(reason: FxFailure): FxResult<T> => ({ ok: false, reason });
+
+/**
+ * Whether a value can be read as a finite decimal.
+ *
+ * Decimal.js accepts a string and yields NaN rather than throwing, so this is
+ * the gate every entry point runs before doing arithmetic on user typing.
+ */
+function readAmount(value: DecimalInstance | number | string): DecimalInstance | null {
+  try {
+    const decimal = toDecimal(value);
+    return decimal.isFinite() && !decimal.isNaN() ? decimal : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * The rate two REAL amounts imply: |destination| ÷ |source|.
+ *
+ * This is the 'derived' case, and it is the most trustworthy number this module
+ * produces because neither input was invented. Two legs that came from bank
+ * feeds have already had the spread and any fee taken out of them, so their
+ * ratio is the rate the person actually got — not the mid-market rate they
+ * didn't.
+ *
+ * Rounded to {@link RATE_DP}. Sign is discarded: see the header.
+ */
+export function deriveRate(
+  sourceAmount: DecimalInstance | number | string,
+  destinationAmount: DecimalInstance | number | string
+): FxResult<DecimalInstance> {
+  const source = readAmount(sourceAmount);
+  const destination = readAmount(destinationAmount);
+  if (source === null || destination === null) return fail('not-a-number');
+  if (source.isZero()) return fail('zero-source');
+
+  return ok(
+    destination
+      .abs()
+      .dividedBy(source.abs())
+      .toDecimalPlaces(RATE_DP, Decimal.ROUND_HALF_UP)
+  );
+}
+
+/**
+ * The destination amount a rate implies: |source| × rate, to the penny.
+ *
+ * The dialog's left-to-right direction. Rounded HALF_UP at
+ * {@link AMOUNT_DP} — the same rounding `formatCurrency` uses, so the figure
+ * the person confirms is the figure they will later read back.
+ */
+export function destinationForRate(
+  sourceAmount: DecimalInstance | number | string,
+  rate: DecimalInstance | number | string
+): FxResult<DecimalInstance> {
+  const source = readAmount(sourceAmount);
+  const rateValue = readAmount(rate);
+  if (source === null || rateValue === null) return fail('not-a-number');
+
+  return ok(
+    source
+      .abs()
+      .times(rateValue.abs())
+      .toDecimalPlaces(AMOUNT_DP, Decimal.ROUND_HALF_UP)
+  );
+}
+
+/**
+ * The rate a destination amount implies, for the dialog's other direction.
+ *
+ * Identical arithmetic to {@link deriveRate}; named separately because the two
+ * call sites mean different things — this one is a person editing a figure,
+ * that one is two feeds being compared — and a stored `source` of 'manual'
+ * versus 'derived' turns on which happened.
+ */
+export function rateForDestination(
+  sourceAmount: DecimalInstance | number | string,
+  destinationAmount: DecimalInstance | number | string
+): FxResult<DecimalInstance> {
+  return deriveRate(sourceAmount, destinationAmount);
+}
+
+/**
+ * A rate as it is STORED: an exact decimal string, trailing zeros removed.
+ *
+ * `toFixed` would pad "0.79" to "0.7900000000", which stores ten digits of
+ * precision the quote never had. Decimal's own `toString` is exact and carries
+ * only the digits that exist — and because the value has already been rounded
+ * to {@link RATE_DP}, it can never arrive here in exponential form for any rate
+ * a real currency pair produces.
+ */
+export function rateToStorageString(rate: DecimalInstance): string {
+  return rate.toDecimalPlaces(RATE_DP, Decimal.ROUND_HALF_UP).toString();
+}
+
+/**
+ * The `metadata.fx` object for one linked pair. Written to BOTH legs unchanged:
+ * the rate is a property of the CONVERSION, not of either row, so two legs that
+ * disagreed about it would be a bug with no correct reading.
+ */
+export function buildFxRecord(
+  rate: DecimalInstance,
+  source: FxRateSource,
+  asOf: Date
+): FxRecord {
+  return {
+    rate: rateToStorageString(rate),
+    source,
+    asOf: asOf.toISOString(),
+  };
+}
+
+/**
+ * Read back an `metadata.fx` written by {@link buildFxRecord}.
+ *
+ * Defensive because metadata is an open jsonb blob that other writers share:
+ * anything shaped wrong reads as absent rather than throwing inside a render.
+ */
+export function readFxRecord(metadata: unknown): FxRecord | null {
+  if (typeof metadata !== 'object' || metadata === null) return null;
+  const fx = (metadata as Record<string, unknown>).fx;
+  if (typeof fx !== 'object' || fx === null) return null;
+
+  const candidate = fx as Record<string, unknown>;
+  const { rate, source, asOf } = candidate;
+  if (typeof rate !== 'string' || rate === '') return null;
+  if (source !== 'api' && source !== 'manual' && source !== 'derived') return null;
+  if (typeof asOf !== 'string' || asOf === '') return null;
+  if (readAmount(rate) === null) return null;
+
+  return { rate, source, asOf };
+}
+
+/**
+ * "1 USD = 0.79 GBP" — the sentence a rate is quoted in.
+ *
+ * Trailing zeros are already gone (see {@link rateToStorageString}), so a rate
+ * of exactly 2 reads "1 GBP = 2 USD" rather than "2.0000000000".
+ */
+export function describeRate(rate: DecimalInstance | string, pair: FxPair): string {
+  const value = typeof rate === 'string' ? rate : rateToStorageString(rate);
+  return `1 ${pair.from} = ${value} ${pair.to}`;
+}

--- a/src/utils/strandedTransfers.ts
+++ b/src/utils/strandedTransfers.ts
@@ -7,7 +7,16 @@ import {
   type SplitLegSuggestion,
   type TransferPairSuggestion,
 } from './transferSweep';
-import type { Category, Transaction, TransactionSplit } from '../types';
+import {
+  accountCurrencyIndex,
+  compareCrossCurrencyCandidates,
+  crossCurrencyCandidate,
+  hasMultipleCurrencies,
+  type AccountCurrencyIndex,
+  type CrossCurrencyRateLookup,
+} from './crossCurrencyMatch';
+import type { CrossCurrency } from './crossCurrencyTransfer';
+import type { Account, Category, Transaction, TransactionSplit } from '../types';
 
 /**
  * Stranded transfers — the residue the clean sweep cannot touch.
@@ -86,6 +95,13 @@ export interface CategorisedTwinFinding extends FindingBase {
   counterpartCategoryName: string;
   daysApart: number;
   descriptionScore: number;
+  /**
+   * Set when the twin is in an account counting in ANOTHER currency, oriented
+   * row → counterpart. The two figures will not match and must not be expected
+   * to; the UI shows both currencies so the user is judging a conversion rather
+   * than an arithmetic error.
+   */
+  crossCurrency?: CrossCurrency;
 }
 
 /** Transfer-shaped, but nothing anywhere in the window is its opposite. */
@@ -113,6 +129,14 @@ export interface StrandedSweepOptions {
    * over a long history is wasted work.
    */
   sweepSuggestions?: TransferPairSuggestion[];
+  /**
+   * The accounts, so a twin in another currency can be recognised as one.
+   * Without them nothing here changes: every classifier keeps asking its
+   * exact-amount question and gets its old answer.
+   */
+  accounts?: readonly Account[];
+  /** A quote used to RANK cross-currency twins. Never to exclude one. */
+  rateLookup?: CrossCurrencyRateLookup;
 }
 
 const pennies = (amount: number): number => toDecimal(amount).times(100).toDecimalPlaces(0).toNumber();
@@ -190,6 +214,11 @@ export function findStrandedTransfers(
     windowDays,
     onlyUncategorised: true,
     categoryIds,
+    // Threaded through so a row the CROSS-CURRENCY pass paired counts as swept
+    // and never turns up here as stranded. A caller that passes its own
+    // `sweepSuggestions` has already made that choice for itself.
+    ...(opts.accounts ? { accounts: opts.accounts } : {}),
+    ...(opts.rateLookup ? { rateLookup: opts.rateLookup } : {}),
   }).suggestions;
 
   const swept = new Set<string>();
@@ -232,13 +261,18 @@ export function findStrandedTransfers(
     return !hasRealCategory;
   });
 
+  // Built only for a book that actually holds more than one currency, and
+  // `null` otherwise — which is the state every existing ledger is in, and the
+  // state in which every classifier below behaves exactly as it did.
+  const crossIndex = buildCrossTwinIndex(transactions, opts);
+
   const findings: StrandedFinding[] = [];
 
   for (const row of population) {
     const finding =
       duplicateFindingFor(row, takenByDayAmount) ??
       claimedTwinFindingFor(row, allByAmount, byId, windowDays) ??
-      categorisedTwinFindingFor(row, allByAmount, categoryById, windowDays) ??
+      categorisedTwinFindingFor(row, allByAmount, categoryById, windowDays, crossIndex) ??
       oneSidedFindingFor(row, allByAmount, windowDays);
     if (finding) findings.push(finding);
   }
@@ -344,21 +378,31 @@ function categorisedTwinFindingFor(
   row: Transaction,
   allByAmount: Map<number, Transaction[]>,
   categoryById: Map<string, Category>,
-  windowDays: number
+  windowDays: number,
+  crossIndex: CrossTwinIndex | null
 ): CategorisedTwinFinding | null {
   if (!isActionable(row)) return null;
 
-  const candidates: CategorisedTwinFinding[] = [];
-  for (const counterpart of allByAmount.get(-pennies(row.amount)) ?? []) {
-    if (counterpart.id === row.id) continue;
-    if (counterpart.accountId === row.accountId) continue;
-    if (isTakenAsTransfer(counterpart)) continue;
-    if (!isActionable(counterpart)) continue;
+  /** The shared eligibility of a twin, whatever currency it counts in. */
+  const filedCategoryOf = (counterpart: Transaction): Category | null => {
+    if (counterpart.id === row.id) return null;
+    if (counterpart.accountId === row.accountId) return null;
+    if (isTakenAsTransfer(counterpart)) return null;
+    if (!isActionable(counterpart)) return null;
 
     const category = counterpart.category ? categoryById.get(counterpart.category) : undefined;
     // A transfer category or an importer's unassigned bucket is not a filing
     // the user made, so neither counts as "somebody categorised this".
-    if (!category || category.isTransferCategory === true || category.isUnassignedBucket === true) continue;
+    if (!category || category.isTransferCategory === true || category.isUnassignedBucket === true) {
+      return null;
+    }
+    return category;
+  };
+
+  const candidates: CategorisedTwinFinding[] = [];
+  for (const counterpart of allByAmount.get(-pennies(row.amount)) ?? []) {
+    const category = filedCategoryOf(counterpart);
+    if (!category) continue;
 
     const daysApart = daysBetween(row, counterpart);
     if (daysApart > windowDays) continue;
@@ -379,7 +423,123 @@ function categorisedTwinFindingFor(
       b.descriptionScore - a.descriptionScore ||
       a.counterpart.id.localeCompare(b.counterpart.id)
   );
-  return candidates[0] ?? null;
+  if (candidates[0]) return candidates[0];
+
+  /**
+   * ── AND ONLY THEN, ACROSS A CURRENCY BOUNDARY ─────────────────────────────
+   *
+   * Reached exclusively when no exact twin exists at all, which is what keeps
+   * every same-currency answer above identical to the character: this branch
+   * cannot run on a row that had one.
+   *
+   * The restraint is also what makes the offer usable. A cross-currency twin is
+   * matched on SIGN alone — no magnitude test is permitted, because the ratio
+   * between the magnitudes is the achieved rate — so on a busy fortnight a row
+   * could otherwise be "twinned" with a dozen unrelated foreign rows. Requiring
+   * that nothing exact exists first means the question is only ever asked where
+   * it is the last remaining explanation.
+   *
+   * The finding's own framing carries the rest: it says the twin is EITHER a
+   * mis-filed transfer leg OR a coincidence, and that nothing here can tell
+   * which. That was already the honest sentence for two same-amount rows; it is
+   * the same sentence, with the amounts no longer expected to match.
+   */
+  return crossIndex ? crossCurrencyTwinFor(row, filedCategoryOf, windowDays, crossIndex) : null;
+}
+
+/**
+ * Free, categorised rows bucketed by calendar day and sign, so a cross-currency
+ * twin can be looked for without an amount to key on.
+ *
+ * The same index the sweep's own cross-currency pass builds and for the same
+ * reason: across a boundary the amount is not a lookup key, and the date is.
+ */
+interface CrossTwinIndex {
+  currencies: AccountCurrencyIndex;
+  positives: Map<number, Transaction[]>;
+  negatives: Map<number, Transaction[]>;
+  rateLookup?: CrossCurrencyRateLookup;
+}
+
+function buildCrossTwinIndex(
+  transactions: Transaction[],
+  opts: StrandedSweepOptions
+): CrossTwinIndex | null {
+  if (!opts.accounts) return null;
+  const currencies = accountCurrencyIndex(opts.accounts);
+  // A single-currency book can produce no cross-currency twin, so it pays for
+  // no index at all.
+  if (!hasMultipleCurrencies(currencies)) return null;
+
+  const positives = new Map<number, Transaction[]>();
+  const negatives = new Map<number, Transaction[]>();
+  for (const t of transactions) {
+    if (toDecimal(t.amount).isZero()) continue;
+    if (!currencies.has(t.accountId)) continue;
+    const bucket = toDecimal(t.amount).isNegative() ? negatives : positives;
+    const day = dayNumberOf(t.date);
+    const list = bucket.get(day);
+    if (list) list.push(t);
+    else bucket.set(day, [t]);
+  }
+
+  return {
+    currencies,
+    positives,
+    negatives,
+    ...(opts.rateLookup ? { rateLookup: opts.rateLookup } : {}),
+  };
+}
+
+const dayNumberOf = (date: Date | string): number => Math.floor(timeOf(date) / DAY_MS);
+
+/** The best cross-currency twin for a row, or null. Ranked date-first. */
+function crossCurrencyTwinFor(
+  row: Transaction,
+  filedCategoryOf: (counterpart: Transaction) => Category | null,
+  windowDays: number,
+  crossIndex: CrossTwinIndex
+): CategorisedTwinFinding | null {
+  const bucket = toDecimal(row.amount).isNegative() ? crossIndex.positives : crossIndex.negatives;
+  const span = Math.ceil(windowDays);
+  const day = dayNumberOf(row.date);
+
+  const candidates: Array<CategorisedTwinFinding & { rateDivergence?: number }> = [];
+  for (let d = day - span; d <= day + span; d += 1) {
+    for (const counterpart of bucket.get(d) ?? []) {
+      const category = filedCategoryOf(counterpart);
+      if (!category) continue;
+
+      const daysApart = daysBetween(row, counterpart);
+      if (daysApart > windowDays) continue;
+
+      const match = crossCurrencyCandidate(row, counterpart, crossIndex.currencies, crossIndex.rateLookup);
+      if (!match) continue;
+
+      candidates.push({
+        kind: 'categorised',
+        row,
+        counterpart,
+        counterpartCategoryName: category.name,
+        daysApart,
+        descriptionScore: calculateStringSimilarity(row.description, counterpart.description),
+        crossCurrency: match.pair,
+        ...(match.rateDivergence === undefined ? {} : { rateDivergence: match.rateDivergence }),
+      });
+    }
+  }
+
+  candidates.sort(
+    (a, b) =>
+      compareCrossCurrencyCandidates(a, b) || a.counterpart.id.localeCompare(b.counterpart.id)
+  );
+
+  const best = candidates[0];
+  if (!best) return null;
+  // `rateDivergence` ranked this list and has no meaning to a reader of the
+  // finding — a market's opinion is not evidence the UI should repeat.
+  const { rateDivergence: _ranked, ...finding } = best;
+  return finding;
 }
 
 /**

--- a/src/utils/transferMatch.ts
+++ b/src/utils/transferMatch.ts
@@ -1,6 +1,13 @@
 import { toDecimal } from './decimal';
 import { calculateStringSimilarity } from './duplicateScan';
-import type { Transaction, Category } from '../types';
+import {
+  accountCurrencyIndex,
+  compareCrossCurrencyCandidates,
+  crossCurrencyCandidate,
+  type CrossCurrencyRateLookup,
+} from './crossCurrencyMatch';
+import { crossedCurrencyPair, type CrossCurrency } from './crossCurrencyTransfer';
+import type { Transaction, Category, Account } from '../types';
 
 /**
  * Transfer matching (the Microsoft Money model): when a transaction is filed
@@ -20,17 +27,64 @@ export interface TransferCandidate {
   daysApart: number;
   /** 0–100 similarity of the two descriptions (tie-breaking only). */
   descriptionScore: number;
+  /**
+   * Set when this candidate sits across a CURRENCY boundary — the source's
+   * currency and the candidate's. Absent for the ordinary same-currency match,
+   * so `crossCurrency` being present is exactly the question the UI asks before
+   * showing the boundary on the row.
+   */
+  crossCurrency?: CrossCurrency;
+  /** See crossCurrencyMatch. Sorting only, and only ever set alongside `crossCurrency`. */
+  rateDivergence?: number;
+}
+
+/**
+ * What this matcher needs in order to consider a candidate in ANOTHER currency.
+ *
+ * A fifth parameter rather than a reshaped fourth, deliberately: `windowDays`
+ * has been the fourth positional argument since this function existed, and the
+ * behaviour of every existing call had to stay identical to the character. A
+ * caller that passes none of this gets precisely the matcher it had before.
+ */
+export interface TransferMatchOptions {
+  /**
+   * The accounts, so the two currencies can be established. Without them no
+   * currency is knowable, and — per `crossedCurrencyPair` — an unknown currency
+   * reads as "same", which keeps the exact-amount rule in force.
+   */
+  accounts?: readonly Account[];
+  /** A quote for ranking cross-currency candidates. Never filters: see crossCurrencyMatch. */
+  rateLookup?: CrossCurrencyRateLookup;
 }
 
 const DAY_MS = 1000 * 60 * 60 * 24;
 
 export const TRANSFER_MATCH_WINDOW_DAYS = 4;
 
+/**
+ * ── ONE ACCOUNT, TWO POSSIBLE RULES ─────────────────────────────────────────
+ *
+ * This matcher looks in exactly one named account, because the user has already
+ * said where the money went. So whether a currency boundary is being crossed is
+ * a property of the CALL, not of each candidate: both currencies are read once,
+ * and the rule that applies to every row in the list follows from them.
+ *
+ * Same currency (or either unknown, or no accounts given): the amount must be
+ * exactly the source negated, as it always has been.
+ *
+ * Different currencies: opposite in sign and non-zero, with no constraint on
+ * magnitude — the engine's own rule for a link across a boundary. Note that the
+ * exact-opposite amount still qualifies, because it is opposite in sign; it
+ * simply stops being privileged, which is right. Two real conversions almost
+ * never produce equal magnitudes, and when they do it is a coincidence rather
+ * than evidence.
+ */
 export function findTransferCandidates(
   transactions: Transaction[],
   source: Transaction,
   targetAccountId: string,
-  windowDays: number = TRANSFER_MATCH_WINDOW_DAYS
+  windowDays: number = TRANSFER_MATCH_WINDOW_DAYS,
+  options: TransferMatchOptions = {}
 ): TransferCandidate[] {
   const sourceAmount = toDecimal(source.amount);
   if (sourceAmount.isZero()) {
@@ -39,6 +93,17 @@ export function findTransferCandidates(
   const oppositeAmount = sourceAmount.negated();
   const sourceTime = new Date(source.date).getTime();
 
+  // Read once, for the whole call. `undefined` on either side means the strict
+  // rule below applies, which is the safe direction.
+  const accounts = options.accounts;
+  const crossed = accounts
+    ? crossedCurrencyPair(
+        accounts.find(a => a.id === source.accountId)?.currency,
+        accounts.find(a => a.id === targetAccountId)?.currency
+      )
+    : null;
+  const index = crossed && accounts ? accountCurrencyIndex(accounts) : null;
+
   const candidates: TransferCandidate[] = [];
   for (const transaction of transactions) {
     if (transaction.accountId !== targetAccountId) continue;
@@ -46,7 +111,12 @@ export function findTransferCandidates(
     // A split parent cannot be a transfer, and an already-linked side is taken.
     if (transaction.isSplit) continue;
     if (transaction.linkedTransferId) continue;
-    if (!toDecimal(transaction.amount).equals(oppositeAmount)) continue;
+
+    // The one branch. Everything else about a candidate is unchanged.
+    const match = index
+      ? crossCurrencyCandidate(source, transaction, index, options.rateLookup)
+      : null;
+    if (index ? !match : !toDecimal(transaction.amount).equals(oppositeAmount)) continue;
 
     const daysApart = Math.abs(new Date(transaction.date).getTime() - sourceTime) / DAY_MS;
     if (daysApart > windowDays) continue;
@@ -55,11 +125,18 @@ export function findTransferCandidates(
       transaction,
       daysApart,
       descriptionScore: calculateStringSimilarity(source.description, transaction.description),
+      ...(match ? { crossCurrency: match.pair, rateDivergence: match.rateDivergence } : {}),
     });
   }
 
-  // Closest date wins; description similarity breaks ties.
-  candidates.sort((a, b) => a.daysApart - b.daysApart || b.descriptionScore - a.descriptionScore);
+  // Closest date wins; description similarity breaks ties. A cross-currency
+  // list uses the shared comparator, which inserts rate plausibility between
+  // those two — and reduces to exactly this ordering when no quote was given.
+  candidates.sort(
+    crossed
+      ? compareCrossCurrencyCandidates
+      : (a, b) => a.daysApart - b.daysApart || b.descriptionScore - a.descriptionScore
+  );
   return candidates;
 }
 

--- a/src/utils/transferSweep.ts
+++ b/src/utils/transferSweep.ts
@@ -1,6 +1,15 @@
 import { toDecimal } from './decimal';
 import { calculateStringSimilarity } from './duplicateScan';
-import type { Transaction, TransactionSplit } from '../types';
+import {
+  accountCurrencyIndex,
+  compareCrossCurrencyCandidates,
+  crossCurrencyCandidate,
+  hasMultipleCurrencies,
+  type AccountCurrencyIndex,
+  type CrossCurrencyRateLookup,
+} from './crossCurrencyMatch';
+import type { CrossCurrency } from './crossCurrencyTransfer';
+import type { Account, Transaction, TransactionSplit } from '../types';
 
 /**
  * Bulk transfer matching — find every unlinked equal-and-opposite pair in one
@@ -50,6 +59,16 @@ export interface TransferPairSuggestion {
   descriptionScore: number;
   /** True when other equally-close candidates existed for this row. */
   ambiguous: boolean;
+  /**
+   * Set only for a pair that crosses a CURRENCY boundary, oriented outgoing →
+   * incoming: `from` is the currency the money left, `to` the currency it
+   * arrived in. Its presence is what tells the review UI to show the boundary
+   * on the row, because the two figures alone cannot say it — a bare
+   * "−100.00 / +74.20" reads as a broken match rather than a conversion.
+   */
+  crossCurrency?: CrossCurrency;
+  /** See crossCurrencyMatch. Sorting only, and only ever set alongside `crossCurrency`. */
+  rateDivergence?: number;
 }
 
 /**
@@ -157,6 +176,15 @@ export function sweepTransferPairs(
      * comes back empty.
      */
     splits?: TransactionSplit[];
+    /**
+     * The accounts, which is the only way to know what currency a row counts
+     * in. Without them the cross-currency pass does not run at all and this
+     * function behaves exactly as it did before that pass existed — the same
+     * bargain `splits` strikes above.
+     */
+    accounts?: readonly Account[];
+    /** A quote used to RANK cross-currency candidates. Never to exclude one. */
+    rateLookup?: CrossCurrencyRateLookup;
   } = {}
 ): TransferSweepResult {
   const windowDays = opts.windowDays ?? SWEEP_WINDOW_DAYS;
@@ -253,6 +281,23 @@ export function sweepTransferPairs(
     ? sweepSplitLegs(legs, eligible, used, windowDays)
     : [];
 
+  // The cross-currency pass, LAST of the three and additive on the same terms.
+  // It shares `used` and runs after both passes above have taken what they
+  // wanted, so every suggestion and every leg match they produced is exactly
+  // what it would have been without this pass existing. It can only ever pair
+  // rows that nothing else could use — which is also the honest description of
+  // what it is for: −$100 and +£74.20 were invisible to both.
+  const index = opts.accounts ? accountCurrencyIndex(opts.accounts) : null;
+  //
+  // APPENDED, never merged in by a re-sort: the same-currency suggestions keep
+  // the exact positions they had, because the order this array comes out in is
+  // observable and pinned by tests. The review UI applies its own ordering to
+  // the rows it shows (compareRows in TransferSweepModal), so nothing on screen
+  // depends on the cross-currency entries arriving at the end.
+  if (index && hasMultipleCurrencies(index)) {
+    suggestions.push(...sweepCrossCurrencyPairs(eligible, used, windowDays, index, opts.rateLookup));
+  }
+
   return { suggestions, legSuggestions, scanned: eligible.length, legsScanned: legs.length };
 }
 
@@ -336,3 +381,156 @@ function sweepSplitLegs(
 
   return suggestions;
 }
+
+/**
+ * Pair what is LEFT across a currency boundary.
+ *
+ * ── WHY THIS PASS CANNOT BUCKET BY AMOUNT, AND WHAT IT BUCKETS BY INSTEAD ────
+ *
+ * Both passes above find their candidates in O(1) by looking up the exact
+ * opposite penny amount. Across a boundary there is no such key: the whole
+ * point is that £74.20 is the opposite of $100.00, and the number that connects
+ * them is a rate this file is not allowed to have an opinion about.
+ *
+ * So the index is the other fact a pair must satisfy — the DATE. Rows are
+ * bucketed by calendar day and by sign, and a row consults only the ±window
+ * days of buckets holding the opposite sign: nine buckets at the standard
+ * window of four days. That keeps the pass linear in the leftovers rather than
+ * quadratic, which matters because the rows reaching it are precisely the ones
+ * nothing else could pair — on a long history that is a big pile.
+ *
+ * The pass is skipped outright for a single-currency book (see
+ * `hasMultipleCurrencies`), which is most books, so none of this is paid for by
+ * a ledger it cannot apply to.
+ */
+function sweepCrossCurrencyPairs(
+  eligible: Transaction[],
+  used: Set<string>,
+  windowDays: number,
+  index: AccountCurrencyIndex,
+  rateLookup?: CrossCurrencyRateLookup
+): TransferPairSuggestion[] {
+  const dayOf = (t: Transaction): number => Math.floor(timeOf(t.date) / DAY_MS);
+  const span = Math.ceil(windowDays);
+
+  // Leftovers only, split by sign: a candidate must be opposite in sign, so the
+  // two halves never look at themselves.
+  const positives = new Map<number, Transaction[]>();
+  const negatives = new Map<number, Transaction[]>();
+  const remaining: Transaction[] = [];
+  for (const t of eligible) {
+    if (used.has(t.id)) continue;
+    // A row in an account of unknown currency can pair with nothing here —
+    // `crossCurrencyCandidate` would decline it — so it is not indexed either.
+    if (!index.has(t.accountId)) continue;
+    remaining.push(t);
+    const bucket = toDecimal(t.amount).isNegative() ? negatives : positives;
+    const day = dayOf(t);
+    const list = bucket.get(day);
+    if (list) list.push(t);
+    else bucket.set(day, [t]);
+  }
+  if (remaining.length === 0) return [];
+
+  /** Every leftover row of the OPPOSITE sign whose day is within the window. */
+  const nearby = (row: Transaction): Transaction[] => {
+    const bucket = toDecimal(row.amount).isNegative() ? positives : negatives;
+    const day = dayOf(row);
+    const found: Transaction[] = [];
+    for (let d = day - span; d <= day + span; d += 1) {
+      const list = bucket.get(d);
+      if (list) found.push(...list);
+    }
+    return found;
+  };
+
+  /** One row's viable partner, with everything the ranking needs. */
+  interface CrossCandidate {
+    transaction: Transaction;
+    pair: CrossCurrency;
+    rateDivergence?: number;
+    daysApart: number;
+    descriptionScore: number;
+  }
+
+  /** The viable partners for `from`, ranked. `skipId` drops a known partner. */
+  const rank = (from: Transaction, skipId?: string): CrossCandidate[] => {
+    const fromTime = timeOf(from.date);
+    return nearby(from)
+      .flatMap<CrossCandidate>(other => {
+        if (used.has(other.id) || other.id === skipId) return [];
+        const daysApart = Math.abs(timeOf(other.date) - fromTime) / DAY_MS;
+        if (daysApart > windowDays) return [];
+        const match = crossCurrencyCandidate(from, other, index, rateLookup);
+        if (!match) return [];
+        return [{
+          transaction: other,
+          pair: match.pair,
+          daysApart,
+          descriptionScore: calculateStringSimilarity(from.description, other.description),
+          ...(match.rateDivergence === undefined ? {} : { rateDivergence: match.rateDivergence }),
+        }];
+      })
+      .sort(compareCrossCurrencyCandidates);
+  };
+
+  // Deterministic order, exactly as the pass above: oldest first, id as the
+  // tie-break, so a re-run over unchanged data pairs identically.
+  const ordered = [...remaining].sort(
+    (a, b) => timeOf(a.date) - timeOf(b.date) || a.id.localeCompare(b.id)
+  );
+
+  const suggestions: TransferPairSuggestion[] = [];
+  for (const row of ordered) {
+    if (used.has(row.id)) continue;
+
+    const candidates = rank(row);
+    const best = candidates[0];
+    if (!best) continue;
+
+    // The reverse direction, on the same terms as the same-currency pass: other
+    // free rows that could equally claim the partner this row chose. Which side
+    // the sweep reaches first is an accident of ordering, so a tie is only
+    // honest if it is checked from both ends. `row` itself is still unused and
+    // therefore in this list, so the top two being level means a genuine tie.
+    const partner = best.transaction;
+    const rivals = rank(partner, partner.id);
+
+    used.add(row.id);
+    used.add(partner.id);
+
+    const rowIsOutgoing = toDecimal(row.amount).isNegative();
+    // `match.pair` is oriented row → partner. The suggestion is oriented
+    // outgoing → incoming, which is the same thing only when the row IS the
+    // outgoing side; otherwise the pair is read the other way round, so that
+    // `from` always names the currency the money actually left.
+    const pair = rowIsOutgoing
+      ? best.pair
+      : { from: best.pair.to, to: best.pair.from };
+
+    suggestions.push({
+      outgoing: rowIsOutgoing ? row : partner,
+      incoming: rowIsOutgoing ? partner : row,
+      daysApart: best.daysApart,
+      descriptionScore: best.descriptionScore,
+      ambiguous: equallyGoodCrossCurrency(candidates) || equallyGoodCrossCurrency(rivals),
+      crossCurrency: pair,
+      ...(best.rateDivergence === undefined ? {} : { rateDivergence: best.rateDivergence }),
+    });
+  }
+
+  return suggestions;
+}
+
+/**
+ * `equallyGood`, for a list ranked with the cross-currency comparator.
+ *
+ * The same-currency version compares the two fields it sorts on. This one has
+ * to consult the comparator itself, because a third field sits between them and
+ * "the top two are indistinguishable" must mean indistinguishable to the thing
+ * that ordered them — otherwise two candidates the rate cleanly separates would
+ * still be flagged ambiguous, and the flag would stop meaning anything.
+ */
+const equallyGoodCrossCurrency = (
+  list: Array<{ daysApart: number; rateDivergence?: number; descriptionScore: number }>
+): boolean => list.length > 1 && compareCrossCurrencyCandidates(list[0], list[1]) === 0;

--- a/supabase/migrations/20260812100000_transfer_linking_across_currencies.sql
+++ b/supabase/migrations/20260812100000_transfer_linking_across_currencies.sql
@@ -1,0 +1,192 @@
+-- ============================================================================
+-- link_transfer_pair — refusal 5 becomes currency-aware
+-- ============================================================================
+-- IMPORTANT: apply with `npm run db:migrate` (see supabase/migrations/README.md
+-- rule 1 — never the SQL editor). One function is replaced. No column is added,
+-- no row is rewritten by the migration itself, no grant changes, and every
+-- same-currency call behaves exactly as it did before.
+--
+-- ── WHY ─────────────────────────────────────────────────────────────────────
+-- 20260716100000:108-110 guards the join with one unconditional rule:
+--
+--     IF v_a.amount = 0 OR v_a.amount <> -v_b.amount THEN
+--       RAISE EXCEPTION 'transfer sides must have exactly opposite non-zero
+--                        amounts (% vs %)', v_a.amount, v_b.amount;
+--
+-- Two amounts sum to zero only when they are in the same currency, or when the
+-- rate between two currencies is exactly 1. So applied across a currency
+-- boundary that rule is not strict — it refuses EVERY legitimate pair. A
+-- conversion that nets to zero is not a conversion.
+--
+-- That was invisible for a year because the thing it refuses is not a thing
+-- anybody could construct by hand to test, and because the sibling verb's
+-- doc-comment (and this verb's own port) recorded "two accounts in different
+-- currencies -> linked", which was true of the CURRENCY check — there has never
+-- been one here — while refusal 5 quietly refused them all on the amounts.
+--
+-- The data settled it. This ledger already contains 70 legal cross-currency
+-- transfer pairs, every one of them written by the MS Money importer, which
+-- INSERTs rows directly and calls no RPC. Not one of them could have been made
+-- through a runtime verb, and after an unlink not one of them could have been
+-- put back. The engines were stricter than the data they were guarding, which
+-- is not an invariant being enforced — it is an invariant that was never true.
+--
+-- ── THE RULE, IDENTICAL IN ALL THREE ENGINES ────────────────────────────────
+-- This RPC, crates/wealth-core/src/verbs/link_transfer_pair.rs, and the demo
+-- mirror in src/services/api/dataService.ts:
+--
+--   * accounts share a currency  -> UNCHANGED. Exactly opposite, non-zero.
+--                                   Not weakened by a penny.
+--   * currencies differ          -> both non-zero and OPPOSITE IN SIGN.
+--                                   No constraint on magnitude.
+--
+-- No magnitude rule across the boundary, deliberately and permanently: the
+-- ratio between the two magnitudes IS the achieved rate, spread and fees
+-- included. The engine cannot know what the rate should have been, and a
+-- tolerance band would refuse a real bank's real conversion on a volatile day.
+-- What the rate WAS gets recorded by the client in metadata.fx, where a figure
+-- can be accounted for; it is not something to re-derive and second-guess here.
+--
+-- Direction survives, because direction is the part that was ever about money:
+-- one account down, one account up. Two sides that both fall are not one
+-- movement seen twice, whatever the currencies.
+--
+-- A NULL or unreadable currency falls to the STRICT branch — the guard fires
+-- only when BOTH currencies are set and differ, the same rule
+-- 20260721090000:63-74 already uses. That is the safe direction: a currency
+-- nobody can establish is not evidence that a conversion happened, so such a
+-- pair must still sum to zero.
+--
+-- ── WHAT IS DELIBERATELY NOT TOUCHED ────────────────────────────────────────
+-- create_transfer_counterpart keeps its flat cross-currency refusal
+-- (20260721090000) and always will. That verb COPIES a number into the other
+-- ledger; copying across a currency boundary is wrong at any rate, and no
+-- dialog changes that. Joining two rows that already exist copies nothing — it
+-- only says two movements that both really happened are one movement. That
+-- distinction is the whole of this migration and it always was the whole of it.
+--
+-- repair_claimed_transfer (20260805145035) and link_split_line_transfer
+-- (20260806094058) still carry the unconditional copy of refusal 5. Both are
+-- join-shaped and the same argument probably reaches them, but "probably" is
+-- not the standard this schema is held to: each needs its own measurement
+-- against the reference cluster and its own specs. Out of scope here, recorded
+-- rather than silently swept in.
+
+BEGIN;
+
+CREATE OR REPLACE FUNCTION public.link_transfer_pair(
+  p_id_a uuid,
+  p_id_b uuid,
+  p_user_id uuid DEFAULT NULL
+)
+RETURNS jsonb
+LANGUAGE plpgsql SECURITY INVOKER
+SET search_path = public
+AS $$
+DECLARE
+  v_a public.transactions;
+  v_b public.transactions;
+  v_a_new public.transactions;
+  v_b_new public.transactions;
+  v_a_currency text;
+  v_b_currency text;
+BEGIN
+  IF p_id_a = p_id_b THEN
+    RAISE EXCEPTION 'a transaction cannot be linked to itself' USING ERRCODE = '22023';
+  END IF;
+
+  -- Deterministic lock order prevents deadlocks between concurrent links.
+  PERFORM 1 FROM public.transactions
+   WHERE id IN (p_id_a, p_id_b)
+     AND (p_user_id IS NULL OR user_id = p_user_id)
+   ORDER BY id
+   FOR UPDATE;
+
+  SELECT * INTO v_a FROM public.transactions
+   WHERE id = p_id_a AND (p_user_id IS NULL OR user_id = p_user_id);
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'transaction_not_found' USING ERRCODE = 'P0002';
+  END IF;
+  SELECT * INTO v_b FROM public.transactions
+   WHERE id = p_id_b AND (p_user_id IS NULL OR user_id = p_user_id);
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'transaction_not_found' USING ERRCODE = 'P0002';
+  END IF;
+
+  IF v_a.user_id <> v_b.user_id THEN
+    RAISE EXCEPTION 'transactions belong to different users' USING ERRCODE = '28000';
+  END IF;
+  IF v_a.account_id = v_b.account_id THEN
+    RAISE EXCEPTION 'a transfer needs two different accounts' USING ERRCODE = 'P0001';
+  END IF;
+
+  -- Refusal 5, in two versions. Which one applies turns on the two ACCOUNTS,
+  -- so they are read HERE and not sooner: every earlier refusal must still
+  -- fire first, and the check just above has guaranteed the two ids differ.
+  -- No FOR UPDATE — this verb is balance-neutral and writes no account row, so
+  -- it has no reason to hold either one against a concurrent writer.
+  SELECT currency INTO v_a_currency FROM public.accounts
+   WHERE id = v_a.account_id AND user_id = v_a.user_id;
+  SELECT currency INTO v_b_currency FROM public.accounts
+   WHERE id = v_b.account_id AND user_id = v_b.user_id;
+
+  IF v_a_currency IS NOT NULL AND v_b_currency IS NOT NULL
+     AND v_a_currency <> v_b_currency THEN
+    -- Across the boundary: direction, and nothing else. Both zero tests are
+    -- spelled out — unlike the same-currency rule below, there is no negation
+    -- here for a zero second side to fall foul of.
+    IF v_a.amount = 0 OR v_b.amount = 0 OR sign(v_a.amount) = sign(v_b.amount) THEN
+      RAISE EXCEPTION 'transfer sides in different currencies must be opposite in sign and non-zero (% % vs % %)',
+        v_a_currency, v_a.amount, v_b_currency, v_b.amount USING ERRCODE = 'P0001';
+    END IF;
+  ELSIF v_a.amount = 0 OR v_a.amount <> -v_b.amount THEN
+    RAISE EXCEPTION 'transfer sides must have exactly opposite non-zero amounts (% vs %)',
+      v_a.amount, v_b.amount USING ERRCODE = 'P0001';
+  END IF;
+
+  IF v_a.is_split OR v_b.is_split THEN
+    RAISE EXCEPTION 'a split transaction cannot become a transfer — remove the split first'
+      USING ERRCODE = 'P0001';
+  END IF;
+  IF v_a.linked_transfer_id IS NOT NULL OR v_b.linked_transfer_id IS NOT NULL THEN
+    RAISE EXCEPTION 'transaction is already part of a linked transfer' USING ERRCODE = 'P0001';
+  END IF;
+
+  -- Each side files under the OTHER account's To/From category.
+  UPDATE public.transactions
+     SET type = 'transfer',
+         category = public.transfer_category_for(v_a.user_id, v_b.account_id, v_a.amount),
+         transfer_account_id = v_b.account_id,
+         linked_transfer_id = v_b.id,
+         updated_at = now()
+   WHERE id = v_a.id
+  RETURNING * INTO v_a_new;
+
+  UPDATE public.transactions
+     SET type = 'transfer',
+         category = public.transfer_category_for(v_b.user_id, v_a.account_id, v_b.amount),
+         transfer_account_id = v_a.account_id,
+         linked_transfer_id = v_a.id,
+         updated_at = now()
+   WHERE id = v_b.id
+  RETURNING * INTO v_b_new;
+
+  -- Amounts are untouched, so this is balance-neutral by construction — and
+  -- that is exactly why a cross-currency join needs no conversion. Each side
+  -- already counts against its own account in its own currency; the link only
+  -- says the two are one movement.
+  PERFORM public.write_financial_audit(
+    v_a_new.user_id, 'transaction', v_a_new.id, 'update', to_jsonb(v_a), to_jsonb(v_a_new));
+  PERFORM public.write_financial_audit(
+    v_b_new.user_id, 'transaction', v_b_new.id, 'update', to_jsonb(v_b), to_jsonb(v_b_new));
+
+  RETURN jsonb_build_object('a', to_jsonb(v_a_new), 'b', to_jsonb(v_b_new));
+END;
+$$;
+
+-- Restated rather than assumed: CREATE OR REPLACE keeps the existing ACL, and
+-- this says out loud that the surface is unchanged from 20260716100000:239-240.
+REVOKE ALL ON FUNCTION public.link_transfer_pair(uuid, uuid, uuid) FROM public, anon;
+GRANT EXECUTE ON FUNCTION public.link_transfer_pair(uuid, uuid, uuid) TO authenticated, service_role;
+
+COMMIT;


### PR DESCRIPTION
The owner's cross-currency spec, complete, in three commits — plus two design rulings and two type cleanups that were entangled with its files.

## Commit 1 — the engine (⚠️ carries a migration)

**`supabase/migrations/20260812100000_transfer_linking_across_currencies.sql` — the owner must apply it** (the function is already live in production from a manual run; `db:migrate` after merge stamps the history).

Refusal 5 becomes currency-aware, identically in the linking RPC, the Rust core, and the demo mirror: same-currency pairs keep the exact-opposite rule to the penny; different-currency pairs need non-zero amounts opposite in sign, with no opinion about magnitude — the ratio IS the achieved rate. Unknown currency falls strict. The mint refusal is untouched. The T-2 integrity view asks the same question now (it was about to flag all 70 legal importer-created pairs as violations). Verified against a live throwaway cluster: RPC and Rust agree message-for-message; four integration tests exist because a deliberate revert of the Rust branch passed the unit suite in full.

## Commit 3 — the feature

- **The dialog**: rate + source + timestamp, editable rate ⇄ editable arriving amount (each recalculates the other), wired into all three creation surfaces; both legs written outright and linked, never minted; offline degrades to the manual box, never blocks.
- **Derived rates**: linking two existing legs asks nothing — the achieved rate (spread included) is stamped at the one seam every link passes through, `source: 'derived'`.
- **`metadata.fx`** on both legs — decimal strings at the local edition's 10dp scale; both editions persist it **today** (cloud jsonb + the Rust update verb); the reader rejects float rates by design; tests prove survival through the exact mapper that used to silently drop transaction sub-objects.
- **Provenance**: "rates as of HH:MM" under converted totals, a visible degraded state when live rates are unavailable, nothing for single-currency ledgers.
- **Matchers**: cross-currency candidates offered (date-windowed, sign-checked, currencies visible beside figures); a market rate may sort candidates, never filter one.
- **Account Settings** shows currency at last — editable only while the account is empty, settled once money exists.
- **Rulings A + B** (DESIGN_RULINGS_2026-08-12): Accounts count de-ambered; circular-button outline suppression removed with the app's focus ring landing in the same change.

## Commit 2 — cleanup

`investmentData` (written, dropped on save, never read — its truth lives in `public.investments` and structured notes) removed end-to-end; `transferMetadata` (never written or read, float `exchangeRate` trap) removed in commit 3 with its entangled files. The mapper skip-branch is down to `location`.

## Verification

lint · typecheck:strict · **5,960 smoke** · cargo 505 + clippy -D · contract 137 · admission 109 · verbs 491/491 · constraints 67/67 · desktop:verify PASS · live browser run: $100 USD→GBP through the dialog, both legs linked, `rate: "0.7407407407", source: "api"` on each. Follow-ups recorded, not swept: `repair_claimed_transfer` / `link_split_line_transfer` keep the strict guard pending their own measurement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)