### PR TITLE
fix: a preferences read that could destroy your row, one focus stroke, and visible row actions

### DIFF
--- a/src/components/AccountRowColumns.tsx
+++ b/src/components/AccountRowColumns.tsx
@@ -82,7 +82,24 @@ export const ACCOUNT_ROW_COLUMNS_CLASS =
  */
 export const ACCOUNT_ROW_SELECTED_CLASS =
   'relative z-10 bg-blue-50/80 dark:bg-blue-900/30 border-transparent ' +
-  'ring-1 ring-[#6B86B3]/50 dark:ring-[#6B86B3]/70 ' +
+  // ─ ONE STROKE WHEN THE KEYBOARD IS DRIVING ─────────────────────────────────
+  // `focus-visible:ring-0` because otherwise an arrowed-to row wears TWO
+  // concentric strokes: this selection ring, and — 2px further out — the
+  // app-wide `*:focus-visible { outline: 2px solid var(--focus-ring-color) }`
+  // in accessibility-colors.css, which carries `!important` and so cannot be
+  // turned off by the row's own `focus:outline-none`. Light mode resolves that
+  // variable to the brand navy, which is why it read as "a blue and a black
+  // double border". Clicking never showed it, because a click does not match
+  // :focus-visible — so the same row looked clean by mouse and doubled by
+  // keyboard.
+  //
+  // The FOCUS outline is the one kept, deliberately: it is the app's single
+  // focus indicator, it is what every other control uses, and it is the stroke
+  // with a contrast obligation (WCAG 2.4.11). The selection ring stands down
+  // while the row holds focus and comes back the moment focus leaves — and the
+  // blue wash and the lift never go anywhere, so a selected row still reads as
+  // selected either way.
+  'ring-1 ring-[#6B86B3]/50 dark:ring-[#6B86B3]/70 focus-visible:ring-0 ' +
   'shadow-[0_4px_6px_-1px_rgba(0,0,0,0.1),0_10px_15px_-3px_rgba(0,0,0,0.1)] ' +
   'dark:shadow-[0_4px_6px_-1px_rgba(0,0,0,0.3),0_10px_15px_-3px_rgba(0,0,0,0.3)]';
 

--- a/src/components/reconciliation/ReconciliationAccountList.tsx
+++ b/src/components/reconciliation/ReconciliationAccountList.tsx
@@ -291,7 +291,22 @@ export default function ReconciliationAccountList({
                       rows below it carry three right-aligned figure columns that
                       run in a straight rail down the whole page, and indenting
                       the band would bend that rail out of true for every account
-                      that happened to have an institution. */}
+                      that happened to have an institution.
+
+                      A COUNT AND NO TOTAL, BY DECISION — not for want of a
+                      converter. The Accounts page's group headings DO carry a
+                      converted total (design ruling C), and the machinery to
+                      convert one is a hook away, so the asymmetry looks like an
+                      omission and is not. Ruling, 2026-08-13: "a total is
+                      earned by a question, not by the availability of numbers."
+                      Net worth is a question people ask in one currency — what
+                      am I worth — while a summed balance across an
+                      institution's accounts answers nothing anyone came to this
+                      page for. This page has one job: how much work is left,
+                      and where. The count IS the total here; a money figure
+                      beside it would be a second, louder number that no reader
+                      acts on. Apply that test before reaching for consistency
+                      with the Accounts page. */}
                   <p className="mb-2 flex items-baseline gap-2 border-b border-line dark:border-gray-700 pb-1.5 text-label uppercase font-semibold text-gray-500 dark:text-gray-400">
                     <span className="truncate">{sub.title}</span>
                     <span className="shrink-0 font-normal normal-case tracking-normal text-gray-400 dark:text-gray-500">

--- a/src/pages/Accounts.tsx
+++ b/src/pages/Accounts.tsx
@@ -949,44 +949,55 @@ export default function Accounts() {
     };
   };
 
