### PR TITLE
fix(recurring): the verdicts are actually LOADED — Confirm existed only in the tests

### DIFF
--- a/src/components/EditTransactionModal.markRecurring.test.tsx
+++ b/src/components/EditTransactionModal.markRecurring.test.tsx
@@ -41,7 +41,8 @@ const mocks = vi.hoisted(() => ({
     linkTransferPair: vi.fn(async () => ({ a: {}, b: {} })),
     createTransferCounterpart: vi.fn(async () => ({ source: {}, counterpart: {} })),
     suggestionDismissals: [] as SuggestionDismissal[],
-    suggestionDismissalsStatus: 'ready' as 'ready' | 'loading',
+    suggestionDismissalsStatus: 'ready' as 'idle' | 'ready' | 'loading',
+    refreshSuggestionDismissals: vi.fn(async () => {}),
     dismissSuggestion: vi.fn(async () => {}),
     restoreSuggestion: vi.fn(async () => {}),
   },
@@ -221,5 +222,18 @@ describe('EditTransactionModal — mark a payment as recurring', () => {
     // An unticked box while the answer is still loading would be a lie about
     // what the user has already said.
     expect(screen.queryByLabelText(/This is a recurring payment/)).not.toBeInTheDocument();
+  });
+
+  it('ASKS for the verdicts when they have never been loaded — the tick cannot appear otherwise', async () => {
+    // The regression that shipped: the tick gated on status 'ready', the
+    // verdicts are lazy-loaded, and nothing in this modal requested them —
+    // so in production the control never existed. 'idle' is the state a
+    // fresh session actually opens in.
+    mocks.app.suggestionDismissalsStatus = 'idle';
+    render(<EditTransactionModal isOpen onClose={vi.fn()} transaction={row()} />);
+
+    await waitFor(() => {
+      expect(mocks.app.refreshSuggestionDismissals).toHaveBeenCalled();
+    });
   });
 });

