### PR TITLE
feat(dashboard): the period pin (design-endorsed) + the closing-balance reword + canvas leaves

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -71,7 +71,6 @@
         "@vitest/ui": "^3.2.4",
         "autoprefixer": "^10.4.17",
         "c8": "^10.1.3",
-        "canvas": "^3.1.2",
         "compression": "^1.8.1",
         "concurrently": "^10.0.3",
         "eslint": "^9.30.1",
@@ -7286,21 +7285,6 @@
       ],
       "license": "CC-BY-4.0"
     },
-    "node_modules/canvas": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/canvas/-/canvas-3.2.0.tgz",
-      "integrity": "sha512-jk0GxrLtUEmW/TmFsk2WghvgHe8B0pxGilqCL21y8lHkPUGa6FTsnCNtHPOzT8O3y+N+m3espawV80bbBlgfTA==",
-      "dev": true,
-      "hasInstallScript": true,
-      "license": "MIT",
-      "dependencies": {
-        "node-addon-api": "^7.0.0",
-        "prebuild-install": "^7.1.3"
-      },
-      "engines": {
-        "node": "^18.12.0 || >= 20.9.0"
-      }
-    },
     "node_modules/canvg": {
       "version": "3.0.11",
       "resolved": "https://registry.npmjs.org/canvg/-/canvg-3.0.11.tgz",
@@ -7428,7 +7412,9 @@
       "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
       "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
       "dev": true,
-      "license": "ISC"
+      "license": "ISC",
+      "optional": true,
+      "peer": true
     },
     "node_modules/chrome-launcher": {
       "version": "0.13.4",
@@ -8276,6 +8262,8 @@
       "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "mimic-response": "^3.1.0"
       },
@@ -8302,6 +8290,8 @@
       "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=4.0.0"
       }
@@ -9550,6 +9540,8 @@
       "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==",
       "dev": true,
       "license": "(MIT OR WTFPL)",
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=6"
       }
@@ -10025,7 +10017,9 @@
       "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
       "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true,
+      "peer": true
     },
     "node_modules/fs-extra": {
       "version": "11.1.0",
@@ -10215,7 +10209,9 @@
       "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
       "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true,
+      "peer": true
     },
     "node_modules/glob": {
       "version": "11.1.0",
@@ -12260,6 +12256,8 @@
       "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -12348,7 +12346,9 @@
       "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
       "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true,
+      "peer": true
     },
     "node_modules/module-details-from-path": {
       "version": "1.0.4",
@@ -12440,7 +12440,9 @@
       "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-2.0.0.tgz",
       "integrity": "sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true,
+      "peer": true
     },
     "node_modules/natural-compare": {
       "version": "1.4.0",
@@ -12475,6 +12477,8 @@
       "integrity": "sha512-Pr/5KdBQGG8TirdkS0qN3B+f3eo8zTOfZQWAxHoJqopMz2/uvRnG+S4fWu/6AZxKei2CP2p/psdQ5HFC2Ap5BA==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "semver": "^7.3.5"
       },
@@ -12488,6 +12492,8 @@
       "integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
       "dev": true,
       "license": "ISC",
+      "optional": true,
+      "peer": true,
       "bin": {
         "semver": "bin/semver.js"
       },
@@ -12500,7 +12506,9 @@
       "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.1.tgz",
       "integrity": "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true,
+      "peer": true
     },
     "node_modules/node-fetch": {
       "version": "2.6.13",
@@ -13310,6 +13318,8 @@
       "integrity": "sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "detect-libc": "^2.0.0",
         "expand-template": "^2.0.3",
@@ -13639,6 +13649,8 @@
       "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
       "dev": true,
       "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "deep-extend": "^0.6.0",
         "ini": "~1.3.0",
@@ -13654,7 +13666,9 @@
       "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
       "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
       "dev": true,
-      "license": "ISC"
+      "license": "ISC",
+      "optional": true,
+      "peer": true
     },
     "node_modules/rc/node_modules/strip-json-comments": {
       "version": "2.0.1",
@@ -13662,6 +13676,8 @@
       "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -14674,7 +14690,9 @@
           "url": "https://feross.org/support"
         }
       ],
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true,
+      "peer": true
     },
     "node_modules/simple-get": {
       "version": "4.0.1",
@@ -14696,6 +14714,8 @@
         }
       ],
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "decompress-response": "^6.0.0",
         "once": "^1.3.1",
@@ -15353,6 +15373,8 @@
       "integrity": "sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "chownr": "^1.1.1",
         "mkdirp-classic": "^0.5.2",
@@ -15373,6 +15395,8 @@
       "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "bl": "^4.0.3",
         "end-of-stream": "^1.4.1",
@@ -15390,6 +15414,8 @@
       "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "buffer": "^5.5.0",
         "inherits": "^2.0.4",
@@ -15416,6 +15442,8 @@
         }
       ],
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "base64-js": "^1.3.1",
         "ieee754": "^1.1.13"
@@ -15427,6 +15455,8 @@
       "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "inherits": "^2.0.3",
         "string_decoder": "^1.1.1",
@@ -16143,6 +16173,8 @@
       "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
       "dev": true,
       "license": "Apache-2.0",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "safe-buffer": "^5.0.1"
       },

--- a/package.json
+++ b/package.json
@@ -156,7 +156,6 @@
     "@vitest/ui": "^3.2.4",
     "autoprefixer": "^10.4.17",
     "c8": "^10.1.3",
-    "canvas": "^3.1.2",
     "compression": "^1.8.1",
     "concurrently": "^10.0.3",
     "eslint": "^9.30.1",

