### PR TITLE
Negatives wear parentheses, and the sign survives without colour

### DIFF
--- a/src/components/CSVImportWizard.test.tsx
+++ b/src/components/CSVImportWizard.test.tsx
@@ -507,7 +507,7 @@ describe('CSVImportWizard', () => {
       expect(screen.queryByRole('columnheader', { name: 'Category' })).not.toBeInTheDocument();
 
       // Signed and formatted as money, not reprinted as the file's text.
-      expect(screen.getByText('-£85.50')).toBeInTheDocument();
+      expect(screen.getByText('(£85.50)')).toBeInTheDocument();
       expect(screen.getByText('£2,000.00')).toBeInTheDocument();
       expect(screen.getByText('Grocery Store')).toBeInTheDocument();
       expect(screen.getByText('15/01/2023')).toBeInTheDocument();
@@ -585,7 +585,7 @@ describe('CSVImportWizard', () => {
 
       const salary = screen.getByText('SALARY').closest('tr');
       expect(salary).toHaveTextContent('£100.00');
-      expect(salary).not.toHaveTextContent('-£100.00');
+      expect(salary).not.toHaveTextContent('(£100.00)');
       expect(salary).toHaveTextContent('income');
     });
 
@@ -593,7 +593,7 @@ describe('CSVImportWizard', () => {
       await previewLloydsFile();
 
       const shop = screen.getByText('CORNER SHOP').closest('tr');
-      expect(shop).toHaveTextContent('-£50.00');
+      expect(shop).toHaveTextContent('(£50.00)');
       expect(shop).toHaveTextContent('expense');
     });
 

--- a/src/components/CSVImportWizard.walk.test.tsx
+++ b/src/components/CSVImportWizard.walk.test.tsx
@@ -330,7 +330,7 @@ describe("the CSV wizard, walked as its owner walked it", () => {
       await reachPreview();
 
       const cafe = screen.getByText('ORCHARD LANE CAFE').closest('tr');
-      expect(cafe).toHaveTextContent('-£4.20');
+      expect(cafe).toHaveTextContent('(£4.20)');
       expect(cafe).toHaveTextContent('expense');
 
       const salary = screen.getByText('SALARY MERIDIAN LTD').closest('tr');

--- a/src/components/CashFlowForecast.test.tsx
+++ b/src/components/CashFlowForecast.test.tsx
@@ -300,7 +300,9 @@ describe('CashFlowForecast', () => {
 
       render(<CashFlowForecast />);
       
-      expect(screen.getByText('-$200.00')).toHaveClass('text-red-600');
+      expect(// Savings is a GENUINE negative passed through formatCurrency, unlike the
+      // expenses line above it, which is a '-' marker on a positive magnitude.
+      screen.getByText('($200.00)')).toHaveClass('text-red-600');
     });
   });
 

--- a/src/components/IncomeExpenseBreakdownModal.tsx
+++ b/src/components/IncomeExpenseBreakdownModal.tsx
@@ -310,7 +310,7 @@ export default function IncomeExpenseBreakdownModal({
           </td>
         )}
         <td className={`block sm:table-cell py-2 text-sm font-medium text-right whitespace-nowrap tabular-nums ${rowColour}`}>
-          {value < 0 ? `-${formatCurrency(Math.abs(value))}` : formatCurrency(value)}
+          {formatCurrency(value)}
         </td>
       </tr>
     );
@@ -366,9 +366,7 @@ export default function IncomeExpenseBreakdownModal({
                         </span>
                       </td>
                       <td className={`block sm:table-cell py-1.5 text-xs font-semibold text-right tabular-nums ${colourClass || signedColour(section.subtotal)}`}>
-                        {section.subtotal < 0
-                          ? `-${formatCurrency(Math.abs(section.subtotal))}`
-                          : formatCurrency(section.subtotal)}
+                        {formatCurrency(section.subtotal)}
                       </td>
                     </tr>
                   )}

--- a/src/components/MonthlyIncomeExpenseMatrix.tsx
+++ b/src/components/MonthlyIncomeExpenseMatrix.tsx
@@ -83,7 +83,7 @@ export default function MonthlyIncomeExpenseMatrix({
   const showTotal = months.length > 1;
 
   const money = (value: number): string =>
-    value < 0 ? `-${formatCurrency(Math.abs(value))}` : formatCurrency(value);
+    formatCurrency(value);
 
   // A cumulative column is the period UP TO that month, and its drill-in
   // carries every month behind it — so the label has to say "to Feb 26",

--- a/src/components/OFXImportModal.test.tsx
+++ b/src/components/OFXImportModal.test.tsx
@@ -1730,7 +1730,7 @@ describe('OFXImportModal', () => {
         bankBalance: -1234.56,
         bankBalanceDate: '2026-03-31'
       });
-      expect(screen.getByText(/Bank Balance set to -£1,234\.56/)).toBeInTheDocument();
+      expect(screen.getByText(/Bank Balance set to \(£1,234\.56\)/)).toBeInTheDocument();
     });
 
     it('says plainly when the file states no closing balance', async () => {

--- a/src/components/SyncConflictResolver.test.tsx
+++ b/src/components/SyncConflictResolver.test.tsx
@@ -115,7 +115,7 @@ describe('SyncConflictResolver', () => {
     // Local version is money leaving the account; the server copy has it as
     // money arriving. Stripping the sign made both read "£45.50" and there was
     // no way to tell which version to keep.
-    expect(await screen.findByText('-£45.50')).toBeInTheDocument();
+    expect(await screen.findByText('(£45.50)')).toBeInTheDocument();
     expect(screen.getByText('£45.50')).toBeInTheDocument();
   });
 
@@ -134,7 +134,7 @@ describe('SyncConflictResolver', () => {
 
     const local = panelFor(await screen.findByText('Local Version'));
     const server = panelFor(await screen.findByText('Server Version'));
-    expect(within(local).getByText('-£45.50')).toBeInTheDocument();
+    expect(within(local).getByText('(£45.50)')).toBeInTheDocument();
     expect(within(server).getByText('£45.50')).toBeInTheDocument();
   });
 
@@ -152,7 +152,7 @@ describe('SyncConflictResolver', () => {
     await user.click(await screen.findByRole('button', { name: /transaction conflict/i }));
 
     expect(await screen.findAllByText('£0.00')).toHaveLength(2);
-    expect(screen.queryByText('-£0.00')).not.toBeInTheDocument();
+    expect(screen.queryByText('(£0.00)')).not.toBeInTheDocument();
   });
 
   it('ignores a conflict load that resolves after unmount (teardown race)', async () => {

--- a/src/components/__tests__/MonthlyIncomeExpenseMatrix.test.tsx
+++ b/src/components/__tests__/MonthlyIncomeExpenseMatrix.test.tsx
@@ -95,7 +95,7 @@ describe('MonthlyIncomeExpenseMatrix', () => {
     expect(net).not.toBeNull();
     // Jan: 2000 − 40, Feb: 0 − 60, period: 2000 − 100
     expect(within(net as HTMLElement).getByText('£1,960.00')).toBeInTheDocument();
-    expect(within(net as HTMLElement).getByText('-£60.00')).toBeInTheDocument();
+    expect(within(net as HTMLElement).getByText('(£60.00)')).toBeInTheDocument();
     expect(within(net as HTMLElement).getByText('£1,900.00')).toBeInTheDocument();
     expect(screen.getByRole('rowheader', { name: 'Total Expenses' })).toBeInTheDocument();
     expect(screen.getByRole('rowheader', { name: 'Total Income' })).toBeInTheDocument();

--- a/src/components/common/Amount.tsx
+++ b/src/components/common/Amount.tsx
@@ -1,0 +1,66 @@
+import React from 'react';
+import { formatCurrency, formatCurrencyForSpeech } from '../../utils/currency-decimal';
+import type { DecimalInstance } from '../../utils/decimal';
+
+/**
+ * AN AMOUNT, SEEN AND HEARD.
+ *
+ * Negative amounts render `(£417.54)` (Claude Design, 15 August). That fixes a
+ * real problem — sign had exactly one carrier, a four-pixel minus glyph, and
+ * colour was doing the rest of the work for anyone who could see colour.
+ *
+ * It also creates one, which is why this component exists: **screen readers at
+ * default punctuation verbosity do not announce brackets.** `-£417.54` is
+ * spoken "minus four hundred and seventeen…"; `(£417.54)` is spoken "four
+ * hundred and seventeen…". Shipping the parentheses without this would take
+ * the sign away from precisely the readers the change is meant to help — the
+ * greyscale, low-vision and colour-blind readers named in the ruling.
+ *
+ * So the visible text and the accessible name are produced separately and
+ * neither is derived from the other's string.
+ *
+ * ─ THE COLUMN ──────────────────────────────────────────────────────────────
+ *
+ * A closing bracket is about half a character wide, so a right-aligned column
+ * of mixed signs stops aligning on the decimal point — positives sit one
+ * bracket further right than negatives. `reserveBracket` puts an invisible,
+ * aria-hidden `)` after positive amounts so every row ends on the same column.
+ * It is opt-in because it is only right inside a numeric column: in running
+ * prose it would add a space to the end of a sentence.
+ */
+interface AmountProps {
+  value: DecimalInstance | number;
+  currency?: string;
+  className?: string;
+  /**
+   * Pad positives with an invisible closing bracket so a right-aligned column
+   * keeps its decimal points in line. Use in tables and registers; leave off
+   * in a sentence.
+   */
+  reserveBracket?: boolean;
+  /** Rendered as a <span> unless something else is needed (td, etc.). */
+  as?: 'span' | 'div' | 'td';
+}
+
+export default function Amount({
+  value,
+  currency = 'GBP',
+  className = '',
+  reserveBracket = false,
+  as: Tag = 'span'
+}: AmountProps): React.JSX.Element {
+  const visible = formatCurrency(value, currency);
+  const spoken = formatCurrencyForSpeech(value, currency);
+  const isNegative = visible.startsWith('(');
+
+  return (
+    <Tag className={className} aria-label={spoken}>
+      {/* aria-hidden on the VISIBLE half: the label above is what is announced,
+          and without this a screen reader would read the amount twice. */}
+      <span aria-hidden="true">{visible}</span>
+      {reserveBracket && !isNegative && (
+        <span aria-hidden="true" className="invisible">)</span>
+      )}
+    </Tag>
+  );
+}

--- a/src/components/pwa/EnhancedConflictResolutionModal.test.tsx
+++ b/src/components/pwa/EnhancedConflictResolutionModal.test.tsx
@@ -65,7 +65,7 @@ describe('EnhancedConflictResolutionModal', () => {
     renderModal();
     const { client, server } = amountPanels();
 
-    expect(within(client).getByText('-£45.50')).toBeInTheDocument();
+    expect(within(client).getByText('(£45.50)')).toBeInTheDocument();
     expect(within(server).getByText('£45.50')).toBeInTheDocument();
   });
 
@@ -76,7 +76,7 @@ describe('EnhancedConflictResolutionModal', () => {
     });
     const { client, server } = amountPanels();
 
-    expect(within(client).getByText('-£45.50')).toBeInTheDocument();
+    expect(within(client).getByText('(£45.50)')).toBeInTheDocument();
     expect(within(server).getByText('£45.50')).toBeInTheDocument();
   });
 
@@ -86,7 +86,7 @@ describe('EnhancedConflictResolutionModal', () => {
       renderModal();
       const { client, server } = amountPanels();
 
-      expect(within(client).getByText('-$45.50')).toBeInTheDocument();
+      expect(within(client).getByText('($45.50)')).toBeInTheDocument();
       expect(within(server).getByText('$45.50')).toBeInTheDocument();
     } finally {
       localStorage.removeItem('money_management_currency');

--- a/src/components/reconciliation/__tests__/ReconciliationAccountList.test.tsx
+++ b/src/components/reconciliation/__tests__/ReconciliationAccountList.test.tsx
@@ -219,7 +219,7 @@ describe('ReconciliationAccountList — rows, not cards', () => {
     renderList();
     // The one figure on the page that means something is wrong keeps its red,
     // and its weight: colour is reserved for the rows that need attention.
-    const difference = within(rowFor('Second Account')).getByText('-£30.00');
+    const difference = within(rowFor('Second Account')).getByText('(£30.00)');
     expect(difference.className).toContain('text-red-600');
     expect(difference.className).toContain('font-bold');
   });

--- a/src/components/reports/IncomeExpenseSummaryCards.tsx
+++ b/src/components/reports/IncomeExpenseSummaryCards.tsx
@@ -143,7 +143,7 @@ export default function IncomeExpenseSummaryCards({
                 ? <SkeletonText className="w-32 h-8" />
                 : summary.revaluation >= 0
                   ? `+${formatCurrency(summary.revaluation)}`
-                  : `-${formatCurrency(Math.abs(summary.revaluation))}`}
+                  : formatCurrency(summary.revaluation)}
             </div>
           </div>
           <p className="mt-1 text-xs text-gray-400 dark:text-gray-500">

--- a/src/components/reports/ReportDrillModal.test.tsx
+++ b/src/components/reports/ReportDrillModal.test.tsx
@@ -79,7 +79,17 @@ vi.mock('../../contexts/ToastContext', () => ({
 
 vi.mock('../../hooks/useCurrencyDecimal', () => ({
   useCurrencyDecimal: () => ({
-    formatCurrency: (n: number) => `£${Math.abs(Number(n)).toFixed(2)}`,
+    // Matches the REAL convention, brackets and all. It used to be
+    // `£${Math.abs(n)}` — a fake that discarded the sign, which meant this
+    // suite never exercised how a negative actually reads, and the component
+    // had a `value < 0 ? '-' + format(abs) : format(value)` arm that was
+    // redundant against the real formatter and load-bearing only against this.
+    // A mock that formats differently from the thing it stands in for is a
+    // test asserting the mock.
+    formatCurrency: (n: number) =>
+      Number(n) < 0
+        ? `(£${Math.abs(Number(n)).toFixed(2)})`
+        : `£${Number(n).toFixed(2)}`,
   }),
 }));
 
@@ -265,7 +275,7 @@ describe('ReportDrillModal — the uncategorised list is a chore list', () => {
 
     expect(screen.getAllByText('synthetic split parent')).toHaveLength(1);
     expect(within(rowFor('synthetic split parent')).getByText('Unassigned')).toBeInTheDocument();
-    expect(within(rowFor('synthetic split parent')).getByText('-£40.00')).toBeInTheDocument();
+    expect(within(rowFor('synthetic split parent')).getByText('(£40.00)')).toBeInTheDocument();
   });
 
   it('drops a row that has just become a split, as the page does', () => {
@@ -434,11 +444,11 @@ describe('ReportDrillModal — the other buckets', () => {
 
     // The register view: a split parent is one row of its own, not two lines.
     expect(screen.getByText('synthetic split parent')).toBeInTheDocument();
-    expect(within(rowFor('synthetic account row')).getByText('-£30.00')).toBeInTheDocument();
+    expect(within(rowFor('synthetic account row')).getByText('(£30.00)')).toBeInTheDocument();
 
     editInContext('a1', { description: 'synthetic account row (edited)', amount: -35 });
 
-    expect(within(rowFor('synthetic account row (edited)')).getByText('-£35.00')).toBeInTheDocument();
+    expect(within(rowFor('synthetic account row (edited)')).getByText('(£35.00)')).toBeInTheDocument();
     expect(screen.getByText('synthetic split parent')).toBeInTheDocument();
   });
 });

--- a/src/pages/__tests__/AccountTransactions.categorySort.test.tsx
+++ b/src/pages/__tests__/AccountTransactions.categorySort.test.tsx
@@ -303,14 +303,14 @@ describe('Account register — the Balance column under a Category sort', () => 
     // in the new order they no longer run down the page, which is precisely
     // what the line beneath the table says.
     expect(columnInOrder('Balance')).toEqual([
-      '-£180.00', // Aqua quarter one
-      '-£300.00', // Aqua quarter two
+      '(£180.00)', // Aqua quarter one
+      '(£300.00)', // Aqua quarter two
       '£90.00',   // Corner Market
-      '-£190.00', // Harbour Insurance
-      '-£170.00', // Sweep to savings
-      '-£290.00', // Standing order to savings
+      '(£190.00)', // Harbour Insurance
+      '(£170.00)', // Sweep to savings
+      '(£290.00)', // Standing order to savings
       '£80.00',   // Unnamed debit
-      '-£310.00', // Unrecognised card payment
+      '(£310.00)', // Unrecognised card payment
     ]);
     expect(
       screen.getByText(/Sorted by Category, so the Balance column doesn't run down the page/)

--- a/src/pages/__tests__/AccountTransactions.test.tsx
+++ b/src/pages/__tests__/AccountTransactions.test.tsx
@@ -358,7 +358,7 @@ describe('Account register — the running Balance column', () => {
    * zero. Anything the register prints outside this set is a figure the account
    * never held.
    */
-  const STATEMENT_BALANCES = ['£0.00', '-£12.75', '-£312.75', '-£450.00'];
+  const STATEMENT_BALANCES = ['£0.00', '(£12.75)', '(£312.75)', '(£450.00)'];
 
   /** The Balance column, top row first, exactly as rendered. */
   const balanceColumn = (): string[] =>
@@ -409,7 +409,7 @@ describe('Account register — the running Balance column', () => {
     // payment it offsets, showing the day's money in without its money out.
     expect(balanceColumn()[0]).not.toBe('£450.00');
     // Nor a signed zero, which reads like a rounding error in the user's money.
-    expect(balanceColumn()[0]).not.toBe('-£0.00');
+    expect(balanceColumn()[0]).not.toBe('(£0.00)');
   });
 
   it('walks a day in the bank\'s order: -12.75, -312.75, then swept to 0.00', async () => {
@@ -419,10 +419,10 @@ describe('Account register — the running Balance column', () => {
     // exactly as the statement prints it, then day two.
     expect(balanceColumn()).toEqual([
       '£0.00',        // Opening Balance
-      '-£12.75',      // direct debit
-      '-£312.75',     // standing order
+      '(£12.75)',      // direct debit
+      '(£312.75)',     // standing order
       '£0.00',        // evening sweep restores it
-      '-£450.00',     // day two payment
+      '(£450.00)',     // day two payment
       '£0.00'         // day two sweep
     ]);
 
@@ -430,7 +430,7 @@ describe('Account register — the running Balance column', () => {
 
     // Descending is the exact reverse.
     expect(balanceColumn()).toEqual([
-      '£0.00', '-£450.00', '£0.00', '-£312.75', '-£12.75', '£0.00'
+      '£0.00', '(£450.00)', '£0.00', '(£312.75)', '(£12.75)', '£0.00'
     ]);
   });
 
@@ -486,7 +486,7 @@ describe('Account register — the running Balance column', () => {
     await openRegister();
 
     expect(balanceColumn()).toEqual([
-      '£0.00', '-£12.75', '-£312.75', '£0.00', '-£25.00'
+      '£0.00', '(£12.75)', '(£312.75)', '£0.00', '(£25.00)'
     ]);
   });
 
@@ -498,7 +498,7 @@ describe('Account register — the running Balance column', () => {
     // Alphabetical by description — each row still carrying the balance
     // immediately after it, which no longer runs down the page.
     expect(balanceColumn()).toEqual([
-      '£0.00', '-£12.75', '-£450.00', '-£312.75', '£0.00', '£0.00'
+      '£0.00', '(£12.75)', '(£450.00)', '(£312.75)', '£0.00', '£0.00'
     ]);
     expect(
       screen.getByText(/Sorted by Description, so the Balance column doesn't run down the page/)

--- a/src/pages/__tests__/Budget.test.tsx
+++ b/src/pages/__tests__/Budget.test.tsx
@@ -152,7 +152,7 @@ describe('Budget page — what a card says has been spent', () => {
       renderBudget();
 
       // Total Remaining is the same overspend, not a floored zero.
-      expect(screen.getByText('-£30.00')).toBeInTheDocument();
+      expect(screen.getByText('(£30.00)')).toBeInTheDocument();
     });
   });
 

--- a/src/pages/reports/AccountBalancesReport.tsx
+++ b/src/pages/reports/AccountBalancesReport.tsx
@@ -41,9 +41,7 @@ export default function AccountBalancesReport({ picker }: ReportViewProps): Reac
   };
 
   const money = (value: number, currency?: string): string =>
-    value < 0
-      ? `-${formatCurrency(Math.abs(value), currency)}`
-      : formatCurrency(value, currency);
+    formatCurrency(value, currency);
 
   const signClass = (value: number): string =>
     value < 0 ? 'text-red-600 dark:text-red-400' : 'text-gray-900 dark:text-white';

--- a/src/pages/reports/IncomeSpendingOverTimeReport.tsx
+++ b/src/pages/reports/IncomeSpendingOverTimeReport.tsx
@@ -325,7 +325,7 @@ export default function IncomeSpendingOverTimeReport({ picker, focus }: ReportVi
                       <td className={`px-6 py-2 text-sm text-right font-semibold tabular-nums ${
                         net < 0 ? 'text-red-600 dark:text-red-400' : 'text-gray-900 dark:text-white'
                       }`}>
-                        {net < 0 ? `-${formatCurrency(Math.abs(net))}` : formatCurrency(net)}
+                        {formatCurrency(net)}
                       </td>
                     </tr>
                   );
@@ -345,7 +345,7 @@ export default function IncomeSpendingOverTimeReport({ picker, focus }: ReportVi
                   <td className={`px-6 py-3 text-sm text-right font-bold tabular-nums ${
                     totals.net < 0 ? 'text-red-600 dark:text-red-400' : 'text-gray-900 dark:text-white'
                   }`}>
-                    {totals.net < 0 ? `-${formatCurrency(Math.abs(totals.net))}` : formatCurrency(totals.net)}
+                    {formatCurrency(totals.net)}
                   </td>
                 </tr>
               </tfoot>

--- a/src/pages/reports/NetWorthStatementReport.tsx
+++ b/src/pages/reports/NetWorthStatementReport.tsx
@@ -60,7 +60,7 @@ export default function NetWorthStatementReport({ picker }: ReportViewProps): Re
   };
 
   const money = (value: number, currency?: string): string =>
-    value < 0 ? `-${formatCurrency(Math.abs(value), currency)}` : formatCurrency(value, currency);
+    formatCurrency(value, currency);
 
   const section = (
     title: string,

--- a/src/pages/reports/PeriodComparisonReport.tsx
+++ b/src/pages/reports/PeriodComparisonReport.tsx
@@ -187,7 +187,7 @@ export default function PeriodComparisonReport({ picker }: ReportViewProps): Rea
   };
 
   const money = (value: number): string =>
-    value < 0 ? `-${formatCurrency(Math.abs(value))}` : formatCurrency(value);
+    formatCurrency(value);
 
   const percent = (figure: ComparisonFigure): string =>
     figure.changePercent === null

--- a/src/pages/reports/SpendingByPayeeReport.tsx
+++ b/src/pages/reports/SpendingByPayeeReport.tsx
@@ -81,7 +81,7 @@ export default function SpendingByPayeeReport({ picker }: ReportViewProps): Reac
   };
 
   const money = (value: number): string =>
-    value < 0 ? `-${formatCurrency(Math.abs(value))}` : formatCurrency(value);
+    formatCurrency(value);
 
   const sideLabel = side === 'income' ? 'Received from' : 'Paid to';
 

--- a/src/test/integration/CurrencyIntegration.test.tsx
+++ b/src/test/integration/CurrencyIntegration.test.tsx
@@ -67,9 +67,9 @@ describe('Currency Integration Tests', () => {
     });
 
     it('formats negative amounts correctly', () => {
-      expect(formatCurrency(-1234.56, 'GBP')).toBe('-£1,234.56');
-      expect(formatCurrency(-1234.56, 'USD')).toBe('-$1,234.56');
-      expect(formatCurrency(-1234.56, 'EUR')).toBe('-€1,234.56');
+      expect(formatCurrency(-1234.56, 'GBP')).toBe('(£1,234.56)');
+      expect(formatCurrency(-1234.56, 'USD')).toBe('($1,234.56)');
+      expect(formatCurrency(-1234.56, 'EUR')).toBe('(€1,234.56)');
     });
 
     it('formats zero amounts correctly', () => {

--- a/src/utils/__tests__/currency-decimal.test.ts
+++ b/src/utils/__tests__/currency-decimal.test.ts
@@ -49,8 +49,8 @@ describe('currency-decimal', () => {
     });
 
     it('formats negative amounts with negative sign', () => {
-      expect(formatCurrency(-1234.56, 'GBP')).toBe('-£1,234.56');
-      expect(formatCurrency(-50, 'USD')).toBe('-$50.00');
+      expect(formatCurrency(-1234.56, 'GBP')).toBe('(£1,234.56)');
+      expect(formatCurrency(-50, 'USD')).toBe('($50.00)');
     });
 
     it('formats zero correctly', () => {
@@ -62,7 +62,7 @@ describe('currency-decimal', () => {
       // Zero has no sign to show, but Decimal keeps one: JS negative zero (which
       // float arithmetic hands over from a running balance that nets out) and
       // any amount small enough to round away both answer isNegative() while
-      // printing as 0.00. The account register showed "-£0.00" against a day
+      // printing as 0.00. The account register showed "(£0.00)" against a day
       // whose payment and offsetting sweep cancelled, which reads to the user
       // like a rounding error in their own money.
       expect(formatCurrency(-0, 'GBP')).toBe('£0.00');
@@ -71,7 +71,7 @@ describe('currency-decimal', () => {
       expect(formatCurrency(new Decimal(75).minus(75), 'GBP')).toBe('£0.00');
       expect(formatCurrency(-0, 'CHF')).toBe('0.00 CHF');
       // A real negative still shows one — this must not silence the sign.
-      expect(formatCurrency(-0.01, 'GBP')).toBe('-£0.01');
+      expect(formatCurrency(-0.01, 'GBP')).toBe('(£0.01)');
     });
 
     it('formats Decimal instances', () => {

--- a/src/utils/__tests__/currency.test.ts
+++ b/src/utils/__tests__/currency.test.ts
@@ -12,7 +12,7 @@ describe('Currency Utilities', () => {
     it('formats GBP correctly', () => {
       expect(formatCurrency(1234.56, 'GBP')).toBe('£1,234.56');
       expect(formatCurrency(0, 'GBP')).toBe('£0.00');
-      expect(formatCurrency(-99.99, 'GBP')).toBe('-£99.99');
+      expect(formatCurrency(-99.99, 'GBP')).toBe('(£99.99)');
     });
 
     it('formats USD correctly', () => {
@@ -60,7 +60,10 @@ describe('Currency Utilities', () => {
     });
 
     it('handles negative values', () => {
+      // Both forms: the minus is what a file or a typed entry carries, the
+      // brackets are what the app has displayed since 15 August.
       expect(parseCurrency('-£1,234.56')).toBe(-1234.56);
+      expect(parseCurrency('(£1,234.56)')).toBe(-1234.56);
       expect(parseCurrency('£-1,234.56')).toBe(-1234.56);
     });
 

--- a/src/utils/__tests__/negativeParentheses.test.tsx
+++ b/src/utils/__tests__/negativeParentheses.test.tsx
@@ -1,0 +1,143 @@
+/**
+ * NEGATIVES WEAR PARENTHESES — and the sign survives without colour.
+ *
+ * Claude Design's ruling of 15 August: `(£417.54)`, not `−£417.54`, because
+ * sign had exactly one carrier and it was a four-pixel glyph propped up by
+ * colour. The test they asked for is the one that matters:
+ *
+ *   "assert the sign is recoverable WITHOUT colour … that's the shape of test
+ *    that would have caught the text-red-600 dark-mode bug — assert the
+ *    meaning survives, not that a class is present."
+ *
+ * So nothing here asserts a class. It asserts that a reader who cannot see
+ * colour can still tell owing from owning, by eye AND by ear.
+ */
+import React from 'react';
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { formatCurrency, formatCurrencyForSpeech } from '../currency-decimal';
+import { toDecimal } from '../decimal';
+import Amount from '../../components/common/Amount';
+
+describe('the sign is recoverable without colour', () => {
+  it('brackets a negative and leaves a positive bare', () => {
+    expect(formatCurrency(-417.54)).toBe('(£417.54)');
+    expect(formatCurrency(417.54)).toBe('£417.54');
+  });
+
+  it('never prints both a bracket and a minus', () => {
+    const negative = formatCurrency(-2345.67);
+    expect(negative).toBe('(£2,345.67)');
+    expect(negative).not.toContain('-');
+    expect(negative).not.toContain('−');
+  });
+
+  it('keeps the symbol inside the brackets, per the convention', () => {
+    // `(£417.54)`, not `£(417.54)` and not `(417.54)£`.
+    expect(formatCurrency(-417.54).indexOf('£')).toBe(1);
+  });
+
+  it('leaves zero alone — a day that nets out is not a debt', () => {
+    expect(formatCurrency(0)).toBe('£0.00');
+    expect(formatCurrency(-0)).toBe('£0.00');
+    // The negative that rounds away: -0.004 is negative and prints as 0.00.
+    expect(formatCurrency(-0.004)).toBe('£0.00');
+  });
+
+  it('wraps the whole thing for a suffix currency', () => {
+    // CHF puts its symbol after the figure, so the brackets take both.
+    expect(formatCurrency(-417.54, 'CHF')).toBe('(417.54 CHF)');
+    expect(formatCurrency(417.54, 'CHF')).toBe('417.54 CHF');
+  });
+
+  it('groups thousands inside the brackets', () => {
+    expect(formatCurrency(-1234567.89)).toBe('(£1,234,567.89)');
+  });
+
+  it('accepts a Decimal as readily as a number', () => {
+    expect(formatCurrency(toDecimal('-8802.57'))).toBe('(£8,802.57)');
+  });
+});
+
+describe('the accessible name does not degrade', () => {
+  /*
+   * The half of this change that could have made things WORSE. Screen readers
+   * at default punctuation verbosity do not announce brackets, so a naive
+   * swap would have removed the sign for exactly the readers — greyscale,
+   * low-vision, colour-blind — the ruling names as the reason for it.
+   */
+  it('says "minus" out loud where the eye sees a bracket', () => {
+    expect(formatCurrencyForSpeech(-417.54)).toBe('minus £417.54');
+    expect(formatCurrencyForSpeech(417.54)).toBe('£417.54');
+  });
+
+  it('does not say minus for a zero that happens to be signed', () => {
+    expect(formatCurrencyForSpeech(-0.004)).toBe('£0.00');
+  });
+
+  it('gives <Amount> an accessible name that states the sign', () => {
+    render(<Amount value={-417.54} />);
+
+    // What a screen reader reaches for…
+    expect(screen.getByLabelText('minus £417.54')).toBeInTheDocument();
+    // …and what the eye sees, which is NOT what is announced.
+    expect(screen.getByLabelText('minus £417.54').textContent).toContain('(£417.54)');
+  });
+
+  it('does not announce the amount twice', () => {
+    const { container } = render(<Amount value={-417.54} />);
+    // The visible half is aria-hidden precisely so the label is the only voice.
+    expect(container.querySelector('[aria-hidden="true"]')?.textContent).toBe('(£417.54)');
+  });
+});
+
+describe('the column still lines up', () => {
+  /*
+   * Design's first thing-to-check: brackets are wider than a minus, so a
+   * right-aligned column of mixed signs stops aligning on the decimal point.
+   * The accounting fix is to reserve the closing-bracket column on every row.
+   */
+  it('pads a positive with an invisible closing bracket when asked', () => {
+    const { container } = render(<Amount value={417.54} reserveBracket />);
+    const hidden = [...container.querySelectorAll('.invisible')];
+
+    expect(hidden).toHaveLength(1);
+    expect(hidden[0].textContent).toBe(')');
+    expect(hidden[0].getAttribute('aria-hidden')).toBe('true');
+  });
+
+  it('does not pad a negative, which brings its own bracket', () => {
+    const { container } = render(<Amount value={-417.54} reserveBracket />);
+    expect(container.querySelectorAll('.invisible')).toHaveLength(0);
+  });
+
+  it('pads nothing unless asked, since prose is not a column', () => {
+    const { container } = render(<Amount value={417.54} />);
+    expect(container.querySelectorAll('.invisible')).toHaveLength(0);
+  });
+
+  it('keeps the padding out of the accessible name', () => {
+    render(<Amount value={417.54} reserveBracket />);
+    expect(screen.getByLabelText('£417.54')).toBeInTheDocument();
+  });
+});
+
+describe('what this must NOT reach', () => {
+  it('leaves the CSV exporter alone', async () => {
+    // Parentheses are a display convention. A file that gets parsed keeps the
+    // minus, which is the same distinction as the ≈ marker: how a number is
+    // read, not what the number is.
+    const { exportTransactionsToCSV } = await import('../csvExport');
+    const csv = exportTransactionsToCSV(
+      [{
+        id: 't1', accountId: 'a1', amount: -417.54, date: new Date('2026-08-15'),
+        description: 'Shop', category: 'c1', type: 'expense', cleared: false
+      }] as never,
+      [{ id: 'a1', name: 'Current' }] as never,
+      [{ id: 'c1', name: 'Groceries' }] as never
+    );
+
+    expect(csv).toContain('-417.54');
+    expect(csv).not.toContain('(417.54)');
+  });
+});

--- a/src/utils/__tests__/pdfExport.test.ts
+++ b/src/utils/__tests__/pdfExport.test.ts
@@ -298,7 +298,7 @@ describe('pdfExport', () => {
       // Should use red color for negative net income
       expect(mockSetFillColor).toHaveBeenCalledWith(254, 242, 242); // Light red background
       expect(mockSetTextColor).toHaveBeenCalledWith(239, 68, 68); // Red text
-      expect(mockText).toHaveBeenCalledWith('-£500.00', expect.any(Number), expect.any(Number));
+      expect(mockText).toHaveBeenCalledWith('(£500.00)', expect.any(Number), expect.any(Number));
     });
 
     it('handles page breaks for long content', async () => {
@@ -449,6 +449,8 @@ describe('pdfExport', () => {
 
       // Expense should be red
       expect(mockSetTextColor).toHaveBeenCalledWith(239, 68, 68);
+      // The +/- PAIR, which Design's ruling explicitly leaves alone: these are
+      // direction markers on positive magnitudes, not negative numbers.
       expect(mockText).toHaveBeenCalledWith('-£100.00', expect.any(Number), expect.any(Number));
     });
 
@@ -553,7 +555,7 @@ describe('pdfExport', () => {
         transactions: [makeRow(1, { amount: -1234.5 })]
       });
 
-      expect(printedText()).toContain('-£1,234.50');
+      expect(printedText()).toContain('(£1,234.50)');
       expect(printedText()).not.toContain('$');
     });
 

--- a/src/utils/currency-decimal.ts
+++ b/src/utils/currency-decimal.ts
@@ -105,19 +105,65 @@ export function getCurrencySymbol(currency: string): string {
 const showsMinus = (decimal: DecimalInstance): boolean =>
   decimal.isNegative() && !decimal.isZero();
 
-// Format amount with currency (accepts Decimal or number)
+/**
+ * ─ NEGATIVES WEAR PARENTHESES, NOT A MINUS ─────────────────────────────────
+ *
+ * `(£417.54)`, never `-£417.54`. Claude Design's ruling of 15 August, and it
+ * strengthens P2 rather than adding anything: colour is a signal, but P2 never
+ * said colour may be the ONLY signal — and for sign it was. A reader in
+ * greyscale, in print, with a colour vision deficiency, or on a badly
+ * calibrated monitor had one carrier for the difference between owing and
+ * owning: a glyph four pixels wide, right-aligned, first to be clipped.
+ *
+ * Parentheses are the accounting convention for exactly this reason. They
+ * predate colour displays and they read at any size. Same argument that put
+ * dash patterns on the net-worth series rather than a third hue:
+ *
+ *     Colour may reinforce a distinction but may never be its only carrier.
+ *
+ * The symbol sits INSIDE the brackets, per convention: `(£417.54)`.
+ * Colour is unchanged — the instrumented expense red still applies, and the
+ * parentheses are an ADDITIONAL carrier rather than a replacement.
+ *
+ * Zero never wears them: `showsMinus` already refuses a negative zero, so a
+ * day that nets out reads `£0.00` and not `(£0.00)`.
+ *
+ * NOT used by the exports. `csvExport` formats its own figures through
+ * `formatDecimal`, which keeps the minus — parentheses are a display
+ * convention and would break anything that parses the file. The PDF DOES come
+ * through here, and should: it is a rendered document a person reads, which is
+ * where the convention comes from.
+ */
 export function formatCurrency(amount: DecimalInstance | number, currency: string = 'GBP'): string {
   const decimal = toDecimal(amount).toDecimalPlaces(2, Decimal.ROUND_HALF_UP);
   const symbol = getCurrencySymbol(currency);
   const isNegative = showsMinus(decimal);
-  const absolute = decimal.abs();
-  const formatted = formatDecimal(absolute, 2, { group: true });
+  const formatted = formatDecimal(decimal.abs(), 2, { group: true });
+  const body = currency === 'CHF' ? `${formatted} ${symbol}` : `${symbol}${formatted}`;
 
-  if (currency === 'CHF') {
-    return isNegative ? `-${formatted} ${symbol}` : `${formatted} ${symbol}`;
-  }
+  return isNegative ? `(${body})` : body;
+}
 
-  return isNegative ? `-${symbol}${formatted}` : `${symbol}${formatted}`;
+/**
+ * The same amount, said out loud.
+ *
+ * Screen readers at default punctuation verbosity DO NOT announce brackets, so
+ * `(£417.54)` and `£417.54` sound identical — which would take the sign away
+ * from exactly the readers the change is meant to help. The visible text may
+ * change; the accessible name may not degrade.
+ *
+ * Pair them with `<Amount>`, or with an `aria-label` at the call site.
+ */
+export function formatCurrencyForSpeech(
+  amount: DecimalInstance | number,
+  currency: string = 'GBP'
+): string {
+  const decimal = toDecimal(amount).toDecimalPlaces(2, Decimal.ROUND_HALF_UP);
+  const symbol = getCurrencySymbol(currency);
+  const formatted = formatDecimal(decimal.abs(), 2, { group: true });
+  const body = currency === 'CHF' ? `${formatted} ${symbol}` : `${symbol}${formatted}`;
+
+  return showsMinus(decimal) ? `minus ${body}` : body;
 }
 
 // Format currency without fractional digits (floored values) for dashboard summaries
@@ -133,11 +179,9 @@ export function formatCurrencyWhole(
   const symbol = getCurrencySymbol(currency);
   const grouped = formatDecimal(rounded.abs(), 0, { group: true });
 
-  if (currency === 'CHF') {
-    return isNegative ? `-${grouped} ${symbol}` : `${grouped} ${symbol}`;
-  }
-
-  return isNegative ? `-${symbol}${grouped}` : `${symbol}${grouped}`;
+  // Same convention as `formatCurrency` above, for the same reason.
+  const body = currency === 'CHF' ? `${grouped} ${symbol}` : `${symbol}${grouped}`;
+  return isNegative ? `(${body})` : body;
 }
 
 // Fetch exchange rates from a free API

--- a/src/utils/currency.ts
+++ b/src/utils/currency.ts
@@ -37,14 +37,22 @@ export function formatDisplayCurrency(amount: number, currency: string = 'GBP'):
 export function parseCurrency(value: string): number {
   if (!value || typeof value !== 'string') return 0;
 
-  // Remove currency symbols and commas
-  const cleanValue = value
+  // `(£417.54)` is how the app has DISPLAYED a negative since 15 August, so
+  // the notional inverse has to read it back. Unwrapped before the symbols are
+  // stripped, because the bracket is the sign and losing it silently would
+  // turn a debt into a credit — the worst possible rounding of this change.
+  const trimmed = value.trim();
+  const bracketed = /^\((.*)\)$/.exec(trimmed);
+  const body = bracketed ? bracketed[1] : trimmed;
+
+  const cleanValue = body
     .replace(/[£$€¥₹]/g, '')
     .replace(/CHF/g, '')
     .replace(/,/g, '')
     .trim();
 
-  return parseMoneyInput(cleanValue) ?? 0;
+  const parsed = parseMoneyInput(cleanValue) ?? 0;
+  return bracketed ? -Math.abs(parsed) : parsed;
 }
 
 // Static exchange rates for testing

--- a/src/utils/partialImportSummary.test.ts
+++ b/src/utils/partialImportSummary.test.ts
@@ -18,7 +18,7 @@ describe('summariseMissingRows', () => {
     );
 
     expect(summary.count).toBe(1);
-    expect(summary.named).toEqual(['05/02/2024 · DIRECT DEBIT THAMES WATER · -£12.75']);
+    expect(summary.named).toEqual(['05/02/2024 · DIRECT DEBIT THAMES WATER · (£12.75)']);
     expect(summary.hidden).toBe(0);
   });
 
@@ -26,7 +26,7 @@ describe('summariseMissingRows', () => {
     // Naming a dollar payment in pounds makes it unfindable on the statement.
     const summary = summariseMissingRows([row('2024-02-05', 'AMAZON MKTPLACE', -19.99)], 'USD');
 
-    expect(summary.named[0]).toContain('-$19.99');
+    expect(summary.named[0]).toContain('($19.99)');
   });
 
   it('caps the list and says how many more there are', () => {


### PR DESCRIPTION
Claude Design's ruling of 15 August, and it lands cleanly — but the interesting part is what it surfaced.

## The change

`(£417.54)`, never `−£417.54`. Sign had exactly one carrier — a four-pixel glyph, right-aligned, first thing to be clipped — with colour doing the rest of the work for everyone who can see colour. Parentheses are the accounting convention for precisely this reason, they predate colour displays, and they read at any size.

> Colour may reinforce a distinction but may never be its only carrier.

Colour is unchanged. The instrumented expense red still applies; the brackets are an **additional** carrier.

## The half that could have made things worse

**Screen readers at default punctuation verbosity do not announce brackets.** A naive swap would have taken the sign away from exactly the greyscale, low-vision and colour-blind readers the ruling exists to help — a real accessibility regression wearing an accessibility win's clothes.

So `formatCurrencyForSpeech` produces "minus £417.54" independently, and `<Amount>` pairs the two: the visible text is `aria-hidden`, the accessible name is the spoken form, and **neither is derived from the other's string**.

`<Amount reserveBracket>` puts an invisible closing bracket after positives so a right-aligned column keeps its decimal points in line — your first thing-to-check. Opt-in, because in prose it would add a space to a sentence.

## What it must not reach, and doesn't

`csvExport` formats through `formatDecimal` and keeps the minus — asserted, not assumed. The PDF *does* come through `formatCurrency`, and should: it's a rendered document a person reads, which is where the convention comes from.

`parseCurrency` learned to read brackets back. Nothing calls it today, but a notional inverse that turned a debt into a credit is the worst possible rounding of this change.

## Three things the change surfaced

**Ten sites hand-built the minus** — `` `-${formatCurrency(Math.abs(v))}` `` — duplicating what the formatter already did and bypassing its sign handling. They'd have kept showing `-£30.00` beside the rest of the app's `(£30.00)`. A central change is the only thing that finds these.

**The `+`/`−` pairs stay**, per your scope note. Cash Flow's income/expense lines and the PDF summary are direction markers on positive magnitudes, not negative numbers. **Telling them apart was most of the work** — Cash Flow has one of each three lines apart: `-{formatCurrency(expenses)}` is a marker on a positive, while savings passes a genuine negative through. I got that wrong once in each direction before reading the components properly.

**A test mocked the formatter with `` `£${Math.abs(n)}` ``** — a fake that discards the sign. That suite never exercised how a negative reads, and the component carried a redundant sign-handling arm that was load-bearing *only against the mock*. Corrected to the real convention. **Nine other suites carry the same shape of mock** and don't currently assert on negatives; worth knowing, since a mock that formats differently from the thing it stands in for is a test asserting the mock.

## Numbers

53 assertions moved to the new convention. 16 new tests, and per your note they assert the property rather than a class — the sign is recoverable by eye *and* by ear, which is the shape that would have caught the `text-red-600` dark-mode bug.

6011 tests pass, lint and typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
