### PR TITLE
fix(design): Claude Design's handover — the correctness half

### DIFF
--- a/src/components/AccountRowColumns.tsx
+++ b/src/components/AccountRowColumns.tsx
@@ -344,13 +344,25 @@ export function AccountBalanceCell({
   smOnly = false,
 }: {
   label: string;
-  value: string;
+  /**
+   * The figure, already formatted — or `null` for NOT KNOWN, which renders an
+   * em-dash.
+   *
+   * The same contract StatPill states, and for the same reason: an account
+   * with no bank feed has no bank balance, which is not the same as a bank
+   * balance of nothing. This cell used to be handed the string 'N/A' by its
+   * caller — an abbreviation the rest of the app does not use, and one the
+   * register and the reconciliation bar had already been moved off.
+   */
+  value: string | null;
   smOnly?: boolean;
 }): React.JSX.Element {
   return (
     <div className={smOnly ? 'hidden lg:block text-right' : 'text-right'}>
       <p className={ROW_LABEL_CLASS}>{label}</p>
-      <p className={`${CELL_FIGURE_LINE_CLASS} ${CELL_FIGURE_CLASS} text-gray-900 dark:text-white`}>{value}</p>
+      <p className={`${CELL_FIGURE_LINE_CLASS} ${CELL_FIGURE_CLASS} text-gray-900 dark:text-white`}>
+        {value ?? '—'}
+      </p>
     </div>
   );
 }

