### PR TITLE
fix(register,modal): the amount wears the flow, notes joins the run, and three raw £ escapes

### DIFF
--- a/src/components/DocumentUpload.tsx
+++ b/src/components/DocumentUpload.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useRef, useCallback } from 'react';
 import { documentService } from '../services/documentService';
 import type { Document, DocumentUploadOptions } from '../services/documentService';
+import { formatCurrency } from '../utils/currency-decimal';
 import {
   UploadIcon,
   FileTextIcon,
@@ -385,7 +386,7 @@ export default function DocumentUpload({
                   {doc.extractedData && (
                     <p className="text-xs text-gray-600 dark:text-gray-400">
                       {doc.extractedData.merchant && `Merchant: ${doc.extractedData.merchant}`}
-                      {doc.extractedData.totalAmount && ` • £${doc.extractedData.totalAmount}`}
+                      {doc.extractedData.totalAmount && ` • ${formatCurrency(doc.extractedData.totalAmount)}`}
                     </p>
                   )}
                 </div>

--- a/src/components/EditTransactionModal.tsx
+++ b/src/components/EditTransactionModal.tsx
@@ -1144,13 +1144,27 @@ export default function EditTransactionModal({ isOpen, onClose, transaction, def
                   }
                 }}
                 placeholder="0.00"
-                className={`w-full px-3 py-2 h-[42px] text-right bg-white dark:bg-gray-800 border border-gray-300/50 dark:border-gray-600/50 rounded-xl focus:border-transparent ${
-                  formData.amount && (parseMoneyInput(formData.amount) ?? 0) < 0
+                // THE COLOUR FOLLOWS WHERE THE MONEY GOES, not the field's
+                // sign. This field holds MAGNITUDES for income/expense (the
+                // seed is Math.abs — the Type toggle above carries the
+                // direction, exactly as Quick Add works), so colouring by the
+                // field's own sign painted every expense income-green: the
+                // value here is never negative unless the user types a minus,
+                // which means a REDUCING line (a refund under income, cashback
+                // under expense) and flips the flow. A transfer's sign IS its
+                // direction, so it passes straight through. (Owner, 17 Aug:
+                // "labelled as an expense but the amount is in green".)
+                className={`w-full px-3 py-2 h-[42px] text-right bg-white dark:bg-gray-800 border border-gray-300/50 dark:border-gray-600/50 rounded-xl focus:border-transparent ${(() => {
+                  const entered = formData.amount ? parseMoneyInput(formData.amount) ?? 0 : 0;
+                  const flow = entered === 0 ? 0
+                    : formData.type === 'expense' ? -Math.sign(entered)
+                    : Math.sign(entered);
+                  return flow < 0
                     ? 'text-red-600 dark:text-red-400'
-                    : formData.amount && (parseMoneyInput(formData.amount) ?? 0) > 0
+                    : flow > 0
                     ? 'text-green-600 dark:text-green-400'
-                    : 'text-gray-900 dark:text-white'
-                }`}
+                    : 'text-gray-900 dark:text-white';
+                })()}`}
                 required
               />
             </div>

--- a/src/components/QuickEditRow.tsx
+++ b/src/components/QuickEditRow.tsx
@@ -87,8 +87,11 @@ import type { Account, Transaction } from '../types';
  * virtualised list (see VirtualizedTable's note on component identity).
  */
 
-/** The three things in the row that can hold the cursor. */
-export type QuickEditField = 'date' | 'description' | 'category';
+/** The things in the row that can hold the cursor.
+    Notes joined on 17 Aug (owner): tidying a statement is a run down ONE
+    field, and notes was the one field on show that still forced the full
+    editor open for every row. */
+export type QuickEditField = 'date' | 'description' | 'category' | 'notes';
 
 /**
  * Where the cursor should land in an editor that is opening, and how.
@@ -176,6 +179,8 @@ interface QuickEditRowContextValue {
   setDate: (value: string) => void;
   description: string;
   setDescription: (value: string) => void;
+  notes: string;
+  setNotes: (value: string) => void;
   category: string;
   chooseCategory: (categoryId: string) => void;
   /** Is the Category cell currently the transfer-to ACCOUNT picker? */
@@ -199,6 +204,7 @@ interface QuickEditRowContextValue {
   cancelTransferPrompt: () => void;
   dateFieldRef: React.RefObject<HTMLDivElement>;
   descriptionRef: React.RefObject<HTMLInputElement>;
+  notesRef: React.RefObject<HTMLInputElement>;
   saveButtonRef: React.RefObject<HTMLButtonElement>;
   saveAndNextButtonRef: React.RefObject<HTMLButtonElement>;
   handleKeyDown: (e: React.KeyboardEvent<HTMLDivElement>) => void;
@@ -267,7 +273,7 @@ export interface QuickEditRowProviderProps {
   children: React.ReactNode;
 }
 
-const ALL_FIELDS: readonly QuickEditField[] = ['date', 'description', 'category'];
+const ALL_FIELDS: readonly QuickEditField[] = ['date', 'description', 'category', 'notes'];
 
 export function QuickEditRowProvider({
   transaction,
@@ -297,6 +303,7 @@ export function QuickEditRowProvider({
   const [date, setDate] = useState(() => (transaction ? toDateInputValue(transaction.date) : ''));
   const [description, setDescription] = useState(transaction?.description ?? '');
   const [category, setCategory] = useState(transaction?.category ?? '');
+  const [notes, setNotes] = useState(transaction?.notes ?? '');
   /**
    * Which button's write is in flight, or null when none is.
    *
@@ -313,6 +320,7 @@ export function QuickEditRowProvider({
   // component's DOM by id.
   const dateFieldRef = useRef<HTMLDivElement>(null);
   const descriptionRef = useRef<HTMLInputElement>(null);
+  const notesRef = useRef<HTMLInputElement>(null);
   // Where the cursor goes when a field's Enter accepts what was typed; see the
   // comment on focusRunButton.
   const saveButtonRef = useRef<HTMLButtonElement>(null);
@@ -404,6 +412,7 @@ export function QuickEditRowProvider({
     setDate(transaction ? toDateInputValue(transaction.date) : '');
     setDescription(transaction?.description ?? '');
     setCategory(transaction?.category ?? '');
+    setNotes(transaction?.notes ?? '');
     // Transfer mode is about the ROW being edited, so it does not travel to the
     // next one: a Save & Next that landed with the account picker still up
     // would offer to move money the moment the user typed.
@@ -452,6 +461,13 @@ export function QuickEditRowProvider({
         // descriptions is nearly always a REPLACEMENT ("ASDA STORES 4021" →
         // "Asda"). Typing overwrites; one press of End or → keeps it instead.
         descriptionRef.current?.select();
+        return;
+      case 'notes':
+        // Same selection rule as the description, for the same reason: a run
+        // down the notes column is filing the same kind of remark row after
+        // row, and what is already there is usually being replaced.
+        notesRef.current?.focus();
+        notesRef.current?.select();
         return;
       case 'category':
         setCategoryOpenToken(token => token + 1);
@@ -556,6 +572,7 @@ export function QuickEditRowProvider({
         await updateTransaction(transaction.id, {
           date: parsedDate,
           description: description.trim(),
+          notes,
           // Reviewed, even though the transfer half of this save has not
           // happened yet: this write COMMITTED the user's field edits, and it
           // was a save button that made it. Cancelling the transfer prompt
@@ -606,6 +623,9 @@ export function QuickEditRowProvider({
       await updateTransaction(transaction.id, {
         date: parsedDate,
         description: description.trim(),
+        // As the full editor's update sends it: the string as typed, and an
+        // emptied field clears the note.
+        notes,
         // A SAVE IS A REVIEW. This is the whole of the Microsoft Money rule the
         // register's bold implements: the row stops being new when a save
         // button commits it, and not a moment before. Opening the editor and
@@ -655,7 +675,7 @@ export function QuickEditRowProvider({
       setSavingAction(null);
     }
   }, [
-    transaction, isSaving, description, date, category, categories, isTransfer, isSplit,
+    transaction, isSaving, description, notes, date, category, categories, isTransfer, isSplit,
     transferMode, transferAccountId, accounts,
     transactions, updateTransaction, propagateCategory, finishSave, showError,
   ]);
@@ -938,6 +958,8 @@ export function QuickEditRowProvider({
       setDate,
       description,
       setDescription,
+      notes,
+      setNotes,
       category,
       chooseCategory,
       transferMode,
@@ -956,6 +978,7 @@ export function QuickEditRowProvider({
       cancelTransferPrompt,
       dateFieldRef,
       descriptionRef,
+      notesRef,
       saveButtonRef,
       saveAndNextButtonRef,
       handleKeyDown,
@@ -965,7 +988,7 @@ export function QuickEditRowProvider({
       dismiss: onDismiss,
     };
   }, [
-    transaction, fields, date, description, category, chooseCategory,
+    transaction, fields, date, description, notes, category, chooseCategory,
     transferMode, toggleTransferMode, transferAccountId, chooseTransferAccount, transferTargets,
     dateFocusToken, categoryOpenToken, showingSuggestion, savingAction, onNext,
     transferPrompt, linkTransfer, createTransfer, cancelTransferPrompt,
@@ -1056,9 +1079,10 @@ function QuickEditCellShell({
  */
 export function QuickEditFieldCell({ field }: { field: QuickEditField }): React.JSX.Element {
   const {
-    transaction, date, setDate, description, setDescription, category, chooseCategory,
+    transaction, date, setDate, description, setDescription, notes, setNotes,
+    category, chooseCategory,
     transferMode, toggleTransferMode, transferAccountId, chooseTransferAccount, transferTargets,
-    dateFocusToken, categoryOpenToken, dateFieldRef, descriptionRef,
+    dateFocusToken, categoryOpenToken, dateFieldRef, descriptionRef, notesRef,
   } = useQuickEditRow();
 
   if (field === 'date') {
@@ -1111,6 +1135,28 @@ export function QuickEditFieldCell({ field }: { field: QuickEditField }): React.
           value={description}
           onChange={(e) => setDescription(e.target.value)}
           aria-label="Transaction description"
+          className="w-full px-2 h-[36px] text-sm font-normal bg-white dark:bg-gray-700 border border-gray-300 dark:border-gray-600 rounded-lg dark:text-white"
+        />
+      </QuickEditCellShell>
+    );
+  }
+
+  if (field === 'notes') {
+    return (
+      // The Notes cell behaves EXACTLY as the description does — type, Enter
+      // (accepts, hands over Save & Next), Enter (saves, moves on, cursor back
+      // here) — because the owner's use of it IS the description's use: the
+      // same annotation filed down a hundred rows. A single-line input, not
+      // the full editor's markdown box: what fits in a register cell is what
+      // can be edited in one; anything longer is the full editor's job, the
+      // same division Amounts already live under.
+      <QuickEditCellShell field="notes" className="px-3 min-w-0">
+        <input
+          ref={notesRef}
+          type="text"
+          value={notes}
+          onChange={(e) => setNotes(e.target.value)}
+          aria-label="Transaction notes"
           className="w-full px-2 h-[36px] text-sm font-normal bg-white dark:bg-gray-700 border border-gray-300 dark:border-gray-600 rounded-lg dark:text-white"
         />
       </QuickEditCellShell>

--- a/src/components/__tests__/EditTransactionModal.test.tsx
+++ b/src/components/__tests__/EditTransactionModal.test.tsx
@@ -5,9 +5,10 @@
 
 import React from 'react';
 import { describe, it, expect, beforeEach, vi } from 'vitest';
-import { screen } from '@testing-library/react';
+import { fireEvent, screen } from '@testing-library/react';
 import { renderWithProviders } from '../../test/testUtils';
 import EditTransactionModal from '../EditTransactionModal';
+import type { Account, Transaction } from '../../types';
 
 describe('EditTransactionModal', () => {
   const defaultProps = {
@@ -25,12 +26,6 @@ describe('EditTransactionModal', () => {
     expect(screen.getByRole('dialog')).toBeInTheDocument();
   });
 
-  it('handles user interactions', async () => {
-    renderWithProviders(<EditTransactionModal {...defaultProps} />);
-    
-    // Add interaction tests
-  });
-
   it('validates form inputs', async () => {
     // Add validation tests
   });
@@ -39,4 +34,70 @@ describe('EditTransactionModal', () => {
     // Add error handling tests
   });
 
+});
+
+/**
+ * THE AMOUNT'S COLOUR FOLLOWS WHERE THE MONEY GOES (owner, 17 Aug).
+ *
+ * The field holds MAGNITUDES for income/expense — the seed is Math.abs and the
+ * Type toggle carries the direction — but the colour was derived from the
+ * field's own sign, which after seeding is always positive. So every expense
+ * opened wearing income green, for months, on a form whose Type toggle said
+ * "Expense" in red two lines up. Every figure below is invented; the repo is
+ * public.
+ */
+describe('EditTransactionModal — the amount wears the flow, not the field sign', () => {
+  const ACCOUNT: Account = {
+    id: 'acc-modal', name: 'Synthetic Current', type: 'current', balance: 0,
+    currency: 'GBP', lastUpdated: new Date('2026-01-01'), openingBalance: 0, isActive: true,
+  };
+
+  const EXPENSE: Transaction = {
+    id: 'txn-modal-0', date: new Date(Date.UTC(2026, 0, 5)),
+    description: 'Synthetic valuation move', amount: -650, type: 'expense',
+    category: '', accountId: ACCOUNT.id, cleared: false,
+  };
+
+  const amountInput = (): HTMLInputElement => {
+    const el = screen.getByPlaceholderText('0.00');
+    if (!(el instanceof HTMLInputElement)) throw new Error('the amount is not an input');
+    return el;
+  };
+
+  it('an expense opens red and unsigned — the type carries the sign, the colour agrees with it', () => {
+    renderWithProviders(
+      <EditTransactionModal isOpen onClose={vi.fn()} transaction={EXPENSE} />,
+      { initialState: { accounts: [ACCOUNT], transactions: [EXPENSE] } }
+    );
+
+    // Magnitude in the field, exactly as Quick Add takes it…
+    expect(amountInput().value).not.toContain('-');
+    // …and the colour states the flow the Type toggle states: money OUT.
+    expect(amountInput().className).toContain('text-red-600');
+    expect(amountInput().className).not.toContain('text-green-600');
+  });
+
+  it('switching the type to Income flips the same figure to green', () => {
+    renderWithProviders(
+      <EditTransactionModal isOpen onClose={vi.fn()} transaction={EXPENSE} />,
+      { initialState: { accounts: [ACCOUNT], transactions: [EXPENSE] } }
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Income' }));
+
+    expect(amountInput().className).toContain('text-green-600');
+  });
+
+  it('a typed minus is a reducing line, and flips the flow back', () => {
+    renderWithProviders(
+      <EditTransactionModal isOpen onClose={vi.fn()} transaction={EXPENSE} />,
+      { initialState: { accounts: [ACCOUNT], transactions: [EXPENSE] } }
+    );
+
+    // Minus on an EXPENSE means money coming back (cashback, a refund line):
+    // the flow is inward, so the colour is the income green.
+    fireEvent.change(amountInput(), { target: { value: '-100' } });
+
+    expect(amountInput().className).toContain('text-green-600');
+  });
 });

--- a/src/pages/AccountTransactions.tsx
+++ b/src/pages/AccountTransactions.tsx
@@ -197,13 +197,16 @@ const EXPANDED_DOCK_RESERVE_PX = 32;
  * The mapping is the whole of the alignment problem: the editor never places
  * anything, it only says which cell it belongs in, and the cell is drawn by the
  * table at the column's own width under the column's own header. Any column not
- * named here — Payment, Deposit, Balance, R, Tags, Notes — stays exactly as it
- * reads. Amounts are the full editor's job.
+ * named here — Payment, Deposit, Balance, R, Tags — stays exactly as it
+ * reads. Amounts are the full editor's job. Notes joined on 17 Aug (owner:
+ * annotating a statement is the same run as tidying descriptions, and it was
+ * the one on-screen text field that still forced the full editor open per row).
  */
 const QUICK_EDIT_COLUMN_FIELDS: Readonly<Record<string, QuickEditField>> = {
   date: 'date',
   description: 'description',
   category: 'category',
+  notes: 'notes',
 };
 
 // Friendly labels for the View dropdown's column checkboxes.
@@ -2857,7 +2860,7 @@ export default function AccountTransactions() {
    */
   const quickEditFields = useMemo<QuickEditField[]>(() => {
     const shown = new Set(columns.map(c => c.key));
-    return (['date', 'description', 'category'] as const).filter(field => {
+    return (['date', 'description', 'category', 'notes'] as const).filter(field => {
       if (!shown.has(field)) return false;
       return field !== 'category' || canEditCategoryInPlace;
     });

--- a/src/pages/__tests__/AccountTransactions.inlineEdit.test.tsx
+++ b/src/pages/__tests__/AccountTransactions.inlineEdit.test.tsx
@@ -85,6 +85,7 @@ const ROWS: Transaction[] = [
   {
     id: 'txn-2', date: new Date(Date.UTC(2026, 0, 9)), description: 'Cobblestone Cafe',
     amount: -6.8, type: 'expense', category: 'det-groceries', accountId: ACCOUNT.id, cleared: false,
+    notes: 'Loyalty stamp',
   },
   {
     id: 'txn-3', date: new Date(Date.UTC(2026, 0, 12)), description: 'Thistledown Books',
@@ -929,5 +930,112 @@ describe('Account register — Escape peels the box off first', () => {
     fireEvent.keyDown(combobox, { key: 'Delete' });
 
     expect(screen.queryByRole('alertdialog')).not.toBeInTheDocument();
+  });
+});
+
+/**
+ * NOTES JOINS THE RUN (owner, 17 Aug): "Can the notes area act just like
+ * description as in if I type something in there and press enter, save & next
+ * gets highlighted and another press of enter saves it and moves to the next."
+ *
+ * The column is hidden by default, so these tests show it the way the owner
+ * did — through the View menu — and the last test pins the other half of the
+ * rule: a hidden column takes its editor with it.
+ */
+describe('Account register — the Notes cell joins the run', () => {
+  const notesField = (): HTMLInputElement => {
+    const el = screen.getByLabelText('Transaction notes');
+    if (!(el instanceof HTMLInputElement)) throw new Error('the notes cell is not an input');
+    return el;
+  };
+
+  /** Tick Notes in the View menu, then close it, exactly as a user would. */
+  const showNotesColumn = async (): Promise<void> => {
+    const viewButton = screen.getByRole('button', { name: 'View' });
+    fireEvent.click(viewButton);
+    fireEvent.click(await screen.findByRole('checkbox', { name: 'Notes' }));
+    fireEvent.click(viewButton);
+  };
+
+  it('puts the notes field in its own cell, seeded with the stored note', async () => {
+    await openRegister();
+    await showNotesColumn();
+
+    clickRow('Cobblestone Cafe');
+
+    const row = editorRow();
+    expect(row.contains(notesField())).toBe(true);
+    expect(notesField()).toHaveValue('Loyalty stamp');
+
+    // Under its own header, same contract as the other three fields.
+    const headers = within(grid())
+      .getAllByRole('columnheader')
+      .map(h => (h.textContent ?? '').replace(/[↑↓]/g, '').trim());
+    const cells = within(row).getAllByRole('gridcell');
+    const cellIndex = cells.indexOf(notesField().closest('[role="gridcell"]') as HTMLElement);
+    expect(cellIndex).toBe(headers.indexOf('Notes'));
+  });
+
+  it('types, Enter accepts, Enter saves the note and moves on — the description rhythm exactly', async () => {
+    const user = userEvent.setup();
+    await openRegister();
+    await showNotesColumn();
+    clickRow('Sandpiper Foods');
+
+    notesField().focus();
+    fireEvent.change(notesField(), { target: { value: 'Card ending 4021' } });
+    fireEvent.keyDown(notesField(), { key: 'Enter' });
+
+    // First Enter accepts and hands over Save & Next — nothing written yet.
+    expect(updateTransaction).not.toHaveBeenCalled();
+    expect(document.activeElement).toBe(saveAndNext());
+
+    await user.keyboard('{Enter}');
+
+    await waitFor(() => {
+      expect(updateTransaction).toHaveBeenCalledTimes(1);
+    });
+    expect(updateTransaction).toHaveBeenCalledWith('txn-1', expect.objectContaining({
+      notes: 'Card ending 4021',
+    }));
+
+    // …and the run lands in the NEXT row's notes, stored text selected, so a
+    // sweep down the column is type, Enter, Enter, type, Enter, Enter.
+    await waitFor(() => {
+      expect(notesField()).toHaveValue('Loyalty stamp');
+    });
+    const next = notesField();
+    expect(document.activeElement).toBe(next);
+    expect(next.selectionStart).toBe(0);
+    expect(next.selectionEnd).toBe('Loyalty stamp'.length);
+  });
+
+  it('saves an untouched note back unchanged when the edit was elsewhere', async () => {
+    const user = userEvent.setup();
+    await openRegister();
+    await showNotesColumn();
+    clickRow('Cobblestone Cafe');
+
+    descriptionField().focus();
+    fireEvent.change(descriptionField(), { target: { value: 'Cobblestone Cafe Ltd' } });
+    fireEvent.keyDown(descriptionField(), { key: 'Enter' });
+    await user.keyboard('{Enter}');
+
+    await waitFor(() => {
+      expect(updateTransaction).toHaveBeenCalledTimes(1);
+    });
+    expect(updateTransaction).toHaveBeenCalledWith('txn-2', expect.objectContaining({
+      description: 'Cobblestone Cafe Ltd',
+      notes: 'Loyalty stamp',
+    }));
+  });
+
+  it('takes its editor with it while the column is hidden', async () => {
+    await openRegister();
+
+    clickRow('Sandpiper Foods');
+
+    expect(isEditing()).toBe(true);
+    expect(screen.queryByLabelText('Transaction notes')).not.toBeInTheDocument();
   });
 });

--- a/src/services/notificationService.ts
+++ b/src/services/notificationService.ts
@@ -279,7 +279,7 @@ export class NotificationService {
             field: 'amount',
             operator: 'greater_than',
             value: this.transactionAlertConfig.largeTransactionThreshold,
-            description: `Transaction amount exceeds £${this.transactionAlertConfig.largeTransactionThreshold}`
+            description: `Transaction amount exceeds ${formatCurrencyDecimal(this.transactionAlertConfig.largeTransactionThreshold)}`
           }
         ],
         actions: [
@@ -561,7 +561,10 @@ export class NotificationService {
         id: `duplicate-transaction-${transaction.id}`,
         type: 'warning',
         title: 'Possible Duplicate Transaction',
-        message: `Similar transaction detected: ${transaction.description} (£${transaction.amount})`,
+        // Through the house formatter, not `£${raw}`: the raw number printed a
+        // minus INSIDE punctuation parentheses — "(£-31.15)" — colliding with
+        // the accounting convention where parentheses ARE the sign.
+        message: `Similar transaction detected: ${transaction.description} at ${formatCurrencyDecimal(transaction.amount)}`,
         timestamp: new Date(),
         read: false,
         action: {


### PR DESCRIPTION
Three register tidy-ups from the owner, 17 August.

## 1. The green expense in the edit modal

The amount input coloured by the **field's own sign** — but income/expense amounts are seeded as `Math.abs` (you type magnitudes; the Type toggle carries the direction, exactly as Quick Add works), so the field was never negative and **every expense opened wearing income green** under a toggle saying "Expense" in red. The colour now follows the effective flow — type direction × entered sign — so an expense is red, a typed minus (a reducing line: cashback, a refund under income) flips it, and a transfer's sign passes straight through. The magnitude stays unsigned in the field, deliberately: that's the entered-domain contract Quick Add shares, and the register's display is where the accounting parentheses live.

## 2. Notes joins the quick-edit run

With the Notes column shown (View menu), its cell becomes an input exactly like Description: **type → Enter accepts and hands over Save & Next → Enter saves and lands in the next row's notes with the stored text selected**. Annotating a statement was a full-editor round trip per row. A hidden column still takes its editor with it. Single-line input by design — what fits in a register cell is what can be edited in one; longer notes stay the full editor's job, the same division Amounts already live under.

The new test caught a real bug in my first cut: `notes` missing from `save()`'s dependency array sent the pre-keystroke value (stale closure). Worth having the test for that alone.

## 3. The owner's app-wide rule: negatives wear (£X) in red

The convention is already centralised — `formatCurrency` has rendered `(£417.54)` since Design's 15 August ruling, with `<Amount>` carrying the screen-reader half. The sweep found **three template-string escapes**: the duplicate-transaction notification printed a raw amount inside punctuation parentheses (`(£-31.15)` — both sign conventions at once), the large-transaction rule text and DocumentUpload's extracted total were raw `£${n}`. All three now route through the house formatter. Chart axis ticks keep their minus deliberately: compact notation in a colourless context, where the glyph is the only sign carrier.

## Verified

- `npm run lint` — 0; `typecheck:strict` — clean
- Full unit suite via pre-commit — green
- New tests: modal flow-colour trio; notes-run quartet (33 + 6 in their files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)