### PR TITLE
Three ways to write a colour that isn't there

### DIFF
--- a/src/components/AccountSettingsModal.tsx
+++ b/src/components/AccountSettingsModal.tsx
@@ -330,7 +330,7 @@ export default function AccountSettingsModal({
               id="account-type"
               value={formData.type}
               onChange={(e) => updateField('type', e.target.value as Account['type'])}
-              className="w-full px-3 py-2 bg-white dark:bg-gray-800-sm border border-gray-300/50 dark:border-gray-600/50 rounded-xl focus:border-transparent dark:text-white"
+              className="w-full px-3 py-2 bg-white dark:bg-gray-800 border border-gray-300/50 dark:border-gray-600/50 rounded-xl focus:border-transparent dark:text-white"
             >
               {accountTypeOptions.map((option) => (
                 <option key={option.value} value={option.value}>
@@ -357,7 +357,7 @@ export default function AccountSettingsModal({
                   id="account-currency"
                   value={formData.currency}
                   onChange={(e) => updateField('currency', e.target.value)}
-                  className="w-full px-3 py-2 bg-white dark:bg-gray-800-sm border border-gray-300/50 dark:border-gray-600/50 rounded-xl focus:border-transparent dark:text-white"
+                  className="w-full px-3 py-2 bg-white dark:bg-gray-800 border border-gray-300/50 dark:border-gray-600/50 rounded-xl focus:border-transparent dark:text-white"
                 >
                   {/* The account's own code is always among these, even if the
                       app does not support it — see accountCurrencyOptions. */}
@@ -413,14 +413,14 @@ export default function AccountSettingsModal({
                 allowNegative
                 value={formData.openingBalance}
                 onChange={(value) => updateField('openingBalance', value)}
-                className="w-full px-3 py-2 bg-white dark:bg-gray-800-sm border border-gray-300/50 dark:border-gray-600/50 rounded-xl focus:border-transparent dark:text-white"
+                className="w-full px-3 py-2 bg-white dark:bg-gray-800 border border-gray-300/50 dark:border-gray-600/50 rounded-xl focus:border-transparent dark:text-white"
                 aria-label="Opening balance amount"
               />
               <DatePicker
                 id="opening-balance-date"
                 value={formData.openingBalanceDate}
                 onChange={(val) => updateField('openingBalanceDate', val)}
-                className="bg-white dark:bg-gray-800-sm border border-gray-300/50 dark:border-gray-600/50 rounded-xl focus:border-transparent dark:text-white"
+                className="bg-white dark:bg-gray-800 border border-gray-300/50 dark:border-gray-600/50 rounded-xl focus:border-transparent dark:text-white"
                 aria-label="Opening balance date"
               />
               {/* Says what BLANK does, because blank is now the normal state for
@@ -448,7 +448,7 @@ export default function AccountSettingsModal({
                 onChange={handleSortCodeChange}
                 placeholder="XX-XX-XX"
                 maxLength={8}
-                className="w-full px-3 py-2 bg-white dark:bg-gray-800-sm border border-gray-300/50 dark:border-gray-600/50 rounded-xl focus:border-transparent dark:text-white"
+                className="w-full px-3 py-2 bg-white dark:bg-gray-800 border border-gray-300/50 dark:border-gray-600/50 rounded-xl focus:border-transparent dark:text-white"
                 aria-label="Bank sort code"
               />
             </div>
@@ -474,7 +474,7 @@ export default function AccountSettingsModal({
                 // (WCAG 2.5.3 Label in Name).
                 aria-label={isCreditCard ? undefined : 'Bank account number'}
                 {...(isBankAccount ? { maxLength: BANK_ACCOUNT_NUMBER_LENGTH } : {})}
-                className="w-full px-3 py-2 bg-white dark:bg-gray-800-sm border border-gray-300/50 dark:border-gray-600/50 rounded-xl focus:border-transparent dark:text-white"
+                className="w-full px-3 py-2 bg-white dark:bg-gray-800 border border-gray-300/50 dark:border-gray-600/50 rounded-xl focus:border-transparent dark:text-white"
               />
               {isCreditCard && <CardNumberGuidance value={formData.accountNumber} />}
             </div>
@@ -490,7 +490,7 @@ export default function AccountSettingsModal({
                 id="account-parent"
                 value={formData.parentAccountId}
                 onChange={(e) => updateField('parentAccountId', e.target.value)}
-                className="w-full px-3 py-2 bg-white dark:bg-gray-800-sm border border-gray-300/50 dark:border-gray-600/50 rounded-xl focus:border-transparent dark:text-white"
+                className="w-full px-3 py-2 bg-white dark:bg-gray-800 border border-gray-300/50 dark:border-gray-600/50 rounded-xl focus:border-transparent dark:text-white"
               >
                 <option value={NO_PARENT_ACCOUNT}>None</option>
                 {/* Grouped and alphabetised like every other account dropdown. */}
@@ -516,7 +516,7 @@ export default function AccountSettingsModal({
               value={formData.institution}
               onChange={(e) => updateField('institution', e.target.value)}
               placeholder="Bank or financial institution name"
-              className="w-full px-3 py-2 bg-white dark:bg-gray-800-sm border border-gray-300/50 dark:border-gray-600/50 rounded-xl focus:border-transparent dark:text-white"
+              className="w-full px-3 py-2 bg-white dark:bg-gray-800 border border-gray-300/50 dark:border-gray-600/50 rounded-xl focus:border-transparent dark:text-white"
             />
           </div>
 
@@ -529,7 +529,7 @@ export default function AccountSettingsModal({
               id="account-active"
               value={formData.isActive ? 'active' : 'closed'}
               onChange={(e) => updateField('isActive', e.target.value === 'active')}
-              className="w-full px-3 py-2 bg-white dark:bg-gray-800-sm border border-gray-300/50 dark:border-gray-600/50 rounded-xl focus:border-transparent dark:text-white"
+              className="w-full px-3 py-2 bg-white dark:bg-gray-800 border border-gray-300/50 dark:border-gray-600/50 rounded-xl focus:border-transparent dark:text-white"
             >
               <option value="active">Open</option>
               <option value="closed">Closed</option>
@@ -574,7 +574,7 @@ export default function AccountSettingsModal({
                   value={formData.lowBalanceThreshold}
                   onChange={(value) => updateField('lowBalanceThreshold', value)}
                   placeholder="e.g. 500"
-                  className="w-full px-3 py-2 bg-white dark:bg-gray-800-sm border border-gray-300/50 dark:border-gray-600/50 rounded-xl focus:border-transparent dark:text-white"
+                  className="w-full px-3 py-2 bg-white dark:bg-gray-800 border border-gray-300/50 dark:border-gray-600/50 rounded-xl focus:border-transparent dark:text-white"
                 />
               </div>
             )}
@@ -591,7 +591,7 @@ export default function AccountSettingsModal({
               onChange={(e) => updateField('notes', e.target.value)}
               rows={3}
               placeholder="Additional information about this account"
-              className="w-full px-3 py-2 bg-white dark:bg-gray-800-sm border border-gray-300/50 dark:border-gray-600/50 rounded-xl focus:border-transparent dark:text-white resize-none"
+              className="w-full px-3 py-2 bg-white dark:bg-gray-800 border border-gray-300/50 dark:border-gray-600/50 rounded-xl focus:border-transparent dark:text-white resize-none"
             />
           </div>
 

--- a/src/components/AddAccountModal.tsx
+++ b/src/components/AddAccountModal.tsx
@@ -239,7 +239,7 @@ export default function AddAccountModal({ isOpen, onClose, prefill, onAccountCre
                       aria-pressed={isSelected}
                       className={`p-3 rounded-xl border-2 transition-all duration-200 ${
                         isSelected
-                          ? 'border-primary bg-[#1a2332]/10 dark:bg-primary/20'
+                          ? 'border-primary bg-[#1a2332]/10 dark:bg-[#1a2332]/20'
                           : 'border-gray-200 dark:border-gray-700 hover:border-gray-300 dark:hover:border-gray-600'
                       } ${isSubmitting ? 'opacity-50 cursor-not-allowed' : ''}`}
                     >
@@ -394,7 +394,7 @@ export default function AddAccountModal({ isOpen, onClose, prefill, onAccountCre
 
             {/* Account Type Info Banner */}
             {selectedType && (
-              <div className="p-4 bg-primary/5 dark:bg-[#1a2332]/10 rounded-xl border border-primary/20">
+              <div className="p-4 bg-[#1a2332]/5 dark:bg-[#1a2332]/10 rounded-xl border border-[#1a2332]/20">
                 <div className="flex gap-3">
                   <selectedType.icon size={20} className="text-primary mt-0.5" />
                   <div>

--- a/src/components/AddInvestmentModal.tsx
+++ b/src/components/AddInvestmentModal.tsx
@@ -150,7 +150,7 @@ export default function AddInvestmentModal({ isOpen, onClose, accountId }: AddIn
               <select
                 value={formData.selectedAccountId}
                 onChange={(e) => updateField('selectedAccountId', e.target.value)}
-                className="w-full px-3 py-2 bg-white dark:bg-gray-800-sm border border-gray-300/50 dark:border-gray-600/50 rounded-xl focus:border-transparent dark:text-white"
+                className="w-full px-3 py-2 bg-white dark:bg-gray-800 border border-gray-300/50 dark:border-gray-600/50 rounded-xl focus:border-transparent dark:text-white"
                 required
               >
                 <option value="">Select an investment account</option>
@@ -211,7 +211,7 @@ export default function AddInvestmentModal({ isOpen, onClose, accountId }: AddIn
                 value={formData.stockCode}
                 onChange={(e) => updateField('stockCode', e.target.value.toUpperCase())}
                 placeholder={formData.investmentType === 'share' ? 'AAPL' : formData.investmentType === 'fund' ? 'ISIN/SEDOL' : 'Optional'}
-                className="w-full px-3 py-2 bg-white dark:bg-gray-800-sm border border-gray-300/50 dark:border-gray-600/50 rounded-xl focus:border-transparent dark:text-white"
+                className="w-full px-3 py-2 bg-white dark:bg-gray-800 border border-gray-300/50 dark:border-gray-600/50 rounded-xl focus:border-transparent dark:text-white"
                 disabled={formData.investmentType === 'cash'}
               />
             </div>
@@ -226,7 +226,7 @@ export default function AddInvestmentModal({ isOpen, onClose, accountId }: AddIn
                 value={formData.name}
                 onChange={(e) => updateField('name', e.target.value)}
                 placeholder={formData.investmentType === 'share' ? 'Apple Inc.' : formData.investmentType === 'fund' ? 'Fund Name' : 'Description'}
-                className="w-full px-3 py-2 bg-white dark:bg-gray-800-sm border border-gray-300/50 dark:border-gray-600/50 rounded-xl focus:border-transparent dark:text-white"
+                className="w-full px-3 py-2 bg-white dark:bg-gray-800 border border-gray-300/50 dark:border-gray-600/50 rounded-xl focus:border-transparent dark:text-white"
                 required
               />
             </div>
@@ -242,7 +242,7 @@ export default function AddInvestmentModal({ isOpen, onClose, accountId }: AddIn
                 value={formData.units}
                 onChange={(e) => updateField('units', e.target.value)}
                 placeholder={formData.investmentType === 'cash' ? '1000.00' : '100'}
-                className="w-full px-3 py-2 bg-white dark:bg-gray-800-sm border border-gray-300/50 dark:border-gray-600/50 rounded-xl focus:border-transparent dark:text-white"
+                className="w-full px-3 py-2 bg-white dark:bg-gray-800 border border-gray-300/50 dark:border-gray-600/50 rounded-xl focus:border-transparent dark:text-white"
                 required
               />
             </div>
@@ -257,7 +257,7 @@ export default function AddInvestmentModal({ isOpen, onClose, accountId }: AddIn
                 value={formData.pricePerUnit}
                 onChange={(value) => updateField('pricePerUnit', value)}
                 placeholder={formData.investmentType === 'cash' ? '1.00' : '150.00'}
-                className="w-full px-3 py-2 bg-white dark:bg-gray-800-sm border border-gray-300/50 dark:border-gray-600/50 rounded-xl focus:border-transparent dark:text-white"
+                className="w-full px-3 py-2 bg-white dark:bg-gray-800 border border-gray-300/50 dark:border-gray-600/50 rounded-xl focus:border-transparent dark:text-white"
                 required
               />
             </div>
@@ -271,7 +271,7 @@ export default function AddInvestmentModal({ isOpen, onClose, accountId }: AddIn
                 id="investment-fees"
                 value={formData.fees}
                 onChange={(value) => updateField('fees', value)}
-                className="w-full px-3 py-2 bg-white dark:bg-gray-800-sm border border-gray-300/50 dark:border-gray-600/50 rounded-xl focus:border-transparent dark:text-white"
+                className="w-full px-3 py-2 bg-white dark:bg-gray-800 border border-gray-300/50 dark:border-gray-600/50 rounded-xl focus:border-transparent dark:text-white"
               />
             </div>
             
@@ -284,7 +284,7 @@ export default function AddInvestmentModal({ isOpen, onClose, accountId }: AddIn
                 id="investment-stamp-duty"
                 value={formData.stampDuty}
                 onChange={(value) => updateField('stampDuty', value)}
-                className="w-full px-3 py-2 bg-white dark:bg-gray-800-sm border border-gray-300/50 dark:border-gray-600/50 rounded-xl focus:border-transparent dark:text-white"
+                className="w-full px-3 py-2 bg-white dark:bg-gray-800 border border-gray-300/50 dark:border-gray-600/50 rounded-xl focus:border-transparent dark:text-white"
               />
             </div>
             
@@ -298,7 +298,7 @@ export default function AddInvestmentModal({ isOpen, onClose, accountId }: AddIn
               <DatePicker
                 value={formData.date}
                 onChange={(val) => updateField('date', val)}
-                className="bg-white dark:bg-gray-800-sm border border-gray-300/50 dark:border-gray-600/50 rounded-xl focus:border-transparent dark:text-white"
+                className="bg-white dark:bg-gray-800 border border-gray-300/50 dark:border-gray-600/50 rounded-xl focus:border-transparent dark:text-white"
                 required
                 aria-label="Purchase date"
               />
@@ -352,7 +352,7 @@ export default function AddInvestmentModal({ isOpen, onClose, accountId }: AddIn
               onChange={(e) => updateField('notes', e.target.value)}
               rows={3}
               placeholder="Additional information about this investment..."
-              className="w-full px-3 py-2 bg-white dark:bg-gray-800-sm border border-gray-300/50 dark:border-gray-600/50 rounded-xl focus:border-transparent dark:text-white"
+              className="w-full px-3 py-2 bg-white dark:bg-gray-800 border border-gray-300/50 dark:border-gray-600/50 rounded-xl focus:border-transparent dark:text-white"
             />
           </div>
           

--- a/src/components/BudgetModal.tsx
+++ b/src/components/BudgetModal.tsx
@@ -220,7 +220,7 @@ export default function BudgetModal({ isOpen, onClose, budget, onEditExisting }:
               required
               value={formData.amount}
               onChange={(value) => updateField('amount', value)}
-              className="w-full px-3 py-2 bg-white dark:bg-gray-800-sm border border-gray-300/50 dark:border-gray-600/50 rounded-xl focus:border-transparent dark:text-white"
+              className="w-full px-3 py-2 bg-white dark:bg-gray-800 border border-gray-300/50 dark:border-gray-600/50 rounded-xl focus:border-transparent dark:text-white"
             />
           </div>
 
@@ -231,7 +231,7 @@ export default function BudgetModal({ isOpen, onClose, budget, onEditExisting }:
             <select
               value={formData.period}
               onChange={(e) => updateField('period', toBudgetPeriod(e.target.value))}
-              className="w-full px-3 py-2 bg-white dark:bg-gray-800-sm border border-gray-300/50 dark:border-gray-600/50 rounded-xl focus:border-transparent dark:text-white"
+              className="w-full px-3 py-2 bg-white dark:bg-gray-800 border border-gray-300/50 dark:border-gray-600/50 rounded-xl focus:border-transparent dark:text-white"
             >
               {PERIOD_OPTIONS.map(option => (
                 <option key={option.value} value={option.value}>{option.label}</option>

--- a/src/components/CSVImportWizard.tsx
+++ b/src/components/CSVImportWizard.tsx
@@ -2177,7 +2177,7 @@ function StepIndicator({
       <div className="relative">
         {/* Animated ring for active step */}
         {isActive && (
-          <div className="absolute inset-0 w-10 h-10 rounded-full bg-primary/20 animate-ping" />
+          <div className="absolute inset-0 w-10 h-10 rounded-full bg-[#1a2332]/20 animate-ping" />
         )}
         <div
           className={`relative w-10 h-10 rounded-full flex items-center justify-center transition-all duration-300 ${

--- a/src/components/CashFlowForecast.tsx
+++ b/src/components/CashFlowForecast.tsx
@@ -303,7 +303,7 @@ export default function CashFlowForecast({ accountIds, className = '' }: CashFlo
         )}
 
         {showPatterns && selectedPattern && (
-          <div className="mt-4 rounded-lg border border-primary/40 bg-primary/5 p-4">
+          <div className="mt-4 rounded-lg border border-[#1a2332]/40 bg-[#1a2332]/5 p-4">
             <div className="flex items-start justify-between gap-4">
               <div>
                 <h4 className="text-sm font-semibold text-gray-900 dark:text-white">

--- a/src/components/CategoryCreationModal.tsx
+++ b/src/components/CategoryCreationModal.tsx
@@ -204,7 +204,7 @@ export default function CategoryCreationModal({
             <select
               value={showNewCategory ? 'new' : formData.selectedCategory}
               onChange={(e) => handleCategoryChange(e.target.value)}
-              className="w-full px-3 py-2 bg-white dark:bg-gray-800-sm border border-gray-300/50 dark:border-gray-600/50 rounded-xl focus:border-transparent dark:text-white"
+              className="w-full px-3 py-2 bg-white dark:bg-gray-800 border border-gray-300/50 dark:border-gray-600/50 rounded-xl focus:border-transparent dark:text-white"
             >
               <option value="">Select a category</option>
               
@@ -234,7 +234,7 @@ export default function CategoryCreationModal({
                 value={formData.newCategoryName}
                 onChange={(e) => updateField('newCategoryName', e.target.value)}
                 placeholder="Enter new category name"
-                className="mt-2 w-full px-3 py-2 bg-white dark:bg-gray-800-sm border border-gray-300/50 dark:border-gray-600/50 rounded-xl focus:border-transparent dark:text-white"
+                className="mt-2 w-full px-3 py-2 bg-white dark:bg-gray-800 border border-gray-300/50 dark:border-gray-600/50 rounded-xl focus:border-transparent dark:text-white"
                 autoFocus
               />
             )}
@@ -250,7 +250,7 @@ export default function CategoryCreationModal({
                 <select
                   value={showNewSpecific ? 'new' : formData.selectedSpecific}
                   onChange={(e) => handleSpecificChange(e.target.value)}
-                  className="w-full px-3 py-2 bg-white dark:bg-gray-800-sm border border-gray-300/50 dark:border-gray-600/50 rounded-xl focus:border-transparent dark:text-white"
+                  className="w-full px-3 py-2 bg-white dark:bg-gray-800 border border-gray-300/50 dark:border-gray-600/50 rounded-xl focus:border-transparent dark:text-white"
                 >
                   <option value="">Select specific category (optional)</option>
                   
@@ -273,7 +273,7 @@ export default function CategoryCreationModal({
                   value={formData.newSpecificName}
                   onChange={(e) => updateField('newSpecificName', e.target.value)}
                   placeholder="Enter new specific category name"
-                  className="mt-2 w-full px-3 py-2 bg-white dark:bg-gray-800-sm border border-gray-300/50 dark:border-gray-600/50 rounded-xl focus:border-transparent dark:text-white"
+                  className="mt-2 w-full px-3 py-2 bg-white dark:bg-gray-800 border border-gray-300/50 dark:border-gray-600/50 rounded-xl focus:border-transparent dark:text-white"
                   autoFocus
                 />
               )}

--- a/src/components/CategorySelector.tsx
+++ b/src/components/CategorySelector.tsx
@@ -770,7 +770,7 @@ export default function CategorySelector({
                         onClick={() => setSelectedParentId(sub.id)}
                         className={`w-full text-left px-2.5 py-1.5 text-sm rounded-lg transition-colors flex items-center gap-2 ${
                           selectedParentId === sub.id
-                            ? 'bg-[#1a2332]/10 text-primary border border-primary/30'
+                            ? 'bg-[#1a2332]/10 text-primary border border-[#1a2332]/30'
                             : 'hover:bg-gray-100 dark:hover:bg-gray-600 text-gray-700 dark:text-gray-300'
                         }`}
                       >

--- a/src/components/CustomReportBuilder.tsx
+++ b/src/components/CustomReportBuilder.tsx
@@ -430,7 +430,7 @@ export default function CustomReportBuilder({
             </button>
             <button
               onClick={handleSave}
-              className="flex items-center gap-2 px-4 py-2 bg-[#1a2332] text-white rounded-lg hover:bg-primary/90"
+              className="flex items-center gap-2 px-4 py-2 bg-[#1a2332] text-white rounded-lg hover:bg-[#1a2332]/90"
             >
               <SaveIcon size={16} />
               Save Report

--- a/src/components/EditTransactionModal.tsx
+++ b/src/components/EditTransactionModal.tsx
@@ -1144,7 +1144,7 @@ export default function EditTransactionModal({ isOpen, onClose, transaction, def
                   }
                 }}
                 placeholder="0.00"
-                className={`w-full px-3 py-2 h-[42px] text-right bg-white dark:bg-gray-800-sm border border-gray-300/50 dark:border-gray-600/50 rounded-xl focus:border-transparent ${
+                className={`w-full px-3 py-2 h-[42px] text-right bg-white dark:bg-gray-800 border border-gray-300/50 dark:border-gray-600/50 rounded-xl focus:border-transparent ${
                   formData.amount && (parseMoneyInput(formData.amount) ?? 0) < 0
                     ? 'text-red-600 dark:text-red-400'
                     : formData.amount && (parseMoneyInput(formData.amount) ?? 0) > 0
@@ -1351,7 +1351,7 @@ export default function EditTransactionModal({ isOpen, onClose, transaction, def
                                 // shop reduces the total), so negatives stay enterable.
                                 allowNegative
                                 aria-label={`Split line ${index + 1} amount`}
-                                className="w-28 shrink-0 px-3 py-2 h-[42px] text-right bg-white dark:bg-gray-800-sm border border-gray-300/50 dark:border-gray-600/50 rounded-xl focus:border-transparent text-gray-900 dark:text-white"
+                                className="w-28 shrink-0 px-3 py-2 h-[42px] text-right bg-white dark:bg-gray-800 border border-gray-300/50 dark:border-gray-600/50 rounded-xl focus:border-transparent text-gray-900 dark:text-white"
                               />
                             )}
                             {splitLines.length > 2 && !lockedLeg && (

--- a/src/components/ImportRulesManager.tsx
+++ b/src/components/ImportRulesManager.tsx
@@ -446,7 +446,7 @@ function RuleFormModal({ rule, categories, accounts, onSave, onClose }: RuleForm
                   type="text"
                   value={formData.name}
                   onChange={(e) => setFormData({ ...formData, name: e.target.value })}
-                  className="w-full px-3 py-2 bg-white dark:bg-gray-800-sm border border-gray-300/50 dark:border-gray-600/50 rounded-lg focus:border-transparent"
+                  className="w-full px-3 py-2 bg-white dark:bg-gray-800 border border-gray-300/50 dark:border-gray-600/50 rounded-lg focus:border-transparent"
                   required
                 />
               </div>
@@ -459,7 +459,7 @@ function RuleFormModal({ rule, categories, accounts, onSave, onClose }: RuleForm
                   type="text"
                   value={formData.description}
                   onChange={(e) => setFormData({ ...formData, description: e.target.value })}
-                  className="w-full px-3 py-2 bg-white dark:bg-gray-800-sm border border-gray-300/50 dark:border-gray-600/50 rounded-lg focus:border-transparent"
+                  className="w-full px-3 py-2 bg-white dark:bg-gray-800 border border-gray-300/50 dark:border-gray-600/50 rounded-lg focus:border-transparent"
                 />
               </div>
 
@@ -473,7 +473,7 @@ function RuleFormModal({ rule, categories, accounts, onSave, onClose }: RuleForm
                     min="1"
                     value={formData.priority}
                     onChange={(e) => setFormData({ ...formData, priority: parseInt(e.target.value) })}
-                    className="w-full px-3 py-2 bg-white dark:bg-gray-800-sm border border-gray-300/50 dark:border-gray-600/50 rounded-lg focus:border-transparent"
+                    className="w-full px-3 py-2 bg-white dark:bg-gray-800 border border-gray-300/50 dark:border-gray-600/50 rounded-lg focus:border-transparent"
                   />
                 </div>
 

--- a/src/components/LargeTransactionAlertSettings.tsx
+++ b/src/components/LargeTransactionAlertSettings.tsx
@@ -54,7 +54,7 @@ export default function LargeTransactionAlertSettings() {
                 // An emptied field falls back to the default threshold, as before.
                 onChange={(value) => setLargeTransactionThreshold(parseMoneyInput(value) || 500)}
                 disabled={!largeTransactionAlertsEnabled}
-                className="flex-1 px-3 py-2 bg-white dark:bg-gray-800-sm border border-gray-300/50 dark:border-gray-600/50 rounded-lg focus:border-transparent disabled:opacity-50 disabled:cursor-not-allowed"
+                className="flex-1 px-3 py-2 bg-white dark:bg-gray-800 border border-gray-300/50 dark:border-gray-600/50 rounded-lg focus:border-transparent disabled:opacity-50 disabled:cursor-not-allowed"
               />
               <span className="text-lg font-semibold text-primary min-w-[100px] text-right">
                 {formatCurrency(largeTransactionThreshold)}

--- a/src/components/TagSelector.tsx
+++ b/src/components/TagSelector.tsx
@@ -166,7 +166,7 @@ export default function TagSelector({
           spellCheck={false}
           autoCapitalize="none"
           placeholder={placeholder}
-          className="w-full px-3 py-2 h-[42px] bg-white dark:bg-gray-800-sm border border-gray-300/50 dark:border-gray-600/50 rounded-xl focus:border-transparent dark:text-white"
+          className="w-full px-3 py-2 h-[42px] bg-white dark:bg-gray-800 border border-gray-300/50 dark:border-gray-600/50 rounded-xl focus:border-transparent dark:text-white"
         />
         
         {/* Dropdown */}

--- a/src/components/auth/SimpleSignIn.tsx
+++ b/src/components/auth/SimpleSignIn.tsx
@@ -44,7 +44,7 @@ export default function SimpleSignIn(): React.JSX.Element {
             <SignUpButton mode="modal">
               <button
                 type="button"
-                className="w-full justify-center py-3 px-4 rounded-xl border border-primary/20 dark:border-gray-600 text-gray-900 dark:text-white font-semibold hover:bg-surface-secondary dark:hover:bg-gray-700 transition-colors"
+                className="w-full justify-center py-3 px-4 rounded-xl border border-[#1a2332]/20 dark:border-gray-600 text-gray-900 dark:text-white font-semibold hover:bg-surface-secondary dark:hover:bg-gray-700 transition-colors"
               >
                 Create account
               </button>

--- a/src/components/banking/LinkBankAccountsModal.tsx
+++ b/src/components/banking/LinkBankAccountsModal.tsx
@@ -357,7 +357,7 @@ export default function LinkBankAccountsModal({
                     key={da.externalAccountId}
                     className={`rounded-xl border-2 p-4 transition-colors ${
                       selectedId
-                        ? 'border-primary/50 bg-primary/5 dark:bg-[#1a2332]/10'
+                        ? 'border-[#1a2332]/50 bg-[#1a2332]/5 dark:bg-[#1a2332]/10'
                         : 'border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800'
                     }`}
                   >

--- a/src/design-system/__tests__/darkModeUtilities.test.ts
+++ b/src/design-system/__tests__/darkModeUtilities.test.ts
@@ -1,0 +1,123 @@
+/**
+ * THREE WAYS TO WRITE A COLOUR THAT ISN'T THERE.
+ *
+ * All three shipped, all three were invisible only in dark mode, and none of
+ * them is a typo a reviewer would catch by reading — each looks exactly like
+ * working code. They were found by the owner opening Settings, which is not a
+ * test strategy.
+ *
+ * 1. A `!important` utility with no dark variant. `.text-theme-heading` set
+ *    `color: var(--color-secondary) !important` — navy — and because of the
+ *    `!important` it also beat the `dark:text-white` that most call sites had
+ *    written beside it. 27 section headings, navy on near-black.
+ *
+ * 2. A class that does not exist. `dark:bg-gray-800-sm` is not a Tailwind
+ *    class, so it emitted nothing and the input kept its light `bg-white`
+ *    while its text obeyed `dark:text-white`. White on white, in 39 places.
+ *    The name is plausible enough to survive review indefinitely.
+ *
+ * 3. An opacity on a bare `var()`. `bg-primary/20` emits no CSS, because
+ *    Tailwind cannot compose an alpha with a variable it cannot parse.
+ *
+ * What unites them: **a colour that fails to apply looks like a colour that
+ * was never asked for.** Nothing errors, nothing warns, and the element simply
+ * inherits. So these are grep tests over source rather than render tests —
+ * the failure is upstream of rendering.
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync, readdirSync, statSync } from 'node:fs';
+import { join } from 'node:path';
+
+const SRC = join(process.cwd(), 'src');
+
+function sourceFiles(dir: string, out: string[] = []): string[] {
+  for (const entry of readdirSync(dir)) {
+    if (entry === 'node_modules' || entry === 'dist') continue;
+    const full = join(dir, entry);
+    if (statSync(full).isDirectory()) sourceFiles(full, out);
+    else if (/\.tsx?$/.test(entry)) out.push(full);
+  }
+  return out;
+}
+
+const FILES = sourceFiles(SRC);
+const CSS = readFileSync(join(SRC, 'index.css'), 'utf8');
+
+/**
+ * Comments blanked, line numbers preserved.
+ *
+ * This repository documents its traps by NAMING them, so `bg-primary/20`
+ * appears in prose more often than in code — including in the comment that
+ * explains this very rule. A line-by-line "starts with //" filter is not
+ * enough: it misses the continuation lines of a block comment, which was this
+ * test's own first false positive.
+ */
+function stripComments(source: string): string {
+  return source
+    .replace(/\/\*[\s\S]*?\*\//g, (block) => block.replace(/[^\n]/g, ' '))
+    .replace(/(^|[^:])\/\/[^\n]*/g, (match, lead: string) => lead + ' '.repeat(match.length - lead.length));
+}
+
+/** `path:line — the offending text`, so a failure is actionable without a hunt. */
+function findInSource(pattern: RegExp): string[] {
+  const hits: string[] = [];
+  for (const file of FILES) {
+    if (file.includes('__tests__') || file.endsWith('.test.ts') || file.endsWith('.test.tsx')) continue;
+    const lines = stripComments(readFileSync(file, 'utf8')).split('\n');
+    lines.forEach((line, i) => {
+      if (pattern.test(line)) hits.push(`${file.replace(SRC, 'src')}:${i + 1} — ${line.trim().slice(0, 90)}`);
+    });
+  }
+  return hits;
+}
+
+describe('dark-mode colours that silently do not apply', () => {
+  it('has no Tailwind class ending in a size suffix that does not exist', () => {
+    // `bg-gray-800-sm`, `text-gray-700-md` and friends. A background has no
+    // size, so any such class is a paste artefact that emits nothing.
+    const hits = findInSource(/\b(?:dark:)?(?:bg|text|border)-\w+-\d{2,3}-(?:sm|md|lg|xl)\b/);
+    expect(hits, `These classes emit no CSS:\n${hits.join('\n')}`).toEqual([]);
+  });
+
+  it('never puts an opacity on a bare CSS variable', () => {
+    // `bg-primary/20`, `text-primary/70`. Tailwind cannot compose an alpha
+    // with `var(--x)`, so the whole declaration is dropped. The app's own
+    // `nav-bg` tokens are the supported way to ask for this.
+    const hits = findInSource(/\b(?:dark:)?(?:bg|text|border)-(?:primary|secondary|tertiary)\/\d+/);
+    expect(hits, `These emit no CSS (opacity on a bare var()):\n${hits.join('\n')}`).toEqual([]);
+  });
+
+  it('gives every !important colour utility a dark-mode counterpart', () => {
+    // The `.text-theme-heading` failure. An `!important` colour beats the
+    // `dark:` variant a call site writes, so the utility itself must answer
+    // for both themes — the call sites are powerless to.
+    // `color:` the PROPERTY, not `background-color:` or `border-color:` — a
+    // brand surface is meant to stay navy on both grounds, and only ink has to
+    // flip. (Written as `\bcolor:` first, which matched `background-color` and
+    // reported ten false positives.)
+    const importantColourRules = [
+      // `\s*` OUTSIDE the alternation. With it inside — `(?:^|[;{]\s*)color:` —
+      // neither branch could reach an indented `color:`, so this matched
+      // nothing and the assertion passed with the bug reintroduced. Caught by
+      // deleting the fix and watching the test stay green.
+      ...CSS.matchAll(/^\.([\w-]+)\s*\{[^}]*?(?:[;{]|^)\s*color:[^;]*!important/gm),
+    ].map((match) => match[1]);
+
+    const missing = importantColourRules.filter(
+      (name) => !new RegExp(`\\.dark\\s+\\.${name}\\b`).test(CSS)
+    );
+
+    expect(
+      missing,
+      `These force a colour with !important and have no .dark rule, so they render ` +
+        `the same ink on both grounds:\n${missing.map((n) => `.${n}`).join('\n')}`
+    ).toEqual([]);
+  });
+
+  it('still forces the heading colour in both modes, which is the fix itself', () => {
+    // Guards the repair rather than the bug: if the .dark rule is ever dropped
+    // the test above catches it, and if the base rule is dropped this does.
+    expect(CSS).toMatch(/\.text-theme-heading\s*\{\s*color:\s*var\(--color-secondary\)\s*!important/);
+    expect(CSS).toMatch(/\.dark\s+\.text-theme-heading\s*\{\s*color:\s*#f9fafb\s*!important/);
+  });
+});

--- a/src/index.css
+++ b/src/index.css
@@ -272,6 +272,55 @@ body {
   color: var(--color-secondary) !important;
 }
 
+/* …and the same rule in dark mode, which it did not have until 2026-08-15.
+ *
+ * `--color-secondary` is rgb(45 58 77) — navy, defined once, with no dark
+ * variant. Because the declaration above carries `!important`, it also beat
+ * the `dark:text-white` that 20 of the 27 call sites had written beside it in
+ * good faith. So every one of them rendered navy-on-near-black: "Personal
+ * Information", "Base Currency", "Appearance", "Portfolio Performance",
+ * "Holdings", "Asset Allocation" — section headings, invisible, app-wide.
+ *
+ * This is the identical failure the note below records for the blues, found
+ * and fixed then, and left in place here because the token is named for a role
+ * rather than a colour and so read as though it must already be theme-aware.
+ * A token that only has one value is not a token; it is a constant with an
+ * ambitious name.
+ *
+ * Fixed on the UTILITY rather than on the 27 call sites, and rather than by
+ * giving `--color-secondary` a dark value: the variable is also a BACKGROUND
+ * (`bg-secondary`), where the navy is correct in both modes. Only its use as
+ * text needs the flip. */
+.dark .text-theme-heading {
+  color: #f9fafb !important;
+}
+
+/* The same fault, in the three utilities the guard found beside it.
+ *
+ * `--color-primary` is rgb(26 35 50) and `--color-secondary` rgb(45 58 77):
+ * near-black navies, correct as INK ON WHITE and invisible as ink on a
+ * gray-900 page. `text-primary` alone is on 104 elements. `--color-tertiary`
+ * is the #d4a843 gold, which does read on dark — it is lifted only enough to
+ * hold the same rank below the other two, and nothing currently uses it.
+ *
+ * The ladder is preserved rather than flattened to white: primary is the
+ * strongest ink, secondary a step down, tertiary the accent. That relationship
+ * is the reason there are three of them.
+ *
+ * See `darkModeUtilities.test.ts`, which now fails if any !important colour
+ * utility is added without a dark counterpart. */
+.dark .text-primary {
+  color: #f9fafb !important;
+}
+
+.dark .text-secondary {
+  color: #d1d5db !important;
+}
+
+.dark .text-tertiary {
+  color: #e2c079 !important;
+}
+
 .bg-theme-accent {
   background-color: var(--color-light-accent) !important;
 }

--- a/src/pages/CustomReports.tsx
+++ b/src/pages/CustomReports.tsx
@@ -175,7 +175,7 @@ export default function CustomReports(): React.JSX.Element {
           </div>
           <button
             onClick={() => setShowBuilder(true)}
-            className="flex items-center gap-2 px-4 py-2 bg-[#1a2332] text-white rounded-lg hover:bg-primary/90"
+            className="flex items-center gap-2 px-4 py-2 bg-[#1a2332] text-white rounded-lg hover:bg-[#1a2332]/90"
           >
             <PlusIcon size={20} />
             Create Report

--- a/src/pages/settings/AppSettings.tsx
+++ b/src/pages/settings/AppSettings.tsx
@@ -93,7 +93,7 @@ export default function AppSettings() {
             value={firstName}
             onChange={(e) => setFirstName(e.target.value)}
             placeholder="Enter your first name"
-            className="w-full px-3 py-2 bg-white dark:bg-gray-800-sm border border-gray-300/50 dark:border-gray-600/50 rounded-xl focus:border-transparent dark:text-white"
+            className="w-full px-3 py-2 bg-white dark:bg-gray-800 border border-gray-300/50 dark:border-gray-600/50 rounded-xl focus:border-transparent dark:text-white"
           />
           <p className="mt-2 text-body text-gray-500 dark:text-gray-400">
             This will be used in the welcome message on your dashboard. Leave blank to use "User".
@@ -117,7 +117,7 @@ export default function AppSettings() {
           aria-label="Default currency"
           value={currency}
           onChange={(e) => setCurrency(e.target.value)}
-          className="w-full px-4 py-2 bg-white dark:bg-gray-800-sm border border-gray-300/50 dark:border-gray-600/50 rounded-xl focus:border-transparent dark:text-white"
+          className="w-full px-4 py-2 bg-white dark:bg-gray-800 border border-gray-300/50 dark:border-gray-600/50 rounded-xl focus:border-transparent dark:text-white"
         >
           {currencies.map((curr) => (
             <option key={curr.code} value={curr.code}>
@@ -142,8 +142,16 @@ export default function AppSettings() {
                 key={value}
                 onClick={() => setTheme(value as 'light' | 'dark' | 'auto' | 'scheduled')}
                 className={`flex items-center justify-center gap-2 px-4 py-3 rounded-lg border-2 transition-colors ${
+                  /* The selected state used to read, in dark mode,
+                     `dark:bg-primary/20 dark:text-primary` — and produced
+                     NEITHER. `--color-primary` is the near-black navy, so the
+                     label was navy on near-black; and an opacity on a bare
+                     `var()` emits no CSS at all, so there was no surface under
+                     it either. The theme you were actually using was the one
+                     option you could not see. Dark mode now gets a real surface
+                     and real ink. See darkModeUtilities.test.ts. */
                   theme === value
-                    ? 'border-primary bg-[#1a2332]/10 text-primary dark:bg-primary/20 dark:text-primary'
+                    ? 'border-primary bg-[#1a2332]/10 text-primary dark:border-gray-400 dark:bg-gray-700 dark:text-white'
                     : 'border-gray-300 dark:border-gray-600 hover:border-gray-400 dark:hover:border-gray-500 text-gray-700 dark:text-gray-300'
                 }`}
               >
@@ -185,7 +193,7 @@ export default function AppSettings() {
                       type="time"
                       value={themeSchedule.lightStartTime}
                       onChange={(e) => setThemeSchedule({ ...themeSchedule, lightStartTime: e.target.value })}
-                      className="w-full px-3 py-2 bg-white dark:bg-gray-800-sm border border-gray-300/50 dark:border-gray-600/50 rounded-lg focus:border-transparent dark:text-white text-body"
+                      className="w-full px-3 py-2 bg-white dark:bg-gray-800 border border-gray-300/50 dark:border-gray-600/50 rounded-lg focus:border-transparent dark:text-white text-body"
                     />
                   </div>
                   <div>
@@ -196,7 +204,7 @@ export default function AppSettings() {
                       type="time"
                       value={themeSchedule.darkStartTime}
                       onChange={(e) => setThemeSchedule({ ...themeSchedule, darkStartTime: e.target.value })}
-                      className="w-full px-3 py-2 bg-white dark:bg-gray-800-sm border border-gray-300/50 dark:border-gray-600/50 rounded-lg focus:border-transparent dark:text-white text-body"
+                      className="w-full px-3 py-2 bg-white dark:bg-gray-800 border border-gray-300/50 dark:border-gray-600/50 rounded-lg focus:border-transparent dark:text-white text-body"
                     />
                   </div>
                 </div>

--- a/src/pages/settings/Tags.tsx
+++ b/src/pages/settings/Tags.tsx
@@ -157,7 +157,7 @@ export default function Tags() {
                 type="text"
                 value={formData.name}
                 onChange={(e) => setFormData({ ...formData, name: e.target.value })}
-                className={`w-full px-3 py-2 bg-white dark:bg-gray-800-sm border rounded-xl focus:border-transparent dark:text-white ${
+                className={`w-full px-3 py-2 bg-white dark:bg-gray-800 border rounded-xl focus:border-transparent dark:text-white ${
                   errors.name ? 'border-red-500/50' : 'border-gray-300/50 dark:border-gray-600/50'
                 }`}
                 placeholder="Enter tag name"
@@ -201,7 +201,7 @@ export default function Tags() {
               <textarea
                 value={formData.description}
                 onChange={(e) => setFormData({ ...formData, description: e.target.value })}
-                className="w-full px-3 py-2 bg-white dark:bg-gray-800-sm border border-gray-300/50 dark:border-gray-600/50 rounded-xl focus:border-transparent dark:text-white"
+                className="w-full px-3 py-2 bg-white dark:bg-gray-800 border border-gray-300/50 dark:border-gray-600/50 rounded-xl focus:border-transparent dark:text-white"
                 rows={3}
                 placeholder="Enter tag description"
               />


### PR DESCRIPTION
Steve opened App Settings in dark mode and found his own name gone, the theme he was using invisible, and every section heading missing.

**Three separate root causes.** All three look like working code, none errors or warns, and all three are invisible in light mode — which is where they were written and reviewed.

## 1. An `!important` utility with no dark rule — 27 headings

`.text-theme-heading` sets `color: var(--color-secondary) !important`. That's navy, one value, no dark variant. And because of the `!important` it **also beat the `dark:text-white` that 20 of its 27 call sites had written beside it in good faith**.

Personal Information · Base Currency · Appearance · Page Visibility · Portfolio Performance · Holdings · Asset Allocation — navy on near-black.

`index.css` already carried a note recording this *exact* failure being found and fixed for the blues. This one survived because the token is named for a **role** rather than a colour, so it reads as though it must already be theme-aware. **A token with one value is a constant with an ambitious name.**

The new guard then found `.text-primary` (104 elements), `.text-secondary` and `.text-tertiary` in the same state. Fixed as a ladder rather than flattened to white — the three ranks are the reason there are three of them.

Fixed on the **utility**, not the 27 call sites, and not by giving the variable a dark value: it is also a background, where the navy is correct in both modes. Only its use as ink needs to flip.

## 2. A class that does not exist — 39 inputs across 10 files

`dark:bg-gray-800-sm`. A background has no size, so the class emits nothing and the input keeps `bg-white` while its text obeys `dark:text-white`. **White on white.** That is the missing "Danielle".

The name is plausible enough to survive review indefinitely.

## 3. An opacity on a bare `var()` — 10 sites

`bg-primary/20` emits **no CSS**: Tailwind cannot compose an alpha with a `var()` it cannot parse. On the theme picker this removed the selected surface *and* left `dark:text-primary` as navy on near-black, so **the theme you were actually using was the one option you could not see**.

`index.css` documents this trap in detail at the token definition. It was documented and still shipped ten more times, which is the argument for the guard rather than another note.

## The guard

`darkModeUtilities.test.ts` fails on all three shapes.

**Proven non-vacuous by reintroducing each bug in turn** — which is how I found that its third assertion was *itself* vacuous: `(?:^|[;{]\s*)color:` could not match an indented declaration, so it was scanning nothing and passing happily. Fixed, re-proven, and it immediately turned up the three utilities in §1 that I would otherwise have missed.

It strips comments before scanning, deliberately: this repository documents its traps by **naming** them, so `bg-primary/20` appears in prose more often than in code.

## What this does not cover

Steve reported more than this, and the rest is queued rather than done: the Investments pie reading as one colour, its legend showing institution names (and `N/A`) instead of account names, the view-option terminology differing from the Dashboard, Reconciliation's empty state being left-aligned where Categorisation centres it, and Open Banking's dark mode. Those are separate changes and one of them is a data question, not a colour one.

5978 tests pass, lint and typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
