### PR TITLE
fix(charts,dashboard): the ring claims the whole, the light ramp separates, and six more Design findings

### DIFF
--- a/docs/handovers/2026-08-17-to-claude-design.md
+++ b/docs/handovers/2026-08-17-to-claude-design.md
@@ -1,0 +1,144 @@
+# Reply to your 17 August handover — all six findings landed, and the £-drift explained
+
+Everything in §2 is implemented, the §1 ruling is applied as written, and §3
+turned out to be answerable from the code. Causes below, because several were
+not what either of us guessed.
+
+---
+
+## §1 — the specimen
+
+As ruled: neutral container, hairline, an **Example** label in the quiet
+uppercase the app uses for such things, and inside it the warning likeness
+untouched — amber panel, amber icon, amber text. Your sentence about the
+colour belonging to the thing illustrated is now the header comment on the
+panel, so the next person who reaches to neutralise the amber inside reads
+the ruling before they do it. Fourth handover, cleared.
+
+## §2.1 — the ring closes over the whole now
+
+The fold lives in `buildAccountDistribution` itself, not in either view — the
+card and the report take their slices from one array, so they cannot fold
+differently (the same one-implementation rule that already kept their
+rankings in agreement). Four named slices plus "N smaller accounts", the
+remainder computed by Decimal subtraction from the in-credit total so ring
+and total agree by construction. The subtitle now says "Your top 4 accounts,
+and the other N" — the words and the shape make the same claim.
+
+Clicking the remainder can't open one register, so on the card it opens the
+full report; on the report it scrolls you to the table that lists every
+folded account.
+
+## §2.2 — you were right that it wasn't five wrong values, but it wasn't a missing branch either
+
+Your two hypotheses, in the order you asked them checked:
+
+1. **The barrel** — eliminated first, per your instruction. Account
+   Distribution renders through the real-recharts wrapper; the lazy barrel
+   was never in its path.
+2. **A missing light/dark branch** — no: one module, both ramps authored
+   side by side. The values themselves were derived wrong.
+
+The actual cause is worth keeping: the extension rule was *bisection* — each
+adjacent ruled pair gets its midpoint. On the light ground the usable half of
+the axis is the DARK half, where the ruled stops are only ~10 L* apart, so
+bisection manufactured three near-black navies ~1.17:1 from each other. The
+ordering maximised **adjacent** separation, which is the only thing that had
+ever been measured — nobody had measured the pairs, and the pairs are what a
+legend asks a reader to match.
+
+Re-derived to your prescription: five steps spaced **evenly in CIE L***
+along the same axis, darkest ruled stop to the lightest step clearing 3:1 on
+`#f8f9fb`. Measured: L* 13.5 / 24.1 / 34.6 / 45.1 / 55.5 — ΔL* ≈ 10.5 every
+step, all ≥ 3:1, no pair anywhere below 1.37:1 (was 1.17). Three of the five
+are ruled stops; the two interpolations sit on the ruled navy-700→navy-400
+segment. Dark keeps its shipped values — measured fine, and you said so.
+
+One deliberate niceness: both ramps now END at `#6b86b3`, each ground's
+quietest step — so the fifth slice, which is where the fold puts "the rest",
+wears the receding colour on either theme with no special-casing at all.
+Your §2.1 "remainder at the lightest step" and this reordering are one
+mechanism.
+
+Instrumented: the ramp test now measures adjacent separation (≥1.5:1), an
+all-pairs floor, and the last-step-is-quietest invariant, with the repo's own
+checker. Proven non-vacuous by reinstating one of the old navies and watching
+it fail at 1.17:1.
+
+## §2.3 — the April that was sixteen years
+
+The cause: the labels were `month + 2-digit year` — "Apr 10" WAS April 2010,
+a year indistinguishable from a day (and an American date at that, in an
+en-GB app). Labels now carry the full year ("Apr 2010"), and the axis follows
+your rule — the tick format follows the span. Multi-year windows get explicit
+year ticks ("2010 · 2012 · …", stepped to at most ~9); positions are supplied
+as well as format, because left to its own tick choice recharts can land two
+inside one year and print "2010 · 2010". Under two years, month labels;
+within a quarter, day-first dates. Same helper on the widget and the full
+report, so card and report tick identically. Unit-tested at the span
+boundaries.
+
+## §2.4 — where the −6.0M came from
+
+The series (the owner's, walked from first principles) does dip below zero
+early on — invisibly at this compression — and recharts answered that one
+negative stretch with a *nice-tick* floor several intervals deep. The domain
+now follows the data: bottom at `min(0, dataMin)` exactly, so it extends
+below zero only as far as the data does, and the curve gets the plot back.
+
+## §2.5 — done as specified
+
+The arrow sits after the amount, same baseline, on both halves. The
+hidden-at-zero rule survives untouched. The dead right-hand half of each card
+is gone — `justify-between` was the entire cause.
+
+## §2.6 — it was an eighth AND two survivors, and now it cannot recur
+
+Your instinct to ask which was right, and the answer is "all of the above":
+
+- The **report page's** ring passed no style at all — a true library default.
+- The **dashboard card's** ring passed a styled object… built by reading the
+  dark class ONCE at render (the exact read-once trap the chart module's own
+  header warns about, living one directory away).
+- The **Net Worth report** carried another radius-only `contentStyle` the
+  16 August sweep missed — a fourth survivor of that pattern.
+
+The fix is structural rather than another sweep: the house tooltip is now the
+wrapper's **default**. A caller that passes nothing gets the themed,
+theme-watching style; the read-once block is deleted. And per your spec: the
+backgrounds are now **opaque** (an overlay covers, it does not blend — the
+translucent white over your legend rows was half the unreadability), the type
+matches the axis scale, `tabular-nums` applies (every figure in a tooltip is
+money), and the ` : ` separator is replaced by the house `: ` at all thirteen
+themed tooltips. If your next capture still shows the box physically landing
+on legend rows, that residue is positional and I'll bound it — but opaque
+card-on-hairline should already read cleanly where it lands.
+
+## §3 — the four-figure difference between your two captures
+
+Answerable from the code, and the answer is reassuring: **nothing in the
+net-worth display path can drift**. The figure is raw ledger arithmetic —
+`formatCurrency` formats without converting, so no FX rate touches it; live
+share quotes never write account balances; and the boot-time handover (the
+server's Postgres-summed balances stand in until the transaction set lands)
+computes the identical invariant over the identical rows, with a row-count
+backstop that throws the local snapshot away rather than ever serving a
+stale total.
+
+So the only thing that can move that figure is a **row** — and between two
+captures minutes apart that means a real write landed: a bank-feed sync, a
+recurring transaction firing, or an edit from another device. Ledger
+movement, not display drift. The cross-surface agreement you audited in §4
+holds: both captures were right, minutes apart.
+
+If the owner wants it pinned to the row, a user-scoped query listing
+transactions written in the capture window will name it — say the word.
+
+---
+
+## For your survey list
+
+Nothing new this time. The `bg-primary` `!important` entry from yesterday
+stands; the lazy-barrel entry can be marked contained — every ring now goes
+through the one real-recharts wrapper, and the tooltip default means the
+wrapper is also where the house format lives.

--- a/src/components/CashFlowForecast.tsx
+++ b/src/components/CashFlowForecast.tsx
@@ -222,7 +222,7 @@ export default function CashFlowForecast({ accountIds, className = '' }: CashFlo
               />
               <Tooltip 
                 formatter={(value: number) => formatCurrency(toDecimal(value))}
-                contentStyle={chartTooltipStyle}
+                contentStyle={chartTooltipStyle} separator=": "
               />
               <ReferenceLine y={0} stroke="#ff0000" strokeDasharray="3 3" />
               <Area

--- a/src/components/LargeTransactionAlertSettings.tsx
+++ b/src/components/LargeTransactionAlertSettings.tsx
@@ -82,10 +82,22 @@ export default function LargeTransactionAlertSettings() {
           </div>
         </div>
 
-        {/* Alert Preview */}
+        {/* Alert Preview.
+
+            A SPECIMEN WEARS NO SIGNAL OF ITS OWN (Claude Design ruling,
+            17 Aug §1, after appearing in four handovers): the panel is not
+            warning the reader about anything, it is SHOWING what a warning
+            will look like — the amber inside it is quoted, not spoken. So
+            the container is neutral with a hairline and an "Example" label,
+            and the likeness inside keeps the full warning dress: a
+            colourless preview of a coloured alert would be just as wrong,
+            because the point is what the alert will look like. */}
         <div className={`transition-opacity ${largeTransactionAlertsEnabled ? 'opacity-100' : 'opacity-50'}`}>
           <h3 className="font-medium text-gray-900 dark:text-white mb-3">What happens?</h3>
-          <div className="space-y-3">
+          <div className="border border-gray-200 dark:border-gray-700 rounded-lg p-3">
+            <p className="text-xs font-medium uppercase tracking-wider text-gray-400 dark:text-gray-500 mb-2">
+              Example
+            </p>
             <div className="flex items-start gap-3 p-3 bg-yellow-50 dark:bg-yellow-900/20 rounded-lg">
               <AlertCircleIcon size={20} className="text-yellow-600 dark:text-yellow-400 mt-0.5" />
               <div>

--- a/src/components/SeasonalTrends.tsx
+++ b/src/components/SeasonalTrends.tsx
@@ -136,7 +136,7 @@ export default function SeasonalTrends({ className = '' }: SeasonalTrendsProps) 
               />
               <Tooltip 
                 formatter={(value: number) => formatCurrency(toDecimal(value))}
-                contentStyle={chartTooltipStyle}
+                contentStyle={chartTooltipStyle} separator=": "
               />
               <Legend />
               <Bar

--- a/src/components/charts/DashboardCharts.tsx
+++ b/src/components/charts/DashboardCharts.tsx
@@ -21,7 +21,7 @@ import {
   Cell
 } from 'recharts';
 import { formatDecimal } from '../../utils/decimal-format';
-import { categoricalColor, useCategoricalRamp } from './chartColors';
+import { categoricalColor, useCategoricalRamp, useChartTooltipStyle } from './chartColors';
 
 export { ResponsiveContainer };
 
@@ -84,6 +84,7 @@ export function BarChart({
   // library-demo colour ended up as the app's Net Worth chart.
   const ramp = useCategoricalRamp();
   const barFill = fill ?? ramp[0];
+  const tooltipStyle = useChartTooltipStyle();
   const formatValue = formatter ?? defaultTickFormatter;
   const summary = buildChartSummary(
     ariaLabel,
@@ -101,7 +102,8 @@ export function BarChart({
         tickFormatter={tickFormatter ?? defaultTickFormatter}
       />
       <Tooltip
-        contentStyle={contentStyle}
+        contentStyle={contentStyle ?? tooltipStyle}
+        separator=": "
         formatter={(value: number | string | Array<number | string>) => {
           const numeric = typeof value === 'number' ? value : Number(value);
           return [formatter ? formatter(numeric) : String(value), label];
@@ -143,6 +145,12 @@ export function PieChart<T extends PieDatum>({
   // into three files.
   const ramp = useCategoricalRamp();
   const sliceColors = colors ?? ramp;
+  // The house tooltip is the DEFAULT, not something each caller remembers to
+  // pass: the Account Distribution report's ring passed nothing and rendered
+  // recharts' bare white box — over its own legend, in dark mode (Design,
+  // 17 Aug §2.6). `separator` likewise: " : " with spaces is a library
+  // default, not the house format.
+  const tooltipStyle = useChartTooltipStyle();
 
   // Recharts wants index-signature rows; keep the original datum reachable by
   // index so onClick hands back the caller's own object, not a copy.
@@ -176,7 +184,8 @@ export function PieChart<T extends PieDatum>({
         ))}
       </Pie>
       <Tooltip
-        contentStyle={contentStyle}
+        contentStyle={contentStyle ?? tooltipStyle}
+        separator=": "
         formatter={(value: number | string | Array<number | string>) => {
           const numeric = typeof value === 'number' ? value : Number(value);
           return formatter ? formatter(numeric) : formatDecimal(numeric, 2);

--- a/src/components/charts/__tests__/categoricalRamp.test.ts
+++ b/src/components/charts/__tests__/categoricalRamp.test.ts
@@ -53,18 +53,74 @@ const withoutComments = (source: string): string =>
   source.replace(/\/\*[\s\S]*?\*\//g, '').replace(/\/\/[^\n]*/g, '');
 
 describe('the categorical ramp is the only chart palette', () => {
-  it('keeps the five ruled values in the axis', () => {
+  it('the axis IS the ruled five', () => {
+    // Until 17 August the axis held nine stops — the ruled five plus bisected
+    // midpoints — and the bisection was the bug Design's §2.2 found: the dark
+    // half of the axis is compressed, so its midpoints landed ~1.17:1 from
+    // their neighbours and three legend swatches read as one colour. Ramp
+    // members are now interpolated evenly in L* (see chartColors), so the
+    // axis exports only what was actually ruled.
+    expect(CATEGORICAL_AXIS.map(c => c.toLowerCase())).toEqual([...RULED]);
+  });
+
+  it('every ruled value still appears in at least one ramp', () => {
+    const members = new Set(
+      [...categoricalRamp(false), ...categoricalRamp(true)].map(c => c.toLowerCase())
+    );
     for (const colour of RULED) {
-      expect(CATEGORICAL_AXIS.map(c => c.toLowerCase())).toContain(colour);
+      expect(members, `${colour} fell out of both ramps`).toContain(colour);
     }
   });
 
-  it('bisects rather than inventing steps: the ruled five sit at even indices', () => {
-    // The extension rule is stated, not ad hoc — each adjacent ruled pair gets
-    // its midpoint, so a nine-step axis holds the five at 0, 2, 4, 6, 8.
-    expect(CATEGORICAL_AXIS).toHaveLength(9);
-    expect([0, 2, 4, 6, 8].map(i => CATEGORICAL_AXIS[i].toLowerCase())).toEqual([...RULED]);
-  });
+  /**
+   * THE §2.2 INSTRUMENT (Claude Design, 17 Aug). The shipped light ramp had
+   * "maximum adjacent separation" in ratio terms and was still unreadable,
+   * because three of its five steps were near-identical and only ADJACENT
+   * pairs had ever been measured. So both floors are pinned: consecutive
+   * slices must separate (≥1.5:1), and NO pair anywhere in a ramp may fall
+   * back into the indistinguishable band (<1.15:1) — measured, not
+   * remembered. The light five sit ΔL* ≈ 10.5 apart; light's worst adjacent
+   * pair measures 2.00:1 and its worst overall 1.37:1; dark's are 1.59:1 and
+   * 1.19:1.
+   */
+  it.each([['light', false], ['dark', true]] as const)(
+    'no two %s-ground steps collapse into one colour',
+    (_name, isDark) => {
+      const ramp = categoricalRamp(isDark);
+      for (let i = 0; i < ramp.length - 1; i++) {
+        const adjacent = ColorContrastChecker.getContrastRatio(ramp[i], ramp[i + 1]);
+        expect(
+          adjacent,
+          `consecutive slices ${ramp[i]} and ${ramp[i + 1]} measure ${adjacent.toFixed(2)}:1`
+        ).toBeGreaterThanOrEqual(1.5);
+      }
+      for (let i = 0; i < ramp.length; i++) {
+        for (let j = i + 1; j < ramp.length; j++) {
+          const pair = ColorContrastChecker.getContrastRatio(ramp[i], ramp[j]);
+          expect(
+            pair,
+            `${ramp[i]} and ${ramp[j]} measure ${pair.toFixed(2)}:1 — legend swatches this close read as one`
+          ).toBeGreaterThanOrEqual(1.15);
+        }
+      }
+    }
+  );
+
+  it.each([
+    ['light', false, '#f8f9fb'],
+    ['dark', true, '#1f2937'],
+  ] as const)(
+    'the last %s-ground step is the quietest — where the folded remainder sits',
+    (_name, isDark, dimmestSurface) => {
+      // capSeriesWithRemainder and buildAccountDistribution put "the rest" in
+      // the fifth slice, and Design's §2.1 ruling puts the remainder at the
+      // ramp's lightest step. Painting slices in ramp order delivers that only
+      // if the last step really is the lowest-contrast one on its own ground.
+      const ramp = categoricalRamp(isDark);
+      const contrasts = ramp.map(c => ColorContrastChecker.getContrastRatio(c, dimmestSurface));
+      expect(contrasts[contrasts.length - 1]).toBe(Math.min(...contrasts));
+    }
+  );
 
   it.each([
     ['light', false, SURFACES_LIGHT],

--- a/src/components/charts/chartColors.ts
+++ b/src/components/charts/chartColors.ts
@@ -45,47 +45,70 @@ import { useEffect, useState } from 'react';
  * darkest-first on light, lightest-first on dark. Same axis, same five ruled
  * values, no second palette.
  *
- * ─ HOW IT EXTENDS PAST FIVE ────────────────────────────────────────────────
- * Some charts draw more series than five (SpendingByCategory draws eight). The
- * stated rule is BISECTION, never a new hue: each adjacent pair of ruled values
- * gets its midpoint, giving a nine-step axis of which the ruled five are still
- * exactly members. Five of those nine clear 3:1 on any one ground, so each
- * theme gets a five-colour ramp and beyond that the ramp CYCLES.
+ * ─ HOW EACH GROUND GETS ITS FIVE ───────────────────────────────────────────
+ * The first derivation rule was BISECTION: midpoints of adjacent ruled pairs,
+ * giving nine fixed stops of which each ground used the half that cleared 3:1.
+ * On light that rule was the bug (Claude Design, 17 Aug §2.2): the usable half
+ * is the DARK half, where the ruled stops sit ~10 L* apart, so bisecting put
+ * three near-black navies (#1a2332/#242f40/#2d3a4d, ~1.17:1 apart) into one
+ * five-step ramp. The legend swatches for slices 1, 3 and 5 were
+ * indistinguishable and two ring wedges read as one mass — spacing that was
+ * "as far apart as the axis allows" in ratio terms had never been measured
+ * PERCEPTUALLY.
  *
- * Cycling is the honest cost of the ruling. A single-hue ramp cannot separate
- * eight categories the way eight hues could — measured, adjacent steps here sit
- * 2.12:1 apart on light and 1.59:1 on dark. Charts must therefore direct-label,
- * which these already do: every consumer draws a legend swatch beside the name
- * or names the slice in its tooltip. Colour groups the series; the label
- * identifies it.
+ * The rule now: each ground's five are spaced EVENLY IN CIE L* along the same
+ * axis line, from the darkest ruled stop to the lightest step that still
+ * clears 3:1 on that ground's dimmest chart surface. Interpolation along the
+ * axis, never a new hue. Measured (17 Aug, this repo's harness + CIE L*):
+ *
+ *   light five  #1a2332  #2d3a4d  #41526e  #556c8f  #6b86b3
+ *      L*         13.5     24.1     34.6     45.1     55.5   (ΔL* ≈ 10.5 even)
+ *      vs #f8f9fb 14.98    10.93     7.50     5.08     3.51  (all ≥ 3:1)
+ *
+ * Three of the light five are ruled stops; the two interpolations sit on the
+ * ruled navy-700→navy-400 segment. The dark five keep their 2026-08 values —
+ * the light half of the axis never bunched (ΔL* 5–18, confirmed working in
+ * the same review) — so only the failing ground changed.
+ *
+ * Beyond five the ramp CYCLES, which is the honest cost of a one-hue ruling:
+ * charts must direct-label, and every consumer already draws a legend swatch
+ * beside the name or names the slice in its tooltip. Colour groups the
+ * series; the label identifies it.
+ *
+ * ─ BOTH RAMPS END AT #6b86b3, AND THE ORDER IS NOT ARBITRARY ───────────────
+ * Ring slices are painted in ramp order, so consecutive steps are interleaved
+ * from the two ends of each five — adjacent wedges are never adjacent
+ * lightness steps (worst adjacent pair: 2.00:1 light, 1.59:1 dark). The LAST
+ * step of each ramp is deliberately its lowest-contrast one on its own
+ * ground — #6b86b3, the one axis step legible on both — because the fifth
+ * slice is where a capped series puts its folded remainder
+ * (capSeriesWithRemainder, accountDistribution), and "the rest" should recede
+ * rather than compete with the named four (Design §2.1: the remainder at the
+ * ramp's lightest step).
  */
 
 /**
- * The axis: the ruled five (index 0, 2, 4, 6, 8) with a bisected midpoint
- * between each adjacent pair. Dark end first. Exported for the test that pins
- * the ruled values and the contrast of everything derived from them.
+ * The axis: the five RULED stops, dark end first. The ramps below are spaced
+ * along the line these describe — interpolated members belong to the ramps,
+ * not the axis. Exported for the tests that pin the ruled values and measure
+ * everything derived from them.
  */
 export const CATEGORICAL_AXIS = [
-  '#1a2332', // navy-900  — ruled
-  '#242f40', //           — bisected
-  '#2d3a4d', // navy-700  — ruled
-  '#4c6080', //           — bisected
-  '#6b86b3', // navy-400  — ruled
-  '#8095b6', //           — bisected
-  '#94a3b8', // slate-400 — ruled
-  '#b1bccc', //           — bisected
-  '#cdd4e0', // line-strong — ruled
+  '#1a2332', // navy-900
+  '#2d3a4d', // navy-700
+  '#6b86b3', // navy-400
+  '#94a3b8', // slate-400
+  '#cdd4e0', // line-strong
 ] as const;
 
 /**
- * The five axis steps that clear 3:1 on a LIGHT ground, ordered so that
- * CONSECUTIVE series are as far apart as the axis allows (2.12:1 worst
- * adjacent pair). Walking the axis in order instead would put neighbouring pie
- * slices 1.17:1 apart, which is no separation at all.
+ * The light-ground five, interleaved so consecutive series sit far apart
+ * (2.00:1 worst adjacent pair, no pair anywhere below 1.37:1) and the
+ * lowest-contrast step lands LAST, where the remainder slice sits.
  */
-const RAMP_ON_LIGHT = ['#1a2332', '#4c6080', '#242f40', '#6b86b3', '#2d3a4d'] as const;
+const RAMP_ON_LIGHT = ['#2d3a4d', '#556c8f', '#1a2332', '#41526e', '#6b86b3'] as const;
 
-/** The same, from the light end, for a dark ground (1.59:1 worst adjacent pair). */
+/** The same idea from the light end, for a dark ground (1.59:1 worst adjacent pair). */
 const RAMP_ON_DARK = ['#94a3b8', '#cdd4e0', '#8095b6', '#b1bccc', '#6b86b3'] as const;
 
 /**
@@ -202,20 +225,32 @@ export function useCategoricalRamp(): readonly string[] {
  * It watches the `dark` class through the same hook as the ramp, and for the
  * same reason: the class is toggled on `<html>` directly, so a value read once
  * at render survives into the wrong theme.
+ *
+ * HOUSE FORMAT, not just house colours (Design, 17 Aug §2.6): the backgrounds
+ * are OPAQUE, because a tooltip can land on a legend and a translucent card
+ * over text leaves both unreadable — an overlay covers, it does not blend.
+ * The type matches the axis scale rather than recharts' default, and every
+ * figure in a tooltip is money, so `tabular-nums` applies here the same as
+ * everywhere else money is printed (P5).
  */
 export function useChartTooltipStyle(): React.CSSProperties {
   const dark = useIsDarkGround();
+  const shared: React.CSSProperties = {
+    borderRadius: '8px',
+    fontSize: '0.75rem',
+    fontVariantNumeric: 'tabular-nums',
+  };
   return dark
     ? {
-        backgroundColor: 'rgba(31, 41, 55, 0.97)', // gray-800
+        ...shared,
+        backgroundColor: '#1f2937', // gray-800
         border: '1px solid #4b5563', // gray-600
-        borderRadius: '8px',
         color: '#f9fafb',
       }
     : {
-        backgroundColor: 'rgba(255, 255, 255, 0.95)',
-        border: '1px solid #ccc',
-        borderRadius: '8px',
+        ...shared,
+        backgroundColor: '#ffffff',
+        border: '1px solid #e5e7eb', // gray-200 hairline
         color: '#111827',
       };
 }
@@ -315,8 +350,9 @@ export const SEMANTIC_SERIES = {
 export const DECOMPOSITION_SERIES = {
   /** The answer. Solid and heaviest — the other two explain it. */
   total: { color: CATEGORICAL_AXIS[0], width: 2.5, dash: undefined },
-  /** A component. Same hue, dashed. */
-  part: { color: CATEGORICAL_AXIS[2], width: 1.5, dash: '6 3' },
+  /** A component. Same hue, dashed. (#2d3a4d — index [1] since the axis
+      became the ruled five; the colour itself did not move.) */
+  part: { color: CATEGORICAL_AXIS[1], width: 1.5, dash: '6 3' },
   /** The other component. Same hue again, dotted, so the two parts differ. */
-  counterpart: { color: CATEGORICAL_AXIS[2], width: 1.5, dash: '1 3' },
+  counterpart: { color: CATEGORICAL_AXIS[1], width: 1.5, dash: '1 3' },
 } as const;

--- a/src/components/dashboard/ImprovedDashboard.tsx
+++ b/src/components/dashboard/ImprovedDashboard.tsx
@@ -51,7 +51,11 @@ import { toDecimal } from '../../utils/decimal';
 import { expandSplitTransactions } from '../../utils/transactionSplits';
 import { computeIncomeExpense } from '../../utils/incomeExpense';
 import { computeAccountBalances } from '../../utils/accountBalances';
-import { buildAccountDistribution, type AccountDistributionEntry } from '../../utils/accountDistribution';
+import {
+  ACCOUNT_DISTRIBUTION_REMAINDER_ID,
+  buildAccountDistribution,
+  type AccountDistributionEntry,
+} from '../../utils/accountDistribution';
 import { groupAccountsBySection } from '../../utils/accountGrouping';
 import { buildCategoryNameLookup } from '../../utils/categoryNames';
 import { buildAttentionItems } from '../../utils/attentionItems';
@@ -420,22 +424,11 @@ export function ImprovedDashboard() {
   // The shared ramp, not a fourth copy of the recharts demo palette that used
   // to live here (and, byte for byte, in two other files).
   const chartRamp = useCategoricalRamp();
-  const isDarkMode = document.documentElement.classList.contains('dark');
-  
-  const chartStyles = useMemo(() => ({
-    tooltip: {
-      backgroundColor: isDarkMode ? 'rgba(31, 41, 55, 0.95)' : 'rgba(255, 255, 255, 0.95)',
-      border: isDarkMode ? '1px solid #374151' : '1px solid #E5E7EB',
-      borderRadius: '8px',
-      color: isDarkMode ? '#E5E7EB' : '#111827'
-    },
-    pieTooltip: {
-      backgroundColor: isDarkMode ? 'rgba(31, 41, 55, 0.95)' : 'rgba(255, 255, 255, 0.95)',
-      border: isDarkMode ? '1px solid #374151' : '1px solid #ccc',
-      borderRadius: '8px',
-      color: isDarkMode ? '#E5E7EB' : '#111827'
-    }
-  }), [isDarkMode]);
+  // No tooltip styles declared here any more: the DashboardCharts wrappers
+  // default to the house style, which WATCHES the dark class. The block this
+  // replaces read it once at render — a chart mounted before dusk kept its
+  // light tooltip all evening (the exact read-once trap chartColors warns
+  // about, living on this page).
 
   const persistSelection = useCallback((ids: string[]) => {
     preferences.setItem('dashboardKeyAccounts', JSON.stringify(ids));
@@ -584,51 +577,52 @@ export function ImprovedDashboard() {
             re-point an arrow the owner asked to keep. Raised in the handover
             rather than assumed. */}
         <div className="grid grid-cols-1 sm:grid-cols-2 gap-4 sm:gap-0 sm:divide-x sm:divide-gray-200 sm:dark:divide-gray-700">
+          {/* THE ARROW SITS WITH ITS FIGURE (Design, 17 Aug §2.5). It is a
+              modifier on the amount — `justify-between` was parking it at the
+              card's far edge, six hundred pixels from the number it modifies,
+              with half a card of nothing connecting them. After the amount,
+              same baseline. */}
           <button
             type="button"
             onClick={() => setBreakdownType('income')}
-            className="flex items-center justify-between p-4 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-700/50 transition-colors cursor-pointer text-left"
+            className="p-4 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-700/50 transition-colors cursor-pointer text-left"
           >
-            <div>
-              <p className="text-sm text-gray-600 dark:text-gray-400">Income</p>
-              {/* NEUTRAL AT ZERO (Design §4), on the reasoning that settled
-                  the arrows one line down: at zero there is no direction, so
-                  the direction signal must not render. A green £0.00 beside a
-                  red £0.00 says "money came in" and "money went out" on a
-                  ledger where neither happened — in the two hues the app
-                  reserves for exactly that claim. Same condition as the arrow,
-                  deliberately. */}
-              <p className={`text-xl font-bold ${
-                performance.income === 0
-                  ? 'text-gray-900 dark:text-white'
-                  : 'text-green-600 dark:text-green-400'
-              }`}>
-                {formatCurrencyWithSymbol(performance.income)}
-              </p>
-            </div>
-            {performance.income !== 0 && (
-              <TrendingUpIcon size={24} className="text-green-500" aria-hidden="true" />
-            )}
+            <p className="text-sm text-gray-600 dark:text-gray-400">Income</p>
+            {/* NEUTRAL AT ZERO (Design §4), on the reasoning that settled
+                the arrow beside it: at zero there is no direction, so the
+                direction signal must not render. A green £0.00 beside a
+                red £0.00 says "money came in" and "money went out" on a
+                ledger where neither happened — in the two hues the app
+                reserves for exactly that claim. Same condition as the arrow,
+                deliberately. */}
+            <p className={`flex items-center gap-2 text-xl font-bold ${
+              performance.income === 0
+                ? 'text-gray-900 dark:text-white'
+                : 'text-green-600 dark:text-green-400'
+            }`}>
+              {formatCurrencyWithSymbol(performance.income)}
+              {performance.income !== 0 && (
+                <TrendingUpIcon size={20} className="text-green-500 flex-shrink-0" aria-hidden="true" />
+              )}
+            </p>
           </button>
 
           <button
             type="button"
             onClick={() => setBreakdownType('expense')}
-            className="flex items-center justify-between p-4 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-700/50 transition-colors cursor-pointer text-left"
+            className="p-4 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-700/50 transition-colors cursor-pointer text-left"
           >
-            <div>
-              <p className="text-sm text-gray-600 dark:text-gray-400">Expenses</p>
-              <p className={`text-xl font-bold ${
-                performance.expenses === 0
-                  ? 'text-gray-900 dark:text-white'
-                  : 'text-red-600 dark:text-red-400'
-              }`}>
-                {formatCurrencyWithSymbol(performance.expenses)}
-              </p>
-            </div>
-            {performance.expenses !== 0 && (
-              <TrendingDownIcon size={24} className="text-red-500" aria-hidden="true" />
-            )}
+            <p className="text-sm text-gray-600 dark:text-gray-400">Expenses</p>
+            <p className={`flex items-center gap-2 text-xl font-bold ${
+              performance.expenses === 0
+                ? 'text-gray-900 dark:text-white'
+                : 'text-red-600 dark:text-red-400'
+            }`}>
+              {formatCurrencyWithSymbol(performance.expenses)}
+              {performance.expenses !== 0 && (
+                <TrendingDownIcon size={20} className="text-red-500 flex-shrink-0" aria-hidden="true" />
+              )}
+            </p>
           </button>
         </div>
       </section>
@@ -702,9 +696,15 @@ export function ImprovedDashboard() {
                   subtitle={
                     <>
                       <span className="text-xs text-gray-500 dark:text-gray-400 truncate">
+                        {/* A closed ring claims the whole (Design, 17 Aug §2.1),
+                            so when accounts were folded the words say so —
+                            "top 5" over a ring quietly missing 45% of the money
+                            was a subtitle contradicted by its own shape. */}
                         {pieData.length === 0
                           ? 'Your largest accounts by balance'
-                          : `Your top ${pieData.length} account${pieData.length === 1 ? '' : 's'} by balance`}
+                          : distribution.foldedCount > 0
+                            ? `Your top ${pieData.length - 1} accounts, and the other ${distribution.foldedCount}`
+                            : `Your top ${pieData.length} account${pieData.length === 1 ? '' : 's'} by balance`}
                       </span>
                       <span className="text-xs text-gray-400 dark:text-gray-500 ml-auto whitespace-nowrap">
                         Current balances
@@ -746,12 +746,17 @@ export function ImprovedDashboard() {
                           // Straight into that account's register. It used to
                           // go to the global list filtered to the account,
                           // which is the same answer one page further away —
-                          // and that page is retired.
+                          // and that page is retired. The remainder slice has
+                          // no single register to open, so it opens the full
+                          // report, where every folded account is a row.
                           onClick={(clickedData: AccountDistributionEntry) => {
-                            navigate(preserveDemoParam(`/accounts/${clickedData.id}`, location.search));
+                            if (clickedData.id === ACCOUNT_DISTRIBUTION_REMAINDER_ID) {
+                              openReport('account-distribution');
+                            } else {
+                              navigate(preserveDemoParam(`/accounts/${clickedData.id}`, location.search));
+                            }
                           }}
                           formatter={(value: number) => formatCurrencyWithSymbol(value, displayCurrency)}
-                          contentStyle={chartStyles.pieTooltip}
                           aria-label="Pie chart showing distribution of account balances"
                         />
                       </ResponsiveContainer>
@@ -762,7 +767,11 @@ export function ImprovedDashboard() {
                         <li key={d.id}>
                           <button
                             type="button"
-                            onClick={() => navigate(preserveDemoParam(`/accounts/${d.id}`, location.search))}
+                            // The remainder row has ninety registers behind it,
+                            // not one — it opens the report that lists them all.
+                            onClick={() => d.id === ACCOUNT_DISTRIBUTION_REMAINDER_ID
+                              ? openReport('account-distribution')
+                              : navigate(preserveDemoParam(`/accounts/${d.id}`, location.search))}
                             className="w-full flex items-center gap-2 rounded-lg px-2 py-1.5 hover:bg-gray-50 dark:hover:bg-gray-700/50 transition-colors text-left"
                           >
                             <span
@@ -1220,7 +1229,6 @@ export function ImprovedDashboard() {
                 dataKey="netWorth"
                 label="Net Worth"
                 formatter={(value: number) => formatCurrencyWithSymbol(value, displayCurrency)}
-                contentStyle={chartStyles.tooltip}
                 tickFormatter={(value: number) => {
                   if (value >= 1000000) return `${formatDecimal(value / 1000000, 1)}M`;
                   if (value >= 1000) return `${formatDecimal(value / 1000, 0)}K`;

--- a/src/components/dashboard/reportWidgets/DashboardReportWidgets.tsx
+++ b/src/components/dashboard/reportWidgets/DashboardReportWidgets.tsx
@@ -16,7 +16,7 @@ import { useCurrencyDecimal } from '../../../hooks/useCurrencyDecimal';
 import { categoricalColor, MAX_CATEGORICAL_SERIES, useCategoricalRamp, SEMANTIC_SERIES, useChartTooltipStyle } from '../../charts/chartColors';
 import { singlePointDot } from '../../charts/singlePointDots';
 import { buildMonthlyTrend } from '../../../utils/monthlyTrend';
-import { buildNetWorthSnapshots, netWorthPointToken } from '../../../utils/netWorthSeries';
+import { buildNetWorthSnapshots, netWorthAxisTicks, netWorthPointToken } from '../../../utils/netWorthSeries';
 import { computeExpenseCategoryNetTotals } from '../../../utils/categoryNetting';
 import { expandSplitTransactions } from '../../../utils/transactionSplits';
 import { formatDecimal } from '../../../utils/decimal-format';
@@ -162,9 +162,16 @@ export function NetWorthWidget({ picker, pin }: {
               if (snapshot) open(netWorthPointToken(snapshot.date));
             }}
           >
-            <XAxis dataKey="label" tick={{ fill: '#6B7280', fontSize: 10 }} minTickGap={32} />
-            <YAxis tick={{ fill: '#6B7280', fontSize: 10 }} tickFormatter={compactTick} width={44} />
-            <Tooltip contentStyle={chartTooltipStyle} formatter={(v: number | string) => formatCurrency(typeof v === 'number' ? v : Number(v))} />
+            {/* Years for a multi-year window, months within one — the tick
+                format follows the span (Design, 17 Aug §2.3). */}
+            <XAxis dataKey="label" tick={{ fill: '#6B7280', fontSize: 10 }} minTickGap={32} {...netWorthAxisTicks(snapshots)} />
+            {/* The domain follows the DATA and dips below zero only when the
+                data does (§2.4): recharts' nice-tick rounding was answering
+                one early negative point with a −6.0M floor, spending a
+                quarter of the plot on nothing and flattening the curve the
+                chart exists to show. */}
+            <YAxis tick={{ fill: '#6B7280', fontSize: 10 }} tickFormatter={compactTick} width={44} domain={[(dataMin: number) => Math.min(0, dataMin), 'auto']} />
+            <Tooltip contentStyle={chartTooltipStyle} separator=": " formatter={(v: number | string) => formatCurrency(typeof v === 'number' ? v : Number(v))} />
             <Line type="monotone" dataKey="netWorth" name="Net Worth" stroke={lineStroke} strokeWidth={2} dot={singlePointDot(snapshots, lineStroke)} isAnimationActive={false} />
           </LineChart>
         </ResponsiveContainer>
@@ -248,7 +255,7 @@ export function IncomeExpenseTrendWidget({ picker, pin }: {
             <CartesianGrid strokeDasharray="3 3" stroke="rgba(107, 114, 128, 0.2)" />
             <XAxis dataKey="month" tick={{ fill: '#6B7280', fontSize: 10 }} minTickGap={32} />
             <YAxis tick={{ fill: '#6B7280', fontSize: 10 }} tickFormatter={compactTick} width={44} />
-            <Tooltip contentStyle={chartTooltipStyle} formatter={(v: number | string) => formatCurrency(typeof v === 'number' ? v : Number(v))} />
+            <Tooltip contentStyle={chartTooltipStyle} separator=": " formatter={(v: number | string) => formatCurrency(typeof v === 'number' ? v : Number(v))} />
             <Line type="monotone" dataKey="income" name="Income" stroke={SEMANTIC_SERIES.income} strokeWidth={2} dot={singlePointDot(data, SEMANTIC_SERIES.income)} isAnimationActive={false} />
             <Line type="monotone" dataKey="expenses" name="Expenses" stroke={SEMANTIC_SERIES.expense} strokeWidth={2} dot={singlePointDot(data, SEMANTIC_SERIES.expense)} isAnimationActive={false} />
           </LineChart>
@@ -373,7 +380,7 @@ export function ExpenseCategoriesWidget({ picker, pin }: {
                     <Cell key={entry.name} fill={categoricalColor(ramp, index)} />
                   ))}
                 </Pie>
-                <Tooltip contentStyle={chartTooltipStyle} formatter={(v: number | string) => formatCurrency(typeof v === 'number' ? v : Number(v))} />
+                <Tooltip contentStyle={chartTooltipStyle} separator=": " formatter={(v: number | string) => formatCurrency(typeof v === 'number' ? v : Number(v))} />
               </RechartsPieChart>
             </ResponsiveContainer>
           </div>

--- a/src/pages/Investments.tsx
+++ b/src/pages/Investments.tsx
@@ -1003,7 +1003,7 @@ export default function Investments() {
               />
               <Tooltip
                 formatter={(value) => formatCurrency(toDecimal(Number(value)))}
-                contentStyle={chartTooltipStyle}
+                contentStyle={chartTooltipStyle} separator=": "
               />
               <Line 
                 type="monotone" 
@@ -1238,7 +1238,6 @@ export default function Investments() {
                     innerRadius={true}
                     colors={ramp}
                     formatter={(value: number) => formatCurrency(toDecimal(value))}
-                    contentStyle={chartTooltipStyle}
                     aria-label="Ring chart of asset allocation by account"
                   />
                 </ResponsiveContainer>
@@ -1322,7 +1321,6 @@ export default function Investments() {
                     innerRadius={true}
                     colors={ramp}
                     formatter={(value: number) => formatCurrency(toDecimal(value))}
-                    contentStyle={chartTooltipStyle}
                     aria-label="Ring chart of allocation by holding"
                   />
                 </ResponsiveContainer>

--- a/src/pages/NetWorthReport.tsx
+++ b/src/pages/NetWorthReport.tsx
@@ -19,11 +19,11 @@ import { singlePointDot } from '../components/charts/singlePointDots';
 import { toDecimal } from '../utils/decimal';
 import { formatDecimal } from '../utils/decimal-format';
 import { preserveDemoParam } from '../utils/navigation';
-import { buildNetWorthSnapshots, netWorthPointToken } from '../utils/netWorthSeries';
+import { buildNetWorthSnapshots, netWorthAxisTicks, netWorthPointToken } from '../utils/netWorthSeries';
 import { useArrivalAction } from '../hooks/useArrivalFocus';
 import { resolveEffectiveOpeningDates } from '../utils/openingDates';
 import { TrendingUpIcon, ChevronRightIcon } from '../components/icons';
-import { DECOMPOSITION_SERIES } from '../components/charts/chartColors';
+import { DECOMPOSITION_SERIES, useChartTooltipStyle } from '../components/charts/chartColors';
 import type { ReportViewProps } from './reports/types';
 import { preferences } from '../services/preferencesService';
 import { useHistoricalAccounts } from '../hooks/useHistoricalAccounts';
@@ -114,6 +114,9 @@ export default function NetWorthReport({ picker, focus }: ReportViewProps): Reac
    */
   const accounts = useHistoricalAccounts(openAccounts);
   const { formatCurrency } = useCurrencyDecimal();
+  // Watches the dark class rather than reading it once — the theme scheduler
+  // can flip the ground under a mounted chart.
+  const chartTooltipStyle = useChartTooltipStyle();
   const navigate = useNavigate();
   const location = useLocation();
   const [drillDate, setDrillDate] = useState<Date | null>(null);
@@ -343,11 +346,17 @@ export default function NetWorthReport({ picker, focus }: ReportViewProps): Reac
                 style={{ cursor: 'pointer' }}
               >
                 <CartesianGrid strokeDasharray="3 3" stroke="rgba(107, 114, 128, 0.2)" />
-                <XAxis dataKey="label" tick={{ fill: '#6B7280', fontSize: 12 }} minTickGap={24} />
-                <YAxis tick={{ fill: '#6B7280', fontSize: 12 }} tickFormatter={compactTick} width={70} />
+                {/* Years for a multi-year window (§2.3) — same helper as the
+                    Dashboard widget, so card and report tick identically. */}
+                <XAxis dataKey="label" tick={{ fill: '#6B7280', fontSize: 12 }} minTickGap={24} {...netWorthAxisTicks(snapshots)} />
+                {/* Below zero only when the data goes there (§2.4). */}
+                <YAxis tick={{ fill: '#6B7280', fontSize: 12 }} tickFormatter={compactTick} width={70} domain={[(dataMin: number) => Math.min(0, dataMin), 'auto']} />
+                {/* The radius-only contentStyle LOOKED themed and set no
+                    colour — the same survivor pattern the 16 Aug sweep found
+                    on three other report pages. */}
                 <Tooltip
                   formatter={(value: number | string) => formatCurrency(typeof value === 'number' ? value : Number(value))}
-                  contentStyle={{ borderRadius: '8px' }}
+                  contentStyle={chartTooltipStyle} separator=": "
                 />
                 <Legend content={<DecompositionLegend />} />
                 {chartType === 'bar' ? (

--- a/src/pages/reports/AccountDistributionReport.tsx
+++ b/src/pages/reports/AccountDistributionReport.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from 'react';
+import React, { useMemo, useRef } from 'react';
 import { Link, useLocation, useNavigate } from 'react-router-dom';
 import { useApp } from '../../contexts/AppContextSupabase';
 import { useCurrencyDecimal } from '../../hooks/useCurrencyDecimal';
@@ -6,6 +6,7 @@ import { PieChart, ResponsiveContainer } from '../../components/charts/Dashboard
 import { categoricalColor, useCategoricalRamp } from '../../components/charts/chartColors';
 import { computeAccountBalances } from '../../utils/accountBalances';
 import {
+  ACCOUNT_DISTRIBUTION_REMAINDER_ID,
   buildAccountDistribution,
   type AccountDistributionEntry,
 } from '../../utils/accountDistribution';
@@ -34,6 +35,9 @@ export default function AccountDistributionReport(): React.JSX.Element {
   const { formatCurrency, displayCurrency } = useCurrencyDecimal();
   const location = useLocation();
   const navigate = useNavigate();
+  // Where a click on the remainder slice lands: the table that lists every
+  // account the slice folded. It has no single register to open.
+  const everyAccountRef = useRef<HTMLDivElement>(null);
   // The shared ramp. This file used to carry its own copy of the recharts demo
   // palette with a comment promising it matched the Dashboard's — a promise
   // nothing checked, and exactly the drift the one-module rule removes.
@@ -96,11 +100,15 @@ export default function AccountDistributionReport(): React.JSX.Element {
           <span className="text-dense text-gray-400 dark:text-gray-500">Current balances</span>
         </div>
         {/* The count comes from the slices themselves, never the cap: with
-            three accounts in credit this must not claim five. */}
+            three accounts in credit this must not claim five. And when the
+            ring folds a remainder (Design, 17 Aug §2.1 — a closed ring is a
+            claim about the whole), the sentence says what was folded. */}
         <p className="text-body text-gray-500 dark:text-gray-400 mb-4">
           {distribution.slices.length === 1
             ? 'The one account in credit'
-            : `The ${distribution.slices.length} largest accounts in credit`}
+            : distribution.foldedCount > 0
+              ? `The ${distribution.slices.length - 1} largest accounts in credit, with the other ${distribution.foldedCount} gathered into one slice`
+              : `The ${distribution.slices.length} largest accounts in credit`}
           {' '}— the same slices the Dashboard shows. Every account is listed below.
           Click a slice for its transactions.
         </p>
@@ -113,7 +121,13 @@ export default function AccountDistributionReport(): React.JSX.Element {
                 data={distribution.slices}
                 innerRadius={true}
                 colors={ramp}
-                onClick={(entry: AccountDistributionEntry) => navigate(transactionsHref(entry.id))}
+                onClick={(entry: AccountDistributionEntry) => {
+                  if (entry.id === ACCOUNT_DISTRIBUTION_REMAINDER_ID) {
+                    everyAccountRef.current?.scrollIntoView({ behavior: 'smooth', block: 'start' });
+                  } else {
+                    navigate(transactionsHref(entry.id));
+                  }
+                }}
                 formatter={(value: number) => money(value)}
                 aria-label="Pie chart showing distribution of account balances"
               />
@@ -122,7 +136,7 @@ export default function AccountDistributionReport(): React.JSX.Element {
         )}
       </div>
 
-      <div className="bg-white dark:bg-gray-800 rounded-lg border border-line dark:border-gray-700">
+      <div ref={everyAccountRef} className="bg-white dark:bg-gray-800 rounded-lg border border-line dark:border-gray-700">
         <div className="p-6 pb-3">
           <h2 className="text-card font-semibold text-theme-heading dark:text-white">Every account</h2>
           <p className="text-body text-gray-500 dark:text-gray-400 mt-1">
@@ -151,8 +165,10 @@ export default function AccountDistributionReport(): React.JSX.Element {
                   <tr key={entry.id} className="border-t border-gray-50 dark:border-gray-700/50">
                     <th scope="row" className="px-4 py-2 text-left font-normal">
                       <span className="flex items-center gap-2">
-                        {/* Only the drawn slices carry a colour — a swatch for a
-                            row the chart does not show would point at nothing. */}
+                        {/* Only the NAMED slices carry a colour. The folded
+                            accounts are in the ring collectively, but ninety
+                            rows all wearing the remainder's colour would claim
+                            each was drawn individually — so they stay bare. */}
                         <span
                           className="w-3 h-3 rounded-sm flex-shrink-0"
                           style={{ backgroundColor: sliceColours.get(entry.id) ?? 'transparent' }}

--- a/src/pages/reports/IncomeSpendingOverTimeReport.tsx
+++ b/src/pages/reports/IncomeSpendingOverTimeReport.tsx
@@ -218,7 +218,7 @@ export default function IncomeSpendingOverTimeReport({ picker, focus }: ReportVi
                 <XAxis dataKey="month" tick={{ fill: '#6B7280', fontSize: 12 }} minTickGap={24} />
                 <YAxis tick={{ fill: '#6B7280', fontSize: 12 }} tickFormatter={compactTick} width={70} />
                 <Tooltip
-                  contentStyle={chartTooltipStyle}
+                  contentStyle={chartTooltipStyle} separator=": "
                   formatter={(value: number | string) =>
                     formatCurrency(typeof value === 'number' ? value : Number(value))
                   }

--- a/src/pages/reports/PeriodComparisonReport.tsx
+++ b/src/pages/reports/PeriodComparisonReport.tsx
@@ -353,7 +353,7 @@ export default function PeriodComparisonReport({ picker }: ReportViewProps): Rea
                       interval={0}
                     />
                     <Tooltip
-                  contentStyle={chartTooltipStyle}
+                  contentStyle={chartTooltipStyle} separator=": "
                       formatter={(value: number | string) =>
                         formatCurrency(typeof value === 'number' ? value : Number(value))
                       }

--- a/src/pages/reports/SpendingByCategoryReport.tsx
+++ b/src/pages/reports/SpendingByCategoryReport.tsx
@@ -145,7 +145,7 @@ export default function SpendingByCategoryReport({ picker, focus }: ReportViewPr
                   ))}
                 </Pie>
                 <Tooltip
-                  contentStyle={chartTooltipStyle}
+                  contentStyle={chartTooltipStyle} separator=": "
                   formatter={(value: number | string) =>
                     formatCurrency(typeof value === 'number' ? value : Number(value))
                   }

--- a/src/pages/reports/SpendingByPayeeReport.tsx
+++ b/src/pages/reports/SpendingByPayeeReport.tsx
@@ -160,7 +160,7 @@ export default function SpendingByPayeeReport({ picker }: ReportViewProps): Reac
                   interval={0}
                 />
                 <Tooltip
-                  contentStyle={chartTooltipStyle}
+                  contentStyle={chartTooltipStyle} separator=": "
                   formatter={(value: number | string) =>
                     formatCurrency(typeof value === 'number' ? value : Number(value))
                   }

--- a/src/utils/accountDistribution.test.ts
+++ b/src/utils/accountDistribution.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect } from 'vitest';
-import { buildAccountDistribution, ACCOUNT_DISTRIBUTION_SLICES } from './accountDistribution';
+import {
+  buildAccountDistribution,
+  ACCOUNT_DISTRIBUTION_REMAINDER_ID,
+  ACCOUNT_DISTRIBUTION_SLICES,
+} from './accountDistribution';
 
 /**
  * The Dashboard card and the full report both read this, so what it decides is
@@ -56,7 +60,11 @@ describe('buildAccountDistribution', () => {
     expect(total).toBeCloseTo(100, 10);
   });
 
-  it('draws only the largest accounts in credit, and never a negative slice', () => {
+  /* Until 17 August this expected slices A–E with F silently dropped — the
+     ring closed at six-sevenths of the money and read as the whole (Design
+     §2.1: "a closed ring is a stronger claim than a subtitle"). The sixth
+     account is now folded, so the ring always sums to what is held. */
+  it('folds everything past the named slices into one counted remainder', () => {
     const accounts = accountsOf('A', 'B', 'C', 'D', 'E', 'F', 'Overdrawn');
     const balances = new Map([
       ['acc-0', 700], ['acc-1', 600], ['acc-2', 500],
@@ -64,13 +72,47 @@ describe('buildAccountDistribution', () => {
       ['acc-6', -1000],
     ]);
 
-    const { slices, entries } = buildAccountDistribution(accounts, id => balances.get(id) ?? 0);
+    const { slices, entries, foldedCount } = buildAccountDistribution(accounts, id => balances.get(id) ?? 0);
 
     expect(slices).toHaveLength(ACCOUNT_DISTRIBUTION_SLICES);
-    expect(slices.map(s => s.name)).toEqual(['A', 'B', 'C', 'D', 'E']);
+    expect(slices.map(s => s.name)).toEqual(['A', 'B', 'C', 'D', '2 smaller accounts']);
+    expect(foldedCount).toBe(2);
+    // The remainder is E + F, and the overdraft plays no part in it.
+    const remainder = slices[slices.length - 1];
+    expect(remainder.id).toBe(ACCOUNT_DISTRIBUTION_REMAINDER_ID);
+    expect(remainder.value).toBe(500);
     expect(slices.every(s => s.value > 0)).toBe(true);
-    // The table still lists everything the chart left out.
+    // The table still lists every real account — never the pseudo-slice.
     expect(entries).toHaveLength(7);
+    expect(entries.some(e => e.id === ACCOUNT_DISTRIBUTION_REMAINDER_ID)).toBe(false);
+  });
+
+  it('the ring sums to the whole: named slices plus remainder equal the in-credit total', () => {
+    const accounts = accountsOf('A', 'B', 'C', 'D', 'E', 'F', 'G', 'H');
+    // Thirds and the like, so a float fold would drift where Decimal cannot.
+    const balances = new Map([
+      ['acc-0', 1000.10], ['acc-1', 900.01], ['acc-2', 800.02], ['acc-3', 700.03],
+      ['acc-4', 33.33], ['acc-5', 33.33], ['acc-6', 33.34], ['acc-7', 0.01],
+    ]);
+
+    const { slices, inCreditTotal } = buildAccountDistribution(accounts, id => balances.get(id) ?? 0);
+
+    const drawn = slices.reduce((sum, s) => sum + s.value, 0);
+    expect(drawn).toBeCloseTo(inCreditTotal.toNumber(), 10);
+    const shares = slices.reduce((sum, s) => sum + (s.share?.toNumber() ?? 0), 0);
+    expect(shares).toBeCloseTo(100, 10);
+  });
+
+  it('draws all five by name when exactly five are in credit — a fold of one would hide nothing', () => {
+    const accounts = accountsOf('A', 'B', 'C', 'D', 'E');
+    const balances = new Map([
+      ['acc-0', 500], ['acc-1', 400], ['acc-2', 300], ['acc-3', 200], ['acc-4', 100],
+    ]);
+
+    const { slices, foldedCount } = buildAccountDistribution(accounts, id => balances.get(id) ?? 0);
+
+    expect(slices.map(s => s.name)).toEqual(['A', 'B', 'C', 'D', 'E']);
+    expect(foldedCount).toBe(0);
   });
 
   it('breaks a tie by name, so equal balances do not swap places between renders', () => {

--- a/src/utils/accountDistribution.ts
+++ b/src/utils/accountDistribution.ts
@@ -38,13 +38,20 @@ export interface AccountDistribution {
   /** Every account, ranked by balance, largest first — nothing dropped. */
   entries: AccountDistributionEntry[];
   /**
-   * The slices a donut can draw: the largest accounts in credit. A pie cannot
-   * show a negative, and past a handful of slices nobody can tell them apart,
-   * so the chart is a summary and the table beside it is the truth.
+   * The slices the donut draws: the largest accounts in credit, and — when
+   * there are more in credit than the ring can name — ONE slice holding
+   * everything else, so the ring always sums to the whole. A pie cannot show
+   * a negative, so overdrawn accounts appear in the table, never the ring.
    */
   slices: AccountDistributionEntry[];
   /** What every share is a share OF: the total held in credit. */
   inCreditTotal: DecimalInstance;
+  /**
+   * How many in-credit accounts the ring folded into its remainder slice —
+   * zero when every one is drawn by name. Exposed so the copy above each ring
+   * can say what was folded without parsing the slice's own label.
+   */
+  foldedCount: number;
 }
 
 /**
@@ -53,6 +60,13 @@ export interface AccountDistribution {
  * of numbers.
  */
 export const ACCOUNT_DISTRIBUTION_SLICES = 5;
+
+/**
+ * The id the folded remainder slice carries instead of an account id. A
+ * sentinel no database id can collide with, so a click handler can tell "open
+ * this account" from "open the full report" without a second data shape.
+ */
+export const ACCOUNT_DISTRIBUTION_REMAINDER_ID = '__account-distribution-remainder__';
 
 /**
  * Rank every account by what it currently holds.
@@ -88,9 +102,41 @@ export function buildAccountDistribution(
       : null,
   }));
 
-  return {
-    entries,
-    slices: entries.filter(entry => entry.value > 0).slice(0, ACCOUNT_DISTRIBUTION_SLICES),
-    inCreditTotal,
-  };
+  /**
+   * A CLOSED RING IS A CLAIM ABOUT THE WHOLE (Claude Design, 17 Aug §2.1).
+   * Drawn from the top five alone it showed ~55% of the money as if it were
+   * 100%, so a reader concluded their largest account was a sixth of their
+   * net worth when it was a thirty-fifth. Everything past the named slices is
+   * folded into ONE remainder slice — same arithmetic as
+   * capSeriesWithRemainder, done here so the card and the report cannot fold
+   * differently. The remainder is NAMED WITH ITS COUNT rather than "Other":
+   * "Other" is a real category in some ledgers, and a visible count tells the
+   * reader whether the fold hid something worth opening the full report for.
+   *
+   * The value comes from inCreditTotal minus the named slices — a Decimal
+   * subtraction, not a float sum of ninety balances — so ring and total agree
+   * to the penny by construction.
+   */
+  const inCredit = entries.filter(entry => entry.value > 0);
+  let slices: AccountDistributionEntry[];
+  let foldedCount = 0;
+  if (inCredit.length <= ACCOUNT_DISTRIBUTION_SLICES) {
+    slices = inCredit;
+  } else {
+    const named = inCredit.slice(0, ACCOUNT_DISTRIBUTION_SLICES - 1);
+    foldedCount = inCredit.length - named.length;
+    const namedTotal = named.reduce((sum, entry) => sum.plus(toDecimal(entry.value)), toDecimal(0));
+    const remainder = inCreditTotal.minus(namedTotal);
+    slices = [
+      ...named,
+      {
+        id: ACCOUNT_DISTRIBUTION_REMAINDER_ID,
+        name: `${foldedCount} smaller account${foldedCount === 1 ? '' : 's'}`,
+        value: remainder.toNumber(),
+        share: inCreditTotal.greaterThan(0) ? remainder.dividedBy(inCreditTotal).times(100) : null,
+      },
+    ];
+  }
+
+  return { entries, slices, inCreditTotal, foldedCount };
 }

--- a/src/utils/netWorthSeries.test.ts
+++ b/src/utils/netWorthSeries.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { buildNetWorthSnapshots } from './netWorthSeries';
+import { buildNetWorthSnapshots, netWorthAxisTicks } from './netWorthSeries';
 import type { Account, Transaction } from '../types';
 import type { PeriodRange } from '../hooks/usePeriod';
 
@@ -92,5 +92,54 @@ describe('buildNetWorthSnapshots — opening balances happen on a date', () => {
     expect(snap?.assets).toBe(300);
     expect(snap?.liabilities).toBe(80);
     expect(snap?.netWorth).toBe(220);
+  });
+});
+
+/**
+ * THE TICK FORMAT FOLLOWS THE SPAN OF THE DOMAIN (Design, 17 Aug §2.3).
+ * A sixteen-year monthly series labelled "Apr 10" read as sixteen dates in one
+ * April — 2-digit years are indistinguishable from days, and day-first is the
+ * en-GB order anyway.
+ */
+describe('netWorthAxisTicks — the tick format follows the span', () => {
+  const seeded = (range: PeriodRange) =>
+    buildNetWorthSnapshots(
+      [account({ id: 'a', name: 'A', openingBalance: 100 })],
+      [],
+      range,
+      range.to ?? new Date(2026, 7, 17)
+    );
+
+  it('monthly labels carry a full year, so a year cannot read as a day', () => {
+    const snaps = seeded({ from: D(2010, 4, 1), to: D(2026, 8, 17) });
+    expect(snaps[0].label).toMatch(/2010/);
+    expect(snaps[0].label).not.toMatch(/\b10\b/);
+  });
+
+  it('a multi-year window ticks in bare years, stepped to fit', () => {
+    const snaps = seeded({ from: D(2010, 4, 1), to: D(2026, 8, 17) });
+    const { ticks, tickFormatter } = netWorthAxisTicks(snaps);
+    expect(ticks).toBeDefined();
+    expect(tickFormatter).toBeDefined();
+    const rendered = ticks!.map(t => tickFormatter!(t));
+    // 16 years → every second year, "2010 · 2012 · …" — never "Apr 10".
+    expect(rendered[0]).toBe('2010');
+    expect(rendered).toEqual(rendered.map(r => r).filter(r => /^\d{4}$/.test(r)));
+    expect(rendered.length).toBeGreaterThanOrEqual(5);
+    expect(rendered.length).toBeLessThanOrEqual(9);
+    // Every tick names a real point, so recharts can place it.
+    const labels = new Set(snaps.map(s => s.label));
+    for (const t of ticks!) expect(labels.has(t)).toBe(true);
+  });
+
+  it('a window under two years keeps its month labels and lets recharts thin them', () => {
+    const snaps = seeded({ from: D(2025, 9, 1), to: D(2026, 8, 17) });
+    expect(netWorthAxisTicks(snaps)).toEqual({});
+  });
+
+  it('a window within one quarter stays day-first — "17 Aug", never "Aug 17"', () => {
+    const snaps = seeded({ from: D(2026, 8, 1), to: D(2026, 8, 17) });
+    expect(netWorthAxisTicks(snaps)).toEqual({});
+    expect(snaps[snaps.length - 1].label).toMatch(/^17 /);
   });
 });

--- a/src/utils/netWorthSeries.ts
+++ b/src/utils/netWorthSeries.ts
@@ -126,13 +126,70 @@ export function buildNetWorthSnapshots(
     }
     out.push({
       date: point,
+      // "Apr 2010", never "Apr 10": with the 2-digit year a sixteen-year
+      // series read as sixteen days inside one April (Design, 17 Aug §2.3) —
+      // and "Apr 10" is an American date besides, in an en-GB app. The daily
+      // cadence stays day-first for the same reason.
       label: point.toLocaleDateString(getDateLocale(), monthly
-        ? { month: 'short', year: '2-digit' }
-        : { day: '2-digit', month: 'short' }),
+        ? { month: 'short', year: 'numeric' }
+        : { day: 'numeric', month: 'short' }),
       assets: assets.toNumber(),
       liabilities: liabilities.toNumber(),
       netWorth: assets.minus(liabilities).toNumber(),
     });
   }
   return out;
+}
+
+/**
+ * X-axis props for a snapshot series: THE TICK FORMAT FOLLOWS THE SPAN OF THE
+ * DOMAIN (Claude Design, 17 Aug §2.3) — years for a multi-year window, month
+ * names for a multi-month one, dates within a month. A sixteen-year series was
+ * ticking "Apr 10 · Apr 12 · … · Aug 26": nine dates apparently inside one
+ * April, with the last tick changing month so it read as a data error rather
+ * than a scale.
+ *
+ * Under two years this returns nothing and recharts thins the month labels
+ * itself. From two years up it hands back explicit ticks — the first snapshot
+ * of each year, stepped so at most ~9 fit ("2010 · 2012 · …") — plus a
+ * formatter that renders each as its bare year. Left to a formatter alone,
+ * recharts' own tick choice can land two ticks inside one year and print
+ * "2010 · 2010", which is why the positions are supplied too.
+ *
+ * The full per-point label ("Apr 2010") survives untouched for the tooltip
+ * and for click identity — labels are what `activeLabel` hands back, so they
+ * must stay unique per point; only the AXIS text compresses.
+ */
+export function netWorthAxisTicks(snapshots: NetWorthSnapshot[]): {
+  ticks?: string[];
+  tickFormatter?: (label: string) => string;
+} {
+  if (snapshots.length < 2) return {};
+  const firstYear = snapshots[0].date.getFullYear();
+  const lastYear = snapshots[snapshots.length - 1].date.getFullYear();
+  const spanYears = lastYear - firstYear;
+  if (spanYears < 2) return {};
+
+  const firstLabelOfYear = new Map<number, string>();
+  const yearOfLabel = new Map<string, number>();
+  for (const snap of snapshots) {
+    const year = snap.date.getFullYear();
+    if (!firstLabelOfYear.has(year)) firstLabelOfYear.set(year, snap.label);
+    yearOfLabel.set(snap.label, year);
+  }
+
+  const step = Math.ceil(spanYears / 8);
+  const ticks: string[] = [];
+  for (let year = firstYear; year <= lastYear; year += step) {
+    const label = firstLabelOfYear.get(year);
+    if (label !== undefined) ticks.push(label);
+  }
+
+  return {
+    ticks,
+    tickFormatter: (label: string) => {
+      const year = yearOfLabel.get(label);
+      return year === undefined ? label : String(year);
+    },
+  };
 }


### PR DESCRIPTION
Claude Design's 17 August review of the populated dashboard — all six §2 findings, the §1 specimen ruling, and a grounded answer to their §3 data check. The reply handover is in `docs/handovers/2026-08-17-to-claude-design.md`.

## The two FIX findings, by cause

**§2.1 — the ring was a false claim about proportion.** The donut closed over the top five accounts alone, so ~55% of the money read as 100% and a reader concluded their largest account was a sixth of the whole when it was a thirty-fifth. The fold now lives inside `buildAccountDistribution` — four named slices plus a **"N smaller accounts"** remainder computed by Decimal subtraction from the in-credit total, so the card, the report, and the total agree by construction. Remainder clicks open the full report (card) or scroll to the every-account table (report); the subtitle names the fold.

**§2.2 — the light ramp bunched, and the extension rule was the bug.** Design's barrel hypothesis was eliminated first (this path uses real recharts); their "one missing branch" hypothesis was also wrong — the values themselves were misderived. Bisecting the ruled stops put three near-black navies ~1.17:1 apart into one five-step ramp, because on light the usable half of the axis is the compressed dark half. Only adjacent separation had ever been measured; legend-matching is a **pairwise** task. The light five are now spaced evenly in CIE L* (ΔL* ≈ 10.5, all ≥3:1 on `#f8f9fb`, no pair below 1.37:1), and both ramps deliberately end at `#6b86b3` — each ground's quietest step — which is exactly where the folded remainder sits, so §2.1's "remainder at the lightest step" costs zero special-casing. The ramp instrument now measures adjacent and all-pairs floors plus the last-step-quietest invariant, and was proven non-vacuous by reinstating an old navy and watching it fail.

## The rest

- **§2.3** "Apr 10" was April 2010 — a 2-digit year reading as a day (and an American date in an en-GB app). Labels carry full years; `netWorthAxisTicks` supplies explicit year ticks (positions and format) on multi-year windows, tested at the span boundaries. Widget and report share the helper.
- **§2.4** Y-domain bottom is `min(0, dataMin)` — the nice-tick floor had answered one early negative stretch with several intervals of empty plot.
- **§2.5** The trend arrows sit after their figures, same baseline; `justify-between` was the whole cause.
- **§2.6** The donut tooltip was a library default three ways (report ring: no style; dashboard ring: read-once style; NetWorthReport: a fourth radius-only survivor). The house tooltip is now the **wrapper default** — opaque, axis-scale type, `tabular-nums`, house `": "` separator at all 13 themed tooltips — and the read-once block is deleted.
- **§1** The alert preview: neutral container + hairline + "Example" label; the amber likeness inside untouched, per the ruling.
- **§3** Answered from code: no FX, quotes, or cache can move the dashboard net worth — only a real row landing between captures. Written up in the handover.

## Verified

- `npm run lint` — 0 warnings; `typecheck:strict` — clean
- Full unit suite via pre-commit — green
- `npm run desktop:verify` — PASS
- Ramp respacing measured with a derivation script + the repo's own `ColorContrastChecker`; instrument mutation-tested

🤖 Generated with [Claude Code](https://claude.com/claude-code)
