### PR TITLE
fix(dark-mode): the sign-up button had my own regression on it, and Find's intro centres

### DIFF
--- a/src/pages/Find.tsx
+++ b/src/pages/Find.tsx
@@ -407,12 +407,21 @@ export default function Find(): React.JSX.Element {
         </div>
       ) : nothingAsked ? (
         // Not an empty state: nothing is missing and nothing is hidden. It is
-        // the page explaining itself before it has been asked anything — so it
-        // keeps its own voice, but reads down the left edge like everything
-        // else now, without the decorative glyph §4 rules out.
-        <div className="bg-white dark:bg-gray-800 rounded-lg shadow-sm border border-gray-200 dark:border-gray-700 px-6 py-10">
+        // the page explaining itself before it has been asked anything, and
+        // that argument is why it was originally left reading down the left
+        // edge while the true empty states were centred.
+        //
+        // Overruled by the owner, on the ground that beats it: he is looking at
+        // a PAGE, not at a taxonomy. Whatever this block is called, it occupies
+        // the same slot as the two states either side of it, and a panel that
+        // jumps from centred to left-aligned depending on which branch rendered
+        // reads as a layout bug rather than as a distinction. Consistency was
+        // his ruling when the empty states were centred ("it looks cleaner,
+        // especially on mobile view") and it applies here for the same reason.
+        // Still no decorative glyph — §4 rules that out either way.
+        <div className="bg-white dark:bg-gray-800 rounded-lg shadow-sm border border-gray-200 dark:border-gray-700 px-6 py-10 text-center">
           <h3 className="text-card font-semibold text-gray-900 dark:text-white">Find looks through every account at once</h3>
-          <p className="mt-1 max-w-2xl text-body text-gray-600 dark:text-gray-400">
+          <p className="mt-1 mx-auto max-w-2xl text-body text-gray-600 dark:text-gray-400">
             Type part of a description, or an amount as your statement prints it — 141.50 finds it
             whichever way the money went. Click a result to open that transaction in its own
             account&rsquo;s register, which is where you can change it.

--- a/src/pages/Welcome.tsx
+++ b/src/pages/Welcome.tsx
@@ -85,7 +85,19 @@ export default function Welcome(): React.JSX.Element {
           <SignUpButton mode="modal">
             <button
               type="button"
-              className="inline-flex items-center justify-center gap-2 px-6 py-3 rounded-xl bg-white text-primary font-semibold shadow-sm hover:bg-white/90 transition-colors"
+              /* `text-nav-bg`, NOT `text-primary` — and the difference is the
+                 whole bug. `.dark .text-primary` is `#f9fafb !important`,
+                 added so the app's primary ink stays readable on dark
+                 SURFACES. This button's surface is not dark: it is `bg-white`
+                 in both modes, deliberately, because it is the one loud thing
+                 on a navy hero. So in dark mode the remap painted near-white
+                 text on a white button and the label vanished.
+
+                 A utility that means "the app's ink, inverted for dark" cannot
+                 serve an element whose own background does not invert. Both
+                 resolve to #1a2332 in light, which is why this looked
+                 identical until someone opened the sign-in page in dark. */
+              className="inline-flex items-center justify-center gap-2 px-6 py-3 rounded-xl bg-white text-nav-bg font-semibold shadow-sm hover:bg-white/90 transition-colors"
             >
               Get started
               <ArrowRightIcon size={18} />


### PR DESCRIPTION
Two from the owner's phone and desktop.

## 1. "Get started" unreadable in dark — and it was mine

`bg-white text-primary` on the Welcome hero. In #295 I added `.dark .text-primary { color: #f9fafb !important }` so the app's primary ink stays readable on dark **surfaces**.

This button's surface is not dark. It is `bg-white` in **both** modes, deliberately, because it is the one loud thing on a navy hero. So the remap painted near-white text on a white button and the label vanished.

> A utility meaning "the app's ink, inverted for dark" cannot serve an element whose own background does not invert.

`text-nav-bg` instead — the same `#1a2332`, declared as the brand navy rather than as a token that flips. Both resolve identically in light, which is why this looked fine until someone opened the sign-in page in dark.

**Checked for siblings.** Four other places pair a light background with `text-primary`; all four are hover states or carry `dark:` variants that put them on dark surfaces, where the remap is doing its job. This was the only genuine offender.

## 2. Find's intro reads centred

It was left aligned left on the argument that it is not an empty state — nothing is missing and nothing is hidden, it is the page explaining itself before it has been asked anything.

Overruled by the owner on the ground that beats it: he is looking at a **page**, not at a taxonomy. Whatever the block is called, it occupies the same slot as the two states either side of it, and a panel that jumps from centred to left-aligned depending on which branch rendered reads as a layout bug rather than as a distinction. Same ruling, and same reason, as when the empty states were centred.

## Verification

lint · `typecheck:strict` · full unit suite (pre-commit) · the 27 Find tests specifically — green.

**Not verified:** that #1 renders correctly in dark. The browser pane runs hidden and skips style recalc after a class change, so dark mode is not observable there. The reasoning is above and the token is a plain hex with no dark variant, so there is nothing left to flip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)