### PR TITLE
Bank connections goes amber when a feed has stopped

### DIFF
--- a/src/desktop/editions/service.ts
+++ b/src/desktop/editions/service.ts
@@ -152,6 +152,9 @@ export const useAccountBankSync: UseServiceBankSync = () => ({
   syncAccount: () => Promise.resolve(),
   syncAllConnections: () => Promise.resolve(),
   connectedCount: 0,
+  // No connections at all, so none of them can be broken — the Accounts page's
+  // own guard reads this as "nothing to warn about" and the button stays quiet.
+  feedsNeedingAttention: 0,
   isSyncingAny: false,
   reloadConnections: () => Promise.resolve()
 });

--- a/src/hooks/__tests__/useAccountBankSync.test.ts
+++ b/src/hooks/__tests__/useAccountBankSync.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { buildAccountBankLinks } from '../useAccountBankSync';
+import { buildAccountBankLinks, countFeedsNeedingAttention } from '../useAccountBankSync';
 import type { BankConnection } from '../../services/bankConnectionService';
 
 function makeConnection(overrides: Partial<BankConnection>): BankConnection {
@@ -63,5 +63,49 @@ describe('buildAccountBankLinks', () => {
       makeConnection({ id: 'conn-new', linkedAccountIds: ['acc-x'] })
     ]);
     expect(links.get('acc-x')?.connectionId).toBe('conn-new');
+  });
+});
+
+/**
+ * ─ WHICH FEEDS COUNT AS BROKEN ─────────────────────────────────────────────
+ *
+ * This number decides whether the Accounts page's "Bank connections" button
+ * goes amber. The owner asked for it after finding a dead link only by opening
+ * the bank-feeds page: "would it be possible to change the colour ... if any of
+ * my account links have an error?"
+ */
+describe('countFeedsNeedingAttention', () => {
+  it('counts an outright error', () => {
+    expect(countFeedsNeedingAttention([makeConnection({ status: 'error' })])).toBe(1);
+  });
+
+  it('counts an EXPIRED CONSENT too — the failure that looks like nothing', () => {
+    /*
+     * The one worth being deliberate about. `reauth_required` shows no error
+     * anywhere on the Accounts page: the feed simply stops and the balances go
+     * quietly stale, which is indistinguishable from an account nobody has
+     * spent from. If anything deserves the amber it is this.
+     */
+    expect(countFeedsNeedingAttention([makeConnection({ status: 'reauth_required' })])).toBe(1);
+  });
+
+  it('does not count healthy connections', () => {
+    expect(countFeedsNeedingAttention([
+      makeConnection({ id: 'a', status: 'connected' }),
+      makeConnection({ id: 'b', status: 'connected' }),
+    ])).toBe(0);
+  });
+
+  it('counts each broken connection once, and ignores the healthy ones beside them', () => {
+    // The owner's own shape: one dead Revolut among two working banks.
+    expect(countFeedsNeedingAttention([
+      makeConnection({ id: 'revolut', status: 'error' }),
+      makeConnection({ id: 'amex', status: 'connected' }),
+      makeConnection({ id: 'hsbc', status: 'connected' }),
+    ])).toBe(1);
+  });
+
+  it('is 0 for no connections at all, which is the desktop edition', () => {
+    expect(countFeedsNeedingAttention([])).toBe(0);
   });
 });

