### PR TITLE
feat(dashboard): the balance cards sit where you put them

### DIFF
--- a/src/components/dashboard/ImprovedDashboard.test.tsx
+++ b/src/components/dashboard/ImprovedDashboard.test.tsx
@@ -407,3 +407,54 @@ describe('the foot of the dashboard', () => {
     expect(screen.queryByText('Add Transaction')).not.toBeInTheDocument();
   });
 });
+
+/**
+ * THE STORED ORDER IS THE SEATING PLAN (owner, 17 Aug: "move it within that
+ * box … like moving an app around on an iPhone screen"). Two things jsdom can
+ * prove: the tiles render in the persisted order rather than account-list
+ * order, and Alt+arrows re-seat a card and persist the result. The pointer
+ * drag itself is geometry (elementFromPoint over a laid-out grid) and is a
+ * browser check, named as such.
+ */
+describe('Key Account Balances — the cards sit where the user put them', () => {
+  beforeEach(() => {
+    mocks.app.accounts = [
+      account({ id: 'acc-a', name: 'Feed Account A', openingBalance: 100 }),
+      account({ id: 'acc-b', name: 'Feed Account B', type: 'savings', openingBalance: 200 }),
+      account({ id: 'acc-c', name: 'Feed Account C', type: 'credit', openingBalance: -50 }),
+    ];
+  });
+
+  const cardNames = (): string[] =>
+    screen.getAllByTestId('account-balance-card')
+      .map(card => within(card).getByText(/Feed Account/).textContent ?? '');
+
+  it('renders the tiles in the STORED order, not the account list order', () => {
+    localStorage.setItem('dashboardKeyAccounts', JSON.stringify(['acc-c', 'acc-a', 'acc-b']));
+    render(<ImprovedDashboard />);
+
+    expect(cardNames()).toEqual(['Feed Account C', 'Feed Account A', 'Feed Account B']);
+  });
+
+  it('Alt+ArrowRight moves a card one seat and persists the new order', () => {
+    localStorage.setItem('dashboardKeyAccounts', JSON.stringify(['acc-a', 'acc-b', 'acc-c']));
+    render(<ImprovedDashboard />);
+
+    const [first] = screen.getAllByTestId('account-balance-card');
+    fireEvent.keyDown(first, { key: 'ArrowRight', altKey: true });
+
+    expect(cardNames()).toEqual(['Feed Account B', 'Feed Account A', 'Feed Account C']);
+    expect(JSON.parse(localStorage.getItem('dashboardKeyAccounts') ?? '[]'))
+      .toEqual(['acc-b', 'acc-a', 'acc-c']);
+  });
+
+  it('a plain arrow key still means what it always meant — only Alt re-seats', () => {
+    localStorage.setItem('dashboardKeyAccounts', JSON.stringify(['acc-a', 'acc-b', 'acc-c']));
+    render(<ImprovedDashboard />);
+
+    const [first] = screen.getAllByTestId('account-balance-card');
+    fireEvent.keyDown(first, { key: 'ArrowRight' });
+
+    expect(cardNames()).toEqual(['Feed Account A', 'Feed Account B', 'Feed Account C']);
+  });
+});

--- a/src/components/dashboard/ImprovedDashboard.tsx
+++ b/src/components/dashboard/ImprovedDashboard.tsx
@@ -57,6 +57,7 @@ import {
   type AccountDistributionEntry,
 } from '../../utils/accountDistribution';
 import { groupAccountsBySection } from '../../utils/accountGrouping';
+import { moveToPosition, moveBySteps } from '../../utils/reorderList';
 import { buildCategoryNameLookup } from '../../utils/categoryNames';
 import { buildAttentionItems } from '../../utils/attentionItems';
 import { loadAutoSyncPrefs } from '../../utils/bankAutoSync';
@@ -446,7 +447,94 @@ export function ImprovedDashboard() {
     });
   };
 
