### PR TITLE
feat(calendar): confirmed patterns feed the forward view

### DIFF
--- a/src/pages/Calendar.tsx
+++ b/src/pages/Calendar.tsx
@@ -1,5 +1,5 @@
 import { useState, useMemo } from 'react';
-import { useNavigate, useLocation } from 'react-router-dom';
+import { Link, useNavigate, useLocation } from 'react-router-dom';
 import { useApp } from '../contexts/AppContextSupabase';
 import { useCurrencyDecimal } from '../hooks/useCurrencyDecimal';
 import { preserveDemoParam } from '../utils/navigation';
@@ -7,6 +7,10 @@ import { ChevronLeftIcon, ChevronRightIcon } from '../components/icons';
 import PageWrapper from '../components/PageWrapper';
 import PageTip from '../components/PageTip';
 import { toDecimal } from '../utils/decimal';
+import { getDateLocale } from '../utils/dateFormatter';
+import { detectRecurring } from '../utils/recurringDetection';
+import { projectRecurringSchedule } from '../utils/recurringSchedule';
+import { dismissedKeys, recurringAnswerKey } from '../utils/suggestionDismissals';
 
 interface DayData {
   date: Date;
@@ -20,7 +24,7 @@ interface DayData {
 }
 
 export default function Calendar() {
-  const { transactions, accounts } = useApp();
+  const { transactions, accounts, suggestionDismissals } = useApp();
   const { formatCurrency } = useCurrencyDecimal();
   const navigate = useNavigate();
   const location = useLocation();
@@ -151,6 +155,51 @@ export default function Calendar() {
     return days;
   }, [transactions, year, month, totalOpeningBalance]);
 
+  /**
+   * THE FORWARD HALF (Design handover 17 Aug, §1 and §8 step 3): what is
+   * DUE, projected from the recurring patterns the user has CONFIRMED on
+   * "What I'm committed to" — and only those. An unconfirmed detection is
+   * the app's opinion, and an opinion must never sit on a calendar looking
+   * like a payment that is going to happen (§5). Everything here is an
+   * inference and is dressed as one: the word is "due", the styling is
+   * quiet, and nothing joins the actual-money figures around it.
+   */
+  const confirmedPatterns = useMemo(() => {
+    const confirmed = dismissedKeys(suggestionDismissals, 'recurring-confirmed');
+    return detectRecurring(transactions, new Date()).filter(
+      d => !d.stopped && confirmed.has(recurringAnswerKey(d.accountId, d.direction, d.payeeKey))
+    );
+  }, [transactions, suggestionDismissals]);
+
+  /** The panel's window: the next 30 days, from today wherever the grid is. */
+  const dueNext = useMemo(() => {
+    const from = new Date();
+    from.setHours(0, 0, 0, 0);
+    const until = new Date(from.getTime() + 30 * 86_400_000);
+    return projectRecurringSchedule(confirmedPatterns, from, until);
+  }, [confirmedPatterns]);
+
+  /** Expected items per day of the VISIBLE month, for the quiet cell marks. */
+  const dueByDay = useMemo(() => {
+    const today = new Date();
+    today.setHours(0, 0, 0, 0);
+    const monthStart = new Date(year, month, 1);
+    const from = monthStart > today ? monthStart : today;
+    const until = new Date(year, month + 1, 0, 23, 59, 59);
+    const byDay = new Map<number, number>();
+    for (const occurrence of projectRecurringSchedule(confirmedPatterns, from, until)) {
+      if (occurrence.date.getMonth() !== month || occurrence.date.getFullYear() !== year) continue;
+      const day = occurrence.date.getDate();
+      byDay.set(day, (byDay.get(day) ?? 0) + 1);
+    }
+    return byDay;
+  }, [confirmedPatterns, year, month]);
+
+  const accountNameById = useMemo(
+    () => new Map(accounts.map(a => [a.id, a.name])),
+    [accounts]
+  );
+
   // Month summary
   const monthSummary = useMemo(() => {
     const monthDays = calendarData.filter(d => d.isCurrentMonth);
@@ -218,6 +267,80 @@ export default function Calendar() {
           <p className="text-lg font-semibold text-gray-900 dark:text-white">{monthSummary.totalTransactions}</p>
         </div>
       </div>
+
+      {/* ─ DUE NEXT — the forward panel (Design handover §1, §8 step 3) ────
+          Confirmed patterns only, and it says so: an unconfirmed detection
+          is an opinion and never sits here looking like a payment that will
+          happen. Every figure is an EXPECTATION — neutral, worded "due",
+          never joining the actual-money hues around it (P8: an inference is
+          not a figure the user entered). */}
+      <section
+        aria-labelledby="due-next-heading"
+        className="bg-white dark:bg-gray-800 rounded-lg shadow-sm border border-gray-100 dark:border-gray-700 px-4 py-3 mb-4"
+      >
+        <div className="flex flex-wrap items-baseline justify-between gap-2">
+          <h2 id="due-next-heading" className="text-sm font-semibold text-gray-900 dark:text-white">
+            Due in the next 30 days
+            {dueNext.length > 0 && (
+              <span className="ml-2 text-xs font-normal text-gray-400 dark:text-gray-500">
+                {dueNext.length}
+              </span>
+            )}
+          </h2>
+          <span className="text-xs text-gray-400 dark:text-gray-500">
+            Only patterns you have confirmed on{' '}
+            <Link
+              to={preserveDemoParam('/reports/recurring-commitments', location.search)}
+              className="text-primary hover:underline"
+            >
+              What I&rsquo;m committed to
+            </Link>
+          </span>
+        </div>
+        {dueNext.length === 0 ? (
+          <p className="mt-1 text-sm text-gray-500 dark:text-gray-400">
+            Nothing confirmed yet — recurring payments you confirm on that
+            report appear here before they fall due.
+          </p>
+        ) : (
+          <>
+            <ul className="mt-2 divide-y divide-gray-50 dark:divide-gray-700/50">
+              {dueNext.slice(0, 8).map((occurrence) => (
+                <li
+                  key={`${occurrence.detection.key}-${occurrence.date.getTime()}`}
+                  className="py-1.5 flex flex-wrap items-baseline justify-between gap-x-4 gap-y-0.5"
+                >
+                  <span className="min-w-0 flex items-baseline gap-2">
+                    <span className="text-xs tabular-nums text-gray-500 dark:text-gray-400 w-14 shrink-0">
+                      {occurrence.date.toLocaleDateString(getDateLocale(), { day: 'numeric', month: 'short' })}
+                    </span>
+                    <span className="text-sm text-gray-900 dark:text-white truncate">
+                      {occurrence.detection.description}
+                    </span>
+                    {accountNameById.get(occurrence.detection.accountId) && (
+                      <span className="text-xs text-gray-400 dark:text-gray-500 truncate">
+                        {accountNameById.get(occurrence.detection.accountId)}
+                      </span>
+                    )}
+                  </span>
+                  <span className="text-sm tabular-nums text-gray-600 dark:text-gray-300 shrink-0">
+                    {formatCurrency(occurrence.amount.toNumber())}
+                    {occurrence.detection.direction === 'in' && (
+                      <span className="ml-1 text-xs text-gray-400 dark:text-gray-500">in</span>
+                    )}
+                  </span>
+                </li>
+              ))}
+            </ul>
+            {dueNext.length > 8 && (
+              /* Named, never silently truncated. */
+              <p className="mt-1.5 text-xs text-gray-400 dark:text-gray-500">
+                …and {dueNext.length - 8} more in the next 30 days.
+              </p>
+            )}
+          </>
+        )}
+      </section>
 
       {/* Calendar header with navigation */}
       <div className="bg-white dark:bg-gray-800 rounded-xl shadow-sm border border-gray-100 dark:border-gray-700 overflow-hidden">
@@ -322,6 +445,17 @@ export default function Calendar() {
                   day.runningBalance < 0 ? 'text-red-500' : 'text-gray-500 dark:text-gray-400'
                 }`}>
                   {formatCurrency(day.runningBalance)}
+                </div>
+              )}
+
+              {/* EXPECTED, not happened: confirmed patterns falling due on
+                  this day. Neutral and worded, deliberately nothing like the
+                  actual-money figures above — an inference on a calendar must
+                  never read as a transaction (P8). The panel above the grid
+                  carries the detail. */}
+              {day.isCurrentMonth && (dueByDay.get(day.day) ?? 0) > 0 && (
+                <div className="text-[10px] text-gray-400 dark:text-gray-500 truncate">
+                  {dueByDay.get(day.day)} due
                 </div>
               )}
             </div>

--- a/src/pages/__tests__/Calendar.test.tsx
+++ b/src/pages/__tests__/Calendar.test.tsx
@@ -14,6 +14,9 @@ vi.mock('../../contexts/AppContextSupabase', () => ({
     accounts: [
       { id: 'acc1', name: 'Test Account', type: 'current', balance: 1000, openingBalance: 1000 },
     ],
+    // The forward panel reads the recurring verdicts; none here, so it shows
+    // its "nothing confirmed yet" line.
+    suggestionDismissals: [],
   }),
 }));
 
@@ -39,6 +42,21 @@ describe('Calendar', () => {
       </MemoryRouter>
     );
     expect(screen.getByText('Calendar')).toBeInTheDocument();
+  });
+
+  it('shows the forward panel gated on CONFIRMED patterns, with the way to confirm', () => {
+    render(
+      <MemoryRouter>
+        <Calendar />
+      </MemoryRouter>
+    );
+
+    // No verdicts in the mock, so the panel states its gate rather than
+    // projecting the app's unconfirmed opinions onto future days (§5).
+    expect(screen.getByText('Due in the next 30 days')).toBeInTheDocument();
+    expect(screen.getByText(/Nothing confirmed yet/)).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /What I’m committed to/ }))
+      .toHaveAttribute('href', '/reports/recurring-commitments');
   });
 
   it('renders day headers', () => {

--- a/src/pages/__tests__/CalendarDueNext.test.tsx
+++ b/src/pages/__tests__/CalendarDueNext.test.tsx
@@ -1,0 +1,71 @@
+import React from 'react';
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, within } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import Calendar from '../Calendar';
+import { recurringAnswerKey } from '../../utils/suggestionDismissals';
+import { normalisePayeeKey } from '../../utils/recurringDetection';
+
+/**
+ * The positive half of the forward panel: a CONFIRMED pattern's expected
+ * payments appear, worded as due — and the projection reaches the panel
+ * end to end, not just the unit. Every payee and figure invented.
+ */
+
+/** Six monthly payments, most recent ten days ago — alive and detectable. */
+const history = () => {
+  const now = new Date();
+  return Array.from({ length: 6 }, (_, i) => ({
+    id: `due-${i}`,
+    accountId: 'acc1',
+    description: 'FLIXWATCH.COM',
+    amount: -7.99,
+    date: new Date(now.getFullYear(), now.getMonth() - i, now.getDate() - 10),
+    type: 'expense' as const,
+    category: 'cat-x',
+  }));
+};
+
+vi.mock('../../contexts/AppContextSupabase', () => ({
+  useApp: () => ({
+    transactions: history(),
+    accounts: [
+      { id: 'acc1', name: 'Synthetic Current', type: 'current', balance: 0, openingBalance: 0 },
+    ],
+    suggestionDismissals: [
+      {
+        id: 'dis-1',
+        kind: 'recurring-confirmed',
+        // Built by the same builder the page uses, so this test pins the
+        // WIRING (verdict → panel), not a copied string.
+        subjectKey: recurringAnswerKey('acc1', 'out', normalisePayeeKey('FLIXWATCH.COM')),
+        subjectIds: [],
+        dismissedAt: new Date(),
+      },
+    ],
+  }),
+}));
+
+vi.mock('../../hooks/useCurrencyDecimal', () => ({
+  useCurrencyDecimal: () => ({
+    formatCurrency: (amount: number) => `£${Number(amount).toFixed(2)}`,
+  }),
+}));
+
+describe('Calendar — confirmed patterns feed the forward panel', () => {
+  it('lists the confirmed pattern as due, with its account, inside 30 days', () => {
+    render(
+      <MemoryRouter>
+        <Calendar />
+      </MemoryRouter>
+    );
+
+    const panel = screen.getByText('Due in the next 30 days').closest('section');
+    expect(panel).not.toBeNull();
+    // Expected ~20 days out (last paid 10 days ago on a monthly rhythm).
+    expect(within(panel as HTMLElement).getByText('FLIXWATCH.COM')).toBeInTheDocument();
+    expect(within(panel as HTMLElement).getByText('£7.99')).toBeInTheDocument();
+    expect(within(panel as HTMLElement).getByText('Synthetic Current')).toBeInTheDocument();
+    expect(within(panel as HTMLElement).queryByText(/Nothing confirmed yet/)).not.toBeInTheDocument();
+  });
+});

--- a/src/utils/recurringSchedule.test.ts
+++ b/src/utils/recurringSchedule.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect } from 'vitest';
+import { toDecimal } from './decimal';
+import { projectRecurringSchedule } from './recurringSchedule';
+import type { RecurringDetection } from './recurringDetection';
+
+/**
+ * The forward schedule's honesty rules: it steps each pattern's OWN rhythm,
+ * projects nothing from a stopped pattern, and folds a late payment onto the
+ * window's first day exactly once. Every figure invented — the repo is public.
+ */
+
+const D = (y: number, m: number, d: number): Date => new Date(y, m - 1, d);
+
+const detection = (over: Partial<RecurringDetection>): RecurringDetection => ({
+  key: 'acc-1::out::synthetic',
+  description: 'SYNTHETIC CLUB',
+  payeeKey: 'synthetic club',
+  accountId: 'acc-1',
+  direction: 'out',
+  cadence: 'monthly',
+  cadenceLabel: 'monthly',
+  amount: toDecimal(9.99),
+  annualEquivalent: toDecimal(119.88),
+  count: 6,
+  firstDate: D(2026, 3, 1),
+  lastDate: D(2026, 8, 1),
+  nextExpected: D(2026, 9, 1),
+  stopped: false,
+  priceChange: null,
+  medianIntervalDays: 30,
+  ...over,
+});
+
+describe('projectRecurringSchedule', () => {
+  it('steps each pattern by its own observed rhythm, inside the window only', () => {
+    const weekly = detection({
+      key: 'w', cadence: 'weekly', cadenceLabel: 'weekly',
+      medianIntervalDays: 7, nextExpected: D(2026, 9, 2),
+    });
+    const due = projectRecurringSchedule([weekly], D(2026, 9, 1), D(2026, 9, 30));
+
+    expect(due.map(o => o.date.getDate())).toEqual([2, 9, 16, 23, 30]);
+    expect(due.every(o => o.amount.toNumber() === 9.99)).toBe(true);
+  });
+
+  it('a stopped pattern has nothing due', () => {
+    const stopped = detection({ stopped: true, nextExpected: null });
+    expect(projectRecurringSchedule([stopped], D(2026, 9, 1), D(2026, 9, 30))).toHaveLength(0);
+  });
+
+  it('a late payment lands on the window start once, then the rhythm resumes', () => {
+    // Expected 25 Aug, window opens 1 Sep: overdue, not yet stopped.
+    const late = detection({ nextExpected: D(2026, 8, 25), medianIntervalDays: 30 });
+    const due = projectRecurringSchedule([late], D(2026, 9, 1), D(2026, 10, 31));
+
+    // Once on the first day (the overdue), then 24 Sep and 24 Oct — never a
+    // phantom occurrence per missed rhythm.
+    expect(due.map(o => `${o.date.getDate()}/${o.date.getMonth() + 1}`))
+      .toEqual(['1/9', '24/9', '24/10']);
+  });
+
+  it('orders a mixed schedule by date', () => {
+    const monthly = detection({ key: 'm', nextExpected: D(2026, 9, 15) });
+    const weekly = detection({
+      key: 'w', cadence: 'weekly', cadenceLabel: 'weekly',
+      medianIntervalDays: 7, nextExpected: D(2026, 9, 4), amount: toDecimal(5),
+    });
+    const due = projectRecurringSchedule([weekly, monthly], D(2026, 9, 1), D(2026, 9, 20));
+
+    expect(due.map(o => o.date.getDate())).toEqual([4, 11, 15, 18]);
+  });
+
+  it('an empty or inverted window projects nothing', () => {
+    expect(projectRecurringSchedule([detection({})], D(2026, 9, 30), D(2026, 9, 1))).toHaveLength(0);
+  });
+});

--- a/src/utils/recurringSchedule.ts
+++ b/src/utils/recurringSchedule.ts
@@ -1,0 +1,75 @@
+import type { DecimalInstance } from './decimal';
+import type { RecurringDetection } from './recurringDetection';
+
+/**
+ * The forward schedule: confirmed recurring patterns, projected ahead.
+ *
+ * This is the "what is due next?" read of the detection work (Design
+ * handover, 17 Aug §1) — and the gate from §5 is the whole contract here:
+ * callers hand this function CONFIRMED detections only. An unconfirmed
+ * detection is the app's opinion, and an opinion must never appear on a
+ * calendar as a payment that is going to happen. The function cannot check
+ * the verdicts itself (they live beside the store), so the report's rule is
+ * restated at this boundary instead: filter before you project.
+ *
+ * A projected occurrence is an INFERENCE about the future — weaker even than
+ * a detection, which at least describes payments that happened. Every
+ * consumer must present these as expected, never as figures in the ledger:
+ * the shape carries the detection so the evidence is one hop away.
+ */
+export interface ExpectedPayment {
+  /** The pattern this occurrence is projected from — the evidence. */
+  detection: RecurringDetection;
+  /** When the payment is expected, stepping the observed rhythm forward. */
+  date: Date;
+  /** The current figure, as a magnitude — direction is on the detection. */
+  amount: DecimalInstance;
+}
+
+const DAY_MS = 86_400_000;
+
+/**
+ * Occurrences of each pattern inside [from, until], in date order.
+ *
+ * Each detection is stepped from its own `nextExpected` by its own median
+ * interval — the rhythm the payments actually showed, not the calendar's
+ * idea of a month. Stopped patterns project nothing: a rhythm that has
+ * fallen silent has nothing due. A `nextExpected` already in the past (the
+ * payment is late, not yet stopped) is still shown from `from`, because
+ * "overdue by three days" is exactly what a schedule is for.
+ */
+export function projectRecurringSchedule(
+  confirmed: readonly RecurringDetection[],
+  from: Date,
+  until: Date
+): ExpectedPayment[] {
+  const occurrences: ExpectedPayment[] = [];
+  const fromTime = from.getTime();
+  const untilTime = until.getTime();
+  if (untilTime <= fromTime) return occurrences;
+
+  for (const detection of confirmed) {
+    if (detection.stopped || detection.nextExpected === null) continue;
+    const step = Math.round(detection.medianIntervalDays) * DAY_MS;
+    if (step <= 0) continue;
+
+    // Walk from the pattern's own next-expected; occurrences before the
+    // window's start are late payments, folded onto its first day rather
+    // than dropped — a schedule that hides the overdue is lying by omission.
+    let time = detection.nextExpected.getTime();
+    if (time < fromTime) {
+      occurrences.push({ detection, date: new Date(fromTime), amount: detection.amount });
+      // Resume the walk at the first occurrence past the window's start, so
+      // the late payment appears once, not once per missed rhythm.
+      while (time < fromTime) time += step;
+    }
+    for (; time <= untilTime; time += step) {
+      occurrences.push({ detection, date: new Date(time), amount: detection.amount });
+    }
+  }
+
+  return occurrences.sort(
+    (a, b) => a.date.getTime() - b.date.getTime() ||
+      b.amount.minus(a.amount).toNumber()
+  );
+}


### PR DESCRIPTION
Step 3 of Design's recurring-and-forecast handover (§8): the Calendar was a backward-looking day ledger; this is its forward half.

## The projection (`utils/recurringSchedule`, pure)

Each **confirmed**, active pattern stepped from its own `nextExpected` by its own median interval — the rhythm the payments actually showed, never the calendar's idea of a month. Stopped patterns project nothing. A payment that is late but not yet stopped folds onto the window's first day exactly once, then the rhythm resumes — "overdue by three days" is exactly what a schedule is for; a phantom occurrence per missed rhythm would not be.

## The gate is the contract

Only patterns confirmed on "What I'm committed to" reach the projection (§5), the panel says so, and its empty state is the way in. An unconfirmed detection is the app's opinion, and an opinion must never sit on a calendar looking like a payment that will happen.

## On the page

- **"Due in the next 30 days"** panel above the grid — date, payee, account, magnitude, income marked "in"; capped at eight rows with the remainder **named**, never silently truncated.
- Future day cells carry a quiet neutral **"N due"** — deliberately nothing like the actual-money figures beside it: an inference must never read as a transaction (P8).

## Verified

- lint 0 · typecheck:strict clean · full unit suite via pre-commit
- 5 projection tests (stepping, stopped rule, late-payment fold, ordering); Calendar suite gains the gated empty state and an end-to-end positive case whose subject key is built by the same builder the page uses — pinning the wiring, not a copied string

🤖 Generated with [Claude Code](https://claude.com/claude-code)
