### PR TITLE
Finishing a reconciliation lands back on the account you left

### DIFF
--- a/src/components/AccountRowColumns.tsx
+++ b/src/components/AccountRowColumns.tsx
@@ -389,6 +389,7 @@ export function AccountCountCell({
   count,
   to,
   openLabel,
+  toState,
 }: {
   label: string;
   count: number;
@@ -399,6 +400,12 @@ export function AccountCountCell({
   to?: string;
   /** Spoken form of the destination, e.g. "Reconcile Main Checking". */
   openLabel?: string;
+  /**
+   * Router state for the jump — the origin's provenance crumbs, so the trip
+   * BACK lands on this row instead of the top of the list. Optional: a caller
+   * with nowhere to return to simply omits it.
+   */
+  toState?: unknown;
 }): React.JSX.Element {
   /*
    * THE PILL BECAME A DOOR — the owner's ask: "if we click on a highlighted
@@ -447,6 +454,7 @@ export function AccountCountCell({
         <div className={CELL_FIGURE_LINE_CLASS}>
         <Link
           to={to}
+          state={toState}
           aria-label={openLabel}
           onClick={event => { event.stopPropagation(); }}
           /*

--- a/src/pages/Accounts.tsx
+++ b/src/pages/Accounts.tsx
@@ -1128,7 +1128,12 @@ export default function Accounts() {
   const renderReconcileButton = (account: Account): ReactNode => (
     <button
       type="button"
-      onClick={() => navigate(preserveDemoParam(`/reconciliation?account=${account.id}&from=accounts`, location.search))}
+      onClick={() => navigate(
+        preserveDemoParam(`/reconciliation?account=${account.id}&from=accounts`, location.search),
+        // The SAME crumbs the register is sent, so the trip back lands on this
+        // row rather than at the top of the list — see `registerLinkState`.
+        { state: registerLinkState(account.id) }
+      )}
       className={`p-3 min-w-[48px] min-h-[48px] flex items-center justify-center text-gray-500 hover:text-blue-700 dark:text-gray-400 dark:hover:text-blue-300 hover:bg-blue-100/50 dark:hover:bg-blue-900/30 rounded-lg relative group ${ROW_ACTION_REVEAL_CLASS}`}
       title={`Reconcile ${account.name}`}
       aria-label={`Reconcile ${account.name}`}
@@ -1329,6 +1334,7 @@ export default function Accounts() {
                                 label="Unreconciled"
                                 count={getUnreconciledCount(account.id)}
                                 to={reconcileHref(account.id)}
+                                toState={registerLinkState(account.id)}
                                 openLabel={`Reconcile ${account.name}`}
                               />
                               {/* To Review — freshly imported rows nobody has
@@ -1514,6 +1520,7 @@ export default function Accounts() {
                               label="Unreconciled"
                               count={getUnreconciledCount(child.id)}
                               to={reconcileHref(child.id)}
+                              toState={registerLinkState(child.id)}
                               openLabel={`Reconcile ${child.name}`}
                             />
                             {/* Its own register means its own arrivals to deal

--- a/src/pages/Reconciliation.tsx
+++ b/src/pages/Reconciliation.tsx
@@ -1,5 +1,5 @@
 import { useState, useMemo, useCallback, useEffect, useRef } from 'react';
-import { useSearchParams, useNavigate } from 'react-router-dom';
+import { useSearchParams, useNavigate, useLocation } from 'react-router-dom';
 import { useApp } from '../contexts/AppContextSupabase';
 import { useToast } from '../contexts/ToastContext';
 import { ArrowLeftIcon, CheckCircleIcon, CheckIcon } from '../components/icons';
@@ -22,6 +22,7 @@ import { todayIsoDay } from '../utils/statementBankBalance';
 import { toDecimal } from '../utils/decimal';
 import type { Transaction } from '../types';
 import { preferences } from '../services/preferencesService';
+import { readProvenance, returnState } from '../utils/navigationProvenance';
 import { STICKY_UNDER_APP_BAR } from '../components/layout/chromeOffsets';
 
 /**
@@ -50,6 +51,24 @@ export default function Reconciliation() {
     searchParams.get('account') || null
   );
   const navigate = useNavigate();
+  const location = useLocation();
+  /*
+   * THE WAY BACK, AND THE ROW TO LAND ON.
+   *
+   * The Accounts page sends its own crumbs (`{ accountId }`) when it opens this
+   * page, exactly as it does for a register. Handing them back is what puts the
+   * user on the account they left rather than at the top of a long list —
+   * "each time it drops me back to the top of the page, and not to the account
+   * that I clicked from ... if I have a long list of accounts and I am
+   * reconciling a few accounts at the bottom, each time I have to re-scroll".
+   *
+   * `returnState` is undefined when there are no crumbs (a direct arrival, or a
+   * link from an older build), which leaves a clean history entry and the old
+   * behaviour — this page never looks inside the crumbs, so the Accounts page
+   * goes on owning their shape.
+   */
+  const backProvenance = readProvenance(location.state);
+  const backState = backProvenance ? returnState(backProvenance) : undefined;
   // Where the user CAME FROM, captured once — later in-page query rewrites
   // (selecting an account re-writes the whole search string) would drop it.
   // Arriving via an Accounts-page reconcile button means "done" and "Back"
@@ -251,13 +270,13 @@ export default function Reconciliation() {
       // Return whence the user came: the Accounts page sent them here for ONE
       // account, so leaving that account means leaving this page too.
       const params = new URLSearchParams(preserveRuntimeControlParams(searchParams));
-      navigate({ pathname: '/accounts', search: params.toString() });
+      navigate({ pathname: '/accounts', search: params.toString() }, { state: backState });
       return;
     }
     setSelectedAccountId(null);
     setSearchParams(prev => preserveRuntimeControlParams(prev));
     window.scrollTo(0, 0);
-  }, [cameFromAccounts, searchParams, navigate, setSearchParams]);
+  }, [cameFromAccounts, searchParams, navigate, setSearchParams, backState]);
 
   /**
    * The remedy on the genuinely-empty state: there is nowhere on THIS page to


### PR DESCRIPTION
> "Each time it drops me back to the top of the page, and not to the account that I clicked from … if I have a long list of accounts and I am reconciling a few accounts at the bottom, each time I have to re-scroll down the page to where I left off."

## The machinery already existed; the reconciliation trip never joined in

The Accounts page writes its own crumbs (`{ accountId }`) into the provenance it sends when opening a **register**, and the register's back button hands exactly those crumbs back — the page reads them and scrolls that row into view, picked out.

Opening **reconciliation** sent no state at all. So there was nothing to hand back and no row to single out, and every return landed at the top.

Both ways in now carry the same crumbs the register gets — the row's Reconcile button, and the Unreconciled count that became a link earlier today — and `handleBack` returns them with `returnState`.

Nothing in `Reconciliation` looks *inside* the crumbs. The Accounts page goes on owning their shape, which is exactly the property that let this be a few lines rather than a new mechanism.

## It covers finalising, not just Back

Worth stating, because the report describes finishing a reconciliation rather than pressing Back: `handleFinalize` ends by calling `handleBack()`, and `handleBack` is in its dependency list, so the finalise path picks up the same fresh closure and the same crumbs. Both routes out land on the account you left.

## What is unchanged

`returnState` is `undefined` when there are no crumbs — a direct arrival at `/reconciliation`, or a link from an older build — which leaves a clean history entry and exactly the previous behaviour. No guessing.

`AccountCountCell` gained an optional `toState` so the count link can carry provenance; a caller with nowhere to return to simply omits it.

## Verification

End to end in the browser:

| Step | Result |
| --- | --- |
| Reconcile button clicked | arrives at `/reconciliation` with `resume: { accountId: 'demo-account-investment' }` |
| Back pressed | returns to `/accounts` carrying those crumbs |
| Landing | **scrollY 301**, the row inside the viewport and visibly selected |

Previously it arrived at the top of the list.

6183 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