--- a/src/components/EditTransactionModal.tsx
+++ b/src/components/EditTransactionModal.tsx
@@ -85,7 +85,7 @@ interface FormData {
 }
 
 export default function EditTransactionModal({ isOpen, onClose, transaction, defaultAccountId, onSaveAndNext, onSaveAndPrevious, hideJumpToAccountId }: EditTransactionModalProps): React.JSX.Element {
-  const { accounts, categories, transactions, updateTransaction, deleteTransaction, getTransactionSplits, setTransactionSplits, linkTransferPair, createTransferCounterpart, repointTransfer, suggestionDismissals, suggestionDismissalsStatus, dismissSuggestion, restoreSuggestion } = useApp();
+  const { accounts, categories, transactions, updateTransaction, deleteTransaction, getTransactionSplits, setTransactionSplits, linkTransferPair, createTransferCounterpart, repointTransfer, suggestionDismissals, suggestionDismissalsStatus, refreshSuggestionDismissals, dismissSuggestion, restoreSuggestion } = useApp();
   const { showSuccess, showError, showWarning } = useToast();
   const { addTransaction } = useTransactionNotifications();
   const { propagateCategory } = usePayeeMemory();
@@ -96,6 +96,13 @@ export default function EditTransactionModal({ isOpen, onClose, transaction, def
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
   /** The recurring verdict write in flight, so a double-click cannot record twice. */
   const [savingRecurring, setSavingRecurring] = useState(false);
+
+  // The verdicts are lazy-loaded; the recurring tick gates on 'ready', so an
+  // open modal must ask or the tick never appears (see the note in
+  // RecurringCommitmentsReport).
+  useEffect(() => {
+    if (isOpen && suggestionDismissalsStatus === 'idle') void refreshSuggestionDismissals();
+  }, [isOpen, suggestionDismissalsStatus, refreshSuggestionDismissals]);
   const [showCategoryModal, setShowCategoryModal] = useState(false);
   const [formattedAmount, setFormattedAmount] = useState('');
   // Money-style cross-type categorization: browse the OTHER direction's

--- a/src/pages/Calendar.tsx
+++ b/src/pages/Calendar.tsx
@@ -1,4 +1,4 @@
-import { useState, useMemo } from 'react';
+import { useEffect, useState, useMemo } from 'react';
 import { Link, useNavigate, useLocation } from 'react-router-dom';
 import { useApp } from '../contexts/AppContextSupabase';
 import { useCurrencyDecimal } from '../hooks/useCurrencyDecimal';
@@ -24,7 +24,17 @@ interface DayData {
 }
 
 export default function Calendar() {
-  const { transactions, accounts, suggestionDismissals } = useApp();
+  const {
+    transactions, accounts,
+    suggestionDismissals, suggestionDismissalsStatus, refreshSuggestionDismissals,
+  } = useApp();
+
+  // The verdicts are lazy-loaded; a reader must ask (see the note in
+  // RecurringCommitmentsReport). Without this the due-next panel's confirmed
+  // set was empty in production whatever the user had confirmed.
+  useEffect(() => {
+    if (suggestionDismissalsStatus === 'idle') void refreshSuggestionDismissals();
+  }, [suggestionDismissalsStatus, refreshSuggestionDismissals]);
   const { formatCurrency } = useCurrencyDecimal();
   const navigate = useNavigate();
   const location = useLocation();

--- a/src/pages/reports/RecurringCommitmentsReport.tsx
+++ b/src/pages/reports/RecurringCommitmentsReport.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useState } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import { Link, useLocation } from 'react-router-dom';
 import { useApp } from '../../contexts/AppContextSupabase';
 import { useToast } from '../../contexts/ToastContext';
@@ -75,11 +75,26 @@ export default function RecurringCommitmentsReport(): React.JSX.Element {
   const {
     accounts, transactions, isLoading,
     suggestionDismissals, suggestionDismissalsStatus,
+    refreshSuggestionDismissals,
     dismissSuggestion, restoreSuggestion,
   } = useApp();
   const { formatCurrency, displayCurrency } = useCurrencyDecimal();
   const { showError } = useToast();
   const location = useLocation();
+
+  /**
+   * THE VERDICTS ARE LAZY-LOADED, AND THIS PAGE IS A CONSUMER. The context
+   * fetches suggestion dismissals "when a sweep opens, not at boot" — so a
+   * surface that reads them must ASK, or it reads an empty list with status
+   * 'idle' forever. That is precisely what shipped: the Confirm controls
+   * gate on status 'ready', nothing here requested the load, and the whole
+   * verdict pipeline was invisible in production (owner, 18 Aug: "Where do I
+   * 'approve' the recurring payment?"). The tests mocked the status as
+   * already 'ready', which is how it slipped.
+   */
+  useEffect(() => {
+    if (suggestionDismissalsStatus === 'idle') void refreshSuggestionDismissals();
+  }, [suggestionDismissalsStatus, refreshSuggestionDismissals]);
 
   const accountName = useMemo(
     () => new Map(accounts.map(a => [a.id, a.name])),

--- a/src/pages/reports/__tests__/RecurringCommitmentsReport.verdicts.test.tsx
+++ b/src/pages/reports/__tests__/RecurringCommitmentsReport.verdicts.test.tsx
@@ -52,6 +52,7 @@ const verdictRow = (kind: 'recurring-confirmed' | 'recurring-not'): SuggestionDi
 
 const dismissSuggestion = vi.fn(async () => {});
 const restoreSuggestion = vi.fn(async () => {});
+const refreshSuggestionDismissals = vi.fn(async () => {});
 
 const renderReport = (dismissals: SuggestionDismissal[] = []): void => {
   __setAppContextValue({
@@ -60,6 +61,7 @@ const renderReport = (dismissals: SuggestionDismissal[] = []): void => {
     isLoading: false,
     suggestionDismissals: dismissals,
     suggestionDismissalsStatus: 'ready',
+    refreshSuggestionDismissals,
     dismissSuggestion,
     restoreSuggestion,
   });
@@ -78,10 +80,48 @@ beforeEach(() => {
   localStorage.clear();
   dismissSuggestion.mockClear();
   restoreSuggestion.mockClear();
+  refreshSuggestionDismissals.mockClear();
 });
 
 afterEach(() => {
   __resetAppContextValue();
+});
+
+describe('Recurring commitments — the verdicts must be ASKED FOR', () => {
+  it('requests the lazy-loaded verdicts when they have never been loaded', async () => {
+    /*
+     * THE REGRESSION THAT SHIPPED. The context loads suggestion dismissals
+     * "when a sweep opens, not at boot" — status starts 'idle'. This page
+     * gated its Confirm controls on status 'ready' and never asked for the
+     * load, so in production the whole verdict pipeline was invisible
+     * (owner, 18 Aug: "Where do I 'approve' the recurring payment?"). Every
+     * test mocked 'ready', which is how it slipped. This one starts at
+     * 'idle', as production does.
+     */
+    __setAppContextValue({
+      accounts: [ACCOUNT],
+      transactions: monthlyHistory(),
+      isLoading: false,
+      suggestionDismissals: [],
+      suggestionDismissalsStatus: 'idle',
+      refreshSuggestionDismissals,
+      dismissSuggestion,
+      restoreSuggestion,
+    });
+    render(
+      <MemoryRouter>
+        <PreferencesProvider>
+          <ToastProvider>
+            <RecurringCommitmentsReport />
+          </ToastProvider>
+        </PreferencesProvider>
+      </MemoryRouter>
+    );
+
+    await waitFor(() => {
+      expect(refreshSuggestionDismissals).toHaveBeenCalled();
+    });
+  });
 });
 
 describe('Recurring commitments — the two verdicts', () => {


### PR DESCRIPTION
## Why

The owner, with a screenshot of 35 detections and not one Confirm control anywhere: *"How do I 'agree' that each of these is a recurring transaction? And why can I not yet see these in the future calendar dates? Where do I 'approve' the recurring payment as a recurring payment?"*

## The defect

Suggestion dismissals are **lazy-loaded** — the context's own comment says *"when a sweep opens, not at boot"*, and the status starts `'idle'`. Three surfaces shipped *reading* that state and gating on `'ready'` without any of them *asking* for the load:

- the recurring report's Confirm / Not-recurring controls,
- the calendar's confirmed-patterns gate,
- the edit modal's "This is a recurring payment" tick.

In production the status sat at `'idle'` forever: the controls never rendered, the calendar's confirmed set was empty whatever had been confirmed, and the entire verdict pipeline was invisible.

**Every test mocked the status as already `'ready'`** — the mocks described a state production never reaches on its own, which is exactly how it slipped.

## The fix

The same three lines in each consumer — if the status is `'idle'`, request the load — the one pattern the codebase already had (`TransferSweepModal` does precisely this on open). The lazy-load doctrine stands: nothing moves to boot; a surface that reads the verdicts asks for them.

## Verification

- `tsc -b` clean, `eslint` clean, full gates green.
- **Two regression tests now start from `'idle'`, as a fresh session actually does**: the report requests the load on mount, the modal on open. The `'ready'` mocks stay for the flows that follow.
- 28 tests across the five affected suites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