--- a/src/hooks/accountBankLinks.ts
+++ b/src/hooks/accountBankLinks.ts
@@ -34,10 +34,37 @@ export interface UseAccountBankSyncResult {
   syncAllConnections: () => Promise<void>;
   /** How many connections a refresh-all would touch. */
   connectedCount: number;
+  /**
+   * How many connections have STOPPED and need the user to act — `error` or
+   * `reauth_required`. Both count: from outside they are one event, the money
+   * stopped arriving, and the expired-consent case is the more dangerous
+   * because nothing looks broken, the balances just go stale.
+   */
+  feedsNeedingAttention: number;
   /** True while any connection is mid-sync. */
   isSyncingAny: boolean;
   /** Re-fetch connection metadata (last sync, status) without triggering a sync. */
   reloadConnections: () => Promise<void>;
+}
+
+/**
+ * How many connections have STOPPED and need the user to act.
+ *
+ * BOTH failing statuses count, because from outside they are one event: the
+ * money stopped arriving. `error` is the bank refusing or failing;
+ * `reauth_required` is a consent that has expired — the quieter and more
+ * dangerous of the two, because nothing looks broken, the balances simply go
+ * stale, and a stale account is indistinguishable from one nobody has spent
+ * from.
+ *
+ * Pure, and here rather than inside the hook, for the same reason
+ * `buildAccountBankLinks` is: it is the part worth testing without mounting
+ * anything.
+ */
+export function countFeedsNeedingAttention(connections: readonly BankConnection[]): number {
+  return connections.filter(
+    (connection) => connection.status === 'error' || connection.status === 'reauth_required'
+  ).length;
 }
 
 /**

--- a/src/hooks/useAccountBankSync.ts
+++ b/src/hooks/useAccountBankSync.ts
@@ -20,10 +20,10 @@ import { createScopedLogger } from '../loggers/scopedLogger';
 // put `@clerk/clerk-react` in front of the Dashboard and the register in a
 // desktop build.
 export type { AccountBankLink, UseAccountBankSyncResult } from './accountBankLinks';
-export { buildAccountBankLinks } from './accountBankLinks';
+export { buildAccountBankLinks, countFeedsNeedingAttention } from './accountBankLinks';
 
 // …and imported for this module's own use, because a re-export is not a binding.
-import { buildAccountBankLinks } from './accountBankLinks';
+import { buildAccountBankLinks, countFeedsNeedingAttention } from './accountBankLinks';
 import type { UseAccountBankSyncResult } from './accountBankLinks';
 
 const logger = createScopedLogger('useAccountBankSync');
@@ -205,12 +205,27 @@ export function useAccountBankSync(options?: { onSynced?: () => void | Promise<v
     [connections]
   );
 
+  /**
+   * Feeds that have stopped and need the user to do something about it.
+   *
+   * BOTH failing statuses count, because from the outside they are the same
+   * event: the money stopped arriving. `error` is the bank refusing or failing;
+   * `reauth_required` is a consent that has expired — the quieter and more
+   * dangerous of the two, since nothing looks broken, the balances simply go
+   * stale. A count rather than a boolean so the caller can say how many.
+   */
+  const feedsNeedingAttention = useMemo(
+    () => countFeedsNeedingAttention(connections),
+    [connections]
+  );
+
   return {
     getAccountLink,
     isAccountSyncing,
     syncAccount,
     syncAllConnections,
     connectedCount,
+    feedsNeedingAttention,
     isSyncingAny: syncingConnectionIds.size > 0,
     reloadConnections,
   };

--- a/src/pages/Accounts.tsx
+++ b/src/pages/Accounts.tsx
@@ -350,7 +350,7 @@ export default function Accounts() {
     [seededBalances, computeLedgerBalance]
   );
   // Per-account bank connection metadata + one-click "pull fresh bank data".
-  const { getAccountLink, isAccountSyncing, syncAccount, syncAllConnections, connectedCount, isSyncingAny } = useAccountBankSync({ onSynced: refreshAccountsAndTransactions });
+  const { getAccountLink, isAccountSyncing, syncAccount, syncAllConnections, connectedCount, feedsNeedingAttention, isSyncingAny } = useAccountBankSync({ onSynced: refreshAccountsAndTransactions });
 
   // Only OPEN accounts appear in the main list and totals; closed ones live in
   // the Closed Accounts section below (the Microsoft Money model — closing
@@ -2204,12 +2204,44 @@ export default function Accounts() {
                 And "Bank Connections" was Title Case standing next to "Refresh
                 feeds" in sentence case — two spellings of one convention, 8px
                 apart. */}
