### PR TITLE
fix(test): a vitest file argument is a filter — stop it matching nested session worktrees

### DIFF
--- a/packages/config/vitest.react.js
+++ b/packages/config/vitest.react.js
@@ -11,7 +11,14 @@ const defaultExclude = [
   'src.backup.*/**',
   '**/src.backup.*/**',
   '**/*.backup.*/**',
-  '**/CLAUDE.md.backup.*'
+  '**/CLAUDE.md.backup.*',
+  // Session worktrees are FULL CHECKOUTS nested under .claude/worktrees, and a
+  // vitest file argument is a FILTER, not a path: measured from the repo root,
+  // `vitest list --filesOnly src/test/supabase/supabase-smoke.test.ts` matched
+  // 7 files — the named one plus six worktree copies, some stale enough to
+  // fail on rules the current tree no longer has. A worktree running its own
+  // suite is unaffected: its files are `src/...` relative to its own root.
+  '**/.claude/**'
 ];
 
 const defaultInclude = [

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -40,6 +40,10 @@ export default createVitestReactConfig({
     '**/*.backup.*/**',
     '**/CLAUDE.md.backup.*',
     'WealthTracker-Backups/**',
+    // Nested session worktrees under .claude/worktrees are full checkouts, and
+    // a vitest file argument is a filter — from the repo root it matches every
+    // worktree's copy too. See packages/config/vitest.react.js for the measure.
+    '**/.claude/**',
     'apps/**',
     'api/**', // Backend API endpoints tested separately
     // The local edition's contract run. It needs a built Rust binary and


### PR DESCRIPTION
## What broke

A pre-push from the root checkout died in the supabase-smoke lane on two test files that do not exist in main's tree — they were **stale copies inside nested session worktrees** under `.claude/worktrees/`, old enough to carry a helper that throws where the current one skips.

## The mechanism, measured

A vitest file argument is a **filter**, not a path. From the repo root:

```
npx vitest list --filesOnly src/test/supabase/supabase-smoke.test.ts
```

matched **seven** files — the named one plus six worktree copies, because session worktrees are full checkouts and the filter matches anything discovery admits whose path contains the argument.

## The fix

Exclude `**/.claude/**`:

- in `packages/config/vitest.react.js`'s `defaultExclude`, which covers every consumer that passes no list of its own;
- in `vitest.config.ts`'s explicit list, because a passed `exclude` **replaces** the default rather than extending it.

Re-measured after the change: 7 matches became 1. A worktree running its own suite is unaffected — its files are `src/`-relative to its own root, so the pattern never self-matches (verified from inside a worktree: its smoke file and a realtime-manifest file both still found).

The other two configs need nothing: `vitest.local.config.ts` and `vitest.desktop.config.ts` use `include` patterns anchored at `src/`, which cannot match a `.claude/…` relative path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
