### PR TITLE
Password-protect a backup, and open one again

### DIFF
--- a/src/components/RestoreBackupModal.tsx
+++ b/src/components/RestoreBackupModal.tsx
@@ -2,6 +2,11 @@ import React, { useCallback, useMemo, useState } from 'react';
 import { Modal, ModalBody, ModalFooter } from './common/Modal';
 import { useApp } from '../contexts/AppContextSupabase';
 import { dataPort } from '@data';
+import {
+  isEncryptedBackup,
+  decryptBackupBundle,
+  type EncryptedBackupEnvelope,
+} from '../services/backup/encryption';
 import type { BackupRestoreOutcome } from '@data';
 import { createScopedLogger } from '../loggers/scopedLogger';
 import { AlertTriangleIcon, CheckCircleIcon, RefreshCwIcon, UploadIcon } from './icons';
@@ -54,7 +59,11 @@ interface Props {
   onClose: () => void;
 }
 
-type Phase = 'pick' | 'ready' | 'wiping' | 'restoring' | 'done' | 'failed';
+// 'locked' — a file that IS a backup and cannot yet be read, which is a
+// different state from a file that cannot be restored. Conflating the two
+// would put "this file cannot be restored" in front of someone whose backup is
+// perfectly good and merely shut.
+type Phase = 'pick' | 'locked' | 'ready' | 'wiping' | 'restoring' | 'done' | 'failed';
 
 const CONFIRM_PHRASE = 'DELETE EVERYTHING';
 
@@ -93,6 +102,10 @@ export default function RestoreBackupModal({ isOpen, onClose }: Props): React.JS
   const [phase, setPhase] = useState<Phase>('pick');
   const [fileName, setFileName] = useState('');
   const [fileProblem, setFileProblem] = useState('');
+  const [locked, setLocked] = useState<EncryptedBackupEnvelope | null>(null);
+  const [password, setPassword] = useState('');
+  const [passwordProblem, setPasswordProblem] = useState('');
+  const [unlocking, setUnlocking] = useState(false);
   const [bundle, setBundle] = useState<BackupBundle | null>(null);
   const [targetIsEmpty, setTargetIsEmpty] = useState<boolean | null>(null);
   const [wipeConfirmText, setWipeConfirmText] = useState('');
@@ -172,6 +185,9 @@ export default function RestoreBackupModal({ isOpen, onClose }: Props): React.JS
     setPhase('pick');
     setFileName('');
     setFileProblem('');
+    setLocked(null);
+    setPassword('');
+    setPasswordProblem('');
     setBundle(null);
     setTargetIsEmpty(null);
     setWipeConfirmText('');
@@ -187,6 +203,38 @@ export default function RestoreBackupModal({ isOpen, onClose }: Props): React.JS
     reset();
     onClose();
   }, [phase, reset, onClose]);
+
+  /**
+   * Everything the restore does once it is holding a readable bundle, whether
+   * that came straight off disk or out of a decrypt. Shared so an encrypted
+   * backup goes through exactly the same validation, the same session check and
+   * the same preflight as a plain one — the encryption is a wrapper, and must
+   * not become a second, thinner path into a destructive operation.
+   */
+  const acceptParsed = useCallback(async (parsed: unknown): Promise<void> => {
+    const validation = validateBackupBundle(parsed);
+    if (!validation.ok) {
+      setFileProblem(validation.problem);
+      setPhase('pick');
+      return;
+    }
+
+    if (cloudSessionPending) {
+      setFileProblem('This session has no database identity yet, so a restore cannot be scoped to your login. Reload the page and try again.');
+      setPhase('pick');
+      return;
+    }
+
+    setBundle(validation.bundle);
+    try {
+      setTargetIsEmpty(await dataPort.financialDataIsEmpty());
+      setPhase('ready');
+    } catch (error) {
+      restoreLogger.error('Preflight emptiness check failed', error);
+      setFileProblem(error instanceof Error ? error.message : `Could not check whether this ${targetName} is empty.`);
+      setPhase('pick');
+    }
+  }, [cloudSessionPending, targetName]);
 
   const handleFile = useCallback(async (file: File) => {
     setFileProblem('');
@@ -204,26 +252,37 @@ export default function RestoreBackupModal({ isOpen, onClose }: Props): React.JS
       return;
     }
 
-    const validation = validateBackupBundle(parsed);
-    if (!validation.ok) {
-      setFileProblem(validation.problem);
+    if (isEncryptedBackup(parsed)) {
+      // Deliberately BEFORE validation: the bundle is inside the ciphertext, so
+      // there is nothing here to validate yet, and the checks below would all
+      // report the wrong fault.
+      setLocked(parsed);
+      setPhase('locked');
       return;
     }
 
-    if (cloudSessionPending) {
-      setFileProblem('This session has no database identity yet, so a restore cannot be scoped to your login. Reload the page and try again.');
-      return;
-    }
+    await acceptParsed(parsed);
+  }, [acceptParsed]);
 
-    setBundle(validation.bundle);
+  const handleUnlock = useCallback(async () => {
+    if (!locked || password === '') return;
+    setUnlocking(true);
+    setPasswordProblem('');
     try {
-      setTargetIsEmpty(await dataPort.financialDataIsEmpty());
-      setPhase('ready');
+      const bundle = await decryptBackupBundle(locked, password);
+      setLocked(null);
+      setPassword('');
+      await acceptParsed(bundle);
     } catch (error) {
-      restoreLogger.error('Preflight emptiness check failed', error);
-      setFileProblem(error instanceof Error ? error.message : `Could not check whether this ${targetName} is empty.`);
+      // The message comes from the decrypt, which names both possible faults
+      // and claims neither — AES-GCM genuinely cannot tell them apart.
+      setPasswordProblem(
+        error instanceof Error ? error.message : 'That password did not open the file.'
+      );
+    } finally {
+      setUnlocking(false);
     }
-  }, [cloudSessionPending, targetName]);
+  }, [locked, password, acceptParsed]);
 
   const handleWipe = useCallback(async () => {
     if (cloudSessionPending) return;
@@ -344,6 +403,71 @@ export default function RestoreBackupModal({ isOpen, onClose }: Props): React.JS
                 <p className="text-sm text-red-700 dark:text-red-300 mt-1">{fileProblem}</p>
               </div>
             )}
