### PR TITLE
Three layout bugs a phone shows and a desktop cannot, and an honest search error

### DIFF
--- a/api/_lib/quotes.ts
+++ b/api/_lib/quotes.ts
@@ -357,6 +357,7 @@ export const searchSymbols = async (
   // having a bad minute.
   let body: unknown = null;
   let lastMessage = 'no response';
+  let lastStatus: number | undefined;
   for (const host of CHART_HOSTS) {
     const url =
       `${host}/v1/finance/search?q=${encodeURIComponent(trimmed)}` +
@@ -365,6 +366,7 @@ export const searchSymbols = async (
       const response = await doFetch(url, { headers: YAHOO_HEADERS, signal: timeoutSignal() });
       if (!response.ok) {
         lastMessage = `upstream returned ${response.status}`;
+        lastStatus = response.status;
         continue;
       }
       body = await response.json();
@@ -375,7 +377,13 @@ export const searchSymbols = async (
   }
 
   if (body === null) {
-    throw new Error(lastMessage);
+    // The STATUS travels with the message. Every upstream failure used to
+    // surface as one indistinguishable "Symbol lookup is unavailable", so a
+    // Yahoo rate limit and a genuine outage read the same — which is exactly
+    // why the owner's watchlist failure could not be diagnosed from the screen.
+    const failure = new Error(lastMessage) as Error & { upstreamStatus?: number };
+    failure.upstreamStatus = lastStatus;
+    throw failure;
   }
   if (!isRecord(body) || !Array.isArray(body.quotes)) {
     return [];

--- a/api/quotes-search.ts
+++ b/api/quotes-search.ts
@@ -74,6 +74,21 @@ async function handler(req: VercelRequest, res: VercelResponse) {
     // Upstream failures are logged server-side; the caller gets a message it can
     // show, never Yahoo's body or our stack.
     console.error('[quotes-search] Lookup failed', error);
+
+    // 429 is not "unavailable", it is "not right now", and the difference is
+    // the whole of what a reader can do about it. Yahoo rate-limits by IP and
+    // both hosts share the limit, so a busy minute takes the lookup out
+    // entirely — which is a fact worth saying rather than hiding behind a
+    // generic failure that also covers genuine outages.
+    const status = (error as { upstreamStatus?: number })?.upstreamStatus;
+    if (status === 429) {
+      return createErrorResponse(
+        res,
+        429,
+        'The price provider is rate-limiting us at the moment. Search will work again shortly.',
+        'upstream_rate_limited'
+      );
+    }
     return createErrorResponse(res, 502, 'Symbol lookup is unavailable', 'upstream_error');
   }
 }

--- a/src/components/dashboard/reportWidgets/DashboardReportWidgets.tsx
+++ b/src/components/dashboard/reportWidgets/DashboardReportWidgets.tsx
@@ -271,7 +271,14 @@ export function ExpenseCategoriesWidget({ picker, pin }: {
           <p className="text-center text-sm text-gray-400">No categorised spending in this period</p>
         </div>
       ) : (
-        <div className={`flex items-center gap-4 ${WIDGET_CHART_HEIGHT}`}>
+        <div className="flex flex-col sm:flex-row sm:items-center gap-4">
+          {/* STACKS ON A PHONE, exactly as the Account Distribution card does.
+              This was a plain `flex` with the height pinned to the WRAPPER, so
+              below sm the ring and a five-row legend fought over ~340px and the
+              legend stayed jammed to the right of the donut. Account
+              Distribution has always been `flex-col sm:flex-row` with the
+              height on the CHART — two cards drawing the same shape of data,
+              behaving differently on the device where it matters most. */}
           {/* A SQUARE FOR THE DONUT, EVERY REMAINING PIXEL FOR THE NAMES.
               The chart box used to be `flex-1` and the legend a fixed `w-36`,
               which is backwards: a donut is circular, so a box wider than it is
@@ -283,7 +290,7 @@ export function ExpenseCategoriesWidget({ picker, pin }: {
               card's height and the list takes the rest, which both moves the
               chart left and buys the names roughly 60px each. `min-w-0` is
               what lets `truncate` keep working in a flex child. */}
-          <div className="h-full aspect-square shrink-0">
+          <div className={`${WIDGET_CHART_HEIGHT} sm:aspect-square sm:flex-shrink-0`}>
             <ResponsiveContainer width="100%" height="100%">
               <RechartsPieChart>
                 {/* A slice opens the report with that category's row
@@ -336,7 +343,7 @@ export function ExpenseCategoriesWidget({ picker, pin }: {
               two cards that draw the same picture of the same shape of data.
               The owner asked for the roomier of the two, both. Five rows at
               this rhythm are ~192px inside the 208px the card allows. */}
-          <ul className="flex-1 min-w-0 space-y-2">
+          <ul className="sm:flex-1 sm:min-w-0 space-y-2">
             {data.map((d, i) => (
               <li key={d.categoryId}>
                 <button

--- a/src/design-system/__tests__/darkModeUtilities.test.ts
+++ b/src/design-system/__tests__/darkModeUtilities.test.ts
@@ -136,3 +136,69 @@ describe('dark-mode colours that silently do not apply', () => {
     expect(CSS).toMatch(/\.dark\s+\.text-theme-heading\s*\{\s*color:\s*#f9fafb\s*!important/);
   });
 });
+
+/**
+ * THE TOUCH-ONLY MEDIA QUERY MAY SET HIT AREAS, NOT LAYOUT.
+ *
+ * `@media (hover: none) and (pointer: coarse)` never matches a desktop
+ * browser, so anything it gets wrong is invisible to everyone developing the
+ * app and visible to everyone using it on a phone. It has now caused three
+ * separate bugs:
+ *
+ *   1. `position: relative` on every button — which outranks Tailwind's
+ *      `.fixed` — put the floating + at the screen's left edge and squeezed
+ *      <main> off-centre on every touch device.
+ *   2. `min-width: 44px` turned a 24px count pill into a 31×44 oval and lifted
+ *      its label 12px.
+ *   3. `padding: 8px 12px` on text inputs beat every `pl-*` utility in the app
+ *      — `input[type="text"]` is (0,1,1), a class is (0,1,0) — so the
+ *      watchlist's search icon sat on top of its own placeholder.
+ *
+ * The pattern is the same each time: a property that belongs to a COMPONENT
+ * being set globally, from a block nobody can see. Hit area is this block's
+ * business. Position, padding and size are not.
+ */
+describe('the touch-only block sets hit areas and nothing else', () => {
+  it('declares no property that a component would reasonably own', () => {
+    const start = CSS.indexOf('@media (hover: none) and (pointer: coarse)');
+    expect(start).toBeGreaterThan(-1);
+
+    // Walk to the matching close brace so the whole block is examined.
+    let depth = 0;
+    let end = start;
+    for (let i = CSS.indexOf('{', start); i < CSS.length; i += 1) {
+      if (CSS[i] === '{') depth += 1;
+      else if (CSS[i] === '}') {
+        depth -= 1;
+        if (depth === 0) { end = i; break; }
+      }
+    }
+
+    // Rules carrying a `hit-area:` comment are declaring that the property IS
+    // the target region rather than layout — a 24px checkbox with 10px margins
+    // is the only way to give it a 44px region. Written deliberately, with a
+    // reason, exactly like the `dark-exempt:` marker one suite over.
+    const raw = CSS.slice(start, end);
+    const block = raw
+      .split(/(?=\/\* hit-area:)/)
+      .map((chunk, i) => (i > 0 && chunk.startsWith('/* hit-area:') ? '' : chunk))
+      .join('')
+      .replace(/\/\*[\s\S]*?\*\//g, ''); // its own commentary names the banned ones
+
+    // `position` is banned outright; `padding`/`margin`/`width`/`height` are
+    // banned as SHORTHANDS or absolutes. `min-width`/`min-height` are the hit
+    // area and are the point of the block. `.touch-target-small::after` is the
+    // invisible expanded hit area, which legitimately positions itself.
+    const offenders = [...block.matchAll(/^\s*(position|padding|margin|width|height)\s*:/gm)]
+      .map((m) => m[1])
+      .filter((prop) => !(prop === 'position' && block.includes('.touch-target-small')))
+      .filter((prop) => !(['width', 'height'].includes(prop) && block.includes('::after')));
+
+    expect(
+      offenders,
+      `This block may set min-width/min-height. It set: ${offenders.join(', ')}. ` +
+        `A property a component owns, set from a query that never matches a desktop, ` +
+        `is a bug nobody developing the app can see.`
+    ).toEqual([]);
+  });
+});

--- a/src/index.css
+++ b/src/index.css
@@ -62,7 +62,25 @@
     margin-top: 8px;
   }
   
-  /* Touch-friendly form elements */
+  /* Touch-friendly form elements.
+   *
+   * MIN-HEIGHT ONLY. This also set `padding: 8px 12px`, and that is a bug with
+   * a very long reach: `input[type="text"]` scores (0,1,1) — an attribute
+   * selector plus a type — while a Tailwind utility like `pl-10` scores
+   * (0,1,0). The element selector WINS, so on every touch device this quietly
+   * flattened the considered padding of all 69 text inputs in the app.
+   *
+   * What it looked like: the watchlist's search field puts its magnifier at
+   * `left-3` and reserves `pl-10` for it. On a phone the padding became 12px,
+   * so the placeholder started underneath the icon — reported as "the search
+   * icon sits in front of the default text". Invisible on a desktop, because
+   * this block is `(hover: none) and (pointer: coarse)` and never matches one.
+   *
+   * The rule's job is the HIT AREA, and `min-height: 44px` is the whole of
+   * that. Horizontal padding is a component's own decision and it was never
+   * this block's business to overrule it. Third distinct bug traced to this
+   * media query — see the note at the top of the file about the `position`
+   * line that once moved every fixed button in the app. */
   input[type="text"],
   input[type="email"],
   input[type="password"],
@@ -72,15 +90,18 @@
   select,
   textarea {
     min-height: 44px;
-    padding: 8px 12px;
   }
   
-  /* Touch-friendly checkboxes and radio buttons */
+  /* hit-area: the margin IS the hit area here, not spacing — a 24px box with
+     10px on each side is the 44px target, which is the one way to give a
+     checkbox a finger-sized region without drawing a finger-sized checkbox.
+     Declared so the guard can tell it from the `padding: 8px 12px` that used
+     to sit above it and was pure layout. */
   input[type="checkbox"],
   input[type="radio"] {
     width: 24px;
     height: 24px;
-    margin: 10px; /* Total 44px with margin */
+    margin: 10px;
   }
 }
 

--- a/src/pages/Accounts.tsx
+++ b/src/pages/Accounts.tsx
@@ -1813,8 +1813,21 @@ export default function Accounts() {
           aria-controls={regionId}
           className="w-full bg-surface-secondary dark:bg-gray-700/50 border-b border-line dark:border-gray-700 px-4 sm:px-6 py-2.5 text-left transition-colors duration-state hover:bg-surface-tertiary dark:hover:bg-gray-700"
         >
-          <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-2">
-            <div className="flex items-center gap-2 md:gap-3">
+          {/* ONE ROW AT EVERY WIDTH, so the total is on the right on a
+              phone too. It was `flex-col sm:flex-row`, which below sm stacked
+              the total UNDER the name and hard against the left edge — while
+              the institution headings one rung down are a plain
+              `flex justify-between` and stayed right. The owner, on his phone:
+              "the group totals are still showing to the left and not on the
+              right as we should have changed."
+
+              Removing the band glyph (#308) lined the two up on DESKTOP; this
+              is the half of it that only shows on a narrow screen, which is
+              why the earlier fix looked complete and was not. The name
+              truncates rather than wrapping, so a long band title cannot push
+              the figure off. */}
+          <div className="flex items-center justify-between gap-3">
+            <div className="flex items-center gap-2 md:gap-3 min-w-0">
               <ChevronRightIcon
                 size={16}
                 className={`flex-shrink-0 text-gray-400 transition-transform duration-200 ${isExpanded ? 'rotate-90' : ''}`}
@@ -1838,12 +1851,12 @@ export default function Accounts() {
 
                   Still an h2 — the outline, and the way a screen-reader user
                   walks this page, are unchanged. */}
-              <h2 className="text-card uppercase font-bold tracking-wide text-gray-900 dark:text-white">{group.title}</h2>
+              <h2 className="text-card uppercase font-bold tracking-wide text-gray-900 dark:text-white truncate">{group.title}</h2>
               <span className="text-dense text-gray-400 dark:text-gray-500">
                 ({group.accounts.length} {group.accounts.length === 1 ? 'account' : 'accounts'})
               </span>
             </div>
-            <p className="text-card font-semibold text-primary dark:text-white">
+            <p className="text-card font-semibold text-primary dark:text-white whitespace-nowrap shrink-0">
               {bandTotalNode(bandTotal)}
             </p>
           </div>

--- a/src/test/api-lib/quotes.test.ts
+++ b/src/test/api-lib/quotes.test.ts
@@ -268,7 +268,6 @@ describe('the nightly cron’s symbol reduction', () => {
 
     expect(stub).toHaveBeenCalledTimes(1);
   });
-});
 
 describe('symbol search', () => {
   const searchStub = (body: unknown, status = 200): FetchLike =>
@@ -335,5 +334,37 @@ describe('symbol search', () => {
     await searchSymbols('shell', stub);
 
     expect(stub).toHaveBeenCalledTimes(1);
+  });
+});
+
+  /*
+   * THE STATUS HAS TO TRAVEL, or every failure reads the same.
+   *
+   * The owner typed "Apple" and got "Symbol lookup is unavailable". Measured
+   * afterwards: Yahoo returns 429 to both hosts and to its own crumb endpoint
+   * — it is rate-limiting by IP, and the two hosts share the limit. So the
+   * fallback added earlier was necessary and not sufficient.
+   *
+   * What made that impossible to see from the screen is that a rate limit, an
+   * outage and a bug all surfaced as one sentence. 429 is not "unavailable",
+   * it is "not right now", and the difference is the whole of what a reader
+   * can do about it.
+   */
+  it('carries the upstream status out, so 429 can be told from a break', async () => {
+    const stub = vi.fn(async () => new Response('{}', { status: 429 })) as unknown as FetchLike;
+
+    await expect(searchSymbols('shell', stub)).rejects.toMatchObject({ upstreamStatus: 429 });
+  });
+
+  it('reports the LAST host it tried, not the first', async () => {
+    // query1 down for one reason, query2 for another: the message a reader
+    // eventually sees should describe the attempt that actually ended it.
+    const stub = vi.fn(async (url: string) =>
+      url.includes('query1')
+        ? new Response('{}', { status: 500 })
+        : new Response('{}', { status: 429 })
+    ) as unknown as FetchLike;
+
+    await expect(searchSymbols('shell', stub)).rejects.toMatchObject({ upstreamStatus: 429 });
   });
 });


### PR DESCRIPTION
All four from your phone — and three are invisible on a laptop by construction.

## 1 — the Expense donut wouldn't stack

Account Distribution has always been `flex-col sm:flex-row` with its height on the **chart**. Expense Categories was a plain `flex` with the height pinned to the **wrapper**, so below `sm` the ring and a five-row legend fought over ~340px and the legend stayed jammed to the right. Two cards drawing the same shape of data, behaving differently on the device where it matters most.

## 2 — the band totals were still left, *on a phone*

Removing the band glyph in #308 lined the section and institution headings up on desktop, which is exactly why the fix looked complete. The heading was `flex-col sm:flex-row`, so below `sm` it stacked the total **under** the name and against the left edge — while the institution headings one rung down are a plain `flex justify-between` and stayed right.

One row at every width now, with the name truncating so a long title can't push the figure off.

## 3 — the search icon sat on its own placeholder

`index.css`'s touch block set `padding: 8px 12px` on text inputs. **`input[type="text"]` scores (0,1,1); a Tailwind class scores (0,1,0).** The element selector wins — so on every touch device that quietly flattened the considered padding of **all 69 text inputs in the app**, and the watchlist's `pl-10`, reserved for the magnifier at `left-3`, became 12px.

The rule's job is the hit area, and `min-height: 44px` is the whole of that.

This is the **third distinct bug** from that media query — after the `position` line that moved every fixed button in the app, and the `min-width` that turned a 24px count pill into a 31×44 oval. So it's guarded now: the block may set `min-width`/`min-height`, and a `hit-area:` marker declares the one legitimate exception (a 24px checkbox with 10px margins *is* its 44px target). Proven non-vacuous by putting the padding back.

## 4 — the search error was hiding its own cause

The host fallback shipped in #305 and it still failed. Measured, just now: **Yahoo returns 429 to both hosts and to its own crumb endpoint.** It rate-limits by IP and the two hosts share the limit — so the fallback was necessary and *not sufficient*.

What made that undiagnosable from the screen is that a rate limit, an outage and a bug all surfaced as one sentence. The upstream status now travels with the error, and 429 says so: *"The price provider is rate-limiting us at the moment."*

**429 is not "unavailable", it's "not right now"** — and that difference is the whole of what a reader can do about it.

**The remaining question is yours, not mine:** whether to authenticate with Yahoo (crumb + cookie, fragile), cache the instrument universe harder, or use a different provider for search. That's a product decision and it is deliberately not in this PR.

6042 tests pass, lint and typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
