### PR TITLE
feat(investments): the owner's seven — tabs that survive refresh, an itemised holdings list, and three small honesties

### DIFF
--- a/src/components/TransferRepointDialog.tsx
+++ b/src/components/TransferRepointDialog.tsx
@@ -102,13 +102,20 @@ export default function TransferRepointDialog({
           came from a bank into a different account would put both registers out by its amount.
         </p>
 
+        {/* `block` on each option, and it is load-bearing: `index.css` makes
+            every button `inline-flex`, which turned the two `block` spans
+            inside — the option's name and its explanation — into flex ITEMS
+            side by side. The name wrapped down a narrow column against the
+            explanation and the owner read it as "all squashed". The class
+            (0,1,0) beats the element rule (0,0,1), and the spans stack the
+            way they were written to. */}
         <div className="space-y-2">
           <button
             ref={firstButtonRef}
             type="button"
             onClick={() => onChoose('release')}
             disabled={busy}
-            className="w-full text-left p-3 rounded-lg border border-gray-200 dark:border-gray-700 hover:border-blue-400 dark:hover:border-blue-500 disabled:opacity-50 disabled:cursor-not-allowed"
+            className="block w-full text-left p-3 rounded-lg border border-gray-200 dark:border-gray-700 hover:border-blue-400 dark:hover:border-blue-500 disabled:opacity-50 disabled:cursor-not-allowed"
           >
             <span className="block font-medium text-gray-900 dark:text-white">
               Leave it where it is
@@ -123,7 +130,7 @@ export default function TransferRepointDialog({
             type="button"
             onClick={() => onChoose('delete')}
             disabled={busy}
-            className="w-full text-left p-3 rounded-lg border border-gray-200 dark:border-gray-700 hover:border-red-400 dark:hover:border-red-500 disabled:opacity-50 disabled:cursor-not-allowed"
+            className="block w-full text-left p-3 rounded-lg border border-gray-200 dark:border-gray-700 hover:border-red-400 dark:hover:border-red-500 disabled:opacity-50 disabled:cursor-not-allowed"
           >
             <span className="block font-medium text-red-700 dark:text-red-400">
               Delete it
@@ -139,7 +146,7 @@ export default function TransferRepointDialog({
             type="button"
             onClick={() => onChoose('move')}
             disabled={busy}
-            className="w-full text-left p-3 rounded-lg border border-gray-200 dark:border-gray-700 hover:border-gray-400 dark:hover:border-gray-500 disabled:opacity-50 disabled:cursor-not-allowed"
+            className="block w-full text-left p-3 rounded-lg border border-gray-200 dark:border-gray-700 hover:border-gray-400 dark:hover:border-gray-500 disabled:opacity-50 disabled:cursor-not-allowed"
           >
             <span className="block font-medium text-gray-900 dark:text-white">
               Move it to {targetAccountName}

--- a/src/components/common/DatePicker.tsx
+++ b/src/components/common/DatePicker.tsx
@@ -476,7 +476,12 @@ export default function DatePicker({
                   ? () => setViewYear(y => y - 1)
                   : () => setViewYear(y => y - YEAR_PAGE)
               }
-              className="p-1 hover:bg-gray-100 dark:hover:bg-gray-700 rounded-lg transition-colors"
+              /* The arrows set NO colour of their own, so they inherited — and
+                 in a dark modal the inherited ink was near-invisible (owner,
+                 16 August: "I can hardly read the left and right arrow").
+                 Named explicitly, both modes, like the month label between
+                 them. */
+              className="p-1 text-gray-600 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700 rounded-lg transition-colors"
               aria-label={view === 'days' ? 'Previous month' : view === 'months' ? 'Previous year' : 'Previous years'}
             >
               <ChevronLeftIcon size={18} />
@@ -504,7 +509,7 @@ export default function DatePicker({
                   ? () => setViewYear(y => y + 1)
                   : () => setViewYear(y => y + YEAR_PAGE)
               }
-              className="p-1 hover:bg-gray-100 dark:hover:bg-gray-700 rounded-lg transition-colors"
+              className="p-1 text-gray-600 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700 rounded-lg transition-colors"
               aria-label={view === 'days' ? 'Next month' : view === 'months' ? 'Next year' : 'Next years'}
             >
               <ChevronRightIcon size={18} />

--- a/src/pages/Investments.tsx
+++ b/src/pages/Investments.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useSearchParams } from 'react-router-dom';
 import { useApp } from '../contexts/AppContextSupabase';
 import { TrendingUpIcon, TrendingDownIcon, BarChart3Icon, AlertCircleIcon, LineChartIcon, EyeIcon, PlusIcon } from '../components/icons';
 import AddInvestmentModal from '../components/AddInvestmentModal';
@@ -87,7 +88,32 @@ export default function Investments() {
   const [customStart, setCustomStart] = useState('');
   const [customEnd, setCustomEnd] = useState('');
   const [showAddInvestmentModal, setShowAddInvestmentModal] = useState(false);
-  const [activeTab, setActiveTab] = useState<'overview' | 'watchlist' | 'portfolio' | 'manage'>('overview');
+  /**
+   * THE TAB LIVES IN THE URL (owner, 16 August: "when I refresh the page if I
+   * am on 'Watchlist' … it refreshes back to the investment page").
+   *
+   * A query parameter rather than component state, because a refresh rebuilds
+   * state from nothing and the URL is the one thing a refresh keeps. It also
+   * makes a tab shareable and back-button-friendly for free. `replace`, not
+   * push: switching tabs is not a navigation the back button should replay
+   * four times.
+   */
+  const [searchParams, setSearchParams] = useSearchParams();
+  const tabParam = searchParams.get('tab');
+  const activeTab: 'overview' | 'watchlist' | 'portfolio' | 'manage' =
+    tabParam === 'watchlist' || tabParam === 'portfolio' || tabParam === 'manage'
+      ? tabParam
+      : 'overview';
+  const setActiveTab = useCallback((tab: 'overview' | 'watchlist' | 'portfolio' | 'manage'): void => {
+    setSearchParams(prev => {
+      const next = new URLSearchParams(prev);
+      // Overview is the default, so it carries no parameter — a clean URL for
+      // the common case, and 'tab=overview' never has to be kept in step.
+      if (tab === 'overview') next.delete('tab');
+      else next.set('tab', tab);
+      return next;
+    }, { replace: true });
+  }, [setSearchParams]);
   const [managingAccountId, setManagingAccountId] = useState<string | null>(null);
 
   // ── Holdings: the MARKET view's data, from public.investments ─────────────
@@ -379,6 +405,43 @@ export default function Investments() {
   // `holdings` is now the market-side data from public.investments, and the two
   // must never be confused for each other on this page.
   const portfolioLines = summary.lines;
+
+  /**
+   * HOW THE HOLDINGS LIST IS ARRANGED — the Accounts page's controls, brought
+   * to the one other long list in the app (owner, 16 August). Persisted for
+   * the same reason the actions toggle is: an arrangement chosen once should
+   * survive a refresh.
+   */
+  const [holdingsSort, setHoldingsSort] = useLocalStorage<'default' | 'name' | 'value'>(
+    'wt_holdings_sort',
+    'default'
+  );
+  const [groupHoldingsByInstitution, setGroupHoldingsByInstitution] = useLocalStorage<boolean>(
+    'wt_holdings_group',
+    false
+  );
+
+  const sortedHoldingLines = useMemo(() => {
+    if (holdingsSort === 'default') return portfolioLines;
+    const lines = [...portfolioLines];
+    if (holdingsSort === 'name') lines.sort((a, b) => a.name.localeCompare(b.name));
+    else lines.sort((a, b) => b.value.comparedTo(a.value));
+    return lines;
+  }, [portfolioLines, holdingsSort]);
+
+  /** institution → its lines, in the sorted order; null when not grouping. */
+  const groupedHoldingLines = useMemo(() => {
+    if (!groupHoldingsByInstitution) return null;
+    const map = new Map<string, typeof portfolioLines>();
+    for (const line of sortedHoldingLines) {
+      const key = line.institution || 'No institution';
+      const list = map.get(key);
+      if (list) list.push(line);
+      else map.set(key, [line]);
+    }
+    return [...map.entries()];
+  }, [groupHoldingsByInstitution, sortedHoldingLines]);
+
   /**
    * WHAT the money is in, as opposed to WHERE it is kept.
    *
@@ -792,100 +855,158 @@ export default function Investments() {
         <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
         {/* Holdings List */}
         <div className="bg-white dark:bg-gray-800 rounded-lg border border-line dark:border-gray-700 p-6">
-          <h2 className="text-card font-semibold mb-4 text-theme-heading dark:text-white">Holdings</h2>
+          <h2 className="text-card font-semibold mb-2 text-theme-heading dark:text-white">Holdings</h2>
+          {/* The Accounts page's controls, on the app's other long list
+              (owner, 16 August). Same pills, same navy, same persistence. */}
+          {portfolioLines.length > 1 && (
+            <div className="flex flex-wrap items-center gap-2 mb-4">
+              <div className="inline-flex rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 p-0.5">
+                {([['default', 'Default'], ['name', 'Name A–Z'], ['value', 'Value ↓']] as const).map(([mode, label]) => (
+                  <button
+                    key={mode}
+                    type="button"
+                    onClick={() => setHoldingsSort(mode)}
+                    aria-pressed={holdingsSort === mode}
+                    className={`px-3 py-1.5 text-sm font-medium rounded-md whitespace-nowrap transition-colors ${
+                      holdingsSort === mode
+                        ? 'bg-[#1a2332] dark:bg-[#2d3a4d] text-white'
+                        : 'text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-200'
+                    }`}
+                  >
+                    {label}
+                  </button>
+                ))}
+              </div>
+              <button
+                type="button"
+                onClick={() => setGroupHoldingsByInstitution(!groupHoldingsByInstitution)}
+                aria-pressed={groupHoldingsByInstitution}
+                className={`px-3 py-1.5 text-sm font-medium rounded-md whitespace-nowrap transition-colors border ${
+                  groupHoldingsByInstitution
+                    ? 'bg-[#1a2332] dark:bg-[#2d3a4d] text-white border-transparent'
+                    : 'text-gray-600 dark:text-gray-400 border-gray-200 dark:border-gray-700 hover:text-gray-900 dark:hover:text-gray-200'
+                }`}
+              >
+                Group by institution
+              </button>
+            </div>
+          )}
           {portfolioLines.length === 0 ? (
             <p className="text-gray-500 dark:text-gray-400 text-center py-8">
               No holdings to display
             </p>
           ) : (
             <div className="space-y-4">
-              {portfolioLines.map((line, index) => {
-                const account = accountsById.get(line.accountId);
-                if (!account) return null;
+              {/* ─ ONE ROW, RESTRUCTURED (owner, 16 August) ──────────────────
+                  The institution line under each name is gone, by the rule
+                  that removed it from the Accounts list: when the list is
+                  grouped by institution the heading says it, and when it is
+                  not, it was a second line of chrome on every row.
 
-                return (
-                  <div
-                    key={account.id}
-                    className="border-b dark:border-gray-700 pb-4 last:border-0 -mx-2 px-2 py-2 rounded"
-                  >
-                    <div className="flex justify-between items-start mb-2">
-                      <div className="flex items-center gap-2">
-                        <div
-                          className="w-3 h-3 rounded-full flex-shrink-0"
-                          style={{ backgroundColor: categoricalColor(ramp, index) }}
-                        />
-                        <div>
-                          <h3 className="font-medium text-gray-900 dark:text-white">
-                            {line.name}
-                          </h3>
-                          <p className="text-body text-gray-500 dark:text-gray-400">
-                            {line.institution || 'N/A'}
-                          </p>
-                        </div>
-                      </div>
-                      <div className="text-right">
-                        <p className="font-semibold text-gray-900 dark:text-white">{formatCurrency(line.value)}</p>
-                      </div>
-                    </div>
-                    {/* The paired cash, inside the line rather than beside it:
-                        the row's value already contains it, so this says what
-                        part of the total is not invested. */}
-                    {line.cash.map(cash => (
-                      <p
-                        key={cash.accountId}
-                        className="ml-5 mb-2 flex justify-between text-dense text-gray-500 dark:text-gray-400"
-                      >
-                        <span>{cash.label}</span>
-                        <span className="tabular-nums">{formatCurrency(cash.value)}</span>
-                      </p>
-                    ))}
-                    {/* ─ WHAT IS SECURED AGAINST THIS HOLDING ────────────────
-                        Under the cash, because it answers the same shape of
-                        question about the same line: what else is true of this
-                        account.
+                  Each row now accounts for its own total: "Investments" is
+                  the total less the paired cash, "Cash" is the paired cash,
+                  and the two sum to the figure on the right — a check the
+                  reader can do by eye, which is the owner's spec verbatim.
 
-                        It reads differently from the cash above it and must,
-                        because the cash IS in the figure and this is not.
-                        Hence "secured against this", and a magnitude rather
-                        than a signed balance — a debt of £750,000 held against
-                        a holding is not "minus £750,000" of it.
+                  The secured liabilities move BELOW the bar under their own
+                  small heading, because they are a different kind of fact:
+                  the two lines above are parts of the total, and these are
+                  not in it at all.
 
-                        Listed here rather than in the toggle's label, on the
-                        owner's ruling: the label had grown into a paragraph
-                        naming every liability across the whole portfolio,
-                        which is unreadable and says nothing about WHICH
-                        holding each one belongs to. */}
-                    {securedAgainstLine(line).map(debt => (
-                      <p
-                        key={debt.id}
-                        className="ml-5 mb-2 flex justify-between text-dense text-gray-500 dark:text-gray-400"
-                      >
-                        <span className="min-w-0 truncate">{debt.name} — secured against this</span>
-                        <span className="tabular-nums shrink-0 ml-3">
-                          {formatCurrency(toDecimal(Math.abs(debt.balance ?? 0)))}
-                        </span>
-                      </p>
-                    ))}
-                    <div className="flex items-center gap-2">
-                      <div className="flex-1 bg-gray-200 dark:bg-gray-700 rounded-full h-2">
-                        <div
-                          className="h-2 rounded-full"
-                          style={{
-                            // Clamped for layout only: a line can be worth a
-                            // negative amount, and a negative width renders
-                            // nothing anywhere.
-                            width: `${Math.min(100, Math.max(0, line.allocation.toNumber()))}%`,
-                            backgroundColor: categoricalColor(ramp, index)
-                          }}
-                        />
-                      </div>
-                      <span className="text-body text-gray-600 dark:text-gray-400 w-12 text-right">
-                        {formatPercentage(line.allocation)}
+                  Colour is keyed by the line's place in the UNSORTED list, so
+                  a dot keeps its colour when the sort changes — the dots and
+                  the allocation slices are derived from the same order, and a
+                  sort that recoloured every holding would break that thread. */}
+              {(groupedHoldingLines ?? [['', sortedHoldingLines]] as const).map(([institution, lines]) => (
+                <div key={institution || 'all'} className="space-y-4">
+                  {institution !== '' && (
+                    <div className="flex items-baseline justify-between border-b border-gray-200 dark:border-gray-700 pb-1">
+                      <h3 className="text-dense uppercase tracking-wide font-semibold text-gray-500 dark:text-gray-400">
+                        {institution}
+                      </h3>
+                      <span className="text-dense tabular-nums text-gray-500 dark:text-gray-400">
+                        {formatCurrency(lines.reduce((t, l) => t.plus(l.value), toDecimal(0)))}
                       </span>
                     </div>
-                  </div>
-                );
-              })}
+                  )}
+                  {lines.map((line) => {
+                    const account = accountsById.get(line.accountId);
+                    if (!account) return null;
+                    const colourIndex = portfolioLines.indexOf(line);
+                    const cashTotal = line.cash.reduce((t, c) => t.plus(c.value), toDecimal(0));
+                    const invested = line.value.minus(cashTotal);
+                    const secured = securedAgainstLine(line);
+
+                    return (
+                      <div
+                        key={account.id}
+                        className="border-b dark:border-gray-700 pb-4 last:border-0 -mx-2 px-2 py-2 rounded"
+                      >
+                        <div className="flex justify-between items-start mb-2">
+                          <div className="flex items-center gap-2 min-w-0">
+                            <div
+                              className="w-3 h-3 rounded-full flex-shrink-0"
+                              style={{ backgroundColor: categoricalColor(ramp, colourIndex) }}
+                            />
+                            <h3 className="font-medium text-gray-900 dark:text-white truncate">
+                              {line.name}
+                            </h3>
+                          </div>
+                          <p className="font-semibold text-gray-900 dark:text-white shrink-0 ml-3">{formatCurrency(line.value)}</p>
+                        </div>
+                        <p className="ml-5 mb-1 flex justify-between text-dense text-gray-500 dark:text-gray-400">
+                          <span>Investments</span>
+                          <span className="tabular-nums">{formatCurrency(invested)}</span>
+                        </p>
+                        {line.cash.length > 0 && (
+                          <p className="ml-5 mb-2 flex justify-between text-dense text-gray-500 dark:text-gray-400">
+                            <span>Cash</span>
+                            <span className="tabular-nums">{formatCurrency(cashTotal)}</span>
+                          </p>
+                        )}
+                        <div className="flex items-center gap-2">
+                          <div className="flex-1 bg-gray-200 dark:bg-gray-700 rounded-full h-2">
+                            <div
+                              className="h-2 rounded-full"
+                              style={{
+                                // Clamped for layout only: a line can be worth a
+                                // negative amount, and a negative width renders
+                                // nothing anywhere.
+                                width: `${Math.min(100, Math.max(0, line.allocation.toNumber()))}%`,
+                                backgroundColor: categoricalColor(ramp, colourIndex)
+                              }}
+                            />
+                          </div>
+                          <span className="text-body text-gray-600 dark:text-gray-400 w-12 text-right">
+                            {formatPercentage(line.allocation)}
+                          </span>
+                        </div>
+                        {secured.length > 0 && (
+                          <div className="ml-5 mt-2">
+                            {/* A magnitude, not a signed balance, and NOT part
+                                of the figures above — which is why it sits the
+                                other side of the bar with its own heading. */}
+                            <p className="text-[10px] uppercase tracking-wide text-gray-400 dark:text-gray-500 mb-1">
+                              Secured liabilities
+                            </p>
+                            {secured.map(debt => (
+                              <p
+                                key={debt.id}
+                                className="flex justify-between text-dense text-gray-500 dark:text-gray-400"
+                              >
+                                <span className="min-w-0 truncate">{debt.name}</span>
+                                <span className="tabular-nums shrink-0 ml-3">
+                                  {formatCurrency(toDecimal(Math.abs(debt.balance ?? 0)))}
+                                </span>
+                              </p>
+                            ))}
+                          </div>
+                        )}
+                      </div>
+                    );
+                  })}
+                </div>
+              ))}
             </div>
           )}
         </div>

--- a/src/pages/__tests__/Investments.test.tsx
+++ b/src/pages/__tests__/Investments.test.tsx
@@ -77,9 +77,22 @@ describe('Investments page — the pair is the portfolio', () => {
     renderInvestments();
 
     // £1,300 in the fund and £200 in its cash: the tile and the holding row
-    // both say £1,500, and the fund's own £1,300 is never shown on its own.
+    // both say £1,500.
     expect(await screen.findAllByText('£1,500.00')).toHaveLength(2);
-    expect(screen.queryByText('£1,300.00')).not.toBeInTheDocument();
+
+    /*
+     * The £1,300 IS shown now, and that is a ruling change, not a leak. This
+     * assertion used to be `.not.toBeInTheDocument()` — the fund's own figure
+     * was never printed, only the pair's total. The owner's 16 August spec
+     * asks for the opposite: each row itemises "Investments" and "Cash", and
+     * the two must sum to the total above them, a check the reader can do by
+     * eye. So the figure appears exactly once, labelled, beside the £200 that
+     * completes it.
+     */
+    // The itemised line, not the page title: both say "Investments", so the
+    // label is read from the same paragraph as its figure.
+    const investedFigure = screen.getByText('£1,300.00');
+    expect(investedFigure.closest('p')?.textContent).toContain('Investments');
   });
 
   it('shows the nested cash inside the holding, not as a holding of its own', async () => {

--- a/src/test/securedLiabilities.test.ts
+++ b/src/test/securedLiabilities.test.ts
@@ -96,13 +96,18 @@ describe('which accounts may be secured, and against what', () => {
     expect(resolveSecuring(ledger[0], ledger).offered).toBe(true);
   });
 
-  it('never offers a debt as the thing to be secured against', () => {
+  it('offers DEBTS as targets too (owner, 16 August)', () => {
+    /*
+     * This test used to assert the opposite. The owner borrows in and lends
+     * the same money out, files the loan-out under Liabilities to keep every
+     * loan in one section, and wants the two tagged — a debt netting another
+     * debt. The link is display-only, so nothing was being protected by the
+     * exclusion except an accounting convention his filing does not follow.
+     */
     const targets = resolveSecuring(ledger[0], ledger).options.map(a => a.id);
-    expect(targets).not.toContain('visa');
-    expect(targets).not.toContain('personal-loan');
-    // Through the alias, which is the half a hand-rolled type set gets wrong:
-    // 'mortgage' files under Loans.
-    expect(targets).not.toContain('mortgage-proper');
+    expect(targets).toContain('visa');
+    expect(targets).toContain('personal-loan');
+    expect(targets).toContain('mortgage-proper');
   });
 
   it('offers assets, investments and unclassified accounts', () => {

--- a/src/utils/accountSecuring.ts
+++ b/src/utils/accountSecuring.ts
@@ -12,21 +12,6 @@
  * both.
  */
 import type { Account } from '../types';
-import { sectionTypeForAccount } from './accountGrouping';
-
-/**
- * The sections whose accounts are somebody's debt, so cannot be a TARGET.
- *
- * Read through `sectionTypeForAccount` rather than off `type` directly, which
- * is what makes the aliases behave: 'mortgage' files under Loans, 'checking'
- * under Current, 'assets' under Assets. A hand-rolled type set gets all three
- * wrong, and gets them wrong silently.
- *
- * 'other' is NOT here. It is the catch-all for a type with no section of its
- * own, so it means "unclassified", not "not a debt" — excluding it would drop
- * legitimate targets on the guess that they might be liabilities.
- */
-export const LIABILITY_SECTIONS: ReadonlySet<string> = new Set(['credit', 'loan', 'liability']);
 
 /** What the field may offer this account, and whether it appears at all. */
 export interface SecuringState {
@@ -62,8 +47,19 @@ export function resolveSecuring(
   account: Account,
   accounts: readonly Account[]
 ): SecuringState {
+  /*
+   * ANY open account except itself — debts included, as of 16 August.
+   *
+   * The first cut excluded liabilities as targets, on the theory that a debt
+   * cannot be secured against a debt. The owner's ledger says otherwise: he
+   * borrows in and lends the same money out, files the loan-out under
+   * Liabilities to keep every loan in one section, and wants the two tagged —
+   * a debt read as NETTING another debt rather than as an asset inflating both
+   * totals. The link is display-only either way, so the exclusion was
+   * protecting nothing except an accounting convention his filing does not
+   * follow.
+   */
   const options = accounts.filter(a =>
-    !LIABILITY_SECTIONS.has(sectionTypeForAccount(a.type)) &&
     a.id !== account.id &&
     a.isActive !== false
   );


### PR DESCRIPTION
## 1 — the tab lives in the URL

Refreshing on Watchlist landed back on Overview, because the tab was component state and a refresh rebuilds state from nothing — the URL is the one thing a refresh keeps. `?tab=watchlist` now, with `replace` so the back button doesn't replay every tab press, and Overview carrying no parameter at all.

**Verified live:** refresh holds the tab, switching writes the URL, `demo=true` survives throughout.

## 2 — a debt may be secured against a debt

The target list excluded liabilities on the theory that a debt cannot be secured against one. **The owner's ledger says otherwise**: he borrows in and lends the same money out, files the loan-out under Liabilities to keep every loan in one section, and wants the two tagged — a debt read as *netting* another debt rather than as an asset inflating both totals.

The link is display-only, so the exclusion protected nothing except an accounting convention his filing does not follow. The test that asserted the exclusion now asserts the opposite, with the reason.

## 3 + 5 — each holding accounts for its own total

The institution line under every name is gone (the Accounts-list rule), and the row now itemises:

- **Investments** — the total less paired cash
- **Cash** — the paired cash
- …the two **summing to the figure on the right**, a check the reader can do by eye. The owner's spec, verbatim.

Secured liabilities move **below** the allocation bar under their own small heading — they are a different kind of fact: the lines above are parts of the total, and these are not in it at all.

One test pinned the old design ("the fund's own £1,300 is never shown on its own") and now asserts the new one, scoped to the row's own paragraph.

## 4 — the Accounts page's controls, on the app's other long list

Sort by Default / Name / Value, and **Group by institution** with a heading and subtotal per group. Both persisted. Colour is keyed by the line's place in the *unsorted* list, so a dot keeps its colour when the sort changes — the dots and the allocation slices derive from the same order.

## 6 — the calendar arrows have an ink

They set no colour of their own and inherited near-invisibility in a dark modal. Named explicitly, both modes.

## 7 — the repoint dialog stops squashing its options

The option name and its explanation were written as stacked `block` spans — but `index.css` makes every button `inline-flex`, which turned them into flex **items** side by side, the name wrapping down a narrow column. `block` on the buttons: the class beats the element rule, and the spans stack as written. **The same global rule's fourth casualty.**

## Verification

lint (zero warnings) · `typecheck:strict` · 6,096 unit tests · `desktop:verify` · item 1 exercised live in the browser.

🤖 Generated with [Claude Code](https://claude.com/claude-code)