### PR TITLE
feat(investments): a foreign buy carries its own rate, and the total follows it

### DIFF
--- a/src/components/PortfolioManager.tsx
+++ b/src/components/PortfolioManager.tsx
@@ -1,6 +1,14 @@
 import { useEffect, useRef, useState } from 'react';
 import { useCurrencyDecimal } from '../hooks/useCurrencyDecimal';
 import { toDecimal, parseMoneyInput, type DecimalInstance } from '../utils/decimal';
+import { useFxQuote } from '../hooks/useFxQuote';
+import {
+  AMOUNT_DP,
+  RATE_DP,
+  destinationForRate,
+  rateToDisplayString,
+  type FxRateSource,
+} from '../utils/fx';
 import { formatDecimal } from '../utils/decimal-format';
 import { supportedCurrencies } from '../utils/currency';
 import MoneyInput from './common/MoneyInput';
@@ -85,6 +93,26 @@ export interface PurchaseDetails {
   totalPaid: DecimalInstance | null;
   /** The trade date — the transfer's date and the holding's purchase date. */
   date: Date;
+  /**
+   * The conversion this buy was struck at, when the instrument's currency and
+   * the funding account's differ. null when they agree — there is nothing to
+   * account for.
+   *
+   * Carried so the figure can be ACCOUNTED FOR later: a total that is 250 USD
+   * at one rate and 250 USD at another are different amounts of sterling, and
+   * a register that records only the sterling cannot say which happened.
+   */
+  fx: {
+    rate: DecimalInstance;
+    /** From the instrument's currency… */
+    from: string;
+    /** …into the funding account's. */
+    to: string;
+    /** Whose figure it is: the provider's, or the owner's. */
+    source: FxRateSource;
+    /** When the rate was true. */
+    asOf: Date;
+  } | null;
 }
 
 interface PortfolioManagerProps {
@@ -169,6 +197,26 @@ const labelClass = 'block text-sm font-medium text-gray-700 dark:text-gray-300 m
 
 const helperClass = 'mt-1 text-xs text-gray-500 dark:text-gray-400';
 
+/**
+ * A typed rate, or null while it is not yet a positive number.
+ *
+ * Deliberately NOT `parseMoneyInput`: a rate is a ratio, not money, and it
+ * carries far more places than pennies (see utils/fx — RATE_DP is ten). A
+ * half-typed box is a normal state, not an error, so this returns null rather
+ * than complaining.
+ */
+function readPositiveRate(text: string): DecimalInstance | null {
+  const trimmed = text.trim();
+  if (trimmed === '') return null;
+  try {
+    const value = toDecimal(trimmed);
+    if (!value.isFinite() || value.isNaN() || value.lessThanOrEqualTo(0)) return null;
+    return value.toDecimalPlaces(RATE_DP);
+  } catch {
+    return null;
+  }
+}
+
 const toDateInputValue = (date: Date): string => {
   const month = `${date.getMonth() + 1}`.padStart(2, '0');
   const day = `${date.getDate()}`.padStart(2, '0');
@@ -208,6 +256,19 @@ export default function PortfolioManager({
   const [fundingAccountId, setFundingAccountId] = useState('');
   const [totalPaid, setTotalPaid] = useState('');
   const [totalPaidTouched, setTotalPaidTouched] = useState(false);
+  /**
+   * The rate this ONE purchase was struck at, when the instrument prices in a
+   * currency the funding account does not count in.
+   *
+   * Owner, 18 Aug: "a currency conversion rate box that defaults to the most
+   * up to date figure we have in the system but if the user got a different
+   * rate (which they likely did), they can input their own rate for this
+   * transaction and we just convert in to the GBP boxes." The default matters
+   * less than the override: a broker's rate includes a spread, so the
+   * mid-market quote is a starting point, never the answer.
+   */
+  const [rateText, setRateText] = useState('');
+  const [rateTouched, setRateTouched] = useState(false);
   const [purchaseDate, setPurchaseDate] = useState(() => toDateInputValue(new Date()));
 
   // The picked instrument's live quote: the trading currency stated by the
@@ -228,6 +289,8 @@ export default function PortfolioManager({
     setFundingAccountId('');
     setTotalPaid('');
     setTotalPaidTouched(false);
+    setRateText('');
+    setRateTouched(false);
     setPurchaseDate(toDateInputValue(new Date()));
     setQuote(null);
     setQuoteLoading(false);
@@ -336,6 +399,29 @@ export default function PortfolioManager({
   const fundingMatchesHoldingCurrency =
     fundingAccount !== null && fundingAccount.currency === holdingCurrency;
 
+  /**
+   * A BUY ACROSS A CURRENCY BOUNDARY.
+   *
+   * The instrument prices in its own currency (Apple in dollars) and the
+   * funding account counts in another (a sterling current account). The cash
+   * that leaves is in the ACCOUNT's currency, so one conversion stands between
+   * "units × price + charges" and the figure that moves.
+   *
+   * This used to be a refusal — "the app will not invent it from an exchange
+   * rate" — which was right about inventing and wrong about helping: it left
+   * the owner to do the arithmetic by hand on every foreign buy. What follows
+   * offers a rate instead, says where it came from, lets it be overwritten,
+   * and still leaves the total editable. Nothing is invented that is not shown
+   * and attributed.
+   */
+  const needsConversion =
+    fundingAccount !== null && fundingAccount.currency !== holdingCurrency;
+  const fxQuote = useFxQuote(
+    needsConversion ? holdingCurrency : null,
+    needsConversion ? fundingAccount.currency : null
+  );
+  const rateValue = rateText === '' ? null : readPositiveRate(rateText);
+
   // A Decimal is a fresh object every render, so the effects below key on its
   // STRING — stable while the figure is, changed exactly when it changes.
   const cashTotalKey = cashTotal !== null ? cashTotal.toDecimalPlaces(2).toString() : null;
@@ -346,6 +432,27 @@ export default function PortfolioManager({
     if (totalPaidTouched || !fundingMatchesHoldingCurrency || cashTotalKey === null) return;
     setTotalPaid(cashTotalKey);
   }, [totalPaidTouched, fundingMatchesHoldingCurrency, cashTotalKey]);
+
+  // Seed the rate box from the quote, and only while the box is untouched: a
+  // quote that resolves late must never overwrite a rate already typed.
+  const quotedRateKey = fxQuote.status === 'ready' ? fxQuote.rate.toString() : null;
+  useEffect(() => {
+    if (rateTouched || quotedRateKey === null) return;
+    setRateText(rateToDisplayString(toDecimal(quotedRateKey)));
+  }, [rateTouched, quotedRateKey]);
+
+  // The converted total, in the funding account's currency. Same rule as the
+  // same-currency default: it fills the box, and the box stays editable —
+  // the contract note wins over any arithmetic done here.
+  const convertedTotalKey = (() => {
+    if (!needsConversion || cashTotal === null || rateValue === null) return null;
+    const converted = destinationForRate(cashTotal, rateValue);
+    return converted.ok ? converted.value.toDecimalPlaces(AMOUNT_DP).toString() : null;
+  })();
+  useEffect(() => {
+    if (totalPaidTouched || convertedTotalKey === null) return;
+    setTotalPaid(convertedTotalKey);
+  }, [totalPaidTouched, convertedTotalKey]);
 
   const previewCostBasis = cashTotal;
   const previewKey = previewCostBasis !== null ? previewCostBasis.toString() : null;
@@ -423,16 +530,24 @@ export default function PortfolioManager({
       charges: toDecimal(chargesValue),
       fundingAccountId: null,
       totalPaid: null,
-      date: new Date(`${purchaseDate}T00:00:00`)
+      date: new Date(`${purchaseDate}T00:00:00`),
+      fx: null
     };
 
     if (!editing && fundingAccountId !== '') {
+      if (needsConversion && rateValue === null) {
+        setFormError(
+          `Enter the rate this purchase was converted at — 1 ${holdingCurrency} in ` +
+          `${fundingAccount?.currency ?? 'the funding account’s currency'}`
+        );
+        return;
+      }
       const paidValue = parseMoneyInput(totalPaid);
       if (paidValue === null || paidValue <= 0) {
         setFormError(
-          fundingMatchesHoldingCurrency
-            ? 'Enter the total paid, including charges'
-            : `Enter the total paid in ${fundingAccount?.currency ?? 'the funding account’s currency'} — it is on the contract note`
+          needsConversion
+            ? `Enter the total paid in ${fundingAccount?.currency ?? 'the funding account’s currency'} — the figure on the contract note`
+            : 'Enter the total paid, including charges'
         );
         return;
       }
@@ -440,7 +555,30 @@ export default function PortfolioManager({
         setFormError('Enter the date the purchase settled');
         return;
       }
-      purchase = { ...purchase, fundingAccountId, totalPaid: toDecimal(paidValue) };
+      purchase = {
+        ...purchase,
+        fundingAccountId,
+        totalPaid: toDecimal(paidValue),
+        /*
+         * 'api' ONLY for a live quote accepted with no edit at all — the same
+         * rule the cross-currency transfer dialog applies, and for the same
+         * reason: the fallback table is wrong the day after it was written, so
+         * stamping it with the provider's name would put their word on a
+         * figure they never quoted. Accepting it is fine; the record then says
+         * the owner answered for it.
+         */
+        fx: needsConversion && rateValue !== null && fundingAccount !== null
+          ? {
+              rate: rateValue,
+              from: holdingCurrency,
+              to: fundingAccount.currency,
+              source: !rateTouched && fxQuote.status === 'ready' && fxQuote.source === 'api'
+                ? 'api'
+                : 'manual',
+              asOf: !rateTouched && fxQuote.status === 'ready' ? fxQuote.asOf : new Date()
+            }
+          : null
+      };
     }
 
     setIsSaving(true);
@@ -768,6 +906,36 @@ export default function PortfolioManager({
                       usePortal
                     />
                   </div>
+                  {/* THE RATE, when the instrument and the money that pays for
+                      it count in different currencies. Shown before the total
+                      it produces, because it is what produces it. */}
+                  {needsConversion && fundingAccount && (
+                    <div className="sm:col-span-2">
+                      <label htmlFor="holding-fx-rate" className={labelClass}>
+                        Rate: 1 {holdingCurrency} in {fundingAccount.currency}
+                      </label>
+                      <input
+                        id="holding-fx-rate"
+                        type="text"
+                        inputMode="decimal"
+                        value={rateText}
+                        onChange={(event) => {
+                          setRateText(event.target.value);
+                          setRateTouched(true);
+                        }}
+                        className={inputClass}
+                        disabled={isSaving}
+                        placeholder="0.0000"
+                      />
+                      <p className={helperClass}>
+                        {fxQuote.status === 'ready' && !rateTouched
+                          ? `Today's rate, from ${fxQuote.provider}. Your broker's will differ — type theirs and the total below follows.`
+                          : fxQuote.status === 'unavailable' && !rateTouched
+                            ? 'No rate available for this pair — the one on your contract note is the one that happened.'
+                            : 'Your rate for this purchase. The total below follows it.'}
+                      </p>
+                    </div>
+                  )}
                   <div>
                     <label htmlFor="holding-total-paid" className={labelClass}>
                       Total paid ({fundingAccount?.currency ?? currency})
@@ -783,9 +951,9 @@ export default function PortfolioManager({
                       disabled={isSaving}
                     />
                     <p className={helperClass}>
-                      {fundingMatchesHoldingCurrency
-                        ? 'Units × cost + charges, prefilled — change it if the contract note says otherwise.'
-                        : `The figure on the contract note, in ${fundingAccount?.currency ?? 'the account’s currency'} — the app will not invent it from an exchange rate.`}
+                      {needsConversion
+                        ? `(Units × cost + charges) × the rate above — change it if the contract note says otherwise. The ${fundingAccount?.currency ?? 'account'} figure is what moves.`
+                        : 'Units × cost + charges, prefilled — change it if the contract note says otherwise.'}
                     </p>
                   </div>
                 </div>

--- a/src/components/__tests__/PortfolioManager.buyFx.test.tsx
+++ b/src/components/__tests__/PortfolioManager.buyFx.test.tsx
@@ -1,0 +1,205 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { PreferencesProvider } from '../../contexts/PreferencesContext';
+import PortfolioManager, { type PurchaseDetails } from '../PortfolioManager';
+import type { Account } from '../../types';
+
+/**
+ * A BUY ACROSS A CURRENCY BOUNDARY.
+ *
+ * Owner, 18 Aug: "a currency conversion rate box that defaults to the most up
+ * to date figure we have in the system but if the user got a different rate
+ * (which they likely did), they can input their own rate for this transaction
+ * and we just convert in to the GBP boxes."
+ *
+ * The rules these pin:
+ *
+ *  - the rate box appears only when the instrument and the money paying for it
+ *    count in different currencies;
+ *  - the system's rate fills it, and a typed rate replaces it;
+ *  - the total paid follows the rate, and stays editable — the contract note
+ *    wins over any arithmetic done here;
+ *  - the rate is CARRIED with the purchase, with provenance: 'api' only for a
+ *    live quote accepted untouched, 'manual' the moment the owner types.
+ *
+ * Every symbol, account and figure invented — this repo is public.
+ */
+
+const QUOTED_RATE = 0.8;
+
+vi.mock('../../hooks/useFxQuote', () => ({
+  useFxQuote: (from: string | null, to: string | null) =>
+    from && to && from !== to
+      ? {
+          status: 'ready',
+          rate: { toString: () => String(QUOTED_RATE) },
+          source: 'api',
+          asOf: new Date('2026-08-18T09:00:00Z'),
+          provider: 'Sample Rates',
+        }
+      : { status: 'unavailable' },
+}));
+
+// The symbol picker reaches the network for a quote; here it just reports the
+// instrument's own currency, which is the fact the conversion turns on.
+vi.mock('../StockSymbolSearch', () => ({
+  default: ({ onSelect }: {
+    onSelect: (symbol: string, match: { name: string; type: string; exchange: string }) => void;
+  }) => (
+    <button
+      type="button"
+      onClick={() => onSelect('SYNTH', { name: 'Synthetic Corp', type: 'equity', exchange: 'NASDAQ' })}
+    >
+      pick a synthetic instrument
+    </button>
+  ),
+}));
+
+vi.mock('../../services/stockPriceService', () => ({
+  fetchQuotes: vi.fn(async () => ({
+    quotes: new Map([['SYNTH', { symbol: 'SYNTH', price: 100, currency: 'USD' }]]),
+    errors: new Map(),
+  })),
+}));
+
+const FUNDING: Account = {
+  id: 'acc-cash',
+  name: 'Sterling Cash',
+  type: 'current',
+  currency: 'GBP',
+  balance: 0,
+  openingBalance: 0,
+  lastUpdated: new Date(2026, 0, 1),
+};
+
+const onAdd = vi.fn(async () => {});
+
+const renderManager = () =>
+  render(
+    <PreferencesProvider>
+      <PortfolioManager
+        holdings={[]}
+        currency="GBP"
+        fundingAccounts={[FUNDING]}
+        onAdd={onAdd}
+        onEdit={vi.fn(async () => {})}
+        onDelete={vi.fn(async () => {})}
+      />
+    </PreferencesProvider>
+  );
+
+/** Open the add form and fill in a 10-unit buy of a dollar-priced instrument. */
+const fillDollarBuy = async (): Promise<void> => {
+  fireEvent.click(screen.getByRole('button', { name: /Add Your First Holding/ }));
+  fireEvent.click(await screen.findByRole('button', { name: 'pick a synthetic instrument' }));
+  // The quote resolves and sets the instrument's currency to USD.
+  await waitFor(() => {
+    expect(screen.getByLabelText('Priced in')).toHaveValue('USD');
+  });
+  fireEvent.change(screen.getByLabelText('Units held'), { target: { value: '10' } });
+  fireEvent.change(screen.getByLabelText('Average cost per unit'), { target: { value: '100' } });
+  fireEvent.change(screen.getByLabelText('Paid from'), { target: { value: FUNDING.id } });
+};
+
+const purchaseOf = (): PurchaseDetails => {
+  const call = onAdd.mock.calls[0] as unknown as [unknown, PurchaseDetails] | undefined;
+  if (!call) throw new Error('nothing was added');
+  return call[1];
+};
+
+beforeEach(() => {
+  onAdd.mockClear();
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('PortfolioManager — a buy across a currency boundary', () => {
+  it('offers the system rate, and converts the total into the account’s money', async () => {
+    renderManager();
+    await fillDollarBuy();
+
+    const rateBox = await screen.findByLabelText('Rate: 1 USD in GBP');
+    expect(rateBox).toHaveValue(String(QUOTED_RATE));
+    expect(screen.getByText(/Sample Rates/)).toBeInTheDocument();
+
+    // 10 × $100 = $1,000, at 0.8 → £800 in the box that pays.
+    await waitFor(() => {
+      expect(screen.getByLabelText('Total paid (GBP)')).toHaveValue('800.00');
+    });
+  });
+
+  it('a typed rate replaces the quote, moves the total, and is recorded as the owner’s', async () => {
+    renderManager();
+    await fillDollarBuy();
+
+    const rateBox = await screen.findByLabelText('Rate: 1 USD in GBP');
+    // The broker's rate, which includes a spread the mid-market quote does not.
+    fireEvent.change(rateBox, { target: { value: '0.75' } });
+
+    await waitFor(() => {
+      expect(screen.getByLabelText('Total paid (GBP)')).toHaveValue('750.00');
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Add holding' }));
+    await waitFor(() => expect(onAdd).toHaveBeenCalled());
+
+    const purchase = purchaseOf();
+    expect(purchase.fx).not.toBeNull();
+    expect(purchase.fx?.rate.toString()).toBe('0.75');
+    expect(purchase.fx?.from).toBe('USD');
+    expect(purchase.fx?.to).toBe('GBP');
+    // Typed, therefore theirs — never stamped with the provider's name.
+    expect(purchase.fx?.source).toBe('manual');
+    expect(purchase.totalPaid?.toString()).toBe('750');
+  });
+
+  it('an untouched live quote is recorded as the provider’s figure', async () => {
+    renderManager();
+    await fillDollarBuy();
+    await screen.findByLabelText('Rate: 1 USD in GBP');
+
+    fireEvent.click(screen.getByRole('button', { name: 'Add holding' }));
+    await waitFor(() => expect(onAdd).toHaveBeenCalled());
+
+    expect(purchaseOf().fx?.source).toBe('api');
+  });
+
+  it('the total stays editable — the contract note wins over the arithmetic', async () => {
+    renderManager();
+    await fillDollarBuy();
+    await screen.findByLabelText('Rate: 1 USD in GBP');
+
+    const total = screen.getByLabelText('Total paid (GBP)');
+    await waitFor(() => expect(total).toHaveValue('800.00'));
+
+    // What actually left the account, per the broker.
+    fireEvent.change(total, { target: { value: '803.15' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Add holding' }));
+    await waitFor(() => expect(onAdd).toHaveBeenCalled());
+
+    expect(purchaseOf().totalPaid?.toString()).toBe('803.15');
+    // The rate is still carried: it is how the figure was reached, and a
+    // register that kept only the sterling could not say which rate happened.
+    expect(purchaseOf().fx?.rate.toString()).toBe(String(QUOTED_RATE));
+  });
+
+  it('shows no rate box at all when the instrument counts in the account’s own currency', async () => {
+    renderManager();
+
+    fireEvent.click(screen.getByRole('button', { name: /Add Your First Holding/ }));
+    fireEvent.click(await screen.findByRole('button', { name: 'pick a synthetic instrument' }));
+    await waitFor(() => expect(screen.getByLabelText('Priced in')).toHaveValue('USD'));
+    // Put the instrument back into sterling: nothing to convert.
+    fireEvent.change(screen.getByLabelText('Priced in'), { target: { value: 'GBP' } });
+    fireEvent.change(screen.getByLabelText('Units held'), { target: { value: '10' } });
+    fireEvent.change(screen.getByLabelText('Average cost per unit'), { target: { value: '100' } });
+    fireEvent.change(screen.getByLabelText('Paid from'), { target: { value: FUNDING.id } });
+
+    expect(screen.queryByLabelText(/^Rate: /)).not.toBeInTheDocument();
+    await waitFor(() => {
+      expect(screen.getByLabelText('Total paid (GBP)')).toHaveValue('1,000.00');
+    });
+  });
+});

--- a/src/pages/Investments.tsx
+++ b/src/pages/Investments.tsx
@@ -23,6 +23,7 @@ import { useLocalStorage } from '../hooks/useLocalStorage';
 import { normaliseSecuredIds } from '../utils/accountSecuring';
 import type { DecimalInstance } from '../utils/decimal';
 import { formatDecimal } from '../utils/decimal-format';
+import { describeRate } from '../utils/fx';
 import PageWrapper from '../components/PageWrapper';
 import ToggleSwitch from '../components/ui/ToggleSwitch';
 import { buildPortfolioSummary, buildPortfolioHistory } from '../utils/portfolioSummary';
@@ -291,6 +292,19 @@ export default function Investments() {
       if (fundingAccount) {
         provenance.push(`Paid from ${fundingAccount.name}.`);
       }
+      /*
+       * THE RATE IS PART OF THE RECORD, not a step on the way to a figure.
+       * 250 USD at one rate and 250 USD at another are different amounts of
+       * sterling; a note that keeps only the sterling cannot say which
+       * happened, and neither can anyone reading it a year later. Stated with
+       * its provenance — the provider's figure, or the owner's own.
+       */
+      if (purchase.fx) {
+        provenance.push(
+          `Converted at ${describeRate(purchase.fx.rate, { from: purchase.fx.from, to: purchase.fx.to })}` +
+          `${purchase.fx.source === 'api' ? " (today's rate)" : ' (your rate)'}.`
+        );
+      }
 
       await dataPort.createInvestment({
         accountId,
@@ -308,9 +322,14 @@ export default function Investments() {
        * THE CASH LEG (owner, 17 Aug; Money's measured model — 2015 of 2029
        * real buys carried one, funded from a freely chosen account). Out of
        * the chosen account, into this investment account, linked by the same
-       * counterpart machinery every transfer uses. Same-currency only — the
-       * form does not offer cross-currency funding, because the counterpart
-       * write copies this row's digits.
+       * counterpart machinery every transfer uses.
+       *
+       * The two ACCOUNTS always agree on currency (the form only offers
+       * funding accounts that count in this one), so the counterpart copying
+       * this row's digits is correct. Where a currency boundary can appear is
+       * between the INSTRUMENT and that money — Apple prices in dollars inside
+       * a sterling ISA — and that conversion happens in the form, at a rate
+       * the owner sees and can overwrite, before any figure reaches here.
        */
       if (fundingAccount && purchase.totalPaid !== null) {
         try {


### PR DESCRIPTION
## Why

The owner, 18 Aug: *"a currency conversion rate box that defaults to the most up to date figure we have in the system but if the user got a different rate (which they likely did), they can input their own rate for this transaction and we just convert in to the GBP boxes."*

## Where the boundary actually is

Not the transfer. The form only offers funding accounts that count in the investment account's own currency, so the two ledgers always agree and the counterpart write copying the row's digits stays correct. The boundary is between the **instrument** and that money — a dollar-priced share bought inside a sterling ISA — and one conversion stands between "units × price + charges" and the figure that leaves the account.

That used to be a refusal: *"the app will not invent it from an exchange rate."* Right about inventing, wrong about helping — it left the owner doing the arithmetic by hand on every foreign buy.

## What changed

- A rate box appears **only** when the instrument and the funding money differ, reading `Rate: 1 USD in GBP`.
- The system's quote seeds it, and only while it is untouched — a rate that resolves late must never overwrite one already typed.
- The total paid follows the rate and **stays editable**: a broker's rate carries a spread the mid-market quote does not, and the contract note wins over any arithmetic done here.
- The rate is carried with the purchase and written into the holding's provenance note with its source. 250 USD at one rate and 250 USD at another are different amounts of sterling; a register keeping only the sterling cannot say which happened.
- `'api'` is stamped **only** on a live quote accepted with no edit at all — the same rule the cross-currency transfer dialog applies, so the provider's name never appears on a figure they did not quote.

Reuses the machinery that already exists rather than growing a second copy: `hooks/useFxQuote` for the quote and its honest `unavailable`, `utils/fx` for `destinationForRate`, `rateToDisplayString` and `describeRate`. A rate is read with its own parser rather than `parseMoneyInput` — a ratio is not money, and carries ten places rather than two.

## Verification

- `tsc -b` clean, `eslint` clean, full pre-commit and pre-push gates green.
- Five new specs: the quote fills the box and converts the total; a typed rate replaces it and is recorded as the owner's; an untouched quote is recorded as the provider's; an edited total survives with the rate still carried; and an instrument priced in the account's own currency shows no rate box at all.

## Not in this PR

Entering price and charges in the base currency for a foreign instrument (the reverse direction). It needs the entered figure converted *into* the instrument's currency for storage, which is a real decision about which side is authoritative — better made deliberately than bolted on here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
