### PR TITLE
feat(design): three rulings read from the source — one navy card, one chart ramp, one focus ring

### DIFF
--- a/src/components/AccountRowColumns.tsx
+++ b/src/components/AccountRowColumns.tsx
@@ -84,7 +84,7 @@ export const ACCOUNT_ROW_SELECTED_CLASS =
   'relative z-10 bg-blue-50/80 dark:bg-blue-900/30 border-transparent ' +
   // ─ ONE STROKE WHEN THE KEYBOARD IS DRIVING ─────────────────────────────────
   // `focus-visible:ring-0` because otherwise an arrowed-to row wears TWO
-  // concentric strokes: this selection ring, and — 2px further out — the
+  // concentric strokes: this SELECTION ring, and — 2px further out — the
   // app-wide `*:focus-visible { outline: 2px solid var(--focus-ring-color) }`
   // in accessibility-colors.css, which carries `!important` and so cannot be
   // turned off by the row's own `focus:outline-none`. Light mode resolves that
@@ -99,6 +99,16 @@ export const ACCOUNT_ROW_SELECTED_CLASS =
   // while the row holds focus and comes back the moment focus leaves — and the
   // blue wash and the lift never go anywhere, so a selected row still reads as
   // selected either way.
+  //
+  // THIS ONE SURVIVED THE APP-WIDE SWEEP, and it is the only `ring-0` left.
+  // Every component-level `focus-visible:ring-*` came out in
+  // RULINGS_ON_CAUSE_2026-08-13 §3, on the grounds that a component declaring
+  // its own ring paints a second one over the global outline. The ruling
+  // expected this workaround to come out with them as having "nothing left to
+  // fight" — but what it suppresses is not a focus ring. It is the `ring-1`
+  // selection indicator on the SAME element, three classes to its left, which
+  // is §6 law and stays. Delete this and a selected, arrowed-to row wears both
+  // strokes again, which is the exact bug that was reported.
   'ring-1 ring-[#6B86B3]/50 dark:ring-[#6B86B3]/70 focus-visible:ring-0 ' +
   'shadow-[0_4px_6px_-1px_rgba(0,0,0,0.1),0_10px_15px_-3px_rgba(0,0,0,0.1)] ' +
   'dark:shadow-[0_4px_6px_-1px_rgba(0,0,0,0.3),0_10px_15px_-3px_rgba(0,0,0,0.3)]';
@@ -135,9 +145,14 @@ export const ACCOUNT_ROW_SELECTED_CLASS =
  * is not the account's name.
  *
  * Resting colour is the caller's (a nested cash row is drawn quieter than the
- * card it sits in); the geometry, the hover and the focus ring are shared, so
- * the hit area cannot come out right for one kind of row and wrong for the
- * other.
+ * card it sits in); the geometry and the hover are shared, so the hit area
+ * cannot come out right for one kind of row and wrong for the other. The link
+ * declares NO focus ring: it used to carry `focus:outline-none
+ * focus-visible:ring-2 focus-visible:ring-blue-500`, which painted a blue ring
+ * INSIDE the app-wide focus outline — the same doubling the selected row above
+ * had to work around. The global outline is the app's one focus ring
+ * (RULINGS_ON_CAUSE_2026-08-13 §3), and `rounded` is kept because the outline
+ * follows the border radius.
  *
  * On touch, index.css floors every anchor at 44×44 — a hit area small enough to
  * miss is its own failure, and 44px beside a four-letter name is still nothing
@@ -145,8 +160,7 @@ export const ACCOUNT_ROW_SELECTED_CLASS =
  */
 export const ACCOUNT_ROW_NAME_LINK_CLASS =
   'block w-fit max-w-full truncate rounded transition-colors ' +
-  'hover:text-blue-600 dark:hover:text-blue-400 hover:underline ' +
-  'focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500';
+  'hover:text-blue-600 dark:hover:text-blue-400 hover:underline';
 
 /** The column heading over a figure — small, quiet, and the same for every row. */
 const CELL_LABEL_CLASS = 'text-[10px] uppercase tracking-wide text-gray-400 dark:text-gray-500';

