### PR TITLE
feat(investments): sleeves are doors, a holding knows its currency, and a buy moves real cash

### DIFF
--- a/docs/investment-register-notes.md
+++ b/docs/investment-register-notes.md
@@ -1,0 +1,84 @@
+# The investment register — Money's model, what ships now, what remains
+
+**Written 17 August 2026**, answering the owner's ask: charges on a purchase,
+the cash leg out of a funding account, and "the investment account needs to
+act as a proper investment register... do some research as to how MS Money
+structured theirs."
+
+## 1. How Microsoft Money actually structured it (measured, not remembered)
+
+From the .mny import work (real files read table-by-table, plus the KB
+archive) — the same sources that drive the importer:
+
+- **The pairing is two real accounts.** An investment account and its cash
+  account are separate rows linked 1:1 (`ACCT.hacctRel`); the cash side has
+  its own register and reconciliation but no settings page of its own. This
+  app mirrors that exactly — the nested "(Cash)" account — and deliberately
+  lifts Money's one limitation (there the link could only be made at
+  creation).
+- **A buy is an investment transaction plus an optional cash leg.** The buy
+  row lives in the investment register with security, units, price and
+  commission; its **total** (units × price + commission) is what the linked
+  cash leg moves. Measured across real files: 2,015 of 2,029 buys carried a
+  cash leg, and the funding account was a **free choice** — any cash account,
+  not just the paired sleeve.
+- **Commission folds into cost.** Money's average cost is total paid ÷ shares
+  held, charges included. There is no "cost excluding fees" figure anywhere
+  in its UI.
+- **Cash sufficiency is never enforced.** Sleeves run negative freely; only
+  negative *share* balances are blocked.
+- **Some flows never touch cash**: reinvested distributions (0 of 1,020 had
+  a cash leg) and employer matches (0 of 92). A cash dividend always did
+  (1,090 of 1,090).
+
+## 2. What ships today (this change)
+
+The Add-a-holding flow now carries Money's buy semantics without a schema
+change:
+
+- **Charges** (stamp duty, levy, commission) fold into the stored average
+  cost — `allInAverageCost` in `services/investments/purchaseMath.ts` — so
+  the derived cost basis is the money actually spent, with a provenance note
+  on the holding. This is Money's own definition of average cost.
+- **"Paid from"** offers any open account in the investment account's
+  currency (the free choice, the paired cash sleeve sorted first) and writes
+  the transfer through the same out-leg + `createTransferCounterpart`
+  machinery every transfer uses. The investment account's register shows the
+  arriving leg described as the buy ("Buy 100 SHEL.L"), so the ledger
+  balance moves by the real cash cost.
+- **The holding carries its own currency**, stated by its quote rather than
+  assumed from the account, and the portfolio totals convert to the display
+  currency instead of summing dollars into pounds.
+
+Cross-currency funding is deliberately not offered in this dialog: the
+counterpart write copies the row's digits, and a converted transfer needs its
+confirmed figure (the CrossCurrencyTransferDialog flow, from the register).
+
+## 3. What a full investment register would add, and what it costs
+
+Money's register shows **investment columns** — activity, security, units,
+price, charges, total — where ours shows a transfer row with a descriptive
+line. Closing that gap properly means:
+
+1. **An investment-transaction shape**: either a sibling table
+   (`investment_transactions`: activity buy/sell/reinvest/dividend, units,
+   price, charges, linked cash transaction id) or typed columns on the
+   holding's history. Money uses the former.
+2. **Sells and dividends**, which are where the shape earns its keep: a sell
+   reduces units and realises a gain (cost-basis lot accounting — Money used
+   average cost; FIFO is the HMRC-relevant alternative the owner may care
+   about); a cash dividend writes income into the cash sleeve against the
+   security.
+3. **Register rendering** for investment accounts: the extra columns, shown
+   only there — the account-type switch the register already does for cards.
+4. **Reconciliation of units**, not just money: statements state holdings.
+
+Each is real work with schema, importer and local-edition (Rust core)
+consequences, so it should be sliced deliberately rather than ridden in on a
+dialog change. The importer already understands Money's investment tables,
+which means a future migration of his own history into this shape is
+tractable.
+
+**Recommended order** when picked up: sells (with average-cost realisation,
+Money-compatible) → dividends into the sleeve → the register columns →
+unit-level reconciliation.

--- a/src/components/PortfolioManager.tsx
+++ b/src/components/PortfolioManager.tsx
@@ -1,9 +1,12 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useCurrencyDecimal } from '../hooks/useCurrencyDecimal';
-import { toDecimal, parseMoneyInput } from '../utils/decimal';
+import { toDecimal, parseMoneyInput, type DecimalInstance } from '../utils/decimal';
 import { formatDecimal } from '../utils/decimal-format';
+import { supportedCurrencies } from '../utils/currency';
 import MoneyInput from './common/MoneyInput';
+import DatePicker from './common/DatePicker';
 import StockSymbolSearch from './StockSymbolSearch';
+import { fetchQuotes, type StockQuote } from '../services/stockPriceService';
 import { PlusIcon, EditIcon, DeleteIcon, CheckIcon } from './icons';
 import { Modal } from './common/Modal';
 import { LoadingButton } from './loading/LoadingState';
@@ -18,6 +21,8 @@ import {
   type InvestmentAssetType,
   type InvestmentHolding
 } from '../services/investments/holding';
