### PR TITLE
feat(investments): type a foreign buy in your money, stored in the instrument's

### DIFF
--- a/src/components/PortfolioManager.tsx
+++ b/src/components/PortfolioManager.tsx
@@ -7,6 +7,7 @@ import {
   RATE_DP,
   destinationForRate,
   rateToDisplayString,
+  sourceForRate,
   type FxRateSource,
 } from '../utils/fx';
 import { formatDecimal } from '../utils/decimal-format';
@@ -269,6 +270,19 @@ export default function PortfolioManager({
    */
   const [rateText, setRateText] = useState('');
   const [rateTouched, setRateTouched] = useState(false);
+  /**
+   * Which currency the COST FIGURES are being typed in, when the instrument
+   * prices in one the account does not count in.
+   *
+   * The other half of the owner's 18 Aug ask: "enter the price and fees
+   * either in his base currency … or … in the investment local currency".
+   * The HOLDING is stored in the instrument's currency whichever is chosen —
+   * its quotes arrive in that currency, and a gain measured across two
+   * currencies is not a gain — so figures typed in the account's money are
+   * converted INTO the instrument's at the rate box, and the conversion is
+   * said out loud in the provenance.
+   */
+  const [entryCurrency, setEntryCurrency] = useState<'instrument' | 'account'>('instrument');
   const [purchaseDate, setPurchaseDate] = useState(() => toDateInputValue(new Date()));
 
   // The picked instrument's live quote: the trading currency stated by the
@@ -291,6 +305,7 @@ export default function PortfolioManager({
     setTotalPaidTouched(false);
     setRateText('');
     setRateTouched(false);
+    setEntryCurrency('instrument');
     setPurchaseDate(toDateInputValue(new Date()));
     setQuote(null);
     setQuoteLoading(false);
@@ -416,22 +431,40 @@ export default function PortfolioManager({
    */
   const needsConversion =
     fundingAccount !== null && fundingAccount.currency !== holdingCurrency;
+  /**
+   * The instrument prices in a currency the ACCOUNT does not count in. Wider
+   * than `needsConversion` (which is about the chosen funding account),
+   * because the reverse entry needs a rate to STORE the cost even when no
+   * funding account is named — and the funding list is filtered to the
+   * account's currency, so the two agree whenever both apply.
+   */
+  const crossCurrency = holdingCurrency !== currency;
+  const enteringInAccountMoney = !editing && crossCurrency && entryCurrency === 'account';
+  /** The money side of the conversion — the funding account's, or the account's own. */
+  const moneyCurrency = fundingAccount?.currency ?? currency;
+  const showRateBox = !editing && (needsConversion || enteringInAccountMoney);
   const fxQuote = useFxQuote(
-    needsConversion ? holdingCurrency : null,
-    needsConversion ? fundingAccount.currency : null
+    showRateBox ? holdingCurrency : null,
+    showRateBox ? moneyCurrency : null
   );
   const rateValue = rateText === '' ? null : readPositiveRate(rateText);
+  /** The currency the price and charges boxes are speaking, right now. */
+  const entryCcy = enteringInAccountMoney ? currency : holdingCurrency;
 
   // A Decimal is a fresh object every render, so the effects below key on its
   // STRING — stable while the figure is, changed exactly when it changes.
   const cashTotalKey = cashTotal !== null ? cashTotal.toDecimalPlaces(2).toString() : null;
 
   // Keep the editable default in step with the figures above it — until the
-  // owner types their own total, which is then theirs.
+  // owner types their own total, which is then theirs. cashTotal is already
+  // in the money's currency in two cases: the funding account counts in the
+  // instrument's currency, or the boxes themselves are speaking the account's
+  // money (the reverse entry) — no rate touches it either way.
+  const cashTotalIsMoney = fundingMatchesHoldingCurrency || enteringInAccountMoney;
   useEffect(() => {
-    if (totalPaidTouched || !fundingMatchesHoldingCurrency || cashTotalKey === null) return;
+    if (totalPaidTouched || !cashTotalIsMoney || cashTotalKey === null) return;
     setTotalPaid(cashTotalKey);
-  }, [totalPaidTouched, fundingMatchesHoldingCurrency, cashTotalKey]);
+  }, [totalPaidTouched, cashTotalIsMoney, cashTotalKey]);
 
   // Seed the rate box from the quote, and only while the box is untouched: a
   // quote that resolves late must never overwrite a rate already typed.
@@ -445,7 +478,8 @@ export default function PortfolioManager({
   // same-currency default: it fills the box, and the box stays editable —
   // the contract note wins over any arithmetic done here.
   const convertedTotalKey = (() => {
-    if (!needsConversion || cashTotal === null || rateValue === null) return null;
+    if (!needsConversion || enteringInAccountMoney) return null;
+    if (cashTotal === null || rateValue === null) return null;
     const converted = destinationForRate(cashTotal, rateValue);
     return converted.ok ? converted.value.toDecimalPlaces(AMOUNT_DP).toString() : null;
   })();
@@ -463,17 +497,17 @@ export default function PortfolioManager({
   const [baseEquivalent, setBaseEquivalent] = useState<DecimalInstance | null>(null);
   useEffect(() => {
     let cancelled = false;
-    if (previewKey === null || holdingCurrency === displayCurrency) {
+    if (previewKey === null || entryCcy === displayCurrency) {
       setBaseEquivalent(null);
       return;
     }
-    void convert(toDecimal(previewKey), holdingCurrency).then((converted) => {
+    void convert(toDecimal(previewKey), entryCcy).then((converted) => {
       if (!cancelled) setBaseEquivalent(converted);
     }).catch(() => {
       if (!cancelled) setBaseEquivalent(null);
     });
     return () => { cancelled = true; };
-  }, [previewKey, holdingCurrency, displayCurrency, convert]);
+  }, [previewKey, entryCcy, displayCurrency, convert]);
 
   /**
    * The list's total, CONVERTED. Summing costBasis raw added dollars to
@@ -517,21 +551,67 @@ export default function PortfolioManager({
       return;
     }
 
+    /**
+     * THE REVERSE ENTRY'S CONVERSION. The boxes were speaking the account's
+     * money; the holding is stored in the instrument's currency (its quotes
+     * arrive in that currency, and a gain measured across two currencies is
+     * not a gain). So the typed price and charges convert INTO the
+     * instrument's currency here, at the rate on screen — division, because
+     * the rate is quoted as 1 instrument-unit in account money. What the
+     * owner typed is what the cash side uses; the stored figures are derived,
+     * and the provenance note says at what rate.
+     */
+    let storedCost = toDecimal(costValue);
+    let storedCharges = toDecimal(chargesValue);
+    if (enteringInAccountMoney) {
+      if (rateValue === null) {
+        setFormError(
+          `Enter the rate — 1 ${holdingCurrency} in ${currency} — so figures typed ` +
+          `in ${currency} can be stored in the instrument's own currency`
+        );
+        return;
+      }
+      const costConverted = sourceForRate(storedCost, rateValue);
+      const chargesConverted = storedCharges.greaterThan(0)
+        ? sourceForRate(storedCharges, rateValue)
+        : { ok: true as const, value: toDecimal(0) };
+      if (!costConverted.ok || !chargesConverted.ok) {
+        setFormError('That rate cannot convert these figures — check both');
+        return;
+      }
+      storedCost = costConverted.value;
+      storedCharges = chargesConverted.value;
+    }
+
     const values: HoldingFormValues = {
       symbol,
       name: name.trim() || symbol,
       quantity: toDecimal(quantityValue),
-      averageCost: toDecimal(costValue),
+      averageCost: storedCost,
       currency: holdingCurrency,
       assetType
     };
 
     let purchase: PurchaseDetails = {
-      charges: toDecimal(chargesValue),
+      charges: storedCharges,
       fundingAccountId: null,
       totalPaid: null,
       date: new Date(`${purchaseDate}T00:00:00`),
-      fx: null
+      // In the reverse entry the conversion happened whether or not any money
+      // moves: the stored cost derives from typed figures through the rate,
+      // and that must be accountable even on a holding recorded with no
+      // funding transfer.
+      fx: enteringInAccountMoney && rateValue !== null
+        ? {
+            rate: rateValue,
+            from: holdingCurrency,
+            to: currency,
+            source: !rateTouched && fxQuote.status === 'ready' && fxQuote.source === 'api'
+              ? 'api'
+              : 'manual',
+            asOf: !rateTouched && fxQuote.status === 'ready' ? fxQuote.asOf : new Date()
+          }
+        : null
     };
 
     if (!editing && fundingAccountId !== '') {
@@ -804,7 +884,7 @@ export default function PortfolioManager({
 
             <div>
               <label htmlFor="holding-average-cost" className={labelClass}>
-                Average cost per unit
+                Average cost per unit{!editing && crossCurrency ? ` (${entryCcy})` : ''}
               </label>
               <MoneyInput
                 id="holding-average-cost"
@@ -839,13 +919,49 @@ export default function PortfolioManager({
                 ))}
               </select>
             </div>
+
+            {/* WHICH CURRENCY IS THE CONTRACT NOTE IN? (owner, 18 Aug: "enter
+                the price and fees either in his base currency … or … in the
+                investment local currency"). The holding is STORED in the
+                instrument's currency either way — its quotes arrive in that
+                currency, and a gain measured across two currencies is not a
+                gain — so figures typed in the account's money convert at the
+                rate box, and the note on the holding says so. */}
+            {!editing && crossCurrency && (
+              <div>
+                <label htmlFor="holding-entry-currency" className={labelClass}>
+                  Enter figures in
+                </label>
+                <select
+                  id="holding-entry-currency"
+                  value={entryCurrency}
+                  onChange={(e) => {
+                    setEntryCurrency(e.target.value === 'account' ? 'account' : 'instrument');
+                    // The default total was computed under the old meaning of
+                    // the boxes; recompute rather than carry a stale figure.
+                    setTotalPaidTouched(false);
+                    setTotalPaid('');
+                  }}
+                  disabled={isSaving}
+                  className={inputClass}
+                >
+                  <option value="instrument">{holdingCurrency} — the instrument's currency</option>
+                  <option value="account">{currency} — your money</option>
+                </select>
+                <p className={helperClass}>
+                  {enteringInAccountMoney
+                    ? `Stored in ${holdingCurrency} either way, converted at the rate below — so gains can be measured against its ${holdingCurrency} quotes.`
+                    : `The contract note's figures, as the instrument prices them.`}
+                </p>
+              </div>
+            )}
           </div>
 
           {!editing && (
             <>
               <div>
                 <label htmlFor="holding-charges" className={labelClass}>
-                  Charges — stamp duty, levies, commission ({holdingCurrency})
+                  Charges — stamp duty, levies, commission ({entryCcy})
                 </label>
                 <MoneyInput
                   id="holding-charges"
@@ -891,6 +1007,39 @@ export default function PortfolioManager({
                 </p>
               </div>
 
+              {/* THE RATE, whenever a conversion stands anywhere in this buy:
+                  between the instrument and the money that pays for it, or —
+                  the reverse entry — between the figures being typed and the
+                  currency the holding is stored in. Outside the funding block
+                  because the second case needs no funding account at all. */}
+              {showRateBox && (
+                <div>
+                  <label htmlFor="holding-fx-rate" className={labelClass}>
+                    Rate: 1 {holdingCurrency} in {moneyCurrency}
+                  </label>
+                  <input
+                    id="holding-fx-rate"
+                    type="text"
+                    inputMode="decimal"
+                    value={rateText}
+                    onChange={(event) => {
+                      setRateText(event.target.value);
+                      setRateTouched(true);
+                    }}
+                    className={inputClass}
+                    disabled={isSaving}
+                    placeholder="0.0000"
+                  />
+                  <p className={helperClass}>
+                    {fxQuote.status === 'ready' && !rateTouched
+                      ? `Today's rate, from ${fxQuote.provider}. Your broker's will differ — type theirs and the figures follow.`
+                      : fxQuote.status === 'unavailable' && !rateTouched
+                        ? 'No rate available for this pair — the one on your contract note is the one that happened.'
+                        : 'Your rate for this purchase. The figures follow it.'}
+                  </p>
+                </div>
+              )}
+
               {fundingAccountId !== '' && (
                 <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
                   <div>
@@ -906,36 +1055,6 @@ export default function PortfolioManager({
                       usePortal
                     />
                   </div>
-                  {/* THE RATE, when the instrument and the money that pays for
-                      it count in different currencies. Shown before the total
-                      it produces, because it is what produces it. */}
-                  {needsConversion && fundingAccount && (
-                    <div className="sm:col-span-2">
-                      <label htmlFor="holding-fx-rate" className={labelClass}>
-                        Rate: 1 {holdingCurrency} in {fundingAccount.currency}
-                      </label>
-                      <input
-                        id="holding-fx-rate"
-                        type="text"
-                        inputMode="decimal"
-                        value={rateText}
-                        onChange={(event) => {
-                          setRateText(event.target.value);
-                          setRateTouched(true);
-                        }}
-                        className={inputClass}
-                        disabled={isSaving}
-                        placeholder="0.0000"
-                      />
-                      <p className={helperClass}>
-                        {fxQuote.status === 'ready' && !rateTouched
-                          ? `Today's rate, from ${fxQuote.provider}. Your broker's will differ — type theirs and the total below follows.`
-                          : fxQuote.status === 'unavailable' && !rateTouched
-                            ? 'No rate available for this pair — the one on your contract note is the one that happened.'
-                            : 'Your rate for this purchase. The total below follows it.'}
-                      </p>
-                    </div>
-                  )}
                   <div>
                     <label htmlFor="holding-total-paid" className={labelClass}>
                       Total paid ({fundingAccount?.currency ?? currency})
@@ -951,7 +1070,7 @@ export default function PortfolioManager({
                       disabled={isSaving}
                     />
                     <p className={helperClass}>
-                      {needsConversion
+                      {needsConversion && !enteringInAccountMoney
                         ? `(Units × cost + charges) × the rate above — change it if the contract note says otherwise. The ${fundingAccount?.currency ?? 'account'} figure is what moves.`
                         : 'Units × cost + charges, prefilled — change it if the contract note says otherwise.'}
                     </p>
@@ -964,7 +1083,7 @@ export default function PortfolioManager({
           {previewCostBasis && (
             <div className="p-4 bg-gray-50 dark:bg-gray-700/50 rounded-lg space-y-1">
               <p className="text-sm text-gray-600 dark:text-gray-400">
-                Cost basis: {formatCurrency(previewCostBasis, holdingCurrency)}
+                Cost basis: {formatCurrency(previewCostBasis, entryCcy)}
                 {chargesValue !== null && chargesValue > 0 && ' including charges'}
               </p>
               {baseEquivalent !== null && (

--- a/src/components/__tests__/PortfolioManager.buyFx.test.tsx
+++ b/src/components/__tests__/PortfolioManager.buyFx.test.tsx
@@ -97,7 +97,7 @@ const fillDollarBuy = async (): Promise<void> => {
     expect(screen.getByLabelText('Priced in')).toHaveValue('USD');
   });
   fireEvent.change(screen.getByLabelText('Units held'), { target: { value: '10' } });
-  fireEvent.change(screen.getByLabelText('Average cost per unit'), { target: { value: '100' } });
+  fireEvent.change(screen.getByLabelText('Average cost per unit (USD)'), { target: { value: '100' } });
   fireEvent.change(screen.getByLabelText('Paid from'), { target: { value: FUNDING.id } });
 };
 
@@ -185,14 +185,89 @@ describe('PortfolioManager — a buy across a currency boundary', () => {
     expect(purchaseOf().fx?.rate.toString()).toBe(String(QUOTED_RATE));
   });
 
+  it('entering in YOUR money converts the stored cost into the instrument’s currency', async () => {
+    // The other half of the owner's ask: type the contract note's sterling
+    // figures for a dollar-priced instrument. The holding must still be
+    // stored in dollars — its quotes arrive in dollars, and a gain measured
+    // across two currencies is not a gain.
+    renderManager();
+    await fillDollarBuy();
+
+    fireEvent.change(screen.getByLabelText('Enter figures in'), {
+      target: { value: 'account' },
+    });
+    // The boxes now speak sterling…
+    expect(screen.getByLabelText('Average cost per unit (GBP)')).toBeInTheDocument();
+    // …and the typed price is the sterling one: £80 a unit at 0.8 is $100.
+    fireEvent.change(screen.getByLabelText('Average cost per unit (GBP)'), {
+      target: { value: '80' },
+    });
+
+    // The total paid needs NO rate arithmetic — the typed figures already are
+    // the account's money: 10 × £80 = £800.
+    await waitFor(() => {
+      expect(screen.getByLabelText('Total paid (GBP)')).toHaveValue('800.00');
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Add holding' }));
+    await waitFor(() => expect(onAdd).toHaveBeenCalled());
+
+    const call = onAdd.mock.calls[0] as unknown as [
+      { averageCost: { toString(): string }; currency: string },
+      PurchaseDetails,
+    ];
+    // Stored in DOLLARS, derived through the rate: £80 ÷ 0.8 = $100.
+    expect(call[0].currency).toBe('USD');
+    expect(call[0].averageCost.toString()).toBe('100');
+    // And the conversion is carried, so the derived figure stays accountable.
+    expect(call[1].fx?.rate.toString()).toBe(String(QUOTED_RATE));
+    expect(call[1].totalPaid?.toString()).toBe('800');
+  });
+
+  it('the reverse entry without a funding account still requires and records the rate', async () => {
+    // Recording a holding with no money moving: the rate is still needed,
+    // because the STORED cost derives through it.
+    renderManager();
+
+    fireEvent.click(screen.getByRole('button', { name: /Add Your First Holding/ }));
+    fireEvent.click(await screen.findByRole('button', { name: 'pick a synthetic instrument' }));
+    await waitFor(() => expect(screen.getByLabelText('Priced in')).toHaveValue('USD'));
+    fireEvent.change(screen.getByLabelText('Enter figures in'), {
+      target: { value: 'account' },
+    });
+    fireEvent.change(screen.getByLabelText('Units held'), { target: { value: '10' } });
+    fireEvent.change(screen.getByLabelText('Average cost per unit (GBP)'), {
+      target: { value: '80' },
+    });
+
+    // The rate box is on screen with no funding account chosen.
+    const rateBox = await screen.findByLabelText('Rate: 1 USD in GBP');
+    // The owner's own rate, not the quote's: £80 ÷ 0.75 = $106.67 stored.
+    fireEvent.change(rateBox, { target: { value: '0.75' } });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Add holding' }));
+    await waitFor(() => expect(onAdd).toHaveBeenCalled());
+
+    const call = onAdd.mock.calls[0] as unknown as [
+      { averageCost: { toString(): string } },
+      PurchaseDetails,
+    ];
+    expect(call[0].averageCost.toString()).toBe('106.67');
+    // No transfer — but the conversion is still on the record.
+    expect(call[1].fundingAccountId).toBeNull();
+    expect(call[1].fx?.source).toBe('manual');
+  });
+
   it('shows no rate box at all when the instrument counts in the account’s own currency', async () => {
     renderManager();
 
     fireEvent.click(screen.getByRole('button', { name: /Add Your First Holding/ }));
     fireEvent.click(await screen.findByRole('button', { name: 'pick a synthetic instrument' }));
     await waitFor(() => expect(screen.getByLabelText('Priced in')).toHaveValue('USD'));
-    // Put the instrument back into sterling: nothing to convert.
+    // Put the instrument back into sterling: nothing to convert, so the cost
+    // label carries no currency suffix and no entry toggle appears.
     fireEvent.change(screen.getByLabelText('Priced in'), { target: { value: 'GBP' } });
+    expect(screen.queryByLabelText('Enter figures in')).not.toBeInTheDocument();
     fireEvent.change(screen.getByLabelText('Units held'), { target: { value: '10' } });
     fireEvent.change(screen.getByLabelText('Average cost per unit'), { target: { value: '100' } });
     fireEvent.change(screen.getByLabelText('Paid from'), { target: { value: FUNDING.id } });

--- a/src/utils/__tests__/fx.test.ts
+++ b/src/utils/__tests__/fx.test.ts
@@ -11,6 +11,7 @@ import {
   rateToDisplayString,
   rateToStorageString,
   readFxRecord,
+  sourceForRate,
 } from '../fx';
 
 /**
@@ -129,6 +130,45 @@ describe('fx', () => {
       expect(result.ok).toBe(false);
       if (result.ok) return;
       expect(result.reason).toBe('not-a-number');
+    });
+  });
+
+  describe('sourceForRate — destinationForRate run backwards', () => {
+    it('divides the destination by the rate, to the penny', () => {
+      // £158 that arrived at 0.79 was $200 before the conversion.
+      const result = sourceForRate('158', '0.79');
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+      expect(result.value.toString()).toBe('200');
+    });
+
+    it('round-trips with destinationForRate up to one penny of rounding', () => {
+      const forward = destinationForRate('127.5', '0.7843');
+      expect(forward.ok).toBe(true);
+      if (!forward.ok) return;
+      const back = sourceForRate(forward.value, '0.7843');
+      expect(back.ok).toBe(true);
+      if (!back.ok) return;
+      expect(back.value.minus('127.5').abs().lessThanOrEqualTo('0.01')).toBe(true);
+    });
+
+    it('discards sign, like every amount here — the legs carry the signs', () => {
+      const result = sourceForRate(-158, '0.79');
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+      expect(result.value.isPositive()).toBe(true);
+    });
+
+    it('refuses a zero or negative rate as not-a-number — no real pair has one', () => {
+      const zero = sourceForRate(100, '0');
+      expect(zero.ok).toBe(false);
+      if (zero.ok) return;
+      expect(zero.reason).toBe('not-a-number');
+
+      const negative = sourceForRate(100, '-0.79');
+      expect(negative.ok).toBe(false);
+      if (negative.ok) return;
+      expect(negative.reason).toBe('not-a-number');
     });
   });
 

--- a/src/utils/fx.ts
+++ b/src/utils/fx.ts
@@ -196,6 +196,37 @@ export function rateForDestination(
 }
 
 /**
+ * The source amount a rate implies: |destination| ÷ rate, to the penny —
+ * {@link destinationForRate} run backwards.
+ *
+ * The buy form's reverse entry is what needs it: a figure typed in the money
+ * that PAYS (the destination side) converted back into the currency the thing
+ * is PRICED in. Same rounding discipline as the forward direction: one
+ * HALF_UP rounding at {@link AMOUNT_DP}, after the division.
+ *
+ * A rate that is zero or negative fails as 'not-a-number' rather than
+ * dividing: no real currency pair has one (the local schema's
+ * `fx_rate_e10 > 0` CHECK says the same thing in storage), so a caller
+ * holding such a rate is holding a parsing mistake, not a conversion.
+ */
+export function sourceForRate(
+  destinationAmount: DecimalInstance | number | string,
+  rate: DecimalInstance | number | string
+): FxResult<DecimalInstance> {
+  const destination = readAmount(destinationAmount);
+  const rateValue = readAmount(rate);
+  if (destination === null || rateValue === null) return fail('not-a-number');
+  if (rateValue.lessThanOrEqualTo(0)) return fail('not-a-number');
+
+  return ok(
+    destination
+      .abs()
+      .dividedBy(rateValue)
+      .toDecimalPlaces(AMOUNT_DP, Decimal.ROUND_HALF_UP)
+  );
+}
+
+/**
  * A rate as it is STORED: an exact decimal string, trailing zeros removed.
  *
  * `toFixed` would pad "0.79" to "0.7900000000", which stores ten digits of


### PR DESCRIPTION
## Why

The other half of the owner's 18 Aug ask: *"enter the price and fees either in his base currency (app wide, in this case GBP) or to enter the price and levy etc in the investment local currency."* #350 built the second half; this builds the first.

## Which side is authoritative

Neither — each currency owns what is natively its:

- The **holding** is stored in the instrument's currency whichever way the figures were typed. Its quotes arrive in that currency, and a gain measured across two currencies is not a gain.
- The **cash** is the account's, and in this direction needs no arithmetic at all: figures typed in the account's money already are what leaves it.
- The **rate** connects the two, on the record.

## What changed

- An **"Enter figures in"** choice appears only when the instrument and the account count in different currencies. Choosing your own money relabels the price and charges boxes to it.
- The rate box (from #350) moved **out of the funding block**: the reverse entry needs it to *store* the cost even when no money moves. It still seeds from the live quote while untouched.
- Stored figures derive by division through the rate (`sourceForRate`, new in `utils/fx` — `destinationForRate` run backwards, one HALF_UP rounding at `AMOUNT_DP`, refusing a zero/negative rate).
- The conversion is carried on the purchase and written into the provenance note **even for a holding recorded with no transfer**: a derived figure with no rate beside it is unauditable.
- `'api'` provenance still only for a live quote accepted with no edit.

## A test-side find worth keeping

React's input value tracker swallows a change event whose value equals what is already in the box — so "typing" the same rate the quote seeded never marks it touched. A test that wants `'manual'` provenance must type a genuinely different rate, which is also the truer scenario.

## Verification

- `tsc -b` clean, `eslint` clean, full pre-commit and pre-push gates green.
- 51 tests across the four suites on this ground, including the new pins: sterling figures for a dollar instrument store a dollar cost derived through the rate; the reverse entry without a funding account still requires and records the rate; the entry toggle is absent entirely when nothing crosses a currency; and four new `sourceForRate` specs (round-trip within a penny, sign discipline, refusals).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
