### PR TITLE
fix(dashboard): the drag preview holds steady, and a held tile loosens on a phone

### DIFF
--- a/src/components/dashboard/ImprovedDashboard.tsx
+++ b/src/components/dashboard/ImprovedDashboard.tsx
@@ -57,7 +57,7 @@ import {
   type AccountDistributionEntry,
 } from '../../utils/accountDistribution';
 import { groupAccountsBySection } from '../../utils/accountGrouping';
-import { swapPositions, moveBySteps } from '../../utils/reorderList';
+import { swapPositions, moveBySteps, previewStep } from '../../utils/reorderList';
 import { buildCategoryNameLookup } from '../../utils/categoryNames';
 import { buildAttentionItems } from '../../utils/attentionItems';
 import { loadAutoSyncPrefs } from '../../utils/bankAutoSync';
@@ -470,7 +470,27 @@ export function ImprovedDashboard() {
    * the pointer moves on — and NOTHING is stored until the button is
    * released. Escape-by-pointercancel reverts to where things were.
    *
-   * `touch-action: pan-y` keeps the page scrollable from a tile on a phone;
+   * THE PREVIEW HAS HYSTERESIS (owner, 18 Aug, on the first cut of the swap:
+   * "the highlight quickly jumps back and forth between the moved from and
+   * the moved to"). The flap was geometric: previewing a swap moves the
+   * DRAGGED tile into the seat under the pointer, so the next move finds the
+   * dragged tile there, cleared the preview, found the target again, swapped
+   * again — every frame. So a preview now only CHANGES when the pointer
+   * reaches a genuinely new tile. The dragged tile under the pointer is the
+   * swap holding steady; a grid gap keeps the last preview; and the partner
+   * tile under the pointer means the pointer is back at the ORIGIN seat —
+   * the swap moved the partner there — which is a drag home, and reverts.
+   *
+   * ON A PHONE, PRESS AND HOLD LIFTS THE TILE (owner, 18 Aug: "if we hold
+   * down for a few seconds, like on an iphone app on the iphone screen, can
+   * it then 'loosen itself' to be swapped before leaving go of the screen?").
+   * Exactly that: `touch-action: pan-y` leaves the page scrollable from a
+   * tile, so a touch drag has no way to BE a drag — the browser claims any
+   * movement as a scroll and cancels the pointer. A hold that stays within
+   * the slop for {@link TOUCH_LIFT_MS} lifts the tile instead: from that
+   * moment a non-passive touchmove listener refuses the scroll claim, the
+   * finger owns the tile, and the same swap-preview-commit flow runs. Before
+   * the lift, movement cancels the hold and the page scrolls as normal.
    * Alt+arrows cover the keyboard.
    */
   const [draggingId, setDraggingId] = useState<string | null>(null);
@@ -481,7 +501,19 @@ export function ImprovedDashboard() {
     baseOrder: string[];
     /** The tile currently previewing into the dragged tile's seat. */
     hoverId: string | null;
+    /** Touch only: the press-and-hold timer, until it fires or moves away. */
+    holdTimer: ReturnType<typeof setTimeout> | null;
+    /** Touch only: the hold completed — the tile is loosened and draggable. */
+    lifted: boolean;
+    pointerType: string;
   } | null>(null);
+  /**
+   * The scroll refusal, held so it can be removed from wherever the gesture
+   * ends. Non-passive deliberately: preventDefault on touchmove is the one
+   * thing that stops a browser mid-gesture from claiming the pan, and a
+   * passive listener is not allowed to say it.
+   */
+  const touchBlockRef = React.useRef<((ev: TouchEvent) => void) | null>(null);
   const [reorderAnnouncement, setReorderAnnouncement] = useState('');
 
   const displayedAccounts = useMemo(() => {
@@ -496,18 +528,65 @@ export function ImprovedDashboard() {
     setReorderAnnouncement(`${name} moved to position ${order.indexOf(accountId) + 1} of ${order.length}`);
   }, [accounts]);
 
+  /** How long a touch must hold still before the tile loosens. */
+  const TOUCH_LIFT_MS = 450;
+
+  /** Undo the lift's scroll refusal and hold timer, from any ending. */
+  const releaseTouchHold = (): void => {
+    const drag = dragRef.current;
+    if (drag?.holdTimer !== null && drag?.holdTimer !== undefined) {
+      clearTimeout(drag.holdTimer);
+      drag.holdTimer = null;
+    }
+    if (touchBlockRef.current) {
+      window.removeEventListener('touchmove', touchBlockRef.current);
+      touchBlockRef.current = null;
+    }
+  };
+
   const handleTilePointerDown = (e: React.PointerEvent, accountId: string): void => {
     if (e.button !== 0) return;
-    dragRef.current = {
+    const drag = {
       id: accountId, startX: e.clientX, startY: e.clientY, moved: false,
       baseOrder: selectedAccountIds, hoverId: null,
+      holdTimer: null as ReturnType<typeof setTimeout> | null,
+      lifted: false,
+      pointerType: e.pointerType,
     };
+    dragRef.current = drag;
     (e.currentTarget as HTMLElement).setPointerCapture(e.pointerId);
+    if (e.pointerType === 'touch') {
+      // The hold. It only fires if the finger stayed within the slop — a
+      // finger that moved is scrolling, and the move handler cancels this.
+      drag.holdTimer = setTimeout(() => {
+        if (dragRef.current !== drag) return;
+        drag.holdTimer = null;
+        drag.lifted = true;
+        drag.moved = true;
+        setDraggingId(drag.id);
+        // From here the finger owns the tile: refuse the browser's claim on
+        // the pan. Possible at all because nothing has moved yet — a pan
+        // already underway could not be refused.
+        const block = (ev: TouchEvent): void => ev.preventDefault();
+        touchBlockRef.current = block;
+        window.addEventListener('touchmove', block, { passive: false });
+      }, TOUCH_LIFT_MS);
+    }
   };
 
   const handleTilePointerMove = (e: React.PointerEvent): void => {
     const drag = dragRef.current;
     if (!drag) return;
+    if (drag.pointerType === 'touch' && !drag.lifted) {
+      // Not loosened yet: a finger that moves is scrolling, not dragging.
+      // Cancel the hold and let the browser have the gesture.
+      if (drag.holdTimer !== null &&
+          Math.hypot(e.clientX - drag.startX, e.clientY - drag.startY) >= 8) {
+        clearTimeout(drag.holdTimer);
+        drag.holdTimer = null;
+      }
+      return;
+    }
     if (!drag.moved) {
       if (Math.hypot(e.clientX - drag.startX, e.clientY - drag.startY) < 8) return;
       drag.moved = true;
@@ -519,15 +598,22 @@ export function ImprovedDashboard() {
       .elementFromPoint(e.clientX, e.clientY)
       ?.closest<HTMLElement>('[data-account-tile-id]');
     const targetId = over?.dataset.accountTileId ?? null;
-    if (targetId === drag.hoverId) return;
-    drag.hoverId = targetId;
-    // Always from the base order: leaving a tile un-hovers it completely.
-    setPreviewOrder(targetId && targetId !== drag.id
-      ? swapPositions(drag.baseOrder, drag.id, targetId)
-      : null);
+    // The anti-judder rule lives in utils/reorderList (previewStep), pure and
+    // pinned there — this handler only carries out its answer.
+    const step = previewStep(targetId, drag.id, drag.hoverId);
+    if (step.kind === 'keep') return;
+    if (step.kind === 'revert') {
+      drag.hoverId = null;
+      setPreviewOrder(null);
+      return;
+    }
+    drag.hoverId = step.targetId;
+    // Always from the base order — never cumulative.
+    setPreviewOrder(swapPositions(drag.baseOrder, drag.id, step.targetId));
   };
 
   const endTileDrag = (): void => {
+    releaseTouchHold();
     const drag = dragRef.current;
     if (drag?.moved && drag.hoverId && drag.hoverId !== drag.id) {
       // THE COMMIT — the one moment the stored order changes.
@@ -544,10 +630,19 @@ export function ImprovedDashboard() {
 
   /** A cancelled drag (pointercancel — a scroll won the touch) commits nothing. */
   const cancelTileDrag = (): void => {
+    releaseTouchHold();
     setPreviewOrder(null);
     setDraggingId(null);
     setTimeout(() => { dragRef.current = null; }, 0);
   };
+
+  // A component that unmounts mid-lift must not leave the page unscrollable.
+  useEffect(() => () => {
+    if (touchBlockRef.current) {
+      window.removeEventListener('touchmove', touchBlockRef.current);
+      touchBlockRef.current = null;
+    }
+  }, []);
 
   /** Alt+arrows re-seat from the keyboard; plain keys keep their meanings. */
   const handleTileKeyDown = (e: React.KeyboardEvent, accountId: string): void => {

--- a/src/utils/reorderList.test.ts
+++ b/src/utils/reorderList.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { swapPositions, moveBySteps } from './reorderList';
+import { swapPositions, moveBySteps, previewStep } from './reorderList';
 
 const IDS = ['a', 'b', 'c', 'd', 'e', 'f'];
 
@@ -33,6 +33,31 @@ describe('swapPositions — the hovered tile takes the dragged tile\'s seat', ()
     const before = [...IDS];
     swapPositions(IDS, 'a', 'f');
     expect(IDS).toEqual(before);
+  });
+});
+
+describe('previewStep — the anti-judder rule (owner: "the highlight quickly jumps back and forth")', () => {
+  it('the dragged tile under the pointer is the swap holding steady — the flap loop is dead', () => {
+    // After swapping a↔e, the pointer sits where it always was, but the
+    // DRAGGED tile now renders there. Treating that as "no target" was the
+    // judder: clear, re-find, re-swap, every frame.
+    expect(previewStep('a', 'a', 'e')).toEqual({ kind: 'keep' });
+  });
+
+  it('a grid gap keeps whatever is showing — release commits it', () => {
+    expect(previewStep(null, 'a', 'e')).toEqual({ kind: 'keep' });
+    expect(previewStep(null, 'a', null)).toEqual({ kind: 'keep' });
+  });
+
+  it('the partner under the pointer is the drag come home, and reverts', () => {
+    // The swap moved the partner into the drag's ORIGIN seat, so pointing at
+    // the partner means pointing at where the drag began.
+    expect(previewStep('e', 'a', 'e')).toEqual({ kind: 'revert' });
+  });
+
+  it('only a genuinely new third tile changes the preview', () => {
+    expect(previewStep('c', 'a', 'e')).toEqual({ kind: 'swap', targetId: 'c' });
+    expect(previewStep('e', 'a', null)).toEqual({ kind: 'swap', targetId: 'e' });
   });
 });
 

--- a/src/utils/reorderList.ts
+++ b/src/utils/reorderList.ts
@@ -33,6 +33,40 @@ export function swapPositions(
 }
 
 /**
+ * What a drag's preview should do, given which tile is under the pointer —
+ * the ANTI-JUDDER rule, pure so it can be pinned without a laid-out grid.
+ *
+ * The flap it exists to prevent (owner, 18 Aug: "the highlight quickly jumps
+ * back and forth between the moved from and the moved to"): previewing a
+ * swap moves the DRAGGED tile into the seat under the pointer, so the next
+ * pointer move finds the dragged tile there; treating that as "no target"
+ * cleared the preview, which put the target back under the pointer, which
+ * swapped again — every frame.
+ *
+ * Three stable answers instead:
+ *  - the dragged tile, or no tile at all (a grid gap), is the current
+ *    preview holding steady: KEEP;
+ *  - the current partner under the pointer means the pointer is at the
+ *    drag's ORIGIN seat (the swap is what moved the partner into it) — the
+ *    drag came home: REVERT;
+ *  - only a genuinely new third tile changes anything: SWAP.
+ */
+export type PreviewStep =
+  | { kind: 'keep' }
+  | { kind: 'revert' }
+  | { kind: 'swap'; targetId: string };
+
+export function previewStep(
+  underPointer: string | null,
+  draggedId: string,
+  partnerId: string | null
+): PreviewStep {
+  if (!underPointer || underPointer === draggedId) return { kind: 'keep' };
+  if (partnerId !== null && underPointer === partnerId) return { kind: 'revert' };
+  return { kind: 'swap', targetId: underPointer };
+}
+
+/**
  * Move one member a signed number of steps, clamped to the ends — the
  * keyboard's version of the same gesture (Alt+arrows), where "one step" is a
  * neighbouring seat and the grid's own wrap decides what that looks like.


### PR DESCRIPTION
## Why

Two reports from the owner on the swap shipped in #347:

1. *"the highlight quickly jumps back and forth between the moved from and the moved to … Not a smooth transfer at all"*
2. Tiles cannot be repositioned on the phone at all — and the ask: *"if we hold down for a few seconds, like on an iphone app on the iphone screen, can it then 'loosen itself' to be swapped before leaving go of the screen?"*

## The judder

Geometric and self-inflicted: previewing a swap moves the **dragged** tile into the seat under the pointer, so the next pointer move found the dragged tile there, read it as "no target", cleared the preview — putting the target back under the pointer, which swapped again. Every frame.

The fix is a hysteresis rule, extracted pure into `utils/reorderList` (`previewStep`) so it can be pinned without a laid-out grid:

- the dragged tile under the pointer is the swap **holding steady** — keep;
- a grid gap keeps whatever is showing — release commits it;
- the **partner** under the pointer means the pointer is at the drag's *origin* seat (the swap is what moved the partner into it) — the drag came home, and the preview reverts;
- only a genuinely new third tile changes the preview.

## The phone: hold to loosen

`touch-action: pan-y` means a touch drag had no way to *be* a drag — the browser claimed any movement as a scroll and cancelled the pointer (and a cancelled drag correctly reverts). A press that holds still for **450ms** now lifts the tile: from that moment a non-passive `touchmove` listener refuses the scroll claim — possible only because nothing has moved yet — and the same swap-preview-commit flow runs under the finger. Movement before the lift cancels the hold and the page scrolls as it always did. The refusal is removed on release, cancel, and unmount, so no path leaves the page unscrollable.

**Not verified on a real phone from here** — the browser harness is Chromium and cannot reproduce Safari's touch behaviour. The owner tests that half on his own screen once deployed.

## Verification

`tsc -b` clean, `eslint` clean, full gates green; 31 tests — four new `previewStep` pins (the flap loop dead, gaps keep, home reverts, third tile swaps) plus every existing reorder and dashboard spec unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
