### PR TITLE
feat(accounts): a debt can be secured against several accounts

### DIFF
--- a/src/components/AccountSettingsModal.tsx
+++ b/src/components/AccountSettingsModal.tsx
@@ -9,7 +9,7 @@ import ToggleSwitch from './ui/ToggleSwitch';
 import CardNumberGuidance from './CardNumberGuidance';
 import GroupedAccountOptions from './common/GroupedAccountOptions';
 import { accountCurrencyOptions, describeAccountCurrency } from '../constants/accountCurrencies';
-import { resolveSecuring } from '../utils/accountSecuring';
+import { resolveSecuring, normaliseSecuredIds } from '../utils/accountSecuring';
 import {
   BANK_ACCOUNT_NUMBER_LENGTH,
   CARD_NUMBER_LABEL,
@@ -66,7 +66,8 @@ interface FormData {
   lowBalanceThreshold: string;
   /** Investment account this one's money sits inside; '' = not paired. */
   parentAccountId: string;
-  securedAgainstAccountId: string;
+  /** One entry per visible dropdown; '' is the unchosen 'Nothing' row. */
+  securedAgainstAccountIds: string[];
 }
 
 const NO_PARENT_ACCOUNT = '';
@@ -162,7 +163,7 @@ export default function AccountSettingsModal({
       lowBalanceAlertEnabled: false,
       lowBalanceThreshold: '',
       parentAccountId: NO_PARENT_ACCOUNT,
-      securedAgainstAccountId: NOT_SECURED
+      securedAgainstAccountIds: [NOT_SECURED]
     },
     {
       onSubmit: async (data) => {
@@ -210,10 +211,14 @@ export default function AccountSettingsModal({
           // Sending it only on a real change means the migration is required
           // to USE the feature, not to save an account. It is also just
           // correct: an update should carry what the user altered.
-          ...(resolveSecuring(account, accounts).offered
-            && data.securedAgainstAccountId !== (account.securedAgainstAccountId ?? NOT_SECURED)
-            ? { securedAgainstAccountId: data.securedAgainstAccountId || null }
-            : {}),
+          ...(() => {
+            if (!resolveSecuring(account, accounts).offered) return {};
+            const next = normaliseSecuredIds(data.securedAgainstAccountIds, account.id);
+            const before = normaliseSecuredIds(account.securedAgainstAccountIds ?? [], account.id);
+            const unchanged =
+              next.length === before.length && next.every((id, i) => id === before[i]);
+            return unchanged ? {} : { securedAgainstAccountIds: next };
+          })(),
           // Same rule, and for a much sharper reason: only ever written when
           // the field was EDITABLE. On an account with history the value on
           // screen is the stored one, so writing it back would be a no-op —
@@ -277,7 +282,8 @@ export default function AccountSettingsModal({
         lowBalanceAlertEnabled: account.lowBalanceAlertEnabled ?? false,
         lowBalanceThreshold: account.lowBalanceThreshold != null ? account.lowBalanceThreshold.toString() : '',
         parentAccountId: account.parentAccountId ?? NO_PARENT_ACCOUNT,
-        securedAgainstAccountId: account.securedAgainstAccountId ?? NOT_SECURED
+        // Always one trailing blank row, so there is something to choose in.
+        securedAgainstAccountIds: [...(account.securedAgainstAccountIds ?? []), NOT_SECURED]
       });
     }
   }, [account, setFormData]);
@@ -535,23 +541,61 @@ export default function AccountSettingsModal({
               is added. */}
           {securing.offered && (
             <div>
-              <label htmlFor="account-secured-against" className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+              <span className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
                 Secured against
-              </label>
-              <select
-                id="account-secured-against"
-                value={formData.securedAgainstAccountId}
-                onChange={(e) => updateField('securedAgainstAccountId', e.target.value)}
-                className="w-full px-3 py-2 bg-white dark:bg-gray-800 border border-gray-300/50 dark:border-gray-600/50 rounded-xl focus:border-transparent dark:text-white"
-              >
-                <option value={NOT_SECURED}>Nothing — this is an unsecured debt</option>
-                <GroupedAccountOptions accounts={securing.options} />
-              </select>
+              </span>
+              {/* ─ ONE ROW PER LINK, AND ONE SPARE ──────────────────────────
+                  A loan can be drawn against two portfolios, so this is a
+                  list. The owner's own shape for it: choose something and a
+                  fresh row appears beneath, choose in that and another
+                  appears — no "add" button to find, and no empty rows piling
+                  up, because the spare only ever exists once at the end.
+
+                  Setting a row back to "Nothing" REMOVES it rather than
+                  leaving a hole, which is what makes the trailing spare
+                  reliable: without that, clearing the middle of three links
+                  would leave a gap that reads as a broken control.
+
+                  Each row already excludes the account itself, and duplicates
+                  are stripped on save by `normaliseSecuredIds` — a portfolio
+                  chosen twice would otherwise be subtracted twice on the
+                  Investments page, which is the one place this list can do
+                  arithmetic damage. */}
+              <div className="space-y-2">
+                {formData.securedAgainstAccountIds.map((selected, index) => {
+                  const chosenElsewhere = new Set(
+                    formData.securedAgainstAccountIds.filter((_, i) => i !== index)
+                  );
+                  const available = securing.options.filter(
+                    a => a.id === selected || !chosenElsewhere.has(a.id)
+                  );
+                  return (
+                    <select
+                      key={`secured-${index}`}
+                      aria-label={index === 0 ? 'Secured against' : `Secured against (${index + 1})`}
+                      value={selected}
+                      onChange={(e) => {
+                        const next = [...formData.securedAgainstAccountIds];
+                        next[index] = e.target.value;
+                        // Drop cleared rows, then guarantee exactly one spare.
+                        const kept = next.filter(id => id !== NOT_SECURED);
+                        updateField('securedAgainstAccountIds', [...kept, NOT_SECURED]);
+                      }}
+                      className="w-full px-3 py-2 bg-white dark:bg-gray-800 border border-gray-300/50 dark:border-gray-600/50 rounded-xl focus:border-transparent dark:text-white"
+                    >
+                      <option value={NOT_SECURED}>
+                        {index === 0 ? 'Nothing — this is an unsecured debt' : 'Add another…'}
+                      </option>
+                      <GroupedAccountOptions accounts={available} />
+                    </select>
+                  );
+                })}
+              </div>
               <p className="mt-1 text-xs text-gray-500 dark:text-gray-400">
                 For a debt held against something you own — a mortgage against
-                its property, a loan drawn against an investment. This account
-                stays exactly where it is and its balance is not added to
-                anything; the link only shows the two together, and lets the
+                its property, a loan drawn against one or more investments. This
+                account stays exactly where it is and its balance is not added
+                to anything; the link only labels the two together, and lets the
                 Investments page offer a net position if you want one.
               </p>
             </div>

--- a/src/pages/Accounts.tsx
+++ b/src/pages/Accounts.tsx
@@ -55,6 +55,7 @@ import {
   buildTopLevelIdByAccountId,
   selectTopLevelAccounts,
 } from '../utils/accountNesting';
+import { buildSecuredByTarget } from '../utils/accountSecuring';
 import { toDecimal, type DecimalInstance } from '../utils/decimal';
 import EmptyState from '../components/EmptyState';
 import FilteredEmptyState from '../components/FilteredEmptyState';
@@ -388,18 +389,7 @@ export default function Accounts() {
    * reason nesting checks it: a row keyed under a card that is not on the page
    * is a row nobody ever sees.
    */
-  const securedByTarget = useMemo(() => {
-    const byId = new Map(openAccounts.map(a => [a.id, a]));
-    const map = new Map<string, Account[]>();
-    for (const account of openAccounts) {
-      const targetId = account.securedAgainstAccountId;
-      if (!targetId || targetId === account.id || !byId.has(targetId)) continue;
-      const list = map.get(targetId);
-      if (list) list.push(account);
-      else map.set(targetId, [account]);
-    }
-    return map;
-  }, [openAccounts]);
+  const securedByTarget = useMemo(() => buildSecuredByTarget(openAccounts), [openAccounts]);
 
   const topLevelAccounts = useMemo(() => selectTopLevelAccounts(openAccounts), [openAccounts]);
   const [closedAccounts, setClosedAccounts] = useState<Account[]>([]);

--- a/src/pages/Investments.tsx
+++ b/src/pages/Investments.tsx
@@ -10,6 +10,7 @@ import { PieChart as RePieChart, Pie, Cell, ResponsiveContainer, Tooltip, LineCh
 import { useCurrencyDecimal } from '../hooks/useCurrencyDecimal';
 import { toDecimal } from '../utils/decimal';
 import { useLocalStorage } from '../hooks/useLocalStorage';
+import { normaliseSecuredIds } from '../utils/accountSecuring';
 import type { DecimalInstance } from '../utils/decimal';
 import { formatDecimal } from '../utils/decimal-format';
 import PageWrapper from '../components/PageWrapper';
@@ -287,8 +288,12 @@ export default function Investments() {
     let total = toDecimal(0);
     const names: string[] = [];
     for (const account of openAccounts) {
-      const target = account.securedAgainstAccountId;
-      if (!target || !withinPortfolio.has(target)) continue;
+      // ONCE PER LIABILITY, not once per link. A loan drawn against two of
+      // these portfolios names both, and subtracting it twice would take
+      // millions off a total for a debt that exists once. `some` rather than a
+      // loop over the ids is the whole guard.
+      const targets = normaliseSecuredIds(account.securedAgainstAccountIds ?? [], account.id);
+      if (!targets.some(id => withinPortfolio.has(id))) continue;
       // A debt is carried negative, and this is a magnitude to subtract.
       total = total.plus(toDecimal(Math.abs(account.balance ?? 0)));
       names.push(account.name);

--- a/src/services/api/accountMapping.ts
+++ b/src/services/api/accountMapping.ts
@@ -175,9 +175,11 @@ export function mapAccountFromDb(row: Record<string, unknown>): Account {
     notes: text(row.notes) ?? '',
     archiveThroughDate: timestamp(row.archive_through_date) ?? null,
     parentAccountId: text(row.parent_account_id) ?? null,
-    // A database without migration 20260815200000 has no such column, which
-    // reads as null — an unsecured liability, which is the honest default.
-    securedAgainstAccountId: text(row.secured_against_account_id) ?? null,
+    // A database without migration 20260815210000 has no such column, which
+    // reads as [] — an unsecured liability, the honest default.
+    securedAgainstAccountIds: Array.isArray(row.secured_against_account_ids)
+      ? row.secured_against_account_ids.filter((id): id is string => typeof id === 'string')
+      : [],
     // Strictly true: a database without migration 20260709140000 has no such
     // column, and "no column" must read as off rather than as undefined, which
     // the settings modal would then show as off anyway.
@@ -210,7 +212,7 @@ const ACCOUNT_FIELD_TO_COLUMN: Record<string, string> = {
   // of 'accounts' in the schema cache" — and PostgREST rejects the whole
   // update, taking the user's real edit (a rename, a type change) down with an
   // unrelated field they never touched.
-  securedAgainstAccountId: 'secured_against_account_id',
+  securedAgainstAccountIds: 'secured_against_account_ids',
   plaidConnectionId: 'plaid_connection_id',
   plaidAccountId: 'plaid_account_id',
   createdAt: 'created_at',

--- a/src/services/backup/format.ts
+++ b/src/services/backup/format.ts
@@ -119,23 +119,10 @@ export type CategoryLevel = (typeof CATEGORY_LEVELS)[number];
  */
 export const RESTORE_CHUNK_SIZE = 500;
 
-/**
- * Account→account references closed after every row exists.
- *
- * Two different relationships travel together because they are closed in the
- * same second pass, not because they mean the same thing: `parent_account_id`
- * nests and counts (the investment cash pairing), `secured_against_account_id`
- * does neither (a mortgage against its property). See the Account type.
- *
- * `parent_account_id` is nullable HERE and not in the column, because a row
- * may now carry only the secured link. Older bundles have neither field
- * missing nor null — they simply never mention the second one, which reads as
- * undefined and restores as an unsecured liability.
- */
+/** Accounts that hang under another account, closed after every row exists. */
 export interface AccountParentLink {
   id: string;
-  parent_account_id: string | null;
-  secured_against_account_id?: string | null;
+  parent_account_id: string;
 }
 
 /** A transfer's pointer at its other half, closed in the same second pass. */
@@ -200,17 +187,7 @@ export function extractAccountParents(rows: readonly BackupRow[]): AccountParent
   for (const row of rows) {
     const id = readString(row, 'id');
     const parent = readString(row, 'parent_account_id');
-    const secured = readString(row, 'secured_against_account_id');
-    // EITHER link is worth a row. Requiring a parent here would drop every
-    // liability that is secured against something without being nested under
-    // it — which is all of them, since securing deliberately does not nest.
-    if (id && (parent || secured)) {
-      links.push({
-        id,
-        parent_account_id: parent ?? null,
-        ...(secured ? { secured_against_account_id: secured } : {})
-      });
-    }
+    if (id && parent) links.push({ id, parent_account_id: parent });
   }
   return links;
 }
@@ -394,15 +371,10 @@ function validateLinks(value: unknown): { ok: true; links: BackupLinks } | { ok:
     }
     const id = readString(entry, 'id');
     const parent = readString(entry, 'parent_account_id');
-    const secured = readString(entry, 'secured_against_account_id');
-    if (!id || (!parent && !secured)) {
-      return { ok: false, problem: 'Every entry in "links.account_parents" needs an id and at least one of parent_account_id or secured_against_account_id.' };
+    if (!id || !parent) {
+      return { ok: false, problem: 'Every entry in "links.account_parents" needs both an id and a parent_account_id.' };
     }
-    account_parents.push({
-      id,
-      parent_account_id: parent ?? null,
-      ...(secured ? { secured_against_account_id: secured } : {})
-    });
+    account_parents.push({ id, parent_account_id: parent });
   }
 
   const transaction_links: TransactionLink[] = [];
@@ -645,10 +617,17 @@ interface EntityReferences {
    * string is a person nobody is going to think about again.
    */
   readonly jsonbIdArrays?: Readonly<Record<string, readonly string[]>>;
+  /**
+   * Columns that are a TOP-LEVEL array of ids — a Postgres uuid[]/text[],
+   * not ids buried in a jsonb document (that is `jsonbIdArrays`). Every
+   * element is remapped, and one that resolves to nothing is reported rather
+   * than dropped, exactly as a scalar reference would be.
+   */
+  readonly idArrays?: readonly string[];
 }
 
 const ENTITY_REFERENCES: Readonly<Record<BackupEntity, EntityReferences>> = {
-  accounts: { uuid: ['parent_account_id', 'secured_against_account_id'] },
+  accounts: { uuid: ['parent_account_id'], idArrays: ['secured_against_account_ids'] },
   categories: { uuid: ['parent_id', 'account_id'] },
   transactions: {
     uuid: ['account_id', 'category_id', 'transfer_account_id', 'linked_transfer_id', 'linked_transfer_split_id'],
@@ -978,6 +957,20 @@ export function remapBackupIds(
         next[column] = document;
       }
 
+      for (const column of spec.idArrays ?? []) {
+        const stored = row[column];
+        if (!Array.isArray(stored)) continue;
+        next[column] = stored.map((element) => {
+          if (typeof element !== 'string') return element;
+          const replacement = lookup(element);
+          if (replacement === undefined) {
+            note(column, element);
+            return element;
+          }
+          return replacement;
+        });
+      }
+
       if (entity === 'suggestion_dismissals') {
         const key = readString(row, 'subject_key');
         if (key) {
@@ -994,22 +987,11 @@ export function remapBackupIds(
   // every transfer pointing at the id it had in the old login.
   const account_parents: AccountParentLink[] = bundle.links.account_parents.map((link) => {
     const id = idMap.get(link.id) ?? link.id;
-    const remapAccount = (field: 'parent_account_id' | 'secured_against_account_id', value: string | null | undefined): string | null | undefined => {
-      if (value === null || value === undefined) return value;
-      const mapped = idMap.get(value);
-      if (mapped === undefined) {
-        danglingRefs.push({ entity: 'links.account_parents', rowId: id, field, value });
-        return value;
-      }
-      return mapped;
-    };
-    const parent = remapAccount('parent_account_id', link.parent_account_id) ?? null;
-    const secured = remapAccount('secured_against_account_id', link.secured_against_account_id);
-    return {
-      id,
-      parent_account_id: parent,
-      ...(secured === undefined ? {} : { secured_against_account_id: secured })
-    };
+    const parent = idMap.get(link.parent_account_id);
+    if (parent === undefined) {
+      danglingRefs.push({ entity: 'links.account_parents', rowId: id, field: 'parent_account_id', value: link.parent_account_id });
+    }
+    return { id, parent_account_id: parent ?? link.parent_account_id };
   });
 
   const transaction_links: TransactionLink[] = bundle.links.transaction_links.map((link) => {

--- a/src/services/local/mappers/columns.ts
+++ b/src/services/local/mappers/columns.ts
@@ -349,7 +349,7 @@ export const ACCOUNT_COLUMNS: readonly Column[] = [
   { key: 'parent_account_id', field: 'parentAccountId', kind: 'text' },
   // Display + one opt-in total only — never nests, never counts. See the
   // Account type and migration 20260815200000.
-  { key: 'secured_against_account_id', field: 'securedAgainstAccountId', kind: 'text' }
+  { key: 'secured_against_account_ids', field: 'securedAgainstAccountIds', kind: 'strings' }
 ];
 
 /**

--- a/src/services/localBackupService.ts
+++ b/src/services/localBackupService.ts
@@ -250,7 +250,7 @@ function accountToRow(app: Record<string, unknown>): BackupRow {
   put(row, 'opening_balance_date', dateColumn(app.openingBalanceDate));
   put(row, 'archive_through_date', app.archiveThroughDate === null ? null : dateColumn(app.archiveThroughDate));
   put(row, 'parent_account_id', app.parentAccountId === null ? null : text(app.parentAccountId));
-  put(row, 'secured_against_account_id', app.securedAgainstAccountId === null ? null : text(app.securedAgainstAccountId));
+  put(row, 'secured_against_account_ids', Array.isArray(app.securedAgainstAccountIds) ? app.securedAgainstAccountIds : undefined);
   put(row, 'notes', app.notes ?? undefined);
   put(row, 'is_active', bool(app.isActive));
   put(row, 'sort_code', text(app.sortCode));
@@ -281,7 +281,7 @@ function accountFromRow(row: BackupRow): Record<string, unknown> {
     openingBalanceDate: text(row.opening_balance_date),
     archiveThroughDate: row.archive_through_date === null ? null : text(row.archive_through_date),
     parentAccountId: row.parent_account_id === null ? null : text(row.parent_account_id),
-    securedAgainstAccountId: row.secured_against_account_id === null ? null : text(row.secured_against_account_id),
+    securedAgainstAccountIds: Array.isArray(row.secured_against_account_ids) ? row.secured_against_account_ids : undefined,
     notes: text(row.notes),
     isActive: bool(row.is_active),
     sortCode: text(row.sort_code),
@@ -990,10 +990,8 @@ function applyLinks(bundle: BackupBundle): {
   transactionsRelinked: number;
 } {
   const parents = new Map<string, string>();
-  const secured = new Map<string, string>();
   for (const link of bundle.links.account_parents) {
     if (link.parent_account_id) parents.set(link.id, link.parent_account_id);
-    if (link.secured_against_account_id) secured.set(link.id, link.secured_against_account_id);
   }
 
   const transfers = new Map<string, { transfer: string | null; split: string | null }>();
@@ -1007,14 +1005,9 @@ function applyLinks(bundle: BackupBundle): {
   const accounts = bundle.data.accounts.map((row) => {
     const id = typeof row.id === 'string' ? row.id : null;
     const parent = id === null ? undefined : parents.get(id);
-    const securedAgainst = id === null ? undefined : secured.get(id);
-    if (parent === undefined && securedAgainst === undefined) return row;
+    if (parent === undefined) return row;
     accountsRelinked += 1;
-    return {
-      ...row,
-      ...(parent === undefined ? {} : { parent_account_id: parent }),
-      ...(securedAgainst === undefined ? {} : { secured_against_account_id: securedAgainst })
-    };
+    return { ...row, parent_account_id: parent };
   });
 
   let transactionsRelinked = 0;

--- a/src/test/securedLiabilities.test.ts
+++ b/src/test/securedLiabilities.test.ts
@@ -18,15 +18,15 @@ import {
   buildTopLevelIdByAccountId
 } from '../utils/accountNesting';
 import { extractAccountParents, buildBackupBundle, remapBackupIds } from '../services/backup/format';
-import { resolveSecuring } from '../utils/accountSecuring';
+import { resolveSecuring, normaliseSecuredIds, buildSecuredByTarget } from '../utils/accountSecuring';
 import { mapAccountToDb } from '../services/api/accountMapping';
 import type { Account } from '../types';
 
 /** The nesting utilities read exactly two fields; this carries a third. */
-const property = { id: 'prop-1', parentAccountId: null, securedAgainstAccountId: null };
-const mortgage = { id: 'debt-1', parentAccountId: null, securedAgainstAccountId: 'prop-1' };
-const cashSleeve = { id: 'cash-1', parentAccountId: 'inv-1', securedAgainstAccountId: null };
-const portfolio = { id: 'inv-1', parentAccountId: null, securedAgainstAccountId: null };
+const property = { id: 'prop-1', parentAccountId: null, securedAgainstAccountIds: [] };
+const mortgage = { id: 'debt-1', parentAccountId: null, securedAgainstAccountIds: ['prop-1'] };
+const cashSleeve = { id: 'cash-1', parentAccountId: 'inv-1', securedAgainstAccountIds: [] };
+const portfolio = { id: 'inv-1', parentAccountId: null, securedAgainstAccountIds: [] };
 
 const all = [property, mortgage, cashSleeve, portfolio];
 
@@ -117,9 +117,58 @@ describe('which accounts may be secured, and against what', () => {
 
   it('keeps a closed target listed, so saving does not silently drop the link', () => {
     const closed = acc('sold-house', 'assets', { isActive: false });
-    const debt = acc('debt', 'loan', { securedAgainstAccountId: 'sold-house' });
+    const debt = acc('debt', 'loan', { securedAgainstAccountIds: ['sold-house'] });
     const targets = resolveSecuring(debt, [debt, closed]).options.map(a => a.id);
     expect(targets).toContain('sold-house');
+  });
+});
+
+describe('a debt held against SEVERAL accounts', () => {
+  /*
+   * The owner's case: a loan drawn against two investment portfolios, labelled
+   * against both without tying the two portfolios to each other.
+   *
+   * The arithmetic trap lives here. A liability names N targets, so anything
+   * that iterates LINKS rather than LIABILITIES counts the debt N times — and
+   * on a portfolio page that is millions removed from a total for a debt that
+   * exists once.
+   */
+  const debt = { id: 'loan', securedAgainstAccountIds: ['inv-a', 'inv-b'] };
+  const invA = { id: 'inv-a', securedAgainstAccountIds: [] };
+  const invB = { id: 'inv-b', securedAgainstAccountIds: [] };
+
+  it('appears under every account it is secured against', () => {
+    const byTarget = buildSecuredByTarget([debt, invA, invB]);
+    expect(byTarget.get('inv-a')?.map(a => a.id)).toEqual(['loan']);
+    expect(byTarget.get('inv-b')?.map(a => a.id)).toEqual(['loan']);
+  });
+
+  it('does not link the two targets to each other', () => {
+    // The owner's words: "not tie the investments together, just put a label
+    // against both of them." Neither portfolio names anything.
+    const byTarget = buildSecuredByTarget([debt, invA, invB]);
+    expect(byTarget.has('loan')).toBe(false);
+    expect(invA.securedAgainstAccountIds).toEqual([]);
+  });
+
+  it('skips a target that is not present — closed, filtered or deleted', () => {
+    // The column has no foreign key, so a deleted account leaves its id behind.
+    // All three cases look the same here and want the same answer.
+    const byTarget = buildSecuredByTarget([debt, invA]);
+    expect(byTarget.get('inv-a')?.map(a => a.id)).toEqual(['loan']);
+    expect(byTarget.has('inv-b')).toBe(false);
+  });
+
+  it('counts a duplicated target once, and drops blanks and self-references', () => {
+    // A duplicate is the one fault that would do arithmetic damage: the same
+    // portfolio chosen twice would subtract the loan twice.
+    expect(normaliseSecuredIds(['inv-a', 'inv-a', '', null, 'loan', 'inv-b'], 'loan'))
+      .toEqual(['inv-a', 'inv-b']);
+  });
+
+  it('lists a doubly-linked debt once under each target, never twice under one', () => {
+    const doubled = { id: 'loan', securedAgainstAccountIds: ['inv-a', 'inv-a'] };
+    expect(buildSecuredByTarget([doubled, invA]).get('inv-a')?.length).toBe(1);
   });
 });
 
@@ -134,21 +183,22 @@ describe('the write path names a real column', () => {
    * and the owner got "Could not find the 'securedAgainstAccountId' column of
    * 'accounts' in the schema cache" while renaming an account type.
    */
-  it('maps securedAgainstAccountId to its snake_case column', () => {
-    expect(mapAccountToDb({ securedAgainstAccountId: 'prop-1' }))
-      .toEqual({ secured_against_account_id: 'prop-1' });
+  it('maps securedAgainstAccountIds to its snake_case column', () => {
+    expect(mapAccountToDb({ securedAgainstAccountIds: ['prop-1', 'inv-1'] }))
+      .toEqual({ secured_against_account_ids: ['prop-1', 'inv-1'] });
   });
 
-  it('sends null through, because null is how a link is CLEARED', () => {
-    // `undefined` means "leave alone" and is dropped; null must survive.
-    expect(mapAccountToDb({ securedAgainstAccountId: null }))
-      .toEqual({ secured_against_account_id: null });
+  it('sends an EMPTY array through, because [] is how every link is cleared', () => {
+    // `undefined` means "leave alone" and is dropped; [] must survive, or
+    // unlinking the last target would silently leave it linked.
+    expect(mapAccountToDb({ securedAgainstAccountIds: [] }))
+      .toEqual({ secured_against_account_ids: [] });
   });
 
   it('emits no camelCase key for any account field it maps', () => {
     // The general form of the bug, so the next field added cannot repeat it.
     const columns = mapAccountToDb({
-      securedAgainstAccountId: 'a',
+      securedAgainstAccountIds: ['a'],
       parentAccountId: 'b',
       openingBalanceDate: new Date('2026-01-01T00:00:00.000Z')
     });
@@ -164,31 +214,16 @@ describe('the backup carries the link through a restore', () => {
    * account→account references are re-applied afterwards from a side channel.
    * A new reference that is not in that channel restores as null, silently.
    */
-  it('extracts a liability that has only a secured link and no parent', () => {
-    // The case that a parent-shaped extractor drops on the floor, which is ALL
-    // of them: securing deliberately does not nest, so there is never a parent.
-    const links = extractAccountParents([
-      { id: 'debt-1', secured_against_account_id: 'prop-1' }
-    ]);
-    expect(links).toEqual([
-      { id: 'debt-1', parent_account_id: null, secured_against_account_id: 'prop-1' }
-    ]);
-  });
-
-  it('still extracts an ordinary parent link, and both together', () => {
+  it('extracts an ordinary parent link', () => {
     expect(extractAccountParents([{ id: 'cash-1', parent_account_id: 'inv-1' }]))
       .toEqual([{ id: 'cash-1', parent_account_id: 'inv-1' }]);
-
-    expect(extractAccountParents([
-      { id: 'x', parent_account_id: 'p', secured_against_account_id: 's' }
-    ])).toEqual([{ id: 'x', parent_account_id: 'p', secured_against_account_id: 's' }]);
   });
 
-  it('emits nothing for an account with neither link', () => {
+  it('emits nothing for an account with no parent', () => {
     expect(extractAccountParents([{ id: 'plain-1' }])).toEqual([]);
   });
 
-  it('REMAPS the secured id on the account row, not just the link', () => {
+  it('REMAPS EVERY id in the secured array, not just the first', () => {
     /*
      * The one that would fail silently. `ENTITY_REFERENCES` declares which
      * columns hold ids that a restore must translate; a new account→account
@@ -205,7 +240,8 @@ describe('the backup carries the link through a restore', () => {
       data: {
         accounts: [
           { id: 'prop-1', name: 'Flat 3' },
-          { id: 'debt-1', name: 'Mortgage', secured_against_account_id: 'prop-1' }
+          { id: 'inv-1', name: 'Portfolio' },
+          { id: 'debt-1', name: 'Mortgage', secured_against_account_ids: ['prop-1', 'inv-1'] }
         ]
       },
       preferences: null
@@ -217,12 +253,13 @@ describe('the backup carries the link through a restore', () => {
     })());
 
     const property = remapped.data.accounts.find(r => r.name === 'Flat 3');
+    const portfolio = remapped.data.accounts.find(r => r.name === 'Portfolio');
     const debt = remapped.data.accounts.find(r => r.name === 'Mortgage');
 
     expect(property?.id).toBe('new-1');
-    expect(debt?.id).toBe('new-2');
-    // The point: it follows the property to its NEW id.
-    expect(debt?.secured_against_account_id).toBe('new-1');
-    expect(debt?.secured_against_account_id).not.toBe('prop-1');
+    expect(portfolio?.id).toBe('new-2');
+    // The point: BOTH follow their targets to the new ids. A remap that
+    // handled element 0 and stopped would restore the second link dangling.
+    expect(debt?.secured_against_account_ids).toEqual(['new-1', 'new-2']);
   });
 });

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -43,8 +43,12 @@ export interface Account {
   parentAccountId?: string | null;
   /**
    * What this liability is HELD AGAINST — a mortgage against its property, a
-   * loan against the portfolio it is drawn on. Set on the LIABILITY, pointing
-   * at the asset. NULL/undefined = an ordinary unsecured liability.
+   * loan against the portfolios it is drawn on. Set on the LIABILITY, naming
+   * the assets. Empty/undefined = an ordinary unsecured liability.
+   *
+   * SEVERAL, because a loan can be drawn against more than one portfolio. The
+   * targets are NOT thereby linked to each other: this is a label each of them
+   * carries, not a grouping.
    *
    * DELIBERATELY NOT `parentAccountId`, and the difference is the whole point.
    * A parent means "belongs inside, and counts toward": a cash sleeve moves
@@ -59,7 +63,7 @@ export interface Account {
    * either way — it already counts the asset and the debt separately, and
    * always did.
    */
-  securedAgainstAccountId?: string | null;
+  securedAgainstAccountIds?: string[];
   holdings?: Holding[];
   notes?: string;
   isActive?: boolean;

--- a/src/utils/accountSecuring.ts
+++ b/src/utils/accountSecuring.ts
@@ -70,10 +70,68 @@ export function resolveSecuring(
 
   // A target that has since been closed stays listed, or saving any other
   // change on the form would silently drop the link.
-  const current = account.securedAgainstAccountId
-    ? accounts.find(a => a.id === account.securedAgainstAccountId)
-    : undefined;
-  if (current && !options.some(a => a.id === current.id)) options.push(current);
+  for (const id of account.securedAgainstAccountIds ?? []) {
+    if (options.some(a => a.id === id)) continue;
+    const current = accounts.find(a => a.id === id);
+    if (current) options.push(current);
+  }
 
   return { offered: options.length > 0, options };
+}
+
+/**
+ * The stored list, cleaned: no blanks, no duplicates, nothing pointing at the
+ * account itself.
+ *
+ * Both the form and every reader go through this, because the three faults it
+ * removes arrive from different directions — a blank from an untouched "add
+ * another" row, a duplicate from picking the same account twice, and a
+ * self-reference from an account that was retyped after being linked. A
+ * duplicate is the one that would do arithmetic damage if it ever reached the
+ * Investments page, so it is removed at the source rather than guarded against
+ * at each use.
+ */
+export function normaliseSecuredIds(
+  ids: readonly (string | null | undefined)[],
+  selfId?: string
+): string[] {
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (const id of ids) {
+    if (!id || id === selfId || seen.has(id)) continue;
+    seen.add(id);
+    out.push(id);
+  }
+  return out;
+}
+
+/**
+ * Target account id → the liabilities secured against it.
+ *
+ * Deliberately NOT built with `buildChildrenByParent`, even though the shape
+ * is nearly identical. That helper answers "where does this account's money
+ * belong", and the answer for a secured liability is "exactly where it already
+ * is". Everything downstream of the nesting utilities is right to count what
+ * it groups, so this must not travel through any of it.
+ *
+ * A target that is not in `accounts` is skipped — closed, filtered out of the
+ * current view, or deleted (the column has no foreign key). All three look the
+ * same from here and all three want the same answer: a row keyed under a card
+ * that is not on the page is a row nobody sees.
+ */
+export function buildSecuredByTarget<T extends {
+  id: string;
+  securedAgainstAccountIds?: string[];
+}>(accounts: readonly T[]): Map<string, T[]> {
+  const present = new Set(accounts.map(a => a.id));
+  const map = new Map<string, T[]>();
+  for (const account of accounts) {
+    for (const targetId of normaliseSecuredIds(account.securedAgainstAccountIds ?? [], account.id)) {
+      if (!present.has(targetId)) continue;
+      const list = map.get(targetId);
+      if (list) list.push(account);
+      else map.set(targetId, [account]);
+    }
+  }
+  return map;
 }

--- a/supabase/migrations/20260815210000_a_debt_may_be_secured_against_several_accounts.sql
+++ b/supabase/migrations/20260815210000_a_debt_may_be_secured_against_several_accounts.sql
@@ -1,0 +1,74 @@
+-- ============================================================================
+-- One debt, several accounts.
+--
+-- 20260815200000 gave a liability a single `secured_against_account_id`, on the
+-- assumption that a debt is held against one thing. The owner's own case says
+-- otherwise: a loan drawn against TWO investment portfolios, which he wants
+-- labelled against both without tying the two portfolios to each other.
+--
+-- Singular → plural, in one step, because the column is days old.
+--
+-- ─ WHY AN ARRAY AND NOT A JOIN TABLE ────────────────────────────────────────
+--
+-- A join table is the textbook answer for many-to-many and is the wrong trade
+-- here. This relationship is DISPLAY-ONLY — it moves nothing between sections
+-- and adds to no total — and it is tiny: a debt is held against one or two
+-- things, not fifty.
+--
+-- Against that, a new table is a new entity in every layer this app carries:
+-- the cloud read path, the local SQLite engine, the backup's entity list, its
+-- id remap, and the restore's ordering. Each is a place to forget, and the
+-- singular column has already proved the point — it shipped with its WRITE
+-- mapping missing and broke saving an account entirely.
+--
+-- An array reuses machinery that already exists and is already tested:
+-- `tags` and `suggestion_dismissals.subject_ids` are both text arrays, and the
+-- local mapper has a `strings` kind for exactly this.
+--
+-- ─ WHAT IS GIVEN UP, AND WHY IT IS AFFORDABLE ───────────────────────────────
+--
+-- Referential integrity. A uuid[] cannot carry a foreign key, so deleting a
+-- property leaves its id sitting in some loan's array, where ON DELETE SET
+-- NULL used to clean up after itself.
+--
+-- That is survivable HERE and would not be elsewhere: every reader of this
+-- column already resolves ids against the accounts it holds and skips what it
+-- cannot find, because it had to — an account may also be closed, or filtered
+-- out of the current view, and neither of those is a deletion. A dangling id
+-- is therefore invisible rather than wrong. It costs a row in the array that
+-- nothing renders.
+--
+-- The alternative — correctness by constraint — costs a table in five layers
+-- to tidy up a value that displays as nothing either way.
+-- ============================================================================
+
+BEGIN;
+
+ALTER TABLE public.accounts
+  ADD COLUMN IF NOT EXISTS secured_against_account_ids uuid[] NOT NULL DEFAULT '{}';
+
+-- Carry over anything already linked through the singular column. Runs before
+-- the DROP below and in the same transaction, so no link can be lost between
+-- the two — including on a database where 20260815200000 was applied and used.
+UPDATE public.accounts
+   SET secured_against_account_ids = ARRAY[secured_against_account_id]
+ WHERE secured_against_account_id IS NOT NULL
+   AND cardinality(secured_against_account_ids) = 0;
+
+ALTER TABLE public.accounts
+  DROP COLUMN IF EXISTS secured_against_account_id;
+
+-- GIN, because every question asked of this column is "which rows contain this
+-- account id" — the Accounts page keying liabilities by what they are secured
+-- against, and the Investments page asking which debts touch a portfolio.
+CREATE INDEX IF NOT EXISTS idx_accounts_secured_against_account_ids
+  ON public.accounts USING GIN (secured_against_account_ids);
+
+COMMENT ON COLUMN public.accounts.secured_against_account_ids IS
+  'The accounts this liability is held against (mortgage → property, loan → '
+  'one or more portfolios). DISPLAY AND OPT-IN TOTALS ONLY: unlike '
+  'parent_account_id the row does not move section and is never added to a '
+  'target''s total. No FK — readers resolve against loaded accounts and skip '
+  'what they cannot find, which they must do for closed accounts anyway.';
+
+COMMIT;


### PR DESCRIPTION
The owner's case: a loan drawn against **two** investment portfolios, labelled against both — *"not tie the investments together, just put a label against both of them."*

Singular column → `uuid[]`, in one migration, because the column is days old. `20260815210000` backfills from it and drops it **inside one transaction**, so no link is lost whether or not the earlier migration was ever applied.

## Why an array and not a join table

A join table is the textbook answer for many-to-many and the wrong trade here. The relationship is display-only and tiny — one or two targets, not fifty. Against that, a new table is a new entity in the cloud read path, the local SQLite engine, the backup's entity list, its id remap **and** the restore's ordering.

Each is a place to forget, and the singular column already proved the point: it shipped with its write mapping missing and broke saving an account entirely.

The array reuses machinery that exists and is tested — `tags` and `subject_ids` are both text arrays, and the local mapper has a `strings` kind for exactly this.

**What is given up:** referential integrity. A `uuid[]` carries no foreign key, so deleting a property leaves its id behind. Affordable *here* because every reader already resolves ids against the accounts it holds and skips what it cannot find — it had to, since an account may equally be closed or filtered out of the view. A dangling id is invisible rather than wrong.

## The arithmetic trap

This is the whole risk of going plural. A liability now names N targets, so anything iterating **links** rather than **liabilities** counts the debt N times — on the Investments page, millions removed from a total for a debt that exists once.

So the net-position sum asks *"does this liability name any of these portfolios?"* and adds it once, and duplicates are stripped at the source by `normaliseSecuredIds` rather than guarded against at each use.

## The control

The owner's own shape: choose something and a fresh row appears beneath; choose in that and another appears. Setting a row back to "Nothing" **removes** it rather than leaving a hole — which is what makes the single trailing spare reliable. Each row hides what the others have already taken.

## Backup

A new `idArrays` reference kind beside the existing `jsonbIdArrays`, because this is a top-level array of ids rather than ids buried in a jsonb document. Every element is remapped and a dangling one is reported, exactly as a scalar reference would be.

## Guards — 19 tests, proven non-vacuous

| mutation | result |
| --- | --- |
| disable the `idArrays` remap | fails the restore case |
| remove the dedupe | fails 2 |
| remove the missing-target guard | fails the deleted-account case |

## Verification

lint (zero warnings) · `typecheck:strict` · 6,084 unit tests · `desktop:verify` — green.

**Migration `20260815210000` must be applied.** It supersedes `20260815200000`; if that one was never run, both apply cleanly in order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)