### PR TITLE
feat(quotes): LSE prices through Twelve Data, verified by the owner's own curl

### DIFF
--- a/api/_lib/quotes.ts
+++ b/api/_lib/quotes.ts
@@ -1,5 +1,5 @@
 import Decimal from 'decimal.js';
-import { fetchQuoteTwelveData, isUnsuffixedSymbol, type TwelveDataQuote } from './twelvedata.js';
+import { fetchQuoteTwelveData, toTwelveDataQuoteRequest, type TwelveDataQuote } from './twelvedata.js';
 
 /**
  * Market quotes, fetched SERVER-SIDE and normalised to major currency units.
@@ -320,8 +320,16 @@ export const fetchQuote = async (symbol: string, fetchImpl?: FetchLike): Promise
    * Yahoo remains the fallback for everything, so a failure here costs a round
    * trip rather than a price. See twelvedata.ts for the whole argument.
    */
+  /*
+   * Routed when Twelve Data can price it: bare US symbols, and — since the
+   * Grow upgrade of 16 August — the suffixes `toTwelveDataQuoteRequest` has a
+   * VERIFIED translation for (today: `.L` alone; the owner priced Vodafone by
+   * hand and the answer was `GBp`, pence correctly labelled, so the same
+   * minor-unit table converts both providers). Everything else stays on
+   * Yahoo, and Yahoo remains the fallback even for what is routed.
+   */
   const apiKey = (process.env.TWELVE_DATA_API_KEY ?? '').trim();
