### PR TITLE
fix: net worth over time counts closed accounts, modal dismissal on eight surfaces, and three design rulings

### DIFF
--- a/src/components/AccountRowColumns.tsx
+++ b/src/components/AccountRowColumns.tsx
@@ -165,6 +165,17 @@ export const ACCOUNT_ROW_NAME_LINK_CLASS =
 /** The column heading over a figure — small, quiet, and the same for every row. */
 const CELL_LABEL_CLASS = 'text-[10px] uppercase tracking-wide text-gray-400 dark:text-gray-500';
 
+/**
+ * The same label ON A ROW: drawn on a phone, spoken everywhere.
+ *
+ * From `sm` up the band's header strip says these four words once, so repeating
+ * them on every row is ink for something already answered — but `sr-only`
+ * rather than `hidden`, because a screen reader reads a row as a row and would
+ * otherwise hear four bare figures. The strip is `aria-hidden` for the mirror
+ * image of the same reason.
+ */
+const ROW_LABEL_CLASS = `${CELL_LABEL_CLASS} sm:sr-only`;
+
 /** The figures themselves: tabular so the digits line up down the column. */
 const CELL_FIGURE_CLASS = 'text-sm font-semibold tabular-nums';
 
@@ -179,6 +190,84 @@ export function AccountRowColumns({ children }: { children: ReactNode }): React.
   return (
     <div data-account-columns className={ACCOUNT_ROW_COLUMNS_CLASS}>
       {children}
+    </div>
+  );
+}
+
+/**
+ * The BOX a row's grid sits in — the padding and border of the account card,
+ * with none of its colour. The header strip wears it so its labels land at the
+ * same x as the figures below them, and keeps landing there if the card's
+ * padding is ever changed.
+ *
+ * Kept beside the column template deliberately: these two together are what
+ * "a column of this list" means, and splitting them across files is how the
+ * strip and the rows would come to disagree.
+ */
+export const ACCOUNT_ROW_COLUMN_HEADER_BOX_CLASS = 'p-3 sm:p-4 border border-transparent';
+
+/** What the four figure columns are called, in the template's own order. */
+const COLUMN_LABELS = ['Bank Bal', 'Account Bal', 'Unreconciled', 'To Review'] as const;
+
+/**
+ * The four column names, said ONCE for a band instead of once per row.
+ *
+ * ─ WHY THIS EXISTS ─────────────────────────────────────────────────────────
+ * Every row carried its own labels — twenty-odd repetitions of the same four
+ * words down a list, which is the cost of a card that has to explain itself in
+ * isolation. The reconciliation list was given one strip per group in the
+ * August design pass; this page never was, and the omission surfaced when a
+ * design objection was drafted on the assumption that a header strip existed
+ * here to be made sticky. It did not. This is that strip.
+ *
+ * ─ IT WEARS THE ROW'S OWN TEMPLATE ─────────────────────────────────────────
+ * `ACCOUNT_ROW_COLUMNS_CLASS`, unchanged — the same fixed widths and the same
+ * nine slots, four named and five empty. A strip that declared its own columns
+ * would be a second definition of the grid and would drift from the rows on the
+ * first edit, which is the exact failure this module was created to stop.
+ *
+ * ─ FROM `sm` ONLY, BECAUSE THAT IS WHERE THE GRID IS ───────────────────────
+ * Below `sm` the template gives way to a wrapping row and a card is read on its
+ * own rather than as part of a table, so the per-cell labels stay there and this
+ * does not render. The labels and the strip are the same information at two
+ * widths; neither surface ever shows both.
+ */
+export function AccountColumnHeader(): React.JSX.Element {
+  return (
+    <div
+      data-account-column-header
+      // `aria-hidden`: each cell keeps its own visually-hidden label, so a
+      // screen reader already hears "Bank Bal £6,378.06" per row and does not
+      // need the strip read to it as four loose words.
+      aria-hidden="true"
+      /*
+       * `justify-end` and the row card's own right inset, because the grid is
+       * CONTENT-SIZED inside each row and pushed to the right by the account
+       * name beside it. Measured before this was written: as a plain block grid
+       * the strip filled the container and packed its fixed columns at the LEFT,
+       * putting "Bank Bal" 471px away from the figures it names. The row's card
+       * carries `p-4` and a 1px border inside the band's own `px-4 sm:px-6`, so
+       * the strip repeats both to land on the same right edge.
+       */
+      className="hidden sm:flex justify-end pb-1"
+    >
+      {/* AN INVISIBLE ROW CARD around the labels, rather than a hand-tuned
+          right margin. A row's grid is inset from the band by the card's own
+          `p-3 sm:p-4` and its 1px border — 17px at this width — and a strip
+          that hard-coded 17 would drift the moment that padding changed, which
+          is exactly how the page shell's `calc(100vh-13rem)` came to be 40px
+          wrong. Wearing the same box means the labels move when the rows move. */}
+      <div className={`${ACCOUNT_ROW_COLUMN_HEADER_BOX_CLASS}`}>
+      <div className={ACCOUNT_ROW_COLUMNS_CLASS}>
+        {COLUMN_LABELS.map(label => (
+          <p key={label} className={CELL_LABEL_CLASS}>{label}</p>
+        ))}
+        {/* The five action slots, empty — the grid has nine columns, and a strip
+            that stopped after four would right-align its labels against the
+            wrong edge. */}
+        {[0, 1, 2, 3, 4].map(slot => <span key={slot} aria-hidden="true" />)}
+      </div>
+      </div>
     </div>
   );
 }
