### PR TITLE
fix: the notification bell and the band headings stop disappearing

### DIFF
--- a/src/components/EnhancedNotificationBell.tsx
+++ b/src/components/EnhancedNotificationBell.tsx
@@ -136,12 +136,29 @@ export default function EnhancedNotificationBell(): React.JSX.Element {
   return (
     <>
       {/* Notification Bell Button */}
+      {/*
+        THE BELL LIVES ON THE NAVY BAR, so it is painted for the navy bar.
+
+        It was `text-gray-700` — #374151, a DARK grey — sitting on the header's
+        #1a2332. Measured: 1.53:1, against the 3:1 WCAG asks of a non-text
+        control, and the owner's report was the plain version of that number:
+        "I still cant see the notification bell."
+
+        `text-white/60`, and the hover, are copied from the Help button
+        immediately to its right, which has been legible at 6.7:1 all along —
+        so this is the header's own idiom rather than a new one. The hover
+        background moves from `gray-100` (a light-mode fill, invisible here) to
+        the same `white/10` its neighbour uses.
+
+        It renders NOWHERE ELSE: Layout mounts it twice, both in this bar, and
+        the desktop edition's chrome returns null for it.
+      */}
       <button
         onClick={() => setIsOpen(!isOpen)}
-        className="relative p-2 hover:bg-gray-100 dark:hover:bg-gray-700 rounded-lg transition-colors flex items-center justify-center"
+        className="relative p-2 rounded-lg text-white/60 hover:text-white hover:bg-white/10 transition-colors flex items-center justify-center"
         aria-label={`Notifications${counts.unread > 0 ? ` (${counts.unread} unread)` : ''}`}
       >
-        <BellIcon size={20} className="text-gray-700 dark:text-gray-200" />
+        <BellIcon size={20} />
         
         {/*
           Unread badge — a COUNT, so it is neutral (design ruling A, and the

--- a/src/pages/Accounts.tsx
+++ b/src/pages/Accounts.tsx
@@ -1585,7 +1585,7 @@ export default function Accounts() {
                   label for the figure beside it, and the figure is the thing
                   worth reading (P1). Still an h2 — the outline, and the way a
                   screen-reader user walks this page, are unchanged. */}
-              <h2 className="text-label uppercase font-semibold text-gray-600 dark:text-gray-300">{group.title}</h2>
+              <h2 className="text-body uppercase font-bold tracking-wide text-gray-900 dark:text-white">{group.title}</h2>
               <span className="text-dense text-gray-400 dark:text-gray-500">
                 ({group.accounts.length} {group.accounts.length === 1 ? 'account' : 'accounts'})
               </span>
@@ -1629,7 +1629,7 @@ export default function Accounts() {
                       {/* The same treatment as the band above it, one step
                           quieter: a line, not a pill with a border of its own. */}
                       <div className="flex items-center justify-between gap-2 border-b border-line dark:border-gray-700 bg-surface-secondary/60 dark:bg-gray-700/30 px-4 sm:px-6 py-1.5">
-                        <p className="text-label uppercase font-semibold text-gray-500 dark:text-gray-400 truncate">
+                        <p className="text-dense uppercase font-semibold tracking-wide text-gray-700 dark:text-gray-200 truncate">
                           {sub.title}
                           <span className="ml-2 font-normal normal-case tracking-normal text-gray-400 dark:text-gray-500">
                             ({countLabel})


### PR DESCRIPTION
Two contrast faults on the Accounts page and the header, both reported while looking for something else.

## 1. The notification bell was a dark icon on a dark bar

> "I still cant see the notification bell."

It was `text-gray-700` — **#374151** — on the header's **#1a2332**.

| control | contrast on the navy bar |
|---|---|
| notification bell | **1.53:1** |
| Help button, six pixels to its right | 6.7:1 |
| WCAG minimum for a non-text control | 3.0:1 |

The header already had the answer and this one control wasn't using it. It now takes `text-white/60` with the same hover, **copied from that neighbour rather than invented** — and the hover fill moves from `gray-100`, a light-mode colour that paints nothing here, to the `white/10` its neighbour uses.

Safe because the bell renders nowhere else: `Layout` mounts it twice, both in this bar, and the desktop edition's chrome returns `null` for it. Verified after: bell and Help compute to the identical `rgba(255, 255, 255, 0.6)`.

It had been like this far longer than tonight — it only surfaced because the owner was staring at the header for another reason.

## 2. The band headings faded into the page

> "They kind of fade in to the background… I miss the headings as I scroll down the page."

Both were 11px `text-label` in grey — the same size as the column captions beneath them and the institution line inside each row, and lighter than the figures beside them. A heading that is the smallest text in its own section is a caption, and on a page of 130 rows the reader loses their place.

| | before | after |
|---|---|---|
| band — `CURRENT ACCOUNTS` | 11px / 600 / gray-600 | **14px / 700 / near-black** |
| institution — `COUTTS` | 11px / 600 / gray-500 | 12px / 600 / gray-700 |

**Two steps for the band and one for the institution, deliberately.** The second sits inside the first, and giving both the same weight would flatten the very structure the grouping exists to show. `tracking-wide` because the scale's letter-spacing lives on `label`, and moving up to `body`/`dense` would otherwise set the capitals solid.

Measured after: 14px / 700 / `rgb(17, 24, 39)`.

## Verification

lint clean · `typecheck:strict` clean · `test:smoke` **396 files / 6157 tests, zero failures** · `npm run build` 8831 modules.

🤖 Generated with [Claude Code](https://claude.com/claude-code)