### PR TITLE
feat(watchlist): a watched share can carry a dummy position

### DIFF
--- a/src/components/StockWatchlist.test.tsx
+++ b/src/components/StockWatchlist.test.tsx
@@ -173,3 +173,46 @@ describe('the cards themselves', () => {
     setInterval.mockRestore();
   });
 });
+
+describe('a dummy position on a watched share', () => {
+  it('tracks shares and a starting price, values them, and upgrades the stored shape', async () => {
+    /*
+     * The whole flow, against a list stored in the OLD shape (a plain string
+     * array — see beforeEach): the migration must not merely read it, it must
+     * survive a write. The owner's spec: "track a number of shares and the
+     * 'starting price' so that the user can almost use it as a dummy
+     * portfolio."
+     */
+    fetchQuotesMock.mockResolvedValue(batch([quote('SHEL.L', '30.00', '29.00')]));
+    const user = userEvent.setup();
+    render(<StockWatchlist />);
+
+    await user.click(await screen.findByRole('button', { name: 'Track a position' }));
+    await user.type(screen.getByLabelText(/Shares/), '10');
+    await user.type(screen.getByLabelText(/Starting price/), '25');
+    await user.click(screen.getByRole('button', { name: 'Save' }));
+
+    // 10 × £30 = £300 valued; 10 × (30 − 25) = +£50, +20%.
+    expect(await screen.findByText('£300.00')).toBeInTheDocument();
+    expect(screen.getByText(/\+£50\.00/)).toBeInTheDocument();
+    expect(screen.getByText(/\+20\.00%/)).toBeInTheDocument();
+
+    // The stored shape upgraded in place — same key, richer entries — and the
+    // symbol with no position stayed a bare item rather than gaining fields.
+    const stored = JSON.parse(window.localStorage.getItem('stock-watchlist') ?? '[]');
+    expect(stored).toEqual([
+      { symbol: 'SHEL.L', shares: '10', startPrice: '25' },
+      { symbol: 'NOTREAL' },
+    ]);
+  });
+
+  it('refuses half a position — Save stays disabled until both fields are in', async () => {
+    fetchQuotesMock.mockResolvedValue(batch([quote('SHEL.L', '30.00', '29.00')]));
+    const user = userEvent.setup();
+    render(<StockWatchlist />);
+
+    await user.click(await screen.findByRole('button', { name: 'Track a position' }));
+    await user.type(screen.getByLabelText(/Shares/), '10');
+    expect(screen.getByRole('button', { name: 'Save' })).toBeDisabled();
+  });
+});

--- a/src/components/StockWatchlist.tsx
+++ b/src/components/StockWatchlist.tsx
@@ -6,6 +6,7 @@ import StockSymbolSearch from './StockSymbolSearch';
 import { PlusIcon, XIcon, RefreshCwIcon, AlertCircleIcon } from './icons';
 import { formatDecimal } from '../utils/decimal-format';
 import { createScopedLogger } from '../loggers/scopedLogger';
+import { normaliseWatchlist, positionMetrics, type WatchedItem } from '../utils/watchlistPositions';
 
 /**
  * A watchlist that tells the truth about what it could not fetch.
@@ -26,7 +27,21 @@ import { createScopedLogger } from '../loggers/scopedLogger';
 
 export default function StockWatchlist(): React.JSX.Element {
   const { formatCurrency } = useCurrencyDecimal();
-  const [watchlist, setWatchlist] = useLocalStorage<string[]>('stock-watchlist', []);
+  /**
+   * SAME KEY, RICHER SHAPE. The list stored plain symbol strings until 16
+   * August; it now stores {symbol, shares?, startPrice?} so a watched share
+   * can carry a dummy position (the owner: "almost use it as a dummy
+   * portfolio"). `normaliseWatchlist` reads all three generations — old
+   * strings, new objects, hand-edited junk — so nobody's list empties on the
+   * day the shape changes. Every write goes back normalised.
+   */
+  const [storedWatchlist, setStoredWatchlist] = useLocalStorage<(string | WatchedItem)[]>('stock-watchlist', []);
+  const items = useMemo(() => normaliseWatchlist(storedWatchlist), [storedWatchlist]);
+  const watchlist = useMemo(() => items.map(i => i.symbol), [items]);
+  /** Which card's position form is open, if any. */
+  const [editingSymbol, setEditingSymbol] = useState<string | null>(null);
+  const [sharesDraft, setSharesDraft] = useState('');
+  const [startPriceDraft, setStartPriceDraft] = useState('');
   const [quotes, setQuotes] = useState<Map<string, StockQuote>>(new Map());
   const [errors, setErrors] = useState<Map<string, string>>(new Map());
   const [isLoading, setIsLoading] = useState(false);
