### PR TITLE
feat(recurring): a renamed payee is one commitment, a marked payee is vouched, and the page moves under Plan

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -52,6 +52,7 @@ const Categorisation = lazyWithPreload(() => import(/* webpackChunkName: "catego
 const Investments = lazyWithPreload(() => import(/* webpackChunkName: "investments" */ './pages/Investments'));
 const Budget = lazyWithPreload(() => import(/* webpackChunkName: "budget", webpackPreload: true */ './pages/Budget'));
 const Calendar = lazyWithPreload(() => import(/* webpackChunkName: "calendar" */ './pages/Calendar'));
+const RecurringPayments = lazyWithPreload(() => import(/* webpackChunkName: "recurring-payments" */ './pages/RecurringPayments'));
 const ReportsHub = lazyWithPreload(() => import(/* webpackChunkName: "reports-hub" */ './pages/ReportsHub'));
 const CustomReports = lazyWithPreload(() => import(/* webpackChunkName: "custom-reports" */ './pages/CustomReports'));
 const SettingsPage = lazyWithPreload(() => import(/* webpackChunkName: "settings" */ './pages/Settings'));
@@ -253,6 +254,14 @@ function App(): React.JSX.Element {
                               <Calendar />
                             </ProtectedSuspense>
                           } />
+                          <Route path="recurring-payments" element={
+                            <ProtectedSuspense>
+                              <RecurringPayments />
+                            </ProtectedSuspense>
+                          } />
+                          {/* Its old gallery address — bookmarks and pinned
+                              links keep working after the move under Plan. */}
+                          <Route path="reports/recurring-commitments" element={<RedirectWithSearch to="/recurring-payments" />} />
                           <Route path="reports" element={
                             <ProtectedSuspense>
                               <ReportsHub />

--- a/src/components/EditTransactionModal.accountJump.test.tsx
+++ b/src/components/EditTransactionModal.accountJump.test.tsx
@@ -38,6 +38,14 @@ const mocks = vi.hoisted(() => ({
     setTransactionSplits: vi.fn(async () => ({ isSplit: false, splitCount: 0, amount: 0 })),
     linkTransferPair: vi.fn(async () => ({ a: {}, b: {} })),
     createTransferCounterpart: vi.fn(async () => ({ source: {}, counterpart: {} })),
+    // The recurring-verdict door (the modal's "This is a recurring payment"
+    // tick). Present in every mock of this context because the component reads
+    // it on every render: an omitted field is a mock claiming a context shape
+    // the app does not have.
+    suggestionDismissals: [],
+    suggestionDismissalsStatus: 'ready',
+    dismissSuggestion: vi.fn(async () => {}),
+    restoreSuggestion: vi.fn(async () => {}),
   },
 }));
 

--- a/src/components/EditTransactionModal.deleteConfirm.test.tsx
+++ b/src/components/EditTransactionModal.deleteConfirm.test.tsx
@@ -56,6 +56,14 @@ const mocks = vi.hoisted(() => ({
     setTransactionSplits: vi.fn(async () => ({ isSplit: false, splitCount: 0, amount: 0 })),
     linkTransferPair: vi.fn(async () => ({ a: {}, b: {} })),
     createTransferCounterpart: vi.fn(async () => ({ source: {}, counterpart: {} })),
+    // The recurring-verdict door (the modal's "This is a recurring payment"
+    // tick). Present in every mock of this context because the component reads
+    // it on every render: an omitted field is a mock claiming a context shape
+    // the app does not have.
+    suggestionDismissals: [],
+    suggestionDismissalsStatus: 'ready',
+    dismissSuggestion: vi.fn(async () => {}),
+    restoreSuggestion: vi.fn(async () => {}),
   },
 }));
 

--- a/src/components/EditTransactionModal.markRecurring.test.tsx
+++ b/src/components/EditTransactionModal.markRecurring.test.tsx
@@ -1,0 +1,225 @@
+/**
+ * "This is a recurring payment" — teaching the app by example.
+ *
+ * The owner's ask, 18 Aug: "the user can pick a transaction and label it
+ * 'recurring' and the system then smartly detects past payments of the same
+ * amount on a similar date the previous months with the same / similar payee
+ * name from the same account". This is that control, and the properties it
+ * has to hold are:
+ *
+ *  - it writes a verdict about the PATTERN, never a change to the row (the
+ *    detector reads the register and must stay the only thing that does);
+ *  - the key it writes is the key "What I'm committed to" and the calendar
+ *    read, so marking one payment and confirming a detection are one act;
+ *  - marking withdraws a standing "not recurring", so the stored state can
+ *    never hold both verdicts;
+ *  - it is absent on a transfer, matching the detector's own rule that a
+ *    standing order between your own accounts is not a commitment to anyone.
+ *
+ * Every name and figure below is invented: this repo is public.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import EditTransactionModal from './EditTransactionModal';
+import { recurringAnswerKey } from '../utils/suggestionDismissals';
+import { normalisePayeeKey } from '../utils/recurringDetection';
+import type { Account, SuggestionDismissal, Transaction } from '../types';
+
+const mocks = vi.hoisted(() => ({
+  app: {
+    accounts: [] as Account[],
+    transactions: [] as Transaction[],
+    categories: [] as unknown[],
+    getSubCategories: () => [],
+    getDetailCategories: () => [],
+    updateTransaction: vi.fn(async () => {}),
+    deleteTransaction: vi.fn(),
+    getTransactionSplits: vi.fn(async () => []),
+    setTransactionSplits: vi.fn(async () => ({ isSplit: false, splitCount: 0, amount: 0 })),
+    linkTransferPair: vi.fn(async () => ({ a: {}, b: {} })),
+    createTransferCounterpart: vi.fn(async () => ({ source: {}, counterpart: {} })),
+    suggestionDismissals: [] as SuggestionDismissal[],
+    suggestionDismissalsStatus: 'ready' as 'ready' | 'loading',
+    dismissSuggestion: vi.fn(async () => {}),
+    restoreSuggestion: vi.fn(async () => {}),
+  },
+}));
+
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual<typeof import('react-router-dom')>('react-router-dom');
+  return {
+    ...actual,
+    useNavigate: () => vi.fn(),
+    useLocation: () => ({ pathname: '/find', search: '', hash: '', state: null, key: 'test' }),
+  };
+});
+
+vi.mock('../contexts/AppContextSupabase', () => ({ useApp: () => mocks.app }));
+
+vi.mock('../contexts/ToastContext', () => ({
+  useToast: () => ({
+    showToast: vi.fn(),
+    showSuccess: vi.fn(),
+    showError: vi.fn(),
+    showWarning: vi.fn(),
+    showInfo: vi.fn(),
+    dismissToast: vi.fn(),
+  }),
+}));
+
+vi.mock('../hooks/useTransactionNotifications', () => ({
+  useTransactionNotifications: () => ({ addTransaction: vi.fn(async () => {}) }),
+}));
+
+vi.mock('../hooks/usePayeeMemory', () => ({
+  usePayeeMemory: () => ({ propagateCategory: vi.fn(async () => {}) }),
+}));
+
+vi.mock('./common/Modal', () => ({
+  Modal: ({ isOpen, children, title }: { isOpen: boolean; children: ReactNode; title: string }) =>
+    isOpen ? <div role="dialog" aria-label={title}>{children}</div> : null,
+  ModalBody: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  ModalFooter: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+}));
+
+vi.mock('./TagSelector', () => ({ default: () => <div data-testid="tag-selector" /> }));
+vi.mock('./MarkdownEditor', () => ({ default: () => <div data-testid="markdown-editor" /> }));
+vi.mock('./DocumentManager', () => ({ default: () => <div data-testid="document-manager" /> }));
+vi.mock('./CategoryCreationModal', () => ({ default: () => null }));
+
+const ACCOUNT_ID = '11111111-1111-4111-8111-111111111111';
+const TRANSACTION_ID = '22222222-2222-4222-8222-222222222222';
+
+const ACCOUNT: Account = {
+  id: ACCOUNT_ID,
+  name: 'Synthetic Current',
+  type: 'current',
+  balance: 500,
+  currency: 'GBP',
+  lastUpdated: new Date('2026-04-01'),
+  isActive: true,
+};
+
+const row = (over: Partial<Transaction> = {}): Transaction => ({
+  id: TRANSACTION_ID,
+  date: new Date('2026-04-02'),
+  description: 'ACME MAINTENANCE',
+  amount: -250,
+  type: 'expense',
+  category: 'det-maintenance',
+  accountId: ACCOUNT_ID,
+  cleared: false,
+  ...over,
+});
+
+/** The key the detector will compute for this row's pattern. */
+const PATTERN_KEY = recurringAnswerKey(
+  ACCOUNT_ID, 'out', normalisePayeeKey('ACME MAINTENANCE')
+);
+
+const verdict = (kind: 'recurring-confirmed' | 'recurring-not'): SuggestionDismissal => ({
+  id: `dis-${kind}`,
+  kind,
+  subjectKey: PATTERN_KEY,
+  subjectIds: [],
+  dismissedAt: new Date(),
+});
+
+const tick = (): HTMLInputElement =>
+  screen.getByLabelText(/This is a recurring payment/) as HTMLInputElement;
+
+describe('EditTransactionModal — mark a payment as recurring', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.app.accounts = [ACCOUNT];
+    mocks.app.transactions = [];
+    mocks.app.suggestionDismissals = [];
+    mocks.app.suggestionDismissalsStatus = 'ready';
+  });
+
+  it('records the verdict against the PATTERN and changes nothing about the row', async () => {
+    render(<EditTransactionModal isOpen onClose={vi.fn()} transaction={row()} />);
+
+    expect(tick().checked).toBe(false);
+    fireEvent.click(tick());
+
+    await waitFor(() => {
+      expect(mocks.app.dismissSuggestion).toHaveBeenCalledWith(
+        'recurring-confirmed', PATTERN_KEY, []
+      );
+    });
+    // The register is read by the detector, never written by it — and this
+    // control is on the detector's side of that line.
+    expect(mocks.app.updateTransaction).not.toHaveBeenCalled();
+    // The key is the one the report and the calendar compute, so one act is
+    // recorded in one place: an account segment a restore can remap, then the
+    // pattern segment.
+    expect(PATTERN_KEY).toMatch(/^account:.+\|recurring:out:/);
+  });
+
+  it('shows as marked when the pattern already carries the verdict, and unticking withdraws it', async () => {
+    mocks.app.suggestionDismissals = [verdict('recurring-confirmed')];
+    render(<EditTransactionModal isOpen onClose={vi.fn()} transaction={row()} />);
+
+    expect(tick().checked).toBe(true);
+    fireEvent.click(tick());
+
+    await waitFor(() => {
+      expect(mocks.app.restoreSuggestion).toHaveBeenCalledWith(
+        'recurring-confirmed', PATTERN_KEY
+      );
+    });
+    expect(mocks.app.dismissSuggestion).not.toHaveBeenCalled();
+  });
+
+  it('marking withdraws a standing "not recurring" first — never both verdicts at once', async () => {
+    mocks.app.suggestionDismissals = [verdict('recurring-not')];
+    render(<EditTransactionModal isOpen onClose={vi.fn()} transaction={row()} />);
+
+    expect(tick().checked).toBe(false);
+    fireEvent.click(tick());
+
+    await waitFor(() => {
+      expect(mocks.app.dismissSuggestion).toHaveBeenCalledWith(
+        'recurring-confirmed', PATTERN_KEY, []
+      );
+    });
+    expect(mocks.app.restoreSuggestion).toHaveBeenCalledWith('recurring-not', PATTERN_KEY);
+  });
+
+  it('says what ticking it will do, and then what it did', async () => {
+    render(<EditTransactionModal isOpen onClose={vi.fn()} transaction={row()} />);
+
+    // Consequence before the act…
+    expect(screen.getByText(/looks back over this payee’s payments/)).toBeInTheDocument();
+
+    mocks.app.suggestionDismissals = [verdict('recurring-confirmed')];
+    render(<EditTransactionModal isOpen onClose={vi.fn()} transaction={row()} />);
+
+    // …and after it, because "what did that do?" is the question a tick raises.
+    expect(screen.getAllByText(/even when the amount varies/).length).toBeGreaterThan(0);
+  });
+
+  it('is absent on a transfer — a standing order to your own savings is not a commitment', () => {
+    render(
+      <EditTransactionModal
+        isOpen
+        onClose={vi.fn()}
+        transaction={row({ type: 'transfer', category: 'transfer' })}
+      />
+    );
+
+    expect(screen.queryByLabelText(/This is a recurring payment/)).not.toBeInTheDocument();
+  });
+
+  it('waits for the verdicts to load rather than showing an empty tick', () => {
+    mocks.app.suggestionDismissalsStatus = 'loading';
+    render(<EditTransactionModal isOpen onClose={vi.fn()} transaction={row()} />);
+
+    // An unticked box while the answer is still loading would be a lie about
+    // what the user has already said.
+    expect(screen.queryByLabelText(/This is a recurring payment/)).not.toBeInTheDocument();
+  });
+});