--- a/src/components/dashboard/ImprovedDashboard.periodPin.test.tsx
+++ b/src/components/dashboard/ImprovedDashboard.periodPin.test.tsx
@@ -1,0 +1,287 @@
+/**
+ * THE DASHBOARD'S ONE CLOCK, AND ITS ONE STATED EXCEPTION.
+ *
+ * ImprovedDashboard.test.tsx holds the rule: one period control under the
+ * heading, everything below it obeying, the storage key unmoved. Every one of
+ * those assertions still passes untouched, and this file is deliberately
+ * separate so that stays visible in a diff.
+ *
+ * What is added here is the amendment the owner asked for after living with the
+ * rule: all-time net worth forced all-time income-vs-expenses, and a stock and
+ * a flow are different lenses. So a card may be PINNED to a window of its own —
+ * and because the crime the original ruling was written against was UNDECLARED
+ * scope rather than divergence, a pinned card says so on its face, holds when
+ * the page moves, blinks once to show it held on purpose, and hands itself back
+ * in one tap.
+ *
+ * The Performance card is exercised through the REAL control; the three report
+ * cards stand in for their windows, as they do in the sibling file, so which
+ * card followed and which held is readable. The report cards' own declaration
+ * is pinned where those cards live —
+ * reportWidgets/DashboardReportWidgets.test.tsx.
+ *
+ * Every account name and figure here is invented.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, within } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { ImprovedDashboard } from './ImprovedDashboard';
+import { preferences } from '../../services/preferencesService';
+import type { Account, Transaction } from '../../types';
+import type { BankConnection } from '../../services/bankConnectionService';
+import type { PeriodRange, UsePeriodResult } from '../../hooks/usePeriod';
+
+const USER_ID = 'user_testonly_0002';
+
+const mocks = vi.hoisted(() => ({
+  navigate: vi.fn(),
+  app: {
+    accounts: [] as Account[],
+    transactions: [] as Transaction[],
+    transactionSplits: [],
+    budgets: [],
+    categories: [],
+    serverBalances: new Map<string, { balance: number; txnCount: number }>(),
+    isLoading: false,
+  },
+  connections: [] as BankConnection[],
+}));
+
+vi.mock('@clerk/clerk-react', () => ({
+  useAuth: () => ({ userId: USER_ID, isSignedIn: true, getToken: vi.fn(), signOut: vi.fn() }),
+  useUser: () => ({ user: null, isLoaded: true }),
+  useSession: () => ({ session: null }),
+}));
+
+vi.mock('../../contexts/AppContextSupabase', () => ({ useApp: () => mocks.app }));
+
+vi.mock('../../hooks/useCurrencyDecimal', () => ({
+  useCurrencyDecimal: () => ({
+    formatCurrency: (amount: number) => `£${Number(amount).toFixed(2)}`,
+    displayCurrency: 'GBP',
+  }),
+}));
+
+vi.mock('../../hooks/useBankConnectionSnapshot', () => ({
+  useBankConnectionSnapshot: () => mocks.connections,
+}));
+
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual<typeof import('react-router-dom')>('react-router-dom');
+  return {
+    ...actual,
+    useNavigate: () => mocks.navigate,
+    useLocation: () => ({ pathname: '/dashboard', search: '', hash: '', state: null, key: 'test' }),
+  };
+});
+
+/** The window a card was handed, in a form a test can read at a glance. */
+const describeRange = (range: PeriodRange): string =>
+  `${range.from ? range.from.toISOString().slice(0, 10) : 'none'}..${range.to ? range.to.toISOString().slice(0, 10) : 'none'}`;
+
+vi.mock('./reportWidgets/DashboardReportWidgets', () => ({
+  NetWorthWidget: ({ picker }: { picker: UsePeriodResult }) => (
+    <div data-testid="net-worth-widget">{describeRange(picker.range)}</div>
+  ),
+  IncomeExpenseTrendWidget: ({ picker }: { picker: UsePeriodResult }) => (
+    <div data-testid="income-expense-widget">{describeRange(picker.range)}</div>
+  ),
+  ExpenseCategoriesWidget: ({ picker }: { picker: UsePeriodResult }) => (
+    <div data-testid="expense-categories-widget">{describeRange(picker.range)}</div>
+  ),
+  CustomReportWidget: () => <div data-testid="custom-report-widget" />,
+}));
+
+vi.mock('../charts/DashboardCharts', () => ({
+  ResponsiveContainer: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  PieChart: () => <div data-testid="pie-chart" />,
+  BarChart: () => <div data-testid="bar-chart" />,
+}));
+
+vi.mock('../EditTransactionModal', () => ({ default: () => null }));
+vi.mock('../IncomeExpenseBreakdownModal', () => ({ default: () => null }));
+vi.mock('../common/Modal', () => ({
+  Modal: ({ isOpen, children }: { isOpen: boolean; children: ReactNode }) =>
+    isOpen ? <div role="dialog">{children}</div> : null,
+  ModalBody: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+}));
+vi.mock('../../services/customReportService', () => ({
+  customReportService: { getCustomReports: () => [] },
+}));
+
+const account = (over: Partial<Account> & { id: string; name: string }): Account => ({
+  type: 'current',
+  balance: 0,
+  currency: 'GBP',
+  lastUpdated: new Date('2026-05-01T00:00:00.000Z'),
+  ...over,
+});
+
+beforeEach(() => {
+  localStorage.clear();
+  // The preferences service is a module singleton and holds its document in
+  // memory, so clearing the browser mirror alone would leave one test's pin
+  // visible to the next. `detach` is the app's own "forget whose settings these
+  // are" and is exactly the reset wanted here.
+  preferences.detach();
+  mocks.navigate.mockReset();
+  mocks.app.accounts = [account({ id: 'acc-a', name: 'Feed Account A', openingBalance: 100 })];
+  mocks.app.transactions = [];
+  mocks.app.isLoading = false;
+  mocks.connections = [];
+  localStorage.setItem('dashboardPinnedReports', JSON.stringify(['net-worth', 'expense-categories']));
+});
+
+const periodBar = (): HTMLElement => screen.getByRole('group', { name: 'Period for this dashboard' });
+const performanceCard = (): HTMLElement => screen.getByRole('region', { name: 'Performance' });
+
+/** Pin the Performance card through the control a user would actually use. */
+const pinPerformanceTo = (label: string): void => {
+  fireEvent.click(within(performanceCard()).getByRole('button', {
+    name: 'Performance: period follows the page. Pin this card to its own period',
+  }));
+  const menu = screen.getByRole('menu', { name: 'Window for Performance' });
+  fireEvent.click(within(menu).getByRole('menuitemradio', { name: label }));
+};
+
+describe('a card that has not been pinned', () => {
+  it('shows no declaration and no new chrome — it is the page’s card', () => {
+    render(<ImprovedDashboard />);
+
+    // The whole point of P1: at rest an obedient card says nothing a page-level
+    // bar is not already saying for it.
+    expect(screen.queryByText(/^pinned ·/)).toBeNull();
+    expect(screen.queryByRole('button', { name: /follow the page period/ })).toBeNull();
+    // The window it is on is still named, exactly as before.
+    expect(within(performanceCard()).getByText('12 months')).toBeInTheDocument();
+  });
+
+  it('writes nothing, so a dashboard with no pins is the dashboard it always was', () => {
+    render(<ImprovedDashboard />);
+
+    fireEvent.click(within(periodBar()).getByRole('button', { name: 'All time' }));
+
+    expect(localStorage.getItem('dashboardReports')).toBe('all');
+    expect(localStorage.getItem('dashboardReports.pin.performancePinned')).toBeNull();
+    expect(localStorage.getItem('dashboardReports.pin.net-worthPinned')).toBeNull();
+    expect(localStorage.getItem('dashboardReports.pin.income-expense-trendPinned')).toBeNull();
+    expect(localStorage.getItem('dashboardReports.pin.expense-categoriesPinned')).toBeNull();
+  });
+});
+
+describe('pinning a card to a window of its own', () => {
+  it('declares the divergence in words, and drops the bare window name', () => {
+    render(<ImprovedDashboard />);
+
+    pinPerformanceTo('All time');
+
+    // The declaration, in the label voice and in the card's resting state —
+    // a scope you have to hover to discover is not declared.
+    expect(within(performanceCard()).getByText('pinned · All time')).toBeInTheDocument();
+    // …and it REPLACES the plain window name rather than sitting beside it:
+    // the same words in the same place would no longer mean the same thing.
+    expect(within(performanceCard()).queryByText('All time')).toBeNull();
+  });
+
+  it('holds when the page clock moves, while its unpinned siblings follow', () => {
+    render(<ImprovedDashboard />);
+    pinPerformanceTo('All time');
+
+    fireEvent.click(within(periodBar()).getByRole('button', { name: 'Last month' }));
+
+    // The page moved…
+    expect(within(periodBar()).getByRole('button', { name: 'Last month' }))
+      .toHaveAttribute('aria-pressed', 'true');
+    const lastMonth = screen.getByTestId('net-worth-widget').textContent;
+    expect(lastMonth).not.toBe('none..none');
+    expect(screen.getByTestId('expense-categories-widget').textContent).toBe(lastMonth);
+    // …and the pinned card did not, and still says why.
+    expect(within(performanceCard()).getByText('pinned · All time')).toBeInTheDocument();
+  });
+
+  it('never unpins itself because the page moved', () => {
+    render(<ImprovedDashboard />);
+    pinPerformanceTo('Tax year');
+
+    fireEvent.click(within(periodBar()).getByRole('button', { name: 'This month' }));
+    fireEvent.click(within(periodBar()).getByRole('button', { name: 'All time' }));
+
+    expect(within(performanceCard()).getByText('pinned · Tax year')).toBeInTheDocument();
+  });
+
+  /**
+   * A pinned card sitting perfectly still while the whole page moves around it
+   * is, at a glance, indistinguishable from a card that is broken. So the
+   * marker blinks once — quiet, no colour, no movement — and clears itself when
+   * the animation ends.
+   */
+  it('acknowledges the page moving, rather than sitting there', () => {
+    render(<ImprovedDashboard />);
+    pinPerformanceTo('All time');
+
+    const marker = (): HTMLElement => within(performanceCard()).getByText('pinned · All time');
+    expect(marker()).not.toHaveClass('animate-pin-ack');
+
+    fireEvent.click(within(periodBar()).getByRole('button', { name: 'Last month' }));
+
+    expect(marker()).toHaveClass('animate-pin-ack');
+
+    // The element clears it itself, so nothing anywhere needs a timer.
+    fireEvent.animationEnd(marker());
+    expect(marker()).not.toHaveClass('animate-pin-ack');
+  });
+
+  it('pins one card without touching its neighbours', () => {
+    render(<ImprovedDashboard />);
+    pinPerformanceTo('All time');
+
+    // Exactly one declaration on the page, and the page's own bar is unmoved.
+    expect(screen.getAllByText(/^pinned ·/)).toHaveLength(1);
+    expect(within(periodBar()).getByRole('button', { name: '12 months' }))
+      .toHaveAttribute('aria-pressed', 'true');
+  });
+
+  it('survives a remount, because it is how the owner reads his figures', () => {
+    const first = render(<ImprovedDashboard />);
+    pinPerformanceTo('All time');
+    expect(localStorage.getItem('dashboardReports.pin.performance')).toBe('all');
+    expect(localStorage.getItem('dashboardReports.pin.performancePinned')).toBe('true');
+    first.unmount();
+
+    render(<ImprovedDashboard />);
+
+    expect(within(performanceCard()).getByText('pinned · All time')).toBeInTheDocument();
+  });
+});
+
+describe('releasing a card back to the page', () => {
+  it('rejoins the page clock on one tap, and says nothing more', () => {
+    render(<ImprovedDashboard />);
+    pinPerformanceTo('All time');
+    fireEvent.click(within(periodBar()).getByRole('button', { name: 'Last month' }));
+
+    fireEvent.click(within(performanceCard()).getByRole('button', {
+      name: 'Performance: follow the page period',
+    }));
+
+    expect(within(performanceCard()).queryByText(/^pinned ·/)).toBeNull();
+    // Back on the page's window, named the plain way again.
+    expect(within(performanceCard()).getByText('Last month')).toBeInTheDocument();
+  });
+
+  it('forgets the pin, so a remount opens following the page', () => {
+    const first = render(<ImprovedDashboard />);
+    pinPerformanceTo('All time');
+    fireEvent.click(within(performanceCard()).getByRole('button', {
+      name: 'Performance: follow the page period',
+    }));
+    expect(localStorage.getItem('dashboardReports.pin.performancePinned')).toBeNull();
+    expect(localStorage.getItem('dashboardReports.pin.performance')).toBeNull();
+    first.unmount();
+
+    render(<ImprovedDashboard />);
+
+    expect(screen.queryByText(/^pinned ·/)).toBeNull();
+    expect(within(performanceCard()).getByText('12 months')).toBeInTheDocument();
+  });
+});

