### PR TITLE
feat(alerts,charts): a card's alert reads spending, and the lazy chart barrel stops eating styles

### DIFF
--- a/docs/handovers/2026-08-16-to-claude-design-evening.md
+++ b/docs/handovers/2026-08-16-to-claude-design-evening.md
@@ -1,0 +1,90 @@
+# Handover back to Claude Design — 16 August, evening
+
+**Covers:** your dashboard second look (all four items), plus a day of
+owner-driven work your next pass will meet on every page. Supersedes nothing —
+the morning handover (§1–§9 of the fresh-ledger pass) stands; this continues
+from it.
+
+---
+
+## Your second look — all four landed
+
+**§1 — Net Worth Over Time was still drawing the empty frame.** Your catch was
+exact and the cause is worth having: our §3 guard was `snapshots.length === 0`,
+and a one-account ledger produces ONE snapshot, so it never fired — the 0–4
+y-axis you saw was recharts' default domain, array indices dressed as money.
+The guard is now `< 2` ("one point is not a time series", as you put it) and
+says so in words, same box height as its neighbours.
+
+**§2 — the dashed rectangle** was recharts drawing its own placeholder for an
+empty series — your hypothesis was right, and it means the same box appears
+anywhere that library is handed no data. Guarded at the call site with words,
+per your rule.
+
+**§3 — Key Account Balances £0.00 in income green** — fixed, and your "check
+the siblings" instruction has now paid twice: Bank Balance carried the same
+treatment. Red survives on a genuinely negative balance; it is the one
+direction a balance has.
+
+**§4 — the zero figures' colours** now follow the same condition as the
+arrows: hues render only when there is a direction to point.
+
+---
+
+## What changed since, that your next pass will see
+
+The owner drove a full day of changes. The ones with design weight:
+
+1. **Secured liabilities, both directions.** A liability names what it is held
+   against; the asset lists what is held against it. NO figures on the
+   Accounts-page labels (his ruling: "a name cannot be added up") but SIGNED
+   figures under each holding on Investments — where his correction to us is
+   one you will approve of: it shipped as a magnitude and he caught the same
+   loan reading `(£X)` on one page and `£X` on another. Coherence beat our
+   "magnitude under a liabilities heading" argument.
+
+2. **Drill-downs are modals now** — the Investments tiles (Net Contributions /
+   Total Return, two levels deep: accounts, then the transfers behind a
+   figure) and the Dashboard's What-you-own / What-you-owe, which simply wire
+   the `onSelect` your Accounts-page pattern already had.
+
+3. **The watchlist carries dummy positions** — shares + start price, Cost /
+   Current value / signed Gain per card. Gain wears the hues (direction);
+   Cost and Value stay neutral (magnitudes). Your rules, applied unprompted.
+
+4. **The count pills flip in dark** — navy circle/white digits on light,
+   light circle/navy digits on dark. In doing it we found `.bg-primary`
+   carries an `!important` in index.css that beats any `dark:` variant — the
+   same landmine class as the grey-text remap from yesterday's note. The pill
+   now uses the literal hex. **Flag for your survey list**: every
+   `bg-primary`+`dark:` pairing in the app is suspect for the same reason.
+
+5. **Charts: the lazy-loading barrel was eating styles.** Your §7 instinct
+   ("worth checking every…") generalises further than either of us knew.
+   `OptimizedCharts` hands recharts lazy stand-in children, and recharts
+   identifies `Cell` and `Tooltip` BY COMPONENT TYPE — so per-slice fills and
+   tooltip themes were silently ignored wherever that barrel was used: the
+   owner's Asset Allocation ring rendered all-grey under a correctly coloured
+   legend, with a black-on-white hover label in dark. Fixed by routing rings
+   through the one real-recharts wrapper, and a sweep found **seven** chart
+   tooltips app-wide with no dark theme (three of them carrying a stale
+   `contentStyle={{borderRadius}}` that LOOKED themed and set no colour —
+   which is why they survived every audit). All themed now.
+
+---
+
+## Still owed, from you
+
+`LargeTransactionAlertSettings.tsx:89` — the **preview** of a notification
+dressed in the warning amber pair. Third handover it has appeared in. It is a
+sample, not a warning; whether a sample may wear the warning's colour is a
+category call and category calls are yours. One sentence back settles it.
+
+---
+
+## State
+
+Everything above is merged and deployed to production. Lint zero-warnings,
+strict types, ~6,110 unit tests, desktop gates green. The owner now has a paid
+Twelve Data plan and LSE prices flow (pence handled — their `GBp` labelling
+matches Yahoo's, verified by his own curl before we routed a single symbol).

--- a/src/components/AccountSettingsModal.tsx
+++ b/src/components/AccountSettingsModal.tsx
@@ -678,12 +678,19 @@ export default function AccountSettingsModal({
             </p>
           </div>
 
-          {/* Low Balance Alert */}
+          {/* ─ THE SAME ALERT, READ IN THE ACCOUNT'S OWN DIRECTION ──────────
+              On a current account the worry is the balance FALLING; on a card
+              it is spending CLIMBING (owner, 16 August). One stored threshold
+              serves both: the user types the positive figure they think in —
+              "warn me at £10,000 of spend" — and utils/attentionItems knows a
+              card's spend is a negative balance, so the line is crossed at
+              −threshold. The words here flip with the type so the number the
+              user types is always the number they mean. */}
           <div>
             <div className="flex items-center justify-between mb-2">
               {/* Not a <label>: the control is a switch button, named via aria-labelledby */}
               <span id="low-balance-alert-label" className="block text-sm font-medium text-gray-700 dark:text-gray-300">
-                Low Balance Alert
+                {isCardAccountType(formData.type) ? 'Spending Alert' : 'Low Balance Alert'}
               </span>
               <ToggleSwitch
                 checked={!!formData.lowBalanceAlertEnabled}
@@ -704,13 +711,15 @@ export default function AccountSettingsModal({
             {formData.isActive && formData.lowBalanceAlertEnabled && (
               <div className="mt-1">
                 <label htmlFor="low-balance-threshold" className="block text-xs text-gray-500 dark:text-gray-400 mb-1">
-                  Alert when balance falls below
+                  {isCardAccountType(formData.type)
+                    ? 'Alert when spending goes above'
+                    : 'Alert when balance falls below'}
                 </label>
                 <MoneyInput
                   id="low-balance-threshold"
                   value={formData.lowBalanceThreshold}
                   onChange={(value) => updateField('lowBalanceThreshold', value)}
-                  placeholder="e.g. 500"
+                  placeholder={isCardAccountType(formData.type) ? 'e.g. 10,000' : 'e.g. 500'}
                   className="w-full px-3 py-2 bg-white dark:bg-gray-800 border border-gray-300/50 dark:border-gray-600/50 rounded-xl focus:border-transparent dark:text-white"
                 />
               </div>

--- a/src/components/dashboard/reportWidgets/DashboardReportWidgets.tsx
+++ b/src/components/dashboard/reportWidgets/DashboardReportWidgets.tsx
@@ -13,7 +13,7 @@ import {
 } from 'recharts';
 import { useApp } from '../../../contexts/AppContextSupabase';
 import { useCurrencyDecimal } from '../../../hooks/useCurrencyDecimal';
-import { categoricalColor, MAX_CATEGORICAL_SERIES, useCategoricalRamp, SEMANTIC_SERIES } from '../../charts/chartColors';
+import { categoricalColor, MAX_CATEGORICAL_SERIES, useCategoricalRamp, SEMANTIC_SERIES, useChartTooltipStyle } from '../../charts/chartColors';
 import { singlePointDot } from '../../charts/singlePointDots';
 import { buildMonthlyTrend } from '../../../utils/monthlyTrend';
 import { buildNetWorthSnapshots, netWorthPointToken } from '../../../utils/netWorthSeries';
@@ -80,6 +80,9 @@ export function NetWorthWidget({ picker, pin }: {
   const { accounts: openAccounts, transactions } = useApp();
   const { formatCurrency } = useCurrencyDecimal();
   const openReport = useReportDrill();
+  // Recharts' default tooltip is black-on-white whatever the page's mode —
+  // the themed style is the difference between a label and a glare in dark.
+  const chartTooltipStyle = useChartTooltipStyle();
 
   /*
    * THE LINE HAS TO SURVIVE THE GROUND IT IS DRAWN ON.
@@ -161,7 +164,7 @@ export function NetWorthWidget({ picker, pin }: {
           >
             <XAxis dataKey="label" tick={{ fill: '#6B7280', fontSize: 10 }} minTickGap={32} />
             <YAxis tick={{ fill: '#6B7280', fontSize: 10 }} tickFormatter={compactTick} width={44} />
-            <Tooltip formatter={(v: number | string) => formatCurrency(typeof v === 'number' ? v : Number(v))} />
+            <Tooltip contentStyle={chartTooltipStyle} formatter={(v: number | string) => formatCurrency(typeof v === 'number' ? v : Number(v))} />
             <Line type="monotone" dataKey="netWorth" name="Net Worth" stroke={lineStroke} strokeWidth={2} dot={singlePointDot(snapshots, lineStroke)} isAnimationActive={false} />
           </LineChart>
         </ResponsiveContainer>
@@ -180,6 +183,9 @@ export function IncomeExpenseTrendWidget({ picker, pin }: {
   const { transactions, transactionSplits, categories } = useApp();
   const { formatCurrency } = useCurrencyDecimal();
   const openReport = useReportDrill();
+  // Recharts' default tooltip is black-on-white whatever the page's mode —
+  // the themed style is the difference between a label and a glare in dark.
+  const chartTooltipStyle = useChartTooltipStyle();
   const { range } = picker;
 
   const data = useMemo(() => {
@@ -242,7 +248,7 @@ export function IncomeExpenseTrendWidget({ picker, pin }: {
             <CartesianGrid strokeDasharray="3 3" stroke="rgba(107, 114, 128, 0.2)" />
             <XAxis dataKey="month" tick={{ fill: '#6B7280', fontSize: 10 }} minTickGap={32} />
             <YAxis tick={{ fill: '#6B7280', fontSize: 10 }} tickFormatter={compactTick} width={44} />
-            <Tooltip formatter={(v: number | string) => formatCurrency(typeof v === 'number' ? v : Number(v))} />
+            <Tooltip contentStyle={chartTooltipStyle} formatter={(v: number | string) => formatCurrency(typeof v === 'number' ? v : Number(v))} />
             <Line type="monotone" dataKey="income" name="Income" stroke={SEMANTIC_SERIES.income} strokeWidth={2} dot={singlePointDot(data, SEMANTIC_SERIES.income)} isAnimationActive={false} />
             <Line type="monotone" dataKey="expenses" name="Expenses" stroke={SEMANTIC_SERIES.expense} strokeWidth={2} dot={singlePointDot(data, SEMANTIC_SERIES.expense)} isAnimationActive={false} />
           </LineChart>
@@ -262,6 +268,9 @@ export function ExpenseCategoriesWidget({ picker, pin }: {
   const { transactions, transactionSplits, categories } = useApp();
   const { formatCurrency } = useCurrencyDecimal();
   const openReport = useReportDrill();
+  // Recharts' default tooltip is black-on-white whatever the page's mode —
+  // the themed style is the difference between a label and a glare in dark.
+  const chartTooltipStyle = useChartTooltipStyle();
   const { range } = picker;
   // The shared ramp — see charts/chartColors. The copy that used to live in
   // this file was byte-identical to three others and drifted from a fourth.
@@ -364,7 +373,7 @@ export function ExpenseCategoriesWidget({ picker, pin }: {
                     <Cell key={entry.name} fill={categoricalColor(ramp, index)} />
                   ))}
                 </Pie>
-                <Tooltip formatter={(v: number | string) => formatCurrency(typeof v === 'number' ? v : Number(v))} />
+                <Tooltip contentStyle={chartTooltipStyle} formatter={(v: number | string) => formatCurrency(typeof v === 'number' ? v : Number(v))} />
               </RechartsPieChart>
             </ResponsiveContainer>
           </div>

--- a/src/pages/Investments.tsx
+++ b/src/pages/Investments.tsx
@@ -10,7 +10,12 @@ import InvestmentMarketView from '../components/InvestmentMarketView';
 import PortfolioManager, { type HoldingFormValues } from '../components/PortfolioManager';
 import StockWatchlist from '../components/StockWatchlist';
 // Use optimized lazy-loaded charts to reduce bundle size
-import { PieChart as RePieChart, Pie, Cell, ResponsiveContainer, Tooltip, LineChart, Line, XAxis, YAxis, CartesianGrid } from '../components/charts/OptimizedCharts';
+import { ResponsiveContainer, LineChart, Line, XAxis, YAxis, CartesianGrid } from '../components/charts/OptimizedCharts';
+// Tooltip comes from recharts ITSELF, not the lazy barrel: recharts identifies
+// a chart's Tooltip child by component type, and the lazy stand-in is a type
+// it has never met — which is how this page's ring tooltips stayed unthemed
+// (16 August). A real Tooltip inside the (equally real) chart type-matches.
+import { Tooltip } from 'recharts';
 import { useCurrencyDecimal } from '../hooks/useCurrencyDecimal';
 import { toDecimal } from '../utils/decimal';
 import { useLocalStorage } from '../hooks/useLocalStorage';
@@ -20,6 +25,7 @@ import { formatDecimal } from '../utils/decimal-format';
 import PageWrapper from '../components/PageWrapper';
 import ToggleSwitch from '../components/ui/ToggleSwitch';
 import { buildPortfolioSummary, buildPortfolioHistory } from '../utils/portfolioSummary';
+import { PieChart as DashboardPieChart } from '../components/charts/DashboardCharts';
 import { buildHoldingAllocation } from '../utils/holdingAllocation';
 // THE SEAM, not the service. This page called `InvestmentService` — and, through
 // it, a Supabase client — directly until slice 31, with a `userIdService` lookup
@@ -1212,27 +1218,29 @@ export default function Investments() {
               {/* h-44, not h-64: this ring carried a twelve-row legend when it
                   was sized, and carries five now. The height it was keeping is
                   what "Allocation by holding" moved into. */}
+              {/* ─ THE WRAPPER, NOT RAW RECHARTS CHILDREN (owner, 16 August:
+                  "the pie chart is all one colour, not the same as the
+                  legend", and the hover label was black in dark mode).
+
+                  Recharts identifies Pie, Cell and Tooltip children BY
+                  COMPONENT TYPE, and OptimizedCharts hands it lazy stand-ins
+                  it does not recognise — so every Cell's fill and the
+                  tooltip's themed style were silently ignored: default-grey
+                  slices under a correctly coloured legend, and recharts' own
+                  black-on-white tooltip. The Dashboard's donuts never had the
+                  bug because they go through DashboardCharts' PieChart, where
+                  the recharts elements are built inside one module and the
+                  types match. Same wrapper here now, both rings. */}
               <div className="h-44">
                 <ResponsiveContainer width="100%" height="100%">
-                  <RePieChart>
-                    <Pie
-                      data={allocationData}
-                      cx="50%"
-                      cy="50%"
-                      innerRadius="60%"
-                      outerRadius="90%"
-                      paddingAngle={3}
-                      dataKey="value"
-                    >
-                      {allocationData.map((_, index) => (
-                        <Cell key={`cell-${index}`} fill={categoricalColor(ramp, index)} />
-                      ))}
-                    </Pie>
-                    <Tooltip
-                      formatter={(value) => formatCurrency(toDecimal(Number(value)))}
-                      contentStyle={chartTooltipStyle}
-                    />
-                  </RePieChart>
+                  <DashboardPieChart
+                    data={allocationData}
+                    innerRadius={true}
+                    colors={ramp}
+                    formatter={(value: number) => formatCurrency(toDecimal(value))}
+                    contentStyle={chartTooltipStyle}
+                    aria-label="Ring chart of asset allocation by account"
+                  />
                 </ResponsiveContainer>
               </div>
               <div className="mt-4 space-y-2">
@@ -1308,25 +1316,15 @@ export default function Investments() {
                   one. Third time this has bitten in this session. */}
               <div className="h-44">
                 <ResponsiveContainer width="100%" height="100%">
-                  <RePieChart>
-                    <Pie
-                      data={holdingSlices}
-                      cx="50%"
-                      cy="50%"
-                      innerRadius="60%"
-                      outerRadius="90%"
-                      paddingAngle={3}
-                      dataKey="value"
-                    >
-                      {holdingSlices.map((slice, index) => (
-                        <Cell key={slice.name} fill={categoricalColor(ramp, index)} />
-                      ))}
-                    </Pie>
-                    <Tooltip
-                      formatter={(value) => formatCurrency(toDecimal(Number(value)))}
-                      contentStyle={chartTooltipStyle}
-                    />
-                  </RePieChart>
+                  {/* Same wrapper as the ring above, same reason. */}
+                  <DashboardPieChart
+                    data={holdingSlices}
+                    innerRadius={true}
+                    colors={ramp}
+                    formatter={(value: number) => formatCurrency(toDecimal(value))}
+                    contentStyle={chartTooltipStyle}
+                    aria-label="Ring chart of allocation by holding"
+                  />
                 </ResponsiveContainer>
               </div>
 

--- a/src/pages/reports/IncomeSpendingOverTimeReport.tsx
+++ b/src/pages/reports/IncomeSpendingOverTimeReport.tsx
@@ -20,7 +20,7 @@ import ReportCumulativeToggle from '../../components/reports/ReportCumulativeTog
 import UncategorisedReviewBand from '../../components/reports/UncategorisedReviewBand';
 import { buildMonthlyTrend } from '../../utils/monthlyTrend';
 import { toCumulativeTrend } from '../../utils/cumulativeSeries';
-import { SEMANTIC_SERIES } from '../../components/charts/chartColors';
+import { SEMANTIC_SERIES, useChartTooltipStyle } from '../../components/charts/chartColors';
 import { singlePointDot } from '../../components/charts/singlePointDots';
 import { toDecimal } from '../../utils/decimal';
 import { formatDecimal } from '../../utils/decimal-format';
@@ -59,6 +59,8 @@ export default function IncomeSpendingOverTimeReport({ picker, focus }: ReportVi
   const monthFocus = useArrivalRowFocus(focus);
   const { accounts, categories, rows, flows } = useReportDataset(picker, selection.scope);
   const { formatCurrency } = useCurrencyDecimal();
+  // Recharts' default tooltip is black-on-white whatever the mode.
+  const chartTooltipStyle = useChartTooltipStyle();
   const [drill, setDrill] = useState<ReportDrillTarget | null>(null);
   const chartRef = useRef<HTMLDivElement>(null);
   // Lines or bars — same data, same drill-in; the choice is persisted.
@@ -216,10 +218,10 @@ export default function IncomeSpendingOverTimeReport({ picker, focus }: ReportVi
                 <XAxis dataKey="month" tick={{ fill: '#6B7280', fontSize: 12 }} minTickGap={24} />
                 <YAxis tick={{ fill: '#6B7280', fontSize: 12 }} tickFormatter={compactTick} width={70} />
                 <Tooltip
+                  contentStyle={chartTooltipStyle}
                   formatter={(value: number | string) =>
                     formatCurrency(typeof value === 'number' ? value : Number(value))
                   }
-                  contentStyle={{ borderRadius: '8px' }}
                 />
                 <Legend />
                 {chartType === 'bar' ? (

--- a/src/pages/reports/PeriodComparisonReport.tsx
+++ b/src/pages/reports/PeriodComparisonReport.tsx
@@ -7,7 +7,7 @@ import ReportAccountMultiSelect from '../../components/reports/ReportAccountMult
 import ReportDrillModal, { type ReportDrillTarget } from '../../components/reports/ReportDrillModal';
 import ReportExportBar from '../../components/reports/ReportExportBar';
 import UncategorisedReviewBand from '../../components/reports/UncategorisedReviewBand';
-import { SEMANTIC_SERIES } from '../../components/charts/chartColors';
+import { SEMANTIC_SERIES, useChartTooltipStyle } from '../../components/charts/chartColors';
 import { computeIncomeExpense } from '../../utils/incomeExpense';
 import {
   buildPeriodComparison,
@@ -60,6 +60,8 @@ export default function PeriodComparisonReport({ picker }: ReportViewProps): Rea
   const { accounts, categories, accountTransactions, transactionSplits, rows, flows } =
     useReportDataset(picker, selection.scope);
   const { formatCurrency } = useCurrencyDecimal();
+  // Recharts' default tooltip is black-on-white whatever the mode.
+  const chartTooltipStyle = useChartTooltipStyle();
   const [drill, setDrill] = useState<ReportDrillTarget | null>(null);
   const chartRef = useRef<HTMLDivElement>(null);
   const [basis, setBasis] = useState<ComparisonBasis>(() =>
@@ -351,11 +353,11 @@ export default function PeriodComparisonReport({ picker }: ReportViewProps): Rea
                       interval={0}
                     />
                     <Tooltip
+                  contentStyle={chartTooltipStyle}
                       formatter={(value: number | string) =>
                         formatCurrency(typeof value === 'number' ? value : Number(value))
                       }
-                      contentStyle={{ borderRadius: '8px' }}
-                    />
+                        />
                     {/* Recharts derives its own legend from each series' single
                         fill, which this chart does not have — so the legend is
                         drawn from what the bars actually are. */}

--- a/src/pages/reports/SpendingByCategoryReport.tsx
+++ b/src/pages/reports/SpendingByCategoryReport.tsx
@@ -13,7 +13,7 @@ import { formatDecimal } from '../../utils/decimal-format';
 import { ARRIVAL_ROW_CLASS, useArrivalRowFocus } from '../../hooks/useArrivalFocus';
 import { PERIOD_LABELS } from '../../hooks/usePeriod';
 import type { ReportViewProps } from './types';
-import { categoricalColor, useCategoricalRamp } from '../../components/charts/chartColors';
+import { categoricalColor, useCategoricalRamp, useChartTooltipStyle } from '../../components/charts/chartColors';
 
 /**
  * "Spending by category" — where the money went, ranked.
@@ -41,6 +41,8 @@ export default function SpendingByCategoryReport({ picker, focus }: ReportViewPr
   const categoryFocus = useArrivalRowFocus(focus);
   const { accounts, categories, rows, flows } = useReportDataset(picker, selection.scope);
   const { formatCurrency } = useCurrencyDecimal();
+  // Recharts' default tooltip is black-on-white whatever the mode.
+  const chartTooltipStyle = useChartTooltipStyle();
   const [drill, setDrill] = useState<ReportDrillTarget | null>(null);
   const chartRef = useRef<HTMLDivElement>(null);
 
@@ -143,6 +145,7 @@ export default function SpendingByCategoryReport({ picker, focus }: ReportViewPr
                   ))}
                 </Pie>
                 <Tooltip
+                  contentStyle={chartTooltipStyle}
                   formatter={(value: number | string) =>
                     formatCurrency(typeof value === 'number' ? value : Number(value))
                   }

--- a/src/pages/reports/SpendingByPayeeReport.tsx
+++ b/src/pages/reports/SpendingByPayeeReport.tsx
@@ -12,7 +12,7 @@ import { formatDecimal } from '../../utils/decimal-format';
 import { PERIOD_LABELS } from '../../hooks/usePeriod';
 import type { ReportViewProps } from './types';
 import { preferences } from '../../services/preferencesService';
-import { categoricalColor, useCategoricalRamp } from '../../components/charts/chartColors';
+import { categoricalColor, useCategoricalRamp, useChartTooltipStyle } from '../../components/charts/chartColors';
 import { getDateLocale } from '../../utils/dateFormatter';
 
 /**
@@ -40,6 +40,8 @@ export default function SpendingByPayeeReport({ picker }: ReportViewProps): Reac
   const selection = useReportAccountSelection();
   const { accounts, categories, rows, flows } = useReportDataset(picker, selection.scope);
   const { formatCurrency } = useCurrencyDecimal();
+  // Recharts' default tooltip is black-on-white whatever the mode.
+  const chartTooltipStyle = useChartTooltipStyle();
   const [drill, setDrill] = useState<ReportDrillTarget | null>(null);
   const chartRef = useRef<HTMLDivElement>(null);
   const [side, setSide] = useState<'expense' | 'income'>(() =>
@@ -158,10 +160,10 @@ export default function SpendingByPayeeReport({ picker }: ReportViewProps): Reac
                   interval={0}
                 />
                 <Tooltip
+                  contentStyle={chartTooltipStyle}
                   formatter={(value: number | string) =>
                     formatCurrency(typeof value === 'number' ? value : Number(value))
                   }
-                  contentStyle={{ borderRadius: '8px' }}
                 />
                 <Bar
                   dataKey="value"

--- a/src/utils/attentionItems.test.ts
+++ b/src/utils/attentionItems.test.ts
@@ -104,6 +104,40 @@ describe('buildAttentionItems — low balance', () => {
   });
 });
 
+describe('buildAttentionItems — card spending (owner, 16 August)', () => {
+  /*
+   * On a card the SAME stored threshold means spending, not balance. The user
+   * types the positive figure they think in — £1,000 of spend — and the line
+   * is crossed at −1,000, because spend on a card IS a negative balance.
+   *
+   * This also repairs the old reading, which was near-useless on a card:
+   * "balance below £500" is almost always true of an account that lives
+   * negative, so an armed card warned forever.
+   */
+  const armedCard = account({
+    id: 'card-s',
+    name: 'Sample Card',
+    type: 'credit',
+    lowBalanceAlertEnabled: true,
+    lowBalanceThreshold: 1000,
+  });
+
+  it('warns once spending crosses the figure the user typed', () => {
+    const [item] = build({ accounts: [armedCard], balances: { 'card-s': -1200 } });
+    expect(item.kind).toBe('card-spending');
+    expect(item.reason).toBe('Spending at £1200.00 — above the £1000.00 you asked to be warned at.');
+  });
+
+  it('stays quiet below the line — including at zero and in credit', () => {
+    expect(build({ accounts: [armedCard], balances: { 'card-s': -1000 } })).toEqual([]);
+    expect(build({ accounts: [armedCard], balances: { 'card-s': -999.99 } })).toEqual([]);
+    expect(build({ accounts: [armedCard], balances: { 'card-s': 0 } })).toEqual([]);
+    // In credit: the old semantics ("balance below £1,000") would have fired
+    // here, on the one person who owes nothing.
+    expect(build({ accounts: [armedCard], balances: { 'card-s': 200 } })).toEqual([]);
+  });
+});
+
 describe('buildAttentionItems — credit utilisation', () => {
   const card = account({ id: 'card-1', name: 'Sample Card', type: 'credit', creditLimit: 1000 });
 
@@ -126,16 +160,25 @@ describe('buildAttentionItems — credit utilisation', () => {
     expect(build({ accounts: [card], balances: { 'card-1': -701 } })).toHaveLength(1);
   });
 
-  it('never joins a low-balance row — one account, one row', () => {
+  it('never joins a spending row — one account, one row', () => {
+    /*
+     * The invariant is unchanged: one account raises at most one row, and the
+     * threshold alert outranks utilisation. What changed (16 August) is the
+     * KIND a card's threshold alert carries — spending, not low-balance —
+     * because on a card the same stored figure means "warn me at this much
+     * spend". The fixture's old −100 threshold was itself an artefact of the
+     * balance reading; a spend threshold is the positive number the user
+     * types.
+     */
     const armedCard = account({
       ...card,
       lowBalanceAlertEnabled: true,
-      lowBalanceThreshold: -100,
+      lowBalanceThreshold: 100,
     });
     const items = build({ accounts: [armedCard], balances: { 'card-1': -900 } });
 
     expect(items).toHaveLength(1);
-    expect(items[0].kind).toBe('low-balance');
+    expect(items[0].kind).toBe('card-spending');
   });
 });
 

--- a/src/utils/attentionItems.ts
+++ b/src/utils/attentionItems.ts
@@ -1,6 +1,7 @@
 import type { Account } from '../types';
 import type { AutoSyncMode } from './bankAutoSync';
 import { toDecimal } from './decimal';
+import { isCardAccountType } from './accountNumberInput';
 
 /**
  * "Needs Your Attention": WHY each account is on the list, in words, and where
@@ -17,7 +18,7 @@ import { toDecimal } from './decimal';
  * below are tested at fixed instants rather than against the wall clock.
  */
 
-export type AttentionKind = 'low-balance' | 'credit-utilisation' | 'feed-stale' | 'feed-reauth';
+export type AttentionKind = 'low-balance' | 'card-spending' | 'credit-utilisation' | 'feed-stale' | 'feed-reauth';
 
 export interface AttentionItem {
   account: Account;
@@ -141,20 +142,41 @@ function buildAccountItem(
   balance: number,
   formatMoney: AttentionInput['formatMoney']
 ): AttentionItem | null {
+  /*
+   * ON A CARD THE SAME NUMBER MEANS SPENDING (owner, 16 August). The user
+   * types the positive figure they think in — "warn me at £10,000 of spend" —
+   * and the app knows spend is a negative balance, so the line is crossed at
+   * −threshold. One stored column, one comparison, two readings.
+   *
+   * This also repairs the old semantics on cards, which were near-useless:
+   * "balance below £500" is almost always TRUE of an account that lives
+   * negative, so a card with this alert on was a card that warned forever.
+   */
+  const isCard = isCardAccountType(account.type);
   if (
     account.lowBalanceAlertEnabled &&
     account.lowBalanceThreshold != null &&
-    balance < account.lowBalanceThreshold
+    balance < (isCard ? -account.lowBalanceThreshold : account.lowBalanceThreshold)
   ) {
-    return {
-      account,
-      kind: 'low-balance',
-      reason:
-        `Down to ${formatMoney(balance, account.currency)} — ` +
-        `below the ${formatMoney(account.lowBalanceThreshold, account.currency)} you asked to be warned at.`,
-      href: `/accounts/${account.id}`,
-      actionLabel: 'Open register',
-    };
+    return isCard
+      ? {
+          account,
+          kind: 'card-spending',
+          reason:
+            `Spending at ${formatMoney(Math.abs(balance), account.currency)} — ` +
+            `above the ${formatMoney(account.lowBalanceThreshold, account.currency)} you asked to be warned at.`,
+          href: `/accounts/${account.id}`,
+          actionLabel: 'Open register',
+        }
+      : {
+          account,
+          kind: 'low-balance',
+          reason:
+            `Down to ${formatMoney(balance, account.currency)} — ` +
+            `below the ${formatMoney(account.lowBalanceThreshold, account.currency)} you asked to be warned at.`,
+          href: `/accounts/${account.id}`,
+          actionLabel: 'Open register',
+        };
   }
 
   // A card IN CREDIT is not using any of its limit. The previous rule took the


### PR DESCRIPTION
Two owner requests from 16 August, plus the refreshed Design handover.

## 1. Credit-card Spending Alert

The low-balance alert read every account the same way: warn when balance drops below the threshold. On a credit card that reading is near-useless — a card lives below zero, so "balance below £500" is almost always true. Now `isCardAccountType` flips the direction: the user types the positive spend figure they care about (the settings block retitles itself **Spending Alert**, helper text "Alert when spending goes above", placeholder `e.g. 10,000`) and the app knows that means **balance ≤ −threshold**. One stored field serves both readings; nothing migrates.

The attention row speaks the user's dialect back: *"Spending at £X — above the £Y you asked to be warned at."*

Tests cover the boundary: warns at spend past the threshold, quiet exactly at it, just under it, at zero, and in credit. The old "never joins a low-balance row" invariant test was rewritten for the new kind — its previous negative-threshold fixture was an artefact of the balance reading, and the file records why.

## 2. The all-grey pie and the black tooltip

recharts identifies `Cell` and `Tooltip` children **by component type**. `OptimizedCharts`' lazy stand-ins are not those types, so per-slice fills and tooltip styles were silently ignored wherever that barrel supplied them — the Asset Allocation ring rendered one colour under a correctly coloured legend, with a black-on-white hover label in dark mode.

- Both Investments rings now render through `DashboardCharts`' `PieChart` wrapper — real recharts composed in one module, which is exactly why the Dashboard donuts never had the bug.
- The Investments line chart imports `Tooltip` directly from `recharts`, with a comment explaining the type-matching constraint.
- A sweep themed **seven** tooltips app-wide via `useChartTooltipStyle` (three report pages carried a radius-only `contentStyle` that *looked* themed and set no colour — why they survived every audit).

## 3. Handover

`docs/handovers/2026-08-16-to-claude-design-evening.md` — the reply to Design's second look (all four landed, with causes) plus the day's design-relevant changes, including the recharts type-matching finding flagged for their survey list.

## Verified

- `npm run lint` — 0 warnings
- `npm run typecheck:strict` — clean
- Full unit suite — **6,110 passed** (397 files)
- `npm run desktop:verify` — PASS, bundle 4080.0 KiB raw against the 4320 budget

🤖 Generated with [Claude Code](https://claude.com/claude-code)