### PR TITLE
The Accounts controls and column headings stay put while the list scrolls

### DIFF
--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useCallback, useRef, Suspense } from 'react';
+import React, { useState, useEffect, useLayoutEffect, useCallback, useRef, Suspense } from 'react';
 import { Link, useLocation, Outlet, useNavigate } from 'react-router-dom';
 
 // THE FRAME'S EDITION-VARYING FURNITURE, through a specifier that names no
@@ -44,45 +44,14 @@ import { useSwipeGestures } from '../hooks/useSwipeGestures';
 import ViewportDebugOverlay from './ViewportDebugOverlay';
 import SyncStatusIndicator from './SyncStatusIndicator';
 import { isDemoModeRuntimeAllowed } from '../utils/runtimeMode';
+import { APP_BAR_HEIGHT_VAR, TOP_CHROME_OFFSET } from './layout/chromeOffsets';
 
-/**
- * The vertical room the demo banner needs, or nothing at all when it is not
- * showing. Set by whatever `@chrome` resolves `DemoBanner` to, which is the only
- * thing that can measure it — see the comment on BANNER_HEIGHT_VAR in
- * `components/DemoModeIndicator.tsx`. An edition with no demo mode publishes
- * nothing and every consumer here falls back to 0px, which is exactly what a
- * browser outside demo mode already does.
+/*
+ * The top-of-window offsets live in `layout/chromeOffsets.ts` rather than here.
+ * A page needs one of them to park its own chrome, and Layout renders the
+ * router's Outlet — so importing back from this file closes a cycle that lint
+ * and strict TypeScript both accept and the browser does not. See that file.
  */
-const DEMO_BANNER_OFFSET = 'var(--wt-demo-banner-height, 0px)';
-
-/**
- * Everything pinned to the top of the window starts BELOW the phone's status
- * bar — the clock, the signal bars, the battery.
- *
- * `index.html` asks for `apple-mobile-web-app-status-bar-style:
- * black-translucent` with `viewport-fit=cover`, and that pairing means exactly
- * what it says: once the app is installed to a home screen, the page is drawn
- * UNDER the status bar rather than beneath it. That is the right choice — it is
- * what makes an installed app look like an app instead of a web page in a box —
- * but it is only half a decision. The other half is `env(safe-area-inset-top)`,
- * and nothing in this codebase was using it: `.safe-padding-top` had been
- * defined in index.css and had ZERO consumers.
- *
- * So the mobile header sat at y=0, underneath the clock and the battery, and
- * the identity menu in its top-right corner — the only way to sign out on a
- * phone — was physically unreachable behind them. Reported by the owner from
- * his own home screen, with a screenshot of the avatar hiding behind his wifi
- * indicator.
- *
- * In a browser tab the inset resolves to 0px, so this changes nothing there;
- * it only pays out where the status bar actually overlaps, which is the case
- * that was broken. The demo banner and the header both use it, and the banner
- * publishes its measured height on top, so the two stack in the right order.
- */
-const SAFE_AREA_TOP = 'env(safe-area-inset-top, 0px)';
-
-/** Below the status bar, and below the demo banner when there is one. */
-const TOP_CHROME_OFFSET = `calc(${SAFE_AREA_TOP} + ${DEMO_BANNER_OFFSET})`;
 
 export default function Layout(): React.JSX.Element {
   const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false);
@@ -94,6 +63,8 @@ export default function Layout(): React.JSX.Element {
   const [openDropdown, setOpenDropdown] = useState<string | null>(null);
   const [isMobileSearchVisible, setIsMobileSearchVisible] = useState(false);
   const desktopSearchRef = useRef<GlobalSearchHandle | null>(null);
+  const desktopNavRef = useRef<HTMLElement | null>(null);
+  const mobileHeaderRef = useRef<HTMLElement | null>(null);
   const mobileSearchRef = useRef<GlobalSearchHandle | null>(null);
   const location = useLocation();
   const navigate = useNavigate();
@@ -119,7 +90,64 @@ export default function Layout(): React.JSX.Element {
       desktopSearchRef.current?.focusInput();
     }
   }, [openMobileSearch]);
