### PR TITLE
fix(calendar): tiles speak income and expenditure, outgoings wear their brackets, the overflow is a door

### DIFF
--- a/src/pages/Calendar.tsx
+++ b/src/pages/Calendar.tsx
@@ -11,6 +11,7 @@ import { getDateLocale } from '../utils/dateFormatter';
 import { detectRecurring } from '../utils/recurringDetection';
 import { projectRecurringSchedule } from '../utils/recurringSchedule';
 import { dismissedKeys, recurringAnswerKey } from '../utils/suggestionDismissals';
+import { computeIncomeExpense } from '../utils/incomeExpense';
 
 interface DayData {
   date: Date;
@@ -25,7 +26,7 @@ interface DayData {
 
 export default function Calendar() {
   const {
-    transactions, accounts,
+    transactions, transactionSplits, categories, accounts,
     suggestionDismissals, suggestionDismissalsStatus, refreshSuggestionDismissals,
   } = useApp();
 
@@ -217,15 +218,38 @@ export default function Calendar() {
     [accounts]
   );
 
-  // Month summary
+  /** The due-next panel, opened out past its eight-row cap. */
+  const [showAllDue, setShowAllDue] = useState(false);
+
+  /**
+   * THE MONTH'S TILES SPEAK INCOME AND EXPENDITURE, NOT CASH MOVEMENT
+   * (owner, 18 Aug, reading a month whose "Money in" included a six-figure
+   * transfer between his own accounts: "These figures are not the figures
+   * for one month. It is misleading… they have to at least be correct and
+   * match up to what has actually been the user's 'income' and
+   * 'expenditure' for that month").
+   *
+   * The old tiles summed the day cells, which are a cash-movement ledger —
+   * every movement counts, transfers included. Right for a DAY's activity,
+   * wrong for a headline that reads as the month's income: a standing order
+   * to savings is not earnings. So the tiles now go through the same
+   * computeIncomeExpense the dashboard's cards use (transfers and
+   * revaluations excluded, splits expanded), over exactly the visible
+   * month. The day cells stay the honest movement ledger they were; the
+   * transaction count stays a movement count and says so.
+   */
   const monthSummary = useMemo(() => {
+    const flows = computeIncomeExpense(transactions, transactionSplits, categories, {
+      from: new Date(year, month, 1),
+      to: new Date(year, month + 1, 0, 23, 59, 59, 999),
+    });
     const monthDays = calendarData.filter(d => d.isCurrentMonth);
     return {
-      totalIncome: monthDays.reduce((s, d) => s.plus(toDecimal(d.income)), toDecimal(0)).toNumber(),
-      totalExpense: monthDays.reduce((s, d) => s.plus(toDecimal(d.expense)), toDecimal(0)).toNumber(),
+      totalIncome: flows.income.toNumber(),
+      totalExpense: flows.expenses.toNumber(),
       totalTransactions: monthDays.reduce((s, d) => s + d.transactionCount, 0),
     };
-  }, [calendarData]);
+  }, [transactions, transactionSplits, categories, year, month, calendarData]);
 
   const monthNames = ['January', 'February', 'March', 'April', 'May', 'June',
     'July', 'August', 'September', 'October', 'November', 'December'];
@@ -256,11 +280,11 @@ export default function Calendar() {
       {/* Month summary bar */}
       <div className="grid grid-cols-2 sm:grid-cols-4 gap-3 mb-4">
         <div className="bg-white dark:bg-gray-800 rounded-lg shadow-sm border border-gray-100 dark:border-gray-700 px-4 py-2">
-          <span className="text-sm text-gray-500 dark:text-gray-400">Money in</span>
+          <span className="text-sm text-gray-500 dark:text-gray-400">Income</span>
           <p className="text-lg font-semibold text-green-600 dark:text-green-400">{formatCurrency(monthSummary.totalIncome)}</p>
         </div>
         <div className="bg-white dark:bg-gray-800 rounded-lg shadow-sm border border-gray-100 dark:border-gray-700 px-4 py-2">
-          <span className="text-sm text-gray-500 dark:text-gray-400">Money out</span>
+          <span className="text-sm text-gray-500 dark:text-gray-400">Expenditure</span>
           {/* `dark:text-red-400` is not decoration — without it this figure is
               unreadable at night. `styles/accessibility-colors.css` remaps
               `.text-red-600` to the brand expense red (#c9304a) with
@@ -271,7 +295,10 @@ export default function Calendar() {
               measured 2.8:1, against the 4.5:1 text needs. The income figure
               four lines up has carried the pair all along, which is why only
               the expense went dark. */}
-          <p className="text-lg font-semibold text-red-600 dark:text-red-400">{formatCurrency(monthSummary.totalExpense)}</p>
+          {/* Through formatCurrency as a NEGATIVE, so it wears the app-wide
+              (£X) — a red figure without its brackets was the drift the
+              owner caught on this very tile. */}
+          <p className="text-lg font-semibold text-red-600 dark:text-red-400">{formatCurrency(-monthSummary.totalExpense)}</p>
         </div>
         <div className="bg-white dark:bg-gray-800 rounded-lg shadow-sm border border-gray-100 dark:border-gray-700 px-4 py-2">
           <span className="text-sm text-gray-500 dark:text-gray-400">Net</span>
@@ -330,7 +357,7 @@ export default function Calendar() {
         ) : (
           <>
             <ul className="mt-2 divide-y divide-gray-50 dark:divide-gray-700/50">
-              {dueNext.slice(0, 8).map((occurrence) => (
+              {(showAllDue ? dueNext : dueNext.slice(0, 8)).map((occurrence) => (
                 <li
                   key={`${occurrence.detection.key}-${occurrence.date.getTime()}`}
                   className="py-1.5 flex flex-wrap items-baseline justify-between gap-x-4 gap-y-0.5"
@@ -348,20 +375,33 @@ export default function Calendar() {
                       </span>
                     )}
                   </span>
-                  <span className="text-sm tabular-nums text-gray-600 dark:text-gray-300 shrink-0">
-                    {formatCurrency(occurrence.amount.toNumber())}
-                    {occurrence.detection.direction === 'in' && (
-                      <span className="ml-1 text-xs text-gray-400 dark:text-gray-500">in</span>
-                    )}
+                  {/* An expected OUTGOING wears the expense convention —
+                      red, (£X) — like every other expense figure in the app
+                      (owner, 18 Aug). Expected income is green with its +. */}
+                  <span className={`text-sm tabular-nums shrink-0 ${
+                    occurrence.detection.direction === 'out'
+                      ? 'text-red-600 dark:text-red-400'
+                      : 'text-green-600 dark:text-green-400'
+                  }`}>
+                    {occurrence.detection.direction === 'out'
+                      ? formatCurrency(-occurrence.amount.toNumber())
+                      : `+${formatCurrency(occurrence.amount.toNumber())}`}
                   </span>
                 </li>
               ))}
             </ul>
             {dueNext.length > 8 && (
-              /* Named, never silently truncated. */
-              <p className="mt-1.5 text-xs text-gray-400 dark:text-gray-500">
-                …and {dueNext.length - 8} more in the next 30 days.
-              </p>
+              /* Named, never silently truncated — and now a door, not a
+                 remark (owner, 18 Aug: "click to view all"). */
+              <button
+                type="button"
+                onClick={() => setShowAllDue(open => !open)}
+                className="mt-1.5 text-xs text-gray-500 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-200 hover:underline"
+              >
+                {showAllDue
+                  ? 'Show fewer'
+                  : `…and ${dueNext.length - 8} more in the next 30 days — show all`}
+              </button>
             )}
           </>
         )}

--- a/src/pages/__tests__/Calendar.test.tsx
+++ b/src/pages/__tests__/Calendar.test.tsx
@@ -14,6 +14,9 @@ vi.mock('../../contexts/AppContextSupabase', () => ({
     accounts: [
       { id: 'acc1', name: 'Test Account', type: 'current', balance: 1000, openingBalance: 1000 },
     ],
+    // The Income/Expenditure tiles run computeIncomeExpense, which needs both.
+    transactionSplits: [],
+    categories: [],
     // The forward panel reads the recurring verdicts; none here, so it shows
     // its "nothing confirmed yet" line.
     suggestionDismissals: [],
@@ -91,11 +94,13 @@ describe('Calendar', () => {
         <Calendar />
       </MemoryRouter>
     );
-    // The calendar is a cash-movement day ledger, so its summary deliberately
-    // says money in/out, never "Income"/"Expenses" (those are category
-    // semantics — see utils/incomeExpense).
-    expect(screen.getByText('Money in')).toBeInTheDocument();
-    expect(screen.getByText('Money out')).toBeInTheDocument();
+    // OVERRULED 18 Aug (owner): the day CELLS stay a cash-movement ledger,
+    // but the month's headline tiles now speak Income/Expenditure — computed
+    // through utils/incomeExpense (transfers and revaluations excluded) —
+    // because a month whose "Money in" included transfers between his own
+    // accounts read as earnings that never happened.
+    expect(screen.getByText('Income')).toBeInTheDocument();
+    expect(screen.getByText('Expenditure')).toBeInTheDocument();
     expect(screen.getByText('Net')).toBeInTheDocument();
     expect(screen.getByText('Transactions')).toBeInTheDocument();
   });

--- a/src/pages/__tests__/CalendarDueNext.test.tsx
+++ b/src/pages/__tests__/CalendarDueNext.test.tsx
@@ -32,6 +32,9 @@ vi.mock('../../contexts/AppContextSupabase', () => ({
     accounts: [
       { id: 'acc1', name: 'Synthetic Current', type: 'current', balance: 0, openingBalance: 0 },
     ],
+    // The Income/Expenditure tiles run computeIncomeExpense, which needs both.
+    transactionSplits: [],
+    categories: [],
     suggestionDismissals: [
       {
         id: 'dis-1',
@@ -48,7 +51,12 @@ vi.mock('../../contexts/AppContextSupabase', () => ({
 
 vi.mock('../../hooks/useCurrencyDecimal', () => ({
   useCurrencyDecimal: () => ({
-    formatCurrency: (amount: number) => `£${Number(amount).toFixed(2)}`,
+    // Models the real formatCurrency's negative convention — (£X) — so an
+    // assertion about an expense figure exercises what production renders.
+    formatCurrency: (amount: number) =>
+      Number(amount) < 0
+        ? `(£${Math.abs(Number(amount)).toFixed(2)})`
+        : `£${Number(amount).toFixed(2)}`,
   }),
 }));
 
@@ -64,7 +72,9 @@ describe('Calendar — confirmed patterns feed the forward panel', () => {
     expect(panel).not.toBeNull();
     // Expected ~20 days out (last paid 10 days ago on a monthly rhythm).
     expect(within(panel as HTMLElement).getByText('FLIXWATCH.COM')).toBeInTheDocument();
-    expect(within(panel as HTMLElement).getByText('£7.99')).toBeInTheDocument();
+    // The app-wide expense convention (owner, 18 Aug): an expected outgoing
+    // wears red and its brackets like every other expense figure.
+    expect(within(panel as HTMLElement).getByText('(£7.99)')).toBeInTheDocument();
     expect(within(panel as HTMLElement).getByText('Synthetic Current')).toBeInTheDocument();
     expect(within(panel as HTMLElement).queryByText(/Nothing confirmed yet/)).not.toBeInTheDocument();
   });


### PR DESCRIPTION
## Why

Three from the owner, reading the calendar against his own August.

## The tiles were cash movement dressed as a month's earnings

*"These figures are not the figures for one month. It is misleading… they have to at least be correct and match up to what has actually been the user's 'income' and 'expenditure' for that month."*

The arithmetic was checked before anything changed: the old tiles **did** sum the visible month — but as the day cells do, every movement counted, so a six-figure transfer between the owner's own accounts read as income. The tiles now go through the same `computeIncomeExpense` the dashboard's cards use (transfers and revaluations excluded, splits expanded), over exactly the visible month, and are labelled **Income** and **Expenditure** — which is what they now are. The day cells stay the honest cash-movement ledger they always were; the transaction count stays a movement count.

The doctrine test that pinned *"Money in/out, never Income/Expenses"* is updated to pin the **overruling**, with the owner's reason recorded in place of the old one.

## The expenditure tile also broke the app-wide rule

Red without its brackets. It goes through `formatCurrency` as a negative now, like every other expense figure. Same for the due-next panel's amounts, which rendered neutral: an expected outgoing wears red `(£X)`; expected income is green with its `+`. One suite's `formatCurrency` mock produced no brackets at all (`£-7.99`) — it is taught the real convention rather than the assertion being bent to the mock.

## "…and 13 more" is now a door

Click to open the full 30-day list, click again to fold it back. Named, never silently truncated — now also reachable.

## Verification

`tsc -b` clean, `eslint` clean, full gates green; both calendar suites pass (10 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
