### PR TITLE
The settings sub-pages convert, three defects the pass shipped, and the P8 sweep

### DIFF
--- a/src/contexts/PreferencesContext.tsx
+++ b/src/contexts/PreferencesContext.tsx
@@ -44,9 +44,6 @@ interface PreferencesContextType {
   // Page visibility settings
   showInvestments: boolean;
   setShowInvestments: (value: boolean) => void;
-  // Goal celebrations
-  enableGoalCelebrations: boolean;
-  setEnableGoalCelebrations: (value: boolean) => void;
 }
 
 const PreferencesContext = createContext<PreferencesContextType | undefined>(undefined);
@@ -106,10 +103,6 @@ export function PreferencesProvider({ children }: { children: ReactNode }): Reac
     (): string => preferences.getItem('money_management_first_name') || ''
   );
 
-  const [enableGoalCelebrations, setEnableGoalCelebrations] = useState(
-    (): boolean => preferences.getItem('money_management_goal_celebrations') !== 'false'
-  );
-
   // Page visibility settings
   const [showInvestments, setShowInvestments] = useState(
     (): boolean => preferences.getItem('money_management_show_investments') !== 'false'
@@ -137,7 +130,6 @@ export function PreferencesProvider({ children }: { children: ReactNode }): Reac
       const storedTheme = preferences.getItem('money_management_theme');
       setTheme(isThemeChoice(storedTheme) ? storedTheme : 'light');
       setFirstName(preferences.getItem('money_management_first_name') || '');
-      setEnableGoalCelebrations(preferences.getItem('money_management_goal_celebrations') !== 'false');
       setShowInvestments(preferences.getItem('money_management_show_investments') !== 'false');
       setThemeSchedule(readThemeSchedule());
     });
@@ -245,13 +237,12 @@ export function PreferencesProvider({ children }: { children: ReactNode }): Reac
       preferences.setItem('money_management_first_name', firstName);
       preferences.setItem('money_management_show_investments', showInvestments.toString());
       preferences.setItem('money_management_theme_schedule', JSON.stringify(themeSchedule));
-      preferences.setItem('money_management_goal_celebrations', enableGoalCelebrations.toString());
     };
 
     const timeoutId = setTimeout(savePreferences, 300);
 
     return (): void => clearTimeout(timeoutId);