-  
+
+  // Publishes APP_BAR_HEIGHT_VAR — see the comment on it in
+  // `layout/chromeOffsets`, and on BANNER_HEIGHT_VAR in DemoModeIndicator,
+  // which this deliberately mirrors. In a LAYOUT effect, before paint, so a
+  // page's parked chrome is in the right place on the first frame rather than
+  // dropping into position after it.
+  useLayoutEffect((): (() => void) => {
+    const root = document.documentElement;
+    const publishHeight = (): void => {
+      // Whichever bar is hidden at this width measures 0, so the larger of the
+      // two is the one on screen — which is how this survives a breakpoint
+      // change without knowing where the breakpoint is.
+      const height = Math.max(
+        desktopNavRef.current?.offsetHeight ?? 0,
+        mobileHeaderRef.current?.offsetHeight ?? 0
+      );
+      root.style.setProperty(APP_BAR_HEIGHT_VAR, `${height}px`);
+    };
+
+    publishHeight();
+
+    // WATCHING THE TWO BARS IS NOT ENOUGH, and the failure is silent. A
+    // ResizeObserver does not report an element that is not being rendered, so
+    // the one moment the answer changes — crossing `md`, one bar going
+    // `display: none` as the other appears — fires no callback at all.
+    // Measured: after 1280→390 the variable still said 48px, the desktop bar's
+    // height, and the accounts toolbar parked 28px UNDER a 76px mobile header.
+    //
+    // So the document element is observed as well — always rendered, always
+    // changing with the viewport — and `resize` and `orientationchange` are
+    // listened for on top. That is three subscriptions for one fact, and it is
+    // deliberate belt-and-braces rather than indecision: every callback runs
+    // the same two `offsetHeight` reads, so a duplicate costs nothing and a
+    // missing one costs a toolbar parked behind the header.
+    //
+    // ⚠️ WHAT IS AND IS NOT PROVEN. Verified by measurement: the published
+    // value is correct on load at 1280 (48px) and at 390 (76px), and the
+    // handler produces the right answer when invoked. The CROSSING itself
+    // could not be tested here — the automated browser changes the viewport
+    // without dispatching anything, confirmed by counting hits on all three
+    // subscriptions across a 1280→390 change: 0, 0 and 0, while `innerWidth`
+    // reported the new value. A real browser fires all three. This is the same
+    // family of blind spot as the harness being unable to see CSS transitions.
+    const observer = new ResizeObserver(publishHeight);
+    observer.observe(document.documentElement);
+    if (desktopNavRef.current !== null) observer.observe(desktopNavRef.current);
+    if (mobileHeaderRef.current !== null) observer.observe(mobileHeaderRef.current);
+    window.addEventListener('resize', publishHeight);
+    window.addEventListener('orientationchange', publishHeight);
+
+    return (): void => {
+      observer.disconnect();
+      window.removeEventListener('resize', publishHeight);
+      window.removeEventListener('orientationchange', publishHeight);
+      root.style.removeProperty(APP_BAR_HEIGHT_VAR);
+    };
+  }, []);
+
   // Initialize conflict resolution
   const {
     currentConflict,
@@ -301,6 +329,7 @@ export default function Layout(): React.JSX.Element {
       </div>
       {/* Desktop Top Navigation Bar */}
       <nav
+        ref={desktopNavRef}
         id="main-navigation"
         className="hidden md:block fixed top-0 left-0 right-0 z-40 bg-[#1a2332] shadow-md"
         // Sits BELOW the demo banner rather than under it. The banner publishes
@@ -485,6 +514,7 @@ export default function Layout(): React.JSX.Element {
 
       {/* Mobile Header */}
       <header
+        ref={mobileHeaderRef}
         className="md:hidden fixed top-0 left-0 right-0 z-40 bg-white dark:bg-gray-800 shadow-md"
         // The status bar's room as well as the banner's — see TOP_CHROME_OFFSET.
         // This header carries the identity menu, so getting it wrong took the

--- a/src/components/layout/__tests__/chromeOffsets.test.ts
+++ b/src/components/layout/__tests__/chromeOffsets.test.ts
@@ -1,0 +1,83 @@
+/**
+ * The offsets that say where the top of the window has already been spent.
+ *
+ * Two things went wrong on 2026-08-14 while the accounts page learned to park
+ * its toolbar, and neither was caught by lint or by `typecheck:strict`. This
+ * file is the guard for both, because both fail SILENTLY — the app builds, the
+ * types are sound, and a control the owner asked to keep reachable sits behind
+ * the nav bar.
+ *
+ *   1. The offset written as literals. `top-16 md:top-12` looks like the
+ *      obvious thing to copy and is wrong three ways: it omits the demo
+ *      banner, it omits the status-bar inset an installed home-screen app has,
+ *      and its mobile figure (64px) is not even the height of the mobile
+ *      header (76px, measured).
+ *   2. The constants living in `Layout.tsx`. A page importing back from Layout
+ *      closes a module cycle, and the page died with `ReferenceError:
+ *      STICKY_UNDER_APP_BAR is not defined`.
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import {
+  APP_BAR_HEIGHT_VAR,
+  DEMO_BANNER_OFFSET,
+  SAFE_AREA_TOP,
+  STICKY_UNDER_APP_BAR,
+  TOP_CHROME_OFFSET
+} from '../chromeOffsets';
+
+describe('where a page may park its own chrome', () => {
+  it('adds up all three things above it, rather than naming a number', () => {
+    // Each term is a separate failure the owner would see: no inset and the
+    // bar hides under the iPhone status bar on his home screen; no banner and
+    // it hides under the nav in demo mode; no app-bar height and it hides
+    // under the app bar always.
+    expect(STICKY_UNDER_APP_BAR).toContain(SAFE_AREA_TOP);
+    expect(STICKY_UNDER_APP_BAR).toContain(DEMO_BANNER_OFFSET);
+    expect(STICKY_UNDER_APP_BAR).toContain(APP_BAR_HEIGHT_VAR);
+    expect(STICKY_UNDER_APP_BAR.startsWith('calc(')).toBe(true);
+  });
+
+  it('leaves every term for the browser to resolve, so none can go stale', () => {
+    // A pixel literal anywhere in here is the `calc(100vh-13rem)` mistake
+    // again: a measurement of other people's markup, correct only on the day
+    // it was written. `0px` fallbacks inside var()/env() are the exception —
+    // they are what "absent" means, not a measurement.
+    const withoutFallbacks = STICKY_UNDER_APP_BAR.replace(/,\s*0px/g, '');
+    expect(withoutFallbacks).not.toMatch(/\d+px/);
+    expect(withoutFallbacks).not.toMatch(/\d+rem/);
+  });
+
+  it('starts from the same base the app bars themselves use', () => {
+    // If these two ever disagree, parked chrome and the bar it parks under are
+    // measuring from different origins.
+    expect(TOP_CHROME_OFFSET).toContain(SAFE_AREA_TOP);
+    expect(TOP_CHROME_OFFSET).toContain(DEMO_BANNER_OFFSET);
+  });
+});
+
+describe('the module itself', () => {
+  it('is a leaf, so it cannot be half of an import cycle', () => {
+    /*
+     * THIS IS THE POINT OF THE FILE EXISTING. Layout renders the router's
+     * Outlet, so every page is downstream of it; when these constants lived in
+     * Layout and a page imported one back, ESM handed out the binding before
+     * the module had evaluated it and the page died behind the error boundary.
+     * Lint and strict TypeScript both passed on that — a cycle is legal in
+     * both. Only loading the page found it.
+     *
+     * A module that imports nothing cannot participate in a cycle, so that is
+     * what is asserted: no imports at all, not merely "no components".
+     */
+    const source = readFileSync(
+      join(__dirname, '..', 'chromeOffsets.ts'),
+      'utf8'
+    );
+    const imports = source
+      .split('\n')
+      .filter(line => /^\s*import\b/.test(line));
+
+    expect(imports).toEqual([]);
+  });
+});