-  /** The look of a row that is selected, or the one it has when it is not. */
+  /**
+   * The look of a row that is selected, or the one it has when it is not.
+   *
+   * ─ NEITHER SKIN DECLARES A FOCUS RING ──────────────────────────────────────
+   * Both used to carry `focus:outline-none focus-visible:ring-2
+   * focus-visible:ring-blue-500`, and that was a duplicate: every focusable
+   * element in the app already gets `outline: 2px solid var(--focus-ring-color)`
+   * from accessibility-colors.css, with `!important`, so the `outline-none`
+   * never took and the row drew ITS ring INSIDE that outline. Arrowing down a
+   * selected row therefore showed three strokes' worth of intent in two
+   * colours — the owner reported it as "a blue and a black double border" —
+   * while clicking the same row looked clean, because a click does not match
+   * :focus-visible. One focus indicator, app-wide, is the rule; a row does not
+   * get a private one.
+   */
   const rowSkin = (accountId: string, unselected: string): string =>
     selectedAccountId === accountId ? ACCOUNT_ROW_SELECTED_CLASS : unselected;
 
   /**
-   * A row's ROUTINE actions, out of the way until they are wanted.
+   * A row's routine actions — VISIBLE AT REST, on every row.
    *
-   * Twelve outlined icon boxes on a four-account screen is a wall of chrome in
-   * front of the figures the page exists to show, and the destructive one was
-   * drawn as loudly as the routine ones (DESIGN_PASS_2026-08 §3.3). They are
-   * revealed on hover or when anything in the row takes the focus.
+   * ─ WHY THIS DEPARTS FROM THE DESIGN PASS, DELIBERATELY ─────────────────────
+   * DESIGN_PASS_2026-08 §3.3 asked for two things about these buttons, and they
+   * are separable. The objection was "twelve outlined boxes on a four-account
+   * screen, and the destructive one is as loud as the routine ones" — a wall of
+   * chrome in front of the figures the page exists to show. The remedy had two
+   * halves: take the BOXES off, and reveal what is left on hover.
    *
-   * ─ WHY NOT display:none ────────────────────────────────────────────────────
-   * A hidden button is not reachable by Tab. These stay in the DOM and in the
-   * tab order at all times, at zero opacity; tabbing to one puts the focus
-   * inside the row, which is what `group-focus-within/row` is reading, so it
-   * fades in as it is reached. Nothing is removed from anybody — it is only
-   * quiet until it is asked for.
+   * The boxes are gone and stay gone: borderless glyphs in a neutral grey, the
+   * delete no louder than the rest until it is hovered. That is where nearly
+   * all of the noise was, and it is the half the owner liked on sight.
    *
-   * ─ WHY THE MEDIA QUERY ─────────────────────────────────────────────────────
-   * A touch screen has no hover. Gated on `hover: hover`, so where hovering is
-   * impossible the buttons never fade at all and a phone shows the row exactly
-   * as it always did. (Tailwind's own `hover:` is a plain `:hover` here —
-   * `hoverOnlyWhenSupported` is not enabled — so the query is written out.)
+   * The hover reveal is the half that came back off (owner's call, 2026-08-13,
+   * after living with it). A control nobody can see is a control most people
+   * never learn they have: hovering to discover what a row can do is a cost
+   * paid on every row by everyone who does not already know, and the
+   * touch-screen case had to be special-cased out of it precisely because the
+   * interaction does not exist there. Quiet and always present beats loud, but
+   * it also beats invisible — and P1's complaint was that the chrome was
+   * SHOUTING, not that it existed. Told to the design author as a notice, in
+   * the same spirit as the period-pin amendment.
    *
-   * ─ WHY ONE RULE AND NOT TWO ────────────────────────────────────────────────
-   * The obvious spelling is "hide, then reveal on hover/focus": an `opacity-0`
-   * plus `group-hover/row:opacity-100`. It was measured in the browser and it
-   * does NOT work here — the reveal is the more specific selector of the two
-   * and still loses to the hider, so a keyboard user tabbed to a control that
-   * stayed invisible. Rather than escalate a cascade fight nobody can read
-   * later, the hidden state is expressed as the only declaration: opacity is
-   * left alone (1) and zeroed ONLY while the row is neither hovered nor holding
-   * the focus. One rule, nothing to outrank, and the keyboard case falls out of
-   * it for free.
+   * If this ever goes back the other way, the thing to keep is what the old
+   * implementation got right: never `display: none`. A hidden button is not
+   * reachable by Tab, so these were kept in the DOM and in the tab order at
+   * zero opacity, and the touch case was gated on `hover: hover` because a
+   * phone can never satisfy the reveal.
    */
