### PR TITLE
feat(reports): "What I'm committed to" — recurring payments, detected with their evidence

### DIFF
--- a/src/pages/__tests__/ReportsHub.test.tsx
+++ b/src/pages/__tests__/ReportsHub.test.tsx
@@ -65,6 +65,7 @@ describe('ReportsHub gallery', () => {
       'Spending by category',
       'Income and spending over time',
       'Spending by payee',
+      'What I’m committed to',
       'This period vs last',
     ]) {
       expect(screen.getByText(title)).toBeInTheDocument();
@@ -81,6 +82,7 @@ describe('ReportsHub gallery', () => {
       '/reports/spending-by-category',
       '/reports/income-and-spending-over-time',
       '/reports/spending-by-payee',
+      '/reports/recurring-commitments',
       '/reports/period-comparison',
       '/reports/custom-reports',
     ]);
@@ -255,6 +257,7 @@ describe('ReportsHub gallery', () => {
     ['spending-by-category', 'Where the money went'],
     ['income-and-spending-over-time', 'Income against spending'],
     ['spending-by-payee', 'Biggest payees'],
+    ['recurring-commitments', 'Committed each year'],
     ['period-comparison', 'Biggest movers'],
   ])('renders the %s report', async (id, heading) => {
     renderHub(`/reports/${id}`);

--- a/src/pages/reports/RecurringCommitmentsReport.tsx
+++ b/src/pages/reports/RecurringCommitmentsReport.tsx
@@ -1,0 +1,271 @@
+import React, { useMemo } from 'react';
+import { Link, useLocation } from 'react-router-dom';
+import { useApp } from '../../contexts/AppContextSupabase';
+import { useCurrencyDecimal } from '../../hooks/useCurrencyDecimal';
+import { toDecimal, type DecimalInstance } from '../../utils/decimal';
+import { getDateLocale } from '../../utils/dateFormatter';
+import { preserveDemoParam } from '../../utils/navigation';
+import {
+  detectRecurring,
+  MIN_PAYMENTS,
+  type RecurringCadence,
+  type RecurringDetection,
+} from '../../utils/recurringDetection';
+
+/**
+ * "What I'm committed to" — recurring payments, detected from the register.
+ *
+ * A FINDING, not a dashboard (Claude Design handover, 17 Aug §1): the app
+ * noticing something in the ledger the user hasn't. Two audiences in one —
+ * the subscription audit ("what am I signed up to?") and the schedule read
+ * ("what is due next?") — designed for the first, with the second falling
+ * out of it.
+ *
+ * The design rules this page lives under, all from the handover:
+ *
+ * - A detection is an INFERENCE and carries its evidence in its resting
+ *   state (§2): the payment count, the span, the most recent date and the
+ *   next expected ARE the confidence. No percentages, ever.
+ * - The number that lands is the ANNUAL equivalent (§3) — £14.99 a month is
+ *   invisible; £179.88 a year is a decision.
+ * - Grouped by CADENCE, not category (§4): cadence is what determines
+ *   commitment. One annualisation provenance line under the headline.
+ * - A price change is a DIRECTION and may wear the hues; the magnitudes
+ *   stay neutral (§3.1).
+ * - Stopped patterns are a band, never a silent deletion (§3.2).
+ * - Read-only: this surface reads the register and never writes to it.
+ *   Confirm / Not-recurring is the next slice (§5, §8 step 2).
+ *
+ * No period picker (usesPeriod: false in the registry): a rhythm needs the
+ * whole history to be seen, and a window that hides half the payments would
+ * weaken every evidence line on the page. Said on screen.
+ */
+
+const CADENCE_BANDS: ReadonlyArray<{ cadence: RecurringCadence; title: string }> = [
+  { cadence: 'monthly', title: 'Monthly' },
+  { cadence: 'weekly', title: 'Weekly' },
+  { cadence: 'annual', title: 'Annual' },
+  { cadence: 'irregular', title: 'Irregular' },
+];
+
+const monthYear = (date: Date): string =>
+  date.toLocaleDateString(getDateLocale(), { month: 'short', year: 'numeric' });
+
+const dayMonth = (date: Date): string =>
+  date.toLocaleDateString(getDateLocale(), { day: 'numeric', month: 'short' });
+
+export default function RecurringCommitmentsReport(): React.JSX.Element {
+  const { accounts, transactions, isLoading } = useApp();
+  const { formatCurrency, displayCurrency } = useCurrencyDecimal();
+  const location = useLocation();
+
+  const accountName = useMemo(
+    () => new Map(accounts.map(a => [a.id, a.name])),
+    [accounts]
+  );
+
+  /**
+   * Outgoing only: this page answers "what am I committed to", and a
+   * commitment is money out. Recurring income (a salary) is detected too,
+   * but belongs to the calendar and the forecast, not the audit.
+   */
+  const detections = useMemo(
+    () => detectRecurring(transactions, new Date()).filter(d => d.direction === 'out'),
+    [transactions]
+  );
+
+  const active = detections.filter(d => !d.stopped);
+  const stopped = detections.filter(d => d.stopped);
+
+  // Decimal throughout — these are money sums read against each other.
+  const annualTotal = active.reduce(
+    (sum, d) => sum.plus(d.annualEquivalent), toDecimal(0)
+  );
+
+  const bandFor = (cadence: RecurringCadence): RecurringDetection[] =>
+    active.filter(d => d.cadence === cadence);
+
+  const bandTotal = (band: RecurringDetection[]): DecimalInstance =>
+    band.reduce((sum, d) => sum.plus(d.annualEquivalent), toDecimal(0));
+
+  /** One detection, with its evidence in its resting state. */
+  const DetectionRow = ({ detection }: { detection: RecurringDetection }): React.JSX.Element => {
+    const account = accountName.get(detection.accountId);
+    return (
+      <li className="py-3 flex flex-wrap items-baseline justify-between gap-x-6 gap-y-1 border-t border-gray-50 dark:border-gray-700/50 first:border-0">
+        <div className="min-w-0">
+          <p className="text-body text-gray-900 dark:text-white truncate">
+            {/* Into the account's register, where the payments themselves are —
+                the same door every other report row opens. */}
+            <Link
+              to={preserveDemoParam(`/accounts/${detection.accountId}`, location.search)}
+              className="hover:text-blue-700 dark:hover:text-blue-400 hover:underline rounded"
+              title={account ? `${account} — open this account's register` : 'Open this account’s register'}
+            >
+              {detection.description}
+            </Link>
+          </p>
+          {/* THE EVIDENCE LINE (§2) — not a tooltip, not a hover: what the
+              claim rests on, where the claim is made. */}
+          <p className="text-dense text-gray-500 dark:text-gray-400">
+            {detection.count} payments since {monthYear(detection.firstDate)}, most
+            recent {dayMonth(detection.lastDate)}
+            {detection.nextExpected && <> · next expected {dayMonth(detection.nextExpected)}</>}
+            {account && <> · {account}</>}
+          </p>
+          {detection.priceChange && (
+            <p className="text-dense text-gray-500 dark:text-gray-400">
+              {formatCurrency(detection.priceChange.from, displayCurrency)} →{' '}
+              {formatCurrency(detection.priceChange.to, displayCurrency)} in{' '}
+              {monthYear(detection.priceChange.when)} ·{' '}
+              {/* The DELTA is a direction and wears the hue — costlier is
+                  red, cheaper is green. The magnitudes around it stay
+                  neutral (§3.1). */}
+              <span className={detection.priceChange.annualDelta.greaterThan(0)
+                ? 'text-red-600 dark:text-red-400'
+                : 'text-green-600 dark:text-green-400'}>
+                {detection.priceChange.annualDelta.greaterThan(0) ? '+' : '−'}
+                {formatCurrency(detection.priceChange.annualDelta.abs(), displayCurrency)} a year
+              </span>
+            </p>
+          )}
+        </div>
+        <div className="text-right shrink-0">
+          {/* The annual figure lands; the per-payment figure explains it. */}
+          <p className="text-body font-semibold tabular-nums text-gray-900 dark:text-white">
+            {formatCurrency(detection.annualEquivalent, displayCurrency)} a year
+          </p>
+          <p className="text-dense tabular-nums text-gray-500 dark:text-gray-400">
+            {formatCurrency(detection.amount, displayCurrency)} {detection.cadenceLabel}
+          </p>
+        </div>
+      </li>
+    );
+  };
+
+  // Skeleton at the real row height, three rows, no pulse (§6) — detection
+  // over a long history is one of the few loads that will actually be seen.
+  if (isLoading && transactions.length === 0) {
+    return (
+      <div className="max-w-[1400px] mx-auto space-y-3">
+        {[0, 1, 2].map(i => (
+          <div key={i} className="h-[72px] bg-gray-100 dark:bg-gray-800 rounded-lg" />
+        ))}
+      </div>
+    );
+  }
+
+  return (
+    <div className="max-w-[1400px] mx-auto space-y-6">
+      <div className="bg-white dark:bg-gray-800 rounded-lg p-6 border border-line dark:border-gray-700">
+        <h2 className="text-label uppercase tracking-wider font-medium text-gray-500 dark:text-gray-400">
+          Committed each year
+        </h2>
+        {/* The page's one earned total: "how much of my year is already
+            spoken for?" is a question people genuinely ask (§3). */}
+        <p className="text-page font-bold mt-1 tabular-nums">
+          {formatCurrency(annualTotal, displayCurrency)}
+        </p>
+        <p className="text-dense text-gray-500 dark:text-gray-400 mt-1">
+          {active.length === 1 ? '1 recurring payment' : `${active.length} recurring payments`}
+          {' '}— weekly and monthly items annualised, read from your whole history.
+          These are patterns the app has noticed, not entries you made: each one
+          shows the payments it rests on.
+        </p>
+      </div>
+
+      {transactions.length === 0 ? (
+        /* CONSEQUENCE, THEN REMEDY (§6): a fresh ledger cannot show rhythm. */
+        <div className="bg-white dark:bg-gray-800 rounded-lg border border-line dark:border-gray-700 p-6">
+          <p className="text-body text-gray-500 dark:text-gray-400">
+            Recurring payments are found by looking for the same amount arriving
+            on the same rhythm, so this needs a few months of history before it
+            can tell you anything.{' '}
+            <Link
+              to={preserveDemoParam('/enhanced-import', location.search)}
+              className="text-primary hover:underline"
+            >
+              Import a statement →
+            </Link>
+          </p>
+        </div>
+      ) : detections.length === 0 ? (
+        /* History, nothing found — a genuine finding, not a failure (§6),
+           said with what it looked for. */
+        <div className="bg-white dark:bg-gray-800 rounded-lg border border-line dark:border-gray-700 p-6">
+          <p className="text-body text-gray-500 dark:text-gray-400">
+            Nothing here repeats. The app looked for {MIN_PAYMENTS} or more
+            payments of the same amount to the same payee on a steady rhythm,
+            and found none — which may be exactly right.
+          </p>
+        </div>
+      ) : (
+        <>
+          {CADENCE_BANDS.map(({ cadence, title }) => {
+            const band = bandFor(cadence);
+            if (band.length === 0) return null;
+            return (
+              <div key={cadence} className="bg-white dark:bg-gray-800 rounded-lg border border-line dark:border-gray-700 p-6">
+                <div className="flex flex-wrap items-baseline justify-between gap-2 mb-2">
+                  <h2 className="text-card font-semibold text-theme-heading dark:text-white">
+                    {title}
+                    <span className="ml-2 text-dense font-normal text-gray-400 dark:text-gray-500">
+                      {band.length}
+                    </span>
+                  </h2>
+                  <span className="text-body font-semibold tabular-nums text-gray-900 dark:text-white">
+                    {formatCurrency(bandTotal(band), displayCurrency)} a year
+                  </span>
+                </div>
+                <ul>
+                  {band.map(d => <DetectionRow key={d.key} detection={d} />)}
+                </ul>
+              </div>
+            );
+          })}
+
+          {stopped.length > 0 && (
+            /* Ran, and then didn't (§3.2) — either cancelled (good to know)
+               or failed (good to look at). Never silently deleted. */
+            <div className="bg-white dark:bg-gray-800 rounded-lg border border-line dark:border-gray-700 p-6">
+              <div className="flex flex-wrap items-baseline justify-between gap-2 mb-2">
+                <h2 className="text-card font-semibold text-theme-heading dark:text-white">
+                  Stopped
+                  <span className="ml-2 text-dense font-normal text-gray-400 dark:text-gray-500">
+                    {stopped.length}
+                  </span>
+                </h2>
+                <span className="text-dense text-gray-500 dark:text-gray-400">
+                  Ran on a rhythm, then didn't — cancelled, or worth a look
+                </span>
+              </div>
+              <ul>
+                {stopped.map(d => (
+                  <li key={d.key} className="py-3 flex flex-wrap items-baseline justify-between gap-x-6 gap-y-1 border-t border-gray-50 dark:border-gray-700/50 first:border-0">
+                    <div className="min-w-0">
+                      <p className="text-body text-gray-900 dark:text-white truncate">
+                        <Link
+                          to={preserveDemoParam(`/accounts/${d.accountId}`, location.search)}
+                          className="hover:text-blue-700 dark:hover:text-blue-400 hover:underline rounded"
+                        >
+                          {d.description}
+                        </Link>
+                      </p>
+                      <p className="text-dense text-gray-500 dark:text-gray-400">
+                        {d.count} payments, {d.cadenceLabel} · last seen {dayMonth(d.lastDate)} {d.lastDate.getFullYear()}
+                        {accountName.get(d.accountId) && <> · {accountName.get(d.accountId)}</>}
+                      </p>
+                    </div>
+                    <p className="text-dense tabular-nums text-gray-500 dark:text-gray-400 shrink-0">
+                      was {formatCurrency(d.amount, displayCurrency)} {d.cadenceLabel}
+                    </p>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          )}
+        </>
+      )}
+    </div>
+  );
+}

--- a/src/pages/reports/reportRegistry.ts
+++ b/src/pages/reports/reportRegistry.ts
@@ -3,6 +3,7 @@ import { lazyWithRecovery } from '../../utils/lazyWithRecovery';
 import {
   BarChart3Icon,
   CalendarIcon,
+  ClockIcon,
   FileTextIcon,
   LandmarkIcon,
   PieChartIcon,
@@ -164,6 +165,19 @@ export const REPORTS: ReportDefinition[] = [
     icon: UsersIcon,
     usesPeriod: true,
     component: lazyWithRecovery(() => import('./SpendingByPayeeReport')),
+  },
+  {
+    id: 'recurring-commitments',
+    title: 'What I’m committed to',
+    description: 'The payments that repeat — what each one costs a year, and what changed.',
+    group: 'spending',
+    icon: ClockIcon,
+    // A rhythm needs the whole history to be seen; a window that hides half
+    // the payments would weaken every evidence line on the page. Like the
+    // distribution report, the hub's period picker is hidden rather than
+    // shown governing nothing.
+    usesPeriod: false,
+    component: lazyWithRecovery(() => import('./RecurringCommitmentsReport')),
   },
   {
     id: 'period-comparison',

--- a/src/utils/recurringDetection.test.ts
+++ b/src/utils/recurringDetection.test.ts
@@ -1,0 +1,174 @@
+import { describe, it, expect } from 'vitest';
+import { detectRecurring, normalisePayeeKey, MIN_PAYMENTS } from './recurringDetection';
+
+/**
+ * The detection's honesty rules, instrumented (Design handover 17 Aug §2):
+ * the evidence IS the confidence, irregular says so in words, a habit is not
+ * a subscription, and stopped is a statement rather than an absence.
+ *
+ * Every payee, date and figure invented — the repo is public.
+ */
+
+const NOW = new Date(2026, 7, 17);
+
+const D = (y: number, m: number, d: number): Date => new Date(y, m - 1, d);
+
+let nextId = 0;
+const expense = (description: string, amount: number, date: Date, accountId = 'acc-1') => ({
+  id: `t-${nextId++}`,
+  accountId,
+  description,
+  amount: -Math.abs(amount),
+  date,
+  type: 'expense' as const,
+});
+
+/** A monthly run: same figure on the same day-of-month. */
+const monthlyRun = (description: string, amount: number, from: Date, months: number) =>
+  Array.from({ length: months }, (_, i) =>
+    expense(description, amount, D(from.getFullYear(), from.getMonth() + 1 + i, from.getDate())));
+
+describe('detectRecurring — what qualifies', () => {
+  it('finds a monthly subscription and states its evidence', () => {
+    const rows = monthlyRun('FLIXWATCH.COM 4029', 7.99, D(2025, 9, 3), 12);
+    const [found] = detectRecurring(rows, NOW);
+
+    expect(found).toBeDefined();
+    expect(found.cadence).toBe('monthly');
+    expect(found.count).toBe(12);
+    expect(found.amount.toNumber()).toBe(7.99);
+    // ×12 exactly — Decimal, not float drift.
+    expect(found.annualEquivalent.toNumber()).toBe(95.88);
+    expect(found.firstDate).toEqual(D(2025, 9, 3));
+    expect(found.lastDate).toEqual(D(2026, 8, 3));
+    expect(found.stopped).toBe(false);
+    // Next expected ≈ one rhythm on from the last payment.
+    expect(found.nextExpected?.getMonth()).toBe(8); // September
+  });
+
+  it(`needs ${MIN_PAYMENTS} qualifying payments — two of anything is a coincidence`, () => {
+    const rows = monthlyRun('GYMBOX', 25, D(2026, 6, 1), 2);
+    expect(detectRecurring(rows, NOW)).toHaveLength(0);
+  });
+
+  it('a shop with a different figure every visit is a habit, not a commitment', () => {
+    // Weekly rhythm, but no two consecutive amounts agree → no sustained run.
+    const rows = [31.42, 58.1, 24.99, 47.05, 39.6, 52.75].map((amount, i) =>
+      expense('MIDTOWN GROCER', amount, D(2026, 6, 1 + i * 7)));
+    expect(detectRecurring(rows, NOW)).toHaveLength(0);
+  });
+
+  it('reference numbers do not split one payee into many', () => {
+    const rows = [
+      expense('STREAMCO 1001', 9.5, D(2026, 5, 10)),
+      expense('STREAMCO 2002', 9.5, D(2026, 6, 10)),
+      expense('STREAMCO 3003', 9.5, D(2026, 7, 10)),
+    ];
+    const found = detectRecurring(rows, NOW);
+    expect(found).toHaveLength(1);
+    expect(found[0].count).toBe(3);
+  });
+
+  it('transfers never qualify — a standing order to savings is not a commitment to anyone else', () => {
+    const rows = monthlyRun('To Savings', 200, D(2026, 1, 1), 8)
+      .map(row => ({ ...row, type: 'transfer' as const }));
+    expect(detectRecurring(rows, NOW)).toHaveLength(0);
+  });
+
+  it('same-day duplicates are not a rhythm', () => {
+    const day = D(2026, 7, 1);
+    const rows = [
+      expense('SPLIT BILL', 10, day),
+      expense('SPLIT BILL', 10, day),
+      expense('SPLIT BILL', 10, day),
+    ];
+    expect(detectRecurring(rows, NOW)).toHaveLength(0);
+  });
+});
+
+describe('detectRecurring — the price change', () => {
+  it('a new sustained figure is reported with its date and annual impact', () => {
+    const rows = [
+      ...monthlyRun('FLIXWATCH.COM', 10.99, D(2025, 9, 3), 6),
+      ...monthlyRun('FLIXWATCH.COM', 12.99, D(2026, 3, 3), 6),
+    ];
+    const [found] = detectRecurring(rows, NOW);
+
+    expect(found.amount.toNumber()).toBe(12.99);
+    expect(found.priceChange).not.toBeNull();
+    expect(found.priceChange?.from.toNumber()).toBe(10.99);
+    expect(found.priceChange?.to.toNumber()).toBe(12.99);
+    expect(found.priceChange?.when).toEqual(D(2026, 3, 3));
+    // +£2.00 a month is +£24.00 a year — the handover's own example shape.
+    expect(found.priceChange?.annualDelta.toNumber()).toBe(24);
+  });
+
+  it('a one-off odd amount drops out without inventing a price change', () => {
+    const rows = [
+      ...monthlyRun('FLIXWATCH.COM', 10.99, D(2025, 11, 3), 4),
+      expense('FLIXWATCH.COM', 3.5, D(2026, 3, 15)), // a partial-month top-up
+      ...monthlyRun('FLIXWATCH.COM', 10.99, D(2026, 4, 3), 4),
+    ];
+    const [found] = detectRecurring(rows, NOW);
+
+    expect(found.count).toBe(8); // the top-up is not part of the pattern
+    expect(found.priceChange).toBeNull();
+    expect(found.amount.toNumber()).toBe(10.99);
+  });
+});
+
+describe('detectRecurring — cadence honesty', () => {
+  it('a weekly figure annualises at 52', () => {
+    const rows = Array.from({ length: 8 }, (_, i) =>
+      expense('LUNCH CLUB', 5, D(2026, 5, 1 + i * 7)));
+    const [found] = detectRecurring(rows, NOW);
+    expect(found.cadence).toBe('weekly');
+    expect(found.annualEquivalent.toNumber()).toBe(260);
+  });
+
+  it('an in-between rhythm is IRREGULAR and says so in words, never rounded to monthly', () => {
+    // Every 5 weeks — the handover's own example of what must not say "monthly".
+    const rows = Array.from({ length: 5 }, (_, i) =>
+      expense('FIVE WEEK CLUB', 20, new Date(D(2026, 1, 1).getTime() + i * 35 * 86_400_000)));
+    const [found] = detectRecurring(rows, NOW);
+    expect(found.cadence).toBe('irregular');
+    expect(found.cadenceLabel).toBe('roughly every 5 weeks');
+  });
+
+  it('a rhythm the dates do not hold to is not called regular', () => {
+    // Same amount, but gaps of 7, 30 and 90 days: no honest cadence word fits.
+    const base = D(2026, 1, 1).getTime();
+    const offsets = [0, 7, 37, 127, 134];
+    const rows = offsets.map(days =>
+      expense('SOMETIMES CLUB', 15, new Date(base + days * 86_400_000)));
+    const [found] = detectRecurring(rows, NOW);
+    expect(found.cadence).toBe('irregular');
+  });
+});
+
+describe('detectRecurring — stopped is a band, not an absence', () => {
+  it('silence past two rhythms marks the pattern stopped, with no next expected', () => {
+    const rows = monthlyRun('OLD PAPER', 6.5, D(2025, 6, 1), 6); // last: Nov 2025
+    const [found] = detectRecurring(rows, NOW);
+    expect(found.stopped).toBe(true);
+    expect(found.nextExpected).toBeNull();
+    expect(found.lastDate).toEqual(D(2025, 11, 1));
+  });
+
+  it('a payment a few days late is NOT pronounced dead', () => {
+    // Last paid 20 days ago on a monthly rhythm — inside two rhythms.
+    const rows = monthlyRun('STILL RUNNING', 9.99, D(2025, 12, 28), 8); // last: Jul 28
+    const [found] = detectRecurring(rows, NOW);
+    expect(found.stopped).toBe(false);
+  });
+});
+
+describe('normalisePayeeKey', () => {
+  it('collapses digits and punctuation to the payee identity', () => {
+    expect(normalisePayeeKey('NETFLIX.COM 4029')).toBe(normalisePayeeKey('netflix com 5817'));
+  });
+
+  it('an all-digit description keeps its raw form rather than collapsing to nothing', () => {
+    expect(normalisePayeeKey('40291234')).toBe('40291234');
+  });
+});

--- a/src/utils/recurringDetection.ts
+++ b/src/utils/recurringDetection.ts
@@ -1,0 +1,270 @@
+import { toDecimal, type DecimalInstance } from './decimal';
+
+/**
+ * Recurring-payment detection — the app noticing a pattern in the ledger.
+ *
+ * DESIGN (Claude Design handover, 17 Aug 2026): a detection is an INFERENCE,
+ * not a fact, and must carry its evidence — the payment count, the span, the
+ * most recent date and the next expected one are the confidence, stated in
+ * terms the reader can check. No confidence percentages, ever: "87% sure" is
+ * a number the app cannot justify to a reader. Irregular patterns say so in
+ * words rather than being rounded to "monthly".
+ *
+ * ── HOW A PATTERN QUALIFIES ────────────────────────────────────────────────
+ * The discriminator between a subscription and a habit is the AMOUNT. Netflix
+ * is the same figure to the penny month after month; a supermarket is a
+ * different figure every visit. So rows are grouped by payee-and-account,
+ * and within a group only RUNS of consecutive identical amounts count —
+ * two or more payments at exactly the same figure. A one-off odd amount at a
+ * regular payee (a top-up, a partial refund) drops out without breaking the
+ * pattern around it; a payee whose every amount differs produces no runs and
+ * no detection. Three qualifying payments is the floor — two of anything is
+ * a coincidence.
+ *
+ * A change of run — one sustained figure giving way to another — is a PRICE
+ * CHANGE, the single most useful thing this detection can surface, and is
+ * reported with its date and annual impact.
+ *
+ * ── WHAT THIS NEVER DOES ───────────────────────────────────────────────────
+ * Reads the register; never writes it. A detection is not a transaction and
+ * must never be edited into one (handover §5). Confirm/dismiss state, when it
+ * ships, lives beside the detections — not on the rows they were read from.
+ */
+
+export type RecurringCadence = 'weekly' | 'monthly' | 'annual' | 'irregular';
+
+export interface RecurringPriceChange {
+  /** Magnitudes, in the account's currency. */
+  from: DecimalInstance;
+  to: DecimalInstance;
+  /** First payment at the new figure. */
+  when: Date;
+  /** Signed: positive when the commitment grew. Annualised at the cadence. */
+  annualDelta: DecimalInstance;
+}
+
+export interface RecurringDetection {
+  /** Stable identity for confirm/dismiss state later: account + normalised payee + direction. */
+  key: string;
+  /** The most recent raw description — what the reader will recognise. */
+  description: string;
+  accountId: string;
+  /** 'out' is a commitment; 'in' is recurring income (a salary), kept for the calendar. */
+  direction: 'in' | 'out';
+  cadence: RecurringCadence;
+  /** "monthly", or in words when irregular: "roughly every 5 weeks". */
+  cadenceLabel: string;
+  /** The CURRENT figure — the latest sustained run's amount, as a magnitude. */
+  amount: DecimalInstance;
+  /** What a year of this costs (or brings), at the cadence. */
+  annualEquivalent: DecimalInstance;
+  /** The evidence: how many qualifying payments, over what span. */
+  count: number;
+  firstDate: Date;
+  lastDate: Date;
+  /** last + the observed rhythm. null when the pattern has stopped. */
+  nextExpected: Date | null;
+  /** Ran, then didn't: more than two rhythms of silence. */
+  stopped: boolean;
+  priceChange: RecurringPriceChange | null;
+  medianIntervalDays: number;
+}
+
+interface TransactionLike {
+  accountId: string;
+  description: string;
+  amount: number;
+  date: Date | string;
+  type: string;
+}
+
+const DAY_MS = 86_400_000;
+
+/** At least this many qualifying payments before a pattern is claimed. */
+export const MIN_PAYMENTS = 3;
+
+/**
+ * The payee identity behind a raw bank description: lowercased, with digits
+ * and punctuation collapsed — "NETFLIX.COM 4029" and "NETFLIX.COM 5817" are
+ * one payee wearing two reference numbers. A description that is ALL digits
+ * keeps its raw form rather than collapsing to nothing.
+ */
+export function normalisePayeeKey(description: string): string {
+  const collapsed = description
+    .toLowerCase()
+    .replace(/\d+/g, ' ')
+    .replace(/[^a-z&' ]+/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+  return collapsed === '' ? description.toLowerCase().trim() : collapsed;
+}
+
+/** Median of a non-empty numeric array. */
+const median = (values: number[]): number => {
+  const sorted = [...values].sort((a, b) => a - b);
+  const mid = Math.floor(sorted.length / 2);
+  return sorted.length % 2 === 1 ? sorted[mid] : (sorted[mid - 1] + sorted[mid]) / 2;
+};
+
+/**
+ * The cadence a rhythm belongs to, with the windows deliberately generous —
+ * a monthly direct debit lands on the nearest working day, so its intervals
+ * wander 28–33 days. Everything outside a window is IRREGULAR and says so in
+ * words (handover §2: rounding "roughly every 5 weeks" to "monthly" is not
+ * honest).
+ */
+function classifyCadence(medianDays: number, maxDeviation: number): {
+  cadence: RecurringCadence;
+  label: string;
+  annualFactor: DecimalInstance;
+} {
+  // A rhythm is only a rhythm if the intervals hold to it: one interval
+  // straying more than half the median from it means the words below would
+  // claim a regularity the dates do not show.
+  const regular = maxDeviation <= medianDays * 0.5;
+  if (regular && medianDays >= 6 && medianDays <= 8) {
+    return { cadence: 'weekly', label: 'weekly', annualFactor: toDecimal(52) };
+  }
+  // 26–33, not 26–35: a real direct debit wanders to 33 (a 31-day month plus
+  // a weekend shift), but 35 is five weeks — the handover's own example of a
+  // rhythm that must NOT be rounded to "monthly".
+  if (regular && medianDays >= 26 && medianDays <= 33) {
+    return { cadence: 'monthly', label: 'monthly', annualFactor: toDecimal(12) };
+  }
+  if (regular && medianDays >= 350 && medianDays <= 380) {
+    return { cadence: 'annual', label: 'annual', annualFactor: toDecimal(1) };
+  }
+  // In words, at the truthful unit: days under a fortnight, weeks under a
+  // quarter, months beyond. 365.25/median annualises what was observed.
+  const label =
+    medianDays < 14 ? `roughly every ${Math.round(medianDays)} days`
+      : medianDays < 90 ? `roughly every ${Math.round(medianDays / 7)} weeks`
+        : `roughly every ${Math.round(medianDays / 30.44)} months`;
+  return {
+    cadence: 'irregular',
+    label,
+    annualFactor: toDecimal(365.25).dividedBy(toDecimal(medianDays)),
+  };
+}
+
+interface QualifyingRow {
+  date: Date;
+  /** Magnitude, to the penny — the run identity. */
+  amountKey: string;
+  amount: DecimalInstance;
+  description: string;
+}
+
+/**
+ * Find every recurring pattern in a transaction set.
+ *
+ * `now` is a parameter, not a read of the clock, so the same ledger always
+ * produces the same detections in a test — and so "stopped" is a statement
+ * about a date the caller chose to stand on.
+ */
+export function detectRecurring(
+  transactions: readonly TransactionLike[],
+  now: Date
+): RecurringDetection[] {
+  // Transfers move money between the user's own accounts — a standing order
+  // to savings is a rhythm, but not a commitment to anyone else, and the
+  // transfer pages already show it.
+  const groups = new Map<string, QualifyingRow[]>();
+  for (const t of transactions) {
+    if (t.type !== 'income' && t.type !== 'expense') continue;
+    if (t.amount === 0) continue;
+    const date = t.date instanceof Date ? t.date : new Date(t.date);
+    if (Number.isNaN(date.getTime())) continue;
+    const direction = t.amount < 0 ? 'out' : 'in';
+    const key = `${t.accountId}::${direction}::${normalisePayeeKey(t.description)}`;
+    const amount = toDecimal(t.amount).abs();
+    const row: QualifyingRow = {
+      date,
+      amount,
+      amountKey: amount.toFixed(2),
+      description: t.description,
+    };
+    const list = groups.get(key);
+    if (list) list.push(row); else groups.set(key, [row]);
+  }
+
+  const detections: RecurringDetection[] = [];
+
+  for (const [key, rows] of groups) {
+    if (rows.length < MIN_PAYMENTS) continue;
+    rows.sort((a, b) => a.date.getTime() - b.date.getTime());
+
+    // Runs of consecutive identical amounts. Only runs of two or more
+    // qualify: a sustained figure is what tells a subscription from a shop.
+    const runs: QualifyingRow[][] = [];
+    let current: QualifyingRow[] = [rows[0]];
+    for (let i = 1; i < rows.length; i++) {
+      if (rows[i].amountKey === current[current.length - 1].amountKey) {
+        current.push(rows[i]);
+      } else {
+        runs.push(current);
+        current = [rows[i]];
+      }
+    }
+    runs.push(current);
+    const sustained = runs.filter(run => run.length >= 2);
+    const qualifying = sustained.flat();
+    if (qualifying.length < MIN_PAYMENTS) continue;
+
+    const intervals: number[] = [];
+    for (let i = 1; i < qualifying.length; i++) {
+      intervals.push((qualifying[i].date.getTime() - qualifying[i - 1].date.getTime()) / DAY_MS);
+    }
+    // Same-day duplicates (a split bill, a retried card) are not a rhythm.
+    if (intervals.some(days => days < 1)) continue;
+    const medianDays = median(intervals);
+    const maxDeviation = Math.max(...intervals.map(days => Math.abs(days - medianDays)));
+    const { cadence, label, annualFactor } = classifyCadence(medianDays, maxDeviation);
+
+    const first = qualifying[0];
+    const last = qualifying[qualifying.length - 1];
+    const currentRun = sustained[sustained.length - 1];
+    const amount = currentRun[0].amount;
+
+    // Stopped: silence longer than two rhythms. Two, not one — a direct debit
+    // that slipped a few days must not be pronounced dead (handover §3.2:
+    // never delete a detection silently; stopped is a band, not an absence).
+    const silenceDays = (now.getTime() - last.date.getTime()) / DAY_MS;
+    const stopped = silenceDays > medianDays * 2;
+
+    // Only a run at a DIFFERENT figure is a price change: two runs of the
+    // same amount (a pattern briefly interrupted by a one-off) changed
+    // nothing worth announcing.
+    const previousRun = sustained.length >= 2 ? sustained[sustained.length - 2] : null;
+    const priceChange: RecurringPriceChange | null =
+      previousRun && !previousRun[0].amount.equals(amount)
+        ? {
+            from: previousRun[0].amount,
+            to: amount,
+            when: currentRun[0].date,
+            annualDelta: amount.minus(previousRun[0].amount).times(annualFactor),
+          }
+        : null;
+
+    detections.push({
+      key,
+      description: last.description,
+      accountId: key.slice(0, key.indexOf('::')),
+      direction: key.includes('::out::') ? 'out' : 'in',
+      cadence,
+      cadenceLabel: label,
+      amount,
+      annualEquivalent: amount.times(annualFactor),
+      count: qualifying.length,
+      firstDate: first.date,
+      lastDate: last.date,
+      nextExpected: stopped ? null : new Date(last.date.getTime() + Math.round(medianDays) * DAY_MS),
+      stopped,
+      priceChange,
+      medianIntervalDays: medianDays,
+    });
+  }
+
+  // Largest commitment first within the caller's own banding.
+  return detections.sort((a, b) => b.annualEquivalent.minus(a.annualEquivalent).toNumber());
+}


### PR DESCRIPTION
Step 1 of Claude Design's recurring-and-forecast handover (17 Aug §8): the **read-only detection report**. Confirm/dismiss and the calendar feed are the next slices; nothing here writes to the register, ever.

## The detection (`utils/recurringDetection` — pure, injectable clock)

- **The discriminator between a subscription and a habit is the amount.** Rows group by payee-and-account (reference numbers collapsed), and only *runs* of consecutive identical figures count: a one-off odd amount at a regular payee drops out without breaking the pattern; a shop whose every figure differs produces nothing. Three qualifying payments is the floor — two of anything is a coincidence.
- **No confidence percentages**, per the handover: the payment count, the span and the next expected date *are* the confidence, stated on every row.
- **Monthly is 26–33 days, deliberately not 35**: a real direct debit wanders to 33, but five weeks is the handover's own example of a rhythm that must say "roughly every 5 weeks" in words — and the test pinning this failed at 35 before the window was tightened.
- A new sustained figure is a **price change**, reported with its date and annualised impact (the handover's `£10.99 → £12.99 · +£24.00 a year` shape, verified by test). Two rhythms of silence marks a pattern **stopped** — a band, never a silent deletion.

## The report (`/reports/recurring-commitments`, no period picker)

A rhythm needs the whole history — a window that hides half the payments weakens every evidence line, so like Account Distribution the picker is hidden and the page says what it reads. The headline is the **annual commitment** with one annualisation provenance line; bands by cadence with counts and band totals; each row leads with the annual figure, the per-payment figure explains it, and the evidence line sits in the resting state. Price-change deltas wear the direction hues, magnitudes stay neutral. Stopped band with last-seen. Both empty states say consequence-then-remedy; the skeleton is three real-height rows, no pulse. Rows open the account's register.

Outgoing only: a commitment is money out. Recurring income is detected (the calendar will want it) but not audited here.

## Verified

- `lint` 0 · `typecheck:strict` clean · full unit suite via pre-commit
- 15 detection tests pin the honesty rules (habit-vs-subscription, the five-week boundary, stopped-not-dead, price-change arithmetic); the hub's gallery and render loops cover the new entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)
