### PR TITLE
polish(display): bold folding headings, 'Hide decimals' wording, and the toggle keeps to the right

### DIFF
--- a/src/contexts/WholePoundsContext.tsx
+++ b/src/contexts/WholePoundsContext.tsx
@@ -53,6 +53,8 @@ export function WholePoundsScope({ page, children }: { page: string; children: R
 /**
  * The checkbox. Context-connected so a page can drop it into whichever
  * toolbar suits without threading props through a 3,000-line component.
+ * Reads "Hide decimals" (owner, 20 Aug, over the first wording): unticked
+ * shows the pennies, ticked hides them.
  */
 export function WholePoundsToggle({ className = '' }: { className?: string }): React.JSX.Element {
   const { wholePounds, setWholePounds } = useContext(WholePoundsContext);
@@ -64,7 +66,7 @@ export function WholePoundsToggle({ className = '' }: { className?: string }): R
         onChange={event => setWholePounds(event.target.checked)}
         className="rounded border-gray-300 dark:border-gray-600"
       />
-      Whole pounds
+      Hide decimals
     </label>
   );
 }

--- a/src/pages/Accounts.tsx
+++ b/src/pages/Accounts.tsx
@@ -2437,6 +2437,13 @@ function AccountsList() {
         );
       })()}
 
+      {/* On the RIGHT, between the summary boxes and the controls — the same
+          side every page keeps this choice on (owner, 20 Aug: "the location
+          on each page should be similar, as in on the right hand side"). */}
+      <div className="-mt-4 mb-2 flex justify-end">
+        <WholePoundsToggle />
+      </div>
+
       {/* Group + sort controls, with bank connections on the right.
           ─ WHICH LABEL GOES WITH WHICH CONTROL ────────────────────────────
           The gap BEFORE a label has to beat the gap AFTER it, or the eye files
@@ -2661,7 +2668,6 @@ function AccountsList() {
           >
             {showRowActions ? 'Hide account buttons' : 'Show account buttons'}
           </button>
-          <WholePoundsToggle className="shrink-0" />
         </div>
         {/* Search — the way to find one account among two hundred. On a
             phone it takes the first row, full width; the pills follow.

--- a/src/pages/Forecast.tsx
+++ b/src/pages/Forecast.tsx
@@ -441,7 +441,7 @@ function ForecastStatement(): React.JSX.Element {
             type="button"
             onClick={() => toggleSection(side)}
             aria-expanded={open}
-            className="flex items-center gap-1.5 text-card font-semibold text-theme-heading dark:text-white"
+            className="flex items-center gap-1.5 text-card font-bold text-theme-heading dark:text-white"
           >
             {open
               ? <ChevronDownIcon size={16} className="text-gray-400 shrink-0" />
@@ -484,7 +484,7 @@ function ForecastStatement(): React.JSX.Element {
                         type="button"
                         onClick={() => toggleGroup(groupKey)}
                         aria-expanded={groupOpen}
-                        className="flex items-center gap-1.5 py-2 text-sm font-medium text-gray-900 dark:text-white"
+                        className="flex items-center gap-1.5 py-2 text-sm font-bold text-gray-900 dark:text-white"
                       >
                         {groupOpen
                           ? <ChevronDownIcon size={14} className="text-gray-400 shrink-0" />
@@ -593,7 +593,7 @@ function ForecastStatement(): React.JSX.Element {
               type="button"
               onClick={() => toggleSection(side)}
               aria-expanded={open}
-              className="flex items-center gap-1.5 text-card font-semibold text-theme-heading dark:text-white"
+              className="flex items-center gap-1.5 text-card font-bold text-theme-heading dark:text-white"
             >
               {open
                 ? <ChevronDownIcon size={16} className="text-gray-400 shrink-0" />
@@ -627,7 +627,7 @@ function ForecastStatement(): React.JSX.Element {
                     type="button"
                     onClick={() => toggleGroup(groupKey)}
                     aria-expanded={groupOpen}
-                    className="flex items-center gap-1.5 text-left text-sm font-medium text-gray-900 dark:text-white truncate max-w-[16rem]"
+                    className="flex items-center gap-1.5 text-left text-sm font-bold text-gray-900 dark:text-white truncate max-w-[16rem]"
                   >
                     {groupOpen
                       ? <ChevronDownIcon size={14} className="text-gray-400 shrink-0" />

--- a/src/pages/__tests__/Forecast.test.tsx
+++ b/src/pages/__tests__/Forecast.test.tsx
@@ -337,7 +337,7 @@ describe('Forecast — whole pounds, this page\'s own checkbox', () => {
 
     // Pennies by default…
     expect(screen.getAllByText('+£24,000.00')).toHaveLength(2);
-    fireEvent.click(screen.getByRole('checkbox', { name: 'Whole pounds' }));
+    fireEvent.click(screen.getByRole('checkbox', { name: 'Hide decimals' }));
     // …whole pounds once asked: totals, averages, the net line, all of it.
     expect(screen.queryByText('+£24,000.00')).not.toBeInTheDocument();
     expect(screen.getAllByText('+£24,000')).toHaveLength(2);
@@ -345,7 +345,7 @@ describe('Forecast — whole pounds, this page\'s own checkbox', () => {
     expect(screen.getByText('£1,483 a month')).toBeInTheDocument();
 
     // And back, because it is a display choice, not a conversion.
-    fireEvent.click(screen.getByRole('checkbox', { name: 'Whole pounds' }));
+    fireEvent.click(screen.getByRole('checkbox', { name: 'Hide decimals' }));
     expect(screen.getAllByText('+£24,000.00')).toHaveLength(2);
   });
 });


### PR DESCRIPTION
Three owner notes on #368's morning work, same day:

- **Bold folding headings** — Income, Expenditure and every group heading read bold in both the list and the months table, so the hierarchy is carried by weight as well as by the band.
- **"Hide decimals"** — the checkbox's wording, over "Whole pounds" (unticked shows the pennies, ticked hides them). Same behaviour, same stored keys, so yesterday's choices survive the rename.
- **The toggle keeps to the right on every page** — Accounts was the stray, wedged mid-toolbar between the sort pills and the search box; it now sits right-aligned between the summary boxes and the controls, exactly where the owner pointed.

Verified live on demo data (Forecast bold + renamed label with the saved state carried over; Accounts in its new spot), plus strict types, zero-warning lint, and 98 specs across the touched suites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)