### PR TITLE
fix: the reconciliation headline, the design findings, and two colours pointing the wrong way

### DIFF
--- a/src/components/AccountRowColumns.tsx
+++ b/src/components/AccountRowColumns.tsx
@@ -193,8 +193,8 @@ export function AccountBalanceCell({
 }
 
 /**
- * A count of outstanding work: quiet slate while there is some, blue when
- * there is none.
+ * A count of outstanding work: readable while there is some, quieter when
+ * there is none. Neither is a colour with a meaning.
  *
  * It wore amber until DESIGN_RULINGS_2026-08-12 (ruling A): amber marks the
  * CONTROL you should touch next — a single, clickable next action — and this
@@ -203,6 +203,17 @@ export function AccountBalanceCell({
  * that amber means "look here-ish", eroding the one signal the yellow thread
  * depends on. If the row should invite the work, the invitation belongs on
  * the row's reconcile control, which already exists.
+ *
+ * ─ AND THE ZERO STOPPED BEING THE LOUDEST THING ON THE ROW ─────────────────
+ * That de-ambering left an inversion behind, which is worth naming because it
+ * was introduced by fixing something else: the count WITH work went quiet
+ * slate while the ZERO kept the app's link blue, so a row with nothing to do
+ * shouted across the page and a row with thirty outstanding rows murmured.
+ * Colour marks what needs attention — ruling A's own argument — and a zero
+ * needs nothing. Neither state is coloured now; the one with work is simply
+ * legible and the one without recedes. (The same correction shipped on the
+ * reconciliation list as finding §1.4, where a settled row wore a link-blue
+ * pill for the ABSENCE of work.)
  *
  * A QUIET 0 RATHER THAN A BLANK, unlike the register's own counters, and the
  * difference is the surface rather than an inconsistency: this is a COLUMN, and
@@ -222,7 +233,7 @@ export function AccountCountCell({
       <p className={CELL_LABEL_CLASS}>{label}</p>
       <p
         className={`${CELL_FIGURE_CLASS} ${
-          count > 0 ? 'text-slate-600 dark:text-gray-300' : 'text-blue-600 dark:text-blue-400'
+          count > 0 ? 'text-slate-600 dark:text-gray-300' : 'text-gray-400 dark:text-gray-500'
         }`}
       >
         {count}

--- a/src/components/dashboard/ImprovedDashboard.tsx
+++ b/src/components/dashboard/ImprovedDashboard.tsx
@@ -51,6 +51,7 @@ import { computeIncomeExpense } from '../../utils/incomeExpense';
 import { computeAccountBalances } from '../../utils/accountBalances';
 import { buildAccountDistribution, type AccountDistributionEntry } from '../../utils/accountDistribution';
 import { groupAccountsBySection } from '../../utils/accountGrouping';
+import { buildCategoryNameLookup } from '../../utils/categoryNames';
 import { buildAttentionItems } from '../../utils/attentionItems';
 import { loadAutoSyncPrefs } from '../../utils/bankAutoSync';
 import { buildAccountBankLinks } from '../../hooks/accountBankLinks';
@@ -247,6 +248,7 @@ export function ImprovedDashboard() {
     // the budget's category REDUCES spend (refunds arrive as income-typed
     // rows, so there is deliberately no type filter — only transfers skip).
     const recentExpanded = expandSplitTransactions(recentTransactions, transactionSplits);
+    const categoryNameFor = buildCategoryNameLookup(categories);
     const budgetStatus = activeBudgets.map(budget => {
       const categoryTransactions = recentExpanded.filter(t =>
         t.category === budget.categoryId && t.type !== 'transfer'
@@ -261,6 +263,14 @@ export function ImprovedDashboard() {
 
       return {
         ...budget,
+        // The budget's own category, NAMED. It was rendering `categoryId`
+        // straight onto the screen — three raw UUIDs down the dashboard where
+        // "Food & Drink" belongs — which is precisely what
+        // `buildCategoryNameLookup` exists to prevent, in its own words: "a raw
+        // category id must never reach a screen." Resolved once here so the
+        // label, the group's aria-label and the progress bar's all say the same
+        // thing.
+        categoryName: categoryNameFor(budget.categoryId),
         spent,
         remaining,
         percentUsed,
@@ -283,7 +293,7 @@ export function ImprovedDashboard() {
       totalSpentOnBudgets,
       overallBudgetPercent
     };
-  }, [accounts, accountBalanceMap, transactions, transactionSplits, budgets]);
+  }, [accounts, accountBalanceMap, transactions, transactionSplits, budgets, categories]);
 
   // Performance figures for the SELECTED period. Income/expenses come from
   // CATEGORY SEMANTICS (utils/incomeExpense): a refund filed under an expense
@@ -744,10 +754,10 @@ export function ImprovedDashboard() {
           
           <div className="space-y-3">
             {metrics.budgetStatus.slice(0, 3).map(budget => (
-              <div key={budget.id} className="space-y-2" role="group" aria-label={`Budget for ${budget.categoryId}`}>
+              <div key={budget.id} className="space-y-2" role="group" aria-label={`Budget for ${budget.categoryName}`}>
                 <div className="flex items-center justify-between text-sm">
                   <span className="font-medium text-gray-700 dark:text-gray-300">
-                    {budget.categoryId}
+                    {budget.categoryName}
                   </span>
                   <span className={`font-medium ${
                     budget.isOverBudget ? 'text-red-600 dark:text-red-400' : 'text-gray-600 dark:text-gray-400'
@@ -761,7 +771,7 @@ export function ImprovedDashboard() {
                   aria-valuenow={Math.min(budget.percentUsed, 100)}
                   aria-valuemin={0}
                   aria-valuemax={100}
-                  aria-label={`${budget.categoryId} budget: ${Math.min(budget.percentUsed, 100).toFixed(0)}% used`}
+                  aria-label={`${budget.categoryName} budget: ${Math.min(budget.percentUsed, 100).toFixed(0)}% used`}
                 >
                   <div 
                     className={`h-full transition-all duration-300 ${

--- a/src/components/reconciliation/ReconciliationAccountList.tsx
+++ b/src/components/reconciliation/ReconciliationAccountList.tsx
@@ -1,6 +1,8 @@
 import React from 'react';
 import { Building2Icon, ChevronRightIcon } from '../icons';
 import { useCurrencyDecimal } from '../../hooks/useCurrencyDecimal';
+import EmptyState from '../EmptyState';
+import FilteredEmptyState from '../FilteredEmptyState';
 import type { ReconciliationSummary } from '../../hooks/useReconciliation';
 import type { ReconciliationGrouping } from './reconciliationGrouping';
 
@@ -12,6 +14,26 @@ interface ReconciliationAccountListProps {
    */
   grouping: ReconciliationGrouping;
   onSelectAccount: (accountId: string) => void;
+  /**
+   * The filter that is hiding rows, when one is on — and the way out of it.
+   *
+   * Present or absent is what decides which of the two empty states this list
+   * draws, and they are NOT the same state: an empty list with no filter means
+   * there is nothing here, while an empty list with a filter on means the rows
+   * exist and something is covering them. Conflating the two is the failure
+   * mode a shared component makes easy (design ruling 2026-08-12 §2, the gate
+   * condition on batch 7 pass 2), so the caller has to say which it is.
+   */
+  filter?: {
+    /** The filter's name, as the user set it. */
+    label: string;
+    /** Accounts that exist on this page and are currently hidden by it. */
+    hiddenCount: number;
+    /** Puts it away. */
+    onClear: () => void;
+  };
+  /** Where a user with no accounts at all goes to make one. */
+  onGoToAccounts?: () => void;
 }
 
 /**
@@ -60,12 +82,33 @@ const COLUMN_WIDTH = {
   difference: 'md:min-w-[100px]',
 } as const;
 
-/** "3 accounts" / "1 account" — a sub-band's count, spoken as well as seen. */
+/**
+ * The horizontal box metrics of a row — worn by the rows AND by the strip that
+ * heads them, for the same reason `COLUMN_WIDTH` is shared.
+ *
+ * Column WIDTHS were already shared; padding is the second alignment axis and
+ * was two literals that happened to agree (`px-5` over a `p-5` card). Un-nesting
+ * changed the row's padding, and a strip that kept the old number would have
+ * labelled columns 3px out of true down the whole page.
+ *
+ * The 3px left border is geometry, not decoration: it is on every row at every
+ * moment and only its COLOUR changes, so a row that gains the attention mark
+ * does not shove its own contents sideways relative to its neighbours. (The
+ * same trick the Accounts row plays with its 1px border.) The colour is
+ * supplied per state rather than defaulted here, because two `border-l-*`
+ * colour utilities in one class list are resolved by stylesheet order, not by
+ * the order they are written in — the transparent one could win.
+ */
+const ROW_INSET_CLASS = 'border-l-[3px] px-3 sm:px-4';
+
+/** "3 accounts" / "1 account" — a band's count, spoken as well as seen. */
 const countLabel = (n: number): string => `${n} ${n === 1 ? 'account' : 'accounts'}`;
 
 export default function ReconciliationAccountList({
   grouping,
   onSelectAccount,
+  filter,
+  onGoToAccounts,
 }: ReconciliationAccountListProps): React.JSX.Element {
   const { formatCurrency } = useCurrencyDecimal();
 
@@ -74,10 +117,43 @@ export default function ReconciliationAccountList({
       ? grouping.summaries.length
       : grouping.groups.reduce((n, g) => n + g.summaries.length, 0);
   if (total === 0) {
+    /**
+     * FILTERED-EMPTY IS NOT EMPTY (DESIGN_PASS §4).
+     *
+     * This page used to answer both with one centred block reading "No accounts
+     * to reconcile / All accounts are fully reconciled" — which is empty-state
+     * copy, asserts something nobody asked it to assert, and offers no way
+     * back. With `Needs attention only` on it was also the more alarming of the
+     * two readings: the accounts had not gone anywhere, they were behind a
+     * switch the user could not see from here.
+     */
+    if (filter && filter.hiddenCount > 0) {
+      return (
+        <div className="bg-white dark:bg-gray-800">
+          <FilteredEmptyState
+            // What is TRUE once the headline counts what the rows count: if no
+            // account needs attention then no listed account has an
+            // unreconciled row, so there is no second figure to report and the
+            // design's example sentence about transactions still outstanding
+            // would be a number this page can no longer produce.
+            title="Nothing needs attention right now"
+            hiddenCount={filter.hiddenCount}
+            scope="accounts"
+            filters={[filter.label]}
+            clearLabel="Show all accounts"
+            onClear={filter.onClear}
+          />
+        </div>
+      );
+    }
+
     return (
-      <div className="text-center py-12 text-gray-500 dark:text-gray-400">
-        <p className="text-lg font-medium">No accounts to reconcile</p>
-        <p className="text-sm mt-1">All accounts are fully reconciled</p>
+      <div className="bg-white dark:bg-gray-800">
+        <EmptyState
+          title="No accounts to reconcile"
+          description="Reconciliation works from your open accounts, and there are none here. A closed account keeps its history but has no statement left to agree, so it is never listed on this page."
+          action={onGoToAccounts ? { label: 'Go to accounts', onClick: onGoToAccounts, icon: null } : undefined}
+        />
       </div>
     );
   }
@@ -117,7 +193,7 @@ export default function ReconciliationAccountList({
         // exactly one per run of rows at every nesting level — the invariant
         // this helper exists to hold.
         data-testid="reconciliation-column-labels"
-        className="hidden md:flex w-full items-center gap-4 border-2 border-transparent px-5 pb-1"
+        className={`hidden md:flex w-full items-center gap-4 border-l-transparent pb-1 ${ROW_INSET_CLASS}`}
       >
         <div className="flex-1" />
         <p className={`${STRIP_LABEL_CLASS} ${COLUMN_WIDTH.bankBalance}`}>Bank Balance</p>
@@ -126,7 +202,13 @@ export default function ReconciliationAccountList({
         {/* The chevron's column, so the labels clear it. */}
         <div className="w-5 ml-2 flex-shrink-0" />
       </div>
-      <div className="grid gap-3">
+      {/* ROWS, NOT CARDS (DESIGN_PASS §3.3, ruled for Accounts and applied here
+          verbatim). Twenty-nine bordered, shadowed ~96px boxes made a list you
+          scroll out of a list you scan; per P4 a row is separated from the next
+          one by a hairline, and the group above it by weight and space. The
+          white is on the run of rows, so the band reads as one surface rather
+          than as twenty-nine floating ones. */}
+      <div className="bg-white dark:bg-gray-800">
         {summaries.map(({ account, unreconciledCount, bankBalance, accountBalance, difference }) => {
           const hasDifference = difference != null && Math.abs(difference) > 0.005;
 
@@ -135,16 +217,31 @@ export default function ReconciliationAccountList({
               key={account.id}
               type="button"
               onClick={() => onSelectAccount(account.id)}
-              className={`w-full text-left bg-white dark:bg-gray-800 rounded-xl border-2 transition-all hover:shadow-md ${
+              /* No focus ring of its own: the app-wide `outline` in
+                 accessibility-colors.css carries `!important`, and a private
+                 ring on top of it is what produced the double border the
+                 Accounts rows had to have removed. */
+              className={`w-full text-left bg-white dark:bg-gray-800 py-3 sm:py-4 border-b border-b-line dark:border-b-gray-700 last:border-b-transparent dark:last:border-b-transparent transition-colors duration-state ${ROW_INSET_CLASS} ${
                 hasDifference
-                  ? 'border-amber-400 dark:border-amber-500'
-                  : 'border-gray-200 dark:border-gray-700 hover:border-primary'
-              } p-4 md:p-5`}
+                  ? // THE ATTENTION SIGNAL, WITHOUT A CARD TO PUT IT ON.
+                    // It was a 2px amber ring around the whole box; a box is
+                    // exactly what the un-nesting removes, and a ring is the
+                    // one thing that cannot survive losing it. So the amber
+                    // becomes a mark down the row's leading edge — the same
+                    // idiom §3.4 reaches for when it asks the demo banner to
+                    // stop being a full-bleed gold bar and become a navy one
+                    // with a gold mark. It reads as a rail down the page at
+                    // the rows that need work, which is stronger at a glance
+                    // than 29 outlines of which a few were amber, and it
+                    // spends less amber, not more (P3).
+                    'border-l-amber-400 dark:border-l-amber-500 hover:bg-amber-50/40 dark:hover:bg-amber-900/10'
+                  : 'border-l-transparent hover:bg-surface-secondary dark:hover:bg-gray-700/40'
+              }`}
             >
               {/* w-full so the columns spread edge-to-edge and the icons
                   line up in a straight rail down the page */}
               {/* The min-widths below add up to 660px, which is what
-                  kept this card off the edge of a phone. They only apply
+                  kept this row off the edge of a phone. They only apply
                   from md up now; under that the row wraps. */}
               <div className="w-full flex flex-wrap items-end md:items-center gap-3 md:gap-4">
                 <div className="flex items-center gap-3 min-w-0 basis-full md:basis-auto md:min-w-[200px]">
@@ -171,11 +268,25 @@ export default function ReconciliationAccountList({
                       {unreconciledCount} unreconciled
                     </span>
                   ) : (
-                    // "Reconciled", not "cleared": this badge is the answer
-                    // to "is there anything left to do here?", and marks are
-                    // not an answer to that — only a finished reconciliation
-                    // is.
-                    <span className="inline-flex items-center px-2.5 py-1 rounded-full text-xs font-medium bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-400">
+                    // "Reconciled", not "cleared": this is the answer to "is
+                    // there anything left to do here?", and marks are not an
+                    // answer to that — only a finished reconciliation is.
+                    //
+                    // NO PILL, AND NO COLOUR. It wore a filled badge in the
+                    // app's LINK blue, on up to twenty-nine rows at once, for
+                    // the state that is the ABSENCE of work — which spent
+                    // blue on "row" and "figure" as well as "link", and gave
+                    // the unremarkable rows a shape as loud as the ones
+                    // asking for something. Colour on this page belongs to
+                    // the rows that need attention (P2), and the pill stays
+                    // with the state that carries a figure.
+                    //
+                    // The words stay, though, because the Difference column
+                    // cannot say this: on every account with no closing
+                    // balance entered that column reads "—", so delegating
+                    // the answer to it would leave the question unanswered on
+                    // exactly the rows this page exists for.
+                    <span className="inline-flex items-center py-1 text-xs font-medium text-gray-500 dark:text-gray-400">
                       All reconciled
                     </span>
                   )}
@@ -232,12 +343,19 @@ export default function ReconciliationAccountList({
                   {/* No second remedy here. The difference is missing for
                       exactly the reason the bank balance is, and the row
                       has already said what to do about it once. */}
-                  <p className={`text-sm font-bold tabular-nums ${
+                  {/* £0.00 IS NOT A LINK. It was set in the same blue the
+                      app's links wear, so a page carrying no links at all
+                      spent link-blue on its most repeated figure. A closed
+                      difference is the quiet confirmation that two numbers
+                      agree; weight and colour are held back for the one that
+                      does not (P4 — weight before boxes, and the register's
+                      own rule that weight says "this is the line"). */}
+                  <p className={`text-sm tabular-nums ${
                     difference == null
-                      ? 'text-gray-400 dark:text-gray-500'
+                      ? 'font-semibold text-gray-400 dark:text-gray-500'
                       : Math.abs(difference) < 0.005
-                      ? 'text-blue-600 dark:text-blue-400'
-                      : 'text-red-600 dark:text-red-400'
+                      ? 'font-semibold text-gray-500 dark:text-gray-400'
+                      : 'font-bold text-red-600 dark:text-red-400'
                   }`}>
                     {difference != null
                       ? formatCurrency(difference, account.currency)
@@ -265,10 +383,17 @@ export default function ReconciliationAccountList({
     <div className="space-y-6">
       {grouping.groups.map(group => (
         <section key={group.label}>
+          {/* THE COUNT NAMES ITS UNIT. This page puts two different units on
+              one screen — the headline counts TRANSACTIONS, a band counts
+              ACCOUNTS — and a bare "(29)" under a headline reading 2,447 left
+              the reader to work out that the two were not the same kind of
+              thing. Naming it costs one word and matches both the Accounts
+              page's bands and the label this band already announces to a
+              screen reader. */}
           <h2 className="text-sm font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-400 mb-2">
             {group.title}
             <span className="ml-2 font-normal normal-case text-gray-400 dark:text-gray-500">
-              ({group.summaries.length})
+              ({countLabel(group.summaries.length)})
             </span>
           </h2>
           {group.subGroups ? (
@@ -310,7 +435,7 @@ export default function ReconciliationAccountList({
                   <p className="mb-2 flex items-baseline gap-2 border-b border-line dark:border-gray-700 pb-1.5 text-label uppercase font-semibold text-gray-500 dark:text-gray-400">
                     <span className="truncate">{sub.title}</span>
                     <span className="shrink-0 font-normal normal-case tracking-normal text-gray-400 dark:text-gray-500">
-                      ({sub.summaries.length})
+                      ({countLabel(sub.summaries.length)})
                     </span>
                   </p>
                   {renderRowGroup(sub.summaries)}

--- a/src/components/reconciliation/__tests__/ReconciliationAccountList.test.tsx
+++ b/src/components/reconciliation/__tests__/ReconciliationAccountList.test.tsx
@@ -126,6 +126,105 @@ describe('ReconciliationAccountList — a missing figure names its remedy', () =
   });
 });
 
+/**
+ * THE ROWS ARE ROWS (DESIGN_PASS §3.3, ruled for Accounts and applied here).
+ *
+ * Twenty-nine bordered, shadowed cards; a link-blue badge on the state that is
+ * the absence of work; a link-blue £0.00. Everything below is the same claim
+ * from different angles: on this page colour and lift belong to the rows that
+ * need attention, and to nothing else.
+ */
+describe('ReconciliationAccountList — rows, not cards', () => {
+  const rowClasses = (name: string): string => rowFor(name).className;
+
+  it('separates rows with a hairline instead of boxing each one', () => {
+    renderList();
+    const classes = rowClasses('Second Account');
+
+    expect(classes).toContain('border-b-line');
+    // The card and its lift are gone: no rounded box, no shadow on hover.
+    expect(classes).not.toMatch(/rounded-(xl|2xl|lg)/);
+    expect(classes).not.toContain('shadow');
+    expect(classes).not.toContain('border-2');
+  });
+
+  it('marks the row that needs attention down its leading edge, in amber', () => {
+    renderList();
+    // 'Second Account' states £220.00 against a £250.00 balance — they disagree.
+    expect(rowClasses('Second Account')).toContain('border-l-amber-400');
+    // …and the row with no closing balance entered has nothing to disagree
+    // with, so it carries no mark.
+    expect(rowClasses('Everyday Account')).not.toContain('amber');
+    expect(rowClasses('Everyday Account')).toContain('border-l-transparent');
+  });
+
+  it('holds the mark\'s width open on every row so nothing shifts sideways', () => {
+    renderList();
+    // The 3px is geometry, present whatever the state; only the colour moves.
+    // Without this the marked rows would indent their own contents relative to
+    // their neighbours, and the column strip would label thin air.
+    expect(rowClasses('Everyday Account')).toContain('border-l-[3px]');
+    expect(rowClasses('Second Account')).toContain('border-l-[3px]');
+  });
+
+  it('keeps the label strip on the row\'s own horizontal metrics', () => {
+    renderList();
+    const strip = screen.getByTestId('reconciliation-column-labels');
+
+    // Shared constant, not two literals that happen to agree: a strip padded
+    // differently from its rows labels the wrong columns.
+    ['border-l-[3px]', 'px-3', 'sm:px-4'].forEach(utility => {
+      expect(strip.className).toContain(utility);
+      expect(rowClasses('Everyday Account')).toContain(utility);
+    });
+  });
+
+  it('spends no colour on the resting state', () => {
+    const reconciled: ReconciliationGrouping = {
+      mode: 'flat',
+      summaries: [{ ...summary('a5', 'Settled Account', 100, 100), unreconciledCount: 0 }],
+    };
+    renderGrouping(reconciled);
+    const badge = screen.getByText('All reconciled');
+
+    // It was `bg-blue-100 text-blue-700` — the app's LINK blue, on a thing that
+    // is not a link, on every unremarkable row at once.
+    expect(badge.className).not.toMatch(/blue|amber|green|red/);
+    // And no pill: the filled shape stays with the state that carries a figure.
+    expect(badge.className).not.toContain('rounded-full');
+    expect(badge.className).not.toMatch(/\bbg-/);
+  });
+
+  it('keeps the pill, and the count, where there IS work', () => {
+    renderList();
+    const badge = within(rowFor('Everyday Account')).getByText('3 unreconciled');
+
+    // Neutral since the de-amber pass, and still a chip — it holds a figure.
+    expect(badge.className).toContain('rounded-full');
+    expect(badge.className).not.toMatch(/amber|blue/);
+  });
+
+  it('stops printing a difference of zero in link blue', () => {
+    const settled: ReconciliationGrouping = {
+      mode: 'flat',
+      summaries: [summary('a6', 'Balanced Account', 100, 100)],
+    };
+    renderGrouping(settled);
+    const difference = within(rowFor('Balanced Account')).getByText('£0.00');
+
+    expect(difference.className).not.toContain('blue');
+  });
+
+  it('still colours the difference that disagrees', () => {
+    renderList();
+    // The one figure on the page that means something is wrong keeps its red,
+    // and its weight: colour is reserved for the rows that need attention.
+    const difference = within(rowFor('Second Account')).getByText('-£30.00');
+    expect(difference.className).toContain('text-red-600');
+    expect(difference.className).toContain('font-bold');
+  });
+});
+
 describe('ReconciliationAccountList — one label strip per group', () => {
   it('heads the group once instead of every row', () => {
     renderList();
@@ -215,7 +314,7 @@ describe('ReconciliationAccountList — both switches on', () => {
     // The type sections are still the outline: h2, as they were.
     const sections = screen.getAllByRole('heading', { level: 2 }).map(h => h.textContent);
     // The count sits in a span with a CSS margin, so textContent runs on.
-    expect(sections).toEqual(['Current Accounts(3)', 'Savings Accounts(1)']);
+    expect(sections).toEqual(['Current Accounts(3 accounts)', 'Savings Accounts(1 account)']);
 
     // The institutions are groups rather than headings, so the page's outline
     // stays section → account name. The same treatment the Accounts page gives
@@ -250,7 +349,7 @@ describe('ReconciliationAccountList — both switches on', () => {
     // that counted only the rows of its first sub-band would be a section
     // lying about its own size.
     expect(screen.getByRole('heading', { level: 2, name: /Current Accounts/ }).textContent)
-      .toContain('(3)');
+      .toContain('(3 accounts)');
   });
 });
 
@@ -277,7 +376,7 @@ describe('ReconciliationAccountList — one switch, and none', () => {
     });
 
     expect(screen.getAllByRole('heading', { level: 2 }).map(h => h.textContent)).toEqual([
-      'Invented Bank(1)',
+      'Invented Bank(1 account)',
     ]);
     expect(strips()).toHaveLength(1);
   });
@@ -299,10 +398,126 @@ describe('ReconciliationAccountList — one switch, and none', () => {
     expect(screen.getByRole('button', { name: /Rainy Day Account/ })).toBeInTheDocument();
   });
 
-  it('says so when the filters have left nothing to reconcile', () => {
+  it('says so when there is genuinely nothing to reconcile', () => {
     renderGrouping({ mode: 'flat', summaries: [] });
 
     expect(screen.getByText('No accounts to reconcile')).toBeInTheDocument();
     expect(screen.queryAllByTestId('reconciliation-column-labels')).toHaveLength(0);
+  });
+});
+
+/**
+ * FILTERED-EMPTY IS NOT EMPTY — the gate condition on batch 7 pass 2, said back
+ * in assertions: "for every surface wired, confirm the *filtered*-empty path is
+ * distinguishable from the empty path — conflating them is the failure mode,
+ * and a shared component makes it easy to wire only one."
+ *
+ * So these tests do not merely check that each path renders. They check the two
+ * paths render DIFFERENT things, from the same empty list, with the filter as
+ * the only difference between them.
+ */
+describe('ReconciliationAccountList — an empty list has two meanings', () => {
+  const filter = {
+    label: 'Needs attention only',
+    hiddenCount: 29,
+    onClear: vi.fn(),
+  };
+
+  it('names the filter, the accounts it is hiding, and the way out', () => {
+    render(
+      <PreferencesProvider>
+        <ReconciliationAccountList
+          grouping={{ mode: 'flat', summaries: [] }}
+          onSelectAccount={vi.fn()}
+          filter={filter}
+        />
+      </PreferencesProvider>
+    );
+
+    expect(screen.getByText('Nothing needs attention right now')).toBeInTheDocument();
+    // The two facts that turn "my accounts are gone" back into "my accounts are
+    // hidden": how many, and what by.
+    expect(document.body.textContent).toContain('29 accounts are hidden by');
+    expect(screen.getByText('Needs attention only')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Show all accounts' })).toBeInTheDocument();
+  });
+
+  it('gives the remedy back to the caller', () => {
+    const onClear = vi.fn();
+    render(
+      <PreferencesProvider>
+        <ReconciliationAccountList
+          grouping={{ mode: 'flat', summaries: [] }}
+          onSelectAccount={vi.fn()}
+          filter={{ ...filter, onClear }}
+        />
+      </PreferencesProvider>
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Show all accounts' }));
+    expect(onClear).toHaveBeenCalledTimes(1);
+  });
+
+  it('is not the same screen as the empty one — same empty list, different state', () => {
+    const { unmount } = render(
+      <PreferencesProvider>
+        <ReconciliationAccountList
+          grouping={{ mode: 'flat', summaries: [] }}
+          onSelectAccount={vi.fn()}
+          filter={filter}
+        />
+      </PreferencesProvider>
+    );
+    const filtered = document.body.textContent ?? '';
+    unmount();
+
+    renderGrouping({ mode: 'flat', summaries: [] });
+    const empty = document.body.textContent ?? '';
+
+    // Distinguishable without reading carefully: different headline, and only
+    // one of them claims there is nothing here.
+    expect(filtered).not.toBe(empty);
+    expect(filtered).toContain('Nothing needs attention right now');
+    expect(filtered).not.toContain('No accounts to reconcile');
+    expect(empty).toContain('No accounts to reconcile');
+    expect(empty).not.toContain('hidden by');
+  });
+
+  it('calls an empty list empty when the filter is hiding nothing', () => {
+    // A filter that is on over no accounts at all has not hidden anything, and
+    // blaming it would send the user to press "Show all accounts" and find the
+    // same blank list.
+    render(
+      <PreferencesProvider>
+        <ReconciliationAccountList
+          grouping={{ mode: 'flat', summaries: [] }}
+          onSelectAccount={vi.fn()}
+          filter={{ ...filter, hiddenCount: 0 }}
+        />
+      </PreferencesProvider>
+    );
+
+    expect(screen.getByText('No accounts to reconcile')).toBeInTheDocument();
+    expect(screen.queryByText('Nothing needs attention right now')).not.toBeInTheDocument();
+  });
+
+  it('is left-aligned in both states, never centred', () => {
+    // DESIGN_PASS §4: a centred block with a picture is a greeting; this is a
+    // consequence and a remedy, and it reads down the left edge like the rest
+    // of the page.
+    const { unmount } = render(
+      <PreferencesProvider>
+        <ReconciliationAccountList
+          grouping={{ mode: 'flat', summaries: [] }}
+          onSelectAccount={vi.fn()}
+          filter={filter}
+        />
+      </PreferencesProvider>
+    );
+    expect(document.querySelector('.text-center')).toBeNull();
+    unmount();
+
+    renderGrouping({ mode: 'flat', summaries: [] });
+    expect(document.querySelector('.text-center')).toBeNull();
   });
 });

--- a/src/hooks/__tests__/useReconciliation.test.ts
+++ b/src/hooks/__tests__/useReconciliation.test.ts
@@ -245,6 +245,102 @@ describe('useReconciliation', () => {
     });
   });
 
+  /**
+   * THE HEADLINE AND THE ROWS COUNT THE SAME THING.
+   *
+   * The tests above this one all assert an absolute: "should be 3", worked out
+   * by hand from the fixture. Every one of them passed on the day the page
+   * displayed 2,447 over a screen of rows that each said "All reconciled",
+   * because not one of them put the two numbers in the same expression. That is
+   * the same failure mode as the pin bug — two facts written from different
+   * sources, read back under different trust rules, and a test suite that could
+   * not see the contradiction because nothing compared them.
+   *
+   * So this block asserts a RELATION rather than a value, and it holds whatever
+   * the fixture is: the headline is the sum of the per-row badges, always. A
+   * future edit that reaches for a different predicate on one side and not the
+   * other fails here, even if it keeps every absolute above green.
+   */
+  describe('the headline is the sum of the rows', () => {
+    /** What the page's own row badges add up to. */
+    const badgeTotal = (details: { unreconciledCount: number }[]): number =>
+      details.reduce((sum, d) => sum + d.unreconciledCount, 0);
+
+    it('agrees with the rows on the ordinary fixture', () => {
+      const { result } = renderHook(() =>
+        useReconciliation(mockAccounts, mockTransactions)
+      );
+
+      expect(result.current.totalUnreconciledCount)
+        .toBe(badgeTotal(result.current.reconciliationDetails));
+    });
+
+    it('still agrees when rows exist on accounts the page is not given', () => {
+      // The owner's book, in miniature: unreconciled rows sitting on an account
+      // this page never lists. Whatever the headline decides to do about them,
+      // it must decide the same thing the rows do — and the rows cannot show a
+      // badge for an account that is not there, so the headline cannot count
+      // one either.
+      const onAClosedAccount: Transaction = {
+        ...mockTransactions[0],
+        id: 'tx-closed',
+        accountId: 'closed-account',
+        cleared: false,
+      };
+
+      const { result } = renderHook(() =>
+        useReconciliation(mockAccounts, [...mockTransactions, onAClosedAccount])
+      );
+
+      expect(result.current.totalUnreconciledCount)
+        .toBe(badgeTotal(result.current.reconciliationDetails));
+    });
+
+    it('still agrees when a row is committed rather than merely marked', () => {
+      // `reconciled` is authoritative where it speaks and `cleared` answers
+      // where it does not (transactionReconciliation.ts). A headline that read
+      // one flag while the badges read the predicate would drift on exactly
+      // these rows and on no others.
+      const committed: Transaction = {
+        ...mockTransactions[0],
+        id: 'tx-committed',
+        cleared: true,
+        reconciled: true,
+      };
+      const markedOnly: Transaction = {
+        ...mockTransactions[0],
+        id: 'tx-marked-only',
+        cleared: true,
+        reconciled: false,
+      };
+
+      const { result } = renderHook(() =>
+        useReconciliation(mockAccounts, [...mockTransactions, committed, markedOnly])
+      );
+
+      expect(result.current.totalUnreconciledCount)
+        .toBe(badgeTotal(result.current.reconciliationDetails));
+      // And the marked-but-uncommitted row is genuinely being counted, so the
+      // agreement above is not two zeroes agreeing.
+      expect(result.current.totalUnreconciledCount).toBe(4);
+    });
+
+    it('agrees at zero, and agrees with no accounts at all', () => {
+      const allCommitted = mockTransactions.map(tx => ({ ...tx, reconciled: true }));
+      const { result } = renderHook(() =>
+        useReconciliation(mockAccounts, allCommitted)
+      );
+
+      expect(result.current.totalUnreconciledCount)
+        .toBe(badgeTotal(result.current.reconciliationDetails));
+      expect(result.current.totalUnreconciledCount).toBe(0);
+
+      const { result: empty } = renderHook(() => useReconciliation([], mockTransactions));
+      expect(empty.current.totalUnreconciledCount)
+        .toBe(badgeTotal(empty.current.reconciliationDetails));
+    });
+  });
+
   describe('getUnreconciledCount', () => {
     it('should return count for specific account', () => {
       const { result } = renderHook(() =>

--- a/src/hooks/__tests__/useReconciliation.test.ts
+++ b/src/hooks/__tests__/useReconciliation.test.ts
@@ -158,6 +158,50 @@ describe('useReconciliation', () => {
       expect(result.current.totalUnreconciledCount).toBe(3);
     });
 
+    it('counts only the accounts it was given, so a closed account cannot inflate it', () => {
+      // The owner's book: the heading read 2,447 while every account on screen
+      // said "All reconciled", because all 2,447 sat on accounts he had
+      // CLOSED — which this page never lists (they are fetched separately) and
+      // which have no statement left to agree against. A row belonging to an
+      // account that is not on the page must not be counted by the number at
+      // the top of it.
+      const rowOnAnAbsentAccount = {
+        ...mockTransactions[0],
+        id: 'tx-on-closed-account',
+        accountId: 'account-that-is-not-listed',
+        cleared: false,
+        reconciled: false,
+      };
+
+      const { result } = renderHook(() =>
+        useReconciliation(mockAccounts, [...mockTransactions, rowOnAnAbsentAccount])
+      );
+
+      // Unchanged by the extra row: still the three uncleared rows that belong
+      // to the listed accounts.
+      expect(result.current.totalUnreconciledCount).toBe(3);
+    });
+
+    it('counts an account the moment it IS given, which is what reopening one does', () => {
+      const reopened = { ...mockAccounts[0], id: 'reopened-account' };
+      const rowOnReopened = {
+        ...mockTransactions[0],
+        id: 'tx-on-reopened',
+        accountId: 'reopened-account',
+        cleared: false,
+        reconciled: false,
+      };
+
+      const { result } = renderHook(() =>
+        useReconciliation(
+          [...mockAccounts, reopened],
+          [...mockTransactions, rowOnReopened]
+        )
+      );
+
+      expect(result.current.totalUnreconciledCount).toBe(4);
+    });
+
     it('should return 0 when all transactions are cleared', () => {
       const clearedTransactions = mockTransactions.map(tx => ({
         ...tx,
@@ -266,13 +310,19 @@ describe('useReconciliation', () => {
   });
 
   describe('edge cases', () => {
-    it('should handle empty accounts array', () => {
+    it('counts nothing when there is nothing to list, however many rows exist', () => {
+      // CHANGED, deliberately: this asserted 3 — every unreconciled row in the
+      // ledger, counted even though no account was on the page to reconcile it
+      // against. That is the shape of the bug the owner found (a heading of
+      // 2,447 above a list saying "All accounts are fully reconciled", because
+      // every one of those rows belonged to a closed account). No accounts
+      // listed, no work shown, no work counted.
       const { result } = renderHook(() =>
         useReconciliation([], mockTransactions)
       );
 
       expect(result.current.reconciliationDetails).toEqual([]);
-      expect(result.current.totalUnreconciledCount).toBe(3);
+      expect(result.current.totalUnreconciledCount).toBe(0);
     });
 
     it('should handle empty transactions array', () => {

--- a/src/hooks/useReconciliation.ts
+++ b/src/hooks/useReconciliation.ts
@@ -147,10 +147,30 @@ export function useReconciliation(accounts: Account[], transactions: Transaction
     [accounts, accountTransactionMap]
   );
 
-  const totalUnreconciledCount = useMemo(() =>
-    transactions.filter(t => !isReconciled(t)).length,
-    [transactions]
-  );
+  /**
+   * The headline figure — and it counts ONLY the accounts this page lists.
+   *
+   * It used to count every unreconciled row in the ledger, which is a
+   * different question from the one the page answers. The owner's book made
+   * the gap plain: the heading read 2,447 while every account on screen said
+   * "All reconciled", because all 2,447 sat on 73 CLOSED accounts. Closed
+   * accounts are deliberately absent from this page (they are fetched
+   * separately and never listed here) — closing one is how you say you are
+   * done with it, and there is no bank statement left to agree it against.
+   * A page whose whole job is "how much work is left, and where" must not
+   * count work it will not show you, and cannot let you do.
+   *
+   * Scoped to `accounts` rather than to a flag, so it stays true by
+   * construction: reopen an account and it returns to that list, and its rows
+   * return to this count with it. Nothing here needs to know what "closed"
+   * means.
+   */
+  const totalUnreconciledCount = useMemo(() => {
+    const listedAccountIds = new Set(accounts.map(a => a.id));
+    return transactions.filter(
+      t => listedAccountIds.has(t.accountId) && !isReconciled(t)
+    ).length;
+  }, [accounts, transactions]);
 
   const getUnreconciledCount = useCallback(
     (accountId: string) =>

--- a/src/pages/Reconciliation.tsx
+++ b/src/pages/Reconciliation.tsx
@@ -2,7 +2,7 @@ import { useState, useMemo, useCallback, useEffect, useRef } from 'react';
 import { useSearchParams, useNavigate } from 'react-router-dom';
 import { useApp } from '../contexts/AppContextSupabase';
 import { useToast } from '../contexts/ToastContext';
-import { ArrowLeftIcon, CheckCircleIcon } from '../components/icons';
+import { ArrowLeftIcon, CheckCircleIcon, CheckIcon } from '../components/icons';
 import { useReconciliation, type ReconciliationSummary } from '../hooks/useReconciliation';
 import ReconciliationAccountList from '../components/reconciliation/ReconciliationAccountList';
 import {
@@ -79,13 +79,20 @@ export default function Reconciliation() {
   const [onlyAttention, setOnlyAttention] = useState<boolean>(() =>
     preferences.getItem('reconciliationOnlyAttention') === 'true'
   );
-  const handleOnlyAttentionToggle = useCallback(() => {
-    setOnlyAttention(prev => {
-      const next = !prev;
-      try { preferences.setItem('reconciliationOnlyAttention', String(next)); } catch { /* storage unavailable */ }
-      return next;
-    });
+  // One writer for the switch, because there are now two ways to move it: the
+  // control itself, and the "Show all accounts" remedy the filtered-empty state
+  // offers. A remedy that set the state without persisting it would put the
+  // list back and then take it away again on the next visit.
+  const setOnlyAttentionPersisted = useCallback((next: boolean) => {
+    setOnlyAttention(next);
+    try { preferences.setItem('reconciliationOnlyAttention', String(next)); } catch { /* storage unavailable */ }
   }, []);
+  const handleOnlyAttentionToggle = useCallback(() => {
+    setOnlyAttentionPersisted(!onlyAttention);
+  }, [onlyAttention, setOnlyAttentionPersisted]);
+  const handleShowAllAccounts = useCallback(() => {
+    setOnlyAttentionPersisted(false);
+  }, [setOnlyAttentionPersisted]);
   const [showFinalizationModal, setShowFinalizationModal] = useState(false);
   const [editingTransaction, setEditingTransaction] = useState<Transaction | null>(null);
   const [isEditModalOpen, setIsEditModalOpen] = useState(false);
@@ -250,6 +257,16 @@ export default function Reconciliation() {
     setSearchParams(prev => preserveRuntimeControlParams(prev));
     window.scrollTo(0, 0);
   }, [cameFromAccounts, searchParams, navigate, setSearchParams]);
+
+  /**
+   * The remedy on the genuinely-empty state: there is nowhere on THIS page to
+   * make an account, so the empty state hands over to the page where there is
+   * one rather than describing the trip.
+   */
+  const handleGoToAccounts = useCallback(() => {
+    const params = new URLSearchParams(preserveRuntimeControlParams(searchParams));
+    navigate({ pathname: '/accounts', search: params.toString() });
+  }, [searchParams, navigate]);
 
   const applyCleared = useCallback(async (requestedIds: string[], cleared: boolean) => {
     // Drop ids that already have a write in flight — the checkbox is disabled
@@ -499,19 +516,34 @@ export default function Reconciliation() {
                 on" is a state the page can be in: institution sub-bands nested
                 inside the type sections. Off and off is one flat list. The
                 owner's report was precisely that this page refused the
-                combination its twin allows. */}
+                combination its twin allows.
+
+                AND NOW THEY LOOK LIKE IT. Both-on is a real state, but wearing
+                the same navy fill as Sort's segmented single-choice beside it,
+                two filled pills read as a broken radio group rather than as two
+                things ticked — a design pass filed it as a bug on exactly that
+                reading. The control has to say which KIND it is before it can
+                be believed about which state it is in, so a pressed toggle now
+                carries a tick: the one glyph that means "this one too" rather
+                than "this one instead". The slot is held open while a switch is
+                off, so ticking one does not shove its own label sideways. */}
             <div className="grid grid-flow-col auto-cols-fr flex-1 sm:flex-none sm:inline-flex gap-2 p-0.5">
               <button
                 type="button"
                 onClick={() => handleGroupingChange({ ...grouping, byType: !grouping.byType })}
                 aria-pressed={grouping.byType}
                 title="Band the list into account-type sections"
-                className={`px-3 py-1.5 text-sm font-medium rounded-lg border transition-colors ${
+                className={`inline-flex items-center justify-center gap-1.5 px-3 py-1.5 text-sm font-medium rounded-lg border transition-colors ${
                   grouping.byType
                     ? 'bg-[#1a2332] dark:bg-blue-600 border-[#1a2332] dark:border-blue-600 text-white'
                     : 'border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-200'
                 }`}
               >
+                {/* aria-hidden: `aria-pressed` already says this to a screen
+                    reader, and the tick would announce it a second time. */}
+                <span aria-hidden="true" className="w-3.5 flex-shrink-0">
+                  {grouping.byType && <CheckIcon size={14} />}
+                </span>
                 Account Type
               </button>
               <button
@@ -519,12 +551,15 @@ export default function Reconciliation() {
                 onClick={() => handleGroupingChange({ ...grouping, byInstitution: !grouping.byInstitution })}
                 aria-pressed={grouping.byInstitution}
                 title="Band the list by institution"
-                className={`px-3 py-1.5 text-sm font-medium rounded-lg border transition-colors ${
+                className={`inline-flex items-center justify-center gap-1.5 px-3 py-1.5 text-sm font-medium rounded-lg border transition-colors ${
                   grouping.byInstitution
                     ? 'bg-[#1a2332] dark:bg-blue-600 border-[#1a2332] dark:border-blue-600 text-white'
                     : 'border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-200'
                 }`}
               >
+                <span aria-hidden="true" className="w-3.5 flex-shrink-0">
+                  {grouping.byInstitution && <CheckIcon size={14} />}
+                </span>
                 Institution
               </button>
             </div>
@@ -583,6 +618,21 @@ export default function Reconciliation() {
         <ReconciliationAccountList
           grouping={accountGrouping}
           onSelectAccount={handleSelectAccount}
+          /* Only when the switch is actually on AND there is something behind
+             it. With no accounts at all, "Needs attention only" is hiding
+             nothing and the honest state is the empty one — the filter is not
+             to blame for a list that would be empty without it. */
+          filter={onlyAttention && reconciliationDetails.length > 0
+            ? {
+                label: 'Needs attention only',
+                // Written as the difference rather than as the total, so it
+                // stays the count of accounts the filter is REMOVING even if
+                // this state is ever reached with some rows still showing.
+                hiddenCount: reconciliationDetails.length - attentionCount,
+                onClear: handleShowAllAccounts,
+              }
+            : undefined}
+          onGoToAccounts={handleGoToAccounts}
         />
       </div>
     );

--- a/src/pages/__tests__/Accounts.toReview.test.tsx
+++ b/src/pages/__tests__/Accounts.toReview.test.tsx
@@ -154,7 +154,7 @@ describe('Accounts list — the To Review column', () => {
     expect(within(columns).getByText('To Review')).toBeInTheDocument();
   });
 
-  it('reads quiet slate while there is work and blue when there is none — a count is not a next action (ruling A)', async () => {
+  it('reads legibly while there is work and recedes when there is none — and the zero is never the louder of the two', async () => {
     __setAppContextValue({
       accounts: [NATWEST, MONZO],
       transactions: [
@@ -170,6 +170,11 @@ describe('Accounts list — the To Review column', () => {
     const waiting = within(card('Synthetic Natwest')).getByText('To Review').nextElementSibling;
     const clear = within(card('Synthetic Monzo')).getByText('To Review').nextElementSibling;
     expect(waiting?.className).toContain('text-slate-600');
-    expect(clear?.className).toContain('text-blue-600');
+    // NOT the app's link blue, which is what a zero wore until this was
+    // corrected — de-ambering the working state had left the count with
+    // NOTHING to do as the loudest figure on the row. Colour marks what needs
+    // attention (ruling A's own argument) and a zero needs nothing.
+    expect(clear?.className).not.toContain('text-blue-600');
+    expect(clear?.className).toContain('text-gray-400');
   });
 });

--- a/src/pages/__tests__/Reconciliation.counts.test.tsx
+++ b/src/pages/__tests__/Reconciliation.counts.test.tsx
@@ -1,0 +1,181 @@
+/**
+ * THE HEADLINE AND THE ROWS COUNT THE SAME THING — on screen, not in a hook.
+ *
+ * The owner's book showed this page saying **2,447 unreconciled transactions
+ * across all accounts** above a screen of rows that every one of them said
+ * "All reconciled", Difference £0.00. Both numbers were produced correctly by
+ * their own lights; they answered different questions, and nothing in the app
+ * or in its tests ever put them side by side. That is the pin bug's failure
+ * mode exactly: two facts written from different sources, read back under
+ * different trust rules, and a suite that passes because no assertion spans
+ * them.
+ *
+ * `useReconciliation.test.ts` now pins the relation where the two numbers are
+ * born. This file pins it where the user actually reads them — the rendered
+ * headline against the rendered badges — because a page is free to display
+ * something other than what its hook returned, and the contradiction the owner
+ * saw was a contradiction between two things ON A SCREEN.
+ *
+ * Every name and figure here is invented; this repo is public.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { PreferencesProvider } from '../../contexts/PreferencesContext';
+import { ToastProvider } from '../../contexts/ToastContext';
+import { NotificationProvider } from '../../contexts/NotificationContext';
+import Reconciliation from '../Reconciliation';
+import { __setAppContextValue, __resetAppContextValue } from '../../test/mocks/AppContextSupabase';
+import type { Account, Transaction } from '../../types';
+
+const account = (id: string, name: string): Account => ({
+  id,
+  name,
+  type: 'current',
+  balance: 0,
+  currency: 'GBP',
+  institution: 'Invented Bank',
+  lastUpdated: new Date('2026-08-01'),
+  openingBalance: 0,
+  isActive: true,
+});
+
+let nextId = 0;
+const row = (accountId: string, reconciled: boolean): Transaction => {
+  nextId += 1;
+  return {
+    id: `t${nextId}`,
+    date: new Date('2026-08-01'),
+    amount: -10,
+    description: 'Invented row',
+    category: 'general',
+    accountId,
+    type: 'expense',
+    cleared: reconciled,
+    reconciled,
+  };
+};
+
+const renderPage = () =>
+  render(
+    <MemoryRouter initialEntries={['/reconciliation']}>
+      <PreferencesProvider>
+        <ToastProvider>
+          <NotificationProvider>
+            <Reconciliation />
+          </NotificationProvider>
+        </ToastProvider>
+      </PreferencesProvider>
+    </MemoryRouter>
+  );
+
+/**
+ * The figure printed at `display` size under the page title — read through the
+ * words that explain it, which is how a reader finds it too.
+ */
+const headline = (): number | null => {
+  const subhead = screen.queryByText(/unreconciled transactions? across all accounts/);
+  if (!subhead) return null;
+  const figure = subhead.previousElementSibling?.textContent ?? '';
+  return Number(figure.replace(/,/g, ''));
+};
+
+/** What the row badges add up to, as printed. */
+const badgeTotal = (): number =>
+  screen
+    .queryAllByText(/^\d+ unreconciled$/)
+    .reduce((sum, badge) => sum + Number((badge.textContent ?? '0').split(' ')[0]), 0);
+
+beforeEach(() => {
+  nextId = 0;
+  localStorage.clear();
+});
+
+afterEach(() => {
+  __resetAppContextValue();
+});
+
+describe('Reconciliation — the headline decomposes into the rows', () => {
+  it('HEADLINE: the figure over the list is the sum of the badges in it', () => {
+    __setAppContextValue({
+      accounts: [account('a1', 'Everyday Invented'), account('a2', 'Second Invented')],
+      transactions: [
+        row('a1', false),
+        row('a1', false),
+        row('a1', true),
+        row('a2', false),
+      ],
+      isLoading: false,
+    });
+    renderPage();
+
+    expect(headline()).toBe(3);
+    expect(badgeTotal()).toBe(3);
+    expect(headline()).toBe(badgeTotal());
+  });
+
+  it('HEADLINE: rows on accounts this page does not list count in NEITHER', () => {
+    // The owner's book, in miniature. 'closed-1' is not in `accounts` — which
+    // is what being closed looks like from here, since closed accounts are
+    // fetched separately and never listed. The page must not promote work it
+    // will not show you and cannot let you do.
+    __setAppContextValue({
+      accounts: [account('a1', 'Everyday Invented')],
+      transactions: [
+        row('a1', true),
+        row('closed-1', false),
+        row('closed-1', false),
+        row('closed-1', false),
+      ],
+      isLoading: false,
+    });
+    renderPage();
+
+    // No headline figure at all — a count of nothing renders as nothing — and
+    // the one listed account agrees that there is nothing to do.
+    expect(headline()).toBeNull();
+    expect(badgeTotal()).toBe(0);
+    expect(screen.getByText('All accounts are up to date')).toBeInTheDocument();
+    expect(screen.getByText('All reconciled')).toBeInTheDocument();
+    // The exact contradiction that cost trust: a headline over a screen that
+    // disagrees with it.
+    expect(screen.queryByText(/unreconciled transactions across all accounts/)).not.toBeInTheDocument();
+  });
+
+  it('agrees while the list is filtered, over the accounts still on screen', () => {
+    // The filter hides rows; it does not change what is true. The badges that
+    // remain must still add up to the headline, which counts the accounts the
+    // page is given rather than the ones it is currently drawing.
+    __setAppContextValue({
+      accounts: [account('a1', 'Everyday Invented'), account('a2', 'Second Invented')],
+      transactions: [row('a1', false), row('a1', false), row('a2', true)],
+      isLoading: false,
+    });
+    renderPage();
+
+    expect(headline()).toBe(2);
+    // 'Second Invented' has nothing outstanding, so it contributes nothing to
+    // either number whether it is on screen or behind the filter.
+    expect(badgeTotal()).toBe(2);
+  });
+
+  it('counts transactions in the headline and accounts in the bands, and says which is which', () => {
+    // Two units on one page is defensible; two units both printed as a bare
+    // number is not. The band says what it is counting.
+    __setAppContextValue({
+      accounts: [account('a1', 'Everyday Invented'), account('a2', 'Second Invented')],
+      transactions: [row('a1', false), row('a1', false), row('a1', false)],
+      isLoading: false,
+    });
+    renderPage();
+
+    expect(headline()).toBe(3);
+    expect(screen.getByText(/unreconciled transactions across all accounts/)).toBeInTheDocument();
+
+    const band = screen.getByRole('heading', { level: 2, name: /Current Accounts/ });
+    expect(band.textContent).toContain('2 accounts');
+    // Never a bare "(2)" under a headline reading 3.
+    expect(band.textContent).not.toMatch(/\(\d+\)/);
+  });
+});

--- a/src/pages/__tests__/Reconciliation.grouping.test.tsx
+++ b/src/pages/__tests__/Reconciliation.grouping.test.tsx
@@ -117,7 +117,7 @@ describe('Reconciliation — grouping is two independent switches', () => {
 
     // And the list nests, exactly as the Accounts page nests: type sections
     // outside, institution sub-bands within, unfiled last inside its section.
-    expect(sections()).toEqual(['Current Accounts(2)', 'Savings Accounts(2)']);
+    expect(sections()).toEqual(['Current Accounts(2 accounts)', 'Savings Accounts(2 accounts)']);
     expect(subBands()).toEqual([
       'Invented Bank, 1 account',
       'Rival Invented Bank, 1 account',
@@ -133,7 +133,7 @@ describe('Reconciliation — grouping is two independent switches', () => {
   it('bands by type alone when only Account Type is on', () => {
     renderList();
 
-    expect(sections()).toEqual(['Current Accounts(2)', 'Savings Accounts(2)']);
+    expect(sections()).toEqual(['Current Accounts(2 accounts)', 'Savings Accounts(2 accounts)']);
     // No sub-bands: one switch, one level.
     expect(subBands()).toEqual([]);
   });
@@ -149,9 +149,9 @@ describe('Reconciliation — grouping is two independent switches', () => {
     // Alphabetical, with the accounts that name no institution last — the
     // shared module's rule, so the two pages order them identically.
     expect(sections()).toEqual([
-      'Invented Bank(2)',
-      'Rival Invented Bank(1)',
-      'Other Accounts(1)',
+      'Invented Bank(2 accounts)',
+      'Rival Invented Bank(1 account)',
+      'Other Accounts(1 account)',
     ]);
     expect(subBands()).toEqual([]);
   });
@@ -180,14 +180,75 @@ describe('Reconciliation — grouping is two independent switches', () => {
 
     // Sorting applies to the INNERMOST list — the rows a user reads down — so
     // the bands are unchanged and the rows inside each are alphabetical.
-    expect(sections()).toEqual(['Current Accounts(2)', 'Savings Accounts(2)']);
+    expect(sections()).toEqual(['Current Accounts(2 accounts)', 'Savings Accounts(2 accounts)']);
 
     // "Needs attention only" drops ROWS. No account here has a bank balance or
     // an unreconciled transaction, so everything is done and the list empties
     // rather than showing empty bands.
+    //
+    // And what it draws then is the FILTERED-empty state, not the empty one:
+    // the four accounts are still there, behind a switch, and the page says so
+    // and offers the way back.
     fireEvent.click(screen.getByRole('button', { name: /Needs attention only/ }));
-    expect(screen.getByText('No accounts to reconcile')).toBeInTheDocument();
+    expect(screen.getByText('Nothing needs attention right now')).toBeInTheDocument();
+    expect(document.body.textContent).toContain('4 accounts are hidden by');
+    expect(screen.queryByText('No accounts to reconcile')).not.toBeInTheDocument();
     expect(sections()).toEqual([]);
+
+    // The way back works, and puts every account on screen again.
+    fireEvent.click(screen.getByRole('button', { name: 'Show all accounts' }));
+    expect(sections()).toEqual(['Current Accounts(2 accounts)', 'Savings Accounts(2 accounts)']);
+  });
+});
+
+/**
+ * THE CONTROL SAYS WHICH KIND IT IS.
+ *
+ * Both-on is a real, wanted state — but next to Sort's segmented single-choice,
+ * two navy-filled pills read as a radio group with a bug, which is exactly how
+ * a design pass filed it. The behaviour was right and the affordance was not,
+ * so the tick is what changes: "this one too", rather than "this one instead".
+ */
+describe('Reconciliation — Group by looks like a multi-select', () => {
+  const tickIn = (name: 'Account Type' | 'Institution'): Element | null =>
+    switchFor(name).querySelector('svg');
+
+  it('ticks the switches that are on, and only those', () => {
+    renderList();
+
+    // Account Type is the default-on switch; Institution starts off.
+    expect(tickIn('Account Type')).not.toBeNull();
+    expect(tickIn('Institution')).toBeNull();
+
+    fireEvent.click(switchFor('Institution'));
+    expect(tickIn('Account Type')).not.toBeNull();
+    expect(tickIn('Institution')).not.toBeNull();
+
+    fireEvent.click(switchFor('Account Type'));
+    expect(tickIn('Account Type')).toBeNull();
+    expect(tickIn('Institution')).not.toBeNull();
+  });
+
+  it('leaves Sort — a single choice — without ticks', () => {
+    renderList();
+
+    // The distinction is the whole point: if the segmented single-choice wore
+    // the same glyph, the tick would stop meaning "and also".
+    ['Default', 'Name A–Z'].forEach(label => {
+      expect(screen.getByRole('button', { name: label }).querySelector('svg')).toBeNull();
+    });
+  });
+
+  it('says it with aria-pressed, not with the glyph, and does not say it twice', () => {
+    renderList();
+
+    // The tick is decoration over a state the button already announces.
+    expect(isOn('Account Type')).toBe(true);
+    expect(switchFor('Account Type').querySelector('[aria-hidden="true"]')).not.toBeNull();
+    // The accessible name is still just the words — the switches are found by
+    // name all over this file, and a glyph that leaked into it would rename
+    // the control every time it was pressed.
+    expect(switchFor('Account Type')).toHaveAccessibleName('Account Type');
   });
 });
 
@@ -235,9 +296,9 @@ describe('Reconciliation — the switches are remembered, and are this page\'s o
     expect(isOn('Account Type')).toBe(false);
     expect(isOn('Institution')).toBe(true);
     expect(sections()).toEqual([
-      'Invented Bank(2)',
-      'Rival Invented Bank(1)',
-      'Other Accounts(1)',
+      'Invented Bank(2 accounts)',
+      'Rival Invented Bank(1 account)',
+      'Other Accounts(1 account)',
     ]);
   });
 });


### PR DESCRIPTION
Four commits: one owner-reported bug, one I owed from a screenshot, one batch of design findings, and one inversion I introduced myself while fixing something else.

## 1. The reconciliation headline counts what the page can show
The owner: "it says I have 2,447 unreconciled transactions but nothing is showing up." Measured against production: **all 2,447 sat on 73 CLOSED accounts** — not one on an account the page lists. The count was right by the app's three-valued rule (a naive count says 50,224) but answered a question the page doesn't ask. Now scoped to the accounts it is given, so the owner's rule holds by construction: *"if it is closed, then it is closed"* — and reopening one brings its rows back with it. One existing test asserted the count stayed at 3 with **no accounts listed at all**; that was the bug, written down, and it now asserts 0.

## 2. Budget Status stops reading UUIDs aloud
Three dashboard rows printed `budget.categoryId` — raw UUIDs in the visible label, the group's aria-label and the progress bar's, so screen readers read them out too. The rule was already written in the helper that exists for it: *"a raw category id must never reach a screen."* Resolved once, in the app's "Parent : Child" convention.

## 3. Reconciliation findings §1.3–§1.5, plus the test that would have caught §1.1
Claude Design's post-implementation read, less the two already settled (§1.1 above; §1.2 is **not a bug** — those Group by switches were made independent on their own ruling and the owner wants both at once).
- **The missing test**: nothing compared the headline with the rows, so every test passed on the day the page read 2,447 above rows saying "All reconciled". The relation is now asserted at the hook *and* at the rendered page.
- **§1.4 the badge**: neither option verbatim. Delegating to the Difference column fails *here* — that column reads an em-dash on exactly the accounts this page exists for. So the count keeps a neutral chip and the settled state becomes quiet text; a real discrepancy keeps red **and** gains weight.
- **§1.5 the cards**: 29 bordered cards → hairline rows. A 2px amber ring can't survive losing its box, so attention becomes a 3px leading-edge mark (§3.4's own idiom), present always with only its colour changing so a marked row can't shove its contents sideways.
- Filtered-empty now uses `FilteredEmptyState` and is provably distinguishable from true-empty; band counts say "N accounts"; Group by gains a tick, beside a Sort that deliberately has none.

## 4. The zero stops being the loudest figure on the row
Self-inflicted: de-ambering the Accounts count for ruling A left the **zero** wearing link blue while the with-work count went quiet slate — a row with nothing to do shouting, a row with thirty outstanding murmuring. Neither is coloured now. Found by the agent that had just fixed the identical inversion one page over.

Verification: lint · typecheck:strict · **6,101 smoke** · 169 reconciliation tests · desktop:verify PASS · browser-walked (headline 100 = 28+16+33+23, both Group by switches nesting, filtered-empty reached honestly by reconciling all four demo accounts).

🤖 Generated with [Claude Code](https://claude.com/claude-code)