### PR TITLE
fix(tokens): bg-primary/10 was a class that did not exist

### DIFF
--- a/src/design-system/__tests__/tokenOpacity.test.ts
+++ b/src/design-system/__tests__/tokenOpacity.test.ts
@@ -1,0 +1,80 @@
+/**
+ * A colour token must survive an opacity modifier.
+ *
+ * ─ THE FAILURE THIS EXISTS TO CATCH ────────────────────────────────────────
+ * `primary` and `secondary` were declared as bare `var(--color-primary)`.
+ * Tailwind 3.4 cannot parse a bare `var()` as a colour, so it did not warn, it
+ * did not fall back, and it did not error: for ANY opacity modifier it emitted
+ * NO RULE AT ALL. `bg-primary` worked and `bg-primary/10` did not exist, so
+ * thirteen call sites painted selected states, highlight tints and hover fills
+ * that computed to transparent — a whole class of invisible UI that no type
+ * checker, linter or test could see, because the class was absent from the
+ * stylesheet rather than wrong in it.
+ *
+ * ─ WHY IT COMPILES THE REAL CONFIG ─────────────────────────────────────────
+ * Asserting on the config OBJECT would only restate the fix. The bug lived in
+ * what the generator does with that object, so the only honest question is
+ * what CSS comes out — which is also why a probe file is compiled rather than
+ * the app: it names the exact classes under test and cannot pass because
+ * something else in the app happens to use them.
+ *
+ * Adding a token? Add it below. The cost of the check is one compile; the cost
+ * of not having it was found by reading source, not by using the app.
+ */
+import { describe, it, expect } from 'vitest';
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, writeFileSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+/** Tokens whose opacity modifiers must resolve to a real declaration. */
+const TOKENS = ['primary', 'secondary'] as const;
+
+/** One probe class per token, plus the plain form as a control. */
+const PROBE_CLASSES = TOKENS.flatMap(token => [
+  `bg-${token}`,
+  `bg-${token}/10`,
+  `border-${token}/40`,
+  `hover:bg-${token}/90`,
+]);
+
+function compileProbe(): string {
+  const dir = mkdtempSync(join(tmpdir(), 'wt-token-probe-'));
+  try {
+    const probe = join(dir, 'probe.tsx');
+    writeFileSync(probe, `export const P = () => <div className="${PROBE_CLASSES.join(' ')}" />;\n`);
+    const out = join(dir, 'probe.css');
+    execFileSync(
+      'npx',
+      ['tailwindcss', '-c', 'tailwind.config.js', '--content', probe, '-o', out],
+      { cwd: process.cwd(), stdio: 'pipe' }
+    );
+    return readFileSync(out, 'utf8');
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+describe('brand colour tokens keep their opacity modifiers', () => {
+  const css = compileProbe();
+
+  it.each(TOKENS)('%s renders at full strength', token => {
+    // The control: if this is missing the probe itself is broken, not the token.
+    expect(css).toContain(`.bg-${token} {`);
+  });
+
+  it.each(TOKENS)('%s survives an opacity modifier rather than vanishing', token => {
+    // Tailwind escapes the slash in the selector: `.bg-primary\/10`.
+    expect(css).toContain(`.bg-${token}\\/10 {`);
+    expect(css).toContain(`.border-${token}\\/40 {`);
+    expect(css).toContain(`.hover\\:bg-${token}\\/90:hover {`);
+  });
+
+  it.each(TOKENS)('%s resolves to an alpha the browser can paint', token => {
+    // Not merely present — carrying the alpha. A rule that emitted the colour
+    // and dropped the modifier would satisfy the check above and still be the
+    // bug, one layer along.
+    const rule = new RegExp(`\\.bg-${token}\\\\/10 \\{[^}]*\\/ 0\\.1\\)`);
+    expect(css).toMatch(rule);
+  });
+});

--- a/src/index.css
+++ b/src/index.css
@@ -117,12 +117,36 @@ input[type="range"] {
 
 /* WealthTracker Brand Colors */
 :root {
-  --color-primary: #1a2332;
+  /*
+   * THE BRAND NAVY, AS A TRIPLE AND AS A COLOUR — one source, two forms.
+   *
+   * The triple is what Tailwind needs. A token defined as a bare
+   * `var(--color-primary)` cannot be parsed as a colour by Tailwind 3.4, so an
+   * opacity modifier on it emits NO RULE AT ALL — silently. `bg-primary`
+   * worked; `bg-primary/10` produced nothing and computed to transparent, and
+   * thirteen call sites across the app were painting selected states, hover
+   * fills and highlight tints that simply did not exist. Nobody saw an error
+   * because there was nothing to see: the class was absent from the
+   * stylesheet, not broken in it. Proven by compiling the real config against
+   * a probe — `.bg-primary\/10` was missing while `.bg-nav-bg\/10` (a literal
+   * hex) compiled correctly.
+   *
+   * The colour form stays because fifty-four places already read
+   * `var(--color-primary)` directly — the `!important` blocks below, the skip
+   * link, `accent-color` on checkboxes — and they want a colour, not three
+   * numbers. Deriving one from the other keeps a single definition: change the
+   * triple and both forms move. Never write a hex here again; write the
+   * triple.
+   */
+  --color-primary-rgb: 26 35 50;
+  --color-primary: rgb(var(--color-primary-rgb));
   /* Secondary is the app's structural accent (heading/button fills, hovers,
      focus). Kept in the navy family (was green #2d4a3e) so the default theme
      reads as one consistent dark scheme; the green/red/pink themes below keep
-     their own accents. */
-  --color-secondary: #2d3a4d;
+     their own accents. Same two-form treatment as primary, for the same
+     reason — `hover:bg-secondary/90` was one of the dead classes. */
+  --color-secondary-rgb: 45 58 77;
+  --color-secondary: rgb(var(--color-secondary-rgb));
   --color-tertiary: #d4a843;
   --color-light-bg: #f8f9fb;
   --color-light-card: #ffffff;

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -9,8 +9,17 @@ export default {
     extend: {
       colors: {
         // Wealth/finance brand palette
-        primary: 'var(--color-primary, #1a2332)',
-        secondary: 'var(--color-secondary, #2d3a4d)',
+        // `rgb(var(--…-rgb) / <alpha-value>)`, not `var(--color-primary)`.
+        // Tailwind 3.4 cannot parse a bare var() as a colour, so it emitted NO
+        // RULE for any opacity modifier on these two — `bg-primary/10` was
+        // absent from the stylesheet and computed to transparent, taking
+        // thirteen selected-state and hover tints with it, silently. The
+        // alpha-value placeholder is how a CSS-variable token keeps its
+        // modifiers; the variables themselves are defined in src/index.css,
+        // which derives the plain colour form from the same triple so the
+        // fifty-four raw `var(--color-primary)` readers are untouched.
+        primary: 'rgb(var(--color-primary-rgb, 26 35 50) / <alpha-value>)',
+        secondary: 'rgb(var(--color-secondary-rgb, 45 58 77) / <alpha-value>)',
         // Gold is a FILL colour only (chips, marks, the yellow thread's box).
         // As text on white it measures 2.21:1 — that is what accent-text is
         // for. (DESIGN_PASS_2026-08 §2.1, instrumented 2026-08-12.)


### PR DESCRIPTION
Thirteen call sites have been painting selected states, highlight tints and hover fills in a navy wash that **computed to transparent**, and nothing anywhere said so.

## The failure
`primary` and `secondary` were declared as bare `var(--color-primary)`. Tailwind 3.4 cannot parse a bare `var()` as a colour, so for any opacity modifier it did not warn, did not fall back and did not error — it emitted **no rule at all**. `bg-primary` worked; `bg-primary/10` was simply absent from the stylesheet.

That is why nothing caught it: a class that does not exist can't be found by a type checker, a linter, or a test that renders the component. The markup is right, the class name is spelled correctly, and the pixel is empty.

**Proven before touching anything** — compiled the real config against a probe: `.bg-primary\/10` missing, `.bg-nav-bg\/10` (a literal hex) present. So the selected row in `CashFlowForecast`, the highlighted option in `CategorySelector`, the chosen account in `AddAccountModal` and two `hover:bg-primary/90` buttons have been showing nothing.

## The fix, with no call site edited
The tokens use the alpha-value placeholder over an RGB triple, and `index.css` derives the plain colour form **from that same triple** — so the fifty-four places already reading `var(--color-primary)` directly (the `!important` blocks, the skip link, `accent-color` on every checkbox) are untouched and keep receiving a colour. One definition, two forms.

Measured after: `bg-primary` → `rgb(26,35,50)` solid · `bg-primary/10` → `rgba(26,35,50,0.1)` where it was `rgba(0,0,0,0)` · `text-primary` unchanged.

## The guard
`src/design-system/__tests__/tokenOpacity.test.ts` compiles the config **for real** and fails if a brand token loses its modifiers again. It asserts the alpha reaches the declaration, not merely that a rule exists — a rule that kept the colour and dropped the modifier is the same bug one layer along. **Proven non-vacuous** by restoring the old declaration and watching two assertions fall.

Verification: lint · typecheck:strict · **6,130 smoke** (+6 new) · desktop:verify PASS · browser-measured on the running app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)