### PR TITLE
feat(ui): summary tiles drill, one Value button, the review round returns, and two inline-flex casualties

### DIFF
--- a/src/components/dashboard/ImprovedDashboard.tsx
+++ b/src/components/dashboard/ImprovedDashboard.tsx
@@ -812,7 +812,9 @@ export function ImprovedDashboard() {
                 ledger where neither happened — in the two hues the app
                 reserves for exactly that claim. Same condition as the arrow,
                 deliberately. */}
-            <p className={`flex items-center gap-2 text-xl font-bold ${
+            {/* text-2xl: the owner asked twice for these two figures to read
+                bigger (19 Aug: "I still think they are a little small"). */}
+            <p className={`flex items-center gap-2 text-2xl font-bold ${
               performance.income === 0
                 ? 'text-gray-900 dark:text-white'
                 : 'text-green-600 dark:text-green-400'
@@ -830,7 +832,7 @@ export function ImprovedDashboard() {
             className="flex flex-col items-start p-4 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-700/50 transition-colors cursor-pointer text-left"
           >
             <p className="text-sm text-gray-600 dark:text-gray-400">Expenses</p>
-            <p className={`flex items-center gap-2 text-xl font-bold ${
+            <p className={`flex items-center gap-2 text-2xl font-bold ${
               performance.expenses === 0
                 ? 'text-gray-900 dark:text-white'
                 : 'text-red-600 dark:text-red-400'

--- a/src/pages/AccountTransactions.tsx
+++ b/src/pages/AccountTransactions.tsx
@@ -547,6 +547,8 @@ export default function AccountTransactions() {
    * the worst kind of stale state — it looks like data loss.
    */
   const [reviewOnly, setReviewOnly] = useState(false);
+  /** Set when the FOCUSED accounts list sent this visit (see the `back` param). */
+  const [backToAccountsReview, setBackToAccountsReview] = useState(false);
   /**
    * The register narrowed to ONE recurring pattern's payments — every label
    * it has worn, so a stitched pattern (a bank rename) shows its whole
@@ -598,8 +600,9 @@ export default function AccountTransactions() {
     const txn = params.get('txn');
     const hasShowArchived = params.has('showArchived');
     const hasReview = params.has('review');
+    const hasBack = params.has('back');
     const hasRecurringPayee = params.has('recurringPayee');
-    if (!txn && !hasShowArchived && !hasReview && !hasRecurringPayee) return;
+    if (!txn && !hasShowArchived && !hasReview && !hasBack && !hasRecurringPayee) return;
     if (txn) {
       pendingTxnRef.current = txn;
       openedAtFootRef.current = accountId ?? null;
@@ -636,6 +639,14 @@ export default function AccountTransactions() {
        */
       if (params.get('review') === '1') setReviewOnly(true);
       params.delete('review');
+    }
+    if (hasBack) {
+      // The FOCUSED accounts list sent this visit as one stop on a review
+      // round — finishing here should return there, still focused, to pick
+      // the next account (owner, 19 Aug). Consumed like the rest: the way
+      // back is because the user came from there one click ago, not stored.
+      if (params.get('back') === 'accounts-review') setBackToAccountsReview(true);
+      params.delete('back');
     }
     if (hasRecurringPayee) {
       // Percent-decoding is URLSearchParams' own; the '|' separator survives
@@ -1000,11 +1011,23 @@ export default function AccountTransactions() {
    * box hides itself at zero — the house rule that a zero count renders
    * nothing). Reviewing the last row is a success, and it should read like one.
    *
+   * When the visit was one stop on a REVIEW ROUND (sent by the focused
+   * accounts list, `back=accounts-review`), finishing goes back to that list —
+   * still focused — to pick the next account, rather than leaving the user in
+   * the register they have just cleared (owner, 19 Aug). Only while the
+   * filter is still on: someone who turned it off and stayed to browse has
+   * left the round, and must not be teleported mid-scroll.
+   *
    * Cannot loop: toReviewCount is computed from the unfiltered list above.
    */
   useEffect(() => {
-    if (toReviewCount === 0) setReviewOnly(false);
-  }, [toReviewCount]);
+    if (toReviewCount !== 0) return;
+    if (backToAccountsReview && reviewOnly) {
+      navigate(preserveDemoParam('/accounts?focus=review', location.search));
+      return;
+    }
+    setReviewOnly(false);
+  }, [toReviewCount, backToAccountsReview, reviewOnly, navigate, location.search]);
 
   /**
    * The rows the table actually lists. One more filter on the end of the chain,

--- a/src/pages/Accounts.tsx
+++ b/src/pages/Accounts.tsx
@@ -836,6 +836,22 @@ export default function Accounts() {
   }, [accountBands]);
 
 
+  /**
+   * ARRIVING BACK MID-ROUND: a register whose review queue just emptied sends
+   * the user here with ?focus=review, consumed and deleted like the register's
+   * own deep-link params. Focus resumes only while there is still work — with
+   * nothing left to review anywhere, the round is over and this is the
+   * ordinary Accounts page (owner, 19 Aug: "until there is no more accounts
+   * to review after which you get taken back to the Accounts Page overall").
+   */
+  useEffect(() => {
+    const params = new URLSearchParams(location.search);
+    if (params.get('focus') !== 'review') return;
+    params.delete('focus');
+    if (reviewTotal > 0) enterFocus('review');
+    navigate({ pathname: location.pathname, search: params.toString() }, { replace: true });
+  }, [location.pathname, location.search, reviewTotal, enterFocus, navigate]);
+
   const matchedTopLevelCount = isSearching
     ? topLevelAccounts.filter(accountOrChildMatches).length
     : topLevelAccounts.length;
@@ -1362,8 +1378,17 @@ export default function Accounts() {
   const reconcileHref = (accountId: string): string =>
     preserveDemoParam(`/reconciliation?account=${accountId}&from=accounts`, location.search);
 
+  /*
+   * From the FOCUSED list the link carries a way back: reviewing an account's
+   * arrivals is one stop on a round, so finishing returns to this page still
+   * focused, to pick the next account — not to the register just cleared
+   * (owner, 19 Aug). From the ordinary list the register keeps you, as ever.
+   */
   const reviewHref = (accountId: string): string =>
-    preserveDemoParam(`/accounts/${accountId}?review=1`, location.search);
+    preserveDemoParam(
+      `/accounts/${accountId}?review=1${focusMode === 'review' ? '&back=accounts-review' : ''}`,
+      location.search
+    );
 
   const renderReconcileButton = (account: Account): ReactNode => (
     <button

--- a/src/pages/Calendar.tsx
+++ b/src/pages/Calendar.tsx
@@ -15,6 +15,7 @@ import { computeIncomeExpense, buildCategoryKindLookup, classifyFlow } from '../
 import { Modal, ModalBody } from '../components/common/Modal';
 import EditTransactionModal from '../components/EditTransactionModal';
 import type { Transaction } from '../types';
+import type { SplitExpandedTransaction } from '../utils/transactionSplits';
 import { createCategoryLabeller } from '../utils/categoryLabel';
 
 interface DayData {
@@ -398,7 +399,19 @@ export default function Calendar() {
    * lines, so the list sums to the figure that was clicked rather than to
    * some quietly different one.
    */
-  const [drill, setDrill] = useState<{ from: Date; to: Date; label: string; bucket: 'in' | 'out' } | null>(null);
+  const [drill, setDrill] = useState<{
+    from: Date; to: Date; label: string;
+    bucket: 'in' | 'out' | 'net';
+    /**
+     * 'movement' decomposes a day cell's cash-movement figure (transfers and
+     * the unfiled as named lines). 'flows' decomposes an Income/Expenditure/
+     * Net TILE — the computeIncomeExpense figure, where transfers,
+     * revaluations and the unfiled are not part of the number, so they are
+     * not part of the list either; totals are SIGNED so a refund-heavy
+     * category reads honestly and the list still sums to the tile.
+     */
+    scope: 'movement' | 'flows';
+  } | null>(null);
   const [drillCategory, setDrillCategory] = useState<string | null>(null);
   const closeDrill = (): void => { setDrill(null); setDrillCategory(null); };
 
@@ -407,12 +420,37 @@ export default function Calendar() {
 
   const drillData = useMemo(() => {
     if (!drill) return null;
+
+    if (drill.scope === 'flows') {
+      // The tiles' own arithmetic, re-run over the drill's window — the one
+      // way the list can sum to the figure that was clicked (splits expanded,
+      // refunds netting, exactly as the tile counted them).
+      const flows = computeIncomeExpense(transactions, transactionSplits, categories, {
+        from: drill.from, to: drill.to,
+      });
+      const rows =
+        drill.bucket === 'in' ? flows.incomeRows
+        : drill.bucket === 'out' ? flows.expenseRows
+        : [...flows.incomeRows, ...flows.expenseRows];
+      const groups = new Map<string, { total: number; rows: SplitExpandedTransaction[] }>();
+      for (const row of rows) {
+        const key = labeller(row) || UNFILED_LABEL;
+        const group = groups.get(key) ?? { total: 0, rows: [] };
+        group.total = toDecimal(group.total).plus(toDecimal(row.amount)).toNumber();
+        group.rows.push(row);
+        groups.set(key, group);
+      }
+      return [...groups.entries()]
+        .map(([label, group]) => ({ label, ...group }))
+        .sort((a, b) => Math.abs(b.total) - Math.abs(a.total));
+    }
+
     const rows = transactions.filter(t => {
       const time = new Date(t.date).getTime();
       if (time < drill.from.getTime() || time > drill.to.getTime()) return false;
       return drill.bucket === 'in' ? t.amount > 0 : t.amount < 0;
     });
-    const groups = new Map<string, { total: number; rows: Transaction[] }>();
+    const groups = new Map<string, { total: number; rows: SplitExpandedTransaction[] }>();
     for (const row of rows) {
       const kind = classifyFlow(row, categoryKinds);
       const key =
@@ -435,7 +473,7 @@ export default function Calendar() {
         if (ra !== -1 || rb !== -1) return (ra === -1 ? -1 : ra + 1) - (rb === -1 ? -1 : rb + 1);
         return b.total - a.total;
       });
-  }, [drill, transactions, categoryKinds, labeller]);
+  }, [drill, transactions, transactionSplits, categories, categoryKinds, labeller]);
 
   /** The real editor, over whichever row was clicked in a day or a drill. */
   const [editing, setEditing] = useState<Transaction | null>(null);
@@ -500,15 +538,36 @@ export default function Calendar() {
     }
   };
 
+  /** The visible window's name — the header's title, and the drills' label. */
+  const windowTitle =
+    view === 'year' ? String(year)
+      : view === 'week' ? weekTitle()
+      : view === 'day' ? currentDate.toLocaleDateString(getDateLocale(), { weekday: 'long', day: 'numeric', month: 'long', year: 'numeric' })
+      : `${monthNames[month]} ${year}`;
+
+  /** A summary tile opens the drill on its own figure (owner, 19 Aug). */
+  const openFlowDrill = (bucket: 'in' | 'out' | 'net'): void =>
+    setDrill({ from: visibleWindow.from, to: visibleWindow.to, label: windowTitle, bucket, scope: 'flows' });
+
   return (
     <PageWrapper title="Calendar">
-      {/* Month summary bar */}
+      {/* Month summary bar — each figure tile is a DRILL into what made it
+          up, the same popup the day cells open (owner, 19 Aug: "the
+          'Income' / 'Expenditure' / 'Net' should be clickable"). */}
       <div className="grid grid-cols-2 sm:grid-cols-4 gap-3 mb-4">
-        <div className="bg-white dark:bg-gray-800 rounded-lg shadow-sm border border-gray-100 dark:border-gray-700 px-4 py-2">
+        <button
+          type="button"
+          onClick={() => openFlowDrill('in')}
+          className="block w-full bg-white dark:bg-gray-800 rounded-lg shadow-sm border border-gray-100 dark:border-gray-700 px-4 py-2 text-left hover:border-gray-300 dark:hover:border-gray-500 transition-colors"
+        >
           <span className="text-sm text-gray-500 dark:text-gray-400">Income</span>
           <p className="text-lg font-semibold text-green-600 dark:text-green-400">{formatCurrency(windowSummary.totalIncome)}</p>
-        </div>
-        <div className="bg-white dark:bg-gray-800 rounded-lg shadow-sm border border-gray-100 dark:border-gray-700 px-4 py-2">
+        </button>
+        <button
+          type="button"
+          onClick={() => openFlowDrill('out')}
+          className="block w-full bg-white dark:bg-gray-800 rounded-lg shadow-sm border border-gray-100 dark:border-gray-700 px-4 py-2 text-left hover:border-gray-300 dark:hover:border-gray-500 transition-colors"
+        >
           <span className="text-sm text-gray-500 dark:text-gray-400">Expenditure</span>
           {/* `dark:text-red-400` is not decoration — without it this figure is
               unreadable at night. `styles/accessibility-colors.css` remaps
@@ -524,13 +583,17 @@ export default function Calendar() {
               (£X) — a red figure without its brackets was the drift the
               owner caught on this very tile. */}
           <p className="text-lg font-semibold text-red-600 dark:text-red-400">{formatCurrency(-windowSummary.totalExpense)}</p>
-        </div>
-        <div className="bg-white dark:bg-gray-800 rounded-lg shadow-sm border border-gray-100 dark:border-gray-700 px-4 py-2">
+        </button>
+        <button
+          type="button"
+          onClick={() => openFlowDrill('net')}
+          className="block w-full bg-white dark:bg-gray-800 rounded-lg shadow-sm border border-gray-100 dark:border-gray-700 px-4 py-2 text-left hover:border-gray-300 dark:hover:border-gray-500 transition-colors"
+        >
           <span className="text-sm text-gray-500 dark:text-gray-400">Net</span>
           <p className={`text-lg font-semibold ${toDecimal(windowSummary.totalIncome).minus(toDecimal(windowSummary.totalExpense)).greaterThanOrEqualTo(0) ? 'text-green-600 dark:text-green-400' : 'text-red-600 dark:text-red-400'}`}>
             {formatCurrency(toDecimal(windowSummary.totalIncome).minus(toDecimal(windowSummary.totalExpense)).toNumber())}
           </p>
-        </div>
+        </button>
         <div className="bg-white dark:bg-gray-800 rounded-lg shadow-sm border border-gray-100 dark:border-gray-700 px-4 py-2">
           <span className="text-sm text-gray-500 dark:text-gray-400">Transactions</span>
           <p className="text-lg font-semibold text-gray-900 dark:text-white">{windowSummary.totalTransactions}</p>
@@ -636,10 +699,7 @@ export default function Calendar() {
       <div className="bg-white dark:bg-gray-800 rounded-xl shadow-sm border border-gray-100 dark:border-gray-700 overflow-hidden">
         <div className="flex items-center justify-between px-6 py-4 border-b border-gray-100 dark:border-gray-700">
           <h2 className="text-xl font-semibold text-gray-900 dark:text-white">
-            {view === 'year' ? year
-              : view === 'week' ? weekTitle()
-              : view === 'day' ? currentDate.toLocaleDateString(getDateLocale(), { weekday: 'long', day: 'numeric', month: 'long', year: 'numeric' })
-              : `${monthNames[month]} ${year}`}
+            {windowTitle}
           </h2>
           <div className="flex items-center gap-2">
             {/* The view, chosen the way Apple Calendar chooses it — a
@@ -767,6 +827,7 @@ export default function Calendar() {
                       to: new Date(day.date.getFullYear(), day.date.getMonth(), day.day, 23, 59, 59, 999),
                       label: day.date.toLocaleDateString(getDateLocale(), { day: 'numeric', month: 'long' }),
                       bucket: 'in',
+                      scope: 'movement',
                     });
                   }}
                   aria-label={`Money in, day ${day.day} — what made it up`}
@@ -785,6 +846,7 @@ export default function Calendar() {
                       to: new Date(day.date.getFullYear(), day.date.getMonth(), day.day, 23, 59, 59, 999),
                       label: day.date.toLocaleDateString(getDateLocale(), { day: 'numeric', month: 'long' }),
                       bucket: 'out',
+                      scope: 'movement',
                     });
                   }}
                   aria-label={`Money out, day ${day.day} — what made it up`}
@@ -834,7 +896,7 @@ export default function Calendar() {
                       <button
                         type="button"
                         onClick={() => {
-                          setDrill({ ...visibleWindow, label: weekTitle(), bucket: 'in' });
+                          setDrill({ ...visibleWindow, label: weekTitle(), bucket: 'in', scope: 'movement' });
                           setDrillCategory(row.label);
                         }}
                         className="w-full py-1.5 flex items-baseline justify-between gap-4 text-left hover:bg-gray-50 dark:hover:bg-gray-700/40 rounded"
@@ -868,7 +930,7 @@ export default function Calendar() {
                       <button
                         type="button"
                         onClick={() => {
-                          setDrill({ ...visibleWindow, label: weekTitle(), bucket: 'out' });
+                          setDrill({ ...visibleWindow, label: weekTitle(), bucket: 'out', scope: 'movement' });
                           setDrillCategory(row.label);
                         }}
                         className="w-full py-1.5 flex items-baseline justify-between gap-4 text-left hover:bg-gray-50 dark:hover:bg-gray-700/40 rounded"
@@ -954,19 +1016,30 @@ export default function Calendar() {
         {/* THE YEAR AS TWELVE MONTHS, each a door into its month view. */}
         {view === 'year' && yearMonths && (
           <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 gap-px bg-gray-100 dark:bg-gray-700" aria-label="Year by month">
+            {/* Each cell's `flex flex-col items-start` is LOAD-BEARING:
+                index.css sets `button { display: inline-flex }` globally —
+                ROW direction — so without it the month name and both figures
+                sat crammed on one line (the owner caught it on this very
+                grid; the sixth casualty of that global rule). NEUTRAL AT
+                ZERO like the dashboard cards: an empty month claims no
+                direction, so it wears neither hue nor sign. */}
             {yearMonths.map(({ month: m, income, expense }) => (
               <button
                 key={m}
                 type="button"
                 onClick={() => { setCurrentDate(new Date(year, m, 1)); setView('month'); }}
-                className="bg-white dark:bg-gray-800 p-4 text-left hover:bg-gray-50 dark:hover:bg-gray-700/60 transition-colors"
+                className="flex flex-col items-start bg-white dark:bg-gray-800 p-4 text-left hover:bg-gray-50 dark:hover:bg-gray-700/60 transition-colors"
                 aria-label={`Open ${monthNames[m]} ${year}`}
               >
                 <p className="text-sm font-semibold text-gray-900 dark:text-white">{monthNames[m]}</p>
-                <p className="text-sm tabular-nums text-green-600 dark:text-green-400 mt-1">
-                  +{formatCurrency(income)}
+                <p className={`text-sm tabular-nums mt-1 ${
+                  income === 0 ? 'text-gray-500 dark:text-gray-400' : 'text-green-600 dark:text-green-400'
+                }`}>
+                  {income === 0 ? formatCurrency(0) : `+${formatCurrency(income)}`}
                 </p>
-                <p className="text-sm tabular-nums text-red-600 dark:text-red-400">
+                <p className={`text-sm tabular-nums ${
+                  expense === 0 ? 'text-gray-500 dark:text-gray-400' : 'text-red-600 dark:text-red-400'
+                }`}>
                   {formatCurrency(-expense)}
                 </p>
               </button>
@@ -983,7 +1056,11 @@ export default function Calendar() {
         isOpen={drill !== null}
         onClose={closeDrill}
         title={drill
-          ? `${drill.bucket === 'in' ? 'Money in' : 'Money out'} — ${drill.label}${drillCategory ? ` — ${drillCategory}` : ''}`
+          ? `${
+            drill.scope === 'flows'
+              ? drill.bucket === 'in' ? 'Income' : drill.bucket === 'out' ? 'Expenditure' : 'Net'
+              : drill.bucket === 'in' ? 'Money in' : 'Money out'
+          } — ${drill.label}${drillCategory ? ` — ${drillCategory}` : ''}`
           : ''}
         size="md"
       >
@@ -1004,11 +1081,22 @@ export default function Calendar() {
                         {group.label}
                         <span className="ml-2 text-xs text-gray-400 dark:text-gray-500">{group.rows.length}</span>
                       </span>
-                      <span className={`text-sm tabular-nums shrink-0 ${
-                        drill.bucket === 'in' ? 'text-green-600 dark:text-green-400' : 'text-red-600 dark:text-red-400'
-                      }`}>
-                        {drill.bucket === 'in' ? `+${formatCurrency(group.total)}` : formatCurrency(-group.total)}
-                      </span>
+                      {/* Movement totals are magnitudes worn by the bucket;
+                          a flows drill's are SIGNED, so a refund-heavy
+                          category shows its real direction. */}
+                      {drill.scope === 'flows' ? (
+                        <span className={`text-sm tabular-nums shrink-0 ${
+                          group.total >= 0 ? 'text-green-600 dark:text-green-400' : 'text-red-600 dark:text-red-400'
+                        }`}>
+                          {group.total >= 0 ? `+${formatCurrency(group.total)}` : formatCurrency(group.total)}
+                        </span>
+                      ) : (
+                        <span className={`text-sm tabular-nums shrink-0 ${
+                          drill.bucket === 'in' ? 'text-green-600 dark:text-green-400' : 'text-red-600 dark:text-red-400'
+                        }`}>
+                          {drill.bucket === 'in' ? `+${formatCurrency(group.total)}` : formatCurrency(-group.total)}
+                        </span>
+                      )}
                     </button>
                   </li>
                 ))}
@@ -1036,7 +1124,16 @@ export default function Calendar() {
                       <li key={row.id} className="border-t border-gray-50 dark:border-gray-700/50 first:border-0">
                         <button
                           type="button"
-                          onClick={() => setEditing(row)}
+                          onClick={() => {
+                            // A flows drill can list a VIRTUAL split line;
+                            // the editor opens the real transaction it
+                            // belongs to, never the projection.
+                            setEditing(
+                              row.splitParentId
+                                ? transactions.find(t => t.id === row.splitParentId) ?? row
+                                : row
+                            );
+                          }}
                           className="w-full py-2 flex items-baseline justify-between gap-4 text-left hover:bg-gray-50 dark:hover:bg-gray-700/40 rounded"
                         >
                           <span className="min-w-0">

--- a/src/pages/Forecast.tsx
+++ b/src/pages/Forecast.tsx
@@ -8,7 +8,7 @@ import { buildCategoryKindLookup, classifyFlow } from '../utils/incomeExpense';
 import { dismissedKeys } from '../utils/suggestionDismissals';
 import { buildPlWindow, bucketIndexOf, dayOf } from '../utils/plWindow';
 import type { PlWindowKind } from '../utils/plWindow';
-import { ChevronDownIcon, ChevronRightIcon } from '../components/icons';
+import { ArrowDownIcon, ArrowUpIcon, ChevronDownIcon, ChevronRightIcon } from '../components/icons';
 import { dataPort } from '@data';
 import type { ForecastAdjustment, Transaction } from '../types';
 
@@ -112,8 +112,22 @@ export default function Forecast(): React.JSX.Element {
   );
 
   const [sectionOpen, setSectionOpen] = useState<{ in: boolean; out: boolean }>({ in: true, out: true });
-  /** The user's ordering: by name, or by value in either direction. */
-  const [sortOrder, setSortOrder] = useState<'name' | 'high' | 'low'>('high');
+  /**
+   * The user's ordering: by name or by value, each button carrying its own
+   * direction (owner, 19 Aug: "A-Z should be clickable to change to Z-A…
+   * just have one button called 'Value' and then an arrow up or an arrow
+   * down"). Clicking the inactive button activates it; clicking the active
+   * one turns its direction around.
+   */
+  const [sort, setSort] = useState<{ mode: 'name' | 'value'; nameAsc: boolean; valueDesc: boolean }>({
+    mode: 'value', nameAsc: true, valueDesc: true,
+  });
+  const chooseSort = (mode: 'name' | 'value'): void =>
+    setSort(previous => previous.mode === mode
+      ? mode === 'name'
+        ? { ...previous, nameAsc: !previous.nameAsc }
+        : { ...previous, valueDesc: !previous.valueDesc }
+      : { ...previous, mode });
   /** Group headings the user has folded shut — everything is open until asked. */
   const [closedGroups, setClosedGroups] = useState<Set<string>>(new Set());
   const [showMonths, setShowMonths] = useState(false);
@@ -224,9 +238,9 @@ export default function Forecast(): React.JSX.Element {
     // The user's ordering, applied at every level. The unfiled line is
     // always last, whatever its size — a remainder, not a category.
     const compare = (aLabel: string, aTotal: number, bLabel: string, bTotal: number): number =>
-      sortOrder === 'name' ? aLabel.localeCompare(bLabel, undefined, { sensitivity: 'base' })
-        : sortOrder === 'low' ? aTotal - bTotal
-          : bTotal - aTotal;
+      sort.mode === 'name'
+        ? (sort.nameAsc ? 1 : -1) * aLabel.localeCompare(bLabel, undefined, { sensitivity: 'base' })
+        : sort.valueDesc ? bTotal - aTotal : aTotal - bTotal;
 
     const finishSide = (entries: Map<string, BuildEntry>): SideEntry[] =>
       [...entries.values()]
@@ -288,7 +302,7 @@ export default function Forecast(): React.JSX.Element {
       transfers,
       revaluations,
     };
-  }, [transactions, plWindow, categoryKinds, categoryById, sortOrder]);
+  }, [transactions, plWindow, categoryKinds, categoryById, sort]);
 
   const average = (total: number): number =>
     toDecimal(total).dividedBy(plWindow.buckets.length).toNumber();
@@ -741,25 +755,36 @@ export default function Forecast(): React.JSX.Element {
             <div className="bg-white dark:bg-gray-800 rounded-lg border border-line dark:border-gray-700 p-4 sm:p-6">
               <div className="flex flex-wrap items-center justify-between gap-2 mb-1">
                 <div className="flex items-center rounded-lg bg-gray-100 dark:bg-gray-700 p-0.5" role="group" aria-label="Sort order">
-                  {([
-                    ['name', 'A to Z'],
-                    ['high', 'Largest first'],
-                    ['low', 'Smallest first'],
-                  ] as const).map(([order, name]) => (
-                    <button
-                      key={order}
-                      type="button"
-                      onClick={() => setSortOrder(order)}
-                      aria-pressed={sortOrder === order}
-                      className={`px-2.5 py-0.5 text-xs font-medium rounded-md transition-colors ${
-                        sortOrder === order
-                          ? 'bg-white dark:bg-gray-800 text-gray-900 dark:text-white shadow-sm'
-                          : 'text-gray-600 dark:text-gray-300 hover:text-gray-900 dark:hover:text-gray-100'
-                      }`}
-                    >
-                      {name}
-                    </button>
-                  ))}
+                  <button
+                    type="button"
+                    onClick={() => chooseSort('name')}
+                    aria-pressed={sort.mode === 'name'}
+                    title={sort.mode === 'name' ? 'Turn the alphabet around' : 'Sort by name'}
+                    className={`px-2.5 py-0.5 text-xs font-medium rounded-md transition-colors ${
+                      sort.mode === 'name'
+                        ? 'bg-white dark:bg-gray-800 text-gray-900 dark:text-white shadow-sm'
+                        : 'text-gray-600 dark:text-gray-300 hover:text-gray-900 dark:hover:text-gray-100'
+                    }`}
+                  >
+                    {sort.nameAsc ? 'A to Z' : 'Z to A'}
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => chooseSort('value')}
+                    aria-pressed={sort.mode === 'value'}
+                    aria-label={sort.valueDesc ? 'Value, largest first' : 'Value, smallest first'}
+                    title={sort.mode === 'value' ? 'Turn the order around' : 'Sort by value'}
+                    className={`flex items-center gap-1 px-2.5 py-0.5 text-xs font-medium rounded-md transition-colors ${
+                      sort.mode === 'value'
+                        ? 'bg-white dark:bg-gray-800 text-gray-900 dark:text-white shadow-sm'
+                        : 'text-gray-600 dark:text-gray-300 hover:text-gray-900 dark:hover:text-gray-100'
+                    }`}
+                  >
+                    Value
+                    {sort.valueDesc
+                      ? <ArrowDownIcon size={12} className="shrink-0" />
+                      : <ArrowUpIcon size={12} className="shrink-0" />}
+                  </button>
                 </div>
                 <button
                   type="button"

--- a/src/pages/__tests__/AccountTransactions.review.test.tsx
+++ b/src/pages/__tests__/AccountTransactions.review.test.tsx
@@ -29,7 +29,7 @@
 import React from 'react';
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { render, screen, fireEvent, waitFor, within } from '@testing-library/react';
-import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { MemoryRouter, Route, Routes, useLocation } from 'react-router-dom';
 import { PreferencesProvider } from '../../contexts/PreferencesContext';
 import { ToastProvider } from '../../contexts/ToastContext';
 import { NotificationProvider } from '../../contexts/NotificationContext';
@@ -358,5 +358,67 @@ describe('Account register — what ends a review, and what does not', () => {
     expect(updateTransaction).not.toHaveBeenCalled();
     expect(isBold('Marsh Lane Grocer')).toBe(true);
     expect(toReviewButton()).toHaveTextContent('1');
+  });
+});
+
+describe('Account register — a review round sent from the focused accounts list', () => {
+  /**
+   * The owner's flow (19 Aug): press "Review x transactions" on Accounts,
+   * pick an account's To Review count, deal with its arrivals — and land
+   * BACK on the focused list to pick the next account, not in the register
+   * just cleared. The link carries `back=accounts-review`; the register
+   * consumes it like every other deep-link param and, when the queue
+   * empties WHILE the filter is on, goes home to `/accounts?focus=review`.
+   */
+  const AccountsProbe = (): React.JSX.Element => {
+    const location = useLocation();
+    return <div data-testid="accounts-probe">{location.search}</div>;
+  };
+
+  const roundTree = (search: string): React.JSX.Element => (
+    <MemoryRouter initialEntries={[`/accounts/${ACCOUNT.id}${search}`]}>
+      <PreferencesProvider>
+        <ToastProvider>
+          <NotificationProvider>
+            <Routes>
+              <Route path="/accounts/:accountId" element={<AccountTransactions />} />
+              <Route path="/accounts" element={<AccountsProbe />} />
+            </Routes>
+          </NotificationProvider>
+        </ToastProvider>
+      </PreferencesProvider>
+    </MemoryRouter>
+  );
+
+  it('returns to the focused list when the queue empties — not to the register just cleared', async () => {
+    const view = render(roundTree('?review=1&back=accounts-review'));
+    await screen.findByRole('heading', { level: 1, name: 'Synthetic Register' });
+    // Arrived filtered to the one arrival.
+    await waitFor(() => {
+      expect(within(grid()).queryByText('Portway Hardware')).not.toBeInTheDocument();
+    });
+    expect(within(grid()).getByText('Marsh Lane Grocer')).toBeInTheDocument();
+
+    // The ledger now holds that arrival dealt with — the queue is empty.
+    seed(ROWS.map(r => (r.id === 'txn-new' ? { ...r, needsReview: false } : r)));
+    view.rerender(roundTree('?review=1&back=accounts-review'));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('accounts-probe')).toHaveTextContent('focus=review');
+    });
+  });
+
+  it('without the marker, an emptied queue keeps you in the register, filter quietly off', async () => {
+    const view = render(roundTree('?review=1'));
+    await screen.findByRole('heading', { level: 1, name: 'Synthetic Register' });
+
+    seed(ROWS.map(r => (r.id === 'txn-new' ? { ...r, needsReview: false } : r)));
+    view.rerender(roundTree('?review=1'));
+
+    // The register stays; every row shows again; nobody is teleported.
+    await waitFor(() => {
+      expect(within(grid()).getByText('Portway Hardware')).toBeInTheDocument();
+    });
+    expect(screen.queryByTestId('accounts-probe')).not.toBeInTheDocument();
   });
 });

--- a/src/pages/__tests__/Accounts.toReview.test.tsx
+++ b/src/pages/__tests__/Accounts.toReview.test.tsx
@@ -208,3 +208,50 @@ describe('Accounts list — the To Review column', () => {
     expect(clear?.className).toContain('font-normal');
   });
 });
+
+describe('Accounts list — arriving back mid-round (?focus=review)', () => {
+  const renderWithSearch = (search: string) =>
+    render(
+      <MemoryRouter initialEntries={[`/accounts${search}`]}>
+        <PreferencesProvider>
+          <ToastProvider>
+            <Accounts />
+          </ToastProvider>
+        </PreferencesProvider>
+      </MemoryRouter>
+    );
+
+  it('resumes the review focus while accounts still carry work', async () => {
+    __setAppContextValue({
+      accounts: [NATWEST, MONZO],
+      transactions: [
+        row('t1', NATWEST.id, { needsReview: true }),
+        row('t2', MONZO.id, { needsReview: false }),
+      ],
+      isLoading: false,
+    });
+
+    renderWithSearch('?focus=review');
+    // The focused list: only the account with arrivals, and the way out named.
+    await screen.findByRole('button', { name: /Showing to review — show all/ });
+    expect(screen.getByRole('heading', { level: 3, name: 'Synthetic Natwest' })).toBeInTheDocument();
+    expect(screen.queryByRole('heading', { level: 3, name: 'Synthetic Monzo' })).not.toBeInTheDocument();
+  });
+
+  it('with nothing left to review anywhere, the round is over — the ordinary page', async () => {
+    __setAppContextValue({
+      accounts: [NATWEST, MONZO],
+      transactions: [
+        row('t1', NATWEST.id, { needsReview: false }),
+        row('t2', MONZO.id, { needsReview: false }),
+      ],
+      isLoading: false,
+    });
+
+    renderWithSearch('?focus=review');
+    await screen.findByRole('heading', { level: 3, name: 'Synthetic Natwest' });
+    // Both accounts show; no focus chrome claims a filter is on.
+    expect(screen.getByRole('heading', { level: 3, name: 'Synthetic Monzo' })).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /Showing to review — show all/ })).not.toBeInTheDocument();
+  });
+});

