### PR TITLE
fix(pwa): pull down to refresh an installed app — and a keyframe that was moving every spinner

### DIFF
--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -26,6 +26,7 @@ import { SidebarLink, TopNavItem, TopNavDropdown } from './layout/NavComponents'
 import { usePreferences } from '../contexts/PreferencesContext';
 import { PageTransition, NavigationProgress } from './layout/SimplePageTransition';
 import { EnhancedSkipLinks, FocusIndicator, RouteAnnouncer } from './layout/AccessibilityImprovements';
+import PullToRefreshIndicator from './PullToRefreshIndicator';
 import OfflineIndicator from './OfflineIndicator';
 import { OfflineStatus } from './OfflineStatus';
 import { SyncConflictResolver } from './SyncConflictResolver';
@@ -274,6 +275,10 @@ export default function Layout(): React.JSX.Element {
           sign-in / daily at a set time — the schedule lives in Settings, and
           signed-out sessions do nothing); on a device there is no feed. */}
       <BackgroundWork />
+      {/* Only draws during a pull, and only in an installed app — a browser tab
+          has Safari's own. It is here rather than per-page because the gesture
+          is about the DOCUMENT, which every page shares. */}
+      <PullToRefreshIndicator />
       <DemoBanner />
       <EnhancedSkipLinks />
       <FocusIndicator />

--- a/src/components/PullToRefreshIndicator.tsx
+++ b/src/components/PullToRefreshIndicator.tsx
@@ -1,0 +1,61 @@
+import React from 'react';
+import { RefreshCwIcon } from './icons';
+import { usePullToRefresh } from '../hooks/usePullToRefresh';
+
+/**
+ * The mark that follows a pull-to-refresh gesture down the page.
+ *
+ * Renders NOTHING at rest, and nothing at all outside an installed app — see
+ * hooks/usePullToRefresh for why the gesture exists and why it is confined to
+ * one. A browser tab has Safari's own pull-to-refresh and needs no second one.
+ *
+ * ── WHY IT IS NOT THE `.pull-to-refresh-indicator` CSS THAT WAS ALREADY HERE ─
+ *
+ * `src/index.css` carried rules for this since long before today, orphaned:
+ * nothing in the app has ever referenced them. They were also written against
+ * an older design — `background: white` with no dark variant, which would have
+ * put a white disc on a gray-900 page, and an ambient `box-shadow` of the kind
+ * `styles/borders.css` was cut back to remove. Reviving them would have meant
+ * shipping a bug the design pass had already ruled out. Deleted with this
+ * commit rather than left for the next reader to wonder about.
+ */
+export default function PullToRefreshIndicator(): React.JSX.Element | null {
+  const { distance, refreshing, ready } = usePullToRefresh();
+
+  if (distance === 0 && !refreshing) return null;
+
+  return (
+    <div
+      // `fixed`, so it hangs over the page rather than displacing it: a pull
+      // that pushed the layout down would fight the scroll it is riding on.
+      className="fixed left-1/2 z-50 -translate-x-1/2 pointer-events-none"
+      style={{
+        // The safe-area inset is what keeps it clear of the iOS clock — the
+        // same reason Layout's own top chrome carries it. An indicator that
+        // appears from under the status bar is the bug this app already had.
+        top: `calc(env(safe-area-inset-top, 0px) + ${Math.round(distance)}px - 40px)`,
+      }}
+      // The gesture is a shortcut for reloading, and a screen reader user has
+      // the browser's own reload. Announcing a decorative disc mid-drag would
+      // be noise, so the whole thing is hidden from the tree.
+      aria-hidden="true"
+    >
+      <div className="flex h-10 w-10 items-center justify-center rounded-full border border-line bg-white shadow-overlay dark:border-gray-700 dark:bg-gray-800">
+        <RefreshCwIcon
+          size={18}
+          className={`text-gray-500 dark:text-gray-400 ${refreshing ? 'animate-spin' : ''}`}
+          // Turns with the pull, so the gesture has a readout before it has a
+          // result — and lands upright exactly as it becomes releasable.
+          style={refreshing ? undefined : { transform: `rotate(${Math.round(distance * 2.5)}deg)` }}
+        />
+      </div>
+      {/* Ready is said by WEIGHT, not colour: nothing here needs attention,
+          it is a control reporting its own state (P3). */}
+      <p className={`mt-1 whitespace-nowrap text-center text-label ${
+        ready ? 'text-gray-700 dark:text-gray-200' : 'text-gray-400 dark:text-gray-500'
+      }`}>
+        {refreshing ? 'Refreshing…' : ready ? 'Release to refresh' : 'Pull to refresh'}
+      </p>
+    </div>
+  );
+}

