### PR TITLE
The account name lines up with its balance, and the row stops repeating its band

### DIFF
--- a/src/components/AccountRowColumns.tsx
+++ b/src/components/AccountRowColumns.tsx
@@ -176,7 +176,21 @@ export const ACCOUNT_ROW_SELECTED_CLASS =
  * like the full width of the row.
  */
 export const ACCOUNT_ROW_NAME_LINK_CLASS =
-  'block w-fit max-w-full truncate rounded transition-colors ' +
+  // ─ `min-h-0 touch-target-small`: THE NAME SAT HIGHER THAN ITS OWN BALANCE ──
+  // The same trap as the count pill, two rows down. `index.css` floors every
+  // `a` at 44px tall on a touch device, so this link's box was 44 while the
+  // balance beside it was 24 — and the row centres both, which put the two
+  // texts 10px apart. Measured at 390px before the fix: link 708→752, balance
+  // 718→742. The owner: "the account name sits higher than the amount on the
+  // right hand side."
+  //
+  // `min-h-0` gives the box back its own height so the two line up; the thumb
+  // keeps its 44px through `touch-target-small`, the app's own opt-in, which
+  // spends no layout to do it. `font-semibold` because he asked for both to be
+  // bold — the name and the figure are one statement, and the name was the
+  // quieter half at 500 against the balance's 600.
+  'block w-fit max-w-full truncate rounded transition-colors font-semibold ' +
+  'min-h-0 touch-target-small ' +
   'hover:text-blue-600 dark:hover:text-blue-400 hover:underline';
 
 /** The column heading over a figure — small, quiet, and the same for every row. */

--- a/src/pages/Accounts.tsx
+++ b/src/pages/Accounts.tsx
@@ -25,7 +25,7 @@ import { preferences } from '../services/preferencesService';
 // Bank connection management lives on this page (the natural home for it);
 // the Data Management page keeps only its URL-driven deep links for ops alerts.
 import type { Account } from '../types';
-import { ALL_ACCOUNT_SECTIONS, sectionTypeForAccount } from '../utils/accountSections';
+import { ALL_ACCOUNT_SECTIONS } from '../utils/accountSections';
 import {
   groupAccountsForDisplay,
   parseAccountGroupingPreference,
@@ -637,17 +637,6 @@ export default function Accounts() {
     return sorted;
   }, [sortMode, computeAccountBalance]);
 
