### PR TITLE
Claude Design's Add Account review — and three of it were one bug

### DIFF
--- a/src/components/AddAccountModal.test.tsx
+++ b/src/components/AddAccountModal.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, fireEvent, waitFor, within } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor, waitFor, within } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import AddAccountModal from './AddAccountModal';
 import { PreferencesProvider } from '../contexts/PreferencesContext';
@@ -274,16 +274,42 @@ describe('AddAccountModal — submission', () => {
     expect(lastPayload()?.sortCode).toBe('123456');
   });
 
-  // The balance is `required`, so native constraint validation blocks the
-  // submit before the component's own "valid balance" check ever runs.
-  it('does not save when the balance is blank', () => {
+  /*
+   * This asserted the OPPOSITE until 15 August: the balance was `required`, so
+   * native constraint validation blocked the submit and a blank box was
+   * refused.
+   *
+   * Claude Design overturned it, and the reason is the kind a test cannot see:
+   * an account opened today with nothing in it HAS a balance, and it is £0.00.
+   * Marking the field required made a person type a zero to satisfy a
+   * validator. Blank is not a missing answer here; it is the commonest one.
+   */
+  it('saves a blank balance as zero, because zero is a real answer', async () => {
     renderModal();
 
     fireEvent.change(nameField(), { target: { value: 'No Balance' } });
     fireEvent.click(submitButton());
 
-    expect(balanceField()).toBeRequired();
-    expect(balanceField()).toBeInvalid();
-    expect(addAccount).not.toHaveBeenCalled();
+    await waitFor(() => expect(addAccount).toHaveBeenCalled());
+    expect(addAccount.mock.calls[0][0]).toMatchObject({ balance: 0 });
+  });
+
+  it('never lets letters into the balance in the first place', () => {
+    /*
+     * Written first as "still refuses something typed that is not a number",
+     * asserting the submit was blocked — and it failed, because the account
+     * saved. The money input FILTERS as you type, so "abc" never reaches
+     * state: the field stays empty, empty now means zero, and zero saves.
+     *
+     * That is the better behaviour and the assertion was wrong about it. The
+     * validator's `isNaN` arm is still right to exist — it guards the state,
+     * not the keyboard — but the case cannot be reached through the UI, and a
+     * test claiming otherwise would be describing a modal that does not exist.
+     */
+    renderModal();
+
+    fireEvent.change(balanceField(), { target: { value: 'abc' } });
+
+    expect((balanceField() as HTMLInputElement).value).not.toContain('a');
   });
 });

