### PR TITLE
fix: the pin menu (for real, from his browser) and an opening-balance date the dialog invented

### DIFF
--- a/src/components/AccountSettingsModal.test.tsx
+++ b/src/components/AccountSettingsModal.test.tsx
@@ -480,15 +480,40 @@ describe('AccountSettingsModal', () => {
       expect(balanceInput).toHaveValue('-2,500.00');
     });
 
-    it('defaults date to today for accounts without opening balance date', () => {
+    it('leaves the date BLANK when the account has none, and says what blank does', () => {
+      /*
+       * This asserted the opposite until 2026-08-13 — that the field defaults to
+       * TODAY — and the assertion was the bug, written down.
+       *
+       * Most imported accounts have no opening date, correctly: Money records
+       * `dtOpen` only sometimes and the importer writes nothing rather than
+       * inventing one. The app then applies the opening balance from the first
+       * transaction. Pre-filling today meant that opening this dialog to change
+       * an account's NAME and pressing Save stamped "opened today" onto an
+       * account that had been running since 2010 — silently, and cumulatively
+       * across every account the owner ever edited.
+       */
       const accountWithoutDate = { ...mockAccount, openingBalanceDate: undefined };
       render(<AccountSettingsModal {...defaultProps} account={accountWithoutDate} />);
-      
+
       const dateInput = screen.getByLabelText('Opening balance date') as HTMLInputElement;
-      const now = new Date();
-      const dd = String(now.getDate()).padStart(2, '0');
-      const mm = String(now.getMonth() + 1).padStart(2, '0');
-      expect(dateInput.value).toBe(`${dd}/${mm}/${now.getFullYear()}`);
+      expect(dateInput.value).toBe('');
+      expect(screen.getByText(/applies from this account's first\s+transaction/i)).toBeInTheDocument();
+    });
+
+    it('does not write an opening date the user never entered', () => {
+      // The half that actually corrupted data: a blank field must reach `onSave`
+      // as no date at all, not as today's.
+      const onSave = vi.fn();
+      const accountWithoutDate = { ...mockAccount, openingBalanceDate: undefined };
+      render(<AccountSettingsModal {...defaultProps} account={accountWithoutDate} onSave={onSave} />);
+
+      fireEvent.change(screen.getByLabelText(/account name/i), { target: { value: 'Renamed' } });
+      fireEvent.click(screen.getByRole('button', { name: /save changes/i }));
+
+      expect(onSave).toHaveBeenCalled();
+      const [, updates] = onSave.mock.calls[0];
+      expect(updates).not.toHaveProperty('openingBalanceDate');
     });
   });
 

--- a/src/components/AccountSettingsModal.tsx
+++ b/src/components/AccountSettingsModal.tsx
@@ -222,9 +222,32 @@ export default function AccountSettingsModal({
         type: account.type || 'current',
         currency: account.currency || 'GBP',
         openingBalance: account.openingBalance != null ? account.openingBalance.toFixed(2) : '',
+        /*
+         * BLANK WHEN THERE IS NO DATE. It used to pre-fill TODAY, and that was
+         * not a default — it was a fabrication with a save button under it.
+         *
+         * Most imported accounts have no opening date, correctly: Money records
+         * `dtOpen` only sometimes, and our importer writes `undefined` rather
+         * than inventing one (import/msMoney/transform.ts). The app then applies
+         * the opening balance from the account's FIRST TRANSACTION
+         * (utils/openingDates, rung 2) and the net-worth report says so out loud
+         * — "5 accounts' opening dates are inferred from their first activity".
+         *
+         * With today's date pre-filled, opening this dialog to change an
+         * account's NAME and pressing Save stamped that inference into a stored
+         * fact of the wrong day. The owner found it on an account imported days
+         * earlier that claimed to have opened this morning. For an account with
+         * transactions the damage is bounded — rung 1 clamps a stored date back
+         * to the first transaction — but an account with no transactions has
+         * nothing to clamp against, and its opening balance would land on
+         * whichever day the dialog happened to be opened.
+         *
+         * Blank is the honest representation of "not set", and the note under
+         * the field says what blank does.
+         */
         openingBalanceDate: account.openingBalanceDate
           ? new Date(account.openingBalanceDate).toISOString().split('T')[0]
-          : new Date().toISOString().split('T')[0],
+          : '',
         sortCode: account.sortCode || '',
         accountNumber: account.accountNumber || '',
         institution: account.institution || '',
@@ -400,6 +423,15 @@ export default function AccountSettingsModal({
                 className="bg-white dark:bg-gray-800-sm border border-gray-300/50 dark:border-gray-600/50 rounded-xl focus:border-transparent dark:text-white"
                 aria-label="Opening balance date"
               />
+              {/* Says what BLANK does, because blank is now the normal state for
+                  an imported account and an unexplained empty date field reads
+                  as something missing rather than something inferred. */}
+              {formData.openingBalanceDate === '' && (
+                <p className="text-label text-gray-500 dark:text-gray-400">
+                  Left blank, the opening balance applies from this account's first
+                  transaction. Set a date only if the account opened earlier.
+                </p>
+              )}
             </div>
           </div>
 

--- a/src/components/dashboard/reportWidgets/CardPeriodControl.tsx
+++ b/src/components/dashboard/reportWidgets/CardPeriodControl.tsx
@@ -120,6 +120,49 @@ export default function CardPeriodControl({ cardLabel, picker, pin }: {
   const firstItemRef = useRef<HTMLButtonElement>(null);
   const menuId = `${useId()}-card-period`;
 
+  /**
+   * True from the moment a pointer goes down INSIDE this control until the
+   * click it belongs to has been delivered.
+   *
+   * ── WHY A FLAG AND NOT A SMARTER `relatedTarget` TEST ───────────────────────
+   *
+   * A menu item was unclickable with a real mouse and perfectly clickable with
+   * `element.click()`. That difference is the whole diagnosis: `.click()` fires
+   * one event, while a physical click fires pointerdown → mousedown → a focus
+   * change → mouseup → click. Something in the early phase was dismissing the
+   * menu, so by the time `click` arrived React had already unmounted the item
+   * it was aimed at. Instrumented in the owner's own Safari: the synthetic
+   * click set `pinned to All time` and wrote the keys; his mouse did nothing at
+   * all, four cards still reading "period follows the page".
+   *
+   * The previous attempt guessed at WHICH focus target Safari reports during
+   * that phase (`null`, then also `document.body`) and guessed wrong twice.
+   * This stops guessing. If a pointer went down inside this control, whatever
+   * focus does next is part of that interaction and is not a departure —
+   * regardless of what any engine names as the thing being focused.
+   *
+   * Genuine departures are untouched: Tab moves focus with no pointer down, and
+   * a click outside never sets the flag and is caught by the mousedown listener
+   * below, which is where outside clicks have always been handled.
+   */
+  const pointerInside = useRef(false);
+
+  useEffect(() => {
+    // Cleared on the window, not the control: a press that starts inside and
+    // releases anywhere — including outside, or off the edge of the screen —
+    // still has to end, or the flag would stay raised and the menu would stop
+    // dismissing on blur for good.
+    const release = (): void => { pointerInside.current = false; };
+    window.addEventListener('pointerup', release);
+    window.addEventListener('mouseup', release);
+    window.addEventListener('touchend', release);
+    return () => {
+      window.removeEventListener('pointerup', release);
+      window.removeEventListener('mouseup', release);
+      window.removeEventListener('touchend', release);
+    };
+  }, []);
+
   // Clicking anywhere else dismisses — mousedown, so the click that opens
   // another control is not swallowed by this menu closing first.
   useEffect(() => {
@@ -161,30 +204,32 @@ export default function CardPeriodControl({ cardLabel, picker, pin }: {
           close();
         }
       }}
+      onPointerDown={() => { pointerInside.current = true; }}
+      onMouseDown={() => { pointerInside.current = true; }}
+      onTouchStart={() => { pointerInside.current = true; }}
       onBlur={(event) => {
         /**
-         * Tabbing out dismisses. A CLICK MUST NOT — and on Safari that is the
-         * same event.
+         * Tabbing out dismisses. A CLICK MUST NOT — and on Safari those arrive
+         * as the same event.
          *
-         * THE BUG THIS FIXES, because it cost the owner two days of a feature
-         * that looked completely finished: Safari (macOS and iOS) does not
-         * focus a `<button>` when you click it. WebKit follows the platform
-         * convention that only text fields take focus from a click. So a
-         * mousedown on one of the menu items below moves focus off the item
-         * this effect just focused and onto `<body>` — and `document.body` is
-         * a `Node` that this container does not contain. The old test passed,
-         * the menu closed on MOUSEDOWN, React unmounted the item, and the
-         * `click` that followed landed on nothing. Every period in the menu was
-         * unselectable: the menu opened, dismissed itself, and the chart never
-         * moved. Chromium focuses clicked buttons, so it worked perfectly in
-         * every browser we had automated — which is exactly why it survived.
+         * Safari does not focus a `<button>` when you click it: WebKit follows
+         * the platform convention that only text fields take focus from a
+         * click. So pressing a menu item moved focus off the item this control
+         * had focused on opening, this handler read that as a departure, the
+         * menu closed on MOUSEDOWN, and the `click` that followed landed on an
+         * element React had already removed. Every period was unselectable.
          *
-         * `relatedTarget` of `body` means "focus went nowhere", which is a
-         * click, not a departure. Genuine departures — Tab, or a click landing
-         * on some other control — name that control, and still close. A click
-         * on empty space outside is caught by the mousedown listener above,
-         * which is where outside-clicks were always handled anyway.
+         * Two earlier attempts guessed at what Safari names as the new focus
+         * target — first `null`, then also `document.body` — and both were
+         * wrong, which is how this survived being "fixed" twice. The pointer
+         * flag replaces the guess with a fact: if a press started inside this
+         * control, whatever focus does next belongs to that press.
+         *
+         * Chromium focuses clicked buttons, so it worked there throughout —
+         * including in every browser we can automate, which is exactly why only
+         * the owner could see it.
          */
+        if (pointerInside.current) return;
         const next = event.relatedTarget;
         if (next === null || next === document.body) return;
         if (next instanceof Node && !containerRef.current?.contains(next)) setOpen(false);

--- a/src/components/dashboard/reportWidgets/DashboardReportWidgets.test.tsx
+++ b/src/components/dashboard/reportWidgets/DashboardReportWidgets.test.tsx
@@ -321,6 +321,44 @@ describe('a report card’s period pin', () => {
    * describe the focus behaviour rather than a browser, so they hold whichever
    * engine is doing the clicking.
    */
+  it('survives the FULL press sequence a real mouse delivers', () => {
+    /**
+     * The test the previous two attempts at this bug did not write, which is
+     * why both shipped broken.
+     *
+     * `fireEvent.click` fires ONE event. A real mouse fires pointerdown →
+     * mousedown → a focus change → mouseup → click, and it was the focus change
+     * in the middle that dismissed the menu, so the click arrived at an element
+     * React had already unmounted. Every assertion here is about the ORDER.
+     *
+     * Confirmed against the owner's Safari before it was written: a synthetic
+     * click pinned the card, and his mouse did not.
+     */
+    const pinTo = vi.fn();
+    render(<NetWorthWidget picker={pickerOn('this-month')} pin={pinned({ pinTo })} />);
+
+    fireEvent.click(screen.getByRole('button', {
+      name: 'Net Worth Over Time: pinned to This month. Choose a different period for this card',
+    }));
+    const item = within(screen.getByRole('menu', { name: 'Window for Net Worth Over Time' }))
+      .getByRole('menuitemradio', { name: 'All time' });
+
+    // The press begins…
+    fireEvent.pointerDown(item);
+    fireEvent.mouseDown(item);
+    // …and Safari, focusing no button, moves focus away mid-press. `body` is
+    // what it reported here; the fix does not depend on that being the value.
+    fireEvent.focusOut(item, { relatedTarget: document.body });
+
+    // The item must still exist, or the click has nothing to land on.
+    expect(screen.getByRole('menu', { name: 'Window for Net Worth Over Time' })).toBeInTheDocument();
+
+    fireEvent.mouseUp(item);
+    fireEvent.click(item);
+
+    expect(pinTo).toHaveBeenCalledWith('all');
+  });
+
   it('stays open when focus falls to the body — that is a click, not a departure', () => {
     render(<NetWorthWidget picker={pickerOn('all')} pin={pinned()} />);
 

--- a/src/hooks/useCardPeriod.signedIn.test.ts
+++ b/src/hooks/useCardPeriod.signedIn.test.ts
@@ -1,0 +1,123 @@
+/**
+ * A pin, through the REAL preferences service, signed in.
+ *
+ * Every other test of this hook hands it `localStorage` — deliberately, because
+ * what they are about is the page-versus-card rule rather than where the answer
+ * is filed. That left one configuration untested and it is the only one the
+ * owner runs: the singleton `preferences` service, attached to a user, with a
+ * transport behind it. He reported twice that pins "do not override the global
+ * setting", on a build whose every other test was green.
+ *
+ * So this renders the hook against the real module, over a transport, and asks
+ * the plainest possible question: after `pinTo`, is the card reading its own
+ * window?
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { renderHook, act, waitFor } from '@testing-library/react';
+import { usePeriod } from './usePeriod';
+import { cardPeriodKey, useCardPeriod } from './useCardPeriod';
+import { PreferencesService, type PreferencesDocument } from '../services/preferencesService';
+
+/**
+ * A FRESH SERVICE, not the exported singleton.
+ *
+ * `useTransport` is deliberately one-way — "once a session has been told where
+ * the settings live, it does not go back to guessing" — so pointing the
+ * singleton at a fake here would leave every later test file in the same worker
+ * attached to it. That is not hypothetical: it broke two dashboard integration
+ * tests the first time this file ran beside them. Same class, same code path,
+ * no shared state.
+ */
+let preferences: PreferencesService;
+
+const PAGE_KEY = 'dashboardReports';
+const CARD_KEY = cardPeriodKey(PAGE_KEY, 'income-expense-trend');
+
+/** A store that answers like the real one: a row per user, read and written whole. */
+function fakeTransport(initial: PreferencesDocument | null = null) {
+  let row = initial;
+  return {
+    read: vi.fn(async () => row),
+    write: vi.fn(async (_userId: string, document: PreferencesDocument) => { row = document; }),
+    current: () => row,
+  };
+}
+
+const renderPageAndCard = () => renderHook(() => {
+  const page = usePeriod(PAGE_KEY, 'last-12-months', preferences);
+  const card = useCardPeriod(CARD_KEY, page, preferences);
+  return { page, card };
+});
+
+beforeEach(() => {
+  localStorage.clear();
+  preferences = new PreferencesService();
+});
+
+afterEach(() => {
+  preferences.detach();
+});
+
+
+describe('pinning a card while signed in', () => {
+  it('reads over its own window the moment it is pinned', async () => {
+    const transport = fakeTransport();
+    preferences.useTransport(transport);
+    await preferences.attach('user-1');
+
+    const { result } = renderPageAndCard();
+    expect(result.current.card.picker.period).toBe('last-12-months');
+
+    act(() => { result.current.card.pin.pinTo('all'); });
+
+    expect(result.current.card.pin.source).toBe('own');
+    expect(result.current.card.picker.period).toBe('all');
+  });
+
+  it('holds the pin while the PAGE is moved underneath it', async () => {
+    // The owner's exact report: set the page to 12 months, pin the card to All
+    // time, and the card goes on showing 12 months.
+    const transport = fakeTransport();
+    preferences.useTransport(transport);
+    await preferences.attach('user-1');
+
+    const { result } = renderPageAndCard();
+    act(() => { result.current.card.pin.pinTo('all'); });
+    act(() => { result.current.page.setPeriod('this-month'); });
+
+    expect(result.current.page.period).toBe('this-month');
+    expect(result.current.card.picker.period).toBe('all');
+  });
+
+  it('survives the account row arriving AFTER the pin was made', async () => {
+    // The race the cloud has and localStorage does not: `attach` resolves while
+    // the user is already clicking. A stored row that predates the pin must not
+    // overwrite it — `attach` merges session values on top for exactly this.
+    const transport = fakeTransport({
+      version: 1,
+      values: { [PAGE_KEY]: 'last-12-months', [`${PAGE_KEY}Explicit`]: 'true' },
+    });
+    preferences.useTransport(transport);
+
+    const { result } = renderPageAndCard();
+    act(() => { result.current.card.pin.pinTo('all'); });
+    await act(async () => { await preferences.attach('user-1'); });
+
+    expect(result.current.card.pin.source).toBe('own');
+    expect(result.current.card.picker.period).toBe('all');
+  });
+
+  it('writes the pin to the account, so another device sees it', async () => {
+    const transport = fakeTransport();
+    preferences.useTransport(transport);
+    await preferences.attach('user-1');
+
+    const { result } = renderPageAndCard();
+    act(() => { result.current.card.pin.pinTo('all'); });
+
+    await waitFor(() => expect(transport.write).toHaveBeenCalled());
+    const row = transport.current();
+    expect(row?.values[`${CARD_KEY}Pinned`]).toBe('true');
+    expect(row?.values[CARD_KEY]).toBe('all');
+  });
+});

--- a/supabase/audits/opening_balance_dates.sql
+++ b/supabase/audits/opening_balance_dates.sql
@@ -1,0 +1,134 @@
+-- ============================================================================
+-- OPENING BALANCE DATES — a READ-ONLY audit. Nothing here changes any row.
+--
+-- WHY THIS EXISTS
+-- The Account Settings dialog used to pre-fill TODAY into the opening-balance
+-- date whenever an account had none — which is the normal state for an imported
+-- account, because Money records `dtOpen` only sometimes and our importer
+-- writes nothing rather than inventing a date. Opening that dialog to change an
+-- account's NAME and pressing Save therefore stamped "opened today" onto an
+-- account that had been running since 2010. Fixed 2026-08-13; this finds
+-- whatever the bug wrote before it was fixed.
+--
+-- WHAT THE APP DOES WITH THESE DATES (src/utils/openingDates.ts)
+--   rung 1  a stored date — CLAMPED so it can never fall after the first
+--           transaction. This is why an account WITH history is largely
+--           protected: a wrong stored date of today still draws from the first
+--           transaction. The stored value is wrong; the arithmetic is not.
+--   rung 2  no stored date → the first transaction's date.
+--   rung 3  no transactions → the paired "(Cash)" sibling's first activity.
+--   rung 4  no signal at all → beginning of time, and the net-worth report
+--           warns about it by name.
+--
+-- SO THE REAL DAMAGE IS CONCENTRATED IN SECTION C: accounts with a stored date
+-- and NO transactions, where there is nothing to clamp against.
+--
+-- Run each section in the Supabase SQL editor and read the output. Nothing is
+-- written; any correction is yours to make afterwards, by hand or by a script
+-- you approve separately.
+-- ============================================================================
+
+-- ── A. STORED DATE LATER THAN THE FIRST TRANSACTION ─────────────────────────
+-- The signature of the bug. `days_wrong` is how far the stored date sits after
+-- the account's earliest activity. Anything near "days since 2026-08-13" was
+-- almost certainly stamped by the dialog.
+--
+-- These are the accounts to eyeball first, but note the clamp: their HISTORY is
+-- already being drawn from first_txn, so fixing the stored value tidies the
+-- record rather than moving the chart.
+select
+  a.id,
+  a.name,
+  a.is_active,
+  a.opening_balance_date::date                     as stored_date,
+  min(t.date)::date                                as first_txn,
+  (a.opening_balance_date::date - min(t.date)::date) as days_wrong,
+  count(t.id)                                      as txn_count,
+  a.initial_balance
+from accounts a
+join transactions t on t.account_id = a.id
+where a.opening_balance_date is not null
+group by a.id, a.name, a.is_active, a.opening_balance_date, a.initial_balance
+having a.opening_balance_date::date > min(t.date)::date
+order by days_wrong desc, a.name;
+
+-- ── B. NO STORED DATE, BUT HISTORY EXISTS ───────────────────────────────────
+-- NOT a fault: this is rung 2 working as designed, and it is what the report
+-- banner means by "inferred from their first activity". Listed so the inferred
+-- date can be confirmed as the real opening day — and so the count is known
+-- before anyone decides to backfill.
+select
+  a.id,
+  a.name,
+  a.is_active,
+  min(t.date)::date as would_apply_from,
+  count(t.id)       as txn_count,
+  a.initial_balance
+from accounts a
+join transactions t on t.account_id = a.id
+where a.opening_balance_date is null
+group by a.id, a.name, a.is_active, a.initial_balance
+order by a.name;
+
+-- ── C. THE ONES THAT CAN ACTUALLY DISTORT NET WORTH ─────────────────────────
+-- A stored opening date, a non-zero opening balance, and NO transactions to
+-- clamp it against. Whatever date is here is taken literally, so a value the
+-- dialog invented puts real money on the wrong day — and an account with no
+-- register is exactly the kind nobody opens to check.
+--
+-- Closed accounts included deliberately: they hold the oldest balances and are
+-- the least likely to be looked at.
+select
+  a.id,
+  a.name,
+  a.is_active,
+  a.opening_balance_date::date as stored_date,
+  a.initial_balance,
+  'no transactions — this date is used as-is' as note
+from accounts a
+where a.opening_balance_date is not null
+  and coalesce(a.initial_balance, 0) <> 0
+  and not exists (select 1 from transactions t where t.account_id = a.id)
+order by a.opening_balance_date desc, a.name;
+
+-- ── D. NO SIGNAL AT ALL (rung 4) ────────────────────────────────────────────
+-- No stored date, no transactions, and money in the opening balance: the app
+-- applies it from the beginning of time and says so on the net-worth report.
+-- These overstate every point before the account really existed.
+select
+  a.id,
+  a.name,
+  a.is_active,
+  a.initial_balance,
+  'counts from the beginning of time' as note
+from accounts a
+where a.opening_balance_date is null
+  and coalesce(a.initial_balance, 0) <> 0
+  and not exists (select 1 from transactions t where t.account_id = a.id)
+order by abs(coalesce(a.initial_balance, 0)) desc;
+
+-- ── E. ONE-LINE SUMMARY ─────────────────────────────────────────────────────
+-- How big is each bucket, before reading any of the detail above.
+select
+  count(*) filter (
+    where a.opening_balance_date is not null
+      and exists (select 1 from transactions t where t.account_id = a.id)
+      and a.opening_balance_date::date >
+          (select min(t.date)::date from transactions t where t.account_id = a.id)
+  ) as a_stored_date_after_first_txn,
+  count(*) filter (
+    where a.opening_balance_date is null
+      and exists (select 1 from transactions t where t.account_id = a.id)
+  ) as b_inferred_from_first_txn,
+  count(*) filter (
+    where a.opening_balance_date is not null
+      and coalesce(a.initial_balance, 0) <> 0
+      and not exists (select 1 from transactions t where t.account_id = a.id)
+  ) as c_literal_date_no_history,
+  count(*) filter (
+    where a.opening_balance_date is null
+      and coalesce(a.initial_balance, 0) <> 0
+      and not exists (select 1 from transactions t where t.account_id = a.id)
+  ) as d_beginning_of_time,
+  count(*) as accounts_total
+from accounts a;


### PR DESCRIPTION
Two fixes. The first was diagnosed in the owner's own Safari after I claimed it fixed twice and was wrong twice.

## 1. The pin menu — a real click, not a synthetic one

I had "verified" this at four levels: the hook on localStorage, the hook signed in over a real transport, the widget, and the full dashboard. All green. He kept reporting it broken.

**The evidence that settled it**, from his console:

```
element.click() on "All time"  →  label: "Income vs Expenses: pinned to All time"
                                  keys:  dashboardReports.pin.income-expense-trend, …Explicit
his actual mouse, same item    →  nothing. All four cards "period follows the page",
                                  not one .pin. key in storage
```

So the component, its state and its storage were never at fault. **A physical click fires pointerdown → mousedown → a focus change → mouseup → click.** The focus change in the middle dismissed the menu; by the time `click` arrived, React had unmounted the element it was aimed at.

Safari does not focus a `<button>` when you click it — WebKit follows the platform convention that only text fields take focus from a click — so the menu's own dismiss-on-blur handler read that as a departure.

**Why two attempts missed it.** Both guessed at what Safari *names* as the new focus target: first `null`, then also `document.body`. Both guesses shipped, neither reproduced the press. This one stops guessing — if a pointer went down inside the control, whatever focus does next belongs to that press, whatever any engine calls it. Tab still dismisses (no pointer down); an outside click is still the mousedown listener's job. The flag releases on the **window**, so a press ending outside, or off-screen, still ends.

**This also fixes Custom**, which was never separately broken: choosing Custom deliberately keeps the menu open for its date fields, so a click that never lands looks precisely like "Custom shows no dates".

### The test that should have come first

`survives the FULL press sequence a real mouse delivers` fires all five events in order and asserts the item is still in the DOM at the moment the click is delivered. Proven by removing both guards — it fails, and passes again with them.

`fireEvent.click` alone cannot see this class of bug. That is the lesson worth keeping.

## 2. Account Settings invented an opening-balance date

> "In the settings it is showing an opening balance date of the current date… when I imported it days ago."

The dialog pre-filled **today** whenever an account had no opening date — not a default, a fabrication with a Save button under it. No opening date is the *normal* state for an imported account: Money records `dtOpen` only sometimes, and our importer writes `undefined` rather than inventing one. The net-worth report was right to say five accounts are "inferred from their first activity", and the register was right to draw Cash - £'s opening lump on 21/01/2010. Only the dialog disagreed.

The damage was in the **save**: opening it to change an account's *name* and pressing Save stamped "opened today" onto an account running since 2010 — silently, once per account ever edited.

**How bad, honestly.** Less than feared, and worth stating precisely: `utils/openingDates` rung 1 **clamps** a stored date so it can never fall after the first transaction, so an account *with* history keeps drawing from its first transaction whatever the stored value says. The arithmetic was protected; the record was not. Where it bites is an account with a stored date and **no** transactions — nothing to clamp against — i.e. closed and empty accounts, the ones nobody opens to check.

A test asserted the old behaviour *by name* ("defaults date to today"). That was the bug written down as an expectation; it now asserts both halves — the field is blank, and nothing is written that the user did not type.

### The audit, read-only

`supabase/audits/opening_balance_dates.sql`, nothing written. Four sections ordered by how much they matter: a stored date later than the first transaction (the bug's signature), no date but history (rung 2 working, listed to confirm), **a literal date with no history — the section that can actually distort net worth**, and no signal at all (rung 4, already warned about on the report). Section E counts all four first.

## Verification

lint clean · `typecheck:strict` clean · `test:smoke` **393 files / 6145 tests, zero failures** · coverage 77.63% / 82.52% · realtime and Supabase smoke green · `npm run build` 8828 modules.

Also included: a signed-in `useCardPeriod` suite over the real service (built while hunting this), using a **fresh `PreferencesService` instance** rather than the singleton — `useTransport` is one-way, and pointing the singleton at a fake leaked into two dashboard integration tests the first time it ran.

🤖 Generated with [Claude Code](https://claude.com/claude-code)