### PR TITLE
Twelve Data behind a provider seam, with Yahoo as the fallback

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -60,3 +60,16 @@ BANKING_ALLOWED_ORIGINS=
 # (KV_REST_API_URL/KV_REST_API_TOKEN are accepted as aliases.)
 UPSTASH_REDIS_REST_URL=
 UPSTASH_REDIS_REST_TOKEN=
+
+# ── SYMBOL SEARCH ──────────────────────────────────────────────────────────
+# Optional. With no key the app searches through Yahoo, exactly as it always
+# has; with one it uses Twelve Data and falls back to Yahoo if that fails.
+#
+# It is here because Yahoo's search is UNKEYED and rate-limits by IP, and a
+# Vercel function shares its egress IP with other customers — so the 429s were
+# a limit this app did not spend. A key attaches the quota to us.
+#
+# NO `VITE_` PREFIX. Vite inlines every VITE_* var into the public browser
+# bundle at build time; this is a server-side key and belongs only to the
+# functions under api/.
+TWELVE_DATA_API_KEY=

--- a/api/_lib/symbolSearch.ts
+++ b/api/_lib/symbolSearch.ts
@@ -1,0 +1,81 @@
+import { searchSymbols as searchYahoo, type SymbolMatch } from './quotes.js';
+import { searchSymbolsTwelveData } from './twelvedata.js';
+
+/**
+ * WHICH PROVIDER ANSWERS "does this ticker exist", and nothing else.
+ *
+ * One file whose whole job is the CHOICE, so that switching providers is an
+ * environment variable rather than an edit — the same shape as
+ * `services/port/index.ts` on the app side, and for the same reason: a
+ * choosing file that also does work is a file whose work only one branch gets.
+ *
+ * ─ WHY THIS EXISTS AT ALL ──────────────────────────────────────────────────
+ *
+ * Yahoo's search is unkeyed and rate-limits by IP. A Vercel function shares its
+ * egress IP with other customers, so the limit is one this app did not spend:
+ * measured 15 August, 429 from both Yahoo hosts AND from Yahoo's own crumb
+ * endpoint, while the app was making a handful of calls a day behind a 300ms
+ * debounce and an hour of CDN cache. A key attaches quota to US rather than to
+ * whichever address the function landed on.
+ *
+ * ─ THE ORDER, AND WHY YAHOO IS STILL HERE ──────────────────────────────────
+ *
+ * Twelve Data when a key is configured, Yahoo otherwise, and Yahoo again if
+ * Twelve Data fails. Not belt and braces:
+ *
+ *   · with no key the app must keep working exactly as it did, so that adding
+ *     the key is a deployment rather than a migration;
+ *   · Twelve Data's free tier has a daily ceiling, and the day it is reached
+ *     the honest behaviour is a degraded search rather than none.
+ *
+ * ─ WHAT A PROVIDER MUST GUARANTEE ──────────────────────────────────────────
+ *
+ * That every symbol it returns can be PRICED by `fetchQuote`, which speaks
+ * Yahoo's dialect. A provider returning `SHEL` where Yahoo wants `SHEL.L` has
+ * not failed loudly — it has handed back a holding that silently never prices,
+ * which looks like it worked. See `toYahooSymbol` in the Twelve Data adapter;
+ * an unmapped exchange is dropped rather than offered.
+ */
+
+export type SymbolSearchProvider = 'twelvedata' | 'yahoo';
+
+/** Which provider this deployment will use, and why. Exported for /api health. */
+export function activeSymbolSearchProvider(
+  env: NodeJS.ProcessEnv = process.env
+): SymbolSearchProvider {
+  return (env.TWELVE_DATA_API_KEY ?? '').trim() === '' ? 'yahoo' : 'twelvedata';
+}
+
+export interface SymbolSearchOptions {
+  env?: NodeJS.ProcessEnv;
+  fetchImpl?: typeof fetch;
+  /** Reported per attempt so a caller can log which provider actually failed. */
+  onProviderError?: (provider: SymbolSearchProvider, error: unknown) => void;
+}
+
+export async function searchSymbolsVia(
+  query: string,
+  options: SymbolSearchOptions = {}
+): Promise<SymbolMatch[]> {
+  const env = options.env ?? process.env;
+  const trimmed = query.trim();
+  if (trimmed === '') return [];
+
+  const apiKey = (env.TWELVE_DATA_API_KEY ?? '').trim();
+
+  if (apiKey !== '') {
+    try {
+      return await searchSymbolsTwelveData(trimmed, {
+        apiKey,
+        fetchImpl: options.fetchImpl
+      });
+    } catch (error) {
+      // Falling through, not swallowing: the caller is told which provider
+      // failed, because "search is down" and "our key is exhausted" want
+      // different actions and the logs are where that distinction survives.
+      options.onProviderError?.('twelvedata', error);
+    }
+  }
+
+  return searchYahoo(trimmed, options.fetchImpl as never);
+}

