### PR TITLE
Enough colours for every slice, the right names, a new allocation chart, and cleared notifications staying cleared

### DIFF
--- a/src/components/CashFlowForecast.tsx
+++ b/src/components/CashFlowForecast.tsx
@@ -17,6 +17,7 @@ import { XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer, Area, AreaCh
 import type { RecurringPattern } from '../services/cashFlowForecastService';
 import type { DecimalInstance } from '../types/decimal-types';
 import { toDecimal } from '../utils/decimal';
+import { useChartTooltipStyle } from './charts/chartColors';
 
 interface CashFlowForecastProps {
   accountIds?: string[];
@@ -24,6 +25,7 @@ interface CashFlowForecastProps {
 }
 
 export default function CashFlowForecast({ accountIds, className = '' }: CashFlowForecastProps) {
+  const chartTooltipStyle = useChartTooltipStyle();
   const { formatCurrency } = useCurrencyDecimal();
   const [forecastMonths, setForecastMonths] = useState(6);
   const [showPatterns, setShowPatterns] = useState(false);
@@ -220,11 +222,7 @@ export default function CashFlowForecast({ accountIds, className = '' }: CashFlo
               />
               <Tooltip 
                 formatter={(value: number) => formatCurrency(toDecimal(value))}
-                contentStyle={{ 
-                  backgroundColor: 'rgba(255, 255, 255, 0.95)',
-                  border: '1px solid #ccc',
-                  borderRadius: '8px'
-                }}
+                contentStyle={chartTooltipStyle}
               />
               <ReferenceLine y={0} stroke="#ff0000" strokeDasharray="3 3" />
               <Area

--- a/src/components/CustomReportViewer.tsx
+++ b/src/components/CustomReportViewer.tsx
@@ -15,7 +15,7 @@ import {
   Legend,
 } from 'recharts';
 import { useCurrencyDecimal } from '../hooks/useCurrencyDecimal';
-import { categoricalColor, useCategoricalRamp } from './charts/chartColors';
+import { capSeriesWithRemainder, categoricalColor, useCategoricalRamp } from './charts/chartColors';
 import { formatDecimal } from '../utils/decimal-format';
 import type { CustomReport, ReportComponent } from './CustomReportBuilder';
 
@@ -156,7 +156,16 @@ export default function CustomReportViewer({
       case 'pie-chart': {
         const pie = componentData as { labels: string[]; data: number[] };
         if (!pie.labels?.length) return <p className="text-sm text-gray-400">No data</p>;
-        const rows = pie.labels.map((name, i) => ({ name, value: pie.data[i] ?? 0 }));
+        // Ring and legend from ONE array, capped at what the ramp can colour.
+        // The ring drew every label while the legend showed eight, so the two
+        // disagreed about what existed and both repeated colours past the
+        // fifth. See capSeriesWithRemainder.
+        const rows = capSeriesWithRemainder(
+          pie.labels.map((name, i) => ({ name, value: pie.data[i] ?? 0 })),
+          (row) => row.value,
+          (row) => row.name,
+          (count) => `${count} smaller`
+        );
         return (
           <div className="h-64 flex items-center gap-4">
             <div className="h-full flex-1 basis-0 min-w-[140px]">
@@ -172,7 +181,7 @@ export default function CustomReportViewer({
               </ResponsiveContainer>
             </div>
             <ul className="w-44 space-y-1">
-              {rows.slice(0, 8).map((row, i) => (
+              {rows.map((row, i) => (
                 <li key={row.name} className="flex items-center gap-2 text-xs">
                   <span className="w-2.5 h-2.5 rounded-sm flex-shrink-0" style={{ backgroundColor: categoricalColor(ramp, i) }} />
                   <span className="flex-1 min-w-0 truncate text-gray-600 dark:text-gray-300">{row.name}</span>
@@ -233,6 +242,8 @@ export default function CustomReportViewer({
         if (rows.length === 0) return <p className="text-sm text-gray-400">No data</p>;
         return (
           <ul className="space-y-1">
+            {/* not-a-charted-series: a plain list of rows, no ramp colour on
+                it, so the palette's five-slice ceiling does not apply. */}
             {rows.slice(0, 10).map((row, i) => (
               <li key={i} className="flex items-center justify-between text-sm">
                 <span className="text-gray-700 dark:text-gray-300 truncate">

--- a/src/components/EmptyState.tsx
+++ b/src/components/EmptyState.tsx
@@ -31,10 +31,24 @@ interface EmptyStateProps {
 /**
  * The empty state, in the one shape the app uses everywhere (DESIGN_PASS §4).
  *
- * LEFT-ALIGNED, never centred with an icon. A centred block with a picture is
- * a greeting; what somebody looking at an empty register needs is the same
- * thing a warning gives them — P6, say the consequence, then the remedy — and
- * that reads down the left edge like the rest of the page.
+ * ─ CENTRED. OWNER OVERRIDE, 15 August 2026 ─────────────────────────────────
+ *
+ * §4 ruled this LEFT-ALIGNED: "a centred block with a picture is a greeting",
+ * and what an empty register needs is a warning's shape — P6, the consequence
+ * then the remedy — read down the left edge like the rest of the page.
+ *
+ * The owner overruled it, and the reason is the one the ruling could not see
+ * from a desktop mock: **on a phone it is not a block on a page, it is the
+ * whole screen.** A left-aligned title in a full-width card with nothing to
+ * its right reads as a layout that has collapsed, not as a sentence. Centred,
+ * it reads as a deliberate state — which is what "filtered-empty is not empty"
+ * is trying to make believable in the first place.
+ *
+ * The ruling's own argument survives it: the shape is still consequence-then-
+ * remedy, and the remedy is still a real control. Only the axis changed.
+ *
+ * Categorisation had been centring its own hand-rolled copy since batch 7,
+ * which is what made the inconsistency visible. It is the one that was right.
  *
  *   No transactions in this account yet
  *   Its balance will read £0.00 and it won't appear in reports until
@@ -53,7 +67,7 @@ export default function EmptyState({
   className = ''
 }: EmptyStateProps): React.JSX.Element {
   return (
-    <div className={`flex flex-col items-start px-6 py-10 ${className}`}>
+    <div className={`flex flex-col items-center text-center px-6 py-10 ${className}`}>
       {icon && (
         <div className="mb-4 text-gray-400 dark:text-gray-500">
           {icon}

--- a/src/components/PeriodBar.tsx
+++ b/src/components/PeriodBar.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { CalendarIcon } from './icons';
 import PeriodPicker from './PeriodPicker';
 import type { UsePeriodResult } from '../hooks/usePeriod';
 
@@ -28,8 +27,12 @@ export default function PeriodBar({ picker, label }: {
   label: string;
 }): React.JSX.Element {
   return (
+    /* No calendar glyph since 15 August. It was `aria-hidden`, so it said
+       nothing to a screen reader, and the pills beneath it already read "This
+       month / Last month / Tax year" — a picture of a calendar next to the
+       word "month" is the definition of decoration charged against the page
+       (P1). On a phone it also cost 26px of the row the pills wrap inside. */
     <div data-period-bar className="flex items-center gap-2">
-      <CalendarIcon className="text-gray-500 flex-shrink-0" size={18} aria-hidden="true" />
       <PeriodPicker picker={picker} label={label} />
     </div>
   );

--- a/src/components/SeasonalTrends.tsx
+++ b/src/components/SeasonalTrends.tsx
@@ -4,7 +4,7 @@ import { useSeasonalAnalysis } from '../hooks/useCashFlowForecast';
 import { useCurrencyDecimal } from '../hooks/useCurrencyDecimal';
 import { toDecimal } from '../utils/decimal';
 import { LoadingState } from './loading/LoadingState';
-import { SEMANTIC_SERIES } from './charts/chartColors';
+import { SEMANTIC_SERIES, useChartTooltipStyle } from './charts/chartColors';
 import { CalendarIcon, TrendingUpIcon, TrendingDownIcon } from './icons';
 
 const monthNames = [
@@ -17,6 +17,7 @@ interface SeasonalTrendsProps {
 }
 
 export default function SeasonalTrends({ className = '' }: SeasonalTrendsProps) {
+  const chartTooltipStyle = useChartTooltipStyle();
   const { formatCurrency } = useCurrencyDecimal();
   const seasonalTrends = useSeasonalAnalysis();
 
@@ -135,11 +136,7 @@ export default function SeasonalTrends({ className = '' }: SeasonalTrendsProps) 
               />
               <Tooltip 
                 formatter={(value: number) => formatCurrency(toDecimal(value))}
-                contentStyle={{ 
-                  backgroundColor: 'rgba(255, 255, 255, 0.95)',
-                  border: '1px solid #ccc',
-                  borderRadius: '8px'
-                }}
+                contentStyle={chartTooltipStyle}
               />
               <Legend />
               <Bar

--- a/src/components/charts/chartColors.ts
+++ b/src/components/charts/chartColors.ts
@@ -1,3 +1,4 @@
+import type React from 'react';
 import { useEffect, useState } from 'react';
 
 /**
@@ -87,6 +88,61 @@ const RAMP_ON_LIGHT = ['#1a2332', '#4c6080', '#242f40', '#6b86b3', '#2d3a4d'] as
 /** The same, from the light end, for a dark ground (1.59:1 worst adjacent pair). */
 const RAMP_ON_DARK = ['#94a3b8', '#cdd4e0', '#8095b6', '#b1bccc', '#6b86b3'] as const;
 
+/**
+ * HOW MANY SLICES A CHART MAY DRAW.
+ *
+ * Five, because the ramp is five, because the axis is ONE HUE walked and each
+ * ground can only use the half of it that clears 3:1 against that ground. Ask
+ * for a sixth and `categoricalColor` cycles: slice 6 is painted exactly like
+ * slice 1, and the picture stops being readable in a way no contrast figure
+ * reports — the Dashboard's expense donut drew six against five and two
+ * categories shared a colour.
+ *
+ * So the cap is not a layout preference, it is the palette's own arithmetic,
+ * and it belongs beside the palette rather than as a number in each widget.
+ * A chart with more than five things to say needs a grouped remainder, not a
+ * longer ramp.
+ */
+export const MAX_CATEGORICAL_SERIES = 5;
+
+/**
+ * The slices a chart may draw, with everything past the ceiling folded into one
+ * named remainder.
+ *
+ * Written once because it went wrong three times in the same week, identically:
+ * the Dashboard's expense donut, the Investments allocation ring and the custom
+ * report viewer's pie each drew more series than the ramp has colours, so the
+ * sixth slice was painted like the first.
+ *
+ * The remainder is NAMED WITH ITS COUNT ("8 smaller accounts") rather than
+ * called "Other", for two reasons: "Other" is a real category in some ledgers
+ * and would collide, and a reader who can see how many things were folded can
+ * tell whether the fold hid something worth looking at.
+ *
+ * Callers must draw the ring AND the legend from the returned array. Drawing
+ * the ring from the raw data and the legend from this is precisely the bug it
+ * exists to prevent.
+ */
+export function capSeriesWithRemainder<T>(
+  items: readonly T[],
+  value: (item: T) => number,
+  name: (item: T) => string,
+  remainderLabel: (count: number) => string
+): Array<{ name: string; value: number }> {
+  const all = items.map((item) => ({ name: name(item), value: value(item) }));
+  if (all.length <= MAX_CATEGORICAL_SERIES) return all;
+
+  const shown = all.slice(0, MAX_CATEGORICAL_SERIES - 1);
+  const rest = all.slice(MAX_CATEGORICAL_SERIES - 1);
+  return [
+    ...shown,
+    {
+      name: remainderLabel(rest.length),
+      value: rest.reduce((sum, entry) => sum + entry.value, 0)
+    }
+  ];
+}
+
 /** The ramp for a given ground. Cycle past the end with `categoricalColor`. */
 export function categoricalRamp(isDarkGround: boolean): readonly string[] {
   return isDarkGround ? RAMP_ON_DARK : RAMP_ON_LIGHT;
@@ -116,7 +172,7 @@ function isDarkGround(): boolean {
  * would keep its light-ground slices after the app went dark, and two of them
  * would be invisible until something unrelated forced a re-render.
  */
-export function useCategoricalRamp(): readonly string[] {
+export function useIsDarkGround(): boolean {
   const [dark, setDark] = useState(isDarkGround);
 
   useEffect(() => {
@@ -128,7 +184,40 @@ export function useCategoricalRamp(): readonly string[] {
     return () => observer.disconnect();
   }, []);
 
-  return categoricalRamp(dark);
+  return dark;
+}
+
+export function useCategoricalRamp(): readonly string[] {
+  return categoricalRamp(useIsDarkGround());
+}
+
+/**
+ * The Recharts tooltip surface, for the ground currently on screen.
+ *
+ * Four charts spelled `rgba(255, 255, 255, 0.95)` with a `#ccc` border inline.
+ * That is readable in dark mode — Recharts' own label text is dark, so it is
+ * dark-on-white — but it is a white card thrown onto a near-black page, which
+ * reads as a rendering fault rather than a design.
+ *
+ * It watches the `dark` class through the same hook as the ramp, and for the
+ * same reason: the class is toggled on `<html>` directly, so a value read once
+ * at render survives into the wrong theme.
+ */
+export function useChartTooltipStyle(): React.CSSProperties {
+  const dark = useIsDarkGround();
+  return dark
+    ? {
+        backgroundColor: 'rgba(31, 41, 55, 0.97)', // gray-800
+        border: '1px solid #4b5563', // gray-600
+        borderRadius: '8px',
+        color: '#f9fafb',
+      }
+    : {
+        backgroundColor: 'rgba(255, 255, 255, 0.95)',
+        border: '1px solid #ccc',
+        borderRadius: '8px',
+        color: '#111827',
+      };
 }
 
 /**

--- a/src/components/dashboard/ImprovedDashboard.tsx
+++ b/src/components/dashboard/ImprovedDashboard.tsx
@@ -588,7 +588,6 @@ export function ImprovedDashboard() {
       <section aria-labelledby="pinned-reports-heading">
         <div className="flex items-center justify-between gap-3 mb-3">
           <h3 id="pinned-reports-heading" className="text-lg font-semibold text-gray-900 dark:text-white flex items-center gap-2">
-            <BarChart3Icon size={24} className="text-gray-500" />
             Your Reports
           </h3>
           <button
@@ -626,7 +625,6 @@ export function ImprovedDashboard() {
               {pieData.length > 0 && (
                 <DashboardWidgetCard
                   title="Account Distribution"
-                  icon={PieChartIcon}
                   subtitle={
                     <>
                       <span className="text-xs text-gray-500 dark:text-gray-400 truncate">
@@ -859,7 +857,6 @@ export function ImprovedDashboard() {
       >
         <div className="flex items-center justify-between mb-4">
           <h3 id="key-accounts-heading" className="text-lg font-semibold text-gray-900 dark:text-white flex items-center gap-2">
-            <WalletIcon size={24} className="text-gray-500" />
             Key Account Balances
             {displayedAccounts.length > 0 && (
               <span className="text-sm font-normal text-gray-500 dark:text-gray-400 whitespace-nowrap">

--- a/src/components/dashboard/reportWidgets/DashboardReportWidgets.tsx
+++ b/src/components/dashboard/reportWidgets/DashboardReportWidgets.tsx
@@ -13,7 +13,7 @@ import {
 } from 'recharts';
 import { useApp } from '../../../contexts/AppContextSupabase';
 import { useCurrencyDecimal } from '../../../hooks/useCurrencyDecimal';
-import { categoricalColor, useCategoricalRamp, SEMANTIC_SERIES } from '../../charts/chartColors';
+import { categoricalColor, MAX_CATEGORICAL_SERIES, useCategoricalRamp, SEMANTIC_SERIES } from '../../charts/chartColors';
 import { singlePointDot } from '../../charts/singlePointDots';
 import { buildMonthlyTrend } from '../../../utils/monthlyTrend';
 import { buildNetWorthSnapshots, netWorthPointToken } from '../../../utils/netWorthSeries';
@@ -22,7 +22,6 @@ import { expandSplitTransactions } from '../../../utils/transactionSplits';
 import { formatDecimal } from '../../../utils/decimal-format';
 import type { UsePeriodResult } from '../../../hooks/usePeriod';
 import type { CardPeriodPin } from '../../../hooks/useCardPeriod';
-import { TrendingUpIcon, PieChartIcon, BarChart3Icon, FileTextIcon } from '../../icons';
 import DashboardWidgetCard from './DashboardWidgetCard';
 import CardPeriodControl from './CardPeriodControl';
 import { WIDGET_CHART_HEIGHT } from './widgetChrome';
@@ -102,7 +101,6 @@ export function NetWorthWidget({ picker, pin }: {
   return (
     <DashboardWidgetCard
       title={NET_WORTH_TITLE}
-      icon={TrendingUpIcon}
       subtitle={
         <>
           <span className="min-w-0 text-xl font-bold text-gray-900 dark:text-white truncate">
@@ -171,7 +169,6 @@ export function IncomeExpenseTrendWidget({ picker, pin }: {
   return (
     <DashboardWidgetCard
       title={INCOME_EXPENSE_TITLE}
-      icon={BarChart3Icon}
       subtitle={
         <>
           <span className="min-w-0 text-xs text-gray-500 dark:text-gray-400 truncate">
@@ -232,7 +229,10 @@ export function ExpenseCategoriesWidget({ picker, pin }: {
       if (range.to && time > range.to.getTime()) return false;
       return true;
     });
-    const top = computeExpenseCategoryNetTotals(rows, categories).slice(0, 6);
+    // FIVE, from the palette, not six. Six slices against a five-colour ramp
+    // meant the sixth was painted like the first — reported by the owner as
+    // "the pie is split into 5 sections and the legend lists 6".
+    const top = computeExpenseCategoryNetTotals(rows, categories).slice(0, MAX_CATEGORICAL_SERIES);
     /*
      * The share is of THE SLICES SHOWN, not of all spending — the ring is the
      * top six and the percentages have to add up to the ring the reader is
@@ -254,7 +254,6 @@ export function ExpenseCategoriesWidget({ picker, pin }: {
   return (
     <DashboardWidgetCard
       title={EXPENSE_CATEGORIES_TITLE}
-      icon={PieChartIcon}
       subtitle={
         <>
           <span className="min-w-0 text-xs text-gray-500 dark:text-gray-400 truncate">
@@ -382,7 +381,6 @@ export function CustomReportWidget({ reportId }: { reportId: string }): React.JS
   return (
     <DashboardWidgetCard
       title={report.name}
-      icon={FileTextIcon}
       onOpen={() => openReport('custom-reports')}
     >
       <p className="text-sm text-gray-500 dark:text-gray-400">

--- a/src/components/dashboard/reportWidgets/DashboardWidgetCard.tsx
+++ b/src/components/dashboard/reportWidgets/DashboardWidgetCard.tsx
@@ -13,13 +13,11 @@ import { WIDGET_SUBTITLE_SLOT } from './widgetChrome';
  */
 export default function DashboardWidgetCard({
   title,
-  icon: Icon,
   subtitle,
   onOpen,
   children,
 }: {
   title: string;
-  icon: React.ElementType;
   /**
    * The line under the title. Optional: a card with no chart (a pinned custom
    * report) has nothing to line up with, and an empty slot there would be a gap
@@ -43,7 +41,6 @@ export default function DashboardWidgetCard({
         className={`flex items-center gap-2 text-left group ${subtitle === undefined ? 'mb-2' : 'mb-1'}`}
         title="Open the full report"
       >
-        <Icon size={18} className="text-gray-500" aria-hidden="true" />
         <span className="text-sm font-semibold text-gray-900 dark:text-white group-hover:text-blue-600 dark:group-hover:text-blue-400 transition-colors">
           {title}
         </span>

--- a/src/components/reconciliation/ReconciliationAccountList.tsx
+++ b/src/components/reconciliation/ReconciliationAccountList.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Building2Icon, ChevronRightIcon } from '../icons';
+import { ChevronRightIcon } from '../icons';
 import { useCurrencyDecimal } from '../../hooks/useCurrencyDecimal';
 import EmptyState from '../EmptyState';
 import FilteredEmptyState from '../FilteredEmptyState';
@@ -245,9 +245,6 @@ export default function ReconciliationAccountList({
                   from md up now; under that the row wraps. */}
               <div className="w-full flex flex-wrap items-end md:items-center gap-3 md:gap-4">
                 <div className="flex items-center gap-3 min-w-0 basis-full md:basis-auto md:min-w-[200px]">
-                  <div className="p-2 bg-gray-100 dark:bg-gray-700 rounded-lg flex-shrink-0">
-                    <Building2Icon size={20} className="text-gray-600 dark:text-gray-400" />
-                  </div>
                   <div>
                     <h3 className="font-semibold text-gray-900 dark:text-white">{account.name}</h3>
                     <p className="text-xs text-gray-500 dark:text-gray-400">

--- a/src/components/reconciliation/__tests__/ReconciliationAccountList.test.tsx
+++ b/src/components/reconciliation/__tests__/ReconciliationAccountList.test.tsx
@@ -501,10 +501,20 @@ describe('ReconciliationAccountList — an empty list has two meanings', () => {
     expect(screen.queryByText('Nothing needs attention right now')).not.toBeInTheDocument();
   });
 
-  it('is left-aligned in both states, never centred', () => {
-    // DESIGN_PASS §4: a centred block with a picture is a greeting; this is a
-    // consequence and a remedy, and it reads down the left edge like the rest
-    // of the page.
+  it('is centred in both states — owner override of §4, 15 August 2026', () => {
+    /*
+     * This asserted the OPPOSITE until today, citing DESIGN_PASS §4: "a centred
+     * block with a picture is a greeting; this is a consequence and a remedy,
+     * and it reads down the left edge like the rest of the page."
+     *
+     * The owner overruled it on a reason the ruling could not see from a
+     * desktop mock: on a phone this is not a block on a page, it is the whole
+     * screen, and a left-aligned title in a full-width card with nothing to its
+     * right reads as a layout that has collapsed rather than as a sentence.
+     *
+     * Kept as an assertion rather than deleted, because the alignment is still
+     * a decision somebody could undo by accident — it has simply changed sides.
+     */
     const { unmount } = render(
       <PreferencesProvider>
         <ReconciliationAccountList
@@ -514,10 +524,10 @@ describe('ReconciliationAccountList — an empty list has two meanings', () => {
         />
       </PreferencesProvider>
     );
-    expect(document.querySelector('.text-center')).toBeNull();
+    expect(document.querySelector('.text-center')).not.toBeNull();
     unmount();
 
     renderGrouping({ mode: 'flat', summaries: [] });
-    expect(document.querySelector('.text-center')).toBeNull();
+    expect(document.querySelector('.text-center')).not.toBeNull();
   });
 });

--- a/src/contexts/NotificationContext.tsx
+++ b/src/contexts/NotificationContext.tsx
@@ -236,10 +236,85 @@ function withCategory(notifications: Notification[], category: NotificationCateg
   return notifications.map((notification): Notification => ({ ...notification, category }));
 }
 
-/** Has this exact alert already been raised inside the dedupe window? */
+/**
+ * ─ THE RAISED-KEY LEDGER ───────────────────────────────────────────────────
+ *
+ * Suppression used to BE the notification list: `hasRecentDuplicate` asked
+ * whether a matching `dedupeKey` was currently on the board. That works right
+ * up until somebody clears the board — at which point the memory of what had
+ * been raised is thrown away with it, the next generator run finds nothing to
+ * dedupe against, and every alert the user has just dismissed comes straight
+ * back. Reported as: "I clear them all and then some old ones pop back up
+ * later on when new ones get added."
+ *
+ * Dismissing is a STRONGER signal than having seen it, not a weaker one, so
+ * the fix is not merely to remember across a clear: dismissing an alert
+ * restarts its window. If the underlying condition is still true tomorrow it
+ * may speak again — that is the design, one warning per budget per day — but
+ * it does not get to speak again this afternoon because the list was tidied.
+ *
+ * Kept apart from the notifications themselves, and persisted separately, so
+ * that clearing one cannot clear the other. Pruned on every write; a key older
+ * than the window can never suppress anything again.
+ */
+const DEDUPE_LEDGER_KEY = 'money_management_notification_dedupe';
+
+type DedupeLedger = Record<string, number>;
+
+function readDedupeLedger(): DedupeLedger {
+  try {
+    const raw = localStorage.getItem(DEDUPE_LEDGER_KEY);
+    if (raw === null) return {};
+    const parsed: unknown = JSON.parse(raw);
+    if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) return {};
+    const out: DedupeLedger = {};
+    for (const [key, value] of Object.entries(parsed)) {
+      if (typeof value === 'number' && Number.isFinite(value)) out[key] = value;
+    }
+    return out;
+  } catch {
+    // A corrupt ledger must not stop notifications working. The cost of
+    // starting empty is one repeated alert; the cost of throwing is the bell.
+    return {};
+  }
+}
+
+function writeDedupeLedger(ledger: DedupeLedger, nowMs: number): DedupeLedger {
+  const oldest = nowMs - DEDUPE_WINDOW_MS;
+  const pruned: DedupeLedger = {};
+  for (const [key, at] of Object.entries(ledger)) {
+    if (at >= oldest) pruned[key] = at;
+  }
+  try {
+    localStorage.setItem(DEDUPE_LEDGER_KEY, JSON.stringify(pruned));
+  } catch {
+    // Storage full or unavailable — in-memory suppression still holds for
+    // this session, which is the case the owner reported.
+  }
+  return pruned;
+}
+
+/** Stamp these keys as raised (or dismissed) now, restarting their windows. */
+function recordDedupeKeys(keys: readonly string[], nowMs: number): void {
+  if (keys.length === 0) return;
+  const ledger = readDedupeLedger();
+  for (const key of keys) ledger[key] = nowMs;
+  writeDedupeLedger(ledger, nowMs);
+}
+
+/**
+ * Has this exact alert already been raised inside the dedupe window?
+ *
+ * Asks the LEDGER as well as the board, and the ledger is the half that
+ * survives a clear.
+ */
 function hasRecentDuplicate(existing: Notification[], dedupeKey: string, nowMs: number): boolean {
   const oldest = nowMs - DEDUPE_WINDOW_MS;
-  return existing.some((n): boolean => n.dedupeKey === dedupeKey && timestampMs(n) >= oldest);
+  if (existing.some((n): boolean => n.dedupeKey === dedupeKey && timestampMs(n) >= oldest)) {
+    return true;
+  }
+  const raisedAt = readDedupeLedger()[dedupeKey];
+  return raisedAt !== undefined && raisedAt >= oldest;
 }
 
 /**
@@ -440,6 +515,11 @@ export function NotificationProvider({ children }: { children: ReactNode }): Rea
       ) {
         return prev;
       }
+      // Stamped on ACCEPT, so the suppression outlives both the notification
+      // and any clear that removes it.
+      if (newNotification.dedupeKey !== undefined) {
+        recordDedupeKeys([newNotification.dedupeKey], newNotification.timestamp.getTime());
+      }
       return [newNotification, ...prev].slice(0, MAX_NOTIFICATIONS);
     });
   }, []);
@@ -463,6 +543,12 @@ export function NotificationProvider({ children }: { children: ReactNode }): Rea
       }
 
       if (accepted.length === 0) return prev;
+      recordDedupeKeys(
+        accepted
+          .map((n): string | undefined => n.dedupeKey)
+          .filter((key): key is string => key !== undefined),
+        nowMs
+      );
       return [...accepted, ...prev].slice(0, MAX_NOTIFICATIONS);
     });
   }, []);
@@ -480,11 +566,29 @@ export function NotificationProvider({ children }: { children: ReactNode }): Rea
   }, []);
 
   const removeNotification = useCallback((id: string): void => {
-    setNotifications((prev): Notification[] => prev.filter((n): boolean => n.id !== id));
+    setNotifications((prev): Notification[] => {
+      const going = prev.find((n): boolean => n.id === id);
+      // Dismissing is a stronger "I have dealt with this" than merely having
+      // seen it, so the window restarts from now rather than from when the
+      // alert was raised.
+      if (going?.dedupeKey !== undefined) recordDedupeKeys([going.dedupeKey], Date.now());
+      return prev.filter((n): boolean => n.id !== id);
+    });
   }, []);
 
   const clearAll = useCallback((): void => {
-    setNotifications([]);
+    setNotifications((prev): Notification[] => {
+      // THE BUG THIS FIXES. `setNotifications([])` on its own threw away the
+      // only record that these had ever been raised, so the next generator
+      // run put them straight back.
+      recordDedupeKeys(
+        prev
+          .map((n): string | undefined => n.dedupeKey)
+          .filter((key): key is string => key !== undefined),
+        Date.now()
+      );
+      return [];
+    });
   }, []);
 
   /**

--- a/src/contexts/__tests__/NotificationContext.clearedStaysCleared.test.tsx
+++ b/src/contexts/__tests__/NotificationContext.clearedStaysCleared.test.tsx
@@ -1,0 +1,139 @@
+/**
+ * CLEARED STAYS CLEARED.
+ *
+ * The owner's report: "I am sure I am clearing them all and then some old ones
+ * are popping back up later on when new ones get added."
+ *
+ * He was right, and the cause was that suppression WAS the notification list.
+ * `hasRecentDuplicate` asked whether a matching `dedupeKey` was currently on
+ * the board — so clearing the board threw away the record of what had been
+ * raised, the next generator run found nothing to dedupe against, and the
+ * dismissed alerts came back.
+ *
+ * The generators are the thing that makes this reachable rather than
+ * theoretical: budget alerts are RECOMPUTED from current data every time the
+ * Budget page runs its effect. They do not remember having fired; the dedupe
+ * ledger is the only thing that does.
+ */
+import React from 'react';
+import { describe, it, expect, beforeEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { NotificationProvider, useNotifications } from '../NotificationContext';
+import { PreferencesProvider } from '../PreferencesContext';
+
+/** The provider reads preferences (the alert on/off switches) on mount. */
+const wrapper = ({ children }: { children: React.ReactNode }) => (
+  <PreferencesProvider>
+    <NotificationProvider>{children}</NotificationProvider>
+  </PreferencesProvider>
+);
+
+const alert = (key: string) => ({
+  type: 'warning' as const,
+  title: 'Budget Warning: Groceries',
+  message: 'You have spent 85% of your monthly budget.',
+  category: 'budget' as const,
+  dedupeKey: key
+});
+
+describe('a cleared notification does not come back', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it('stays gone when the same alert is recomputed after Clear all', () => {
+    const { result } = renderHook(() => useNotifications(), { wrapper });
+
+    act(() => { result.current.addNotification(alert('budget-1-warning')); });
+    expect(result.current.notifications).toHaveLength(1);
+
+    act(() => { result.current.clearAll(); });
+    expect(result.current.notifications).toHaveLength(0);
+
+    // The Budget page recomputes and raises the identical alert, which is what
+    // it does on every visit for as long as the budget is still over.
+    act(() => { result.current.addNotification(alert('budget-1-warning')); });
+
+    expect(result.current.notifications).toHaveLength(0);
+  });
+
+  it('stays gone when dismissed one at a time', () => {
+    const { result } = renderHook(() => useNotifications(), { wrapper });
+
+    act(() => { result.current.addNotification(alert('budget-2-warning')); });
+    const id = result.current.notifications[0].id;
+
+    act(() => { result.current.removeNotification(id); });
+    act(() => { result.current.addNotification(alert('budget-2-warning')); });
+
+    expect(result.current.notifications).toHaveLength(0);
+  });
+
+  it('still lets a DIFFERENT alert through afterwards', () => {
+    // The failure mode of over-correcting: a ledger that suppressed everything
+    // would be indistinguishable from a broken bell.
+    const { result } = renderHook(() => useNotifications(), { wrapper });
+
+    act(() => { result.current.addNotification(alert('budget-3-warning')); });
+    act(() => { result.current.clearAll(); });
+    act(() => { result.current.addNotification(alert('budget-4-warning')); });
+
+    expect(result.current.notifications).toHaveLength(1);
+    expect(result.current.notifications[0].dedupeKey).toBe('budget-4-warning');
+  });
+
+  it('does not suppress unkeyed notifications, which are one-offs', () => {
+    const { result } = renderHook(() => useNotifications(), { wrapper });
+
+    act(() => {
+      result.current.addNotification({
+        type: 'success',
+        title: 'Import finished',
+        message: '42 transactions added.'
+      });
+    });
+    act(() => { result.current.clearAll(); });
+    act(() => {
+      result.current.addNotification({
+        type: 'success',
+        title: 'Import finished',
+        message: '7 transactions added.'
+      });
+    });
+
+    // No dedupeKey means "this is an event, not a condition" — a second import
+    // genuinely is a second thing to say.
+    expect(result.current.notifications).toHaveLength(1);
+  });
+
+  it('survives a reload, since the ledger is persisted and the list may not be', () => {
+    const first = renderHook(() => useNotifications(), { wrapper });
+    act(() => { first.result.current.addNotification(alert('budget-5-warning')); });
+    act(() => { first.result.current.clearAll(); });
+    first.unmount();
+
+    const second = renderHook(() => useNotifications(), { wrapper });
+    act(() => { second.result.current.addNotification(alert('budget-5-warning')); });
+
+    expect(second.result.current.notifications).toHaveLength(0);
+  });
+
+  it('lets it speak again once the window has passed', () => {
+    // Suppression is a day, not forever: a budget still over tomorrow is a new
+    // fact worth one more warning. Written by ageing the ledger entry rather
+    // than by faking the clock, so it exercises the real comparison.
+    const { result } = renderHook(() => useNotifications(), { wrapper });
+
+    act(() => { result.current.addNotification(alert('budget-6-warning')); });
+    act(() => { result.current.clearAll(); });
+
+    const LEDGER = 'money_management_notification_dedupe';
+    const ledger = JSON.parse(localStorage.getItem(LEDGER) ?? '{}') as Record<string, number>;
+    ledger['budget-6-warning'] = Date.now() - (25 * 60 * 60 * 1000);
+    localStorage.setItem(LEDGER, JSON.stringify(ledger));
+
+    act(() => { result.current.addNotification(alert('budget-6-warning')); });
+
+    expect(result.current.notifications).toHaveLength(1);
+  });
+});

--- a/src/design-system/__tests__/categoricalSliceCount.test.ts
+++ b/src/design-system/__tests__/categoricalSliceCount.test.ts
@@ -1,0 +1,85 @@
+/**
+ * A CHART MAY NOT DRAW MORE SLICES THAN THE PALETTE CAN COLOUR.
+ *
+ * `categoricalColor` cycles past the end of the ramp, silently — ask for a
+ * sixth series and it comes back painted exactly like the first. Nothing
+ * throws, no contrast figure moves, and the only symptom is a reader who
+ * cannot tell two categories apart.
+ *
+ * Both live charts had it. The Dashboard's expense donut sliced to six against
+ * a five-colour ramp ("the pie seems to be split into 5 sections and the
+ * legend is listing 6"). The Investments ring drew one slice per account —
+ * twelve — so slices 1, 6 and 11 were identical and it read as one grey
+ * doughnut.
+ *
+ * The ceiling is the palette's own arithmetic rather than a layout preference:
+ * the categorical axis is ONE HUE walked, and each ground can only use the
+ * half of it that clears 3:1 against that ground. A chart with more than five
+ * things to say needs a grouped remainder, not a longer ramp.
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync, readdirSync, statSync } from 'node:fs';
+import { join } from 'node:path';
+import { categoricalRamp, MAX_CATEGORICAL_SERIES } from '../../components/charts/chartColors';
+
+const SRC = join(process.cwd(), 'src');
+
+function sourceFiles(dir: string, out: string[] = []): string[] {
+  for (const entry of readdirSync(dir)) {
+    if (entry === 'node_modules' || entry === 'dist') continue;
+    const full = join(dir, entry);
+    if (statSync(full).isDirectory()) sourceFiles(full, out);
+    else if (/\.tsx?$/.test(entry)) out.push(full);
+  }
+  return out;
+}
+
+/** Comments blanked, line numbers kept — this repo names its traps in prose. */
+function stripComments(source: string): string {
+  return source
+    .replace(/\/\*[\s\S]*?\*\//g, (block) => block.replace(/[^\n]/g, ' '))
+    .replace(/(^|[^:])\/\/[^\n]*/g, (match, lead: string) => lead + ' '.repeat(match.length - lead.length));
+}
+
+describe('categorical slice count', () => {
+  it('keeps both ramps and the stated ceiling in step', () => {
+    expect(categoricalRamp(false)).toHaveLength(MAX_CATEGORICAL_SERIES);
+    expect(categoricalRamp(true)).toHaveLength(MAX_CATEGORICAL_SERIES);
+  });
+
+  it('has no chart capping itself above the ceiling', () => {
+    // FILE-LEVEL, and the window heuristic that replaced it was worse: the
+    // Dashboard's cap lives in a useMemo and its Cells are ~80 lines below, so
+    // "does categoricalColor appear near the slice" missed the exact bug this
+    // test was written for. (Caught by reintroducing `.slice(0, 6)` and
+    // watching the test stay green.)
+    //
+    // So the rule is the blunt one — do not hard-code a cap in a file that
+    // colours through the ramp — with a marker for the genuine exceptions,
+    // which are lists that are not charted at all. The marker has to be
+    // written deliberately, which is the point.
+    const ALLOW = 'not-a-charted-series';
+    const offenders: string[] = [];
+    for (const file of sourceFiles(SRC)) {
+      if (file.includes('__tests__') || /\.test\.tsx?$/.test(file)) continue;
+      const raw = readFileSync(file, 'utf8');
+      const source = stripComments(raw);
+      if (!source.includes('categoricalColor')) continue;
+      const rawLines = raw.split('\n');
+      source.split('\n').forEach((line, i) => {
+        const match = /\.slice\(0,\s*(\d+)\)/.exec(line);
+        if (!match || Number(match[1]) <= MAX_CATEGORICAL_SERIES) return;
+        // The marker may sit on the line or on the two above it.
+        const nearby = rawLines.slice(Math.max(0, i - 2), i + 1).join('\n');
+        if (nearby.includes(ALLOW)) return;
+        offenders.push(`${file.replace(SRC, 'src')}:${i + 1} — ${line.trim().slice(0, 80)}`);
+      });
+    }
+
+    expect(
+      offenders,
+      `These colour series through the ramp but cap above it, so the extra ` +
+        `slices repeat colours:\n${offenders.join('\n')}`
+    ).toEqual([]);
+  });
+});

--- a/src/pages/Categorisation.tsx
+++ b/src/pages/Categorisation.tsx
@@ -10,7 +10,8 @@ import { useToast } from '../contexts/ToastContext';
 import TransferSweepModal from '../components/TransferSweepModal';
 import BulkCategorizeModal from '../components/BulkCategorizeModal';
 import ReportDrillModal, { type ReportDrillTarget } from '../components/reports/ReportDrillModal';
-import { ArrowRightLeftIcon, TagIcon, ListIcon, CheckCircleIcon, Building2Icon, ChevronRightIcon } from '../components/icons';
+import { ArrowRightLeftIcon, TagIcon, ListIcon, CheckCircleIcon, ChevronRightIcon } from '../components/icons';
+import EmptyState from '../components/EmptyState';
 import type { Transaction } from '../types';
 
 /**
@@ -127,14 +128,19 @@ export default function Categorisation(): React.JSX.Element {
       </div>
 
       {count === 0 ? (
-        <div className="bg-white dark:bg-gray-800 rounded-xl border-2 border-gray-200 dark:border-gray-700 p-8 text-center">
-          <CheckCircleIcon size={32} className="mx-auto text-blue-600 dark:text-blue-400" />
-          <p className="mt-3 font-semibold text-gray-900 dark:text-white">Everything is filed</p>
-          <p className="mt-1 text-sm text-gray-500 dark:text-gray-400">
-            {suggestedCount === 0
-              ? 'Every transaction has a category, so every report is counting all of your money.'
-              : 'Every transaction has a category, so every report is counting all of your money — but some of those categories are still the app’s suggestions, below.'}
-          </p>
+        // The hand-rolled centred copy this page carried since batch 7 is what
+        // exposed the inconsistency — and it was the one that was right. Now
+        // the shared component, which the owner centred app-wide on 15 August.
+        <div className="bg-white dark:bg-gray-800 rounded-xl border-2 border-gray-200 dark:border-gray-700">
+          <EmptyState
+            icon={<CheckCircleIcon size={32} className="text-blue-600 dark:text-blue-400" />}
+            title="Everything is filed"
+            description={
+              suggestedCount === 0
+                ? 'Every transaction has a category, so every report is counting all of your money.'
+                : 'Every transaction has a category, so every report is counting all of your money — but some of those categories are still the app’s suggestions, below.'
+            }
+          />
         </div>
       ) : (
         <>
@@ -199,9 +205,6 @@ export default function Categorisation(): React.JSX.Element {
                   onClick={() => openDrill(`Uncategorised — ${accountName(accountId)}`, accountRows)}
                   className="w-full text-left bg-white dark:bg-gray-800 rounded-xl border-2 border-gray-200 dark:border-gray-700 hover:border-primary hover:shadow-md transition-all p-4 flex items-center gap-3"
                 >
-                  <div className="p-2 bg-gray-100 dark:bg-gray-700 rounded-lg flex-shrink-0">
-                    <Building2Icon size={20} className="text-gray-600 dark:text-gray-400" />
-                  </div>
                   <span className="font-medium text-gray-900 dark:text-white truncate min-w-0 flex-1">
                     {accountName(accountId)}
                   </span>

--- a/src/pages/Investments.tsx
+++ b/src/pages/Investments.tsx
@@ -14,6 +14,7 @@ import { formatDecimal } from '../utils/decimal-format';
 import PageWrapper from '../components/PageWrapper';
 import GroupedAccountOptions from '../components/common/GroupedAccountOptions';
 import { buildPortfolioSummary, buildPortfolioHistory } from '../utils/portfolioSummary';
+import { buildHoldingAllocation } from '../utils/holdingAllocation';
 // THE SEAM, not the service. This page called `InvestmentService` — and, through
 // it, a Supabase client — directly until slice 31, with a `userIdService` lookup
 // at every one of its five call sites. That is the coupling `src/desktop/routes.ts`
@@ -27,12 +28,54 @@ import { buildPortfolioSummary, buildPortfolioHistory } from '../utils/portfolio
 import { dataPort } from '@data';
 import type { InvestmentHolding } from '@data';
 import { fetchQuotes } from '../services/stockPriceService';
-import { categoricalColor, useCategoricalRamp } from '../components/charts/chartColors';
+import { capSeriesWithRemainder, categoricalColor, useCategoricalRamp, useChartTooltipStyle } from '../components/charts/chartColors';
+import { resolvePeriod } from '../hooks/usePeriod';
+
+/**
+ * The windows this chart offers, in the app's own words.
+ *
+ * `3 months` rather than `3M`: the abbreviation saved eleven characters on a
+ * control that has room, at the cost of matching nothing else in the product.
+ */
+const INVESTMENT_PERIODS = ['1-month', '3-months', '6-months', '12-months', 'tax-year', 'all'] as const;
+type InvestmentPeriod = (typeof INVESTMENT_PERIODS)[number];
+
+const INVESTMENT_PERIOD_LABELS: Record<InvestmentPeriod, string> = {
+  '1-month': '1 month',
+  '3-months': '3 months',
+  '6-months': '6 months',
+  '12-months': '12 months',
+  'tax-year': 'Tax year',
+  all: 'All time',
+};
+
+/** Trailing windows only; 'tax-year' and 'all' resolve elsewhere. */
+const INVESTMENT_PERIOD_MONTHS: Record<'1-month' | '3-months' | '6-months' | '12-months', number> = {
+  '1-month': 1,
+  '3-months': 3,
+  '6-months': 6,
+  '12-months': 12,
+};
 
 export default function Investments() {
   const { accounts, transactions, transactionSplits, categories } = useApp();
   const { formatCurrency } = useCurrencyDecimal();
-  const [selectedPeriod, setSelectedPeriod] = useState<'1M' | '3M' | '6M' | '1Y' | 'ALL'>('1Y');
+  /**
+   * THE APP'S PERIOD VOCABULARY, spoken here too.
+   *
+   * This picker used to read `1M 3M 6M 1Y ALL` while every other surface in the
+   * app said "This month / Tax year / 12 months / All time". Two vocabularies
+   * for one idea means the reader has to translate between screens, and the one
+   * period a UK user most wants of an investment chart — the tax year — was
+   * missing from the only page where gains are realised.
+   *
+   * The WINDOWS stay trailing rather than becoming the Dashboard's calendar
+   * periods: "the last 3 months" is the right question of a performance line,
+   * and "this month" is not. What is shared is the wording and the tax-year
+   * rule itself, which comes from `resolvePeriod` so that Tax year means 6
+   * April here and on the Dashboard, forever, from one definition.
+   */
+  const [selectedPeriod, setSelectedPeriod] = useState<InvestmentPeriod>('12-months');
   const [showAddInvestmentModal, setShowAddInvestmentModal] = useState(false);
   const [activeTab, setActiveTab] = useState<'overview' | 'watchlist' | 'portfolio' | 'manage'>('overview');
   const [managingAccountId, setManagingAccountId] = useState<string | null>(null);
@@ -206,8 +249,12 @@ export default function Investments() {
   // The window the chart covers. 'ALL' is unbounded at both ends, which the
   // history walk reads as "first transaction until today".
   const historyRange = useMemo(() => {
-    if (selectedPeriod === 'ALL') return { from: null, to: null };
-    const months = { '1M': 1, '3M': 3, '6M': 6, '1Y': 12 }[selectedPeriod];
+    if (selectedPeriod === 'all') return { from: null, to: null };
+    // Borrowed whole, so the two pages cannot disagree about when the tax year
+    // starts — including in the days between 1 and 5 April, which is exactly
+    // when a second implementation would have been caught.
+    if (selectedPeriod === 'tax-year') return resolvePeriod('tax-year', '', '');
+    const months = INVESTMENT_PERIOD_MONTHS[selectedPeriod];
     const now = new Date();
     return { from: new Date(now.getFullYear(), now.getMonth() - months, now.getDate()), to: now };
   }, [selectedPeriod]);
@@ -220,12 +267,28 @@ export default function Investments() {
   );
 
   // Numbers for the donut, converted once at the chart boundary.
+  /**
+   * THE SLICES, capped at what the palette can colour.
+   *
+   * This drew one slice per account — twelve, against a five-colour ramp — so
+   * slices 1 and 6 and 11 were painted identically and the ring read as one
+   * grey doughnut. Reported by the owner as "the pie looks all the same colour
+   * to the eye vs the legend".
+   *
+   * The four largest keep their own slice and everything below them becomes a
+   * single remainder, which is the honest shape: a 0.01% wedge is not a slice
+   * anybody can see or click, and pretending otherwise is what made the legend
+   * twelve rows long. The remainder is NAMED with its count so the total is
+   * still accounted for — a share that does not add up is the one thing a
+   * finance chart may not do.
+   */
   const allocationData = useMemo(
-    () => summary.lines.map(line => ({
-      name: line.name,
-      ticker: line.institution || 'N/A',
-      value: line.value.toNumber()
-    })),
+    () => capSeriesWithRemainder(
+      summary.lines.filter(line => line.value.greaterThan(0)),
+      line => line.value.toNumber(),
+      line => line.name,
+      count => `${count} smaller accounts`
+    ),
     [summary.lines]
   );
 
@@ -233,11 +296,44 @@ export default function Investments() {
   // `holdings` is now the market-side data from public.investments, and the two
   // must never be confused for each other on this page.
   const portfolioLines = summary.lines;
+  /**
+   * WHAT the money is in, as opposed to WHERE it is kept.
+   *
+   * The ring above answers "which account holds it", which tells somebody with
+   * one broker and six wrappers nothing. This one crosses accounts: Apple held
+   * in an ISA and in a dealing account is one position, and every settlement
+   * sleeve in the portfolio is a single Cash category.
+   */
+  const holdingAllocation = useMemo(
+    () => buildHoldingAllocation(holdings, summary.lines),
+    [holdings, summary.lines]
+  );
+
+  const holdingSlices = useMemo(
+    () => capSeriesWithRemainder(
+      holdingAllocation.slices,
+      slice => slice.value.toNumber(),
+      slice => slice.label,
+      count => `${count} smaller holdings`
+    ),
+    [holdingAllocation.slices]
+  );
+
+  const holdingSlicesTotal = useMemo(
+    () => holdingSlices.reduce((sum, slice) => sum + slice.value, 0),
+    [holdingSlices]
+  );
+
+  const allocationTotal = useMemo(
+    () => allocationData.reduce((sum, slice) => sum + slice.value, 0),
+    [allocationData]
+  );
   const isGain = summary.totalReturn.greaterThanOrEqualTo(0);
   // The shared ramp. The array that stood here claimed to be "consistent
   // colors" while being the only one of the app's palettes to differ from its
   // twin — positions seven and eight had drifted to a cyan and a lime.
   const ramp = useCategoricalRamp();
+  const chartTooltipStyle = useChartTooltipStyle();
 
   // If no investment accounts, show empty state
   if (investmentAccounts.length === 0) {
@@ -449,17 +545,17 @@ export default function Investments() {
         <div className="flex justify-between items-center mb-4">
           <h2 className="text-card font-semibold text-theme-heading dark:text-white">Portfolio Performance</h2>
           <div className="flex gap-2">
-            {['1M', '3M', '6M', '1Y', 'ALL'].map((period) => (
+            {INVESTMENT_PERIODS.map((period) => (
               <button
                 key={period}
-                onClick={() => setSelectedPeriod(period as '1M' | '3M' | '6M' | '1Y' | 'ALL')}
+                onClick={() => setSelectedPeriod(period)}
                 className={`px-3 py-1 text-body rounded-lg transition-colors ${
                   selectedPeriod === period
-                    ? 'bg-[#1a2332] text-white'
+                    ? 'bg-[#1a2332] text-white dark:bg-gray-600 dark:text-white'
                     : 'bg-gray-100 dark:bg-gray-700 text-gray-700 dark:text-gray-300 hover:bg-gray-200 dark:hover:bg-gray-600'
                 }`}
               >
-                {period}
+                {INVESTMENT_PERIOD_LABELS[period]}
               </button>
             ))}
           </div>
@@ -485,11 +581,7 @@ export default function Investments() {
               />
               <Tooltip
                 formatter={(value) => formatCurrency(toDecimal(Number(value)))}
-                contentStyle={{
-                  backgroundColor: 'rgba(255, 255, 255, 0.95)',
-                  border: '1px solid #ccc',
-                  borderRadius: '8px'
-                }}
+                contentStyle={chartTooltipStyle}
               />
               <Line 
                 type="monotone" 
@@ -605,27 +697,43 @@ export default function Investments() {
                     </Pie>
                     <Tooltip
                       formatter={(value) => formatCurrency(toDecimal(Number(value)))}
-                      contentStyle={{
-                        backgroundColor: 'rgba(255, 255, 255, 0.95)',
-                        border: '1px solid #ccc',
-                        borderRadius: '8px'
-                      }}
+                      contentStyle={chartTooltipStyle}
                     />
                   </RePieChart>
                 </ResponsiveContainer>
               </div>
               <div className="mt-4 space-y-2">
-                {portfolioLines.map((line, index) => (
-                  <div key={line.accountId} className="flex items-center justify-between text-body">
+                {/* Walks THE SLICES, not the accounts. The legend used to walk
+                    `portfolioLines` while the ring walked `allocationData`, so
+                    the two could differ in length and did — twelve rows beside
+                    a five-colour ring. One source now, so a row and a wedge
+                    cannot disagree about what exists. */}
+                {allocationData.map((slice, index) => (
+                  <div key={slice.name} className="flex items-center justify-between text-body">
                     <div className="flex items-center gap-2">
                       <div
                         className="w-3 h-3 rounded-full"
                         style={{ backgroundColor: categoricalColor(ramp, index) }}
                       />
-                      <span className="text-gray-700 dark:text-gray-300">{line.institution || 'N/A'}</span>
+                      {/* The ACCOUNT, which is what the slice is. This read
+                          `line.institution || 'N/A'` — so a portfolio held at
+                          one bank showed the same word against four different
+                          slices, and every account with no institution on file
+                          was labelled "N/A". The legend is the only thing
+                          identifying a slice (the ramp is one hue walked, and
+                          it cycles), so naming it wrongly leaves the chart
+                          unreadable rather than merely untidy. */}
+                      <span className="text-gray-700 dark:text-gray-300">{slice.name}</span>
                     </div>
+                    {/* The share is of THE RING, so the rows add to 100% — the
+                        same rule the Dashboard's donut states. Taken from the
+                        slice rather than from `line.allocation`, which was a
+                        share of every account including the ones now folded
+                        into the remainder, and so would no longer sum. */}
                     <span className="text-gray-900 dark:text-white font-medium">
-                      {formatPercentage(line.allocation)}
+                      {allocationTotal > 0
+                        ? `${((slice.value / allocationTotal) * 100).toFixed(2)}%`
+                        : '0.00%'}
                     </span>
                   </div>
                 ))}
@@ -633,6 +741,90 @@ export default function Investments() {
             </>
           )}
         </div>
+        </div>
+
+        {/* ─ WHAT IT IS IN ────────────────────────────────────────────────────
+            A second ring, because the first one's card was mostly empty space
+            below a twelve-row legend and because it answers a different
+            question. Where the money is KEPT and what it is INVESTED IN are
+            not the same fact, and only the second one is a decision. */}
+        <div className="bg-white dark:bg-gray-800 rounded-lg border border-line dark:border-gray-700 p-6 mt-6">
+          <h2 className="text-card font-semibold mb-1 text-theme-heading dark:text-white">
+            Allocation by holding
+          </h2>
+          <p className="text-body text-gray-500 dark:text-gray-400 mb-4">
+            Every account together — one line per security, with all settlement cash as one.
+          </p>
+
+          {holdingSlices.length === 0 ? (
+            <p className="text-body text-gray-500 dark:text-gray-400">
+              {holdingAllocation.unpricedCount > 0
+                ? 'None of your holdings has a price yet, so there is nothing to size this by. Use “Update prices” on an account above.'
+                : 'No priced holdings and no settlement cash, so there is nothing to divide up yet.'}
+            </p>
+          ) : (
+            <div className="flex flex-col lg:flex-row lg:items-center gap-6">
+              <div className="h-56 w-full lg:w-56 shrink-0">
+                <ResponsiveContainer width="100%" height="100%">
+                  <RePieChart>
+                    <Pie
+                      data={holdingSlices}
+                      cx="50%"
+                      cy="50%"
+                      innerRadius={55}
+                      outerRadius={80}
+                      paddingAngle={3}
+                      dataKey="value"
+                    >
+                      {holdingSlices.map((slice, index) => (
+                        <Cell key={slice.name} fill={categoricalColor(ramp, index)} />
+                      ))}
+                    </Pie>
+                    <Tooltip
+                      formatter={(value) => formatCurrency(toDecimal(Number(value)))}
+                      contentStyle={chartTooltipStyle}
+                    />
+                  </RePieChart>
+                </ResponsiveContainer>
+              </div>
+
+              <div className="flex-1 min-w-0 space-y-2">
+                {holdingSlices.map((slice, index) => (
+                  <div key={slice.name} className="flex items-center justify-between gap-3 text-body">
+                    <div className="flex items-center gap-2 min-w-0">
+                      <div
+                        className="w-3 h-3 rounded-full shrink-0"
+                        style={{ backgroundColor: categoricalColor(ramp, index) }}
+                      />
+                      <span className="text-gray-700 dark:text-gray-300 truncate">{slice.name}</span>
+                    </div>
+                    <div className="flex items-center gap-3 shrink-0">
+                      <span className="text-gray-500 dark:text-gray-400 tabular-nums">
+                        {formatCurrency(toDecimal(slice.value))}
+                      </span>
+                      <span className="text-gray-900 dark:text-white font-medium tabular-nums w-16 text-right">
+                        {holdingSlicesTotal > 0
+                          ? `${((slice.value / holdingSlicesTotal) * 100).toFixed(2)}%`
+                          : '0.00%'}
+                      </span>
+                    </div>
+                  </div>
+                ))}
+
+                {/* SAID, not swallowed. A position with no price cannot be
+                    sized, so it is not in the ring — and a chart that quietly
+                    leaves out part of what you own is the same offence as a
+                    filtered list claiming your money is gone. */}
+                {holdingAllocation.unpricedCount > 0 && (
+                  <p className="pt-2 text-body text-gray-500 dark:text-gray-400">
+                    {holdingAllocation.unpricedCount === 1
+                      ? '1 holding has no price yet, so it is not counted above.'
+                      : `${holdingAllocation.unpricedCount} holdings have no price yet, so they are not counted above.`}
+                  </p>
+                )}
+              </div>
+            </div>
+          )}
         </div>
 
         {/* Investment Tips */}

--- a/src/pages/OpenBanking.tsx
+++ b/src/pages/OpenBanking.tsx
@@ -253,7 +253,6 @@ export default function OpenBanking() {
                 className="flex items-center justify-between p-4 border border-gray-200 dark:border-gray-700 rounded-lg"
               >
                 <div className="flex items-center gap-3">
-                  <BankIcon size={24} className="text-blue-600" />
                   <div>
                     <p className="font-medium">{connection.institutionName}</p>
                     <div className="flex items-center gap-2 text-sm text-gray-500">

--- a/src/pages/__tests__/Investments.test.tsx
+++ b/src/pages/__tests__/Investments.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, afterEach } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { render, screen, within } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import { PreferencesProvider } from '../../contexts/PreferencesContext';
 import Investments from '../Investments';
@@ -89,14 +89,25 @@ describe('Investments page — the pair is the portfolio', () => {
     expect(screen.queryByRole('heading', { level: 3, name: 'Fund ISA (Cash)' })).not.toBeInTheDocument();
 
     // Sub-line under the row: the importer's "<Name> (Cash)" reads as 'Cash'.
-    expect(screen.getByText('Cash')).toBeInTheDocument();
-    expect(screen.getByText('£200.00')).toBeInTheDocument();
+    // Scoped to the Holdings list because "Allocation by holding" (added 15
+    // August) has a Cash slice of its own — a second, deliberate use of the
+    // word on this page, and a page-wide getByText can no longer tell them
+    // apart. Asserting on the one this test is about, not on there being one.
+    const holdingsPanel = screen.getByRole('heading', { name: 'Holdings' }).closest('div');
+    expect(holdingsPanel).not.toBeNull();
+    expect(within(holdingsPanel as HTMLElement).getByText('Cash')).toBeInTheDocument();
+    expect(within(holdingsPanel as HTMLElement).getByText('£200.00')).toBeInTheDocument();
   });
 
   it('counts the whole portfolio once, at 100% allocation', async () => {
     renderInvestments();
 
-    expect(await screen.findAllByText('100.00%')).toHaveLength(2);
+    // THREE since 15 August, not two: the fixture's single account is 100% of
+    // the account ring, 100% of its own row — and now 100% of the new
+    // "Allocation by holding" ring too, whose only slice is that account's
+    // cash. The count is the point of the test (nothing is double-counted), so
+    // it moves with the page rather than being loosened to "at least one".
+    expect(await screen.findAllByText('100.00%')).toHaveLength(3);
   });
 });
 

--- a/src/pages/reports/ReportGallery.tsx
+++ b/src/pages/reports/ReportGallery.tsx
@@ -53,21 +53,23 @@ export default function ReportGallery(): React.JSX.Element {
 
             <ul className={`grid grid-cols-1 ${gridColumnsClass(reports.length)} gap-4`}>
               {reports.map(report => {
-                const Icon = report.icon;
                 return (
                   <li key={report.id}>
                     {/* No chevron: the whole card is the link, and an arrow
                         announcing that is chrome charged against the words that
-                        say what the report is (P1). No tile behind the icon
-                        either — a 20px glyph does not need a box to be found. */}
+                        say what the report is (P1).
+                        No icon either, since 15 August. The note that used to
+                        stand here argued a 20px glyph needs no box behind it —
+                        true, and it stopped one step short. Eleven cards each
+                        carrying a glyph, three of them the same pie, meant the
+                        icons distinguished nothing and the titles did all the
+                        work. The same reduction the Accounts page made when it
+                        dropped its per-row type icons (#281): one icon per
+                        KIND, never one per row. */}
                     <Link
                       to={preserveDemoParam(`/reports/${report.id}`, location.search)}
                       className="group h-full flex items-start gap-3 bg-white dark:bg-gray-800 rounded-lg border border-line dark:border-gray-700 p-4 hover:border-primary dark:hover:border-blue-500 transition-colors duration-state"
                     >
-                      <Icon
-                        size={20}
-                        className="mt-0.5 flex-shrink-0 text-gray-500 dark:text-gray-400 group-hover:text-primary dark:group-hover:text-blue-400"
-                      />
                       <span className="min-w-0 flex-1">
                         <span className="block text-body font-semibold text-gray-900 dark:text-white group-hover:text-primary dark:group-hover:text-blue-400">
                           {report.title}

--- a/src/utils/__tests__/holdingAllocation.test.ts
+++ b/src/utils/__tests__/holdingAllocation.test.ts
@@ -1,0 +1,167 @@
+/**
+ * Allocation by security rather than by account.
+ *
+ * The tests that matter are the honesty ones: a holding with no price must be
+ * COUNTED and reported rather than quietly dropped, and cash must appear as one
+ * category however many sleeves it is spread across.
+ */
+import { describe, it, expect } from 'vitest';
+import { buildHoldingAllocation, CASH_SLICE_LABEL } from '../holdingAllocation';
+import { toDecimal } from '../decimal';
+import type { InvestmentHolding } from '../../services/investments/holding';
+import type { PortfolioLine } from '../portfolioSummary';
+
+function holding(over: Partial<InvestmentHolding> & { symbol: string }): InvestmentHolding {
+  const quantity = over.quantity ?? toDecimal(10);
+  const price = over.currentPrice === undefined ? toDecimal(100) : over.currentPrice;
+  return {
+    id: `h-${over.symbol}-${Math.abs(quantity.toNumber())}`,
+    accountId: 'acc-1',
+    name: over.name ?? over.symbol,
+    quantity,
+    costBasis: toDecimal(0),
+    averageCost: toDecimal(0),
+    currentPrice: price,
+    marketValue: over.marketValue !== undefined
+      ? over.marketValue
+      : price === null ? null : price.times(quantity),
+    currency: 'GBP',
+    assetType: 'stock',
+    purchaseDate: null,
+    purchasePrice: null,
+    lastUpdated: null,
+    notes: '',
+    ...over
+  } as InvestmentHolding;
+}
+
+function line(cash: Array<{ label: string; value: number }>): PortfolioLine {
+  return {
+    accountId: 'acc-1',
+    name: 'An account',
+    institution: '',
+    value: toDecimal(0),
+    cash: cash.map((entry, i) => ({
+      accountId: `cash-${i}`,
+      label: entry.label,
+      value: toDecimal(entry.value)
+    })),
+    allocation: toDecimal(0)
+  } as PortfolioLine;
+}
+
+describe('allocation by holding', () => {
+  it('adds one security up across every account that holds it', () => {
+    const result = buildHoldingAllocation(
+      [
+        holding({ symbol: 'AAPL', quantity: toDecimal(10), currentPrice: toDecimal(100) }),
+        holding({ symbol: 'AAPL', quantity: toDecimal(5), currentPrice: toDecimal(100) }),
+        holding({ symbol: 'MSFT', quantity: toDecimal(2), currentPrice: toDecimal(50) })
+      ],
+      []
+    );
+
+    // An ISA and a dealing account holding Apple is one position, not two.
+    expect(result.slices.map(s => [s.key, s.value.toNumber()])).toEqual([
+      ['AAPL', 1500],
+      ['MSFT', 100]
+    ]);
+    expect(result.total.toNumber()).toBe(1600);
+  });
+
+  it('matches on the ticker even when the two rows spell the name differently', () => {
+    const result = buildHoldingAllocation(
+      [
+        holding({ symbol: 'aapl', name: 'Apple Inc', quantity: toDecimal(1), currentPrice: toDecimal(10) }),
+        holding({ symbol: 'AAPL', name: 'Apple Inc.', quantity: toDecimal(1), currentPrice: toDecimal(10) })
+      ],
+      []
+    );
+
+    expect(result.slices).toHaveLength(1);
+    expect(result.slices[0].value.toNumber()).toBe(20);
+  });
+
+  it('gathers every cash sleeve into one category', () => {
+    const result = buildHoldingAllocation(
+      [holding({ symbol: 'AAPL', quantity: toDecimal(1), currentPrice: toDecimal(100) })],
+      [
+        line([{ label: 'Cash', value: 30 }, { label: 'Cash', value: 20 }]),
+        line([{ label: 'Cash', value: 50 }])
+      ]
+    );
+
+    const cash = result.slices.filter(s => s.label === CASH_SLICE_LABEL);
+    expect(cash).toHaveLength(1);
+    expect(cash[0].value.toNumber()).toBe(100);
+  });
+
+  it('ranks cash by size like anything else, not last', () => {
+    // A portfolio that has just sold up is mostly cash, and burying it at the
+    // end of the legend would be the one arrangement that misleads.
+    const result = buildHoldingAllocation(
+      [holding({ symbol: 'AAPL', quantity: toDecimal(1), currentPrice: toDecimal(10) })],
+      [line([{ label: 'Cash', value: 900 }])]
+    );
+
+    expect(result.slices[0].label).toBe(CASH_SLICE_LABEL);
+  });
+
+  describe('holdings with no price', () => {
+    it('counts them instead of pretending they are not owned', () => {
+      const result = buildHoldingAllocation(
+        [
+          holding({ symbol: 'AAPL', quantity: toDecimal(1), currentPrice: toDecimal(100) }),
+          holding({ symbol: 'XYZ', currentPrice: null, marketValue: null }),
+          holding({ symbol: 'ABC', currentPrice: null, marketValue: null })
+        ],
+        []
+      );
+
+      expect(result.unpricedCount).toBe(2);
+      // Not in the ring, because there is no number for them…
+      expect(result.slices.map(s => s.key)).toEqual(['AAPL']);
+      // …and therefore not in the total either, so the shares still add to 100
+      // of what IS shown, and the caller says what is missing.
+      expect(result.total.toNumber()).toBe(100);
+    });
+
+    it('reports none when everything is priced', () => {
+      const result = buildHoldingAllocation(
+        [holding({ symbol: 'AAPL', quantity: toDecimal(1), currentPrice: toDecimal(1) })],
+        []
+      );
+      expect(result.unpricedCount).toBe(0);
+    });
+  });
+
+  describe('nothing to show', () => {
+    it('is empty rather than a zero slice when there is nothing at all', () => {
+      const result = buildHoldingAllocation([], []);
+      expect(result.slices).toEqual([]);
+      expect(result.total.toNumber()).toBe(0);
+      expect(result.unpricedCount).toBe(0);
+    });
+
+    it('leaves out a security worth nothing, and cash worth nothing', () => {
+      const result = buildHoldingAllocation(
+        [holding({ symbol: 'GONE', quantity: toDecimal(0), currentPrice: toDecimal(100) })],
+        [line([{ label: 'Cash', value: 0 }])]
+      );
+      // A 0% wedge is not a slice anybody can see or click.
+      expect(result.slices).toEqual([]);
+    });
+
+    it('leaves out a short position rather than drawing a negative wedge', () => {
+      const result = buildHoldingAllocation(
+        [
+          holding({ symbol: 'LONG', quantity: toDecimal(2), currentPrice: toDecimal(100) }),
+          holding({ symbol: 'SHORT', quantity: toDecimal(-3), currentPrice: toDecimal(100) })
+        ],
+        []
+      );
+      expect(result.slices.map(s => s.key)).toEqual(['LONG']);
+      expect(result.total.toNumber()).toBe(200);
+    });
+  });
+});

--- a/src/utils/holdingAllocation.ts
+++ b/src/utils/holdingAllocation.ts
@@ -1,0 +1,108 @@
+/**
+ * WHAT THE PORTFOLIO IS ACTUALLY IN — by security, not by account.
+ *
+ * The Asset Allocation ring answers "which of my accounts holds the money".
+ * That is a question about where things are kept, and somebody with one broker
+ * and six wrappers learns nothing from it. This answers the other one: how much
+ * of the portfolio is Apple, how much is the bond fund, how much is sitting in
+ * cash — across every account at once, because a holding split over an ISA and
+ * a dealing account is one position.
+ *
+ * ─ WHICH NUMBER, AND WHY IT IS NOT THE LEDGER'S ────────────────────────────
+ *
+ * Securities are valued at `quantity × price`, which is the MARKET side of the
+ * page. `Investments.tsx` states the rule this obeys: holdings × price is a
+ * second opinion about the same money, and the ledger figures are the page's
+ * truth — the two are never added together.
+ *
+ * Adding CASH to it does not break that rule, because cash and securities are
+ * disjoint: an investment account's value is its holdings plus its settlement
+ * cash, so summing market-valued securities with ledger cash produces one
+ * coherent market-side total. What would break the rule is adding an account's
+ * ledger value on top, and nothing here does.
+ *
+ * ─ UNPRICED HOLDINGS ARE COUNTED AND REPORTED, NEVER DROPPED ───────────────
+ *
+ * `marketValue` is null when a holding has never been priced. Such a position
+ * cannot go in the ring — there is no number for it — but silently omitting it
+ * would make the shares add to 100% of a total that is missing something the
+ * user owns. So they are counted separately and handed back for the caller to
+ * say out loud. A chart that quietly excludes part of your portfolio is the
+ * same offence as a filtered-empty list claiming your money is gone.
+ */
+import { toDecimal, type DecimalInstance } from './decimal';
+import type { InvestmentHolding } from '../services/investments/holding';
+import type { PortfolioLine } from './portfolioSummary';
+
+export interface HoldingAllocationSlice {
+  /** Ticker where there is one, otherwise the holding's name. */
+  key: string;
+  label: string;
+  value: DecimalInstance;
+}
+
+export interface HoldingAllocation {
+  /** Securities by symbol plus, when there is any, a single Cash entry. */
+  slices: HoldingAllocationSlice[];
+  total: DecimalInstance;
+  /** Positions with no price. Their value is unknown, so it is not in `total`. */
+  unpricedCount: number;
+}
+
+/** The label for the one cash slice. Exported so the UI cannot misspell it. */
+export const CASH_SLICE_LABEL = 'Cash';
+
+export function buildHoldingAllocation(
+  holdings: readonly InvestmentHolding[],
+  lines: readonly PortfolioLine[]
+): HoldingAllocation {
+  const bySymbol = new Map<string, HoldingAllocationSlice>();
+  let unpricedCount = 0;
+
+  for (const holding of holdings) {
+    if (holding.marketValue === null) {
+      // Owned, and worth something unknown. See the note above.
+      unpricedCount += 1;
+      continue;
+    }
+    if (holding.marketValue.lessThanOrEqualTo(0)) continue;
+
+    // Apple in an ISA and Apple in a dealing account are ONE position. The
+    // symbol is the identity; the name is only what to print, and two rows for
+    // the same ticker can spell it differently.
+    const key = (holding.symbol || holding.name).trim().toUpperCase();
+    const existing = bySymbol.get(key);
+    if (existing) {
+      existing.value = existing.value.plus(holding.marketValue);
+    } else {
+      bySymbol.set(key, {
+        key,
+        label: holding.name?.trim() || holding.symbol,
+        value: holding.marketValue
+      });
+    }
+  }
+
+  // Every settlement sleeve in the portfolio, as ONE category — the owner's
+  // ask, and the right shape: six brokers' cash is one answer to "how much of
+  // this is not invested", and six slices of it would drown the securities.
+  const cashTotal = lines.reduce(
+    (sum, line) => line.cash.reduce((inner, cash) => inner.plus(cash.value), sum),
+    toDecimal(0)
+  );
+
+  const slices = [...bySymbol.values()].sort((a, b) => b.value.comparedTo(a.value));
+  if (cashTotal.greaterThan(0)) {
+    slices.push({ key: '__cash__', label: CASH_SLICE_LABEL, value: cashTotal });
+  }
+  // Re-sorted so Cash takes its place by size rather than always trailing:
+  // for most portfolios it is a small tail, but for one that has just sold up
+  // it is the largest single thing and hiding it at the end would mislead.
+  slices.sort((a, b) => b.value.comparedTo(a.value));
+
+  return {
+    slices,
+    total: slices.reduce((sum, slice) => sum.plus(slice.value), toDecimal(0)),
+    unpricedCount
+  };
+}


### PR DESCRIPTION
Everything from this morning's screenshots, plus the notifications question.

## One root cause behind three of the chart bugs

`categoricalColor` **cycles past the end of the ramp, silently**. Ask for a sixth series and it comes back painted exactly like the first. Nothing throws, no contrast figure moves, and the only symptom is a reader who can't tell two things apart.

- The Dashboard's expense donut sliced to 6 against a 5-colour ramp — *"the pie seems to be split into 5 sections and the legend is listing 6"*.
- The Investments ring drew **one slice per account, twelve of them**.
- The custom report viewer drew every label in the ring and eight in the legend, so those two also disagreed about what existed.

The ceiling isn't a layout preference, it's the palette's own arithmetic: the axis is one hue walked, and each ground can only use the half that clears 3:1 against it. So `MAX_CATEGORICAL_SERIES` now lives beside the ramp, and `capSeriesWithRemainder` folds the tail into one named row — **"8 smaller accounts"** rather than "Other", because Other is a real category in some ledgers, and a reader who can see the count can judge whether the fold hid anything worth looking at.

**The guard for this was vacuous when I first wrote it.** I scoped it to "does `categoricalColor` appear near the `.slice`", which misses the Dashboard entirely — its cap is in a `useMemo` and the Cells are eighty lines below. Found by reintroducing `.slice(0, 6)` and watching the test stay green. It's now the blunt file-level rule with an explicit opt-out marker for genuinely uncoloured lists.

## The Investments legend named the wrong field

`line.institution || 'N/A'` — so four accounts at one bank showed the same word four times, and everything without an institution on file read "N/A". It's `line.name`. Ring and legend now walk one array, so they can't disagree about what exists.

## Allocation by holding — the new chart, in the dead space

The existing ring answers *which account holds the money*, which tells someone with one broker and six wrappers nothing. This answers what the money is **in**: one line per security across every account (Apple in an ISA and in a dealing account is one position), with every settlement sleeve as a single **Cash** category, ranked by size like anything else.

Securities are valued at quantity × price. That respects the page's existing rule — *holdings × price is a second opinion and the two are never added* — because cash and securities are disjoint. What would break it is adding an account's ledger value on top, and nothing does.

**A holding with no price is counted and reported, never dropped.** A chart that quietly leaves out part of what you own is the same offence as a filtered list claiming your money is gone.

## Notifications: cleared now stays cleared

*"I am sure I am clearing them all and then some old ones are popping back up later on."*

You were right. **Suppression was the list.** `hasRecentDuplicate` asked whether a matching key was currently on the board — so clearing the board threw away the only record that those alerts had ever been raised, and the next generator run put them straight back. Budget alerts are recomputed from current data on every visit; they don't remember having fired, and the list was the memory.

Now there's a persisted key→timestamp ledger, kept under its own storage key so clearing one can't clear the other. **Dismissing restarts the window** rather than merely preserving it — dismissing is a stronger signal than having seen it. If the budget is still over tomorrow it may speak again; it doesn't get to speak again this afternoon because you tidied the list.

Six tests: three fail without the fix, three guard the over-correction and pass either way on purpose — a ledger that suppressed everything would be indistinguishable from a broken bell.

## Icons, and the period vocabulary

Per-item icons removed from Reconciliation rows, Categorisation rows, Open Banking's connected banks, the Reports gallery cards, the Dashboard's two section headings and its report cards, and the period bar's calendar. Same reduction Accounts made in #281: one icon per **kind**, never one per row. Eleven report cards each carried a glyph and three of them were the same pie. **The income and expense arrows stay** — they carry direction, not decoration.

The Investments picker said `1M 3M 6M 1Y ALL` while every other surface said "This month / Tax year / 12 months / All time", and the one period a UK user most wants of an investment chart was missing. Spelled out, Tax year added, and the tax-year *rule* borrowed from `resolvePeriod` so the two pages can't disagree about the 6th of April.

## Empty states are centred — your override of DESIGN_PASS §4

§4 ruled left-aligned: *"a centred block with a picture is a greeting."* Your reason is one a desktop mock couldn't show: on a phone it isn't a block on a page, it's the whole screen, and a left-aligned title in a full-width card reads as a layout that has collapsed.

Categorisation had been centring its own hand-rolled copy since batch 7 — **it was the one that was right**, and it now uses the shared component. The test that pinned the old rule asserts the new one rather than being deleted.

Also: the four hard-coded white chart tooltips now follow the theme.

5965 tests pass, lint and typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
