### PR TITLE
feat(forecast): the scenario — stated deviations over the visible base, kept by both engines

### DIFF
--- a/crates/wealth-core/src/backup.rs
+++ b/crates/wealth-core/src/backup.rs
@@ -486,6 +486,17 @@ const SUGGESTION_DISMISSALS: &[Column] = &[
         // is not crossed. A file whose `filters` still named the exporter's
         // accounts would restore into a report that narrows to nothing — wrong,
         // and wrong in a way that is visible on the page rather than in a total.
+        // `monthly_minor` travels under ONE name in both engines — the cloud
+        // column is already an integer of pennies (bigint), so there is no
+        // `_minor` rename and no scale conversion anywhere on this row's trip.
+const FORECAST_ADJUSTMENTS: &[Column] = &[
+            text("id"),
+            text("category_id"),
+            ordinal("monthly_minor"),
+            stamp("created_at"),
+            stamp("updated_at"),
+];
+
 const CUSTOM_REPORTS: &[Column] = &[
             text("id"),
             text("name"),
@@ -554,10 +565,14 @@ pub enum Entity {
     WidgetPreferences,
     /// Carried so a cloud backup restores whole.
     SuggestionDismissals,
-    /// The saved reports. The newest entity the format carries, and the one that
-    /// makes this list fifteen — added by `20260812140000`, which is also where
+    /// The saved reports — added by `20260812140000`, which is also where
     /// the cloud's `restore_user_chunk` grew its fifteenth branch.
     CustomReports,
+    /// The forecast scenario's stated deviations — one row per adjusted
+    /// category. The sixteenth, added by `20260819150000`; relational rather
+    /// than a document precisely so THIS machinery's plainest case (a uuid
+    /// column) is the one that carries its category reference.
+    ForecastAdjustments,
 }
 
 impl Entity {
@@ -569,7 +584,7 @@ impl Entity {
     /// walks it, and so does the exhaustiveness test below. A file whose
     /// sections came out in a different order from the cloud's would be a
     /// different file for no reason a reader could see.
-    pub const ALL: [Self; 15] = [
+    pub const ALL: [Self; 16] = [
         Self::Accounts,
         Self::Categories,
         Self::Transactions,
@@ -585,6 +600,7 @@ impl Entity {
         Self::WidgetPreferences,
         Self::SuggestionDismissals,
         Self::CustomReports,
+        Self::ForecastAdjustments,
     ];
 
     /// The table this entity is stored in.
@@ -606,6 +622,7 @@ impl Entity {
             Self::WidgetPreferences => "widget_preferences",
             Self::SuggestionDismissals => "suggestion_dismissals",
             Self::CustomReports => "custom_reports",
+            Self::ForecastAdjustments => "forecast_adjustments",
         }
     }
 
@@ -636,6 +653,7 @@ impl Entity {
             "widget_preferences" => Self::WidgetPreferences,
             "suggestion_dismissals" => Self::SuggestionDismissals,
             "custom_reports" => Self::CustomReports,
+            "forecast_adjustments" => Self::ForecastAdjustments,
             other => {
                 return Err(CoreError::refuse(
                     "restore_entity_unknown",
@@ -668,6 +686,7 @@ impl Entity {
             Self::WidgetPreferences => WIDGET_PREFERENCES,
             Self::SuggestionDismissals => SUGGESTION_DISMISSALS,
             Self::CustomReports => CUSTOM_REPORTS,
+            Self::ForecastAdjustments => FORECAST_ADJUSTMENTS,
         }
     }
 
@@ -1606,8 +1625,9 @@ mod tests {
     fn every_entity_the_format_carries_is_in_the_walk() {
         // `ALL` is what the collector walks, so an entity missing from it would
         // be a table exported by nobody — the silent half of the same mistake
-        // the exhaustive `columns()` match catches on the way in.
-        assert_eq!(Entity::ALL.len(), 15);
+        // the exhaustive `columns()` match catches on the way in. SIXTEEN
+        // since forecast_adjustments (20260819150000).
+        assert_eq!(Entity::ALL.len(), 16);
         let mut seen = std::collections::BTreeSet::new();
         for entity in Entity::ALL {
             assert!(seen.insert(entity.as_str()), "{} is in ALL twice", entity.as_str());

--- a/crates/wealth-core/src/command.rs
+++ b/crates/wealth-core/src/command.rs
@@ -80,7 +80,7 @@ use crate::error::CoreError;
 use crate::verbs::{
     account_balances, apply_category_to_uncategorized, apply_investment_prices,
     archive_transactions_before,
-    clear_transfer_links, close_account, collect_backup,
+    clear_forecast_adjustment, clear_transfer_links, close_account, collect_backup,
     confirm_transaction_categories, create_account, create_budget, create_categories,
     create_category, create_custom_report, create_goal, create_investment, create_transaction,
     create_transfer_counterpart, delete_budget,
@@ -91,10 +91,12 @@ use crate::verbs::{
     link_bank_account_snap, link_split_line_transfer, link_transfer_pair, list_accounts,
     list_budgets, list_categories, list_closed_accounts, list_custom_reports, list_goals,
     list_investments,
+    list_forecast_adjustments,
     list_suggestion_dismissals,
     list_transaction_splits, list_transactions, load_boot, merge_categories, read_preferences,
     repair_claimed_transfer, repoint_transfer, restore_backup, restore_suggestion,
     restore_user_chunk, seed_categories,
+    set_forecast_adjustment,
     set_transaction_splits_with_legs, set_transactions_archived, set_transactions_cleared,
     splits_for, unarchive_account, update_account, update_budget, update_category,
     update_custom_report,
@@ -102,7 +104,7 @@ use crate::verbs::{
     verify_integrity,
     wipe_user_financial_data, write_preferences,
     ApplyCategoryToUncategorized, ApplyInvestmentPrices, ArchiveTransactionsBefore,
-    ClearTransferLinks, CloseAccount,
+    ClearForecastAdjustment, ClearTransferLinks, CloseAccount,
     CollectBackup, ConfirmTransactionCategories,
     CreateAccount, CreateBudget, CreateCategories, CreateCategory, CreateCustomReport,
     CreateGoal, CreateTransaction,
@@ -115,7 +117,8 @@ use crate::verbs::{
     RepointTransfer,
     RestoreBackup, RestoreSuggestion,
     RestoreUserChunk,
-    SeedCategories, SetTransactionSplitsWithLegs, SetTransactionsArchived, SetTransactionsCleared,
+    SeedCategories, SetForecastAdjustment,
+    SetTransactionSplitsWithLegs, SetTransactionsArchived, SetTransactionsCleared,
     SplitsFor, UnarchiveAccount, UpdateAccount, UpdateBudget,
     UpdateCategory, UpdateCustomReport, UpdateGoal, UpdateInvestment, UpdateTransaction,
     UserFinancialDataIsEmpty,
@@ -305,6 +308,11 @@ pub enum Command {
     // either engine. [`crate::verbs::dismiss_suggestion`] carries it in full.
     /// [`crate::verbs::dismiss_suggestion`].
     DismissSuggestion(Box<DismissSuggestion>),
+    /// [`crate::verbs::set_forecast_adjustment`] — state one category's
+    /// scenario figure. The dismissal family's company: a judgment, unaudited.
+    SetForecastAdjustment(Box<SetForecastAdjustment>),
+    /// [`crate::verbs::clear_forecast_adjustment`] — back to the base.
+    ClearForecastAdjustment(Box<ClearForecastAdjustment>),
     /// [`crate::verbs::restore_suggestion`].
     RestoreSuggestion(Box<RestoreSuggestion>),
     // The restore family. Four verb strings, each spelled exactly as the
@@ -421,6 +429,8 @@ pub enum Command {
     ListInvestments(Box<OwnedRead>),
     /// [`crate::verbs::list_suggestion_dismissals`].
     ListSuggestionDismissals(Box<OwnedRead>),
+    /// [`crate::verbs::list_forecast_adjustments`].
+    ListForecastAdjustments(Box<OwnedRead>),
     // The heavy four. They differ from the six above in what they run over —
     // one person's whole history rather than a page of settings — which is why
     // their plans are measured at 50k rows in [`crate::verbs::reads`] rather
@@ -692,6 +702,12 @@ pub fn dispatch(
         Command::DismissSuggestion(payload) => {
             dismiss_suggestion(connection, *payload).and_then(as_json)
         }
+        Command::SetForecastAdjustment(payload) => {
+            set_forecast_adjustment(connection, *payload).and_then(as_json)
+        }
+        Command::ClearForecastAdjustment(payload) => {
+            clear_forecast_adjustment(connection, *payload).and_then(as_json)
+        }
         Command::RestoreSuggestion(payload) => {
             restore_suggestion(connection, *payload).and_then(as_json)
         }
@@ -763,6 +779,9 @@ pub fn dispatch(
         }
         Command::ListSuggestionDismissals(payload) => {
             list_suggestion_dismissals(&*connection, *payload).and_then(as_json)
+        }
+        Command::ListForecastAdjustments(payload) => {
+            list_forecast_adjustments(&*connection, *payload).and_then(as_json)
         }
         Command::ListTransactions(payload) => {
             list_transactions(&*connection, *payload).and_then(as_json)

--- a/crates/wealth-core/src/row.rs
+++ b/crates/wealth-core/src/row.rs
@@ -104,6 +104,7 @@ pub mod budget;
 pub mod category;
 pub mod custom_report;
 pub mod dismissal;
+pub mod forecast_adjustment;
 pub mod goal;
 pub mod investment;
 pub mod recurring;

--- a/crates/wealth-core/src/row/forecast_adjustment.rs
+++ b/crates/wealth-core/src/row/forecast_adjustment.rs
@@ -1,0 +1,110 @@
+//! `forecast_adjustments` — the scenario's stated deviations from the base.
+//!
+//! One row per category the user has ADJUSTED in the forecast scenario
+//! (`20260819150000` in the cloud, the same table here): the monthly figure
+//! the scenario uses in place of the twelve-month base average. Holds no
+//! ledger data and changes no figure — the scenario READS the base and lays
+//! these on top, and Budget is only ever written by the explicit stage-2
+//! promotion, which does not exist yet.
+//!
+//! # Why relational, not a document
+//!
+//! The backup format's reason, measured rather than tasted: `remapBackupIds`
+//! rewrites uuid COLUMNS, id arrays and named arrays inside a jsonb value —
+//! never the KEYS of a jsonb object. A document keyed by category ids would
+//! restore verbatim into a login whose categories carry fresh ids and
+//! silently adjust nothing. As a column the reference remaps, dangles
+//! loudly, and `ON DELETE CASCADE` takes an adjustment away with its
+//! category — a judgment about a category that no longer exists judges
+//! nothing.
+//!
+//! # `monthly_minor` is pennies, in both engines
+//!
+//! A `bigint` there and an `INTEGER` here — the one representation of money
+//! the two engines hold identically, so this figure crosses the seam without
+//! a scale conversion anywhere. A magnitude: the category's own
+//! income/expense type says which side it lands on.
+
+use rusqlite::{params, Connection};
+use serde::Serialize;
+
+use crate::error::CoreResult;
+
+/// The column list every read here selects, in the order `row_of` reads it.
+const COLUMNS: &str = "id, user_id, category_id, monthly_minor, created_at, updated_at";
+
+/// One adjustment, exactly as the table holds it.
+#[derive(Debug, Clone, Serialize)]
+pub struct ForecastAdjustmentRow {
+    /// Primary key. Client-minted or verb-minted — B-5, like every id here.
+    pub id: String,
+    /// Owner. `NOT NULL` and a foreign key in both engines.
+    pub user_id: String,
+    /// The category whose monthly figure the scenario overrides. CASCADEs.
+    pub category_id: String,
+    /// The scenario's monthly figure for that category, in pennies.
+    pub monthly_minor: i64,
+    /// When the adjustment was first stated.
+    pub created_at: String,
+    /// When it last changed — the one honest remnant of its edit history.
+    pub updated_at: String,
+}
+
+fn row_of(row: &rusqlite::Row<'_>) -> rusqlite::Result<ForecastAdjustmentRow> {
+    Ok(ForecastAdjustmentRow {
+        id: row.get(0)?,
+        user_id: row.get(1)?,
+        category_id: row.get(2)?,
+        monthly_minor: row.get(3)?,
+        created_at: row.get(4)?,
+        updated_at: row.get(5)?,
+    })
+}
+
+/// Every adjustment this login has stated, oldest first.
+///
+/// `created_at, id` — the crate's own list order and its stated tie-break
+/// (see [`crate::verbs::reads`]), not that it shows: the page draws these
+/// into a map keyed by category, so the order is for determinism rather than
+/// for a reader.
+///
+/// # Errors
+/// [`crate::error::CoreError::Storage`] if the read fails.
+pub fn list_all(
+    connection: &Connection,
+    user_id: &str,
+) -> CoreResult<Vec<ForecastAdjustmentRow>> {
+    let mut statement = connection.prepare(&format!(
+        "SELECT {COLUMNS}
+           FROM forecast_adjustments
+          WHERE user_id = ?1
+          ORDER BY created_at, id"
+    ))?;
+    let rows = statement.query_map(params![user_id], row_of)?;
+
+    let mut adjustments = Vec::new();
+    for adjustment in rows {
+        adjustments.push(adjustment?);
+    }
+    Ok(adjustments)
+}
+
+/// The adjustment one (owner, category) pair holds, if any — the read-back
+/// the upsert answers with, so the caller sees what storage holds rather
+/// than what the verb intended.
+///
+/// # Errors
+/// [`crate::error::CoreError::Storage`] if the read fails.
+pub fn read_for_category(
+    connection: &Connection,
+    user_id: &str,
+    category_id: &str,
+) -> CoreResult<Option<ForecastAdjustmentRow>> {
+    let mut statement = connection.prepare(&format!(
+        "SELECT {COLUMNS}
+           FROM forecast_adjustments
+          WHERE user_id = ?1 AND category_id = ?2"
+    ))?;
+    let mut rows = statement.query_map(params![user_id, category_id], row_of)?;
+    rows.next().transpose().map_err(Into::into)
+}

--- a/crates/wealth-core/src/verbs/clear_forecast_adjustment.rs
+++ b/crates/wealth-core/src/verbs/clear_forecast_adjustment.rs
@@ -1,0 +1,54 @@
+//! `clear_forecast_adjustment` — a category goes back to following the base.
+//!
+//! The undo of [`super::set_forecast_adjustment`], and like a suggestion's
+//! restore it is a real DELETE rather than a tombstone: an absent row IS the
+//! state "no adjustment — the scenario reads the base average", so nothing
+//! about the row needs remembering. Clearing a category that holds no
+//! adjustment is a no-op, not an error — the caller asked for a state, and
+//! the state is already so.
+
+use rusqlite::{params, Connection, TransactionBehavior};
+use serde::{Deserialize, Serialize};
+
+use crate::error::CoreResult;
+
+/// The command: whose adjustment, on which category.
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ClearForecastAdjustment {
+    /// Owner.
+    pub user_id: String,
+    /// The category going back to the base.
+    pub category_id: String,
+}
+
+/// What the verb hands back.
+#[derive(Debug, Serialize)]
+pub struct ClearForecastAdjustmentResult {
+    /// 1 when an adjustment was removed, 0 when there was none to remove.
+    pub removed: i64,
+}
+
+/// Remove one category's scenario figure, if it holds one.
+///
+/// # Errors
+/// [`crate::error::CoreError::Storage`] if the write fails.
+#[allow(clippy::needless_pass_by_value)]
+pub fn clear_forecast_adjustment(
+    connection: &mut Connection,
+    command: ClearForecastAdjustment,
+) -> CoreResult<ClearForecastAdjustmentResult> {
+    let transaction = connection.transaction_with_behavior(TransactionBehavior::Immediate)?;
+
+    let removed = transaction.execute(
+        "DELETE FROM forecast_adjustments WHERE user_id = ?1 AND category_id = ?2",
+        params![command.user_id, command.category_id],
+    )?;
+
+    transaction.commit()?;
+
+    Ok(ClearForecastAdjustmentResult {
+        // One row at most — the pair is UNIQUE — so the cast cannot wrap.
+        removed: i64::try_from(removed).unwrap_or(i64::MAX),
+    })
+}

--- a/crates/wealth-core/src/verbs/mod.rs
+++ b/crates/wealth-core/src/verbs/mod.rs
@@ -628,6 +628,7 @@ mod confirm_transaction_categories;
 mod create_account;
 mod create_budget;
 mod create_category;
+mod clear_forecast_adjustment;
 mod create_custom_report;
 mod create_transaction;
 mod create_transfer_counterpart;
@@ -641,6 +642,7 @@ mod delete_investment;
 mod delete_transaction;
 mod delete_unused_categories;
 mod dismiss_suggestion;
+mod set_forecast_adjustment;
 mod finalize_reconciliation;
 mod finalize_user_restore;
 mod import_bank_transactions;
@@ -728,6 +730,15 @@ pub use update_goal::{update_goal, GoalPatch, UpdateGoal, UpdateGoalResult};
 // [`create_custom_report`] carries that argument, and
 // [`update_custom_report`] carries the one a reader coming from
 // [`update_goal`] needs: these blobs REPLACE rather than merge.
+pub use clear_forecast_adjustment::{
+    clear_forecast_adjustment, ClearForecastAdjustment, ClearForecastAdjustmentResult,
+};
+// The adjustment pair keeps the DISMISSAL family's company rather than the
+// report family's: a judgment about how the ledger is read, unaudited and
+// uncounted by the wipe — set_forecast_adjustment's docs carry the argument.
+pub use set_forecast_adjustment::{
+    set_forecast_adjustment, SetForecastAdjustment, SetForecastAdjustmentResult,
+};
 pub use create_custom_report::{
     create_custom_report, CreateCustomReport, CreateCustomReportResult, CustomReportDraft,
 };
@@ -816,10 +827,12 @@ pub use merge_categories::{merge_categories, MergeCategories, MergeCategoriesRes
 // its documentation is where the ordering and the query plans live.
 pub use reads::{
     account_balances, list_accounts, list_budgets, list_categories, list_closed_accounts,
-    list_custom_reports, list_goals, list_investments, list_suggestion_dismissals,
+    list_custom_reports, list_forecast_adjustments, list_goals, list_investments,
+    list_suggestion_dismissals,
     list_transaction_splits,
     list_transactions, splits_for,
-    AccountBalances, Accounts, Answered, Budgets, Categories, ClosedAccounts, CustomReports, Goals,
+    AccountBalances, Accounts, Answered, Budgets, Categories, ClosedAccounts, CustomReports,
+    ForecastAdjustments, Goals,
     Investments,
     OwnedRead, Splits, SplitsFor, SuggestionDismissals, TransactionSplits, Transactions,
 };

--- a/crates/wealth-core/src/verbs/reads.rs
+++ b/crates/wealth-core/src/verbs/reads.rs
@@ -261,6 +261,7 @@ use crate::error::CoreResult;
 use crate::row::account::{self, ListedAccount};
 use crate::row::balance::{self, AccountBalance};
 use crate::row::budget::{self, ListedBudget};
+use crate::row::forecast_adjustment::{self, ForecastAdjustmentRow};
 use crate::row::category::{self, CategoryRow};
 use crate::row::custom_report::{self, CustomReportRow};
 use crate::row::dismissal::{self, DismissalRow};
@@ -366,6 +367,13 @@ pub struct CustomReports {
 pub struct SuggestionDismissals {
     /// Every dismissal, newest first, each with its subjects in role order.
     pub suggestion_dismissals: Vec<DismissalRow>,
+}
+
+/// The scenario's stated deviations from the forecast base.
+#[derive(Debug, Serialize)]
+pub struct ForecastAdjustments {
+    /// Every adjustment this login has stated, oldest first.
+    pub forecast_adjustments: Vec<ForecastAdjustmentRow>,
 }
 
 /// The ledger itself.
@@ -498,6 +506,22 @@ pub fn list_custom_reports(
     Ok(Answered {
         answer: CustomReports {
             custom_reports: custom_report::list_all(connection, &command.user_id)?,
+        },
+    })
+}
+
+/// Every scenario adjustment this login has stated.
+///
+/// # Errors
+/// [`crate::error::CoreError::Storage`] if the read fails.
+#[allow(clippy::needless_pass_by_value)]
+pub fn list_forecast_adjustments(
+    connection: &Connection,
+    command: OwnedRead,
+) -> CoreResult<Answered<ForecastAdjustments>> {
+    Ok(Answered {
+        answer: ForecastAdjustments {
+            forecast_adjustments: forecast_adjustment::list_all(connection, &command.user_id)?,
         },
     })
 }

--- a/crates/wealth-core/src/verbs/set_forecast_adjustment.rs
+++ b/crates/wealth-core/src/verbs/set_forecast_adjustment.rs
@@ -1,0 +1,98 @@
+//! `set_forecast_adjustment` — state, or restate, one category's scenario figure.
+//!
+//! # What it is a port of
+//!
+//! The cloud's upsert onto `forecast_adjustments` (`20260819150000`): one row
+//! per (owner, category), `ON CONFLICT` replacing the monthly figure, because
+//! the scenario is a single stated figure per category rather than a history
+//! of edits — `updated_at` is the history's one honest remnant.
+//!
+//! # A judgment, not authored work — so it does not audit
+//!
+//! The line `wipe_user_financial_data` draws between `custom_reports`
+//! (counted, audited — work the person WROTE) and the dismissals (uncounted,
+//! unaudited — records of how the ledger is READ) puts adjustments with the
+//! dismissals, and this verb keeps that company: no audit entry, exactly as
+//! [`super::dismiss_suggestion`] writes none. Nothing here is money moving —
+//! the figure is a scenario's input, and the scenario changes no register.
+//!
+//! # The FILE refuses the bad category, not this verb
+//!
+//! `category_id` is a foreign key in both engines, so an adjustment naming a
+//! category that does not exist is refused by the schema — surfaced as the
+//! same `constraint_violated` refusal every foreign key here produces — and
+//! this verb holds no second copy of that rule. `monthly_minor >= 0` is the
+//! same story: a CHECK, in both engines.
+
+use rusqlite::{params, Connection, TransactionBehavior};
+use serde::{Deserialize, Serialize};
+
+use crate::db;
+use crate::error::{CoreError, CoreResult};
+use crate::row::forecast_adjustment::{self, ForecastAdjustmentRow};
+
+/// The command: which category, and what its scenario month costs or brings.
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct SetForecastAdjustment {
+    /// Owner. `NOT NULL` and a foreign key in both engines.
+    pub user_id: String,
+    /// The category being adjusted. A foreign key — the file judges it.
+    pub category_id: String,
+    /// The scenario's monthly figure, in pennies. `>= 0` by CHECK.
+    pub monthly_minor: i64,
+    /// Client-minted, or minted here when absent — B-5, the dismissal's rule:
+    /// the differential harness needs to name the same row on both engines.
+    /// Ignored when the pair already holds a row (the upsert keeps its id).
+    #[serde(default)]
+    pub id: Option<String>,
+}
+
+/// What the verb hands back: the row as storage now holds it.
+#[derive(Debug, Serialize)]
+pub struct SetForecastAdjustmentResult {
+    /// The adjustment, read back rather than reconstructed.
+    pub answer: ForecastAdjustmentRow,
+}
+
+/// State one category's scenario figure, replacing any earlier statement.
+///
+/// # Errors
+/// [`CoreError::Refused`] for a rule the file enforced — the category or
+/// users foreign key, or `monthly_minor >= 0`;
+/// [`CoreError::Storage`] for a fault.
+#[allow(clippy::needless_pass_by_value)]
+pub fn set_forecast_adjustment(
+    connection: &mut Connection,
+    command: SetForecastAdjustment,
+) -> CoreResult<SetForecastAdjustmentResult> {
+    let transaction = connection.transaction_with_behavior(TransactionBehavior::Immediate)?;
+    let now = db::now(&transaction)?;
+
+    let id = super::minted_uuid(command.id.as_deref());
+
+    transaction.execute(
+        "INSERT INTO forecast_adjustments (
+           id, user_id, category_id, monthly_minor, created_at, updated_at
+         ) VALUES (?1, ?2, ?3, ?4, ?5, ?5)
+         ON CONFLICT (user_id, category_id) DO UPDATE SET
+           monthly_minor = excluded.monthly_minor,
+           updated_at    = excluded.updated_at",
+        params![id, command.user_id, command.category_id, command.monthly_minor, now],
+    )?;
+
+    // Read back, so the answer is what storage holds — including the ORIGINAL
+    // id and created_at when the upsert landed on an existing row.
+    let stored =
+        forecast_adjustment::read_for_category(&transaction, &command.user_id, &command.category_id)?
+            .ok_or_else(|| {
+                CoreError::refuse(
+                    "forecast_adjustment_not_found",
+                    "the adjustment disappeared between writing it and reading it back",
+                )
+            })?;
+
+    transaction.commit()?;
+
+    Ok(SetForecastAdjustmentResult { answer: stored })
+}

--- a/crates/wealth-core/src/verbs/wipe_user_financial_data.rs
+++ b/crates/wealth-core/src/verbs/wipe_user_financial_data.rs
@@ -322,7 +322,7 @@ pub fn wipe_user_financial_data(
     // Counted by nothing, exactly as the RPC counts them by nothing: these are
     // UI state, and a number telling a user how many dismissed suggestions they
     // just lost is not a number anybody wants.
-    for table in ["suggestion_dismissals", "dashboard_layouts", "widget_preferences", "notifications"] {
+    for table in ["suggestion_dismissals", "forecast_adjustments", "dashboard_layouts", "widget_preferences", "notifications"] {
         delete(table)?;
     }
 

--- a/crates/wealth-core/tests/backup_round_trip.rs
+++ b/crates/wealth-core/tests/backup_round_trip.rs
@@ -492,20 +492,21 @@ fn a_collect_with_no_owner_is_refused_rather_than_reading_the_nearest_ledger() {
 }
 
 #[test]
-fn a_new_file_collects_to_fifteen_empty_sections_rather_than_to_nothing() {
+fn a_new_file_collects_to_sixteen_empty_sections_rather_than_to_nothing() {
     // `buildBackupBundle`'s rule, kept on this side of the seam too: *"a reader
     // should not have to tell 'this user has no investments' apart from 'this
     // export forgot about investments'."*
     //
     // FIFTEEN since custom reports became rows in the file rather than a key in
-    // the WebView's `localStorage`. The count is asserted rather than derived
-    // precisely so that adding a table without deciding what a backup does with
-    // it fails here — a report the file holds and the file's own backup does not
-    // carry would be the original bug wearing a different coat.
+    // the WebView's `localStorage`; SIXTEEN since forecast_adjustments
+    // (20260819150000). The count is asserted rather than derived precisely so
+    // that adding a table without deciding what a backup does with it fails
+    // here — a report the file holds and the file's own backup does not carry
+    // would be the original bug wearing a different coat.
     let mut connection = blank();
     let file = collect(&mut connection);
     let sections = file.as_object().expect("an object");
-    assert_eq!(sections.len(), 15);
+    assert_eq!(sections.len(), 16);
     for (name, rows) in sections {
         assert_eq!(rows, &json!([]), "{name} should be an empty array");
     }

--- a/scripts/local-sqlite/schema.sql
+++ b/scripts/local-sqlite/schema.sql
@@ -1651,6 +1651,33 @@ CREATE INDEX idx_custom_reports_user ON custom_reports(user_id);
 --     dozen rows is write cost bought against a sort of a dozen rows. The
 --     argument, with the measurement behind it, is at `crate::verbs::reads`.
 
+-- One row per category the user has ADJUSTED in the forecast scenario
+-- (20260819150000): the monthly figure the scenario uses in place of the
+-- twelve-month base average. Holds no ledger data and changes no figure —
+-- the scenario reads the base and lays these on top; Budget is only ever
+-- written by the explicit stage-2 promotion, which does not exist yet.
+--
+-- RELATIONAL rather than a json document keyed by category ids, and the
+-- reason is the backup format's: the restore remapper rewrites uuid COLUMNS,
+-- never the keys of a json object, so a document would restore verbatim into
+-- a login with fresh ids and silently adjust nothing. As a column the
+-- reference remaps, dangles loudly, and CASCADEs away with its category.
+--
+-- `monthly_minor` is an INTEGER of pennies — this file's money discipline;
+-- a magnitude, with the category's own income/expense type saying which side
+-- it lands on.
+CREATE TABLE forecast_adjustments (
+  id            TEXT PRIMARY KEY,
+  user_id       TEXT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  category_id   TEXT NOT NULL REFERENCES categories(id) ON DELETE CASCADE,
+  monthly_minor INTEGER NOT NULL CHECK (monthly_minor >= 0),
+  created_at    TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now')),
+  updated_at    TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now')),
+  -- One adjustment per category per user — the scenario is a single stated
+  -- figure, not a history of edits. Doubles as the by-owner lookup.
+  CONSTRAINT forecast_adjustments_one_per_category UNIQUE (user_id, category_id)
+) STRICT;
+
 
 -- ============================================================================
 -- 9. INVESTMENTS

--- a/src/contexts/__tests__/AppContextBootThroughPort.test.tsx
+++ b/src/contexts/__tests__/AppContextBootThroughPort.test.tsx
@@ -228,12 +228,18 @@ vi.mock('../../services/port', () => {
     listCustomReports: answer('listCustomReports', seam.customReports),
     listCategories: answer('listCategories', seam.categories),
     listSuggestionDismissals: answer('listSuggestionDismissals', []),
+    // Reads the boot must NOT make, in the stub because the surface rule
+    // requires the whole seam: the scenario's adjustments are the Forecast
+    // page's own, fetched when it mounts.
+    listForecastAdjustments: answer('listForecastAdjustments', []),
     // A read the boot must NOT make: holdings are the Investments page's own,
     // fetched when that page mounts. It is in the stub because the surface rule
     // requires the whole seam — and it LOGS, so a boot that started reaching for
     // a portfolio would show up in the call list below rather than as a slower
     // launch nobody could account for.
     listInvestments: answer('listInvestments', []),
+    setForecastAdjustment: refuse('setForecastAdjustment'),
+    clearForecastAdjustment: refuse('clearForecastAdjustment'),
     /**
      * The composite, answering with all six at once — which is exactly what an
      * engine is free to do, and what the local edition will do from one

--- a/src/pages/Forecast.tsx
+++ b/src/pages/Forecast.tsx
@@ -8,7 +8,10 @@ import { getDateLocale } from '../utils/dateFormatter';
 import { buildCategoryKindLookup, classifyFlow } from '../utils/incomeExpense';
 import { createCategoryLabeller } from '../utils/categoryLabel';
 import { dismissedKeys } from '../utils/suggestionDismissals';
-import type { Transaction } from '../types';
+import { dataPort } from '@data';
+import MoneyInput from '../components/common/MoneyInput';
+import { parseMoneyInput } from '../utils/decimal';
+import type { ForecastAdjustment, Transaction } from '../types';
 
 /**
  * THE FORECAST'S BASE — the last twelve months, category by category.
@@ -41,11 +44,30 @@ import type { Transaction } from '../types';
  * - The unfiled remainder is a NAMED line per side, excludable like any
  *   category's rows — a one-off that was never categorised is still a
  *   one-off.
+ *
+ * ── THE SCENARIO IS STATED ADJUSTMENTS OVER THE VISIBLE BASE ───────────────
+ *
+ * Design's interrogability rule, and the owner's ruling, made literal: each
+ * category row shows its base average AND its scenario figure side by side.
+ * A category follows the base until the user states otherwise; a stated
+ * figure shows its deviation against the base it deviates from, and one
+ * click returns it. The adjustments persist through the seam
+ * ('forecast_adjustments', both engines — a signed-out browser refuses the
+ * write out loud rather than keeping it somewhere no backup carries). An
+ * adjustment whose category has no recent activity is still SHOWN, in its
+ * own band: a stored deviation that influenced no visible row would be a
+ * scenario nobody can interrogate.
  */
 
 const UNFILED_LABEL = 'Uncategorised — not yet filed';
 
+/** Which side of the P&L a category's flow kind lands on. */
+const categoryKindOfSide = (kind: string | null): 'in' | 'out' | null =>
+  kind === 'income' ? 'in' : kind === 'expense' ? 'out' : null;
+
 interface BaseGroup {
+  /** null for the unfiled remainder — the one line with nothing to adjust. */
+  categoryId: string | null;
   label: string;
   total: number;
   rows: Transaction[];
@@ -92,11 +114,19 @@ export default function Forecast(): React.JSX.Element {
     let revaluations = 0;
     const excluded: Transaction[] = [];
 
-    const add = (side: Map<string, BaseGroup>, label: string, row: Transaction): void => {
-      const group = side.get(label) ?? { label, total: 0, rows: [] };
+    // Keyed by CATEGORY ID, not label — the scenario attaches to the id, and
+    // two categories that happened to share a wording must not share a figure.
+    const add = (
+      side: Map<string, BaseGroup>,
+      categoryId: string | null,
+      label: string,
+      row: Transaction
+    ): void => {
+      const key = categoryId ?? UNFILED_LABEL;
+      const group = side.get(key) ?? { categoryId, label, total: 0, rows: [] };
       group.total = toDecimal(group.total).plus(toDecimal(row.amount).abs()).toNumber();
       group.rows.push(row);
-      side.set(label, group);
+      side.set(key, group);
     };
 
     for (const row of transactions) {
@@ -107,10 +137,10 @@ export default function Forecast(): React.JSX.Element {
       if (kind === 'transfer') { transfers++; continue; }
       if (kind === 'revaluation') { revaluations++; continue; }
       if (kind === 'uncategorized') {
-        add(row.amount >= 0 ? income : expense, UNFILED_LABEL, row);
+        add(row.amount >= 0 ? income : expense, null, UNFILED_LABEL, row);
         continue;
       }
-      add(kind === 'income' ? income : expense, labeller(row) || UNFILED_LABEL, row);
+      add(kind === 'income' ? income : expense, row.category, labeller(row) || UNFILED_LABEL, row);
     }
 
     const finish = (side: Map<string, BaseGroup>): BaseGroup[] =>
@@ -147,6 +177,76 @@ export default function Forecast(): React.JSX.Element {
   const [openGroup, setOpenGroup] = useState<string | null>(null);
   const [savingId, setSavingId] = useState<string | null>(null);
 
+  /**
+   * THE SCENARIO's stored deviations, keyed by category. Loaded through the
+   * seam rather than the app context: the context does not carry them, and
+   * the one page that reads them is this one — the asymmetry the port's own
+   * docs argue against putting them in the boot.
+   */
+  const [adjustments, setAdjustments] = useState<Map<string, ForecastAdjustment>>(new Map());
+  const [adjustmentsStatus, setAdjustmentsStatus] = useState<'loading' | 'ready' | 'error'>('loading');
+  useEffect(() => {
+    let live = true;
+    void (async () => {
+      try {
+        const rows = await dataPort.listForecastAdjustments();
+        if (!live) return;
+        setAdjustments(new Map(rows.map(row => [row.categoryId, row])));
+        setAdjustmentsStatus('ready');
+      } catch {
+        if (!live) return;
+        // A failed read is a scenario that FOLLOWS THE BASE, said on screen —
+        // never invented deviations from another store.
+        setAdjustmentsStatus('error');
+      }
+    })();
+    return () => { live = false; };
+  }, []);
+
+  /** The category currently being adjusted, and the draft in its box. */
+  const [editingCategory, setEditingCategory] = useState<string | null>(null);
+  const [draftMonthly, setDraftMonthly] = useState('');
+  const [savingAdjustment, setSavingAdjustment] = useState(false);
+
+  const stateAdjustment = async (categoryId: string): Promise<void> => {
+    const pounds = parseMoneyInput(draftMonthly);
+    if (pounds === null || pounds < 0) {
+      showError(new Error('Enter the monthly figure for the scenario — zero or more'));
+      return;
+    }
+    setSavingAdjustment(true);
+    try {
+      const stated = await dataPort.setForecastAdjustment(
+        categoryId,
+        toDecimal(pounds).times(100).toNumber()
+      );
+      setAdjustments(previous => new Map(previous).set(categoryId, stated));
+      setEditingCategory(null);
+      setDraftMonthly('');
+    } catch (error) {
+      showError(error);
+    } finally {
+      setSavingAdjustment(false);
+    }
+  };
+
+  const followBase = async (categoryId: string): Promise<void> => {
+    setSavingAdjustment(true);
+    try {
+      await dataPort.clearForecastAdjustment(categoryId);
+      setAdjustments(previous => {
+        const next = new Map(previous);
+        next.delete(categoryId);
+        return next;
+      });
+      setEditingCategory(null);
+    } catch (error) {
+      showError(error);
+    } finally {
+      setSavingAdjustment(false);
+    }
+  };
+
   const exclude = async (row: Transaction): Promise<void> => {
     setSavingId(row.id);
     try {
@@ -167,6 +267,58 @@ export default function Forecast(): React.JSX.Element {
     } finally {
       setSavingId(null);
     }
+  };
+
+  /** A group's SCENARIO monthly figure, in pounds: stated, or the base's. */
+  const scenarioMonthly = (group: BaseGroup): number => {
+    if (group.categoryId !== null) {
+      const stated = adjustments.get(group.categoryId);
+      if (stated) return toDecimal(stated.monthlyMinor).dividedBy(100).toNumber();
+    }
+    return average(group.total);
+  };
+
+  /**
+   * Adjustments on categories the base does not show — no activity in the
+   * window, or category gone from the ledger's list. STILL SHOWN, in their
+   * own band, and still counted in the scenario's totals: a stored deviation
+   * that influenced no visible figure would be a scenario nobody can
+   * interrogate.
+   */
+  const orphanAdjustments = useMemo(() => {
+    const inBase = new Set(
+      [...base.income, ...base.expense]
+        .map(group => group.categoryId)
+        .filter((id): id is string => id !== null)
+    );
+    const named = new Map(categories.map(category => [category.id, category]));
+    return [...adjustments.values()]
+      .filter(adjustment => !inBase.has(adjustment.categoryId))
+      .map(adjustment => {
+        const category = named.get(adjustment.categoryId);
+        return {
+          adjustment,
+          label: category
+            ? (labeller({ category: adjustment.categoryId }) || category.name)
+            : 'A category no longer in your list',
+          side: (category && categoryKindOfSide(categoryKinds.get(adjustment.categoryId) ?? null)) ?? 'out',
+        };
+      });
+  }, [adjustments, base.income, base.expense, categories, labeller, categoryKinds]);
+
+  /** One side's scenario monthly total: its groups' effective figures plus its orphans. */
+  const scenarioSideTotal = (groups: BaseGroup[], side: 'in' | 'out'): number => {
+    const fromGroups = groups.reduce(
+      (total, group) => toDecimal(total).plus(toDecimal(scenarioMonthly(group))).toNumber(),
+      0
+    );
+    return orphanAdjustments
+      .filter(orphan => orphan.side === side)
+      .reduce(
+        (total, orphan) =>
+          toDecimal(total).plus(toDecimal(orphan.adjustment.monthlyMinor).dividedBy(100)).toNumber(),
+        fromGroups
+      );
   };
 
   const monthRange = `${window.from.toLocaleDateString(getDateLocale(), { month: 'long', year: 'numeric' })} to ${window.to.toLocaleDateString(getDateLocale(), { month: 'long', year: 'numeric' })}`;
@@ -194,6 +346,14 @@ export default function Forecast(): React.JSX.Element {
           <span className="block text-dense tabular-nums text-gray-500 dark:text-gray-400">
             {formatCurrency(average(total))} a month
           </span>
+          {/* The side's SCENARIO month, only when it differs — a scenario
+              that follows the base has nothing to announce. */}
+          {adjustmentsStatus === 'ready' &&
+            toDecimal(scenarioSideTotal(groups, side)).minus(toDecimal(average(total))).abs().greaterThan(0.004) && (
+            <span className="block text-dense tabular-nums text-gray-700 dark:text-gray-300">
+              scenario: {formatCurrency(scenarioSideTotal(groups, side))} a month
+            </span>
+          )}
         </span>
       </div>
       {groups.length === 0 ? (
@@ -230,6 +390,83 @@ export default function Forecast(): React.JSX.Element {
                     </span>
                   </span>
                 </button>
+                {/* THE SCENARIO'S FIGURE for this category — stated, or the
+                    base's. Outside the expansion button: adjusting is not
+                    the same act as inspecting the rows. The unfiled line has
+                    nothing to attach an adjustment to; the honest advice is
+                    to FILE the rows, and the base note already carries it. */}
+                {group.categoryId !== null && adjustmentsStatus === 'ready' && (
+                  <div className="pb-2 pl-2 flex flex-wrap items-baseline justify-end gap-x-3 gap-y-1">
+                    {editingCategory === group.categoryId ? (
+                      <>
+                        <label className="flex items-center gap-2 text-xs text-gray-500 dark:text-gray-400">
+                          Scenario, a month
+                          <MoneyInput
+                            value={draftMonthly}
+                            onChange={setDraftMonthly}
+                            className="w-28 px-2 py-1 text-sm text-right tabular-nums border border-line dark:border-gray-600 rounded bg-white dark:bg-gray-800 text-gray-900 dark:text-white"
+                            aria-label={`Scenario monthly figure for ${group.label}`}
+                          />
+                        </label>
+                        <button
+                          type="button"
+                          onClick={() => void stateAdjustment(group.categoryId as string)}
+                          disabled={savingAdjustment}
+                          className="text-xs font-medium text-gray-700 dark:text-gray-300 hover:text-gray-900 dark:hover:text-white hover:underline disabled:opacity-50"
+                        >
+                          State it
+                        </button>
+                        <button
+                          type="button"
+                          onClick={() => { setEditingCategory(null); setDraftMonthly(''); }}
+                          className="text-xs text-gray-500 dark:text-gray-400 hover:underline"
+                        >
+                          Cancel
+                        </button>
+                      </>
+                    ) : adjustments.has(group.categoryId) ? (
+                      <>
+                        {/* A DEVIATION, stated against the base it deviates
+                            from — the whole of the interrogability rule. */}
+                        <span className="text-xs tabular-nums text-gray-700 dark:text-gray-300">
+                          scenario {formatCurrency(scenarioMonthly(group))} a month
+                          <span className="text-gray-400 dark:text-gray-500"> · base {formatCurrency(average(group.total))}</span>
+                        </span>
+                        <button
+                          type="button"
+                          onClick={() => {
+                            setEditingCategory(group.categoryId);
+                            setDraftMonthly(toDecimal(scenarioMonthly(group)).toFixed(2));
+                          }}
+                          className="text-xs text-gray-500 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-200 hover:underline"
+                        >
+                          Change
+                        </button>
+                        <button
+                          type="button"
+                          onClick={() => void followBase(group.categoryId as string)}
+                          disabled={savingAdjustment}
+                          className="text-xs text-gray-500 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-200 hover:underline disabled:opacity-50"
+                        >
+                          Back to base
+                        </button>
+                      </>
+                    ) : (
+                      <button
+                        type="button"
+                        onClick={() => {
+                          setEditingCategory(group.categoryId);
+                          setDraftMonthly(toDecimal(average(group.total)).toFixed(2));
+                        }}
+                        className="text-xs text-gray-400 dark:text-gray-500 hover:text-gray-700 dark:hover:text-gray-300 hover:underline"
+                        title="State a different monthly figure for the scenario — the base stays exactly as it is"
+                        aria-label={`Adjust ${group.label} for the scenario`}
+                      >
+                        Adjust for the scenario
+                      </button>
+                    )}
+                  </div>
+                )}
                 {open && (
                   <ul className="pb-2 pl-2">
                     {group.rows.map(row => (
@@ -304,12 +541,69 @@ export default function Forecast(): React.JSX.Element {
               from the base — listed at the foot of the page, restorable any time.</>
             )}
           </p>
+          {adjustmentsStatus === 'ready' && adjustments.size > 0 && (
+            <p className="text-dense text-gray-700 dark:text-gray-300 mt-2">
+              The scenario adjusts {adjustments.size === 1 ? '1 category' : `${adjustments.size} categories`} —
+              every deviation is shown on its row, against the base it deviates
+              from, and one click returns it. Scenario month:{' '}
+              <span className="tabular-nums">+{formatCurrency(scenarioSideTotal(base.income, 'in'))}</span> in,{' '}
+              <span className="tabular-nums">{formatCurrency(-scenarioSideTotal(base.expense, 'out'))}</span> out.
+            </p>
+          )}
+          {adjustmentsStatus === 'error' && (
+            /* A failed read is a scenario that FOLLOWS THE BASE — said, not
+               guessed at. Deviations invented from a stale copy would be the
+               one dishonesty this page exists to prevent. */
+            <p className="text-dense text-gray-500 dark:text-gray-400 mt-2">
+              Your scenario adjustments could not be loaded just now, so the
+              figures below show the base alone. Reload to try again.
+            </p>
+          )}
         </div>
 
         <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
           <SideCard side="in" title="Income" groups={base.income} total={base.incomeTotal} />
           <SideCard side="out" title="Expenditure" groups={base.expense} total={base.expenseTotal} />
         </div>
+
+        {orphanAdjustments.length > 0 && (
+          /* Stored deviations whose categories show no recent activity — still
+             visible, still counted in the scenario totals, still returnable:
+             a deviation influencing figures from off-screen would make the
+             scenario uninterrogatable. */
+          <div className="bg-white dark:bg-gray-800 rounded-lg border border-line dark:border-gray-700 p-4 sm:p-6">
+            <h2 className="text-card font-semibold text-theme-heading dark:text-white mb-1">
+              Adjustments on quiet categories
+              <span className="ml-2 text-dense font-normal text-gray-400 dark:text-gray-500">
+                {orphanAdjustments.length}
+              </span>
+            </h2>
+            <p className="text-dense text-gray-500 dark:text-gray-400 mb-2">
+              Stated for categories with nothing in these twelve months — still
+              counted in the scenario's totals above.
+            </p>
+            <ul>
+              {orphanAdjustments.map(({ adjustment, label }) => (
+                <li key={adjustment.categoryId} className="py-1.5 flex items-baseline justify-between gap-4 border-t border-gray-50 dark:border-gray-700/50 first:border-0">
+                  <span className="text-sm text-gray-900 dark:text-white truncate">{label}</span>
+                  <span className="flex items-baseline gap-3 shrink-0">
+                    <span className="text-sm tabular-nums text-gray-700 dark:text-gray-300">
+                      {formatCurrency(toDecimal(adjustment.monthlyMinor).dividedBy(100).toNumber())} a month
+                    </span>
+                    <button
+                      type="button"
+                      onClick={() => void followBase(adjustment.categoryId)}
+                      disabled={savingAdjustment}
+                      className="text-xs text-gray-500 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-200 hover:underline disabled:opacity-50"
+                    >
+                      Back to base
+                    </button>
+                  </span>
+                </li>
+              ))}
+            </ul>
+          </div>
+        )}
 
         {base.excluded.length > 0 && (
           /* STATED, never silent (§7.1) — and restorable, because a judgment

--- a/src/pages/__tests__/Forecast.test.tsx
+++ b/src/pages/__tests__/Forecast.test.tsx
@@ -6,7 +6,18 @@ import { PreferencesProvider } from '../../contexts/PreferencesContext';
 import { ToastProvider } from '../../contexts/ToastContext';
 import { __setAppContextValue, __resetAppContextValue } from '../../test/mocks/AppContextSupabase';
 import Forecast from '../Forecast';
-import type { Account, Category, SuggestionDismissal, Transaction } from '../../types';
+import type { Account, Category, ForecastAdjustment, SuggestionDismissal, Transaction } from '../../types';
+
+// The SEAM, not a service: the page reads and writes its scenario through
+// `dataPort`, so the tests stub exactly the three verbs it uses.
+const seam = vi.hoisted(() => ({
+  listForecastAdjustments: vi.fn(async (): Promise<ForecastAdjustment[]> => []),
+  setForecastAdjustment: vi.fn(async (categoryId: string, monthlyMinor: number): Promise<ForecastAdjustment> => ({
+    id: 'adj-1', categoryId, monthlyMinor,
+  })),
+  clearForecastAdjustment: vi.fn(async () => {}),
+}));
+vi.mock('@data', () => ({ dataPort: seam }));
 
 /**
  * THE FORECAST'S BASE (docs/forecast-direction.md step 4): twelve COMPLETE
@@ -114,6 +125,10 @@ beforeEach(() => {
   dismissSuggestion.mockClear();
   restoreSuggestion.mockClear();
   refreshSuggestionDismissals.mockClear();
+  seam.listForecastAdjustments.mockClear();
+  seam.listForecastAdjustments.mockResolvedValue([]);
+  seam.setForecastAdjustment.mockClear();
+  seam.clearForecastAdjustment.mockClear();
 });
 
 afterEach(() => {
@@ -176,6 +191,68 @@ describe('Forecast — the base', () => {
     await waitFor(() => {
       expect(restoreSuggestion).toHaveBeenCalledWith('forecast-excluded', ONE_OFF_ID);
     });
+  });
+
+  it('a category can be adjusted for the scenario — the deviation stated against its base', async () => {
+    renderForecast();
+    await waitFor(() => expect(seam.listForecastAdjustments).toHaveBeenCalled());
+
+    // Food's base average is £100 a month. State £90 for the scenario.
+    fireEvent.click(screen.getByRole('button', { name: 'Adjust Food for the scenario' }));
+    fireEvent.change(screen.getByLabelText('Scenario monthly figure for Food'), {
+      target: { value: '90' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'State it' }));
+
+    await waitFor(() => {
+      // Pennies across the seam — £90 crosses as 9000.
+      expect(seam.setForecastAdjustment).toHaveBeenCalledWith('cat-food', 9000);
+    });
+    // The deviation is STATED against the base it deviates from…
+    expect(screen.getByText(/scenario £90\.00 a month/)).toBeInTheDocument();
+    expect(screen.getByText(/base £100\.00/)).toBeInTheDocument();
+    // …and the base's own figures are untouched.
+    expect(screen.getByText('(£1,200.00)')).toBeInTheDocument();
+
+    // One click returns it.
+    fireEvent.click(screen.getByRole('button', { name: 'Back to base' }));
+    await waitFor(() => {
+      expect(seam.clearForecastAdjustment).toHaveBeenCalledWith('cat-food');
+    });
+  });
+
+  it('a stored adjustment on a quiet category is still shown, and still returnable', async () => {
+    seam.listForecastAdjustments.mockResolvedValue([
+      { id: 'adj-q', categoryId: 'cat-quiet', monthlyMinor: 40000 },
+    ]);
+    __setAppContextValue({
+      accounts: [ACCOUNT],
+      categories: [...CATEGORIES, { id: 'cat-quiet', name: 'Club membership', type: 'expense', level: 'detail' }],
+      transactions: LEDGER,
+      isLoading: false,
+      suggestionDismissals: [],
+      suggestionDismissalsStatus: 'ready',
+      refreshSuggestionDismissals,
+      dismissSuggestion,
+      restoreSuggestion,
+    });
+    render(
+      <MemoryRouter>
+        <PreferencesProvider>
+          <ToastProvider>
+            <Forecast />
+          </ToastProvider>
+        </PreferencesProvider>
+      </MemoryRouter>
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('Adjustments on quiet categories')).toBeInTheDocument();
+    });
+    expect(screen.getByText('Club membership')).toBeInTheDocument();
+    expect(screen.getByText('£400.00 a month')).toBeInTheDocument();
+    // Counted in the scenario's stated totals, not silently off-screen.
+    expect(screen.getByText(/The scenario adjusts 1 category/)).toBeInTheDocument();
   });
 
   it('ASKS for the lazy-loaded verdicts when they have never been loaded', async () => {

--- a/src/services/__tests__/dataService.test.ts
+++ b/src/services/__tests__/dataService.test.ts
@@ -3685,10 +3685,10 @@ describe('DataService.capabilities (what this engine says it can do)', () => {
       realtime: false,
       maxConcurrentWrites: 1,
       backupTarget: 'device',
-      // The BROWSER's store, which holds seven of the fourteen. Asserted by
-      // name here rather than by count: this list is what `RestoreBackupModal`
-      // warns a person with before a restore, and a table that quietly left it
-      // would be rows lost in silence.
+      // The BROWSER's store, which cannot keep EIGHT of the sixteen. Asserted
+      // by name here rather than by count: this list is what
+      // `RestoreBackupModal` warns a person with before a restore, and a
+      // table that quietly left it would be rows lost in silence.
       cannotKeep: [
         { entity: 'goal_contributions', label: 'Goal contributions', absence: expect.any(String) },
         { entity: 'investments', label: 'Investments', absence: expect.any(String) },
@@ -3696,7 +3696,8 @@ describe('DataService.capabilities (what this engine says it can do)', () => {
         { entity: 'recurring_transactions', label: 'Recurring transactions', absence: expect.any(String) },
         { entity: 'notifications', label: 'Notifications', absence: expect.any(String) },
         { entity: 'dashboard_layouts', label: 'Dashboard layouts', absence: expect.any(String) },
-        { entity: 'widget_preferences', label: 'Widget preferences', absence: expect.any(String) }
+        { entity: 'widget_preferences', label: 'Widget preferences', absence: expect.any(String) },
+        { entity: 'forecast_adjustments', label: 'Forecast adjustments', absence: expect.any(String) }
       ]
     });
   });

--- a/src/services/api/dataService.ts
+++ b/src/services/api/dataService.ts
@@ -76,7 +76,7 @@ import type * as DeviceBackupService from '../localBackupService';
 // two-pass transfer linking, the chunked writer — and exactly the people who
 // press Import once ever should be the people who download it.
 import type * as MsMoneyImportService from '../import/msMoney/msMoneyImport';
-import type { Account, AccountUpdate, Transaction, TransactionSplit, TransactionSplitInput, SplitWriteResult, Budget, CustomReport, Goal, Category, CategoryMergeResult, DismissalKind, SuggestionDismissal, TransferDisplacedDisposition, TransferDisplacedOutcome, TransferRepointResult } from '../../types';
+import type { Account, AccountUpdate, Transaction, TransactionSplit, TransactionSplitInput, SplitWriteResult, Budget, CustomReport, ForecastAdjustment, Goal, Category, CategoryMergeResult, DismissalKind, SuggestionDismissal, TransferDisplacedDisposition, TransferDisplacedOutcome, TransferRepointResult } from '../../types';
 // The crossover rule a linked pair is filed by — each side's To/From category
 // names the OTHER account. Written down once so the browser-storage mirror and
 // repoint_transfer cannot drift apart on the one thing that is easy to get
@@ -131,9 +131,10 @@ type PlanningServiceLike = Pick<typeof PlanningService,
   'mergeCategories' | 'createBudget' | 'updateBudget' | 'deleteBudget'
   | 'createGoal' | 'updateGoal' | 'deleteGoal'
   | 'createCustomReport' | 'updateCustomReport' | 'deleteCustomReport'
+  | 'setForecastAdjustment' | 'clearForecastAdjustment'
   | 'createCategory' | 'createCategories' | 'updateCategory' | 'deleteCategory'
   | 'deleteUnusedCategories'> &
-  Partial<Pick<typeof PlanningService, 'getBudgets' | 'getGoals' | 'getCustomReports' | 'ensureCategories'>>;
+  Partial<Pick<typeof PlanningService, 'getBudgets' | 'getGoals' | 'getCustomReports' | 'getForecastAdjustments' | 'ensureCategories'>>;
 type SuggestionDismissalServiceLike = Pick<typeof SuggestionDismissalService,
   'list' | 'dismiss' | 'restore'>;
 /**
@@ -2842,6 +2843,45 @@ class DataServiceImpl implements DataPort {
   }
 
   /**
+   * The scenario's stated deviations. The BROWSER branch answers an empty
+   * list — divergence B-12's shape, investments' precedent: browser storage
+   * has never had an adjustments store, a writer or a reader, the absence is
+   * declared in `backup/browserCoverage.ts`, and an empty list is the honest
+   * answer where there is nowhere to keep one.
+   */
+  async listForecastAdjustments(): Promise<ForecastAdjustment[]> {
+    const userId = this.userIdService.getCurrentDatabaseUserId();
+    if (userId && this.supabaseChecker() && this.planningService.getForecastAdjustments) {
+      return this.planningService.getForecastAdjustments(userId);
+    }
+    return [];
+  }
+
+  /**
+   * State one category's scenario figure. No browser branch AT ALL — the
+   * refusal is loud where the report family's browser branch is a store,
+   * because a signed-out browser has nowhere the backup could carry an
+   * adjustment out of (see `browserCoverage.ts`), and a write that landed
+   * somewhere invisible would be the custom-reports localStorage failure
+   * born again.
+   */
+  async setForecastAdjustment(categoryId: string, monthlyMinor: number): Promise<ForecastAdjustment> {
+    const userId = this.userIdService.getCurrentDatabaseUserId();
+    if (userId && this.supabaseChecker() && this.planningService.setForecastAdjustment) {
+      return this.planningService.setForecastAdjustment(userId, categoryId, monthlyMinor);
+    }
+    throw new Error('Sign in to adjust the forecast — scenario adjustments are kept with your account.');
+  }
+
+  async clearForecastAdjustment(categoryId: string): Promise<void> {
+    const userId = this.userIdService.getCurrentDatabaseUserId();
+    if (userId && this.supabaseChecker() && this.planningService.clearForecastAdjustment) {
+      return this.planningService.clearForecastAdjustment(userId, categoryId);
+    }
+    throw new Error('Sign in to adjust the forecast — scenario adjustments are kept with your account.');
+  }
+
+  /**
    * Save a report somebody built.
    *
    * Branch, owner rule, delegation and unwrapped promise exactly as `createGoal`
@@ -3629,6 +3669,18 @@ export class DataService {
 
   static listCustomReports(): Promise<CustomReport[]> {
     return this.service.listCustomReports();
+  }
+
+  static listForecastAdjustments(): Promise<ForecastAdjustment[]> {
+    return this.service.listForecastAdjustments();
+  }
+
+  static setForecastAdjustment(categoryId: string, monthlyMinor: number): Promise<ForecastAdjustment> {
+    return this.service.setForecastAdjustment(categoryId, monthlyMinor);
+  }
+
+  static clearForecastAdjustment(categoryId: string): Promise<void> {
+    return this.service.clearForecastAdjustment(categoryId);
   }
 
   static createCustomReport(report: Omit<CustomReport, 'id'>): Promise<CustomReport> {

--- a/src/services/api/planningService.ts
+++ b/src/services/api/planningService.ts
@@ -54,6 +54,7 @@ import { createScopedLogger } from '../../loggers/scopedLogger';
 import { getDefaultCategories } from '../../data/defaultCategories';
 import { parseReportComponents, parseReportFilters } from '../reports/document';
 import type {
+  ForecastAdjustment,
   Budget,
   Category,
   CategoryMergeResult,
@@ -240,6 +241,16 @@ export const goalToDb = (g: Partial<Goal>, userId?: string, existingMetadata?: R
  * round trip, and the one path with no test at all is how `isActive` came to be
  * silently dropped from a goal.
  */
+export const forecastAdjustmentFromDb = (row: Row): ForecastAdjustment => ({
+  id: String(row.id),
+  categoryId: String(row.category_id),
+  // A bigint of pennies. Number() is exact here: JS integers are exact to
+  // 2^53 and a monthly figure in pennies is nowhere near it.
+  monthlyMinor: Number(row.monthly_minor),
+  createdAt: row.created_at ? new Date(String(row.created_at)) : undefined,
+  updatedAt: row.updated_at ? new Date(String(row.updated_at)) : undefined,
+});
+
 export const customReportFromDb = (row: Row): CustomReport => ({
   id: String(row.id),
   name: str(row.name) ?? '',
@@ -581,6 +592,81 @@ export class PlanningService {
       .from('custom_reports')
       .delete()
       .eq('id', id)
+      .eq('user_id', userId);
+    if (error) throw new Error(handleSupabaseError(error));
+  }
+
+  // ----- Forecast adjustments -----
+  //
+  // The scenario's stated deviations from the base (20260819150000). The
+  // dismissal family's shape rather than the report family's: a judgment
+  // about how the ledger is READ, one row per (owner, category), upserted
+  // because the scenario is a single stated figure per category rather than
+  // a history of edits.
+
+  /**
+   * Every adjustment the owner has stated, oldest first — the order every
+   * list here is read in. A FAILED CLOUD READ IS NO ADJUSTMENTS, `getBudgets`'
+   * argument: the scenario quietly follows the base rather than inventing
+   * deviations from another store.
+   */
+  static async getForecastAdjustments(userId: string | null): Promise<ForecastAdjustment[]> {
+    if (!this.cloudReady || !userId) {
+      throw new Error('getForecastAdjustments requires the cloud connection (local mode goes through DataService)');
+    }
+
+    const { data, error } = await supabase!
+      .from('forecast_adjustments')
+      .select('*')
+      .eq('user_id', userId)
+      .order('created_at', { ascending: true });
+    if (error) {
+      logger.error('getForecastAdjustments cloud read failed — returning none', error);
+      return [];
+    }
+    return ((data ?? []) as Row[]).map(forecastAdjustmentFromDb);
+  }
+
+  /**
+   * State, or restate, one category's scenario figure. An UPSERT on the
+   * (owner, category) unique pair: the row keeps its identity and its
+   * created_at, and only the figure and updated_at move.
+   */
+  static async setForecastAdjustment(
+    userId: string | null,
+    categoryId: string,
+    monthlyMinor: number
+  ): Promise<ForecastAdjustment> {
+    if (!this.cloudReady || !userId) {
+      throw new Error('setForecastAdjustment requires the cloud connection (local mode goes through DataService)');
+    }
+
+    const { data, error } = await supabase!
+      .from('forecast_adjustments')
+      .upsert(
+        { user_id: userId, category_id: categoryId, monthly_minor: monthlyMinor } as never,
+        { onConflict: 'user_id,category_id' }
+      )
+      .select()
+      .single();
+    if (error) throw new Error(handleSupabaseError(error));
+    return forecastAdjustmentFromDb(data as Row);
+  }
+
+  /**
+   * The category goes back to following the base. No `.single()`: clearing a
+   * category that holds no adjustment is a successful nothing — the caller
+   * asked for a state, and the state is already so.
+   */
+  static async clearForecastAdjustment(userId: string | null, categoryId: string): Promise<void> {
+    if (!this.cloudReady || !userId) {
+      throw new Error('clearForecastAdjustment requires the cloud connection (local mode goes through DataService)');
+    }
+
+    const { error } = await supabase!
+      .from('forecast_adjustments')
+      .delete()
+      .eq('category_id', categoryId)
       .eq('user_id', userId);
     if (error) throw new Error(handleSupabaseError(error));
   }

--- a/src/services/backup/browserCoverage.ts
+++ b/src/services/backup/browserCoverage.ts
@@ -103,6 +103,11 @@ export const BROWSER_CANNOT_KEEP: readonly UnstorableEntity[] = [
     entity: 'widget_preferences',
     label: 'Widget preferences',
     absence: 'widget settings are only saved when you are signed in'
+  },
+  {
+    entity: 'forecast_adjustments',
+    label: 'Forecast adjustments',
+    absence: 'forecast scenario adjustments are only kept when you are signed in'
   }
 ];
 

--- a/src/services/backup/format.ts
+++ b/src/services/backup/format.ts
@@ -68,8 +68,11 @@ export const BACKUP_FORMAT = 'wealthtracker-backup-v2';
  * only — nothing gates on it, and a file stamped with either older value
  * restores exactly as it always did (its `custom_reports` array is simply
  * absent, which `validateBackupBundle` already reads as "this file has none").
+ *
+ * Bumped again to 20260819150000 when `forecast_adjustments` became the
+ * sixteenth table, by the same argument end to end.
  */
-export const BACKUP_SCHEMA_VERSION = '20260812140000';
+export const BACKUP_SCHEMA_VERSION = '20260819150000';
 
 /** Rows travel exactly as the database returned them. No mapping, no reshaping. */
 export type BackupRow = Record<string, unknown>;
@@ -104,6 +107,12 @@ export const BACKUP_ENTITIES = [
   // Appending rather than inserting also keeps every older file's `counts`
   // consistent with the list this build walks.
   'custom_reports',
+  // Appended for custom_reports' reason. One row per category the user has
+  // ADJUSTED in the forecast's scenario — the stated deviation from the base
+  // average. References its category through an ordinary uuid column, so the
+  // remapper's plainest mechanism covers it; restored after categories exist
+  // (see RESTORE_STEPS).
+  'forecast_adjustments',
 ] as const;
 
 export type BackupEntity = (typeof BACKUP_ENTITIES)[number];
@@ -683,6 +692,16 @@ const ENTITY_REFERENCES: Readonly<Record<BackupEntity, EntityReferences>> = {
    * spec's own documentation refuses.
    */
   custom_reports: { jsonbIdArrays: { filters: ['accounts', 'categories'] } },
+  /**
+   * The whole point of this table being RELATIONAL rather than a jsonb of
+   * {categoryId: amount}: the id sits in a plain uuid column, so the restore
+   * rewrites it with the same mechanism as every scalar reference above, and
+   * an adjustment whose category did not survive the file is REPORTED as a
+   * dangling reference rather than silently orphaned inside a blob no
+   * constraint watches. Keys of a jsonb object are a shape the remapper
+   * deliberately has no mechanism for.
+   */
+  forecast_adjustments: { uuid: ['category_id'] },
 };
 
 /**
@@ -1071,6 +1090,7 @@ export const RESTORE_STEPS: readonly RestoreStep[] = [
   { entity: 'widget_preferences', label: 'Widget preferences' },
   { entity: 'suggestion_dismissals', label: 'Dismissed suggestions' },
   { entity: 'custom_reports', label: 'Custom reports' },
+  { entity: 'forecast_adjustments', label: 'Forecast adjustments' },
 ];
 
 /** The rows one step sends, in the order the file holds them. */

--- a/src/services/backupService.test.ts
+++ b/src/services/backupService.test.ts
@@ -324,6 +324,9 @@ describe('restore ordering', () => {
       // column with no foreign key behind it, so the database would take it
       // first. See RESTORE_STEPS for why "last" is nonetheless the right answer.
       'custom_reports',
+      // Adjustments reference categories through a REAL foreign key, so this
+      // one's position IS a constraint: after the categories exist.
+      'forecast_adjustments',
     ]);
   });
 

--- a/src/services/local/localDataPort.ts
+++ b/src/services/local/localDataPort.ts
@@ -151,6 +151,7 @@ import type {
   Category,
   CategoryMergeResult,
   CustomReport,
+  ForecastAdjustment,
   DismissalKind,
   Goal,
   SplitWriteResult,
@@ -242,6 +243,7 @@ import {
   toBudget,
   toCategory,
   toCustomReport,
+  toForecastAdjustment,
   toDismissal,
   toDisplaced,
   toGoal,
@@ -708,6 +710,12 @@ export class LocalDataPort implements DataPort {
   async listCustomReports(): Promise<CustomReport[]> {
     const answer = await this.#ask('list_custom_reports');
     return rowsOf(answer, 'list_custom_reports', 'custom_reports').map(toCustomReport);
+  }
+
+  async listForecastAdjustments(): Promise<ForecastAdjustment[]> {
+    const answer = await this.#ask('list_forecast_adjustments');
+    return rowsOf(answer, 'list_forecast_adjustments', 'forecast_adjustments')
+      .map(toForecastAdjustment);
   }
 
   async listCategories(): Promise<Category[]> {
@@ -1531,6 +1539,24 @@ export class LocalDataPort implements DataPort {
    */
   async deleteCustomReport(id: string): Promise<void> {
     await this.#ask('delete_custom_report', { id });
+  }
+
+  /**
+   * The scenario pair. The figure crosses as the integer of pennies it is in
+   * both stores — the one money field in this file with no scale conversion
+   * anywhere on its trip. A category the file does not hold is refused by
+   * its own foreign key, surfaced as the crate's constraint refusal.
+   */
+  async setForecastAdjustment(categoryId: string, monthlyMinor: number): Promise<ForecastAdjustment> {
+    const answer = await this.#ask('set_forecast_adjustment', {
+      category_id: categoryId,
+      monthly_minor: monthlyMinor
+    });
+    return toForecastAdjustment(rowOf(answer, 'set_forecast_adjustment', 'answer'));
+  }
+
+  async clearForecastAdjustment(categoryId: string): Promise<void> {
+    await this.#ask('clear_forecast_adjustment', { category_id: categoryId });
   }
 
   // ── Holdings ──────────────────────────────────────────────────────────────

--- a/src/services/local/mappers/rows.ts
+++ b/src/services/local/mappers/rows.ts
@@ -84,6 +84,7 @@ import type {
   Budget,
   Category,
   CustomReport,
+  ForecastAdjustment,
   Goal,
   SuggestionDismissal,
   Transaction,
@@ -403,6 +404,22 @@ export const toGoal = (row: Record<string, unknown>): Goal => {
  * the epoch rather than to `new Date()` the way every other mapper in this file
  * does — a row whose clock could not be read is not a row created now.
  */
+/**
+ * A forecast adjustment, from either engine's answer row.
+ *
+ * Read directly rather than through a `Column` spec: three fields, none of
+ * them money-scaled or tri-state — `monthly_minor` is an integer of pennies
+ * in BOTH engines, the row's whole point, so there is no conversion for a
+ * spec to declare.
+ */
+export const toForecastAdjustment = (row: Record<string, unknown>): ForecastAdjustment => ({
+  id: textOr(row.id, ''),
+  categoryId: textOr(row.category_id, ''),
+  monthlyMinor: Number(row.monthly_minor ?? 0),
+  createdAt: instant(row.created_at) ?? new Date(0),
+  updatedAt: instant(row.updated_at) ?? new Date(0)
+});
+
 export const toCustomReport = (row: Record<string, unknown>): CustomReport => {
   const value = fieldsOf(CUSTOM_REPORT_COLUMNS, row);
   return {

--- a/src/services/localBackupService.ts
+++ b/src/services/localBackupService.ts
@@ -745,6 +745,7 @@ export const LOCAL_BACKUP_BINDINGS: Readonly<Record<BackupEntity, LocalEntityBin
   notifications: absent('notifications'),
   dashboard_layouts: absent('dashboard_layouts'),
   widget_preferences: absent('widget_preferences'),
+  forecast_adjustments: absent('forecast_adjustments'),
 };
 
 // A binding missing at runtime would mean an entity silently vanished from

--- a/src/services/port/__tests__/contract.ts
+++ b/src/services/port/__tests__/contract.ts
@@ -195,6 +195,7 @@ export const DATA_PORT_OPERATIONS: readonly (keyof DataPort)[] = [
   'listBudgets',
   'listGoals',
   'listCustomReports',
+  'listForecastAdjustments',
   'listCategories',
   'listSuggestionDismissals',
   'listInvestments',
@@ -251,6 +252,9 @@ export const DATA_PORT_OPERATIONS: readonly (keyof DataPort)[] = [
   // Dismissal writes
   'dismissSuggestion',
   'restoreSuggestion',
+  // Forecast scenario writes — the dismissal family's company
+  'setForecastAdjustment',
+  'clearForecastAdjustment',
   // Backup lifecycle
   'financialDataIsEmpty',
   'collectBackup',
@@ -576,7 +580,8 @@ const BACKUP_COVERAGE: Record<
       { entity: 'recurring_transactions', label: 'Recurring transactions' },
       { entity: 'notifications', label: 'Notifications' },
       { entity: 'dashboard_layouts', label: 'Dashboard layouts' },
-      { entity: 'widget_preferences', label: 'Widget preferences' }
+      { entity: 'widget_preferences', label: 'Widget preferences' },
+      { entity: 'forecast_adjustments', label: 'Forecast adjustments' }
     ]
   },
   // Every table in the format is a table in the database — the format was read
@@ -625,6 +630,21 @@ const INVESTMENT_STORAGE: Record<DataPortEngine, 'keeps' | 'has nowhere to keep 
   // `investments` in `schema.sql`, with quantity and both unit prices at 1e8
   // rather than the cloud's old `numeric(10,2)` — the bug migration
   // 20260809120000 fixed in the cloud was fixed in this schema before it shipped.
+  'local-core': 'keeps'
+};
+
+/**
+ * Where the forecast scenario's adjustments live — investments' shape, one
+ * tier over: the browser has no store for them (declared in
+ * `backup/browserCoverage.ts`, so `cannotKeep` says it), and a signed-out
+ * write REFUSES rather than landing somewhere invisible — the custom-reports
+ * localStorage failure is the scar this rule keeps closed.
+ */
+const ADJUSTMENT_STORAGE: Record<DataPortEngine, 'keeps' | 'has nowhere to keep them'> = {
+  'browser-storage': 'has nowhere to keep them',
+  // `public.forecast_adjustments`, 20260819150000.
+  supabase: 'keeps',
+  // `forecast_adjustments` in `schema.sql`, the same integer of pennies.
   'local-core': 'keeps'
 };
 
@@ -2293,6 +2313,66 @@ export function runDataPortContract(name: string, harness: DataPortContractHarne
 
         expect((await read()).goals).toEqual([]);
       });
+    });
+
+    describe('the forecast scenario\u2019s adjustments', () => {
+      rule(
+        ['setForecastAdjustment', 'clearForecastAdjustment', 'listForecastAdjustments'],
+        `B-12: this engine ${ADJUSTMENT_STORAGE[engine]}`,
+        async () => {
+          const { port } = await harness.create({ accounts: threeAccounts() });
+
+          if (ADJUSTMENT_STORAGE[engine] === 'has nowhere to keep them') {
+            await expect(port.setForecastAdjustment('any-category', 90000)).rejects.toThrow();
+            // …and the read is not a rejection: the Forecast page draws a
+            // scenario that simply follows the base.
+            await expect(port.listForecastAdjustments()).resolves.toEqual([]);
+            expect(
+              port.capabilities().cannotKeep.map(entry => entry.entity)
+            ).toContain('forecast_adjustments');
+            return;
+          }
+
+          // A category of the ledger's own, minted through the seam — the
+          // harness seeds none beyond each account's To/From.
+          const category = await port.createCategory(aNewCategory('Groceries'));
+
+          // State a figure: £900 a month, as the 90000 pennies it crosses as.
+          const stated = await port.setForecastAdjustment(category.id, 90000);
+          expect(stated.categoryId).toBe(category.id);
+          expect(stated.monthlyMinor).toBe(90000);
+          expect(stated.id).toBeTruthy();
+
+          // RESTATE it: the row keeps its identity — the scenario is a single
+          // stated figure per category, not a history of edits.
+          const restated = await port.setForecastAdjustment(category.id, 75000);
+          expect(restated.id).toBe(stated.id);
+          expect(restated.monthlyMinor).toBe(75000);
+          expect((await port.listForecastAdjustments()).map(row => [row.categoryId, row.monthlyMinor]))
+            .toEqual([[category.id, 75000]]);
+
+          // Clear it: back to the base, and clearing again is a successful
+          // nothing rather than an error.
+          await port.clearForecastAdjustment(category.id);
+          await port.clearForecastAdjustment(category.id);
+          expect(await port.listForecastAdjustments()).toEqual([]);
+        }
+      );
+
+      rule(
+        ['setForecastAdjustment'],
+        'refuses an adjustment on a category the ledger does not hold — the FILE judges it',
+        async () => {
+          if (ADJUSTMENT_STORAGE[engine] === 'has nowhere to keep them') return;
+          const { port } = await harness.create({ accounts: threeAccounts() });
+
+          // The foreign key's refusal, not a check either implementation
+          // writes — the dismissal family's discipline, one table over.
+          await expect(
+            port.setForecastAdjustment('99999999-9999-4999-8999-999999999999', 90000)
+          ).rejects.toThrow();
+        }
+      );
     });
 
     describe('writing a custom report', () => {

--- a/src/services/port/dataPort.ts
+++ b/src/services/port/dataPort.ts
@@ -82,6 +82,7 @@ import type {
   Category,
   CategoryMergeResult,
   CustomReport,
+  ForecastAdjustment,
   DismissalKind,
   Goal,
   SplitWriteResult,
@@ -397,6 +398,16 @@ export interface DataPortReads {
    * report without saying so.
    */
   listCustomReports(): Promise<CustomReport[]>;
+  /**
+   * The forecast scenario's stated deviations — one per adjusted category.
+   *
+   * NOT in the boot payload, unlike custom reports, and the asymmetry is
+   * argued rather than inherited: reports went into boot because two of
+   * their readers are SYNCHRONOUS; the one reader of adjustments is the
+   * Forecast page, which is async from birth, and a boot that carried them
+   * would tax every session for one page's convenience.
+   */
+  listForecastAdjustments(): Promise<ForecastAdjustment[]>;
   listCategories(): Promise<Category[]>;
   listSuggestionDismissals(): Promise<SuggestionDismissal[]>;
   /**
@@ -1123,6 +1134,25 @@ export interface DataPortReportWrites {
    * that got there first, must not turn a decision into an error message.
    */
   deleteCustomReport(id: string): Promise<void>;
+
+  /**
+   * State, or restate, one category's scenario monthly figure — PENNIES, an
+   * integer, the figure both engines store verbatim. An upsert on the
+   * (owner, category) unique pair: the scenario is a single stated figure
+   * per category, and `updated_at` is its edit history's one remnant.
+   *
+   * A category the engine does not hold is REFUSED by the file's own foreign
+   * key, not by a check either implementation writes — the dismissal
+   * family's discipline.
+   */
+  setForecastAdjustment(categoryId: string, monthlyMinor: number): Promise<ForecastAdjustment>;
+
+  /**
+   * The category goes back to following the base. A real delete: an absent
+   * row IS "no adjustment". Clearing a category that holds none is a
+   * successful nothing.
+   */
+  clearForecastAdjustment(categoryId: string): Promise<void>;
 }
 
 /**

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -612,6 +612,27 @@ export interface ReportComponent {
   width: 'full' | 'half' | 'third';
 }
 
+/**
+ * One stated deviation from the forecast BASE: the monthly figure the
+ * scenario uses for one category in place of the twelve-month average
+ * (docs/forecast-direction.md — the scenario tool, whose Budget writes only
+ * ever happen by the explicit stage-2 promotion).
+ *
+ * `monthlyMinor` is PENNIES, an integer — the one representation of money
+ * both engines hold exactly, crossing the seam without a scale conversion.
+ * A magnitude: the category's own income/expense type says which side it
+ * lands on. Relational (one row per category, `categoryId` a real column)
+ * rather than a document keyed by ids, because the restore remapper rewrites
+ * uuid COLUMNS and deliberately never the keys of a jsonb object.
+ */
+export interface ForecastAdjustment {
+  id: string;
+  categoryId: string;
+  monthlyMinor: number;
+  createdAt?: Date;
+  updatedAt?: Date;
+}
+
 export interface CustomReport {
   id: string;
   name: string;

--- a/supabase/migrations/20260819150000_forecast_adjustments.sql
+++ b/supabase/migrations/20260819150000_forecast_adjustments.sql
@@ -1,0 +1,559 @@
+-- ============================================================================
+-- FORECAST ADJUSTMENTS — the scenario's stated deviations from the base
+-- ============================================================================
+-- IMPORTANT: apply with `npm run db:migrate` (see supabase/migrations/README.md
+-- rule 1 — never the SQL editor).
+--
+-- ORDERING: apply AFTER 20260819130000_forecast_exclusions.sql (the timestamps
+-- order them; one `npm run db:migrate` applies both), and BEFORE the matching
+-- client deploys. A database with this applied and the old client running
+-- behaves exactly as now — nothing reads the new table until a client that
+-- knows about it arrives.
+--
+-- ── WHY ─────────────────────────────────────────────────────────────────────
+--
+-- The forecast is a SCENARIO TOOL (owner's ruling, 17 Aug —
+-- docs/forecast-direction.md): the user plays against the twelve-month base,
+-- and every deviation is STATED — "Food at £900 a month, base says £843" —
+-- because a scenario whose adjustments cannot be interrogated is Design's
+-- named failure mode. This table is those deviations: one row per category
+-- the user has adjusted, holding the monthly figure the scenario uses in
+-- place of the base average. No row here changes a register, a budget or a
+-- report — the scenario READS the base and lays these on top, and Budget is
+-- only ever written by the user''s explicit stage-2 promotion, which does not
+-- exist yet.
+--
+-- ── WHY A RELATIONAL TABLE AND NOT A JSONB DOCUMENT ─────────────────────────
+--
+-- The obvious shape is one row holding {categoryId: monthly} — and it is the
+-- wrong one, for a reason measured in the backup format rather than argued
+-- from taste. remapBackupIds rewrites row ids on restore through three
+-- declared mechanisms (uuid columns, id arrays, named arrays INSIDE a jsonb
+-- value); the KEYS of a jsonb object are deliberately none of them. A
+-- document keyed by category ids would restore verbatim into a login whose
+-- categories have fresh ids and silently adjust nothing. As a table, the
+-- reference is a plain uuid column — the remapper''s simplest case — a
+-- dangling one is REPORTED, and ON DELETE CASCADE means an adjustment dies
+-- with its category instead of lingering as a phantom judgment.
+--
+-- `monthly_minor` is a bigint of pennies: the one representation both engines
+-- hold exactly, per the local schema''s money discipline.
+--
+-- ── SAFE TO RUN TWICE? ──────────────────────────────────────────────────────
+-- No — guard 2 refuses a second run by name, exactly as 20260812140000 does
+-- and for its reason.
+-- ============================================================================
+
+BEGIN;
+
+-- ── Guard 1: this is the database this migration was written against ────────
+DO $g$
+BEGIN
+  IF to_regprocedure('public.requesting_user_id()') IS NULL THEN
+    RAISE EXCEPTION 'wrong_base_missing_requesting_user_id: public.requesting_user_id() does not exist, so this database predates 20260610130000_restore_rls_data_isolation and cannot express owner-only policies.'
+      USING ERRCODE = 'P0001',
+            HINT = 'Apply the migrations in order with `npm run db:migrate`.';
+  END IF;
+  IF to_regclass('public.categories') IS NULL THEN
+    RAISE EXCEPTION 'wrong_base_missing_categories: public.categories does not exist, so an adjustment has nothing to reference.'
+      USING ERRCODE = 'P0001',
+            HINT = 'Apply 20251030003814__initial-schema.sql first.';
+  END IF;
+END;
+$g$;
+
+-- ── Guard 2: refuse a double-run, by name ───────────────────────────────────
+DO $g$
+BEGIN
+  IF to_regclass('public.forecast_adjustments') IS NOT NULL THEN
+    RAISE EXCEPTION 'forecast_adjustments_already_exists: this migration has already been applied and must not run twice.'
+      USING ERRCODE = 'P0001',
+            HINT = 'If something needs changing, write a new migration for it.';
+  END IF;
+END;
+$g$;
+
+-- ── Guard 3: the shared updated_at trigger is the one expected ──────────────
+DO $g$
+DECLARE
+  v_body text;
+BEGIN
+  IF to_regprocedure('public.update_updated_at_column()') IS NULL THEN
+    RAISE EXCEPTION 'wrong_base_missing_update_updated_at_column: forecast_adjustments.updated_at would never be stamped.'
+      USING ERRCODE = 'P0001';
+  END IF;
+  SELECT pg_get_functiondef(to_regprocedure('public.update_updated_at_column()')) INTO v_body;
+  IF v_body !~* 'updated_at' THEN
+    RAISE EXCEPTION 'update_updated_at_column_not_recognised: the shared trigger function no longer mentions updated_at.'
+      USING ERRCODE = 'P0001';
+  END IF;
+END;
+$g$;
+
+-- ── Guard 4: the two functions this file redefines actually exist ───────────
+DO $g$
+BEGIN
+  IF to_regprocedure('public.restore_user_chunk(text, jsonb, uuid)') IS NULL THEN
+    RAISE EXCEPTION 'wrong_base_missing_restore_user_chunk: this database predates 20260807083000_user_data_restore — the redefinition below would create a PARTIAL restore path rather than extend a whole one.'
+      USING ERRCODE = 'P0001',
+            HINT = 'Apply the migrations in order with `npm run db:migrate`.';
+  END IF;
+  IF to_regprocedure('public.wipe_user_financial_data(text, uuid)') IS NULL THEN
+    RAISE EXCEPTION 'wrong_base_missing_wipe_user_financial_data: this database predates 20260807083000_user_data_restore.'
+      USING ERRCODE = 'P0001';
+  END IF;
+END;
+$g$;
+
+-- ── Guard 5: the copies below were taken from the LATEST definitions ────────
+-- The rule 20260812140000 wrote after making this mistake once: when
+-- redefining a shared function, take the text from the LATEST migration that
+-- defines it, never from the one that created it. These copies were taken
+-- from 20260812140000 itself, whose marker in both functions is the
+-- custom_reports branch — absent, and the database''s current functions are
+-- not the ones these copies extend.
+DO $g$
+BEGIN
+  IF pg_get_functiondef(to_regprocedure('public.restore_user_chunk(text, jsonb, uuid)'))
+       NOT LIKE '%custom_reports%' THEN
+    RAISE EXCEPTION 'restore_user_chunk_predates_20260812140000: replacing it with this file''s copy would be a downgrade rather than an extension.'
+      USING ERRCODE = 'P0001',
+            HINT = 'Apply 20260812140000_reports_outlive_the_browser.sql first, with `npm run db:migrate`.';
+  END IF;
+  IF pg_get_functiondef(to_regprocedure('public.wipe_user_financial_data(text, uuid)'))
+       NOT LIKE '%custom_reports%' THEN
+    RAISE EXCEPTION 'wipe_user_financial_data_predates_20260812140000: replacing it with this file''s copy would be a downgrade rather than an extension.'
+      USING ERRCODE = 'P0001',
+            HINT = 'Apply 20260812140000_reports_outlive_the_browser.sql first, with `npm run db:migrate`.';
+  END IF;
+END;
+$g$;
+
+-- ── The table ───────────────────────────────────────────────────────────────
+
+CREATE TABLE public.forecast_adjustments (
+  id            uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id       uuid NOT NULL REFERENCES public.users(id) ON DELETE CASCADE,
+
+  -- The category whose monthly figure the scenario overrides. CASCADE: an
+  -- adjustment of a deleted category adjusts nothing and must not linger.
+  category_id   uuid NOT NULL REFERENCES public.categories(id) ON DELETE CASCADE,
+
+  -- The scenario''s monthly figure for that category, in PENNIES — a bigint,
+  -- because an integer of minor units is the one representation of money both
+  -- engines hold exactly. Non-negative: a scenario states what a category
+  -- will cost or bring, and a negative monthly figure is a different category.
+  monthly_minor bigint NOT NULL CHECK (monthly_minor >= 0),
+
+  -- Nullable for restore_user_chunk''s reason, argued at length on
+  -- custom_reports: rows arrive through jsonb_populate_recordset, absent keys
+  -- become SQL NULL, and NOT NULL here would refuse a file whose rows lack a
+  -- timestamp — the one operation a user cannot afford to have fail.
+  created_at    timestamptz DEFAULT now(),
+  updated_at    timestamptz DEFAULT now(),
+
+  -- ONE adjustment per category per user — the scenario is a single stated
+  -- figure, not a history of edits (updated_at is the history''s one honest
+  -- remnant). Doubles as the list''s index: every lookup here is by user.
+  CONSTRAINT forecast_adjustments_one_per_category UNIQUE (user_id, category_id)
+);
+
+COMMENT ON TABLE public.forecast_adjustments IS
+  'One row per category the user has adjusted in the forecast scenario: the monthly figure the scenario uses in place of the twelve-month base average. Holds no ledger data and changes no figure anywhere — the scenario reads the base and lays these on top, and Budget is only ever written by the explicit stage-2 promotion (docs/forecast-direction.md). Created by 20260819150000.';
+
+COMMENT ON COLUMN public.forecast_adjustments.monthly_minor IS
+  'The adjusted monthly figure in pennies (bigint). The category''s own income/expense type says which side it lands on; the amount is a magnitude.';
+
+CREATE TRIGGER update_forecast_adjustments_updated_at
+  BEFORE UPDATE ON public.forecast_adjustments
+  FOR EACH ROW EXECUTE FUNCTION public.update_updated_at_column();
+
+-- ── RLS: the owner, and nobody else ─────────────────────────────────────────
+ALTER TABLE public.forecast_adjustments ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS forecast_adjustments_select_own ON public.forecast_adjustments;
+CREATE POLICY forecast_adjustments_select_own ON public.forecast_adjustments
+  FOR SELECT TO authenticated
+  USING (user_id = public.requesting_user_id());
+
+DROP POLICY IF EXISTS forecast_adjustments_insert_own ON public.forecast_adjustments;
+CREATE POLICY forecast_adjustments_insert_own ON public.forecast_adjustments
+  FOR INSERT TO authenticated
+  WITH CHECK (user_id = public.requesting_user_id());
+
+DROP POLICY IF EXISTS forecast_adjustments_update_own ON public.forecast_adjustments;
+CREATE POLICY forecast_adjustments_update_own ON public.forecast_adjustments
+  FOR UPDATE TO authenticated
+  USING (user_id = public.requesting_user_id())
+  WITH CHECK (user_id = public.requesting_user_id());
+
+DROP POLICY IF EXISTS forecast_adjustments_delete_own ON public.forecast_adjustments;
+CREATE POLICY forecast_adjustments_delete_own ON public.forecast_adjustments
+  FOR DELETE TO authenticated
+  USING (user_id = public.requesting_user_id());
+
+-- ── Grants ──────────────────────────────────────────────────────────────────
+-- Naming anon explicitly — REVOKE FROM PUBLIC alone does not remove Supabase''s
+-- named default grant to anon (the 20260725120000 trap).
+REVOKE ALL ON TABLE public.forecast_adjustments FROM PUBLIC, anon;
+GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE public.forecast_adjustments TO authenticated;
+GRANT ALL ON TABLE public.forecast_adjustments TO service_role;
+
+
+-- ── The wipe learns about adjustments ───────────────────────────────────────
+-- Redefined from 20260812140000 with ONE uncounted statement added beside the
+-- dismissals. Everything else is that file''s text, unchanged.
+CREATE OR REPLACE FUNCTION public.wipe_user_financial_data(
+  p_confirm text,
+  p_user_id uuid DEFAULT NULL
+)
+RETURNS jsonb
+LANGUAGE plpgsql SECURITY INVOKER
+SET search_path = public
+AS $$
+DECLARE
+  v_owner  uuid;
+  v_counts jsonb := '{}'::jsonb;
+  v_n      bigint;
+  v_row    record;
+BEGIN
+  IF p_confirm IS DISTINCT FROM 'DELETE EVERYTHING' THEN
+    RAISE EXCEPTION 'wipe_not_confirmed: this erases every account, transaction, budget and goal in this login — the caller must pass the exact confirmation phrase'
+      USING ERRCODE = 'P0001';
+  END IF;
+
+  v_owner := COALESCE(p_user_id, public.requesting_user_id());
+  IF v_owner IS NULL THEN
+    RAISE EXCEPTION 'owner_unknown: could not establish which account to clear'
+      USING ERRCODE = '42501';
+  END IF;
+
+  -- Per-row audit BEFORE deleting, while the rows still exist to describe.
+  FOR v_row IN SELECT * FROM public.transactions WHERE user_id = v_owner LOOP
+    PERFORM public.write_financial_audit(
+      v_owner, 'transaction', v_row.id, 'delete', to_jsonb(v_row), NULL);
+  END LOOP;
+
+  FOR v_row IN SELECT * FROM public.accounts WHERE user_id = v_owner LOOP
+    PERFORM public.write_financial_audit(
+      v_owner, 'account', v_row.id, 'delete', to_jsonb(v_row), NULL);
+  END LOOP;
+
+  -- Accounts first: categories and transactions follow by cascade.
+  DELETE FROM public.accounts WHERE user_id = v_owner;
+  GET DIAGNOSTICS v_n = ROW_COUNT;
+  v_counts := v_counts || jsonb_build_object('accounts', v_n);
+
+  DELETE FROM public.transactions WHERE user_id = v_owner;
+  GET DIAGNOSTICS v_n = ROW_COUNT;
+  v_counts := v_counts || jsonb_build_object('transactions', v_n);
+
+  DELETE FROM public.categories WHERE user_id = v_owner;
+  GET DIAGNOSTICS v_n = ROW_COUNT;
+  v_counts := v_counts || jsonb_build_object('categories', v_n);
+
+  DELETE FROM public.budgets WHERE user_id = v_owner;
+  GET DIAGNOSTICS v_n = ROW_COUNT;
+  v_counts := v_counts || jsonb_build_object('budgets', v_n);
+
+  DELETE FROM public.goals WHERE user_id = v_owner;
+  GET DIAGNOSTICS v_n = ROW_COUNT;
+  v_counts := v_counts || jsonb_build_object('goals', v_n);
+
+  DELETE FROM public.investments WHERE user_id = v_owner;
+  GET DIAGNOSTICS v_n = ROW_COUNT;
+  v_counts := v_counts || jsonb_build_object('investments', v_n);
+
+  -- COUNTED, unlike the four below it, and the line between them is what the
+  -- row IS rather than which table it sits in. A dismissal, a layout and a
+  -- widget setting are all records of how somebody has arranged the app; a
+  -- custom report is something they WROTE. A wipe that reported six numbers and
+  -- silently took a year of composed reports with them would be under-reporting
+  -- the loss in the one place a person is looking for its size.
+  --
+  -- It is also what the local edition already answers: `wipe_user_financial_data`
+  -- in the crate returns a `custom_reports` count, and `npm run test:local-verbs`
+  -- compares the two answers key for key. Leaving it uncounted here made five
+  -- wipe specs fail with "row.custom_reports: 0 vs (absent)" — a divergence
+  -- nobody had declared and nobody wanted.
+  DELETE FROM public.custom_reports WHERE user_id = v_owner;
+  GET DIAGNOSTICS v_n = ROW_COUNT;
+  v_counts := v_counts || jsonb_build_object('custom_reports', v_n);
+
+  DELETE FROM public.suggestion_dismissals WHERE user_id = v_owner;
+  -- Uncounted, WITH the dismissals rather than with the counted reports,
+  -- and the line the reports migration drew is why: an adjustment is a
+  -- JUDGMENT about how the ledger is read ("this one-off is not my typical
+  -- month"), not work the person authored. The local crate's wipe puts it
+  -- in the same uncounted loop, so `npm run test:local-verbs` sees the two
+  -- engines answer with the same keys.
+  DELETE FROM public.forecast_adjustments  WHERE user_id = v_owner;
+  DELETE FROM public.dashboard_layouts     WHERE user_id = v_owner;
+  DELETE FROM public.widget_preferences    WHERE user_id = v_owner;
+  DELETE FROM public.notifications         WHERE user_id = v_owner;
+
+  RETURN v_counts;
+END;
+$$;
+
+COMMENT ON FUNCTION public.wipe_user_financial_data(text, uuid) IS
+  'Erases the caller''s financial data so a backup can be restored into a clean login. Requires the literal confirmation phrase. Deletes accounts first so cascaded category deletion clears protect_transfer_category_on_delete. Audits every transaction and account row individually before deleting. Clears custom_reports (counted — authored work) and forecast_adjustments (uncounted, with the dismissals — a judgment about how the ledger is read). Returns per-table counts.';
+
+
+-- ── The restore learns about adjustments ────────────────────────────────────
+-- Redefined from 20260812140000 with ONE branch added immediately before the
+-- ELSE. Every other line is that file''s, unchanged — including the
+-- catalogue-read defaults 20260811090000 added, which guard 5 protects.
+CREATE OR REPLACE FUNCTION public.restore_user_chunk(
+  p_entity  text,
+  p_rows    jsonb,
+  p_user_id uuid DEFAULT NULL
+)
+RETURNS bigint
+LANGUAGE plpgsql SECURITY INVOKER
+SET search_path = public
+AS $$
+DECLARE
+  v_owner    uuid;
+  v_clerk    text;
+  v_rows     jsonb;
+  v_n        bigint := 0;
+  -- The table p_entity names, if it names one. Only ever used to READ that
+  -- table's defaults; which table is WRITTEN is decided by the chain below.
+  v_table    oid;
+  -- The SELECT list of that table's applicable defaults, built from the
+  -- catalogue. NULL when the table has none, which is the common case.
+  v_select   text;
+  -- Those defaults, evaluated: {column: value}. Empty until proven otherwise,
+  -- so every path through this function that does not fill it in behaves
+  -- exactly as this function did before.
+  v_defaults jsonb := '{}'::jsonb;
+BEGIN
+  v_owner := COALESCE(p_user_id, public.requesting_user_id());
+  IF v_owner IS NULL THEN
+    RAISE EXCEPTION 'owner_unknown: could not establish which login to restore into'
+      USING ERRCODE = '42501';
+  END IF;
+
+  IF jsonb_typeof(p_rows) <> 'array' THEN
+    RAISE EXCEPTION 'rows_not_an_array: each chunk must be a JSON array of whole rows'
+      USING ERRCODE = '22023';
+  END IF;
+
+  IF jsonb_array_length(p_rows) = 0 THEN
+    RETURN 0;
+  END IF;
+
+  -- The precondition, checked on the first chunk. accounts always leads the
+  -- order, so this fires before a single row lands.
+  IF p_entity = 'accounts' AND NOT public.user_financial_data_is_empty(v_owner) THEN
+    RAISE EXCEPTION 'restore_target_not_empty: this login already holds data — clear it first, because restoring on top would mix two datasets and silently re-date your history'
+      USING ERRCODE = 'P0001',
+            HINT = 'Erase everything first, or restore into a fresh login.';
+  END IF;
+
+  -- Whitelists the split guard for this transaction so restored split parents
+  -- can carry is_split = true. Same mechanism set_transaction_splits uses.
+  PERFORM set_config('app.split_rpc', '1', true);
+
+  -- ── What the past did not know ────────────────────────────────────────────
+  -- The defaults this schema would apply to a row that stays silent about a
+  -- column — read from the catalogue rather than remembered, so a column added
+  -- after this file was written is covered without anybody thinking of it.
+  --
+  -- Restricted to NOT NULL columns because that is exactly the class whose
+  -- omission is FATAL: a nullable column takes the NULL and the row lands, and
+  -- filling one in would overwrite a deliberate absence (money that was never
+  -- stated, an is_reconciled that means "ask is_cleared").
+  --
+  -- Restricted to Const defaults, and to columns outside the primary key,
+  -- because a generated default invents an identity or a time. See the header.
+  --
+  -- Not found, not a table, or nothing applicable: v_defaults stays empty and
+  -- the merge below is a no-op.
+  SELECT c.oid INTO v_table
+    FROM pg_class c
+    JOIN pg_namespace n ON n.oid = c.relnamespace
+   WHERE n.nspname = 'public' AND c.relname = p_entity AND c.relkind = 'r';
+
+  IF v_table IS NOT NULL THEN
+    SELECT string_agg(format('%s AS %I', pg_get_expr(d.adbin, d.adrelid), a.attname), ', '
+                      ORDER BY a.attnum)
+      INTO v_select
+      FROM pg_attribute a
+      JOIN pg_attrdef d ON d.adrelid = a.attrelid AND d.adnum = a.attnum
+     WHERE a.attrelid = v_table
+       AND a.attnum > 0
+       AND NOT a.attisdropped
+       AND a.attnotnull
+       AND d.adbin::text LIKE '{CONST%'
+       AND NOT EXISTS (
+             SELECT 1 FROM pg_index i
+              WHERE i.indrelid = a.attrelid
+                AND i.indisprimary
+                AND a.attnum = ANY(i.indkey));
+
+    IF v_select IS NOT NULL THEN
+      -- Only ever a SELECT of literals: the filter above admits no expression
+      -- that can call anything.
+      EXECUTE format('SELECT to_jsonb(d) FROM (SELECT %s) AS d', v_select)
+         INTO v_defaults;
+    END IF;
+  END IF;
+
+  -- Re-own every row to the caller, and strip the columns that must not travel:
+  --   plaid_* are GLOBALLY unique, so restoring them collides with whoever
+  --     exported the file;
+  --   connection_id points at bank_connections, which a backup deliberately
+  --     does not carry (it holds credentials);
+  --   the two self-references and the transactions<->splits cycle are deferred
+  --     to finalize_user_restore because no constraint here is DEFERRABLE.
+  --
+  -- Then lay the defaults UNDERNEATH the result, which is where the file wins:
+  -- `v_defaults || stated` keeps every key the file states, including a
+  -- deliberate null on a nullable column, and answers only for keys it does not
+  -- state. The subtraction first turns "stated as null on a column that cannot
+  -- hold null" into "not stated", because no legal export could have produced
+  -- it — see the header. Only keys that carry a default are considered, so a
+  -- NOT NULL column WITHOUT one still refuses a null, loudly, as it must.
+  SELECT jsonb_agg(
+           v_defaults || (stated.doc - ARRAY(
+             SELECT k
+               FROM jsonb_object_keys(v_defaults) AS k
+              WHERE stated.doc -> k = 'null'::jsonb)))
+    INTO v_rows
+    FROM (
+      SELECT CASE p_entity
+               WHEN 'accounts' THEN
+                 (e - 'plaid_account_id' - 'plaid_connection_id')
+                   || jsonb_build_object('user_id', v_owner, 'parent_account_id', NULL)
+               WHEN 'transactions' THEN
+                 (e - 'plaid_transaction_id' - 'connection_id'
+                    - 'external_transaction_id' - 'external_provider')
+                   || jsonb_build_object('user_id', v_owner,
+                                         'linked_transfer_id', NULL,
+                                         'linked_transfer_split_id', NULL)
+               ELSE
+                 e || jsonb_build_object('user_id', v_owner)
+             END AS doc
+        FROM jsonb_array_elements(p_rows) AS e
+    ) AS stated;
+
+  IF p_entity = 'accounts' THEN
+    INSERT INTO public.accounts
+    SELECT r.* FROM jsonb_populate_recordset(NULL::public.accounts, v_rows) AS r;
+
+  ELSIF p_entity = 'categories' THEN
+    -- Sent level by level (type, then sub, then detail) so parent_id always
+    -- resolves and categories_user_id_name_parent_id_key cannot be tripped by
+    -- two same-named details under different parents.
+    INSERT INTO public.categories
+    SELECT r.* FROM jsonb_populate_recordset(NULL::public.categories, v_rows) AS r;
+
+  ELSIF p_entity = 'transactions' THEN
+    INSERT INTO public.transactions
+    SELECT r.* FROM jsonb_populate_recordset(NULL::public.transactions, v_rows) AS r;
+
+  ELSIF p_entity = 'transaction_splits' THEN
+    INSERT INTO public.transaction_splits
+    SELECT r.* FROM jsonb_populate_recordset(NULL::public.transaction_splits, v_rows) AS r;
+
+  ELSIF p_entity = 'budgets' THEN
+    INSERT INTO public.budgets
+    SELECT r.* FROM jsonb_populate_recordset(NULL::public.budgets, v_rows) AS r;
+
+  ELSIF p_entity = 'goals' THEN
+    INSERT INTO public.goals
+    SELECT r.* FROM jsonb_populate_recordset(NULL::public.goals, v_rows) AS r;
+
+  ELSIF p_entity = 'goal_contributions' THEN
+    INSERT INTO public.goal_contributions
+    SELECT r.* FROM jsonb_populate_recordset(NULL::public.goal_contributions, v_rows) AS r;
+
+  ELSIF p_entity = 'investments' THEN
+    INSERT INTO public.investments
+    SELECT r.* FROM jsonb_populate_recordset(NULL::public.investments, v_rows) AS r;
+
+  ELSIF p_entity = 'investment_transactions' THEN
+    INSERT INTO public.investment_transactions
+    SELECT r.* FROM jsonb_populate_recordset(NULL::public.investment_transactions, v_rows) AS r;
+
+  ELSIF p_entity = 'recurring_transactions' THEN
+    -- The odd one out: user_id here is TEXT referencing
+    -- user_profiles(clerk_user_id), not users(id). The uuid written above would
+    -- be the wrong shape AND the wrong identity, so overwrite it again.
+    v_clerk := public.requesting_clerk_id();
+    IF v_clerk IS NULL THEN
+      RAISE EXCEPTION 'clerk_identity_unknown: recurring templates are keyed by sign-in identity and this session has none'
+        USING ERRCODE = '42501';
+    END IF;
+    SELECT jsonb_agg(e || jsonb_build_object('user_id', v_clerk))
+      INTO v_rows
+      FROM jsonb_array_elements(v_rows) AS e;
+    INSERT INTO public.recurring_transactions
+    SELECT r.* FROM jsonb_populate_recordset(NULL::public.recurring_transactions, v_rows) AS r;
+
+  ELSIF p_entity = 'notifications' THEN
+    INSERT INTO public.notifications
+    SELECT r.* FROM jsonb_populate_recordset(NULL::public.notifications, v_rows) AS r;
+
+  ELSIF p_entity = 'dashboard_layouts' THEN
+    INSERT INTO public.dashboard_layouts
+    SELECT r.* FROM jsonb_populate_recordset(NULL::public.dashboard_layouts, v_rows) AS r;
+
+  ELSIF p_entity = 'widget_preferences' THEN
+    INSERT INTO public.widget_preferences
+    SELECT r.* FROM jsonb_populate_recordset(NULL::public.widget_preferences, v_rows) AS r;
+
+  ELSIF p_entity = 'suggestion_dismissals' THEN
+    INSERT INTO public.suggestion_dismissals
+    SELECT r.* FROM jsonb_populate_recordset(NULL::public.suggestion_dismissals, v_rows) AS r;
+
+  ELSIF p_entity = 'custom_reports' THEN
+    INSERT INTO public.custom_reports
+    SELECT r.* FROM jsonb_populate_recordset(NULL::public.custom_reports, v_rows) AS r;
+
+  ELSIF p_entity = 'forecast_adjustments' THEN
+    -- category_id was already rewritten on the client by remapBackupIds — a
+    -- plain uuid column, the remapper's own simplest case, which is the whole
+    -- reason this table is relational rather than a jsonb keyed by ids. The
+    -- generic re-owning arm above is exactly right for it.
+    INSERT INTO public.forecast_adjustments
+    SELECT r.* FROM jsonb_populate_recordset(NULL::public.forecast_adjustments, v_rows) AS r;
+
+  ELSE
+    RAISE EXCEPTION 'restore_entity_unknown: "%" is not something this backup format carries', p_entity
+      USING ERRCODE = '22023';
+  END IF;
+
+  GET DIAGNOSTICS v_n = ROW_COUNT;
+  RETURN v_n;
+END;
+$$;
+
+COMMIT;
+
+
+-- ============================================================================
+-- VERIFICATION — read this output after applying
+-- ============================================================================
+-- 1. The table, its policies and its grants. Expected: rls_enabled = true,
+--    four policies (DELETE, INSERT, SELECT, UPDATE), no anon privileges.
+SELECT
+  c.relrowsecurity AS rls_enabled,
+  (SELECT string_agg(p.cmd, ', ' ORDER BY p.cmd) FROM pg_policies p
+    WHERE p.schemaname = 'public' AND p.tablename = 'forecast_adjustments') AS commands
+FROM pg_class c
+JOIN pg_namespace n ON n.oid = c.relnamespace
+WHERE n.nspname = 'public' AND c.relname = 'forecast_adjustments';
+
+-- 2. Both functions now carry the forecast_adjustments branch AND still carry
+--    custom_reports — extension, not downgrade. Expected: t, t.
+SELECT
+  pg_get_functiondef(to_regprocedure('public.restore_user_chunk(text, jsonb, uuid)')) LIKE '%forecast_adjustments%'
+    AND pg_get_functiondef(to_regprocedure('public.restore_user_chunk(text, jsonb, uuid)')) LIKE '%custom_reports%' AS restore_extended,
+  pg_get_functiondef(to_regprocedure('public.wipe_user_financial_data(text, uuid)')) LIKE '%forecast_adjustments%'
+    AND pg_get_functiondef(to_regprocedure('public.wipe_user_financial_data(text, uuid)')) LIKE '%custom_reports%' AS wipe_extended;
+
+-- 3. Adjustments held. Expected: zero immediately after applying.
+SELECT count(*) AS adjustments FROM public.forecast_adjustments;


### PR DESCRIPTION
## ⚠️ Stacked on #359 — merge order and migrations

This PR is **stacked on `claude/forecast-base` (#359)** and shows only the scenario diff. Merge #359 first, then this. Both wait on the owner running `npm run db:migrate` once, which applies the two parked migrations in order (`20260819130000`, `20260819150000`). A throwaway Postgres already applied the whole history to **"unapplied: 0"** as the rehearsal.

## What this is

Build order step 5 of `docs/forecast-direction.md`: the scenario — **stated adjustments over the visible base**, persisted by both engines.

## Why a table and not a document — the decision everything else follows

The obvious shape is one jsonb of `{categoryId: monthly}`, and it is wrong for a measured reason: `remapBackupIds` rewrites uuid **columns**, id arrays and named arrays inside a jsonb value — never the **keys** of a jsonb object. A document keyed by category ids would restore verbatim into a login with fresh ids and silently adjust nothing. So `forecast_adjustments` is relational: one row per adjusted category, the reference a plain uuid column (the remapper's simplest case), a dangling one **reported**, and `ON DELETE CASCADE` taking an adjustment away with its category. `monthly_minor` is a bigint of **pennies** — the figure crosses the seam with no scale conversion anywhere.

## Every layer, one change each

The migration follows `20260812140000`'s discipline to the letter (five guards, including the copied-from-the-**latest**-definition check that migration wrote after making the mistake itself; the wipe gains one *uncounted* delete beside the dismissals — a judgment about how the ledger is read, matching the crate's uncounted loop so the verb-parity lane sees identical keys; the restore gains one ordinary branch). Then: the backup format's sixteenth entity; the local schema's STRICT twin; the crate's verb pair (set = upsert keeping the row's identity; clear = a real delete where absence *is* the state) + read + dispatch + backup entity; all four `DataPort` implementers, compiler-named; the browser engine **refuses the write out loud** rather than keeping it somewhere no backup carries — the custom-reports localStorage failure is the scar that rule keeps closed.

**Four ratchet tests named the change and were widened with it** — the two literal cannot-keep lists, the restore-ordering list, and the boot's whole-seam stub. Each is a tripwire this repo built deliberately, and each fired exactly as designed when the sixteenth table arrived.

## The page

Each category row shows base **and** scenario side by side. A category follows the base until a figure is stated; a stated figure shows its deviation against the base it deviates from, and one click returns it. Sides announce a scenario month only when it differs. Adjustments on categories with no recent activity sit in their own band, counted in the totals — a deviation influencing figures from off-screen would make the scenario uninterrogatable. A failed load says the scenario is **following the base** rather than inventing deviations from a stale copy.

## Found in passing (not this PR's, spun off)

One local-admission spec is timezone-sensitive — green on CI's UTC runners, red on a BST machine — verified pre-existing on a clean tree.

## Verification

`tsc -b` clean, `eslint` clean, full gates green; 26 crate suites + `clippy -D warnings` clean; the contract lane at **144** (three new rules: the round-trip keeping identity across a restatement; the browser refusal with `cannotKeep` saying so; the foreign key refusing a category the ledger does not hold); admission at its pre-existing 108/109; all 72 desktop tests; 6 page specs; 251 capability-suite tests; 73 across the backup-order and boot-stub suites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
