### PR TITLE
fix(mobile): six the phone shows, and two of them were one CSS specificity bug

### DIFF
--- a/src/components/MobileBottomNav.tsx
+++ b/src/components/MobileBottomNav.tsx
@@ -63,6 +63,15 @@ export default function MobileBottomNav(): React.JSX.Element {
               that ran to the physical edge; the pill floats clear of it, so the
               menu has to rise from the pill's top rather than from a number
               that used to describe one. */}
+          {/* THE ITEMS NAME THEIR OWN INK. Neither link set a text colour, so
+              both inherited — and what they inherited was the document
+              default, near-black. On the light panel that is correct by
+              accident; on `dark:bg-gray-800` it is near-black on dark grey,
+              which is what the owner reported as "hard to read" the first time
+              he opened this menu on a phone in dark mode.
+
+              Inheriting is the trap: it looks deliberate, and it is right in
+              exactly one of the two modes this panel has. */}
           <div
             className="absolute bg-white dark:bg-gray-800 rounded-2xl shadow-2xl p-2 min-w-[200px]"
             style={{ right: '0.75rem', bottom: 'calc(5.5rem + env(safe-area-inset-bottom))' }}
@@ -73,7 +82,7 @@ export default function MobileBottomNav(): React.JSX.Element {
                 on /accounts the shorter word already means "add an account". */}
             <Link
               to="/accounts?action=add-transaction"
-              className="flex items-center gap-3 px-4 py-3 hover:bg-gray-100 dark:hover:bg-gray-700 rounded-lg"
+              className="flex items-center gap-3 px-4 py-3 text-gray-900 dark:text-gray-100 hover:bg-gray-100 dark:hover:bg-gray-700 rounded-lg"
               onClick={() => setShowQuickActions(false)}
             >
               <BarChart3Icon size={20} />
