### PR TITLE
refactor(design-system): the next-action yellow moves up, and its ratios stop being remembered

### DIFF
--- a/docs/handovers/2026-08-15-to-claude-design.md
+++ b/docs/handovers/2026-08-15-to-claude-design.md
@@ -1,0 +1,195 @@
+# Handover back to Claude Design — 15 August 2026
+
+**From:** the implementation side
+**Covers:** everything since the conversion-queue handover, PRs #294 onwards
+
+---
+
+## 0. What this document is, and what it is not
+
+It is a **letter**, not a record of rulings.
+
+This repo keeps design rulings in the header comment of the code they govern,
+deliberately — `CLAUDE.md` says so, and the reason is that a document restating
+a ruling drifts away from the code and then argues with it. Section 5 below is
+a live demonstration of exactly that failure, caught this morning.
+
+So: no colour rules are restated here. Where a ruling is mentioned, the file
+that owns it is named. Grep the header before re-litigating anything.
+
+---
+
+## 1. Design's queue is closed
+
+Both handovers landed in full.
+
+| Handover | Shipped in | Notes |
+| --- | --- | --- |
+| Negative parentheses | [#298](../../) | Plus a follow-through Design did not ask for — see §4 |
+| Add Account modal review (8 items) | [#302](../../), [#304](../../) | 7 of 8 implemented; 1 declined, see §3 |
+
+Three of the eight "items" in the modal review turned out to be **one bug**
+wearing three faces, which is why #302's title says so. Worth knowing for how
+future lists are written: the symptoms were reported separately and were not
+separate.
+
+Everything else in #294–#311 came from the owner testing against his real
+ledger and his phone, not from Design. Listing it would be noise; the relevant
+outcomes are §3–§5.
+
+---
+
+## 2. The encryption question — answered, and built
+
+Design asked what was happening with export encryption. The owner's steer was
+"why can't we encrypt it, or give the user the option?" It shipped in
+[#294](../../).
+
+**What it is:** AES-256-GCM, with PBKDF2-SHA-256 at 600,000 iterations
+(OWASP's 2023 floor) turning the password into a key. Optional — an
+unencrypted backup is still available.
+
+**Three decisions Design may care about, because they are user-visible:**
+
+1. **It is still a `.json` file, and it says what it is.** The envelope carries
+   the algorithm, the KDF, the iteration count and the salt in readable
+   fields. Someone who finds one of these in five years, with this app long
+   gone, can read the header and knows how to open it. A backup that cannot be
+   opened without its original software is not a backup.
+2. **The iteration count travels in the file**, so raising it later does not
+   strand files written before the change.
+3. **GCM is authenticated**, which is the whole reason for choosing it: a file
+   altered by one byte fails to decrypt, rather than decrypting into
+   plausible-looking rubbish that then gets restored over real data.
+
+The failure copy names **both** faults it could be — wrong password, or damaged
+file — because the app genuinely cannot tell which, and guessing at one would
+send someone hunting for the wrong problem. `BackupDecryptionError`.
+
+**Not** built on the app's existing CryptoJS helper, which derives keys with the
+old OpenSSL `EVP_BytesToKey` construction (a few MD5 rounds, no configurable
+cost) and was separately measured at ~92% of the cost of every write in the app.
+
+---
+
+## 3. Declined: the interest-rate field on Loan/Savings
+
+Design's Add Account review asked for an interest-rate field on the Loan and
+Savings account types. **Not built.** The reason is not taste:
+
+- there is no `interest_rate` column on the accounts table in `supabase/`;
+- nothing in `src/` reads an interest rate off an account (the only
+  `interestRate` in the tree belongs to `types/financial-planning.ts`, a
+  separate feature with its own model);
+- so the field would accept a number, report it back on reopening, and change
+  nothing anywhere.
+
+That is the precise shape of the four controls we had just **removed** in
+[#305](../../) — Two-Factor, Biometric, End-to-End Encryption and Read-Only
+Mode, all of which stored a preference nothing read. A dead control in a
+security panel is a false statement about safety; a dead control on an account
+is a false statement about money. Neither is worth shipping to close a list
+item.
+
+**It is a good idea.** It wants the column, a decision about compounding, and
+somewhere that displays the consequence — then the field is honest. Happy to
+build it that way if Design wants to spec it.
+
+---
+
+## 4. Two findings from the parentheses work Design should know about
+
+**The mocks.** Applying the parentheses ruling surfaced that the test suite
+contained **24** hand-rolled fake currency formatters — tests asserting against
+their own invented `£1,234.56`, not against the app's real `formatCurrency`.
+They would have passed no matter what the ruling did to real output. All 24 now
+call the real formatter (#300). Design's ruling was fine; the instrument
+measuring it was not.
+
+**The speech path.** Parentheses are silent to a screen reader — `(£100.00)`
+and `£100.00` can read identically depending on the engine, which would have
+made the ruling *remove* information for anyone not looking at the screen. So
+`Amount` renders the visible text `aria-hidden` and supplies an accessible name
+from `formatCurrencyForSpeech`, which says the word "minus". Flagging it
+because any future ruling that changes how a sign is *drawn* has the same
+obligation.
+
+---
+
+## 5. What Design owes back: one open question
+
+**`src/components/LargeTransactionAlertSettings.tsx:89`** — the amber panel.
+
+It is a **preview**. It shows the user an example of the notification they will
+receive, and it is currently dressed in the warning pair.
+
+The question: does a preview of a warning wear the warning's colour? It is not
+warning anyone about anything — it is a sample. Under the four categories, a
+sample looks like it belongs in a neutral one, but that is a category call and
+category calls are Design's.
+
+Deliberately left alone. It was inside the blast radius of the AA sweep
+([#309](../../)) and I would not recategorise a panel on my own authority while
+already touching its neighbours.
+
+*(The other open question, "balance as of date", was resolved by the owner
+directly: Add Account now asks for an **opening** balance and when it was true
+— #304. No input needed.)*
+
+---
+
+## 6. A doctrine failure worth reporting, because it is Design's doctrine
+
+`semantic-contrast.test.ts` exists because Design asked, correctly, that
+contrast be **measured in this repo's harness, not calculated and asserted from
+memory** — after calculated figures failed here twice.
+
+This morning, moving `NEXT_ACTION_YELLOW` into the design system, the same
+failure was found one level up. The ratios were written **in prose** in the
+constant's header and **again** in prose at a call site, and the copies had
+drifted:
+
+| | claimed | measured |
+| --- | --- | --- |
+| amber-800 on amber-100 | 6.37 *and* 6.15 | **6.37** |
+| dark pair, as quoted at the call site | 10.7 | **9.16** on the card it sits on |
+
+The dark number was not merely stale — it was measured against the **gray-900
+page** and quoted for a panel that sits on a **gray-800 card**. That is the
+exact error Design's own rule was written to prevent, committed in prose by the
+person enforcing it in tests.
+
+Nothing failed AA; every pair clears it with room. That is *why* it survived
+three PRs.
+
+**Fixed properly:** the prose figures are gone, and the constant's six pairs are
+now measured on both surfaces by `semantic-contrast.test.ts`, reading the
+shades **out of the constant itself** so a shade change re-measures rather than
+re-remembers. Proven non-vacuous by breaking it four ways (injecting a
+non-colour utility, darkening the light text, darkening the dark text, dropping
+the hover state) and confirming each fails.
+
+**The generalisable rule, for Design's consideration:** a measured number
+written into prose becomes a remembered number the moment it is copied. If a
+ratio matters enough to state, it belongs in the assertion, and the prose should
+point at the test.
+
+---
+
+## 7. Parked, with reasons
+
+| Item | Status |
+| --- | --- |
+| Save & Next category bug | Owner's call: wait for the next bank import to reproduce it honestly rather than guess at it |
+| 844px tablet breakpoint | Owner's decision pending |
+| Twelve Data stock search | Built and merged (#311), inert until an API key is added to the deployment. Provider seam, so switching is config, not a rewrite |
+
+---
+
+## 8. State of the tree
+
+18 PRs merged in this stream, none open, working tree clean. Lint, strict
+types, 6,000+ unit tests, the desktop renderer's cloud-free greps and its size
+ratchet all green. The renderer got **5.6 KiB smaller** as a side effect of §6's
+move: `SubscriptionStatus` no longer pulls a reconciliation module into its
+chunk, which is the clearest argument that the constant was in the wrong place.

--- a/src/components/SubscriptionStatus.tsx
+++ b/src/components/SubscriptionStatus.tsx
@@ -3,7 +3,7 @@ import { CheckIcon, AlertCircleIcon, CreditCardIcon, CrownIcon, ZapIcon, UsersIc
 import { useSubscription } from '../contexts/SubscriptionContext';
 import { formatDistanceToNow } from 'date-fns';
 import { createScopedLogger } from '../loggers/scopedLogger';
-import { NEXT_ACTION_YELLOW } from './reconciliation/nextActionYellow';
+import { NEXT_ACTION_YELLOW } from '../design-system/nextActionYellow';
 
 interface PlanFeature {
   name: string;
@@ -207,17 +207,18 @@ export default function SubscriptionStatus(): React.JSX.Element {
                   sentence telling somebody their subscription is ending was
                   the least readable thing on the page.
 
-                  `NEXT_ACTION_YELLOW` is amber-800 on amber-100 — 6.15:1
-                  measured, and 10.7:1 for the dark pair. Swapped in whole
-                  rather than appended, per the constant's own constraint:
-                  Tailwind resolves two utilities for one property by source
-                  order, so mixing them leaves the winner to the compiler.
+                  `NEXT_ACTION_YELLOW` replaced it. Swapped in whole rather
+                  than appended, per the constant's own constraint: Tailwind
+                  resolves two utilities for one property by source order, so
+                  mixing them leaves the winner to the compiler.
 
-                  Note on its home: the constant lives under
-                  `components/reconciliation/` because that is where the idea
-                  was born, and it is no longer only theirs — Accounts wears it
-                  and now so does this. Moving it up is a follow-up, not a
-                  rider on an accessibility fix. */}
+                  No ratio is quoted here on purpose. The two that used to be
+                  had both drifted from the constant's own header, and one of
+                  them was the wrong SURFACE besides — a dark figure measured
+                  against the gray-900 page, quoted for a panel that sits on a
+                  gray-800 card. Neither failed AA, which is precisely why
+                  nobody noticed. `semantic-contrast.test.ts` measures every
+                  pair on both surfaces now; read the number off that. */}
               {cancelAtPeriodEnd && (
                 <div className={`p-3 rounded-lg border ${NEXT_ACTION_YELLOW}`}>
                   <div className="flex items-start gap-2">

--- a/src/components/reconciliation/ReconciliationBalanceBar.tsx
+++ b/src/components/reconciliation/ReconciliationBalanceBar.tsx
@@ -3,7 +3,8 @@ import { parseMoneyInput, toDecimal } from '../../utils/decimal';
 import MoneyInput from '../common/MoneyInput';
 import { useCurrencyDecimal } from '../../hooks/useCurrencyDecimal';
 import { formatDate } from '../../utils/dateFormatter';
-import { NEXT_ACTION_YELLOW, CONFIRM_BALANCE_HINT_ID } from './nextActionYellow';
+import { NEXT_ACTION_YELLOW } from '../../design-system/nextActionYellow';
+import { CONFIRM_BALANCE_HINT_ID } from './nextActionYellow';
 import type { ClearedSummary } from '../../hooks/useReconciliation';
 
 interface ReconciliationBalanceBarProps {

--- a/src/components/reconciliation/__tests__/ReconciliationBalanceBar.test.tsx
+++ b/src/components/reconciliation/__tests__/ReconciliationBalanceBar.test.tsx
@@ -3,7 +3,8 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { screen, fireEvent } from '@testing-library/react';
 import { renderWithProviders } from '../../../test/testUtils';
 import ReconciliationBalanceBar from '../ReconciliationBalanceBar';
-import { NEXT_ACTION_YELLOW, CONFIRM_BALANCE_HINT_ID } from '../nextActionYellow';
+import { NEXT_ACTION_YELLOW } from '../../../design-system/nextActionYellow';
+import { CONFIRM_BALANCE_HINT_ID } from '../nextActionYellow';
 
 /**
  * The closing balance — the statement's ending figure — is the only number on

--- a/src/components/reconciliation/nextActionYellow.ts
+++ b/src/components/reconciliation/nextActionYellow.ts
@@ -1,56 +1,4 @@
 /**
- * The yellow that means "your next action is here".
- *
- * ONE constant, worn by exactly ONE control at a time — and it MOVES. While the
- * closing balance is unconfirmed the question is on the balance bar, so the
- * closing-balance affordance wears it (the figure, the invitation to type one,
- * the editor) while Finalize Reconciliation sits dimmed and disabled. Confirm
- * the figure and the bar goes quiet while Finalize lights up in this same
- * yellow, because pressing it is now the only thing left to do. The eye follows
- * the colour from the question to the action.
- *
- * It used to mean "blocked", and was worn by both controls at once. That read
- * as two refusals rather than one instruction, and it left the user's actual
- * next step — the Confirm button — the quietest thing on the bar. Same eight
- * utilities, one meaning changed, so the name changed with it: a constant
- * called UNCONFIRMED_YELLOW hanging off a CONFIRMED button would be a lie in
- * the one place the design has to be read literally.
- *
- * CONSTRAINT: mutually exclusive, by construction. Both consumers branch on the
- * same fact — the closing balance has been agreed to — and emit this on
- * OPPOSITE sides of it, so there is no state in which both are yellow and none
- * in which neither is while the question is still open. Structural tests in
- * src/pages/__tests__/Reconciliation.yellowThread.test.tsx assert exactly that,
- * in both directions of the transition, because a thread that has drifted is
- * worse than no thread: the colours then claim a relationship that is no longer
- * true.
- *
- * CONSTRAINT: swap this in, never append it. Every utility here sets a colour
- * (background, text, border), and Tailwind resolves two utilities for the same
- * property by CSS source order, not by their order in a className — so emitting
- * this alongside `text-gray-900` or `dark:bg-gray-700` would leave the winner
- * to whichever the compiler happened to write last. Callers pick one branch or
- * the other.
- *
- * CONSTRAINT: colour only. Border WIDTH, radius, padding and typography stay
- * with each element, because a header button and a figure in a four-up grid do
- * not share those. Keeping this list purely `amber-*` is also what lets the
- * structural test compare two elements' yellow exactly, and catch a hardcoded
- * near-miss.
- *
- * CONTRAST: this is now an ENABLED control's colour on the Finalize side, so it
- * has to clear WCAG 1.4.3 AA (4.5:1) on its own — a disabled control would have
- * been exempt, a pressable one is not. Measured: amber-800 on amber-100 is
- * 6.37:1, and 5.69:1 against the amber-200 hover; in dark, amber-300 over
- * amber-900/30 composited on the page's gray-900 is 10.68:1, and 9.34:1 against
- * the amber-900/50 hover. All four pass AA; both dark pairs pass AAA. Re-measure
- * before changing any shade here.
- */
-export const NEXT_ACTION_YELLOW =
-  'bg-amber-100 text-amber-800 border-amber-300 hover:bg-amber-200 ' +
-  'dark:bg-amber-900/30 dark:text-amber-300 dark:border-amber-600 dark:hover:bg-amber-900/50';
-
-/**
  * The id of the paragraph that says, in words, why the balance bar is yellow
  * and why Finalize will not press.
  *
@@ -59,5 +7,10 @@ export const NEXT_ACTION_YELLOW =
  * is never the only signal, and a hardcoded id in three files is a dangling
  * reference waiting to happen. Referenced ONLY while that paragraph is
  * rendered (i.e. while unconfirmed), so it never points at nothing.
+ *
+ * NEXT_ACTION_YELLOW used to sit beside this and has moved to
+ * `src/design-system/nextActionYellow.ts`: three areas import the colour, only
+ * this page has this paragraph. The file kept its name so the reconciliation
+ * imports still read the same way.
  */
 export const CONFIRM_BALANCE_HINT_ID = 'reconciliation-confirm-hint';

--- a/src/design-system/__tests__/semantic-contrast.test.ts
+++ b/src/design-system/__tests__/semantic-contrast.test.ts
@@ -176,3 +176,104 @@ describe('semantic amount colours (DESIGN_PASS_2026-08 §2.1)', () => {
     expect(indexCss).toMatch(/body\s*\{[^}]*font-variant-numeric:\s*tabular-nums/);
   });
 });
+
+/**
+ * NEXT_ACTION_YELLOW, instrumented.
+ *
+ * Added 15 August 2026, when the constant moved out of
+ * `components/reconciliation/` and into the design system. The move surfaced
+ * why it needed a gate: the ratios were written in prose in the constant's
+ * header AND again at a call site, and the copies had drifted — 6.37 against
+ * 6.15 for the same light pair, and a dark figure measured on the gray-900
+ * page quoted for a panel sitting on a gray-800 card, where the real number is
+ * a point and a half lower. Nothing failed AA, which is exactly why it went
+ * unnoticed for three PRs.
+ *
+ * So the shades are read out of the constant itself rather than restated here.
+ * Change `text-amber-800` to `text-amber-600` and this re-measures and fails;
+ * hardcode the utilities in this file instead and it would happily keep
+ * measuring a colour the app no longer uses.
+ *
+ * BORDERS ARE DELIBERATELY NOT ASSERTED. `border-amber-300` on `bg-amber-100`
+ * is nowhere near 3:1, and should not be: the panel is identified by its
+ * background and its text, not by its edge, so WCAG 1.4.11 does not bite. An
+ * assertion invented here would only have had to be weakened later.
+ */
+describe('NEXT_ACTION_YELLOW (the one "your next action is here" colour)', () => {
+  // Tailwind v3 defaults; this project does not override amber.
+  const AMBER: Readonly<Record<string, string>> = {
+    '100': '#fef3c7', '200': '#fde68a', '300': '#fcd34d', '400': '#fbbf24',
+    '500': '#f59e0b', '600': '#d97706', '700': '#b45309', '800': '#92400e',
+    '900': '#78350f'
+  };
+
+  const source = read('src/design-system/nextActionYellow.ts');
+  const declaration = extract(
+    source,
+    /export const NEXT_ACTION_YELLOW\s*=([\s\S]*?);/,
+    'the NEXT_ACTION_YELLOW declaration'
+  );
+  const utilities = declaration.replace(/['"+]/g, ' ').split(/\s+/).filter(Boolean);
+
+  /** The hex a `bg-amber-900/30`-style utility actually paints on `surface`. */
+  const paint = (utility: string, surface: string): string => {
+    const match = utility.match(/amber-(\d+)(?:\/(\d+))?$/);
+    if (match === null) throw new Error(`Not an amber utility: ${utility}`);
+    const hex = AMBER[match[1]];
+    if (hex === undefined) throw new Error(`Unknown amber shade in ${utility}`);
+    if (match[2] === undefined) return hex;
+
+    const alpha = Number(match[2]) / 100;
+    const fg = ColorContrastChecker.hexToRgb(hex);
+    const bg = ColorContrastChecker.hexToRgb(surface);
+    return ColorContrastChecker.rgbToHex({
+      r: Math.round(fg.r * alpha + bg.r * (1 - alpha)),
+      g: Math.round(fg.g * alpha + bg.g * (1 - alpha)),
+      b: Math.round(fg.b * alpha + bg.b * (1 - alpha))
+    });
+  };
+
+  const only = (prefix: string): string[] =>
+    utilities.filter((u) => u.startsWith(prefix));
+
+  it('is colour ONLY, and all of it amber (the constant\'s own constraint)', () => {
+    // Border width, radius, padding and type belong to each element; a stray
+    // `px-3` here would silently impose a header button's padding on a figure
+    // in a four-up grid. And a non-amber utility would break the structural
+    // test that compares two elements' yellow exactly.
+    expect(utilities.length).toBeGreaterThan(0);
+    for (const utility of utilities) {
+      expect(utility).toMatch(/^(dark:)?(hover:)?(bg|text|border)-amber-\d+(\/\d+)?$/);
+    }
+  });
+
+  it('clears AA in light mode, at rest and on hover', () => {
+    const text = paint(only('text-amber')[0], '#ffffff');
+    const backgrounds = [...only('bg-amber'), ...only('hover:bg-amber')];
+    expect(backgrounds.length).toBe(2); // rest + hover, or the sweep below is partial
+
+    for (const background of backgrounds) {
+      const measured = ratio(text, paint(background, '#ffffff'));
+      expect(measured, `${text} on ${background}`).toBeGreaterThanOrEqual(AA_TEXT);
+    }
+  });
+
+  it('clears AA in dark on the gray-900 page AND the gray-800 cards', () => {
+    // The rule this whole file exists for: contrast is measured against the
+    // SURFACE the text sits on, not the page it sits in. This constant is worn
+    // on both — Reconciliation's balance bar sits on the page, the
+    // subscription notice sits in a card — and the two differ by ~1.5:1.
+    const darkText = only('dark:text-amber')[0];
+    const backgrounds = [...only('dark:bg-amber'), ...only('dark:hover:bg-amber')];
+    expect(backgrounds.length).toBe(2);
+
+    for (const surface of SURFACES_DARK) {
+      const text = paint(darkText, surface);
+      for (const background of backgrounds) {
+        const measured = ratio(text, paint(background, surface));
+        expect(measured, `${darkText} on ${background} over ${surface}`)
+          .toBeGreaterThanOrEqual(AA_TEXT);
+      }
+    }
+  });
+});

--- a/src/design-system/index.ts
+++ b/src/design-system/index.ts
@@ -1,4 +1,5 @@
 // Design System exports
+export * from './nextActionYellow';
 export * from './tokens';
 export * from './themes';
 export * from './utils';

--- a/src/design-system/nextActionYellow.ts
+++ b/src/design-system/nextActionYellow.ts
@@ -1,0 +1,84 @@
+/**
+ * The yellow that means "your next action is here".
+ *
+ * ─ WHY IT LIVES HERE NOW ───────────────────────────────────────────────────
+ *
+ * It was born in `components/reconciliation/`, and stayed there through two
+ * more consumers on the grounds that moving it was never worth its own risk on
+ * top of whatever fix was in hand. Three consumers in three different areas is
+ * where that stops being true: a constant every area imports, that lives inside
+ * one area, reads as though that area owns the meaning. It does not. The
+ * meaning is the app's.
+ *
+ * `CONFIRM_BALANCE_HINT_ID` did NOT come with it, and the split is the point —
+ * that id names one paragraph on one page, and is reconciliation's own.
+ *
+ * ─ WHAT IT MEANS ───────────────────────────────────────────────────────────
+ *
+ * A condition holds, and exactly ONE control ends it. Wear this on that
+ * control. It is not "blocked", not "warning", not "attention" — it is an
+ * instruction about where to go next, and it is the only colour in the app that
+ * means that.
+ *
+ * It once meant "blocked", and was worn by two controls at once. That read as
+ * two refusals rather than one instruction, and left the user's actual next
+ * step the quietest thing on screen. Same eight utilities, one meaning changed,
+ * so the name changed with it: a constant called UNCONFIRMED_YELLOW hanging off
+ * a CONFIRMED button would be a lie in the one place a design must read
+ * literally.
+ *
+ * Its original thread is still the clearest illustration. While the closing
+ * balance is unconfirmed the question is on the balance bar, so the
+ * closing-balance affordance wears it while Finalize sits dimmed and disabled.
+ * Confirm the figure and the bar goes quiet while Finalize lights up in this
+ * same yellow, because pressing it is now the only thing left to do. The eye
+ * follows the colour from the question to the action.
+ *
+ * ─ CONSTRAINT: one at a time, PER CONTEXT ──────────────────────────────────
+ *
+ * Within a view, at most one control may wear this — two next actions is no
+ * next action. Across views it is unremarkable: Reconciliation's thread and a
+ * subscription notice on another page never share a screen.
+ *
+ * Reconciliation's pair are mutually exclusive BY CONSTRUCTION, both branching
+ * on the same fact and emitting on opposite sides of it, and
+ * `src/pages/__tests__/Reconciliation.yellowThread.test.tsx` asserts that in
+ * both directions of the transition. A thread that has drifted is worse than no
+ * thread: the colours then claim a relationship that is no longer true.
+ *
+ * ─ CONSTRAINT: swap this in, never append it ───────────────────────────────
+ *
+ * Every utility here sets a colour (background, text, border), and Tailwind
+ * resolves two utilities for the same property by CSS source order, not by
+ * their order in a className — so emitting this alongside `text-gray-900` or
+ * `dark:bg-gray-700` would leave the winner to whichever the compiler happened
+ * to write last. Callers pick one branch or the other.
+ *
+ * ─ CONSTRAINT: colour only ─────────────────────────────────────────────────
+ *
+ * Border WIDTH, radius, padding and typography stay with each element, because
+ * a header button, a figure in a four-up grid and a notice in a card do not
+ * share those. Keeping this list purely `amber-*` is also what lets the
+ * structural test compare two elements' yellow exactly, and catch a hardcoded
+ * near-miss.
+ *
+ * ─ CONTRAST: measured, and no longer remembered ────────────────────────────
+ *
+ * This is an ENABLED control's colour wherever it lands, so it clears WCAG
+ * 1.4.3 AA (4.5:1) on its own — a disabled control would have been exempt, a
+ * pressable one is not.
+ *
+ * The figures are NOT quoted here any more. They were, in this header and again
+ * in prose at each call site, and by 15 August the copies disagreed: 6.37 here
+ * against 6.15 in `SubscriptionStatus`, and a dark figure of 10.7 quoted there
+ * for a panel that sits on a CARD, where the real number is 9.16. Nothing was
+ * failing — every pair clears AA with room — but a remembered number that has
+ * drifted is exactly what this repo's contrast doctrine exists to prevent.
+ *
+ * `src/design-system/__tests__/semantic-contrast.test.ts` now measures all six
+ * pairs on every surface this is used on, and fails if a shade here changes
+ * into something that does not clear AA. Read the number off the test.
+ */
+export const NEXT_ACTION_YELLOW =
+  'bg-amber-100 text-amber-800 border-amber-300 hover:bg-amber-200 ' +
+  'dark:bg-amber-900/30 dark:text-amber-300 dark:border-amber-600 dark:hover:bg-amber-900/50';

--- a/src/pages/Reconciliation.tsx
+++ b/src/pages/Reconciliation.tsx
@@ -13,7 +13,8 @@ import {
 } from '../components/reconciliation/reconciliationGrouping';
 import type { AccountGroupingOptions } from '../utils/accountGrouping';
 import ReconciliationBalanceBar, { CONFIRM_BALANCE_CONSEQUENCE } from '../components/reconciliation/ReconciliationBalanceBar';
-import { NEXT_ACTION_YELLOW, CONFIRM_BALANCE_HINT_ID } from '../components/reconciliation/nextActionYellow';
+import { NEXT_ACTION_YELLOW } from '../design-system/nextActionYellow';
+import { CONFIRM_BALANCE_HINT_ID } from '../components/reconciliation/nextActionYellow';
 import ReconciliationTransactionList from '../components/reconciliation/ReconciliationTransactionList';
 import ReconciliationFinalizationModal from '../components/reconciliation/ReconciliationFinalizationModal';
 import EditTransactionModal from '../components/EditTransactionModal';

--- a/src/pages/__tests__/Reconciliation.yellowThread.test.tsx
+++ b/src/pages/__tests__/Reconciliation.yellowThread.test.tsx
@@ -33,10 +33,8 @@ import { PreferencesProvider } from '../../contexts/PreferencesContext';
 import { ToastProvider } from '../../contexts/ToastContext';
 import { NotificationProvider } from '../../contexts/NotificationContext';
 import Reconciliation from '../Reconciliation';
-import {
-  NEXT_ACTION_YELLOW,
-  CONFIRM_BALANCE_HINT_ID,
-} from '../../components/reconciliation/nextActionYellow';
+import { NEXT_ACTION_YELLOW } from '../../design-system/nextActionYellow';
+import { CONFIRM_BALANCE_HINT_ID } from '../../components/reconciliation/nextActionYellow';
 import { __setAppContextValue, __resetAppContextValue } from '../../test/mocks/AppContextSupabase';
 import type { Account, Transaction } from '../../types';
 


### PR DESCRIPTION
Closes the last two items on the implementation side's list: the constant move that three PRs kept deferring, and the letter back to Claude Design.

## The move

`NEXT_ACTION_YELLOW` was defined in `components/reconciliation/` and imported by three areas. A constant every area imports, living inside one area, reads as though that area owns the meaning. It does not.

`CONFIRM_BALANCE_HINT_ID` did **not** come with it — that id names one paragraph on one page and is reconciliation's own. The file kept its name so the reconciliation imports still read the same way.

## What the move surfaced

The contrast ratios were written in prose in the constant's header **and again** at a call site, and the copies had drifted:

| | claimed | measured |
| --- | --- | --- |
| amber-800 on amber-100 | 6.37 *and* 6.15 | **6.37** |
| dark pair, at the call site | 10.7 | **9.16** on the card it sits on |

The dark number wasn't just stale — it was measured against the **gray-900 page** and quoted for a panel sitting on a **gray-800 card**. That is precisely the error `semantic-contrast.test.ts` was written to prevent, committed in prose by the file enforcing it in tests.

Nothing failed AA. Every pair clears it with room. That is *why* it survived three PRs.

## The fix

Prose figures deleted. `semantic-contrast.test.ts` now measures all six pairs on **both** dark surfaces, reading the shades **out of the constant itself** — so changing `text-amber-800` to `text-amber-600` re-measures and fails, rather than continuing to measure a colour the app no longer uses.

Borders are deliberately **not** asserted: `border-amber-300` on `bg-amber-100` is nowhere near 3:1 and shouldn't be, since the panel is identified by its background and text rather than its edge. An assertion invented there would only have had to be weakened later.

**Proven non-vacuous.** Broken four ways, each confirmed to fail while the clean constant passes:

| mutation | result |
| --- | --- |
| inject `px-3` (colour-only rule) | fails |
| `text-amber-800` → `text-amber-400` | fails |
| `dark:text-amber-300` → `dark:text-amber-700` | fails |
| drop `hover:bg-amber-200` | fails |

## Side effect

Desktop renderer is **5.6 KiB smaller raw** — `SubscriptionStatus` no longer pulls a reconciliation module into its chunk. The clearest argument that the constant was in the wrong place.

## The handover

`docs/handovers/2026-08-15-to-claude-design.md` — the encryption answer Design asked for, the one item declined (an interest-rate field with no column behind it, which would have been the same dead-control offence as the four removed in #305), the one question owed back (`LargeTransactionAlertSettings.tsx:89`, a *preview* wearing the warning pair), and the doctrine failure above.

It deliberately restates no rulings — this repo keeps those in the header of the code they govern, and section 6 is a live demonstration of why.

## Verification

lint · `typecheck:strict` · full unit suite (pre-commit) · `desktop:verify` (cloud-free greps + size ratchet) — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)