--- a/src/design-system/__tests__/keyframeCollision.test.ts
+++ b/src/design-system/__tests__/keyframeCollision.test.ts
@@ -1,0 +1,91 @@
+/**
+ * No two `@keyframes` may share a name.
+ *
+ * ─ THE FAILURE THIS EXISTS TO CATCH ────────────────────────────────────────
+ * `src/index.css` defined `@keyframes spin` for an orphaned pull-to-refresh
+ * indicator — `to { transform: translate(-50%) translateY(80px) rotate(360deg) }`.
+ * Tailwind defines `spin` too, for `animate-spin`, as a pure rotation.
+ *
+ * CSS resolves a duplicate keyframe name by taking the LAST definition, and the
+ * hand-written one landed after Tailwind's in the bundle. Measured on the built
+ * stylesheet before the fix: Tailwind's at byte 20,124 and the stray at 70,974.
+ * So the stray won, and every one of the app's SIXTY-FOUR `animate-spin`
+ * elements — the loading spinners, the refresh glyphs, the busy buttons — was
+ * displacing itself 80px down and half its own width left while it turned.
+ *
+ * Nothing could see it. The class is correct, the element is correct, the
+ * animation runs. Only the coordinates are wrong, and only because a name
+ * collided with one the framework owns. Same family as `bg-primary/10` emitting
+ * no rule and `rotate-90` being blamed for a hidden tab: CSS that type-checks,
+ * lints, renders, and does the wrong thing.
+ *
+ * ─ WHY IT READS THE BUILT SHEET ────────────────────────────────────────────
+ * A collision between OUR css and TAILWIND's cannot be seen in either source —
+ * it exists only where the two are concatenated. So this compiles the real
+ * thing, which is also the only place the winning order is decided.
+ */
+import { describe, it, expect } from 'vitest';
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, writeFileSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+/**
+ * Compile the app's real entry stylesheet against the real config, with a probe
+ * that uses the animation utilities — so Tailwind emits its own keyframes and
+ * any collision with ours is present in the output.
+ */
+function compileAppCss(): string {
+  const dir = mkdtempSync(join(tmpdir(), 'wt-keyframes-'));
+  try {
+    const probe = join(dir, 'probe.tsx');
+    writeFileSync(
+      probe,
+      'export const P = () => <div className="animate-spin animate-pulse animate-ping animate-bounce" />;\n'
+    );
+    const out = join(dir, 'app.css');
+    execFileSync(
+      'npx',
+      ['tailwindcss', '-c', 'tailwind.config.js', '-i', 'src/index.css', '--content', probe, '-o', out],
+      { cwd: process.cwd(), stdio: 'pipe' }
+    );
+    return readFileSync(out, 'utf8');
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+describe('keyframe names are unique across the whole stylesheet', () => {
+  const css = compileAppCss();
+
+  it('compiled something with keyframes in it (the guard is not vacuous)', () => {
+    expect(css.length).toBeGreaterThan(1000);
+    expect(css).toMatch(/@keyframes\s+spin\b/);
+  });
+
+  it('defines each animation name exactly once', () => {
+    const counts = new Map<string, number>();
+    for (const match of css.matchAll(/@(?:-webkit-)?keyframes\s+([A-Za-z0-9_-]+)/g)) {
+      const name = match[1];
+      counts.set(name, (counts.get(name) ?? 0) + 1);
+    }
+
+    const collisions = [...counts.entries()]
+      .filter(([, n]) => n > 1)
+      .map(([name, n]) => `${name} (defined ${n}×)`);
+
+    expect(
+      collisions,
+      'A duplicate @keyframes name silently overrides the earlier one — including Tailwind\'s own. ' +
+        'Rename the local animation rather than shadowing a framework name.'
+    ).toEqual([]);
+  });
+
+  it('leaves Tailwind’s spin a pure rotation', () => {
+    // The specific shape of the bug: `spin` must not translate. If a future
+    // animation wants to move as it turns, it needs its own name.
+    const spin = css.match(/@keyframes\s+spin\s*\{[^}]*\}[^}]*\}/)?.[0] ?? '';
+    expect(spin).toMatch(/rotate\(360deg\)/);
+    expect(spin).not.toMatch(/translate/);
+  });
+});

