### PR TITLE
fix(accounts): Liability is a type you can choose, and grey text survives dark mode

### DIFF
--- a/src/components/AccountSettingsModal.test.tsx
+++ b/src/components/AccountSettingsModal.test.tsx
@@ -132,8 +132,14 @@ describe('AccountSettingsModal', () => {
       expect(typeSelect).toContainHTML('<option value="loan">Loan Account</option>');
       expect(typeSelect).toContainHTML('<option value="credit">Credit Card</option>');
       expect(typeSelect).toContainHTML('<option value="investment">Investments</option>');
-      expect(typeSelect).toContainHTML('<option value="assets">Other Asset</option>');
-      expect(typeSelect).toContainHTML('<option value="other">Other Liability</option>');
+      // 'assets' and 'liability' — the two that name the ASSETS and
+      // LIABILITIES sections. 'other' was offered here as "Other Liability"
+      // and filed under "Other Accounts", because it is not a section type at
+      // all, so choosing it moved an account somewhere the label never
+      // mentioned.
+      expect(typeSelect).toContainHTML('<option value="assets">Asset</option>');
+      expect(typeSelect).toContainHTML('<option value="liability">Liability</option>');
+      expect(typeSelect).not.toContainHTML('<option value="other">');
     });
 
     it('shows help text for account type', () => {

--- a/src/components/AccountSettingsModal.tsx
+++ b/src/components/AccountSettingsModal.tsx
@@ -11,6 +11,11 @@ import GroupedAccountOptions from './common/GroupedAccountOptions';
 import { accountCurrencyOptions, describeAccountCurrency } from '../constants/accountCurrencies';
 import { resolveSecuring, normaliseSecuredIds } from '../utils/accountSecuring';
 import {
+  ACCOUNT_SECTION_DEFINITIONS,
+  OTHER_SECTION_DEFINITION,
+  sectionTypeForAccount
+} from '../utils/accountGrouping';
+import {
   BANK_ACCOUNT_NUMBER_LENGTH,
   CARD_NUMBER_LABEL,
   accountNumberForStorage,
@@ -128,9 +133,45 @@ const accountTypeOptions = [
   { value: 'loan', label: 'Loan Account' },
   { value: 'credit', label: 'Credit Card' },
   { value: 'investment', label: 'Investments' },
-  { value: 'assets', label: 'Other Asset' },
-  { value: 'other', label: 'Other Liability' }
+  // 'assets' and 'liability' name the ASSETS and LIABILITIES sections — the
+  // two the owner actually files into. 'other' is deliberately NOT offered:
+  // it was labelled "Other Liability" and filed under "Other Accounts",
+  // because it is not a section type at all (see sectionTypeForAccount's
+  // catch-all). Choosing it moved an account somewhere the label had not
+  // mentioned, which is how a loan ended up alone in its own band.
+  //
+  // 'other' remains a valid STORED type — imports write it, and the catch-all
+  // section exists so such a row still renders — it is simply not something a
+  // person should be able to choose by accident.
+  { value: 'assets', label: 'Asset' },
+  { value: 'liability', label: 'Liability' }
 ];
+
+/**
+ * The offered types, plus this account's OWN type when the list has no entry
+ * for it.
+ *
+ * A select whose value is absent from its own options does not show an empty
+ * box — it shows the FIRST option, and saving that silently retypes the
+ * account to whatever happens to be at the top. The same trap the pairing
+ * dropdown documents, and a live one here: 'other', 'checking', 'mortgage',
+ * 'cash' and 'asset' are all storable and none of them is offered. An imported
+ * ledger is full of exactly those.
+ *
+ * So a stored type is always representable, labelled by the SECTION it files
+ * under, which is the question the field actually answers ("where does this
+ * account appear?"). Choosing anything else still moves it; nothing forces the
+ * legacy value to be kept.
+ */
+function typeOptionsFor(current: BaseAccount['type']): { value: string; label: string }[] {
+  if (accountTypeOptions.some(o => o.value === current)) return accountTypeOptions;
+  const section = ACCOUNT_SECTION_DEFINITIONS
+    .find(s => s.type === sectionTypeForAccount(current));
+  return [
+    ...accountTypeOptions,
+    { value: current, label: `${section?.title ?? OTHER_SECTION_DEFINITION.title} (as imported)` }
+  ];
+}
 
 export default function AccountSettingsModal({
   isOpen,
@@ -361,7 +402,7 @@ export default function AccountSettingsModal({
               onChange={(e) => updateField('type', e.target.value as Account['type'])}
               className="w-full px-3 py-2 bg-white dark:bg-gray-800 border border-gray-300/50 dark:border-gray-600/50 rounded-xl focus:border-transparent dark:text-white"
             >
-              {accountTypeOptions.map((option) => (
+              {typeOptionsFor(account?.type ?? 'current').map((option) => (
                 <option key={option.value} value={option.value}>
                   {option.label}
                 </option>

--- a/src/components/AddAccountModal.tsx
+++ b/src/components/AddAccountModal.tsx
@@ -54,7 +54,12 @@ const accountTypes = [
   { value: 'credit', label: 'Credit Card', icon: CreditCardIcon, description: 'Credit line account' },
   { value: 'loan', label: 'Loan', icon: BanknoteIcon, description: 'Mortgages, personal loans' },
   { value: 'investment', label: 'Investment', icon: TrendingUpIcon, description: 'Stocks, bonds, funds' },
-  { value: 'assets', label: 'Other Assets', icon: PackageIcon, description: 'Property, valuables' },
+  { value: 'assets', label: 'Asset', icon: PackageIcon, description: 'Property, valuables' },
+  // There was NO way to create a liability here, so anything that was not a
+  // loan or a card had to be made as something else and retyped afterwards —
+  // and Account Settings then offered only "Other Liability", which filed it
+  // under Other Accounts rather than Liabilities.
+  { value: 'liability', label: 'Liability', icon: BanknoteIcon, description: 'Anything else you owe' },
 ];
 
 // The supported list, shared with Account Settings — which now SHOWS an

--- a/src/components/dashboard/ImprovedDashboard.tsx
+++ b/src/components/dashboard/ImprovedDashboard.tsx
@@ -483,8 +483,10 @@ export function ImprovedDashboard() {
   );
   const customPinnedReports = pinnedReports.filter(id => id.startsWith('custom:'));
   // A column with nothing in it is not drawn — an empty half of a two-column
-  // grid is a hole, not a layout.
-  const showAssetsColumn = assetsReports.length > 0 || pieData.length > 0;
+  // grid is a hole, not a layout. Account Distribution is ALWAYS one of its
+  // contents now (see the card itself), so this no longer turns on whether
+  // there is data to draw.
+  const showAssetsColumn = true;
   const showFlowsColumn = flowsReports.length > 0;
 
   return (
@@ -622,13 +624,28 @@ export function ImprovedDashboard() {
                   states none of its own, and sending one would move the window
                   the NEXT report opens on from a control the destination does
                   not even show. The way back travels — see useReportDrill. */}
-              {pieData.length > 0 && (
+              {/* ALWAYS RENDERED, empty or not. It used to disappear when
+                  there were no balances to draw, which on a fresh ledger left
+                  the left column blank beside two cards on the right — the
+                  owner read that as a chart that had failed, not as one with
+                  nothing to say. His ruling: "It should still be shown, but
+                  just with zero data, like the others."
+
+                  What is shown when empty is a SENTENCE, not an empty ring.
+                  Claude Design's §3 asks for exactly that and gives the reason:
+                  an axis (or a ring) with nothing on it asserts there is
+                  something to plot and reads as a failed load. The two rulings
+                  agree once separated — the owner is asking for the CARD to be
+                  present, Design is asking for the FRAME not to be. */}
+              {(
                 <DashboardWidgetCard
                   title="Account Distribution"
                   subtitle={
                     <>
                       <span className="text-xs text-gray-500 dark:text-gray-400 truncate">
-                        Your top {pieData.length} account{pieData.length === 1 ? '' : 's'} by balance
+                        {pieData.length === 0
+                          ? 'Your largest accounts by balance'
+                          : `Your top ${pieData.length} account${pieData.length === 1 ? '' : 's'} by balance`}
                       </span>
                       <span className="text-xs text-gray-400 dark:text-gray-500 ml-auto whitespace-nowrap">
                         Current balances
@@ -637,6 +654,12 @@ export function ImprovedDashboard() {
                   }
                   onOpen={() => openReport('account-distribution')}
                 >
+                  {pieData.length === 0 ? (
+                    <p className="py-8 text-center text-sm text-gray-500 dark:text-gray-400">
+                      No account balances to compare yet
+                    </p>
+                  ) : (
+                  <>
                   {/* A SQUARE for the ring, ALL remaining width for the names —
                       the same rule the Expense Categories card follows, so the
                       two donuts on this page sit at the same size and start at
@@ -690,6 +713,8 @@ export function ImprovedDashboard() {
                       ))}
                     </ul>
                   </div>
+                  </>
+                  )}
                 </DashboardWidgetCard>
               )}
             </div>

--- a/src/pages/Accounts.tsx
+++ b/src/pages/Accounts.tsx
@@ -1099,10 +1099,22 @@ export default function Accounts() {
     setSelectedAccountId(nextId);
     const node = document.getElementById(rowDomId(nextId));
     // The row is already rendered — only its tabindex changes — so it can be
-    // handed the focus directly. `nearest`: browsing, so the least scroll that
-    // shows the row, and none at all while it is already visible.
+    // handed the focus directly.
+    //
+    // `center`, NOT `nearest`. `nearest` is defined as "scroll the least that
+    // makes it visible", which means it does nothing at all while the row is
+    // on screen and then jumps when it reaches an edge — the owner's report:
+    // "the page doesn't move until the highlighted account is out of sight,
+    // then the page starts scrolling". It reads as a stall followed by a lurch.
+    //
+    // `center` keeps the selection in the middle and the list moving under it,
+    // which is what the register already does (useArrivalFocus) and is the
+    // behaviour he asked this page to match. The clamping he described at the
+    // ends — "unless you are that near the bottom or the top that the page
+    // cannot move any more" — needs no code: a scroll container cannot scroll
+    // past its own extent, so the row simply walks up or down the screen there.
     node?.focus({ preventScroll: true });
-    node?.scrollIntoView?.({ block: 'nearest' });
+    node?.scrollIntoView?.({ block: 'center' });
   }, [navigableRowIds, selectedAccountId]);
 
   /**

--- a/src/pages/__tests__/Accounts.selection.test.tsx
+++ b/src/pages/__tests__/Accounts.selection.test.tsx
@@ -535,11 +535,16 @@ describe('Accounts list — the arrow keys walk it', () => {
       fireEvent.click(row('Synthetic Everyday'));
       fireEvent.keyDown(row('Synthetic Everyday'), { key: 'ArrowDown' });
 
-      // `nearest`: this is browsing, so the least scroll that shows the row —
-      // and none at all while it is already on screen. A row arrowed onto below
-      // the fold that stayed below the fold would make the arrows useless on
-      // the long list they exist for.
-      expect(scrollIntoView).toHaveBeenCalledWith({ block: 'nearest' });
+      // `center`, and this test used to pin `nearest`. `nearest` is DEFINED
+      // as "scroll the least that makes it visible", so it does nothing while
+      // the row is on screen and then jumps when it reaches an edge — the
+      // owner's report: "the page doesn't move until the highlighted account
+      // is out of sight, then the page starts scrolling". A stall then a lurch.
+      //
+      // `center` keeps the selection mid-screen with the list moving under it,
+      // which is what the register already does (useArrivalFocus). Clamping at
+      // the ends needs no code: a container cannot scroll past its own extent.
+      expect(scrollIntoView).toHaveBeenCalledWith({ block: 'center' });
       expect(scrollIntoView.mock.instances[0]).toBe(row('Synthetic Portfolio'));
     } finally {
       restoreScrollIntoView();

--- a/src/styles/accessibility-colors.css
+++ b/src/styles/accessibility-colors.css
@@ -137,18 +137,33 @@ textarea:focus-visible {
   font-weight: 500 !important; /* Make errors slightly bolder for visibility */
 }
 
-/* Gray text contrast improvements */
-.text-gray-500 {
+/* Gray text contrast improvements — LIGHT MODE ONLY.
+ *
+ * `html:not(.dark)` is the whole fix, and it is here because these three rules
+ * were darkening text in DARK mode too. They carry `!important`, so they beat
+ * every `dark:` variant a component declares no matter how specific it is: an
+ * element written `text-xs text-gray-500 dark:text-gray-300` rendered at
+ * #374151 on a #1f2937 card — 1.3:1, which is not dim, it is absent.
+ *
+ * That is what the owner reported as "you can't see the 'last updated' font
+ * within the accounts", and it was never one component's bug: 462 elements
+ * across the app pair a gray-500/400 with a small-text class.
+ *
+ * Scoping rather than deleting, because the light-mode reasoning is sound —
+ * Tailwind's gray-500 on white is 4.0:1 and misses AA for body text. In dark
+ * mode the components' own `dark:` variants are what should decide, and now
+ * they can. */
+html:not(.dark) .text-gray-500 {
   color: #4b5563 !important; /* gray-600 for better contrast */
 }
 
-.text-gray-400 {
+html:not(.dark) .text-gray-400 {
   color: #6b7280 !important; /* gray-500 for better contrast */
 }
 
 /* Widget and card text contrast */
-.text-xs.text-gray-500,
-.text-sm.text-gray-500 {
+html:not(.dark) .text-xs.text-gray-500,
+html:not(.dark) .text-sm.text-gray-500 {
   color: #374151 !important; /* gray-700 for small text */
 }
 

--- a/src/test/mobileChromeRegressions.test.ts
+++ b/src/test/mobileChromeRegressions.test.ts
@@ -128,3 +128,52 @@ describe('the global button rule that lets rows overflow', () => {
     expect(block, 'the global button rule moved — re-point this guard').not.toBeNull();
   });
 });
+
+describe('a light-mode contrast remap may not reach dark mode', () => {
+  /*
+   * `accessibility-colors.css` raises grey text for WCAG on WHITE. Every rule
+   * in it carries `!important`, which beats any `dark:` variant a component
+   * declares however specific — so an unscoped rule does not merely fail to
+   * help in dark mode, it actively overrides the colour that was chosen for
+   * dark mode.
+   *
+   * Measured: an element written `text-xs text-gray-500 dark:text-gray-300`
+   * rendered at #374151 on a #1f2937 card. That is 1.3:1 — not dim, absent.
+   * The owner reported it as "you can't see the 'last updated' font within
+   * the accounts", and it was never that component's bug: 462 elements across
+   * the app pair a grey with a small-text class.
+   *
+   * The rule: a light-tuned colour must say so in its selector.
+   */
+  const remapCss = read('src/styles/accessibility-colors.css');
+
+  it('scopes every grey remap to light mode', () => {
+    // Comments stripped first, or the prose explaining this rule reads as a
+    // rule. Then each selector in each rule's selector LIST is judged on its
+    // own — a list is only as scoped as its least-scoped member.
+    const withoutComments = remapCss.replace(/\/\*[\s\S]*?\*\//g, '');
+    const offenders: string[] = [];
+
+    for (const rule of withoutComments.matchAll(/([^{}]+)\{([^}]*)\}/g)) {
+      if (!/color\s*:/.test(rule[2])) continue;
+      for (const selector of rule[1].split(',')) {
+        const trimmed = selector.trim();
+        // The BARE utility — `.text-gray-500`, not Tailwind's escaped
+        // `.dark\:text-gray-500`, which is a different class entirely and is
+        // supposed to apply in dark mode.
+        if (!/(?:^|[\s>+~])\.text-gray-(?:400|500)\b/.test(trimmed)) continue;
+        if (trimmed.includes('html:not(.dark)') || /(?:^|\s)\.dark(?:\s|$)/.test(trimmed)) continue;
+        offenders.push(trimmed);
+      }
+    }
+
+    expect(offenders, 'these darken grey text in DARK mode too').toEqual([]);
+  });
+
+  it('still applies them in light mode, which is what they are for', () => {
+    // Scoping must not become deleting: Tailwind's gray-500 on white is 4.0:1
+    // and misses AA for body text, which is why these exist.
+    expect(remapCss).toMatch(/html:not\(\.dark\)\s+\.text-gray-500\s*\{[^}]*color:/);
+    expect(remapCss).toMatch(/html:not\(\.dark\)\s+\.text-xs\.text-gray-500/);
+  });
+});


### PR DESCRIPTION
Four from the owner. The first two each turned out to be a cause rather than a component.

## 1. "Other Liability" filed under "Other Accounts"

The option wrote type `'other'` — which is **not a section type at all**. `sectionTypeForAccount` sends it to the catch-all, so choosing the only liability-sounding option moved the account somewhere its own label never mentioned.

Now `'liability'` and `'assets'`, which name the **Liabilities** and **Assets** sections. Add Account offers a Liability at all for the first time — previously anything that wasn't a loan or a card had to be created as something else and retyped.

**A trap this opened, and closed:** a stored type the list doesn't offer (`other`, `checking`, `mortgage`, `cash`) is now appended as an option labelled by its section. A `<select>` whose value is absent from its options does not render empty — it renders the **first** option, and saving that silently retypes the account. An imported ledger is full of exactly those types.

## 2. Grey text invisible in dark mode — app-wide

`accessibility-colors.css` raises grey text for WCAG **on white**, with `!important` on every rule, and three were unscoped. `!important` beats any `dark:` variant however specific:

> `text-xs text-gray-500 dark:text-gray-300` rendered at **#374151 on #1f2937 — 1.3:1**. Not dim. Absent.

**462 elements** pair a grey with a small-text class, so this is very likely behind more than one dark-mode complaint.

Scoped to `html:not(.dark)` rather than deleted — the light-mode reasoning is sound (Tailwind's gray-500 on white is 4.0:1 and misses AA for body text). In dark mode the components' own variants now decide, which is what they were written to do.

## 3. The arrow keys stalled, then lurched

`scrollIntoView({ block: 'nearest' })` is *defined* as "scroll the least that makes it visible" — so it does nothing while the row is on screen and jumps when it hits an edge. Exactly the report: *"the page doesn't move until the highlighted account is out of sight, then the page starts scrolling."*

`center` now, matching the register. The clamping at the ends needs no code — a container cannot scroll past its own extent.

## 4. Account Distribution vanished on an empty ledger

Leaving the left column blank beside two cards on the right, which reads as a chart that failed rather than one with nothing to say.

Always rendered now, and when empty it shows a **sentence** rather than an empty ring. That satisfies both rulings at once: the owner asked for the **card** to be present, Claude Design's §3 asks for the **frame** not to be. They only conflict if you conflate the two.

## Guards

The grey remap has a test that judges **every selector in every selector list** — a list is only as scoped as its least-scoped member. Proven non-vacuous by unscoping each of the three rules in turn (2 failures, 1, 1).

Two existing tests pinned the old behaviour and were **updated with the reasons**, not deleted.

## Verification

lint (zero warnings) · `typecheck:strict` · 6,086 unit tests · `desktop:verify` — green.

**Not verified:** dark-mode rendering. The browser pane can't restyle after a class change, so items 2 and 4 carry stylesheet guards instead of screenshots.

🤖 Generated with [Claude Code](https://claude.com/claude-code)