### PR TITLE
fix(money): the last four hand-built figures go through the formatter — and a guard so no fifth arrives

### DIFF
--- a/src/components/EnhancedNotificationBell.tsx
+++ b/src/components/EnhancedNotificationBell.tsx
@@ -283,9 +283,9 @@ export default function EnhancedNotificationBell(): React.JSX.Element {
                                 </p>
                                 {activity.amount !== undefined && (
                                   <p className={`text-sm font-medium mt-1 ${
-                                    activity.amount > 0 ? 'text-green-600' : 'text-red-600'
+                                    activity.amount > 0 ? 'text-green-600 dark:text-green-400' : 'text-red-600 dark:text-red-400'
                                   }`}>
-                                    {formatCurrency(Math.abs(activity.amount))}
+                                    {formatCurrency(activity.amount)}
                                   </p>
                                 )}
                                 <p className="text-xs text-gray-500 dark:text-gray-500 mt-1">

--- a/src/components/QIFImportModal.test.tsx
+++ b/src/components/QIFImportModal.test.tsx
@@ -393,7 +393,7 @@ describe('QIFImportModal', () => {
         expect(screen.getByText('Preview (First 5 transactions)')).toBeInTheDocument();
         expect(screen.getByText('2024-01-15 - Grocery Store')).toBeInTheDocument();
         expect(screen.getByText('2024-01-16 - Salary Payment')).toBeInTheDocument();
-        expect(screen.getByText('£50.00')).toBeInTheDocument();
+        expect(screen.getByText('(£50.00)')).toBeInTheDocument();
         expect(screen.getByText('£100.00')).toBeInTheDocument();
       });
     });

