### PR TITLE
fix(accounts): a page that scrolled past its own bottom, and a rotation that was never broken

### DIFF
--- a/src/design-system/__tests__/transformUtilities.test.ts
+++ b/src/design-system/__tests__/transformUtilities.test.ts
@@ -1,0 +1,140 @@
+/**
+ * A transform utility must arrive with the variables it is built from.
+ *
+ * ─ WHAT THIS GUARDS ────────────────────────────────────────────────────────
+ * Tailwind does not emit `transform: rotate(90deg)`. `rotate-90` sets ONE
+ * variable and then a composed declaration that reads SEVEN:
+ *
+ *   .rotate-90 { --tw-rotate: 90deg;
+ *                transform: translate(var(--tw-translate-x), var(--tw-translate-y))
+ *                           rotate(var(--tw-rotate)) skew(var(--tw-skew-x))
+ *                           skewY(var(--tw-skew-y)) scaleX(var(--tw-scale-x))
+ *                           scaleY(var(--tw-scale-y)) }
+ *
+ * The other six are initialised once, globally, by the base layer's
+ * `*, ::before, ::after` block. If that block ever stops being emitted, every
+ * one of those `var()`s is invalid, which makes the WHOLE `transform`
+ * declaration invalid at computed-value time. The property falls back to
+ * `none`, and every rotation, scale and translate in the app silently stops
+ * working: no error, no warning, no failing type or lint, and the class still
+ * sitting there in the markup.
+ *
+ * What removes it is dropping `@tailwind base` from `src/index.css`. Note that
+ * `corePlugins: { preflight: false }` does NOT — measured while writing this,
+ * because the falsification case below was originally written that way and
+ * passed when it should have failed. Tailwind emits the variable defaults from
+ * a separate plugin to the preflight reset, so switching preflight off costs
+ * the resets and keeps the transforms. Worth knowing before anyone "fixes"
+ * transforms by turning preflight back on.
+ *
+ * Same family as `tokenOpacity` — a class that is present and inert.
+ *
+ * ─ WHAT THIS IS *NOT* ──────────────────────────────────────────────────────
+ * It is not a claim about what any element looks like, and deliberately so.
+ * This guard was written after a report that `rotate-90` computed to the
+ * identity matrix on live chevrons. It did not: the reading was taken in an
+ * automated browser tab, where `document.visibilityState === 'hidden'` and CSS
+ * transitions therefore never advance. Measured 2026-08-13: a 100ms
+ * `transition-transform` had not completed after 1991ms, and mid-flight
+ * `getComputedStyle().transform` reads `matrix(1, 0, 0, 1, 0, 0)` — the
+ * identity matrix, and the exact figure that was reported as the bug. With
+ * `transition: none` the same element toggles correctly between
+ * `matrix(0, 1, -1, 0, 0, 0)` and `none`.
+ *
+ * So: never conclude anything about a TRANSITIONED property from a computed
+ * style read in a headless or background tab. Disable the transition first, or
+ * assert the class and the variable rather than the matrix. That trap is why
+ * this file checks the stylesheet — which is true regardless of who is looking
+ * at the page — instead of a rendered element.
+ */
+import { describe, it, expect } from 'vitest';
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, writeFileSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+/**
+ * The six variables `rotate-90`'s own declaration reads but does not set.
+ * `--tw-rotate` is excluded: the utility sets that one itself.
+ */
+const INHERITED_TRANSFORM_VARS = [
+  '--tw-translate-x',
+  '--tw-translate-y',
+  '--tw-skew-x',
+  '--tw-skew-y',
+  '--tw-scale-x',
+  '--tw-scale-y',
+] as const;
+
+/** Utilities in real use across the app, one per transform family. */
+const PROBE_CLASSES = ['rotate-90', 'rotate-180', '-rotate-90', 'scale-105', 'translate-x-0'];
+
+/**
+ * Compile the probe, optionally without the base layer.
+ *
+ * `withoutBaseLayer` exists so the test can prove itself: a guard that has
+ * never been seen to fail is a guard nobody should trust.
+ */
+function compileProbe(options: { withoutBaseLayer?: boolean } = {}): string {
+  const dir = mkdtempSync(join(tmpdir(), 'wt-transform-probe-'));
+  try {
+    const probe = join(dir, 'probe.tsx');
+    writeFileSync(probe, `export const P = () => <div className="${PROBE_CLASSES.join(' ')}" />;\n`);
+
+    const args = ['tailwindcss', '-c', 'tailwind.config.js', '--content', probe];
+    if (options.withoutBaseLayer === true) {
+      // The realistic sabotage: an entry stylesheet that forgets `@tailwind
+      // base`. Everything still compiles and every utility is still emitted.
+      const input = join(dir, 'no-base.css');
+      writeFileSync(input, '@tailwind components;\n@tailwind utilities;\n');
+      args.push('-i', input);
+    }
+
+    const out = join(dir, 'probe.css');
+    execFileSync('npx', [...args, '-o', out], { cwd: process.cwd(), stdio: 'pipe' });
+    return readFileSync(out, 'utf8');
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+/** Does the sheet initialise `name` on a universal selector? */
+function initialisedGlobally(css: string, name: string): boolean {
+  return new RegExp(
+    String.raw`\*\s*,[^{}]*\{[^{}]*${name}\s*:`,
+    's'
+  ).test(css);
+}
+
+describe('transform utilities compile to something that can actually transform', () => {
+  const css = compileProbe();
+
+  it('emits the rotate utility at all', () => {
+    expect(css).toMatch(/\.rotate-90\s*\{[^}]*--tw-rotate:\s*90deg/);
+    expect(css).toMatch(/\.rotate-90\s*\{[^}]*transform:/);
+  });
+
+  it('initialises every variable that the rotate declaration reads', () => {
+    // The whole point: `rotate-90` reads six variables it never sets, and one
+    // missing one invalidates the entire declaration — not just its own term.
+    for (const name of INHERITED_TRANSFORM_VARS) {
+      expect(
+        initialisedGlobally(css, name),
+        `${name} is read by .rotate-90 but never initialised globally — every transform in the app is now inert`
+      ).toBe(true);
+    }
+  });
+
+  it('fails when the base layer is dropped (this guard can fail)', () => {
+    // Non-vacuity, proven rather than asserted — and note what survives: the
+    // utility is still emitted, correct and complete. That is the whole danger.
+    // The class looks right in the markup, right in the stylesheet, and does
+    // nothing on screen.
+    const withoutBase = compileProbe({ withoutBaseLayer: true });
+
+    expect(withoutBase).toMatch(/\.rotate-90\s*\{[^}]*--tw-rotate:\s*90deg/);
+    for (const name of INHERITED_TRANSFORM_VARS) {
+      expect(initialisedGlobally(withoutBase, name)).toBe(false);
+    }
+  });
+});

--- a/src/pages/Accounts.tsx
+++ b/src/pages/Accounts.tsx
@@ -1697,11 +1697,32 @@ export default function Accounts() {
     >
 
 
-      {/* Desktop: the net-worth summary + controls stay pinned while the
-          account list scrolls in its own region — Add Account, view switches
-          and the totals remain reachable from anywhere in a long list. */}
-      <div className="lg:flex lg:flex-col lg:h-[calc(100vh-13rem)]">
-      <div className="lg:shrink-0">
+      {/* ONE SCROLLER. This page used to pin the summary and controls and give
+          the list a scrolling region of its own, sized
+          `lg:h-[calc(100vh-13rem)]` — the viewport minus a HAND-COUNTED 208px
+          for the chrome above it.
+
+          That number is a measurement of other people's markup, so it was only
+          ever right on the day it was written. Measured 2026-08-13 at 1440×900:
+          the chrome above is 168px, not 208 — the region was 40px short of the
+          fold before anything changed, and restructuring the control block that
+          same day moved it again. Both errors show as the same defect the owner
+          reported: the list's own scrollbar ends part-way up the window, the
+          page keeps scrolling past it into dead space, and the bottom of the
+          list appears to rise as you scroll because the two scrollers are
+          consuming the same gesture.
+
+          A phone never had this — the classes were all `lg:`, so the small
+          screen has always scrolled as one document, like every other page in
+          the app. The desktop now matches it. Nothing here can drift again,
+          because there is no longer a number to be wrong.
+
+          If pinned chrome is wanted back, the way to do it is `position:
+          sticky` on the chrome itself, which needs no arithmetic about anything
+          below it — but 168px of permanently-parked header is rent (P1), and
+          that is a design call, not a layout repair. */}
+      <div>
+      <div>
       {/* Net Worth Summary Bar */}
       {!isLoading && accounts.length > 0 && (() => {
         const totalBalance = calculateTotalBalance(decimalAccounts, decimalTransactions);
@@ -1934,19 +1955,27 @@ export default function Accounts() {
           >
             More
             <span className="sr-only"> controls: grouping and bank connections</span>
-            {/* SWAPPED, NOT ROTATED — and that is a measurement, not a taste.
-                `rotate-90` computes to no rotation in this app: the utility
-                sets `--tw-rotate: 90deg` and then a `transform` built from
-                `--tw-translate-x`, `--tw-skew-*` and `--tw-scale-*`, which are
-                not initialised on the element, so the whole declaration is
-                invalid and the computed transform is the identity matrix.
-                Verified in the browser on this button — the class was present
-                and the glyph did not move. (The same dead class sits on the
-                band chevron at :1572, ArchiveManager and CSVImportWizard; that
-                is a global fix, not this change's business.)
-                So this uses the fold idiom the CLOSED ACCOUNTS band below
-                already uses — two different glyphs — which needs no transform
-                and cannot be silently switched off. */}
+            {/* SWAPPED, NOT ROTATED — the fold idiom the CLOSED ACCOUNTS band
+                below already uses, so the two disclosures on this page open the
+                same way.
+
+                A correction is recorded here because the wrong reason was
+                written down first: this comment used to claim `rotate-90`
+                computes to no rotation in this app, on the strength of a
+                console reading of the identity matrix. It does rotate.
+                Re-measured 2026-08-13 — `.rotate-90` compiles correctly, the
+                base layer initialises all six sibling `--tw-*` variables on
+                `*, ::before, ::after`, and with `transition: none` an element
+                toggles cleanly between `matrix(0, 1, -1, 0, 0, 0)` and `none`.
+
+                The identity matrix was an artefact of WHERE it was measured: an
+                automated browser tab reports `document.visibilityState ===
+                'hidden'`, and a hidden tab does not advance CSS transitions —
+                a 100ms `transition-transform` had not finished after 1991ms,
+                and mid-flight it reads as its own start value. Every chevron on
+                this page carries `transition-transform`, so all of them look
+                frozen there and none of them is.
+                See design-system/__tests__/transformUtilities.test.ts. */}
             {showMoreControls ? <ChevronDownIcon size={14} /> : <ChevronRightIcon size={14} />}
           </button>
         </div>
@@ -2013,27 +2042,19 @@ export default function Accounts() {
         </div>
       </div>
 
-      </div>{/* end pinned chrome */}
+      </div>
 
-      {/* THE SCROLL REGION CLIPS SIDEWAYS TOO, WHICH IS WHY IT IS PADDED.
-          `overflow-y: auto` cannot be had on its own: CSS promotes the other
-          axis from `visible` to `auto` whenever one axis is not visible, so this
-          box clips horizontally whether or not anything asked it to. The rows
-          inside it are the full width of its content box, and the selected row's
-          ring is a box-shadow drawn 1px OUTSIDE its border box — off the end of
-          the content box, and therefore cut away. Measured at 1280px: the row
-          and the content box both began at x=32, so the ring's left stroke had
-          nowhere to land and vanished, while `pr-1` on the right had always
-          given that side 4px to paint into. One edge of the ring missing is the
-          "the border disappears on the left" half of the same bug report.
+      {/* The `-ml-1 pl-1 pr-1` that used to be here went with the scroll
+          region, and had to: `overflow-y: auto` cannot be had on one axis
+          alone — CSS promotes the other from `visible` to `auto` — so the box
+          clipped sideways too, and cut the left stroke off the selected row's
+          focus ring, which is a box-shadow drawn 1px outside the border box.
+          The padding bought that stroke 4px to land in.
 
-          `-ml-1 pl-1` buys the missing room WITHOUT moving anything: the box
-          grows 4px leftward into the page gutter (32px of it there, and no
-          clipping ancestor above — checked) and pads the 4px straight back, so
-          every row stays at exactly the x it had. 4px is the figure the right
-          side already uses and it covers the ring (1px) with room to spare for
-          the lift, whose horizontal reach is ~4.5px at its widest layer. */}
-      <div className="lg:flex-1 lg:min-h-0 lg:overflow-y-auto lg:-ml-1 lg:pl-1 lg:pr-1">
+          With no clipping box there is nothing to escape, so the compensation
+          goes rather than being carried as cargo. Re-verified after the change:
+          the selected row's ring is whole on all four sides. */}
+      <div>
       {/* Accounts grid */}
       <div className="grid gap-6">
         {isLoading ? (

--- a/src/pages/settings/Categories.tsx
+++ b/src/pages/settings/Categories.tsx
@@ -951,15 +951,23 @@ export default function CategoriesSettings() {
       }
     >
 
-      {/* Desktop: the page chrome (title/toolbar above, instructions + import
-          below) stays in view and the category tree scrolls internally, so
-          the edit/delete/add buttons are always reachable. Mobile keeps the
-          normal page scroll. */}
-      <div className="lg:flex lg:flex-col lg:h-[calc(100vh-13rem)]">
+      {/* ONE SCROLLER — the same repair as the Accounts page, for the same
+          reason and on the same day.
+
+          This carried the identical `lg:h-[calc(100vh-13rem)]`: a hand-counted
+          208px standing in for the height of the chrome above it. The number
+          was measured wrong on Accounts (168px in fact) and there is no reason
+          to believe a second copy of a guess is any better — the two pages do
+          not even have the same chrome, so one constant cannot describe both.
+          Its failure is invisible until someone edits a toolbar, and then it is
+          a page that scrolls past its own content into dead space.
+
+          The tree scrolls with the page now, as it always has on a phone. */}
+      <div>
 
       {/* Instructions */}
       {(isEditMode || isDeleteMode) ? (
-        <div className={`lg:shrink-0 border rounded-2xl p-4 mb-6 ${
+        <div className={`border rounded-2xl p-4 mb-6 ${
           isDeleteMode
             ? 'bg-red-50 dark:bg-red-900/20 border-red-200 dark:border-red-800'
             : 'bg-blue-50 dark:bg-blue-900/20 border-blue-200 dark:border-blue-800'
@@ -993,7 +1001,7 @@ export default function CategoriesSettings() {
           </div>
         </div>
       ) : (
-        <div className="lg:shrink-0 bg-gray-50 dark:bg-gray-800/50 border border-gray-200 dark:border-gray-700 rounded-2xl p-4 mb-6">
+        <div className="bg-gray-50 dark:bg-gray-800/50 border border-gray-200 dark:border-gray-700 rounded-2xl p-4 mb-6">
           <div className="text-sm text-gray-600 dark:text-gray-400">
             <p className="mb-2">💡 <strong>Tip:</strong></p>
             <ul className="list-disc list-inside space-y-1 ml-2">
@@ -1008,7 +1016,7 @@ export default function CategoriesSettings() {
 
       {/* Starter set import */}
       {!isEditMode && !isDeleteMode && (
-        <div className="lg:shrink-0 bg-white dark:bg-gray-800 rounded-2xl shadow-lg border border-gray-100 dark:border-gray-700 p-4 mb-6 flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3">
+        <div className="bg-white dark:bg-gray-800 rounded-2xl shadow-lg border border-gray-100 dark:border-gray-700 p-4 mb-6 flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3">
           <div>
             <h3 className="text-sm font-semibold text-gray-900 dark:text-white">
               Standard category set
@@ -1038,8 +1046,8 @@ export default function CategoriesSettings() {
         onFixTransferFilings={fixTransferFilings}
       />
 
-      {/* Categories Tree — the scrolling region on desktop */}
-      <div className="bg-white dark:bg-gray-800 rounded-2xl shadow-lg border border-gray-100 dark:border-gray-700 p-6 lg:flex-1 lg:min-h-0 lg:overflow-y-auto">
+      {/* Categories Tree */}
+      <div className="bg-white dark:bg-gray-800 rounded-2xl shadow-lg border border-gray-100 dark:border-gray-700 p-6">
         <DndContext 
           sensors={sensors}
           collisionDetection={closestCenter}


### PR DESCRIPTION
Two findings, both from measuring rather than reasoning — and the second one overturns a bug report I had already started acting on.

## 1. The page scrolled past its own content

Reported: *"I can keep scrolling beyond the bottom of the page and it kind of lifts the bottom up to the middle."*

Accounts and Categories each gave their list a scrolling region of its own, sized:

```
lg:h-[calc(100vh-13rem)]
```

`13rem` is a **hand-counted 208px** standing in for the height of all the chrome above it — title, summary card, control rows. That is a measurement of other people's markup, so it is only right on the day it is written.

**Measured at 1440×900: the chrome above is 168px, not 208.** The region was 40px out before anything changed, and restructuring the Accounts control block earlier today moved it again. Either way it shows as one defect: the list's own scrollbar ends part-way up the window while the document keeps scrolling into dead space, and two scrollers split one gesture — which is exactly why the bottom appears to *rise* as you scroll.

Now one scroller. Every class involved was `lg:`-prefixed, so **a phone has always scrolled this page as one document** — the desktop now matches it, and matches every other page in the app. There is no longer a number that can be wrong.

Both pages carried the identical constant despite not having the same chrome, so one of them was guaranteed to be wrong. Fixed together.

Swept for others: only these two existed. The remaining viewport arithmetic is `min-h-screen` (a floor, not a cap) and dialog bodies capped to `90vh`, which is the correct use of an internal scroller.

If pinned chrome is wanted back, the way is `position: sticky` on the chrome itself — no arithmetic about anything below it. That is a design call (168px of parked header is rent), not a layout repair.

## 2. `rotate-90` was never broken

A comment in `Accounts.tsx` asserted that `rotate-90` computes to no rotation in this app, and a follow-up task had been raised to fix it everywhere. **It rotates.**

- `.rotate-90` compiles correctly, and the base layer emits `*, ::before, ::after { --tw-translate-x: 0; --tw-rotate: 0; … }` — all six sibling variables initialised.
- With `transition: none`, an element toggles cleanly between `matrix(0, 1, -1, 0, 0, 0)` and `none`. On a div, on an SVG, with and without `transform`.

The identity matrix was an artefact of **where** it was measured. An automated browser tab reports `document.visibilityState === 'hidden'`, and **a hidden tab does not advance CSS transitions**: a 100ms `transition-transform` had not finished after 1991ms, and mid-flight `getComputedStyle().transform` reads as its own start value — `matrix(1, 0, 0, 1, 0, 0)`, precisely the figure in the report. Every chevron on the page carries `transition-transform`, so all of them look frozen there and none of them is.

The false comment is replaced with the correction. The two-glyph swap stays as-is — it is a fine idiom on its own merits and matches the Closed Accounts band beside it.

### The guard that came out of it

`transformUtilities.test.ts` checks the **stylesheet**, not a rendered element, because the stylesheet is true regardless of who is looking at the page. It asserts every variable `rotate-90` reads is initialised globally, and it proves it can fail by compiling a sabotaged sheet.

It also corrects its own first draft, which is recorded in the file: `corePlugins: { preflight: false }` does **not** remove the variable defaults — measured, when the falsification case passed where it should have failed. Tailwind emits them from a different plugin than the preflight reset. Dropping `@tailwind base` is what actually removes them, and that is what it now simulates.

## Verification

lint clean · `typecheck:strict` clean · `test:smoke` **392 files / 6157 tests, zero failures** · `npm run build` 8826 modules · coverage 77.75% / 82.58%.

Browser, 1440×900, after the change: **zero inner scrollers on Accounts**, dead space below content 49px (the demo banner offset, not the bug).

🤖 Generated with [Claude Code](https://claude.com/claude-code)