### PR TITLE
fix(mobile,dashboard): five owner catches — shrunk figures, cramped footer, wrong end, two maps, and the tick

### DIFF
--- a/src/components/EditTransactionModal.tsx
+++ b/src/components/EditTransactionModal.tsx
@@ -1606,22 +1606,28 @@ export default function EditTransactionModal({ isOpen, onClose, transaction, def
                 {ownAccountJump.label}
               </button>
             )}
-            <div className="flex justify-between gap-3 w-full">
+            {/* WRAPS on a phone (owner, 17 Aug): five buttons in a
+                non-wrapping row compressed until "Delete" and "Cancel"
+                overflowed their own boxes and "Save Changes" broke mid-word.
+                whitespace-nowrap keeps each label whole so a button wraps as
+                a UNIT onto the next line; the tighter phone padding buys the
+                common case one row. */}
+            <div className="flex flex-wrap justify-between gap-2 sm:gap-3 w-full">
               {transaction && (
                 <button
                   type="button"
                   onClick={() => setShowDeleteConfirm(true)}
-                  className="px-4 py-2 bg-red-500 text-white rounded-lg hover:bg-red-600"
+                  className="px-3 sm:px-4 py-2 whitespace-nowrap bg-red-500 text-white rounded-lg hover:bg-red-600"
                 >
                   Delete
                 </button>
               )}
-              
-              <div className="flex gap-3 ml-auto">
+
+              <div className="flex flex-wrap justify-end gap-2 sm:gap-3 ml-auto">
                 <button
                   type="button"
                   onClick={onClose}
-                  className="px-4 py-2 border border-gray-300 dark:border-gray-600 text-gray-700 dark:text-gray-300 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-700"
+                  className="px-3 sm:px-4 py-2 whitespace-nowrap border border-gray-300 dark:border-gray-600 text-gray-700 dark:text-gray-300 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-700"
                 >
                   Cancel
                 </button>
