### PR TITLE
fix(accounts): counts with work become a shape — and the avatar reverts

### DIFF
--- a/src/components/AccountRowColumns.tsx
+++ b/src/components/AccountRowColumns.tsx
@@ -336,30 +336,38 @@ export function AccountCountCell({
       <p className={ROW_LABEL_CLASS}>{label}</p>
       <p
         /*
-         * SIZE AND WEIGHT CARRY IT, NOT A HUE.
+         * A FILLED SHAPE, NOT LOUDER TEXT.
          *
-         * The two states used to differ by colour alone — slate-600 against
-         * gray-400, both `font-semibold` — and the owner reported the outcome
-         * that matters: "I miss them because when there are these things to do,
-         * they dont stand out vs all the other accounts with zero's."
+         * Three attempts at this column, and the first two were the same idea
+         * at different volumes. It began as colour alone — slate-600 against
+         * gray-400, both `font-semibold` — and the owner could not find the
+         * rows that mattered: "I miss them because when there are these things
+         * to do, they dont stand out vs all the other accounts with zero's."
+         * Near-black, bold and a step larger was better and still not enough:
+         * "BETTER BUT IT NEEDS TO STAND OUT MORE."
          *
-         * He was right to expect this to be contentious and it is not. The
-         * ruling below bans AMBER, because amber marks the one control you
-         * should touch next and a count is not clickable; and it bans a loud
-         * ZERO, because nothing is not something to attend to. Neither says a
-         * count with work in it must whisper. "Colour marks what needs
-         * attention" is the argument FOR separating these, and hierarchy in
-         * this app is carried by size and weight before any new colour is
-         * spent (the summary card makes the same move).
+         * It was never going to be enough, because every one of those is text
+         * competing with text down a column of 130 rows. A filled pill breaks
+         * the rhythm instead of raising its voice within it — the eye finds a
+         * SHAPE among words without reading any of them.
          *
-         * So a count with work is a step larger, bolder and near-black, and a
-         * zero drops to normal weight and recedes. No hue is spent, the yellow
-         * thread keeps its monopoly on "do this next", and a page of zeroes
-         * still reads as a page of zeroes.
+         * ─ WHY NAVY, AND WHY THAT IS NOT THE THING RULING A BANNED ──────────
+         * Amber belongs to the one CONTROL you should touch next and this is
+         * not clickable; green and red mean money in and money out, and a count
+         * is neither. Navy is the brand's own ink, already the fill of every
+         * primary control, and it says "here" without claiming to be a
+         * direction or an alarm. It is also the shape ActivityBadge already
+         * uses for a count that carries a figure, so the app has one idiom for
+         * this rather than two.
+         *
+         * The ZERO is untouched by all of it: still plain, still light, still
+         * receding. Ruling A's correction — that nothing is not something to
+         * attend to — is exactly why the contrast between the two can be this
+         * strong without the zero shouting.
          */
         className={`tabular-nums ${
           count > 0
-            ? 'text-base font-bold text-gray-900 dark:text-white'
+            ? 'inline-flex items-center justify-center min-w-[24px] px-1.5 py-0.5 rounded-full bg-primary text-white text-sm font-bold'
             : 'text-sm font-normal text-gray-400 dark:text-gray-500'
         }`}
       >

--- a/src/components/__tests__/AccountCountCell.test.tsx
+++ b/src/components/__tests__/AccountCountCell.test.tsx
@@ -39,22 +39,35 @@ const classesFor = (count: number): string => {
 };
 
 describe('a count of outstanding work', () => {
-  it('is bigger and bolder when there IS work than when there is none', () => {
+  it('is a filled pill when there IS work, and plain text when there is none', () => {
     const withWork = classesFor(3);
     const none = classesFor(0);
 
     expect(withWork).not.toBe(none);
-    // Two independent signals, so neither a font stack that flattens weights
-    // nor a colour-blind reader is left with one.
-    expect(withWork).toContain('text-base');
+    /*
+     * A SHAPE, not louder text. Colour alone was missed entirely; near-black
+     * and bold was "better but it needs to stand out more". Both were text
+     * competing with text down a column of 130 rows — the eye finds a filled
+     * disc among words without reading any of them.
+     */
+    expect(withWork).toContain('rounded-full');
+    expect(withWork).toContain('bg-primary');
     expect(withWork).toContain('font-bold');
-    expect(none).toContain('text-sm');
+    // The zero gains nothing: no fill, no ring, no weight.
+    expect(none).not.toContain('rounded-full');
+    expect(none).not.toMatch(/\bbg-/);
     expect(none).toContain('font-normal');
   });
 
-  it('spends no hue on either state', () => {
-    // Amber belongs to the next-action control; green and red mean money in
-    // and money out. A count is a quantity and gets the neutral ramp.
+  it('spends no SEMANTIC colour on either state', () => {
+    /*
+     * The fill is the brand navy, which is a hue — so the invariant is not
+     * "no colour" but "no colour that already MEANS something else". Amber
+     * belongs to the one control you should touch next and this is not
+     * clickable; green and red mean money in and money out, and a count is
+     * neither. Navy is the app's own ink, already the fill of every primary
+     * control, and it says "here" without claiming a direction or an alarm.
+     */
     for (const className of [classesFor(7), classesFor(0)]) {
       expect(className).not.toMatch(/amber|yellow|text-income|text-expense|red-|green-/);
     }
@@ -64,7 +77,8 @@ describe('a count of outstanding work', () => {
     // The inversion that had to be fixed once already: a row with nothing to do
     // must not shout across the page while a row with thirty murmurs.
     expect(classesFor(0)).toMatch(/text-gray-4|text-gray-5/);
-    expect(classesFor(3)).toMatch(/text-gray-900|text-white/);
+    // White ON the navy fill — the count's ink, not a colour of its own.
+    expect(classesFor(3)).toContain('text-white');
   });
 
   it('still renders the number itself, and keeps digits aligned', () => {

--- a/src/index.css
+++ b/src/index.css
@@ -763,28 +763,25 @@ button.rounded-full:focus-visible,
 }
 
 /*
- * CLERK'S GENERATED AVATAR, AND ONLY THAT.
+ * CLERK'S GENERATED AVATAR — REVERTED, AND WHY.
  *
- * The design review's "single most-seen element in the product and the only
- * gradient in it" is a purple→blue disc top-right of every page. It is not ours
- * — Clerk generates it for a user who has uploaded no photo — and it is not a
- * background either, which is why setting one in the appearance object changed
- * nothing visible: measured in the owner's console, `span.cl-avatarBox` had
- * `background-color: rgb(26, 35, 50)` applied and an `<img>` from
- * img.clerk.com sitting on top of it.
+ * A rule here hid Clerk's generated default avatar image so the slate box set
+ * in main.tsx would show instead, answering the design review's "the only
+ * gradient in the product". It shipped and broke the header: the box colour is
+ * the app slate #1a2332, which is EXACTLY the colour of the nav bar it sits on,
+ * so removing the picture left a navy disc on navy — the owner's report was
+ * "you cant see notifications now or the user avatar icon".
  *
- * ── WHY THE SELECTOR IS THIS FUSSY ─────────────────────────────────────────
- * `display: none` on every avatar image would also hide a REAL photo the day
- * anyone uploads one. Clerk encodes what the image is into the URL: the srcset
- * carries base64 whose first field is `{"type":"default",` — decoded from the
- * marker below, not guessed. So this hides the generated disc and leaves an
- * uploaded portrait alone.
+ * The colour was only half of it. Clerk's span contains the image and nothing
+ * else, so hiding it leaves an EMPTY disc at any colour: there is no initial
+ * underneath to fall back to, because the generated image IS how Clerk draws
+ * the initial. A visible purple avatar beats an invisible correct one, so the
+ * gradient comes back until there is a real answer.
  *
- * If Clerk ever changes that payload the rule stops matching and the gradient
- * comes back — visible, and the wrong colour, rather than silently wrong about
- * a number. That is the right way round for a failure nobody is watching for.
+ * THE REAL ANSWER is our own avatar in place of Clerk's — an initial we render
+ * ourselves on #f1f3f7, which is the review's own second option and the one
+ * that does not depend on what Clerk puts inside its box. That is a component,
+ * not a stylesheet rule, and it is not a thing to attempt blind at the end of
+ * an evening.
  */
-.cl-avatarBox img[srcset*="eyJ0eXBlIjoiZGVmYXVsdCIs"],
-.cl-avatarBox img[src*="eyJ0eXBlIjoiZGVmYXVsdCIs"] {
-  display: none;
-}
+

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -204,33 +204,29 @@ const clerkAppearance: Appearance = {
     // Social / secondary buttons stay neutral (near-black label, never blue).
     socialButtonsBlockButton: { color: '#111827' },
     /*
-     * THE AVATAR, which is the most-seen element in the product and was the
-     * only gradient in it.
+     * THE AVATAR — no rule, deliberately, after two attempts that made it worse.
      *
-     * The design review flagged a purple→blue gradient "top-right of every page
-     * in the app" and reasonably assumed it was ours. It is not — it is Clerk's
-     * GENERATED default avatar, which is why searching our source for
-     * `from-purple-500 to-blue-600` finds nothing. The conclusion that we could
-     * therefore not change it was also wrong: this appearance object reaches
-     * every Clerk surface and simply had no rule for the avatar.
+     * The design review's "single most-seen element in the product and the only
+     * gradient in it" is Clerk's GENERATED default avatar, not ours. Two things
+     * were learned the hard way and are recorded so a third attempt starts from
+     * them:
      *
-     * ── AND THE FIRST ATTEMPT WAS RIGHT AND STILL INVISIBLE ──────────────────
+     * 1. A background here is invisible. Measured in the owner's console: this
+     *    object DID apply `background-color: rgb(26, 35, 50)` and
+     *    `background-image: none` to `span.cl-avatarBox` — and the gradient
+     *    stayed, because Clerk renders an `<img>` from img.clerk.com inside the
+     *    span. A background sits behind a picture.
      *
-     * These three lines applied — measured in the owner's own console:
-     * `background-color: rgb(26, 35, 50)` and `background-image: none` on
-     * `span.cl-avatarBox`. The gradient survived anyway, because Clerk does not
-     * paint it as a background at all: it renders an `<img>` from img.clerk.com
-     * INSIDE the span, and a background sits behind a picture.
+     * 2. Hiding that image leaves an EMPTY disc. Clerk's span holds the image
+     *    and nothing else; the generated picture IS how it draws the initial,
+     *    so there is no text underneath to fall back to. Worse, slate is the
+     *    nav bar's own colour, so the disc vanished entirely — "you cant see
+     *    notifications now or the user avatar icon".
      *
-     * That is what `src/index.css`'s `.cl-avatarBox img[srcset*=…]` rule is
-     * for, and why it is written as narrowly as it is. Keep this box: it is
-     * what shows once the image is gone.
+     * The answer is our own avatar — an initial rendered by us on #f1f3f7,
+     * which is the review's second option and the only one that does not depend
+     * on what Clerk puts inside its box. A component, not an appearance key.
      */
-    avatarBox: {
-      backgroundImage: 'none',
-      backgroundColor: '#1a2332',
-      color: '#ffffff'
-    }
   }
 };
 

--- a/src/pages/__tests__/Accounts.toReview.test.tsx
+++ b/src/pages/__tests__/Accounts.toReview.test.tsx
@@ -176,13 +176,13 @@ describe('Accounts list — the To Review column', () => {
      * all the other accounts with zero's." Two steps on the grey ramp is not a
      * difference you can find down 130 rows.
      *
-     * It is now separated by SIZE and WEIGHT as well — near-black, a step
-     * larger, bold — which is how this app carries hierarchy everywhere and
-     * spends no hue doing it. See AccountCountCell.test.tsx.
+     * Near-black and bold was the second attempt and drew "BETTER BUT IT NEEDS
+     * TO STAND OUT MORE". Both attempts were text competing with text; a filled
+     * navy pill breaks the rhythm instead. See AccountCountCell.test.tsx.
      */
-    expect(waiting?.className).toContain('text-gray-900');
+    expect(waiting?.className).toContain('bg-primary');
+    expect(waiting?.className).toContain('rounded-full');
     expect(waiting?.className).toContain('font-bold');
-    expect(waiting?.className).toContain('text-base');
     // NOT the app's link blue, which is what a zero wore until this was
     // corrected — de-ambering the working state had left the count with
     // NOTHING to do as the loudest figure on the row. Colour marks what needs


### PR DESCRIPTION
Two things, one of them undoing my own mistake from an hour ago.

## 1. A count with work becomes a shape, not louder text

> "UNRECONCILED AND TO REVIEW ARE BETTER BUT IT NEEDS TO STAND OUT MORE."

Third attempt, and the first two were the same idea at different volumes:

| attempt | treatment | outcome |
|---|---|---|
| 1 | colour alone — slate-600 vs gray-400, both semibold | missed entirely |
| 2 | near-black, bold, a step larger | "better but it needs to stand out more" |
| 3 | **a filled navy pill** | a shape among words |

Both earlier attempts were **text competing with text** down a column of 130 rows — a contest the four rows that matter cannot win by being slightly heavier. A filled pill breaks the rhythm rather than raising its voice within it: the eye finds a disc without reading anything.

Measured in the running app: a **24×24 navy disc, white bold figure, fully rounded** (`bg-primary` verified to actually paint — that token has form for emitting nothing).

**Why navy is not what ruling A banned.** Amber belongs to the one *control* you should touch next, and this is not clickable. Green and red mean money in and money out, and a count is neither. Navy is the app's own ink, already the fill of every primary control, and says "here" without claiming a direction or an alarm. It is also the shape `ActivityBadge` already gives a count carrying a figure — one idiom, not two.

The **zero is untouched**: still plain, still light, still receding. That the two can now differ this strongly *without* the zero shouting is precisely what ruling A's correction was for.

Tests move from asserting a weight to asserting a shape, and one was renamed for honesty — "spends no hue" became "spends no **semantic** colour", because a navy fill *is* a hue and the real invariant is that it is not a colour which already means something else.

## 2. The avatar reverts

> "You cant see notifications now or the user avatar icon."

Hiding Clerk's generated avatar left the slate box behind it as the only thing drawn — and slate is `#1a2332`, **exactly the colour of the nav bar it sits on**. A navy disc on navy: the button was still there, still worked, and nobody could see it.

The colour was only half the fault. Clerk's span holds that image and *nothing else* — the generated picture **is** how it draws the initial — so hiding it leaves an empty disc at any colour. Even with a light background this would have been a blank circle where a person's avatar goes.

So both halves revert, and the gradient returns until there is a real answer. A visible purple avatar beats an invisible correct one.

**What the two attempts established**, kept in the comments so a third starts from them:
1. A background on `.cl-avatarBox` is invisible — it applied (measured in the owner's console) and lost to an `<img>` drawn on top.
2. Removing that image leaves nothing, because it is not decoration, it is the content.

The real answer is our own avatar — an initial we render on `#f1f3f7`, the design review's own second option, and the only one that does not depend on what Clerk puts inside its box. That is a component, not an appearance key.

## Verification

lint clean · `typecheck:strict` clean · `test:smoke` **396 files / 6157 tests, zero failures** · `npm run build` 8831 modules.

🤖 Generated with [Claude Code](https://claude.com/claude-code)