@@ -68,14 +83,37 @@ export default function StockWatchlist(): React.JSX.Element {
 
   const addToWatchlist = (symbol: string): void => {
     const upper = symbol.toUpperCase();
-    if (!watchlist.includes(upper)) {
-      setWatchlist([...watchlist, upper]);
+    if (!items.some((i) => i.symbol === upper)) {
+      setStoredWatchlist([...items, { symbol: upper }]);
     }
     setShowAddStock(false);
   };
 
+  /**
+   * Both fields or neither — a position missing one of the two answers half
+   * the question it was configured for, so Save requires both and Clear
+   * removes both. Strings straight from the inputs; `normaliseWatchlist`
+   * drops anything non-numeric on the way back in.
+   */
+  const savePosition = (symbol: string, shares: string, startPrice: string): void => {
+    setStoredWatchlist(items.map((i) => {
+      if (i.symbol !== symbol) return i;
+      const s = shares.trim();
+      const p = startPrice.trim();
+      if (s === '' && p === '') return { symbol: i.symbol };
+      return { symbol: i.symbol, shares: s, startPrice: p };
+    }));
+    setEditingSymbol(null);
+  };
+
+  const openPositionForm = (item: WatchedItem): void => {
+    setEditingSymbol(item.symbol);
+    setSharesDraft(item.shares ?? '');
+    setStartPriceDraft(item.startPrice ?? '');
+  };
+
   const removeFromWatchlist = (symbol: string): void => {
-    setWatchlist(watchlist.filter((s) => s !== symbol));
+    setStoredWatchlist(items.filter((i) => i.symbol !== symbol));
     setQuotes((current) => {
       const next = new Map(current);
       next.delete(symbol);
@@ -188,7 +226,8 @@ export default function StockWatchlist(): React.JSX.Element {
       {showAddStock && addPanel}
 
       <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
-        {watchlist.map((symbol) => {
+        {items.map((item) => {
+          const symbol = item.symbol;
           const quote = quotes.get(symbol);
           const failure = errors.get(symbol);
 
@@ -247,6 +286,114 @@ export default function StockWatchlist(): React.JSX.Element {
                       No previous close to compare
                     </p>
                   )}
+
+                  {/* ─ THE DUMMY POSITION ────────────────────────────────────
+                      Owner, 16 August: shares and a starting price, "almost a
+                      dummy portfolio". It touches nothing real — no account,
+                      no transaction, no total; the arithmetic lives in
+                      utils/watchlistPositions with its own tests, because a
+                      gain is money and a units slip here shows a fake profit.
+
+                      The gain wears the hues because it has a DIRECTION,
+                      which is what the hues are for; the value beside it is a
+                      magnitude and stays neutral. */}
+                  {editingSymbol === symbol ? (
+                    <div className="mt-3 pt-3 border-t border-gray-200 dark:border-gray-600 space-y-2">
+                      <label className="block text-xs text-gray-500 dark:text-gray-400">
+                        Shares
+                        <input
+                          type="text"
+                          inputMode="decimal"
+                          value={sharesDraft}
+                          onChange={(e) => setSharesDraft(e.target.value)}
+                          className="mt-0.5 w-full px-2 py-1.5 text-sm rounded border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 text-gray-900 dark:text-white"
+                        />
+                      </label>
+                      <label className="block text-xs text-gray-500 dark:text-gray-400">
+                        Starting price ({quote.currency})
+                        <input
+                          type="text"
+                          inputMode="decimal"
+                          value={startPriceDraft}
+                          onChange={(e) => setStartPriceDraft(e.target.value)}
+                          className="mt-0.5 w-full px-2 py-1.5 text-sm rounded border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 text-gray-900 dark:text-white"
+                        />
+                      </label>
+                      <div className="flex gap-2 pt-1">
+                        <button
+                          type="button"
+                          onClick={() => savePosition(symbol, sharesDraft, startPriceDraft)}
+                          disabled={(sharesDraft.trim() === '') !== (startPriceDraft.trim() === '')}
+                          className="px-3 py-1 text-sm font-medium rounded bg-[#1a2332] dark:bg-[#2d3a4d] text-white disabled:opacity-50"
+                        >
+                          Save
+                        </button>
+                        <button
+                          type="button"
+                          onClick={() => setEditingSymbol(null)}
+                          className="px-3 py-1 text-sm text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-300"
+                        >
+                          Cancel
+                        </button>
+                        {(item.shares !== undefined || item.startPrice !== undefined) && (
+                          <button
+                            type="button"
+                            onClick={() => savePosition(symbol, '', '')}
+                            className="ml-auto px-3 py-1 text-sm text-red-600 dark:text-red-400 hover:underline"
+                          >
+                            Clear
+                          </button>
+                        )}
+                      </div>
+                    </div>
+                  ) : (() => {
+                    const metrics = positionMetrics(item, quote.price.toString());
+                    if (metrics === null) {
+                      return (
+                        <button
+                          type="button"
+                          onClick={() => openPositionForm(item)}
+                          className="mt-3 text-xs text-gray-500 dark:text-gray-400 underline decoration-dotted underline-offset-2 hover:text-blue-600 dark:hover:text-blue-400"
+                        >
+                          Track a position
+                        </button>
+                      );
+                    }
+                    const gaining = metrics.gain.greaterThanOrEqualTo(0);
+                    return (
+                      <div className="mt-3 pt-3 border-t border-gray-200 dark:border-gray-600">
+                        <div className="flex items-center justify-between">
+                          <p className="text-xs text-gray-500 dark:text-gray-400">
+                            {item.shares} shares @ {item.startPrice}
+                          </p>
+                          <button
+                            type="button"
+                            onClick={() => openPositionForm(item)}
+                            className="text-xs text-gray-400 dark:text-gray-500 underline decoration-dotted underline-offset-2 hover:text-blue-600 dark:hover:text-blue-400"
+                          >
+                            Edit
+                          </button>
+                        </div>
+                        <p className="flex justify-between text-sm mt-1">
+                          <span className="text-gray-500 dark:text-gray-400">Value</span>
+                          <span className="tabular-nums font-semibold text-gray-900 dark:text-white">
+                            {formatCurrency(metrics.value, quote.currency)}
+                          </span>
+                        </p>
+                        <p className={`flex justify-between text-sm ${
+                          gaining ? 'text-green-600 dark:text-green-400' : 'text-red-600 dark:text-red-400'
+                        }`}>
+                          <span>Gain</span>
+                          <span className="tabular-nums">
+                            {gaining ? '+' : ''}{formatCurrency(metrics.gain, quote.currency)}
+                            {metrics.gainPercent !== null && (
+                              <> ({gaining ? '+' : ''}{formatDecimal(metrics.gainPercent, 2)}%)</>
+                            )}
+                          </span>
+                        </p>
+                      </div>
+                    );
+                  })()}
                 </div>
               ) : failure ? (
                 <div className="bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-lg p-4">

--- a/src/utils/__tests__/watchlistPositions.test.ts
+++ b/src/utils/__tests__/watchlistPositions.test.ts
@@ -1,0 +1,75 @@
+/**
+ * The watchlist's dummy positions — the migration and the money arithmetic.
+ *
+ * Two quiet failure modes, each pinned: a reader that mishandles the OLD
+ * stored shape (a plain array of symbol strings) empties somebody's list on
+ * the day this ships; and the gain is money, where float maths is banned and
+ * an off-by-a-unit shows a fake profit.
+ */
+import { describe, it, expect } from 'vitest';
+import { normaliseWatchlist, positionMetrics } from '../watchlistPositions';
+
+describe('the migration: whatever is stored becomes a clean list', () => {
+  it('reads the OLD shape — plain symbol strings — as position-less items', () => {
+    // The one that must never break: every existing user has this shape.
+    expect(normaliseWatchlist(['AAPL', 'vod.l'])).toEqual([
+      { symbol: 'AAPL' },
+      { symbol: 'VOD.L' },
+    ]);
+  });
+
+  it('reads the new shape, dropping malformed numbers rather than keeping them', () => {
+    expect(normaliseWatchlist([
+      { symbol: 'AAPL', shares: '10', startPrice: '250.50' },
+      { symbol: 'MSFT', shares: 'ten', startPrice: '-5' },
+    ])).toEqual([
+      { symbol: 'AAPL', shares: '10', startPrice: '250.50' },
+      { symbol: 'MSFT' },
+    ]);
+  });
+
+  it('drops junk without taking the list with it', () => {
+    // localStorage is hand-editable; one bad entry must cost one entry.
+    expect(normaliseWatchlist(['AAPL', 42, null, {}, { symbol: '' }])).toEqual([
+      { symbol: 'AAPL' },
+    ]);
+    expect(normaliseWatchlist('not-an-array')).toEqual([]);
+  });
+
+  it('keeps the first of a duplicated symbol', () => {
+    expect(normaliseWatchlist([
+      { symbol: 'AAPL', shares: '10', startPrice: '1' },
+      'AAPL',
+    ])).toEqual([{ symbol: 'AAPL', shares: '10', startPrice: '1' }]);
+  });
+});
+
+describe('the arithmetic: a dummy position against a live price', () => {
+  it('values the position and signs the gain', () => {
+    const metrics = positionMetrics({ symbol: 'AAPL', shares: '10', startPrice: '250' }, '305.93');
+    expect(metrics).not.toBeNull();
+    expect(metrics?.value.toFixed(2)).toBe('3059.30');
+    expect(metrics?.gain.toFixed(2)).toBe('559.30');
+    expect(metrics?.gainPercent?.toFixed(2)).toBe('22.37');
+  });
+
+  it('shows a LOSS as negative, not as absolute', () => {
+    const metrics = positionMetrics({ symbol: 'AAPL', shares: '4', startPrice: '350' }, '305.93');
+    expect(metrics?.gain.toFixed(2)).toBe('-176.28');
+    expect(metrics?.gainPercent?.toFixed(2)).toBe('-12.59');
+  });
+
+  it('is exact where floats are not', () => {
+    // 0.1 + 0.2 country: 3 × (0.30 − 0.10) must be 0.60, not 0.6000000000000001.
+    const metrics = positionMetrics({ symbol: 'X', shares: '3', startPrice: '0.10' }, '0.30');
+    expect(metrics?.gain.toString()).toBe('0.6');
+  });
+
+  it('answers null for half a position — both fields or neither', () => {
+    // Shares without a start price could show a value but not a gain, and a
+    // card answering half its configured question reads as broken.
+    expect(positionMetrics({ symbol: 'AAPL', shares: '10' }, '300')).toBeNull();
+    expect(positionMetrics({ symbol: 'AAPL', startPrice: '250' }, '300')).toBeNull();
+    expect(positionMetrics({ symbol: 'AAPL' }, '300')).toBeNull();
+  });
+});

--- a/src/utils/watchlistPositions.ts
+++ b/src/utils/watchlistPositions.ts
@@ -1,0 +1,112 @@
+/**
+ * THE WATCHLIST'S DUMMY POSITIONS (owner, 16 August): "we want to be able to
+ * track a number of shares and the 'starting price' so that the user can
+ * almost use it as a dummy portfolio."
+ *
+ * A watched symbol may carry a hypothetical position — how many shares, and
+ * the price they were notionally taken at. Nothing here touches the ledger:
+ * no account, no transactions, no effect on any total. It is the "what if I
+ * had bought" view, and it lives where the watchlist lives, in the browser.
+ *
+ * Pure functions in a leaf module, because two things here can go quietly
+ * wrong and both deserve tests: the MIGRATION (the stored shape used to be a
+ * plain array of symbol strings, and a reader that mishandles it empties
+ * somebody's list), and the ARITHMETIC (gains are money, and float maths on
+ * money is banned in this codebase).
+ */
+import { toDecimal } from './decimal';
+import type { DecimalInstance } from './decimal';
+
+export interface WatchedItem {
+  symbol: string;
+  /**
+   * Decimal STRINGS, not numbers — they multiply into money, and this repo
+   * does not do float arithmetic on money. Absent = watched with no position,
+   * which is exactly what every item was before this feature.
+   */
+  shares?: string;
+  /** In the same unit the quote displays — USD for AAPL, whatever the card says. */
+  startPrice?: string;
+}
+
+const isRecord = (v: unknown): v is Record<string, unknown> =>
+  typeof v === 'object' && v !== null && !Array.isArray(v);
+
+const numericString = (v: unknown): string | undefined => {
+  if (typeof v !== 'string' && typeof v !== 'number') return undefined;
+  const text = String(v).trim();
+  if (text === '') return undefined;
+  const n = Number(text);
+  if (!Number.isFinite(n) || n <= 0) return undefined;
+  return text;
+};
+
+/**
+ * Whatever is in storage → a clean list.
+ *
+ * Three generations may be found under the key: the original `string[]`, the
+ * new `WatchedItem[]`, and (because localStorage is hand-editable) junk. A
+ * string becomes a position-less item — the exact meaning it always had — and
+ * junk is dropped rather than crashing the list it sits in. Duplicate symbols
+ * keep the FIRST occurrence, which is the one the user has seen at the top.
+ */
+export function normaliseWatchlist(raw: unknown): WatchedItem[] {
+  if (!Array.isArray(raw)) return [];
+  const seen = new Set<string>();
+  const out: WatchedItem[] = [];
+  for (const entry of raw) {
+    let item: WatchedItem | null = null;
+    if (typeof entry === 'string' && entry.trim() !== '') {
+      item = { symbol: entry.trim().toUpperCase() };
+    } else if (isRecord(entry) && typeof entry.symbol === 'string' && entry.symbol.trim() !== '') {
+      const shares = numericString(entry.shares);
+      const startPrice = numericString(entry.startPrice);
+      item = {
+        symbol: entry.symbol.trim().toUpperCase(),
+        ...(shares === undefined ? {} : { shares }),
+        ...(startPrice === undefined ? {} : { startPrice }),
+      };
+    }
+    if (item === null || seen.has(item.symbol)) continue;
+    seen.add(item.symbol);
+    out.push(item);
+  }
+  return out;
+}
+
+export interface PositionMetrics {
+  /** shares × current price. */
+  value: DecimalInstance;
+  /** shares × (current − start). Signed — a loss is negative. */
+  gain: DecimalInstance;
+  /** (current − start) / start × 100. Null when the start price is zero. */
+  gainPercent: DecimalInstance | null;
+}
+
+/**
+ * What the position is worth against a live price — or null when the item
+ * carries no complete position, which renders as the plain card it always was.
+ *
+ * BOTH fields or neither: shares without a start price could still show a
+ * value, but it could not show a gain, and a card that answers half the
+ * question it was configured to ask reads as broken rather than as partial.
+ * The form enforces the same rule, so this is defence in depth, not the UX.
+ */
+export function positionMetrics(
+  item: WatchedItem,
+  currentPrice: string | number
+): PositionMetrics | null {
+  if (item.shares === undefined || item.startPrice === undefined) return null;
+  const shares = toDecimal(item.shares);
+  const start = toDecimal(item.startPrice);
+  const price = toDecimal(currentPrice);
+  if (shares.lessThanOrEqualTo(0) || start.lessThan(0)) return null;
+
+  const value = shares.times(price);
+  const gain = shares.times(price.minus(start));
+  return {
+    value,
+    gain,
+    gainPercent: start.isZero() ? null : price.minus(start).dividedBy(start).times(100),
+  };
+}


### PR DESCRIPTION
> "we want to be able to track a number of shares and the 'starting price' so that the user can almost use it as a dummy portfolio"

Each card gains **Track a position** — shares and a starting price in the quote's own currency — and then shows **Value** (shares × price, neutral: a magnitude) and **Gain** (shares × the move since start, signed and in the hues, because a gain has a direction and directions are what the hues are for). Nothing touches the ledger: no account, no transaction, no total anywhere else.

## The stored shape upgrades in place

`stock-watchlist` held a plain array of symbol strings; it now holds `{symbol, shares?, startPrice?}`. `normaliseWatchlist` reads all three generations — old strings, new objects, hand-edited junk — so nobody's list empties on the day the shape changes, and every write goes back normalised.

The component test **seeds the old shape and asserts the write upgrades it**, because a migration that reads but cannot survive a save is half a migration.

## The arithmetic is a tested leaf module

`utils/watchlistPositions` — shares and prices are decimal **strings** multiplied with Decimal. A gain is money, float maths on money is banned here, and the test pins the 0.1+0.2 case by name. A loss is signed, never absolute.

## Both fields or neither

Shares without a starting price could show a value but not a gain, and a card answering half the question it was configured for reads as broken. Save stays disabled on half a form; Clear removes both; the normaliser enforces the same rule against hand-edited storage.

## Verification

lint (zero warnings) · `typecheck:strict` · **6,107 unit tests** (10 new). Not verified in the browser — the dev server has no API functions, so a priced card cannot render there; the flow is pinned by component tests instead (render, track, save, re-read storage).

🤖 Generated with [Claude Code](https://claude.com/claude-code)