### PR TITLE
feat(investments,watchlist): cost on the card, list view, flipping sorts, level rings, and Manage folds into Portfolio

### DIFF
--- a/src/components/InvestmentMarketView.tsx
+++ b/src/components/InvestmentMarketView.tsx
@@ -102,7 +102,7 @@ export default function InvestmentMarketView({
     return (
       <div className="text-center py-8">
         <p className="text-gray-500 dark:text-gray-400">
-          No holdings recorded for this account. Add them on the Manage tab to see market values.
+          No holdings recorded for this account. Press Manage holdings above to add them and see market values.
         </p>
       </div>
     );

--- a/src/components/StockWatchlist.tsx
+++ b/src/components/StockWatchlist.tsx
@@ -36,8 +36,17 @@ export default function StockWatchlist(): React.JSX.Element {
    * day the shape changes. Every write goes back normalised.
    */
   const [storedWatchlist, setStoredWatchlist] = useLocalStorage<(string | WatchedItem)[]>('stock-watchlist', []);
+  /**
+   * Arrangement (owner, 16 August): sort by name or by position value, each
+   * direction toggleable, and a list view beside the grid. Persisted like the
+   * Accounts and Holdings arrangements are. Sorting reads the DISPLAYED list
+   * only — mutations key by symbol, so reordering cannot misdirect a save.
+   */
+  const [watchlistSort, setWatchlistSort] = useLocalStorage<'default' | 'name-asc' | 'name-desc' | 'value-desc' | 'value-asc'>('wt_watchlist_sort', 'default');
+  const [watchlistView, setWatchlistView] = useLocalStorage<'grid' | 'list'>('wt_watchlist_view', 'grid');
   const items = useMemo(() => normaliseWatchlist(storedWatchlist), [storedWatchlist]);
   const watchlist = useMemo(() => items.map(i => i.symbol), [items]);
+
   /** Which card's position form is open, if any. */
   const [editingSymbol, setEditingSymbol] = useState<string | null>(null);
   const [sharesDraft, setSharesDraft] = useState('');
@@ -47,6 +56,34 @@ export default function StockWatchlist(): React.JSX.Element {
   const [isLoading, setIsLoading] = useState(false);
   const [showAddStock, setShowAddStock] = useState(false);
   const [lastUpdated, setLastUpdated] = useState<Date | null>(null);
+
+  const displayedItems = useMemo(() => {
+    if (watchlistSort === 'default') return items;
+    const sorted = [...items];
+    if (watchlistSort === 'name-asc' || watchlistSort === 'name-desc') {
+      sorted.sort((a, b) => a.symbol.localeCompare(b.symbol));
+      if (watchlistSort === 'name-desc') sorted.reverse();
+      return sorted;
+    }
+    // Value = the dummy position's worth. A card with no position has no
+    // value to rank by, so it sorts after every card that has one — in both
+    // directions, because "no position" is not "worth nothing".
+    const valueOf = (item: WatchedItem): number | null => {
+      const quote = quotes.get(item.symbol);
+      if (!quote) return null;
+      const metrics = positionMetrics(item, quote.price.toString());
+      return metrics === null ? null : metrics.value.toNumber();
+    };
+    sorted.sort((a, b) => {
+      const va = valueOf(a);
+      const vb = valueOf(b);
+      if (va === null && vb === null) return 0;
+      if (va === null) return 1;
+      if (vb === null) return -1;
+      return watchlistSort === 'value-desc' ? vb - va : va - vb;
+    });
+    return sorted;
+  }, [items, watchlistSort, quotes]);
   const logger = useMemo(() => createScopedLogger('StockWatchlist'), []);
 
   const fetchAll = useCallback(async () => {
@@ -225,8 +262,62 @@ export default function StockWatchlist(): React.JSX.Element {
 
       {showAddStock && addPanel}
 
-      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
-        {items.map((item) => {
+      {/* The arrangement controls, from two cards up — the same pills every
+          other list in the app wears, with both directions on each axis. */}
+      {items.length > 1 && (
+        <div className="flex flex-wrap items-center gap-2 mb-4">
+          <div className="inline-flex rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 p-0.5">
+            <button
+              type="button"
+              onClick={() => setWatchlistSort('default')}
+              aria-pressed={watchlistSort === 'default'}
+              className={`px-3 py-1.5 text-sm font-medium rounded-md whitespace-nowrap transition-colors ${
+                watchlistSort === 'default'
+                  ? 'bg-[#1a2332] dark:bg-[#2d3a4d] text-white'
+                  : 'text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-200'
+              }`}
+            >
+              Default
+            </button>
+            <button
+              type="button"
+              onClick={() => setWatchlistSort(watchlistSort === 'name-asc' ? 'name-desc' : 'name-asc')}
+              aria-pressed={watchlistSort === 'name-asc' || watchlistSort === 'name-desc'}
+              className={`px-3 py-1.5 text-sm font-medium rounded-md whitespace-nowrap transition-colors ${
+                watchlistSort === 'name-asc' || watchlistSort === 'name-desc'
+                  ? 'bg-[#1a2332] dark:bg-[#2d3a4d] text-white'
+                  : 'text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-200'
+              }`}
+            >
+              Name {watchlistSort === 'name-desc' ? 'Z–A' : 'A–Z'}
+            </button>
+            <button
+              type="button"
+              onClick={() => setWatchlistSort(watchlistSort === 'value-desc' ? 'value-asc' : 'value-desc')}
+              aria-pressed={watchlistSort === 'value-desc' || watchlistSort === 'value-asc'}
+              className={`px-3 py-1.5 text-sm font-medium rounded-md whitespace-nowrap transition-colors ${
+                watchlistSort === 'value-desc' || watchlistSort === 'value-asc'
+                  ? 'bg-[#1a2332] dark:bg-[#2d3a4d] text-white'
+                  : 'text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-200'
+              }`}
+            >
+              Value {watchlistSort === 'value-asc' ? '↑' : '↓'}
+            </button>
+          </div>
+          <button
+            type="button"
+            onClick={() => setWatchlistView(watchlistView === 'grid' ? 'list' : 'grid')}
+            className="ml-auto px-3 py-1.5 text-sm font-medium rounded-md text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-200 transition-colors border border-gray-200 dark:border-gray-700"
+          >
+            {watchlistView === 'grid' ? 'List view' : 'Grid view'}
+          </button>
+        </div>
+      )}
+
+      <div className={watchlistView === 'list'
+        ? 'space-y-3'
+        : 'grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4'}>
+        {displayedItems.map((item) => {
           const symbol = item.symbol;
           const quote = quotes.get(symbol);
           const failure = errors.get(symbol);
@@ -374,8 +465,18 @@ export default function StockWatchlist(): React.JSX.Element {
                             Edit
                           </button>
                         </div>
+                        {/* Cost, then current value, then the gain — the
+                            identity in reading order: cost + gain = value,
+                            checkable by eye. Cost and value are magnitudes and
+                            stay neutral; the gain carries the direction. */}
                         <p className="flex justify-between text-sm mt-1">
-                          <span className="text-gray-500 dark:text-gray-400">Value</span>
+                          <span className="text-gray-500 dark:text-gray-400">Cost</span>
+                          <span className="tabular-nums text-gray-700 dark:text-gray-300">
+                            {formatCurrency(metrics.cost, quote.currency)}
+                          </span>
+                        </p>
+                        <p className="flex justify-between text-sm">
+                          <span className="text-gray-500 dark:text-gray-400">Current value</span>
                           <span className="tabular-nums font-semibold text-gray-900 dark:text-white">
                             {formatCurrency(metrics.value, quote.currency)}
                           </span>

--- a/src/pages/Accounts.tsx
+++ b/src/pages/Accounts.tsx
@@ -37,7 +37,7 @@ import {
   type AccountDisplayGroup,
 } from '../utils/accountGrouping';
 
-type AccountSortMode = 'default' | 'name' | 'balance-desc' | 'balance-asc';
+type AccountSortMode = 'default' | 'name' | 'name-desc' | 'balance-desc' | 'balance-asc';
 import { IconButton } from '../components/icons/IconButton';
 import { useCurrencyDecimal } from '../hooks/useCurrencyDecimal';
 import {
@@ -234,7 +234,7 @@ export default function Accounts() {
   const [grouping, setGrouping] = useState<AccountGroupingOptions>(readStoredGrouping);
   const [sortMode, setSortMode] = useState<AccountSortMode>(() => {
     const stored = preferences.getItem('accountsSortMode');
-    return stored === 'name' || stored === 'balance-desc' || stored === 'balance-asc'
+    return stored === 'name' || stored === 'name-desc' || stored === 'balance-desc' || stored === 'balance-asc'
       ? stored
       : 'default';
   });
@@ -689,8 +689,9 @@ export default function Accounts() {
       return list;
     }
     const sorted = [...list];
-    if (sortMode === 'name') {
+    if (sortMode === 'name' || sortMode === 'name-desc') {
       sorted.sort((a, b) => a.name.localeCompare(b.name, undefined, { sensitivity: 'base' }));
+      if (sortMode === 'name-desc') sorted.reverse();
     } else {
       sorted.sort((a, b) => {
         const comparison = toDecimal(computeAccountBalance(a.id))
@@ -2601,14 +2602,16 @@ export default function Accounts() {
               Default
             </button>
             <button
-              onClick={() => handleSortChange('name')}
+              // Pressing it again flips the direction, exactly as Value does
+              // one pill along (owner, 16 August: "you cannot flip to Z–A").
+              onClick={() => handleSortChange(sortMode === 'name' ? 'name-desc' : 'name')}
               className={`px-3 py-1.5 text-sm font-medium rounded-md whitespace-nowrap transition-colors ${
-                sortMode === 'name'
+                sortMode === 'name' || sortMode === 'name-desc'
                   ? 'bg-[#1a2332] dark:bg-[#2d3a4d] text-white'
                   : 'text-gray-600 dark:text-gray-400 hover:text-gray-900'
               }`}
             >
-              Name A–Z
+              Name {sortMode === 'name-desc' ? 'Z–A' : 'A–Z'}
             </button>
             <button
               onClick={() => handleSortChange(sortMode === 'balance-desc' ? 'balance-asc' : 'balance-desc')}

--- a/src/pages/Investments.tsx
+++ b/src/pages/Investments.tsx
@@ -425,7 +425,7 @@ export default function Investments() {
    * the same reason the actions toggle is: an arrangement chosen once should
    * survive a refresh.
    */
-  const [holdingsSort, setHoldingsSort] = useLocalStorage<'default' | 'name' | 'value'>(
+  const [holdingsSort, setHoldingsSort] = useLocalStorage<'default' | 'name' | 'name-desc' | 'value' | 'value-asc'>(
     'wt_holdings_sort',
     'default'
   );
@@ -437,8 +437,13 @@ export default function Investments() {
   const sortedHoldingLines = useMemo(() => {
     if (holdingsSort === 'default') return portfolioLines;
     const lines = [...portfolioLines];
-    if (holdingsSort === 'name') lines.sort((a, b) => a.name.localeCompare(b.name));
-    else lines.sort((a, b) => b.value.comparedTo(a.value));
+    if (holdingsSort === 'name' || holdingsSort === 'name-desc') {
+      lines.sort((a, b) => a.name.localeCompare(b.name));
+      if (holdingsSort === 'name-desc') lines.reverse();
+    } else {
+      lines.sort((a, b) => b.value.comparedTo(a.value));
+      if (holdingsSort === 'value-asc') lines.reverse();
+    }
     return lines;
   }, [portfolioLines, holdingsSort]);
 
@@ -1019,14 +1024,20 @@ export default function Investments() {
           {portfolioLines.length > 1 && (
             <div className="flex flex-wrap items-center gap-2 mb-4">
               <div className="inline-flex rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 p-0.5">
-                {([['default', 'Default'], ['name', 'Name A–Z'], ['value', 'Value ↓']] as const).map(([mode, label]) => (
+                {/* Both directions on both axes — a second press flips, as
+                    everywhere (owner, 16 August). */}
+                {([
+                  ['default', 'Default', 'default'],
+                  [holdingsSort === 'name' ? 'name-desc' : 'name', `Name ${holdingsSort === 'name-desc' ? 'Z–A' : 'A–Z'}`, 'name'],
+                  [holdingsSort === 'value' ? 'value-asc' : 'value', `Value ${holdingsSort === 'value-asc' ? '↑' : '↓'}`, 'value'],
+                ] as const).map(([next, label, axis]) => (
                   <button
-                    key={mode}
+                    key={axis}
                     type="button"
-                    onClick={() => setHoldingsSort(mode)}
-                    aria-pressed={holdingsSort === mode}
+                    onClick={() => setHoldingsSort(next)}
+                    aria-pressed={holdingsSort === axis || holdingsSort === `${axis}-desc` || holdingsSort === `${axis}-asc`}
                     className={`px-3 py-1.5 text-sm font-medium rounded-md whitespace-nowrap transition-colors ${
-                      holdingsSort === mode
+                      holdingsSort.startsWith(axis)
                         ? 'bg-[#1a2332] dark:bg-[#2d3a4d] text-white'
                         : 'text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-200'
                     }`}

--- a/src/pages/Investments.tsx
+++ b/src/pages/Investments.tsx
@@ -4,7 +4,7 @@ import { preserveDemoParam } from '../utils/navigation';
 import { Modal, ModalBody } from '../components/common/Modal';
 import { formatDate } from '../utils/dateFormatter';
 import { useApp } from '../contexts/AppContextSupabase';
-import { TrendingUpIcon, TrendingDownIcon, BarChart3Icon, AlertCircleIcon, LineChartIcon, EyeIcon, PlusIcon } from '../components/icons';
+import { TrendingUpIcon, TrendingDownIcon, BarChart3Icon, AlertCircleIcon, LineChartIcon, EyeIcon } from '../components/icons';
 import AddInvestmentModal from '../components/AddInvestmentModal';
 import InvestmentMarketView from '../components/InvestmentMarketView';
 import PortfolioManager, { type HoldingFormValues } from '../components/PortfolioManager';
@@ -18,7 +18,6 @@ import { normaliseSecuredIds } from '../utils/accountSecuring';
 import type { DecimalInstance } from '../utils/decimal';
 import { formatDecimal } from '../utils/decimal-format';
 import PageWrapper from '../components/PageWrapper';
-import GroupedAccountOptions from '../components/common/GroupedAccountOptions';
 import ToggleSwitch from '../components/ui/ToggleSwitch';
 import { buildPortfolioSummary, buildPortfolioHistory } from '../utils/portfolioSummary';
 import { buildHoldingAllocation } from '../utils/holdingAllocation';
@@ -104,11 +103,20 @@ export default function Investments() {
   const location = useLocation();
   const [searchParams, setSearchParams] = useSearchParams();
   const tabParam = searchParams.get('tab');
-  const activeTab: 'overview' | 'watchlist' | 'portfolio' | 'manage' =
+  /**
+   * THREE TABS since 16 August. "Manage" was the Portfolio tab with a dropdown
+   * instead of a scroll — pick an account, then add holdings — while Portfolio
+   * was pick an account by scrolling, then a button whose whole job was
+   * switching to Manage. Two doors to one room (the owner: "kind of take you
+   * to the same place, just a different way"). The manager now opens INLINE on
+   * the Portfolio card it concerns; `tab=manage` in an old URL lands on
+   * Portfolio rather than nowhere.
+   */
+  const activeTab: 'overview' | 'watchlist' | 'portfolio' =
     tabParam === 'watchlist' || tabParam === 'portfolio' || tabParam === 'manage'
-      ? tabParam
+      ? (tabParam === 'manage' ? 'portfolio' : tabParam)
       : 'overview';
-  const setActiveTab = useCallback((tab: 'overview' | 'watchlist' | 'portfolio' | 'manage'): void => {
+  const setActiveTab = useCallback((tab: 'overview' | 'watchlist' | 'portfolio'): void => {
     setSearchParams(prev => {
       const next = new URLSearchParams(prev);
       // Overview is the default, so it carries no parameter — a clean URL for
@@ -632,17 +640,6 @@ export default function Investments() {
         >
           <LineChartIcon size={16} />
           Portfolio
-        </button>
-        <button
-          onClick={() => setActiveTab('manage')}
-          className={`flex-1 flex items-center justify-center gap-2 px-4 py-2 text-body font-medium rounded-md transition-colors ${
-            activeTab === 'manage'
-              ? 'bg-white dark:bg-gray-600 text-gray-900 dark:text-white shadow-sm'
-              : 'text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-300'
-          }`}
-        >
-          <PlusIcon size={16} />
-          Manage
         </button>
       </div>
 
@@ -1333,7 +1330,14 @@ export default function Investments() {
                 </ResponsiveContainer>
               </div>
 
-              <div className="mt-4 space-y-2">
+              {/* RESERVES FIVE ROWS' HEIGHT even holding one (owner, 16
+                  August: "that allocation by holding should be the same size
+                  card with just the space for the remaining 4 legend spots").
+                  The card above caps its legend at five entries, so five rows
+                  — 8.5rem at this row height — is the tallest either legend
+                  gets, and pinning this one to it keeps the two cards level
+                  however many securities are priced. */}
+              <div className="mt-4 space-y-2 min-h-[8.5rem]">
                 {holdingSlices.map((slice, index) => (
                   <div key={slice.name} className="flex items-center justify-between gap-3 text-body">
                     <div className="flex items-center gap-2 min-w-0">
@@ -1420,13 +1424,11 @@ export default function Investments() {
                   <h3 className="text-card font-semibold text-gray-900 dark:text-white">{account.name}</h3>
                   <button
                     type="button"
-                    onClick={() => {
-                      setManagingAccountId(account.id);
-                      setActiveTab('manage');
-                    }}
+                    onClick={() => setManagingAccountId(managingAccountId === account.id ? null : account.id)}
+                    aria-expanded={managingAccountId === account.id}
                     className="text-body text-primary hover:text-secondary transition-colors"
                   >
-                    Manage holdings →
+                    {managingAccountId === account.id ? 'Done' : 'Manage holdings'}
                   </button>
                 </div>
                 <InvestmentMarketView
@@ -1442,57 +1444,23 @@ export default function Investments() {
                   updateError={quotedAccountId === account.id ? quoteError : null}
                   symbolErrors={quotedAccountId === account.id ? symbolErrors : undefined}
                 />
+                {managingAccountId === account.id && (
+                  <div className="mt-4 pt-4 border-t border-gray-200 dark:border-gray-700">
+                    <PortfolioManager
+                      holdings={accountHoldings}
+                      currency={account.currency}
+                      onAdd={(values) => handleAddHolding(account.id, account.currency, values)}
+                      onEdit={handleEditHolding}
+                      onDelete={handleDeleteHolding}
+                    />
+                  </div>
+                )}
               </div>
             );
           })}
         </div>
       )}
 
-      {/* Manage Tab */}
-      {activeTab === 'manage' && (
-        <div className="space-y-6">
-          {holdingsError && (
-            <div role="alert" className="bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-2xl p-4">
-              <p className="text-body text-red-700 dark:text-red-300">{holdingsError}</p>
-            </div>
-          )}
-
-          {/* Account Selector */}
-          <div className="bg-white dark:bg-gray-800 rounded-lg border border-line dark:border-gray-700 p-4">
-            <label htmlFor="manage-account" className="block text-body font-medium text-gray-700 dark:text-gray-300 mb-2">
-              Select investment account
-            </label>
-            <select
-              id="manage-account"
-              value={managingAccountId || ''}
-              onChange={(e) => setManagingAccountId(e.target.value)}
-              className="w-full px-4 py-2 border border-gray-300 dark:border-gray-600 rounded-lg focus:border-transparent dark:bg-gray-700 dark:text-white"
-            >
-              <option value="">Choose an account...</option>
-              {/* Grouped and alphabetised like every other account
-                  dropdown in the app. */}
-              <GroupedAccountOptions accounts={investmentAccounts} />
-            </select>
-          </div>
-
-          {managingAccountId && (() => {
-            const account = investmentAccounts.find(a => a.id === managingAccountId);
-            if (!account) return null;
-
-            return (
-              <div className="bg-white dark:bg-gray-800 rounded-lg border border-line dark:border-gray-700 p-6">
-                <PortfolioManager
-                  holdings={holdingsByAccount.get(account.id) ?? []}
-                  currency={account.currency}
-                  onAdd={(values) => handleAddHolding(account.id, account.currency, values)}
-                  onEdit={handleEditHolding}
-                  onDelete={handleDeleteHolding}
-                />
-              </div>
-            );
-          })()}
-        </div>
-      )}
 
       {/* Add Investment Modal */}
       <AddInvestmentModal

--- a/src/utils/__tests__/watchlistPositions.test.ts
+++ b/src/utils/__tests__/watchlistPositions.test.ts
@@ -48,7 +48,11 @@ describe('the arithmetic: a dummy position against a live price', () => {
   it('values the position and signs the gain', () => {
     const metrics = positionMetrics({ symbol: 'AAPL', shares: '10', startPrice: '250' }, '305.93');
     expect(metrics).not.toBeNull();
+    // Cost is what the position notionally went in at; value is what it is
+    // now; and cost + gain must equal value — the identity the card states.
+    expect(metrics?.cost.toFixed(2)).toBe('2500.00');
     expect(metrics?.value.toFixed(2)).toBe('3059.30');
+    expect(metrics?.cost.plus(metrics.gain).toFixed(2)).toBe(metrics?.value.toFixed(2));
     expect(metrics?.gain.toFixed(2)).toBe('559.30');
     expect(metrics?.gainPercent?.toFixed(2)).toBe('22.37');
   });

--- a/src/utils/watchlistPositions.ts
+++ b/src/utils/watchlistPositions.ts
@@ -75,6 +75,8 @@ export function normaliseWatchlist(raw: unknown): WatchedItem[] {
 }
 
 export interface PositionMetrics {
+  /** shares × start price — what the dummy position notionally cost. */
+  cost: DecimalInstance;
   /** shares × current price. */
   value: DecimalInstance;
   /** shares × (current − start). Signed — a loss is negative. */
@@ -105,6 +107,7 @@ export function positionMetrics(
   const value = shares.times(price);
   const gain = shares.times(price.minus(start));
   return {
+    cost: shares.times(start),
     value,
     gain,
     gainPercent: start.isZero() ? null : price.minus(start).dividedBy(start).times(100),


### PR DESCRIPTION
Two commits, one feature area. (The second was meant for its own branch; the name collided with a stale relic from the disconnect work, so it landed here — the content is closely related and the PR carries both honestly.)

## The card states the identity in reading order

**Cost** (shares × start), then **Current value** (renamed from "Value"), then **Gain** — cost + gain = value, checkable by eye. Cost and value are magnitudes and stay neutral; the gain carries the direction and the hues.

## The watchlist gains the app's arrangement controls

Default / Name / Value pills — both directions each — and a **grid ⇄ list** toggle, persisted. Sorting reads the displayed list only; mutations key by symbol, so reordering cannot misdirect a save. A card with no position sorts after every card with one in *both* value directions — "no position" is not "worth nothing".

## Name sorts flip everywhere

> "you cannot flip to Z–A, whereas you can go for largest or smallest value"

Accounts, Holdings and the watchlist all toggle on a second press, label following. Stored preferences widen compatibly.

## The two rings sit level

Asset Allocation caps its legend at five entries, so five rows is the tallest either legend gets — "Allocation by holding" reserves that height even holding one row, keeping the two cards level however many securities are priced.

## Manage is gone as a tab, kept as an act

It was the Portfolio tab with a dropdown instead of a scroll, while Portfolio ended in a button whose whole job was switching to Manage — *"kind of take you to the same place, just a different way."* The manager now opens **inline on the Portfolio card it concerns**: "Manage holdings" expands the card, "Done" closes it. `tab=manage` in an old URL lands on Portfolio rather than nowhere, and the empty-state copy that pointed at the dead tab points at the button that replaced it.

## Verification

lint (zero warnings) · `typecheck:strict` · 6,108 unit tests · `desktop:verify` — green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)