### PR TITLE
The two account report sub-pages join the design pass (and a lost commit recovered)

### DIFF
--- a/src/components/BankConnections.tsx
+++ b/src/components/BankConnections.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useMemo } from 'react';
+import React, { useState, useEffect } from 'react';
 import { useAuth as useClerkAuth } from '@clerk/clerk-react';
 import { bankConnectionService, type BankConnection, type BankInstitution } from '../services/bankConnectionService';
 import { Modal } from './common/Modal';
@@ -18,6 +18,11 @@ import {
 } from './icons';
 import { format } from 'date-fns';
 import { createScopedLogger } from '../loggers/scopedLogger';
+
+// Module scope, not a useMemo: the loaders below are started from a mount
+// effect, and a logger created inside the component makes them look unstable to
+// react-hooks/exhaustive-deps. `useAccountBankSync.ts` already does it this way.
+const logger = createScopedLogger('BankConnections');
 
 interface BankConnectionsProps {
   onAccountsLinked?: () => void;
@@ -81,7 +86,7 @@ export default function BankConnections({
   // reported a balance to open them with left the user staring at a connection
   // with nothing under it and no reason given.
   const [syncNotice, setSyncNotice] = useState<string | null>(null);
-  const logger = useMemo(() => createScopedLogger('BankConnections'), []);
+
   const { getToken } = useClerkAuth();
 
   useEffect(() => {

--- a/src/pages/Calendar.tsx
+++ b/src/pages/Calendar.tsx
@@ -195,11 +195,21 @@ export default function Calendar() {
         </div>
         <div className="bg-white dark:bg-gray-800 rounded-lg shadow-sm border border-gray-100 dark:border-gray-700 px-4 py-2">
           <span className="text-sm text-gray-500 dark:text-gray-400">Money out</span>
-          <p className="text-lg font-semibold text-red-600">{formatCurrency(monthSummary.totalExpense)}</p>
+          {/* `dark:text-red-400` is not decoration — without it this figure is
+              unreadable at night. `styles/accessibility-colors.css` remaps
+              `.text-red-600` to the brand expense red (#c9304a) with
+              `!important` and publishes NO dark-mode counterpart; the dark
+              handling lives entirely in `.dark .dark\:text-red-400`, which only
+              applies to elements that carry that class. So a bare
+              `text-red-600` paints #c9304a on a gray-800 card in dark mode —
+              measured 2.8:1, against the 4.5:1 text needs. The income figure
+              four lines up has carried the pair all along, which is why only
+              the expense went dark. */}
+          <p className="text-lg font-semibold text-red-600 dark:text-red-400">{formatCurrency(monthSummary.totalExpense)}</p>
         </div>
         <div className="bg-white dark:bg-gray-800 rounded-lg shadow-sm border border-gray-100 dark:border-gray-700 px-4 py-2">
           <span className="text-sm text-gray-500 dark:text-gray-400">Net</span>
-          <p className={`text-lg font-semibold ${toDecimal(monthSummary.totalIncome).minus(toDecimal(monthSummary.totalExpense)).greaterThanOrEqualTo(0) ? 'text-green-600 dark:text-green-400' : 'text-red-600'}`}>
+          <p className={`text-lg font-semibold ${toDecimal(monthSummary.totalIncome).minus(toDecimal(monthSummary.totalExpense)).greaterThanOrEqualTo(0) ? 'text-green-600 dark:text-green-400' : 'text-red-600 dark:text-red-400'}`}>
             {formatCurrency(toDecimal(monthSummary.totalIncome).minus(toDecimal(monthSummary.totalExpense)).toNumber())}
           </p>
         </div>

--- a/src/pages/reports/AccountBalancesReport.tsx
+++ b/src/pages/reports/AccountBalancesReport.tsx
@@ -48,41 +48,41 @@ export default function AccountBalancesReport({ picker }: ReportViewProps): Reac
   const signClass = (value: number): string =>
     value < 0 ? 'text-red-600 dark:text-red-400' : 'text-gray-900 dark:text-white';
 
-  const headCell = 'px-3 py-2 text-xs font-semibold uppercase tracking-wider text-gray-500 dark:text-gray-400';
-  const cell = 'px-3 py-2 text-sm text-right tabular-nums whitespace-nowrap';
+  const headCell = 'px-3 py-2 text-dense font-semibold uppercase tracking-wider text-gray-500 dark:text-gray-400';
+  const cell = 'px-3 py-2 text-body text-right tabular-nums whitespace-nowrap';
 
   return (
     <div className="max-w-[1400px] mx-auto space-y-6">
       <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
-        <div className="bg-[#1a2332] dark:bg-gray-700 rounded-2xl p-6 text-white">
-          <p className="text-xs text-white/60 uppercase tracking-wider font-medium">
+        <div className="bg-white dark:bg-gray-800 rounded-lg p-6 border border-line dark:border-gray-700">
+          <p className="text-label uppercase tracking-wider font-medium text-gray-500 dark:text-gray-400">
             Total balance
           </p>
-          <p className="text-2xl font-bold mt-1">{money(report.netWorth)}</p>
-          <p className="text-xs text-white/60 mt-1">
+          <p className="text-page font-bold mt-1">{money(report.netWorth)}</p>
+          <p className="text-dense text-gray-500 dark:text-gray-400 mt-1">
             As at {report.asOf.toLocaleDateString('en-GB', { day: 'numeric', month: 'long', year: 'numeric' })}
           </p>
         </div>
-        <div className="bg-white dark:bg-gray-800 rounded-2xl p-6 border border-gray-100 dark:border-gray-700">
-          <p className="text-xs text-gray-500 uppercase tracking-wider font-medium">In credit</p>
-          <p className="text-2xl font-bold mt-1 text-green-600 dark:text-green-400">
+        <div className="bg-white dark:bg-gray-800 rounded-lg p-6 border border-line dark:border-gray-700">
+          <p className="text-dense text-gray-500 uppercase tracking-wider font-medium">In credit</p>
+          <p className="text-page font-semibold mt-1 text-primary dark:text-white">
             {formatCurrency(report.assets)}
           </p>
         </div>
-        <div className="bg-white dark:bg-gray-800 rounded-2xl p-6 border border-gray-100 dark:border-gray-700">
-          <p className="text-xs text-gray-500 uppercase tracking-wider font-medium">Overdrawn / owed</p>
-          <p className="text-2xl font-bold mt-1 text-red-600 dark:text-red-400">
+        <div className="bg-white dark:bg-gray-800 rounded-lg p-6 border border-line dark:border-gray-700">
+          <p className="text-dense text-gray-500 uppercase tracking-wider font-medium">Overdrawn / owed</p>
+          <p className="text-page font-semibold mt-1 text-primary dark:text-white">
             {formatCurrency(report.liabilities)}
           </p>
         </div>
       </div>
 
-      <div className="bg-white dark:bg-gray-800 rounded-2xl shadow-lg border border-gray-100 dark:border-gray-700">
+      <div className="bg-white dark:bg-gray-800 rounded-lg border border-line dark:border-gray-700">
         <div className="p-6 pb-3">
           <h2 className="text-lg font-semibold text-theme-heading dark:text-white">
             Balances by account
           </h2>
-          <p className="text-sm text-gray-500 dark:text-gray-400 mt-1">
+          <p className="text-body text-gray-500 dark:text-gray-400 mt-1">
             {PERIOD_LABELS[picker.period]} — click an account to see the transactions behind its movement.
           </p>
         </div>
@@ -92,7 +92,7 @@ export default function AccountBalancesReport({ picker }: ReportViewProps): Reac
         ) : (
           /* The table scrolls inside its own box; the page never scrolls sideways. */
           <div className="overflow-x-auto rounded-b-2xl">
-            <table className="min-w-full text-sm">
+            <table className="min-w-full text-body">
               <caption className="sr-only">
                 Opening balance, money in and out, and closing balance for every account
               </caption>
@@ -112,7 +112,7 @@ export default function AccountBalancesReport({ picker }: ReportViewProps): Reac
                   <tr className="bg-gray-50 dark:bg-gray-700/50">
                     <th
                       scope="row"
-                      className="px-3 py-1.5 text-left text-xs font-semibold uppercase tracking-wide text-gray-600 dark:text-gray-300"
+                      className="px-3 py-1.5 text-left text-dense font-semibold uppercase tracking-wide text-gray-600 dark:text-gray-300"
                     >
                       {group.label}
                     </th>
@@ -129,7 +129,7 @@ export default function AccountBalancesReport({ picker }: ReportViewProps): Reac
                         <button
                           type="button"
                           onClick={() => drillIntoAccount(row)}
-                          className="text-sm text-gray-900 dark:text-white hover:text-blue-700 dark:hover:text-blue-400 hover:underline rounded"
+                          className="text-body text-gray-900 dark:text-white hover:text-blue-700 dark:hover:text-blue-400 hover:underline rounded"
                           title={`${row.name} — view these transactions`}
                         >
                           {row.name}
@@ -159,7 +159,7 @@ export default function AccountBalancesReport({ picker }: ReportViewProps): Reac
               ))}
               <tfoot className="border-t-2 border-gray-200 dark:border-gray-600">
                 <tr>
-                  <th scope="row" className="px-3 py-3 text-left text-sm font-semibold text-gray-900 dark:text-white">
+                  <th scope="row" className="px-3 py-3 text-left text-body font-semibold text-gray-900 dark:text-white">
                     Total
                   </th>
                   <td className={`${cell} font-semibold ${signClass(report.openingNetWorth)}`}>

--- a/src/pages/reports/AccountDistributionReport.tsx
+++ b/src/pages/reports/AccountDistributionReport.tsx
@@ -60,44 +60,44 @@ export default function AccountDistributionReport(): React.JSX.Element {
   const shareOf = (entry: AccountDistributionEntry): string =>
     entry.share ? `${formatDecimal(entry.share, 1)}%` : '—';
 
-  const headCell = 'px-4 py-2 text-xs font-semibold uppercase tracking-wider text-gray-500 dark:text-gray-400';
+  const headCell = 'px-4 py-2 text-dense font-semibold uppercase tracking-wider text-gray-500 dark:text-gray-400';
 
   return (
     <div className="max-w-[1400px] mx-auto space-y-6">
       <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
-        <div className="bg-[#1a2332] dark:bg-gray-700 rounded-2xl p-6 text-white">
-          <p className="text-xs text-white/60 uppercase tracking-wider font-medium">Held in credit</p>
-          <p className="text-2xl font-bold mt-1">{money(distribution.inCreditTotal.toNumber())}</p>
+        <div className="bg-white dark:bg-gray-800 rounded-lg p-6 border border-line dark:border-gray-700">
+          <p className="text-label uppercase tracking-wider font-medium text-gray-500 dark:text-gray-400">Held in credit</p>
+          <p className="text-page font-bold mt-1">{money(distribution.inCreditTotal.toNumber())}</p>
           {/* What every share below is a share OF, said once. */}
-          <p className="text-xs text-white/60 mt-1">Current balances — every share below is of this total</p>
+          <p className="text-dense text-gray-500 dark:text-gray-400 mt-1">Current balances — every share below is of this total</p>
         </div>
-        <div className="bg-white dark:bg-gray-800 rounded-2xl p-6 border border-gray-100 dark:border-gray-700">
-          <p className="text-xs text-gray-500 uppercase tracking-wider font-medium">Accounts</p>
-          <p className="text-2xl font-bold mt-1 text-gray-900 dark:text-white">
+        <div className="bg-white dark:bg-gray-800 rounded-lg p-6 border border-line dark:border-gray-700">
+          <p className="text-dense text-gray-500 uppercase tracking-wider font-medium">Accounts</p>
+          <p className="text-page font-bold mt-1 text-gray-900 dark:text-white">
             {distribution.entries.length.toLocaleString()}
           </p>
         </div>
-        <div className="bg-white dark:bg-gray-800 rounded-2xl p-6 border border-gray-100 dark:border-gray-700">
-          <p className="text-xs text-gray-500 uppercase tracking-wider font-medium">Largest holding</p>
-          <p className="text-2xl font-bold mt-1 text-gray-900 dark:text-white truncate">
+        <div className="bg-white dark:bg-gray-800 rounded-lg p-6 border border-line dark:border-gray-700">
+          <p className="text-dense text-gray-500 uppercase tracking-wider font-medium">Largest holding</p>
+          <p className="text-page font-bold mt-1 text-gray-900 dark:text-white truncate">
             {distribution.slices.length > 0 ? shareOf(distribution.slices[0]) : '—'}
           </p>
-          <p className="text-xs text-gray-500 dark:text-gray-400 mt-1 truncate">
+          <p className="text-dense text-gray-500 dark:text-gray-400 mt-1 truncate">
             {distribution.slices.length > 0 ? distribution.slices[0].name : 'Nothing in credit'}
           </p>
         </div>
       </div>
 
-      <div className="bg-white dark:bg-gray-800 rounded-2xl shadow-lg border border-gray-100 dark:border-gray-700 p-6">
+      <div className="bg-white dark:bg-gray-800 rounded-lg border border-line dark:border-gray-700 p-6">
         <div className="flex flex-wrap items-baseline justify-between gap-2 mb-1">
           <h2 className="text-lg font-semibold text-theme-heading dark:text-white">
             Where the money sits
           </h2>
-          <span className="text-xs text-gray-400 dark:text-gray-500">Current balances</span>
+          <span className="text-dense text-gray-400 dark:text-gray-500">Current balances</span>
         </div>
         {/* The count comes from the slices themselves, never the cap: with
             three accounts in credit this must not claim five. */}
-        <p className="text-sm text-gray-500 dark:text-gray-400 mb-4">
+        <p className="text-body text-gray-500 dark:text-gray-400 mb-4">
           {distribution.slices.length === 1
             ? 'The one account in credit'
             : `The ${distribution.slices.length} largest accounts in credit`}
@@ -122,10 +122,10 @@ export default function AccountDistributionReport(): React.JSX.Element {
         )}
       </div>
 
-      <div className="bg-white dark:bg-gray-800 rounded-2xl shadow-lg border border-gray-100 dark:border-gray-700">
+      <div className="bg-white dark:bg-gray-800 rounded-lg border border-line dark:border-gray-700">
         <div className="p-6 pb-3">
           <h2 className="text-lg font-semibold text-theme-heading dark:text-white">Every account</h2>
-          <p className="text-sm text-gray-500 dark:text-gray-400 mt-1">
+          <p className="text-body text-gray-500 dark:text-gray-400 mt-1">
             Ranked by what it holds now. Click an account to see its transactions.
           </p>
         </div>
@@ -135,7 +135,7 @@ export default function AccountDistributionReport(): React.JSX.Element {
         ) : (
           /* The table scrolls inside its own box; the page never scrolls sideways. */
           <div className="overflow-x-auto rounded-b-2xl">
-            <table className="min-w-full text-sm">
+            <table className="min-w-full text-body">
               <caption className="sr-only">
                 Every account ranked by its current balance, with each account&apos;s share of the total held in credit
               </caption>
@@ -160,7 +160,7 @@ export default function AccountDistributionReport(): React.JSX.Element {
                         />
                         <Link
                           to={transactionsHref(entry.id)}
-                          className="text-sm text-gray-900 dark:text-white hover:text-blue-700 dark:hover:text-blue-400 hover:underline rounded"
+                          className="text-body text-gray-900 dark:text-white hover:text-blue-700 dark:hover:text-blue-400 hover:underline rounded"
                           title={`${entry.name} — view these transactions`}
                         >
                           {entry.name}
@@ -168,13 +168,13 @@ export default function AccountDistributionReport(): React.JSX.Element {
                       </span>
                     </th>
                     <td
-                      className={`px-4 py-2 text-sm text-right font-semibold tabular-nums whitespace-nowrap ${
+                      className={`px-4 py-2 text-body text-right font-semibold tabular-nums whitespace-nowrap ${
                         entry.value < 0 ? 'text-red-600 dark:text-red-400' : 'text-gray-900 dark:text-white'
                       }`}
                     >
                       {money(entry.value)}
                     </td>
-                    <td className="px-4 py-2 text-sm text-right tabular-nums text-gray-500 dark:text-gray-400">
+                    <td className="px-4 py-2 text-body text-right tabular-nums text-gray-500 dark:text-gray-400">
                       {shareOf(entry)}
                     </td>
                   </tr>
@@ -182,10 +182,10 @@ export default function AccountDistributionReport(): React.JSX.Element {
               </tbody>
               <tfoot className="border-t-2 border-gray-200 dark:border-gray-600">
                 <tr>
-                  <th scope="row" className="px-4 py-3 text-left text-sm font-semibold text-gray-900 dark:text-white">
+                  <th scope="row" className="px-4 py-3 text-left text-body font-semibold text-gray-900 dark:text-white">
                     Held in credit
                   </th>
-                  <td className="px-4 py-3 text-sm text-right font-bold tabular-nums text-gray-900 dark:text-white">
+                  <td className="px-4 py-3 text-body text-right font-bold tabular-nums text-gray-900 dark:text-white">
                     {money(distribution.inCreditTotal.toNumber())}
                   </td>
                   <td className="px-4 py-3" />
@@ -198,7 +198,7 @@ export default function AccountDistributionReport(): React.JSX.Element {
         {/* An overdrawn account has no share of a positive total, and saying so
             is better than printing a negative percentage nobody can read. */}
         {distribution.entries.some(entry => entry.value <= 0) && (
-          <p className="px-6 pb-6 pt-3 text-xs text-gray-500 dark:text-gray-400">
+          <p className="px-6 pb-6 pt-3 text-dense text-gray-500 dark:text-gray-400">
             Accounts holding nothing, or overdrawn, are listed with no share: a share of the money
             held is only meaningful for money held. The total above is what is in credit, so it is
             not your net worth — see the Net worth report for what you own less what you owe.


### PR DESCRIPTION
Second pair of the conversion pass — plus a recovery.

## ⚠️ First: #286 merged an empty squash

The Calendar dark-mode fix and the lint warning that went with it **never reached main**. I piped `git push`, so its failure was invisible; the PR's diff against main was empty, GitHub squashed it with the previous PR's subject, and merging it changed nothing. A later rebase then dropped the commit from the branch.

Both are recovered here (cherry-picked `8b512e6c`) and verified present: Calendar has its paired reds, `BankConnections` has its module-scope logger, lint is back to zero warnings. This time the push was verified by comparing local and remote SHAs rather than by reading a piped log.

## A correction to the audit

The audit says both report pages "render a navy slab with green 'assets' and red 'liabilities'". Both carry the navy slab; **only `AccountBalancesReport` has the colour pair.** `AccountDistributionReport`'s three figures are "Held in credit", "Accounts" (a count) and "Largest holding" — all neutral already. Its only green/red is a negative-value sign in a table, which is a sign, not a direction on a magnitude.

## What changed

- **The navy slab, both pages.** A navy first cell made one of three equal figures look like the important one and the other two like afterthoughts — the same reasoning that gave `NetWorthSummary` one card, three columns and a hairline. All three cells now match, and the white-on-navy captions took the ordinary label ink with them.
- **Item 2, `AccountBalancesReport` only.** "In credit" and "Overdrawn / owed" are **quantities**: nothing went anywhere to earn a colour, and the labels already say which is which. Both are now `text-primary`.
- **Items 1 and 4, both pages.** `rounded-2xl shadow-lg` → hairline at radius 8; the six-size scale throughout.

## What keeps its colour, deliberately

The balances table's `moneyIn` (green) and `moneyOut` (red) are **flows** — the app's core convention — and `change` is a **delta**, the one case the ruling preserves those colours for. Neither is a magnitude wearing a direction, so neither was touched.

## Not converted to the shared summary card

`NetWorthSummary` would fit the three figures, but its labels are fixed ("Net worth / What you own / What you owe") and it has no slot for this report's "As at &lt;date&gt;". Swapping it in would change wording and lose information — a design decision rather than a mechanical one.

6188 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
