### PR TITLE
fix: the five bugs one evening of real use found

### DIFF
--- a/src/components/AccountRowColumns.tsx
+++ b/src/components/AccountRowColumns.tsx
@@ -61,9 +61,27 @@ export const ACCOUNT_ROW_COLUMNS_CLASS =
  * `font-weight: 600` would embolden every word on the card rather than mark it.
  * What is left — colour, ring, lift — is the part that means "this one", and it
  * is what is copied here.
+ *
+ * ─ WHY `border-transparent` IS IN A LIST OF SELECTION COLOURS ───────────────
+ * Because a row wears a 1px `border` at every moment of its life — the width is
+ * geometry, held constant so a card cannot jump 1px as it is picked out — and a
+ * border with no colour of its own does not stay invisible. Tailwind's preflight
+ * gives every element `border-color: #e5e7eb`, so a selected row that named no
+ * colour drew that near-white hairline on three sides while the fourth kept the
+ * list's divider (#e2e6ed light, gray-700 dark) — a second and third tone packed
+ * against the ring, which is the "two colours in the border" the owner saw. It
+ * is worst in dark mode, where #e5e7eb is a light-mode grey sitting on a dark
+ * card. Naming the colour transparent here leaves the ring as the only stroke
+ * the row draws, uniform on all four sides.
+ *
+ * This is a state's OWN colour rather than a fight with the base class: the row
+ * that is NOT selected names `border-transparent border-b-line …` for itself
+ * (see Accounts.tsx). Neither state has to outrank the other in a cascade whose
+ * order between `border-*`, `border-b-*`, `last:` and `dark:` is Tailwind's to
+ * decide and not ours to depend on.
  */
 export const ACCOUNT_ROW_SELECTED_CLASS =
-  'relative z-10 bg-blue-50/80 dark:bg-blue-900/30 ' +
+  'relative z-10 bg-blue-50/80 dark:bg-blue-900/30 border-transparent ' +
   'ring-1 ring-[#6B86B3]/50 dark:ring-[#6B86B3]/70 ' +
   'shadow-[0_4px_6px_-1px_rgba(0,0,0,0.1),0_10px_15px_-3px_rgba(0,0,0,0.1)] ' +
   'dark:shadow-[0_4px_6px_-1px_rgba(0,0,0,0.3),0_10px_15px_-3px_rgba(0,0,0,0.3)]';

--- a/src/components/dashboard/reportWidgets/DashboardReportWidgets.test.tsx
+++ b/src/components/dashboard/reportWidgets/DashboardReportWidgets.test.tsx
@@ -14,8 +14,9 @@ import React from 'react';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, fireEvent, within } from '@testing-library/react';
 import type { Category, Transaction } from '../../../types';
-import { resolvePeriod, type PeriodKey, type UsePeriodResult } from '../../../hooks/usePeriod';
-import type { CardPeriodPin } from '../../../hooks/useCardPeriod';
+import { resolvePeriod, usePeriod, type PeriodKey, type UsePeriodResult } from '../../../hooks/usePeriod';
+import { cardPeriodKey, useCardPeriod, type CardPeriodPin } from '../../../hooks/useCardPeriod';
+import { periodPinKey } from '../../../services/preferencesService';
 
 const mocks = vi.hoisted(() => ({
   navigate: vi.fn(),
@@ -253,5 +254,107 @@ describe('a report card’s period pin', () => {
 
     expect(screen.queryByText(/^pinned ·/)).toBeNull();
     expect(screen.queryByRole('button', { name: /period follows the page/ })).toBeNull();
+  });
+});
+
+/**
+ * WHAT A PIN IS FOR: THE FIGURES, NOT THE LABEL.
+ *
+ * Every test above this point hands the card a `picker` and a `pin` built by
+ * hand, side by side, already agreeing with each other. That is the right shape
+ * for asking what the CONTROL does — and it is exactly why the shipped suite
+ * could be green while the owner's dashboard was not. Nothing above ever asked
+ * the question he was asking: *does the chart move?*
+ *
+ * It did not. A card's pin is filed as two facts — the flag saying it has a
+ * window of its own, and the window itself — and they were read back under two
+ * different rules. `usePeriod` distrusts a stored period that carries no
+ * `…Explicit` flag beside it and falls back to the default it was handed, which
+ * was the PAGE's window; the flag was read raw. So a store where those two
+ * disagreed rendered a card that said "pinned · All time" in the resting-state
+ * declaration and drew THIS MONTH underneath it — the pin announcing itself and
+ * changing nothing, silently, because the label and the chart both read the one
+ * picker and the picker was the page's.
+ *
+ * So these drive the REAL hook against a REAL store and assert the rendered
+ * DATA, with the page clock held still. The row below exists only outside the
+ * page's window: if the card is reading the page's clock the legend cannot name
+ * it, whatever the label says.
+ */
+const PAGE_KEY = 'dashboardReports';
+const CARD_KEY = cardPeriodKey(PAGE_KEY, 'expense-categories');
+
+/** A spend on a given day, so a window can include or exclude it. */
+const spendOn = (id: string, amount: number, date: Date): Transaction =>
+  ({ ...spend(id, amount), date } as unknown as Transaction);
+
+/**
+ * The composition the Dashboard actually builds: one page clock, one card
+ * hanging off it, and the card's own picker driving the real widget.
+ */
+function PageAndPinnedCard({ pageOn }: { pageOn: PeriodKey }): React.JSX.Element {
+  const page = usePeriod(PAGE_KEY, pageOn, localStorage);
+  const card = useCardPeriod(CARD_KEY, page, localStorage);
+  return (
+    <>
+      <span data-testid="page-window">{page.period}</span>
+      <ExpenseCategoriesWidget picker={card.picker} pin={card.pin} />
+    </>
+  );
+}
+
+describe('a pinned card’s FIGURES', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    // Last year's spending, and nothing since: "This month" must find nothing
+    // here, and "All time" must find this.
+    const lastYear = new Date();
+    lastYear.setFullYear(lastYear.getFullYear() - 1);
+    mocks.app.transactions = [spendOn('t-old', -40, lastYear)];
+  });
+
+  it('is read over the PINNED window, not the page’s, when the page is elsewhere', () => {
+    localStorage.setItem(CARD_KEY, 'all');
+    localStorage.setItem(`${CARD_KEY}Explicit`, 'true');
+    localStorage.setItem(periodPinKey(CARD_KEY), 'true');
+
+    render(<PageAndPinnedCard pageOn="this-month" />);
+
+    // The DATA: last year's category is on the card, which can only be true if
+    // the card was read over All time.
+    expect(screen.getByRole('button', { name: /Groceries/ })).toBeInTheDocument();
+    expect(screen.queryByText('No categorised spending in this period')).toBeNull();
+    // …and the page clock did not move to get it there.
+    expect(screen.getByTestId('page-window')).toHaveTextContent('this-month');
+    expect(screen.getByText('pinned · All time')).toBeInTheDocument();
+  });
+
+  /**
+   * THE OWNER'S BUG, held down at the level it actually showed: a stored pin
+   * whose window carries no `…Explicit` flag beside it. The card used to
+   * declare the pin and quietly draw the page's window; the figures are what
+   * says whether it still does.
+   */
+  it('honours a stored pin whose window was never flagged as a choice', () => {
+    localStorage.setItem(CARD_KEY, 'all');
+    localStorage.setItem(periodPinKey(CARD_KEY), 'true');
+
+    render(<PageAndPinnedCard pageOn="this-month" />);
+
+    expect(screen.getByRole('button', { name: /Groceries/ })).toBeInTheDocument();
+    expect(screen.queryByText('No categorised spending in this period')).toBeNull();
+    expect(screen.getByTestId('page-window')).toHaveTextContent('this-month');
+    // The declaration names the window the figures were actually read over —
+    // the two cannot drift apart, because there is only one picker.
+    expect(screen.getByText('pinned · All time')).toBeInTheDocument();
+  });
+
+  /** The other direction, so the assertion above cannot pass by accident. */
+  it('shows the page’s figures while it is NOT pinned', () => {
+    render(<PageAndPinnedCard pageOn="this-month" />);
+
+    expect(screen.getByText('No categorised spending in this period')).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /Groceries/ })).toBeNull();
+    expect(screen.queryByText(/^pinned ·/)).toBeNull();
   });
 });

--- a/src/components/reconciliation/ReconciliationAccountList.tsx
+++ b/src/components/reconciliation/ReconciliationAccountList.tsx
@@ -2,15 +2,15 @@ import React from 'react';
 import { Building2Icon, ChevronRightIcon } from '../icons';
 import { useCurrencyDecimal } from '../../hooks/useCurrencyDecimal';
 import type { ReconciliationSummary } from '../../hooks/useReconciliation';
-
-export interface ReconciliationGroup {
-  title: string;
-  summaries: ReconciliationSummary[];
-}
+import type { ReconciliationGrouping } from './reconciliationGrouping';
 
 interface ReconciliationAccountListProps {
-  /** Accounts grouped into titled sections (same groupings as the Accounts page). */
-  groups: ReconciliationGroup[];
+  /**
+   * The banded list, decided by the shared grouper (see `reconciliationGrouping`)
+   * — flat, one level of bands, or type sections with institution sub-bands
+   * inside them, which is what both switches on means on the Accounts page too.
+   */
+  grouping: ReconciliationGrouping;
   onSelectAccount: (accountId: string) => void;
 }
 
@@ -60,13 +60,19 @@ const COLUMN_WIDTH = {
   difference: 'md:min-w-[100px]',
 } as const;
 
