### PR TITLE
The icon pass reaches the last of them, and three spacing fixes

### DIFF
--- a/src/components/SubscriptionStatus.tsx
+++ b/src/components/SubscriptionStatus.tsx
@@ -313,39 +313,14 @@ export default function SubscriptionStatus(): React.JSX.Element {
         </div>
       </div>
 
-      {/* Upgrade Options */}
-      {tier === 'free' && (
-        <div className="bg-gradient-to-r from-blue-50 to-purple-50 dark:from-blue-900/20 dark:to-purple-900/20 rounded-lg p-6">
-          <h3 className="text-lg font-semibold text-gray-900 dark:text-white mb-2">
-            Unlock Premium Features
-          </h3>
-          <p className="text-sm text-gray-600 dark:text-gray-400 mb-4">
-            Upgrade to Pro or Business to access unlimited accounts, bank sync, advanced analytics, and more.
-          </p>
-          <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
-            <div className="bg-white dark:bg-gray-800 rounded-lg p-4">
-              <div className="flex items-center gap-2 mb-2">
-                <CrownIcon size={20} className="text-blue-600" />
-                <span className="font-medium text-gray-900 dark:text-white">Pro</span>
-                <span className="text-sm text-gray-500">£9.99/mo</span>
-              </div>
-              <p className="text-xs text-gray-600 dark:text-gray-400">
-                Perfect for individuals managing personal finances
-              </p>
-            </div>
-            <div className="bg-white dark:bg-gray-800 rounded-lg p-4">
-              <div className="flex items-center gap-2 mb-2">
-                <UsersIcon size={20} className="text-purple-600" />
-                <span className="font-medium text-gray-900 dark:text-white">Business</span>
-                <span className="text-sm text-gray-500">£24.99/mo</span>
-              </div>
-              <p className="text-xs text-gray-600 dark:text-gray-400">
-                Ideal for small businesses and freelancers
-              </p>
-            </div>
-          </div>
-        </div>
-      )}
+      {/* The "Unlock Premium Features" block was here, and it is gone on the
+          owner's ruling. Two reasons, and the second is the one that matters:
+          it duplicated the Upgrade buttons six inches above it, and it
+          advertised a BUSINESS tier at £24.99 "ideal for small businesses and
+          freelancers" — a plan this product does not sell and is not built to
+          be. Naming a price for something that does not exist is the same
+          offence as a dead toggle, in a place where somebody might get out a
+          card. */}
     </div>
   );
 }

--- a/src/pages/Accounts.tsx
+++ b/src/pages/Accounts.tsx
@@ -25,7 +25,6 @@ import { preferences } from '../services/preferencesService';
 // Bank connection management lives on this page (the natural home for it);
 // the Data Management page keeps only its URL-driven deep links for ops alerts.
 import type { Account } from '../types';