--- a/src/components/AccountSettingsModal.tsx
+++ b/src/components/AccountSettingsModal.tsx
@@ -289,7 +289,7 @@ export default function AccountSettingsModal({
               required
               value={formData.name}
               onChange={(e) => updateField('name', e.target.value)}
-              className="w-full px-3 py-2 bg-white dark:bg-gray-800 border border-gray-300/50 dark:border-gray-600/50 rounded-xl focus:outline-none focus:ring-2 focus:ring-primary focus:border-transparent dark:text-white"
+              className="w-full px-3 py-2 bg-white dark:bg-gray-800 border border-gray-300/50 dark:border-gray-600/50 rounded-xl focus:border-transparent dark:text-white"
               aria-label="Account name"
             />
             <p className="mt-1 text-xs text-gray-500 dark:text-gray-400">
@@ -307,7 +307,7 @@ export default function AccountSettingsModal({
               id="account-type"
               value={formData.type}
               onChange={(e) => updateField('type', e.target.value as Account['type'])}
-              className="w-full px-3 py-2 bg-white dark:bg-gray-800-sm border border-gray-300/50 dark:border-gray-600/50 rounded-xl focus:outline-none focus:ring-2 focus:ring-primary focus:border-transparent dark:text-white"
+              className="w-full px-3 py-2 bg-white dark:bg-gray-800-sm border border-gray-300/50 dark:border-gray-600/50 rounded-xl focus:border-transparent dark:text-white"
             >
               {accountTypeOptions.map((option) => (
                 <option key={option.value} value={option.value}>
@@ -334,7 +334,7 @@ export default function AccountSettingsModal({
                   id="account-currency"
                   value={formData.currency}
                   onChange={(e) => updateField('currency', e.target.value)}
-                  className="w-full px-3 py-2 bg-white dark:bg-gray-800-sm border border-gray-300/50 dark:border-gray-600/50 rounded-xl focus:outline-none focus:ring-2 focus:ring-primary focus:border-transparent dark:text-white"
+                  className="w-full px-3 py-2 bg-white dark:bg-gray-800-sm border border-gray-300/50 dark:border-gray-600/50 rounded-xl focus:border-transparent dark:text-white"
                 >
                   {/* The account's own code is always among these, even if the
                       app does not support it — see accountCurrencyOptions. */}
@@ -390,14 +390,14 @@ export default function AccountSettingsModal({
                 allowNegative
                 value={formData.openingBalance}
                 onChange={(value) => updateField('openingBalance', value)}
-                className="w-full px-3 py-2 bg-white dark:bg-gray-800-sm border border-gray-300/50 dark:border-gray-600/50 rounded-xl focus:outline-none focus:ring-2 focus:ring-primary focus:border-transparent dark:text-white"
+                className="w-full px-3 py-2 bg-white dark:bg-gray-800-sm border border-gray-300/50 dark:border-gray-600/50 rounded-xl focus:border-transparent dark:text-white"
                 aria-label="Opening balance amount"
               />
               <DatePicker
                 id="opening-balance-date"
                 value={formData.openingBalanceDate}
                 onChange={(val) => updateField('openingBalanceDate', val)}
-                className="bg-white dark:bg-gray-800-sm border border-gray-300/50 dark:border-gray-600/50 rounded-xl focus:outline-none focus:ring-2 focus:ring-primary focus:border-transparent dark:text-white"
+                className="bg-white dark:bg-gray-800-sm border border-gray-300/50 dark:border-gray-600/50 rounded-xl focus:border-transparent dark:text-white"
                 aria-label="Opening balance date"
               />
             </div>
@@ -416,7 +416,7 @@ export default function AccountSettingsModal({
                 onChange={handleSortCodeChange}
                 placeholder="XX-XX-XX"
                 maxLength={8}
-                className="w-full px-3 py-2 bg-white dark:bg-gray-800-sm border border-gray-300/50 dark:border-gray-600/50 rounded-xl focus:outline-none focus:ring-2 focus:ring-primary focus:border-transparent dark:text-white"
+                className="w-full px-3 py-2 bg-white dark:bg-gray-800-sm border border-gray-300/50 dark:border-gray-600/50 rounded-xl focus:border-transparent dark:text-white"
                 aria-label="Bank sort code"
               />
             </div>
@@ -439,7 +439,7 @@ export default function AccountSettingsModal({
                 // (WCAG 2.5.3 Label in Name).
                 aria-label={isCreditCard ? undefined : 'Bank account number'}
                 {...(isBankAccount ? { maxLength: BANK_ACCOUNT_NUMBER_LENGTH } : {})}
-                className="w-full px-3 py-2 bg-white dark:bg-gray-800-sm border border-gray-300/50 dark:border-gray-600/50 rounded-xl focus:outline-none focus:ring-2 focus:ring-primary focus:border-transparent dark:text-white"
+                className="w-full px-3 py-2 bg-white dark:bg-gray-800-sm border border-gray-300/50 dark:border-gray-600/50 rounded-xl focus:border-transparent dark:text-white"
               />
               {isCreditCard && <CardNumberGuidance value={formData.accountNumber} />}
             </div>
@@ -455,7 +455,7 @@ export default function AccountSettingsModal({
                 id="account-parent"
                 value={formData.parentAccountId}
                 onChange={(e) => updateField('parentAccountId', e.target.value)}
-                className="w-full px-3 py-2 bg-white dark:bg-gray-800-sm border border-gray-300/50 dark:border-gray-600/50 rounded-xl focus:outline-none focus:ring-2 focus:ring-primary focus:border-transparent dark:text-white"
+                className="w-full px-3 py-2 bg-white dark:bg-gray-800-sm border border-gray-300/50 dark:border-gray-600/50 rounded-xl focus:border-transparent dark:text-white"
               >
                 <option value={NO_PARENT_ACCOUNT}>None</option>
                 {/* Grouped and alphabetised like every other account dropdown. */}
@@ -481,7 +481,7 @@ export default function AccountSettingsModal({
               value={formData.institution}
               onChange={(e) => updateField('institution', e.target.value)}
               placeholder="Bank or financial institution name"
-              className="w-full px-3 py-2 bg-white dark:bg-gray-800-sm border border-gray-300/50 dark:border-gray-600/50 rounded-xl focus:outline-none focus:ring-2 focus:ring-primary focus:border-transparent dark:text-white"
+              className="w-full px-3 py-2 bg-white dark:bg-gray-800-sm border border-gray-300/50 dark:border-gray-600/50 rounded-xl focus:border-transparent dark:text-white"
             />
           </div>
 
@@ -494,7 +494,7 @@ export default function AccountSettingsModal({
               id="account-active"
               value={formData.isActive ? 'active' : 'closed'}
               onChange={(e) => updateField('isActive', e.target.value === 'active')}
-              className="w-full px-3 py-2 bg-white dark:bg-gray-800-sm border border-gray-300/50 dark:border-gray-600/50 rounded-xl focus:outline-none focus:ring-2 focus:ring-primary focus:border-transparent dark:text-white"
+              className="w-full px-3 py-2 bg-white dark:bg-gray-800-sm border border-gray-300/50 dark:border-gray-600/50 rounded-xl focus:border-transparent dark:text-white"
             >
               <option value="active">Open</option>
               <option value="closed">Closed</option>
@@ -539,7 +539,7 @@ export default function AccountSettingsModal({
                   value={formData.lowBalanceThreshold}
                   onChange={(value) => updateField('lowBalanceThreshold', value)}
                   placeholder="e.g. 500"
-                  className="w-full px-3 py-2 bg-white dark:bg-gray-800-sm border border-gray-300/50 dark:border-gray-600/50 rounded-xl focus:outline-none focus:ring-2 focus:ring-primary focus:border-transparent dark:text-white"
+                  className="w-full px-3 py-2 bg-white dark:bg-gray-800-sm border border-gray-300/50 dark:border-gray-600/50 rounded-xl focus:border-transparent dark:text-white"
                 />
               </div>
             )}
@@ -556,7 +556,7 @@ export default function AccountSettingsModal({
               onChange={(e) => updateField('notes', e.target.value)}
               rows={3}
               placeholder="Additional information about this account"
-              className="w-full px-3 py-2 bg-white dark:bg-gray-800-sm border border-gray-300/50 dark:border-gray-600/50 rounded-xl focus:outline-none focus:ring-2 focus:ring-primary focus:border-transparent dark:text-white resize-none"
+              className="w-full px-3 py-2 bg-white dark:bg-gray-800-sm border border-gray-300/50 dark:border-gray-600/50 rounded-xl focus:border-transparent dark:text-white resize-none"
             />
           </div>
 

--- a/src/components/AddAccountModal.tsx
+++ b/src/components/AddAccountModal.tsx
@@ -211,7 +211,7 @@ export default function AddAccountModal({ isOpen, onClose, prefill, onAccountCre
                 type="text"
                 value={formData.name}
                 onChange={(e) => updateField('name', e.target.value)}
-                className="w-full px-4 py-3 bg-white dark:bg-gray-800 border-2 border-gray-200 dark:border-gray-700 rounded-xl focus:outline-none focus:ring-3 focus:ring-primary/20 focus:border-primary dark:text-white transition-all duration-200"
+                className="w-full px-4 py-3 bg-white dark:bg-gray-800 border-2 border-gray-200 dark:border-gray-700 rounded-xl focus:border-primary dark:text-white transition-all duration-200"
                 placeholder="e.g., Main Checking Account"
                 required
                 autoFocus
@@ -282,7 +282,7 @@ export default function AddAccountModal({ isOpen, onClose, prefill, onAccountCre
                     allowNegative
                     value={formData.balance}
                     onChange={(value) => updateField('balance', value)}
-                    className="w-full pl-8 pr-4 py-3 bg-white dark:bg-gray-800 border-2 border-gray-200 dark:border-gray-700 rounded-xl focus:outline-none focus:ring-3 focus:ring-primary/20 focus:border-primary dark:text-white transition-all duration-200"
+                    className="w-full pl-8 pr-4 py-3 bg-white dark:bg-gray-800 border-2 border-gray-200 dark:border-gray-700 rounded-xl focus:border-primary dark:text-white transition-all duration-200"
                     required
                     disabled={isSubmitting}
                   />
@@ -299,7 +299,7 @@ export default function AddAccountModal({ isOpen, onClose, prefill, onAccountCre
                   value={formData.currency}
                   onChange={(e) => updateField('currency', e.target.value)}
                   disabled={isSubmitting}
-                  className="w-full px-4 py-3 bg-white dark:bg-gray-800 border-2 border-gray-200 dark:border-gray-700 rounded-xl focus:outline-none focus:ring-3 focus:ring-primary/20 focus:border-primary dark:text-white transition-all duration-200 appearance-none cursor-pointer"
+                  className="w-full px-4 py-3 bg-white dark:bg-gray-800 border-2 border-gray-200 dark:border-gray-700 rounded-xl focus:border-primary dark:text-white transition-all duration-200 appearance-none cursor-pointer"
                   style={{
                     backgroundImage: `url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 20 20'%3e%3cpath stroke='%236b7280' stroke-linecap='round' stroke-linejoin='round' stroke-width='1.5' d='M6 8l4 4 4-4'/%3e%3c/svg%3e")`,
                     backgroundPosition: 'right 0.5rem center',
@@ -330,7 +330,7 @@ export default function AddAccountModal({ isOpen, onClose, prefill, onAccountCre
                   type="text"
                   value={formData.institution}
                   onChange={(e) => updateField('institution', e.target.value)}
-                  className="w-full pl-11 pr-4 py-3 bg-white dark:bg-gray-800 border-2 border-gray-200 dark:border-gray-700 rounded-xl focus:outline-none focus:ring-3 focus:ring-primary/20 focus:border-primary dark:text-white transition-all duration-200"
+                  className="w-full pl-11 pr-4 py-3 bg-white dark:bg-gray-800 border-2 border-gray-200 dark:border-gray-700 rounded-xl focus:border-primary dark:text-white transition-all duration-200"
                   placeholder="e.g., Barclays, HSBC, NatWest"
                   disabled={isSubmitting}
                 />
@@ -355,7 +355,7 @@ export default function AddAccountModal({ isOpen, onClose, prefill, onAccountCre
                       type="text"
                       value={formData.sortCode}
                       onChange={(e) => updateField('sortCode', formatSortCode(e.target.value))}
-                      className="w-full px-4 py-3 bg-white dark:bg-gray-800 border-2 border-gray-200 dark:border-gray-700 rounded-xl focus:outline-none focus:ring-3 focus:ring-primary/20 focus:border-primary dark:text-white transition-all duration-200"
+                      className="w-full px-4 py-3 bg-white dark:bg-gray-800 border-2 border-gray-200 dark:border-gray-700 rounded-xl focus:border-primary dark:text-white transition-all duration-200"
                       placeholder="XX-XX-XX"
                       maxLength={8}
                       aria-label="Bank sort code"
@@ -374,7 +374,7 @@ export default function AddAccountModal({ isOpen, onClose, prefill, onAccountCre
                     inputMode="numeric"
                     value={formData.accountNumber}
                     onChange={(e) => updateField('accountNumber', nextAccountNumberValue(e.target.value, isCreditCard))}
-                    className="w-full px-4 py-3 bg-white dark:bg-gray-800 border-2 border-gray-200 dark:border-gray-700 rounded-xl focus:outline-none focus:ring-3 focus:ring-primary/20 focus:border-primary dark:text-white transition-all duration-200"
+                    className="w-full px-4 py-3 bg-white dark:bg-gray-800 border-2 border-gray-200 dark:border-gray-700 rounded-xl focus:border-primary dark:text-white transition-all duration-200"
                     placeholder={isCreditCard ? '1234' : '12345678'}
                     // No aria-label for a card: it would override the visible
                     // "Card Number — last 4 digits only" with wording that does

--- a/src/components/AddInvestmentModal.tsx
+++ b/src/components/AddInvestmentModal.tsx
@@ -150,7 +150,7 @@ export default function AddInvestmentModal({ isOpen, onClose, accountId }: AddIn
               <select
                 value={formData.selectedAccountId}
                 onChange={(e) => updateField('selectedAccountId', e.target.value)}
-                className="w-full px-3 py-2 bg-white dark:bg-gray-800-sm border border-gray-300/50 dark:border-gray-600/50 rounded-xl focus:outline-none focus:ring-2 focus:ring-primary focus:border-transparent dark:text-white"
+                className="w-full px-3 py-2 bg-white dark:bg-gray-800-sm border border-gray-300/50 dark:border-gray-600/50 rounded-xl focus:border-transparent dark:text-white"
                 required
               >
                 <option value="">Select an investment account</option>
@@ -211,7 +211,7 @@ export default function AddInvestmentModal({ isOpen, onClose, accountId }: AddIn
                 value={formData.stockCode}
                 onChange={(e) => updateField('stockCode', e.target.value.toUpperCase())}
                 placeholder={formData.investmentType === 'share' ? 'AAPL' : formData.investmentType === 'fund' ? 'ISIN/SEDOL' : 'Optional'}
-                className="w-full px-3 py-2 bg-white dark:bg-gray-800-sm border border-gray-300/50 dark:border-gray-600/50 rounded-xl focus:outline-none focus:ring-2 focus:ring-primary focus:border-transparent dark:text-white"
+                className="w-full px-3 py-2 bg-white dark:bg-gray-800-sm border border-gray-300/50 dark:border-gray-600/50 rounded-xl focus:border-transparent dark:text-white"
                 disabled={formData.investmentType === 'cash'}
               />
             </div>
@@ -226,7 +226,7 @@ export default function AddInvestmentModal({ isOpen, onClose, accountId }: AddIn
                 value={formData.name}
                 onChange={(e) => updateField('name', e.target.value)}
                 placeholder={formData.investmentType === 'share' ? 'Apple Inc.' : formData.investmentType === 'fund' ? 'Fund Name' : 'Description'}
-                className="w-full px-3 py-2 bg-white dark:bg-gray-800-sm border border-gray-300/50 dark:border-gray-600/50 rounded-xl focus:outline-none focus:ring-2 focus:ring-primary focus:border-transparent dark:text-white"
+                className="w-full px-3 py-2 bg-white dark:bg-gray-800-sm border border-gray-300/50 dark:border-gray-600/50 rounded-xl focus:border-transparent dark:text-white"
                 required
               />
             </div>
@@ -242,7 +242,7 @@ export default function AddInvestmentModal({ isOpen, onClose, accountId }: AddIn
                 value={formData.units}
                 onChange={(e) => updateField('units', e.target.value)}
                 placeholder={formData.investmentType === 'cash' ? '1000.00' : '100'}
-                className="w-full px-3 py-2 bg-white dark:bg-gray-800-sm border border-gray-300/50 dark:border-gray-600/50 rounded-xl focus:outline-none focus:ring-2 focus:ring-primary focus:border-transparent dark:text-white"
+                className="w-full px-3 py-2 bg-white dark:bg-gray-800-sm border border-gray-300/50 dark:border-gray-600/50 rounded-xl focus:border-transparent dark:text-white"
                 required
               />
             </div>
@@ -257,7 +257,7 @@ export default function AddInvestmentModal({ isOpen, onClose, accountId }: AddIn
                 value={formData.pricePerUnit}
                 onChange={(value) => updateField('pricePerUnit', value)}
                 placeholder={formData.investmentType === 'cash' ? '1.00' : '150.00'}
-                className="w-full px-3 py-2 bg-white dark:bg-gray-800-sm border border-gray-300/50 dark:border-gray-600/50 rounded-xl focus:outline-none focus:ring-2 focus:ring-primary focus:border-transparent dark:text-white"
+                className="w-full px-3 py-2 bg-white dark:bg-gray-800-sm border border-gray-300/50 dark:border-gray-600/50 rounded-xl focus:border-transparent dark:text-white"
                 required
               />
             </div>
@@ -271,7 +271,7 @@ export default function AddInvestmentModal({ isOpen, onClose, accountId }: AddIn
                 id="investment-fees"
                 value={formData.fees}
                 onChange={(value) => updateField('fees', value)}
-                className="w-full px-3 py-2 bg-white dark:bg-gray-800-sm border border-gray-300/50 dark:border-gray-600/50 rounded-xl focus:outline-none focus:ring-2 focus:ring-primary focus:border-transparent dark:text-white"
+                className="w-full px-3 py-2 bg-white dark:bg-gray-800-sm border border-gray-300/50 dark:border-gray-600/50 rounded-xl focus:border-transparent dark:text-white"
               />
             </div>
             
@@ -284,7 +284,7 @@ export default function AddInvestmentModal({ isOpen, onClose, accountId }: AddIn
                 id="investment-stamp-duty"
                 value={formData.stampDuty}
                 onChange={(value) => updateField('stampDuty', value)}
-                className="w-full px-3 py-2 bg-white dark:bg-gray-800-sm border border-gray-300/50 dark:border-gray-600/50 rounded-xl focus:outline-none focus:ring-2 focus:ring-primary focus:border-transparent dark:text-white"
+                className="w-full px-3 py-2 bg-white dark:bg-gray-800-sm border border-gray-300/50 dark:border-gray-600/50 rounded-xl focus:border-transparent dark:text-white"
               />
             </div>
             
@@ -298,7 +298,7 @@ export default function AddInvestmentModal({ isOpen, onClose, accountId }: AddIn
               <DatePicker
                 value={formData.date}
                 onChange={(val) => updateField('date', val)}
-                className="bg-white dark:bg-gray-800-sm border border-gray-300/50 dark:border-gray-600/50 rounded-xl focus:outline-none focus:ring-2 focus:ring-primary focus:border-transparent dark:text-white"
+                className="bg-white dark:bg-gray-800-sm border border-gray-300/50 dark:border-gray-600/50 rounded-xl focus:border-transparent dark:text-white"
                 required
                 aria-label="Purchase date"
               />
@@ -352,7 +352,7 @@ export default function AddInvestmentModal({ isOpen, onClose, accountId }: AddIn
               onChange={(e) => updateField('notes', e.target.value)}
               rows={3}
               placeholder="Additional information about this investment..."
-              className="w-full px-3 py-2 bg-white dark:bg-gray-800-sm border border-gray-300/50 dark:border-gray-600/50 rounded-xl focus:outline-none focus:ring-2 focus:ring-primary focus:border-transparent dark:text-white"
+              className="w-full px-3 py-2 bg-white dark:bg-gray-800-sm border border-gray-300/50 dark:border-gray-600/50 rounded-xl focus:border-transparent dark:text-white"
             />
           </div>
           

--- a/src/components/AddTransactionModal.tsx
+++ b/src/components/AddTransactionModal.tsx
@@ -464,7 +464,7 @@ export default function AddTransactionModal({ isOpen, onClose, initialAccountId 
                 onAccountChange={(accountId) => updateField('accountId', accountId)}
                 placeholder="Search or select account…"
                 formatLabel={(account) => `${account.name} (${account.type})`}
-                className="w-full px-3 py-3 sm:py-2 text-base sm:text-sm bg-white dark:bg-gray-700 border-2 border-gray-300 dark:border-gray-500 rounded-lg focus:outline-none focus:ring-2 focus:ring-primary dark:focus:ring-blue-400 focus:border-transparent dark:text-white min-h-[48px] sm:min-h-[auto]"
+                className="w-full px-3 py-3 sm:py-2 text-base sm:text-sm bg-white dark:bg-gray-700 border-2 border-gray-300 dark:border-gray-500 rounded-lg focus:border-transparent dark:text-white min-h-[48px] sm:min-h-[auto]"
                 usePortal
                 required
                 ariaLabel="Select account for transaction"
@@ -485,7 +485,7 @@ export default function AddTransactionModal({ isOpen, onClose, initialAccountId 
                     setValidationErrors(prev => ({ ...prev, description: '' }));
                   }
                 }}
-                className={`w-full px-3 py-3 sm:py-2 text-base sm:text-sm bg-white dark:bg-gray-700 border-2 ${validationErrors.description ? 'border-red-500' : 'border-gray-300 dark:border-gray-500'} rounded-lg focus:outline-none focus:ring-2 focus:ring-primary dark:focus:ring-blue-400 focus:border-transparent dark:text-white min-h-[48px] sm:min-h-[auto]`}
+                className={`w-full px-3 py-3 sm:py-2 text-base sm:text-sm bg-white dark:bg-gray-700 border-2 ${validationErrors.description ?'border-red-500':'border-gray-300 dark:border-gray-500'} rounded-lg focus:border-transparent dark:text-white min-h-[48px] sm:min-h-[auto]`}
                 placeholder="e.g., Grocery shopping"
                 maxLength={500}
                 required
@@ -515,7 +515,7 @@ export default function AddTransactionModal({ isOpen, onClose, initialAccountId 
                     setValidationErrors(prev => ({ ...prev, amount: '' }));
                   }
                 }}
-                className={`w-full px-3 py-3 sm:py-2 text-base sm:text-sm bg-white dark:bg-gray-700 border-2 ${validationErrors.amount ? 'border-red-500' : 'border-gray-300 dark:border-gray-500'} rounded-lg focus:outline-none focus:ring-2 focus:ring-primary dark:focus:ring-blue-400 focus:border-transparent dark:text-white min-h-[48px] sm:min-h-[auto]`}
+                className={`w-full px-3 py-3 sm:py-2 text-base sm:text-sm bg-white dark:bg-gray-700 border-2 ${validationErrors.amount ?'border-red-500':'border-gray-300 dark:border-gray-500'} rounded-lg focus:border-transparent dark:text-white min-h-[48px] sm:min-h-[auto]`}
                 required
                 aria-label="Transaction amount"
                 aria-describedby={validationErrors.amount ? "amount-error" : undefined}
@@ -552,7 +552,7 @@ export default function AddTransactionModal({ isOpen, onClose, initialAccountId 
                   }}
                   placeholder="Search or select the account the money moved to…"
                   formatLabel={(account) => `${account.name} (${account.type})`}
-                  className="w-full px-3 py-3 sm:py-2 text-base sm:text-sm bg-white dark:bg-gray-700 border-2 border-gray-300 dark:border-gray-500 rounded-lg focus:outline-none focus:ring-2 focus:ring-primary dark:focus:ring-blue-400 focus:border-transparent dark:text-white min-h-[48px] sm:min-h-[auto]"
+                  className="w-full px-3 py-3 sm:py-2 text-base sm:text-sm bg-white dark:bg-gray-700 border-2 border-gray-300 dark:border-gray-500 rounded-lg focus:border-transparent dark:text-white min-h-[48px] sm:min-h-[auto]"
                   usePortal
                   required
                   ariaLabel="Select the account to transfer to"
@@ -588,7 +588,7 @@ export default function AddTransactionModal({ isOpen, onClose, initialAccountId 
                     updateField('subCategory', e.target.value);
                     updateField('category', ''); // Reset detail category
                   }}
-                  className="w-full px-3 py-3 sm:py-2 text-base sm:text-sm bg-white dark:bg-gray-700 border-2 border-gray-300 dark:border-gray-500 rounded-lg focus:outline-none focus:ring-2 focus:ring-primary dark:focus:ring-blue-400 focus:border-transparent dark:text-white min-h-[48px] sm:min-h-[auto]"
+                  className="w-full px-3 py-3 sm:py-2 text-base sm:text-sm bg-white dark:bg-gray-700 border-2 border-gray-300 dark:border-gray-500 rounded-lg focus:border-transparent dark:text-white min-h-[48px] sm:min-h-[auto]"
                   required
                   aria-label="Select transaction category"
                 >
@@ -609,7 +609,7 @@ export default function AddTransactionModal({ isOpen, onClose, initialAccountId 
                     id="subcategory-select"
                     value={formData.category}
                     onChange={(e) => updateField('category', e.target.value)}
-                    className="w-full px-3 py-3 sm:py-2 text-base sm:text-sm bg-white dark:bg-gray-700 border-2 border-gray-300 dark:border-gray-500 rounded-lg focus:outline-none focus:ring-2 focus:ring-primary dark:focus:ring-blue-400 focus:border-transparent dark:text-white min-h-[48px] sm:min-h-[auto]"
+                    className="w-full px-3 py-3 sm:py-2 text-base sm:text-sm bg-white dark:bg-gray-700 border-2 border-gray-300 dark:border-gray-500 rounded-lg focus:border-transparent dark:text-white min-h-[48px] sm:min-h-[auto]"
                     required
                     aria-label="Select transaction sub-category"
                   >
@@ -641,7 +641,7 @@ export default function AddTransactionModal({ isOpen, onClose, initialAccountId 
                 id="date-input"
                 value={formData.date}
                 onChange={(val) => updateField('date', val)}
-                className="text-base sm:text-sm bg-white dark:bg-gray-700 border-2 border-gray-300 dark:border-gray-500 rounded-lg focus:outline-none focus:ring-2 focus:ring-primary dark:focus:ring-blue-400 focus:border-transparent dark:text-white min-h-[48px] sm:min-h-[auto]"
+                className="text-base sm:text-sm bg-white dark:bg-gray-700 border-2 border-gray-300 dark:border-gray-500 rounded-lg focus:border-transparent dark:text-white min-h-[48px] sm:min-h-[auto]"
                 required
                 aria-label="Transaction date"
               />

--- a/src/components/AddWithoutCategoryConfirm.tsx
+++ b/src/components/AddWithoutCategoryConfirm.tsx
@@ -102,7 +102,7 @@ export default function AddWithoutCategoryConfirm({
             ref={cancelRef}
             type="button"
             onClick={onCancel}
-            className="px-4 py-2 border border-gray-300 dark:border-gray-600 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-700 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
+            className="px-4 py-2 border border-gray-300 dark:border-gray-600 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-700"
           >
             Cancel
           </button>
@@ -110,7 +110,7 @@ export default function AddWithoutCategoryConfirm({
             ref={confirmRef}
             type="button"
             onClick={onConfirm}
-            className="px-4 py-2 bg-[#1a2332] text-white rounded-lg hover:bg-secondary focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-400 focus-visible:ring-offset-2 dark:focus-visible:ring-offset-gray-800"
+            className="px-4 py-2 bg-[#1a2332] text-white rounded-lg hover:bg-secondary"
           >
             Continue
           </button>

--- a/src/components/ArchiveManager.tsx
+++ b/src/components/ArchiveManager.tsx
@@ -267,7 +267,7 @@ export default function ArchiveManager() {
               type="button"
               onClick={event => { event.stopPropagation(); openAccountHistory(account.id); }}
               title={`Open ${account.name} with archived transactions shown`}
-              className="text-left hover:underline focus:outline-none focus:ring-2 focus:ring-[#1a2332] dark:focus:ring-blue-500 rounded"
+              className="text-left hover:underline rounded"
             >
               {account.name}
             </button>

--- a/src/components/BankConnections.tsx
+++ b/src/components/BankConnections.tsx
@@ -485,7 +485,7 @@ export default function BankConnections({
               value={searchTerm}
               onChange={(e) => setSearchTerm(e.target.value)}
               placeholder="Search for your bank..."
-              className="w-full pl-10 pr-4 py-2 border border-gray-300 dark:border-gray-600 rounded-lg focus:ring-2 focus:ring-primary focus:border-transparent dark:bg-gray-700 dark:text-white"
+              className="w-full pl-10 pr-4 py-2 border border-gray-300 dark:border-gray-600 rounded-lg focus:border-transparent dark:bg-gray-700 dark:text-white"
             />
           </div>
 

--- a/src/components/BudgetModal.tsx
+++ b/src/components/BudgetModal.tsx
@@ -220,7 +220,7 @@ export default function BudgetModal({ isOpen, onClose, budget, onEditExisting }:
               required
               value={formData.amount}
               onChange={(value) => updateField('amount', value)}
-              className="w-full px-3 py-2 bg-white dark:bg-gray-800-sm border border-gray-300/50 dark:border-gray-600/50 rounded-xl focus:outline-none focus:ring-2 focus:ring-primary focus:border-transparent dark:text-white"
+              className="w-full px-3 py-2 bg-white dark:bg-gray-800-sm border border-gray-300/50 dark:border-gray-600/50 rounded-xl focus:border-transparent dark:text-white"
             />
           </div>
 
@@ -231,7 +231,7 @@ export default function BudgetModal({ isOpen, onClose, budget, onEditExisting }:
             <select
               value={formData.period}
               onChange={(e) => updateField('period', toBudgetPeriod(e.target.value))}
-              className="w-full px-3 py-2 bg-white dark:bg-gray-800-sm border border-gray-300/50 dark:border-gray-600/50 rounded-xl focus:outline-none focus:ring-2 focus:ring-primary focus:border-transparent dark:text-white"
+              className="w-full px-3 py-2 bg-white dark:bg-gray-800-sm border border-gray-300/50 dark:border-gray-600/50 rounded-xl focus:border-transparent dark:text-white"
             >
               {PERIOD_OPTIONS.map(option => (
                 <option key={option.value} value={option.value}>{option.label}</option>

--- a/src/components/BulkDeleteTransactionsConfirm.tsx
+++ b/src/components/BulkDeleteTransactionsConfirm.tsx
@@ -164,7 +164,7 @@ export default function BulkDeleteTransactionsConfirm({
             type="button"
             onClick={onCancel}
             disabled={busy}
-            className="px-4 py-2 border border-gray-300 dark:border-gray-600 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-700 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 disabled:opacity-50 dark:text-gray-200"
+            className="px-4 py-2 border border-gray-300 dark:border-gray-600 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-700 disabled:opacity-50 dark:text-gray-200"
           >
             {nothingToDelete ? 'Close' : 'Cancel'}
           </button>
@@ -174,7 +174,7 @@ export default function BulkDeleteTransactionsConfirm({
               type="button"
               onClick={onConfirm}
               disabled={busy}
-              className="px-4 py-2 bg-red-600 text-white rounded-lg hover:bg-red-700 focus:outline-none focus-visible:ring-2 focus-visible:ring-red-400 focus-visible:ring-offset-2 dark:focus-visible:ring-offset-gray-800 disabled:opacity-50 disabled:cursor-not-allowed"
+              className="px-4 py-2 bg-red-600 text-white rounded-lg hover:bg-red-700 disabled:opacity-50 disabled:cursor-not-allowed"
             >
               {busy ? 'Deleting…' : count === 1 ? 'Delete 1 transaction' : `Delete ${count} transactions`}
             </button>

--- a/src/components/CSVBankTemplates.tsx
+++ b/src/components/CSVBankTemplates.tsx
@@ -87,7 +87,7 @@ export default function CSVBankTemplates({
         value={query}
         onChange={event => setQuery(event.target.value)}
         placeholder="Barclays, Monzo, Wells Fargo, &quot;paid out&quot;…"
-        className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg focus:ring-2 focus:ring-primary focus:border-transparent dark:bg-gray-700 dark:text-white"
+        className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg focus:border-transparent dark:bg-gray-700 dark:text-white"
       />
 
       {matches.length === 0 ? (
@@ -116,7 +116,7 @@ export default function CSVBankTemplates({
                         // the banner further up the step.
                         aria-pressed={isSelected}
                         onClick={() => onSelectBank(template)}
-                        className={`w-full text-left px-3 py-2 rounded-lg transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-primary ${
+                        className={`w-full text-left px-3 py-2 rounded-lg transition-colors ${
                           isSelected
                             ? 'bg-blue-50 dark:bg-blue-900/30 ring-1 ring-blue-400'
                             : 'bg-gray-100 dark:bg-gray-700 hover:bg-gray-200 dark:hover:bg-gray-600'

--- a/src/components/CSVImportWizard.tsx
+++ b/src/components/CSVImportWizard.tsx
@@ -1220,7 +1220,7 @@ export default function CSVImportWizard({ isOpen, onClose, initialFile }: CSVImp
                   type="button"
                   onClick={() => setShowTemplates(value => !value)}
                   aria-expanded={showTemplates}
-                  className="flex items-center gap-2 text-sm font-medium text-primary hover:text-secondary transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-primary rounded"
+                  className="flex items-center gap-2 text-sm font-medium text-primary hover:text-secondary transition-colors rounded"
                 >
                   <ChevronRightIcon
                     size={16}
@@ -1299,7 +1299,7 @@ export default function CSVImportWizard({ isOpen, onClose, initialFile }: CSVImp
                       type="button"
                       onClick={() => setShowHeaderPicker(value => !value)}
                       aria-expanded={showHeaderPicker}
-                      className="text-sm text-primary hover:text-secondary transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-primary rounded"
+                      className="text-sm text-primary hover:text-secondary transition-colors rounded"
                     >
                       {showHeaderPicker ? 'Hide the file’s first lines' : 'Not right? Choose the heading line'}
                     </button>
@@ -1382,7 +1382,7 @@ export default function CSVImportWizard({ isOpen, onClose, initialFile }: CSVImp
                       );
                     }}
                     aria-describedby={dateFormatNote ? 'csv-date-format-note' : undefined}
-                    className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg focus:ring-2 focus:ring-primary focus:border-transparent dark:bg-gray-700 dark:text-white"
+                    className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg focus:border-transparent dark:bg-gray-700 dark:text-white"
                   >
                     {/* 'auto' stays the selected value until the user moves it,
                         even when the file is ambiguous and we can name the
@@ -1482,7 +1482,7 @@ export default function CSVImportWizard({ isOpen, onClose, initialFile }: CSVImp
                   onAccountChange={setDestinationAccountId}
                   placeholder="Search or select an account…"
                   formatLabel={(account: Account) => `${account.name} (${account.type})`}
-                  className="w-full px-3 py-2 h-[42px] border border-gray-300 dark:border-gray-600 rounded-lg focus:ring-2 focus:ring-primary focus:border-transparent dark:bg-gray-700 dark:text-white"
+                  className="w-full px-3 py-2 h-[42px] border border-gray-300 dark:border-gray-600 rounded-lg focus:border-transparent dark:bg-gray-700 dark:text-white"
                   usePortal
                   required
                   ariaLabel="Import these transactions into"
@@ -1567,7 +1567,7 @@ export default function CSVImportWizard({ isOpen, onClose, initialFile }: CSVImp
                     if (profile) loadProfile(profile);
                     else setSelectedProfile(null);
                   }}
-                  className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg focus:ring-2 focus:ring-primary focus:border-transparent dark:bg-gray-700 dark:text-white"
+                  className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg focus:border-transparent dark:bg-gray-700 dark:text-white"
                 >
                   <option value="">Select a saved profile...</option>
                   {profiles.map(profile => (
@@ -1596,7 +1596,7 @@ export default function CSVImportWizard({ isOpen, onClose, initialFile }: CSVImp
                           aria-label={`CSV column for mapping ${index + 1}`}
                           value={mapping.sourceColumn}
                           onChange={(e) => updateMapping(index, 'sourceColumn', e.target.value)}
-                          className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg focus:ring-2 focus:ring-primary focus:border-transparent dark:bg-gray-700 dark:text-white"
+                          className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg focus:border-transparent dark:bg-gray-700 dark:text-white"
                         >
                           <option value="">Select CSV column...</option>
                           {headers.map(header => (
@@ -1633,7 +1633,7 @@ export default function CSVImportWizard({ isOpen, onClose, initialFile }: CSVImp
                           aria-label={`Target field for mapping ${index + 1}`}
                           value={mapping.targetField}
                           onChange={(e) => updateMapping(index, 'targetField', e.target.value)}
-                          className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg focus:ring-2 focus:ring-primary focus:border-transparent dark:bg-gray-700 dark:text-white"
+                          className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg focus:border-transparent dark:bg-gray-700 dark:text-white"
                         >
                           <option value="">Select target field...</option>
                           {targetFields.map(field => (
@@ -1736,7 +1736,7 @@ export default function CSVImportWizard({ isOpen, onClose, initialFile }: CSVImp
                       type="checkbox"
                       checked={showDuplicates}
                       onChange={(e) => setShowDuplicates(e.target.checked)}
-                      className="rounded border-gray-300 text-primary focus:ring-primary"
+                      className="rounded border-gray-300 text-primary"
                     />
                     <span className="text-sm font-medium text-gray-700 dark:text-gray-300">
                       Skip duplicate transactions
@@ -1752,7 +1752,7 @@ export default function CSVImportWizard({ isOpen, onClose, initialFile }: CSVImp
                       onChange={(e) => setDuplicateThreshold(Number(e.target.value))}
                       min="50"
                       max="100"
-                      className="w-16 px-2 py-1 text-sm border border-gray-300 dark:border-gray-600 rounded focus:ring-2 focus:ring-primary focus:border-transparent dark:bg-gray-700 dark:text-white"
+                      className="w-16 px-2 py-1 text-sm border border-gray-300 dark:border-gray-600 rounded focus:border-transparent dark:bg-gray-700 dark:text-white"
                     />
                     <span className="text-sm text-gray-600 dark:text-gray-400">%</span>
                   </div>

--- a/src/components/CashFlowForecast.tsx
+++ b/src/components/CashFlowForecast.tsx
@@ -92,7 +92,7 @@ export default function CashFlowForecast({ accountIds, className = '' }: CashFlo
           <select
             value={forecastMonths}
             onChange={(e) => setForecastMonths(Number(e.target.value))}
-            className="px-4 py-2 border border-gray-300 dark:border-gray-600 rounded-lg focus:ring-2 focus:ring-primary focus:border-transparent dark:bg-gray-700 dark:text-white"
+            className="px-4 py-2 border border-gray-300 dark:border-gray-600 rounded-lg focus:border-transparent dark:bg-gray-700 dark:text-white"
           >
             <option value={3}>3 months</option>
             <option value={6}>6 months</option>

--- a/src/components/CategoryCreationModal.tsx
+++ b/src/components/CategoryCreationModal.tsx
@@ -204,7 +204,7 @@ export default function CategoryCreationModal({
             <select
               value={showNewCategory ? 'new' : formData.selectedCategory}
               onChange={(e) => handleCategoryChange(e.target.value)}
-              className="w-full px-3 py-2 bg-white dark:bg-gray-800-sm border border-gray-300/50 dark:border-gray-600/50 rounded-xl focus:outline-none focus:ring-2 focus:ring-primary focus:border-transparent dark:text-white"
+              className="w-full px-3 py-2 bg-white dark:bg-gray-800-sm border border-gray-300/50 dark:border-gray-600/50 rounded-xl focus:border-transparent dark:text-white"
             >
               <option value="">Select a category</option>
               
@@ -234,7 +234,7 @@ export default function CategoryCreationModal({
                 value={formData.newCategoryName}
                 onChange={(e) => updateField('newCategoryName', e.target.value)}
                 placeholder="Enter new category name"
-                className="mt-2 w-full px-3 py-2 bg-white dark:bg-gray-800-sm border border-gray-300/50 dark:border-gray-600/50 rounded-xl focus:outline-none focus:ring-2 focus:ring-primary focus:border-transparent dark:text-white"
+                className="mt-2 w-full px-3 py-2 bg-white dark:bg-gray-800-sm border border-gray-300/50 dark:border-gray-600/50 rounded-xl focus:border-transparent dark:text-white"
                 autoFocus
               />
             )}
@@ -250,7 +250,7 @@ export default function CategoryCreationModal({
                 <select
                   value={showNewSpecific ? 'new' : formData.selectedSpecific}
                   onChange={(e) => handleSpecificChange(e.target.value)}
-                  className="w-full px-3 py-2 bg-white dark:bg-gray-800-sm border border-gray-300/50 dark:border-gray-600/50 rounded-xl focus:outline-none focus:ring-2 focus:ring-primary focus:border-transparent dark:text-white"
+                  className="w-full px-3 py-2 bg-white dark:bg-gray-800-sm border border-gray-300/50 dark:border-gray-600/50 rounded-xl focus:border-transparent dark:text-white"
                 >
                   <option value="">Select specific category (optional)</option>
                   
@@ -273,7 +273,7 @@ export default function CategoryCreationModal({
                   value={formData.newSpecificName}
                   onChange={(e) => updateField('newSpecificName', e.target.value)}
                   placeholder="Enter new specific category name"
-                  className="mt-2 w-full px-3 py-2 bg-white dark:bg-gray-800-sm border border-gray-300/50 dark:border-gray-600/50 rounded-xl focus:outline-none focus:ring-2 focus:ring-primary focus:border-transparent dark:text-white"
+                  className="mt-2 w-full px-3 py-2 bg-white dark:bg-gray-800-sm border border-gray-300/50 dark:border-gray-600/50 rounded-xl focus:border-transparent dark:text-white"
                   autoFocus
                 />
               )}

--- a/src/components/CategorySelector.tsx
+++ b/src/components/CategorySelector.tsx
@@ -718,7 +718,7 @@ export default function CategorySelector({
                     value={newCategoryName}
                     onChange={(e) => setNewCategoryName(e.target.value)}
                     placeholder="e.g. Gym Membership"
-                    className="w-full px-2.5 py-1.5 text-sm bg-white dark:bg-gray-800 border border-gray-300 dark:border-gray-600 rounded-lg focus:outline-none focus:ring-1 focus:ring-primary dark:text-white"
+                    className="w-full px-2.5 py-1.5 text-sm bg-white dark:bg-gray-800 border border-gray-300 dark:border-gray-600 rounded-lg dark:text-white"
                     onKeyDown={(e) => {
                       if (e.key === 'Enter') {
                         e.preventDefault();

--- a/src/components/CrossCurrencyTransferDialog.tsx
+++ b/src/components/CrossCurrencyTransferDialog.tsx
@@ -196,7 +196,7 @@ export default function CrossCurrencyTransferDialog({
   const controlClass =
     'w-full px-3 py-2 h-[42px] text-right tabular-nums bg-white dark:bg-gray-800 ' +
     'border border-line dark:border-gray-600 rounded ' +
-    'focus:outline-none focus:ring-2 focus:ring-primary focus:border-transparent ' +
+'focus:border-transparent'+
     'text-gray-900 dark:text-white';
 
   // Portalled to document.body for the reason TransferMatchDialog gives: a

--- a/src/components/CustomReportBuilder.tsx
+++ b/src/components/CustomReportBuilder.tsx
@@ -448,7 +448,7 @@ export default function CustomReportBuilder({
               type="text"
               value={reportName}
               onChange={(e) => setReportName(e.target.value)}
-              className="w-full px-3 py-2 bg-white dark:bg-gray-800 border border-gray-300 dark:border-gray-600 rounded-lg focus:outline-none focus:ring-2 focus:ring-primary"
+              className="w-full px-3 py-2 bg-white dark:bg-gray-800 border border-gray-300 dark:border-gray-600 rounded-lg"
               placeholder="Monthly Financial Summary"
             />
           </div>
@@ -460,7 +460,7 @@ export default function CustomReportBuilder({
               type="text"
               value={reportDescription}
               onChange={(e) => setReportDescription(e.target.value)}
-              className="w-full px-3 py-2 bg-white dark:bg-gray-800 border border-gray-300 dark:border-gray-600 rounded-lg focus:outline-none focus:ring-2 focus:ring-primary"
+              className="w-full px-3 py-2 bg-white dark:bg-gray-800 border border-gray-300 dark:border-gray-600 rounded-lg"
               placeholder="Overview of monthly income, expenses, and savings"
             />
           </div>

--- a/src/components/CustomReportViewer.tsx
+++ b/src/components/CustomReportViewer.tsx
@@ -15,6 +15,7 @@ import {
   Legend,
 } from 'recharts';
 import { useCurrencyDecimal } from '../hooks/useCurrencyDecimal';
+import { categoricalColor, useCategoricalRamp } from './charts/chartColors';
 import { formatDecimal } from '../utils/decimal-format';
 import type { CustomReport, ReportComponent } from './CustomReportBuilder';
 
@@ -25,11 +26,6 @@ import type { CustomReport, ReportComponent } from './CustomReportBuilder';
  * one library), and every figure comes from customReportService's generators,
  * which classify through the shared category semantics.
  */
-
-const CATEGORY_COLORS = [
-  '#3B82F6', '#10B981', '#F59E0B', '#EF4444',
-  '#8B5CF6', '#EC4899', '#6366F1', '#14B8A6'
-];
 
 export interface GeneratedReport {
   report: CustomReport;
@@ -68,6 +64,10 @@ export default function CustomReportViewer({
 }): React.JSX.Element {
   const { formatCurrency } = useCurrencyDecimal();
   const { report, dateRange, data } = generated;
+  // One ramp for every chart in the app. The eight-colour array that used to
+  // sit at the top of this file put an emerald and a red in a CATEGORICAL
+  // list, inches from figures where those two hues mean income and expense.
+  const ramp = useCategoricalRamp();
 
   const money = (v: number | string): string =>
     formatCurrency(typeof v === 'number' ? v : Number(v));
@@ -123,7 +123,7 @@ export default function CustomReportViewer({
                       key={ds.label}
                       type="monotone"
                       dataKey={ds.label}
-                      stroke={ds.borderColor ?? CATEGORY_COLORS[i % CATEGORY_COLORS.length]}
+                      stroke={ds.borderColor ?? categoricalColor(ramp, i)}
                       strokeWidth={2}
                       dot={false}
                       isAnimationActive={false}
@@ -141,7 +141,7 @@ export default function CustomReportViewer({
                     <Bar
                       key={ds.label}
                       dataKey={ds.label}
-                      fill={ds.backgroundColor ?? CATEGORY_COLORS[i % CATEGORY_COLORS.length]}
+                      fill={ds.backgroundColor ?? categoricalColor(ramp, i)}
                       radius={[3, 3, 0, 0]}
                       isAnimationActive={false}
                     />
@@ -164,7 +164,7 @@ export default function CustomReportViewer({
                 <RechartsPieChart>
                   <Pie data={rows} dataKey="value" nameKey="name" innerRadius="55%" outerRadius="88%" strokeWidth={0} isAnimationActive={false}>
                     {rows.map((row, i) => (
-                      <Cell key={row.name} fill={CATEGORY_COLORS[i % CATEGORY_COLORS.length]} />
+                      <Cell key={row.name} fill={categoricalColor(ramp, i)} />
                     ))}
                   </Pie>
                   <Tooltip formatter={money} />
@@ -174,7 +174,7 @@ export default function CustomReportViewer({
             <ul className="w-44 space-y-1">
               {rows.slice(0, 8).map((row, i) => (
                 <li key={row.name} className="flex items-center gap-2 text-xs">
-                  <span className="w-2.5 h-2.5 rounded-sm flex-shrink-0" style={{ backgroundColor: CATEGORY_COLORS[i % CATEGORY_COLORS.length] }} />
+                  <span className="w-2.5 h-2.5 rounded-sm flex-shrink-0" style={{ backgroundColor: categoricalColor(ramp, i) }} />
                   <span className="flex-1 min-w-0 truncate text-gray-600 dark:text-gray-300">{row.name}</span>
                   <span className="tabular-nums text-gray-900 dark:text-white">{money(row.value)}</span>
                 </li>

--- a/src/components/DeleteTransactionConfirm.tsx
+++ b/src/components/DeleteTransactionConfirm.tsx
@@ -129,14 +129,14 @@ export default function DeleteTransactionConfirm({
   // buttons, and "Delete this side only" is exactly the length that invites it.
   // Whole buttons may wrap instead (sm:flex-wrap below); words may not.
   const outlinedButton =
-    'px-4 py-2 whitespace-nowrap border border-gray-300 dark:border-gray-600 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-700 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500';
+'px-4 py-2 whitespace-nowrap border border-gray-300 dark:border-gray-600 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-700';
   const destructiveButton =
-    'px-4 py-2 whitespace-nowrap bg-red-600 text-white rounded-lg hover:bg-red-700 focus:outline-none focus-visible:ring-2 focus-visible:ring-red-400 focus-visible:ring-offset-2 dark:focus-visible:ring-offset-gray-800';
+'px-4 py-2 whitespace-nowrap bg-red-600 text-white rounded-lg hover:bg-red-700';
   // Outlined, but in the destructive colour: the narrower of the two deletes is
   // still a delete, and a neutral grey beside Cancel would read as a second way
   // of backing out.
   const narrowerDestructiveButton =
-    'px-4 py-2 whitespace-nowrap border border-red-300 dark:border-red-700 text-red-700 dark:text-red-400 rounded-lg hover:bg-red-50 dark:hover:bg-red-900/20 focus:outline-none focus-visible:ring-2 focus-visible:ring-red-400 focus-visible:ring-offset-2 dark:focus-visible:ring-offset-gray-800';
+'px-4 py-2 whitespace-nowrap border border-red-300 dark:border-red-700 text-red-700 dark:text-red-400 rounded-lg hover:bg-red-50 dark:hover:bg-red-900/20';
 
   return createPortal(
     <div

--- a/src/components/DocumentManager.tsx
+++ b/src/components/DocumentManager.tsx
@@ -268,7 +268,7 @@ export default function DocumentManager({
               placeholder="Search documents..."
               value={searchTerm}
               onChange={(e) => setSearchTerm(e.target.value)}
-              className="w-full pl-10 pr-4 py-2 border border-gray-300 dark:border-gray-600 rounded-lg focus:ring-2 focus:ring-blue-600 focus:border-transparent dark:bg-gray-700 dark:text-white"
+              className="w-full pl-10 pr-4 py-2 border border-gray-300 dark:border-gray-600 rounded-lg focus:border-transparent dark:bg-gray-700 dark:text-white"
             />
           </div>
 
@@ -284,7 +284,7 @@ export default function DocumentManager({
                 setFilterType(value);
               }
             }}
-            className="px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg focus:ring-2 focus:ring-blue-600 dark:bg-gray-700 dark:text-white"
+            className="px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg dark:bg-gray-700 dark:text-white"
           >
             <option value="all">All Types</option>
             <option value="receipt">Receipts</option>
@@ -304,7 +304,7 @@ export default function DocumentManager({
                   setFilterTags([...filterTags, e.target.value]);
                 }
               }}
-              className="px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg focus:ring-2 focus:ring-blue-600 dark:bg-gray-700 dark:text-white"
+              className="px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg dark:bg-gray-700 dark:text-white"
             >
               <option value="">Filter by tag...</option>
               {getAllTags().map(tag => (

--- a/src/components/EditCategoryModal.tsx
+++ b/src/components/EditCategoryModal.tsx
@@ -127,7 +127,7 @@ export default function EditCategoryModal({
                 if (e.key === 'Enter') void handleSave();
               }}
               autoFocus
-              className="w-full px-3 py-2 rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-900 text-gray-900 dark:text-white focus:outline-none focus:ring-2 focus:ring-[var(--color-primary)]"
+              className="w-full px-3 py-2 rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-900 text-gray-900 dark:text-white"
             />
           </div>
 
@@ -145,7 +145,7 @@ export default function EditCategoryModal({
                     type="checkbox"
                     checked={isAdjustment}
                     onChange={(e) => setIsAdjustment(e.target.checked)}
-                    className="mt-1 h-4 w-4 shrink-0 rounded border-gray-300 dark:border-gray-600 text-[var(--color-primary)] focus:ring-[var(--color-primary)]"
+                    className="mt-1 h-4 w-4 shrink-0 rounded border-gray-300 dark:border-gray-600 text-[var(--color-primary)]"
                   />
                   <span>
                     <span className="block text-sm font-medium text-gray-900 dark:text-white">

--- a/src/components/EditTransactionModal.tsx
+++ b/src/components/EditTransactionModal.tsx
@@ -996,7 +996,7 @@ export default function EditTransactionModal({ isOpen, onClose, transaction, def
               <DatePicker
                 value={formData.date}
                 onChange={(val) => updateField('date', val)}
-                className="min-w-0 h-12 sm:h-[42px] text-base sm:text-sm bg-white dark:bg-gray-700 border-2 border-gray-300 dark:border-gray-500 rounded-lg focus:outline-none focus:ring-2 focus:ring-primary dark:focus:ring-blue-400 focus:border-transparent dark:text-white"
+                className="min-w-0 h-12 sm:h-[42px] text-base sm:text-sm bg-white dark:bg-gray-700 border-2 border-gray-300 dark:border-gray-500 rounded-lg focus:border-transparent dark:text-white"
                 required
                 aria-label="Transaction date"
               />
@@ -1018,7 +1018,7 @@ export default function EditTransactionModal({ isOpen, onClose, transaction, def
                 onAccountChange={(accountId) => updateField('accountId', accountId)}
                 placeholder="Search or select account…"
                 formatLabel={(acc) => `${acc.name} (${acc.type})`}
-                className="w-full px-3 py-3 sm:py-2 h-12 sm:h-[42px] text-base sm:text-sm bg-white dark:bg-gray-700 border-2 border-gray-300 dark:border-gray-500 rounded-lg focus:outline-none focus:ring-2 focus:ring-primary dark:focus:ring-blue-400 focus:border-transparent dark:text-white"
+                className="w-full px-3 py-3 sm:py-2 h-12 sm:h-[42px] text-base sm:text-sm bg-white dark:bg-gray-700 border-2 border-gray-300 dark:border-gray-500 rounded-lg focus:border-transparent dark:text-white"
                 usePortal
                 required
               />
@@ -1034,7 +1034,7 @@ export default function EditTransactionModal({ isOpen, onClose, transaction, def
                 type="text"
                 value={formData.description}
                 onChange={(e) => updateField('description', e.target.value)}
-                className="w-full px-3 py-3 sm:py-2 h-12 sm:h-[42px] text-base sm:text-sm bg-white dark:bg-gray-700 border-2 border-gray-300 dark:border-gray-500 rounded-lg focus:outline-none focus:ring-2 focus:ring-primary dark:focus:ring-blue-400 focus:border-transparent dark:text-white"
+                className="w-full px-3 py-3 sm:py-2 h-12 sm:h-[42px] text-base sm:text-sm bg-white dark:bg-gray-700 border-2 border-gray-300 dark:border-gray-500 rounded-lg focus:border-transparent dark:text-white"
                 required
               />
             </div>
@@ -1140,7 +1140,7 @@ export default function EditTransactionModal({ isOpen, onClose, transaction, def
                   }
                 }}
                 placeholder="0.00"
-                className={`w-full px-3 py-2 h-[42px] text-right bg-white dark:bg-gray-800-sm border border-gray-300/50 dark:border-gray-600/50 rounded-xl focus:outline-none focus:ring-2 focus:ring-primary focus:border-transparent ${
+                className={`w-full px-3 py-2 h-[42px] text-right bg-white dark:bg-gray-800-sm border border-gray-300/50 dark:border-gray-600/50 rounded-xl focus:border-transparent ${
                   formData.amount && (parseMoneyInput(formData.amount) ?? 0) < 0
                     ? 'text-red-600 dark:text-red-400'
                     : formData.amount && (parseMoneyInput(formData.amount) ?? 0) > 0
@@ -1347,7 +1347,7 @@ export default function EditTransactionModal({ isOpen, onClose, transaction, def
                                 // shop reduces the total), so negatives stay enterable.
                                 allowNegative
                                 aria-label={`Split line ${index + 1} amount`}
-                                className="w-28 shrink-0 px-3 py-2 h-[42px] text-right bg-white dark:bg-gray-800-sm border border-gray-300/50 dark:border-gray-600/50 rounded-xl focus:outline-none focus:ring-2 focus:ring-primary focus:border-transparent text-gray-900 dark:text-white"
+                                className="w-28 shrink-0 px-3 py-2 h-[42px] text-right bg-white dark:bg-gray-800-sm border border-gray-300/50 dark:border-gray-600/50 rounded-xl focus:border-transparent text-gray-900 dark:text-white"
                               />
                             )}
                             {splitLines.length > 2 && !lockedLeg && (

--- a/src/components/ErrorFallback.tsx
+++ b/src/components/ErrorFallback.tsx
@@ -21,13 +21,13 @@ export function ErrorFallback({ error, resetError }: ErrorFallbackProps): React.
         <div className="mt-6 flex gap-3">
           <button
             onClick={resetError}
-            className="flex-1 justify-center px-4 py-2 text-sm font-medium text-white bg-indigo-600 rounded-md hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500"
+            className="flex-1 justify-center px-4 py-2 text-sm font-medium text-white bg-indigo-600 rounded-md hover:bg-indigo-700"
           >
             Try again
           </button>
           <button
             onClick={() => window.location.reload()}
-            className="flex-1 justify-center px-4 py-2 text-sm font-medium text-gray-700 bg-gray-200 rounded-md hover:bg-gray-300 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-gray-500"
+            className="flex-1 justify-center px-4 py-2 text-sm font-medium text-gray-700 bg-gray-200 rounded-md hover:bg-gray-300"
           >
             Reload page
           </button>

--- a/src/components/GoalModal.tsx
+++ b/src/components/GoalModal.tsx
@@ -25,7 +25,7 @@ interface FormData {
 }
 
 const inputClasses =
-  "w-full px-3 py-2 bg-white dark:bg-gray-800-sm border border-gray-300/50 dark:border-gray-600/50 rounded-xl focus:outline-none focus:ring-2 focus:ring-primary focus:border-transparent dark:text-white";
+"w-full px-3 py-2 bg-white dark:bg-gray-800-sm border border-gray-300/50 dark:border-gray-600/50 rounded-xl focus:border-transparent dark:text-white";
 
 export default function GoalModal({ isOpen, onClose, goal }: GoalModalProps): React.JSX.Element {
   const { addGoal, updateGoal, accounts } = useApp();
@@ -258,7 +258,7 @@ export default function GoalModal({ isOpen, onClose, goal }: GoalModalProps): Re
                     type="checkbox"
                     checked={formData.linkedAccountIds.includes(account.id)}
                     onChange={() => toggleLinkedAccount(account.id)}
-                    className="mr-2 h-4 w-4 text-blue-600 focus:ring-blue-600 border-gray-300 rounded"
+                    className="mr-2 h-4 w-4 text-blue-600 border-gray-300 rounded"
                   />
                   <span className="text-sm text-gray-700 dark:text-gray-300">
                     {account.name} ({account.type})
@@ -287,7 +287,7 @@ export default function GoalModal({ isOpen, onClose, goal }: GoalModalProps): Re
                     <button
                       type="button"
                       onClick={() => removeLinkedAccount(accountId)}
-                      className="text-sm font-medium text-amber-900 dark:text-amber-100 underline hover:no-underline focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-600 rounded"
+                      className="text-sm font-medium text-amber-900 dark:text-amber-100 underline hover:no-underline rounded"
                     >
                       Remove
                     </button>
@@ -303,7 +303,7 @@ export default function GoalModal({ isOpen, onClose, goal }: GoalModalProps): Re
                 type="checkbox"
                 checked={formData.isActive}
                 onChange={(e) => updateField('isActive', e.target.checked)}
-                className="mr-2 h-4 w-4 text-blue-600 focus:ring-blue-600 border-gray-300 rounded"
+                className="mr-2 h-4 w-4 text-blue-600 border-gray-300 rounded"
               />
               <span className="text-sm text-gray-700 dark:text-gray-300">
                 Active Goal
@@ -328,7 +328,7 @@ export default function GoalModal({ isOpen, onClose, goal }: GoalModalProps): Re
             <button
               type="submit"
               disabled={isSubmitting}
-              className="px-4 py-2 bg-[#1a2332] text-white rounded-2xl hover:bg-[#2d3a4d] focus:outline-none focus:ring-2 focus:ring-blue-600 disabled:opacity-60 disabled:cursor-not-allowed"
+              className="px-4 py-2 bg-[#1a2332] text-white rounded-2xl hover:bg-[#2d3a4d] disabled:opacity-60 disabled:cursor-not-allowed"
             >
               {goal ? "Update Goal" : "Create Goal"}
             </button>

--- a/src/components/ImportRulesManager.tsx
+++ b/src/components/ImportRulesManager.tsx
@@ -446,7 +446,7 @@ function RuleFormModal({ rule, categories, accounts, onSave, onClose }: RuleForm
                   type="text"
                   value={formData.name}
                   onChange={(e) => setFormData({ ...formData, name: e.target.value })}
-                  className="w-full px-3 py-2 bg-white dark:bg-gray-800-sm border border-gray-300/50 dark:border-gray-600/50 rounded-lg focus:outline-none focus:ring-2 focus:ring-primary focus:border-transparent"
+                  className="w-full px-3 py-2 bg-white dark:bg-gray-800-sm border border-gray-300/50 dark:border-gray-600/50 rounded-lg focus:border-transparent"
                   required
                 />
               </div>
@@ -459,7 +459,7 @@ function RuleFormModal({ rule, categories, accounts, onSave, onClose }: RuleForm
                   type="text"
                   value={formData.description}
                   onChange={(e) => setFormData({ ...formData, description: e.target.value })}
-                  className="w-full px-3 py-2 bg-white dark:bg-gray-800-sm border border-gray-300/50 dark:border-gray-600/50 rounded-lg focus:outline-none focus:ring-2 focus:ring-primary focus:border-transparent"
+                  className="w-full px-3 py-2 bg-white dark:bg-gray-800-sm border border-gray-300/50 dark:border-gray-600/50 rounded-lg focus:border-transparent"
                 />
               </div>
 
@@ -473,7 +473,7 @@ function RuleFormModal({ rule, categories, accounts, onSave, onClose }: RuleForm
                     min="1"
                     value={formData.priority}
                     onChange={(e) => setFormData({ ...formData, priority: parseInt(e.target.value) })}
-                    className="w-full px-3 py-2 bg-white dark:bg-gray-800-sm border border-gray-300/50 dark:border-gray-600/50 rounded-lg focus:outline-none focus:ring-2 focus:ring-primary focus:border-transparent"
+                    className="w-full px-3 py-2 bg-white dark:bg-gray-800-sm border border-gray-300/50 dark:border-gray-600/50 rounded-lg focus:border-transparent"
                   />
                 </div>
 

--- a/src/components/LargeTransactionAlertSettings.tsx
+++ b/src/components/LargeTransactionAlertSettings.tsx
@@ -54,7 +54,7 @@ export default function LargeTransactionAlertSettings() {
                 // An emptied field falls back to the default threshold, as before.
                 onChange={(value) => setLargeTransactionThreshold(parseMoneyInput(value) || 500)}
                 disabled={!largeTransactionAlertsEnabled}
-                className="flex-1 px-3 py-2 bg-white dark:bg-gray-800-sm border border-gray-300/50 dark:border-gray-600/50 rounded-lg focus:outline-none focus:ring-2 focus:ring-primary focus:border-transparent disabled:opacity-50 disabled:cursor-not-allowed"
+                className="flex-1 px-3 py-2 bg-white dark:bg-gray-800-sm border border-gray-300/50 dark:border-gray-600/50 rounded-lg focus:border-transparent disabled:opacity-50 disabled:cursor-not-allowed"
               />
               <span className="text-lg font-semibold text-primary min-w-[100px] text-right">
                 {formatCurrency(largeTransactionThreshold)}

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -254,13 +254,13 @@ export default function Layout(): React.JSX.Element {
       <div className="sr-only focus:not-sr-only focus:absolute focus:top-4 focus:left-4 z-50">
         <a 
           href="#main-content" 
-          className="inline-block px-4 py-2 bg-[#1a2332] text-white rounded-md focus:outline-none focus:ring-2 focus:ring-blue-600 focus:ring-offset-2"
+          className="inline-block px-4 py-2 bg-[#1a2332] text-white rounded-md"
         >
           Skip to main content
         </a>
         <a 
           href="#main-navigation" 
-          className="inline-block px-4 py-2 ml-2 bg-[#1a2332] text-white rounded-md focus:outline-none focus:ring-2 focus:ring-blue-600 focus:ring-offset-2"
+          className="inline-block px-4 py-2 ml-2 bg-[#1a2332] text-white rounded-md"
         >
           Skip to navigation
         </a>
@@ -515,7 +515,7 @@ export default function Layout(): React.JSX.Element {
         >
           <nav 
             id="mobile-menu"
-            className="w-full max-w-sm h-full bg-[#1a2332] dark:bg-gray-800 shadow-2xl overflow-y-auto rounded-r-2xl"
+            className="focus-ring-on-dark w-full max-w-sm h-full bg-[#1a2332] dark:bg-gray-800 shadow-2xl overflow-y-auto rounded-r-2xl"
             onClick={e => e.stopPropagation()}
             role="navigation"
             aria-label="Mobile navigation menu"
@@ -530,14 +530,14 @@ export default function Layout(): React.JSX.Element {
                       openMobileSearch();
                       toggleMobileMenu();
                     }}
-                    className="p-2 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-600 focus:outline-none focus:ring-2 focus:ring-white/50"
+                    className="p-2 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-600"
                     aria-label="Open global search"
                   >
                     <SearchIcon size={24} className="text-white dark:text-gray-300" />
                   </button>
                   <button
                     onClick={toggleMobileMenu}
-                    className="p-2 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-600 focus:outline-none focus:ring-2 focus:ring-white/50"
+                    className="p-2 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-600"
                     aria-label="Close navigation menu"
                   >
                     <XIcon size={24} className="text-white dark:text-gray-300" />

--- a/src/components/LazyErrorBoundary.tsx
+++ b/src/components/LazyErrorBoundary.tsx
@@ -72,7 +72,7 @@ export class LazyErrorBoundary extends Component<Props, State> {
           </p>
           <button
             onClick={staleChunk ? () => window.location.reload() : this.handleRetry}
-            className="flex items-center gap-2 px-4 py-2 bg-[#1a2332] text-white rounded-lg hover:bg-[#2d3a4d] transition-colors focus:outline-none focus:ring-2 focus:ring-blue-600 focus:ring-offset-2"
+            className="flex items-center gap-2 px-4 py-2 bg-[#1a2332] text-white rounded-lg hover:bg-[#2d3a4d] transition-colors"
             aria-label={staleChunk ? 'Reload the page' : 'Retry loading component'}
           >
             <RefreshCwIcon className="w-4 h-4" aria-hidden="true" />

--- a/src/components/MonthlyIncomeExpenseMatrix.tsx
+++ b/src/components/MonthlyIncomeExpenseMatrix.tsx
@@ -170,7 +170,7 @@ export default function MonthlyIncomeExpenseMatrix({
         <button
           type="button"
           onClick={() => drill(monthKey, value)}
-          className="w-full justify-end text-right rounded px-1 -mx-1 hover:bg-blue-50 dark:hover:bg-blue-900/30 hover:underline focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
+          className="w-full justify-end text-right rounded px-1 -mx-1 hover:bg-blue-50 dark:hover:bg-blue-900/30 hover:underline"
           title={`${row.label} · ${labelOfMonth(monthKey)} — view these transactions`}
         >
           {money(value)}

--- a/src/components/MsMoneyImportModal.tsx
+++ b/src/components/MsMoneyImportModal.tsx
@@ -201,7 +201,7 @@ export default function MsMoneyImportModal({ isOpen, onClose, onBackup, onExecut
                   </label>
                   <input value={confirmText} onChange={e => setConfirmText(e.target.value)}
                     placeholder={CONFIRM_WORD}
-                    className="w-full px-3 py-2 rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-900 text-gray-900 dark:text-white focus:outline-none focus:ring-2 focus:ring-red-500" />
+                    className="w-full px-3 py-2 rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-900 text-gray-900 dark:text-white"/>
                   {!backedUp && (
                     <p className="text-xs text-gray-500 dark:text-gray-400 mt-1">Download a backup to enable the import.</p>
                   )}

--- a/src/components/NetWorthSummary.tsx
+++ b/src/components/NetWorthSummary.tsx
@@ -76,36 +76,67 @@ export default function NetWorthSummary({
   unconverted = [],
   displayCurrency,
 }: NetWorthSummaryProps): React.JSX.Element {
+  /**
+   * ALL THREE figures are navy. None of them is a direction of travel.
+   *
+   * This card used to argue the point for one cell and then contradict itself
+   * in the next two: net worth was navy because "net worth is the answer, not a
+   * direction of travel, and the sign in front of it says which way it went"
+   * — and then Assets rendered in `text-income` and Liabilities in
+   * `text-expense`. But Assets is a magnitude, exactly as net worth is. So is
+   * Liabilities. The reasoning was written down and applied to one cell in
+   * three (RULINGS_ON_CAUSE_2026-08-13 §1).
+   *
+   * What the inconsistency cost is not on this card, it is everywhere else:
+   * green and red mean money in and money out, and spending them on two
+   * standing magnitudes makes them quieter in the register, where direction is
+   * the whole point (P2 — colour is a signal, never a surface).
+   *
+   * Hierarchy is carried by SIZE, not colour — `display` for the headline,
+   * `page` for the two components it is made of. That is the same job the old
+   * navy slab was doing with a background, and it still works with every cell
+   * the same colour.
+   *
+   * ─ WHY `text-gray-900` AND NOT `text-primary` ──────────────────────────────
+   * index.css locks `.text-primary { color: var(--color-primary) !important }`,
+   * and `!important` beats a `dark:` variant whatever its specificity. So
+   * `text-primary dark:text-white` — which is what the net worth cell actually
+   * shipped — never flipped: MEASURED in the running app, the figure computed
+   * to #1a2332 on the #1f2937 dark card, a contrast of 1.08:1. Net worth was
+   * invisible in dark mode, and applying that class to the other two cells
+   * would have made all three so.
+   * The app's documented way out (see SimpleSignIn) is that anything which
+   * must flip for dark mode uses the neutral gray tokens, which are not
+   * locked. `text-gray-900` is #111827 against the brand's #1a2332 — the same
+   * near-black navy to the eye, and the colour the rest of the app's headline
+   * figures already use.
+   */
+  const NET_FIGURE_CLASS = 'text-display font-semibold text-gray-900 dark:text-white';
+  const COMPONENT_FIGURE_CLASS = 'text-page font-semibold text-gray-900 dark:text-white';
+
   const cells: ReadonlyArray<{
     figure: NetWorthFigure;
     label: string;
     value: string;
-    /**
-     * Net worth is the headline, at `display`; its two components read one
-     * step down at `page`, which is the hierarchy the old navy slab was using
-     * a background colour to state.
-     */
     figureClass: string;
   }> = [
     {
       figure: 'net',
       label: 'Net worth',
       value: netWorth,
-      // Navy, not green/red: net worth is the answer, not a direction of
-      // travel, and the sign in front of it says which way it went (P2).
-      figureClass: 'text-display font-semibold text-primary dark:text-white',
+      figureClass: NET_FIGURE_CLASS,
     },
     {
       figure: 'assets',
       label: 'Assets',
       value: assets,
-      figureClass: 'text-page font-semibold text-income dark:text-green-400',
+      figureClass: COMPONENT_FIGURE_CLASS,
     },
     {
       figure: 'liabilities',
       label: 'Liabilities',
       value: liabilities,
-      figureClass: 'text-page font-semibold text-expense dark:text-red-400',
+      figureClass: COMPONENT_FIGURE_CLASS,
     },
   ];
 
@@ -129,7 +160,7 @@ export default function NetWorthSummary({
               key={figure}
               type="button"
               onClick={() => onSelect(figure)}
-              className="flex flex-col items-start p-4 text-left transition-colors duration-state hover:bg-surface-secondary dark:hover:bg-gray-700/50 focus:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-blue-500 !shadow-none"
+              className="flex flex-col items-start p-4 text-left transition-colors duration-state hover:bg-surface-secondary dark:hover:bg-gray-700/50 !shadow-none"
               title="See the accounts behind this figure"
             >
               {content}

--- a/src/components/OFXImportModal.tsx
+++ b/src/components/OFXImportModal.tsx
@@ -701,7 +701,7 @@ export default function OFXImportModal({ isOpen, onClose, initialFile }: OFXImpo
                 onAccountChange={handleAccountChange}
                 placeholder="Search or select an account…"
                 formatLabel={(account) => `${account.name} (${account.type})`}
-                className="w-full px-3 py-2 h-[42px] border border-gray-300 dark:border-gray-600 rounded-lg focus:ring-2 focus:ring-primary focus:border-transparent dark:bg-gray-700 dark:text-white"
+                className="w-full px-3 py-2 h-[42px] border border-gray-300 dark:border-gray-600 rounded-lg focus:border-transparent dark:bg-gray-700 dark:text-white"
                 usePortal
                 required
                 ariaLabel="Import to Account"
@@ -717,7 +717,7 @@ export default function OFXImportModal({ isOpen, onClose, initialFile }: OFXImpo
                       type="checkbox"
                       checked={saveDetails}
                       onChange={(e) => setSaveDetailsOverride(e.target.checked)}
-                      className="mt-0.5 rounded border-gray-300 text-primary focus:ring-primary"
+                      className="mt-0.5 rounded border-gray-300 text-primary"
                     />
                     <span className="text-sm font-medium text-gray-700 dark:text-gray-300">
                       Save this file&apos;s {detailsToSave.summary} to {selectedAccount.name}
@@ -749,7 +749,7 @@ export default function OFXImportModal({ isOpen, onClose, initialFile }: OFXImpo
                   type="checkbox"
                   checked={skipDuplicates}
                   onChange={(e) => setSkipDuplicates(e.target.checked)}
-                  className="rounded border-gray-300 text-primary focus:ring-primary"
+                  className="rounded border-gray-300 text-primary"
                 />
                 <span className="text-sm font-medium text-gray-700 dark:text-gray-300">
                   Skip transactions you already have
@@ -797,7 +797,7 @@ export default function OFXImportModal({ isOpen, onClose, initialFile }: OFXImpo
                           type="checkbox"
                           checked={match.fitId !== null && importAnywayFitIds.has(match.fitId)}
                           onChange={() => toggleImportAnyway(match.fitId)}
-                          className="mt-1 rounded border-gray-300 text-primary focus:ring-primary"
+                          className="mt-1 rounded border-gray-300 text-primary"
                         />
                         <span className="flex-1 min-w-0 text-sm">
                           <span className="block font-medium text-gray-900 dark:text-white">

--- a/src/components/OnboardingModal.tsx
+++ b/src/components/OnboardingModal.tsx
@@ -90,7 +90,7 @@ export default function OnboardingModal({ isOpen, onComplete }: OnboardingModalP
               type="text"
               value={firstName}
               onChange={(e) => setFirstName(e.target.value)}
-              className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-white rounded-lg focus:outline-none focus:ring-2 focus:ring-primary"
+              className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-white rounded-lg"
               placeholder="Enter your first name"
               required
               autoFocus
@@ -108,7 +108,7 @@ export default function OnboardingModal({ isOpen, onComplete }: OnboardingModalP
               aria-label="Preferred base currency"
               value={baseCurrency}
               onChange={(e) => setBaseCurrency(e.target.value)}
-              className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-white rounded-lg focus:outline-none focus:ring-2 focus:ring-primary"
+              className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-white rounded-lg"
             >
               {supportedCurrencies.map((curr) => (
                 <option key={curr.code} value={curr.code}>

--- a/src/components/PortfolioManager.tsx
+++ b/src/components/PortfolioManager.tsx
@@ -353,7 +353,7 @@ export default function PortfolioManager({
                 if (chosen) setAssetType(chosen);
               }}
               disabled={isSaving}
-              className="w-full px-4 py-2 border border-gray-300 dark:border-gray-600 rounded-lg focus:ring-2 focus:ring-primary focus:border-transparent dark:bg-gray-700 dark:text-white"
+              className="w-full px-4 py-2 border border-gray-300 dark:border-gray-600 rounded-lg focus:border-transparent dark:bg-gray-700 dark:text-white"
             >
               {INVESTMENT_ASSET_TYPES.map((type) => (
                 <option key={type} value={type}>
@@ -379,7 +379,7 @@ export default function PortfolioManager({
               step="any"
               min="0"
               disabled={isSaving}
-              className="w-full px-4 py-2 border border-gray-300 dark:border-gray-600 rounded-lg focus:ring-2 focus:ring-primary focus:border-transparent dark:bg-gray-700 dark:text-white"
+              className="w-full px-4 py-2 border border-gray-300 dark:border-gray-600 rounded-lg focus:border-transparent dark:bg-gray-700 dark:text-white"
             />
             <p className="mt-1 text-xs text-gray-500 dark:text-gray-400">
               Fractional units are fine — funds are usually held to several decimal places.
@@ -397,7 +397,7 @@ export default function PortfolioManager({
               id="holding-average-cost"
               value={averageCost}
               onChange={setAverageCost}
-              className="w-full px-4 py-2 border border-gray-300 dark:border-gray-600 rounded-lg focus:ring-2 focus:ring-primary focus:border-transparent dark:bg-gray-700 dark:text-white"
+              className="w-full px-4 py-2 border border-gray-300 dark:border-gray-600 rounded-lg focus:border-transparent dark:bg-gray-700 dark:text-white"
               disabled={isSaving}
             />
           </div>

--- a/src/components/QIFImportModal.tsx
+++ b/src/components/QIFImportModal.tsx
@@ -360,7 +360,7 @@ export default function QIFImportModal({ isOpen, onClose, initialFile }: QIFImpo
                 onAccountChange={setSelectedAccountId}
                 placeholder="Search or select an account…"
                 formatLabel={(account) => `${account.name} (${account.type})`}
-                className="w-full px-3 py-2 h-[42px] border border-gray-300 dark:border-gray-600 rounded-lg focus:ring-2 focus:ring-primary focus:border-transparent dark:bg-gray-700 dark:text-white"
+                className="w-full px-3 py-2 h-[42px] border border-gray-300 dark:border-gray-600 rounded-lg focus:border-transparent dark:bg-gray-700 dark:text-white"
                 usePortal
                 required
                 ariaLabel="Import to Account"
@@ -377,7 +377,7 @@ export default function QIFImportModal({ isOpen, onClose, initialFile }: QIFImpo
                   type="checkbox"
                   checked={skipDuplicates}
                   onChange={(e) => setSkipDuplicates(e.target.checked)}
-                  className="rounded border-gray-300 text-primary focus:ring-primary"
+                  className="rounded border-gray-300 text-primary"
                 />
                 <span className="text-sm font-medium text-gray-700 dark:text-gray-300">
                   Skip potential duplicates

--- a/src/components/RenamePayeesModal.tsx
+++ b/src/components/RenamePayeesModal.tsx
@@ -137,7 +137,7 @@ export default function RenamePayeesModal({
             onChange={(e) => setNewName(e.target.value)}
             disabled={renaming}
             placeholder="e.g. Amazon"
-            className="w-full px-3 py-2 bg-white dark:bg-gray-800 border border-gray-300/50 dark:border-gray-600/50 rounded-xl focus:outline-none focus:ring-2 focus:ring-primary focus:border-transparent dark:text-white disabled:opacity-50"
+            className="w-full px-3 py-2 bg-white dark:bg-gray-800 border border-gray-300/50 dark:border-gray-600/50 rounded-xl focus:border-transparent dark:text-white disabled:opacity-50"
           />
           {sharedMerchant !== null && trimmedName !== sharedMerchant && (
             <button

--- a/src/components/RestoreBackupModal.tsx
+++ b/src/components/RestoreBackupModal.tsx
@@ -422,7 +422,7 @@ export default function RestoreBackupModal({ isOpen, onClose }: Props): React.JS
                   onChange={(e) => setWipeConfirmText(e.target.value)}
                   aria-label={`Type ${CONFIRM_PHRASE} to confirm`}
                   placeholder={CONFIRM_PHRASE}
-                  className="w-full px-3 py-2 rounded-lg border border-red-300 dark:border-red-700 bg-white dark:bg-gray-900 text-gray-900 dark:text-white focus:outline-none focus:ring-2 focus:ring-red-500"
+                  className="w-full px-3 py-2 rounded-lg border border-red-300 dark:border-red-700 bg-white dark:bg-gray-900 text-gray-900 dark:text-white"
                 />
                 <button
                   onClick={() => { void handleWipe(); }}

--- a/src/components/ServiceWorkerUpdateNotification.tsx
+++ b/src/components/ServiceWorkerUpdateNotification.tsx
@@ -101,7 +101,7 @@ export default function ServiceWorkerUpdateNotification({
               <button
                 onClick={handleUpdate}
                 disabled={isUpdating}
-                className="px-4 py-2 text-sm font-medium text-white bg-[#1a2332] hover:bg-[#2d3a4d] disabled:bg-blue-400 rounded-lg transition-colors duration-200 focus:outline-none focus:ring-2 focus:ring-blue-600 focus:ring-offset-2 dark:focus:ring-offset-gray-800"
+                className="px-4 py-2 text-sm font-medium text-white bg-[#1a2332] hover:bg-[#2d3a4d] disabled:bg-blue-400 rounded-lg transition-colors duration-200"
               >
                 {isUpdating ? 'Updating...' : 'Update Now'}
               </button>
@@ -109,7 +109,7 @@ export default function ServiceWorkerUpdateNotification({
               <button
                 onClick={handleDismiss}
                 disabled={isUpdating}
-                className="px-4 py-2 text-sm font-medium text-gray-700 dark:text-gray-300 bg-gray-100 dark:bg-gray-700 hover:bg-gray-200 dark:hover:bg-gray-600 rounded-lg transition-colors duration-200 focus:outline-none focus:ring-2 focus:ring-gray-500 focus:ring-offset-2 dark:focus:ring-offset-gray-800"
+                className="px-4 py-2 text-sm font-medium text-gray-700 dark:text-gray-300 bg-gray-100 dark:bg-gray-700 hover:bg-gray-200 dark:hover:bg-gray-600 rounded-lg transition-colors duration-200"
               >
                 Later
               </button>

--- a/src/components/StockSymbolSearch.tsx
+++ b/src/components/StockSymbolSearch.tsx
@@ -106,7 +106,7 @@ export default function StockSymbolSearch({
           aria-controls={listId}
           aria-expanded={matches.length > 0}
           autoFocus={autoFocus}
-          className="w-full pl-10 pr-10 py-2 border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-700 text-gray-900 dark:text-white placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-[var(--color-primary)] focus:border-transparent"
+          className="w-full pl-10 pr-10 py-2 border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-700 text-gray-900 dark:text-white placeholder-gray-500 focus:border-transparent"
         />
         {isSearching && (
           <RefreshCwIcon

--- a/src/components/TagSelector.tsx
+++ b/src/components/TagSelector.tsx
@@ -161,7 +161,7 @@ export default function TagSelector({
           onFocus={handleInputFocus}
           onKeyDown={handleKeyDown}
           placeholder={placeholder}
-          className="w-full px-3 py-2 h-[42px] bg-white dark:bg-gray-800-sm border border-gray-300/50 dark:border-gray-600/50 rounded-xl focus:outline-none focus:ring-2 focus:ring-primary focus:border-transparent dark:text-white"
+          className="w-full px-3 py-2 h-[42px] bg-white dark:bg-gray-800-sm border border-gray-300/50 dark:border-gray-600/50 rounded-xl focus:border-transparent dark:text-white"
         />
         
         {/* Dropdown */}

--- a/src/components/auth/SimpleSignIn.tsx
+++ b/src/components/auth/SimpleSignIn.tsx
@@ -35,7 +35,7 @@ export default function SimpleSignIn(): React.JSX.Element {
             <SignInButton mode="modal">
               <button
                 type="button"
-                className="w-full justify-center py-3 px-4 rounded-xl border border-transparent dark:border-white/20 bg-primary text-white font-semibold hover:bg-secondary transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-primary dark:focus-visible:ring-white focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:focus-visible:ring-offset-gray-800"
+                className="w-full justify-center py-3 px-4 rounded-xl border border-transparent dark:border-white/20 bg-primary text-white font-semibold hover:bg-secondary transition-colors"
               >
                 Sign in
               </button>
@@ -44,7 +44,7 @@ export default function SimpleSignIn(): React.JSX.Element {
             <SignUpButton mode="modal">
               <button
                 type="button"
-                className="w-full justify-center py-3 px-4 rounded-xl border border-primary/20 dark:border-gray-600 text-gray-900 dark:text-white font-semibold hover:bg-surface-secondary dark:hover:bg-gray-700 transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-primary dark:focus-visible:ring-white focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:focus-visible:ring-offset-gray-800"
+                className="w-full justify-center py-3 px-4 rounded-xl border border-primary/20 dark:border-gray-600 text-gray-900 dark:text-white font-semibold hover:bg-surface-secondary dark:hover:bg-gray-700 transition-colors"
               >
                 Create account
               </button>
@@ -68,7 +68,7 @@ export default function SimpleSignIn(): React.JSX.Element {
             </div>
             <a
               href="/dashboard"
-              className="block w-full py-3 px-4 rounded-xl border border-transparent dark:border-white/20 bg-primary text-white font-semibold hover:bg-secondary transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-primary dark:focus-visible:ring-white focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:focus-visible:ring-offset-gray-800"
+              className="block w-full py-3 px-4 rounded-xl border border-transparent dark:border-white/20 bg-primary text-white font-semibold hover:bg-secondary transition-colors"
             >
               Go to Dashboard
             </a>

--- a/src/components/charts/ChartComponents.tsx
+++ b/src/components/charts/ChartComponents.tsx
@@ -27,7 +27,6 @@ import {
   Brush,
   LabelList
 } from 'recharts';
-import { CHART_COLORS } from './chartColors';
 
 // Re-export for named imports
 export {
@@ -83,8 +82,7 @@ const ChartComponents = {
   ReferenceArea,
   ReferenceDot,
   Brush,
-  LabelList,
-  CHART_COLORS
+  LabelList
 };
 
 export default ChartComponents;

--- a/src/components/charts/DashboardCharts.tsx
+++ b/src/components/charts/DashboardCharts.tsx
@@ -21,6 +21,7 @@ import {
   Cell
 } from 'recharts';
 import { formatDecimal } from '../../utils/decimal-format';
+import { categoricalColor, useCategoricalRamp } from './chartColors';
 
 export { ResponsiveContainer };
 
@@ -70,7 +71,7 @@ export function BarChart({
   data,
   dataKey,
   xKey = 'month',
-  fill = '#8B5CF6',
+  fill,
   label = 'Value',
   formatter,
   tickFormatter,
@@ -78,6 +79,11 @@ export function BarChart({
   showGrid = true,
   'aria-label': ariaLabel
 }: BarChartProps): React.JSX.Element {
+  // A single-series bar takes the first step of the shared ramp. It used to
+  // default to `#8B5CF6` — a purple belonging to no token, which is how a
+  // library-demo colour ended up as the app's Net Worth chart.
+  const ramp = useCategoricalRamp();
+  const barFill = fill ?? ramp[0];
   const formatValue = formatter ?? defaultTickFormatter;
   const summary = buildChartSummary(
     ariaLabel,
@@ -101,7 +107,7 @@ export function BarChart({
           return [formatter ? formatter(numeric) : String(value), label];
         }}
       />
-      <Bar dataKey={dataKey} name={label} fill={fill} radius={[4, 4, 0, 0]} />
+      <Bar dataKey={dataKey} name={label} fill={barFill} radius={[4, 4, 0, 0]} />
     </RechartsBarChart>
   );
 }
@@ -113,7 +119,7 @@ export interface PieDatum {
 
 interface PieChartProps<T extends PieDatum> {
   data: T[];
-  colors?: string[];
+  colors?: readonly string[];
   /** Render as a doughnut when true. */
   innerRadius?: boolean;
   onClick?: (datum: T) => void;
@@ -122,17 +128,22 @@ interface PieChartProps<T extends PieDatum> {
   'aria-label'?: string;
 }
 
-const DEFAULT_COLORS = ['#0088FE', '#00C49F', '#FFBB28', '#FF8042', '#8884D8'];
-
 export function PieChart<T extends PieDatum>({
   data,
-  colors = DEFAULT_COLORS,
+  colors,
   innerRadius = false,
   onClick,
   formatter,
   contentStyle,
   'aria-label': ariaLabel
 }: PieChartProps<T>): React.JSX.Element {
+  // `colors` stays overridable only so a caller can colour slices by MEANING
+  // (a two-slice income/expense split). Left alone it is the shared ramp —
+  // where the default used to be the recharts documentation palette, copied
+  // into three files.
+  const ramp = useCategoricalRamp();
+  const sliceColors = colors ?? ramp;
+
   // Recharts wants index-signature rows; keep the original datum reachable by
   // index so onClick hands back the caller's own object, not a copy.
   const chartData = data.map((d, index) => ({ name: d.name, value: d.value, index }));
@@ -161,7 +172,7 @@ export function PieChart<T extends PieDatum>({
         cursor={onClick ? 'pointer' : undefined}
       >
         {chartData.map((entry) => (
-          <Cell key={entry.name} fill={colors[entry.index % colors.length]} />
+          <Cell key={entry.name} fill={categoricalColor(sliceColors, entry.index)} />
         ))}
       </Pie>
       <Tooltip

--- a/src/components/charts/OptimizedCharts.tsx
+++ b/src/components/charts/OptimizedCharts.tsx
@@ -206,6 +206,3 @@ export function preloadCharts() {
     });
   }
 }
-
-// eslint-disable-next-line react-refresh/only-export-components
-export { CHART_COLORS } from './chartColors';

--- a/src/components/charts/__tests__/categoricalRamp.test.ts
+++ b/src/components/charts/__tests__/categoricalRamp.test.ts
@@ -1,0 +1,119 @@
+/**
+ * The one categorical chart ramp, instrumented — RULINGS_ON_CAUSE_2026-08-13 §2.
+ *
+ * The app used to carry NINE categorical palettes under six names, three of
+ * them the recharts documentation example verbatim. This file is the gate that
+ * keeps it at one, and it pins the two things the ruling actually cares about:
+ *
+ * 1. NO SIXTH PALETTE. No chart component may declare its own array of hex
+ *    colours. The check greps the chart consumers rather than trusting review,
+ *    because that is precisely what nine palettes got past.
+ *
+ * 2. THE RAMP IS VISIBLE, AND IT IS NOT A SIGNAL. Every step clears the 3:1
+ *    WCAG bar a graphical object owes, measured with the repo's own harness
+ *    against BOTH surfaces of its own theme — the same rule
+ *    semantic-contrast.test.ts enforces for text, and the reason the ramp has
+ *    to depend on the ground at all. And no step may be confusable with income
+ *    green or expense red, because those two hues state whether money came in
+ *    or went out and a pie slice must never borrow them.
+ *
+ * No exact hue is pinned beyond the ruled five: a future rebrand only has to
+ * keep the measuring honest.
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { ColorContrastChecker } from '../../../utils/color-contrast-checker';
+import { CATEGORICAL_AXIS, categoricalColor, categoricalRamp } from '../chartColors';
+
+const AA_GRAPHICS = 3.0;
+const SURFACES_LIGHT = ['#ffffff', '#f8f9fb'] as const;
+const SURFACES_DARK = ['#111827', '#1f2937'] as const;
+
+/** The five the ruling named. They must survive any re-derivation of the axis. */
+const RULED = ['#1a2332', '#2d3a4d', '#6b86b3', '#94a3b8', '#cdd4e0'] as const;
+
+/** Every module that draws a categorical chart, relative to the repo root. */
+const CHART_CONSUMERS = [
+  'src/components/charts/DashboardCharts.tsx',
+  'src/components/CustomReportViewer.tsx',
+  'src/components/dashboard/ImprovedDashboard.tsx',
+  'src/components/dashboard/reportWidgets/DashboardReportWidgets.tsx',
+  'src/pages/Investments.tsx',
+  'src/pages/reports/AccountDistributionReport.tsx',
+  'src/pages/reports/SpendingByCategoryReport.tsx',
+  'src/pages/reports/SpendingByPayeeReport.tsx',
+] as const;
+
+const read = (repoPath: string): string =>
+  readFileSync(resolve(process.cwd(), repoPath), 'utf8');
+
+/** Strip comments so the prose explaining the old palettes is not mistaken for one. */
+const withoutComments = (source: string): string =>
+  source.replace(/\/\*[\s\S]*?\*\//g, '').replace(/\/\/[^\n]*/g, '');
+
+describe('the categorical ramp is the only chart palette', () => {
+  it('keeps the five ruled values in the axis', () => {
+    for (const colour of RULED) {
+      expect(CATEGORICAL_AXIS.map(c => c.toLowerCase())).toContain(colour);
+    }
+  });
+
+  it('bisects rather than inventing steps: the ruled five sit at even indices', () => {
+    // The extension rule is stated, not ad hoc — each adjacent ruled pair gets
+    // its midpoint, so a nine-step axis holds the five at 0, 2, 4, 6, 8.
+    expect(CATEGORICAL_AXIS).toHaveLength(9);
+    expect([0, 2, 4, 6, 8].map(i => CATEGORICAL_AXIS[i].toLowerCase())).toEqual([...RULED]);
+  });
+
+  it.each([
+    ['light', false, SURFACES_LIGHT],
+    ['dark', true, SURFACES_DARK],
+  ] as const)('every %s-ground step clears the 3:1 graphics bar on both its surfaces', (_name, isDark, surfaces) => {
+    const ramp = categoricalRamp(isDark);
+    expect(ramp.length).toBeGreaterThan(0);
+    for (const colour of ramp) {
+      for (const surface of surfaces) {
+        const ratio = ColorContrastChecker.getContrastRatio(colour, surface);
+        expect(
+          ratio,
+          `${colour} on ${surface} measures ${ratio.toFixed(2)}:1`
+        ).toBeGreaterThanOrEqual(AA_GRAPHICS);
+      }
+    }
+  });
+
+  it.each([['light', false], ['dark', true]] as const)(
+    'spends no signal: no %s-ground step is a green or a red',
+    (_name, isDark) => {
+      for (const colour of categoricalRamp(isDark)) {
+        const { r, g, b } = ColorContrastChecker.hexToRgb(colour);
+        // Navy through slate is blue-dominant and near-neutral. Income green
+        // and expense red are the two channels a categorical slice may never
+        // lead with, so blue must not be the quietest channel.
+        expect(b, `${colour} is not on the navy-slate axis`).toBeGreaterThanOrEqual(r);
+        expect(b, `${colour} is not on the navy-slate axis`).toBeGreaterThanOrEqual(g);
+      }
+    }
+  );
+
+  it('cycles past the end of the ramp rather than running out', () => {
+    const ramp = categoricalRamp(false);
+    expect(categoricalColor(ramp, 0)).toBe(ramp[0]);
+    expect(categoricalColor(ramp, ramp.length)).toBe(ramp[0]);
+    expect(categoricalColor(ramp, ramp.length + 2)).toBe(ramp[2]);
+  });
+
+  it('leaves no chart component declaring a palette of its own', () => {
+    // A palette has a SHAPE: an array literal of three or more hex strings.
+    // That is what all nine deleted ones looked like, and matching the shape
+    // rather than counting hexes is what lets axis-tick greys and a deliberate
+    // two-colour income/expense pair through — those are chrome and meaning,
+    // neither of them a categorical ramp.
+    const PALETTE_SHAPE = /\[[^\]]*(?:['"]#[0-9a-fA-F]{3,8}['"][^\]]*){3,}\]/g;
+    for (const path of CHART_CONSUMERS) {
+      const found = withoutComments(read(path)).match(PALETTE_SHAPE) ?? [];
+      expect(found, `${path} declares a palette of its own: ${found.join(' ')}`).toEqual([]);
+    }
+  });
+});

--- a/src/components/charts/chartColors.ts
+++ b/src/components/charts/chartColors.ts
@@ -1,12 +1,132 @@
-export const CHART_COLORS = [
-  '#8b5cf6', // Purple
-  '#06b6d4', // Cyan
-  '#10b981', // Emerald
-  '#f59e0b', // Amber
-  '#ef4444', // Red
-  '#3b82f6', // Blue
-  '#ec4899', // Pink
-  '#14b8a6', // Teal
-  '#f97316', // Orange
-  '#84cc16', // Lime
-];
+import { useEffect, useState } from 'react';
+
+/**
+ * THE categorical chart ramp. One module, one ramp, every chart reads it.
+ *
+ * ─ WHAT WAS HERE BEFORE, AND WHAT IT COST ──────────────────────────────────
+ * Nobody ever chose a chart palette. There were NINE arrays under six names:
+ * `DEFAULT_COLORS` in DashboardCharts, `COLORS` in ImprovedDashboard, another
+ * `COLORS` in AccountDistributionReport, `CATEGORY_COLORS` in
+ * CustomReportViewer, another in DashboardReportWidgets, a third in
+ * SpendingByCategoryReport, `BAR_COLOURS` in SpendingByPayeeReport, a fourth
+ * `COLORS` in Investments, and a ten-colour `CHART_COLORS` right here that no
+ * component ever rendered a pixel with. Three of them were the recharts
+ * documentation example verbatim; the Investments one had silently drifted
+ * from its twin at positions seven and eight.
+ *
+ * The cost was not ugliness, it was MEANING. `#00C49F` and `#10B981` are close
+ * enough to income green, and `#FF8042`/`#EF4444` to expense red, that a pie
+ * slice sat inches from a Performance card where those two hues state whether
+ * money came in or went out. Every rainbow slice spent a signal the register
+ * needs (P2 — colour is a signal, never a surface). So the ramp is navy
+ * through slate, and GREEN AND RED ARE NEVER IN IT
+ * (RULINGS_ON_CAUSE_2026-08-13 §2).
+ *
+ * They were deleted rather than aligned: five palettes agreeing today is five
+ * palettes drifting next month, which is exactly how Investments got its two
+ * odd colours.
+ *
+ * ─ WHY THE RAMP DEPENDS ON THE GROUND ──────────────────────────────────────
+ * The ruled five span the whole navy→slate axis, and MEASURED against the
+ * repo's own harness that means no single ordering works on both themes. Against
+ * the dimmest surface each theme actually uses (`#f8f9fb` cards on light,
+ * `#1f2937` on dark), at the 3:1 WCAG bar a graphical object owes:
+ *
+ *     #1a2332   light 14.98 ✓   dark  1.08 ✗   <- invisible on a dark card
+ *     #2d3a4d   light 10.93 ✓   dark  1.27 ✗
+ *     #6B86B3   light  3.51 ✓   dark  3.97 ✓   <- the only step good on both
+ *     #94a3b8   light  2.43 ✗   dark  5.72 ✓
+ *     #cdd4e0   light  1.41 ✗   dark  9.85 ✓   <- invisible on a white card
+ *
+ * A fixed ramp would therefore have shipped two invisible slices in one theme
+ * or the other — the old rainbow was mid-bright and dodged this by accident.
+ * So the ramp is ONE axis walked from whichever END contrasts with the ground:
+ * darkest-first on light, lightest-first on dark. Same axis, same five ruled
+ * values, no second palette.
+ *
+ * ─ HOW IT EXTENDS PAST FIVE ────────────────────────────────────────────────
+ * Some charts draw more series than five (SpendingByCategory draws eight). The
+ * stated rule is BISECTION, never a new hue: each adjacent pair of ruled values
+ * gets its midpoint, giving a nine-step axis of which the ruled five are still
+ * exactly members. Five of those nine clear 3:1 on any one ground, so each
+ * theme gets a five-colour ramp and beyond that the ramp CYCLES.
+ *
+ * Cycling is the honest cost of the ruling. A single-hue ramp cannot separate
+ * eight categories the way eight hues could — measured, adjacent steps here sit
+ * 2.12:1 apart on light and 1.59:1 on dark. Charts must therefore direct-label,
+ * which these already do: every consumer draws a legend swatch beside the name
+ * or names the slice in its tooltip. Colour groups the series; the label
+ * identifies it.
+ */
+
+/**
+ * The axis: the ruled five (index 0, 2, 4, 6, 8) with a bisected midpoint
+ * between each adjacent pair. Dark end first. Exported for the test that pins
+ * the ruled values and the contrast of everything derived from them.
+ */
+export const CATEGORICAL_AXIS = [
+  '#1a2332', // navy-900  — ruled
+  '#242f40', //           — bisected
+  '#2d3a4d', // navy-700  — ruled
+  '#4c6080', //           — bisected
+  '#6b86b3', // navy-400  — ruled
+  '#8095b6', //           — bisected
+  '#94a3b8', // slate-400 — ruled
+  '#b1bccc', //           — bisected
+  '#cdd4e0', // line-strong — ruled
+] as const;
+
+/**
+ * The five axis steps that clear 3:1 on a LIGHT ground, ordered so that
+ * CONSECUTIVE series are as far apart as the axis allows (2.12:1 worst
+ * adjacent pair). Walking the axis in order instead would put neighbouring pie
+ * slices 1.17:1 apart, which is no separation at all.
+ */
+const RAMP_ON_LIGHT = ['#1a2332', '#4c6080', '#242f40', '#6b86b3', '#2d3a4d'] as const;
+
+/** The same, from the light end, for a dark ground (1.59:1 worst adjacent pair). */
+const RAMP_ON_DARK = ['#94a3b8', '#cdd4e0', '#8095b6', '#b1bccc', '#6b86b3'] as const;
+
+/** The ramp for a given ground. Cycle past the end with `categoricalColor`. */
+export function categoricalRamp(isDarkGround: boolean): readonly string[] {
+  return isDarkGround ? RAMP_ON_DARK : RAMP_ON_LIGHT;
+}
+
+/**
+ * The colour for series `index`, cycling once the ramp runs out. Every chart
+ * used to spell `PALETTE[i % PALETTE.length]` at each call site; going through
+ * one function means the cycling rule is stated once.
+ */
+export function categoricalColor(ramp: readonly string[], index: number): string {
+  return ramp[index % ramp.length] as string;
+}
+
+/** Is the app currently painting on a dark ground? */
+function isDarkGround(): boolean {
+  return typeof document !== 'undefined' && document.documentElement.classList.contains('dark');
+}
+
+/**
+ * The ramp for the theme on screen right now.
+ *
+ * It watches the `dark` class rather than reading it once, because the class is
+ * toggled on `<html>` directly (PreferencesContext, and the theme scheduler
+ * that can flip it at dusk with no React state change behind it). Read once at
+ * render — which is what the Dashboard's tooltip colours still do — a chart
+ * would keep its light-ground slices after the app went dark, and two of them
+ * would be invisible until something unrelated forced a re-render.
+ */
+export function useCategoricalRamp(): readonly string[] {
+  const [dark, setDark] = useState(isDarkGround);
+
+  useEffect(() => {
+    const root = document.documentElement;
+    const observer = new MutationObserver(() => setDark(isDarkGround()));
+    observer.observe(root, { attributes: true, attributeFilter: ['class'] });
+    // The class can change between first render and this effect running.
+    setDark(isDarkGround());
+    return () => observer.disconnect();
+  }, []);
+
+  return categoricalRamp(dark);
+}

--- a/src/components/common/AccessibleFormField.test.tsx
+++ b/src/components/common/AccessibleFormField.test.tsx
@@ -364,11 +364,16 @@ describe('AccessibleFormField', () => {
       expect(input).toHaveClass('w-full', 'px-3', 'py-2', 'rounded-lg');
     });
 
-    it('applies focus styles', () => {
+    it('declares no focus ring of its own — the app draws the only one', () => {
+      // Was: asserted `focus:outline-none focus:ring-2`. A focused input gets
+      // its outline AND its border recoloured by accessibility-colors.css,
+      // both !important, so the pair here only ever added a third stroke
+      // (RULINGS_ON_CAUSE_2026-08-13 §3).
       render(<AccessibleFormField {...defaultProps} />);
-      
+
       const input = screen.getByRole('textbox');
-      expect(input).toHaveClass('focus:outline-none', 'focus:ring-2');
+      expect(input.className).not.toMatch(/focus(-visible)?:ring/);
+      expect(input.className).not.toMatch(/focus(-visible)?:outline-none/);
     });
 
     it('applies dark mode classes', () => {

--- a/src/components/common/AccessibleFormField.tsx
+++ b/src/components/common/AccessibleFormField.tsx
@@ -50,7 +50,7 @@ export function AccessibleFormField({
 
   const baseInputClasses = `w-full px-3 py-2 bg-white dark:bg-gray-700 border-2 ${
     error ? 'border-red-500' : 'border-gray-300 dark:border-gray-500'
-  } rounded-lg focus:outline-none focus:ring-2 focus:ring-primary dark:focus:ring-blue-400 focus:border-transparent dark:text-white`;
+  } rounded-lg focus:border-transparent dark:text-white`;
 
   const renderField = () => {
     switch (type) {

--- a/src/components/common/Button.test.tsx
+++ b/src/components/common/Button.test.tsx
@@ -320,13 +320,19 @@ describe('Button', () => {
   });
 
   describe('focus management', () => {
-    it('shows focus ring when focused', () => {
-      render(<Button>Focus Me</Button>);
-      
-      const button = screen.getByRole('button');
-      expect(button.className).toContain('focus:outline-none');
-      expect(button.className).toContain('focus:ring-2');
-      expect(button.className).toContain('focus:ring-offset-2');
+    it('declares no focus ring of its own — the app draws the only one', () => {
+      // Was: asserted this button set `focus:outline-none focus:ring-2
+      // focus:ring-offset-2`. Those painted a SECOND indicator inside the
+      // app-wide `*:focus-visible` outline, which carries !important and so
+      // ignored the `outline-none` (RULINGS_ON_CAUSE_2026-08-13 §3). Every
+      // variant is checked because each used to name its own ring colour.
+      for (const variant of ['primary', 'secondary', 'danger', 'success', 'ghost'] as const) {
+        const { unmount } = render(<Button variant={variant}>Focus Me</Button>);
+        const button = screen.getByRole('button');
+        expect(button.className).not.toMatch(/focus(-visible)?:ring/);
+        expect(button.className).not.toMatch(/focus(-visible)?:outline-none/);
+        unmount();
+      }
     });
 
     it('can be focused programmatically', () => {

--- a/src/components/common/Button.tsx
+++ b/src/components/common/Button.tsx
@@ -25,7 +25,6 @@ export function Button({
   const baseStyles = `
     inline-flex items-center justify-center font-medium
     transition-all duration-[var(--duration-fast)] ease-[var(--easing-inOut)]
-    focus:outline-none focus:ring-2 focus:ring-offset-2
     disabled:opacity-50 disabled:cursor-not-allowed
   `;
   
@@ -34,28 +33,23 @@ export function Button({
       bg-[var(--color-interactive-primary)] text-white
       hover:bg-[var(--color-interactive-primaryHover)]
       active:bg-[var(--color-interactive-primaryActive)]
-      focus:ring-[var(--color-interactive-primary)]
     `,
     secondary: `
       bg-[var(--color-surface-secondary)] text-[var(--color-text-primary)]
       border border-[var(--color-border-primary)]
       hover:bg-[var(--color-surface-tertiary)]
-      focus:ring-[var(--color-border-focus)]
     `,
     danger: `
       bg-[var(--color-status-error)] text-white
       hover:opacity-90
-      focus:ring-[var(--color-status-error)]
     `,
     success: `
       bg-[var(--color-status-success)] text-white
       hover:opacity-90
-      focus:ring-[var(--color-status-success)]
     `,
     ghost: `
       bg-transparent text-[var(--color-text-primary)]
       hover:bg-[var(--color-surface-secondary)]
-      focus:ring-[var(--color-border-focus)]
     `,
   };
   

--- a/src/components/common/Modal.tsx
+++ b/src/components/common/Modal.tsx
@@ -239,9 +239,6 @@ export function Modal({
                   dark:hover:bg-gray-800
                   transition-all
                   duration-200
-                  focus:outline-none
-                  focus:ring-2
-                  focus:ring-primary/50
                 "
                 aria-label="Close modal"
               >

--- a/src/components/common/Toast.tsx
+++ b/src/components/common/Toast.tsx
@@ -103,7 +103,6 @@ export function Toast({ toast, onDismiss }: ToastProps): React.JSX.Element {
             className={`
               mt-2 text-sm font-medium underline
               ${textColors[toast.type]} hover:no-underline
-              focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary
             `}
           >
             {toast.action.label}
@@ -116,7 +115,6 @@ export function Toast({ toast, onDismiss }: ToastProps): React.JSX.Element {
         className={`
           flex-shrink-0 p-1 rounded-md
           ${textColors[toast.type]} hover:bg-black/5 dark:hover:bg-white/5
-          focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary
           min-w-[44px] min-h-[44px] flex items-center justify-center
         `}
         aria-label="Dismiss notification"

--- a/src/components/csvImport/DeleteProfileConfirm.tsx
+++ b/src/components/csvImport/DeleteProfileConfirm.tsx
@@ -90,7 +90,7 @@ export default function DeleteProfileConfirm({
             ref={cancelRef}
             type="button"
             onClick={onCancel}
-            className="px-4 py-2 border border-gray-300 dark:border-gray-600 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-700 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 dark:text-gray-200"
+            className="px-4 py-2 border border-gray-300 dark:border-gray-600 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-700 dark:text-gray-200"
           >
             Keep it
           </button>
@@ -98,7 +98,7 @@ export default function DeleteProfileConfirm({
             ref={confirmRef}
             type="button"
             onClick={onConfirm}
-            className="px-4 py-2 bg-red-600 text-white rounded-lg hover:bg-red-700 focus:outline-none focus-visible:ring-2 focus-visible:ring-red-400 focus-visible:ring-offset-2 dark:focus-visible:ring-offset-gray-800"
+            className="px-4 py-2 bg-red-600 text-white rounded-lg hover:bg-red-700"
           >
             Delete profile
           </button>

--- a/src/components/csvImport/ProfileNameDialog.tsx
+++ b/src/components/csvImport/ProfileNameDialog.tsx
@@ -132,7 +132,7 @@ export default function ProfileNameDialog({
           }}
           aria-invalid={showEmptyWarning}
           aria-describedby={showEmptyWarning ? errorId : undefined}
-          className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg focus:ring-2 focus:ring-primary focus:border-transparent dark:bg-gray-700 dark:text-white"
+          className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg focus:border-transparent dark:bg-gray-700 dark:text-white"
         />
         {showEmptyWarning && (
           <p id={errorId} role="alert" className="mt-2 text-sm text-amber-700 dark:text-amber-400">
@@ -145,14 +145,14 @@ export default function ProfileNameDialog({
           <button
             type="button"
             onClick={onCancel}
-            className="px-4 py-2 border border-gray-300 dark:border-gray-600 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-700 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 dark:text-gray-200"
+            className="px-4 py-2 border border-gray-300 dark:border-gray-600 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-700 dark:text-gray-200"
           >
             Cancel
           </button>
           <button
             type="button"
             onClick={submit}
-            className="px-4 py-2 bg-[#1a2332] text-white rounded-lg hover:bg-secondary focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-400 focus-visible:ring-offset-2 dark:focus-visible:ring-offset-gray-800"
+            className="px-4 py-2 bg-[#1a2332] text-white rounded-lg hover:bg-secondary"
           >
             {confirmLabel}
           </button>

--- a/src/components/dashboard/ImprovedDashboard.tsx
+++ b/src/components/dashboard/ImprovedDashboard.tsx
@@ -44,6 +44,7 @@ import { useReportDrill } from './reportWidgets/useReportDrill';
 import { WIDGET_CHART_HEIGHT } from './reportWidgets/widgetChrome';
 import { BUILT_IN_REPORTS, type PinnableReportId } from './reportWidgets/pinnableReports';
 import { PieChart, BarChart, ResponsiveContainer } from '../charts/DashboardCharts';
+import { categoricalColor, useCategoricalRamp } from '../charts/chartColors';
 import { formatDecimal } from '../../utils/decimal-format';
 import { toDecimal } from '../../utils/decimal';
 import { expandSplitTransactions } from '../../utils/transactionSplits';
@@ -365,7 +366,9 @@ export function ImprovedDashboard() {
   );
   const pieData = distribution.slices;
 
-  const COLORS = ['#0088FE', '#00C49F', '#FFBB28', '#FF8042', '#8884D8'];
+  // The shared ramp, not a fourth copy of the recharts demo palette that used
+  // to live here (and, byte for byte, in two other files).
+  const chartRamp = useCategoricalRamp();
   const isDarkMode = document.documentElement.classList.contains('dark');
   
   const chartStyles = useMemo(() => ({
@@ -598,7 +601,7 @@ export function ImprovedDashboard() {
                         <PieChart
                           data={pieData}
                           innerRadius={true}
-                          colors={COLORS}
+                          colors={chartRamp}
                           // Straight into that account's register. It used to
                           // go to the global list filtered to the account,
                           // which is the same answer one page further away —
@@ -623,7 +626,7 @@ export function ImprovedDashboard() {
                           >
                             <span
                               className="w-3 h-3 rounded-sm flex-shrink-0"
-                              style={{ backgroundColor: COLORS[i % COLORS.length] }}
+                              style={{ backgroundColor: categoricalColor(chartRamp, i) }}
                               aria-hidden="true"
                             />
                             <span className="flex-1 min-w-0 truncate text-sm text-gray-700 dark:text-gray-300">{d.name}</span>
@@ -815,7 +818,7 @@ export function ImprovedDashboard() {
           </h3>
           <button
             onClick={() => setShowAccountSettings(!showAccountSettings)}
-            className="p-2 hover:bg-gray-100 dark:hover:bg-gray-700 rounded-lg transition-colors focus:outline-none focus:ring-2 focus:ring-blue-600 focus:ring-offset-2"
+            className="p-2 hover:bg-gray-100 dark:hover:bg-gray-700 rounded-lg transition-colors"
             aria-label="Customize displayed accounts"
             aria-expanded={showAccountSettings}
           >
@@ -832,7 +835,7 @@ export function ImprovedDashboard() {
               </p>
               <button
                 onClick={() => setShowAccountSettings(false)}
-                className="p-1 hover:bg-gray-200 dark:hover:bg-gray-600 rounded focus:outline-none focus:ring-2 focus:ring-blue-600"
+                className="p-1 hover:bg-gray-200 dark:hover:bg-gray-600 rounded"
                 aria-label="Close account settings"
               >
                 <XIcon size={16} className="text-gray-500" />
@@ -844,14 +847,14 @@ export function ImprovedDashboard() {
               <button
                 type="button"
                 onClick={selectAllAccounts}
-                className="px-4 py-2 min-h-[44px] sm:min-h-0 sm:py-1.5 text-sm font-medium rounded-lg bg-[#1a2332] dark:bg-blue-600 text-white hover:bg-[#2d3a4d] dark:hover:bg-blue-700 transition-colors focus:outline-none focus:ring-2 focus:ring-blue-600 focus:ring-offset-2"
+                className="px-4 py-2 min-h-[44px] sm:min-h-0 sm:py-1.5 text-sm font-medium rounded-lg bg-[#1a2332] dark:bg-blue-600 text-white hover:bg-[#2d3a4d] dark:hover:bg-blue-700 transition-colors"
               >
                 Select all
               </button>
               <button
                 type="button"
                 onClick={clearAllAccounts}
-                className="px-4 py-2 min-h-[44px] sm:min-h-0 sm:py-1.5 text-sm font-medium rounded-lg bg-[#1a2332] dark:bg-blue-600 text-white hover:bg-[#2d3a4d] dark:hover:bg-blue-700 transition-colors focus:outline-none focus:ring-2 focus:ring-blue-600 focus:ring-offset-2"
+                className="px-4 py-2 min-h-[44px] sm:min-h-0 sm:py-1.5 text-sm font-medium rounded-lg bg-[#1a2332] dark:bg-blue-600 text-white hover:bg-[#2d3a4d] dark:hover:bg-blue-700 transition-colors"
               >
                 Clear all
               </button>
@@ -908,7 +911,7 @@ export function ImprovedDashboard() {
             displayedAccounts.map(account => (
               <div 
                 key={account.id}
-                className="flex items-center justify-between p-4 bg-gray-50 dark:bg-gray-700 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-600 transition-colors cursor-pointer focus:outline-none focus:ring-2 focus:ring-blue-600 focus:ring-offset-2"
+                className="flex items-center justify-between p-4 bg-gray-50 dark:bg-gray-700 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-600 transition-colors cursor-pointer"
                 data-testid="account-balance-card"
                 onClick={() => navigate(preserveDemoParam(`/accounts/${account.id}`, location.search))}
                 role="button"
@@ -1020,7 +1023,7 @@ export function ImprovedDashboard() {
                 key={`${item.kind}:${item.account.id}`}
                 type="button"
                 data-testid="attention-row"
-                className="w-full flex items-center justify-between gap-3 p-3 bg-gray-50 dark:bg-gray-700 rounded-lg text-left hover:shadow-md transition-shadow focus:outline-none focus:ring-2 focus:ring-amber-500 focus:ring-offset-2"
+                className="w-full flex items-center justify-between gap-3 p-3 bg-gray-50 dark:bg-gray-700 rounded-lg text-left hover:shadow-md transition-shadow"
                 onClick={() => navigate(preserveDemoParam(item.href, location.search))}
                 aria-label={`${item.account.name} needs attention: ${item.reason} ${item.actionLabel}`}
               >
@@ -1063,7 +1066,6 @@ export function ImprovedDashboard() {
               <BarChart
                 data={netWorthData}
                 dataKey="netWorth"
-                fill="#8B5CF6"
                 label="Net Worth"
                 formatter={(value: number) => formatCurrencyWithSymbol(value, displayCurrency)}
                 contentStyle={chartStyles.tooltip}

--- a/src/components/dashboard/reportWidgets/CardPeriodControl.tsx
+++ b/src/components/dashboard/reportWidgets/CardPeriodControl.tsx
@@ -119,7 +119,7 @@ export default function CardPeriodControl({ cardLabel, period, pin }: {
         aria-label={pin.isPinned
           ? `${cardLabel}: pinned to ${PERIOD_LABELS[period]}. Choose a different period for this card`
           : `${cardLabel}: period follows the page. Pin this card to its own period`}
-        className="flex items-center rounded px-1.5 py-0.5 text-gray-500 hover:bg-gray-50 hover:text-gray-700 dark:text-gray-400 dark:hover:bg-gray-700/50 dark:hover:text-gray-200 transition-colors duration-state focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
+        className="flex items-center rounded px-1.5 py-0.5 text-gray-500 hover:bg-gray-50 hover:text-gray-700 dark:text-gray-400 dark:hover:bg-gray-700/50 dark:hover:text-gray-200 transition-colors duration-state"
       >
         {pin.isPinned ? (
           <span
@@ -143,7 +143,7 @@ export default function CardPeriodControl({ cardLabel, period, pin }: {
           type="button"
           onClick={pin.follow}
           aria-label={`${cardLabel}: follow the page period`}
-          className="rounded px-1.5 py-0.5 text-label whitespace-nowrap text-gray-500 hover:bg-gray-50 hover:text-gray-700 dark:text-gray-400 dark:hover:bg-gray-700/50 dark:hover:text-gray-200 transition-colors duration-state focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
+          className="rounded px-1.5 py-0.5 text-label whitespace-nowrap text-gray-500 hover:bg-gray-50 hover:text-gray-700 dark:text-gray-400 dark:hover:bg-gray-700/50 dark:hover:text-gray-200 transition-colors duration-state"
         >
           Follow page
         </button>

--- a/src/components/dashboard/reportWidgets/DashboardReportWidgets.tsx
+++ b/src/components/dashboard/reportWidgets/DashboardReportWidgets.tsx
@@ -13,6 +13,7 @@ import {
 } from 'recharts';
 import { useApp } from '../../../contexts/AppContextSupabase';
 import { useCurrencyDecimal } from '../../../hooks/useCurrencyDecimal';
+import { categoricalColor, useCategoricalRamp } from '../../charts/chartColors';
 import { buildMonthlyTrend } from '../../../utils/monthlyTrend';
 import { buildNetWorthSnapshots, netWorthPointToken } from '../../../utils/netWorthSeries';
 import { computeExpenseCategoryNetTotals } from '../../../utils/categoryNetting';
@@ -60,11 +61,6 @@ import { useReportDrill } from './useReportDrill';
  * `pin` is optional: a card rendered without it is a card with no period
  * affordance, which is exactly what these three were before the pin existed.
  */
-
-const CATEGORY_COLORS = [
-  '#3B82F6', '#10B981', '#F59E0B', '#EF4444',
-  '#8B5CF6', '#EC4899', '#6366F1', '#14B8A6'
-];
 
 const compactTick = (value: number): string => {
   const abs = Math.abs(value);
@@ -211,6 +207,9 @@ export function ExpenseCategoriesWidget({ picker, pin }: {
   const { formatCurrency } = useCurrencyDecimal();
   const openReport = useReportDrill();
   const { range } = picker;
+  // The shared ramp — see charts/chartColors. The copy that used to live in
+  // this file was byte-identical to three others and drifted from a fourth.
+  const ramp = useCategoricalRamp();
 
   const data = useMemo(() => {
     const rows = expandSplitTransactions(transactions, transactionSplits).filter(t => {
@@ -270,7 +269,7 @@ export function ExpenseCategoriesWidget({ picker, pin }: {
                   }}
                 >
                   {data.map((entry, index) => (
-                    <Cell key={entry.name} fill={CATEGORY_COLORS[index % CATEGORY_COLORS.length]} />
+                    <Cell key={entry.name} fill={categoricalColor(ramp, index)} />
                   ))}
                 </Pie>
                 <Tooltip formatter={(v: number | string) => formatCurrency(typeof v === 'number' ? v : Number(v))} />
@@ -289,7 +288,7 @@ export function ExpenseCategoriesWidget({ picker, pin }: {
                   title={`${d.name} — open the full report on this category`}
                   className="w-full flex items-center gap-1.5 rounded px-1 py-0.5 text-left text-xs text-gray-600 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-700/50 transition-colors"
                 >
-                  <span className="w-2 h-2 rounded-sm flex-shrink-0" style={{ backgroundColor: CATEGORY_COLORS[i % CATEGORY_COLORS.length] }} aria-hidden="true" />
+                  <span className="w-2 h-2 rounded-sm flex-shrink-0" style={{ backgroundColor: categoricalColor(ramp, i) }} aria-hidden="true" />
                   <span className="truncate">{d.name}</span>
                 </button>
               </li>

--- a/src/components/layout/AccessibilityImprovements.tsx
+++ b/src/components/layout/AccessibilityImprovements.tsx
@@ -75,42 +75,39 @@ export function AccessibleSpinner({ label = 'Loading...' }: { label?: string }) 
   );
 }
 
-// Focus visible indicator component
+/**
+ * Touch-target sizing, injected at runtime.
+ *
+ * ─ THIS USED TO DECLARE A FOCUS RING, AND IT WAS THE ONE THAT WON ──────────
+ * It injected `.user-is-tabbing *:focus-visible { outline: 2px solid #94a3b8
+ * !important }` and toggled `user-is-tabbing` on <body> from a keydown
+ * listener. Being a runtime <style> with higher specificity than the app-wide
+ * `*:focus-visible` rule AND carrying `!important`, it beat
+ * accessibility-colors.css everywhere — so the ring was ALWAYS the hardcoded
+ * slate, and `--focus-ring-color` (which the light theme sets to the brand
+ * navy) never painted once the user had pressed Tab. Two costs, both
+ * measured: light mode drew #94a3b8 on white at 2.56:1, under the 3:1 that
+ * WCAG 2.4.11 asks of a focus indicator; and a scoped override of the
+ * variable — the mechanism the app now uses for controls on a navy ground —
+ * could not take effect, because the colour here was not a variable at all.
+ *
+ * It was also redundant: `:focus-visible` already means "focus that deserves
+ * a ring", which is the entire job the `user-is-tabbing` class was doing by
+ * hand. The rule, the class and its two listeners all went with it
+ * (RULINGS_ON_CAUSE_2026-08-13 §3). Nothing else referenced the class, and
+ * `data-suppress-focus-outline` was an escape hatch no element ever used.
+ *
+ * The mouse-focus suppression went too — it was written as
+ * `*:focus:not(.focus-visible)`, a polyfill CLASS this app never applies, so
+ * it matched every focused element and did nothing useful. index.css has the
+ * correct `:focus:not(:focus-visible)` form.
+ *
+ * What remains is the touch-target floor, which is the only thing here that
+ * was ever load-bearing.
+ */
 export function FocusIndicator() {
-  React.useEffect(() => {
-    // Add focus-visible class to body when using keyboard navigation
-    const handleFirstTab = (e: KeyboardEvent) => {
-      if (e.key === 'Tab') {
-        document.body.classList.add('user-is-tabbing');
-      }
-    };
-
-    const handleMouseDown = () => {
-      document.body.classList.remove('user-is-tabbing');
-    };
-
-    window.addEventListener('keydown', handleFirstTab);
-    window.addEventListener('mousedown', handleMouseDown);
-
-    return () => {
-      window.removeEventListener('keydown', handleFirstTab);
-      window.removeEventListener('mousedown', handleMouseDown);
-    };
-  }, []);
-
   return (
     <style dangerouslySetInnerHTML={{ __html: `
-      /* Enhanced focus styles for keyboard navigation */
-      .user-is-tabbing *:focus-visible:not([data-suppress-focus-outline="true"]) {
-        outline: 2px solid #94a3b8 !important;
-        outline-offset: 2px !important;
-      }
-
-      /* Remove default focus for mouse users */
-      *:focus:not(.focus-visible) {
-        outline: none;
-      }
-
       /* Ensure interactive elements have minimum TOUCH target size.
          Scoped to coarse pointers: applying this on desktop inflated every
          compact control (toggle switches rendered as 44x44 blobs). Controls
@@ -191,7 +188,6 @@ export function AccessibleIconButton({
         min-w-[44px] min-h-[44px] 
         flex items-center justify-center 
         rounded-lg transition-colors
-        focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary
         ${variantClasses[variant]}
         ${className}
       `}
@@ -245,7 +241,7 @@ export function AccessibleFormField({
         className={`
           w-full px-3 py-2 
           border rounded-lg
-          focus:outline-none focus:ring-2 focus:ring-primary focus:border-transparent
+             focus:border-transparent
           ${error 
             ? 'border-red-500 dark:border-red-400' 
             : 'border-gray-300 dark:border-gray-600'

--- a/src/components/reconciliation/ReconciliationTransactionList.tsx
+++ b/src/components/reconciliation/ReconciliationTransactionList.tsx
@@ -210,7 +210,7 @@ export default function ReconciliationTransactionList({
             placeholder="Search transactions..."
             value={searchTerm}
             onChange={(e) => setSearchTerm(e.target.value)}
-            className="w-full pl-9 pr-3 py-2 text-sm bg-white dark:bg-gray-700 border border-gray-300 dark:border-gray-600 rounded-lg focus:ring-2 focus:ring-primary dark:text-white"
+            className="w-full pl-9 pr-3 py-2 text-sm bg-white dark:bg-gray-700 border border-gray-300 dark:border-gray-600 rounded-lg dark:text-white"
           />
         </div>
 

--- a/src/components/reports/ReportAccountMultiSelect.tsx
+++ b/src/components/reports/ReportAccountMultiSelect.tsx
@@ -124,7 +124,7 @@ export default function ReportAccountMultiSelect({
   };
 
   const actionClass =
-    'text-xs font-medium text-primary dark:text-blue-400 rounded px-1 hover:underline focus:outline-none focus-visible:ring-2 focus-visible:ring-primary';
+'text-xs font-medium text-primary dark:text-blue-400 rounded px-1 hover:underline';
 
   return (
     <div className="flex items-center gap-2">
@@ -136,7 +136,7 @@ export default function ReportAccountMultiSelect({
           onClick={() => (open ? cancel() : openPanel())}
           aria-expanded={open}
           aria-controls={open ? panelId : undefined}
-          className="flex items-center gap-2 px-3 py-1.5 text-sm bg-white dark:bg-gray-800 border border-gray-300/50 dark:border-gray-600/50 rounded-lg text-gray-900 dark:text-white focus:outline-none focus:ring-2 focus:ring-primary"
+          className="flex items-center gap-2 px-3 py-1.5 text-sm bg-white dark:bg-gray-800 border border-gray-300/50 dark:border-gray-600/50 rounded-lg text-gray-900 dark:text-white"
         >
           {/* The visible text is the value; the control still has to say what
               it is for. */}
@@ -197,7 +197,7 @@ export default function ReportAccountMultiSelect({
                           type="checkbox"
                           checked={draft.has(account.id)}
                           onChange={() => toggleDraft(account.id)}
-                          className="rounded border-gray-300 dark:border-gray-600 text-primary focus:ring-2 focus:ring-primary"
+                          className="rounded border-gray-300 dark:border-gray-600 text-primary"
                         />
                         <span className="truncate text-gray-900 dark:text-white">{account.name}</span>
                       </label>
@@ -212,14 +212,14 @@ export default function ReportAccountMultiSelect({
               <button
                 type="button"
                 onClick={cancel}
-                className="px-3 py-1 text-sm font-medium rounded-md border border-gray-300 dark:border-gray-600 text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700 focus:outline-none focus-visible:ring-2 focus-visible:ring-primary"
+                className="px-3 py-1 text-sm font-medium rounded-md border border-gray-300 dark:border-gray-600 text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700"
               >
                 Cancel
               </button>
               <button
                 type="button"
                 onClick={save}
-                className="px-3 py-1 text-sm font-medium rounded-md bg-[#1a2332] dark:bg-blue-600 text-white hover:opacity-90 focus:outline-none focus-visible:ring-2 focus-visible:ring-primary"
+                className="px-3 py-1 text-sm font-medium rounded-md bg-[#1a2332] dark:bg-blue-600 text-white hover:opacity-90"
               >
                 Save
               </button>

--- a/src/components/reports/ReportCumulativeToggle.tsx
+++ b/src/components/reports/ReportCumulativeToggle.tsx
@@ -19,7 +19,7 @@ export default function ReportCumulativeToggle({
         type="checkbox"
         checked={toggle.cumulative}
         onChange={e => toggle.setCumulative(e.target.checked)}
-        className="rounded border-gray-300 dark:border-gray-600 focus:ring-2 focus:ring-primary"
+        className="rounded border-gray-300 dark:border-gray-600"
       />
       Cumulative
     </label>

--- a/src/components/settings/LocaleSelector.tsx
+++ b/src/components/settings/LocaleSelector.tsx
@@ -61,7 +61,7 @@ export default function LocaleSelector({ onLocaleChange }: LocaleSelectorProps):
             id="locale-select"
             value={currentLocale}
             onChange={(e) => handleLocaleChange(e.target.value)}
-            className="w-full px-4 py-2 bg-white dark:bg-gray-700 border border-gray-300 dark:border-gray-600 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-600 dark:focus:ring-blue-400 text-gray-900 dark:text-white"
+            className="w-full px-4 py-2 bg-white dark:bg-gray-700 border border-gray-300 dark:border-gray-600 rounded-lg text-gray-900 dark:text-white"
           >
             {SUPPORTED_LOCALES.map((locale) => (
               <option key={locale.code} value={locale.code}>

--- a/src/components/settings/ShowTipsAgain.tsx
+++ b/src/components/settings/ShowTipsAgain.tsx
@@ -31,7 +31,7 @@ export default function ShowTipsAgain(): React.JSX.Element {
         <button
           type="button"
           onClick={handleShowAgain}
-          className="px-4 py-2 text-sm font-medium rounded-lg border border-gray-300 dark:border-gray-600 text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-700 transition-colors focus:outline-none focus:ring-2 focus:ring-primary"
+          className="px-4 py-2 text-sm font-medium rounded-lg border border-gray-300 dark:border-gray-600 text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-700 transition-colors"
         >
           Show tips again
         </button>

--- a/src/components/ui/ToggleSwitch.tsx
+++ b/src/components/ui/ToggleSwitch.tsx
@@ -42,7 +42,6 @@ const ToggleSwitch = forwardRef<HTMLButtonElement, ToggleSwitchProps>(function T
       <span
         aria-hidden="true"
         className={`relative inline-block h-6 w-11 shrink-0 rounded-full transition-colors duration-200 ease-in-out
-          group-focus-visible:ring-2 group-focus-visible:ring-offset-2 group-focus-visible:ring-[#1a2332] dark:group-focus-visible:ring-blue-500 dark:group-focus-visible:ring-offset-gray-800
           ${checked
             ? 'bg-[#1a2332] dark:bg-blue-600'
             : 'bg-gray-300 dark:bg-gray-600'}

--- a/src/index.css
+++ b/src/index.css
@@ -221,9 +221,6 @@ body {
   background-color: var(--color-secondary) !important;
 }
 
-.focus\:ring-primary:focus {
-  --tw-ring-color: var(--color-primary) !important;
-}
 
 .bg-secondary {
   background-color: var(--color-secondary) !important;
@@ -361,11 +358,20 @@ button[style*="borderRadius"], button.rounded-full {
   filter: drop-shadow(0 2px 4px rgba(0, 0, 0, 0.1));
 }
 
-/* Completely remove all borders and outlines from circular buttons */
+/* Remove all BORDERS from circular buttons.
+   The `outline: none !important` that used to sit in both blocks below is
+   gone. It was written to kill the browser's default focus ring, but `*` is
+   not what it hit: `button.rounded-full` outranks the app-wide
+   `*:focus-visible` rule in accessibility-colors.css on specificity, and
+   carried `!important` where borders.css's replacement did not — so every
+   circular button in the app had NO focus indicator at all, and the repair
+   written for it in borders.css could never win. A keyboard user tabbing onto
+   one saw nothing move.
+   Mouse clicks stay clean without it, because `:focus:not(:focus-visible)`
+   further down this file already suppresses the outline for pointer focus. */
 button.rounded-full,
 .no-border-button {
   border: none !important;
-  outline: none !important;
   box-shadow: none !important;
   -webkit-appearance: none !important;
   -moz-appearance: none !important;
@@ -382,17 +388,17 @@ button.rounded-full:focus-visible,
 .no-border-button:hover,
 .no-border-button:focus-visible {
   border: none !important;
-  outline: none !important;
   box-shadow: none !important;
   -webkit-appearance: none !important;
   -moz-appearance: none !important;
   appearance: none !important;
 }
 
-/* Specific fix for the lock button */
+/* Specific fix for the lock button. `outline: none !important` came out for
+   the same reason as the circular buttons above: it also outranked the
+   app-wide focus rule, so this control could be tabbed to and never said so. */
 .lock-button {
   border: none !important;
-  outline: none !important;
   box-shadow: none !important;
   background-clip: padding-box !important;
   -webkit-tap-highlight-color: transparent !important;
@@ -527,10 +533,13 @@ button.rounded-full:focus-visible,
     }
   }
   
-  /* Improved focus states for mobile */
+  /* Improved focus states for mobile. Same variable as every other focus
+     rule — this used to reach for --color-primary, which is the same navy in
+     light mode but does NOT follow the .dark override, so a touch user in
+     dark mode got a navy outline on a near-black panel. */
   @media (hover: none) {
     button:focus, a:focus {
-      outline: 2px solid var(--color-primary);
+      outline: 2px solid var(--focus-ring-color, #94a3b8);
       outline-offset: 2px;
     }
   }
@@ -617,11 +626,6 @@ button.rounded-full:focus-visible,
     }
   }
   
-  /* Focus indicators for accessibility */
-  .focus-visible {
-    @apply outline-2 outline-offset-2 outline-[var(--color-primary)];
-  }
-  
   /* Skip link for screen readers */
   .skip-link {
     @apply absolute -top-10 left-4 z-50 bg-[var(--color-primary)] text-white px-4 py-2 rounded-md;
@@ -672,12 +676,6 @@ button.rounded-full:focus-visible,
     white-space: normal;
   }
 
-  /* Focus Visible for Better Keyboard Navigation */
-  :focus-visible {
-    outline: 2px solid #94a3b8;
-    outline-offset: 2px;
-  }
-
   /* Remove default focus styles for mouse users */
   :focus:not(:focus-visible) {
     outline: none;
@@ -685,9 +683,12 @@ button.rounded-full:focus-visible,
 
   /* High Contrast Mode Support */
   @media (prefers-contrast: high) {
+    /* !important because accessibility-colors.css declares the app's focus
+       ring with it; without a match here this block lost every cascade and
+       high-contrast users silently got the ordinary 2px ring. */
     :focus-visible {
-      outline: 3px solid;
-      outline-offset: 3px;
+      outline: 3px solid !important;
+      outline-offset: 3px !important;
     }
     
     .border {

--- a/src/pages/AccountTransactions.tsx
+++ b/src/pages/AccountTransactions.tsx
@@ -3320,7 +3320,7 @@ export default function AccountTransactions() {
                   placeholder="Search by description, amount, category..."
                   value={searchTerm}
                   onChange={(e) => setSearchTerm(e.target.value)}
-                  className="w-full pl-10 pr-4 py-3 sm:py-2 text-base sm:text-sm bg-white dark:bg-gray-700 border-2 border-gray-300 dark:border-gray-500 rounded-lg focus:outline-none focus:ring-2 focus:ring-primary dark:focus:ring-blue-400 focus:border-transparent dark:text-white min-h-[48px] sm:min-h-[auto]"
+                  className="w-full pl-10 pr-4 py-3 sm:py-2 text-base sm:text-sm bg-white dark:bg-gray-700 border-2 border-gray-300 dark:border-gray-500 rounded-lg focus:border-transparent dark:text-white min-h-[48px] sm:min-h-[auto]"
                 />
               </div>
             </div>
@@ -3380,7 +3380,7 @@ export default function AccountTransactions() {
                 <DatePicker
                   value={dateFrom}
                   onChange={(val) => setDateFrom(val)}
-                  className="bg-white dark:bg-gray-700 border border-gray-300 dark:border-gray-500 rounded-lg focus:outline-none focus:ring-2 focus:ring-primary dark:text-white text-sm"
+                  className="bg-white dark:bg-gray-700 border border-gray-300 dark:border-gray-500 rounded-lg dark:text-white text-sm"
                   aria-label="Filter from date"
                 />
               </div>
@@ -3389,7 +3389,7 @@ export default function AccountTransactions() {
                 <DatePicker
                   value={dateTo}
                   onChange={(val) => setDateTo(val)}
-                  className="bg-white dark:bg-gray-700 border border-gray-300 dark:border-gray-500 rounded-lg focus:outline-none focus:ring-2 focus:ring-primary dark:text-white text-sm"
+                  className="bg-white dark:bg-gray-700 border border-gray-300 dark:border-gray-500 rounded-lg dark:text-white text-sm"
                   aria-label="Filter to date"
                 />
               </div>
@@ -3504,7 +3504,7 @@ export default function AccountTransactions() {
         // at 60% while the same figures are fetched again. Blanking a register
         // to reload it is indistinguishable, for the half-second it lasts,
         // from losing the data (DESIGN_PASS §4).
-        className={`hidden lg:block overflow-hidden focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2 dark:focus-visible:ring-offset-gray-900 ${
+        className={`hidden lg:block overflow-hidden ${
           isLoading ? 'opacity-60 transition-opacity duration-enter' : ''
         }`}
         role="grid"
@@ -3671,7 +3671,7 @@ export default function AccountTransactions() {
                 id="quick-add-date"
                 value={quickAddForm.date}
                 onChange={(val) => { clearQuickAddError(); setQuickAddForm({ ...quickAddForm, date: val }); }}
-                className="h-auto sm:h-[32px] bg-white dark:bg-gray-700 border border-gray-300 dark:border-gray-600 rounded-lg focus:outline-none focus:ring-1 focus:ring-primary dark:text-white text-xs"
+                className="h-auto sm:h-[32px] bg-white dark:bg-gray-700 border border-gray-300 dark:border-gray-600 rounded-lg dark:text-white text-xs"
               />
             </div>
 
@@ -3732,10 +3732,10 @@ export default function AccountTransactions() {
                 required
                 aria-invalid={quickAddError?.field === 'description' ? true : undefined}
                 aria-describedby={quickAddError?.field === 'description' ? QUICK_ADD_ERROR_ID : undefined}
-                className={`w-full px-2.5 py-1.5 h-auto sm:h-[32px] text-xs bg-white dark:bg-gray-700 border rounded-lg focus:outline-none focus:ring-1 dark:text-white ${
+                className={`w-full px-2.5 py-1.5 h-auto sm:h-[32px] text-xs bg-white dark:bg-gray-700 border rounded-lg dark:text-white ${
                   quickAddError?.field === 'description'
-                    ? 'border-red-500 dark:border-red-400 focus:ring-red-500'
-                    : 'border-gray-300 dark:border-gray-600 focus:ring-primary'
+                    ?'border-red-500 dark:border-red-400'
+                    :'border-gray-300 dark:border-gray-600'
                 }`}
               />
             </div>
@@ -3823,10 +3823,10 @@ export default function AccountTransactions() {
                 onChange={(value) => { clearQuickAddError(); setQuickAddForm({ ...quickAddForm, amount: value }); }}
                 aria-invalid={quickAddError?.field === 'amount' ? true : undefined}
                 aria-describedby={quickAddError?.field === 'amount' ? QUICK_ADD_ERROR_ID : undefined}
-                className={`w-full px-2.5 py-1.5 h-auto sm:h-[32px] text-xs text-right bg-white dark:bg-gray-700 border rounded-lg focus:outline-none focus:ring-1 dark:text-white ${
+                className={`w-full px-2.5 py-1.5 h-auto sm:h-[32px] text-xs text-right bg-white dark:bg-gray-700 border rounded-lg dark:text-white ${
                   quickAddError?.field === 'amount'
-                    ? 'border-red-500 dark:border-red-400 focus:ring-red-500'
-                    : 'border-gray-300 dark:border-gray-600 focus:ring-primary'
+                    ?'border-red-500 dark:border-red-400'
+                    :'border-gray-300 dark:border-gray-600'
                 }`}
                 required
               />

--- a/src/pages/Accounts.tsx
+++ b/src/pages/Accounts.tsx
@@ -1323,7 +1323,7 @@ export default function Accounts() {
                           key={child.id}
                           ref={isArrivalRow(child.id) ? arrivalRowRef : undefined}
                           {...rowProps(child.id)}
-                          className={`group/row mt-3 ml-6 sm:ml-9 flex flex-col sm:flex-row sm:items-center sm:justify-between gap-2 sm:gap-3 rounded-xl border border-dashed pl-3 pr-3 sm:pr-0 py-2.5 cursor-pointer select-none transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 ${rowSkin(
+                          className={`group/row mt-3 ml-6 sm:ml-9 flex flex-col sm:flex-row sm:items-center sm:justify-between gap-2 sm:gap-3 rounded-xl border border-dashed pl-3 pr-3 sm:pr-0 py-2.5 cursor-pointer select-none transition-colors ${rowSkin(
                             child.id,
                             'border-gray-300 dark:border-gray-500 bg-gray-100 dark:bg-gray-700/60 hover:border-gray-400 dark:hover:border-gray-400'
                           )}`}
@@ -1794,7 +1794,7 @@ export default function Accounts() {
               value={accountSearch}
               onChange={(e) => setAccountSearch(e.target.value)}
               placeholder="Search accounts…"
-              className="w-full pl-9 pr-3 py-1.5 text-sm rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 text-gray-900 dark:text-white placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+              className="w-full pl-9 pr-3 py-1.5 text-sm rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 text-gray-900 dark:text-white placeholder-gray-400 focus:border-transparent"
             />
           </div>
           {isSearching && (

--- a/src/pages/Calendar.tsx
+++ b/src/pages/Calendar.tsx
@@ -272,7 +272,7 @@ export default function Calendar() {
                 min-h-[60px] sm:min-h-[100px] p-1 sm:p-2 border-b border-r border-gray-50 dark:border-gray-700/50
                 ${!day.isCurrentMonth ? 'bg-gray-50 dark:bg-gray-800/50 opacity-40' : 'bg-white dark:bg-gray-800'}
                 ${day.isToday ? 'ring-2 ring-inset ring-blue-500' : ''}
-                ${day.transactionCount > 0 ? 'cursor-pointer hover:bg-gray-50 dark:hover:bg-gray-700/50 focus:outline-none focus:ring-2 focus:ring-inset focus:ring-blue-500' : ''}
+                ${day.transactionCount > 0 ?'cursor-pointer hover:bg-gray-50 dark:hover:bg-gray-700/50':''}
                 transition-colors
               `}
             >

--- a/src/pages/Find.tsx
+++ b/src/pages/Find.tsx
@@ -348,7 +348,7 @@ export default function Find(): React.JSX.Element {
             autoFocus
             placeholder="Find a description or an amount…"
             aria-label="Find transactions by description or amount"
-            className="w-full pl-10 pr-4 py-2.5 rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 text-gray-900 dark:text-white placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-[#6B86B3]"
+            className="w-full pl-10 pr-4 py-2.5 rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 text-gray-900 dark:text-white placeholder-gray-500"
           />
         </div>
 
@@ -359,7 +359,7 @@ export default function Find(): React.JSX.Element {
               <button
                 type="button"
                 onClick={clearDates}
-                className="rounded-full p-0.5 hover:bg-gray-200 dark:hover:bg-gray-600 focus:outline-none focus:ring-2 focus:ring-[#6B86B3]"
+                className="rounded-full p-0.5 hover:bg-gray-200 dark:hover:bg-gray-600"
                 aria-label="Clear the date range"
                 title="Clear the date range"
               >
@@ -473,7 +473,7 @@ export default function Find(): React.JSX.Element {
                       onKeyDown={event => handleRowKeyDown(event, transaction)}
                       tabIndex={transaction.id === tabStopId ? 0 : -1}
                       aria-current={isCurrent ? 'true' : undefined}
-                      className={`cursor-pointer select-none transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-[#6B86B3] ${
+                      className={`cursor-pointer select-none transition-colors ${
                         isCurrent ? FIND_ROW_SELECTED_CLASS : 'hover:bg-gray-50 dark:hover:bg-gray-700/50'
                       }`}
                     >

--- a/src/pages/Goals.tsx
+++ b/src/pages/Goals.tsx
@@ -299,7 +299,7 @@ export default function Goals(): React.JSX.Element {
         <button
           type="button"
           onClick={() => setIsModalOpen(true)}
-          className="cursor-pointer rounded-full focus:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2"
+          className="cursor-pointer rounded-full"
           aria-label="Add goal"
         >
           <svg
@@ -509,7 +509,7 @@ export default function Goals(): React.JSX.Element {
                             key={account.id}
                             type="button"
                             onClick={() => openAccount(account.id)}
-                            className="px-2 py-1 rounded-lg text-xs font-medium bg-gray-100 dark:bg-gray-700 text-gray-700 dark:text-gray-200 hover:bg-gray-200 dark:hover:bg-gray-600 focus:outline-none focus-visible:ring-2 focus-visible:ring-primary"
+                            className="px-2 py-1 rounded-lg text-xs font-medium bg-gray-100 dark:bg-gray-700 text-gray-700 dark:text-gray-200 hover:bg-gray-200 dark:hover:bg-gray-600"
                             aria-label={`Open ${account.name}`}
                           >
                             {account.name}

--- a/src/pages/Investments.tsx
+++ b/src/pages/Investments.tsx
@@ -27,6 +27,7 @@ import { buildPortfolioSummary, buildPortfolioHistory } from '../utils/portfolio
 import { dataPort } from '@data';
 import type { InvestmentHolding } from '@data';
 import { fetchQuotes } from '../services/stockPriceService';
+import { categoricalColor, useCategoricalRamp } from '../components/charts/chartColors';
 
 export default function Investments() {
   const { accounts, transactions, transactionSplits, categories } = useApp();
@@ -233,8 +234,10 @@ export default function Investments() {
   // must never be confused for each other on this page.
   const portfolioLines = summary.lines;
   const isGain = summary.totalReturn.greaterThanOrEqualTo(0);
-  // Use consistent colors for better visual coherence
-  const COLORS = ['#3B82F6', '#10B981', '#F59E0B', '#EF4444', '#8B5CF6', '#EC4899', '#06B6D4', '#84CC16'];
+  // The shared ramp. The array that stood here claimed to be "consistent
+  // colors" while being the only one of the app's palettes to differ from its
+  // twin — positions seven and eight had drifted to a cyan and a lime.
+  const ramp = useCategoricalRamp();
 
   // If no investment accounts, show empty state
   if (investmentAccounts.length === 0) {
@@ -268,7 +271,7 @@ export default function Investments() {
           <button
             type="button"
             onClick={() => setShowAddInvestmentModal(true)}
-            className="cursor-pointer rounded-full focus:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2"
+            className="cursor-pointer rounded-full"
             aria-label="Add investment"
           >
             <svg
@@ -522,7 +525,7 @@ export default function Investments() {
                       <div className="flex items-center gap-2">
                         <div
                           className="w-3 h-3 rounded-full flex-shrink-0"
-                          style={{ backgroundColor: COLORS[index % COLORS.length] }}
+                          style={{ backgroundColor: categoricalColor(ramp, index) }}
                         />
                         <div>
                           <h3 className="font-medium text-gray-900 dark:text-white">
@@ -558,7 +561,7 @@ export default function Investments() {
                             // negative amount, and a negative width renders
                             // nothing anywhere.
                             width: `${Math.min(100, Math.max(0, line.allocation.toNumber()))}%`,
-                            backgroundColor: COLORS[index % COLORS.length]
+                            backgroundColor: categoricalColor(ramp, index)
                           }}
                         />
                       </div>
@@ -595,7 +598,7 @@ export default function Investments() {
                       dataKey="value"
                     >
                       {allocationData.map((_, index) => (
-                        <Cell key={`cell-${index}`} fill={COLORS[index % COLORS.length]} />
+                        <Cell key={`cell-${index}`} fill={categoricalColor(ramp, index)} />
                       ))}
                     </Pie>
                     <Tooltip
@@ -615,7 +618,7 @@ export default function Investments() {
                     <div className="flex items-center gap-2">
                       <div
                         className="w-3 h-3 rounded-full"
-                        style={{ backgroundColor: COLORS[index % COLORS.length] }}
+                        style={{ backgroundColor: categoricalColor(ramp, index) }}
                       />
                       <span className="text-gray-700 dark:text-gray-300">{line.institution || 'N/A'}</span>
                     </div>
@@ -722,7 +725,7 @@ export default function Investments() {
               id="manage-account"
               value={managingAccountId || ''}
               onChange={(e) => setManagingAccountId(e.target.value)}
-              className="w-full px-4 py-2 border border-gray-300 dark:border-gray-600 rounded-lg focus:ring-2 focus:ring-primary focus:border-transparent dark:bg-gray-700 dark:text-white"
+              className="w-full px-4 py-2 border border-gray-300 dark:border-gray-600 rounded-lg focus:border-transparent dark:bg-gray-700 dark:text-white"
             >
               <option value="">Choose an account...</option>
               {/* Grouped and alphabetised like every other account

--- a/src/pages/Reports.tsx
+++ b/src/pages/Reports.tsx
@@ -96,7 +96,7 @@ export default function Reports({ picker }: ReportViewProps): React.JSX.Element 
               type="checkbox"
               checked={showRevaluations}
               onChange={toggleRevaluations}
-              className="rounded border-gray-300 dark:border-gray-600 focus:ring-2 focus:ring-primary"
+              className="rounded border-gray-300 dark:border-gray-600"
             />
             Show gains, losses &amp; adjustments
           </label>

--- a/src/pages/Welcome.tsx
+++ b/src/pages/Welcome.tsx
@@ -62,7 +62,7 @@ export default function Welcome(): React.JSX.Element {
           read as one thing. */}
       <section
         aria-labelledby="welcome-heading"
-        className="rounded-2xl bg-primary px-6 py-12 sm:px-10 sm:py-14 text-center shadow-lg"
+        className="focus-ring-on-dark rounded-2xl bg-primary px-6 py-12 sm:px-10 sm:py-14 text-center shadow-lg"
       >
         <div className="flex items-center justify-center gap-2 text-white/70">
           <WalletIcon size={20} />
@@ -85,7 +85,7 @@ export default function Welcome(): React.JSX.Element {
           <SignUpButton mode="modal">
             <button
               type="button"
-              className="inline-flex items-center justify-center gap-2 px-6 py-3 rounded-xl bg-white text-primary font-semibold shadow-sm hover:bg-white/90 transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-white focus-visible:ring-offset-2 focus-visible:ring-offset-primary"
+              className="inline-flex items-center justify-center gap-2 px-6 py-3 rounded-xl bg-white text-primary font-semibold shadow-sm hover:bg-white/90 transition-colors"
             >
               Get started
               <ArrowRightIcon size={18} />
@@ -94,7 +94,7 @@ export default function Welcome(): React.JSX.Element {
           <SignInButton mode="modal">
             <button
               type="button"
-              className="inline-flex items-center justify-center px-6 py-3 rounded-xl border border-white/25 text-white font-semibold hover:bg-white/10 transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-white focus-visible:ring-offset-2 focus-visible:ring-offset-primary"
+              className="inline-flex items-center justify-center px-6 py-3 rounded-xl border border-white/25 text-white font-semibold hover:bg-white/10 transition-colors"
             >
               Sign in
             </button>

--- a/src/pages/__tests__/Accounts.selection.test.tsx
+++ b/src/pages/__tests__/Accounts.selection.test.tsx
@@ -360,9 +360,16 @@ describe('Accounts list — the link is the letters, and no wider', () => {
   it('draws the keyboard focus ring round the name, where it can be seen', async () => {
     await openList();
 
-    // The ring belongs to the link, so it is the size of the link — which is
-    // now the size of the letters and not of the row.
-    expect(classesOf(nameLink('Synthetic Everyday'))).toContain('focus-visible:ring-2');
+    // The indicator belongs to the link, so it is the size of the link — which
+    // is the size of the letters and not of the row.
+    //
+    // It used to be asserted as the link's own `focus-visible:ring-2`. That
+    // ring is gone: it painted INSIDE the app-wide `*:focus-visible` outline,
+    // so the name wore two (RULINGS_ON_CAUSE_2026-08-13 §3). What still has to
+    // hold is the GEOMETRY the outline inherits — `w-fit` is what makes the
+    // indicator hug the letters, and it is now the only thing that does.
+    expect(classesOf(nameLink('Synthetic Everyday'))).toContain('w-fit');
+    expect(classesOf(nameLink('Synthetic Everyday'))).not.toContain('focus-visible:ring-2');
     // …and the heading around it no longer clips. `truncate` there had nothing
     // left to clip once the link capped itself, but it did clip the ring: an
     // ancestor's overflow clips a descendant's outline and box-shadow alike, so

--- a/src/pages/reports/AccountBalancesReport.tsx
+++ b/src/pages/reports/AccountBalancesReport.tsx
@@ -129,7 +129,7 @@ export default function AccountBalancesReport({ picker }: ReportViewProps): Reac
                         <button
                           type="button"
                           onClick={() => drillIntoAccount(row)}
-                          className="text-sm text-gray-900 dark:text-white hover:text-blue-700 dark:hover:text-blue-400 hover:underline rounded focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
+                          className="text-sm text-gray-900 dark:text-white hover:text-blue-700 dark:hover:text-blue-400 hover:underline rounded"
                           title={`${row.name} — view these transactions`}
                         >
                           {row.name}

--- a/src/pages/reports/AccountDistributionReport.tsx
+++ b/src/pages/reports/AccountDistributionReport.tsx
@@ -3,6 +3,7 @@ import { Link, useLocation, useNavigate } from 'react-router-dom';
 import { useApp } from '../../contexts/AppContextSupabase';
 import { useCurrencyDecimal } from '../../hooks/useCurrencyDecimal';
 import { PieChart, ResponsiveContainer } from '../../components/charts/DashboardCharts';
+import { categoricalColor, useCategoricalRamp } from '../../components/charts/chartColors';
 import { computeAccountBalances } from '../../utils/accountBalances';
 import {
   buildAccountDistribution,
@@ -28,14 +29,15 @@ import { preserveDemoParam } from '../../utils/navigation';
  * Closed accounts are not, because they are never loaded.
  */
 
-/** The same five colours the Dashboard card uses, in the same order. */
-const COLORS = ['#0088FE', '#00C49F', '#FFBB28', '#FF8042', '#8884D8'];
-
 export default function AccountDistributionReport(): React.JSX.Element {
   const { accounts, transactions, serverBalances } = useApp();
   const { formatCurrency, displayCurrency } = useCurrencyDecimal();
   const location = useLocation();
   const navigate = useNavigate();
+  // The shared ramp. This file used to carry its own copy of the recharts demo
+  // palette with a comment promising it matched the Dashboard's — a promise
+  // nothing checked, and exactly the drift the one-module rule removes.
+  const ramp = useCategoricalRamp();
 
   const distribution = useMemo(() => {
     const balances = computeAccountBalances(accounts, transactions, serverBalances);
@@ -44,8 +46,8 @@ export default function AccountDistributionReport(): React.JSX.Element {
 
   /** Which colour each drawn slice got, so the table's swatches match the donut. */
   const sliceColours = useMemo(
-    () => new Map(distribution.slices.map((entry, index) => [entry.id, COLORS[index % COLORS.length]])),
-    [distribution.slices]
+    () => new Map(distribution.slices.map((entry, index) => [entry.id, categoricalColor(ramp, index)])),
+    [distribution.slices, ramp]
   );
 
   // The account's register, not the retired global list filtered to it.
@@ -110,7 +112,7 @@ export default function AccountDistributionReport(): React.JSX.Element {
               <PieChart
                 data={distribution.slices}
                 innerRadius={true}
-                colors={COLORS}
+                colors={ramp}
                 onClick={(entry: AccountDistributionEntry) => navigate(transactionsHref(entry.id))}
                 formatter={(value: number) => money(value)}
                 aria-label="Pie chart showing distribution of account balances"
@@ -158,7 +160,7 @@ export default function AccountDistributionReport(): React.JSX.Element {
                         />
                         <Link
                           to={transactionsHref(entry.id)}
-                          className="text-sm text-gray-900 dark:text-white hover:text-blue-700 dark:hover:text-blue-400 hover:underline rounded focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
+                          className="text-sm text-gray-900 dark:text-white hover:text-blue-700 dark:hover:text-blue-400 hover:underline rounded"
                           title={`${entry.name} — view these transactions`}
                         >
                           {entry.name}

--- a/src/pages/reports/IncomeSpendingOverTimeReport.tsx
+++ b/src/pages/reports/IncomeSpendingOverTimeReport.tsx
@@ -149,7 +149,7 @@ export default function IncomeSpendingOverTimeReport({ picker, focus }: ReportVi
     <button
       type="button"
       onClick={onClick}
-      className={`w-full justify-end text-right rounded px-1 -mx-1 tabular-nums hover:bg-blue-50 dark:hover:bg-blue-900/30 hover:underline focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 ${colour}`}
+      className={`w-full justify-end text-right rounded px-1 -mx-1 tabular-nums hover:bg-blue-50 dark:hover:bg-blue-900/30 hover:underline ${colour}`}
       title={`${label} — view these transactions`}
     >
       {formatCurrency(value)}

--- a/src/pages/reports/NetWorthStatementReport.tsx
+++ b/src/pages/reports/NetWorthStatementReport.tsx
@@ -100,7 +100,7 @@ export default function NetWorthStatementReport({ picker }: ReportViewProps): Re
                     <button
                       type="button"
                       onClick={() => drillIntoAccount(row)}
-                      className="text-left rounded focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
+                      className="text-left rounded"
                       title={`${row.name} — view these transactions`}
                     >
                       <span className="block text-sm text-gray-900 dark:text-white hover:text-blue-700 dark:hover:text-blue-400 hover:underline">

--- a/src/pages/reports/PeriodComparisonReport.tsx
+++ b/src/pages/reports/PeriodComparisonReport.tsx
@@ -211,7 +211,7 @@ export default function PeriodComparisonReport({ picker }: ReportViewProps): Rea
         <button
           type="button"
           onClick={() => drillIntoSide(bucket, 'current', figure.current)}
-          className={`text-2xl font-bold mt-1 rounded hover:underline focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 ${
+          className={`text-2xl font-bold mt-1 rounded hover:underline ${
             bucket === 'income' ? 'text-green-700 dark:text-green-400' : 'text-red-600 dark:text-red-400'
           }`}
           title={`${label} — view these transactions`}
@@ -232,7 +232,7 @@ export default function PeriodComparisonReport({ picker }: ReportViewProps): Rea
           <button
             type="button"
             onClick={() => drillIntoSide(bucket, 'previous', figure.previous)}
-            className="rounded hover:underline focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
+            className="rounded hover:underline"
             title="View the comparison period's transactions"
           >
             was {money(figure.previous)}
@@ -431,7 +431,7 @@ export default function PeriodComparisonReport({ picker }: ReportViewProps): Rea
                           <button
                             type="button"
                             onClick={() => drillIntoCategory(row, 'current')}
-                            className="w-full justify-end text-right rounded px-1 -mx-1 tabular-nums text-gray-900 dark:text-white hover:bg-blue-50 dark:hover:bg-blue-900/30 hover:underline focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
+                            className="w-full justify-end text-right rounded px-1 -mx-1 tabular-nums text-gray-900 dark:text-white hover:bg-blue-50 dark:hover:bg-blue-900/30 hover:underline"
                             title={`${labelOf(row)}, this period — view these transactions`}
                           >
                             {money(row.current)}
@@ -441,7 +441,7 @@ export default function PeriodComparisonReport({ picker }: ReportViewProps): Rea
                           <button
                             type="button"
                             onClick={() => drillIntoCategory(row, 'previous')}
-                            className="w-full justify-end text-right rounded px-1 -mx-1 tabular-nums text-gray-500 dark:text-gray-400 hover:bg-blue-50 dark:hover:bg-blue-900/30 hover:underline focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
+                            className="w-full justify-end text-right rounded px-1 -mx-1 tabular-nums text-gray-500 dark:text-gray-400 hover:bg-blue-50 dark:hover:bg-blue-900/30 hover:underline"
                             title={`${labelOf(row)}, comparison period — view these transactions`}
                           >
                             {money(row.previous)}

--- a/src/pages/reports/ReportGallery.tsx
+++ b/src/pages/reports/ReportGallery.tsx
@@ -62,7 +62,7 @@ export default function ReportGallery(): React.JSX.Element {
                         either — a 20px glyph does not need a box to be found. */}
                     <Link
                       to={preserveDemoParam(`/reports/${report.id}`, location.search)}
-                      className="group h-full flex items-start gap-3 bg-white dark:bg-gray-800 rounded-lg border border-line dark:border-gray-700 p-4 hover:border-primary dark:hover:border-blue-500 transition-colors duration-state focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
+                      className="group h-full flex items-start gap-3 bg-white dark:bg-gray-800 rounded-lg border border-line dark:border-gray-700 p-4 hover:border-primary dark:hover:border-blue-500 transition-colors duration-state"
                     >
                       <Icon
                         size={20}

--- a/src/pages/reports/SpendingByCategoryReport.tsx
+++ b/src/pages/reports/SpendingByCategoryReport.tsx
@@ -13,6 +13,7 @@ import { formatDecimal } from '../../utils/decimal-format';
 import { ARRIVAL_ROW_CLASS, useArrivalRowFocus } from '../../hooks/useArrivalFocus';
 import { PERIOD_LABELS } from '../../hooks/usePeriod';
 import type { ReportViewProps } from './types';
+import { categoricalColor, useCategoricalRamp } from '../../components/charts/chartColors';
 
 /**
  * "Spending by category" — where the money went, ranked.
@@ -24,15 +25,15 @@ import type { ReportViewProps } from './types';
  * through to the transactions behind it.
  */
 
-const CATEGORY_COLORS = [
-  '#3B82F6', '#10B981', '#F59E0B', '#EF4444',
-  '#8B5CF6', '#EC4899', '#6366F1', '#14B8A6',
-];
-
 /** Slices beyond this become hard to tell apart; the table still lists all. */
 const PIE_SLICES = 8;
 
 export default function SpendingByCategoryReport({ picker, focus }: ReportViewProps): React.JSX.Element {
+  // The shared ramp. Note it is five long per theme against PIE_SLICES of
+  // eight, so the last three slices repeat a colour — the stated cost of a
+  // single-hue ramp. The legend and tooltip name every slice, which is what
+  // actually identifies it.
+  const ramp = useCategoricalRamp();
   const selection = useReportAccountSelection();
   // A slice clicked on the Dashboard's Expense Categories card names a
   // category; its row in the ranked table below is highlighted and scrolled to,
@@ -138,7 +139,7 @@ export default function SpendingByCategoryReport({ picker, focus }: ReportViewPr
                   }}
                 >
                   {pieData.map((entry, index) => (
-                    <Cell key={entry.categoryId} fill={CATEGORY_COLORS[index % CATEGORY_COLORS.length]} />
+                    <Cell key={entry.categoryId} fill={categoricalColor(ramp, index)} />
                   ))}
                 </Pie>
                 <Tooltip
@@ -197,7 +198,7 @@ export default function SpendingByCategoryReport({ picker, focus }: ReportViewPr
                       <button
                         type="button"
                         onClick={() => drillIntoCategory(entry.key, entry.name, entry.value)}
-                        className="text-sm text-gray-900 dark:text-white hover:text-blue-700 dark:hover:text-blue-400 hover:underline rounded focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
+                        className="text-sm text-gray-900 dark:text-white hover:text-blue-700 dark:hover:text-blue-400 hover:underline rounded"
                         title={`${entry.name} — view these transactions`}
                       >
                         {entry.name}

--- a/src/pages/reports/SpendingByPayeeReport.tsx
+++ b/src/pages/reports/SpendingByPayeeReport.tsx
@@ -12,6 +12,7 @@ import { formatDecimal } from '../../utils/decimal-format';
 import { PERIOD_LABELS } from '../../hooks/usePeriod';
 import type { ReportViewProps } from './types';
 import { preferences } from '../../services/preferencesService';
+import { categoricalColor, useCategoricalRamp } from '../../components/charts/chartColors';
 
 /**
  * "Spending by payee" — who the money actually went to.
@@ -25,14 +26,16 @@ import { preferences } from '../../services/preferencesService';
  * uncategorised rows never reach either side.
  */
 
-const BAR_COLOURS = ['#3B82F6', '#10B981', '#F59E0B', '#EF4444', '#8B5CF6', '#EC4899', '#6366F1', '#14B8A6'];
-
 /** Bars beyond this stop being readable; the table still lists every payee. */
 const CHART_ROWS = 12;
 
 const SIDE_KEY = 'reportsPayeeSide';
 
 export default function SpendingByPayeeReport({ picker }: ReportViewProps): React.JSX.Element {
+  // The shared ramp. CHART_ROWS is twelve, so colours repeat past the fifth
+  // bar — readable here because a bar is labelled on its own axis, unlike a
+  // pie slice.
+  const ramp = useCategoricalRamp();
   const selection = useReportAccountSelection();
   const { accounts, categories, rows, flows } = useReportDataset(picker, selection.scope);
   const { formatCurrency } = useCurrencyDecimal();
@@ -171,7 +174,7 @@ export default function SpendingByPayeeReport({ picker }: ReportViewProps): Reac
                   }}
                 >
                   {chartData.map((entry, index) => (
-                    <Cell key={entry.payee} fill={BAR_COLOURS[index % BAR_COLOURS.length]} />
+                    <Cell key={entry.payee} fill={categoricalColor(ramp, index)} />
                   ))}
                 </Bar>
               </BarChart>
@@ -227,7 +230,7 @@ export default function SpendingByPayeeReport({ picker }: ReportViewProps): Reac
                       <button
                         type="button"
                         onClick={() => drillIntoPayee(row)}
-                        className="text-sm text-gray-900 dark:text-white hover:text-blue-700 dark:hover:text-blue-400 hover:underline rounded focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
+                        className="text-sm text-gray-900 dark:text-white hover:text-blue-700 dark:hover:text-blue-400 hover:underline rounded"
                         title={`${row.displayName} — view these transactions`}
                       >
                         {row.displayName}

--- a/src/pages/settings/AppSettings.tsx
+++ b/src/pages/settings/AppSettings.tsx
@@ -95,7 +95,7 @@ export default function AppSettings() {
             value={firstName}
             onChange={(e) => setFirstName(e.target.value)}
             placeholder="Enter your first name"
-            className="w-full px-3 py-2 bg-white dark:bg-gray-800-sm border border-gray-300/50 dark:border-gray-600/50 rounded-xl focus:outline-none focus:ring-2 focus:ring-primary focus:border-transparent dark:text-white"
+            className="w-full px-3 py-2 bg-white dark:bg-gray-800-sm border border-gray-300/50 dark:border-gray-600/50 rounded-xl focus:border-transparent dark:text-white"
           />
           <p className="mt-2 text-sm text-gray-500 dark:text-gray-400">
             This will be used in the welcome message on your dashboard. Leave blank to use "User".
@@ -119,7 +119,7 @@ export default function AppSettings() {
           aria-label="Default currency"
           value={currency}
           onChange={(e) => setCurrency(e.target.value)}
-          className="w-full px-4 py-2 bg-white dark:bg-gray-800-sm border border-gray-300/50 dark:border-gray-600/50 rounded-xl focus:outline-none focus:ring-2 focus:ring-primary focus:border-transparent dark:text-white"
+          className="w-full px-4 py-2 bg-white dark:bg-gray-800-sm border border-gray-300/50 dark:border-gray-600/50 rounded-xl focus:border-transparent dark:text-white"
         >
           {currencies.map((curr) => (
             <option key={curr.code} value={curr.code}>
@@ -172,7 +172,7 @@ export default function AppSettings() {
                   type="checkbox"
                   checked={themeSchedule.enabled}
                   onChange={(e) => setThemeSchedule({ ...themeSchedule, enabled: e.target.checked })}
-                  className="w-4 h-4 text-primary bg-gray-100 border-gray-300 rounded focus:ring-primary focus:ring-2 dark:bg-gray-700 dark:border-gray-600"
+                  className="w-4 h-4 text-primary bg-gray-100 border-gray-300 rounded dark:bg-gray-700 dark:border-gray-600"
                 />
                 <span className="text-sm text-gray-700 dark:text-gray-300">Enable scheduling</span>
               </label>
@@ -187,7 +187,7 @@ export default function AppSettings() {
                       type="time"
                       value={themeSchedule.lightStartTime}
                       onChange={(e) => setThemeSchedule({ ...themeSchedule, lightStartTime: e.target.value })}
-                      className="w-full px-3 py-2 bg-white dark:bg-gray-800-sm border border-gray-300/50 dark:border-gray-600/50 rounded-lg focus:outline-none focus:ring-2 focus:ring-primary focus:border-transparent dark:text-white text-sm"
+                      className="w-full px-3 py-2 bg-white dark:bg-gray-800-sm border border-gray-300/50 dark:border-gray-600/50 rounded-lg focus:border-transparent dark:text-white text-sm"
                     />
                   </div>
                   <div>
@@ -198,7 +198,7 @@ export default function AppSettings() {
                       type="time"
                       value={themeSchedule.darkStartTime}
                       onChange={(e) => setThemeSchedule({ ...themeSchedule, darkStartTime: e.target.value })}
-                      className="w-full px-3 py-2 bg-white dark:bg-gray-800-sm border border-gray-300/50 dark:border-gray-600/50 rounded-lg focus:outline-none focus:ring-2 focus:ring-primary focus:border-transparent dark:text-white text-sm"
+                      className="w-full px-3 py-2 bg-white dark:bg-gray-800-sm border border-gray-300/50 dark:border-gray-600/50 rounded-lg focus:border-transparent dark:text-white text-sm"
                     />
                   </div>
                 </div>

--- a/src/pages/settings/DataManagement.tsx
+++ b/src/pages/settings/DataManagement.tsx
@@ -331,7 +331,7 @@ export default function DataManagementSettings() {
                 onChange={(e) => setClearConfirmText(e.target.value)}
                 disabled={isClearing}
                 placeholder="DELETE"
-                className="w-full px-3 py-2 rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-900 text-gray-900 dark:text-white focus:outline-none focus:ring-2 focus:ring-red-500 disabled:opacity-40"
+                className="w-full px-3 py-2 rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-900 text-gray-900 dark:text-white disabled:opacity-40"
               />
             </div>
 

--- a/src/pages/settings/PayeeCleanup.tsx
+++ b/src/pages/settings/PayeeCleanup.tsx
@@ -150,7 +150,7 @@ const SuggestionRow = React.memo(function SuggestionRow({
         aria-pressed={active}
         // ring-inset, because the row is flush to the sides of a box that
         // scrolls: an outset focus ring would be clipped by the overflow.
-        className={`w-full flex items-baseline gap-3 px-3 py-2 text-left text-xs transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-primary ${
+        className={`w-full flex items-baseline gap-3 px-3 py-2 text-left text-xs transition-colors ${
           active
             ? 'bg-blue-50 text-blue-900 dark:bg-blue-900/40 dark:text-blue-100'
             : 'text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700'
@@ -878,7 +878,7 @@ export default function PayeeCleanup(): React.JSX.Element {
             }}
             placeholder="Search payees — try amazon, or interest"
             aria-label="Search payees"
-            className="w-full pl-9 pr-3 py-2 bg-white dark:bg-gray-900 border border-gray-300/50 dark:border-gray-600/50 rounded-xl focus:outline-none focus:ring-2 focus:ring-primary focus:border-transparent dark:text-white"
+            className="w-full pl-9 pr-3 py-2 bg-white dark:bg-gray-900 border border-gray-300/50 dark:border-gray-600/50 rounded-xl focus:border-transparent dark:text-white"
           />
         </div>
 

--- a/src/pages/settings/Tags.tsx
+++ b/src/pages/settings/Tags.tsx
@@ -157,7 +157,7 @@ export default function Tags() {
                 type="text"
                 value={formData.name}
                 onChange={(e) => setFormData({ ...formData, name: e.target.value })}
-                className={`w-full px-3 py-2 bg-white dark:bg-gray-800-sm border rounded-xl focus:outline-none focus:ring-2 focus:ring-primary focus:border-transparent dark:text-white ${
+                className={`w-full px-3 py-2 bg-white dark:bg-gray-800-sm border rounded-xl focus:border-transparent dark:text-white ${
                   errors.name ? 'border-red-500/50' : 'border-gray-300/50 dark:border-gray-600/50'
                 }`}
                 placeholder="Enter tag name"
@@ -201,7 +201,7 @@ export default function Tags() {
               <textarea
                 value={formData.description}
                 onChange={(e) => setFormData({ ...formData, description: e.target.value })}
-                className="w-full px-3 py-2 bg-white dark:bg-gray-800-sm border border-gray-300/50 dark:border-gray-600/50 rounded-xl focus:outline-none focus:ring-2 focus:ring-primary focus:border-transparent dark:text-white"
+                className="w-full px-3 py-2 bg-white dark:bg-gray-800-sm border border-gray-300/50 dark:border-gray-600/50 rounded-xl focus:border-transparent dark:text-white"
                 rows={3}
                 placeholder="Enter tag description"
               />

--- a/src/styles/accessibility-colors.css
+++ b/src/styles/accessibility-colors.css
@@ -72,7 +72,14 @@
   outline-offset: 2px !important;
 }
 
-/* Focus indicators - ensure 3:1 contrast */
+/* Focus indicators - ensure 3:1 contrast.
+   THIS IS THE APP'S ONE FOCUS RING (RULINGS_ON_CAUSE_2026-08-13 §3). No
+   component declares its own. Roughly 200 Tailwind `focus-visible:ring-*` /
+   `focus:ring-*` utilities used to sit on top of it, and because the rule
+   below carries `!important` their `focus:outline-none` never took — so those
+   controls painted BOTH, a coloured ring inside this outline. Where a control
+   needs a different ring COLOUR, it overrides --focus-ring-color in its own
+   scope (see .focus-ring-on-dark below); it does not add a second ring. */
 *:focus-visible {
   outline: 2px solid var(--focus-ring-color, #94a3b8) !important;
   outline-offset: 2px !important;
@@ -82,6 +89,19 @@
 button:focus-visible {
   outline: 2px solid var(--focus-ring-color, #94a3b8) !important;
   outline-offset: 2px !important;
+}
+
+/* The one legitimate reason to change the ring: the GROUND under it.
+   `outline-offset: 2px` draws the ring just outside the control, so what it
+   lands on is the PARENT's background, not the control's. That is why a red
+   destructive button needs nothing here — its ring falls on the modal behind
+   it. A control inside a navy panel is the real exception: light mode resolves
+   --focus-ring-color to the brand navy (#1a2332), which on a navy panel is
+   invisible. Redefining the variable propagates to all six rules in this file
+   at once — a second ring would not. */
+.focus-ring-on-dark {
+  --focus-ring-color: #ffffff;
+  --color-border-focus: #ffffff;
 }
 
 /* Link focus states */

--- a/src/test/a11y/oneFocusRing.test.tsx
+++ b/src/test/a11y/oneFocusRing.test.tsx
@@ -1,0 +1,188 @@
+/**
+ * Exactly ONE focus indicator is drawn — RULINGS_ON_CAUSE_2026-08-13 §3.
+ *
+ * The app declares its focus ring once, globally, in accessibility-colors.css:
+ *
+ *     *:focus-visible { outline: 2px solid var(--focus-ring-color) !important }
+ *
+ * Because of the `!important`, a component that ALSO asked for a Tailwind
+ * `focus-visible:ring-*` got BOTH — its own ring, and 2px further out the
+ * global outline, with its `focus:outline-none` powerless to stop it. About
+ * 200 utilities across 74 files were doing this, in six different colours, and
+ * one component (AccountRowColumns) had already found the bug and worked around
+ * it locally. That is what this file exists to keep from coming back.
+ *
+ * ─ WHY IT IS SHAPED LIKE THIS ──────────────────────────────────────────────
+ * Claude Design asked for the RENDERED treatment to be asserted, not "each
+ * component sets a ring" — the latter is what let six rings coexist. jsdom
+ * cannot answer that question directly: it does not match `:focus-visible`,
+ * and it does not implement the `!important` cascade across linked
+ * stylesheets, so `getComputedStyle` on a focused node reports nothing useful
+ * (see accessibility-testing.ts, which is unwired for exactly this reason).
+ *
+ * So "exactly one" is proven as one plus zero, from the two sources that
+ * actually decide it:
+ *   ONE  — the global rule is present, carries !important, and nothing
+ *          outranks it (the `button.rounded-full` outline-kill did, and had to
+ *          be removed for this to be true).
+ *   ZERO — no shipped control carries a focus-ring utility of its own. Checked
+ *          against the real rendered className of a sample of controls, and
+ *          then against every source file so a new one cannot slip in.
+ * Both halves measured, in the idiom of semantic-contrast.test.ts.
+ */
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { readFileSync, readdirSync, statSync } from 'node:fs';
+import { resolve, join } from 'node:path';
+import React from 'react';
+import { ColorContrastChecker } from '../../utils/color-contrast-checker';
+import { Button } from '../../components/common/Button';
+import ToggleSwitch from '../../components/ui/ToggleSwitch';
+import {
+  ACCOUNT_ROW_NAME_LINK_CLASS,
+  ACCOUNT_ROW_SELECTED_CLASS,
+} from '../../components/AccountRowColumns';
+
+const read = (repoPath: string): string =>
+  readFileSync(resolve(process.cwd(), repoPath), 'utf8');
+
+const remapCss = read('src/styles/accessibility-colors.css');
+const indexCss = read('src/index.css');
+
+/** Any component-declared focus ring. `focus-within:` is deliberately absent. */
+const FOCUS_RING = /(?:dark:)?(?:group-)?focus(?:-visible)?:ring/;
+const FOCUS_OUTLINE_NONE = /(?:dark:)?focus(?:-visible)?:outline-none/;
+
+const AA_GRAPHICS = 3.0;
+const SURFACES_LIGHT = ['#ffffff', '#f8f9fb'] as const;
+const SURFACES_DARK = ['#111827', '#1f2937'] as const;
+
+function extract(source: string, pattern: RegExp, where: string): string {
+  const match = source.match(pattern);
+  if (match === null) throw new Error(`Not found: ${where} — has the declaration moved?`);
+  return match[1].toLowerCase();
+}
+
+describe('ONE — the app draws a focus ring', () => {
+  it('declares the global focus outline with !important, so it always paints', () => {
+    expect(remapCss).toMatch(
+      /\*:focus-visible\s*\{[^}]*outline:\s*2px solid var\(--focus-ring-color[^)]*\)\s*!important/
+    );
+  });
+
+  it('lets nothing outrank it: no rule kills an outline on focus-visible', () => {
+    // `button.rounded-full:focus-visible { outline: none !important }` used to
+    // live in index.css. It beat the global rule on specificity AND carried
+    // !important, so every circular button in the app — the toggle switches,
+    // the icon buttons — had no focus indicator whatsoever, and the repair
+    // written for it in borders.css could never win.
+    // Comments come out first — this very file explains the bug in prose that
+    // would otherwise read as a rule declaring it.
+    const withoutComments = (css: string): string => css.replace(/\/\*[\s\S]*?\*\//g, '');
+    for (const [name, css] of [['index.css', indexCss], ['accessibility-colors.css', remapCss]] as const) {
+      const offenders = withoutComments(css)
+        .split('}')
+        .filter(block => /outline:\s*none\s*!important/.test(block) && /:focus-visible/.test(block))
+        .map(block => block.trim().split('\n')[0]);
+      expect(offenders, `${name} kills the focus outline: ${offenders.join(' | ')}`).toEqual([]);
+    }
+  });
+
+  it('is visible on the grounds it is drawn against, measured', () => {
+    // The ring sits at outline-offset 2px, so it lands on the surface BEHIND
+    // the control — which is why a red destructive button needs no override
+    // and a control inside a navy panel does.
+    const light = extract(indexCss, /--focus-ring-color:\s*(#[0-9a-f]{6})/i, 'light --focus-ring-color');
+    const dark = extract(indexCss, /\.dark\s*\{[\s\S]*?--focus-ring-color:\s*(#[0-9a-f]{6})/i, 'dark --focus-ring-color');
+
+    for (const surface of SURFACES_LIGHT) {
+      const ratio = ColorContrastChecker.getContrastRatio(light, surface);
+      expect(ratio, `${light} on ${surface} is ${ratio.toFixed(2)}:1`).toBeGreaterThanOrEqual(AA_GRAPHICS);
+    }
+    for (const surface of SURFACES_DARK) {
+      const ratio = ColorContrastChecker.getContrastRatio(dark, surface);
+      expect(ratio, `${dark} on ${surface} is ${ratio.toFixed(2)}:1`).toBeGreaterThanOrEqual(AA_GRAPHICS);
+    }
+  });
+
+  it('changes COLOUR, not count, where the ground is navy', () => {
+    const scoped = extract(remapCss, /\.focus-ring-on-dark\s*\{\s*--focus-ring-color:\s*(#[0-9a-f]{6})/i, '.focus-ring-on-dark');
+    for (const navy of ['#1a2332', '#2d3a4d', '#1f2937']) {
+      const ratio = ColorContrastChecker.getContrastRatio(scoped, navy);
+      expect(ratio, `${scoped} on ${navy} is ${ratio.toFixed(2)}:1`).toBeGreaterThanOrEqual(AA_GRAPHICS);
+    }
+  });
+});
+
+describe('ZERO — no control adds a second one', () => {
+  it.each([
+    ['primary button', <Button key="p">Save</Button>],
+    ['secondary button', <Button key="s" variant="secondary">Cancel</Button>],
+    ['destructive button', <Button key="d" variant="danger">Delete</Button>],
+    ['toggle switch', <ToggleSwitch key="t" checked={false} onChange={() => {}} aria-label="Toggle" />],
+  ])('%s renders with no focus ring of its own', (_name, element) => {
+    const { container, unmount } = render(element);
+    // Every element, not just the root: the toggle's ring used to live on an
+    // inner span via `group-focus-visible:`.
+    for (const node of Array.from(container.querySelectorAll('*'))) {
+      const className = node.getAttribute('class') ?? '';
+      expect(className, `${_name} → ${className}`).not.toMatch(FOCUS_RING);
+      expect(className, `${_name} → ${className}`).not.toMatch(FOCUS_OUTLINE_NONE);
+    }
+    unmount();
+  });
+
+  it('a link and a text input render with no focus ring of their own', () => {
+    render(
+      <div>
+        <a href="/accounts" className={ACCOUNT_ROW_NAME_LINK_CLASS}>Everyday</a>
+        <input type="text" aria-label="Amount" />
+      </div>
+    );
+    expect(screen.getByRole('link').className).not.toMatch(FOCUS_RING);
+    expect(screen.getByRole('link').className).not.toMatch(FOCUS_OUTLINE_NONE);
+    expect(screen.getByRole('textbox').className).not.toMatch(FOCUS_RING);
+  });
+
+  it('the selected row keeps its SELECTION ring and suppresses it only while focused', () => {
+    // The one `focus-visible:ring-0` left in the app. It is not fighting a
+    // focus ring — it stands the `ring-1` selection indicator down so a
+    // selected, arrowed-to row wears one stroke rather than two. §6 law keeps
+    // the selection ring; removing this would bring the double border back.
+    expect(ACCOUNT_ROW_SELECTED_CLASS).toContain('ring-1');
+    expect(ACCOUNT_ROW_SELECTED_CLASS).toContain('focus-visible:ring-0');
+  });
+});
+
+describe('ZERO — and it stays zero', () => {
+  const SOURCE_ROOT = 'src';
+  /** The row's documented `ring-0`, which suppresses a SELECTION ring. */
+  const ALLOWED = new Map([['src/components/AccountRowColumns.tsx', 1]]);
+
+  function sourceFiles(dir: string): string[] {
+    const out: string[] = [];
+    for (const entry of readdirSync(resolve(process.cwd(), dir))) {
+      const rel = join(dir, entry);
+      if (statSync(resolve(process.cwd(), rel)).isDirectory()) {
+        out.push(...sourceFiles(rel));
+      } else if (/\.tsx?$/.test(entry) && !/\.test\.tsx?$/.test(entry)) {
+        out.push(rel);
+      }
+    }
+    return out;
+  }
+
+  it('no component in src/ declares a focus ring', () => {
+    const stripped = (src: string): string =>
+      src.replace(/\/\*[\s\S]*?\*\//g, '').replace(/\/\/[^\n]*/g, '');
+    const offenders: string[] = [];
+
+    for (const file of sourceFiles(SOURCE_ROOT)) {
+      const hits = stripped(read(file)).match(/(?:dark:)?(?:group-)?focus(?:-visible)?:ring[\w[\]#./-]*/g) ?? [];
+      const allowed = ALLOWED.get(file) ?? 0;
+      if (hits.length > allowed) offenders.push(`${file}: ${hits.join(' ')}`);
+    }
+
+    expect(offenders, `a second focus ring is back:\n${offenders.join('\n')}`).toEqual([]);
+  });
+});


### PR DESCRIPTION
Claude Design read the repository rather than screenshots and ruled on cause. All three approved by the owner. Each turned out worse than the ruling knew, and the measurements are the point.

## §2.1 — all three summary figures go navy
The card already carried the argument — *"net worth is the answer, not a direction of travel"* — and applied it to one cell of three. Assets isn't a direction of travel either. Hierarchy stays with size.

**But not via `text-primary`, as the ruling's letter said.** `index.css` locks that class with `!important`, which beats any `dark:` variant — so the net-worth figure has been rendering navy on a near-black card in dark mode at **1.08:1, invisible**. Following the letter would have hidden the entire card in dark mode. The neutral gray tokens flip, so they ship, and a pre-existing dark-mode bug goes with them.

## §2.6 — one chart ramp, and there were **nine** palettes, not five
Under six names, including the recharts documentation example verbatim in two files and a `#8B5CF6` purple belonging to no token. All deleted. One navy-through-slate ramp remains, extended past five steps by **bisection** rather than reaching for a hue, and past nine by cycling — the honest cost of a single-hue ramp.

Then the finding that shaped it: measured at the 3:1 graphics bar, the darkest steps fail on a dark ground and the lightest fail on a light one, so a *fixed* ramp ships invisible slices in one theme or the other. It's one axis walked from whichever end contrasts with the ground — five usable steps per theme, still one palette. Green and red never appear in it; they mean money in and money out.

## §3 — one focus ring
**445 component ring utilities and 155 companion `focus:outline-none` across 75 files, in 21 distinct colours**, removed. The global `*:focus-visible` outline is the app's only focus indicator, with `.focus-ring-on-dark` for the two grounds needing a different colour.

Three things the ruling couldn't have known:
- **A sixth ring was injected at runtime** with `!important` at **2.56:1** — below WCAG 2.4.11, beating every override, so `--focus-ring-color` never painted at all.
- **`index.css` killed outlines outright** on circular and icon buttons: they had *no* focus indicator, and the repair in `borders.css` could never win.
- Four upload labels keep `focus-within:ring` because the global rule matches their visually-hidden input rather than anything visible.

**The `AccountRowColumns` `ring-0` stays, against the ruling's letter and for the ruling's own reason**: it isn't fighting a focus ring, it suppresses the **selection** ring three classes to its left, which is §6 law. Removing it reinstates the exact double border the owner reported.

The test asserts "exactly one" as one-plus-zero — the global rule exists and nothing kills an outline on `:focus-visible`, and no rendered control carries a ring of its own — proven non-vacuous by reintroducing a ring and a palette and watching both gates fail with the offending file named.

Verification: lint · typecheck:strict · **6,120 smoke** · realtime 240 · desktop:verify PASS (+6.3 KiB) · browser-walked in light **and** dark: summary card on both pages, chart legend flipping palette ends with no reload, and button/link/input/select/row/icon-button/navy-ground controls each showing exactly one indicator.

🤖 Generated with [Claude Code](https://claude.com/claude-code)