### PR TITLE
fix(accounts): securing works on any account, and saving an account works again

### DIFF
--- a/src/components/AccountSettingsModal.tsx
+++ b/src/components/AccountSettingsModal.tsx
@@ -9,6 +9,7 @@ import ToggleSwitch from './ui/ToggleSwitch';
 import CardNumberGuidance from './CardNumberGuidance';
 import GroupedAccountOptions from './common/GroupedAccountOptions';
 import { accountCurrencyOptions, describeAccountCurrency } from '../constants/accountCurrencies';
+import { resolveSecuring } from '../utils/accountSecuring';
 import {
   BANK_ACCOUNT_NUMBER_LENGTH,
   CARD_NUMBER_LABEL,
@@ -70,42 +71,6 @@ interface FormData {
 
 const NO_PARENT_ACCOUNT = '';
 const NOT_SECURED = '';
-
-/** The types that are somebody's debt. Everything else can BE secured against. */
-const LIABILITY_TYPES: ReadonlySet<string> = new Set(['loan', 'credit', 'other']);
-
-/**
- * What this liability may be held against: any account that is not itself a
- * debt, and is not this one.
- *
- * Nested accounts ARE offered, unlike the pairing dropdown above, and the
- * asymmetry is deliberate. Pairing refuses them because nesting a nested
- * account would make a chain that has to be walked and could cycle. Securing
- * walks nothing — it is one hop, read for display — so a loan may perfectly
- * well be held against a cash sleeve inside a portfolio, which is exactly the
- * arrangement the owner described.
- */
-function resolveSecuring(
-  account: BaseAccount,
-  accounts: readonly BaseAccount[],
-  selectedType: BaseAccount['type']
-): PairingState {
-  const options = accounts.filter(a =>
-    !LIABILITY_TYPES.has(a.type) &&
-    a.id !== account.id &&
-    a.isActive !== false
-  );
-  const current = account.securedAgainstAccountId
-    ? accounts.find(a => a.id === account.securedAgainstAccountId)
-    : undefined;
-  // A target that has since been closed stays listed, or saving any other
-  // change on this form would silently drop the link.
-  if (current && !options.some(a => a.id === current.id)) options.push(current);
-  return {
-    offered: LIABILITY_TYPES.has(selectedType) && options.length > 0,
-    options
-  };
-}
 
 /** What the pairing field may offer this account, and whether it appears at all. */
 interface PairingState {
@@ -235,7 +200,7 @@ export default function AccountSettingsModal({
           // Same rule, same reason: changing an account's type from Loan to
           // Savings takes the control off screen, and a link written from a
           // field nobody saw is a link nobody chose.
-          ...(resolveSecuring(account, accounts, data.type).offered
+          ...(resolveSecuring(account, accounts).offered
             ? { securedAgainstAccountId: data.securedAgainstAccountId || null }
             : {}),
           // Same rule, and for a much sharper reason: only ever written when
@@ -334,7 +299,7 @@ export default function AccountSettingsModal({
   // (so editing a closed account never quietly reopens it).
   const isClosedAccount = account.isActive === false;
   const pairing = resolvePairing(account, accounts, formData.type);
-  const securing = resolveSecuring(account, accounts, formData.type);
+  const securing = resolveSecuring(account, accounts);
 
   return (
     <Modal isOpen={isOpen} onClose={onClose} title="Account Settings" size="md">
@@ -572,11 +537,11 @@ export default function AccountSettingsModal({
                 <GroupedAccountOptions accounts={securing.options} />
               </select>
               <p className="mt-1 text-xs text-gray-500 dark:text-gray-400">
-                For a mortgage held against a property, or a loan drawn against
-                an investment. This account stays where it is under Liabilities
-                and its balance is not added to anything — the link only shows
-                the two together, and lets the Investments page offer a net
-                position if you want one.
+                For a debt held against something you own — a mortgage against
+                its property, a loan drawn against an investment. This account
+                stays exactly where it is and its balance is not added to
+                anything; the link only shows the two together, and lets the
+                Investments page offer a net position if you want one.
               </p>
             </div>
           )}

--- a/src/components/AccountSettingsModal.tsx
+++ b/src/components/AccountSettingsModal.tsx
@@ -197,10 +197,21 @@ export default function AccountSettingsModal({
           ...(resolvePairing(account, accounts, data.type).offered
             ? { parentAccountId: data.parentAccountId || null }
             : {}),
-          // Same rule, same reason: changing an account's type from Loan to
-          // Savings takes the control off screen, and a link written from a
-          // field nobody saw is a link nobody chose.
+          // ONLY WHEN IT ACTUALLY CHANGED, which is a stronger rule than the
+          // one above and is here for a reason the pairing field never had.
+          //
+          // This column arrives with migration 20260815200000, and a database
+          // that has not had it applied yet rejects the WHOLE update when an
+          // unknown column is named — so an unchanged link riding along on
+          // every save took renames and type changes down with it. The owner
+          // hit exactly that: he retyped an account and got "Could not find
+          // the 'securedAgainstAccountId' column of 'accounts'".
+          //
+          // Sending it only on a real change means the migration is required
+          // to USE the feature, not to save an account. It is also just
+          // correct: an update should carry what the user altered.
           ...(resolveSecuring(account, accounts).offered
+            && data.securedAgainstAccountId !== (account.securedAgainstAccountId ?? NOT_SECURED)
             ? { securedAgainstAccountId: data.securedAgainstAccountId || null }
             : {}),
           // Same rule, and for a much sharper reason: only ever written when

--- a/src/services/api/accountMapping.ts
+++ b/src/services/api/accountMapping.ts
@@ -204,6 +204,13 @@ const ACCOUNT_FIELD_TO_COLUMN: Record<string, string> = {
   lowBalanceThreshold: 'low_balance_threshold',
   archiveThroughDate: 'archive_through_date',
   parentAccountId: 'parent_account_id',
+  // MISSING THIS BROKE EVERY SAVE ON THE ACCOUNTS THAT COULD SET IT. The
+  // fallback in mapAccountToDb is `?? field`, so an unmapped name is sent to
+  // PostgREST verbatim — "Could not find the 'securedAgainstAccountId' column
+  // of 'accounts' in the schema cache" — and PostgREST rejects the whole
+  // update, taking the user's real edit (a rename, a type change) down with an
+  // unrelated field they never touched.
+  securedAgainstAccountId: 'secured_against_account_id',
   plaidConnectionId: 'plaid_connection_id',
   plaidAccountId: 'plaid_account_id',
   createdAt: 'created_at',

--- a/src/test/securedLiabilities.test.ts
+++ b/src/test/securedLiabilities.test.ts
@@ -18,6 +18,8 @@ import {
   buildTopLevelIdByAccountId
 } from '../utils/accountNesting';
 import { extractAccountParents, buildBackupBundle, remapBackupIds } from '../services/backup/format';
+import { resolveSecuring } from '../utils/accountSecuring';
+import type { Account } from '../types';
 
 /** The nesting utilities read exactly two fields; this carries a third. */
 const property = { id: 'prop-1', parentAccountId: null, securedAgainstAccountId: null };
@@ -49,6 +51,74 @@ describe('securing does not nest, and does not count', () => {
     const roots = buildTopLevelIdByAccountId(all);
     expect(roots.get('debt-1')).toBe('debt-1');
     expect(roots.get('cash-1')).toBe('inv-1'); // the pairing still does count
+  });
+});
+
+describe('which accounts may be secured, and against what', () => {
+  /*
+   * The owner's own mortgage is typed CURRENT. It is unmistakably a mortgage,
+   * it carries a negative balance, and the app's type says current account —
+   * which is what a decade of Microsoft Money imports actually looks like.
+   *
+   * The first cut gated the control on loan/credit/other and so showed nothing
+   * at all on that account. These pin the rule that replaced it.
+   */
+  // Built as real Accounts rather than cast into shape: a cast here would let
+  // the fixture drift from the type the function actually receives, which is
+  // the one thing these tests exist to be sure about.
+  const acc = (
+    id: string,
+    type: Account['type'],
+    extra: Partial<Account> = {}
+  ): Account => ({
+    id,
+    name: id,
+    type,
+    balance: 0,
+    currency: 'GBP',
+    lastUpdated: new Date('2026-08-15T00:00:00.000Z'),
+    ...extra
+  });
+
+  const ledger = [
+    acc('mortgage-as-current', 'current'),   // the owner's real shape
+    acc('property', 'assets'),               // alias: files under Assets
+    acc('portfolio', 'investment'),
+    acc('visa', 'credit'),                   // a debt — never a target
+    acc('personal-loan', 'loan'),            // a debt — never a target
+    acc('mortgage-proper', 'mortgage'),      // alias: files under Loans
+    acc('misc', 'other')                     // unclassified — still a target
+  ];
+
+  it('offers the control on a mortgage typed as a current account', () => {
+    // The bug, in one assertion.
+    expect(resolveSecuring(ledger[0], ledger).offered).toBe(true);
+  });
+
+  it('never offers a debt as the thing to be secured against', () => {
+    const targets = resolveSecuring(ledger[0], ledger).options.map(a => a.id);
+    expect(targets).not.toContain('visa');
+    expect(targets).not.toContain('personal-loan');
+    // Through the alias, which is the half a hand-rolled type set gets wrong:
+    // 'mortgage' files under Loans.
+    expect(targets).not.toContain('mortgage-proper');
+  });
+
+  it('offers assets, investments and unclassified accounts', () => {
+    const targets = resolveSecuring(ledger[0], ledger).options.map(a => a.id);
+    // 'assets' is an alias for the Assets section — the owner's property.
+    expect(targets).toEqual(expect.arrayContaining(['property', 'portfolio', 'misc']));
+  });
+
+  it('never offers the account itself', () => {
+    expect(resolveSecuring(ledger[1], ledger).options.map(a => a.id)).not.toContain('property');
+  });
+
+  it('keeps a closed target listed, so saving does not silently drop the link', () => {
+    const closed = acc('sold-house', 'assets', { isActive: false });
+    const debt = acc('debt', 'loan', { securedAgainstAccountId: 'sold-house' });
+    const targets = resolveSecuring(debt, [debt, closed]).options.map(a => a.id);
+    expect(targets).toContain('sold-house');
   });
 });
 

--- a/src/test/securedLiabilities.test.ts
+++ b/src/test/securedLiabilities.test.ts
@@ -19,6 +19,7 @@ import {
 } from '../utils/accountNesting';
 import { extractAccountParents, buildBackupBundle, remapBackupIds } from '../services/backup/format';
 import { resolveSecuring } from '../utils/accountSecuring';
+import { mapAccountToDb } from '../services/api/accountMapping';
 import type { Account } from '../types';
 
 /** The nesting utilities read exactly two fields; this carries a third. */
@@ -119,6 +120,41 @@ describe('which accounts may be secured, and against what', () => {
     const debt = acc('debt', 'loan', { securedAgainstAccountId: 'sold-house' });
     const targets = resolveSecuring(debt, [debt, closed]).options.map(a => a.id);
     expect(targets).toContain('sold-house');
+  });
+});
+
+describe('the write path names a real column', () => {
+  /*
+   * `mapAccountToDb` falls back to `?? field` for anything it has no mapping
+   * for, so an unmapped camelCase name is sent to PostgREST verbatim. PostgREST
+   * rejects the WHOLE update, which means one missing line here breaks saving
+   * an account entirely — including edits to fields the user did touch.
+   *
+   * That is what shipped: the read path was mapped, the write path was not,
+   * and the owner got "Could not find the 'securedAgainstAccountId' column of
+   * 'accounts' in the schema cache" while renaming an account type.
+   */
+  it('maps securedAgainstAccountId to its snake_case column', () => {
+    expect(mapAccountToDb({ securedAgainstAccountId: 'prop-1' }))
+      .toEqual({ secured_against_account_id: 'prop-1' });
+  });
+
+  it('sends null through, because null is how a link is CLEARED', () => {
+    // `undefined` means "leave alone" and is dropped; null must survive.
+    expect(mapAccountToDb({ securedAgainstAccountId: null }))
+      .toEqual({ secured_against_account_id: null });
+  });
+
+  it('emits no camelCase key for any account field it maps', () => {
+    // The general form of the bug, so the next field added cannot repeat it.
+    const columns = mapAccountToDb({
+      securedAgainstAccountId: 'a',
+      parentAccountId: 'b',
+      openingBalanceDate: new Date('2026-01-01T00:00:00.000Z')
+    });
+    for (const key of Object.keys(columns)) {
+      expect(key, `${key} is not a snake_case column name`).not.toMatch(/[A-Z]/);
+    }
   });
 });
 

--- a/src/utils/accountSecuring.ts
+++ b/src/utils/accountSecuring.ts
@@ -1,0 +1,79 @@
+/**
+ * WHAT AN ACCOUNT MAY BE RECORDED AS HELD AGAINST — a mortgage against its
+ * property, a loan drawn against a portfolio.
+ *
+ * A leaf module beside `accountNesting`, and for the same two reasons: the
+ * rule is consumed by more than the dialog that edits it, and a rule living
+ * inside a component is a rule the next page reimplements slightly differently.
+ *
+ * The relationship this describes is DISPLAY-ONLY. It moves nothing between
+ * sections and adds nothing to any total — see `Account.securedAgainstAccountId`
+ * and migration 20260815200000 for why it is not `parentAccountId`, which does
+ * both.
+ */
+import type { Account } from '../types';
+import { sectionTypeForAccount } from './accountGrouping';
+
+/**
+ * The sections whose accounts are somebody's debt, so cannot be a TARGET.
+ *
+ * Read through `sectionTypeForAccount` rather than off `type` directly, which
+ * is what makes the aliases behave: 'mortgage' files under Loans, 'checking'
+ * under Current, 'assets' under Assets. A hand-rolled type set gets all three
+ * wrong, and gets them wrong silently.
+ *
+ * 'other' is NOT here. It is the catch-all for a type with no section of its
+ * own, so it means "unclassified", not "not a debt" — excluding it would drop
+ * legitimate targets on the guess that they might be liabilities.
+ */
+export const LIABILITY_SECTIONS: ReadonlySet<string> = new Set(['credit', 'loan', 'liability']);
+
+/** What the field may offer this account, and whether it appears at all. */
+export interface SecuringState {
+  offered: boolean;
+  options: Account[];
+}
+
+/**
+ * ─ WHY THE CONTROL IS NOT GATED ON THIS ACCOUNT'S TYPE ─────────────────────
+ *
+ * It was, at first — offered only on loan/credit/other, on the reasonable
+ * theory that only a debt is secured against anything. The owner then opened
+ * his "Mortgage - Corporation Avenue" and found no control at all, because
+ * that account is typed CURRENT in his ledger. It is unmistakably a mortgage,
+ * it carries a negative balance, and the app's own type says current account.
+ * So are the rest of his debts: the Microsoft Money import gave every one of
+ * them the same type.
+ *
+ * That will be corrected in his data, and this stays ungated anyway. An
+ * account's type in an imported ledger is a WEAK SIGNAL, and a gate built on a
+ * weak signal hides the feature in exactly the cases it was built for. The
+ * link is display-only, so the cost of offering it too widely is a dropdown
+ * somebody ignores, while the cost of offering it too narrowly is a feature
+ * that does not work on the owner's own mortgage.
+ *
+ * Nested accounts ARE offered, unlike the investment↔cash pairing, and that
+ * asymmetry is deliberate too. Pairing refuses them because nesting a nested
+ * account makes a chain that has to be walked and could cycle. Securing walks
+ * nothing — one hop, read for display — so a loan may perfectly well be held
+ * against a cash sleeve inside a portfolio.
+ */
+export function resolveSecuring(
+  account: Account,
+  accounts: readonly Account[]
+): SecuringState {
+  const options = accounts.filter(a =>
+    !LIABILITY_SECTIONS.has(sectionTypeForAccount(a.type)) &&
+    a.id !== account.id &&
+    a.isActive !== false
+  );
+
+  // A target that has since been closed stays listed, or saving any other
+  // change on the form would silently drop the link.
+  const current = account.securedAgainstAccountId
+    ? accounts.find(a => a.id === account.securedAgainstAccountId)
+    : undefined;
+  if (current && !options.some(a => a.id === current.id)) options.push(current);
+
+  return { offered: options.length > 0, options };
+}


### PR DESCRIPTION
Two things, the second urgent — **saving an account was broken on main**.

## 1. The gate was on the wrong thing

The control was offered only on `loan`/`credit`/`other`, on the reasonable theory that only a debt is secured against anything. The owner opened his "Mortgage - Corporation Avenue" and found no control at all: **that account is typed `current`**. So are the rest of his debts — every one arrived from the Microsoft Money import as a bank account.

An account's type in an imported ledger is a **weak signal**, and a gate built on a weak signal hides the feature in exactly the cases it was built for. The subject is ungated now; the **target list** carries the whole rule.

Targets exclude debts **by section**, read through `sectionTypeForAccount`. That is what makes the aliases behave — `mortgage` files under Loans, `checking` under Current, `assets` under Assets. The hand-rolled type set this replaces got all three wrong, silently.

`other` stays a valid target: it is the catch-all for a type with no section, so it means *unclassified*, not *not a debt*.

Moved to `utils/accountSecuring`, a leaf module beside `accountNesting` — more than one consumer now, and exporting a function from a component file tripped `react-refresh`. The repo's standard is zero warnings, and the warning was pointing at a real design smell.

## 2. The write path never named the column

> Could not find the `securedAgainstAccountId` column of `accounts` in the schema cache

Hit while changing an account's **type** — a field with nothing to do with securing. Two mistakes stacked:

**The mapping was half done.** `accountMapping` has a read path and a write path. I added the field to the read path and both column maps and missed `ACCOUNT_FIELD_TO_COLUMN`. `mapAccountToDb` falls back to `?? field`, so the camelCase name went to PostgREST verbatim — and PostgREST rejects the **whole** update, taking the user's real edit down with a field they never touched.

**It was sent on every save.** Even mapped correctly, the column only exists after migration `20260815200000`, and naming an absent column fails the same way. The field is now sent **only when it actually changed** — which makes the migration a requirement for *using* the feature rather than for *saving an account*, and is the more correct behaviour regardless.

## Guards

| mutation | result |
| --- | --- |
| reinstate the type gate | fails the mortgage case |
| read `type` instead of the section classifier | fails the alias case |
| delete the `ACCOUNT_FIELD_TO_COLUMN` line | fails 3 tests |

The third write-path test is the general form — no key `mapAccountToDb` emits may contain an uppercase letter — so the next field added cannot repeat this.

## Verification

lint (zero warnings) · `typecheck:strict` · 6,077 unit tests · `desktop:verify` — green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)