@@ -200,7 +289,7 @@ export function AccountBalanceCell({
 }): React.JSX.Element {
   return (
     <div className={smOnly ? 'hidden sm:block text-right' : 'text-right'}>
-      <p className={CELL_LABEL_CLASS}>{label}</p>
+      <p className={ROW_LABEL_CLASS}>{label}</p>
       <p className={`${CELL_FIGURE_CLASS} text-gray-900 dark:text-white`}>{value}</p>
     </div>
   );
@@ -244,7 +333,7 @@ export function AccountCountCell({
 }): React.JSX.Element {
   return (
     <div className="text-right">
-      <p className={CELL_LABEL_CLASS}>{label}</p>
+      <p className={ROW_LABEL_CLASS}>{label}</p>
       <p
         className={`${CELL_FIGURE_CLASS} ${
           count > 0 ? 'text-slate-600 dark:text-gray-300' : 'text-gray-400 dark:text-gray-500'

--- a/src/components/CategoryTransactionsModal.tsx
+++ b/src/components/CategoryTransactionsModal.tsx
@@ -9,6 +9,7 @@ import EditTransactionModal from './EditTransactionModal';
 import DatePicker from './common/DatePicker';
 import { expandSplitTransactions, type SplitExpandedTransaction } from '../utils/transactionSplits';
 import type { Transaction } from '../types';
+import { useBackdropDismiss } from '../hooks/useBackdropDismiss';
 
 interface CategoryTransactionsModalProps {
   isOpen: boolean;
@@ -25,6 +26,10 @@ export default function CategoryTransactionsModal({
   categoryId,
   categoryName 
 }: CategoryTransactionsModalProps) {
+  // Press AND release must both be on the backdrop — see useBackdropDismiss.
+  const backdropDismiss = useBackdropDismiss(onClose);
+
+
   const { transactions, transactionSplits, accounts } = useApp();
   const { formatCurrency } = useCurrencyDecimal();
   
@@ -176,7 +181,7 @@ export default function CategoryTransactionsModal({
   
   return (
     <div className="fixed inset-0 bg-black bg-opacity-50 flex items-end sm:items-center justify-center z-50"
-          onClick={(e) => { if (e.target === e.currentTarget) onClose(); }}>
+          {...backdropDismiss}>
       <div className="bg-white dark:bg-gray-800 rounded-t-lg sm:rounded-lg shadow-xl w-full sm:max-w-4xl max-h-[90vh] sm:max-h-[85vh] flex flex-col">
         {/* Header */}
         <div className="px-4 sm:px-6 py-3 sm:py-4 border-b border-gray-200 dark:border-gray-700">

--- a/src/components/CrossCurrencyTransferDialog.tsx
+++ b/src/components/CrossCurrencyTransferDialog.tsx
@@ -12,6 +12,7 @@ import {
 } from '../utils/fx';
 import { useFxQuote } from '../hooks/useFxQuote';
 import type { ConfirmedConversion } from '../utils/crossCurrencyTransfer';
+import { useBackdropDismiss } from '../hooks/useBackdropDismiss';
 
 /**
  * The one question a cross-currency transfer has to ask, asked once.
@@ -73,6 +74,7 @@ const asMoneyText = (value: DecimalInstance): string => value.toFixed(AMOUNT_DP)
  * returns `null` rather than clamping.
  */
 function readPositive(text: string): DecimalInstance | null {
+
   const trimmed = text.trim();
   if (trimmed === '') return null;
   try {
@@ -95,6 +97,9 @@ export default function CrossCurrencyTransferDialog({
   onConfirm,
   onCancel,
 }: CrossCurrencyTransferDialogProps): React.JSX.Element | null {
+  // Press AND release must both be on the backdrop — see useBackdropDismiss.
+  const backdropDismiss = useBackdropDismiss(onCancel);
+
   const quote = useFxQuote(isOpen ? sourceCurrency : null, isOpen ? destinationCurrency : null);
 
   const [rateText, setRateText] = useState('');
@@ -205,7 +210,7 @@ export default function CrossCurrencyTransferDialog({
   return createPortal(
     <div
       className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-[70] p-4"
-      onClick={(e) => { if (e.target === e.currentTarget) onCancel(); }}
+      {...backdropDismiss}
     >
       <div
         role="dialog"

--- a/src/components/TransferMatchDialog.tsx
+++ b/src/components/TransferMatchDialog.tsx
@@ -5,6 +5,7 @@ import { amountWithCurrencyCode } from '../utils/crossCurrencyLabel';
 import { ArrowRightLeftIcon } from './icons';
 import type { Transaction } from '../types';
 import type { TransferCandidate } from '../utils/transferMatch';
+import { useBackdropDismiss } from '../hooks/useBackdropDismiss';
 
 /**
  * The Money-style transfer confirmation. Shown when a transaction is filed
@@ -40,6 +41,10 @@ export default function TransferMatchDialog({
   onCreate,
   onCancel,
 }: TransferMatchDialogProps): React.JSX.Element | null {
+  // Press AND release must both be on the backdrop — see useBackdropDismiss.
+  const backdropDismiss = useBackdropDismiss(onCancel);
+
+
   const { formatCurrency } = useCurrencyDecimal();
   // Seeded at mount, not just in the effect: the effect alone left a frame
   // where the dialog was visible with "Link as transfer" still disabled — a
@@ -82,7 +87,7 @@ export default function TransferMatchDialog({
   return createPortal(
     <div
       className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-[70] p-4"
-      onClick={(e) => { if (e.target === e.currentTarget) onCancel(); }}
+      {...backdropDismiss}
     >
       <div className="bg-white dark:bg-gray-800 rounded-2xl p-4 sm:p-6 w-full max-w-lg mx-4 shadow-xl">
         <div className="flex items-center gap-3 mb-3">

--- a/src/components/TransferRepointDialog.tsx
+++ b/src/components/TransferRepointDialog.tsx
@@ -3,6 +3,7 @@ import { createPortal } from 'react-dom';
 import { useCurrencyDecimal } from '../hooks/useCurrencyDecimal';
 import { ArrowRightLeftIcon } from './icons';
 import type { Transaction, TransferDisplacedDisposition } from '../types';
+import { useBackdropDismiss } from '../hooks/useBackdropDismiss';
 
 /**
  * "This transfer's other side may be a real transaction. What should happen to
@@ -50,6 +51,10 @@ export default function TransferRepointDialog({
   onChoose,
   onCancel,
 }: TransferRepointDialogProps): React.JSX.Element {
+  // Press AND release must both be on the backdrop — see useBackdropDismiss.
+  const backdropDismiss = useBackdropDismiss(onCancel);
+
+
   const { formatCurrency } = useCurrencyDecimal();
   const firstButtonRef = useRef<HTMLButtonElement>(null);
 
@@ -76,7 +81,7 @@ export default function TransferRepointDialog({
           onCancel();
         }
       }}
-      onClick={(e) => { if (e.target === e.currentTarget) onCancel(); }}
+      {...backdropDismiss}
     >
       <div className="bg-white dark:bg-gray-800 rounded-2xl p-4 sm:p-6 w-full max-w-lg mx-4 shadow-xl">
         <div className="flex items-center gap-3 mb-3">

--- a/src/components/__tests__/Layout.test.tsx
+++ b/src/components/__tests__/Layout.test.tsx
@@ -312,9 +312,30 @@ describe('Layout — the Plan menu and split triggers', () => {
 
     renderWithProviders(<Layout />);
 
-    // By its heading: "Add Transaction" is also a word on the modal's own save
-    // button, and the query has to name the thing that proves it is open.
-    expect(await screen.findByRole('heading', { name: 'Add Transaction' })).toBeInTheDocument();
+    /*
+     * By its heading: "Add Transaction" is also a word on the modal's own save
+     * button, and the query has to name the thing that proves it is open.
+     *
+     * THE EXPLICIT TIMEOUT IS A MEASUREMENT, NOT A SHRUG. This assertion failed
+     * three times inside `npm run test:coverage` on 2026-08-13 and could not be
+     * reproduced afterwards in four attempts — three with instrumentation on
+     * this file plus its neighbour, one over the whole 396-file suite.
+     *
+     * What it costs unloaded is 190ms against testing-library's 1000ms default,
+     * so the budget is roughly 5x. That is thin rather than generous: this
+     * renders the WHOLE frame — nav, search, the modal — and every failure
+     * happened during a pre-push run while a Vite dev server and a browser were
+     * competing for the same cores. A 5x slowdown under that is ordinary.
+     *
+     * So the timeout is raised rather than the test rewritten, because there is
+     * no race to fix: the assertion is inherently eventual (render → effect →
+     * modal) and deterministic. 5s keeps it failing fast if the behaviour ever
+     * genuinely breaks, while removing a coin toss that costs a four-minute
+     * gate re-run when it lands.
+     */
+    expect(
+      await screen.findByRole('heading', { name: 'Add Transaction' }, { timeout: 5000 })
+    ).toBeInTheDocument();
     // And the parameter is spent, so back or refresh cannot re-open it.
     await waitFor(() => {
       expect(new URLSearchParams(window.location.search).get('action')).toBeNull();

--- a/src/components/charts/chartColors.ts
+++ b/src/components/charts/chartColors.ts
@@ -187,3 +187,47 @@ export const SEMANTIC_SERIES = {
   income: '#0d9f6f',
   expense: '#d94052',
 } as const;
+
+/**
+ * A measurement drawn beside the parts it is made of — separated by SHAPE, in
+ * one hue (design ruling, 2026-08-13 night, §3.1).
+ *
+ * ── WHY NOT THREE COLOURS ───────────────────────────────────────────────────
+ *
+ * Net worth over time draws three lines, and they were income-green and
+ * expense-red, which said the wrong thing twice: assets and liabilities are
+ * MAGNITUDES, not money in and out, and colouring them that way reinstated on
+ * the chart exactly what the design pass had removed from the summary card two
+ * inches above it.
+ *
+ * The obvious repair — three steps of the categorical ramp — fails, measured:
+ * ramp indices 0 and 2 are 1.17:1 apart on light and 1.19:1 on dark, so Net
+ * worth and Liabilities come out the same colour. Nothing in a navy→slate axis
+ * separates three traceable lines on both grounds.
+ *
+ * A third HUE was the other option and was refused for a better reason than
+ * contrast. These are not three categories: assets and liabilities are the two
+ * components of net worth, one measurement decomposed, exactly as the summary
+ * card's three cells are. A hue of its own would assert that liabilities are a
+ * third unrelated thing — the same false statement the green and red were
+ * making.
+ *
+ * So shape carries identity, weight carries hierarchy, and one hue says these
+ * belong to each other. It survives greyscale, print and a colour-blind reader,
+ * none of which a third hue would have given.
+ *
+ * ── THE CONDITION THE RULING CAME WITH ──────────────────────────────────────
+ *
+ * The legend must show the ACTUAL dash pattern. Three identical navy squares
+ * would be worse than the bug this replaces, so the chart supplies its own
+ * legend content rather than trusting recharts' default swatch — see
+ * NetWorthReport. `dash` is `strokeDasharray`; `undefined` is a solid line.
+ */
+export const DECOMPOSITION_SERIES = {
+  /** The answer. Solid and heaviest — the other two explain it. */
+  total: { color: CATEGORICAL_AXIS[0], width: 2.5, dash: undefined },
+  /** A component. Same hue, dashed. */
+  part: { color: CATEGORICAL_AXIS[2], width: 1.5, dash: '6 3' },
+  /** The other component. Same hue again, dotted, so the two parts differ. */
+  counterpart: { color: CATEGORICAL_AXIS[2], width: 1.5, dash: '1 3' },
+} as const;

--- a/src/components/common/Modal.dismiss.test.tsx
+++ b/src/components/common/Modal.dismiss.test.tsx
@@ -1,0 +1,104 @@
+/**
+ * What counts as "clicked outside" a dialog.
+ *
+ * ─ THE BUG THIS EXISTS TO CATCH ────────────────────────────────────────────
+ * Selecting text inside a modal and releasing the mouse a few pixels outside it
+ * threw the dialog away, losing whatever had been typed. The owner hit it on
+ * Account Settings while selecting an institution name; because the dismissal
+ * lives in this shared component, it was live on all 35 surfaces that use it.
+ *
+ * The cause is that a browser attributes a `click` to the nearest common
+ * ancestor of where the button went DOWN and where it came UP. Press inside the
+ * panel, release over the backdrop, and the common ancestor is the backdrop
+ * container — so `e.target === e.currentTarget` was true and the modal read a
+ * text selection as a dismissal.
+ *
+ * ─ WHY THE TESTS LOOK LIKE THIS ────────────────────────────────────────────
+ * Every case here fires the WHOLE gesture — pointerdown somewhere, click
+ * somewhere — because a test that fires only `click` cannot tell the two apart
+ * and would have passed against the broken code. That is the same lesson the
+ * dashboard's period menu taught the hard way: a click is five events, and the
+ * last one on its own is not the gesture.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { Modal } from './Modal';
+
+/** The full-screen container that owns the dismissal, as the DOM sees it. */
+const backdrop = (): HTMLElement => {
+  const dialog = screen.getByRole('dialog');
+  const container = dialog.parentElement;
+  if (!(container instanceof HTMLElement)) throw new Error('dialog has no container');
+  return container;
+};
+
+const open = (onClose: () => void) =>
+  render(
+    <Modal isOpen onClose={onClose} title="Account Settings">
+      <input aria-label="Institution" defaultValue="Investec" />
+    </Modal>
+  );
+
+describe('dismissing a modal by clicking outside it', () => {
+  it('closes when the press AND the release are both outside', () => {
+    const onClose = vi.fn();
+    open(onClose);
+
+    fireEvent.pointerDown(backdrop());
+    fireEvent.click(backdrop());
+
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('does NOT close when a selection starts inside and ends outside', () => {
+    // The reported bug, in one test. The click lands on the container because
+    // that is the common ancestor of the two ends of the drag — which is not
+    // the same statement as "the user clicked outside".
+    const onClose = vi.fn();
+    open(onClose);
+
+    fireEvent.pointerDown(screen.getByLabelText('Institution'));
+    fireEvent.click(backdrop());
+
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it('does not close on a click inside the panel', () => {
+    const onClose = vi.fn();
+    open(onClose);
+
+    fireEvent.pointerDown(screen.getByLabelText('Institution'));
+    fireEvent.click(screen.getByLabelText('Institution'));
+
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it('forgets the press, so the NEXT outside click still dismisses', () => {
+    // The flag has to be cleared or one drag-out would arm the dialog against
+    // every later dismissal — a bug fix that quietly breaks the feature.
+    const onClose = vi.fn();
+    open(onClose);
+
+    fireEvent.pointerDown(screen.getByLabelText('Institution'));
+    fireEvent.click(backdrop());
+    expect(onClose).not.toHaveBeenCalled();
+
+    fireEvent.pointerDown(backdrop());
+    fireEvent.click(backdrop());
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('never dismisses on the backdrop when the caller has forbidden it', () => {
+    const onClose = vi.fn();
+    render(
+      <Modal isOpen onClose={onClose} title="Importing" closeOnBackdrop={false}>
+        <p>Do not interrupt</p>
+      </Modal>
+    );
+
+    fireEvent.pointerDown(backdrop());
+    fireEvent.click(backdrop());
+
+    expect(onClose).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/common/Modal.test.tsx
+++ b/src/components/common/Modal.test.tsx
@@ -160,7 +160,15 @@ describe('Modal', () => {
       // Outside-clicks land on the full-screen CONTAINER (it sits above the
       // decorative backdrop); the modal closes only when the click target is
       // the container itself, never something inside the panel.
+      //
+      // The pointerDown is not ceremony: a dismissal now requires the press AND
+      // the release to be on the container, because a click is attributed to
+      // the common ancestor of where the button went down and came up — so a
+      // selection that started inside the panel and ended outside it was
+      // closing the dialog and losing the edit. Modal.dismiss.test.tsx covers
+      // that gesture; this one still asserts the ordinary case works.
       const container = document.querySelector('[role="dialog"]')!.parentElement!;
+      fireEvent.pointerDown(container);
       fireEvent.click(container);
 
       expect(mockOnClose).toHaveBeenCalledTimes(1);

--- a/src/components/common/Modal.tsx
+++ b/src/components/common/Modal.tsx
@@ -41,6 +41,14 @@ export function Modal({
 }: ModalProps): React.JSX.Element | null {
   const modalRef = useRef<HTMLDivElement>(null);
   const previousActiveElement = useRef<HTMLElement | null>(null);
+  /**
+   * Did the press that is about to become a click START on the backdrop?
+   *
+   * A ref rather than state: it is written during a pointer event and read in
+   * the click that follows, and nothing renders from it — making it state would
+   * re-render every open modal on every press for a value no one draws.
+   */
+  const pressedOnBackdrop = useRef(false);
 
   // Latest-callback ref: callers routinely pass inline `onClose={() => …}`
   // handlers whose identity changes every render. With onClose in the effect
@@ -180,10 +188,31 @@ export function Modal({
       {/* Modal Container - Top-aligned below search bar. The container covers
           the whole screen ABOVE the backdrop, so outside-clicks land here —
           close only when the click is on the container itself, never on
-          anything inside the panel. */}
+          anything inside the panel.
+
+          ── AND ONLY WHEN THE PRESS BEGAN THERE TOO ──────────────────────────
+          `e.target === e.currentTarget` alone is not "clicked outside", it is
+          "the click EVENT was attributed to the container" — and a browser
+          attributes a click to the nearest common ancestor of where the button
+          went down and where it came up. So selecting text in a field and
+          releasing the mouse a few pixels outside the panel produced a click on
+          this container and threw the dialog away mid-edit, losing whatever had
+          been typed. The owner hit it on Account Settings while selecting an
+          institution name, and it was live on all 35 surfaces that use this
+          component, not just that one.
+
+          Recording the pointer-down settles it: a dismissal now needs the press
+          AND the release to be on the container. Same shape as the fix the
+          dashboard's period menu needed, and the same lesson — a click is five
+          events, and treating the last one as the whole gesture is what makes a
+          control unusable in ways no test that fires `click` can see. */}
       <div
         className="fixed inset-0 z-50 flex items-start justify-center px-4 pt-16 pb-6 overflow-y-auto"
-        onClick={closeOnBackdrop ? (e) => { if (e.target === e.currentTarget) onClose(); } : undefined}
+        onPointerDown={closeOnBackdrop ? (e) => { pressedOnBackdrop.current = e.target === e.currentTarget; } : undefined}
+        onClick={closeOnBackdrop ? (e) => {
+          if (e.target === e.currentTarget && pressedOnBackdrop.current) onClose();
+          pressedOnBackdrop.current = false;
+        } : undefined}
       >
         <div
           ref={modalRef}

--- a/src/components/common/StatPill.tsx
+++ b/src/components/common/StatPill.tsx
@@ -1,0 +1,127 @@
+import React from 'react';
+
+/**
+ * ONE FIGURE UNDER ONE LABEL — the smallest thing in this app that carries a
+ * design decision about how a number is presented.
+ *
+ * ─ WHY THIS AND NOT A SHARED CARD ──────────────────────────────────────────
+ *
+ * The design review flagged that the register header had "opted out" of the
+ * shared net-worth summary card, and the follow-up ruling withdrew that: the
+ * register should NOT be converted. Its four figures are single-account
+ * RECONCILIATION state in that account's own currency, where
+ * `assets − liabilities = net worth` is replaced by `bank − ledger =
+ * difference`, and two of the four can legitimately be unknown. A component
+ * holding both would need a currency mode and a nullable mode, "at which point
+ * it's two components wearing one name".
+ *
+ * The rule the ruling left behind, which is why this file is small:
+ *
+ *   Share the smallest element that carries a decision, not the largest
+ *   arrangement that looks similar. Composition is cheap; a shared component
+ *   with two modes is a permanent tax.
+ *
+ * So what is shared is the PAIR — a label and the figure under it — and the
+ * decisions that pair embodies: the label's voice, the figure's weight, digits
+ * that line up, one colour vocabulary, and one way of saying "not known".
+ * Arrangement stays with the surface: the summary card stacks three of these in
+ * a divided grid, the register lays four along a header. Neither has to ask
+ * this component's permission to do that.
+ *
+ * ─ TABULAR FIGURES ARE NOT DECORATION HERE ─────────────────────────────────
+ *
+ * `tabular-nums` is app-wide on `body`, but it is named again on the figure
+ * because these are the numbers most likely to be READ AS A COLUMN — four
+ * balances down a phone screen, three totals across a card — and a proportional
+ * digit set makes a column of money jitter. Naming it locally means a future
+ * font change on `body` cannot quietly take it away from the one place it
+ * matters most.
+ */
+
+/** What a figure MEANS, when it means anything. */
+export type StatTone =
+  /** A magnitude. Net worth, a balance, a count — most figures. */
+  | 'neutral'
+  /** Money in, or a balance in credit. */
+  | 'positive'
+  /** Money out, or a balance in the red. */
+  | 'negative'
+  /** Agreed, matched, nothing outstanding. */
+  | 'settled';
+
+const TONE_CLASS: Record<StatTone, string> = {
+  neutral: 'text-gray-900 dark:text-white',
+  positive: 'text-green-600 dark:text-green-400',
+  negative: 'text-red-600 dark:text-red-400',
+  settled: 'text-blue-600 dark:text-blue-400',
+};
+
+/** How large the figure is. Hierarchy is carried by SIZE, never by colour. */
+export type StatSize = 'display' | 'page' | 'dense';
+
+const SIZE_CLASS: Record<StatSize, string> = {
+  display: 'text-display font-semibold',
+  page: 'text-page font-semibold',
+  dense: 'text-sm font-bold',
+};
+
+export interface StatPillProps {
+  /** What the figure is. Sentence case; the surface decides about capitals. */
+  label: string;
+  /**
+   * The figure, ALREADY FORMATTED by the caller — this component never sees a
+   * number and so can never format one in the wrong currency.
+   *
+   * `null` means NOT KNOWN, and renders an em-dash. That is a different
+   * statement from zero, and the distinction is load-bearing in the register:
+   * an account with no bank feed has no bank balance, which is not the same as
+   * a bank balance of nothing. It replaces the "N/A" the register used to
+   * print — an abbreviation the rest of the app does not use.
+   */
+  value: string | null;
+  tone?: StatTone;
+  size?: StatSize;
+  /**
+   * `stacked` puts the label over the figure (a card cell); `inline` puts them
+   * side by side with the figure at the end (a header pill). Two arrangements
+   * because the app genuinely has two, and both are this pair — not two
+   * components wearing one name.
+   */
+  layout?: 'stacked' | 'inline';
+}
+
+/** The label's voice, wherever it appears. */
+const LABEL_CLASS = 'text-label text-gray-500 dark:text-gray-400';
+
+export default function StatPill({
+  label,
+  value,
+  tone = 'neutral',
+  size = 'dense',
+  layout = 'stacked',
+}: StatPillProps): React.JSX.Element {
+  // An unknown figure is never coloured: a tone would be a claim about a value
+  // that is not there.
+  const figureTone = value === null ? 'text-gray-400 dark:text-gray-500' : TONE_CLASS[tone];
+  const figure = (
+    <span className={`${SIZE_CLASS[size]} tabular-nums whitespace-nowrap ${figureTone}`}>
+      {value ?? '—'}
+    </span>
+  );
+
+  if (layout === 'inline') {
+    return (
+      <span className="flex items-center gap-3 justify-between lg:justify-normal">
+        <span className={`${LABEL_CLASS} whitespace-nowrap`}>{label}</span>
+        {figure}
+      </span>
+    );
+  }
+
+  return (
+    <span className="flex flex-col items-start">
+      <span className={`${LABEL_CLASS} uppercase font-medium`}>{label}</span>
+      <span className="mt-1">{figure}</span>
+    </span>
+  );
+}

--- a/src/components/dashboard/reportWidgets/DashboardReportWidgets.tsx
+++ b/src/components/dashboard/reportWidgets/DashboardReportWidgets.tsx
@@ -27,6 +27,7 @@ import DashboardWidgetCard from './DashboardWidgetCard';
 import CardPeriodControl from './CardPeriodControl';
 import { WIDGET_CHART_HEIGHT } from './widgetChrome';
 import { useReportDrill } from './useReportDrill';
+import { useHistoricalAccounts } from '../../../hooks/useHistoricalAccounts';
 
 /**
  * Compact, live versions of the Reports-hub reports for the Dashboard's
@@ -77,9 +78,17 @@ export function NetWorthWidget({ picker, pin }: {
   picker: UsePeriodResult;
   pin?: CardPeriodPin;
 }): React.JSX.Element {
-  const { accounts, transactions } = useApp();
+  const { accounts: openAccounts, transactions } = useApp();
   const { formatCurrency } = useCurrencyDecimal();
   const openReport = useReportDrill();
+
+  /**
+   * OPEN AND CLOSED. This card draws the same series as the full report and
+   * must not disagree with it: the app context holds open accounts only, so
+   * both used to omit whatever the owner's closed accounts held at each point
+   * in the past. See useHistoricalAccounts.
+   */
+  const accounts = useHistoricalAccounts(openAccounts);
 
   const snapshots = useMemo(
     () => buildNetWorthSnapshots(accounts, transactions, picker.range),

--- a/src/components/reconciliation/ReconciliationFinalizationModal.tsx
+++ b/src/components/reconciliation/ReconciliationFinalizationModal.tsx
@@ -6,6 +6,7 @@ import DatePicker from '../common/DatePicker';
 import { useCurrencyDecimal } from '../../hooks/useCurrencyDecimal';
 import { parseMoneyInput, toDecimal } from '../../utils/decimal';
 import { deriveAdjustment } from '../../utils/reconciliation';
+import { useBackdropDismiss } from '../../hooks/useBackdropDismiss';
 
 interface ReconciliationFinalizationModalProps {
   isOpen: boolean;
@@ -57,6 +58,10 @@ export default function ReconciliationFinalizationModal({
   onFinalize,
   onCreateAdjustment,
 }: ReconciliationFinalizationModalProps): React.JSX.Element | null {
+  // Press AND release must both be on the backdrop — see useBackdropDismiss.
+  const backdropDismiss = useBackdropDismiss(onClose);
+
+
   const { formatCurrency } = useCurrencyDecimal();
 
   const difference = toDecimal(confirmedBalance).minus(toDecimal(clearedBalance)).toNumber();
@@ -119,7 +124,7 @@ export default function ReconciliationFinalizationModal({
 
   return (
     <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4"
-          onClick={(e) => { if (e.target === e.currentTarget) onClose(); }}>
+          {...backdropDismiss}>
       <div className="bg-white dark:bg-gray-800 rounded-2xl shadow-xl max-w-md w-full p-6">
         {/* Header */}
         <div className="flex items-center justify-between mb-4">

--- a/src/hooks/useBackdropDismiss.ts
+++ b/src/hooks/useBackdropDismiss.ts
@@ -1,0 +1,65 @@
+import { useCallback, useRef } from 'react';
+import type { PointerEvent as ReactPointerEvent, MouseEvent as ReactMouseEvent } from 'react';
+
+/**
+ * What counts as "clicked outside" a dialog — one answer, for every dialog.
+ *
+ * ─ THE BUG ─────────────────────────────────────────────────────────────────
+ *
+ * Eight surfaces each wrote this, and each wrote it the same way:
+ *
+ *   onClick={(e) => { if (e.target === e.currentTarget) onClose(); }}
+ *
+ * which reads as "the click was on the backdrop, not the panel" and is not
+ * what it says. A browser attributes a `click` to the nearest common ANCESTOR
+ * of where the button went down and where it came up. So selecting text in a
+ * field and releasing the mouse a few pixels past the panel's edge produces a
+ * click on the backdrop — and the dialog threw itself away mid-edit, taking
+ * whatever had been typed with it.
+ *
+ * The owner found it selecting an institution name in Account Settings, then
+ * asked the right question: "I also dont know if the same problem is anywhere
+ * else?" It was, in all eight.
+ *
+ * ─ THE ANSWER ──────────────────────────────────────────────────────────────
+ *
+ * A dismissal needs the press AND the release on the backdrop. Recording the
+ * pointer-down is the whole fix, and putting it here means the next dialog
+ * inherits it instead of re-deriving it.
+ *
+ * ─ WHAT THIS IS NOT FOR ────────────────────────────────────────────────────
+ *
+ * The dropdowns and popovers that dismiss via a document-level `mousedown`
+ * listener are a different pattern and are already correct: they close on the
+ * PRESS, so a drag that began inside them never reaches the listener at all.
+ * They need nothing from this hook.
+ */
+export interface BackdropDismissHandlers {
+  onPointerDown: (event: ReactPointerEvent<HTMLElement>) => void;
+  onClick: (event: ReactMouseEvent<HTMLElement>) => void;
+}
+
+export function useBackdropDismiss(onDismiss: () => void): BackdropDismissHandlers {
+  /**
+   * Whether the press that is about to become a click began on the backdrop.
+   *
+   * A ref, not state: written during a pointer event, read in the click that
+   * follows, and drawn by nothing — as state it would re-render the whole
+   * dialog on every press to store a boolean no one displays.
+   */
+  const pressedOnBackdrop = useRef(false);
+
+  const onPointerDown = useCallback((event: ReactPointerEvent<HTMLElement>): void => {
+    pressedOnBackdrop.current = event.target === event.currentTarget;
+  }, []);
+
+  const onClick = useCallback((event: ReactMouseEvent<HTMLElement>): void => {
+    const outside = event.target === event.currentTarget && pressedOnBackdrop.current;
+    // Cleared either way. Left set, one drag-out would arm the dialog against
+    // every dismissal after it — a fix that quietly removes the feature.
+    pressedOnBackdrop.current = false;
+    if (outside) onDismiss();
+  }, [onDismiss]);
+
+  return { onPointerDown, onClick };
+}

--- a/src/hooks/useHistoricalAccounts.ts
+++ b/src/hooks/useHistoricalAccounts.ts
@@ -1,0 +1,80 @@
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { dataPort } from '@data';
+import type { Account } from '../types';
+
+/**
+ * Every account that has ever held money — open AND closed.
+ *
+ * ─ THE BUG THIS EXISTS TO FIX ──────────────────────────────────────────────
+ *
+ * `accountService.getAccounts` fetches with `.eq('is_active', true)`, so the
+ * app context holds OPEN accounts only. Closed ones are a separate call
+ * (`listClosedAccounts`) that, until now, only the Accounts page ever made.
+ *
+ * Net worth over time was built from the context's list, so it silently
+ * excluded every closed account. The owner has 110 of them, and asked the
+ * question that found it: "Does my net worth over time report include closed
+ * accounts?" It did not — so an account that ran from 2010 to 2020 with money
+ * in it contributed NOTHING to the 2015 point. The error grows the further back
+ * you look, because more of a person's closed accounts were open then, which is
+ * exactly the shape of "the early years look flatter than I remember".
+ *
+ * ─ WHY A CLOSED ACCOUNT BELONGS IN HISTORY ─────────────────────────────────
+ *
+ * Closing is the Microsoft Money model this app follows: it HIDES an account
+ * and preserves every transaction, and it can be reopened at any time. The
+ * money was really there on the day. A chart of what you were worth that omits
+ * it is answering a different question — "what my currently-open accounts were
+ * worth back then" — which nobody asked.
+ *
+ * ─ WHY THE TRANSACTIONS NEED NO EQUIVALENT ─────────────────────────────────
+ *
+ * They are already loaded. `getTransactions` pages by USER, not by account, so
+ * the rows belonging to closed accounts were in memory the whole time — they
+ * simply had no account to attach to and fell out of the walk. That is why this
+ * is a small fix rather than a second fetch of 50,000 rows.
+ *
+ * ─ WHAT IT DOES NOT CHANGE ─────────────────────────────────────────────────
+ *
+ * The Accounts list keeps its own open/closed split — that page is about what
+ * you hold now and deliberately files the archive separately. This hook is for
+ * surfaces that walk HISTORY.
+ */
+export function useHistoricalAccounts(openAccounts: Account[]): Account[] {
+  const [closed, setClosed] = useState<Account[]>([]);
+
+  /**
+   * The fetch outlives the page whenever somebody navigates before it lands,
+   * and a state write after that is a write to a component that no longer
+   * exists. Same guard, and the same reason, as the Accounts page's own.
+   */
+  const isMounted = useRef(true);
+  useEffect(() => {
+    isMounted.current = true;
+    return () => { isMounted.current = false; };
+  }, []);
+
+  useEffect(() => {
+    let cancelled = false;
+    void (async () => {
+      try {
+        const rows = await dataPort.listClosedAccounts();
+        if (!cancelled && isMounted.current) setClosed(rows);
+      } catch {
+        // Non-fatal, and it degrades to exactly the old behaviour: the history
+        // is drawn from the open accounts alone. Better a chart that understates
+        // than a report that refuses to render.
+        if (!cancelled && isMounted.current) setClosed([]);
+      }
+    })();
+    return () => { cancelled = true; };
+  }, []);
+
+  return useMemo(() => {
+    if (closed.length === 0) return openAccounts;
+    // Guarded against an id appearing in both lists — a reopen that races the
+    // fetch would otherwise count that account's balance twice.
+    const seen = new Set(openAccounts.map(a => a.id));
+    return [...openAccounts, ...closed.filter(a => !seen.has(a.id))];
+  }, [openAccounts, closed]);
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -202,7 +202,28 @@ const clerkAppearance: Appearance = {
     headerTitle: { color: '#111827' },
     headerSubtitle: { color: '#6b7280' },
     // Social / secondary buttons stay neutral (near-black label, never blue).
-    socialButtonsBlockButton: { color: '#111827' }
+    socialButtonsBlockButton: { color: '#111827' },
+    /*
+     * THE AVATAR, which is the most-seen element in the product and was the
+     * only gradient in it.
+     *
+     * The design review flagged a purple→blue gradient "top-right of every page
+     * in the app" and reasonably assumed it was ours. It is not — it is Clerk's
+     * generated initials avatar, which is why searching our source for
+     * `from-purple-500 to-blue-600` finds nothing. But the conclusion that we
+     * could not change it was also wrong: this appearance object reaches every
+     * Clerk surface, and it simply had no rule for the avatar.
+     *
+     * `backgroundImage: 'none'` first, because the default is a background
+     * IMAGE — a colour alone would paint underneath it and change nothing.
+     * Slate with a white initial, matching the ruling and every other Clerk
+     * surface above.
+     */
+    avatarBox: {
+      backgroundImage: 'none',
+      backgroundColor: '#1a2332',
+      color: '#ffffff'
+    }
   }
 };
 

--- a/src/pages/AccountTransactions.tsx
+++ b/src/pages/AccountTransactions.tsx
@@ -11,6 +11,7 @@ import { isReconciled } from '../utils/transactionReconciliation';
 import { preserveDemoParam } from '../utils/navigation';
 import { useCurrencyDecimal } from '../hooks/useCurrencyDecimal';
 import { ArrowLeftIcon, SearchIcon, PlusIcon, CalendarIcon, XIcon, SettingsIcon, FilterIcon, ChevronUpIcon, ChevronDownIcon, MaximizeIcon, MinimizeIcon, EyeIcon, KeyboardIcon, AlertCircleIcon } from '../components/icons';
+import StatPill from '../components/common/StatPill';
 import DatePicker from '../components/common/DatePicker';
 import MoneyInput from '../components/common/MoneyInput';
 import EditTransactionModal from '../components/EditTransactionModal';
@@ -3032,53 +3033,51 @@ export default function AccountTransactions() {
             figure right — they used to wrap into ragged rows of unequal
             pills. From lg they sit inline beside the title as before. */}
         <div className="grid grid-cols-1 gap-2 w-full lg:w-auto lg:flex lg:flex-wrap lg:items-center">
-          <div className="bg-white/90 dark:bg-gray-800/90 backdrop-blur-xl rounded-lg border border-gray-100 dark:border-gray-700 px-3 py-1.5 flex items-center gap-3 justify-between lg:justify-normal">
-            <span className="text-xs text-gray-500 dark:text-gray-400 whitespace-nowrap">Account Balance</span>
-            <span className={`text-sm font-bold whitespace-nowrap ${
-              computedAccountBalance >= 0
-                ? 'text-green-600 dark:text-green-400'
-                : 'text-red-600 dark:text-red-400'
-            }`}>
-              {formatRegisterMoney(computedAccountBalance)}
-            </span>
+          {/* Four pills, four <StatPill>s — the register keeps its own
+              ARRANGEMENT (a header strip, label beside figure) and shares only
+              the pair. The design ruling was explicit that this header must not
+              become the net-worth summary card: `bank − ledger = difference` in
+              one account's own currency is a different statement from
+              `assets − liabilities = net worth` across all of them.
+
+              Two of these four can be UNKNOWN rather than zero — an account
+              with no bank feed has no bank balance — which used to print "N/A"
+              and now prints an em-dash, uncoloured. */}
+          <div className="bg-white/90 dark:bg-gray-800/90 backdrop-blur-xl rounded-lg border border-gray-100 dark:border-gray-700 px-3 py-1.5">
+            <StatPill
+              label="Account Balance"
+              value={formatRegisterMoney(computedAccountBalance)}
+              tone={computedAccountBalance >= 0 ? 'positive' : 'negative'}
+              layout="inline"
+            />
           </div>
 
-          <div className="bg-white/90 dark:bg-gray-800/90 backdrop-blur-xl rounded-lg border border-gray-100 dark:border-gray-700 px-3 py-1.5 flex items-center gap-3 justify-between lg:justify-normal">
-            <span className="text-xs text-gray-500 dark:text-gray-400 whitespace-nowrap">Bank Balance</span>
-            <span className={`text-sm font-bold whitespace-nowrap ${
-              bankBalance != null
-                ? bankBalance >= 0
-                  ? 'text-green-600 dark:text-green-400'
-                  : 'text-red-600 dark:text-red-400'
-                : 'text-gray-400 dark:text-gray-500'
-            }`}>
-              {bankBalance != null ? formatRegisterMoney(bankBalance) : 'N/A'}
-            </span>
+          <div className="bg-white/90 dark:bg-gray-800/90 backdrop-blur-xl rounded-lg border border-gray-100 dark:border-gray-700 px-3 py-1.5">
+            <StatPill
+              label="Bank Balance"
+              value={bankBalance != null ? formatRegisterMoney(bankBalance) : null}
+              tone={bankBalance != null && bankBalance < 0 ? 'negative' : 'positive'}
+              layout="inline"
+            />
           </div>
 
-          <div className="bg-white/90 dark:bg-gray-800/90 backdrop-blur-xl rounded-lg border border-gray-100 dark:border-gray-700 px-3 py-1.5 flex items-center gap-3 justify-between lg:justify-normal">
-            <span className="text-xs text-gray-500 dark:text-gray-400 whitespace-nowrap">Unreconciled</span>
-            <span className="text-sm font-bold text-gray-900 dark:text-white whitespace-nowrap">
-              {formatRegisterMoney(unreconciledTotal)}
-            </span>
+          <div className="bg-white/90 dark:bg-gray-800/90 backdrop-blur-xl rounded-lg border border-gray-100 dark:border-gray-700 px-3 py-1.5">
+            <StatPill
+              label="Unreconciled"
+              value={formatRegisterMoney(unreconciledTotal)}
+              layout="inline"
+            />
           </div>
 
-          <div className="bg-white/90 dark:bg-gray-800/90 backdrop-blur-xl rounded-lg border border-gray-100 dark:border-gray-700 px-3 py-1.5 flex items-center gap-3 justify-between lg:justify-normal">
-            <span className="text-xs text-gray-500 dark:text-gray-400 whitespace-nowrap">Difference</span>
-            {bankBalance != null ? (() => {
-              const difference = bankBalance - computedAccountBalance;
-              return (
-                <span className={`text-sm font-bold whitespace-nowrap ${
-                  difference === 0
-                    ? 'text-blue-600 dark:text-blue-400'
-                    : 'text-red-600 dark:text-red-400'
-                }`}>
-                  {formatRegisterMoney(difference)}
-                </span>
-              );
-            })() : (
-              <span className="text-sm font-bold text-gray-400 dark:text-gray-500 whitespace-nowrap">N/A</span>
-            )}
+          <div className="bg-white/90 dark:bg-gray-800/90 backdrop-blur-xl rounded-lg border border-gray-100 dark:border-gray-700 px-3 py-1.5">
+            <StatPill
+              label="Difference"
+              value={bankBalance != null ? formatRegisterMoney(bankBalance - computedAccountBalance) : null}
+              // Agreed is the good outcome here, and it is not "positive money"
+              // — it is settled. Anything else is a gap to explain.
+              tone={bankBalance != null && bankBalance - computedAccountBalance === 0 ? 'settled' : 'negative'}
+              layout="inline"
+            />
           </div>
         </div>
       </div>

--- a/src/pages/Accounts.tsx
+++ b/src/pages/Accounts.tsx
@@ -62,6 +62,7 @@ import FilteredEmptyState from '../components/FilteredEmptyState';
 import { TableSkeleton, type TableSkeletonColumn } from '../components/loading/TableSkeleton';
 import {
   AccountRowColumns,
+  AccountColumnHeader,
   AccountBalanceCell,
   AccountCountCell,
   AccountRowEmptyCell,
@@ -1589,6 +1590,16 @@ export default function Accounts() {
 
         {isExpanded && (
           <div id={regionId} className="bg-white dark:bg-gray-800">
+            {/* ONE STRIP PER BAND, not four labels on every row.
+                Twenty-odd repetitions of "Bank Bal / Account Bal /
+                Unreconciled / To Review" were the cost of a card that has to
+                explain itself in isolation — the reconciliation list was given
+                one strip per group in the August design pass and this page
+                never was. It sits above the sub-bands rather than inside each
+                one, so an account list grouped by nine institutions says the
+                four words once, not nine times. Phones keep the per-row labels
+                (see AccountRowColumns): below `sm` there is no grid to head. */}
+            <AccountColumnHeader />
             {subBands
               ? subBands.map(sub => {
                   // Count and total describe the WHOLE sub-band, as the section

--- a/src/pages/Accounts.tsx
+++ b/src/pages/Accounts.tsx
@@ -74,6 +74,7 @@ import { useArrivalRowFocus } from '../hooks/useArrivalFocus';
 // The same predicate the Transactions table asks, kept in one place: a click on
 // a row's own button belongs to the button, on both pages.
 import { clickedOwnControl } from '../hooks/useRowClickGesture';
+import { useBackdropDismiss } from '../hooks/useBackdropDismiss';
 import {
   currentPageProvenance,
   readResumeCrumbs,
@@ -310,6 +311,13 @@ export default function Accounts() {
   }, [location.pathname, location.search, navigate]);
 
   const { getUnreconciledCount, computeAccountBalance: computeLedgerBalance } = useReconciliation(accounts, transactions);
+
+  // Both of this page's own dialogs dismiss only when the press AND the release
+  // are on the backdrop — a selection that ends outside is not a dismissal.
+  const closeBankConnections = useCallback(() => setBankConnectionsView(null), []);
+  const closePortfolio = useCallback(() => setPortfolioAccountId(null), []);
+  const bankConnectionsDismiss = useBackdropDismiss(closeBankConnections);
+  const portfolioDismiss = useBackdropDismiss(closePortfolio);
 
   /**
    * How much freshly-imported work is waiting in each account.
@@ -2217,7 +2225,7 @@ export default function Accounts() {
       {bankConnectionsView !== null && (
         <div
           className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50 p-4"
-          onClick={(e) => { if (e.target === e.currentTarget) setBankConnectionsView(null); }}
+          {...bankConnectionsDismiss}
         >
           <div className="bg-white dark:bg-gray-800 rounded-2xl max-w-4xl w-full max-h-[90vh] overflow-hidden">
             <div className="p-6 border-b border-gray-200 dark:border-gray-700 flex justify-between items-center">
@@ -2254,7 +2262,7 @@ export default function Accounts() {
         return (
           <div
             className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50 p-4"
-            onClick={(e) => { if (e.target === e.currentTarget) setPortfolioAccountId(null); }}
+            {...portfolioDismiss}
           >
             <div className="bg-white dark:bg-gray-800 rounded-2xl w-full max-w-6xl max-h-[90vh] overflow-y-auto">
               <div className="p-6">

--- a/src/pages/NetWorthReport.tsx
+++ b/src/pages/NetWorthReport.tsx
@@ -26,6 +26,7 @@ import { TrendingUpIcon, ChevronRightIcon } from '../components/icons';
 import { DECOMPOSITION_SERIES } from '../components/charts/chartColors';
 import type { ReportViewProps } from './reports/types';
 import { preferences } from '../services/preferencesService';
+import { useHistoricalAccounts } from '../hooks/useHistoricalAccounts';
 
 /**
  * Net worth over time — the Microsoft Money report, rebuilt on real data.
@@ -96,7 +97,21 @@ const compactTick = (value: number): string => {
 };
 
 export default function NetWorthReport({ picker, focus }: ReportViewProps): React.JSX.Element {
-  const { accounts, transactions } = useApp();
+  const { accounts: openAccounts, transactions } = useApp();
+  /**
+   * OPEN AND CLOSED, because this page walks history.
+   *
+   * The app context holds open accounts only (`getAccounts` filters on
+   * `is_active`), so every point on this chart used to omit whatever the
+   * owner's 110 closed accounts held at the time — understating the past, and
+   * understating it more the further back you look. See useHistoricalAccounts.
+   *
+   * Everything on this page reads from it: the series, the effective opening
+   * dates, the per-date drill and the caveat note. They must agree, and the
+   * headline above the chart is the LAST POINT of the series rather than a
+   * separately-computed figure, so it moves with them.
+   */
+  const accounts = useHistoricalAccounts(openAccounts);
   const { formatCurrency } = useCurrencyDecimal();
   const navigate = useNavigate();
   const location = useLocation();

--- a/src/pages/NetWorthReport.tsx
+++ b/src/pages/NetWorthReport.tsx
@@ -23,6 +23,7 @@ import { buildNetWorthSnapshots, netWorthPointToken } from '../utils/netWorthSer
 import { useArrivalAction } from '../hooks/useArrivalFocus';
 import { resolveEffectiveOpeningDates } from '../utils/openingDates';
 import { TrendingUpIcon, ChevronRightIcon } from '../components/icons';
+import { DECOMPOSITION_SERIES } from '../components/charts/chartColors';
 import type { ReportViewProps } from './reports/types';
 import { preferences } from '../services/preferencesService';
 
@@ -38,6 +39,53 @@ import { preferences } from '../services/preferencesService';
  * click an account to open its register.
  */
 
+
+/**
+ * The legend, drawing each series as the LINE IT ACTUALLY IS.
+ *
+ * The design ruling that separated these three by shape rather than colour came
+ * with one condition attached: "the legend must show the actual dash pattern,
+ * not a coloured square. A legend that renders three identical navy squares is
+ * worse than the bug we started with."
+ *
+ * Recharts' default legend does not meet that. Measured before writing this:
+ * its swatch is a `<path>` carrying `stroke` and no `stroke-dasharray` at all,
+ * so Assets and Liabilities — deliberately the same hue — came out as two
+ * identical navy lines. The whole point of the ruling is that shape carries
+ * identity, and the default legend is the one place shape was being dropped.
+ *
+ * So the swatch is drawn here from the same `DECOMPOSITION_SERIES` entry the
+ * chart draws from, which is also what stops the two drifting: there is no
+ * second copy of the pattern to forget to update.
+ */
+function DecompositionLegend({ payload }: { payload?: readonly { value?: string }[] }): React.JSX.Element {
+  const style = (name: string | undefined): typeof DECOMPOSITION_SERIES[keyof typeof DECOMPOSITION_SERIES] =>
+    name === 'Assets' ? DECOMPOSITION_SERIES.part
+      : name === 'Liabilities' ? DECOMPOSITION_SERIES.counterpart
+        : DECOMPOSITION_SERIES.total;
+
+  return (
+    <ul className="flex flex-wrap items-center justify-center gap-4 pt-1">
+      {(payload ?? []).map(entry => {
+        const series = style(entry.value);
+        return (
+          <li key={entry.value} className="flex items-center gap-1.5 text-label text-gray-600 dark:text-gray-300">
+            {/* 24px of the real line: same colour, same weight, same dash. */}
+            <svg width="24" height="10" aria-hidden="true" className="flex-shrink-0">
+              <line
+                x1="0" y1="5" x2="24" y2="5"
+                stroke={series.color}
+                strokeWidth={series.width}
+                strokeDasharray={series.dash}
+              />
+            </svg>
+            {entry.value}
+          </li>
+        );
+      })}
+    </ul>
+  );
+}
 
 const compactTick = (value: number): string => {
   const abs = Math.abs(value);
@@ -285,19 +333,46 @@ export default function NetWorthReport({ picker, focus }: ReportViewProps): Reac
                   formatter={(value: number | string) => formatCurrency(typeof value === 'number' ? value : Number(value))}
                   contentStyle={{ borderRadius: '8px' }}
                 />
-                <Legend />
+                <Legend content={<DecompositionLegend />} />
                 {chartType === 'bar' ? (
                   // Money-style bar view: net worth as bars, assets/liabilities
                   // as context lines. Same data, same click-to-drill.
-                  <Bar dataKey="netWorth" name="Net Worth" fill="#1a2332" radius={[3, 3, 0, 0]} cursor="pointer" />
+                  <Bar dataKey="netWorth" name="Net Worth" fill={DECOMPOSITION_SERIES.total.color} radius={[3, 3, 0, 0]} cursor="pointer" />
                 ) : (
-                  <Line type="monotone" dataKey="netWorth" name="Net Worth" stroke="#1a2332" strokeWidth={2.5} dot={singlePointDot(snapshots, '#1a2332')} activeDot={{ r: 5 }} />
+                  <Line
+                    type="monotone"
+                    dataKey="netWorth"
+                    name="Net Worth"
+                    stroke={DECOMPOSITION_SERIES.total.color}
+                    strokeWidth={DECOMPOSITION_SERIES.total.width}
+                    dot={singlePointDot(snapshots, DECOMPOSITION_SERIES.total.color)}
+                    activeDot={{ r: 5 }}
+                    isAnimationActive={false}
+                  />
                 )}
                 {showDetail && (
-                  <Line type="monotone" dataKey="assets" name="Assets" stroke="#10B981" strokeWidth={1.5} dot={singlePointDot(snapshots, '#10B981')} />
+                  <Line
+                    type="monotone"
+                    dataKey="assets"
+                    name="Assets"
+                    stroke={DECOMPOSITION_SERIES.part.color}
+                    strokeWidth={DECOMPOSITION_SERIES.part.width}
+                    strokeDasharray={DECOMPOSITION_SERIES.part.dash}
+                    dot={singlePointDot(snapshots, DECOMPOSITION_SERIES.part.color)}
+                    isAnimationActive={false}
+                  />
                 )}
                 {showDetail && (
-                  <Line type="monotone" dataKey="liabilities" name="Liabilities" stroke="#EF4444" strokeWidth={1.5} dot={singlePointDot(snapshots, '#EF4444')} />
+                  <Line
+                    type="monotone"
+                    dataKey="liabilities"
+                    name="Liabilities"
+                    stroke={DECOMPOSITION_SERIES.counterpart.color}
+                    strokeWidth={DECOMPOSITION_SERIES.counterpart.width}
+                    strokeDasharray={DECOMPOSITION_SERIES.counterpart.dash}
+                    dot={singlePointDot(snapshots, DECOMPOSITION_SERIES.counterpart.color)}
+                    isAnimationActive={false}
+                  />
                 )}
               </ComposedChart>
             </ResponsiveContainer>

--- a/src/pages/__tests__/Reconciliation.holdingState.test.tsx
+++ b/src/pages/__tests__/Reconciliation.holdingState.test.tsx
@@ -129,8 +129,19 @@ const renderAccounts = () =>
   );
 
 /** The figure under a stat column's label on the Accounts page. */
+/**
+ * The figure under a column heading ON AN ACCOUNT ROW.
+ *
+ * Scoped to `[data-account-columns]` — a row's grid — rather than taking the
+ * first "Unreconciled" on the page. The band now carries a column-header strip
+ * that says the same four words once above the rows, so the first match became
+ * a heading whose next sibling is the NEXT heading: this asserted 'To Review'
+ * where it meant '3'. The row is what the test was always about.
+ */
 const accountsStat = (label: string): string => {
-  const labelNode = screen.getAllByText(label)[0];
+  const row = document.querySelector('[data-account-columns]');
+  if (!(row instanceof HTMLElement)) throw new Error('no account row rendered');
+  const labelNode = within(row).getAllByText(label)[0];
   const value = labelNode.nextElementSibling;
   if (!(value instanceof HTMLElement)) throw new Error(`"${label}" has no figure under it`);
   return value.textContent ?? '';

--- a/src/utils/__tests__/netWorthClosedAccounts.test.ts
+++ b/src/utils/__tests__/netWorthClosedAccounts.test.ts
@@ -1,0 +1,98 @@
+/**
+ * A closed account still counts toward what you WERE worth.
+ *
+ * ─ THE BUG ─────────────────────────────────────────────────────────────────
+ * `accountService.getAccounts` fetches with `.eq('is_active', true)`, so the
+ * app context holds open accounts only, and the net-worth history was built
+ * from that list. Every closed account was therefore missing from every point
+ * in the past — and the owner has 110 of them.
+ *
+ * He found it by asking: "Does my net worth over time report include closed
+ * accounts?" It did not, and his answer to the diagnosis was "then that is what
+ * has been the problem with my net worth over time".
+ *
+ * The error is not uniform, which is what made it hard to see: it grows the
+ * FURTHER BACK you look, because more of a person's closed accounts were open
+ * then. A chart understated by a slowly-increasing amount reads as a gentler
+ * slope rather than as a mistake.
+ *
+ * These tests are on the series builder, deliberately. What the hook does —
+ * fetch the closed list and merge it — is plumbing; what matters is that money
+ * in a closed account lands on the right day, and that is arithmetic.
+ */
+import { describe, it, expect } from 'vitest';
+import { buildNetWorthSnapshots } from '../netWorthSeries';
+import type { Account, Transaction } from '../../types';
+
+const account = (id: string, isActive: boolean, opening: number): Account => ({
+  id,
+  name: `Account ${id}`,
+  type: 'current',
+  balance: opening,
+  currency: 'GBP',
+  institution: 'Test Bank',
+  lastUpdated: new Date('2020-01-01'),
+  openingBalance: opening,
+  openingBalanceDate: new Date('2015-01-01'),
+  isActive,
+} as Account);
+
+const txn = (id: string, accountId: string, date: string, amount: number): Transaction => ({
+  id,
+  accountId,
+  date: new Date(date),
+  description: 'Test',
+  amount,
+  type: amount >= 0 ? 'income' : 'expense',
+  category: 'cat-1',
+  cleared: true,
+} as Transaction);
+
+/** 2015 through 2020, which spans both accounts' lives. */
+const RANGE = { from: new Date('2015-01-01'), to: new Date('2020-12-31') };
+
+describe('net worth over time, with a closed account in the history', () => {
+  it('counts a closed account’s money, and does not when it is left out', () => {
+    const open = account('open-1', true, 1000);
+    const closed = account('closed-1', false, 5000);
+    const transactions = [txn('t1', 'open-1', '2016-06-01', 500)];
+
+    const withoutClosed = buildNetWorthSnapshots([open], transactions, RANGE);
+    const withClosed = buildNetWorthSnapshots([open, closed], transactions, RANGE);
+
+    const lastOf = (s: typeof withClosed): number => s[s.length - 1].netWorth;
+
+    // The whole bug in two numbers: the same ledger, £5,000 apart, because one
+    // walk was handed an account list the database had already filtered.
+    expect(lastOf(withoutClosed)).toBe(1500);
+    expect(lastOf(withClosed)).toBe(6500);
+  });
+
+  it('puts the closed account’s balance on the right DAY, not at the start of time', () => {
+    // Opening dates still govern: a closed account joins history when it opened
+    // and not before, exactly as an open one does. Otherwise "include the
+    // closed accounts" would trade one overstatement for another.
+    const closed = { ...account('closed-1', false, 5000), openingBalanceDate: new Date('2018-01-01') };
+    const snapshots = buildNetWorthSnapshots([closed], [], RANGE);
+
+    const before = snapshots.find(s => s.date < new Date('2018-01-01'));
+    const after = snapshots[snapshots.length - 1];
+
+    expect(before?.netWorth).toBe(0);
+    expect(after.netWorth).toBe(5000);
+  });
+
+  it('counts a closed account’s transactions too, not just its opening balance', () => {
+    const closed = account('closed-1', false, 5000);
+    const transactions = [
+      txn('t1', 'closed-1', '2016-03-01', -2000),
+      txn('t2', 'closed-1', '2017-03-01', 500),
+    ];
+
+    const snapshots = buildNetWorthSnapshots([closed], transactions, RANGE);
+
+    // 5000 - 2000 + 500. The rows were always loaded — `getTransactions` pages
+    // by user, not by account — they simply had no account to attach to.
+    expect(snapshots[snapshots.length - 1].netWorth).toBe(3500);
+  });
+});


### PR DESCRIPTION
## 0. Net worth over time was missing every closed account

> "Does my net worth over time report include closed accounts?" … "then that is what has been the problem with my net worth over time"

It did not. `accountService.getAccounts` fetches with `.eq('is_active', true)`, so the app context holds **open accounts only** — closed ones are a separate call that until now only the Accounts page ever made. The history walk read the context's list, so all **110** of the owner's closed accounts contributed nothing to any point in the past.

**Why it was hard to see:** the error is not uniform. It grows the further back you look, because more of a person's closed accounts were open then — so an understated chart reads as a gentler slope rather than as a mistake, which is exactly how it was described.

**Why it is a small fix:** the transactions were already loaded. `getTransactions` pages by *user*, not by account, so all 51,525 rows including the closed accounts' were in memory the whole time; they simply had no account to attach to and fell out of the walk. Only the account list was truncated.

`useHistoricalAccounts` merges the closed list in, guards against an id in both (a reopen racing the fetch would double-count a balance), and degrades to the old behaviour if the fetch fails — a chart that understates beats a report that will not render.

Wired into the report **and** the dashboard card, which draw the same series and must not disagree. The report's headline is the *last point* of that series rather than a separately computed figure, so it moves with the line. The per-date drill reads the same list, so the balances behind a point add up to the point.

Opening dates still govern — a closed account joins history when it opened, not at the dawn of time. That is the second of three tests; without it this would trade one overstatement for another. The first is the bug in two numbers: same ledger, **£1,500 without the closed account, £6,500 with it**.

The Accounts page keeps its own open/closed split, untouched.

---Five commits: a bug the owner found, three rulings from Claude Design's night reply, and one measured test hardening.

## 1. Selecting text and releasing outside threw the dialog away

> "When I am in account settings, and I highlight some text but leave go of the mouse outside the box, the app thinks I am clicking outside the box and closes the account settings… I also dont know if the same problem is anywhere else?"

It was, in **eight** places. A browser attributes a `click` to the nearest common **ancestor** of where the button went down and where it came up — so pressing inside the panel and releasing over the backdrop produces a click on the backdrop, and every dialog read that as "clicked outside". A text selection was indistinguishable from a dismissal, and the edit went with it.

The shared `Modal` covers 35 surfaces; seven more hand-rolled dialogs had each re-derived the same wrong predicate (cross-currency transfer, transfer repoint, transfer match, category transactions, reconciliation finalisation, and both of the Accounts page's own).

Rather than patch eight copies, the decision is extracted once as **`useBackdropDismiss`** — "what counts as clicking outside" being exactly the smallest-element-carrying-a-decision that the stat-pill ruling was about. A dismissal now needs the press **and** the release on the backdrop, and the flag clears either way (left set, one drag-out would arm a dialog against every dismissal after it).

**Not changed, deliberately:** the ten dropdowns that dismiss via a document-level `mousedown` listener are already correct — they close on the *press*, so a drag beginning inside them never reaches the listener.

Five tests fire the whole gesture; two fail against the old predicate, checked by reverting it.

Correction to the report: this was **never** fixed in the transaction modal — that modal uses the same shared component and the guard was not in the code.

## 2. §3.1 — the three net-worth series, separated by shape

Design ruled dash patterns, one hue, because the three are *not three categories*: assets and liabilities are the two components of net worth, and a third hue would assert an unrelated third thing.

| series | stroke | pattern | weight |
|---|---|---|---|
| Net worth | ramp 0 | solid | 2.5 |
| Assets | ramp 2 | `6 3` | 1.5 |
| Liabilities | ramp 2 | `1 3` | 1.5 |

Two things measurement caught that reading would not: recharts' default legend swatch carries **no `stroke-dasharray`**, so Assets and Liabilities would have rendered as two identical navy lines — the exact "worse than the bug we started with" case the ruling named; and recharts *animates* `stroke-dasharray` to draw a line, overwriting the pattern (`"0px, 744.8px"` instead of `"6 3"`). Custom legend, animation off, both verified in the running app.

## 3. §2.2 — the Accounts column names, once per band

The labels were per-cell props repeated on every row. Reconciliation got a strip in the August pass; this page never did — which surfaced when a design objection was drafted assuming a strip existed here to make sticky.

One strip per **band**, not per sub-band, so nine institutions say the four words once. It wears the row card's own invisible box rather than a hand-tuned margin: as a plain block grid it packed its columns 471px left of the figures, and a `17px` fudge would have drifted the way `calc(100vh-13rem)` did. **Verified: all four right edges identical to the row's, delta 0px.** Phones keep per-row labels (no grid to head below `sm`); between the two they are `sm:sr-only`, so a screen reader still hears "Bank Bal £6,378.06".

## 4. The avatar (their §2.3)

Clerk's generated initials avatar, not ours — but my reply to them ("needs a Clerk appearance prop, not a CSS change") was half a shrug: this app already has a Clerk appearance object; it simply had no rule for the avatar. `backgroundImage: 'none'` first, because the default is an image. **Not verified on screen** — `UserButton` renders only when signed in and this harness cannot sign in.

## 5. A measured test timeout

One assertion failed three times inside `test:coverage`, each costing a four-minute gate re-run, and could not be reproduced in four attempts afterwards. Measured unloaded: **190ms against a 1000ms default** — thin for an assertion that renders the whole frame, and every failure happened while a dev server and browser competed for the same cores. Raised to 5s, which still fails fast if the behaviour breaks.

The report that prompted it named two flaky tests; the second was a **real regression** from the column strip (a query took the first "Unreconciled" and read its next sibling, which became the next heading once a strip existed) and is fixed in the same PR.

## Verification

lint clean · `typecheck:strict` clean · `test:smoke` **394 files / 6150 tests, zero failures** · `npm run build` 8830 modules · full `test:coverage` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)