--- a/src/components/EditTransactionModal.provenance.test.tsx
+++ b/src/components/EditTransactionModal.provenance.test.tsx
@@ -49,6 +49,14 @@ const mocks = vi.hoisted(() => ({
     setTransactionSplits: vi.fn(async () => ({ isSplit: false, splitCount: 0, amount: 0 })),
     linkTransferPair: vi.fn(async () => ({ a: {}, b: {} })),
     createTransferCounterpart: vi.fn(async () => ({ source: {}, counterpart: {} })),
+    // The recurring-verdict door (the modal's "This is a recurring payment"
+    // tick). Present in every mock of this context because the component reads
+    // it on every render: an omitted field is a mock claiming a context shape
+    // the app does not have.
+    suggestionDismissals: [],
+    suggestionDismissalsStatus: 'ready',
+    dismissSuggestion: vi.fn(async () => {}),
+    restoreSuggestion: vi.fn(async () => {}),
   },
 }));
 

--- a/src/components/EditTransactionModal.repoint.test.tsx
+++ b/src/components/EditTransactionModal.repoint.test.tsx
@@ -55,6 +55,14 @@ const mocks = vi.hoisted(() => ({
     linkTransferPair: vi.fn(async () => ({ a: {}, b: {} })),
     createTransferCounterpart: vi.fn(async () => ({ source: {}, counterpart: {} })),
     repointTransfer: vi.fn(async () => ({ source: {}, counterpart: {}, displaced: { kind: 'moved', fromAccountId: ids.ACC_B } })),
+    // The recurring-verdict door (the modal's "This is a recurring payment"
+    // tick). Present in every mock of this context because the component reads
+    // it on every render: an omitted field is a mock claiming a context shape
+    // the app does not have.
+    suggestionDismissals: [],
+    suggestionDismissalsStatus: 'ready',
+    dismissSuggestion: vi.fn(async () => {}),
+    restoreSuggestion: vi.fn(async () => {}),
   },
 }));
 

--- a/src/components/EditTransactionModal.review.test.tsx
+++ b/src/components/EditTransactionModal.review.test.tsx
@@ -43,6 +43,14 @@ const mocks = vi.hoisted(() => ({
     setTransactionSplits: vi.fn(async () => ({ isSplit: false, splitCount: 0, amount: 0 })),
     linkTransferPair: vi.fn(async () => ({ a: {}, b: {} })),
     createTransferCounterpart: vi.fn(async () => ({ source: {}, counterpart: {} })),
+    // The recurring-verdict door (the modal's "This is a recurring payment"
+    // tick). Present in every mock of this context because the component reads
+    // it on every render: an omitted field is a mock claiming a context shape
+    // the app does not have.
+    suggestionDismissals: [],
+    suggestionDismissalsStatus: 'ready',
+    dismissSuggestion: vi.fn(async () => {}),
+    restoreSuggestion: vi.fn(async () => {}),
   },
 }));
 

--- a/src/components/EditTransactionModal.splitLeg.test.tsx
+++ b/src/components/EditTransactionModal.splitLeg.test.tsx
@@ -99,6 +99,14 @@ const mocks = vi.hoisted(() => ({
     })),
     linkTransferPair: vi.fn(),
     createTransferCounterpart: vi.fn(),
+    // The recurring-verdict door (the modal's "This is a recurring payment"
+    // tick). Present in every mock of this context because the component reads
+    // it on every render: an omitted field is a mock claiming a context shape
+    // the app does not have.
+    suggestionDismissals: [],
+    suggestionDismissalsStatus: 'ready',
+    dismissSuggestion: vi.fn(async () => {}),
+    restoreSuggestion: vi.fn(async () => {}),
   },
 }));
 