--- a/src/components/PeriodPicker.tsx
+++ b/src/components/PeriodPicker.tsx
@@ -39,7 +39,16 @@ export default function PeriodPicker({ picker, label }: {
             aria-pressed={period === key}
             className={`px-3 py-1.5 text-sm font-medium rounded-md transition-colors whitespace-nowrap ${
               period === key
-                ? 'bg-[#1a2332] dark:bg-blue-600 text-white'
+                // `#2d3a4d`, NOT `blue-600` (Claude Design §7). The dark
+                // variant reached for a stock Tailwind blue that appears
+                // nowhere in the token set, so the same control had two
+                // identities: navy in light, a vivid blue in dark.
+                //
+                // #2d3a4d is navy-700 — the app's own next step up from
+                // #1a2332, and already the answer the floating nav pill gives
+                // to this exact question (`dark:bg-[#2d3a4d]`). It is the
+                // brand colour lifted off a dark ground, not a different hue.
+                ? 'bg-[#1a2332] dark:bg-[#2d3a4d] text-white'
                 : 'text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-200'
             }`}
           >

--- a/src/components/dashboard/ImprovedDashboard.tsx
+++ b/src/components/dashboard/ImprovedDashboard.tsx
@@ -543,11 +543,40 @@ export function ImprovedDashboard() {
           />
         </div>
 
-        <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+        {/* ─ NO TINTED GROUND (Claude Design §2, and §2.5 before it) ────────
+            These were `bg-green-50` and `bg-red-50` side by side. The figures
+            are already green and red; the tint said the same thing a second
+            time, in the one place P2 reserves for meaning. The card surface
+            and a hairline between them do the separating now.
+
+            ─ THE ARROWS: A DIRECTION, NOT A TREND ───────────────────────────
+            Design's §1 asked for these to go on an empty ledger, on the
+            grounds that they render from a default rather than from a
+            computed change and so claim a trend that does not exist.
+
+            Half applied, deliberately. The owner asked for these two
+            explicitly — "keep the up arrow and down arrow in the income and
+            expenses boxes" — when the decorative glyphs came off this page,
+            and he is right that they are not decoration: up is money coming
+            IN and down is money going OUT, which is a direction, and the
+            app's own rule permits the hues on directions.
+
+            What Design is right about is the ZERO. £0.00 has no direction to
+            point in, so on a fresh ledger the arrow was the only thing on the
+            card making a claim. It is hidden at zero and shown otherwise —
+            which is the same rule this app already applies to colour on a
+            zero, now applied to the arrow beside it.
+
+            NOT made into a change-vs-previous-period indicator, which is what
+            §1 literally asks for. That is a different feature (it needs a
+            prior period, and a number for the change) and it would silently
+            re-point an arrow the owner asked to keep. Raised in the handover
+            rather than assumed. */}
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-4 sm:gap-0 sm:divide-x sm:divide-gray-200 sm:dark:divide-gray-700">
           <button
             type="button"
             onClick={() => setBreakdownType('income')}
-            className="flex items-center justify-between p-4 bg-green-50 dark:bg-green-900/20 rounded-lg hover:bg-green-100 dark:hover:bg-green-900/30 transition-colors cursor-pointer text-left"
+            className="flex items-center justify-between p-4 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-700/50 transition-colors cursor-pointer text-left"
           >
             <div>
               <p className="text-sm text-gray-600 dark:text-gray-400">Income</p>
@@ -555,13 +584,15 @@ export function ImprovedDashboard() {
                 {formatCurrencyWithSymbol(performance.income)}
               </p>
             </div>
-            <TrendingUpIcon size={24} className="text-green-500" />
+            {performance.income !== 0 && (
+              <TrendingUpIcon size={24} className="text-green-500" aria-hidden="true" />
+            )}
           </button>
 
           <button
             type="button"
             onClick={() => setBreakdownType('expense')}
-            className="flex items-center justify-between p-4 bg-red-50 dark:bg-red-900/20 rounded-lg hover:bg-red-100 dark:hover:bg-red-900/30 transition-colors cursor-pointer text-left"
+            className="flex items-center justify-between p-4 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-700/50 transition-colors cursor-pointer text-left"
           >
             <div>
               <p className="text-sm text-gray-600 dark:text-gray-400">Expenses</p>
@@ -569,7 +600,9 @@ export function ImprovedDashboard() {
                 {formatCurrencyWithSymbol(performance.expenses)}
               </p>
             </div>
-            <TrendingDownIcon size={24} className="text-red-500" />
+            {performance.expenses !== 0 && (
+              <TrendingDownIcon size={24} className="text-red-500" aria-hidden="true" />
+            )}
           </button>
         </div>
       </section>

--- a/src/components/dashboard/reportWidgets/DashboardReportWidgets.tsx
+++ b/src/components/dashboard/reportWidgets/DashboardReportWidgets.tsx
@@ -128,6 +128,17 @@ export function NetWorthWidget({ picker, pin }: {
       }
       onOpen={() => open()}
     >
+      {/* AN AXIS WITH NOTHING ON IT IS A CLAIM (Claude Design §3). The frame
+          asserts there is something to plot, so an empty one reads as a chart
+          that failed to load rather than as a period with no data — and
+          Expense Categories, on the same page, already says so in words. Same
+          box height either way, so an empty card does not shrink out of line
+          with its neighbour. */}
+      {snapshots.length === 0 ? (
+        <div className={`${WIDGET_CHART_HEIGHT} flex items-center justify-center`}>
+          <p className="text-center text-sm text-gray-400">No balances recorded in this period</p>
+        </div>
+      ) : (
       <div className={WIDGET_CHART_HEIGHT}>
         <ResponsiveContainer width="100%" height="100%">
           {/* Clicking a point opens the report on the same window with THAT
@@ -155,6 +166,7 @@ export function NetWorthWidget({ picker, pin }: {
           </LineChart>
         </ResponsiveContainer>
       </div>
+      )}
     </DashboardWidgetCard>
   );
 }

--- a/src/components/reconciliation/ReconciliationBalanceBar.tsx
+++ b/src/components/reconciliation/ReconciliationBalanceBar.tsx
@@ -63,7 +63,10 @@ interface ReconciliationBalanceBarProps {
  * different screen.
  */
 const REMOVE_CONSEQUENCE =
-  'Remove the closing balance. Difference goes back to N/A until you enter another.';
+  // "not known" rather than "N/A": the figure it describes is now an em-dash,
+  // and an em-dash read aloud is either silence or the words "em dash". A
+  // spoken label has to say the thing the symbol means.
+  'Remove the closing balance. Difference goes back to not known until you enter another.';
 const REMOVE_CONSEQUENCE_WITH_FALLBACK =
   'Remove the closing balance. Difference falls back to the balance your last reconciliation ended on, which you would then have to confirm.';
 
@@ -337,7 +340,9 @@ export default function ReconciliationBalanceBar({
               {formatCurrency(difference, currency)}
             </p>
           ) : (
-            <p className="text-lg font-bold text-gray-400">N/A</p>
+            /* Em-dash, not "N/A" — the same replacement the register and the
+               Accounts row carry. Not known is not zero. */
+            <p className="text-lg font-bold text-gray-400">—</p>
           )}
         </div>
       </div>

--- a/src/components/reconciliation/__tests__/ReconciliationBalanceBar.test.tsx
+++ b/src/components/reconciliation/__tests__/ReconciliationBalanceBar.test.tsx
@@ -12,6 +12,11 @@ import { CONFIRM_BALANCE_HINT_ID } from '../nextActionYellow';
  * number existed there was no way back to "no closing balance" and a Difference
  * of N/A. These tests hold the way back open.
  *
+ * The symbol itself changed on 15 August, on Claude Design's §4: an em-dash,
+ * not "N/A", which is an abbreviation the rest of the app does not use. What
+ * these tests pin is unchanged — that "not known" and "zero" stay different
+ * statements — so only the character moved.
+ *
  * Every figure here is invented: this repo is public.
  */
 describe('ReconciliationBalanceBar', () => {
@@ -46,12 +51,12 @@ describe('ReconciliationBalanceBar', () => {
   it('shows the difference against a recorded bank balance', () => {
     renderBar(220);
     expect(screen.getByText('Difference')).toBeInTheDocument();
-    expect(screen.queryByText('N/A')).not.toBeInTheDocument();
+    expect(screen.queryByText('—')).not.toBeInTheDocument();
   });
 
-  it('shows N/A and an invitation to type one when there is no bank balance', () => {
+  it('shows an em-dash and an invitation to type one when there is no bank balance', () => {
     renderBar(null);
-    expect(screen.getByText('N/A')).toBeInTheDocument();
+    expect(screen.getByText('—')).toBeInTheDocument();
     expect(screen.getByText('Enter balance')).toBeInTheDocument();
   });
 
@@ -69,19 +74,19 @@ describe('ReconciliationBalanceBar', () => {
     openEditor();
     expect(
       screen.getByRole('button', {
-        name: 'Remove the closing balance. Difference goes back to N/A until you enter another.'
+        name: 'Remove the closing balance. Difference goes back to not known until you enter another.'
       })
     ).toBeInTheDocument();
   });
 
-  it('falls straight back to N/A on removal, before the write has landed', () => {
+  it('falls straight back to an em-dash on removal, before the write has landed', () => {
     // The prop still says 220 — the parent has not saved yet. The bar must
     // already show the state the user asked for, or the click looks ignored.
     renderBar(220);
     openEditor();
     fireEvent.click(screen.getByRole('button', { name: /Remove the closing balance/ }));
 
-    expect(screen.getByText('N/A')).toBeInTheDocument();
+    expect(screen.getByText('—')).toBeInTheDocument();
     expect(screen.getByText('Enter balance')).toBeInTheDocument();
   });
 

--- a/src/pages/AccountTransactions.tsx
+++ b/src/pages/AccountTransactions.tsx
@@ -3070,19 +3070,29 @@ export default function AccountTransactions() {
               with no bank feed has no bank balance — which used to print "N/A"
               and now prints an em-dash, uncoloured. */}
           <div className="bg-white/90 dark:bg-gray-800/90 backdrop-blur-xl rounded-lg border border-gray-100 dark:border-gray-700 px-3 py-1.5">
+            {/* NEUTRAL — a balance is a MAGNITUDE (Claude Design §5). This
+                read `>= 0 ? positive : negative`, so £0.00 printed in income
+                green, and the rule this app already carries is that the hues
+                are banned on magnitudes and permitted on directions. How much
+                is in the account is not a direction; on a credit card the
+                green would have been actively wrong. Net Worth on the summary
+                card is neutral for the same reason. */}
             <StatPill
               label="Account Balance"
               value={formatRegisterMoney(computedAccountBalance)}
-              tone={computedAccountBalance >= 0 ? 'positive' : 'negative'}
+              tone="neutral"
               layout="inline"
             />
           </div>
 
           <div className="bg-white/90 dark:bg-gray-800/90 backdrop-blur-xl rounded-lg border border-gray-100 dark:border-gray-700 px-3 py-1.5">
+            {/* Same rule, and Design's own instruction to check the siblings
+                found it: what the BANK says is in the account is a magnitude
+                too, and it was carrying the same green. */}
             <StatPill
               label="Bank Balance"
               value={bankBalance != null ? formatRegisterMoney(bankBalance) : null}
-              tone={bankBalance != null && bankBalance < 0 ? 'negative' : 'positive'}
+              tone="neutral"
               layout="inline"
             />
           </div>

--- a/src/pages/Accounts.tsx
+++ b/src/pages/Accounts.tsx
@@ -1495,11 +1495,22 @@ export default function Accounts() {
                           in components/AccountRowColumns. */}
                       <div className="flex flex-col sm:flex-row items-stretch sm:items-center gap-2 sm:gap-3">
                             <AccountRowColumns>
+                              {/* AN EM-DASH, NOT "N/A" (Claude Design §4). The
+                                  register and the reconciliation bar were both
+                                  moved off "N/A" and this, their sibling
+                                  surface, was missed — the third time a fix has
+                                  landed on one screen and not the one beside it.
+
+                                  The distinction it draws is load-bearing: an
+                                  account with no bank feed has no bank balance,
+                                  which is not the same as a bank balance of
+                                  nothing. "N/A" is also an abbreviation the rest
+                                  of the app does not use anywhere. */}
                               <AccountBalanceCell
                                 label="Bank Bal"
                                 value={account.bankBalance != null
                                   ? formatDisplayCurrency(account.bankBalance, account.currency)
-                                  : 'N/A'}
+                                  : null}
                               />
                               <AccountBalanceCell
                                 label="Account Bal"
@@ -2657,7 +2668,16 @@ export default function Accounts() {
           content edges — the same ones this sticky box is measured to. The
           strip goes on wearing the row card's box (see AccountRowColumns) to
           match the inset the CARD adds, which is the part that would drift. */}
-      <AccountColumnHeader />
+      {/* HIDDEN WHEN THERE IS NOTHING BELOW IT (Claude Design §6). When there
+          are no rows there are no columns: the labels have nothing to sit over,
+          and on an otherwise empty page the strip is the heaviest thing on it,
+          heading a table that is not there.
+
+          Both empty cases, not just the ledger-is-empty one — a search that
+          matches nothing leaves exactly the same strip over exactly the same
+          nothing, and the filtered empty state below already explains itself
+          without a column header helping. */}
+      {!isLoading && matchedTopLevelCount > 0 && <AccountColumnHeader />}
       </div>
 
       {/* The `-ml-1 pl-1 pr-1` that used to be here went with the scroll


### PR DESCRIPTION
Their §10 order, taken as written: the two that mislead first, then the two that are correctness rather than polish, then the furniture-without-data pair.

## §1 + §2 — the Income and Expenses card

**Tints removed.** The figures are already green and red; the tint said it a second time, in the one place P2 reserves for meaning. Card surface, hairline between.

**The arrows are half applied, deliberately.** §1 asks for them to render from a computed change vs a prior period. The owner asked for these two explicitly when the decorative glyphs came off this page, and he's right that they aren't decoration — up is money **in**, down is money **out**, which is a direction, and the app's own rule permits the hues on directions.

What §1 *is* right about is the **zero**. £0.00 points nowhere, and on a fresh ledger the arrow was the only thing on the card making a claim. Hidden at zero, shown otherwise.

Not turned into a change-vs-prior-period indicator: that's a different feature, and it would silently re-point an arrow the owner asked to keep. Flagging rather than assuming.

## §4 — `N/A` on Accounts

Em-dash. The fix went into `AccountBalanceCell`, not its call site — `value: string | null` now, the same contract `StatPill` already states, so a caller **cannot** hand it the string `'N/A'` again.

The grep Design asked for found one more, in the reconciliation bar. Its aria-label said *"goes back to N/A"* and now says *"goes back to not known"* — an em-dash read aloud is either silence or the words "em dash".

## §5 — Account Balance in income green

`>= 0 ? positive : negative`, so **£0.00 was green**. A balance is a magnitude — how much is there, not which way it went — and on a credit card the green would have been actively wrong.

Design's instruction to check the siblings found **Bank Balance** carrying the same treatment. `Difference` keeps its tone, because settled-vs-not genuinely is a state.

## §6 — the column strip over an empty table

Hidden when there's nothing under it. **Both** empty cases, not only the ledger-is-empty one — a search matching nothing leaves the same strip over the same nothing.

## §3 — the empty chart frame

Net Worth Over Time drew axes with no data, which asserts there's something to plot and reads as a failed load. It says so in words now, in the same box height, matching Expense Categories beside it.

## §7 — the stock blue

`dark:bg-blue-600` on the selected period pill — a colour that appears nowhere in the token set, so one control had two identities. Now `#2d3a4d` (navy-700), which is what the floating nav pill already answers to this exact question.

**Not swept app-wide.** There are **151** `dark:bg-blue-*` and most will be legitimate (links, info states). That's a survey, not a fix, and Design said as much.

## Still open from the handover

§8 (grid fills by flow) and §9 (the FX dialog's ten decimal places) — next batch.

## Verification

lint (zero warnings) · `typecheck:strict` · 6,086 unit tests · `desktop:verify` — green. Four existing tests pinned old behaviour and were **updated with their reasons**, not deleted.

**Not verified:** dark-mode rendering, per the usual harness limit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)