### PR TITLE
The phone stops navigating away, and a count becomes a door

### DIFF
--- a/src/components/AccountRowColumns.tsx
+++ b/src/components/AccountRowColumns.tsx
@@ -1,4 +1,5 @@
 import type { ReactNode } from 'react';
+import { Link } from 'react-router-dom';
 
 /**
  * The ONE column definition the Accounts list's rows share.
@@ -327,10 +328,77 @@ export function AccountBalanceCell({
 export function AccountCountCell({
   label,
   count,
+  to,
+  openLabel,
 }: {
   label: string;
   count: number;
+  /**
+   * Where this count's work is done. Given only when there IS somewhere: a
+   * count of zero is never a door, because there is nothing behind it.
+   */
+  to?: string;
+  /** Spoken form of the destination, e.g. "Reconcile Main Checking". */
+  openLabel?: string;
 }): React.JSX.Element {
+  /*
+   * THE PILL BECAME A DOOR — the owner's ask: "if we click on a highlighted
+   * 'Unreconciled' figure or a 'To Review' figure, that has something to
+   * reconcile, or review, it takes you to that specific reconciliation page,
+   * or that specific view in the account register".
+   *
+   * It reads as one because it already looks like one: a filled navy shape is
+   * what this app's primary controls wear, and the figure was ALREADY the
+   * thing the eye lands on when scanning for work. The only thing it was
+   * missing was the ability to act on what it found.
+   *
+   * ─ AND IT IS STILL NOT AMBER ────────────────────────────────────────────
+   * The comment above says navy partly "because this is not clickable", and
+   * that half of the argument has just expired — so here is the half that has
+   * not. Ruling A gives amber to the ONE control you should touch next. A
+   * count is now clickable but it is not singular: a list can show eight of
+   * them at once, and eight ambers is precisely the erosion the ruling exists
+   * to prevent. Amber's monopoly is on "this one, next" — not on "clickable".
+   */
+  const pillClass = `tabular-nums ${
+    count > 0
+      ? 'inline-flex items-center justify-center min-w-[24px] px-1.5 py-0.5 rounded-full bg-primary text-white text-sm font-bold'
+      : 'text-sm font-normal text-gray-400 dark:text-gray-500'
+  }`;
+
+  if (count > 0 && to !== undefined) {
+    return (
+      <div className="text-right">
+        <p className={ROW_LABEL_CLASS}>{label}</p>
+        <Link
+          to={to}
+          aria-label={openLabel}
+          onClick={event => { event.stopPropagation(); }}
+          /*
+           * THE BOX IS UNCHANGED, and that is load-bearing. The column strip's
+           * labels are aligned to these cells to the pixel (verified across
+           * all four columns), so a link that added padding to reach a 44px
+           * touch target would drag "Unreconciled" out of line with the
+           * figures it names.
+           *
+           * `after:-inset-[10px]` grows the TAPPABLE area to ~44px in every
+           * direction without occupying a single pixel of layout — an absolute
+           * pseudo-element takes no space. The phone gets a target it can hit;
+           * the grid does not move.
+           *
+           * `stopPropagation` because the row itself is clickable (it selects
+           * the account): without it, opening the reconciliation view would
+           * also pick out the row behind it, and coming back would land on a
+           * selection the user never made.
+           */
+          className={`${pillClass} relative after:absolute after:-inset-[10px] after:content-[''] hover:brightness-125 transition-[filter] duration-state`}
+        >
+          {count}
+        </Link>
+      </div>
+    );
+  }
+
   return (
     <div className="text-right">
       <p className={ROW_LABEL_CLASS}>{label}</p>

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -40,7 +40,6 @@ import { useKeyboardShortcutsHelp } from '../hooks/useKeyboardShortcutsHelp';
 import { useGlobalKeyboardShortcuts } from '../hooks/useKeyboardShortcuts';
 import KeyboardSequenceIndicator from './KeyboardSequenceIndicator';
 import MobileBottomNav from './MobileBottomNav';
-import { useSwipeGestures } from '../hooks/useSwipeGestures';
 import ViewportDebugOverlay from './ViewportDebugOverlay';
 import SyncStatusIndicator from './SyncStatusIndicator';
 import { isDemoModeRuntimeAllowed } from '../utils/runtimeMode';
@@ -161,37 +160,34 @@ export default function Layout(): React.JSX.Element {
   // Initialize global keyboard shortcuts
   const { activeSequence } = useGlobalKeyboardShortcuts(openHelp);
 
-  // Simple page navigation helper. Swipe walks the PAGES a phone browses;
-  // Find is a question you ask, not somewhere you swipe into, so it is not
-  // here (nor is the retired /transactions it replaced).
-  const getNextPrevPage = (direction: 'next' | 'prev', currentPath: string): string | null => {
-    const pages = ['/dashboard', '/accounts', '/investments', '/reports'];
-    const currentIndex = pages.indexOf(currentPath);
-    
-    if (currentIndex === -1) return null;
-    
-    if (direction === 'next') {
-      return currentIndex < pages.length - 1 ? pages[currentIndex + 1] : null;
-    } else {
-      return currentIndex > 0 ? pages[currentIndex - 1] : null;
-    }
-  };
-
-  // Swipe navigation for mobile
-  const swipeRef = useSwipeGestures({
-    onSwipeLeft: () => {
-      if (window.innerWidth <= 768) { // Only on mobile
-        const nextPage = getNextPrevPage('next', location.pathname);
-        if (nextPage) navigate(nextPage);
-      }
-    },
-    onSwipeRight: () => {
-      if (window.innerWidth <= 768) { // Only on mobile
-        const prevPage = getNextPrevPage('prev', location.pathname);
-        if (prevPage) navigate(prevPage);
-      }
-    }
-  });
+  /*
+   * NO SWIPE-BETWEEN-PAGES. A horizontal swipe anywhere in `main` used to walk
+   * /dashboard → /accounts → /investments → /reports, and it is gone rather
+   * than narrowed.
+   *
+   * ─ WHY ─────────────────────────────────────────────────────────────────────
+   * A page-level horizontal gesture cannot coexist with horizontally scrollable
+   * CONTENT, and it loses the argument every time, because the content is what
+   * the user is deliberately reaching for. Reported from a phone: the account
+   * rows' settings / reconcile / close buttons sat off to the right, and
+   * "if I scroll a little to the right to make them visible, the page thinks I
+   * am trying to scroll 'forward' a page and takes me to the investment page."
+   * The gesture did not merely conflict with the reach — it PUNISHED it, by
+   * throwing the page away mid-reach.
+   *
+   * It is also a second, worse copy of a gesture the platform already owns:
+   * iOS Safari's edge swipe is back/forward, so the same flick meant two
+   * different things depending on how near the bezel it started.
+   *
+   * Nothing is lost. The bottom nav is on every phone screen and goes to these
+   * pages directly, by name, in one tap — a discoverable control replacing an
+   * invisible one whose main effect was accidental navigation. The owner asked
+   * for exactly this: "we disable the ability to 'scroll through pages' by
+   * scrolling left and right".
+   *
+   * `useSwipeGestures` itself stays — BottomSheet and SwipeableTransactionRow
+   * use it for gestures scoped to one element, which is where a swipe belongs.
+   */
 
   // Close dropdown on route change
   useEffect(() => {
@@ -703,7 +699,6 @@ export default function Layout(): React.JSX.Element {
 
       {/* Main Content */}
       <main
-        ref={swipeRef.ref}
         id="main-content"
         // A plain block child now — flex-1/min-w-0 died with the parent's
         // flex row. (Their history: min-w-0 once stopped a non-wrapping row

--- a/src/components/__tests__/AccountCountCell.test.tsx
+++ b/src/components/__tests__/AccountCountCell.test.tsx
@@ -27,7 +27,8 @@
  * flattens the two states back together.
  */
 import { describe, it, expect } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
 import { AccountCountCell } from '../AccountRowColumns';
 
 const classesFor = (count: number): string => {
@@ -82,6 +83,107 @@ describe('a count of outstanding work', () => {
   });
 
   it('still renders the number itself, and keeps digits aligned', () => {
+    // A column of counts is read down, so the figures stay tabular whatever
+    // else changes about them.
+    expect(classesFor(12)).toContain('tabular-nums');
+    render(<AccountCountCell label="To Review" count={12} />);
+    expect(screen.getByText('12')).toBeInTheDocument();
+  });
+});
+
+/**
+ * ─ THE COUNT IS ALSO A DOOR ────────────────────────────────────────────────
+ * "If we click on a highlighted 'Unreconciled' figure or a 'To Review' figure,
+ * that has something to reconcile, or review, it takes you to that specific
+ * reconciliation page, or that specific view in the account register."
+ *
+ * The invariant worth guarding is not the destination — that is the caller's —
+ * but WHEN the cell becomes a link at all, because the answer is not simply
+ * "when a link was offered".
+ */
+describe('a count you can act on', () => {
+  const renderLinked = (count: number) =>
+    render(
+      <MemoryRouter>
+        <AccountCountCell
+          label="Unreconciled"
+          count={count}
+          to="/reconciliation?account=abc&from=accounts"
+          openLabel="Reconcile Current Account"
+        />
+      </MemoryRouter>
+    );
+
+  it('opens the work when there is work', () => {
+    renderLinked(3);
+    const link = screen.getByRole('link', { name: 'Reconcile Current Account' });
+    expect(link).toHaveAttribute('href', '/reconciliation?account=abc&from=accounts');
+    // Still the same pill — becoming clickable must not restyle it, or the
+    // column strip stops lining up with the figures it names.
+    expect(link.getAttribute('class')).toContain('bg-primary');
+    expect(link.getAttribute('class')).toContain('rounded-full');
+  });
+
+  it('is NOT a link when the count is zero, even though one was offered', () => {
+    /*
+     * The whole point. A zero is not a door: there is nothing behind it, and a
+     * row of 130 clickable noughts would hand the eye 130 things to consider
+     * and 130 dead ends to discover. This is the same argument that keeps the
+     * zero out of the pill — nothing is not something to attend to — applied
+     * to behaviour rather than to colour.
+     */
+    renderLinked(0);
+    expect(screen.queryByRole('link')).toBeNull();
+    expect(screen.getByText('0')).toBeInTheDocument();
+  });
+
+  it('keeps a touch target without taking any layout for it', () => {
+    /*
+     * The pill is ~24px, under the 44px a thumb needs. The room is bought with
+     * an absolutely-positioned pseudo-element, which occupies no space, rather
+     * than with padding, which would drag this cell out of alignment with the
+     * parked column strip above it.
+     */
+    renderLinked(7);
+    const cls = screen.getByRole('link').getAttribute('class') ?? '';
+    expect(cls).toContain('after:absolute');
+    expect(cls).toContain('after:-inset-[10px]');
+    expect(cls).not.toMatch(/\bp-[3-9]\b/);
+  });
+
+  it('does not let opening the work also select the row behind it', () => {
+    // The row is itself clickable. Without stopPropagation the click would
+    // both navigate and pick out the account, so coming back would land on a
+    // selection nobody made.
+    //
+    // The cell is rendered INSIDE the clickable row, in one React tree, because
+    // that is the only arrangement that tests anything: React delivers events
+    // through its own root listener, so a handler bolted onto a detached node
+    // never hears them and the assertion passes for the wrong reason.
+    let rowClicks = 0;
+    render(
+      <MemoryRouter>
+        <div onClick={() => { rowClicks += 1; }}>
+          <AccountCountCell
+            label="Unreconciled"
+            count={4}
+            to="/reconciliation?account=abc&from=accounts"
+            openLabel="Reconcile Current Account"
+          />
+        </div>
+      </MemoryRouter>
+    );
+
+    fireEvent.click(screen.getByRole('link'));
+    expect(rowClicks).toBe(0);
+  });
+});
+
+describe('the unlinked cell is unchanged', () => {
+  it('renders without a router at all', () => {
+    // Nested cash rows and any future caller that offers no destination must
+    // keep working outside a Router — the Link is conditional, not universal.
+    expect(() => render(<AccountCountCell label="Unreconciled" count={5} />)).not.toThrow();
     // A column of counts is read down, so the figures stay tabular whatever
     // else changes about them.
     expect(classesFor(12)).toContain('tabular-nums');

--- a/src/pages/AccountTransactions.tsx
+++ b/src/pages/AccountTransactions.tsx
@@ -582,7 +582,8 @@ export default function AccountTransactions() {
     const params = new URLSearchParams(location.search);
     const txn = params.get('txn');
     const hasShowArchived = params.has('showArchived');
-    if (!txn && !hasShowArchived) return;
+    const hasReview = params.has('review');
+    if (!txn && !hasShowArchived && !hasReview) return;
     if (txn) {
       pendingTxnRef.current = txn;
       openedAtFootRef.current = accountId ?? null;
@@ -595,6 +596,30 @@ export default function AccountTransactions() {
       // state above.
       if (params.get('showArchived') === '1') setShowArchived(true);
       params.delete('showArchived');
+    }
+    if (hasReview) {
+      /*
+       * ARRIVING ALREADY FILTERED, from the To Review count on the accounts
+       * list. The owner's ask: clicking that figure should take you to "that
+       * specific view in the account register, filtered to show items 'to
+       * review' only".
+       *
+       * A URL PARAMETER RATHER THAN STORED STATE, and deliberately: the
+       * comment on `reviewOnly` argues that a filter must not outlive the
+       * session that set it, because "coming back to a register showing four
+       * of its nine hundred rows, with no memory of why" reads as data loss.
+       * A parameter is the opposite of stored — it is consumed and deleted in
+       * the same pass as `txn` and `showArchived` below, so the filter is on
+       * because the user asked for it one click ago and is gone the moment
+       * they navigate away. `=== '1'` so `?review=0` can turn it off rather
+       * than mean the same as `?review=1`.
+       *
+       * The register drops the filter by itself when the count reaches zero
+       * (the effect beside `toReviewCount`), so this cannot strand anyone on
+       * an empty list after they have dealt with the last arrival.
+       */
+      if (params.get('review') === '1') setReviewOnly(true);
+      params.delete('review');
     }
     // The state is carried across by hand. React Router gives a replaced entry
     // null state unless told otherwise, and the state here is the provenance

--- a/src/pages/Accounts.tsx
+++ b/src/pages/Accounts.tsx
@@ -1096,6 +1096,19 @@ export default function Accounts() {
    * Named for the account it belongs to: a card now shows two of these, and
    * "Reconcile" twice over is a control nobody can tell apart by ear.
    */
+  /*
+   * WHERE A COUNT'S WORK IS DONE. Two doors, one per column, and neither is a
+   * new destination — Unreconciled goes exactly where the row's own Reconcile
+   * button goes, and To Review goes to the register the account name already
+   * opens, arriving with the register's existing To Review filter switched on.
+   * The feature is the shortcut, not a new screen.
+   */
+  const reconcileHref = (accountId: string): string =>
+    preserveDemoParam(`/reconciliation?account=${accountId}&from=accounts`, location.search);
+
+  const reviewHref = (accountId: string): string =>
+    preserveDemoParam(`/accounts/${accountId}?review=1`, location.search);
+
   const renderReconcileButton = (account: Account): ReactNode => (
     <button
       type="button"
@@ -1279,7 +1292,12 @@ export default function Accounts() {
                                 value={formatDisplayCurrency(computeAccountBalance(account.id), account.currency)}
                                 smOnly
                               />
-                              <AccountCountCell label="Unreconciled" count={getUnreconciledCount(account.id)} />
+                              <AccountCountCell
+                                label="Unreconciled"
+                                count={getUnreconciledCount(account.id)}
+                                to={reconcileHref(account.id)}
+                                openLabel={`Reconcile ${account.name}`}
+                              />
                               {/* To Review — freshly imported rows nobody has
                                   dealt with, so the size of the job is visible
                                   from the list rather than only from inside the
@@ -1287,7 +1305,12 @@ export default function Accounts() {
                                   the two are the same shape of question — how
                                   much is outstanding — and reading them as a
                                   pair is the point. */}
-                              <AccountCountCell label="To Review" count={toReviewByAccount.get(account.id) ?? 0} />
+                              <AccountCountCell
+                                label="To Review"
+                                count={toReviewByAccount.get(account.id) ?? 0}
+                                to={reviewHref(account.id)}
+                                openLabel={`Review new transactions in ${account.name}`}
+                              />
                               <AccountRowActionSlot>
                                 {account.type === 'investment' && account.holdings && account.holdings.length > 0 && (
                                 <button
@@ -1454,10 +1477,20 @@ export default function Accounts() {
                               value={formatDisplayCurrency(computeAccountBalance(child.id), child.currency)}
                               smOnly
                             />
-                            <AccountCountCell label="Unreconciled" count={getUnreconciledCount(child.id)} />
+                            <AccountCountCell
+                              label="Unreconciled"
+                              count={getUnreconciledCount(child.id)}
+                              to={reconcileHref(child.id)}
+                              openLabel={`Reconcile ${child.name}`}
+                            />
                             {/* Its own register means its own arrivals to deal
                                 with, so it gets this column too. */}
-                            <AccountCountCell label="To Review" count={toReviewByAccount.get(child.id) ?? 0} />
+                            <AccountCountCell
+                              label="To Review"
+                              count={toReviewByAccount.get(child.id) ?? 0}
+                              to={reviewHref(child.id)}
+                              openLabel={`Review new transactions in ${child.name}`}
+                            />
                             {/* Portfolio, feed and settings: not this row's to
                                 offer. The slots stay so the Reconcile button
                                 lands under its parent's. */}


### PR DESCRIPTION
Two reports from a phone, one cause between them, and one feature on top.

## The swipe

> "The settings / reconciliation / close account buttons are on the right and the reconciliation and close accounts ones are hidden from the normal view. If I scroll a little to the right to make them visible, the page thinks I am trying to scroll 'forward' a page and takes me to the investment page."

A horizontal swipe anywhere in `main` walked /dashboard → /accounts → /investments → /reports. That gesture cannot coexist with horizontally scrollable content, and it loses the argument every time, because the content is what the user is deliberately reaching for. Here it did not merely conflict with the reach — it **punished** it, by throwing the page away mid-reach. It is also a second, worse copy of iOS Safari's own edge swipe, so the same flick meant two different things depending on how near the bezel it started.

Removed rather than narrowed, as suggested. Nothing is lost: the bottom nav is on every phone screen and reaches those pages by name in one tap — a discoverable control replacing an invisible one whose main effect was accidental navigation. `useSwipeGestures` stays for `BottomSheet` and `SwipeableTransactionRow`, where a swipe is scoped to one element.

⚠️ **The row overflow itself did not reproduce on the current build.** Measured at 375px and 320px: all twelve action buttons sit fully on screen (right edges 166/226/290 against a 320px viewport) and the document has zero horizontal overflow — the icons wrap to a second line. That points at the home-screen app running a stale build, which it does because it resumes rather than reloads. Worth a full close-and-reopen before we redesign the row.

## The count is also a door

> "If we click on a highlighted 'Unreconciled' figure or a 'To Review' figure, that has something to reconcile, or review, it takes you to that specific reconciliation page, or that specific view in the account register."

Neither destination is new. Unreconciled goes exactly where the row's own Reconcile button goes; To Review opens the register the account name already opens, with the register's **existing** To Review filter switched on. The feature is the shortcut, not a new screen.

- **A zero is never a door.** Nothing is behind it, and 130 clickable noughts is 130 things to consider and 130 dead ends to discover. The same argument that keeps the zero out of the pill, applied to behaviour rather than colour.
- **Still navy, not amber.** Half the old reason ("this is not clickable") has just expired; the other half has not — amber marks the *one* control to touch next, and a list can show eight of these at once.
- **The box does not change.** The parked column strip is aligned to these cells to the pixel, so the 44px touch target is bought with an absolutely-positioned pseudo-element — which occupies no layout — rather than with padding, which would drag "Unreconciled" out of line with the figures it names.
- **`?review=1` is a parameter**, consumed and deleted on arrival like `txn` and `showArchived`. The filter must not outlive the session that set it: a register showing four of nine hundred rows with no memory of why reads as data loss.

## Verification

| Check | Result |
| --- | --- |
| Linked counts on the demo list | 5, correct hrefs, demo flag preserved |
| Zeros | not links |
| `?review=1` | consumed and stripped on arrival |
| Tests | 6166 pass |
| New guards | fail when a zero is made clickable, or `stopPropagation` is dropped |

⚠️ **Not verified end-to-end:** the To Review filter switching *on*, because no demo account has anything to review. It shares its code path with `showArchived`, which is proven, and it is covered by unit test — but it has not been watched working against a live non-zero count.

🤖 Generated with [Claude Code](https://claude.com/claude-code)