--- a/api/_lib/twelvedata.ts
+++ b/api/_lib/twelvedata.ts
@@ -1,0 +1,189 @@
+import type { SymbolMatch } from './quotes.js';
+
+/**
+ * TWELVE DATA, for symbol search only.
+ *
+ * ─ WHY A SECOND PROVIDER AT ALL ────────────────────────────────────────────
+ *
+ * Yahoo's search is unkeyed, and it rate-limits by IP. A Vercel function shares
+ * its egress IP with other customers, so the limit we hit is one we did not
+ * spend — measured on 15 August: 429 from BOTH hosts and from Yahoo's own crumb
+ * endpoint, while the app was making a handful of calls a day behind a 300ms
+ * debounce and an hour of CDN cache.
+ *
+ * A key is the fix, not a bigger allowance: quota attached to US rather than to
+ * whichever address the function happened to land on.
+ *
+ * ─ THE THING THAT MATTERS MOST HERE: SYMBOL FORMAT ─────────────────────────
+ *
+ * A symbol picked in search is stored on the holding and later priced by the
+ * YAHOO quote path (`fetchQuote`, and the nightly cron). So a search result has
+ * to be expressed in Yahoo's dialect or the holding silently never prices —
+ * which is a worse outcome than search being down, because it looks like it
+ * worked.
+ *
+ * Twelve Data answers `{ symbol: 'SHEL', exchange: 'LSE' }` where Yahoo wants
+ * `SHEL.L`. `EXCHANGE_SUFFIX` is that translation, and it is deliberately a
+ * SHORT list of exchanges this app's users actually hold rather than a complete
+ * one: a wrong suffix produces a symbol that looks right and never prices.
+ *
+ * An unmapped exchange is DROPPED rather than returned. Offering somebody a
+ * result that cannot price is the same offence as a dead toggle — it accepts
+ * the choice and quietly fails afterwards. Both forms stay typeable by hand, so
+ * dropping a result never blocks recording a holding.
+ */
+
+/** Twelve Data exchange (or MIC) → the suffix Yahoo wants. '' means none. */
+const EXCHANGE_SUFFIX: Readonly<Record<string, string>> = {
+  // The ones this app's users hold. US first: Yahoo takes these bare.
+  NASDAQ: '',
+  NYSE: '',
+  'NYSE AMERICAN': '',
+  'NYSE ARCA': '',
+  BATS: '',
+  OTC: '',
+  // UK — the reason for the whole exercise.
+  LSE: '.L',
+  XLON: '.L',
+  'LONDON STOCK EXCHANGE': '.L',
+  // Ireland and the near continent, which a UK holder reaches often enough.
+  EURONEXT: '.PA',
+  XPAR: '.PA',
+  XAMS: '.AS',
+  XBRU: '.BR',
+  XDUB: '.IR',
+  XETR: '.DE',
+  XETRA: '.DE',
+  FSX: '.F',
+  SIX: '.SW',
+  XSWX: '.SW',
+  XMIL: '.MI',
+  BME: '.MC',
+  // Further afield, where the mapping is unambiguous.
+  TSX: '.TO',
+  XTSE: '.TO',
+  ASX: '.AX',
+  XASX: '.AX',
+  TSE: '.T',
+  XTKS: '.T',
+  HKEX: '.HK',
+  XHKG: '.HK'
+};
+
+interface TwelveDataRow {
+  symbol?: unknown;
+  instrument_name?: unknown;
+  exchange?: unknown;
+  mic_code?: unknown;
+  instrument_type?: unknown;
+  country?: unknown;
+}
+
+const asString = (value: unknown): string =>
+  typeof value === 'string' ? value.trim() : '';
+
+/**
+ * The Yahoo-dialect symbol for a Twelve Data row, or null when this app cannot
+ * price it. Exported for the test that pins the translation, because a wrong
+ * suffix is invisible until a price fails to arrive weeks later.
+ */
+export function toYahooSymbol(row: {
+  symbol: string;
+  exchange: string;
+  micCode: string;
+}): string | null {
+  const base = row.symbol.trim().toUpperCase();
+  if (base === '') return null;
+  // Already carries a suffix (some feeds do) — leave it alone rather than
+  // appending a second one.
+  if (base.includes('.')) return base;
+
+  const byExchange = EXCHANGE_SUFFIX[row.exchange.trim().toUpperCase()];
+  const byMic = EXCHANGE_SUFFIX[row.micCode.trim().toUpperCase()];
+  const suffix = byExchange !== undefined ? byExchange : byMic;
+
+  if (suffix === undefined) return null; // unmapped: cannot price it, so do not offer it
+  return `${base}${suffix}`;
+}
+
+export interface TwelveDataOptions {
+  apiKey: string;
+  fetchImpl?: typeof fetch;
+  limit?: number;
+  signal?: AbortSignal;
+}
+
+/**
+ * Ticker/name lookup through Twelve Data.
+ *
+ * Throws on an unusable response for the same reason the Yahoo path does:
+ * "nothing matched" and "the lookup is broken" are different answers, and
+ * telling somebody their real ticker does not exist is the worse of the two.
+ */
+export async function searchSymbolsTwelveData(
+  query: string,
+  options: TwelveDataOptions
+): Promise<SymbolMatch[]> {
+  const trimmed = query.trim();
+  if (trimmed === '') return [];
+
+  const doFetch = options.fetchImpl ?? fetch;
+  const url =
+    'https://api.twelvedata.com/symbol_search' +
+    `?symbol=${encodeURIComponent(trimmed)}` +
+    `&outputsize=${options.limit ?? 10}`;
+
+  // The key goes in a HEADER, never the query string: Vercel logs full URLs,
+  // and a key in a log is a key that has leaked.
+  const response = await doFetch(url, {
+    headers: { Authorization: `apikey ${options.apiKey}`, Accept: 'application/json' },
+    signal: options.signal
+  });
+
+  if (!response.ok) {
+    const failure = new Error(`upstream returned ${response.status}`) as Error & {
+      upstreamStatus?: number;
+    };
+    failure.upstreamStatus = response.status;
+    throw failure;
+  }
+
+  const body: unknown = await response.json();
+  if (typeof body !== 'object' || body === null) return [];
+
+  // Twelve Data answers 200 with `{ code, message }` for a bad key or an
+  // exhausted plan. A 200 that is really an error must not read as "no
+  // results" — that is the shape that tells somebody their ticker is fictional.
+  const asRecord = body as { code?: unknown; message?: unknown; data?: unknown };
+  if (typeof asRecord.code === 'number' && asRecord.code >= 400) {
+    const failure = new Error(
+      asString(asRecord.message) || `upstream returned ${asRecord.code}`
+    ) as Error & { upstreamStatus?: number };
+    failure.upstreamStatus = asRecord.code;
+    throw failure;
+  }
+
+  const rows = Array.isArray(asRecord.data) ? asRecord.data : [];
+  const matches: SymbolMatch[] = [];
+
+  for (const entry of rows) {
+    if (typeof entry !== 'object' || entry === null) continue;
+    const row = entry as TwelveDataRow;
+
+    const symbol = toYahooSymbol({
+      symbol: asString(row.symbol),
+      exchange: asString(row.exchange),
+      micCode: asString(row.mic_code)
+    });
+    if (symbol === null) continue;
+
+    matches.push({
+      symbol,
+      name: asString(row.instrument_name) || symbol,
+      exchange: asString(row.exchange),
+      type: asString(row.instrument_type)
+    });
+  }
+
+  return matches;
+}

