### PR TITLE
fix(dashboard): tile drag previews one swap, commits on release

### DIFF
--- a/src/components/dashboard/ImprovedDashboard.tsx
+++ b/src/components/dashboard/ImprovedDashboard.tsx
@@ -57,7 +57,7 @@ import {
   type AccountDistributionEntry,
 } from '../../utils/accountDistribution';
 import { groupAccountsBySection } from '../../utils/accountGrouping';
-import { moveToPosition, moveBySteps } from '../../utils/reorderList';
+import { swapPositions, moveBySteps } from '../../utils/reorderList';
 import { buildCategoryNameLookup } from '../../utils/categoryNames';
 import { buildAttentionItems } from '../../utils/attentionItems';
 import { loadAutoSyncPrefs } from '../../utils/bankAutoSync';
@@ -454,31 +454,42 @@ export function ImprovedDashboard() {
    * user chose — the id list the picker already persists simply becomes the
    * seating plan.
    */
-  const displayedAccounts = useMemo(() => {
-    const byId = new Map(accounts.map(a => [a.id, a]));
-    return selectedAccountIds
-      .map(id => byId.get(id))
-      .filter((a): a is typeof accounts[number] => a !== undefined);
-  }, [accounts, selectedAccountIds]);
-
   /**
    * ─ DRAGGING A TILE TO A NEW SEAT ──────────────────────────────────────────
    * Pointer events, one set for mouse, pen and touch. A press is not a drag
    * until it has moved 8px — the tile is also a button that opens the
    * account, and the moved flag is what keeps one gesture from being both.
-   * While dragging, the tile under the pointer becomes the target and the
-   * order re-seats LIVE (moveToPosition preserves every other relative
-   * order); the drop persists it. `touch-action: pan-y` keeps the page
-   * scrollable from a tile on a phone, which means a touch drag reorders
-   * cleanly sideways and yields to scrolling vertically — the full gesture
-   * belongs to the mouse this feature was asked for, and Alt+arrows cover
-   * the keyboard.
+   *
+   * THE SEMANTICS ARE A SWAP, PREVIEWED, COMMITTED ON RELEASE (owner,
+   * 18 Aug). The first cut re-seated the stored order live as the pointer
+   * crossed each tile, so a drag from top-right to bottom-left displaced
+   * every tile it crossed — "it is too easy to move the wrong one". Now:
+   * the tile under the pointer previews sliding into the dragged tile's
+   * ORIGINAL seat — computed fresh from the pre-drag order on every move,
+   * never cumulatively, so a tile merely crossed springs back the moment
+   * the pointer moves on — and NOTHING is stored until the button is
+   * released. Escape-by-pointercancel reverts to where things were.
+   *
+   * `touch-action: pan-y` keeps the page scrollable from a tile on a phone;
+   * Alt+arrows cover the keyboard.
    */
   const [draggingId, setDraggingId] = useState<string | null>(null);
-  const dragRef = React.useRef<{ id: string; startX: number; startY: number; moved: boolean } | null>(null);
-  const orderRef = React.useRef<string[]>(selectedAccountIds);
-  orderRef.current = selectedAccountIds;
+  const [previewOrder, setPreviewOrder] = useState<string[] | null>(null);
+  const dragRef = React.useRef<{
+    id: string; startX: number; startY: number; moved: boolean;
+    /** The seating plan as the drag began — every preview derives from THIS. */
+    baseOrder: string[];
+    /** The tile currently previewing into the dragged tile's seat. */
+    hoverId: string | null;
+  } | null>(null);
   const [reorderAnnouncement, setReorderAnnouncement] = useState('');
+
+  const displayedAccounts = useMemo(() => {
+    const byId = new Map(accounts.map(a => [a.id, a]));
+    return (previewOrder ?? selectedAccountIds)
+      .map(id => byId.get(id))
+      .filter((a): a is typeof accounts[number] => a !== undefined);
+  }, [accounts, selectedAccountIds, previewOrder]);
 
   const announceSeat = useCallback((accountId: string, order: string[]): void => {
     const name = accounts.find(a => a.id === accountId)?.name ?? 'Account';
@@ -487,7 +498,10 @@ export function ImprovedDashboard() {
 
   const handleTilePointerDown = (e: React.PointerEvent, accountId: string): void => {
     if (e.button !== 0) return;
-    dragRef.current = { id: accountId, startX: e.clientX, startY: e.clientY, moved: false };
+    dragRef.current = {
+      id: accountId, startX: e.clientX, startY: e.clientY, moved: false,
+      baseOrder: selectedAccountIds, hoverId: null,
+    };
     (e.currentTarget as HTMLElement).setPointerCapture(e.pointerId);
   };
 
@@ -504,20 +518,34 @@ export function ImprovedDashboard() {
     const over = document
       .elementFromPoint(e.clientX, e.clientY)
       ?.closest<HTMLElement>('[data-account-tile-id]');
-    const targetId = over?.dataset.accountTileId;
-    if (!targetId || targetId === drag.id) return;
-    setSelectedAccountIds(prev => moveToPosition(prev, drag.id, targetId));
+    const targetId = over?.dataset.accountTileId ?? null;
+    if (targetId === drag.hoverId) return;
+    drag.hoverId = targetId;
+    // Always from the base order: leaving a tile un-hovers it completely.
+    setPreviewOrder(targetId && targetId !== drag.id
+      ? swapPositions(drag.baseOrder, drag.id, targetId)
+      : null);
   };
 
   const endTileDrag = (): void => {
     const drag = dragRef.current;
-    if (drag?.moved) {
-      persistSelection(orderRef.current);
-      announceSeat(drag.id, orderRef.current);
+    if (drag?.moved && drag.hoverId && drag.hoverId !== drag.id) {
+      // THE COMMIT — the one moment the stored order changes.
+      const final = swapPositions(drag.baseOrder, drag.id, drag.hoverId);
+      persistSelection(final);
+      announceSeat(drag.id, final);
     }
+    setPreviewOrder(null);
     setDraggingId(null);
     // The moved flag must outlive pointerup by one tick: the click event the
     // browser fires AFTER a drag's release is the one to swallow.
+    setTimeout(() => { dragRef.current = null; }, 0);
+  };
+
+  /** A cancelled drag (pointercancel — a scroll won the touch) commits nothing. */
+  const cancelTileDrag = (): void => {
+    setPreviewOrder(null);
+    setDraggingId(null);
     setTimeout(() => { dragRef.current = null; }, 0);
   };
 
@@ -1195,7 +1223,7 @@ export function ImprovedDashboard() {
                 onPointerDown={(e) => handleTilePointerDown(e, account.id)}
                 onPointerMove={handleTilePointerMove}
                 onPointerUp={endTileDrag}
-                onPointerCancel={endTileDrag}
+                onPointerCancel={cancelTileDrag}
                 role="button"
                 tabIndex={0}
                 onKeyDown={(e) => {

--- a/src/utils/reorderList.test.ts
+++ b/src/utils/reorderList.test.ts
@@ -1,29 +1,37 @@
 import { describe, it, expect } from 'vitest';
-import { moveToPosition, moveBySteps } from './reorderList';
+import { swapPositions, moveBySteps } from './reorderList';
 
 const IDS = ['a', 'b', 'c', 'd', 'e', 'f'];
 
-describe('moveToPosition — drag a tile onto another seat', () => {
-  it('moves forward, shifting the crossed members back', () => {
-    expect(moveToPosition(IDS, 'b', 'e')).toEqual(['a', 'c', 'd', 'e', 'b', 'f']);
+describe('swapPositions — the hovered tile takes the dragged tile\'s seat', () => {
+  it('swaps two seats and moves nobody else (owner: crossing tiles must not displace them)', () => {
+    expect(swapPositions(IDS, 'a', 'e')).toEqual(['e', 'b', 'c', 'd', 'a', 'f']);
+    expect(swapPositions(IDS, 'e', 'a')).toEqual(['e', 'b', 'c', 'd', 'a', 'f']);
   });
 
-  it('moves backward, shifting the crossed members forward', () => {
-    expect(moveToPosition(IDS, 'e', 'b')).toEqual(['a', 'e', 'b', 'c', 'd', 'f']);
+  it('previewing from the PRE-DRAG order is not cumulative — a new hover replaces the last, never stacks on it', () => {
+    // Dragging 'a' across 'c' and then to 'e': each preview computes from the
+    // base order, so 'c' is back in its own seat the moment the pointer moves
+    // on. This is the whole of the owner's complaint with the first cut.
+    const overC = swapPositions(IDS, 'a', 'c');
+    const overE = swapPositions(IDS, 'a', 'e');
+    expect(overC).toEqual(['c', 'b', 'a', 'd', 'e', 'f']);
+    expect(overE).toEqual(['e', 'b', 'c', 'd', 'a', 'f']);
+    expect(overE.indexOf('c')).toBe(2); // untouched by having been crossed
   });
 
-  it('dropping a tile on itself changes nothing', () => {
-    expect(moveToPosition(IDS, 'c', 'c')).toEqual(IDS);
+  it('hovering a tile over itself changes nothing', () => {
+    expect(swapPositions(IDS, 'c', 'c')).toEqual(IDS);
   });
 
   it('a drag that raced a deletion is a no-op, not a crash', () => {
-    expect(moveToPosition(IDS, 'gone', 'c')).toEqual(IDS);
-    expect(moveToPosition(IDS, 'c', 'gone')).toEqual(IDS);
+    expect(swapPositions(IDS, 'gone', 'c')).toEqual(IDS);
+    expect(swapPositions(IDS, 'c', 'gone')).toEqual(IDS);
   });
 
   it('never mutates its input', () => {
     const before = [...IDS];
-    moveToPosition(IDS, 'a', 'f');
+    swapPositions(IDS, 'a', 'f');
     expect(IDS).toEqual(before);
   });
 });

--- a/src/utils/reorderList.ts
+++ b/src/utils/reorderList.ts
@@ -1,28 +1,34 @@
 /**
- * Move one member of a list to another member's position, preserving every
- * other relative order — the arithmetic behind dragging a Key Account Balance
- * tile onto a new seat (owner, 17 Aug: "like moving an app around on an
- * iPhone screen").
+ * Swap two members' seats, leaving everyone else exactly where they were —
+ * the arithmetic behind dragging a Key Account Balance tile (owner, 18 Aug:
+ * "whatever other account I am hovering over slips into the position I have
+ * just left — but that only gets confirmed once I let go").
+ *
+ * A SWAP, deliberately not an insertion. The first cut re-seated the list
+ * live as the pointer crossed each tile, so dragging top-right to
+ * bottom-left displaced every tile crossed on the way — "it is too easy to
+ * move the wrong one". The caller now previews `swapPositions(preDragOrder,
+ * dragged, hovered)` — always computed from the order the drag STARTED from,
+ * never cumulatively — and commits only on release.
  *
  * Pure and id-based, because the caller persists an ID LIST: the dashboard's
- * chosen accounts are stored as an array of ids, and from this change onward
- * that array's ORDER is the display order.
+ * chosen accounts are stored as an array of ids, and that array's order is
+ * the display order.
  */
-export function moveToPosition(
+export function swapPositions(
   ids: readonly string[],
-  movingId: string,
-  targetId: string
+  aId: string,
+  bId: string
 ): string[] {
-  if (movingId === targetId) return [...ids];
-  const from = ids.indexOf(movingId);
-  const to = ids.indexOf(targetId);
-  // A member the list does not hold cannot be moved, and moving ONTO one
-  // would invent a position — both answer with the list unchanged rather
-  // than a throw: a drag that raced a deletion is a no-op, not a crash.
-  if (from === -1 || to === -1) return [...ids];
   const next = [...ids];
-  next.splice(from, 1);
-  next.splice(to, 0, movingId);
+  if (aId === bId) return next;
+  const a = ids.indexOf(aId);
+  const b = ids.indexOf(bId);
+  // A member the list does not hold has no seat to swap — a drag that raced
+  // a deletion is a no-op, not a crash.
+  if (a === -1 || b === -1) return next;
+  next[a] = bId;
+  next[b] = aId;
   return next;
 }
 


### PR DESCRIPTION
## What

Fixes the Key Account Balances drag per the owner's report on v1 (#346): dragging one tile across others re-seated every tile it crossed, live — "it is too easy at the minute to move the wrong one".

Now a drag is a **swap, previewed, committed on release**:

- The hovered tile slips into the dragged tile's **original** seat; nobody else moves.
- The preview is computed fresh from the **pre-drag order** on every pointer move — a tile merely crossed springs back the moment the pointer moves on; hovers replace each other, they never stack.
- Nothing is **stored** until the button is released. `pointercancel` (a scroll winning the touch) reverts entirely and commits nothing.
- Alt+arrows keep their stepping behaviour, unchanged.

## How

- `swapPositions(preDragOrder, draggedId, hoveredId)` replaces `moveToPosition` in `src/utils/reorderList.ts` — pure, id-based, no-op on missing ids or self-hover.
- `ImprovedDashboard`: the drag ref carries `baseOrder` + `hoverId`; a `previewOrder` state feeds the rendered order; `persistSelection` runs only in `endTileDrag`.

## Verification

- `npm run typecheck:strict` ✅  `npm run lint` ✅
- `reorderList.test.ts` + `ImprovedDashboard.test.tsx`: **27 passed (27)** — including the pinned regression: previewing from the pre-drag order is not cumulative (a crossed tile's seat asserted untouched after the pointer moves on).
- Full pre-commit and pre-push gates green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
