### PR TITLE
The phone stops scrolling sideways, and the count is a circle again

### DIFF
--- a/src/components/AccountRowColumns.tsx
+++ b/src/components/AccountRowColumns.tsx
@@ -32,12 +32,28 @@ import { Link } from 'react-router-dom';
  * than dropping the column: an omitted cell pulls everything to its right one
  * place along, which is precisely the alignment this file exists to keep.
  *
- * ─ PHONES ──────────────────────────────────────────────────────────────────
- * Below sm the grid gives way to a wrapping row: the stat columns need about
- * 490px and a phone card offers ~330, so the figures take one line and the
- * buttons the next. The balance is shown beside the account NAME at that width
- * instead (where a banking app puts it), which is why AccountBalanceCell can be
- * asked to keep itself off small screens rather than saying it twice.
+ * ─ PHONES, AND WHY THE GRID STARTS AT `lg` AND NOT AT `sm` ─────────────────
+ * Below the breakpoint the grid gives way to a wrapping row: the figures take
+ * one line and the buttons the next. The balance is shown beside the account
+ * NAME at that width instead (where a banking app puts it), which is why
+ * AccountBalanceCell can be asked to keep itself off small screens rather than
+ * saying it twice.
+ *
+ * That breakpoint was `sm` (640px) until 2026-08-14, and it was too low by a
+ * whole class of device. The grid's tracks are FIXED — 104 + 120 + 88 + 88 +
+ * five 48s, plus gaps — so it cannot be squeezed; it can only overflow. Turn a
+ * phone on its side and the viewport is 844px, comfortably past `sm`, so a
+ * landscape phone was handed the desktop table: measured at 844x390, the rows
+ * wanted 915px and the page scrolled sideways by 95. The owner's report was
+ * the plain version of that: "in landscape it should all fit in a page width
+ * and I should not have to scroll right to look at anything."
+ *
+ * `lg` (1024px) is the first width where the whole template genuinely fits, so
+ * it is where it now begins. Everything that dresses the grid moves with it —
+ * the per-row labels that hide when the column strip takes over, the strip
+ * itself, the balance cell's small-screen twin, and the empty spacer cells —
+ * because a grid at one breakpoint and its captions at another is how a row
+ * ends up with both, or neither.
  */
 
 /**
@@ -46,9 +62,9 @@ import { Link } from 'react-router-dom';
  * up with each other is the whole point.
  */
 export const ACCOUNT_ROW_COLUMNS_CLASS =
-  'flex flex-wrap items-center justify-end gap-x-4 gap-y-1 sm:grid ' +
-  'sm:grid-cols-[6.5rem_7.5rem_5.5rem_5.5rem_repeat(5,3rem)] ' +
-  'sm:justify-items-end sm:items-center sm:gap-x-2 sm:gap-y-0';
+  'flex flex-wrap items-center justify-end gap-x-4 gap-y-1 lg:grid ' +
+  'lg:grid-cols-[6.5rem_7.5rem_5.5rem_5.5rem_repeat(5,3rem)] ' +
+  'lg:justify-items-end lg:items-center lg:gap-x-2 lg:gap-y-0';
 
 /**
  * The look of a row the user has picked out, echoing the register's own active
@@ -175,10 +191,39 @@ const CELL_LABEL_CLASS = 'text-[10px] uppercase tracking-wide text-gray-400 dark
  * otherwise hear four bare figures. The strip is `aria-hidden` for the mirror
  * image of the same reason.
  */
-const ROW_LABEL_CLASS = `${CELL_LABEL_CLASS} sm:sr-only`;
+const ROW_LABEL_CLASS = `${CELL_LABEL_CLASS} lg:sr-only`;
 
 /** The figures themselves: tabular so the digits line up down the column. */
 const CELL_FIGURE_CLASS = 'text-sm font-semibold tabular-nums';
