### PR TITLE
fix(net-worth): the axis floor belongs to the data, not the tick step

### DIFF
--- a/src/components/dashboard/reportWidgets/DashboardReportWidgets.tsx
+++ b/src/components/dashboard/reportWidgets/DashboardReportWidgets.tsx
@@ -16,7 +16,7 @@ import { useCurrencyDecimal } from '../../../hooks/useCurrencyDecimal';
 import { categoricalColor, MAX_CATEGORICAL_SERIES, useCategoricalRamp, SEMANTIC_SERIES, useChartTooltipStyle } from '../../charts/chartColors';
 import { singlePointDot } from '../../charts/singlePointDots';
 import { buildMonthlyTrend } from '../../../utils/monthlyTrend';
-import { buildNetWorthSnapshots, netWorthAxisTicks, netWorthPointToken } from '../../../utils/netWorthSeries';
+import { buildNetWorthSnapshots, netWorthAxisTicks, netWorthPointToken, netWorthValueAxis } from '../../../utils/netWorthSeries';
 import { computeExpenseCategoryNetTotals } from '../../../utils/categoryNetting';
 import { expandSplitTransactions } from '../../../utils/transactionSplits';
 import { formatDecimal } from '../../../utils/decimal-format';
@@ -166,11 +166,16 @@ export function NetWorthWidget({ picker, pin }: {
                 format follows the span (Design, 17 Aug §2.3). */}
             <XAxis dataKey="label" tick={{ fill: '#6B7280', fontSize: 10 }} minTickGap={32} {...netWorthAxisTicks(snapshots)} />
             {/* The domain follows the DATA and dips below zero only when the
-                data does (§2.4): recharts' nice-tick rounding was answering
-                one early negative point with a −6.0M floor, spending a
-                quarter of the plot on nothing and flattening the curve the
-                chart exists to show. */}
-            <YAxis tick={{ fill: '#6B7280', fontSize: 10 }} tickFormatter={compactTick} width={44} domain={[(dataMin: number) => Math.min(0, dataMin), 'auto']} />
+                data does (§2.4). The ticks are OURS (netWorthValueAxis): the
+                function-form domain alone did not stop recharts' nice-tick
+                rounding from answering one shallow early dip with a floor a
+                full tick step below zero — a quarter of the plot spent on
+                nothing, flattening the curve the chart exists to show
+                (owner, 19 Aug, on his real ledger). */}
+            <YAxis
+              tick={{ fill: '#6B7280', fontSize: 10 }} tickFormatter={compactTick} width={44}
+              {...netWorthValueAxis(snapshots.map(s => s.netWorth))}
+            />
             <Tooltip contentStyle={chartTooltipStyle} separator=": " formatter={(v: number | string) => formatCurrency(typeof v === 'number' ? v : Number(v))} />
             <Line type="monotone" dataKey="netWorth" name="Net Worth" stroke={lineStroke} strokeWidth={2} dot={singlePointDot(snapshots, lineStroke)} isAnimationActive={false} />
           </LineChart>

--- a/src/pages/NetWorthReport.tsx
+++ b/src/pages/NetWorthReport.tsx
@@ -19,7 +19,7 @@ import { singlePointDot } from '../components/charts/singlePointDots';
 import { toDecimal } from '../utils/decimal';
 import { formatDecimal } from '../utils/decimal-format';
 import { preserveDemoParam } from '../utils/navigation';
-import { buildNetWorthSnapshots, netWorthAxisTicks, netWorthPointToken } from '../utils/netWorthSeries';
+import { buildNetWorthSnapshots, netWorthAxisTicks, netWorthPointToken, netWorthValueAxis } from '../utils/netWorthSeries';
 import { useArrivalAction } from '../hooks/useArrivalFocus';
 import { resolveEffectiveOpeningDates } from '../utils/openingDates';
 import { TrendingUpIcon, ChevronRightIcon } from '../components/icons';
@@ -349,8 +349,22 @@ export default function NetWorthReport({ picker, focus }: ReportViewProps): Reac
                 {/* Years for a multi-year window (§2.3) — same helper as the
                     Dashboard widget, so card and report tick identically. */}
                 <XAxis dataKey="label" tick={{ fill: '#6B7280', fontSize: 12 }} minTickGap={24} {...netWorthAxisTicks(snapshots)} />
