### PR TITLE
Enter after typing picks the top match, in both pickers — and institutions fold

### DIFF
--- a/src/components/CategorySelector.test.tsx
+++ b/src/components/CategorySelector.test.tsx
@@ -166,6 +166,47 @@ describe('CategorySelector', () => {
       expect(onCategoryChange).toHaveBeenCalledWith('det-groceries');
     });
 
+    it('picks the TOP MATCH with Enter when the filter leaves several', () => {
+      /*
+       * The one that was silently broken, and the reason the owner's edits kept
+       * reverting to their suggested category.
+       *
+       * The highlight is reset to -1 on every change to `searchTerm`, so typing
+       * a filter always leaves nothing highlighted. Enter used to choose the
+       * highlighted option, or the only survivor when the filter left exactly
+       * one, and OTHERWISE NOTHING — with `preventDefault` swallowing the key,
+       * so the row looked as though it had taken a category it had not.
+       *
+       * Unreachable with a mouse, unavoidable with the keyboard: "the only
+       * difference this time to what I did before is I pressed next & save with
+       * the mouse and last time I was typing the category and then pressing
+       * enter > enter."
+       *
+       * A filter that leaves SEVERAL is the case this covers — one survivor
+       * already worked, which is exactly why the gap went unnoticed.
+       */
+      const { onCategoryChange } = renderOpen({ includeAllTypes: true });
+      const input = screen.getByPlaceholderText(PLACEHOLDER);
+
+      // A substring both options share, so the list keeps more than one.
+      fireEvent.change(input, { target: { value: 'o' } });
+      expect(screen.getAllByRole('option').length).toBeGreaterThan(1);
+
+      fireEvent.keyDown(input, { key: 'Enter' });
+      expect(onCategoryChange).toHaveBeenCalledTimes(1);
+    });
+
+    it('still does nothing on Enter with no search and nothing highlighted', () => {
+      // With no filter there is no "best match" to be top of — the list is
+      // simply every category, and quietly filing the first one would be worse
+      // than doing nothing.
+      const { onCategoryChange } = renderOpen({ includeAllTypes: true });
+      const input = screen.getByPlaceholderText(PLACEHOLDER);
+
+      fireEvent.keyDown(input, { key: 'Enter' });
+      expect(onCategoryChange).not.toHaveBeenCalled();
+    });
+
     it('closes with Escape and returns focus to the trigger', () => {
       renderOpen();
       const input = screen.getByPlaceholderText(PLACEHOLDER);

--- a/src/components/CategorySelector.tsx
+++ b/src/components/CategorySelector.tsx
@@ -547,8 +547,34 @@ export default function CategorySelector({
         break;
       case 'Enter': {
         e.preventDefault();
-        const chosen = flatOptions[highlightIndex] ??
-          (flatOptions.length === 1 ? flatOptions[0] : undefined);
+        /*
+         * ─ ENTER AFTER TYPING CHOOSES THE TOP MATCH ────────────────────────
+         *
+         * It used to choose the highlighted option, or the only option if the
+         * filter had left exactly one, and OTHERWISE NOTHING AT ALL — while
+         * `preventDefault` above swallowed the keystroke, so the row looked as
+         * though it had accepted a category it had not.
+         *
+         * That is unreachable with a mouse and unavoidable with the keyboard,
+         * because the highlight is reset to -1 on every change to `searchTerm`
+         * (see the effect beside it: "any change to the option list invalidates
+         * the highlight"). So typing a filter ALWAYS left nothing highlighted,
+         * and unless the text happened to narrow the list to one, Enter was a
+         * key that did nothing and said nothing.
+         *
+         * The owner found the difference by doing the same edit twice: "the
+         * only difference this time to what I did before is I pressed next &
+         * save with the mouse and last time I was typing the category and then
+         * pressing enter > enter."
+         *
+         * With a search term the first option is the best match by the list's
+         * own ordering, so it is what Enter means. With NO search term there is
+         * no match to be top of — the list is simply every category — and
+         * silently filing the alphabetically-first one would be worse than
+         * doing nothing, so the old behaviour stands there.
+         */
+        const chosen = flatOptions[highlightIndex]
+          ?? (searchTerm.trim() !== '' || flatOptions.length === 1 ? flatOptions[0] : undefined);
         if (chosen) handleCategorySelect(chosen.id);
         break;
       }

--- a/src/components/common/AccountSelector.test.tsx
+++ b/src/components/common/AccountSelector.test.tsx
@@ -569,3 +569,51 @@ describe('a cash account linked to an investment', () => {
     expect(screen.getByText('Wiseville Spare Cash (current)')).toBeInTheDocument();
   });
 });
+
+/**
+ * ─ THE SAME KEYBOARD GAP CategorySelector HAD ──────────────────────────────
+ *
+ * Both pickers chose nothing when a filter left SEVERAL matches and nothing was
+ * highlighted — which is always the case after typing, because the highlight is
+ * reset on every change to the option list. `preventDefault` swallowed the key,
+ * so the control looked as though it had accepted something.
+ *
+ * Found in CategorySelector, fixed in both after the owner asked the right
+ * question: "if this is a problem in a few areas will it be fixed in all?"
+ */
+describe('Enter after typing', () => {
+  it('picks the top match when the filter leaves several', () => {
+    const { onAccountChange } = renderPicker();
+    open();
+    const search = screen.getByPlaceholderText(PLACEHOLDER);
+
+    // 'Natwest' matches the current account, the savings account and the ISA.
+    fireEvent.change(search, { target: { value: 'nat' } });
+    expect(screen.getAllByRole('option').length).toBeGreaterThan(1);
+
+    fireEvent.keyDown(search, { key: 'Enter' });
+    expect(onAccountChange).toHaveBeenCalledTimes(1);
+  });
+
+  it('does nothing on Enter with no search and nothing highlighted', () => {
+    // No filter means no "best match" — the list is simply every account, and
+    // quietly choosing the first would be worse than doing nothing.
+    const { onAccountChange } = renderPicker();
+    open();
+    fireEvent.keyDown(screen.getByPlaceholderText(PLACEHOLDER), { key: 'Enter' });
+    expect(onAccountChange).not.toHaveBeenCalled();
+  });
+
+  it('never lets a filtered Enter fall on the clear row', () => {
+    // The clear row is pinned FIRST, so "top match" has to mean top matching
+    // ACCOUNT or a search would file "no account" the moment it narrowed.
+    const { onAccountChange } = renderPicker({ clearOption: 'Keep in current account' });
+    open();
+    const search = screen.getByPlaceholderText(PLACEHOLDER);
+    fireEvent.change(search, { target: { value: 'nat' } });
+    fireEvent.keyDown(search, { key: 'Enter' });
+
+    expect(onAccountChange).toHaveBeenCalledTimes(1);
+    expect(onAccountChange).not.toHaveBeenCalledWith('');
+  });
+});

--- a/src/components/common/AccountSelector.tsx
+++ b/src/components/common/AccountSelector.tsx
@@ -455,13 +455,35 @@ export default function AccountSelector<T extends SelectableAccount>({
         break;
       case 'Enter': {
         e.preventDefault();
-        // With no explicit highlight, Enter takes the sole matching ACCOUNT —
+        // With no explicit highlight, Enter takes the top matching ACCOUNT —
         // never the clear or create row, which are not what a search narrowed to.
         const accountsOnly = flatOptions.filter(
           option => option.id !== CLEAR_ID && option.id !== createOption?.value
         );
+        /*
+         * ─ THE TOP MATCH, NOT ONLY THE SOLE ONE ────────────────────────────
+         *
+         * This read `accountsOnly.length === 1`, and CategorySelector had the
+         * identical line — so both pickers chose nothing when a filter left
+         * SEVERAL matches and nothing was highlighted, which is always the case
+         * after typing: the highlight is reset to -1 on every change to the
+         * option list (the effect above). `preventDefault` then swallowed the
+         * key, so the control looked as though it had accepted something.
+         *
+         * Unreachable with a mouse, unavoidable with the keyboard. Found in
+         * CategorySelector when the owner noticed his edits kept reverting —
+         * "the only difference this time to what I did before is I pressed next
+         * & save with the mouse" — and fixed HERE in the same breath because he
+         * asked the right next question: "if this is a problem in a few areas
+         * will it be fixed in all?" Two pickers share the idiom; both are fixed.
+         *
+         * With NO search term there is nothing to be top of — the list is every
+         * account — so the sole-match rule still stands there and Enter on an
+         * unfiltered list with no highlight goes on doing nothing.
+         */
         const chosen =
-          flatOptions[highlightIndex] ?? (accountsOnly.length === 1 ? accountsOnly[0] : undefined);
+          flatOptions[highlightIndex]
+          ?? (searchTerm.trim() !== '' || accountsOnly.length === 1 ? accountsOnly[0] : undefined);
         if (chosen) handleSelect(chosen.id);
         break;
       }

--- a/src/pages/Accounts.tsx
+++ b/src/pages/Accounts.tsx
@@ -167,6 +167,12 @@ interface DisplayedSubBand {
   accounts: readonly Account[];
   /** What actually renders, sorted and filtered. */
   displayed: Account[];
+  /**
+   * Whether this institution is unfolded. Folded, it leaves its name, its count
+   * and its total — which is what makes folding worth doing rather than merely
+   * possible. Always true while searching; see where this is computed.
+   */
+  isExpanded: boolean;
 }
 
 interface DisplayedBand {
@@ -765,6 +771,27 @@ export default function Accounts() {
           title: sub.title,
           accounts: sub.accounts,
           displayed: sortAccounts(isSearching ? sub.accounts.filter(accountOrChildMatches) : sub.accounts),
+          /*
+           * AN INSTITUTION FOLDS TOO, on the same terms as the section above it.
+           * "It means that if I just want to see an institutions summary — name
+           * and total amount I can … it may help make the scrolling less if you
+           * want to hide some accounts on view."
+           *
+           * The same key shape as a top-level band, `institution:<label>`, and
+           * that has a consequence worth stating rather than discovering:
+           * folding "Coutts" folds it in EVERY type section it appears in, and
+           * a Coutts folded here stays folded if the Account Type switch is
+           * turned off and Coutts becomes a top-level band. That is the design
+           * `collapsedGroups` already committed to — the key names the
+           * DIMENSION and the label, never the path — and the alternative
+           * (keying by "which section is it under") would lose the fold every
+           * time the grouping switches flip, which is exactly what that comment
+           * says it set out to avoid.
+           *
+           * Search ignores the fold for the same reason it does above: a folded
+           * institution must not swallow a row the user is hunting for.
+           */
+          isExpanded: isSearching || !collapsedGroups.has(collapseKeyFor('institution', sub.label)),
         }))
         .filter(sub => sub.displayed.length > 0) ?? null;
       bands.push({
@@ -1687,6 +1714,11 @@ export default function Accounts() {
                     subBandTotalKey(group.kind, group.label, sub.label),
                     sub.accounts
                   );
+                  // Scoped to the SECTION as well as the institution: the same
+                  // bank appears under Current Accounts and under Credit Cards,
+                  // and two elements may not share a DOM id even when they fold
+                  // together.
+                  const subRegionId = `${groupRegionId(group.kind, group.label)}-${groupRegionId('institution', sub.label)}`;
                   return (
                     // A sub-band is a group, not a heading: the outline stays
                     // section (h2) → account name (h3), and screen readers get
@@ -1714,10 +1746,32 @@ export default function Accounts() {
                           `first:` resets all three: the opening institution in
                           a band sits directly under that band's own heading and
                           has nothing above it to be separated from. */}
-                      <div className="flex items-center justify-between gap-2 mt-4 first:mt-0 border-t-2 first:border-t-0 border-b border-line dark:border-gray-700 bg-surface-secondary dark:bg-gray-700/50 px-4 sm:px-6 py-2">
-                        <p className="text-body uppercase font-bold tracking-wide text-gray-900 dark:text-white truncate">
-                          {sub.title}
-                          <span className="ml-2 font-normal normal-case tracking-normal text-gray-400 dark:text-gray-500">
+                      {/* A BUTTON NOW, not a caption — see `isExpanded` on the
+                          sub-band. It is the section heading's control one rung
+                          down and is spelt identically: same chevron, same
+                          rotation, same `aria-expanded`/`aria-controls` pair,
+                          so the two folds are one idiom rather than two.
+
+                          The count and the total stay in the heading precisely
+                          BECAUSE it folds: what a collapsed institution leaves
+                          on screen is its name, how many accounts are inside
+                          and what they come to, which is the whole point of
+                          folding it — "if I just want to see an institutions
+                          summary — name and total amount I can". */}
+                      <button
+                        type="button"
+                        onClick={() => toggleGroupCollapsed(collapseKeyFor('institution', sub.label))}
+                        aria-expanded={sub.isExpanded}
+                        aria-controls={subRegionId}
+                        className="w-full text-left flex items-center justify-between gap-2 mt-4 first:mt-0 border-t-2 first:border-t-0 border-b border-line dark:border-gray-700 bg-surface-secondary dark:bg-gray-700/50 hover:bg-surface-tertiary dark:hover:bg-gray-700 transition-colors duration-state px-4 sm:px-6 py-2"
+                      >
+                        <p className="flex items-center gap-2 min-w-0 text-body uppercase font-bold tracking-wide text-gray-900 dark:text-white truncate">
+                          <ChevronRightIcon
+                            size={14}
+                            className={`flex-shrink-0 text-gray-400 transition-transform duration-200 ${sub.isExpanded ? 'rotate-90' : ''}`}
+                          />
+                          <span className="truncate">{sub.title}</span>
+                          <span className="shrink-0 font-normal normal-case tracking-normal text-gray-400 dark:text-gray-500">
                             ({countLabel})
                           </span>
                         </p>
@@ -1726,8 +1780,10 @@ export default function Accounts() {
                               its group label, so the mark is decoration here. */}
                           <span aria-hidden="true">{subTotal.text}</span>
                         </p>
+                      </button>
+                      <div id={subRegionId}>
+                        {sub.isExpanded && sub.displayed.map(renderAccountCard)}
                       </div>
-                      {sub.displayed.map(renderAccountCard)}
                     </div>
                   );
                 })


### PR DESCRIPTION
## The keyboard lost the category; the mouse did not

Found by doing the same edit twice:

> "The only difference this time to what I did before is I pressed next & save with the mouse and last time I was typing the category and then pressing enter > enter."

`CategorySelector`'s Enter chose the **highlighted** option, or the only option when a filter had left exactly one, and **otherwise nothing at all** — while the `preventDefault` above it swallowed the keystroke, so the row looked as though it had accepted a category it had not.

That is unreachable with a mouse and unavoidable with the keyboard, because the highlight is reset to −1 on every change to `searchTerm` (the effect beside it: *"any change to the option list invalidates the highlight"*). So typing a filter **always** left nothing highlighted, and unless the text happened to narrow the list to one, Enter was a key that did nothing and said nothing. Type, Enter, Enter — and the row saved with the *suggested* category still on it.

With a search term the first option is the best match by the list's own ordering, so that is what Enter now means. With **no** search term there is nothing to be top of — the list is simply every category — so the old behaviour stands there rather than quietly filing the alphabetically-first one.

### And the same gap in `AccountSelector`

> "If this is a problem in a few areas will it be fixed in all?"

The right question. `AccountSelector` carried the identical line, so the transfer and bulk-edit pickers had it too. `highlightIndex` appears in **exactly two components** in this codebase — both are fixed, so there is no third picker holding the same gap.

Its clear row keeps its exemption and gains a guard: it is pinned *first*, so "top match" has to mean top matching **account**, or a search would file "no account" the moment it narrowed.

⚠️ **This is not yet proven to be the whole of the review-flow bug** that was parked earlier — it is a real defect found while looking for it, and it matches the one difference between the run that worked and the run that did not.

## An institution folds, like the section above it

> "If I just want to see an institutions summary — name and total amount I can … it may help make the scrolling less if you want to hide some accounts on view."

The same control one rung down, spelt identically: same chevron, same rotation, same `aria-expanded`/`aria-controls` pair. The count and total stay in the heading precisely *because* it folds — what a collapsed institution leaves behind is its name, how many accounts are in it, and what they come to.

Keyed `institution:<label>`, the shape `collapsedGroups` already committed to. **Consequence worth stating:** folding "Coutts" folds it in every type section it appears in, and it stays folded if Account Type is switched off and Coutts becomes a top-level band. Keying by path instead would lose the fold every time the grouping switches flip — which is what that comment says it set out to avoid. Search ignores the fold, as it does one level up.

Verified in the browser: rows hidden, `aria-expanded` false, chevron unrotated, name/count/total still on screen, the type band above untouched, and the fold surviving a reload via `accountsCollapsedGroups`.

## Guards

Both pickers: the top match is taken when several survive; nothing happens with no search; and for accounts, a filtered Enter never lands on the clear row. Proven non-vacuous — reverting each fix fails exactly the tests that describe it.

6183 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