+          </div>
+        )}
+
+        {/* ── Step 1b: the file is a backup, and it is shut ──────────────
+            Its own step rather than an error on step 1. Nothing is wrong here:
+            the file is exactly what it should be, and the only missing thing is
+            the password. Saying "this file cannot be restored" would be false
+            and would send someone looking for another copy. */}
+        {phase === 'locked' && locked && (
+          <div className="space-y-4">
+            <div>
+              <p className="text-body font-medium text-gray-900 dark:text-white">
+                This backup is password-protected
+              </p>
+              <p className="text-body text-gray-600 dark:text-gray-400 mt-1">
+                {fileName} was made on{' '}
+                {new Date(locked.exportedAt).toLocaleDateString('en-GB', {
+                  day: 'numeric',
+                  month: 'long',
+                  year: 'numeric',
+                })}
+                . Enter the password you chose when you exported it.
+              </p>
+            </div>
+
+            <div>
+              <label htmlFor="restore-password" className="block text-body font-medium text-gray-700 dark:text-gray-300 mb-1">
+                Password
+              </label>
+              <input
+                id="restore-password"
+                type="password"
+                autoComplete="current-password"
+                value={password}
+                onChange={(e) => { setPassword(e.target.value); setPasswordProblem(''); }}
+                onKeyDown={(e) => { if (e.key === 'Enter' && password !== '') void handleUnlock(); }}
+                disabled={unlocking}
+                className="w-full max-w-sm px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-700 text-gray-900 dark:text-white"
+              />
+            </div>
+
+            {passwordProblem && (
+              <div className="rounded-xl border border-red-200 dark:border-red-800 bg-red-50 dark:bg-red-900/20 p-3">
+                <p className="text-sm text-red-700 dark:text-red-300">{passwordProblem}</p>
+              </div>
+            )}
+
+            <div className="flex items-center gap-3">
+              <button
+                type="button"
+                onClick={() => { void handleUnlock(); }}
+                disabled={password === '' || unlocking}
+                className="px-4 py-2 bg-[#1a2332] text-white rounded-lg hover:bg-[#1a2332]/90 disabled:opacity-50 disabled:cursor-not-allowed"
+              >
+                {unlocking ? 'Opening…' : 'Open backup'}
+              </button>
+              <button
+                type="button"
+                onClick={reset}
+                disabled={unlocking}
+                className="px-4 py-2 text-gray-700 dark:text-gray-300 border border-gray-300 dark:border-gray-600 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-700 disabled:opacity-50"
+              >
+                Choose a different file
+              </button>
+            </div>
           </div>
         )}
 

--- a/src/components/__tests__/RestoreBackupModal.encrypted.test.tsx
+++ b/src/components/__tests__/RestoreBackupModal.encrypted.test.tsx
@@ -1,0 +1,151 @@
+/**
+ * Restoring a password-protected backup.
+ *
+ * The dialog's own rule is that nothing wipes implicitly and every refusal says
+ * what is wrong. An encrypted file tests both: it is a perfectly good backup
+ * that cannot be read yet, and calling that "this file cannot be restored"
+ * would send someone off to look for another copy of a file that is fine.
+ *
+ * The encryption is a wrapper, not a second door — so the test that matters
+ * most is the last one: an unlocked bundle must land in the same validation and
+ * the same preflight a plain file goes through.
+ */
+import React from 'react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { encryptBackupBundle } from '../../services/backup/encryption';
+import { buildBackupBundle, type BackupBundle } from '../../services/backup/format';
+
+const financialDataIsEmpty = vi.fn(async () => true);
+
+vi.mock('@data', () => ({
+  dataPort: {
+    financialDataIsEmpty: () => financialDataIsEmpty(),
+    restoreBackup: vi.fn(),
+  },
+}));
+
+vi.mock('../../contexts/AppContextSupabase', () => ({
+  useApp: () => ({
+    refreshAccountsAndTransactions: vi.fn(),
+    refreshCategories: vi.fn(),
+    // `cannotKeep` is not optional — the preflight memo calls .filter on it, so
+    // omitting it throws AFTER the assertions pass, which is how it hid: green
+    // tests and an unhandled error in the run summary.
+    capabilities: {
+      backupTarget: 'login',
+      session: 'ready',
+      edition: 'cloud',
+      cannotKeep: [],
+    },
+  }),
+}));
+
+const { default: RestoreBackupModal } = await import('../RestoreBackupModal');
+
+const PASSWORD = 'a good long password';
+
+/**
+ * Built by the app's OWN builder rather than hand-written here. A fixture that
+ * merely looks like a bundle would sail past this suite and prove nothing about
+ * whether a decrypted file survives the real validation — which is the single
+ * claim these tests exist to make.
+ */
+function bundleFixture(): BackupBundle {
+  return JSON.parse(JSON.stringify(buildBackupBundle({
+    sourceUserId: 'u-1',
+    exportedAt: '2026-08-15T09:30:00.000Z',
+    data: {
+      accounts: [{ id: 'acc-1', name: 'Everyday', balance: '1234.56' }],
+    },
+  }))) as BackupBundle;
+}
+
+/** A File whose `.text()` resolves, which jsdom's own File does not do here. */
+function fileOf(contents: unknown, name: string): File {
+  const file = new File([JSON.stringify(contents)], name, { type: 'application/json' });
+  Object.defineProperty(file, 'text', {
+    value: async () => JSON.stringify(contents),
+  });
+  return file;
+}
+
+async function pick(file: File): Promise<void> {
+  const input = screen.getByLabelText(/backup file|choose|file/i, { selector: 'input[type="file"]' });
+  await userEvent.upload(input, file);
+}
+
+describe('Restore — a password-protected backup', () => {
+  beforeEach(() => {
+    financialDataIsEmpty.mockClear();
+    financialDataIsEmpty.mockResolvedValue(true);
+  });
+
+  it('asks for the password instead of calling the file unreadable', async () => {
+    const envelope = await encryptBackupBundle(bundleFixture(), PASSWORD);
+    render(<RestoreBackupModal isOpen onClose={vi.fn()} />);
+    await pick(fileOf(envelope, 'backup-encrypted.json'));
+
+    await waitFor(() => {
+      expect(screen.getByText(/password-protected/i)).toBeInTheDocument();
+    });
+
+    // The claim that would send someone looking for another copy.
+    expect(screen.queryByText(/cannot be restored/i)).not.toBeInTheDocument();
+    expect(screen.getByLabelText('Password')).toBeInTheDocument();
+  });
+
+  it('names the date before asking, so three files can be told apart', async () => {
+    const envelope = await encryptBackupBundle(bundleFixture(), PASSWORD);
+    render(<RestoreBackupModal isOpen onClose={vi.fn()} />);
+    await pick(fileOf(envelope, 'backup-encrypted.json'));
+
+    await waitFor(() => {
+      expect(screen.getByText(/15 August 2026/)).toBeInTheDocument();
+    });
+  });
+
+  it('refuses a wrong password and stays on the same step', async () => {
+    const envelope = await encryptBackupBundle(bundleFixture(), PASSWORD);
+    render(<RestoreBackupModal isOpen onClose={vi.fn()} />);
+    await pick(fileOf(envelope, 'backup-encrypted.json'));
+
+    await waitFor(() => expect(screen.getByLabelText('Password')).toBeInTheDocument());
+    await userEvent.type(screen.getByLabelText('Password'), 'wrong password');
+    await userEvent.click(screen.getByRole('button', { name: 'Open backup' }));
+
+    await waitFor(() => {
+      expect(screen.getByText(/did not open the file/i)).toBeInTheDocument();
+    });
+    // Still askable — a mistyped password must not cost the user the file.
+    expect(screen.getByLabelText('Password')).toBeInTheDocument();
+  });
+
+  it('opens with the right password and reaches the ordinary preflight', async () => {
+    const envelope = await encryptBackupBundle(bundleFixture(), PASSWORD);
+    render(<RestoreBackupModal isOpen onClose={vi.fn()} />);
+    await pick(fileOf(envelope, 'backup-encrypted.json'));
+
+    await waitFor(() => expect(screen.getByLabelText('Password')).toBeInTheDocument());
+    await userEvent.type(screen.getByLabelText('Password'), PASSWORD);
+    await userEvent.click(screen.getByRole('button', { name: 'Open backup' }));
+
+    // The preflight is the shared path: it ran, which means the decrypted
+    // bundle went through validation and the emptiness check like any other.
+    await waitFor(() => {
+      expect(financialDataIsEmpty).toHaveBeenCalled();
+    });
+    expect(screen.queryByText(/password-protected/i)).not.toBeInTheDocument();
+  });
+
+  it('still reads a plain backup exactly as before', async () => {
+    render(<RestoreBackupModal isOpen onClose={vi.fn()} />);
+    await pick(fileOf(bundleFixture(), 'backup.json'));
+
+    await waitFor(() => {
+      expect(financialDataIsEmpty).toHaveBeenCalled();
+    });
+    expect(screen.queryByLabelText('Password')).not.toBeInTheDocument();
+  });
+});