-                {/* Below zero only when the data goes there (§2.4). */}
-                <YAxis tick={{ fill: '#6B7280', fontSize: 12 }} tickFormatter={compactTick} width={70} domain={[(dataMin: number) => Math.min(0, dataMin), 'auto']} />
+                {/* Below zero only when the data goes there (§2.4) — with
+                    OUR ticks (netWorthValueAxis), because recharts' own
+                    rounding answered a shallow early dip with a floor a
+                    full tick step down. All three plotted series feed the
+                    scale. */}
+                <YAxis
+                  tick={{ fill: '#6B7280', fontSize: 12 }} tickFormatter={compactTick} width={70}
+                  {...netWorthValueAxis(
+                    // The scale covers what is DRAWN: the context series join
+                    // it only when their lines are on, or the net line would
+                    // float in the bottom half of an axis sized for assets.
+                    showDetail
+                      ? snapshots.flatMap(s => [s.netWorth, s.assets, s.liabilities])
+                      : snapshots.map(s => s.netWorth)
+                  )}
+                />
                 {/* The radius-only contentStyle LOOKED themed and set no
                     colour — the same survivor pattern the 16 Aug sweep found
                     on three other report pages. */}

--- a/src/utils/netWorthSeries.test.ts
+++ b/src/utils/netWorthSeries.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { buildNetWorthSnapshots, netWorthAxisTicks } from './netWorthSeries';
+import { buildNetWorthSnapshots, netWorthAxisTicks, netWorthValueAxis } from './netWorthSeries';
 import type { Account, Transaction } from '../types';
 import type { PeriodRange } from '../hooks/usePeriod';
 
@@ -141,5 +141,49 @@ describe('netWorthAxisTicks — the tick format follows the span', () => {
     const snaps = seeded({ from: D(2026, 8, 1), to: D(2026, 8, 17) });
     expect(netWorthAxisTicks(snaps)).toEqual({});
     expect(snaps[snaps.length - 1].label).toMatch(/^17 /);
+  });
+});
+
+describe('netWorthValueAxis — the floor belongs to the data, not the tick step', () => {
+  it('a shallow dip below zero never buys a full tick-step band (the measured floor)', () => {
+    // The owner's real SHAPE in invented figures: an early dip a small
+    // fraction of one tick step deep, a large positive peak at the end.
+    // recharts' own rounding answered this with a floor one full step
+    // below zero; ours grazes just under the dip.
+    const axis = netWorthValueAxis([-90_000, 2_000_000, 21_000_000]);
+    expect(Math.min(...axis.ticks)).toBe(0);
+    expect(axis.domain[0]).toBeLessThan(-90_000);
+    expect(axis.domain[0]).toBeGreaterThan(-600_000);
+    expect(axis.domain[1]).toBe(Math.max(...axis.ticks));
+    expect(axis.domain[1]).toBeGreaterThanOrEqual(21_000_000);
+    expect(axis.ticks).toContain(0);
+  });
+
+  it('a genuinely deep negative earns real negative ticks', () => {
+    const axis = netWorthValueAxis([-8_000_000, 17_000_000]);
+    expect(Math.min(...axis.ticks)).toBeLessThan(0);
+    expect(axis.domain[0]).toBeLessThan(-8_000_000);
+  });
+
+  it('all-positive data keeps the zero floor it always had', () => {
+    const axis = netWorthValueAxis([50_000, 900_000]);
+    expect(axis.domain[0]).toBe(0);
+    expect(axis.ticks[0]).toBe(0);
+    expect(axis.domain[1]).toBeGreaterThanOrEqual(900_000);
+  });
+
+  it('ticks are nice multiples of one step, zero among them, top covering the data', () => {
+    const axis = netWorthValueAxis([-90_000, 21_000_000]);
+    const step = axis.ticks[1] - axis.ticks[0];
+    axis.ticks.forEach((tick, i) => {
+      expect(tick).toBeCloseTo(axis.ticks[0] + i * step, 6);
+    });
+    expect(axis.ticks).toContain(0);
+    expect(Object.is(axis.ticks.find(t => t === 0), -0)).toBe(false);
+  });
+
+  it('an empty or all-zero series stays sane', () => {
+    expect(netWorthValueAxis([])).toEqual({ domain: [0, 1], ticks: [0, 1] });
+    expect(netWorthValueAxis([0, 0])).toEqual({ domain: [0, 1], ticks: [0, 1] });
   });
 });