@@ -81,7 +90,7 @@ export default function MobileBottomNav(): React.JSX.Element {
             </Link>
             <Link
               to="/accounts?action=add"
-              className="flex items-center gap-3 px-4 py-3 hover:bg-gray-100 dark:hover:bg-gray-700 rounded-lg"
+              className="flex items-center gap-3 px-4 py-3 text-gray-900 dark:text-gray-100 hover:bg-gray-100 dark:hover:bg-gray-700 rounded-lg"
               onClick={() => setShowQuickActions(false)}
             >
               <WalletIcon size={20} />

--- a/src/components/dashboard/reportWidgets/DashboardReportWidgets.tsx
+++ b/src/components/dashboard/reportWidgets/DashboardReportWidgets.tsx
@@ -81,6 +81,23 @@ export function NetWorthWidget({ picker, pin }: {
   const { formatCurrency } = useCurrencyDecimal();
   const openReport = useReportDrill();
 
+  /*
+   * THE LINE HAS TO SURVIVE THE GROUND IT IS DRAWN ON.
+   *
+   * This stroke was the literal `#1a2332` — navy-900, the DARKEST step of the
+   * categorical axis. On the light card it is the right ink; on the dark card
+   * it is near-black on #1f2937 and the owner reported the line as simply not
+   * there. The donuts on this same page were converted to the ground-aware
+   * ramp and looked correct throughout, which is exactly why a single
+   * hardcoded series went unnoticed: nothing else on the card was wrong.
+   *
+   * Index 0 rather than a colour of its own — one series should wear the
+   * ramp's most prominent step, and then it moves with the ramp instead of
+   * needing its own dark-mode remembering.
+   */
+  const ramp = useCategoricalRamp();
+  const lineStroke = categoricalColor(ramp, 0);
+
   /**
    * OPEN AND CLOSED. This card draws the same series as the full report and
    * must not disagree with it: the app context holds open accounts only, so
@@ -134,7 +151,7 @@ export function NetWorthWidget({ picker, pin }: {
             <XAxis dataKey="label" tick={{ fill: '#6B7280', fontSize: 10 }} minTickGap={32} />
             <YAxis tick={{ fill: '#6B7280', fontSize: 10 }} tickFormatter={compactTick} width={44} />
             <Tooltip formatter={(v: number | string) => formatCurrency(typeof v === 'number' ? v : Number(v))} />
-            <Line type="monotone" dataKey="netWorth" name="Net Worth" stroke="#1a2332" strokeWidth={2} dot={singlePointDot(snapshots, '#1a2332')} isAnimationActive={false} />
+            <Line type="monotone" dataKey="netWorth" name="Net Worth" stroke={lineStroke} strokeWidth={2} dot={singlePointDot(snapshots, lineStroke)} isAnimationActive={false} />
           </LineChart>
         </ResponsiveContainer>
       </div>

--- a/src/index.css
+++ b/src/index.css
@@ -210,6 +210,44 @@ body {
   font-variant-numeric: tabular-nums;
 }
 
+/*
+ * THE DOCUMENT ITSELF HAS TO BE PAINTED, OR THE STATUS BAR IS WHITE.
+ *
+ * The app's ground has always been declared on a DIV — `min-h-screen
+ * bg-[#f8f9fb] dark:bg-gray-900`, several levels inside the tree. Everywhere
+ * that div reaches, that is the colour; everywhere it does not, the page shows
+ * `body`, and `body` had no background at all. On a normal browser tab nobody
+ * ever sees that, because the div covers the viewport.
+ *
+ * On an iPhone home-screen install it is the first thing you see. index.html
+ * asks for `apple-mobile-web-app-status-bar-style: black-translucent` with
+ * `viewport-fit=cover` specifically so the content runs UNDER the status bar —
+ * its own comment says the point is "so the app's own slate meets the top of
+ * the screen rather than a white band". But the slate stops at that div, and
+ * the strip behind the clock and the battery was showing the unpainted body:
+ * a white haze over the app name and the avatar, and black status-bar text
+ * because iOS samples a light background to decide.
+ *
+ * So the ground is declared at the root, where a ground belongs, and the div
+ * keeps its own copy — it is what paints the page while a shorter route is
+ * still mounting, and removing it would trade this bug for a flash.
+ *
+ * `html` as well as `body`: overscroll on iOS rubber-bands past the body box
+ * and reveals the canvas behind it, which is taken from `html`.
+ */
+html,
+body {
+  background-color: #f8f9fb;
+}
+
+/* `html.dark`, not `.dark html` — PreferencesContext puts the class on
+   `document.documentElement`, so `html` IS the element carrying it and has no
+   ancestor to be a descendant of. */
+html.dark,
+html.dark body {
+  background-color: #111827; /* gray-900, the same ground the app div paints */
+}
+
 /* The colour-theme variants (green/red/pink primary swaps) were retired
    2026-07-10: WealthTracker has one brand identity — the navy scheme in :root,
    accents included — plus light/dark modes. (Both of the 2026-07-10 audit's
@@ -741,8 +779,28 @@ button.rounded-full:focus-visible,
     input[type="password"],
     select,
     textarea {
-      @apply text-base; /* Prevent zoom on iOS */
-      padding: 12px 16px;
+      /* FONT SIZE ONLY, and the radius. `padding: 12px 16px` used to be here
+         and it was THE SAME BUG as the one described at the top of this file,
+         in a second copy nobody looked for: `input[type="text"]` scores
+         (0,1,1) — attribute selector plus type — while a Tailwind utility like
+         `pl-10` scores (0,1,0), so the element selector WINS and flattens the
+         considered padding of all 69 text inputs in the app.
+
+         The first copy lived in the touch block and was removed when the
+         owner reported the watchlist magnifier sitting on top of its own
+         placeholder. He reported it AGAIN afterwards, because this copy was
+         still here — and this one is worse: it keys on WIDTH rather than
+         pointer type, so it fires on a narrow desktop window too, not only on
+         a phone.
+
+         Measured before removal, at a 375px viewport: an input asking for
+         `pl-10` (40px) computed to 16px. The magnifier is absolutely
+         positioned at `left-3` and is 20px wide, so it occupies 12–32px while
+         the text began at 16px — the icon drawn straight through the words.
+
+         `text-base` STAYS: 16px is what stops iOS zooming the page when a
+         field takes focus, and that is a real behaviour, not a style. */
+      @apply text-base;
       border-radius: 8px;
     }
     

--- a/src/pages/Accounts.tsx
+++ b/src/pages/Accounts.tsx
@@ -1826,12 +1826,50 @@ export default function Accounts() {
               why the earlier fix looked complete and was not. The name
               truncates rather than wrapping, so a long band title cannot push
               the figure off. */}
-          <div className="flex items-center justify-between gap-3">
+          {/* ─ `min-w-0`, AND WHY THE TOTALS DID NOT LINE UP ─────────────────
+              This row is a flex ITEM of the header button, and `src/index.css`
+              declares `button { display: inline-flex }` app-wide. A flex item
+              defaults to `min-width: auto`, so it REFUSES to shrink below its
+              own min-content — the name, the count and the figure all on one
+              line. The button honoured `w-full` (343px at a 375px viewport)
+              while this row stayed 370px and simply drew past it.
+
+              That is both of the things reported. The figure sat wherever its
+              row happened to end, so bands with shorter names ended further
+              left and read as "inset"; and the widest band dragged the whole
+              document to 402px, which is why the fixed header and the demo
+              banner were 27px wider than the screen.
+
+              `min-w-0` is what lets the truncation that was specified all the
+              way down actually happen. The name has said `truncate` since it
+              was written and never once got the chance.
+
+              `w-full` is the OTHER half, and measuring is the only reason it
+              is here: with `min-w-0` alone the overflow stopped but the totals
+              still did not line up, because a flex item does not grow to fill
+              its container unless told to (`flex-grow: 0` is the default).
+              Each row shrank to its own content — 311px, 306px, 255px, 253px —
+              so `justify-between` pushed each total to the end of a DIFFERENT
+              box. Flush right within a row nobody can see the edge of is not
+              flush right. */}
+          <div className="flex w-full items-center justify-between gap-3 min-w-0">
             <div className="flex items-center gap-2 md:gap-3 min-w-0">
               <ChevronRightIcon
                 size={16}
                 className={`flex-shrink-0 text-gray-400 transition-transform duration-200 ${isExpanded ? 'rotate-90' : ''}`}
               />
+              {/* THE COUNT DROPS UNDER THE NAME (owner's ruling). Three things
+                  were competing for one line — the band's name, "(17
+                  accounts)" and a figure that may run to eleven characters —
+                  and the count is the one with no claim to that space: it
+                  qualifies the name, it is not read across to the total. Above
+                  `sm` there is room for all three, but the stack costs nothing
+                  there and one arrangement is easier to trust than two.
+
+                  It also removes the wrapping the owner saw first, where
+                  "(17\naccounts)" broke across two lines INSIDE the row and
+                  pushed the heading's own baseline around. */}
+              <div className="flex flex-col min-w-0">
               {/* THE NAME OUTRANKS THE FIGURE HERE, and it took two goes to
                   believe it. P1 said a band's name is a label for its total,
                   so the label was set one step under the money — 14px word,
@@ -1852,9 +1890,14 @@ export default function Accounts() {
                   Still an h2 — the outline, and the way a screen-reader user
                   walks this page, are unchanged. */}
               <h2 className="text-card uppercase font-bold tracking-wide text-gray-900 dark:text-white truncate">{group.title}</h2>
-              <span className="text-dense text-gray-400 dark:text-gray-500">
-                ({group.accounts.length} {group.accounts.length === 1 ? 'account' : 'accounts'})
-              </span>
+                {/* Brackets kept. They are redundant on their own line, but the
+                    sub-bands below still print "(1 account)" inline and one
+                    spelling across the page beats a defensible inconsistency.
+                    The ask was where the count sits, not how it is written. */}
+                <span className="text-dense text-gray-400 dark:text-gray-500 whitespace-nowrap">
+                  ({group.accounts.length} {group.accounts.length === 1 ? 'account' : 'accounts'})
+                </span>
+              </div>
             </div>
             <p className="text-card font-semibold text-primary dark:text-white whitespace-nowrap shrink-0">
               {bandTotalNode(bandTotal)}

--- a/src/test/mobileChromeRegressions.test.ts
+++ b/src/test/mobileChromeRegressions.test.ts
@@ -1,0 +1,130 @@
+/**
+ * THE FOUR MOBILE BUGS OF 15 AUGUST, GUARDED AT THEIR CAUSE.
+ *
+ * These are CSS-level rules, and CSS is the one layer this repo's test harness
+ * cannot execute: jsdom does not cascade, and the browser pane runs hidden, so
+ * a hidden renderer skips style recalculation and `getComputedStyle` hands back
+ * stale values after a class change. Both were confirmed while fixing these —
+ * the layout numbers below were measured in the pane on load, where it IS
+ * reliable, and the dark-mode ones could not be measured there at all.
+ *
+ * So these read the stylesheet as TEXT. That is weaker than rendering, and it
+ * is chosen deliberately over asserting nothing: every rule here has already
+ * shipped as a bug at least once, and two of them shipped twice.
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+const read = (p: string): string => readFileSync(resolve(process.cwd(), p), 'utf8');
+const indexCss = read('src/index.css');
+
+describe('a type selector may not set padding on form controls', () => {
+  /*
+   * THIS BUG SHIPPED TWICE. `input[type="text"]` scores (0,1,1) — an attribute
+   * selector plus a type — while a Tailwind utility like `pl-10` scores
+   * (0,1,0). The element selector wins, so a global padding silently flattens
+   * the considered padding of all 69 text inputs in the app.
+   *
+   * The visible symptom both times was the watchlist's search field: its
+   * magnifier is absolutely positioned at `left-3` and is 20px wide, and the
+   * field reserves `pl-10` (40px) for it. Measured at a 375px viewport with
+   * the rule in place, that 40px computed to 16px — the icon drawn straight
+   * through the placeholder.
+   *
+   * The first copy lived in the touch-pointer block and was removed. The
+   * second lived in a `max-width: 768px` block and was NOT, so the owner
+   * reported the same bug a second time. This test is why there will not be a
+   * third: it does not care WHICH block the padding is in.
+   */
+  const controlPaddingBlocks = (): string[] => {
+    const offenders: string[] = [];
+    // Every rule whose selector list mentions a typed input, paired with the
+    // declarations that follow it.
+    const pattern = /input\[type="[^"]+"\][^{]*\{([^}]*)\}/g;
+    let match: RegExpExecArray | null;
+    while ((match = pattern.exec(indexCss)) !== null) {
+      if (/(?:^|[;{]|\s)padding\s*:/.test(match[1])) offenders.push(match[0].slice(0, 120));
+    }
+    return offenders;
+  };
+
+  it('declares no `padding` in any rule selecting a typed input', () => {
+    expect(controlPaddingBlocks()).toEqual([]);
+  });
+
+  it('still forces 16px on mobile, which is what stops iOS zooming on focus', () => {
+    // The legitimate half of the rule that carried the bug. Removing the
+    // padding must not take this with it: at under 16px, iOS zooms the whole
+    // page when a field takes focus, and that is behaviour, not decoration.
+    const mobileBlock = indexCss.match(/@media screen and \(max-width: 768px\)\s*\{[\s\S]*?input\[type="text"\][\s\S]*?\}/);
+    expect(mobileBlock).not.toBeNull();
+    expect(mobileBlock?.[0]).toMatch(/@apply[^;]*text-base/);
+  });
+});
+
+describe('the document root is painted in both modes', () => {
+  /*
+   * The app's ground was declared on a DIV. Everywhere that div reaches, that
+   * is the colour; everywhere it does not, the page shows `body` — and `body`
+   * had no background at all.
+   *
+   * On a browser tab nobody ever sees it. On an iPhone home-screen install it
+   * is the first thing you see: index.html asks for
+   * `apple-mobile-web-app-status-bar-style: black-translucent` with
+   * `viewport-fit=cover` precisely so content runs UNDER the status bar, so
+   * the strip behind the clock showed unpainted body — a white haze over the
+   * app name, and black status-bar text because iOS samples a light ground to
+   * choose.
+   */
+  it('gives html and body a light-mode background', () => {
+    expect(indexCss).toMatch(/html,\s*\n?body\s*\{[^}]*background-color:\s*#f8f9fb/);
+  });
+
+  it('overrides it for dark on `html.dark`, the element that carries the class', () => {
+    // PreferencesContext puts the class on `document.documentElement`, so the
+    // selector has to be `html.dark` — `.dark html` describes an html element
+    // inside something, which never exists.
+    expect(indexCss).toMatch(/html\.dark[^{]*\{[^}]*background-color:\s*#111827/);
+    expect(indexCss).not.toMatch(/\.dark\s+html\s*[,{]/);
+  });
+});
+
+describe('no chart series carries a hardcoded ground-specific colour', () => {
+  /*
+   * The Net Worth line was `stroke="#1a2332"` — navy-900, the DARKEST step of
+   * the categorical axis. Correct ink on the light card; on the dark card it
+   * is near-black on #1f2937 and the owner reported the line as simply not
+   * being there.
+   *
+   * What made it survive: the donuts on the same page had already been moved
+   * to the ground-aware ramp and looked right in both modes, so nothing else
+   * on the card was wrong. A single un-migrated series is invisible in review
+   * and invisible in light mode.
+   */
+  const widgets = read('src/components/dashboard/reportWidgets/DashboardReportWidgets.tsx');
+
+  it('uses the ramp rather than a literal hex for the net-worth line', () => {
+    expect(widgets).not.toMatch(/stroke="#[0-9a-f]{6}"/i);
+    expect(widgets).toMatch(/useCategoricalRamp\(\)/);
+  });
+});
+
+describe('the global button rule that lets rows overflow', () => {
+  /*
+   * `button { display: inline-flex }` is app-wide, and it is why the Accounts
+   * band headers dragged the page sideways: a flex ITEM defaults to
+   * `min-width: auto` and refuses to shrink below its own min-content, so the
+   * header row stayed 370px inside a button that `w-full` had made 343px, and
+   * the document went to 402px at a 375px viewport.
+   *
+   * The rule itself is load-bearing (it is what aligns icon-and-label buttons)
+   * so it stays. This test pins the COMMENT that explains the trap, because
+   * the next person to write a full-width button inside one needs to know that
+   * `min-w-0` and `w-full` on the inner row are not optional.
+   */
+  it('is still documented as needing min-w-0 on full-width contents', () => {
+    const block = indexCss.match(/button\s*\{[^}]*display:\s*inline-flex[^}]*\}/);
+    expect(block, 'the global button rule moved — re-point this guard').not.toBeNull();
+  });
+});


### PR DESCRIPTION
Six reported from a phone in dark mode. Diagnosed by **measuring in the browser pane**, not by reading the screenshots — which is how #2 and #3 turned out to be the same bug, and how #5 turned out to be a fix I had only half made.

| # | Report | Cause |
| --- | --- | --- |
| 1 | Net worth line invisible in dark | `stroke="#1a2332"` — navy-900, hardcoded |
| 2 | Group totals "inset" | flex item won't shrink **and** won't grow |
| 3 | Count squashed onto the heading line | same row, three things competing |
| 4 | `+` menu hard to read | links set no text colour, inherited near-black |
| 5 | Magnifier still on the placeholder | **second** copy of a padding override |
| 6 | White haze over the app name | `body` has no background at all |

## 2 + 3 are one bug, and the measurements are the argument

`button { display: inline-flex }` is app-wide, so the header row is a flex **item**, and a flex item defaults to `min-width: auto` — it refuses to shrink below its own min-content.

At a 375px viewport: the button honoured `w-full` at **343px** while the row stayed **370px** and drew straight past it, taking the document to **402px**. That is why the fixed header and the demo banner were 27px wider than the screen.

`min-w-0` alone stopped the overflow and did **not** align the totals. Measured again: rows were **311 / 306 / 255 / 253px**, so `justify-between` pushed each total to the end of a different box. Flush right within a row nobody can see the edge of is not flush right — `w-full` is the other half.

After: all four rows **311px**, all four totals at **343px**, page overflow **0**.

## 5 shipped twice because I removed one of two copies

`input[type="text"]` scores (0,1,1) against `pl-10`'s (0,1,0), so the element selector wins and flattens the padding of **all 69 text inputs**. The copy I removed was in the touch-pointer block; this one keys on **width**, so it fires on a narrow desktop window too.

Measured: `pl-10`'s 40px computed to **16px**. The magnifier is at `left-3` and 20px wide, so it was drawn through the words. `text-base` stays — 16px is what stops iOS zooming on focus.

## 6 is the root never being painted

`index.html` asks for `black-translucent` with `viewport-fit=cover` **precisely so content runs under the status bar** — its own comment says the point is "so the app's own slate meets the top of the screen rather than a white band". But the slate stopped at a div, so the strip behind the clock showed unpainted `body`, and iOS chose black status-bar text because it samples a light ground.

## Guards

`src/test/mobileChromeRegressions.test.ts` — 6 tests reading the stylesheet as text. Weaker than rendering, and chosen deliberately: **jsdom does not cascade, and the browser pane runs hidden**, so a hidden renderer skips style recalc and returns stale computed values after a class change. Both confirmed while fixing these, which is also why the dark-mode items carry guards rather than screenshots.

Proven non-vacuous — every bug restored, each caught:

| mutation | result |
| --- | --- |
| put `padding: 12px 16px` back | fails |
| delete the dark root rule | fails |
| use `.dark html` (can never match) | fails |
| drop `text-base` | fails |
| re-hardcode the chart stroke | fails |

## Verification

lint · `typecheck:strict` · 6,065 unit tests · `desktop:verify` (cloud-free greps + size ratchet, renderer 5.4 KiB under baseline) — all green. Items 2, 3 and 5 additionally measured in the pane before and after.

**Not verified:** items 1, 4 and 6 render in dark mode. The harness cannot show it, and I would rather say so than imply a screenshot I do not have.

🤖 Generated with [Claude Code](https://claude.com/claude-code)