-  }, [compactView, currency, theme, firstName, showInvestments, themeSchedule, enableGoalCelebrations]);
+  }, [compactView, currency, theme, firstName, showInvestments, themeSchedule]);
 
   return (
     <PreferencesContext.Provider value={{
@@ -268,8 +259,6 @@ export function PreferencesProvider({ children }: { children: ReactNode }): Reac
       setThemeSchedule,
       showInvestments,
       setShowInvestments,
-      enableGoalCelebrations,
-      setEnableGoalCelebrations,
     }}>
       {children}
     </PreferencesContext.Provider>

--- a/src/pages/EnhancedImport.tsx
+++ b/src/pages/EnhancedImport.tsx
@@ -118,7 +118,9 @@ export default function EnhancedImport(): React.JSX.Element {
                 bank files, or another app.
               </p>
             </div>
-            <UploadIcon size={48} className="text-white/80" />
+            {/* Decorative — see ExportManager's twin. text-white/80 was invisible once
+                the navy slab became a white card. */}
+            <UploadIcon size={48} className="text-gray-300 dark:text-gray-600" />
           </div>
         </div>
 

--- a/src/pages/ExportManager.tsx
+++ b/src/pages/ExportManager.tsx
@@ -285,7 +285,10 @@ export default function ExportManager(): React.JSX.Element {
                 Generate reports, export to Excel, and save reusable export templates
               </p>
             </div>
-            <DownloadIcon size={48} className="text-white/80" />
+            {/* Decorative. Grey, not ink: the heading beside it already names the page,
+                and at 48px full-contrast ink would outweigh it. Was text-white/80 — correct
+                on the navy slab this card replaced, invisible on white. */}
+            <DownloadIcon size={48} className="text-gray-300 dark:text-gray-600" />
           </div>
         </div>
 

--- a/src/pages/Investments.tsx
+++ b/src/pages/Investments.tsx
@@ -243,8 +243,10 @@ export default function Investments() {
   if (investmentAccounts.length === 0) {
     return (
       <div>
-        <div className="bg-secondary dark:bg-gray-700 rounded-2xl shadow p-4 mb-6">
-          <h1 className="text-display font-bold text-white">Investments</h1>
+        {/* The conversion pass reached the populated page and not this branch, because an
+            early return is easy to read past. Same hairline card, same ink, as everywhere. */}
+        <div className="bg-white dark:bg-gray-800 rounded-lg border border-line dark:border-gray-700 p-4 mb-6">
+          <h1 className="text-page font-semibold text-gray-900 dark:text-white">Investments</h1>
         </div>
         
         <div className="bg-white dark:bg-gray-800 rounded-lg border border-line dark:border-gray-700 p-8 text-center">

--- a/src/pages/settings/AppSettings.tsx
+++ b/src/pages/settings/AppSettings.tsx
@@ -24,8 +24,6 @@ export default function AppSettings() {
     setThemeSchedule,
     showInvestments,
     setShowInvestments,
-    enableGoalCelebrations,
-    setEnableGoalCelebrations
   } = usePreferences();
 
   const currencies = [
@@ -255,24 +253,10 @@ export default function AppSettings() {
       {/* Large Transaction Alerts */}
       <LargeTransactionAlertSettings />
 
-      {/* Goal Celebrations */}
-      <div className="bg-white dark:bg-gray-800 rounded-2xl shadow p-6">
-        <h3 className="text-card font-semibold text-gray-900 dark:text-white mb-4">Goal Celebrations</h3>
-        
-        <div className="flex items-center justify-between">
-          <div>
-            <p className="font-medium text-gray-900 dark:text-white">Enable Celebrations</p>
-            <p className="text-body text-gray-500 dark:text-gray-400">
-              Show confetti and celebration messages when you achieve your goals
-            </p>
-          </div>
-          <ToggleSwitch
-            checked={enableGoalCelebrations}
-            onChange={setEnableGoalCelebrations}
-            aria-label="Enable goal celebrations"
-          />
-        </div>
-      </div>
+      {/* Goal Celebrations retired 2026-08-14 with the Goals page. The toggle promised
+          "confetti and celebration messages when you achieve your goals" and, once Goals
+          went, nothing read the preference and no goal could be achieved. A control that
+          changes nothing is worse than a missing one: it is a claim the app can't keep. */}
 
       {/* Page Tips */}
       <ShowTipsAgain />

--- a/src/pages/settings/AuditLogs.tsx
+++ b/src/pages/settings/AuditLogs.tsx
@@ -173,7 +173,7 @@ export default function AuditLogs() {
       width: '120px',
       accessor: (log) => (
         <div className="flex items-center gap-2">
-          <span className="text-lg">{getActionIcon(log.action)}</span>
+          <span className="text-card">{getActionIcon(log.action)}</span>
           <span className={`text-sm font-medium capitalize ${getActionColor(log.action)}`}>
             {log.action}
           </span>
@@ -240,7 +240,7 @@ export default function AuditLogs() {
         <div className="bg-gradient-to-r from-gray-600 to-gray-800 dark:from-gray-800 dark:to-gray-900 rounded-2xl p-6 mb-6 text-white shadow-lg">
           <div className="flex items-center justify-between">
             <div>
-              <h1 className="text-3xl font-bold mb-2">Audit Logs</h1>
+              <h1 className="text-page font-bold mb-2">Audit Logs</h1>
               <p className="text-gray-100">
                 Complete history of all system activities and changes
               </p>

--- a/src/pages/settings/Categories.tsx
+++ b/src/pages/settings/Categories.tsx
@@ -782,7 +782,7 @@ export default function CategoriesSettings() {
     
     return (
       <div>
-        <h3 className="text-lg font-medium text-gray-700 dark:text-gray-300 mb-3">{title}</h3>
+        <h3 className="text-card font-medium text-gray-700 dark:text-gray-300 mb-3">{title}</h3>
         <SortableContext 
           items={[...orderedSubCategories.map(c => c.id), ...allDetailIds]}
           strategy={verticalListSortingStrategy}
@@ -1016,7 +1016,7 @@ export default function CategoriesSettings() {
 
       {/* Starter set import */}
       {!isEditMode && !isDeleteMode && (
-        <div className="bg-white dark:bg-gray-800 rounded-2xl shadow-lg border border-gray-100 dark:border-gray-700 p-4 mb-6 flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3">
+        <div className="bg-white dark:bg-gray-800 rounded-lg border border-line dark:border-gray-700 p-4 mb-6 flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3">
           <div>
             <h3 className="text-sm font-semibold text-gray-900 dark:text-white">
               Standard category set
@@ -1047,7 +1047,7 @@ export default function CategoriesSettings() {
       />
 
       {/* Categories Tree */}
-      <div className="bg-white dark:bg-gray-800 rounded-2xl shadow-lg border border-gray-100 dark:border-gray-700 p-6">
+      <div className="bg-white dark:bg-gray-800 rounded-lg border border-line dark:border-gray-700 p-6">
         <DndContext 
           sensors={sensors}
           collisionDetection={closestCenter}
@@ -1061,7 +1061,7 @@ export default function CategoriesSettings() {
           
           {/* Other Categories */}
           <div>
-            <h3 className="text-lg font-medium text-gray-700 dark:text-gray-300 mb-3">Other Categories</h3>
+            <h3 className="text-card font-medium text-gray-700 dark:text-gray-300 mb-3">Other Categories</h3>
             <div className="space-y-1">
               {categories.filter(cat => cat.type === 'both' && cat.level === 'detail' && !cat.parentId && cat.isActive !== false).map(category => {
                 const transactionCount = categoryTransactionCounts.get(category.id) ?? 0;
@@ -1114,7 +1114,7 @@ export default function CategoriesSettings() {
           >
             <div className="flex items-center gap-3 mb-4">
               <AlertCircleIcon className="text-orange-500" size={24} />
-              <h3 id="delete-category-heading" className="text-lg font-semibold text-gray-900 dark:text-white">
+              <h3 id="delete-category-heading" className="text-card font-semibold text-gray-900 dark:text-white">
                 Delete Category
               </h3>
             </div>
@@ -1214,7 +1214,7 @@ export default function CategoriesSettings() {
           >
             <div className="flex items-center gap-3 mb-4">
               <MergeIcon className="text-primary" size={24} />
-              <h3 id="merge-category-heading" className="text-lg font-semibold text-gray-900 dark:text-white">
+              <h3 id="merge-category-heading" className="text-card font-semibold text-gray-900 dark:text-white">
                 Merge Category
               </h3>
             </div>
@@ -1327,7 +1327,7 @@ export default function CategoriesSettings() {
       {viewingCategoryId && !showTransactionsModal && (
         <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50 p-4">
           <div className="bg-white dark:bg-gray-800 rounded-2xl p-6 max-w-md w-full">
-            <h3 className="text-lg font-semibold text-gray-900 dark:text-white mb-4">
+            <h3 className="text-card font-semibold text-gray-900 dark:text-white mb-4">
               View Transactions
             </h3>
             <p className="text-gray-600 dark:text-gray-400 mb-6">

--- a/src/pages/settings/DataManagement.tsx
+++ b/src/pages/settings/DataManagement.tsx
@@ -213,8 +213,8 @@ export default function DataManagementSettings() {
 
   return (
     <div>
-      <div className="bg-secondary dark:bg-gray-700 rounded-2xl shadow p-4 mb-6">
-        <h1 className="text-3xl font-bold text-white">Data Management</h1>
+      <div className="bg-white dark:bg-gray-800 rounded-lg border border-line dark:border-gray-700 p-4 mb-6">
+        <h1 className="text-page font-semibold text-gray-900 dark:text-white">Data Management</h1>
       </div>
 
       {/* Retired 2026-08-07: the orange "Test Data Active" banner and the
@@ -277,7 +277,7 @@ export default function DataManagementSettings() {
 
       {/* ── Danger Zone ────────────────────────────────────────── */}
       <div className="rounded-2xl border border-red-200 dark:border-red-900/50 bg-white dark:bg-gray-800 shadow-sm p-6 mb-6">
-        <h3 className="text-lg font-semibold text-red-700 dark:text-red-400 mb-1">Danger Zone</h3>
+        <h3 className="text-card font-semibold text-red-700 dark:text-red-400 mb-1">Danger Zone</h3>
         <p className="text-sm text-gray-500 dark:text-gray-400 mb-4">Irreversible actions — handle with care.</p>
         <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
           <button
@@ -309,7 +309,7 @@ export default function DataManagementSettings() {
           <div className="bg-white dark:bg-gray-800 rounded-2xl p-6 max-w-md w-full">
             <div className="flex items-center gap-3 mb-4">
               <AlertCircleIcon className="text-red-500" size={24} />
-              <h3 className="text-lg font-semibold text-gray-900 dark:text-white">Confirm Delete All Data</h3>
+              <h3 className="text-card font-semibold text-gray-900 dark:text-white">Confirm Delete All Data</h3>
             </div>
             <p className="text-gray-600 dark:text-gray-400 mb-4">
               Are you sure you want to delete all data? This will permanently remove:
@@ -453,7 +453,7 @@ export default function DataManagementSettings() {
         <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50 p-4">
           <div className="bg-white dark:bg-gray-800 rounded-2xl max-w-4xl w-full max-h-[90vh] overflow-hidden">
             <div className="p-6 border-b border-gray-200 dark:border-gray-700 flex justify-between items-center">
-              <h2 className="text-2xl font-bold text-gray-900 dark:text-white">Bank Connections</h2>
+              <h2 className="text-page font-bold text-gray-900 dark:text-white">Bank Connections</h2>
               <button
                 onClick={closeBankConnections}
                 className="text-gray-400 hover:text-gray-600 dark:hover:text-gray-300"
@@ -489,8 +489,8 @@ function Section({ title, description, children }: {
   title: string; description: string; children: React.ReactNode;
 }) {
   return (
-    <div className="bg-white dark:bg-gray-800 rounded-2xl shadow-sm border border-gray-100 dark:border-gray-700 p-6 mb-6">
-      <h3 className="text-lg font-semibold text-gray-900 dark:text-white">{title}</h3>
+    <div className="bg-white dark:bg-gray-800 rounded-lg border border-line dark:border-gray-700 p-6 mb-6">
+      <h3 className="text-card font-semibold text-gray-900 dark:text-white">{title}</h3>
       <p className="text-sm text-gray-500 dark:text-gray-400 mb-4">{description}</p>
       <div className="space-y-3">{children}</div>
     </div>

--- a/src/pages/settings/PayeeCleanup.tsx
+++ b/src/pages/settings/PayeeCleanup.tsx
@@ -731,7 +731,7 @@ export default function PayeeCleanup(): React.JSX.Element {
       </p>
 
       {allClusters.length > 0 && (
-        <div className="bg-white dark:bg-gray-800 rounded-2xl shadow border border-gray-100 dark:border-gray-700 p-4">
+        <div className="bg-white dark:bg-gray-800 rounded-lg border border-line dark:border-gray-700 p-4">
           <div className="flex flex-wrap items-center gap-3 mb-1">
             {/* The total, in the heading, because the owner could not tell how
                 much work the page was proposing: "when you tidy up one, the
@@ -861,7 +861,7 @@ export default function PayeeCleanup(): React.JSX.Element {
         </div>
       )}
 
-      <div className="bg-white dark:bg-gray-800 rounded-2xl shadow border border-gray-100 dark:border-gray-700 p-4 space-y-3">
+      <div className="bg-white dark:bg-gray-800 rounded-lg border border-line dark:border-gray-700 p-4 space-y-3">
         <div className="relative">
           <SearchIcon
             size={16}

--- a/src/pages/settings/SecuritySettings.tsx
+++ b/src/pages/settings/SecuritySettings.tsx
@@ -27,7 +27,11 @@ export default function SecuritySettings() {
   const [showTwoFactorSetup, setShowTwoFactorSetup] = useState(false);
   const [twoFactorSecret, setTwoFactorSecret] = useState<ReturnType<typeof securityService.generateTwoFactorSecret> | null>(null);
   const [verificationCode, setVerificationCode] = useState('');
-  const [biometricAvailable, setBiometricAvailable] = useState(false);
+  // null until the capability check answers. P8 — nothing may speak until it knows:
+  // initialised to `false` this told people with Face ID that their device hasn't got
+  // it, and disabled the button that would have proved otherwise. The three states are
+  // distinct on purpose; a device that genuinely can't do this must STILL be told so.
+  const [biometricAvailable, setBiometricAvailable] = useState<boolean | null>(null);
   const [setupMessage, setSetupMessage] = useState<{ type: 'success' | 'error'; text: string } | null>(null);
 
   useEffect(() => {
@@ -197,25 +201,32 @@ export default function SecuritySettings() {
               </div>
               <button
                 onClick={handleToggleBiometric}
-                disabled={!biometricAvailable}
+                disabled={biometricAvailable !== true}
                 className={`px-4 py-2 rounded-lg font-medium transition-colors ${
-                  !biometricAvailable
+                  biometricAvailable !== true
                     ? 'bg-gray-100 text-gray-400 dark:bg-gray-700 cursor-not-allowed'
                     : settings.biometricEnabled
                     ? 'bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-400 hover:bg-red-200 dark:hover:bg-red-900/50'
                     : 'bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-400 hover:bg-blue-200 dark:hover:bg-blue-900/50'
                 }`}
               >
-                {!biometricAvailable ? 'Not Available' : settings.biometricEnabled ? 'Disable' : 'Enable'}
+                {biometricAvailable === null
+                  ? 'Checking…'
+                  : biometricAvailable === false
+                  ? 'Not Available'
+                  : settings.biometricEnabled
+                  ? 'Disable'
+                  : 'Enable'}
               </button>
             </div>
-            
-            {!biometricAvailable && (
-              <div className="mt-4 p-3 bg-yellow-50 dark:bg-yellow-900/20 rounded-lg">
-                <p className="text-sm text-yellow-800 dark:text-yellow-200">
-                  Biometric authentication is not available on this device
-                </p>
-              </div>
+
+            {/* Only once the check has answered, and only on false. A caveat about what
+                this device can do is a standing truth, not a transient problem, so it
+                takes neutral text rather than the warning tint it used to wear. */}
+            {biometricAvailable === false && (
+              <p className="mt-4 text-sm text-gray-500 dark:text-gray-400">
+                Biometric authentication is not available on this device
+              </p>
             )}
           </div>
 

--- a/src/pages/settings/SecuritySettings.tsx
+++ b/src/pages/settings/SecuritySettings.tsx
@@ -119,15 +119,15 @@ export default function SecuritySettings() {
     <PageWrapper title="Security Settings">
       <div className="max-w-4xl mx-auto">
         {/* Header */}
-        <div className="bg-[#1a2332] dark:bg-gray-800 rounded-2xl p-6 mb-6 text-white shadow-lg">
+        <div className="bg-white dark:bg-gray-800 border border-line dark:border-gray-700 rounded-lg p-6 mb-6">
           <div className="flex items-center justify-between">
             <div>
-              <h1 className="text-3xl font-bold mb-2">Security Settings</h1>
-              <p className="text-white/70">
+              <h1 className="text-page font-semibold mb-2 text-gray-900 dark:text-white">Security Settings</h1>
+              <p className="text-body text-gray-500 dark:text-gray-400">
                 Protect your financial data with advanced security features
               </p>
             </div>
-            <ShieldIcon size={48} className="text-white/80" />
+            <ShieldIcon size={48} className="text-gray-300 dark:text-gray-600" />
           </div>
         </div>
 
@@ -153,7 +153,7 @@ export default function SecuritySettings() {
           <div className="bg-white dark:bg-gray-800 rounded-lg shadow-sm p-6">
             <div className="flex items-start justify-between">
               <div className="flex-1">
-                <h3 className="text-lg font-semibold text-gray-900 dark:text-white flex items-center gap-2">
+                <h3 className="text-card font-semibold text-gray-900 dark:text-white flex items-center gap-2">
                   <PhoneIcon size={20} className="text-indigo-600 dark:text-indigo-400" />
                   Two-Factor Authentication
                 </h3>
@@ -187,7 +187,7 @@ export default function SecuritySettings() {
           <div className="bg-white dark:bg-gray-800 rounded-lg shadow-sm p-6">
             <div className="flex items-start justify-between">
               <div className="flex-1">
-                <h3 className="text-lg font-semibold text-gray-900 dark:text-white flex items-center gap-2">
+                <h3 className="text-card font-semibold text-gray-900 dark:text-white flex items-center gap-2">
                   <FingerprintIcon size={20} className="text-purple-600 dark:text-purple-400" />
                   Biometric Authentication
                 </h3>
@@ -223,7 +223,7 @@ export default function SecuritySettings() {
           <div className="bg-white dark:bg-gray-800 rounded-lg shadow-sm p-6">
             <div className="flex items-start justify-between">
               <div className="flex-1">
-                <h3 className="text-lg font-semibold text-gray-900 dark:text-white flex items-center gap-2">
+                <h3 className="text-card font-semibold text-gray-900 dark:text-white flex items-center gap-2">
                   <LockIcon size={20} className="text-blue-600 dark:text-blue-400" />
                   End-to-End Encryption
                 </h3>
@@ -257,7 +257,7 @@ export default function SecuritySettings() {
           <div className="bg-white dark:bg-gray-800 rounded-lg shadow-sm p-6">
             <div className="flex items-start justify-between">
               <div className="flex-1">
-                <h3 className="text-lg font-semibold text-gray-900 dark:text-white flex items-center gap-2">
+                <h3 className="text-card font-semibold text-gray-900 dark:text-white flex items-center gap-2">
                   <EyeIcon size={20} className="text-blue-700 dark:text-blue-400" />
                   Read-Only Mode
                 </h3>
@@ -289,7 +289,7 @@ export default function SecuritySettings() {
 
           {/* Session Timeout */}
           <div className="bg-white dark:bg-gray-800 rounded-lg shadow-sm p-6">
-            <h3 className="text-lg font-semibold text-gray-900 dark:text-white flex items-center gap-2 mb-4">
+            <h3 className="text-card font-semibold text-gray-900 dark:text-white flex items-center gap-2 mb-4">
               <RefreshCwIcon size={20} className="text-orange-600 dark:text-orange-400" />
               Session Timeout
             </h3>
@@ -319,7 +319,7 @@ export default function SecuritySettings() {
 
           {/* Audit Logs */}
           <div className="bg-white dark:bg-gray-800 rounded-lg shadow-sm p-6">
-            <h3 className="text-lg font-semibold text-gray-900 dark:text-white flex items-center gap-2 mb-4">
+            <h3 className="text-card font-semibold text-gray-900 dark:text-white flex items-center gap-2 mb-4">
               <FileTextIcon size={20} className="text-gray-600 dark:text-gray-400" />
               Security Information
             </h3>
@@ -357,7 +357,7 @@ export default function SecuritySettings() {
         {showTwoFactorSetup && twoFactorSecret && (
           <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50 p-4">
             <div className="bg-white dark:bg-gray-800 rounded-2xl w-full max-w-md p-6">
-              <h3 className="text-lg font-semibold text-gray-900 dark:text-white mb-4">
+              <h3 className="text-card font-semibold text-gray-900 dark:text-white mb-4">
                 Set Up Two-Factor Authentication
               </h3>
               
@@ -393,7 +393,7 @@ export default function SecuritySettings() {
                     onChange={(e) => setVerificationCode(e.target.value)}
                     placeholder="000000"
                     maxLength={6}
-                    className="w-full px-4 py-2 border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-700 text-gray-900 dark:text-white text-center font-mono text-lg"
+                    className="w-full px-4 py-2 border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-700 text-gray-900 dark:text-white text-center font-mono text-card"
                   />
                 </div>
                 

--- a/src/pages/settings/Tags.tsx
+++ b/src/pages/settings/Tags.tsx
@@ -143,8 +143,8 @@ export default function Tags() {
 
       {/* Add/Edit Form */}
       {showAddForm && (
-        <div className="bg-white dark:bg-gray-800 rounded-2xl shadow-lg border border-gray-100 dark:border-gray-700 p-6 mb-6">
-          <h2 className="text-xl font-semibold text-blue-800 dark:text-white mb-4">
+        <div className="bg-white dark:bg-gray-800 rounded-lg border border-line dark:border-gray-700 p-6 mb-6">
+          <h2 className="text-card font-semibold text-blue-800 dark:text-white mb-4">
             {editingTag ? 'Edit Tag' : 'Add New Tag'}
           </h2>
           
@@ -229,9 +229,9 @@ export default function Tags() {
       )}
 
       {/* Tags List */}
-      <div className="bg-white dark:bg-gray-800 rounded-2xl shadow-lg border border-gray-100 dark:border-gray-700">
+      <div className="bg-white dark:bg-gray-800 rounded-lg border border-line dark:border-gray-700">
         <div className="px-6 py-4 border-b border-gray-200 dark:border-gray-700">
-          <h2 className="text-lg font-semibold text-blue-800 dark:text-white">
+          <h2 className="text-card font-semibold text-blue-800 dark:text-white">
             All Tags ({tags.length})
           </h2>
         </div>
@@ -239,7 +239,7 @@ export default function Tags() {
         {tags.length === 0 ? (
           <div className="p-8 text-center">
             <HashIcon className="mx-auto text-gray-400 mb-4" size={48} />
-            <h3 className="text-lg font-medium text-gray-900 dark:text-white mb-2">
+            <h3 className="text-card font-medium text-gray-900 dark:text-white mb-2">
               No tags yet
             </h3>
             <p className="text-gray-500 dark:text-gray-400 mb-4">
@@ -301,14 +301,14 @@ export default function Tags() {
 
       {/* Usage Statistics */}
       {tags.length > 0 && (
-        <div className="mt-6 bg-white dark:bg-gray-800 rounded-2xl shadow p-6">
-          <h3 className="text-lg font-semibold text-gray-900 dark:text-white mb-4 flex items-center gap-2">
+        <div className="mt-6 bg-white dark:bg-gray-800 rounded-lg border border-line dark:border-gray-700 p-6">
+          <h3 className="text-card font-semibold text-gray-900 dark:text-white mb-4 flex items-center gap-2">
             <AlertCircleIcon size={20} />
             Tag Usage Statistics
           </h3>
           <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
             <div className="text-center p-4 bg-blue-50 dark:bg-blue-900/20 rounded-2xl">
-              <div className="text-2xl font-bold text-blue-700 dark:text-blue-400">
+              <div className="text-page font-bold text-blue-700 dark:text-blue-400">
                 {tags.length}
               </div>
               <div className="text-sm text-gray-600 dark:text-gray-400">
@@ -316,7 +316,7 @@ export default function Tags() {
               </div>
             </div>
             <div className="text-center p-4 bg-blue-50 dark:bg-blue-900/20 rounded-2xl">
-              <div className="text-2xl font-bold text-blue-600 dark:text-blue-400">
+              <div className="text-page font-bold text-blue-600 dark:text-blue-400">
                 {tags.filter(tag => getTagUsageCount(tag.name) > 0).length}
               </div>
               <div className="text-sm text-gray-600 dark:text-gray-400">
@@ -324,7 +324,7 @@ export default function Tags() {
               </div>
             </div>
             <div className="text-center p-4 bg-orange-50 dark:bg-orange-900/20 rounded-2xl">
-              <div className="text-2xl font-bold text-orange-600 dark:text-orange-400">
+              <div className="text-page font-bold text-orange-600 dark:text-orange-400">
                 {tags.filter(tag => getTagUsageCount(tag.name) === 0).length}
               </div>
               <div className="text-sm text-gray-600 dark:text-gray-400">

--- a/src/pages/settings/ThemeSettings.tsx
+++ b/src/pages/settings/ThemeSettings.tsx
@@ -119,19 +119,19 @@ export default function ThemeSettings() {
     <PageWrapper title="Theme Settings">
       <div className="max-w-6xl mx-auto">
         {/* Header */}
-        <div className="bg-[#1a2332] dark:bg-gray-800 rounded-2xl p-6 mb-6 text-white shadow-lg">
+        <div className="bg-white dark:bg-gray-800 border border-line dark:border-gray-700 rounded-lg p-6 mb-6">
           <div className="flex items-center justify-between">
             <div>
-              <h1 className="text-3xl font-bold mb-2">Theme Settings</h1>
-              <p className="text-white/70">
-                Customize appearance and automate theme switching
+              <h1 className="text-page font-semibold mb-2 text-gray-900 dark:text-white">Theme Settings</h1>
+              <p className="text-body text-gray-500 dark:text-gray-400">
+                Customise appearance and automate theme switching
               </p>
             </div>
             <div className="flex items-center gap-4">
               {getCurrentTheme() === 'dark' ? (
-                <MoonIcon size={48} className="text-white/80" />
+                <MoonIcon size={48} className="text-gray-300 dark:text-gray-600" />
               ) : (
-                <SunIcon size={48} className="text-white/80" />
+                <SunIcon size={48} className="text-gray-300 dark:text-gray-600" />
               )}
             </div>
           </div>
@@ -231,7 +231,7 @@ export default function ThemeSettings() {
         {activeTab === 'schedules' && (
           <div className="space-y-6">
             <div className="flex items-center justify-between">
-              <h3 className="text-lg font-semibold text-gray-900 dark:text-white">Theme Schedules</h3>
+              <h3 className="text-card font-semibold text-gray-900 dark:text-white">Theme Schedules</h3>
               <button
                 onClick={() => setShowCreateSchedule(true)}
                 className="flex items-center gap-2 px-4 py-2 bg-[var(--color-primary)] text-white rounded-lg hover:bg-[var(--color-primary)]/90"
@@ -359,7 +359,7 @@ export default function ThemeSettings() {
         {activeTab === 'presets' && (
           <div className="space-y-6">
             <div className="flex items-center justify-between">
-              <h3 className="text-lg font-semibold text-gray-900 dark:text-white">Theme Presets</h3>
+              <h3 className="text-card font-semibold text-gray-900 dark:text-white">Theme Presets</h3>
               <button
                 onClick={() => setShowCreatePreset(true)}
                 className="flex items-center gap-2 px-4 py-2 bg-[var(--color-primary)] text-white rounded-lg hover:bg-[var(--color-primary)]/90"
@@ -443,7 +443,7 @@ export default function ThemeSettings() {
         {/* Settings Tab */}
         {activeTab === 'settings' && (
           <div className="space-y-6">
-            <h3 className="text-lg font-semibold text-gray-900 dark:text-white">Advanced Settings</h3>
+            <h3 className="text-card font-semibold text-gray-900 dark:text-white">Advanced Settings</h3>
             
             <div className="bg-white dark:bg-gray-800 rounded-lg shadow-sm p-6">
               <h4 className="font-medium text-gray-900 dark:text-white mb-4">System Integration</h4>
@@ -501,7 +501,7 @@ export default function ThemeSettings() {
         {showCreateSchedule && (
           <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50 p-4">
             <div className="bg-white dark:bg-gray-800 rounded-2xl w-full max-w-md p-6">
-              <h3 className="text-lg font-semibold text-gray-900 dark:text-white mb-4">
+              <h3 className="text-card font-semibold text-gray-900 dark:text-white mb-4">
                 Create Theme Schedule
               </h3>
               <p className="text-gray-600 dark:text-gray-400 mb-4">

--- a/src/pages/settings/__tests__/SecuritySettings.biometricUnknown.test.tsx
+++ b/src/pages/settings/__tests__/SecuritySettings.biometricUnknown.test.tsx
@@ -1,0 +1,106 @@
+/**
+ * P8 — nothing may speak until it knows.
+ *
+ * `biometricAvailable` used to start `false`, and the page rendered that as a
+ * finding: a disabled button reading "Not Available" and a warning panel saying
+ * "Biometric authentication is not available on this device". On a phone with
+ * Face ID both statements were false, and they were shown before
+ * `securityService.isBiometricAvailable()` had been asked.
+ *
+ * The three states are now distinct, and the third test here is the one that
+ * makes the principle enforceable: a device that genuinely cannot do this must
+ * STILL be told so. Without it the fix could be "delete the message", which
+ * trades a false statement for a silence.
+ */
+import React from 'react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, waitFor, within } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { ToastProvider } from '../../../contexts/ToastContext';
+
+/** Resolves only when the test says so, so the "still asking" window is real. */
+let answer: (available: boolean) => void = () => {};
+const isBiometricAvailable = vi.fn(
+  () => new Promise<boolean>(resolve => { answer = resolve; })
+);
+
+vi.mock('../../../services/securityService', () => ({
+  securityService: {
+    isBiometricAvailable,
+    getSecuritySettings: () => ({
+      twoFactorEnabled: false,
+      biometricEnabled: false,
+      encryptionEnabled: false,
+      sessionTimeout: 30,
+      autoLockEnabled: false,
+      requirePasswordForExport: false,
+    }),
+    updateSecuritySettings: vi.fn(),
+    generateTwoFactorSecret: vi.fn(),
+    setupBiometric: vi.fn(),
+  },
+}));
+
+const { default: SecuritySettings } = await import('../SecuritySettings');
+
+function renderPage() {
+  return render(
+    <MemoryRouter>
+      <ToastProvider>
+        <SecuritySettings />
+      </ToastProvider>
+    </MemoryRouter>
+  );
+}
+
+/** The card headed "Biometric Authentication", so sibling sections' buttons don't match. */
+function biometricCard(): HTMLElement {
+  const heading = screen.getByText('Biometric Authentication');
+  const card = heading.closest('div.bg-white');
+  if (!card) throw new Error('biometric card not found');
+  return card as HTMLElement;
+}
+
+describe('Security settings — the biometric capability check', () => {
+  beforeEach(() => {
+    isBiometricAvailable.mockClear();
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('says nothing about the device while the check is still out', async () => {
+    renderPage();
+
+    // The claim that used to be here, on a device that may well have Face ID.
+    expect(
+      screen.queryByText(/not available on this device/i)
+    ).not.toBeInTheDocument();
+    expect(screen.queryByText('Not Available')).not.toBeInTheDocument();
+  });
+
+  it('offers the control once the device says yes', async () => {
+    renderPage();
+    answer(true);
+
+    // Two-Factor and Data Encryption carry "Enable" buttons of their own, so the
+    // query is scoped to the biometric card rather than the page.
+    await waitFor(() => {
+      expect(within(biometricCard()).getByRole('button', { name: 'Enable' })).toBeEnabled();
+    });
+    expect(
+      screen.queryByText(/not available on this device/i)
+    ).not.toBeInTheDocument();
+  });
+
+  it('STILL tells a device that genuinely cannot do it', async () => {
+    renderPage();
+    answer(false);
+
+    await waitFor(() => {
+      expect(screen.getByText(/not available on this device/i)).toBeInTheDocument();
+    });
+    expect(screen.getByRole('button', { name: 'Not Available' })).toBeDisabled();
+  });
+});


### PR DESCRIPTION
The last of your conversion queue — the settings sub-pages, which you put last as "rarely visited and mostly forms". That was right: seven files, no rulings needed, and the interesting part was what the pass found rather than what it changed.

## Three defects the conversion itself shipped

Found by grepping the *already-converted* pages for `text-white`, which I should have done two PRs ago:

- **`ExportManager` and `EnhancedImport` kept `text-white/80` on their 48px header icons.** Correct on the navy slab; **invisible on the white card that replaced it.** Live on `main` since #291 and #292. Both icons are decorative — the heading beside them names the page — so they take grey rather than ink.
- **Investments' empty state was never converted.** It sits in an early return above the body I did convert, so the slab, the `text-display font-bold`, and the whole branch went untouched. It is the branch a new user sees first.

The general lesson, which is worth more than the three fixes: **a conversion that changes a container's ground must re-check every colour that assumed the old ground.** White-on-navy is not a colour, it is a relationship, and item 3 breaks it silently. The early return is the same failure in a different key — the pass matched on class names, and class names do not tell you about control flow.

## The settings pages

Two navy slabs (Security, Theme) and one `bg-secondary` (Data Management) to the hairline card. Every `rounded-2xl shadow*` card likewise — there were three more spellings than the audit's `shadow-lg` (`shadow`, `shadow-sm`, and borderless variants). All of settings onto the six-size scale.

## Two things I did not convert, and want on the record

**1. Categories' `<DragOverlay>` keeps its shadow.** It is the floating preview that follows the cursor while a category is dragged. The shadow is not decoration there — it is the only thing saying the element has *left the page*, which is the entire message a drag overlay exists to send. Item 1 is about cards at rest on a surface; this is not one.

**2. `text-sm` and `text-xs` are left alone.** They are already 14px and 12px — exactly `body` and `dense`. Renaming them produces a large diff, zero visual change, and a worse chance of anyone reviewing it. I converted the oversized headings, which is where item 4's actual complaint lives. If you want the names uniform for grepability, say so and it is a one-line codemod; I did not want to spend a 400-line diff on it without asking.

## One dead control removed

**"Goal Celebrations"** — a toggle promising "confetti and celebration messages when you achieve your goals". Goals went this morning. Nothing read the preference, and no goal could be reached to celebrate.

This is your own ruling from answer 3 — *an affordance that leads nowhere is a defect, not a convenience* — arriving somewhere you did not aim it. A dead link wastes a click; a dead **toggle** is worse, because it accepts the input and reports back a state, so it reads as working. The preference and its localStorage key go with it rather than being orphaned.

Also `Customize` → `Customise`, which the UK-English test would have caught eventually.

5945 tests pass, lint and typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

# The P8 sweep

Added to this PR after the fact, because its one real find is in `SecuritySettings` — a file this PR was already converting.

## What it found

**`biometricAvailable` started `false`, and the page rendered that as a finding.** A **disabled** button reading "Not Available", plus a warning panel: *"Biometric authentication is not available on this device"* — both before `securityService.isBiometricAvailable()` had been asked. On a phone with Face ID, both statements were false.

This is worse than the bank-connections case it generalises from. That one flickered a message. This one **also disables the control that would have disproved it**, so on a slow check a live capability sits behind a dead button, and the user has been given a reason not to try again.

Three states now, `boolean | null`. The panel takes neutral text on the way past: "this device can't do it" is a standing truth about the hardware, which is your 7.2 caveat rule, not a transient problem wearing a warning tint.

Three tests. The third — *STILL tells a device that genuinely cannot do it* — is the one that makes P8 enforceable, and it passes both with and without the fix on purpose: it exists so the fix cannot be "delete the message". Proven non-vacuous by restoring the `false` initial value, which fails the first test and leaves the other two green.

## What it did not find, which is the more useful half

I swept every component that awaits a load and then renders a claim about emptiness. **Lists were almost all clean** — they `return null` on empty, and null states nothing.

So the shape is narrower than the original bug suggested, and worth naming precisely:

> **P8's dangerous case is a boolean capability or config flag initialised `false`.**

`[]` and `false` are not equally dangerous. An empty array is usually rendered as "nothing here yet", which is a *description of a list* and is at worst premature. A `false` capability flag gets rendered as **a fact about the user's device or account** — "not configured", "not available", "not connected" — and it is indistinguishable from "not yet asked" because the same value means both. `null` costs one union member and makes the two distinguishable, which is the whole fix in both cases found so far.

That gives the principle a grep-able signature for future work: `useState(false)` whose setter is called after an `await`, feeding copy that says *not*.

**Two found, two fixed** — bank connections (#285) and this one. I'd expect more to appear as new async capability checks are written, which is an argument for a lint rule rather than another sweep.
