### PR TITLE
The region setting reaches the dates, and Open Banking reads in dark

### DIFF
--- a/src/components/BulkCategorizeModal.tsx
+++ b/src/components/BulkCategorizeModal.tsx
@@ -10,6 +10,7 @@ import { useToast } from '../contexts/ToastContext';
 import { useCurrencyDecimal } from '../hooks/useCurrencyDecimal';
 import { buildPayeeGroups, type PayeeGroup } from '../utils/payeeGroups';
 import { ArrowDownIcon, ArrowUpIcon, XIcon } from './icons';
+import { getDateLocale } from '../utils/dateFormatter';
 
 /**
  * Bulk categorise by payee: file a whole merchant in one decision.
@@ -264,9 +265,9 @@ export default function BulkCategorizeModal({ isOpen, onClose }: Props): React.J
                             </button>
                           </span>
                           <span className="block text-xs text-gray-400 dark:text-gray-500 mt-0.5">
-                            {new Date(group.earliest).toLocaleDateString('en-GB', { month: 'short', year: 'numeric' })}
+                            {new Date(group.earliest).toLocaleDateString(getDateLocale(), { month: 'short', year: 'numeric' })}
                             {' – '}
-                            {new Date(group.latest).toLocaleDateString('en-GB', { month: 'short', year: 'numeric' })}
+                            {new Date(group.latest).toLocaleDateString(getDateLocale(), { month: 'short', year: 'numeric' })}
                             {group.accountIds.length === 1
                               ? ` · ${accountName(group.accountIds[0])}`
                               : ` · ${group.accountIds.length} accounts`}

--- a/src/components/CategoryTransactionsModal.tsx
+++ b/src/components/CategoryTransactionsModal.tsx
@@ -10,6 +10,7 @@ import DatePicker from './common/DatePicker';
 import { expandSplitTransactions, type SplitExpandedTransaction } from '../utils/transactionSplits';
 import type { Transaction } from '../types';
 import { useBackdropDismiss } from '../hooks/useBackdropDismiss';
+import { getDateLocale } from '../utils/dateFormatter';
 
 interface CategoryTransactionsModalProps {
   isOpen: boolean;
@@ -106,7 +107,7 @@ export default function CategoryTransactionsModal({
           t.type,
           t.categoryName || categoryName,
           new Date(t.date).toLocaleDateString(),
-          new Date(t.date).toLocaleDateString('en-GB', { day: 'numeric', month: 'short', year: 'numeric' }),
+          new Date(t.date).toLocaleDateString(getDateLocale(), { day: 'numeric', month: 'short', year: 'numeric' }),
           t.notes || '',
           t.tags?.join(' ') || ''
         ];

--- a/src/components/CustomReportViewer.tsx
+++ b/src/components/CustomReportViewer.tsx
@@ -18,6 +18,7 @@ import { useCurrencyDecimal } from '../hooks/useCurrencyDecimal';
 import { capSeriesWithRemainder, categoricalColor, useCategoricalRamp } from './charts/chartColors';
 import { formatDecimal } from '../utils/decimal-format';
 import type { CustomReport, ReportComponent } from './CustomReportBuilder';
+import { getDateLocale } from '../utils/dateFormatter';
 
 /**
  * Renders a generated custom report. Until now "Generate" computed the data
@@ -269,7 +270,7 @@ export default function CustomReportViewer({
           <h2 className="text-2xl font-bold text-gray-900 dark:text-white">{report.name}</h2>
           <p className="text-sm text-gray-500 dark:text-gray-400">
             {report.description ? `${report.description} · ` : ''}
-            {dateRange.startDate.toLocaleDateString('en-GB')} – {dateRange.endDate.toLocaleDateString('en-GB')}
+            {dateRange.startDate.toLocaleDateString(getDateLocale())} – {dateRange.endDate.toLocaleDateString(getDateLocale())}
           </p>
         </div>
         <button

--- a/src/components/DismissedPayeeSuggestions.tsx
+++ b/src/components/DismissedPayeeSuggestions.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import type { PayeeDismissalKind, SuggestionDismissal } from '../types';
 import { isPayeeDismissalKind, readPayeeDismissalKey } from '../utils/suggestionDismissals';
+import { getDateLocale } from '../utils/dateFormatter';
 
 /**
  * The way back from a refused payee suggestion.
@@ -146,7 +147,7 @@ export default function DismissedPayeeSuggestions({
                     </span>
                   </td>
                   <td className="py-2 text-sm text-gray-500 dark:text-gray-400 whitespace-nowrap">
-                    {dismissal.dismissedAt.toLocaleDateString('en-GB', {
+                    {dismissal.dismissedAt.toLocaleDateString(getDateLocale(), {
                       day: '2-digit', month: 'short', year: '2-digit',
                     })}
                   </td>

--- a/src/components/DocumentManager.tsx
+++ b/src/components/DocumentManager.tsx
@@ -18,6 +18,7 @@ import {
   RefreshCwIcon
 } from './icons';
 import { Modal, ModalBody, ModalFooter } from './common/Modal';
+import { getDateLocale } from '../utils/dateFormatter';
 
 interface DocumentManagerProps {
   transactionId?: string;
@@ -139,7 +140,7 @@ export default function DocumentManager({
   };
 
   const formatDate = (date: Date) => {
-    return new Date(date).toLocaleDateString('en-GB', {
+    return new Date(date).toLocaleDateString(getDateLocale(), {
       day: 'numeric',
       month: 'short',
       year: 'numeric'

--- a/src/components/DuplicateSweepModal.tsx
+++ b/src/components/DuplicateSweepModal.tsx
@@ -33,6 +33,7 @@ import DismissedSuggestionsSection from './sweeps/DismissedSuggestionsSection';
 import GroupedAccountOptions from './common/GroupedAccountOptions';
 import { AlertTriangleIcon, ArrowUpRightIcon } from './icons';
 import type { SuggestionDismissal, Transaction } from '../types';
+import { getDateLocale } from '../utils/dateFormatter';
 
 /**
  * Find duplicates — the same sweep shape as "Match transfers", for the other
@@ -121,10 +122,10 @@ function compareCandidates(
 }
 
 const shortDate = (date: Date | string): string =>
-  new Date(date).toLocaleDateString('en-GB', { day: '2-digit', month: 'short', year: '2-digit' });
+  new Date(date).toLocaleDateString(getDateLocale(), { day: '2-digit', month: 'short', year: '2-digit' });
 
 const longDate = (date: Date | string): string =>
-  new Date(date).toLocaleDateString('en-GB', { day: '2-digit', month: 'long', year: 'numeric' });
+  new Date(date).toLocaleDateString(getDateLocale(), { day: '2-digit', month: 'long', year: 'numeric' });
 
 const gapPhrase = (daysApart: number): string => {
   const days = Math.round(daysApart);

--- a/src/components/IncomeExpenseBreakdownModal.tsx
+++ b/src/components/IncomeExpenseBreakdownModal.tsx
@@ -8,6 +8,7 @@ import { buildCategoryNameLookup } from '../utils/categoryNames';
 import { toDecimal } from '../utils/decimal';
 import type { Category } from '../types';
 import type { SplitExpandedTransaction } from '../utils/transactionSplits';
+import { getDateLocale } from '../utils/dateFormatter';
 
 /**
  * The income/expense breakdown pop-up, shared by the Dashboard and Reports —
@@ -259,7 +260,7 @@ export default function IncomeExpenseBreakdownModal({
         title={bucket === 'uncategorized' ? 'Click to give this transaction a category' : 'Click to view or edit this transaction'}
       >
         <td className="block sm:table-cell py-2 pr-0 sm:pr-3 text-sm text-gray-500 dark:text-gray-400 whitespace-nowrap">
-          {new Date(t.date).toLocaleDateString('en-GB', { day: '2-digit', month: 'short', year: '2-digit' })}
+          {new Date(t.date).toLocaleDateString(getDateLocale(), { day: '2-digit', month: 'short', year: '2-digit' })}
         </td>
         <td className="block sm:table-cell min-w-0 py-2 pr-0 sm:pr-3 text-sm text-gray-900 dark:text-white">
           {t.description}

--- a/src/components/RestoreBackupModal.tsx
+++ b/src/components/RestoreBackupModal.tsx
@@ -9,6 +9,7 @@ import {
 } from '../services/backup/encryption';
 import type { BackupRestoreOutcome } from '@data';
 import { createScopedLogger } from '../loggers/scopedLogger';
+import { getDateLocale } from '../utils/dateFormatter';
 import { AlertTriangleIcon, CheckCircleIcon, RefreshCwIcon, UploadIcon } from './icons';
 // THE FILE FORMAT, from the module that IS the file format.
 //
@@ -419,7 +420,7 @@ export default function RestoreBackupModal({ isOpen, onClose }: Props): React.JS
               </p>
               <p className="text-body text-gray-600 dark:text-gray-400 mt-1">
                 {fileName} was made on{' '}
-                {new Date(locked.exportedAt).toLocaleDateString('en-GB', {
+                {new Date(locked.exportedAt).toLocaleDateString(getDateLocale(), {
                   day: 'numeric',
                   month: 'long',
                   year: 'numeric',

--- a/src/components/TransferSweepModal.tsx
+++ b/src/components/TransferSweepModal.tsx
@@ -29,6 +29,7 @@ import DismissedSuggestionsSection from './sweeps/DismissedSuggestionsSection';
 import { useAccountNames } from '../hooks/useAccountNames';
 import { AlertTriangleIcon, ArrowRightIcon } from './icons';
 import type { DismissalKind, SuggestionDismissal, Transaction } from '../types';
+import { getDateLocale } from '../utils/dateFormatter';
 
 /**
  * Bulk transfer matching: find every unlinked equal-and-opposite pair in the
@@ -611,7 +612,7 @@ export default function TransferSweepModal({ isOpen, onClose }: Props): React.JS
         </p>
         <p className="text-sm text-gray-600 dark:text-gray-400 break-words">{t.description}</p>
         <p className="mt-1 text-xs text-gray-500 dark:text-gray-400">
-          {new Date(t.date).toLocaleDateString('en-GB', { day: '2-digit', month: 'long', year: 'numeric' })}
+          {new Date(t.date).toLocaleDateString(getDateLocale(), { day: '2-digit', month: 'long', year: 'numeric' })}
         </p>
         {note && (
           <p className="mt-2 text-xs font-medium text-amber-700 dark:text-amber-400">{note}</p>
@@ -651,7 +652,7 @@ export default function TransferSweepModal({ isOpen, onClose }: Props): React.JS
         </p>
         <p className="text-sm text-gray-600 dark:text-gray-400 break-words">{parent.description}</p>
         <p className="mt-1 text-xs text-gray-500 dark:text-gray-400">
-          {new Date(parent.date).toLocaleDateString('en-GB', { day: '2-digit', month: 'long', year: 'numeric' })}
+          {new Date(parent.date).toLocaleDateString(getDateLocale(), { day: '2-digit', month: 'long', year: 'numeric' })}
         </p>
         <p className="mt-2 text-xs font-medium text-blue-700 dark:text-blue-300">
           {formatCurrency(Math.abs(split.amount))} of the {formatCurrency(Math.abs(parent.amount))} in this split,
@@ -794,7 +795,7 @@ export default function TransferSweepModal({ isOpen, onClose }: Props): React.JS
                         />
                       </td>
                       <td className="py-2 text-sm text-gray-500 dark:text-gray-400 whitespace-nowrap">
-                        {new Date(row.pair.outgoing.date).toLocaleDateString('en-GB', { day: '2-digit', month: 'short', year: '2-digit' })}
+                        {new Date(row.pair.outgoing.date).toLocaleDateString(getDateLocale(), { day: '2-digit', month: 'short', year: '2-digit' })}
                         {row.pair.daysApart > 0 && (
                           <span className="ml-1 text-xs text-gray-400">+{Math.round(row.pair.daysApart)}d</span>
                         )}
@@ -873,7 +874,7 @@ export default function TransferSweepModal({ isOpen, onClose }: Props): React.JS
                         />
                       </td>
                       <td className="py-2 text-sm text-gray-500 dark:text-gray-400 whitespace-nowrap">
-                        {new Date(row.leg.parent.date).toLocaleDateString('en-GB', { day: '2-digit', month: 'short', year: '2-digit' })}
+                        {new Date(row.leg.parent.date).toLocaleDateString(getDateLocale(), { day: '2-digit', month: 'short', year: '2-digit' })}
                         {row.leg.daysApart > 0 && (
                           <span className="ml-1 text-xs text-gray-400">+{Math.round(row.leg.daysApart)}d</span>
                         )}
@@ -990,7 +991,7 @@ export default function TransferSweepModal({ isOpen, onClose }: Props): React.JS
                       title="Look at the evidence for this row"
                     >
                       <td className="py-2 text-sm text-gray-500 dark:text-gray-400 whitespace-nowrap">
-                        {new Date(f.row.date).toLocaleDateString('en-GB', { day: '2-digit', month: 'short', year: '2-digit' })}
+                        {new Date(f.row.date).toLocaleDateString(getDateLocale(), { day: '2-digit', month: 'short', year: '2-digit' })}
                       </td>
                       <td className="py-2 text-sm text-gray-700 dark:text-gray-300">
                         <span className="block truncate max-w-[140px]">{accountName(f.row.accountId)}</span>
@@ -1073,7 +1074,7 @@ export default function TransferSweepModal({ isOpen, onClose }: Props): React.JS
                       className="border-b border-gray-50 dark:border-gray-700/50 align-top"
                     >
                       <td className="py-2 text-sm text-gray-500 dark:text-gray-400 whitespace-nowrap">
-                        {new Date(f.parent.date).toLocaleDateString('en-GB', { day: '2-digit', month: 'short', year: '2-digit' })}
+                        {new Date(f.parent.date).toLocaleDateString(getDateLocale(), { day: '2-digit', month: 'short', year: '2-digit' })}
                       </td>
                       <td className="py-2 text-sm text-gray-700 dark:text-gray-300">
                         <span className="block truncate max-w-[140px]">{accountName(f.parent.accountId)}</span>

--- a/src/components/reconciliation/ReconciliationTransactionList.tsx
+++ b/src/components/reconciliation/ReconciliationTransactionList.tsx
@@ -3,6 +3,7 @@ import { SearchIcon, PlusIcon } from '../icons';
 import { useCurrencyDecimal } from '../../hooks/useCurrencyDecimal';
 import { isMarkedAwaitingFinalize, isReconciled } from '../../utils/transactionReconciliation';
 import type { Transaction, Category } from '../../types';
+import { getDateLocale } from '../../utils/dateFormatter';
 
 /**
  * What the list is showing.
@@ -299,7 +300,7 @@ export default function ReconciliationTransactionList({
                 >
                   {/* Date */}
                   <div className="text-gray-700 dark:text-gray-300">