+            {/* ─ AND IT TURNS AMBER WHEN A FEED HAS STOPPED ──────────────────
+                "Would it be possible to change the colour of the 'Bank
+                Connections' button on the accounts page if any of my account
+                links have an error?"
+
+                Yes — and this is the yellow thread's own case rather than an
+                exception to it. Ruling A gives amber to the ONE control you
+                should touch next, which is why a COUNT was taken off it: a
+                count is not clickable and there can be eight of them. A broken
+                feed is the opposite on both counts. There is a single control
+                that fixes it, this is that control, and until it is pressed the
+                balances on this page are quietly going stale — the page cannot
+                say so anywhere else, because a stopped feed looks exactly like
+                an account nobody has spent from.
+
+                Colour is not the only carrier: the label changes too, so the
+                reason survives for anyone who cannot see the difference, and
+                the button says how many rather than merely that something is
+                wrong. `reauth_required` counts as broken — see
+                `feedsNeedingAttention` — because an expired consent is the
+                failure that looks like nothing at all.
+
+                The amber is `accessible-colors.ts`'s warning pair, not a hand
+                mixed one: amber-700 on amber-100 measures 5.5:1, amber-300 on
+                amber-900 10.7:1. Its neighbour Refresh feeds keeps the quiet
+                outline, so there is still exactly one loud control here. */}
             <button
               onClick={() => setBankConnectionsView('plain')}
-              className="w-full sm:w-auto justify-center px-3 py-1.5 text-sm font-medium rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors flex items-center gap-2"
+              className={`w-full sm:w-auto justify-center px-3 py-1.5 text-sm font-medium rounded-lg border transition-colors flex items-center gap-2 ${
+                feedsNeedingAttention > 0
+                  ? 'border-amber-400 bg-amber-100 text-amber-700 hover:bg-amber-200 dark:border-amber-500 dark:bg-amber-900 dark:text-amber-300 dark:hover:bg-amber-800'
+                  : 'border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700'
+              }`}
             >
               <BankIcon size={16} />
-              Bank connections
+              {feedsNeedingAttention > 0
+                ? `Bank connections — ${feedsNeedingAttention} need${feedsNeedingAttention === 1 ? 's' : ''} attention`
+                : 'Bank connections'}
             </button>
           </div>
         </div>


### PR DESCRIPTION
> "Would it be possible to change the colour of the 'Bank Connections' button on the accounts page if any of my account links have an error?"

Found only by opening the bank-feeds page and seeing a dead Revolut link sitting between two working banks. The button now goes amber and reads **"Bank connections — 1 needs attention"**.

## This is the yellow thread's own case, not an exception to it

Ruling A gives amber to the **one control you should touch next** — which is precisely why it was taken *off* the Unreconciled counts: a count is not clickable, and a list can show eight at once. A stopped feed is the opposite on both points. There is a single control that fixes it, this is that control, and until it is pressed the balances on this page are quietly going stale. Refresh feeds beside it keeps the quiet outline, so there is still exactly one loud thing on the page.

## `reauth_required` counts as broken, as well as `error`

The half worth being deliberate about. An expired consent shows nothing anywhere — the feed simply stops, and a stale account is indistinguishable from one nobody has spent from. Revolut at least says "Connection error"; an expired consent would have said nothing at all. If anything deserves the amber, it is the failure that looks like nothing.

*(If you'd rather it fired only on hard errors, that's a one-word change to the predicate.)*

## Details

- **Colour is not the only carrier.** The label states the reason and the number, so it survives for anyone who cannot see the difference.
- **The amber is `accessible-colors.ts`'s warning pair**, not hand-mixed: amber-700 on amber-100 is 5.5:1, amber-300 on amber-900 is 10.7:1.
- **The count is pure** — `countFeedsNeedingAttention` sits in `accountBankLinks.ts` beside `buildAccountBankLinks`, for that file's own stated reason: it is the part worth testing without mounting anything.
- **The desktop edition returns 0** (no connections exist there). The shared `UseAccountBankSyncResult` type is what forced that stub to keep step — TypeScript refused to build until it did.

## Guards

An error counts; an expired consent counts; healthy ones do not; one broken among two healthy counts once; none is 0.

Proven non-vacuous by dropping `reauth_required` from the predicate — **only** the expired-consent test fails, which is exactly the one that would otherwise have rotted silently.

6178 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
