### PR TITLE
Add Account asks for an opening balance, and when it was true

### DIFF
--- a/src/components/AddAccountModal.test.tsx
+++ b/src/components/AddAccountModal.test.tsx
@@ -33,8 +33,11 @@ const renderModal = (props: Partial<AddAccountModalProps> = {}) =>
  * The balance is a MoneyInput, which renders `type="text"` + `inputMode="decimal"`,
  * so it is a `textbox` rather than a `spinbutton`.
  */
-const nameField = () => screen.getByRole('textbox', { name: /Account Name/ });
-const balanceField = () => screen.getByRole('textbox', { name: /Current Balance/ });
+// Case-insensitive since 15 August: the labels moved to sentence case
+// ("Account name", "Opening balance") so they read like the rest of the app
+// and like the new "Opening balance as of" beside them.
+const nameField = () => screen.getByRole('textbox', { name: /Account Name/i });
+const balanceField = () => screen.getByRole('textbox', { name: /Opening balance$/i });
 const submitButton = () => screen.getByRole('button', { name: 'Add Account' });
 
 /** Fill in the name and balance the form requires, then choose Credit Card. */
@@ -130,7 +133,7 @@ describe('AddAccountModal — every field is announced by its visible label', ()
 
     expect(nameField()).toBeInTheDocument();
     expect(balanceField()).toBeInTheDocument();
-    expect(screen.getByRole('combobox', { name: /Currency/ })).toBeInTheDocument();
+    expect(screen.getByRole('combobox', { name: /Currency/i })).toBeInTheDocument();
     expect(screen.getByRole('textbox', { name: /Financial Institution/ })).toBeInTheDocument();
     // These two carry an explicit aria-label, which wins over the visible
     // label, so they are named by it rather than by the label text.
@@ -141,9 +144,9 @@ describe('AddAccountModal — every field is announced by its visible label', ()
   it('derives each accessible name from a visible label, not an aria-label', () => {
     renderModal();
 
-    expectVisibleLabel(nameField(), /Account Name/);
-    expectVisibleLabel(balanceField(), /Current Balance/);
-    expectVisibleLabel(screen.getByRole('combobox', { name: /Currency/ }), /Currency/);
+    expectVisibleLabel(nameField(), /Account Name/i);
+    expectVisibleLabel(balanceField(), /Opening balance$/i);
+    expectVisibleLabel(screen.getByRole('combobox', { name: /Currency/i }), /Currency/i);
     expectVisibleLabel(screen.getByRole('textbox', { name: /Financial Institution/ }), /Financial Institution/);
   });
 
@@ -208,7 +211,7 @@ describe('AddAccountModal — the account type buttons are a labelled group', ()
   it('labels the group and reports the selected type', () => {
     renderModal();
 
-    const group = screen.getByRole('group', { name: /Account Type/ });
+    const group = screen.getByRole('group', { name: /Account Type/i });
     expect(within(group).getByRole('button', { name: /Current Account/ })).toHaveAttribute('aria-pressed', 'true');
     expect(within(group).getByRole('button', { name: /Savings Account/ })).toHaveAttribute('aria-pressed', 'false');
   });
@@ -216,7 +219,7 @@ describe('AddAccountModal — the account type buttons are a labelled group', ()
   it('moves the pressed state when another type is chosen', () => {
     renderModal();
 
-    const group = screen.getByRole('group', { name: /Account Type/ });
+    const group = screen.getByRole('group', { name: /Account Type/i });
     fireEvent.click(within(group).getByRole('button', { name: /Savings Account/ }));
 
     expect(within(group).getByRole('button', { name: /Savings Account/ })).toHaveAttribute('aria-pressed', 'true');
@@ -239,7 +242,7 @@ describe('AddAccountModal — submission', () => {
 
     fireEvent.change(nameField(), { target: { value: 'Everyday Current' } });
     fireEvent.change(balanceField(), { target: { value: '250.75' } });
-    fireEvent.change(screen.getByRole('combobox', { name: /Currency/ }), { target: { value: 'USD' } });
+    fireEvent.change(screen.getByRole('combobox', { name: /Currency/i }), { target: { value: 'USD' } });
     fireEvent.change(screen.getByRole('textbox', { name: /Financial Institution/ }), {
       target: { value: 'HSBC' }
     });
@@ -311,5 +314,82 @@ describe('AddAccountModal — submission', () => {
     fireEvent.change(balanceField(), { target: { value: 'abc' } });
 
     expect((balanceField() as HTMLInputElement).value).not.toContain('a');
+  });
+});
+
+/**
+ * THE OPENING BALANCE, AND WHEN IT WAS TRUE.
+ *
+ * The figure was labelled "Current Balance" and stored as `openingBalance`,
+ * dated `new Date()` — written silently and never shown. The register builds
+ * its running balance FORWARD from it (AccountTransactions.tsx), so the label
+ * and the behaviour disagreed in the one case that costs money: add an
+ * account, type what the bank says today, then import a year of history, and
+ * the year lands on top of a figure that already included it.
+ *
+ * The owner's ruling, 15 August: the field is the OPENING balance and says so,
+ * and the date it was true is a field rather than an assumption.
+ */
+describe('AddAccountModal — the opening balance', () => {
+  it('asks for an opening balance, not a current one', () => {
+    renderModal();
+
+    expect(screen.getByLabelText(/Opening balance$/i)).toBeInTheDocument();
+    // The old wording, which said one thing while the code stored another.
+    expect(screen.queryByLabelText(/Current Balance/i)).not.toBeInTheDocument();
+  });
+
+  it('defaults the as-of date to today, since that is right for a fresh account', () => {
+    renderModal();
+
+    // `DatePicker` shows dd/mm/yyyy, not the ISO value it holds — the app is
+    // en-GB and the field reads the way the rest of the app's dates do. The
+    // suite runs on a frozen clock, so "today" is read rather than assumed.
+    const today = new Date();
+    const dd = String(today.getDate()).padStart(2, '0');
+    const mm = String(today.getMonth() + 1).padStart(2, '0');
+    expect(screen.getByLabelText('Opening balance as of'))
+      .toHaveValue(`${dd}/${mm}/${today.getFullYear()}`);
+  });
+
+  it('saves the date the user chose rather than the moment the row was written', async () => {
+    renderModal();
+
+    fireEvent.change(nameField(), { target: { value: 'Imported Account' } });
+    // Typed the way a person types it, which is what the field accepts.
+    const asOf = screen.getByLabelText('Opening balance as of');
+    fireEvent.change(asOf, { target: { value: '06/04/2018' } });
+    fireEvent.blur(asOf);
+    fireEvent.click(submitButton());
+
+    await waitFor(() => expect(addAccount).toHaveBeenCalled());
+    const saved = addAccount.mock.calls[0][0] as { openingBalanceDate?: Date };
+    expect(saved.openingBalanceDate?.getFullYear()).toBe(2018);
+    expect(saved.openingBalanceDate?.getMonth()).toBe(3); // April
+    expect(saved.openingBalanceDate?.getDate()).toBe(6);
+  });
+
+  it('carries the typed figure into openingBalance, which is what the register reads', async () => {
+    renderModal();
+
+    fireEvent.change(nameField(), { target: { value: 'Opening Figure' } });
+    fireEvent.change(balanceField(), { target: { value: '1250.00' } });
+    fireEvent.click(submitButton());
+
+    await waitFor(() => expect(addAccount).toHaveBeenCalled());
+    expect(addAccount.mock.calls[0][0]).toMatchObject({
+      balance: 1250,
+      openingBalance: 1250,
+    });
+  });
+
+  it('marks nothing with an asterisk, since the optional fields say so themselves', () => {
+    // Two conventions for one question (Claude Design, item 4): `*` on the
+    // required ones AND `(Optional)` on the rest. `(Optional)` is the plainer
+    // and needs no legend, so the stars go.
+    const { container } = renderModal();
+    expect(container.textContent).not.toContain('Name *');
+    expect(container.textContent).not.toContain('Type *');
+    expect(container.textContent).not.toContain('Currency *');
   });
 });

--- a/src/components/AddAccountModal.tsx
+++ b/src/components/AddAccountModal.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useMemo, useState } from 'react';
+import DatePicker from './common/DatePicker';
 import { useApp } from '../contexts/AppContextSupabase';
 import { usePreferences } from '../contexts/PreferencesContext';
 import { Modal, ModalBody, ModalFooter } from './common/Modal';
@@ -43,6 +44,8 @@ interface AccountFormData {
   institution: string;
   sortCode: string;
   accountNumber: string;
+  /** yyyy-mm-dd, the date the opening balance was true. */
+  openingBalanceDate: string;
 }
 
 const accountTypes = [
@@ -59,6 +62,14 @@ const accountTypes = [
 // account was made. See constants/accountCurrencies.
 const currencies = ACCOUNT_CURRENCIES;
 
+/** Today as yyyy-mm-dd, which is what a date input speaks. */
+const todayForInput = (): string => {
+  const now = new Date();
+  const month = String(now.getMonth() + 1).padStart(2, '0');
+  const day = String(now.getDate()).padStart(2, '0');
+  return `${now.getFullYear()}-${month}-${day}`;
+};
+
 export default function AddAccountModal({ isOpen, onClose, prefill, onAccountCreated }: AddAccountModalProps): React.JSX.Element {
   const { addAccount } = useApp();
   const { currency: defaultCurrency } = usePreferences();
@@ -72,7 +83,8 @@ export default function AddAccountModal({ isOpen, onClose, prefill, onAccountCre
     currency: defaultCurrency,
     institution: '',
     sortCode: '',
-    accountNumber: ''
+    accountNumber: '',
+    openingBalanceDate: todayForInput()
   });
 
   // Reset form when modal opens (seed from prefill if provided)
@@ -86,6 +98,7 @@ export default function AddAccountModal({ isOpen, onClose, prefill, onAccountCre
         institution: prefill?.institution ?? '',
         sortCode: prefill?.sortCode ? formatSortCode(prefill.sortCode) : '',
         accountNumber: prefill?.accountNumber ?? '',
+        openingBalanceDate: todayForInput(),
       });
       setError(null);
       setIsSubmitting(false);
@@ -144,7 +157,10 @@ export default function AddAccountModal({ isOpen, onClose, prefill, onAccountCre
         institution: formData.institution.trim() || undefined,
         lastUpdated: new Date(),
         openingBalance: balance,
-        openingBalanceDate: new Date(),
+        // The date the user gave, not the moment the row was written.
+        openingBalanceDate: formData.openingBalanceDate
+          ? new Date(formData.openingBalanceDate)
+          : new Date(),
         isActive: true,
         sortCode: rawSortCode || undefined,
         // A card is created holding its last 4 digits and nothing else — the
@@ -167,6 +183,9 @@ export default function AddAccountModal({ isOpen, onClose, prefill, onAccountCre
         institution: '',
         sortCode: '',
         accountNumber: '',
+        // Back to today, not to whatever the last account used: the next
+        // account is a different account.
+        openingBalanceDate: todayForInput(),
       });
       setIsSubmitting(false);
 
@@ -211,7 +230,7 @@ export default function AddAccountModal({ isOpen, onClose, prefill, onAccountCre
             {/* Account Name */}
             <div>
               <label htmlFor="add-account-name" className="block text-sm font-semibold text-gray-700 dark:text-gray-200 mb-2">
-                Account Name *
+                Account name
               </label>
               <input
                 id="add-account-name"
@@ -230,7 +249,7 @@ export default function AddAccountModal({ isOpen, onClose, prefill, onAccountCre
             <div>
               {/* Not a <label>: the control is a group of buttons, not a single input */}
               <span id="add-account-type-label" className="block text-sm font-semibold text-gray-700 dark:text-gray-200 mb-2">
-                Account Type *
+                Account type
               </span>
               <div role="group" aria-labelledby="add-account-type-label" className="grid grid-cols-2 gap-3">
                 {accountTypes.map((type) => {
@@ -282,7 +301,7 @@ export default function AddAccountModal({ isOpen, onClose, prefill, onAccountCre
               {/* Current Balance */}
               <div>
                 <label htmlFor="add-account-balance" className="block text-sm font-semibold text-gray-700 dark:text-gray-200 mb-2">
-                  Current Balance *
+                  Opening balance
                 </label>
                 <div className="relative">
                   <span className="absolute left-4 top-1/2 -translate-y-1/2 text-gray-500 dark:text-gray-400 font-medium">
@@ -308,7 +327,7 @@ export default function AddAccountModal({ isOpen, onClose, prefill, onAccountCre
               {/* Currency */}
               <div>
                 <label htmlFor="add-account-currency" className="block text-sm font-semibold text-gray-700 dark:text-gray-200 mb-2">
-                  Currency *
+                  Currency
                 </label>
                 <select
                   id="add-account-currency"
@@ -351,6 +370,39 @@ export default function AddAccountModal({ isOpen, onClose, prefill, onAccountCre
                   disabled={isSubmitting}
                 />
               </div>
+            </div>
+
+            {/* ─ WHEN THE OPENING BALANCE APPLIES ────────────────────────────
+                This was written silently as `new Date()` and never shown, so
+                every account's opening balance was dated the day it was created
+                whether or not that was true.
+
+                It matters because the register builds its running balance
+                FORWARD from this figure (AccountTransactions.tsx). Add an
+                account, type what the bank says today, then import a year of
+                history into it, and the year lands ON TOP of a figure that
+                already included it.
+
+                Today is still the default — it is right for an account you are
+                starting fresh — but it is now a default rather than a fact,
+                and somebody importing history can set it to before their
+                earliest transaction, which is what makes the running balance
+                mean anything. */}
+            <div>
+              <label htmlFor="add-account-opening-date" className="block text-sm font-semibold text-gray-700 dark:text-gray-200 mb-2">
+                Opening balance as of
+              </label>
+              <DatePicker
+                id="add-account-opening-date"
+                value={formData.openingBalanceDate}
+                onChange={(value) => updateField('openingBalanceDate', value)}
+                aria-label="Opening balance as of"
+                className="w-full px-4 py-3 bg-white dark:bg-gray-800 border-2 border-gray-200 dark:border-gray-700 rounded-xl focus:border-primary dark:text-white transition-all duration-200"
+              />
+              <p className="mt-2 text-xs text-gray-500 dark:text-gray-400">
+                The date that balance was true. If you are about to import older
+                transactions, set this to before the earliest of them.
+              </p>
             </div>
 
             {/* Bank details: sort code + account number for a UK bank account,

--- a/src/utils/openingDates.test.ts
+++ b/src/utils/openingDates.test.ts
@@ -130,3 +130,56 @@ describe('resolveEffectiveOpeningDates — one pass over a multi-account fixture
     expect(map.get('a')).toEqual(D(2021, 6, 6));
   });
 });
+
+/**
+ * THE OWNER'S SPECIFICATION, 15 August 2026, as one story.
+ *
+ * The rungs above are tested individually. This walks the sequence he
+ * described, because the point of it is that each step follows from the last
+ * without anyone writing a date anywhere:
+ *
+ *   "Editable date but defaults to today. If the user does not change the date
+ *    then in the register the opening balance of x gets placed with today's
+ *    date. If the user then goes to edit the account settings and changes the
+ *    opening date, I want the register to change with it, or the opening value
+ *    if the user changes that. If the user imports transactions and the
+ *    earliest transaction imported is earlier than the currently held opening
+ *    date then the opening date gets changed automatically to the same date as
+ *    that first imported transaction."
+ *
+ * All of it holds, and holds by DERIVATION rather than storage: the register
+ * asks this resolver on every render, so an edit in Account Settings is
+ * followed because nothing cached it, and an import moves the date because the
+ * clamp recomputes rather than because anything rewrote the column. A stored
+ * answer would have needed a migration AND a backfill AND would drift the
+ * first time a transaction was deleted.
+ */
+describe('the opening date through an account’s life', () => {
+  const TODAY = D(2026, 8, 15);
+
+  it('sits on today for a fresh account nobody has imported into', () => {
+    const acc = account({ id: 'a', name: 'New', openingBalanceDate: TODAY });
+    expect(effectiveOpeningDate(acc, undefined, undefined)).toEqual(TODAY);
+  });
+
+  it('follows the account settings when the date is edited', () => {
+    // Nothing cached it, so "follows" is not a feature — it is the absence of
+    // one. The register reads the account on every render.
+    const edited = account({ id: 'a', name: 'New', openingBalanceDate: D(2018, 4, 6) });
+    expect(effectiveOpeningDate(edited, undefined, undefined)).toEqual(D(2018, 4, 6));
+  });
+
+  it('moves itself back when an import lands earlier than it', () => {
+    const acc = account({ id: 'a', name: 'New', openingBalanceDate: TODAY });
+    // A year of history imported, earliest 2 January.
+    expect(effectiveOpeningDate(acc, D(2026, 1, 2), undefined)).toEqual(D(2026, 1, 2));
+  });
+
+  it('stays put when the import is all LATER than the opening date', () => {
+    // The clamp only ever pulls backwards. An opening balance dated before the
+    // history is a legitimate statement — it is where the running balance
+    // starts — and moving it forward would silently drop the gap.
+    const acc = account({ id: 'a', name: 'New', openingBalanceDate: D(2018, 4, 6) });
+    expect(effectiveOpeningDate(acc, D(2020, 1, 1), undefined)).toEqual(D(2018, 4, 6));
+  });
+});


### PR DESCRIPTION
Your call, implemented — plus a finding that makes it smaller than expected.

## The problem it fixes

The field said **"Current Balance"** and the code stored `openingBalance`, dated `new Date()` — written silently, never shown. The register builds its running balance **forward** from that figure (`AccountTransactions.tsx:1048`).

So the label and the behaviour disagreed in the one case that costs money: add an account, type what the bank says today, then import a year of history — and the year lands on top of a figure that already included it.

It now says **Opening balance**, with **Opening balance as of** beside it. Today is still the default (right for an account you're starting fresh) but it's a default rather than a fact, and anyone importing history can set it before their earliest transaction.

## Your four rules already held

> *"If the user does not change the date then in the register the opening balance of x gets placed with today's date. If the user then goes to edit the account settings and changes the opening date, I want the register to change with it, or the opening value if the user changes that. If the user imports transactions and the earliest transaction imported is earlier than the currently held opening date then the opening date gets changed automatically…"*

All four. `effectiveOpeningDate` has carried these rules since it was written — including the clamp that pulls an explicit date back to the first transaction — and the register calls it **on every render**.

Which is why the settings edit is followed: **nothing cached it**. And why the import moves the date: the clamp *recomputes* rather than anything rewriting a column.

That's worth saying plainly, because it's the difference between a small change and a large one. A **stored** answer would have needed a migration, a backfill, and would have drifted the first time a transaction was deleted. Derivation was already the right shape — the only thing missing was the field.

I've pinned your sequence as one named test anyway. The rungs were each covered; the *sequence* wasn't, and the sequence is what you're relying on.

## Also, Design's item 4

The asterisks are gone. The form marked required fields with `*` **and** optional ones with `(Optional)` — two systems for one question. `(Optional)` is the plainer and needs no legend. Labels move to sentence case while they're being edited, so they read like "Opening balance as of" beside them.

Two test helpers matched `/Account Name/` case-sensitively and one asserted the old label — relaxed and repointed, rather than reverting the labels.

6039 tests pass, lint and typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)