### PR TITLE
fix(dashboard): the per-card pin never fired on Safari, and now takes a custom range

### DIFF
--- a/src/components/dashboard/ImprovedDashboard.tsx
+++ b/src/components/dashboard/ImprovedDashboard.tsx
@@ -488,7 +488,7 @@ export function ImprovedDashboard() {
           )}
           <CardPeriodControl
             cardLabel="Performance"
-            period={performancePeriod.period}
+            picker={performancePeriod}
             pin={performanceCard.pin}
           />
         </div>

--- a/src/components/dashboard/reportWidgets/CardPeriodControl.tsx
+++ b/src/components/dashboard/reportWidgets/CardPeriodControl.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useId, useRef, useState } from 'react';
 import { CalendarIcon } from '../../icons';
-import { PERIOD_LABELS, type PeriodKey } from '../../../hooks/usePeriod';
+import DatePicker from '../../common/DatePicker';
+import { PERIOD_LABELS, type PeriodKey, type UsePeriodResult } from '../../../hooks/usePeriod';
 import type { CardPeriodPin } from '../../../hooks/useCardPeriod';
 
 /**
@@ -23,13 +24,25 @@ import type { CardPeriodPin } from '../../../hooks/useCardPeriod';
  * Beside it, the release — one tap, named for what it does rather than for
  * undoing what was done.
  *
- * ── WHY THE MENU OFFERS NO CUSTOM RANGE ─────────────────────────────────────
+ * ── THE CUSTOM RANGE ────────────────────────────────────────────────────────
  *
- * Five windows, not the bar's six. A custom range is a statement about what the
- * whole page is being read over and comes with two date fields to say it; a pin
- * is the narrower claim *"this lens wants a different standard window from that
- * one"*. Nothing stops the page bar from being set to a custom range — a pinned
- * card simply cannot be the thing that asks for one.
+ * All six windows, including Custom — which this deliberately did NOT offer at
+ * first, on the reasoning that a custom range is a statement about what the
+ * whole page is being read over, while a pin is the narrower claim "this lens
+ * wants a different standard window from that one".
+ *
+ * The owner asked for it, and the argument does not survive his use of it: he
+ * reads net worth over all time and one flow chart over a quarter he cares
+ * about, and "a quarter he cares about" is not one of the five standard
+ * windows. A card that can hold any window except the one you want is a card
+ * that sends you back to the page bar, which moves every OTHER card too — the
+ * exact problem the pin exists to solve.
+ *
+ * The two date fields live in the menu rather than on the card face, because
+ * the card face is a subtitle row with a chart under it and no room for a pair
+ * of inputs. Choosing Custom therefore does not close the menu: the choice is
+ * not finished until the dates are in, and closing on the click would ask the
+ * user to reopen the menu to complete what they just started.
  */
 
 /** The windows a card can be pinned to, in the page bar's own order. */
@@ -39,6 +52,7 @@ const PINNABLE_PERIODS: PeriodKey[] = [
   'tax-year',
   'last-12-months',
   'all',
+  'custom',
 ];
 
 /**
@@ -60,13 +74,19 @@ const PINNABLE_PERIODS: PeriodKey[] = [
  */
 const QUIET_AT_REST = 'transition-opacity duration-state';
 
