### PR TITLE
Enhanced Import and App Settings join the design pass

### DIFF
--- a/src/pages/EnhancedImport.tsx
+++ b/src/pages/EnhancedImport.tsx
@@ -109,11 +109,11 @@ export default function EnhancedImport(): React.JSX.Element {
     <PageWrapper title="Import Data">
       <div className="max-w-6xl mx-auto">
         {/* Header */}
-        <div className="bg-[#1a2332] dark:bg-gray-800 rounded-2xl p-6 mb-6 text-white shadow-lg">
+        <div className="bg-white dark:bg-gray-800 border border-line dark:border-gray-700 rounded-lg p-6 mb-6">
           <div className="flex items-center justify-between">
             <div>
-              <h1 className="text-3xl font-bold mb-2">Import Data</h1>
-              <p className="text-white/70">
+              <h1 className="text-page font-semibold mb-2 text-gray-900 dark:text-white">Import Data</h1>
+              <p className="text-body text-gray-500 dark:text-gray-400">
                 Every way to bring your data in — a full Microsoft Money migration, your own backup file,
                 bank files, or another app.
               </p>
@@ -132,7 +132,7 @@ export default function EnhancedImport(): React.JSX.Element {
           </span>
           <span className="min-w-0">
             <span className="block font-semibold text-gray-900 dark:text-white">Import from Microsoft Money</span>
-            <span className="block text-sm text-gray-500 dark:text-gray-400">
+            <span className="block text-body text-gray-500 dark:text-gray-400">
               Migrate your entire <code>.mny</code> file — every account, transaction and transfer. Replaces all current data.
             </span>
           </span>
@@ -153,12 +153,12 @@ export default function EnhancedImport(): React.JSX.Element {
           {/* Named as the button actually reads on the Export page, and as the
               restore dialog itself names it — a page and the dialog it opens
               must not send someone looking for two different buttons. */}
-          <p className="text-sm text-gray-600 dark:text-gray-400">
+          <p className="text-body text-gray-600 dark:text-gray-400">
             A restore reads back the JSON file from <strong>Manage &rarr; Export &rarr; &ldquo;Download full
             backup (JSON)&rdquo;</strong> — every account, transaction, budget and goal in one go. It is
             not a CSV, OFX or QIF import and it cannot read a bank statement.
           </p>
-          <p className="text-sm text-gray-600 dark:text-gray-400">
+          <p className="text-body text-gray-600 dark:text-gray-400">
             It only ever writes into an <strong>empty login</strong>. Unlike the Microsoft Money
             migration above, it will not replace what is already here: if this login holds data the
             restore stops and asks you to erase it first, which is a separate confirmation you type
@@ -216,7 +216,7 @@ export default function EnhancedImport(): React.JSX.Element {
           description="Rules that categorise and transform transactions as they come in."
         >
           <div className="flex items-center justify-between gap-4">
-            <p className="text-sm text-gray-600 dark:text-gray-400">
+            <p className="text-body text-gray-600 dark:text-gray-400">
               {activeRules.length > 0
                 ? `${activeRules.length} active rule${activeRules.length === 1 ? '' : 's'} run on every import.`
                 : 'No import rules yet — create one to auto-categorise incoming transactions.'}
@@ -233,21 +233,21 @@ export default function EnhancedImport(): React.JSX.Element {
 
         {/* Supported bank formats — reassurance that the file will be understood */}
         <div className="bg-white dark:bg-gray-800 rounded-2xl shadow-sm border border-gray-100 dark:border-gray-700 p-6">
-          <h3 className="text-lg font-semibold text-gray-900 dark:text-white mb-4">
+          <h3 className="text-card font-semibold text-gray-900 dark:text-white mb-4">
             Recognised bank formats ({bankFormats.length}+)
           </h3>
           <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-6 gap-3">
             {bankFormats.map(bank => (
               <div key={bank} className="flex items-center gap-2 p-2 bg-gray-50 dark:bg-gray-700 rounded-lg">
                 <GlobeIcon size={14} className="text-blue-700 dark:text-blue-400 flex-shrink-0" />
-                <span className="text-sm text-gray-700 dark:text-gray-300 truncate">{bank}</span>
+                <span className="text-body text-gray-700 dark:text-gray-300 truncate">{bank}</span>
               </div>
             ))}
           </div>
-          <div className="mt-4 p-4 bg-blue-50 dark:bg-blue-900/20 rounded-lg">
+          <div className="mt-4 p-4 bg-white dark:bg-gray-800 border border-line dark:border-gray-700 rounded-lg">
             <div className="flex items-start gap-3">
               <AlertCircleIcon size={20} className="text-blue-700 dark:text-blue-400 flex-shrink-0 mt-0.5" />
-              <div className="text-sm">
+              <div className="text-body">
                 <p className="text-blue-900 dark:text-blue-100 font-medium mb-1">Don't see your bank?</p>
                 <p className="text-blue-800 dark:text-blue-200">
                   Use CSV Import to map columns for any file, or create an import rule to transform data from any institution.
@@ -333,7 +333,7 @@ export default function EnhancedImport(): React.JSX.Element {
         <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50 p-4">
           <div className="bg-white dark:bg-gray-800 rounded-2xl w-full max-w-5xl max-h-[90vh] overflow-hidden">
             <div className="p-6 border-b border-gray-200 dark:border-gray-700 flex justify-between items-center">
-              <h2 className="text-xl font-semibold text-gray-900 dark:text-white">Import Rules & Transformations</h2>
+              <h2 className="text-card font-semibold text-gray-900 dark:text-white">Import Rules & Transformations</h2>
               <button
                 onClick={() => setShowRulesManager(false)}
                 className="p-2 hover:bg-gray-100 dark:hover:bg-gray-700 rounded-lg transition-colors text-gray-500 dark:text-gray-400"
@@ -362,8 +362,8 @@ function Section({ title, description, children }: {
 }) {
   return (
     <div className="bg-white dark:bg-gray-800 rounded-2xl shadow-sm border border-gray-100 dark:border-gray-700 p-6 mb-6">
-      <h3 className="text-lg font-semibold text-gray-900 dark:text-white">{title}</h3>
-      <p className="text-sm text-gray-500 dark:text-gray-400 mb-4">{description}</p>
+      <h3 className="text-card font-semibold text-gray-900 dark:text-white">{title}</h3>
+      <p className="text-body text-gray-500 dark:text-gray-400 mb-4">{description}</p>
       <div className="space-y-3">{children}</div>
     </div>
   );
@@ -382,8 +382,8 @@ function ActionButton({ icon: Icon, title, description, onClick }: {
         <Icon size={18} />
       </span>
       <span className="min-w-0">
-        <span className="block text-sm font-medium text-gray-900 dark:text-white">{title}</span>
-        <span className="block text-xs text-gray-500 dark:text-gray-400">{description}</span>
+        <span className="block text-body font-medium text-gray-900 dark:text-white">{title}</span>
+        <span className="block text-dense text-gray-500 dark:text-gray-400">{description}</span>
       </span>
     </button>
   );

--- a/src/pages/settings/AppSettings.tsx
+++ b/src/pages/settings/AppSettings.tsx
@@ -84,10 +84,10 @@ export default function AppSettings() {
       <BankFeedRefreshSettings />
 
       {/* Personal Information */}
-      <div className="bg-white dark:bg-gray-800 rounded-2xl shadow-lg border border-gray-100 dark:border-gray-700 p-6">
-        <h2 className="text-xl font-semibold text-theme-heading dark:text-white mb-4">Personal Information</h2>
+      <div className="bg-white dark:bg-gray-800 rounded-lg border border-line dark:border-gray-700 p-6">
+        <h2 className="text-card font-semibold text-theme-heading dark:text-white mb-4">Personal Information</h2>
         <div className="mb-6">
-          <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-3">
+          <label className="block text-body font-medium text-gray-700 dark:text-gray-300 mb-3">
             First Name
           </label>
           <input
@@ -97,7 +97,7 @@ export default function AppSettings() {
             placeholder="Enter your first name"
             className="w-full px-3 py-2 bg-white dark:bg-gray-800-sm border border-gray-300/50 dark:border-gray-600/50 rounded-xl focus:border-transparent dark:text-white"
           />
-          <p className="mt-2 text-sm text-gray-500 dark:text-gray-400">
+          <p className="mt-2 text-body text-gray-500 dark:text-gray-400">
             This will be used in the welcome message on your dashboard. Leave blank to use "User".
           </p>
         </div>
@@ -107,10 +107,10 @@ export default function AppSettings() {
       <LocaleSelector />
 
       {/* Base Currency */}
-      <div className="bg-white dark:bg-gray-800 rounded-2xl shadow-lg border border-gray-100 dark:border-gray-700 p-6">
+      <div className="bg-white dark:bg-gray-800 rounded-lg border border-line dark:border-gray-700 p-6">
         <div className="flex items-center gap-3 mb-4">
           <GlobeIcon className="text-gray-600 dark:text-gray-400" size={20} />
-          <h2 className="text-xl font-semibold text-theme-heading dark:text-white">Base Currency</h2>
+          <h2 className="text-card font-semibold text-theme-heading dark:text-white">Base Currency</h2>
         </div>
         <p className="text-gray-600 dark:text-gray-400 mb-4">
           Choose your preferred base currency for displaying your net worth and performing currency conversions
@@ -130,12 +130,12 @@ export default function AppSettings() {
       </div>
 
       {/* Appearance */}
-      <div className="bg-white dark:bg-gray-800 rounded-2xl shadow-lg border border-gray-100 dark:border-gray-700 p-6">
-        <h2 className="text-xl font-semibold text-theme-heading dark:text-white mb-4">Appearance</h2>
+      <div className="bg-white dark:bg-gray-800 rounded-lg border border-line dark:border-gray-700 p-6">
+        <h2 className="text-card font-semibold text-theme-heading dark:text-white mb-4">Appearance</h2>
         
         {/* Theme Selection */}
         <div className="mb-6">
-          <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-3">
+          <label className="block text-body font-medium text-gray-700 dark:text-gray-300 mb-3">
             Theme
           </label>
           <div className="grid grid-cols-3 gap-3">
@@ -161,7 +161,7 @@ export default function AppSettings() {
           <div className="mb-6 p-4 bg-gray-50 dark:bg-gray-700/50 rounded-lg">
             <div className="flex items-center gap-2 mb-3">
               <ClockIcon size={20} className="text-primary" />
-              <h3 className="text-sm font-medium text-gray-700 dark:text-gray-300">
+              <h3 className="text-body font-medium text-gray-700 dark:text-gray-300">
                 Schedule Settings
               </h3>
             </div>
@@ -174,31 +174,31 @@ export default function AppSettings() {
                   onChange={(e) => setThemeSchedule({ ...themeSchedule, enabled: e.target.checked })}
                   className="w-4 h-4 text-primary bg-gray-100 border-gray-300 rounded dark:bg-gray-700 dark:border-gray-600"
                 />
-                <span className="text-sm text-gray-700 dark:text-gray-300">Enable scheduling</span>
+                <span className="text-body text-gray-700 dark:text-gray-300">Enable scheduling</span>
               </label>
               
               {themeSchedule.enabled && (
                 <div className="grid grid-cols-2 gap-4 ml-7">
                   <div>
-                    <label className="block text-xs text-gray-600 dark:text-gray-400 mb-1">
+                    <label className="block text-dense text-gray-600 dark:text-gray-400 mb-1">
                       Light theme starts at
                     </label>
                     <input
                       type="time"
                       value={themeSchedule.lightStartTime}
                       onChange={(e) => setThemeSchedule({ ...themeSchedule, lightStartTime: e.target.value })}
-                      className="w-full px-3 py-2 bg-white dark:bg-gray-800-sm border border-gray-300/50 dark:border-gray-600/50 rounded-lg focus:border-transparent dark:text-white text-sm"
+                      className="w-full px-3 py-2 bg-white dark:bg-gray-800-sm border border-gray-300/50 dark:border-gray-600/50 rounded-lg focus:border-transparent dark:text-white text-body"
                     />
                   </div>
                   <div>
-                    <label className="block text-xs text-gray-600 dark:text-gray-400 mb-1">
+                    <label className="block text-dense text-gray-600 dark:text-gray-400 mb-1">
                       Dark theme starts at
                     </label>
                     <input
                       type="time"
                       value={themeSchedule.darkStartTime}
                       onChange={(e) => setThemeSchedule({ ...themeSchedule, darkStartTime: e.target.value })}
-                      className="w-full px-3 py-2 bg-white dark:bg-gray-800-sm border border-gray-300/50 dark:border-gray-600/50 rounded-lg focus:border-transparent dark:text-white text-sm"
+                      className="w-full px-3 py-2 bg-white dark:bg-gray-800-sm border border-gray-300/50 dark:border-gray-600/50 rounded-lg focus:border-transparent dark:text-white text-body"
                     />
                   </div>
                 </div>
@@ -209,8 +209,8 @@ export default function AppSettings() {
       </div>
 
       {/* Page Visibility */}
-      <div className="bg-white dark:bg-gray-800 rounded-2xl shadow-lg border border-gray-100 dark:border-gray-700 p-6">
-        <h2 className="text-xl font-semibold text-theme-heading dark:text-white mb-4">Page Visibility</h2>
+      <div className="bg-white dark:bg-gray-800 rounded-lg border border-line dark:border-gray-700 p-6">
+        <h2 className="text-card font-semibold text-theme-heading dark:text-white mb-4">Page Visibility</h2>
         <p className="text-gray-600 dark:text-gray-400 mb-6">
           Choose which pages appear in the navigation sidebar
         </p>
@@ -229,7 +229,7 @@ export default function AppSettings() {
                   />
                   <h3 className="font-medium text-gray-900 dark:text-white">{toggle.title}</h3>
                 </div>
-                <p className="text-sm text-gray-600 dark:text-gray-400 mt-1 ml-8">
+                <p className="text-body text-gray-600 dark:text-gray-400 mt-1 ml-8">
                   {toggle.description}
                 </p>
               </div>
@@ -243,7 +243,7 @@ export default function AppSettings() {
         </div>
 
         <div className="mt-6 p-4 bg-theme-accent dark:bg-gray-800/50 rounded-2xl">
-          <p className="text-sm text-theme-heading dark:text-gray-300">
+          <p className="text-body text-theme-heading dark:text-gray-300">
             <strong>Note:</strong> Hidden pages will not appear in the sidebar navigation but can still be accessed if you have a direct link.
           </p>
         </div>
@@ -257,12 +257,12 @@ export default function AppSettings() {
 
       {/* Goal Celebrations */}
       <div className="bg-white dark:bg-gray-800 rounded-2xl shadow p-6">
-        <h3 className="text-lg font-semibold text-gray-900 dark:text-white mb-4">Goal Celebrations</h3>
+        <h3 className="text-card font-semibold text-gray-900 dark:text-white mb-4">Goal Celebrations</h3>
         
         <div className="flex items-center justify-between">
           <div>
             <p className="font-medium text-gray-900 dark:text-white">Enable Celebrations</p>
-            <p className="text-sm text-gray-500 dark:text-gray-400">
+            <p className="text-body text-gray-500 dark:text-gray-400">
               Show confetti and celebration messages when you achieve your goals
             </p>
           </div>


### PR DESCRIPTION
Fourth pair. Import was the other half of your "Import and Export (navy slabs)"; App Settings is the first of the settings sub-pages, which you put last on the grounds that they are rarely visited and mostly forms — true, and also why they convert in one pass with nothing to decide.

## Enhanced Import

- The page-header **navy slab** becomes the hairline card, its white-on-navy text taking the ordinary ink — identical to Export Data's, since they were the same slab.
- The tinted blue **info panel** becomes white with a hairline.
- The whole page onto the six-size scale.

The big **"Import from Microsoft Money"** call-to-action keeps its navy tint and navy icon chip. It is a control, not a panel, and a control may look like one — the same distinction that kept Export Data's checkbox and selected row.

## App Settings

Four identical cards to the hairline, plus the type scale. The `bg-[#1a2332]/10` at line 148 is a **selected option**, so it stays for the reason above.

## Nothing here needed a ruling

Items 1 and 4, with one colour question that answered itself. That is what you meant by calling the queue a lint-and-fix job rather than a design job — and it is holding: the only decisions in the last two pairs were the Investments panel classification and the Export encryption notice, both of which came back to you rather than being guessed at.

6057 tests pass, lint and typecheck clean.

**Queue after this:** the remaining settings sub-pages, and the P8 sweep you approved ("nothing may speak until it knows") — which I have not started, and which wants its own pass since it is a behavioural audit rather than a class-name one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