-  // Get icon for account type
-  const getAccountTypeIcon = (type: string) => {
-    const typeConfig = accountTypes.find(t => t.type === sectionTypeForAccount(type));
-    return typeConfig?.icon || WalletIcon;
-  };
-
-  const getAccountTypeColor = (type: string) => {
-    const typeConfig = accountTypes.find(t => t.type === sectionTypeForAccount(type));
-    return typeConfig?.color || 'text-gray-600';
-  };
-
   const handleClose = (accountId: string) => {
     if (window.confirm('Close this account? It moves to the Closed Accounts section — every transaction is preserved and you can reopen it at any time. Its transfer category is hidden from transaction dropdowns while closed.')) {
       void (async () => {
@@ -1130,8 +1119,11 @@ export default function Accounts() {
   const renderAccountCard = (account: Account) => {
     const bankLink = getAccountLink(account.id);
     const syncing = isAccountSyncing(account.id);
-    const TypeIcon = getAccountTypeIcon(account.type);
-    const typeColor = getAccountTypeColor(account.type);
+    // No TypeIcon/typeColor here any more — the row stopped drawing a per-account
+    // type glyph (see the name row below). The two helpers that fed them went
+    // with it: the BAND headings have always drawn their own icon through
+    // `bandHeadingIcon`, so nothing else was reading them. Lint is what caught
+    // the first version of this comment claiming otherwise.
     // '' when the date is absent or unparseable — formatDate answers that way
     // rather than throwing or handing back "Invalid Date".
     const lastUpdated = formatDate(account.lastUpdated);
@@ -1179,8 +1171,22 @@ export default function Accounts() {
                   >
                     <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3">
                       <div className="flex-1 min-w-0">
+                        {/* NO TYPE ICON ON THE ROW. Every account carried a
+                            16px glyph saying what KIND it is — and it sat
+                            inside a band already headed "Current Accounts",
+                            with its own icon, above rows that are all that
+                            kind. It repeated the heading once per row and
+                            bought nothing: the owner, "do we need the icons
+                            next to every account name? I think we dont, and it
+                            is just used up space especially with the limited
+                            real estate we have on mobile."
+
+                            The band headings keep theirs, which is where the
+                            distinction is actually being drawn — one icon per
+                            KIND rather than one per row. Worth ~24px of a
+                            phone's width back on every line, on the page whose
+                            names were overflowing it. */}
                         <div className="flex items-center gap-2">
-                          <TypeIcon className={typeColor} size={16} />
                           {/* The name is the way IN — a real link, so it can be
                               opened in a new tab, followed from the keyboard,
                               or copied as an address. The rest of the row means
@@ -1690,9 +1696,25 @@ export default function Accounts() {
                       role="group"
                       aria-label={`${sub.title}, ${countLabel}, total ${subTotal.spoken}`}
                     >
-                      {/* The same treatment as the band above it, one step
-                          quieter: a line, not a pill with a border of its own. */}
-                      <div className="flex items-center justify-between gap-2 border-b border-line dark:border-gray-700 bg-surface-secondary/60 dark:bg-gray-700/30 px-4 sm:px-6 py-1.5">
+                      {/* ONE INSTITUTION HAS TO END BEFORE THE NEXT BEGINS.
+                          This was a single hairline UNDER the name with a 60%
+                          wash behind it — enough to head a list, not enough to
+                          close one. Scrolling nine Coutts accounts into seven
+                          AMEX ones, the join read as another row: "the
+                          separation between institutions needs to be more
+                          visible, both on desktop but certainly on mobile."
+
+                          Three changes, all of them separation rather than
+                          decoration: a rule ABOVE as well as below (the one
+                          that actually ends the previous institution), space
+                          before it so the gap does the first half of the work,
+                          and a solid wash instead of 60% so the strip reads as
+                          a band rather than a tinted row.
+
+                          `first:` resets all three: the opening institution in
+                          a band sits directly under that band's own heading and
+                          has nothing above it to be separated from. */}
+                      <div className="flex items-center justify-between gap-2 mt-4 first:mt-0 border-t-2 first:border-t-0 border-b border-line dark:border-gray-700 bg-surface-secondary dark:bg-gray-700/50 px-4 sm:px-6 py-2">
                         <p className="text-body uppercase font-bold tracking-wide text-gray-900 dark:text-white truncate">
                           {sub.title}
                           <span className="ml-2 font-normal normal-case tracking-normal text-gray-400 dark:text-gray-500">


### PR DESCRIPTION
Four asks from a phone — one of which turned out to be the oval-count bug wearing a different hat.

## The name sat higher than the amount

> "The account name sits higher than the amount on the right hand side."

Same cause as the count pill: the name is an `<a>`, and `index.css` floors every link at **44px tall** inside `@media (hover: none) and (pointer: coarse)`. So the name's box was 44 and the balance's 24; the row centres both, leaving the two texts 10px apart.

Measured at 390px — before: name 708→752, balance 718→742. After: both 724→748, gap **0**.

`min-h-0` gives the box its own height back; the thumb keeps 44px through `touch-target-small`, which spends no layout. That is now the *third* element this media block has quietly inflated — worth suspecting first for anything misaligned only on a phone.

## Both are bold now

The name was `font-medium` (500) against the balance's 600, so the figure won a contest the pair should not have been having. Both 600 — they are one statement.

## The row stopped repeating its own band

Every account carried a 16px type glyph, inside a band already headed "Current Accounts" *with its own icon*, above rows that are all that kind.

> "Do we need the icons next to every account name? I think we dont, and it is just used up space especially with the limited real estate we have on mobile."

Quite so — and it returns ~24px of width per line on the page whose names were overflowing it. Band headings keep theirs, which is where the distinction is actually drawn. `getAccountTypeIcon` and `getAccountTypeColor` went with it; nothing else read them, because band headings have always used `bandHeadingIcon`. Lint caught my first version of that comment claiming otherwise.

## One institution now ends before the next begins

A single hairline under the name with a 60% wash is enough to *head* a list and not enough to *close* one, so nine Coutts accounts running into seven AMEX ones read as one more row. Now a rule above as well as below, space before it, and a solid wash — with `first:` resetting all three, since the opening institution sits under its band's own heading and has nothing to be separated from.

⚠️ **The separator itself is not visually verified.** Every institution in the demo data is the first in its band, so only the `first:` reset is exercised. The classes, the reset, the padding and the background were all measured; a band holding two institutions was not available to look at.

6173 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