-import { ALL_ACCOUNT_SECTIONS } from '../utils/accountSections';
 import {
   groupAccountsForDisplay,
   parseAccountGroupingPreference,
@@ -590,11 +589,6 @@ export default function Accounts() {
     displayCurrency,
     groupCurrencyEntries
   );
-
-  // The shared account-type sections (same groupings everywhere), catch-all
-  // last — a type without a section renders under "Other Accounts", never
-  // nowhere.
-  const accountTypes = ALL_ACCOUNT_SECTIONS;
 
   // Each switch flips on its own: both on nests, both off flattens.
   const handleGroupingChange = (next: AccountGroupingOptions) => {
@@ -1705,16 +1699,17 @@ export default function Accounts() {
     );
   };
 
-  // The band's own glyph: its section's icon and colour for a type band, the
-  // bank mark for an institution band.
-  const bandHeadingIcon = (group: AccountDisplayGroup<Account>): ReactNode => {
-    if (group.kind === 'institution') {
-      return <BankIcon className="text-[#1a2332] dark:text-gray-400" size={20} />;
-    }
-    const section = accountTypes.find(t => t.type === group.label);
-    const Icon = section?.icon ?? WalletIcon;
-    return <Icon className={section?.color ?? 'text-gray-600'} size={20} />;
-  };
+  // The band heading's glyph went on 15 August, with the rest of the app's
+  // per-row icons (#296, #302, and the Accounts row's own in #281). The
+  // argument is the one that has held every time: a wallet beside "CURRENT
+  // ACCOUNTS", above rows that are all current accounts, names the band a
+  // second time in a picture. The owner: "everywhere else we have taken them
+  // away has looked better."
+  //
+  // It also cost the alignment. With the glyph gone, a section heading and the
+  // institution heading below it now begin at the same x — chevron, name,
+  // count — and their totals land in the same column as the account figures,
+  // which is what he asked for and what the icon was quietly preventing.
 
   // ONE renderer for every banded view: a heading that folds the band away,
   // and — when open — either the account cards or, with both switches on, the
@@ -1824,7 +1819,6 @@ export default function Accounts() {
                 size={16}
                 className={`flex-shrink-0 text-gray-400 transition-transform duration-200 ${isExpanded ? 'rotate-90' : ''}`}
               />
-              {bandHeadingIcon(group)}
               {/* THE NAME OUTRANKS THE FIGURE HERE, and it took two goes to
                   believe it. P1 said a band's name is a label for its total,
                   so the label was set one step under the money — 14px word,

--- a/src/pages/Budget.tsx
+++ b/src/pages/Budget.tsx
@@ -358,12 +358,13 @@ export default function Budget() {
         <div className="bg-white dark:bg-gray-800 rounded-lg border border-line dark:border-gray-700 p-6">
           <div className="flex items-center justify-between">
             <div>
+              {/* No banknote. See the Investments summary cards — a picture of
+                  money beside a money figure is the label twice. */}
               <p className="text-gray-600 dark:text-gray-400 text-body">Total Budgeted</p>
               <p className="text-page font-bold text-gray-900 dark:text-white">
                 {isLoading ? <SkeletonText className="w-32 h-8" /> : totalBudgeted}
               </p>
             </div>
-            <BanknoteIcon className="text-gray-400" size={24} />
           </div>
         </div>
 

--- a/src/pages/Investments.tsx
+++ b/src/pages/Investments.tsx
@@ -471,13 +471,16 @@ export default function Investments() {
         <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6">
         <div className="bg-white dark:bg-gray-800 rounded-lg border border-line dark:border-gray-700 p-6">
           <div className="flex items-center justify-between">
+            {/* No glyph. A bar chart beside "Portfolio Value" says the word
+                again in a picture; the arrows on Total Return and Return %
+                below stay, because those carry DIRECTION and a direction is
+                not decoration. Same reduction as #281 and #296. */}
             <div>
               <p className="text-body text-gray-500 dark:text-gray-400">Portfolio Value</p>
               <p className="text-page font-bold text-gray-900 dark:text-white">
                 {formatCurrency(summary.value)}
               </p>
             </div>
-            <BarChart3Icon className="text-primary" size={24} />
           </div>
         </div>
 
@@ -492,7 +495,6 @@ export default function Investments() {
                 Transferred in, less transferred out
               </p>
             </div>
-            <BarChart3Icon className="text-blue-500" size={24} />
           </div>
         </div>
 

--- a/src/pages/OpenBanking.tsx
+++ b/src/pages/OpenBanking.tsx
@@ -4,7 +4,7 @@ import { useAuth as useClerkAuth } from '@clerk/clerk-react';
 import PageWrapper from '../components/PageWrapper';
 import { bankConnectionService } from '../services/bankConnectionService';
 import type { BankConnection } from '../services/bankConnectionService';
-import { BankIcon, ShieldIcon, CheckCircleIcon, RefreshCwIcon, TrashIcon, AlertCircleIcon, LinkIcon } from '../components/icons';
+import { ShieldIcon, CheckCircleIcon, RefreshCwIcon, TrashIcon, AlertCircleIcon, LinkIcon } from '../components/icons';
 import LinkBankAccountsModal from '../components/banking/LinkBankAccountsModal';
 
 type ConnectStatus = 'idle' | 'connecting' | 'error';
@@ -165,10 +165,14 @@ export default function OpenBanking() {
         <div className="bg-white dark:bg-gray-800 rounded-lg shadow-md p-6">
           <div className="flex items-center justify-between">
             <div>
+              {/* No glyph on any of the three. A bank beside "Connected
+                  Banks" and a tick beside "Synced Accounts" restate the label
+                  in a picture; the figure is the content. Removed all three
+                  rather than two, so the row does not become one card with an
+                  icon and two without. */}
               <p className="text-sm text-gray-600 dark:text-gray-400">Connected Banks</p>
               <p className="text-page font-semibold text-gray-900 dark:text-white">{connectedCount}</p>
             </div>
-            <BankIcon size={32} className="text-blue-600" />
           </div>
         </div>
         <div className="bg-white dark:bg-gray-800 rounded-lg shadow-md p-6">
@@ -177,7 +181,6 @@ export default function OpenBanking() {
               <p className="text-sm text-gray-600 dark:text-gray-400">Synced Accounts</p>
               <p className="text-page font-semibold text-gray-900 dark:text-white">{totalAccounts}</p>
             </div>
-            <CheckCircleIcon size={32} className="text-blue-600" />
           </div>
         </div>
         <div className="bg-white dark:bg-gray-800 rounded-lg shadow-md p-6">
@@ -186,7 +189,6 @@ export default function OpenBanking() {
               <p className="text-sm text-gray-600 dark:text-gray-400">Security Status</p>
               <p className="text-lg font-semibold text-blue-600">Secured</p>
             </div>
-            <ShieldIcon size={32} className="text-blue-600" />
           </div>
         </div>
       </div>
@@ -354,7 +356,13 @@ export default function OpenBanking() {
           <ShieldIcon size={24} className="text-blue-600" />
           <h3 className="text-card font-semibold text-gray-900 dark:text-white">Bank-Level Security</h3>
         </div>
-        <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+        {/* Capped and gutter-ed. The card is the full page width and these are
+            two SHORT lists, so a plain 50/50 grid put "Data Protection" hard
+            against the left edge, "Privacy First" at exactly halfway, and half
+            a screen of nothing to the right of it — which reads as a column
+            that failed to load rather than as margin. Constraining the pair
+            makes the leftover space obviously the page's, not the layout's. */}
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-8 md:gap-16 max-w-3xl">
           <div>
             <h4 className="font-medium mb-2 text-gray-900 dark:text-white">Data Protection</h4>
             <ul className="space-y-1 text-sm text-gray-600 dark:text-gray-400">

--- a/src/pages/reports/ReportGallery.tsx
+++ b/src/pages/reports/ReportGallery.tsx
@@ -30,12 +30,22 @@ export default function ReportGallery(): React.JSX.Element {
   const location = useLocation();
 
   return (
-    <div className="space-y-8">
+    <div className="space-y-14">
+      {/* space-y-14, not 8. The groups are "What I have", "Spending" and
+          "Custom reports", and at 32px the gap between two GROUPS was barely
+          bigger than the 16px gap between two cards inside one — so the page
+          read as eleven cards in a stack rather than as three answers to three
+          different questions. The heading is what separates them; it needs
+          room to be seen doing it.
+
+          (A JSX comment cannot sit between `return (` and the element. Fourth
+          time this has bitten today — it is always the same shape: one
+          expression slot, and a comment is an expression.) */}
       {REPORT_GROUPS.map(group => {
         const reports = reportsInGroup(group.id);
         return (
           <section key={group.id} aria-labelledby={`report-group-${group.id}`}>
-            <div className="mb-3">
+            <div className="mb-4">
               <h2
                 id={`report-group-${group.id}`}
                 className="text-card font-semibold text-gray-900 dark:text-white"


### PR DESCRIPTION
Items 5 to 11. **Stacked on [#305](https://github.com/steveg1983/wealthtracker-pro/pull/305)** — merge that first and this retargets to main.

## The icons (5, 6, 7, 9)

Your argument, which has now held four times running: *"everywhere else we have taken them away has looked better."*

- **Account band headings.** A wallet beside "CURRENT ACCOUNTS", above rows that are all current accounts, names the band a second time in a picture. It was also costing the **alignment** — with the glyph gone, a section heading and the institution heading below it begin at the same x, so their totals land in the same column as the account figures. That's the second half of what you asked for, and the icon was quietly preventing it.
- **Portfolio Value and Net Contributions.** The arrows on Total Return and Return % **stay** — those carry direction, and a direction isn't decoration.
- **Open Banking's stat cards.** All three, not the two you named: one card with an icon and two without is worse than either.
- **Budget's Total Budgeted.** A picture of money beside a money figure.

## The spacing (8, 10)

**Bank-Level Security** was a plain 50/50 grid in a full-width card holding two short lists — so "Data Protection" sat hard against the left edge, "Privacy First" at exactly halfway, and half a screen of nothing to the right of it. That reads as a column that failed to load rather than as margin. Capped and gutter-ed so the leftover space is obviously the page's.

**The reports gallery** ran `space-y-8` between *groups* against `gap-4` between cards *inside* one — so eleven cards read as a stack rather than as three answers to three different questions. The heading is what separates them; it needed room to be seen doing it.

## And one removal (11)

**"Unlock Premium Features"** is gone. It duplicated the Upgrade buttons six inches above it, and it advertised a **Business tier at £24.99** "ideal for small businesses and freelancers" — a plan this product doesn't sell. Naming a price for something that doesn't exist is the same offence as a dead toggle, in a place where somebody might get out a card.

`bandHeadingIcon`, its `accountTypes` alias and the `ALL_ACCOUNT_SECTIONS` import went with it — lint found each one, one layer at a time.

6039 tests pass, lint and typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