--- a/src/pages/__tests__/Calendar.test.tsx
+++ b/src/pages/__tests__/Calendar.test.tsx
@@ -119,6 +119,54 @@ describe('Calendar', () => {
     expect(screen.getByText('Transactions')).toBeInTheDocument();
   });
 
+  it('a summary tile drills into the transactions that make up its figure', () => {
+    render(
+      <MemoryRouter>
+        <Calendar />
+      </MemoryRouter>
+    );
+
+    // The Income tile is CLICKABLE (owner, 19 Aug) and opens the same drill
+    // the day cells open: categories first, then one category's rows, then
+    // the real editor.
+    fireEvent.click(screen.getByRole('button', { name: 'Income £200.00' }));
+    expect(screen.getByText(/^Income — /)).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: /Salary/ }));
+    fireEvent.click(screen.getByRole('button', { name: /Test income/ }));
+    expect(screen.getByTestId('edit-modal')).toHaveTextContent('2');
+  });
+
+  it('the Expenditure drill sums to the tile — the unfiled row is not in the figure, so not in the list', () => {
+    render(
+      <MemoryRouter>
+        <Calendar />
+      </MemoryRouter>
+    );
+
+    // The tile reads £50.00 (computeIncomeExpense counts only classified
+    // expense rows); its decomposition must sum to exactly that, so the
+    // £12.50 unfiled row — absent from the figure — is absent from the list.
+    fireEvent.click(screen.getByRole('button', { name: 'Expenditure (£50.00)' }));
+    expect(screen.getByText(/^Expenditure — /)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Food/ })).toBeInTheDocument();
+    expect(screen.queryByText('Unfiled expense')).not.toBeInTheDocument();
+    expect(screen.queryByText(/Uncategorised/)).not.toBeInTheDocument();
+  });
+
+  it('the Net drill shows both directions, signed', () => {
+    render(
+      <MemoryRouter>
+        <Calendar />
+      </MemoryRouter>
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Net £150.00' }));
+    expect(screen.getByText(/^Net — /)).toBeInTheDocument();
+    const dialog = screen.getByRole('dialog');
+    expect(within(dialog).getByText('+£200.00')).toBeInTheDocument();
+    expect(within(dialog).getByText('(£50.00)')).toBeInTheDocument();
+  });
+
   it('navigates to previous month', () => {
     render(
       <MemoryRouter>

--- a/src/pages/__tests__/Forecast.test.tsx
+++ b/src/pages/__tests__/Forecast.test.tsx
@@ -214,13 +214,22 @@ describe('Forecast — the Current P&L', () => {
       return Boolean(a.compareDocumentPosition(b) & Node.DOCUMENT_POSITION_FOLLOWING);
     };
 
-    // Largest first is the default…
+    // Value, largest first is the default…
     expect(ordered('Utilities', 'Living')).toBe(true);
     // …A to Z reorders by name…
     fireEvent.click(screen.getByRole('button', { name: 'A to Z' }));
     expect(ordered('Living', 'Utilities')).toBe(true);
-    // …smallest first by value, ascending.
-    fireEvent.click(screen.getByRole('button', { name: 'Smallest first' }));
+    // …and clicking it AGAIN turns the alphabet around (owner, 19 Aug:
+    // "A-Z should be clickable to change to Z-A") — the label follows.
+    fireEvent.click(screen.getByRole('button', { name: 'A to Z' }));
+    expect(screen.getByRole('button', { name: 'Z to A' })).toBeInTheDocument();
+    expect(ordered('Utilities', 'Living')).toBe(true);
+    // ONE Value button, wearing an arrow: first click returns to value…
+    fireEvent.click(screen.getByRole('button', { name: 'Value, largest first' }));
+    expect(ordered('Utilities', 'Living')).toBe(true);
+    // …second click turns the order around.
+    fireEvent.click(screen.getByRole('button', { name: 'Value, largest first' }));
+    expect(screen.getByRole('button', { name: 'Value, smallest first' })).toBeInTheDocument();
     expect(ordered('Living', 'Utilities')).toBe(true);
     // The unfiled £5,000 outweighs and out-alphabets both, and is still last.
     expect(ordered('Utilities', /Uncategorised — not yet filed/)).toBe(true);


### PR DESCRIPTION
## What this is

Five of the owner's 19 Aug evening notes, batched:

### 1. Calendar summary tiles drill (Income / Expenditure / Net clickable)

Each tile opens the same popup the day cells open — categories first, one category's rows next, the real editor last. The drill gains a **`flows` scope** beside the existing movement scope: it re-runs the tiles' own `computeIncomeExpense` over the visible window, so **the list sums exactly to the figure that was clicked** — splits expanded, refunds netting, and transfers/revaluations/unfiled absent because they are not in the number. Net decomposes both directions with signed totals. A virtual split line opens the editor on its **real parent** transaction. Verified live on demo data: the Income drill's rows sum to the tile to the penny.

### 2. Forecast sort: two buttons, not three

"A to Z" flips to "Z to A" on a second click; one **Value** button wears an up/down arrow and turns around when clicked. The inactive button activates keeping its last direction.

### 3. The review round returns to the focused list

From the **focused** accounts list ("Review x transactions"), an account's To Review count now carries `back=accounts-review`. When the register's review queue empties **while the filter is on**, it returns to `/accounts?focus=review` — which resumes focus only while accounts still carry work, so a finished round lands on the ordinary Accounts page. Someone who turned the filter off and stayed to browse is never teleported; from the ordinary list nothing changes. Four integration specs drive the real router through the whole trip, both with and without the marker.

### 4. Dashboard Income/Expenses figures bigger

`text-xl` → `text-2xl` — the owner's second ask on these two figures.

### 5. Calendar year view uncrammed

The **sixth casualty** of the global `button{display:inline-flex}`: the month cells' three stacked lines rendered in a row ("January+£0.10(£27,110.95)"). `flex-col` restores the stack at equal sizes, and empty months now wear quiet grey `£0.00`s — neither hue nor sign, the dashboard cards' neutral-at-zero rule.

## Verified

57 specs across the five touched suites (new: three tile-drill specs including exact-sum and the split-parent rule; four review-round specs; the sort-toggle sequence), strict types, lint — and items 1, 2, 4, 5 exercised live in the browser on demo data. Item 3 has no demo fixture (demo carries nothing to review) and is covered by the router-level specs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
