### PR TITLE
fix(reconciliation): the freeze diagnosed twice over, and the reconcile round joins the review round

### DIFF
--- a/src/components/reconciliation/ReconciliationFinalizationModal.tsx
+++ b/src/components/reconciliation/ReconciliationFinalizationModal.tsx
@@ -28,6 +28,15 @@ interface ReconciliationFinalizationModalProps {
   onClose: () => void;
   onFinalize: () => void;
   /**
+   * True while the finalize write is in flight. A first-ever finalize can
+   * convert thousands of rows and take real seconds server-side; a button
+   * that sits silent through that reads as frozen and gets pressed again —
+   * the owner pressed it "10-20 times" over 7,000 rows, stacking RPCs
+   * behind the first one's locks. The button says what it is doing and
+   * refuses seconds.
+   */
+  finalizing?: boolean;
+  /**
    * Create a cleared adjustment transaction. Amount is SIGNED per the app-wide
    * convention (income positive, expense negative). The modal stays open —
    * the parent recomputes clearedBalance and the modal re-renders with the
@@ -56,6 +65,7 @@ export default function ReconciliationFinalizationModal({
   awaitingFinalizeCount,
   onClose,
   onFinalize,
+  finalizing = false,
   onCreateAdjustment,
 }: ReconciliationFinalizationModalProps): React.JSX.Element | null {
   // Press AND release must both be on the backdrop — see useBackdropDismiss.
@@ -157,9 +167,11 @@ export default function ReconciliationFinalizationModal({
             </p>
             <button
               onClick={onFinalize}
-              className="px-6 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors font-medium"
+              disabled={finalizing}
+              aria-busy={finalizing}
+              className="px-6 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors font-medium disabled:opacity-60 disabled:cursor-wait"
             >
-              Complete Reconciliation
+              {finalizing ? 'Completing…' : 'Complete Reconciliation'}
             </button>
           </div>
         ) : (

--- a/src/pages/Accounts.tsx
+++ b/src/pages/Accounts.tsx
@@ -837,20 +837,23 @@ export default function Accounts() {
 
 
   /**
-   * ARRIVING BACK MID-ROUND: a register whose review queue just emptied sends
-   * the user here with ?focus=review, consumed and deleted like the register's
-   * own deep-link params. Focus resumes only while there is still work — with
-   * nothing left to review anywhere, the round is over and this is the
-   * ordinary Accounts page (owner, 19 Aug: "until there is no more accounts
-   * to review after which you get taken back to the Accounts Page overall").
+   * ARRIVING BACK MID-ROUND: a register whose review queue just emptied — or
+   * a reconciliation just finished — sends the user here with ?focus=<mode>,
+   * consumed and deleted like the register's own deep-link params. Focus
+   * resumes only while that mode still has work — with nothing left anywhere,
+   * the round is over and this is the ordinary Accounts page (owner, 19 Aug:
+   * "until there is no more accounts to review after which you get taken
+   * back to the Accounts Page overall", and the same round for reconciling).
    */
   useEffect(() => {
     const params = new URLSearchParams(location.search);
-    if (params.get('focus') !== 'review') return;
+    const focus = params.get('focus');
+    if (focus !== 'review' && focus !== 'reconcile') return;
     params.delete('focus');
-    if (reviewTotal > 0) enterFocus('review');
+    const hasWork = focus === 'review' ? reviewTotal > 0 : reconcileAccountCount > 0;
+    if (hasWork) enterFocus(focus);
     navigate({ pathname: location.pathname, search: params.toString() }, { replace: true });
-  }, [location.pathname, location.search, reviewTotal, enterFocus, navigate]);
+  }, [location.pathname, location.search, reviewTotal, reconcileAccountCount, enterFocus, navigate]);
 
   const matchedTopLevelCount = isSearching
     ? topLevelAccounts.filter(accountOrChildMatches).length
