### PR TITLE
feat(display): whole pounds, one checkbox per page — and the P&L's folding rows wear a band

### DIFF
--- a/src/components/dashboard/ImprovedDashboard.tsx
+++ b/src/components/dashboard/ImprovedDashboard.tsx
@@ -29,6 +29,7 @@ import EditTransactionModal from '../EditTransactionModal';
 import IncomeExpenseBreakdownModal from '../IncomeExpenseBreakdownModal';
 import { Modal, ModalBody } from '../common/Modal';
 import PeriodBar from '../../components/PeriodBar';
+import { WholePoundsToggle } from '../../contexts/WholePoundsContext';
 import NetWorthSummary from '../../components/NetWorthSummary';
 import AccountBreakdownModal, { type AccountBreakdownView } from '../../components/AccountBreakdownModal';
 import { PERIOD_LABELS, usePeriod } from '../../hooks/usePeriod';
@@ -707,7 +708,10 @@ export function ImprovedDashboard() {
     <div className="space-y-4 max-w-[1400px] mx-auto">
       {/* The one control that says what window this page is being read over.
           Directly under the page heading, so its position states its scope. */}
-      <PeriodBar picker={period} label="Period for this dashboard" />
+      <div className="flex flex-wrap items-center justify-between gap-2">
+        <PeriodBar picker={period} label="Period for this dashboard" />
+        <WholePoundsToggle />
+      </div>
 
       {/* Net worth and the two figures it is made of — one card, three
           columns. The navy slab this replaces put a second heavy horizontal

--- a/src/contexts/WholePoundsContext.tsx
+++ b/src/contexts/WholePoundsContext.tsx
@@ -1,0 +1,70 @@
+/* eslint-disable react-refresh/only-export-components -- a context file
+   exports its hook beside its provider, exactly as PreferencesContext does */
+import React, { createContext, useCallback, useContext, useMemo, useState } from 'react';
+import type { ReactNode } from 'react';
+import { preferences } from '../services/preferencesService';
+
+/**
+ * WHOLE POUNDS, PER PAGE.
+ *
+ * The owner's ask (19 Aug): "a check box somewhere to offer the user to hide
+ * decimal points. Sometimes, when looking at a lot of data, it is cleaner to
+ * look at rounded whole figures" — refined a message later to "the decimal
+ * display should be PAGE specific". So this is a SCOPE, not a global switch:
+ * each page wraps itself in one, remembers its own answer under its own key,
+ * and everything inside — the page's own figures and every widget it mounts —
+ * follows, because useCurrencyDecimal reads this context where it is called.
+ *
+ * Pennies are a DISPLAY choice here and nothing else: the ledger, exports,
+ * inputs and tooltips keep their exactness; only what formatCurrency prints
+ * inside a scope rounds (half-up, in utils/currency-decimal).
+ */
+
+interface WholePoundsScopeValue {
+  wholePounds: boolean;
+  setWholePounds: (value: boolean) => void;
+}
+
+/** Outside any scope: pennies stay, and the toggle (if rendered) does nothing. */
+const WholePoundsContext = createContext<WholePoundsScopeValue>({
+  wholePounds: false,
+  setWholePounds: () => {},
+});
+
+/** What useCurrencyDecimal reads: is this render inside a whole-pounds scope that is ON? */
+export const useWholePoundsDisplay = (): boolean => useContext(WholePoundsContext).wholePounds;
+
+/**
+ * One page's scope. `page` is the storage key's tail — give each page its own
+ * stable name ('dashboard', 'accounts', …) and its choice survives the session
+ * through the preferences document like every other display preference.
+ */
+export function WholePoundsScope({ page, children }: { page: string; children: ReactNode }): React.JSX.Element {
+  const key = `money_management_whole_pounds_${page}`;
+  const [wholePounds, setState] = useState((): boolean => preferences.getItem(key) === 'true');
+  const setWholePounds = useCallback((value: boolean): void => {
+    setState(value);
+    preferences.setItem(key, value ? 'true' : 'false');
+  }, [key]);
+  const value = useMemo(() => ({ wholePounds, setWholePounds }), [wholePounds, setWholePounds]);
+  return <WholePoundsContext.Provider value={value}>{children}</WholePoundsContext.Provider>;
+}
+
+/**
+ * The checkbox. Context-connected so a page can drop it into whichever
+ * toolbar suits without threading props through a 3,000-line component.
+ */
+export function WholePoundsToggle({ className = '' }: { className?: string }): React.JSX.Element {
+  const { wholePounds, setWholePounds } = useContext(WholePoundsContext);
+  return (
+    <label className={`flex items-center gap-1.5 text-xs text-gray-500 dark:text-gray-400 cursor-pointer select-none ${className}`}>
+      <input
+        type="checkbox"
+        checked={wholePounds}
+        onChange={event => setWholePounds(event.target.checked)}
+        className="rounded border-gray-300 dark:border-gray-600"
+      />
+      Whole pounds
+    </label>
+  );
+}

--- a/src/hooks/useCurrencyDecimal.ts
+++ b/src/hooks/useCurrencyDecimal.ts
@@ -1,5 +1,6 @@
 import { useCallback, useMemo } from 'react';
 import { usePreferences } from '../contexts/PreferencesContext';
+import { useWholePoundsDisplay } from '../contexts/WholePoundsContext';
 import { 
   convertCurrency, 
   convertMultipleCurrencies, 
@@ -19,13 +20,16 @@ export function useCurrencyDecimal(): {
   getCurrencySymbol: (currency: string) => string;
 } {
   const { currency: displayCurrency } = usePreferences();
+  // Whether this render sits inside a page's whole-pounds scope with the box
+  // ticked (WholePoundsContext) — a per-page display choice, owner 19 Aug.
+  const wholePounds = useWholePoundsDisplay();
   const logger = useMemoizedLogger('useCurrencyDecimal');
 
   // Format amount in display currency (accepts Decimal or number)
   const formatCurrency = useCallback((amount: DecimalInstance | number, originalCurrency?: string) => {
     const currencyToUse = originalCurrency || displayCurrency;
-    return formatCurrencyDecimal(amount, currencyToUse);
-  }, [displayCurrency]);
+    return formatCurrencyDecimal(amount, currencyToUse, { wholePounds });
+  }, [displayCurrency, wholePounds]);
 
   // Convert and format amount from one currency to display currency
   const convertAndFormat = useCallback(async (amount: DecimalInstance | number, fromCurrency: string) => {

--- a/src/pages/Accounts.tsx
+++ b/src/pages/Accounts.tsx
@@ -4,6 +4,7 @@ import { useApp } from '../contexts/AppContextSupabase';
 import { useToast } from '../contexts/ToastContext';
 import { dataPort } from '@data';
 import { preserveDemoParam } from '../utils/navigation';
+import { WholePoundsScope, WholePoundsToggle } from '../contexts/WholePoundsContext';
 import AddAccountModal from '../components/AddAccountModal';
 import AccountSettingsModal from '../components/AccountSettingsModal';
 import AccountBreakdownModal, { type AccountBreakdownView } from '../components/AccountBreakdownModal';
@@ -214,6 +215,17 @@ type DisplayedList =
   | { mode: 'grouped'; bands: DisplayedBand[] };
 
 export default function Accounts() {
+  // The whole-pounds scope must sit above every useCurrencyDecimal call,
+  // including this page's own — hence the thin shell (owner, 19 Aug:
+  // page-specific decimal display).
+  return (
+    <WholePoundsScope page="accounts">
+      <AccountsList />
+    </WholePoundsScope>
+  );
+}
+
+function AccountsList() {
   const { accounts, transactions, serverBalances, updateAccount, closeAccount, refreshAccountsAndTransactions, refreshCategories } = useApp();
   const { showError } = useToast();
   const { formatCurrency: formatDisplayCurrency, displayCurrency } = useCurrencyDecimal();
@@ -2649,6 +2661,7 @@ export default function Accounts() {
           >
             {showRowActions ? 'Hide account buttons' : 'Show account buttons'}
           </button>
+          <WholePoundsToggle className="shrink-0" />
         </div>
         {/* Search — the way to find one account among two hundred. On a
             phone it takes the first row, full width; the pills follow.

--- a/src/pages/Budget.tsx
+++ b/src/pages/Budget.tsx
@@ -15,6 +15,7 @@ import ZeroBasedBudgeting from '../components/ZeroBasedBudgeting';
 import type { Budget } from '../types';
 import { getEffectiveBudgetAmount } from '../utils/budgetAmounts';
 import PageWrapper from '../components/PageWrapper';
+import { WholePoundsScope, WholePoundsToggle } from '../contexts/WholePoundsContext';
 import PageTip from '../components/PageTip';
 import { calculateBudgetPercentage } from '../utils/calculations-decimal';
 import {
@@ -30,6 +31,17 @@ import { formatDecimal } from '../utils/decimal-format';
 import { SkeletonCard, SkeletonText } from '../components/loading/Skeleton';
 
 export default function Budget() {
+  // The whole-pounds scope must sit above every useCurrencyDecimal call,
+  // including this page's own — hence the thin shell (owner, 19 Aug:
+  // page-specific decimal display).
+  return (
+    <WholePoundsScope page="budget">
+      <BudgetView />
+    </WholePoundsScope>
+  );
+}
+
+function BudgetView() {
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [editingBudget, setEditingBudget] = useState<Budget | null>(null);
   const [activeTab, setActiveTab] = useState<'traditional' | 'envelope' | 'templates' | 'rollover' | 'alerts' | 'zero-based'>('traditional');
@@ -278,6 +290,9 @@ export default function Budget() {
       }
     >
 
+      <div className="flex justify-end mb-2">
+        <WholePoundsToggle />
+      </div>
       {/* Navigation Tabs */}
       <div className="flex space-x-1 bg-gray-100 dark:bg-gray-700 p-1 rounded-lg mb-6">
         <button

--- a/src/pages/Calendar.tsx
+++ b/src/pages/Calendar.tsx
@@ -17,6 +17,7 @@ import EditTransactionModal from '../components/EditTransactionModal';
 import type { Transaction } from '../types';
 import type { SplitExpandedTransaction } from '../utils/transactionSplits';
 import { createCategoryLabeller } from '../utils/categoryLabel';
+import { WholePoundsScope, WholePoundsToggle } from '../contexts/WholePoundsContext';
 
 interface DayData {
   date: Date;
@@ -30,6 +31,17 @@ interface DayData {
 }
 
 export default function Calendar() {
+  // The whole-pounds scope must sit above every useCurrencyDecimal call,
+  // including this page's own — hence the thin shell (owner, 19 Aug:
+  // page-specific decimal display).
+  return (
+    <WholePoundsScope page="calendar">
+      <CalendarView />
+    </WholePoundsScope>
+  );
+}
+
+function CalendarView() {
   const {
     transactions, transactionSplits, categories, accounts,
     suggestionDismissals, suggestionDismissalsStatus, refreshSuggestionDismissals,
@@ -745,19 +757,23 @@ export default function Calendar() {
           </div>
         </div>
 
-        {view === 'month' && (<>
-        {/* The daily net-worth line is opt-in (owner: not a default). */}
-        <div className="flex justify-end px-4 py-1.5 border-b border-gray-100 dark:border-gray-700">
-          <label className="flex items-center gap-2 text-xs text-gray-500 dark:text-gray-400 cursor-pointer">
-            <input
-              type="checkbox"
-              checked={showNetWorth}
-              onChange={toggleNetWorth}
-              className="rounded border-gray-300 dark:border-gray-600"
-            />
-            Daily net worth
-          </label>
+        {/* Display choices, every view: whole pounds always; the daily
+            net-worth line is month-view's own (owner: not a default). */}
+        <div className="flex justify-end items-center gap-4 px-4 py-1.5 border-b border-gray-100 dark:border-gray-700">
+          <WholePoundsToggle />
+          {view === 'month' && (
+            <label className="flex items-center gap-2 text-xs text-gray-500 dark:text-gray-400 cursor-pointer">
+              <input
+                type="checkbox"
+                checked={showNetWorth}
+                onChange={toggleNetWorth}
+                className="rounded border-gray-300 dark:border-gray-600"
+              />
+              Daily net worth
+            </label>
+          )}
         </div>
+        {view === 'month' && (<>
         {/* Day headers */}
         <div className="grid grid-cols-7 border-b border-gray-100 dark:border-gray-700">
           {dayNames.map(day => (

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect, Suspense } from 'react';
 import { lazyWithRecovery } from '../utils/lazyWithRecovery';
 import { usePreferences } from '../contexts/PreferencesContext';
 import PageWrapper from '../components/PageWrapper';
+import { WholePoundsScope } from '../contexts/WholePoundsContext';
 import { SkeletonCard } from '../components/loading/Skeleton';
 import LazyErrorBoundary from '../components/LazyErrorBoundary';
 import PageTip from '../components/PageTip';
@@ -55,12 +56,16 @@ export default function Dashboard() {
 
   return (
     <PageWrapper title="Dashboard">
-      {/* Render the consolidated dashboard */}
-      <LazyErrorBoundary componentName="Dashboard">
-        <Suspense fallback={<SkeletonCard className="h-96" />}>
-          <ImprovedDashboard />
-        </Suspense>
-      </LazyErrorBoundary>
+      {/* Render the consolidated dashboard — inside its whole-pounds scope,
+          so every widget's useCurrencyDecimal follows the page's checkbox
+          (owner, 19 Aug: page-specific decimal display). */}
+      <WholePoundsScope page="dashboard">
+        <LazyErrorBoundary componentName="Dashboard">
+          <Suspense fallback={<SkeletonCard className="h-96" />}>
+            <ImprovedDashboard />
+          </Suspense>
+        </LazyErrorBoundary>
+      </WholePoundsScope>
 
       {/* id bumped from `dashboard-welcome`: the old copy promised a recent
           activity list that no longer exists, so anyone who dismissed it needs

--- a/src/pages/Forecast.tsx
+++ b/src/pages/Forecast.tsx
@@ -9,6 +9,7 @@ import { dismissedKeys } from '../utils/suggestionDismissals';
 import { buildPlWindow, bucketIndexOf, dayOf } from '../utils/plWindow';
 import type { PlWindowKind } from '../utils/plWindow';
 import { ArrowDownIcon, ArrowUpIcon, ChevronDownIcon, ChevronRightIcon } from '../components/icons';
+import { WholePoundsScope, WholePoundsToggle } from '../contexts/WholePoundsContext';
 import { dataPort } from '@data';
 import type { ForecastAdjustment, Transaction } from '../types';
 
@@ -86,6 +87,16 @@ const entryTotal = (entry: SideEntry): number =>
   entry.kind === 'group' ? entry.total : entry.category.total;
 
 export default function Forecast(): React.JSX.Element {
+  // The scope must sit ABOVE every useCurrencyDecimal call, including this
+  // page's own — hence the thin shell around the statement.
+  return (
+    <WholePoundsScope page="forecast">
+      <ForecastStatement />
+    </WholePoundsScope>
+  );
+}
+
+function ForecastStatement(): React.JSX.Element {
   const {
     accounts, categories, transactions,
     suggestionDismissals, suggestionDismissalsStatus, refreshSuggestionDismissals,
@@ -422,7 +433,10 @@ export default function Forecast(): React.JSX.Element {
     const open = sectionOpen[side];
     return (
       <div className="border-t border-gray-100 dark:border-gray-700/60 first:border-0">
-        <div className="flex items-baseline justify-between gap-4 py-2">
+        {/* A row that FOLDS wears a quiet band (owner, 19 Aug: "anything…
+            that has a drop down arrow should have its row highlighted
+            slightly") — the same band its table-mode twin wears. */}
+        <div className="flex items-baseline justify-between gap-4 py-2 px-2 -mx-2 rounded bg-gray-50 dark:bg-gray-700">
           <button
             type="button"
             onClick={() => toggleSection(side)}
@@ -465,7 +479,7 @@ export default function Forecast(): React.JSX.Element {
                 const groupOpen = !closedGroups.has(groupKey);
                 return (
                   <li key={entry.key} className="border-t border-gray-50 dark:border-gray-700/50 first:border-0">
-                    <div className="flex items-baseline justify-between gap-4">
+                    <div className="flex items-baseline justify-between gap-4 px-2 -mx-2 rounded bg-gray-50 dark:bg-gray-700">
                       <button
                         type="button"
                         onClick={() => toggleGroup(groupKey)}
@@ -570,8 +584,11 @@ export default function Forecast(): React.JSX.Element {
     const open = sectionOpen[side];
     return (
       <>
-        <tr className="border-t border-gray-100 dark:border-gray-700/60">
-          <td className="sticky left-0 bg-white dark:bg-gray-800 py-2 pr-4">
+        {/* A folding row wears the band; its sticky cell paints the SAME
+            colour, opaque, or the first column would break the band while
+            the months scroll beneath it. */}
+        <tr className="border-t border-gray-100 dark:border-gray-700/60 bg-gray-50 dark:bg-gray-700">
+          <td className="sticky left-0 bg-gray-50 dark:bg-gray-700 py-2 pr-4">
             <button
               type="button"
               onClick={() => toggleSection(side)}
@@ -604,8 +621,8 @@ export default function Forecast(): React.JSX.Element {
           const groupOpen = !closedGroups.has(groupKey);
           return (
             <React.Fragment key={entry.key}>
-              <tr className="border-t border-gray-50 dark:border-gray-700/50">
-                <td className="sticky left-0 bg-white dark:bg-gray-800 py-1.5 pl-4 pr-4">
+              <tr className="border-t border-gray-50 dark:border-gray-700/50 bg-gray-50 dark:bg-gray-700">
+                <td className="sticky left-0 bg-gray-50 dark:bg-gray-700 py-1.5 pl-4 pr-4">
                   <button
                     type="button"
                     onClick={() => toggleGroup(groupKey)}
@@ -786,17 +803,20 @@ export default function Forecast(): React.JSX.Element {
                       : <ArrowUpIcon size={12} className="shrink-0" />}
                   </button>
                 </div>
-                <button
-                  type="button"
-                  onClick={() => setShowMonths(previous => !previous)}
-                  aria-pressed={showMonths}
-                  className="flex items-center gap-1 text-xs text-gray-500 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-200 hover:underline"
-                >
-                  {showMonths
-                    ? <ChevronDownIcon size={14} className="shrink-0" />
-                    : <ChevronRightIcon size={14} className="shrink-0" />}
-                  {showMonths ? 'Hide the months' : 'Show the months'}
-                </button>
+                <div className="flex items-center gap-4">
+                  <WholePoundsToggle />
+                  <button
+                    type="button"
+                    onClick={() => setShowMonths(previous => !previous)}
+                    aria-pressed={showMonths}
+                    className="flex items-center gap-1 text-xs text-gray-500 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-200 hover:underline"
+                  >
+                    {showMonths
+                      ? <ChevronDownIcon size={14} className="shrink-0" />
+                      : <ChevronRightIcon size={14} className="shrink-0" />}
+                    {showMonths ? 'Hide the months' : 'Show the months'}
+                  </button>
+                </div>
               </div>
 
               {showMonths ? (

--- a/src/pages/Investments.tsx
+++ b/src/pages/Investments.tsx
@@ -25,6 +25,7 @@ import type { DecimalInstance } from '../utils/decimal';
 import { formatDecimal } from '../utils/decimal-format';
 import { describeRate } from '../utils/fx';
 import PageWrapper from '../components/PageWrapper';
+import { WholePoundsScope, WholePoundsToggle } from '../contexts/WholePoundsContext';
 import ToggleSwitch from '../components/ui/ToggleSwitch';
 import { buildPortfolioSummary, buildPortfolioHistory } from '../utils/portfolioSummary';
 import { PieChart as DashboardPieChart } from '../components/charts/DashboardCharts';
@@ -74,6 +75,17 @@ const INVESTMENT_PERIOD_MONTHS: Record<'1-month' | '3-months' | '6-months' | '12
 };
 
 export default function Investments() {
+  // The whole-pounds scope must sit above every useCurrencyDecimal call,
+  // including this page's own — hence the thin shell (owner, 19 Aug:
+  // page-specific decimal display).
+  return (
+    <WholePoundsScope page="investments">
+      <InvestmentsView />
+    </WholePoundsScope>
+  );
+}
+
+function InvestmentsView() {
   const {
     accounts, transactions, transactionSplits, categories,
     // The purchase's cash half: the out leg is an ordinary transaction and the
@@ -751,7 +763,9 @@ export default function Investments() {
         )
       }
     >
-
+      <div className="flex justify-end mb-2">
+        <WholePoundsToggle />
+      </div>
       {/* Navigation Tabs */}
       <div className="flex space-x-1 bg-gray-100 dark:bg-gray-700 p-1 rounded-lg mb-6">
         <button

--- a/src/pages/__tests__/Forecast.test.tsx
+++ b/src/pages/__tests__/Forecast.test.tsx
@@ -330,3 +330,22 @@ describe('Forecast — the Forecast tab', () => {
     });
   });
 });
+
+describe('Forecast — whole pounds, this page\'s own checkbox', () => {
+  it('ticking it drops the pennies from every figure on the statement', () => {
+    renderForecast();
+
+    // Pennies by default…
+    expect(screen.getAllByText('+£24,000.00')).toHaveLength(2);
+    fireEvent.click(screen.getByRole('checkbox', { name: 'Whole pounds' }));
+    // …whole pounds once asked: totals, averages, the net line, all of it.
+    expect(screen.queryByText('+£24,000.00')).not.toBeInTheDocument();
+    expect(screen.getAllByText('+£24,000')).toHaveLength(2);
+    expect(screen.getByText('+£17,800')).toBeInTheDocument();
+    expect(screen.getByText('£1,483 a month')).toBeInTheDocument();
+
+    // And back, because it is a display choice, not a conversion.
+    fireEvent.click(screen.getByRole('checkbox', { name: 'Whole pounds' }));
+    expect(screen.getAllByText('+£24,000.00')).toHaveLength(2);
+  });
+});

--- a/src/utils/__tests__/currency-decimal.test.ts
+++ b/src/utils/__tests__/currency-decimal.test.ts
@@ -552,3 +552,20 @@ describe('currency-decimal', () => {
     });
   });
 });
+
+describe('formatCurrency — whole pounds (per-page display choice, owner 19 Aug)', () => {
+  it('rounds half-up to the pound and drops the pennies, keeping grouping and brackets', () => {
+    expect(formatCurrency(24354.39, 'GBP', { wholePounds: true })).toBe('£24,354');
+    expect(formatCurrency(24354.5, 'GBP', { wholePounds: true })).toBe('£24,355');
+    expect(formatCurrency(-42150.21, 'GBP', { wholePounds: true })).toBe('(£42,150)');
+  });
+
+  it('a figure that rounds to zero wears no brackets — the sign rides the ROUNDED value', () => {
+    expect(formatCurrency(-0.4, 'GBP', { wholePounds: true })).toBe('£0');
+  });
+
+  it('without the option, nothing changes', () => {
+    expect(formatCurrency(24354.39)).toBe('£24,354.39');
+    expect(formatCurrency(-42150.21)).toBe('(£42,150.21)');
+  });
+});

--- a/src/utils/currency-decimal.ts
+++ b/src/utils/currency-decimal.ts
@@ -134,11 +134,26 @@ const showsMinus = (decimal: DecimalInstance): boolean =>
  * through here, and should: it is a rendered document a person reads, which is
  * where the convention comes from.
  */
-export function formatCurrency(amount: DecimalInstance | number, currency: string = 'GBP'): string {
-  const decimal = toDecimal(amount).toDecimalPlaces(2, Decimal.ROUND_HALF_UP);
+/**
+ * `wholePounds` is a DISPLAY choice, per page (see WholePoundsContext): the
+ * figure rounds half-up to the pound and drops its pennies. The sign rule
+ * rides on the ROUNDED value, so a −£0.40 that rounds to zero wears no
+ * brackets — the same guard formatCurrencyWhole below has always kept.
+ */
+export interface FormatCurrencyOptions {
+  wholePounds?: boolean;
+}
+
+export function formatCurrency(
+  amount: DecimalInstance | number,
+  currency: string = 'GBP',
+  options: FormatCurrencyOptions = {}
+): string {
+  const places = options.wholePounds ? 0 : 2;
+  const decimal = toDecimal(amount).toDecimalPlaces(places, Decimal.ROUND_HALF_UP);
   const symbol = getCurrencySymbol(currency);
   const isNegative = showsMinus(decimal);
-  const formatted = formatDecimal(decimal.abs(), 2, { group: true });
+  const formatted = formatDecimal(decimal.abs(), places, { group: true });
   const body = currency === 'CHF' ? `${formatted} ${symbol}` : `${symbol}${formatted}`;
 
   return isNegative ? `(${body})` : body;


### PR DESCRIPTION
## Two owner notes, 19–20 Aug

### Whole pounds — one checkbox per page

**"a check box somewhere to offer the user to hide decimal points. Sometimes, when looking at a lot of data, it is cleaner to look at rounded whole figures"** — refined a message later to **"the decimal display should be page specific."**

So it is a **scope, not a global switch** (`WholePoundsContext`): each of the six pages — Dashboard, Accounts, Investments, Budget, Calendar, Forecast — wraps itself in one, remembers its own answer under its own preferences key, and everything inside follows because `useCurrencyDecimal` reads the context where it is called. The Dashboard's widgets needed no wiring of their own; the checkbox itself is context-connected, so each page drops it into whichever toolbar suits without threading props through a 3,000-line component.

- Rounding is **half-up to the pound**, grouping and brackets kept.
- The sign rides the **rounded** value, so a figure that rounds to zero wears no brackets (the `formatCurrencyWhole` guard, kept).
- A **display choice only**: the ledger, inputs, tooltips-through-other-formatters and exports keep their pennies.

### The P&L's folding rows wear a band

**"anything on the 'P&L' that has a drop down arrow should have its 'row' highlighted slightly to differentiate it to the individual category names."** Section headers and group headings wear a quiet `bg-gray-50` / dark `gray-700` band in both layouts; in the months table the sticky first cell paints the **same colour, opaque**, so the band survives the columns scrolling beneath it. Category rows stay plain.

## Verified

Strict types, zero-warning lint, 197 specs across the touched suites (new: the whole-pounds formatter trio including the rounds-to-zero-loses-its-brackets guard, and a Forecast round-trip through the real context, formatter and preferences store) — and exercised live on demo data: the Forecast statement and the whole Dashboard (headline cards, widgets, chart headline) drop their pennies when their own box is ticked, each page remembering separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