-  const displayedAccounts = accounts.filter(a => selectedAccountIds.includes(a.id));
+  /**
+   * THE STORED ORDER IS THE DISPLAY ORDER (owner, 17 Aug: "move it within
+   * that box … like moving an app around on an iPhone screen"). This used to
+   * filter the ACCOUNTS array, so the tiles sat in load order whatever the
+   * user chose — the id list the picker already persists simply becomes the
+   * seating plan.
+   */
+  const displayedAccounts = useMemo(() => {
+    const byId = new Map(accounts.map(a => [a.id, a]));
+    return selectedAccountIds
+      .map(id => byId.get(id))
+      .filter((a): a is typeof accounts[number] => a !== undefined);
+  }, [accounts, selectedAccountIds]);
+
+  /**
+   * ─ DRAGGING A TILE TO A NEW SEAT ──────────────────────────────────────────
+   * Pointer events, one set for mouse, pen and touch. A press is not a drag
+   * until it has moved 8px — the tile is also a button that opens the
+   * account, and the moved flag is what keeps one gesture from being both.
+   * While dragging, the tile under the pointer becomes the target and the
+   * order re-seats LIVE (moveToPosition preserves every other relative
+   * order); the drop persists it. `touch-action: pan-y` keeps the page
+   * scrollable from a tile on a phone, which means a touch drag reorders
+   * cleanly sideways and yields to scrolling vertically — the full gesture
+   * belongs to the mouse this feature was asked for, and Alt+arrows cover
+   * the keyboard.
+   */
+  const [draggingId, setDraggingId] = useState<string | null>(null);
+  const dragRef = React.useRef<{ id: string; startX: number; startY: number; moved: boolean } | null>(null);
+  const orderRef = React.useRef<string[]>(selectedAccountIds);
+  orderRef.current = selectedAccountIds;
+  const [reorderAnnouncement, setReorderAnnouncement] = useState('');
+
+  const announceSeat = useCallback((accountId: string, order: string[]): void => {
+    const name = accounts.find(a => a.id === accountId)?.name ?? 'Account';
+    setReorderAnnouncement(`${name} moved to position ${order.indexOf(accountId) + 1} of ${order.length}`);
+  }, [accounts]);
+
+  const handleTilePointerDown = (e: React.PointerEvent, accountId: string): void => {
+    if (e.button !== 0) return;
+    dragRef.current = { id: accountId, startX: e.clientX, startY: e.clientY, moved: false };
+    (e.currentTarget as HTMLElement).setPointerCapture(e.pointerId);
+  };
+
+  const handleTilePointerMove = (e: React.PointerEvent): void => {
+    const drag = dragRef.current;
+    if (!drag) return;
+    if (!drag.moved) {
+      if (Math.hypot(e.clientX - drag.startX, e.clientY - drag.startY) < 8) return;
+      drag.moved = true;
+      setDraggingId(drag.id);
+    }
+    // The captured element receives every move, so the tile under the pointer
+    // is found by position rather than by event target.
+    const over = document
+      .elementFromPoint(e.clientX, e.clientY)
+      ?.closest<HTMLElement>('[data-account-tile-id]');
+    const targetId = over?.dataset.accountTileId;
+    if (!targetId || targetId === drag.id) return;
+    setSelectedAccountIds(prev => moveToPosition(prev, drag.id, targetId));
+  };
+
+  const endTileDrag = (): void => {
+    const drag = dragRef.current;
+    if (drag?.moved) {
+      persistSelection(orderRef.current);
+      announceSeat(drag.id, orderRef.current);
+    }
+    setDraggingId(null);
+    // The moved flag must outlive pointerup by one tick: the click event the
+    // browser fires AFTER a drag's release is the one to swallow.
+    setTimeout(() => { dragRef.current = null; }, 0);
+  };
+
+  /** Alt+arrows re-seat from the keyboard; plain keys keep their meanings. */
+  const handleTileKeyDown = (e: React.KeyboardEvent, accountId: string): void => {
+    if (!e.altKey) return;
+    const steps =
+      e.key === 'ArrowLeft' ? -1 :
+      e.key === 'ArrowRight' ? 1 :
+      e.key === 'ArrowUp' ? -2 :
+      e.key === 'ArrowDown' ? 2 : 0;
+    if (steps === 0) return;
+    e.preventDefault();
+    const next = moveBySteps(selectedAccountIds, accountId, steps);
+    persistSelection(next);
+    announceSeat(accountId, next);
+  };
 
   /**
    * "None yet" and "none arrived yet" are different sentences, and the panel
@@ -1079,28 +1167,46 @@ export function ImprovedDashboard() {
               ))}
             </div>
             <div className="mt-3 text-xs text-gray-500 dark:text-gray-400">
-              Tip: Select your most important accounts for quick access
+              Tip: Select your most important accounts, then drag a card to
+              put them in the order you want
             </div>
           </div>
         )}
         
+        {/* Where a moved card landed, for anyone who cannot see it land. */}
+        <div className="sr-only" aria-live="polite">{reorderAnnouncement}</div>
         <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
           {displayedAccounts.length > 0 ? (
             displayedAccounts.map(account => (
-              <div 
+              <div
                 key={account.id}
-                className="flex items-center justify-between p-4 bg-gray-50 dark:bg-gray-700 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-600 transition-colors cursor-pointer"
+                className={`flex items-center justify-between p-4 bg-gray-50 dark:bg-gray-700 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-600 transition-colors cursor-pointer select-none ${
+                  draggingId === account.id ? 'ring-2 ring-[#6b86b3] shadow-lg opacity-90' : ''
+                }`}
+                style={{ touchAction: 'pan-y' }}
                 data-testid="account-balance-card"
-                onClick={() => navigate(preserveDemoParam(`/accounts/${account.id}`, location.search))}
+                data-account-tile-id={account.id}
+                // A drag's release fires a click; the moved flag swallows it so
+                // one gesture is never both a reorder and a navigation.
+                onClick={() => {
+                  if (dragRef.current?.moved) return;
+                  navigate(preserveDemoParam(`/accounts/${account.id}`, location.search));
+                }}
+                onPointerDown={(e) => handleTilePointerDown(e, account.id)}
+                onPointerMove={handleTilePointerMove}
+                onPointerUp={endTileDrag}
+                onPointerCancel={endTileDrag}
                 role="button"
                 tabIndex={0}
                 onKeyDown={(e) => {
+                  handleTileKeyDown(e, account.id);
+                  if (e.defaultPrevented) return;
                   if (e.key === 'Enter' || e.key === ' ') {
                     e.preventDefault();
                     navigate(preserveDemoParam(`/accounts/${account.id}`, location.search));
                   }
                 }}
-                aria-label={`View ${account.name} account details. Balance: ${formatCurrencyWithSymbol(getAccountBalance(account))}`}
+                aria-label={`View ${account.name} account details. Balance: ${formatCurrencyWithSymbol(getAccountBalance(account))}. Hold Alt and press an arrow key to move this card.`}
               >
                 <div className="flex-1">
                   <p className="font-medium text-gray-900 dark:text-white">

--- a/src/utils/reorderList.test.ts
+++ b/src/utils/reorderList.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect } from 'vitest';
+import { moveToPosition, moveBySteps } from './reorderList';
+
+const IDS = ['a', 'b', 'c', 'd', 'e', 'f'];
+
+describe('moveToPosition — drag a tile onto another seat', () => {
+  it('moves forward, shifting the crossed members back', () => {
+    expect(moveToPosition(IDS, 'b', 'e')).toEqual(['a', 'c', 'd', 'e', 'b', 'f']);
+  });
+
+  it('moves backward, shifting the crossed members forward', () => {
+    expect(moveToPosition(IDS, 'e', 'b')).toEqual(['a', 'e', 'b', 'c', 'd', 'f']);
+  });
+
+  it('dropping a tile on itself changes nothing', () => {
+    expect(moveToPosition(IDS, 'c', 'c')).toEqual(IDS);
+  });
+
+  it('a drag that raced a deletion is a no-op, not a crash', () => {
+    expect(moveToPosition(IDS, 'gone', 'c')).toEqual(IDS);
+    expect(moveToPosition(IDS, 'c', 'gone')).toEqual(IDS);
+  });
+
+  it('never mutates its input', () => {
+    const before = [...IDS];
+    moveToPosition(IDS, 'a', 'f');
+    expect(IDS).toEqual(before);
+  });
+});
+
+describe('moveBySteps — the keyboard version of the same gesture', () => {
+  it('steps in both directions', () => {
+    expect(moveBySteps(IDS, 'c', 1)).toEqual(['a', 'b', 'd', 'c', 'e', 'f']);
+    expect(moveBySteps(IDS, 'c', -2)).toEqual(['c', 'a', 'b', 'd', 'e', 'f']);
+  });
+
+  it('clamps at the ends instead of wrapping or throwing', () => {
+    expect(moveBySteps(IDS, 'a', -1)).toEqual(IDS);
+    expect(moveBySteps(IDS, 'f', 5)).toEqual(IDS);
+    expect(moveBySteps(IDS, 'e', 99)).toEqual(['a', 'b', 'c', 'd', 'f', 'e']);
+  });
+});

--- a/src/utils/reorderList.ts
+++ b/src/utils/reorderList.ts
@@ -1,0 +1,47 @@
+/**
+ * Move one member of a list to another member's position, preserving every
+ * other relative order — the arithmetic behind dragging a Key Account Balance
+ * tile onto a new seat (owner, 17 Aug: "like moving an app around on an
+ * iPhone screen").
+ *
+ * Pure and id-based, because the caller persists an ID LIST: the dashboard's
+ * chosen accounts are stored as an array of ids, and from this change onward
+ * that array's ORDER is the display order.
+ */
+export function moveToPosition(
+  ids: readonly string[],
+  movingId: string,
+  targetId: string
+): string[] {
+  if (movingId === targetId) return [...ids];
+  const from = ids.indexOf(movingId);
+  const to = ids.indexOf(targetId);
+  // A member the list does not hold cannot be moved, and moving ONTO one
+  // would invent a position — both answer with the list unchanged rather
+  // than a throw: a drag that raced a deletion is a no-op, not a crash.
+  if (from === -1 || to === -1) return [...ids];
+  const next = [...ids];
+  next.splice(from, 1);
+  next.splice(to, 0, movingId);
+  return next;
+}
+
+/**
+ * Move one member a signed number of steps, clamped to the ends — the
+ * keyboard's version of the same gesture (Alt+arrows), where "one step" is a
+ * neighbouring seat and the grid's own wrap decides what that looks like.
+ */
+export function moveBySteps(
+  ids: readonly string[],
+  movingId: string,
+  steps: number
+): string[] {
+  const from = ids.indexOf(movingId);
+  if (from === -1 || steps === 0) return [...ids];
+  const to = Math.min(ids.length - 1, Math.max(0, from + steps));
+  if (to === from) return [...ids];
+  const next = [...ids];
+  next.splice(from, 1);
+  next.splice(to, 0, movingId);
+  return next;
+}


### PR DESCRIPTION
Owner, 17 Aug: *"hold my mouse on 1 of the six, and move it within that box, and then the others move around — like moving an app around on an iPhone screen."*

## The stored order becomes the seating plan

`displayedAccounts` used to **filter** the accounts array, so the tiles sat in load order whatever the user chose. It now maps the persisted id list — which makes reordering a one-array change everything else already round-trips.

## The gesture

Pointer events, one set for mouse, pen and touch. A press is not a drag until it has moved 8px — the tile is also the button that opens the account, and the moved flag swallows the click a drag's release fires, so one gesture is never both. While dragging, the tile under the pointer becomes the target and the order re-seats **live** (`moveToPosition` preserves every other relative order); the drop persists. `touch-action: pan-y` keeps the page scrollable from a tile on a phone — a touch drag reorders sideways and yields to vertical scrolling; the full gesture belongs to the mouse it was asked for.

**Alt+arrows** re-seat from the keyboard (plain keys keep their meanings), clamped at the ends, with a live region saying where the card landed for anyone who cannot see it land.

## Verified

- lint 0 · typecheck:strict clean · `reorderList` 7/7 (both directions, self-drop, raced-deletion no-op, clamping, no mutation) · dashboard suite 20/20 (stored-order render, Alt+arrow persist, plain-arrow guard) · full gate via pre-commit and pre-push
- The pointer drag itself is geometry over a laid-out grid — a browser check, named as such in the test header

🤖 Generated with [Claude Code](https://claude.com/claude-code)