--- a/src/pages/ExportManager.tsx
+++ b/src/pages/ExportManager.tsx
@@ -27,6 +27,7 @@ import { dataPort } from '@data';
 // bundle through `dataPort` and only needs the file's own vocabulary, while
 // `backupService` opens with a Supabase client. See docs/edition-gating.md.
 import { downloadBackupBundle, type ExportProgress } from '../services/backup/format';
+import { encryptBackupBundle, downloadEncryptedBackup } from '../services/backup/encryption';
 import { selectExportData, describeExportRange, type AccountsScope } from '../utils/exportSelection';
 import { generateDataExportPDF } from '../utils/pdfExport';
 import {
@@ -87,6 +88,15 @@ export default function ExportManager(): React.JSX.Element {
   const [isBackingUp, setIsBackingUp] = useState(false);
   const [backupProgress, setBackupProgress] = useState<ExportProgress | null>(null);
   const [backupError, setBackupError] = useState('');
+  // Password-protection is OPT-IN, and stays that way. A forgotten password
+  // makes the file unopenable by anyone including us, and a backup you cannot
+  // open is worse than none: you spent the months since believing you had one.
+  // Plain JSON also stays genuinely useful — readable, greppable, scriptable —
+  // which is most of what makes it a portability export.
+  const [protectBackup, setProtectBackup] = useState(false);
+  const [backupPassword, setBackupPassword] = useState('');
+  const [backupPasswordConfirm, setBackupPasswordConfirm] = useState('');
+  const [isProtecting, setIsProtecting] = useState(false);
   const [format, setFormat] = useState<ExportFormat>('pdf');
   const [includeTransactions, setIncludeTransactions] = useState(true);
   const [includeAccounts, setIncludeAccounts] = useState(true);
@@ -209,7 +219,16 @@ export default function ExportManager(): React.JSX.Element {
     setBackupProgress(null);
     try {
       const bundle = await dataPort.collectBackup({ onProgress: setBackupProgress });
-      downloadBackupBundle(bundle);
+      if (protectBackup) {
+        // Key derivation is deliberately slow — 600,000 PBKDF2 rounds, about
+        // half a second — so the button has to say what it is doing or it
+        // reads as hung right at the end of a long read.
+        setBackupProgress(null);
+        setIsProtecting(true);
+        downloadEncryptedBackup(await encryptBackupBundle(bundle, backupPassword));
+      } else {
+        downloadBackupBundle(bundle);
+      }
     } catch (error) {
       exportManagerLogger.error('Full backup failed', error);
       // Say what the database said. A half-read backup that downloads anyway is
@@ -217,9 +236,27 @@ export default function ExportManager(): React.JSX.Element {
       setBackupError(error instanceof Error ? error.message : 'The backup could not be completed.');
     } finally {
       setIsBackingUp(false);
+      setIsProtecting(false);
       setBackupProgress(null);
     }
   };
+
+  /**
+   * The reason the button is disabled, or null. Said out loud rather than left
+   * for the user to deduce from a dead control — the same rule that governs
+   * every other refusal in the app.
+   *
+   * Eight characters is a floor, not advice. The thing that actually protects
+   * this file is the 600,000-round derivation behind it; a short password is
+   * still the weak end, so the copy asks for a phrase rather than a password.
+   */
+  const backupPasswordProblem = useMemo((): string | null => {
+    if (!protectBackup) return null;
+    if (backupPassword.length === 0) return 'Enter a password to protect the file.';
+    if (backupPassword.length < 8) return 'Use at least 8 characters.';
+    if (backupPasswordConfirm !== backupPassword) return 'The two passwords do not match.';
+    return null;
+  }, [protectBackup, backupPassword, backupPasswordConfirm]);
 
   /**
    * Apply a template — ALL of it. The previous version overwrote the saved
@@ -482,23 +519,120 @@ export default function ExportManager(): React.JSX.Element {
                   &rarr; Restore from backup reads it back. It also satisfies a data-portability request.
                 </p>
 
-                <div className="rounded-xl border border-amber-200 dark:border-amber-800 bg-amber-50 dark:bg-amber-900/20 p-3 mb-4 flex items-start gap-3">
-                  <AlertTriangleIcon className="text-amber-600 dark:text-amber-400 mt-0.5 shrink-0" size={18} />
-                  <p className="text-body text-amber-900 dark:text-amber-200">
-                    This file is plain, readable JSON and it is <strong>not encrypted</strong>. Anyone who
-                    opens it can see every account name, balance and transaction you have. Keep it
-                    somewhere you would be willing to keep a bank statement — not a shared drive, not a
-                    Downloads folder you never empty.
-                  </p>
+                {/* CONDITIONAL, and that is Claude Design's ruling rather than a
+                    convenience (answers of 15 Aug, §1). This is a WARNING, not a
+                    caveat: a caveat describes the view and costs a skimmer
+                    nothing, while this describes what happens to the file after
+                    it leaves the app, where we can no longer protect it. So it
+                    keeps the warning pair and its position beside the button —
+                    and it disappears when the file is protected, because then it
+                    is not true. Amber that can be absent is the same property
+                    the yellow thread has, and the reason it still means
+                    something when present. */}
+                {!protectBackup && (
+                  <div className="rounded-xl border border-amber-200 dark:border-amber-800 bg-amber-50 dark:bg-amber-900/20 p-3 mb-4 flex items-start gap-3">
+                    <AlertTriangleIcon className="text-amber-600 dark:text-amber-400 mt-0.5 shrink-0" size={18} />
+                    <p className="text-body text-amber-900 dark:text-amber-200">
+                      This file is plain, readable JSON and it is <strong>not encrypted</strong>. Anyone who
+                      opens it can see every account name, balance and transaction you have. Keep it
+                      somewhere you would be willing to keep a bank statement — not a shared drive, not a
+                      Downloads folder you never empty.
+                    </p>
+                  </div>
+                )}
+
+                <div className="mb-4">
+                  <label className="flex items-start gap-3 cursor-pointer">
+                    <input
+                      type="checkbox"
+                      checked={protectBackup}
+                      onChange={(e) => {
+                        setProtectBackup(e.target.checked);
+                        // Not left lying in state once the choice is reversed.
+                        if (!e.target.checked) {
+                          setBackupPassword('');
+                          setBackupPasswordConfirm('');
+                        }
+                      }}
+                      className="mt-0.5 h-4 w-4 rounded border-gray-300 dark:border-gray-600"
+                    />
+                    <span>
+                      <span className="block text-body font-medium text-gray-900 dark:text-white">
+                        Protect this backup with a password
+                      </span>
+                      <span className="block text-body text-gray-500 dark:text-gray-400">
+                        Encrypts the file so its contents cannot be read without the password.
+                        You will be asked for it when restoring.
+                      </span>
+                    </span>
+                  </label>
+
+                  {protectBackup && (
+                    <div className="mt-3 pl-7 space-y-3">
+                      <div>
+                        <label htmlFor="backup-password" className="block text-body font-medium text-gray-700 dark:text-gray-300 mb-1">
+                          Password
+                        </label>
+                        <input
+                          id="backup-password"
+                          type="password"
+                          autoComplete="new-password"
+                          value={backupPassword}
+                          onChange={(e) => setBackupPassword(e.target.value)}
+                          className="w-full max-w-sm px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-700 text-gray-900 dark:text-white"
+                        />
+                      </div>
+                      <div>
+                        <label htmlFor="backup-password-confirm" className="block text-body font-medium text-gray-700 dark:text-gray-300 mb-1">
+                          Password again
+                        </label>
+                        <input
+                          id="backup-password-confirm"
+                          type="password"
+                          autoComplete="new-password"
+                          value={backupPasswordConfirm}
+                          onChange={(e) => setBackupPasswordConfirm(e.target.value)}
+                          className="w-full max-w-sm px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-700 text-gray-900 dark:text-white"
+                        />
+                      </div>
+
+                      {/* The consequence first, then the remedy — and the
+                          consequence here is total. Nobody can open this file
+                          without the password: not another device, not a
+                          support request, not us. That is the point of it, and
+                          it is the one thing someone ticking this box may not
+                          have thought through. */}
+                      <div className="rounded-xl border border-amber-200 dark:border-amber-800 bg-amber-50 dark:bg-amber-900/20 p-3 flex items-start gap-3">
+                        <AlertTriangleIcon className="text-amber-600 dark:text-amber-400 mt-0.5 shrink-0" size={18} />
+                        <p className="text-body text-amber-900 dark:text-amber-200">
+                          <strong>If you lose this password the backup cannot be opened</strong> — not by
+                          another device, not by us. There is no reset. Write it down somewhere separate
+                          from the file, or keep it in a password manager.
+                        </p>
+                      </div>
+
+                      {backupPasswordProblem && (
+                        <p className="text-body text-gray-600 dark:text-gray-400" aria-live="polite">
+                          {backupPasswordProblem}
+                        </p>
+                      )}
+                    </div>
+                  )}
                 </div>
 
                 <button
                   onClick={() => { void handleExportEverything(); }}
-                  disabled={isBackingUp}
+                  disabled={isBackingUp || backupPasswordProblem !== null}
                   className="flex items-center gap-2 px-4 py-3 text-gray-700 dark:text-gray-300 border border-gray-300 dark:border-gray-600 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-700 disabled:opacity-50 disabled:cursor-not-allowed"
                 >
                   {isBackingUp ? <RefreshCwIcon size={16} className="animate-spin" /> : <DownloadIcon size={16} />}
-                  {isBackingUp ? 'Reading your data…' : 'Download full backup (JSON)'}
+                  {isProtecting
+                    ? 'Protecting the file…'
+                    : isBackingUp
+                    ? 'Reading your data…'
+                    : protectBackup
+                    ? 'Download protected backup (JSON)'
+                    : 'Download full backup (JSON)'}
                 </button>
 
                 {/* A real dataset is 50k+ transactions and 50+ round trips, so

--- a/src/pages/__tests__/ExportManager.test.tsx
+++ b/src/pages/__tests__/ExportManager.test.tsx
@@ -461,4 +461,102 @@ describe('Export Data page', () => {
       expect(screen.getByText('No templates')).toBeInTheDocument();
     });
   });
+
+  /**
+   * Password-protecting the backup.
+   *
+   * Two claims worth a test. The first is cryptographic: what lands on disk
+   * must not contain the account names and balances that went in. The second
+   * is Claude Design's ruling of 15 August — the "not encrypted" warning is a
+   * WARNING rather than a caveat, which is why it keeps the amber pair, and
+   * why it must be ABSENT when it is no longer true. Amber that cannot be
+   * absent stops meaning anything.
+   */
+  describe('protecting the full backup with a password', () => {
+    const bundle = buildBackupBundle({
+      sourceUserId: 'source-login',
+      exportedAt: '2026-03-04T10:00:00.000Z',
+      data: {
+        accounts: [{ id: 'acct-1', name: 'Everyday', type: 'current', balance: '10.00' }]
+      },
+      preferences: null
+    });
+
+    const tick = (): void =>
+      fireEvent.click(screen.getByLabelText(/Protect this backup with a password/i));
+
+    const typeBoth = (value: string): void => {
+      fireEvent.change(screen.getByLabelText('Password'), { target: { value } });
+      fireEvent.change(screen.getByLabelText('Password again'), { target: { value } });
+    };
+
+    it('warns that the file is readable, and stops warning once it is not', async () => {
+      renderPage();
+
+      expect(screen.getByText(/not encrypted/i)).toBeInTheDocument();
+
+      tick();
+
+      // The statement has become false, so it goes. What replaces it is the
+      // consequence of the choice just made, which is a different warning.
+      expect(screen.queryByText(/not encrypted/i)).not.toBeInTheDocument();
+      expect(screen.getByText(/cannot be opened/i)).toBeInTheDocument();
+    });
+
+    it('will not export until the two passwords agree', async () => {
+      renderPage();
+      tick();
+
+      const button = screen.getByRole('button', { name: /Download protected backup/i });
+      expect(button).toBeDisabled();
+
+      fireEvent.change(screen.getByLabelText('Password'), { target: { value: 'longenough' } });
+      fireEvent.change(screen.getByLabelText('Password again'), { target: { value: 'different!' } });
+      expect(button).toBeDisabled();
+      expect(screen.getByText(/do not match/i)).toBeInTheDocument();
+
+      typeBoth('longenough');
+      expect(button).toBeEnabled();
+    });
+
+    it('says why a short password is refused rather than just going dead', async () => {
+      renderPage();
+      tick();
+      typeBoth('short');
+
+      expect(screen.getByText(/at least 8 characters/i)).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: /Download protected backup/i })).toBeDisabled();
+    });
+
+    it('writes a file with nothing readable in it', async () => {
+      seam.collectBackup.mockResolvedValue(bundle);
+      renderPage();
+      tick();
+      typeBoth('a good long password');
+
+      fireEvent.click(screen.getByRole('button', { name: /Download protected backup/i }));
+
+      await waitFor(() => expect(downloads.length).toBe(1));
+      const written = downloads[0].text;
+
+      // The whole point, checked on the actual bytes that reach the disk.
+      expect(written).not.toContain('Everyday');
+      expect(written).not.toContain('10.00');
+      expect(written).not.toContain('acct-1');
+      // And it still says what it is, so a reader is not left guessing.
+      expect(written).toContain('wealthtracker-encrypted-backup');
+      expect(written).toContain('PBKDF2');
+    });
+
+    it('leaves the plain path exactly as it was', async () => {
+      seam.collectBackup.mockResolvedValue(bundle);
+      renderPage();
+
+      fireEvent.click(screen.getByRole('button', { name: /Download full backup/i }));
+
+      await waitFor(() => expect(downloads.length).toBe(1));
+      expect(downloads[0].text).toContain('Everyday');
+    });
+  });
+
 });

