### PR TITLE
Investments and Export Data join the design pass

### DIFF
--- a/src/pages/ExportManager.tsx
+++ b/src/pages/ExportManager.tsx
@@ -277,11 +277,11 @@ export default function ExportManager(): React.JSX.Element {
     <PageWrapper title="Export Data">
       <div className="max-w-7xl mx-auto">
         {/* Header */}
-        <div className="bg-[#1a2332] dark:bg-gray-800 rounded-2xl p-6 mb-6 text-white shadow-lg">
+        <div className="bg-white dark:bg-gray-800 border border-line dark:border-gray-700 rounded-lg p-6 mb-6">
           <div className="flex items-center justify-between">
             <div>
-              <h1 className="text-3xl font-bold mb-2">Export Data</h1>
-              <p className="text-white/70">
+              <h1 className="text-page font-semibold mb-2 text-gray-900 dark:text-white">Export Data</h1>
+              <p className="text-body text-gray-500 dark:text-gray-400">
                 Generate reports, export to Excel, and save reusable export templates
               </p>
             </div>
@@ -295,7 +295,7 @@ export default function ExportManager(): React.JSX.Element {
             <nav className="flex space-x-8 overflow-x-auto">
               <button
                 onClick={() => setActiveTab('export')}
-                className={`py-4 px-6 border-b-2 font-medium text-sm whitespace-nowrap ${
+                className={`py-4 px-6 border-b-2 font-medium text-body whitespace-nowrap ${
                   activeTab === 'export'
                     ? 'border-[var(--color-primary)] text-[var(--color-primary)]'
                     : 'border-transparent text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-300'
@@ -308,7 +308,7 @@ export default function ExportManager(): React.JSX.Element {
               </button>
               <button
                 onClick={() => setActiveTab('templates')}
-                className={`py-4 px-6 border-b-2 font-medium text-sm whitespace-nowrap ${
+                className={`py-4 px-6 border-b-2 font-medium text-body whitespace-nowrap ${
                   activeTab === 'templates'
                     ? 'border-[var(--color-primary)] text-[var(--color-primary)]'
                     : 'border-transparent text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-300'
@@ -329,12 +329,12 @@ export default function ExportManager(): React.JSX.Element {
             {/* Export Options */}
             <div className="lg:col-span-2 space-y-6">
               <div className="bg-white dark:bg-gray-800 rounded-lg shadow-sm p-6">
-                <h3 className="text-lg font-semibold text-gray-900 dark:text-white mb-4">Export Options</h3>
+                <h3 className="text-card font-semibold text-gray-900 dark:text-white mb-4">Export Options</h3>
 
                 {/* Period — the same control, and the same meaning, as every
                     report in the app. */}
                 <div className="mb-6">
-                  <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
+                  <label className="block text-body font-medium text-gray-700 dark:text-gray-300 mb-2">
                     Period
                   </label>
                   <PeriodPicker picker={picker} label="Export period" />
@@ -344,7 +344,7 @@ export default function ExportManager(): React.JSX.Element {
                 <div className="mb-6 max-w-sm">
                   <label
                     htmlFor="export-format"
-                    className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2"
+                    className="block text-body font-medium text-gray-700 dark:text-gray-300 mb-2"
                   >
                     Format
                   </label>
@@ -367,7 +367,7 @@ export default function ExportManager(): React.JSX.Element {
 
                 {/* Include Options */}
                 <div>
-                  <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-3">
+                  <label className="block text-body font-medium text-gray-700 dark:text-gray-300 mb-3">
                     Include in Export
                   </label>
                   <div className="grid grid-cols-2 md:grid-cols-3 gap-2">
@@ -405,7 +405,7 @@ export default function ExportManager(): React.JSX.Element {
                         }`}>
                           {checked && <CheckIcon size={12} />}
                         </div>
-                        <span className="text-sm text-gray-700 dark:text-gray-300">{label}</span>
+                        <span className="text-body text-gray-700 dark:text-gray-300">{label}</span>
                       </button>
                     ))}
                   </div>
@@ -415,7 +415,7 @@ export default function ExportManager(): React.JSX.Element {
                       a hard-coded empty list, budgets were never passed at all,
                       and "Charts" printed the sentence "Charts would be rendered
                       here from DOM elements" into the PDF. */}
-                  <p className="text-sm text-gray-600 dark:text-gray-400 mt-3">
+                  <p className="text-body text-gray-600 dark:text-gray-400 mt-3">
                     {interchange
                       ? 'QIF and OFX describe transactions grouped under the accounts they belong to, so both are always included — and only accounts with transactions in this period are named, to avoid creating empty ones wherever you import the file.'
                       : format === 'csv'
@@ -470,8 +470,8 @@ export default function ExportManager(): React.JSX.Element {
                   financial life on their disk. Both facts need saying where
                   the button is, not in a tooltip. */}
               <div className="bg-white dark:bg-gray-800 rounded-lg shadow-sm p-6">
-                <h3 className="text-lg font-semibold text-gray-900 dark:text-white">Full backup</h3>
-                <p className="text-sm text-gray-600 dark:text-gray-400 mt-1 mb-4">
+                <h3 className="text-card font-semibold text-gray-900 dark:text-white">Full backup</h3>
+                <p className="text-body text-gray-600 dark:text-gray-400 mt-1 mb-4">
                   {capabilities.edition === 'cloud'
                     ? 'Every record we hold for you, straight from the database — accounts, transactions, splits, categories, budgets, goals, investments and the rest.'
                     : 'Everything this browser is holding — accounts, transactions, splits, categories, budgets and goals. Nothing here has been sent anywhere, so this file is the only copy that exists.'}
@@ -481,7 +481,7 @@ export default function ExportManager(): React.JSX.Element {
 
                 <div className="rounded-xl border border-amber-200 dark:border-amber-800 bg-amber-50 dark:bg-amber-900/20 p-3 mb-4 flex items-start gap-3">
                   <AlertTriangleIcon className="text-amber-600 dark:text-amber-400 mt-0.5 shrink-0" size={18} />
-                  <p className="text-sm text-amber-900 dark:text-amber-200">
+                  <p className="text-body text-amber-900 dark:text-amber-200">
                     This file is plain, readable JSON and it is <strong>not encrypted</strong>. Anyone who
                     opens it can see every account name, balance and transaction you have. Keep it
                     somewhere you would be willing to keep a bank statement — not a shared drive, not a
@@ -502,14 +502,14 @@ export default function ExportManager(): React.JSX.Element {
                     the button reports what it is on rather than sitting silent
                     long enough to look broken. */}
                 {backupProgress && (
-                  <p className="text-sm text-gray-600 dark:text-gray-400 mt-3" aria-live="polite">
+                  <p className="text-body text-gray-600 dark:text-gray-400 mt-3" aria-live="polite">
                     {backupProgress.entity.replace(/_/g, ' ')} ({backupProgress.entityNumber} of{' '}
                     {backupProgress.entityCount}) — {backupProgress.rows.toLocaleString()} rows
                   </p>
                 )}
 
                 {backupError && (
-                  <p className="text-sm text-red-600 dark:text-red-400 mt-3">
+                  <p className="text-body text-red-600 dark:text-red-400 mt-3">
                     The backup stopped and no file was written: {backupError}
                   </p>
                 )}
@@ -519,8 +519,8 @@ export default function ExportManager(): React.JSX.Element {
             {/* Preview — a description of the FILE, not of the dataset. Every
                 figure here comes from the same selection the export writes. */}
             <div className="bg-white dark:bg-gray-800 rounded-lg shadow-sm p-6 self-start">
-              <h3 className="text-lg font-semibold text-gray-900 dark:text-white mb-4">Preview</h3>
-              <div className="space-y-3 text-sm">
+              <h3 className="text-card font-semibold text-gray-900 dark:text-white mb-4">Preview</h3>
+              <div className="space-y-3 text-body">
                 <div className="flex justify-between gap-4">
                   <span className="text-gray-600 dark:text-gray-400">Period:</span>
                   <span className="text-gray-900 dark:text-white text-right">{rangeDescription}</span>
@@ -544,7 +544,7 @@ export default function ExportManager(): React.JSX.Element {
               </div>
 
               {!hasSomethingToExport && (
-                <p className="text-sm text-amber-700 dark:text-amber-300 mt-4">
+                <p className="text-body text-amber-700 dark:text-amber-300 mt-4">
                   Nothing falls in this period with these options, so there is no file to write.
                 </p>
               )}
@@ -557,7 +557,7 @@ export default function ExportManager(): React.JSX.Element {
           <div className="bg-white dark:bg-gray-800 rounded-lg shadow-sm">
             <div className="p-6 border-b border-gray-200 dark:border-gray-700">
               <div className="flex items-center justify-between">
-                <h3 className="text-lg font-semibold text-gray-900 dark:text-white">Export Templates</h3>
+                <h3 className="text-card font-semibold text-gray-900 dark:text-white">Export Templates</h3>
                 <button
                   onClick={() => setActiveTab('export')}
                   className="flex items-center gap-2 px-4 py-2 bg-[var(--color-primary)] text-white rounded-lg hover:bg-[var(--color-primary)]/90"
@@ -573,7 +573,7 @@ export default function ExportManager(): React.JSX.Element {
                 <div className="text-center py-8">
                   <FileTextIcon size={48} className="mx-auto mb-4 text-gray-400" />
                   <p className="text-gray-500 dark:text-gray-400">No templates</p>
-                  <p className="text-sm text-gray-400 dark:text-gray-500 mt-2">
+                  <p className="text-body text-gray-400 dark:text-gray-500 mt-2">
                     Set up an export the way you like it, then use Save as Template on the Quick Export tab.
                   </p>
                 </div>
@@ -587,7 +587,7 @@ export default function ExportManager(): React.JSX.Element {
                           {/* A label, not a lock: these came with the app, and
                               they delete like any other. */}
                           {template.isStarter && (
-                            <span className="ml-2 text-xs bg-blue-100 text-blue-800 dark:bg-blue-900/20 dark:text-blue-200 px-2 py-1 rounded">
+                            <span className="ml-2 text-dense bg-blue-100 text-blue-800 dark:bg-blue-900/20 dark:text-blue-200 px-2 py-1 rounded">
                               Starter
                             </span>
                           )}
@@ -611,10 +611,10 @@ export default function ExportManager(): React.JSX.Element {
                           </button>
                         </div>
                       </div>
-                      <p className="text-sm text-gray-600 dark:text-gray-400 mb-3">
+                      <p className="text-body text-gray-600 dark:text-gray-400 mb-3">
                         {template.description}
                       </p>
-                      <div className="text-xs text-gray-500 dark:text-gray-400 space-y-1">
+                      <div className="text-dense text-gray-500 dark:text-gray-400 space-y-1">
                         <div>Format: {template.options.format.toUpperCase()}</div>
                         {/* The period is stored as a RULE, so it says what it
                             will do next time — not what it did in the month it

--- a/src/pages/Investments.tsx
+++ b/src/pages/Investments.tsx
@@ -244,18 +244,18 @@ export default function Investments() {
     return (
       <div>
         <div className="bg-secondary dark:bg-gray-700 rounded-2xl shadow p-4 mb-6">
-          <h1 className="text-3xl font-bold text-white">Investments</h1>
+          <h1 className="text-display font-bold text-white">Investments</h1>
         </div>
         
-        <div className="bg-white dark:bg-gray-800 rounded-2xl shadow-lg border border-gray-100 dark:border-gray-700 p-8 text-center">
+        <div className="bg-white dark:bg-gray-800 rounded-lg border border-line dark:border-gray-700 p-8 text-center">
           <BarChart3Icon className="mx-auto text-gray-400 mb-4" size={64} />
-          <h2 className="text-xl font-semibold text-theme-heading dark:text-white mb-2">
+          <h2 className="text-card font-semibold text-theme-heading dark:text-white mb-2">
             No Investment Accounts Yet
           </h2>
           <p className="text-gray-600 dark:text-gray-400 mb-4">
             Add an investment account to start tracking your portfolio performance.
           </p>
-          <p className="text-sm text-gray-500 dark:text-gray-500">
+          <p className="text-body text-gray-500 dark:text-gray-500">
             Go to Accounts → Add Account → Choose "Investment" as the account type
           </p>
         </div>
@@ -311,7 +311,7 @@ export default function Investments() {
       <div className="flex space-x-1 bg-gray-100 dark:bg-gray-700 p-1 rounded-lg mb-6">
         <button
           onClick={() => setActiveTab('overview')}
-          className={`flex-1 flex items-center justify-center gap-2 px-4 py-2 text-sm font-medium rounded-md transition-colors ${
+          className={`flex-1 flex items-center justify-center gap-2 px-4 py-2 text-body font-medium rounded-md transition-colors ${
             activeTab === 'overview'
               ? 'bg-white dark:bg-gray-600 text-gray-900 dark:text-white shadow-sm'
               : 'text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-300'
@@ -322,7 +322,7 @@ export default function Investments() {
         </button>
         <button
           onClick={() => setActiveTab('watchlist')}
-          className={`flex-1 flex items-center justify-center gap-2 px-4 py-2 text-sm font-medium rounded-md transition-colors ${
+          className={`flex-1 flex items-center justify-center gap-2 px-4 py-2 text-body font-medium rounded-md transition-colors ${
             activeTab === 'watchlist'
               ? 'bg-white dark:bg-gray-600 text-gray-900 dark:text-white shadow-sm'
               : 'text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-300'
@@ -333,7 +333,7 @@ export default function Investments() {
         </button>
         <button
           onClick={() => setActiveTab('portfolio')}
-          className={`flex-1 flex items-center justify-center gap-2 px-4 py-2 text-sm font-medium rounded-md transition-colors ${
+          className={`flex-1 flex items-center justify-center gap-2 px-4 py-2 text-body font-medium rounded-md transition-colors ${
             activeTab === 'portfolio'
               ? 'bg-white dark:bg-gray-600 text-gray-900 dark:text-white shadow-sm'
               : 'text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-300'
@@ -344,7 +344,7 @@ export default function Investments() {
         </button>
         <button
           onClick={() => setActiveTab('manage')}
-          className={`flex-1 flex items-center justify-center gap-2 px-4 py-2 text-sm font-medium rounded-md transition-colors ${
+          className={`flex-1 flex items-center justify-center gap-2 px-4 py-2 text-body font-medium rounded-md transition-colors ${
             activeTab === 'manage'
               ? 'bg-white dark:bg-gray-600 text-gray-900 dark:text-white shadow-sm'
               : 'text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-300'
@@ -360,11 +360,11 @@ export default function Investments() {
         <div className="grid gap-6">
         {/* Summary Cards */}
         <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6">
-        <div className="bg-white dark:bg-gray-800 rounded-2xl shadow-lg border border-gray-100 dark:border-gray-700 p-6">
+        <div className="bg-white dark:bg-gray-800 rounded-lg border border-line dark:border-gray-700 p-6">
           <div className="flex items-center justify-between">
             <div>
-              <p className="text-sm text-gray-500 dark:text-gray-400">Portfolio Value</p>
-              <p className="text-2xl font-bold text-gray-900 dark:text-white">
+              <p className="text-body text-gray-500 dark:text-gray-400">Portfolio Value</p>
+              <p className="text-page font-bold text-gray-900 dark:text-white">
                 {formatCurrency(summary.value)}
               </p>
             </div>
@@ -372,14 +372,14 @@ export default function Investments() {
           </div>
         </div>
 
-        <div className="bg-white dark:bg-gray-800 rounded-2xl shadow-lg border border-gray-100 dark:border-gray-700 p-6">
+        <div className="bg-white dark:bg-gray-800 rounded-lg border border-line dark:border-gray-700 p-6">
           <div className="flex items-center justify-between">
             <div>
-              <p className="text-sm text-gray-500 dark:text-gray-400">Net Contributions</p>
-              <p className="text-2xl font-bold text-blue-700 dark:text-blue-400">
+              <p className="text-body text-gray-500 dark:text-gray-400">Net Contributions</p>
+              <p className="text-page font-bold text-blue-700 dark:text-blue-400">
                 {formatCurrency(summary.netContributions)}
               </p>
-              <p className="text-xs text-gray-500 dark:text-gray-400 mt-1">
+              <p className="text-dense text-gray-500 dark:text-gray-400 mt-1">
                 Transferred in, less transferred out
               </p>
             </div>
@@ -387,11 +387,11 @@ export default function Investments() {
           </div>
         </div>
 
-        <div className="bg-white dark:bg-gray-800 rounded-2xl shadow-lg border border-gray-100 dark:border-gray-700 p-6">
+        <div className="bg-white dark:bg-gray-800 rounded-lg border border-line dark:border-gray-700 p-6">
           <div className="flex items-center justify-between">
             <div>
-              <p className="text-sm text-gray-500 dark:text-gray-400">Total Return</p>
-              <p className={`text-2xl font-bold ${isGain ? 'text-green-600 dark:text-green-400' : 'text-red-600 dark:text-red-400'}`}>
+              <p className="text-body text-gray-500 dark:text-gray-400">Total Return</p>
+              <p className={`text-page font-bold ${isGain ? 'text-green-600 dark:text-green-400' : 'text-red-600 dark:text-red-400'}`}>
                 {isGain ? '+' : ''}{formatCurrency(summary.totalReturn)}
               </p>
             </div>
@@ -399,19 +399,19 @@ export default function Investments() {
           </div>
         </div>
 
-        <div className="bg-white dark:bg-gray-800 rounded-2xl shadow-lg border border-gray-100 dark:border-gray-700 p-6">
+        <div className="bg-white dark:bg-gray-800 rounded-lg border border-line dark:border-gray-700 p-6">
           <div className="flex items-center justify-between">
             <div>
-              <p className="text-sm text-gray-500 dark:text-gray-400">Return %</p>
+              <p className="text-body text-gray-500 dark:text-gray-400">Return %</p>
               {summary.returnPercent === null ? (
                 <>
-                  <p className="text-2xl font-bold text-gray-500 dark:text-gray-400">—</p>
-                  <p className="text-xs text-gray-500 dark:text-gray-400 mt-1">
+                  <p className="text-page font-bold text-gray-500 dark:text-gray-400">—</p>
+                  <p className="text-dense text-gray-500 dark:text-gray-400 mt-1">
                     No contributions to measure a return against
                   </p>
                 </>
               ) : (
-                <p className={`text-2xl font-bold ${isGain ? 'text-green-600 dark:text-green-400' : 'text-red-600 dark:text-red-400'}`}>
+                <p className={`text-page font-bold ${isGain ? 'text-green-600 dark:text-green-400' : 'text-red-600 dark:text-red-400'}`}>
                   {isGain ? '+' : ''}{formatPercentage(summary.returnPercent)}
                 </p>
               )}
@@ -432,8 +432,8 @@ export default function Investments() {
             with it, not how many rows there are — and renders nothing at all
             when every transfer is accounted for. */}
         {summary.unattributedTransfers.count > 0 && (
-          <div className="bg-amber-50 dark:bg-amber-900/20 border border-amber-200 dark:border-amber-800 rounded-2xl p-4">
-            <p className="text-sm text-amber-900 dark:text-amber-200">
+          <div className="rounded-lg p-4">
+            <p className="text-body text-gray-500 dark:text-gray-400">
               {formatCurrency(summary.unattributedTransfers.amount)} of transfers in and out of
               these accounts have no matching row in another account, so they are counted as
               money from outside. Any that were moves within the portfolio make Net Contributions
@@ -443,15 +443,15 @@ export default function Investments() {
         )}
 
         {/* Performance Chart */}
-        <div className="bg-white dark:bg-gray-800 rounded-2xl shadow-lg border border-gray-100 dark:border-gray-700 p-6">
+        <div className="bg-white dark:bg-gray-800 rounded-lg border border-line dark:border-gray-700 p-6">
         <div className="flex justify-between items-center mb-4">
-          <h2 className="text-xl font-semibold text-theme-heading dark:text-white">Portfolio Performance</h2>
+          <h2 className="text-card font-semibold text-theme-heading dark:text-white">Portfolio Performance</h2>
           <div className="flex gap-2">
             {['1M', '3M', '6M', '1Y', 'ALL'].map((period) => (
               <button
                 key={period}
                 onClick={() => setSelectedPeriod(period as '1M' | '3M' | '6M' | '1Y' | 'ALL')}
-                className={`px-3 py-1 text-sm rounded-lg transition-colors ${
+                className={`px-3 py-1 text-body rounded-lg transition-colors ${
                   selectedPeriod === period
                     ? 'bg-[#1a2332] text-white'
                     : 'bg-gray-100 dark:bg-gray-700 text-gray-700 dark:text-gray-300 hover:bg-gray-200 dark:hover:bg-gray-600'
@@ -504,8 +504,8 @@ export default function Investments() {
         {/* Holdings */}
         <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
         {/* Holdings List */}
-        <div className="bg-white dark:bg-gray-800 rounded-2xl shadow-lg border border-gray-100 dark:border-gray-700 p-6">
-          <h2 className="text-xl font-semibold mb-4 text-theme-heading dark:text-white">Holdings</h2>
+        <div className="bg-white dark:bg-gray-800 rounded-lg border border-line dark:border-gray-700 p-6">
+          <h2 className="text-card font-semibold mb-4 text-theme-heading dark:text-white">Holdings</h2>
           {portfolioLines.length === 0 ? (
             <p className="text-gray-500 dark:text-gray-400 text-center py-8">
               No holdings to display
@@ -531,7 +531,7 @@ export default function Investments() {
                           <h3 className="font-medium text-gray-900 dark:text-white">
                             {line.name}
                           </h3>
-                          <p className="text-sm text-gray-500 dark:text-gray-400">
+                          <p className="text-body text-gray-500 dark:text-gray-400">
                             {line.institution || 'N/A'}
                           </p>
                         </div>
@@ -546,7 +546,7 @@ export default function Investments() {
                     {line.cash.map(cash => (
                       <p
                         key={cash.accountId}
-                        className="ml-5 mb-2 flex justify-between text-xs text-gray-500 dark:text-gray-400"
+                        className="ml-5 mb-2 flex justify-between text-dense text-gray-500 dark:text-gray-400"
                       >
                         <span>{cash.label}</span>
                         <span className="tabular-nums">{formatCurrency(cash.value)}</span>
@@ -565,7 +565,7 @@ export default function Investments() {
                           }}
                         />
                       </div>
-                      <span className="text-sm text-gray-600 dark:text-gray-400 w-12 text-right">
+                      <span className="text-body text-gray-600 dark:text-gray-400 w-12 text-right">
                         {formatPercentage(line.allocation)}
                       </span>
                     </div>
@@ -577,8 +577,8 @@ export default function Investments() {
         </div>
 
         {/* Allocation Chart */}
-        <div className="bg-white dark:bg-gray-800 rounded-2xl shadow-lg border border-gray-100 dark:border-gray-700 p-6">
-          <h2 className="text-xl font-semibold mb-4 text-theme-heading dark:text-white">Asset Allocation</h2>
+        <div className="bg-white dark:bg-gray-800 rounded-lg border border-line dark:border-gray-700 p-6">
+          <h2 className="text-card font-semibold mb-4 text-theme-heading dark:text-white">Asset Allocation</h2>
           {portfolioLines.length === 0 ? (
             <p className="text-gray-500 dark:text-gray-400 text-center py-8">
               No data to display
@@ -614,7 +614,7 @@ export default function Investments() {
               </div>
               <div className="mt-4 space-y-2">
                 {portfolioLines.map((line, index) => (
-                  <div key={line.accountId} className="flex items-center justify-between text-sm">
+                  <div key={line.accountId} className="flex items-center justify-between text-body">
                     <div className="flex items-center gap-2">
                       <div
                         className="w-3 h-3 rounded-full"
@@ -634,12 +634,12 @@ export default function Investments() {
         </div>
 
         {/* Investment Tips */}
-        <div className="bg-blue-50 dark:bg-blue-900/20 border border-blue-200 dark:border-blue-800 rounded-2xl p-6">
+        <div className="bg-white dark:bg-gray-800 border border-line dark:border-gray-700 rounded-lg p-6">
           <div className="flex items-start gap-3">
             <AlertCircleIcon className="text-blue-700 dark:text-blue-400 mt-1" size={20} />
             <div>
               <h3 className="font-semibold text-blue-900 dark:text-blue-300 mb-2">How these figures are worked out</h3>
-              <ul className="text-sm text-blue-800 dark:text-blue-200 space-y-1">
+              <ul className="text-body text-blue-800 dark:text-blue-200 space-y-1">
                 <li>• A line is worth the investment account plus any cash account paired with it — set the pairing in Account Settings → Part of investment account</li>
                 <li>• Money transferred in from elsewhere counts as a contribution; moving money between an investment account and its own cash does not</li>
                 <li>• Total Return is what the portfolio is worth today less what was put into it</li>
@@ -667,23 +667,23 @@ export default function Investments() {
         <div className="space-y-6">
           {holdingsError && (
             <div role="alert" className="bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-2xl p-4">
-              <p className="text-sm text-red-700 dark:text-red-300">{holdingsError}</p>
+              <p className="text-body text-red-700 dark:text-red-300">{holdingsError}</p>
             </div>
           )}
 
           {investmentAccounts.map((account) => {
             const accountHoldings = holdingsByAccount.get(account.id) ?? [];
             return (
-              <div key={account.id} className="bg-white dark:bg-gray-800 rounded-2xl shadow-lg border border-gray-100 dark:border-gray-700 p-6">
+              <div key={account.id} className="bg-white dark:bg-gray-800 rounded-lg border border-line dark:border-gray-700 p-6">
                 <div className="flex flex-wrap justify-between items-center gap-2 mb-4">
-                  <h3 className="text-lg font-semibold text-gray-900 dark:text-white">{account.name}</h3>
+                  <h3 className="text-card font-semibold text-gray-900 dark:text-white">{account.name}</h3>
                   <button
                     type="button"
                     onClick={() => {
                       setManagingAccountId(account.id);
                       setActiveTab('manage');
                     }}
-                    className="text-sm text-primary hover:text-secondary transition-colors"
+                    className="text-body text-primary hover:text-secondary transition-colors"
                   >
                     Manage holdings →
                   </button>
@@ -712,13 +712,13 @@ export default function Investments() {
         <div className="space-y-6">
           {holdingsError && (
             <div role="alert" className="bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-2xl p-4">
-              <p className="text-sm text-red-700 dark:text-red-300">{holdingsError}</p>
+              <p className="text-body text-red-700 dark:text-red-300">{holdingsError}</p>
             </div>
           )}
 
           {/* Account Selector */}
-          <div className="bg-white dark:bg-gray-800 rounded-2xl shadow-lg border border-gray-100 dark:border-gray-700 p-4">
-            <label htmlFor="manage-account" className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
+          <div className="bg-white dark:bg-gray-800 rounded-lg border border-line dark:border-gray-700 p-4">
+            <label htmlFor="manage-account" className="block text-body font-medium text-gray-700 dark:text-gray-300 mb-2">
               Select investment account
             </label>
             <select
@@ -739,7 +739,7 @@ export default function Investments() {
             if (!account) return null;
 
             return (
-              <div className="bg-white dark:bg-gray-800 rounded-2xl shadow-lg border border-gray-100 dark:border-gray-700 p-6">
+              <div className="bg-white dark:bg-gray-800 rounded-lg border border-line dark:border-gray-700 p-6">
                 <PortfolioManager
                   holdings={holdingsByAccount.get(account.id) ?? []}
                   currency={account.currency}


### PR DESCRIPTION
Third pair of the conversion queue. You said not to hold Investments for the screenshots — items 1–5 are decided and independent of anything a capture would show — so it went now.

## Investments: the three tinted panels, classified

Your §7.3 left this open pending what the panels actually **say**. Read, and your bet was right on the first:

- **The amber panel is a caveat.** *"X of transfers have no matching row in another account … make Net Contributions too big and Total Return too small"* is a standing statement about what these figures cannot account for, and no control ends it. Neutral text, same treatment as Budget's currency note.
- **"Investment Tips" is a tinted panel** — item 3, white with a hairline.
- **The red panel is a genuine error** — `holdingsError` under `role="alert"`, a transient failure. Your ruling says an error takes the error pair rather than amber or neutral, so it is **correct as it stands** and was not touched.

Two of the three needed changing; the third needed reading.

Plus eleven cards to the hairline and the whole page onto the six-size scale.

**What keeps its colour:** `isGain ? green : red` on total return is a **delta**, the one case the ruling preserves. The `bg-[#1a2332]` at the period selector is a pressed **tab**, not a slab — a control may look pressed.

## Export Data: the navy slab

The page-header slab becomes the hairline card and its white-on-navy text takes the ordinary ink. The other two hits are a checkbox and a selected row — control states, which stay for the same reason.

## ⚠️ One thing not converted, and flagged rather than decided

Export Data carries an amber panel saying the backup file **"is not encrypted. Anyone who opens it can see every account name, balance and transaction you have."**

By the letter of §7.2 that is a caveat — nothing pressable ends it — and caveats take neutral text.

But every caveat we have neutralised so far was about **data completeness** ("this figure leaves out other currencies"). This one is about **user harm**, and it already says the consequence and the remedy in exactly the form the principles ask for.

Quietening a security notice to a grey footnote is not a call I should make by pattern-matching a rule written for a different species of sentence. Unchanged, and back to you as a question: **does the caveat rule reach a safety warning, or does that want its own treatment?**

6057 tests pass, lint and typecheck clean.

Remaining in the queue: Enhanced Import (navy slabs), then the settings sub-pages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
