### PR TITLE
fix(reports): the Account Distribution legend sums to net worth — liabilities included

### DIFF
--- a/src/components/dashboard/ImprovedDashboard.tsx
+++ b/src/components/dashboard/ImprovedDashboard.tsx
@@ -702,14 +702,21 @@ export function ImprovedDashboard() {
                   subtitle={
                     <>
                       <span className="text-xs text-gray-500 dark:text-gray-400 truncate">
-                        {/* A closed ring claims the whole (Design, 17 Aug §2.1),
-                            so when accounts were folded the words say so —
-                            "top 5" over a ring quietly missing 45% of the money
-                            was a subtitle contradicted by its own shape. */}
+                        {/* THE LEGEND SUMS TO NET WORTH (owner, 17 Aug). The
+                            in-credit fold's legend totalled far more than net
+                            worth — gross investments and loans-out counted,
+                            liabilities ignored — "otherwise it looks like a
+                            useless report". The remainder now nets EVERY other
+                            account, and the words say what the shape claims.
+                            When that net remainder is below zero the ring
+                            cannot draw it (a pie has no negative wedge), so
+                            the subtitle says where the rest went instead. */}
                         {pieData.length === 0
                           ? 'Your largest accounts by balance'
                           : distribution.foldedCount > 0
-                            ? `Your top ${pieData.length - 1} accounts, and the other ${distribution.foldedCount}`
+                            ? (pieData[pieData.length - 1].value >= 0
+                              ? `Your top ${pieData.length - 1} accounts and the other ${distribution.foldedCount}, net — together, your net worth`
+                              : `Your top ${pieData.length - 1} accounts — the other ${distribution.foldedCount} net below zero`)
                             : `Your top ${pieData.length} account${pieData.length === 1 ? '' : 's'} by balance`}
                       </span>
                       <span className="text-xs text-gray-400 dark:text-gray-500 ml-auto whitespace-nowrap">
@@ -719,7 +726,7 @@ export function ImprovedDashboard() {
                   }
                   onOpen={() => openReport('account-distribution')}
                 >
-                  {pieData.length === 0 ? (
+                  {distribution.wedges.length === 0 ? (
                     /* THE SAME BOX THE CHART WOULD FILL, which is what makes
                        this card the same height as Expense Categories beside
                        it. Shipped first as a bare `py-8`, and the owner saw it
@@ -746,7 +753,11 @@ export function ImprovedDashboard() {
                     <div className={`${WIDGET_CHART_HEIGHT} sm:aspect-square sm:flex-shrink-0`}>
                       <ResponsiveContainer width="100%" height="100%">
                         <PieChart
-                          data={pieData}
+                          // The ring draws `wedges` and the legend `slices` —
+                          // one derivation apart (see accountDistribution): a
+                          // below-zero remainder stays in the legend, in its
+                          // accounting parentheses, and out of the ring.
+                          data={distribution.wedges}
                           innerRadius={true}
                           colors={chartRamp}
                           // Straight into that account's register. It used to
@@ -786,11 +797,21 @@ export function ImprovedDashboard() {
                               aria-hidden="true"
                             />
                             <span className="flex-1 min-w-0 truncate text-sm text-gray-700 dark:text-gray-300">{d.name}</span>
-                            <span className="text-sm font-medium tabular-nums text-gray-900 dark:text-white whitespace-nowrap">
+                            {/* A negative remainder wears the accounting
+                                parentheses and the red every negative figure
+                                wears — the legend states the netting the ring
+                                cannot draw. */}
+                            <span className={`text-sm font-medium tabular-nums whitespace-nowrap ${
+                              d.value < 0 ? 'text-red-600 dark:text-red-400' : 'text-gray-900 dark:text-white'
+                            }`}>
                               {formatCurrencyWithSymbol(d.value, displayCurrency)}
                             </span>
                             <span className="w-12 text-right text-xs tabular-nums text-gray-400 dark:text-gray-500">
-                              {d.share ? `${formatDecimal(d.share, 1)}%` : ''}
+                              {d.share
+                                ? d.share.lessThan(0)
+                                  ? `(${formatDecimal(d.share.abs(), 1)}%)`
+                                  : `${formatDecimal(d.share, 1)}%`
+                                : ''}
                             </span>
                           </button>
                         </li>

--- a/src/pages/reports/AccountDistributionReport.tsx
+++ b/src/pages/reports/AccountDistributionReport.tsx
@@ -61,8 +61,14 @@ export default function AccountDistributionReport(): React.JSX.Element {
   const money = (value: number): string =>
     formatCurrency(value, displayCurrency);
 
+  // A negative contribution wears the accounting parentheses, exactly as the
+  // figure it derives from does — "(0.1%)", never a bare minus.
   const shareOf = (entry: AccountDistributionEntry): string =>
-    entry.share ? `${formatDecimal(entry.share, 1)}%` : '—';
+    entry.share
+      ? entry.share.lessThan(0)
+        ? `(${formatDecimal(entry.share.abs(), 1)}%)`
+        : `${formatDecimal(entry.share, 1)}%`
+      : '—';
 
   const headCell = 'px-4 py-2 text-dense font-semibold uppercase tracking-wider text-gray-500 dark:text-gray-400';
 
@@ -70,10 +76,14 @@ export default function AccountDistributionReport(): React.JSX.Element {
     <div className="max-w-[1400px] mx-auto space-y-6">
       <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
         <div className="bg-white dark:bg-gray-800 rounded-lg p-6 border border-line dark:border-gray-700">
-          <p className="text-label uppercase tracking-wider font-medium text-gray-500 dark:text-gray-400">Held in credit</p>
-          <p className="text-page font-bold mt-1">{money(distribution.inCreditTotal.toNumber())}</p>
+          {/* NET WORTH, not "held in credit" (owner, 17 Aug): the ring now
+              reconciles to net worth, so the figure everything is a share OF
+              must be the one the Dashboard's headline shows — two totals for
+              one page is the disagreement this report exists to prevent. */}
+          <p className="text-label uppercase tracking-wider font-medium text-gray-500 dark:text-gray-400">Net worth</p>
+          <p className="text-page font-bold mt-1">{money(distribution.netWorth.toNumber())}</p>
           {/* What every share below is a share OF, said once. */}
-          <p className="text-dense text-gray-500 dark:text-gray-400 mt-1">Current balances — every share below is of this total</p>
+          <p className="text-dense text-gray-500 dark:text-gray-400 mt-1">Current balances — every share below is a contribution to this total</p>
         </div>
         <div className="bg-white dark:bg-gray-800 rounded-lg p-6 border border-line dark:border-gray-700">
           <p className="text-dense text-gray-500 uppercase tracking-wider font-medium">Accounts</p>
@@ -84,10 +94,10 @@ export default function AccountDistributionReport(): React.JSX.Element {
         <div className="bg-white dark:bg-gray-800 rounded-lg p-6 border border-line dark:border-gray-700">
           <p className="text-dense text-gray-500 uppercase tracking-wider font-medium">Largest holding</p>
           <p className="text-page font-bold mt-1 text-gray-900 dark:text-white truncate">
-            {distribution.slices.length > 0 ? shareOf(distribution.slices[0]) : '—'}
+            {distribution.wedges.length > 0 ? shareOf(distribution.wedges[0]) : '—'}
           </p>
           <p className="text-dense text-gray-500 dark:text-gray-400 mt-1 truncate">
-            {distribution.slices.length > 0 ? distribution.slices[0].name : 'Nothing in credit'}
+            {distribution.wedges.length > 0 ? distribution.wedges[0].name : 'Nothing in credit'}
           </p>
         </div>
       </div>
@@ -101,24 +111,27 @@ export default function AccountDistributionReport(): React.JSX.Element {
         </div>
         {/* The count comes from the slices themselves, never the cap: with
             three accounts in credit this must not claim five. And when the
-            ring folds a remainder (Design, 17 Aug §2.1 — a closed ring is a
-            claim about the whole), the sentence says what was folded. */}
+            ring folds a remainder, the sentence says what was gathered — and
+            that the whole is NET WORTH (owner, 17 Aug: the legend's figures
+            must come back to that number, "otherwise it looks like a useless
+            report"). */}
         <p className="text-body text-gray-500 dark:text-gray-400 mb-4">
-          {distribution.slices.length === 1
-            ? 'The one account in credit'
-            : distribution.foldedCount > 0
-              ? `The ${distribution.slices.length - 1} largest accounts in credit, with the other ${distribution.foldedCount} gathered into one slice`
-              : `The ${distribution.slices.length} largest accounts in credit`}
+          {distribution.foldedCount > 0
+            ? `The ${distribution.slices.length - 1} largest accounts in credit, with every other account netted into one slice — together, your net worth`
+            : 'Every account, drawn to its balance — together, your net worth'}
           {' '}— the same slices the Dashboard shows. Every account is listed below.
           Click a slice for its transactions.
         </p>
-        {distribution.slices.length === 0 ? (
+        {distribution.wedges.length === 0 ? (
           <p className="text-center py-16 text-gray-400">No account is in credit</p>
         ) : (
           <div className="h-80">
             <ResponsiveContainer width="100%" height="100%">
               <PieChart
-                data={distribution.slices}
+                // The ring draws `wedges`, the table lists everything — one
+                // derivation apart (see accountDistribution): a below-zero
+                // remainder is parenthesised in the legend, never a wedge.
+                data={distribution.wedges}
                 innerRadius={true}
                 colors={ramp}
                 onClick={(entry: AccountDistributionEntry) => {
@@ -198,11 +211,16 @@ export default function AccountDistributionReport(): React.JSX.Element {
               </tbody>
               <tfoot className="border-t-2 border-gray-200 dark:border-gray-600">
                 <tr>
+                  {/* The Balance column's own sum IS net worth — the footer
+                      states what the rows already add to, so the table and
+                      the ring above reconcile by inspection. */}
                   <th scope="row" className="px-4 py-3 text-left text-body font-semibold text-gray-900 dark:text-white">
-                    Held in credit
+                    Net worth
                   </th>
-                  <td className="px-4 py-3 text-body text-right font-bold tabular-nums text-gray-900 dark:text-white">
-                    {money(distribution.inCreditTotal.toNumber())}
+                  <td className={`px-4 py-3 text-body text-right font-bold tabular-nums ${
+                    distribution.netWorth.lessThan(0) ? 'text-red-600 dark:text-red-400' : 'text-gray-900 dark:text-white'
+                  }`}>
+                    {money(distribution.netWorth.toNumber())}
                   </td>
                   <td className="px-4 py-3" />
                 </tr>
@@ -211,13 +229,14 @@ export default function AccountDistributionReport(): React.JSX.Element {
           </div>
         )}
 
-        {/* An overdrawn account has no share of a positive total, and saying so
-            is better than printing a negative percentage nobody can read. */}
-        {distribution.entries.some(entry => entry.value <= 0) && (
+        {/* The shares are CONTRIBUTIONS to net worth now, so a liability's is
+            honestly negative — in the same parentheses every negative figure
+            wears. Zero balances still show none: nothing contributes nothing. */}
+        {distribution.entries.some(entry => entry.value < 0) && (
           <p className="px-6 pb-6 pt-3 text-dense text-gray-500 dark:text-gray-400">
-            Accounts holding nothing, or overdrawn, are listed with no share: a share of the money
-            held is only meaningful for money held. The total above is what is in credit, so it is
-            not your net worth — see the Net worth report for what you own less what you owe.
+            A parenthesised share is a liability&rsquo;s contribution to your net worth —
+            what it takes away. The shares sum to 100% across every account, which is
+            what makes the total above the same net worth the Dashboard shows.
           </p>
         )}
       </div>

--- a/src/utils/accountDistribution.test.ts
+++ b/src/utils/accountDistribution.test.ts
@@ -37,17 +37,19 @@ describe('buildAccountDistribution', () => {
     ]);
   });
 
-  it('gives a share only to accounts with something to share', () => {
+  it('shares are contributions to NET WORTH — negative for a liability, none for a zero', () => {
     const accounts = accountsOf('In credit', 'Empty', 'Overdrawn');
     const balances = new Map([['acc-0', 500], ['acc-1', 0], ['acc-2', -250]]);
 
-    const { entries, inCreditTotal } = buildAccountDistribution(accounts, id => balances.get(id) ?? 0);
+    const { entries, netWorth, inCreditTotal } = buildAccountDistribution(accounts, id => balances.get(id) ?? 0);
 
-    // The total is what is HELD, so the overdraft does not reduce it.
+    expect(netWorth.toNumber()).toBe(250);
     expect(inCreditTotal.toNumber()).toBe(500);
-    expect(entries[0].share?.toNumber()).toBe(100);
+    // 500 of a 250 net worth is honestly 200% — an account CAN hold more than
+    // you are worth when a liability sits against it.
+    expect(entries[0].share?.toNumber()).toBe(200);
     expect(entries[1].share).toBeNull();
-    expect(entries[2].share).toBeNull();
+    expect(entries[2].share?.toNumber()).toBe(-100);
   });
 
   it('splits the shares in Decimal, so thirds still add to a hundred', () => {
@@ -60,11 +62,23 @@ describe('buildAccountDistribution', () => {
     expect(total).toBeCloseTo(100, 10);
   });
 
-  /* Until 17 August this expected slices A–E with F silently dropped — the
-     ring closed at six-sevenths of the money and read as the whole (Design
-     §2.1: "a closed ring is a stronger claim than a subtitle"). The sixth
-     account is now folded, so the ring always sums to what is held. */
-  it('folds everything past the named slices into one counted remainder', () => {
+  it('with liabilities in the ledger, the shares still sum to a hundred — of net worth', () => {
+    const accounts = accountsOf('Asset', 'Loan');
+    const balances = new Map([['acc-0', 300], ['acc-1', -100]]);
+
+    const { entries } = buildAccountDistribution(accounts, id => balances.get(id) ?? 0);
+
+    // 150% − 50% = 100%: the decomposition of net worth, signs and all.
+    const total = entries.reduce((sum, e) => sum + (e.share?.toNumber() ?? 0), 0);
+    expect(total).toBeCloseTo(100, 10);
+  });
+
+  /* Until 18 August the remainder gathered only the accounts IN CREDIT, and
+     on a real ledger the legend totalled far MORE than net worth — gross
+     values counted, every liability ignored. The owner read it exactly:
+     "otherwise it looks like a useless report". The remainder now nets EVERY
+     other account, and the legend's five figures sum to net worth. */
+  it('the legend sums to NET WORTH — the remainder nets every other account, liabilities included', () => {
     const accounts = accountsOf('A', 'B', 'C', 'D', 'E', 'F', 'Overdrawn');
     const balances = new Map([
       ['acc-0', 700], ['acc-1', 600], ['acc-2', 500],
@@ -72,47 +86,68 @@ describe('buildAccountDistribution', () => {
       ['acc-6', -1000],
     ]);
 
-    const { slices, entries, foldedCount } = buildAccountDistribution(accounts, id => balances.get(id) ?? 0);
+    const { slices, wedges, entries, netWorth, foldedCount } =
+      buildAccountDistribution(accounts, id => balances.get(id) ?? 0);
 
-    expect(slices).toHaveLength(ACCOUNT_DISTRIBUTION_SLICES);
-    expect(slices.map(s => s.name)).toEqual(['A', 'B', 'C', 'D', '2 smaller accounts']);
-    expect(foldedCount).toBe(2);
-    // The remainder is E + F, and the overdraft plays no part in it.
+    expect(netWorth.toNumber()).toBe(1700);
+    expect(slices.map(s => s.name)).toEqual(['A', 'B', 'C', 'D', '3 other accounts']);
+    expect(foldedCount).toBe(3);
+    // 300 + 200 − 1000: the remainder is a NET figure, and here it is owed.
     const remainder = slices[slices.length - 1];
     expect(remainder.id).toBe(ACCOUNT_DISTRIBUTION_REMAINDER_ID);
-    expect(remainder.value).toBe(500);
-    expect(slices.every(s => s.value > 0)).toBe(true);
+    expect(remainder.value).toBe(-500);
+    // The legend reconciles to the penny…
+    expect(slices.reduce((sum, s) => sum + s.value, 0)).toBe(1700);
+    // …and the ring draws only what a pie can: the negative remainder stays
+    // in the legend, so the wedges are the four named slices, colours intact.
+    expect(wedges.map(s => s.name)).toEqual(['A', 'B', 'C', 'D']);
     // The table still lists every real account — never the pseudo-slice.
     expect(entries).toHaveLength(7);
     expect(entries.some(e => e.id === ACCOUNT_DISTRIBUTION_REMAINDER_ID)).toBe(false);
   });
 
-  it('the ring sums to the whole: named slices plus remainder equal the in-credit total', () => {
-    const accounts = accountsOf('A', 'B', 'C', 'D', 'E', 'F', 'G', 'H');
+  it('legend figures and shares both decompose net worth exactly', () => {
+    const accounts = accountsOf('A', 'B', 'C', 'D', 'E', 'F', 'G', 'Loan');
     // Thirds and the like, so a float fold would drift where Decimal cannot.
     const balances = new Map([
       ['acc-0', 1000.10], ['acc-1', 900.01], ['acc-2', 800.02], ['acc-3', 700.03],
-      ['acc-4', 33.33], ['acc-5', 33.33], ['acc-6', 33.34], ['acc-7', 0.01],
+      ['acc-4', 33.33], ['acc-5', 33.33], ['acc-6', 33.34], ['acc-7', -100.16],
     ]);
 
-    const { slices, inCreditTotal } = buildAccountDistribution(accounts, id => balances.get(id) ?? 0);
+    const { slices, netWorth } = buildAccountDistribution(accounts, id => balances.get(id) ?? 0);
 
-    const drawn = slices.reduce((sum, s) => sum + s.value, 0);
-    expect(drawn).toBeCloseTo(inCreditTotal.toNumber(), 10);
+    expect(slices).toHaveLength(ACCOUNT_DISTRIBUTION_SLICES);
+    const legendSum = slices.reduce((sum, s) => sum + s.value, 0);
+    expect(legendSum).toBeCloseTo(netWorth.toNumber(), 10);
     const shares = slices.reduce((sum, s) => sum + (s.share?.toNumber() ?? 0), 0);
     expect(shares).toBeCloseTo(100, 10);
   });
 
-  it('draws all five by name when exactly five are in credit — a fold of one would hide nothing', () => {
-    const accounts = accountsOf('A', 'B', 'C', 'D', 'E');
+  it('exactly one account left over is shown by NAME — a fold of one hides nothing and loses the name', () => {
+    const accounts = accountsOf('A', 'B', 'C', 'D', 'Mortgage');
     const balances = new Map([
-      ['acc-0', 500], ['acc-1', 400], ['acc-2', 300], ['acc-3', 200], ['acc-4', 100],
+      ['acc-0', 500], ['acc-1', 400], ['acc-2', 300], ['acc-3', 200], ['acc-4', -150],
     ]);
 
-    const { slices, foldedCount } = buildAccountDistribution(accounts, id => balances.get(id) ?? 0);
+    const { slices, wedges, foldedCount } = buildAccountDistribution(accounts, id => balances.get(id) ?? 0);
 
-    expect(slices.map(s => s.name)).toEqual(['A', 'B', 'C', 'D', 'E']);
+    expect(slices.map(s => s.name)).toEqual(['A', 'B', 'C', 'D', 'Mortgage']);
     expect(foldedCount).toBe(0);
+    // The liability keeps its name in the legend and stays out of the ring.
+    expect(wedges.map(s => s.name)).toEqual(['A', 'B', 'C', 'D']);
+    expect(slices.reduce((sum, s) => sum + s.value, 0)).toBe(1250);
+  });
+
+  it('a net worth at or below zero yields no shares — a percentage of a debt reads as nothing', () => {
+    const accounts = accountsOf('Cash', 'Big Loan');
+    const balances = new Map([['acc-0', 100], ['acc-1', -400]]);
+
+    const { entries, slices, netWorth } = buildAccountDistribution(accounts, id => balances.get(id) ?? 0);
+
+    expect(netWorth.toNumber()).toBe(-300);
+    expect(entries.every(e => e.share === null)).toBe(true);
+    // The legend still reconciles: what you hold, less what you owe.
+    expect(slices.reduce((sum, s) => sum + s.value, 0)).toBe(-300);
   });
 
   it('breaks a tie by name, so equal balances do not swap places between renders', () => {
@@ -124,12 +159,15 @@ describe('buildAccountDistribution', () => {
     expect(entries.map(e => e.name)).toEqual(['Aardvark', 'Zebra']);
   });
 
-  it('has nothing to draw when nothing is in credit', () => {
+  it('with nothing in credit the ring is empty but the legend still tells the truth', () => {
     const accounts = accountsOf('Overdrawn');
 
-    const { slices, inCreditTotal, entries } = buildAccountDistribution(accounts, () => -40);
+    const { slices, wedges, inCreditTotal, entries } = buildAccountDistribution(accounts, () => -40);
 
-    expect(slices).toEqual([]);
+    // No wedge to draw — but the account is not hidden: the legend names it,
+    // parenthesised, because an all-debt ledger is a fact, not an absence.
+    expect(wedges).toEqual([]);
+    expect(slices.map(s => s.name)).toEqual(['Overdrawn']);
     expect(inCreditTotal.toNumber()).toBe(0);
     expect(entries[0].share).toBeNull();
   });

--- a/src/utils/accountDistribution.ts
+++ b/src/utils/accountDistribution.ts
@@ -26,10 +26,11 @@ export interface AccountDistributionEntry {
   /** Current balance: openingBalance + Σ transactions (see computeAccountBalances). */
   value: number;
   /**
-   * Percentage of everything held in credit, or null when the account holds
-   * nothing to take a share of. A share of a positive whole is only meaningful
-   * for a positive part: an overdrawn account is not "-4% of the money", and a
-   * zero balance is not 0% of anything it is part of.
+   * This entry's contribution to NET WORTH, as a percentage — negative for a
+   * liability, because owing money is a negative contribution and pretending
+   * otherwise is how the ring stopped adding up. null when net worth is not
+   * positive: a share of nothing (or of a debt) is not a percentage anyone
+   * can read.
    */
   share: DecimalInstance | null;
 }
@@ -38,18 +39,30 @@ export interface AccountDistribution {
   /** Every account, ranked by balance, largest first — nothing dropped. */
   entries: AccountDistributionEntry[];
   /**
-   * The slices the donut draws: the largest accounts in credit, and — when
-   * there are more in credit than the ring can name — ONE slice holding
-   * everything else, so the ring always sums to the whole. A pie cannot show
-   * a negative, so overdrawn accounts appear in the table, never the ring.
+   * The LEGEND: the largest accounts in credit, and — when more than one
+   * other account exists — ONE remainder netting everything else, negatives
+   * included, so the legend's figures SUM TO NET WORTH. Exactly one account
+   * left over is shown by its own name instead: a fold of one hides nothing
+   * and loses the name. The remainder is always LAST.
    */
   slices: AccountDistributionEntry[];
-  /** What every share is a share OF: the total held in credit. */
+  /**
+   * The RING: the slices a pie can draw — the positive ones, in the same
+   * order. A pie has no negative wedge, so a below-zero remainder (or a
+   * singly-named liability) lives in the legend alone, parenthesised. One
+   * derivation here, not a filter at each call site, so the ring and the
+   * legend can never disagree about what was dropped — and because anything
+   * dropped is LAST, every drawn slice keeps the colour index its legend row
+   * has.
+   */
+  wedges: AccountDistributionEntry[];
+  /** What every share is a share OF now: everything owned less everything owed. */
+  netWorth: DecimalInstance;
+  /** Kept for surfaces that speak about money held: the sum of positive balances. */
   inCreditTotal: DecimalInstance;
   /**
-   * How many in-credit accounts the ring folded into its remainder slice —
-   * zero when every one is drawn by name. Exposed so the copy above each ring
-   * can say what was folded without parsing the slice's own label.
+   * How many accounts the remainder gathers — every account not named, of
+   * either sign. Zero when every account is drawn by name.
    */
   foldedCount: number;
 }
@@ -88,55 +101,82 @@ export function buildAccountDistribution(
     // a stable order between renders instead of swapping places.
     .sort((a, b) => (b.value - a.value) || a.name.localeCompare(b.name));
 
+  const netWorth = balances.reduce(
+    (sum, entry) => sum.plus(toDecimal(entry.value)),
+    toDecimal(0)
+  );
   const inCreditTotal = balances.reduce(
     (sum, entry) => (entry.value > 0 ? sum.plus(toDecimal(entry.value)) : sum),
     toDecimal(0)
   );
 
   // Decimal, not float: a share is derived from money, and the percentages are
-  // read against each other.
+  // read against each other. The denominator is NET WORTH — see the ruling on
+  // the slices below — and a liability's contribution is honestly negative.
+  const shareOf = (value: number): DecimalInstance | null =>
+    netWorth.greaterThan(0) && value !== 0
+      ? toDecimal(value).dividedBy(netWorth).times(100)
+      : null;
+
   const entries: AccountDistributionEntry[] = balances.map(entry => ({
     ...entry,
-    share: entry.value > 0 && inCreditTotal.greaterThan(0)
-      ? toDecimal(entry.value).dividedBy(inCreditTotal).times(100)
-      : null,
+    share: shareOf(entry.value),
   }));
 
   /**
-   * A CLOSED RING IS A CLAIM ABOUT THE WHOLE (Claude Design, 17 Aug §2.1).
-   * Drawn from the top five alone it showed ~55% of the money as if it were
-   * 100%, so a reader concluded their largest account was a sixth of their
-   * net worth when it was a thirty-fifth. Everything past the named slices is
-   * folded into ONE remainder slice — same arithmetic as
-   * capSeriesWithRemainder, done here so the card and the report cannot fold
-   * differently. The remainder is NAMED WITH ITS COUNT rather than "Other":
-   * "Other" is a real category in some ledgers, and a visible count tells the
-   * reader whether the fold hid something worth opening the full report for.
+   * THE LEGEND SUMS TO NET WORTH (owner, 17 Aug). The first fold gathered
+   * only the accounts IN CREDIT, and on a real ledger that legend totalled
+   * far MORE than net worth — gross investment values and loans-out counted,
+   * every liability ignored — which the owner read exactly right: "otherwise
+   * it looks like a useless report". So the remainder now gathers EVERY
+   * account not named, negatives included, and the whole is net worth:
    *
-   * The value comes from inCreditTotal minus the named slices — a Decimal
-   * subtraction, not a float sum of ninety balances — so ring and total agree
-   * to the penny by construction.
+   *     top accounts in credit  +  everything else, net  =  net worth
+   *
+   * The remainder is a Decimal subtraction from net worth, not a float sum
+   * of ninety balances, so the reconciliation holds to the penny by
+   * construction. It is NAMED WITH ITS COUNT ("51 other accounts") rather
+   * than "Other" — "Other" is a real category in some ledgers, and a count
+   * tells the reader how much the fold gathered.
+   *
+   * A pie cannot draw a negative wedge, so when the net remainder is below
+   * zero the LEGEND still shows it — in the accounting parentheses — and the
+   * ring draws the named slices alone. The remainder being LAST is what
+   * makes that safe: dropping the last element leaves every named slice's
+   * colour index untouched, so a filtered ring and a full legend cannot
+   * disagree about which colour is whose.
    */
-  const inCredit = entries.filter(entry => entry.value > 0);
+  const named = entries
+    .filter(entry => entry.value > 0)
+    .slice(0, ACCOUNT_DISTRIBUTION_SLICES - 1);
+  const namedIds = new Set(named.map(entry => entry.id));
+  const rest = entries.filter(entry => !namedIds.has(entry.id));
+
   let slices: AccountDistributionEntry[];
   let foldedCount = 0;
-  if (inCredit.length <= ACCOUNT_DISTRIBUTION_SLICES) {
-    slices = inCredit;
+  if (rest.length === 0) {
+    slices = named;
+  } else if (rest.length === 1) {
+    // A fold of one hides nothing and loses the name — the last account is
+    // its own row, sign and all. The reconciliation still holds: the five
+    // rows are simply every account.
+    slices = [...named, rest[0]];
   } else {
-    const named = inCredit.slice(0, ACCOUNT_DISTRIBUTION_SLICES - 1);
-    foldedCount = inCredit.length - named.length;
+    foldedCount = rest.length;
     const namedTotal = named.reduce((sum, entry) => sum.plus(toDecimal(entry.value)), toDecimal(0));
-    const remainder = inCreditTotal.minus(namedTotal);
+    const remainder = netWorth.minus(namedTotal);
     slices = [
       ...named,
       {
         id: ACCOUNT_DISTRIBUTION_REMAINDER_ID,
-        name: `${foldedCount} smaller account${foldedCount === 1 ? '' : 's'}`,
+        name: `${foldedCount} other accounts`,
         value: remainder.toNumber(),
-        share: inCreditTotal.greaterThan(0) ? remainder.dividedBy(inCreditTotal).times(100) : null,
+        share: shareOf(remainder.toNumber()),
       },
     ];
   }
 
-  return { entries, slices, inCreditTotal, foldedCount };
+  const wedges = slices.filter(entry => entry.value > 0);
+
+  return { entries, slices, wedges, netWorth, inCreditTotal, foldedCount };
 }


### PR DESCRIPTION
The owner, 17 Aug: the ring's legend totalled far **more** than net worth — the in-credit fold counted gross investment values and loans-out while ignoring every liability — *"I feel the total sum of those 5 totals in that legend should come back to my net worth, otherwise it looks like a useless report."* Design's ethos handover independently flagged the same ring as a brand risk the same day. One semantic change, made in one place:

> **top accounts in credit + everything else, net = net worth**

## What changed

- **The remainder nets every other account**, negatives included — a Decimal subtraction from net worth, so the reconciliation holds to the penny by construction. Renamed "N **other** accounts": they are not all smaller, and some are owed.
- **Shares are contributions to net worth.** An account can honestly hold more than you are worth (200% beside a −100% liability); the signed shares sum to 100; negative contributions print in the accounting parentheses. Net worth at or below zero yields no shares — a percentage of a debt reads as nothing.
- **A pie has no negative wedge**, so the util derives `wedges` (drawable) beside `slices` (the legend) — one derivation, not a filter per call site, and anything dropped is always **last**, so every drawn slice keeps the colour index its legend row has. A below-zero remainder stays in the legend, red and parenthesised, and the subtitle says where the rest went.
- **A remainder of one is shown by name** — a fold of one hides nothing and loses the name (a lone mortgage under four assets reads as itself).
- **The full report moves with the card**: headline tile is **Net worth** (the same figure the Dashboard shows — two totals for one page is the disagreement this report exists to prevent), the table footer states what the Balance column already sums to, and the footnote explains parenthesised contributions.

## Verified

- lint 0 · typecheck:strict clean · rewritten arithmetic tests + dashboard suite 28/28 · full gate via pre-commit and pre-push
- Rebased onto #343 so the dashboard edits compose

🤖 Generated with [Claude Code](https://claude.com/claude-code)
