### PR TITLE
feat: Expense Categories gains figures, and the net-worth statement joins the shared card

### DIFF
--- a/src/components/AccountRowColumns.tsx
+++ b/src/components/AccountRowColumns.tsx
@@ -335,8 +335,32 @@ export function AccountCountCell({
     <div className="text-right">
       <p className={ROW_LABEL_CLASS}>{label}</p>
       <p
-        className={`${CELL_FIGURE_CLASS} ${
-          count > 0 ? 'text-slate-600 dark:text-gray-300' : 'text-gray-400 dark:text-gray-500'
+        /*
+         * SIZE AND WEIGHT CARRY IT, NOT A HUE.
+         *
+         * The two states used to differ by colour alone — slate-600 against
+         * gray-400, both `font-semibold` — and the owner reported the outcome
+         * that matters: "I miss them because when there are these things to do,
+         * they dont stand out vs all the other accounts with zero's."
+         *
+         * He was right to expect this to be contentious and it is not. The
+         * ruling below bans AMBER, because amber marks the one control you
+         * should touch next and a count is not clickable; and it bans a loud
+         * ZERO, because nothing is not something to attend to. Neither says a
+         * count with work in it must whisper. "Colour marks what needs
+         * attention" is the argument FOR separating these, and hierarchy in
+         * this app is carried by size and weight before any new colour is
+         * spent (the summary card makes the same move).
+         *
+         * So a count with work is a step larger, bolder and near-black, and a
+         * zero drops to normal weight and recedes. No hue is spent, the yellow
+         * thread keeps its monopoly on "do this next", and a page of zeroes
+         * still reads as a page of zeroes.
+         */
+        className={`tabular-nums ${
+          count > 0
+            ? 'text-base font-bold text-gray-900 dark:text-white'
+            : 'text-sm font-normal text-gray-400 dark:text-gray-500'
         }`}
       >
         {count}

--- a/src/components/NetWorthSummary.tsx
+++ b/src/components/NetWorthSummary.tsx
@@ -62,6 +62,22 @@ interface NetWorthSummaryProps {
   unconverted?: readonly string[];
   /** The currency the three figures are expressed in. */
   displayCurrency?: string;
+  /**
+   * What the two components are CALLED.
+   *
+   * Plain English by default, on a design ruling (13 Aug night §3.3): "What you
+   * own" and "What you owe" are the Reports-gallery voice, and that voice is
+   * more of this product's identity than any colour in the token sheet. The
+   * terser accounting pair is the OVERRIDE, not the reverse — a summary card
+   * that cannot take plainer words is a card that enforces jargon.
+   *
+   * They exist as props at all because the net-worth STATEMENT report had
+   * already chosen the plainer words for itself, and converting it to this card
+   * would otherwise have silently overwritten somebody's word choice. That is a
+   * content decision, and a refactor is not allowed to make it.
+   */
+  assetsLabel?: string;
+  liabilitiesLabel?: string;
 }
 
 /** The column heading over each figure. */
@@ -75,6 +91,8 @@ export default function NetWorthSummary({
   provenance = null,
   unconverted = [],
   displayCurrency,
+  assetsLabel = 'What you own',
+  liabilitiesLabel = 'What you owe',
 }: NetWorthSummaryProps): React.JSX.Element {
   /**
    * ALL THREE figures are navy. None of them is a direction of travel.
@@ -128,13 +146,13 @@ export default function NetWorthSummary({
     },
     {
       figure: 'assets',
-      label: 'Assets',
+      label: assetsLabel,
       value: assets,
       figureClass: COMPONENT_FIGURE_CLASS,
     },
     {
       figure: 'liabilities',
-      label: 'Liabilities',
+      label: liabilitiesLabel,
       value: liabilities,
       figureClass: COMPONENT_FIGURE_CLASS,
     },

--- a/src/components/__tests__/AccountCountCell.test.tsx
+++ b/src/components/__tests__/AccountCountCell.test.tsx
@@ -1,0 +1,77 @@
+/**
+ * A count with work in it has to be findable down a long list.
+ *
+ * ─ THE REPORT ──────────────────────────────────────────────────────────────
+ * "When there are transactions to review in the register and to reconcile, I
+ * miss them because when there are these things to do, they dont stand out vs
+ * all the other accounts with zero's '0' in their rows."
+ *
+ * He had 130-odd rows of `0` and four rows of `3`, rendered at the same size,
+ * the same weight, and two steps apart on the grey ramp.
+ *
+ * ─ WHY THIS DOES NOT BREAK THE RULINGS IT LOOKS LIKE IT BREAKS ─────────────
+ * DESIGN_RULINGS_2026-08-12 ruling A took AMBER off this count, because amber
+ * marks the one CONTROL you should touch next and a count is not clickable. A
+ * later correction stopped the ZERO being the loud one, because nothing is not
+ * something to attend to. Neither says a count with work must whisper — the
+ * ruling's own argument is that colour marks what needs attention, and this is
+ * the thing that needs it.
+ *
+ * So the separation is by SIZE and WEIGHT, which is how this app carries
+ * hierarchy everywhere else (the summary card's three figures make the same
+ * move), and no hue is spent. The yellow thread keeps its monopoly on "do this
+ * next".
+ *
+ * These assertions are about the DIFFERENCE, not about specific values: a
+ * future restyle may pick other tokens, and should still fail here if it
+ * flattens the two states back together.
+ */
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { AccountCountCell } from '../AccountRowColumns';
+
+const classesFor = (count: number): string => {
+  const { unmount } = render(<AccountCountCell label="Unreconciled" count={count} />);
+  const figure = screen.getByText(String(count));
+  const className = figure.getAttribute('class') ?? '';
+  unmount();
+  return className;
+};
+
+describe('a count of outstanding work', () => {
+  it('is bigger and bolder when there IS work than when there is none', () => {
+    const withWork = classesFor(3);
+    const none = classesFor(0);
+
+    expect(withWork).not.toBe(none);
+    // Two independent signals, so neither a font stack that flattens weights
+    // nor a colour-blind reader is left with one.
+    expect(withWork).toContain('text-base');
+    expect(withWork).toContain('font-bold');
+    expect(none).toContain('text-sm');
+    expect(none).toContain('font-normal');
+  });
+
+  it('spends no hue on either state', () => {
+    // Amber belongs to the next-action control; green and red mean money in
+    // and money out. A count is a quantity and gets the neutral ramp.
+    for (const className of [classesFor(7), classesFor(0)]) {
+      expect(className).not.toMatch(/amber|yellow|text-income|text-expense|red-|green-/);
+    }
+  });
+
+  it('gives the zero the quieter end of the ramp, not the louder', () => {
+    // The inversion that had to be fixed once already: a row with nothing to do
+    // must not shout across the page while a row with thirty murmurs.
+    expect(classesFor(0)).toMatch(/text-gray-4|text-gray-5/);
+    expect(classesFor(3)).toMatch(/text-gray-900|text-white/);
+  });
+
+  it('still renders the number itself, and keeps digits aligned', () => {
+    // A column of counts is read down, so the figures stay tabular whatever
+    // else changes about them.
+    expect(classesFor(12)).toContain('tabular-nums');
+    render(<AccountCountCell label="To Review" count={12} />);
+    expect(screen.getByText('12')).toBeInTheDocument();
+  });
+});

--- a/src/components/dashboard/reportWidgets/DashboardReportWidgets.tsx
+++ b/src/components/dashboard/reportWidgets/DashboardReportWidgets.tsx
@@ -232,9 +232,20 @@ export function ExpenseCategoriesWidget({ picker, pin }: {
       if (range.to && time > range.to.getTime()) return false;
       return true;
     });
-    return computeExpenseCategoryNetTotals(rows, categories)
-      .slice(0, 6)
-      .map(({ key, name, value }) => ({ categoryId: key, name, value }));
+    const top = computeExpenseCategoryNetTotals(rows, categories).slice(0, 6);
+    /*
+     * The share is of THE SLICES SHOWN, not of all spending — the ring is the
+     * top six and the percentages have to add up to the ring the reader is
+     * looking at. A share of the whole would leave the visible slices summing
+     * to some number under 100 with nothing on screen to explain the rest.
+     */
+    const shown = top.reduce((sum, row) => sum + row.value, 0);
+    return top.map(({ key, name, value }) => ({
+      categoryId: key,
+      name,
+      value,
+      share: shown > 0 ? (value / shown) * 100 : 0,
+    }));
   }, [transactions, transactionSplits, categories, range]);
 
   const open = (focus?: string): void =>
@@ -304,17 +315,38 @@ export function ExpenseCategoriesWidget({ picker, pin }: {
           {/* The legend does the same as the slice beside it, and is the only
               one of the two a keyboard can reach: an SVG sector is not a
               control. Same idiom as the Account Distribution card's legend. */}
+          {/* NAME, FIGURE, SHARE — the same three the Account Distribution card
+              beside it gives, and for the same reason: a ring says which slice
+              is biggest and refuses to say by how much. The owner asked for
+              them here after using that card. Each row still opens the full
+              report on its category, as it always did. */}
+          {/* EVERY slice the ring draws, not five of its six. With the shares
+              computed over the shown slices, a legend one row short made them
+              sum to 84.6% — a number nothing on screen accounted for. Six rows
+              fit the card's height, so the list and the ring say the same
+              thing and the percentages close at 100. */}
           <ul className="flex-1 min-w-0 space-y-1">
-            {data.slice(0, 5).map((d, i) => (
+            {data.map((d, i) => (
               <li key={d.categoryId}>
                 <button
                   type="button"
                   onClick={() => open(d.categoryId)}
                   title={`${d.name} — open the full report on this category`}
-                  className="w-full flex items-center gap-1.5 rounded px-1 py-0.5 text-left text-xs text-gray-600 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-700/50 transition-colors"
+                  className="w-full flex items-center gap-2 rounded px-1 py-0.5 text-left text-xs text-gray-600 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-700/50 transition-colors"
                 >
                   <span className="w-2 h-2 rounded-sm flex-shrink-0" style={{ backgroundColor: categoricalColor(ramp, i) }} aria-hidden="true" />
-                  <span className="truncate">{d.name}</span>
+                  <span className="flex-1 min-w-0 truncate">{d.name}</span>
+                  {/* The figure takes what it needs and the name yields — a
+                      truncated CATEGORY is still readable, a truncated amount
+                      is a wrong number. */}
+                  <span className="shrink-0 tabular-nums font-medium text-gray-900 dark:text-white">
+                    {formatCurrency(d.value)}
+                  </span>
+                  {/* The share is context rather than the answer, so it recedes
+                      — same weight and width as the distribution card's. */}
+                  <span className="w-10 shrink-0 text-right tabular-nums text-gray-400 dark:text-gray-500">
+                    {formatDecimal(d.share, 1)}%
+                  </span>
                 </button>
               </li>
             ))}

--- a/src/index.css
+++ b/src/index.css
@@ -761,3 +761,30 @@ button.rounded-full:focus-visible,
     font-size: 1rem !important;
   }
 }
+
+/*
+ * CLERK'S GENERATED AVATAR, AND ONLY THAT.
+ *
+ * The design review's "single most-seen element in the product and the only
+ * gradient in it" is a purple→blue disc top-right of every page. It is not ours
+ * — Clerk generates it for a user who has uploaded no photo — and it is not a
+ * background either, which is why setting one in the appearance object changed
+ * nothing visible: measured in the owner's console, `span.cl-avatarBox` had
+ * `background-color: rgb(26, 35, 50)` applied and an `<img>` from
+ * img.clerk.com sitting on top of it.
+ *
+ * ── WHY THE SELECTOR IS THIS FUSSY ─────────────────────────────────────────
+ * `display: none` on every avatar image would also hide a REAL photo the day
+ * anyone uploads one. Clerk encodes what the image is into the URL: the srcset
+ * carries base64 whose first field is `{"type":"default",` — decoded from the
+ * marker below, not guessed. So this hides the generated disc and leaves an
+ * uploaded portrait alone.
+ *
+ * If Clerk ever changes that payload the rule stops matching and the gradient
+ * comes back — visible, and the wrong colour, rather than silently wrong about
+ * a number. That is the right way round for a failure nobody is watching for.
+ */
+.cl-avatarBox img[srcset*="eyJ0eXBlIjoiZGVmYXVsdCIs"],
+.cl-avatarBox img[src*="eyJ0eXBlIjoiZGVmYXVsdCIs"] {
+  display: none;
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -209,15 +209,22 @@ const clerkAppearance: Appearance = {
      *
      * The design review flagged a purple→blue gradient "top-right of every page
      * in the app" and reasonably assumed it was ours. It is not — it is Clerk's
-     * generated initials avatar, which is why searching our source for
-     * `from-purple-500 to-blue-600` finds nothing. But the conclusion that we
-     * could not change it was also wrong: this appearance object reaches every
-     * Clerk surface, and it simply had no rule for the avatar.
+     * GENERATED default avatar, which is why searching our source for
+     * `from-purple-500 to-blue-600` finds nothing. The conclusion that we could
+     * therefore not change it was also wrong: this appearance object reaches
+     * every Clerk surface and simply had no rule for the avatar.
      *
-     * `backgroundImage: 'none'` first, because the default is a background
-     * IMAGE — a colour alone would paint underneath it and change nothing.
-     * Slate with a white initial, matching the ruling and every other Clerk
-     * surface above.
+     * ── AND THE FIRST ATTEMPT WAS RIGHT AND STILL INVISIBLE ──────────────────
+     *
+     * These three lines applied — measured in the owner's own console:
+     * `background-color: rgb(26, 35, 50)` and `background-image: none` on
+     * `span.cl-avatarBox`. The gradient survived anyway, because Clerk does not
+     * paint it as a background at all: it renders an `<img>` from img.clerk.com
+     * INSIDE the span, and a background sits behind a picture.
+     *
+     * That is what `src/index.css`'s `.cl-avatarBox img[srcset*=…]` rule is
+     * for, and why it is written as narrowly as it is. Keep this box: it is
+     * what shows once the image is gone.
      */
     avatarBox: {
       backgroundImage: 'none',

--- a/src/pages/__tests__/Accounts.toReview.test.tsx
+++ b/src/pages/__tests__/Accounts.toReview.test.tsx
@@ -169,12 +169,26 @@ describe('Accounts list — the To Review column', () => {
 
     const waiting = within(card('Synthetic Natwest')).getByText('To Review').nextElementSibling;
     const clear = within(card('Synthetic Monzo')).getByText('To Review').nextElementSibling;
-    expect(waiting?.className).toContain('text-slate-600');
+    /*
+     * The working state was `text-slate-600` at the same size and weight as the
+     * zero until 2026-08-13, when the owner reported the consequence: "I miss
+     * them because when there are these things to do, they dont stand out vs
+     * all the other accounts with zero's." Two steps on the grey ramp is not a
+     * difference you can find down 130 rows.
+     *
+     * It is now separated by SIZE and WEIGHT as well — near-black, a step
+     * larger, bold — which is how this app carries hierarchy everywhere and
+     * spends no hue doing it. See AccountCountCell.test.tsx.
+     */
+    expect(waiting?.className).toContain('text-gray-900');
+    expect(waiting?.className).toContain('font-bold');
+    expect(waiting?.className).toContain('text-base');
     // NOT the app's link blue, which is what a zero wore until this was
     // corrected — de-ambering the working state had left the count with
     // NOTHING to do as the loudest figure on the row. Colour marks what needs
     // attention (ruling A's own argument) and a zero needs nothing.
     expect(clear?.className).not.toContain('text-blue-600');
     expect(clear?.className).toContain('text-gray-400');
+    expect(clear?.className).toContain('font-normal');
   });
 });

--- a/src/pages/reports/NetWorthStatementReport.tsx
+++ b/src/pages/reports/NetWorthStatementReport.tsx
@@ -4,6 +4,7 @@ import { useCurrencyDecimal } from '../../hooks/useCurrencyDecimal';
 import ReportDrillModal, { type ReportDrillTarget } from '../../components/reports/ReportDrillModal';
 import { buildAccountBalanceReport, type AccountBalanceRow } from '../../utils/accountBalanceReport';
 import { PERIOD_LABELS } from '../../hooks/usePeriod';
+import NetWorthSummary from '../../components/NetWorthSummary';
 import type { ReportViewProps } from './types';
 
 /**
@@ -130,40 +131,44 @@ export default function NetWorthStatementReport({ picker }: ReportViewProps): Re
 
   return (
     <div className="max-w-[1400px] mx-auto space-y-6">
-      <div className="grid grid-cols-1 md:grid-cols-4 gap-4">
-        <div className="bg-[#1a2332] dark:bg-gray-700 rounded-2xl p-6 text-white">
-          <p className="text-xs text-white/60 uppercase tracking-wider font-medium">Net worth</p>
-          <p className="text-2xl font-bold mt-1">{money(report.netWorth)}</p>
-          <p className="text-xs text-white/60 mt-1">
-            As at {report.asOf.toLocaleDateString('en-GB', { day: 'numeric', month: 'long', year: 'numeric' })}
-          </p>
-        </div>
-        <div className="bg-white dark:bg-gray-800 rounded-2xl p-6 border border-gray-100 dark:border-gray-700">
-          <p className="text-xs text-gray-500 uppercase tracking-wider font-medium">What you own</p>
-          <p className="text-2xl font-bold mt-1 text-green-600 dark:text-green-400">
-            {formatCurrency(report.assets)}
-          </p>
-        </div>
-        <div className="bg-white dark:bg-gray-800 rounded-2xl p-6 border border-gray-100 dark:border-gray-700">
-          <p className="text-xs text-gray-500 uppercase tracking-wider font-medium">What you owe</p>
-          <p className="text-2xl font-bold mt-1 text-red-600 dark:text-red-400">
-            {formatCurrency(report.liabilities)}
-          </p>
-        </div>
-        <div className="bg-white dark:bg-gray-800 rounded-2xl p-6 border border-gray-100 dark:border-gray-700">
-          <p className="text-xs text-gray-500 uppercase tracking-wider font-medium">
-            Change — {PERIOD_LABELS[picker.period]}
-          </p>
-          <p className={`text-2xl font-bold mt-1 ${
-            report.change < 0 ? 'text-red-600 dark:text-red-400' : 'text-green-600 dark:text-green-400'
-          }`}>
-            {report.change > 0 ? '+' : ''}{money(report.change)}
-          </p>
-          <p className="text-xs text-gray-400 dark:text-gray-500 mt-1">
-            From {money(report.openingNetWorth)}
-          </p>
-        </div>
-      </div>
+      {/* THE SHARED CARD, and the plainer words kept.
+
+          This page drew its own navy slab plus three white cards — the exact
+          arrangement NetWorthSummary was written to abolish, and the third copy
+          of it in the app. Opting out is not free: the dark-mode fault that
+          card's comment documents was found and fixed once and reached every
+          surface using it, while each copy went on carrying its own version of
+          the same class of bug.
+
+          Its LABELS survive the conversion, and are now the shared card's
+          defaults everywhere (design ruling, 13 Aug night §3.3): "What you own"
+          and "What you owe" are better than the accounting pair, so the terser
+          words became the override rather than the rule. Converting a surface
+          is not permission to overwrite the words somebody chose for it. */}
+      <NetWorthSummary
+        netWorth={money(report.netWorth)}
+        assets={formatCurrency(report.assets)}
+        liabilities={formatCurrency(report.liabilities)}
+      />
+
+      {/* As-at and change, in the caption voice the net-worth report uses for
+          the same two facts — so the two reports say them the same way.
+
+          The CHANGE keeps the semantic colours while the three figures above it
+          do not, and that is the rule rather than an exception to it: a delta is
+          nothing but a direction of travel, which is the one thing green and red
+          are for. */}
+      <p className="text-body text-gray-500 dark:text-gray-400">
+        As at{' '}
+        <span className="font-medium text-gray-900 dark:text-gray-100">
+          {report.asOf.toLocaleDateString('en-GB', { day: 'numeric', month: 'long', year: 'numeric' })}
+        </span>
+        . Change over {PERIOD_LABELS[picker.period].toLowerCase()}{' '}
+        <span className={report.change < 0 ? 'text-expense font-medium' : 'text-income font-medium'}>
+          {report.change > 0 ? '+' : ''}{money(report.change)}
+        </span>
+        , from {money(report.openingNetWorth)}.
+      </p>
 
       <div className="grid grid-cols-1 lg:grid-cols-2 gap-6 items-start">
         {section('What you own', sides.owned, report.assets, 'No account is in credit in this period')}

--- a/src/test/integration/DashboardInteractionsIntegration.test.tsx
+++ b/src/test/integration/DashboardInteractionsIntegration.test.tsx
@@ -71,9 +71,13 @@ describe('Dashboard Interactions Integration', () => {
       // full coverage suite runs under load. Query both labels concurrently so
       // their wait windows overlap (sequential 5s waits could otherwise sum
       // past the per-test timeout) and give the test an explicit generous cap.
+      // "What you own / What you owe" since 2026-08-13: the shared summary
+      // card's labels became props with the plainer pair as the DEFAULT, on a
+      // design ruling that this is the product's voice and the accounting pair
+      // is the override. The card is the same card; only the words moved.
       const [assetsLabel, liabilitiesLabel] = await Promise.all([
-        screen.findByText(/assets/i, { selector: 'p' }, { timeout: 15000 }),
-        screen.findByText(/liabilities/i, { selector: 'p' }, { timeout: 15000 })
+        screen.findByText(/what you own/i, { selector: 'p' }, { timeout: 15000 }),
+        screen.findByText(/what you owe/i, { selector: 'p' }, { timeout: 15000 })
       ]);
       expect(assetsLabel).toBeInTheDocument();
       expect(liabilitiesLabel).toBeInTheDocument();
@@ -146,7 +150,7 @@ describe('Dashboard Interactions Integration', () => {
         });
       }
 
-      const assetsLabel = await screen.findByText(/assets/i, { selector: 'p' });
+      const assetsLabel = await screen.findByText(/what you own/i, { selector: 'p' });
       expect(assetsLabel).toBeInTheDocument();
     });
 


### PR DESCRIPTION
Two items, both requested.

## 1. Expense Categories says how much, not just which

> "I think we should have values next to the Expense Categories, that can be clicked in to just like the Account Distribution Report"

A ring says which slice is biggest and refuses to say by how much — the one thing you came to a spending report for. Each row now carries **name, figure and share**, and still opens the full report on its category.

**Two things measurement settled:**

The share is of the **slices shown**, not of all spending, because the ring *is* those slices and the percentages have to add up to what the reader is looking at.

Which caught the second: the ring drew **six** slices and the legend listed **five**, so the shares summed to **84.6%** — a number nothing on screen accounted for. The list now names every slice the ring draws; six rows fit the card's height, and the percentages close at exactly **100.0%** (verified in the running app).

The figure takes the width it needs and the name yields — a truncated category is still readable, a truncated amount is a wrong number.

## 2. §3.3 — the net-worth statement joins the shared card

Design ruled: convert, but the labels become props.

This page drew its own navy slab plus three white cards — the arrangement `NetWorthSummary` exists to abolish, and the **third** copy of it. Opting out is not free, and this repo has the receipt: the dark-mode fault that card's comment documents was found once and fixed for every surface using it, while each copy carried its own version of the same class of bug.

**The words are the point of the ruling.** "What you own" / "What you owe" were this page's own choice and are better than the accounting pair — the Reports-gallery voice, which is more of this product's identity than any colour in the token sheet. So they became the shared card's **default** and the terser pair the override, not the reverse. Converting a surface is not permission to overwrite the words somebody chose for it.

**That default reaches the Dashboard and Accounts too** — the ruling working as intended rather than a side effect: three surfaces, one voice. Two integration tests asserted the old wording and now assert the new.

The **change** figure keeps the semantic colours while the three magnitudes above it do not, and that is the rule rather than an exception: a delta is nothing but a direction of travel, which is the one thing green and red are for. It moves into the caption line the net-worth report already uses for the same two facts.

## Verification

lint clean · `typecheck:strict` clean · `test:smoke` **395 files / 6153 tests, zero failures** · `npm run build` 8831 modules · `desktop:verify` 17/17.

🤖 Generated with [Claude Code](https://claude.com/claude-code)