@@ -1376,7 +1379,11 @@ export default function Accounts() {
    * The feature is the shortcut, not a new screen.
    */
   const reconcileHref = (accountId: string): string =>
-    preserveDemoParam(`/reconciliation?account=${accountId}&from=accounts`, location.search);
+    preserveDemoParam(
+      `/reconciliation?account=${accountId}&from=accounts${
+        focusMode === 'reconcile' ? '&back=accounts-reconcile' : ''}`,
+      location.search
+    );
 
   /*
    * From the FOCUSED list the link carries a way back: reviewing an account's
@@ -1394,7 +1401,7 @@ export default function Accounts() {
     <button
       type="button"
       onClick={() => navigate(
-        preserveDemoParam(`/reconciliation?account=${account.id}&from=accounts`, location.search),
+        reconcileHref(account.id),
         // The SAME crumbs the register is sent, so the trip back lands on this
         // row rather than at the top of the list — see `registerLinkState`.
         { state: registerLinkState(account.id) }

--- a/src/pages/Reconciliation.tsx
+++ b/src/pages/Reconciliation.tsx
@@ -75,6 +75,13 @@ export default function Reconciliation() {
   // Arriving via an Accounts-page reconcile button means "done" and "Back"
   // both return THERE, not to this page's own account list.
   const [cameFromAccounts] = useState<boolean>(() => searchParams.get('from') === 'accounts');
+  /**
+   * Sent by the FOCUSED accounts list ("Reconcile N instead"): this visit is
+   * one stop on a reconcile round, so leaving — finished or not — returns to
+   * that list, still focused, to pick the next account (owner, 19 Aug; the
+   * same round the review flow walks).
+   */
+  const [cameFromFocusedRound] = useState<boolean>(() => searchParams.get('back') === 'accounts-reconcile');
   // Group + sort for the account list — the same controls, the same module
   // behind them and the same persistence shape as the Accounts page, so the two
   // pages always feel the same. Two INDEPENDENT switches, never an either/or:
@@ -267,6 +274,16 @@ export default function Reconciliation() {
   }, [setSearchParams]);
 
   const handleBack = useCallback(() => {
+    if (cameFromFocusedRound) {
+      // Mid-round: back to the FOCUSED list to pick the next account. The
+      // accounts page consumes ?focus and drops it by itself once nothing is
+      // left to reconcile anywhere, so a finished round ends on the ordinary
+      // page without this side knowing the round's state.
+      const params = new URLSearchParams(preserveRuntimeControlParams(searchParams));
+      params.set('focus', 'reconcile');
+      navigate({ pathname: '/accounts', search: params.toString() }, { state: backState });
+      return;
+    }
     if (cameFromAccounts) {
       // Return whence the user came: the Accounts page sent them here for ONE
       // account, so leaving that account means leaving this page too.
@@ -277,7 +294,7 @@ export default function Reconciliation() {
     setSelectedAccountId(null);
     setSearchParams(prev => preserveRuntimeControlParams(prev));
     window.scrollTo(0, 0);
-  }, [cameFromAccounts, searchParams, navigate, setSearchParams, backState]);
+  }, [cameFromFocusedRound, cameFromAccounts, searchParams, navigate, setSearchParams, backState]);
 
   /**
    * The remedy on the genuinely-empty state: there is nowhere on THIS page to
@@ -374,10 +391,21 @@ export default function Reconciliation() {
    * ending balance being written down, and a reconciliation settled against a
    * figure nobody read is the thing this whole change exists to prevent.
    */
