### PR TITLE
feat(recurring): a payee opens the register narrowed to its pattern — every label it has worn

### DIFF
--- a/src/pages/AccountTransactions.tsx
+++ b/src/pages/AccountTransactions.tsx
@@ -50,6 +50,7 @@ import { effectiveOpeningDate, findSiblingAccount } from '../utils/openingDates'
 import { describeDeleteStranding, resolveTransferOtherSide } from '../utils/transferOtherSide';
 import { deleteTransferPair } from '../utils/transferSurvivorRelease';
 import { buildTransactionRegisterPath } from '../utils/transactionDeepLink';
+import { normalisePayeeKey } from '../utils/recurringDetection';
 import { readProvenance, returnState } from '../utils/navigationProvenance';
 import { planBulkDelete, type BulkDeletePlan } from '../utils/registerBulkDelete';
 import { DATE_COLUMN_WIDTH_PX } from '../utils/registerDateColumn';
@@ -546,6 +547,16 @@ export default function AccountTransactions() {
    * the worst kind of stale state — it looks like data loss.
    */
   const [reviewOnly, setReviewOnly] = useState(false);
+  /**
+   * The register narrowed to ONE recurring pattern's payments — every label
+   * it has worn, so a stitched pattern (a bank rename) shows its whole
+   * history in one view. Arrives by URL from Plan → Recurring Payments
+   * (owner, 18 Aug: sending the user to the bare account "is pretty
+   * pointless"), consumed-and-deleted like ?review= so the filter cannot
+   * outlive the click that asked for it. Matching is by the DETECTOR's own
+   * payee normaliser, never a re-derivation that could drift from it.
+   */
+  const [recurringPayeeFilter, setRecurringPayeeFilter] = useState<string[] | null>(null);
   const viewRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
@@ -587,7 +598,8 @@ export default function AccountTransactions() {
     const txn = params.get('txn');
     const hasShowArchived = params.has('showArchived');
     const hasReview = params.has('review');
-    if (!txn && !hasShowArchived && !hasReview) return;
+    const hasRecurringPayee = params.has('recurringPayee');
+    if (!txn && !hasShowArchived && !hasReview && !hasRecurringPayee) return;
     if (txn) {
       pendingTxnRef.current = txn;
       openedAtFootRef.current = accountId ?? null;
@@ -624,6 +636,19 @@ export default function AccountTransactions() {
        */
       if (params.get('review') === '1') setReviewOnly(true);
       params.delete('review');
+    }
+    if (hasRecurringPayee) {
+      // Percent-decoding is URLSearchParams' own; the '|' separator survives
+      // because a normalised payee key cannot contain one (letters, &, '
+      // and spaces only — see normalisePayeeKey).
+      const keys = (params.get('recurringPayee') ?? '')
+        .split('|').map(k => k.trim()).filter(Boolean);
+      if (keys.length > 0) {
+        setRecurringPayeeFilter(keys);
+        // A pattern's history usually predates any archive window.
+        setArchive(prev => (prev.range === 'all' ? prev : { range: 'all', from: '', to: '' }));
+      }
+      params.delete('recurringPayee');
     }
     // The state is carried across by hand. React Router gives a replaced entry
     // null state unless told otherwise, and the state here is the provenance
@@ -907,6 +932,10 @@ export default function AccountTransactions() {
         // Soft archive: hidden from the live register unless the user opts in.
         if (!showArchived && t.archived) return false;
 
+        // One recurring pattern's payments, across every label it has worn.
+        if (recurringPayeeFilter &&
+            !recurringPayeeFilter.includes(normalisePayeeKey(t.description))) return false;
+
         // Type filter
         if (typeFilter !== 'all' && t.type !== typeFilter) return false;
 
@@ -940,7 +969,7 @@ export default function AccountTransactions() {
     // categories is not a dependency: the only thing here that reads them is
     // categoryLabel, which is memoised on exactly them (and on accounts) — so a
     // renamed category rebuilds the labeller and this list follows.
-  }, [account, transactions, searchTerm, dateFrom, dateTo, typeFilter, archiveWindow, showArchived, sortField, sortDirection, categoryLabel]);
+  }, [account, transactions, searchTerm, dateFrom, dateTo, typeFilter, archiveWindow, showArchived, sortField, sortDirection, categoryLabel, recurringPayeeFilter]);
 
   /**
    * How many rows in front of the user have arrived and not been dealt with —
@@ -1010,9 +1039,13 @@ export default function AccountTransactions() {
       names.push(`Show: ${preset?.label ?? archive.range}`);
     }
     if (reviewOnly) names.push('To Review only');
+    if (recurringPayeeFilter) {
+      names.push(`Recurring payee: ${recurringPayeeFilter[0]}${
+        recurringPayeeFilter.length > 1 ? ' (including former names)' : ''}`);
+    }
     if (hasArchivedHere && !showArchived) names.push('archived rows being hidden');
     return names;
-  }, [searchTerm, typeFilter, dateFrom, dateTo, archive.range, reviewOnly, hasArchivedHere, showArchived]);
+  }, [searchTerm, typeFilter, dateFrom, dateTo, archive.range, reviewOnly, recurringPayeeFilter, hasArchivedHere, showArchived]);
 
   /** Puts every one of the above away — the remedy the filtered-empty offers. */
   const clearAllFilters = useCallback((): void => {
@@ -1022,6 +1055,7 @@ export default function AccountTransactions() {
     setDateTo('');
     setArchive(prev => ({ ...prev, range: 'all' }));
     setReviewOnly(false);
+    setRecurringPayeeFilter(null);
     // "Clear filters" has to mean it: if archived rows are among what is
     // hidden, a button that left them hidden would empty the register again
     // and read as broken.
@@ -3175,11 +3209,26 @@ export default function AccountTransactions() {
           <FilterIcon size={14} />
           <span className="sm:hidden">Filters</span>
           <span className="hidden sm:inline">Search &amp; filters</span>
-          {(searchTerm || typeFilter !== 'all' || dateFrom || dateTo) && (
+          {(searchTerm || typeFilter !== 'all' || dateFrom || dateTo || recurringPayeeFilter) && (
             <span className="w-2 h-2 rounded-full bg-blue-500" title="Filters active" />
           )}
           {showFilters ? <ChevronUpIcon size={14} /> : <ChevronDownIcon size={14} />}
         </button>
+
+        {/* ARRIVED FROM A RECURRING PATTERN — the register is narrowed to
+            its payments, and must say so while showing rows, not only when
+            empty (batch-7: a filtered register must never read as the whole
+            account). The one control lets go of just this filter. */}
+        {recurringPayeeFilter && (
+          <button
+            onClick={() => setRecurringPayeeFilter(null)}
+            className={`${TOOLBAR_QUIET_BUTTON} ${TOOLBAR_QUIET_ACTIVE}`}
+            title="Showing one recurring pattern's payments — click to show the whole register"
+          >
+            Recurring payee: {recurringPayeeFilter[0]}
+            {recurringPayeeFilter.length > 1 ? ' (including former names)' : ''} ✕
+          </button>
+        )}
 
         {/* Soft-archive toggle — only when this account has archived history */}
         {hasArchivedHere && (

--- a/src/pages/__tests__/AccountTransactions.recurringPayee.test.tsx
+++ b/src/pages/__tests__/AccountTransactions.recurringPayee.test.tsx
@@ -1,0 +1,125 @@
+/**
+ * ARRIVING FROM A RECURRING PATTERN — the register narrowed to its payments.
+ *
+ * Owner, 18 Aug: clicking a payee on Plan → Recurring Payments sent him to
+ * the bare account register — "pretty pointless". The link now carries
+ * ?recurringPayee=<keys joined by |>, every label the pattern has worn, and
+ * the register:
+ *
+ *  - shows ONLY that pattern's rows, matched by the DETECTOR's own payee
+ *    normaliser (reference numbers collapse, so two raw wordings of one
+ *    payee both match);
+ *  - names the filter among the active filters, so a narrowed register can
+ *    never read as the whole account;
+ *  - consumes the parameter with a replace, like ?review= — the filter dies
+ *    with the click that asked for it;
+ *  - lets go from its own toolbar chip, and from Clear filters with the rest.
+ *
+ * Every name and figure invented — this repo is public.
+ */
+
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { render, screen, fireEvent, within } from '@testing-library/react';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { PreferencesProvider } from '../../contexts/PreferencesContext';
+import { ToastProvider } from '../../contexts/ToastContext';
+import { NotificationProvider } from '../../contexts/NotificationContext';
+import { __setAppContextValue, __resetAppContextValue } from '../../test/mocks/AppContextSupabase';
+import AccountTransactions from '../AccountTransactions';
+import type { Account, Transaction } from '../../types';
+
+const ACCOUNT: Account = {
+  id: 'acc-register', name: 'Synthetic Register', type: 'current', balance: 0,
+  currency: 'GBP', lastUpdated: new Date('2026-01-01'), openingBalance: 100, isActive: true,
+};
+
+const base = {
+  amount: -25,
+  type: 'expense' as const,
+  category: 'det-x',
+  accountId: ACCOUNT.id,
+  cleared: false,
+};
+
+/** The pattern, under its NEW label (a reference number varies per row). */
+const NEW_LABEL_ROW: Transaction = {
+  ...base, id: 'txn-a', description: 'ACME LTD PROPERTY 4021',
+  date: new Date(Date.UTC(2026, 6, 3)),
+};
+/** …and under the label the bank used before the rename. */
+const OLD_LABEL_ROW: Transaction = {
+  ...base, id: 'txn-b', description: 'ACME 9944',
+  date: new Date(Date.UTC(2026, 5, 3)),
+};
+/** A bystander at the same account, not part of the pattern. */
+const OTHER_ROW: Transaction = {
+  ...base, id: 'txn-c', description: 'Midtown Grocer',
+  date: new Date(Date.UTC(2026, 6, 10)),
+};
+
+const renderAt = (url: string) => {
+  __setAppContextValue({
+    accounts: [ACCOUNT],
+    transactions: [NEW_LABEL_ROW, OLD_LABEL_ROW, OTHER_ROW],
+    categories: [],
+    isLoading: false,
+    updateTransaction: vi.fn(async () => {}),
+  });
+  return render(
+    <MemoryRouter initialEntries={[url]}>
+      <PreferencesProvider>
+        <ToastProvider>
+          <NotificationProvider>
+            <Routes>
+              <Route path="/accounts/:accountId" element={<AccountTransactions />} />
+            </Routes>
+          </NotificationProvider>
+        </ToastProvider>
+      </PreferencesProvider>
+    </MemoryRouter>
+  );
+};
+
+const grid = (): HTMLElement =>
+  screen.getByRole('grid', { name: 'Synthetic Register transactions' });
+
+afterEach(() => {
+  __resetAppContextValue();
+});
+
+describe('Account register — arriving from a recurring pattern', () => {
+  it('shows only the pattern’s rows, across every label it has worn', async () => {
+    // The keys are NORMALISED payee identities (the detector's own), so the
+    // raw reference numbers on the rows must not defeat the match.
+    const keys = encodeURIComponent('acme ltd property|acme');
+    renderAt(`/accounts/${ACCOUNT.id}?recurringPayee=${keys}`);
+    await screen.findByRole('heading', { level: 1, name: 'Synthetic Register' });
+
+    expect(within(grid()).getByText('ACME LTD PROPERTY 4021')).toBeInTheDocument();
+    expect(within(grid()).getByText('ACME 9944')).toBeInTheDocument();
+    expect(within(grid()).queryByText('Midtown Grocer')).not.toBeInTheDocument();
+
+    // Named, so a narrowed register can never read as the whole account.
+    expect(screen.getByText(/Recurring payee: acme ltd property \(including former names\)/)).toBeInTheDocument();
+  });
+
+  it('the filter chip is the way out — one click restores the whole register', async () => {
+    const keys = encodeURIComponent('acme ltd property|acme');
+    renderAt(`/accounts/${ACCOUNT.id}?recurringPayee=${keys}`);
+    await screen.findByRole('heading', { level: 1, name: 'Synthetic Register' });
+    expect(within(grid()).queryByText('Midtown Grocer')).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: /Recurring payee:/ }));
+
+    expect(within(grid()).getByText('Midtown Grocer')).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /Recurring payee:/ })).not.toBeInTheDocument();
+  });
+
+  it('without the parameter the register is untouched', async () => {
+    renderAt(`/accounts/${ACCOUNT.id}`);
+    await screen.findByRole('heading', { level: 1, name: 'Synthetic Register' });
+
+    expect(within(grid()).getByText('Midtown Grocer')).toBeInTheDocument();
+    expect(screen.queryByText(/Recurring payee:/)).not.toBeInTheDocument();
+  });
+});

--- a/src/pages/reports/RecurringCommitmentsReport.tsx
+++ b/src/pages/reports/RecurringCommitmentsReport.tsx
@@ -287,10 +287,17 @@ export default function RecurringCommitmentsReport(): React.JSX.Element {
           <p className="text-body text-gray-900 dark:text-white truncate">
             {/* Into the account's register, where the payments themselves are —
                 the same door every other report row opens. */}
+            {/* Into the register FILTERED TO THIS PATTERN — every label it
+                has worn, so a stitched pattern shows its whole history
+                (owner, 18 Aug: the bare account link "is pretty pointless").
+                The register consumes the parameter and names the filter. */}
             <Link
-              to={preserveDemoParam(`/accounts/${detection.accountId}`, location.search)}
+              to={preserveDemoParam(
+                `/accounts/${detection.accountId}?recurringPayee=${encodeURIComponent(detection.payeeKeys.join('|'))}`,
+                location.search
+              )}
               className="hover:text-blue-700 dark:hover:text-blue-400 hover:underline rounded"
-              title={account ? `${account} — open this account's register` : 'Open this account’s register'}
+              title={account ? `${account} — this pattern's payments in the register` : 'This pattern’s payments in the register'}
             >
               {detection.description}
             </Link>
@@ -563,7 +570,10 @@ export default function RecurringCommitmentsReport(): React.JSX.Element {
                     <div className="min-w-0">
                       <p className="text-body text-gray-900 dark:text-white truncate">
                         <Link
-                          to={preserveDemoParam(`/accounts/${d.accountId}`, location.search)}
+                          to={preserveDemoParam(
+                            `/accounts/${d.accountId}?recurringPayee=${encodeURIComponent(d.payeeKeys.join('|'))}`,
+                            location.search
+                          )}
                           className="hover:text-blue-700 dark:hover:text-blue-400 hover:underline rounded"
                         >
                           {d.description}

--- a/src/pages/reports/__tests__/RecurringCommitmentsReport.navigation.test.tsx
+++ b/src/pages/reports/__tests__/RecurringCommitmentsReport.navigation.test.tsx
@@ -170,6 +170,19 @@ describe('Recurring commitments — navigation', () => {
     expect(screen.getByText('£900.00')).toBeInTheDocument();
   });
 
+  it('a payee links to the register FILTERED to the pattern, not the bare account', () => {
+    // Owner, 18 Aug: the bare account link "is pretty pointless". The link
+    // carries every label the pattern has worn, so the register can show a
+    // stitched pattern's whole history in one view.
+    renderReport();
+
+    const link = screen.getByRole('link', { name: 'ZEBRA GYM' });
+    expect(link).toHaveAttribute(
+      'href',
+      `/accounts/acc-a?recurringPayee=${encodeURIComponent('zebra gym')}`
+    );
+  });
+
   it('a verdict stored under a payee’s OLD label still reads as confirmed', () => {
     // The owner's Green GJ case: the bank renamed the payee mid-stream, so the
     // stitched pattern's current label is the long one — but the Confirm he
@@ -222,6 +235,12 @@ describe('Recurring commitments — navigation', () => {
 
     // One pattern, wearing its current label, and the evidence names the old.
     expect(screen.getByText('ACME LTD PROPERTY MAINT')).toBeInTheDocument();
+    // Its register link carries BOTH labels, so the filtered view holds the
+    // whole stitched history.
+    expect(screen.getByRole('link', { name: 'ACME LTD PROPERTY MAINT' })).toHaveAttribute(
+      'href',
+      `/accounts/acc-a?recurringPayee=${encodeURIComponent('acme ltd property maint|acme ltd')}`
+    );
     expect(screen.getByText(/previously labelled ‘ACME LTD’/)).toBeInTheDocument();
     // And the standing verdict is FOUND rather than offered again.
     expect(screen.getByText('Confirmed')).toBeInTheDocument();


### PR DESCRIPTION
## Why

The owner, on clicking a payee name on Plan → Recurring Payments: *"at the minute it takes me in to the account that this / these transactions come from. Not a very helpful link… What would be more helpful is if the account register came up but only with the transactions that are in the exact list you have clicked on… just sending the user to the account in question is pretty pointless to be honest."*

## What changed

The link now carries the pattern: `?recurringPayee=<its payee keys, |-joined>` — **every label the pattern has worn**, so a stitched pattern (a bank rename) opens with its whole history in one view, both wordings together.

- The register consumes it inside the **same one effect** that consumes `?txn=`, `?showArchived=` and `?review=` — that file's own doctrine (one effect, one replace, so consumers cannot overwrite each other's navigation). `?review=` is the exact precedent: a filter that arrives by click, is deleted in the same pass, and cannot outlive the session that asked for it.
- The archive window widens to All on arrival — a pattern's history usually predates any preset.
- Matching is by the **detector's own normaliser** (`normalisePayeeKey`, imported, never re-derived), so the reference numbers on raw rows cannot defeat the match. The `|` separator is safe by construction: a normalised key cannot contain one.
- A narrowed register **says so while showing rows**, not only when empty: a toolbar chip names the payee ("including former names" when stitched) and is itself the way out — one click restores the whole register. The filter is also named in the filtered-empty state and cleared by Clear filters with everything else.

## Verification

`tsc -b` clean, `eslint` clean, full gates green; 26 tests across three suites — the new register suite (both labels' rows shown, bystander hidden, chip named and clears, no-parameter untouched), the report's link pins (single-label and stitched hrefs), and the `?review=` suite unchanged beside its new neighbour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
