### PR TITLE
feat(forecast): the base — twelve months of category actuals, one-offs struck out loud

### DIFF
--- a/crates/wealth-core/src/row/dismissal.rs
+++ b/crates/wealth-core/src/row/dismissal.rs
@@ -59,8 +59,9 @@ pub struct DismissalRow {
     /// transfer sweep makes (`transfer-pair`, `transfer-leg`, `stranded`,
     /// `duplicate`), the three Payee cleanup makes (`payee-merchant`,
     /// `payee-line`, `payee-hidden`), and the two recurring verdicts
-    /// (`recurring-confirmed`, `recurring-not` — 20260817220000). See the
-    /// module docs.
+    /// (`recurring-confirmed`, `recurring-not` — 20260817220000), and the
+    /// forecast base's one-row exclusion (`forecast-excluded` —
+    /// 20260819130000). See the module docs.
     pub kind: String,
     /// What was refused, as the sweep names it. Unique per (owner, kind).
     pub subject_key: String,

--- a/crates/wealth-core/tests/dismissal_writes.rs
+++ b/crates/wealth-core/tests/dismissal_writes.rs
@@ -231,10 +231,26 @@ fn a_payee_refusal_names_text_and_stores_no_subjects() {
         assert!(answer.answer.subject_ids.is_empty());
     }
 
-    assert_eq!(scalar(&connection, "SELECT COUNT(*) FROM suggestion_dismissals"), 5);
+    // forecast-excluded (20260819130000): a judgment about ONE ROW, so —
+    // unlike the recurring kinds — its subject id is CARRIED: deleting the
+    // transaction cascades the exclusion away, which is correct, because an
+    // exclusion of a row that no longer exists excludes nothing.
+    let excluded = dismiss_suggestion(
+        &mut connection,
+        refusal(
+            "forecast-excluded",
+            SECOND_ROW,
+            &[SECOND_ROW],
+        ),
+    )
+    .expect("forecast exclusion");
+    assert!(excluded.recorded);
+    assert_eq!(excluded.answer.subject_ids.len(), 1);
+
+    assert_eq!(scalar(&connection, "SELECT COUNT(*) FROM suggestion_dismissals"), 6);
     assert_eq!(
         scalar(&connection, "SELECT COUNT(*) FROM suggestion_dismissal_subjects"),
-        0
+        1
     );
 }
 

--- a/scripts/local-sqlite/schema.sql
+++ b/scripts/local-sqlite/schema.sql
@@ -1857,10 +1857,13 @@ CREATE TABLE suggestion_dismissals (
   -- whose payee text no id remapper can touch — with one role-prefixed
   -- ACCOUNT id segment that a restore's remapping rewrites in place, so the
   -- verdict follows the account into its new login.
+  -- forecast-excluded (20260819130000): "not part of my typical month" —
+  -- one row struck from the forecast BASE, key = the row's bare uuid,
+  -- subject id carried so a deleted row takes its exclusion with it.
   kind         TEXT NOT NULL CHECK (kind IN (
                  'transfer-pair','transfer-leg','stranded','duplicate',
                  'payee-merchant','payee-line','payee-hidden',
-                 'recurring-confirmed','recurring-not')),
+                 'recurring-confirmed','recurring-not','forecast-excluded')),
 
   subject_key  TEXT NOT NULL CHECK (trim(subject_key) <> ''),
   dismissed_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now')),

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -53,6 +53,7 @@ const Investments = lazyWithPreload(() => import(/* webpackChunkName: "investmen
 const Budget = lazyWithPreload(() => import(/* webpackChunkName: "budget", webpackPreload: true */ './pages/Budget'));
 const Calendar = lazyWithPreload(() => import(/* webpackChunkName: "calendar" */ './pages/Calendar'));
 const RecurringPayments = lazyWithPreload(() => import(/* webpackChunkName: "recurring-payments" */ './pages/RecurringPayments'));
+const Forecast = lazyWithPreload(() => import(/* webpackChunkName: "forecast" */ './pages/Forecast'));
 const ReportsHub = lazyWithPreload(() => import(/* webpackChunkName: "reports-hub" */ './pages/ReportsHub'));
 const CustomReports = lazyWithPreload(() => import(/* webpackChunkName: "custom-reports" */ './pages/CustomReports'));
 const SettingsPage = lazyWithPreload(() => import(/* webpackChunkName: "settings" */ './pages/Settings'));
@@ -262,6 +263,11 @@ function App(): React.JSX.Element {
                           {/* Its old gallery address — bookmarks and pinned
                               links keep working after the move under Plan. */}
                           <Route path="reports/recurring-commitments" element={<RedirectWithSearch to="/recurring-payments" />} />
+                          <Route path="forecast" element={
+                            <ProtectedSuspense>
+                              <Forecast />
+                            </ProtectedSuspense>
+                          } />
                           <Route path="reports" element={
                             <ProtectedSuspense>
                               <ReportsHub />

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -398,8 +398,12 @@ export default function Layout(): React.JSX.Element {
                 // says what the page is; the page's own heading keeps the
                 // question it answers — "What I'm committed to".
                 { to: '/recurring-payments', icon: ClockIcon, label: 'Recurring Payments' },
+                // The scenario tool's base — review twelve months of actuals,
+                // strike the one-offs, and only ever promote to Budget by an
+                // explicit, per-category act (docs/forecast-direction.md).
+                { to: '/forecast', icon: TrendingUpIcon, label: 'Forecast' },
               ]}
-              activePaths={['/budget', '/calendar', '/recurring-payments']}
+              activePaths={['/budget', '/calendar', '/recurring-payments', '/forecast']}
               openDropdown={openDropdown}
               setOpenDropdown={setOpenDropdown}
             />
@@ -678,6 +682,7 @@ export default function Layout(): React.JSX.Element {
                       <SidebarLink to="/budget" icon={BarChart3Icon} label="Budget" isCollapsed={false} isSubItem={true} onNavigate={toggleMobileMenu} />
                       <SidebarLink to="/calendar" icon={CalendarIcon} label="Calendar" isCollapsed={false} isSubItem={true} onNavigate={toggleMobileMenu} />
                       <SidebarLink to="/recurring-payments" icon={ClockIcon} label="Recurring Payments" isCollapsed={false} isSubItem={true} onNavigate={toggleMobileMenu} />
+                      <SidebarLink to="/forecast" icon={TrendingUpIcon} label="Forecast" isCollapsed={false} isSubItem={true} onNavigate={toggleMobileMenu} />
                     </div>
                   )}
                 </div>