--- a/src/components/dashboard/ImprovedDashboard.tsx
+++ b/src/components/dashboard/ImprovedDashboard.tsx
@@ -31,6 +31,7 @@ import { Modal, ModalBody } from '../common/Modal';
 import PeriodBar from '../../components/PeriodBar';
 import NetWorthSummary from '../../components/NetWorthSummary';
 import { PERIOD_LABELS, usePeriod } from '../../hooks/usePeriod';
+import { cardPeriodKey, useCardPeriod } from '../../hooks/useCardPeriod';
 import { customReportService } from '../../services/customReportService';
 import {
   NetWorthWidget,
@@ -39,6 +40,7 @@ import {
   CustomReportWidget,
 } from './reportWidgets/DashboardReportWidgets';
 import DashboardWidgetCard from './reportWidgets/DashboardWidgetCard';
+import CardPeriodControl from './reportWidgets/CardPeriodControl';
 import { useReportDrill } from './reportWidgets/useReportDrill';
 import { WIDGET_CHART_HEIGHT } from './reportWidgets/widgetChrome';
 import { BUILT_IN_REPORTS, type PinnableReportId } from './reportWidgets/pinnableReports';
@@ -139,6 +141,33 @@ export function ImprovedDashboard() {
    * moves underneath them.
    */
   const period = usePeriod(DASHBOARD_PERIOD_KEY, 'last-12-months');
+
+  /**
+   * …AND THE FOUR CARDS THAT MAY DECLARE THEMSELVES OUT OF IT.
+   *
+   * The page clock above is still the law, and it is still the default for
+   * every one of these. What changed is that the law now has a stated
+   * exception, because the owner hit the cost of not having one: all-time net
+   * worth forced all-time income-vs-expenses, and a stock and a flow are
+   * different lenses with different natural windows.
+   *
+   * These are the page's period CONSUMERS, and they are all of them. Net worth
+   * summary, account distribution, key balances and the attention list read
+   * today's balances; budget status reads a rolling thirty days on purpose;
+   * a pinned custom report carries its own filters. None of those four can be
+   * pinned, because none of them is being read over the page's window in the
+   * first place — a period control on a card that ignores periods is the same
+   * undeclared scope this whole design is against, pointed the other way.
+   *
+   * An unpinned card is handed `period` ITSELF, not a copy of it, so "follows
+   * the page" needs nothing keeping it true. See hooks/useCardPeriod.
+   */
+  const performanceCard = useCardPeriod(cardPeriodKey(DASHBOARD_PERIOD_KEY, 'performance'), period);
+  const netWorthCard = useCardPeriod(cardPeriodKey(DASHBOARD_PERIOD_KEY, 'net-worth'), period);
+  const trendCard = useCardPeriod(cardPeriodKey(DASHBOARD_PERIOD_KEY, 'income-expense-trend'), period);
+  const categoriesCard = useCardPeriod(cardPeriodKey(DASHBOARD_PERIOD_KEY, 'expense-categories'), period);
+  const performancePeriod = performanceCard.picker;
+
   // The Account Distribution card lives here rather than in
   // DashboardReportWidgets, so it reaches for the same click-through as its
   // neighbours instead of growing a second one that drifts.
@@ -258,7 +287,7 @@ export function ImprovedDashboard() {
   // movement never decides the bucket. The cards and the breakdown modal read
   // these same totals, so both always describe one and the same window.
   const performance = useMemo(() => {
-    const { from, to } = period.range;
+    const { from, to } = performancePeriod.range;
     const flows = computeIncomeExpense(transactions, transactionSplits, categories, {
       from: from ?? undefined,
       to: to ?? undefined,
@@ -269,7 +298,7 @@ export function ImprovedDashboard() {
       incomeRows: flows.incomeRows,
       expenseRows: flows.expenseRows,
     };
-  }, [transactions, transactionSplits, categories, period.range]);
+  }, [transactions, transactionSplits, categories, performancePeriod.range]);
 
   // Generate net worth data for chart - ONLY REAL DATA
   const netWorthData = useMemo(() => {
@@ -425,17 +454,26 @@ export function ImprovedDashboard() {
       {/* Secondary Focus: Performance over the chosen period */}
       <section
         aria-labelledby="performance-heading"
-        className="bg-white dark:bg-gray-800 rounded-xl shadow-sm border border-gray-100 dark:border-gray-700 p-6"
+        className="group/card bg-white dark:bg-gray-800 rounded-xl shadow-sm border border-gray-100 dark:border-gray-700 p-6"
       >
-        {/* No picker of its own: this card reads over the page's period, like
-            everything else below the bar at the top. */}
+        {/* Reads over the page's period like everything else below the bar,
+            until it is pinned — and then it says "pinned · …" instead of the
+            bare window name, because the same words in the same place would no
+            longer be saying the same thing. */}
         <div className="flex flex-wrap items-center gap-3 mb-4">
           <h3 id="performance-heading" className="text-lg font-semibold text-gray-900 dark:text-white">
             Performance
           </h3>
-          <span className="text-body text-gray-500 dark:text-gray-400">
-            {PERIOD_LABELS[period.period]}
-          </span>
+          {!performanceCard.pin.isPinned && (
+            <span className="text-body text-gray-500 dark:text-gray-400">
+              {PERIOD_LABELS[performancePeriod.period]}
+            </span>
+          )}
+          <CardPeriodControl
+            cardLabel="Performance"
+            period={performancePeriod.period}
+            pin={performanceCard.pin}
+          />
         </div>
 
         <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
@@ -504,7 +542,9 @@ export function ImprovedDashboard() {
         <div className={`grid grid-cols-1 gap-6 ${showAssetsColumn && showFlowsColumn ? 'lg:grid-cols-2' : ''}`}>
           {showAssetsColumn && (
             <div className="space-y-4">
-              {assetsReports.map(id => <NetWorthWidget key={id} picker={period} />)}
+              {assetsReports.map(id => (
+                <NetWorthWidget key={id} picker={netWorthCard.picker} pin={netWorthCard.pin} />
+              ))}
 
               {/* Account distribution: a snapshot of TODAY, sitting under a
                   period control it deliberately ignores — so it says so.
@@ -593,8 +633,8 @@ export function ImprovedDashboard() {
             <div className="space-y-4">
               {flowsReports.map(id => (
                 id === 'income-expense-trend'
-                  ? <IncomeExpenseTrendWidget key={id} picker={period} />
-                  : <ExpenseCategoriesWidget key={id} picker={period} />
+                  ? <IncomeExpenseTrendWidget key={id} picker={trendCard.picker} pin={trendCard.pin} />
+                  : <ExpenseCategoriesWidget key={id} picker={categoriesCard.picker} pin={categoriesCard.pin} />
               ))}
             </div>
           )}
@@ -666,7 +706,7 @@ export function ImprovedDashboard() {
       <IncomeExpenseBreakdownModal
         isOpen={breakdownType !== null}
         onClose={() => setBreakdownType(null)}
-        title={`${breakdownType === 'income' ? 'Income' : 'Expenses'} — ${PERIOD_LABELS[period.period]}`}
+        title={`${breakdownType === 'income' ? 'Income' : 'Expenses'} — ${PERIOD_LABELS[performancePeriod.period]}`}
         bucket={breakdownType ?? 'income'}
         rows={breakdownType === 'income' ? performance.incomeRows : performance.expenseRows}
         total={breakdownType === 'income' ? performance.income : performance.expenses}

--- a/src/components/dashboard/reportWidgets/CardPeriodControl.tsx
+++ b/src/components/dashboard/reportWidgets/CardPeriodControl.tsx
@@ -1,0 +1,180 @@
+import React, { useEffect, useId, useRef, useState } from 'react';
+import { CalendarIcon } from '../../icons';
+import { PERIOD_LABELS, type PeriodKey } from '../../../hooks/usePeriod';
+import type { CardPeriodPin } from '../../../hooks/useCardPeriod';
+
+/**
+ * One card's period affordance: the way to pin it to a window of its own, and —
+ * once pinned — the declaration that it has been.
+ *
+ * ── WHAT IS VISIBLE WHEN ────────────────────────────────────────────────────
+ *
+ * AT REST, on an unpinned card, nothing. P1 charges chrome rent, and a card
+ * obeying the page clock has nothing to say that the bar under the heading is
+ * not already saying for the whole page. The trigger fades in on hover or when
+ * focus enters the card — the same idiom the Accounts page's row actions use,
+ * including the `hover:hover` guard that keeps it permanently visible on a
+ * touch screen, where there is no hover to reveal it with.
+ *
+ * PINNED, always: `pinned · All time`, in the label voice, in the same grey as
+ * every other secondary line on the card. NOT amber (P3): a card reading over a
+ * window the user deliberately chose is not a warning, and colouring it as one
+ * would spend the only colour the page has for things that are actually wrong.
+ * Beside it, the release — one tap, named for what it does rather than for
+ * undoing what was done.
+ *
+ * ── WHY THE MENU OFFERS NO CUSTOM RANGE ─────────────────────────────────────
+ *
+ * Five windows, not the bar's six. A custom range is a statement about what the
+ * whole page is being read over and comes with two date fields to say it; a pin
+ * is the narrower claim *"this lens wants a different standard window from that
+ * one"*. Nothing stops the page bar from being set to a custom range — a pinned
+ * card simply cannot be the thing that asks for one.
+ */
+
+/** The windows a card can be pinned to, in the page bar's own order. */
+const PINNABLE_PERIODS: PeriodKey[] = [
+  'this-month',
+  'last-month',
+  'tax-year',
+  'last-12-months',
+  'all',
+];
+
+/**
+ * Hidden until the card is hovered or holds focus. `group/card` is on the card
+ * shell; the `hover:hover` guard is what keeps it visible on a touch screen.
+ */
+const QUIET_AT_REST =
+  'transition-opacity duration-state [@media(hover:hover)]:group-[:not(:hover):not(:focus-within)]/card:opacity-0';
+
+export default function CardPeriodControl({ cardLabel, period, pin }: {
+  /** What this control governs, for anyone who cannot see which card it is on. */
+  cardLabel: string;
+  /** The window the card is on right now — the page's, or its own. */
+  period: PeriodKey;
+  pin: CardPeriodPin;
+}): React.JSX.Element {
+  const [open, setOpen] = useState(false);
+  const containerRef = useRef<HTMLDivElement>(null);
+  const triggerRef = useRef<HTMLButtonElement>(null);
+  const firstItemRef = useRef<HTMLButtonElement>(null);
+  const menuId = `${useId()}-card-period`;
+
+  // Clicking anywhere else dismisses — mousedown, so the click that opens
+  // another control is not swallowed by this menu closing first.
+  useEffect(() => {
+    if (!open) return;
+    const handleClickOutside = (event: MouseEvent): void => {
+      if (!containerRef.current?.contains(event.target as Node)) setOpen(false);
+    };
+    document.addEventListener('mousedown', handleClickOutside);
+    return () => document.removeEventListener('mousedown', handleClickOutside);
+  }, [open]);
+
+  // Opening puts the keyboard on the first window, so the list is reachable
+  // without tabbing back through the trigger.
+  useEffect(() => {
+    if (open) firstItemRef.current?.focus();
+  }, [open]);
+
+  const close = (): void => {
+    setOpen(false);
+    triggerRef.current?.focus();
+  };
+
+  const choose = (key: PeriodKey): void => {
+    pin.pinTo(key);
+    close();
+  };
+
+  return (
+    <div
+      ref={containerRef}
+      className={`relative ml-auto flex shrink-0 items-center gap-1.5 ${
+        pin.isPinned || open ? '' : QUIET_AT_REST
+      }`}
+      onKeyDown={(event) => {
+        if (event.key === 'Escape' && open) {
+          event.stopPropagation();
+          close();
+        }
+      }}
+      onBlur={(event) => {
+        // Tabbing out dismisses; a click on the menu's own padding blurs to
+        // nothing at all, and must NOT.
+        const next = event.relatedTarget;
+        if (next instanceof Node && !containerRef.current?.contains(next)) setOpen(false);
+      }}
+    >
+      <button
+        ref={triggerRef}
+        type="button"
+        onClick={() => setOpen(!open)}
+        aria-haspopup="menu"
+        aria-expanded={open}
+        aria-controls={open ? menuId : undefined}
+        // The visible text is the DECLARATION, which is a statement rather than
+        // an instruction, so the control still has to say what it is for.
+        aria-label={pin.isPinned
+          ? `${cardLabel}: pinned to ${PERIOD_LABELS[period]}. Choose a different period for this card`
+          : `${cardLabel}: period follows the page. Pin this card to its own period`}
+        className="flex items-center rounded px-1.5 py-0.5 text-gray-500 hover:bg-gray-50 hover:text-gray-700 dark:text-gray-400 dark:hover:bg-gray-700/50 dark:hover:text-gray-200 transition-colors duration-state focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
+      >
+        {pin.isPinned ? (
+          <span
+            aria-hidden="true"
+            data-pin-marker
+            // The blink that says "the page moved and I did not" — see
+            // hooks/useCardPeriod's `justHeld`. The element clears it itself
+            // when the animation ends, so nothing here needs a timer.
+            className={`text-label whitespace-nowrap ${pin.justHeld ? 'animate-pin-ack' : ''}`}
+            onAnimationEnd={pin.onHeldShown}
+          >
+            pinned · {PERIOD_LABELS[period]}
+          </span>
+        ) : (
+          <CalendarIcon size={14} aria-hidden="true" />
+        )}
+      </button>
+
+      {pin.isPinned && (
+        <button
+          type="button"
+          onClick={pin.follow}
+          aria-label={`${cardLabel}: follow the page period`}
+          className="rounded px-1.5 py-0.5 text-label whitespace-nowrap text-gray-500 hover:bg-gray-50 hover:text-gray-700 dark:text-gray-400 dark:hover:bg-gray-700/50 dark:hover:text-gray-200 transition-colors duration-state focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
+        >
+          Follow page
+        </button>
+      )}
+
+      {open && (
+        <div
+          id={menuId}
+          role="menu"
+          aria-label={`Window for ${cardLabel}`}
+          className="absolute right-0 top-full z-30 mt-1 min-w-[9.5rem] rounded border border-line dark:border-gray-700 bg-white dark:bg-gray-800 py-1 shadow-overlay"
+        >
+          {PINNABLE_PERIODS.map((key, index) => (
+            <button
+              key={key}
+              ref={index === 0 ? firstItemRef : undefined}
+              type="button"
+              role="menuitemradio"
+              aria-checked={pin.isPinned && period === key}
+              onClick={() => choose(key)}
+              className={`flex w-full items-center px-3 py-1.5 text-left text-body transition-colors duration-state hover:bg-surface-secondary dark:hover:bg-gray-700 focus:outline-none focus-visible:bg-surface-secondary dark:focus-visible:bg-gray-700 ${
+                pin.isPinned && period === key
+                  ? 'font-medium text-gray-900 dark:text-white'
+                  : 'text-gray-600 dark:text-gray-300'
+              }`}
+            >
+              {PERIOD_LABELS[key]}
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/dashboard/reportWidgets/DashboardReportWidgets.test.tsx
+++ b/src/components/dashboard/reportWidgets/DashboardReportWidgets.test.tsx
@@ -12,9 +12,10 @@
  */
 import React from 'react';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen, fireEvent, within } from '@testing-library/react';
 import type { Category, Transaction } from '../../../types';
 import { resolvePeriod, type PeriodKey, type UsePeriodResult } from '../../../hooks/usePeriod';
+import type { CardPeriodPin } from '../../../hooks/useCardPeriod';
 
 const mocks = vi.hoisted(() => ({
   navigate: vi.fn(),
@@ -146,5 +147,111 @@ describe('a point on a report card', () => {
       '/reports/spending-by-category?period=this-month',
       FROM_DASHBOARD
     );
+  });
+});
+
+/**
+ * A card pinned to a window of its own has to SAY SO.
+ *
+ * The page-level bar is still the law and still the default (the sibling ruling
+ * in ImprovedDashboard.test.tsx). What the owner asked for after living with it
+ * is an exception a card can declare: all-time net worth was forcing all-time
+ * income-vs-expenses, and a stock and a flow are different lenses. The crime
+ * being prevented was never divergence — it was undeclared scope. So the
+ * divergence is spelled out, in the card's resting state, where the figures it
+ * changes are.
+ *
+ * `pin` carries no window of its own on purpose: the card's chart, its
+ * click-through and its declaration all read the one `picker`, so they cannot
+ * come to disagree about which window this card is on.
+ */
+const following = (): CardPeriodPin => ({
+  isPinned: false,
+  pinTo: vi.fn(),
+  follow: vi.fn(),
+  justHeld: false,
+  onHeldShown: vi.fn(),
+});
+
+const pinned = (over: Partial<CardPeriodPin> = {}): CardPeriodPin => ({
+  ...following(),
+  isPinned: true,
+  ...over,
+});
+
+describe('a report card’s period pin', () => {
+  it('says nothing at all while the card follows the page', () => {
+    render(<NetWorthWidget picker={pickerOn('last-12-months')} pin={following()} />);
+
+    expect(screen.queryByText(/^pinned ·/)).toBeNull();
+    expect(screen.queryByRole('button', { name: /follow the page period/ })).toBeNull();
+    // The way to pin it is there — quiet, and named for anyone who cannot see
+    // which card it sits on.
+    expect(screen.getByRole('button', {
+      name: 'Net Worth Over Time: period follows the page. Pin this card to its own period',
+    })).toBeInTheDocument();
+  });
+
+  it('declares the window it was pinned to, and offers the way back', () => {
+    render(<NetWorthWidget picker={pickerOn('all')} pin={pinned()} />);
+
+    expect(screen.getByText('pinned · All time')).toBeInTheDocument();
+    expect(screen.getByRole('button', {
+      name: 'Net Worth Over Time: follow the page period',
+    })).toBeInTheDocument();
+  });
+
+  it('names the card in every window it offers, and marks the one in force', () => {
+    render(<ExpenseCategoriesWidget picker={pickerOn('tax-year')} pin={pinned()} />);
+
+    fireEvent.click(screen.getByRole('button', {
+      name: 'Expense Categories: pinned to Tax year. Choose a different period for this card',
+    }));
+
+    const menu = screen.getByRole('menu', { name: 'Window for Expense Categories' });
+    expect(within(menu).getByRole('menuitemradio', { name: 'Tax year' }))
+      .toHaveAttribute('aria-checked', 'true');
+    // A custom range is a statement about a whole page, and comes with two date
+    // fields to make it. A pin is the narrower claim that this lens wants a
+    // different STANDARD window.
+    expect(within(menu).queryByRole('menuitemradio', { name: 'Custom' })).toBeNull();
+    expect(within(menu).getAllByRole('menuitemradio')).toHaveLength(5);
+  });
+
+  it('pins to the window that was picked, and releases on one tap', () => {
+    const pinTo = vi.fn();
+    const follow = vi.fn();
+    render(<IncomeExpenseTrendWidget picker={pickerOn('this-month')} pin={pinned({ pinTo, follow })} />);
+
+    fireEvent.click(screen.getByRole('button', {
+      name: 'Income vs Expenses: pinned to This month. Choose a different period for this card',
+    }));
+    fireEvent.click(within(screen.getByRole('menu', { name: 'Window for Income vs Expenses' }))
+      .getByRole('menuitemradio', { name: 'All time' }));
+    expect(pinTo).toHaveBeenCalledWith('all');
+
+    fireEvent.click(screen.getByRole('button', {
+      name: 'Income vs Expenses: follow the page period',
+    }));
+    expect(follow).toHaveBeenCalledTimes(1);
+  });
+
+  it('blinks once when the page clock moved under it, then clears itself', () => {
+    const onHeldShown = vi.fn();
+    render(<NetWorthWidget picker={pickerOn('all')} pin={pinned({ justHeld: true, onHeldShown })} />);
+
+    const marker = screen.getByText('pinned · All time');
+    expect(marker).toHaveClass('animate-pin-ack');
+
+    fireEvent.animationEnd(marker);
+    expect(onHeldShown).toHaveBeenCalledTimes(1);
+  });
+
+  /** No `pin`, no affordance: exactly the card these were before pins existed. */
+  it('renders as it always did when it is given no pin at all', () => {
+    render(<NetWorthWidget picker={pickerOn('this-month')} />);
+
+    expect(screen.queryByText(/^pinned ·/)).toBeNull();
+    expect(screen.queryByRole('button', { name: /period follows the page/ })).toBeNull();
   });
 });

--- a/src/components/dashboard/reportWidgets/DashboardReportWidgets.tsx
+++ b/src/components/dashboard/reportWidgets/DashboardReportWidgets.tsx
@@ -20,8 +20,10 @@ import { expandSplitTransactions } from '../../../utils/transactionSplits';
 import { formatDecimal } from '../../../utils/decimal-format';
 import { customReportService } from '../../../services/customReportService';
 import type { UsePeriodResult } from '../../../hooks/usePeriod';
+import type { CardPeriodPin } from '../../../hooks/useCardPeriod';
 import { TrendingUpIcon, PieChartIcon, BarChart3Icon, FileTextIcon } from '../../icons';
 import DashboardWidgetCard from './DashboardWidgetCard';
+import CardPeriodControl from './CardPeriodControl';
 import { WIDGET_CHART_HEIGHT } from './widgetChrome';
 import { useReportDrill } from './useReportDrill';
 
@@ -46,6 +48,18 @@ import { useReportDrill } from './useReportDrill';
  *
  * Every chart area is WIDGET_CHART_HEIGHT and every card wears the same shell,
  * so the four cards in the section are one height rather than four.
+ *
+ * ── `picker` AND `pin` ARE NOT TWO WINDOWS ──────────────────────────────────
+ *
+ * `picker` is the window the card is read over, whether that is the page's or
+ * one this card was pinned to; the Dashboard resolves which before handing it
+ * over (hooks/useCardPeriod). `pin` carries no window at all — only whether
+ * this card has one of its own and the two ways to change that — so the card's
+ * chart, its click-through and its declaration cannot disagree about the
+ * window, because there is only one of them to read.
+ *
+ * `pin` is optional: a card rendered without it is a card with no period
+ * affordance, which is exactly what these three were before the pin existed.
  */
 
 const CATEGORY_COLORS = [
@@ -61,7 +75,12 @@ const compactTick = (value: number): string => {
   return formatDecimal(value, 0);
 };
 
-export function NetWorthWidget({ picker }: { picker: UsePeriodResult }): React.JSX.Element {
+const NET_WORTH_TITLE = 'Net Worth Over Time';
+
+export function NetWorthWidget({ picker, pin }: {
+  picker: UsePeriodResult;
+  pin?: CardPeriodPin;
+}): React.JSX.Element {
   const { accounts, transactions } = useApp();
   const { formatCurrency } = useCurrencyDecimal();
   const openReport = useReportDrill();
@@ -77,12 +96,15 @@ export function NetWorthWidget({ picker }: { picker: UsePeriodResult }): React.J
 
   return (
     <DashboardWidgetCard
-      title="Net Worth Over Time"
+      title={NET_WORTH_TITLE}
       icon={TrendingUpIcon}
       subtitle={
-        <span className="text-xl font-bold text-gray-900 dark:text-white truncate">
-          {latest ? formatCurrency(latest.netWorth) : '—'}
-        </span>
+        <>
+          <span className="min-w-0 text-xl font-bold text-gray-900 dark:text-white truncate">
+            {latest ? formatCurrency(latest.netWorth) : '—'}
+          </span>
+          {pin && <CardPeriodControl cardLabel={NET_WORTH_TITLE} period={picker.period} pin={pin} />}
+        </>
       }
       onOpen={() => open()}
     >
@@ -113,7 +135,12 @@ export function NetWorthWidget({ picker }: { picker: UsePeriodResult }): React.J
   );
 }
 
-export function IncomeExpenseTrendWidget({ picker }: { picker: UsePeriodResult }): React.JSX.Element {
+const INCOME_EXPENSE_TITLE = 'Income vs Expenses';
+
+export function IncomeExpenseTrendWidget({ picker, pin }: {
+  picker: UsePeriodResult;
+  pin?: CardPeriodPin;
+}): React.JSX.Element {
   const { transactions, transactionSplits, categories } = useApp();
   const { formatCurrency } = useCurrencyDecimal();
   const openReport = useReportDrill();
@@ -134,12 +161,15 @@ export function IncomeExpenseTrendWidget({ picker }: { picker: UsePeriodResult }
 
   return (
     <DashboardWidgetCard
-      title="Income vs Expenses"
+      title={INCOME_EXPENSE_TITLE}
       icon={BarChart3Icon}
       subtitle={
-        <span className="text-xs text-gray-500 dark:text-gray-400 truncate">
-          Month by month, what came in against what went out
-        </span>
+        <>
+          <span className="min-w-0 text-xs text-gray-500 dark:text-gray-400 truncate">
+            Month by month, what came in against what went out
+          </span>
+          {pin && <CardPeriodControl cardLabel={INCOME_EXPENSE_TITLE} period={picker.period} pin={pin} />}
+        </>
       }
       onOpen={() => open()}
     >
@@ -172,7 +202,12 @@ export function IncomeExpenseTrendWidget({ picker }: { picker: UsePeriodResult }
   );
 }
 
-export function ExpenseCategoriesWidget({ picker }: { picker: UsePeriodResult }): React.JSX.Element {
+const EXPENSE_CATEGORIES_TITLE = 'Expense Categories';
+
+export function ExpenseCategoriesWidget({ picker, pin }: {
+  picker: UsePeriodResult;
+  pin?: CardPeriodPin;
+}): React.JSX.Element {
   const { transactions, transactionSplits, categories } = useApp();
   const { formatCurrency } = useCurrencyDecimal();
   const openReport = useReportDrill();
@@ -195,12 +230,15 @@ export function ExpenseCategoriesWidget({ picker }: { picker: UsePeriodResult })
 
   return (
     <DashboardWidgetCard
-      title="Expense Categories"
+      title={EXPENSE_CATEGORIES_TITLE}
       icon={PieChartIcon}
       subtitle={
-        <span className="text-xs text-gray-500 dark:text-gray-400 truncate">
-          Where the money went, biggest first
-        </span>
+        <>
+          <span className="min-w-0 text-xs text-gray-500 dark:text-gray-400 truncate">
+            Where the money went, biggest first
+          </span>
+          {pin && <CardPeriodControl cardLabel={EXPENSE_CATEGORIES_TITLE} period={picker.period} pin={pin} />}
+        </>
       }
       onOpen={() => open()}
     >

--- a/src/components/dashboard/reportWidgets/DashboardWidgetCard.tsx
+++ b/src/components/dashboard/reportWidgets/DashboardWidgetCard.tsx
@@ -30,7 +30,11 @@ export default function DashboardWidgetCard({
   children: React.ReactNode;
 }): React.JSX.Element {
   return (
-    <div className="bg-white dark:bg-gray-800 rounded-xl shadow-sm border border-gray-100 dark:border-gray-700 p-4 flex flex-col">
+    // `group/card` is what the card's quiet controls hang off: a period
+    // affordance that is charged rent has to know when the card is hovered or
+    // holds focus (see CardPeriodControl). Named rather than bare, so a nested
+    // group inside a chart legend can never claim it.
+    <div className="group/card bg-white dark:bg-gray-800 rounded-xl shadow-sm border border-gray-100 dark:border-gray-700 p-4 flex flex-col">
       <button
         type="button"
         onClick={onOpen}

--- a/src/components/reconciliation/ReconciliationAccountList.tsx
+++ b/src/components/reconciliation/ReconciliationAccountList.tsx
@@ -194,8 +194,17 @@ export default function ReconciliationAccountList({
                               affordance wears (P7), never amber: on this page
                               amber belongs to the travelling thread alone
                               (P3). */}
+                          {/* "Closing balance", not "bank balance": a link
+                              names its DESTINATION, and the screen it opens
+                              deliberately says Closing Balance — the number
+                              you agree to, not a live feed figure. The column
+                              above stays Bank Balance because it really is
+                              the feed's number; the two names mark two
+                              different figures, and the gap between them is
+                              the Difference column — the thing reconciliation
+                              exists to close. (Design ruling, 2026-08-12.) */}
                           <span className="block text-[11px] font-medium text-primary dark:text-blue-400">
-                            Enter bank balance
+                            Enter closing balance
                           </span>
                         </>
                       )}

--- a/src/components/reconciliation/__tests__/ReconciliationAccountList.test.tsx
+++ b/src/components/reconciliation/__tests__/ReconciliationAccountList.test.tsx
@@ -83,22 +83,22 @@ describe('ReconciliationAccountList — a missing figure names its remedy', () =
     renderList();
     const row = rowFor('Everyday Account');
 
-    expect(within(row).getByText('Enter bank balance')).toBeInTheDocument();
+    expect(within(row).getByText('Enter closing balance')).toBeInTheDocument();
     // Not repeated beside the difference — the row has already said it.
-    expect(within(row).getAllByText('Enter bank balance')).toHaveLength(1);
+    expect(within(row).getAllByText('Enter closing balance')).toHaveLength(1);
   });
 
   it('says nothing about entering a balance on a row that has one', () => {
     renderList();
     const row = rowFor('Second Account');
 
-    expect(within(row).queryByText('Enter bank balance')).not.toBeInTheDocument();
+    expect(within(row).queryByText('Enter closing balance')).not.toBeInTheDocument();
     expect(within(row).getByText('£220.00')).toBeInTheDocument();
   });
 
   it('keeps amber off the remedy — the thread owns amber on this page', () => {
     renderList();
-    const remedy = within(rowFor('Everyday Account')).getByText('Enter bank balance');
+    const remedy = within(rowFor('Everyday Account')).getByText('Enter closing balance');
 
     // P3: one amber in the building, and on this page it belongs to the
     // travelling next action, never to a link that is merely available.

--- a/src/hooks/useCardPeriod.test.ts
+++ b/src/hooks/useCardPeriod.test.ts
@@ -1,0 +1,214 @@
+/**
+ * A dashboard card's period pin: the page clock stays the law, and a card may
+ * declare itself out of it.
+ *
+ * The claims these hold down, in the order they matter:
+ *
+ *  1. a user with NO pins is byte-identical to the build before pins existed —
+ *     nothing read, nothing written, and the card is handed the page's own
+ *     picker rather than a copy that has to be kept in step;
+ *  2. a pinned card holds when the page clock moves, and says so;
+ *  3. releasing it rejoins the page immediately and forgets the pin ever
+ *     happened, keys and all;
+ *  4. a pin survives a remount, because it is a statement about how the owner
+ *     reads his figures rather than about this visit.
+ */
+import { describe, it, expect, beforeEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { usePeriod } from './usePeriod';
+import { cardPeriodKey, useCardPeriod } from './useCardPeriod';
+import { cardPeriodPreferenceKeys, periodPinKey } from '../services/preferencesService';
+
+const PAGE_KEY = 'dashboardReports';
+const CARD_KEY = cardPeriodKey(PAGE_KEY, 'net-worth');
+
+/**
+ * Plain localStorage rather than the preferences document, exactly as
+ * usePeriod's own suite does and for the same reason: what is under test is the
+ * page-versus-card rule, not where the answer is filed. The adapter exists so a
+ * test can hold the store still.
+ */
+const store = localStorage;
+
+/** The real composition: one page clock, one card hanging off it. */
+const renderPageAndCard = () => renderHook(() => {
+  const page = usePeriod(PAGE_KEY, 'last-12-months', store);
+  const card = useCardPeriod(CARD_KEY, page, store);
+  return { page, card };
+});
+
+beforeEach(() => {
+  localStorage.clear();
+});
+
+describe('a card that has not been pinned', () => {
+  it('is handed the page’s picker itself, not a copy of it', () => {
+    const { result } = renderPageAndCard();
+
+    // Identity, deliberately: "follows the page" is not a rule anything has to
+    // keep true — it is the same object.
+    expect(result.current.card.picker).toBe(result.current.page);
+    expect(result.current.card.pin.isPinned).toBe(false);
+  });
+
+  it('reads and writes nothing of its own', () => {
+    renderPageAndCard();
+
+    for (const key of cardPeriodPreferenceKeys(CARD_KEY)) {
+      expect(localStorage.getItem(key)).toBeNull();
+    }
+  });
+
+  it('follows the page clock wherever it goes', () => {
+    const { result } = renderPageAndCard();
+
+    act(() => result.current.page.setPeriod('all'));
+
+    expect(result.current.card.picker.period).toBe('all');
+    expect(result.current.card.picker.range.from).toBeNull();
+    expect(result.current.card.pin.isPinned).toBe(false);
+  });
+
+  /**
+   * THE REGRESSION PIN for everybody who already has a stored dashboard. The
+   * merge that made one clock out of three kept the original key; this keeps
+   * that promise a second time. There is no migration because there is no old
+   * shape — the absence of a pin flag IS "follows the page", which is what
+   * every stored dashboard has always meant.
+   */
+  it('loads a dashboard stored before pins existed, unchanged', () => {
+    localStorage.setItem(PAGE_KEY, 'all');
+    localStorage.setItem(`${PAGE_KEY}Explicit`, 'true');
+
+    const { result } = renderPageAndCard();
+
+    expect(result.current.page.period).toBe('all');
+    expect(result.current.card.picker).toBe(result.current.page);
+    expect(result.current.card.pin.isPinned).toBe(false);
+    // And it did not quietly write itself a pin on the way past.
+    expect(localStorage.getItem(periodPinKey(CARD_KEY))).toBeNull();
+  });
+});
+
+describe('a card pinned to a window of its own', () => {
+  it('diverges from the page the moment it is pinned', () => {
+    const { result } = renderPageAndCard();
+
+    act(() => result.current.card.pin.pinTo('all'));
+
+    expect(result.current.card.pin.isPinned).toBe(true);
+    expect(result.current.card.picker.period).toBe('all');
+    // The page is untouched: pinning a card is not a statement about the page.
+    expect(result.current.page.period).toBe('last-12-months');
+  });
+
+  it('HOLDS when the page clock moves', () => {
+    const { result } = renderPageAndCard();
+    act(() => result.current.card.pin.pinTo('all'));
+
+    act(() => result.current.page.setPeriod('this-month'));
+
+    expect(result.current.page.period).toBe('this-month');
+    expect(result.current.card.picker.period).toBe('all');
+    expect(result.current.card.pin.isPinned).toBe(true);
+  });
+
+  it('acknowledges the page moving, once, and only while pinned', () => {
+    const { result } = renderPageAndCard();
+
+    // Nothing to acknowledge before there is a pin.
+    act(() => result.current.page.setPeriod('this-month'));
+    expect(result.current.card.pin.justHeld).toBe(false);
+
+    act(() => result.current.card.pin.pinTo('all'));
+    // Pinning is not the page moving.
+    expect(result.current.card.pin.justHeld).toBe(false);
+
+    act(() => result.current.page.setPeriod('tax-year'));
+    expect(result.current.card.pin.justHeld).toBe(true);
+
+    // The marker clears it when the blink has played out.
+    act(() => result.current.card.pin.onHeldShown());
+    expect(result.current.card.pin.justHeld).toBe(false);
+  });
+
+  it('remembers the pin, and the window, across a remount', () => {
+    const first = renderPageAndCard();
+    act(() => first.result.current.card.pin.pinTo('all'));
+    first.unmount();
+
+    const second = renderPageAndCard();
+
+    expect(second.result.current.card.pin.isPinned).toBe(true);
+    expect(second.result.current.card.picker.period).toBe('all');
+    // …and the page opened on its own default, untouched by the card.
+    expect(second.result.current.page.period).toBe('last-12-months');
+  });
+
+  it('files itself under the page’s key, beside the page’s own choice', () => {
+    const { result } = renderPageAndCard();
+
+    act(() => result.current.card.pin.pinTo('tax-year'));
+
+    expect(localStorage.getItem('dashboardReports.pin.net-worth')).toBe('tax-year');
+    expect(localStorage.getItem('dashboardReports.pin.net-worthPinned')).toBe('true');
+  });
+});
+
+describe('releasing a card back to the page', () => {
+  it('rejoins the page clock immediately', () => {
+    const { result } = renderPageAndCard();
+    act(() => result.current.card.pin.pinTo('all'));
+    act(() => result.current.page.setPeriod('this-month'));
+
+    act(() => result.current.card.pin.follow());
+
+    expect(result.current.card.pin.isPinned).toBe(false);
+    expect(result.current.card.picker).toBe(result.current.page);
+    expect(result.current.card.picker.period).toBe('this-month');
+  });
+
+  it('forgets it was ever pinned, keys and all', () => {
+    const { result } = renderPageAndCard();
+    act(() => result.current.card.pin.pinTo('all'));
+
+    act(() => result.current.card.pin.follow());
+
+    for (const key of cardPeriodPreferenceKeys(CARD_KEY)) {
+      expect(localStorage.getItem(key)).toBeNull();
+    }
+  });
+
+  it('stays released across a remount', () => {
+    const first = renderPageAndCard();
+    act(() => first.result.current.card.pin.pinTo('all'));
+    act(() => first.result.current.card.pin.follow());
+    first.unmount();
+
+    const second = renderPageAndCard();
+
+    expect(second.result.current.card.pin.isPinned).toBe(false);
+    expect(second.result.current.card.picker).toBe(second.result.current.page);
+  });
+});
+
+describe('two cards on one page', () => {
+  it('pin independently — one holds, the other follows', () => {
+    const { result } = renderHook(() => {
+      const page = usePeriod(PAGE_KEY, 'last-12-months', store);
+      return {
+        page,
+        netWorth: useCardPeriod(cardPeriodKey(PAGE_KEY, 'net-worth'), page, store),
+        flows: useCardPeriod(cardPeriodKey(PAGE_KEY, 'income-expense-trend'), page, store),
+      };
+    });
+
+    act(() => result.current.netWorth.pin.pinTo('all'));
+    act(() => result.current.page.setPeriod('this-month'));
+
+    // The stock keeps forever; the flow follows the page, as it always did.
+    expect(result.current.netWorth.picker.period).toBe('all');
+    expect(result.current.flows.picker.period).toBe('this-month');
+    expect(result.current.flows.pin.isPinned).toBe(false);
+  });
+});

--- a/src/hooks/useCardPeriod.ts
+++ b/src/hooks/useCardPeriod.ts
@@ -1,0 +1,164 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import {
+  cardPeriodPreferenceKeys,
+  periodPinKey,
+  preferences,
+} from '../services/preferencesService';
+import { usePeriod, type PeriodKey, type PeriodStorage, type UsePeriodResult } from './usePeriod';
+
+/**
+ * A dashboard card's period, and whether it is the page's or its own.
+ *
+ * ── WHY A CARD MAY DIVERGE AT ALL ───────────────────────────────────────────
+ *
+ * The page-level clock is the law (DESIGN_RULINGS_2026-08-12 §C's sibling
+ * ruling, and components/PeriodBar's header): one control, under the heading,
+ * governing everything below it, because three identically-styled pickers feet
+ * apart declared nothing about what each covered.
+ *
+ * That ruling stands, and the owner then hit its cost in practice. Net worth is
+ * a STOCK — what you are worth, and its natural window is forever. Income
+ * against expenses is a FLOW — what moved, and its natural window is a period.
+ * Reading the first over all time forced the second over all time too, which is
+ * not a longer answer to the same question, it is a different question nobody
+ * asked. The two cards are different lenses and a single clock made them one.
+ *
+ * So a card may be PINNED to a window of its own — and the crime the original
+ * ruling was written against was never divergence, it was UNDECLARED scope. A
+ * pinned card therefore says so, out loud, permanently, on its own face
+ * ("pinned · All time"), with the release one tap away. An unpinned card is
+ * handed the page's picker itself, so "follows the page" is not a rule this
+ * module keeps — it is the same object.
+ *
+ * ── WHERE THE PIN LIVES ─────────────────────────────────────────────────────
+ *
+ * Nowhere new. A pinned card is an ordinary period surface: `usePeriod` with a
+ * storage key of its own, writing the same four strings it has always written,
+ * through the same preferences document that carries the page's own choice —
+ * so the pin travels with the ACCOUNT, survives a restore, and reaches the
+ * desktop edition without this file naming an edition (services/preferencesService
+ * reaches its store through `@prefs-store`).
+ *
+ * The one addition is a fifth key, the pin flag itself
+ * (services/preferencesService `periodPinKey`). It is what lets a card be
+ * released without inventing a way to un-choose a period, which `usePeriod`
+ * deliberately does not have and which every other surface would have had to
+ * grow a field for.
+ *
+ * ── A USER WITH NO PINS ─────────────────────────────────────────────────────
+ *
+ * Reads three keys that are not there, writes nothing, and is handed the page's
+ * picker unchanged. There is no migration because there is no old shape: the
+ * keys below did not exist before, and their absence is the answer "follows the
+ * page" — which is what every stored dashboard already meant. Pinned in
+ * hooks/__tests__/useCardPeriod.test.ts.
+ */
+
+/** Whether this card has a window of its own, and the two ways to change that. */
+export interface CardPeriodPin {
+  /** True when the card is being read over its own window, not the page's. */
+  isPinned: boolean;
+  /** Pin the card to `key`. Pinning IS choosing, so it persists. */
+  pinTo: (key: PeriodKey) => void;
+  /** Give the card back to the page clock, and forget it was ever pinned. */
+  follow: () => void;
+  /**
+   * True from the moment the PAGE clock moves under a pinned card until the
+   * card has acknowledged it.
+   *
+   * A pinned card holding still while the whole page moves around it is
+   * indistinguishable, at a glance, from a card that is broken. So the marker
+   * blinks once — the user sees the page move AND sees this card deliberately
+   * decline to. An acknowledgement, not an alarm: no colour, no movement, once.
+   */
+  justHeld: boolean;
+  /** Called by the marker when the acknowledgement has played out. */
+  onHeldShown: () => void;
+}
+
+export interface CardPeriod {
+  /**
+   * The window the card is actually read over — the page's picker itself when
+   * unpinned, the card's own when pinned.
+   *
+   * ONE object, deliberately: the window a card DRAWS and the window its
+   * click-through CARRIES have to be the same one, and a second prop saying
+   * nearly the same thing is how those two drift (the rule
+   * ImprovedDashboard.test.tsx already states about `picker`).
+   */
+  picker: UsePeriodResult;
+  pin: CardPeriodPin;
+}
+
+/**
+ * Where one card's pin is filed, derived from the PAGE's key so the relationship
+ * is visible in storage rather than inferred: `dashboardReports.pin.net-worth`
+ * beside `dashboardReports`.
+ */
+export const cardPeriodKey = (pageKey: string, cardId: string): string =>
+  `${pageKey}.pin.${cardId}`;
+
+export function useCardPeriod(
+  storageKey: string,
+  page: UsePeriodResult,
+  storage: PeriodStorage = preferences
+): CardPeriod {
+  /**
+   * The card's own surface. Its `defaultKey` is the page's current window, and
+   * it is never seen: an unpinned card is handed `page` below, and a pin always
+   * arrives through `pinTo` with a window the user just picked. The default
+   * matters only for a hand-edited store that says "pinned" without saying to
+   * what, where following the page is the sane reading.
+   */
+  const own = usePeriod(storageKey, page.period, storage);
+  const { setPeriod: setOwnPeriod } = own;
+
+  const [isPinned, setIsPinned] = useState<boolean>(
+    () => storage.getItem(periodPinKey(storageKey)) === 'true'
+  );
+
+  const pinTo = useCallback((key: PeriodKey): void => {
+    setOwnPeriod(key);
+    storage.setItem(periodPinKey(storageKey), 'true');
+    setIsPinned(true);
+  }, [setOwnPeriod, storage, storageKey]);
+
+  /**
+   * The page window this card last saw.
+   *
+   * `page.range` rather than `page.period`, because editing the bounds of a
+   * custom range moves the page's window without changing its name — and a
+   * pinned card has just as deliberately not followed that. The range object's
+   * identity is memoised on exactly the three things that define the window, so
+   * it changes when the window does and not once more (see usePeriod).
+   */
+  const [justHeld, setJustHeld] = useState(false);
+  const lastPageRange = useRef(page.range);
+
+  useEffect(() => {
+    if (lastPageRange.current === page.range) return;
+    lastPageRange.current = page.range;
+    // Only a card that HELD has anything to acknowledge. An unpinned card
+    // followed, which the figures redrawing already says.
+    if (isPinned) setJustHeld(true);
+  }, [page.range, isPinned]);
+
+  const onHeldShown = useCallback((): void => setJustHeld(false), []);
+
+  const follow = useCallback((): void => {
+    setIsPinned(false);
+    setJustHeld(false);
+    // Every key this card owns, not just the flag: a released card left a
+    // window behind in the document, and a document that grows a line per card
+    // the user has ever experimented with is a document that never shrinks.
+    // `own` keeps its last value in memory and nothing can read it — an
+    // unpinned card is handed `page`, and re-pinning arrives with a window of
+    // its own.
+    for (const key of cardPeriodPreferenceKeys(storageKey)) storage.removeItem(key);
+  }, [storage, storageKey]);
+
+  return {
+    picker: isPinned ? own : page,
+    pin: { isPinned, pinTo, follow, justHeld, onHeldShown },
+  };
+}

--- a/src/services/preferencesService.ts
+++ b/src/services/preferencesService.ts
@@ -97,6 +97,28 @@ export function periodPreferenceKeys(base: string): string[] {
 }
 
 /**
+ * Where a CARD's "this one has a window of its own" flag lives.
+ *
+ * A pinned dashboard card is an ordinary period surface — same four keys, same
+ * hook — plus one bit that says the pin is in force. The bit is separate from
+ * `…Explicit` on purpose: that flag answers *"did the user choose this value, or
+ * did a surface suggest it?"*, and the card needs the different question *"is
+ * this card being read over its own window, or over the page's?"*. Conflating a
+ * value with a state is exactly what `readStoredSelection`'s long note is about.
+ *
+ * The separation is also what makes a user with no pins byte-identical to
+ * today: no flag, no key, nothing read, nothing written.
+ */
+export function periodPinKey(base: string): string {
+  return `${base}Pinned`;
+}
+
+/** Everything one pinnable card can store: the period surface, plus the pin. */
+export function cardPeriodPreferenceKeys(base: string): string[] {
+  return [...periodPreferenceKeys(base), periodPinKey(base)];
+}
+
+/**
  * Every key that travels with the account.
  *
  * This list does TWO jobs, and only the first is load-bearing at runtime:
@@ -122,6 +144,14 @@ export const PORTABLE_PREFERENCE_KEYS: readonly string[] = [
   ...periodPreferenceKeys('dashboardReports'),
   ...periodPreferenceKeys('dashboardReportsFlows'),
   ...periodPreferenceKeys('dashboardPerformance'),
+  // …and the cards that have been PINNED to a window of their own, against the
+  // page's. A statement about how the owner reads HIS figures — an all-time net
+  // worth beside twelve months of flows — so it travels with the account like
+  // every other statement of that kind. See hooks/useCardPeriod.
+  ...cardPeriodPreferenceKeys('dashboardReports.pin.performance'),
+  ...cardPeriodPreferenceKeys('dashboardReports.pin.net-worth'),
+  ...cardPeriodPreferenceKeys('dashboardReports.pin.income-expense-trend'),
+  ...cardPeriodPreferenceKeys('dashboardReports.pin.expense-categories'),
 
   // ── Reports ──────────────────────────────────────────────────────────────
   ...periodPreferenceKeys('reportsPeriod'),

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -127,6 +127,19 @@ export default {
           '0%': { transform: 'translateY(1rem)' },
           '100%': { transform: 'translateY(0)' },
         },
+        // A pinned dashboard card re-stating itself when the PAGE clock moves
+        // (components/dashboard/reportWidgets/CardPeriodControl). One quiet
+        // blink, so a card that deliberately did not follow is SEEN not to have
+        // followed rather than appearing to be stuck.
+        //
+        // Opacity only, on purpose: no colour, because amber is reserved for
+        // things that are actually wrong (P3) and a window the user chose is
+        // not one of them; and no transform, because a marker that moves is a
+        // layout shift charged to every neighbour on the row.
+        'pin-ack': {
+          '0%, 100%': { opacity: '1' },
+          '50%': { opacity: '0.25' },
+        },
       },
       animation: {
         'in': 'fade-in 0.2s ease-out, zoom-in-95 0.2s ease-out, slide-in-from-bottom-4 0.2s ease-out',
@@ -134,6 +147,12 @@ export default {
         // once and then holds still. Named rather than written inline so the
         // 200ms is the same 200ms as the delay that decides to show it.
         'fade-in': 'fade-in 200ms ease-out',
+        // The `enter` duration (200ms), because this is an arrival: the marker
+        // re-states itself rather than changing state. It runs ONCE per move of
+        // the page clock, and the element clears the class on `animationend` —
+        // which still fires under prefers-reduced-motion, where index.css
+        // shortens animations to 0.01ms rather than removing them.
+        'pin-ack': 'pin-ack 200ms ease-out',
       },
     },
   },


### PR DESCRIPTION
Three pieces, two commits, all verified together.

## The pin (owner-approved, design-author-endorsed with three conditions — all met)
- Page clock stays the law and the default; a card pins to its own window and **declares it in its resting state** ("pinned · All time" + one-tap Follow page).
- Pinning is only ever a user act; a user with no pins gets today **byte for byte** (absence IS the default — no migration, regression-pinned three ways; `usePeriod` itself has zero diff and every existing period test passes unedited).
- Condition (c): when the page clock moves, a pinned card blinks its marker once — self-clearing on animationend, no timers, reduced-motion safe.
- Four period-consuming cards got the affordance; period-blind cards deliberately did not.

## The reword (design ruling, answered discriminator)
Reconciliation's remedy now reads **"Enter closing balance"** — a link names its destination. The discriminator came back on the first branch with code evidence: `bank_balance` is the feed's most-recently-reported figure (migration 20260613090000's own words) while Closing Balance is the figure you agree to — two numbers, both names correct, their gap the Difference column.

## canvas leaves (chip task, empirical proof)
Broke CI twice in a day (prebuilt fetch flakes → headerless source builds). With it removed: **6,031 smoke, 240 realtime, full coverage 77.51/82.64 over the 75/80 floors, desktop:verify green.** Every `getContext` site in src is null-checked browser-runtime code. Lockfile needed direct surgery (optional peers are kept forever by `npm uninstall` alone); `npm ci` reproduces the tree without it. Kills the flake class permanently.

Desktop ratchet: 4081.3 KiB raw vs the honest 4070.0 baseline (+11.3, the pin's measured cost), budget 4320.

🤖 Generated with [Claude Code](https://claude.com/claude-code)