--- a/src/components/EditTransactionModal.test.tsx
+++ b/src/components/EditTransactionModal.test.tsx
@@ -114,6 +114,8 @@ vi.mock('../services/validationService', () => ({
 // module, so its glyphs (calendar + the calendar's own chevrons) belong here too.
 vi.mock('../components/icons', () => ({
   CalendarIcon: () => <div data-testid="calendar-icon">📅</div>,
+  // The recurring-payment tick's glyph, in the Status column.
+  ClockIcon: () => <div data-testid="clock-icon">🕐</div>,
   ChevronLeftIcon: () => <div data-testid="chevron-left-icon">‹</div>,
   ChevronRightIcon: () => <div data-testid="chevron-right-icon">›</div>,
   // The account combobox's own chevron.

--- a/src/components/EditTransactionModal.transferFiling.test.tsx
+++ b/src/components/EditTransactionModal.transferFiling.test.tsx
@@ -59,6 +59,14 @@ const mocks = vi.hoisted(() => ({
     linkTransferPair: vi.fn(async () => ({ a: {}, b: {} })),
     createTransferCounterpart: vi.fn(async () => ({ source: {}, counterpart: {} })),
     repointTransfer: vi.fn(async () => ({})),
+    // The recurring-verdict door (the modal's "This is a recurring payment"
+    // tick). Present in every mock of this context because the component reads
+    // it on every render: an omitted field is a mock claiming a context shape
+    // the app does not have.
+    suggestionDismissals: [],
+    suggestionDismissalsStatus: 'ready',
+    dismissSuggestion: vi.fn(async () => {}),
+    restoreSuggestion: vi.fn(async () => {}),
   },
 }));
 

--- a/src/components/EditTransactionModal.transferJump.test.tsx
+++ b/src/components/EditTransactionModal.transferJump.test.tsx
@@ -36,6 +36,14 @@ const mocks = vi.hoisted(() => ({
     setTransactionSplits: vi.fn(async () => ({ isSplit: false, splitCount: 0, amount: 0 })),
     linkTransferPair: vi.fn(async () => ({ a: {}, b: {} })),
     createTransferCounterpart: vi.fn(async () => ({ source: {}, counterpart: {} })),
+    // The recurring-verdict door (the modal's "This is a recurring payment"
+    // tick). Present in every mock of this context because the component reads
+    // it on every render: an omitted field is a mock claiming a context shape
+    // the app does not have.
+    suggestionDismissals: [],
+    suggestionDismissalsStatus: 'ready',
+    dismissSuggestion: vi.fn(async () => {}),
+    restoreSuggestion: vi.fn(async () => {}),
   },
 }));
 

--- a/src/components/EditTransactionModal.tsx
+++ b/src/components/EditTransactionModal.tsx
@@ -3,7 +3,7 @@ import { useNavigate, useLocation } from 'react-router-dom';
 import { useApp } from '../contexts/AppContextSupabase';
 import { useTransactionNotifications } from '../hooks/useTransactionNotifications';
 import { usePayeeMemory } from '../hooks/usePayeeMemory';
-import { CalendarIcon, TagIcon, FileTextIcon, CheckIcon2, LinkIcon, PlusIcon, HashIcon, WalletIcon, ArrowRightLeftIcon, ArrowUpRightIcon, BanknoteIcon, PaperclipIcon, XIcon } from '../components/icons';
+import { CalendarIcon, ClockIcon, TagIcon, FileTextIcon, CheckIcon2, LinkIcon, PlusIcon, HashIcon, WalletIcon, ArrowRightLeftIcon, ArrowUpRightIcon, BanknoteIcon, PaperclipIcon, XIcon } from '../components/icons';
 import type { Transaction, TransferDisplacedDisposition } from '../types';
 import {
   splitRemainder,
@@ -24,6 +24,8 @@ import { describeCounterpartOrigin } from '../utils/transferCounterpartOrigin';
 import { describeDeleteStranding, resolveTransferOtherSide } from '../utils/transferOtherSide';
 import { deleteTransferPair } from '../utils/transferSurvivorRelease';
 import { buildTransactionRegisterPath } from '../utils/transactionDeepLink';
+import { dismissedKeys, recurringAnswerKey } from '../utils/suggestionDismissals';
+import { normalisePayeeKey, recurringDirectionOf } from '../utils/recurringDetection';
 import AccountSelector from './common/AccountSelector';
 import DatePicker from './common/DatePicker';
 import { useToast } from '../contexts/ToastContext';
@@ -83,7 +85,7 @@ interface FormData {
 }
 
 export default function EditTransactionModal({ isOpen, onClose, transaction, defaultAccountId, onSaveAndNext, onSaveAndPrevious, hideJumpToAccountId }: EditTransactionModalProps): React.JSX.Element {
-  const { accounts, categories, transactions, updateTransaction, deleteTransaction, getTransactionSplits, setTransactionSplits, linkTransferPair, createTransferCounterpart, repointTransfer } = useApp();
+  const { accounts, categories, transactions, updateTransaction, deleteTransaction, getTransactionSplits, setTransactionSplits, linkTransferPair, createTransferCounterpart, repointTransfer, suggestionDismissals, suggestionDismissalsStatus, dismissSuggestion, restoreSuggestion } = useApp();
   const { showSuccess, showError, showWarning } = useToast();
   const { addTransaction } = useTransactionNotifications();
   const { propagateCategory } = usePayeeMemory();
@@ -92,6 +94,8 @@ export default function EditTransactionModal({ isOpen, onClose, transaction, def
   const logger = useMemo(() => createScopedLogger('EditTransactionModal'), []);
 
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
+  /** The recurring verdict write in flight, so a double-click cannot record twice. */
+  const [savingRecurring, setSavingRecurring] = useState(false);
   const [showCategoryModal, setShowCategoryModal] = useState(false);
   const [formattedAmount, setFormattedAmount] = useState('');
   // Money-style cross-type categorization: browse the OTHER direction's
@@ -875,6 +879,61 @@ export default function EditTransactionModal({ isOpen, onClose, transaction, def
   }, [transaction, accounts, hideJumpToAccountId]);
 
   /**
+   * TEACH THE APP BY EXAMPLE (owner, 18 Aug: "the user can pick a transaction
+   * and label it 'recurring' and the system then smartly detects past payments
+   * of the same amount on a similar date … from the same account").
+   *
+   * The verdict is stored against the PAYEE PATTERN this row belongs to — the
+   * same key "What I'm committed to" writes, so marking one payment and
+   * confirming the detection are the same act recorded in the same place. Two
+   * consequences follow immediately, both on the detection side: the payee is
+   * read leniently (every payment counts, amounts need not repeat), and the
+   * pattern may feed the calendar's forward view.
+   *
+   * Read from the STORED row, like the transfer and statement facts beside it:
+   * an account half-changed in the form above is not what this row is filed
+   * under yet. Transfers are excluded — a standing order between the user's own
+   * accounts is a rhythm but not a commitment to anyone, which is the same rule
+   * the detector applies.
+   */
+  const recurringMark = useMemo(() => {
+    if (!transaction) return null;
+    if (transaction.type !== 'income' && transaction.type !== 'expense') return null;
+    const direction = recurringDirectionOf(transaction.amount);
+    const key = recurringAnswerKey(
+      transaction.accountId, direction, normalisePayeeKey(transaction.description)
+    );
+    return {
+      key,
+      marked: dismissedKeys(suggestionDismissals, 'recurring-confirmed').has(key),
+      // A row the user called a coincidence: marking it recurring must withdraw
+      // that first, so the stored state can never hold both verdicts.
+      standingRefusal: dismissedKeys(suggestionDismissals, 'recurring-not').has(key) ? key : null,
+    };
+  }, [transaction, suggestionDismissals]);
+
+  const toggleRecurringMark = useCallback(async (): Promise<void> => {
+    if (!recurringMark) return;
+    setSavingRecurring(true);
+    try {
+      if (recurringMark.marked) {
+        await restoreSuggestion('recurring-confirmed', recurringMark.key);
+        showSuccess('No longer marked as recurring');
+      } else {
+        if (recurringMark.standingRefusal) {
+          await restoreSuggestion('recurring-not', recurringMark.standingRefusal);
+        }
+        await dismissSuggestion('recurring-confirmed', recurringMark.key, []);
+        showSuccess('Marked as recurring — this payee now shows under Plan → Recurring Payments');
+      }
+    } catch (error) {
+      showError(error);
+    } finally {
+      setSavingRecurring(false);
+    }
+  }, [recurringMark, dismissSuggestion, restoreSuggestion, showSuccess, showError]);
+
+  /**
    * Is the category in the picker still only the app's guess?
    *
    * Read from the STORED row, exactly as the quick-edit panel does — provenance
@@ -1582,6 +1641,37 @@ export default function EditTransactionModal({ isOpen, onClose, transaction, def
                 <div className="flex items-center gap-2 text-sm text-blue-700 dark:text-blue-400">
                   <LinkIcon size={16} />
                   <span>Reconciled with transaction ID: {transaction.reconciledWith}</span>
+                </div>
+              )}
+
+              {/* THE FOURTH THING TRUE ABOUT THIS ROW: is its payee a
+                  commitment? A checkbox rather than a button because that is
+                  what it is — a fact the user asserts, sitting with the other
+                  facts. It writes no transaction: the verdict is stored beside
+                  the detections, and the row itself is untouched. */}
+              {recurringMark && suggestionDismissalsStatus === 'ready' && (
+                <div>
+                  <label className="flex items-center gap-2">
+                    <input
+                      type="checkbox"
+                      checked={recurringMark.marked}
+                      disabled={savingRecurring}
+                      onChange={() => void toggleRecurringMark()}
+                      className="rounded border-gray-300 dark:border-gray-600 disabled:opacity-50"
+                    />
+                    <ClockIcon size={16} className="text-blue-600 dark:text-blue-400" />
+                    <span className="text-sm text-gray-700 dark:text-gray-300">
+                      This is a recurring payment
+                    </span>
+                  </label>
+                  {/* Say the consequence, not the mechanism — and say it in
+                      both states, because "what did that do?" is the question
+                      a tick like this raises. */}
+                  <p className="text-xs text-gray-500 dark:text-gray-400 mt-1 ml-6">
+                    {recurringMark.marked
+                      ? 'The app reads this payee’s whole history as a commitment, even when the amount varies, and it can appear in the calendar before it falls due.'
+                      : 'Tick this and the app looks back over this payee’s payments from this account, works out the rhythm, and shows what is due next.'}
+                  </p>
                 </div>
               )}
             </div>

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -21,7 +21,7 @@ import {
   RealtimeDot,
   type GlobalSearchHandle
 } from '@chrome';
-import { HomeIcon, CreditCardIcon, WalletIcon, TrendingUpIcon, SettingsIcon, MenuIcon, XIcon, ArrowRightLeftIcon, BarChart3Icon, ChevronRightIcon, DatabaseIcon, TagIcon, Settings2Icon, TargetIcon, HashIcon, SearchIcon, PieChartIcon, ShieldIcon, UploadIcon, DownloadIcon, FolderIcon, BankIcon, CalendarIcon, UsersIcon } from '../components/icons';
+import { HomeIcon, CreditCardIcon, WalletIcon, TrendingUpIcon, SettingsIcon, MenuIcon, XIcon, ArrowRightLeftIcon, BarChart3Icon, ChevronRightIcon, ClockIcon, DatabaseIcon, TagIcon, Settings2Icon, TargetIcon, HashIcon, SearchIcon, PieChartIcon, ShieldIcon, UploadIcon, DownloadIcon, FolderIcon, BankIcon, CalendarIcon, UsersIcon } from '../components/icons';
 import { SidebarLink, TopNavItem, TopNavDropdown } from './layout/NavComponents';
 import { usePreferences } from '../contexts/PreferencesContext';
 import { PageTransition, NavigationProgress } from './layout/SimplePageTransition';
@@ -392,8 +392,14 @@ export default function Layout(): React.JSX.Element {
               items={[
                 { to: '/budget', icon: BarChart3Icon, label: 'Budget' },
                 { to: '/calendar', icon: CalendarIcon, label: 'Calendar' },
+                // Recurring Payments is Plan's third page, not a report: the
+                // verdicts given there are what let a pattern reach the
+                // calendar and the forecast (owner's ruling, 18 Aug). The MENU
+                // says what the page is; the page's own heading keeps the
+                // question it answers — "What I'm committed to".
+                { to: '/recurring-payments', icon: ClockIcon, label: 'Recurring Payments' },
               ]}
-              activePaths={['/budget', '/calendar']}
+              activePaths={['/budget', '/calendar', '/recurring-payments']}
               openDropdown={openDropdown}
               setOpenDropdown={setOpenDropdown}
             />
@@ -648,11 +654,11 @@ export default function Layout(): React.JSX.Element {
                   )}
                 </div>
 
-                {/* Plan — Budget and Calendar, mirroring the desktop menu.
-                    This group used to be "deliberately absent" as desk work;
-                    the owner overruled it (17 Aug), and the Calendar now
-                    carries the due-next panel, which is exactly a thing to
-                    check from a phone. */}
+                {/* Plan — Budget, Calendar and Recurring Payments, mirroring
+                    the desktop menu. This group used to be "deliberately
+                    absent" as desk work; the owner overruled it (17 Aug), and
+                    the Calendar now carries the due-next panel, which is
+                    exactly a thing to check from a phone. */}
                 <div>
                   <button
                     type="button"
@@ -671,6 +677,7 @@ export default function Layout(): React.JSX.Element {
                     <div className="mt-1 space-y-1">
                       <SidebarLink to="/budget" icon={BarChart3Icon} label="Budget" isCollapsed={false} isSubItem={true} onNavigate={toggleMobileMenu} />
                       <SidebarLink to="/calendar" icon={CalendarIcon} label="Calendar" isCollapsed={false} isSubItem={true} onNavigate={toggleMobileMenu} />
+                      <SidebarLink to="/recurring-payments" icon={ClockIcon} label="Recurring Payments" isCollapsed={false} isSubItem={true} onNavigate={toggleMobileMenu} />
                     </div>
                   )}
                 </div>

--- a/src/components/__tests__/Layout.test.tsx
+++ b/src/components/__tests__/Layout.test.tsx
@@ -212,11 +212,25 @@ describe('Layout — the Plan menu and split triggers', () => {
   it('groups the forward-looking pages under Plan, not as top-level items', () => {
     renderWithProviders(<Layout />);
 
-    // Plan's label navigates to Budget, its menu holds both.
+    // Plan's label navigates to Budget, its menu holds all three.
     expect(navLink('Plan')).toHaveAttribute('href', '/budget');
     fireEvent.click(menuButton('Plan'));
     expect(navLink('Budget')).toHaveAttribute('href', '/budget');
     expect(navLink('Calendar')).toHaveAttribute('href', '/calendar');
+    // Recurring Payments joined Plan on 18 Aug, out of the Reports gallery:
+    // the verdicts given there are what let a pattern reach the calendar and
+    // the forecast, which makes it forward-looking work rather than a report.
+    expect(navLink('Recurring Payments')).toHaveAttribute('href', '/recurring-payments');
+  });
+
+  it('orders Plan as Budget, Calendar, Recurring Payments', () => {
+    renderWithProviders(<Layout />);
+
+    expect(openMenuItems('Plan')).toEqual([
+      'Budget',
+      'Calendar',
+      'Recurring Payments',
+    ]);
   });
 
   it('offers Goals nowhere at all — the feature is gone', () => {

--- a/src/desktop/MountedLedger.tsx
+++ b/src/desktop/MountedLedger.tsx
@@ -74,6 +74,7 @@ const Reconciliation = lazyWithPreload(() => import(/* webpackChunkName: "reconc
 const Categorisation = lazyWithPreload(() => import(/* webpackChunkName: "categorisation" */ '../pages/Categorisation'));
 const Budget = lazyWithPreload(() => import(/* webpackChunkName: "budget" */ '../pages/Budget'));
 const Calendar = lazyWithPreload(() => import(/* webpackChunkName: "calendar" */ '../pages/Calendar'));
+const RecurringPayments = lazyWithPreload(() => import(/* webpackChunkName: "recurring-payments" */ '../pages/RecurringPayments'));
 const ReportsHub = lazyWithPreload(() => import(/* webpackChunkName: "reports-hub" */ '../pages/ReportsHub'));
 // Mounted rather than excluded as of the gating decision `routes.ts` records:
 // the local edition is a one-time purchase and its buyer is on the only tier
@@ -235,6 +236,8 @@ export default function MountedLedger(): ReactElement {
     categorisation: page(<Categorisation />),
     budget: page(<Budget />),
     calendar: page(<Calendar />),
+    'recurring-payments': page(<RecurringPayments />),
+    'reports/recurring-commitments': <RedirectWithSearch to="/recurring-payments" />,
     reports: page(<ReportsHub />),
     'reports/:reportId': page(<ReportsHub />),
     'custom-reports': page(<CustomReports />),

--- a/src/desktop/__tests__/desktopRouter.test.tsx
+++ b/src/desktop/__tests__/desktopRouter.test.tsx
@@ -174,7 +174,15 @@ describe('the desktop router', () => {
     // short version is that the premise ("a device edition has no plans") was
     // wrong rather than the reasoning, because a one-time purchase IS a plan and
     // its buyer is on it.
-    expect(mounted.length).toBe(40);
+    //
+    // FORTY-TWO now, and the two arrived together on 18 Aug because a page MOVED
+    // rather than because one was added: "What I'm committed to" left the
+    // reports gallery for its own address under Plan (`recurring-payments`),
+    // and its old gallery address stayed behind as a redirect so a pin made
+    // before the move still lands. Both are as local as the register they read
+    // — detection reads the open file's rows, the verdicts live in the file's
+    // own `suggestion_dismissals`.
+    expect(mounted.length).toBe(42);
 
     // EMPTY, and the list is kept rather than deleted — `routes.ts` says why:
     // this is one of three ANSWERS a route can have, not an exception to a rule,

--- a/src/desktop/routes.ts
+++ b/src/desktop/routes.ts
@@ -181,6 +181,13 @@ export const DESKTOP_ROUTES = [
   { path: 'categorisation', at: 'categorisation', title: 'Categorise' },
   { path: 'budget', at: 'budget', title: 'Budget' },
   { path: 'calendar', at: 'calendar', title: 'Calendar' },
+  // Plan's third page. Detection reads the open ledger's own rows and the
+  // verdicts live in `suggestion_dismissals`, which the file holds — so this
+  // is as local as the register it reads.
+  { path: 'recurring-payments', at: 'recurring-payments', title: 'Recurring payments' },
+  // Its old gallery address, kept as a redirect in both editions so a pin or
+  // bookmark made before the move under Plan still lands somewhere.
+  { path: 'reports/recurring-commitments', at: 'reports/recurring-commitments', title: 'Recurring payments' },
   { path: 'reports', at: 'reports', title: 'Reports' },
   { path: 'reports/:reportId', at: 'reports/:reportId', title: 'Reports' },
   { path: 'custom-reports', at: 'custom-reports', title: 'Custom reports' },

--- a/src/pages/Calendar.tsx
+++ b/src/pages/Calendar.tsx
@@ -166,8 +166,15 @@ export default function Calendar() {
    */
   const confirmedPatterns = useMemo(() => {
     const confirmed = dismissedKeys(suggestionDismissals, 'recurring-confirmed');
-    return detectRecurring(transactions, new Date()).filter(
-      d => !d.stopped && confirmed.has(recurringAnswerKey(d.accountId, d.direction, d.payeeKey))
+    const isVouched = (accountId: string, direction: 'in' | 'out', payeeKey: string): boolean =>
+      confirmed.has(recurringAnswerKey(accountId, direction, payeeKey));
+    // The verdicts are handed to detection as well as applied after it: a
+    // vouched payee is read leniently (its amounts need not repeat), which is
+    // the whole point of marking a variable commitment recurring. Matched
+    // across every label the pattern has worn, so a Confirm given before the
+    // bank renamed the payee still reaches this calendar.
+    return detectRecurring(transactions, new Date(), { isVouched }).filter(
+      d => !d.stopped && d.payeeKeys.some(payee => isVouched(d.accountId, d.direction, payee))
     );
   }, [transactions, suggestionDismissals]);
 
@@ -290,7 +297,7 @@ export default function Calendar() {
           <span className="text-xs text-gray-400 dark:text-gray-500">
             Only patterns you have confirmed on{' '}
             <Link
-              to={preserveDemoParam('/reports/recurring-commitments', location.search)}
+              to={preserveDemoParam('/recurring-payments', location.search)}
               className="text-primary hover:underline"
             >
               What I&rsquo;m committed to
@@ -299,8 +306,16 @@ export default function Calendar() {
         </div>
         {dueNext.length === 0 ? (
           <p className="mt-1 text-sm text-gray-500 dark:text-gray-400">
-            Nothing confirmed yet — recurring payments you confirm on that
-            report appear here before they fall due.
+            Nothing confirmed yet — open{' '}
+            <Link
+              to={preserveDemoParam('/recurring-payments', location.search)}
+              className="text-primary hover:underline"
+            >
+              Recurring Payments
+            </Link>
+            {' '}under Plan and confirm a pattern: it appears here before it
+            falls due. You can also mark any payment in a register as
+            recurring.
           </p>
         ) : (
           <>

--- a/src/pages/RecurringPayments.tsx
+++ b/src/pages/RecurringPayments.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import PageWrapper from '../components/PageWrapper';
+import RecurringCommitmentsReport from './reports/RecurringCommitmentsReport';
+
+/**
+ * Plan → Recurring Payments (owner's ruling, 18 Aug: the MENU says what the
+ * page is; the HEADING keeps the question the page answers).
+ *
+ * This used to be a Reports gallery entry. It moved out because it is not a
+ * read-out: confirming patterns here is what feeds the calendar's forward
+ * view and, next, the forecast — which makes it a working surface among the
+ * forward-looking pages, beside Budget and Calendar. The old address,
+ * /reports/recurring-commitments, redirects here so a bookmark or a pinned
+ * link keeps working.
+ */
+export default function RecurringPayments(): React.JSX.Element {
+  return (
+    <PageWrapper title="What I'm committed to">
+      <RecurringCommitmentsReport />
+    </PageWrapper>
+  );
+}

--- a/src/pages/__tests__/Calendar.test.tsx
+++ b/src/pages/__tests__/Calendar.test.tsx
@@ -55,8 +55,11 @@ describe('Calendar', () => {
     // projecting the app's unconfirmed opinions onto future days (§5).
     expect(screen.getByText('Due in the next 30 days')).toBeInTheDocument();
     expect(screen.getByText(/Nothing confirmed yet/)).toBeInTheDocument();
+    // Its own page under Plan since 18 Aug, not a report in the gallery.
     expect(screen.getByRole('link', { name: /What I’m committed to/ }))
-      .toHaveAttribute('href', '/reports/recurring-commitments');
+      .toHaveAttribute('href', '/recurring-payments');
+    expect(screen.getByRole('link', { name: 'Recurring Payments' }))
+      .toHaveAttribute('href', '/recurring-payments');
   });
 
   it('renders day headers', () => {

--- a/src/pages/__tests__/ReportsHub.test.tsx
+++ b/src/pages/__tests__/ReportsHub.test.tsx
@@ -65,7 +65,6 @@ describe('ReportsHub gallery', () => {
       'Spending by category',
       'Income and spending over time',
       'Spending by payee',
-      'What I’m committed to',
       'This period vs last',
     ]) {
       expect(screen.getByText(title)).toBeInTheDocument();
@@ -82,7 +81,6 @@ describe('ReportsHub gallery', () => {
       '/reports/spending-by-category',
       '/reports/income-and-spending-over-time',
       '/reports/spending-by-payee',
-      '/reports/recurring-commitments',
       '/reports/period-comparison',
       '/reports/custom-reports',
     ]);
@@ -257,7 +255,10 @@ describe('ReportsHub gallery', () => {
     ['spending-by-category', 'Where the money went'],
     ['income-and-spending-over-time', 'Income against spending'],
     ['spending-by-payee', 'Biggest payees'],
-    ['recurring-commitments', 'Committed each year'],
+    // "What I'm committed to" is NOT here: it moved out of the gallery to its
+    // own page under Plan (pages/RecurringPayments) on 18 Aug, because
+    // confirming a pattern there feeds the calendar and the forecast — a
+    // working surface, not a report to read. Its own suites cover it.
     ['period-comparison', 'Biggest movers'],
   ])('renders the %s report', async (id, heading) => {
     renderHub(`/reports/${id}`);

--- a/src/pages/reports/RecurringCommitmentsReport.tsx
+++ b/src/pages/reports/RecurringCommitmentsReport.tsx
@@ -7,6 +7,7 @@ import { toDecimal, type DecimalInstance } from '../../utils/decimal';
 import { getDateLocale } from '../../utils/dateFormatter';
 import { preserveDemoParam } from '../../utils/navigation';
 import { dismissedKeys, recurringAnswerKey } from '../../utils/suggestionDismissals';
+import { SearchIcon } from '../../components/icons';
 import type { RecurringAnswerKind } from '../../types';
 import {
   detectRecurring,
@@ -24,24 +25,32 @@ import {
  * ("what is due next?") — designed for the first, with the second falling
  * out of it.
  *
+ * Lives under PLAN as its own page (owner's ruling, 18 Aug — the nav says
+ * "Recurring Payments", the heading keeps the question), not in the Reports
+ * gallery: confirming patterns here is what feeds the calendar and the
+ * forecast, which makes it a working surface rather than a read-out.
+ *
  * The design rules this page lives under, all from the handover:
  *
  * - A detection is an INFERENCE and carries its evidence in its resting
  *   state (§2): the payment count, the span, the most recent date and the
- *   next expected ARE the confidence. No percentages, ever.
+ *   next expected ARE the confidence. No percentages, ever. A stitched
+ *   pattern names its former labels; a vouched pattern says the user's
+ *   judgment is what admitted it.
  * - The number that lands is the ANNUAL equivalent (§3) — £14.99 a month is
  *   invisible; £179.88 a year is a decision.
- * - Grouped by CADENCE, not category (§4): cadence is what determines
- *   commitment. One annualisation provenance line under the headline.
+ * - Grouped by CADENCE by default (§4); the user can regroup by institution
+ *   (the Accounts page's idiom), search, and re-sort — navigation, never a
+ *   change to what is claimed.
  * - A price change is a DIRECTION and may wear the hues; the magnitudes
  *   stay neutral (§3.1).
  * - Stopped patterns are a band, never a silent deletion (§3.2).
- * - Read-only: this surface reads the register and never writes to it.
- *   Confirm / Not-recurring is the next slice (§5, §8 step 2).
+ * - Read-only over the register: verdicts live beside the detections
+ *   (suggestion dismissals), never on the rows they were read from.
  *
- * No period picker (usesPeriod: false in the registry): a rhythm needs the
- * whole history to be seen, and a window that hides half the payments would
- * weaken every evidence line on the page. Said on screen.
+ * No period picker: a rhythm needs the whole history to be seen, and a
+ * window that hides half the payments would weaken every evidence line on
+ * the page. Said on screen.
  */
 
 const CADENCE_BANDS: ReadonlyArray<{ cadence: RecurringCadence; title: string }> = [
@@ -50,6 +59,11 @@ const CADENCE_BANDS: ReadonlyArray<{ cadence: RecurringCadence; title: string }>
   { cadence: 'annual', title: 'Annual' },
   { cadence: 'irregular', title: 'Irregular' },
 ];
+
+type SortBy = 'largest' | 'az' | 'payment';
+type GroupBy = 'cadence' | 'institution';
+
+const NO_INSTITUTION = 'No institution';
 
 const monthYear = (date: Date): string =>
   date.toLocaleDateString(getDateLocale(), { month: 'short', year: 'numeric' });
@@ -71,15 +85,9 @@ export default function RecurringCommitmentsReport(): React.JSX.Element {
     () => new Map(accounts.map(a => [a.id, a.name])),
     [accounts]
   );
-
-  /**
-   * Outgoing only: this page answers "what am I committed to", and a
-   * commitment is money out. Recurring income (a salary) is detected too,
-   * but belongs to the calendar and the forecast, not the audit.
-   */
-  const detections = useMemo(
-    () => detectRecurring(transactions, new Date()).filter(d => d.direction === 'out'),
-    [transactions]
+  const accountInstitution = useMemo(
+    () => new Map(accounts.map(a => [a.id, a.institution?.trim() || null])),
+    [accounts]
   );
 
   /**
@@ -97,8 +105,42 @@ export default function RecurringCommitmentsReport(): React.JSX.Element {
     () => dismissedKeys(suggestionDismissals, 'recurring-not'),
     [suggestionDismissals]
   );
+
+  /**
+   * Outgoing only: this page answers "what am I committed to", and a
+   * commitment is money out. Recurring income (a salary) is detected too,
+   * but belongs to the calendar and the forecast, not the audit.
+   *
+   * The confirmed verdicts feed BACK into detection: a payee the user has
+   * vouched for is read leniently (every payment counts, two are enough),
+   * so confirming is also what keeps a variable commitment on the page.
+   */
+  const detections = useMemo(
+    () =>
+      detectRecurring(transactions, new Date(), {
+        isVouched: (accountId, direction, payeeKey) =>
+          confirmedKeys.has(recurringAnswerKey(accountId, direction, payeeKey)),
+      }).filter(d => d.direction === 'out'),
+    [transactions, confirmedKeys]
+  );
+
+  /** Where a NEW verdict is stored: always the current label's key. */
   const answerKeyOf = (d: RecurringDetection): string =>
     recurringAnswerKey(d.accountId, d.direction, d.payeeKey);
+
+  /**
+   * Where a STANDING verdict actually lives — possibly under a label the
+   * bank has since renamed away. A Confirm given before the rename must
+   * still be found, and its Undo must delete the row that exists rather
+   * than a row that never did.
+   */
+  const storedKeyOf = (d: RecurringDetection, keys: Set<string>): string | null => {
+    for (const payee of d.payeeKeys) {
+      const key = recurringAnswerKey(d.accountId, d.direction, payee);
+      if (keys.has(key)) return key;
+    }
+    return null;
+  };
 
   // Which write is in flight, so a double-click cannot record twice and the
   // pressed control is the one that shows it is busy.
@@ -112,8 +154,11 @@ export default function RecurringCommitmentsReport(): React.JSX.Element {
     try {
       // One verdict at a time: giving one answer withdraws the other, so the
       // stored state can never say "confirmed AND a coincidence".
-      if ((opposite === 'recurring-confirmed' ? confirmedKeys : notRecurringKeys).has(key)) {
-        await restoreSuggestion(opposite, key);
+      const standingOpposite = storedKeyOf(
+        d, opposite === 'recurring-confirmed' ? confirmedKeys : notRecurringKeys
+      );
+      if (standingOpposite) {
+        await restoreSuggestion(opposite, standingOpposite);
       }
       await dismissSuggestion(kind, key, []);
     } catch (error) {
@@ -124,10 +169,12 @@ export default function RecurringCommitmentsReport(): React.JSX.Element {
   };
 
   const withdrawVerdict = async (d: RecurringDetection, kind: RecurringAnswerKind): Promise<void> => {
-    const key = answerKeyOf(d);
-    setSavingKey(key);
+    const stored = storedKeyOf(
+      d, kind === 'recurring-confirmed' ? confirmedKeys : notRecurringKeys
+    ) ?? answerKeyOf(d);
+    setSavingKey(answerKeyOf(d));
     try {
-      await restoreSuggestion(kind, key);
+      await restoreSuggestion(kind, stored);
     } catch (error) {
       showError(error);
     } finally {
@@ -140,18 +187,78 @@ export default function RecurringCommitmentsReport(): React.JSX.Element {
   // A pattern the user has called a coincidence leaves the audit — but never
   // the page (§5: a mis-tap must be recoverable, and the app must not be
   // seen to hide evidence). It moves to the collapsed band at the foot.
-  const dismissed = detections.filter(d => notRecurringKeys.has(answerKeyOf(d)));
-  const considered = detections.filter(d => !notRecurringKeys.has(answerKeyOf(d)));
+  const dismissed = detections.filter(d => storedKeyOf(d, notRecurringKeys) !== null);
+  const considered = detections.filter(d => storedKeyOf(d, notRecurringKeys) === null);
   const active = considered.filter(d => !d.stopped);
   const stopped = considered.filter(d => d.stopped);
+
+  /**
+   * NAVIGATION (owner, 18 Aug): search, sort, and the Accounts page's
+   * institution grouping. These change how the page is walked, never what
+   * it claims — the headline total stays the whole ledger's, and anything
+   * a search hides is counted out loud rather than silently gone.
+   */
+  const [query, setQuery] = useState('');
+  const [sortBy, setSortBy] = useState<SortBy>('largest');
+  const [groupBy, setGroupBy] = useState<GroupBy>('cadence');
+
+  const trimmedQuery = query.trim().toLowerCase();
+  const matchesQuery = (d: RecurringDetection): boolean => {
+    if (!trimmedQuery) return true;
+    return (
+      d.description.toLowerCase().includes(trimmedQuery) ||
+      d.formerLabels.some(label => label.toLowerCase().includes(trimmedQuery)) ||
+      (accountName.get(d.accountId) ?? '').toLowerCase().includes(trimmedQuery) ||
+      (accountInstitution.get(d.accountId) ?? '').toLowerCase().includes(trimmedQuery)
+    );
+  };
+  const shownActive = active.filter(matchesQuery);
+  const shownStopped = stopped.filter(matchesQuery);
+  const hiddenBySearch = active.length + stopped.length - shownActive.length - shownStopped.length;
+
+  const compare = (a: RecurringDetection, b: RecurringDetection): number => {
+    switch (sortBy) {
+      case 'az':
+        return a.description.localeCompare(b.description, undefined, { sensitivity: 'base' });
+      case 'payment':
+        return b.amount.minus(a.amount).toNumber();
+      case 'largest':
+        return b.annualEquivalent.minus(a.annualEquivalent).toNumber();
+    }
+  };
+
+  /** The bands the active patterns sit in, under the chosen grouping. */
+  const bands: Array<{ id: string; title: string; rows: RecurringDetection[] }> =
+    groupBy === 'cadence'
+      ? CADENCE_BANDS
+          .map(({ cadence, title }) => ({
+            id: cadence,
+            title,
+            rows: shownActive.filter(d => d.cadence === cadence).sort(compare),
+          }))
+          .filter(band => band.rows.length > 0)
+      : (() => {
+          const byInstitution = new Map<string, RecurringDetection[]>();
+          for (const d of shownActive) {
+            const institution = accountInstitution.get(d.accountId) ?? NO_INSTITUTION;
+            const rows = byInstitution.get(institution);
+            if (rows) rows.push(d);
+            else byInstitution.set(institution, [d]);
+          }
+          return [...byInstitution.keys()]
+            .sort((a, b) =>
+              a === NO_INSTITUTION ? 1 : b === NO_INSTITUTION ? -1 : a.localeCompare(b))
+            .map(institution => ({
+              id: `institution-${institution}`,
+              title: institution,
+              rows: (byInstitution.get(institution) ?? []).sort(compare),
+            }));
+        })();
 
   // Decimal throughout — these are money sums read against each other.
   const annualTotal = active.reduce(
     (sum, d) => sum.plus(d.annualEquivalent), toDecimal(0)
   );
-
-  const bandFor = (cadence: RecurringCadence): RecurringDetection[] =>
-    active.filter(d => d.cadence === cadence);
 
   const bandTotal = (band: RecurringDetection[]): DecimalInstance =>
     band.reduce((sum, d) => sum.plus(d.annualEquivalent), toDecimal(0));
@@ -180,6 +287,15 @@ export default function RecurringCommitmentsReport(): React.JSX.Element {
             recent {dayMonth(detection.lastDate)}
             {detection.nextExpected && <> · next expected {dayMonth(detection.nextExpected)}</>}
             {account && <> · {account}</>}
+            {/* A stitched pattern says where its earlier payments lived — the
+                claim of continuity across a bank's rename is checkable, so it
+                is stated. */}
+            {detection.formerLabels.length > 0 && (
+              <> · previously labelled {detection.formerLabels.map(label => `‘${label}’`).join(', ')}</>
+            )}
+            {/* A claim resting on the user's own judgment must not dress as
+                one resting on the arithmetic. */}
+            {detection.relaxed && <> · every payment counted because you marked this recurring</>}
           </p>
           {detection.priceChange && (
             <p className="text-dense text-gray-500 dark:text-gray-400">
@@ -212,7 +328,7 @@ export default function RecurringCommitmentsReport(): React.JSX.Element {
               feed the calendar and the forecast; unanswered, it stays an
               opinion and feeds nothing. */}
           {answersReady && (
-            confirmedKeys.has(answerKeyOf(detection)) ? (
+            storedKeyOf(detection, confirmedKeys) !== null ? (
               <p className="text-dense text-gray-500 dark:text-gray-400">
                 Confirmed
                 <button
@@ -284,6 +400,49 @@ export default function RecurringCommitmentsReport(): React.JSX.Element {
         </p>
       </div>
 
+      {active.length + stopped.length > 0 && (
+        /* The controls change how the page is walked, never what it claims. */
+        <div className="bg-white dark:bg-gray-800 rounded-lg border border-line dark:border-gray-700 p-4 flex flex-wrap items-center gap-x-4 gap-y-3">
+          <div className="relative flex-1 min-w-[220px]">
+            <SearchIcon
+              size={16}
+              className="absolute left-3 top-1/2 -translate-y-1/2 text-gray-400 dark:text-gray-500 pointer-events-none"
+            />
+            <input
+              type="search"
+              value={query}
+              onChange={e => setQuery(e.target.value)}
+              placeholder="Search payee, account or institution"
+              aria-label="Search recurring payments"
+              className="w-full pl-9 pr-3 py-2 text-body bg-transparent border border-line dark:border-gray-600 rounded-lg text-gray-900 dark:text-white placeholder:text-gray-400 dark:placeholder:text-gray-500"
+            />
+          </div>
+          <label className="flex items-center gap-2 text-dense text-gray-500 dark:text-gray-400">
+            Sort
+            <select
+              value={sortBy}
+              onChange={e => setSortBy(e.target.value as SortBy)}
+              className="bg-white dark:bg-gray-800 border border-line dark:border-gray-600 rounded-lg px-2 py-1.5 text-body text-gray-900 dark:text-white"
+            >
+              <option value="largest">Largest a year</option>
+              <option value="az">A to Z</option>
+              <option value="payment">Largest payment</option>
+            </select>
+          </label>
+          <label className="flex items-center gap-2 text-dense text-gray-500 dark:text-gray-400">
+            Group
+            <select
+              value={groupBy}
+              onChange={e => setGroupBy(e.target.value as GroupBy)}
+              className="bg-white dark:bg-gray-800 border border-line dark:border-gray-600 rounded-lg px-2 py-1.5 text-body text-gray-900 dark:text-white"
+            >
+              <option value="cadence">By cadence</option>
+              <option value="institution">By institution</option>
+            </select>
+          </label>
+        </div>
+      )}
+
       {detections.length > 0 && dismissed.length === detections.length ? (
         /* Every pattern struck off — a FILTERED empty, not an empty: the
            count and the reason are named, per the batch-7 rule. */
@@ -317,35 +476,58 @@ export default function RecurringCommitmentsReport(): React.JSX.Element {
           <p className="text-body text-gray-500 dark:text-gray-400">
             Nothing here repeats. The app looked for {MIN_PAYMENTS} or more
             payments of the same amount to the same payee on a steady rhythm,
-            and found none — which may be exactly right.
+            and found none — which may be exactly right. You can also open any
+            payment in its register and mark it recurring yourself — the app
+            then reads that payee's history as a commitment.
+          </p>
+        </div>
+      ) : trimmedQuery && shownActive.length + shownStopped.length === 0 ? (
+        /* The search hid everything — a filtered empty, with the count, the
+           filter responsible and the way back (batch-7 rule). */
+        <div className="bg-white dark:bg-gray-800 rounded-lg border border-line dark:border-gray-700 p-6">
+          <p className="text-body text-gray-500 dark:text-gray-400">
+            No recurring payments match ‘{query.trim()}’ — {hiddenBySearch === 1
+              ? '1 is hidden by the search'
+              : `${hiddenBySearch} are hidden by the search`}.{' '}
+            <button
+              type="button"
+              onClick={() => setQuery('')}
+              className="text-primary hover:underline"
+            >
+              Clear the search
+            </button>
           </p>
         </div>
       ) : (
         <>
-          {CADENCE_BANDS.map(({ cadence, title }) => {
-            const band = bandFor(cadence);
-            if (band.length === 0) return null;
-            return (
-              <div key={cadence} className="bg-white dark:bg-gray-800 rounded-lg border border-line dark:border-gray-700 p-6">
-                <div className="flex flex-wrap items-baseline justify-between gap-2 mb-2">
-                  <h2 className="text-card font-semibold text-theme-heading dark:text-white">
-                    {title}
-                    <span className="ml-2 text-dense font-normal text-gray-400 dark:text-gray-500">
-                      {band.length}
-                    </span>
-                  </h2>
-                  <span className="text-body font-semibold tabular-nums text-gray-900 dark:text-white">
-                    {formatCurrency(bandTotal(band), displayCurrency)} a year
-                  </span>
-                </div>
-                <ul>
-                  {band.map(d => <DetectionRow key={d.key} detection={d} />)}
-                </ul>
-              </div>
-            );
-          })}
+          {hiddenBySearch > 0 && (
+            <p className="text-dense text-gray-500 dark:text-gray-400">
+              Showing {shownActive.length + shownStopped.length} of{' '}
+              {active.length + stopped.length} recurring payments —{' '}
+              {hiddenBySearch} hidden by the search.
+            </p>
+          )}
 
-          {stopped.length > 0 && (
+          {bands.map(band => (
+            <div key={band.id} className="bg-white dark:bg-gray-800 rounded-lg border border-line dark:border-gray-700 p-6">
+              <div className="flex flex-wrap items-baseline justify-between gap-2 mb-2">
+                <h2 className="text-card font-semibold text-theme-heading dark:text-white">
+                  {band.title}
+                  <span className="ml-2 text-dense font-normal text-gray-400 dark:text-gray-500">
+                    {band.rows.length}
+                  </span>
+                </h2>
+                <span className="text-body font-semibold tabular-nums text-gray-900 dark:text-white">
+                  {formatCurrency(bandTotal(band.rows), displayCurrency)} a year
+                </span>
+              </div>
+              <ul>
+                {band.rows.map(d => <DetectionRow key={d.key} detection={d} />)}
+              </ul>
+            </div>
+          ))}
+
+          {shownStopped.length > 0 && (
             /* Ran, and then didn't (§3.2) — either cancelled (good to know)
                or failed (good to look at). Never silently deleted. */
             <div className="bg-white dark:bg-gray-800 rounded-lg border border-line dark:border-gray-700 p-6">
@@ -353,7 +535,7 @@ export default function RecurringCommitmentsReport(): React.JSX.Element {
                 <h2 className="text-card font-semibold text-theme-heading dark:text-white">
                   Stopped
                   <span className="ml-2 text-dense font-normal text-gray-400 dark:text-gray-500">
-                    {stopped.length}
+                    {shownStopped.length}
                   </span>
                 </h2>
                 <span className="text-dense text-gray-500 dark:text-gray-400">
@@ -361,7 +543,7 @@ export default function RecurringCommitmentsReport(): React.JSX.Element {
                 </span>
               </div>
               <ul>
-                {stopped.map(d => (
+                {shownStopped.map(d => (
                   <li key={d.key} className="py-3 flex flex-wrap items-baseline justify-between gap-x-6 gap-y-1 border-t border-gray-50 dark:border-gray-700/50 first:border-0">
                     <div className="min-w-0">
                       <p className="text-body text-gray-900 dark:text-white truncate">

--- a/src/pages/reports/__tests__/RecurringCommitmentsReport.navigation.test.tsx
+++ b/src/pages/reports/__tests__/RecurringCommitmentsReport.navigation.test.tsx
@@ -1,0 +1,230 @@
+import React from 'react';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { render, screen, fireEvent, within } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { PreferencesProvider } from '../../../contexts/PreferencesContext';
+import { ToastProvider } from '../../../contexts/ToastContext';
+import { __setAppContextValue, __resetAppContextValue } from '../../../test/mocks/AppContextSupabase';
+import RecurringCommitmentsReport from '../RecurringCommitmentsReport';
+import { recurringAnswerKey } from '../../../utils/suggestionDismissals';
+import { normalisePayeeKey } from '../../../utils/recurringDetection';
+import type { Account, SuggestionDismissal, Transaction } from '../../../types';
+
+/**
+ * Navigation, on the owner's ask of 18 Aug: "Offer up viewing by
+ * 'institution' like on the accounts page. Offer sort by A-Z and by amount.
+ * Offer a search function too. It needs to be easy to navigate."
+ *
+ * The rule these are held to: navigation changes how the page is WALKED and
+ * never what it claims. The headline total stays the whole ledger's, and
+ * anything a search hides is counted out loud rather than silently gone.
+ *
+ * Every payee, institution and figure invented — the repo is public.
+ */
+
+const ACCOUNTS: Account[] = [
+  {
+    id: 'acc-a', name: 'Synthetic Current', type: 'current', balance: 0,
+    currency: 'GBP', lastUpdated: new Date(), openingBalance: 0, isActive: true,
+    institution: 'Northgate Bank',
+  },
+  {
+    id: 'acc-b', name: 'Synthetic Card', type: 'credit', balance: 0,
+    currency: 'GBP', lastUpdated: new Date(), openingBalance: 0, isActive: true,
+    institution: 'Westfell Cards',
+  },
+];
+
+/** Twelve months of the same figure, most recent ten days ago. */
+const monthly = (
+  accountId: string,
+  description: string,
+  amount: number,
+  idPrefix: string
+): Transaction[] => {
+  const now = new Date();
+  return Array.from({ length: 12 }, (_, i) => ({
+    id: `${idPrefix}-${i}`,
+    accountId,
+    description,
+    amount: -amount,
+    date: new Date(now.getFullYear(), now.getMonth() - i, now.getDate() - 10),
+    type: 'expense' as const,
+    category: 'cat-x',
+  }));
+};
+
+const LEDGER: Transaction[] = [
+  ...monthly('acc-a', 'ZEBRA GYM', 40, 'z'),          // £480 a year
+  ...monthly('acc-a', 'ALPHA STREAMING', 10, 'a'),    // £120 a year
+  ...monthly('acc-b', 'MIDLAND WATER', 25, 'm'),      // £300 a year
+];
+
+const renderReport = (dismissals: SuggestionDismissal[] = []): void => {
+  __setAppContextValue({
+    accounts: ACCOUNTS,
+    transactions: LEDGER,
+    isLoading: false,
+    suggestionDismissals: dismissals,
+    suggestionDismissalsStatus: 'ready',
+    dismissSuggestion: vi.fn(async () => {}),
+    restoreSuggestion: vi.fn(async () => {}),
+  });
+  render(
+    <MemoryRouter>
+      <PreferencesProvider>
+        <ToastProvider>
+          <RecurringCommitmentsReport />
+        </ToastProvider>
+      </PreferencesProvider>
+    </MemoryRouter>
+  );
+};
+
+/** The payee names on screen, in the order the page presents them. */
+const payeeOrder = (): string[] =>
+  screen.getAllByRole('link')
+    .map(link => link.textContent?.trim() ?? '')
+    .filter(text => LEDGER.some(row => row.description === text));
+
+beforeEach(() => {
+  localStorage.clear();
+});
+
+afterEach(() => {
+  __resetAppContextValue();
+});
+
+describe('Recurring commitments — navigation', () => {
+  it('sorts by annual cost first, and A–Z on request', () => {
+    renderReport();
+
+    expect(payeeOrder()).toEqual(['ZEBRA GYM', 'MIDLAND WATER', 'ALPHA STREAMING']);
+
+    fireEvent.change(screen.getByLabelText('Sort'), { target: { value: 'az' } });
+    expect(payeeOrder()).toEqual(['ALPHA STREAMING', 'MIDLAND WATER', 'ZEBRA GYM']);
+  });
+
+  it('groups by institution, using the account’s own institution name', () => {
+    renderReport();
+
+    // Cadence is the default grouping (handover §4).
+    expect(screen.getByRole('heading', { name: /Monthly/ })).toBeInTheDocument();
+
+    fireEvent.change(screen.getByLabelText('Group'), { target: { value: 'institution' } });
+
+    const northgate = screen.getByRole('heading', { name: /Northgate Bank/ });
+    const westfell = screen.getByRole('heading', { name: /Westfell Cards/ });
+    expect(northgate).toBeInTheDocument();
+    expect(westfell).toBeInTheDocument();
+    expect(screen.queryByRole('heading', { name: /Monthly/ })).not.toBeInTheDocument();
+
+    // The card's one commitment sits under the card's institution.
+    const band = westfell.closest('div')?.parentElement as HTMLElement;
+    expect(within(band).getByText('MIDLAND WATER')).toBeInTheDocument();
+  });
+
+  it('searches payee AND account, and says what the search is hiding', () => {
+    renderReport();
+
+    fireEvent.change(screen.getByLabelText('Search recurring payments'), {
+      target: { value: 'zebra' },
+    });
+
+    expect(payeeOrder()).toEqual(['ZEBRA GYM']);
+    // The hidden count is named — a filtered view must never read as the
+    // whole picture (batch-7 rule).
+    expect(screen.getByText(/2 hidden by the search/)).toBeInTheDocument();
+
+    // The account name is searchable too, not just the payee.
+    fireEvent.change(screen.getByLabelText('Search recurring payments'), {
+      target: { value: 'Synthetic Card' },
+    });
+    expect(payeeOrder()).toEqual(['MIDLAND WATER']);
+  });
+
+  it('a search that matches nothing names the count, the filter and the way back', () => {
+    renderReport();
+
+    fireEvent.change(screen.getByLabelText('Search recurring payments'), {
+      target: { value: 'nothing at all matches this' },
+    });
+
+    expect(screen.getByText(/3 are hidden by the search/)).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: 'Clear the search' }));
+    expect(payeeOrder()).toHaveLength(3);
+  });
+
+  it('the headline total is the whole ledger’s, whatever the search hides', () => {
+    renderReport();
+
+    const total = screen.getByText('£900.00');
+    expect(total).toBeInTheDocument();
+
+    fireEvent.change(screen.getByLabelText('Search recurring payments'), {
+      target: { value: 'zebra' },
+    });
+
+    // Still £900: the page's one earned total answers "how much of my year is
+    // spoken for", which a search does not change.
+    expect(screen.getByText('£900.00')).toBeInTheDocument();
+  });
+
+  it('a verdict stored under a payee’s OLD label still reads as confirmed', () => {
+    // The owner's Green GJ case: the bank renamed the payee mid-stream, so the
+    // stitched pattern's current label is the long one — but the Confirm he
+    // gave was recorded against the short one.
+    const now = new Date();
+    const renamed: Transaction[] = [
+      ...Array.from({ length: 8 }, (_, i) => ({
+        id: `old-${i}`,
+        accountId: 'acc-a',
+        description: 'ACME LTD',
+        amount: -250,
+        date: new Date(now.getFullYear(), now.getMonth() - 11 + i, 3),
+        type: 'expense' as const,
+        category: 'cat-maint',
+      })),
+      ...Array.from({ length: 3 }, (_, i) => ({
+        id: `new-${i}`,
+        accountId: 'acc-a',
+        description: 'ACME LTD PROPERTY MAINT',
+        amount: -250,
+        date: new Date(now.getFullYear(), now.getMonth() - 3 + i, 3),
+        type: 'expense' as const,
+        category: 'cat-maint',
+      })),
+    ];
+    __setAppContextValue({
+      accounts: ACCOUNTS,
+      transactions: renamed,
+      isLoading: false,
+      suggestionDismissals: [{
+        id: 'dis-old',
+        kind: 'recurring-confirmed',
+        subjectKey: recurringAnswerKey('acc-a', 'out', normalisePayeeKey('ACME LTD')),
+        subjectIds: [],
+        dismissedAt: new Date(),
+      }],
+      suggestionDismissalsStatus: 'ready',
+      dismissSuggestion: vi.fn(async () => {}),
+      restoreSuggestion: vi.fn(async () => {}),
+    });
+    render(
+      <MemoryRouter>
+        <PreferencesProvider>
+          <ToastProvider>
+            <RecurringCommitmentsReport />
+          </ToastProvider>
+        </PreferencesProvider>
+      </MemoryRouter>
+    );
+
+    // One pattern, wearing its current label, and the evidence names the old.
+    expect(screen.getByText('ACME LTD PROPERTY MAINT')).toBeInTheDocument();
+    expect(screen.getByText(/previously labelled ‘ACME LTD’/)).toBeInTheDocument();
+    // And the standing verdict is FOUND rather than offered again.
+    expect(screen.getByText('Confirmed')).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Confirm' })).not.toBeInTheDocument();
+  });
+});

--- a/src/pages/reports/reportRegistry.ts
+++ b/src/pages/reports/reportRegistry.ts
@@ -3,7 +3,6 @@ import { lazyWithRecovery } from '../../utils/lazyWithRecovery';
 import {
   BarChart3Icon,
   CalendarIcon,
-  ClockIcon,
   FileTextIcon,
   LandmarkIcon,
   PieChartIcon,
@@ -166,19 +165,18 @@ export const REPORTS: ReportDefinition[] = [
     usesPeriod: true,
     component: lazyWithRecovery(() => import('./SpendingByPayeeReport')),
   },
-  {
-    id: 'recurring-commitments',
-    title: 'What I’m committed to',
-    description: 'The payments that repeat — what each one costs a year, and what changed.',
-    group: 'spending',
-    icon: ClockIcon,
-    // A rhythm needs the whole history to be seen; a window that hides half
-    // the payments would weaken every evidence line on the page. Like the
-    // distribution report, the hub's period picker is hidden rather than
-    // shown governing nothing.
-    usesPeriod: false,
-    component: lazyWithRecovery(() => import('./RecurringCommitmentsReport')),
-  },
+  /*
+   * "What I'm committed to" WAS here, as 'recurring-commitments'. It moved to
+   * its own page under Plan (pages/RecurringPayments, at /recurring-payments)
+   * on the owner's ruling, 18 Aug: confirming a pattern there is what feeds
+   * the calendar's forward view and the forecast, which makes it a working
+   * surface rather than a report to read. Its old address redirects, so
+   * bookmarks and dashboard pins survive the move.
+   *
+   * The component itself still lives under reports/ — it is written as a
+   * report body and the page wraps it — so nothing about its design rules
+   * changed with its address.
+   */
   {
     id: 'period-comparison',
     title: 'This period vs last',

--- a/src/utils/recurringDetection.test.ts
+++ b/src/utils/recurringDetection.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect } from 'vitest';
-import { detectRecurring, normalisePayeeKey, MIN_PAYMENTS } from './recurringDetection';
+import {
+  detectRecurring,
+  normalisePayeeKey,
+  recurringDirectionOf,
+  MIN_PAYMENTS,
+} from './recurringDetection';
 
 /**
  * The detection's honesty rules, instrumented (Design handover 17 Aug §2):
@@ -14,19 +19,32 @@ const NOW = new Date(2026, 7, 17);
 const D = (y: number, m: number, d: number): Date => new Date(y, m - 1, d);
 
 let nextId = 0;
-const expense = (description: string, amount: number, date: Date, accountId = 'acc-1') => ({
+const expense = (
+  description: string,
+  amount: number,
+  date: Date,
+  accountId = 'acc-1',
+  category?: string
+) => ({
   id: `t-${nextId++}`,
   accountId,
   description,
   amount: -Math.abs(amount),
   date,
   type: 'expense' as const,
+  category,
 });
 
 /** A monthly run: same figure on the same day-of-month. */
-const monthlyRun = (description: string, amount: number, from: Date, months: number) =>
+const monthlyRun = (
+  description: string,
+  amount: number,
+  from: Date,
+  months: number,
+  category?: string
+) =>
   Array.from({ length: months }, (_, i) =>
-    expense(description, amount, D(from.getFullYear(), from.getMonth() + 1 + i, from.getDate())));
+    expense(description, amount, D(from.getFullYear(), from.getMonth() + 1 + i, from.getDate()), 'acc-1', category));
 
 describe('detectRecurring — what qualifies', () => {
   it('finds a monthly subscription and states its evidence', () => {
@@ -160,6 +178,160 @@ describe('detectRecurring — stopped is a band, not an absence', () => {
     const rows = monthlyRun('STILL RUNNING', 9.99, D(2025, 12, 28), 8); // last: Jul 28
     const [found] = detectRecurring(rows, NOW);
     expect(found.stopped).toBe(false);
+  });
+});
+
+describe('detectRecurring — a renamed payee is still one commitment', () => {
+  /**
+   * The owner's own case (18 Aug): a maintenance payment running for years
+   * under one wording, re-labelled longer by the bank mid-stream — same
+   * account, figure, category and day-of-month. Payees invented; the shape
+   * is his.
+   */
+  const rename = () => [
+    ...monthlyRun('ACME LTD', 250, D(2025, 9, 3), 8, 'cat-maintenance'),      // to Apr 2026
+    ...monthlyRun('ACME LTD PROPERTY MAINT', 250, D(2026, 5, 3), 4, 'cat-maintenance'), // May–Aug
+  ];
+
+  it('stitches the two labels into ONE pattern with the whole history', () => {
+    const found = detectRecurring(rename(), NOW);
+    expect(found).toHaveLength(1);
+    const [d] = found;
+    expect(d.count).toBe(12);
+    expect(d.firstDate).toEqual(D(2025, 9, 3));
+    expect(d.lastDate).toEqual(D(2026, 8, 3));
+    expect(d.stopped).toBe(false);
+    expect(d.cadence).toBe('monthly');
+    // The newest label is the identity the reader recognises…
+    expect(d.description).toBe('ACME LTD PROPERTY MAINT');
+    // …and the evidence names where the earlier payments lived.
+    expect(d.formerLabels).toEqual(['ACME LTD']);
+    // A verdict stored under EITHER label finds this pattern.
+    expect(d.payeeKeys).toEqual([
+      normalisePayeeKey('ACME LTD PROPERTY MAINT'),
+      normalisePayeeKey('ACME LTD'),
+    ]);
+  });
+
+  it('the stitched-away label does not also appear as a stopped pattern', () => {
+    const found = detectRecurring(rename(), NOW);
+    expect(found.filter(d => d.stopped)).toHaveLength(0);
+  });
+
+  it('a verdict given under the OLD label still vouches the stitched pattern', () => {
+    const oldKey = normalisePayeeKey('ACME LTD');
+    const [d] = detectRecurring(rename(), NOW, {
+      isVouched: (_account, _direction, payeeKey) => payeeKey === oldKey,
+    });
+    expect(d).toBeDefined();
+    expect(d.payeeKeys).toContain(oldKey);
+  });
+
+  it('two unrelated payees that merely share a figure and category never stitch', () => {
+    // One subscription cancelled, another started next month at the same
+    // price, same broad category — different wording, so two patterns.
+    const rows = [
+      ...monthlyRun('FLIXWATCH.COM', 9.99, D(2025, 9, 3), 8, 'cat-subs'),
+      ...monthlyRun('MOUSEHOUSE PLUS', 9.99, D(2026, 5, 3), 4, 'cat-subs'),
+    ];
+    const found = detectRecurring(rows, NOW);
+    expect(found).toHaveLength(2);
+    expect(found.every(d => d.formerLabels.length === 0)).toBe(true);
+  });
+
+  it('a different category at the joint blocks the stitch', () => {
+    const rows = [
+      ...monthlyRun('ACME LTD', 250, D(2025, 9, 3), 8, 'cat-maintenance'),
+      ...monthlyRun('ACME LTD PROPERTY MAINT', 250, D(2026, 5, 3), 4, 'cat-insurance'),
+    ];
+    expect(detectRecurring(rows, NOW)).toHaveLength(2);
+  });
+
+  it('a gap where the rhythm paused between the labels blocks the stitch', () => {
+    const rows = [
+      ...monthlyRun('ACME LTD', 250, D(2025, 6, 3), 6, 'cat-maintenance'),   // to Nov 2025
+      ...monthlyRun('ACME LTD PROPERTY MAINT', 250, D(2026, 5, 3), 4, 'cat-maintenance'), // 6-month hole
+    ];
+    const found = detectRecurring(rows, NOW);
+    expect(found).toHaveLength(2);
+  });
+
+  it('overlapping labels are two payees, not a rename', () => {
+    const rows = [
+      ...monthlyRun('ACME LTD', 250, D(2025, 9, 3), 12, 'cat-maintenance'),
+      ...monthlyRun('ACME LTD PROPERTY MAINT', 250, D(2026, 5, 10), 4, 'cat-maintenance'),
+    ];
+    const found = detectRecurring(rows, NOW);
+    expect(found).toHaveLength(2);
+  });
+
+  it('a twice-renamed payee stitches the whole chain', () => {
+    const rows = [
+      ...monthlyRun('ACME', 250, D(2025, 5, 3), 4, 'cat-maintenance'),               // to Aug 2025
+      ...monthlyRun('ACME LTD', 250, D(2025, 9, 3), 8, 'cat-maintenance'),           // to Apr 2026
+      ...monthlyRun('ACME LTD PROPERTY MAINT', 250, D(2026, 5, 3), 4, 'cat-maintenance'),
+    ];
+    const found = detectRecurring(rows, NOW);
+    expect(found).toHaveLength(1);
+    expect(found[0].count).toBe(16);
+    expect(found[0].formerLabels).toEqual(['ACME', 'ACME LTD']);
+  });
+});
+
+describe('detectRecurring — a payee the user vouched for is read leniently', () => {
+  const vouchAll = { isVouched: () => true };
+
+  it('varying amounts at a vouched payee are a pattern; unvouched they are a habit', () => {
+    // A retainer whose figure moves — no two consecutive amounts agree —
+    // on a monthly rhythm.
+    const rows = [280, 310, 265, 290, 305, 275].map((amount, i) =>
+      expense('HOME CARE SERVICES', amount, D(2026, 2 + i, 3)));
+
+    expect(detectRecurring(rows, NOW)).toHaveLength(0);
+
+    const [d] = detectRecurring(rows, NOW, vouchAll);
+    expect(d).toBeDefined();
+    expect(d.relaxed).toBe(true);
+    expect(d.count).toBe(6);
+    expect(d.cadence).toBe('monthly');
+    // The figure shown is simply the latest payment's…
+    expect(d.amount.toNumber()).toBe(275);
+    // …and no price change is invented between unsustained figures.
+    expect(d.priceChange).toBeNull();
+  });
+
+  it('two payments are enough once vouched — but still classified honestly', () => {
+    const rows = [
+      expense('HOME CARE SERVICES', 280, D(2026, 6, 3)),
+      expense('HOME CARE SERVICES', 295, D(2026, 7, 3)),
+    ];
+    expect(detectRecurring(rows, NOW)).toHaveLength(0);
+    const [d] = detectRecurring(rows, NOW, vouchAll);
+    expect(d).toBeDefined();
+    expect(d.count).toBe(2);
+    expect(d.cadence).toBe('monthly');
+  });
+
+  it('one payment shows nothing, vouched or not — a rhythm needs two points', () => {
+    const rows = [expense('HOME CARE SERVICES', 280, D(2026, 7, 3))];
+    expect(detectRecurring(rows, NOW, vouchAll)).toHaveLength(0);
+  });
+
+  it('a vouched payee whose runs already qualify keeps the strict reading and its price change', () => {
+    const rows = [
+      ...monthlyRun('FLIXWATCH.COM', 10.99, D(2025, 9, 3), 6),
+      ...monthlyRun('FLIXWATCH.COM', 12.99, D(2026, 3, 3), 6),
+    ];
+    const [d] = detectRecurring(rows, NOW, vouchAll);
+    expect(d.relaxed).toBe(false);
+    expect(d.priceChange).not.toBeNull();
+  });
+});
+
+describe('recurringDirectionOf', () => {
+  it('matches the grouping: negative is out, positive is in', () => {
+    expect(recurringDirectionOf(-9.99)).toBe('out');
+    expect(recurringDirectionOf(1200)).toBe('in');
   });
 });
 

--- a/src/utils/recurringDetection.ts
+++ b/src/utils/recurringDetection.ts
@@ -25,10 +25,44 @@ import { toDecimal, type DecimalInstance } from './decimal';
  * CHANGE, the single most useful thing this detection can surface, and is
  * reported with its date and annual impact.
  *
+ * ── A PAYEE THE USER HAS VOUCHED FOR IS READ LENIENTLY ─────────────────────
+ * The amount rule tells a subscription from a shop, but it also silences a
+ * commitment whose figure genuinely moves — a tradesman's retainer, a
+ * variable utility. When the user has CONFIRMED a pattern (the report's
+ * Confirm, or Mark as recurring on a transaction), that judgment outranks the
+ * heuristic: every payment at the payee counts, two payments are enough to
+ * show a rhythm, and the cadence is still classified honestly — a vouched
+ * pattern that wanders says "roughly every 5 weeks" like any other. What
+ * vouching never does is invent payments or a rhythm; one payment is still
+ * one payment, and shows nothing.
+ *
+ * ── A RENAMED PAYEE IS STILL ONE COMMITMENT ────────────────────────────────
+ * Banks re-label. The owner's own case (18 Aug): a maintenance payment that
+ * ran for years under one wording, then reappeared under a longer one — same
+ * account, same figure, same category, same day-of-month — and the detector
+ * reported a stopped pattern plus a young one. So groups are STITCHED when
+ * the evidence is overwhelming, all five conditions at once:
+ *
+ *   1. one label's words are contained in the other's (a rename extends or
+ *      truncates; "ACME" ⊂ "ACME PROPERTY MAINTENANCE" stitches, while two
+ *      unrelated payees that merely share a figure never do);
+ *   2. the figure at the joint matches to the penny;
+ *   3. the category at the joint matches, and both rows have one;
+ *   4. both sides are sustained — two or more payments each;
+ *   5. the combined dates still hold ONE rhythm (which also rules out a gap
+ *      at the joint: a rhythm with a hole in it is not regular).
+ *
+ * The newest label is the identity; the older ones are carried as
+ * `formerLabels` so the evidence line can say "previously labelled …", and
+ * `payeeKeys` carries every identity so a verdict stored before the rename
+ * still finds its pattern. A replacement that shares no wording (one
+ * supplier swapped for another at the same price) deliberately does NOT
+ * stitch — that is a question for the user, not an inference.
+ *
  * ── WHAT THIS NEVER DOES ───────────────────────────────────────────────────
  * Reads the register; never writes it. A detection is not a transaction and
- * must never be edited into one (handover §5). Confirm/dismiss state, when it
- * ships, lives beside the detections — not on the rows they were read from.
+ * must never be edited into one (handover §5). Confirm/dismiss state lives
+ * beside the detections — not on the rows they were read from.
  */
 
 export type RecurringCadence = 'weekly' | 'monthly' | 'annual' | 'irregular';
@@ -55,6 +89,19 @@ export interface RecurringDetection {
    * that could drift from this module's.
    */
   payeeKey: string;
+  /**
+   * EVERY identity this pattern has worn, newest first — `payeeKey` plus the
+   * normalised keys of any stitched-away labels. A verdict is MATCHED against
+   * all of them (a Confirm given before the bank renamed the payee must keep
+   * feeding the calendar) and STORED against the first.
+   */
+  payeeKeys: string[];
+  /**
+   * The most recent raw description of each stitched-away label, oldest
+   * first — what "previously labelled …" shows. Empty when nothing was
+   * stitched.
+   */
+  formerLabels: string[];
   accountId: string;
   /** 'out' is a commitment; 'in' is recurring income (a salary), kept for the calendar. */
   direction: 'in' | 'out';
@@ -75,6 +122,13 @@ export interface RecurringDetection {
   stopped: boolean;
   priceChange: RecurringPriceChange | null;
   medianIntervalDays: number;
+  /**
+   * True when the identical-amounts rule was WAIVED because the user vouched
+   * for the payee: every payment counted, and the figure shown is simply the
+   * latest. The evidence line says so — a claim resting on the user's own
+   * judgment must not dress as one resting on the arithmetic.
+   */
+  relaxed: boolean;
 }
 
 interface TransactionLike {
@@ -83,12 +137,36 @@ interface TransactionLike {
   amount: number;
   date: Date | string;
   type: string;
+  /** The category id, when filed — one of the stitch's corroborators. */
+  category?: string;
+}
+
+export interface RecurringDetectionOptions {
+  /**
+   * Has the user vouched for this payee? Wired to the stored
+   * 'recurring-confirmed' verdicts by every caller (the report, the
+   * calendar), but taken as a predicate so this module never learns the
+   * dismissal-key format.
+   */
+  isVouched?: (accountId: string, direction: 'in' | 'out', payeeKey: string) => boolean;
 }
 
 const DAY_MS = 86_400_000;
 
 /** At least this many qualifying payments before a pattern is claimed. */
 export const MIN_PAYMENTS = 3;
+
+/** Payments enough to show a rhythm once the USER has said it is one. */
+export const MIN_VOUCHED_PAYMENTS = 2;
+
+/**
+ * The direction a signed amount travels — one definition, used by the
+ * detector and by every surface that writes a verdict about a transaction,
+ * so a key built at a call site cannot disagree with the grouping here.
+ */
+export function recurringDirectionOf(amount: number): 'in' | 'out' {
+  return amount < 0 ? 'out' : 'in';
+}
 
 /**
  * The payee identity behind a raw bank description: lowercased, with digits
@@ -160,6 +238,86 @@ interface QualifyingRow {
   amountKey: string;
   amount: DecimalInstance;
   description: string;
+  /** The category id, or null when the row is unfiled. */
+  category: string | null;
+}
+
+interface Group {
+  accountId: string;
+  direction: 'in' | 'out';
+  payeeKey: string;
+  /** Sorted by date, oldest first, before the stitch pass runs. */
+  rows: QualifyingRow[];
+  /** See {@link RecurringDetection.formerLabels}. */
+  formerLabels: string[];
+  /** The normalised keys of every stitched-away label. */
+  formerPayeeKeys: string[];
+}
+
+const tokensOf = (payeeKey: string): Set<string> =>
+  new Set(payeeKey.split(' ').filter(Boolean));
+
+/** True when the smaller set's every token appears in the larger's. */
+const oneLabelContainsTheOther = (a: string, b: string): boolean => {
+  const [tokensA, tokensB] = [tokensOf(a), tokensOf(b)];
+  const [small, large] = tokensA.size <= tokensB.size ? [tokensA, tokensB] : [tokensB, tokensA];
+  for (const token of small) if (!large.has(token)) return false;
+  return true;
+};
+
+/**
+ * Do these dates, in order, hold to ONE rhythm? The same regularity test the
+ * cadence words use (no interval straying more than half the median), which
+ * is what makes it the right joint test for a stitch: a gap where a rhythm
+ * paused between two labels fails it, and so does a same-day duplicate.
+ */
+const rhythmHolds = (rows: readonly QualifyingRow[]): boolean => {
+  const intervals: number[] = [];
+  for (let i = 1; i < rows.length; i++) {
+    intervals.push((rows[i].date.getTime() - rows[i - 1].date.getTime()) / DAY_MS);
+  }
+  if (intervals.length === 0 || intervals.some(days => days < 1)) return false;
+  const medianDays = median(intervals);
+  return intervals.every(days => Math.abs(days - medianDays) <= medianDays * 0.5);
+};
+
+/**
+ * Merge groups that are one commitment under a renamed label — the five
+ * conditions in the header, all required. The newest label absorbs the
+ * older; a fixpoint loop lets a twice-renamed payee (A → B → C) stitch in
+ * two passes, each joint proven on its own evidence.
+ */
+function stitchRenamedPayees(groups: Map<string, Group>): void {
+  let merged = true;
+  while (merged) {
+    merged = false;
+    const entries = [...groups.entries()];
+    outer:
+    for (const [, newer] of entries) {
+      for (const [olderKey, older] of entries) {
+        if (older === newer) continue;
+        if (older.accountId !== newer.accountId || older.direction !== newer.direction) continue;
+        if (older.rows.length < 2 || newer.rows.length < 2) continue;
+        const olderLast = older.rows[older.rows.length - 1];
+        const newerFirst = newer.rows[0];
+        // The older label must have finished before the newer began — a
+        // period where both labels were paying is two payees, not a rename.
+        if (olderLast.date.getTime() >= newerFirst.date.getTime()) continue;
+        if (olderLast.amountKey !== newerFirst.amountKey) continue;
+        if (!olderLast.category || olderLast.category !== newerFirst.category) continue;
+        if (!oneLabelContainsTheOther(older.payeeKey, newer.payeeKey)) continue;
+        const combined = [...older.rows, ...newer.rows];
+        if (!rhythmHolds(combined)) continue;
+
+        newer.rows = combined;
+        newer.formerLabels.push(...older.formerLabels, olderLast.description);
+        newer.formerPayeeKeys.push(...older.formerPayeeKeys, older.payeeKey);
+        groups.delete(olderKey);
+        merged = true;
+        break outer;
+      }
+    }
+  }
 }
 
 /**
@@ -171,24 +329,19 @@ interface QualifyingRow {
  */
 export function detectRecurring(
   transactions: readonly TransactionLike[],
-  now: Date
+  now: Date,
+  options?: RecurringDetectionOptions
 ): RecurringDetection[] {
   // Transfers move money between the user's own accounts — a standing order
   // to savings is a rhythm, but not a commitment to anyone else, and the
   // transfer pages already show it.
-  interface Group {
-    accountId: string;
-    direction: 'in' | 'out';
-    payeeKey: string;
-    rows: QualifyingRow[];
-  }
   const groups = new Map<string, Group>();
   for (const t of transactions) {
     if (t.type !== 'income' && t.type !== 'expense') continue;
     if (t.amount === 0) continue;
     const date = t.date instanceof Date ? t.date : new Date(t.date);
     if (Number.isNaN(date.getTime())) continue;
-    const direction = t.amount < 0 ? 'out' : 'in';
+    const direction = recurringDirectionOf(t.amount);
     const payeeKey = normalisePayeeKey(t.description);
     const key = `${t.accountId}::${direction}::${payeeKey}`;
     const amount = toDecimal(t.amount).abs();
@@ -197,17 +350,34 @@ export function detectRecurring(
       amount,
       amountKey: amount.toFixed(2),
       description: t.description,
+      category: t.category ?? null,
     };
     const group = groups.get(key);
     if (group) group.rows.push(row);
-    else groups.set(key, { accountId: t.accountId, direction, payeeKey, rows: [row] });
+    else {
+      groups.set(key, {
+        accountId: t.accountId, direction, payeeKey,
+        rows: [row], formerLabels: [], formerPayeeKeys: [],
+      });
+    }
   }
+
+  for (const group of groups.values()) {
+    group.rows.sort((a, b) => a.date.getTime() - b.date.getTime());
+  }
+  stitchRenamedPayees(groups);
 
   const detections: RecurringDetection[] = [];
 
-  for (const [key, { accountId, direction, payeeKey, rows }] of groups) {
-    if (rows.length < MIN_PAYMENTS) continue;
-    rows.sort((a, b) => a.date.getTime() - b.date.getTime());
+  for (const [key, group] of groups) {
+    const { accountId, direction, payeeKey, rows, formerLabels, formerPayeeKeys } = group;
+    const payeeKeys = [payeeKey, ...formerPayeeKeys];
+    // Vouched under ANY of its labels — a Confirm given before the bank
+    // renamed the payee still counts.
+    const vouched = payeeKeys.some(
+      k => options?.isVouched?.(accountId, direction, k) ?? false
+    );
+    if (rows.length < (vouched ? MIN_VOUCHED_PAYMENTS : MIN_PAYMENTS)) continue;
 
     // Runs of consecutive identical amounts. Only runs of two or more
     // qualify: a sustained figure is what tells a subscription from a shop.
@@ -223,8 +393,12 @@ export function detectRecurring(
     }
     runs.push(current);
     const sustained = runs.filter(run => run.length >= 2);
-    const qualifying = sustained.flat();
-    if (qualifying.length < MIN_PAYMENTS) continue;
+    let qualifying = sustained.flat();
+    // The vouched relaxation: when the amount rule finds too little but the
+    // user has said this IS a commitment, every payment counts as it stands.
+    const relaxed = qualifying.length < MIN_PAYMENTS && vouched;
+    if (relaxed) qualifying = rows;
+    if (qualifying.length < (vouched ? MIN_VOUCHED_PAYMENTS : MIN_PAYMENTS)) continue;
 
     const intervals: number[] = [];
     for (let i = 1; i < qualifying.length; i++) {
@@ -238,8 +412,12 @@ export function detectRecurring(
 
     const first = qualifying[0];
     const last = qualifying[qualifying.length - 1];
-    const currentRun = sustained[sustained.length - 1];
-    const amount = currentRun[0].amount;
+    // Relaxed patterns have no runs to lean on: the current figure is simply
+    // the latest payment's, and no price change is claimed — a delta between
+    // two figures that were never sustained is not a price change.
+    const amount = relaxed
+      ? last.amount
+      : sustained[sustained.length - 1][0].amount;
 
     // Stopped: silence longer than two rhythms. Two, not one — a direct debit
     // that slipped a few days must not be pronounced dead (handover §3.2:
@@ -250,9 +428,10 @@ export function detectRecurring(
     // Only a run at a DIFFERENT figure is a price change: two runs of the
     // same amount (a pattern briefly interrupted by a one-off) changed
     // nothing worth announcing.
-    const previousRun = sustained.length >= 2 ? sustained[sustained.length - 2] : null;
+    const previousRun = !relaxed && sustained.length >= 2 ? sustained[sustained.length - 2] : null;
+    const currentRun = relaxed ? null : sustained[sustained.length - 1];
     const priceChange: RecurringPriceChange | null =
-      previousRun && !previousRun[0].amount.equals(amount)
+      previousRun && currentRun && !previousRun[0].amount.equals(amount)
         ? {
             from: previousRun[0].amount,
             to: amount,
@@ -265,6 +444,8 @@ export function detectRecurring(
       key,
       description: last.description,
       payeeKey,
+      payeeKeys,
+      formerLabels,
       accountId,
       direction,
       cadence,
@@ -278,6 +459,7 @@ export function detectRecurring(
       stopped,
       priceChange,
       medianIntervalDays: medianDays,
+      relaxed,
     });
   }
 


### PR DESCRIPTION
## Why

The owner tested the recurring pipeline on his own ledger and found the detector reporting **4 payments since May** for a commitment he has been paying for years. The cause: his bank re-labelled the payee mid-stream. Same account, same figure, same category, same day of the month — two different strings, so two different patterns, one of them filed as *Stopped*.

His second point was the more important one: *"Getting input from the user I think is important too."*

## What changed

**Continuation stitching.** Two payee groups merge into one commitment only when the evidence is overwhelming — all five at once:

1. one label's words are contained in the other's (a rename extends or truncates);
2. the figure at the joint matches to the penny;
3. the category at the joint matches, and both rows have one;
4. both sides are sustained (two or more payments each);
5. the combined dates still hold **one** rhythm — which also rules out a gap where the rhythm paused.

The newest label becomes the identity; older ones appear in the evidence line as *"previously labelled 'X'"*, and the stitched-away group leaves the Stopped band rather than being reported dead beside its living self. Two unrelated payees that merely share a price and a category never stitch — that is a question for the user, not an inference. A twice-renamed payee stitches its whole chain, each joint proven on its own evidence.

Verdicts are matched across **every** label a pattern has worn, so a Confirm given before a rename keeps feeding the calendar. New verdicts store against the current label; an Undo deletes the row that actually exists.

**Teach by example.** "This is a recurring payment" now sits in the edit modal's Status column, beside the statement and transfer facts. It writes the same verdict key the report's Confirm writes — one act recorded in one place — and the detector then reads that payee leniently: every payment counts, the amounts need not repeat, two are enough. That is what makes a variable commitment (a retainer, a tradesman) visible at all. It writes nothing to the register, the cadence stays honestly classified, and one payment still shows nothing.

**Plan, not Reports** (owner's ruling). Menu: **Recurring Payments**. Page heading: **What I'm committed to**. Confirming here feeds the calendar and the forecast, so it is forward-looking work rather than a report to read. `/reports/recurring-commitments` redirects, in both editions, so pins and bookmarks survive.

**Navigation, as asked.** Search across payee, former labels, account and institution; sort by annual cost / A–Z / payment size; group by cadence or by institution (the Accounts page's idiom). A search that hides rows names the count and offers the way back; the headline total stays the whole ledger's.

## Verification

- `tsc -b` clean, `eslint` clean, full pre-commit and pre-push gates green.
- **28** detection specs — the stitch chain, each blocking condition (category mismatch, rhythm gap, overlap, unrelated wording), the relaxation and its limits.
- **6** navigation specs, including a verdict stored under a renamed payee's old label still reading as confirmed.
- **6** mark-as-recurring specs: writes the pattern key, never the row; withdraws a standing "not recurring"; absent on transfers; waits for the verdicts to load.
- All **10** EditTransactionModal suites (113 tests), Layout's pinned menu order, the desktop router's 42-route ratchet, the desktop mount suite's 17 screens.

The gate caught two real defects on the first attempt: eight of the nine hand-written modal context mocks omitted the verdict fields the new tick reads, and a ninth mocks the icon module by explicit list. Both fixed in the mocks — they were describing a context shape the app does not have — rather than by guarding the component against a field its type says is always present.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