--- a/src/services/backup/__tests__/encryption.test.ts
+++ b/src/services/backup/__tests__/encryption.test.ts
@@ -1,0 +1,212 @@
+/**
+ * Password-protected backups — against real Web Crypto, not a stubbed cipher.
+ *
+ * jsdom ships an object at `crypto.subtle` whose `deriveKey` is missing, so
+ * `src/test/browserShims.ts` swaps in Node's `webcrypto`. That is the same
+ * specification and the same algorithms, so everything below exercises real
+ * AES-GCM and real PBKDF2 — a break in the cipher would fail these tests.
+ *
+ * The tests that matter most are the refusals. An encryption feature whose
+ * happy path works and whose failure path silently returns rubbish is worse
+ * than no encryption, because the rubbish gets restored over real data.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  encryptBackupBundle,
+  decryptBackupBundle,
+  isEncryptedBackup,
+  encryptedBackupFileName,
+  BackupDecryptionError,
+  ENCRYPTED_BACKUP_FORMAT,
+  PBKDF2_ITERATIONS,
+} from '../encryption';
+import type { BackupBundle } from '../format';
+
+/** Shaped like a bundle, with values chosen so a partial decrypt is obvious. */
+function bundleFixture(): BackupBundle {
+  return {
+    format: 'wealthtracker-backup-v2',
+    version: '20260812140000',
+    exportedAt: '2026-08-15T09:30:00.000Z',
+    rows: {
+      accounts: [{ id: 'acc-1', name: 'Everyday', balance: '1234.56' }],
+      transactions: [{ id: 'txn-1', account_id: 'acc-1', amount: '-19.99' }],
+    },
+    links: { accountParents: [], transactionLinks: [] },
+    preferences: { currency: 'GBP' },
+  } as unknown as BackupBundle;
+}
+
+const PASSWORD = 'correct horse battery staple';
+
+describe('backup encryption', () => {
+  describe('the round trip', () => {
+    it('gives back exactly the bundle that went in', async () => {
+      const original = bundleFixture();
+      const envelope = await encryptBackupBundle(original, PASSWORD);
+      const restored = await decryptBackupBundle(envelope, PASSWORD);
+
+      expect(restored).toEqual(original);
+    });
+
+    it('puts nothing readable in the envelope', async () => {
+      const envelope = await encryptBackupBundle(bundleFixture(), PASSWORD);
+      const asText = JSON.stringify(envelope);
+
+      // The values a person would care about leaking, checked individually so
+      // a failure names which one escaped.
+      expect(asText).not.toContain('Everyday');
+      expect(asText).not.toContain('1234.56');
+      expect(asText).not.toContain('19.99');
+      expect(asText).not.toContain('acc-1');
+      expect(asText).not.toContain('GBP');
+    });
+
+    it('publishes the date, and only the date', async () => {
+      const envelope = await encryptBackupBundle(bundleFixture(), PASSWORD);
+
+      // So the restore dialog can label three files without opening them.
+      expect(envelope.exportedAt).toBe('2026-08-15T09:30:00.000Z');
+      expect(envelope.kdf.iterations).toBe(PBKDF2_ITERATIONS);
+      expect(envelope.kdf.name).toBe('PBKDF2');
+      expect(envelope.cipher.name).toBe('AES-GCM');
+    });
+
+    it('never writes the same file twice for the same input', async () => {
+      const bundle = bundleFixture();
+      const first = await encryptBackupBundle(bundle, PASSWORD);
+      const second = await encryptBackupBundle(bundle, PASSWORD);
+
+      // Fresh salt and IV each time. Equal ciphertexts would mean a fixed IV,
+      // which is the classic way to make GCM leak.
+      expect(first.cipher.iv).not.toBe(second.cipher.iv);
+      expect(first.kdf.salt).not.toBe(second.kdf.salt);
+      expect(first.ciphertext).not.toBe(second.ciphertext);
+    });
+  });
+
+  describe('the refusals', () => {
+    it('refuses the wrong password without guessing which fault it was', async () => {
+      const envelope = await encryptBackupBundle(bundleFixture(), PASSWORD);
+
+      await expect(
+        decryptBackupBundle(envelope, 'not the password')
+      ).rejects.toThrow(BackupDecryptionError);
+
+      // Naming only "wrong password" would send someone away to retype a
+      // password that was right, when the file was the thing that changed.
+      await expect(
+        decryptBackupBundle(envelope, 'not the password')
+      ).rejects.toThrow(/altered since it was made/);
+    });
+
+    it('refuses a file altered by one byte', async () => {
+      const envelope = await encryptBackupBundle(bundleFixture(), PASSWORD);
+      const bytes = atob(envelope.ciphertext);
+      const flipped = `${String.fromCharCode(bytes.charCodeAt(0) ^ 0x01)}${bytes.slice(1)}`;
+
+      // This is the property that makes GCM the right choice: a tampered
+      // backup fails loudly instead of restoring plausible rubbish.
+      await expect(
+        decryptBackupBundle({ ...envelope, ciphertext: btoa(flipped) }, PASSWORD)
+      ).rejects.toThrow(BackupDecryptionError);
+    });
+
+    it('refuses a file whose header says it is newer than this app', async () => {
+      const envelope = await encryptBackupBundle(bundleFixture(), PASSWORD);
+
+      await expect(
+        decryptBackupBundle({ ...envelope, version: 99 }, PASSWORD)
+      ).rejects.toThrow(/newer version/);
+    });
+
+    it('will not encrypt with an empty password', async () => {
+      await expect(encryptBackupBundle(bundleFixture(), '')).rejects.toThrow(
+        /password is required/
+      );
+    });
+  });
+
+  describe('recognising an encrypted file', () => {
+    it('recognises one it wrote', async () => {
+      const envelope = await encryptBackupBundle(bundleFixture(), PASSWORD);
+      expect(isEncryptedBackup(envelope)).toBe(true);
+    });
+
+    it('does not mistake a plain backup for one', () => {
+      expect(isEncryptedBackup(bundleFixture())).toBe(false);
+    });
+
+    it('rejects a file that claims the format but lacks its parts', () => {
+      // Reaches "this file is damaged" rather than throwing inside decrypt.
+      expect(isEncryptedBackup({ format: ENCRYPTED_BACKUP_FORMAT })).toBe(false);
+      expect(
+        isEncryptedBackup({
+          format: ENCRYPTED_BACKUP_FORMAT,
+          ciphertext: 'x',
+          cipher: { iv: 'y' },
+          kdf: { salt: 'z' }, // no iterations
+        })
+      ).toBe(false);
+    });
+
+    it('survives the things a file picker actually yields', () => {
+      expect(isEncryptedBackup(null)).toBe(false);
+      expect(isEncryptedBackup(undefined)).toBe(false);
+      expect(isEncryptedBackup('a string')).toBe(false);
+      expect(isEncryptedBackup([])).toBe(false);
+    });
+  });
+
+  describe('data that is large or awkward', () => {
+    it('handles a bundle far past the chunking boundary', async () => {
+      // toBase64 chunks at 0x8000; `fromCharCode(...bytes)` on the whole array
+      // would overflow the stack, and only on the big files worth protecting.
+      const big = bundleFixture();
+      (big as unknown as { rows: { transactions: unknown[] } }).rows.transactions =
+        Array.from({ length: 5000 }, (_, i) => ({
+          id: `txn-${i}`,
+          description: `Payment number ${i}`,
+          amount: '-12.34',
+        }));
+
+      const envelope = await encryptBackupBundle(big, PASSWORD);
+      const restored = await decryptBackupBundle(envelope, PASSWORD);
+
+      expect(restored).toEqual(big);
+    });
+
+    it('keeps non-ASCII intact through the trip', async () => {
+      const bundle = bundleFixture();
+      (bundle as unknown as { rows: { accounts: Record<string, unknown>[] } }).rows.accounts = [
+        { id: 'a', name: 'Café — Épargne 💷 £' },
+      ];
+
+      const restored = await decryptBackupBundle(
+        await encryptBackupBundle(bundle, PASSWORD),
+        PASSWORD
+      );
+
+      expect(
+        (restored as unknown as { rows: { accounts: { name: string }[] } }).rows.accounts[0].name
+      ).toBe('Café — Épargne 💷 £');
+    });
+
+    it('accepts a password with spaces and symbols', async () => {
+      const password = ' pass phrase — with "quotes" & £symbols\t ';
+      const restored = await decryptBackupBundle(
+        await encryptBackupBundle(bundleFixture(), password),
+        password
+      );
+      expect(restored).toEqual(bundleFixture());
+    });
+  });
+
+  describe('the file name', () => {
+    it('carries the date and says it is encrypted', () => {
+      expect(encryptedBackupFileName('2026-08-15T09:30:00.000Z')).toBe(
+        'wealthtracker-backup-2026-08-15-encrypted.json'
+      );
+    });
+  });
+});

