### PR TITLE
feat(dashboard,investments): the drill-downs become pop-ups, open a level deeper, and two dark-mode flips

### DIFF
--- a/src/components/AccountRowColumns.tsx
+++ b/src/components/AccountRowColumns.tsx
@@ -451,9 +451,20 @@ export function AccountCountCell({
    * type or clip it. The break is at 100 because that is where the width has to
    * give, not because of anything about the number.
    */
+  /* THE PILL FLIPS IN DARK (owner, 16 August). `bg-primary` is the near-black
+     navy: the right "attend to this" mark on a white row, and a circle you can
+     barely see on a gray-800 one — the count read as white digits floating on
+     nothing. Dark inverts it: the light ground with navy digits, the same
+     relationship the other way up, and the same reason the band totals swap
+     ink rather than keep it.
+
+     `bg-[#1a2332]`, NOT `bg-primary`: index.css gives `.bg-primary` an
+     `!important`, which beats any `dark:` variant however specific — the same
+     mechanism that blanked the grey text app-wide this morning. The literal
+     hex is the same colour without the landmine. */
   const pillClass = `tabular-nums ${
     count > 0
-      ? `inline-flex items-center justify-center h-6 rounded-full bg-primary text-white text-sm font-bold ${
+      ? `inline-flex items-center justify-center h-6 rounded-full bg-[#1a2332] text-white dark:bg-gray-200 dark:text-[#1a2332] text-sm font-bold ${
           count < 100 ? 'w-6' : 'min-w-[24px] px-1.5'
         }`
       : 'text-sm font-normal text-gray-400 dark:text-gray-500'
@@ -542,7 +553,8 @@ export function AccountCountCell({
          */
         className={`tabular-nums ${
           count > 0
-            ? 'inline-flex items-center justify-center min-w-[24px] px-1.5 py-0.5 rounded-full bg-primary text-white text-sm font-bold'
+            // Flipped in dark for the reason the linked pill above states.
+            ? 'inline-flex items-center justify-center min-w-[24px] px-1.5 py-0.5 rounded-full bg-[#1a2332] text-white dark:bg-gray-200 dark:text-[#1a2332] text-sm font-bold'
             : 'text-sm font-normal text-gray-400 dark:text-gray-500'
         }`}
       >

--- a/src/components/__tests__/AccountCountCell.test.tsx
+++ b/src/components/__tests__/AccountCountCell.test.tsx
@@ -52,7 +52,12 @@ describe('a count of outstanding work', () => {
      * disc among words without reading any of them.
      */
     expect(withWork).toContain('rounded-full');
-    expect(withWork).toContain('bg-primary');
+    // `bg-[#1a2332]`, not `bg-primary`: index.css gives `.bg-primary` an
+    // `!important`, which would beat the pill's dark-mode flip (16 August —
+    // the pill now inverts to a light ground with navy digits on dark rows,
+    // where the navy circle had been invisible).
+    expect(withWork).toContain('bg-[#1a2332]');
+    expect(withWork).toContain('dark:bg-gray-200');
     expect(withWork).toContain('font-bold');
     // The zero gains nothing: no fill, no ring, no weight.
     expect(none).not.toContain('rounded-full');
@@ -120,7 +125,7 @@ describe('a count you can act on', () => {
     expect(link).toHaveAttribute('href', '/reconciliation?account=abc&from=accounts');
     // Still the same pill — becoming clickable must not restyle it, or the
     // column strip stops lining up with the figures it names.
-    expect(link.getAttribute('class')).toContain('bg-primary');
+    expect(link.getAttribute('class')).toContain('bg-[#1a2332]');
     expect(link.getAttribute('class')).toContain('rounded-full');
   });
 

--- a/src/components/dashboard/ImprovedDashboard.tsx
+++ b/src/components/dashboard/ImprovedDashboard.tsx
@@ -30,6 +30,7 @@ import IncomeExpenseBreakdownModal from '../IncomeExpenseBreakdownModal';
 import { Modal, ModalBody } from '../common/Modal';
 import PeriodBar from '../../components/PeriodBar';
 import NetWorthSummary from '../../components/NetWorthSummary';
+import AccountBreakdownModal, { type AccountBreakdownView } from '../../components/AccountBreakdownModal';
 import { PERIOD_LABELS, usePeriod } from '../../hooks/usePeriod';
 import { cardPeriodKey, useCardPeriod } from '../../hooks/useCardPeriod';
 import {
@@ -251,6 +252,15 @@ export function ImprovedDashboard() {
   // ~50 MILLION Decimal operations per render on a 50k-row dataset. While the
   // transaction pages are still streaming in, the server's one-round-trip
   // balances stand in (see computeAccountBalances).
+  /**
+   * Which summary figure is opened out into its accounts — the same
+   * AccountBreakdownModal the Accounts page drills with (owner, 16 August:
+   * "make the 'what you own' and 'what you owe' clickable"). Rows are fed
+   * from the SAME accountBalanceMap the tiles sum, so the modal's total and
+   * the tile cannot disagree.
+   */
+  const [breakdownView, setBreakdownView] = useState<AccountBreakdownView | null>(null);
+
   const accountBalanceMap = useMemo(
     () => computeAccountBalances(accounts, transactions, serverBalances),
     [accounts, transactions, serverBalances]
@@ -508,6 +518,7 @@ export function ImprovedDashboard() {
           netWorth={formatCurrencyWithSymbol(metrics.netWorth)}
           assets={formatCurrencyWithSymbol(metrics.totalAssets)}
           liabilities={formatCurrencyWithSymbol(metrics.totalLiabilities)}
+          onSelect={figure => setBreakdownView(figure)}
         />
       </section>
 
@@ -1231,6 +1242,27 @@ export function ImprovedDashboard() {
           tiles pushed the figures up a screenful to repeat the navigation.
           The phone keeps its floating "+" (components/MobileBottomNav) — there
           the sidebar is behind a tap, so quick-add is the only door. */}
+
+      {/* The SAME modal the Accounts page drills with, fed from the SAME
+          balance map the three tiles sum — so its total and the tile cannot
+          disagree, which is the whole precondition for offering the click. */}
+      <AccountBreakdownModal
+        view={breakdownView}
+        onClose={() => setBreakdownView(null)}
+        rows={accounts.map(a => ({
+          id: a.id,
+          name: a.name,
+          institution: a.institution,
+          accountType: a.type,
+          balance: accountBalanceMap.get(a.id) ?? 0,
+          formatted: formatCurrencyWithSymbol(accountBalanceMap.get(a.id) ?? 0),
+        }))}
+        formatTotal={(v) => formatCurrencyWithSymbol(v)}
+        onOpenAccount={(accountId) => {
+          setBreakdownView(null);
+          navigate(preserveDemoParam(`/accounts/${accountId}`, location.search));
+        }}
+      />
     </div>
   );
 }

--- a/src/pages/Investments.tsx
+++ b/src/pages/Investments.tsx
@@ -1,6 +1,8 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { Link, useLocation, useSearchParams } from 'react-router-dom';
 import { preserveDemoParam } from '../utils/navigation';
+import { Modal, ModalBody } from '../components/common/Modal';
+import { formatDate } from '../utils/dateFormatter';
 import { useApp } from '../contexts/AppContextSupabase';
 import { TrendingUpIcon, TrendingDownIcon, BarChart3Icon, AlertCircleIcon, LineChartIcon, EyeIcon, PlusIcon } from '../components/icons';
 import AddInvestmentModal from '../components/AddInvestmentModal';
@@ -124,6 +126,8 @@ export default function Investments() {
    * see the transactions". Clicking the open tile again closes it.
    */
   const [openBreakdown, setOpenBreakdown] = useState<'contributions' | 'return' | null>(null);
+  /** Second level: which line's transactions are on screen. Null = the list. */
+  const [drillLineId, setDrillLineId] = useState<string | null>(null);
 
   // ── Holdings: the MARKET view's data, from public.investments ─────────────
   // Kept deliberately apart from `summary` below. Holdings × price is a second
@@ -778,41 +782,133 @@ export default function Investments() {
         </div>
         </div>
 
-        {/* ─ THE BREAKDOWN A TILE OPENS ─────────────────────────────────────
-            One panel serving both tiles, full-width under the row. Each line
-            is a pair from the SAME walk that produced the tile's figure — one
-            classification, two aggregations — so the rows sum to the tile
-            exactly, and the total row at the bottom proves it in print. Each
-            account name links to its register, which is the second half of
-            the owner's spec: summary level here, transactions one click on. */}
-        {openBreakdown !== null && (
-          <div className="bg-white dark:bg-gray-800 rounded-lg border border-line dark:border-gray-700 p-6">
-            <h3 className="text-card font-semibold text-theme-heading dark:text-white mb-3">
-              {openBreakdown === 'contributions' ? 'Net Contributions by account' : 'Total Return by account'}
-            </h3>
-            <div className="space-y-1">
-              {portfolioLines.map(line => (
-                <p key={line.accountId} className="flex justify-between gap-3 py-1 border-b border-gray-100 dark:border-gray-700/60 last:border-0">
-                  <Link
-                    to={preserveDemoParam(`/accounts/${line.accountId}`, location.search)}
-                    className="min-w-0 truncate text-body text-gray-700 dark:text-gray-300 underline decoration-dotted underline-offset-2 hover:text-blue-600 dark:hover:text-blue-400"
+        {/* ─ THE BREAKDOWN A TILE OPENS — a MODAL, like the app's other
+            drill-downs (owner, 16 August). It shipped as an inline panel and
+            pushed the whole page down; a pop-up leaves the tiles where the
+            eye was.
+
+            TWO LEVELS. The list is per account, from the SAME walk as the
+            tile — one classification, two aggregations — with a Total row
+            proving the sum. Clicking a line opens what the figure is MADE OF:
+            the external transfers behind it, each on the member account it
+            actually sat on. That last part is the lesson of the owner's IG
+            Index click: the root's register was empty because the money moved
+            through the cash sleeve, so "which account" and "where did this
+            figure come from" had different answers. This is the second one. */}
+        <Modal
+          isOpen={openBreakdown !== null}
+          onClose={() => { setOpenBreakdown(null); setDrillLineId(null); }}
+          title={openBreakdown === 'contributions' ? 'Net Contributions by account' : 'Total Return by account'}
+          size="lg"
+        >
+          <ModalBody>
+            {(() => {
+              const drillLine = drillLineId === null
+                ? null
+                : portfolioLines.find(l => l.accountId === drillLineId) ?? null;
+              if (openBreakdown === null) return null;
+
+              if (drillLine === null) {
+                return (
+                  <div className="space-y-1">
+                    {portfolioLines.map(line => (
+                      <button
+                        key={line.accountId}
+                        type="button"
+                        onClick={() => setDrillLineId(line.accountId)}
+                        className="block w-full text-left py-2 px-2 -mx-2 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-700/50 border-b border-gray-100 dark:border-gray-700/60 last:border-0"
+                      >
+                        <span className="flex justify-between gap-3">
+                          <span className="min-w-0 truncate text-body text-gray-700 dark:text-gray-300">{line.name}</span>
+                          <span className="tabular-nums shrink-0 text-body text-gray-900 dark:text-white">
+                            {formatCurrency(openBreakdown === 'contributions' ? line.netContributions : line.totalReturn)}
+                          </span>
+                        </span>
+                      </button>
+                    ))}
+                    <p className="flex justify-between gap-3 pt-3 font-semibold text-body text-gray-900 dark:text-white">
+                      <span>Total</span>
+                      <span className="tabular-nums">
+                        {formatCurrency(openBreakdown === 'contributions' ? summary.netContributions : summary.totalReturn)}
+                      </span>
+                    </p>
+                  </div>
+                );
+              }
+
+              return (
+                <div>
+                  <button
+                    type="button"
+                    onClick={() => setDrillLineId(null)}
+                    className="text-body text-gray-500 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-200 mb-3"
                   >
-                    {line.name}
+                    ← All accounts
+                  </button>
+                  <h4 className="text-card font-semibold text-gray-900 dark:text-white mb-2">{drillLine.name}</h4>
+
+                  {/* The identity first, because it is what a RETURN is made
+                      of — a residual, not a list of rows. Contributions are
+                      the half that has transactions behind it, and they
+                      follow. */}
+                  <div className="mb-4 space-y-1">
+                    <p className="flex justify-between text-body text-gray-600 dark:text-gray-400">
+                      <span>Value today</span>
+                      <span className="tabular-nums">{formatCurrency(drillLine.value)}</span>
+                    </p>
+                    <p className="flex justify-between text-body text-gray-600 dark:text-gray-400">
+                      <span>Less net contributions</span>
+                      <span className="tabular-nums">{formatCurrency(drillLine.netContributions)}</span>
+                    </p>
+                    <p className="flex justify-between font-semibold text-body text-gray-900 dark:text-white border-t border-gray-200 dark:border-gray-700 pt-1">
+                      <span>Total return</span>
+                      <span className="tabular-nums">{formatCurrency(drillLine.totalReturn)}</span>
+                    </p>
+                  </div>
+
+                  <p className="text-[10px] uppercase tracking-wide text-gray-400 dark:text-gray-500 mb-1">
+                    The transfers behind the contributions
+                  </p>
+                  {drillLine.contributionRows.length === 0 ? (
+                    <p className="text-body text-gray-500 dark:text-gray-400 py-2">
+                      No external transfers recorded — this account's whole value is return.
+                    </p>
+                  ) : (
+                    <div className="space-y-1">
+                      {drillLine.contributionRows.map(row => {
+                        const rowAccount = accountsById.get(row.accountId);
+                        return (
+                          <p key={row.transactionId} className="flex justify-between gap-3 py-1 border-b border-gray-100 dark:border-gray-700/60 last:border-0">
+                            <span className="min-w-0 truncate text-body text-gray-700 dark:text-gray-300">
+                              {formatDate(row.date)} · {row.description || '(no description)'}
+                              {rowAccount && rowAccount.id !== drillLine.accountId && (
+                                <span className="text-gray-400 dark:text-gray-500"> — {rowAccount.name}</span>
+                              )}
+                            </span>
+                            <span className="tabular-nums shrink-0 text-body text-gray-900 dark:text-white">
+                              {formatCurrency(row.amount)}
+                            </span>
+                          </p>
+                        );
+                      })}
+                      <p className="flex justify-between gap-3 pt-2 font-semibold text-body text-gray-900 dark:text-white">
+                        <span>Net contributions</span>
+                        <span className="tabular-nums">{formatCurrency(drillLine.netContributions)}</span>
+                      </p>
+                    </div>
+                  )}
+
+                  <Link
+                    to={preserveDemoParam(`/accounts/${drillLine.cash[0]?.accountId ?? drillLine.accountId}`, location.search)}
+                    className="inline-block mt-4 text-body text-gray-500 dark:text-gray-400 underline decoration-dotted underline-offset-2 hover:text-blue-600 dark:hover:text-blue-400"
+                  >
+                    Open the register these sit in
                   </Link>
-                  <span className="tabular-nums shrink-0 text-body text-gray-900 dark:text-white">
-                    {formatCurrency(openBreakdown === 'contributions' ? line.netContributions : line.totalReturn)}
-                  </span>
-                </p>
-              ))}
-              <p className="flex justify-between gap-3 pt-2 font-semibold text-body text-gray-900 dark:text-white">
-                <span>Total</span>
-                <span className="tabular-nums">
-                  {formatCurrency(openBreakdown === 'contributions' ? summary.netContributions : summary.totalReturn)}
-                </span>
-              </p>
-            </div>
-          </div>
-        )}
+                </div>
+              );
+            })()}
+          </ModalBody>
+        </Modal>
 
         {/* What the contributions figure rests on. Says what could be WRONG
             with it, not how many rows there are — and renders nothing at all

--- a/src/pages/__tests__/Accounts.toReview.test.tsx
+++ b/src/pages/__tests__/Accounts.toReview.test.tsx
@@ -194,7 +194,9 @@ describe('Accounts list — the To Review column', () => {
      * TO STAND OUT MORE". Both attempts were text competing with text; a filled
      * navy pill breaks the rhythm instead. See AccountCountCell.test.tsx.
      */
-    expect(waiting?.className).toContain('bg-primary');
+    // The literal navy, not bg-primary — that class carries an !important
+    // which would beat the pill's dark-mode flip (16 August).
+    expect(waiting?.className).toContain('bg-[#1a2332]');
     expect(waiting?.className).toContain('rounded-full');
     expect(waiting?.className).toContain('font-bold');
     // NOT the app's link blue, which is what a zero wore until this was

--- a/src/utils/portfolioSummary.ts
+++ b/src/utils/portfolioSummary.ts
@@ -36,6 +36,23 @@ export interface PortfolioCashLine {
   value: DecimalInstance;
 }
 
+/**
+ * One external transfer, as the drill-down shows it — the rows that MAKE UP a
+ * line's `netContributions`. Kept because the owner clicked a figure of
+ * (£40,759.08), followed the account link, and landed on an empty register:
+ * the money had moved through the pair's cash sleeve, so "which account is
+ * this" and "where did this figure come from" had different answers. These
+ * are the second answer.
+ */
+export interface ContributionRow {
+  transactionId: string;
+  /** The MEMBER account the row sits on — often the cash sleeve, not the root. */
+  accountId: string;
+  date: Date;
+  description: string;
+  amount: DecimalInstance;
+}
+
 /** One row of the Holdings list, and one slice of the allocation donut. */
 export interface PortfolioLine {
   accountId: string;
@@ -58,6 +75,8 @@ export interface PortfolioLine {
   netContributions: DecimalInstance;
   /** value − netContributions, for this pair alone. The lines sum to the portfolio's. */
   totalReturn: DecimalInstance;
+  /** The external transfers behind `netContributions`, newest first. */
+  contributionRows: ContributionRow[];
 }
 
 /**
@@ -202,6 +221,7 @@ export function buildPortfolioSummary(input: PortfolioSummaryInput): PortfolioSu
     // object is complete from birth.
     netContributions: ZERO,
     totalReturn: ZERO,
+    contributionRows: [],
   }));
 
   // Contributions: transfer rows sitting on a member account whose other side
@@ -224,6 +244,7 @@ export function buildPortfolioSummary(input: PortfolioSummaryInput): PortfolioSu
   // row belongs to. Kept in the SAME loop so the split cannot drift from the
   // total — one classification, two aggregations.
   const contributionsByLine = new Map<string, DecimalInstance>();
+  const contributionRowsByLine = new Map<string, ContributionRow[]>();
   for (const row of memberRows) {
     if (classifyFlow(row, categoryKinds) !== 'transfer') continue;
     const other = counterpartyAccountId(row, transactionsById, categoryAccounts);
@@ -237,6 +258,15 @@ export function buildPortfolioSummary(input: PortfolioSummaryInput): PortfolioSu
     netContributions = netContributions.plus(amount);
     const lineId = topLevelIdByAccountId.get(row.accountId) ?? row.accountId;
     contributionsByLine.set(lineId, (contributionsByLine.get(lineId) ?? ZERO).plus(amount));
+    const rows = contributionRowsByLine.get(lineId) ?? [];
+    rows.push({
+      transactionId: row.id,
+      accountId: row.accountId,
+      date: row.date instanceof Date ? row.date : new Date(row.date),
+      description: row.description ?? '',
+      amount,
+    });
+    contributionRowsByLine.set(lineId, rows);
     if (other === undefined) {
       unattributedCount += 1;
       unattributedAmount = unattributedAmount.plus(amount.abs());
@@ -251,6 +281,8 @@ export function buildPortfolioSummary(input: PortfolioSummaryInput): PortfolioSu
     const contributed = contributionsByLine.get(line.accountId) ?? ZERO;
     line.netContributions = contributed;
     line.totalReturn = line.value.minus(contributed);
+    line.contributionRows = (contributionRowsByLine.get(line.accountId) ?? [])
+      .sort((a, b) => b.date.getTime() - a.date.getTime());
   }
 
   return {


### PR DESCRIPTION
## The Investments breakdown is a modal

> "pop up windows rather than on the page itself, like other drill down page buttons"

The inline panel pushed the whole page down; the pop-up leaves the tiles where the eye was.

## And it opens a level deeper

The owner's own click exposed a flaw in what shipped: IG Index showed contributions of `(£40,759.08)`, and its register link opened an **empty** register — the money had moved through the pair's cash sleeve, so *"which account is this"* and *"where did this figure come from"* had different answers.

Clicking a line now answers the second one:

1. the identity first — value, less net contributions, = total return
2. then **the external transfers behind the contributions**, each shown on the member account it actually sat on
3. and a link to the register those rows genuinely live in

`portfolioSummary` carries the rows per line, collected in the **same walk** as the figures.

## What you own / What you owe open too

`NetWorthSummary` already had `onSelect` — the Accounts page has drilled through it since it was built — and the Dashboard simply never passed it. Wired to the **same** `AccountBreakdownModal`, fed from the **same** `accountBalanceMap` the tiles sum, so the modal's total and the tile cannot disagree.

## The count pill flips in dark

The near-black navy is the right "attend to this" mark on a white row and a circle you can barely see on a gray-800 one — white digits floating on nothing. Dark inverts it: light ground, navy digits, the same relationship the other way up.

**`bg-[#1a2332]`, not `bg-primary`** — and the difference is a landmine: `index.css` gives `.bg-primary` an `!important`, which beats any `dark:` variant however specific. The same mechanism that blanked the app's grey text yesterday, caught this time before shipping. Three tests pinned the old class and now pin the new one, each with the reason.

## Verification

lint (zero warnings) · `typecheck:strict` · 6,097 unit tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)