-export default function CardPeriodControl({ cardLabel, period, pin }: {
+export default function CardPeriodControl({ cardLabel, picker, pin }: {
   /** What this control governs, for anyone who cannot see which card it is on. */
   cardLabel: string;
-  /** The window the card is on right now — the page's, or its own. */
-  period: PeriodKey;
+  /**
+   * The window the card is read over — the page's picker when it follows, its
+   * own when pinned. The WHOLE picker rather than just the key, because a
+   * custom range is two dates as well as a name, and the control that offers
+   * Custom has to be the control that can set them.
+   */
+  picker: UsePeriodResult;
   pin: CardPeriodPin;
 }): React.JSX.Element {
+  const { period, customStart, customEnd, setCustomStart, setCustomEnd } = picker;
   const [open, setOpen] = useState(false);
   const containerRef = useRef<HTMLDivElement>(null);
   const triggerRef = useRef<HTMLButtonElement>(null);
@@ -97,7 +117,9 @@ export default function CardPeriodControl({ cardLabel, period, pin }: {
 
   const choose = (key: PeriodKey): void => {
     pin.pinTo(key);
-    close();
+    // Custom is not finished at the click — its two dates are in the panel
+    // below, so the panel stays. Every other window is complete on choosing.
+    if (key !== 'custom') close();
   };
 
   return (
@@ -113,9 +135,31 @@ export default function CardPeriodControl({ cardLabel, period, pin }: {
         }
       }}
       onBlur={(event) => {
-        // Tabbing out dismisses; a click on the menu's own padding blurs to
-        // nothing at all, and must NOT.
+        /**
+         * Tabbing out dismisses. A CLICK MUST NOT — and on Safari that is the
+         * same event.
+         *
+         * THE BUG THIS FIXES, because it cost the owner two days of a feature
+         * that looked completely finished: Safari (macOS and iOS) does not
+         * focus a `<button>` when you click it. WebKit follows the platform
+         * convention that only text fields take focus from a click. So a
+         * mousedown on one of the menu items below moves focus off the item
+         * this effect just focused and onto `<body>` — and `document.body` is
+         * a `Node` that this container does not contain. The old test passed,
+         * the menu closed on MOUSEDOWN, React unmounted the item, and the
+         * `click` that followed landed on nothing. Every period in the menu was
+         * unselectable: the menu opened, dismissed itself, and the chart never
+         * moved. Chromium focuses clicked buttons, so it worked perfectly in
+         * every browser we had automated — which is exactly why it survived.
+         *
+         * `relatedTarget` of `body` means "focus went nowhere", which is a
+         * click, not a departure. Genuine departures — Tab, or a click landing
+         * on some other control — name that control, and still close. A click
+         * on empty space outside is caught by the mousedown listener above,
+         * which is where outside-clicks were always handled anyway.
+         */
         const next = event.relatedTarget;
+        if (next === null || next === document.body) return;
         if (next instanceof Node && !containerRef.current?.contains(next)) setOpen(false);
       }}
     >
@@ -185,6 +229,43 @@ export default function CardPeriodControl({ cardLabel, period, pin }: {
               {PERIOD_LABELS[key]}
             </button>
           ))}
+
+          {pin.isPinned && period === 'custom' && (
+            /* The dates for the window just chosen. Inside the menu because the
+               card face has a chart under it and nowhere to put a pair of
+               inputs; under a rule because they answer the choice above rather
+               than being a sixth choice beside it.
+
+               `DatePicker` rather than a bare `type="date"`: a native date
+               input renders in the BROWSER's locale, and this app is dd/mm/yyyy
+               throughout regardless of what machine it is on. Same component,
+               same reason, as the page bar's own custom range. */
+            <div className="mt-1 border-t border-line dark:border-gray-700 px-3 pb-2 pt-2">
+              <div className="flex items-center gap-2">
+                <div className="w-32">
+                  <DatePicker
+                    size="sm"
+                    value={customStart}
+                    onChange={setCustomStart}
+                    aria-label={`${cardLabel}: custom period start date`}
+                    className="text-sm rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 text-gray-900 dark:text-white"
+                  />
+                </div>
+                <span className="text-label text-gray-500 dark:text-gray-400">to</span>
+                <div className="w-32">
+                  <DatePicker
+                    size="sm"
+                    value={customEnd}
+                    onChange={setCustomEnd}
+                    aria-label={`${cardLabel}: custom period end date`}
+                    className="text-sm rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 text-gray-900 dark:text-white"
+                  />
+                </div>
+              </div>
+              {/* An unbounded end is a real answer ("from March onwards"), so
+                  neither field is required and neither is nagged about. */}
+            </div>
+          )}
         </div>
       )}
     </div>

--- a/src/components/dashboard/reportWidgets/DashboardReportWidgets.test.tsx
+++ b/src/components/dashboard/reportWidgets/DashboardReportWidgets.test.tsx
@@ -212,11 +212,98 @@ describe('a report card’s period pin', () => {
     const menu = screen.getByRole('menu', { name: 'Window for Expense Categories' });
     expect(within(menu).getByRole('menuitemradio', { name: 'Tax year' }))
       .toHaveAttribute('aria-checked', 'true');
-    // A custom range is a statement about a whole page, and comes with two date
-    // fields to make it. A pin is the narrower claim that this lens wants a
-    // different STANDARD window.
-    expect(within(menu).queryByRole('menuitemradio', { name: 'Custom' })).toBeNull();
-    expect(within(menu).getAllByRole('menuitemradio')).toHaveLength(5);
+    // All SIX windows, Custom included. This asserted the opposite until
+    // 2026-08-13, on the reasoning that a custom range is a statement about a
+    // whole page while a pin is the narrower claim that one lens wants a
+    // different STANDARD window. The owner asked for it, and his use of the
+    // feature is the counter-argument: the window he wants for one flow chart
+    // is a particular quarter, which is not one of the five — so a card that
+    // could hold any window except that one sent him back to the page bar,
+    // moving every other card with it.
+    expect(within(menu).getByRole('menuitemradio', { name: 'Custom' })).toBeInTheDocument();
+    expect(within(menu).getAllByRole('menuitemradio')).toHaveLength(6);
+  });
+
+  it('asks for the two dates when Custom is chosen, and keeps the menu open to take them', () => {
+    // Choosing Custom is not a finished choice: the window it names does not
+    // exist until the dates do. Closing on the click would ask the user to
+    // reopen the menu to complete what they had just started.
+    const setCustomStart = vi.fn();
+    render(
+      <NetWorthWidget
+        picker={pickerOn('custom')}
+        pin={pinned({ pinTo: vi.fn() })}
+      />
+    );
+
+    fireEvent.click(screen.getByRole('button', {
+      name: 'Net Worth Over Time: pinned to Custom. Choose a different period for this card',
+    }));
+
+    const menu = screen.getByRole('menu', { name: 'Window for Net Worth Over Time' });
+    expect(within(menu).getByLabelText('Net Worth Over Time: custom period start date')).toBeInTheDocument();
+    expect(within(menu).getByLabelText('Net Worth Over Time: custom period end date')).toBeInTheDocument();
+    expect(setCustomStart).not.toHaveBeenCalled();
+  });
+
+  /**
+   * THE BUG THAT MADE THE WHOLE FEATURE INERT ON SAFARI.
+   *
+   * Safari does not focus a `<button>` when you click it — WebKit follows the
+   * platform convention that only text fields take focus from a click. So a
+   * mousedown on a menu item moved focus to `<body>`, the container's blur
+   * handler saw a `Node` it did not contain, closed the menu on MOUSEDOWN, and
+   * the `click` that followed landed on an element React had already removed.
+   *
+   * Every window in the menu was unselectable. The owner reported it as "the
+   * pin options are genuinely not doing anything", and he was exactly right.
+   * Chromium focuses clicked buttons, so it worked in every browser we could
+   * automate — which is why it shipped and why these two tests exist: they
+   * describe the focus behaviour rather than a browser, so they hold whichever
+   * engine is doing the clicking.
+   */
+  it('stays open when focus falls to the body — that is a click, not a departure', () => {
+    render(<NetWorthWidget picker={pickerOn('all')} pin={pinned()} />);
+
+    fireEvent.click(screen.getByRole('button', {
+      name: 'Net Worth Over Time: pinned to All time. Choose a different period for this card',
+    }));
+    const menu = screen.getByRole('menu', { name: 'Window for Net Worth Over Time' });
+
+    fireEvent.focusOut(menu, { relatedTarget: document.body });
+
+    expect(screen.getByRole('menu', { name: 'Window for Net Worth Over Time' })).toBeInTheDocument();
+    expect(within(menu).getByRole('menuitemradio', { name: 'Tax year' })).toBeInTheDocument();
+  });
+
+  it('still closes when focus genuinely leaves for another control', () => {
+    // The other half of the same rule: naming a real destination outside the
+    // container is a departure, and must still dismiss. Without this, the fix
+    // above could be "never close" and pass.
+    const outside = document.createElement('button');
+    document.body.appendChild(outside);
+
+    render(<NetWorthWidget picker={pickerOn('all')} pin={pinned()} />);
+    fireEvent.click(screen.getByRole('button', {
+      name: 'Net Worth Over Time: pinned to All time. Choose a different period for this card',
+    }));
+    const menu = screen.getByRole('menu', { name: 'Window for Net Worth Over Time' });
+
+    fireEvent.focusOut(menu, { relatedTarget: outside });
+
+    expect(screen.queryByRole('menu', { name: 'Window for Net Worth Over Time' })).toBeNull();
+    outside.remove();
+  });
+
+  it('offers no date fields for a window that needs none', () => {
+    render(<NetWorthWidget picker={pickerOn('tax-year')} pin={pinned()} />);
+
+    fireEvent.click(screen.getByRole('button', {
+      name: 'Net Worth Over Time: pinned to Tax year. Choose a different period for this card',
+    }));
+
+    const menu = screen.getByRole('menu', { name: 'Window for Net Worth Over Time' });
+    expect(within(menu).queryByLabelText('Net Worth Over Time: custom period start date')).toBeNull();
   });
 
   it('pins to the window that was picked, and releases on one tap', () => {

--- a/src/components/dashboard/reportWidgets/DashboardReportWidgets.tsx
+++ b/src/components/dashboard/reportWidgets/DashboardReportWidgets.tsx
@@ -99,7 +99,7 @@ export function NetWorthWidget({ picker, pin }: {
           <span className="min-w-0 text-xl font-bold text-gray-900 dark:text-white truncate">
             {latest ? formatCurrency(latest.netWorth) : '—'}
           </span>
-          {pin && <CardPeriodControl cardLabel={NET_WORTH_TITLE} period={picker.period} pin={pin} />}
+          {pin && <CardPeriodControl cardLabel={NET_WORTH_TITLE} picker={picker} pin={pin} />}
         </>
       }
       onOpen={() => open()}
@@ -168,7 +168,7 @@ export function IncomeExpenseTrendWidget({ picker, pin }: {
           <span className="min-w-0 text-xs text-gray-500 dark:text-gray-400 truncate">
             Month by month, what came in against what went out
           </span>
-          {pin && <CardPeriodControl cardLabel={INCOME_EXPENSE_TITLE} period={picker.period} pin={pin} />}
+          {pin && <CardPeriodControl cardLabel={INCOME_EXPENSE_TITLE} picker={picker} pin={pin} />}
         </>
       }
       onOpen={() => open()}
@@ -240,7 +240,7 @@ export function ExpenseCategoriesWidget({ picker, pin }: {
           <span className="min-w-0 text-xs text-gray-500 dark:text-gray-400 truncate">
             Where the money went, biggest first
           </span>
-          {pin && <CardPeriodControl cardLabel={EXPENSE_CATEGORIES_TITLE} period={picker.period} pin={pin} />}
+          {pin && <CardPeriodControl cardLabel={EXPENSE_CATEGORIES_TITLE} picker={picker} pin={pin} />}
         </>
       }
       onOpen={() => open()}


### PR DESCRIPTION
> "The pin options are genuinely not doing anything. The global view is the only one that works."

He was right, and I had verified the opposite four times. Worth recording why, because the harness could not see it.

## The bug

**Safari does not focus a `<button>` when you click it.** WebKit follows the platform convention that only text fields take focus from a click. So mousedown on a menu item moved focus to `<body>`, and the menu's blur handler said:

```js
if (next instanceof Node && !containerRef.current?.contains(next)) setOpen(false);
```

`document.body` is a `Node`, and the container does not contain it. The menu closed on **mousedown**, React removed the item, and the `click` that followed landed on nothing. Every window in the menu was unselectable; the card silently went on following the page.

The detail in the screenshots that identified it: the control never showed **"pinned · …"**, only the calendar glyph. That meant `isPinned` was never becoming true — so the failure was upstream of all the period logic I had been reading.

**Chromium focuses clicked buttons.** That is the whole reason this shipped: it worked in demo mode, at three viewports, across all five windows, after a reload, and under a synthetic mousedown carrying `relatedTarget: null` — which was already guarded. `body` is the same event wearing a different hat.

Reproduced by dispatching `focusout` with `relatedTarget: document.body`: menu gone on mousedown, item out of the DOM, label unchanged. With the fix: menu survives, item present, label moves `All time` → `Tax year`.

Focus landing on nothing is a **click**. A departure names a real destination, and still dismisses — the outside-click case was always the document `mousedown` listener's job anyway.

## Two tests, one falsified

`stays open when focus falls to the body` and `still closes when focus genuinely leaves for another control`. The second exists so the first cannot be satisfied by "never close". Reverting the fix fails the first — checked, not assumed.

They describe focus behaviour rather than a browser, so they hold whichever engine does the clicking.

## The custom range

The menu offered five windows and argued in its own comment that a custom range is a statement about a whole page while a pin is the narrower claim that one lens wants a different *standard* window.

His use of it is the counter-argument: the window he wants for one flow chart is a particular quarter. A card that can hold any window except the one you want sends you back to the page bar — which moves every other card with it, the exact problem the pin exists to solve.

Six windows now. **Choosing Custom keeps the menu open**, because the choice is not finished until its two dates are; closing on the click would ask him to reopen the menu to finish what he had just started. The fields are `DatePicker`, not a native `type="date"` — a native date input renders in the *browser's* locale and this app is dd/mm/yyyy throughout.

Verified end to end in the running app: `01/06/2026`–`30/06/2026` narrows that card to **Jun 2026 alone**, the bounds persist under the card's own keys (`…CustomStart` / `…CustomEnd`, already in the pin's key set, so releasing still cleans up), and the one-month window draws as **two solid marks** rather than an empty chart — the single-point fix from earlier today composing with this one.

## Verification

lint clean · `typecheck:strict` clean · `test:smoke` **392 files / 6161 tests, zero failures** · `npm run build` 8826 modules · dashboard suites 44/44.

🤖 Generated with [Claude Code](https://claude.com/claude-code)