--- a/src/components/AddAccountModal.tsx
+++ b/src/components/AddAccountModal.tsx
@@ -116,7 +116,15 @@ export default function AddAccountModal({ isOpen, onClose, prefill, onAccountCre
         throw new Error('Account name is required');
       }
       
-      const balance = parseMoneyInput(formData.balance) ?? NaN;
+      // BLANK MEANS ZERO, which is what a new account opened today holds.
+      // The field stopped being `required` with this (Claude Design, 15 Aug);
+      // without this line the two disagreed and an empty box was refused by
+      // the validator instead of the browser — the same dead end one layer
+      // down. Something TYPED that will not parse is still an error: "abc" is
+      // a mistake, and empty is an answer.
+      const balance = formData.balance.trim() === ''
+        ? 0
+        : parseMoneyInput(formData.balance) ?? NaN;
       if (isNaN(balance)) {
         throw new Error('Please enter a valid balance');
       }
@@ -179,7 +187,6 @@ export default function AddAccountModal({ isOpen, onClose, prefill, onAccountCre
     }
   };
 
-  const selectedType = accountTypes.find(t => t.value === formData.type);
   const selectedCurrency = currencies.find(c => c.value === formData.currency);
   const isCreditCard = isCardAccountType(formData.type);
   const isBankAccount = formData.type === 'current' || formData.type === 'savings';
@@ -239,7 +246,12 @@ export default function AddAccountModal({ isOpen, onClose, prefill, onAccountCre
                       aria-pressed={isSelected}
                       className={`p-3 rounded-xl border-2 transition-all duration-200 ${
                         isSelected
-                          ? 'border-primary bg-[#1a2332]/10 dark:bg-[#1a2332]/20'
+                          // The FILL, which was `dark:bg-[#1a2332]/20` — navy at
+                          // a fifth, on a gray-800 modal. Under a ring that was
+                          // itself navy (see index.css), a selected tile in dark
+                          // mode looked exactly like an unselected one, which is
+                          // what Claude Design read as "no type is chosen".
+                          ? 'border-primary bg-[#1a2332]/10 dark:bg-gray-700'
                           : 'border-gray-200 dark:border-gray-700 hover:border-gray-300 dark:hover:border-gray-600'
                       } ${isSubmitting ? 'opacity-50 cursor-not-allowed' : ''}`}
                     >
@@ -283,7 +295,11 @@ export default function AddAccountModal({ isOpen, onClose, prefill, onAccountCre
                     value={formData.balance}
                     onChange={(value) => updateField('balance', value)}
                     className="w-full pl-8 pr-4 py-3 bg-white dark:bg-gray-800 border-2 border-gray-200 dark:border-gray-700 rounded-xl focus:border-primary dark:text-white transition-all duration-200"
-                    required
+                    // NOT required (Claude Design, 15 August). An account opened
+                    // today with nothing in it has a balance of £0.00, and
+                    // marking this required made a person type a zero to satisfy
+                    // a validator. The placeholder already showed 0.00; blank
+                    // now means what it looks like it means.
                     disabled={isSubmitting}
                   />
                 </div>
@@ -392,22 +408,14 @@ export default function AddAccountModal({ isOpen, onClose, prefill, onAccountCre
               </div>
             )}
 
-            {/* Account Type Info Banner */}
-            {selectedType && (
-              <div className="p-4 bg-[#1a2332]/5 dark:bg-[#1a2332]/10 rounded-xl border border-[#1a2332]/20">
-                <div className="flex gap-3">
-                  <selectedType.icon size={20} className="text-primary mt-0.5" />
-                  <div>
-                    <div className="text-sm font-medium text-gray-700 dark:text-gray-200">
-                      {selectedType.label}
-                    </div>
-                    <div className="text-xs text-gray-600 dark:text-gray-400 mt-1">
-                      {selectedType.description}
-                    </div>
-                  </div>
-                </div>
-              </div>
-            )}
+            {/* The "Account Type Info Banner" was here: an icon, the type's
+                name and its description, repeated verbatim from the tile that
+                is ringed six inches above it. Claude Design, 15 August — it was
+                the THIRD statement of one fact, carried no label saying what it
+                was, and a reader had to work out it was a confirmation rather
+                than another control. Dropped rather than relabelled: the modal
+                is not tall enough for the tiles to scroll out of view, so it
+                was not keeping the choice visible either. */}
           </div>
         </ModalBody>
         <ModalFooter>
@@ -423,7 +431,15 @@ export default function AddAccountModal({ isOpen, onClose, prefill, onAccountCre
             <button
               type="submit"
               disabled={isSubmitting}
-              className="flex-1 justify-center px-6 py-3 bg-gradient-to-r from-primary to-secondary text-white rounded-xl hover:shadow-lg hover:scale-[1.02] font-medium transition-all duration-200 disabled:opacity-50 disabled:cursor-not-allowed disabled:hover:scale-100"
+              /* The dark treatment is not decoration. `from-primary to-secondary`
+                 is #1a2332 → #2d3a4d, and on a gray-800 modal that is navy on
+                 navy: the button reads as MUTED. Claude Design saw it in four
+                 dark captures and reported the primary action as "a dead end …
+                 a disabled primary and no route forward". It was never
+                 disabled — `disabled={isSubmitting}` is the whole of it — it
+                 just could not be seen to be enabled. Third instance of one
+                 root cause on this modal; see index.css's .dark .border-primary. */
+              className="flex-1 justify-center px-6 py-3 bg-gradient-to-r from-primary to-secondary dark:from-gray-600 dark:to-gray-500 text-white rounded-xl hover:shadow-lg hover:scale-[1.02] font-medium transition-all duration-200 disabled:opacity-50 disabled:cursor-not-allowed disabled:hover:scale-100"
             >
               {isSubmitting ? 'Adding...' : 'Add Account'}
             </button>

--- a/src/components/CardNumberGuidance.test.tsx
+++ b/src/components/CardNumberGuidance.test.tsx
@@ -3,11 +3,15 @@ import { describe, expect, it } from 'vitest';
 import CardNumberGuidance from './CardNumberGuidance';
 
 describe('CardNumberGuidance', () => {
-  it('states the rule before anything has been typed', () => {
+  it('states the rule before anything has been typed, in one line', () => {
+    // Two paragraphs until 15 August — about fifty words under one optional
+    // field — and the second wore the warning pair while saying the user was
+    // safe. Claude Design merged them and ruled the colour off: a REASSURANCE
+    // states a protection the app applies, and never takes the warning pair.
     render(<CardNumberGuidance value="" />);
 
     expect(
-      screen.getByText(/Only the last 4 digits are ever saved/)
+      screen.getByText(/a full card number is never stored/i)
     ).toBeInTheDocument();
   });
 

--- a/src/components/CardNumberGuidance.tsx
+++ b/src/components/CardNumberGuidance.tsx
@@ -27,20 +27,39 @@ export default function CardNumberGuidance({
 
   return (
     <>
+      {/* ONE line, and NOT amber. Claude Design, 15 August.
+       *
+       * It was two paragraphs — about fifty words under one optional field, in
+       * a modal where no other field has any — and the second was in the
+       * warning pair. Applying their own export test: a warning describes a
+       * consequence OUTSIDE the app of the action about to be taken, and a
+       * reader who skims it can be harmed. This says the opposite. Nothing the
+       * user types can escape, because the app drops it before saving.
+       *
+       * That is a REASSURANCE, and the ruling names it as a fourth category
+       * beside caveat / warning / next action:
+       *
+       *   Reassurance — states a protection the app applies to the user's
+       *   data. Neutral or positive. Never the warning pair.
+       *
+       * Amber here made the reader tense at the colour and then read text
+       * telling them they are safe. The writing was already good; only the
+       * colour was making a claim the words did not. */}
       <p className="mt-1 text-xs text-gray-500 dark:text-gray-400">
-        The last 4 digits printed on the card are what matches this account to
-        your bank feed, so a linked card lands here instead of asking you every
-        time.
-      </p>
-      <p className="mt-1 text-xs text-amber-700 dark:text-amber-400">
-        Only the last 4 digits are ever saved. Anything longer is dropped when
-        you save, so a full card number never reaches your backups, your JSON
-        export or your audit history.
+        The last 4 digits are what match this account to your bank feed. Anything
+        longer is dropped when you save — a full card number is never stored.
       </p>
       <div role="status">
         {hasMoreThanLastFour(value) && (
-          <div className="mt-2 rounded-xl border border-amber-300 dark:border-amber-700 bg-amber-50 dark:bg-amber-900/20 px-3 py-2">
-            <p className="text-xs text-amber-800 dark:text-amber-300">
+          /* The live one goes the same way, and for the same reason. It tells
+             you what the app is about to protect you from, which is the
+             reassurance category again — the reader has done nothing wrong,
+             and amber says they have. It stays a panel so it is still noticed;
+             it stops being an alarm. (Design ruled on the static line; this is
+             their principle applied to its neighbour, which is worth their
+             confirming.) */
+          <div className="mt-2 rounded-xl border border-line dark:border-gray-700 bg-gray-50 dark:bg-gray-800 px-3 py-2">
+            <p className="text-xs text-gray-600 dark:text-gray-300">
               That is {digits.length} digits. Saving will store {keepLastFour(value)} and
               discard the rest.
             </p>

--- a/src/design-system/__tests__/darkModeUtilities.test.ts
+++ b/src/design-system/__tests__/darkModeUtilities.test.ts
@@ -91,26 +91,41 @@ describe('dark-mode colours that silently do not apply', () => {
     // The `.text-theme-heading` failure. An `!important` colour beats the
     // `dark:` variant a call site writes, so the utility itself must answer
     // for both themes — the call sites are powerless to.
-    // `color:` the PROPERTY, not `background-color:` or `border-color:` — a
-    // brand surface is meant to stay navy on both grounds, and only ink has to
-    // flip. (Written as `\bcolor:` first, which matched `background-color` and
-    // reported ten false positives.)
+    // `color:` and `border-color:`, but NOT `background-color:`.
+    //
+    // The first pass took only `color:`, reasoning that a brand surface stays
+    // navy on both grounds and only ink has to flip. Half right: a BACKGROUND
+    // is a surface, and `.bg-primary` is correct in both modes. A BORDER
+    // usually is not — `.border-primary` is the ring that says which tile is
+    // selected, and navy on a gray-800 modal is no ring at all. That shipped,
+    // and was read from screenshots as "no type is selected".
+    //
+    // (Also written as `\bcolor:` at one point, which matched
+    // `background-color` and reported ten false positives.)
     const importantColourRules = [
       // `\s*` OUTSIDE the alternation. With it inside — `(?:^|[;{]\s*)color:` —
       // neither branch could reach an indented `color:`, so this matched
       // nothing and the assertion passed with the bug reintroduced. Caught by
       // deleting the fix and watching the test stay green.
-      ...CSS.matchAll(/^\.([\w-]+)\s*\{[^}]*?(?:[;{]|^)\s*color:[^;]*!important/gm),
+      ...CSS.matchAll(/^\.([\w-]+)\s*\{[^}]*?(?:[;{]|^)\s*(?:border-)?color:[^;]*!important/gm),
     ].map((match) => match[1]);
 
+    // `dark-exempt:` in a comment ON the rule is how a utility says its GROUND
+    // does not change with the theme — the sidebar's navy, for instance. It has
+    // to be written deliberately and it has to give a reason, which is the
+    // point: the exemptions worth having are the ones somebody argued for.
+    const exempt = new Set(
+      [...CSS.matchAll(/dark-exempt:[^*]*\*\/\s*\n\.([\w-]+)\s*\{/g)].map((m) => m[1])
+    );
+
     const missing = importantColourRules.filter(
-      (name) => !new RegExp(`\\.dark\\s+\\.${name}\\b`).test(CSS)
+      (name) => !exempt.has(name) && !new RegExp(`\\.dark\\s+\\.${name}\\b`).test(CSS)
     );
 
     expect(
       missing,
-      `These force a colour with !important and have no .dark rule, so they render ` +
-        `the same ink on both grounds:\n${missing.map((n) => `.${n}`).join('\n')}`
+      `These force a colour or a border with !important and have no .dark rule, ` +
+        `so they paint the same on both grounds:\n${missing.map((n) => `.${n}`).join('\n')}`
     ).toEqual([]);
   });
 

--- a/src/index.css
+++ b/src/index.css
@@ -235,6 +235,31 @@ body {
   --tw-ring-color: var(--color-primary) !important;
 }
 
+/* …and both of them in dark mode, for the reason `.text-primary` needed one.
+ *
+ * `--color-primary` is rgb(26 35 50). As a BACKGROUND that is a brand surface
+ * and correct on both grounds, which is why the dark-mode sweep left
+ * `.bg-primary` alone. As a BORDER it is usually not a surface at all — it is
+ * the ring that says WHICH TILE IS SELECTED, and navy on a gray-800 modal is
+ * no ring.
+ *
+ * Found on the Add Account modal: Claude Design read four dark captures and
+ * reported that the default type "is selected in state but not in the tiles".
+ * The tile was ringed the whole time. `formData.type` starts 'current' and the
+ * selected branch applies — the ring simply could not be seen, and neither
+ * could `dark:bg-[#1a2332]/20` behind it.
+ *
+ * The slate is the one the focus ring already uses on dark (`.dark`'s
+ * `--focus-ring-color`), so a selected tile and a focused control belong to
+ * the same family instead of inventing a second highlight colour. */
+.dark .border-primary {
+  border-color: #94a3b8 !important;
+}
+
+.dark .ring-primary {
+  --tw-ring-color: #94a3b8 !important;
+}
+
 .hover\:bg-secondary:hover {
   background-color: var(--color-secondary) !important;
 }
@@ -256,6 +281,9 @@ body {
   background-color: var(--color-sidebar-active) !important;
 }
 
+/* dark-exempt: the sidebar is navy in BOTH modes — it is a brand surface, not
+   a themed one — so a border drawn against it needs no counterpart. The ground
+   is what decides, and this ground does not move. */
 .border-sidebar {
   border-color: var(--color-sidebar-border) !important;
 }
@@ -325,6 +353,10 @@ body {
   background-color: var(--color-light-accent) !important;
 }
 
+/* dark-exempt: unused. Nothing in src/ carries this class — kept with its
+   `bg-theme-accent` sibling rather than deleted piecemeal. If it is ever used,
+   #f1f3f7 is a near-white line and will want a dark value; the guard will not
+   catch that, because this comment is what silences it. */
 .border-theme-accent {
   border-color: var(--color-light-accent) !important;
 }


### PR DESCRIPTION
Six of the eight items. The finding worth your attention is that **items 1 and 3 have the same cause as each other, and as last night's dark-mode sweep.**

## Items 1 and 3 aren't what they looked like

Design read four dark captures and reported (1) *"the default type is selected in state but not in the tiles"* and (3) the primary button as *"a dead end … a disabled primary and no route forward"*.

Neither is what was happening. `formData.type` starts `'current'` and the selected branch **does** apply; the button is `disabled={isSubmitting}` and nothing else. Both were simply **invisible**:

- `.border-primary` forces navy with `!important` and had **no `.dark` rule** — so the selection ring was navy on a gray-800 modal. The fill under it was `dark:bg-[#1a2332]/20`, navy at a fifth. A selected tile and an unselected one looked identical.
- The submit button is `from-primary to-secondary` — #1a2332 → #2d3a4d — navy on navy, which reads as muted.

Both now have dark treatments, using the slate the focus ring already takes on dark so a selected tile and a focused control belong to one family.

**The guard missed this because I told it to.** `darkModeUtilities` checked `color:` and deliberately *not* `border-color:`, on the reasoning that a brand surface stays navy on both grounds. Half right — a background is a surface; a border usually isn't, it's the ring saying which tile is chosen. Widened, with a `dark-exempt:` marker for the two rules whose ground genuinely doesn't move (the sidebar's navy). An exemption somebody argued for is worth more than a rule nobody can satisfy.

## The rest

**2.** The type summary block is gone — third statement of one fact, no label saying what it was, and the modal isn't tall enough for the tiles to scroll away, so it wasn't keeping the choice visible either.

**5.** Current Balance is no longer required. An account opened today has a balance and it's £0.00; the field made people type a zero to satisfy a validator. Blank now means zero **in the validator too** — otherwise it's the same dead end one layer down.

**7 and 8.** The card-number guidance is one line, and not amber. Your own export test settles it: a warning describes a consequence *outside* the app of the action about to be taken, and a skimming reader can be harmed. This says the opposite. That's the fourth category — **Reassurance: states a protection the app applies to the user's data. Neutral or positive. Never the warning pair.**

The live "that is N digits" panel goes the same way. That's the principle applied to its neighbour rather than the ruling itself, so it wants confirming.

## One test rewritten, and why

I added *"still refuses something typed that is not a number"* — and it **failed**, because the money input filters as you type. "abc" never reaches state, the field stays empty, empty means zero, and it saves. The behaviour is better than my assertion and my assertion was wrong about it. Rewritten to assert what actually protects the field.

## Not done, deliberately

**Item 6, the balance as-of date** — the largest, and the one Design calls *"the field that makes the first reconciliation possible"*. It needs somewhere to put the date, so it's a schema question before it's a form question.

**The interest-rate suggestion** stays unbuilt, on Design's own test: nothing reads it, and an unread field is a dead toggle in slower motion.

6023 tests pass, lint and typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)