### PR TITLE
feat(forecast): Current is a real P&L — income over expenditure, net at the foot, months behind a toggle, four windows

### DIFF
--- a/src/pages/Forecast.tsx
+++ b/src/pages/Forecast.tsx
@@ -1,75 +1,62 @@
 import React, { useEffect, useMemo, useState } from 'react';
 import PageWrapper from '../components/PageWrapper';
 import { useApp } from '../contexts/AppContextSupabase';
-import { useToast } from '../contexts/ToastContext';
 import { useCurrencyDecimal } from '../hooks/useCurrencyDecimal';
 import { toDecimal } from '../utils/decimal';
 import { getDateLocale } from '../utils/dateFormatter';
 import { buildCategoryKindLookup, classifyFlow } from '../utils/incomeExpense';
 import { createCategoryLabeller } from '../utils/categoryLabel';
 import { dismissedKeys } from '../utils/suggestionDismissals';
+import { buildPlWindow, bucketIndexOf, dayOf } from '../utils/plWindow';
+import type { PlWindowKind } from '../utils/plWindow';
+import { ChevronDownIcon, ChevronRightIcon } from '../components/icons';
 import { dataPort } from '@data';
-import MoneyInput from '../components/common/MoneyInput';
-import { parseMoneyInput } from '../utils/decimal';
 import type { ForecastAdjustment, Transaction } from '../types';
 
 /**
- * THE FORECAST'S BASE — the last twelve months, category by category.
+ * CURRENT AND FORECAST — a P&L of what happened, and the room the scenario
+ * tool will move into.
  *
- * Build order step 4 of docs/forecast-direction.md, shipped BEFORE any
- * projection exists because the ruling demands an inspectable foundation:
- * the forecast is a SCENARIO TOOL (owner, 17 Aug), it never writes to
- * Budget on its own, and a scenario that stands on unreviewed actuals
- * cannot be interrogated. This page is that review — useful alone as a
- * twelve-month category P&L.
+ * Reshaped to the owner's 19 Aug direction, replacing the side-by-side
+ * base cards: "more like a 'P&L', with income above, and expenses below
+ * and then a 'net income' or a 'net expenditure' figure at the bottom" —
+ * with collapsible sections, a months toggle ("the twelve months going
+ * across to the right just like looking at a full 12 month P&L", hidden
+ * by default), and a choice of windows. "Lets get the basic look of the
+ * current 'P&L' right first… Forecast can be blank for the minute until
+ * I decide how I would like it built."
  *
- * ── THE BASE IS HONEST OR IT IS NOTHING ────────────────────────────────────
+ * ── THE CURRENT TAB IS ACTUALS, WHOLE ──────────────────────────────────────
  *
- * - TWELVE COMPLETE MONTHS, stated on screen. The current month is not in
- *   the base: a half-month would understate every category it touches.
- * - ONE-OFFS ARE EXCLUDABLE, AND THE EXCLUSIONS ARE STATED (§7.1: "with
- *   the exclusions stated"). The roof, the payout, the car — excluding
- *   them is what makes the monthly average a typical month; hiding that
- *   they were excluded would make the average a fiction. The excluded rows
- *   sit in their own restorable band, counted in the headline.
- * - An exclusion is a VERDICT, stored beside the app's other suggestion
- *   answers ('forecast-excluded', migration 20260819130000), keyed by the
- *   row's own id: it survives reloads and restores, and dies with its row.
- *   The register is untouched — only this base stops counting the row.
- * - WHOLE TRANSACTIONS, deliberately. The figures here are grouped from
- *   the same real rows the expansion lists, so a category's total is
- *   exactly the sum of the rows shown under it — never a quietly different
- *   number computed some other way. Transfers and revaluations are not
- *   income or spending and are left out BY NAME, with their counts.
- * - The unfiled remainder is a NAMED line per side, excludable like any
- *   category's rows — a one-off that was never categorised is still a
- *   one-off.
+ * - Every figure is grouped from the same real rows a category expands to,
+ *   so a total is exactly the sum of the rows shown under it. Transfers
+ *   and revaluations are not income or spending and are left out BY NAME,
+ *   with their counts. The unfiled remainder is a NAMED line per side.
+ * - Every window holds only COMPLETE periods — the current part month
+ *   would understate every category it touches. The windows themselves
+ *   (last twelve months, calendar year, tax year in 6th-to-5th tax months,
+ *   custom) live in utils/plWindow, where their boundaries are pinned.
+ * - Forecast-exclusion verdicts do NOT thin this tab: a P&L of what
+ *   happened shows what happened. The verdicts are kept — they belong to
+ *   the forecast's base, and resurface with the redesigned Forecast tab.
  *
- * ── THE SCENARIO IS STATED ADJUSTMENTS OVER THE VISIBLE BASE ───────────────
+ * ── THE FORECAST TAB IS DELIBERATELY EMPTY ─────────────────────────────────
  *
- * Design's interrogability rule, and the owner's ruling, made literal: each
- * category row shows its base average AND its scenario figure side by side.
- * A category follows the base until the user states otherwise; a stated
- * figure shows its deviation against the base it deviates from, and one
- * click returns it. The adjustments persist through the seam
- * ('forecast_adjustments', both engines — a signed-out browser refuses the
- * write out loud rather than keeping it somewhere no backup carries). An
- * adjustment whose category has no recent activity is still SHOWN, in its
- * own band: a stored deviation that influenced no visible row would be a
- * scenario nobody can interrogate.
+ * The scenario tool (stated deviations over a reviewed base — see
+ * docs/forecast-direction.md and the 'forecast_adjustments' seam, which
+ * both engines still keep) is being redesigned to the owner's brief. The
+ * tab says so, and names what is already stored for it rather than
+ * letting stated judgments look lost. Nothing here writes to Budget —
+ * that ruling is unchanged.
  */
 
 const UNFILED_LABEL = 'Uncategorised — not yet filed';
 
