### PR TITLE
feat(copy): the ethos, said where it is already enforced

### DIFF
--- a/index.html
+++ b/index.html
@@ -17,8 +17,8 @@
     <meta name="apple-mobile-web-app-title" content="WealthTracker" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
     <meta name="theme-color" content="#1a2332" />
-    <meta name="description" content="Personal finance tracking application" />
-    <title>WealthTracker - Personal Finance Management</title>
+    <meta name="description" content="A personal finance ledger built on agreement, not estimation. Every figure traces to a line you entered and reconciled. Imports Microsoft Money." />
+    <title>WealthTracker — a ledger you can prove</title>
     
     <!-- Preconnect to external domains -->
     <link rel="preconnect" href="https://fonts.googleapis.com" crossorigin>

--- a/src/components/CSVImportWizard.tsx
+++ b/src/components/CSVImportWizard.tsx
@@ -1678,7 +1678,14 @@ export default function CSVImportWizard({ isOpen, onClose, initialFile }: CSVImp
                   Preview Import
                 </h3>
                 <p className="text-sm text-gray-600 dark:text-gray-400">
-                  Review the first few rows to ensure correct mapping
+                  Review the first few rows to ensure correct mapping.
+                  {/* True by construction, and worth saying (Design, 17 Aug
+                      §6): the wizard parses with FileReader in this browser
+                      and the service makes no network call — verified before
+                      this sentence was written. Only accepted rows are saved
+                      to the ledger. */}
+                  {' '}Your file is read on this device and never uploaded —
+                  only the rows you accept are saved to your ledger.
                 </p>
               </div>
 

--- a/src/components/CrossCurrencyTransferDialog.tsx
+++ b/src/components/CrossCurrencyTransferDialog.tsx
@@ -310,7 +310,11 @@ export default function CrossCurrencyTransferDialog({
               two things this line ALONE can carry — who quoted it and when —
               to the end where they read as an afterthought. */}
           {quote.status === 'ready' && quote.source === 'api' && (
-            <>{quote.provider}, {quotedAt}</>
+            /* The ethos said once, where it is being enforced (Design, 17 Aug
+               §6): this dialog already records more about a converted figure
+               than most apps show — say that it does. */
+            <>{quote.provider}, {quotedAt}. Every converted figure records the
+            rate it used and when.</>
           )}
           {quote.status === 'ready' && quote.source === 'fallback' && (
             <>No live rate right now, so this one is approximate — check it against your

--- a/src/components/OnboardingModal.tsx
+++ b/src/components/OnboardingModal.tsx
@@ -130,9 +130,12 @@ export default function OnboardingModal({ isOpen, onComplete }: OnboardingModalP
             them nothing about the one they had just opened
             (DESIGN_PASS_2026-08 §3.4). Each field now also says what the app
             DOES with the answer. */}
+        {/* Purpose before manner (Design, 17 Aug §3): a reader learns what
+            the app is FOR before how it feels to use. Same length. */}
         <p className="text-gray-600 dark:text-gray-400 mb-6">
-          Two answers and you're in. This is a dense, keyboard-driven ledger:
-          your figures stay yours, and every report says what it leaves out.
+          Two answers and you're in. WealthTracker is a ledger, not an
+          estimator — every figure traces to something you entered or
+          imported, and every report says what it leaves out.
         </p>
 
         <form onSubmit={handleSubmit} className="space-y-4">

--- a/src/pages/AccountTransactions.tsx
+++ b/src/pages/AccountTransactions.tsx
@@ -3012,7 +3012,7 @@ export default function AccountTransactions() {
   const registerEmptyState = fullAccountTransactions.length === 0 ? (
     <EmptyState
       title="No transactions in this account yet"
-      description={`Its balance stays at ${formatRegisterMoney(computedAccountBalance)}, and this account adds nothing to your reports until something lands here.`}
+      description={`Its balance stays at ${formatRegisterMoney(computedAccountBalance)}, and this account adds nothing to your reports until something lands here. Nothing is estimated, so nothing appears until you add it.`}
       action={{ label: 'Add transaction', onClick: () => setShowAddTransaction(true) }}
       secondaryAction={{
         label: 'Import a statement',

--- a/src/pages/Accounts.tsx
+++ b/src/pages/Accounts.tsx
@@ -2985,7 +2985,7 @@ export default function Accounts() {
         <div className="bg-white dark:bg-gray-800 rounded-2xl shadow-lg border border-gray-100 dark:border-gray-700">
           <EmptyState
             title="No accounts yet"
-            description="Every balance, report and budget in WealthTracker is built up from accounts, so until there is one here the rest of the app has nothing to show."
+            description="Every balance, report and budget in WealthTracker is built up from accounts, so until there is one here the rest of the app has nothing to show. Nothing here is estimated, so nothing appears until you add it."
             action={{ label: 'Add Account', onClick: () => setIsAddModalOpen(true) }}
           />
         </div>

--- a/src/pages/Reconciliation.tsx
+++ b/src/pages/Reconciliation.tsx
@@ -501,6 +501,13 @@ export default function Reconciliation() {
           <h1 className="text-2xl font-bold text-gray-900 dark:text-white">
             Reconciliation
           </h1>
+          {/* WHY THIS SCREEN EXISTS (Design, 17 Aug §6): the one page no
+              competitor has an equivalent of, finally saying so. This is the
+              ethos as a sentence — agreement, not estimation. */}
+          <p className="mt-1 text-sm text-gray-500 dark:text-gray-400">
+            Agree each account against the statement you hold. This is what makes
+            every other number in the app defensible.
+          </p>
           {totalUnreconciledCount > 0 ? (
             <>
               <p className="mt-1 text-display font-semibold text-primary dark:text-white tabular-nums">

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -80,7 +80,8 @@ export default function Settings() {
             itself. */}
         <p className="mt-4 text-body text-gray-500 dark:text-gray-400">
           A ledger for your own money: what you have, what you owe, and where
-          it went.
+          it went. Every figure traces to something you entered or imported —
+          nothing is estimated.
         </p>
 
         <h3 className="mt-6 text-card font-semibold text-gray-900 dark:text-white">

--- a/src/pages/Welcome.tsx
+++ b/src/pages/Welcome.tsx
@@ -5,23 +5,28 @@ import { usePreferences } from '../contexts/PreferencesContext';
 import { WalletIcon, TagIcon, PieChartIcon, UploadIcon, ArrowRightIcon } from '../components/icons';
 import type { IconProps } from '../components/icons/IconBase';
 
-// Plain statements of what the app does — no claims, no counts, no adjectives
-// doing the work a screenshot should. Each maps to a real part of the product.
+// THE ETHOS, not the aggregator's pitch (Design handover, 17 Aug; owner
+// approved the copy). "All in one place" was close to verbatim what the
+// aggregators lead with — competing on their strongest ground with none of
+// their plumbing — and it undersold the one capability nobody else has:
+// every figure here traces to a line you entered and reconciled. The claim
+// no report can leave out leads, because it is the most unusual one in the
+// market.
 const FEATURES: ReadonlyArray<{ Icon: React.FC<IconProps>; title: string; body: string }> = [
   {
+    Icon: PieChartIcon,
+    title: 'Every report says what it leaves out',
+    body: 'Uncategorised rows, excluded currencies, the rate used and when — stated on the page, never buried.',
+  },
+  {
     Icon: WalletIcon,
-    title: 'All your accounts in one place',
-    body: 'Current accounts, savings, cards and investments, side by side.',
+    title: 'Everything counts, not just what a bank will tell you',
+    body: 'The house, the pension, the loan to your brother. An API can only see accounts a bank chose to expose.',
   },
   {
     Icon: TagIcon,
-    title: 'Every transaction categorised',
-    body: 'Sorted and searchable, so you can see where your money goes.',
-  },
-  {
-    Icon: PieChartIcon,
-    title: 'Reports that match reality',
-    body: 'Net worth over time, and income and expenses by month.',
+    title: 'You decide what everything is',
+    body: 'No machine quietly filing your mortgage under shopping — and no way for that to go unnoticed.',
   },
   {
     Icon: UploadIcon,
@@ -73,12 +78,15 @@ export default function Welcome(): React.JSX.Element {
           id="welcome-heading"
           className="mt-5 text-3xl sm:text-4xl md:text-5xl font-bold text-white"
         >
-          Your money, all in one place
+          Other apps show you a number.
+          <br />
+          WealthTracker lets you prove it.
         </h1>
 
         <p className="mt-4 mx-auto max-w-2xl text-base sm:text-lg leading-relaxed text-white/75">
-          Every account, every transaction and every report together — a modern take on
-          Microsoft Money.
+          Every figure traces back to a line you entered, categorised and reconciled
+          against your own statements. Nothing is guessed. Import twenty years of
+          Microsoft Money and carry on.
         </p>
 
         <div className="mt-8 flex flex-col sm:flex-row gap-3 justify-center">


### PR DESCRIPTION
Design's ethos-injection handover (17 Aug), owner-approved including the hero. The app already **enforces** the ethos in code — P8, the provenance lines, "what this report leaves out" — but its two most-read surfaces argued against it.

## The two that sold the competitor's product

- **The landing hero** was "Your money, all in one place" — the aggregator's claim, nearly verbatim. It now leads with the one capability nobody else has: **"Other apps show you a number. WealthTracker lets you prove it."** The four feature cards re-point the same way, with "Every report says what it leaves out" — the most unusual claim in the market — read first. The two load-bearing `!important` comments in that file are untouched, as the handover warned.
- **The title tag and meta description** were category placeholders. Now: *"WealthTracker — a ledger you can prove."*

## One line each, added to copy that was already good

- Onboarding leads with **purpose before manner**: "a ledger, not an estimator" before "dense, keyboard-driven".
- Settings' About gains the tracing clause (its marketing paragraph and Technology section were already gone — §4 largely predated itself).
- The Accounts and register empty states say why they are empty: *"Nothing is estimated, so nothing appears until you add it."*
- **Reconciliation** — the one screen no competitor has — finally says why it exists: *"Agree each account against the statement you hold. This is what makes every other number in the app defensible."*
- The FX dialog claims the honesty it already practices: *"Every converted figure records the rate it used and when."*
- The import preview says the file never leaves the device — **verified before written**: the wizard parses via FileReader and the service makes no network call.

§7's two re-prioritised findings both closed the same day: the ring reconciles to net worth (#344), and the capture drift was answered as real ledger movement (the 17 Aug reply handover).

## Verified

- lint 0 · typecheck:strict clean · copy-pinning register suite 11/11 · full gate via pre-commit and pre-push (one load-flake retry; the three flaked suites pass 25/25 in isolation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
