### PR TITLE
A linked cash account is filed where its investment lives

### DIFF
--- a/src/components/common/AccountSelector.test.tsx
+++ b/src/components/common/AccountSelector.test.tsx
@@ -16,6 +16,7 @@ interface TestAccount {
   institution?: string;
   sortCode?: string;
   balance?: number;
+  parentAccountId?: string | null;
 }
 
 const PLACEHOLDER = 'Search or select account…';
@@ -483,5 +484,88 @@ describe('AccountSelector', () => {
 
       expect(container.contains(screen.getByRole('listbox'))).toBe(true);
     });
+  });
+});
+
+/**
+ * ─ A LINKED CASH SLEEVE IS FILED WHERE ITS INVESTMENT LIVES ────────────────
+ *
+ * Reported from the transfer picker: "(Beards) - Wiseville Investments" and
+ * "Coutts - Investment P…" are the cash sleeves of investment accounts, and
+ * both were listed under CURRENT ACCOUNTS — while the Accounts page shows them
+ * nested inside their investment parent.
+ *
+ * The owner's rule is the page's own behaviour written down: "linked, it sits
+ * within the investment account it is linked to; unlink, and it moves up to
+ * current accounts." This file's header already promised that this picker "and
+ * that page can never disagree about where an account belongs" — so this is
+ * that promise being kept, not a new idea.
+ */
+describe('a cash account linked to an investment', () => {
+  const sleeve: TestAccount = {
+    id: 'cash-linked',
+    name: 'Wiseville Cash',
+    type: 'current',
+    institution: 'Beards',
+    parentAccountId: 'inv1',
+  };
+  const investment: TestAccount = {
+    id: 'inv1',
+    name: 'Wiseville Investments',
+    type: 'investment',
+    institution: 'Beards',
+  };
+  const loose: TestAccount = {
+    id: 'cash-loose',
+    name: 'Wiseville Spare Cash',
+    type: 'current',
+    institution: 'Beards',
+  };
+
+  const pickerFor = (list: TestAccount[], onAccountChange = vi.fn()) => {
+    render(
+      <AccountSelector
+        accounts={list}
+        selectedAccountId=""
+        onAccountChange={onAccountChange}
+        placeholder={PLACEHOLDER}
+        formatLabel={(account) => `${account.name} (${account.type})`}
+      />
+    );
+    open();
+    return onAccountChange;
+  };
+
+  it('files the sleeve under Investments, leaving no Current Accounts section', () => {
+    /*
+     * The sharp version of the rule: the ONLY `type: current` account here is
+     * the sleeve, so if it is filed correctly there is no current-accounts
+     * section left to draw. Asserting the absence is what makes this fail on
+     * the old behaviour rather than merely on a reordering.
+     */
+    pickerFor([sleeve, investment]);
+
+    expect(headings()).not.toContain('Current Accounts');
+    expect(headings()).toContain('Investments');
+    expect(screen.getByText('Wiseville Cash (current)')).toBeInTheDocument();
+  });
+
+  it('keeps its own name and type on the row, and reports its own id', () => {
+    // Sectioning borrows the parent's type; the OPTION stays the real account,
+    // or the picker would hand back an investment where cash was chosen.
+    const onAccountChange = pickerFor([sleeve, investment]);
+    fireEvent.click(screen.getByText('Wiseville Cash (current)'));
+
+    expect(onAccountChange).toHaveBeenCalledWith('cash-linked');
+  });
+
+  it('leaves an UNLINKED cash account under Current Accounts', () => {
+    // The rule keys on the LINK, not on the name or the institution — which
+    // this sibling shares with the sleeve, and is why it is the useful control.
+    pickerFor([sleeve, investment, loose]);
+
+    expect(headings()).toContain('Current Accounts');
+    expect(headings()).toContain('Investments');
+    expect(screen.getByText('Wiseville Spare Cash (current)')).toBeInTheDocument();
   });
 });

--- a/src/components/common/AccountSelector.tsx
+++ b/src/components/common/AccountSelector.tsx
@@ -7,6 +7,7 @@ import {
   NO_INSTITUTION_TITLE,
   type GroupableAccount,
 } from '../../utils/accountGrouping';
+import { buildTopLevelIdByAccountId } from '../../utils/accountNesting';
 import { ChevronDownIcon, PlusIcon } from '../icons';
 import FitLabel from './FitLabel';
 
@@ -24,9 +25,15 @@ import FitLabel from './FitLabel';
  * that page can never disagree about where an account belongs.
  */
 
-/** What an option needs: an id to report, plus what groups and finds it. */
+/**
+ * What an option needs: an id to report, plus what groups and finds it.
+ *
+ * `parentAccountId` is optional and most callers never set it — but where it IS
+ * set it decides which SECTION the option lands in. See the `sections` memo.
+ */
 export interface SelectableAccount extends GroupableAccount {
   id: string;
+  parentAccountId?: string | null;
 }
 
 /** Fixed-position coordinates for the portaled dropdown (usePortal mode). */