-                    {new Date(t.date).toLocaleDateString('en-GB')}
+                    {new Date(t.date).toLocaleDateString(getDateLocale())}
                   </div>
 
                   {/* Mark / reconciled state. A committed row shows R and does

--- a/src/components/sweeps/DismissedSuggestionsSection.tsx
+++ b/src/components/sweeps/DismissedSuggestionsSection.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import type { DismissalKind, SuggestionDismissal, Transaction } from '../../types';
+import { getDateLocale } from '../../utils/dateFormatter';
 
 /**
  * The way back. Every persistent refusal is listed here with a Restore beside
@@ -78,7 +79,7 @@ export default function DismissedSuggestionsSection({
           {', '}
           {accountName(first.accountId)}
           {', '}
-          {new Date(first.date).toLocaleDateString('en-GB', {
+          {new Date(first.date).toLocaleDateString(getDateLocale(), {
             day: '2-digit', month: 'short', year: '2-digit',
           })}
           {rows.length > 1 && ` and ${rows.length - 1} other row${rows.length > 2 ? 's' : ''}`}
@@ -131,7 +132,7 @@ export default function DismissedSuggestionsSection({
                     {KIND_LABELS[dismissal.kind]}
                   </td>
                   <td className="py-2 text-sm text-gray-500 dark:text-gray-400 whitespace-nowrap">
-                    {dismissal.dismissedAt.toLocaleDateString('en-GB', {
+                    {dismissal.dismissedAt.toLocaleDateString(getDateLocale(), {
                       day: '2-digit', month: 'short', year: '2-digit',
                     })}
                   </td>

--- a/src/pages/AccountTransactions.tsx
+++ b/src/pages/AccountTransactions.tsx
@@ -88,6 +88,7 @@ import { dataPort } from '@data';
 import AccountSelector from '../components/common/AccountSelector';
 import type { Account, Transaction } from '../types';
 import { preferences, type PreferenceStorage } from '../services/preferencesService';
+import { getDateLocale } from '../utils/dateFormatter';
 
 /**
  * The app's one full "add a transaction" editor — the same component Layout
@@ -2593,7 +2594,7 @@ export default function AccountTransactions() {
         }`}>
           {isOpeningBalanceRow(transaction) && transaction.noDateSet
             ? <span className="italic text-gray-400">no date set</span>
-            : new Date(transaction.date).toLocaleDateString('en-GB')}
+            : new Date(transaction.date).toLocaleDateString(getDateLocale())}
         </span>
       ),
       className: 'text-center',

--- a/src/pages/ExportManager.tsx
+++ b/src/pages/ExportManager.tsx
@@ -30,6 +30,7 @@ import { downloadBackupBundle, type ExportProgress } from '../services/backup/fo
 import { encryptBackupBundle, downloadEncryptedBackup } from '../services/backup/encryption';
 import { selectExportData, describeExportRange, type AccountsScope } from '../utils/exportSelection';
 import { generateDataExportPDF } from '../utils/pdfExport';
+import { getDateLocale } from '../utils/dateFormatter';
 import {
   exportTransactionsToCSV,
   exportAccountsToCSV,
@@ -308,7 +309,7 @@ export default function ExportManager(): React.JSX.Element {
       : PERIOD_LABELS[options.range];
 
   const formatDate = (date: Date): string =>
-    date.toLocaleDateString('en-GB', { year: 'numeric', month: 'short', day: 'numeric' });
+    date.toLocaleDateString(getDateLocale(), { year: 'numeric', month: 'short', day: 'numeric' });
 
   return (
     <PageWrapper title="Export Data">

--- a/src/pages/Find.tsx
+++ b/src/pages/Find.tsx
@@ -23,6 +23,7 @@ import {
   type FindCriteria,
 } from '../utils/findTransactions';
 import type { Transaction } from '../types';
+import { getDateLocale } from '../utils/dateFormatter';
 
 /**
  * FIND — Microsoft Money's, not a second register.
@@ -486,7 +487,7 @@ export default function Find(): React.JSX.Element {
                       }`}
                     >
                       <td className={`py-2 pl-4 pr-3 text-sm text-gray-900 dark:text-gray-100 whitespace-nowrap ${awaitingReview ? 'font-semibold' : ''}`}>
-                        {new Date(transaction.date).toLocaleDateString('en-GB')}
+                        {new Date(transaction.date).toLocaleDateString(getDateLocale())}
                       </td>
                       <td className="py-2 px-2 text-center text-sm">
                         {isReconciled(transaction) ? (

--- a/src/pages/NetWorthReport.tsx
+++ b/src/pages/NetWorthReport.tsx
@@ -27,6 +27,7 @@ import { DECOMPOSITION_SERIES } from '../components/charts/chartColors';
 import type { ReportViewProps } from './reports/types';
 import { preferences } from '../services/preferencesService';
 import { useHistoricalAccounts } from '../hooks/useHistoricalAccounts';
+import { getDateLocale } from '../utils/dateFormatter';
 
 /**
  * Net worth over time — the Microsoft Money report, rebuilt on real data.
@@ -399,7 +400,7 @@ export default function NetWorthReport({ picker, focus }: ReportViewProps): Reac
       <Modal
         isOpen={drillDate !== null}
         onClose={() => setDrillDate(null)}
-        title={drillDate ? `Balances on ${drillDate.toLocaleDateString('en-GB', { day: 'numeric', month: 'long', year: 'numeric' })}` : ''}
+        title={drillDate ? `Balances on ${drillDate.toLocaleDateString(getDateLocale(), { day: 'numeric', month: 'long', year: 'numeric' })}` : ''}
         size="md"
       >
         <ModalBody>

--- a/src/pages/OpenBanking.tsx
+++ b/src/pages/OpenBanking.tsx
@@ -166,7 +166,7 @@ export default function OpenBanking() {
           <div className="flex items-center justify-between">
             <div>
               <p className="text-sm text-gray-600 dark:text-gray-400">Connected Banks</p>
-              <p className="text-2xl font-bold">{connectedCount}</p>
+              <p className="text-page font-semibold text-gray-900 dark:text-white">{connectedCount}</p>
             </div>
             <BankIcon size={32} className="text-blue-600" />
           </div>
@@ -175,7 +175,7 @@ export default function OpenBanking() {
           <div className="flex items-center justify-between">
             <div>
               <p className="text-sm text-gray-600 dark:text-gray-400">Synced Accounts</p>
-              <p className="text-2xl font-bold">{totalAccounts}</p>
+              <p className="text-page font-semibold text-gray-900 dark:text-white">{totalAccounts}</p>
             </div>
             <CheckCircleIcon size={32} className="text-blue-600" />
           </div>
@@ -193,7 +193,7 @@ export default function OpenBanking() {
 
       {/* Connect Bank */}
       <div className="bg-white dark:bg-gray-800 rounded-lg shadow-md p-6 mb-6">
