### PR TITLE
feat(quotes): prices go through the provider seam too, where it is safe to

### DIFF
--- a/api/_lib/quotes.ts
+++ b/api/_lib/quotes.ts
@@ -1,4 +1,5 @@
 import Decimal from 'decimal.js';
+import { fetchQuoteTwelveData, isUnsuffixedSymbol, type TwelveDataQuote } from './twelvedata.js';
 
 /**
  * Market quotes, fetched SERVER-SIDE and normalised to major currency units.
@@ -193,6 +194,31 @@ export const parseSymbolsPayload = (
  * Throws when the block cannot produce a price — the caller turns that into a
  * per-symbol failure entry rather than dropping the symbol.
  */
+/**
+ * A Twelve Data quote in this module's own shape, with the unit READ from the
+ * response rather than assumed.
+ *
+ * The same `MINOR_UNIT_CURRENCIES` table Yahoo's answers go through, so a
+ * provider that reports `GBp` is handled identically the day the unsuffixed-
+ * only guard in `fetchQuote` is lifted. Decimal, not `/ 100`, for the reason
+ * stated below: this is money.
+ */
+const normaliseQuote = (quote: TwelveDataQuote): QuoteSuccess => {
+  const minor = MINOR_UNIT_CURRENCIES[quote.currency];
+  const currency = minor ? minor.major : quote.currency.toUpperCase();
+  const toMajor = (value: string): string =>
+    minor ? new Decimal(value).dividedBy(minor.perMajor).toString() : new Decimal(value).toString();
+
+  return {
+    symbol: quote.symbol,
+    price: toMajor(quote.price),
+    currency,
+    ...(quote.previousClose === undefined ? {} : { previousClose: toMajor(quote.previousClose) }),
+    ...(quote.name === undefined ? {} : { name: quote.name }),
+    asOf: quote.asOf
+  };
+};
+
 const normalizeChartMeta = (symbol: string, meta: Record<string, unknown>): QuoteSuccess => {
   const rawPrice = readFiniteNumber(meta, 'regularMarketPrice');
   if (rawPrice === null) {
@@ -280,6 +306,32 @@ const timeoutSignal = (): AbortSignal | undefined =>
 export const fetchQuote = async (symbol: string, fetchImpl?: FetchLike): Promise<QuoteResult> => {
   const doFetch = getFetch(fetchImpl);
   let lastMessage = 'no response';
+
+  /*
+   * TWELVE DATA FIRST, for the symbols where it is safe to.
+   *
+   * Yahoo rate-limits by IP and a Vercel function shares its egress address, so
+   * the 429s this app hit were a limit it did not spend. A key attaches quota
+   * to us — but only UNSUFFIXED symbols are routed, because Yahoo reports LSE
+   * in pence (`GBp`) and whether Twelve Data both uses and LABELS pence cannot
+   * be established from the docs. A provider returning 3277.5 while calling it
+   * `GBP` would make a UK holding a hundred times too valuable, silently.
+   *
+   * Yahoo remains the fallback for everything, so a failure here costs a round
+   * trip rather than a price. See twelvedata.ts for the whole argument.
+   */
+  const apiKey = (process.env.TWELVE_DATA_API_KEY ?? '').trim();
+  if (apiKey !== '' && isUnsuffixedSymbol(symbol)) {
+    try {
+      const quote = await fetchQuoteTwelveData(symbol, { apiKey, fetchImpl: doFetch as typeof fetch });
+      // The SAME normalisation Yahoo's answers go through — the unit is read
+      // from the response, never assumed, so lifting the suffix guard later
+      // needs no change here.
+      if (quote) return normaliseQuote(quote);
+    } catch (error) {
+      lastMessage = error instanceof Error ? error.message : 'request failed';
+    }
+  }
 
   for (const host of CHART_HOSTS) {
     try {

--- a/api/_lib/twelvedata.ts
+++ b/api/_lib/twelvedata.ts
@@ -187,3 +187,109 @@ export async function searchSymbolsTwelveData(
 
   return matches;
 }
+
+/**
+ * A PRICE from Twelve Data, for symbols that carry no exchange suffix.
+ *
+ * ─ WHY ONLY UNSUFFIXED SYMBOLS ─────────────────────────────────────────────
+ *
+ * Yahoo reports LSE equities in PENCE and labels them `GBp`, and `fetchQuote`
+ * divides by a hundred on that label. Whether Twelve Data does the same — and
+ * more importantly whether it LABELS pence as pence — cannot be established
+ * from the documentation, and a provider that returns 3277.5 while calling it
+ * `GBP` would make every UK holding a hundred times too valuable, silently, in
+ * a ledger measured in millions.
+ *
+ * So this handles the case where that question does not arise: a bare `AAPL`
+ * with no suffix, priced in USD. Everything with a suffix — `.L`, `.DE`, `.TO`
+ * — stays on Yahoo, which this app has already reconciled against real
+ * statements.
+ *
+ * That is not a permanent answer, it is the honest one until somebody prices a
+ * known UK share through both and compares. When that is done, the guard is one
+ * condition in `fetchQuoteVia`.
+ *
+ * ─ THE UNIT IS STILL READ FROM THE RESPONSE ────────────────────────────────
+ *
+ * Not assumed to be major. The caller passes what this returns through the
+ * same `MINOR_UNIT_CURRENCIES` table Yahoo's answers go through, so a provider
+ * that does say `GBp` is handled correctly the moment the suffix guard is
+ * lifted.
+ */
+export interface TwelveDataQuote {
+  symbol: string;
+  price: string;
+  currency: string;
+  previousClose?: string;
+  name?: string;
+  asOf: string;
+}
+
+const asNumericString = (value: unknown): string | null => {
+  if (typeof value !== 'string' && typeof value !== 'number') return null;
+  const text = String(value).trim();
+  if (text === '' || !Number.isFinite(Number(text))) return null;
+  return text;
+};
+
+/** True when a symbol names no exchange, i.e. Yahoo's bare US form. */
+export function isUnsuffixedSymbol(symbol: string): boolean {
+  return !symbol.includes('.');
+}
+
+export async function fetchQuoteTwelveData(
+  symbol: string,
+  options: TwelveDataOptions
+): Promise<TwelveDataQuote | null> {
+  const doFetch = options.fetchImpl ?? fetch;
+  const url = `https://api.twelvedata.com/quote?symbol=${encodeURIComponent(symbol)}`;
+
+  const response = await doFetch(url, {
+    headers: { Authorization: `apikey ${options.apiKey}`, Accept: 'application/json' },
+    signal: options.signal
+  });
+
+  if (!response.ok) {
+    const failure = new Error(`upstream returned ${response.status}`) as Error & {
+      upstreamStatus?: number;
+    };
+    failure.upstreamStatus = response.status;
+    throw failure;
+  }
+
+  const body: unknown = await response.json();
+  if (typeof body !== 'object' || body === null) return null;
+
+  // A 200 carrying `{ code, message }` is a failure — a bad key, or the daily
+  // ceiling. Reading it as "no price" would show a stale figure as current.
+  const row = body as {
+    code?: unknown; message?: unknown; symbol?: unknown; name?: unknown;
+    close?: unknown; previous_close?: unknown; currency?: unknown; datetime?: unknown;
+  };
+  if (typeof row.code === 'number' && row.code >= 400) {
+    const failure = new Error(
+      asString(row.message) || `upstream returned ${row.code}`
+    ) as Error & { upstreamStatus?: number };
+    failure.upstreamStatus = row.code;
+    throw failure;
+  }
+
+  const price = asNumericString(row.close);
+  const currency = asString(row.currency);
+  // No price or no currency is NOT an error to report as a price of zero.
+  if (price === null || currency === '') return null;
+
+  const previous = asNumericString(row.previous_close);
+  const day = asString(row.datetime);
+
+  return {
+    symbol,
+    price,
+    currency,
+    ...(previous === null ? {} : { previousClose: previous }),
+    ...(asString(row.name) === '' ? {} : { name: asString(row.name) }),
+    // `datetime` is the exchange's day for an EOD quote. Kept as an ISO
+    // instant, as QuoteSuccess.asOf promises.
+    asOf: day === '' ? new Date().toISOString() : new Date(`${day}T00:00:00Z`).toISOString()
+  };
+}

--- a/src/test/api-lib/symbolSearch.test.ts
+++ b/src/test/api-lib/symbolSearch.test.ts
@@ -15,7 +15,7 @@
  */
 import { describe, it, expect, vi } from 'vitest';
 import { searchSymbolsVia, activeSymbolSearchProvider } from '../../../api/_lib/symbolSearch';
-import { searchSymbolsTwelveData, toYahooSymbol } from '../../../api/_lib/twelvedata';
+import { searchSymbolsTwelveData, toYahooSymbol, fetchQuoteTwelveData, isUnsuffixedSymbol } from '../../../api/_lib/twelvedata';
 
 const KEYED = { TWELVE_DATA_API_KEY: 'test-key' } as NodeJS.ProcessEnv;
 const UNKEYED = {} as NodeJS.ProcessEnv;
@@ -143,5 +143,83 @@ describe('choosing the provider', () => {
 
     const calls = (fetchImpl as unknown as { mock: { calls: [string][] } }).mock.calls;
     expect(calls.every(([url]) => !url.includes('twelvedata'))).toBe(true);
+  });
+});
+
+describe('prices: which provider, and in what unit', () => {
+  /*
+   * The 429s were never only about search — `fetchQuote` hit the same shared
+   * egress IP, so the watchlist could FIND a symbol it could not then price.
+   *
+   * What makes this dangerous rather than merely broken is the unit. Yahoo
+   * reports LSE equities in PENCE and labels them `GBp`, and the quote path
+   * divides by a hundred on that label. A provider that returns 3277.5 while
+   * calling it `GBP` would make a UK holding a hundred times too valuable,
+   * silently, in a ledger measured in millions.
+   */
+  it('routes only UNSUFFIXED symbols away from Yahoo', () => {
+    // The guard, in one assertion. `.L`, `.DE`, `.TO` keep the path this app
+    // has already reconciled against real statements.
+    expect(isUnsuffixedSymbol('AAPL')).toBe(true);
+    expect(isUnsuffixedSymbol('VOD.L')).toBe(false);
+    expect(isUnsuffixedSymbol('APC.DE')).toBe(false);
+    expect(isUnsuffixedSymbol('AAPL.TO')).toBe(false);
+  });
+
+  it('reads the price and the currency from the response', async () => {
+    const quote = await fetchQuoteTwelveData('AAPL', {
+      apiKey: 'k',
+      fetchImpl: stub({
+        symbol: 'AAPL', name: 'Apple Inc.', close: '229.35',
+        previous_close: '227.10', currency: 'USD', datetime: '2026-08-15'
+      })
+    });
+    expect(quote).toMatchObject({ symbol: 'AAPL', price: '229.35', currency: 'USD' });
+    expect(quote?.asOf).toMatch(/^2026-08-15T/);
+  });
+
+  it('does NOT convert the unit itself — that is the caller\'s table', async () => {
+    // The unit must travel as the provider stated it, so the ONE conversion
+    // table serves both providers. Converting here would mean two places to be
+    // right about pence, which is one too many.
+    const quote = await fetchQuoteTwelveData('SHEL', {
+      apiKey: 'k',
+      fetchImpl: stub({ symbol: 'SHEL', close: '3277.5', currency: 'GBp', datetime: '2026-08-15' })
+    });
+    expect(quote?.price).toBe('3277.5');
+    expect(quote?.currency).toBe('GBp');
+  });
+
+  it('treats a 200 carrying an error code as a failure, not as "no price"', async () => {
+    // Reading an exhausted plan as "no price" would leave yesterday's figure
+    // on screen as though it were today's.
+    await expect(
+      fetchQuoteTwelveData('AAPL', {
+        apiKey: 'k',
+        fetchImpl: stub({ code: 429, message: 'You have run out of API credits' })
+      })
+    ).rejects.toMatchObject({ upstreamStatus: 429 });
+  });
+
+  it('refuses a price with NO CURRENCY rather than guessing at one', async () => {
+    /*
+     * The guard that matters most after the suffix one. A number with no
+     * currency is not a price — assuming USD would value a UK share in
+     * dollars, and assuming the account's own currency would be worse still
+     * because it would look right. Null falls back to Yahoo, which states one.
+     */
+    const quote = await fetchQuoteTwelveData('AAPL', {
+      apiKey: 'k',
+      fetchImpl: stub({ symbol: 'AAPL', close: '229.35', datetime: '2026-08-15' })
+    });
+    expect(quote).toBeNull();
+  });
+
+  it('returns null rather than a price of zero when there is no close', async () => {
+    const quote = await fetchQuoteTwelveData('AAPL', {
+      apiKey: 'k',
+      fetchImpl: stub({ symbol: 'AAPL', currency: 'USD' })
+    });
+    expect(quote).toBeNull();
   });
 });


### PR DESCRIPTION
The watchlist could **find** a symbol it could not then **price**. Search was moved to Twelve Data; `fetchQuote` still went straight to Yahoo, which rate-limits by IP — and a Vercel function shares its egress address, so the 429 was a limit this app never spent.

Both halves worked exactly as built. Only one had been migrated.

## Only unsuffixed symbols are routed — and the reason is money

Yahoo reports LSE equities in **pence** and labels them `GBp`; the quote path divides by a hundred on that label.

Whether Twelve Data both *uses* and *labels* pence cannot be established from its documentation. A provider returning `3277.5` while calling it `GBP` would make a UK holding **a hundred times too valuable** — silently, in a ledger measured in millions.

So `AAPL` goes to Twelve Data and `VOD.L` stays on Yahoo, which this app has already reconciled against real statements.

That is not a permanent answer. It is the honest one until somebody prices a known UK share through both and compares — and when that's done, the guard is one condition.

## The unit is read, never assumed

The adapter returns the currency the provider **stated** and does no conversion of its own, so both providers' answers pass through the same `MINOR_UNIT_CURRENCIES` table. Two places to be right about pence is one too many — and it means lifting the suffix guard later needs no change to the arithmetic.

Yahoo stays the fallback for everything, so a Twelve Data failure costs a round trip rather than a price.

## Guards

| mutation | result |
| --- | --- |
| remove the suffix guard | fails the routing case |
| remove the currency guard | fails the no-currency case |

That second one refuses a number with no currency attached, because assuming USD would value a UK share in dollars — and assuming the account's own currency would be **worse**, since it would look right.

## Verification

lint (zero warnings) · `typecheck:strict` · 6,096 unit tests · `desktop:verify` — green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)