@@ -221,7 +228,64 @@ export default function AccountSelector<T extends SelectableAccount>({
     const pool = accounts.filter(
       account => !excluded.has(account.id) && accountMatchesQuery(account, searchTerm)
     );
-    const grouped = groupAccountsForDisplay(pool, NESTED_BANDS);
+    /*
+     * A LINKED CASH ACCOUNT IS FILED WHERE ITS INVESTMENT LIVES, not where its
+     * own type would put it.
+     *
+     * Reported from the transfer picker: "(Beards) - Wiseville Investments" and
+     * "Coutts - Investment P…" are the cash sleeves of investment accounts, and
+     * both were listed under CURRENT ACCOUNTS — while the Accounts page shows
+     * them nested inside their investment parent. The owner's rule, which is
+     * simply the page's own behaviour written down: "linked, it sits within the
+     * investment account it is linked to; unlink, and it moves up to current
+     * accounts."
+     *
+     * The header of this file already promised that this picker "and that page
+     * can never disagree about where an account belongs". They did disagree,
+     * because the page groups only TOP-LEVEL accounts and renders children
+     * inside their parent's row, while this list handed every account to the
+     * grouper on its own terms — so a cash sleeve was sectioned by `type:
+     * 'current'` rather than by the investment it belongs to.
+     *
+     * Sectioning is therefore done with the ANCESTOR's type and institution,
+     * and only the sectioning: the option that gets rendered, searched, and
+     * reported is the real account, so its own name and type still show. The
+     * ancestor is resolved against the FULL account list rather than the
+     * filtered pool, because a search that matches the child but not its parent
+     * must still file the child correctly.
+     */
+    const topLevelIdByAccountId = buildTopLevelIdByAccountId(accounts);
+    const byId = new Map(accounts.map(account => [account.id, account]));
+    const forGrouping = pool.map(account => {
+      const topLevelId = topLevelIdByAccountId.get(account.id);
+      const ancestor = topLevelId !== undefined && topLevelId !== account.id
+        ? byId.get(topLevelId)
+        : undefined;
+      return {
+        // Everything the grouper reads, taken from the ancestor when there is
+        // one; everything the LIST reads comes off `source` below.
+        name: account.name,
+        type: ancestor?.type ?? account.type,
+        institution: ancestor?.institution ?? account.institution,
+        sortCode: account.sortCode,
+        source: account,
+      };
+    });
+
+    const groupedProxies = groupAccountsForDisplay(forGrouping, NESTED_BANDS);
+    const grouped = groupedProxies.mode === 'grouped'
+      ? {
+          mode: 'grouped' as const,
+          groups: groupedProxies.groups.map(group => ({
+            ...group,
+            accounts: group.accounts.map(proxy => proxy.source),
+            subGroups: group.subGroups?.map(sub => ({
+              ...sub,
+              accounts: sub.accounts.map(proxy => proxy.source),
+            })),
+          })),
+        }
+      : { mode: 'flat' as const, accounts: groupedProxies.accounts.map(proxy => proxy.source) };
     // byType is on, so grouping is always banded; [] is the honest floor.
     const groups = grouped.mode === 'grouped' ? grouped.groups : [];
     return groups.map(group => {


### PR DESCRIPTION
From the transfer picker: "(Beards) - Wiseville Investments" and "Coutts - Investment P…" are the cash sleeves of investment accounts, and both were listed under **Current Accounts** — while the Accounts page shows them nested inside their investment parent.

The rule is that page's own behaviour written down: *linked, it sits within the investment account it is linked to; unlink, and it moves up to current accounts.*

`AccountSelector`'s header already promised that this picker "and that page can never disagree about where an account belongs". They disagreed because the page groups only **top-level** accounts and renders children inside their parent's row, while this list handed every account to the grouper on its own terms — so a cash sleeve was sectioned by `type: 'current'` rather than by the investment it belongs to.

Sectioning now uses the **ancestor's** type and institution, resolved with `buildTopLevelIdByAccountId` — the same helper the page nests with. Only the sectioning: the option rendered, searched and reported is still the real account, so its own name and type show, and choosing it still reports its own id.

`SelectableAccount` gained an optional `parentAccountId`; call sites pass whole `Account` objects, which already carry it. This fixes every picker at once — transfers, bulk edit, import rules.

## Guards

- The sleeve is filed under Investments with **no Current Accounts section left to draw** — the sharp form, so it fails on the old behaviour rather than merely on a reordering.
- The row keeps its own name and type, and reports its own id.
- An unlinked sibling sharing the same name *and* institution stays under Current Accounts — the rule keys on the link, not on either of those.

Proven non-vacuous by reverting the ancestor lookup: the first guard fails, the rest hold.

6173 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