--- a/src/components/__tests__/Layout.test.tsx
+++ b/src/components/__tests__/Layout.test.tsx
@@ -223,13 +223,14 @@ describe('Layout — the Plan menu and split triggers', () => {
     expect(navLink('Recurring Payments')).toHaveAttribute('href', '/recurring-payments');
   });
 
-  it('orders Plan as Budget, Calendar, Recurring Payments', () => {
+  it('orders Plan as Budget, Calendar, Recurring Payments, Forecast', () => {
     renderWithProviders(<Layout />);
 
     expect(openMenuItems('Plan')).toEqual([
       'Budget',
       'Calendar',
       'Recurring Payments',
+      'Forecast',
     ]);
   });
 

--- a/src/components/sweeps/DismissedSuggestionsSection.tsx
+++ b/src/components/sweeps/DismissedSuggestionsSection.tsx
@@ -34,6 +34,7 @@ const KIND_LABELS: Record<DismissalKind, string> = {
   // its own restorable band — and, like the payee kinds, they name no rows.
   'recurring-confirmed': 'Confirmed as recurring',
   'recurring-not': 'Not recurring',
+  'forecast-excluded': 'Excluded from the forecast base',
 };
 
 interface Props {

--- a/src/desktop/MountedLedger.tsx
+++ b/src/desktop/MountedLedger.tsx
@@ -75,6 +75,7 @@ const Categorisation = lazyWithPreload(() => import(/* webpackChunkName: "catego
 const Budget = lazyWithPreload(() => import(/* webpackChunkName: "budget" */ '../pages/Budget'));
 const Calendar = lazyWithPreload(() => import(/* webpackChunkName: "calendar" */ '../pages/Calendar'));
 const RecurringPayments = lazyWithPreload(() => import(/* webpackChunkName: "recurring-payments" */ '../pages/RecurringPayments'));
+const Forecast = lazyWithPreload(() => import(/* webpackChunkName: "forecast" */ '../pages/Forecast'));
 const ReportsHub = lazyWithPreload(() => import(/* webpackChunkName: "reports-hub" */ '../pages/ReportsHub'));
 // Mounted rather than excluded as of the gating decision `routes.ts` records:
 // the local edition is a one-time purchase and its buyer is on the only tier
@@ -238,6 +239,7 @@ export default function MountedLedger(): ReactElement {
     calendar: page(<Calendar />),
     'recurring-payments': page(<RecurringPayments />),
     'reports/recurring-commitments': <RedirectWithSearch to="/recurring-payments" />,
+    forecast: page(<Forecast />),
     reports: page(<ReportsHub />),
     'reports/:reportId': page(<ReportsHub />),
     'custom-reports': page(<CustomReports />),

--- a/src/desktop/__tests__/desktopRouter.test.tsx
+++ b/src/desktop/__tests__/desktopRouter.test.tsx
@@ -182,7 +182,10 @@ describe('the desktop router', () => {
     // before the move still lands. Both are as local as the register they read
     // — detection reads the open file's rows, the verdicts live in the file's
     // own `suggestion_dismissals`.
-    expect(mounted.length).toBe(42);
+    // FORTY-THREE: `forecast` joined on 19 Aug — the scenario tool's base
+    // table (docs/forecast-direction.md step 4), as local as the register it
+    // reviews.
+    expect(mounted.length).toBe(43);
 
     // EMPTY, and the list is kept rather than deleted — `routes.ts` says why:
     // this is one of three ANSWERS a route can have, not an exception to a rule,

--- a/src/desktop/routes.ts
+++ b/src/desktop/routes.ts
@@ -188,6 +188,10 @@ export const DESKTOP_ROUTES = [
   // Its old gallery address, kept as a redirect in both editions so a pin or
   // bookmark made before the move under Plan still lands somewhere.
   { path: 'reports/recurring-commitments', at: 'reports/recurring-commitments', title: 'Recurring payments' },
+  // The forecast's BASE (docs/forecast-direction.md step 4): reads the open
+  // ledger's rows; its exclusions are verdicts in the file's own
+  // suggestion_dismissals — as local as the register it reviews.
+  { path: 'forecast', at: 'forecast', title: 'Forecast' },
   { path: 'reports', at: 'reports', title: 'Reports' },
   { path: 'reports/:reportId', at: 'reports/:reportId', title: 'Reports' },
   { path: 'custom-reports', at: 'custom-reports', title: 'Custom reports' },

--- a/src/pages/Forecast.tsx
+++ b/src/pages/Forecast.tsx
@@ -1,0 +1,359 @@
+import React, { useEffect, useMemo, useState } from 'react';
+import PageWrapper from '../components/PageWrapper';
+import { useApp } from '../contexts/AppContextSupabase';
+import { useToast } from '../contexts/ToastContext';
+import { useCurrencyDecimal } from '../hooks/useCurrencyDecimal';
+import { toDecimal } from '../utils/decimal';
+import { getDateLocale } from '../utils/dateFormatter';
+import { buildCategoryKindLookup, classifyFlow } from '../utils/incomeExpense';
+import { createCategoryLabeller } from '../utils/categoryLabel';
+import { dismissedKeys } from '../utils/suggestionDismissals';
+import type { Transaction } from '../types';
+
+/**
+ * THE FORECAST'S BASE — the last twelve months, category by category.
+ *
+ * Build order step 4 of docs/forecast-direction.md, shipped BEFORE any
+ * projection exists because the ruling demands an inspectable foundation:
+ * the forecast is a SCENARIO TOOL (owner, 17 Aug), it never writes to
+ * Budget on its own, and a scenario that stands on unreviewed actuals
+ * cannot be interrogated. This page is that review — useful alone as a
+ * twelve-month category P&L.
+ *
+ * ── THE BASE IS HONEST OR IT IS NOTHING ────────────────────────────────────
+ *
+ * - TWELVE COMPLETE MONTHS, stated on screen. The current month is not in
+ *   the base: a half-month would understate every category it touches.
+ * - ONE-OFFS ARE EXCLUDABLE, AND THE EXCLUSIONS ARE STATED (§7.1: "with
+ *   the exclusions stated"). The roof, the payout, the car — excluding
+ *   them is what makes the monthly average a typical month; hiding that
+ *   they were excluded would make the average a fiction. The excluded rows
+ *   sit in their own restorable band, counted in the headline.
+ * - An exclusion is a VERDICT, stored beside the app's other suggestion
+ *   answers ('forecast-excluded', migration 20260819130000), keyed by the
+ *   row's own id: it survives reloads and restores, and dies with its row.
+ *   The register is untouched — only this base stops counting the row.
+ * - WHOLE TRANSACTIONS, deliberately. The figures here are grouped from
+ *   the same real rows the expansion lists, so a category's total is
+ *   exactly the sum of the rows shown under it — never a quietly different
+ *   number computed some other way. Transfers and revaluations are not
+ *   income or spending and are left out BY NAME, with their counts.
+ * - The unfiled remainder is a NAMED line per side, excludable like any
+ *   category's rows — a one-off that was never categorised is still a
+ *   one-off.
+ */
+
+const UNFILED_LABEL = 'Uncategorised — not yet filed';
+
+interface BaseGroup {
+  label: string;
+  total: number;
+  rows: Transaction[];
+}
+
+export default function Forecast(): React.JSX.Element {
+  const {
+    accounts, categories, transactions,
+    suggestionDismissals, suggestionDismissalsStatus, refreshSuggestionDismissals,
+    dismissSuggestion, restoreSuggestion,
+  } = useApp();
+  const { formatCurrency } = useCurrencyDecimal();
+  const { showError } = useToast();
+
+  // The verdicts are lazy-loaded; a reader must ask (the #353 lesson — a
+  // surface that gates on 'ready' without requesting the load is invisible).
+  useEffect(() => {
+    if (suggestionDismissalsStatus === 'idle') void refreshSuggestionDismissals();
+  }, [suggestionDismissalsStatus, refreshSuggestionDismissals]);
+
+  const answersReady = suggestionDismissalsStatus === 'ready';
+
+  const excludedIds = useMemo(
+    () => dismissedKeys(suggestionDismissals, 'forecast-excluded'),
+    [suggestionDismissals]
+  );
+
+  /** Twelve COMPLETE months: first of (this month − 12) … last day of last month. */
+  const window = useMemo(() => {
+    const now = new Date();
+    return {
+      from: new Date(now.getFullYear(), now.getMonth() - 12, 1),
+      to: new Date(now.getFullYear(), now.getMonth(), 0, 23, 59, 59, 999),
+    };
+  }, []);
+
+  const labeller = useMemo(() => createCategoryLabeller(categories, accounts), [categories, accounts]);
+  const categoryKinds = useMemo(() => buildCategoryKindLookup(categories), [categories]);
+
+  const base = useMemo(() => {
+    const income = new Map<string, BaseGroup>();
+    const expense = new Map<string, BaseGroup>();
+    let transfers = 0;
+    let revaluations = 0;
+    const excluded: Transaction[] = [];
+
+    const add = (side: Map<string, BaseGroup>, label: string, row: Transaction): void => {
+      const group = side.get(label) ?? { label, total: 0, rows: [] };
+      group.total = toDecimal(group.total).plus(toDecimal(row.amount).abs()).toNumber();
+      group.rows.push(row);
+      side.set(label, group);
+    };
+
+    for (const row of transactions) {
+      const time = new Date(row.date).getTime();
+      if (time < window.from.getTime() || time > window.to.getTime()) continue;
+      if (excludedIds.has(row.id)) { excluded.push(row); continue; }
+      const kind = classifyFlow(row, categoryKinds);
+      if (kind === 'transfer') { transfers++; continue; }
+      if (kind === 'revaluation') { revaluations++; continue; }
+      if (kind === 'uncategorized') {
+        add(row.amount >= 0 ? income : expense, UNFILED_LABEL, row);
+        continue;
+      }
+      add(kind === 'income' ? income : expense, labeller(row) || UNFILED_LABEL, row);
+    }
+
+    const finish = (side: Map<string, BaseGroup>): BaseGroup[] =>
+      [...side.values()]
+        .map(group => ({
+          ...group,
+          rows: [...group.rows].sort((a, b) => Math.abs(b.amount) - Math.abs(a.amount)),
+        }))
+        .sort((a, b) => {
+          // The unfiled line last, whatever its size — it is a remainder,
+          // not a category.
+          if (a.label === UNFILED_LABEL) return 1;
+          if (b.label === UNFILED_LABEL) return -1;
+          return b.total - a.total;
+        });
+
+    const sum = (groups: BaseGroup[]): number =>
+      groups.reduce((total, group) => toDecimal(total).plus(toDecimal(group.total)).toNumber(), 0);
+
+    const incomeGroups = finish(income);
+    const expenseGroups = finish(expense);
+    return {
+      income: incomeGroups,
+      expense: expenseGroups,
+      incomeTotal: sum(incomeGroups),
+      expenseTotal: sum(expenseGroups),
+      transfers,
+      revaluations,
+      excluded: excluded.sort((a, b) => Math.abs(b.amount) - Math.abs(a.amount)),
+    };
+  }, [transactions, window, excludedIds, categoryKinds, labeller]);
+
+  /** Which category's rows are open, as `${side}:${label}`. */
+  const [openGroup, setOpenGroup] = useState<string | null>(null);
+  const [savingId, setSavingId] = useState<string | null>(null);
+
+  const exclude = async (row: Transaction): Promise<void> => {
+    setSavingId(row.id);
+    try {
+      await dismissSuggestion('forecast-excluded', row.id, [row.id]);
+    } catch (error) {
+      showError(error);
+    } finally {
+      setSavingId(null);
+    }
+  };
+
+  const restore = async (id: string): Promise<void> => {
+    setSavingId(id);
+    try {
+      await restoreSuggestion('forecast-excluded', id);
+    } catch (error) {
+      showError(error);
+    } finally {
+      setSavingId(null);
+    }
+  };
+
+  const monthRange = `${window.from.toLocaleDateString(getDateLocale(), { month: 'long', year: 'numeric' })} to ${window.to.toLocaleDateString(getDateLocale(), { month: 'long', year: 'numeric' })}`;
+
+  const average = (total: number): number => toDecimal(total).dividedBy(12).toNumber();
+
+  const accountNameById = useMemo(
+    () => new Map(accounts.map(a => [a.id, a.name])),
+    [accounts]
+  );
+
+  /** One side of the P&L — Income or Expenditure — as a card of groups. */
+  const SideCard = ({ side, title, groups, total }: {
+    side: 'in' | 'out'; title: string; groups: BaseGroup[]; total: number;
+  }): React.JSX.Element => (
+    <div className="bg-white dark:bg-gray-800 rounded-lg border border-line dark:border-gray-700 p-4 sm:p-6">
+      <div className="flex flex-wrap items-baseline justify-between gap-2 mb-2">
+        <h2 className="text-card font-semibold text-theme-heading dark:text-white">{title}</h2>
+        <span className="text-right">
+          <span className={`block text-body font-semibold tabular-nums ${
+            side === 'in' ? 'text-green-600 dark:text-green-400' : 'text-red-600 dark:text-red-400'
+          }`}>
+            {side === 'in' ? `+${formatCurrency(total)}` : formatCurrency(-total)}
+          </span>
+          <span className="block text-dense tabular-nums text-gray-500 dark:text-gray-400">
+            {formatCurrency(average(total))} a month
+          </span>
+        </span>
+      </div>
+      {groups.length === 0 ? (
+        <p className="text-body text-gray-500 dark:text-gray-400">
+          Nothing on this side of the ledger in these twelve months.
+        </p>
+      ) : (
+        <ul>
+          {groups.map(group => {
+            const key = `${side}:${group.label}`;
+            const open = openGroup === key;
+            return (
+              <li key={group.label} className="border-t border-gray-50 dark:border-gray-700/50 first:border-0">
+                <button
+                  type="button"
+                  onClick={() => setOpenGroup(open ? null : key)}
+                  aria-expanded={open}
+                  className="w-full py-2 flex items-baseline justify-between gap-4 text-left hover:bg-gray-50 dark:hover:bg-gray-700/40 rounded"
+                >
+                  <span className={`text-sm truncate ${
+                    group.label === UNFILED_LABEL
+                      ? 'text-gray-500 dark:text-gray-400'
+                      : 'text-gray-900 dark:text-white'
+                  }`}>
+                    {group.label}
+                    <span className="ml-2 text-xs text-gray-400 dark:text-gray-500">{group.rows.length}</span>
+                  </span>
+                  <span className="text-right shrink-0">
+                    <span className="block text-sm tabular-nums text-gray-900 dark:text-white">
+                      {side === 'in' ? `+${formatCurrency(group.total)}` : formatCurrency(-group.total)}
+                    </span>
+                    <span className="block text-xs tabular-nums text-gray-500 dark:text-gray-400">
+                      {formatCurrency(average(group.total))} a month
+                    </span>
+                  </span>
+                </button>
+                {open && (
+                  <ul className="pb-2 pl-2">
+                    {group.rows.map(row => (
+                      <li key={row.id} className="py-1.5 flex flex-wrap items-baseline justify-between gap-x-4 gap-y-0.5 border-t border-gray-50 dark:border-gray-700/50 first:border-0">
+                        <span className="min-w-0 flex items-baseline gap-2">
+                          <span className="text-xs tabular-nums text-gray-500 dark:text-gray-400 w-16 shrink-0">
+                            {new Date(row.date).toLocaleDateString(getDateLocale(), { day: 'numeric', month: 'short', year: '2-digit' })}
+                          </span>
+                          <span className="text-sm text-gray-900 dark:text-white truncate">{row.description}</span>
+                          {accountNameById.get(row.accountId) && (
+                            <span className="text-xs text-gray-400 dark:text-gray-500 truncate">
+                              {accountNameById.get(row.accountId)}
+                            </span>
+                          )}
+                        </span>
+                        <span className="flex items-baseline gap-3 shrink-0">
+                          <span className={`text-sm tabular-nums ${
+                            row.amount >= 0 ? 'text-green-600 dark:text-green-400' : 'text-red-600 dark:text-red-400'
+                          }`}>
+                            {row.amount >= 0 ? `+${formatCurrency(row.amount)}` : formatCurrency(row.amount)}
+                          </span>
+                          {/* The one-off strike. Quiet: there are hundreds of
+                              rows on this page and amber's monopoly holds. */}
+                          {answersReady && (
+                            <button
+                              type="button"
+                              onClick={() => void exclude(row)}
+                              disabled={savingId === row.id}
+                              className="text-xs text-gray-500 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-200 hover:underline disabled:opacity-50"
+                              title="A one-off, not part of a typical month — the base stops counting it; the register is untouched, and it is listed below where it can be restored"
+                            >
+                              Exclude
+                            </button>
+                          )}
+                        </span>
+                      </li>
+                    ))}
+                  </ul>
+                )}
+              </li>
+            );
+          })}
+        </ul>
+      )}
+    </div>
+  );
+
+  return (
+    <PageWrapper title="Forecast">
+      <div className="max-w-[1400px] mx-auto space-y-6">
+        <div className="bg-white dark:bg-gray-800 rounded-lg p-6 border border-line dark:border-gray-700">
+          <h2 className="text-label uppercase tracking-wider font-medium text-gray-500 dark:text-gray-400">
+            The base — your last twelve months
+          </h2>
+          <p className="text-dense text-gray-500 dark:text-gray-400 mt-1">
+            {monthRange}, complete months only — category by category, exactly
+            as the register holds them. This is the ground a scenario stands
+            on: review it, strike out the one-offs that are not part of a
+            typical month, and the averages become honest.{' '}
+            <span className="text-gray-700 dark:text-gray-300">
+              Nothing here writes to your Budget
+            </span>
+            {' '}— a scenario only ever becomes budgets by your explicit,
+            per-category say-so, in a later step.
+          </p>
+          <p className="text-dense text-gray-500 dark:text-gray-400 mt-2">
+            Transfers between your accounts are not income or spending and are
+            left out{base.transfers > 0 && <> ({base.transfers} in this stretch)</>}
+            {base.revaluations > 0 && <>; {base.revaluations} revaluations — ledger arithmetic — likewise</>}.
+            {base.excluded.length > 0 && (
+              <> {base.excluded.length === 1 ? '1 one-off is' : `${base.excluded.length} one-offs are`} excluded
+              from the base — listed at the foot of the page, restorable any time.</>
+            )}
+          </p>
+        </div>
+
+        <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
+          <SideCard side="in" title="Income" groups={base.income} total={base.incomeTotal} />
+          <SideCard side="out" title="Expenditure" groups={base.expense} total={base.expenseTotal} />
+        </div>
+
+        {base.excluded.length > 0 && (
+          /* STATED, never silent (§7.1) — and restorable, because a judgment
+             the user cannot revisit is a deletion wearing a nicer name. */
+          <details className="bg-white dark:bg-gray-800 rounded-lg border border-line dark:border-gray-700">
+            <summary className="cursor-pointer select-none p-6 text-card font-semibold text-theme-heading dark:text-white">
+              Excluded from the base
+              <span className="ml-2 text-dense font-normal text-gray-400 dark:text-gray-500">
+                {base.excluded.length}
+              </span>
+              <span className="ml-3 text-dense font-normal text-gray-500 dark:text-gray-400">
+                One-offs you said are not part of a typical month
+              </span>
+            </summary>
+            <ul className="px-6 pb-6">
+              {base.excluded.map(row => (
+                <li key={row.id} className="py-2 flex flex-wrap items-baseline justify-between gap-x-4 gap-y-0.5 border-t border-gray-50 dark:border-gray-700/50 first:border-0">
+                  <span className="min-w-0 flex items-baseline gap-2">
+                    <span className="text-xs tabular-nums text-gray-500 dark:text-gray-400 w-16 shrink-0">
+                      {new Date(row.date).toLocaleDateString(getDateLocale(), { day: 'numeric', month: 'short', year: '2-digit' })}
+                    </span>
+                    <span className="text-sm text-gray-900 dark:text-white truncate">{row.description}</span>
+                  </span>
+                  <span className="flex items-baseline gap-3 shrink-0">
+                    <span className={`text-sm tabular-nums ${
+                      row.amount >= 0 ? 'text-green-600 dark:text-green-400' : 'text-red-600 dark:text-red-400'
+                    }`}>
+                      {row.amount >= 0 ? `+${formatCurrency(row.amount)}` : formatCurrency(row.amount)}
+                    </span>
+                    <button
+                      type="button"
+                      onClick={() => void restore(row.id)}
+                      disabled={savingId === row.id}
+                      className="text-xs text-gray-500 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-200 hover:underline disabled:opacity-50"
+                    >
+                      Restore
+                    </button>
+                  </span>
+                </li>
+              ))}
+            </ul>
+          </details>
+        )}
+      </div>
+    </PageWrapper>
+  );
+}

--- a/src/pages/__tests__/Forecast.test.tsx
+++ b/src/pages/__tests__/Forecast.test.tsx
@@ -1,0 +1,188 @@
+import React from 'react';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { render, screen, fireEvent, waitFor, within } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { PreferencesProvider } from '../../contexts/PreferencesContext';
+import { ToastProvider } from '../../contexts/ToastContext';
+import { __setAppContextValue, __resetAppContextValue } from '../../test/mocks/AppContextSupabase';
+import Forecast from '../Forecast';
+import type { Account, Category, SuggestionDismissal, Transaction } from '../../types';
+
+/**
+ * THE FORECAST'S BASE (docs/forecast-direction.md step 4): twelve COMPLETE
+ * months of category actuals, one-offs excludable with the exclusions
+ * STATED. The rules pinned here:
+ *
+ *  - the current month is not in the base — a half-month understates;
+ *  - a category's figures are the sum of the rows shown under it;
+ *  - an exclusion is a verdict about ONE ROW ('forecast-excluded', key and
+ *    subject id both the row's own id), and excluded rows are listed in a
+ *    restorable band, never silently subtracted;
+ *  - the unfiled remainder is a named line, excludable like any other;
+ *  - the verdicts are lazy-loaded and this page ASKS (the #353 lesson);
+ *  - the page says, in words, that it never writes to Budget.
+ *
+ * Every payee, category and figure invented — the repo is public.
+ */
+
+const ACCOUNT: Account = {
+  id: 'acc-base', name: 'Synthetic Current', type: 'current', balance: 0,
+  currency: 'GBP', lastUpdated: new Date(), openingBalance: 0, isActive: true,
+};
+
+const CATEGORIES: Category[] = [
+  { id: 'cat-food', name: 'Food', type: 'expense', level: 'detail' },
+  { id: 'cat-salary', name: 'Salary', type: 'income', level: 'detail' },
+];
+
+const now = new Date();
+/** The 15th of each of the twelve complete months before this one. */
+const monthAgo = (monthsBack: number): Date =>
+  new Date(now.getFullYear(), now.getMonth() - monthsBack, 15);
+
+const ONE_OFF_ID = 'txn-one-off';
+
+const LEDGER: Transaction[] = [
+  // Twelve months of £100 Food and £2,000 Salary.
+  ...Array.from({ length: 12 }, (_, i): Transaction[] => ([
+    {
+      id: `food-${i}`, accountId: ACCOUNT.id, description: 'Grocer',
+      amount: -100, date: monthAgo(i + 1), type: 'expense', category: 'cat-food',
+    },
+    {
+      id: `pay-${i}`, accountId: ACCOUNT.id, description: 'Payroll',
+      amount: 2000, date: monthAgo(i + 1), type: 'income', category: 'cat-salary',
+    },
+  ])).flat(),
+  // A £5,000 unfiled one-off — the roof.
+  {
+    id: ONE_OFF_ID, accountId: ACCOUNT.id, description: 'Roof repair',
+    amount: -5000, date: monthAgo(3), type: 'expense', category: '',
+  },
+  // A transfer: neither income nor spending, counted out loud.
+  {
+    id: 'txn-transfer', accountId: ACCOUNT.id, description: 'To savings',
+    amount: -500, date: monthAgo(2), type: 'transfer', category: '',
+  },
+  // THIS month — outside the base by definition.
+  {
+    id: 'txn-current', accountId: ACCOUNT.id, description: 'Current month spend',
+    amount: -999, date: new Date(now.getFullYear(), now.getMonth(), 2), type: 'expense', category: 'cat-food',
+  },
+];
+
+const dismissSuggestion = vi.fn(async () => {});
+const restoreSuggestion = vi.fn(async () => {});
+const refreshSuggestionDismissals = vi.fn(async () => {});
+
+const renderForecast = (
+  dismissals: SuggestionDismissal[] = [],
+  status: 'idle' | 'ready' = 'ready'
+): void => {
+  __setAppContextValue({
+    accounts: [ACCOUNT],
+    categories: CATEGORIES,
+    transactions: LEDGER,
+    isLoading: false,
+    suggestionDismissals: dismissals,
+    suggestionDismissalsStatus: status,
+    refreshSuggestionDismissals,
+    dismissSuggestion,
+    restoreSuggestion,
+  });
+  render(
+    <MemoryRouter>
+      <PreferencesProvider>
+        <ToastProvider>
+          <Forecast />
+        </ToastProvider>
+      </PreferencesProvider>
+    </MemoryRouter>
+  );
+};
+
+const excludedVerdict: SuggestionDismissal = {
+  id: 'dis-roof',
+  kind: 'forecast-excluded',
+  subjectKey: ONE_OFF_ID,
+  subjectIds: [ONE_OFF_ID],
+  dismissedAt: new Date(),
+};
+
+beforeEach(() => {
+  localStorage.clear();
+  dismissSuggestion.mockClear();
+  restoreSuggestion.mockClear();
+  refreshSuggestionDismissals.mockClear();
+});
+
+afterEach(() => {
+  __resetAppContextValue();
+});
+
+describe('Forecast — the base', () => {
+  it('shows twelve complete months by category, with honest averages — the current month left out', () => {
+    renderForecast();
+
+    // Food: 12 × £100 — and NOT 13: the current month's £999 is outside the
+    // base, or the average would claim a typical month that never was.
+    expect(screen.getByText('Food')).toBeInTheDocument();
+    expect(screen.getByText('(£1,200.00)')).toBeInTheDocument();
+    // Salary: 12 × £2,000 — the figure appears TWICE by construction, as the
+    // income side's total and as its only category's, and the two agreeing
+    // is itself the property (a category's figures are the sum of its rows).
+    expect(screen.getByText('Salary')).toBeInTheDocument();
+    expect(screen.getAllByText('+£24,000.00')).toHaveLength(2);
+    expect(screen.getAllByText('£2,000.00 a month')).toHaveLength(2);
+
+    // The unfiled one-off sits under its NAMED line on the expenditure side…
+    expect(screen.getByText('Uncategorised — not yet filed')).toBeInTheDocument();
+    // …and the transfer is left out BY NAME, with its count.
+    expect(screen.getByText(/Transfers between your accounts are not income or spending/)).toBeInTheDocument();
+    expect(screen.getByText(/\(1 in this stretch\)/)).toBeInTheDocument();
+
+    // The ruling, in words, on the page.
+    expect(screen.getByText(/Nothing here writes to your Budget/)).toBeInTheDocument();
+  });
+
+  it('a category expands to the rows its figure is the sum of, and Exclude records the verdict', async () => {
+    renderForecast();
+
+    fireEvent.click(screen.getByRole('button', { name: /Uncategorised — not yet filed/ }));
+    expect(screen.getByText('Roof repair')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Exclude' }));
+    await waitFor(() => {
+      // The verdict is about ONE ROW: key and subject id are both the row's
+      // own id, so a restore remaps it and a deleted row cascades it away.
+      expect(dismissSuggestion).toHaveBeenCalledWith('forecast-excluded', ONE_OFF_ID, [ONE_OFF_ID]);
+    });
+  });
+
+  it('an excluded one-off leaves the figures and sits in a restorable band, stated in the headline', async () => {
+    renderForecast([excludedVerdict]);
+
+    // The expenditure side is Food alone now — the roof is out of the sums,
+    // so the side total and Food's total agree at (£1,200.00).
+    expect(screen.getAllByText('(£1,200.00)')).toHaveLength(2);
+    expect(screen.queryByRole('button', { name: /Uncategorised — not yet filed/ })).not.toBeInTheDocument();
+
+    // …and STATED, twice: in the headline note and in the band.
+    expect(screen.getByText(/1 one-off is excluded/)).toBeInTheDocument();
+    const band = screen.getByText('Excluded from the base').closest('details') as HTMLElement;
+    expect(within(band).getByText('Roof repair')).toBeInTheDocument();
+
+    fireEvent.click(within(band).getByRole('button', { name: 'Restore' }));
+    await waitFor(() => {
+      expect(restoreSuggestion).toHaveBeenCalledWith('forecast-excluded', ONE_OFF_ID);
+    });
+  });
+
+  it('ASKS for the lazy-loaded verdicts when they have never been loaded', async () => {
+    renderForecast([], 'idle');
+
+    await waitFor(() => {
+      expect(refreshSuggestionDismissals).toHaveBeenCalled();
+    });
+  });
+});

--- a/src/services/api/suggestionDismissalService.ts
+++ b/src/services/api/suggestionDismissalService.ts
@@ -19,7 +19,7 @@ import type { DismissalKind, SuggestionDismissal } from '../../types';
 const KINDS: readonly DismissalKind[] = [
   'transfer-pair', 'transfer-leg', 'stranded', 'duplicate',
   'payee-merchant', 'payee-line', 'payee-hidden',
-  'recurring-confirmed', 'recurring-not',
+  'recurring-confirmed', 'recurring-not', 'forecast-excluded',
 ];
 
 const asText = (value: unknown): string | null => (typeof value === 'string' ? value : null);

--- a/src/services/local/mappers/rows.ts
+++ b/src/services/local/mappers/rows.ts
@@ -443,7 +443,8 @@ const DISMISSAL_KINDS: Record<SuggestionDismissal['kind'], true> = {
   'payee-line': true,
   'payee-hidden': true,
   'recurring-confirmed': true,
-  'recurring-not': true
+  'recurring-not': true,
+  'forecast-excluded': true
 };
 
 /**

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -471,7 +471,16 @@ export type DismissalKind =
   | 'stranded'
   | 'duplicate'
   | PayeeDismissalKind
-  | RecurringAnswerKind;
+  | RecurringAnswerKind
+  /**
+   * "Not part of my typical month" — one transaction struck from the
+   * forecast BASE (20260819130000). A judgment about a single row, so its
+   * key is the row's bare uuid (remapped on restore like any id) and its
+   * subject_ids carry the same id, so deleting the row cascades the
+   * exclusion away. The row itself is untouched; only the forecast base
+   * stops counting it — and states that it has.
+   */
+  | 'forecast-excluded';
 
 /**
  * A suggestion the user has told a sweep to stop offering. Holds no financial

--- a/src/utils/suggestionDismissals.ts
+++ b/src/utils/suggestionDismissals.ts
@@ -226,6 +226,7 @@ export function isPayeeDismissalKind(kind: DismissalKind): kind is PayeeDismissa
     case 'duplicate':
     case 'recurring-confirmed':
     case 'recurring-not':
+    case 'forecast-excluded':
       return false;
   }
 }

--- a/supabase/migrations/20260819130000_forecast_exclusions.sql
+++ b/supabase/migrations/20260819130000_forecast_exclusions.sql
@@ -1,0 +1,124 @@
+-- ============================================================================
+-- FORECAST EXCLUSIONS — "this one-off is not part of my typical month"
+-- ============================================================================
+-- IMPORTANT: apply with `npm run db:migrate` (see supabase/migrations/README.md
+-- rule 1 — never the SQL editor).
+--
+-- ORDERING: apply BEFORE the matching client deploys — the same rule as
+-- 20260817220000, for the same reason. It only WIDENS a CHECK constraint, so
+-- the database with this applied and the old client running behaves exactly
+-- as now — but a client that ships first cannot save an exclusion at all, and
+-- the forecast base table has to tell the user their judgment was not kept.
+--
+-- ── WHY ─────────────────────────────────────────────────────────────────────
+--
+-- The forecast is a SCENARIO TOOL (owner's ruling, 17 Aug —
+-- docs/forecast-direction.md): it never writes to Budget on its own, and it
+-- stands on an inspectable base — the last twelve months of category actuals.
+-- A base that includes the one-off (the insurance payout, the roof, the car)
+-- projects a typical month that never happens. So the user may EXCLUDE a
+-- transaction from the base, and the exclusions are STATED on screen — never
+-- a silent subtraction.
+--
+--   forecast-excluded    "not part of my typical month" — the row still sits
+--                        in its register untouched; only the forecast base
+--                        stops counting it, and says so.
+--
+-- The table doctrine holds: a row here holds no financial data and changes no
+-- figure in any register. An exclusion can only narrow what a DERIVED surface
+-- reads.
+--
+-- ── THE KEY SHAPE ───────────────────────────────────────────────────────────
+--
+--   <transaction uuid>
+--
+-- A bare row id, deliberately — unlike the recurring kinds, this verdict is
+-- about ONE ROW, not a pattern that outlives its rows. remapBackupIds treats
+-- a bare uuid-shaped segment as an id and rewrites it on restore, so the
+-- exclusion follows its transaction into a new login. subject_ids carries the
+-- same id, so deleting the transaction cascades the exclusion away with it —
+-- an exclusion of a row that no longer exists excludes nothing and must not
+-- linger as a phantom judgment.
+--
+-- ── SAFE TO RUN TWICE ───────────────────────────────────────────────────────
+-- DROP CONSTRAINT IF EXISTS + ADD CONSTRAINT inside one transaction, exactly
+-- as 20260817220000: idempotent, and the table is never left unconstrained.
+-- ============================================================================
+
+BEGIN;
+
+-- Guard: widening is only valid if every stored row already satisfies the
+-- NEW constraint — which it must, the new list being a superset. "Must" is
+-- not "does": fail here naming the stray, not in the validating scan.
+DO $$
+DECLARE
+  stray_kind text;
+BEGIN
+  SELECT kind INTO stray_kind
+    FROM public.suggestion_dismissals
+   WHERE kind NOT IN (
+     'transfer-pair', 'transfer-leg', 'stranded', 'duplicate',
+     'payee-merchant', 'payee-line', 'payee-hidden',
+     'recurring-confirmed', 'recurring-not', 'forecast-excluded'
+   )
+   LIMIT 1;
+
+  IF stray_kind IS NOT NULL THEN
+    RAISE EXCEPTION
+      'suggestion_dismissals holds kind "%" which this migration does not admit; widen the list here before applying',
+      stray_kind;
+  END IF;
+END $$;
+
+ALTER TABLE public.suggestion_dismissals
+  DROP CONSTRAINT IF EXISTS suggestion_dismissals_kind_known;
+
+ALTER TABLE public.suggestion_dismissals
+  ADD CONSTRAINT suggestion_dismissals_kind_known
+  CHECK (kind IN (
+    'transfer-pair',
+    'transfer-leg',
+    'stranded',
+    'duplicate',
+    'payee-merchant',
+    'payee-line',
+    'payee-hidden',
+    'recurring-confirmed',
+    'recurring-not',
+    'forecast-excluded'
+  ));
+
+COMMENT ON TABLE public.suggestion_dismissals IS
+  'The user''s recorded verdicts on the app''s suggestions. Introduced as refusals ("stop offering me this"); recurring-confirmed (20260817220000) was the first positive verdict; forecast-excluded (20260819130000) is a judgment about one row — "not part of my typical month" — that narrows what the forecast base reads. Every kind holds no financial data and changes no figure.';
+
+COMMENT ON COLUMN public.suggestion_dismissals.subject_key IS
+  'Canonical identity of the suggestion answered: sorted ids joined with "|", prefixed by the finding kind where one scan can produce several kinds of offer about the same rows. The payee-cleanup kinds hold role-prefixed, percent-encoded payee text; the recurring kinds hold account:<id>|recurring:<direction>:<percent-encoded payee key>; forecast-excluded holds a bare transaction uuid, which the restore path remaps like any other id. Unique per (user_id, kind).';
+
+COMMIT;
+
+-- ============================================================================
+-- VERIFICATION — read this output after applying
+-- ============================================================================
+-- 1. The constraint now admits all ten kinds and nothing else.
+SELECT pg_get_constraintdef(oid) AS kind_check
+  FROM pg_constraint
+ WHERE conrelid = 'public.suggestion_dismissals'::regclass
+   AND conname = 'suggestion_dismissals_kind_known';
+
+-- 2. Nothing else moved. Expected: rls_enabled = true and the same three
+--    policies (SELECT, INSERT, DELETE) this table has always had.
+SELECT
+  c.relrowsecurity AS rls_enabled,
+  (SELECT string_agg(p.cmd, ', ' ORDER BY p.cmd) FROM pg_policies p
+    WHERE p.schemaname = 'public' AND p.tablename = 'suggestion_dismissals') AS commands
+FROM pg_class c
+JOIN pg_namespace n ON n.oid = c.relnamespace
+WHERE n.nspname = 'public' AND c.relname = 'suggestion_dismissals';
+
+-- 3. Verdicts by kind. Expected: zero forecast-excluded rows immediately
+--    after applying; afterwards, the count of one-offs the owner has struck
+--    from the base on the Forecast page.
+SELECT kind, count(*) AS verdicts
+  FROM public.suggestion_dismissals
+ GROUP BY kind
+ ORDER BY kind;


### PR DESCRIPTION
## ⚠️ Migration first

**Do not merge until `20260819130000_forecast_exclusions.sql` is applied** (`npm run db:migrate` with the inline `SUPABASE_DB_URL` export). Same ordering rule as `20260817220000`: it only widens the kind CHECK, so the database with it applied and the old client running behaves exactly as now — but a client that ships first cannot save an exclusion at all.

## What this is

Build order step 4 of `docs/forecast-direction.md`, with the ruling on the page in words: the forecast is a **scenario tool**, it never writes to Budget on its own, and a scenario that stands on unreviewed actuals cannot be interrogated. This page is that review — useful alone as a twelve-month category P&L, at **Plan → Forecast**.

## The base is honest or it is nothing

- **Twelve complete months**, stated with their dates — the current month is out, or every category it touches would understate.
- **Whole transactions**: a category's figures are grouped from the same real rows its expansion lists, so a total is exactly the sum of the rows shown under it.
- Transfers and revaluations are neither income nor spending and are left out **by name**, with counts. The unfiled remainder is a named line per side, excludable like any other — a one-off that was never categorised is still a one-off.

## Exclusions are stated, never silent (§7.1)

Striking the roof or the payout is what makes the monthly average a typical month; hiding that they were struck would make the average a fiction. Excluded rows sit in a restorable band, counted in the headline note. An exclusion is a **verdict** — kind `forecast-excluded` — keyed by the row's own bare uuid (remapped on restore like any id) with the same id in `subject_ids`, so **deleting the transaction cascades the exclusion away**. The crate's write test *proved* that cascade: the first cut named a transaction the fixture did not hold, and the FOREIGN KEY refused it.

The kind is admitted across every engine in one change: the cloud CHECK, the local schema's CHECK, the Rust crate's write test, both TS lists, the exhaustive label Record, and the compiler-checked `isPayeeDismissalKind` switch.

The page **asks** for the lazy-loaded verdicts when idle — the #353 lesson, pinned again from the state a fresh session is actually in.

## Wiring

Plan's menu order becomes Budget, Calendar, Recurring Payments, **Forecast**; the desktop router serves the same page over the open file (43 routes) — the verdicts live in the file's own `suggestion_dismissals`, so the base is as local as the register it reviews.

## Verification

`tsc -b` clean, `eslint` clean, full gates green; 16 crate write tests; 4 page specs (honest-average arithmetic with the current month proven out, the verdict's exact shape, the stated-and-restorable band, the idle-state ask); Layout's pinned menu order; the router ratchet at 43; the desktop mount suite's 17 screens.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