--- a/src/components/QIFImportModal.tsx
+++ b/src/components/QIFImportModal.tsx
@@ -397,8 +397,11 @@ export default function QIFImportModal({ isOpen, onClose, initialFile }: QIFImpo
                 {parseResult.transactions.slice(0, 5).map((trx, index) => (
                   <div key={index} className="flex justify-between text-gray-600 dark:text-gray-400">
                     <span>{trx.date} - {trx.payee || trx.memo || 'No description'}</span>
-                    <span className={trx.amount < 0 ? 'text-red-600' : 'text-green-600'}>
-                      {formatCurrency(Math.abs(trx.amount))}
+                    {/* Signed through the formatter, so a negative wears its
+                        (£X) — a red figure without its brackets was the drift
+                        the owner caught on the calendar's own tile. */}
+                    <span className={trx.amount < 0 ? 'text-red-600 dark:text-red-400' : 'text-green-600 dark:text-green-400'}>
+                      {formatCurrency(trx.amount)}
                     </span>
                   </div>
                 ))}

--- a/src/components/TransferRepointDialog.tsx
+++ b/src/components/TransferRepointDialog.tsx
@@ -95,7 +95,7 @@ export default function TransferRepointDialog({
           This transfer is moving to {targetAccountName}. Its other half is a transaction{' '}
           {where}
           {counterpart
-            ? ` for ${counterpart.amount >= 0 ? '+' : '-'}${formatCurrency(Math.abs(counterpart.amount))} on ${new Date(counterpart.date).toLocaleDateString()}`
+            ? ` for ${counterpart.amount >= 0 ? '+' : ''}${formatCurrency(counterpart.amount)} on ${new Date(counterpart.date).toLocaleDateString()}`
             : ''}
           , and it might be a real one rather than one this app created —{' '}
           {reasons[0] ?? 'nothing about it says where it came from'}. Moving a transaction that

--- a/src/hooks/useActivityLogger.ts
+++ b/src/hooks/useActivityLogger.ts
@@ -1,7 +1,7 @@
 import { useEffect, useRef } from 'react';
 import { useApp } from '../contexts/AppContextSupabase';
 import { logActivity } from './useActivityTracking';
-import { formatDecimal } from '../utils/decimal-format';
+import { formatCurrency } from '../utils/currency-decimal';
 import { toDecimal } from '../utils/decimal';
 import { buildTransactionRegisterPath } from '../utils/transactionDeepLink';
 
@@ -79,7 +79,7 @@ export function useActivityLogger() {
           logActivity({
             type: 'account',
             title: `${account.name} Balance Updated`,
-            description: `Balance changed by £${formatDecimal(Math.abs(diff), 2)}`,
+            description: `Balance changed by ${formatCurrency(Math.abs(diff))}`,
             amount: diff,
             // THIS account's register, not the list of all of them. The alert
             // names one account and states a movement; the next question is

--- a/src/test/moneyFormatGuard.test.ts
+++ b/src/test/moneyFormatGuard.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync, readdirSync, statSync } from 'node:fs';
+import path from 'node:path';
+
+/**
+ * NO MONEY FIGURE IS HAND-BUILT. Every amount a user reads goes through the
+ * house formatter, because the formatter is where the app-wide convention
+ * lives: a negative wears red and its brackets — (£417.54), never -£417.54
+ * (Claude Design's ruling of 15 Aug; utils/currency-decimal is the one
+ * definition).
+ *
+ * This guard exists because the convention decayed one surface at a time:
+ * the calendar's own expenditure tile shipped red WITHOUT its brackets (the
+ * owner caught it, 18 Aug), and the 19 Aug audit behind this file found the
+ * same shape in the QIF preview and the notification bell — each a
+ * `formatCurrency(Math.abs(x))` beside a hand-rolled sign colour — plus one
+ * raw `£${…}` template that bypassed the formatter entirely.
+ *
+ * What is BANNED here is the mechanically detectable half: interpolating a
+ * literal pound sign next to a computed value. There is no legitimate use —
+ * a magnitude in prose still goes through formatCurrency, which brings the
+ * locale, the rounding discipline and the negative-zero clamp with it. The
+ * colour half of the convention cannot be greppped (it lives in Tailwind
+ * classes whose correctness depends on the value's sign) and is verified
+ * visually — flagged for Claude Design's capture passes.
+ *
+ * Scanned: every runtime module under src/. Not scanned: tests and mocks
+ * (their invented figures never reach a user) and this file itself.
+ */
+
+const SRC = path.resolve(__dirname, '..');
+
+/** A literal £ immediately followed by an interpolation — the formatter bypass. */
+const RAW_POUND_INTERPOLATION = /£\$\{/;
+
+const isRuntimeModule = (filePath: string): boolean => {
+  if (!/\.(ts|tsx)$/.test(filePath)) return false;
+  if (/\.(test|spec)\.(ts|tsx)$/.test(filePath)) return false;
+  const relative = path.relative(SRC, filePath);
+  if (relative.startsWith(`test${path.sep}`)) return false;
+  if (relative.split(path.sep).includes('__tests__')) return false;
+  if (relative.split(path.sep).includes('mocks')) return false;
+  return true;
+};
+
+const walk = (dir: string, out: string[] = []): string[] => {
+  for (const entry of readdirSync(dir)) {
+    const full = path.join(dir, entry);
+    if (statSync(full).isDirectory()) walk(full, out);
+    else if (isRuntimeModule(full)) out.push(full);
+  }
+  return out;
+};
+
+describe('money figures go through the house formatter', () => {
+  it('no runtime module interpolates a raw £ next to a value', () => {
+    const offenders: string[] = [];
+    for (const file of walk(SRC)) {
+      const source = readFileSync(file, 'utf8');
+      if (!RAW_POUND_INTERPOLATION.test(source)) continue;
+      source.split('\n').forEach((line, index) => {
+        // A comment MENTIONING the banned shape is documentation, not a
+        // rendering — several files explain this very rule in their margins.
+        const code = line.replace(/\/\/.*$/, '').replace(/\/\*.*?\*\//g, '');
+        if (RAW_POUND_INTERPOLATION.test(code)) {
+          offenders.push(`${path.relative(SRC, file)}:${index + 1} — ${line.trim()}`);
+        }
+      });
+    }
+
+    // Named, so the failure tells the author what to do: route the figure
+    // through formatCurrency (utils/currency-decimal, or the
+    // useCurrencyDecimal hook in a component) rather than building it by
+    // hand. If a genuine exception ever exists, it is argued here, in this
+    // file, where the rule is — not silently in the rendering.
+    expect(offenders).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Why

The owner, 18 Aug, after catching the calendar tile red without its brackets: *"Do we need to do an app wide audit of income and expenditure that does not follow the 'green / (red)' rule?"* Yes — and here it is, enumerated mechanically rather than eyeballed.

## The sweep

Every raw `£${…}` interpolation, every `formatCurrency(Math.abs(…))` beside a hand-rolled sign colour, every hand-written minus. **Four genuine violations** survived the #338 sweep:

- `useActivityLogger` built "Balance changed by £X" with a raw pound sign — the one formatter bypass left in runtime code;
- the **QIF import preview** and the **notification bell** both coloured by sign and then *stripped* the sign — a red figure without its brackets, the calendar tile's drift twice more (both also lacked their dark-mode colour halves — unreadable at night per the measured note in Calendar);
- the **transfer repoint dialog** hand-wrote `+`/`-` before a magnitude — the formatter brackets the negative itself now, and the positive keeps its `+` in prose.

## Ruled exceptions, deliberately untouched

The transfer and duplicate sweeps speak in **magnitudes with role words** ("Link £500 transfer") — a transfer is neither income nor expense and its size is not a signed flow. Export files carry data in their own formats. Chart axis ticks keep their colourless minus (Design's standing ruling).

## The guard

`src/test/moneyFormatGuard.test.ts` scans every runtime module under `src/` for a literal £ against an interpolation, naming offenders `file:line` with the fix in the failure text. Comments *mentioning* the shape are exempt — several margins explain this very rule. **Proven non-vacuous** the way the design-pass guards were: the logger's escape was reintroduced, the guard named it, the fix restored.

The **colour half** cannot be grepped — it lives in Tailwind classes whose truth depends on the value's sign — and stays with Claude Design's visual capture passes, as already flagged.

## Verification

`tsc -b` clean, `eslint` clean, full gates green; 78 tests across the five touched suites, including the QIF preview pin updated to assert the bracketed figure it now correctly shows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
