### PR TITLE
feat(accounts): a liability can say what it is secured against

### DIFF
--- a/src/components/AccountSettingsModal.tsx
+++ b/src/components/AccountSettingsModal.tsx
@@ -65,9 +65,47 @@ interface FormData {
   lowBalanceThreshold: string;
   /** Investment account this one's money sits inside; '' = not paired. */
   parentAccountId: string;
+  securedAgainstAccountId: string;
 }
 
 const NO_PARENT_ACCOUNT = '';
+const NOT_SECURED = '';
+
+/** The types that are somebody's debt. Everything else can BE secured against. */
+const LIABILITY_TYPES: ReadonlySet<string> = new Set(['loan', 'credit', 'other']);
+
+/**
+ * What this liability may be held against: any account that is not itself a
+ * debt, and is not this one.
+ *
+ * Nested accounts ARE offered, unlike the pairing dropdown above, and the
+ * asymmetry is deliberate. Pairing refuses them because nesting a nested
+ * account would make a chain that has to be walked and could cycle. Securing
+ * walks nothing — it is one hop, read for display — so a loan may perfectly
+ * well be held against a cash sleeve inside a portfolio, which is exactly the
+ * arrangement the owner described.
+ */
+function resolveSecuring(
+  account: BaseAccount,
+  accounts: readonly BaseAccount[],
+  selectedType: BaseAccount['type']
+): PairingState {
+  const options = accounts.filter(a =>
+    !LIABILITY_TYPES.has(a.type) &&
+    a.id !== account.id &&
+    a.isActive !== false
+  );
+  const current = account.securedAgainstAccountId
+    ? accounts.find(a => a.id === account.securedAgainstAccountId)
+    : undefined;
+  // A target that has since been closed stays listed, or saving any other
+  // change on this form would silently drop the link.
+  if (current && !options.some(a => a.id === current.id)) options.push(current);
+  return {
+    offered: LIABILITY_TYPES.has(selectedType) && options.length > 0,
+    options
+  };
+}
 
 /** What the pairing field may offer this account, and whether it appears at all. */
 interface PairingState {
@@ -158,7 +196,8 @@ export default function AccountSettingsModal({
       isActive: true,
       lowBalanceAlertEnabled: false,
       lowBalanceThreshold: '',
-      parentAccountId: NO_PARENT_ACCOUNT
+      parentAccountId: NO_PARENT_ACCOUNT,
+      securedAgainstAccountId: NOT_SECURED
     },
     {
       onSubmit: async (data) => {
@@ -192,6 +231,12 @@ export default function AccountSettingsModal({
           // clears it — mapAccountToDb drops undefined fields.
           ...(resolvePairing(account, accounts, data.type).offered
             ? { parentAccountId: data.parentAccountId || null }
+            : {}),
+          // Same rule, same reason: changing an account's type from Loan to
+          // Savings takes the control off screen, and a link written from a
+          // field nobody saw is a link nobody chose.
+          ...(resolveSecuring(account, accounts, data.type).offered
+            ? { securedAgainstAccountId: data.securedAgainstAccountId || null }
             : {}),
           // Same rule, and for a much sharper reason: only ever written when
           // the field was EDITABLE. On an account with history the value on
@@ -255,7 +300,8 @@ export default function AccountSettingsModal({
         isActive: account.isActive !== false,
         lowBalanceAlertEnabled: account.lowBalanceAlertEnabled ?? false,
         lowBalanceThreshold: account.lowBalanceThreshold != null ? account.lowBalanceThreshold.toString() : '',
-        parentAccountId: account.parentAccountId ?? NO_PARENT_ACCOUNT
+        parentAccountId: account.parentAccountId ?? NO_PARENT_ACCOUNT,
+        securedAgainstAccountId: account.securedAgainstAccountId ?? NOT_SECURED
       });
     }
   }, [account, setFormData]);
@@ -288,6 +334,7 @@ export default function AccountSettingsModal({
   // (so editing a closed account never quietly reopens it).
   const isClosedAccount = account.isActive === false;
   const pairing = resolvePairing(account, accounts, formData.type);
+  const securing = resolveSecuring(account, accounts, formData.type);
 
   return (
     <Modal isOpen={isOpen} onClose={onClose} title="Account Settings" size="md">
@@ -501,6 +548,35 @@ export default function AccountSettingsModal({
                 keeps its own register and transactions; it moves inside that
                 account on the Accounts page, and its balance counts towards
                 that investment's value.
+              </p>
+            </div>
+          )}
+
+          {/* What this debt is held against — see the Account type for why this
+              is not the pairing above. The helper text has to do real work
+              here: the two controls look identical and mean opposite things
+              about totals, so it says plainly that nothing moves and nothing
+              is added. */}
+          {securing.offered && (
+            <div>
+              <label htmlFor="account-secured-against" className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+                Secured against
+              </label>
+              <select
+                id="account-secured-against"
+                value={formData.securedAgainstAccountId}
+                onChange={(e) => updateField('securedAgainstAccountId', e.target.value)}
+                className="w-full px-3 py-2 bg-white dark:bg-gray-800 border border-gray-300/50 dark:border-gray-600/50 rounded-xl focus:border-transparent dark:text-white"
+              >
+                <option value={NOT_SECURED}>Nothing — this is an unsecured debt</option>
+                <GroupedAccountOptions accounts={securing.options} />
+              </select>
+              <p className="mt-1 text-xs text-gray-500 dark:text-gray-400">
+                For a mortgage held against a property, or a loan drawn against
+                an investment. This account stays where it is under Liabilities
+                and its balance is not added to anything — the link only shows
+                the two together, and lets the Investments page offer a net
+                position if you want one.
               </p>
             </div>
           )}

--- a/src/pages/Accounts.tsx
+++ b/src/pages/Accounts.tsx
@@ -371,6 +371,36 @@ export default function Accounts() {
   // can never disagree about what a paired account is worth.
   const nestedByParent = useMemo(() => buildChildrenByParent(openAccounts), [openAccounts]);
 
+  /**
+   * Secured liabilities, keyed by the account they are held AGAINST — a
+   * mortgage under its property, a loan under the portfolio it is drawn on.
+   *
+   * Deliberately NOT built with `buildChildrenByParent`, even though the shape
+   * is identical. That helper answers "where does this account's money belong",
+   * and the answer for a secured liability is "exactly where it already is".
+   * Everything downstream of the nesting utilities — the band totals, the
+   * top-level walk, the portfolio summary — is right to count what it groups,
+   * so this must not travel through any of it. A separate map that only the
+   * renderer reads is the difference between showing a relationship and
+   * asserting one.
+   *
+   * The target must be OPEN and must not be the liability itself, for the same
+   * reason nesting checks it: a row keyed under a card that is not on the page
+   * is a row nobody ever sees.
+   */
+  const securedByTarget = useMemo(() => {
+    const byId = new Map(openAccounts.map(a => [a.id, a]));
+    const map = new Map<string, Account[]>();
+    for (const account of openAccounts) {
+      const targetId = account.securedAgainstAccountId;
+      if (!targetId || targetId === account.id || !byId.has(targetId)) continue;
+      const list = map.get(targetId);
+      if (list) list.push(account);
+      else map.set(targetId, [account]);
+    }
+    return map;
+  }, [openAccounts]);
+
   const topLevelAccounts = useMemo(() => selectTopLevelAccounts(openAccounts), [openAccounts]);
   const [closedAccounts, setClosedAccounts] = useState<Account[]>([]);
   const [showClosedAccounts, setShowClosedAccounts] = useState(false);
@@ -1695,6 +1725,57 @@ export default function Accounts() {
                         </div>
                       );
                     })}
+
+                    {/* ─ WHAT IS HELD AGAINST THIS ACCOUNT ────────────────────
+                        A mortgage under its property, a loan under the
+                        portfolio it is drawn on. These rows are NOT the same
+                        kind of thing as the cash sleeves above them, and the
+                        design has to say so before the reader assumes they are:
+
+                          · the cash sleeve is part of this account and its
+                            money is already in the figure above. A secured
+                            liability is somebody else's claim, counted in
+                            Liabilities, and adding it here would restate the
+                            value of a house as its equity.
+                          · so this row prints no columns. AccountRowColumns is
+                            the grammar of "a row that participates"; borrowing
+                            it would put a debt in the Account Bal column and
+                            invite exactly the arithmetic this must not imply.
+
+                        NO FIGURE, on the owner's ruling, and it is the sharper
+                        version of the same argument: "we are just highlighting
+                        that this account is linked with a liability —
+                        fundamentally it does not change the workings of the
+                        accounts page." A balance printed here would sit inches
+                        under the account's own and invite the subtraction, no
+                        matter what the caption said. A name cannot be added up.
+                        The figure lives where the debt lives, in Liabilities,
+                        and on the Investments page where a net position can be
+                        asked for deliberately.
+
+                        No colour and no icon of alarm. A mortgage against a
+                        house needs no attention — it is the ordinary shape of
+                        owning one — and colour marks what needs attention. */}
+                    {(securedByTarget.get(account.id) ?? []).length > 0 && (
+                      <p className="mt-2 ml-6 sm:ml-9 text-[11px] text-gray-500 dark:text-gray-400">
+                        <span className="font-medium">Linked liabilities:</span>{' '}
+                        {(securedByTarget.get(account.id) ?? []).map((liability, i) => (
+                          <span key={liability.id}>
+                            {i > 0 && ', '}
+                            <Link
+                              to={registerPath(liability.id)}
+                              state={registerLinkState(liability.id)}
+                              className={`${ACCOUNT_ROW_NAME_LINK_CLASS} underline decoration-dotted underline-offset-2`}
+                              title={`Open ${liability.name}`}
+                            >
+                              {liability.name}
+                            </Link>
+                          </span>
+                        ))}
+                        {' — '}shown for information; counted under Liabilities,
+                        not here.
+                      </p>
+                    )}
                   </div>
     );
   };

--- a/src/pages/Investments.tsx
+++ b/src/pages/Investments.tsx
@@ -9,6 +9,7 @@ import StockWatchlist from '../components/StockWatchlist';
 import { PieChart as RePieChart, Pie, Cell, ResponsiveContainer, Tooltip, LineChart, Line, XAxis, YAxis, CartesianGrid } from '../components/charts/OptimizedCharts';
 import { useCurrencyDecimal } from '../hooks/useCurrencyDecimal';
 import { toDecimal } from '../utils/decimal';
+import { useLocalStorage } from '../hooks/useLocalStorage';
 import type { DecimalInstance } from '../utils/decimal';
 import { formatDecimal } from '../utils/decimal-format';
 import PageWrapper from '../components/PageWrapper';
@@ -253,6 +254,53 @@ export default function Investments() {
     [openAccounts, transactions, transactionSplits, categories]
   );
 
+  /**
+   * GROSS OR NET — the one place a secured liability is allowed near a total.
+   *
+   * `securedAgainstAccountId` is display-only everywhere else by design: a
+   * mortgage does not move section and is never added to the asset it is held
+   * against. This is the deliberate exception, and it is opt-in for the reason
+   * that makes it safe — GROSS is the default and is what this page has always
+   * shown, so nobody's portfolio value changes meaning without them asking.
+   *
+   * Only liabilities secured against an account that COUNTS toward this
+   * portfolio are subtracted, which is the pairs the summary already walks:
+   * a loan drawn against a cash sleeve is drawn against the portfolio, because
+   * the sleeve's money is in the portfolio's value.
+   */
+  const [showNetPosition, setShowNetPosition] = useLocalStorage<boolean>(
+    'wt_investments_net_position',
+    false
+  );
+
+  const securedAgainstPortfolio = useMemo(() => {
+    // Every account whose money counts toward an investment account.
+    const withinPortfolio = new Set<string>();
+    for (const account of openAccounts) {
+      if (account.type === 'investment') withinPortfolio.add(account.id);
+    }
+    for (const account of openAccounts) {
+      const parentId = account.parentAccountId;
+      if (parentId && withinPortfolio.has(parentId)) withinPortfolio.add(account.id);
+    }
+
+    let total = toDecimal(0);
+    const names: string[] = [];
+    for (const account of openAccounts) {
+      const target = account.securedAgainstAccountId;
+      if (!target || !withinPortfolio.has(target)) continue;
+      // A debt is carried negative, and this is a magnitude to subtract.
+      total = total.plus(toDecimal(Math.abs(account.balance ?? 0)));
+      names.push(account.name);
+    }
+    return { total, names };
+  }, [openAccounts]);
+
+  const netPortfolioValue = useMemo(
+    () => toDecimal(summary.value).minus(securedAgainstPortfolio.total),
+    [summary.value, securedAgainstPortfolio.total]
+  );
+
   // The window the chart covers. 'ALL' is unbounded at both ends, which the
   // history walk reads as "first transaction until today".
   const historyRange = useMemo(() => {
@@ -475,11 +523,43 @@ export default function Investments() {
                 again in a picture; the arrows on Total Return and Return %
                 below stay, because those carry DIRECTION and a direction is
                 not decoration. Same reduction as #281 and #296. */}
-            <div>
-              <p className="text-body text-gray-500 dark:text-gray-400">Portfolio Value</p>
-              <p className="text-page font-bold text-gray-900 dark:text-white">
-                {formatCurrency(summary.value)}
+            <div className="min-w-0">
+              <p className="text-body text-gray-500 dark:text-gray-400">
+                {showNetPosition && securedAgainstPortfolio.names.length > 0
+                  ? 'Portfolio Value (net)'
+                  : 'Portfolio Value'}
               </p>
+              <p className="text-page font-bold text-gray-900 dark:text-white">
+                {formatCurrency(
+                  showNetPosition && securedAgainstPortfolio.names.length > 0
+                    ? netPortfolioValue
+                    : summary.value
+                )}
+              </p>
+              {/* The control appears ONLY when something is actually secured
+                  against this portfolio. A gross/net switch with nothing to
+                  net off is a question about a distinction that does not exist
+                  here, and answering it changes no number — which teaches the
+                  reader that the switch does nothing.
+
+                  When it IS shown, the label says which liabilities, because
+                  "net" is not self-explanatory and a total whose composition
+                  you cannot see is a total you cannot check. */}
+              {securedAgainstPortfolio.names.length > 0 && (
+                <div className="mt-3">
+                  <label className="flex items-start gap-2 cursor-pointer">
+                    <input
+                      type="checkbox"
+                      checked={showNetPosition}
+                      onChange={(e) => setShowNetPosition(e.target.checked)}
+                      className="mt-0.5 shrink-0"
+                    />
+                    <span className="text-dense text-gray-500 dark:text-gray-400">
+                      Subtract secured liabilities ({securedAgainstPortfolio.names.join(', ')})
+                    </span>
+                  </label>
+                </div>
+              )}
             </div>
           </div>
         </div>

--- a/src/services/api/accountMapping.ts
+++ b/src/services/api/accountMapping.ts
@@ -175,6 +175,9 @@ export function mapAccountFromDb(row: Record<string, unknown>): Account {
     notes: text(row.notes) ?? '',
     archiveThroughDate: timestamp(row.archive_through_date) ?? null,
     parentAccountId: text(row.parent_account_id) ?? null,
+    // A database without migration 20260815200000 has no such column, which
+    // reads as null — an unsecured liability, which is the honest default.
+    securedAgainstAccountId: text(row.secured_against_account_id) ?? null,
     // Strictly true: a database without migration 20260709140000 has no such
     // column, and "no column" must read as off rather than as undefined, which
     // the settings modal would then show as off anyway.

--- a/src/services/backup/__tests__/encryption.test.ts
+++ b/src/services/backup/__tests__/encryption.test.ts
@@ -51,15 +51,38 @@ describe('backup encryption', () => {
 
     it('puts nothing readable in the envelope', async () => {
       const envelope = await encryptBackupBundle(bundleFixture(), PASSWORD);
-      const asText = JSON.stringify(envelope);
 
-      // The values a person would care about leaking, checked individually so
-      // a failure names which one escaped.
-      expect(asText).not.toContain('Everyday');
-      expect(asText).not.toContain('1234.56');
-      expect(asText).not.toContain('19.99');
-      expect(asText).not.toContain('acc-1');
-      expect(asText).not.toContain('GBP');
+      /*
+       * SEARCHED IN THE DECODED BYTES, NOT IN THE BASE64.
+       *
+       * This test used to run `JSON.stringify(envelope)` and assert the
+       * secrets were absent from THAT — which includes the base64 ciphertext.
+       * Base64 of random bytes is random text over [A-Za-z0-9+/], so any short
+       * needle drawn from that alphabet turns up by chance eventually. On 15
+       * August it did: the ciphertext contained "…aeCGBPHPgd…" and CI failed
+       * on a PR that had not touched encryption. Roughly a 1-in-380 run for a
+       * three-character needle across ~700 characters of ciphertext, which is
+       * frequent enough to erode trust in the suite and rare enough to be
+       * blamed on whatever change was in flight.
+       *
+       * The property actually worth asserting is that the PLAINTEXT is not
+       * recoverable from the envelope, so decode the ciphertext and look in
+       * the bytes. A match there would be a real leak; a match in the base64
+       * is an artefact of the encoding.
+       */
+      const cipherBytes = Uint8Array.from(atob(envelope.ciphertext), c => c.charCodeAt(0));
+      const asBytes = new TextDecoder('utf-8', { fatal: false }).decode(cipherBytes);
+
+      // The metadata is the other half: everything OUTSIDE the ciphertext is
+      // published in clear, so it is checked in clear.
+      const { ciphertext: _ciphertext, ...metadata } = envelope;
+      const asMetadata = JSON.stringify(metadata);
+
+      // Checked individually so a failure names which one escaped.
+      for (const secret of ['Everyday', '1234.56', '19.99', 'acc-1', 'GBP']) {
+        expect(asBytes, `${secret} found in the ciphertext`).not.toContain(secret);
+        expect(asMetadata, `${secret} found in the envelope metadata`).not.toContain(secret);
+      }
     });
 
     it('publishes the date, and only the date', async () => {

--- a/src/services/backup/format.ts
+++ b/src/services/backup/format.ts
@@ -119,10 +119,23 @@ export type CategoryLevel = (typeof CATEGORY_LEVELS)[number];
  */
 export const RESTORE_CHUNK_SIZE = 500;
 
-/** Accounts that hang under another account, closed after every row exists. */
+/**
+ * Account→account references closed after every row exists.
+ *
+ * Two different relationships travel together because they are closed in the
+ * same second pass, not because they mean the same thing: `parent_account_id`
+ * nests and counts (the investment cash pairing), `secured_against_account_id`
+ * does neither (a mortgage against its property). See the Account type.
+ *
+ * `parent_account_id` is nullable HERE and not in the column, because a row
+ * may now carry only the secured link. Older bundles have neither field
+ * missing nor null — they simply never mention the second one, which reads as
+ * undefined and restores as an unsecured liability.
+ */
 export interface AccountParentLink {
   id: string;
-  parent_account_id: string;
+  parent_account_id: string | null;
+  secured_against_account_id?: string | null;
 }
 
 /** A transfer's pointer at its other half, closed in the same second pass. */
@@ -187,7 +200,17 @@ export function extractAccountParents(rows: readonly BackupRow[]): AccountParent
   for (const row of rows) {
     const id = readString(row, 'id');
     const parent = readString(row, 'parent_account_id');
-    if (id && parent) links.push({ id, parent_account_id: parent });
+    const secured = readString(row, 'secured_against_account_id');
+    // EITHER link is worth a row. Requiring a parent here would drop every
+    // liability that is secured against something without being nested under
+    // it — which is all of them, since securing deliberately does not nest.
+    if (id && (parent || secured)) {
+      links.push({
+        id,
+        parent_account_id: parent ?? null,
+        ...(secured ? { secured_against_account_id: secured } : {})
+      });
+    }
   }
   return links;
 }
@@ -371,10 +394,15 @@ function validateLinks(value: unknown): { ok: true; links: BackupLinks } | { ok:
     }
     const id = readString(entry, 'id');
     const parent = readString(entry, 'parent_account_id');
-    if (!id || !parent) {
-      return { ok: false, problem: 'Every entry in "links.account_parents" needs both an id and a parent_account_id.' };
+    const secured = readString(entry, 'secured_against_account_id');
+    if (!id || (!parent && !secured)) {
+      return { ok: false, problem: 'Every entry in "links.account_parents" needs an id and at least one of parent_account_id or secured_against_account_id.' };
     }
-    account_parents.push({ id, parent_account_id: parent });
+    account_parents.push({
+      id,
+      parent_account_id: parent ?? null,
+      ...(secured ? { secured_against_account_id: secured } : {})
+    });
   }
 
   const transaction_links: TransactionLink[] = [];
@@ -620,7 +648,7 @@ interface EntityReferences {
 }
 
 const ENTITY_REFERENCES: Readonly<Record<BackupEntity, EntityReferences>> = {
-  accounts: { uuid: ['parent_account_id'] },
+  accounts: { uuid: ['parent_account_id', 'secured_against_account_id'] },
   categories: { uuid: ['parent_id', 'account_id'] },
   transactions: {
     uuid: ['account_id', 'category_id', 'transfer_account_id', 'linked_transfer_id', 'linked_transfer_split_id'],
@@ -966,11 +994,22 @@ export function remapBackupIds(
   // every transfer pointing at the id it had in the old login.
   const account_parents: AccountParentLink[] = bundle.links.account_parents.map((link) => {
     const id = idMap.get(link.id) ?? link.id;
-    const parent = idMap.get(link.parent_account_id);
-    if (parent === undefined) {
-      danglingRefs.push({ entity: 'links.account_parents', rowId: id, field: 'parent_account_id', value: link.parent_account_id });
-    }
-    return { id, parent_account_id: parent ?? link.parent_account_id };
+    const remapAccount = (field: 'parent_account_id' | 'secured_against_account_id', value: string | null | undefined): string | null | undefined => {
+      if (value === null || value === undefined) return value;
+      const mapped = idMap.get(value);
+      if (mapped === undefined) {
+        danglingRefs.push({ entity: 'links.account_parents', rowId: id, field, value });
+        return value;
+      }
+      return mapped;
+    };
+    const parent = remapAccount('parent_account_id', link.parent_account_id) ?? null;
+    const secured = remapAccount('secured_against_account_id', link.secured_against_account_id);
+    return {
+      id,
+      parent_account_id: parent,
+      ...(secured === undefined ? {} : { secured_against_account_id: secured })
+    };
   });
 
   const transaction_links: TransactionLink[] = bundle.links.transaction_links.map((link) => {

--- a/src/services/local/mappers/columns.ts
+++ b/src/services/local/mappers/columns.ts
@@ -346,7 +346,10 @@ export const ACCOUNT_COLUMNS: readonly Column[] = [
   { key: 'bank_balance_date', field: 'bankBalanceDate', kind: 'day' },
   { key: 'last_reconciled_date', field: 'lastReconciledDate', kind: 'day' },
   { key: 'last_reconciled_balance', field: 'lastReconciledBalance', kind: 'money' },
-  { key: 'parent_account_id', field: 'parentAccountId', kind: 'text' }
+  { key: 'parent_account_id', field: 'parentAccountId', kind: 'text' },
+  // Display + one opt-in total only — never nests, never counts. See the
+  // Account type and migration 20260815200000.
+  { key: 'secured_against_account_id', field: 'securedAgainstAccountId', kind: 'text' }
 ];
 
 /**

--- a/src/services/localBackupService.ts
+++ b/src/services/localBackupService.ts
@@ -250,6 +250,7 @@ function accountToRow(app: Record<string, unknown>): BackupRow {
   put(row, 'opening_balance_date', dateColumn(app.openingBalanceDate));
   put(row, 'archive_through_date', app.archiveThroughDate === null ? null : dateColumn(app.archiveThroughDate));
   put(row, 'parent_account_id', app.parentAccountId === null ? null : text(app.parentAccountId));
+  put(row, 'secured_against_account_id', app.securedAgainstAccountId === null ? null : text(app.securedAgainstAccountId));
   put(row, 'notes', app.notes ?? undefined);
   put(row, 'is_active', bool(app.isActive));
   put(row, 'sort_code', text(app.sortCode));
@@ -280,6 +281,7 @@ function accountFromRow(row: BackupRow): Record<string, unknown> {
     openingBalanceDate: text(row.opening_balance_date),
     archiveThroughDate: row.archive_through_date === null ? null : text(row.archive_through_date),
     parentAccountId: row.parent_account_id === null ? null : text(row.parent_account_id),
+    securedAgainstAccountId: row.secured_against_account_id === null ? null : text(row.secured_against_account_id),
     notes: text(row.notes),
     isActive: bool(row.is_active),
     sortCode: text(row.sort_code),
@@ -988,8 +990,10 @@ function applyLinks(bundle: BackupBundle): {
   transactionsRelinked: number;
 } {
   const parents = new Map<string, string>();
+  const secured = new Map<string, string>();
   for (const link of bundle.links.account_parents) {
     if (link.parent_account_id) parents.set(link.id, link.parent_account_id);
+    if (link.secured_against_account_id) secured.set(link.id, link.secured_against_account_id);
   }
 
   const transfers = new Map<string, { transfer: string | null; split: string | null }>();
@@ -1003,9 +1007,14 @@ function applyLinks(bundle: BackupBundle): {
   const accounts = bundle.data.accounts.map((row) => {
     const id = typeof row.id === 'string' ? row.id : null;
     const parent = id === null ? undefined : parents.get(id);
-    if (parent === undefined) return row;
+    const securedAgainst = id === null ? undefined : secured.get(id);
+    if (parent === undefined && securedAgainst === undefined) return row;
     accountsRelinked += 1;
-    return { ...row, parent_account_id: parent };
+    return {
+      ...row,
+      ...(parent === undefined ? {} : { parent_account_id: parent }),
+      ...(securedAgainst === undefined ? {} : { secured_against_account_id: securedAgainst })
+    };
   });
 
   let transactionsRelinked = 0;

--- a/src/test/securedLiabilities.test.ts
+++ b/src/test/securedLiabilities.test.ts
@@ -1,0 +1,122 @@
+/**
+ * SECURED LIABILITIES — a link that must never become a sum.
+ *
+ * `securedAgainstAccountId` records that a mortgage is held against a property,
+ * or a loan against the portfolio it is drawn on. The whole risk of the feature
+ * is that it starts behaving like `parentAccountId`, which nests AND counts.
+ * If it ever did, a house would silently be restated as its equity.
+ *
+ * So these tests pin the two things that make it safe: the nesting utilities do
+ * not see it at all, and the backup carries it through the id remap that a
+ * restore performs — the second because a link that survives export and dies on
+ * restore is worse than one that was never stored.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  buildChildrenByParent,
+  selectTopLevelAccounts,
+  buildTopLevelIdByAccountId
+} from '../utils/accountNesting';
+import { extractAccountParents, buildBackupBundle, remapBackupIds } from '../services/backup/format';
+
+/** The nesting utilities read exactly two fields; this carries a third. */
+const property = { id: 'prop-1', parentAccountId: null, securedAgainstAccountId: null };
+const mortgage = { id: 'debt-1', parentAccountId: null, securedAgainstAccountId: 'prop-1' };
+const cashSleeve = { id: 'cash-1', parentAccountId: 'inv-1', securedAgainstAccountId: null };
+const portfolio = { id: 'inv-1', parentAccountId: null, securedAgainstAccountId: null };
+
+const all = [property, mortgage, cashSleeve, portfolio];
+
+describe('securing does not nest, and does not count', () => {
+  it('puts no secured liability in anybody\'s children', () => {
+    const children = buildChildrenByParent(all);
+    // The cash sleeve nests, because it belongs inside and its money is part
+    // of the portfolio. The mortgage does not, because neither is true of it.
+    expect(children.get('inv-1')?.map(a => a.id)).toEqual(['cash-1']);
+    expect(children.has('prop-1')).toBe(false);
+  });
+
+  it('leaves the liability top-level, so it still renders under Liabilities', () => {
+    // The owner's constraint, in one assertion: "I don't want the liabilities
+    // to move from the liabilities area on the accounts page."
+    expect(selectTopLevelAccounts(all).map(a => a.id))
+      .toEqual(['prop-1', 'debt-1', 'inv-1']);
+  });
+
+  it('does not route the debt\'s money toward the asset it is secured against', () => {
+    // buildTopLevelIdByAccountId is what band totals are grouped by, so this is
+    // the assertion that stops a mortgage being subtracted from a house.
+    const roots = buildTopLevelIdByAccountId(all);
+    expect(roots.get('debt-1')).toBe('debt-1');
+    expect(roots.get('cash-1')).toBe('inv-1'); // the pairing still does count
+  });
+});
+
+describe('the backup carries the link through a restore', () => {
+  /*
+   * Restores REMAP every id — global primary keys collide across logins — and
+   * account→account references are re-applied afterwards from a side channel.
+   * A new reference that is not in that channel restores as null, silently.
+   */
+  it('extracts a liability that has only a secured link and no parent', () => {
+    // The case that a parent-shaped extractor drops on the floor, which is ALL
+    // of them: securing deliberately does not nest, so there is never a parent.
+    const links = extractAccountParents([
+      { id: 'debt-1', secured_against_account_id: 'prop-1' }
+    ]);
+    expect(links).toEqual([
+      { id: 'debt-1', parent_account_id: null, secured_against_account_id: 'prop-1' }
+    ]);
+  });
+
+  it('still extracts an ordinary parent link, and both together', () => {
+    expect(extractAccountParents([{ id: 'cash-1', parent_account_id: 'inv-1' }]))
+      .toEqual([{ id: 'cash-1', parent_account_id: 'inv-1' }]);
+
+    expect(extractAccountParents([
+      { id: 'x', parent_account_id: 'p', secured_against_account_id: 's' }
+    ])).toEqual([{ id: 'x', parent_account_id: 'p', secured_against_account_id: 's' }]);
+  });
+
+  it('emits nothing for an account with neither link', () => {
+    expect(extractAccountParents([{ id: 'plain-1' }])).toEqual([]);
+  });
+
+  it('REMAPS the secured id on the account row, not just the link', () => {
+    /*
+     * The one that would fail silently. `ENTITY_REFERENCES` declares which
+     * columns hold ids that a restore must translate; a new account→account
+     * column missing from that list survives export, survives validation, and
+     * restores pointing at an id from the OLD login — which resolves to
+     * nothing, so the link is simply gone and no error is raised anywhere.
+     *
+     * Written after watching the earlier tests here stay green while the
+     * column was deleted from that list.
+     */
+    const bundle = buildBackupBundle({
+      sourceUserId: 'user-1',
+      exportedAt: '2026-08-15T00:00:00.000Z',
+      data: {
+        accounts: [
+          { id: 'prop-1', name: 'Flat 3' },
+          { id: 'debt-1', name: 'Mortgage', secured_against_account_id: 'prop-1' }
+        ]
+      },
+      preferences: null
+    });
+
+    const { bundle: remapped } = remapBackupIds(bundle, (() => {
+      let n = 0;
+      return () => `new-${++n}`;
+    })());
+
+    const property = remapped.data.accounts.find(r => r.name === 'Flat 3');
+    const debt = remapped.data.accounts.find(r => r.name === 'Mortgage');
+
+    expect(property?.id).toBe('new-1');
+    expect(debt?.id).toBe('new-2');
+    // The point: it follows the property to its NEW id.
+    expect(debt?.secured_against_account_id).toBe('new-1');
+    expect(debt?.secured_against_account_id).not.toBe('prop-1');
+  });
+});

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -41,6 +41,25 @@ export interface Account {
    * transfers, reconciliation). NULL/undefined = a normal top-level account.
    */
   parentAccountId?: string | null;
+  /**
+   * What this liability is HELD AGAINST — a mortgage against its property, a
+   * loan against the portfolio it is drawn on. Set on the LIABILITY, pointing
+   * at the asset. NULL/undefined = an ordinary unsecured liability.
+   *
+   * DELIBERATELY NOT `parentAccountId`, and the difference is the whole point.
+   * A parent means "belongs inside, and counts toward": a cash sleeve moves
+   * into its portfolio's card and into its total, because it genuinely is part
+   * of it. A secured liability does neither. It stays in Liabilities, where a
+   * debt belongs, and it is never added to the asset's total — doing that
+   * would silently restate the value of a house as its equity.
+   *
+   * So this field is read by DISPLAY, and by exactly one opt-in total: the
+   * Investments page can show a NET position (portfolio less what is secured
+   * against it) when asked. Gross stays the default. Net worth is untouched
+   * either way — it already counts the asset and the debt separately, and
+   * always did.
+   */
+  securedAgainstAccountId?: string | null;
   holdings?: Holding[];
   notes?: string;
   isActive?: boolean;

--- a/supabase/migrations/20260815200000_liabilities_secured_against_an_account.sql
+++ b/supabase/migrations/20260815200000_liabilities_secured_against_an_account.sql
@@ -1,0 +1,79 @@
+-- ============================================================================
+-- Secured liabilities — say WHAT a debt is held against, without moving it.
+--
+-- A mortgage is held against a property. A loan is held against an investment
+-- portfolio. Today the app can record both accounts and cannot record the
+-- relationship, so the two numbers sit in different sections of the Accounts
+-- page with nothing joining them and the owner has to hold the pairing in his
+-- head.
+--
+-- ─ WHY THIS IS NOT parent_account_id ────────────────────────────────────────
+--
+-- 20260722090000 added `parent_account_id` for the Microsoft Money investment
+-- cash pairing, and that column means something this one must NOT mean:
+-- "belongs inside, and COUNTS TOWARD". A cash sleeve genuinely is part of its
+-- portfolio, so it moves into the parent's card and into the parent's total.
+--
+-- A secured liability is the opposite on both points:
+--
+--   · it does NOT move. A mortgage stays in Liabilities where the owner
+--     expects to find his debts; being secured against a house does not stop
+--     it being a debt.
+--   · it does NOT count. Adding it to the property's total would silently
+--     restate the value of the house as its equity, which is a different
+--     number that nobody asked for.
+--
+-- Two behaviours that opposite could be squeezed into one column by branching
+-- on account type at every read. They are not, because every one of those
+-- branches would be a place to forget: the nesting utilities, the band totals,
+-- the portfolio summary and the backup remap all consume `parent_account_id`
+-- and all of them are RIGHT to nest and count. A separate column is a separate
+-- meaning, and the code that ignores it does so by construction rather than by
+-- remembering to check.
+--
+-- ─ WHAT READS IT ────────────────────────────────────────────────────────────
+--
+-- Display, and one opt-in total. The Accounts page prints the liability under
+-- the account it is secured against, marked as information only. The
+-- Investments page offers a NET position — portfolio value less the
+-- liabilities secured against those portfolios — with GROSS remaining the
+-- default, because gross is what the page has always shown and a total that
+-- changes meaning without being asked is worse than one that is merely
+-- incomplete.
+--
+-- Net worth is untouched in both cases: it already counts the asset and the
+-- debt separately and correctly, and always did.
+--
+-- ON DELETE SET NULL, as with the pairing above: if the property is deleted
+-- the mortgage becomes an ordinary unsecured liability rather than blocking
+-- the delete or vanishing with it.
+-- ============================================================================
+
+BEGIN;
+
+ALTER TABLE public.accounts
+  ADD COLUMN IF NOT EXISTS secured_against_account_id uuid
+    REFERENCES public.accounts(id) ON DELETE SET NULL;
+
+-- An account cannot be secured against itself.
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint WHERE conname = 'accounts_secured_against_not_self'
+  ) THEN
+    ALTER TABLE public.accounts
+      ADD CONSTRAINT accounts_secured_against_not_self
+      CHECK (secured_against_account_id IS NULL OR secured_against_account_id <> id);
+  END IF;
+END $$;
+
+CREATE INDEX IF NOT EXISTS idx_accounts_secured_against_account_id
+  ON public.accounts (secured_against_account_id)
+  WHERE secured_against_account_id IS NOT NULL;
+
+COMMENT ON COLUMN public.accounts.secured_against_account_id IS
+  'The account this liability is held against (mortgage → property, loan → '
+  'portfolio). DISPLAY AND OPT-IN TOTALS ONLY: unlike parent_account_id the '
+  'row does not move section and is never added to the target''s total.';
+
+COMMIT;


### PR DESCRIPTION
A mortgage is held against a property; a loan is drawn against a portfolio. The app could record both accounts and not the relationship.

## Why this is not `parent_account_id`

That column exists and means something this must **not** mean: *belongs inside, and counts toward*.

| | `parent_account_id` (cash sleeve) | `secured_against_account_id` (mortgage) |
| --- | --- | --- |
| moves section | yes, into the parent's card | **no** — stays under Liabilities |
| counts toward the target | yes | **no** |

Both behaviours could have been squeezed into one column by branching on account type at every read. They are not, because every one of those branches is a place to forget — the nesting utilities, the band totals, the top-level walk and the backup remap all consume `parent_account_id` and all of them are *right* to nest and count. A separate column is a separate meaning, and the code that ignores it does so by construction rather than by remembering to check.

## What it shows

**Accounts page** — the names of linked liabilities under the account they are held against, and **no figure**, on the owner's ruling:

> we are just highlighting that this account is linked with a liability; fundamentally it does not change the workings of the accounts page

A balance printed inches under the account's own would invite the subtraction whatever the caption said. **A name cannot be added up.** The row also prints no columns — `AccountRowColumns` is the grammar of "a row that participates", and borrowing it would put a debt in the Account Bal column.

**Investments page** — the one place a figure is deliberate. An opt-in subtraction of liabilities secured against the portfolio, **off by default**, because gross is what the page has always shown and a total that changes meaning without being asked is worse than one that is merely incomplete. The control appears only when something is actually secured against that portfolio, and names which liabilities.

**Net worth is untouched** throughout — it already counts the asset and the debt separately, and always did.

## The backup trap

A restore remaps every id, so a new account→account reference must be declared in **two** places or it survives export, survives validation, and restores pointing at an id from the old login — resolving to nothing, silently.

The test for the second was written only after watching the first four stay green while the column was deleted from the remap list:

| mutation | result |
| --- | --- |
| parent-only extractor (drops every secured link) | fails |
| column removed from the uuid remap list | fails |

## Migration

`20260815200000` — column, not-self check, partial index. **Needs applying before the dropdown does anything.** Without it the mapper reads the missing column as null, which is an unsecured liability — the honest default rather than an error.

## Verification

lint · `typecheck:strict` · 6,072 unit tests · `desktop:verify` — all green. No `as any` / `as unknown as`.

**Not verified:** rendering, in either mode. The browser pane cannot restyle after a class change, and the feature needs the migration applied before there is anything to render.

🤖 Generated with [Claude Code](https://claude.com/claude-code)