--- a/api/quotes-search.ts
+++ b/api/quotes-search.ts
@@ -4,7 +4,8 @@ import { setCorsHeaders } from './_lib/cors.js';
 import { createErrorResponse } from './_lib/http-error.js';
 import { applyRateLimit } from './_lib/rate-limit.js';
 import { withSentry } from './_lib/sentry.js';
-import { searchSymbols, type SymbolMatch } from './_lib/quotes.js';
+import { type SymbolMatch } from './_lib/quotes.js';
+import { searchSymbolsVia, activeSymbolSearchProvider } from './_lib/symbolSearch.js';
 
 /**
  * GET /api/quotes-search?q=… — ticker lookup.
@@ -60,7 +61,14 @@ async function handler(req: VercelRequest, res: VercelResponse) {
       );
     }
 
-    const matches = await searchSymbols(query);
+    // Through the seam, not the provider: which service answers is
+    // `symbolSearch.ts`'s decision and an environment variable, so switching
+    // is a deployment rather than an edit here.
+    const matches = await searchSymbolsVia(query, {
+      onProviderError: (provider, error) => {
+        console.error(`[quotes-search] ${provider} failed, falling back`, error);
+      }
+    });
 
     // The instrument universe changes by the day, not the minute.
     res.setHeader('Cache-Control', 'public, max-age=0, s-maxage=3600, stale-while-revalidate=3600');
@@ -73,13 +81,19 @@ async function handler(req: VercelRequest, res: VercelResponse) {
     }
     // Upstream failures are logged server-side; the caller gets a message it can
     // show, never Yahoo's body or our stack.
-    console.error('[quotes-search] Lookup failed', error);
+    // The provider is named, because "search is down" reads very differently
+    // depending on WHICH one gave up and there is no other record of it.
+    console.error(
+      `[quotes-search] Lookup failed (provider: ${activeSymbolSearchProvider()})`,
+      error
+    );
 
     // 429 is not "unavailable", it is "not right now", and the difference is
-    // the whole of what a reader can do about it. Yahoo rate-limits by IP and
-    // both hosts share the limit, so a busy minute takes the lookup out
-    // entirely — which is a fact worth saying rather than hiding behind a
-    // generic failure that also covers genuine outages.
+    // the whole of what a reader can do about it. It survives the provider
+    // change because it is not a Yahoo fact: Twelve Data's free tier has a
+    // daily ceiling and answers 429 when it is reached, so a rate limit is
+    // now something EITHER provider can report — which is the more reason to
+    // say it plainly rather than folding it into a generic failure.
     const status = (error as { upstreamStatus?: number })?.upstreamStatus;
     if (status === 429) {
       return createErrorResponse(

--- a/src/test/api-lib/symbolSearch.test.ts
+++ b/src/test/api-lib/symbolSearch.test.ts
@@ -1,0 +1,147 @@
+/**
+ * SYMBOL SEARCH, AND THE PROVIDER THAT ANSWERS IT.
+ *
+ * The reason this exists: Yahoo's search is unkeyed and rate-limits by IP, and
+ * a Vercel function shares its egress IP with other customers — so the limit
+ * hit is one this app did not spend. Measured 15 August: 429 from both Yahoo
+ * hosts and from Yahoo's own crumb endpoint, while the app was making a handful
+ * of calls a day. A key attaches quota to us rather than to an address.
+ *
+ * The tests that matter most are the TRANSLATION ones. A symbol picked in
+ * search is stored on the holding and later priced by the Yahoo quote path, so
+ * a provider returning `SHEL` where Yahoo wants `SHEL.L` has not failed
+ * loudly — it has handed back a holding that silently never prices, which looks
+ * exactly like success until a price fails to arrive weeks later.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { searchSymbolsVia, activeSymbolSearchProvider } from '../../../api/_lib/symbolSearch';
+import { searchSymbolsTwelveData, toYahooSymbol } from '../../../api/_lib/twelvedata';
+
+const KEYED = { TWELVE_DATA_API_KEY: 'test-key' } as NodeJS.ProcessEnv;
+const UNKEYED = {} as NodeJS.ProcessEnv;
+
+const twelveDataBody = (rows: unknown[]) => ({ data: rows });
+
+const stub = (body: unknown, status = 200) =>
+  vi.fn(async () => new Response(JSON.stringify(body), { status })) as unknown as typeof fetch;
+
+describe('the symbol a search returns must be one the quote path can price', () => {
+  it('gives an LSE listing the .L Yahoo wants', () => {
+    expect(toYahooSymbol({ symbol: 'SHEL', exchange: 'LSE', micCode: 'XLON' })).toBe('SHEL.L');
+  });
+
+  it('leaves a US listing bare, which is what Yahoo takes', () => {
+    expect(toYahooSymbol({ symbol: 'AAPL', exchange: 'NASDAQ', micCode: 'XNAS' })).toBe('AAPL');
+    expect(toYahooSymbol({ symbol: 'BRK.B', exchange: 'NYSE', micCode: 'XNYS' })).toBe('BRK.B');
+  });
+
+  it('falls back to the MIC when the exchange name is unfamiliar', () => {
+    // Providers spell exchange names inconsistently; MICs are the standard.
+    expect(toYahooSymbol({ symbol: 'SHEL', exchange: 'London Stock Exch.', micCode: 'XLON' }))
+      .toBe('SHEL.L');
+  });
+
+  it('does not append a second suffix to a symbol that already carries one', () => {
+    expect(toYahooSymbol({ symbol: 'SHEL.L', exchange: 'LSE', micCode: 'XLON' })).toBe('SHEL.L');
+  });
+
+  it('DROPS an exchange it cannot translate, rather than offering a dead symbol', () => {
+    /*
+     * The important one. Offering a result that cannot price is the same
+     * offence as a dead toggle: it accepts the choice and fails silently
+     * afterwards. Both fields stay typeable by hand, so dropping never blocks
+     * recording a holding — it only stops the app suggesting one it cannot keep.
+     */
+    expect(toYahooSymbol({ symbol: 'ABC', exchange: 'Bourse de Nowhere', micCode: 'XZZZ' }))
+      .toBeNull();
+  });
+
+  it('drops an empty symbol', () => {
+    expect(toYahooSymbol({ symbol: '   ', exchange: 'LSE', micCode: 'XLON' })).toBeNull();
+  });
+});
+
+describe('the Twelve Data adapter', () => {
+  it('maps a mixed UK/US response into Yahoo dialect', async () => {
+    const matches = await searchSymbolsTwelveData('shell', {
+      apiKey: 'k',
+      fetchImpl: stub(twelveDataBody([
+        { symbol: 'SHEL', instrument_name: 'Shell plc', exchange: 'LSE', mic_code: 'XLON', instrument_type: 'Common Stock' },
+        { symbol: 'SHEL', instrument_name: 'Shell plc ADR', exchange: 'NYSE', mic_code: 'XNYS', instrument_type: 'Common Stock' }
+      ]))
+    });
+
+    expect(matches.map((m) => m.symbol)).toEqual(['SHEL.L', 'SHEL']);
+    expect(matches[0]).toMatchObject({ name: 'Shell plc', exchange: 'LSE' });
+  });
+
+  it('treats a 200 carrying an error code as a failure, not as "no results"', async () => {
+    /*
+     * Twelve Data answers 200 with `{ code, message }` for a bad key or an
+     * exhausted plan. Reading that as an empty list would tell somebody their
+     * real ticker does not exist — the single most misleading thing a lookup
+     * can do.
+     */
+    await expect(
+      searchSymbolsTwelveData('shell', {
+        apiKey: 'k',
+        fetchImpl: stub({ code: 429, message: 'You have run out of API credits' })
+      })
+    ).rejects.toMatchObject({ upstreamStatus: 429 });
+  });
+
+  it('sends the key as a header, never in the URL', async () => {
+    // Vercel logs full URLs; a key in a log is a key that has leaked.
+    const fetchImpl = stub(twelveDataBody([]));
+    await searchSymbolsTwelveData('shell', { apiKey: 'secret-key', fetchImpl });
+
+    const [url, init] = (fetchImpl as unknown as { mock: { calls: [string, RequestInit][] } }).mock.calls[0];
+    expect(url).not.toContain('secret-key');
+    expect((init.headers as Record<string, string>).Authorization).toContain('secret-key');
+  });
+
+  it('returns nothing for an empty query without calling upstream', async () => {
+    const fetchImpl = stub(twelveDataBody([]));
+    expect(await searchSymbolsTwelveData('   ', { apiKey: 'k', fetchImpl })).toEqual([]);
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+});
+
+describe('choosing the provider', () => {
+  it('uses Yahoo when no key is configured, so adding one is a deployment', () => {
+    expect(activeSymbolSearchProvider(UNKEYED)).toBe('yahoo');
+    expect(activeSymbolSearchProvider(KEYED)).toBe('twelvedata');
+  });
+
+  it('treats a blank key as no key', () => {
+    expect(activeSymbolSearchProvider({ TWELVE_DATA_API_KEY: '   ' } as NodeJS.ProcessEnv))
+      .toBe('yahoo');
+  });
+
+  it('falls back to Yahoo when Twelve Data fails, and says which failed', async () => {
+    const onProviderError = vi.fn();
+    // Twelve Data 500s; Yahoo answers. One fetch stub serves both, branching on
+    // the host, which is also how the real failover is exercised.
+    const fetchImpl = vi.fn(async (url: string) =>
+      url.includes('twelvedata')
+        ? new Response('{}', { status: 500 })
+        : new Response(JSON.stringify({ quotes: [{ symbol: 'AAPL', longname: 'Apple Inc.' }] }), { status: 200 })
+    ) as unknown as typeof fetch;
+
+    const matches = await searchSymbolsVia('apple', { env: KEYED, fetchImpl, onProviderError });
+
+    expect(matches.map((m) => m.symbol)).toEqual(['AAPL']);
+    expect(onProviderError).toHaveBeenCalledWith('twelvedata', expect.anything());
+  });
+
+  it('does not call Twelve Data at all when there is no key', async () => {
+    const fetchImpl = vi.fn(async () =>
+      new Response(JSON.stringify({ quotes: [{ symbol: 'AAPL', longname: 'Apple Inc.' }] }), { status: 200 })
+    ) as unknown as typeof fetch;
+
+    await searchSymbolsVia('apple', { env: UNKEYED, fetchImpl });
+
+    const calls = (fetchImpl as unknown as { mock: { calls: [string][] } }).mock.calls;
+    expect(calls.every(([url]) => !url.includes('twelvedata'))).toBe(true);
+  });
+});


### PR DESCRIPTION
Twelve Data, built behind a seam so switching again is an environment variable rather than an edit.

## Why a second provider

Yahoo's search is **unkeyed and rate-limits by IP** — and a Vercel function shares its egress IP with other customers, so the limit you hit is one this app never spent. Measured yesterday: 429 from both Yahoo hosts *and* from Yahoo's own crumb endpoint, while the app was making a handful of calls a day behind a 300ms debounce and an hour of CDN cache.

**A key is the fix, not a bigger allowance** — quota attached to us rather than to whichever address the function landed on.

## The part that would have failed silently

A symbol picked in search is stored on the holding and later priced by the **Yahoo** quote path, including the nightly cron. Twelve Data answers `{ symbol: 'SHEL', exchange: 'LSE' }` where Yahoo wants `SHEL.L`.

Returning the raw symbol wouldn't have failed loudly — it would have handed back **a holding that never prices**, which looks exactly like success until a price fails to arrive weeks later.

`toYahooSymbol` is that translation, and an **unmapped exchange is dropped rather than offered**: suggesting a result the app can't price is the same offence as a dead toggle. Both fields stay typeable, so dropping never blocks recording a holding.

The map is deliberately short — the exchanges your portfolio actually touches — because a *wrong* suffix produces a symbol that looks right and never prices.

## Two failure modes worth naming

**A 200 carrying an error.** Twelve Data answers `200` with `{ code, message }` for a bad key or an exhausted plan. Read as an empty list, that tells somebody their real ticker doesn't exist — the most misleading thing a lookup can do. It throws, carrying the code.

**The key goes in a header, never the query string.** Vercel logs full URLs, and a key in a log is a key that has leaked. Asserted in a test.

## The order

Twelve Data when a key is set, Yahoo otherwise, Yahoo again if Twelve Data fails.

With no key the app behaves **exactly as it does today** — so adding your key is a deployment, not a migration. And when the free tier's daily ceiling is reached, a degraded search beats none.

The provider that failed is **named in the log**: "search is down" and "our key is exhausted" want different actions.

## What you need to do

Add `TWELVE_DATA_API_KEY` to the Vercel environment (documented in `.env.example`, with the reminder never to prefix a server key with `VITE_`). Nothing else — no migration, no redeploy of the client.

14 new tests; 6053 pass overall, lint and typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
