### PR TITLE
feat(investments): the drill-down, and a secured liability shows its signed balance

### DIFF
--- a/src/pages/Investments.tsx
+++ b/src/pages/Investments.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
-import { useSearchParams } from 'react-router-dom';
+import { Link, useLocation, useSearchParams } from 'react-router-dom';
+import { preserveDemoParam } from '../utils/navigation';
 import { useApp } from '../contexts/AppContextSupabase';
 import { TrendingUpIcon, TrendingDownIcon, BarChart3Icon, AlertCircleIcon, LineChartIcon, EyeIcon, PlusIcon } from '../components/icons';
 import AddInvestmentModal from '../components/AddInvestmentModal';
@@ -98,6 +99,7 @@ export default function Investments() {
    * push: switching tabs is not a navigation the back button should replay
    * four times.
    */
+  const location = useLocation();
   const [searchParams, setSearchParams] = useSearchParams();
   const tabParam = searchParams.get('tab');
   const activeTab: 'overview' | 'watchlist' | 'portfolio' | 'manage' =
@@ -115,6 +117,13 @@ export default function Investments() {
     }, { replace: true });
   }, [setSearchParams]);
   const [managingAccountId, setManagingAccountId] = useState<string | null>(null);
+  /**
+   * Which summary tile is opened out into its per-account rows — the owner's
+   * drill-down, asked for twice: "even if the figures are then investment
+   * account summary level and from there, each account can be clicked on to
+   * see the transactions". Clicking the open tile again closes it.
+   */
+  const [openBreakdown, setOpenBreakdown] = useState<'contributions' | 'return' | null>(null);
 
   // ── Holdings: the MARKET view's data, from public.investments ─────────────
   // Kept deliberately apart from `summary` below. Holdings × price is a second