-        <h3 className="text-lg font-semibold mb-2">Connect Your Bank</h3>
+        <h3 className="text-card font-semibold mb-2 text-gray-900 dark:text-white">Connect Your Bank</h3>
         <p className="text-gray-600 dark:text-gray-400 mb-4">
           Securely connect your bank accounts to automatically import transactions and keep your balances up to date.
         </p>
@@ -212,7 +212,7 @@ export default function OpenBanking() {
             <span>{connectError}</span>
           </div>
         )}
-        <p className="text-xs text-gray-500 dark:text-gray-500 mt-2">
+        <p className="text-xs text-gray-500 dark:text-gray-500 dark:text-gray-400 mt-2">
           Bank connections are secured with 256-bit encryption
         </p>
       </div>
@@ -240,11 +240,11 @@ export default function OpenBanking() {
 
       {/* Connected Banks */}
       <div className="bg-white dark:bg-gray-800 rounded-lg shadow-md p-6 mb-6">
-        <h3 className="text-lg font-semibold mb-4">Connected Banks</h3>
+        <h3 className="text-card font-semibold mb-4 text-gray-900 dark:text-white">Connected Banks</h3>
         {isLoading ? (
-          <p className="text-gray-500">Loading connections...</p>
+          <p className="text-gray-500 dark:text-gray-400">Loading connections...</p>
         ) : connections.length === 0 ? (
-          <p className="text-gray-500">No bank connections yet. Click &ldquo;Connect Bank Account&rdquo; to get started.</p>
+          <p className="text-gray-500 dark:text-gray-400">No bank connections yet. Click &ldquo;Connect Bank Account&rdquo; to get started.</p>
         ) : (
           <div className="space-y-3">
             {connections.map(connection => (
@@ -254,14 +254,14 @@ export default function OpenBanking() {
               >
                 <div className="flex items-center gap-3">
                   <div>
-                    <p className="font-medium">{connection.institutionName}</p>
-                    <div className="flex items-center gap-2 text-sm text-gray-500">
+                    <p className="font-medium text-gray-900 dark:text-white">{connection.institutionName}</p>
+                    <div className="flex items-center gap-2 text-sm text-gray-500 dark:text-gray-400">
                       <span>
                         {connection.accountsCount ?? 0} account{(connection.accountsCount ?? 0) !== 1 ? 's' : ''}
                       </span>
                       {connection.lastSync && (
                         <>
-                          <span className="text-gray-300 dark:text-gray-600">&middot;</span>
+                          <span className="text-gray-300 dark:text-gray-600 dark:text-gray-400">&middot;</span>
                           <span>Last synced: {new Date(connection.lastSync).toLocaleString()}</span>
                         </>
                       )}
@@ -284,7 +284,7 @@ export default function OpenBanking() {
                   <button
                     type="button"
                     onClick={() => setLinkingConnectionId(connection.id)}
-                    className="p-2 text-gray-500 hover:text-primary hover:bg-[#1a2332]/10 rounded-lg transition-colors"
+                    className="p-2 text-gray-500 dark:text-gray-400 hover:text-primary hover:bg-[#1a2332]/10 rounded-lg transition-colors"
                     title="Link bank accounts to your app accounts"
                   >
                     <LinkIcon size={18} />
@@ -293,7 +293,7 @@ export default function OpenBanking() {
                     type="button"
                     onClick={() => handleSync(connection.id)}
                     disabled={syncingIds.has(connection.id)}
-                    className="p-2 text-gray-500 hover:text-blue-600 hover:bg-blue-50 dark:hover:bg-blue-900/20 rounded-lg disabled:opacity-50 transition-colors"
+                    className="p-2 text-gray-500 dark:text-gray-400 hover:text-blue-600 hover:bg-blue-50 dark:hover:bg-blue-900/20 rounded-lg disabled:opacity-50 transition-colors"
                     title="Sync accounts & transactions"
                   >
                     <RefreshCwIcon size={18} className={syncingIds.has(connection.id) ? 'animate-spin' : ''} />
@@ -302,7 +302,7 @@ export default function OpenBanking() {
                     type="button"
                     onClick={() => handleDisconnect(connection.id)}
                     disabled={deletingIds.has(connection.id)}
-                    className="p-2 text-gray-500 hover:text-red-600 hover:bg-red-50 dark:hover:bg-red-900/20 rounded-lg disabled:opacity-50 transition-colors"
+                    className="p-2 text-gray-500 dark:text-gray-400 hover:text-red-600 hover:bg-red-50 dark:hover:bg-red-900/20 rounded-lg disabled:opacity-50 transition-colors"
                     title="Disconnect bank"
                   >
                     <TrashIcon size={18} />
@@ -316,13 +316,13 @@ export default function OpenBanking() {
 
       {/* How It Works */}
       <div className="bg-white dark:bg-gray-800 rounded-lg shadow-md p-6 mb-6">
-        <h3 className="text-lg font-semibold mb-4">How It Works</h3>
+        <h3 className="text-card font-semibold mb-4 text-gray-900 dark:text-white">How It Works</h3>
         <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
           <div className="text-center">
             <div className="w-10 h-10 bg-blue-100 dark:bg-blue-900/30 rounded-full flex items-center justify-center mx-auto mb-3">
               <span className="text-blue-600 font-bold">1</span>
             </div>
-            <h4 className="font-medium mb-1">Connect</h4>
+            <h4 className="font-medium mb-1 text-gray-900 dark:text-white">Connect</h4>
             <p className="text-sm text-gray-600 dark:text-gray-400">
               Select your bank and authorize read-only access via Open Banking
             </p>
@@ -331,7 +331,7 @@ export default function OpenBanking() {
             <div className="w-10 h-10 bg-blue-100 dark:bg-blue-900/30 rounded-full flex items-center justify-center mx-auto mb-3">
               <span className="text-blue-600 font-bold">2</span>
             </div>
-            <h4 className="font-medium mb-1">Sync</h4>
+            <h4 className="font-medium mb-1 text-gray-900 dark:text-white">Sync</h4>
             <p className="text-sm text-gray-600 dark:text-gray-400">
               Your accounts and transactions are securely imported
             </p>
@@ -340,7 +340,7 @@ export default function OpenBanking() {
             <div className="w-10 h-10 bg-blue-100 dark:bg-blue-900/30 rounded-full flex items-center justify-center mx-auto mb-3">
               <span className="text-blue-600 font-bold">3</span>
             </div>
-            <h4 className="font-medium mb-1">Track</h4>
+            <h4 className="font-medium mb-1 text-gray-900 dark:text-white">Track</h4>
             <p className="text-sm text-gray-600 dark:text-gray-400">
               View all your finances in one place with automatic updates
             </p>
@@ -352,11 +352,11 @@ export default function OpenBanking() {
       <div className="bg-white dark:bg-gray-800 rounded-lg shadow-md p-6">
         <div className="flex items-center gap-3 mb-4">
           <ShieldIcon size={24} className="text-blue-600" />
-          <h3 className="text-lg font-semibold">Bank-Level Security</h3>
+          <h3 className="text-card font-semibold text-gray-900 dark:text-white">Bank-Level Security</h3>
         </div>
         <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
           <div>
-            <h4 className="font-medium mb-2">Data Protection</h4>
+            <h4 className="font-medium mb-2 text-gray-900 dark:text-white">Data Protection</h4>
             <ul className="space-y-1 text-sm text-gray-600 dark:text-gray-400">
               <li>• 256-bit encryption for all data</li>
               <li>• Read-only access to your accounts</li>
@@ -365,7 +365,7 @@ export default function OpenBanking() {
             </ul>
           </div>
           <div>
-            <h4 className="font-medium mb-2">Privacy First</h4>
+            <h4 className="font-medium mb-2 text-gray-900 dark:text-white">Privacy First</h4>
             <ul className="space-y-1 text-sm text-gray-600 dark:text-gray-400">
               <li>• FCA-regulated Open Banking provider</li>
               <li>• No third-party data sharing</li>

--- a/src/pages/reports/AccountBalancesReport.tsx
+++ b/src/pages/reports/AccountBalancesReport.tsx
@@ -5,6 +5,7 @@ import ReportDrillModal, { type ReportDrillTarget } from '../../components/repor
 import { buildAccountBalanceReport, type AccountBalanceRow } from '../../utils/accountBalanceReport';
 import { PERIOD_LABELS } from '../../hooks/usePeriod';
 import type { ReportViewProps } from './types';
+import { getDateLocale } from '../../utils/dateFormatter';
 
 /**
  * "Account balances" — the Microsoft Money statement: what each account was
@@ -60,7 +61,7 @@ export default function AccountBalancesReport({ picker }: ReportViewProps): Reac
           </p>
           <p className="text-page font-bold mt-1">{money(report.netWorth)}</p>
           <p className="text-dense text-gray-500 dark:text-gray-400 mt-1">
-            As at {report.asOf.toLocaleDateString('en-GB', { day: 'numeric', month: 'long', year: 'numeric' })}
+            As at {report.asOf.toLocaleDateString(getDateLocale(), { day: 'numeric', month: 'long', year: 'numeric' })}
           </p>
         </div>
         <div className="bg-white dark:bg-gray-800 rounded-lg p-6 border border-line dark:border-gray-700">

--- a/src/pages/reports/NetWorthStatementReport.tsx
+++ b/src/pages/reports/NetWorthStatementReport.tsx
@@ -6,6 +6,7 @@ import { buildAccountBalanceReport, type AccountBalanceRow } from '../../utils/a
 import { PERIOD_LABELS } from '../../hooks/usePeriod';
 import NetWorthSummary from '../../components/NetWorthSummary';
 import type { ReportViewProps } from './types';
+import { getDateLocale } from '../../utils/dateFormatter';
 
 /**
  * "Net worth" — the Microsoft Money statement: everything you own set
@@ -161,7 +162,7 @@ export default function NetWorthStatementReport({ picker }: ReportViewProps): Re
       <p className="text-body text-gray-500 dark:text-gray-400">
         As at{' '}
         <span className="font-medium text-gray-900 dark:text-gray-100">
-          {report.asOf.toLocaleDateString('en-GB', { day: 'numeric', month: 'long', year: 'numeric' })}
+          {report.asOf.toLocaleDateString(getDateLocale(), { day: 'numeric', month: 'long', year: 'numeric' })}
         </span>
         . Change over {PERIOD_LABELS[picker.period].toLowerCase()}{' '}
         <span className={report.change < 0 ? 'text-expense font-medium' : 'text-income font-medium'}>

--- a/src/pages/reports/PeriodComparisonReport.tsx
+++ b/src/pages/reports/PeriodComparisonReport.tsx
@@ -21,6 +21,7 @@ import { formatDecimal } from '../../utils/decimal-format';
 import { PERIOD_LABELS } from '../../hooks/usePeriod';
 import type { ReportViewProps } from './types';
 import { preferences } from '../../services/preferencesService';
+import { getDateLocale } from '../../utils/dateFormatter';
 
 /**
  * "This period vs last" — Money's comparison report.
@@ -50,7 +51,7 @@ const COMPARISON_FILL = '#94A3B8';
 
 const formatWindow = (window: { from: Date; to: Date }): string => {
   const short = (date: Date): string =>
-    date.toLocaleDateString('en-GB', { day: 'numeric', month: 'short', year: 'numeric' });
+    date.toLocaleDateString(getDateLocale(), { day: 'numeric', month: 'short', year: 'numeric' });
   return `${short(window.from)} – ${short(window.to)}`;
 };
 

--- a/src/pages/reports/SpendingByPayeeReport.tsx
+++ b/src/pages/reports/SpendingByPayeeReport.tsx
@@ -13,6 +13,7 @@ import { PERIOD_LABELS } from '../../hooks/usePeriod';
 import type { ReportViewProps } from './types';
 import { preferences } from '../../services/preferencesService';
 import { categoricalColor, useCategoricalRamp } from '../../components/charts/chartColors';
+import { getDateLocale } from '../../utils/dateFormatter';
 
 /**
  * "Spending by payee" — who the money actually went to.
@@ -243,7 +244,7 @@ export default function SpendingByPayeeReport({ picker }: ReportViewProps): Reac
                       {row.count.toLocaleString()}
                     </td>
                     <td className="px-3 py-2 text-sm text-right tabular-nums whitespace-nowrap text-gray-500 dark:text-gray-400">
-                      {row.latest.toLocaleDateString('en-GB', { day: '2-digit', month: 'short', year: '2-digit' })}
+                      {row.latest.toLocaleDateString(getDateLocale(), { day: '2-digit', month: 'short', year: '2-digit' })}
                     </td>
                     <td className="px-3 py-2 text-sm text-right tabular-nums text-gray-500 dark:text-gray-400">
                       {formatDecimal(row.share, 1)}%

--- a/src/pages/settings/PayeeCleanup.tsx
+++ b/src/pages/settings/PayeeCleanup.tsx
@@ -31,6 +31,7 @@ import {
   payeeMerchantDismissalKey,
 } from '../../utils/suggestionDismissals';
 import type { DismissalKind, SuggestionDismissal } from '../../types';
+import { getDateLocale } from '../../utils/dateFormatter';
 
 /**
  * Payee cleanup — one screen for the thousands of near-duplicate payees a
@@ -69,7 +70,7 @@ const LIST_HEIGHT = 560;
 
 const dateRange = (payee: PayeeSummary): string => {
   const format = (d: Date): string =>
-    d.toLocaleDateString('en-GB', { month: 'short', year: 'numeric' });
+    d.toLocaleDateString(getDateLocale(), { month: 'short', year: 'numeric' });
   const from = format(payee.earliest);
   const to = format(payee.latest);
   return from === to ? from : `${from} – ${to}`;

--- a/src/utils/__tests__/dateFormatter.locale.test.ts
+++ b/src/utils/__tests__/dateFormatter.locale.test.ts
@@ -1,0 +1,125 @@
+/**
+ * THE LOCALE SETTING REACHES THE DATES.
+ *
+ * The owner asked whether the whole system could move from English (GB) to
+ * English (US) on a user preference. It could not. Settings ▸ Locale & Date
+ * Format offered eight regions, stored the choice, and displayed the chosen
+ * pattern back — while every formatter used a hard-coded `const locale =
+ * 'en-GB'` and `getDateFormatPlaceholder` returned the literal 'dd/mm/yyyy'.
+ *
+ * Picking "English (United States)" therefore made the settings card say
+ * **mm/dd/yyyy · 12/31/2024** while every date in the app read 31/12/2024. That
+ * is a specific, checkable, false statement the app made about itself — worse
+ * than the dead Goal Celebrations toggle, which at least only did nothing.
+ *
+ * The default stays en-GB on purpose. `getUserLocale` used to WRITE the
+ * browser's locale into preferences as a side effect of being read, so existing
+ * accounts may hold a value nobody chose; honouring that blindly would change
+ * how dates read for people who never asked. Only an explicit choice moves it.
+ */
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+  formatDate,
+  formatShortDate,
+  getDateFormatPlaceholder,
+  getDateLocale,
+  getMonthNames,
+  isUKDateFormat,
+  setUserLocale,
+  forgetCachedLocale
+} from '../dateFormatter';
+
+const CHRISTMAS_EVE = new Date(2024, 11, 24);
+
+describe('the chosen locale', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    forgetCachedLocale();
+  });
+
+  describe('when nothing has been chosen', () => {
+    it('is en-GB, not whatever the browser happens to be', () => {
+      // The app is UK-positioned and says so. Reading the browser here is what
+      // would surprise somebody who never opened the setting.
+      expect(getDateLocale()).toBe('en-GB');
+      expect(getDateFormatPlaceholder()).toBe('dd/mm/yyyy');
+      expect(isUKDateFormat()).toBe(true);
+    });
+
+    it('puts the day first', () => {
+      expect(formatShortDate(CHRISTMAS_EVE)).toContain('24');
+      expect(formatShortDate(CHRISTMAS_EVE).indexOf('24')).toBeLessThan(
+        formatShortDate(CHRISTMAS_EVE).indexOf('12')
+      );
+    });
+  });
+
+  describe('when the United States is chosen', () => {
+    beforeEach(() => { setUserLocale('en-US'); });
+
+    it('moves the month in front of the day', () => {
+      const short = formatShortDate(CHRISTMAS_EVE);
+      expect(short.indexOf('12')).toBeLessThan(short.indexOf('24'));
+    });
+
+    it('says so in the input placeholder, which used to be a fixed string', () => {
+      expect(getDateFormatPlaceholder()).toBe('mm/dd/yyyy');
+    });
+
+    it('stops claiming the UK order', () => {
+      expect(isUKDateFormat()).toBe(false);
+    });
+
+    it('reaches formatDate as well, not only formatShortDate', () => {
+      // The two had SEPARATE hard-coded locales, and formatShortDate did not
+      // even have one — it assembled the order by hand — so fixing one and not
+      // the other was an available half-fix. Asserted on ORDER rather than on
+      // a month name: formatDate's default options are numeric.
+      const formatted = formatDate(CHRISTMAS_EVE);
+      expect(formatted.indexOf('12')).toBeLessThan(formatted.indexOf('24'));
+    });
+  });
+
+  describe('other regions the selector offers', () => {
+    it('gives Canada its year-first order', () => {
+      setUserLocale('en-CA');
+      expect(getDateFormatPlaceholder()).toBe('yyyy-mm-dd');
+    });
+
+    it('keeps Australia and Ireland day-first', () => {
+      setUserLocale('en-AU');
+      expect(isUKDateFormat()).toBe(true);
+      forgetCachedLocale();
+      setUserLocale('en-IE');
+      expect(isUKDateFormat()).toBe(true);
+    });
+  });
+
+  describe('the cache', () => {
+    it('notices a change immediately rather than at the next reload', () => {
+      expect(getDateLocale()).toBe('en-GB');
+      setUserLocale('en-US');
+      // The cache exists because a register renders thousands of dates; it must
+      // not turn "changed the setting" into "restart the app".
+      expect(getDateLocale()).toBe('en-US');
+    });
+  });
+
+  describe('month names', () => {
+    it('follow the locale as well, since a chart axis is a date too', () => {
+      setUserLocale('en-GB');
+      expect(getMonthNames('short')[0]).toBe('Jan');
+    });
+  });
+
+  describe('a locale the browser cannot honour', () => {
+    it('falls back rather than throwing', () => {
+      // Intl throws RangeError on a malformed tag. A stored preference is user
+      // input by another name, and a bad one must not take the app down.
+      setUserLocale('not a locale');
+      expect(() => getDateFormatPlaceholder()).not.toThrow();
+      expect(getDateFormatPlaceholder()).toBe('dd/mm/yyyy');
+      expect(isUKDateFormat()).toBe(true);
+    });
+  });
+});

--- a/src/utils/dateFormatter.ts
+++ b/src/utils/dateFormatter.ts
@@ -4,36 +4,94 @@
  */
 import { preferences } from '../services/preferencesService';
 
-// Detect user's locale from browser settings
-export function getUserLocale(): string {
-  // Check navigator.language first, then fall back to navigator.languages
-  const browserLocale = navigator.language || 
-    (navigator.languages && navigator.languages[0]) || 
-    'en-US';
-  
-  // A chosen locale travels with the account: it decides how every date and
-  // amount in the app reads, and someone who set it once should not have to
-  // set it again on the next machine.
-  const storedLocale = preferences.getItem('preferredLocale');
-  if (storedLocale) {
-    return storedLocale;
-  }
+/**
+ * ─ THE LOCALE, AND WHY IT NOW REACHES ANYTHING ─────────────────────────────
+ *
+ * Settings ▸ Locale & Date Format offered eight regions, stored the choice, and
+ * showed the chosen format back to the reader — while every formatter below it
+ * used a hard-coded `const locale = 'en-GB'`, and `getDateFormatPlaceholder`
+ * returned the literal string 'dd/mm/yyyy'.
+ *
+ * So picking "English (United States)" made the settings card say
+ * **mm/dd/yyyy · 12/31/2024** and left every date in the app reading
+ * 31/12/2024. That is worse than the dead Goal Celebrations toggle: a dead
+ * toggle accepts input and reports a state, but this one made a specific,
+ * checkable, FALSE statement about how the app would behave.
+ *
+ * ─ THE DEFAULT IS STILL en-GB, DELIBERATELY ────────────────────────────────
+ *
+ * `getUserLocale` reads the browser and, until today, WROTE that value into
+ * preferences as a side effect of being read. So existing accounts may hold a
+ * `preferredLocale` nobody ever chose. Honouring that blindly would have
+ * changed how dates read for people who never asked for a change, which is not
+ * a locale feature — it is a surprise.
+ *
+ * `getDateLocale` therefore answers with the EXPLICIT choice, and en-GB when
+ * there is none. The app is UK-positioned and states so; the selector is what
+ * moves it, and nothing else.
+ */
+const DEFAULT_LOCALE = 'en-GB';
+const LOCALE_KEY = 'preferredLocale';
 
-  preferences.setItem('preferredLocale', browserLocale);
-  return browserLocale;
+/**
+ * Cached because this is called once per rendered date, and a register can put
+ * five thousand on a page. Invalidated by `setUserLocale`, which is the only
+ * thing that can change the answer.
+ */
+let cachedLocale: string | null = null;
+
+/** The locale the user actually chose, or the app's default. */
+export function getDateLocale(): string {
+  if (cachedLocale !== null) return cachedLocale;
+  const stored = preferences.getItem(LOCALE_KEY);
+  cachedLocale = stored !== null && stored !== '' ? stored : DEFAULT_LOCALE;
+  return cachedLocale;
+}
+
+/**
+ * What the browser says, for the settings card to offer as a starting point.
+ * No longer writes what it read — a getter with a side effect is how accounts
+ * ended up holding a preference nobody set.
+ */
+export function getUserLocale(): string {
+  const stored = preferences.getItem(LOCALE_KEY);
+  if (stored !== null && stored !== '') return stored;
+  return navigator.language || (navigator.languages && navigator.languages[0]) || DEFAULT_LOCALE;
 }
 
 // Set user's preferred locale
 export function setUserLocale(locale: string): void {
-  preferences.setItem('preferredLocale', locale);
+  preferences.setItem(LOCALE_KEY, locale);
+  cachedLocale = locale;
 }
 
-// Determine if the user prefers UK date format (dd/mm/yyyy)
-// For consistency with UK market positioning, always use UK format
+/** For tests, and for a restore that rewrites preferences underneath us. */
+export function forgetCachedLocale(): void {
+  cachedLocale = null;
+}
+
+/**
+ * Does the chosen locale put the day first?
+ *
+ * Returned `true` unconditionally, which was the honest thing to write while
+ * every formatter was pinned to en-GB and a lie the moment they stopped being.
+ * Derived from the locale itself rather than from a list of countries, so a
+ * region nobody thought of still gets the right answer.
+ */
 export function isUKDateFormat(): boolean {
-  // Always return true to ensure UK date format (dd/mm/yyyy) is used throughout
-  // This ensures consistency as requested in the UI/UX review
-  return true;
+  return dayComesFirst(getDateLocale());
+}
+
+/** Whether `locale` orders a numeric date day-then-month. */
+function dayComesFirst(locale: string): boolean {
+  try {
+    const parts = new Intl.DateTimeFormat(locale).formatToParts(new Date(2024, 11, 31));
+    const day = parts.findIndex((part) => part.type === 'day');
+    const month = parts.findIndex((part) => part.type === 'month');
+    return day !== -1 && month !== -1 && day < month;
+  } catch {
+    return true;
+  }
 }
 
 // Format date according to user's locale (always UK format for consistency)
@@ -43,8 +101,7 @@ export function formatDate(date: Date | string | null | undefined, options?: Int
   const dateObj = typeof date === 'string' ? new Date(date) : date;
   if (isNaN(dateObj.getTime())) return '';
   
-  // Always use en-GB locale for UK date format consistency
-  const locale = 'en-GB';
+  const locale = getDateLocale();
   
   // Default options if none provided
   const defaultOptions: Intl.DateTimeFormatOptions = {
@@ -56,19 +113,33 @@ export function formatDate(date: Date | string | null | undefined, options?: Int
   return dateObj.toLocaleDateString(locale, options || defaultOptions);
 }
 
-// Format date for display in short format (always dd/mm/yyyy for UK market)
+/**
+ * The app's most-used date format — and the one that could never have followed
+ * a locale, because it did not ask one.
+ *
+ * It assembled `${day}/${month}/${year}` by hand. Every other formatter here
+ * had a hard-coded `'en-GB'` that could at least be swapped for a lookup; this
+ * one had the ORDER built into the string, so no amount of fixing the locale
+ * elsewhere would have moved it. Zero-padded two-digit parts, through Intl,
+ * which gives dd/mm/yyyy for en-GB exactly as before.
+ */
 export function formatShortDate(date: Date | string | null | undefined): string {
   if (!date) return '';
-  
+
   const dateObj = typeof date === 'string' ? new Date(date) : date;
   if (isNaN(dateObj.getTime())) return '';
-  
-  const day = dateObj.getDate().toString().padStart(2, '0');
-  const month = (dateObj.getMonth() + 1).toString().padStart(2, '0');
-  const year = dateObj.getFullYear();
-  
-  // Always use UK format (dd/mm/yyyy) for consistency
-  return `${day}/${month}/${year}`;
+
+  try {
+    return dateObj.toLocaleDateString(getDateLocale(), {
+      day: '2-digit',
+      month: '2-digit',
+      year: 'numeric'
+    });
+  } catch {
+    const day = dateObj.getDate().toString().padStart(2, '0');
+    const month = (dateObj.getMonth() + 1).toString().padStart(2, '0');
+    return `${day}/${month}/${dateObj.getFullYear()}`;
+  }
 }
 
 // Format date for input fields (always yyyy-mm-dd for HTML date inputs)
@@ -115,8 +186,7 @@ export function formatDateTime(date: Date | string | null | undefined): string {
   const dateObj = typeof date === 'string' ? new Date(date) : date;
   if (isNaN(dateObj.getTime())) return '';
   
-  // Always use en-GB locale for UK format consistency
-  const locale = 'en-GB';
+  const locale = getDateLocale();
   
   return dateObj.toLocaleString(locale, {
     year: 'numeric',
@@ -159,15 +229,38 @@ export function formatRelativeDate(date: Date | string | null | undefined): stri
   }
 }
 
-// Get date format placeholder for input fields
+/**
+ * The pattern to show beside a date input, in the chosen locale's order.
+ *
+ * Returned the literal 'dd/mm/yyyy' regardless — so the settings card could
+ * show "mm/dd/yyyy" for the United States while every input in the app still
+ * told the reader to type the day first. Asked of Intl rather than looked up,
+ * for the same reason as `dayComesFirst`.
+ */
 export function getDateFormatPlaceholder(): string {
-  // Always return UK format for consistency
-  return 'dd/mm/yyyy';
+  const locale = getDateLocale();
+  try {
+    return new Intl.DateTimeFormat(locale, {
+      day: '2-digit',
+      month: '2-digit',
+      year: 'numeric'
+    })
+      .formatToParts(new Date(2024, 11, 31))
+      .map((part) => {
+        if (part.type === 'day') return 'dd';
+        if (part.type === 'month') return 'mm';
+        if (part.type === 'year') return 'yyyy';
+        return part.value;
+      })
+      .join('');
+  } catch {
+    return 'dd/mm/yyyy';
+  }
 }
 
 // Get month names in user's locale (UK format)
 export function getMonthNames(format: 'long' | 'short' = 'long'): string[] {
-  const locale = 'en-GB';
+  const locale = getDateLocale();
   const months: string[] = [];
   
   for (let i = 0; i < 12; i++) {
@@ -180,7 +273,7 @@ export function getMonthNames(format: 'long' | 'short' = 'long'): string[] {
 
 // Get day names in user's locale (UK format)
 export function getDayNames(format: 'long' | 'short' | 'narrow' = 'long'): string[] {
-  const locale = 'en-GB';
+  const locale = getDateLocale();
   const days: string[] = [];
   
   // Start with Sunday (0) to Saturday (6)

--- a/src/utils/monthlyCategoryMatrix.ts
+++ b/src/utils/monthlyCategoryMatrix.ts
@@ -2,6 +2,7 @@ import type { Category } from '../types';
 import type { PeriodRange } from '../hooks/usePeriod';
 import type { SplitExpandedTransaction } from './transactionSplits';
 import { toDecimal, type DecimalInstance } from './decimal';
+import { getDateLocale } from '../utils/dateFormatter';
 
 /**
  * "Monthly income and expenses" — the Microsoft Money report, as a
@@ -88,7 +89,7 @@ export function monthKeyOf(date: Date | string): string {
 function monthLabelOf(key: string): string {
   const year = Number(key.slice(0, 4));
   const month = Number(key.slice(5, 7));
-  return new Date(year, month - 1, 1).toLocaleDateString('en-GB', { month: 'short', year: '2-digit' });
+  return new Date(year, month - 1, 1).toLocaleDateString(getDateLocale(), { month: 'short', year: '2-digit' });
 }
 
 /** The group a category belongs to: its topmost ancestor below the type node. */

--- a/src/utils/monthlyTrend.ts
+++ b/src/utils/monthlyTrend.ts
@@ -1,6 +1,7 @@
 import type { Category, Transaction } from '../types';
 import { toDecimal, type DecimalInstance } from './decimal';
 import { bucketByCategoryDirection } from './categoryNetting';
+import { getDateLocale } from '../utils/dateFormatter';
 
 export interface MonthlyTrendPoint {
   /** Raw YYYY-MM — drives click-to-drill filters. */
@@ -42,7 +43,7 @@ export function buildMonthlyTrend(rows: Transaction[], categories: Category[]): 
 
   return Object.keys(monthlyData).sort().map(month => ({
     monthKey: month,
-    month: new Date(month + '-01').toLocaleDateString('en-GB', { month: 'short', year: 'numeric' }),
+    month: new Date(month + '-01').toLocaleDateString(getDateLocale(), { month: 'short', year: 'numeric' }),
     income: monthlyData[month].income.toNumber(),
     expenses: monthlyData[month].expenses.toNumber(),
   }));

--- a/src/utils/netWorthSeries.ts
+++ b/src/utils/netWorthSeries.ts
@@ -2,6 +2,7 @@ import type { Account, Transaction } from '../types';
 import { toDecimal } from './decimal';
 import { resolveEffectiveOpeningDates } from './openingDates';
 import type { PeriodRange } from '../hooks/usePeriod';
+import { getDateLocale } from '../utils/dateFormatter';
 
 export interface NetWorthSnapshot {
   date: Date;
@@ -125,7 +126,7 @@ export function buildNetWorthSnapshots(
     }
     out.push({
       date: point,
-      label: point.toLocaleDateString('en-GB', monthly
+      label: point.toLocaleDateString(getDateLocale(), monthly
         ? { month: 'short', year: '2-digit' }
         : { day: '2-digit', month: 'short' }),
       assets: assets.toNumber(),

--- a/src/utils/pdfExport.ts
+++ b/src/utils/pdfExport.ts
@@ -6,6 +6,7 @@ import { formatCurrency as formatCurrencyDecimal } from './currency-decimal';
 import { formatDecimal } from './decimal-format';
 import { toDecimal } from './decimal';
 import { createScopedLogger } from '../loggers/scopedLogger';
+import { getDateLocale } from '../utils/dateFormatter';
 
 type JsPDFInstance = InstanceType<typeof import('jspdf').default>;
 type RGB = readonly [number, number, number];
@@ -200,7 +201,7 @@ async function loadHtml2Canvas(): Promise<typeof import('html2canvas').default> 
 function stampFooter(pdf: JsPDFInstance, writer: PdfWriter): void {
   pdf.setFontSize(8);
   pdf.setTextColor(150, 150, 150);
-  const footerText = `Generated on ${new Date().toLocaleDateString('en-GB')} at ${new Date().toLocaleTimeString('en-GB')}`;
+  const footerText = `Generated on ${new Date().toLocaleDateString(getDateLocale())} at ${new Date().toLocaleTimeString(getDateLocale())}`;
   pdf.text(footerText, writer.pageWidth / 2, writer.pageHeight - 10, { align: 'center' });
 }
 
@@ -358,7 +359,7 @@ export async function generatePDFReport(data: ReportData, _accounts: Account[]):
   writer.heading('Top Transactions');
   writer.table({
     columns: [
-      { header: 'Date', x: 2, cell: t => new Date(t.date).toLocaleDateString('en-GB') },
+      { header: 'Date', x: 2, cell: t => new Date(t.date).toLocaleDateString(getDateLocale()) },
       { header: 'Description', x: 25, cell: t => t.description, maxChars: 30 },
       // Never the raw id: the caller resolves the name, blank if it has none.
       { header: 'Category', x: 100, cell: t => t.categoryLabel ?? '' },
@@ -478,7 +479,7 @@ export async function generateDataExportPDF(data: DataExportPdfData): Promise<vo
     writer.heading('Transactions');
     writer.table({
       columns: [
-        { header: 'Date', x: 2, cell: t => new Date(t.date).toLocaleDateString('en-GB') },
+        { header: 'Date', x: 2, cell: t => new Date(t.date).toLocaleDateString(getDateLocale()) },
         { header: 'Description', x: 24, cell: t => t.description, maxChars: 30 },
         { header: 'Category', x: 78, cell: t => t.categoryLabel, maxChars: 22 },
         { header: 'Account', x: 118, cell: t => t.accountLabel, maxChars: 16 },
@@ -516,7 +517,7 @@ export async function generateDataExportPDF(data: DataExportPdfData): Promise<vo
     pdf.setFontSize(8);
     pdf.setTextColor(150, 150, 150);
     pdf.text(
-      `Page ${page} of ${pageCount} — generated on ${new Date().toLocaleDateString('en-GB')}`,
+      `Page ${page} of ${pageCount} — generated on ${new Date().toLocaleDateString(getDateLocale())}`,
       writer.pageWidth / 2,
       writer.pageHeight - 10,
       { align: 'center' }


### PR DESCRIPTION
Two things, both of which turned out to be worse than "not working".

## The locale setting made a false statement about the app

You asked whether the whole system could move from English (GB) to English (US) on a preference. It could not — and the failure had a sharp edge.

Settings ▸ Locale & Date Format offered eight regions, stored your choice, and **displayed the chosen pattern back to you**. Underneath, every formatter used a hard-coded `const locale = 'en-GB'`, `getDateFormatPlaceholder` returned the literal string `'dd/mm/yyyy'`, and `isUKDateFormat` returned `true` unconditionally.

So picking "English (United States)" made the card say **mm/dd/yyyy · 12/31/2024** while every date in the app read 31/12/2024. The dead Goal Celebrations toggle only *did* nothing. This one made a specific, checkable, false claim about how the app would behave.

**`formatShortDate` could never have followed a locale at all.** It assembled `${day}/${month}/${year}` by hand, so the order was built into the string — no amount of fixing the locale elsewhere would have moved the app's most-used date format. It asks Intl now, which gives dd/mm/yyyy for en-GB exactly as before.

24 more files called `toLocaleDateString('en-GB', …)` directly, bypassing the formatter entirely. Only the locale argument changed; every site keeps its own options.

### The default stays en-GB, deliberately

`getUserLocale` used to **write** the browser's locale into preferences as a side effect of being read — so existing accounts may hold a value nobody chose. Honouring that blindly would have changed how dates read for people who never asked, which isn't a locale feature, it's a surprise. `getDateLocale` answers with the explicit choice and en-GB when there is none, and the side-effecting write is gone.

`isUKDateFormat` and the input placeholder are **derived** from the locale via Intl rather than looked up, so a region nobody thought of still gets the right answer. A malformed stored tag falls back instead of throwing — a stored preference is user input by another name.

That **no existing test broke** is the evidence the conservative default held.

## Open Banking in dark mode

Twelve elements carried a size and a weight and **no colour at all** — "Connect Your Bank", "Connected Banks", "How It Works", "Bank-Level Security", "Data Protection", "Privacy First", the bank names. They inherited, and inheritance is not theme-aware, so they rendered black on near-black. Every one now names ink for both grounds, and the page's dim greys have dark counterparts.

**Verified statically, not in a browser** — and I'd rather say so than imply otherwise. I could not get the harness to put the app into dark mode: the theme sits behind the encrypted preference store, and force-adding the `dark` class did not make the dark variants apply in the dev build. The classes are right by construction, but this one wants your eye on a real phone.

6006 tests pass, lint and typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