+
+/**
+ * THE LINE A FIGURE SITS ON, held at one height for every cell in the row.
+ *
+ * ─ WHY THIS EXISTS ─────────────────────────────────────────────────────────
+ * Reported from a phone: "the highlighted number looks oval and not round, and
+ * you can see the 'Unreconciled' word above has risen and sits higher than
+ * 'Bank Bal' and 'To Review'."
+ *
+ * Both halves were one cause. A count with work in it became a LINK when the
+ * counts turned into doors, and `index.css` gives every `a` on a touch device
+ * `min-width: 44px; min-height: 44px` — a floor meant for thumbs, applied to a
+ * 20px figure. Measured at 390px: the pill came out 31 wide by 44 tall (the
+ * oval), which made its cell 24px taller than its neighbours, which lifted its
+ * label 12px above theirs. Nothing was wrong with the pill's own styling; it
+ * was being inflated from outside, by a rule that never matches a desktop
+ * browser — the same media block that once put the floating + button at the
+ * left edge of the screen.
+ *
+ * The fix is the owner's own second option — "increase the default height of
+ * everything else on the same row" — because it is the one that cannot come
+ * undone. Levelling the pill alone would hold only until the next cell learns
+ * a state with a different height. A shared line height means a figure may be
+ * text, money, or a filled disc and the labels above them still agree.
+ *
+ * 24px because that is the disc's diameter; plain text at `text-sm` is 20 and
+ * centres inside it without moving.
+ */
+const CELL_FIGURE_LINE_CLASS = 'flex items-center justify-end min-h-[24px]';
 
 /**
  * The columns of one row.
@@ -250,7 +295,7 @@ export function AccountColumnHeader(): React.JSX.Element {
        * carries `p-4` and a 1px border inside the band's own `px-4 sm:px-6`, so
        * the strip repeats both to land on the same right edge.
        */