+/** "3 accounts" / "1 account" — a sub-band's count, spoken as well as seen. */
+const countLabel = (n: number): string => `${n} ${n === 1 ? 'account' : 'accounts'}`;
+
 export default function ReconciliationAccountList({
-  groups,
+  grouping,
   onSelectAccount,
 }: ReconciliationAccountListProps): React.JSX.Element {
   const { formatCurrency } = useCurrencyDecimal();
 
-  const total = groups.reduce((n, g) => n + g.summaries.length, 0);
+  const total =
+    grouping.mode === 'flat'
+      ? grouping.summaries.length
+      : grouping.groups.reduce((n, g) => n + g.summaries.length, 0);
   if (total === 0) {
     return (
       <div className="text-center py-12 text-gray-500 dark:text-gray-400">
@@ -76,168 +82,229 @@ export default function ReconciliationAccountList({
     );
   }
 
+  /**
+   * A run of rows and the strip that heads it — ONE unit, always drawn together.
+   *
+   * That pairing is the whole reason this is a function rather than two pieces
+   * of the section markup. The strip labels the columns of the rows directly
+   * beneath it, so it belongs to the ROW GROUP, not to the section: with both
+   * switches on the rows live inside the institution sub-bands, and a strip
+   * left up at section level would head the first sub-band's heading instead of
+   * any rows at all, with every later sub-band's columns unlabelled.
+   */
+  const renderRowGroup = (summaries: readonly ReconciliationSummary[]): React.JSX.Element => (
+    <>
+      {/* ONE label strip per row group instead of three labels per row.
+          BANK BALANCE / ACCOUNT BALANCE / DIFFERENCE printed on every card
+          was six words repeated down the page, competing with the figures
+          they name (P1 — the figure is the interface).
+
+          It mirrors the row card's box metrics exactly — the same 2px
+          border (transparent here), the same md padding, the same gap and
+          the same column widths — so the headings sit over the columns they
+          name. The rows' three cells are flex-none and the chevron cannot
+          shrink, which leaves the flex-1 spacer as the only elastic part of
+          a row: the right-hand columns stay pinned to the right edge no
+          matter how long an account name runs, and this strip pins to the
+          same edge the same way.
+
+          aria-hidden because it is a second voice for labels the rows still
+          carry themselves (see ROW_LABEL_CLASS) — announced twice, it would
+          read as six columns rather than three. */}
+      <div
+        aria-hidden="true"
+        // Named so a test can count strips against row groups. There must be
+        // exactly one per run of rows at every nesting level — the invariant
+        // this helper exists to hold.
+        data-testid="reconciliation-column-labels"
+        className="hidden md:flex w-full items-center gap-4 border-2 border-transparent px-5 pb-1"
+      >
+        <div className="flex-1" />
+        <p className={`${STRIP_LABEL_CLASS} ${COLUMN_WIDTH.bankBalance}`}>Bank Balance</p>
+        <p className={`${STRIP_LABEL_CLASS} ${COLUMN_WIDTH.accountBalance}`}>Account Balance</p>
+        <p className={`${STRIP_LABEL_CLASS} ${COLUMN_WIDTH.difference}`}>Difference</p>
+        {/* The chevron's column, so the labels clear it. */}
+        <div className="w-5 ml-2 flex-shrink-0" />
+      </div>
+      <div className="grid gap-3">
+        {summaries.map(({ account, unreconciledCount, bankBalance, accountBalance, difference }) => {
+          const hasDifference = difference != null && Math.abs(difference) > 0.005;
+
+          return (
+            <button
+              key={account.id}
+              type="button"
+              onClick={() => onSelectAccount(account.id)}
+              className={`w-full text-left bg-white dark:bg-gray-800 rounded-xl border-2 transition-all hover:shadow-md ${
+                hasDifference
+                  ? 'border-amber-400 dark:border-amber-500'
+                  : 'border-gray-200 dark:border-gray-700 hover:border-primary'
+              } p-4 md:p-5`}
+            >
+              {/* w-full so the columns spread edge-to-edge and the icons
+                  line up in a straight rail down the page */}
+              {/* The min-widths below add up to 660px, which is what
+                  kept this card off the edge of a phone. They only apply
+                  from md up now; under that the row wraps. */}
+              <div className="w-full flex flex-wrap items-end md:items-center gap-3 md:gap-4">
+                <div className="flex items-center gap-3 min-w-0 basis-full md:basis-auto md:min-w-[200px]">
+                  <div className="p-2 bg-gray-100 dark:bg-gray-700 rounded-lg flex-shrink-0">
+                    <Building2Icon size={20} className="text-gray-600 dark:text-gray-400" />
+                  </div>
+                  <div>
+                    <h3 className="font-semibold text-gray-900 dark:text-white">{account.name}</h3>
+                    <p className="text-xs text-gray-500 dark:text-gray-400">
+                      {account.institution ?? account.type}
+                    </p>
+                  </div>
+                </div>
+
+                <div className="basis-full md:basis-auto md:min-w-[120px]">
+                  {unreconciledCount > 0 ? (
+                    // Neutral, deliberately: this is a COUNT, not an
+                    // action. It wore amber until the design pass pointed
+                    // out that four amber chips on this page competed with
+                    // the one amber that means "your next move" — the
+                    // travelling yellow on the balance bar. The thread
+                    // works because amber is otherwise absent (P3).
+                    <span className="inline-flex items-center px-2.5 py-1 rounded-full text-xs font-medium bg-surface-tertiary text-slate-600 dark:bg-gray-700 dark:text-gray-300">
+                      {unreconciledCount} unreconciled
+                    </span>
+                  ) : (
+                    // "Reconciled", not "cleared": this badge is the answer
+                    // to "is there anything left to do here?", and marks are
+                    // not an answer to that — only a finished reconciliation
+                    // is.
+                    <span className="inline-flex items-center px-2.5 py-1 rounded-full text-xs font-medium bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-400">
+                      All reconciled
+                    </span>
+                  )}
+                </div>
+
+                <div className="hidden md:block flex-1" />
+
+                <div className={`text-right flex-1 min-w-[84px] md:flex-none ${COLUMN_WIDTH.bankBalance}`}>
+                  <p className={ROW_LABEL_CLASS}>Bank Balance</p>
+                  {bankBalance != null ? (
+                    <p className="text-sm font-semibold text-gray-900 dark:text-white tabular-nums">
+                      {formatCurrency(bankBalance, account.currency)}
+                    </p>
+                  ) : (
+                    <>
+                      <p className="text-sm font-semibold text-gray-400 dark:text-gray-500 tabular-nums">
+                        {ABSENT_FIGURE}
+                      </p>
+                      {/* The remedy, on the row that needs it.
+                          A span rather than a nested control, and that is
+                          not a compromise: the whole card already opens
+                          this account's reconciliation view, which is where
+                          the closing balance is typed, so a button here
+                          would be a second tab stop to the identical
+                          destination — and a button inside a button is
+                          invalid markup besides. It wears the quiet-text
+                          role the balance bar's own "Enter balance"
+                          affordance wears (P7), never amber: on this page
+                          amber belongs to the travelling thread alone
+                          (P3). */}
+                      {/* "Closing balance", not "bank balance": a link
+                          names its DESTINATION, and the screen it opens
+                          deliberately says Closing Balance — the number
+                          you agree to, not a live feed figure. The column
+                          above stays Bank Balance because it really is
+                          the feed's number; the two names mark two
+                          different figures, and the gap between them is
+                          the Difference column — the thing reconciliation
+                          exists to close. (Design ruling, 2026-08-12.) */}
+                      <span className="block text-[11px] font-medium text-primary dark:text-blue-400">
+                        Enter closing balance
+                      </span>
+                    </>
+                  )}
+                </div>
+                <div className={`text-right flex-1 min-w-[84px] md:flex-none ${COLUMN_WIDTH.accountBalance}`}>
+                  <p className={ROW_LABEL_CLASS}>Account Balance</p>
+                  <p className="text-sm font-semibold text-gray-900 dark:text-white tabular-nums">
+                    {formatCurrency(accountBalance, account.currency)}
+                  </p>
+                </div>
+                <div className={`text-right flex-1 min-w-[84px] md:flex-none ${COLUMN_WIDTH.difference}`}>
+                  <p className={ROW_LABEL_CLASS}>Difference</p>
+                  {/* No second remedy here. The difference is missing for
+                      exactly the reason the bank balance is, and the row
+                      has already said what to do about it once. */}
+                  <p className={`text-sm font-bold tabular-nums ${
+                    difference == null
+                      ? 'text-gray-400 dark:text-gray-500'
+                      : Math.abs(difference) < 0.005
+                      ? 'text-blue-600 dark:text-blue-400'
+                      : 'text-red-600 dark:text-red-400'
+                  }`}>
+                    {difference != null
+                      ? formatCurrency(difference, account.currency)
+                      : ABSENT_FIGURE}
+                  </p>
+                </div>
+                <ChevronRightIcon size={20} className="text-gray-400 flex-shrink-0 ml-2" />
+              </div>
+            </button>
+          );
+        })}
+      </div>
+    </>
+  );
+
+  // Neither switch on: one list, no headings and no counts — the same answer
+  // `groupAccountsForDisplay` gives the Accounts page for the same combination
+  // (a flat mode carrying no band chrome at all, rather than one nameless
+  // group the caller might head by accident).
+  if (grouping.mode === 'flat') {
+    return <div>{renderRowGroup(grouping.summaries)}</div>;
+  }
+
   return (
     <div className="space-y-6">
-      {groups.map(group => group.summaries.length > 0 && (
-        <section key={group.title}>
+      {grouping.groups.map(group => (
+        <section key={group.label}>
           <h2 className="text-sm font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-400 mb-2">
             {group.title}
             <span className="ml-2 font-normal normal-case text-gray-400 dark:text-gray-500">
               ({group.summaries.length})
             </span>
           </h2>
-          {/* ONE label strip per group instead of three labels per row.
-              BANK BALANCE / ACCOUNT BALANCE / DIFFERENCE printed on every card
-              was six words repeated down the page, competing with the figures
-              they name (P1 — the figure is the interface).
-
-              It mirrors the row card's box metrics exactly — the same 2px
-              border (transparent here), the same md padding, the same gap and
-              the same column widths — so the headings sit over the columns they
-              name. The rows' three cells are flex-none and the chevron cannot
-              shrink, which leaves the flex-1 spacer as the only elastic part of
-              a row: the right-hand columns stay pinned to the right edge no
-              matter how long an account name runs, and this strip pins to the
-              same edge the same way.
-
-              aria-hidden because it is a second voice for labels the rows still
-              carry themselves (see ROW_LABEL_CLASS) — announced twice, it would
-              read as six columns rather than three. */}
-          <div
-            aria-hidden="true"
-            className="hidden md:flex w-full items-center gap-4 border-2 border-transparent px-5 pb-1"
-          >
-            <div className="flex-1" />
-            <p className={`${STRIP_LABEL_CLASS} ${COLUMN_WIDTH.bankBalance}`}>Bank Balance</p>
-            <p className={`${STRIP_LABEL_CLASS} ${COLUMN_WIDTH.accountBalance}`}>Account Balance</p>
-            <p className={`${STRIP_LABEL_CLASS} ${COLUMN_WIDTH.difference}`}>Difference</p>
-            {/* The chevron's column, so the labels clear it. */}
-            <div className="w-5 ml-2 flex-shrink-0" />
-          </div>
-          <div className="grid gap-3">
-            {group.summaries.map(({ account, unreconciledCount, bankBalance, accountBalance, difference }) => {
-              const hasDifference = difference != null && Math.abs(difference) > 0.005;
-
-              return (
-                <button
-                  key={account.id}
-                  type="button"
-                  onClick={() => onSelectAccount(account.id)}
-                  className={`w-full text-left bg-white dark:bg-gray-800 rounded-xl border-2 transition-all hover:shadow-md ${
-                    hasDifference
-                      ? 'border-amber-400 dark:border-amber-500'
-                      : 'border-gray-200 dark:border-gray-700 hover:border-primary'
-                  } p-4 md:p-5`}
+          {group.subGroups ? (
+            <div className="space-y-5">
+              {group.subGroups.map(sub => (
+                // A sub-band is a GROUP, not a heading. The page's outline stays
+                // section (h2) → account name (h3), which is what a screen
+                // reader walks; the institution, and how many accounts are under
+                // it, arrive as this container's label instead. Exactly the
+                // treatment the Accounts page gives its own institution
+                // sub-bands, for exactly that reason.
+                <div
+                  key={sub.label}
+                  role="group"
+                  aria-label={`${sub.title}, ${countLabel(sub.summaries.length)}`}
                 >
-                  {/* w-full so the columns spread edge-to-edge and the icons
-                      line up in a straight rail down the page */}
-                  {/* The min-widths below add up to 660px, which is what
-                      kept this card off the edge of a phone. They only apply
-                      from md up now; under that the row wraps. */}
-                  <div className="w-full flex flex-wrap items-end md:items-center gap-3 md:gap-4">
-                    <div className="flex items-center gap-3 min-w-0 basis-full md:basis-auto md:min-w-[200px]">
-                      <div className="p-2 bg-gray-100 dark:bg-gray-700 rounded-lg flex-shrink-0">
-                        <Building2Icon size={20} className="text-gray-600 dark:text-gray-400" />
-                      </div>
-                      <div>
-                        <h3 className="font-semibold text-gray-900 dark:text-white">{account.name}</h3>
-                        <p className="text-xs text-gray-500 dark:text-gray-400">
-                          {account.institution ?? account.type}
-                        </p>
-                      </div>
-                    </div>
-
-                    <div className="basis-full md:basis-auto md:min-w-[120px]">
-                      {unreconciledCount > 0 ? (
-                        // Neutral, deliberately: this is a COUNT, not an
-                        // action. It wore amber until the design pass pointed
-                        // out that four amber chips on this page competed with
-                        // the one amber that means "your next move" — the
-                        // travelling yellow on the balance bar. The thread
-                        // works because amber is otherwise absent (P3).
-                        <span className="inline-flex items-center px-2.5 py-1 rounded-full text-xs font-medium bg-surface-tertiary text-slate-600 dark:bg-gray-700 dark:text-gray-300">
-                          {unreconciledCount} unreconciled
-                        </span>
-                      ) : (
-                        // "Reconciled", not "cleared": this badge is the answer
-                        // to "is there anything left to do here?", and marks are
-                        // not an answer to that — only a finished reconciliation
-                        // is.
-                        <span className="inline-flex items-center px-2.5 py-1 rounded-full text-xs font-medium bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-400">
-                          All reconciled
-                        </span>
-                      )}
-                    </div>
-
-                    <div className="hidden md:block flex-1" />
-
-                    <div className={`text-right flex-1 min-w-[84px] md:flex-none ${COLUMN_WIDTH.bankBalance}`}>
-                      <p className={ROW_LABEL_CLASS}>Bank Balance</p>
-                      {bankBalance != null ? (
-                        <p className="text-sm font-semibold text-gray-900 dark:text-white tabular-nums">
-                          {formatCurrency(bankBalance, account.currency)}
-                        </p>
-                      ) : (
-                        <>
-                          <p className="text-sm font-semibold text-gray-400 dark:text-gray-500 tabular-nums">
-                            {ABSENT_FIGURE}
-                          </p>
-                          {/* The remedy, on the row that needs it.
-                              A span rather than a nested control, and that is
-                              not a compromise: the whole card already opens
-                              this account's reconciliation view, which is where
-                              the closing balance is typed, so a button here
-                              would be a second tab stop to the identical
-                              destination — and a button inside a button is
-                              invalid markup besides. It wears the quiet-text
-                              role the balance bar's own "Enter balance"
-                              affordance wears (P7), never amber: on this page
-                              amber belongs to the travelling thread alone
-                              (P3). */}
-                          {/* "Closing balance", not "bank balance": a link
-                              names its DESTINATION, and the screen it opens
-                              deliberately says Closing Balance — the number
-                              you agree to, not a live feed figure. The column
-                              above stays Bank Balance because it really is
-                              the feed's number; the two names mark two
-                              different figures, and the gap between them is
-                              the Difference column — the thing reconciliation
-                              exists to close. (Design ruling, 2026-08-12.) */}
-                          <span className="block text-[11px] font-medium text-primary dark:text-blue-400">
-                            Enter closing balance
-                          </span>
-                        </>
-                      )}
-                    </div>
-                    <div className={`text-right flex-1 min-w-[84px] md:flex-none ${COLUMN_WIDTH.accountBalance}`}>
-                      <p className={ROW_LABEL_CLASS}>Account Balance</p>
-                      <p className="text-sm font-semibold text-gray-900 dark:text-white tabular-nums">
-                        {formatCurrency(accountBalance, account.currency)}
-                      </p>
-                    </div>
-                    <div className={`text-right flex-1 min-w-[84px] md:flex-none ${COLUMN_WIDTH.difference}`}>
-                      <p className={ROW_LABEL_CLASS}>Difference</p>
-                      {/* No second remedy here. The difference is missing for
-                          exactly the reason the bank balance is, and the row
-                          has already said what to do about it once. */}
-                      <p className={`text-sm font-bold tabular-nums ${
-                        difference == null
-                          ? 'text-gray-400 dark:text-gray-500'
-                          : Math.abs(difference) < 0.005
-                          ? 'text-blue-600 dark:text-blue-400'
-                          : 'text-red-600 dark:text-red-400'
-                      }`}>
-                        {difference != null
-                          ? formatCurrency(difference, account.currency)
-                          : ABSENT_FIGURE}
-                      </p>
-                    </div>
-                    <ChevronRightIcon size={20} className="text-gray-400 flex-shrink-0 ml-2" />
-                  </div>
-                </button>
-              );
-            })}
-          </div>
+                  {/* The section heading above, one step quieter and separated
+                      by a hairline rather than by a box of its own (P4: weight
+                      and space before borders). Deliberately NOT indented: the
+                      rows below it carry three right-aligned figure columns that
+                      run in a straight rail down the whole page, and indenting
+                      the band would bend that rail out of true for every account
+                      that happened to have an institution. */}
+                  <p className="mb-2 flex items-baseline gap-2 border-b border-line dark:border-gray-700 pb-1.5 text-label uppercase font-semibold text-gray-500 dark:text-gray-400">
+                    <span className="truncate">{sub.title}</span>
+                    <span className="shrink-0 font-normal normal-case tracking-normal text-gray-400 dark:text-gray-500">
+                      ({sub.summaries.length})
+                    </span>
+                  </p>
+                  {renderRowGroup(sub.summaries)}
+                </div>
+              ))}
+            </div>
+          ) : (
+            renderRowGroup(group.summaries)
+          )}
         </section>
       ))}
     </div>

--- a/src/components/reconciliation/__tests__/ReconciliationAccountList.test.tsx
+++ b/src/components/reconciliation/__tests__/ReconciliationAccountList.test.tsx
@@ -1,7 +1,8 @@
 import { describe, it, expect, vi } from 'vitest';
 import { render, screen, fireEvent, within } from '@testing-library/react';
 import { PreferencesProvider } from '../../../contexts/PreferencesContext';
-import ReconciliationAccountList, { type ReconciliationGroup } from '../ReconciliationAccountList';
+import ReconciliationAccountList from '../ReconciliationAccountList';
+import type { ReconciliationGrouping } from '../reconciliationGrouping';
 import type { ReconciliationSummary } from '../../../hooks/useReconciliation';
 import type { Account } from '../../../types';
 
@@ -42,26 +43,35 @@ const summary = (
   lastReconciledBalance: null,
 });
 
-const groups: ReconciliationGroup[] = [
-  {
-    title: 'Current Accounts',
-    summaries: [
-      summary('a1', 'Everyday Account', null, 250),
-      summary('a2', 'Second Account', 220, 250),
-    ],
-  },
-];
+const grouping: ReconciliationGrouping = {
+  mode: 'grouped',
+  groups: [
+    {
+      label: 'current',
+      title: 'Current Accounts',
+      summaries: [
+        summary('a1', 'Everyday Account', null, 250),
+        summary('a2', 'Second Account', 220, 250),
+      ],
+    },
+  ],
+};
 
-const renderList = (onSelectAccount = vi.fn()) => {
+const renderGrouping = (
+  value: ReconciliationGrouping,
+  onSelectAccount = vi.fn()
+): ReturnType<typeof vi.fn> => {
   render(
     // The list formats through useCurrencyDecimal, which reads the display
     // currency from preferences.
     <PreferencesProvider>
-      <ReconciliationAccountList groups={groups} onSelectAccount={onSelectAccount} />
+      <ReconciliationAccountList grouping={value} onSelectAccount={onSelectAccount} />
     </PreferencesProvider>
   );
   return onSelectAccount;
 };
+
+const renderList = (onSelectAccount = vi.fn()) => renderGrouping(grouping, onSelectAccount);
 
 const rowFor = (name: string): HTMLElement =>
   screen.getByRole('button', { name: new RegExp(name) });
@@ -144,5 +154,155 @@ describe('ReconciliationAccountList — one label strip per group', () => {
     // The strip is a second voice for labels the rows still carry, so it is
     // hidden from assistive technology rather than duplicated into it.
     expect(document.querySelector('[aria-hidden="true"]')).toHaveAttribute('aria-hidden', 'true');
+  });
+});
+
+/**
+ * NESTING — the owner's bug, at the rendering end.
+ *
+ * "I cannot sort the reconciliation page by account type AND Institution, its
+ * one or the other, unlike in Accounts where you can set them both to 'ON'."
+ * Both on means institution sub-bands inside the type sections, and the thing
+ * most easily got wrong is the column label strip: it heads a RUN OF ROWS, so
+ * once nested there must be one per sub-band, not one stranded up at section
+ * level with every sub-band's columns unlabelled beneath it.
+ */
+const nested: ReconciliationGrouping = {
+  mode: 'grouped',
+  groups: [
+    {
+      label: 'current',
+      title: 'Current Accounts',
+      summaries: [
+        summary('a1', 'Everyday Account', 100, 100),
+        summary('a2', 'Second Account', 220, 250),
+        summary('a3', 'Third Account', 40, 40),
+      ],
+      subGroups: [
+        {
+          label: 'Invented Bank',
+          title: 'Invented Bank',
+          summaries: [summary('a1', 'Everyday Account', 100, 100), summary('a2', 'Second Account', 220, 250)],
+        },
+        {
+          label: 'Second Invented Bank',
+          title: 'Second Invented Bank',
+          summaries: [summary('a3', 'Third Account', 40, 40)],
+        },
+      ],
+    },
+    {
+      label: 'savings',
+      title: 'Savings Accounts',
+      summaries: [summary('a4', 'Rainy Day Account', 500, 500)],
+      subGroups: [
+        {
+          label: 'Invented Bank',
+          title: 'Invented Bank',
+          summaries: [summary('a4', 'Rainy Day Account', 500, 500)],
+        },
+      ],
+    },
+  ],
+};
+
+const strips = (): HTMLElement[] => screen.getAllByTestId('reconciliation-column-labels');
+
+describe('ReconciliationAccountList — both switches on', () => {
+  it('nests the institution sub-bands inside the type sections', () => {
+    renderGrouping(nested);
+
+    // The type sections are still the outline: h2, as they were.
+    const sections = screen.getAllByRole('heading', { level: 2 }).map(h => h.textContent);
+    // The count sits in a span with a CSS margin, so textContent runs on.
+    expect(sections).toEqual(['Current Accounts(3)', 'Savings Accounts(1)']);
+
+    // The institutions are groups rather than headings, so the page's outline
+    // stays section → account name. The same treatment the Accounts page gives
+    // its own sub-bands.
+    const bands = screen.getAllByRole('group').map(g => g.getAttribute('aria-label'));
+    expect(bands).toEqual([
+      'Invented Bank, 2 accounts',
+      'Second Invented Bank, 1 account',
+      'Invented Bank, 1 account',
+    ]);
+  });
+
+  it('heads every sub-band with the column labels, and heads nothing else', () => {
+    renderGrouping(nested);
+
+    // Three sub-bands, three strips. NOT two (one per section, orphaning the
+    // rows below the first sub-heading), and not five (a section strip plus a
+    // sub-band strip, labelling the columns twice over).
+    expect(strips()).toHaveLength(3);
+
+    // And each one is inside the sub-band whose rows it labels, not floating
+    // above the whole section.
+    screen.getAllByRole('group').forEach(band => {
+      expect(within(band).getAllByTestId('reconciliation-column-labels')).toHaveLength(1);
+    });
+  });
+
+  it('keeps the section count describing the whole band, not the first sub-band', () => {
+    renderGrouping(nested);
+
+    // Current Accounts holds three accounts across two institutions. A heading
+    // that counted only the rows of its first sub-band would be a section
+    // lying about its own size.
+    expect(screen.getByRole('heading', { level: 2, name: /Current Accounts/ }).textContent)
+      .toContain('(3)');
+  });
+});
+
+describe('ReconciliationAccountList — one switch, and none', () => {
+  it('heads each band once when there are no sub-bands', () => {
+    renderGrouping({
+      mode: 'grouped',
+      groups: [
+        { label: 'current', title: 'Current Accounts', summaries: [summary('a1', 'Everyday Account', 100, 100)] },
+        { label: 'savings', title: 'Savings Accounts', summaries: [summary('a4', 'Rainy Day Account', 500, 500)] },
+      ],
+    });
+
+    expect(strips()).toHaveLength(2);
+    expect(screen.queryAllByRole('group')).toHaveLength(0);
+  });
+
+  it('bands by institution alone with no type sections in sight', () => {
+    renderGrouping({
+      mode: 'grouped',
+      groups: [
+        { label: 'Invented Bank', title: 'Invented Bank', summaries: [summary('a1', 'Everyday Account', 100, 100)] },
+      ],
+    });
+
+    expect(screen.getAllByRole('heading', { level: 2 }).map(h => h.textContent)).toEqual([
+      'Invented Bank(1)',
+    ]);
+    expect(strips()).toHaveLength(1);
+  });
+
+  it('draws one unheaded list when neither switch is on', () => {
+    renderGrouping({
+      mode: 'flat',
+      summaries: [summary('a1', 'Everyday Account', 100, 100), summary('a4', 'Rainy Day Account', 500, 500)],
+    });
+
+    // What the Accounts page does with neither switch on (accountGrouping's
+    // `flat` mode): a single list carrying no band chrome at all — no heading,
+    // no count, nothing to fold.
+    expect(screen.queryAllByRole('heading', { level: 2 })).toHaveLength(0);
+    expect(screen.queryAllByRole('group')).toHaveLength(0);
+    // Still ONE strip: there is one run of rows, and it is still labelled.
+    expect(strips()).toHaveLength(1);
+    expect(screen.getByRole('button', { name: /Everyday Account/ })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Rainy Day Account/ })).toBeInTheDocument();
+  });
+
+  it('says so when the filters have left nothing to reconcile', () => {
+    renderGrouping({ mode: 'flat', summaries: [] });
+
+    expect(screen.getByText('No accounts to reconcile')).toBeInTheDocument();
+    expect(screen.queryAllByTestId('reconciliation-column-labels')).toHaveLength(0);
   });
 });

--- a/src/components/reconciliation/reconciliationGrouping.ts
+++ b/src/components/reconciliation/reconciliationGrouping.ts
@@ -1,0 +1,173 @@
+/**
+ * HOW THE RECONCILIATION LIST IS BANDED — the Accounts page's answer, applied
+ * to reconciliation summaries.
+ *
+ * This page used to hold its own `useState<'type' | 'institution'>`: two
+ * buttons that looked exactly like the Accounts page's pair but behaved as an
+ * either/or, so turning Institution on turned Account Type off. The owner found
+ * it by trying to do what the other page lets him do — "I cannot sort the
+ * reconciliation page by account type AND Institution, its one or the other,
+ * unlike in Accounts where you can set them both to 'ON'." Two identical
+ * controls with different behaviour is exactly what P7 (one control set)
+ * forbids.
+ *
+ * So the banding decision is not made here at all. `groupAccountsForDisplay` in
+ * `utils/accountGrouping` decides it for both pages — all four switch
+ * combinations, the institution catch-all, the case-insensitive institution
+ * matching, the section order — and this module does nothing but carry
+ * reconciliation summaries through it and hand back the same shape wearing
+ * their names. Nothing about grouping can drift between the two pages, because
+ * there is only one implementation of it.
+ */
+import {
+  groupAccountsForDisplay,
+  parseAccountGroupingPreference,
+  serializeAccountGroupingPreference,
+  DEFAULT_ACCOUNT_GROUPING,
+  type AccountGroupingOptions,
+  type GroupableAccount,
+} from '../../utils/accountGrouping';
+import { preferences } from '../../services/preferencesService';
+import type { ReconciliationSummary } from '../../hooks/useReconciliation';
+
+/**
+ * This page's own switches — deliberately NOT the Accounts page's key.
+ *
+ * The two screens answer different questions. Accounts is a portfolio read, and
+ * the owner keeps it banded the way he thinks about his money; reconciliation
+ * is a worklist, and the useful banding there is whichever one makes the next
+ * statement easy to find. Sharing one stored value would mean grouping the
+ * worklist by institution silently re-banded the portfolio, which is a page
+ * changing under the user because he touched a different page.
+ *
+ * Versioned for the same reason `accountsGroupBy` was: v1 held a single
+ * either/or string, and it is still read once so an existing view survives.
+ */
+export const RECONCILIATION_GROUPING_STORAGE_KEY = 'reconciliationGroupBy.v2';
+/** The pre-toggle key: `'type'` or `'institution'`, one or the other. */
+export const LEGACY_RECONCILIATION_GROUPING_STORAGE_KEY = 'reconciliationGroupBy';
+
+/** An institution sub-band inside a type section — present only with both switches on. */
+export interface ReconciliationSubGroup {
+  /** Stable React key and heading: the institution as first spelled. */
+  label: string;
+  title: string;
+  summaries: ReconciliationSummary[];
+}
+
+/** One band of the list: its heading, everything in it, and its sub-bands if any. */
+export interface ReconciliationGroup {
+  /** The section type ('current') or the institution name — unique within a grouping. */
+  label: string;
+  title: string;
+  /**
+   * Every summary in the band. With sub-bands present the ROWS are drawn from
+   * `subGroups`; this stays whole because the heading's count describes the
+   * band, exactly as the Accounts page's band heading does.
+   */
+  summaries: ReconciliationSummary[];
+  subGroups?: ReconciliationSubGroup[];
+}
+
+/**
+ * Flat carries no heading, no count and no band chrome, so it is its own shape
+ * rather than one nameless group — the list cannot accidentally head it.
+ */
+export type ReconciliationGrouping =
+  | { mode: 'flat'; summaries: ReconciliationSummary[] }
+  | { mode: 'grouped'; groups: ReconciliationGroup[] };
+
+/**
+ * A summary wearing the three fields the shared grouper reads, with the summary
+ * itself along for the ride. Structural typing is what makes this free:
+ * `GroupableAccount` asks for a name, a type and an institution, and asks for
+ * nothing about where they came from.
+ */
+interface GroupableSummary extends GroupableAccount {
+  summary: ReconciliationSummary;
+}
+
+const groupable = (summary: ReconciliationSummary): GroupableSummary => ({
+  name: summary.account.name,
+  type: summary.account.type,
+  institution: summary.account.institution,
+  summary,
+});
+
+const unwrap = (rows: readonly GroupableSummary[]): ReconciliationSummary[] =>
+  rows.map(row => row.summary);
+
+/**
+ * Band the summaries the way the Accounts page bands accounts.
+ *
+ * `sortSummaries` is applied to the INNERMOST list every time — the rows a user
+ * actually reads down — which is why it is the caller's to supply: the shared
+ * grouper deliberately preserves input order so each page can impose its own
+ * Default/Name/Value sort. With both switches on that means sorting inside each
+ * institution sub-band, not inside the type section that contains them.
+ */
+export function groupReconciliationSummaries(
+  summaries: readonly ReconciliationSummary[],
+  options: AccountGroupingOptions,
+  sortSummaries: (list: ReconciliationSummary[]) => ReconciliationSummary[]
+): ReconciliationGrouping {
+  const grouped = groupAccountsForDisplay(summaries.map(groupable), options);
+
+  if (grouped.mode === 'flat') {
+    return { mode: 'flat', summaries: sortSummaries(unwrap(grouped.accounts)) };
+  }
+
+  return {
+    mode: 'grouped',
+    groups: grouped.groups.map(group => ({
+      label: group.label,
+      title: group.title,
+      summaries: sortSummaries(unwrap(group.accounts)),
+      ...(group.subGroups
+        ? {
+            subGroups: group.subGroups.map(sub => ({
+              label: sub.label,
+              title: sub.title,
+              summaries: sortSummaries(unwrap(sub.accounts)),
+            })),
+          }
+        : {}),
+    })),
+  };
+}
+
+/**
+ * Both switches as stored, through the SHARED parser — so the migration from
+ * the single either/or ('institution' → institution only, anything else → type
+ * only) is the one the Accounts page already proved, rather than a second
+ * reading of the same idea.
+ *
+ * The legacy value is read from preferences rather than from `localStorage`
+ * (which is where the Accounts page has to look for its own): this page's key
+ * has travelled with the account since it was introduced, so that is where an
+ * existing choice actually is.
+ *
+ * Preferences can throw outright, which must never stop the list rendering.
+ */
+export function readStoredReconciliationGrouping(): AccountGroupingOptions {
+  try {
+    return parseAccountGroupingPreference(
+      preferences.getItem(RECONCILIATION_GROUPING_STORAGE_KEY),
+      preferences.getItem(LEGACY_RECONCILIATION_GROUPING_STORAGE_KEY)
+    );
+  } catch {
+    return DEFAULT_ACCOUNT_GROUPING;
+  }
+}
+
+/** Remember both switches. A storage failure loses the memory, never the view. */
+export function writeReconciliationGrouping(options: AccountGroupingOptions): void {
+  try {
+    preferences.setItem(
+      RECONCILIATION_GROUPING_STORAGE_KEY,
+      serializeAccountGroupingPreference(options)
+    );
+  } catch {
+    /* storage unavailable — the switches still work for this session */
+  }
+}

--- a/src/hooks/useCardPeriod.test.ts
+++ b/src/hooks/useCardPeriod.test.ts
@@ -145,6 +145,46 @@ describe('a card pinned to a window of its own', () => {
     expect(second.result.current.page.period).toBe('last-12-months');
   });
 
+  /**
+   * THE OWNER'S BUG, at the level it was caused.
+   *
+   * A pin is two facts in storage — the flag saying this card has a window of
+   * its own, and the window — and they were read back under different rules.
+   * `usePeriod` distrusts a stored period that carries no `…Explicit` flag
+   * beside it and falls back to the `defaultKey` it was handed, which was the
+   * PAGE's window. So a store where the two disagreed produced a card that
+   * declared "pinned · All time" and was read over the page's clock: a pin that
+   * announces itself and changes nothing, with no error anywhere.
+   *
+   * The pin flag IS the statement that this window was chosen, so it decides —
+   * the stored window is honoured whenever it can be read at all.
+   */
+  it('is read over its stored window even when nothing flagged it a choice', () => {
+    localStorage.setItem(CARD_KEY, 'all');
+    localStorage.setItem(periodPinKey(CARD_KEY), 'true');
+
+    const { result } = renderPageAndCard();
+
+    expect(result.current.card.pin.isPinned).toBe(true);
+    expect(result.current.card.picker.period).toBe('all');
+    // The window itself, not only its name: All time is unbounded and the
+    // page's twelve months is not, so this is the assertion that would have
+    // caught a card quietly drawing the page's figures.
+    expect(result.current.card.picker.range.from).toBeNull();
+    // …and the page clock never moved to make that true.
+    expect(result.current.page.period).toBe('last-12-months');
+  });
+
+  /** A pin naming no window this build can read still has to mean something. */
+  it('falls back to the page when the pin names no window it can read', () => {
+    localStorage.setItem(CARD_KEY, 'a-window-this-build-does-not-have');
+    localStorage.setItem(periodPinKey(CARD_KEY), 'true');
+
+    const { result } = renderPageAndCard();
+
+    expect(result.current.card.picker.period).toBe('last-12-months');
+  });
+
   it('files itself under the page’s key, beside the page’s own choice', () => {
     const { result } = renderPageAndCard();
 

--- a/src/hooks/useCardPeriod.ts
+++ b/src/hooks/useCardPeriod.ts
@@ -4,7 +4,13 @@ import {
   periodPinKey,
   preferences,
 } from '../services/preferencesService';
-import { usePeriod, type PeriodKey, type PeriodStorage, type UsePeriodResult } from './usePeriod';
+import {
+  isPeriodKey,
+  usePeriod,
+  type PeriodKey,
+  type PeriodStorage,
+  type UsePeriodResult,
+} from './usePeriod';
 
 /**
  * A dashboard card's period, and whether it is the page's or its own.
@@ -51,7 +57,7 @@ import { usePeriod, type PeriodKey, type PeriodStorage, type UsePeriodResult } f
  * picker unchanged. There is no migration because there is no old shape: the
  * keys below did not exist before, and their absence is the answer "follows the
  * page" — which is what every stored dashboard already meant. Pinned in
- * hooks/__tests__/useCardPeriod.test.ts.
+ * hooks/useCardPeriod.test.ts.
  */
 
 /** Whether this card has a window of its own, and the two ways to change that. */
@@ -104,23 +110,54 @@ export function useCardPeriod(
   storage: PeriodStorage = preferences
 ): CardPeriod {
   /**
-   * The card's own surface. Its `defaultKey` is the page's current window, and
-   * it is never seen: an unpinned card is handed `page` below, and a pin always
-   * arrives through `pinTo` with a window the user just picked. The default
-   * matters only for a hand-edited store that says "pinned" without saying to
-   * what, where following the page is the sane reading.
+   * The pin as storage holds it, read ONCE and as ONE fact: whether this card
+   * has a window of its own, and which window that is.
+   *
+   * Both together, deliberately. They used to be read apart — the flag here,
+   * the window through `usePeriod`'s stored-selection rule — and that rule
+   * distrusts a stored period carrying no `…Explicit` flag beside it, falling
+   * back to the `defaultKey` it was handed. That default was the PAGE's window.
+   * So any store in which those two keys disagreed produced a card that
+   * declared "pinned · …" and was handed the page's clock to draw: a pin that
+   * announces itself and changes nothing, which is the owner's bug. It fails
+   * SILENTLY because the declaration reads the same picker the chart does — the
+   * card looks correct and quotes the page's figures.
+   *
+   * `usePeriod`'s distrust is right where it lives: an unflagged `reportsPeriod`
+   * is a leftover from a build that wrote that key meaning something narrower
+   * (see `readStoredSelection`'s note). A card's pin key has no such history —
+   * it was born with this feature, and the pin flag beside it IS the statement
+   * that the user chose this window. So here the PIN decides, and the stored
+   * window is honoured whenever it can be read at all.
    */
-  const own = usePeriod(storageKey, page.period, storage);
+  const [storedPin] = useState<{ pinned: boolean; window: PeriodKey | null }>(() => {
+    const pinned = storage.getItem(periodPinKey(storageKey)) === 'true';
+    const stored = pinned ? storage.getItem(storageKey) : null;
+    return { pinned, window: stored !== null && isPeriodKey(stored) ? stored : null };
+  });
+
+  /**
+   * The card's own surface. Its `defaultKey` is the window this card was pinned
+   * to, and the page's only when there is no readable pin — which covers both
+   * the unpinned card (whose `own` is never seen, because it is handed `page`
+   * below) and the hand-edited store that says "pinned" without saying to what,
+   * where following the page remains the sane reading.
+   */
+  const own = usePeriod(storageKey, storedPin.window ?? page.period, storage);
   const { setPeriod: setOwnPeriod } = own;
 
-  const [isPinned, setIsPinned] = useState<boolean>(
-    () => storage.getItem(periodPinKey(storageKey)) === 'true'
-  );
+  const [isPinned, setIsPinned] = useState<boolean>(storedPin.pinned);
 
   const pinTo = useCallback((key: PeriodKey): void => {
+    // Both halves of "this card is pinned, and to `key`" are set before
+    // anything is written down, rather than with a write in between them. An
+    // unwritable store must cost the user the MEMORY of the pin, never the pin
+    // itself: when the write sat in the middle, a store that threw left the
+    // card holding its own window with `isPinned` still false — which renders
+    // as the page's window, the same silent failure from the other side.
+    setIsPinned(true);
     setOwnPeriod(key);
     storage.setItem(periodPinKey(storageKey), 'true');
-    setIsPinned(true);
   }, [setOwnPeriod, storage, storageKey]);
 
   /**

--- a/src/hooks/usePeriod.ts
+++ b/src/hooks/usePeriod.ts
@@ -122,8 +122,14 @@ export type PeriodStorage = PreferenceStorage;
 /** Where the "the user picked this themselves" flag lives, per surface. */
 const explicitStorageKey = (storageKey: string): string => `${storageKey}Explicit`;
 
-/** Storage holds whatever an older build (or the user) put there. */
-const isPeriodKey = (value: string): value is PeriodKey => value in PERIOD_LABELS;
+/**
+ * Storage holds whatever an older build (or the user) put there.
+ *
+ * Exported for `useCardPeriod`, which reads a card's pinned window out of
+ * storage itself rather than through `readStoredSelection` below — see the note
+ * there on why a card's pin is trusted where a bare `reportsPeriod` is not.
+ */
+export const isPeriodKey = (value: string): value is PeriodKey => value in PERIOD_LABELS;
 
 interface PeriodSelection {
   period: PeriodKey;

--- a/src/pages/Accounts.tsx
+++ b/src/pages/Accounts.tsx
@@ -1042,9 +1042,31 @@ export default function Accounts() {
                     // (§3.3). The rounding stays and is simply invisible while
                     // the row is white on white — it is there for the selected
                     // state, whose wash and ring do show it.
-                    className={`group/row p-3 sm:p-4 rounded-2xl border border-b-line dark:border-b-gray-700 last:border-b-transparent transition-all duration-300 cursor-pointer select-none focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 ${rowSkin(
+                    //
+                    // THE BASE OWNS THE BORDER'S WIDTH, EACH STATE ITS COLOUR.
+                    // 1px on all four sides at all times is geometry: take it
+                    // away for one state and the card moves 1px as it is picked
+                    // out. The COLOUR is a different question with a different
+                    // answer per state, so the divider hairline travels with the
+                    // unselected skin below and the selected skin names its own
+                    // (transparent — the ring is its only stroke). It used to
+                    // live here, on both states at once, which meant a selected
+                    // row drew the divider AND Tailwind's default #e5e7eb on the
+                    // other three sides underneath the ring: the two-tone border
+                    // this comment exists to keep from coming back.
+                    className={`group/row p-3 sm:p-4 rounded-2xl border transition-all duration-300 cursor-pointer select-none focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 ${rowSkin(
                       account.id,
-                      'bg-white dark:bg-gray-800 border-transparent hover:bg-surface-secondary dark:hover:bg-gray-700/40'
+                      // `dark:last:` as well as `last:`, and it is not
+                      // belt-and-braces. Both `dark:border-b-gray-700` and
+                      // `last:border-b-transparent` set border-bottom-color at
+                      // equal specificity, so the winner is decided by the order
+                      // Tailwind happens to emit them in — and `dark:` is
+                      // emitted last, so in DARK MODE the band's final row drew
+                      // a divider under it while light mode correctly drew
+                      // none. Stacking the two variants raises the suppression
+                      // above the plain `dark:` rule instead of hoping the
+                      // generator keeps its current order.
+                      'bg-white dark:bg-gray-800 border-transparent border-b-line dark:border-b-gray-700 last:border-b-transparent dark:last:border-b-transparent hover:bg-surface-secondary dark:hover:bg-gray-700/40'
                     )}`}
                   >
                     <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3">
@@ -1799,7 +1821,25 @@ export default function Accounts() {
 
       </div>{/* end pinned chrome */}
 
-      <div className="lg:flex-1 lg:min-h-0 lg:overflow-y-auto lg:pr-1">
+      {/* THE SCROLL REGION CLIPS SIDEWAYS TOO, WHICH IS WHY IT IS PADDED.
+          `overflow-y: auto` cannot be had on its own: CSS promotes the other
+          axis from `visible` to `auto` whenever one axis is not visible, so this
+          box clips horizontally whether or not anything asked it to. The rows
+          inside it are the full width of its content box, and the selected row's
+          ring is a box-shadow drawn 1px OUTSIDE its border box — off the end of
+          the content box, and therefore cut away. Measured at 1280px: the row
+          and the content box both began at x=32, so the ring's left stroke had
+          nowhere to land and vanished, while `pr-1` on the right had always
+          given that side 4px to paint into. One edge of the ring missing is the
+          "the border disappears on the left" half of the same bug report.
+
+          `-ml-1 pl-1` buys the missing room WITHOUT moving anything: the box
+          grows 4px leftward into the page gutter (32px of it there, and no
+          clipping ancestor above — checked) and pads the 4px straight back, so
+          every row stays at exactly the x it had. 4px is the figure the right
+          side already uses and it covers the ring (1px) with room to spare for
+          the lift, whose horizontal reach is ~4.5px at its widest layer. */}
+      <div className="lg:flex-1 lg:min-h-0 lg:overflow-y-auto lg:-ml-1 lg:pl-1 lg:pr-1">
       {/* Accounts grid */}
       <div className="grid gap-6">
         {isLoading ? (

--- a/src/pages/Reconciliation.tsx
+++ b/src/pages/Reconciliation.tsx
@@ -4,8 +4,14 @@ import { useApp } from '../contexts/AppContextSupabase';
 import { useToast } from '../contexts/ToastContext';
 import { ArrowLeftIcon, CheckCircleIcon } from '../components/icons';
 import { useReconciliation } from '../hooks/useReconciliation';
-import ReconciliationAccountList, { type ReconciliationGroup } from '../components/reconciliation/ReconciliationAccountList';
-import { ALL_ACCOUNT_SECTIONS, sectionTypeForAccount } from '../utils/accountSections';
+import ReconciliationAccountList from '../components/reconciliation/ReconciliationAccountList';
+import {
+  groupReconciliationSummaries,
+  readStoredReconciliationGrouping,
+  writeReconciliationGrouping,
+  type ReconciliationGrouping,
+} from '../components/reconciliation/reconciliationGrouping';
+import type { AccountGroupingOptions } from '../utils/accountGrouping';
 import ReconciliationBalanceBar, { CONFIRM_BALANCE_CONSEQUENCE } from '../components/reconciliation/ReconciliationBalanceBar';
 import { NEXT_ACTION_YELLOW, CONFIRM_BALANCE_HINT_ID } from '../components/reconciliation/nextActionYellow';
 import ReconciliationTransactionList from '../components/reconciliation/ReconciliationTransactionList';
@@ -34,18 +40,20 @@ export default function Reconciliation() {
   // Arriving via an Accounts-page reconcile button means "done" and "Back"
   // both return THERE, not to this page's own account list.
   const [cameFromAccounts] = useState<boolean>(() => searchParams.get('from') === 'accounts');
-  // Group + sort for the account list — the same controls (and persistence
-  // keys pattern) as the Accounts page, so the two pages always feel the same.
-  const [groupBy, setGroupBy] = useState<'type' | 'institution'>(() =>
-    (preferences.getItem('reconciliationGroupBy') as 'type' | 'institution') || 'type'
-  );
+  // Group + sort for the account list — the same controls, the same module
+  // behind them and the same persistence shape as the Accounts page, so the two
+  // pages always feel the same. Two INDEPENDENT switches, never an either/or:
+  // this page held its own `'type' | 'institution'` state behind two buttons
+  // that looked exactly like the Accounts page's pair, and the owner found the
+  // difference by trying to turn both on.
+  const [grouping, setGrouping] = useState<AccountGroupingOptions>(readStoredReconciliationGrouping);
   const [sortMode, setSortMode] = useState<'default' | 'name' | 'balance-desc' | 'balance-asc'>(() => {
     const stored = preferences.getItem('reconciliationSortMode');
     return stored === 'name' || stored === 'balance-desc' || stored === 'balance-asc' ? stored : 'default';
   });
-  const handleGroupByChange = useCallback((value: 'type' | 'institution') => {
-    setGroupBy(value);
-    try { preferences.setItem('reconciliationGroupBy', value); } catch { /* storage unavailable */ }
+  const handleGroupingChange = useCallback((next: AccountGroupingOptions) => {
+    setGrouping(next);
+    writeReconciliationGrouping(next);
   }, []);
   const handleSortChange = useCallback((value: 'default' | 'name' | 'balance-desc' | 'balance-asc') => {
     setSortMode(value);
@@ -118,8 +126,15 @@ export default function Reconciliation() {
     [reconciliationDetails]
   );
 
-  // Build the grouped, sorted account list (same sections as the Accounts page).
-  const accountGroups = useMemo<ReconciliationGroup[]>(() => {
+  // Build the banded, sorted account list. The banding is the Accounts page's,
+  // decided by the one shared module, so a 'mortgage' account reconciles under
+  // Loans here exactly as it files under Loans there — and both switches nest
+  // here exactly as they nest there.
+  //
+  // The `Needs attention only` filter runs FIRST and on the rows alone: it
+  // drops accounts, never sections, and a band left with nothing in it drops
+  // out on its own because the grouper omits empty bands.
+  const accountGrouping = useMemo<ReconciliationGrouping>(() => {
     const visibleDetails = onlyAttention
       ? reconciliationDetails.filter(
           s => s.unreconciledCount > 0 || (s.difference != null && s.difference !== 0)
@@ -134,29 +149,8 @@ export default function Reconciliation() {
       return sorted;
     };
 
-    if (groupBy === 'institution') {
-      const byInstitution = new Map<string, typeof reconciliationDetails>();
-      for (const s of visibleDetails) {
-        const key = s.account.institution || 'Other Accounts';
-        (byInstitution.get(key) ?? byInstitution.set(key, []).get(key)!).push(s);
-      }
-      return [...byInstitution.entries()]
-        .sort((a, b) => a[0].localeCompare(b[0]))
-        .map(([title, summaries]) => ({ title, summaries: sortSummaries(summaries) }));
-    }
-
-    // Same aliasing as the Accounts page (sectionTypeForAccount), so a
-    // 'mortgage' account reconciles under Loans there AND here — this page's
-    // old local catch-all put it under "Other" while Accounts showed it under
-    // Loans, and the module exists precisely so the two cannot diverge.
-    const groups: ReconciliationGroup[] = ALL_ACCOUNT_SECTIONS.map(section => ({
-      title: section.title,
-      summaries: sortSummaries(
-        visibleDetails.filter(s => sectionTypeForAccount(s.account.type) === section.type)
-      ),
-    })).filter(g => g.summaries.length > 0);
-    return groups;
-  }, [reconciliationDetails, groupBy, sortMode, onlyAttention]);
+    return groupReconciliationSummaries(visibleDetails, grouping, sortSummaries);
+  }, [reconciliationDetails, grouping, sortMode, onlyAttention]);
 
   // Selected account data
   const selectedAccount = useMemo(
@@ -480,25 +474,58 @@ export default function Reconciliation() {
           )}
         </div>
 
-        {/* Group + sort controls — mirrors the Accounts page */}
-        <div className="flex flex-wrap items-center gap-x-6 gap-y-2 mb-4">
+        {/* Group + sort controls — the Accounts page's, down to the class
+            names, because they ARE the same controls: same words, same
+            behaviour, same shared module underneath.
+
+            gap-x-8 rather than 6 for the reason the Accounts page carries the
+            same number: with the Group by pills borderless, 24px would leave
+            the Institution pill closer to the words "Sort:" than that label is
+            to its own buttons, and it would read as Institution's caption. */}
+        <div className="flex flex-wrap items-center gap-x-8 gap-y-2 mb-4">
           <div className="w-full sm:w-auto flex items-center gap-2">
-            <span className="text-sm text-gray-500 dark:text-gray-400 w-20 shrink-0">Group by:</span>
-            <div className="grid grid-flow-col auto-cols-fr flex-1 sm:flex-none sm:inline-flex rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 p-0.5">
-              {([['type', 'Account Type'], ['institution', 'Institution']] as const).map(([value, label]) => (
-                <button key={value} onClick={() => handleGroupByChange(value)}
-                  className={`px-3 py-1.5 text-sm font-medium rounded-md transition-colors ${
-                    groupBy === value
-                      ? 'bg-[#1a2332] dark:bg-blue-600 text-white'
-                      : 'text-gray-600 dark:text-gray-400 hover:text-gray-900'
-                  }`}>
-                  {label}
-                </button>
-              ))}
+            <span className="text-sm font-semibold text-gray-600 dark:text-gray-300 w-20 sm:w-auto shrink-0">Group by:</span>
+            {/* TWO SWITCHES, NOT A CHOICE. Each is a toggle in its own right —
+                aria-pressed, not a radio — so "Account Type on, Institution
+                on" is a state the page can be in: institution sub-bands nested
+                inside the type sections. Off and off is one flat list. The
+                owner's report was precisely that this page refused the
+                combination its twin allows. */}
+            <div className="grid grid-flow-col auto-cols-fr flex-1 sm:flex-none sm:inline-flex gap-2 p-0.5">
+              <button
+                type="button"
+                onClick={() => handleGroupingChange({ ...grouping, byType: !grouping.byType })}
+                aria-pressed={grouping.byType}
+                title="Band the list into account-type sections"
+                className={`px-3 py-1.5 text-sm font-medium rounded-lg border transition-colors ${
+                  grouping.byType
+                    ? 'bg-[#1a2332] dark:bg-blue-600 border-[#1a2332] dark:border-blue-600 text-white'
+                    : 'border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-200'
+                }`}
+              >
+                Account Type
+              </button>
+              <button
+                type="button"
+                onClick={() => handleGroupingChange({ ...grouping, byInstitution: !grouping.byInstitution })}
+                aria-pressed={grouping.byInstitution}
+                title="Band the list by institution"
+                className={`px-3 py-1.5 text-sm font-medium rounded-lg border transition-colors ${
+                  grouping.byInstitution
+                    ? 'bg-[#1a2332] dark:bg-blue-600 border-[#1a2332] dark:border-blue-600 text-white'
+                    : 'border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-200'
+                }`}
+              >
+                Institution
+              </button>
             </div>
           </div>
           <div className="w-full sm:w-auto flex items-center gap-2">
-            <span className="text-sm text-gray-500 dark:text-gray-400 w-20 shrink-0">Sort:</span>
+            {/* Same weight as "Group by:" beside it. It was the quieter of the
+                two only because the Group by label had not been through the
+                design pass yet; leaving it grey now would make one row of
+                controls carry two different captions for the same job. */}
+            <span className="text-sm font-semibold text-gray-600 dark:text-gray-300 w-20 sm:w-auto shrink-0">Sort:</span>
             <div className="grid grid-flow-col auto-cols-fr flex-1 sm:flex-none sm:inline-flex rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 p-0.5">
               <button onClick={() => handleSortChange('default')}
                 className={`px-3 py-1.5 text-sm font-medium rounded-md transition-colors ${
@@ -545,7 +572,7 @@ export default function Reconciliation() {
         </div>
 
         <ReconciliationAccountList
-          groups={accountGroups}
+          grouping={accountGrouping}
           onSelectAccount={handleSelectAccount}
         />
       </div>

--- a/src/pages/__tests__/Reconciliation.grouping.test.tsx
+++ b/src/pages/__tests__/Reconciliation.grouping.test.tsx
@@ -1,0 +1,243 @@
+/**
+ * TWO SWITCHES, NOT A CHOICE — the owner's report, turned into assertions.
+ *
+ * In his words: "I cannot sort the reconciliation page by account type AND
+ * Institution, its one or the other, unlike in Accounts where you can set them
+ * both to 'ON'." This page held a hand-rolled `'type' | 'institution'` state
+ * behind two buttons that looked exactly like the Accounts page's independent
+ * pair — the same words, the same pill, different behaviour, which is the one
+ * thing P7 (one control set) forbids outright.
+ *
+ * The fix was to delete the local rule and let `utils/accountGrouping` decide,
+ * as it already does for Accounts. So the tests below walk all four
+ * combinations, and the last of them pins the thing that makes the two pages
+ * genuinely one control: they must not share a stored preference.
+ *
+ * Every name and figure here is invented; this repo is public.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { render, screen, fireEvent, within } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { PreferencesProvider } from '../../contexts/PreferencesContext';
+import { ToastProvider } from '../../contexts/ToastContext';
+import { NotificationProvider } from '../../contexts/NotificationContext';
+import Reconciliation from '../Reconciliation';
+import { preferences } from '../../services/preferencesService';
+import {
+  RECONCILIATION_GROUPING_STORAGE_KEY,
+  LEGACY_RECONCILIATION_GROUPING_STORAGE_KEY,
+} from '../../components/reconciliation/reconciliationGrouping';
+import { ACCOUNT_GROUPING_STORAGE_KEY } from '../../utils/accountGrouping';
+import { __setAppContextValue, __resetAppContextValue } from '../../test/mocks/AppContextSupabase';
+import type { Account } from '../../types';
+
+const account = (
+  id: string,
+  name: string,
+  type: Account['type'],
+  institution?: string
+): Account => ({
+  id,
+  name,
+  type,
+  balance: 0,
+  currency: 'GBP',
+  ...(institution === undefined ? {} : { institution }),
+  lastUpdated: new Date('2026-08-01'),
+  openingBalance: 0,
+  isActive: true,
+});
+
+/**
+ * Four accounts across two types and two institutions, plus one with no
+ * institution at all — because "no institution" is a band of its own in the
+ * shared module, and a nesting that quietly dropped those accounts would be
+ * the bug this page had before (a type with no section rendered nowhere).
+ */
+const ACCOUNTS: Account[] = [
+  account('a1', 'Everyday Invented', 'current', 'Invented Bank'),
+  account('a2', 'Second Everyday', 'current', 'Rival Invented Bank'),
+  account('a3', 'Rainy Day Invented', 'savings', 'Invented Bank'),
+  account('a4', 'Unfiled Invented', 'savings'),
+];
+
+const renderList = () =>
+  render(
+    <MemoryRouter initialEntries={['/reconciliation']}>
+      <PreferencesProvider>
+        <ToastProvider>
+          {/* The page mounts EditTransactionModal, which reads the
+              notification context even while closed. */}
+          <NotificationProvider>
+            <Reconciliation />
+          </NotificationProvider>
+        </ToastProvider>
+      </PreferencesProvider>
+    </MemoryRouter>
+  );
+
+const switchFor = (name: 'Account Type' | 'Institution'): HTMLElement =>
+  screen.getByRole('button', { name });
+
+const isOn = (name: 'Account Type' | 'Institution'): boolean =>
+  switchFor(name).getAttribute('aria-pressed') === 'true';
+
+/** The section headings, top to bottom. */
+const sections = (): string[] =>
+  screen.queryAllByRole('heading', { level: 2 }).map(h => h.textContent ?? '');
+
+/** The institution sub-bands, top to bottom, by the label they announce. */
+const subBands = (): string[] =>
+  screen.queryAllByRole('group').map(g => g.getAttribute('aria-label') ?? '');
+
+beforeEach(() => {
+  localStorage.clear();
+  __setAppContextValue({ accounts: ACCOUNTS, transactions: [], isLoading: false });
+});
+
+afterEach(() => {
+  __resetAppContextValue();
+});
+
+describe('Reconciliation — grouping is two independent switches', () => {
+  it('HEADLINE: both can be ON at once, and the list nests', () => {
+    renderList();
+
+    // Account Type is the default, as it always was.
+    expect(isOn('Account Type')).toBe(true);
+    expect(isOn('Institution')).toBe(false);
+
+    // The owner's move: turn Institution on as well.
+    fireEvent.click(switchFor('Institution'));
+
+    // Neither switch turned the other off. This is the whole bug.
+    expect(isOn('Account Type')).toBe(true);
+    expect(isOn('Institution')).toBe(true);
+
+    // And the list nests, exactly as the Accounts page nests: type sections
+    // outside, institution sub-bands within, unfiled last inside its section.
+    expect(sections()).toEqual(['Current Accounts(2)', 'Savings Accounts(2)']);
+    expect(subBands()).toEqual([
+      'Invented Bank, 1 account',
+      'Rival Invented Bank, 1 account',
+      'Invented Bank, 1 account',
+      'Other Accounts, 1 account',
+    ]);
+
+    // The rows really are inside their sub-bands, not siblings of them.
+    const [firstBand] = screen.getAllByRole('group');
+    expect(within(firstBand).getByRole('button', { name: /Everyday Invented/ })).toBeInTheDocument();
+  });
+
+  it('bands by type alone when only Account Type is on', () => {
+    renderList();
+
+    expect(sections()).toEqual(['Current Accounts(2)', 'Savings Accounts(2)']);
+    // No sub-bands: one switch, one level.
+    expect(subBands()).toEqual([]);
+  });
+
+  it('bands by institution alone when only Institution is on', () => {
+    renderList();
+    fireEvent.click(switchFor('Institution'));
+    fireEvent.click(switchFor('Account Type'));
+
+    expect(isOn('Account Type')).toBe(false);
+    expect(isOn('Institution')).toBe(true);
+
+    // Alphabetical, with the accounts that name no institution last — the
+    // shared module's rule, so the two pages order them identically.
+    expect(sections()).toEqual([
+      'Invented Bank(2)',
+      'Rival Invented Bank(1)',
+      'Other Accounts(1)',
+    ]);
+    expect(subBands()).toEqual([]);
+  });
+
+  it('draws one flat list when NEITHER switch is on', () => {
+    renderList();
+    fireEvent.click(switchFor('Account Type'));
+
+    expect(isOn('Account Type')).toBe(false);
+    expect(isOn('Institution')).toBe(false);
+
+    // What accountGrouping's `flat` mode means, and what the Accounts page
+    // does with the same pair of switches off: no headings, no counts, no
+    // bands — just the accounts.
+    expect(sections()).toEqual([]);
+    expect(subBands()).toEqual([]);
+    ACCOUNTS.forEach(a => {
+      expect(screen.getByRole('button', { name: new RegExp(a.name) })).toBeInTheDocument();
+    });
+  });
+
+  it('keeps the filter and the sort working across the nested list', () => {
+    renderList();
+    fireEvent.click(switchFor('Institution'));
+    fireEvent.click(screen.getByRole('button', { name: 'Name A–Z' }));
+
+    // Sorting applies to the INNERMOST list — the rows a user reads down — so
+    // the bands are unchanged and the rows inside each are alphabetical.
+    expect(sections()).toEqual(['Current Accounts(2)', 'Savings Accounts(2)']);
+
+    // "Needs attention only" drops ROWS. No account here has a bank balance or
+    // an unreconciled transaction, so everything is done and the list empties
+    // rather than showing empty bands.
+    fireEvent.click(screen.getByRole('button', { name: /Needs attention only/ }));
+    expect(screen.getByText('No accounts to reconcile')).toBeInTheDocument();
+    expect(sections()).toEqual([]);
+  });
+});
+
+describe('Reconciliation — the switches are remembered, and are this page\'s own', () => {
+  it('remembers both switches across a remount', () => {
+    const first = renderList();
+    fireEvent.click(switchFor('Institution'));
+    expect(preferences.getItem(RECONCILIATION_GROUPING_STORAGE_KEY))
+      .toBe('{"byType":true,"byInstitution":true}');
+    first.unmount();
+
+    renderList();
+    expect(isOn('Account Type')).toBe(true);
+    expect(isOn('Institution')).toBe(true);
+    expect(subBands()).toHaveLength(4);
+  });
+
+  it('does not touch the Accounts page\'s preference, or read from it', () => {
+    // The two screens answer different questions — a portfolio read and a
+    // worklist — and a user may reasonably want them banded differently.
+    // Sharing one key would mean grouping the worklist silently re-banded the
+    // portfolio, which is a page changing because a different page was touched.
+    preferences.setItem(ACCOUNT_GROUPING_STORAGE_KEY, '{"byType":false,"byInstitution":true}');
+
+    const first = renderList();
+    // The Accounts page's institution-only view did not arrive here.
+    expect(isOn('Account Type')).toBe(true);
+    expect(isOn('Institution')).toBe(false);
+
+    fireEvent.click(switchFor('Institution'));
+    first.unmount();
+
+    // …and this page's change did not go back the other way.
+    expect(preferences.getItem(ACCOUNT_GROUPING_STORAGE_KEY))
+      .toBe('{"byType":false,"byInstitution":true}');
+  });
+
+  it('carries the pre-toggle choice over rather than resetting the view', () => {
+    // Someone whose reconciliation list was banded by institution yesterday —
+    // under the single either/or key — must still see institution bands today,
+    // not be silently moved back to the default.
+    preferences.setItem(LEGACY_RECONCILIATION_GROUPING_STORAGE_KEY, 'institution');
+
+    renderList();
+    expect(isOn('Account Type')).toBe(false);
+    expect(isOn('Institution')).toBe(true);
+    expect(sections()).toEqual([
+      'Invented Bank(2)',
+      'Rival Invented Bank(1)',
+      'Other Accounts(1)',
+    ]);
+  });
+});

--- a/src/services/import/msMoney/msMoneyImport.ts
+++ b/src/services/import/msMoney/msMoneyImport.ts
@@ -363,6 +363,32 @@ export const WIPE_TABLE_ORDER: readonly string[] = [
  */
 export const WIPE_CHUNK_SIZE = 2000;
 
+/**
+ * Ids per REQUEST — a different limit, from a different failure.
+ *
+ * The same 51,343-row account, chunked exactly as above, then answered
+ * `Failed while clearing transactions: Bad Request`. Nothing had timed out.
+ * PostgREST puts an `in` list in the QUERY STRING — `?id=in.(uuid,uuid,…)` —
+ * and a chunk of 2,000 UUIDs encodes to 78,071 bytes of request line, so the
+ * edge refused it with a 400 before Postgres ever saw a statement. Chunking had
+ * made each statement small and each URL enormous.
+ *
+ * 150 ids encode to 5,921 bytes against a Supabase project URL, comfortably
+ * inside the 8 KB request line the proxies in the path allow, with room to spare
+ * for a longer host or a table name twice the length. 200 measures 7,871 —
+ * inside the limit, and outside the point of having one.
+ *
+ * This bounds the WRITE only. The SELECT that feeds each pass filters on
+ * `user_id` and is a few hundred bytes however many ids it returns, so the wipe
+ * still pages at WIPE_CHUNK_SIZE and still reports progress a chunk at a time.
+ * It simply spends several requests emptying each chunk.
+ *
+ * (The architectural alternative is a server-side wipe RPC, which carries no id
+ * list at all. That surface exists and authenticates differently; this is not
+ * the change that moves the wipe onto it.)
+ */
+export const WIPE_REQUEST_IDS = 150;
+
 /** What a wipe is doing right now, for a caller with a progress bar. */
 export interface WipeProgress {
   table: string;
@@ -398,15 +424,24 @@ export interface WipeStore {
   idsFor(table: string, userId: string, limit: number): Promise<string[]>;
   /** Up to `limit` ids of this user's transactions that still carry a transfer link. */
   linkedTransferIds(userId: string, limit: number): Promise<string[]>;
-  /** Null both transfer-link columns on exactly these rows. */
+  /**
+   * Null both transfer-link columns on exactly these rows, in ONE request.
+   * Keeping the list short enough to BE one request is the caller's job, not
+   * this verb's — see WIPE_REQUEST_IDS.
+   */
   unlinkTransfers(ids: string[]): Promise<void>;
-  /** Delete exactly these rows from `table`. */
+  /** Delete exactly these rows from `table`, in one request. Same bargain. */
   deleteByIds(table: string, ids: string[]): Promise<void>;
 }
 
 export interface WipeOptions {
   onProgress?: (progress: WipeProgress) => void;
   chunkSize?: number;
+  /**
+   * Ids per write request. Overridable for the same reason `chunkSize` is: so a
+   * test can drive the batching arithmetic without shipping a different number.
+   */
+  idsPerRequest?: number;
   /** Overridable so a test can run the loop against a store it can inspect. */
   store?: WipeStore;
 }
@@ -460,11 +495,15 @@ export function supabaseWipeStore(supabase: SupabaseClient): WipeStore {
 
 /**
  * Delete ALL of the user's financial data under the authenticated client, in
- * chunks small enough that no single statement can time out.
+ * chunks small enough that no single statement can time out, sent in requests
+ * short enough that the edge will carry them.
  *
- * ── WHY CHUNKED ─────────────────────────────────────────────────────────────
- * See WIPE_CHUNK_SIZE. One statement per table died on a real 51k-row account
- * and left the login half-wiped.
+ * ── WHY CHUNKED, AND THEN BATCHED ───────────────────────────────────────────
+ * See WIPE_CHUNK_SIZE: one statement per table died on a real 51k-row account
+ * and left the login half-wiped. Then see WIPE_REQUEST_IDS: the chunks that
+ * fixed it were sent as one URL each, and 2,000 ids do not fit in a URL. Two
+ * limits, two failures, and neither one implies the other — a chunk is how much
+ * work a statement does, a batch is how much text a request is.
  *
  * ── WHAT A FAILURE LEAVES BEHIND ────────────────────────────────────────────
  * Chunks commit as they go, so a failure part-way through leaves the user with
@@ -487,6 +526,23 @@ export async function wipeCloudData(
 }
 
 /**
+ * One chunk's ids, split into request-sized batches.
+ *
+ * This is the function that keeps the URL under 8 KB, so what matters about it
+ * is what it does NOT do: it never reorders, drops or dedupes. The batches
+ * concatenate back to exactly the ids handed in, which is what lets each pass
+ * still clear the whole of the column it selected on — the property the loops
+ * below terminate by.
+ */
+function requestBatches(ids: readonly string[], size: number): string[][] {
+  const batches: string[][] = [];
+  for (let from = 0; from < ids.length; from += size) {
+    batches.push(ids.slice(from, from + size));
+  }
+  return batches;
+}
+
+/**
  * The wipe itself, over the port.
  *
  * Split from `wipeCloudData` so the loop can be exercised against a real
@@ -501,6 +557,7 @@ export async function runWipe(
   options: Omit<WipeOptions, 'store'> = {}
 ): Promise<void> {
   const chunkSize = Math.max(1, options.chunkSize ?? WIPE_CHUNK_SIZE);
+  const idsPerRequest = Math.max(1, options.idsPerRequest ?? WIPE_REQUEST_IDS);
   const stepCount = WIPE_TABLE_ORDER.length + 1; // +1 for the unlink pass
 
   // ── Step 1: break the transfer links ──────────────────────────────────────
@@ -509,7 +566,9 @@ export async function runWipe(
   // time out on its own, so it is chunked like everything else.
   //
   // The loop terminates because each pass clears the very column it selects on:
-  // a row updated here can never be returned by the next read.
+  // a row updated here can never be returned by the next read. Splitting a chunk
+  // across several requests does not weaken that — every batch commits before
+  // the next read happens, and the batches cover the chunk exactly.
   {
     const total = await store.count('transactions', userId);
     let unlinked = 0;
@@ -519,7 +578,12 @@ export async function runWipe(
       try {
         ids = await store.linkedTransferIds(userId, chunkSize);
         if (ids.length === 0) break;
-        await store.unlinkTransfers(ids);
+        // Sequentially, not Promise.all: these are writes against the rows the
+        // next read depends on, and a burst of them is how you turn a request
+        // that was too long into a database that is too busy.
+        for (const batch of requestBatches(ids, idsPerRequest)) {
+          await store.unlinkTransfers(batch);
+        }
       } catch (error) {
         throw new Error(`Failed while unlinking transfers: ${error instanceof Error ? error.message : String(error)}`);
       }
@@ -540,11 +604,16 @@ export async function runWipe(
       try {
         ids = await store.idsFor(table, userId, chunkSize);
         if (ids.length === 0) break;
-        await store.deleteByIds(table, ids);
+        for (const batch of requestBatches(ids, idsPerRequest)) {
+          await store.deleteByIds(table, batch);
+        }
       } catch (error) {
         throw new Error(`Failed while clearing ${table}: ${error instanceof Error ? error.message : String(error)}`);
       }
       deleted += ids.length;
+      // Once per chunk, not once per request: the count is of rows actually
+      // gone either way, and 343 events where there were 26 is a progress bar
+      // that costs more than it tells.
       options.onProgress?.({ table, deleted, total, step, stepCount });
     }
   }

--- a/src/services/import/msMoney/wipeCloudData.test.ts
+++ b/src/services/import/msMoney/wipeCloudData.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import {
   WIPE_CHUNK_SIZE,
+  WIPE_REQUEST_IDS,
   WIPE_TABLE_ORDER,
   runWipe,
   type WipeProgress,
@@ -8,21 +9,45 @@ import {
 } from './msMoneyImport';
 
 /**
- * The bug these exist for, in the owner's words: "Delete All Data" reported
- * `canceling statement due to statement timeout` on 51,000 transactions and
- * left the login with its transfer links nulled and its splits gone and every
- * transaction still there.
+ * Two bugs, both from the same 51,343-row account, both reported by the owner
+ * as "Delete All Data" simply failing.
+ *
+ * The first: `canceling statement due to statement timeout`, which left the
+ * login with its transfer links nulled and its splits gone and every
+ * transaction still there. Chunking fixed it.
+ *
+ * The second, which the chunking then caused: `Bad Request`. A chunk of 2,000
+ * ids goes to PostgREST in the query string, and 2,000 UUIDs is 78 KB of
+ * request line — refused by the edge before Postgres saw it. Hence a second
+ * limit, on the size of a REQUEST rather than of a statement, and the
+ * `the request the edge refused` block at the bottom of this file.
  *
  * The store below is a REAL in-memory implementation of the five verbs a wipe
  * uses, not a fake query builder. A mock that recorded calls would only prove
  * the chain was invoked in the order the test expected; this one can be asked
- * what is actually left.
+ * what is actually left, and it keeps the id arrays it was handed so the URL
+ * they would have encoded to can be measured.
  */
 
 interface Row {
   id: string;
   user_id: string;
   linked: boolean;
+}
+
+/** One call at the port, which is exactly one request in production. */
+interface Call {
+  verb: 'select' | 'select-linked' | 'unlink' | 'delete';
+  table: string;
+  ids: string[];
+}
+
+/**
+ * A 36-character id — the shape the real tables hold. The URL arithmetic is
+ * about nothing else, so a test that measures it has to use real-length ids.
+ */
+function uuidLike(n: number): string {
+  return `00000000-0000-4000-8000-${n.toString(16).padStart(12, '0')}`;
 }
 
 /** Every table, populated with `counts[table]` rows belonging to `user`. */
@@ -33,29 +58,34 @@ function memoryStore(
     linkedTransfers?: number;
     /** Someone else's rows, which a wipe must not touch. */
     otherUser?: Partial<Record<string, number>>;
-    /** Fail the nth call to this table's delete (1-based). */
-    failDelete?: { table: string; onCall: number; message: string };
+    /** Fail this table's delete once `afterRows` of its rows have already gone. */
+    failDelete?: { table: string; afterRows: number; message: string };
     countFails?: boolean;
+    /** Ids the length of real UUIDs, for the tests that measure a URL. */
+    uuidIds?: boolean;
   } = {}
-): WipeStore & { tables: Map<string, Row[]>; calls: { verb: string; table: string; rows: number }[] } {
+): WipeStore & { tables: Map<string, Row[]>; calls: Call[] } {
   const user = options.user ?? 'u-1';
   const tables = new Map<string, Row[]>();
+  let nextId = 0;
+  const idFor = (table: string, label: string): string =>
+    options.uuidIds ? uuidLike(nextId++) : `${table}-${label}`;
   for (const table of WIPE_TABLE_ORDER) {
     const mine = Array.from({ length: counts[table] ?? 0 }, (_, n) => ({
-      id: `${table}-${n}`,
+      id: idFor(table, `${n}`),
       user_id: user,
       linked: table === 'transactions' && n < (options.linkedTransfers ?? 0),
     }));
     const theirs = Array.from({ length: options.otherUser?.[table] ?? 0 }, (_, n) => ({
-      id: `${table}-other-${n}`,
+      id: idFor(table, `other-${n}`),
       user_id: 'someone-else',
       linked: false,
     }));
     tables.set(table, [...mine, ...theirs]);
   }
 
-  const calls: { verb: string; table: string; rows: number }[] = [];
-  const deletesSeen = new Map<string, number>();
+  const calls: Call[] = [];
+  const rowsDeleted = new Map<string, number>();
 
   return {
     tables,
@@ -69,7 +99,7 @@ function memoryStore(
         .filter(row => row.user_id === userId)
         .slice(0, limit)
         .map(row => row.id);
-      calls.push({ verb: 'select', table, rows: ids.length });
+      calls.push({ verb: 'select', table, ids });
       return ids;
     },
     async linkedTransferIds(userId, limit) {
@@ -77,23 +107,23 @@ function memoryStore(
         .filter(row => row.user_id === userId && row.linked)
         .slice(0, limit)
         .map(row => row.id);
-      calls.push({ verb: 'select-linked', table: 'transactions', rows: ids.length });
+      calls.push({ verb: 'select-linked', table: 'transactions', ids });
       return ids;
     },
     async unlinkTransfers(ids) {
-      calls.push({ verb: 'unlink', table: 'transactions', rows: ids.length });
+      calls.push({ verb: 'unlink', table: 'transactions', ids });
       const set = new Set(ids);
       for (const row of tables.get('transactions') ?? []) {
         if (set.has(row.id)) row.linked = false;
       }
     },
     async deleteByIds(table, ids) {
-      const seen = (deletesSeen.get(table) ?? 0) + 1;
-      deletesSeen.set(table, seen);
-      if (options.failDelete && options.failDelete.table === table && options.failDelete.onCall === seen) {
+      const gone = rowsDeleted.get(table) ?? 0;
+      if (options.failDelete?.table === table && gone >= options.failDelete.afterRows) {
         throw new Error(options.failDelete.message);
       }
-      calls.push({ verb: 'delete', table, rows: ids.length });
+      rowsDeleted.set(table, gone + ids.length);
+      calls.push({ verb: 'delete', table, ids });
       const set = new Set(ids);
       tables.set(table, (tables.get(table) ?? []).filter(row => !set.has(row.id)));
     },
@@ -105,10 +135,15 @@ describe('the wipe — chunking', () => {
     // The failure: DELETE FROM transactions WHERE user_id = … over 51k rows.
     const store = memoryStore({ transactions: 5_000 });
 
-    await runWipe(store, 'u-1', { chunkSize: 2_000 });
+    await runWipe(store, 'u-1', { chunkSize: 2_000, idsPerRequest: 500 });
 
+    // The chunk is what the SELECT pages at — the statement-sized unit.
+    const selects = store.calls.filter(call => call.verb === 'select' && call.table === 'transactions');
+    expect(selects.map(call => call.ids.length)).toEqual([2_000, 2_000, 1_000, 0]);
+
+    // The batch is what a request carries. Ten of them, covering the 5,000.
     const deletes = store.calls.filter(call => call.verb === 'delete' && call.table === 'transactions');
-    expect(deletes.map(call => call.rows)).toEqual([2_000, 2_000, 1_000]);
+    expect(deletes.map(call => call.ids.length)).toEqual(Array.from({ length: 10 }, () => 500));
     expect(store.tables.get('transactions')).toEqual([]);
   });
 
@@ -171,10 +206,94 @@ describe('the wipe — the order the database demands', () => {
   it('chunks the transfer-unlink pass too — it touched 13,000 rows for real', async () => {
     const store = memoryStore({ transactions: 5_000 }, { linkedTransfers: 5_000 });
 
-    await runWipe(store, 'u-1', { chunkSize: 2_000 });
+    await runWipe(store, 'u-1', { chunkSize: 2_000, idsPerRequest: 1_000 });
+
+    const selected = store.calls.filter(call => call.verb === 'select-linked');
+    expect(selected.map(call => call.ids.length)).toEqual([2_000, 2_000, 1_000, 0]);
 
     const unlinks = store.calls.filter(call => call.verb === 'unlink');
-    expect(unlinks.map(call => call.rows)).toEqual([2_000, 2_000, 1_000]);
+    expect(unlinks.map(call => call.ids.length)).toEqual([1_000, 1_000, 1_000, 1_000, 1_000]);
+  });
+});
+
+describe('the wipe — the request the edge refused', () => {
+  /**
+   * The URL supabase-js builds for `.in('id', ids)`, byte for byte:
+   * PostgrestFilterBuilder appends `in.(a,b,c)` to the query string, and
+   * URLSearchParams percent-encodes the brackets and every comma. Reproduced
+   * here rather than asserted against a mocked client, because the length of
+   * this string IS the bug — a store that returned 400 would be a test of the
+   * store's error handling, not of the thing that made the edge send one.
+   */
+  function requestUrlBytes(table: string, ids: readonly string[]): number {
+    const url = new URL(`https://abcdefghijklmnopqrst.supabase.co/rest/v1/${table}`);
+    url.searchParams.append('id', `in.(${ids.join(',')})`);
+    return url.toString().length;
+  }
+
+  /** What the proxies in front of PostgREST allow a request line to be. */
+  const REQUEST_LINE_LIMIT = 8_192;
+
+  it('measures the failure: a whole chunk of uuids is a 78 KB request line', () => {
+    const chunk = Array.from({ length: WIPE_CHUNK_SIZE }, (_, n) => uuidLike(n));
+
+    expect(requestUrlBytes('transactions', chunk)).toBeGreaterThan(70_000);
+    // …and the batch that ships measures 5,921, which is inside the limit with
+    // room for a longer project host and a longer table name. "Comfortably" is
+    // the whole reason the number is 150 and not the 200 that also fits.
+    expect(requestUrlBytes('transactions', chunk.slice(0, WIPE_REQUEST_IDS)))
+      .toBeLessThan(6_500);
+  });
+
+  it('hands no delete more ids than one URL can carry, on shipping defaults', async () => {
+    // Over one full chunk, so the batching has to happen inside a chunk and
+    // again for the remainder — the arithmetic the 51,343-row account hit.
+    const store = memoryStore(
+      { transactions: 2_500, transaction_splits: 400, accounts: 12 },
+      { uuidIds: true }
+    );
+
+    await runWipe(store, 'u-1');
+
+    const deletes = store.calls.filter(call => call.verb === 'delete');
+    expect(deletes.length).toBeGreaterThanOrEqual(Math.ceil(2_500 / WIPE_REQUEST_IDS));
+    for (const call of deletes) {
+      expect(call.ids.length).toBeLessThanOrEqual(WIPE_REQUEST_IDS);
+      expect(requestUrlBytes(call.table, call.ids)).toBeLessThan(REQUEST_LINE_LIMIT);
+    }
+    // Batched, and still complete: the limit is on the request, not the wipe.
+    for (const table of WIPE_TABLE_ORDER) {
+      expect(store.tables.get(table)).toEqual([]);
+    }
+  });
+
+  it('holds for the unlink pass too — it sends the same kind of id list', async () => {
+    const store = memoryStore({ transactions: 2_500 }, { uuidIds: true, linkedTransfers: 2_500 });
+
+    await runWipe(store, 'u-1');
+
+    const unlinks = store.calls.filter(call => call.verb === 'unlink');
+    expect(unlinks.length).toBeGreaterThanOrEqual(Math.ceil(2_500 / WIPE_REQUEST_IDS));
+    for (const call of unlinks) {
+      expect(call.ids.length).toBeLessThanOrEqual(WIPE_REQUEST_IDS);
+      expect(requestUrlBytes('transactions', call.ids)).toBeLessThan(REQUEST_LINE_LIMIT);
+    }
+    expect(unlinks.reduce((sum, call) => sum + call.ids.length, 0)).toBe(2_500);
+  });
+
+  it('batches without losing or repeating an id', async () => {
+    // The one way sub-batching could break the loop's termination proof: a
+    // batch that does not cover its chunk leaves rows the next read returns
+    // forever. Every id selected must be written exactly once.
+    const store = memoryStore({ transactions: 2_500 }, { uuidIds: true });
+
+    await runWipe(store, 'u-1');
+
+    const written = store.calls
+      .filter(call => call.verb === 'delete' && call.table === 'transactions')
+      .flatMap(call => call.ids);
+    expect(written).toHaveLength(2_500);
+    expect(new Set(written).size).toBe(2_500);
   });
 });
 
@@ -185,9 +304,15 @@ describe('the wipe — progress', () => {
 
     await runWipe(store, 'u-1', { chunkSize: 2_000, onProgress: p => seen.push(p) });
 
+    // Once per chunk, NOT once per request. Emptying these 3,000 rows takes
+    // twenty requests at the shipping batch size; twenty events would say
+    // nothing the three say, and the count each one carries is of rows actually
+    // gone either way.
     const transactions = seen.filter(p => p.table === 'transactions');
     expect(transactions.map(p => p.deleted)).toEqual([0, 2_000, 3_000]);
     expect(transactions.every(p => p.total === 3_000)).toBe(true);
+    const deletes = store.calls.filter(call => call.verb === 'delete' && call.table === 'transactions');
+    expect(deletes.length).toBeGreaterThan(transactions.length);
 
     // Every step announces itself, including the ones with nothing to do — a
     // step that stays silent reads as a step that hung.
@@ -215,24 +340,41 @@ describe('the wipe — failure part-way through', () => {
   it('names the table it stopped on and keeps the database\'s own message', async () => {
     const store = memoryStore(
       { transactions: 6_000 },
-      { failDelete: { table: 'transactions', onCall: 2, message: 'canceling statement due to statement timeout' } }
+      { failDelete: { table: 'transactions', afterRows: 2_000, message: 'canceling statement due to statement timeout' } }
     );
 
     await expect(runWipe(store, 'u-1', { chunkSize: 2_000 }))
       .rejects.toThrow(/Failed while clearing transactions: canceling statement due to statement timeout/);
   });
 
+  it('names the table for the 400 as well — the message the edge sends is the one the user sees', async () => {
+    // The second failure: no statement ran, the request was too long to send.
+    const store = memoryStore(
+      { transactions: 6_000 },
+      { failDelete: { table: 'transactions', afterRows: 0, message: 'Bad Request' } }
+    );
+
+    await expect(runWipe(store, 'u-1'))
+      .rejects.toThrow(/Failed while clearing transactions: Bad Request/);
+  });
+
   it('leaves a state the same call can finish — deleting what has already gone is a no-op', async () => {
     const failing = memoryStore(
       { transaction_splits: 10, transactions: 6_000, accounts: 1 },
-      { failDelete: { table: 'transactions', onCall: 2, message: 'canceling statement due to statement timeout' } }
+      { failDelete: { table: 'transactions', afterRows: 2_000, message: 'canceling statement due to statement timeout' } }
     );
 
     await expect(runWipe(failing, 'u-1', { chunkSize: 2_000 })).rejects.toThrow();
 
-    // Part-way: the splits went, 2,000 transactions went, the rest are there.
+    // Part-way, and part-way is the point: the splits went, some thousands of
+    // transactions went, the rest are still there, nothing after them started.
+    // Batching a chunk across requests does not change that — it only changes
+    // where inside a chunk the stopping happens, so this asserts the shape
+    // rather than a row count that would be pinning the batch size.
     expect(failing.tables.get('transaction_splits')).toEqual([]);
-    expect(failing.tables.get('transactions')).toHaveLength(4_000);
+    const left = failing.tables.get('transactions') ?? [];
+    expect(left.length).toBeGreaterThan(0);
+    expect(left.length).toBeLessThan(6_000);
     expect(failing.tables.get('accounts')).toHaveLength(1);
 
     // Run it again — the recovery the dialog tells the user about — against the

--- a/src/services/preferencesService.test.ts
+++ b/src/services/preferencesService.test.ts
@@ -298,6 +298,45 @@ describe('write-through', () => {
     expect(store.row?.values.reportsAccountFilterIds).toBeUndefined();
   });
 
+  /**
+   * A preference the document never held is still a preference the BROWSER
+   * holds, and `getItem` reads the browser for anything the document is missing
+   * until the account's row lands. So a removal that skipped the mirror did not
+   * remove anything — it hid the key for this session and handed it back on the
+   * next boot.
+   *
+   * The dashboard's period pins are where this drew blood. Releasing a pinned
+   * card removes the five keys it owns, and the pin FLAG is removed last; when
+   * the flag was in the browser but not in this session's document — a boot
+   * that read before `attach` resolved, an offline boot, a session whose writes
+   * never reached the server — the four keys carrying the WINDOW went and the
+   * flag stayed. The card came back declaring itself pinned with no window to
+   * be pinned to, which renders as a pin that changes nothing.
+   */
+  it('removes a preference the browser holds but the document never did', async () => {
+    const browser = mirror({ 'dashboardReports.pin.net-worthPinned': 'true' });
+    const store = transport({ version: 1, values: {} });
+    const service = new PreferencesService({ mirror: browser, transport: store, ...immediate });
+    await service.attach('user-1');
+
+    service.removeItem('dashboardReports.pin.net-worthPinned');
+
+    expect(browser.values['dashboardReports.pin.net-worthPinned']).toBeUndefined();
+    expect(service.getItem('dashboardReports.pin.net-worthPinned')).toBeNull();
+  });
+
+  /** …and the same before the row has landed, where the mirror IS the store. */
+  it('removes a browser-only preference before the account has spoken', () => {
+    const browser = mirror({ 'dashboardReports.pin.net-worthPinned': 'true' });
+    const service = new PreferencesService({ mirror: browser, transport: null });
+
+    expect(service.getItem('dashboardReports.pin.net-worthPinned')).toBe('true');
+    service.removeItem('dashboardReports.pin.net-worthPinned');
+
+    expect(service.getItem('dashboardReports.pin.net-worthPinned')).toBeNull();
+    expect(browser.values['dashboardReports.pin.net-worthPinned']).toBeUndefined();
+  });
+
   it('does not write at all before a user is attached', async () => {
     const store = transport(null);
     const service = new PreferencesService({ mirror: mirror(), transport: store, ...immediate });

--- a/src/services/preferencesService.ts
+++ b/src/services/preferencesService.ts
@@ -174,6 +174,10 @@ export const PORTABLE_PREFERENCE_KEYS: readonly string[] = [
   'accountsCollapsedGroups',
 
   // ── Reconciliation ───────────────────────────────────────────────────────
+  'reconciliationGroupBy.v2',
+  // The pre-toggle key, when banding this list was one choice rather than two
+  // switches. Still carried so an existing view survives the upgrade — it is
+  // read once, by the migration in `reconciliationGrouping`.
   'reconciliationGroupBy',
   'reconciliationSortMode',
   'reconciliationOnlyAttention',
@@ -462,15 +466,30 @@ export class PreferencesService implements PreferenceStorage {
   }
 
   removeItem(key: string): void {
-    if (!(key in this.document.values)) return;
-    const values = { ...this.document.values };
-    delete values[key];
-    this.document = { ...this.document, values };
+    // The MIRROR is cleared whether or not the document held this key, and that
+    // asymmetry with the early return below is the whole point.
+    //
+    // `getItem` above reads the mirror for any key the document does not hold,
+    // right up until the account's row lands — so a key left behind here is not
+    // dormant, it is live, and it comes back on the next boot as a setting the
+    // user already switched off. The dashboard's period pins are where that bit:
+    // a released card removes its five keys, the four that carry the WINDOW are
+    // in the document and go, and the fifth — the pin flag, removed last — is
+    // mirror-only whenever this session's document did not happen to hold it
+    // (a boot that read before `attach` resolved, an offline boot, a session
+    // whose writes never reached the server). What survives is a pin flag with
+    // no window beside it: the card comes back declaring itself pinned with
+    // nothing to be pinned to. See hooks/useCardPeriod.
     try {
       this.mirror?.removeItem(key);
     } catch {
       // Unwritable storage costs the mirror, never the in-memory truth.
     }
+    // Nothing to forget in the document, so nothing to write back or announce.
+    if (!(key in this.document.values)) return;
+    const values = { ...this.document.values };
+    delete values[key];
+    this.document = { ...this.document, values };
     this.scheduleWrite();
     this.notify();
   }


### PR DESCRIPTION
Every one of these came from the owner opening the app and using it with real data. None was visible to 6,000 passing tests — so each commit ships the test that would have caught it.

## 1. Delete All Data → "Bad Request"
Reproduced on a 51,343-transaction account (it had already hit a second user). PostgREST puts an `in` list in the **query string**: 2,000 ids encoded to **78,071 bytes** of request line, refused by the edge with a bare 400 before Postgres saw a statement. Deletes and unlinks now sub-batch at 150 ids (5,921 bytes against the 8,192 limit); outer paging and the documented termination proof are intact. The regression test reconstructs the URL byte-for-byte and asserts its length — reverting the batching fails it five ways.

## 2. Accounts: "two colours in the border, and the left edge disappears"
Two independent defects, both measured. The selected skin named no border **colour**, so Tailwind's preflight `#e5e7eb` painted three sides beside the navy ring (in dark mode: a light-mode near-white on a dark card). And the scroll region's `overflow-y: auto` clips the *horizontal* axis too, eating the ring's 1px outside stroke — proven by fattening the ring to 8px and watching only the left side get sliced. Riding along: the last row of each band drew a divider in dark mode only, because `dark:` and `last:` set the same property at equal specificity and emission order decided the winner; `dark:last:` wins on specificity instead (verified in the built CSS after a live-DOM measurement proved unreliable).

## 3. Reconciliation: Group by was either/or while looking like Accounts'
Accounts drives the shared `accountGrouping` module (two independent switches that nest); Reconciliation held its own `useState<'type'|'institution'>` behind identical-looking controls. The local copy is gone; one rule now serves both pages. The column-label strip travels with its **row group**, so nested sub-bands can't end up unlabelled. Separate stored preference per page, deliberately — a portfolio read and a worklist are different questions. Sub-bands show label + count but **no total**: this list renders each row in its own currency, and summing them would fabricate a figure.

## 4. Dashboard pins declared "pinned" and drew the page's clock
The pin is two facts — flag and window — written together but read back under different trust rules, so the window silently fell back to the page's. Beneath it, `preferencesService.removeItem` early-returned without clearing the browser mirror that `getItem` still reads, so releasing a pin removed the window keys and **left the flag**, manufacturing the disagreement. That is why it reproduced on desktop and cloud but not in a signed-out demo session. Both fixed. The old suite hand-wired pin and picker as agreeing literals and mocked the widgets out entirely; the new test drives the real hook into the real widget and asserts what the chart **drew**.

Verification on the combined tree: lint · typecheck:strict · **6,058 smoke tests** · desktop:verify PASS (cloud-free + ratchet).

🤖 Generated with [Claude Code](https://claude.com/claude-code)