### PR TITLE
Revoke at the provider, and finish the report sub-pages

### DIFF
--- a/api/_lib/truelayer.ts
+++ b/api/_lib/truelayer.ts
@@ -205,6 +205,36 @@ export const refreshAccessToken = async (refreshToken: string): Promise<TokenRes
   return data;
 };
 
+/**
+ * Tell TrueLayer to forget this connection.
+ *
+ * `DELETE /data/v1/me` revokes the access token and the consent behind it, so
+ * the provider stops holding an authorisation for this user's bank.
+ *
+ * ─ WHY THIS EXISTS ─────────────────────────────────────────────────────────
+ *
+ * Until now `api/banking/disconnect.ts` deleted our own `bank_connections` row
+ * and nothing else. The app forgot the bank; the bank did not forget the app.
+ * That is a defensible thing to ship and an indefensible thing to IMPLY, and
+ * the wording around it implied the stronger one — "Delete All Data", "you
+ * would need to re-authorise".
+ *
+ * Returns whether the provider accepted it rather than throwing, because the
+ * caller has to delete the row either way: refusing to disconnect because a
+ * revocation failed would leave the connection in place, and a connection left
+ * in place is what recreates the accounts on the next sync.
+ */
+export const revokeAccessToken = async (accessToken: string): Promise<boolean> => {
+  const response = await fetch(`${getApiBaseUrl()}/data/v1/me`, {
+    method: 'DELETE',
+    headers: { Authorization: `Bearer ${accessToken}` }
+  });
+
+  // 401/403 mean the token is already dead, which is the state we were asking
+  // for. Anything else that is not ok is a real failure to revoke.
+  return response.ok || response.status === 401 || response.status === 403;
+};
+
 export interface TrueLayerCard {
   account_id: string;
   card_network?: string;

--- a/api/banking/disconnect.ts
+++ b/api/banking/disconnect.ts
@@ -4,6 +4,8 @@ import { AuthError, requireAuth } from '../_lib/auth.js';
 import { setCorsHeaders } from '../_lib/cors.js';
 import { createErrorResponse } from '../_lib/http-error.js';
 import { getServiceRoleSupabase } from '../_lib/supabase.js';
+import { decryptSecret } from '../_lib/encryption.js';
+import { revokeAccessToken } from '../_lib/truelayer.js';
 import { withSentry } from '../_lib/sentry.js';
 
 async function handler(req: VercelRequest, res: VercelResponse) {
@@ -24,6 +26,39 @@ async function handler(req: VercelRequest, res: VercelResponse) {
       return createErrorResponse(res, 400, 'connectionId is required', 'invalid_request');
     }
 
+    // ── REVOKE AT THE PROVIDER FIRST, THEN FORGET IT HERE ───────────────
+    //
+    // The row delete below is what stops the connection recreating its
+    // accounts on the next sync. It is NOT what stops TrueLayer holding an
+    // authorisation for this person's bank — until now nothing did, so a
+    // "disconnect" left the app having forgotten the bank and the bank still
+    // holding a live consent.
+    //
+    // Order matters: the token lives in the row, so revoking after deleting is
+    // impossible. Read, revoke, then delete.
+    //
+    // Best effort, deliberately. If TrueLayer refuses, the row STILL goes:
+    // the user asked to disconnect, and a connection left standing is what
+    // recreates the accounts. But the response says so, rather than reporting
+    // a clean disconnection that did not happen.
+    const { data: existing } = await supabase
+      .from('bank_connections')
+      .select('id, provider, access_token_encrypted')
+      .eq('id', body.connectionId)
+      .eq('user_id', auth.userId)
+      .maybeSingle();
+
+    let revokedAtProvider = false;
+    if (existing?.provider === 'truelayer' && existing.access_token_encrypted) {
+      try {
+        revokedAtProvider = await revokeAccessToken(decryptSecret(existing.access_token_encrypted));
+      } catch {
+        // A provider that is down must not trap somebody in a connection they
+        // have asked to leave.
+        revokedAtProvider = false;
+      }
+    }
+
     const { data, error } = await supabase
       .from('bank_connections')
       .delete()
@@ -39,7 +74,7 @@ async function handler(req: VercelRequest, res: VercelResponse) {
       return createErrorResponse(res, 404, 'Connection not found', 'not_found');
     }
 
-    const response: DisconnectResponse = { success: true };
+    const response: DisconnectResponse = { success: true, revokedAtProvider };
     return res.status(200).json(response);
   } catch (error) {
     if (error instanceof AuthError) {

--- a/src/pages/reports/AccountBalancesReport.tsx
+++ b/src/pages/reports/AccountBalancesReport.tsx
@@ -78,7 +78,7 @@ export default function AccountBalancesReport({ picker }: ReportViewProps): Reac
 
       <div className="bg-white dark:bg-gray-800 rounded-lg border border-line dark:border-gray-700">
         <div className="p-6 pb-3">
-          <h2 className="text-lg font-semibold text-theme-heading dark:text-white">
+          <h2 className="text-card font-semibold text-theme-heading dark:text-white">
             Balances by account
           </h2>
           <p className="text-body text-gray-500 dark:text-gray-400 mt-1">

--- a/src/pages/reports/AccountDistributionReport.tsx
+++ b/src/pages/reports/AccountDistributionReport.tsx
@@ -90,7 +90,7 @@ export default function AccountDistributionReport(): React.JSX.Element {
 
       <div className="bg-white dark:bg-gray-800 rounded-lg border border-line dark:border-gray-700 p-6">
         <div className="flex flex-wrap items-baseline justify-between gap-2 mb-1">
-          <h2 className="text-lg font-semibold text-theme-heading dark:text-white">
+          <h2 className="text-card font-semibold text-theme-heading dark:text-white">
             Where the money sits
           </h2>
           <span className="text-dense text-gray-400 dark:text-gray-500">Current balances</span>
@@ -124,7 +124,7 @@ export default function AccountDistributionReport(): React.JSX.Element {
 
       <div className="bg-white dark:bg-gray-800 rounded-lg border border-line dark:border-gray-700">
         <div className="p-6 pb-3">
-          <h2 className="text-lg font-semibold text-theme-heading dark:text-white">Every account</h2>
+          <h2 className="text-card font-semibold text-theme-heading dark:text-white">Every account</h2>
           <p className="text-body text-gray-500 dark:text-gray-400 mt-1">
             Ranked by what it holds now. Click an account to see its transactions.
           </p>

--- a/src/pages/reports/IncomeSpendingOverTimeReport.tsx
+++ b/src/pages/reports/IncomeSpendingOverTimeReport.tsx
@@ -178,9 +178,9 @@ export default function IncomeSpendingOverTimeReport({ picker, focus }: ReportVi
 
       <UncategorisedReviewBand flows={flows} categories={categories} />
 
-      <div className="bg-white dark:bg-gray-800 rounded-2xl shadow-lg border border-gray-100 dark:border-gray-700 p-6">
+      <div className="bg-white dark:bg-gray-800 rounded-lg border border-line dark:border-gray-700 p-6">
         <div className="flex flex-wrap items-start justify-between gap-2 mb-1">
-          <h2 className="text-lg font-semibold text-theme-heading dark:text-white">
+          <h2 className="text-card font-semibold text-theme-heading dark:text-white">
             {cumulative ? 'Income against spending, running totals' : 'Income against spending'}
           </h2>
           <div className="inline-flex rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 p-0.5">
@@ -256,9 +256,9 @@ export default function IncomeSpendingOverTimeReport({ picker, focus }: ReportVi
         )}
       </div>
 
-      <div className="bg-white dark:bg-gray-800 rounded-2xl shadow-lg border border-gray-100 dark:border-gray-700">
+      <div className="bg-white dark:bg-gray-800 rounded-lg border border-line dark:border-gray-700">
         <div className="p-6 pb-3">
-          <h2 className="text-lg font-semibold text-theme-heading dark:text-white">Month by month</h2>
+          <h2 className="text-card font-semibold text-theme-heading dark:text-white">Month by month</h2>
           <p className="text-sm text-gray-500 dark:text-gray-400 mt-1">
             {cumulative
               ? 'Running totals: every row is the period up to the end of that month.'

--- a/src/pages/reports/NetWorthStatementReport.tsx
+++ b/src/pages/reports/NetWorthStatementReport.tsx
@@ -69,10 +69,10 @@ export default function NetWorthStatementReport({ picker }: ReportViewProps): Re
     total: number,
     emptyText: string
   ): React.JSX.Element => (
-    <div className="bg-white dark:bg-gray-800 rounded-2xl shadow-lg border border-gray-100 dark:border-gray-700">
+    <div className="bg-white dark:bg-gray-800 rounded-lg border border-line dark:border-gray-700">
       <div className="flex items-baseline justify-between gap-3 p-6 pb-3">
-        <h2 className="text-lg font-semibold text-theme-heading dark:text-white">{title}</h2>
-        <span className="text-lg font-bold tabular-nums text-gray-900 dark:text-white">
+        <h2 className="text-card font-semibold text-theme-heading dark:text-white">{title}</h2>
+        <span className="text-card font-bold tabular-nums text-gray-900 dark:text-white">
           {formatCurrency(total)}
         </span>
       </div>

--- a/src/pages/reports/PeriodComparisonReport.tsx
+++ b/src/pages/reports/PeriodComparisonReport.tsx
@@ -208,17 +208,17 @@ export default function PeriodComparisonReport({ picker }: ReportViewProps): Rea
     goodWhen: 'up' | 'down',
     bucket: 'income' | 'expense' | null
   ): React.JSX.Element => (
-    <div className="bg-white dark:bg-gray-800 rounded-2xl shadow-lg border border-gray-100 dark:border-gray-700 p-6">
+    <div className="bg-white dark:bg-gray-800 rounded-lg border border-line dark:border-gray-700 p-6">
       <p className="text-xs text-gray-500 uppercase tracking-wider font-medium">{label}</p>
       {bucket === null ? (
-        <p className={`text-2xl font-bold mt-1 ${figure.current < 0 ? 'text-red-600 dark:text-red-400' : 'text-gray-900 dark:text-white'}`}>
+        <p className={`text-page font-bold mt-1 ${figure.current < 0 ? 'text-red-600 dark:text-red-400' : 'text-gray-900 dark:text-white'}`}>
           {money(figure.current)}
         </p>
       ) : (
         <button
           type="button"
           onClick={() => drillIntoSide(bucket, 'current', figure.current)}
-          className={`text-2xl font-bold mt-1 rounded hover:underline ${
+          className={`text-page font-bold mt-1 rounded hover:underline ${
             bucket === 'income' ? 'text-green-700 dark:text-green-400' : 'text-red-600 dark:text-red-400'
           }`}
           title={`${label} — view these transactions`}
@@ -294,7 +294,7 @@ export default function PeriodComparisonReport({ picker }: ReportViewProps): Rea
       </div>
 
       {ranges === null || comparison === null ? (
-        <div className="bg-white dark:bg-gray-800 rounded-2xl shadow-lg border border-gray-100 dark:border-gray-700 p-10 text-center">
+        <div className="bg-white dark:bg-gray-800 rounded-lg border border-line dark:border-gray-700 p-10 text-center">
           <p className="text-gray-500 dark:text-gray-400">
             This report needs a period with a start date to compare against.
           </p>
@@ -324,8 +324,8 @@ export default function PeriodComparisonReport({ picker }: ReportViewProps): Rea
             {summaryCard('Left over', comparison.net, 'up', null)}
           </div>
 
-          <div className="bg-white dark:bg-gray-800 rounded-2xl shadow-lg border border-gray-100 dark:border-gray-700 p-6">
-            <h2 className="text-lg font-semibold text-theme-heading dark:text-white mb-1">
+          <div className="bg-white dark:bg-gray-800 rounded-lg border border-line dark:border-gray-700 p-6">
+            <h2 className="text-card font-semibold text-theme-heading dark:text-white mb-1">
               Biggest movers
             </h2>
             <p className="text-sm text-gray-500 dark:text-gray-400 mb-4">
@@ -390,9 +390,9 @@ export default function PeriodComparisonReport({ picker }: ReportViewProps): Rea
             )}
           </div>
 
-          <div className="bg-white dark:bg-gray-800 rounded-2xl shadow-lg border border-gray-100 dark:border-gray-700">
+          <div className="bg-white dark:bg-gray-800 rounded-lg border border-line dark:border-gray-700">
             <div className="p-6 pb-3">
-              <h2 className="text-lg font-semibold text-theme-heading dark:text-white">Category by category</h2>
+              <h2 className="text-card font-semibold text-theme-heading dark:text-white">Category by category</h2>
               <p className="text-sm text-gray-500 dark:text-gray-400 mt-1">
                 Click either figure to see the transactions behind it.
               </p>

--- a/src/pages/reports/SpendingByCategoryReport.tsx
+++ b/src/pages/reports/SpendingByCategoryReport.tsx
@@ -106,12 +106,12 @@ export default function SpendingByCategoryReport({ picker, focus }: ReportViewPr
 
       <UncategorisedReviewBand flows={flows} categories={categories} />
 
-      <div className="bg-white dark:bg-gray-800 rounded-2xl shadow-lg border border-gray-100 dark:border-gray-700 p-6">
+      <div className="bg-white dark:bg-gray-800 rounded-lg border border-line dark:border-gray-700 p-6">
         <div className="flex flex-wrap items-baseline justify-between gap-2 mb-1">
-          <h2 className="text-lg font-semibold text-theme-heading dark:text-white">
+          <h2 className="text-card font-semibold text-theme-heading dark:text-white">
             Where the money went
           </h2>
-          <span className="text-lg font-bold tabular-nums text-red-600 dark:text-red-400">
+          <span className="text-card font-bold tabular-nums text-red-600 dark:text-red-400">
             {formatCurrency(flows.expenses)}
           </span>
         </div>
@@ -154,9 +154,9 @@ export default function SpendingByCategoryReport({ picker, focus }: ReportViewPr
         )}
       </div>
 
-      <div className="bg-white dark:bg-gray-800 rounded-2xl shadow-lg border border-gray-100 dark:border-gray-700">
+      <div className="bg-white dark:bg-gray-800 rounded-lg border border-line dark:border-gray-700">
         <div className="p-6 pb-3">
-          <h2 className="text-lg font-semibold text-theme-heading dark:text-white">Every category</h2>
+          <h2 className="text-card font-semibold text-theme-heading dark:text-white">Every category</h2>
           <p className="text-sm text-gray-500 dark:text-gray-400 mt-1">
             Ranked by spend. Click any category to see its transactions.
           </p>

--- a/src/pages/reports/SpendingByPayeeReport.tsx
+++ b/src/pages/reports/SpendingByPayeeReport.tsx
@@ -122,12 +122,12 @@ export default function SpendingByPayeeReport({ picker }: ReportViewProps): Reac
 
       <UncategorisedReviewBand flows={flows} categories={categories} />
 
-      <div className="bg-white dark:bg-gray-800 rounded-2xl shadow-lg border border-gray-100 dark:border-gray-700 p-6">
+      <div className="bg-white dark:bg-gray-800 rounded-lg border border-line dark:border-gray-700 p-6">
         <div className="flex flex-wrap items-baseline justify-between gap-2 mb-1">
-          <h2 className="text-lg font-semibold text-theme-heading dark:text-white">
+          <h2 className="text-card font-semibold text-theme-heading dark:text-white">
             {side === 'income' ? 'Biggest sources' : 'Biggest payees'}
           </h2>
-          <span className={`text-lg font-bold tabular-nums ${
+          <span className={`text-card font-bold tabular-nums ${
             side === 'income' ? 'text-green-700 dark:text-green-400' : 'text-red-600 dark:text-red-400'
           }`}>
             {money(totals.total)}
@@ -184,9 +184,9 @@ export default function SpendingByPayeeReport({ picker }: ReportViewProps): Reac
         )}
       </div>
 
-      <div className="bg-white dark:bg-gray-800 rounded-2xl shadow-lg border border-gray-100 dark:border-gray-700">
+      <div className="bg-white dark:bg-gray-800 rounded-lg border border-line dark:border-gray-700">
         <div className="p-6 pb-3">
-          <h2 className="text-lg font-semibold text-theme-heading dark:text-white">Every payee</h2>
+          <h2 className="text-card font-semibold text-theme-heading dark:text-white">Every payee</h2>
           <p className="text-sm text-gray-500 dark:text-gray-400 mt-1">
             Ranked by value, with the category each payee is usually filed under.
           </p>

--- a/src/pages/settings/DataManagement.tsx
+++ b/src/pages/settings/DataManagement.tsx
@@ -324,7 +324,7 @@ export default function DataManagementSettings() {
                   revoked now, and revoking means re-authorising with the bank,
                   which is a consequence somebody deserves to know BEFORE they
                   type the word rather than when they next open the page. */}
-              <li>every bank connection, which you would need to set up again</li>
+              <li>every bank connection, which you would need to authorise again</li>
             </ul>
             <p className="text-sm font-semibold text-red-600 dark:text-red-400 mb-4">
               This action cannot be undone!

--- a/src/services/api/dataService.ts
+++ b/src/services/api/dataService.ts
@@ -1435,14 +1435,19 @@ class DataServiceImpl implements DataPort {
       // Through `disconnect` rather than a SQL delete of our own, so there is
       // ONE path that removes a connection and both callers take it.
       //
-      // ⚠️ It deletes the `bank_connections` row and NOTHING ELSE. There is no
-      // provider-side revocation anywhere in `api/banking/` — checked — so
-      // after this the app has forgotten the bank and the bank has not
-      // forgotten the app. That is enough to stop the resurrection this fixes,
-      // and it is NOT the same as withdrawing consent. Anyone reading this
-      // while adding a "revoke at the provider" step: it belongs in
-      // `api/banking/disconnect.ts`, so the single-connection delete on the
-      // Open Banking page gets it too.
+      // It revokes at TrueLayer and then deletes the `bank_connections` row.
+      //
+      // The revocation was added afterwards, and the gap is worth remembering:
+      // for a while this deleted the row and nothing else, so the app forgot
+      // the bank and the bank did not forget the app — while the dialog said
+      // "you would need to re-authorise", which implied the stronger thing.
+      // The revocation lives in the ENDPOINT rather than here, so the
+      // single-connection delete on the Open Banking page gets it too.
+      //
+      // A provider that refuses does not block the disconnect: the row goes
+      // either way, because a connection left standing is what recreates the
+      // accounts. `revokedAtProvider` on the response is how a caller tells a
+      // full disconnection from a local one.
       //
       // Failures are collected and thrown at the END: one bank refusing must
       // not leave the others connected, and the wipe of the ledger above has

--- a/src/types/banking-api.ts
+++ b/src/types/banking-api.ts
@@ -157,6 +157,18 @@ export interface DisconnectRequest {
 
 export interface DisconnectResponse {
   success: boolean;
+  /**
+   * Whether the PROVIDER accepted the revocation, as distinct from whether we
+   * forgot the connection.
+   *
+   * The two used to be the same thing said once, and the thing being said was
+   * the weaker of them: `disconnect` deleted our row and never touched
+   * TrueLayer, so the app forgot the bank and the bank did not forget the app.
+   * The row delete still always happens — a connection left standing recreates
+   * its accounts on the next sync — so this is how a caller can tell a full
+   * disconnection from a local one.
+   */
+  revokedAtProvider?: boolean;
   error?: string;
 }
 


### PR DESCRIPTION
Both of the things you said 'do it' to.

## The disconnect now reaches TrueLayer

`api/banking/disconnect.ts` deleted our own row and nothing else — the app forgot the bank, the bank didn't forget the app. Defensible to ship, indefensible to *imply*, and the wording around it implied the stronger thing.

`revokeAccessToken` calls `DELETE /data/v1/me`, which revokes the token and the consent behind it. It's in the **endpoint**, not the wipe, so the single-connection delete on the Open Banking page gets it too — the wipe was never the only caller.

Three decisions worth your eye:

- **Read, revoke, then delete.** The token lives in the row, so revoking after deleting is impossible.
- **A refusal doesn't block the disconnect.** The row goes either way — a connection left standing is what recreates the accounts, which is the bug this whole thread started with. A provider that's down mustn't trap someone in a connection they've asked to leave.
- **401 and 403 count as success.** The token is already dead, which is the state we were asking for.

`revokedAtProvider` on the response is how a caller tells a full disconnection from a local one; those used to be one field saying the weaker thing. The dialog goes back to "authorise again", which is true now.

## The twelve report sub-pages

Design's advice was a grep rather than an audit, and it held: **seven files needed items 1 and 4**, eleven cards of a single pattern, no rulings required.

Their two extra checks — the ones a class-name pass can't see — both came back **clean**, which is worth recording rather than leaving as silence:

- **No `text-white/` leftovers.** Nothing here had a navy slab to lose, so no colour was orphaned by a changed ground.
- **No hidden early returns.** The four `return (` matches are all inside `.map()`, not branches a grep would sail past.

And the §2.1 colour check is clean for a reason worth naming rather than assuming: the green and red still in these tables sit on columns headed **In** and **Out**, and on `change`. That's income against expense, and a delta — exactly what those hues mean everywhere else in the app. The ban was never on the hues; it was on spending them where they mean nothing.

6030 tests pass, lint and typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)