+import { purchaseCashTotal } from '../services/investments/purchaseMath';
+import type { Account } from '../types';
 
 /**
  * Add, change and remove holdings — and actually keep them.
@@ -36,22 +41,64 @@ import {
  * would not answer anyway. It therefore rejected EVERY symbol, including AAPL,
  * with "not found". The field is now a lookup: you pick a real instrument, so
  * there is nothing left to validate.
+ *
+ * ── THE CURRENCY IS THE INSTRUMENT'S, NOT THE ACCOUNT'S (owner, 17 Aug) ─────
+ * "Average cost per unit (GBP)" was a claim, not a question: Apple trades in
+ * dollars whatever currency the account counts in, and a dollar figure filed
+ * as pounds is wrong by the exchange rate forever after. Picking a symbol now
+ * fetches its QUOTE — the one source that states the trading currency
+ * authoritatively (LSE pence already normalised to pounds at the proxy) — and
+ * the price it brings back is shown, so the owner can sanity-check the figure
+ * they are about to type. No quote (a fund with no price today, the provider
+ * rate-limiting) degrades to a sensible default and an editable dropdown,
+ * never a blocked form.
+ *
+ * ── THE PURCHASE IS ALSO CASH LEAVING SOMEWHERE (owner, 17 Aug) ─────────────
+ * Money's model, measured from real .mny files: a buy could name any funding
+ * account (2015 of 2029 buys carried a cash leg), commission folded into the
+ * total, and the cash leg moved that total. So the add form offers the same:
+ * charges (stamp duty, a levy, commission) that fold into the all-in average
+ * cost, and an optional "paid from" account that writes the transfer — out of
+ * the chosen account, into this investment account — through the same
+ * machinery every other transfer uses. The page owns those writes; this form
+ * only gathers the answers.
  */
 
 /** What a save needs, independent of whether it is an add or an edit. */
 export interface HoldingFormValues {
   symbol: string;
   name: string;
-  quantity: ReturnType<typeof toDecimal>;
-  averageCost: ReturnType<typeof toDecimal>;
+  quantity: DecimalInstance;
+  averageCost: DecimalInstance;
+  /** The currency the cost figures are IN — the instrument's, not the account's. */
+  currency: string;
   assetType: InvestmentAssetType;
+}
+
+/** The cash half of an add: charges, and where the money came from. */
+export interface PurchaseDetails {
+  /** In the holding's currency; folds into the all-in average cost. Zero when none. */
+  charges: DecimalInstance;
+  /** null: just record the holding, no transfer. */
+  fundingAccountId: string | null;
+  /** What actually left the funding account, in ITS currency. null without funding. */
+  totalPaid: DecimalInstance | null;
+  /** The trade date — the transfer's date and the holding's purchase date. */
+  date: Date;
 }
 
 interface PortfolioManagerProps {
   holdings: readonly InvestmentHolding[];
-  /** The account's currency — what the cost figures are entered in. */
+  /** The investment account's currency — the fallback when a holding has none. */
   currency: string;
-  onAdd: (values: HoldingFormValues) => Promise<void>;
+  /**
+   * Accounts a purchase may be funded from: open, not this account, and in
+   * THIS ACCOUNT'S currency — the counterpart write mints the far side from
+   * the same digits, so a cross-currency funding needs the transfer dialog's
+   * confirmed-figure flow, not a silent copy. The page filters; this renders.
+   */
+  fundingAccounts: readonly Account[];
+  onAdd: (values: HoldingFormValues, purchase: PurchaseDetails) => Promise<void>;
   onEdit: (id: string, values: HoldingFormValues) => Promise<void>;
   onDelete: (id: string) => Promise<void>;
 }
@@ -78,14 +125,41 @@ function assetTypeFromLookup(type: string): InvestmentAssetType {
   return 'other';
 }
 
