### PR TITLE
fix(accounts): five fixed action slots on their own line, on phones

### DIFF
--- a/src/pages/Accounts.tsx
+++ b/src/pages/Accounts.tsx
@@ -1654,6 +1654,35 @@ export default function Accounts() {
                                 to={reviewHref(account.id)}
                                 openLabel={`Review new transactions in ${account.name}`}
                               />
+                              {/* ─ FIVE FIXED SLOTS, ON THEIR OWN LINE ─────
+                                  MEASURED at 375px: the four stat cells and
+                                  the five action slots were siblings of one
+                                  `flex flex-wrap`, so the wrap point moved with
+                                  the BUTTON COUNT — a three-button account put
+                                  settings at (302, 0) and reconcile at
+                                  (242, 48), a four-button one shifted them all.
+
+                                  Five 44px slots is 220px and the stats need
+                                  ~254px, so the two cannot share a line at this
+                                  width. `w-full` gives the actions their own,
+                                  which is what makes the slots FIXED: every
+                                  account draws the same five columns whether it
+                                  has three buttons or four, and an absent one
+                                  leaves its column empty rather than pulling
+                                  the others along.
+
+                                  It also settles the labels riding high. Flex
+                                  centres within each LINE — the stats used to
+                                  share theirs with whichever button fitted, so
+                                  39px cells sat at the top of a 92px row. On a
+                                  line of their own there is nothing to be high
+                                  against.
+
+                                  `lg:contents` leaves the desktop grid exactly
+                                  as it was: the wrapper dissolves and the five
+                                  slots become direct children of the nine-column
+                                  grid again. */}
+                              <div className="grid w-full grid-cols-5 justify-items-end gap-1 lg:contents">
                               <AccountRowActionSlot>
                                 {account.type === 'investment' && account.holdings && account.holdings.length > 0 && (
                                 <button
@@ -1742,6 +1771,7 @@ export default function Accounts() {
                                   </span>
                                 </div>
                               </AccountRowActionSlot>
+                              </div>
                             </AccountRowColumns>
                       </div>
                     </div>
@@ -1837,7 +1867,14 @@ export default function Accounts() {
                             />
                             {/* Portfolio, feed and settings: not this row's to
                                 offer. The slots stay so the Reconcile button
-                                lands under its parent's. */}
+                                lands under its parent's — and the WRAPPER stays
+                                too, for the same reason one line up: below `lg`
+                                the parent's five actions are their own
+                                five-column line, so a cash row that let them
+                                flex-wrap instead would put its chevron and its
+                                reconcile somewhere else entirely. Identical
+                                structure is the whole guarantee. */}
+                            <div className="grid w-full grid-cols-5 justify-items-end gap-1 lg:contents">
                             <AccountRowEmptyCell />
                             <AccountRowEmptyCell />
                             <AccountRowEmptyCell />
@@ -1851,6 +1888,7 @@ export default function Accounts() {
                                 <ChevronRightIcon size={16} className="text-gray-400 flex-shrink-0" />
                               </span>
                             </AccountRowActionSlot>
+                            </div>
                           </AccountRowColumns>
                         </div>
                       );

--- a/src/pages/__tests__/Accounts.selection.test.tsx
+++ b/src/pages/__tests__/Accounts.selection.test.tsx
@@ -693,8 +693,25 @@ describe('Accounts list — both rows read down the same columns', () => {
   it('gives both rows the same nine slots, in the same order', async () => {
     await openList();
 
-    const parentSlots = Array.from(columnsOf(row('Synthetic Portfolio')).children);
-    const cashSlots = Array.from(columnsOf(row('Cash')).children);
+    /*
+     * FLATTENED THROUGH THE ACTION WRAPPER. The nine slots are still nine and
+     * still in this order; the last five now sit inside a `lg:contents`
+     * wrapper, which below `lg` makes them a fixed five-column line and above
+     * it dissolves so they are direct children of the nine-column grid exactly
+     * as before.
+     *
+     * That wrapper is why the parent and the cash row must BOTH have it —
+     * measured at 375px, the actions used to flex-wrap and their positions
+     * moved with the button count. What this test guards is unchanged: the two
+     * rows read down the same columns in the same order.
+     */
+    const slotsOf = (node: HTMLElement): Element[] =>
+      Array.from(node.children).flatMap(child =>
+        child.matches('[class*="lg:contents"]') ? Array.from(child.children) : [child]
+      );
+
+    const parentSlots = slotsOf(columnsOf(row('Synthetic Portfolio')));
+    const cashSlots = slotsOf(columnsOf(row('Cash')));
 
     expect(parentSlots).toHaveLength(9);
     expect(cashSlots).toHaveLength(9);


### PR DESCRIPTION
The owner's items 3 and 4 — and they were **one cause**.

## What was measured, at 375px

The four stat cells and the five action slots were siblings of a single `flex flex-wrap`, so the wrap point moved with the **button count**:

| | 3-button account | 4-button account |
|---|---|---|
| settings | (302, 0) | shifted |
| reconcile | (242, 48) | shifted |

The same wrap explained the labels riding high. Flex centres within each **line**, and the stats shared theirs with whichever button happened to fit — 39px cells at the top of a 92px row, with 50px of dead space beneath.

## Five slots, on their own line

Five 44px slots is 220px and the stats need ~254px, so the two **cannot** share a line at this width. `w-full` gives the actions their own — and that is what makes the slots fixed: every account draws the same five columns whether it has three buttons or four, and an absent button leaves its column empty rather than pulling the others along.

**Measured after, across four accounts including one with an extra button:**

| | before | after |
|---|---|---|
| settings | (302, 0) | **x174 on every row** |
| reconcile | (242, 48) | **x238 on every row** |
| close | (302, 48) | **x302 on every row** |
| row height | 92px | **87px** |
| page overflow | — | **0** |

The investment account's fourth button sits at x45 and **moved none of the others**.

## Desktop untouched

`lg:contents` dissolves the wrapper so the five slots become direct children of the nine-column grid again. Verified at 1280px: still `display: grid`, still **9 columns**, buttons on one row, 48px tall, zero overflow.

## Both rows get the wrapper

The nested cash row must have identical structure or its reconcile button stops landing under its parent's below `lg` — which is the guarantee `Accounts.selection.test.tsx` exists to hold. That test now flattens through the wrapper rather than counting direct children, so it still asserts nine slots in one order on both rows.

## An earlier attempt made it worse

A 2-column grid took the row to **139px** — five slots in two columns is three rows, because the two conditionally-empty slots still occupy cells. Reverted, measured, done properly. Happy to switch to four slots if you prefer the look.

## Verification

lint (zero warnings) · `typecheck:strict` · 6,096 unit tests · measured at 375px and 1280px.

🤖 Generated with [Claude Code](https://claude.com/claude-code)