@@ -1630,7 +1636,7 @@ export default function EditTransactionModal({ isOpen, onClose, transaction, def
                     type="submit"
                     disabled={isSubmitting || splitValidationMessage !== null}
                     onClick={() => { advanceDirectionRef.current = 'previous'; }}
-                    className="px-4 py-2 bg-[#2d3a4d] text-white rounded-lg hover:bg-[#3a4a5f] disabled:opacity-50 disabled:cursor-not-allowed"
+                    className="px-3 sm:px-4 py-2 whitespace-nowrap bg-[#2d3a4d] text-white rounded-lg hover:bg-[#3a4a5f] disabled:opacity-50 disabled:cursor-not-allowed"
                     title="Save this transaction and move to the previous one in the list"
                   >
                     Previous
@@ -1639,7 +1645,7 @@ export default function EditTransactionModal({ isOpen, onClose, transaction, def
                 <button
                   type="submit"
                   disabled={isSubmitting || splitValidationMessage !== null}
-                  className="px-4 py-2 bg-[#1a2332] text-white rounded-lg hover:bg-secondary disabled:opacity-50 disabled:cursor-not-allowed"
+                  className="px-3 sm:px-4 py-2 whitespace-nowrap bg-[#1a2332] text-white rounded-lg hover:bg-secondary disabled:opacity-50 disabled:cursor-not-allowed"
                 >
                   {isSubmitting ? 'Saving…' : transaction ? 'Save Changes' : 'Add Transaction'}
                 </button>
@@ -1648,7 +1654,7 @@ export default function EditTransactionModal({ isOpen, onClose, transaction, def
                     type="submit"
                     disabled={isSubmitting || splitValidationMessage !== null}
                     onClick={() => { advanceDirectionRef.current = 'next'; }}
-                    className="px-4 py-2 bg-[#2d3a4d] text-white rounded-lg hover:bg-[#3a4a5f] disabled:opacity-50 disabled:cursor-not-allowed"
+                    className="px-3 sm:px-4 py-2 whitespace-nowrap bg-[#2d3a4d] text-white rounded-lg hover:bg-[#3a4a5f] disabled:opacity-50 disabled:cursor-not-allowed"
                     title="Save this transaction and move to the next one in the list"
                   >
                     Save &amp; Next

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -56,6 +56,8 @@ export default function Layout(): React.JSX.Element {
   const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false);
   const [settingsExpanded, setSettingsExpanded] = useState(false);
   const [accountsExpanded, setAccountsExpanded] = useState(false);
+  const [planExpanded, setPlanExpanded] = useState(false);
+  const [manageExpanded, setManageExpanded] = useState(false);
   // advancedExpanded removed — Advanced section now uses TopNavDropdown on desktop and direct links on mobile
   // investmentsExpanded removed with /enhanced-investments — Investments has no
   // sub-pages left, so it is a plain link in the drawer.
@@ -628,9 +630,17 @@ export default function Layout(): React.JSX.Element {
                       className={`text-gray-400 transition-transform duration-200 ${accountsExpanded ? 'rotate-90' : ''}`} 
                     />
                   </Link>
+                  {/* THE SAME SHAPE AS THE DESKTOP ACCOUNTS MENU (owner,
+                      17 Aug: "the drop-down headings … the same layout as the
+                      main app"). Investments moved in from a top-level link
+                      for the same reason it moved on desktop: a holding IS an
+                      account. One layout, learned once. */}
                   {accountsExpanded && (
                     <div className="mt-1 space-y-1">
                       <SidebarLink to="/find" icon={SearchIcon} label="Find Transactions" isCollapsed={false} isSubItem={true} onNavigate={toggleMobileMenu} />
+                      {showInvestments && (
+                        <SidebarLink to="/investments" icon={TrendingUpIcon} label="Investments" isCollapsed={false} isSubItem={true} onNavigate={toggleMobileMenu} />
+                      )}
                       <SidebarLink to="/reconciliation" icon={ArrowRightLeftIcon} label="Reconciliation" isCollapsed={false} isSubItem={true} onNavigate={toggleMobileMenu} />
                       <SidebarLink to="/categorisation" icon={TagIcon} label="Categorisation" isCollapsed={false} isSubItem={true} onNavigate={toggleMobileMenu} />
                       <SidebarLink to="/open-banking" icon={BankIcon} label="Bank Feeds" isCollapsed={false} isSubItem={true} onNavigate={toggleMobileMenu} />
@@ -638,24 +648,68 @@ export default function Layout(): React.JSX.Element {
                   )}
                 </div>
 
-                {/* Investments. A plain link, not a disclosure: the one child
-                    it ever had was /enhanced-investments, and a chevron that
-                    expands to nothing is a promise the menu cannot keep. */}
-                {showInvestments && (
-                  <SidebarLink
-                    to="/investments"
-                    icon={TrendingUpIcon}
-                    label="Investments"
-                    isCollapsed={false}
-                    onNavigate={toggleMobileMenu}
-                  />
-                )}
-                
-                {/* Plan (Budget, Goals, Forecasting, Calendar) is desk work
-                    and deliberately absent here — the drawer is the phone's
-                    menu, and the desktop top-nav keeps the full Plan menu. */}
+                {/* Plan — Budget and Calendar, mirroring the desktop menu.
+                    This group used to be "deliberately absent" as desk work;
+                    the owner overruled it (17 Aug), and the Calendar now
+                    carries the due-next panel, which is exactly a thing to
+                    check from a phone. */}
+                <div>
+                  <button
+                    type="button"
+                    onClick={() => setPlanExpanded(!planExpanded)}
+                    aria-expanded={planExpanded}
+                    className="w-full flex items-center gap-2 px-3 py-2.5 md:py-2 rounded-lg transition-colors min-h-[40px] md:min-h-[auto] bg-secondary text-white dark:text-gray-300 hover:bg-secondary dark:hover:bg-gray-800/50"
+                  >
+                    <TargetIcon size={18} />
+                    <span className="flex-1 text-sm text-left">Plan</span>
+                    <ChevronRightIcon
+                      size={14}
+                      className={`text-gray-400 transition-transform duration-200 ${planExpanded ? 'rotate-90' : ''}`}
+                    />
+                  </button>
+                  {planExpanded && (
+                    <div className="mt-1 space-y-1">
+                      <SidebarLink to="/budget" icon={BarChart3Icon} label="Budget" isCollapsed={false} isSubItem={true} onNavigate={toggleMobileMenu} />
+                      <SidebarLink to="/calendar" icon={CalendarIcon} label="Calendar" isCollapsed={false} isSubItem={true} onNavigate={toggleMobileMenu} />
+                    </div>
+                  )}
+                </div>
+
                 <SidebarLink to="/reports" icon={PieChartIcon} label="Reports" isCollapsed={false} onNavigate={toggleMobileMenu} />
-                {/* Settings with Sub-navigation */}
+
+                {/* Manage — data admin, exactly the desktop menu's list and
+                    order. These lived under Settings here, which taught the
+                    phone a different map from the desk (owner, 17 Aug: "on
+                    the mobile there is no 'manage' section"). */}
+                <div>
+                  <button
+                    type="button"
+                    onClick={() => setManageExpanded(!manageExpanded)}
+                    aria-expanded={manageExpanded}
+                    className="w-full flex items-center gap-2 px-3 py-2.5 md:py-2 rounded-lg transition-colors min-h-[40px] md:min-h-[auto] bg-secondary text-white dark:text-gray-300 hover:bg-secondary dark:hover:bg-gray-800/50"
+                  >
+                    <SettingsIcon size={18} />
+                    <span className="flex-1 text-sm text-left">Manage</span>
+                    <ChevronRightIcon
+                      size={14}
+                      className={`text-gray-400 transition-transform duration-200 ${manageExpanded ? 'rotate-90' : ''}`}
+                    />
+                  </button>
+                  {manageExpanded && (
+                    <div className="mt-1 space-y-1">
+                      <SidebarLink to="/settings/categories" icon={TagIcon} label="Categories" isCollapsed={false} isSubItem={true} onNavigate={toggleMobileMenu} />
+                      <SidebarLink to="/settings/payees" icon={UsersIcon} label="Payees" isCollapsed={false} isSubItem={true} onNavigate={toggleMobileMenu} />
+                      <SidebarLink to="/settings/tags" icon={HashIcon} label="Tags" isCollapsed={false} isSubItem={true} onNavigate={toggleMobileMenu} />
+                      {/* "Import Data", as the desktop menu names it — one
+                          page, one name, whichever menu found it. */}
+                      <SidebarLink to="/enhanced-import" icon={UploadIcon} label="Import Data" isCollapsed={false} isSubItem={true} onNavigate={toggleMobileMenu} />
+                      <SidebarLink to="/export-manager" icon={DownloadIcon} label="Export Data" isCollapsed={false} isSubItem={true} onNavigate={toggleMobileMenu} />
+                      <SidebarLink to="/documents" icon={FolderIcon} label="Documents" isCollapsed={false} isSubItem={true} onNavigate={toggleMobileMenu} />
+                    </div>
+                  )}
+                </div>
+
+                {/* Settings — the app itself, exactly the desktop menu's list. */}
                 <div>
                   <Link
                     to={isDemoModeRoutingEnabled ? '/settings?demo=true' : '/settings'}
@@ -673,19 +727,8 @@ export default function Layout(): React.JSX.Element {
                     <div className="mt-1 space-y-1">
                       <SidebarLink to="/settings/app" icon={Settings2Icon} label="App Settings" isCollapsed={false} isSubItem={true} onNavigate={toggleMobileMenu} />
                       <SidebarLink to="/settings/data" icon={DatabaseIcon} label="Data Management" isCollapsed={false} isSubItem={true} onNavigate={toggleMobileMenu} />
-                      {/* Same order as the desktop Manage menu — the drawer and
-                          the top nav must not teach two different shapes. */}
-                      <SidebarLink to="/settings/categories" icon={TagIcon} label="Categories" isCollapsed={false} isSubItem={true} onNavigate={toggleMobileMenu} />
-                      <SidebarLink to="/settings/payees" icon={UsersIcon} label="Payees" isCollapsed={false} isSubItem={true} onNavigate={toggleMobileMenu} />
-                      <SidebarLink to="/settings/tags" icon={HashIcon} label="Tags" isCollapsed={false} isSubItem={true} onNavigate={toggleMobileMenu} />
                       <SidebarLink to="/settings/security" icon={ShieldIcon} label="Security" isCollapsed={false} isSubItem={true} onNavigate={toggleMobileMenu} />
-                      <SidebarLink to="/enhanced-import" icon={UploadIcon} label="Enhanced Import" isCollapsed={false} isSubItem={true} onNavigate={toggleMobileMenu} />
-                      {/* Same destination as the top-level link above, so it
-                          carries the same name — one page cannot be two things
-                          depending on which menu you found it in. */}
-                      <SidebarLink to="/export-manager" icon={DownloadIcon} label="Export Data" isCollapsed={false} isSubItem={true} onNavigate={toggleMobileMenu} />
-                      <SidebarLink to="/documents" icon={FolderIcon} label="Documents" isCollapsed={false} isSubItem={true} onNavigate={toggleMobileMenu} />
-                      <SidebarLink to="/open-banking" icon={BankIcon} label="Open Banking" isCollapsed={false} isSubItem={true} onNavigate={toggleMobileMenu} />
+                      <SidebarLink to="/subscription" icon={CreditCardIcon} label="Subscription" isCollapsed={false} isSubItem={true} onNavigate={toggleMobileMenu} />
                     </div>
                   )}
                 </div>

--- a/src/components/SyncStatusIndicator.tsx
+++ b/src/components/SyncStatusIndicator.tsx
@@ -86,6 +86,19 @@ export default function SyncStatusIndicator({
   };
 
   if (variant === 'compact') {
+    /**
+     * QUIET WHEN SETTLED (owner, 17 Aug: "what is this 'tick' … when it
+     * looks like it does absolutely nothing"). All-synced used to render a
+     * permanent green tick — a signal spent on a state that needs none, on
+     * a button whose press had no visible consequence, which is how a
+     * working indicator reads as a broken control. The compact indicator
+     * now appears only in the states that NEED attention — offline,
+     * syncing, pending changes, error — which are also exactly the states
+     * where pressing it (a manual sync) has real work to do.
+     */
+    if (isOnline && status === 'synced' && !isManualSyncing) {
+      return <></>;
+    }
     return (
       <button
         onClick={handleManualSync}

--- a/src/components/dashboard/ImprovedDashboard.tsx
+++ b/src/components/dashboard/ImprovedDashboard.tsx
@@ -582,10 +582,16 @@ export function ImprovedDashboard() {
               card's far edge, six hundred pixels from the number it modifies,
               with half a card of nothing connecting them. After the amount,
               same baseline. */}
+          {/* `flex-col` is LOAD-BEARING, not layout tidiness: index.css sets
+              `button { display: inline-flex }` globally, and a grid child
+              blockifies that to flex — ROW direction — so without it the
+              label and the figure sit side by side and the whole card reads
+              shrunken (the owner caught it within a day; the fifth casualty
+              of that global rule). */}
           <button
             type="button"
             onClick={() => setBreakdownType('income')}
-            className="p-4 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-700/50 transition-colors cursor-pointer text-left"
+            className="flex flex-col items-start p-4 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-700/50 transition-colors cursor-pointer text-left"
           >
             <p className="text-sm text-gray-600 dark:text-gray-400">Income</p>
             {/* NEUTRAL AT ZERO (Design §4), on the reasoning that settled
@@ -610,7 +616,7 @@ export function ImprovedDashboard() {
           <button
             type="button"
             onClick={() => setBreakdownType('expense')}
-            className="p-4 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-700/50 transition-colors cursor-pointer text-left"
+            className="flex flex-col items-start p-4 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-700/50 transition-colors cursor-pointer text-left"
           >
             <p className="text-sm text-gray-600 dark:text-gray-400">Expenses</p>
             <p className={`flex items-center gap-2 text-xl font-bold ${

--- a/src/pages/AccountTransactions.tsx
+++ b/src/pages/AccountTransactions.tsx
@@ -1200,6 +1200,25 @@ export default function AccountTransactions() {
     return `Sorted by ${SORT_FIELD_LABELS[sortField]}, so the Balance column doesn't run down the page. Each row still shows what ${account?.name ?? 'the account'} was worth immediately after that transaction — sort by Date to read the column as a running balance.`;
   }, [sortField, account?.name]);
 
+  /**
+   * NEWEST FIRST on a phone (owner, 17 Aug: opening on a row from years ago
+   * read as starting at the wrong end). The desktop table keeps Money's
+   * chronology and opens AT the foot; a page-scrolled infinite list cannot
+   * start at its own foot without fighting its loading direction, and
+   * newest-at-top is what every phone banking app has taught a thumb to
+   * expect. Only the DEFAULT chronology is reversed — a sort the user chose
+   * is shown exactly as they chose it. Each row carries its own precomputed
+   * running balance, so the order is presentation, not arithmetic. Memoised:
+   * an 11,000-row copy per keystroke is the kind of quiet quadratic the
+   * dashboard perf pass existed to remove.
+   */
+  const phoneListRows = useMemo(
+    () => (sortField === 'date' && sortDirection === 'asc'
+      ? [...transactionsWithBalance].reverse()
+      : transactionsWithBalance),
+    [transactionsWithBalance, sortField, sortDirection]
+  );
+
   // ── Opening at the foot of the register ────────────────────────────────────
   // Money's register is ordered oldest-first with the NEWEST transaction on the
   // last line, and it opens showing that line. The order is untouched (see
@@ -3466,7 +3485,7 @@ export default function AccountTransactions() {
         className="lg:hidden bg-white dark:bg-gray-800 rounded-2xl shadow-lg border border-gray-100 dark:border-gray-700 overflow-hidden"
       >
         <InfiniteScrollTransactionList
-          transactions={transactionsWithBalance}
+          transactions={phoneListRows}
           accounts={[]}
           categories={categories}
           // A phone is still looking at the REGISTER, with the same To Review


### PR DESCRIPTION
Five items from the owner's 17 August sweep, each with its cause.

1. **The shrunken Income/Expenses figures** — #337's arrow fix removed the wrapper div inside each button, and `index.css` sets `button{display:inline-flex}` globally; a grid child blockifies that to row-flex, so the label and figure sat side by side and the card read collapsed. `flex-col` restores the stack — the **fifth casualty** of that global rule, named in a comment where the next victim will look.
2. **The edit modal's footer** held five buttons in a non-wrapping row: on a phone "Delete" and "Cancel" overflowed their own boxes and "Save Changes" broke mid-word. It wraps now, each label kept whole (`whitespace-nowrap` — a button wraps as a unit), with tighter phone padding.
3. **The phone register opened on the OLDEST row** — the desktop table (which owns the foot-scroll) is `hidden lg:block`; the phone's infinite list rendered chronological rows top-down. A page-scrolled infinite list can't start at its own foot without fighting its loading direction, so the phone now shows **newest first** (the idiom every banking app teaches) while desktop keeps Money's foot-anchored chronology. Only the default order reverses; a chosen sort shows as chosen. Memoised — an 11,000-row copy per keystroke is the quiet quadratic the perf pass exists to prevent.
4. **The drawer taught a different map from the desktop nav.** It now mirrors the desktop menus exactly: Accounts (Find, Investments, Reconciliation, Categorisation, Bank Feeds), **Plan** (Budget, Calendar — the "desk work" exclusion overruled by the owner, and the Calendar now carries the due-next panel), Reports, **Manage** (Categories, Payees, Tags, Import Data, Export Data, Documents), Settings (App Settings, Data Management, Security, Subscription). One layout, learned once.
5. **The header tick** — the compact sync indicator rendered a permanent green check for "everything's fine": a signal spent on a settled state, on a button whose press had no visible effect. It now renders **nothing** when online and synced, and appears only in the states that need attention — which are exactly the states where its manual-sync press has real work to do.

## Verified

- lint 0 · typecheck:strict clean · affected suites 66/66 + register suites 19/19 · full gate via pre-commit and pre-push

🤖 Generated with [Claude Code](https://claude.com/claude-code)
