### PR TITLE
feat(design): batch 7 pass 1 — the reconciliation page finds its voice, and group totals learn honesty about currency

### DIFF
--- a/.github/workflows/handoff-snapshot.yml
+++ b/.github/workflows/handoff-snapshot.yml
@@ -25,11 +25,19 @@ jobs:
           cache-dependency-path: package-lock.json
 
       - name: Install dependencies
+        # --ignore-scripts, deliberately, in THIS job only: the snapshot check
+        # runs no tests and compiles nothing, but a plain `npm ci` still builds
+        # `canvas` (jsdom's test-time dependency) from source whenever its
+        # prebuilt-binary fetch flakes — and the runner image carries no pixman/
+        # cairo headers, so the whole job dies for a native module it never
+        # uses (twice on 2026-08-12). Skipping lifecycle scripts sidesteps
+        # node-gyp entirely. quality-gates keeps its full `npm ci`: its tests
+        # DO need the postinstalls (esbuild among them).
         run: |
           if [ -f package-lock.json ]; then
-            npm ci
+            npm ci --ignore-scripts
           else
-            npm install
+            npm install --ignore-scripts
           fi
 
       - name: Run handoff snapshot update

--- a/scripts/desktop-bundle-size.mjs
+++ b/scripts/desktop-bundle-size.mjs
@@ -149,9 +149,37 @@ const BINARY = path.join(REPO, 'apps', 'desktop', 'src-tauri', 'target', 'releas
  * paragraph above still applies unchanged — xlsx, jspdf, html2canvas and
  * recharts are 1,335 KiB of the 3,924, and the slice that fixes them is the
  * web app's.
+ *
+ * ── RE-RECORDED AFTER THE DESIGN PASS AND THE FX FEATURE ────────────────────
+ *
+ * 3924.1 → 4070.0 KiB raw, 1211.2 → 1240.6 KiB gzip, measured on a pristine
+ * checkout of a2eec741 (#254). +145.9 raw over two merges, and the whole step
+ * decomposes with no unexplained remainder — each part was measured by the
+ * change that made it, at the time it was made:
+ *
+ *   #253 (design batches 3–6)   ~125 KiB. The design pass's own components —
+ *                               PeriodBar, NetWorthSummary, the skeleton/
+ *                               filtered-empty patterns, the register's new
+ *                               chrome, the de-carded gallery — plus the token
+ *                               sheet's growth in the shared stylesheet.
+ *   #254 (cross-currency FX)    ~20 KiB. The rate dialog, the fx arithmetic,
+ *                               the cross-currency matchers and the provenance
+ *                               line under converted totals.
+ *
+ * Neither is an accidental arrival; both wear the tokens and both passed the
+ * cloud greps on the day. The baseline had simply fallen two merges behind the
+ * renderer it describes, which turned the drift figure into a ~146 KiB head
+ * start for whatever came next — the exact blindness this file exists to
+ * prevent. Budgets unchanged: 4320/1335 now sit ~6–8% above measured, tighter
+ * than the ~10% convention, which is the right side to err on.
+ *
+ * One correction to the standing analysis above: chart.js is GONE — the web
+ * bundle work of 2026-08-12 confirmed recharts is the product's only charting
+ * library, so "recharts AND chart.js" is history and the recharts 274 KiB is
+ * no longer waiting on a consolidation decision, only on a lazy-loading one.
  */
-const BASELINE_TOTAL_RAW_KIB = 3924.1;
-const BASELINE_TOTAL_GZIP_KIB = 1211.2;
+const BASELINE_TOTAL_RAW_KIB = 4070.0;
+const BASELINE_TOTAL_GZIP_KIB = 1240.6;
 
 // ~10% above measured, which is this file's own convention and matters more
 // than the number: tight enough that the next ACCIDENTAL arrival fails.

--- a/src/components/reconciliation/ReconciliationAccountList.tsx
+++ b/src/components/reconciliation/ReconciliationAccountList.tsx
@@ -14,6 +14,52 @@ interface ReconciliationAccountListProps {
   onSelectAccount: (accountId: string) => void;
 }
 
+/**
+ * The figure that is absent, rather than a word claiming it is unavailable.
+ *
+ * "N/A" reads as a refusal — as though the app could not work the number out.
+ * It can: there is simply no statement balance entered yet, and the row says so
+ * underneath in the one place the remedy belongs (P6 — say the consequence,
+ * then the remedy).
+ */
+const ABSENT_FIGURE = '—';
+
+/**
+ * The per-row metric labels, printed only where the columns wrap.
+ *
+ * Below `md` the row's cells wrap under the account name and each figure needs
+ * its own label, because there is no column above it to inherit one from. From
+ * `md` up the group's header strip carries the labels once and these go
+ * `sr-only` — visually silent, still announced, so a screen reader on a desktop
+ * hears "Bank Balance £220.00" rather than three unlabelled numbers. Deleting
+ * them outright would have made the strip a sighted-only affordance.
+ */
+const ROW_LABEL_CLASS =
+  'text-[10px] uppercase tracking-wide text-gray-400 dark:text-gray-500 md:sr-only';
+
+/** The column heading over each figure, once per group, from `md` up. */
+const STRIP_LABEL_CLASS =
+  'flex-none text-right text-label uppercase font-medium text-gray-500 dark:text-gray-400';
+
+/**
+ * The three figure columns' widths from `md` up — ONE definition, worn by both
+ * the header strip and the row cells beneath it.
+ *
+ * Shared rather than repeated because a strip whose columns are a different
+ * width from the rows' is a strip that labels the wrong figure, and two
+ * matching literals in two places is exactly the drift that produces one.
+ *
+ * 132px is not arbitrary: "Account Balance" sets 128px at `text-label`, and a
+ * column narrower than its own heading grows to fit the heading — which pushed
+ * the neighbouring column 2px out of true, measured in the browser. The widest
+ * heading plus a little air is the floor.
+ */
+const COLUMN_WIDTH = {
+  bankBalance: 'md:min-w-[132px]',
+  accountBalance: 'md:min-w-[132px]',
+  difference: 'md:min-w-[100px]',
+} as const;
+
 export default function ReconciliationAccountList({
   groups,
   onSelectAccount,
@@ -40,6 +86,34 @@ export default function ReconciliationAccountList({
               ({group.summaries.length})
             </span>
           </h2>
+          {/* ONE label strip per group instead of three labels per row.
+              BANK BALANCE / ACCOUNT BALANCE / DIFFERENCE printed on every card
+              was six words repeated down the page, competing with the figures
+              they name (P1 — the figure is the interface).
+
+              It mirrors the row card's box metrics exactly — the same 2px
+              border (transparent here), the same md padding, the same gap and
+              the same column widths — so the headings sit over the columns they
+              name. The rows' three cells are flex-none and the chevron cannot
+              shrink, which leaves the flex-1 spacer as the only elastic part of
+              a row: the right-hand columns stay pinned to the right edge no
+              matter how long an account name runs, and this strip pins to the
+              same edge the same way.
+
+              aria-hidden because it is a second voice for labels the rows still
+              carry themselves (see ROW_LABEL_CLASS) — announced twice, it would
+              read as six columns rather than three. */}
+          <div
+            aria-hidden="true"
+            className="hidden md:flex w-full items-center gap-4 border-2 border-transparent px-5 pb-1"
+          >
+            <div className="flex-1" />
+            <p className={`${STRIP_LABEL_CLASS} ${COLUMN_WIDTH.bankBalance}`}>Bank Balance</p>
+            <p className={`${STRIP_LABEL_CLASS} ${COLUMN_WIDTH.accountBalance}`}>Account Balance</p>
+            <p className={`${STRIP_LABEL_CLASS} ${COLUMN_WIDTH.difference}`}>Difference</p>
+            {/* The chevron's column, so the labels clear it. */}
+            <div className="w-5 ml-2 flex-shrink-0" />
+          </div>
           <div className="grid gap-3">
             {group.summaries.map(({ account, unreconciledCount, bankBalance, accountBalance, difference }) => {
               const hasDifference = difference != null && Math.abs(difference) > 0.005;
@@ -97,32 +171,56 @@ export default function ReconciliationAccountList({
 
                     <div className="hidden md:block flex-1" />
 
-                    <div className="text-right flex-1 min-w-[84px] md:flex-none md:min-w-[120px]">
-                      <p className="text-[10px] uppercase tracking-wide text-gray-400 dark:text-gray-500">Bank Balance</p>
-                      <p className="text-sm font-semibold text-gray-900 dark:text-white tabular-nums">
-                        {bankBalance != null
-                          ? formatCurrency(bankBalance, account.currency)
-                          : 'N/A'}
-                      </p>
+                    <div className={`text-right flex-1 min-w-[84px] md:flex-none ${COLUMN_WIDTH.bankBalance}`}>
+                      <p className={ROW_LABEL_CLASS}>Bank Balance</p>
+                      {bankBalance != null ? (
+                        <p className="text-sm font-semibold text-gray-900 dark:text-white tabular-nums">
+                          {formatCurrency(bankBalance, account.currency)}
+                        </p>
+                      ) : (
+                        <>
+                          <p className="text-sm font-semibold text-gray-400 dark:text-gray-500 tabular-nums">
+                            {ABSENT_FIGURE}
+                          </p>
+                          {/* The remedy, on the row that needs it.
+                              A span rather than a nested control, and that is
+                              not a compromise: the whole card already opens
+                              this account's reconciliation view, which is where
+                              the closing balance is typed, so a button here
+                              would be a second tab stop to the identical
+                              destination — and a button inside a button is
+                              invalid markup besides. It wears the quiet-text
+                              role the balance bar's own "Enter balance"
+                              affordance wears (P7), never amber: on this page
+                              amber belongs to the travelling thread alone
+                              (P3). */}
+                          <span className="block text-[11px] font-medium text-primary dark:text-blue-400">
+                            Enter bank balance
+                          </span>
+                        </>
+                      )}
                     </div>
-                    <div className="text-right flex-1 min-w-[84px] md:flex-none md:min-w-[120px]">
-                      <p className="text-[10px] uppercase tracking-wide text-gray-400 dark:text-gray-500">Account Balance</p>
+                    <div className={`text-right flex-1 min-w-[84px] md:flex-none ${COLUMN_WIDTH.accountBalance}`}>
+                      <p className={ROW_LABEL_CLASS}>Account Balance</p>
                       <p className="text-sm font-semibold text-gray-900 dark:text-white tabular-nums">
                         {formatCurrency(accountBalance, account.currency)}
                       </p>
                     </div>
-                    <div className="text-right flex-1 min-w-[84px] md:flex-none md:min-w-[100px]">
-                      <p className="text-[10px] uppercase tracking-wide text-gray-400 dark:text-gray-500">Difference</p>
+                    <div className={`text-right flex-1 min-w-[84px] md:flex-none ${COLUMN_WIDTH.difference}`}>
+                      <p className={ROW_LABEL_CLASS}>Difference</p>
+                      {/* No second remedy here. The difference is missing for
+                          exactly the reason the bank balance is, and the row
+                          has already said what to do about it once. */}
                       <p className={`text-sm font-bold tabular-nums ${
                         difference == null
-                          ? 'text-gray-400'
+                          ? 'text-gray-400 dark:text-gray-500'
                           : Math.abs(difference) < 0.005
                           ? 'text-blue-600 dark:text-blue-400'
                           : 'text-red-600 dark:text-red-400'
                       }`}>
                         {difference != null
                           ? formatCurrency(difference, account.currency)
-                          : 'N/A'}
+                          : ABSENT_FIGURE}
                       </p>
                     </div>
                     <ChevronRightIcon size={20} className="text-gray-400 flex-shrink-0 ml-2" />

--- a/src/components/reconciliation/__tests__/ReconciliationAccountList.test.tsx
+++ b/src/components/reconciliation/__tests__/ReconciliationAccountList.test.tsx
@@ -1,0 +1,148 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent, within } from '@testing-library/react';
+import { PreferencesProvider } from '../../../contexts/PreferencesContext';
+import ReconciliationAccountList, { type ReconciliationGroup } from '../ReconciliationAccountList';
+import type { ReconciliationSummary } from '../../../hooks/useReconciliation';
+import type { Account } from '../../../types';
+
+/**
+ * The reconciliation account list — DESIGN_PASS_2026-08 §3.2.
+ *
+ * Three changes are pinned here: the missing figure reads as absent and offers
+ * its remedy (P6), the three metric labels are printed once per group rather
+ * than once per row (P1), and the labels survive for screen readers and for the
+ * narrow layout where the columns wrap.
+ *
+ * Every figure here is invented; this repo is public.
+ */
+
+const account = (id: string, name: string): Account => ({
+  id,
+  name,
+  type: 'current',
+  balance: 0,
+  currency: 'GBP',
+  institution: 'Test Bank',
+  lastUpdated: new Date('2026-08-01'),
+});
+
+const summary = (
+  id: string,
+  name: string,
+  bankBalance: number | null,
+  accountBalance: number
+): ReconciliationSummary => ({
+  account: account(id, name),
+  unreconciledCount: 3,
+  bankBalance,
+  accountBalance,
+  clearedBalance: accountBalance,
+  difference: bankBalance == null ? null : bankBalance - accountBalance,
+  lastReconciledDate: null,
+  lastReconciledBalance: null,
+});
+
+const groups: ReconciliationGroup[] = [
+  {
+    title: 'Current Accounts',
+    summaries: [
+      summary('a1', 'Everyday Account', null, 250),
+      summary('a2', 'Second Account', 220, 250),
+    ],
+  },
+];
+
+const renderList = (onSelectAccount = vi.fn()) => {
+  render(
+    // The list formats through useCurrencyDecimal, which reads the display
+    // currency from preferences.
+    <PreferencesProvider>
+      <ReconciliationAccountList groups={groups} onSelectAccount={onSelectAccount} />
+    </PreferencesProvider>
+  );
+  return onSelectAccount;
+};
+
+const rowFor = (name: string): HTMLElement =>
+  screen.getByRole('button', { name: new RegExp(name) });
+
+describe('ReconciliationAccountList — a missing figure names its remedy', () => {
+  it('prints an em-dash rather than N/A where no closing balance was entered', () => {
+    renderList();
+    const row = rowFor('Everyday Account');
+
+    // "N/A" reads as "the app could not work it out". It can: nobody has
+    // entered a statement balance yet.
+    expect(within(row).queryByText('N/A')).not.toBeInTheDocument();
+    // Twice: the bank balance itself, and the difference that cannot exist
+    // without it.
+    expect(within(row).getAllByText('—')).toHaveLength(2);
+  });
+
+  it('offers the remedy on the row, once', () => {
+    renderList();
+    const row = rowFor('Everyday Account');
+
+    expect(within(row).getByText('Enter bank balance')).toBeInTheDocument();
+    // Not repeated beside the difference — the row has already said it.
+    expect(within(row).getAllByText('Enter bank balance')).toHaveLength(1);
+  });
+
+  it('says nothing about entering a balance on a row that has one', () => {
+    renderList();
+    const row = rowFor('Second Account');
+
+    expect(within(row).queryByText('Enter bank balance')).not.toBeInTheDocument();
+    expect(within(row).getByText('£220.00')).toBeInTheDocument();
+  });
+
+  it('keeps amber off the remedy — the thread owns amber on this page', () => {
+    renderList();
+    const remedy = within(rowFor('Everyday Account')).getByText('Enter bank balance');
+
+    // P3: one amber in the building, and on this page it belongs to the
+    // travelling next action, never to a link that is merely available.
+    expect(remedy.className).not.toMatch(/amber|yellow|accent/);
+  });
+
+  it('reaches the reconciliation view by pressing the row it sits on', () => {
+    const onSelectAccount = renderList();
+    fireEvent.click(rowFor('Everyday Account'));
+
+    // The remedy is text inside the row, not a control of its own: the row
+    // already opens the place the balance is typed, so a second tab stop would
+    // lead to the identical destination.
+    expect(onSelectAccount).toHaveBeenCalledWith('a1');
+  });
+});
+
+describe('ReconciliationAccountList — one label strip per group', () => {
+  it('heads the group once instead of every row', () => {
+    renderList();
+
+    // One visual strip for the group…
+    const strip = document.querySelector('[aria-hidden="true"]');
+    expect(strip).not.toBeNull();
+    expect(strip?.textContent).toBe('Bank BalanceAccount BalanceDifference');
+  });
+
+  it('keeps a label on every row for screen readers and the wrapped layout', () => {
+    renderList();
+    const row = rowFor('Everyday Account');
+
+    // Still in the DOM, still announced — visually silent only from `md` up,
+    // where the strip above has taken the job. Below `md` the row's columns
+    // wrap under the account name and these are the only labels there are.
+    const label = within(row).getByText('Account Balance');
+    expect(label).toBeInTheDocument();
+    expect(label.className).toContain('md:sr-only');
+  });
+
+  it('does not announce the strip twice over', () => {
+    renderList();
+
+    // The strip is a second voice for labels the rows still carry, so it is
+    // hidden from assistive technology rather than duplicated into it.
+    expect(document.querySelector('[aria-hidden="true"]')).toHaveAttribute('aria-hidden', 'true');
+  });
+});

--- a/src/hooks/useConvertedNetWorth.ts
+++ b/src/hooks/useConvertedNetWorth.ts
@@ -39,6 +39,46 @@ export interface AccountBalanceEntry {
   currency: string;
 }
 
+/** A currency inside a group, and everything the group holds in it. */
+export interface CurrencySubtotal {
+  currency: string;
+  amount: DecimalInstance;
+}
+
+/**
+ * One group header's total — a band on the Accounts list, or one of its
+ * institution sub-bands.
+ *
+ * Computed in the SAME pass as net worth, from the same rate table, into the
+ * same state object. That is the whole point of putting it here rather than in
+ * a hook of its own: a page must never show a confident group total above a
+ * degraded net worth, and the only way to guarantee "at the same moment" is for
+ * the two figures to BE the same moment — one effect, one setState, one
+ * provenance. Two hooks would agree almost always and disagree in exactly the
+ * render that matters.
+ */
+export interface ConvertedGroupTotal {
+  /** In the display currency, once every currency in the group had a rate. */
+  total: DecimalInstance;
+  /**
+   * A rate was applied, so the figure is an approximation and must be marked
+   * (`≈`). False for a group already whole in the display currency — that
+   * figure is exact, needs no rate, and is never marked.
+   */
+  isConverted: boolean;
+  /**
+   * The group's holdings per currency, unsummed. Only rendered in the failure
+   * state below, where there is no honest single figure to print.
+   */
+  byCurrency: readonly CurrencySubtotal[];
+  /**
+   * Currencies in THIS group with no available rate. Non-empty means `total` is
+   * wrong by whatever those amounts are, and the caller must fall back to the
+   * unsummed pair rather than print it.
+   */
+  unconverted: readonly string[];
+}
+
 export interface ConvertedNetWorth {
   netWorth: DecimalInstance;
   assets: DecimalInstance;
@@ -52,7 +92,12 @@ export interface ConvertedNetWorth {
    * false for a single-currency ledger, which resolves on the first render.
    */
   isReady: boolean;
+  /** Keyed by whatever key the caller passed in `groups`. Empty when none was. */
+  groupTotals: ReadonlyMap<string, ConvertedGroupTotal>;
 }
+
+/** Stable identity, so a caller with no groups never re-runs the effect. */
+const NO_GROUPS: ReadonlyMap<string, readonly AccountBalanceEntry[]> = new Map();
 
 /** Assets are the positive balances, liabilities the magnitude of the negative. */
 function split(entries: readonly AccountBalanceEntry[]) {
@@ -77,19 +122,57 @@ function split(entries: readonly AccountBalanceEntry[]) {
 const sum = (amounts: ReadonlyArray<{ amount: DecimalInstance }>): DecimalInstance =>
   amounts.reduce((total, { amount }) => total.plus(amount), new Decimal(0));
 
+/**
+ * A group's holdings folded to one line per currency, in first-seen order.
+ *
+ * Needs no rates, so it is available on the first render — which is what lets a
+ * group that CANNOT be converted print the honest unsummed pair immediately
+ * instead of waiting for a rate that will never arrive.
+ */
+function byCurrencyOf(entries: readonly AccountBalanceEntry[]): CurrencySubtotal[] {
+  const totals = new Map<string, DecimalInstance>();
+  for (const { balance, currency } of entries) {
+    totals.set(currency, (totals.get(currency) ?? new Decimal(0)).plus(toDecimal(balance)));
+  }
+  return [...totals].map(([currency, amount]) => ({ currency, amount }));
+}
+
 export function useConvertedNetWorth(
   entries: readonly AccountBalanceEntry[],
-  displayCurrency: string
+  displayCurrency: string,
+  /**
+   * Optional sub-totals to convert in the same pass, keyed however the caller
+   * likes. Omit it and this hook behaves exactly as it always has.
+   */
+  groups: ReadonlyMap<string, readonly AccountBalanceEntry[]> = NO_GROUPS
 ): ConvertedNetWorth {
   const { assets, liabilities } = useMemo(() => split(entries), [entries]);
+
+  /**
+   * The shape of every group — which currencies it holds and whether any of
+   * them needs a rate — worked out without one.
+   */
+  const groupShapes = useMemo(() => {
+    const shapes = new Map<string, { isConverted: boolean; byCurrency: CurrencySubtotal[] }>();
+    for (const [key, groupEntries] of groups) {
+      const byCurrency = byCurrencyOf(groupEntries);
+      shapes.set(key, {
+        isConverted: byCurrency.some(line => line.currency !== displayCurrency),
+        byCurrency,
+      });
+    }
+    return shapes;
+  }, [groups, displayCurrency]);
 
   /**
    * The whole ledger already reads in one currency. Nothing to convert, so the
    * answer is arithmetic and is available now — see the header.
    */
   const isSingleCurrency = useMemo(
-    () => entries.every(entry => entry.currency === displayCurrency),
-    [entries, displayCurrency]
+    () =>
+      entries.every(entry => entry.currency === displayCurrency) &&
+      [...groupShapes.values()].every(shape => !shape.isConverted),
+    [entries, displayCurrency, groupShapes]
   );
 
   const synchronous = useMemo<ConvertedNetWorth>(() => {
@@ -102,8 +185,20 @@ export function useConvertedNetWorth(
       provenance: null,
       unconverted: [],
       isReady: true,
+      // Every group is whole in the display currency here, so each total is a
+      // plain sum and none of them is marked.
+      groupTotals: new Map(
+        [...groupShapes].map(([key, shape]) => [
+          key,
+          {
+            ...shape,
+            total: shape.byCurrency.reduce((t, line) => t.plus(line.amount), new Decimal(0)),
+            unconverted: [],
+          },
+        ])
+      ),
     };
-  }, [assets, liabilities]);
+  }, [assets, liabilities, groupShapes]);
 
   const [converted, setConverted] = useState<ConvertedNetWorth | null>(null);
 
@@ -124,6 +219,30 @@ export function useConvertedNetWorth(
       ]);
       if (cancelled) return;
 
+      /**
+       * The groups go SECOND, deliberately.
+       *
+       * The pair above has just populated the module-level rate cache in
+       * currency-decimal, so every group below is arithmetic against a table
+       * that is already in memory — one page's worth of group headers costs no
+       * additional request. Fired alongside the pair instead, a cold cache
+       * would see one request per group, since the fetch is not deduped while
+       * in flight.
+       */
+      const groupKeys = [...groups.keys()];
+      const groupResults = await Promise.all(
+        groupKeys.map(key =>
+          convertMultipleCurrenciesWithProvenance(
+            (groupShapes.get(key)?.byCurrency ?? []).map(line => ({
+              amount: line.amount,
+              currency: line.currency,
+            })),
+            displayCurrency
+          )
+        )
+      );
+      if (cancelled) return;
+
       // One list may be empty (a ledger with no debts), and an empty list
       // reports no provenance — so the disclosure comes from whichever side
       // actually used rates.
@@ -139,6 +258,21 @@ export function useConvertedNetWorth(
         provenance,
         unconverted,
         isReady: true,
+        groupTotals: new Map(
+          groupKeys.map((key, index) => {
+            const shape = groupShapes.get(key);
+            const result = groupResults[index];
+            return [
+              key,
+              {
+                isConverted: shape?.isConverted ?? false,
+                byCurrency: shape?.byCurrency ?? [],
+                total: result?.total ?? new Decimal(0),
+                unconverted: result?.unconverted ?? [],
+              },
+            ];
+          })
+        ),
       });
     };
 
@@ -147,7 +281,7 @@ export function useConvertedNetWorth(
     return () => {
       cancelled = true;
     };
-  }, [assets, liabilities, displayCurrency, isSingleCurrency]);
+  }, [assets, liabilities, displayCurrency, isSingleCurrency, groups, groupShapes]);
 
   if (isSingleCurrency) return synchronous;
 
@@ -158,6 +292,11 @@ export function useConvertedNetWorth(
    * unconverted figure first would put a number on screen that is true in no
    * currency — briefly, and then correct itself, which is the worst of both:
    * long enough to be read, short enough not to be questioned.
+   *
+   * Group totals hold to the same rule and for the same reason: a group that
+   * needs a rate reports zero until it has one, so the account list cannot show
+   * a settled-looking band total above a net worth that is still resolving.
+   * They arrive together or not at all.
    */
   return (
     converted ?? {
@@ -167,6 +306,12 @@ export function useConvertedNetWorth(
       provenance: null,
       unconverted: [],
       isReady: false,
+      groupTotals: new Map(
+        [...groupShapes].map(([key, shape]) => [
+          key,
+          { ...shape, total: new Decimal(0), unconverted: [] },
+        ])
+      ),
     }
   );
 }

--- a/src/pages/Accounts.tsx
+++ b/src/pages/Accounts.tsx
@@ -41,7 +41,10 @@ import {
 type AccountSortMode = 'default' | 'name' | 'balance-desc' | 'balance-asc';
 import { IconButton } from '../components/icons/IconButton';
 import { useCurrencyDecimal } from '../hooks/useCurrencyDecimal';
-import { useConvertedNetWorth } from '../hooks/useConvertedNetWorth';
+import {
+  useConvertedNetWorth,
+  type AccountBalanceEntry,
+} from '../hooks/useConvertedNetWorth';
 import { useReconciliation } from '../hooks/useReconciliation';
 import { countAwaitingReviewByAccount } from '../utils/transactionReview';
 import { useAccountBankSync } from '@service';
@@ -141,6 +144,33 @@ interface DisplayedBand {
   displayed: Account[];
   subBands: DisplayedSubBand[] | null;
   isExpanded: boolean;
+}
+
+/**
+ * Where a band's converted total is filed.
+ *
+ * Module-level so the pass that BUILDS the totals and the pass that draws them
+ * cannot drift into two different spellings of the same band. It happens to
+ * read like `collapseKeyFor`; that is a coincidence of format, not a shared
+ * meaning, and the two are deliberately not the same function.
+ */
+const bandTotalKey = (kind: AccountGroupKind, label: string): string => `${kind}:${label}`;
+const subBandTotalKey = (kind: AccountGroupKind, label: string, subLabel: string): string =>
+  `${kind}:${label}::${subLabel}`;
+
+/** Stable identity for the single-currency case: no groups, so no conversion. */
+const NO_GROUP_ENTRIES: ReadonlyMap<string, readonly AccountBalanceEntry[]> = new Map();
+
+/**
+ * A group total, ready to print, and the same thing said out loud.
+ *
+ * The two differ in exactly one place: `≈` is a glyph screen readers do not
+ * reliably announce, so the spoken form says "approximately" and the visible
+ * form keeps the mark the design pass asked for.
+ */
+interface BandTotalFigure {
+  text: string;
+  spoken: string;
 }
 
 type DisplayedList =
@@ -373,7 +403,9 @@ export default function Accounts() {
     [netWorthEntries, displayCurrency]
   );
 
-  const convertedNetWorth = useConvertedNetWorth(netWorthEntries, displayCurrency);
+  // The conversion itself is set up below, once the band decomposition it also
+  // feeds (`groupCurrencyEntries`) exists — one pass converts the card and every
+  // group header together. See `totalForBand`.
 
   // The open list's bands, straight from the two switches — type sections,
   // institution bands, type sections with institution sub-bands, or one flat
@@ -418,6 +450,77 @@ export default function Accounts() {
       decimalTransactions
     );
   }, [decimalAccounts, decimalTransactions, topLevelIdByAccountId]);
+
+  /**
+   * The same band total as above, split into one line per currency HELD.
+   *
+   * Deliberately the same decomposition: identical account expansion, identical
+   * `calculateTotalBalance`, merely partitioned by currency first. Because that
+   * partition is a plain sum, these lines add back up to exactly the figure
+   * `totalForBand` returns — so a converted band total is the band total this
+   * page has always shown, converted, and never a second opinion about what the
+   * band is worth.
+   *
+   * A nested account contributes its OWN currency, not its parent's: a dollar
+   * cash sleeve inside a sterling investment account is still dollars.
+   */
+  const currencySubtotalsForBand = useCallback(
+    (bandAccounts: readonly Account[]): AccountBalanceEntry[] => {
+      const ids = new Set(bandAccounts.map(a => a.id));
+      const inBand = decimalAccounts.filter(a => ids.has(topLevelIdByAccountId.get(a.id) ?? a.id));
+      const buckets = new Map<string, typeof inBand>();
+      for (const account of inBand) {
+        const currency = account.currency || displayCurrency;
+        const bucket = buckets.get(currency);
+        if (bucket) bucket.push(account);
+        else buckets.set(currency, [account]);
+      }
+      return [...buckets].map(([currency, bucket]) => ({
+        balance: calculateTotalBalance(bucket, decimalTransactions),
+        currency,
+      }));
+    },
+    [decimalAccounts, decimalTransactions, topLevelIdByAccountId, displayCurrency]
+  );
+
+  /**
+   * Every band and sub-band on the page, decomposed for the one conversion pass.
+   *
+   * Empty — and therefore free — whenever the ledger reads in one currency,
+   * which is the common case: no decomposition, no map, no conversion, and the
+   * headers below fall through to the untouched `totalForBand` path.
+   */
+  const groupCurrencyEntries = useMemo<ReadonlyMap<string, readonly AccountBalanceEntry[]>>(() => {
+    if (!spansCurrencies || accountBands.mode !== 'grouped') return NO_GROUP_ENTRIES;
+    const entries = new Map<string, readonly AccountBalanceEntry[]>();
+    for (const group of accountBands.groups) {
+      entries.set(bandTotalKey(group.kind, group.label), currencySubtotalsForBand(group.accounts));
+      for (const sub of group.subGroups ?? []) {
+        entries.set(
+          subBandTotalKey(group.kind, group.label, sub.label),
+          currencySubtotalsForBand(sub.accounts)
+        );
+      }
+    }
+    return entries;
+  }, [spansCurrencies, accountBands, currencySubtotalsForBand]);
+
+  /**
+   * ONE conversion for the whole page: the net-worth card's three figures and
+   * every group header's total, off one rate table, resolved in one state
+   * update.
+   *
+   * That single call is what makes the ruling's coherence requirement
+   * structural rather than aspirational. A group total cannot look confident
+   * while the card above it reads degraded, because neither figure has a
+   * provenance of its own to disagree with — there is one, and the `≈` on a
+   * group total is a pointer to it (`ConvertedTotalNote`, under the card).
+   */
+  const convertedNetWorth = useConvertedNetWorth(
+    netWorthEntries,
+    displayCurrency,
+    groupCurrencyEntries
+  );
 
   // The shared account-type sections (same groupings everywhere), catch-all
   // last — a type without a section renders under "Other Accounts", never
@@ -1254,8 +1357,62 @@ export default function Accounts() {
   //
   // What is IN the band was decided by `displayedList` — the same answer the
   // arrow keys walk, so the two can never differ about which rows exist.
+  /**
+   * A group header's total, and how it declares that a rate was applied.
+   *
+   * Three outcomes, in the order they are checked:
+   *
+   *  1. **Whole in the display currency** — the plain figure this page has
+   *     always printed, from the untouched `totalForBand` path, with no mark.
+   *     Nothing was converted, so there is nothing to disclose and no reason for
+   *     a single-currency ledger to grow a symbol it cannot explain.
+   *  2. **A currency in the band has no rate at all** — the FAILURE state. There
+   *     is no honest single figure, so the band reports the unsummed pair
+   *     ("£X + $Y"). Never the default: it only appears where a rate is
+   *     genuinely unresolvable, and the card above it is saying so at the same
+   *     moment, out of the same `unconverted` list.
+   *  3. **Converted** — the figure, marked `≈`. The mark is the whole
+   *     disclosure: WHICH rate and WHEN is stated once per page, by
+   *     `ConvertedTotalNote` under the net-worth card, and repeating it per
+   *     group would make the scanning aid the widest thing on the row.
+   */
+  const bandTotalFigure = (key: string, bandAccounts: readonly Account[]): BandTotalFigure => {
+    const converted = convertedNetWorth.groupTotals.get(key);
+
+    if (!converted?.isConverted) {
+      const plain = formatDisplayCurrency(totalForBand(bandAccounts));
+      return { text: plain, spoken: plain };
+    }
+
+    if (converted.unconverted.length > 0) {
+      const pair = converted.byCurrency
+        .map(line => formatDisplayCurrency(line.amount, line.currency))
+        .join(' + ');
+      return { text: pair, spoken: pair };
+    }
+
+    const figure = formatDisplayCurrency(converted.total);
+    return { text: `≈ ${figure}`, spoken: `approximately ${figure}` };
+  };
+
+  /**
+   * The figure as a node. An unmarked total renders as the bare string it
+   * always was — same DOM, same textContent — and only a marked one splits into
+   * a seen glyph and a spoken word, because `≈` is not reliably announced.
+   */
+  const bandTotalNode = (figure: BandTotalFigure): ReactNode =>
+    figure.text === figure.spoken ? (
+      figure.text
+    ) : (
+      <>
+        <span aria-hidden="true">{figure.text}</span>
+        <span className="sr-only">{figure.spoken}</span>
+      </>
+    );
+
   const renderAccountBand = ({ group, displayed, subBands, isExpanded }: DisplayedBand): ReactNode => {
     const regionId = groupRegionId(group.kind, group.label);
+    const bandTotal = bandTotalFigure(bandTotalKey(group.kind, group.label), group.accounts);
 
     return (
       // NOT A CARD. This used to be a white bordered, shadowed box containing a
@@ -1291,7 +1448,7 @@ export default function Accounts() {
               </span>
             </div>
             <p className="text-card font-semibold text-primary dark:text-white">
-              {formatDisplayCurrency(totalForBand(group.accounts))}
+              {bandTotalNode(bandTotal)}
             </p>
           </div>
         </button>
@@ -1303,7 +1460,10 @@ export default function Accounts() {
                   // Count and total describe the WHOLE sub-band, as the section
                   // header does — a search narrows the rows, not the figures.
                   const countLabel = `${sub.accounts.length} ${sub.accounts.length === 1 ? 'account' : 'accounts'}`;
-                  const subTotal = formatDisplayCurrency(totalForBand(sub.accounts));
+                  const subTotal = bandTotalFigure(
+                    subBandTotalKey(group.kind, group.label, sub.label),
+                    sub.accounts
+                  );
                   return (
                     // A sub-band is a group, not a heading: the outline stays
                     // section (h2) → account name (h3), and screen readers get
@@ -1311,7 +1471,7 @@ export default function Accounts() {
                     <div
                       key={sub.label}
                       role="group"
-                      aria-label={`${sub.title}, ${countLabel}, total ${subTotal}`}
+                      aria-label={`${sub.title}, ${countLabel}, total ${subTotal.spoken}`}
                     >
                       {/* The same treatment as the band above it, one step
                           quieter: a line, not a pill with a border of its own. */}
@@ -1323,7 +1483,9 @@ export default function Accounts() {
                           </span>
                         </p>
                         <p className="shrink-0 text-dense font-semibold text-gray-600 dark:text-gray-300">
-                          {subTotal}
+                          {/* The container already carries the spoken form in
+                              its group label, so the mark is decoration here. */}
+                          <span aria-hidden="true">{subTotal.text}</span>
                         </p>
                       </div>
                       {sub.displayed.map(renderAccountCard)}

--- a/src/pages/Reconciliation.tsx
+++ b/src/pages/Reconciliation.tsx
@@ -450,15 +450,34 @@ export default function Reconciliation() {
   if (!selectedAccountId) {
     return (
       <div className="flex flex-col h-full">
+        {/* Heading → figure → content, the page anatomy the design pass settled
+            on (P7). What this page is FOR is the count of work outstanding, and
+            it was set in 14px grey under the title — smaller than the account
+            names below it, and the only number on the screen that describes the
+            whole screen. It reads at `display` now, with the words that explain
+            it demoted to a subhead: the figure first, then what it counts. */}
         <div className="mb-6">
           <h1 className="text-2xl font-bold text-gray-900 dark:text-white">
             Reconciliation
           </h1>
-          <p className="text-sm text-gray-500 dark:text-gray-400 mt-1">
-            {totalUnreconciledCount > 0
-              ? `${totalUnreconciledCount} unreconciled transactions across all accounts`
-              : 'All accounts are up to date'}
-          </p>
+          {totalUnreconciledCount > 0 ? (
+            <>
+              <p className="mt-1 text-display font-semibold text-primary dark:text-white tabular-nums">
+                {totalUnreconciledCount.toLocaleString()}
+              </p>
+              <p className="text-sm text-gray-500 dark:text-gray-400">
+                unreconciled {totalUnreconciledCount === 1 ? 'transaction' : 'transactions'} across all accounts
+              </p>
+            </>
+          ) : (
+            // No headline figure when the figure is zero. A 32px "0" would be
+            // the loudest thing on a page with nothing to do on it — the app's
+            // rule is that a count of nothing renders as nothing, and what is
+            // worth saying here is the reassurance, not the number.
+            <p className="text-sm text-gray-500 dark:text-gray-400 mt-1">
+              All accounts are up to date
+            </p>
+          )}
         </div>
 
         {/* Group + sort controls — mirrors the Accounts page */}

--- a/src/pages/__tests__/Accounts.groupTotals.test.tsx
+++ b/src/pages/__tests__/Accounts.groupTotals.test.tsx
@@ -1,0 +1,181 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { render, screen, waitFor, cleanup } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { PreferencesProvider } from '../../contexts/PreferencesContext';
+import { ToastProvider } from '../../contexts/ToastContext';
+import Accounts from '../Accounts';
+import { __setAppContextValue, __resetAppContextValue } from '../../test/mocks/AppContextSupabase';
+import type { Account } from '../../types';
+
+/**
+ * Group headers that span currencies — DESIGN_RULINGS_2026-08-12 §C.
+ *
+ * A band used to add its accounts up one-for-one and print the answer with a
+ * "£": a dollar counted as a pound, the same fault the net-worth card was
+ * carrying until it learned to convert. The ruling is that group totals convert
+ * the same way the card does, mark themselves `≈`, and say nothing else —
+ * WHICH rate and WHEN is stated once per page, under the card.
+ *
+ * Every figure here is invented; this repo is public.
+ */
+
+const renderAccounts = () =>
+  render(
+    <MemoryRouter initialEntries={['/accounts']}>
+      <PreferencesProvider>
+        <ToastProvider>
+          <Accounts />
+        </ToastProvider>
+      </PreferencesProvider>
+    </MemoryRouter>
+  );
+
+const account = (
+  id: string,
+  name: string,
+  type: Account['type'],
+  currency: string,
+  openingBalance: number
+): Account => ({
+  id, name, type, currency, openingBalance,
+  balance: openingBalance,
+  lastUpdated: new Date('2026-08-01'),
+});
+
+/** Sterling everywhere. The overwhelmingly common ledger, and the control. */
+const STERLING_ONLY: Account[] = [
+  account('a1', 'Everyday Account', 'current', 'GBP', 1000),
+  account('a3', 'Rainy Day', 'savings', 'GBP', 500),
+];
+
+/**
+ * The same ledger with one dollar account added to Current Accounts.
+ *
+ * Savings is untouched and still whole in sterling — it is the regression pin:
+ * a second currency elsewhere on the page must not change it by one byte.
+ */
+const MIXED: Account[] = [
+  account('a1', 'Everyday Account', 'current', 'GBP', 1000),
+  // 250 USD at 1.25 to the pound is 200 GBP, so Current Accounts totals £1,200
+  // — never £1,250, which is what adding the two numbers raw would print.
+  account('a2', 'Dollar Account', 'current', 'USD', 250),
+  account('a3', 'Rainy Day', 'savings', 'GBP', 500),
+];
+
+const bandHeader = (name: RegExp) => screen.getByRole('button', { name });
+
+describe('Accounts page — group totals across currencies', () => {
+  const mockFetch = vi.fn();
+
+  beforeEach(() => {
+    localStorage.clear();
+    vi.clearAllMocks();
+    global.fetch = mockFetch;
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ base: 'GBP', rates: { GBP: 1, USD: 1.25, EUR: 1.2 } }),
+    });
+  });
+
+  afterEach(() => {
+    __resetAppContextValue();
+    vi.restoreAllMocks();
+  });
+
+  it('leaves a single-currency group byte-for-byte as it was', async () => {
+    __setAppContextValue({ accounts: STERLING_ONLY, transactions: [] });
+    renderAccounts();
+    const before = (await screen.findByRole('button', { name: /Savings Accounts/ })).textContent;
+    expect(before).toMatch(/£500\.00/);
+
+    cleanup();
+
+    // The same ledger, plus a dollar account in a DIFFERENT band.
+    __setAppContextValue({ accounts: MIXED, transactions: [] });
+    renderAccounts();
+    // Wait for the page's conversion to settle, so this compares the finished
+    // state rather than a moment before the rates land.
+    await waitFor(() => expect(screen.getByText('≈ £1,200.00')).toBeInTheDocument());
+
+    expect(bandHeader(/Savings Accounts/).textContent).toBe(before);
+  });
+
+  it('never marks a single-currency group, even on a page that converts', async () => {
+    __setAppContextValue({ accounts: MIXED, transactions: [] });
+    renderAccounts();
+
+    await waitFor(() => expect(screen.getByText('≈ £1,200.00')).toBeInTheDocument());
+
+    // Savings needed no rate, so it makes no claim about one.
+    const savings = bandHeader(/Savings Accounts/).textContent ?? '';
+    expect(savings).toMatch(/£500\.00/);
+    expect(savings).not.toContain('≈');
+    expect(savings).not.toContain('approximately');
+  });
+
+  it('converts a mixed group and marks it with ≈', async () => {
+    __setAppContextValue({ accounts: MIXED, transactions: [] });
+    renderAccounts();
+
+    await waitFor(() => expect(screen.getByText('≈ £1,200.00')).toBeInTheDocument());
+    expect(bandHeader(/Current Accounts/).textContent).toMatch(/≈ £1,200\.00/);
+  });
+
+  it('says "approximately" where the ≈ cannot be heard', async () => {
+    __setAppContextValue({ accounts: MIXED, transactions: [] });
+    renderAccounts();
+
+    // The glyph is decoration; the accessible name carries the word. A screen
+    // reader that skips "≈" would otherwise hear a converted figure as an exact
+    // one — the one thing the mark exists to prevent.
+    await waitFor(() =>
+      expect(screen.getByRole('button', { name: /Current Accounts.*approximately £1,200\.00/ }))
+        .toBeInTheDocument()
+    );
+  });
+
+  it('never shows the raw cross-currency sum, not even for a frame', async () => {
+    __setAppContextValue({ accounts: MIXED, transactions: [] });
+    renderAccounts();
+
+    // £1,250.00 is what 1000 + 250 prints when a dollar is counted as a pound.
+    // It must not appear before the conversion, during it, or after.
+    expect(screen.queryByText(/£1,250\.00/)).not.toBeInTheDocument();
+    await waitFor(() => expect(screen.getByText('≈ £1,200.00')).toBeInTheDocument());
+    expect(screen.queryByText(/£1,250\.00/)).not.toBeInTheDocument();
+  });
+
+  it('carries exactly one provenance line for the whole page', async () => {
+    __setAppContextValue({ accounts: MIXED, transactions: [] });
+    renderAccounts();
+
+    await waitFor(() => expect(screen.getByText('≈ £1,200.00')).toBeInTheDocument());
+
+    // The `≈` on the group total points AT this line; it does not repeat it.
+    expect(screen.getAllByTestId('converted-total-note')).toHaveLength(1);
+  });
+
+  it('falls back to the unsummed pair when a currency has no rate at all', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    __setAppContextValue({
+      accounts: [
+        account('a1', 'Everyday Account', 'current', 'GBP', 1000),
+        account('a2', 'Mystery Account', 'current', 'ZZZ', 250),
+      ],
+      transactions: [],
+    });
+    renderAccounts();
+
+    // No rate exists for ZZZ, so there is no honest single figure for this
+    // band. The unsummed pair is the failure state — and the card above says
+    // the same thing about the same currency, in the same render, off the same
+    // `unconverted` list. Neither surface can be confident while the other is
+    // not, because there is only one of them.
+    await waitFor(() =>
+      expect(screen.getByTestId('converted-total-note')).toHaveTextContent(/This total is wrong/)
+    );
+    expect(bandHeader(/Current Accounts/).textContent).toMatch(/£1,000\.00 \+ ZZZ\s?250\.00/);
+    expect(bandHeader(/Current Accounts/).textContent).not.toContain('≈');
+    warn.mockRestore();
+  });
+});

--- a/src/pages/__tests__/Accounts.groupTotalsDegraded.test.tsx
+++ b/src/pages/__tests__/Accounts.groupTotalsDegraded.test.tsx
@@ -1,0 +1,117 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { PreferencesProvider } from '../../contexts/PreferencesContext';
+import { ToastProvider } from '../../contexts/ToastContext';
+import Accounts from '../Accounts';
+import { __setAppContextValue, __resetAppContextValue } from '../../test/mocks/AppContextSupabase';
+import type { Account } from '../../types';
+
+/**
+ * The degraded state, on both surfaces at once — DESIGN_RULINGS_2026-08-12 §C.
+ *
+ * "One page must never show a confident group total above a degraded net
+ * worth." This asserts that through ONE provider state: a single render, a
+ * single rate outage, and both the net-worth card's provenance line and the
+ * band header read together. Two stubs — one per surface — could be made to
+ * agree in a test while the app disagreed on screen, which is exactly the bug
+ * the ruling is guarding against.
+ *
+ * It lives in a file of its own because the rates cache is module state, and
+ * Vitest gives each test FILE a cold module registry. A suite that had already
+ * fetched a live quote would answer this test from that cache and never take
+ * the fallback path at all.
+ *
+ * Every figure here is invented; this repo is public.
+ */
+
+const account = (
+  id: string,
+  name: string,
+  type: Account['type'],
+  currency: string,
+  openingBalance: number
+): Account => ({
+  id, name, type, currency, openingBalance,
+  balance: openingBalance,
+  lastUpdated: new Date('2026-08-01'),
+});
+
+describe('Accounts page — group totals degrade with the net-worth card', () => {
+  const mockFetch = vi.fn();
+  let errorSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    localStorage.clear();
+    // The rate provider is unreachable. Nothing else about the page changes.
+    global.fetch = mockFetch;
+    mockFetch.mockRejectedValue(new Error('offline'));
+    errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    __setAppContextValue({
+      accounts: [
+        account('a1', 'Everyday Account', 'current', 'GBP', 1000),
+        account('a2', 'Dollar Account', 'current', 'USD', 250),
+        account('a3', 'Rainy Day', 'savings', 'GBP', 500),
+      ],
+      transactions: [],
+    });
+  });
+
+  afterEach(() => {
+    __resetAppContextValue();
+    errorSpy.mockRestore();
+    vi.restoreAllMocks();
+  });
+
+  it('marks the group total in the same render the card admits the rates are stored', async () => {
+    render(
+      <MemoryRouter initialEntries={['/accounts']}>
+        <PreferencesProvider>
+          <ToastProvider>
+            <Accounts />
+          </ToastProvider>
+        </PreferencesProvider>
+      </MemoryRouter>
+    );
+
+    // The card degrades…
+    await waitFor(() =>
+      expect(screen.getByTestId('converted-total-note'))
+        .toHaveTextContent(/Approximate — converted at stored rates, not live ones/)
+    );
+
+    // …and in that same DOM, the band that needed a rate is marked, so the mark
+    // and the line it refers to are on screen together. Read at one instant:
+    // both figures come from one conversion pass and one state update, so there
+    // is no window in which one has settled and the other has not.
+    const current = screen.getByRole('button', { name: /Current Accounts/ }).textContent ?? '';
+    expect(current).toContain('≈');
+    // Still never the raw cross-currency sum, outage or not.
+    expect(current).not.toContain('£1,250.00');
+
+    // And the band that never needed a rate is untouched by the outage: it has
+    // nothing to degrade, which is why the ruling exempts it and the
+    // regression pin holds.
+    const savings = screen.getByRole('button', { name: /Savings Accounts/ }).textContent ?? '';
+    expect(savings).toMatch(/£500\.00/);
+    expect(savings).not.toContain('≈');
+  });
+
+  it('offers no confident group total before the card has any provenance', () => {
+    render(
+      <MemoryRouter initialEntries={['/accounts']}>
+        <PreferencesProvider>
+          <ToastProvider>
+            <Accounts />
+          </ToastProvider>
+        </PreferencesProvider>
+      </MemoryRouter>
+    );
+
+    // First render, conversion still in flight: no note yet, and therefore no
+    // settled-looking band total either. The naive sum is the thing that must
+    // not be on screen while the page has nothing to say about rates.
+    expect(screen.queryByTestId('converted-total-note')).not.toBeInTheDocument();
+    expect(screen.queryByText(/£1,250\.00/)).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
DESIGN_PASS §3.2's three unassigned items as one pass (per the rulings' sequencing note) + ruling C.

- **Headline**: "N unreconciled across all accounts" promoted to the display-size page figure, tabular, subhead beneath; zero renders the reassurance, not a giant 0.
- **Nine N/A's → em-dash + quiet remedy** ("Enter bank balance", quiet text — the thread keeps its amber monopoly; rendered as a span because the row card is already the button that opens the very screen where the balance is typed).
- **One label strip per group** instead of three labels per row; below md the wrapped rows keep their own labels, `sr-only` from md up so screen readers always hear labelled figures. One shared column-width constant worn by strip and rows — the browser measurement caught the strip's own widest heading pushing a column 2px out of true.
- **Ruling C**: Accounts group totals convert through the SAME single effect/rate-table/setState as the net-worth card, marked `≈`, one provenance line per page, degraded together or confident together by construction; single-currency groups byte-identical, regression-pinned.

Thread law: `yellowThread` (13) and `holdingState` (13) pass **unmodified**; page-level audit finds zero amber on the list.

Flagged for the design author's next round: the list says "Bank Balance", the reconciling screen deliberately says "Closing Balance", and the thread's tests insist the two never meet — the remedy wording follows the doc verbatim; the naming tension is recorded, not freelanced.

Verification: lint · typecheck:strict · smoke 5,977 · touched suites 202 · desktop:verify PASS (+3.1 KiB raw measured against pristine HEAD).

🤖 Generated with [Claude Code](https://claude.com/claude-code)