-  const ROW_ACTION_REVEAL_CLASS =
-    'transition-opacity duration-state [@media(hover:hover)]:group-[:not(:hover):not(:focus-within)]/row:opacity-0';
+  const ROW_ACTION_REVEAL_CLASS = 'transition-opacity duration-state';
 
   /**
    * "Agree this account with the bank" — the same control for every row.
@@ -1054,7 +1065,7 @@ export default function Accounts() {
                     // row drew the divider AND Tailwind's default #e5e7eb on the
                     // other three sides underneath the ring: the two-tone border
                     // this comment exists to keep from coming back.
-                    className={`group/row p-3 sm:p-4 rounded-2xl border transition-all duration-300 cursor-pointer select-none focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 ${rowSkin(
+                    className={`group/row p-3 sm:p-4 rounded-2xl border transition-all duration-300 cursor-pointer select-none ${rowSkin(
                       account.id,
                       // `dark:last:` as well as `last:`, and it is not
                       // belt-and-braces. Both `dark:border-b-gray-700` and

--- a/src/pages/Reconciliation.tsx
+++ b/src/pages/Reconciliation.tsx
@@ -3,7 +3,7 @@ import { useSearchParams, useNavigate } from 'react-router-dom';
 import { useApp } from '../contexts/AppContextSupabase';
 import { useToast } from '../contexts/ToastContext';
 import { ArrowLeftIcon, CheckCircleIcon } from '../components/icons';
-import { useReconciliation } from '../hooks/useReconciliation';
+import { useReconciliation, type ReconciliationSummary } from '../hooks/useReconciliation';
 import ReconciliationAccountList from '../components/reconciliation/ReconciliationAccountList';
 import {
   groupReconciliationSummaries,
@@ -22,6 +22,20 @@ import { todayIsoDay } from '../utils/statementBankBalance';
 import { toDecimal } from '../utils/decimal';
 import type { Transaction } from '../types';
 import { preferences } from '../services/preferencesService';
+
+/**
+ * Does this account still want work?
+ *
+ * ONE definition, because two numbers on this page are derived from it and
+ * they must be the same number: the count in the `Needs attention only (N)`
+ * control, and — since the filter runs before the banding — the counts in the
+ * band headings once it is on. They were two identical copies of this
+ * expression, which agreed today and would have drifted the first time
+ * somebody edited one of them (design ruling, 2026-08-13, which asked for the
+ * heading and the control to show the same number).
+ */
+const needsAttention = (s: ReconciliationSummary): boolean =>
+  s.unreconciledCount > 0 || (s.difference != null && s.difference !== 0);
 
 export default function Reconciliation() {
   const {
@@ -119,10 +133,7 @@ export default function Reconciliation() {
   // stated bank balance disagrees with the cleared balance. difference is
   // Decimal-computed, so a balanced account is exactly 0.
   const attentionCount = useMemo(
-    () =>
-      reconciliationDetails.filter(
-        s => s.unreconciledCount > 0 || (s.difference != null && s.difference !== 0)
-      ).length,
+    () => reconciliationDetails.filter(needsAttention).length,
     [reconciliationDetails]
   );
 
@@ -136,9 +147,7 @@ export default function Reconciliation() {
   // out on its own because the grouper omits empty bands.
   const accountGrouping = useMemo<ReconciliationGrouping>(() => {
     const visibleDetails = onlyAttention
-      ? reconciliationDetails.filter(
-          s => s.unreconciledCount > 0 || (s.difference != null && s.difference !== 0)
-        )
+      ? reconciliationDetails.filter(needsAttention)
       : reconciliationDetails;
 
     const sortSummaries = (list: typeof reconciliationDetails) => {

--- a/src/services/preferencesService.test.ts
+++ b/src/services/preferencesService.test.ts
@@ -200,6 +200,73 @@ describe('loading an existing row', () => {
 
     expect(service.getItem('accountsSortMode')).toBe('name');
   });
+
+  /**
+   * A BOOT THAT COULD NOT READ THE ROW MUST NEVER WRITE ONE.
+   *
+   * The read above fails and the session carries on, which is right: the mirror
+   * holds everything this machine had. What was wrong is what happened NEXT.
+   * `attach` returned from its catch without marking the load done and without
+   * forgetting the user, so `userId` was set and the in-memory document was
+   * still empty — and `scheduleWrite` only ever asked whether there was a user.
+   *
+   * So the first preference anything touched afterwards uploaded the whole
+   * in-memory document, which was that one key and nothing else, over a row
+   * holding the user's every stored choice. `PreferencesContext` writes its
+   * seven app-wide values 300ms after mount on EVERY boot, so "anything
+   * touched a preference" is not a rare event — it is every session.
+   *
+   * The keys that survive such a write are the ones some mount effect rewrites
+   * each boot; the ones that only ever get written when the user deliberately
+   * does something — a dashboard card pinned to its own window — are gone, and
+   * nothing brings them back. That is data loss with no error in front of it,
+   * which is why the assertion is on the WRITES and not on what `getItem` says.
+   */
+  it('never writes after a read it could not complete, so it cannot replace the row', async () => {
+    const browser = mirror({ accountsSortMode: 'name' });
+    const writes: PreferencesDocument[] = [];
+    const failing: PreferencesTransport = {
+      read: () => Promise.reject(new Error('offline')),
+      write: (_userId, document) => { writes.push(document); return Promise.resolve(); },
+    };
+    const service = new PreferencesService({ mirror: browser, transport: failing, ...immediate });
+
+    await service.attach('user-1');
+    // The card pin the owner just made, and the theme write every boot makes.
+    service.setItem('dashboardReports.pin.net-worthPinned', 'true');
+    service.setItem('money_management_theme', 'dark');
+    await service.flush();
+
+    expect(writes).toEqual([]);
+    // …and the session is unharmed: both still read back, from the mirror.
+    expect(service.getItem('dashboardReports.pin.net-worthPinned')).toBe('true');
+    expect(service.getItem('accountsSortMode')).toBe('name');
+  });
+
+  /** …and once a read DOES complete, the same session writes normally again. */
+  it('writes again after a later attach succeeds', async () => {
+    let failNext = true;
+    const store = transport({ version: 1, values: { accountsSortMode: 'name' } });
+    const flaky: PreferencesTransport = {
+      read: (userId) => (failNext
+        ? Promise.reject(new Error('offline'))
+        : store.read(userId)),
+      write: (userId, document) => store.write(userId, document),
+    };
+    const service = new PreferencesService({ mirror: mirror(), transport: flaky, ...immediate });
+
+    await service.attach('user-1');
+    failNext = false;
+    service.detach();
+    await service.attach('user-1');
+
+    service.setItem('dashboardReports.pin.net-worthPinned', 'true');
+    await service.flush();
+
+    expect(store.row?.values['dashboardReports.pin.net-worthPinned']).toBe('true');
+    // The row it could finally read is still underneath it.
+    expect(store.row?.values.accountsSortMode).toBe('name');
+  });
 });
 
 describe('write-through', () => {

--- a/src/services/preferencesService.ts
+++ b/src/services/preferencesService.ts
@@ -334,6 +334,17 @@ export class PreferencesService implements PreferenceStorage {
   /** Resolves when nothing is queued — the whole reason tests need not sleep. */
   private inFlight: Promise<void> = Promise.resolve();
   private loaded = false;
+  /**
+   * True when this session asked the store for the row and did not get an
+   * answer — as against `loaded`, which says an answer ARRIVED.
+   *
+   * The two are not opposites and the difference is the whole point. An
+   * unloaded session that never asked has nothing to lose by writing; one whose
+   * read FAILED is holding an empty document that means *"I don't know"*, and a
+   * write would publish that ignorance over a row it never saw. See
+   * {@link PreferencesService.scheduleWrite}.
+   */
+  private readFailed = false;
 
   constructor(options: PreferencesServiceOptions = {}) {
     this.injectedMirror = options.mirror;
@@ -537,6 +548,7 @@ export class PreferencesService implements PreferenceStorage {
   async attach(userId: string): Promise<void> {
     if (this.userId === userId && this.loaded) return;
     this.userId = userId;
+    this.readFailed = false;
 
     const transport = this.resolveTransport();
     if (!transport) {
@@ -553,7 +565,21 @@ export class PreferencesService implements PreferenceStorage {
       // so does an offline boot. Both are survivable: the browser mirror holds
       // exactly what this machine held before, which is where every one of
       // these settings lived until today.
-      preferencesLogger.warn('Could not read stored preferences; using this browser\'s copy', error);
+      //
+      // What this session may NOT do is write. It is holding an empty document
+      // and a set user id, and `write` uploads the document WHOLE — so the
+      // first preference anything touched afterwards replaced the user's entire
+      // stored row with the one or two keys this session happened to set. That
+      // is silent data loss, and it falls hardest on preferences written only
+      // when the user deliberately does something (a dashboard card pinned to
+      // its own window): everything a mount effect rewrites each boot comes
+      // back, and those do not. This session stays local; the next boot retries
+      // the read and writes normally once it has an answer.
+      this.readFailed = true;
+      preferencesLogger.warn(
+        'Could not read your stored preferences, so changes made now will stay on this device until the next reload',
+        error
+      );
       return;
     }
 
@@ -597,6 +623,7 @@ export class PreferencesService implements PreferenceStorage {
     this.cancelPendingWrite();
     this.userId = null;
     this.loaded = false;
+    this.readFailed = false;
     this.document = { version: PREFERENCES_DOCUMENT_VERSION, values: {} };
     this.notify();
   }
@@ -611,7 +638,11 @@ export class PreferencesService implements PreferenceStorage {
   }
 
   private scheduleWrite(): void {
-    if (this.userId === null) return;
+    // No user, or a user whose row this session could not read. The second is
+    // the dangerous one: the document is empty because the read failed, not
+    // because the settings are, and `write` would publish it over the row. See
+    // `readFailed`.
+    if (this.userId === null || this.readFailed) return;
     this.cancelPendingWrite();
     this.pendingWrite = this.setTimeoutFn(() => {
       this.pendingWrite = undefined;


### PR DESCRIPTION
Four commits, all from the owner using the app.

## 1. A failed preferences read could destroy the row it could not read ⚠️
Chasing "the dashboard pins still don't work", the pin mechanism proved sound end to end — and this turned up underneath it. `attach()` returned from its catch without setting `loaded` **and without clearing `userId`**, so a failed read left an empty document with a user attached, while `scheduleWrite` only asked whether there was a user. The next `setItem` uploaded that near-empty document over everything.

Not a rare path: `PreferencesContext` writes seven app-wide values 300ms after every mount, from above `AppProvider`. It explains the owner's production row exactly — his theme, sort modes and page clock survive (rewritten automatically each boot) while **not one card pin** does. Anything a person deliberately sets was erased and never came back.

`readFailed` is now distinct from `loaded` — "I asked and got nothing" is not "an answer arrived" — and writes are withheld until a read succeeds. The test writes after a failed read and asserts the row is never replaced; it fails without the fix.

## 2. One focus stroke, not two
Arrowing onto a selected row drew two concentric strokes (light blue inside dark navy) while clicking the same row looked clean — a click doesn't match `:focus-visible`. The row carried its own `focus-visible:ring-2 ring-blue-500` **on top of** the app-wide `*:focus-visible { outline: … }` in accessibility-colors.css, whose `!important` meant the row's `outline-none` never took. Rows no longer declare a private focus indicator, and the selected skin stands its selection ring down while focused. Wash and lift are unchanged, so selection still reads in every state.

## 3. Row actions are visible at rest (departs from §3.3, deliberately)
DESIGN_PASS §3.3 asked for two things — take the **boxes** off, and reveal the rest on hover. The boxes are gone and stay gone (borderless grey glyphs, delete no louder until hovered): that was where nearly all the noise was. The hover-reveal is off, on the owner's call after living with it — a control nobody can see is one most people never learn they have, and the touch case had to be special-cased out of the reveal precisely because the interaction doesn't exist there. Told to the design author as a notice, like the period-pin amendment.

## 4. The reconciliation sub-band ruling, recorded
Design ruling 2026-08-13: sub-bands show a count and no total, by decision — "a total is earned by a question, not by the availability of numbers". Written where somebody would otherwise "fix" it. The ruling also asked that the band heading and the `Needs attention only (N)` control show the same number; they did, but via two byte-identical copies of the predicate that would have drifted on first edit. One definition now — the agreement is structural, not lucky.

Verification: lint · typecheck:strict · **6,075 smoke** · 511 page-suite tests · browser-verified (one stroke under keyboard nav; icons visible at rest).

🤖 Generated with [Claude Code](https://claude.com/claude-code)