### PR TITLE
fix(admission): the lane's verdict no longer depends on the operator's holiday plans

### DIFF
--- a/scripts/local-sqlite/admission-specs/dedupe-a-date-only-the-browser-can-read-is-unreadable-to-the-port.spec.mjs
+++ b/scripts/local-sqlite/admission-specs/dedupe-a-date-only-the-browser-can-read-is-unreadable-to-the-port.spec.mjs
@@ -6,6 +6,15 @@
 // whose meaning depends on the reader's nationality. Porting that would mean
 // porting V8.
 //
+// It depends on the reader's TIMEZONE too, not just their nationality, and
+// that is one layer deeper than this file first recorded: the fallback forms
+// parse at LOCAL midnight while the standard form parses at UTC midnight
+// (ECMA-262's date-only rule), so the day_gap below is 0 in London and 1 in
+// Central Europe for the very same file. The harness pins TZ=UTC (see
+// admission.mjs) so this comparison of two ENGINES cannot change verdict with
+// the operator's location; the production TS really does vary this way, which
+// is one more cost of the fallback parser this spec exists to record.
+//
 // The direction of the consequence is why the port is allowed to be stricter: a
 // date it cannot read drops the row out of MATCHING, so the row imports and is
 // visible in the register. It fails towards "an extra row the user can see",

--- a/scripts/local-sqlite/admission.mjs
+++ b/scripts/local-sqlite/admission.mjs
@@ -22,6 +22,22 @@
 // behind. This asks whether two implementations of one DECISION agree — and
 // there are no rows to compare, because nothing is written.
 //
+// THE CLOCK'S ZONE IS PINNED, AND WHY IT HAS TO BE
+// -------------------------------------------------
+// Set before any import can construct a Date, because V8 reads TZ once. The
+// dedupe fixtures carry dates in two spellings on purpose — the standard
+// date-only form, which ECMA-262 parses at UTC midnight, and V8's fallback
+// forms, which parse at LOCAL midnight — so the day a fallback date lands on
+// depends on where the machine running this harness happens to be. Measured,
+// 19 Aug 2026, on a laptop set to CEST: '2027-2-7' parsed to 06 Feb 23:00Z,
+// one UTC day before its well-formed twin, and the day-gap spec went red on a
+// machine while CI stayed green. That variation is REAL production behaviour
+// (a browser in Sydney genuinely computes a different gap than one in London
+// — TS-I7's spec now says so), but this harness compares two ENGINES, and a
+// comparison must not change verdict with the operator's holiday plans. UTC
+// is CI's zone, so a spec that passes here passes there.
+process.env.TZ = 'UTC';
+
 // The oracle is different too, and it is the reason this lane exists at all.
 // Every verb in verbs.mjs is a port of a live Postgres function, so Postgres
 // can be asked. PHASE1-PLAN §5 counts 48 invariants with no SQL side anywhere


### PR DESCRIPTION
## Why

One admission spec — `dedupe-a-date-only-the-browser-can-read` [TS-I7] — went red on a laptop while CI stayed green. The cause completes the spec's own point one layer deeper than it had recorded: V8's fallback parser reads `'2027-2-7'` at **local** midnight, while ECMA-262 reads the well-formed `'2027-02-07'` at **UTC** midnight. In London-February the two agree; on a machine set to CEST (measured, 19 Aug: the fallback parsed to `06 Feb 23:00Z`) they land on different UTC days, and the expected `day_gap: 0` became 1. The fallback's meaning depends on the reader's **timezone** as well as their nationality — which the spec now says.

## The fix

The variation is real production behaviour — a browser in Sydney genuinely computes a different gap than one in London for the same file, one more cost of the fallback parser the spec exists to record. But this harness compares two **engines**, and a comparison must not change verdict with the machine's location. So `admission.mjs` pins `TZ=UTC` before any import can construct a Date, with the measurement in the margin. UTC is CI's zone: a spec that passes here now passes there, and vice versa.

The alternative — an elastic `day_gap` expectation — would have grown the harness a per-field either-of matcher for one spec, and would have *loosened* the pin: the divergence half (TS offers a possible duplicate, the port offers none) is what the spec is for, and it holds in every zone.

## Verification

109/109 on the CEST machine that failed, and 109/109 again under `TZ=Australia/Sydney` — the zone that flips the fallback's calendar day.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