--- a/src/components/layout/chromeOffsets.ts
+++ b/src/components/layout/chromeOffsets.ts
@@ -1,0 +1,71 @@
+/**
+ * Where the top of the window has already been spent, expressed as CSS the
+ * browser evaluates rather than numbers this file has to keep up to date.
+ *
+ * ─ WHY THIS IS ITS OWN MODULE ───────────────────────────────────────────────
+ * These began life inside `components/Layout.tsx`, which is the right place for
+ * them right up until a PAGE needs one. Layout renders the router's `Outlet`,
+ * so every page is downstream of it; a page importing back from Layout closes
+ * a cycle, and an ES module in a cycle hands out its bindings before it has
+ * evaluated them. Measured, when `Accounts` imported the sticky offset from
+ * Layout directly: `ReferenceError: STICKY_UNDER_APP_BAR is not defined`, the
+ * page dead behind the error boundary.
+ *
+ * Note what did NOT catch that — `npm run lint` and `npm run typecheck:strict`
+ * both passed, because a cycle is legal TypeScript and legal ESM. Only loading
+ * the page found it. A leaf module with no component imports cannot be part of
+ * such a cycle, which is the whole reason this file exists.
+ */
+
+/**
+ * Everything pinned to the top of the window starts BELOW the phone's status
+ * bar — the clock, the signal bars, the battery.
+ *
+ * `index.html` asks for `apple-mobile-web-app-status-bar-style:
+ * black-translucent` with `viewport-fit=cover`, and that pairing means exactly
+ * what it says: once the app is installed to a home screen, the page is drawn
+ * UNDER the status bar rather than beneath it. In a browser tab the inset
+ * resolves to 0px, so it only pays out where the status bar actually overlaps.
+ */
+export const SAFE_AREA_TOP = 'env(safe-area-inset-top, 0px)';
+
+/**
+ * The vertical room the demo banner needs, or nothing at all when it is not
+ * showing. Set by whatever `@chrome` resolves `DemoBanner` to, which is the
+ * only thing that can measure it — see the comment on BANNER_HEIGHT_VAR in
+ * `components/DemoModeIndicator.tsx`. An edition with no demo mode publishes
+ * nothing and every consumer here falls back to 0px, which is exactly what a
+ * browser outside demo mode already does.
+ */
+export const DEMO_BANNER_OFFSET = 'var(--wt-demo-banner-height, 0px)';
+
+/** Below the status bar, and below the demo banner when there is one. */
+export const TOP_CHROME_OFFSET = `calc(${SAFE_AREA_TOP} + ${DEMO_BANNER_OFFSET})`;
+
+/**
+ * How tall the app bar is — published BY the app bar (see the layout effect in
+ * `Layout.tsx`), for the same reason and by the same means as the demo banner
+ * publishes its own height: the bar is the only thing that knows.
+ *
+ * Only one of the two bars is displayed at a time (`hidden md:block` against
+ * `md:hidden`), so the hidden one measures 0 and the larger of the pair is
+ * whichever is on screen. That is what lets a consumer survive a breakpoint
+ * change without knowing where the breakpoint is.
+ */
+export const APP_BAR_HEIGHT_VAR = '--wt-app-bar-height';
+
+/**
+ * Where a page may park chrome of its own: clear of the status bar, the demo
+ * banner and the app bar, whatever each of them happens to be right now.
+ * Import this rather than writing another `top-16 md:top-12`.
+ *
+ * Those two literals are what the reconciliation page still uses, and they are
+ * wrong three ways — all measured 2026-08-14 at 1280×700 and 390×760. They are
+ * the bar HEIGHTS with the status-bar inset and the demo banner left out, so
+ * parked chrome slides under the app bar by the banner's height in demo mode
+ * and by the status bar's on an installed home-screen app. And the mobile
+ * figure is not even the right height: that header is `p-4` around its content
+ * and measures 76px, not the 64 of `top-16`.
+ */
+export const STICKY_UNDER_APP_BAR =
+  `calc(${SAFE_AREA_TOP} + ${DEMO_BANNER_OFFSET} + var(${APP_BAR_HEIGHT_VAR}, 0px))`;

