### PR TITLE
fix(accounts): the sort pills stop being crushed by the actions toggle

### DIFF
--- a/src/pages/Accounts.tsx
+++ b/src/pages/Accounts.tsx
@@ -2575,14 +2575,26 @@ export default function Accounts() {
             </button>
           </div>
         </div>
-        <div className="w-full sm:w-auto flex items-center gap-2">
+        {/* `flex-wrap` and `shrink-0` on the pill group (owner, 16 August).
+            Adding "Hide account buttons" to this row squeezed the pills to
+            their 44px touch minimum — measured at 375px: three pills at
+            x107/x129/x152, overlapping, text wrapped to three lines. A flex
+            child gives way before it wraps, so the toggle has to be ALLOWED
+            to drop to its own line and the pills to refuse to shrink. */}
+        <div className="w-full sm:w-auto flex flex-wrap items-center gap-2">
           <span className="text-sm font-semibold text-gray-600 dark:text-gray-300 w-20 sm:w-auto shrink-0">Sort:</span>
-          <div className="grid grid-flow-col auto-cols-fr flex-1 sm:flex-none sm:inline-flex rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 p-0.5">
+          {/* `grow shrink-0`, NOT `flex-1`. flex-1 is basis 0% — the group
+              starts from nothing and takes only what is left over, and with
+              the toggle on the row that leftover crushed all three pills to
+              their 44px touch minimum, overlapping. Basis auto starts from the
+              labels' own width; shrink-0 holds it; the toggle then WRAPS to
+              its own line on a phone instead of squeezing this one. */}
+          <div className="grid grid-flow-col auto-cols-fr grow shrink-0 sm:flex-none sm:inline-flex rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 p-0.5">
             <button
               onClick={() => handleSortChange('default')}
-              className={`px-3 py-1.5 text-sm font-medium rounded-md transition-colors ${
+              className={`px-3 py-1.5 text-sm font-medium rounded-md whitespace-nowrap transition-colors ${
                 sortMode === 'default'
-                  ? 'bg-[#1a2332] dark:bg-blue-600 text-white'
+                  ? 'bg-[#1a2332] dark:bg-[#2d3a4d] text-white'
                   : 'text-gray-600 dark:text-gray-400 hover:text-gray-900'
               }`}
             >
@@ -2590,9 +2602,9 @@ export default function Accounts() {
             </button>
             <button
               onClick={() => handleSortChange('name')}
-              className={`px-3 py-1.5 text-sm font-medium rounded-md transition-colors ${
+              className={`px-3 py-1.5 text-sm font-medium rounded-md whitespace-nowrap transition-colors ${
                 sortMode === 'name'
-                  ? 'bg-[#1a2332] dark:bg-blue-600 text-white'
+                  ? 'bg-[#1a2332] dark:bg-[#2d3a4d] text-white'
                   : 'text-gray-600 dark:text-gray-400 hover:text-gray-900'
               }`}
             >
@@ -2605,9 +2617,9 @@ export default function Accounts() {
                 : sortMode === 'balance-asc'
                   ? 'Sorted lowest value first — click for highest first'
                   : 'Sort by account value'}
-              className={`px-3 py-1.5 text-sm font-medium rounded-md transition-colors ${
+              className={`px-3 py-1.5 text-sm font-medium rounded-md whitespace-nowrap transition-colors ${
                 sortMode === 'balance-desc' || sortMode === 'balance-asc'
-                  ? 'bg-[#1a2332] dark:bg-blue-600 text-white'
+                  ? 'bg-[#1a2332] dark:bg-[#2d3a4d] text-white'
                   : 'text-gray-600 dark:text-gray-400 hover:text-gray-900'
               }`}
             >

--- a/src/pages/__tests__/Accounts.test.tsx
+++ b/src/pages/__tests__/Accounts.test.tsx
@@ -287,7 +287,12 @@ describe('Accounts page — the toolbar reads as three labelled groups', () => {
     // Side by side, the gap BEFORE a label (between groups) has to beat the gap
     // after it (label to controls). gap-x-8 = 32px against the groups' own
     // gap-2 = 8px.
-    const toolbar = sort.closest('.flex-wrap');
+    // `closest('.gap-x-8')`, not `.flex-wrap` — the Sort group itself became
+    // flex-wrap on 16 August (so the phone-only actions toggle drops to its
+    // own line instead of crushing the pills), which made the old selector
+    // find the GROUP and fail on the toolbar's class. The property under test
+    // is the toolbar's 32px inter-group gap, so select by that.
+    const toolbar = sort.closest('[class*="gap-x-8"]');
     if (!(toolbar instanceof HTMLElement)) throw new Error('no toolbar row');
     expect(toolbar.className).toContain('gap-x-8');
     const group = sort.parentElement;


### PR DESCRIPTION
**My own toggle did this, one PR ago.** Measured at 375px: adding "Hide account buttons" to the Sort row squeezed all three pills to their 44px touch minimum — x107/x129/x152, physically overlapping, labels wrapped to three lines.

## Three causes, each one line

- **`flex-1` on the pill group is basis 0%** — it starts from nothing and takes only the leftover, and the toggle ate the leftover. `grow shrink-0` starts from the labels' own width and refuses to give it up.
- **The row couldn't wrap**, so the toggle crushed rather than dropped. `flex-wrap`: on a phone it now takes its own line.
- **The pill labels could wrap mid-word.** `whitespace-nowrap`.

## And one the crush exposed

The selected pill wore `dark:bg-blue-600` — the stock blue Design's §7 flagged, fixed on `PeriodPicker` two days ago and **missed here, a third copy of the same choice**. Now `#2d3a4d`, the navy the app answers this question with.

## Measured after

| | 375px | 1280px |
|---|---|---|
| pills | 112px each at x19/x131/x244, one line, no overlap | 32px, one row |
| toggle | its own line | absent |
| overflow | 0 | 0 |

The toolbar-grouping test selected the toolbar with `closest('.flex-wrap')`, which now finds the Sort group first — it selects by the property it actually asserts (`gap-x-8`) instead.

## Verification

lint (zero warnings) · `typecheck:strict` · 6,096 unit tests · measured both widths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)