### PR TITLE
Two amber panels that failed AA, and one that was the wrong category

### DIFF
--- a/src/components/SubscriptionStatus.tsx
+++ b/src/components/SubscriptionStatus.tsx
@@ -3,6 +3,7 @@ import { CheckIcon, AlertCircleIcon, CreditCardIcon, CrownIcon, ZapIcon, UsersIc
 import { useSubscription } from '../contexts/SubscriptionContext';
 import { formatDistanceToNow } from 'date-fns';
 import { createScopedLogger } from '../loggers/scopedLogger';
+import { NEXT_ACTION_YELLOW } from './reconciliation/nextActionYellow';
 
 interface PlanFeature {
   name: string;
@@ -197,17 +198,37 @@ export default function SubscriptionStatus(): React.JSX.Element {
                 </div>
               )}
 
+              {/* ─ A NEXT ACTION, IN THE APP'S OWN YELLOW ────────────────────
+                  This is Ruling A's own case: a condition, and exactly one
+                  control that ends it. It was wearing hand-rolled `yellow-50`
+                  with `yellow-600` text — off the palette (the app's amber is
+                  amber, not yellow) and, measured, **2.84:1**, which fails
+                  WCAG AA for text outright. So this was not a token tidy; the
+                  sentence telling somebody their subscription is ending was
+                  the least readable thing on the page.
+
+                  `NEXT_ACTION_YELLOW` is amber-800 on amber-100 — 6.15:1
+                  measured, and 10.7:1 for the dark pair. Swapped in whole
+                  rather than appended, per the constant's own constraint:
+                  Tailwind resolves two utilities for one property by source
+                  order, so mixing them leaves the winner to the compiler.
+
+                  Note on its home: the constant lives under
+                  `components/reconciliation/` because that is where the idea
+                  was born, and it is no longer only theirs — Accounts wears it
+                  and now so does this. Moving it up is a follow-up, not a
+                  rider on an accessibility fix. */}
               {cancelAtPeriodEnd && (
-                <div className="p-3 bg-yellow-50 dark:bg-yellow-900/20 rounded-lg">
+                <div className={`p-3 rounded-lg border ${NEXT_ACTION_YELLOW}`}>
                   <div className="flex items-start gap-2">
-                    <AlertCircleIcon size={16} className="text-yellow-600 dark:text-yellow-400 mt-0.5" />
+                    <AlertCircleIcon size={16} className="mt-0.5" />
                     <div className="flex-1">
-                      <p className="text-sm text-yellow-600 dark:text-yellow-400">
+                      <p className="text-sm">
                         Your subscription will end {formatDistanceToNow(new Date(nextBillingDate!), { addSuffix: true })}
                       </p>
                       <button
                         onClick={handleReactivate}
-                        className="mt-2 text-sm text-yellow-700 dark:text-yellow-300 hover:underline"
+                        className="mt-2 text-sm font-medium underline"
                       >
                         Reactivate subscription
                       </button>

--- a/src/components/SyncStatusIndicator.tsx
+++ b/src/components/SyncStatusIndicator.tsx
@@ -142,8 +142,17 @@ export default function SyncStatusIndicator({
           </div>
         )}
 
+        {/* NEUTRAL, and it fixes two things at once.
+            "Changes will sync when you reconnect" is a REASSURANCE — it states
+            a protection the app applies to your work. Nothing bad happens and
+            a reader who skims it cannot be harmed, which is Claude Design's
+            test for what is NOT a warning. It was in the warning pair, telling
+            somebody to tense up and then telling them they are fine.
+            It was also yellow-600 on yellow-50: 2.84:1 measured, failing AA
+            for text. So the most alarming-looking line here was the least
+            readable one. Neutral is both the right category and legible. */}
         {!isOnline && (
-          <div className="mt-2 p-2 bg-yellow-50 dark:bg-yellow-900/20 rounded text-xs text-yellow-600 dark:text-yellow-400">
+          <div className="mt-2 p-2 bg-gray-50 dark:bg-gray-800 rounded text-xs text-gray-600 dark:text-gray-300">
             You're offline. Changes will sync when you reconnect.
           </div>
         )}


### PR DESCRIPTION
Started as the token tidy you said to fix. **Measuring it turned it into an accessibility fix.**

## The subscription notice was 2.84:1

`yellow-600` on `yellow-50`. That fails WCAG AA for text outright — so the sentence telling somebody their subscription is ending was **the least readable thing on the page**.

It's Ruling A's own case: a condition, and exactly one control that ends it (Reactivate). So it now wears `NEXT_ACTION_YELLOW` — amber-800 on amber-100, **6.15:1** measured, 10.7:1 for the dark pair. Swapped in whole rather than appended, per that constant's own constraint about Tailwind resolving two utilities for one property by source order.

## The offline notice was the wrong category *and* 2.84:1

> *"You're offline. Changes will sync when you reconnect."*

That's a **Reassurance** by Design's test — it states a protection the app applies to your work, nothing bad happens, and a reader who skims it can't be harmed. It was in the warning pair, telling somebody to tense up and then telling them they're fine — in the same failing yellow.

Neutral fixes both at once: right category, and **7.23:1 / 9.96:1**.

## What was checked and left

Every `bg-yellow-50` paired with yellow text, **measured rather than eyeballed**. The two delete confirmations use yellow-800 on yellow-50 at **6.62:1** — off the palette, since the app's warning colour is amber, but comfortably readable and correctly a warning. Left alone: recolouring a passing surface is a design change, and this was an accessibility one.

**`LargeTransactionAlertSettings` is deliberately left for Design.** Its amber panel sits under "What happens?" and says "you'll receive a notification", which reads as a reassurance — *but* it may be a **preview** of what that alert will look like, in which case the amber is a sample rather than a claim and removing it breaks the preview. That's a judgement their category exists to make, not mine.

One note recorded for later: `NEXT_ACTION_YELLOW` lives under `components/reconciliation/` because that's where the idea was born, and it isn't only theirs any more — Accounts wears it and now so does this. Moving it up is a follow-up, not a rider on an accessibility fix.

6039 tests pass, lint and typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
