### PR TITLE
The Calendar's expense figure is readable at night, and a lint warning I shipped

### DIFF
--- a/src/components/BankConnections.tsx
+++ b/src/components/BankConnections.tsx
@@ -47,6 +47,33 @@ export default function BankConnections({
   const [isLoading, setIsLoading] = useState(false);
   const [syncingConnections, setSyncingConnections] = useState<Set<string>>(new Set());
   const [configStatus, setConfigStatus] = useState({ plaid: false, trueLayer: false });
+  /*
+   * ─ WHAT WE KNOW, AS OPPOSED TO WHAT WE HAVE NOT ASKED YET ──────────────────
+   *
+   * Both of these start false and become true when their own fetch resolves,
+   * and they exist because this panel used to say two untrue things on its way
+   * to saying a true one. Reported: "there seems to be 2 other pages that occupy
+   * the pop up before it settles ... the app flicks through them that quick I
+   * cannot get a screenshot."
+   *
+   * They were these, in order:
+   *   1. "Bank connections not configured — add your provider credentials to
+   *      the backend environment variables", because `configStatus` defaults to
+   *      neither provider being on and the warning renders on `!plaid &&
+   *      !trueLayer`;
+   *   2. "No banks connected — Connect Your First Bank", because `connections`
+   *      defaults to `[]` and the list renders on `connections.length > 0`.
+   *
+   * Both are the same mistake: an EMPTY initial value rendered as a finding.
+   * On an account with three live banks the modal opened by announcing that
+   * the feature was unconfigured and that nothing was linked — which, for the
+   * half-second it lasted, is indistinguishable from having lost them.
+   *
+   * Two flags rather than one, because the two fetches are independent and one
+   * being slow must not hold back the other's answer.
+   */
+  const [connectionsLoaded, setConnectionsLoaded] = useState(false);
+  const [configChecked, setConfigChecked] = useState(false);
   const [linkingConnectionId, setLinkingConnectionId] = useState<string | null>(null);
   const [oauthError, setOauthError] = useState<string | null>(null);
   // What an incomplete sync could not do. It used to go to the console only,
@@ -132,8 +159,21 @@ export default function BankConnections({
   };
 
   const loadConnections = async () => {
-    await bankConnectionService.refreshConnections();
-    setConnections(bankConnectionService.getConnections());
+    try {
+      await bankConnectionService.refreshConnections();
+      setConnections(bankConnectionService.getConnections());
+    } catch (error) {
+      // Caught rather than left to bubble: both loaders are started with
+      // `void`, so a rejection here became an unhandled promise rejection —
+      // which predates the flags but only showed up once a test held a refresh
+      // open and failed it on purpose.
+      logger.error('Failed to load bank connections', error as Error);
+    } finally {
+      // In `finally` so a failed refresh still stops the panel waiting: a fetch
+      // that threw has told us as much as it is going to, and holding the blank
+      // forever would be its own kind of lie.
+      setConnectionsLoaded(true);
+    }
   };
 
   const loadInstitutions = async () => {
@@ -142,8 +182,14 @@ export default function BankConnections({
   };
 
   const checkConfig = async () => {
-    await bankConnectionService.refreshConfigStatus();
-    setConfigStatus(bankConnectionService.getConfigStatus());
+    try {
+      await bankConnectionService.refreshConfigStatus();
+      setConfigStatus(bankConnectionService.getConfigStatus());
+    } catch (error) {
+      logger.error('Failed to check bank provider configuration', error as Error);
+    } finally {
+      setConfigChecked(true);
+    }
   };
 
   const handleConnect = async (institution: BankInstitution) => {
@@ -261,7 +307,7 @@ export default function BankConnections({
   return (
     <div className="space-y-6">
       {/* Configuration Warning */}
-      {!configStatus.plaid && !configStatus.trueLayer && (
+      {configChecked && !configStatus.plaid && !configStatus.trueLayer && (
         <div className="bg-yellow-50 dark:bg-yellow-900/20 border border-yellow-200 dark:border-yellow-800 rounded-xl p-4">
           <div className="flex items-start gap-3">
             <AlertCircleIcon className="text-yellow-600 dark:text-yellow-400 mt-0.5" size={20} />
@@ -370,7 +416,7 @@ export default function BankConnections({
       </div>
 
       {/* Connected Banks List */}
-      {connections.length > 0 ? (
+      {!connectionsLoaded ? null : connections.length > 0 ? (
         <div className="space-y-3">
           {connections.map(connection => (
             <div

--- a/src/components/__tests__/BankConnections.firstPaint.test.tsx
+++ b/src/components/__tests__/BankConnections.firstPaint.test.tsx
@@ -1,0 +1,134 @@
+/**
+ * WHAT THE BANK-CONNECTIONS PANEL SAYS BEFORE IT KNOWS ANYTHING.
+ *
+ * ─ THE REPORT ──────────────────────────────────────────────────────────────
+ * "There seems to be 2 other pages that occupy the pop up before it settles on
+ * the one I have attached but the app flicks through them that quick I cannot
+ * get a screenshot."
+ *
+ * They were these, in order, on an account with three live bank connections:
+ *
+ *   1. "Bank connections not configured — add your provider credentials to the
+ *      backend environment variables". `configStatus` starts as
+ *      `{ plaid: false, trueLayer: false }` and the warning renders on
+ *      `!plaid && !trueLayer`, so it showed until `refreshConfigStatus()`
+ *      returned.
+ *   2. "No banks connected — Connect Your First Bank". `connections` starts as
+ *      `[]` and the list renders on `connections.length > 0`, so the empty
+ *      state showed until `refreshConnections()` returned.
+ *
+ * Both are one mistake — an EMPTY INITIAL VALUE RENDERED AS A FINDING — and in
+ * a finance app it is the expensive kind: for the half-second it lasted, the
+ * panel was indistinguishable from having lost every bank link.
+ *
+ * These tests hold the fetches open deliberately. That is the whole point: the
+ * bug lives entirely in the window before they resolve, which is why it was too
+ * quick to photograph and why nothing that waited for the settled state could
+ * ever have caught it.
+ */
+import React from 'react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, cleanup, waitFor } from '@testing-library/react';
+
+vi.mock('@clerk/clerk-react', () => ({
+  useAuth: () => ({ getToken: async () => 'test-token' })
+}));
+
+const refreshConnections = vi.fn();
+const refreshConfigStatus = vi.fn();
+const getConnections = vi.fn(() => []);
+const getConfigStatus = vi.fn(() => ({ plaid: false, trueLayer: false }));
+
+vi.mock('../../services/bankConnectionService', () => ({
+  bankConnectionService: {
+    setAuthTokenProvider: vi.fn(),
+    refreshConnections: (...args: unknown[]) => refreshConnections(...args),
+    getConnections: () => getConnections(),
+    refreshConfigStatus: (...args: unknown[]) => refreshConfigStatus(...args),
+    getConfigStatus: () => getConfigStatus(),
+    getInstitutions: async () => [],
+  }
+}));
+
+import BankConnections from '../BankConnections';
+
+/** A promise that never settles — the panel is held in its unknown state. */
+const pending = (): Promise<never> => new Promise<never>(() => {});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  getConnections.mockReturnValue([]);
+  getConfigStatus.mockReturnValue({ plaid: false, trueLayer: false });
+});
+afterEach(cleanup);
+
+describe('before the first fetch has answered', () => {
+  it('does not announce that bank connections are unconfigured', () => {
+    refreshConfigStatus.mockImplementation(pending);
+    refreshConnections.mockImplementation(pending);
+
+    render(<BankConnections />);
+
+    // The yellow panel is a FINDING about the backend. Until the check returns
+    // there is no finding, only an unanswered question.
+    expect(screen.queryByText(/not configured/i)).toBeNull();
+  });
+
+  it('does not announce that no banks are connected', () => {
+    refreshConfigStatus.mockImplementation(pending);
+    refreshConnections.mockImplementation(pending);
+
+    render(<BankConnections />);
+
+    // The sentence the owner saw flash on an account with three banks.
+    expect(screen.queryByText(/No banks connected/i)).toBeNull();
+    expect(screen.queryByText(/Connect Your First Bank/i)).toBeNull();
+  });
+});
+
+describe('once the fetches answer', () => {
+  it('says so when there really are no banks', async () => {
+    // The empty state is not being removed — it is being made TRUE. A genuinely
+    // empty account must still be told, or the fix would trade one silence for
+    // another.
+    refreshConnections.mockResolvedValue(undefined);
+    refreshConfigStatus.mockResolvedValue(undefined);
+    getConnections.mockReturnValue([]);
+
+    render(<BankConnections />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/No banks connected/i)).toBeInTheDocument();
+    });
+  });
+
+  it('says so when the providers really are unconfigured', async () => {
+    refreshConnections.mockResolvedValue(undefined);
+    refreshConfigStatus.mockResolvedValue(undefined);
+    getConfigStatus.mockReturnValue({ plaid: false, trueLayer: false });
+
+    render(<BankConnections />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/not configured/i)).toBeInTheDocument();
+    });
+  });
+
+  it('stops waiting even when the fetch FAILS', async () => {
+    /*
+     * The `finally` in both loaders. A rejected refresh has told us as much as
+     * it is going to, and a panel that waited forever for an answer that never
+     * comes would be its own kind of lie — a permanent blank instead of a
+     * momentary false one.
+     */
+    refreshConnections.mockRejectedValue(new Error('network'));
+    refreshConfigStatus.mockRejectedValue(new Error('network'));
+    getConnections.mockReturnValue([]);
+
+    render(<BankConnections />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/No banks connected/i)).toBeInTheDocument();
+    });
+  });
+});


### PR DESCRIPTION
Two fixes: one from Claude Design's coverage audit, one I shipped myself yesterday and should not have.

## The Calendar's expense figure is unreadable at night (audit §3.1 — verified)

`Calendar.tsx` printed the month's "Money out" as a bare `text-red-600`, and the net figure's negative branch likewise.

`styles/accessibility-colors.css` remaps `.text-red-600` to the brand expense red (`#c9304a`) with `!important` and publishes **no dark-mode counterpart** — the dark handling lives entirely in `.dark .dark\:text-red-400`, which only reaches elements carrying that class. So a bare `text-red-600` paints `#c9304a` on a gray-800 card at night.

Measured in the browser rather than argued:

| | colour | contrast on the card |
| --- | --- | --- |
| bare `text-red-600` | `rgb(201,48,74)` | **2.8:1** ✗ |
| paired with `dark:text-red-400` | `rgb(248,113,113)` | **5.31:1** ✓ |
| the income figure (already paired) | `rgb(52,211,153)` | 7.64:1 ✓ |

The income figure four lines up has carried its pair all along, which is exactly why only the expense went dark.

⚠️ **My first measurement said the fix changed nothing.** It was the same-tick computed-style trap this harness has produced repeatedly — set a class and read it back in one call and you get the old value. Re-measured across two calls with a real reflow, it is 5.31:1. Recorded because the false reading was convincing enough that I nearly reported a working fix as broken.

## A lint warning I introduced in #285

The `catch` blocks added there reference `logger`, a `useMemo` value, which made the two loaders look unstable to `react-hooks/exhaustive-deps` and produced a warning on the mount effect.

Confirmed mine rather than assumed: linted the file at `origin/main~1` (clean) against the current one (warning).

The logger moves to module scope — what `useAccountBankSync.ts` already does, and what makes the loaders stable again. `useMemo` was left unused and went with it. Lint is back to **zero warnings**, which is the repo's stated standard.

6188 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