-/** Which side of the P&L a category's flow kind lands on. */
-const categoryKindOfSide = (kind: string | null): 'in' | 'out' | null =>
-  kind === 'income' ? 'in' : kind === 'expense' ? 'out' : null;
-
-interface BaseGroup {
-  /** null for the unfiled remainder — the one line with nothing to adjust. */
+interface StatementGroup {
   categoryId: string | null;
   label: string;
   total: number;
+  perBucket: number[];
   rows: Transaction[];
 }
 
@@ -77,73 +64,110 @@ export default function Forecast(): React.JSX.Element {
   const {
     accounts, categories, transactions,
     suggestionDismissals, suggestionDismissalsStatus, refreshSuggestionDismissals,
-    dismissSuggestion, restoreSuggestion,
   } = useApp();
   const { formatCurrency } = useCurrencyDecimal();
-  const { showError } = useToast();
 
-  // The verdicts are lazy-loaded; a reader must ask (the #353 lesson — a
-  // surface that gates on 'ready' without requesting the load is invisible).
+  const [tab, setTab] = useState<'current' | 'forecast'>('current');
+
+  /** Which "twelve months" the P&L reads over. */
+  const [windowKind, setWindowKind] = useState<PlWindowKind>('last-12');
+  const defaultCustom = useMemo(() => {
+    const lastTwelve = buildPlWindow('last-12', new Date());
+    return {
+      from: lastTwelve.buckets[0].key,
+      to: lastTwelve.buckets[lastTwelve.buckets.length - 1].key,
+    };
+  }, []);
+  const [customFrom, setCustomFrom] = useState(defaultCustom.from);
+  const [customTo, setCustomTo] = useState(defaultCustom.to);
+
+  const plWindow = useMemo(
+    () => buildPlWindow(windowKind, new Date(), { fromMonth: customFrom, toMonth: customTo }),
+    [windowKind, customFrom, customTo]
+  );
+
+  const [sectionOpen, setSectionOpen] = useState<{ in: boolean; out: boolean }>({ in: true, out: true });
+  const [showMonths, setShowMonths] = useState(false);
+  /** Which category's rows are open, as `${side}:${label}`. */
+  const [openGroup, setOpenGroup] = useState<string | null>(null);
+
+  // The exclusion verdicts are lazy-loaded and this page ASKS (the #353
+  // lesson) — the Forecast tab names how many are kept for the redesign.
   useEffect(() => {
     if (suggestionDismissalsStatus === 'idle') void refreshSuggestionDismissals();
   }, [suggestionDismissalsStatus, refreshSuggestionDismissals]);
 
-  const answersReady = suggestionDismissalsStatus === 'ready';
-
-  const excludedIds = useMemo(
-    () => dismissedKeys(suggestionDismissals, 'forecast-excluded'),
+  const excludedCount = useMemo(
+    () => dismissedKeys(suggestionDismissals, 'forecast-excluded').size,
     [suggestionDismissals]
   );
 
-  /** Twelve COMPLETE months: first of (this month − 12) … last day of last month. */
-  const window = useMemo(() => {
-    const now = new Date();
-    return {
-      from: new Date(now.getFullYear(), now.getMonth() - 12, 1),
-      to: new Date(now.getFullYear(), now.getMonth(), 0, 23, 59, 59, 999),
-    };
+  /**
+   * The scenario's stored deviations — read only to COUNT them on the
+   * Forecast tab while the tool is being redesigned. A failed read is said,
+   * never guessed at.
+   */
+  const [adjustments, setAdjustments] = useState<ForecastAdjustment[]>([]);
+  const [adjustmentsStatus, setAdjustmentsStatus] = useState<'loading' | 'ready' | 'error'>('loading');
+  useEffect(() => {
+    let live = true;
+    void (async () => {
+      try {
+        const rows = await dataPort.listForecastAdjustments();
+        if (!live) return;
+        setAdjustments(rows);
+        setAdjustmentsStatus('ready');
+      } catch {
+        if (!live) return;
+        setAdjustmentsStatus('error');
+      }
+    })();
+    return () => { live = false; };
   }, []);
 
   const labeller = useMemo(() => createCategoryLabeller(categories, accounts), [categories, accounts]);
   const categoryKinds = useMemo(() => buildCategoryKindLookup(categories), [categories]);
 
-  const base = useMemo(() => {
-    const income = new Map<string, BaseGroup>();
-    const expense = new Map<string, BaseGroup>();
+  const statement = useMemo(() => {
+    const bucketCount = plWindow.buckets.length;
+    const income = new Map<string, StatementGroup>();
+    const expense = new Map<string, StatementGroup>();
     let transfers = 0;
     let revaluations = 0;
-    const excluded: Transaction[] = [];
 
-    // Keyed by CATEGORY ID, not label — the scenario attaches to the id, and
-    // two categories that happened to share a wording must not share a figure.
+    // Keyed by CATEGORY ID, not label — two categories that happened to
+    // share a wording must not share a figure.
     const add = (
-      side: Map<string, BaseGroup>,
+      side: Map<string, StatementGroup>,
       categoryId: string | null,
       label: string,
-      row: Transaction
+      row: Transaction,
+      bucket: number
     ): void => {
       const key = categoryId ?? UNFILED_LABEL;
-      const group = side.get(key) ?? { categoryId, label, total: 0, rows: [] };
-      group.total = toDecimal(group.total).plus(toDecimal(row.amount).abs()).toNumber();
+      const group = side.get(key)
+        ?? { categoryId, label, total: 0, perBucket: Array.from({ length: bucketCount }, () => 0), rows: [] };
+      const magnitude = toDecimal(row.amount).abs();
+      group.total = toDecimal(group.total).plus(magnitude).toNumber();
+      group.perBucket[bucket] = toDecimal(group.perBucket[bucket]).plus(magnitude).toNumber();
       group.rows.push(row);
       side.set(key, group);
     };
 
     for (const row of transactions) {
-      const time = new Date(row.date).getTime();
-      if (time < window.from.getTime() || time > window.to.getTime()) continue;
-      if (excludedIds.has(row.id)) { excluded.push(row); continue; }
+      const bucket = bucketIndexOf(dayOf(row.date), plWindow.buckets);
+      if (bucket === -1) continue;
       const kind = classifyFlow(row, categoryKinds);
       if (kind === 'transfer') { transfers++; continue; }
       if (kind === 'revaluation') { revaluations++; continue; }
       if (kind === 'uncategorized') {
-        add(row.amount >= 0 ? income : expense, null, UNFILED_LABEL, row);
+        add(row.amount >= 0 ? income : expense, null, UNFILED_LABEL, row, bucket);
         continue;
       }
-      add(kind === 'income' ? income : expense, row.category, labeller(row) || UNFILED_LABEL, row);
+      add(kind === 'income' ? income : expense, row.category, labeller(row) || UNFILED_LABEL, row, bucket);
     }
 
-    const finish = (side: Map<string, BaseGroup>): BaseGroup[] =>
+    const finish = (side: Map<string, StatementGroup>): StatementGroup[] =>
       [...side.values()]
         .map(group => ({
           ...group,
@@ -157,495 +181,458 @@ export default function Forecast(): React.JSX.Element {
           return b.total - a.total;
         });
 
-    const sum = (groups: BaseGroup[]): number =>
-      groups.reduce((total, group) => toDecimal(total).plus(toDecimal(group.total)).toNumber(), 0);
+    const sumBuckets = (groups: StatementGroup[]): number[] =>
+      Array.from({ length: bucketCount }, (_, i) =>
+        groups.reduce((total, group) => toDecimal(total).plus(toDecimal(group.perBucket[i])).toNumber(), 0)
+      );
 
     const incomeGroups = finish(income);
     const expenseGroups = finish(expense);
+    const incomePerBucket = sumBuckets(incomeGroups);
+    const expensePerBucket = sumBuckets(expenseGroups);
+    const incomeTotal = incomePerBucket.reduce((a, b) => toDecimal(a).plus(toDecimal(b)).toNumber(), 0);
+    const expenseTotal = expensePerBucket.reduce((a, b) => toDecimal(a).plus(toDecimal(b)).toNumber(), 0);
+
     return {
       income: incomeGroups,
       expense: expenseGroups,
-      incomeTotal: sum(incomeGroups),
-      expenseTotal: sum(expenseGroups),
+      incomeTotal,
+      expenseTotal,
+      incomePerBucket,
+      expensePerBucket,
+      net: toDecimal(incomeTotal).minus(toDecimal(expenseTotal)).toNumber(),
+      netPerBucket: incomePerBucket.map((v, i) =>
+        toDecimal(v).minus(toDecimal(expensePerBucket[i])).toNumber()
+      ),
       transfers,
       revaluations,
-      excluded: excluded.sort((a, b) => Math.abs(b.amount) - Math.abs(a.amount)),
     };
-  }, [transactions, window, excludedIds, categoryKinds, labeller]);
+  }, [transactions, plWindow, categoryKinds, labeller]);
 
-  /** Which category's rows are open, as `${side}:${label}`. */
-  const [openGroup, setOpenGroup] = useState<string | null>(null);
-  const [savingId, setSavingId] = useState<string | null>(null);
-
-  /**
-   * THE SCENARIO's stored deviations, keyed by category. Loaded through the
-   * seam rather than the app context: the context does not carry them, and
-   * the one page that reads them is this one — the asymmetry the port's own
-   * docs argue against putting them in the boot.
-   */
-  const [adjustments, setAdjustments] = useState<Map<string, ForecastAdjustment>>(new Map());
-  const [adjustmentsStatus, setAdjustmentsStatus] = useState<'loading' | 'ready' | 'error'>('loading');
-  useEffect(() => {
-    let live = true;
-    void (async () => {
-      try {
-        const rows = await dataPort.listForecastAdjustments();
-        if (!live) return;
-        setAdjustments(new Map(rows.map(row => [row.categoryId, row])));
-        setAdjustmentsStatus('ready');
-      } catch {
-        if (!live) return;
-        // A failed read is a scenario that FOLLOWS THE BASE, said on screen —
-        // never invented deviations from another store.
-        setAdjustmentsStatus('error');
-      }
-    })();
-    return () => { live = false; };
-  }, []);
-
-  /** The category currently being adjusted, and the draft in its box. */
-  const [editingCategory, setEditingCategory] = useState<string | null>(null);
-  const [draftMonthly, setDraftMonthly] = useState('');
-  const [savingAdjustment, setSavingAdjustment] = useState(false);
-
-  const stateAdjustment = async (categoryId: string): Promise<void> => {
-    const pounds = parseMoneyInput(draftMonthly);
-    if (pounds === null || pounds < 0) {
-      showError(new Error('Enter the monthly figure for the scenario — zero or more'));
-      return;
-    }
-    setSavingAdjustment(true);
-    try {
-      const stated = await dataPort.setForecastAdjustment(
-        categoryId,
-        toDecimal(pounds).times(100).toNumber()
-      );
-      setAdjustments(previous => new Map(previous).set(categoryId, stated));
-      setEditingCategory(null);
-      setDraftMonthly('');
-    } catch (error) {
-      showError(error);
-    } finally {
-      setSavingAdjustment(false);
-    }
-  };
-
-  const followBase = async (categoryId: string): Promise<void> => {
-    setSavingAdjustment(true);
-    try {
-      await dataPort.clearForecastAdjustment(categoryId);
-      setAdjustments(previous => {
-        const next = new Map(previous);
-        next.delete(categoryId);
-        return next;
-      });
-      setEditingCategory(null);
-    } catch (error) {
-      showError(error);
-    } finally {
-      setSavingAdjustment(false);
-    }
-  };
-
-  const exclude = async (row: Transaction): Promise<void> => {
-    setSavingId(row.id);
-    try {
-      await dismissSuggestion('forecast-excluded', row.id, [row.id]);
-    } catch (error) {
-      showError(error);
-    } finally {
-      setSavingId(null);
-    }
-  };
-
-  const restore = async (id: string): Promise<void> => {
-    setSavingId(id);
-    try {
-      await restoreSuggestion('forecast-excluded', id);
-    } catch (error) {
-      showError(error);
-    } finally {
-      setSavingId(null);
-    }
-  };
-
-  /** A group's SCENARIO monthly figure, in pounds: stated, or the base's. */
-  const scenarioMonthly = (group: BaseGroup): number => {
-    if (group.categoryId !== null) {
-      const stated = adjustments.get(group.categoryId);
-      if (stated) return toDecimal(stated.monthlyMinor).dividedBy(100).toNumber();
-    }
-    return average(group.total);
-  };
-
-  /**
-   * Adjustments on categories the base does not show — no activity in the
-   * window, or category gone from the ledger's list. STILL SHOWN, in their
-   * own band, and still counted in the scenario's totals: a stored deviation
-   * that influenced no visible figure would be a scenario nobody can
-   * interrogate.
-   */
-  const orphanAdjustments = useMemo(() => {
-    const inBase = new Set(
-      [...base.income, ...base.expense]
-        .map(group => group.categoryId)
-        .filter((id): id is string => id !== null)
-    );
-    const named = new Map(categories.map(category => [category.id, category]));
-    return [...adjustments.values()]
-      .filter(adjustment => !inBase.has(adjustment.categoryId))
-      .map(adjustment => {
-        const category = named.get(adjustment.categoryId);
-        return {
-          adjustment,
-          label: category
-            ? (labeller({ category: adjustment.categoryId }) || category.name)
-            : 'A category no longer in your list',
-          side: (category && categoryKindOfSide(categoryKinds.get(adjustment.categoryId) ?? null)) ?? 'out',
-        };
-      });
-  }, [adjustments, base.income, base.expense, categories, labeller, categoryKinds]);
-
-  /** One side's scenario monthly total: its groups' effective figures plus its orphans. */
-  const scenarioSideTotal = (groups: BaseGroup[], side: 'in' | 'out'): number => {
-    const fromGroups = groups.reduce(
-      (total, group) => toDecimal(total).plus(toDecimal(scenarioMonthly(group))).toNumber(),
-      0
-    );
-    return orphanAdjustments
-      .filter(orphan => orphan.side === side)
-      .reduce(
-        (total, orphan) =>
-          toDecimal(total).plus(toDecimal(orphan.adjustment.monthlyMinor).dividedBy(100)).toNumber(),
-        fromGroups
-      );
-  };
-
-  const monthRange = `${window.from.toLocaleDateString(getDateLocale(), { month: 'long', year: 'numeric' })} to ${window.to.toLocaleDateString(getDateLocale(), { month: 'long', year: 'numeric' })}`;
-
-  const average = (total: number): number => toDecimal(total).dividedBy(12).toNumber();
+  const average = (total: number): number =>
+    toDecimal(total).dividedBy(plWindow.buckets.length).toNumber();
 
   const accountNameById = useMemo(
     () => new Map(accounts.map(a => [a.id, a.name])),
     [accounts]
   );
 
-  /** One side of the P&L — Income or Expenditure — as a card of groups. */
-  const SideCard = ({ side, title, groups, total }: {
-    side: 'in' | 'out'; title: string; groups: BaseGroup[]; total: number;
-  }): React.JSX.Element => (
-    <div className="bg-white dark:bg-gray-800 rounded-lg border border-line dark:border-gray-700 p-4 sm:p-6">
-      <div className="flex flex-wrap items-baseline justify-between gap-2 mb-2">
-        <h2 className="text-card font-semibold text-theme-heading dark:text-white">{title}</h2>
-        <span className="text-right">
-          <span className={`block text-body font-semibold tabular-nums ${
-            side === 'in' ? 'text-green-600 dark:text-green-400' : 'text-red-600 dark:text-red-400'
-          }`}>
-            {side === 'in' ? `+${formatCurrency(total)}` : formatCurrency(-total)}
-          </span>
-          <span className="block text-dense tabular-nums text-gray-500 dark:text-gray-400">
-            {formatCurrency(average(total))} a month
-          </span>
-          {/* The side's SCENARIO month, only when it differs — a scenario
-              that follows the base has nothing to announce. */}
-          {adjustmentsStatus === 'ready' &&
-            toDecimal(scenarioSideTotal(groups, side)).minus(toDecimal(average(total))).abs().greaterThan(0.004) && (
-            <span className="block text-dense tabular-nums text-gray-700 dark:text-gray-300">
-              scenario: {formatCurrency(scenarioSideTotal(groups, side))} a month
+  /** A flow figure worn the app's way: income +£X, expenditure (£X) — and a
+   * zero wears neither sign nor colour, because it needs no attention. */
+  const flowText = (side: 'in' | 'out', value: number): string =>
+    value === 0 ? formatCurrency(0)
+      : side === 'in' ? `+${formatCurrency(value)}` : formatCurrency(-value);
+
+  const sideColour = (side: 'in' | 'out', value: number): string =>
+    value === 0 ? 'text-gray-900 dark:text-white'
+      : side === 'in' ? 'text-green-600 dark:text-green-400' : 'text-red-600 dark:text-red-400';
+
+  /** A month cell — a quiet dash where nothing happened, never £0.00 noise. */
+  const cellText = (side: 'in' | 'out', value: number): string =>
+    value === 0 ? '—' : flowText(side, value);
+
+  const netText = (value: number): string =>
+    value === 0 ? formatCurrency(0)
+      : value > 0 ? `+${formatCurrency(value)}` : formatCurrency(value);
+
+  const netLabel = statement.net >= 0 ? 'Net income' : 'Net expenditure';
+  const netColour = statement.net === 0 ? 'text-gray-900 dark:text-white'
+    : statement.net > 0
+      ? 'text-green-600 dark:text-green-400'
+      : 'text-red-600 dark:text-red-400';
+
+  const windowSentence: Record<PlWindowKind, string> = {
+    'last-12': 'the last twelve complete months — the current part month is left out, it would understate every category it touches',
+    'calendar-year': 'the last full calendar year',
+    'tax-year': 'the last complete tax year; months run 6th to 5th, as tax months do',
+    'custom': 'whole months, chosen by you',
+  };
+
+  const toggleSection = (side: 'in' | 'out'): void =>
+    setSectionOpen(previous => ({ ...previous, [side]: !previous[side] }));
+
+  /** The rows a category's figure is the sum of — shared by both layouts. */
+  const TransactionRows = ({ rows }: { rows: Transaction[] }): React.JSX.Element => (
+    <ul className="pb-2 pl-2">
+      {rows.map(row => (
+        <li key={row.id} className="py-1.5 flex flex-wrap items-baseline justify-between gap-x-4 gap-y-0.5 border-t border-gray-50 dark:border-gray-700/50 first:border-0">
+          <span className="min-w-0 flex items-baseline gap-2">
+            <span className="text-xs tabular-nums text-gray-500 dark:text-gray-400 w-16 shrink-0">
+              {new Date(row.date).toLocaleDateString(getDateLocale(), { day: 'numeric', month: 'short', year: '2-digit' })}
             </span>
-          )}
-        </span>
+            <span className="text-sm text-gray-900 dark:text-white truncate">{row.description}</span>
+            {accountNameById.get(row.accountId) && (
+              <span className="text-xs text-gray-400 dark:text-gray-500 truncate">
+                {accountNameById.get(row.accountId)}
+              </span>
+            )}
+          </span>
+          <span className={`text-sm tabular-nums shrink-0 ${
+            row.amount >= 0 ? 'text-green-600 dark:text-green-400' : 'text-red-600 dark:text-red-400'
+          }`}>
+            {row.amount >= 0 ? `+${formatCurrency(row.amount)}` : formatCurrency(row.amount)}
+          </span>
+        </li>
+      ))}
+    </ul>
+  );
+
+  /** One P&L section in the list layout — heading collapsible, rows drillable. */
+  const SectionList = ({ side, title, groups, total }: {
+    side: 'in' | 'out'; title: string; groups: StatementGroup[]; total: number;
+  }): React.JSX.Element => {
+    const open = sectionOpen[side];
+    return (
+      <div className="border-t border-gray-100 dark:border-gray-700/60 first:border-0">
+        <div className="flex items-baseline justify-between gap-4 py-2">
+          <button
+            type="button"
+            onClick={() => toggleSection(side)}
+            aria-expanded={open}
+            className="flex items-center gap-1.5 text-card font-semibold text-theme-heading dark:text-white"
+          >
+            {open
+              ? <ChevronDownIcon size={16} className="text-gray-400 shrink-0" />
+              : <ChevronRightIcon size={16} className="text-gray-400 shrink-0" />}
+            {title}
+          </button>
+          <span className="text-right shrink-0">
+            <span className={`block text-body font-semibold tabular-nums ${sideColour(side, total)}`}>
+              {flowText(side, total)}
+            </span>
+            <span className="block text-dense tabular-nums text-gray-500 dark:text-gray-400">
+              {formatCurrency(average(total))} a month
+            </span>
+          </span>
+        </div>
+        {open && (
+          groups.length === 0 ? (
+            <p className="pb-2 pl-6 text-body text-gray-500 dark:text-gray-400">
+              Nothing on this side of the ledger in this window.
+            </p>
+          ) : (
+            <ul className="pb-1 pl-4">
+              {groups.map(group => {
+                const key = `${side}:${group.label}`;
+                const rowsOpen = openGroup === key;
+                return (
+                  <li key={group.label} className="border-t border-gray-50 dark:border-gray-700/50 first:border-0">
+                    <button
+                      type="button"
+                      onClick={() => setOpenGroup(rowsOpen ? null : key)}
+                      aria-expanded={rowsOpen}
+                      className="w-full py-2 flex items-baseline justify-between gap-4 text-left hover:bg-gray-50 dark:hover:bg-gray-700/40 rounded"
+                    >
+                      <span className={`text-sm truncate ${
+                        group.label === UNFILED_LABEL
+                          ? 'text-gray-500 dark:text-gray-400'
+                          : 'text-gray-900 dark:text-white'
+                      }`}>
+                        {group.label}
+                        <span className="ml-2 text-xs text-gray-400 dark:text-gray-500">{group.rows.length}</span>
+                      </span>
+                      <span className="text-right shrink-0">
+                        <span className="block text-sm tabular-nums text-gray-900 dark:text-white">
+                          {flowText(side, group.total)}
+                        </span>
+                        <span className="block text-xs tabular-nums text-gray-500 dark:text-gray-400">
+                          {formatCurrency(average(group.total))} a month
+                        </span>
+                      </span>
+                    </button>
+                    {rowsOpen && <TransactionRows rows={group.rows} />}
+                  </li>
+                );
+              })}
+            </ul>
+          )
+        )}
       </div>
-      {groups.length === 0 ? (
-        <p className="text-body text-gray-500 dark:text-gray-400">
-          Nothing on this side of the ledger in these twelve months.
-        </p>
-      ) : (
-        <ul>
-          {groups.map(group => {
-            const key = `${side}:${group.label}`;
-            const open = openGroup === key;
-            return (
-              <li key={group.label} className="border-t border-gray-50 dark:border-gray-700/50 first:border-0">
-                <button
-                  type="button"
-                  onClick={() => setOpenGroup(open ? null : key)}
-                  aria-expanded={open}
-                  className="w-full py-2 flex items-baseline justify-between gap-4 text-left hover:bg-gray-50 dark:hover:bg-gray-700/40 rounded"
-                >
-                  <span className={`text-sm truncate ${
-                    group.label === UNFILED_LABEL
-                      ? 'text-gray-500 dark:text-gray-400'
-                      : 'text-gray-900 dark:text-white'
-                  }`}>
+    );
+  };
+
+  const columnCount = plWindow.buckets.length + 3;
+
+  /** One P&L section in the months-across table layout. */
+  const sectionTableRows = (
+    side: 'in' | 'out',
+    title: string,
+    groups: StatementGroup[],
+    total: number,
+    perBucket: number[]
+  ): React.JSX.Element => {
+    const open = sectionOpen[side];
+    return (
+      <>
+        <tr className="border-t border-gray-100 dark:border-gray-700/60">
+          <td className="sticky left-0 bg-white dark:bg-gray-800 py-2 pr-4">
+            <button
+              type="button"
+              onClick={() => toggleSection(side)}
+              aria-expanded={open}
+              className="flex items-center gap-1.5 text-card font-semibold text-theme-heading dark:text-white"
+            >
+              {open
+                ? <ChevronDownIcon size={16} className="text-gray-400 shrink-0" />
+                : <ChevronRightIcon size={16} className="text-gray-400 shrink-0" />}
+              {title}
+            </button>
+          </td>
+          {perBucket.map((value, i) => (
+            <td key={plWindow.buckets[i].key} className="py-2 px-2 text-right text-sm tabular-nums font-medium text-gray-900 dark:text-white whitespace-nowrap">
+              {cellText(side, value)}
+            </td>
+          ))}
+          <td className={`py-2 pl-3 text-right text-sm tabular-nums font-semibold whitespace-nowrap ${sideColour(side, total)}`}>
+            {flowText(side, total)}
+          </td>
+          <td className="py-2 pl-3 text-right text-sm tabular-nums text-gray-500 dark:text-gray-400 whitespace-nowrap">
+            {formatCurrency(average(total))}
+          </td>
+        </tr>
+        {open && groups.map(group => {
+          const key = `${side}:${group.label}`;
+          const rowsOpen = openGroup === key;
+          return (
+            <React.Fragment key={group.label}>
+              <tr className="border-t border-gray-50 dark:border-gray-700/50">
+                <td className="sticky left-0 bg-white dark:bg-gray-800 py-1.5 pl-4 pr-4">
+                  <button
+                    type="button"
+                    onClick={() => setOpenGroup(rowsOpen ? null : key)}
+                    aria-expanded={rowsOpen}
+                    className={`text-left text-sm truncate max-w-[16rem] ${
+                      group.label === UNFILED_LABEL
+                        ? 'text-gray-500 dark:text-gray-400'
+                        : 'text-gray-900 dark:text-white'
+                    }`}
+                  >
                     {group.label}
                     <span className="ml-2 text-xs text-gray-400 dark:text-gray-500">{group.rows.length}</span>
-                  </span>
-                  <span className="text-right shrink-0">
-                    <span className="block text-sm tabular-nums text-gray-900 dark:text-white">
-                      {side === 'in' ? `+${formatCurrency(group.total)}` : formatCurrency(-group.total)}
-                    </span>
-                    <span className="block text-xs tabular-nums text-gray-500 dark:text-gray-400">
-                      {formatCurrency(average(group.total))} a month
-                    </span>
-                  </span>
-                </button>
-                {/* THE SCENARIO'S FIGURE for this category — stated, or the
-                    base's. Outside the expansion button: adjusting is not
-                    the same act as inspecting the rows. The unfiled line has
-                    nothing to attach an adjustment to; the honest advice is
-                    to FILE the rows, and the base note already carries it. */}
-                {group.categoryId !== null && adjustmentsStatus === 'ready' && (
-                  <div className="pb-2 pl-2 flex flex-wrap items-baseline justify-end gap-x-3 gap-y-1">
-                    {editingCategory === group.categoryId ? (
-                      <>
-                        <label className="flex items-center gap-2 text-xs text-gray-500 dark:text-gray-400">
-                          Scenario, a month
-                          <MoneyInput
-                            value={draftMonthly}
-                            onChange={setDraftMonthly}
-                            className="w-28 px-2 py-1 text-sm text-right tabular-nums border border-line dark:border-gray-600 rounded bg-white dark:bg-gray-800 text-gray-900 dark:text-white"
-                            aria-label={`Scenario monthly figure for ${group.label}`}
-                          />
-                        </label>
-                        <button
-                          type="button"
-                          onClick={() => void stateAdjustment(group.categoryId as string)}
-                          disabled={savingAdjustment}
-                          className="text-xs font-medium text-gray-700 dark:text-gray-300 hover:text-gray-900 dark:hover:text-white hover:underline disabled:opacity-50"
-                        >
-                          State it
-                        </button>
-                        <button
-                          type="button"
-                          onClick={() => { setEditingCategory(null); setDraftMonthly(''); }}
-                          className="text-xs text-gray-500 dark:text-gray-400 hover:underline"
-                        >
-                          Cancel
-                        </button>
-                      </>
-                    ) : adjustments.has(group.categoryId) ? (
-                      <>
-                        {/* A DEVIATION, stated against the base it deviates
-                            from — the whole of the interrogability rule. */}
-                        <span className="text-xs tabular-nums text-gray-700 dark:text-gray-300">
-                          scenario {formatCurrency(scenarioMonthly(group))} a month
-                          <span className="text-gray-400 dark:text-gray-500"> · base {formatCurrency(average(group.total))}</span>
-                        </span>
-                        <button
-                          type="button"
-                          onClick={() => {
-                            setEditingCategory(group.categoryId);
-                            setDraftMonthly(toDecimal(scenarioMonthly(group)).toFixed(2));
-                          }}
-                          className="text-xs text-gray-500 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-200 hover:underline"
-                        >
-                          Change
-                        </button>
-                        <button
-                          type="button"
-                          onClick={() => void followBase(group.categoryId as string)}
-                          disabled={savingAdjustment}
-                          className="text-xs text-gray-500 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-200 hover:underline disabled:opacity-50"
-                        >
-                          Back to base
-                        </button>
-                      </>
-                    ) : (
-                      <button
-                        type="button"
-                        onClick={() => {
-                          setEditingCategory(group.categoryId);
-                          setDraftMonthly(toDecimal(average(group.total)).toFixed(2));
-                        }}
-                        className="text-xs text-gray-400 dark:text-gray-500 hover:text-gray-700 dark:hover:text-gray-300 hover:underline"
-                        title="State a different monthly figure for the scenario — the base stays exactly as it is"
-                        aria-label={`Adjust ${group.label} for the scenario`}
-                      >
-                        Adjust for the scenario
-                      </button>
-                    )}
-                  </div>
-                )}
-                {open && (
-                  <ul className="pb-2 pl-2">
-                    {group.rows.map(row => (
-                      <li key={row.id} className="py-1.5 flex flex-wrap items-baseline justify-between gap-x-4 gap-y-0.5 border-t border-gray-50 dark:border-gray-700/50 first:border-0">
-                        <span className="min-w-0 flex items-baseline gap-2">
-                          <span className="text-xs tabular-nums text-gray-500 dark:text-gray-400 w-16 shrink-0">
-                            {new Date(row.date).toLocaleDateString(getDateLocale(), { day: 'numeric', month: 'short', year: '2-digit' })}
-                          </span>
-                          <span className="text-sm text-gray-900 dark:text-white truncate">{row.description}</span>
-                          {accountNameById.get(row.accountId) && (
-                            <span className="text-xs text-gray-400 dark:text-gray-500 truncate">
-                              {accountNameById.get(row.accountId)}
-                            </span>
-                          )}
-                        </span>
-                        <span className="flex items-baseline gap-3 shrink-0">
-                          <span className={`text-sm tabular-nums ${
-                            row.amount >= 0 ? 'text-green-600 dark:text-green-400' : 'text-red-600 dark:text-red-400'
-                          }`}>
-                            {row.amount >= 0 ? `+${formatCurrency(row.amount)}` : formatCurrency(row.amount)}
-                          </span>
-                          {/* The one-off strike. Quiet: there are hundreds of
-                              rows on this page and amber's monopoly holds. */}
-                          {answersReady && (
-                            <button
-                              type="button"
-                              onClick={() => void exclude(row)}
-                              disabled={savingId === row.id}
-                              className="text-xs text-gray-500 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-200 hover:underline disabled:opacity-50"
-                              title="A one-off, not part of a typical month — the base stops counting it; the register is untouched, and it is listed below where it can be restored"
-                            >
-                              Exclude
-                            </button>
-                          )}
-                        </span>
-                      </li>
-                    ))}
-                  </ul>
-                )}
-              </li>
-            );
-          })}
-        </ul>
-      )}
-    </div>
-  );
+                  </button>
+                </td>
+                {group.perBucket.map((value, i) => (
+                  <td key={plWindow.buckets[i].key} className="py-1.5 px-2 text-right text-sm tabular-nums text-gray-700 dark:text-gray-300 whitespace-nowrap">
+                    {cellText(side, value)}
+                  </td>
+                ))}
+                <td className="py-1.5 pl-3 text-right text-sm tabular-nums text-gray-900 dark:text-white whitespace-nowrap">
+                  {flowText(side, group.total)}
+                </td>
+                <td className="py-1.5 pl-3 text-right text-sm tabular-nums text-gray-500 dark:text-gray-400 whitespace-nowrap">
+                  {formatCurrency(average(group.total))}
+                </td>
+              </tr>
+              {rowsOpen && (
+                <tr>
+                  <td colSpan={columnCount} className="pl-4">
+                    <TransactionRows rows={group.rows} />
+                  </td>
+                </tr>
+              )}
+            </React.Fragment>
+          );
+        })}
+      </>
+    );
+  };
+
+  /** What is already stored for the redesigned Forecast tab, in words. */
+  const keptParts = [
+    adjustmentsStatus === 'ready' && adjustments.length > 0
+      ? (adjustments.length === 1 ? '1 adjusted category' : `${adjustments.length} adjusted categories`)
+      : null,
+    suggestionDismissalsStatus === 'ready' && excludedCount > 0
+      ? (excludedCount === 1 ? '1 excluded one-off' : `${excludedCount} excluded one-offs`)
+      : null,
+  ].filter((part): part is string => part !== null);
 
   return (
     <PageWrapper title="Forecast">
       <div className="max-w-[1400px] mx-auto space-y-6">
-        <div className="bg-white dark:bg-gray-800 rounded-lg p-6 border border-line dark:border-gray-700">
-          <h2 className="text-label uppercase tracking-wider font-medium text-gray-500 dark:text-gray-400">
-            The base — your last twelve months
-          </h2>
-          <p className="text-dense text-gray-500 dark:text-gray-400 mt-1">
-            {monthRange}, complete months only — category by category, exactly
-            as the register holds them. This is the ground a scenario stands
-            on: review it, strike out the one-offs that are not part of a
-            typical month, and the averages become honest.{' '}
-            <span className="text-gray-700 dark:text-gray-300">
-              Nothing here writes to your Budget
-            </span>
-            {' '}— a scenario only ever becomes budgets by your explicit,
-            per-category say-so, in a later step.
-          </p>
-          <p className="text-dense text-gray-500 dark:text-gray-400 mt-2">
-            Transfers between your accounts are not income or spending and are
-            left out{base.transfers > 0 && <> ({base.transfers} in this stretch)</>}
-            {base.revaluations > 0 && <>; {base.revaluations} revaluations — ledger arithmetic — likewise</>}.
-            {base.excluded.length > 0 && (
-              <> {base.excluded.length === 1 ? '1 one-off is' : `${base.excluded.length} one-offs are`} excluded
-              from the base — listed at the foot of the page, restorable any time.</>
-            )}
-          </p>
-          {adjustmentsStatus === 'ready' && adjustments.size > 0 && (
-            <p className="text-dense text-gray-700 dark:text-gray-300 mt-2">
-              The scenario adjusts {adjustments.size === 1 ? '1 category' : `${adjustments.size} categories`} —
-              every deviation is shown on its row, against the base it deviates
-              from, and one click returns it. Scenario month:{' '}
-              <span className="tabular-nums">+{formatCurrency(scenarioSideTotal(base.income, 'in'))}</span> in,{' '}
-              <span className="tabular-nums">{formatCurrency(-scenarioSideTotal(base.expense, 'out'))}</span> out.
-            </p>
-          )}
-          {adjustmentsStatus === 'error' && (
-            /* A failed read is a scenario that FOLLOWS THE BASE — said, not
-               guessed at. Deviations invented from a stale copy would be the
-               one dishonesty this page exists to prevent. */
-            <p className="text-dense text-gray-500 dark:text-gray-400 mt-2">
-              Your scenario adjustments could not be loaded just now, so the
-              figures below show the base alone. Reload to try again.
-            </p>
-          )}
-        </div>
-
-        <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
-          <SideCard side="in" title="Income" groups={base.income} total={base.incomeTotal} />
-          <SideCard side="out" title="Expenditure" groups={base.expense} total={base.expenseTotal} />
-        </div>
-
-        {orphanAdjustments.length > 0 && (
-          /* Stored deviations whose categories show no recent activity — still
-             visible, still counted in the scenario totals, still returnable:
-             a deviation influencing figures from off-screen would make the
-             scenario uninterrogatable. */
-          <div className="bg-white dark:bg-gray-800 rounded-lg border border-line dark:border-gray-700 p-4 sm:p-6">
-            <h2 className="text-card font-semibold text-theme-heading dark:text-white mb-1">
-              Adjustments on quiet categories
-              <span className="ml-2 text-dense font-normal text-gray-400 dark:text-gray-500">
-                {orphanAdjustments.length}
-              </span>
-            </h2>
-            <p className="text-dense text-gray-500 dark:text-gray-400 mb-2">
-              Stated for categories with nothing in these twelve months — still
-              counted in the scenario's totals above.
-            </p>
-            <ul>
-              {orphanAdjustments.map(({ adjustment, label }) => (
-                <li key={adjustment.categoryId} className="py-1.5 flex items-baseline justify-between gap-4 border-t border-gray-50 dark:border-gray-700/50 first:border-0">
-                  <span className="text-sm text-gray-900 dark:text-white truncate">{label}</span>
-                  <span className="flex items-baseline gap-3 shrink-0">
-                    <span className="text-sm tabular-nums text-gray-700 dark:text-gray-300">
-                      {formatCurrency(toDecimal(adjustment.monthlyMinor).dividedBy(100).toNumber())} a month
-                    </span>
-                    <button
-                      type="button"
-                      onClick={() => void followBase(adjustment.categoryId)}
-                      disabled={savingAdjustment}
-                      className="text-xs text-gray-500 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-200 hover:underline disabled:opacity-50"
-                    >
-                      Back to base
-                    </button>
-                  </span>
-                </li>
-              ))}
-            </ul>
+        <div className="flex flex-wrap items-center justify-between gap-3">
+          {/* The tab, chosen the way the calendar chooses its view — a
+              segmented control (owner, 19 Aug: "Lets have two tabs for now.
+              Current and forecast"). */}
+          <div className="flex items-center rounded-lg bg-gray-100 dark:bg-gray-700 p-0.5" role="group" aria-label="Forecast view">
+            {(['current', 'forecast'] as const).map(option => (
+              <button
+                key={option}
+                type="button"
+                onClick={() => setTab(option)}
+                aria-pressed={tab === option}
+                className={`px-3 py-1 text-sm font-medium rounded-md transition-colors ${
+                  tab === option
+                    ? 'bg-white dark:bg-gray-800 text-gray-900 dark:text-white shadow-sm'
+                    : 'text-gray-600 dark:text-gray-300 hover:text-gray-900 dark:hover:text-gray-100'
+                }`}
+              >
+                {option === 'current' ? 'Current' : 'Forecast'}
+              </button>
+            ))}
           </div>
-        )}
 
-        {base.excluded.length > 0 && (
-          /* STATED, never silent (§7.1) — and restorable, because a judgment
-             the user cannot revisit is a deletion wearing a nicer name. */
-          <details className="bg-white dark:bg-gray-800 rounded-lg border border-line dark:border-gray-700">
-            <summary className="cursor-pointer select-none p-6 text-card font-semibold text-theme-heading dark:text-white">
-              Excluded from the base
-              <span className="ml-2 text-dense font-normal text-gray-400 dark:text-gray-500">
-                {base.excluded.length}
-              </span>
-              <span className="ml-3 text-dense font-normal text-gray-500 dark:text-gray-400">
-                One-offs you said are not part of a typical month
-              </span>
-            </summary>
-            <ul className="px-6 pb-6">
-              {base.excluded.map(row => (
-                <li key={row.id} className="py-2 flex flex-wrap items-baseline justify-between gap-x-4 gap-y-0.5 border-t border-gray-50 dark:border-gray-700/50 first:border-0">
-                  <span className="min-w-0 flex items-baseline gap-2">
-                    <span className="text-xs tabular-nums text-gray-500 dark:text-gray-400 w-16 shrink-0">
-                      {new Date(row.date).toLocaleDateString(getDateLocale(), { day: 'numeric', month: 'short', year: '2-digit' })}
+          {tab === 'current' && (
+            <div className="flex flex-wrap items-center gap-2">
+              <div className="flex items-center rounded-lg bg-gray-100 dark:bg-gray-700 p-0.5" role="group" aria-label="Which months the figures read over">
+                {([
+                  ['last-12', 'Last 12 months'],
+                  ['calendar-year', 'Calendar year'],
+                  ['tax-year', 'Tax year'],
+                  ['custom', 'Custom'],
+                ] as const).map(([kind, name]) => (
+                  <button
+                    key={kind}
+                    type="button"
+                    onClick={() => setWindowKind(kind)}
+                    aria-pressed={windowKind === kind}
+                    className={`px-3 py-1 text-sm font-medium rounded-md transition-colors ${
+                      windowKind === kind
+                        ? 'bg-white dark:bg-gray-800 text-gray-900 dark:text-white shadow-sm'
+                        : 'text-gray-600 dark:text-gray-300 hover:text-gray-900 dark:hover:text-gray-100'
+                    }`}
+                  >
+                    {name}
+                  </button>
+                ))}
+              </div>
+              {windowKind === 'custom' && (
+                <span className="flex items-center gap-2 text-dense text-gray-500 dark:text-gray-400">
+                  <label className="flex items-center gap-1.5">
+                    From
+                    <input
+                      type="month"
+                      value={customFrom}
+                      onChange={event => setCustomFrom(event.target.value)}
+                      className="px-2 py-1 text-sm border border-line dark:border-gray-600 rounded bg-white dark:bg-gray-800 text-gray-900 dark:text-white"
+                    />
+                  </label>
+                  <label className="flex items-center gap-1.5">
+                    To
+                    <input
+                      type="month"
+                      value={customTo}
+                      onChange={event => setCustomTo(event.target.value)}
+                      className="px-2 py-1 text-sm border border-line dark:border-gray-600 rounded bg-white dark:bg-gray-800 text-gray-900 dark:text-white"
+                    />
+                  </label>
+                </span>
+              )}
+            </div>
+          )}
+        </div>
+
+        {tab === 'current' ? (
+          <>
+            <div className="bg-white dark:bg-gray-800 rounded-lg p-6 border border-line dark:border-gray-700">
+              <h2 className="text-label uppercase tracking-wider font-medium text-gray-500 dark:text-gray-400">
+                Your profit and loss
+              </h2>
+              <p className="text-dense text-gray-500 dark:text-gray-400 mt-1">
+                {plWindow.label} — {windowSentence[windowKind]}. Category by
+                category, exactly as the register holds them.{' '}
+                <span className="text-gray-700 dark:text-gray-300">
+                  Nothing here writes to your Budget
+                </span>
+                {' '}— a scenario only ever becomes budgets by your explicit,
+                per-category say-so.
+              </p>
+              <p className="text-dense text-gray-500 dark:text-gray-400 mt-2">
+                Transfers between your accounts are not income or spending and are
+                left out{statement.transfers > 0 && <> ({statement.transfers} in this stretch)</>}
+                {statement.revaluations > 0 && <>; {statement.revaluations} revaluations — ledger arithmetic — likewise</>}.
+              </p>
+            </div>
+
+            <div className="bg-white dark:bg-gray-800 rounded-lg border border-line dark:border-gray-700 p-4 sm:p-6">
+              <div className="flex justify-end mb-1">
+                <button
+                  type="button"
+                  onClick={() => setShowMonths(previous => !previous)}
+                  aria-pressed={showMonths}
+                  className="flex items-center gap-1 text-xs text-gray-500 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-200 hover:underline"
+                >
+                  {showMonths
+                    ? <ChevronDownIcon size={14} className="shrink-0" />
+                    : <ChevronRightIcon size={14} className="shrink-0" />}
+                  {showMonths ? 'Hide the months' : 'Show the months'}
+                </button>
+              </div>
+
+              {showMonths ? (
+                <div className="overflow-x-auto">
+                  <table className="w-full">
+                    <thead>
+                      <tr className="text-xs text-gray-500 dark:text-gray-400">
+                        <th scope="col" className="sticky left-0 bg-white dark:bg-gray-800 py-1 pr-4 text-left font-normal" aria-label="Category" />
+                        {plWindow.buckets.map(bucket => (
+                          <th key={bucket.key} scope="col" className="py-1 px-2 text-right font-normal whitespace-nowrap">
+                            {bucket.label}
+                          </th>
+                        ))}
+                        <th scope="col" className="py-1 pl-3 text-right font-medium whitespace-nowrap">Total</th>
+                        <th scope="col" className="py-1 pl-3 text-right font-normal whitespace-nowrap">A month</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {sectionTableRows('in', 'Income', statement.income, statement.incomeTotal, statement.incomePerBucket)}
+                      {sectionTableRows('out', 'Expenditure', statement.expense, statement.expenseTotal, statement.expensePerBucket)}
+                      <tr className="border-t-2 border-gray-200 dark:border-gray-600">
+                        <td className="sticky left-0 bg-white dark:bg-gray-800 py-2 pr-4 text-card font-semibold text-theme-heading dark:text-white whitespace-nowrap">
+                          {netLabel}
+                        </td>
+                        {statement.netPerBucket.map((value, i) => (
+                          <td key={plWindow.buckets[i].key} className="py-2 px-2 text-right text-sm tabular-nums font-medium text-gray-900 dark:text-white whitespace-nowrap">
+                            {value === 0 ? '—' : netText(value)}
+                          </td>
+                        ))}
+                        <td className={`py-2 pl-3 text-right text-sm tabular-nums font-semibold whitespace-nowrap ${netColour}`}>
+                          {netText(statement.net)}
+                        </td>
+                        <td className="py-2 pl-3 text-right text-sm tabular-nums text-gray-500 dark:text-gray-400 whitespace-nowrap">
+                          {formatCurrency(average(statement.net))}
+                        </td>
+                      </tr>
+                    </tbody>
+                  </table>
+                </div>
+              ) : (
+                <div>
+                  <SectionList side="in" title="Income" groups={statement.income} total={statement.incomeTotal} />
+                  <SectionList side="out" title="Expenditure" groups={statement.expense} total={statement.expenseTotal} />
+                  <div className="mt-1 pt-3 border-t-2 border-gray-200 dark:border-gray-600 flex items-baseline justify-between gap-4">
+                    <span className="text-card font-semibold text-theme-heading dark:text-white">{netLabel}</span>
+                    <span className="text-right shrink-0">
+                      <span className={`block text-body font-semibold tabular-nums ${netColour}`}>
+                        {netText(statement.net)}
+                      </span>
+                      <span className="block text-dense tabular-nums text-gray-500 dark:text-gray-400">
+                        {formatCurrency(average(statement.net))} a month
+                      </span>
                     </span>
-                    <span className="text-sm text-gray-900 dark:text-white truncate">{row.description}</span>
-                  </span>
-                  <span className="flex items-baseline gap-3 shrink-0">
-                    <span className={`text-sm tabular-nums ${
-                      row.amount >= 0 ? 'text-green-600 dark:text-green-400' : 'text-red-600 dark:text-red-400'
-                    }`}>
-                      {row.amount >= 0 ? `+${formatCurrency(row.amount)}` : formatCurrency(row.amount)}
-                    </span>
-                    <button
-                      type="button"
-                      onClick={() => void restore(row.id)}
-                      disabled={savingId === row.id}
-                      className="text-xs text-gray-500 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-200 hover:underline disabled:opacity-50"
-                    >
-                      Restore
-                    </button>
-                  </span>
-                </li>
-              ))}
-            </ul>
-          </details>
+                  </div>
+                </div>
+              )}
+            </div>
+          </>
+        ) : (
+          <div className="bg-white dark:bg-gray-800 rounded-lg border border-line dark:border-gray-700 p-6">
+            <h2 className="text-card font-semibold text-theme-heading dark:text-white">The forecast</h2>
+            <p className="text-body text-gray-500 dark:text-gray-400 mt-1">
+              The scenario tool will live here — it is being designed.
+            </p>
+            {keptParts.length > 0 && (
+              <p className="text-dense text-gray-700 dark:text-gray-300 mt-2">
+                Kept for it: {keptParts.join(' and ')} — they will reappear when it lands.
+              </p>
+            )}
+            {adjustmentsStatus === 'error' && (
+              <p className="text-dense text-gray-500 dark:text-gray-400 mt-2">
+                Your stated adjustments could not be read just now; they are kept
+                in your ledger regardless.
+              </p>
+            )}
+          </div>
         )}
       </div>
     </PageWrapper>

--- a/src/pages/__tests__/Forecast.test.tsx
+++ b/src/pages/__tests__/Forecast.test.tsx
@@ -8,28 +8,26 @@ import { __setAppContextValue, __resetAppContextValue } from '../../test/mocks/A
 import Forecast from '../Forecast';
 import type { Account, Category, ForecastAdjustment, SuggestionDismissal, Transaction } from '../../types';
 
-// The SEAM, not a service: the page reads and writes its scenario through
-// `dataPort`, so the tests stub exactly the three verbs it uses.
+// The SEAM, not a service: the page reads its stored scenario through
+// `dataPort` — for now only to COUNT it on the Forecast tab.
 const seam = vi.hoisted(() => ({
   listForecastAdjustments: vi.fn(async (): Promise<ForecastAdjustment[]> => []),
-  setForecastAdjustment: vi.fn(async (categoryId: string, monthlyMinor: number): Promise<ForecastAdjustment> => ({
-    id: 'adj-1', categoryId, monthlyMinor,
-  })),
-  clearForecastAdjustment: vi.fn(async () => {}),
 }));
 vi.mock('@data', () => ({ dataPort: seam }));
 
 /**
- * THE FORECAST'S BASE (docs/forecast-direction.md step 4): twelve COMPLETE
- * months of category actuals, one-offs excludable with the exclusions
- * STATED. The rules pinned here:
+ * THE P&L (owner, 19 Aug): income above, expenditure below, a net figure
+ * at the bottom; sections collapsible; the months hidden behind a toggle;
+ * a choice of windows. The rules pinned here:
  *
- *  - the current month is not in the base — a half-month understates;
- *  - a category's figures are the sum of the rows shown under it;
- *  - an exclusion is a verdict about ONE ROW ('forecast-excluded', key and
- *    subject id both the row's own id), and excluded rows are listed in a
- *    restorable band, never silently subtracted;
- *  - the unfiled remainder is a named line, excludable like any other;
+ *  - the current part month is not in the last-12 window;
+ *  - income sits ABOVE expenditure in the document, net below both;
+ *  - a section collapses to its total, and the months toggle turns the
+ *    list into a twelve-column table;
+ *  - the Current tab is ACTUALS, whole — a forecast-exclusion verdict no
+ *    longer thins it (the verdicts are kept for the Forecast redesign,
+ *    and the Forecast tab names what is kept);
+ *  - the average divides by the WINDOW's month count, not always 12;
  *  - the verdicts are lazy-loaded and this page ASKS (the #353 lesson);
  *  - the page says, in words, that it never writes to Budget.
  *
@@ -75,31 +73,28 @@ const LEDGER: Transaction[] = [
     id: 'txn-transfer', accountId: ACCOUNT.id, description: 'To savings',
     amount: -500, date: monthAgo(2), type: 'transfer', category: '',
   },
-  // THIS month — outside the base by definition.
+  // THIS month — outside the last-12 window by definition.
   {
     id: 'txn-current', accountId: ACCOUNT.id, description: 'Current month spend',
     amount: -999, date: new Date(now.getFullYear(), now.getMonth(), 2), type: 'expense', category: 'cat-food',
   },
 ];
 
-const dismissSuggestion = vi.fn(async () => {});
-const restoreSuggestion = vi.fn(async () => {});
 const refreshSuggestionDismissals = vi.fn(async () => {});
 
 const renderForecast = (
   dismissals: SuggestionDismissal[] = [],
-  status: 'idle' | 'ready' = 'ready'
+  status: 'idle' | 'ready' = 'ready',
+  transactions: Transaction[] = LEDGER
 ): void => {
   __setAppContextValue({
     accounts: [ACCOUNT],
     categories: CATEGORIES,
-    transactions: LEDGER,
+    transactions,
     isLoading: false,
     suggestionDismissals: dismissals,
     suggestionDismissalsStatus: status,
     refreshSuggestionDismissals,
-    dismissSuggestion,
-    restoreSuggestion,
   });
   render(
     <MemoryRouter>
@@ -122,144 +117,149 @@ const excludedVerdict: SuggestionDismissal = {
 
 beforeEach(() => {
   localStorage.clear();
-  dismissSuggestion.mockClear();
-  restoreSuggestion.mockClear();
   refreshSuggestionDismissals.mockClear();
   seam.listForecastAdjustments.mockClear();
   seam.listForecastAdjustments.mockResolvedValue([]);
-  seam.setForecastAdjustment.mockClear();
-  seam.clearForecastAdjustment.mockClear();
 });
 
 afterEach(() => {
   __resetAppContextValue();
 });
 
-describe('Forecast — the base', () => {
-  it('shows twelve complete months by category, with honest averages — the current month left out', () => {
+describe('Forecast — the Current P&L', () => {
+  it('reads income above expenditure with net below, over the last twelve complete months', () => {
     renderForecast();
 
     // Food: 12 × £100 — and NOT 13: the current month's £999 is outside the
-    // base, or the average would claim a typical month that never was.
+    // window, or the figures would claim a typical month that never was.
     expect(screen.getByText('Food')).toBeInTheDocument();
     expect(screen.getByText('(£1,200.00)')).toBeInTheDocument();
-    // Salary: 12 × £2,000 — the figure appears TWICE by construction, as the
-    // income side's total and as its only category's, and the two agreeing
-    // is itself the property (a category's figures are the sum of its rows).
-    expect(screen.getByText('Salary')).toBeInTheDocument();
+    // Salary: the figure appears TWICE by construction, as the income side's
+    // total and as its only category's — the two agreeing is the property.
     expect(screen.getAllByText('+£24,000.00')).toHaveLength(2);
     expect(screen.getAllByText('£2,000.00 a month')).toHaveLength(2);
-
-    // The unfiled one-off sits under its NAMED line on the expenditure side…
+    // The unfiled one-off under its NAMED line, the transfer out BY NAME.
     expect(screen.getByText('Uncategorised — not yet filed')).toBeInTheDocument();
-    // …and the transfer is left out BY NAME, with its count.
-    expect(screen.getByText(/Transfers between your accounts are not income or spending/)).toBeInTheDocument();
     expect(screen.getByText(/\(1 in this stretch\)/)).toBeInTheDocument();
+
+    // The P&L's shape: Income ABOVE Expenditure, net at the foot.
+    const income = screen.getByRole('button', { name: 'Income' });
+    const expenditure = screen.getByRole('button', { name: 'Expenditure' });
+    expect(income.compareDocumentPosition(expenditure) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+    // Net = £24,000 − £6,200: named for its direction, worn the app's way.
+    expect(screen.getByText('Net income')).toBeInTheDocument();
+    expect(screen.getByText('+£17,800.00')).toBeInTheDocument();
+    expect(screen.getByText('£1,483.33 a month')).toBeInTheDocument();
 
     // The ruling, in words, on the page.
     expect(screen.getByText(/Nothing here writes to your Budget/)).toBeInTheDocument();
   });
 
-  it('a category expands to the rows its figure is the sum of, and Exclude records the verdict', async () => {
+  it('a section heading collapses to its total; a category expands to its rows', () => {
     renderForecast();
 
+    // Collapse Income: Salary's row goes, the side total stays.
+    fireEvent.click(screen.getByRole('button', { name: 'Income' }));
+    expect(screen.queryByText('Salary')).not.toBeInTheDocument();
+    expect(screen.getAllByText('+£24,000.00')).toHaveLength(1);
+
+    // A category drills to the rows its figure is the sum of.
     fireEvent.click(screen.getByRole('button', { name: /Uncategorised — not yet filed/ }));
     expect(screen.getByText('Roof repair')).toBeInTheDocument();
-
-    fireEvent.click(screen.getByRole('button', { name: 'Exclude' }));
-    await waitFor(() => {
-      // The verdict is about ONE ROW: key and subject id are both the row's
-      // own id, so a restore remaps it and a deleted row cascades it away.
-      expect(dismissSuggestion).toHaveBeenCalledWith('forecast-excluded', ONE_OFF_ID, [ONE_OFF_ID]);
-    });
   });
 
-  it('an excluded one-off leaves the figures and sits in a restorable band, stated in the headline', async () => {
+  it('the months are hidden by default, and the toggle spreads them across like a full P&L', () => {
+    renderForecast();
+
+    expect(screen.queryByRole('table')).not.toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: 'Show the months' }));
+
+    // Twelve month columns plus Total and the monthly average.
+    expect(screen.getByRole('table')).toBeInTheDocument();
+    expect(screen.getByRole('columnheader', { name: 'Total' })).toBeInTheDocument();
+    // Food's £100 in each of ITS OWN twelve cells — the section's cells
+    // carry their own sums (£5,100 where the roof month lands).
+    const foodRow = screen.getByRole('button', { name: /Food/ }).closest('tr') as HTMLElement;
+    expect(within(foodRow).getAllByText('(£100.00)')).toHaveLength(12);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Hide the months' }));
+    expect(screen.queryByRole('table')).not.toBeInTheDocument();
+  });
+
+  it('a forecast-exclusion verdict no longer thins the Current tab — actuals are whole', () => {
     renderForecast([excludedVerdict]);
 
-    // The expenditure side is Food alone now — the roof is out of the sums,
-    // so the side total and Food's total agree at (£1,200.00).
-    expect(screen.getAllByText('(£1,200.00)')).toHaveLength(2);
-    expect(screen.queryByRole('button', { name: /Uncategorised — not yet filed/ })).not.toBeInTheDocument();
-
-    // …and STATED, twice: in the headline note and in the band.
-    expect(screen.getByText(/1 one-off is excluded/)).toBeInTheDocument();
-    const band = screen.getByText('Excluded from the base').closest('details') as HTMLElement;
-    expect(within(band).getByText('Roof repair')).toBeInTheDocument();
-
-    fireEvent.click(within(band).getByRole('button', { name: 'Restore' }));
-    await waitFor(() => {
-      expect(restoreSuggestion).toHaveBeenCalledWith('forecast-excluded', ONE_OFF_ID);
-    });
+    // The roof stays in the expenditure figures: £1,200 + £5,000.
+    expect(screen.getByText('(£6,200.00)')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Uncategorised — not yet filed/ })).toBeInTheDocument();
   });
 
-  it('a category can be adjusted for the scenario — the deviation stated against its base', async () => {
+  it('a custom window averages over ITS month count, not twelve', () => {
+    // Three months, one £300 row in the middle one — £100 a month.
+    const year = now.getFullYear() - 2;
+    renderForecast([], 'ready', [{
+      id: 'txn-past', accountId: ACCOUNT.id, description: 'Old grocer',
+      amount: -300, date: new Date(year, 1, 10), type: 'expense', category: 'cat-food',
+    }]);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Custom' }));
+    fireEvent.change(screen.getByLabelText('From'), { target: { value: `${year}-01` } });
+    fireEvent.change(screen.getByLabelText('To'), { target: { value: `${year}-03` } });
+
+    // THREE agreeing figures by construction — the category, its side, and
+    // (with no income) the net — and £300 over three months is £100 a month.
+    // The net's average wears the brackets its direction earns.
+    expect(screen.getAllByText('(£300.00)')).toHaveLength(3);
+    expect(screen.getByText('Net expenditure')).toBeInTheDocument();
+    expect(screen.getAllByText('£100.00 a month')).toHaveLength(2);
+    expect(screen.getByText('(£100.00) a month')).toBeInTheDocument();
+  });
+
+  it('the tax year window says its convention out loud', () => {
     renderForecast();
-    await waitFor(() => expect(seam.listForecastAdjustments).toHaveBeenCalled());
-
-    // Food's base average is £100 a month. State £90 for the scenario.
-    fireEvent.click(screen.getByRole('button', { name: 'Adjust Food for the scenario' }));
-    fireEvent.change(screen.getByLabelText('Scenario monthly figure for Food'), {
-      target: { value: '90' },
-    });
-    fireEvent.click(screen.getByRole('button', { name: 'State it' }));
-
-    await waitFor(() => {
-      // Pennies across the seam — £90 crosses as 9000.
-      expect(seam.setForecastAdjustment).toHaveBeenCalledWith('cat-food', 9000);
-    });
-    // The deviation is STATED against the base it deviates from…
-    expect(screen.getByText(/scenario £90\.00 a month/)).toBeInTheDocument();
-    expect(screen.getByText(/base £100\.00/)).toBeInTheDocument();
-    // …and the base's own figures are untouched.
-    expect(screen.getByText('(£1,200.00)')).toBeInTheDocument();
-
-    // One click returns it.
-    fireEvent.click(screen.getByRole('button', { name: 'Back to base' }));
-    await waitFor(() => {
-      expect(seam.clearForecastAdjustment).toHaveBeenCalledWith('cat-food');
-    });
-  });
-
-  it('a stored adjustment on a quiet category is still shown, and still returnable', async () => {
-    seam.listForecastAdjustments.mockResolvedValue([
-      { id: 'adj-q', categoryId: 'cat-quiet', monthlyMinor: 40000 },
-    ]);
-    __setAppContextValue({
-      accounts: [ACCOUNT],
-      categories: [...CATEGORIES, { id: 'cat-quiet', name: 'Club membership', type: 'expense', level: 'detail' }],
-      transactions: LEDGER,
-      isLoading: false,
-      suggestionDismissals: [],
-      suggestionDismissalsStatus: 'ready',
-      refreshSuggestionDismissals,
-      dismissSuggestion,
-      restoreSuggestion,
-    });
-    render(
-      <MemoryRouter>
-        <PreferencesProvider>
-          <ToastProvider>
-            <Forecast />
-          </ToastProvider>
-        </PreferencesProvider>
-      </MemoryRouter>
-    );
-
-    await waitFor(() => {
-      expect(screen.getByText('Adjustments on quiet categories')).toBeInTheDocument();
-    });
-    expect(screen.getByText('Club membership')).toBeInTheDocument();
-    expect(screen.getByText('£400.00 a month')).toBeInTheDocument();
-    // Counted in the scenario's stated totals, not silently off-screen.
-    expect(screen.getByText(/The scenario adjusts 1 category/)).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: 'Tax year' }));
+    expect(screen.getByText(/6 April \d{4} to 5 April \d{4}/)).toBeInTheDocument();
+    expect(screen.getByText(/months run 6th to 5th, as tax months do/)).toBeInTheDocument();
   });
 
   it('ASKS for the lazy-loaded verdicts when they have never been loaded', async () => {
     renderForecast([], 'idle');
-
     await waitFor(() => {
       expect(refreshSuggestionDismissals).toHaveBeenCalled();
+    });
+  });
+});
+
+describe('Forecast — the Forecast tab', () => {
+  it('is deliberately empty while the tool is designed, and names what is kept', async () => {
+    seam.listForecastAdjustments.mockResolvedValue([
+      { id: 'adj-1', categoryId: 'cat-food', monthlyMinor: 9000 },
+    ]);
+    renderForecast([excludedVerdict]);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Forecast' }));
+    expect(screen.getByText(/it is being designed/)).toBeInTheDocument();
+    // Stated judgments are not lost, and the tab says so by count.
+    await waitFor(() => {
+      expect(screen.getByText(/Kept for it: 1 adjusted category and 1 excluded one-off/)).toBeInTheDocument();
+    });
+    // The P&L itself is off-screen on this tab.
+    expect(screen.queryByText('Net income')).not.toBeInTheDocument();
+  });
+
+  it('with nothing stated, it claims nothing — zero counts render nothing', () => {
+    renderForecast();
+    fireEvent.click(screen.getByRole('button', { name: 'Forecast' }));
+    expect(screen.getByText(/it is being designed/)).toBeInTheDocument();
+    expect(screen.queryByText(/Kept for it/)).not.toBeInTheDocument();
+  });
+
+  it('a failed adjustments read is said, never guessed at', async () => {
+    seam.listForecastAdjustments.mockRejectedValue(new Error('offline'));
+    renderForecast();
+    fireEvent.click(screen.getByRole('button', { name: 'Forecast' }));
+    await waitFor(() => {
+      expect(screen.getByText(/could not be read just now/)).toBeInTheDocument();
     });
   });
 });

--- a/src/utils/plWindow.test.ts
+++ b/src/utils/plWindow.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect } from 'vitest';
+import { buildPlWindow, bucketIndexOf, dayOf } from './plWindow';
+
+/**
+ * The P&L's windows, pinned on FIXED dates — the boundaries are the law:
+ *
+ *  - "last 12 months" holds no current part month (owner, 19 Aug);
+ *  - the calendar year is the last FULL one;
+ *  - the tax year runs 6 April to 5 April, in HMRC tax months (6th–5th),
+ *    and is only offered once it is COMPLETE — on 5 April the year ends
+ *    that very day and is not yet whole;
+ *  - a custom range is whole calendar months, reversed inputs swapped.
+ */
+
+const AUG_19_2026 = new Date(2026, 7, 19);
+
+describe('buildPlWindow', () => {
+  it('last-12: the twelve complete months, the current part month left out', () => {
+    const window = buildPlWindow('last-12', AUG_19_2026);
+    expect(window.buckets).toHaveLength(12);
+    expect(window.start).toBe('2025-08-01');
+    expect(window.endExclusive).toBe('2026-08-01');
+    expect(window.label).toBe('August 2025 to July 2026');
+    // 19 Aug 2026 itself is outside — the part month would understate.
+    expect(bucketIndexOf('2026-08-19', window.buckets)).toBe(-1);
+    expect(bucketIndexOf('2026-07-31', window.buckets)).toBe(11);
+  });
+
+  it('calendar-year: the last full calendar year', () => {
+    const window = buildPlWindow('calendar-year', AUG_19_2026);
+    expect(window.start).toBe('2025-01-01');
+    expect(window.endExclusive).toBe('2026-01-01');
+    expect(window.label).toBe('January 2025 to December 2025');
+    expect(window.buckets[0].label).toBe('Jan 25');
+  });
+
+  it('tax-year: 6 April to 5 April, in tax months that run 6th to 5th', () => {
+    const window = buildPlWindow('tax-year', AUG_19_2026);
+    expect(window.label).toBe('6 April 2025 to 5 April 2026');
+    expect(window.buckets).toHaveLength(12);
+    expect(window.buckets[0]).toMatchObject({ start: '2025-04-06', endExclusive: '2025-05-06', label: 'Apr 25' });
+    expect(window.buckets[11]).toMatchObject({ start: '2026-03-06', endExclusive: '2026-04-06' });
+    // The 5th belongs to the OLD tax month, the 6th to the new — both edges.
+    expect(bucketIndexOf('2025-04-05', window.buckets)).toBe(-1);
+    expect(bucketIndexOf('2025-04-06', window.buckets)).toBe(0);
+    expect(bucketIndexOf('2025-05-05', window.buckets)).toBe(0);
+    expect(bucketIndexOf('2025-05-06', window.buckets)).toBe(1);
+    expect(bucketIndexOf('2026-04-05', window.buckets)).toBe(11);
+    expect(bucketIndexOf('2026-04-06', window.buckets)).toBe(-1);
+  });
+
+  it('a tax year is only offered once it is complete', () => {
+    // 5 April 2026: 2025/26 ends TODAY — not yet whole, so 2024/25 stands.
+    expect(buildPlWindow('tax-year', new Date(2026, 3, 5)).start).toBe('2024-04-06');
+    // 6 April 2026: 2025/26 completed yesterday.
+    expect(buildPlWindow('tax-year', new Date(2026, 3, 6)).start).toBe('2025-04-06');
+  });
+
+  it('custom: whole calendar months, inclusive, reversed inputs swapped', () => {
+    const window = buildPlWindow('custom', AUG_19_2026, { fromMonth: '2024-11', toMonth: '2025-02' });
+    expect(window.buckets).toHaveLength(4);
+    expect(window.start).toBe('2024-11-01');
+    expect(window.endExclusive).toBe('2025-03-01');
+    expect(window.label).toBe('November 2024 to February 2025');
+
+    const swapped = buildPlWindow('custom', AUG_19_2026, { fromMonth: '2025-02', toMonth: '2024-11' });
+    expect(swapped.start).toBe('2024-11-01');
+
+    const single = buildPlWindow('custom', AUG_19_2026, { fromMonth: '2025-06', toMonth: '2025-06' });
+    expect(single.buckets).toHaveLength(1);
+    expect(single.label).toBe('June 2025');
+  });
+
+  it('custom without a stated range falls back to the last twelve months', () => {
+    const window = buildPlWindow('custom', AUG_19_2026, { fromMonth: '', toMonth: '' });
+    expect(window.start).toBe('2025-08-01');
+    expect(window.buckets).toHaveLength(12);
+  });
+
+  it('the year wraps cleanly inside a window', () => {
+    const window = buildPlWindow('last-12', new Date(2027, 1, 7));
+    expect(window.start).toBe('2026-02-01');
+    expect(bucketIndexOf('2026-12-31', window.buckets)).toBe(10);
+    expect(bucketIndexOf('2027-01-01', window.buckets)).toBe(11);
+  });
+});
+
+describe('dayOf', () => {
+  it('slices a string and never parses it — the timezone cannot move the day', () => {
+    expect(dayOf('2027-02-07')).toBe('2027-02-07');
+    expect(dayOf('2027-02-07T23:30:00Z')).toBe('2027-02-07');
+  });
+
+  it('reads a Date object as its local day', () => {
+    expect(dayOf(new Date(2027, 1, 7))).toBe('2027-02-07');
+  });
+});

--- a/src/utils/plWindow.ts
+++ b/src/utils/plWindow.ts
@@ -1,0 +1,178 @@
+import { getDateLocale } from './dateFormatter';
+
+/**
+ * THE P&L's WINDOWS — the "twelve months" a profit-and-loss can mean.
+ *
+ * The owner's ask (19 Aug): "We should offer the user a few different
+ * '12 months'" — the last full calendar year, the last tax year, the last
+ * full twelve months ("not including a current part month"), and custom.
+ * Each window is a list of MONTH BUCKETS carrying their own [start,
+ * endExclusive) day range, because one of them cannot be described by
+ * calendar months at all:
+ *
+ * ── TAX MONTHS RUN 6th TO 5th ──────────────────────────────────────────────
+ *
+ * The UK tax year runs 6 April to 5 April, so its "months" are HMRC's tax
+ * months — 6 April to 5 May is month 1, exactly as payroll counts them.
+ * Splitting the tax year on calendar months instead would give thirteen
+ * columns with part-months at both ends, and a total that no longer reads
+ * as the sum of its columns. Twelve true twelfths, each 6th-to-5th, keeps
+ * both properties. The page says the convention on screen.
+ *
+ * ── DAYS ARE STRINGS, COMPARED AS STRINGS ──────────────────────────────────
+ *
+ * Every boundary here is a YYYY-MM-DD string and rows are bucketed by
+ * LEXICAL comparison — deliberately. Date parsing is where the timezone
+ * bugs live (V8's fallback parser reads at local midnight, the standard
+ * form at UTC midnight; the admission lane pins TZ=UTC over exactly this),
+ * and a P&L must not change its columns with the reader's holiday
+ * location. ISO day strings order the same way everywhere.
+ */
+
+export type PlWindowKind = 'last-12' | 'calendar-year' | 'tax-year' | 'custom';
+
+export interface PlBucket {
+  key: string;
+  /** Column heading, e.g. "Aug 25". A tax month is labelled by its 6th. */
+  label: string;
+  /** First day IN the bucket, YYYY-MM-DD. */
+  start: string;
+  /** First day AFTER the bucket, YYYY-MM-DD. */
+  endExclusive: string;
+}
+
+export interface PlWindow {
+  kind: PlWindowKind;
+  /** The range in words, e.g. "August 2025 to July 2026". */
+  label: string;
+  buckets: PlBucket[];
+  start: string;
+  endExclusive: string;
+}
+
+const pad = (n: number): string => String(n).padStart(2, '0');
+const isoDay = (year: number, month1: number, day: number): string =>
+  `${year}-${pad(month1)}-${pad(day)}`;
+
+/** Normalise an out-of-range month index the way Date does (month0 −1 → last December). */
+const normalise = (year: number, month0: number): { year: number; month0: number } => {
+  const rolled = new Date(year, month0, 1);
+  return { year: rolled.getFullYear(), month0: rolled.getMonth() };
+};
+
+const shortLabel = (year: number, month0: number, day: number): string =>
+  new Date(year, month0, day).toLocaleDateString(getDateLocale(), { month: 'short', year: '2-digit' });
+
+const longMonth = (year: number, month0: number): string =>
+  new Date(year, month0, 1).toLocaleDateString(getDateLocale(), { month: 'long', year: 'numeric' });
+
+const calendarBuckets = (startYear: number, startMonth0: number, count: number): PlBucket[] =>
+  Array.from({ length: count }, (_, i) => {
+    const m = normalise(startYear, startMonth0 + i);
+    const next = normalise(startYear, startMonth0 + i + 1);
+    return {
+      key: `${m.year}-${pad(m.month0 + 1)}`,
+      label: shortLabel(m.year, m.month0, 1),
+      start: isoDay(m.year, m.month0 + 1, 1),
+      endExclusive: isoDay(next.year, next.month0 + 1, 1),
+    };
+  });
+
+/** Twelve HMRC tax months: 6 April startYear … 5 April startYear+1. */
+const taxBuckets = (startYear: number): PlBucket[] =>
+  Array.from({ length: 12 }, (_, i) => {
+    const m = normalise(startYear, 3 + i);
+    const next = normalise(startYear, 3 + i + 1);
+    return {
+      key: `${m.year}-${pad(m.month0 + 1)}-tax`,
+      label: shortLabel(m.year, m.month0, 6),
+      start: isoDay(m.year, m.month0 + 1, 6),
+      endExclusive: isoDay(next.year, next.month0 + 1, 6),
+    };
+  });
+
+const monthRangeLabel = (buckets: PlBucket[]): string => {
+  const first = buckets[0];
+  const last = buckets[buckets.length - 1];
+  const firstLabel = longMonth(Number(first.start.slice(0, 4)), Number(first.start.slice(5, 7)) - 1);
+  const lastLabel = longMonth(Number(last.start.slice(0, 4)), Number(last.start.slice(5, 7)) - 1);
+  return firstLabel === lastLabel ? firstLabel : `${firstLabel} to ${lastLabel}`;
+};
+
+const finish = (kind: PlWindowKind, label: string, buckets: PlBucket[]): PlWindow => ({
+  kind,
+  label,
+  buckets,
+  start: buckets[0].start,
+  endExclusive: buckets[buckets.length - 1].endExclusive,
+});
+
+const MONTH_INPUT = /^\d{4}-\d{2}$/;
+
+/**
+ * Build the chosen window as it stands on `today`. Every window holds only
+ * COMPLETE periods — "the last 12 months should be the last full 12 months
+ * so not including a current part month" (owner, 19 Aug), and the same
+ * completeness rule picks the calendar and tax years.
+ */
+export function buildPlWindow(
+  kind: PlWindowKind,
+  today: Date,
+  custom?: { fromMonth: string; toMonth: string }
+): PlWindow {
+  if (kind === 'calendar-year') {
+    const year = today.getFullYear() - 1;
+    return finish(kind, `January ${year} to December ${year}`, calendarBuckets(year, 0, 12));
+  }
+
+  if (kind === 'tax-year') {
+    // The last COMPLETE tax year: 2025/26 only once 6 April 2026 has passed —
+    // on 5 April 2026 the year ends today and is not yet whole.
+    const pastApril6 = today.getMonth() > 3 || (today.getMonth() === 3 && today.getDate() >= 6);
+    const startYear = pastApril6 ? today.getFullYear() - 1 : today.getFullYear() - 2;
+    return finish(
+      kind,
+      `6 April ${startYear} to 5 April ${startYear + 1}`,
+      taxBuckets(startYear)
+    );
+  }
+
+  if (kind === 'custom' && custom && MONTH_INPUT.test(custom.fromMonth) && MONTH_INPUT.test(custom.toMonth)) {
+    const [from, to] = custom.fromMonth <= custom.toMonth
+      ? [custom.fromMonth, custom.toMonth]
+      : [custom.toMonth, custom.fromMonth];
+    const fromYear = Number(from.slice(0, 4));
+    const fromMonth0 = Number(from.slice(5, 7)) - 1;
+    const count = (Number(to.slice(0, 4)) - fromYear) * 12 + (Number(to.slice(5, 7)) - 1 - fromMonth0) + 1;
+    const buckets = calendarBuckets(fromYear, fromMonth0, count);
+    return finish(kind, monthRangeLabel(buckets), buckets);
+  }
+
+  // 'last-12', and the fallback for a custom range not yet stated: the last
+  // twelve complete months, first of (this month − 12) … end of last month.
+  const start = normalise(today.getFullYear(), today.getMonth() - 12);
+  const buckets = calendarBuckets(start.year, start.month0, 12);
+  return finish(kind === 'custom' ? 'custom' : 'last-12', monthRangeLabel(buckets), buckets);
+}
+
+/** The bucket a day lands in, or −1 when the window does not hold it. */
+export function bucketIndexOf(day: string, buckets: PlBucket[]): number {
+  let lo = 0;
+  let hi = buckets.length - 1;
+  while (lo <= hi) {
+    const mid = (lo + hi) >> 1;
+    if (day < buckets[mid].start) hi = mid - 1;
+    else if (day >= buckets[mid].endExclusive) lo = mid + 1;
+    else return mid;
+  }
+  return -1;
+}
+
+/**
+ * A row's day as YYYY-MM-DD. A string is sliced, never parsed; a Date reads
+ * its LOCAL day, matching how the rest of the app renders it.
+ */
+export const dayOf = (date: Date | string): string =>
+  typeof date === 'string'
+    ? date.slice(0, 10)
+    : isoDay(date.getFullYear(), date.getMonth() + 1, date.getDate());


### PR DESCRIPTION
## What this is

The owner's 19 Aug direction for the Forecast page, ahead of stage 2: **"more like a 'P&L', with income above, and expenses below and then a 'net income' or a 'net expenditure' figure at the bottom"** — plus a choice of "twelve months", collapsible sections, the monthly spread behind a toggle, and two tabs with Forecast deliberately blank until the scenario tool's interaction design is decided.

## The Current tab

- **Income above, Expenditure below, net at the foot** — named for its direction (Net income / Net expenditure), coloured only there.
- **Section headings collapse** to their totals, so the page can read as three lines: income total, expenditure total, net.
- **"Show the months"** turns the list into a months-across table — one column per month, then Total and A month — inside its own horizontal scroll. Cells where nothing happened are a quiet dash, never £0.00 noise. Categories still drill to the rows their figure is the sum of, in both layouts.
- **Four windows**, built in `utils/plWindow` where the boundaries are pinned by test:
  - *Last 12 months* — the last full twelve, no current part month;
  - *Calendar year* — the last full one;
  - *Tax year* — 6 April to 5 April, in **HMRC tax months (6th to 5th)**: twelve true twelfths whose sum is the total, rather than thirteen columns with part-months at both ends. The page says the convention on screen. A tax year is only offered once complete — on 5 April the year ends that day and is not yet whole;
  - *Custom* — a month range, whose average divides by **its** month count, not always twelve.
- Boundaries are ISO day strings compared lexically — no date parser, so no timezone can move a row between columns (the lesson the admission lane's TZ pin taught).

## Two deliberate semantic shifts

1. **The Current tab is actuals, whole.** A forecast-exclusion verdict no longer thins it — a P&L of what happened shows what happened. The verdicts are kept: they belong to the forecast's base and resurface with the redesigned tab. Pinned by test.
2. **A zero wears neither sign nor colour** — spotted live when an empty tax year rendered a green `+£0.00` against the palette rule.

## The Forecast tab

Deliberately empty while the tool is redesigned — and it names what is already stored for it (adjusted categories, excluded one-offs, by count) so stated judgments never look lost. A failed read of the stored adjustments is said, never guessed at. The `forecast_adjustments` seam and both engines' storage are untouched.

## Verified

19 unit specs (9 window-boundary, 10 page), strict types, lint — and exercised live in the browser on demo data: list and table modes, collapse, all four windows (custom re-averaging over 3 months confirmed to the penny), the drill-down inside the table, the Forecast tab, and the phone width.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