--- a/src/hooks/usePullToRefresh.ts
+++ b/src/hooks/usePullToRefresh.ts
@@ -1,0 +1,152 @@
+import { useEffect, useRef, useState } from 'react';
+
+/**
+ * Pull down at the top of the page to reload — but only in an INSTALLED app.
+ *
+ * ── WHY THIS EXISTS AT ALL ──────────────────────────────────────────────────
+ *
+ * The owner added WealthTracker to his home screen, and two days later the
+ * Accounts page was drawing itself the way it had before that morning's fixes:
+ * the header under the iOS clock, the controls squashed. Fully closing the app
+ * and reopening it fixed everything.
+ *
+ * That is not a caching bug, and it was worth measuring before assuming one —
+ * production serves `cache-control: public, max-age=0, must-revalidate` on both
+ * `/` and `/accounts` (checked 2026-08-13), so the HTML revalidates whenever it
+ * is actually requested. The point is that it stops being requested: iOS keeps a
+ * standalone web app's page ALIVE between launches. Reopening from the app
+ * switcher resumes the document that is already there, so a session can run for
+ * days on the build it happened to start with.
+ *
+ * And a standalone app has no address bar and no Safari pull-to-refresh, so
+ * there was no way out of it from inside. His words: "I dont have a pull down to
+ * refresh option... But no refresh."
+ *
+ * ── WHY ONLY WHEN INSTALLED ─────────────────────────────────────────────────
+ *
+ * In a browser tab Safari already does this, better, at the OS level. Adding a
+ * second gesture on top of the platform's own is how a page ends up fighting
+ * its user for a scroll. The check is `display-mode: standalone` plus the
+ * `navigator.standalone` flag that iOS uses instead — the same pair
+ * `mobileService.isPWAInstalled` already reads.
+ *
+ * ── WHAT IT DOES NOT DO ─────────────────────────────────────────────────────
+ *
+ * It does not re-fetch data and leave the page running. A refetch would answer
+ * a different complaint — stale FIGURES — and would have left him exactly where
+ * he was, on a stale BUILD. `location.reload()` is the honest action for what
+ * this is for.
+ */
+
+/** How far the finger must travel before a release counts as a pull. */
+const TRIGGER_DISTANCE = 72;
+
+/**
+ * How far the indicator is allowed to travel, so a long drag does not run the
+ * spinner down the page. Resistance below makes the last pixels expensive.
+ */
+const MAX_DISTANCE = 96;
+
+/** Below this, a drag is a scroll that happened to start at the top. */
+const ENGAGE_SLOP = 8;
+
+export interface PullToRefresh {
+  /** How far the pull has been dragged, in px. 0 when idle. */
+  distance: number;
+  /** True once released past the threshold, while the reload is in flight. */
+  refreshing: boolean;
+  /** True when a release now would reload. Drives the indicator's readiness. */
+  ready: boolean;
+}
+
+/** True in an installed app, where the platform offers no refresh of its own. */
+function isInstalledApp(): boolean {
+  if (typeof window === 'undefined') return false;
+  const standaloneDisplay = window.matchMedia?.('(display-mode: standalone)').matches === true;
+  const iosStandalone = (window.navigator as Navigator & { standalone?: boolean }).standalone === true;
+  return standaloneDisplay || iosStandalone;
+}
+
+export function usePullToRefresh(reload: () => void = () => window.location.reload()): PullToRefresh {
+  const [distance, setDistance] = useState(0);
+  const [refreshing, setRefreshing] = useState(false);
+
+  /**
+   * Where the finger started, or null when this touch is not a candidate.
+   * A ref rather than state: it is written from a touch handler on every move
+   * and nothing renders from it, so making it state would re-render the whole
+   * layout per frame to store a number the layout never reads.
+   */
+  const startY = useRef<number | null>(null);
+  const engaged = useRef(false);
+
+  useEffect(() => {
+    if (!isInstalledApp()) return;
+
+    const onTouchStart = (event: TouchEvent): void => {
+      // Only a gesture that begins AT the top can be a pull. Starting anywhere
+      // else is a scroll, and a scroll that later reaches the top must stay one.
+      if (window.scrollY > 0 || event.touches.length !== 1) {
+        startY.current = null;
+        return;
+      }
+      startY.current = event.touches[0].clientY;
+      engaged.current = false;
+    };
+
+    const onTouchMove = (event: TouchEvent): void => {
+      const start = startY.current;
+      if (start === null || refreshing) return;
+
+      const travelled = event.touches[0].clientY - start;
+      if (travelled <= ENGAGE_SLOP) {
+        // Upward, or too small to mean anything. If the user has started
+        // scrolling up, this touch is done being a candidate.
+        if (travelled < 0) startY.current = null;
+        return;
+      }
+
+      // Resistance: the pull follows the finger at first and then increasingly
+      // resists, so the gesture has a floor and cannot be flung open.
+      const pulled = Math.min(MAX_DISTANCE, travelled * 0.5);
+      engaged.current = true;
+      setDistance(pulled);
+
+      // Only now — once this is definitely a pull rather than a scroll — is it
+      // right to take the gesture away from the page. Calling preventDefault
+      // any earlier would stop ordinary scrolling from the top of the page.
+      if (event.cancelable) event.preventDefault();
+    };
+
+    const onTouchEnd = (): void => {
+      const shouldReload = engaged.current && distance >= TRIGGER_DISTANCE;
+      startY.current = null;
+      engaged.current = false;
+
+      if (!shouldReload) {
+        setDistance(0);
+        return;
+      }
+      // Held open while the document goes away, so the gesture does not snap
+      // back and read as "nothing happened" in the moment before the reload.
+      setRefreshing(true);
+      setDistance(TRIGGER_DISTANCE);
+      reload();
+    };
+
+    // NOT passive: this listener conditionally calls preventDefault, and a
+    // passive listener that does so is ignored with a console warning.
+    window.addEventListener('touchstart', onTouchStart, { passive: true });
+    window.addEventListener('touchmove', onTouchMove, { passive: false });
+    window.addEventListener('touchend', onTouchEnd, { passive: true });
+    window.addEventListener('touchcancel', onTouchEnd, { passive: true });
+    return () => {
+      window.removeEventListener('touchstart', onTouchStart);
+      window.removeEventListener('touchmove', onTouchMove);
+      window.removeEventListener('touchend', onTouchEnd);
+      window.removeEventListener('touchcancel', onTouchEnd);
+    };
+  }, [distance, refreshing, reload]);
+
+  return { distance, refreshing, ready: distance >= TRIGGER_DISTANCE };
+}

