### PR TITLE
Custom period, the two rings share a column, and 24 honest mocks

### DIFF
--- a/src/components/BulkCategorizeModal.sort.test.tsx
+++ b/src/components/BulkCategorizeModal.sort.test.tsx
@@ -28,7 +28,10 @@ vi.mock('../contexts/ToastContext', () => ({
 
 vi.mock('../hooks/useCurrencyDecimal', () => ({
   useCurrencyDecimal: () => ({
-    formatCurrency: (amount: number) => `£${Math.abs(amount).toFixed(2)}`,
+    formatCurrency: (amount: number) =>
+      Number(amount) < 0
+        ? `(£${Math.abs(Number(amount)).toFixed(2)})`
+        : `£${Number(amount).toFixed(2)}`,
     displayCurrency: 'GBP',
     getCurrencySymbol: () => '£',
     convert: vi.fn(),

--- a/src/components/CategoryTransactionsModal.test.tsx
+++ b/src/components/CategoryTransactionsModal.test.tsx
@@ -27,7 +27,10 @@ vi.mock('./EditTransactionModal', () => ({
 
 vi.mock('../hooks/useCurrencyDecimal', () => ({
   useCurrencyDecimal: () => ({
-    formatCurrency: (n: number) => `£${Math.abs(Number(n)).toFixed(2)}`,
+    formatCurrency: (n: number) =>
+      Number(n) < 0
+        ? `(£${Math.abs(Number(n)).toFixed(2)})`
+        : `£${Number(n).toFixed(2)}`,
   }),
 }));
 

--- a/src/components/DuplicateSweepModal.test.tsx
+++ b/src/components/DuplicateSweepModal.test.tsx
@@ -31,7 +31,10 @@ vi.mock('../contexts/ToastContext', () => ({
 
 vi.mock('../hooks/useCurrencyDecimal', () => ({
   useCurrencyDecimal: () => ({
-    formatCurrency: (amount: number) => `£${Math.abs(amount).toFixed(2)}`,
+    formatCurrency: (amount: number) =>
+      Number(amount) < 0
+        ? `(£${Math.abs(Number(amount)).toFixed(2)})`
+        : `£${Number(amount).toFixed(2)}`,
     displayCurrency: 'GBP',
     getCurrencySymbol: () => '£',
     convert: vi.fn(),

--- a/src/components/EditTransactionModal.repoint.test.tsx
+++ b/src/components/EditTransactionModal.repoint.test.tsx
@@ -87,7 +87,10 @@ vi.mock('../hooks/usePayeeMemory', () => ({
   usePayeeMemory: () => ({ propagateCategory: vi.fn(async () => {}) }),
 }));
 vi.mock('../hooks/useCurrencyDecimal', () => ({
-  useCurrencyDecimal: () => ({ formatCurrency: (n: number) => `£${Math.abs(Number(n)).toFixed(2)}` }),
+  useCurrencyDecimal: () => ({ formatCurrency: (n: number) =>
+      Number(n) < 0
+        ? `(£${Math.abs(Number(n)).toFixed(2)})`
+        : `£${Number(n).toFixed(2)}` }),
 }));
 
 vi.mock('./common/Modal', () => ({

--- a/src/components/QuickEditRow.provenance.test.tsx
+++ b/src/components/QuickEditRow.provenance.test.tsx
@@ -83,7 +83,10 @@ vi.mock('../contexts/ToastContext', () => ({
 
 vi.mock('../hooks/useCurrencyDecimal', () => ({
   useCurrencyDecimal: () => ({
-    formatCurrency: (n: number) => `£${Math.abs(Number(n)).toFixed(2)}`,
+    formatCurrency: (n: number) =>
+      Number(n) < 0
+        ? `(£${Math.abs(Number(n)).toFixed(2)})`
+        : `£${Number(n).toFixed(2)}`,
   }),
 }));
 

--- a/src/components/QuickEditRow.transfer.test.tsx
+++ b/src/components/QuickEditRow.transfer.test.tsx
@@ -99,7 +99,10 @@ vi.mock('../contexts/ToastContext', () => ({
 
 vi.mock('../hooks/useCurrencyDecimal', () => ({
   useCurrencyDecimal: () => ({
-    formatCurrency: (n: number) => `£${Math.abs(Number(n)).toFixed(2)}`,
+    formatCurrency: (n: number) =>
+      Number(n) < 0
+        ? `(£${Math.abs(Number(n)).toFixed(2)})`
+        : `£${Number(n).toFixed(2)}`,
   }),
 }));
 

--- a/src/components/QuickEditRow.transferToggle.test.tsx
+++ b/src/components/QuickEditRow.transferToggle.test.tsx
@@ -93,7 +93,10 @@ vi.mock('../hooks/usePayeeMemory', () => ({
 }));
 
 vi.mock('../hooks/useCurrencyDecimal', () => ({
-  useCurrencyDecimal: () => ({ formatCurrency: (n: number) => `£${Math.abs(Number(n)).toFixed(2)}` }),
+  useCurrencyDecimal: () => ({ formatCurrency: (n: number) =>
+      Number(n) < 0
+        ? `(£${Math.abs(Number(n)).toFixed(2)})`
+        : `£${Number(n).toFixed(2)}` }),
 }));
 
 function RowEditor(props: Omit<QuickEditRowProviderProps, 'children'>): React.JSX.Element {

--- a/src/components/SwipeableTransactionRow.provenance.test.tsx
+++ b/src/components/SwipeableTransactionRow.provenance.test.tsx
@@ -16,7 +16,10 @@ import { SwipeableTransactionRow } from './SwipeableTransactionRow';
 import type { Transaction } from '../types';
 
 const handlers = {
-  formatCurrency: (n: number) => `£${Math.abs(n).toFixed(2)}`,
+  formatCurrency: (n: number) =>
+      Number(n) < 0
+        ? `(£${Math.abs(Number(n)).toFixed(2)})`
+        : `£${Number(n).toFixed(2)}`,
   onEdit: vi.fn(),
   onDelete: vi.fn(),
   onView: vi.fn(),

--- a/src/components/SwipeableTransactionRow.review.test.tsx
+++ b/src/components/SwipeableTransactionRow.review.test.tsx
@@ -21,7 +21,10 @@ import { SwipeableTransactionRow } from './SwipeableTransactionRow';
 import type { Transaction } from '../types';
 
 const handlers = {
-  formatCurrency: (n: number) => `£${Math.abs(n).toFixed(2)}`,
+  formatCurrency: (n: number) =>
+      Number(n) < 0
+        ? `(£${Math.abs(Number(n)).toFixed(2)})`
+        : `£${Number(n).toFixed(2)}`,
   onEdit: vi.fn(),
   onDelete: vi.fn(),
   onView: vi.fn(),

--- a/src/components/TransferMatchDialog.test.tsx
+++ b/src/components/TransferMatchDialog.test.tsx
@@ -6,7 +6,10 @@ import type { TransferCandidate } from '../utils/transferMatch';
 
 vi.mock('../hooks/useCurrencyDecimal', () => ({
   useCurrencyDecimal: () => ({
-    formatCurrency: (n: number) => `£${Math.abs(Number(n)).toFixed(2)}`,
+    formatCurrency: (n: number) =>
+      Number(n) < 0
+        ? `(£${Math.abs(Number(n)).toFixed(2)})`
+        : `£${Number(n).toFixed(2)}`,
   }),
 }));
 

--- a/src/components/TransferSweepModal.dismissals.test.tsx
+++ b/src/components/TransferSweepModal.dismissals.test.tsx
@@ -29,7 +29,10 @@ vi.mock('../contexts/ToastContext', () => ({
 
 vi.mock('../hooks/useCurrencyDecimal', () => ({
   useCurrencyDecimal: () => ({
-    formatCurrency: (amount: number) => `£${Math.abs(amount).toFixed(2)}`,
+    formatCurrency: (amount: number) =>
+      Number(amount) < 0
+        ? `(£${Math.abs(Number(amount)).toFixed(2)})`
+        : `£${Number(amount).toFixed(2)}`,
     displayCurrency: 'GBP',
     getCurrencySymbol: () => '£',
     convert: vi.fn(),

--- a/src/components/TransferSweepModal.splitLine.test.tsx
+++ b/src/components/TransferSweepModal.splitLine.test.tsx
@@ -33,7 +33,10 @@ vi.mock('../contexts/ToastContext', () => ({
 
 vi.mock('../hooks/useCurrencyDecimal', () => ({
   useCurrencyDecimal: () => ({
-    formatCurrency: (amount: number) => `£${Math.abs(amount).toFixed(2)}`,
+    formatCurrency: (amount: number) =>
+      Number(amount) < 0
+        ? `(£${Math.abs(Number(amount)).toFixed(2)})`
+        : `£${Number(amount).toFixed(2)}`,
     displayCurrency: 'GBP',
     getCurrencySymbol: () => '£',
     convert: vi.fn(),

--- a/src/components/TransferSweepModal.stranded.test.tsx
+++ b/src/components/TransferSweepModal.stranded.test.tsx
@@ -32,7 +32,10 @@ vi.mock('../contexts/ToastContext', () => ({
 
 vi.mock('../hooks/useCurrencyDecimal', () => ({
   useCurrencyDecimal: () => ({
-    formatCurrency: (amount: number) => `£${Math.abs(amount).toFixed(2)}`,
+    formatCurrency: (amount: number) =>
+      Number(amount) < 0
+        ? `(£${Math.abs(Number(amount)).toFixed(2)})`
+        : `£${Number(amount).toFixed(2)}`,
     displayCurrency: 'GBP',
     getCurrencySymbol: () => '£',
     convert: vi.fn(),

--- a/src/components/reports/TopTransactionsTable.test.tsx
+++ b/src/components/reports/TopTransactionsTable.test.tsx
@@ -13,7 +13,10 @@ import type { Category, Transaction } from '../../types';
 
 vi.mock('../../hooks/useCurrencyDecimal', () => ({
   useCurrencyDecimal: () => ({
-    formatCurrency: (n: number) => `£${Math.abs(Number(n)).toFixed(2)}`,
+    formatCurrency: (n: number) =>
+      Number(n) < 0
+        ? `(£${Math.abs(Number(n)).toFixed(2)})`
+        : `£${Number(n).toFixed(2)}`,
   }),
 }));
 

--- a/src/pages/Investments.tsx
+++ b/src/pages/Investments.tsx
@@ -30,6 +30,7 @@ import type { InvestmentHolding } from '@data';
 import { fetchQuotes } from '../services/stockPriceService';
 import { capSeriesWithRemainder, categoricalColor, useCategoricalRamp, useChartTooltipStyle } from '../components/charts/chartColors';
 import { resolvePeriod } from '../hooks/usePeriod';
+import DatePicker from '../components/common/DatePicker';
 
 /**
  * The windows this chart offers, in the app's own words.
@@ -37,7 +38,7 @@ import { resolvePeriod } from '../hooks/usePeriod';
  * `3 months` rather than `3M`: the abbreviation saved eleven characters on a
  * control that has room, at the cost of matching nothing else in the product.
  */
-const INVESTMENT_PERIODS = ['1-month', '3-months', '6-months', '12-months', 'tax-year', 'all'] as const;
+const INVESTMENT_PERIODS = ['1-month', '3-months', '6-months', '12-months', 'tax-year', 'all', 'custom'] as const;
 type InvestmentPeriod = (typeof INVESTMENT_PERIODS)[number];
 
 const INVESTMENT_PERIOD_LABELS: Record<InvestmentPeriod, string> = {
@@ -47,6 +48,7 @@ const INVESTMENT_PERIOD_LABELS: Record<InvestmentPeriod, string> = {
   '12-months': '12 months',
   'tax-year': 'Tax year',
   all: 'All time',
+  custom: 'Custom',
 };
 
 /** Trailing windows only; 'tax-year' and 'all' resolve elsewhere. */
@@ -76,6 +78,11 @@ export default function Investments() {
    * April here and on the Dashboard, forever, from one definition.
    */
   const [selectedPeriod, setSelectedPeriod] = useState<InvestmentPeriod>('12-months');
+  // Bare yyyy-mm-dd, which is what `DatePicker` speaks and what a date input
+  // needs. Empty means unbounded on that side, so choosing Custom and setting
+  // only a start reads as "from then until today" rather than showing nothing.
+  const [customStart, setCustomStart] = useState('');
+  const [customEnd, setCustomEnd] = useState('');
   const [showAddInvestmentModal, setShowAddInvestmentModal] = useState(false);
   const [activeTab, setActiveTab] = useState<'overview' | 'watchlist' | 'portfolio' | 'manage'>('overview');
   const [managingAccountId, setManagingAccountId] = useState<string | null>(null);
@@ -254,10 +261,14 @@ export default function Investments() {
     // starts — including in the days between 1 and 5 April, which is exactly
     // when a second implementation would have been caught.
     if (selectedPeriod === 'tax-year') return resolvePeriod('tax-year', '', '');
+    // Straight through the app's own resolver, so "Custom" means here exactly
+    // what it means on the Dashboard and on Reports — including how it treats
+    // a half-filled range.
+    if (selectedPeriod === 'custom') return resolvePeriod('custom', customStart, customEnd);
     const months = INVESTMENT_PERIOD_MONTHS[selectedPeriod];
     const now = new Date();
     return { from: new Date(now.getFullYear(), now.getMonth() - months, now.getDate()), to: now };
-  }, [selectedPeriod]);
+  }, [selectedPeriod, customStart, customEnd]);
 
   // Real history: what the pair was worth on each date, never a projection of
   // today's figure backwards.
@@ -542,9 +553,11 @@ export default function Investments() {
 
         {/* Performance Chart */}
         <div className="bg-white dark:bg-gray-800 rounded-lg border border-line dark:border-gray-700 p-6">
-        <div className="flex justify-between items-center mb-4">
+        {/* Wraps: seven pills at ~90px each need ~630px, and a phone offers
+            ~340. `items-start` so the heading stays put when they do. */}
+        <div className="flex flex-wrap justify-between items-start gap-3 mb-4">
           <h2 className="text-card font-semibold text-theme-heading dark:text-white">Portfolio Performance</h2>
-          <div className="flex gap-2">
+          <div className="flex flex-wrap gap-2">
             {INVESTMENT_PERIODS.map((period) => (
               <button
                 key={period}
@@ -560,6 +573,34 @@ export default function Investments() {
             ))}
           </div>
         </div>
+
+        {/* The two bounds, in the same shape the Dashboard and Reports use —
+            `DatePicker` rather than a bare date input, so the field reads
+            dd/mm/yyyy like every other date in the app instead of taking the
+            browser's locale. */}
+        {selectedPeriod === 'custom' && (
+          <div className="flex flex-wrap items-center gap-2 mb-4">
+            <div className="w-36">
+              <DatePicker
+                size="sm"
+                value={customStart}
+                onChange={setCustomStart}
+                aria-label="Custom period start date"
+                className="text-sm rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 text-gray-900 dark:text-white"
+              />
+            </div>
+            <span className="text-body text-gray-500 dark:text-gray-400">to</span>
+            <div className="w-36">
+              <DatePicker
+                size="sm"
+                value={customEnd}
+                onChange={setCustomEnd}
+                aria-label="Custom period end date"
+                className="text-sm rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 text-gray-900 dark:text-white"
+              />
+            </div>
+          </div>
+        )}
         <div className="h-64">
           <ResponsiveContainer width="100%" height="100%">
             <LineChart data={performanceData}>
@@ -670,6 +711,14 @@ export default function Investments() {
           )}
         </div>
 
+        {/* THE RIGHT-HAND COLUMN, which is now a STACK of two.
+            "Asset Allocation" answers where the money is kept; "Allocation by
+            holding" beneath it answers what it is in. Both are short — five
+            slices each since the cap — and the Holdings list beside them is
+            long, so the column had a screen of empty space under one legend
+            while the second ring sat below the fold in a full-width card of
+            its own. */}
+        <div className="space-y-6">
         {/* Allocation Chart */}
         <div className="bg-white dark:bg-gray-800 rounded-lg border border-line dark:border-gray-700 p-6">
           <h2 className="text-card font-semibold mb-4 text-theme-heading dark:text-white">Asset Allocation</h2>
@@ -679,16 +728,19 @@ export default function Investments() {
             </p>
           ) : (
             <>
-              <div className="h-64">
+              {/* h-44, not h-64: this ring carried a twelve-row legend when it
+                  was sized, and carries five now. The height it was keeping is
+                  what "Allocation by holding" moved into. */}
+              <div className="h-44">
                 <ResponsiveContainer width="100%" height="100%">
                   <RePieChart>
                     <Pie
                       data={allocationData}
                       cx="50%"
                       cy="50%"
-                      innerRadius={60}
-                      outerRadius={80}
-                      paddingAngle={5}
+                      innerRadius="60%"
+                      outerRadius="90%"
+                      paddingAngle={3}
                       dataKey="value"
                     >
                       {allocationData.map((_, index) => (
@@ -741,14 +793,13 @@ export default function Investments() {
             </>
           )}
         </div>
-        </div>
 
         {/* ─ WHAT IT IS IN ────────────────────────────────────────────────────
             A second ring, because the first one's card was mostly empty space
             below a twelve-row legend and because it answers a different
             question. Where the money is KEPT and what it is INVESTED IN are
             not the same fact, and only the second one is a decision. */}
-        <div className="bg-white dark:bg-gray-800 rounded-lg border border-line dark:border-gray-700 p-6 mt-6">
+        <div className="bg-white dark:bg-gray-800 rounded-lg border border-line dark:border-gray-700 p-6">
           <h2 className="text-card font-semibold mb-1 text-theme-heading dark:text-white">
             Allocation by holding
           </h2>
@@ -763,16 +814,16 @@ export default function Investments() {
                 : 'No priced holdings and no settlement cash, so there is nothing to divide up yet.'}
             </p>
           ) : (
-            <div className="flex flex-col lg:flex-row lg:items-center gap-6">
-              <div className="h-56 w-full lg:w-56 shrink-0">
+            <div className="flex flex-col sm:flex-row sm:items-center gap-4">
+              <div className="h-44 w-full sm:w-44 shrink-0">
                 <ResponsiveContainer width="100%" height="100%">
                   <RePieChart>
                     <Pie
                       data={holdingSlices}
                       cx="50%"
                       cy="50%"
-                      innerRadius={55}
-                      outerRadius={80}
+                      innerRadius="60%"
+                      outerRadius="90%"
                       paddingAngle={3}
                       dataKey="value"
                     >
@@ -825,6 +876,8 @@ export default function Investments() {
               </div>
             </div>
           )}
+        </div>
+        </div>
         </div>
 
         {/* Investment Tips */}

--- a/src/pages/__tests__/Calendar.test.tsx
+++ b/src/pages/__tests__/Calendar.test.tsx
@@ -20,7 +20,10 @@ vi.mock('../../contexts/AppContextSupabase', () => ({
 // Mock currency hook
 vi.mock('../../hooks/useCurrencyDecimal', () => ({
   useCurrencyDecimal: () => ({
-    formatCurrency: (amount: number) => `£${Math.abs(amount).toFixed(2)}`,
+    formatCurrency: (amount: number) =>
+      Number(amount) < 0
+        ? `(£${Math.abs(Number(amount)).toFixed(2)})`
+        : `£${Number(amount).toFixed(2)}`,
   }),
 }));
 

--- a/src/pages/settings/Categories.adjustment.test.tsx
+++ b/src/pages/settings/Categories.adjustment.test.tsx
@@ -34,7 +34,10 @@ vi.mock('../../contexts/ToastContext', () => ({ useToast: () => toast }));
 
 vi.mock('../../hooks/useCurrencyDecimal', () => ({
   useCurrencyDecimal: () => ({
-    formatCurrency: (amount: number) => `£${Math.abs(amount).toFixed(2)}`,
+    formatCurrency: (amount: number) =>
+      Number(amount) < 0
+        ? `(£${Math.abs(Number(amount)).toFixed(2)})`
+        : `£${Number(amount).toFixed(2)}`,
     displayCurrency: 'GBP',
     getCurrencySymbol: () => '£',
     convert: vi.fn(),

--- a/src/pages/settings/Categories.dataHealth.test.tsx
+++ b/src/pages/settings/Categories.dataHealth.test.tsx
@@ -43,7 +43,10 @@ vi.mock('../../contexts/ToastContext', () => ({ useToast: () => toast }));
 
 vi.mock('../../hooks/useCurrencyDecimal', () => ({
   useCurrencyDecimal: () => ({
-    formatCurrency: (amount: number) => `£${Math.abs(amount).toFixed(2)}`,
+    formatCurrency: (amount: number) =>
+      Number(amount) < 0
+        ? `(£${Math.abs(Number(amount)).toFixed(2)})`
+        : `£${Number(amount).toFixed(2)}`,
     displayCurrency: 'GBP',
     getCurrencySymbol: () => '£',
     convert: vi.fn(),

--- a/src/pages/settings/Categories.merge.test.tsx
+++ b/src/pages/settings/Categories.merge.test.tsx
@@ -33,7 +33,10 @@ vi.mock('../../contexts/ToastContext', () => ({ useToast: () => toast }));
 
 vi.mock('../../hooks/useCurrencyDecimal', () => ({
   useCurrencyDecimal: () => ({
-    formatCurrency: (amount: number) => `£${Math.abs(amount).toFixed(2)}`,
+    formatCurrency: (amount: number) =>
+      Number(amount) < 0
+        ? `(£${Math.abs(Number(amount)).toFixed(2)})`
+        : `£${Number(amount).toFixed(2)}`,
     displayCurrency: 'GBP',
     getCurrencySymbol: () => '£',
     convert: vi.fn(),

--- a/src/pages/settings/PayeeCleanup.dismissals.test.tsx
+++ b/src/pages/settings/PayeeCleanup.dismissals.test.tsx
@@ -33,7 +33,10 @@ vi.mock('../../contexts/ToastContext', () => ({
 
 vi.mock('../../hooks/useCurrencyDecimal', () => ({
   useCurrencyDecimal: () => ({
-    formatCurrency: (amount: number) => `£${Math.abs(amount).toFixed(2)}`,
+    formatCurrency: (amount: number) =>
+      Number(amount) < 0
+        ? `(£${Math.abs(Number(amount)).toFixed(2)})`
+        : `£${Number(amount).toFixed(2)}`,
     displayCurrency: 'GBP',
     getCurrencySymbol: () => '£',
     convert: vi.fn(),

--- a/src/pages/settings/PayeeCleanup.emptyStates.test.tsx
+++ b/src/pages/settings/PayeeCleanup.emptyStates.test.tsx
@@ -31,7 +31,10 @@ vi.mock('../../contexts/ToastContext', () => ({ useToast: () => toast }));
 
 vi.mock('../../hooks/useCurrencyDecimal', () => ({
   useCurrencyDecimal: () => ({
-    formatCurrency: (amount: number) => `£${Math.abs(amount).toFixed(2)}`,
+    formatCurrency: (amount: number) =>
+      Number(amount) < 0
+        ? `(£${Math.abs(Number(amount)).toFixed(2)})`
+        : `£${Number(amount).toFixed(2)}`,
     displayCurrency: 'GBP',
     getCurrencySymbol: () => '£',
     convert: vi.fn(), convertAndFormat: vi.fn(), convertAndSum: vi.fn(),

--- a/src/pages/settings/PayeeCleanup.hidden.test.tsx
+++ b/src/pages/settings/PayeeCleanup.hidden.test.tsx
@@ -39,7 +39,10 @@ vi.mock('../../contexts/ToastContext', () => ({ useToast: () => toast }));
 
 vi.mock('../../hooks/useCurrencyDecimal', () => ({
   useCurrencyDecimal: () => ({
-    formatCurrency: (amount: number) => `£${Math.abs(amount).toFixed(2)}`,
+    formatCurrency: (amount: number) =>
+      Number(amount) < 0
+        ? `(£${Math.abs(Number(amount)).toFixed(2)})`
+        : `£${Number(amount).toFixed(2)}`,
     displayCurrency: 'GBP',
     getCurrencySymbol: () => '£',
     convert: vi.fn(), convertAndFormat: vi.fn(), convertAndSum: vi.fn(),

--- a/src/pages/settings/PayeeCleanup.sizing.test.tsx
+++ b/src/pages/settings/PayeeCleanup.sizing.test.tsx
@@ -158,7 +158,10 @@ vi.mock('../../contexts/ToastContext', () => ({
 
 vi.mock('../../hooks/useCurrencyDecimal', () => ({
   useCurrencyDecimal: () => ({
-    formatCurrency: (amount: number) => `£${Math.abs(amount).toFixed(2)}`,
+    formatCurrency: (amount: number) =>
+      Number(amount) < 0
+        ? `(£${Math.abs(Number(amount)).toFixed(2)})`
+        : `£${Number(amount).toFixed(2)}`,
     displayCurrency: 'GBP',
     getCurrencySymbol: () => '£',
     convert: vi.fn(), convertAndFormat: vi.fn(), convertAndSum: vi.fn(),

--- a/src/pages/settings/PayeeCleanup.sorting.test.tsx
+++ b/src/pages/settings/PayeeCleanup.sorting.test.tsx
@@ -39,7 +39,10 @@ vi.mock('../../contexts/ToastContext', () => ({
 
 vi.mock('../../hooks/useCurrencyDecimal', () => ({
   useCurrencyDecimal: () => ({
-    formatCurrency: (amount: number) => `£${Math.abs(amount).toFixed(2)}`,
+    formatCurrency: (amount: number) =>
+      Number(amount) < 0
+        ? `(£${Math.abs(Number(amount)).toFixed(2)})`
+        : `£${Number(amount).toFixed(2)}`,
     displayCurrency: 'GBP',
     getCurrencySymbol: () => '£',
     convert: vi.fn(), convertAndFormat: vi.fn(), convertAndSum: vi.fn(),

--- a/src/pages/settings/PayeeCleanup.suggestions.test.tsx
+++ b/src/pages/settings/PayeeCleanup.suggestions.test.tsx
@@ -41,7 +41,10 @@ vi.mock('../../contexts/ToastContext', () => ({
 
 vi.mock('../../hooks/useCurrencyDecimal', () => ({
   useCurrencyDecimal: () => ({
-    formatCurrency: (amount: number) => `£${Math.abs(amount).toFixed(2)}`,
+    formatCurrency: (amount: number) =>
+      Number(amount) < 0
+        ? `(£${Math.abs(Number(amount)).toFixed(2)})`
+        : `£${Number(amount).toFixed(2)}`,
     displayCurrency: 'GBP',
     getCurrencySymbol: () => '£',
     convert: vi.fn(), convertAndFormat: vi.fn(), convertAndSum: vi.fn(),


### PR DESCRIPTION
Three things, one of which is me finishing work I'd left half-done.

## Custom, which the period sweep missed

You spotted it: the Investments picker took the app's vocabulary but not all of it — "Custom" was on the Dashboard and Reports and not here. Added, with both bounds resolved through `resolvePeriod` so Custom means the same thing on all three pages, including how it treats a half-filled range. Seven pills need ~630px and a phone offers ~340, so the row wraps now.

## The right column is a stack of two

"Allocation by holding" sat in a full-width card below the fold while the column beside Holdings held one short legend and a screen of empty space. It moves into that space, under "Asset Allocation" — where you asked for it, and where comparing the two is actually possible.

Both rings shrink to `h-44` and take the same 60/90 radii. Worth noting *why* Asset Allocation had room to give: it was sized when it carried a **twelve-row legend**, and it carries five since the slice cap. The height it was keeping is exactly what the second card moved into.

## The 24 mocks — finished, not sampled

The parentheses PR corrected **one** test mock, the one that happened to fail, and reported the rest as "nine other suites carry the same shape". Both halves of that were wrong: it's **24**, and leaving them was leaving a hole in the kind of check this app's credibility rests on.

Every one was `formatCurrency: n => \`£${Math.abs(n)}\`` — a fake that discards the sign. A suite mocking that **could not have noticed a negative rendering as a positive**, which is the single most expensive thing a finance app can get wrong. All 24 now format the way the real one does.

All 6022 tests pass unchanged, which says the fakes weren't hiding a live bug. They were making one unnoticeable, and that's the thing worth fixing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)