### PR TITLE
fix: the phone's control block, five design items, and an app that spells like its dates

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="en">
+<html lang="en-GB">
   <head>
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/icon.svg" />

--- a/src/components/AccountSettingsModal.tsx
+++ b/src/components/AccountSettingsModal.tsx
@@ -431,6 +431,9 @@ export default function AccountSettingsModal({
                 id="account-number"
                 type="text"
                 inputMode="numeric"
+                // A reference number, not a word.
+                spellCheck={false}
+                autoCapitalize="none"
                 value={formData.accountNumber}
                 onChange={handleAccountNumberChange}
                 placeholder={isCreditCard ? '1234' : '12345678'}

--- a/src/components/AddAccountModal.tsx
+++ b/src/components/AddAccountModal.tsx
@@ -372,6 +372,9 @@ export default function AddAccountModal({ isOpen, onClose, prefill, onAccountCre
                     id="add-account-number"
                     type="text"
                     inputMode="numeric"
+                    // A reference number, not a word.
+                    spellCheck={false}
+                    autoCapitalize="none"
                     value={formData.accountNumber}
                     onChange={(e) => updateField('accountNumber', nextAccountNumberValue(e.target.value, isCreditCard))}
                     className="w-full px-4 py-3 bg-white dark:bg-gray-800 border-2 border-gray-200 dark:border-gray-700 rounded-xl focus:border-primary dark:text-white transition-all duration-200"

--- a/src/components/BankConnections.tsx
+++ b/src/components/BankConnections.tsx
@@ -485,6 +485,8 @@ export default function BankConnections({
               value={searchTerm}
               onChange={(e) => setSearchTerm(e.target.value)}
               placeholder="Search for your bank..."
+              spellCheck={false}
+              autoCapitalize="none"
               className="w-full pl-10 pr-4 py-2 border border-gray-300 dark:border-gray-600 rounded-lg focus:border-transparent dark:bg-gray-700 dark:text-white"
             />
           </div>

--- a/src/components/CSVBankTemplates.tsx
+++ b/src/components/CSVBankTemplates.tsx
@@ -84,6 +84,8 @@ export default function CSVBankTemplates({
       <input
         id={searchId}
         type="search"
+        spellCheck={false}
+        autoCapitalize="none"
         value={query}
         onChange={event => setQuery(event.target.value)}
         placeholder="Barclays, Monzo, Wells Fargo, &quot;paid out&quot;…"

--- a/src/components/CashFlowForecast.test.tsx
+++ b/src/components/CashFlowForecast.test.tsx
@@ -168,7 +168,7 @@ describe('CashFlowForecast', () => {
       render(<CashFlowForecast />);
       
       expect(screen.getByTestId('loading-state')).toBeInTheDocument();
-      expect(screen.getByText('Analyzing cash flow patterns...')).toBeInTheDocument();
+      expect(screen.getByText('Analysing cash flow patterns...')).toBeInTheDocument();
     });
 
     it('shows error state', () => {

--- a/src/components/CashFlowForecast.tsx
+++ b/src/components/CashFlowForecast.tsx
@@ -41,7 +41,7 @@ export default function CashFlowForecast({ accountIds, className = '' }: CashFlo
   });
 
   if (isLoading) {
-    return <LoadingState message="Analyzing cash flow patterns..." />;
+    return <LoadingState message="Analysing cash flow patterns..." />;
   }
 
   if (error) {

--- a/src/components/CategorySelect.test.tsx
+++ b/src/components/CategorySelect.test.tsx
@@ -62,7 +62,7 @@ describe('CategorySelect', () => {
         />
       );
       
-      expect(screen.getByRole('option', { name: 'Uncategorized' })).toBeInTheDocument();
+      expect(screen.getByRole('option', { name: 'Uncategorised' })).toBeInTheDocument();
     });
 
     it('hides uncategorized option when showUncategorized is false', () => {
@@ -75,7 +75,7 @@ describe('CategorySelect', () => {
         />
       );
       
-      expect(screen.queryByRole('option', { name: 'Uncategorized' })).not.toBeInTheDocument();
+      expect(screen.queryByRole('option', { name: 'Uncategorised' })).not.toBeInTheDocument();
     });
 
     it('shows multiple option when showMultiple is true', () => {
@@ -275,7 +275,7 @@ describe('CategorySelect', () => {
       );
       
       // Should only show uncategorized option
-      expect(screen.getByRole('option', { name: 'Uncategorized' })).toBeInTheDocument();
+      expect(screen.getByRole('option', { name: 'Uncategorised' })).toBeInTheDocument();
       expect(screen.getAllByRole('option')).toHaveLength(1);
     });
 
@@ -325,7 +325,7 @@ describe('CategorySelect', () => {
         />
       );
       
-      expect(screen.getByRole('option', { name: 'Uncategorized' })).toBeInTheDocument();
+      expect(screen.getByRole('option', { name: 'Uncategorised' })).toBeInTheDocument();
       expect(screen.getByRole('option', { name: 'Multiple' })).toBeInTheDocument();
       // Placeholder not shown when showUncategorized is true
       expect(screen.queryByRole('option', { name: 'Pick one' })).not.toBeInTheDocument();

--- a/src/components/CategorySelect.tsx
+++ b/src/components/CategorySelect.tsx
@@ -34,7 +34,7 @@ export default function CategorySelect({
       className={className}
       disabled={disabled}
     >
-      {showUncategorized && <option value="">Uncategorized</option>}
+      {showUncategorized && <option value="">Uncategorised</option>}
       {showMultiple && <option value="multiple">Multiple</option>}
       {placeholder && !showUncategorized && !value && (
         <option value="" disabled>{placeholder}</option>

--- a/src/components/CategorySelector.tsx
+++ b/src/components/CategorySelector.tsx
@@ -649,6 +649,9 @@ export default function CategorySelector({
                   onChange={handleInputChange}
                   onFocus={handleInputFocus}
                   onKeyDown={(e) => handleSearchKeyDown(e, flatOptions)}
+                  // Filtering a list of the user's own category names.
+                  spellCheck={false}
+                  autoCapitalize="none"
                   placeholder={placeholder}
                   aria-autocomplete="list"
                   aria-controls={listboxId}

--- a/src/components/CategoryTransactionsModal.tsx
+++ b/src/components/CategoryTransactionsModal.tsx
@@ -271,6 +271,8 @@ export default function CategoryTransactionsModal({
                 value={searchQuery}
                 onChange={(e) => setSearchQuery(e.target.value)}
                 placeholder="Search transactions..."
+                spellCheck={false}
+                autoCapitalize="none"
                 className="w-full pl-9 pr-3 py-1.5 border border-gray-300 dark:border-gray-600 rounded-lg dark:bg-gray-700 dark:text-white text-sm"
               />
               {searchQuery && (

--- a/src/components/CrossCurrencyTransferDialog.tsx
+++ b/src/components/CrossCurrencyTransferDialog.tsx
@@ -245,6 +245,8 @@ export default function CrossCurrencyTransferDialog({
                 ref={rateBoxRef}
                 type="text"
                 inputMode="decimal"
+                spellCheck={false}
+                autoCapitalize="none"
                 value={rateText}
                 onChange={(e) => handleRateChange(e.target.value)}
                 disabled={busy}
@@ -267,6 +269,8 @@ export default function CrossCurrencyTransferDialog({
                 id="cross-currency-destination"
                 type="text"
                 inputMode="decimal"
+                spellCheck={false}
+                autoCapitalize="none"
                 value={destinationText}
                 onChange={(e) => handleDestinationChange(e.target.value)}
                 disabled={busy}

--- a/src/components/DocumentManager.tsx
+++ b/src/components/DocumentManager.tsx
@@ -266,6 +266,8 @@ export default function DocumentManager({
             <input
               type="text"
               placeholder="Search documents..."
+              spellCheck={false}
+              autoCapitalize="none"
               value={searchTerm}
               onChange={(e) => setSearchTerm(e.target.value)}
               className="w-full pl-10 pr-4 py-2 border border-gray-300 dark:border-gray-600 rounded-lg focus:border-transparent dark:bg-gray-700 dark:text-white"
@@ -356,7 +358,7 @@ export default function DocumentManager({
           </h3>
           <p className="text-gray-600 dark:text-gray-400 mb-4">
             {documents.length === 0 
-              ? 'Upload receipts, invoices, and other documents to keep them organized'
+              ? 'Upload receipts, invoices, and other documents to keep them organised'
               : 'Try adjusting your search or filters'
             }
           </p>

--- a/src/components/EditTransactionModal.tsx
+++ b/src/components/EditTransactionModal.tsx
@@ -1114,6 +1114,10 @@ export default function EditTransactionModal({ isOpen, onClose, transaction, def
               <input
                 ref={amountInputRef}
                 type="text"
+                // Hand-rolled rather than MoneyInput, so it needs saying here
+                // too: an amount has nothing to spell.
+                spellCheck={false}
+                autoCapitalize="none"
                 value={formattedAmount}
                 onChange={(e) => {
                   const value = e.target.value;

--- a/src/components/GlobalSearch.tsx
+++ b/src/components/GlobalSearch.tsx
@@ -260,6 +260,11 @@ const GlobalSearch = forwardRef<GlobalSearchHandle, GlobalSearchProps>(
             placeholder={placeholder}
             className="w-full pl-10 pr-4 py-3 bg-transparent border-0 text-gray-900 dark:text-white placeholder-gray-500"
             autoComplete="off"
+            // Payees, account names and amounts — the three things typed here —
+            // are none of them dictionary words, so the spell-checker's only
+            // possible contribution is a red underline under a correct search.
+            spellCheck={false}
+            autoCapitalize="none"
             role="combobox"
             aria-label="Search transactions, accounts and pages"
             aria-autocomplete="list"

--- a/src/components/MerchantEnrichment.tsx
+++ b/src/components/MerchantEnrichment.tsx
@@ -283,6 +283,8 @@ export default function MerchantEnrichment({ onDataChange: _onDataChange }: Merc
             value={searchTerm}
             onChange={(e) => setSearchTerm(e.target.value)}
             placeholder="Search merchants..."
+            spellCheck={false}
+            autoCapitalize="none"
             className="px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-800 text-gray-900 dark:text-white text-sm"
           />
         </div>

--- a/src/components/PageWrapper.tsx
+++ b/src/components/PageWrapper.tsx
@@ -28,7 +28,32 @@ export default function PageWrapper({ title, headerContent, children, rightConte
           </div>
         )}
       </div>
-      <div className={`relative pb-24 lg:pb-0 ${contentClassName}`.trimEnd()}>
+      {/*
+        NO BOTTOM RESERVATION HERE — Layout already makes it, once
+        (PHONE_CAPTURES_REVIEW_2026-08-13 §3.3).
+
+        This used to carry `pb-24 lg:pb-0`, and on a phone that was the SECOND
+        reservation for the same strip of screen: Layout's `page-bottom-gutter`
+        already reserves 9.5rem for the bottom nav and the quick-add button
+        floating above it, and says in its own comment that the reservation is
+        one number precisely so the two cannot drift. MEASURED on the Find page
+        at 375×812 before this change: a 208px empty-state card followed by
+        96px here plus 152px there — 248px of nothing under a card a fifth of
+        that tall, which is what the review photographed and read, reasonably,
+        as a card with a min-height failing to fill.
+
+        The two breakpoints did not even agree. `page-bottom-gutter` applies at
+        `max-width: 767px`, exactly matching `MobileBottomNav`'s `md:hidden`, so
+        the gutter exists when and only when the chrome it clears exists. The
+        `lg:pb-0` here ran to 1023px, so between 768 and 1023 this reserved
+        96px for a nav bar that is not on screen. Above `md`, Layout's own
+        `md:pb-8` is the whole answer.
+
+        Height comes from the content. If a page ever needs more room at the
+        bottom, the number belongs in Layout beside the measurements it is made
+        of — not here, where it is invisible to the comment that explains it.
+      */}
+      <div className={`relative ${contentClassName}`.trimEnd()}>
         {children}
       </div>
     </>

--- a/src/components/SeasonalTrends.tsx
+++ b/src/components/SeasonalTrends.tsx
@@ -4,6 +4,7 @@ import { useSeasonalAnalysis } from '../hooks/useCashFlowForecast';
 import { useCurrencyDecimal } from '../hooks/useCurrencyDecimal';
 import { toDecimal } from '../utils/decimal';
 import { LoadingState } from './loading/LoadingState';
+import { SEMANTIC_SERIES } from './charts/chartColors';
 import { CalendarIcon, TrendingUpIcon, TrendingDownIcon } from './icons';
 
 const monthNames = [
@@ -20,7 +21,7 @@ export default function SeasonalTrends({ className = '' }: SeasonalTrendsProps) 
   const seasonalTrends = useSeasonalAnalysis();
 
   if (!seasonalTrends) {
-    return <LoadingState message="Analyzing seasonal patterns..." />;
+    return <LoadingState message="Analysing seasonal patterns..." />;
   }
 
   // Convert Map to chart data
@@ -141,15 +142,15 @@ export default function SeasonalTrends({ className = '' }: SeasonalTrendsProps) 
                 }}
               />
               <Legend />
-              <Bar 
-                dataKey="income" 
-                fill="#10b981" 
+              <Bar
+                dataKey="income"
+                fill={SEMANTIC_SERIES.income}
                 name="Income"
                 radius={[4, 4, 0, 0]}
               />
-              <Bar 
-                dataKey="expenses" 
-                fill="#ef4444" 
+              <Bar
+                dataKey="expenses"
+                fill={SEMANTIC_SERIES.expense}
                 name="Expenses"
                 radius={[4, 4, 0, 0]}
               />

--- a/src/components/SpendingPatterns.tsx
+++ b/src/components/SpendingPatterns.tsx
@@ -160,7 +160,7 @@ export default function SpendingPatterns({ onDataChange }: SpendingPatternsProps
           className="flex items-center gap-2 px-4 py-2 bg-[var(--color-primary)] text-white rounded-lg hover:bg-[var(--color-primary)]/90 disabled:opacity-50"
         >
           <RefreshCwIcon size={16} className={isAnalyzing ? 'animate-spin' : ''} />
-          {isAnalyzing ? 'Analyzing...' : 'Analyze Patterns'}
+          {isAnalyzing ? 'Analysing...' : 'Analyse Patterns'}
         </button>
       </div>
 

--- a/src/components/StockSymbolSearch.tsx
+++ b/src/components/StockSymbolSearch.tsx
@@ -102,6 +102,10 @@ export default function StockSymbolSearch({
           value={query}
           onChange={(e) => setQuery(e.target.value)}
           placeholder={placeholder}
+          // A ticker is not a word. Autocapitalise is worse than the squiggle
+          // here — it rewrites what was typed, and the symbol is the query.
+          spellCheck={false}
+          autoCapitalize="none"
           aria-label="Search for a stock, fund or ETF"
           aria-controls={listId}
           aria-expanded={matches.length > 0}

--- a/src/components/SwipeableTransactionRow.tsx
+++ b/src/components/SwipeableTransactionRow.tsx
@@ -130,7 +130,7 @@ export const SwipeableTransactionRow = memo(function SwipeableTransactionRow({
                 setIsRevealed(null);
               }}
               className="p-3 bg-yellow-500 text-white rounded-lg"
-              aria-label="Favorite"
+              aria-label="Favourite"
             >
               <StarIcon size={20} />
             </button>
@@ -150,7 +150,7 @@ export const SwipeableTransactionRow = memo(function SwipeableTransactionRow({
                 setIsRevealed(null);
               }}
               className="p-3 bg-purple-500 text-white rounded-lg"
-              aria-label="Categorize"
+              aria-label="Categorise"
             >
               <FolderIcon size={20} />
             </button>

--- a/src/components/TagSelector.tsx
+++ b/src/components/TagSelector.tsx
@@ -160,6 +160,11 @@ export default function TagSelector({
           onChange={handleInputChange}
           onFocus={handleInputFocus}
           onKeyDown={handleKeyDown}
+          // Tags are lowercase tokens, and this box both searches them and
+          // creates them — so an autocapitalised first letter would not merely
+          // look wrong, it would be stored.
+          spellCheck={false}
+          autoCapitalize="none"
           placeholder={placeholder}
           className="w-full px-3 py-2 h-[42px] bg-white dark:bg-gray-800-sm border border-gray-300/50 dark:border-gray-600/50 rounded-xl focus:border-transparent dark:text-white"
         />

--- a/src/components/TaxPlanning.tsx
+++ b/src/components/TaxPlanning.tsx
@@ -501,9 +501,9 @@ export default function TaxPlanning(): React.JSX.Element {
                 ) : (
                   <div className="text-center py-8 text-gray-500 dark:text-gray-400">
                     <CheckCircleIcon size={48} className="mx-auto mb-3 opacity-50" />
-                    <p>Your tax strategy is well optimized!</p>
+                    <p>Your tax strategy is well optimised!</p>
                     <p className="text-sm mt-2">
-                      We'll notify you when new optimization opportunities arise.
+                      We'll notify you when new optimisation opportunities arise.
                     </p>
                   </div>
                 )}

--- a/src/components/charts/__tests__/singlePointDots.test.tsx
+++ b/src/components/charts/__tests__/singlePointDots.test.tsx
@@ -1,0 +1,90 @@
+/**
+ * A one-point line series has to draw something a reader can see.
+ *
+ * These pin the MEASURED behaviour of the real recharts, not an expectation
+ * about it — the difference decided the fix. The reported symptom was a
+ * period-filtered chart on a one-month window showing axes around an empty
+ * plot, diagnosed as "a Line draws segments between points, so one point
+ * draws nothing". Rendering it says otherwise: recharts special-cases the
+ * lone point and DOES draw it — as a 3px circle filled `#fff` with a 2px
+ * ring, which on a white card is a speck, and `dot={false}` / `dot={true}`
+ * produce that same element either way.
+ *
+ * So the tempting one-liner `dot={data.length === 1}` changes nothing at all.
+ * The second test below is that fact, kept as a specimen: if a future recharts
+ * makes the boolean meaningful again, it fails and this module can be
+ * reconsidered.
+ *
+ * No ResponsiveContainer: it measures the DOM and jsdom lays nothing out, so
+ * the charts get explicit dimensions. Every figure is invented — this repo is
+ * public.
+ */
+import React from 'react';
+import { describe, it, expect } from 'vitest';
+import { render } from '@testing-library/react';
+import { LineChart, Line, XAxis } from 'recharts';
+import { singlePointDot } from '../singlePointDots';
+
+const SERIES_COLOUR = '#0d9f6f';
+const ONE_MONTH = [{ month: 'Aug 2026', income: 4200 }];
+const THREE_MONTHS = [
+  { month: 'Jun 2026', income: 3100 },
+  { month: 'Jul 2026', income: 3800 },
+  { month: 'Aug 2026', income: 4200 },
+];
+
+/** Renders the series and reports what recharts actually put in the DOM. */
+function draw(data: typeof THREE_MONTHS, dot: ReturnType<typeof singlePointDot> | boolean) {
+  const { container } = render(
+    <LineChart width={600} height={300} data={data}>
+      <XAxis dataKey="month" />
+      <Line type="monotone" dataKey="income" stroke={SERIES_COLOUR} strokeWidth={2} dot={dot} isAnimationActive={false} />
+    </LineChart>
+  );
+  const dot0 = container.querySelector('.recharts-line-dot');
+  return {
+    curves: container.querySelectorAll('.recharts-line-curve').length,
+    dots: container.querySelectorAll('.recharts-line-dot').length,
+    fill: dot0?.getAttribute('fill') ?? null,
+    r: dot0?.getAttribute('r') ?? null,
+    strokeWidth: dot0?.getAttribute('stroke-width') ?? null,
+  };
+}
+
+describe('singlePointDot', () => {
+  it('asks for a solid mark for one point, and no dots either side of it', () => {
+    expect(singlePointDot([], SERIES_COLOUR)).toBe(false);
+    expect(singlePointDot(['a', 'b'], SERIES_COLOUR)).toBe(false);
+    expect(singlePointDot(['a'], SERIES_COLOUR)).toEqual({ r: 4, fill: SERIES_COLOUR, strokeWidth: 0 });
+  });
+});
+
+describe('what recharts actually renders', () => {
+  it('THE CAUSE: one point draws no line, only a white-filled speck', () => {
+    const one = draw(ONE_MONTH, false);
+    expect(one.curves).toBe(0);   // no segment: the "empty plot"
+    expect(one.dots).toBe(1);     // but the point IS there…
+    expect(one.fill).toBe('#fff'); // …filled white, so it reads as absent
+    expect(one.r).toBe('3');
+  });
+
+  it('THE TRAP: the boolean is inert, so `dot={data.length === 1}` fixes nothing', () => {
+    const asFalse = draw(ONE_MONTH, false);
+    const asTrue = draw(ONE_MONTH, true);
+    expect(asTrue).toEqual(asFalse);
+  });
+
+  it('THE FIX: the config gives the lone point solid ink in the series colour', () => {
+    const fixed = draw(ONE_MONTH, singlePointDot(ONE_MONTH, SERIES_COLOUR));
+    expect(fixed.dots).toBe(1);
+    expect(fixed.fill).toBe(SERIES_COLOUR);
+    expect(fixed.strokeWidth).toBe('0');
+    expect(fixed.r).toBe('4');
+  });
+
+  it('leaves the common case alone: many points stay dotless with a line', () => {
+    const many = draw(THREE_MONTHS, singlePointDot(THREE_MONTHS, SERIES_COLOUR));
+    expect(many.dots).toBe(0);
+    expect(many.curves).toBe(1);
+  });
+});

--- a/src/components/charts/chartColors.ts
+++ b/src/components/charts/chartColors.ts
@@ -130,3 +130,60 @@ export function useCategoricalRamp(): readonly string[] {
 
   return categoricalRamp(dark);
 }
+
+/**
+ * ─ THE TWO SEMANTIC SERIES — NOT PART OF THE RAMP ABOVE ────────────────────
+ *
+ * Everything above this line is the CATEGORICAL ramp: colours that separate
+ * one arbitrary slice from another and mean nothing individually. These two
+ * mean something. A series called "Income" is the same idea as a `+£141.50`
+ * in the register, and it had been painted `#10B981`/`#EF4444` in five files —
+ * a SECOND definition of income and expense, living beside the instrumented
+ * one and free to drift from it (PHONE_CAPTURES_REVIEW_2026-08-13 §4).
+ *
+ * That is why green and red are still banned from the ramp and are declared
+ * here instead: the ban was never on the hues, it was on spending them where
+ * they mean nothing. A chart of income against expenses is the one place in a
+ * chart they mean exactly what they mean everywhere else.
+ *
+ * ─ WHY THESE ARE THE FILL COLOURS AND NOT text-income / text-expense ───────
+ * WCAG asks 4.5:1 of text and 3:1 of a graphical object (1.4.11). The amount
+ * colours are built for the harder bar and are correspondingly dark; a 1.5px
+ * line in a dark green reads as black on a chart. The token sheet already had
+ * `income-fill` for exactly this, being the green the amounts gave up when
+ * they moved to the 4.5:1 pair — `expense-fill` is now its counterpart, the
+ * red they gave up in the same change. So the series pair is the retired text
+ * pair, which is why it is the same family of colour and not a new one.
+ *
+ * ─ WHY ONE VALUE SERVES BOTH THEMES, WHEN THE RAMP NEEDED TWO ──────────────
+ * The ramp walks navy→slate, so its ends are invisible on one ground or the
+ * other and it has to be entered from the end that contrasts. These two sit in
+ * the middle of the lightness range, and MEASURED with the repo's own harness
+ * (ColorContrastChecker, 2026-08-13) they clear the 3:1 graphics bar on every
+ * surface a chart is drawn on in either theme:
+ *
+ *                     #fff   #f8f9fb   #1f2937   #111827
+ *     income-fill     3.38     3.21      4.34      5.24   ✓ all four
+ *     expense-fill    4.37     4.15      3.36      4.06   ✓ all four
+ *
+ * Both are deliberately under 4.5:1 on white: they are series colours, and
+ * `semantic-contrast.test.ts` fails if one is promoted to text.
+ *
+ * ─ THE COST, STATED ────────────────────────────────────────────────────────
+ * Green against red is the one pair colour-blind readers cannot separate, and
+ * these two are 1.29:1 apart in luminance, so contrast does not rescue it
+ * either. Every consumer therefore direct-labels: each of the four charts
+ * draws a `<Legend />` and names the series in its tooltip, which is the same
+ * rule the ramp above works under — colour groups the series, the label
+ * identifies it. A chart that cannot label its series must not use this pair.
+ *
+ * Declared in `tailwind.config.js` (`income-fill` / `expense-fill`) and
+ * mirrored here because recharts takes a colour, not a class name. The mirror
+ * is pinned to the token sheet by semantic-contrast.test.ts, the same way the
+ * amount colours are pinned across their three files — a copy nobody checks is
+ * how there came to be five palettes.
+ */
+export const SEMANTIC_SERIES = {
+  income: '#0d9f6f',
+  expense: '#d94052',
+} as const;

--- a/src/components/charts/singlePointDots.ts
+++ b/src/components/charts/singlePointDots.ts
@@ -1,0 +1,59 @@
+/**
+ * How a line series draws a window that holds a single point.
+ *
+ * ─ THE SYMPTOM, AND WHAT IT ACTUALLY IS ────────────────────────────────────
+ * Pinning a period-filtered line chart to a one-month window (the Dashboard's
+ * "Income vs Expenses" on `This month`) leaves the card looking like a chart
+ * that failed to load: axes, grid and legend around what reads as an empty
+ * plot. In a finance app the reader's next thought is about their data, not
+ * about recharts, which is what makes it worth fixing rather than tolerating.
+ *
+ * The obvious diagnosis is that nothing is drawn — a `<Line>` draws the
+ * segments BETWEEN points, so one point yields no path. MEASURED against the
+ * real recharts in this repo, that is only half true, and the other half is
+ * what decides the fix:
+ *
+ *     ONE point,   dot={false}   curves=0   dots=1   r=3 stroke=<series> stroke-width=2 fill=#fff
+ *     ONE point,   dot={true}    curves=0   dots=1   r=3 stroke=<series> stroke-width=2 fill=#fff
+ *     THREE points,dot={false}   curves=1   dots=0
+ *
+ * Two things follow, and both are load-bearing:
+ *
+ * 1. **The point IS drawn.** recharts already special-cases a lone point, so
+ *    the plot is not empty — it holds a 6px circle whose fill is WHITE and
+ *    whose only ink is a 2px ring. On a white card, in a ~200px-tall widget,
+ *    that is a speck. The chart does not look broken because nothing is
+ *    there; it looks broken because what is there is nearly invisible.
+ *
+ * 2. **The boolean is inert.** `dot={false}` and `dot={true}` produce the
+ *    identical element for a one-point series. So the tempting one-liner —
+ *    `dot={data.length === 1}` — changes not a single rendered pixel. It
+ *    would have read like a fix, passed review, and left the card exactly as
+ *    it was.
+ *
+ * ─ THE FIX ─────────────────────────────────────────────────────────────────
+ * Give the lone point a dot CONFIG rather than a boolean: solid, in the
+ * series' own colour, slightly larger than the default ring. A single filled
+ * mark states "one month, this value" — which is the true shape of the data,
+ * not a degenerate version of a line.
+ *
+ * Multi-point series keep `false`, which is what they already had and still
+ * want: dots on a two-hundred-point series are noise, and these charts carry
+ * their click target on the CHART rather than on each dot.
+ *
+ * An AREA chart has the same defect for the same reason and takes the same
+ * treatment; there are none in the app today, and this sentence is here so
+ * the next one added does not have to rediscover it. A BAR chart needs none
+ * of this — one bar is one rectangle, and it renders.
+ *
+ * Stated once, for the same reason `categoricalColor` is a function: five
+ * call sites spelling this inline is five chances to spell it differently,
+ * and this one is subtle enough that the wrong version looks right.
+ */
+
+/** What recharts wants for a visible single mark; `false` is "draw no dots". */
+export type SinglePointDot = false | { r: number; fill: string; strokeWidth: number };
+
+export function singlePointDot(series: readonly unknown[], colour: string): SinglePointDot {
+  return series.length === 1 ? { r: 4, fill: colour, strokeWidth: 0 } : false;
+}

--- a/src/components/common/AccountSelector.tsx
+++ b/src/components/common/AccountSelector.tsx
@@ -587,6 +587,10 @@ export default function AccountSelector<T extends SelectableAccount>({
                 // The trigger toggles the menu; a click that lands in the
                 // search box is placing a cursor, not asking to close.
                 onClick={e => e.stopPropagation()}
+                // Filtering a list of account names, none of which the
+                // dictionary has heard of.
+                spellCheck={false}
+                autoCapitalize="none"
                 placeholder={searchPlaceholder ?? placeholder}
                 aria-autocomplete="list"
                 aria-controls={listboxId}

--- a/src/components/common/MoneyInput.tsx
+++ b/src/components/common/MoneyInput.tsx
@@ -110,6 +110,15 @@ const MoneyInput = forwardRef<HTMLInputElement, MoneyInputProps>(function MoneyI
       ref={setRefs}
       type="text"
       inputMode="decimal"
+      // A SPELL-CHECKED AMOUNT IS NONSENSE. This field is deliberately
+      // `type="text"` so it can hold "1,234.50" while it is being typed — which
+      // also hands it to the browser's dictionary, and a red underline under
+      // somebody's opening balance says the app thinks the money is misspelled.
+      // Autocapitalise has even less to answer for: there is no letter here it
+      // could capitalise, and on a phone it puts the keyboard in the wrong
+      // shift state to start a number.
+      spellCheck={false}
+      autoCapitalize="none"
       value={draft ?? formatMoneyForDisplay(value, decimals)}
       onChange={handleChange}
       onBlur={handleBlur}

--- a/src/components/dashboard/ImprovedDashboard.test.tsx
+++ b/src/components/dashboard/ImprovedDashboard.test.tsx
@@ -207,7 +207,7 @@ describe('Key Account Balances — select all / clear all', () => {
   });
 
   const openPanel = (): void => {
-    fireEvent.click(screen.getByLabelText('Customize displayed accounts'));
+    fireEvent.click(screen.getByLabelText('Customise displayed accounts'));
   };
 
   it('takes every listed account in one click', () => {

--- a/src/components/dashboard/ImprovedDashboard.tsx
+++ b/src/components/dashboard/ImprovedDashboard.tsx
@@ -819,7 +819,7 @@ export function ImprovedDashboard() {
           <button
             onClick={() => setShowAccountSettings(!showAccountSettings)}
             className="p-2 hover:bg-gray-100 dark:hover:bg-gray-700 rounded-lg transition-colors"
-            aria-label="Customize displayed accounts"
+            aria-label="Customise displayed accounts"
             aria-expanded={showAccountSettings}
           >
             <SettingsIcon size={20} className="text-gray-500" />

--- a/src/components/dashboard/reportWidgets/CardPeriodControl.tsx
+++ b/src/components/dashboard/reportWidgets/CardPeriodControl.tsx
@@ -42,11 +42,23 @@ const PINNABLE_PERIODS: PeriodKey[] = [
 ];
 
 /**
- * Hidden until the card is hovered or holds focus. `group/card` is on the card
- * shell; the `hover:hover` guard is what keeps it visible on a touch screen.
+ * VISIBLE AT REST — it used to hide until the card was hovered.
+ *
+ * That was the same hover-reveal the row actions on the Accounts page wore, and
+ * it failed here for the same reason and worse. The owner reported that he
+ * "still cannot change the date viewings on the charts": the pins worked, the
+ * menu worked, and the control that opens it was invisible until a mouse
+ * happened to pass over the card. A control nobody can see is a feature nobody
+ * has — and unlike the row actions, this one has no second route to it
+ * anywhere in the app.
+ *
+ * It is a 16px calendar glyph in the card's own quiet grey, which is what P1
+ * asks of chrome: small, not absent. And it settles a related awkwardness —
+ * the design ruling required a PINNED card to declare itself at rest, so the
+ * declaration was permanent while the control that produced it was not: a
+ * state you could see but not reach.
  */
-const QUIET_AT_REST =
-  'transition-opacity duration-state [@media(hover:hover)]:group-[:not(:hover):not(:focus-within)]/card:opacity-0';
+const QUIET_AT_REST = 'transition-opacity duration-state';
 
 export default function CardPeriodControl({ cardLabel, period, pin }: {
   /** What this control governs, for anyone who cannot see which card it is on. */

--- a/src/components/dashboard/reportWidgets/DashboardReportWidgets.tsx
+++ b/src/components/dashboard/reportWidgets/DashboardReportWidgets.tsx
@@ -13,7 +13,8 @@ import {
 } from 'recharts';
 import { useApp } from '../../../contexts/AppContextSupabase';
 import { useCurrencyDecimal } from '../../../hooks/useCurrencyDecimal';
-import { categoricalColor, useCategoricalRamp } from '../../charts/chartColors';
+import { categoricalColor, useCategoricalRamp, SEMANTIC_SERIES } from '../../charts/chartColors';
+import { singlePointDot } from '../../charts/singlePointDots';
 import { buildMonthlyTrend } from '../../../utils/monthlyTrend';
 import { buildNetWorthSnapshots, netWorthPointToken } from '../../../utils/netWorthSeries';
 import { computeExpenseCategoryNetTotals } from '../../../utils/categoryNetting';
@@ -108,9 +109,13 @@ export function NetWorthWidget({ picker, pin }: {
           {/* Clicking a point opens the report on the same window with THAT
               day's balances already showing — the report's own answer to a
               point, reached from the card. The chart carries the click (not
-              each dot) because the line is drawn without dots: recharts hands
-              back the label under the pointer, which is enough to name the
-              snapshot. */}
+              each dot) because the line is normally drawn without dots:
+              recharts hands back the label under the pointer, which is enough
+              to name the snapshot. (A window holding ONE snapshot draws a
+              solid mark instead: recharts gives a lone point a white-filled
+              3px ring that reads as an empty plot — see
+              charts/singlePointDots for the measurement. The click still
+              comes from the chart, so that case needs nothing extra here.) */}
           <LineChart
             data={snapshots}
             style={{ cursor: 'pointer' }}
@@ -122,7 +127,7 @@ export function NetWorthWidget({ picker, pin }: {
             <XAxis dataKey="label" tick={{ fill: '#6B7280', fontSize: 10 }} minTickGap={32} />
             <YAxis tick={{ fill: '#6B7280', fontSize: 10 }} tickFormatter={compactTick} width={44} />
             <Tooltip formatter={(v: number | string) => formatCurrency(typeof v === 'number' ? v : Number(v))} />
-            <Line type="monotone" dataKey="netWorth" name="Net Worth" stroke="#1a2332" strokeWidth={2} dot={false} isAnimationActive={false} />
+            <Line type="monotone" dataKey="netWorth" name="Net Worth" stroke="#1a2332" strokeWidth={2} dot={singlePointDot(snapshots, '#1a2332')} isAnimationActive={false} />
           </LineChart>
         </ResponsiveContainer>
       </div>
@@ -188,8 +193,8 @@ export function IncomeExpenseTrendWidget({ picker, pin }: {
             <XAxis dataKey="month" tick={{ fill: '#6B7280', fontSize: 10 }} minTickGap={32} />
             <YAxis tick={{ fill: '#6B7280', fontSize: 10 }} tickFormatter={compactTick} width={44} />
             <Tooltip formatter={(v: number | string) => formatCurrency(typeof v === 'number' ? v : Number(v))} />
-            <Line type="monotone" dataKey="income" name="Income" stroke="#10B981" strokeWidth={2} dot={false} isAnimationActive={false} />
-            <Line type="monotone" dataKey="expenses" name="Expenses" stroke="#EF4444" strokeWidth={2} dot={false} isAnimationActive={false} />
+            <Line type="monotone" dataKey="income" name="Income" stroke={SEMANTIC_SERIES.income} strokeWidth={2} dot={singlePointDot(data, SEMANTIC_SERIES.income)} isAnimationActive={false} />
+            <Line type="monotone" dataKey="expenses" name="Expenses" stroke={SEMANTIC_SERIES.expense} strokeWidth={2} dot={singlePointDot(data, SEMANTIC_SERIES.expense)} isAnimationActive={false} />
           </LineChart>
         </ResponsiveContainer>
       </div>

--- a/src/components/layout/Breadcrumbs.tsx
+++ b/src/components/layout/Breadcrumbs.tsx
@@ -32,36 +32,62 @@ const routeLabels: Record<string, string> = {
   'reconciliation': 'Reconciliation'
 };
 
-// Mobile-only back link to the parent route. Deliberately not a breadcrumb
-// trail — the trail was removed app-wide as it crowded narrow viewports.
+/**
+ * Mobile-only back link to the PARENT route. Deliberately not a breadcrumb
+ * trail — the trail was removed app-wide as it crowded narrow viewports.
+ *
+ * ─ WHY IT RENDERS NOTHING ON A TOP-LEVEL PAGE ──────────────────────────────
+ * On `/find` this row said "‹ Find", directly above a page title reading
+ * "Find", directly above a nav bar whose middle tab reads "Find" — three in
+ * about 250px of a 812px screen, of which this row spent ~60px
+ * (PHONE_CAPTURES_REVIEW_2026-08-13 §3.4).
+ *
+ * The repetition was a symptom of something worse: the row was labelled with
+ * the page you are ON and linked to the page you would GO to. On `/find` that
+ * is a control saying "Find" which takes you to the Dashboard. So on a
+ * top-level route it was simultaneously the title again and a mis-signed exit,
+ * and the honest back affordance is the one already on screen — the bottom nav
+ * reaches every top-level route, and the OS edge gesture reaches the last one.
+ *
+ * ─ WHY IT STILL RENDERS ON A NESTED ONE ────────────────────────────────────
+ * "Drop it on mobile" would take the row out everywhere, because `sm:hidden`
+ * means mobile is the only place it has ever rendered. But `/settings/tags`
+ * has no tab in the bottom nav (Home · Accounts · Find · Reconcile ·
+ * Categorise), so up-one-level is genuinely unreachable there without this.
+ * The rule that keeps both facts is therefore about DEPTH, not width: a route
+ * with one segment repeats the title and is covered by the nav; a route with
+ * two or more has a parent worth a control.
+ *
+ * And the surviving row now names its DESTINATION — "‹ Settings" from
+ * `/settings/tags`, "‹ Accounts" from an account register — so it no longer
+ * repeats the title of the page it sits on, which was the finding.
+ */
 export function MobileBreadcrumb() {
   const location = useLocation();
   const { accounts } = useApp();
   const pathSegments = location.pathname.split('/').filter(Boolean);
 
-  // Don't show on home page
-  if (pathSegments.length === 0) {
+  // Home, and every top-level page: the bottom nav is the affordance.
+  if (pathSegments.length < 2) {
     return null;
   }
 
-  const currentPage = pathSegments[pathSegments.length - 1];
-  const matchedAccount = accounts.find(a => a.id === currentPage);
+  const parentPath = `/${pathSegments.slice(0, -1).join('/')}`;
+  const parentSegment = pathSegments[pathSegments.length - 2];
+  // A route nested under a single account names that account, not its id.
+  const matchedAccount = accounts.find(a => a.id === parentSegment);
   const label = matchedAccount
     ? matchedAccount.name
-    : routeLabels[currentPage] || currentPage.charAt(0).toUpperCase() + currentPage.slice(1);
-
-  // Determine parent path
-  const parentPath = pathSegments.length > 1 
-    ? `/${pathSegments.slice(0, -1).join('/')}`
-    : '/';
+    : routeLabels[parentSegment] || parentSegment.charAt(0).toUpperCase() + parentSegment.slice(1);
 
   return (
     <div className="sm:hidden bg-white dark:bg-gray-800 border-b border-gray-200 dark:border-gray-700 px-4 py-3">
       <Link
         to={preserveDemoParam(parentPath, location.search)}
+        aria-label={`Back to ${label}`}
         className="flex items-center gap-2 text-primary dark:text-primary-light"
       >
-        <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
           <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 19l-7-7 7-7" />
         </svg>
         <span className="text-sm font-medium">{label}</span>

--- a/src/components/reconciliation/ReconciliationTransactionList.tsx
+++ b/src/components/reconciliation/ReconciliationTransactionList.tsx
@@ -208,6 +208,8 @@ export default function ReconciliationTransactionList({
           <input
             type="text"
             placeholder="Search transactions..."
+            spellCheck={false}
+            autoCapitalize="none"
             value={searchTerm}
             onChange={(e) => setSearchTerm(e.target.value)}
             className="w-full pl-9 pr-3 py-2 text-sm bg-white dark:bg-gray-700 border border-gray-300 dark:border-gray-600 rounded-lg dark:text-white"

--- a/src/components/subscription/UsageLimitWarning.tsx
+++ b/src/components/subscription/UsageLimitWarning.tsx
@@ -167,7 +167,7 @@ export function UpgradeBenefits({ feature, className = '' }: UpgradeBenefitsProp
     accounts: [
       'Unlimited bank accounts',
       'Unlimited investment accounts',
-      'Advanced account categorization',
+      'Advanced account categorisation',
       'Account performance tracking'
     ],
     transactions: [

--- a/src/contexts/CategoryContext.test.tsx
+++ b/src/contexts/CategoryContext.test.tsx
@@ -363,20 +363,20 @@ describe('CategoryContext', () => {
       expect(path).toBe('Income');
     });
 
-    it('returns Uncategorized for empty id', () => {
+    it('returns Uncategorised for empty id', () => {
       const { result } = renderHook(() => useCategories(), { wrapper });
 
       const path = result.current.getCategoryPath('');
 
-      expect(path).toBe('Uncategorized');
+      expect(path).toBe('Uncategorised');
     });
 
-    it('returns Uncategorized for non-existent id', () => {
+    it('returns Uncategorised for non-existent id', () => {
       const { result } = renderHook(() => useCategories(), { wrapper });
 
       const path = result.current.getCategoryPath('non-existent');
 
-      expect(path).toBe('Uncategorized');
+      expect(path).toBe('Uncategorised');
     });
 
     it('handles broken parent chain gracefully', () => {

--- a/src/contexts/CategoryContext.tsx
+++ b/src/contexts/CategoryContext.tsx
@@ -3,6 +3,7 @@ import { createContext, useContext, useState, useEffect, useMemo } from 'react';
 import type { ReactNode } from 'react';
 import { v4 as uuidv4 } from 'uuid';
 import { getDefaultCategories } from '../data/defaultCategories';
+import { UNCATEGORISED_LABEL } from '../utils/categoryNames';
 
 interface Category {
   id: string;
@@ -86,7 +87,7 @@ export function CategoryProvider({ children, initialCategories }: CategoryProvid
     const pathCache = new Map<string, string>();
     
     return (categoryId: string): string => {
-      if (!categoryId) return 'Uncategorized';
+      if (!categoryId) return UNCATEGORISED_LABEL;
       
       // Check cache first
       if (pathCache.has(categoryId)) {
@@ -94,7 +95,7 @@ export function CategoryProvider({ children, initialCategories }: CategoryProvid
       }
       
       const category = categories.find(c => c.id === categoryId);
-      if (!category) return 'Uncategorized';
+      if (!category) return UNCATEGORISED_LABEL;
       
       // Build the full path for the category
       let path = category.name;

--- a/src/design-system/__tests__/semantic-contrast.test.ts
+++ b/src/design-system/__tests__/semantic-contrast.test.ts
@@ -33,6 +33,7 @@ import { describe, it, expect } from 'vitest';
 import { readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 import { ColorContrastChecker } from '../../utils/color-contrast-checker';
+import { CATEGORICAL_AXIS, SEMANTIC_SERIES } from '../../components/charts/chartColors';
 
 const read = (repoPath: string): string =>
   readFileSync(resolve(process.cwd(), repoPath), 'utf8');
@@ -58,6 +59,7 @@ const token = {
   income: extract(tailwindConfig, /\bincome: '(#[0-9a-f]{6})'/i, 'tailwind income'),
   incomeFill: extract(tailwindConfig, /'income-fill': '(#[0-9a-f]{6})'/i, 'tailwind income-fill'),
   expense: extract(tailwindConfig, /\bexpense: '(#[0-9a-f]{6})'/i, 'tailwind expense'),
+  expenseFill: extract(tailwindConfig, /'expense-fill': '(#[0-9a-f]{6})'/i, 'tailwind expense-fill'),
   accentText: extract(tailwindConfig, /'accent-text': '(#[0-9a-f]{6})'/i, 'tailwind accent-text'),
 };
 
@@ -112,6 +114,62 @@ describe('semantic amount colours (DESIGN_PASS_2026-08 §2.1)', () => {
     // to a text token this stops being the right test — see §2.1.
     expect(ratio(token.incomeFill, '#ffffff')).toBeGreaterThanOrEqual(AA_GRAPHICS);
     expect(ratio(token.incomeFill, '#ffffff')).toBeLessThan(AA_TEXT);
+  });
+
+  /**
+   * THE CHART SERIES PAIR (PHONE_CAPTURES_REVIEW_2026-08-13 §4).
+   *
+   * `#10B981`/`#EF4444` were a second definition of income and expense, hard
+   * coded in five files. The series now read the token sheet, and these pin
+   * the two things that made the old arrangement rot: that the pair agrees
+   * with the tokens, and that it is measured at the bar it actually owes.
+   *
+   * A series colour differs from a text colour in one way that matters here:
+   * it is ONE hex for both themes — recharts takes a colour, not a class, so
+   * there is no `dark:` variant to fall back on. It therefore has to clear
+   * 3:1 on the dark card as well, which is a test the text pairs never sit.
+   */
+  describe('the chart series pair', () => {
+    const SURFACES_ALL = [...SURFACES_LIGHT, ...SURFACES_DARK] as const;
+
+    it('agrees with the module the charts actually read', () => {
+      // The tokens are the declaration; SEMANTIC_SERIES is the copy recharts
+      // consumes. Same rule as income/expense across their three files — an
+      // unchecked copy is how there came to be five chart palettes.
+      expect(SEMANTIC_SERIES.income.toLowerCase()).toBe(token.incomeFill);
+      expect(SEMANTIC_SERIES.expense.toLowerCase()).toBe(token.expenseFill);
+    });
+
+    it('clears the 3:1 graphics bar on every surface a chart is drawn on', () => {
+      for (const surface of SURFACES_ALL) {
+        expect(ratio(token.incomeFill, surface)).toBeGreaterThanOrEqual(AA_GRAPHICS);
+        expect(ratio(token.expenseFill, surface)).toBeGreaterThanOrEqual(AA_GRAPHICS);
+      }
+    });
+
+    it('is not text, and fails here if someone makes it text', () => {
+      // Both sit under 4.5:1 on white BY DESIGN: they are the colours the
+      // amounts retired for exactly that reason. An amount that wants green
+      // wants `income`, which is measured against the text bar above.
+      expect(ratio(token.incomeFill, '#ffffff')).toBeLessThan(AA_TEXT);
+      expect(ratio(token.expenseFill, '#ffffff')).toBeLessThan(AA_TEXT);
+    });
+
+    it('is not the same colour as the amounts, and not the old hard-coded pair', () => {
+      expect(token.incomeFill).not.toBe(token.income);
+      expect(token.expenseFill).not.toBe(token.expense);
+      expect([token.incomeFill, token.expenseFill]).not.toContain('#10b981');
+      expect([token.incomeFill, token.expenseFill]).not.toContain('#ef4444');
+    });
+
+    it('keeps green and red out of the categorical ramp (RULINGS §2)', () => {
+      // The ramp is navy through slate. If a semantic hue ever appears in it,
+      // a pie slice starts claiming to be income.
+      for (const step of CATEGORICAL_AXIS) {
+        expect(step.toLowerCase()).not.toBe(token.incomeFill);
+        expect(step.toLowerCase()).not.toBe(token.expenseFill);
+      }
+    });
   });
 
   it('tabular figures are the app-wide default (P5)', () => {

--- a/src/design-system/__tests__/ukEnglish.test.ts
+++ b/src/design-system/__tests__/ukEnglish.test.ts
@@ -1,0 +1,190 @@
+/**
+ * The app speaks one English, and it is the one its dates are in.
+ *
+ * ── WHY THIS IS A TEST AND NOT A STYLE NOTE ─────────────────────────────────
+ *
+ * Every date this app prints is dd/mm/yyyy and every amount is in pounds —
+ * `utils/dateFormatter` hard-codes `en-GB` and `isUKDateFormat()` returns a
+ * literal `true`, so there is no US edition to be consistent WITH. The copy had
+ * drifted anyway: "Uncategorised" in the payee reports and the category name
+ * lookup, "Uncategorized" in CategoryContext, the category dropdown, the search
+ * results and the QIF export — two spellings of one word, both reachable from
+ * the same screen, under dates that could only be British.
+ *
+ * A sweep fixes that once. This fixes it for good, because the failure mode is
+ * not ignorance, it is that `Uncategorized` looks completely correct to
+ * whoever types it next.
+ *
+ * ── WHAT IT DOES AND DOES NOT CLAIM ─────────────────────────────────────────
+ *
+ * It reads the copy — quoted strings and JSX text in the components, pages and
+ * contexts — and looks for a short list of words that Britain and America spell
+ * differently AND that this app actually says. It is not a dictionary and does
+ * not pretend to be: `color`, `center` and `behavior` are absent from the list
+ * on purpose, because in a React codebase they are overwhelmingly CSS
+ * properties and Tailwind classes, and a guard that cries wolf gets deleted.
+ *
+ * IDENTIFIERS ARE NOT COPY. `BulkCategorizeModal`, `normalizePayee` and
+ * `applyCategoryToUncategorized` are names, and renaming them would be churn
+ * with no reader. Only what a person can read on screen is in scope, so import
+ * lines, module paths and hyphenated/underscored tokens (`data-testid`s, storage
+ * keys) are skipped.
+ *
+ * ── IF A US EDITION EVER SHIPS ──────────────────────────────────────────────
+ *
+ * The owner's ask was "if they choose US dates, the spelling should follow".
+ * There is nothing to follow today — no such choice exists — and building a
+ * branch nobody can reach would be worse than not building it. When that choice
+ * arrives, this file is the inventory of every word that has to move, and
+ * `UNCATEGORISED_LABEL` is the shape the rest should take: one constant, read
+ * everywhere, switched in one place.
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync, readdirSync, statSync } from 'node:fs';
+import { resolve, join } from 'node:path';
+
+/** Where a user can read words. Services and utils are swept via their callers. */
+const COPY_ROOTS = ['src/components', 'src/pages', 'src/contexts'];
+
+/**
+ * The words this app says that the two Englishes spell differently.
+ *
+ * Each is a stem plus whatever endings we actually use, so `Categorize` and
+ * `Categorizing` are both caught by one entry.
+ */
+const US_SPELLINGS: { pattern: RegExp; uk: string }[] = [
+  { pattern: /\b(un)?categoriz(e|es|ed|ing|ation)?\b/i, uk: 'categorise / uncategorised' },
+  { pattern: /\banalyz(e|es|ed|ing|er)?\b/i, uk: 'analyse' },
+  { pattern: /\bcustomiz(e|es|ed|ing|ation)?\b/i, uk: 'customise' },
+  { pattern: /\borganiz(e|es|ed|ing|ation)?\b/i, uk: 'organise' },
+  { pattern: /\bpersonaliz(e|es|ed|ing|ation)?\b/i, uk: 'personalise' },
+  { pattern: /\boptimiz(e|es|ed|ing|ation)?\b/i, uk: 'optimise' },
+  { pattern: /\bfavorite(s)?\b/i, uk: 'favourite' },
+  { pattern: /\bcancel(ed|ing)\b/i, uk: 'cancelled / cancelling' },
+];
+
+function sourceFiles(dir: string): string[] {
+  const out: string[] = [];
+  for (const entry of readdirSync(dir)) {
+    const full = join(dir, entry);
+    if (statSync(full).isDirectory()) {
+      if (entry === '__tests__') continue;
+      out.push(...sourceFiles(full));
+      continue;
+    }
+    if (!/\.tsx?$/.test(entry)) continue;
+    if (/\.(test|spec)\.tsx?$/.test(entry)) continue;
+    out.push(full);
+  }
+  return out;
+}
+
+/**
+ * Strip what a user never reads: comments (including the multi-line ones this
+ * codebase is full of, whose middle lines start with prose rather than a `*`)
+ * and diagnostic logging.
+ *
+ * Returns the file as lines, with non-copy blanked rather than removed, so the
+ * line numbers this test reports are the line numbers in the editor.
+ */
+function readableLines(source: string): string[] {
+  let inBlock = false;
+  return source.split('\n').map(raw => {
+    let line = raw;
+    if (inBlock) {
+      const close = line.indexOf('*/');
+      if (close === -1) return '';
+      line = line.slice(close + 2);
+      inBlock = false;
+    }
+    const open = line.indexOf('/*');
+    if (open !== -1) {
+      const close = line.indexOf('*/', open + 2);
+      if (close === -1) {
+        inBlock = true;
+        line = line.slice(0, open);
+      } else {
+        line = line.slice(0, open) + line.slice(close + 2);
+      }
+    }
+    const lineComment = line.indexOf('//');
+    if (lineComment !== -1) line = line.slice(0, lineComment);
+    // A message to a console is a message to us.
+    if (/\b(console|logger|log)\.[a-z]+\(/.test(line)) return '';
+    // Imports and module paths are addresses, not sentences.
+    if (/^\s*import\b/.test(line) || /\bfrom\s+['"]/.test(line)) return '';
+    return line;
+  });
+}
+
+/**
+ * The readable words on one line: quoted strings and JSX text.
+ *
+ * A quoted string counts as COPY only if it is a phrase (has a space) or is
+ * capitalised. A bare lowercase token — `'uncategorized'`, `'canceled'` — is an
+ * identifier: a union member, a Stripe status, a storage key. Those are names,
+ * and this codebase has a settled rule that names are not copy; changing them
+ * would be churn with no reader, and `'canceled'` in particular is Stripe's own
+ * API value, which we compare against. JSX text has no such ambiguity — if it
+ * sits between the tags, someone reads it.
+ */
+function copyOn(line: string): string[] {
+  const found: string[] = [];
+  // The last two alternatives are what catch a sentence WRAPPED across lines —
+  // `<p>` on one line, the sentence on the next. Missing those is how "new
+  // optimization opportunities" survived the first pass of this very test.
+  // `(?<!=)` keeps an arrow function from reading as a JSX tag: without it,
+  // `row => classifyFlow(row) === 'uncategorized'` is "text after a >".
+  for (const match of line.matchAll(/'([^'\\]*)'|"([^"\\]*)"|(?<!=)>([^<>{}]+)<|(?<!=)>([^<>{}=]+)$|^([^<>{}=]+)</g)) {
+    const quoted = match[1] ?? match[2];
+    const text = (quoted ?? match[3] ?? match[4] ?? match[5] ?? '').trim();
+    if (text.length === 0) continue;
+    if (quoted !== undefined && !/\s/.test(text) && !/^[A-Z]/.test(text)) continue;
+    // A hyphenated or underscored token is a key, a class or a test id.
+    if (/^[\w-]*[-_][\w-]*$/.test(text)) continue;
+    found.push(text);
+  }
+  return found;
+}
+
+describe('the app speaks British English, like its dates', () => {
+  const files = COPY_ROOTS.flatMap(root => sourceFiles(resolve(process.cwd(), root)));
+
+  it('has copy to read at all (the guard is not vacuous)', () => {
+    expect(files.length).toBeGreaterThan(200);
+  });
+
+  it('says no American spelling that Britain spells differently', () => {
+    const offences: string[] = [];
+
+    for (const file of files) {
+      const lines = readableLines(readFileSync(file, 'utf8'));
+      lines.forEach((line, index) => {
+        for (const text of copyOn(line)) {
+          for (const { pattern, uk } of US_SPELLINGS) {
+            const hit = text.match(pattern);
+            if (hit === null) continue;
+            // `-ise` spellings match none of the patterns above; only the `-ize`
+            // family and the two irregulars reach here.
+            offences.push(
+              `${file.replace(process.cwd() + '/', '')}:${index + 1} — "${hit[0]}" (use ${uk})`
+            );
+          }
+        }
+      });
+    }
+
+    expect(offences).toEqual([]);
+  });
+
+  it('declares one spelling of the word for a row with no category', () => {
+    // The specific drift that prompted this: two spellings, both on screen.
+    const lookup = readFileSync(resolve(process.cwd(), 'src/utils/categoryNames.ts'), 'utf8');
+    expect(lookup).toContain("UNCATEGORISED_LABEL = 'Uncategorised'");
+  });
+
+  it('tells the browser which English, so its own spellchecker agrees', () => {
+    const html = readFileSync(resolve(process.cwd(), 'index.html'), 'utf8');
+    expect(html).toMatch(/<html lang="en-GB"/);
+  });
+});

--- a/src/pages/Accounts.tsx
+++ b/src/pages/Accounts.tsx
@@ -1,4 +1,4 @@
-import { useState, useMemo, useEffect, useCallback, useRef, Suspense, type ReactNode } from 'react';
+import { useState, useMemo, useEffect, useCallback, useRef, useId, Suspense, type ReactNode } from 'react';
 import { useNavigate, useLocation, Link } from 'react-router-dom';
 import { useApp } from '../contexts/AppContextSupabase';
 import { useToast } from '../contexts/ToastContext';
@@ -12,7 +12,7 @@ import { formatDate } from '../utils/dateFormatter';
 import { accountHasHistory } from '../utils/accountHistory';
 import PortfolioView from '../components/PortfolioView';
 // No longer importing from lucide-react - all icons are now custom
-import { ArchiveIcon, SettingsIcon, WalletIcon, CheckCircleIcon, PieChartIcon, BankIcon, RefreshCwIcon, AlertTriangleIcon, ChevronRightIcon, ChevronDownIcon, XCircleIcon, SearchIcon } from '../components/icons';
+import { ArchiveIcon, SettingsIcon, WalletIcon, CheckCircleIcon, CheckIcon, PieChartIcon, BankIcon, RefreshCwIcon, AlertTriangleIcon, ChevronRightIcon, ChevronDownIcon, XCircleIcon, SearchIcon } from '../components/icons';
 // Both bank-feed surfaces on this page come through `@service`, the seam for
 // what a shared page says about the account you hold WITH somebody. On a
 // device the badge draws nothing and the hook answers no connections, which
@@ -256,6 +256,47 @@ export default function Accounts() {
   // is a substring test over a couple of hundred rows.
   const [accountSearch, setAccountSearch] = useState('');
 
+  /**
+   * FOUR ROWS OF CONTROLS BEFORE ANY DATA — on the page whose content is a list.
+   *
+   * On a phone the toolbar stacks: search, Group by, Sort, then the feed
+   * actions, each full width, together about 40% of the viewport above the
+   * first account. P1 charges chrome rent, and four rows of it is more than
+   * this page can pay before it has shown a single balance.
+   *
+   * Search and Sort stay: one finds an account among two hundred, the other
+   * decides what the top of the list means, and both are wanted BEFORE
+   * looking. Grouping and the two bank-feed actions go behind one switch —
+   * grouping is a preference you set once and it persists, and the feeds are
+   * an errand rather than a way of reading the list.
+   *
+   * A DISCLOSURE, NOT A MENU, AND NOT A HOOK.
+   * The register's toolbar already solves this exact problem this exact way
+   * (a button that reveals the rest of its controls), and the disclosure —
+   * `aria-expanded` + `aria-controls` on a button that shows a block — is the
+   * most-repeated control idiom in the app. A popover would be a fifth
+   * hand-rolled anchored panel with its own focus management, which P7 calls a
+   * bug report. And the reveal is a STYLE swap over one DOM, so it is Tailwind
+   * classes rather than `useIsMobileViewport`, exactly as `useMediaQuery`'s own
+   * doc comment instructs: the hook is for a component swap, and everything
+   * else in this app is an `sm:` class.
+   *
+   * WHICH IS WHY THE DESKTOP CANNOT NOTICE. Every hidden thing is `sm:flex`
+   * and the switch itself is `sm:hidden`, so from 640px up the browser
+   * computes precisely what it computed before — same elements, same order,
+   * same gaps — and this state is not consulted at all.
+   *
+   * No "active" dot on the switch, though the register has one. Grouping is ON
+   * by default (`DEFAULT_ACCOUNT_GROUPING` is byType), so a dot meaning "a
+   * control in here is set" would be lit for nearly every user nearly always,
+   * and a light that is always on is not a signal. The banded list behind it
+   * already says the list is banded.
+   */
+  const [showMoreControls, setShowMoreControls] = useState(false);
+  const controlsId = useId();
+  const groupPanelId = `${controlsId}-group`;
+  const feedPanelId = `${controlsId}-feeds`;
+
   // The mobile +'s "Add Account" deep-links /accounts?action=add — open the
   // modal and consume the param (replace), so back/refresh cannot re-open it.
   useEffect(() => {
@@ -366,21 +407,6 @@ export default function Accounts() {
       setReopeningId(null);
     }
   }, [reopeningId, updateAccount, refreshAccountsAndTransactions, refreshCategories, loadClosedAccounts, showError]);
-
-  // Closed accounts get the SAME grouping as the open list, in all four switch
-  // combinations, so the archive reads the way the live list does. Rows within
-  // a group are alphabetical by name; that was the whole point of this change
-  // (they used to arrive in no order at all). The grouping preserves input
-  // order, so sorting once up front sorts every band. Empty bands don't render.
-  // Kept independent of `sortMode`: the live list's Value/Default sorts are for
-  // triage, but an archive you're scanning for one name always wants A–Z.
-  const closedAccountBands = useMemo(
-    () => groupAccountsForDisplay(
-      [...closedAccounts].sort((a, b) => a.name.localeCompare(b.name, undefined, { sensitivity: 'base' })),
-      grouping
-    ),
-    [closedAccounts, grouping]
-  );
 
   // Convert accounts to decimal for calculations
   const decimalAccounts = useMemo(() => openAccounts.map(a => ({
@@ -653,6 +679,54 @@ export default function Accounts() {
   const matchedTopLevelCount = isSearching
     ? topLevelAccounts.filter(accountOrChildMatches).length
     : topLevelAccounts.length;
+
+  /**
+   * THE CLOSED BAND OBEYS THE SEARCH, LIKE EVERYTHING ELSE ON THE PAGE.
+   *
+   * It did not, and a phone capture caught what that costs: "87 of your
+   * accounts are hidden by Search: …" printed directly above a live
+   * **Closed Accounts (110)** band. The page was simultaneously reporting that
+   * nothing matched and showing a group larger than the count it had just
+   * quoted. Either half could be defended alone; together they say the search
+   * cannot be trusted, on the page where trusting it is the whole point.
+   *
+   * The filter is the same predicate the open list uses — `accountMatchesSearch`
+   * rather than `accountOrChildMatches`, because nesting is an OPEN-list idea:
+   * `nestedByParent` is built from open accounts and closed rows are always
+   * drawn flat, so a closed account has no child that could keep it on screen.
+   *
+   * Three consequences follow, and they are all just "the count means what is
+   * on screen":
+   *   · a search that matches no closed account renders no band at all;
+   *   · a search that matches one still shows it — the user asked for it by
+   *     name, and an archive that hides a name you typed is worse than no
+   *     archive;
+   *   · the heading counts the rows in the band, not the rows in the database.
+   */
+  const matchedClosedAccounts = useMemo(
+    () => (isSearching ? closedAccounts.filter(accountMatchesSearch) : closedAccounts),
+    [isSearching, closedAccounts, accountMatchesSearch]
+  );
+
+  // Closed accounts get the SAME grouping as the open list, in all four switch
+  // combinations, so the archive reads the way the live list does. Rows within
+  // a group are alphabetical by name; that was the whole point of this change
+  // (they used to arrive in no order at all). The grouping preserves input
+  // order, so sorting once up front sorts every band. Empty bands don't render.
+  // Kept independent of `sortMode`: the live list's Value/Default sorts are for
+  // triage, but an archive you're scanning for one name always wants A–Z.
+  const closedAccountBands = useMemo(
+    () => groupAccountsForDisplay(
+      [...matchedClosedAccounts].sort((a, b) => a.name.localeCompare(b.name, undefined, { sensitivity: 'base' })),
+      grouping
+    ),
+    [matchedClosedAccounts, grouping]
+  );
+
+  // The archive's fold is the user's while they are browsing, and the search's
+  // while they are searching — same rule, and the same words, as the open
+  // bands above.
+  const closedBandExpanded = showClosedAccounts || isSearching;
 
   // The collapsed-set key and the region id both key off the band's dimension
   // and label — see `collapsedGroups` for why the dimension is part of the key.
@@ -1697,8 +1771,26 @@ export default function Accounts() {
             on their own they band the list one way, together they nest
             institutions inside the type sections, and off they leave one flat
             list. The p-0.5 is not decoration — it matches the height the Sort
-            group gets from its own border and padding, so the two rows line up. */}
-        <div className="w-full sm:w-auto flex items-center gap-2">
+            group gets from its own border and padding, so the two rows line up.
+
+            AND THEY HAVE TO LOOK LIKE IT. Both-on is a real state, but wearing
+            the same navy fill as Sort's segmented single-choice directly
+            beneath, two filled pills read as a broken radio group rather than
+            as two things ticked — a phone capture of THIS page is what filed
+            it, twice. The control has to say which KIND it is before it can be
+            believed about which state it is in, so a pressed toggle carries a
+            tick: the one glyph that means "this one too" rather than "this one
+            instead". The slot is held open while a switch is off, so ticking
+            one does not shove its own label sideways.
+
+            Identical to the reconciliation page's, deliberately — same glyph,
+            same size, same held-open slot. Two pages, one idiom; a tick that
+            meant something subtly different on each would be worse than no
+            tick at all. */}
+        <div
+          id={groupPanelId}
+          className={`w-full sm:w-auto ${showMoreControls ? 'flex' : 'hidden'} sm:flex items-center gap-2`}
+        >
           {/* Semibold, and a grade darker: these two words are the only thing
               telling anyone what the row of pills beside them does, and at
               gray-500/normal they read as a footnote to the buttons rather than
@@ -1710,12 +1802,17 @@ export default function Accounts() {
               onClick={() => handleGroupingChange({ ...grouping, byType: !grouping.byType })}
               aria-pressed={grouping.byType}
               title="Band the list into account-type sections"
-              className={`px-3 py-1.5 text-sm font-medium rounded-lg border transition-colors ${
+              className={`inline-flex items-center justify-center gap-1.5 px-3 py-1.5 text-sm font-medium rounded-lg border transition-colors ${
                 grouping.byType
                   ? 'bg-[#1a2332] dark:bg-blue-600 border-[#1a2332] dark:border-blue-600 text-white'
                   : 'border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-200'
               }`}
             >
+              {/* aria-hidden: `aria-pressed` already says this to a screen
+                  reader, and the tick would announce it a second time. */}
+              <span aria-hidden="true" className="w-3.5 flex-shrink-0">
+                {grouping.byType && <CheckIcon size={14} />}
+              </span>
               Account Type
             </button>
             <button
@@ -1723,12 +1820,15 @@ export default function Accounts() {
               onClick={() => handleGroupingChange({ ...grouping, byInstitution: !grouping.byInstitution })}
               aria-pressed={grouping.byInstitution}
               title="Band the list by institution"
-              className={`px-3 py-1.5 text-sm font-medium rounded-lg border transition-colors ${
+              className={`inline-flex items-center justify-center gap-1.5 px-3 py-1.5 text-sm font-medium rounded-lg border transition-colors ${
                 grouping.byInstitution
                   ? 'bg-[#1a2332] dark:bg-blue-600 border-[#1a2332] dark:border-blue-600 text-white'
                   : 'border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-200'
               }`}
             >
+              <span aria-hidden="true" className="w-3.5 flex-shrink-0">
+                {grouping.byInstitution && <CheckIcon size={14} />}
+              </span>
               Institution
             </button>
           </div>
@@ -1788,45 +1888,128 @@ export default function Accounts() {
               being refused by the input's own intrinsic width. */}
           <div className="relative flex-1 min-w-0">
             <SearchIcon className="absolute left-3 top-1/2 -translate-y-1/2 text-gray-400 pointer-events-none" size={16} />
+            {/* A SEARCH TERM IS NOT PROSE. A phone capture caught the browser
+                underlining a search term in red, which is the platform telling
+                somebody their bank is misspelled. Institution names, sort codes
+                and account nicknames are in no dictionary, so the squiggle is
+                at best noise and at worst a suggestion that the reason nothing
+                matched is that they typed it wrong.
+                Autocapitalise is the same argument on a phone keyboard: the
+                match is a case-insensitive substring test, so capitalising the
+                first letter changes nothing except what the user watches
+                themselves type. */}
             <input
               id="account-search"
               type="search"
               value={accountSearch}
               onChange={(e) => setAccountSearch(e.target.value)}
               placeholder="Search accounts…"
+              spellCheck={false}
+              autoCapitalize="none"
               className="w-full pl-9 pr-3 py-1.5 text-sm rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 text-gray-900 dark:text-white placeholder-gray-400 focus:border-transparent"
             />
           </div>
           {isSearching && (
             <span className="text-xs text-gray-500 dark:text-gray-400 whitespace-nowrap" aria-live="polite">
-              {matchedTopLevelCount} of {topLevelAccounts.length} accounts
+              {matchedTopLevelCount + matchedClosedAccounts.length} of {topLevelAccounts.length + closedAccounts.length} accounts
             </span>
           )}
+          {/* THE SWITCH RIDES THE SEARCH ROW rather than taking one of its own,
+              which would spend a row to save two. Phone only — `sm:hidden` —
+              so at every width the toolbar was designed for, this button does
+              not exist.
+
+              The visible word is the accessible name's first word, not a
+              shorter alias for it: a control whose spoken name has nothing to
+              do with its printed one is unusable by voice, and "More" alone
+              would be unusable by everyone else. The `sr-only` half is how
+              this app already says the part that does not fit (see the report
+              filter's own hidden label). */}
+          <button
+            type="button"
+            onClick={() => setShowMoreControls(prev => !prev)}
+            aria-expanded={showMoreControls}
+            aria-controls={`${groupPanelId} ${feedPanelId}`}
+            className="sm:hidden shrink-0 inline-flex items-center gap-1.5 px-3 py-1.5 text-sm font-medium rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-200 transition-colors"
+          >
+            More
+            <span className="sr-only"> controls: grouping and bank connections</span>
+            {/* SWAPPED, NOT ROTATED — and that is a measurement, not a taste.
+                `rotate-90` computes to no rotation in this app: the utility
+                sets `--tw-rotate: 90deg` and then a `transform` built from
+                `--tw-translate-x`, `--tw-skew-*` and `--tw-scale-*`, which are
+                not initialised on the element, so the whole declaration is
+                invalid and the computed transform is the identity matrix.
+                Verified in the browser on this button — the class was present
+                and the glyph did not move. (The same dead class sits on the
+                band chevron at :1572, ArchiveManager and CSVImportWizard; that
+                is a global fix, not this change's business.)
+                So this uses the fold idiom the CLOSED ACCOUNTS band below
+                already uses — two different glyphs — which needs no transform
+                and cannot be silently switched off. */}
+            {showMoreControls ? <ChevronDownIcon size={14} /> : <ChevronRightIcon size={14} />}
+          </button>
         </div>
-        <div className="basis-full sm:basis-auto sm:ml-auto flex items-center gap-2">
+        {/* THE BADGES DO NOT GO IN THE DRAWER. Both render `null` unless a
+            banking incident is actually live, which makes them alarms rather
+            than controls, and an alarm behind a switch labelled "More" is an
+            alarm nobody hears. They stay in the always-visible half; only the
+            two errands fold away. */}
+        {/* `contents` while the drawer is shut, and it is load-bearing rather
+            than clever: measured at 375px, a container holding two null badges
+            and one hidden wrapper still claimed a whole wrap line, so the
+            toolbar stood at three rows when the point of the exercise was two.
+            `display: contents` makes the box itself stop existing while its
+            children go on being laid out by the toolbar — so a live incident
+            badge still appears (as a flex item of the row above), and nothing
+            appears when there is no badge and no open drawer.
+            The register's toolbar already dissolves a wrapper this way at
+            phone widths; `sm:flex` takes the box back at every width the
+            desktop uses. */}
+        <div className={`${showMoreControls ? 'basis-full flex' : 'contents'} sm:basis-auto sm:ml-auto sm:flex items-center gap-2`}>
           <BankingCriticalIncidentBadge onClick={() => setBankConnectionsView('critical')} />
           <BankingCriticalIncidentBadge mode="truelayer_jwks" onClick={() => setBankConnectionsView('jwks')} />
-          {/* One hit for every feed — the per-account buttons remain for a
-              single stubborn connection. Rendered whenever any connection
-              exists so the toolbar's shape stays put. */}
-          {connectedCount > 0 && (
-            <button
-              onClick={() => void syncAllConnections()}
-              disabled={isSyncingAny}
-              className="w-full sm:w-auto justify-center px-3 py-1.5 text-sm font-medium rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors flex items-center gap-2 disabled:opacity-60 disabled:cursor-wait"
-              title="Pull fresh data from every connected bank"
-            >
-              <RefreshCwIcon size={16} className={isSyncingAny ? 'animate-spin' : ''} />
-              {isSyncingAny ? 'Refreshing…' : 'Refresh feeds'}
-            </button>
-          )}
-          <button
-            onClick={() => setBankConnectionsView('plain')}
-            className="w-full sm:w-auto justify-center px-3 py-1.5 text-sm font-medium rounded-lg bg-[#1a2332] dark:bg-blue-600 text-white hover:bg-[#2d3a4d] dark:hover:bg-blue-700 transition-colors flex items-center gap-2"
+          {/* The inner wrapper is what the switch actually hides, and it is
+              built so the desktop cannot tell it arrived: `gap-2` inside
+              matching `gap-2` outside leaves every button exactly 8px from its
+              neighbour, which is where they were. */}
+          <div
+            id={feedPanelId}
+            className={`w-full sm:w-auto ${showMoreControls ? 'flex' : 'hidden'} sm:flex items-center gap-2`}
           >
-            <BankIcon size={16} />
-            Bank Connections
-          </button>
+            {/* One hit for every feed — the per-account buttons remain for a
+                single stubborn connection. Rendered whenever any connection
+                exists so the toolbar's shape stays put. */}
+            {connectedCount > 0 && (
+              <button
+                onClick={() => void syncAllConnections()}
+                disabled={isSyncingAny}
+                className="w-full sm:w-auto justify-center px-3 py-1.5 text-sm font-medium rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors flex items-center gap-2 disabled:opacity-60 disabled:cursor-wait"
+                title="Pull fresh data from every connected bank"
+              >
+                <RefreshCwIcon size={16} className={isSyncingAny ? 'animate-spin' : ''} />
+                {isSyncingAny ? 'Refreshing…' : 'Refresh feeds'}
+              </button>
+            )}
+            {/* SECONDARY, AND SPELT LIKE ITS NEIGHBOUR.
+                It wore the navy fill — primary weight — for going to a screen,
+                while the page's actual primary action (Add Account) sits in the
+                header wearing the same navy. Two navy buttons on one page teach
+                that navy means "a button", which spends the one signal that
+                says "this is the thing to do here". P7 allows four roles and
+                this is the second: quiet outline, identical to Refresh feeds
+                beside it, because they are peers.
+                And "Bank Connections" was Title Case standing next to "Refresh
+                feeds" in sentence case — two spellings of one convention, 8px
+                apart. */}
+            <button
+              onClick={() => setBankConnectionsView('plain')}
+              className="w-full sm:w-auto justify-center px-3 py-1.5 text-sm font-medium rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors flex items-center gap-2"
+            >
+              <BankIcon size={16} />
+              Bank connections
+            </button>
+          </div>
         </div>
       </div>
 
@@ -1878,13 +2061,24 @@ export default function Accounts() {
           them is terrifying, so this one names how many accounts are still
           there, what is hiding them, and the control that gives them back.
           Search is the only thing on this page that hides a row: the group and
-          sort switches rearrange the list, and closed accounts have their own
-          section below rather than being filtered out of this one. */}
-      {!isLoading && isSearching && matchedTopLevelCount === 0 && openAccounts.length > 0 && (
+          sort switches rearrange the list.
+
+          "NOTHING MATCHED" HAS TO MEAN NOTHING MATCHED. The closed band is
+          searched now too, so a hit down there is a hit — printing this card
+          above it would be the page contradicting itself in the other
+          direction, which is how the contradiction was found in the first
+          place. Hence the closed-match gate.
+
+          And the count covers both populations, for the reason the count
+          exists: it is the promise that Clear filters gives them back, so it
+          has to count everything this search is holding — the top-level cards
+          in the list and the closed rows in the band beneath it. The figure and
+          the remedy describe the same set or neither is worth printing. */}
+      {!isLoading && isSearching && matchedTopLevelCount === 0 && matchedClosedAccounts.length === 0 && openAccounts.length > 0 && (
         <div className="bg-white dark:bg-gray-800 rounded-2xl shadow-lg border border-gray-100 dark:border-gray-700">
           <FilteredEmptyState
             title="No accounts match your search"
-            hiddenCount={topLevelAccounts.length}
+            hiddenCount={topLevelAccounts.length + closedAccounts.length}
             scope="of your accounts"
             filters={[`Search: ${accountSearch.trim()}`]}
             onClear={() => setAccountSearch('')}
@@ -1908,23 +2102,36 @@ export default function Accounts() {
         </div>
       )}
 
-      {/* Closed Accounts (Microsoft Money model: hidden, never deleted) */}
-      {closedAccounts.length > 0 && (
+      {/* Closed Accounts (Microsoft Money model: hidden, never deleted)
+
+          Gated on the SEARCHED list, and counted from it. With the box clear
+          the two are the same list and this section is exactly what it always
+          was; with a search running, the band is a band of results like every
+          other band on the page, and a search that matches nothing in the
+          archive leaves no archive on screen to contradict it.
+
+          Forced open while searching, for the reason the open bands ignore
+          their collapsed state while searching (see `displayedList`): a folded
+          section must not swallow a result somebody is actively looking for.
+          Here it would be worse than a fold — the band would be a closed door
+          with a count on it, and the count would be the only evidence the
+          search had found anything at all. */}
+      {matchedClosedAccounts.length > 0 && (
         <div className="mt-6 bg-white dark:bg-gray-800 rounded-2xl shadow-lg border border-gray-100 dark:border-gray-700 overflow-hidden">
           <button
             onClick={() => setShowClosedAccounts(prev => !prev)}
             className="w-full flex items-center justify-between px-4 py-3 text-left hover:bg-gray-50 dark:hover:bg-gray-750 transition-colors"
           >
             <span className="flex items-center gap-2 text-sm font-semibold text-gray-600 dark:text-gray-300">
-              {showClosedAccounts ? <ChevronDownIcon size={16} /> : <ChevronRightIcon size={16} />}
-              Closed Accounts ({closedAccounts.length})
+              {closedBandExpanded ? <ChevronDownIcon size={16} /> : <ChevronRightIcon size={16} />}
+              Closed Accounts ({matchedClosedAccounts.length})
             </span>
             <span className="text-xs text-gray-400 dark:text-gray-500">
               History preserved — reopen any time
             </span>
           </button>
 
-          {showClosedAccounts && (
+          {closedBandExpanded && (
             <div data-testid="closed-accounts" className="border-t border-gray-100 dark:border-gray-700">
               {/* Grouped exactly like the open list — both switches included,
                   so an institution sub-band nests here too — but kept quiet: a

--- a/src/pages/EnhancedImport.tsx
+++ b/src/pages/EnhancedImport.tsx
@@ -213,13 +213,13 @@ export default function EnhancedImport(): React.JSX.Element {
         {/* ── Automation ───────────────────────────────────────────── */}
         <Section
           title="Automation"
-          description="Rules that categorize and transform transactions as they come in."
+          description="Rules that categorise and transform transactions as they come in."
         >
           <div className="flex items-center justify-between gap-4">
             <p className="text-sm text-gray-600 dark:text-gray-400">
               {activeRules.length > 0
                 ? `${activeRules.length} active rule${activeRules.length === 1 ? '' : 's'} run on every import.`
-                : 'No import rules yet — create one to auto-categorize incoming transactions.'}
+                : 'No import rules yet — create one to auto-categorise incoming transactions.'}
             </p>
             <button
               onClick={() => setShowRulesManager(true)}

--- a/src/pages/Find.tsx
+++ b/src/pages/Find.tsx
@@ -13,6 +13,7 @@ import { SearchIcon, XIcon } from '../components/icons';
 import { transactionRowDomId } from '../components/transactionRowDomId';
 import { buildTransactionRegisterPath } from '../utils/transactionDeepLink';
 import { createCategoryLabeller } from '../utils/categoryLabel';
+import { UNCATEGORISED_LABEL } from '../utils/categoryNames';
 import { isMarkedAwaitingFinalize, isReconciled } from '../utils/transactionReconciliation';
 import { isAwaitingReview } from '../utils/transactionReview';
 import {
@@ -346,6 +347,13 @@ export default function Find(): React.JSX.Element {
             onChange={event => setText(event.target.value)}
             // autoFocus: this page has one job, and the user came here to type.
             autoFocus
+            // This box takes a description OR an amount, so the spell-checker
+            // is offered merchant names and "141.50" and has an opinion about
+            // both. A red underline under a search term reads as "you typed it
+            // wrong" at the exact moment the page is saying "nothing matched" —
+            // two accusations for one perfectly good query.
+            spellCheck={false}
+            autoCapitalize="none"
             placeholder="Find a description or an amount…"
             aria-label="Find transactions by description or amount"
             className="w-full pl-10 pr-4 py-2.5 rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 text-gray-900 dark:text-white placeholder-gray-500"
@@ -504,7 +512,7 @@ export default function Find(): React.JSX.Element {
                         {awaitingReview && <span className="sr-only"> — new, not reviewed yet</span>}
                       </td>
                       <td className="py-2 px-3 text-sm text-gray-600 dark:text-gray-400 hidden md:table-cell">
-                        {categoryLabel(transaction) || <span className="italic text-gray-400">Uncategorized</span>}
+                        {categoryLabel(transaction) || <span className="italic text-gray-400">{UNCATEGORISED_LABEL}</span>}
                       </td>
                       <td className={`py-2 pl-3 pr-4 text-sm text-right font-medium whitespace-nowrap ${isExpense ? 'text-red-600' : 'text-green-600'}`}>
                         {/* Accounting notation, as every other list here draws

--- a/src/pages/NetWorthReport.tsx
+++ b/src/pages/NetWorthReport.tsx
@@ -14,6 +14,8 @@ import {
 import { useApp } from '../contexts/AppContextSupabase';
 import { useCurrencyDecimal } from '../hooks/useCurrencyDecimal';
 import { Modal, ModalBody } from '../components/common/Modal';
+import NetWorthSummary from '../components/NetWorthSummary';
+import { singlePointDot } from '../components/charts/singlePointDots';
 import { toDecimal } from '../utils/decimal';
 import { formatDecimal } from '../utils/decimal-format';
 import { preserveDemoParam } from '../utils/navigation';
@@ -164,26 +166,39 @@ export default function NetWorthReport({ picker, focus }: ReportViewProps): Reac
   return (
     <div className="max-w-[1400px] mx-auto">
       {/* The period comes from the hub, so it persists between reports. */}
-      {/* Headline */}
-      <div className="grid grid-cols-1 md:grid-cols-3 gap-4 mb-6">
-        <div className="bg-[#1a2332] dark:bg-gray-700 rounded-2xl p-6 text-white">
-          <p className="text-xs text-white/60 uppercase tracking-wider font-medium">Net Worth {latest ? `— ${latest.label}` : ''}</p>
-          <p className="text-2xl font-bold mt-1">{latest ? formatCurrency(latest.netWorth) : '—'}</p>
-        </div>
-        <div className="bg-white dark:bg-gray-800 rounded-2xl p-6 border border-gray-100 dark:border-gray-700">
-          <p className="text-xs text-gray-500 uppercase tracking-wider font-medium">Change over period</p>
-          <p className={`text-2xl font-bold mt-1 ${change.greaterThanOrEqualTo(0) ? 'text-green-600 dark:text-green-400' : 'text-red-600'}`}>
+      {/*
+        THE SAME THREE FIGURES AS THE DASHBOARD AND THE ACCOUNTS LIST, SO THE
+        SAME CARD (PHONE_CAPTURES_REVIEW_2026-08-13 §4).
+
+        What used to be here was the navy slab plus two white cards that
+        NetWorthSummary was written to abolish — and opting out of the shared
+        card is not free. The dark-mode fault that card's comment documents was
+        found and fixed ONCE and reached all three surfaces that use it; this
+        page, which had copied the markup instead, was still carrying its own
+        version of the same class of bug: `text-red-600` with NO `dark:`
+        variant, so Liabilities rendered #dc2626 on the #1f2937 dark card. That
+        is the whole argument for sharing, and it is why the copy is gone.
+
+        The three magnitudes are navy in the shared card because none of them is
+        a direction of travel (RULINGS_ON_CAUSE_2026-08-13 §1). The CHANGE below
+        them is the exception that proves it: a delta is nothing BUT a direction
+        of travel, so it is the one figure on this page that keeps the semantic
+        colours — which is also what stops green and red here from being
+        decoration.
+      */}
+      <div className="mb-6 space-y-2">
+        <NetWorthSummary
+          netWorth={latest ? formatCurrency(latest.netWorth) : '—'}
+          assets={latest ? formatCurrency(latest.assets) : '—'}
+          liabilities={latest ? formatCurrency(latest.liabilities) : '—'}
+        />
+        <p className="text-body text-gray-600 dark:text-gray-400">
+          {latest ? <>As at <span className="font-medium text-gray-900 dark:text-gray-100">{latest.label}</span>. </> : null}
+          Change over the period{' '}
+          <span className={change.greaterThanOrEqualTo(0) ? 'font-medium text-green-600 dark:text-green-400' : 'font-medium text-red-600 dark:text-red-400'}>
             {change.greaterThanOrEqualTo(0) ? '+' : ''}{formatCurrency(change.toNumber())}
-          </p>
-        </div>
-        <div className="bg-white dark:bg-gray-800 rounded-2xl p-6 border border-gray-100 dark:border-gray-700">
-          <p className="text-xs text-gray-500 uppercase tracking-wider font-medium">Assets / Liabilities {latest ? `— ${latest.label}` : ''}</p>
-          <p className="text-lg font-semibold mt-1">
-            <span className="text-green-600 dark:text-green-400">{latest ? formatCurrency(latest.assets) : '—'}</span>
-            <span className="text-gray-400 mx-2">/</span>
-            <span className="text-red-600">{latest ? formatCurrency(latest.liabilities) : '—'}</span>
-          </p>
-        </div>
+          </span>.
+        </p>
       </div>
 
       {/* Opening-date caveat — shown right above the chart it qualifies, and
@@ -276,13 +291,13 @@ export default function NetWorthReport({ picker, focus }: ReportViewProps): Reac
                   // as context lines. Same data, same click-to-drill.
                   <Bar dataKey="netWorth" name="Net Worth" fill="#1a2332" radius={[3, 3, 0, 0]} cursor="pointer" />
                 ) : (
-                  <Line type="monotone" dataKey="netWorth" name="Net Worth" stroke="#1a2332" strokeWidth={2.5} dot={false} activeDot={{ r: 5 }} />
+                  <Line type="monotone" dataKey="netWorth" name="Net Worth" stroke="#1a2332" strokeWidth={2.5} dot={singlePointDot(snapshots, '#1a2332')} activeDot={{ r: 5 }} />
                 )}
                 {showDetail && (
-                  <Line type="monotone" dataKey="assets" name="Assets" stroke="#10B981" strokeWidth={1.5} dot={false} />
+                  <Line type="monotone" dataKey="assets" name="Assets" stroke="#10B981" strokeWidth={1.5} dot={singlePointDot(snapshots, '#10B981')} />
                 )}
                 {showDetail && (
-                  <Line type="monotone" dataKey="liabilities" name="Liabilities" stroke="#EF4444" strokeWidth={1.5} dot={false} />
+                  <Line type="monotone" dataKey="liabilities" name="Liabilities" stroke="#EF4444" strokeWidth={1.5} dot={singlePointDot(snapshots, '#EF4444')} />
                 )}
               </ComposedChart>
             </ResponsiveContainer>

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -91,7 +91,7 @@ export default function Settings() {
             "bullet" seven times. */}
         <ul className="mt-2 list-disc pl-5 space-y-1 text-body text-gray-500 dark:text-gray-400">
           <li>Account management and tracking</li>
-          <li>Transaction recording and categorization</li>
+          <li>Transaction recording and categorisation</li>
           <li>Budget planning and monitoring</li>
           <li>Investment portfolio tracking</li>
           <li>Financial goal setting</li>

--- a/src/pages/TaxPlanning.tsx
+++ b/src/pages/TaxPlanning.tsx
@@ -8,7 +8,7 @@ export default function TaxPlanningPage() {
     <PageWrapper 
       title="Tax Planning"
       rightContent={
-        <div className="cursor-pointer" title="Tax Planning & Optimization">
+        <div className="cursor-pointer" title="Tax Planning & Optimisation">
           <svg
             width="48"
             height="48"

--- a/src/pages/__tests__/Accounts.test.tsx
+++ b/src/pages/__tests__/Accounts.test.tsx
@@ -562,6 +562,100 @@ describe('Accounts page — closed accounts ordering', () => {
 });
 
 /**
+ * THE ARCHIVE OBEYS THE SEARCH.
+ *
+ * A phone capture caught the page saying "87 of your accounts are hidden by
+ * Search: …" with a live **Closed Accounts (110)** band directly beneath it —
+ * reporting that nothing matched while showing a group bigger than the count
+ * it had just quoted. The band was the one list on the page the search did not
+ * touch.
+ *
+ * The three facts below are the fix, and they are one rule seen from three
+ * sides: what is on screen is what matched.
+ */
+describe('Accounts page — the closed band obeys the search', () => {
+  const closedAccount = (id: string, name: string, type: Account['type']): Account => ({
+    id, name, type, balance: 0, currency: 'GBP', lastUpdated: new Date(),
+    openingBalance: 0, isActive: false,
+  });
+
+  const closed: Account[] = [
+    closedAccount('c1', 'Zephyr Current', 'current'),
+    closedAccount('c2', 'Nimbus Card', 'credit'),
+  ];
+
+  const searchFor = (term: string): void => {
+    fireEvent.change(screen.getByLabelText('Search accounts by name or institution'), {
+      target: { value: term },
+    });
+  };
+
+  beforeEach(() => {
+    localStorage.clear();
+    vi.spyOn(DataService, 'listClosedAccounts').mockResolvedValue(closed);
+  });
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('renders no closed band at all when the search matches nothing anywhere', async () => {
+    renderAccounts();
+    // Finding the band by its count waits out the async closed load, so the
+    // disappearance below is a real removal rather than a slow arrival.
+    await screen.findByRole('button', { name: /Closed Accounts \(2\)/ });
+
+    searchFor('quenchless ironmongery');
+
+    expect(screen.queryByRole('button', { name: /Closed Accounts/ })).not.toBeInTheDocument();
+    // …and THEN the page is allowed to say nothing matched.
+    expect(
+      screen.getByRole('heading', { level: 3, name: 'No accounts match your search' })
+    ).toBeInTheDocument();
+  });
+
+  it('still shows a closed account that matches, counting only what it shows', async () => {
+    renderAccounts();
+    await screen.findByRole('button', { name: /Closed Accounts \(2\)/ });
+
+    searchFor('zephyr');
+
+    // One of the two survived, and the heading says one — not two, and not the
+    // number in the database.
+    expect(screen.getByRole('button', { name: /Closed Accounts \(1\)/ })).toBeInTheDocument();
+    const closedSection = screen.getByTestId('closed-accounts');
+    expect(within(closedSection).getByText('Zephyr Current')).toBeInTheDocument();
+    expect(within(closedSection).queryByText('Nimbus Card')).not.toBeInTheDocument();
+  });
+
+  it('does not claim nothing matched while a closed match is on screen', async () => {
+    renderAccounts();
+    await screen.findByRole('button', { name: /Closed Accounts \(2\)/ });
+
+    // A term no OPEN account can match, that one CLOSED account does. The old
+    // gate looked only at the open list and would have printed the empty state
+    // directly above the band holding the hit.
+    searchFor('zephyr');
+
+    expect(
+      screen.queryByRole('heading', { name: 'No accounts match your search' })
+    ).not.toBeInTheDocument();
+  });
+
+  it('opens the archive while searching, so a fold cannot swallow the hit', async () => {
+    renderAccounts();
+    // The band starts folded — proved by the absence of its contents.
+    await screen.findByRole('button', { name: /Closed Accounts \(2\)/ });
+    expect(screen.queryByTestId('closed-accounts')).not.toBeInTheDocument();
+
+    searchFor('zephyr');
+
+    // No click: the search opened it. A closed door with a count on it would
+    // make the count the only evidence the search found anything.
+    expect(screen.getByTestId('closed-accounts')).toBeInTheDocument();
+  });
+});
+
+/**
  * Settings on a closed account, without reopening it. Reopen–edit–close was
  * three steps to check or correct one fact (its name, its opening date), so
  * every closed row carries its own settings button. The archive still stays an

--- a/src/pages/reports/IncomeSpendingOverTimeReport.tsx
+++ b/src/pages/reports/IncomeSpendingOverTimeReport.tsx
@@ -20,6 +20,8 @@ import ReportCumulativeToggle from '../../components/reports/ReportCumulativeTog
 import UncategorisedReviewBand from '../../components/reports/UncategorisedReviewBand';
 import { buildMonthlyTrend } from '../../utils/monthlyTrend';
 import { toCumulativeTrend } from '../../utils/cumulativeSeries';
+import { SEMANTIC_SERIES } from '../../components/charts/chartColors';
+import { singlePointDot } from '../../components/charts/singlePointDots';
 import { toDecimal } from '../../utils/decimal';
 import { formatDecimal } from '../../utils/decimal-format';
 import { useCumulativeReport } from '../../hooks/useCumulativeReport';
@@ -221,29 +223,29 @@ export default function IncomeSpendingOverTimeReport({ picker, focus }: ReportVi
                 />
                 <Legend />
                 {chartType === 'bar' ? (
-                  <Bar dataKey="income" name={incomeSeriesName} fill="#10B981" radius={[3, 3, 0, 0]} cursor="pointer" isAnimationActive={false} onClick={handlePointClick('income')} />
+                  <Bar dataKey="income" name={incomeSeriesName} fill={SEMANTIC_SERIES.income} radius={[3, 3, 0, 0]} cursor="pointer" isAnimationActive={false} onClick={handlePointClick('income')} />
                 ) : (
                   <Line
                     type="monotone"
                     dataKey="income"
                     name={incomeSeriesName}
-                    stroke="#10B981"
+                    stroke={SEMANTIC_SERIES.income}
                     strokeWidth={2}
-                    dot={false}
+                    dot={singlePointDot(series, SEMANTIC_SERIES.income)}
                     isAnimationActive={false}
                     activeDot={{ r: 6, cursor: 'pointer', onClick: handlePointClick('income') }}
                   />
                 )}
                 {chartType === 'bar' ? (
-                  <Bar dataKey="expenses" name={expenseSeriesName} fill="#EF4444" radius={[3, 3, 0, 0]} cursor="pointer" isAnimationActive={false} onClick={handlePointClick('expenses')} />
+                  <Bar dataKey="expenses" name={expenseSeriesName} fill={SEMANTIC_SERIES.expense} radius={[3, 3, 0, 0]} cursor="pointer" isAnimationActive={false} onClick={handlePointClick('expenses')} />
                 ) : (
                   <Line
                     type="monotone"
                     dataKey="expenses"
                     name={expenseSeriesName}
-                    stroke="#EF4444"
+                    stroke={SEMANTIC_SERIES.expense}
                     strokeWidth={2}
-                    dot={false}
+                    dot={singlePointDot(series, SEMANTIC_SERIES.expense)}
                     isAnimationActive={false}
                     activeDot={{ r: 6, cursor: 'pointer', onClick: handlePointClick('expenses') }}
                   />

--- a/src/pages/reports/PeriodComparisonReport.tsx
+++ b/src/pages/reports/PeriodComparisonReport.tsx
@@ -7,6 +7,7 @@ import ReportAccountMultiSelect from '../../components/reports/ReportAccountMult
 import ReportDrillModal, { type ReportDrillTarget } from '../../components/reports/ReportDrillModal';
 import ReportExportBar from '../../components/reports/ReportExportBar';
 import UncategorisedReviewBand from '../../components/reports/UncategorisedReviewBand';
+import { SEMANTIC_SERIES } from '../../components/charts/chartColors';
 import { computeIncomeExpense } from '../../utils/incomeExpense';
 import {
   buildPeriodComparison,
@@ -36,9 +37,14 @@ import { preferences } from '../../services/preferencesService';
 
 const BASIS_KEY = 'reportsComparisonBasis';
 
-/** The app's chart colours for the two sides of the money — as on every other report. */
-const INCOME_FILL = '#10B981';
-const EXPENSE_FILL = '#EF4444';
+/**
+ * The app's chart colours for the two sides of the money — as on every other
+ * report, and now literally so: these were a local pair of hexes that happened
+ * to match four other files, which is how a second definition of income and
+ * expense stays in step until the day it doesn't.
+ */
+const INCOME_FILL = SEMANTIC_SERIES.income;
+const EXPENSE_FILL = SEMANTIC_SERIES.expense;
 /** The comparison window is deliberately colourless: it is the yardstick, not the news. */
 const COMPARISON_FILL = '#94A3B8';
 

--- a/src/pages/reports/__tests__/PeriodComparisonReportChart.test.tsx
+++ b/src/pages/reports/__tests__/PeriodComparisonReportChart.test.tsx
@@ -7,6 +7,7 @@ import { ToastProvider } from '../../../contexts/ToastContext';
 import { usePeriod } from '../../../hooks/usePeriod';
 import { __setAppContextValue, __resetAppContextValue } from '../../../test/mocks/AppContextSupabase';
 import PeriodComparisonReport from '../PeriodComparisonReport';
+import { SEMANTIC_SERIES } from '../../../components/charts/chartColors';
 import type { Account, Category, Transaction } from '../../../types';
 
 /**
@@ -27,8 +28,11 @@ vi.mock('recharts', async importOriginal => {
   };
 });
 
-const INCOME_FILL = '#10B981';
-const EXPENSE_FILL = '#EF4444';
+// Read from the token module, not re-typed: a test that hard-codes the colour
+// it expects passes just as happily when the chart and the token sheet have
+// drifted apart, which is the failure this pair of tokens exists to stop.
+const INCOME_FILL = SEMANTIC_SERIES.income;
+const EXPENSE_FILL = SEMANTIC_SERIES.expense;
 const COMPARISON_FILL = '#94A3B8';
 
 const ACCOUNTS: Account[] = [

--- a/src/pages/settings/AuditLogs.tsx
+++ b/src/pages/settings/AuditLogs.tsx
@@ -269,6 +269,8 @@ export default function AuditLogs() {
                   value={filters.search}
                   onChange={(e) => handleFilterChange('search', e.target.value)}
                   placeholder="Search logs..."
+                  spellCheck={false}
+                  autoCapitalize="none"
                   className="w-full pl-9 pr-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-700 text-gray-900 dark:text-white"
                 />
               </div>

--- a/src/pages/settings/PayeeCleanup.tsx
+++ b/src/pages/settings/PayeeCleanup.tsx
@@ -878,6 +878,11 @@ export default function PayeeCleanup(): React.JSX.Element {
             }}
             placeholder="Search payees — try amazon, or interest"
             aria-label="Search payees"
+            // Raw payee strings off a bank feed are the least dictionary-like
+            // text in the app; this is the box most likely to be underlined
+            // end to end.
+            spellCheck={false}
+            autoCapitalize="none"
             className="w-full pl-9 pr-3 py-2 bg-white dark:bg-gray-900 border border-gray-300/50 dark:border-gray-600/50 rounded-xl focus:border-transparent dark:text-white"
           />
         </div>

--- a/src/services/exportService.ts
+++ b/src/services/exportService.ts
@@ -1,7 +1,7 @@
 import type { Transaction, Account, Category } from '../types';
 import type { PeriodKey } from '../hooks/usePeriod';
 import { formatDecimal } from '../utils/decimal-format';
-import { buildCategoryNameLookup } from '../utils/categoryNames';
+import { buildCategoryNameLookup, UNCATEGORISED_LABEL } from '../utils/categoryNames';
 import { createScopedLogger, type ScopedLogger } from '../loggers/scopedLogger';
 import { preferences } from './preferencesService';
 
@@ -381,7 +381,7 @@ export class ExportService {
           // Amounts are stored signed (expenses negative), so emit as-is — no per-type '-' prefix
           qifContent += `T${formatDecimal(transaction.amount, 2)}\n`;
           qifContent += `P${transaction.description || ''}\n`;
-          qifContent += `L${categoryName ? categoryName(transaction.category) : (transaction.category || 'Uncategorized')}\n`;
+          qifContent += `L${categoryName ? categoryName(transaction.category) : (transaction.category || UNCATEGORISED_LABEL)}\n`;
 
           if (transaction.notes) {
             qifContent += `M${transaction.notes}\n`;

--- a/src/utils/categoryNames.ts
+++ b/src/utils/categoryNames.ts
@@ -1,6 +1,20 @@
 import type { Category } from '../types';
 
 /**
+ * What a row with no category is CALLED, everywhere, in one place.
+ *
+ * It was written out by hand in each place that needed it, and the two halves
+ * of the app drifted into disagreeing about the spelling: this module and the
+ * payee reports said "Uncategorised", while CategoryContext's own path lookup,
+ * the category dropdown and the QIF export said "Uncategorized". Both were
+ * reachable from the same screen, so the app contradicted itself in the space
+ * of one page — under dates it prints dd/mm/yyyy and a currency it prints in
+ * pounds. A constant rather than a convention, because a convention is what
+ * just failed.
+ */
+export const UNCATEGORISED_LABEL = 'Uncategorised';
+
+/**
  * One definition of how a category is NAMED for display: "Parent : Child"
  * (the Money convention used across this app), with "Uncategorised" for a
  * missing or dangling id.
@@ -22,9 +36,9 @@ export function buildCategoryNameLookup(
 ): (id: string | null | undefined) => string {
   const byId = new Map(categories.map(c => [c.id, c]));
   return (id: string | null | undefined): string => {
-    if (!id) return 'Uncategorised';
+    if (!id) return UNCATEGORISED_LABEL;
     const category = byId.get(id);
-    if (!category) return 'Uncategorised';
+    if (!category) return UNCATEGORISED_LABEL;
     const parent = category.parentId ? byId.get(category.parentId) : undefined;
     // The top 'type' nodes ("Income"/"Expense") add nothing to a label.
     return parent && parent.level !== 'type' ? `${parent.name}${separator}${category.name}` : category.name;

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -56,6 +56,19 @@ export default {
         income: '#0a7d57', // 5.14:1 on #fff (was #0d9f6f, 3.38:1)
         'income-fill': '#0d9f6f', // chart series only
         expense: '#c9304a', // 5.24:1 on #fff (was #d94052, 4.37:1)
+        // The expense counterpart to income-fill, and the same story: the two
+        // colours the amounts RETIRED for failing the 4.5:1 text bar are
+        // exactly the two that clear the 3:1 bar a chart series owes, so the
+        // retired pair becomes the series pair rather than a third definition
+        // of income and expense (PHONE_CAPTURES_REVIEW_2026-08-13 §4).
+        // MEASURED with ColorContrastChecker, 2026-08-13, on all four surfaces
+        // a chart can sit on — a series colour is ONE hex for both themes, so
+        // unlike text it has to clear its bar on the dark card as well:
+        //   income-fill  #0d9f6f  3.38 / 3.21 / 4.34 / 5.24  ✓ (#fff, #f8f9fb, #1f2937, #111827)
+        //   expense-fill #d94052  4.37 / 4.15 / 3.36 / 4.06  ✓
+        // Both stay UNDER 4.5:1 on white: they are not text colours, and
+        // semantic-contrast.test.ts fails if either is promoted to one.
+        'expense-fill': '#d94052', // chart series only
         success: '#0a7d57',
         danger: '#c9304a',
         warning: '#e5a00d',


### PR DESCRIPTION
Three strands. Every claim below was measured in the running app or by a test, not inferred.

## 1. The card period control was invisible

The owner reported twice that he "cannot change the date viewings on the charts on the dashboard". The pins worked and the menu worked; the button that opens it was hidden until a mouse passed over the card — the same hover-reveal taken off the Accounts row actions two days ago, and worse here because there is no second route to it anywhere in the app.

Verified after the fix, without hovering: three controls found, all `opacity: 1`. Then the whole mechanism was exercised end to end — page on **All time**, each card pinned in turn:

| card | before | after |
|---|---|---|
| Income vs Expenses | ticks `May/Jun/Aug 2026` | `Jul 2026` (Last month) |
| Performance | two figures | both changed on This month |
| Net Worth Over Time | `31 May … 13 Aug` | `06–31 Jul` |

It survives a reload (page still All time, card still `pinned · Last month`) and it survives a Safari-shaped click — mousedown plus a `focusout` carrying a null `relatedTarget`, which is what Safari does when you click a button, since Safari does not focus one.

## 2. The phone

The Accounts control block was four stacked full-width cards: **228px**, about 40% of a 375px viewport, before a single account. A phone-only disclosure over the same DOM takes it to **110px**; the desktop row is byte-identically unaffected (trigger `display:none`).

The page could also say "no accounts match" and render **Closed Accounts (110)** directly beneath it. The closed band now obeys the same search predicate and its heading counts what is shown, so neither side of that contradiction can happen. Four tests, each falsified by reverting the thing it guards.

Spell-check and autocapitalise are off across every search, amount and reference field — 18 files; there was no prior convention in the repo.

## 3. Five design items

- **Chart series** read the token sheet instead of two hard-coded hexes in five files. Measured at the 3:1 graphics bar on **all four** surfaces, because a recharts colour is one hex for both themes with no `dark:` variant to fall back on.
- **Net worth report** joins the shared summary card. Not cosmetic: it carried `text-red-600` with no dark variant, so Liabilities was genuinely broken on the dark card — which is precisely the argument for sharing it.
- **The phone's tall empty state** had no min-height at all. Two bottom reservations were stacked, 96px of which was reserved for a nav bar that is not on screen above 767px. Measured on Find at 375×812: a 208px card followed by 248px of nothing.
- **The breadcrumb** repeated the title because it was labelled with the page you are on while linking to its parent — on `/find`, a control saying "Find" that takes you to the Dashboard. Now hidden on top-level routes and labelled with its destination on nested ones.
- **A line chart holding one point** drew a white speck. recharts does special-case the lone point, so the obvious `dot={data.length === 1}` would have shipped a pixel-identical card; it takes a dot config to put ink on the page.

## 4. One English

Every date this app prints is `dd/mm/yyyy` and `isUKDateFormat()` returns a literal `true` — there is no US edition to be consistent with, and no locale switch for spelling to follow. The copy disagreed anyway: "Uncategorised" in the payee reports and "Uncategorized" in the search results and the category dropdown, both reachable from one screen, plus Analyzing, Customize, Optimization and categorization elsewhere.

The label that had two spellings is now one constant, the rest are British, `index.html` declares `lang="en-GB"`, and a test reads the copy and fails on the next one. **It caught twelve real sites on its first run**, so it cannot pass by doing nothing. Identifiers are explicitly out of scope — `BulkCategorizeModal` and the `'uncategorized'` union member are names, and Stripe's `'canceled'` is an API value.

## Verification

lint clean · `typecheck:strict` clean · `test:smoke` **391 files / 6154 tests, zero failures** · `npm run build` 8826 modules · bundle **318.0 KB gz against a 320 KB budget** (tight — 6.6 KB up, worth watching) · `desktop:verify` PASS, 17/17 mount tests, within the ratchet · coverage 77.73% statements / 82.56% branches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)