### PR TITLE
Budget and Goals join the design pass

### DIFF
--- a/src/pages/Budget.tsx
+++ b/src/pages/Budget.tsx
@@ -267,7 +267,7 @@ export default function Budget() {
       rightContent={
         <button
           onClick={() => setIsModalOpen(true)}
-          className="inline-flex items-center gap-2 px-4 py-2 bg-[#1a2332] text-white text-sm font-medium rounded-lg hover:bg-[#2d3a4d] transition-colors shadow-sm"
+          className="inline-flex items-center gap-2 px-4 py-2 bg-[#1a2332] text-white text-body font-medium rounded-lg hover:bg-[#2d3a4d] transition-colors shadow-sm"
           title="Add Budget"
         >
           <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round">
@@ -282,7 +282,7 @@ export default function Budget() {
       <div className="flex space-x-1 bg-gray-100 dark:bg-gray-700 p-1 rounded-lg mb-6">
         <button
           onClick={() => setActiveTab('traditional')}
-          className={`flex-1 flex items-center justify-center gap-2 px-4 py-2 text-sm font-medium rounded-md transition-colors ${
+          className={`flex-1 flex items-center justify-center gap-2 px-4 py-2 text-body font-medium rounded-md transition-colors ${
             activeTab === 'traditional'
               ? 'bg-white dark:bg-gray-600 text-gray-900 dark:text-white shadow-sm'
               : 'text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-300'
@@ -294,7 +294,7 @@ export default function Budget() {
         </button>
         <button
           onClick={() => setActiveTab('envelope')}
-          className={`flex-1 flex items-center justify-center gap-2 px-4 py-2 text-sm font-medium rounded-md transition-colors ${
+          className={`flex-1 flex items-center justify-center gap-2 px-4 py-2 text-body font-medium rounded-md transition-colors ${
             activeTab === 'envelope'
               ? 'bg-white dark:bg-gray-600 text-gray-900 dark:text-white shadow-sm'
               : 'text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-300'
@@ -306,7 +306,7 @@ export default function Budget() {
         </button>
         <button
           onClick={() => setActiveTab('templates')}
-          className={`flex-1 flex items-center justify-center gap-2 px-4 py-2 text-sm font-medium rounded-md transition-colors ${
+          className={`flex-1 flex items-center justify-center gap-2 px-4 py-2 text-body font-medium rounded-md transition-colors ${
             activeTab === 'templates'
               ? 'bg-white dark:bg-gray-600 text-gray-900 dark:text-white shadow-sm'
               : 'text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-300'
@@ -317,7 +317,7 @@ export default function Budget() {
         </button>
         <button
           onClick={() => setActiveTab('rollover')}
-          className={`flex-1 flex items-center justify-center gap-2 px-4 py-2 text-sm font-medium rounded-md transition-colors ${
+          className={`flex-1 flex items-center justify-center gap-2 px-4 py-2 text-body font-medium rounded-md transition-colors ${
             activeTab === 'rollover'
               ? 'bg-white dark:bg-gray-600 text-gray-900 dark:text-white shadow-sm'
               : 'text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-300'
@@ -328,7 +328,7 @@ export default function Budget() {
         </button>
         <button
           onClick={() => setActiveTab('alerts')}
-          className={`flex-1 flex items-center justify-center gap-2 px-4 py-2 text-sm font-medium rounded-md transition-colors ${
+          className={`flex-1 flex items-center justify-center gap-2 px-4 py-2 text-body font-medium rounded-md transition-colors ${
             activeTab === 'alerts'
               ? 'bg-white dark:bg-gray-600 text-gray-900 dark:text-white shadow-sm'
               : 'text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-300'
@@ -339,7 +339,7 @@ export default function Budget() {
         </button>
         <button
           onClick={() => setActiveTab('zero-based')}
-          className={`flex-1 flex items-center justify-center gap-2 px-4 py-2 text-sm font-medium rounded-md transition-colors ${
+          className={`flex-1 flex items-center justify-center gap-2 px-4 py-2 text-body font-medium rounded-md transition-colors ${
             activeTab === 'zero-based'
               ? 'bg-white dark:bg-gray-600 text-gray-900 dark:text-white shadow-sm'
               : 'text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-300'
@@ -355,11 +355,11 @@ export default function Budget() {
         <div className="grid gap-6">
         {/* Summary Cards */}
         <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
-        <div className="bg-white dark:bg-gray-800 rounded-2xl shadow-lg border border-gray-100 dark:border-gray-700 p-6">
+        <div className="bg-white dark:bg-gray-800 rounded-lg border border-line dark:border-gray-700 p-6">
           <div className="flex items-center justify-between">
             <div>
-              <p className="text-gray-600 dark:text-gray-400 text-sm">Total Budgeted</p>
-              <p className="text-2xl font-bold text-gray-900 dark:text-white">
+              <p className="text-gray-600 dark:text-gray-400 text-body">Total Budgeted</p>
+              <p className="text-page font-bold text-gray-900 dark:text-white">
                 {isLoading ? <SkeletonText className="w-32 h-8" /> : totalBudgeted}
               </p>
             </div>
@@ -367,11 +367,11 @@ export default function Budget() {
           </div>
         </div>
 
-        <div className="bg-white dark:bg-gray-800 rounded-2xl shadow-lg border border-gray-100 dark:border-gray-700 p-6">
+        <div className="bg-white dark:bg-gray-800 rounded-lg border border-line dark:border-gray-700 p-6">
           <div className="flex items-center justify-between">
             <div>
-              <p className="text-gray-600 dark:text-gray-400 text-sm">Total Spent</p>
-              <p className="text-2xl font-bold text-gray-900 dark:text-white">
+              <p className="text-gray-600 dark:text-gray-400 text-body">Total Spent</p>
+              <p className="text-page font-bold text-gray-900 dark:text-white">
                 {isLoading ? <SkeletonText className="w-32 h-8" /> : totalSpent}
               </p>
             </div>
@@ -379,11 +379,11 @@ export default function Budget() {
           </div>
         </div>
 
-        <div className="bg-white dark:bg-gray-800 rounded-2xl shadow-lg border border-gray-100 dark:border-gray-700 p-6">
+        <div className="bg-white dark:bg-gray-800 rounded-lg border border-line dark:border-gray-700 p-6">
           <div className="flex items-center justify-between">
             <div>
-              <p className="text-gray-600 dark:text-gray-400 text-sm">Total Remaining</p>
-              <p className={`text-2xl font-bold ${
+              <p className="text-gray-600 dark:text-gray-400 text-body">Total Remaining</p>
+              <p className={`text-page font-bold ${
                 totalRemainingValue >= 0 ? 'text-green-600 dark:text-green-400' : 'text-red-600 dark:text-red-400'
               }`}>
                 {isLoading ? <SkeletonText className="w-32 h-8" /> : totalRemaining}
@@ -407,16 +407,16 @@ export default function Budget() {
         ) : budgetsWithSpent.map(budget => budget && (
           <div
             key={budget.id}
-            className={`bg-white dark:bg-gray-800 rounded-2xl shadow-lg border border-gray-100 dark:border-gray-700 p-6 ${
+            className={`bg-white dark:bg-gray-800 rounded-lg border border-line dark:border-gray-700 p-6 ${
               budget.isActive === false ? 'opacity-60' : ''
             }`}
           >
             <div className="flex justify-between items-start mb-4">
               <div>
-                <h3 className="text-lg font-semibold text-gray-900 dark:text-white">
+                <h3 className="text-card font-semibold text-gray-900 dark:text-white">
                   {getBudgetCategoryLabel(budget)}
                 </h3>
-                <p className="text-sm text-gray-600 dark:text-gray-400">
+                <p className="text-body text-gray-600 dark:text-gray-400">
                   {/* The budget's ACTUAL period — a weekly or quarterly budget
                       used to be captioned "Yearly" because anything that was
                       not monthly fell through to the same branch. */}
@@ -427,7 +427,7 @@ export default function Budget() {
               <div className="flex gap-3">
                 <button
                   onClick={() => void handleToggleActive(budget.id, budget.isActive)}
-                  className={`px-3 py-1 text-sm rounded ${
+                  className={`px-3 py-1 text-body rounded ${
                     budget.isActive !== false
                       ? 'bg-blue-100 dark:bg-blue-900/20 text-blue-700 dark:text-blue-300'
                       : 'bg-gray-100 dark:bg-gray-700 text-gray-700 dark:text-gray-300'
@@ -459,7 +459,7 @@ export default function Budget() {
             </div>
 
             <div className="space-y-3">
-              <div className="flex justify-between text-sm">
+              <div className="flex justify-between text-body">
                 <span className="text-gray-600 dark:text-gray-400">Spent</span>
                 <span className="font-medium text-gray-900 dark:text-white">
                   {formatCurrency(budget.spent)} of {formatCurrency(budget.effectiveAmount)}
@@ -482,7 +482,7 @@ export default function Budget() {
                 />
               </div>
 
-              <div className="flex justify-between text-sm">
+              <div className="flex justify-between text-body">
                 <span className="text-gray-600 dark:text-gray-400">
                   {`${formatPercentage(budget.percentage, 0)}% used`}
                 </span>
@@ -499,7 +499,7 @@ export default function Budget() {
                   no rate is applied to another currency in this wave, so the
                   spend shown is short of what was actually spent. */}
               {budget.excludedForeignCount > 0 && (
-                <p className="text-xs text-amber-700 dark:text-amber-400">
+                <p className="text-dense text-amber-700 dark:text-amber-400">
                   Spending on accounts in another currency is left out, so you have spent more than this.
                 </p>
               )}
@@ -509,7 +509,7 @@ export default function Budget() {
           </div>
 
           {budgets.length === 0 && (
-          <div className="text-center py-12 bg-white dark:bg-gray-800 rounded-2xl shadow-lg border border-gray-100 dark:border-gray-700">
+          <div className="text-center py-12 bg-white dark:bg-gray-800 rounded-lg border border-line dark:border-gray-700">
             <p className="text-gray-500 dark:text-gray-400 mb-4">No budgets set up yet</p>
             <button
               onClick={() => setIsModalOpen(true)}

--- a/src/pages/Goals.tsx
+++ b/src/pages/Goals.tsx
@@ -338,21 +338,21 @@ export default function Goals(): React.JSX.Element {
       <div className="grid gap-6">
         {/* Summary Cards */}
         <div className="grid grid-cols-1 md:grid-cols-4 gap-4">
-        <div className="bg-white dark:bg-gray-800 rounded-2xl shadow-lg border border-gray-100 dark:border-gray-700 p-4">
+        <div className="bg-white dark:bg-gray-800 rounded-lg border border-line dark:border-gray-700 p-4">
           <div className="flex items-center justify-between">
             <div>
-              <p className="text-gray-500 dark:text-gray-400 text-sm">Active Goals</p>
-              <p className="text-2xl font-bold text-gray-900 dark:text-white">{activeViews.length}</p>
+              <p className="text-gray-500 dark:text-gray-400 text-body">Active Goals</p>
+              <p className="text-page font-bold text-gray-900 dark:text-white">{activeViews.length}</p>
             </div>
             <TargetIcon className="h-8 w-8 text-blue-600" />
           </div>
         </div>
 
-        <div className="bg-white dark:bg-gray-800 rounded-2xl shadow-lg border border-gray-100 dark:border-gray-700 p-4">
+        <div className="bg-white dark:bg-gray-800 rounded-lg border border-line dark:border-gray-700 p-4">
           <div className="flex items-center justify-between">
             <div>
-              <p className="text-gray-500 dark:text-gray-400 text-sm">Total Target</p>
-              <p className="text-2xl font-bold text-gray-900 dark:text-white">
+              <p className="text-gray-500 dark:text-gray-400 text-body">Total Target</p>
+              <p className="text-page font-bold text-gray-900 dark:text-white">
                 {formatCurrency(totalTargetAmount)}
               </p>
             </div>
@@ -360,11 +360,11 @@ export default function Goals(): React.JSX.Element {
           </div>
         </div>
 
-        <div className="bg-white dark:bg-gray-800 rounded-2xl shadow-lg border border-gray-100 dark:border-gray-700 p-4">
+        <div className="bg-white dark:bg-gray-800 rounded-lg border border-line dark:border-gray-700 p-4">
           <div className="flex items-center justify-between">
             <div>
-              <p className="text-gray-500 dark:text-gray-400 text-sm">Total Saved</p>
-              <p className="text-2xl font-bold text-gray-900 dark:text-white">
+              <p className="text-gray-500 dark:text-gray-400 text-body">Total Saved</p>
+              <p className="text-page font-bold text-gray-900 dark:text-white">
                 {formatCurrency(totalCurrentAmount)}
               </p>
             </div>
@@ -385,13 +385,13 @@ export default function Goals(): React.JSX.Element {
           </div>
         </div>
 
-        <div className="bg-white dark:bg-gray-800 rounded-2xl shadow-lg border border-gray-100 dark:border-gray-700 p-4">
+        <div className="bg-white dark:bg-gray-800 rounded-lg border border-line dark:border-gray-700 p-4">
           <div className="flex items-center justify-between">
             <div>
-              <p className="text-gray-500 dark:text-gray-400 text-sm">Completed</p>
-              <p className="text-2xl font-bold text-gray-900 dark:text-white">{completedViews.length}</p>
+              <p className="text-gray-500 dark:text-gray-400 text-body">Completed</p>
+              <p className="text-page font-bold text-gray-900 dark:text-white">{completedViews.length}</p>
             </div>
-            <div className="text-2xl">🏆</div>
+            <div className="text-page">🏆</div>
           </div>
         </div>
         </div>
@@ -400,7 +400,7 @@ export default function Goals(): React.JSX.Element {
         <div className="pt-4">
           {activeViews.length > 0 && (
         <div className="mb-6">
-          <h2 className="text-xl font-semibold text-theme-heading dark:text-white mb-4">Active Goals</h2>
+          <h2 className="text-card font-semibold text-theme-heading dark:text-white mb-4">Active Goals</h2>
           <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
             {activeViews.map((view) => {
               const { goal } = view;
@@ -416,13 +416,13 @@ export default function Goals(): React.JSX.Element {
               });
 
               return (
-                <div key={goal.id} className="bg-white dark:bg-gray-800 rounded-2xl shadow-lg border border-gray-100 dark:border-gray-700 p-6">
+                <div key={goal.id} className="bg-white dark:bg-gray-800 rounded-lg border border-line dark:border-gray-700 p-6">
                   <div className="flex justify-between items-start mb-4">
                     <div className="flex items-start gap-3">
-                      <span className="text-2xl">{getGoalIcon(goal.type)}</span>
+                      <span className="text-page">{getGoalIcon(goal.type)}</span>
                       <div>
                         <h3 className="font-semibold text-gray-900 dark:text-white">{goal.name}</h3>
-                        <p className="text-sm text-gray-500 dark:text-gray-400 capitalize">{(goal.type ?? "savings").replace("-", " ")}</p>
+                        <p className="text-body text-gray-500 dark:text-gray-400 capitalize">{(goal.type ?? "savings").replace("-", " ")}</p>
                       </div>
                     </div>
                     <div className="flex gap-2">
@@ -446,12 +446,12 @@ export default function Goals(): React.JSX.Element {
                   </div>
 
                   {goal.description && (
-                    <p className="text-sm text-gray-600 dark:text-gray-400 mb-4">{goal.description}</p>
+                    <p className="text-body text-gray-600 dark:text-gray-400 mb-4">{goal.description}</p>
                   )}
 
                   <div className="space-y-4">
                     <div>
-                      <div className="flex justify-between text-sm mb-1">
+                      <div className="flex justify-between text-body mb-1">
                         <span className="text-gray-600 dark:text-gray-400">Progress</span>
                         <span className="font-medium text-gray-900 dark:text-white">{progressDisplay}%</span>
                       </div>
@@ -465,7 +465,7 @@ export default function Goals(): React.JSX.Element {
                       </div>
                     </div>
 
-                    <div className="grid grid-cols-2 gap-4 text-sm">
+                    <div className="grid grid-cols-2 gap-4 text-body">
                       <div>
                         <p className="text-gray-500 dark:text-gray-400">Current</p>
                         <p className="font-semibold text-gray-900 dark:text-white">
@@ -481,12 +481,12 @@ export default function Goals(): React.JSX.Element {
                     </div>
 
                     {monthlyTarget && (
-                      <p className="text-sm font-medium text-gray-700 dark:text-gray-300">
+                      <p className="text-body font-medium text-gray-700 dark:text-gray-300">
                         {formatCurrency(monthlyTarget)}/month to stay on track
                       </p>
                     )}
 
-                    <div className="flex items-center gap-4 text-sm">
+                    <div className="flex items-center gap-4 text-body">
                       <div className="flex items-center gap-1">
                         <CalendarIcon className="h-4 w-4 text-gray-400" />
                         <span className={isDeadlineUrgent(daysLeft) ? "text-red-600" : "text-gray-600 dark:text-gray-400"}>
@@ -509,7 +509,7 @@ export default function Goals(): React.JSX.Element {
                             key={account.id}
                             type="button"
                             onClick={() => openAccount(account.id)}
-                            className="px-2 py-1 rounded-lg text-xs font-medium bg-gray-100 dark:bg-gray-700 text-gray-700 dark:text-gray-200 hover:bg-gray-200 dark:hover:bg-gray-600"
+                            className="px-2 py-1 rounded-lg text-dense font-medium bg-gray-100 dark:bg-gray-700 text-gray-700 dark:text-gray-200 hover:bg-gray-200 dark:hover:bg-gray-600"
                             aria-label={`Open ${account.name}`}
                           >
                             {account.name}
@@ -519,7 +519,7 @@ export default function Goals(): React.JSX.Element {
                     )}
 
                     {view.unavailableCount > 0 && (
-                      <p className="text-sm text-amber-700 dark:text-amber-400">
+                      <p className="text-body text-amber-700 dark:text-amber-400">
                         {view.unavailableCount === 1
                           ? '1 linked account unavailable'
                           : `${view.unavailableCount} linked accounts unavailable`}
@@ -538,10 +538,10 @@ export default function Goals(): React.JSX.Element {
 
       {activeViews.length === 0 && goals.length === 0 && (
         /* Empty state when no goals at all */
-        <div className="bg-white dark:bg-gray-800 rounded-2xl shadow-lg border border-gray-100 dark:border-gray-700 p-12" data-testid="empty-state">
+        <div className="bg-white dark:bg-gray-800 rounded-lg border border-line dark:border-gray-700 p-12" data-testid="empty-state">
           <div className="text-center">
             <TargetIcon className="h-24 w-24 mx-auto text-gray-300 dark:text-gray-600 mb-4" />
-            <h3 className="text-xl font-semibold text-gray-900 dark:text-white mb-2">
+            <h3 className="text-card font-semibold text-gray-900 dark:text-white mb-2">
               No goals yet
             </h3>
             <p className="text-gray-500 dark:text-gray-400 mb-6 max-w-md mx-auto">
@@ -556,24 +556,24 @@ export default function Goals(): React.JSX.Element {
             </button>
 
             <div className="mt-8 grid grid-cols-1 sm:grid-cols-3 gap-4 max-w-2xl mx-auto">
-              <div className="p-4 bg-blue-50 dark:bg-blue-900/20 rounded-lg">
-                <div className="text-2xl mb-2">💰</div>
-                <h4 className="font-medium text-gray-900 dark:text-white text-sm">Savings Goal</h4>
-                <p className="text-xs text-gray-600 dark:text-gray-400 mt-1">
+              <div className="p-4 bg-white dark:bg-gray-800 rounded-lg border border-line dark:border-gray-700">
+                <div className="text-page mb-2">💰</div>
+                <h4 className="font-medium text-gray-900 dark:text-white text-body">Savings Goal</h4>
+                <p className="text-dense text-gray-600 dark:text-gray-400 mt-1">
                   Build your emergency fund or save for a big purchase
                 </p>
               </div>
-              <div className="p-4 bg-blue-50 dark:bg-blue-900/20 rounded-lg">
-                <div className="text-2xl mb-2">💳</div>
-                <h4 className="font-medium text-gray-900 dark:text-white text-sm">Debt Payoff</h4>
-                <p className="text-xs text-gray-600 dark:text-gray-400 mt-1">
+              <div className="p-4 bg-white dark:bg-gray-800 rounded-lg border border-line dark:border-gray-700">
+                <div className="text-page mb-2">💳</div>
+                <h4 className="font-medium text-gray-900 dark:text-white text-body">Debt Payoff</h4>
+                <p className="text-dense text-gray-600 dark:text-gray-400 mt-1">
                   Track progress on paying down credit cards or loans
                 </p>
               </div>
-              <div className="p-4 bg-purple-50 dark:bg-purple-900/20 rounded-lg">
-                <div className="text-2xl mb-2">📈</div>
-                <h4 className="font-medium text-gray-900 dark:text-white text-sm">Investment</h4>
-                <p className="text-xs text-gray-600 dark:text-gray-400 mt-1">
+              <div className="p-4 bg-white dark:bg-gray-800 rounded-lg border border-line dark:border-gray-700">
+                <div className="text-page mb-2">📈</div>
+                <h4 className="font-medium text-gray-900 dark:text-white text-body">Investment</h4>
+                <p className="text-dense text-gray-600 dark:text-gray-400 mt-1">
                   Monitor your investment portfolio growth targets
                 </p>
               </div>
@@ -585,10 +585,10 @@ export default function Goals(): React.JSX.Element {
       {activeViews.length === 0 && goals.length > 0 && (
         /* Goals exist, none of them active: say which, rather than claiming
            everything is finished when some are merely paused. */
-        <div className="bg-white dark:bg-gray-800 rounded-2xl shadow-lg border border-gray-100 dark:border-gray-700 p-12" data-testid="empty-state">
+        <div className="bg-white dark:bg-gray-800 rounded-lg border border-line dark:border-gray-700 p-12" data-testid="empty-state">
           <div className="text-center">
             <div className="text-5xl mb-4">{completedViews.length > 0 ? '🎉' : '⏸️'}</div>
-            <h3 className="text-xl font-semibold text-gray-900 dark:text-white mb-2">
+            <h3 className="text-card font-semibold text-gray-900 dark:text-white mb-2">
               {completedViews.length > 0 && pausedViews.length === 0
                 ? 'All goals completed!'
                 : 'No active goals'}
@@ -612,8 +612,8 @@ export default function Goals(): React.JSX.Element {
       {/* Paused Goals */}
       {pausedViews.length > 0 && (
         <div className="mb-6">
-          <h2 className="text-xl font-semibold text-theme-heading dark:text-white mb-4">Paused Goals</h2>
-          <div className="bg-white dark:bg-gray-800 rounded-2xl shadow-lg border border-gray-100 dark:border-gray-700">
+          <h2 className="text-card font-semibold text-theme-heading dark:text-white mb-4">Paused Goals</h2>
+          <div className="bg-white dark:bg-gray-800 rounded-lg border border-line dark:border-gray-700">
             <div className="divide-y divide-gray-200 dark:divide-gray-700">
               {pausedViews.map((view) => (
                 <div key={view.goal.id} className="p-4 flex items-center justify-between">
@@ -621,7 +621,7 @@ export default function Goals(): React.JSX.Element {
                     <span className="text-xl opacity-50">{getGoalIcon(view.goal.type)}</span>
                     <div>
                       <h4 className="font-medium text-gray-900 dark:text-white">{view.goal.name}</h4>
-                      <p className="text-sm text-gray-500 dark:text-gray-400">
+                      <p className="text-body text-gray-500 dark:text-gray-400">
                         Paused • {formatCurrency(view.current)} of {formatCurrency(view.target)}
                       </p>
                     </div>
@@ -654,8 +654,8 @@ export default function Goals(): React.JSX.Element {
       {/* Completed Goals */}
       {completedViews.length > 0 && (
         <div>
-          <h2 className="text-xl font-semibold text-theme-heading dark:text-white mb-4">Completed Goals</h2>
-          <div className="bg-white dark:bg-gray-800 rounded-2xl shadow-lg border border-gray-100 dark:border-gray-700">
+          <h2 className="text-card font-semibold text-theme-heading dark:text-white mb-4">Completed Goals</h2>
+          <div className="bg-white dark:bg-gray-800 rounded-lg border border-line dark:border-gray-700">
             <div className="divide-y divide-gray-200 dark:divide-gray-700">
               {completedViews.map((view) => (
                 <div key={view.goal.id} className="p-4 flex items-center justify-between">
@@ -663,7 +663,7 @@ export default function Goals(): React.JSX.Element {
                     <span className="text-xl opacity-50">{getGoalIcon(view.goal.type)}</span>
                     <div>
                       <h4 className="font-medium text-gray-900 dark:text-white">{view.goal.name}</h4>
-                      <p className="text-sm text-gray-500 dark:text-gray-400">
+                      <p className="text-body text-gray-500 dark:text-gray-400">
                         {view.goal.completedAt
                           ? `Completed ${format(new Date(view.goal.completedAt), 'd MMM yyyy')}`
                           : 'Completed'} • {formatCurrency(view.target)}


### PR DESCRIPTION
First pair of the conversion pass Claude Design's coverage audit called for — *"a lint-and-fix job, not a design job"*. Both pages were wholly pre-pass and both are consumer-facing, which is why they lead the queue.

## Applied, of the five ruled items

**1 — `rounded-2xl shadow-lg` → hairline at radius 8.** Fourteen cards (5 Budget, 9 Goals), all the same shape, now `rounded-lg border border-line` — the idiom `NetWorthSummary` already uses, so the converted surfaces cannot disagree about what a card is.

**3 — Tinted panels → white with a hairline.** Goals' three (blue, blue, purple) sat inside the "no goals yet" state explaining the kinds of goal. The tint did nothing the words weren't already doing, and three coloured surfaces on one screen is what the rule exists to stop.

**4 — The six-size scale.** 47 replacements: `text-2xl`→`text-page`, `text-sm`→`text-body`, `text-xs`→`text-dense` (all exact), and `text-lg`/`text-xl` on **headings** → `text-card`. Budget is now entirely on scale.

## Deliberately not touched, and why

- **Budget's colour — nothing changed.** You reserved judgement pending a dark-mode screenshot, on the grounds that green/red on *remaining* is a **delta**, the one case where those colours are correct. Its `bg-red-500`/`yellow`/`green` turn out to be progress-**bar fills** rather than tinted panels, so item 3 doesn't reach them either.
- **Goals' two remaining `text-xl` spans** are emoji **icons**, not type. An icon's size isn't the type scale's business.
- **The empty states.** Item 5 asks for the batch-7 pattern *with a remedy*, and both of Goals' already carry one ("Create Your First Goal", "set a new target"). Their substance was right; only the styling was pre-pass. Converting them to the shared `<EmptyState>` would have **deleted the three explainer cards** — a content decision rather than a mechanical one, so I left it to you.

## Two things for you, found while converting

Neither acted on, both the yellow thread outside reconciliation — the same unruled territory as the amber panel you flagged on Investments:

- **Goals' progress bars run amber.**
- **Budget carries an amber currency warning** ("Spending on accounts in another currency is left out…").

## Verification

Browser at 1280px, light: both pages read as converted surfaces — hairline cards, no shadows, type on scale — and Budget's green "remaining" is untouched. 6188 tests pass.

Next pair in the queue: the two report sub-pages carrying the §2.1 colour error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