+  /**
+   * True while the finalize write is in flight — held in state so the modal's
+   * button can say "Completing…" and refuse seconds. A first-ever finalize
+   * converts an account's whole marked history (the owner's ran to 7,199
+   * rows) and takes real seconds server-side; without this, every extra
+   * press fired ANOTHER finalize RPC, each queueing behind the first one's
+   * account lock, and the screen read as frozen the whole time.
+   */
+  const [finalizing, setFinalizing] = useState(false);
+
   const handleFinalize = useCallback(async () => {
-    if (!selectedAccountId || !balanceConfirmed || confirmedBalance == null) {
+    if (!selectedAccountId || !balanceConfirmed || confirmedBalance == null || finalizing) {
       return;
     }
+    setFinalizing(true);
     try {
       // Await the write — success feedback must not fire on a failed save.
       const reconciled = await finalizeReconciliation(
@@ -396,9 +424,11 @@ export default function Reconciliation() {
       handleBack();
     } catch (error) {
       showError(error);
+    } finally {
+      setFinalizing(false);
     }
   }, [
-    selectedAccountId, balanceConfirmed, confirmedBalance, finalizeReconciliation,
+    selectedAccountId, balanceConfirmed, confirmedBalance, finalizing, finalizeReconciliation,
     handleBack, showSuccess, showError
   ]);
 
@@ -814,6 +844,7 @@ export default function Reconciliation() {
           awaitingFinalizeCount={clearedSummary?.awaitingFinalizeCount ?? 0}
           onClose={() => setShowFinalizationModal(false)}
           onFinalize={handleFinalize}
+          finalizing={finalizing}
           onCreateAdjustment={handleCreateAdjustment}
         />
       )}

--- a/src/pages/__tests__/Reconciliation.round.test.tsx
+++ b/src/pages/__tests__/Reconciliation.round.test.tsx
@@ -1,0 +1,216 @@
+/**
+ * The reconcile ROUND, and the finalize button that stopped lying.
+ *
+ * Owner, 19 Aug, after the review round shipped: "Can you check if this is
+ * how it also works when reconciling an account / accounts" — it did not,
+ * and now does: from the FOCUSED accounts list, finishing (or backing out
+ * of) one account's reconciliation returns to that list, still focused, to
+ * pick the next; with nothing left anywhere the round is over and the
+ * ordinary Accounts page stands.
+ *
+ * And the same evening's bug, in his words: "when I press 'complete
+ * reconciliation' it has been freezing and nothing happening. I pressed it
+ * about 10-20 times and eventually it kind of completed." A first-ever
+ * finalize converts thousands of rows and takes real seconds server-side;
+ * the button now says "Completing…", refuses seconds, and a stack of
+ * presses fires exactly ONE write.
+ *
+ * Every name and figure here is invented: this repo is public.
+ */
+
+import React from 'react';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { render, screen, fireEvent, act, waitFor } from '@testing-library/react';
+import { MemoryRouter, Route, Routes, useLocation } from 'react-router-dom';
+import { PreferencesProvider } from '../../contexts/PreferencesContext';
+import { ToastProvider } from '../../contexts/ToastContext';
+import { NotificationProvider } from '../../contexts/NotificationContext';
+import Reconciliation from '../Reconciliation';
+import Accounts from '../Accounts';
+import { __setAppContextValue, __resetAppContextValue } from '../../test/mocks/AppContextSupabase';
+import type { Account, Transaction } from '../../types';
+
+const ACCOUNT: Account = {
+  id: 'acc-round',
+  name: 'Roundabout Invented',
+  type: 'current',
+  balance: 0,
+  currency: 'GBP',
+  institution: 'Invented Bank',
+  lastUpdated: new Date('2026-05-01'),
+  openingBalance: 0,
+  isActive: true,
+  bankBalance: 40,
+  bankBalanceDate: '2026-05-01',
+};
+
+const row = (id: string, over: Partial<Transaction> = {}): Transaction => ({
+  id,
+  accountId: ACCOUNT.id,
+  date: new Date('2026-05-04'),
+  amount: 20,
+  description: `Invented ${id}`,
+  category: 'det-sundries',
+  type: 'income',
+  cleared: true,
+  reconciled: false,
+  ...over,
+});
+
+const AccountsProbe = (): React.JSX.Element => {
+  const location = useLocation();
+  return <div data-testid="accounts-probe">{location.search}</div>;
+};
+
+const renderRound = (search: string) =>
+  render(
+    <MemoryRouter initialEntries={[`/reconciliation${search}`]}>
+      <PreferencesProvider>
+        <ToastProvider>
+          <NotificationProvider>
+            <Routes>
+              <Route path="/reconciliation" element={<Reconciliation />} />
+              <Route path="/accounts" element={<AccountsProbe />} />
+            </Routes>
+          </NotificationProvider>
+        </ToastProvider>
+      </PreferencesProvider>
+    </MemoryRouter>
+  );
+
+beforeEach(() => {
+  localStorage.clear();
+});
+
+afterEach(() => {
+  __resetAppContextValue();
+});
+
+describe('Reconciliation — the round from the focused accounts list', () => {
+  it('finishing returns to the focused list, to pick the next account', async () => {
+    __setAppContextValue({
+      accounts: [ACCOUNT],
+      transactions: [row('t1'), row('t2')],
+      finalizeReconciliation: vi.fn(async () => 2),
+      isLoading: false,
+    });
+
+    renderRound(`?account=${ACCOUNT.id}&from=accounts&back=accounts-reconcile`);
+    fireEvent.click(screen.getByRole('button', { name: 'Confirm' }));
+    fireEvent.click(screen.getByRole('button', { name: /Finalize Reconciliation/ }));
+    await act(async () => {
+      fireEvent.click(screen.getByText('Complete Reconciliation'));
+    });
+
+    expect(screen.getByTestId('accounts-probe')).toHaveTextContent('focus=reconcile');
+  });
+
+  it('backing out mid-account also returns to the focused list — it is where the user came from', () => {
+    __setAppContextValue({
+      accounts: [ACCOUNT],
+      transactions: [row('t1')],
+      isLoading: false,
+    });
+
+    renderRound(`?account=${ACCOUNT.id}&from=accounts&back=accounts-reconcile`);
+    fireEvent.click(screen.getByRole('button', { name: /Back/ }));
+
+    expect(screen.getByTestId('accounts-probe')).toHaveTextContent('focus=reconcile');
+  });
+
+  it('without the marker, leaving goes to the ordinary Accounts page, exactly as before', () => {
+    __setAppContextValue({
+      accounts: [ACCOUNT],
+      transactions: [row('t1')],
+      isLoading: false,
+    });
+
+    renderRound(`?account=${ACCOUNT.id}&from=accounts`);
+    fireEvent.click(screen.getByRole('button', { name: /Back/ }));
+
+    expect(screen.getByTestId('accounts-probe')).not.toHaveTextContent('focus');
+  });
+});
+
+describe('Reconciliation — Complete refuses seconds while the write is in flight', () => {
+  it('says "Completing…", disables, and a stack of presses fires ONE write', async () => {
+    let release: (value: number) => void = () => {};
+    const finalizeReconciliation = vi.fn(
+      () => new Promise<number>(resolve => { release = resolve; })
+    );
+    __setAppContextValue({
+      accounts: [ACCOUNT],
+      transactions: [row('t1'), row('t2')],
+      finalizeReconciliation,
+      isLoading: false,
+    });
+
+    renderRound(`?account=${ACCOUNT.id}`);
+    fireEvent.click(screen.getByRole('button', { name: 'Confirm' }));
+    fireEvent.click(screen.getByRole('button', { name: /Finalize Reconciliation/ }));
+    fireEvent.click(screen.getByText('Complete Reconciliation'));
+
+    // In flight: the button says what it is doing and refuses more presses —
+    // the owner's 7,199-row finalize took seconds and got pressed 10-20
+    // times, each press another RPC queueing behind the first one's locks.
+    const busy = await screen.findByRole('button', { name: 'Completing…' });
+    expect(busy).toBeDisabled();
+    fireEvent.click(busy);
+    fireEvent.click(busy);
+    expect(finalizeReconciliation).toHaveBeenCalledTimes(1);
+
+    await act(async () => { release(2); });
+    expect(finalizeReconciliation).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('Accounts — ?focus=reconcile resumes the round', () => {
+  const OTHER: Account = {
+    ...ACCOUNT, id: 'acc-clean', name: 'Clean Invented', institution: 'Other Bank',
+  };
+
+  const renderAccountsWith = (search: string) =>
+    render(
+      <MemoryRouter initialEntries={[`/accounts${search}`]}>
+        <PreferencesProvider>
+          <ToastProvider>
+            <Accounts />
+          </ToastProvider>
+        </PreferencesProvider>
+      </MemoryRouter>
+    );
+
+  it('while an account still carries unreconciled work', async () => {
+    __setAppContextValue({
+      accounts: [ACCOUNT, OTHER],
+      transactions: [
+        row('t1', { cleared: false }),
+        row('t2', { accountId: OTHER.id, reconciled: true }),
+      ],
+      isLoading: false,
+    });
+
+    renderAccountsWith('?focus=reconcile');
+    await screen.findByRole('button', { name: /Showing to reconcile — show all/ });
+    expect(screen.getByRole('heading', { level: 3, name: ACCOUNT.name })).toBeInTheDocument();
+    expect(screen.queryByRole('heading', { level: 3, name: OTHER.name })).not.toBeInTheDocument();
+  });
+
+  it('with everything reconciled, the round is over — the ordinary page', async () => {
+    __setAppContextValue({
+      accounts: [ACCOUNT, OTHER],
+      transactions: [
+        row('t1', { reconciled: true }),
+        row('t2', { accountId: OTHER.id, reconciled: true }),
+      ],
+      isLoading: false,
+    });
+
+    renderAccountsWith('?focus=reconcile');
+    await screen.findByRole('heading', { level: 3, name: ACCOUNT.name });
+    await waitFor(() => {
+      expect(screen.getByRole('heading', { level: 3, name: OTHER.name })).toBeInTheDocument();
+    });
+    expect(screen.queryByRole('button', { name: /Showing to reconcile — show all/ })).not.toBeInTheDocument();
+  });
+});

--- a/supabase/migrations/20260819230000_finalize_reconciliation_set_based.sql
+++ b/supabase/migrations/20260819230000_finalize_reconciliation_set_based.sql
@@ -1,0 +1,250 @@
+-- ============================================================================
+-- finalize_reconciliation, SET-BASED — the freeze the owner pressed through
+-- ============================================================================
+--
+-- MEASURED INCIDENT (19 Aug 2026): finalizing a first-ever reconciliation over
+-- 7,199 marked rows froze the screen. The owner pressed Complete "10-20
+-- times"; every press fired another RPC, each queueing behind the first one's
+-- `SELECT ... FOR UPDATE` on the account row, until the first finally
+-- committed and the rest found nothing left to convert.
+--
+-- THE COST WAS THE LOOP. 20260810200000's finalize_reconciliation walked the
+-- marked rows one at a time: one UPDATE statement per row, then one
+-- write_financial_audit call per row — and each of those audit calls resolves
+-- the caller's identity again (a GUC read plus a users lookup) before its
+-- INSERT. 7,199 rows meant ~14,400 statements and 7,199 identity resolutions
+-- inside one transaction. This migration replaces the loop with ONE update
+-- and ONE audit insert, keeping every property the loop had:
+--
+--   * the SAME rows convert (identical predicate, is_cleared AND
+--     is_reconciled IS NOT DISTINCT FROM false — NULL rows are pre-split
+--     history and stay untouched);
+--   * the SAME audit fidelity: one financial_audit_log row PER TRANSACTION,
+--     carrying the full before and after row images, exactly as the loop
+--     wrote them — nothing is summarised away;
+--   * the SAME account stamp and account audit row;
+--   * the SAME return shape, and all of it still one database transaction.
+--
+-- write_financial_audit stays the sole PER-ROW write path into
+-- financial_audit_log; this adds its batch sibling, write_financial_audit_
+-- batch, with the identity block copied verbatim — checked ONCE for the
+-- batch, which is precisely the saving: the caller's identity does not
+-- change between row 1 and row 7,199.
+--
+-- The sweep trigger (trg_sweep_reconciled_into_archive) is untouched and
+-- still fires per updated row; it is a BEFORE trigger, so the after-images
+-- audited here include any archive flag it sets — as they did under the loop.
+-- ============================================================================
+
+-- ── Guards: refuse to run against a database this was not written for ──────
+DO $$
+BEGIN
+  -- 1. The function being replaced exists with the expected signature.
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_proc p JOIN pg_namespace n ON n.oid = p.pronamespace
+     WHERE n.nspname = 'public' AND p.proname = 'finalize_reconciliation'
+       AND pg_get_function_identity_arguments(p.oid) = 'p_user_id uuid, p_account_id uuid, p_ending_balance numeric, p_reconciled_on date'
+  ) THEN
+    RAISE EXCEPTION 'finalize_reconciliation(uuid, uuid, numeric, date) not found — apply 20260810200000 first';
+  END IF;
+
+  -- 2. The definition being replaced is the one this file was written
+  --    against (the per-row loop). If it has since changed, STOP and
+  --    reconcile this rewrite with the newer definition by hand.
+  IF (
+    SELECT pg_get_functiondef(p.oid)
+      FROM pg_proc p JOIN pg_namespace n ON n.oid = p.pronamespace
+     WHERE n.nspname = 'public' AND p.proname = 'finalize_reconciliation'
+       AND pg_get_function_identity_arguments(p.oid) = 'p_user_id uuid, p_account_id uuid, p_ending_balance numeric, p_reconciled_on date'
+  ) NOT LIKE '%FOR v_old IN%' THEN
+    RAISE EXCEPTION 'finalize_reconciliation is not 20260810200000''s per-row loop — this rewrite was authored against that definition; reconcile by hand';
+  END IF;
+
+  -- 3. The audit function whose identity block is copied here exists.
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_proc p JOIN pg_namespace n ON n.oid = p.pronamespace
+     WHERE n.nspname = 'public' AND p.proname = 'write_financial_audit'
+       AND pg_get_function_identity_arguments(p.oid) = 'p_user_id uuid, p_entity text, p_entity_id uuid, p_action text, p_before jsonb, p_after jsonb'
+  ) THEN
+    RAISE EXCEPTION 'write_financial_audit(uuid, text, uuid, text, jsonb, jsonb) not found — apply 20260725120000 first';
+  END IF;
+
+  -- 4. The audit table carries exactly the columns the batch insert names.
+  IF (
+    SELECT count(*) FROM information_schema.columns
+     WHERE table_schema = 'public' AND table_name = 'financial_audit_log'
+       AND column_name IN ('user_id','actor_clerk_id','entity','entity_id','action','before_data','after_data')
+  ) <> 7 THEN
+    RAISE EXCEPTION 'financial_audit_log does not carry the seven columns this batch insert names';
+  END IF;
+END $$;
+
+BEGIN;
+
+-- ── The batch sibling of write_financial_audit ──────────────────────────────
+-- IDENTITY BLOCK COPIED VERBATIM from 20260725120000's write_financial_audit
+-- — the whole point of the batch is that it runs once instead of once per
+-- row, so it must be the SAME check or the batch would be the weaker door.
+CREATE OR REPLACE FUNCTION public.write_financial_audit_batch(
+  p_user_id uuid,
+  p_entries jsonb
+) RETURNS void
+LANGUAGE plpgsql SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  -- Cheap: a GUC read, no table access. Deliberately resolved before the
+  -- users lookup so bulk service-role imports never pay for one.
+  v_clerk text := public.requesting_clerk_id();
+  v_role  text;
+  v_user  uuid;
+BEGIN
+  IF v_clerk IS NOT NULL THEN
+    v_user := public.requesting_user_id();
+    IF v_user IS NULL OR p_user_id IS DISTINCT FROM v_user THEN
+      RAISE EXCEPTION 'audit_identity_mismatch'
+        USING ERRCODE = '42501',
+              HINT = 'A financial audit row may only be written for the user in the caller''s own session token.';
+    END IF;
+  ELSE
+    v_role := COALESCE(
+      NULLIF(current_setting('request.jwt.claims', true), '')::jsonb ->> 'role',
+      NULLIF(current_setting('role', true), 'none')
+    );
+    IF v_role IS NOT NULL AND v_role <> 'service_role' THEN
+      RAISE EXCEPTION 'audit_identity_required'
+        USING ERRCODE = '42501',
+              HINT = 'Only an end-user session or the service role may write financial audit rows.';
+    END IF;
+    v_user := p_user_id;
+  END IF;
+
+  INSERT INTO public.financial_audit_log
+    (user_id, actor_clerk_id, entity, entity_id, action, before_data, after_data)
+  SELECT v_user, v_clerk, e.entity, e.entity_id, e.action, e.before_data, e.after_data
+    FROM jsonb_to_recordset(COALESCE(p_entries, '[]'::jsonb))
+      AS e(entity text, entity_id uuid, action text, before_data jsonb, after_data jsonb);
+END;
+$$;
+
+COMMENT ON FUNCTION public.write_financial_audit_batch(uuid, jsonb) IS
+  'write_financial_audit''s batch sibling: the same identity verification, run once for a set of rows instead of once per row. Exists for the one caller whose row count is unbounded — finalize_reconciliation — where per-row identity resolution was measured freezing a 7,199-row finalize. Entries are [{entity, entity_id, action, before_data, after_data}].';
+
+REVOKE ALL ON FUNCTION public.write_financial_audit_batch(uuid, jsonb) FROM public, anon;
+GRANT EXECUTE ON FUNCTION public.write_financial_audit_batch(uuid, jsonb) TO authenticated, service_role;
+
+-- ── finalize_reconciliation, one UPDATE and one audit insert ────────────────
+-- Everything 20260810200000's comment promised still holds: it commits the
+-- account's marked-but-uncommitted rows, records the statement they were
+-- settled against, is all-or-nothing, and is balance-neutral.
+CREATE OR REPLACE FUNCTION public.finalize_reconciliation(
+  p_user_id uuid,
+  p_account_id uuid,
+  p_ending_balance numeric,
+  p_reconciled_on date
+)
+RETURNS jsonb
+LANGUAGE plpgsql SECURITY INVOKER
+SET search_path = public
+AS $$
+DECLARE
+  v_before public.accounts;
+  v_after public.accounts;
+  v_count integer := 0;
+  v_entries jsonb := '[]'::jsonb;
+BEGIN
+  IF p_ending_balance IS NULL THEN
+    -- Not a defensive nicety: the ending balance is the whole point of
+    -- finishing, and a NULL one would record "reconciled against nothing".
+    RAISE EXCEPTION 'ending_balance_required' USING ERRCODE = '22023';
+  END IF;
+
+  SELECT * INTO v_before
+    FROM public.accounts
+   WHERE id = p_account_id AND user_id = p_user_id
+   FOR UPDATE;
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'account_not_found_or_not_owned' USING ERRCODE = 'P0002';
+  END IF;
+
+  -- ONE statement: snapshot the before-images, convert the rows, and build
+  -- the per-row audit entries from the pair. The BEFORE sweep trigger fires
+  -- per updated row exactly as it did under the loop, and its effect is in
+  -- the after-image because RETURNING reads the row the trigger produced.
+  WITH before AS (
+    SELECT * FROM public.transactions
+     WHERE user_id = p_user_id
+       AND account_id = p_account_id
+       AND is_cleared = true
+       AND is_reconciled IS NOT DISTINCT FROM false
+     FOR UPDATE
+  ),
+  updated AS (
+    UPDATE public.transactions t
+       SET is_reconciled = true,
+           updated_at = now()
+      FROM before b
+     WHERE t.id = b.id
+    RETURNING t.*
+  )
+  SELECT count(*)::int,
+         COALESCE(jsonb_agg(jsonb_build_object(
+           'entity', 'transaction',
+           'entity_id', u.id,
+           'action', 'update',
+           'before_data', to_jsonb(b),
+           'after_data', to_jsonb(u)
+         )), '[]'::jsonb)
+    INTO v_count, v_entries
+    FROM updated u
+    JOIN before b ON b.id = u.id;
+
+  IF v_count > 0 THEN
+    PERFORM public.write_financial_audit_batch(p_user_id, v_entries);
+  END IF;
+
+  UPDATE public.accounts
+     SET last_reconciled_date = COALESCE(p_reconciled_on, CURRENT_DATE),
+         last_reconciled_balance = p_ending_balance,
+         updated_at = now()
+   WHERE id = p_account_id AND user_id = p_user_id
+  RETURNING * INTO v_after;
+
+  PERFORM public.write_financial_audit(
+    p_user_id, 'account', p_account_id, 'update', to_jsonb(v_before), to_jsonb(v_after)
+  );
+
+  RETURN jsonb_build_object(
+    'reconciled', v_count,
+    'ending_balance', p_ending_balance,
+    'reconciled_on', COALESCE(p_reconciled_on, CURRENT_DATE)
+  );
+END;
+$$;
+
+COMMENT ON FUNCTION public.finalize_reconciliation(uuid, uuid, numeric, date) IS
+  'Commit an account''s marked-but-uncommitted transactions and record the statement the reconciliation was settled against, in one database transaction. Set-based since 20260819230000 (one UPDATE, one batch audit insert — a 7,199-row finalize froze under the per-row loop); converts only rows whose is_reconciled is explicitly false (NULL rows are pre-split history the archive and the counts already treat as reconciled). Balance-neutral: writes one flag per row and two records on the account, and never touches balance or initial_balance.';
+
+REVOKE ALL ON FUNCTION public.finalize_reconciliation(uuid, uuid, numeric, date) FROM public, anon;
+GRANT EXECUTE ON FUNCTION public.finalize_reconciliation(uuid, uuid, numeric, date) TO authenticated, service_role;
+
+COMMIT;
+
+-- ============================================================================
+-- Verification — run after applying.
+-- ============================================================================
+
+-- 1. Both functions exist; finalize no longer contains the per-row loop.
+-- Expected: two rows; finalize's definition contains 'jsonb_agg' and not 'FOR v_old IN'.
+-- SELECT p.proname, pg_get_functiondef(p.oid) LIKE '%FOR v_old IN%' AS still_loops
+--   FROM pg_proc p JOIN pg_namespace n ON n.oid = p.pronamespace
+--  WHERE n.nspname = 'public'
+--    AND p.proname IN ('finalize_reconciliation', 'write_financial_audit_batch');
+
+-- 2. anon can execute neither.
+-- Expected: zero rows.
+-- SELECT p.proname
+--   FROM pg_proc p JOIN pg_namespace n ON n.oid = p.pronamespace
+--  WHERE n.nspname = 'public'
+--    AND p.proname IN ('finalize_reconciliation', 'write_financial_audit_batch')
+--    AND has_function_privilege('anon', p.oid, 'EXECUTE');


### PR DESCRIPTION
## The freeze, diagnosed twice over

The owner's report: **"when I press 'complete reconciliation' it has been freezing and nothing happening. I pressed it about 10-20 times and eventually it kind of completed"** — on an account whose first-ever finalize converted **7,199 rows**. His data is safe (the first RPC committed atomically; the rest found nothing left), but two real defects produced the experience:

### 1. The server looped — migration `20260819230000`

`finalize_reconciliation` walked the marked rows one at a time: one UPDATE per row, then one `write_financial_audit` call per row, each re-resolving the caller's identity — ~14,400 statements plus 7,199 identity resolutions in one transaction. The rewrite is **one UPDATE and one batch audit insert**, keeping every property the loop had:

- same predicate (only `is_cleared AND is_reconciled IS NOT DISTINCT FROM false`);
- same **per-row audit fidelity** — one `financial_audit_log` row per transaction with full before/after images, via `write_financial_audit_batch`, the audit door's new sibling with the identity block copied verbatim and checked once;
- same account stamp, account audit row, return shape; still one database transaction; the sweep trigger untouched.

Guards refuse to run unless the definition being replaced is exactly 20260810200000's loop. **Rehearsed on the throwaway Postgres**: applied clean over the full migration history, and a 500-row functional smoke converted exactly the cleared rows, left the uncleared one untouched, wrote 500 full-image audit rows plus the account's, and stamped the statement (all rolled back).

**Ordering: none.** The RPC's signature and return shape are unchanged, so this PR deploys first and the speedup lands whenever the migration is applied.

### 2. The button sat silent

No in-flight state, no re-entry guard — every extra press fired another RPC, each queueing behind the first one's account lock. Complete now says **"Completing…"**, disables, and a stack of presses fires exactly **one** write (pinned by a deferred-promise spec that presses three times mid-flight).

## And the reconcile round

**"Can you check if this is how it also works when reconciling an account / accounts"** — it did not: the page always returned to the plain Accounts list. Now, from the **focused** list ("Reconcile N instead"), the reconcile links carry `back=accounts-reconcile`; finishing — or backing out mid-account — returns to `/accounts?focus=reconcile`, which resumes focus only while accounts still carry unreconciled work, and is the ordinary Accounts page once none do. The `?focus` consumer on Accounts now serves both rounds. From the ordinary list, nothing changes — pinned both ways.

## Verified

69 specs across the six touched suites (6 new: the round both ways plus the no-marker control, the one-write busy spec, and the two `?focus=reconcile` resumption states), strict types, lint, and the SQL rehearsal above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
