### PR TITLE
fix(fx): a rate is quoted in four places, not the ten it is stored in

### DIFF
--- a/src/components/CrossCurrencyTransferDialog.tsx
+++ b/src/components/CrossCurrencyTransferDialog.tsx
@@ -8,7 +8,7 @@ import {
   RATE_DP,
   destinationForRate,
   rateForDestination,
-  rateToStorageString,
+  rateToDisplayString,
 } from '../utils/fx';
 import { useFxQuote } from '../hooks/useFxQuote';
 import type { ConfirmedConversion } from '../utils/crossCurrencyTransfer';
@@ -124,7 +124,7 @@ export default function CrossCurrencyTransferDialog({
   useEffect(() => {
     if (!isOpen || lastEdited !== null) return;
     if (quote.status !== 'ready') return;
-    setRateText(rateToStorageString(quote.rate));
+    setRateText(rateToDisplayString(quote.rate));
     const destination = destinationForRate(magnitude, quote.rate);
     setDestinationText(destination.ok ? asMoneyText(destination.value) : '');
   }, [isOpen, quote, magnitude, lastEdited]);
@@ -162,7 +162,7 @@ export default function CrossCurrencyTransferDialog({
     const destination = readPositive(next);
     if (!destination) return;
     const rate = rateForDestination(magnitude, destination);
-    if (rate.ok) setRateText(rateToStorageString(rate.value));
+    if (rate.ok) setRateText(rateToDisplayString(rate.value));
   };
 
   const destinationAmount = readPositive(destinationText);
@@ -291,9 +291,14 @@ export default function CrossCurrencyTransferDialog({
             and an amber here would spend the one the yellow thread owns. */}
         <p className="text-dense text-gray-500 dark:text-gray-400 mb-5 min-h-[16px]">
           {quote.status === 'loading' && 'Fetching a rate…'}
+          {/* THE SOURCE AND THE TIME, and not the rate a second time (Claude
+              Design §9.2). The field directly above this already prints the
+              rate in an input the reader can edit; repeating it here in full
+              spent a line saying something already on screen, and pushed the
+              two things this line ALONE can carry — who quoted it and when —
+              to the end where they read as an afterthought. */}
           {quote.status === 'ready' && quote.source === 'api' && (
-            <>1 {sourceCurrency} = <span className="tabular-nums">{rateToStorageString(quote.rate)}</span>{' '}
-            {destinationCurrency} — {quote.provider}, {quotedAt}</>
+            <>{quote.provider}, {quotedAt}</>
           )}
           {quote.status === 'ready' && quote.source === 'fallback' && (
             <>No live rate right now, so this one is approximate — check it against your

--- a/src/utils/__tests__/fx.test.ts
+++ b/src/utils/__tests__/fx.test.ts
@@ -8,6 +8,7 @@ import {
   describeRate,
   destinationForRate,
   rateForDestination,
+  rateToDisplayString,
   rateToStorageString,
   readFxRecord,
 } from '../fx';
@@ -254,5 +255,48 @@ describe('fx', () => {
     it('takes a Decimal and prints it without padding', () => {
       expect(describeRate(new Decimal('2'), { from: 'GBP', to: 'USD' })).toBe('1 GBP = 2 USD');
     });
+  });
+});
+
+describe('a rate is QUOTED shorter than it is STORED (Claude Design §9.1)', () => {
+  const toDecimal = (v: string): Decimal => new Decimal(v);
+  /*
+   * Storage keeps ten places because a DERIVED rate is a division and division
+   * does not terminate: $100 arriving as £74.07 gives 0.7407407407…, and the
+   * stored figure has to reproduce the amounts it came from.
+   *
+   * Display has the opposite duty. Ten places presented a float artefact as
+   * precision the quote never had, in an app that measures its numbers
+   * carefully everywhere else.
+   */
+  it('shows four places where it stores ten', () => {
+    const derived = deriveRate(100, 74.074074);
+    expect(derived.ok).toBe(true);
+    if (!derived.ok) return;
+    expect(rateToStorageString(derived.value)).toMatch(/^0\.7407407/);
+    expect(rateToDisplayString(derived.value)).toBe('0.7407');
+  });
+
+  it('keeps a short rate short — no padding to four', () => {
+    // "1 GBP = 2 USD", not "2.0000".
+    expect(rateToDisplayString(toDecimal('2'))).toBe('2');
+    expect(rateToDisplayString(toDecimal('1.35'))).toBe('1.35');
+  });
+
+  it('does not round an exotic pair away to zero', () => {
+    // 1 JPY = 0.0000052 GBP is 0.0000 at four places, and a rate shown as zero
+    // is worse than a long one. Significant digits take over.
+    const tiny = rateToDisplayString(toDecimal('0.0000052'));
+    expect(tiny).not.toBe('0');
+    expect(Number(tiny)).toBeGreaterThan(0);
+  });
+
+  it('reconciles against the recorded amounts, which is the point', () => {
+    // Design's requirement: what is displayed must be what the figures agree
+    // with. $100 at the DISPLAYED 0.7407 is £74.07 — the amount recorded.
+    const derived = deriveRate(100, 74.074074);
+    if (!derived.ok) throw new Error('rate should derive');
+    const displayed = toDecimal(rateToDisplayString(derived.value));
+    expect(toDecimal('100').times(displayed).toDecimalPlaces(2).toString()).toBe('74.07');
   });
 });

--- a/src/utils/fx.ts
+++ b/src/utils/fx.ts
@@ -208,6 +208,39 @@ export function rateToStorageString(rate: DecimalInstance): string {
   return rate.toDecimalPlaces(RATE_DP, Decimal.ROUND_HALF_UP).toString();
 }
 
+/** Decimal places a rate is QUOTED in. The FX convention, and Claude Design's §9.1. */
+export const RATE_DISPLAY_DP = 4;
+
+/**
+ * A rate as it is SHOWN — four decimal places, trailing zeros gone.
+ *
+ * Distinct from {@link rateToStorageString}, and the split is the point.
+ * Storage keeps {@link RATE_DP} because a DERIVED rate is a division and
+ * division does not terminate: $100 arriving as £74.07 gives 0.7407407407…,
+ * and the stored figure has to reproduce the amounts it came from.
+ *
+ * Display has the opposite duty. Ten places presented a float artefact as
+ * precision the quote never had — in an app that measures its numbers
+ * carefully everywhere else — so the reader was shown ten digits of confidence
+ * about a number that is really "about 0.74".
+ *
+ * WHAT IS AUTHORITATIVE IS THE AMOUNTS, not the rate. Both legs record their
+ * own currency's figure to the penny, and the rate is provenance for how they
+ * relate. So rounding the DISPLAY cannot make the ledger disagree with itself:
+ * $100 x 0.7407 is £74.07, which is the figure recorded, which is Design's
+ * requirement that "the recorded figures reconcile against the displayed rate".
+ *
+ * The significant-digits fallback is for the pairs where four places is not a
+ * convention but a deletion — 1 JPY = 0.0000052 GBP rounds to 0.0000 at four,
+ * and a rate shown as zero is worse than a long one.
+ */
+export function rateToDisplayString(rate: DecimalInstance | string): string {
+  const value = typeof rate === 'string' ? new Decimal(rate) : rate;
+  const rounded = value.toDecimalPlaces(RATE_DISPLAY_DP, Decimal.ROUND_HALF_UP);
+  if (!rounded.isZero() || value.isZero()) return rounded.toString();
+  return value.toSignificantDigits(RATE_DISPLAY_DP, Decimal.ROUND_HALF_UP).toString();
+}
+
 /**
  * The `metadata.fx` object for one linked pair. Written to BOTH legs unchanged:
  * the rate is a property of the CONVERSION, not of either row, so two legs that
@@ -253,6 +286,5 @@ export function readFxRecord(metadata: unknown): FxRecord | null {
  * of exactly 2 reads "1 GBP = 2 USD" rather than "2.0000000000".
  */
 export function describeRate(rate: DecimalInstance | string, pair: FxPair): string {
-  const value = typeof rate === 'string' ? rate : rateToStorageString(rate);
-  return `1 ${pair.from} = ${value} ${pair.to}`;
+  return `1 ${pair.from} = ${rateToDisplayString(rate)} ${pair.to}`;
 }


### PR DESCRIPTION
Claude Design §9. The dialog read **`1 USD = 0.7407407407 GBP`** — a float artefact presented as precision, in an app that measures its numbers carefully everywhere else.

## The cause: one function doing two jobs

`rateToStorageString` keeps `RATE_DP` (ten) for a good reason — a **derived** rate is a division, and division does not terminate. $100 arriving as £74.07 gives 0.7407407407…, and the stored figure has to reproduce the amounts it came from.

Display was reusing it, so the reader saw ten digits of confidence about a number that is really *about 0.74*.

`rateToDisplayString` is the other job: four places, the FX convention, trailing zeros gone so "1 GBP = 2 USD" doesn't read "2.0000". Used by the provenance line, by `describeRate`, and by the **editable rate field** — that field is what you check against your statement, and a statement doesn't quote ten places either.

## Why rounding the display is safe

**What is authoritative is the amounts.** Both legs record their own currency's figure to the penny; the rate is provenance for how they relate. So rounding the display cannot make the ledger disagree with itself — which is Design's own requirement:

> $100 at the displayed `0.7407` is £74.07 — the figure recorded.

There's a test asserting exactly that reconciliation.

A significant-digits fallback covers pairs where four places is not a convention but a deletion: `1 JPY = 0.0000052 GBP` rounds to `0.0000` at four, and a rate shown as zero is worse than a long one.

## §9.2 — the provenance line

No longer repeats the rate. The field directly above prints it in an editable input, so repeating it in full spent a line on something already on screen, and pushed the two things that line **alone** can carry — who quoted it and when — to the end where they read as an afterthought.

## Guards

| mutation | result |
| --- | --- |
| display back to ten places | fails |
| remove the exotic-pair fallback | fails |

## §8 — not done, deliberately

It asked the report grid to fill by flow rather than fixed columns, on the evidence that Net Worth Over Time sat alone beside two cards. **That was Account Distribution hiding itself when empty**, fixed in #320.

The hole cannot recur: unpinning both right-hand reports collapses the grid to one full-width column, and unpinning net-worth still leaves Account Distribution there. What's left is a ragged bottom — and flattening would cost the deliberate "what you're worth / what moved" split to buy it.

## Verification

lint (zero warnings) · `typecheck:strict` · 6,090 unit tests · `desktop:verify` — green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)