--- a/src/utils/netWorthSeries.ts
+++ b/src/utils/netWorthSeries.ts
@@ -160,6 +160,61 @@ export function buildNetWorthSnapshots(
  * and for click identity — labels are what `activeLabel` hands back, so they
  * must stay unique per point; only the AXIS text compresses.
  */
+/**
+ * The classic 1-2-5 "nice" step. Deliberately NOT recharts' ladder, which
+ * includes 2.5: a 2.5K step renders "0 · 3K · 5K · 8K · 10K" through the
+ * compact tick formatter's whole-unit rounding — an axis that looks
+ * mis-spaced. Every 1-2-5 multiple survives the formatter intact.
+ */
+const niceStep = (raw: number): number => {
+  const power = Math.pow(10, Math.floor(Math.log10(raw)));
+  const fraction = raw / power;
+  return power * (fraction <= 1 ? 1 : fraction <= 2 ? 2 : fraction <= 5 ? 5 : 10);
+};
+
+/**
+ * Y-axis domain and ticks for a value series that MAY dip below zero.
+ *
+ * Exists because recharts' own nice-tick rounding answers any dip below
+ * zero, however shallow, by extending the axis floor to the next full tick
+ * step DOWN. Measured on the owner's real ledger (19 Aug): an early dip a
+ * small fraction of one tick step deep bought the Net Worth chart a floor
+ * a FULL step below zero — a quarter of the plot spent on nothing,
+ * flattening the curve the chart exists to show. The
+ * `domain={[dataMin => Math.min(0, dataMin), 'auto']}` form does NOT
+ * prevent this: it sets the data floor, and the tick generator still
+ * rounds below it.
+ *
+ * So the ticks are supplied, not delegated: nice multiples of one step,
+ * covering the top of the data, with 0 always among them — and the floor is
+ * the DATA's own low point plus 2% breathing room, never a tick-step
+ * flourish. A shallow dip shows as a line grazing below the 0 gridline; a
+ * genuinely deep negative earns real negative ticks because they then fall
+ * inside the domain. All-positive data keeps the 0 floor it always had.
+ *
+ * Chart geometry, not money arithmetic — floats are fine here.
+ */
+export function netWorthValueAxis(values: number[]): { domain: [number, number]; ticks: number[] } {
+  const max = Math.max(0, ...values);
+  const min = Math.min(0, ...values);
+  const magnitude = Math.max(max, -min);
+  if (magnitude === 0) return { domain: [0, 1], ticks: [0, 1] };
+
+  const step = niceStep(magnitude / 5);
+  const top = max > 0 ? Math.ceil(max / step - 1e-9) * step : 0;
+  const bottom = min < 0 ? min - (top - min) * 0.02 : 0;
+
+  const ticks: number[] = [];
+  const first = Math.ceil(bottom / step - 1e-9);
+  const last = Math.round(top / step);
+  for (let i = first; i <= last; i++) {
+    // Integer multiples, so a long axis never drifts off its step — and
+    // −0 (which prints as "-0" through some formatters) normalised away.
+    ticks.push(i === 0 ? 0 : i * step);
+  }
+  return { domain: [bottom, top], ticks };
+}
+
 export function netWorthAxisTicks(snapshots: NetWorthSnapshot[]): {
   ticks?: string[];
   tickFormatter?: (label: string) => string;


### PR DESCRIPTION
## The question

The owner, on his real ledger: **"why in the net worth over time chart does the Y axis begin at -£6.0m? I had a negative net worth back then but it was like -£100k or so."**

## The answer

recharts' nice-tick rounding answers **any** dip below zero, however shallow, by extending the axis floor to the next full tick step down — and the steps on a large series are millions apiece, so a shallow dip buys a whole basement band: a quarter of the plot spent on nothing, flattening the curve the chart exists to show. The widget even carried a comment claiming `domain={[dataMin => Math.min(0, dataMin), 'auto']}` had fixed exactly this; it had not — the function form sets the *data* floor, and the tick generator still rounds below it.

## The fix

`netWorthValueAxis` supplies the ticks instead of delegating them:

- nice **1-2-5** multiples of one step, covering the top of the data, **zero always among them**;
- the floor is the **data's own low point** plus 2% breathing room — a shallow dip grazes below the 0 gridline instead of commandeering a band;
- a genuinely deep negative earns real negative ticks, because they then fall inside the domain;
- all-positive data keeps the 0 floor it always had.

The 1-2-5 ladder (dropping recharts' 2.5) is deliberate and measured: a 2.5K step rendered "0 · 3K · 5K · 8K · 10K" through the compact formatter's whole-unit rounding on the demo ledger.

Both charts use it — the Dashboard widget over its one series, and the full report over **what is actually drawn**: the assets/liabilities context series join the scale only when their lines are switched on, so the net line no longer floats in the bottom half of an axis sized for assets.

## Verified

5 new specs (the measured shallow-dip shape, deep negatives, all-positive, step/zero properties, empty-series sanity — 14 in the suite), strict types, lint, and the demo ledger's axis read live in the browser before and after the ladder change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