--- a/src/index.css
+++ b/src/index.css
@@ -11,12 +11,6 @@
    focus state at all. Mouse clicks show no outline (they don't match
    :focus-visible), so nothing "blue flashes" on ordinary clicking. */
 
-/* Pull to Refresh Styles */
-.pull-to-refresh {
-  position: relative;
-  -webkit-overflow-scrolling: touch;
-}
-
 /* Touch Target Optimization */
 @media (hover: none) and (pointer: coarse) {
   /* Ensure all interactive elements have minimum touch target size.
@@ -331,40 +325,12 @@ button {
   opacity: 1 !important;
 }
 
-/* Pull to refresh styles */
-.pull-to-refresh {
-  position: relative;
-  overflow: hidden;
-}
-
-.pull-to-refresh-indicator {
-  position: absolute;
-  top: -60px;
-  left: 50%;
-  transform: translateX(-50%);
-  width: 40px;
-  height: 40px;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  background: white;
-  border-radius: 50%;
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
-  transition: transform 0.3s ease;
-}
-
-.pull-to-refresh-indicator.pulling {
-  transform: translateX(-50%) translateY(calc(var(--pull-distance) * 1px));
-}
-
-.pull-to-refresh-indicator.refreshing {
-  transform: translateX(-50%) translateY(80px);
-  animation: spin 1s linear infinite;
-}
-
-@keyframes spin {
-  to { transform: translateX(-50%) translateY(80px) rotate(360deg); }
-}
+/* The `.pull-to-refresh*` rules were here, orphaned: nothing in the app ever
+   referenced them, and they were written against an older design — a hardcoded
+   white disc with no dark variant, and an ambient box-shadow of the kind
+   styles/borders.css was cut back to remove. The gesture shipped for real on
+   2026-08-13 (components/PullToRefreshIndicator) with tokens that have both
+   themes. Deleted rather than revived. */
 
 /* Override for buttons that need to be less rounded */
 button.rounded-sm {


### PR DESCRIPTION
Two fixes. The one that was asked for, and a considerably worse one found on the way to it.

## 1. An installed app with no way to refresh

The home-screen app spent two days drawing Accounts the way it had *before* that morning's fixes — header under the iOS clock, controls squashed — while Safari on the same phone drew it correctly. A full close-and-reopen fixed it.

**Not a caching bug**, and worth measuring before assuming one. Production sends `cache-control: public, max-age=0, must-revalidate` on **both** `/` and `/accounts` (verified today), so the HTML revalidates whenever it is actually requested.

The point is that it stops being requested. **iOS keeps a standalone web app's page alive between launches** — reopening from the app switcher resumes the document that is already there — so a session runs for days on the build it started with. And a standalone app has no address bar and no Safari pull-to-refresh, so there was no way out from inside it.

Now there is: pull down at the top of any page and it reloads.

- **Only in an installed app.** A browser tab has Safari's own; a second gesture on top of the platform's is how a page ends up fighting its user for a scroll.
- **Reloads, doesn't re-fetch.** The complaint was a stale *build*; a refetch of data would have left him exactly where he was.
- **Does not hijack scrolling.** The touch is only taken from the page once the gesture is definitely a pull — starting at the top, moving down, past 8px of slop — and resistance means it cannot be flung open.
- The indicator carries `env(safe-area-inset-top)`, so it cannot emerge from under the iOS clock. That bug has been paid for once already.

## 2. Every spinner in the app was moving while it span

`src/index.css` carried `@keyframes spin` for a pull-to-refresh indicator **nothing has ever rendered**. Tailwind defines `spin` too, for `animate-spin`.

CSS resolves a duplicated keyframe name by taking the **last** definition, and ours landed after Tailwind's. Measured in the built stylesheet:

```
offset   20124  @keyframes spin{to{transform:rotate(360deg)}}                          ← Tailwind
offset   70974  @keyframes spin{to{transform:translate(-50%) translateY(80px) rotate(360deg)}}  ← wins
```

So all **64** `animate-spin` elements in this app — every loading spinner, refresh glyph and busy button — were displacing themselves 80px down and half their width left as they turned. The class is right, the element is right, the animation runs; only the coordinates are wrong, because a name collided with one the framework owns.

Deleting the orphan leaves one definition, a pure rotation. Rebuilt and confirmed: `spin definitions now: 1`.

This is the third member of a family now: `bg-primary/10` emitting no rule at all, `rotate-90` blamed for what a hidden tab was doing, and now a keyframe shadowing a framework name. All of them type-check, lint, render, and do the wrong thing.

### The guard

`keyframeCollision.test.ts` compiles the **real** entry stylesheet against the **real** config — the collision exists in neither source alone, only where the two are concatenated — and fails on any duplicated `@keyframes` name, with a third assertion pinning the specific shape (`spin` must not translate).

Proven by putting the bug back: it fails with `expected [ 'spin (defined 2×)' ] to deeply equal []`, and passes again when removed.

## Verification

lint clean · `typecheck:strict` clean · `test:smoke` **392 files / 6139 tests, zero failures** · `npm run build` 8828 modules · `desktop:verify` 17/17 within the ratchet.

Note the gesture itself is touch-only and cannot be exercised in the automated browser (which is a backgrounded Chromium with no touch); it is guarded by construction — the hook returns early unless `display-mode: standalone` — and the keyframe half, which is the part that affects everyone, is verified against the compiled stylesheet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)