--- a/src/services/backup/encryption.ts
+++ b/src/services/backup/encryption.ts
@@ -1,0 +1,245 @@
+/**
+ * PASSWORD-PROTECTING A BACKUP.
+ *
+ * The full backup is the only export that can be restored, and the only one
+ * that puts a readable copy of someone's entire financial life on their disk.
+ * Until now it was plain JSON with a warning attached. This makes the warning
+ * optional by making the plainness optional.
+ *
+ * ## What this uses, and what it deliberately does not
+ *
+ * Web Crypto (`crypto.subtle`): **AES-256-GCM** for the cipher, **PBKDF2** with
+ * SHA-256 to turn a password into a key. Both are native, both are current.
+ *
+ * It does NOT use `encryptedStorageService`, the app's existing CryptoJS-based
+ * helper, for two measured reasons: CryptoJS's passphrase mode derives its key
+ * with the old OpenSSL `EVP_BytesToKey` construction (a small number of MD5
+ * rounds, no configurable cost), and CryptoJS was measured at ~92% of the cost
+ * of every write in this app. A backup is the one file where key-stretching
+ * cost is a feature and throughput is irrelevant.
+ *
+ * **GCM is authenticated**, which is the property that matters here: a file
+ * that has been altered by one byte fails to decrypt rather than decrypting
+ * into plausible-looking rubbish that then gets restored over real data.
+ *
+ * ## Why the envelope is JSON
+ *
+ * An encrypted backup is still a `.json` file, and restore still begins by
+ * parsing it. That means detection is a field check rather than a sniff, and —
+ * more importantly — the file says what it is. Someone who finds one of these
+ * in five years, with this app long gone, can read the header and knows the
+ * algorithm, the KDF, the iteration count and the salt. A backup format that
+ * cannot be opened without its original software is not a backup.
+ *
+ * The iteration count travels IN the file for the same reason: raising it later
+ * must not strand the files written before the change.
+ */
+import type { BackupBundle } from './format';
+
+export const ENCRYPTED_BACKUP_FORMAT = 'wealthtracker-encrypted-backup';
+export const ENCRYPTED_BACKUP_VERSION = 1;
+
+/**
+ * OWASP's 2023 floor for PBKDF2-SHA-256. Roughly half a second on a current
+ * laptop — unnoticeable once, when writing a file you will keep for years, and
+ * the entire defence against someone brute-forcing a weak password offline
+ * after the file leaks. Raise it freely; old files carry their own count.
+ */
+export const PBKDF2_ITERATIONS = 600_000;
+
+const SALT_BYTES = 16;
+const IV_BYTES = 12; // 96 bits, the size GCM is specified for
+
+export interface EncryptedBackupEnvelope {
+  format: typeof ENCRYPTED_BACKUP_FORMAT;
+  version: number;
+  /** Plain, so a person can read what protects the file without decrypting it. */
+  kdf: {
+    name: 'PBKDF2';
+    hash: 'SHA-256';
+    iterations: number;
+    salt: string;
+  };
+  cipher: {
+    name: 'AES-GCM';
+    iv: string;
+  };
+  ciphertext: string;
+  /**
+   * Unencrypted, and only ever this. It lets the restore dialog say "made on
+   * the 14th of August" before asking for a password, so someone choosing
+   * between three backup files does not have to guess-and-decrypt. Anything
+   * that would identify an account, a balance or a person stays inside.
+   */
+  exportedAt: string;
+}
+
+/** Thrown when a file will not open. See the message for why it is one error. */
+export class BackupDecryptionError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'BackupDecryptionError';
+  }
+}
+
+/**
+ * Chunked, because a real backup is tens of megabytes and
+ * `String.fromCharCode(...bytes)` on that many arguments overflows the stack —
+ * a bug that only appears on the large files most worth protecting.
+ */
+function toBase64(bytes: Uint8Array): string {
+  const CHUNK = 0x8000;
+  let binary = '';
+  for (let i = 0; i < bytes.length; i += CHUNK) {
+    binary += String.fromCharCode(...bytes.subarray(i, i + CHUNK));
+  }
+  return btoa(binary);
+}
+
+function fromBase64(value: string): Uint8Array {
+  const binary = atob(value);
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i += 1) {
+    bytes[i] = binary.charCodeAt(i);
+  }
+  return bytes;
+}
+
+async function deriveKey(
+  passphrase: string,
+  salt: Uint8Array,
+  iterations: number
+): Promise<CryptoKey> {
+  const material = await crypto.subtle.importKey(
+    'raw',
+    new TextEncoder().encode(passphrase),
+    'PBKDF2',
+    false,
+    ['deriveKey']
+  );
+  return crypto.subtle.deriveKey(
+    { name: 'PBKDF2', salt: salt as BufferSource, iterations, hash: 'SHA-256' },
+    material,
+    { name: 'AES-GCM', length: 256 },
+    false,
+    ['encrypt', 'decrypt']
+  );
+}
+
+export async function encryptBackupBundle(
+  bundle: BackupBundle,
+  passphrase: string
+): Promise<EncryptedBackupEnvelope> {
+  if (passphrase === '') {
+    throw new Error('A password is required to encrypt a backup.');
+  }
+
+  const salt = crypto.getRandomValues(new Uint8Array(SALT_BYTES));
+  const iv = crypto.getRandomValues(new Uint8Array(IV_BYTES));
+  const key = await deriveKey(passphrase, salt, PBKDF2_ITERATIONS);
+
+  const plaintext = new TextEncoder().encode(JSON.stringify(bundle));
+  const ciphertext = await crypto.subtle.encrypt(
+    { name: 'AES-GCM', iv: iv as BufferSource },
+    key,
+    plaintext as BufferSource
+  );
+
+  return {
+    format: ENCRYPTED_BACKUP_FORMAT,
+    version: ENCRYPTED_BACKUP_VERSION,
+    kdf: {
+      name: 'PBKDF2',
+      hash: 'SHA-256',
+      iterations: PBKDF2_ITERATIONS,
+      salt: toBase64(salt),
+    },
+    cipher: { name: 'AES-GCM', iv: toBase64(iv) },
+    ciphertext: toBase64(new Uint8Array(ciphertext)),
+    exportedAt: bundle.exportedAt,
+  };
+}
+
+/**
+ * Structural, not a `format ===` check alone: a file claiming to be encrypted
+ * but missing its salt should reach the "this file is damaged" message rather
+ * than throwing somewhere inside the decrypt.
+ */
+export function isEncryptedBackup(parsed: unknown): parsed is EncryptedBackupEnvelope {
+  if (typeof parsed !== 'object' || parsed === null) return false;
+  const candidate = parsed as Partial<EncryptedBackupEnvelope>;
+  return (
+    candidate.format === ENCRYPTED_BACKUP_FORMAT &&
+    typeof candidate.ciphertext === 'string' &&
+    typeof candidate.kdf?.salt === 'string' &&
+    typeof candidate.kdf?.iterations === 'number' &&
+    typeof candidate.cipher?.iv === 'string'
+  );
+}
+
+export async function decryptBackupBundle(
+  envelope: EncryptedBackupEnvelope,
+  passphrase: string
+): Promise<BackupBundle> {
+  if (envelope.version > ENCRYPTED_BACKUP_VERSION) {
+    throw new BackupDecryptionError(
+      `This backup was written by a newer version of WealthTracker (format ${envelope.version}). Update the app and try again.`
+    );
+  }
+
+  const key = await deriveKey(
+    passphrase,
+    fromBase64(envelope.kdf.salt),
+    envelope.kdf.iterations
+  );
+
+  let plaintext: ArrayBuffer;
+  try {
+    plaintext = await crypto.subtle.decrypt(
+      { name: 'AES-GCM', iv: fromBase64(envelope.cipher.iv) as BufferSource },
+      key,
+      fromBase64(envelope.ciphertext) as BufferSource
+    );
+  } catch {
+    // GCM cannot tell a wrong key from altered bytes, and it is not a
+    // shortcoming — refusing to distinguish them is what stops an attacker
+    // learning about the key by feeding in edits. So the message names both
+    // and claims neither. Guessing "wrong password" would send someone off to
+    // retype a password that was right all along.
+    throw new BackupDecryptionError(
+      'That password did not open the file, or the file has been altered since it was made.'
+    );
+  }
+
+  try {
+    return JSON.parse(new TextDecoder().decode(plaintext)) as BackupBundle;
+  } catch {
+    throw new BackupDecryptionError(
+      'The file was decrypted but its contents are not a readable backup.'
+    );
+  }
+}
+
+/**
+ * The name carries `-encrypted` because a folder of backups is the place the
+ * distinction is needed and the only place it is invisible: both files end
+ * `.json`, both open in an editor, and only one of them shows you an account
+ * list when it does.
+ */
+export function encryptedBackupFileName(exportedAt: string): string {
+  const stamp = exportedAt.slice(0, 10);
+  return `wealthtracker-backup-${stamp}-encrypted.json`;
+}
+
+/** The sibling of `downloadBackupBundle`, kept beside what it writes. */
+export function downloadEncryptedBackup(envelope: EncryptedBackupEnvelope): void {
+  const blob = new Blob([JSON.stringify(envelope, null, 2)], { type: 'application/json' });
+  const url = URL.createObjectURL(blob);
+  const link = document.createElement('a');
+  link.href = url;
+  link.download = encryptedBackupFileName(envelope.exportedAt);
+  document.body.appendChild(link);
+  link.click();
+  document.body.removeChild(link);
+  URL.revokeObjectURL(url);
+}