@@ -697,21 +706,38 @@ export default function Investments() {
           </div>
         </div>
 
-        <div className="bg-white dark:bg-gray-800 rounded-lg border border-line dark:border-gray-700 p-6">
-          <div className="flex items-center justify-between">
-            <div>
-              <p className="text-body text-gray-500 dark:text-gray-400">Net Contributions</p>
-              <p className="text-page font-bold text-blue-700 dark:text-blue-400">
-                {formatCurrency(summary.netContributions)}
-              </p>
-              <p className="text-dense text-gray-500 dark:text-gray-400 mt-1">
-                Transferred in, less transferred out
-              </p>
-            </div>
-          </div>
-        </div>
+        {/* ─ TWO TILES THAT OPEN (owner, 16 August, asked twice) ────────────
+            Buttons, with `block` against the global inline-flex rule and
+            `text-left` so they keep reading as the tiles they were. The
+            breakdown they open renders full-width under the tile row —
+            per-account figures from the SAME walk as the totals (see
+            portfolioSummary: one classification, two aggregations, so the
+            rows always sum to the tile). */}
+        <button
+          type="button"
+          onClick={() => setOpenBreakdown(openBreakdown === 'contributions' ? null : 'contributions')}
+          aria-expanded={openBreakdown === 'contributions'}
+          className={`block w-full text-left bg-white dark:bg-gray-800 rounded-lg border p-6 transition-colors hover:border-gray-300 dark:hover:border-gray-500 ${
+            openBreakdown === 'contributions' ? 'border-[#6b86b3]' : 'border-line dark:border-gray-700'
+          }`}
+        >
+          <p className="text-body text-gray-500 dark:text-gray-400">Net Contributions</p>
+          <p className="text-page font-bold text-blue-700 dark:text-blue-400">
+            {formatCurrency(summary.netContributions)}
+          </p>
+          <p className="text-dense text-gray-500 dark:text-gray-400 mt-1">
+            Transferred in, less transferred out — click for each account's share
+          </p>
+        </button>
 
-        <div className="bg-white dark:bg-gray-800 rounded-lg border border-line dark:border-gray-700 p-6">
+        <button
+          type="button"
+          onClick={() => setOpenBreakdown(openBreakdown === 'return' ? null : 'return')}
+          aria-expanded={openBreakdown === 'return'}
+          className={`block w-full text-left bg-white dark:bg-gray-800 rounded-lg border p-6 transition-colors hover:border-gray-300 dark:hover:border-gray-500 ${
+            openBreakdown === 'return' ? 'border-[#6b86b3]' : 'border-line dark:border-gray-700'
+          }`}
+        >
           <div className="flex items-center justify-between">
             <div>
               <p className="text-body text-gray-500 dark:text-gray-400">Total Return</p>
@@ -721,7 +747,7 @@ export default function Investments() {
             </div>
             <TrendingUpIcon className={isGain ? 'text-green-500' : 'text-red-500'} size={24} />
           </div>
-        </div>
+        </button>
 
         <div className="bg-white dark:bg-gray-800 rounded-lg border border-line dark:border-gray-700 p-6">
           <div className="flex items-center justify-between">
@@ -751,6 +777,42 @@ export default function Investments() {
           </div>
         </div>
         </div>
+
+        {/* ─ THE BREAKDOWN A TILE OPENS ─────────────────────────────────────
+            One panel serving both tiles, full-width under the row. Each line
+            is a pair from the SAME walk that produced the tile's figure — one
+            classification, two aggregations — so the rows sum to the tile
+            exactly, and the total row at the bottom proves it in print. Each
+            account name links to its register, which is the second half of
+            the owner's spec: summary level here, transactions one click on. */}
+        {openBreakdown !== null && (
+          <div className="bg-white dark:bg-gray-800 rounded-lg border border-line dark:border-gray-700 p-6">
+            <h3 className="text-card font-semibold text-theme-heading dark:text-white mb-3">
+              {openBreakdown === 'contributions' ? 'Net Contributions by account' : 'Total Return by account'}
+            </h3>
+            <div className="space-y-1">
+              {portfolioLines.map(line => (
+                <p key={line.accountId} className="flex justify-between gap-3 py-1 border-b border-gray-100 dark:border-gray-700/60 last:border-0">
+                  <Link
+                    to={preserveDemoParam(`/accounts/${line.accountId}`, location.search)}
+                    className="min-w-0 truncate text-body text-gray-700 dark:text-gray-300 underline decoration-dotted underline-offset-2 hover:text-blue-600 dark:hover:text-blue-400"
+                  >
+                    {line.name}
+                  </Link>
+                  <span className="tabular-nums shrink-0 text-body text-gray-900 dark:text-white">
+                    {formatCurrency(openBreakdown === 'contributions' ? line.netContributions : line.totalReturn)}
+                  </span>
+                </p>
+              ))}
+              <p className="flex justify-between gap-3 pt-2 font-semibold text-body text-gray-900 dark:text-white">
+                <span>Total</span>
+                <span className="tabular-nums">
+                  {formatCurrency(openBreakdown === 'contributions' ? summary.netContributions : summary.totalReturn)}
+                </span>
+              </p>
+            </div>
+          </div>
+        )}
 
         {/* What the contributions figure rests on. Says what could be WRONG
             with it, not how many rows there are — and renders nothing at all

--- a/src/pages/Investments.tsx
+++ b/src/pages/Investments.tsx
@@ -983,9 +983,24 @@ export default function Investments() {
                         </div>
                         {secured.length > 0 && (
                           <div className="ml-5 mt-2">
-                            {/* A magnitude, not a signed balance, and NOT part
-                                of the figures above — which is why it sits the
-                                other side of the bar with its own heading. */}
+                            {/* THE SIGNED BALANCE, exactly as the Accounts page
+                                prints it (owner, 16 August). This shipped as a
+                                magnitude — "the size of the debt is the datum
+                                under a heading that already says liabilities" —
+                                and the owner caught the cost within the hour:
+                                the same loan read (£1,400,000.00) on one page
+                                and £1,400,000.00 on this one. Two surfaces
+                                disagreeing about one account's figure is the
+                                exact failure the pairing rules exist to
+                                prevent, and "liabilities stay negative" is the
+                                app's own display law.
+
+                                The brackets also do the "not in the total" job
+                                BETTER than the magnitude did: a parenthesised
+                                figure visibly does not sum with the unbracketed
+                                Investments and Cash lines above it. (The
+                                net-position arithmetic keeps its own abs — what
+                                to SUBTRACT is a magnitude by definition.) */}
                             <p className="text-[10px] uppercase tracking-wide text-gray-400 dark:text-gray-500 mb-1">
                               Secured liabilities
                             </p>
@@ -996,7 +1011,7 @@ export default function Investments() {
                               >
                                 <span className="min-w-0 truncate">{debt.name}</span>
                                 <span className="tabular-nums shrink-0 ml-3">
-                                  {formatCurrency(toDecimal(Math.abs(debt.balance ?? 0)))}
+                                  {formatCurrency(toDecimal(debt.balance ?? 0))}
                                 </span>
                               </p>
                             ))}

--- a/src/utils/portfolioSummary.test.ts
+++ b/src/utils/portfolioSummary.test.ts
@@ -144,6 +144,30 @@ describe('buildPortfolioSummary — net external contributions', () => {
     expect(summaryOf().netContributions.toNumber()).toBe(400);
   });
 
+  it('splits contributions and return per line, and the lines SUM to the totals', () => {
+    /*
+     * The drill-down's whole guarantee (owner, 16 August): the per-account
+     * rows a tile opens into must add up to the tile, exactly. The split is
+     * accumulated in the same loop as the totals — one classification, two
+     * aggregations — and this is the assertion that keeps it that way.
+     */
+    const summary = summaryOf();
+
+    const contributionsSum = summary.lines.reduce(
+      (t, line) => t.plus(line.netContributions), summary.netContributions.minus(summary.netContributions)
+    );
+    const returnSum = summary.lines.reduce(
+      (t, line) => t.plus(line.totalReturn), summary.totalReturn.minus(summary.totalReturn)
+    );
+
+    expect(contributionsSum.toNumber()).toBe(summary.netContributions.toNumber());
+    expect(returnSum.toNumber()).toBe(summary.totalReturn.toNumber());
+    // And per line, the identity the tile states for the whole portfolio:
+    for (const line of summary.lines) {
+      expect(line.totalReturn.toNumber()).toBe(line.value.minus(line.netContributions).toNumber());
+    }
+  });
+
   it('excludes an internal move filed only under the other side\'s transfer category', () => {
     const filed = transactions.map(t =>
       t.id === 't-internal-out'

--- a/src/utils/portfolioSummary.ts
+++ b/src/utils/portfolioSummary.ts
@@ -48,6 +48,16 @@ export interface PortfolioLine {
   cash: PortfolioCashLine[];
   /** Share of the whole portfolio, 0–100. Zero when the portfolio is worth nothing. */
   allocation: DecimalInstance;
+  /**
+   * This pair's share of `netContributions` — the same walk, attributed by the
+   * MEMBER account each transfer row sits on, so the lines always sum to the
+   * portfolio figure exactly. A transfer between two pairs counts −X on one
+   * line and +X on the other, netting to zero across the list just as it does
+   * in the total.
+   */
+  netContributions: DecimalInstance;
+  /** value − netContributions, for this pair alone. The lines sum to the portfolio's. */
+  totalReturn: DecimalInstance;
 }
 
 /**
@@ -188,6 +198,10 @@ export function buildPortfolioSummary(input: PortfolioSummaryInput): PortfolioSu
     value: line.value,
     cash: line.cash,
     allocation: value.isZero() ? ZERO : line.value.dividedBy(value).times(100),
+    // Filled in after the contributions walk below; ZERO until then so the
+    // object is complete from birth.
+    netContributions: ZERO,
+    totalReturn: ZERO,
   }));
 
   // Contributions: transfer rows sitting on a member account whose other side
@@ -206,6 +220,10 @@ export function buildPortfolioSummary(input: PortfolioSummaryInput): PortfolioSu
   let netContributions = ZERO;
   let unattributedCount = 0;
   let unattributedAmount = ZERO;
+  // Per pair, for the drill-down: the same figures, attributed to the line the
+  // row belongs to. Kept in the SAME loop so the split cannot drift from the
+  // total — one classification, two aggregations.
+  const contributionsByLine = new Map<string, DecimalInstance>();
   for (const row of memberRows) {
     if (classifyFlow(row, categoryKinds) !== 'transfer') continue;
     const other = counterpartyAccountId(row, transactionsById, categoryAccounts);
@@ -217,6 +235,8 @@ export function buildPortfolioSummary(input: PortfolioSummaryInput): PortfolioSu
     }
     const amount = toDecimal(row.amount);
     netContributions = netContributions.plus(amount);
+    const lineId = topLevelIdByAccountId.get(row.accountId) ?? row.accountId;
+    contributionsByLine.set(lineId, (contributionsByLine.get(lineId) ?? ZERO).plus(amount));
     if (other === undefined) {
       unattributedCount += 1;
       unattributedAmount = unattributedAmount.plus(amount.abs());
@@ -224,6 +244,14 @@ export function buildPortfolioSummary(input: PortfolioSummaryInput): PortfolioSu
   }
 
   const totalReturn = value.minus(netContributions);
+
+  // Attach the split. Lines were built before the walk, so this closes the
+  // shape rather than re-deriving anything.
+  for (const line of lines) {
+    const contributed = contributionsByLine.get(line.accountId) ?? ZERO;
+    line.netContributions = contributed;
+    line.totalReturn = line.value.minus(contributed);
+  }
 
   return {
     lines,


### PR DESCRIPTION
Two commits — the sign fix the owner caught, and the drill-down he asked for twice.

## Net Contributions and Total Return open into per-account rows

> "even if the figures are then investment account summary level and from there, each account can be clicked on to see the transactions"

**The split is the same walk as the totals.** `portfolioSummary` already classified every transfer row and knew which pair it belonged to; the per-line figures are accumulated in that same loop — one classification, two aggregations — so the rows **cannot** drift from the tile they open from. A transfer between two pairs counts −X on one line and +X on the other, netting across the list exactly as it nets in the total.

The test pins the sum both ways and the per-line identity (`return = value − contributions`). Proven non-vacuous: keying the split off the member account instead of its pair drops the sleeve's rows from the lines and the sum breaks.

The tiles are buttons — `block text-left` against the global inline-flex rule, accent border while open, `aria-expanded`, click again to close. One panel serves both: account name (a link to its register — the spec's second half), the figure, and a **Total row that visibly matches the tile**. The Net Contributions subtitle now says the tile opens, because a tile that does something and looks identical to three that don't is a control nobody finds.

## The signed balance

The same loan read `(£1,400,000.00)` on the Accounts page and `£1,400,000.00` under Secured liabilities. Two surfaces disagreeing about one account's figure is the exact failure the pairing rules exist to prevent, and **liabilities stay negative** is the app's own display law. The brackets also do the "not in the total" job *better* — a parenthesised figure visibly doesn't sum with the unbracketed lines above it. The net-position arithmetic keeps its own `abs`: what to subtract is a magnitude by definition.

## Verification

lint (zero warnings) · `typecheck:strict` · 6,097 unit tests · `desktop:verify` — green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)