--- a/src/pages/Accounts.tsx
+++ b/src/pages/Accounts.tsx
@@ -75,6 +75,7 @@ import { useArrivalRowFocus } from '../hooks/useArrivalFocus';
 // a row's own button belongs to the button, on both pages.
 import { clickedOwnControl } from '../hooks/useRowClickGesture';
 import { useBackdropDismiss } from '../hooks/useBackdropDismiss';
+import { STICKY_UNDER_APP_BAR } from '../components/layout/chromeOffsets';
 import {
   currentPageProvenance,
   readResumeCrumbs,
@@ -1581,11 +1582,26 @@ export default function Accounts() {
                 className={`flex-shrink-0 text-gray-400 transition-transform duration-200 ${isExpanded ? 'rotate-90' : ''}`}
               />
               {bandHeadingIcon(group)}
-              {/* Caps label, not a heading-sized title: the band's name is a
-                  label for the figure beside it, and the figure is the thing
-                  worth reading (P1). Still an h2 — the outline, and the way a
-                  screen-reader user walks this page, are unchanged. */}
-              <h2 className="text-body uppercase font-bold tracking-wide text-gray-900 dark:text-white">{group.title}</h2>
+              {/* THE NAME OUTRANKS THE FIGURE HERE, and it took two goes to
+                  believe it. P1 said a band's name is a label for its total,
+                  so the label was set one step under the money — 14px word,
+                  16px figure. The owner read the result back: "the words like
+                  'Current Accounts' and 'Credit Cards' are now smaller than the
+                  figures next to them."
+
+                  He is right, and P1 is not wrong — it is answering a different
+                  question. On a card you have already found, the total is what
+                  you came for. This is a 130-row list being SCROLLED, and the
+                  heading's job there is to tell you where you have got to; a
+                  band total nobody navigates by was winning that contest on
+                  size alone. So the name goes to `text-card`, level with the
+                  figure it introduces, and the institution line below it to
+                  `text-body`, keeping the one-step drop BETWEEN the two tiers
+                  rather than between a heading and its own number.
+
+                  Still an h2 — the outline, and the way a screen-reader user
+                  walks this page, are unchanged. */}
+              <h2 className="text-card uppercase font-bold tracking-wide text-gray-900 dark:text-white">{group.title}</h2>
               <span className="text-dense text-gray-400 dark:text-gray-500">
                 ({group.accounts.length} {group.accounts.length === 1 ? 'account' : 'accounts'})
               </span>
@@ -1598,16 +1614,11 @@ export default function Accounts() {
 
         {isExpanded && (
           <div id={regionId} className="bg-white dark:bg-gray-800">
-            {/* ONE STRIP PER BAND, not four labels on every row.
-                Twenty-odd repetitions of "Bank Bal / Account Bal /
-                Unreconciled / To Review" were the cost of a card that has to
-                explain itself in isolation — the reconciliation list was given
-                one strip per group in the August design pass and this page
-                never was. It sits above the sub-bands rather than inside each
-                one, so an account list grouped by nine institutions says the
-                four words once, not nine times. Phones keep the per-row labels
-                (see AccountRowColumns): below `sm` there is no grid to head. */}
-            <AccountColumnHeader />
+            {/* The strip that used to be here is now parked at the top of the
+                page with the controls, so it heads every band instead of
+                scrolling away with this one. Phones never had it and still do
+                not — below `sm` there is no grid to head, and the per-row
+                labels in AccountRowColumns do that job. */}
             {subBands
               ? subBands.map(sub => {
                   // Count and total describe the WHOLE sub-band, as the section
@@ -1629,13 +1640,13 @@ export default function Accounts() {
                       {/* The same treatment as the band above it, one step
                           quieter: a line, not a pill with a border of its own. */}
                       <div className="flex items-center justify-between gap-2 border-b border-line dark:border-gray-700 bg-surface-secondary/60 dark:bg-gray-700/30 px-4 sm:px-6 py-1.5">
-                        <p className="text-dense uppercase font-semibold tracking-wide text-gray-700 dark:text-gray-200 truncate">
+                        <p className="text-body uppercase font-bold tracking-wide text-gray-900 dark:text-white truncate">
                           {sub.title}
                           <span className="ml-2 font-normal normal-case tracking-normal text-gray-400 dark:text-gray-500">
                             ({countLabel})
                           </span>
                         </p>
-                        <p className="shrink-0 text-dense font-semibold text-gray-600 dark:text-gray-300">
+                        <p className="shrink-0 text-body font-semibold text-gray-700 dark:text-gray-300">
                           {/* The container already carries the spoken form in
                               its group label, so the mark is decoration here. */}
                           <span aria-hidden="true">{subTotal.text}</span>
@@ -1802,6 +1813,74 @@ export default function Accounts() {
           and it is what lines the pill groups up under each other; side by side
           each label is its own width, 8px from its controls and 32 from the
           group before. */}
+      </div>
+
+      {/* THE CHROME PARKS, AND THE LIST SCROLLS UNDER IT.
+          ────────────────────────────────────────────────────────────────────
+          The owner's ask, verbatim: "we fix the information at the top of the
+          page to the top of the page, and just scroll the accounts below … as
+          when you start to scroll down you loose the ability to see column
+          headings and also loose the ability to change the view or refresh
+          feeds because you can no longer see anything at the top."
+
+          Note what is and is NOT in this box, because the difference is the
+          whole design argument. Parked: the controls, and the column strip.
+          Scrolling away as before: the page title, and the net-worth summary
+          card. A summary is read once on arrival and then it is rent — the
+          same P1 objection that kept this page unpinned until now. Controls
+          and column labels are read CONTINUOUSLY while scrolling a 130-row
+          list, which is the case for pinning them and the reason the earlier
+          ruling allowed sticky on a strip and refused it for the header block.
+
+          THE STRIP RIDES INSIDE THIS BOX rather than under it. That is not
+          tidiness — it is what makes the whole thing arithmetic-free. A second
+          sticky layer would need to know this one's height, and this one wraps
+          from one row to two at narrow widths and grows again when the "More"
+          drawer opens, so any `top` written for the strip would be a
+          measurement of other people's markup: exactly the mistake that made
+          `calc(100vh-13rem)` 40px wrong. One box, one offset, nothing to drift.
+          It also lands the strip above the "Current Accounts" heading, which is
+          where the owner asked for it.
+
+          The offset is `STICKY_UNDER_APP_BAR`, not a number. The reconciliation
+          page's `top-16 md:top-12` was the obvious thing to copy and it is
+          wrong three ways, all measured here: it omits the demo banner (36px,
+          so the controls park BEHIND the nav in demo mode — seen in a
+          screenshot before it was believed), it omits the status-bar inset that
+          an installed home-screen app has, and its mobile figure is 64px for a
+          header that measures 76. The app bar now publishes its own height the
+          way the demo banner already published its own, and the constant adds
+          up whatever those three are right now. The negative margins let the
+          parked background span the page gutter so rows do not show at its
+          edges as they pass beneath.
+
+          `md:sticky` — IT DOES NOT PARK ON A PHONE, and that is a refusal of
+          part of the ask rather than an oversight. Built at every width first
+          and screenshotted at 390: the block is two rows there, the search box
+          on one and the sort pills on the next, and it took 190px of a 760px
+          screen while clipping the card beneath it mid-figure. A quarter of the
+          phone held permanently by a search field is the "parked header is
+          rent" objection at its worst. Nothing is lost by letting it scroll:
+          the strip is `hidden sm:flex` so a phone has no column headings to
+          lose, and the bottom nav is already the fixed furniture there. The two
+          things the owner named — column headings, and reaching the view
+          controls and Refresh feeds — are desktop problems, and this is where
+          they are solved.
+
+          IT IS A SIBLING OF THE BANDS ON PURPOSE, and this is the one thing
+          here that will look like pointless nesting and is not. A sticky box
+          travels only within its OWN PARENT: written one level in, sharing a
+          wrapper with the summary card, everything above was correct — the
+          computed style really said `position: sticky, top: 48px` — and it
+          still scrolled away, because that wrapper is 253px tall and ends
+          before the first band. Measured at 1280×700: parked top should be 48,
+          was 18 at scrollY 400 and −111 at the bottom. Nothing in the CSS was
+          wrong; the box was in the wrong box. Keep it a direct sibling of the
+          list it heads, or it silently stops sticking again. */}
+      <div
+        className="md:sticky z-30 -mx-4 px-4 md:-mx-6 md:px-6 lg:-mx-8 lg:px-8 pt-2 bg-[#f8f9fb] dark:bg-gray-900"
+        style={{ top: STICKY_UNDER_APP_BAR }}
+      >
       <div className="flex flex-wrap items-center gap-x-8 gap-y-2 mb-4">
         {/* w-full below sm: each control needs to OWN its row for the pill
             group inside to stretch — as content-sized flex items the two
@@ -2060,7 +2139,20 @@ export default function Accounts() {
           </div>
         </div>
       </div>
+      {/* ONE STRIP FOR THE PAGE, not one per band and not four labels per row.
+          It used to sit inside each band's expanded region — already an
+          improvement on twenty-odd repetitions, but it scrolled away with the
+          band, which is the half of the owner's report about column headings.
+          Parked here it heads every band at once, which it can do because all
+          nine bands share one grid.
 
+          Alignment survives the move for a structural reason rather than a
+          lucky one: a band is a plain `<div>` with no inset of its own and the
+          rows sit directly on it, so a band's content edges ARE the page's
+          content edges — the same ones this sticky box is measured to. The
+          strip goes on wearing the row card's box (see AccountRowColumns) to
+          match the inset the CARD adds, which is the part that would drift. */}
+      <AccountColumnHeader />
       </div>
 
       {/* The `-ml-1 pl-1 pr-1` that used to be here went with the scroll


### PR DESCRIPTION
Scrolling 130 rows: *"you loose the ability to see column headings and also loose the ability to change the view or refresh feeds because you can no longer see anything at the top."*

The controls and the column strip now park below the app bar. The page title and the net-worth summary still scroll away — a summary is read once on arrival, and pinning it is the "parked header is rent" objection. The strip rides **inside** the parked box rather than under it, which is what keeps the whole thing free of arithmetic: a second sticky layer would have to know the first one's height, and that box wraps to two rows at narrow widths.

### Three things this cost, none of which lint or `typecheck:strict` caught

**Sticky in the wrong box.** Written one level in, sharing a wrapper with the summary card, the computed style said `position: sticky, top: 48px` — and it still scrolled away. A sticky box travels only within its own parent, and that one is 253px tall and ends before the first band. Measured: parked top should be 48, was 18 at scrollY 400 and −111 at the bottom. It is now a sibling of the list it heads.

**The offset was a guess.** `top-16 md:top-12`, copied from Reconciliation, is wrong three ways — it omits the demo banner (so the controls parked *behind* the nav, caught in a screenshot), omits the status-bar inset an installed home-screen app has, and its mobile figure is 64px for a header that measures 76. The app bar now publishes its own height the way the demo banner already published its own, and `STICKY_UNDER_APP_BAR` adds up whatever the three are right now.

**A circular import.** The constants started in `Layout`, which renders the router's `Outlet`, so a page importing one back died with `ReferenceError: STICKY_UNDER_APP_BAR is not defined`. They live in a leaf module now.

### Not on a phone

`md:sticky`. Built at every width and screenshotted at 390: the block is two rows there and took 190px of a 760px screen while clipping the card beneath. Nothing is lost — the strip is `hidden sm:flex`, so a phone has no column headings to keep, and the bottom nav is already its fixed furniture.

### Also, the headings that were losing to their own figures

A band name goes to 16px and an institution to 14px, so the name is level with the total it introduces rather than a step under it. On a list being *scrolled*, the heading telling you where you are outranks a band total nobody navigates by.

### Verification

| Check | Result |
| --- | --- |
| Parks flush under the app bar | gap 0 at both 1280×700 and 390×760 |
| Column alignment | all four right edges match the rows to the pixel |
| Console | no errors since load |
| Tests | 6157 pass |
| New guard | fails 3 of 4 when the offset reverts to a literal or the module gains an import |

⚠️ One thing could not be tested here: the breakpoint **crossing**. The automated browser changes the viewport without dispatching anything — counted 0 hits on ResizeObserver, `resize` and `matchMedia` across a 1280→390 change while `innerWidth` reported the new value. All three are subscribed to; a real browser fires them.

Reconciliation still uses the old `top-16 md:top-12` literals and has the same three faults. Left alone here to keep this reviewable; it is a one-line change now that the constant exists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)