--- a/src/test/browserShims.ts
+++ b/src/test/browserShims.ts
@@ -191,3 +191,24 @@ global.requestAnimationFrame = vi.fn((callback) => {
 global.cancelAnimationFrame = vi.fn((id) => {
   clearTimeout(id);
 });
+
+// WEB CRYPTO — a SHIM, and worth being precise about which kind.
+//
+// jsdom supplies `crypto.getRandomValues` and an object at `crypto.subtle`,
+// but that object is a stub: `deriveKey` is not a function. So a feature
+// built on PBKDF2 + AES-GCM typechecks, runs in every real browser, and dies
+// only under test — the worst shape a gap can have.
+//
+// Node's `webcrypto` is the SAME SPEC and the same algorithms, so this is a
+// polyfill rather than a mock: the backup encryption tests exercise real
+// cryptography and would catch a real break. Nothing here is faked, and no
+// test may assert against a stubbed cipher.
+import { webcrypto } from 'node:crypto';
+
+if (typeof globalThis.crypto?.subtle?.deriveKey !== 'function') {
+  Object.defineProperty(globalThis, 'crypto', {
+    value: webcrypto,
+    configurable: true,
+    writable: true,
+  });
+}


### PR DESCRIPTION
The full backup was plain JSON with a warning attached. This makes the plainness optional — which makes the warning conditional, exactly as Claude Design's §1 anticipated ("if the export options grow a password-protect choice later, the notice becomes conditional and disappears when protection is on").

## The cryptography

**AES-256-GCM**, keyed by **PBKDF2-SHA-256 at 600,000 rounds** (OWASP's 2023 floor), through Web Crypto.

Not the existing CryptoJS helper, for two measured reasons: its passphrase mode derives keys with the old OpenSSL `EVP_BytesToKey` construction (a few MD5 rounds, no configurable cost), and CryptoJS was previously measured at ~92% of the cost of every write in this app. A backup is the one file where key-stretching cost is a feature and throughput is irrelevant.

**GCM is authenticated**, which is what earns it the place: a file altered by one byte fails to decrypt rather than decrypting into plausible rubbish that then gets restored over real data.

## The file says what it is

A JSON envelope, so restore still begins by parsing and detection is a field check rather than a sniff. More importantly: algorithm, KDF, iteration count and salt are all in the clear. Someone who finds one of these in five years, with this app long gone, can read the header and knows how to open it. **A backup that needs its original software is not a backup.**

The iteration count travels *in* the file, so raising it later strands nothing. `exportedAt` is the only other plaintext, so the restore dialog can say "made on the 15th of August" before asking for a password — enough to tell three backup files apart without guess-and-decrypt.

## The refusals, which are most of the work

A wrong password and an altered file produce **one message that names both and claims neither**. GCM genuinely cannot distinguish them, and refusing to is the point — it's what stops an attacker learning about the key by feeding in edits. Guessing "wrong password" would send someone off to retype a password that was right all along.

Restore gains a **`locked` phase rather than an error**. An encrypted backup is a perfectly good file that is merely shut; "this file cannot be restored" would send someone looking for another copy of something that is fine.

Decrypted bundles then go through **the same validation, the same session check and the same preflight** as a plain file. The encryption is a wrapper, not a second and thinner path into a destructive operation.

## Opt-in, and staying that way

A forgotten password makes the file unopenable by anyone, us included. **A backup you cannot open is worse than none**, because you spent the months since believing you had one. That is the one thing someone ticking the box may not have thought through, so it sits under the fields rather than in a tooltip. Plain JSON also stays genuinely useful — readable, greppable, scriptable — which is most of what makes it a portability export.

## One test-environment fix

jsdom supplies an object at `crypto.subtle` whose `deriveKey` is missing. This feature would have typechecked, run in every real browser, and died only under test — the worst shape a gap can have. `browserShims` now swaps in Node's `webcrypto`: the same specification and the same algorithms, so these tests exercise **real** cryptography rather than a stubbed cipher.

26 new tests. The ones that matter are the refusals — an encryption feature whose happy path works and whose failure path silently returns rubbish is worse than no encryption.

5974 tests pass, lint and typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