+/**
+ * The currency to OFFER before (or without) a quote: LSE listings price in
+ * pounds once the proxy has normalised the pence, a bare symbol is Yahoo's US
+ * dialect, anything else falls back to the account. A guess, deliberately
+ * displayed in an editable dropdown — the quote corrects it when one arrives,
+ * and the owner corrects it when one does not.
+ */
+function defaultCurrencyFor(symbol: string, exchange: string, fallback: string): string {
+  if (exchange === 'LSE' || symbol.toUpperCase().endsWith('.L')) return 'GBP';
+  if (!symbol.includes('.')) return 'USD';
+  return fallback;
+}
+
+const inputClass =
+  'w-full px-4 py-2 border border-gray-300 dark:border-gray-600 rounded-lg focus:border-transparent dark:bg-gray-700 dark:text-white';
+
+const labelClass = 'block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1';
+
+const helperClass = 'mt-1 text-xs text-gray-500 dark:text-gray-400';
+
+const toDateInputValue = (date: Date): string => {
+  const month = `${date.getMonth() + 1}`.padStart(2, '0');
+  const day = `${date.getDate()}`.padStart(2, '0');
+  return `${date.getFullYear()}-${month}-${day}`;
+};
+
 export default function PortfolioManager({
   holdings,
   currency,
+  fundingAccounts,
   onAdd,
   onEdit,
   onDelete
 }: PortfolioManagerProps): React.JSX.Element {
-  const { formatCurrency } = useCurrencyDecimal();
+  const { formatCurrency, convert, convertAndSum, displayCurrency } = useCurrencyDecimal();
   const [isAddOpen, setIsAddOpen] = useState(false);
   const [editing, setEditing] = useState<InvestmentHolding | null>(null);
   const [isSaving, setIsSaving] = useState(false);
@@ -100,6 +174,20 @@ export default function PortfolioManager({
   const [pickingSymbol, setPickingSymbol] = useState(true);
   const [quantity, setQuantity] = useState('');
   const [averageCost, setAverageCost] = useState('');
+  const [holdingCurrency, setHoldingCurrency] = useState(currency);
+  // Once the owner has picked a currency by hand, a quote arriving later must
+  // not overrule them — they may know something the feed does not.
+  const [currencyTouched, setCurrencyTouched] = useState(false);
+  const [charges, setCharges] = useState('');
+  const [fundingAccountId, setFundingAccountId] = useState('');
+  const [totalPaid, setTotalPaid] = useState('');
+  const [totalPaidTouched, setTotalPaidTouched] = useState(false);
+  const [purchaseDate, setPurchaseDate] = useState(() => toDateInputValue(new Date()));
+
+  // The picked instrument's live quote: the trading currency stated by the
+  // exchange, and a price to sanity-check the typed cost against.
+  const [quote, setQuote] = useState<StockQuote | null>(null);
+  const [quoteLoading, setQuoteLoading] = useState(false);
 
   const resetForm = (): void => {
     setSymbol('');
@@ -108,6 +196,15 @@ export default function PortfolioManager({
     setPickingSymbol(true);
     setQuantity('');
     setAverageCost('');
+    setHoldingCurrency(currency);
+    setCurrencyTouched(false);
+    setCharges('');
+    setFundingAccountId('');
+    setTotalPaid('');
+    setTotalPaidTouched(false);
+    setPurchaseDate(toDateInputValue(new Date()));
+    setQuote(null);
+    setQuoteLoading(false);
     setFormError('');
   };
 
@@ -130,7 +227,32 @@ export default function PortfolioManager({
     setPickingSymbol(false);
     setQuantity(holding.quantity.toString());
     setAverageCost(holding.averageCost.toString());
+    setHoldingCurrency(holding.currency || currency);
+    setCurrencyTouched(true);
+    setQuote(null);
     setEditing(holding);
+  };
+
+  /** Ask the exchange what this instrument trades in, and at. */
+  const loadQuote = (picked: string): void => {
+    setQuote(null);
+    setQuoteLoading(true);
+    void fetchQuotes([picked])
+      .then((batch) => {
+        const found = batch.quotes.get(picked.toUpperCase());
+        if (found) {
+          setQuote(found);
+          setCurrencyTouched((touched) => {
+            if (!touched) setHoldingCurrency(found.currency);
+            return touched;
+          });
+        }
+      })
+      .catch(() => {
+        // No quote is not an error the form needs to announce: the currency
+        // dropdown already holds a sensible default and stays editable.
+      })
+      .finally(() => setQuoteLoading(false));
   };
 
   const handleDelete = async (holding: InvestmentHolding): Promise<void> => {
@@ -148,6 +270,77 @@ export default function PortfolioManager({
     }
   };
 
+  const fundingAccount = fundingAccounts.find((a) => a.id === fundingAccountId) ?? null;
+  const chargesValue = charges === '' ? 0 : parseMoneyInput(charges);
+  const quantityValue = Number(quantity);
+  const costValue = parseMoneyInput(averageCost);
+
+  /**
+   * What the purchase costs in cash, in the HOLDING's currency — the default
+   * for "total paid" whenever the funding account counts in that currency.
+   * Across a currency boundary there is no default: the true figure is on the
+   * broker's note, and inventing one via an FX rate would write an unverified
+   * number into two registers.
+   */
+  const cashTotal =
+    quantityValue > 0 && costValue !== null && costValue > 0 && chargesValue !== null && chargesValue >= 0
+      ? purchaseCashTotal(toDecimal(quantityValue), toDecimal(costValue), toDecimal(chargesValue))
+      : null;
+
+  const fundingMatchesHoldingCurrency =
+    fundingAccount !== null && fundingAccount.currency === holdingCurrency;
+
+  // A Decimal is a fresh object every render, so the effects below key on its
+  // STRING — stable while the figure is, changed exactly when it changes.
+  const cashTotalKey = cashTotal !== null ? cashTotal.toDecimalPlaces(2).toString() : null;
+
+  // Keep the editable default in step with the figures above it — until the
+  // owner types their own total, which is then theirs.
+  useEffect(() => {
+    if (totalPaidTouched || !fundingMatchesHoldingCurrency || cashTotalKey === null) return;
+    setTotalPaid(cashTotalKey);
+  }, [totalPaidTouched, fundingMatchesHoldingCurrency, cashTotalKey]);
+
+  const previewCostBasis = cashTotal;
+  const previewKey = previewCostBasis !== null ? previewCostBasis.toString() : null;
+
+  // The preview in the owner's BASE currency, when the holding trades in
+  // another. Display-only, today's cached rate — same convention as every
+  // other converted figure in the app.
+  const [baseEquivalent, setBaseEquivalent] = useState<DecimalInstance | null>(null);
+  useEffect(() => {
+    let cancelled = false;
+    if (previewKey === null || holdingCurrency === displayCurrency) {
+      setBaseEquivalent(null);
+      return;
+    }
+    void convert(toDecimal(previewKey), holdingCurrency).then((converted) => {
+      if (!cancelled) setBaseEquivalent(converted);
+    }).catch(() => {
+      if (!cancelled) setBaseEquivalent(null);
+    });
+    return () => { cancelled = true; };
+  }, [previewKey, holdingCurrency, displayCurrency, convert]);
+
+  /**
+   * The list's total, CONVERTED. Summing costBasis raw added dollars to
+   * pounds the moment one holding traded in another currency — the exact
+   * "portfolio balance correct in the user's base currency" ask.
+   */
+  const [totalCostBasisInBase, setTotalCostBasisInBase] = useState<DecimalInstance | null>(null);
+  const mixedCurrencies = holdings.some((h) => (h.currency || currency) !== displayCurrency);
+  useEffect(() => {
+    let cancelled = false;
+    void convertAndSum(
+      holdings.map((h) => ({ amount: h.costBasis, currency: h.currency || currency }))
+    ).then((total) => {
+      if (!cancelled) setTotalCostBasisInBase(total);
+    }).catch(() => {
+      if (!cancelled) setTotalCostBasisInBase(null);
+    });
+    return () => { cancelled = true; };
+  }, [holdings, currency, convertAndSum]);
+
   const handleSave = async (): Promise<void> => {
     setFormError('');
 
@@ -156,15 +349,18 @@ export default function PortfolioManager({
       return;
     }
 
-    const quantityValue = Number(quantity);
     if (!Number.isFinite(quantityValue) || quantityValue <= 0) {
       setFormError('Units must be a positive number');
       return;
     }
 
-    const costValue = parseMoneyInput(averageCost);
     if (costValue === null || !Number.isFinite(costValue) || costValue <= 0) {
       setFormError('Average cost must be a positive amount');
+      return;
+    }
+
+    if (chargesValue === null || chargesValue < 0) {
+      setFormError('Charges must be zero or more');
       return;
     }
 
@@ -173,15 +369,40 @@ export default function PortfolioManager({
       name: name.trim() || symbol,
       quantity: toDecimal(quantityValue),
       averageCost: toDecimal(costValue),
+      currency: holdingCurrency,
       assetType
     };
+
+    let purchase: PurchaseDetails = {
+      charges: toDecimal(chargesValue),
+      fundingAccountId: null,
+      totalPaid: null,
+      date: new Date(`${purchaseDate}T00:00:00`)
+    };
+
+    if (!editing && fundingAccountId !== '') {
+      const paidValue = parseMoneyInput(totalPaid);
+      if (paidValue === null || paidValue <= 0) {
+        setFormError(
+          fundingMatchesHoldingCurrency
+            ? 'Enter the total paid, including charges'
+            : `Enter the total paid in ${fundingAccount?.currency ?? 'the funding account’s currency'} — it is on the contract note`
+        );
+        return;
+      }
+      if (Number.isNaN(purchase.date.getTime())) {
+        setFormError('Enter the date the purchase settled');
+        return;
+      }
+      purchase = { ...purchase, fundingAccountId, totalPaid: toDecimal(paidValue) };
+    }
 
     setIsSaving(true);
     try {
       if (editing) {
         await onEdit(editing.id, values);
       } else {
-        await onAdd(values);
+        await onAdd(values, purchase);
       }
       closeModal();
     } catch (error) {
@@ -194,13 +415,6 @@ export default function PortfolioManager({
       setIsSaving(false);
     }
   };
-
-  const totalCostBasis = holdings.reduce((sum, h) => sum.plus(h.costBasis), toDecimal(0));
-
-  const previewCostBasis =
-    quantity && averageCost && Number.isFinite(Number(quantity)) && parseMoneyInput(averageCost) !== null
-      ? toDecimal(Number(quantity)).times(toDecimal(parseMoneyInput(averageCost) ?? 0))
-      : null;
 
   return (
     <div className="space-y-6">
@@ -291,9 +505,18 @@ export default function PortfolioManager({
 
           <div className="mt-4 pt-4 border-t border-gray-200 dark:border-gray-700">
             <div className="flex justify-between items-center">
-              <span className="font-semibold text-gray-900 dark:text-white">Total cost basis</span>
+              <span className="font-semibold text-gray-900 dark:text-white">
+                Total cost basis
+                {/* Named only when it did WORK: with a dollar holding in the
+                    list, an unlabelled total silently added currencies. */}
+                {mixedCurrencies && (
+                  <span className="ml-2 text-xs font-normal text-gray-500 dark:text-gray-400">
+                    in {displayCurrency}, at today's rate
+                  </span>
+                )}
+              </span>
               <span className="text-xl font-bold text-gray-900 dark:text-white tabular-nums">
-                {formatCurrency(totalCostBasis, currency)}
+                {totalCostBasisInBase !== null ? formatCurrency(totalCostBasisInBase, displayCurrency) : '—'}
               </span>
             </div>
           </div>
@@ -307,7 +530,7 @@ export default function PortfolioManager({
       >
         <div className="space-y-4">
           <div>
-            <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+            <label className={labelClass}>
               Share, fund or ETF
             </label>
             {pickingSymbol ? (
@@ -317,6 +540,10 @@ export default function PortfolioManager({
                   setName(match.name);
                   setAssetType(assetTypeFromLookup(match.type));
                   setPickingSymbol(false);
+                  if (!currencyTouched) {
+                    setHoldingCurrency(defaultCurrencyFor(picked, match.exchange, currency));
+                  }
+                  loadQuote(picked);
                 }}
                 hint="Search by ticker or name — UK listings included (SHEL.L, VUSA.L)."
                 autoFocus={!editing}
@@ -336,77 +563,201 @@ export default function PortfolioManager({
                 </button>
               </div>
             )}
+            {/* What the exchange says it trades at — the sanity check for the
+                cost about to be typed, and the authority for the currency. */}
+            {quoteLoading && (
+              <p className={helperClass}>Checking the current price…</p>
+            )}
+            {quote && (
+              <p className={helperClass}>
+                Trading at {formatCurrency(toDecimal(quote.price), quote.currency)} ({quote.currency})
+              </p>
+            )}
           </div>
 
-          <div>
-            <label
-              htmlFor="holding-asset-type"
-              className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1"
-            >
-              Kind
-            </label>
-            <select
-              id="holding-asset-type"
-              value={assetType}
-              onChange={(e) => {
-                const chosen = INVESTMENT_ASSET_TYPES.find((type) => type === e.target.value);
-                if (chosen) setAssetType(chosen);
-              }}
-              disabled={isSaving}
-              className="w-full px-4 py-2 border border-gray-300 dark:border-gray-600 rounded-lg focus:border-transparent dark:bg-gray-700 dark:text-white"
-            >
-              {INVESTMENT_ASSET_TYPES.map((type) => (
-                <option key={type} value={type}>
-                  {ASSET_TYPE_LABELS[type]}
-                </option>
-              ))}
-            </select>
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+            <div>
+              <label htmlFor="holding-asset-type" className={labelClass}>
+                Kind
+              </label>
+              <select
+                id="holding-asset-type"
+                value={assetType}
+                onChange={(e) => {
+                  const chosen = INVESTMENT_ASSET_TYPES.find((type) => type === e.target.value);
+                  if (chosen) setAssetType(chosen);
+                }}
+                disabled={isSaving}
+                className={inputClass}
+              >
+                {INVESTMENT_ASSET_TYPES.map((type) => (
+                  <option key={type} value={type}>
+                    {ASSET_TYPE_LABELS[type]}
+                  </option>
+                ))}
+              </select>
+            </div>
+
+            <div>
+              <label htmlFor="holding-quantity" className={labelClass}>
+                Units held
+              </label>
+              <input
+                id="holding-quantity"
+                type="number"
+                value={quantity}
+                onChange={(e) => setQuantity(e.target.value)}
+                placeholder="0"
+                step="any"
+                min="0"
+                disabled={isSaving}
+                className={inputClass}
+              />
+              <p className={helperClass}>
+                Fractional units are fine.
+              </p>
+            </div>
+
+            <div>
+              <label htmlFor="holding-average-cost" className={labelClass}>
+                Average cost per unit
+              </label>
+              <MoneyInput
+                id="holding-average-cost"
+                value={averageCost}
+                onChange={setAverageCost}
+                className={inputClass}
+                disabled={isSaving}
+              />
+            </div>
+
+            <div>
+              <label htmlFor="holding-currency" className={labelClass}>
+                Priced in
+              </label>
+              {/* The instrument's own currency — set from the quote when one
+                  arrives, editable always. Apple is dollars whatever currency
+                  the account counts in. */}
+              <select
+                id="holding-currency"
+                value={holdingCurrency}
+                onChange={(e) => {
+                  setHoldingCurrency(e.target.value);
+                  setCurrencyTouched(true);
+                }}
+                disabled={isSaving}
+                className={inputClass}
+              >
+                {supportedCurrencies.map((option) => (
+                  <option key={option.code} value={option.code}>
+                    {option.code} — {option.name}
+                  </option>
+                ))}
+              </select>
+            </div>
           </div>
 
-          <div>
-            <label
-              htmlFor="holding-quantity"
-              className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1"
-            >
-              Units held
-            </label>
-            <input
-              id="holding-quantity"
-              type="number"
-              value={quantity}
-              onChange={(e) => setQuantity(e.target.value)}
-              placeholder="0"
-              step="any"
-              min="0"
-              disabled={isSaving}
-              className="w-full px-4 py-2 border border-gray-300 dark:border-gray-600 rounded-lg focus:border-transparent dark:bg-gray-700 dark:text-white"
-            />
-            <p className="mt-1 text-xs text-gray-500 dark:text-gray-400">
-              Fractional units are fine — funds are usually held to several decimal places.
-            </p>
-          </div>
+          {!editing && (
+            <>
+              <div>
+                <label htmlFor="holding-charges" className={labelClass}>
+                  Charges — stamp duty, levies, commission ({holdingCurrency})
+                </label>
+                <MoneyInput
+                  id="holding-charges"
+                  value={charges}
+                  onChange={setCharges}
+                  className={inputClass}
+                  disabled={isSaving}
+                />
+                <p className={helperClass}>
+                  Folded into the cost basis, the way a contract note's total is.
+                  Charged in another currency? Leave this at zero and put them in
+                  the total paid below.
+                </p>
+              </div>
 
-          <div>
-            <label
-              htmlFor="holding-average-cost"
-              className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1"
-            >
-              Average cost per unit ({currency})
-            </label>
-            <MoneyInput
-              id="holding-average-cost"
-              value={averageCost}
-              onChange={setAverageCost}
-              className="w-full px-4 py-2 border border-gray-300 dark:border-gray-600 rounded-lg focus:border-transparent dark:bg-gray-700 dark:text-white"
-              disabled={isSaving}
-            />
-          </div>
+              <div>
+                <label htmlFor="holding-funding" className={labelClass}>
+                  Paid from
+                </label>
+                <select
+                  id="holding-funding"
+                  value={fundingAccountId}
+                  onChange={(e) => {
+                    setFundingAccountId(e.target.value);
+                    setTotalPaidTouched(false);
+                    setTotalPaid('');
+                  }}
+                  disabled={isSaving}
+                  className={inputClass}
+                >
+                  <option value="">Just record the holding — no money moves</option>
+                  {fundingAccounts.map((account) => (
+                    <option key={account.id} value={account.id}>
+                      {account.name}
+                    </option>
+                  ))}
+                </select>
+                <p className={helperClass}>
+                  Writes the transfer: out of the account you pick, into this
+                  investment account. Accounts in other currencies are not
+                  offered — a converted transfer needs its confirmed figure, so
+                  make it from the register instead.
+                </p>
+              </div>
+
+              {fundingAccountId !== '' && (
+                <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+                  <div>
+                    <label htmlFor="holding-purchase-date" className={labelClass}>
+                      Purchase date
+                    </label>
+                    <DatePicker
+                      id="holding-purchase-date"
+                      value={purchaseDate}
+                      onChange={setPurchaseDate}
+                      className={inputClass}
+                      aria-label="Purchase date"
+                      usePortal
+                    />
+                  </div>
+                  <div>
+                    <label htmlFor="holding-total-paid" className={labelClass}>
+                      Total paid ({fundingAccount?.currency ?? currency})
+                    </label>
+                    <MoneyInput
+                      id="holding-total-paid"
+                      value={totalPaid}
+                      onChange={(value) => {
+                        setTotalPaid(value);
+                        setTotalPaidTouched(true);
+                      }}
+                      className={inputClass}
+                      disabled={isSaving}
+                    />
+                    <p className={helperClass}>
+                      {fundingMatchesHoldingCurrency
+                        ? 'Units × cost + charges, prefilled — change it if the contract note says otherwise.'
+                        : `The figure on the contract note, in ${fundingAccount?.currency ?? 'the account’s currency'} — the app will not invent it from an exchange rate.`}
+                    </p>
+                  </div>
+                </div>
+              )}
+            </>
+          )}
 
           {previewCostBasis && (
-            <div className="p-4 bg-gray-50 dark:bg-gray-700/50 rounded-lg">
+            <div className="p-4 bg-gray-50 dark:bg-gray-700/50 rounded-lg space-y-1">
               <p className="text-sm text-gray-600 dark:text-gray-400">
-                Cost basis: {formatCurrency(previewCostBasis, currency)}
+                Cost basis: {formatCurrency(previewCostBasis, holdingCurrency)}
+                {chargesValue !== null && chargesValue > 0 && ' including charges'}
               </p>
+              {baseEquivalent !== null && (
+                <p className="text-xs text-gray-500 dark:text-gray-400">
+                  ≈ {formatCurrency(baseEquivalent, displayCurrency)} at today's rate
+                </p>
+              )}
             </div>
           )}
 

--- a/src/pages/Investments.tsx
+++ b/src/pages/Investments.tsx
@@ -7,7 +7,9 @@ import { useApp } from '../contexts/AppContextSupabase';
 import { TrendingUpIcon, TrendingDownIcon, BarChart3Icon, AlertCircleIcon, LineChartIcon, EyeIcon } from '../components/icons';
 import AddInvestmentModal from '../components/AddInvestmentModal';
 import InvestmentMarketView from '../components/InvestmentMarketView';
-import PortfolioManager, { type HoldingFormValues } from '../components/PortfolioManager';
+import PortfolioManager, { type HoldingFormValues, type PurchaseDetails } from '../components/PortfolioManager';
+import { allInAverageCost } from '../services/investments/purchaseMath';
+import { transferCategoryIdFor } from '../utils/transferRepoint';
 import StockWatchlist from '../components/StockWatchlist';
 // Use optimized lazy-loaded charts to reduce bundle size
 import { ResponsiveContainer, LineChart, Line, XAxis, YAxis, CartesianGrid } from '../components/charts/OptimizedCharts';
@@ -72,7 +74,12 @@ const INVESTMENT_PERIOD_MONTHS: Record<'1-month' | '3-months' | '6-months' | '12
 };
 
 export default function Investments() {
-  const { accounts, transactions, transactionSplits, categories } = useApp();
+  const {
+    accounts, transactions, transactionSplits, categories,
+    // The purchase's cash half: the out leg is an ordinary transaction and the
+    // far side is minted and linked by the same machinery every transfer uses.
+    addTransaction, createTransferCounterpart,
+  } = useApp();
   const { formatCurrency } = useCurrencyDecimal();
   /**
    * THE APP'S PERIOD VOCABULARY, spoken here too.
@@ -233,19 +240,73 @@ export default function Investments() {
   }, [reloadHoldings]);
 
   const handleAddHolding = useCallback(
-    async (accountId: string, currency: string, values: HoldingFormValues): Promise<void> => {
+    async (accountId: string, values: HoldingFormValues, purchase: PurchaseDetails): Promise<void> => {
+      const fundingAccount = purchase.fundingAccountId !== null
+        ? accounts.find(a => a.id === purchase.fundingAccountId) ?? null
+        : null;
+
+      /**
+       * Charges fold into the stored average cost — Money's own definition
+       * (total paid ÷ shares, commission included), and the only place they
+       * CAN live: costBasis is derived from averageCost so the two can never
+       * disagree. The provenance note keeps the fold auditable.
+       */
+      const averageCost = allInAverageCost(values.quantity, values.averageCost, purchase.charges);
+      const provenance: string[] = [];
+      if (purchase.charges.greaterThan(0)) {
+        provenance.push(`Cost includes ${formatCurrency(purchase.charges, values.currency)} in charges.`);
+      }
+      if (fundingAccount) {
+        provenance.push(`Paid from ${fundingAccount.name}.`);
+      }
+
       await dataPort.createInvestment({
         accountId,
         symbol: values.symbol,
         name: values.name,
         quantity: values.quantity,
-        averageCost: values.averageCost,
-        currency,
-        assetType: values.assetType
+        averageCost,
+        currency: values.currency,
+        assetType: values.assetType,
+        purchaseDate: purchase.date,
+        notes: provenance.join(' ')
       });
+
+      /**
+       * THE CASH LEG (owner, 17 Aug; Money's measured model — 2015 of 2029
+       * real buys carried one, funded from a freely chosen account). Out of
+       * the chosen account, into this investment account, linked by the same
+       * counterpart machinery every transfer uses. Same-currency only — the
+       * form does not offer cross-currency funding, because the counterpart
+       * write copies this row's digits.
+       */
+      if (fundingAccount && purchase.totalPaid !== null) {
+        try {
+          const total = purchase.totalPaid.toNumber();
+          const outLeg = await addTransaction({
+            accountId: fundingAccount.id,
+            amount: -Math.abs(total),
+            type: 'transfer',
+            date: purchase.date,
+            description: `Buy ${formatDecimal(values.quantity, 4)} ${values.symbol}`,
+            category: transferCategoryIdFor(categories, accountId, -Math.abs(total)),
+            cleared: false,
+          });
+          await createTransferCounterpart(outLeg.id, accountId);
+        } catch (error) {
+          // The holding IS saved. Saying so is what stops a retry from
+          // doubling the position.
+          throw new Error(
+            `The holding was saved, but the transfer from ${fundingAccount.name} could not be written` +
+            `${error instanceof Error ? ` (${error.message})` : ''}. ` +
+            'Close this dialog and add the transfer from the register instead.'
+          );
+        }
+      }
+
       await reloadHoldings();
     },
-    [reloadHoldings]
+    [accounts, categories, addTransaction, createTransferCounterpart, formatCurrency, reloadHoldings]
   );
 
   const handleEditHolding = useCallback(
@@ -1126,16 +1187,47 @@ export default function Investments() {
                           </div>
                           <p className="font-semibold text-gray-900 dark:text-white shrink-0 ml-3">{formatCurrency(line.value)}</p>
                         </div>
+                        {/* EACH SLEEVE IS A DOOR (owner, 17 August): the word
+                            opens that sleeve's own register — Investments is
+                            the parent account, Cash its nested account(s).
+                            With several cash accounts one word cannot name a
+                            register, so each gets its own linked row under its
+                            own name, which says more than a summed "Cash"
+                            ever did. */}
                         <p className="ml-5 mb-1 flex justify-between text-dense text-gray-500 dark:text-gray-400">
-                          <span>Investments</span>
+                          <Link
+                            to={preserveDemoParam(`/accounts/${line.accountId}`, location.search)}
+                            className="hover:text-blue-700 dark:hover:text-blue-400 hover:underline rounded"
+                            title={`${line.name} — open this account's register`}
+                          >
+                            Investments
+                          </Link>
                           <span className="tabular-nums">{formatCurrency(invested)}</span>
                         </p>
-                        {line.cash.length > 0 && (
+                        {line.cash.length === 1 && (
                           <p className="ml-5 mb-2 flex justify-between text-dense text-gray-500 dark:text-gray-400">
-                            <span>Cash</span>
+                            <Link
+                              to={preserveDemoParam(`/accounts/${line.cash[0].accountId}`, location.search)}
+                              className="hover:text-blue-700 dark:hover:text-blue-400 hover:underline rounded"
+                              title={`${accountsById.get(line.cash[0].accountId)?.name ?? 'Cash'} — open this account's register`}
+                            >
+                              Cash
+                            </Link>
                             <span className="tabular-nums">{formatCurrency(cashTotal)}</span>
                           </p>
                         )}
+                        {line.cash.length > 1 && line.cash.map(cashLine => (
+                          <p key={cashLine.accountId} className="ml-5 mb-1 last:mb-2 flex justify-between text-dense text-gray-500 dark:text-gray-400">
+                            <Link
+                              to={preserveDemoParam(`/accounts/${cashLine.accountId}`, location.search)}
+                              className="min-w-0 truncate hover:text-blue-700 dark:hover:text-blue-400 hover:underline rounded"
+                              title={`${accountsById.get(cashLine.accountId)?.name ?? 'Cash'} — open this account's register`}
+                            >
+                              {accountsById.get(cashLine.accountId)?.name ?? 'Cash'}
+                            </Link>
+                            <span className="tabular-nums shrink-0 ml-3">{formatCurrency(cashLine.value)}</span>
+                          </p>
+                        ))}
                         <div className="flex items-center gap-2">
                           <div className="flex-1 bg-gray-200 dark:bg-gray-700 rounded-full h-2">
                             <div
@@ -1181,7 +1273,16 @@ export default function Investments() {
                                 key={debt.id}
                                 className="flex justify-between text-dense text-gray-500 dark:text-gray-400"
                               >
-                                <span className="min-w-0 truncate">{debt.name}</span>
+                                {/* To the REGISTER, not the Accounts-page jump
+                                    the tags use (owner, 17 Aug: "take you to
+                                    that respective account register"). */}
+                                <Link
+                                  to={preserveDemoParam(`/accounts/${debt.id}`, location.search)}
+                                  className="min-w-0 truncate hover:text-blue-700 dark:hover:text-blue-400 hover:underline rounded"
+                                  title={`${debt.name} — open this account's register`}
+                                >
+                                  {debt.name}
+                                </Link>
                                 <span className="tabular-nums shrink-0 ml-3">
                                   {formatCurrency(toDecimal(debt.balance ?? 0))}
                                 </span>
@@ -1445,7 +1546,22 @@ export default function Investments() {
                     <PortfolioManager
                       holdings={accountHoldings}
                       currency={account.currency}
-                      onAdd={(values) => handleAddHolding(account.id, account.currency, values)}
+                      // Where the purchase money may come from: any open account
+                      // in THIS account's currency (Money let a buy name any
+                      // funding account — measured, 2015 of 2029 did), with this
+                      // account's own cash sleeve(s) first because that is the
+                      // answer nine times in ten. Same-currency only: the
+                      // counterpart write copies the row's digits, and a
+                      // converted transfer needs its confirmed figure.
+                      fundingAccounts={openAccounts
+                        .filter(a =>
+                          a.id !== account.id &&
+                          a.type !== 'investment' &&
+                          a.currency === account.currency)
+                        .sort((a, b) =>
+                          Number(b.parentAccountId === account.id) - Number(a.parentAccountId === account.id) ||
+                          a.name.localeCompare(b.name))}
+                      onAdd={(values, purchase) => handleAddHolding(account.id, values, purchase)}
                       onEdit={handleEditHolding}
                       onDelete={handleDeleteHolding}
                     />

--- a/src/services/investments/purchaseMath.test.ts
+++ b/src/services/investments/purchaseMath.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect } from 'vitest';
+import { toDecimal } from '../../utils/decimal';
+import { allInAverageCost, purchaseCashTotal } from './purchaseMath';
+
+/** Every figure invented — the repo is public. */
+describe('allInAverageCost — charges fold into the per-unit figure', () => {
+  it('spreads the charges across the units, Money-style', () => {
+    // 100 units at 5.00 plus 25.00 of stamp duty: 525 ÷ 100.
+    const allIn = allInAverageCost(toDecimal(100), toDecimal(5), toDecimal(25));
+    expect(allIn.toNumber()).toBe(5.25);
+  });
+
+  it('cost basis derived from it is the money actually spent', () => {
+    const quantity = toDecimal(3);
+    const allIn = allInAverageCost(quantity, toDecimal(33.333), toDecimal(1));
+    // 3 × 33.333 + 1 = 100.999 exactly — Decimal, no float drift.
+    expect(quantity.times(allIn).toNumber()).toBe(100.999);
+  });
+
+  it('zero charges change nothing', () => {
+    const allIn = allInAverageCost(toDecimal(8), toDecimal(12.5), toDecimal(0));
+    expect(allIn.toNumber()).toBe(12.5);
+  });
+
+  it('a zero-unit purchase cannot divide — the entered cost stands', () => {
+    const allIn = allInAverageCost(toDecimal(0), toDecimal(12.5), toDecimal(9));
+    expect(allIn.toNumber()).toBe(12.5);
+  });
+});
+
+describe('purchaseCashTotal — what leaves the cash account', () => {
+  it('is units × price + charges', () => {
+    expect(purchaseCashTotal(toDecimal(100), toDecimal(5), toDecimal(25)).toNumber()).toBe(525);
+  });
+
+  it('is the gross alone when there are no charges', () => {
+    expect(purchaseCashTotal(toDecimal(2), toDecimal(7.75), toDecimal(0)).toNumber()).toBe(15.5);
+  });
+});

--- a/src/services/investments/purchaseMath.ts
+++ b/src/services/investments/purchaseMath.ts
@@ -1,0 +1,44 @@
+import { toDecimal, type DecimalInstance } from '../../utils/decimal';
+
+/**
+ * The all-in average cost of a purchase: (units × price + charges) ÷ units.
+ *
+ * Microsoft Money's "average cost" is exactly this — total paid divided by
+ * shares held, commission included — and it is what a broker's contract note
+ * calls the figure too. The holding schema derives costBasis from averageCost
+ * so the two can never disagree, which means charges (stamp duty, levies,
+ * commission) have nowhere else to live: folding them here is what makes the
+ * stored cost basis the money actually spent rather than the money spent on
+ * shares alone.
+ *
+ * Charges must be in the SAME currency as the price. A charge in another
+ * currency (a UK broker's commission on a US buy) belongs in the funding
+ * transfer's total, not here — mixing currencies in one division would
+ * manufacture a figure in no currency at all.
+ */
+export function allInAverageCost(
+  quantity: DecimalInstance,
+  averageCost: DecimalInstance,
+  charges: DecimalInstance
+): DecimalInstance {
+  if (charges.lessThanOrEqualTo(0) || quantity.lessThanOrEqualTo(0)) return averageCost;
+  return quantity.times(averageCost).plus(charges).dividedBy(quantity);
+}
+
+/**
+ * What the purchase costs in cash: units × price + charges.
+ *
+ * The default for "total paid" when the funding account counts in the same
+ * currency as the price — editable, because a real contract note can differ
+ * by rounding. When the currencies differ there is no default: the true cash
+ * figure is on the broker's note and only the owner has it.
+ */
+export function purchaseCashTotal(
+  quantity: DecimalInstance,
+  averageCost: DecimalInstance,
+  charges: DecimalInstance
+): DecimalInstance {
+  // Charges are validated non-negative before they reach here; a negative
+  // would mean a rebate, which is a different transaction, not a discount.
+  return quantity.times(averageCost).plus(charges.greaterThan(0) ? charges : toDecimal(0));
+}


### PR DESCRIPTION
Three owner requests from 17 August, grounded in Microsoft Money's measured model — the research is in [docs/investment-register-notes.md](docs/investment-register-notes.md).

## 1. The Holdings card's rows open registers

**Investments** opens the parent account's register; **Cash** opens the nested cash account's (with several cash accounts, each gets its own linked row under its own name — one word can't name two registers). The **secured liability** names open their registers too — the owner's explicit ask here, distinct from the Accounts-page in-page jump the tags use.

## 2. Add-a-holding grows up

"Average cost per unit (GBP)" was a claim, not a question — Apple trades in dollars whatever currency the account counts in. Picking a symbol now **fetches its quote**: the exchange states the trading currency authoritatively (LSE pence already normalised at the proxy), and the live price is shown as a sanity check for the cost about to be typed. No quote degrades to a sensible default plus an always-editable dropdown — never a blocked form. The preview shows the base-currency equivalent at today's rate, and the list's **total cost basis now converts** to the display currency — it was summing dollars into pounds raw — and labels itself when that did work.

## 3. A buy moves real cash, the way Money did it

Measured from real .mny files: 2,015 of 2,029 buys carried a cash leg, funded from a **free choice** of account, with commission folded into total ÷ shares.

- **Charges** (stamp duty, levies, commission) fold into the stored average cost via `allInAverageCost` — the only place they can live, since `costBasis` derives from `averageCost` by invariant — with a provenance note on the holding.
- **"Paid from"** offers any open same-currency account (the paired cash sleeve sorted first) and writes the transfer through the same out-leg + `createTransferCounterpart` machinery every transfer uses, dated to the purchase. The investment account's register shows the arriving leg described as the buy.
- Cross-currency funding is deliberately not offered: the counterpart write copies the row's digits, and a converted transfer needs its confirmed figure (the register's dialog flow).
- If the transfer fails after the holding saved, the error **says the holding exists** — which is what stops a retry doubling the position.

The full investment register (activity/units/price columns, sells with realisation, dividends into the sleeve) is scoped in the doc as deliberate future slices — each has schema, importer and Rust-core consequences.

## Verified

- `npm run lint` — 0; `typecheck:strict` — clean
- `purchaseMath` 6/6 · pages suite 521/521 · portfolio integration 5/5 · full unit suite via pre-commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)