### PR TITLE
feat(design): batch 7 pass 2 — the empty-state wiring, with the distinguishability gate

### DIFF
--- a/src/components/EmptyState.tsx
+++ b/src/components/EmptyState.tsx
@@ -70,8 +70,14 @@ export default function EmptyState({
         </p>
       )}
 
+      {/* THE REMEDIES CLEAR 44px WHERE A FINGER IS THE POINTER, and keep the
+          register's own control height where a mouse is (the project's mobile
+          rule; `lg` is the same breakpoint the register switches from the table
+          to the phone's card list at). text-body's 20px line over py-2 is 36px,
+          which is a comfortable button under a cursor and a miss under a
+          thumb. */}
       {(action || secondaryAction) && (
-        <div className="mt-4 flex flex-wrap items-center gap-2">
+        <div className="mt-4 flex flex-wrap items-center gap-2 [&>button]:min-h-[44px] lg:[&>button]:min-h-0">
           {action && (
             <button
               type="button"

--- a/src/components/FilteredEmptyState.tsx
+++ b/src/components/FilteredEmptyState.tsx
@@ -2,6 +2,16 @@ import React from 'react';
 import EmptyState from './EmptyState';
 
 interface FilteredEmptyStateProps {
+  /**
+   * Sentence 1, when the thing being hidden is not a transaction.
+   *
+   * The register is where this pattern was born, so "transactions" is the
+   * default — but a list of ACCOUNTS that said "No transactions match these
+   * filters" would be describing something that is not on the screen, and the
+   * whole job of this state is to be believed. Every caller that hides
+   * something else names it.
+   */
+  title?: React.ReactNode;
   /** How many rows exist here that the filters are currently hiding. */
   hiddenCount: number;
   /**
@@ -12,6 +22,13 @@ interface FilteredEmptyStateProps {
   filters: string[];
   /** Puts every one of them away. */
   onClear: () => void;
+  /**
+   * What the remedy button says. "Clear filters" is right wherever the user
+   * set filters — but the dashboard's "filter" is an account SELECTION, and a
+   * button that names a control the surface does not have is a small lie in
+   * the one state whose whole job is to be believed. Same rule as `title`.
+   */
+  clearLabel?: string;
   /** Where the hidden rows are, for the sentence. */
   scope?: string;
   className?: string;
@@ -44,16 +61,18 @@ function joinFilters(names: string[]): React.ReactNode {
  * the data is still there.
  */
 export default function FilteredEmptyState({
+  title = 'No transactions match these filters',
   hiddenCount,
   filters,
   onClear,
+  clearLabel = 'Clear filters',
   scope = 'in this account',
   className = ''
 }: FilteredEmptyStateProps): React.JSX.Element {
   return (
     <EmptyState
       className={className}
-      title="No transactions match these filters"
+      title={title}
       description={
         <>
           <span className="font-medium text-gray-900 dark:text-gray-100 tabular-nums">
@@ -64,7 +83,7 @@ export default function FilteredEmptyState({
         </>
       }
       action={{
-        label: 'Clear filters',
+        label: clearLabel,
         onClick: onClear,
         // No plus: this remedy takes something away.
         icon: null

--- a/src/components/InfiniteScrollTransactionList.tsx
+++ b/src/components/InfiniteScrollTransactionList.tsx
@@ -1,7 +1,22 @@
-import React, { useState, useEffect, useCallback, useMemo, useRef, memo } from 'react';
+import React, { useState, useEffect, useCallback, useMemo, useRef, memo, type ReactNode } from 'react';
 import { SwipeableTransactionRow } from './SwipeableTransactionRow';
 import type { Transaction, Account, Category } from '../types';
 import { LoadingSpinner } from './LoadingSpinner';
+import { TableSkeleton, type TableSkeletonColumn } from './loading/TableSkeleton';
+import { useDelayedFlag } from '../hooks/useDelayedFlag';
+
+/**
+ * What a transaction card is shaped like, for the placeholder that waits in
+ * its place (DESIGN_PASS §4): `p-4` around a description line over a
+ * date-and-category line, with the amount right-aligned.
+ */
+const CARD_SKELETON_COLUMNS: TableSkeletonColumn[] = [
+  { key: 'description', className: 'flex-1' },
+  { key: 'amount', width: '6rem' },
+];
+
+/** `p-4` over the card's two lines — measured at 375px in the running app. */
+const CARD_HEIGHT = 77;
 
 interface InfiniteScrollTransactionListProps {
   transactions: Transaction[];
@@ -14,6 +29,19 @@ interface InfiniteScrollTransactionListProps {
   selectedTransactions?: Set<string>;
   onSelectionChange?: (selected: Set<string>) => void;
   isLoading?: boolean;
+  /**
+   * What stands where the cards would be when there are none.
+   *
+   * REQUIRED, unlike VirtualizedTable's optional one, and that is the point.
+   * This list used to answer every kind of nothing with a single sentence —
+   * "No transactions found / Try adjusting your filters or add some
+   * transactions" — which is the exact conflation DESIGN_PASS §4 forbids: it
+   * tells somebody whose register is empty to adjust filters they have not
+   * set, and somebody whose filter is hiding 1,284 rows that they have none.
+   * The caller knows which of the two it is; a phone that could forget to say
+   * is a phone that will.
+   */
+  emptyContent: ReactNode;
   itemsPerBatch?: number;
   /**
    * Should rows that have arrived and not been dealt with be drawn as new?
@@ -44,15 +72,20 @@ export const InfiniteScrollTransactionList = memo(function InfiniteScrollTransac
   selectedTransactions,
   onSelectionChange,
   isLoading = false,
+  emptyContent,
   itemsPerBatch = 20,
   markNewArrivals = false
-}: InfiniteScrollTransactionListProps): React.JSX.Element {
+  // `| null` is the 200ms rule in the type: a load too short to be worth
+  // explaining renders NOTHING, which is not an element.
+}: InfiniteScrollTransactionListProps): React.JSX.Element | null {
   const [displayedItems, setDisplayedItems] = useState(itemsPerBatch);
   const categoryNameById = useMemo(
     () => new Map(categories.map(c => [c.id, c.name])),
     [categories]
   );
   const [isLoadingMore, setIsLoadingMore] = useState(false);
+  /** Under 200ms the phone shows nothing rather than a flash of grey bars. */
+  const showSkeleton = useDelayedFlag(isLoading && transactions.length === 0);
   const loadMoreRef = useRef<HTMLDivElement>(null);
   const observerRef = useRef<IntersectionObserver | null>(null);
 
@@ -118,30 +151,19 @@ export const InfiniteScrollTransactionList = memo(function InfiniteScrollTransac
     onSelectionChange(newSelected);
   }, [selectedTransactions, onSelectionChange]);
 
-  // Initial loading state
+  // SHAPE, NOT SPINNER, and no pulsing (DESIGN_PASS §4). This was five cards
+  // at a height no card has, breathing — on the one device where a repaint of
+  // every visible row costs the most.
   if (isLoading && transactions.length === 0) {
-    return (
-      <div className="space-y-3 p-4">
-        {[...Array(5)].map((_, i) => (
-          <div key={i} className="bg-white dark:bg-gray-800 rounded-lg p-4 animate-pulse">
-            <div className="h-5 bg-gray-200 dark:bg-gray-700 rounded w-3/4 mb-2" />
-            <div className="h-4 bg-gray-200 dark:bg-gray-700 rounded w-1/2 mb-2" />
-            <div className="h-3 bg-gray-200 dark:bg-gray-700 rounded w-1/3" />
-          </div>
-        ))}
-      </div>
-    );
+    return showSkeleton
+      ? <TableSkeleton columns={CARD_SKELETON_COLUMNS} rowHeight={CARD_HEIGHT} />
+      : null;
   }
 
+  // Whose nothing this is — an empty register or a filter hiding all of it —
+  // is the caller's to say, and it always says.
   if (transactions.length === 0) {
-    return (
-      <div className="text-center py-12">
-        <p className="text-gray-500 dark:text-gray-400">No transactions found</p>
-        <p className="text-sm text-gray-400 dark:text-gray-500 mt-2">
-          Try adjusting your filters or add some transactions
-        </p>
-      </div>
-    );
+    return <>{emptyContent}</>;
   }
 
   const visibleTransactions = transactions.slice(0, displayedItems);

--- a/src/components/dashboard/ImprovedDashboard.test.tsx
+++ b/src/components/dashboard/ImprovedDashboard.test.tsx
@@ -228,8 +228,40 @@ describe('Key Account Balances — select all / clear all', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Clear all' }));
 
     expect(screen.queryByTestId('account-balance-card')).not.toBeInTheDocument();
-    expect(screen.getByText('No accounts selected')).toBeInTheDocument();
+    // A SELECTION IS A FILTER, so the panel says what it is hiding and how
+    // much of it, rather than pointing at a settings icon (DESIGN_PASS §4).
+    expect(
+      screen.getByRole('heading', { level: 3, name: 'No accounts are selected for the dashboard' })
+    ).toBeInTheDocument();
+    expect(screen.getByText('3')).toBeInTheDocument();
+    expect(screen.getByText('the dashboard’s account selection')).toBeInTheDocument();
     expect(localStorage.getItem('dashboardKeyAccounts')).toBe('[]');
+  });
+
+  it('offers one control that brings every account back, and it does', () => {
+    localStorage.setItem('dashboardKeyAccounts', JSON.stringify([]));
+    render(<ImprovedDashboard />);
+
+    expect(screen.queryByTestId('account-balance-card')).not.toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: 'Show all accounts' }));
+
+    expect(screen.getAllByTestId('account-balance-card')).toHaveLength(3);
+  });
+
+  it('a dashboard with no accounts AT ALL is a different state from one with none selected', () => {
+    mocks.app.accounts = [];
+    mocks.app.isLoading = false;
+    render(<ImprovedDashboard />);
+
+    // The first run: what this panel will hold, and the control that starts it
+    // — never the selection sentence, which would send a brand-new user
+    // hunting for accounts to tick that do not exist.
+    expect(screen.getByRole('heading', { level: 3, name: 'No accounts yet' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Add Account' })).toBeInTheDocument();
+    expect(
+      screen.queryByRole('heading', { name: 'No accounts are selected for the dashboard' })
+    ).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Show all accounts' })).not.toBeInTheDocument();
   });
 });
 

--- a/src/components/dashboard/ImprovedDashboard.tsx
+++ b/src/components/dashboard/ImprovedDashboard.tsx
@@ -21,6 +21,10 @@ import {
 import { useApp } from '../../contexts/AppContextSupabase';
 import { useCurrencyDecimal } from '../../hooks/useCurrencyDecimal';
 import { preserveDemoParam } from '../../utils/navigation';
+import EmptyState from '../EmptyState';
+import FilteredEmptyState from '../FilteredEmptyState';
+import { TableSkeleton, type TableSkeletonColumn } from '../loading/TableSkeleton';
+import { useDelayedFlag } from '../../hooks/useDelayedFlag';
 import EditTransactionModal from '../EditTransactionModal';
 import IncomeExpenseBreakdownModal from '../IncomeExpenseBreakdownModal';
 import { Modal, ModalBody } from '../common/Modal';
@@ -64,6 +68,28 @@ import { preferences } from '../../services/preferencesService';
  * simply ignored.)
  */
 const DASHBOARD_PERIOD_KEY = 'dashboardReports';
+
+/**
+ * What a balance card is shaped like, for the placeholder that waits in its
+ * place (DESIGN_PASS §4).
+ *
+ * The card is `p-4` around two stacked lines on the left (name over
+ * institution) and the figure on the right, so the placeholder gets the same
+ * two tracks at the same height and the grid does not reflow when the real
+ * cards land.
+ */
+const ACCOUNT_CARD_SKELETON_COLUMNS: TableSkeletonColumn[] = [
+  { key: 'name', className: 'flex-1' },
+  { key: 'balance', width: '7rem' },
+];
+
+/**
+ * What a balance card measures. MEASURED in the running app at 1280px, not
+ * added up from the classes: `p-4` over two short lines reads as 76px on
+ * paper and is 120px in the DOM, and a placeholder at the paper figure would
+ * let the page jump by a third of a card per row as the real ones land.
+ */
+const ACCOUNT_CARD_HEIGHT = 120;
 
 /**
  * Improved Dashboard with better information hierarchy
@@ -331,6 +357,19 @@ export function ImprovedDashboard() {
   };
 
   const displayedAccounts = accounts.filter(a => selectedAccountIds.includes(a.id));
+
+  /**
+   * "None yet" and "none arrived yet" are different sentences, and the panel
+   * below was only able to say the first (DESIGN_PASS §4).
+   *
+   * A first-run empty state is a welcome; the same words during a cold boot are
+   * a false report that the user's accounts are gone. So while the load is
+   * running the panel shows the shape of the cards instead — and shows nothing
+   * at all until 200ms have passed, because a placeholder that flashes makes a
+   * fast dashboard look like a slow one (useDelayedFlag).
+   */
+  const accountsStillArriving = isLoading && accounts.length === 0;
+  const showAccountSkeleton = useDelayedFlag(accountsStillArriving);
 
   // The "which accounts to show here" picker, banded and alphabetised the way
   // every account list in the app is. It is not a <select>, so it cannot take
@@ -852,17 +891,43 @@ export function ImprovedDashboard() {
                 </div>
               </div>
             ))
-          ) : accounts.length > 0 ? (
-            <div className="col-span-2 text-center py-8 text-gray-500 dark:text-gray-400" role="status" aria-live="polite">
-              <SettingsIcon size={48} className="mx-auto mb-3 opacity-50" />
-              <p className="font-medium">No accounts selected</p>
-              <p className="text-sm mt-1">Click the settings icon above to select accounts to display</p>
+          ) : showAccountSkeleton ? (
+            /* SHAPE, NOT SPINNER, at the real card geometry — and nothing at
+               all for the first 200ms (DESIGN_PASS §4). Without this the
+               dashboard asserted "No accounts added yet" at every cold boot,
+               for as long as the accounts took to arrive. */
+            <div className="col-span-2">
+              <TableSkeleton columns={ACCOUNT_CARD_SKELETON_COLUMNS} rowHeight={ACCOUNT_CARD_HEIGHT} />
+            </div>
+          ) : accountsStillArriving ? null : accounts.length > 0 ? (
+            /* A SELECTION IS A FILTER. The accounts exist, the user has simply
+               picked none of them to show — so this names how many are being
+               held back and offers the one control that shows them, rather
+               than sending the user off to find a settings icon. */
+            <div className="col-span-2" role="status" aria-live="polite">
+              <FilteredEmptyState
+                title="No accounts are selected for the dashboard"
+                hiddenCount={accounts.length}
+                scope="of your accounts"
+                filters={['the dashboard’s account selection']}
+                onClear={selectAllAccounts}
+                // Not "Clear filters": the thing hiding these accounts is a
+                // selection, and the remedy should name the control it is.
+                clearLabel="Show all accounts"
+              />
             </div>
           ) : (
-            <div className="col-span-2 text-center py-8 text-gray-500 dark:text-gray-400">
-              <WalletIcon size={48} className="mx-auto mb-3 opacity-50" />
-              <p className="font-medium">No accounts added yet</p>
-              <p className="text-sm mt-1">Add your first account to start tracking</p>
+            /* No accounts at all: the first run. Say what this panel will hold
+               once there is one, and hand over the control that starts it. */
+            <div className="col-span-2">
+              <EmptyState
+                title="No accounts yet"
+                description="This is where each account's balance will sit, and it is what every total, chart and budget on this dashboard is worked out from — so until you add one, the dashboard has nothing to report."
+                action={{
+                  label: 'Add Account',
+                  onClick: () => navigate(preserveDemoParam('/accounts?action=add', location.search))
+                }}
+              />
             </div>
           )}
         </div>

--- a/src/pages/AccountTransactions.tsx
+++ b/src/pages/AccountTransactions.tsx
@@ -3419,7 +3419,14 @@ export default function AccountTransactions() {
           they shrink into each other and the headers paint on top of one
           another. A register is also read differently on a phone: tap a row to
           see or change everything. */}
-      <div className="lg:hidden bg-white dark:bg-gray-800 rounded-2xl shadow-lg border border-gray-100 dark:border-gray-700 overflow-hidden">
+      <div
+        // The phone's half of the register, named so a test can ask it what it
+        // is showing separately from the table's. Both are in the DOM at once
+        // and CSS decides which one a person sees, so "the register says X" is
+        // only a true claim when it is asked of one viewport at a time.
+        data-testid="register-phone-list"
+        className="lg:hidden bg-white dark:bg-gray-800 rounded-2xl shadow-lg border border-gray-100 dark:border-gray-700 overflow-hidden"
+      >
         <InfiniteScrollTransactionList
           transactions={transactionsWithBalance}
           accounts={[]}
@@ -3429,6 +3436,14 @@ export default function AccountTransactions() {
           // that offers neither — a report, a Find result — gets the default
           // and says nothing.
           markNewArrivals
+          // THE SAME NODE THE DESKTOP TABLE GETS. The phone used to answer both
+          // kinds of nothing with one sentence that told a user with an empty
+          // register to adjust filters and a user with a filter to add
+          // transactions; passing the register's own split state means the two
+          // viewports cannot drift into disagreeing about what happened to the
+          // rows (DESIGN_PASS §4).
+          emptyContent={registerEmptyState}
+          isLoading={isLoading}
           formatCurrency={formatRegisterMoney}
           onEdit={(t) => { setSelectedTransaction(t); setSelectedTransactionId(t.id); setIsEditModalOpen(true); }}
           onView={(t) => { setSelectedTransaction(t); setSelectedTransactionId(t.id); setIsEditModalOpen(true); }}
@@ -3534,10 +3549,11 @@ export default function AccountTransactions() {
           sortDirection={sortDirection}
           onColumnReorder={handleColumnReorder}
           onColumnResize={handleColumnResize}
-          emptyMessage="No transactions found"
           // Where the rows would be, when there are none: what is absent, what
           // follows from that, and the control that fixes it — never a blank
-          // table (DESIGN_PASS §4).
+          // table (DESIGN_PASS §4). No emptyMessage beside it: emptyContent
+          // always wins, so a string here would be unreachable copy that a
+          // later reader could mistake for what the register says.
           emptyContent={registerEmptyState}
           threshold={50}
           /* ONE TREATMENT, not four. The navy fill, the blue-grey ring, the

--- a/src/pages/Accounts.tsx
+++ b/src/pages/Accounts.tsx
@@ -57,7 +57,9 @@ import {
   selectTopLevelAccounts,
 } from '../utils/accountNesting';
 import { toDecimal, type DecimalInstance } from '../utils/decimal';
-import { SkeletonCard } from '../components/loading/Skeleton';
+import EmptyState from '../components/EmptyState';
+import FilteredEmptyState from '../components/FilteredEmptyState';
+import { TableSkeleton, type TableSkeletonColumn } from '../components/loading/TableSkeleton';
 import {
   AccountRowColumns,
   AccountBalanceCell,
@@ -77,6 +79,31 @@ import {
   withProvenance,
   type ProvenanceState,
 } from '../utils/navigationProvenance';
+
+/**
+ * What an account row is shaped like, for the placeholder that waits in its
+ * place (DESIGN_PASS §4).
+ *
+ * Two tracks, because that is what a row is at a glance: the name taking the
+ * flexible track on the left, and the figures right-aligned in the fixed ones
+ * ACCOUNT_ROW_COLUMNS_CLASS lays out. The second figure hides below `sm`
+ * exactly as AccountBalanceCell's `smOnly` cell does, so the placeholder is one
+ * column narrower on a phone in the same place the real row is.
+ */
+const ACCOUNT_SKELETON_COLUMNS: TableSkeletonColumn[] = [
+  { key: 'name', className: 'flex-1' },
+  { key: 'balance', width: '6.5rem' },
+  { key: 'secondary', width: '7.5rem', className: 'hidden sm:block' },
+];
+
+/**
+ * What a row measures: `p-3 sm:p-4` around the name, the institution line and
+ * the row of figures. MEASURED in the running app at 1280px rather than added
+ * up from the classes — the arithmetic said 88 and the DOM says 98, and a
+ * placeholder 10px short of the row it stands in for is the layout shift this
+ * pattern exists to prevent.
+ */
+const ACCOUNT_ROW_HEIGHT = 98;
 
 /**
  * The two "Group by" switches as stored. Read through the shared parser, which
@@ -1776,11 +1803,14 @@ export default function Accounts() {
       {/* Accounts grid */}
       <div className="grid gap-6">
         {isLoading ? (
-          <>
-            <SkeletonCard className="h-48" />
-            <SkeletonCard className="h-48" />
-            <SkeletonCard className="h-48" />
-          </>
+          /* SHAPE, NOT SPINNER (DESIGN_PASS §4). Three rows at the height an
+             account row actually is, in the two tracks it actually has — the
+             name on the left, the balance right-aligned — so the list does not
+             jump when the accounts arrive. It replaced three 192px cards that
+             matched no row on this page and breathed while they waited. */
+          <div className="bg-white dark:bg-gray-800">
+            <TableSkeleton columns={ACCOUNT_SKELETON_COLUMNS} rowHeight={ACCOUNT_ROW_HEIGHT} />
+          </div>
         ) : displayedList.mode === 'flat' ? (
           /* Both switches off: one list, no band chrome at all — the rows on
              white, separated by the same hairline the banded views use. */
@@ -1792,21 +1822,38 @@ export default function Accounts() {
         )}
       </div>
 
-      {/* An active search that matches nothing gets a plain-spoken empty state
-          rather than a blank frame — the count above already reads "0 of N". */}
+      {/* A SEARCH THAT HIDES EVERY ACCOUNT IS NOT AN EMPTY ACCOUNT LIST
+          (DESIGN_PASS §4). On a finance app the two look identical and one of
+          them is terrifying, so this one names how many accounts are still
+          there, what is hiding them, and the control that gives them back.
+          Search is the only thing on this page that hides a row: the group and
+          sort switches rearrange the list, and closed accounts have their own
+          section below rather than being filtered out of this one. */}
       {!isLoading && isSearching && matchedTopLevelCount === 0 && openAccounts.length > 0 && (
-        <div className="bg-white dark:bg-gray-800 rounded-2xl shadow-lg border border-gray-100 dark:border-gray-700 p-8 text-center">
-          <p className="text-gray-500 dark:text-gray-400">
-            No accounts match “{accountSearch.trim()}”.
-          </p>
+        <div className="bg-white dark:bg-gray-800 rounded-2xl shadow-lg border border-gray-100 dark:border-gray-700">
+          <FilteredEmptyState
+            title="No accounts match your search"
+            hiddenCount={topLevelAccounts.length}
+            scope="of your accounts"
+            filters={[`Search: ${accountSearch.trim()}`]}
+            onClear={() => setAccountSearch('')}
+          />
         </div>
       )}
 
-      {openAccounts.length === 0 && (
-        <div className="bg-white dark:bg-gray-800 rounded-2xl shadow-lg border border-gray-100 dark:border-gray-700 p-8 text-center">
-          <p className="text-gray-500 dark:text-gray-400">
-            No accounts yet. Click "Add Account" to get started!
-          </p>
+      {/* Gated on !isLoading, which it was not. The window is small — this
+          page's isLoading is local and drops on the first effect pass — but
+          for that first paint "No accounts yet" rendered directly beneath the
+          loading placeholder, which is the page contradicting itself about
+          whether the user has any accounts. The two are now mutually exclusive
+          by construction rather than by how fast an effect runs. */}
+      {!isLoading && openAccounts.length === 0 && (
+        <div className="bg-white dark:bg-gray-800 rounded-2xl shadow-lg border border-gray-100 dark:border-gray-700">
+          <EmptyState
+            title="No accounts yet"
+            description="Every balance, report and budget in WealthTracker is built up from accounts, so until there is one here the rest of the app has nothing to show."
+            action={{ label: 'Add Account', onClick: () => setIsAddModalOpen(true) }}
+          />
         </div>
       )}
 

--- a/src/pages/Find.tsx
+++ b/src/pages/Find.tsx
@@ -4,6 +4,11 @@ import { useApp } from '../contexts/AppContextSupabase';
 import { useCurrencyDecimal } from '../hooks/useCurrencyDecimal';
 import { useDebounce } from '../hooks/useDebounce';
 import PageWrapper from '../components/PageWrapper';
+import EmptyState from '../components/EmptyState';
+import FilteredEmptyState from '../components/FilteredEmptyState';
+import { TableSkeleton, type TableSkeletonColumn } from '../components/loading/TableSkeleton';
+import { useDelayedFlag } from '../hooks/useDelayedFlag';
+import { preserveDemoParam } from '../utils/navigation';
 import { SearchIcon, XIcon } from '../components/icons';
 import { transactionRowDomId } from '../components/transactionRowDomId';
 import { buildTransactionRegisterPath } from '../utils/transactionDeepLink';
@@ -64,6 +69,31 @@ export const FIND_ROW_SELECTED_CLASS =
   '[&>td]:border-y [&>td]:border-[#6B86B3]/50 dark:[&>td]:border-[#6B86B3]/70 ' +
   '[&>td:first-child]:border-l [&>td:last-child]:border-r';
 
+/**
+ * The results table's geometry, for the placeholder that stands in for it.
+ *
+ * The table below is hand-written `<th>`s rather than a `Column[]`, so this is
+ * the one place the two could drift apart — and a placeholder of the wrong
+ * shape is a layout shift with extra steps. Find.emptyStates.test.tsx counts
+ * the placeholder's cells against the real header's in the rendered DOM, so a
+ * column added to one and not the other fails rather than quietly misaligning.
+ *
+ * The `hidden sm:block` / `hidden md:block` pairs mirror the header's own
+ * `hidden sm:table-cell` / `hidden md:table-cell`: at 375px the real table
+ * draws four columns, so the placeholder must draw four too.
+ */
+const FIND_SKELETON_COLUMNS: TableSkeletonColumn[] = [
+  { key: 'date', width: '14%' },
+  { key: 'cr', width: '6%' },
+  { key: 'account', width: '18%', className: 'hidden sm:block' },
+  { key: 'description', width: '32%' },
+  { key: 'category', width: '16%', className: 'hidden md:block' },
+  { key: 'amount', width: '14%' },
+];
+
+/** `py-2` over `text-sm`'s 20px line — the height a result row actually is. */
+const FIND_ROW_HEIGHT = 36;
+
 /** How a day is written in the range chip — the app's date style, spelled out. */
 const DAY_FORMAT = new Intl.DateTimeFormat('en-GB', { day: 'numeric', month: 'short', year: 'numeric' });
 
@@ -75,7 +105,7 @@ function formatDay(day: string): string {
 }
 
 export default function Find(): React.JSX.Element {
-  const { transactions, accounts, categories } = useApp();
+  const { transactions, accounts, categories, isLoading } = useApp();
   const { formatCurrency } = useCurrencyDecimal();
   const navigate = useNavigate();
   const location = useLocation();
@@ -255,6 +285,52 @@ export default function Find(): React.JSX.Element {
     setSearchParams(params, { replace: true });
   }, [setSearchParams]);
 
+  /**
+   * Everything the search is currently asking for, let go of at once — the
+   * remedy the filtered-empty state offers.
+   *
+   * The box is cleared as well as the URL: the box is what the user is looking
+   * at, and a "Clear" that emptied the results while leaving the query sitting
+   * in the field would read as the search having broken.
+   */
+  const clearSearch = useCallback((): void => {
+    setText('');
+    const params = new URLSearchParams(latestSearch.current);
+    params.delete('q');
+    params.delete('dateFrom');
+    params.delete('dateTo');
+    setSearchParams(params, { replace: true });
+  }, [setSearchParams]);
+
+  /**
+   * The filters holding every result back, named the way the user set them
+   * (DESIGN_PASS §4). "Gone" and "hidden" look identical on a search page, and
+   * only the count and these names tell them apart.
+   */
+  const activeFilterNames = useMemo<string[]>(() => {
+    const names: string[] = [];
+    const typed = debouncedText.trim();
+    if (typed) names.push(`Search: ${typed}`);
+    if (dateFrom || dateTo) names.push('the date range');
+    return names;
+  }, [debouncedText, dateFrom, dateTo]);
+
+  /**
+   * NOTHING TO SEARCH, versus NOTHING FOUND — and the difference is the whole
+   * reason this page can be trusted.
+   *
+   * Find reads the rows already in memory, so before they arrive every search
+   * legitimately matches nothing. Saying "Nothing matches Ferrier" at that
+   * moment is a FALSE NEGATIVE about the user's own money: they conclude the
+   * transaction is not there and go looking somewhere else. So a load that has
+   * not finished shows the shape of the table instead, and only once it has —
+   * and only once 200ms have passed, or a quick load flashes grey bars for
+   * nothing (useDelayedFlag).
+   */
+  const stillArriving = isLoading && transactions.length === 0;
+  const showResultsSkeleton = useDelayedFlag(stillArriving);
+  const nothingToSearch = !isLoading && transactions.length === 0;
+
   const rangeLabel = dateFrom && dateTo && dateFrom !== dateTo
     ? `${formatDay(dateFrom)} – ${formatDay(dateTo)}`
     : formatDay(dateFrom || dateTo);
@@ -294,30 +370,66 @@ export default function Find(): React.JSX.Element {
         )}
       </div>
 
-      {nothingAsked ? (
-        <div className="bg-white dark:bg-gray-800 rounded-lg shadow-sm border border-gray-200 dark:border-gray-700 p-8 text-center">
-          <SearchIcon size={32} className="mx-auto mb-3 text-gray-400" />
-          <p className="text-base font-medium text-gray-900 dark:text-white">Find looks through every account at once</p>
-          <p className="mt-2 text-sm text-gray-600 dark:text-gray-300 max-w-prose mx-auto">
+      {stillArriving ? (
+        // SHAPE, NOT SPINNER — and nothing at all under 200ms. Never the words
+        // "Nothing matches" while the rows are still on their way.
+        showResultsSkeleton ? (
+          <div className="bg-white dark:bg-gray-800 rounded-lg shadow-sm border border-gray-200 dark:border-gray-700 overflow-hidden">
+            <TableSkeleton columns={FIND_SKELETON_COLUMNS} rowHeight={FIND_ROW_HEIGHT} />
+          </div>
+        ) : null
+      ) : nothingToSearch ? (
+        // There is nothing in the ledger at all, so no query could ever match.
+        // Saying "Nothing matches Ferrier" here would blame the search for the
+        // absence of the data.
+        <div className="bg-white dark:bg-gray-800 rounded-lg shadow-sm border border-gray-200 dark:border-gray-700">
+          <EmptyState
+            title="There are no transactions to search yet"
+            description="Find looks through every account at once — so until something lands in one of them, every search here comes back empty."
+            action={{
+              label: 'Import a statement',
+              onClick: () => navigate(preserveDemoParam('/enhanced-import', location.search))
+            }}
+            secondaryAction={{
+              label: 'Go to Accounts',
+              onClick: () => navigate(preserveDemoParam('/accounts', location.search))
+            }}
+          />
+        </div>
+      ) : nothingAsked ? (
+        // Not an empty state: nothing is missing and nothing is hidden. It is
+        // the page explaining itself before it has been asked anything — so it
+        // keeps its own voice, but reads down the left edge like everything
+        // else now, without the decorative glyph §4 rules out.
+        <div className="bg-white dark:bg-gray-800 rounded-lg shadow-sm border border-gray-200 dark:border-gray-700 px-6 py-10">
+          <h3 className="text-card font-semibold text-gray-900 dark:text-white">Find looks through every account at once</h3>
+          <p className="mt-1 max-w-2xl text-body text-gray-600 dark:text-gray-400">
             Type part of a description, or an amount as your statement prints it — 141.50 finds it
             whichever way the money went. Click a result to open that transaction in its own
             account&rsquo;s register, which is where you can change it.
           </p>
         </div>
       ) : outcome.total === 0 ? (
-        <div className="bg-white dark:bg-gray-800 rounded-lg shadow-sm border border-gray-200 dark:border-gray-700 p-8 text-center">
-          <p className="text-base font-medium text-gray-900 dark:text-white">
-            {debouncedText.trim() === ''
-              ? 'Nothing was recorded in that date range'
-              : `Nothing matches “${debouncedText.trim()}”`}
-          </p>
-          <p className="mt-2 text-sm text-gray-600 dark:text-gray-300">
-            Find looks at descriptions and amounts. Categories, tags and notes are searched inside
-            an account&rsquo;s own register.
-          </p>
+        // The rows ARE there — this search is what is hiding them. Say how
+        // many, say what is doing it, and offer the one control that undoes it.
+        <div className="bg-white dark:bg-gray-800 rounded-lg shadow-sm border border-gray-200 dark:border-gray-700">
+          <FilteredEmptyState
+            hiddenCount={transactions.length}
+            scope="across your accounts"
+            filters={activeFilterNames}
+            onClear={clearSearch}
+          />
         </div>
       ) : (
-        <div className="bg-white dark:bg-gray-800 rounded-lg shadow-sm border border-gray-200 dark:border-gray-700 overflow-hidden">
+        // A REFETCH DIMS, IT NEVER BLANKS: results already on screen stay where
+        // they are at 60% while the ledger is fetched again. Blanking them is
+        // indistinguishable, for as long as it lasts, from losing them
+        // (DESIGN_PASS §4).
+        <div
+          className={`bg-white dark:bg-gray-800 rounded-lg shadow-sm border border-gray-200 dark:border-gray-700 overflow-hidden ${
+            isLoading ? 'opacity-60 transition-opacity duration-enter' : ''
+          }`}
+        >
           <p className="px-4 py-3 text-sm text-gray-600 dark:text-gray-300 border-b border-gray-200 dark:border-gray-700">
             {outcome.capped
               ? `Showing the first ${FIND_RESULT_CAP} of ${outcome.total} matches — narrow the search.`

--- a/src/pages/__tests__/AccountTransactions.categorySort.test.tsx
+++ b/src/pages/__tests__/AccountTransactions.categorySort.test.tsx
@@ -428,6 +428,12 @@ describe('Account register — searching finds what the Category column says', (
     // is the empty string, and the empty string must go on matching nothing
     // rather than everything.
     expect(columnInOrder('Description')).toEqual([]);
-    expect(screen.getAllByText('No transactions found').length).toBeGreaterThan(0);
+    // And says so as a FILTERED-empty, in both viewports: the rows are behind
+    // the search, not missing (DESIGN_PASS §4). This used to read
+    // 'No transactions found', which was the same words for both cases.
+    expect(
+      screen.getAllByRole('heading', { level: 3, name: 'No transactions match these filters' })
+    ).toHaveLength(2);
+    expect(screen.getAllByText('Search: Quenchless').length).toBeGreaterThan(0);
   });
 });

--- a/src/pages/__tests__/AccountTransactions.registerChrome.test.tsx
+++ b/src/pages/__tests__/AccountTransactions.registerChrome.test.tsx
@@ -87,6 +87,13 @@ const renderRegister = (transactions: Transaction[] = ROWS): void => {
 
 const grid = (): HTMLElement => screen.getByRole('grid', { name: 'Synthetic Chrome transactions' });
 
+/**
+ * The phone's card list. Both viewports are in the DOM at once and CSS picks
+ * one, so every claim about what the register SAYS has to be addressed to a
+ * viewport — an unscoped query would match twice and pass for the wrong reason.
+ */
+const phoneList = (): HTMLElement => screen.getByTestId('register-phone-list');
+
 /** Which cell of a row holds the named column, read off the header itself. */
 const columnIndex = (header: string): number => {
   const headers = Array.from(grid().querySelectorAll('[role="columnheader"]'));
@@ -198,15 +205,27 @@ describe('a register with nothing in it', () => {
     renderRegister([]);
     await screen.findByRole('heading', { level: 1, name: 'Synthetic Chrome' });
 
-    expect(screen.getByRole('heading', { level: 3, name: 'No transactions in this account yet' })).toBeInTheDocument();
+    expect(within(grid()).getByRole('heading', { level: 3, name: 'No transactions in this account yet' })).toBeInTheDocument();
     // The consequence, in the account's own currency.
-    expect(screen.getByText(/Its balance stays at \$100\.00/)).toBeInTheDocument();
-    expect(screen.getByText(/adds nothing to your reports/)).toBeInTheDocument();
+    expect(within(grid()).getByText(/Its balance stays at \$100\.00/)).toBeInTheDocument();
+    expect(within(grid()).getByText(/adds nothing to your reports/)).toBeInTheDocument();
     // Remedies as real controls, not directions to find one — and IN THE
     // TABLE, where the rows are missing, rather than only in the toolbar the
     // user has just failed to notice.
     expect(within(grid()).getByRole('button', { name: 'Add transaction' })).toBeInTheDocument();
     expect(within(grid()).getByRole('button', { name: 'Import a statement' })).toBeInTheDocument();
+  });
+
+  it('says the same thing on a phone, which used to be told to adjust filters it had not set', async () => {
+    renderRegister([]);
+    await screen.findByRole('heading', { level: 1, name: 'Synthetic Chrome' });
+
+    const phone = within(phoneList());
+    expect(phone.getByRole('heading', { level: 3, name: 'No transactions in this account yet' })).toBeInTheDocument();
+    expect(phone.getByRole('button', { name: 'Add transaction' })).toBeInTheDocument();
+    // The sentence the card list used to end on, gone: it was the advice for
+    // the OTHER state, given to everybody.
+    expect(phone.queryByText(/Try adjusting your filters/)).not.toBeInTheDocument();
   });
 });
 
@@ -224,10 +243,31 @@ describe('a register emptied by a filter is not an empty register', () => {
 
     searchFor('Quenchless');
 
-    expect(screen.getByRole('heading', { level: 3, name: 'No transactions match these filters' })).toBeInTheDocument();
+    const table = within(grid());
+    expect(table.getByRole('heading', { level: 3, name: 'No transactions match these filters' })).toBeInTheDocument();
     // THE COUNT IS THE POINT: it is the sentence that says the rows still exist.
-    expect(screen.getByText('3')).toBeInTheDocument();
-    expect(screen.getByText('Search: Quenchless')).toBeInTheDocument();
+    expect(table.getByText('3')).toBeInTheDocument();
+    expect(table.getByText('Search: Quenchless')).toBeInTheDocument();
+  });
+
+  it('is a DIFFERENT state from an empty register, in both viewports', async () => {
+    renderRegister();
+    await screen.findByRole('heading', { level: 1, name: 'Synthetic Chrome' });
+
+    searchFor('Quenchless');
+
+    // The distinguishing words, either way round: the filtered state names the
+    // count and the filter and offers to let go; the empty one names the
+    // balance and offers the two ways in. Neither may wear the other's voice.
+    for (const scope of [within(grid()), within(phoneList())]) {
+      expect(scope.getByRole('heading', { level: 3, name: 'No transactions match these filters' })).toBeInTheDocument();
+      expect(scope.getByText('Search: Quenchless')).toBeInTheDocument();
+      expect(scope.getByRole('button', { name: 'Clear filters' })).toBeInTheDocument();
+
+      expect(scope.queryByRole('heading', { name: 'No transactions in this account yet' })).not.toBeInTheDocument();
+      expect(scope.queryByRole('button', { name: 'Add transaction' })).not.toBeInTheDocument();
+      expect(scope.queryByText(/Its balance stays at/)).not.toBeInTheDocument();
+    }
   });
 
   it('offers one control that gives them back, and it gives them back', async () => {
@@ -237,7 +277,7 @@ describe('a register emptied by a filter is not an empty register', () => {
     searchFor('Quenchless');
     expect(dataRows()).toHaveLength(0);
 
-    fireEvent.click(screen.getByRole('button', { name: 'Clear filters' }));
+    fireEvent.click(within(grid()).getByRole('button', { name: 'Clear filters' }));
 
     expect(dataRows()).toHaveLength(3);
     expect(screen.queryByRole('heading', { name: 'No transactions match these filters' })).not.toBeInTheDocument();

--- a/src/pages/__tests__/Accounts.emptyStates.test.tsx
+++ b/src/pages/__tests__/Accounts.emptyStates.test.tsx
@@ -1,0 +1,110 @@
+/**
+ * THE ACCOUNTS PAGE'S TWO KINDS OF NOTHING (DESIGN_PASS §4).
+ *
+ * On a personal-finance app these two states look identical and one of them is
+ * terrifying. "No accounts" on a page that had eleven of them a moment ago is
+ * indistinguishable, for as long as it lasts, from having lost them — so a
+ * search that hides every account has to say how many are still there, what is
+ * hiding them, and offer the one control that lets go.
+ *
+ * The true-empty state is the opposite job: a first run, where the remedy is
+ * the whole point and there is nothing to reassure anybody about.
+ *
+ * Every account name and institution below comes from the shared synthetic
+ * fixture: this repo is public.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { render, screen, fireEvent, within } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { PreferencesProvider } from '../../contexts/PreferencesContext';
+import { ToastProvider } from '../../contexts/ToastContext';
+import Accounts from '../Accounts';
+import { __setAppContextValue, __resetAppContextValue } from '../../test/mocks/AppContextSupabase';
+import { DataService } from '../../services/api/dataService';
+
+const renderAccounts = () =>
+  render(
+    <MemoryRouter initialEntries={['/accounts']}>
+      <PreferencesProvider>
+        <ToastProvider>
+          <Accounts />
+        </ToastProvider>
+      </PreferencesProvider>
+    </MemoryRouter>
+  );
+
+const searchFor = (term: string): void => {
+  fireEvent.change(screen.getByLabelText('Search accounts by name or institution'), {
+    target: { value: term }
+  });
+};
+
+beforeEach(() => {
+  localStorage.clear();
+  vi.spyOn(DataService, 'listClosedAccounts').mockResolvedValue([]);
+});
+
+afterEach(() => {
+  __resetAppContextValue();
+  vi.clearAllMocks();
+});
+
+describe('an accounts list with nothing in it', () => {
+  it('says what is absent, what follows from it, and offers the way in', async () => {
+    __setAppContextValue({ accounts: [], transactions: [], categories: [], isLoading: false });
+    renderAccounts();
+
+    const heading = await screen.findByRole('heading', { level: 3, name: 'No accounts yet' });
+    // The consequence — why an empty accounts page empties the whole app.
+    expect(screen.getByText(/the rest of the app has nothing to show/)).toBeInTheDocument();
+    // The remedy as a real control IN THE EMPTY STATE, not an instruction to
+    // go and find the toolbar's copy of it. The old copy was the instruction:
+    // No accounts yet. Click "Add Account" to get started!
+    const emptyState = heading.parentElement;
+    expect(emptyState).not.toBeNull();
+    expect(within(emptyState as HTMLElement).getByRole('button', { name: 'Add Account' })).toBeInTheDocument();
+  });
+});
+
+describe('an accounts list emptied by the search is not an empty accounts list', () => {
+  it('names how many are hidden and what is hiding them', async () => {
+    renderAccounts();
+    await screen.findByRole('heading', { level: 2, name: 'Current Accounts' });
+
+    searchFor('quenchless ironmongery');
+
+    expect(
+      screen.getByRole('heading', { level: 3, name: 'No accounts match your search' })
+    ).toBeInTheDocument();
+    // THE COUNT IS THE POINT: it is the sentence that says they still exist.
+    expect(screen.getByText(/of your accounts are hidden by/)).toBeInTheDocument();
+    expect(screen.getByText('Search: quenchless ironmongery')).toBeInTheDocument();
+  });
+
+  it('is distinguishable from the empty list by every word that matters', async () => {
+    renderAccounts();
+    await screen.findByRole('heading', { level: 2, name: 'Current Accounts' });
+
+    searchFor('quenchless ironmongery');
+
+    // None of the first-run voice: an established user whose search missed is
+    // not being welcomed to the product, and must not be offered "Add Account"
+    // as the fix for accounts that are merely hidden.
+    expect(screen.queryByRole('heading', { name: 'No accounts yet' })).not.toBeInTheDocument();
+    expect(screen.queryByText(/the rest of the app has nothing to show/)).not.toBeInTheDocument();
+  });
+
+  it('offers one control that gives them back, and it gives them back', async () => {
+    renderAccounts();
+    await screen.findByRole('heading', { level: 2, name: 'Current Accounts' });
+
+    searchFor('quenchless ironmongery');
+    expect(screen.queryByRole('heading', { level: 3, name: 'Natwest Current Account' })).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Clear filters' }));
+
+    expect(screen.getByRole('heading', { level: 3, name: 'Natwest Current Account' })).toBeInTheDocument();
+    expect(screen.queryByRole('heading', { name: 'No accounts match your search' })).not.toBeInTheDocument();
+  });
+});

--- a/src/pages/__tests__/Find.emptyStates.test.tsx
+++ b/src/pages/__tests__/Find.emptyStates.test.tsx
@@ -1,0 +1,214 @@
+/**
+ * FIND'S THREE KINDS OF NOTHING, and why they must never wear each other's
+ * words (DESIGN_PASS §4).
+ *
+ * Find is the one page in the app whose MAIN empty state is a filtered one: a
+ * search that hits nothing is the normal way to use it. That makes the failure
+ * mode acute — a page that says "nothing matches" when the truth is "nothing
+ * has loaded yet" tells the user their money is not there, and they go looking
+ * somewhere else.
+ *
+ * So:
+ *   loading    the shape of the table, never a verdict on the search;
+ *   empty      no transactions exist to search, which is not the search's
+ *              fault and does not blame it;
+ *   filtered   they exist, this search is over them, and here is the count,
+ *              the culprit and the way out.
+ *
+ * Every name, figure and date below is invented: this repo is public.
+ */
+
+import React from 'react';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { render, screen, fireEvent, waitFor, act, cleanup } from '@testing-library/react';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { PreferencesProvider } from '../../contexts/PreferencesContext';
+import { __setAppContextValue, __resetAppContextValue } from '../../test/mocks/AppContextSupabase';
+import { LOADING_REVEAL_DELAY_MS } from '../../hooks/useDelayedFlag';
+import Find from '../Find';
+import type { Account, Transaction } from '../../types';
+
+const ACCOUNT: Account = {
+  id: 'acc-find-empty', name: 'Everyday Current', type: 'current', balance: 0,
+  currency: 'GBP', lastUpdated: new Date('2026-01-01'), openingBalance: 0, isActive: true,
+};
+
+const ROWS: Transaction[] = [
+  {
+    id: 'txn-a', description: 'Halberd Ironmongers', amount: -141.5, type: 'expense',
+    accountId: ACCOUNT.id, category: '', cleared: false, date: new Date(Date.UTC(2026, 3, 1)),
+  },
+  {
+    id: 'txn-b', description: 'Wexford Bakery', amount: -22.75, type: 'expense',
+    accountId: ACCOUNT.id, category: '', cleared: false, date: new Date(Date.UTC(2026, 3, 2)),
+  },
+];
+
+const openFind = (
+  { transactions = ROWS, isLoading = false }: { transactions?: Transaction[]; isLoading?: boolean } = {}
+): void => {
+  __setAppContextValue({
+    accounts: [ACCOUNT],
+    transactions,
+    categories: [],
+    isLoading,
+    getSubCategories: () => [],
+    getDetailCategories: () => [],
+  });
+  render(
+    <MemoryRouter initialEntries={['/find']}>
+      <PreferencesProvider>
+        <Routes>
+          <Route path="/find" element={<Find />} />
+          <Route path="/enhanced-import" element={<div>Import page</div>} />
+          <Route path="/accounts" element={<div>Accounts page</div>} />
+        </Routes>
+      </PreferencesProvider>
+    </MemoryRouter>
+  );
+};
+
+const type = (text: string): void => {
+  fireEvent.change(screen.getByLabelText('Find transactions by description or amount'), {
+    target: { value: text }
+  });
+};
+
+beforeEach(() => {
+  localStorage.clear();
+});
+
+afterEach(() => {
+  __resetAppContextValue();
+  vi.clearAllMocks();
+});
+
+describe('Find with nothing to search', () => {
+  it('says the ledger is empty rather than blaming the search', async () => {
+    openFind({ transactions: [] });
+
+    expect(
+      await screen.findByRole('heading', { level: 3, name: 'There are no transactions to search yet' })
+    ).toBeInTheDocument();
+    // The consequence: why every search here will come back empty.
+    expect(screen.getByText(/every search here comes back empty/)).toBeInTheDocument();
+    // Remedies as real controls.
+    expect(screen.getByRole('button', { name: 'Import a statement' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Go to Accounts' })).toBeInTheDocument();
+  });
+
+  it('keeps saying it once a query is typed, because the query is not why', async () => {
+    openFind({ transactions: [] });
+    type('ironmongers');
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole('heading', { level: 3, name: 'There are no transactions to search yet' })
+      ).toBeInTheDocument();
+    });
+    // Never the filtered sentence: there is nothing behind the filter to count,
+    // and "0 are hidden by Search: ironmongers" is an absurdity.
+    expect(screen.queryByText(/are hidden by/)).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Clear filters' })).not.toBeInTheDocument();
+  });
+});
+
+describe('Find emptied by the search is not Find with nothing in it', () => {
+  it('names the count, the query doing it, and the way out', async () => {
+    openFind();
+    type('quenchless');
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole('heading', { level: 3, name: 'No transactions match these filters' })
+      ).toBeInTheDocument();
+    });
+    // THE COUNT IS THE POINT: two rows still exist, across the accounts.
+    expect(screen.getByText('2')).toBeInTheDocument();
+    expect(screen.getByText(/across your accounts are hidden by/)).toBeInTheDocument();
+    expect(screen.getByText('Search: quenchless')).toBeInTheDocument();
+  });
+
+  it('is distinguishable from the empty state by every word that matters', async () => {
+    openFind();
+    type('quenchless');
+
+    await waitFor(() => {
+      expect(screen.getByText('Search: quenchless')).toBeInTheDocument();
+    });
+    // None of the empty state's voice may appear here: no "nothing to search",
+    // and no remedy that treats the absence as the user's to fix by importing.
+    expect(
+      screen.queryByRole('heading', { name: 'There are no transactions to search yet' })
+    ).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Import a statement' })).not.toBeInTheDocument();
+  });
+
+  it('gives them back when the one control is pressed', async () => {
+    openFind();
+    type('quenchless');
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'Clear filters' })).toBeInTheDocument();
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Clear filters' }));
+
+    await waitFor(() => {
+      expect(screen.queryByRole('heading', { name: 'No transactions match these filters' })).not.toBeInTheDocument();
+    });
+    // Back to the page's opening question, and the box is empty too — a
+    // "Clear" that left the query sitting in the field would read as broken.
+    expect(screen.getByRole('heading', { name: 'Find looks through every account at once' })).toBeInTheDocument();
+    expect(screen.getByLabelText('Find transactions by description or amount')).toHaveValue('');
+  });
+});
+
+describe('Find while the ledger is still arriving', () => {
+  beforeEach(() => {
+    // The shared setup has already mocked the clock with setSystemTime, and
+    // faking timers over the top of that throws — hand the real clock back
+    // first (the same dance useDelayedFlag.test.ts does).
+    vi.useRealTimers();
+    vi.useFakeTimers();
+  });
+  afterEach(() => { vi.useRealTimers(); });
+
+  it('shows NOTHING for the first 200ms — a fast load must look fast', () => {
+    openFind({ transactions: [], isLoading: true });
+
+    expect(screen.queryByRole('status', { name: 'Loading transactions' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('heading', { level: 3 })).not.toBeInTheDocument();
+  });
+
+  it('then shows the shape of the table, and never a verdict on the search', () => {
+    openFind({ transactions: [], isLoading: true });
+    act(() => { vi.advanceTimersByTime(LOADING_REVEAL_DELAY_MS); });
+
+    expect(screen.getByRole('status', { name: 'Loading transactions' })).toBeInTheDocument();
+    // THE FALSE NEGATIVE THIS EXISTS TO PREVENT. Before this wiring, a query
+    // typed while the rows were still loading was answered "Nothing matches" —
+    // a page telling somebody their transaction is not there, about their own
+    // money, when it simply had not arrived.
+    expect(screen.queryByText(/No transactions match/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/There are no transactions to search yet/)).not.toBeInTheDocument();
+  });
+
+  it('draws the placeholder with one cell per column the real table has', () => {
+    // The results table is hand-written <th>s rather than a Column[], so the
+    // placeholder's geometry is the one thing here that could silently drift
+    // out of step with it — and a placeholder of the wrong shape is a layout
+    // shift with extra steps. Count both, in the DOM, and compare.
+    openFind({ transactions: [], isLoading: true });
+    act(() => { vi.advanceTimersByTime(LOADING_REVEAL_DELAY_MS); });
+    const skeletonRow = screen.getByRole('status', { name: 'Loading transactions' }).firstElementChild;
+    const placeholderCells = skeletonRow?.children.length ?? 0;
+    cleanup();
+
+    openFind();
+    type('bakery');
+    act(() => { vi.advanceTimersByTime(500); });
+    const headerCells = screen.getAllByRole('columnheader').length;
+
+    expect(placeholderCells).toBe(headerCells);
+  });
+});

--- a/src/pages/__tests__/Find.test.tsx
+++ b/src/pages/__tests__/Find.test.tsx
@@ -168,16 +168,23 @@ describe('Find — what it matches', () => {
     expect(within(results()).queryByText('Pellam Tyres')).not.toBeInTheDocument();
   });
 
-  it('says so plainly when nothing matches', async () => {
+  it('says so plainly when nothing matches — and says the rows are still there', async () => {
     openFind();
 
     type('ironmongers of nowhere');
 
     await waitFor(() => {
-      expect(screen.getByText(/Nothing matches/)).toBeInTheDocument();
+      expect(
+        screen.getByRole('heading', { level: 3, name: 'No transactions match these filters' })
+      ).toBeInTheDocument();
     });
-    // And states what it looked at, so "no matches" means something.
-    expect(screen.getByText(/Find looks at descriptions and amounts/)).toBeInTheDocument();
+    // THE COUNT AND THE CULPRIT. "Nothing matches X" told the user what did not
+    // happen; on a page that searches every account at once, what they need to
+    // know is that all of it is still there and this search is what is over it
+    // (DESIGN_PASS §4).
+    expect(screen.getByText(/are hidden by/)).toBeInTheDocument();
+    expect(screen.getByText('Search: ironmongers of nowhere')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Clear filters' })).toBeInTheDocument();
   });
 
   it('shows the row the way the register does — C, R, the account, the bold', async () => {

--- a/src/pages/settings/AuditLogs.emptyStates.test.tsx
+++ b/src/pages/settings/AuditLogs.emptyStates.test.tsx
@@ -1,0 +1,107 @@
+/**
+ * THE AUDIT TRAIL'S TWO KINDS OF NOTHING (DESIGN_PASS §4).
+ *
+ * An audit trail that looks empty is a worse lie than a register that does:
+ * the entire value of one is that it is COMPLETE, so a filter that hides every
+ * entry must say it is a filter doing it. "Try adjusting your filters to see
+ * more results" — the sentence that used to be here — states neither how much
+ * is being held back nor which filter is holding it, and reads identically to
+ * a trail that has been wiped.
+ *
+ * Every user id, action and resource below is invented: this repo is public.
+ */
+
+import React from 'react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { PreferencesProvider } from '../../contexts/PreferencesContext';
+import { securityService, type AuditLog } from '../../services/securityService';
+import AuditLogs from './AuditLogs';
+
+const LOGS: AuditLog[] = [
+  {
+    id: 'log-1', timestamp: new Date('2026-05-01T09:00:00Z'), userId: 'user_testonly_0001',
+    action: 'create', resourceType: 'transaction', resourceId: 'txn-quenchless',
+  },
+  {
+    id: 'log-2', timestamp: new Date('2026-05-02T09:00:00Z'), userId: 'user_testonly_0001',
+    action: 'update', resourceType: 'account', resourceId: 'acc-halberd',
+  },
+];
+
+const renderAuditLogs = (logs: AuditLog[]): void => {
+  vi.spyOn(securityService, 'getAuditLogs').mockReturnValue(logs);
+  render(
+    <MemoryRouter initialEntries={['/settings/audit-logs']}>
+      <PreferencesProvider>
+        <AuditLogs />
+      </PreferencesProvider>
+    </MemoryRouter>
+  );
+};
+
+const searchFor = (term: string): void => {
+  fireEvent.change(screen.getByPlaceholderText(/Search/i), { target: { value: term } });
+};
+
+beforeEach(() => {
+  localStorage.clear();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('an audit trail with nothing in it', () => {
+  it('says what is absent and what will fill it, without inventing a control', () => {
+    renderAuditLogs([]);
+
+    expect(
+      screen.getByRole('heading', { level: 3, name: 'No activity has been logged yet' })
+    ).toBeInTheDocument();
+    // The consequence: what a trail with nothing in it means.
+    expect(screen.getByText(/Until something is changed there is nothing to audit/)).toBeInTheDocument();
+    // NO REMEDY BUTTON, deliberately. The trail is written by the app as the
+    // user works; a control here would be a button that fabricates an audit
+    // entry, which is the one thing an audit trail must never offer.
+    expect(screen.queryByRole('button', { name: 'Clear filters' })).not.toBeInTheDocument();
+  });
+});
+
+describe('an audit trail emptied by a filter is not an empty audit trail', () => {
+  it('names how many entries are hidden and which filter is hiding them', () => {
+    renderAuditLogs(LOGS);
+
+    searchFor('quenchless ironmongery');
+
+    expect(
+      screen.getByRole('heading', { level: 3, name: 'No activity matches these filters' })
+    ).toBeInTheDocument();
+    // THE COUNT IS THE POINT: the trail is intact, this filter is over it.
+    expect(screen.getByText('2')).toBeInTheDocument();
+    expect(screen.getByText(/logged activities are hidden by/)).toBeInTheDocument();
+    expect(screen.getByText('Search: quenchless ironmongery')).toBeInTheDocument();
+  });
+
+  it('is distinguishable from the empty trail by every word that matters', () => {
+    renderAuditLogs(LOGS);
+
+    searchFor('quenchless ironmongery');
+
+    expect(
+      screen.queryByRole('heading', { name: 'No activity has been logged yet' })
+    ).not.toBeInTheDocument();
+    expect(screen.queryByText(/Until something is changed there is nothing to audit/)).not.toBeInTheDocument();
+  });
+
+  it('offers one control that gives them back, and it gives them back', () => {
+    renderAuditLogs(LOGS);
+
+    searchFor('quenchless ironmongery');
+    fireEvent.click(screen.getByRole('button', { name: 'Clear filters' }));
+
+    expect(screen.queryByRole('heading', { name: 'No activity matches these filters' })).not.toBeInTheDocument();
+    expect(screen.getByText(/Showing 2 of 2 logs/)).toBeInTheDocument();
+  });
+});

--- a/src/pages/settings/AuditLogs.tsx
+++ b/src/pages/settings/AuditLogs.tsx
@@ -11,6 +11,8 @@ import {
 import PageWrapper from '../../components/PageWrapper';
 import DatePicker from '../../components/common/DatePicker';
 import { VirtualizedTable, Column } from '../../components/VirtualizedTable';
+import EmptyState from '../../components/EmptyState';
+import FilteredEmptyState from '../../components/FilteredEmptyState';
 import type { AuditLog } from '../../services/securityService';
 
 export default function AuditLogs() {
@@ -89,6 +91,21 @@ export default function AuditLogs() {
       search: ''
     });
   };
+
+  /**
+   * Every filter currently holding a log back, named the way the user set it
+   * (DESIGN_PASS §4). An audit trail that looks empty is a worse lie than a
+   * register that does: the whole point of one is that it is complete, so a
+   * filter that hides every entry has to say it is a filter doing it.
+   */
+  const activeFilterNames = useMemo<string[]>(() => {
+    const names: string[] = [];
+    if (filters.search) names.push(`Search: ${filters.search}`);
+    if (filters.action) names.push(`Action: ${filters.action}`);
+    if (filters.resourceType) names.push(`Type: ${filters.resourceType}`);
+    if (filters.startDate || filters.endDate) names.push('the date range');
+    return names;
+  }, [filters]);
 
   const getActionIcon = (action: string) => {
     switch (action) {
@@ -347,10 +364,28 @@ export default function AuditLogs() {
             columns={columns}
             getItemKey={(log: AuditLog) => log.id}
             rowHeight={80}
-            emptyMessage={
-              logs.length === 0
-                ? 'No activities have been logged yet'
-                : 'Try adjusting your filters to see more results'
+            // Nothing logged at all, versus everything logged being behind a
+            // filter — one is a new install, the other looks like a wiped
+            // trail. They are not the same sentence (DESIGN_PASS §4).
+            emptyContent={
+              logs.length === 0 ? (
+                <EmptyState
+                  title="No activity has been logged yet"
+                  // No remedy button, deliberately: the trail is written BY the
+                  // app as you use it, and a control here would be a button
+                  // that fabricates an audit entry — the one thing an audit
+                  // trail must never offer.
+                  description="Every change to an account, a transaction or a category is recorded here as you make it. Until something is changed there is nothing to audit."
+                />
+              ) : (
+                <FilteredEmptyState
+                  title="No activity matches these filters"
+                  hiddenCount={logs.length}
+                  scope="logged activities"
+                  filters={activeFilterNames}
+                  onClear={clearFilters}
+                />
+              )
             }
             threshold={50}
           />

--- a/src/pages/settings/PayeeCleanup.emptyStates.test.tsx
+++ b/src/pages/settings/PayeeCleanup.emptyStates.test.tsx
@@ -1,0 +1,150 @@
+/**
+ * PAYEE CLEANUP'S THREE KINDS OF NOTHING (DESIGN_PASS §4).
+ *
+ * This screen already told them apart in prose — it was one of the few that
+ * did — but it said them as bare sentences with no count and no way out. The
+ * count is what turns "my payees are gone" back into "they are hidden", and on
+ * a screen whose entire purpose is bulk-editing thousands of payees, that
+ * distinction is the difference between a search that missed and a tidy-up
+ * that ate the list.
+ *
+ *   empty      the ledger has no transactions, so there are no payees at all;
+ *   hidden     every payee has been dismissed off this page;
+ *   searched   the payees are right there and the query is over them.
+ *
+ * Every payee below is invented: this repo is public.
+ */
+
+import { describe, it, expect, vi, afterEach, beforeEach } from 'vitest';
+import { render, screen, fireEvent, cleanup, within } from '@testing-library/react';
+import PayeeCleanup from './PayeeCleanup';
+import { __setAppContextValue, __resetAppContextValue } from '../../test/mocks/AppContextSupabase';
+import { payeeHiddenDismissalKey } from '../../utils/suggestionDismissals';
+import type { SuggestionDismissal, Transaction } from '../../types';
+
+const toast = vi.hoisted(() => ({
+  showToast: vi.fn(), showSuccess: vi.fn(), showError: vi.fn(),
+  showWarning: vi.fn(), showInfo: vi.fn(), dismissToast: vi.fn(),
+}));
+
+vi.mock('../../contexts/ToastContext', () => ({ useToast: () => toast }));
+
+vi.mock('../../hooks/useCurrencyDecimal', () => ({
+  useCurrencyDecimal: () => ({
+    formatCurrency: (amount: number) => `£${Math.abs(amount).toFixed(2)}`,
+    displayCurrency: 'GBP',
+    getCurrencySymbol: () => '£',
+    convert: vi.fn(), convertAndFormat: vi.fn(), convertAndSum: vi.fn(),
+  }),
+}));
+
+const txn = (over: Partial<Transaction> & { id: string; description: string }): Transaction => ({
+  date: new Date('2026-03-01'),
+  amount: -10,
+  category: 'cat-1',
+  accountId: 'acc-1',
+  type: 'expense',
+  ...over,
+});
+
+const BOOTS = 'BOOTS';
+const TESCO = 'TESCO STORES 3411';
+const REGISTER: Transaction[] = [
+  txn({ id: 't1', description: BOOTS }),
+  txn({ id: 't2', description: TESCO }),
+];
+
+const dismissal = (subjectKey: string): SuggestionDismissal => ({
+  id: `d-${subjectKey}`, kind: 'payee-hidden', subjectKey, subjectIds: [],
+  dismissedAt: new Date('2026-06-01'),
+});
+
+const searchFor = (term: string): void => {
+  fireEvent.change(screen.getByLabelText('Search payees'), { target: { value: term } });
+};
+
+beforeEach(() => {
+  toast.showSuccess.mockClear();
+  toast.showError.mockClear();
+});
+
+afterEach(() => {
+  cleanup();
+  __resetAppContextValue();
+});
+
+describe('payee cleanup with no payees at all', () => {
+  it('says what is absent and what would put something here', () => {
+    __setAppContextValue({ transactions: [] });
+    render(<PayeeCleanup />);
+
+    expect(screen.getByRole('heading', { level: 3, name: 'No payees to tidy yet' })).toBeInTheDocument();
+    // The consequence, and where payees actually come from — this screen
+    // gathers them, it does not create them.
+    expect(screen.getByText(/nothing here to merge or rename/)).toBeInTheDocument();
+    // No fabricated remedy: nothing on THIS page makes a payee.
+    expect(screen.queryByRole('button', { name: 'Clear filters' })).not.toBeInTheDocument();
+  });
+});
+
+describe('payee cleanup emptied by the search is not payee cleanup with nothing in it', () => {
+  it('names how many payees are hidden and the query hiding them', () => {
+    __setAppContextValue({ transactions: REGISTER });
+    render(<PayeeCleanup />);
+
+    searchFor('quenchless');
+
+    expect(
+      screen.getByRole('heading', { level: 3, name: 'No payees match your search' })
+    ).toBeInTheDocument();
+    // THE COUNT IS THE POINT: both payees still exist.
+    expect(screen.getByText(/payees are hidden by/)).toBeInTheDocument();
+    expect(screen.getByText('Search: quenchless')).toBeInTheDocument();
+  });
+
+  it('is distinguishable from the empty screen by every word that matters', () => {
+    __setAppContextValue({ transactions: REGISTER });
+    render(<PayeeCleanup />);
+
+    searchFor('quenchless');
+
+    expect(screen.queryByRole('heading', { name: 'No payees to tidy yet' })).not.toBeInTheDocument();
+    expect(screen.queryByText(/nothing here to merge or rename/)).not.toBeInTheDocument();
+  });
+
+  it('offers one control that gives them back, and it gives them back', () => {
+    __setAppContextValue({ transactions: REGISTER });
+    render(<PayeeCleanup />);
+
+    searchFor('quenchless');
+    fireEvent.click(screen.getByRole('button', { name: 'Clear filters' }));
+
+    expect(screen.queryByRole('heading', { name: 'No payees match your search' })).not.toBeInTheDocument();
+    expect(screen.getByLabelText('Search payees')).toHaveValue('');
+    expect(screen.getByLabelText(`Select ${BOOTS}`)).toBeInTheDocument();
+  });
+});
+
+describe('payee cleanup with every payee dismissed off the page', () => {
+  it('is its own state: the payees exist, they are simply not here', () => {
+    __setAppContextValue({
+      transactions: REGISTER,
+      suggestionDismissals: [
+        dismissal(payeeHiddenDismissalKey(BOOTS)),
+        dismissal(payeeHiddenDismissalKey(TESCO)),
+      ],
+    });
+    render(<PayeeCleanup />);
+
+    const heading = screen.getByRole('heading', { level: 3, name: 'Every payee is hidden' });
+    // The count, because "hidden" without a number is still indistinguishable
+    // from "lost" — and the place the individual undo lives. Scoped to the
+    // state itself: the toolbar above prints its own "2 hidden" tally, and an
+    // unscoped match would pass on that one without this state saying anything.
+    const emptyState = heading.parentElement as HTMLElement;
+    expect(within(emptyState).getByText('2')).toBeInTheDocument();
+    expect(within(emptyState).getByText(/still on your transactions/)).toBeInTheDocument();
+    // Not the first-run sentence, which would claim there is nothing to tidy.
+    expect(screen.queryByRole('heading', { name: 'No payees to tidy yet' })).not.toBeInTheDocument();
+  });
+});

--- a/src/pages/settings/PayeeCleanup.tsx
+++ b/src/pages/settings/PayeeCleanup.tsx
@@ -4,6 +4,8 @@ import { useToast } from '../../contexts/ToastContext';
 import { useCurrencyDecimal } from '../../hooks/useCurrencyDecimal';
 import PageWrapper from '../../components/PageWrapper';
 import { VirtualizedTable, type Column } from '../../components/VirtualizedTable';
+import EmptyState from '../../components/EmptyState';
+import FilteredEmptyState from '../../components/FilteredEmptyState';
 import RenamePayeesModal from '../../components/RenamePayeesModal';
 import DismissSuggestionPrompt from '../../components/sweeps/DismissSuggestionPrompt';
 import DismissedPayeeSuggestions from '../../components/DismissedPayeeSuggestions';
@@ -1010,12 +1012,49 @@ export default function PayeeCleanup(): React.JSX.Element {
             rowClassName={(payee: PayeeSummary) =>
               selected.has(payee.description) ? 'bg-blue-50 dark:bg-blue-900/30' : ''
             }
-            emptyMessage={
-              everyPayee.length === 0
-                ? 'No transactions yet, so there are no payees to tidy.'
-                : payees.length === 0
-                  ? 'Every payee is hidden. Bring one back from “Dismissed suggestions” below.'
-                  : 'No payee matches that search.'
+            // Three different nothings, and they are not interchangeable
+            // (DESIGN_PASS §4): a ledger with no payees in it yet, a list whose
+            // payees have all been put away, and a search that matched none of
+            // the payees sitting right there.
+            emptyContent={
+              everyPayee.length === 0 ? (
+                <EmptyState
+                  // No remedy control, for the same reason the audit trail has
+                  // none: this page does not CREATE payees, it tidies the ones
+                  // your transactions already carry. The button that fixes this
+                  // is on another screen entirely, and a page that grew a
+                  // router dependency to point at it would be decorating the
+                  // sentence rather than shortening the trip.
+                  title="No payees to tidy yet"
+                  description="Payees are the descriptions on your transactions, gathered up and counted. Until something lands in an account there is nothing here to merge or rename."
+                />
+              ) : payees.length === 0 ? (
+                <EmptyState
+                  // Not a FilteredEmptyState: there is no ONE control that
+                  // undoes this. Dismissals are let go of individually, in the
+                  // "Dismissed suggestions" section already on this page, so
+                  // the count is what this state owes the user — a [Clear] that
+                  // restored everything would be a bulk action invented for the
+                  // sake of a button.
+                  title="Every payee is hidden"
+                  description={
+                    <>
+                      <span className="font-medium text-gray-900 dark:text-gray-100 tabular-nums">
+                        {everyPayee.length.toLocaleString()}
+                      </span>
+                      {` ${everyPayee.length === 1 ? 'payee is' : 'payees are'} still on your transactions — they are just off this page. Bring one back from “Dismissed suggestions” below.`}
+                    </>
+                  }
+                />
+              ) : (
+                <FilteredEmptyState
+                  title="No payees match your search"
+                  hiddenCount={payees.length}
+                  scope="payees"
+                  filters={[`Search: ${query.trim()}`]}
+                  onClear={() => setQuery('')}
+                />
+              )
             }
           />
         </div>


### PR DESCRIPTION
The final approved item of the design programme: §4's empty/loading/filtered-empty patterns wired into all seven remaining surfaces (Accounts, Dashboard, Find, the phone list, AuditLogs, PayeeCleanup, plus the shared components' small honest extensions).

**The gate check, per Claude Design's explicit instruction:** every surface carries a test pair proving true-empty and filtered-empty are distinguishable by their words — asserting the other state's heading and control are *absent*, not just present-elsewhere. Seven surfaces, seven pairs, four new test files.

Notable calls, all reported by the implementing agent and verified:
- **Two principled refusals**: AuditLogs and PayeeCleanup get no remedy button on true-empty — those pages gather rows; a control there would fabricate evidence.
- **Skeleton heights measured, not computed**: the browser corrected two wrong assumptions (98px vs 88, 120px vs 76) — the exact layout shift §4 exists to prevent.
- **The dashboard had no loading branch at all** — it asserted "No accounts added yet" during every cold boot. Now it waits its 200ms.
- **"Show all accounts", not "Clear filters"** on the dashboard — the hider there is a selection, and the believed-state must not name a control the surface lacks (`clearLabel` prop, orchestrator's call on the agent's flagged question).

Verification: lint clean · typecheck:strict clean · smoke **6,002** · realtime 240 · desktop:verify PASS (+3.3 KiB against the freshly honest baseline).

🤖 Generated with [Claude Code](https://claude.com/claude-code)