-  if (apiKey !== '' && isUnsuffixedSymbol(symbol)) {
+  if (apiKey !== '' && toTwelveDataQuoteRequest(symbol) !== null) {
     try {
       const quote = await fetchQuoteTwelveData(symbol, { apiKey, fetchImpl: doFetch as typeof fetch });
       // The SAME normalisation Yahoo's answers go through — the unit is read

--- a/api/_lib/twelvedata.ts
+++ b/api/_lib/twelvedata.ts
@@ -237,12 +237,55 @@ export function isUnsuffixedSymbol(symbol: string): boolean {
   return !symbol.includes('.');
 }
 
+/**
+ * Yahoo suffix → the `exchange` parameter Twelve Data prices it under.
+ *
+ * ONE entry, deliberately. The owner upgraded to the Grow plan on 16 August
+ * and verified LSE by hand: `symbol=VOD&exchange=LSE` answered with
+ * `"currency":"GBp"` — pence, correctly labelled, so the existing
+ * MINOR_UNIT_CURRENCIES table converts it with no special case. That curl is
+ * the ONLY exchange that has been exercised, so it is the only one routed;
+ * every other suffix stays on Yahoo until someone prices a known share
+ * through both the same way. A wrong entry here is a symbol priced on the
+ * wrong exchange, which can look plausible for weeks.
+ */
+const SUFFIX_TO_EXCHANGE: Readonly<Record<string, string>> = {
+  '.L': 'LSE',
+};
+
+/**
+ * The request Twelve Data needs for a Yahoo-dialect symbol, or null when this
+ * app has not verified that translation.
+ *
+ * `VOD.L` becomes `{ symbol: 'VOD', exchange: 'LSE' }` — Twelve Data does not
+ * speak the suffix form for quotes; the owner's first curl with `VOD.L`
+ * failed where `VOD&exchange=LSE` answered.
+ */
+export function toTwelveDataQuoteRequest(
+  yahooSymbol: string
+): { symbol: string; exchange?: string } | null {
+  if (isUnsuffixedSymbol(yahooSymbol)) return { symbol: yahooSymbol };
+  const dot = yahooSymbol.lastIndexOf('.');
+  const exchange = SUFFIX_TO_EXCHANGE[yahooSymbol.slice(dot)];
+  if (exchange === undefined) return null;
+  const base = yahooSymbol.slice(0, dot);
+  if (base === '') return null;
+  return { symbol: base, exchange };
+}
+
 export async function fetchQuoteTwelveData(
   symbol: string,
   options: TwelveDataOptions
 ): Promise<TwelveDataQuote | null> {
   const doFetch = options.fetchImpl ?? fetch;
-  const url = `https://api.twelvedata.com/quote?symbol=${encodeURIComponent(symbol)}`;
+  // The SYMBOL STAYS IN YAHOO'S DIALECT on the way out. The caller keys its
+  // maps by what it asked for (`VOD.L`), and the nightly cron stores prices
+  // against the same form — a quote answering under a different name would
+  // simply never land on its holding.
+  const request = toTwelveDataQuoteRequest(symbol);
+  if (request === null) return null;
+  const url = `https://api.twelvedata.com/quote?symbol=${encodeURIComponent(request.symbol)}`
+    + (request.exchange === undefined ? '' : `&exchange=${encodeURIComponent(request.exchange)}`);
 
   const response = await doFetch(url, {
     headers: { Authorization: `apikey ${options.apiKey}`, Accept: 'application/json' },

--- a/src/test/api-lib/symbolSearch.test.ts
+++ b/src/test/api-lib/symbolSearch.test.ts
@@ -15,7 +15,7 @@
  */
 import { describe, it, expect, vi } from 'vitest';
 import { searchSymbolsVia, activeSymbolSearchProvider } from '../../../api/_lib/symbolSearch';
-import { searchSymbolsTwelveData, toYahooSymbol, fetchQuoteTwelveData, isUnsuffixedSymbol } from '../../../api/_lib/twelvedata';
+import { searchSymbolsTwelveData, toYahooSymbol, fetchQuoteTwelveData, isUnsuffixedSymbol, toTwelveDataQuoteRequest } from '../../../api/_lib/twelvedata';
 
 const KEYED = { TWELVE_DATA_API_KEY: 'test-key' } as NodeJS.ProcessEnv;
 const UNKEYED = {} as NodeJS.ProcessEnv;
@@ -157,13 +157,42 @@ describe('prices: which provider, and in what unit', () => {
    * calling it `GBP` would make a UK holding a hundred times too valuable,
    * silently, in a ledger measured in millions.
    */
-  it('routes only UNSUFFIXED symbols away from Yahoo', () => {
-    // The guard, in one assertion. `.L`, `.DE`, `.TO` keep the path this app
-    // has already reconciled against real statements.
+  it('routes bare symbols AND the verified .L, and nothing else', () => {
+    /*
+     * The guard, widened by exactly one entry on 16 August: the owner
+     * upgraded to Grow and priced Vodafone by hand — `symbol=VOD&exchange=LSE`
+     * answered `"currency":"GBp"`, pence correctly labelled — so `.L` has a
+     * verified translation. `.DE` and `.TO` have not been exercised the same
+     * way and stay on Yahoo, because a symbol priced on the wrong exchange
+     * can look plausible for weeks.
+     */
     expect(isUnsuffixedSymbol('AAPL')).toBe(true);
-    expect(isUnsuffixedSymbol('VOD.L')).toBe(false);
-    expect(isUnsuffixedSymbol('APC.DE')).toBe(false);
-    expect(isUnsuffixedSymbol('AAPL.TO')).toBe(false);
+    expect(toTwelveDataQuoteRequest('AAPL')).toEqual({ symbol: 'AAPL' });
+    expect(toTwelveDataQuoteRequest('VOD.L')).toEqual({ symbol: 'VOD', exchange: 'LSE' });
+    expect(toTwelveDataQuoteRequest('APC.DE')).toBeNull();
+    expect(toTwelveDataQuoteRequest('AAPL.TO')).toBeNull();
+    expect(toTwelveDataQuoteRequest('.L')).toBeNull();
+  });
+
+  it('asks Twelve Data in ITS dialect and answers in Yahoo\'s', async () => {
+    /*
+     * The owner's first curl proved `VOD.L` is not a symbol Twelve Data
+     * knows; the second proved `VOD&exchange=LSE` is. And the caller keys
+     * its maps by what it asked for, so the answer must come back as VOD.L —
+     * a quote under a different name never lands on its holding.
+     */
+    const fetchImpl = stub({
+      symbol: 'VOD', name: 'Vodafone Group Public Limited Company',
+      close: '121.55', currency: 'GBp', datetime: '2026-08-14'
+    });
+    const result = await fetchQuoteTwelveData('VOD.L', { apiKey: 'k', fetchImpl });
+
+    const [url] = (fetchImpl as unknown as { mock: { calls: [string][] } }).mock.calls[0];
+    expect(url).toContain('symbol=VOD');
+    expect(url).toContain('exchange=LSE');
+    expect(url).not.toContain('VOD.L');
+
+    expect(result).toMatchObject({ symbol: 'VOD.L', price: '121.55', currency: 'GBp' });
   });
 
   it('reads the price and the currency from the response', async () => {


### PR DESCRIPTION
The owner upgraded to the Grow plan and ran the two curls that gated this change. They answered both open questions at once:

## The dialect

`symbol=VOD.L` is **not** a form Twelve Data knows; `symbol=VOD&exchange=LSE` answered in full. The adapter now translates Yahoo's dialect on the way out — `VOD.L` → `{symbol: 'VOD', exchange: 'LSE'}` — and answers in Yahoo's dialect on the way back, because the caller keys its maps by what it asked for and the nightly cron stores prices under the same form. A quote under a different name never lands on its holding.

## The 100× question, settled

```
"currency": "GBp"  ·  "close": "121.55000"
```

**Pence, correctly labelled** — exactly as Yahoo labels it. So the one `MINOR_UNIT_CURRENCIES` table converts both providers with no special case: 121.55 GBp → £1.2155. The mislabel that kept the guard on does not exist.

## One suffix, deliberately

`.L` is the only translation that has been exercised against a real quote, so it is the only one routed. `.DE`, `.TO` and the rest stay on Yahoo until someone prices a known share through both the same way — a symbol priced on the wrong exchange can look plausible for weeks, which is a worse failure than a 429.

Yahoo remains the fallback even for what is routed.

## Guards

| mutation | result |
| --- | --- |
| add an unverified `.DE` entry | fails |
| leave the suffix on the outgoing symbol | fails ×2 |

## Verification

lint (zero warnings) · `typecheck:strict` · 6,108 unit tests · the LSE behaviour itself verified by the owner's live curl against his own paid key.

🤖 Generated with [Claude Code](https://claude.com/claude-code)