-      className="hidden sm:flex justify-end pb-1"
+      className="hidden lg:flex justify-end pb-1"
     >
       {/* AN INVISIBLE ROW CARD around the labels, rather than a hand-tuned
           right margin. A row's grid is inset from the band by the card's own
@@ -289,9 +334,9 @@ export function AccountBalanceCell({
   smOnly?: boolean;
 }): React.JSX.Element {
   return (
-    <div className={smOnly ? 'hidden sm:block text-right' : 'text-right'}>
+    <div className={smOnly ? 'hidden lg:block text-right' : 'text-right'}>
       <p className={ROW_LABEL_CLASS}>{label}</p>
-      <p className={`${CELL_FIGURE_CLASS} text-gray-900 dark:text-white`}>{value}</p>
+      <p className={`${CELL_FIGURE_LINE_CLASS} ${CELL_FIGURE_CLASS} text-gray-900 dark:text-white`}>{value}</p>
     </div>
   );
 }
@@ -360,9 +405,24 @@ export function AccountCountCell({
    * them at once, and eight ambers is precisely the erosion the ruling exists
    * to prevent. Amber's monopoly is on "this one, next" — not on "clickable".
    */
+  /*
+   * A CIRCLE UNTIL THE NUMBER OUTGROWS ONE. "The highlighted number looks oval
+   * and not round" — and it stayed faintly oval even after the 44px floor was
+   * lifted, because a width of `min-w + padding` lands wherever the digits put
+   * it: 31 across against 24 down for two digits.
+   *
+   * So one and two digits get a FIXED 24x24 — a real disc, the shape that was
+   * asked for and the shape a count badge is everywhere else. Three digits and
+   * up keep the padded form and become a lozenge, which is the honest answer:
+   * 130 does not fit in a 24px circle, and squeezing it would either shrink the
+   * type or clip it. The break is at 100 because that is where the width has to
+   * give, not because of anything about the number.
+   */
   const pillClass = `tabular-nums ${
     count > 0
-      ? 'inline-flex items-center justify-center min-w-[24px] px-1.5 py-0.5 rounded-full bg-primary text-white text-sm font-bold'
+      ? `inline-flex items-center justify-center h-6 rounded-full bg-primary text-white text-sm font-bold ${
+          count < 100 ? 'w-6' : 'min-w-[24px] px-1.5'
+        }`
       : 'text-sm font-normal text-gray-400 dark:text-gray-500'
   }`;
 
@@ -370,31 +430,43 @@ export function AccountCountCell({
     return (
       <div className="text-right">
         <p className={ROW_LABEL_CLASS}>{label}</p>
+        <div className={CELL_FIGURE_LINE_CLASS}>
         <Link
           to={to}
           aria-label={openLabel}
           onClick={event => { event.stopPropagation(); }}
           /*
-           * THE BOX IS UNCHANGED, and that is load-bearing. The column strip's
-           * labels are aligned to these cells to the pixel (verified across
-           * all four columns), so a link that added padding to reach a 44px
-           * touch target would drag "Unreconciled" out of line with the
-           * figures it names.
+           * `touch-target-small` and `min-h-0` are BOTH required, and neither
+           * is decoration.
            *
-           * `after:-inset-[10px]` grows the TAPPABLE area to ~44px in every
-           * direction without occupying a single pixel of layout — an absolute
-           * pseudo-element takes no space. The phone gets a target it can hit;
-           * the grid does not move.
+           * `min-h-0 min-w-0` is the pair that undoes the damage, and it took
+           * two passes to learn it needs BOTH. On a touch device `index.css`
+           * floors every `a` at 44x44 — sound for a control, wrong for a 20px
+           * figure — and it inflated this disc to 31x44, lifting its label 12px
+           * above its neighbours'. Undoing only the height fixed the label and
+           * left a 44x24 lozenge: `min-width` had simply taken over from
+           * `min-height` as the thing overriding the disc's own size, and
+           * `w-6` cannot win against a min-width whatever it says. A utility
+           * outranks that element rule, so this is where the disc gets its size
+           * back — on both axes, or not at all.
+           *
+           * `touch-target-small` is what gives the thumb its 44px back, and it
+           * is the app's OWN opt-in for exactly this problem — a centred 44x44
+           * pseudo-element over a small visible control, taking no layout. It
+           * replaces a hand-rolled `after:-inset-[10px]` written here before I
+           * noticed index.css already had the idiom; one mechanism, in one
+           * place, is worth more than a slightly tidier inset.
            *
            * `stopPropagation` because the row itself is clickable (it selects
            * the account): without it, opening the reconciliation view would
            * also pick out the row behind it, and coming back would land on a
            * selection the user never made.
            */
-          className={`${pillClass} relative after:absolute after:-inset-[10px] after:content-[''] hover:brightness-125 transition-[filter] duration-state`}
+          className={`${pillClass} min-h-0 min-w-0 touch-target-small hover:brightness-125 transition-[filter] duration-state`}
         >
           {count}
         </Link>
+        </div>
       </div>
     );
   }
@@ -402,6 +474,7 @@ export function AccountCountCell({
   return (
     <div className="text-right">
       <p className={ROW_LABEL_CLASS}>{label}</p>
+      <div className={CELL_FIGURE_LINE_CLASS}>
       <p
         /*
          * A FILLED SHAPE, NOT LOUDER TEXT.
@@ -441,6 +514,7 @@ export function AccountCountCell({
       >
         {count}
       </p>
+      </div>
     </div>
   );
 }
@@ -453,7 +527,7 @@ export function AccountCountCell({
  * wrapping flex row, and an invisible item there would only add a gap.
  */
 export function AccountRowEmptyCell(): React.JSX.Element {
-  return <div className="hidden sm:block" aria-hidden="true" />;
+  return <div className="hidden lg:block" aria-hidden="true" />;
 }
 
 /**

--- a/src/components/__tests__/AccountCountCell.test.tsx
+++ b/src/components/__tests__/AccountCountCell.test.tsx
@@ -139,16 +139,58 @@ describe('a count you can act on', () => {
 
   it('keeps a touch target without taking any layout for it', () => {
     /*
-     * The pill is ~24px, under the 44px a thumb needs. The room is bought with
-     * an absolutely-positioned pseudo-element, which occupies no space, rather
-     * than with padding, which would drag this cell out of alignment with the
-     * parked column strip above it.
+     * The pill is 24px, under the 44px a thumb needs. The room comes from
+     * `touch-target-small` — the app's OWN opt-in in index.css, a centred 44x44
+     * pseudo-element that occupies no layout — rather than from padding, which
+     * would drag this cell out of alignment with the parked column strip.
      */
     renderLinked(7);
     const cls = screen.getByRole('link').getAttribute('class') ?? '';
-    expect(cls).toContain('after:absolute');
-    expect(cls).toContain('after:-inset-[10px]');
+    expect(cls).toContain('touch-target-small');
     expect(cls).not.toMatch(/\bp-[3-9]\b/);
+  });
+
+  it('refuses the 44px floor that index.css puts under every link', () => {
+    /*
+     * THE REGRESSION THIS FILE EXISTS TO STOP HAPPENING TWICE.
+     *
+     * `index.css` floors every `a` at 44x44 inside
+     * `@media (hover: none) and (pointer: coarse)` — right for a control,
+     * ruinous for a 20px figure, and invisible on every desktop because that
+     * query never matches one. Shipped: the disc came out 31 wide by 44 tall,
+     * which the owner reported as "the highlighted number looks oval and not
+     * round", and its inflated cell lifted "Unreconciled" 12px above "Bank Bal"
+     * and "To Review" beside it.
+     *
+     * BOTH axes, because fixing only the height moved the problem rather than
+     * solving it: min-width simply took over as the thing overriding the disc,
+     * leaving a 44x24 lozenge. A `w-6` cannot beat a `min-width`.
+     */
+    renderLinked(7);
+    const cls = screen.getByRole('link').getAttribute('class') ?? '';
+    expect(cls).toContain('min-h-0');
+    expect(cls).toContain('min-w-0');
+  });
+
+  it('is a circle for one and two digits, and a lozenge beyond', () => {
+    // 130 does not fit in a 24px circle; squeezing it would shrink or clip the
+    // type. Under 100 the disc is fixed at 24x24 so it is round rather than
+    // "however wide the digits made it".
+    render(
+      <MemoryRouter>
+        <AccountCountCell label="Unreconciled" count={38} to="/x" openLabel="a" />
+      </MemoryRouter>
+    );
+    expect(screen.getByRole('link').getAttribute('class')).toContain('w-6');
+
+    render(
+      <MemoryRouter>
+        <AccountCountCell label="Unreconciled" count={130} to="/y" openLabel="b" />
+      </MemoryRouter>
+    );
+    const wide = screen.getByRole('link', { name: 'b' }).getAttribute('class') ?? '';
+    expect(wide).not.toMatch(/\bw-6\b/);
+    expect(wide).toContain('min-w-[24px]');
   });
 
   it('does not let opening the work also select the row behind it', () => {

--- a/src/components/layout/__tests__/chromeOffsets.test.ts
+++ b/src/components/layout/__tests__/chromeOffsets.test.ts
@@ -17,6 +17,7 @@
  *      STICKY_UNDER_APP_BAR is not defined`.
  */
 import { describe, it, expect } from 'vitest';
+import { execFileSync } from 'node:child_process';
 import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import {
@@ -54,6 +55,58 @@ describe('where a page may park its own chrome', () => {
     // measuring from different origins.
     expect(TOP_CHROME_OFFSET).toContain(SAFE_AREA_TOP);
     expect(TOP_CHROME_OFFSET).toContain(DEMO_BANNER_OFFSET);
+  });
+});
+
+describe('no page re-invents the offset with literals', () => {
+  it('has no `top-16 md:top-12` left anywhere in src', () => {
+    /*
+     * The exact pair that was wrong on two pages. Accounts copied it from
+     * Reconciliation, which is how a wrong number spreads — it looked like the
+     * established idiom, because it WAS the established idiom.
+     *
+     * Both now use STICKY_UNDER_APP_BAR. This fails if a third page copies the
+     * literals from the git history, or from a screenshot, or from an LLM that
+     * learned them from this repo before today.
+     *
+     * Scoped to that exact pair rather than to `top-16` generally: plenty of
+     * elements legitimately sit 4rem from something, and a guard that shouts at
+     * all of them would be turned off within a week.
+     *
+     * It matches the pair only where it is APPLIED — on a `className` — and not
+     * where it is merely named. Written as a bare string first, this failed
+     * immediately on six hits, every one of them prose: the comments on both
+     * fixed pages explaining what the numbers used to be, the constant's own
+     * doc block, and this file. A guard that forbids DESCRIBING the bug would
+     * be paid for by deleting the explanations of it, which is a bad trade.
+     */
+    const repoRoot = join(__dirname, '..', '..', '..', '..');
+    /*
+     * Assembled from pieces so this FILE never contains the phrase it is
+     * hunting. Spelled out in one string, the only thing the guard found was
+     * its own search pattern — a test that fails because of itself, which is
+     * the same defect as one that passes because of itself.
+     */
+    const pattern = `className=.*${['top-16', 'md:top-12'].join(' ')}`;
+    let offenders: string;
+    try {
+      offenders = execFileSync(
+        'git',
+        ['grep', '-l', '-E', '-e', pattern, '--', 'src'],
+        { cwd: repoRoot, encoding: 'utf8' }
+      ).trim();
+    } catch (error) {
+      /*
+       * `git grep` exits 1 when it finds NOTHING, which is the passing case —
+       * so this catch must distinguish "clean" from "git failed", or the guard
+       * would go green on a broken checkout and prove nothing at all.
+       */
+      const failure = error as { status?: number; stdout?: string };
+      if (failure.status !== 1) throw error;
+      offenders = (failure.stdout ?? '').trim();
+    }
+
+    expect(offenders).toBe('');
   });
 });
 

--- a/src/pages/Accounts.tsx
+++ b/src/pages/Accounts.tsx
@@ -1600,7 +1600,27 @@ export default function Accounts() {
       // directly on white below, and the 24px between one band and the next is
       // the `gap-6` of the grid this returns into. One border and one shadow
       // fewer per group.
-      <div key={`${group.kind}:${group.label}`}>
+      //
+      // ─ `min-w-0`: WITHOUT IT A LONG ACCOUNT NAME DRAGS THE PAGE SIDEWAYS ──
+      // A band is an item of the `grid gap-6` that lists them, and a grid item
+      // defaults to `min-width: auto` — it may not shrink below its own
+      // MIN-CONTENT. The name link already says `max-w-full truncate` and every
+      // box between it and here already says `min-w-0`, so the truncation was
+      // specified correctly the whole way down and simply never got the chance:
+      // the band refused to be narrower than its widest descendant, so there
+      // was nothing for the name to truncate against.
+      //
+      // Measured at 390px with a name the length of the owner's real ones
+      // ("Mortgage - Corporation Avenue, Llanelli"): the grid track was 358px,
+      // the band took 426, and the document scrolled sideways by 54 — which is
+      // why his row actions sat off the right edge with only the settings cog
+      // reachable. Demo data never showed it, because "Main Checking" fits.
+      //
+      // The odd empty strips he saw at the top and bottom are the same defect
+      // from the other side: once the document is wider than the window,
+      // scrolling right reveals background beside chrome that was only ever as
+      // wide as the viewport.
+      <div key={`${group.kind}:${group.label}`} className="min-w-0">
         <button
           type="button"
           onClick={() => toggleGroupCollapsed(collapseKeyFor(group.kind, group.label))}

--- a/src/pages/Reconciliation.tsx
+++ b/src/pages/Reconciliation.tsx
@@ -22,6 +22,7 @@ import { todayIsoDay } from '../utils/statementBankBalance';
 import { toDecimal } from '../utils/decimal';
 import type { Transaction } from '../types';
 import { preferences } from '../services/preferencesService';
+import { STICKY_UNDER_APP_BAR } from '../components/layout/chromeOffsets';
 
 /**
  * Does this account still want work?
@@ -646,8 +647,31 @@ export default function Reconciliation() {
           cleared balance approach the bank's figure, so the numbers — and the
           way out, Finalize — must never scroll away. The negative margins
           bleed the strip across the page gutters so passing rows (and their
-          shadows) never peek out at the sides. */}
-      <div className="sticky top-16 md:top-12 z-30 bg-[#f8f9fb] dark:bg-gray-900 -mx-4 px-4 md:-mx-6 md:px-6 lg:-mx-8 lg:px-8 pb-2 flex flex-col gap-4">
+          shadows) never peek out at the sides.
+
+          ─ THE OFFSET IS A CONSTANT, NOT TWO NUMBERS ────────────────────────
+          This read `top-16 md:top-12` until 2026-08-14, and those literals are
+          the bar HEIGHTS with everything above them left out. Measured while
+          building the equivalent on the accounts page (#276), all three ways
+          they are wrong:
+
+            · the demo banner is not counted, so in demo mode this strip parked
+              BEHIND the fixed app nav — the nav is itself pushed down by
+              `var(--wt-demo-banner-height)` and this was not;
+            · `env(safe-area-inset-top)` is not counted, which is non-zero on an
+              installed home-screen app — where the owner actually runs this;
+            · and `top-16` is 64px for a mobile header that measures 76, because
+              that header is `p-4` around its content rather than a fixed height.
+
+          `STICKY_UNDER_APP_BAR` adds up whatever those three are at the moment
+          it is read. Imported from `layout/chromeOffsets`, which is a LEAF
+          module — importing the same constant from `Layout` closes a cycle
+          (Layout renders the router's Outlet) and throws `ReferenceError` at
+          runtime, with lint and strict TypeScript both passing on it. */}
+      <div
+        className="sticky z-30 bg-[#f8f9fb] dark:bg-gray-900 -mx-4 px-4 md:-mx-6 md:px-6 lg:-mx-8 lg:px-8 pb-2 flex flex-col gap-4"
+        style={{ top: STICKY_UNDER_APP_BAR }}
+      >
         {/* Header */}
         <div className="flex flex-wrap items-center justify-between gap-3">
           <div className="flex items-center gap-3 min-w-0">

--- a/src/pages/__tests__/Accounts.toReview.test.tsx
+++ b/src/pages/__tests__/Accounts.toReview.test.tsx
@@ -167,8 +167,22 @@ describe('Accounts list — the To Review column', () => {
     renderAccounts();
     await screen.findByRole('heading', { level: 3, name: 'Synthetic Natwest' });
 
-    const waiting = within(card('Synthetic Natwest')).getByText('To Review').nextElementSibling;
-    const clear = within(card('Synthetic Monzo')).getByText('To Review').nextElementSibling;
+    /*
+     * `.firstElementChild` because the figure now sits inside a fixed-height
+     * LINE BOX rather than being the label's immediate sibling — see
+     * CELL_FIGURE_LINE_CLASS in AccountRowColumns, which exists so that a cell
+     * showing a 24px disc stays level with cells showing 20px text.
+     *
+     * Worth stepping into rather than loosening: `clear` below asserts what the
+     * class does NOT contain, and a bare wrapper satisfies that trivially. Left
+     * pointing at the wrapper, half of this test would have gone on passing
+     * while measuring nothing at all.
+     */
+    const figure = (name: string): Element | null | undefined =>
+      within(card(name)).getByText('To Review').nextElementSibling?.firstElementChild;
+
+    const waiting = figure('Synthetic Natwest');
+    const clear = figure('Synthetic Monzo');
     /*
      * The working state was `text-slate-600` at the same size and weight as the
      * zero until 2026-08-13, when the owner reported the consequence: "I miss


### PR DESCRIPTION
Four faults — three of them mine from earlier today — all found by measuring rather than reading.

## The page scrolled sideways in portrait

> "In portrait mode … you would not want that in an official iOS app? You would want it so it just scrolls down."

A band is an item of the `grid gap-6` that lists them, and **a grid item defaults to `min-width: auto`** — it may not shrink below its own min-content. The account name already said `max-w-full truncate` and every box between them already said `min-w-0`, so the truncation was specified correctly the whole way down and simply never got the chance: the band refused to be narrower than its widest descendant, so the name had nothing to truncate *against*.

Measured at 390px with a name the length of the real ones: grid track 358px, band 426px, document scrolling sideways by 54 — which is exactly why the row actions sat off the right edge with only the settings cog reachable. Demo data never showed it, because "Main Checking" fits and "Mortgage - Corporation Avenue, Llanelli" does not.

One `min-w-0` on the band. At 320px with a 52-character name: overflow 0, all three action buttons on screen, name truncating. **No second row of buttons was needed after all** — the offer is noted but unspent.

The odd empty strips at the top and bottom of the screenshots are the same defect from the other side: once the document is wider than the window, scrolling right reveals background beside chrome that was only ever viewport-wide.

## Landscape handed a phone the desktop table

The row grid's tracks are fixed, so it cannot be squeezed — only overflow. It began at `sm` (640px), and a phone on its side is 844px, so landscape got the desktop table: rows wanted 915px against 844, scrolling sideways by 95.

It now begins at `lg` (1024px), the first width where it genuinely fits, and everything that dresses it moves with it — per-row labels, the column strip, the balance cell's small-screen twin, the spacer cells — because a grid at one breakpoint and its captions at another gives a row both or neither.

## The count was an oval, and sat above its neighbours

Mine, from making the counts clickable. `index.css` floors every `a` at 44×44 inside `@media (hover: none) and (pointer: coarse)` — right for a control, ruinous for a 20px figure, and invisible on any desktop because that query never matches one. The disc came out **31×44**, and its inflated cell lifted "Unreconciled" **12px** above "Bank Bal" and "To Review".

- `min-h-0 min-w-0` refuses the floor — **both** axes, because undoing only the height left `min-width` overriding a `w-6`, giving a 44×24 lozenge instead.
- The thumb gets its 44px back from `touch-target-small`, the app's own opt-in for precisely this, replacing a hand-rolled inset I wrote before noticing index.css already had the idiom.
- The levelling is the second option offered — "increase the default height of everything else on the same row" — because it cannot come undone by the next cell that learns a state with a different height.
- Under 100 the disc is a fixed 24×24 circle; beyond that a lozenge, because 130 does not fit in 24px.

## And Reconciliation's parked toolbar

`top-16 md:top-12` there too, wrong the same three ways. Now `STICKY_UNDER_APP_BAR`: parks flush under the app bar (gap 0) at both 1280×700 and 390×760, where it previously sat 68px too high on a phone. A guard now fails if a third page writes those literals into a `className` — scoped to `className` after a first attempt flagged six hits that were all prose explaining the bug.

## Verification

| Check | Result |
| --- | --- |
| Portrait 320 / 390, 52-char name | overflow 0, 3/3 buttons on screen, name truncates |
| Landscape 844 | overflow 0 (was 95) |
| Desktop 1280 | strip alignment exactly 0 on all four columns |
| Count pill | 24×24 circle, labels level to the pixel |
| Reconciliation | gap 0 under the app bar at both widths |
| Tests | 6170 pass |

One measurement worth recording: a −4px strip misalignment I chased for several rounds turned out to be a stale hot-reload artifact — it vanished on a clean load and never existed in the built page. Worth chasing to ground rather than "fixing" with a magic 4px.

⚠️ **Not fixed, and deliberately separate:** at 844px the desktop **nav's** search box overlaps Reports, Manage and Settings (measured: search starts at 440, those span 412–655). Nav chrome is keyed to `md`, and moving it to `lg` would change what tablets get — that's a call to make explicitly, not silently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)