### PR TITLE
feat(reports): Confirm and Not-recurring — the verdicts that gate the forecast

### DIFF
--- a/crates/wealth-core/src/row/dismissal.rs
+++ b/crates/wealth-core/src/row/dismissal.rs
@@ -55,10 +55,12 @@ use crate::error::CoreResult;
 pub struct DismissalRow {
     /// Primary key.
     pub id: String,
-    /// One of the seven `suggestion_dismissals_kind_known` admits: the four the
+    /// One of the nine `suggestion_dismissals_kind_known` admits: the four the
     /// transfer sweep makes (`transfer-pair`, `transfer-leg`, `stranded`,
-    /// `duplicate`) and the three Payee cleanup makes (`payee-merchant`,
-    /// `payee-line`, `payee-hidden`). See the module docs.
+    /// `duplicate`), the three Payee cleanup makes (`payee-merchant`,
+    /// `payee-line`, `payee-hidden`), and the two recurring verdicts
+    /// (`recurring-confirmed`, `recurring-not` — 20260817220000). See the
+    /// module docs.
     pub kind: String,
     /// What was refused, as the sweep names it. Unique per (owner, kind).
     pub subject_key: String,

--- a/crates/wealth-core/src/verbs/dismiss_suggestion.rs
+++ b/crates/wealth-core/src/verbs/dismiss_suggestion.rs
@@ -115,7 +115,7 @@ use crate::wire::null_if_empty;
 pub struct DismissSuggestion {
     /// Owner. `NOT NULL` and a foreign key in both engines.
     pub user_id: String,
-    /// Which sort of offer is being refused — one of the seven
+    /// Which sort of suggestion is being answered — one of the nine
     /// `suggestion_dismissals_kind_known` admits. Enumerated by CHECK in both
     /// engines, so the FILE judges it and this verb does not hold a second copy
     /// of the list.

--- a/crates/wealth-core/tests/dismissal_writes.rs
+++ b/crates/wealth-core/tests/dismissal_writes.rs
@@ -211,7 +211,27 @@ fn a_payee_refusal_names_text_and_stores_no_subjects() {
         assert!(answer.answer.subject_ids.is_empty());
     }
 
-    assert_eq!(scalar(&connection, "SELECT COUNT(*) FROM suggestion_dismissals"), 3);
+    // The two RECURRING verdicts (20260817220000) travel the same door with
+    // the same two habits: no subject rows, and a key whose payee text no id
+    // remapper can touch. recurring-confirmed is the first POSITIVE verdict
+    // this table holds — the gate that lets a detected pattern feed derived
+    // surfaces — and a CHECK that refused it would be the whole Confirm
+    // control failing to save on a local file.
+    for kind in ["recurring-confirmed", "recurring-not"] {
+        let answer = dismiss_suggestion(
+            &mut connection,
+            refusal(
+                kind,
+                &format!("account:11111111-1111-4111-8111-111111111111|recurring:out:{kind}%20payee"),
+                &[],
+            ),
+        )
+        .expect("recurring verdict");
+        assert!(answer.recorded);
+        assert!(answer.answer.subject_ids.is_empty());
+    }
+
+    assert_eq!(scalar(&connection, "SELECT COUNT(*) FROM suggestion_dismissals"), 5);
     assert_eq!(
         scalar(&connection, "SELECT COUNT(*) FROM suggestion_dismissal_subjects"),
         0

--- a/docs/forecast-direction.md
+++ b/docs/forecast-direction.md
@@ -1,0 +1,45 @@
+# The forecast's relationship to Budget — decided
+
+**Owner's ruling, 17 August 2026**, answering the question Claude Design's
+recurring-and-forecast handover (§7.2) required settled in writing before any
+forecast layout. Their three coherent options were: the forecast produces the
+budget; different horizons; or a scenario that never writes to Budget.
+
+The decision, in the owner's own words:
+
+> "I see the forecast more as a 'scenario tool' for the user to 'play with' —
+> but by play I don't mean a basic or mediocre offering, I want it to be
+> really robust. A stage 2 that you should keep in mind is that the user
+> *can*, if they want, turn a scenario into a 'forecast' and have a toggle to
+> say they want to apply the forecast figures as their 'budgets' for the next
+> 12-month period — or even to select which categories they would like to
+> apply as a budget, in case the user does not want to budget every category;
+> they may just want to target a few."
+
+## What this means, operationally
+
+1. **The forecast is a scenario tool first.** It never writes to Budget on
+   its own, and the page says so — Design's option 3, with its honesty rule.
+2. **Stage 2 is a deliberate, user-driven bridge to Budget**: a scenario can
+   be *promoted* to a forecast, and its figures applied as the next twelve
+   months' budgets — wholesale via a toggle, or **category by category**,
+   because a user may want to target a few categories rather than budget all
+   of them. Applying is an explicit act with an explicit scope; nothing
+   inherits silently.
+3. **Robustness is part of the ruling**, not an aspiration: the inspectable
+   base-period table (§7.1 — twelve months of category actuals, one-offs
+   excludable with the exclusions stated) is the foundation, and it ships
+   before any projection exists, as Design's build order already argues.
+
+This composes the strengths of Design's options 1 and 3: the interrogability
+of stated adjustments over a visible base, with Budget only ever changed by a
+user's explicit, scoped instruction.
+
+## Build order (unchanged from the handover's §8)
+
+1. ✅ Detection, read-only ("What I'm committed to", shipped 17 Aug).
+2. Confirm / Not-recurring verdicts (this change) — only confirmed patterns
+   may ever feed the calendar or a forecast.
+3. Confirmed items feed the forward calendar.
+4. The base-period review table — useful alone as a 12-month category P&L.
+5. The scenario tool, then its stage-2 promotion into budgets.

--- a/scripts/local-sqlite/schema.sql
+++ b/scripts/local-sqlite/schema.sql
@@ -1816,7 +1816,8 @@ CREATE TABLE suggestion_dismissals (
   id           TEXT PRIMARY KEY,
   user_id      TEXT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
 
-  -- SEVEN, not the four this file admitted until slice 23.
+  -- NINE, matching 20260817220000 — this list and the cloud CHECK must widen
+  -- together, and the parity lane is what notices when they do not.
   --
   -- 20260806180000:99-100 created the constraint with four kinds;
   -- 20260808120000 added payee-merchant and payee-line, and 20260808190000
@@ -1828,8 +1829,8 @@ CREATE TABLE suggestion_dismissals (
   --
   -- It is closed HERE, by exactly the argument that closed
   -- `last_reconciled_balance_minor` above: `dismissSuggestion(kind:
-  -- DismissalKind, …)` is the seam's own signature, `DismissalKind` names all
-  -- seven, and a value the seam's own type carries that this file cannot hold
+  -- DismissalKind, …)` is the seam's own signature, `DismissalKind` names every
+  -- kind, and a value the seam's own type carries that this file cannot hold
   -- is a write the local edition would have to refuse while the cloud accepts
   -- it. Settings → Payee cleanup drives all three of the payee kinds through
   -- that one door (PayeeCleanup.tsx:433, :449, :491), so the four-kind CHECK
@@ -1847,9 +1848,19 @@ CREATE TABLE suggestion_dismissals (
   -- the wording, re-import the statement, and the same wording arrives on brand
   -- new ids, so a refusal that expired with the rows would put the payee the
   -- user struck off straight back on the screen (20260808190000:57-61).
+  --
+  -- The two RECURRING kinds (20260817220000) answer "is this detected pattern
+  -- a real commitment?" — recurring-confirmed is the first POSITIVE verdict
+  -- stored here, the gate that lets a pattern feed the calendar and forecast;
+  -- recurring-not moves it to a recoverable band. Same two habits as the
+  -- payee kinds: no subject rows (a pattern outlives its rows), and a key
+  -- whose payee text no id remapper can touch — with one role-prefixed
+  -- ACCOUNT id segment that a restore's remapping rewrites in place, so the
+  -- verdict follows the account into its new login.
   kind         TEXT NOT NULL CHECK (kind IN (
                  'transfer-pair','transfer-leg','stranded','duplicate',
-                 'payee-merchant','payee-line','payee-hidden')),
+                 'payee-merchant','payee-line','payee-hidden',
+                 'recurring-confirmed','recurring-not')),
 
   subject_key  TEXT NOT NULL CHECK (trim(subject_key) <> ''),
   dismissed_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now')),

--- a/scripts/local-sqlite/verb-specs/dismiss-a-recurring-verdict-gates-the-derived-surfaces.spec.mjs
+++ b/scripts/local-sqlite/verb-specs/dismiss-a-recurring-verdict-gates-the-derived-surfaces.spec.mjs
@@ -1,0 +1,54 @@
+import {
+  USER, NEW_DISMISSAL,
+  dismissalShape, subjectsInRoleOrder, dismissalsOwnedBy, subjectRowsInTotal,
+} from './_shared.mjs';
+
+// THE SPEC THAT PINS THE CHECK 20260817220000 WIDENED — on both engines.
+//
+// `recurring-confirmed` is the first POSITIVE verdict this table holds: the
+// user vouching that a detected recurring pattern is a real commitment, which
+// is the statement that lets it feed the forward calendar and the forecast
+// (Design handover 17 Aug §5 — an unconfirmed detection is the app's opinion
+// and may never silently feed anything). A CHECK that refused it would be the
+// whole Confirm control failing to save on a local file. Narrow either
+// engine's list back and this spec goes red on that engine alone.
+export default {
+  invariant: 'B-7',
+  title: 'a recurring verdict names its pattern and no rows at all',
+  design: '20260817220000 added recurring-confirmed and recurring-not by DROP + ADD of suggestion_dismissals_kind_known. The key is account:<id>|recurring:<direction>:<percent-encoded payee key> — the account segment is a role-prefixed row id the restore path remaps IN PLACE, so a verdict follows its account into a new login; the pattern segment’s value always contains a further ":", so no remapper can mistake the payee text for an id',
+  consequence: 'The "What I’m committed to" report drives both kinds through the seam’s one dismissSuggestion door. subject_ids is EMPTY because a pattern outlives its rows: delete a year of statements and re-import, and the same payments arrive on new ids — a verdict that expired with the rows would put the question straight back in front of a user who had already answered it',
+  parity: 'match',
+
+  command: {
+    verb: 'dismiss_suggestion',
+    payload: {
+      id: NEW_DISMISSAL,
+      user_id: USER,
+      kind: 'recurring-confirmed',
+      subject_key: 'account:11111111-1111-4111-8111-111111111111|recurring:out:FLIXWATCH%20COM',
+      // EMPTY, and the emptiness is the feature — see consequence above.
+      subject_ids: [],
+    },
+  },
+
+  expect: { outcome: 'ok' },
+
+  result: {
+    kind: 'recurring-confirmed',
+    subject_key: 'account:11111111-1111-4111-8111-111111111111|recurring:out:FLIXWATCH%20COM',
+    subject_ids: [],
+  },
+
+  rowDivergence: {
+    dismissed_at: 'the instant of the write, on two clocks and in two transactions',
+  },
+
+  state: [
+    dismissalShape('recurring-confirmed', 'account:11111111-1111-4111-8111-111111111111|recurring:out:FLIXWATCH%20COM',
+      'recurring-confirmed:account:11111111-1111-4111-8111-111111111111|recurring:out:FLIXWATCH%20COM:0'),
+    subjectsInRoleOrder('recurring-confirmed', 'account:11111111-1111-4111-8111-111111111111|recurring:out:FLIXWATCH%20COM', 'NONE'),
+    dismissalsOwnedBy(USER, '1'),
+    // Nothing was written to the child table, on the engine that has one.
+    subjectRowsInTotal('0'),
+  ],
+};

--- a/src/components/sweeps/DismissedSuggestionsSection.tsx
+++ b/src/components/sweeps/DismissedSuggestionsSection.tsx
@@ -29,6 +29,11 @@ const KIND_LABELS: Record<DismissalKind, string> = {
   'payee-merchant': 'Not one merchant',
   'payee-line': 'Not part of that merchant',
   'payee-hidden': 'Hidden from payee cleanup',
+  // The recurring verdicts likewise live on their own surface — the "What
+  // I'm committed to" report shows Confirmed in place and Not-recurring in
+  // its own restorable band — and, like the payee kinds, they name no rows.
+  'recurring-confirmed': 'Confirmed as recurring',
+  'recurring-not': 'Not recurring',
 };
 
 interface Props {

--- a/src/pages/reports/RecurringCommitmentsReport.tsx
+++ b/src/pages/reports/RecurringCommitmentsReport.tsx
@@ -1,10 +1,13 @@
-import React, { useMemo } from 'react';
+import React, { useMemo, useState } from 'react';
 import { Link, useLocation } from 'react-router-dom';
 import { useApp } from '../../contexts/AppContextSupabase';
+import { useToast } from '../../contexts/ToastContext';
 import { useCurrencyDecimal } from '../../hooks/useCurrencyDecimal';
 import { toDecimal, type DecimalInstance } from '../../utils/decimal';
 import { getDateLocale } from '../../utils/dateFormatter';
 import { preserveDemoParam } from '../../utils/navigation';
+import { dismissedKeys, recurringAnswerKey } from '../../utils/suggestionDismissals';
+import type { RecurringAnswerKind } from '../../types';
 import {
   detectRecurring,
   MIN_PAYMENTS,
@@ -55,8 +58,13 @@ const dayMonth = (date: Date): string =>
   date.toLocaleDateString(getDateLocale(), { day: 'numeric', month: 'short' });
 
 export default function RecurringCommitmentsReport(): React.JSX.Element {
-  const { accounts, transactions, isLoading } = useApp();
+  const {
+    accounts, transactions, isLoading,
+    suggestionDismissals, suggestionDismissalsStatus,
+    dismissSuggestion, restoreSuggestion,
+  } = useApp();
   const { formatCurrency, displayCurrency } = useCurrencyDecimal();
+  const { showError } = useToast();
   const location = useLocation();
 
   const accountName = useMemo(
@@ -74,8 +82,68 @@ export default function RecurringCommitmentsReport(): React.JSX.Element {
     [transactions]
   );
 
-  const active = detections.filter(d => !d.stopped);
-  const stopped = detections.filter(d => d.stopped);
+  /**
+   * THE VERDICTS (handover §5). Stored through the same door every other
+   * suggestion answer goes through, keyed to the PATTERN rather than to any
+   * row of it, so an answer survives the next statement import. Load-bearing
+   * beyond this page: only a confirmed detection may ever feed the calendar
+   * or the forecast — an unconfirmed one is the app's opinion.
+   */
+  const confirmedKeys = useMemo(
+    () => dismissedKeys(suggestionDismissals, 'recurring-confirmed'),
+    [suggestionDismissals]
+  );
+  const notRecurringKeys = useMemo(
+    () => dismissedKeys(suggestionDismissals, 'recurring-not'),
+    [suggestionDismissals]
+  );
+  const answerKeyOf = (d: RecurringDetection): string =>
+    recurringAnswerKey(d.accountId, d.direction, d.payeeKey);
+
+  // Which write is in flight, so a double-click cannot record twice and the
+  // pressed control is the one that shows it is busy.
+  const [savingKey, setSavingKey] = useState<string | null>(null);
+
+  const giveVerdict = async (d: RecurringDetection, kind: RecurringAnswerKind): Promise<void> => {
+    const key = answerKeyOf(d);
+    const opposite: RecurringAnswerKind =
+      kind === 'recurring-confirmed' ? 'recurring-not' : 'recurring-confirmed';
+    setSavingKey(key);
+    try {
+      // One verdict at a time: giving one answer withdraws the other, so the
+      // stored state can never say "confirmed AND a coincidence".
+      if ((opposite === 'recurring-confirmed' ? confirmedKeys : notRecurringKeys).has(key)) {
+        await restoreSuggestion(opposite, key);
+      }
+      await dismissSuggestion(kind, key, []);
+    } catch (error) {
+      showError(error);
+    } finally {
+      setSavingKey(null);
+    }
+  };
+
+  const withdrawVerdict = async (d: RecurringDetection, kind: RecurringAnswerKind): Promise<void> => {
+    const key = answerKeyOf(d);
+    setSavingKey(key);
+    try {
+      await restoreSuggestion(kind, key);
+    } catch (error) {
+      showError(error);
+    } finally {
+      setSavingKey(null);
+    }
+  };
+
+  const answersReady = suggestionDismissalsStatus === 'ready';
+
+  // A pattern the user has called a coincidence leaves the audit — but never
+  // the page (§5: a mis-tap must be recoverable, and the app must not be
+  // seen to hide evidence). It moves to the collapsed band at the foot.
+  const dismissed = detections.filter(d => notRecurringKeys.has(answerKeyOf(d)));
+  const considered = detections.filter(d => !notRecurringKeys.has(answerKeyOf(d)));
+  const active = considered.filter(d => !d.stopped);
+  const stopped = considered.filter(d => d.stopped);
 
   // Decimal throughout — these are money sums read against each other.
   const annualTotal = active.reduce(
@@ -138,6 +206,48 @@ export default function RecurringCommitmentsReport(): React.JSX.Element {
           <p className="text-dense tabular-nums text-gray-500 dark:text-gray-400">
             {formatCurrency(detection.amount, displayCurrency)} {detection.cadenceLabel}
           </p>
+          {/* THE TWO QUIET CONTROLS (§5). Confirm is deliberately NOT amber —
+              there are twenty of these on a page, and amber's monopoly on
+              "your next action" holds. Confirming is what lets this pattern
+              feed the calendar and the forecast; unanswered, it stays an
+              opinion and feeds nothing. */}
+          {answersReady && (
+            confirmedKeys.has(answerKeyOf(detection)) ? (
+              <p className="text-dense text-gray-500 dark:text-gray-400">
+                Confirmed
+                <button
+                  type="button"
+                  onClick={() => void withdrawVerdict(detection, 'recurring-confirmed')}
+                  disabled={savingKey === answerKeyOf(detection)}
+                  className="ml-2 text-gray-400 dark:text-gray-500 hover:text-gray-600 dark:hover:text-gray-300 hover:underline disabled:opacity-50"
+                >
+                  Undo
+                </button>
+              </p>
+            ) : (
+              <p className="text-dense">
+                <button
+                  type="button"
+                  onClick={() => void giveVerdict(detection, 'recurring-confirmed')}
+                  disabled={savingKey === answerKeyOf(detection)}
+                  className="text-gray-500 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-200 hover:underline disabled:opacity-50"
+                  title="Yes, this is a real commitment — confirmed items can feed the calendar and the forecast"
+                >
+                  Confirm
+                </button>
+                <span className="mx-1.5 text-gray-300 dark:text-gray-600">·</span>
+                <button
+                  type="button"
+                  onClick={() => void giveVerdict(detection, 'recurring-not')}
+                  disabled={savingKey === answerKeyOf(detection)}
+                  className="text-gray-500 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-200 hover:underline disabled:opacity-50"
+                  title="A coincidence, not a commitment — it moves to the band at the foot of the page, where it can be restored"
+                >
+                  Not recurring
+                </button>
+              </p>
+            )
+          )}
         </div>
       </li>
     );
@@ -174,7 +284,18 @@ export default function RecurringCommitmentsReport(): React.JSX.Element {
         </p>
       </div>
 
-      {transactions.length === 0 ? (
+      {detections.length > 0 && dismissed.length === detections.length ? (
+        /* Every pattern struck off — a FILTERED empty, not an empty: the
+           count and the reason are named, per the batch-7 rule. */
+        <div className="bg-white dark:bg-gray-800 rounded-lg border border-line dark:border-gray-700 p-6">
+          <p className="text-body text-gray-500 dark:text-gray-400">
+            {dismissed.length === 1
+              ? 'The one pattern the app found is marked not recurring'
+              : `All ${dismissed.length} patterns the app found are marked not recurring`}
+            {' '}— they are in the band below, where any can be restored.
+          </p>
+        </div>
+      ) : transactions.length === 0 ? (
         /* CONSEQUENCE, THEN REMEDY (§6): a fresh ledger cannot show rhythm. */
         <div className="bg-white dark:bg-gray-800 rounded-lg border border-line dark:border-gray-700 p-6">
           <p className="text-body text-gray-500 dark:text-gray-400">
@@ -265,6 +386,44 @@ export default function RecurringCommitmentsReport(): React.JSX.Element {
             </div>
           )}
         </>
+      )}
+
+      {dismissed.length > 0 && (
+        /* NOT RECURRING — collapsed, never gone (§5): a mis-tap is one click
+           to recover, and the app is not silently hiding evidence. These
+           patterns count in no total on this page. */
+        <details className="bg-white dark:bg-gray-800 rounded-lg border border-line dark:border-gray-700">
+          <summary className="cursor-pointer select-none p-6 text-card font-semibold text-theme-heading dark:text-white">
+            Not recurring
+            <span className="ml-2 text-dense font-normal text-gray-400 dark:text-gray-500">
+              {dismissed.length}
+            </span>
+            <span className="ml-3 text-dense font-normal text-gray-500 dark:text-gray-400">
+              Patterns you said are coincidence — restorable any time
+            </span>
+          </summary>
+          <ul className="px-6 pb-6">
+            {dismissed.map(d => (
+              <li key={d.key} className="py-3 flex flex-wrap items-baseline justify-between gap-x-6 gap-y-1 border-t border-gray-50 dark:border-gray-700/50 first:border-0">
+                <div className="min-w-0">
+                  <p className="text-body text-gray-900 dark:text-white truncate">{d.description}</p>
+                  <p className="text-dense text-gray-500 dark:text-gray-400">
+                    {d.count} payments, {d.cadenceLabel}
+                    {accountName.get(d.accountId) && <> · {accountName.get(d.accountId)}</>}
+                  </p>
+                </div>
+                <button
+                  type="button"
+                  onClick={() => void withdrawVerdict(d, 'recurring-not')}
+                  disabled={savingKey === answerKeyOf(d)}
+                  className="text-dense text-gray-500 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-200 hover:underline disabled:opacity-50 shrink-0"
+                >
+                  Restore
+                </button>
+              </li>
+            ))}
+          </ul>
+        </details>
       )}
     </div>
   );

--- a/src/pages/reports/__tests__/RecurringCommitmentsReport.verdicts.test.tsx
+++ b/src/pages/reports/__tests__/RecurringCommitmentsReport.verdicts.test.tsx
@@ -1,0 +1,143 @@
+import React from 'react';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { render, screen, fireEvent, waitFor, within } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { PreferencesProvider } from '../../../contexts/PreferencesContext';
+import { ToastProvider } from '../../../contexts/ToastContext';
+import { __setAppContextValue, __resetAppContextValue } from '../../../test/mocks/AppContextSupabase';
+import RecurringCommitmentsReport from '../RecurringCommitmentsReport';
+import { recurringAnswerKey } from '../../../utils/suggestionDismissals';
+import { normalisePayeeKey } from '../../../utils/recurringDetection';
+import type { Account, SuggestionDismissal, Transaction } from '../../../types';
+
+/**
+ * The two verdicts, end to end (Design handover 17 Aug §5): Confirm and
+ * Not-recurring write through the seam's one dismissSuggestion door, a
+ * dismissed pattern moves to a recoverable band rather than vanishing, and
+ * one verdict withdraws the other. Every payee and figure invented — the
+ * repo is public.
+ */
+
+const ACCOUNT: Account = {
+  id: 'acc-rec', name: 'Synthetic Current', type: 'current', balance: 0,
+  currency: 'GBP', lastUpdated: new Date(), openingBalance: 0, isActive: true,
+};
+
+/** Six monthly payments, the most recent ten days ago — alive and detectable. */
+const monthlyHistory = (): Transaction[] => {
+  const now = new Date();
+  return Array.from({ length: 6 }, (_, i) => {
+    const date = new Date(now.getFullYear(), now.getMonth() - i, now.getDate() - 10);
+    return {
+      id: `rec-${i}`,
+      accountId: ACCOUNT.id,
+      description: 'FLIXWATCH.COM',
+      amount: -7.99,
+      date,
+      type: 'expense' as const,
+      category: 'cat-x',
+    };
+  });
+};
+
+const ANSWER_KEY = recurringAnswerKey(ACCOUNT.id, 'out', normalisePayeeKey('FLIXWATCH.COM'));
+
+const verdictRow = (kind: 'recurring-confirmed' | 'recurring-not'): SuggestionDismissal => ({
+  id: `dis-${kind}`,
+  kind,
+  subjectKey: ANSWER_KEY,
+  subjectIds: [],
+  dismissedAt: new Date(),
+});
+
+const dismissSuggestion = vi.fn(async () => {});
+const restoreSuggestion = vi.fn(async () => {});
+
+const renderReport = (dismissals: SuggestionDismissal[] = []): void => {
+  __setAppContextValue({
+    accounts: [ACCOUNT],
+    transactions: monthlyHistory(),
+    isLoading: false,
+    suggestionDismissals: dismissals,
+    suggestionDismissalsStatus: 'ready',
+    dismissSuggestion,
+    restoreSuggestion,
+  });
+  render(
+    <MemoryRouter>
+      <PreferencesProvider>
+        <ToastProvider>
+          <RecurringCommitmentsReport />
+        </ToastProvider>
+      </PreferencesProvider>
+    </MemoryRouter>
+  );
+};
+
+beforeEach(() => {
+  localStorage.clear();
+  dismissSuggestion.mockClear();
+  restoreSuggestion.mockClear();
+});
+
+afterEach(() => {
+  __resetAppContextValue();
+});
+
+describe('Recurring commitments — the two verdicts', () => {
+  it('Confirm records the verdict against the pattern, not any row of it', async () => {
+    renderReport();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Confirm' }));
+
+    await waitFor(() => {
+      expect(dismissSuggestion).toHaveBeenCalledWith('recurring-confirmed', ANSWER_KEY, []);
+    });
+    // The key carries a remappable account segment and an id-proof pattern
+    // segment — the restore-path contract the migration's verification pins.
+    expect(ANSWER_KEY).toMatch(/^account:acc-rec\|recurring:out:/);
+    expect(restoreSuggestion).not.toHaveBeenCalled();
+  });
+
+  it('a confirmed pattern says so quietly, and Undo withdraws it', async () => {
+    renderReport([verdictRow('recurring-confirmed')]);
+
+    expect(screen.getByText('Confirmed')).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Confirm' })).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Undo' }));
+    await waitFor(() => {
+      expect(restoreSuggestion).toHaveBeenCalledWith('recurring-confirmed', ANSWER_KEY);
+    });
+  });
+
+  it('Not recurring moves the pattern to a recoverable band and out of every total', async () => {
+    renderReport([verdictRow('recurring-not')]);
+
+    // Out of the audit: no Monthly band, and the filtered-empty sentence
+    // names the count and the reason rather than pretending an empty ledger.
+    expect(screen.queryByRole('heading', { name: /Monthly/ })).not.toBeInTheDocument();
+    expect(screen.getByText(/marked not recurring/)).toBeInTheDocument();
+
+    // …but never gone: the band lists it with a Restore.
+    const band = screen.getByText('Not recurring').closest('details');
+    expect(band).not.toBeNull();
+    expect(within(band as HTMLElement).getByText('FLIXWATCH.COM')).toBeInTheDocument();
+
+    fireEvent.click(within(band as HTMLElement).getByRole('button', { name: 'Restore' }));
+    await waitFor(() => {
+      expect(restoreSuggestion).toHaveBeenCalledWith('recurring-not', ANSWER_KEY);
+    });
+  });
+
+  it('giving the opposite verdict withdraws the standing one first', async () => {
+    renderReport([verdictRow('recurring-confirmed')]);
+
+    // A confirmed pattern shows no "Not recurring" control — Undo first is
+    // the deliberate single path, so the stored state can never say
+    // "confirmed AND a coincidence". This pins the guard from the other
+    // side: the only way to reverse is through Undo.
+    expect(screen.queryByRole('button', { name: 'Not recurring' })).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Undo' })).toBeInTheDocument();
+  });
+});

--- a/src/services/api/suggestionDismissalService.ts
+++ b/src/services/api/suggestionDismissalService.ts
@@ -19,6 +19,7 @@ import type { DismissalKind, SuggestionDismissal } from '../../types';
 const KINDS: readonly DismissalKind[] = [
   'transfer-pair', 'transfer-leg', 'stranded', 'duplicate',
   'payee-merchant', 'payee-line', 'payee-hidden',
+  'recurring-confirmed', 'recurring-not',
 ];
 
 const asText = (value: unknown): string | null => (typeof value === 'string' ? value : null);

--- a/src/services/local/mappers/rows.ts
+++ b/src/services/local/mappers/rows.ts
@@ -441,7 +441,9 @@ const DISMISSAL_KINDS: Record<SuggestionDismissal['kind'], true> = {
   duplicate: true,
   'payee-merchant': true,
   'payee-line': true,
-  'payee-hidden': true
+  'payee-hidden': true,
+  'recurring-confirmed': true,
+  'recurring-not': true
 };
 
 /**

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -439,12 +439,27 @@ export type PayeeDismissalKind =
   /** One payee text the screen must stop listing and stop counting entirely. */
   | 'payee-hidden';
 
+/**
+ * The two ANSWERS a recurring detection can be given (Design handover,
+ * 17 Aug §5). Not both refusals: `recurring-confirmed` is the user vouching
+ * for a pattern — the statement that lets it feed the calendar and the
+ * forecast, which an unconfirmed detection never may. Neither holds financial
+ * data and neither changes a figure; confirming can only ALLOW a derived
+ * surface to read what the register already says.
+ */
+export type RecurringAnswerKind =
+  /** "Yes, this is a real commitment" — the gate to every derived surface. */
+  | 'recurring-confirmed'
+  /** "A coincidence" — hidden into a recoverable band, never deleted. */
+  | 'recurring-not';
+
 export type DismissalKind =
   | 'transfer-pair'
   | 'transfer-leg'
   | 'stranded'
   | 'duplicate'
-  | PayeeDismissalKind;
+  | PayeeDismissalKind
+  | RecurringAnswerKind;
 
 /**
  * A suggestion the user has told a sweep to stop offering. Holds no financial

--- a/src/utils/recurringDetection.ts
+++ b/src/utils/recurringDetection.ts
@@ -44,10 +44,17 @@ export interface RecurringPriceChange {
 }
 
 export interface RecurringDetection {
-  /** Stable identity for confirm/dismiss state later: account + normalised payee + direction. */
+  /** Stable identity for confirm/dismiss state: account + normalised payee + direction. */
   key: string;
   /** The most recent raw description — what the reader will recognise. */
   description: string;
+  /**
+   * The normalised payee identity the pattern was grouped by. Exposed so an
+   * answer can be STORED against the pattern (utils/suggestionDismissals'
+   * recurringAnswerKey) without re-deriving the normalisation at a call site
+   * that could drift from this module's.
+   */
+  payeeKey: string;
   accountId: string;
   /** 'out' is a commitment; 'in' is recurring income (a salary), kept for the calendar. */
   direction: 'in' | 'out';
@@ -169,14 +176,21 @@ export function detectRecurring(
   // Transfers move money between the user's own accounts — a standing order
   // to savings is a rhythm, but not a commitment to anyone else, and the
   // transfer pages already show it.
-  const groups = new Map<string, QualifyingRow[]>();
+  interface Group {
+    accountId: string;
+    direction: 'in' | 'out';
+    payeeKey: string;
+    rows: QualifyingRow[];
+  }
+  const groups = new Map<string, Group>();
   for (const t of transactions) {
     if (t.type !== 'income' && t.type !== 'expense') continue;
     if (t.amount === 0) continue;
     const date = t.date instanceof Date ? t.date : new Date(t.date);
     if (Number.isNaN(date.getTime())) continue;
     const direction = t.amount < 0 ? 'out' : 'in';
-    const key = `${t.accountId}::${direction}::${normalisePayeeKey(t.description)}`;
+    const payeeKey = normalisePayeeKey(t.description);
+    const key = `${t.accountId}::${direction}::${payeeKey}`;
     const amount = toDecimal(t.amount).abs();
     const row: QualifyingRow = {
       date,
@@ -184,13 +198,14 @@ export function detectRecurring(
       amountKey: amount.toFixed(2),
       description: t.description,
     };
-    const list = groups.get(key);
-    if (list) list.push(row); else groups.set(key, [row]);
+    const group = groups.get(key);
+    if (group) group.rows.push(row);
+    else groups.set(key, { accountId: t.accountId, direction, payeeKey, rows: [row] });
   }
 
   const detections: RecurringDetection[] = [];
 
-  for (const [key, rows] of groups) {
+  for (const [key, { accountId, direction, payeeKey, rows }] of groups) {
     if (rows.length < MIN_PAYMENTS) continue;
     rows.sort((a, b) => a.date.getTime() - b.date.getTime());
 
@@ -249,8 +264,9 @@ export function detectRecurring(
     detections.push({
       key,
       description: last.description,
-      accountId: key.slice(0, key.indexOf('::')),
-      direction: key.includes('::out::') ? 'out' : 'in',
+      payeeKey,
+      accountId,
+      direction,
       cadence,
       cadenceLabel: label,
       amount,

--- a/src/utils/suggestionDismissals.ts
+++ b/src/utils/suggestionDismissals.ts
@@ -224,8 +224,45 @@ export function isPayeeDismissalKind(kind: DismissalKind): kind is PayeeDismissa
     case 'transfer-leg':
     case 'stranded':
     case 'duplicate':
+    case 'recurring-confirmed':
+    case 'recurring-not':
       return false;
   }
+}
+
+/* ── Recurring detections: an answer about a PATTERN, not about rows ──────── */
+
+/**
+ * The identity of a recurring detection, as an answer is stored against it.
+ *
+ * Two segments:
+ *
+ *   account:<id>|recurring:<direction>:<percent-encoded payee key>
+ *
+ * The ACCOUNT segment is a role-prefixed row id, exactly the shape
+ * remapDismissalKey (services/backup/format) is built to handle: the value
+ * after the single role prefix is the bare uuid, so a restore into a new
+ * login rewrites it in place — and the detection, re-derived from the
+ * restored rows, computes the same key and finds its answer waiting. A bare
+ * unprefixed id would ALSO remap, but would join the re-sorted positions;
+ * the prefix keeps the segments in their spoken order.
+ *
+ * The PATTERN segment follows the payee-cleanup convention for the same
+ * reason it exists there: the value after `recurring:` always contains a
+ * further ':' (the direction), so it can never look uuid-shaped and no
+ * remapper can touch the payee text — even a payee whose bank wording IS a
+ * uuid. Percent-encoding removes '|' and ':' from the text itself.
+ *
+ * Keyed by the normalised payee, not the raw description, because the raw
+ * form changes reference numbers between statements while the pattern does
+ * not — an answer must survive the next import, or the question comes back.
+ */
+export function recurringAnswerKey(
+  accountId: string,
+  direction: 'in' | 'out',
+  payeeKey: string
+): string {
+  return `account:${accountId}${SEPARATOR}recurring:${direction}:${encodeURIComponent(payeeKey)}`;
 }
 
 /**

--- a/supabase/migrations/20260817220000_recurring_answers.sql
+++ b/supabase/migrations/20260817220000_recurring_answers.sql
@@ -1,0 +1,146 @@
+-- ============================================================================
+-- RECURRING ANSWERS — Confirm and Not-recurring on detected patterns
+-- ============================================================================
+-- IMPORTANT: apply with `npm run db:migrate` (see supabase/migrations/README.md
+-- rule 1 — never the SQL editor).
+--
+-- ORDERING: apply this BEFORE the matching client deploys — the same rule as
+-- 20260808190000, for the same reason. It only WIDENS a CHECK constraint, so a
+-- database with it applied and the old client running behaves exactly as it
+-- does now — but a client that ships first cannot save either answer AT ALL,
+-- and the "What I'm committed to" report has to tell the user their Confirm
+-- was not kept.
+--
+-- ── WHY ─────────────────────────────────────────────────────────────────────
+--
+-- The recurring-detection report (Claude Design handover, 17 Aug §5) asks the
+-- user two quiet questions about every pattern the app has noticed: is this a
+-- real commitment (Confirm), or a coincidence (Not recurring)? The answers are
+-- load-bearing rather than cosmetic: ONLY a confirmed detection may ever feed
+-- the forward calendar or the forecast — an unconfirmed detection is the app's
+-- opinion, and a forecast that inherits unreviewed opinions can no longer be
+-- interrogated.
+--
+--   recurring-confirmed   "yes, a real commitment" — the gate that lets the
+--                         pattern feed derived surfaces.
+--   recurring-not         "a coincidence" — the pattern moves to a collapsed,
+--                         recoverable band on the report. Never a deletion.
+--
+-- ── A WORD ON DOCTRINE ──────────────────────────────────────────────────────
+--
+-- This table was introduced as refusals — "a dismissal can only hide an
+-- offer". `recurring-confirmed` is not a refusal; it is the first POSITIVE
+-- answer stored here, and the table's honest description is now "the user's
+-- recorded verdicts on the app's suggestions". The invariant that mattered is
+-- unchanged and still holds for both new kinds: a row here holds no financial
+-- data and changes no figure. Confirming can only ALLOW a derived surface to
+-- read what the register already says; it writes nothing into the register.
+--
+-- ── THE KEY SHAPE ───────────────────────────────────────────────────────────
+--
+--   account:<uuid>|recurring:<direction>:<percent-encoded payee key>
+--
+-- The account segment is a ROLE-PREFIXED row id: remapDismissalKey
+-- (services/backup/format) rewrites the value behind a single role prefix in
+-- place, so a restore into a new login re-points the answer at the restored
+-- account — and the detection, re-derived from the restored rows, computes
+-- the same key and finds its answer waiting. The pattern segment follows the
+-- payee-cleanup convention: the value behind `recurring:` always contains a
+-- further ':', so no remapper can mistake the payee text for an id.
+--
+-- subject_ids is EMPTY, exactly as the payee kinds argue: a pattern outlives
+-- its rows. Delete a year of statements and re-import them, and the same
+-- payments arrive on brand-new ids — an answer that expired with the rows
+-- would put the question straight back in front of a user who had already
+-- given it.
+--
+-- ── SAFE TO RUN TWICE ───────────────────────────────────────────────────────
+-- DROP CONSTRAINT IF EXISTS + ADD CONSTRAINT inside one transaction, exactly
+-- as 20260808190000: idempotent, and the table is never left unconstrained.
+-- ============================================================================
+
+BEGIN;
+
+-- Guard: the widening below is only valid if every stored row already
+-- satisfies the NEW constraint — which it must, the new list being a superset.
+-- "Must" is not "does": fail here naming the stray, not in the validating scan.
+DO $$
+DECLARE
+  stray_kind text;
+BEGIN
+  SELECT kind INTO stray_kind
+    FROM public.suggestion_dismissals
+   WHERE kind NOT IN (
+     'transfer-pair', 'transfer-leg', 'stranded', 'duplicate',
+     'payee-merchant', 'payee-line', 'payee-hidden',
+     'recurring-confirmed', 'recurring-not'
+   )
+   LIMIT 1;
+
+  IF stray_kind IS NOT NULL THEN
+    RAISE EXCEPTION
+      'suggestion_dismissals holds kind "%" which this migration does not admit; widen the list here before applying',
+      stray_kind;
+  END IF;
+END $$;
+
+ALTER TABLE public.suggestion_dismissals
+  DROP CONSTRAINT IF EXISTS suggestion_dismissals_kind_known;
+
+ALTER TABLE public.suggestion_dismissals
+  ADD CONSTRAINT suggestion_dismissals_kind_known
+  CHECK (kind IN (
+    'transfer-pair',
+    'transfer-leg',
+    'stranded',
+    'duplicate',
+    'payee-merchant',
+    'payee-line',
+    'payee-hidden',
+    'recurring-confirmed',
+    'recurring-not'
+  ));
+
+COMMENT ON TABLE public.suggestion_dismissals IS
+  'The user''s recorded verdicts on the app''s suggestions. Introduced as refusals ("stop offering me this"); recurring-confirmed (20260817220000) is the first positive verdict — the statement that lets a detected recurring pattern feed the calendar and the forecast. Every kind holds no financial data and changes no figure.';
+
+COMMENT ON COLUMN public.suggestion_dismissals.subject_key IS
+  'Canonical identity of the suggestion answered: sorted ids joined with "|", prefixed by the finding kind where one scan can produce several kinds of offer about the same rows. The payee-cleanup kinds hold role-prefixed, percent-encoded payee text; the recurring kinds hold account:<id>|recurring:<direction>:<percent-encoded payee key> — the account segment remaps on restore, the payee text never can. Unique per (user_id, kind).';
+
+COMMIT;
+
+-- ============================================================================
+-- VERIFICATION — read this output after applying
+-- ============================================================================
+-- 1. The constraint now admits all nine kinds and nothing else.
+SELECT pg_get_constraintdef(oid) AS kind_check
+  FROM pg_constraint
+ WHERE conrelid = 'public.suggestion_dismissals'::regclass
+   AND conname = 'suggestion_dismissals_kind_known';
+
+-- 2. Nothing else moved. Expected: rls_enabled = true and the same three
+--    policies (SELECT, INSERT, DELETE) this table has always had.
+SELECT
+  c.relrowsecurity AS rls_enabled,
+  (SELECT string_agg(p.cmd, ', ' ORDER BY p.cmd) FROM pg_policies p
+    WHERE p.schemaname = 'public' AND p.tablename = 'suggestion_dismissals') AS commands
+FROM pg_class c
+JOIN pg_namespace n ON n.oid = c.relnamespace
+WHERE n.nspname = 'public' AND c.relname = 'suggestion_dismissals';
+
+-- 3. Verdicts by kind. Expected: zero recurring rows immediately after
+--    applying; afterwards, the count of patterns the owner has confirmed or
+--    struck off on "What I'm committed to".
+SELECT kind, count(*) AS verdicts
+  FROM public.suggestion_dismissals
+ GROUP BY kind
+ ORDER BY kind;
+
+-- 4. Every recurring key is shaped the way the restore path needs: one
+--    role-prefixed account segment, one role-prefixed pattern segment.
+--    Expected: zero rows. Any row here would survive a restore with its
+--    account un-remapped — an answer silently orphaned from its pattern.
+SELECT id, kind, subject_key
+  FROM public.suggestion_dismissals
+ WHERE kind IN ('recurring-confirmed', 'recurring-not')
+   AND subject_key !~ '^account:[^|:]+\|recurring:(in|out):[^|]*$';


### PR DESCRIPTION
Step 2 of Design's recurring-and-forecast handover (§5), plus the owner's forecast ruling recorded in writing.

## ⚠️ Merge order: the migration goes first

`supabase/migrations/20260817220000_recurring_answers.sql` must be applied **before this client deploys** — the same ordering rule as the payee-kinds migration it is modelled on. It only widens a CHECK, so the old client on the new database behaves exactly as today; but the new client on the old database cannot save either verdict at all. **Do not merge until the migration is applied** (`npm run db:migrate`).

## The verdicts

Two quiet controls per detection — **Confirm** (deliberately not amber: twenty of them on a page, and amber's monopoly on "your next action" holds) and **Not recurring**. They travel the seam's one `dismissSuggestion` door as two new kinds beside the seven refusals. `recurring-confirmed` is the first **positive** verdict the table holds, so the migration restates the table's doctrine: a verdict holds no financial data and changes no figure — confirming can only *allow* a derived surface to read what the register already says. **Only confirmed patterns may ever feed the calendar or the forecast.**

- Confirmed shows in place with an Undo; a coincidence moves to a collapsed, restorable band and out of every total; every pattern struck off is a *filtered* empty naming the count and the reason.
- One verdict at a time: giving one withdraws the other, and a confirmed row offers only Undo — the stored state can never say "confirmed AND coincidence".

## The key shape carries the restore path

`account:<id>|recurring:<direction>:<percent-encoded payee key>` — the account segment is a role-prefixed row id that `remapDismissalKey` rewrites in place, so a verdict follows its account into a restored login; the pattern segment's value always contains a further `:`, so no remapper can mistake payee text for an id. `subject_ids` is empty: a pattern outlives its rows.

## Widened together, as the parity lane demands

The cloud CHECK, the local SQLite mirror, the crate's tests (16/16 dismissals, **521 across the core**, clippy `-D warnings` clean), both TS kind lists (one an exhaustive `Record` whose compile error found the sweep's label list), and a nightly verb-spec that goes red on whichever engine narrows its list back.

## Also in this PR

`docs/forecast-direction.md` — the owner's §7.2 decision in writing: the forecast is a **scenario tool** that never writes to Budget silently; stage 2 promotes a scenario into next-12-month budgets by explicit toggle, wholesale or **category-by-category**.

## Verified

- lint 0 · typecheck:strict clean · full unit suite via pre-commit · 4 verdict tests pin the flows

🤖 Generated with [Claude Code](https://claude.com/claude-code)
